### PR TITLE
docs: add information about persistence and removal of DevTools Extensions

### DIFF
--- a/docs/tutorial/devtools-extension.md
+++ b/docs/tutorial/devtools-extension.md
@@ -50,7 +50,7 @@ will not return and instead log a warning to the console.
 You can pass the name of the extension to the `BrowserWindow.removeDevToolsExtension`
 API to remove it. The name of the extension is returned by
 `BrowserWindow.addDevToolsExtension` and you can get the names of all installed
-DevTools Extensions using the `BrowserWindow.getDevToolsExtensions` API. 
+DevTools Extensions using the `BrowserWindow.getDevToolsExtensions` API.
 
 ## Supported DevTools Extensions
 

--- a/docs/tutorial/devtools-extension.md
+++ b/docs/tutorial/devtools-extension.md
@@ -41,10 +41,16 @@ Using the [React Developer Tools][react-devtools] as example:
 **Note:** The `BrowserWindow.addDevToolsExtension` API cannot be called before the
 ready event of the app module is emitted.
 
-The extension will be remembered so you only need to call this API once per extension. If you try to add an extension that has already been loaded, this method will not return and instead log a warning to the console.
+The extension will be remembered so you only need to call this API once per
+extension. If you try to add an extension that has already been loaded, this method
+will not return and instead log a warning to the console.
 
 ### How to remove a DevTools Extension
-You can pass the name of the extension to the `BrowserWindow.removeDevToolsExtension` API to remove it. The name of the extension is returned by `BrowserWindow.addDevToolsExtension` and you can get the names of all installed DevTools Extensions using the `BrowserWindow.getDevToolsExtensions` API. 
+
+You can pass the name of the extension to the `BrowserWindow.removeDevToolsExtension`
+API to remove it. The name of the extension is returned by
+`BrowserWindow.addDevToolsExtension` and you can get the names of all installed
+DevTools Extensions using the `BrowserWindow.getDevToolsExtensions` API. 
 
 ## Supported DevTools Extensions
 

--- a/docs/tutorial/devtools-extension.md
+++ b/docs/tutorial/devtools-extension.md
@@ -41,9 +41,10 @@ Using the [React Developer Tools][react-devtools] as example:
 **Note:** The `BrowserWindow.addDevToolsExtension` API cannot be called before the
 ready event of the app module is emitted.
 
-The name of the extension is returned by `BrowserWindow.addDevToolsExtension`,
-and you can pass the name of the extension to the `BrowserWindow.removeDevToolsExtension`
-API to unload it.
+The extension will be remembered so you only need to call this API once per extension. If you try to add an extension that has already been loaded, this method will not return and instead log a warning to the console.
+
+### How to remove a DevTools Extension
+You can pass the name of the extension to the `BrowserWindow.removeDevToolsExtension` API to remove it. The name of the extension is returned by `BrowserWindow.addDevToolsExtension` and you can get the names of all installed DevTools Extensions using the `BrowserWindow.getDevToolsExtensions` API. 
 
 ## Supported DevTools Extensions
 


### PR DESCRIPTION
Add information about the persistence of extensions to the DevTools Extensions tutorial, and add a little bit about how to subsequently remove extensions as well.

#### Release Notes

Notes: no-notes
