### PR TITLE
fix: use effectiveAppearance to check dark mode on mojave and above

### DIFF
--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -10,6 +10,7 @@
 #include "atom/browser/mac/atom_application.h"
 #include "atom/browser/ui/cocoa/NSString+ANSI.h"
 #include "atom/browser/ui/cocoa/atom_menu_controller.h"
+#include "base/mac/sdk_forward_declarations.h"
 #include "base/strings/sys_string_conversions.h"
 #include "ui/display/screen.h"
 #include "ui/events/cocoa/cocoa_event_utils.h"

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "atom/browser/mac/atom_application.h"
 #include "atom/browser/ui/cocoa/NSString+ANSI.h"
 #include "atom/browser/ui/cocoa/atom_menu_controller.h"
 #include "base/strings/sys_string_conversions.h"
@@ -146,6 +147,10 @@ const CGFloat kVerticalTitleMargin = 2;
 }
 
 - (BOOL)isDarkMode {
+  if (@available(macOS 10.14, *)) {
+    return [[NSApplication sharedApplication].effectiveAppearance.name
+        isEqualToString:NSAppearanceNameDarkAqua];
+  }
   NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
   NSString* mode = [defaults stringForKey:@"AppleInterfaceStyle"];
   return mode && [mode isEqualToString:@"Dark"];


### PR DESCRIPTION
Fixes #18663

So on Catalina there is a new "auto" mode that doesn't update the user pref but does update `effectiveAppearance`.  The correct thing to do here is read it from `effectiveAppearance` anyway so let's just do that.

In the future I plan on doing #18664 but this is a solution for all our maintained versions 👍 

Notes: Fixed issue on macOS Catalina where the tray icon would be highlighted incorrectly and sometimes invisible