### PR TITLE
build: fix breakpad symbol generation on linux arm

### DIFF
--- a/patches/common/chromium/.patches
+++ b/patches/common/chromium/.patches
@@ -78,3 +78,4 @@ add_contentgpuclient_precreatemessageloop_callback.patch
 disable_custom_libcxx_on_windows.patch
 feat_offscreen_rendering_with_viz_compositor.patch
 worker_context_will_destroy.patch
+fix_breakpad_symbol_generation_on_linux_arm.patch

--- a/patches/common/chromium/fix_breakpad_symbol_generation_on_linux_arm.patch
+++ b/patches/common/chromium/fix_breakpad_symbol_generation_on_linux_arm.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Tue, 28 May 2019 18:12:17 -0700
+Subject: fix: breakpad symbol generation on linux arm
+
+Fixes broken Linux ARM breakpad symbol generation by patching
+out an `ldd`-related call that was throwing.
+
+diff --git a/components/crash/content/tools/generate_breakpad_symbols.py b/components/crash/content/tools/generate_breakpad_symbols.py
+index 4249d7b26f9037b60a40e073f56037f9ff036138..0ad9ff9b9bc7dd535655b37013270ad504aa6a34 100755
+--- a/components/crash/content/tools/generate_breakpad_symbols.py
++++ b/components/crash/content/tools/generate_breakpad_symbols.py
+@@ -67,7 +67,8 @@ def GetSharedLibraryDependenciesLinux(binary, options):
+   """Return absolute paths to all shared library dependencies of the binary.
+ 
+   This implementation assumes that we're running on a Linux system."""
+-  ldd = subprocess.check_output(['ldd', binary])
++  p = subprocess.Popen(['ldd', binary], stdout=subprocess.PIPE)
++  ldd = p.communicate()[0]
+   lib_re = re.compile('\t.* => (.+) \(.*\)$')
+   result = []
+   for line in ldd.splitlines():


### PR DESCRIPTION
#### Description of Change

Fixes broken Linux ARM breakpad symbol generation by patching out an `ldd`-related call that was throwing. 

cc @MarshallOfSound @jkleinsc 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
