### PR TITLE
docs: specify use case for the 'services' role

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -108,7 +108,7 @@ The following additional roles are available on _macOS_:
 * `moveTabToNewWindow` - Map to the `moveTabToNewWindow` action.
 * `window` - The submenu is a "Window" menu.
 * `help` - The submenu is a "Help" menu.
-* `services` - The submenu is a "Services" menu.
+* `services` - The submenu is a ["Services"](https://developer.apple.com/documentation/appkit/nsapplication/1428608-servicesmenu?language=objc) menu; this is not the same as a menu item populated with [NSServices](https://developer.apple.com/documentation/bundleresources/information_property_list/nsservices?language=objc) and should not be used in context menus.
 * `recentDocuments` - The submenu is an "Open Recent" menu.
 * `clearRecentDocuments` - Map to the `clearRecentDocuments` action.
 

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -108,7 +108,7 @@ The following additional roles are available on _macOS_:
 * `moveTabToNewWindow` - Map to the `moveTabToNewWindow` action.
 * `window` - The submenu is a "Window" menu.
 * `help` - The submenu is a "Help" menu.
-* `services` - The submenu is a ["Services"](https://developer.apple.com/documentation/appkit/nsapplication/1428608-servicesmenu?language=objc) menu; this is not the same as a menu item populated with [NSServices](https://developer.apple.com/documentation/bundleresources/information_property_list/nsservices?language=objc) and should not be used in context menus.
+* `services` - The submenu is a ["Services"](https://developer.apple.com/documentation/appkit/nsapplication/1428608-servicesmenu?language=objc) menu. This is only intended for use in the Application Menu and is *not* the same as the "Services" submenu used in context menus in macOS apps, which is not implemented in Electron.
 * `recentDocuments` - The submenu is an "Open Recent" menu.
 * `clearRecentDocuments` - Map to the `clearRecentDocuments` action.
 

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -277,7 +277,6 @@ window.addEventListener('contextmenu', (e) => {
 </script>
 ```
 
-
 ## Notes on macOS Application Menu
 
 macOS has a completely different style of application menu from Windows and
@@ -285,7 +284,7 @@ Linux. Here are some notes on making your app's menu more native-like.
 
 ### Standard Menus
 
-On macOS there are many system-defined standard menus, like the `Services` and
+On macOS there are many system-defined standard menus, like the [`Services`](https://developer.apple.com/documentation/appkit/nsapplication/1428608-servicesmenu?language=objc) and
 `Windows` menus. To make your menu a standard menu, you should set your menu's
 `role` to one of the following and Electron will recognize them and make them
 become standard menus:


### PR DESCRIPTION
#### Description of Change

Partially addresses https://github.com/electron/electron/issues/18476.

Specifies that the `services` role is not the same as a menu item populated with [NSServices](https://developer.apple.com/documentation/bundleresources/information_property_list/nsservices?language=objc) and should not be used in context menus.

cc @nornagon @miniak @MarshallOfSound

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
