### PR TITLE
ci: add retries to downloads for arm testing

### DIFF
--- a/script/download-circleci-artifacts.js
+++ b/script/download-circleci-artifacts.js
@@ -49,9 +49,28 @@ async function downloadArtifact (name, buildNum, dest) {
     process.exit(1)
   } else {
     console.log(`Downloading ${artifactToDownload.url}.`)
-    await downloadFile(artifactToDownload.url, dest)
-    console.log(`Successfully downloaded ${name}.`)
+    let downloadError = false
+    await downloadWithRetry(artifactToDownload.url, dest).catch(err => {
+      console.log(`Error downnloading ${artifactToDownload.url} :`, err)
+      downloadError = true
+    })
+    if (!downloadError) {
+      console.log(`Successfully downloaded ${name}.`)
+    }
   }
+}
+
+async function downloadWithRetry (url, directory) {
+  let lastError
+  for (let i = 0; i < 5; i++) {
+    console.log(`Attempting to download ${url} - attempt #${(i + 1)}`)
+    try {
+      return await downloadFile(url, directory)
+    } catch (err) {
+      lastError = err
+    }
+  }
+  throw lastError
 }
 
 function downloadFile (url, directory) {


### PR DESCRIPTION
#### Description of Change
For some reason sometimes downloading assets from CircleCI for arm testing results in a 502 response.  This PR adds retry logic to the download script to hopefully handle this condition.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
