### PR TITLE
fix: respect minimizable/closable for customButtonsOnHover

### DIFF
--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -164,7 +164,7 @@ class NativeWindowMac : public NativeWindow {
 
  private:
   // Add custom layers to the content view.
-  void AddContentViewLayers();
+  void AddContentViewLayers(bool minimizable, bool closable);
 
   void InternalSetParentWindow(NativeWindow* parent, bool attach);
   void ShowWindowButton(NSWindowButton button);


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/18425.

See that PR for details.

Notes: Fixed an issue whereby `minimizable` and `closable` weren't respected in `customButtonsOnHover` mode.