### PR TITLE
build: show ninja stats for testing/debug builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ env-disable-crash-reporter-tests: &env-disable-crash-reporter-tests
   DISABLE_CRASH_REPORTER_TESTS: true
 
 env-ninja-status: &env-ninja-status
-  NINJA_STATUS: "[%r processes, %f/%t @ %o/s : %es ]"
+  NINJA_STATUS: "[%r processes, %f/%t @ %o/s : %es]"
 
 # Individual (shared) steps.
 step-maybe-notify-slack-failure: &step-maybe-notify-slack-failure

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -542,8 +542,7 @@ step-ninja-summary: &step-ninja-summary
   run:
     name: Print ninja summary
     command: |
-      cd src
-      python third_party/depot_tools/post_build_ninja_summary.py -C out/Default
+      python depot_tools/post_build_ninja_summary.py -C src/out/Default
 
 # Lists of steps.
 steps-lint: &steps-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,9 @@ env-mac-large: &env-mac-large
 env-disable-crash-reporter-tests: &env-disable-crash-reporter-tests
   DISABLE_CRASH_REPORTER_TESTS: true
 
+env-ninja-status: &env-ninja-status
+  NINJA_STATUS: "[%r processes, %f/%t @ %o/s : %es ]"
+
 # Individual (shared) steps.
 step-maybe-notify-slack-failure: &step-maybe-notify-slack-failure
   run:
@@ -535,6 +538,13 @@ step-fix-known-hosts-linux: &step-fix-known-hosts-linux
         ./src/electron/.circleci/fix-known-hosts.sh
       fi
 
+step-ninja-summary: &step-ninja-summary
+  run:
+    name: Print ninja summary
+    command: |
+      cd src
+      python third_party/depot_tools/post_build_ninja_summary.py -C out/Default
+
 # Lists of steps.
 steps-lint: &steps-lint
   steps:
@@ -683,6 +693,7 @@ steps-electron-build: &steps-electron-build
     - *step-electron-build
     - *step-electron-dist-build
     - *step-electron-dist-store
+    - *step-ninja-summary
 
     # Node.js headers
     - *step-nodejs-headers-build
@@ -706,6 +717,7 @@ steps-electron-build-for-tests: &steps-electron-build-for-tests
     - *step-maybe-electron-dist-strip
     - *step-electron-dist-build
     - *step-electron-dist-store
+    - *step-ninja-summary
 
     # Node.js headers
     - *step-nodejs-headers-build
@@ -958,6 +970,7 @@ jobs:
       <<: *env-linux-2xlarge
       <<: *env-debug-build
       <<: *env-enable-sccache
+      <<: *env-ninja-status
     <<: *steps-electron-build
 
   linux-x64-debug-gn-check:
@@ -973,6 +986,7 @@ jobs:
       <<: *env-linux-2xlarge
       <<: *env-testing-build
       <<: *env-enable-sccache
+      <<: *env-ninja-status
     <<: *steps-electron-build-for-tests
 
   linux-x64-testing-gn-check:
@@ -998,6 +1012,7 @@ jobs:
       <<: *env-release-build
       <<: *env-enable-sccache
       <<: *env-send-slack-notifications
+      <<: *env-ninja-status
     <<: *steps-electron-build-for-tests
 
   linux-x64-publish:
@@ -1015,6 +1030,7 @@ jobs:
       <<: *env-ia32
       <<: *env-debug-build
       <<: *env-enable-sccache
+      <<: *env-ninja-status
     <<: *steps-electron-build
 
   linux-ia32-testing:
@@ -1024,6 +1040,7 @@ jobs:
       <<: *env-ia32
       <<: *env-testing-build
       <<: *env-enable-sccache
+      <<: *env-ninja-status
     <<: *steps-electron-build-for-tests
 
   linux-ia32-chromedriver:
@@ -1044,6 +1061,7 @@ jobs:
       <<: *env-release-build
       <<: *env-enable-sccache
       <<: *env-send-slack-notifications
+      <<: *env-ninja-status
     <<: *steps-electron-build-for-tests
 
   linux-ia32-publish:
@@ -1062,6 +1080,7 @@ jobs:
       <<: *env-arm
       <<: *env-debug-build
       <<: *env-enable-sccache
+      <<: *env-ninja-status
     <<: *steps-electron-build
 
   linux-arm-testing:
@@ -1071,6 +1090,7 @@ jobs:
       <<: *env-arm
       <<: *env-testing-build
       <<: *env-enable-sccache
+      <<: *env-ninja-status
       TRIGGER_ARM_TEST: true
     <<: *steps-electron-build-for-tests
 
@@ -1092,6 +1112,7 @@ jobs:
       <<: *env-release-build
       <<: *env-enable-sccache
       <<: *env-send-slack-notifications
+      <<: *env-ninja-status
     <<: *steps-electron-build-for-tests
 
   linux-arm-publish:
@@ -1110,6 +1131,7 @@ jobs:
       <<: *env-arm64
       <<: *env-debug-build
       <<: *env-enable-sccache
+      <<: *env-ninja-status
     <<: *steps-electron-build
 
   linux-arm64-debug-gn-check:
@@ -1127,6 +1149,7 @@ jobs:
       <<: *env-arm64
       <<: *env-testing-build
       <<: *env-enable-sccache
+      <<: *env-ninja-status
       TRIGGER_ARM_TEST: true
     <<: *steps-electron-build-for-tests
 
@@ -1156,6 +1179,7 @@ jobs:
       <<: *env-release-build
       <<: *env-enable-sccache
       <<: *env-send-slack-notifications
+      <<: *env-ninja-status
     <<: *steps-electron-build-for-tests
 
   linux-arm64-publish:
@@ -1173,6 +1197,7 @@ jobs:
       <<: *env-mac-large
       <<: *env-testing-build
       <<: *env-enable-sccache
+      <<: *env-ninja-status
     <<: *steps-electron-build-for-tests
 
   osx-debug-gn-check:
@@ -1204,6 +1229,7 @@ jobs:
       <<: *env-mac-large
       <<: *env-release-build
       <<: *env-enable-sccache
+      <<: *env-ninja-status
     <<: *steps-electron-build-for-tests
 
   osx-publish:
@@ -1221,6 +1247,7 @@ jobs:
       <<: *env-mas
       <<: *env-testing-build
       <<: *env-enable-sccache
+      <<: *env-ninja-status
     <<: *steps-electron-build-for-tests
 
   mas-debug-gn-check:
@@ -1255,6 +1282,7 @@ jobs:
       <<: *env-mas
       <<: *env-release-build
       <<: *env-enable-sccache
+      <<: *env-ninja-status      
     <<: *steps-electron-build-for-tests
 
   mas-publish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,6 +50,7 @@ build_script:
       if(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {
         Write-warning "Skipping PR build for branch"; Exit-AppveyorBuild
       }
+  - where gclient
   - echo "Building $env:GN_CONFIG build"
   - git config --global core.longpaths true
   - cd ..
@@ -61,7 +62,7 @@ build_script:
       if ($env:GN_CONFIG -eq 'release') {
         $env:GCLIENT_EXTRA_ARGS="--custom-var=checkout_boto=True --custom-var=checkout_requests=True"
       } else {
-        $env:NINJA_STATUS="[%r processes, %f/%t @ %o/s : %es ] "
+        $env:NINJA_STATUS="[%r processes, %f/%t @ %o/s : %es] "
       }
   - >-
       gclient config

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,6 @@ build_script:
       if(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {
         Write-warning "Skipping PR build for branch"; Exit-AppveyorBuild
       }
-  - where gclient
   - echo "Building $env:GN_CONFIG build"
   - git config --global core.longpaths true
   - cd ..
@@ -79,7 +78,7 @@ build_script:
   - gn check out/Default //electron:manifests
   - gn check out/Default //electron/atom/common/api:mojo
   - ninja -C out/Default electron:electron_app
-  - if "%GN_CONFIG%"=="testing" ( python C:\depot_tools\post_build_ninja_summary.py -C out\Default )  
+  - if "%GN_CONFIG%"=="testing" ( python C:\Users\electron\depot_tools\post_build_ninja_summary.py -C out\Default )  
   - gn gen out/ffmpeg "--args=import(\"//electron/build/args/ffmpeg.gn\") %GN_EXTRA_ARGS%"
   - ninja -C out/ffmpeg electron:electron_ffmpeg_zip
   - ninja -C out/Default electron:electron_dist_zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -78,7 +78,7 @@ build_script:
   - gn check out/Default //electron:manifests
   - gn check out/Default //electron/atom/common/api:mojo
   - ninja -C out/Default electron:electron_app
-  - if "%GN_CONFIG%"=="testing" ( python third_party\depot_tools\post_build_ninja_summary.py -C out\Default )  
+  - if "%GN_CONFIG%"=="testing" ( python C:\depot_tools\post_build_ninja_summary.py -C out\Default )  
   - gn gen out/ffmpeg "--args=import(\"//electron/build/args/ffmpeg.gn\") %GN_EXTRA_ARGS%"
   - ninja -C out/ffmpeg electron:electron_ffmpeg_zip
   - ninja -C out/Default electron:electron_dist_zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,6 +60,8 @@ build_script:
   - ps: >-
       if ($env:GN_CONFIG -eq 'release') {
         $env:GCLIENT_EXTRA_ARGS="--custom-var=checkout_boto=True --custom-var=checkout_requests=True"
+      } else {
+        $env:NINJA_STATUS="[%r processes, %f/%t @ %o/s : %es ] "
       }
   - >-
       gclient config
@@ -76,6 +78,7 @@ build_script:
   - gn check out/Default //electron:manifests
   - gn check out/Default //electron/atom/common/api:mojo
   - ninja -C out/Default electron:electron_app
+  - if "%GN_CONFIG%"=="testing" ( python third_party\depot_tools\post_build_ninja_summary.py -C out\Default )  
   - gn gen out/ffmpeg "--args=import(\"//electron/build/args/ffmpeg.gn\") %GN_EXTRA_ARGS%"
   - ninja -C out/ffmpeg electron:electron_ffmpeg_zip
   - ninja -C out/Default electron:electron_dist_zip


### PR DESCRIPTION
This PR adds ninja stats output for testing and debug builds.  This is primarily informational,  but could be useful in diagnosing where our [builds are slow](https://chromium.googlesource.com/chromium/src/+/master/docs/windows_build_instructions.md#Why-is-my-build-slow).  

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
