### PR TITLE
refactor: set appLevelAppearance prop on systemPreferences

### DIFF
--- a/atom/browser/api/atom_api_system_preferences.cc
+++ b/atom/browser/api/atom_api_system_preferences.cc
@@ -106,6 +106,9 @@ void SystemPreferences::BuildPrototype(
                  &SystemPreferences::GetAppLevelAppearance)
       .SetMethod("setAppLevelAppearance",
                  &SystemPreferences::SetAppLevelAppearance)
+      .SetProperty("appLevelAppearance",
+                   &SystemPreferences::GetAppLevelAppearance,
+                   &SystemPreferences::SetAppLevelAppearance)
       .SetMethod("getSystemColor", &SystemPreferences::GetSystemColor)
       .SetMethod("canPromptTouchID", &SystemPreferences::CanPromptTouchID)
       .SetMethod("promptTouchID", &SystemPreferences::PromptTouchID)

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -667,7 +667,7 @@ to the npm modules spec. You should usually also specify a `productName`
 field, which is your application's full capitalized name, and which will be
 preferred over `name` by Electron.
 
-**[Deprecated Soon](modernization/property-updates.md)**
+**[Deprecated](modernization/property-updates.md)**
 
 ### `app.setName(name)`
 
@@ -675,7 +675,7 @@ preferred over `name` by Electron.
 
 Overrides the current application's name.
 
-**[Deprecated Soon](modernization/property-updates.md)**
+**[Deprecated](modernization/property-updates.md)**
 
 ### `app.getLocale()`
 
@@ -1070,13 +1070,13 @@ On macOS, it shows on the dock icon. On Linux, it only works for Unity launcher.
 **Note:** Unity launcher requires the existence of a `.desktop` file to work,
 for more information please read [Desktop Environment Integration][unity-requirement].
 
-**[Deprecated Soon](modernization/property-updates.md)**
+**[Deprecated](modernization/property-updates.md)**
 
 ### `app.getBadgeCount()` _Linux_ _macOS_
 
 Returns `Integer` - The current value displayed in the counter badge.
 
-**[Deprecated Soon](modernization/property-updates.md)**
+**[Deprecated](modernization/property-updates.md)**
 
 ### `app.isUnityRunning()` _Linux_
 
@@ -1152,7 +1152,7 @@ technologies, such as screen readers, has been detected. See
 https://www.chromium.org/developers/design-documents/accessibility for more
 details.
 
-**[Deprecated Soon](modernization/property-updates.md)**
+**[Deprecated](modernization/property-updates.md)**
 
 ### `app.setAccessibilitySupportEnabled(enabled)` _macOS_ _Windows_
 
@@ -1165,7 +1165,7 @@ This API must be called after the `ready` event is emitted.
 
 **Note:** Rendering accessibility tree can significantly affect the performance of your app. It should not be enabled by default.
 
-**[Deprecated Soon](modernization/property-updates.md)**
+**[Deprecated](modernization/property-updates.md)**
 
 ### `app.showAboutPanel()` _macOS_ _Linux_
 

--- a/docs/api/modernization/property-updates.md
+++ b/docs/api/modernization/property-updates.md
@@ -32,8 +32,6 @@ The Electron team is currently undergoing an initiative to convert separate gett
   * `paused`
 * `Session` module
   * `preloads`
-* `SystemPreferences` module
-  * `appLevelAppearance`
 * `webContents` module
   * `zoomFactor`
   * `zoomLevel`
@@ -58,3 +56,5 @@ The Electron team is currently undergoing an initiative to convert separate gett
   * `name`
 * `NativeImage`
   * `isMacTemplateImage`
+* `SystemPreferences` module
+  * `appLevelAppearance`

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -275,13 +275,13 @@ Returns [`Size`](structures/size.md)
 
 Marks the image as a template image.
 
-**[Deprecated Soon](modernization/property-updates.md)**
+**[Deprecated](modernization/property-updates.md)**
 
 #### `image.isTemplateImage()`
 
 Returns `Boolean` - Whether the image is a template image.
 
-**[Deprecated Soon](modernization/property-updates.md)**
+**[Deprecated](modernization/property-updates.md)**
 
 #### `image.crop(rect)`
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -380,11 +380,15 @@ You can use the `setAppLevelAppearance` API to set this value.
 Sets the appearance setting for your application, this should override the
 system default and override the value of `getEffectiveAppearance`.
 
+**[Deprecated](modernization/property-updates.md)**
+
 ### `systemPreferences.canPromptTouchID()` _macOS_
 
 Returns `Boolean` - whether or not this device has the ability to use Touch ID.
 
 **NOTE:** This API will return `false` on macOS systems older than Sierra 10.12.2.
+
+**[Deprecated](modernization/property-updates.md)**
 
 ### `systemPreferences.promptTouchID(reason)` _macOS_
 
@@ -439,3 +443,13 @@ Returns `Object`:
 * `prefersReducedMotion` Boolean - Determines whether the user desires reduced motion based on platform APIs.
 
 Returns an object with system animation settings.
+
+## Properties
+
+### `systemPreferences.appLevelAppearance` _macOS_
+
+A `String` property that determines the macOS appearance setting for
+your application. This maps to values in: [NSApplication.appearance](https://developer.apple.com/documentation/appkit/nsapplication/2967170-appearance?language=objc). Setting this will override the
+system default as well as the value of `getEffectiveAppearance`.
+
+Possible values that can be set are `dark` and `light`, and possible return values are `dark`, `light`, and `unknown`.

--- a/lib/browser/api/system-preferences.js
+++ b/lib/browser/api/system-preferences.js
@@ -1,10 +1,15 @@
 'use strict'
 
 const { EventEmitter } = require('events')
+const { deprecate } = require('electron')
 const { systemPreferences, SystemPreferences } = process.electronBinding('system_preferences')
 
 // SystemPreferences is an EventEmitter.
 Object.setPrototypeOf(SystemPreferences.prototype, EventEmitter.prototype)
 EventEmitter.call(systemPreferences)
+
+if ('appLevelAppearance' in systemPreferences) {
+  deprecate.fnToProperty(systemPreferences, 'appLevelAppearance', '_getAppLevelAppearance', '_setAppLevelAppearance')
+}
 
 module.exports = systemPreferences

--- a/spec/api-system-preferences-spec.js
+++ b/spec/api-system-preferences-spec.js
@@ -151,6 +151,16 @@ describe('systemPreferences module', () => {
     })
   })
 
+  describe('systemPreferences.appLevelAppearance', () => {
+    before(function () {
+      if (process.platform !== 'darwin') this.skip()
+    })
+
+    it('has an appLevelAppearance property', () => {
+      expect(systemPreferences).to.have.a.property('appLevelAppearance')
+    })
+  })
+
   describe('systemPreferences.setUserDefault(key, type, value)', () => {
     before(function () {
       if (process.platform !== 'darwin') {

--- a/spec/api-system-preferences-spec.js
+++ b/spec/api-system-preferences-spec.js
@@ -158,6 +158,10 @@ describe('systemPreferences module', () => {
 
     it('has an appLevelAppearance property', () => {
       expect(systemPreferences).to.have.a.property('appLevelAppearance')
+
+      // TODO(codebytere): remove when propertyification is complete
+      expect(systemPreferences.getAppLevelAppearance).to.be.a('function')
+      expect(systemPreferences.setAppLevelAppearance).to.be.a('function')
     })
   })
 


### PR DESCRIPTION
#### Description of Change

Set `appLevelAppearance` as a property on `systemPreferences` as part of the property modernization effort.

cc @miniak @jkleinsc  @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Converted `appLevelAppearance` to be a property on `systemPreferences`
