### PR TITLE
refactor: lazy load child_process in the crash-reporter module

### DIFF
--- a/lib/browser/crash-reporter-init.js
+++ b/lib/browser/crash-reporter-init.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { app } = require('electron')
-const cp = require('child_process')
 const path = require('path')
 
 const getTempDirectory = function () {
@@ -30,7 +29,7 @@ exports.crashReporterInit = function (options) {
       '--v=1'
     ]
 
-    const crashServiceProcess = cp.spawn(process.helperExecPath, args, {
+    const crashServiceProcess = require('child_process').spawn(process.helperExecPath, args, {
       env,
       detached: true
     })


### PR DESCRIPTION
This module is on the hot load path and we don't need cp till later

Notes: no-notes