### PR TITLE
refactor: don't use export default

### DIFF
--- a/lib/browser/api/app.ts
+++ b/lib/browser/api/app.ts
@@ -8,7 +8,7 @@ const commandLine = process.electronBinding('command_line')
 const { app, App } = bindings
 
 // Only one app object permitted.
-export default app
+export = app
 
 let dockMenu: Electron.Menu | null = null
 

--- a/lib/browser/api/exports/electron.js
+++ b/lib/browser/api/exports/electron.js
@@ -10,6 +10,6 @@ common.defineProperties(exports)
 for (const module of moduleList) {
   Object.defineProperty(exports, module.name, {
     enumerable: !module.private,
-    get: common.handleESModule(module.loader)
+    get: module.loader
   })
 }

--- a/lib/browser/api/ipc-main.ts
+++ b/lib/browser/api/ipc-main.ts
@@ -37,4 +37,4 @@ const ipcMain = new IpcMain()
 // Do not throw exception when channel name is "error".
 ipcMain.on('error', () => {})
 
-export default ipcMain
+export = ipcMain

--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -26,4 +26,4 @@ Object.setPrototypeOf(protocol, new Proxy({}, {
   }
 }))
 
-export default protocol
+export = protocol

--- a/lib/common/api/deprecate.ts
+++ b/lib/common/api/deprecate.ts
@@ -177,4 +177,4 @@ const deprecate: ElectronInternal.DeprecationUtil = {
   }
 }
 
-export default deprecate
+export = deprecate

--- a/lib/common/api/exports/electron.js
+++ b/lib/common/api/exports/electron.js
@@ -2,12 +2,6 @@
 
 const moduleList = require('@electron/internal/common/api/module-list')
 
-exports.handleESModule = (loader) => () => {
-  const value = loader()
-  if (value.__esModule) return value.default
-  return value
-}
-
 exports.memoizedGetter = (getter) => {
   /*
    * It's ok to leak this value as it would be leaked by the global
@@ -30,7 +24,7 @@ exports.defineProperties = function (targetExports) {
   for (const module of moduleList) {
     descriptors[module.name] = {
       enumerable: !module.private,
-      get: exports.handleESModule(module.loader)
+      get: module.loader
     }
   }
   return Object.defineProperties(targetExports, descriptors)

--- a/lib/renderer/api/exports/electron.js
+++ b/lib/renderer/api/exports/electron.js
@@ -9,6 +9,6 @@ common.defineProperties(exports)
 for (const module of moduleList) {
   Object.defineProperty(exports, module.name, {
     enumerable: !module.private,
-    get: common.handleESModule(module.loader)
+    get: module.loader
   })
 }

--- a/lib/renderer/api/web-frame.ts
+++ b/lib/renderer/api/web-frame.ts
@@ -66,4 +66,4 @@ function getWebFrame (context: Window) {
 
 const _webFrame = new WebFrame(window)
 
-export default _webFrame
+export = _webFrame

--- a/lib/sandboxed_renderer/api/exports/electron.js
+++ b/lib/sandboxed_renderer/api/exports/electron.js
@@ -2,12 +2,6 @@
 
 const moduleList = require('@electron/internal/sandboxed_renderer/api/module-list')
 
-const handleESModule = (m) => {
-  // Handle Typescript modules with an "export default X" statement
-  if (m.__esModule) return m.default
-  return m
-}
-
 for (const {
   name,
   load,
@@ -20,6 +14,6 @@ for (const {
 
   Object.defineProperty(exports, name, {
     enumerable: !isPrivate,
-    get: () => handleESModule(load())
+    get: () => load()
   })
 }


### PR DESCRIPTION
#### Description of Change
Use `export = xyz` as this does not need the `handleESModule` hack, which is not reliable as `__esModule` does not necessarily mean that `default` export is used.

/cc @MarshallOfSound

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes