### PR TITLE
feat: sandbox renderer processes for cross-origin frames

### DIFF
--- a/shell/app/atom_main_delegate.cc
+++ b/shell/app/atom_main_delegate.cc
@@ -59,6 +59,11 @@ bool IsBrowserProcess(base::CommandLine* cmd) {
   return process_type.empty();
 }
 
+bool IsSandboxEnabled(base::CommandLine* command_line) {
+  return command_line->HasSwitch(switches::kEnableSandbox) ||
+         !command_line->HasSwitch(service_manager::switches::kNoSandbox);
+}
+
 // Returns true if this subprocess type needs the ResourceBundle initialized
 // and resources loaded.
 bool SubprocessNeedsResourceBundle(const std::string& process_type) {
@@ -281,10 +286,9 @@ content::ContentGpuClient* AtomMainDelegate::CreateContentGpuClient() {
 
 content::ContentRendererClient*
 AtomMainDelegate::CreateContentRendererClient() {
-  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kEnableSandbox) ||
-      !base::CommandLine::ForCurrentProcess()->HasSwitch(
-          service_manager::switches::kNoSandbox)) {
+  auto* command_line = base::CommandLine::ForCurrentProcess();
+
+  if (IsSandboxEnabled(command_line)) {
     renderer_client_.reset(new AtomSandboxedRendererClient);
   } else {
     renderer_client_.reset(new AtomRendererClient);

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -1213,6 +1213,18 @@ base::ProcessId WebContents::GetOSProcessID() const {
   return base::GetProcId(process_handle);
 }
 
+base::ProcessId WebContents::GetOSProcessIdForFrame(
+    const std::string& name,
+    const std::string& document_url) const {
+  for (auto* frame : web_contents()->GetAllFrames()) {
+    if (frame->GetFrameName() == name &&
+        frame->GetLastCommittedURL().spec() == document_url) {
+      return base::GetProcId(frame->GetProcess()->GetProcess().Handle());
+    }
+  }
+  return base::kNullProcessId;
+}
+
 WebContents::Type WebContents::GetType() const {
   return type_;
 }
@@ -2194,6 +2206,8 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
                  &WebContents::SetBackgroundThrottling)
       .SetMethod("getProcessId", &WebContents::GetProcessID)
       .SetMethod("getOSProcessId", &WebContents::GetOSProcessID)
+      .SetMethod("_getOSProcessIdForFrame",
+                 &WebContents::GetOSProcessIdForFrame)
       .SetMethod("equal", &WebContents::Equal)
       .SetMethod("_loadURL", &WebContents::LoadURL)
       .SetMethod("downloadURL", &WebContents::DownloadURL)

--- a/shell/browser/api/atom_api_web_contents.h
+++ b/shell/browser/api/atom_api_web_contents.h
@@ -138,6 +138,8 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void SetBackgroundThrottling(bool allowed);
   int GetProcessID() const;
   base::ProcessId GetOSProcessID() const;
+  base::ProcessId GetOSProcessIdForFrame(const std::string& name,
+                                         const std::string& document_url) const;
   Type GetType() const;
   bool Equal(const WebContents* web_contents) const;
   void LoadURL(const GURL& url, const mate::Dictionary& options);

--- a/shell/browser/atom_browser_client.h
+++ b/shell/browser/atom_browser_client.h
@@ -235,10 +235,14 @@ class AtomBrowserClient : public content::ContentBrowserClient,
   void ConsiderSiteInstanceForAffinity(content::RenderFrameHost* rfh,
                                        content::SiteInstance* site_instance);
 
+  bool IsRendererSubFrame(int process_id) const;
+
   // pending_render_process => web contents.
   std::map<int, content::WebContents*> pending_processes_;
 
   std::map<int, base::ProcessId> render_process_host_pids_;
+
+  std::set<int> renderer_is_subframe_;
 
   // list of site per affinity. weak_ptr to prevent instance locking
   std::map<std::string, content::SiteInstance*> site_per_affinities_;

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -271,7 +271,8 @@ WebContentsPreferences* WebContentsPreferences::From(
 }
 
 void WebContentsPreferences::AppendCommandLineSwitches(
-    base::CommandLine* command_line) {
+    base::CommandLine* command_line,
+    bool is_subframe) {
   // Check if plugins are enabled.
   if (IsEnabled(options::kPlugins))
     command_line->AppendSwitch(switches::kEnablePlugins);
@@ -293,10 +294,16 @@ void WebContentsPreferences::AppendCommandLineSwitches(
   if (IsEnabled(options::kWebviewTag))
     command_line->AppendSwitch(switches::kWebviewTag);
 
+  // Sandbox can be enabled for renderer processes hosting cross-origin frames
+  // unless nodeIntegrationInSubFrames is enabled
+  bool can_sandbox_frame =
+      is_subframe && !IsEnabled(options::kNodeIntegrationInSubFrames);
+
   // If the `sandbox` option was passed to the BrowserWindow's webPreferences,
   // pass `--enable-sandbox` to the renderer so it won't have any node.js
-  // integration.
-  if (IsEnabled(options::kSandbox)) {
+  // integration. Otherwise disable Chromium sandbox, unless app.enableSandbox()
+  // was called.
+  if (IsEnabled(options::kSandbox) || can_sandbox_frame) {
     command_line->AppendSwitch(switches::kEnableSandbox);
   } else if (!command_line->HasSwitch(switches::kEnableSandbox)) {
     command_line->AppendSwitch(service_manager::switches::kNoSandbox);

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -47,7 +47,8 @@ class WebContentsPreferences
   void Merge(const base::DictionaryValue& new_web_preferences);
 
   // Append command paramters according to preferences.
-  void AppendCommandLineSwitches(base::CommandLine* command_line);
+  void AppendCommandLineSwitches(base::CommandLine* command_line,
+                                 bool is_subframe);
 
   // Modify the WebPreferences according to preferences.
   void OverrideWebkitPrefs(content::WebPreferences* prefs);


### PR DESCRIPTION
#### Description of Change
Cross-origin frames, which have a separate renderer process due to site isolation do not have their own `webContents` and therefore use the `webPreferences` of the main frame. When `nodeIntegrationInSubFrames` is not enabled, there is no reason not to sandbox the renderer process as we are not executing any internal JavaScript code or initializing node, which would be impacted by the sandbox.

Follow up to #15821

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Renderer processes hosting cross-origin frames are now sandboxed unless the parent `BrowserWindow` enables `nodeIntegrationInSubFrames`.