### PR TITLE
refactor: lazy load V8 module in browser/init

### DIFF
--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -2,7 +2,6 @@ import { Buffer } from 'buffer'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as util from 'util'
-import * as v8 from 'v8'
 
 const Module = require('module')
 
@@ -141,9 +140,10 @@ if (packageJson.desktopName != null) {
   app.setDesktopName(`${app.name}.desktop`)
 }
 
-// Set v8 flags
+// Set v8 flags, delibrately lazy load so that apps that do not use this
+// feature do not pay the price
 if (packageJson.v8Flags != null) {
-  v8.setFlagsFromString(packageJson.v8Flags)
+  require('v8').setFlagsFromString(packageJson.v8Flags)
 }
 
 app._setDefaultAppPaths(packagePath)


### PR DESCRIPTION
Most apps don't use this and the cost of importing `v8` all the time is >=5ms

Notes: no-notes