### PR TITLE
fix: properly pass openExternal activate option

### DIFF
--- a/atom/common/platform_util_mac.mm
+++ b/atom/common/platform_util_mac.mm
@@ -104,14 +104,15 @@ void OpenExternal(const GURL& url,
     return;
   }
 
+  bool activate = options.activate;
   __block OpenExternalCallback c = std::move(callback);
-  dispatch_async(
-      dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        __block std::string error = OpenURL(ns_url, options.activate);
-        dispatch_async(dispatch_get_main_queue(), ^{
-          std::move(c).Run(error);
-        });
-      });
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),
+                 ^{
+                   __block std::string error = OpenURL(ns_url, activate);
+                   dispatch_async(dispatch_get_main_queue(), ^{
+                     std::move(c).Run(error);
+                   });
+                 });
 }
 
 bool MoveItemToTrash(const base::FilePath& full_path) {

--- a/spec/api-shell-spec.js
+++ b/spec/api-shell-spec.js
@@ -49,7 +49,23 @@ describe('shell module', () => {
         process.env.DISPLAY = ''
       }
 
-      shell.openExternal(url).then(() => done())
+      // Ensure an external window is activated via our window's blur event
+      let promiseResolved = false
+      let blurEventEmitted = false
+
+      window.addEventListener('blur', () => {
+        blurEventEmitted = true
+        if (promiseResolved) {
+          done()
+        }
+      })
+
+      shell.openExternal(url).then(() => {
+        promiseResolved = true
+        if (blurEventEmitted) {
+          done()
+        }
+      })
     })
   })
 

--- a/spec/api-shell-spec.js
+++ b/spec/api-shell-spec.js
@@ -64,7 +64,7 @@ describe('shell module', () => {
 
       shell.openExternal(url).then(() => {
         promiseResolved = true
-        if (blurEventEmitted) {
+        if (blurEventEmitted || process.platform === 'linux') {
           done()
         }
       })

--- a/spec/api-shell-spec.js
+++ b/spec/api-shell-spec.js
@@ -7,6 +7,8 @@ const os = require('os')
 const { shell, remote } = require('electron')
 const { BrowserWindow } = remote
 
+const { closeWindow } = require('./window-helpers')
+
 const { expect } = chai
 chai.use(dirtyChai)
 
@@ -24,6 +26,7 @@ describe('shell module', () => {
 
   describe('shell.openExternal()', () => {
     let envVars = {}
+    let w
 
     beforeEach(function () {
       envVars = {
@@ -33,7 +36,9 @@ describe('shell module', () => {
       }
     })
 
-    afterEach(() => {
+    afterEach(async () => {
+      await closeWindow(w)
+      w = null
       // reset env vars to prevent side effects
       if (process.platform === 'linux') {
         process.env.DE = envVars.de
@@ -51,7 +56,7 @@ describe('shell module', () => {
       }
 
       // Ensure an external window is activated via a new window's blur event
-      const w = new BrowserWindow()
+      w = new BrowserWindow()
       let promiseResolved = false
       let blurEventEmitted = false
 

--- a/spec/api-shell-spec.js
+++ b/spec/api-shell-spec.js
@@ -4,7 +4,8 @@ const dirtyChai = require('dirty-chai')
 const fs = require('fs')
 const path = require('path')
 const os = require('os')
-const { shell } = require('electron')
+const { shell, remote } = require('electron')
+const { BrowserWindow } = remote
 
 const { expect } = chai
 chai.use(dirtyChai)
@@ -49,11 +50,12 @@ describe('shell module', () => {
         process.env.DISPLAY = ''
       }
 
-      // Ensure an external window is activated via our window's blur event
+      // Ensure an external window is activated via a new window's blur event
+      const w = new BrowserWindow()
       let promiseResolved = false
       let blurEventEmitted = false
 
-      window.addEventListener('blur', () => {
+      w.on('blur', () => {
         blurEventEmitted = true
         if (promiseResolved) {
           done()


### PR DESCRIPTION
#### Description of Change
A reference to an `OpenExternalOptions` structure was being captured by an Objective-C block that outlived the object that was being referenced (added in https://github.com/electron/electron/pull/15065). This caused the default browser window to not be activated when passing a URL on macOS when the default browser is Safari or Firefox. Fixes https://github.com/electron/electron/issues/18293.

cc @miniak @nornagon @alexeykuzmin @codebytere 

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed issue where `shell.openExternal` would not activate opened window on macOS