### PR TITLE
refactor: mojofy zoom api

### DIFF
--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -474,7 +474,6 @@ class WebContents : public mate::TrackableObject<WebContents>,
 #endif
 
  private:
-  struct FrameDispatchHelper;
   AtomBrowserContext* GetBrowserContext() const;
 
   // Binds the given request for the ElectronBrowser API. When the
@@ -509,15 +508,11 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void MessageHost(const std::string& channel, base::Value arguments) override;
   void UpdateDraggableRegions(
       std::vector<mojom::DraggableRegionPtr> regions) override;
+  void SetTemporaryZoomLevel(double level) override;
+  void DoGetZoomLevel(DoGetZoomLevelCallback callback) override;
 
   // Called when we receive a CursorChange message from chromium.
   void OnCursorChange(const content::WebCursor& cursor);
-
-  // Called when received a synchronous message from renderer to
-  // set temporary zoom level.
-  void OnSetTemporaryZoomLevel(content::RenderFrameHost* frame_host,
-                               double level,
-                               IPC::Message* reply_msg);
 
   // Called when received a synchronous message from renderer to
   // get the zoom level.

--- a/atom/common/api/api.mojom
+++ b/atom/common/api/api.mojom
@@ -59,4 +59,9 @@ interface ElectronBrowser {
 
   UpdateDraggableRegions(
     array<DraggableRegion> regions);
+
+  SetTemporaryZoomLevel(double zoom_level);
+
+  [Sync]
+  DoGetZoomLevel() => (double result);
 };

--- a/atom/common/api/api_messages.h
+++ b/atom/common/api/api_messages.h
@@ -31,11 +31,3 @@ IPC_MESSAGE_ROUTED1(AtomAutofillFrameMsg_AcceptSuggestion,
 
 // Update renderer process preferences.
 IPC_MESSAGE_CONTROL1(AtomMsg_UpdatePreferences, base::ListValue)
-
-// Sent by renderer to set the temporary zoom level.
-IPC_SYNC_MESSAGE_ROUTED1_1(AtomFrameHostMsg_SetTemporaryZoomLevel,
-                           double /* zoom level */,
-                           double /* result */)
-
-// Sent by renderer to get the zoom level.
-IPC_SYNC_MESSAGE_ROUTED0_1(AtomFrameHostMsg_GetZoomLevel, double /* result */)

--- a/atom/common/api/api_messages.h
+++ b/atom/common/api/api_messages.h
@@ -11,9 +11,6 @@
 #include "ui/gfx/geometry/rect_f.h"
 #include "ui/gfx/ipc/gfx_param_traits.h"
 
-// The message starter should be declared in ipc/ipc_message_start.h. Since
-// we don't want to patch Chromium, we just pretend to be Content Shell.
-
 #define IPC_MESSAGE_START ElectronMsgStart
 
 IPC_MESSAGE_ROUTED3(AtomAutofillFrameHostMsg_ShowPopup,

--- a/atom/common/api/api_messages.h
+++ b/atom/common/api/api_messages.h
@@ -7,12 +7,9 @@
 #include "base/strings/string16.h"
 #include "base/values.h"
 #include "content/public/common/common_param_traits.h"
-#include "content/public/common/referrer.h"
 #include "ipc/ipc_message_macros.h"
-#include "ipc/ipc_platform_file.h"
 #include "ui/gfx/geometry/rect_f.h"
 #include "ui/gfx/ipc/gfx_param_traits.h"
-#include "url/gurl.h"
 
 // The message starter should be declared in ipc/ipc_message_start.h. Since
 // we don't want to patch Chromium, we just pretend to be Content Shell.

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "atom/common/api/api.mojom.h"
 #include "atom/common/api/api_messages.h"
 #include "atom/common/api/event_emitter_caller.h"
 #include "atom/common/native_mate_converters/blink_converter.h"
@@ -23,6 +24,7 @@
 #include "content/public/renderer/render_view.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/object_template_builder.h"
+#include "services/service_manager/public/cpp/interface_provider.h"
 #include "third_party/blink/public/platform/web_cache.h"
 #include "third_party/blink/public/platform/web_isolated_world_info.h"
 #include "third_party/blink/public/web/web_custom_element.h"
@@ -201,25 +203,26 @@ void SetName(v8::Local<v8::Value> window, const std::string& name) {
       blink::WebString::FromUTF8(name));
 }
 
-double SetZoomLevel(v8::Local<v8::Value> window, double level) {
-  double result = 0.0;
+void SetZoomLevel(v8::Local<v8::Value> window, double level) {
   content::RenderFrame* render_frame = GetRenderFrame(window);
-  render_frame->Send(new AtomFrameHostMsg_SetTemporaryZoomLevel(
-      render_frame->GetRoutingID(), level, &result));
-  return result;
+  mojom::ElectronBrowserPtr browser_ptr;
+  render_frame->GetRemoteInterfaces()->GetInterface(
+      mojo::MakeRequest(&browser_ptr));
+  browser_ptr->SetTemporaryZoomLevel(level);
 }
 
 double GetZoomLevel(v8::Local<v8::Value> window) {
   double result = 0.0;
   content::RenderFrame* render_frame = GetRenderFrame(window);
-  render_frame->Send(
-      new AtomFrameHostMsg_GetZoomLevel(render_frame->GetRoutingID(), &result));
+  mojom::ElectronBrowserPtr browser_ptr;
+  render_frame->GetRemoteInterfaces()->GetInterface(
+      mojo::MakeRequest(&browser_ptr));
+  browser_ptr->DoGetZoomLevel(&result);
   return result;
 }
 
-double SetZoomFactor(v8::Local<v8::Value> window, double factor) {
-  return blink::WebView::ZoomLevelToZoomFactor(
-      SetZoomLevel(window, blink::WebView::ZoomFactorToZoomLevel(factor)));
+void SetZoomFactor(v8::Local<v8::Value> window, double factor) {
+  SetZoomLevel(window, blink::WebView::ZoomFactorToZoomLevel(factor));
 }
 
 double GetZoomFactor(v8::Local<v8::Value> window) {


### PR DESCRIPTION
#### Description of Change
Mojofies the webFrame.{get,set}ZoomLevel API.

`setZoomLevel` used to return the new zoom level, but that wasn't documented or tested anywhere, so I removed the return value in order to make the IPC asynchronous. The `getZoomLevel` API is unfortunately synchronous, but because there aren't any weird ordering dependencies I was able to use `[Sync]` instead of jumping through the hoops I had to do for `MessageSync`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes