### PR TITLE
fix: handle gzipped chrome WebUI resources

### DIFF
--- a/atom/app/atom_content_client.cc
+++ b/atom/app/atom_content_client.cc
@@ -268,4 +268,8 @@ void AtomContentClient::AddContentDecryptionModules(
   }
 }
 
+bool AtomContentClient::IsDataResourceGzipped(int resource_id) const {
+  return ui::ResourceBundle::GetSharedInstance().IsGzipped(resource_id);
+}
+
 }  // namespace atom

--- a/atom/app/atom_content_client.h
+++ b/atom/app/atom_content_client.h
@@ -31,6 +31,7 @@ class AtomContentClient : public content::ContentClient {
   void AddContentDecryptionModules(
       std::vector<content::CdmInfo>* cdms,
       std::vector<media::CdmHostFilePath>* cdm_host_file_paths) override;
+  bool IsDataResourceGzipped(int resource_id) const override;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(AtomContentClient);


### PR DESCRIPTION
Fixes: #18503
Refs: https://chromium-review.googlesource.com/c/chromium/src/+/1576232

For whatever reason Chromium made this change and then made the default //content behavior to return false for all IsDataResourceGzipped requests.  This PR updates our ContentClient impl to return the correct values.

Notes: Fixed issues where some `chrome://*` URLs would not render correctly