### PR TITLE
fix: reverse dialog cancel bool for openDialog

### DIFF
--- a/atom/browser/ui/file_dialog_win.cc
+++ b/atom/browser/ui/file_dialog_win.cc
@@ -97,7 +97,7 @@ void RunOpenDialogInNewThread(const RunState& run_state,
   bool result = ShowOpenDialogSync(settings, &paths);
   run_state.ui_task_runner->PostTask(
       FROM_HERE,
-      base::BindOnce(&OnDialogOpened, std::move(promise), result, paths));
+      base::BindOnce(&OnDialogOpened, std::move(promise), !result, paths));
   run_state.ui_task_runner->DeleteSoon(FROM_HERE, run_state.dialog_thread);
 }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/18406.

Corrects the boolean cancellation value for `showOpenDialog` on Windows.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Corrected the boolean cancellation value for `showOpenDialog` on Windows.
