### PR TITLE
fix: don't export private V8 symbols that can cause native node modules to crash

### DIFF
--- a/patches/common/v8/.patches
+++ b/patches/common/v8/.patches
@@ -5,3 +5,4 @@ deps_provide_more_v8_backwards_compatibility.patch
 dcheck.patch
 export_symbols_needed_for_windows_build.patch
 workaround_an_undefined_symbol_error.patch
+do_not_export_private_v8_symbols_on_windows.patch

--- a/patches/common/v8/do_not_export_private_v8_symbols_on_windows.patch
+++ b/patches/common/v8/do_not_export_private_v8_symbols_on_windows.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tomas Rycl <torycl@microsoft.com>
+Date: Mon, 13 May 2019 15:48:48 +0200
+Subject: Do not export private V8 symbols on Windows
+
+This change stops private V8 symbols and internal crt methods being exported.
+It fixes an issue where native node modules can import
+incorrect CRT methods and crash on Windows.
+It also reduces size of node.lib by 75%.
+
+This patch can be safely removed if, when it is removed, `node.lib` does not
+contain any standard C++ library exports (e.g. `std::ostringstream`).
+
+diff --git a/BUILD.gn b/BUILD.gn
+index 1acc7006545bd4ff6112b444758bde4c16d0c3e5..748d700cead149f5cdeebcfe11d07516db3d6a86 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -269,6 +269,10 @@ config("internal_config") {
+     ":v8_header_features",
+   ]
+ 
++  if (!is_component_build && is_electron_build) {
++    defines += [ "HIDE_PRIVATE_SYMBOLS" ]
++  }
++
+   if (is_component_build || is_electron_build) {
+     defines += [ "BUILDING_V8_SHARED" ]
+   }
+diff --git a/src/base/macros.h b/src/base/macros.h
+index ad70e9820ddb4a63639ca7738c1836cb87766db5..d40be9b57294583f74594d88d9b7d7b937b2db3c 100644
+--- a/src/base/macros.h
++++ b/src/base/macros.h
+@@ -414,13 +414,17 @@ bool is_inbounds(float_t v) {
+ #ifdef V8_OS_WIN
+ 
+ // Setup for Windows shared library export.
++#if defined(HIDE_PRIVATE_SYMBOLS)
++#define V8_EXPORT_PRIVATE
++#else //if !defined(HIDE_PRIVATE_SYMBOLS)
+ #ifdef BUILDING_V8_SHARED
+ #define V8_EXPORT_PRIVATE __declspec(dllexport)
+ #elif USING_V8_SHARED
+ #define V8_EXPORT_PRIVATE __declspec(dllimport)
+-#else
++#else //!(BUILDING_V8_SHARED || USING_V8_SHARED)
+ #define V8_EXPORT_PRIVATE
+-#endif  // BUILDING_V8_SHARED
++#endif
++#endif
+ 
+ #else  // V8_OS_WIN
+ 


### PR DESCRIPTION
#### Description of Change
Backport of #18281

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Removed incorrectly published internal V8 symbols and CRT methods from node.lib, causing heap corruptions with node modules using the dynamic CRT on Windows.