### PR TITLE
test: run nan tests to ensure v8 compat has not broken

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -871,6 +871,21 @@ steps-tests: &steps-tests
 
     - *step-maybe-notify-slack-failure
 
+steps-test-nan: &steps-test-nan
+  steps:
+    - attach_workspace:
+          at: .
+    - *step-depot-tools-add-to-path
+    - *step-electron-dist-unzip
+    - *step-setup-linux-for-headless-testing
+    - *step-fix-known-hosts-linux
+    - run:
+        name: Run Nan Tests
+        command: |
+          cd src
+          export ELECTRON_OUT_DIR=Default
+          node electron/script/nan-spec-runner.js
+
 chromium-upgrade-branches: &chromium-upgrade-branches
   /chromium\-upgrade\/[0-9]+/
 
@@ -1276,6 +1291,14 @@ jobs:
       <<: *env-stack-dumping
     <<: *steps-tests
 
+  linux-x64-testing-nan:
+    <<: *machine-linux-medium
+    environment:
+      <<: *env-linux-medium
+      <<: *env-headless-testing
+      <<: *env-stack-dumping
+    <<: *steps-test-nan
+
   linux-x64-release-tests:
     <<: *machine-linux-medium
     environment:
@@ -1308,6 +1331,15 @@ jobs:
       <<: *env-headless-testing
       <<: *env-stack-dumping
     <<: *steps-tests
+
+  linux-ia32-testing-nan:
+    <<: *machine-linux-medium
+    environment:
+      <<: *env-linux-medium
+      <<: *env-ia32
+      <<: *env-headless-testing
+      <<: *env-stack-dumping
+    <<: *steps-test-nan
 
   linux-ia32-release-tests:
     <<: *machine-linux-medium
@@ -1470,6 +1502,9 @@ workflows:
       - linux-x64-testing-tests:
           requires:
             - linux-x64-testing
+      - linux-x64-testing-nan:
+          requires:
+            - linux-x64-testing
 
       - linux-ia32-debug:
           requires:
@@ -1478,6 +1513,9 @@ workflows:
           requires:
             - linux-checkout
       - linux-ia32-testing-tests:
+          requires:
+            - linux-ia32-testing
+      - linux-ia32-testing-nan:
           requires:
             - linux-ia32-testing
 

--- a/DEPS
+++ b/DEPS
@@ -13,6 +13,8 @@ vars = {
     'ab588d36191964c4bca8de5c320534d95606c861',
   'node_version':
     'a86a4a160dc520c61a602c949a32a1bc4c0fc633',
+  'nan_version':
+    '960dd6c70fc9eb136efdf37b4bef18fadbc3436f',
 
   'boto_version': 'f7574aa6cc2c819430c1f05e9a1a1a666ef8169b',
   'pyyaml_version': '3.12',
@@ -21,10 +23,12 @@ vars = {
   'boto_git': 'https://github.com/boto',
   'chromium_git': 'https://chromium.googlesource.com',
   'electron_git': 'https://github.com/electron',
+  # FIXME: Once https://github.com/nodejs/nan/pull/857 lands this should point at nodejs/nan
+  'nodejs_git': 'https://github.com/marshallofsound',
   'requests_git': 'https://github.com/kennethreitz',
   'yaml_git': 'https://github.com/yaml',
 
-  # KEEP IN SYNC WITH spec-runner FILE
+  # KEEP IN SYNC WITH utils.js FILE
   'yarn_version': '1.15.2',
 
   # To be able to build clean Chromium from sources.
@@ -36,6 +40,7 @@ vars = {
   # To allow in-house builds to checkout those manually.
   'checkout_chromium': True,
   'checkout_node': True,
+  'checkout_nan': True,
 
   # It's only needed to parse the native tests configurations.
   'checkout_pyyaml': False,
@@ -68,6 +73,10 @@ deps = {
   'src': {
     'url': (Var("chromium_git")) + '/chromium/src.git@' + (Var("chromium_version")),
     'condition': 'checkout_chromium and process_deps',
+  },
+  'src/third_party/nan': {
+    'url': (Var("nodejs_git")) + '/nan.git@' + (Var("nan_version")),
+    'condition': 'checkout_nan and process_deps',
   },
   'src/third_party/electron_node': {
     'url': (Var("electron_git")) + '/node.git@' + (Var("node_version")),

--- a/script/lib/utils.js
+++ b/script/lib/utils.js
@@ -1,3 +1,6 @@
+// KEEP IN SYNC WITH DEPS FILE
+const YARN_VERSION = '1.15.2'
+
 const OUT_DIR = process.env.ELECTRON_OUT_DIR || 'Debug'
 
 const { GitProcess } = require('dugite')
@@ -42,5 +45,6 @@ module.exports = {
   getCurrentBranch,
   getElectronExec,
   getAbsoluteElectronExec,
-  OUT_DIR
+  OUT_DIR,
+  YARN_VERSION
 }

--- a/script/nan-spec-runner.js
+++ b/script/nan-spec-runner.js
@@ -1,0 +1,63 @@
+const cp = require('child_process')
+const fs = require('fs')
+const path = require('path')
+
+const BASE = path.resolve(__dirname, '../..')
+const NAN_DIR = path.resolve(BASE, 'third_party', 'nan')
+const NPX_CMD = process.platform === 'win32' ? 'npx.cmd' : 'npx'
+
+const utils = require('./lib/utils')
+
+if (!process.mainModule) {
+  throw new Error('Must call the nan spec runner directly')
+}
+
+async function main () {
+  const nodeDir = path.resolve(BASE, `out/${utils.OUT_DIR}/gen/node_headers`)
+  const env = Object.assign({}, process.env, {
+    npm_config_nodedir: nodeDir,
+    npm_config_msvs_version: '2017',
+    npm_config_arch: process.env.NPM_CONFIG_ARCH
+  })
+  const { status: buildStatus } = cp.spawnSync(NPX_CMD, ['node-gyp', 'rebuild', '--directory', 'test'], {
+    env,
+    cwd: NAN_DIR,
+    stdio: 'inherit'
+  })
+  if (buildStatus !== 0) {
+    console.error('Failed to build nan test modules')
+    return process.exit(buildStatus)
+  }
+
+  const { status: installStatus } = cp.spawnSync(NPX_CMD, [`yarn@${utils.YARN_VERSION}`, 'install'], {
+    env,
+    cwd: NAN_DIR,
+    stdio: 'inherit'
+  })
+  if (installStatus !== 0) {
+    console.error('Failed to install nan node_modules')
+    return process.exit(installStatus)
+  }
+
+  const DISABLED_TESTS = ['nannew-test.js']
+  const testsToRun = fs.readdirSync(path.resolve(NAN_DIR, 'test', 'js'))
+    .filter(test => !DISABLED_TESTS.includes(test))
+    .map(test => `test/js/${test}`)
+
+  const testChild = cp.spawn(utils.getAbsoluteElectronExec(), ['node_modules/.bin/tap', ...testsToRun], {
+    env: {
+      ...process.env,
+      ELECTRON_RUN_AS_NODE: 'true'
+    },
+    cwd: NAN_DIR,
+    stdio: 'inherit'
+  })
+  testChild.on('exit', (testCode) => {
+    process.exit(testCode)
+  })
+}
+
+main().catch((err) => {
+  console.error('An unhandled error occurred in the nan spec runner', err)
+  process.exit(1)
+})

--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -26,8 +26,6 @@ const utils = require('./lib/utils')
 const BASE = path.resolve(__dirname, '../..')
 const NPM_CMD = process.platform === 'win32' ? 'npm.cmd' : 'npm'
 const NPX_CMD = process.platform === 'win32' ? 'npx.cmd' : 'npx'
-// KEEP IN SYNC WITH DEPS FILE
-const YARN_VERSION = '1.15.2'
 
 const specHashPath = path.resolve(__dirname, '../spec/.hash')
 
@@ -146,7 +144,7 @@ async function installSpecModules () {
     npm_config_nodedir: nodeDir,
     npm_config_msvs_version: '2017'
   })
-  const { status } = childProcess.spawnSync(NPX_CMD, [`yarn@${YARN_VERSION}`, 'install', '--frozen-lockfile'], {
+  const { status } = childProcess.spawnSync(NPX_CMD, [`yarn@${utils.YARN_VERSION}`, 'install', '--frozen-lockfile'], {
     env,
     cwd: path.resolve(__dirname, '../spec'),
     stdio: 'inherit'


### PR DESCRIPTION
As discussed in the Upgrades WG meeting this morning we should probably be running some nan tests to ensure that native modules are gonna be 🆗 on each roll.

This adds some scripts to run `nan`'s test suite on every PR for both x64 and ia32 linux.  Currently depending on a fork until https://github.com/nodejs/nan/pull/857 has been merged upstream

Notes: no-notes