### PR TITLE
feat: add basic edit (cut/copy/paste) menu to "browser" mode in default app

### DIFF
--- a/default_app/default_app.ts
+++ b/default_app/default_app.ts
@@ -1,4 +1,4 @@
-import { app, dialog, BrowserWindow, shell, ipcMain } from 'electron'
+import { app, dialog, BrowserWindow, Menu, shell, ipcMain } from 'electron'
 import * as path from 'path'
 
 let mainWindow: BrowserWindow | null = null
@@ -45,6 +45,18 @@ ipcMain.on('bootstrap', (event) => {
   }
 })
 
+const editMenuTemplate: Electron.MenuItemConstructorOptions[] = [
+  { role: 'undo' },
+  { role: 'redo' },
+  { type: 'separator' },
+  { role: 'cut' },
+  { role: 'copy' },
+  { role: 'paste' },
+  { role: 'pasteandmatchstyle' },
+  { role: 'delete' },
+  { role: 'selectall' }
+]
+
 async function createWindow () {
   await app.whenReady()
 
@@ -69,6 +81,21 @@ async function createWindow () {
 
   mainWindow = new BrowserWindow(options)
   mainWindow.on('ready-to-show', () => mainWindow!.show())
+
+  mainWindow.webContents.on('context-menu', (event, params) => {
+    const menu = Menu.buildFromTemplate([
+      ...(params.isEditable ? editMenuTemplate : []),
+      { type: 'separator' },
+      {
+        label: 'Inspect',
+        click: () => {
+          mainWindow!.webContents.inspectElement(params.x, params.y)
+        }
+      }
+    ])
+
+    menu.popup()
+  })
 
   mainWindow.webContents.on('new-window', (event, url) => {
     event.preventDefault()


### PR DESCRIPTION
#### Description of Change
Add simple context menu to the default app with basic editing commands (cut / copy / paste) for editable elements + always visible inspect item.

Reason: when you open a webpage with electron via the default-app, there is no context menu at all without this change on `<input type="text">` or `<textarea>`

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added basic edit (cut/copy/paste) menu to "browser" mode in default app.