### PR TITLE
build: install python-dbusmock via pip for a Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
 RUN pip install -U crcmod
 
 # dbusmock is needed for Electron tests
-RUN pip install python-dbusmock==0.18.1
+RUN pip install python-dbusmock
 
 RUN mkdir /tmp/workspace
 RUN chown builduser:builduser /tmp/workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     locales \
     lsb-release \
     nano \
-    python-dbusmock \
+    python-dbus \
     python-pip \
     python-setuptools \
     sudo \
@@ -32,6 +32,9 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
 
 # crcmod is required by gsutil, which is used for filling the gclient git cache
 RUN pip install -U crcmod
+
+# dbusmock is needed for Electron tests
+RUN pip install python-dbusmock==0.18.1
 
 RUN mkdir /tmp/workspace
 RUN chown builduser:builduser /tmp/workspace


### PR DESCRIPTION
#### Description of Change
To prevent timeout errors with some other python-dbusmock versions.

Related to #18523.
* Linux builds are timing out but passing tests. It turns out that dbusmock was hanging on dbus_stop. This PR changes the docker container to use a newer version of python-dbusmock which adds timeouts to dbus_stop.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes