### PR TITLE
build: remove Vulkan mock ICD

### DIFF
--- a/build/zip.py
+++ b/build/zip.py
@@ -12,8 +12,8 @@ EXTENSIONS_TO_SKIP = [
 
 PATHS_TO_SKIP = [
   'angledata', #Skipping because it is an output of //ui/gl that we don't need
-  './libVkLayer_', #Skipping because these are outputs that we don't need
-  './VkLayerLayer_', #Skipping because these are outputs that we don't need
+  './libVkICD_mock_', #Skipping because these are outputs that we don't need
+  './VkICD_mock_', #Skipping because these are outputs that we don't need
 
   # //chrome/browser:resources depends on this via
   # //chrome/browser/resources/ssl/ssl_error_assistant, but we don't need to

--- a/script/dist_zip.linux.arm.manifest
+++ b/script/dist_zip.linux.arm.manifest
@@ -7,7 +7,6 @@ electron
 icudtl.dat
 libEGL.so
 libGLESv2.so
-libVkICD_mock_icd.so
 libffmpeg.so
 locales/am.pak
 locales/ar.pak

--- a/script/dist_zip.linux.arm64.manifest
+++ b/script/dist_zip.linux.arm64.manifest
@@ -7,7 +7,6 @@ electron
 icudtl.dat
 libEGL.so
 libGLESv2.so
-libVkICD_mock_icd.so
 libffmpeg.so
 locales/am.pak
 locales/ar.pak

--- a/script/dist_zip.linux.x64.manifest
+++ b/script/dist_zip.linux.x64.manifest
@@ -7,7 +7,6 @@ electron
 icudtl.dat
 libEGL.so
 libGLESv2.so
-libVkICD_mock_icd.so
 libffmpeg.so
 locales/am.pak
 locales/ar.pak

--- a/script/dist_zip.linux.x86.manifest
+++ b/script/dist_zip.linux.x86.manifest
@@ -7,7 +7,6 @@ electron
 icudtl.dat
 libEGL.so
 libGLESv2.so
-libVkICD_mock_icd.so
 libffmpeg.so
 locales/am.pak
 locales/ar.pak


### PR DESCRIPTION
#### Description of Change
Removes from electron.zip:
- VkICD_mock_icd.dll
- libVkICD_mock_icd.so

Chrome is not shipping those files either. Follow up to #17985

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Removed Vulkan mock ICD from electron.zip, which is only meant to be used for Chromium development.