### PR TITLE
test: move some remote specs to the main runner

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -752,7 +752,7 @@ Calling `event.preventDefault()` will make it return empty sources.
 
 Returns:
 
-* `event` Event
+* `event` IpcMainEvent
 * `moduleName` String
 
 Emitted when `remote.require()` is called in the renderer process.
@@ -763,7 +763,7 @@ Custom value can be returned by setting `event.returnValue`.
 
 Returns:
 
-* `event` Event
+* `event` IpcMainEvent
 * `globalName` String
 
 Emitted when `remote.getGlobal()` is called in the renderer process.
@@ -774,7 +774,7 @@ Custom value can be returned by setting `event.returnValue`.
 
 Returns:
 
-* `event` Event
+* `event` IpcMainEvent
 * `moduleName` String
 
 Emitted when `remote.getBuiltin()` is called in the renderer process.
@@ -785,7 +785,7 @@ Custom value can be returned by setting `event.returnValue`.
 
 Returns:
 
-* `event` Event
+* `event` IpcMainEvent
 
 Emitted when `remote.getCurrentWindow()` is called in the renderer process.
 Calling `event.preventDefault()` will prevent the object from being returned.
@@ -795,7 +795,7 @@ Custom value can be returned by setting `event.returnValue`.
 
 Returns:
 
-* `event` Event
+* `event` IpcMainEvent
 
 Emitted when `remote.getCurrentWebContents()` is called in the renderer process.
 Calling `event.preventDefault()` will prevent the object from being returned.
@@ -805,7 +805,7 @@ Custom value can be returned by setting `event.returnValue`.
 
 Returns:
 
-* `event` Event
+* `event` IpcMainEvent
 * `guestWebContents` [WebContents](web-contents.md)
 
 Emitted when `<webview>.getWebContents()` is called in the renderer process.

--- a/spec-main/api-remote-spec.ts
+++ b/spec-main/api-remote-spec.ts
@@ -1,0 +1,112 @@
+import { expect } from 'chai'
+import { closeWindow } from './window-helpers'
+
+import { BrowserWindow } from 'electron'
+
+describe('remote module', () => {
+  let w = null as unknown as BrowserWindow
+  before(async () => {
+    w = new BrowserWindow({show: false, webPreferences: {nodeIntegration: true}})
+    await w.loadURL('about:blank')
+  })
+  after(async () => {
+    await closeWindow(w)
+  })
+
+  async function remotely(script: string) {
+    // executeJavaScript never returns if the script throws an error, so catch
+    // any errors manually.
+    const assembledScript = `(function() {
+      try {
+        return { result: ${script} }
+      } catch (e) {
+        return { error: e.message }
+      }
+    })()`
+    const {result, error} = await w.webContents.executeJavaScript(assembledScript)
+    if (error) {
+      throw new Error(error)
+    }
+    return result
+  }
+
+  describe('remote.getGlobal filtering', () => {
+    it('can return custom values', async () => {
+      w.webContents.once('remote-get-global', (event, name) => {
+        event.returnValue = name
+      })
+      expect(await remotely(`require('electron').remote.getGlobal('test')`)).to.equal('test')
+    })
+
+    it('throws when no returnValue set', async () => {
+      w.webContents.once('remote-get-global', (event, name) => {
+        event.preventDefault()
+      })
+      await expect(remotely(`require('electron').remote.getGlobal('test')`)).to.eventually.be.rejected(`Blocked remote.getGlobal('test')`)
+    })
+  })
+
+  describe('remote.getBuiltin filtering', () => {
+    it('can return custom values', async () => {
+      w.webContents.once('remote-get-builtin', (event, name) => {
+        event.returnValue = name
+      })
+      expect(await remotely(`require('electron').remote.getBuiltin('test')`)).to.equal('test')
+    })
+
+    it('throws when no returnValue set', async () => {
+      w.webContents.once('remote-get-builtin', (event, name) => {
+        event.preventDefault()
+      })
+      await expect(remotely(`require('electron').remote.getBuiltin('test')`)).to.eventually.be.rejected(`Blocked remote.getGlobal('test')`)
+    })
+  })
+
+  describe('remote.require filtering', () => {
+    it('can return custom values', async () => {
+      w.webContents.once('remote-require', (event, name) => {
+        event.returnValue = name
+      })
+      expect(await remotely(`require('electron').remote.require('test')`)).to.equal('test')
+    })
+
+    it('throws when no returnValue set', async () => {
+      w.webContents.once('remote-require', (event, name) => {
+        event.preventDefault()
+      })
+      await expect(remotely(`require('electron').remote.require('test')`)).to.eventually.be.rejected(`Blocked remote.require('test')`)
+    })
+  })
+
+  describe('remote.getCurrentWindow filtering', () => {
+    it('can return custom value', async () => {
+      w.webContents.once('remote-get-current-window', (e) => {
+        e.returnValue = 'some window'
+      })
+      expect(await remotely(`require('electron').remote.getCurrentWindow()`)).to.equal('some window')
+    })
+
+    it('throws when no returnValue set', async () => {
+      w.webContents.once('remote-get-current-window', (event) => {
+        event.preventDefault()
+      })
+      await expect(remotely(`require('electron').remote.getCurrentWindow()`)).to.eventually.be.rejected(`Blocked remote.getCurrentWindow()`)
+    })
+  })
+
+  describe('remote.getCurrentWebContents filtering', () => {
+    it('can return custom value', async () => {
+      w.webContents.once('remote-get-current-web-contents', (event) => {
+        event.returnValue = 'some web contents'
+      })
+      expect(await remotely(`require('electron').remote.getCurrentWebContents()`)).to.equal('some web contents')
+    })
+
+    it('throws when no returnValue set', async () => {
+      w.webContents.once('remote-get-current-web-contents', (event) => {
+        event.preventDefault()
+      })
+      await expect(remotely(`require('electron').remote.getCurrentWebContents()`)).to.eventually.be.rejected(`Blocked remote.getCurrentWebContents()`)
+    })
+  })
+})

--- a/spec/api-remote-spec.js
+++ b/spec/api-remote-spec.js
@@ -23,42 +23,6 @@ const comparePaths = (path1, path2) => {
 describe('remote module', () => {
   const fixtures = path.join(__dirname, 'fixtures')
 
-  describe('remote.getGlobal filtering', () => {
-    it('can return custom values', () => {
-      ipcRenderer.send('handle-next-remote-get-global', { test: 'Hello World!' })
-      expect(remote.getGlobal('test')).to.be.equal('Hello World!')
-    })
-
-    it('throws when no returnValue set', () => {
-      ipcRenderer.send('handle-next-remote-get-global')
-      expect(() => remote.getGlobal('test')).to.throw(`Blocked remote.getGlobal('test')`)
-    })
-  })
-
-  describe('remote.getBuiltin filtering', () => {
-    it('can return custom values', () => {
-      ipcRenderer.send('handle-next-remote-get-builtin', { test: 'Hello World!' })
-      expect(remote.getBuiltin('test')).to.be.equal('Hello World!')
-    })
-
-    it('throws when no returnValue set', () => {
-      ipcRenderer.send('handle-next-remote-get-builtin')
-      expect(() => remote.getBuiltin('test')).to.throw(`Blocked remote.getBuiltin('test')`)
-    })
-  })
-
-  describe('remote.require filtering', () => {
-    it('can return custom values', () => {
-      ipcRenderer.send('handle-next-remote-require', { test: 'Hello World!' })
-      expect(remote.require('test')).to.be.equal('Hello World!')
-    })
-
-    it('throws when no returnValue set', () => {
-      ipcRenderer.send('handle-next-remote-require')
-      expect(() => remote.require('test')).to.throw(`Blocked remote.require('test')`)
-    })
-  })
-
   describe('remote.require', () => {
     it('should returns same object for the same module', () => {
       const dialog1 = remote.require('electron')
@@ -456,30 +420,6 @@ describe('remote module', () => {
       const contents1 = remote.getCurrentWindow().webContents
       const contents2 = remote.getCurrentWebContents()
       expect(contents1).to.equal(contents2)
-    })
-  })
-
-  describe('remote.getCurrentWindow filtering', () => {
-    it('can return custom value', () => {
-      ipcRenderer.send('handle-next-remote-get-current-window', 'Hello World!')
-      expect(remote.getCurrentWindow()).to.be.equal('Hello World!')
-    })
-
-    it('throws when no returnValue set', () => {
-      ipcRenderer.send('handle-next-remote-get-current-window')
-      expect(() => remote.getCurrentWindow()).to.throw('Blocked remote.getCurrentWindow()')
-    })
-  })
-
-  describe('remote.getCurrentWebContents filtering', () => {
-    it('can return custom value', () => {
-      ipcRenderer.send('handle-next-remote-get-current-web-contents', 'Hello World!')
-      expect(remote.getCurrentWebContents()).to.be.equal('Hello World!')
-    })
-
-    it('throws when no returnValue set', () => {
-      ipcRenderer.send('handle-next-remote-get-current-web-contents')
-      expect(() => remote.getCurrentWebContents()).to.throw('Blocked remote.getCurrentWebContents()')
     })
   })
 

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -185,25 +185,7 @@ ipcMain.on('handle-next-ipc-message-sync', function (event, returnValue) {
 })
 
 for (const eventName of [
-  'remote-require',
-  'remote-get-global',
-  'remote-get-builtin'
-]) {
-  ipcMain.on(`handle-next-${eventName}`, function (event, valuesMap = {}) {
-    event.sender.once(eventName, (event, name) => {
-      if (valuesMap.hasOwnProperty(name)) {
-        event.returnValue = valuesMap[name]
-      } else {
-        event.preventDefault()
-      }
-    })
-  })
-}
-
-for (const eventName of [
   'desktop-capturer-get-sources',
-  'remote-get-current-window',
-  'remote-get-current-web-contents',
   'remote-get-guest-web-contents'
 ]) {
   ipcMain.on(`handle-next-${eventName}`, function (event, returnValue) {


### PR DESCRIPTION
#### Description of Change
This moves some remote specs to the main process so they don't need to use IPC handlers to set up the test.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes