### PR TITLE
fix: delay handling occlusion events to avoid flicker on macOS

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -77,3 +77,4 @@ frame_host_manager.patch
 cross_site_document_resource_handler.patch
 woa_compiler_workaround.patch
 crashpad_pid_check.patch
+chore_add_debounce_on_the_updatewebcontentsvisibility_method_to.patch

--- a/patches/chromium/chore_add_debounce_on_the_updatewebcontentsvisibility_method_to.patch
+++ b/patches/chromium/chore_add_debounce_on_the_updatewebcontentsvisibility_method_to.patch
@@ -4,7 +4,6 @@ Date: Wed, 5 Jun 2019 15:11:00 -0700
 Subject: chore: add debounce on the updateWebContentsVisibility method to
  ensure quick changes in occlusion do not result in flickering
 
-
 diff --git a/content/app_shim_remote_cocoa/web_contents_view_cocoa.h b/content/app_shim_remote_cocoa/web_contents_view_cocoa.h
 index 230e259f6017310e556d11dec43973b74015f191..ebd19fc31efef50677da417dfd69f0c8cce6c682 100644
 --- a/content/app_shim_remote_cocoa/web_contents_view_cocoa.h

--- a/patches/common/chromium/chore_add_debounce_on_the_updatewebcontentsvisibility_method_to.patch
+++ b/patches/common/chromium/chore_add_debounce_on_the_updatewebcontentsvisibility_method_to.patch
@@ -1,0 +1,66 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Samuel Attard <sattard@slack-corp.com>
+Date: Wed, 5 Jun 2019 15:11:00 -0700
+Subject: chore: add debounce on the updateWebContentsVisibility method to
+ ensure quick changes in occlusion do not result in flickering
+
+
+diff --git a/content/app_shim_remote_cocoa/web_contents_view_cocoa.h b/content/app_shim_remote_cocoa/web_contents_view_cocoa.h
+index 230e259f6017310e556d11dec43973b74015f191..ebd19fc31efef50677da417dfd69f0c8cce6c682 100644
+--- a/content/app_shim_remote_cocoa/web_contents_view_cocoa.h
++++ b/content/app_shim_remote_cocoa/web_contents_view_cocoa.h
+@@ -58,6 +58,8 @@ CONTENT_EXPORT
+                        offset:(NSPoint)offset;
+ - (void)clearViewsHostableView;
+ - (void)updateWebContentsVisibility;
++- (remote_cocoa::mojom::Visibility)currentVisibility;
++- (void)notifyWebContentsVisibilityChanged;
+ - (void)viewDidBecomeFirstResponder:(NSNotification*)notification;
+ @end
+ 
+diff --git a/content/app_shim_remote_cocoa/web_contents_view_cocoa.mm b/content/app_shim_remote_cocoa/web_contents_view_cocoa.mm
+index 615fe671d415747cb84f673327629d3dc771039e..6c31ba5b9149161784f5813598ddcf30e2d8af2a 100644
+--- a/content/app_shim_remote_cocoa/web_contents_view_cocoa.mm
++++ b/content/app_shim_remote_cocoa/web_contents_view_cocoa.mm
+@@ -257,9 +257,14 @@ - (void)viewDidBecomeFirstResponder:(NSNotification*)notification {
+   host_->OnBecameFirstResponder(direction);
+ }
+ 
+-- (void)updateWebContentsVisibility {
++- (void)notifyWebContentsVisibilityChanged {
+   if (!host_)
+     return;
++
++  host_->OnWindowVisibilityChanged([self currentVisibility]);
++}
++
++- (Visibility)currentVisibility {
+   Visibility visibility = Visibility::kVisible;
+   if ([self isHiddenOrHasHiddenAncestor] || ![self window])
+     visibility = Visibility::kHidden;
+@@ -267,7 +272,24 @@ - (void)updateWebContentsVisibility {
+     visibility = Visibility::kVisible;
+   else
+     visibility = Visibility::kOccluded;
+-  host_->OnWindowVisibilityChanged(visibility);
++  return visibility;
++}
++
++- (void)updateWebContentsVisibility {
++  if (!host_)
++    return;
++  // Cancel any pending notifications visibility changes, this ensures that the latest incoming change is the only
++  // change that will take affect
++  [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(notifyWebContentsVisibilityChanged) object:nil];
++
++  Visibility visibility = [self currentVisibility];
++
++  // If it's visible, notify immediately to render ASAP
++  if (visibility == Visibility::kVisible)
++    host_->OnWindowVisibilityChanged(visibility);
++  else
++    // If it's occluded queue it for 3 seconds to be sure that it isn't a double kOccluded -> kVisible
++    [self performSelector:@selector(notifyWebContentsVisibilityChanged) withObject:nil afterDelay:3.0];
+ }
+ 
+ - (void)resizeSubviewsWithOldSize:(NSSize)oldBoundsSize {


### PR DESCRIPTION
Fixes #17942 and #18410

The issue here is caused by a refactor in Chromium to listen to these occlusion events at at this remove view level.  macOS issues two events very quickly during fullscreen transitions.  The first says "occluded" the next says "visible".  When in fact the window is never occluded.

This adds a patch that I hope to upstream to delay handling of the "occluded" event for a few seconds to ensure that a follow up "visible" event isn't incoming.

The second commit here is just patch hash updates.

Notes: Fixed random flicker that occurred on macOS when performing fullscreen or workspace transitions