### PR TITLE
fix: Update gen-filenames.js to generate posix paths

### DIFF
--- a/script/gen-filenames.js
+++ b/script/gen-filenames.js
@@ -73,7 +73,7 @@ const main = async () => {
       // Ignore empty lines
       .filter(line => line)
       // Get the relative path
-      .map(line => path.relative(rootPath, line))
+      .map(line => path.relative(rootPath, line).replace(/\\/g, '/'))
       // Only care about files in //electron
       .filter(line => !line.startsWith('..'))
       // Only care about our own files


### PR DESCRIPTION
#### Description of Change
gen-filenames.js on win creates relative paths with `\`.
We want to have posix path separators.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes