### PR TITLE
build: fix v8 symbols for Windows on Arm

### DIFF
--- a/patches/common/v8/build_gn.patch
+++ b/patches/common/v8/build_gn.patch
@@ -1,37 +1,48 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From b8362980ad805e6835d2ca528da06e0cfacf11bf Mon Sep 17 00:00:00 2001
 From: Jeremy Apthorp <nornagon@nornagon.net>
 Date: Tue, 16 Apr 2019 10:43:04 -0700
 Subject: build_gn.patch
 
+Patch-Filename: build_gn.patch
+---
+ BUILD.gn | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
 
 diff --git a/BUILD.gn b/BUILD.gn
-index bb9372d63ba90a1f78db0310bde991d5ff789285..01ef8b8420cb951db372753a4d8b9e987cfb237c 100644
+index bb9372d63b..7d063f0ed9 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -269,7 +269,7 @@ config("internal_config") {
+@@ -269,7 +269,11 @@ config("internal_config") {
      ":v8_header_features",
    ]
- 
+
 -  if (is_component_build) {
-+  if (is_component_build || is_electron_build) {
++  if (is_component_build ||
++      (is_electron_build && (!(is_win && target_cpu == "arm64") ||
++                             current_toolchain != host_toolchain))) {
++    # Condition is checking Arm64 Windows => using target toolchain
++    # Reduce via De Morgan's Law: to !(Arm64 Windows) v target toolchain
      defines += [ "BUILDING_V8_SHARED" ]
    }
  }
-@@ -3784,7 +3784,7 @@ if (current_toolchain == v8_generator_toolchain) {
+@@ -3784,7 +3788,7 @@ if (current_toolchain == v8_generator_toolchain) {
        "src/interpreter/bytecodes.h",
      ]
- 
+
 -    configs = [ ":internal_config" ]
 +    configs = [ ":internal_config_base" ]
- 
+
      deps = [
        ":v8_libbase",
-@@ -3815,6 +3815,8 @@ if (v8_use_snapshot && current_toolchain == v8_snapshot_toolchain) {
- 
+@@ -3815,6 +3819,8 @@ if (v8_use_snapshot && current_toolchain == v8_snapshot_toolchain) {
+
      configs = [ ":internal_config" ]
- 
+
 +    configs += [ "//electron/build/config:build_time_executable" ]
 +
      deps = [
        ":v8_base_without_compiler",
        ":v8_compiler_for_mksnapshot",
+--
+2.19.1.windows.1
+

--- a/patches/common/v8/workaround_an_undefined_symbol_error.patch
+++ b/patches/common/v8/workaround_an_undefined_symbol_error.patch
@@ -3,73 +3,31 @@ From: Richard Townsend <richard.townsend@arm.com>
 Date: Wed, 24 Apr 2019 13:57:36 +0100
 Subject: Workaround an undefined symbol error
 
-Previously, builds configured with dcheck_always_on=true would error
-with messages like this in the log:
+Previously, electron builds configured with dcheck_always_on=true would
+error out with messages like this in the log:
+
  lld-link: error: undefined symbol: public: bool __cdecl
-  v8::internal::CPURegister::IsZero(void) const
+   v8::internal::CPURegister::IsZero(void) const
 
-By moving some functions out of the the arm64-assembler header file,
-this error no longer seems to happen.
+This problem is caused by electron's unusual build configuration, where
+symbols are exported, but the binary is non-component. By adding a
+header into the appropriate place, this error no longer occurs.
+---
+ src/regexp/arm64/regexp-macro-assembler-arm64.h | 1 +
+ 1 file changed, 1 insertion(+)
 
-diff --git a/src/arm64/assembler-arm64.cc b/src/arm64/assembler-arm64.cc
-index 770dbd0827f03d40d30b530504ba0900f56011f1..b5e0e706ce2bda34f286c68e55d8ba993c4cf9db 100644
---- a/src/arm64/assembler-arm64.cc
-+++ b/src/arm64/assembler-arm64.cc
-@@ -4013,6 +4013,22 @@ void Assembler::MoveWide(const Register& rd, uint64_t imm, int shift,
-        ImmMoveWide(static_cast<int>(imm)) | ShiftMoveWide(shift));
- }
- 
-+Instr Assembler::RmNot31(CPURegister rm) {
-+  DCHECK_NE(rm.code(), kSPRegInternalCode);
-+  DCHECK(!rm.IsZero());
-+  return Rm(rm);
-+}
-+
-+Instr Assembler::RdSP(Register rd) {
-+  DCHECK(!rd.IsZero());
-+  return (rd.code() & kRegCodeMask) << Rd_offset;
-+}
-+
-+Instr Assembler::RnSP(Register rn) {
-+  DCHECK(!rn.IsZero());
-+  return (rn.code() & kRegCodeMask) << Rn_offset;
-+}
-+
- void Assembler::AddSub(const Register& rd, const Register& rn,
-                        const Operand& operand, FlagsUpdate S, AddSubOp op) {
-   DCHECK_EQ(rd.SizeInBits(), rn.SizeInBits());
-diff --git a/src/arm64/assembler-arm64.h b/src/arm64/assembler-arm64.h
-index 4791dcdbc7062a5d222d5c11a9c49c811e0e3fe6..bf69046dc3ff6c773261f2257b5cdb0be6822d52 100644
---- a/src/arm64/assembler-arm64.h
-+++ b/src/arm64/assembler-arm64.h
-@@ -2226,11 +2226,7 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase {
-     return rm.code() << Rm_offset;
-   }
- 
--  static Instr RmNot31(CPURegister rm) {
--    DCHECK_NE(rm.code(), kSPRegInternalCode);
--    DCHECK(!rm.IsZero());
--    return Rm(rm);
--  }
-+  static Instr RmNot31(CPURegister rm);
- 
-   static Instr Ra(CPURegister ra) {
-     DCHECK_NE(ra.code(), kSPRegInternalCode);
-@@ -2254,15 +2250,8 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase {
- 
-   // These encoding functions allow the stack pointer to be encoded, and
-   // disallow the zero register.
--  static Instr RdSP(Register rd) {
--    DCHECK(!rd.IsZero());
--    return (rd.code() & kRegCodeMask) << Rd_offset;
--  }
--
--  static Instr RnSP(Register rn) {
--    DCHECK(!rn.IsZero());
--    return (rn.code() & kRegCodeMask) << Rn_offset;
--  }
-+  static Instr RdSP(Register rd);
-+  static Instr RnSP(Register rn);
- 
-   // Flags encoding.
-   inline static Instr Flags(FlagsUpdate S);
+diff --git a/src/regexp/arm64/regexp-macro-assembler-arm64.h b/src/regexp/arm64/regexp-macro-assembler-arm64.h
+index 4c6f579655..0a24056beb 100644
+--- a/src/regexp/arm64/regexp-macro-assembler-arm64.h
++++ b/src/regexp/arm64/regexp-macro-assembler-arm64.h
+@@ -6,6 +6,7 @@
+ #define V8_REGEXP_ARM64_REGEXP_MACRO_ASSEMBLER_ARM64_H_
+
+ #include "src/arm64/assembler-arm64.h"
++#include "src/arm64/assembler-arm64-inl.h"
+ #include "src/codegen/macro-assembler.h"
+ #include "src/regexp/regexp-macro-assembler.h"
+
+--
+2.19.1.windows.1
+


### PR DESCRIPTION
#### Description of Change
Adjusts V8 symbol visibility so that symbols are kept private for the host toolchain and are exposed for the target toolchain, which means significantly fewer workarounds are needed for symbol visibility on Windows on Arm. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
