### PR TITLE
docs: remove obsolete callback argument from dialog.showOpenDialog()

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -111,7 +111,6 @@ dialog.showOpenDialogSync(mainWindow, {
   * `message` String (optional) _macOS_ - Message to display above input
     boxes.
   * `securityScopedBookmarks` Boolean (optional) _masOS_ _mas_ - Create [security scoped bookmarks](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) when packaged for the Mac App Store.
-* `callback` Function (optional)
 
 Returns `Promise<Object>` - Resolve with an object containing the following:
 


### PR DESCRIPTION
#### Description of Change
Follow up to https://github.com/electron/electron/pull/17907

cc @codebytere

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes