### PR TITLE
docs: use | instead of 'or' for docs

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -796,7 +796,7 @@ Returns `Object`:
 
 ### `app.setJumpList(categories)` _Windows_
 
-* `categories` [JumpListCategory[]](structures/jump-list-category.md) or `null` - Array of `JumpListCategory` objects.
+* `categories` [JumpListCategory[]](structures/jump-list-category.md) | `null` - Array of `JumpListCategory` objects.
 
 Sets or removes a custom Jump List for the application, and returns one of the
 following strings:


### PR DESCRIPTION
Handling `or` in the docs-parser was annoying and adding complicated logic, turns out we only use `or` in one place so let's just, not 👍 

Notes: no-notes