### PR TITLE
build: move Windows release builds to AppVeyor cloud

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # These env vars are only necessary for creating Electron releases.
 # See docs/development/releasing.md
 
-APPVEYOR_TOKEN=
+APPVEYOR_CLOUD_TOKEN=
 CIRCLE_TOKEN=
 ELECTRON_GITHUB_TOKEN=
 VSTS_TOKEN=

--- a/script/ci-release-build.js
+++ b/script/ci-release-build.js
@@ -104,7 +104,7 @@ async function callAppVeyor (targetBranch, job, options) {
   const requestOpts = {
     url: buildAppVeyorURL,
     auth: {
-      bearer: process.env.APPVEYOR_TOKEN
+      bearer: process.env.APPVEYOR_CLOUD_TOKEN
     },
     headers: {
       'Content-Type': 'application/json'

--- a/script/ci-release-build.js
+++ b/script/ci-release-build.js
@@ -2,11 +2,11 @@ require('dotenv-safe').load()
 
 const assert = require('assert')
 const request = require('request')
-const buildAppVeyorURL = 'https://windows-ci.electronjs.org/api/builds'
+const buildAppVeyorURL = 'https://ci.appveyor.com/api/builds'
 
 const appVeyorJobs = {
-  'electron-x64': 'electron',
-  'electron-ia32': 'electron-39ng6'
+  'electron-x64': 'electron-x64-release',
+  'electron-ia32': 'electron-ia32-release'
 }
 
 const circleCIJobs = [
@@ -110,7 +110,7 @@ async function callAppVeyor (targetBranch, job, options) {
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({
-      accountName: 'AppVeyor',
+      accountName: 'electron-bot',
       projectSlug: appVeyorJobs[job],
       branch: targetBranch,
       environmentVariables
@@ -120,7 +120,7 @@ async function callAppVeyor (targetBranch, job, options) {
   let appVeyorResponse = await makeRequest(requestOpts, true).catch(err => {
     console.log('Error calling AppVeyor:', err)
   })
-  const buildUrl = `https://windows-ci.electronjs.org/project/AppVeyor/${appVeyorJobs[job]}/build/${appVeyorResponse.version}`
+  const buildUrl = `https://ci.appveyor.com/project/electron-bot/${appVeyorJobs[job]}/build/${appVeyorResponse.version}`
   console.log(`AppVeyor release build request for ${job} successful.  Check build status at ${buildUrl}`)
 }
 


### PR DESCRIPTION
#### Description of Change
Manual backport of #18337 for 3-1-x.

This PR moves our Windows builds from our self hosted AppVeyor instance to AppVeyor's cloud hosted instance.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
