### PR TITLE
fix: contractions handling in spellchecker (5-0-x)

### DIFF
--- a/atom/renderer/api/atom_api_spell_check_client.h
+++ b/atom/renderer/api/atom_api_spell_check_client.h
@@ -6,6 +6,7 @@
 #define ATOM_RENDERER_API_ATOM_API_SPELL_CHECK_CLIENT_H_
 
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -68,7 +69,7 @@ class SpellCheckClient : public blink::WebSpellCheckPanelHostClient,
   // The javascript function will callback OnSpellCheckDone
   // with the results of all the misspelled words.
   void SpellCheckWords(const SpellCheckScope& scope,
-                       const std::vector<base::string16>& words);
+                       const std::set<base::string16>& words);
 
   // Returns whether or not the given word is a contraction of valid words
   // (e.g. "word:word").

--- a/spec/api-web-frame-spec.js
+++ b/spec/api-web-frame-spec.js
@@ -41,19 +41,19 @@ describe('webFrame module', function () {
     const spellCheckerFeedback =
       new Promise(resolve => {
         ipcMain.on('spec-spell-check', (e, words, callback) => {
-          if (words.length === 2) {
-            // The promise is resolved only after this event is received twice
-            // Array contains only 1 word first time and 2 the next time
+          if (words.length === 5) {
+            // The API calls the provider after every completed word.
+            // The promise is resolved only after this event is received with all words.
             resolve([words, callback])
           }
         })
       })
-    const inputText = 'spleling test '
+    const inputText = `spleling test you're `
     for (const keyCode of inputText) {
       w.webContents.sendInputEvent({ type: 'char', keyCode })
     }
     const [words, callback] = await spellCheckerFeedback
-    expect(words).to.deep.equal(['spleling', 'test'])
+    expect(words.sort()).to.deep.equal(['spleling', 'test', `you're`, 'you', 're'].sort())
     expect(callback).to.be.true()
   })
 


### PR DESCRIPTION
Backport of #18506 

Notes: Spellcheck providers are now (again) called with contractions and their parts