### PR TITLE
build: strip swiftshader binaries

### DIFF
--- a/script/strip-binaries.py
+++ b/script/strip-binaries.py
@@ -9,7 +9,9 @@ LINUX_BINARIES_TO_STRIP = [
   'electron',
   'libffmpeg.so',
   'libGLESv2.so',
-  'libEGL.so'
+  'libEGL.so',
+  'swiftshader/libGLESv2.so',
+  'swiftshader/libEGL.so'
 ]
 
 def strip_binaries(directory, target_cpu):


### PR DESCRIPTION
#### Description of Change
Add missing swiftshader libraries (`libEGL.so`, `libGLESv2.so`) to `LINUX_BINARIES_TO_STRIP`.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed electron.zip size increase regression on Linux (compared to Electron 3) by stripping swiftshader libraries (`libEGL.so`, `libGLESv2.so`).