### PR TITLE
refactor: remove menu-will-close / setTimeout workaround

### DIFF
--- a/lib/browser/devtools.js
+++ b/lib/browser/devtools.js
@@ -69,14 +69,7 @@ ipcMainUtils.handle('ELECTRON_INSPECTOR_CONTEXT_MENU', function (event, items, i
     const menu = Menu.buildFromTemplate(template)
     const window = event.sender.getOwnerBrowserWindow()
 
-    menu.once('menu-will-close', () => {
-      // menu-will-close is emitted before the click handler, but needs to be sent after.
-      // otherwise, DevToolsAPI.contextMenuCleared() would be called before
-      // DevToolsAPI.contextMenuItemSelected(id) and the menu will not work properly.
-      setTimeout(() => resolve())
-    })
-
-    menu.popup({ window })
+    menu.popup({ window, callback: () => resolve() })
   })
 })
 


### PR DESCRIPTION
#### Description of Change
Change the `ELECTRON_INSPECTOR_CONTEXT_MENU` handler to not rely on a timeout.
The timeout was added when reimplementing the inspector APIs to not use the remote module. 
This PR changes the implementation to something more straightforward so that a three-line explanation comment is no longer necessary.

We want the callback handler (ie, calling `resolve()`) to happen when the menu closed. The old impl used a timer to do this after `menu-will-close` fired; the new impl uses the closed callback from the [`Menu.popup() options`](https://electronjs.org/docs/api/menu#menupopupoptions) instead.

See discussion at https://github.com/electron/electron/pull/16607#pullrequestreview-200797896 (and followup discussion at https://github.com/electron/electron/pull/16794#pullrequestreview-200834486) for more details.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes