### PR TITLE
chore: DirectoryLister memory management improvement

### DIFF
--- a/shell/browser/web_dialog_helper.h
+++ b/shell/browser/web_dialog_helper.h
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "base/memory/weak_ptr.h"
-#include "net/base/directory_lister.h"
 #include "third_party/blink/public/mojom/choosers/file_chooser.mojom.h"
 
 namespace base {
@@ -23,32 +22,6 @@ class WebContents;
 }  // namespace content
 
 namespace electron {
-
-class DirectoryListerHelperDelegate {
- public:
-  virtual void OnDirectoryListerDone(
-      std::vector<blink::mojom::FileChooserFileInfoPtr> file_info,
-      base::FilePath base_dir) = 0;
-};
-
-class DirectoryListerHelper
-    : public net::DirectoryLister::DirectoryListerDelegate {
- public:
-  DirectoryListerHelper(base::FilePath base,
-                        DirectoryListerHelperDelegate* helper);
-  ~DirectoryListerHelper() override;
-
- private:
-  void OnListFile(
-      const net::DirectoryLister::DirectoryListerData& data) override;
-  void OnListDone(int error) override;
-
-  base::FilePath base_dir_;
-  DirectoryListerHelperDelegate* delegate_;
-  std::vector<base::FilePath> paths_;
-
-  DISALLOW_COPY_AND_ASSIGN(DirectoryListerHelper);
-};
 
 class NativeWindow;
 


### PR DESCRIPTION
#### Description of Change

Minor memory cleanups in `web_dialog_helper`.

This PR changes a range-based loop to use const refs instead of copies, ensures that `FileSelectHelper` is destroyed when WebContents is destroyed, and removes unneeded `atom::DirectoryListerHelper`.

cc @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
