### PR TITLE
refactor: use the URL api to resolve urls in BrowserWindowProxy

### DIFF
--- a/lib/renderer/window-setup.ts
+++ b/lib/renderer/window-setup.ts
@@ -20,12 +20,7 @@ import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-in
 const { defineProperty } = Object
 
 // Helper function to resolve relative url.
-let a: HTMLAnchorElement
-const resolveURL = function (url: string) {
-  a = a || window.document.createElement('a')
-  a.href = url
-  return a.href
-}
+const resolveURL = (url: string, base: string) => new URL(url, base).href
 
 // Use this method to ensure values expected as strings in the main process
 // are convertible to strings in the renderer process. This ensures exceptions
@@ -129,7 +124,7 @@ class BrowserWindowProxy {
     return this._location
   }
   public set location (url: string | any) {
-    url = resolveURL(url)
+    url = resolveURL(url, this.location.href)
     this._invokeWebContentsMethodSync('loadURL', url)
   }
 
@@ -194,7 +189,7 @@ export const windowSetup = (
     // Make the browser window or guest view emit "new-window" event.
     (window as any).open = function (url?: string, frameName?: string, features?: string) {
       if (url != null && url !== '') {
-        url = resolveURL(url)
+        url = resolveURL(url, location.href)
       }
       const guestId = ipcRendererInternal.sendSync('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', url, toString(frameName), toString(features))
       if (guestId != null) {


### PR DESCRIPTION
#### Description of Change
Use the URL API instead of creating a dummy <a> element for resolving URLs in BrowserWindowProxy and related classes.

Ref https://github.com/electron/electron/pull/18571#discussion_r290060229

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes