### PR TITLE
fix: reject the executeJavaScript promise when it fails to execute the script

### DIFF
--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -107,7 +107,8 @@ class ScriptExecutionCallback : public blink::WebScriptExecutionCallback {
         promise_.Resolve(result[0]);
       } else {
         promise_.RejectWithErrorMessage(
-            "Script failed to execute, this normally means a syncronous error "
+            "Script failed to execute, this normally means an error "
+            "was thrown. Check the renderer console for the error."
             "was thrown, check the renderer console for the error");
       }
     } else {

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -114,7 +114,7 @@ class ScriptExecutionCallback : public blink::WebScriptExecutionCallback {
     } else {
       promise_.RejectWithErrorMessage(
           "WebFrame was removed before script could run. This normally means "
-          "the underlying frame was destroyed")
+          "the underlying frame was destroyed");
     }
     delete this;
   }

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -101,9 +101,20 @@ class ScriptExecutionCallback : public blink::WebScriptExecutionCallback {
 
   void Completed(
       const blink::WebVector<v8::Local<v8::Value>>& result) override {
-    if (!result.empty() && !result[0].IsEmpty())
-      // Right now only single results per frame is supported.
-      promise_.Resolve(result[0]);
+    if (!result.empty()) {
+      if (!result[0].IsEmpty()) {
+        // Right now only single results per frame is supported.
+        promise_.Resolve(result[0]);
+      } else {
+        promise_.RejectWithErrorMessage(
+            "Script failed to execute, this normally means a syncronous error "
+            "was thrown, check the renderer console for the error");
+      }
+    } else {
+      promise_.RejectWithErrorMessage(
+          "WebFrame was removed before script could run, this normally means "
+          "the underlying frame was destroyed")
+    }
     delete this;
   }
 

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -113,7 +113,7 @@ class ScriptExecutionCallback : public blink::WebScriptExecutionCallback {
       }
     } else {
       promise_.RejectWithErrorMessage(
-          "WebFrame was removed before script could run, this normally means "
+          "WebFrame was removed before script could run. This normally means "
           "the underlying frame was destroyed")
     }
     delete this;


### PR DESCRIPTION
Closes #9102

Unfortunately we can't get the _actual_ error message, but can at least reject the promise to avoid leaving it dangling.  The best we can do is tell them that their script failed, but not why.

Notes: `.executeJavaScript` will never leave a promise dangling now, scripts that fail to execute will correctly be rejected