### PR TITLE
fix: use isEqual instead of pointer equality to convert NSAppearance

### DIFF
--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -65,11 +65,11 @@ struct Converter<NSAppearance*> {
       return v8::Null(isolate);
     }
 
-    if (val.name == NSAppearanceNameAqua) {
+    if ([val.name isEqualToString:NSAppearanceNameAqua]) {
       return mate::ConvertToV8(isolate, "light");
     }
     if (@available(macOS 10.14, *)) {
-      if (val.name == NSAppearanceNameDarkAqua) {
+      if ([val.name isEqualToString:NSAppearanceNameDarkAqua]) {
         return mate::ConvertToV8(isolate, "dark");
       }
     }


### PR DESCRIPTION
Yeah so this sometimes worked, but sometimes doesn't.  We should be checking string equality not pointer equality.

Notes: Fixed issue where `getEffectiveApperance` and `getAppLevelAppearance` would return `unknown` instead of the correct value sometimes