### PR TITLE
refactor: make autoHideMenuBar a property on BrowserWindows

### DIFF
--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -1146,9 +1146,10 @@ void TopLevelWindow::BuildPrototype(v8::Isolate* isolate,
                    &TopLevelWindow::IsExcludedFromShownWindowsMenu,
                    &TopLevelWindow::SetExcludedFromShownWindowsMenu)
 #endif
-      .SetMethod("setAutoHideMenuBar", &TopLevelWindow::SetAutoHideMenuBar)
-      .SetMethod("isMenuBarAutoHide", &TopLevelWindow::IsMenuBarAutoHide)
-      .SetMethod("setMenuBarVisibility", &TopLevelWindow::SetMenuBarVisibility)
+      .SetMethod("_setAutoHideMenuBar", &TopLevelWindow::SetAutoHideMenuBar)
+      .SetMethod("_isMenuBarAutoHide", &TopLevelWindow::IsMenuBarAutoHide)
+      .SetProperty("autoHideMenuBar", &TopLevelWindow::IsMenuBarAutoHide,
+                   &TopLevelWindow::SetAutoHideMenuBar)
       .SetMethod("isMenuBarVisible", &TopLevelWindow::IsMenuBarVisible)
       .SetMethod("setAspectRatio", &TopLevelWindow::SetAspectRatio)
       .SetMethod("previewFile", &TopLevelWindow::PreviewFile)

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1470,9 +1470,13 @@ menu bar will only show when users press the single `Alt` key.
 If the menu bar is already visible, calling `setAutoHideMenuBar(true)` won't
 hide it immediately.
 
+**[Deprecated](modernization/property-updates.md)**
+
 #### `win.isMenuBarAutoHide()`
 
 Returns `Boolean` - Whether menu bar automatically hides itself.
+
+**[Deprecated](modernization/property-updates.md)**
 
 #### `win.setMenuBarVisibility(visible)` _Windows_ _Linux_
 
@@ -1641,6 +1645,13 @@ removed in future Electron releases.
 [chrome-content-scripts]: https://developer.chrome.com/extensions/content_scripts#execution-environment
 
 ### Properties
+
+#### `win.autoHideMenuBar`
+
+A `Boolean` property that determines whether the window menu bar should hide itself automatically. Once set, the menu bar will only show when users press the single `Alt` key.
+
+If the menu bar is already visible, setting this property to `true` won't
+hide it immediately.
 
 #### `win.excludedFromShownWindowsMenu` _macOS_
 

--- a/docs/api/modernization/property-updates.md
+++ b/docs/api/modernization/property-updates.md
@@ -22,7 +22,6 @@ The Electron team is currently undergoing an initiative to convert separate gett
   * `title`
   * `documentEdited`
   * `hasShadow`
-  * `autohideMenuBar`
   * `menubarVisible`
   * `visibleOnAllWorkspaces`
 * `crashReporter` module
@@ -54,6 +53,8 @@ The Electron team is currently undergoing an initiative to convert separate gett
   * `applicationMenu`
   * `badgeCount`
   * `name`
+* `BrowserWindow` module
+  * `autohideMenuBar`
 * `NativeImage`
   * `isMacTemplateImage`
 * `SystemPreferences` module

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const electron = require('electron')
-const { WebContentsView, TopLevelWindow } = electron
+const { WebContentsView, TopLevelWindow, deprecate } = electron
 const { BrowserWindow } = process.electronBinding('window')
 
 Object.setPrototypeOf(BrowserWindow.prototype, TopLevelWindow.prototype)
@@ -190,5 +190,8 @@ Object.assign(BrowserWindow.prototype, {
     this.webContents.setBackgroundThrottling(allowed)
   }
 })
+
+// Deprecations
+deprecate.fnToProperty(BrowserWindow.prototype, 'autoHideMenuBar', '_isMenuBarAutoHide', '_setAutoHideMenuBar')
 
 module.exports = BrowserWindow

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -513,6 +513,16 @@ describe('BrowserWindow module', () => {
     })
   })
 
+  describe('BrowserWindow autoHideMenuBar property', () => {
+    it('has an autoHideMenuBar property', () => {
+      expect(w).to.have.a.property('autoHideMenuBar')
+
+      // TODO(codebytere): remove when propertyification is complete
+      expect(w.setAutoHideMenuBar).to.be.a('function')
+      expect(w.isMenuBarAutoHide).to.be.a('function')
+    })
+  })
+
   describe('BrowserWindow.moveTop()', () => {
     it('should not steal focus', async () => {
       const posDelta = 50


### PR DESCRIPTION
#### Description of Change

This PR converts a getter/setter function pair on BrowserWindows that that determines whether the window menu bar should hide itself automatically to a bespoke property `autoHideMenuBar`.

cc @miniak @jkleinsc 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Converted `autoHideMenuBar` to a property on `BrowserWindow` instances.
