### PR TITLE
fix: respect minimizable/closable for customButtonsOnHover

### DIFF
--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -167,7 +167,7 @@ class NativeWindowMac : public NativeWindow {
 
  private:
   // Add custom layers to the content view.
-  void AddContentViewLayers();
+  void AddContentViewLayers(bool minimizable, bool closable);
 
   void InternalSetParentWindow(NativeWindow* parent, bool attach);
   void SetForwardMouseMessages(bool forward);

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -73,9 +73,11 @@
   NSButton* close_button =
       [NSWindow standardWindowButton:NSWindowCloseButton
                         forStyleMask:NSWindowStyleMaskTitled];
+  [close_button setTag:1];
   NSButton* miniaturize_button =
       [NSWindow standardWindowButton:NSWindowMiniaturizeButton
                         forStyleMask:NSWindowStyleMaskTitled];
+  [miniaturize_button setTag:2];
 
   CGFloat x = 0;
   const CGFloat space_between = 20;
@@ -459,7 +461,7 @@ NativeWindowMac::NativeWindowMac(const mate::Dictionary& options,
 
   // Default content view.
   SetContentView(new views::View());
-  AddContentViewLayers();
+  AddContentViewLayers(minimizable, closable);
 
   original_frame_ = [window_ frame];
   original_level_ = [window_ level];
@@ -851,9 +853,9 @@ void NativeWindowMac::SetAlwaysOnTop(bool top,
   if (newLevel >= minWindowLevel && newLevel <= maxWindowLevel) {
     [window_ setLevel:newLevel];
   } else {
-    *error = std::string([
-        [NSString stringWithFormat:@"relativeLevel must be between %d and %d",
-                                   minWindowLevel, maxWindowLevel] UTF8String]);
+    *error = std::string([[NSString
+        stringWithFormat:@"relativeLevel must be between %d and %d",
+                         minWindowLevel, maxWindowLevel] UTF8String]);
   }
 }
 
@@ -1102,7 +1104,7 @@ void NativeWindowMac::RemoveBrowserView(NativeBrowserView* view) {
   }
 
   [view->GetInspectableWebContentsView()->GetNativeView().GetNativeNSView()
-          removeFromSuperview];
+      removeFromSuperview];
   remove_browser_view(view);
 
   [CATransaction commit];
@@ -1384,7 +1386,7 @@ views::View* NativeWindowMac::GetContentsView() {
   return root_view_.get();
 }
 
-void NativeWindowMac::AddContentViewLayers() {
+void NativeWindowMac::AddContentViewLayers(bool minimizable, bool closable) {
   // Make sure the bottom corner is rounded for non-modal windows:
   // http://crbug.com/396264.
   if (!is_modal()) {
@@ -1424,6 +1426,12 @@ void NativeWindowMac::AddContentViewLayers() {
           [[CustomWindowButtonView alloc] initWithFrame:NSZeroRect]);
       // NSWindowStyleMaskFullSizeContentView does not work with zoom button
       SetFullScreenable(false);
+
+      if (!minimizable)
+        [[buttons_view_ viewWithTag:2] removeFromSuperview];
+      if (!closable)
+        [[buttons_view_ viewWithTag:1] removeFromSuperview];
+
       [[window_ contentView] addSubview:buttons_view_];
     } else {
       if (title_bar_style_ != NORMAL)
@@ -1480,7 +1488,7 @@ void NativeWindowMac::OverrideNSWindowContentView() {
       setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
   [container_view_ setFrame:[[[window_ contentView] superview] bounds]];
   [window_ setContentView:container_view_];
-  AddContentViewLayers();
+  AddContentViewLayers(IsMinimizable(), IsClosable());
 }
 
 void NativeWindowMac::SetStyleMask(bool on, NSUInteger flag) {


### PR DESCRIPTION
Backport of #18425

See that PR for details.

Notes: Fixed an issue whereby `minimizable` and `closable` weren't respected in `customButtonsOnHover` mode.