### PR TITLE
fix: don't export private V8 symbols that can cause native node modules to crash

### DIFF
--- a/patches/common/v8/.patches
+++ b/patches/common/v8/.patches
@@ -8,3 +8,4 @@ do_not_run_arm_arm64_mksnapshot_binaries.patch
 deps_provide_more_v8_backwards_compatibility.patch
 dcheck.patch
 expose_protected_v8_platform_systemclocktimemillis.patch
+do_not_export_private_v8_symbols_on_windows.patch

--- a/patches/common/v8/do_not_export_private_v8_symbols_on_windows.patch
+++ b/patches/common/v8/do_not_export_private_v8_symbols_on_windows.patch
@@ -1,0 +1,63 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tomas Rycl <torycl@microsoft.com>
+Date: Mon, 13 May 2019 15:48:48 +0200
+Subject: Do not export private V8 symbols on Windows
+
+This change stops private V8 symbols and internal crt methods being exported.
+It fixes an issue where native node modules can import
+incorrect CRT methods and crash on Windows.
+It also reduces size of node.lib by 75%.
+
+This patch can be safely removed if, when it is removed, `node.lib` does not
+contain any standard C++ library exports (e.g. `std::ostringstream`).
+
+diff --git a/BUILD.gn b/BUILD.gn
+index 465247a682cc1012d77c28c731fe1553565f128f..d208b9a2fbb6409bd436169b29786349a4df3b19 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -229,6 +229,7 @@ v8_toolset_for_shell = "host"
+ # Configurations
+ #
+ config("internal_config") {
++  defines = []
+   visibility = [ ":*" ]  # Only targets in this file can depend on this.
+ 
+   include_dirs = [
+@@ -238,8 +239,12 @@ config("internal_config") {
+ 
+   configs = [ "//build/config/compiler:wexit_time_destructors" ]
+ 
++  if (!is_component_build && is_electron_build) {
++    defines += [ "HIDE_PRIVATE_SYMBOLS" ]
++  }
++
+   if (is_component_build || is_electron_build) {
+-    defines = [ "BUILDING_V8_SHARED" ]
++    defines += [ "BUILDING_V8_SHARED" ]
+   }
+ }
+ 
+diff --git a/src/base/macros.h b/src/base/macros.h
+index 8a088ffc40eacb15b2833d6a85612e2075315fb9..76791d31b4a695ba9f8bb80121a791f512d99879 100644
+--- a/src/base/macros.h
++++ b/src/base/macros.h
+@@ -415,13 +415,17 @@ bool is_inbounds(float_t v) {
+ #ifdef V8_OS_WIN
+ 
+ // Setup for Windows shared library export.
++#if defined(HIDE_PRIVATE_SYMBOLS)
++#define V8_EXPORT_PRIVATE
++#else //if !defined(HIDE_PRIVATE_SYMBOLS)
+ #ifdef BUILDING_V8_SHARED
+ #define V8_EXPORT_PRIVATE __declspec(dllexport)
+ #elif USING_V8_SHARED
+ #define V8_EXPORT_PRIVATE __declspec(dllimport)
+-#else
++#else //!(BUILDING_V8_SHARED || USING_V8_SHARED)
+ #define V8_EXPORT_PRIVATE
+-#endif  // BUILDING_V8_SHARED
++#endif
++#endif
+ 
+ #else  // V8_OS_WIN
+ 


### PR DESCRIPTION
#### Description of Change
Backport of #18281

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Removed incorrectly published internal V8 symbols and CRT methods from node.lib, causing heap corruptions with node modules using the dynamic CRT on Windows.