### PR TITLE
feat: allow resigning current NSUserActivity

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -1417,6 +1417,8 @@ void App::BuildPrototype(v8::Isolate* isolate,
       .SetMethod(
           "invalidateCurrentActivity",
           base::BindRepeating(&Browser::InvalidateCurrentActivity, browser))
+      .SetMethod("resignCurrentActivity",
+                 base::BindRepeating(&Browser::ResignCurrentActivity, browser))
       .SetMethod("updateCurrentActivity",
                  base::BindRepeating(&Browser::UpdateCurrentActivity, browser))
       // TODO(juturu): Remove in 2.0, deprecate before then with warnings

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -128,8 +128,12 @@ class Browser : public WindowListObserver {
   // Returns the type name of the current user activity.
   std::string GetCurrentActivityType();
 
-  // Invalidates the current user activity.
+  // Invalidates an activity and marks it as no longer eligible for
+  // continuation
   void InvalidateCurrentActivity();
+
+  // Marks this activity object as inactive without invalidating it.
+  void ResignCurrentActivity();
 
   // Updates the current user activity
   void UpdateCurrentActivity(const std::string& type,

--- a/atom/browser/browser_mac.mm
+++ b/atom/browser/browser_mac.mm
@@ -161,6 +161,10 @@ void Browser::InvalidateCurrentActivity() {
   [[AtomApplication sharedApplication] invalidateCurrentActivity];
 }
 
+void Browser::ResignCurrentActivity() {
+  [[AtomApplication sharedApplication] resignCurrentActivity];
+}
+
 void Browser::UpdateCurrentActivity(const std::string& type,
                                     const base::DictionaryValue& user_info) {
   [[AtomApplication sharedApplication]

--- a/atom/browser/mac/atom_application.h
+++ b/atom/browser/mac/atom_application.h
@@ -132,6 +132,7 @@ typedef NS_ENUM(NSInteger, AVAuthorizationStatusMac) {
               withUserInfo:(NSDictionary*)userInfo
             withWebpageURL:(NSURL*)webpageURL;
 - (void)invalidateCurrentActivity;
+- (void)resignCurrentActivity;
 - (void)updateCurrentActivity:(NSString*)type
                  withUserInfo:(NSDictionary*)userInfo;
 

--- a/atom/browser/mac/atom_application.mm
+++ b/atom/browser/mac/atom_application.mm
@@ -93,6 +93,11 @@ inline void dispatch_sync_main(dispatch_block_t block) {
   }
 }
 
+- (void)resignCurrentActivity {
+  if (currentActivity_)
+    [currentActivity_ resignCurrent];
+}
+
 - (void)updateCurrentActivity:(NSString*)type
                  withUserInfo:(NSDictionary*)userInfo {
   if (currentActivity_) {

--- a/atom/browser/mac/atom_application.mm
+++ b/atom/browser/mac/atom_application.mm
@@ -94,8 +94,10 @@ inline void dispatch_sync_main(dispatch_block_t block) {
 }
 
 - (void)resignCurrentActivity {
-  if (currentActivity_)
-    [currentActivity_ resignCurrent];
+  if (@available(macOS 10.11, *)) {
+    if (currentActivity_)
+      [currentActivity_ resignCurrent];
+  }
 }
 
 - (void)updateCurrentActivity:(NSString*)type

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -964,10 +964,11 @@ Returns `String` - The type of the currently running activity.
 
 ### `app.invalidateCurrentActivity()` _macOS_
 
-* `type` String - Uniquely identifies the activity. Maps to
-  [`NSUserActivity.activityType`][activity-type].
-
 Invalidates the current [Handoff][handoff] user activity.
+
+### `app.resignCurrentActivity()` _macOS_
+
+Marks the current [Handoff][handoff] user activity as inactive without invalidating it.
 
 ### `app.updateCurrentActivity(type, userInfo)` _macOS_
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/9622 by addressing last outstanding API request.

This PR adds a method to the app module: `app.resignCurrentActivity()`. This new method allows for the current Handoff user activity to be marked as inactive without invalidating it.

cc @miniak @nornagon @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added a method `app.resignCurrentActivity()` to allows marking inactive the current Handoff user activity without invalidating it.
