### PR TITLE
build: bring in a later compiler for Windows on Arm

### DIFF
--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -194,15 +194,38 @@ $ gn gen out/Debug-x86 --args='... target_cpu = "x86"'
 ```
 
 Not all combinations of source and target CPU/OS are supported by Chromium.
-Only cross-compiling Windows 32-bit from Windows 64-bit and Linux 32-bit from
-Linux 64-bit have been tested in Electron. If you test other combinations and
-find them to work, please update this document :)
+
+<table>
+<tr><th>Host</th><th>Target</th><th>Status</th></tr>
+<tr><td>Windows x64</td><td>Windows arm64</td><td>Experimental</td>
+<tr><td>Windows x64</td><td>Windows x86</td><td>Automatically tested</td></tr>
+<tr><td>Linux x64</td><td>Linux x86</td><td>Automatically tested</td></tr>
+</table>
+
+If you test other combinations and find them to work, please update this document :)
 
 See the GN reference for allowable values of [`target_os`][target_os values]
-and [`target_cpu`][target_cpu values]
+and [`target_cpu`][target_cpu values].
 
 [target_os values]: https://gn.googlesource.com/gn/+/master/docs/reference.md#built_in-predefined-variables-target_os_the-desired-operating-system-for-the-build-possible-values
 [target_cpu values]: https://gn.googlesource.com/gn/+/master/docs/reference.md#built_in-predefined-variables-target_cpu_the-desired-cpu-architecture-for-the-build-possible-values
+
+#### Windows on Arm (experimental)
+To cross-compile for Windows on Arm, [follow Chromium's guide](https://chromium.googlesource.com/chromium/src/+/refs/heads/master/docs/windows_build_instructions.md#Visual-Studio) to get the necessary dependencies, SDK and libraries, then build with `ELECTRON_BUILDING_WOA=1` in your environment before running `gclient sync`.
+
+```bat
+set ELECTRON_BUILDING_WOA=1
+gclient sync -f --with_branch_heads --with_tags
+```
+
+Or (if using PowerShell):
+```powershell
+$env:ELECTRON_BUILDING_WOA=1
+gclient sync -f --with_branch_heads --with_tags
+```
+
+Next, run `gn gen` as above with `target_cpu="arm64"`.
+
 
 ## Tests
 

--- a/patches/common/chromium/.patches
+++ b/patches/common/chromium/.patches
@@ -78,3 +78,4 @@ worker_context_will_destroy.patch
 fix_breakpad_symbol_generation_on_linux_arm.patch
 cross_site_document_resource_handler.patch
 frame_host_manager.patch
+woa_compiler_workaround.patch

--- a/patches/common/chromium/woa_compiler_workaround.patch
+++ b/patches/common/chromium/woa_compiler_workaround.patch
@@ -1,0 +1,37 @@
+From b3414d055399d0a21f6166a536467ea752b2aa8a Mon Sep 17 00:00:00 2001
+From: Richard Townsend <richard.townsend@arm.com>
+Date: Mon, 3 Jun 2019 09:52:49 +0100
+Subject: build: pull in a fixed compiler for Windows on Arm
+
+Due to a code-generation defect in the version of Clang used for the M76
+branch related to virtual method thunks, it's necessary to build M76
+with a later version of Clang. This change pulls in a corrected version
+by setting ELECTRON_BUILDING_WOA=1 or similar in the environment.
+
+This PR is only intended to be a temporary workaround and will be
+removed when Electron's Chromium updates to a compiler unaffected by
+this issue.
+---
+ tools/clang/scripts/update.py | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/tools/clang/scripts/update.py b/tools/clang/scripts/update.py
+index 876fb66d1ac6..69c2688aaf55 100755
+--- a/tools/clang/scripts/update.py
++++ b/tools/clang/scripts/update.py
+@@ -40,6 +40,12 @@ CLANG_REVISION = '67510fac36d27b2e22c7cd955fc167136b737b93'
+ CLANG_SVN_REVISION = '361212'
+ CLANG_SUB_REVISION = 2
+
++if os.getenv('ELECTRON_BUILDING_WOA'):
++    CLANG_REVISION = '56bee1a90a71876cb5067b108bf5715fa1c4e843'
++    CLANG_SVN_REVISION = '361657'
++    CLANG_SUB_REVISION = 1
++
++
+ PACKAGE_VERSION = '%s-%s-%s' % (CLANG_SVN_REVISION, CLANG_REVISION[:8],
+                                 CLANG_SUB_REVISION)
+ RELEASE_VERSION = '9.0.0'
+--
+2.19.1.windows.1
+


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Due to a code-gen defect affecting virtual method calls in the official Clang used in the M76 branch, it's necessary to use a slightly newer compiler for Windows. [The issue has been fixed upstream](https://bugs.llvm.org/show_bug.cgi?id=41997), but for various reasons it was not possible to update the compiler to a version that worked on all devices in M76. This is only intended to be a temporary workaround and will be removed when upstream Chromium updates to a Clang version which fixes the problem.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added experimental support for building for Windows on Arm <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
