### PR TITLE
perf: lazily create the anchor tag used for URL resolving

### DIFF
--- a/lib/renderer/window-setup.ts
+++ b/lib/renderer/window-setup.ts
@@ -20,8 +20,9 @@ import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-in
 const { defineProperty } = Object
 
 // Helper function to resolve relative url.
-const a = window.document.createElement('a')
+let a: HTMLAnchorElement
 const resolveURL = function (url: string) {
+  a = a || window.document.createElement('a')
   a.href = url
   return a.href
 }


### PR DESCRIPTION
1ms is 1ms 🤷‍♂ No point making this element on the hot load path of the renderer

Notes: no-notes