### PR TITLE
feat: HTTP preconnect feature minimal for electronjs

### DIFF
--- a/atom/browser/net/preconnect_manager_factory.cc
+++ b/atom/browser/net/preconnect_manager_factory.cc
@@ -1,0 +1,73 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+#include <memory>
+
+#include "atom/atom/browser/net/preconnect_manager_factory.h"
+
+#include "chrome/browser/predictors/preconnect_manager.h"
+#include "chrome/browser/profiles/profile.h"
+#include "components/keyed_service/content/browser_context_dependency_manager.h"
+#include "components/keyed_service/content/browser_context_keyed_service_factory.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/storage_partition.h"
+
+namespace {
+class StubDelegate : public predictors::PreconnectManager::Delegate {
+ public:
+  void PreconnectFinished(
+      std::unique_ptr<predictors::PreconnectStats> stats) override {}
+};
+
+class PreconnectManagerWrapper : public KeyedService {
+ public:
+  PreconnectManagerWrapper(
+      base::WeakPtr<predictors::PreconnectManager::Delegate> delegate,
+      Profile* profile)
+      : ptr_(new predictors::PreconnectManager(delegate, profile)) {
+    ptr_->SetNetworkContextForTesting(
+        content::BrowserContext::GetDefaultStoragePartition(profile)
+            ->GetNetworkContext());
+  }
+  ~PreconnectManagerWrapper() override {
+    delete ptr_;
+    ptr_ = NULL;
+  }
+  predictors::PreconnectManager* GetPtr() { return ptr_; }
+
+ private:
+  predictors::PreconnectManager* ptr_;
+};
+}  // namespace
+
+namespace atom {
+
+// static
+predictors::PreconnectManager* PreconnectManagerFactory::GetForProfile(
+    Profile* profile) {
+  return static_cast<PreconnectManagerWrapper*>(
+             GetInstance()->GetServiceForBrowserContext(profile, true))
+      ->GetPtr();
+}
+
+// static
+PreconnectManagerFactory* PreconnectManagerFactory::GetInstance() {
+  return base::Singleton<PreconnectManagerFactory>::get();
+}
+
+PreconnectManagerFactory::PreconnectManagerFactory()
+    : BrowserContextKeyedServiceFactory(
+          "PreconnectManager",
+          BrowserContextDependencyManager::GetInstance()),
+      weak_factory_(new StubDelegate()) {}
+
+PreconnectManagerFactory::~PreconnectManagerFactory() {}
+
+KeyedService* PreconnectManagerFactory::BuildServiceInstanceFor(
+    content::BrowserContext* context) const {
+  Profile* profile = static_cast<Profile*>(context);
+  return new PreconnectManagerWrapper(weak_factory_.GetWeakPtr(), profile);
+}
+
+}  // namespace atom

--- a/atom/browser/net/preconnect_manager_factory.h
+++ b/atom/browser/net/preconnect_manager_factory.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_NET_PRECONNECT_MANAGER_FACTORY_H_
+#define ATOM_BROWSER_NET_PRECONNECT_MANAGER_FACTORY_H_
+
+#include "base/macros.h"
+#include "base/memory/singleton.h"
+#include "base/memory/weak_ptr.h"
+#include "chrome/browser/predictors/preconnect_manager.h"
+#include "components/keyed_service/content/browser_context_keyed_service_factory.h"
+
+class Profile;
+
+namespace atom {
+
+class PreconnectManagerFactory : public BrowserContextKeyedServiceFactory {
+ public:
+  static predictors::PreconnectManager* GetForProfile(Profile* profile);
+  static PreconnectManagerFactory* GetInstance();
+
+ private:
+  friend struct base::DefaultSingletonTraits<PreconnectManagerFactory>;
+
+  PreconnectManagerFactory();
+  ~PreconnectManagerFactory() override;
+
+  // BrowserContextKeyedServiceFactory:
+  KeyedService* BuildServiceInstanceFor(
+      content::BrowserContext* context) const override;
+
+  mutable base::WeakPtrFactory<predictors::PreconnectManager::Delegate>
+      weak_factory_;
+
+  DISALLOW_COPY_AND_ASSIGN(PreconnectManagerFactory);
+};
+
+}  // namespace atom
+
+#endif  // ATOM_BROWSER_NET_PRECONNECT_MANAGER_FACTORY_H_

--- a/atom/browser/net/preconnect_manager_tab_helper.cc
+++ b/atom/browser/net/preconnect_manager_tab_helper.cc
@@ -1,0 +1,97 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "atom/browser/net/preconnect_manager_tab_helper.h"
+
+#include "atom/browser/net/preconnect_manager_factory.h"
+#include "atom/browser/web_contents_preferences.h"
+#include "atom/common/options_switches.h"
+
+#include "base/task/post_task.h"
+#include "chrome/browser/profiles/profile.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/browser_task_traits.h"
+#include "content/public/browser/browser_thread.h"
+#include "content/public/browser/render_process_host.h"
+
+namespace atom {
+
+PreconnectManagerTabHelper::PreconnectManagerTabHelper(
+    content::WebContents* web_contents)
+    : content::WebContentsObserver(web_contents),
+      preconnect_manager_(nullptr),
+      number_of_sockets_to_preconnect_(-1) {
+  preconnect_manager_ = atom::PreconnectManagerFactory::GetForProfile(
+      static_cast<Profile*>(web_contents->GetBrowserContext()));
+}
+
+PreconnectManagerTabHelper::~PreconnectManagerTabHelper() = default;
+
+void PreconnectManagerTabHelper::DidStartNavigation(
+    content::NavigationHandle* navigation_handle) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  if (!preconnect_manager_)
+    return;
+
+  if (navigation_handle->GetURL().is_empty() ||
+      !navigation_handle->GetURL().SchemeIsHTTPOrHTTPS())
+    return;
+
+  if (number_of_sockets_to_preconnect_ >= 0) {
+    std::vector<predictors::PreconnectRequest> requests;
+    requests.emplace_back(navigation_handle->GetURL().GetOrigin(),
+                          number_of_sockets_to_preconnect_);
+
+    base::PostTaskWithTraits(
+        FROM_HERE, {content::BrowserThread::UI},
+        base::BindOnce(&predictors::PreconnectManager::Start,
+                       base::Unretained(preconnect_manager_),
+                       navigation_handle->GetURL(), requests));
+  }
+}
+
+static bool GetAsInteger(const base::Value* val,
+                         const base::StringPiece& path,
+                         int* out) {
+  if (val) {
+    auto* found = val->FindKey(path);
+    if (found && found->is_int()) {
+      *out = found->GetInt();
+      return true;
+    } else if (found && found->is_string()) {
+      return base::StringToInt(found->GetString(), out);
+    }
+  }
+  return false;
+}
+
+int PreconnectManagerTabHelper::GetNumberOfSocketsToPreconnect(
+    WebContentsPreferences* prefs) {
+  int num_sockets_to_preconnect = -1;
+  if (GetAsInteger(prefs->preference(), options::kNumSocketsToPreconnect,
+                   &num_sockets_to_preconnect)) {
+    const int kMinSocketsToPreconnect = 1;
+    const int kMaxSocketsToPreconnect = 6;
+    num_sockets_to_preconnect =
+        std::max(num_sockets_to_preconnect, kMinSocketsToPreconnect);
+    num_sockets_to_preconnect =
+        std::min(num_sockets_to_preconnect, kMaxSocketsToPreconnect);
+  }
+  return num_sockets_to_preconnect;
+}
+
+void PreconnectManagerTabHelper::SetNumberOfSocketsToPreconnect(
+    int numSockets) {
+  number_of_sockets_to_preconnect_ = numSockets;
+}
+
+WEB_CONTENTS_USER_DATA_KEY_IMPL(PreconnectManagerTabHelper)
+
+}  // namespace atom

--- a/atom/browser/net/preconnect_manager_tab_helper.h
+++ b/atom/browser/net/preconnect_manager_tab_helper.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_NET_PRECONNECT_MANAGER_TAB_HELPER_H_
+#define ATOM_BROWSER_NET_PRECONNECT_MANAGER_TAB_HELPER_H_
+
+#include "content/public/browser/navigation_handle.h"
+#include "content/public/browser/web_contents_observer.h"
+#include "content/public/browser/web_contents_user_data.h"
+
+namespace predictors {
+class PreconnectManager;
+}
+
+namespace atom {
+
+class WebContentsPreferences;
+
+class PreconnectManagerTabHelper
+    : public content::WebContentsObserver,
+      public content::WebContentsUserData<PreconnectManagerTabHelper> {
+ public:
+  ~PreconnectManagerTabHelper() override;
+
+  // content::WebContentsObserver implementation
+  void DidStartNavigation(
+      content::NavigationHandle* navigation_handle) override;
+
+  // -1 - in case of number of preconnect sockets option is not set
+  static int GetNumberOfSocketsToPreconnect(WebContentsPreferences* prefs);
+
+  void SetNumberOfSocketsToPreconnect(int numSockets);
+
+ private:
+  explicit PreconnectManagerTabHelper(content::WebContents* web_contents);
+  friend class content::WebContentsUserData<PreconnectManagerTabHelper>;
+
+  predictors::PreconnectManager* preconnect_manager_;
+
+  int number_of_sockets_to_preconnect_;
+
+  WEB_CONTENTS_USER_DATA_KEY_DECL();
+
+  DISALLOW_COPY_AND_ASSIGN(PreconnectManagerTabHelper);
+};
+
+}  // namespace atom
+
+#endif  // ATOM_BROWSER_NET_PRECONNECT_MANAGER_TAB_HELPER_H_

--- a/atom/browser/renderer_host/DEPS
+++ b/atom/browser/renderer_host/DEPS
@@ -1,0 +1,6 @@
+include_rules = [
+  # renderer_host is intended to support the content layer's renderers. No
+  # reference to the tab contents is allowed.
+  "-chrome/browser/tab_contents",
+]
+

--- a/atom/browser/renderer_host/atom_render_message_filter.cc
+++ b/atom/browser/renderer_host/atom_render_message_filter.cc
@@ -1,0 +1,98 @@
+// Copyright (c) 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <stdint.h>
+#include <memory>
+#include <string>
+
+#include "atom/browser/net/preconnect_manager_factory.h"
+#include "atom/browser/renderer_host/atom_render_message_filter.h"
+
+#include "base/bind.h"
+#include "base/bind_helpers.h"
+#include "base/logging.h"
+#include "base/stl_util.h"
+#include "base/task/post_task.h"
+#include "chrome/browser/browser_process.h"
+#include "chrome/browser/chrome_notification_types.h"
+#include "chrome/browser/predictors/preconnect_manager.h"
+#include "chrome/browser/profiles/profile.h"
+#include "components/network_hints/common/network_hints_common.h"
+#include "components/network_hints/common/network_hints_messages.h"
+#include "content/public/browser/browser_task_traits.h"
+#include "content/public/browser/notification_service.h"
+#include "content/public/browser/render_process_host.h"
+#include "content/public/browser/storage_partition.h"
+
+using content::BrowserThread;
+
+namespace {
+
+const uint32_t kRenderFilteredMessageClasses[] = {
+    NetworkHintsMsgStart,
+};
+
+}  // namespace
+
+AtomRenderMessageFilter::AtomRenderMessageFilter(
+    int render_process_id,
+    Profile* profile,
+    int number_of_sockets_to_preconnect)
+    : BrowserMessageFilter(kRenderFilteredMessageClasses,
+                           base::size(kRenderFilteredMessageClasses)),
+      render_process_id_(render_process_id),
+      preconnect_manager_(nullptr),
+      number_of_sockets_to_preconnect_(number_of_sockets_to_preconnect) {
+  preconnect_manager_ = atom::PreconnectManagerFactory::GetForProfile(profile);
+}
+
+AtomRenderMessageFilter::~AtomRenderMessageFilter() {}
+
+bool AtomRenderMessageFilter::OnMessageReceived(const IPC::Message& message) {
+  bool handled = true;
+  IPC_BEGIN_MESSAGE_MAP(AtomRenderMessageFilter, message)
+    IPC_MESSAGE_HANDLER(NetworkHintsMsg_Preconnect, OnPreconnect)
+    IPC_MESSAGE_UNHANDLED(handled = false)
+  IPC_END_MESSAGE_MAP()
+
+  return handled;
+}
+
+void AtomRenderMessageFilter::OnPreconnect(const GURL& url,
+                                           bool allow_credentials,
+                                           int count) {
+  if (count < 1) {
+    LOG(WARNING) << "NetworkHintsMsg_Preconnect IPC with invalid count: "
+                 << count;
+    return;
+  }
+
+  if (!url.is_valid() || !url.has_host() || !url.has_scheme() ||
+      !url.SchemeIsHTTPOrHTTPS()) {
+    return;
+  }
+
+  if (!preconnect_manager_) {
+    return;
+  }
+
+  if (number_of_sockets_to_preconnect_ > 0) {
+    std::vector<predictors::PreconnectRequest> requests;
+    requests.emplace_back(url.GetOrigin(), number_of_sockets_to_preconnect_);
+
+    base::PostTaskWithTraits(
+        FROM_HERE, {BrowserThread::UI},
+        base::BindOnce(&predictors::PreconnectManager::Start,
+                       base::Unretained(preconnect_manager_), url, requests));
+  }
+}
+
+namespace predictors {
+
+PreconnectRequest::PreconnectRequest(const GURL& origin, int num_sockets)
+    : origin(origin), num_sockets(num_sockets) {
+  DCHECK_GE(num_sockets, 0);
+}
+
+}  // namespace predictors

--- a/atom/browser/renderer_host/atom_render_message_filter.h
+++ b/atom/browser/renderer_host/atom_render_message_filter.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_RENDERER_HOST_ATOM_RENDER_MESSAGE_FILTER_H_
+#define ATOM_BROWSER_RENDERER_HOST_ATOM_RENDER_MESSAGE_FILTER_H_
+
+#include <string>
+#include <vector>
+
+#include "base/callback.h"
+#include "base/macros.h"
+#include "base/sequenced_task_runner_helpers.h"
+#include "content/public/browser/browser_message_filter.h"
+#include "content/public/browser/browser_thread.h"
+#include "extensions/buildflags/buildflags.h"
+#include "ppapi/buildflags/buildflags.h"
+
+class GURL;
+class Profile;
+
+namespace predictors {
+class PreconnectManager;
+}
+
+namespace content_settings {
+class CookieSettings;
+}
+
+namespace network_hints {
+struct LookupRequest;
+}
+
+class AtomPreconnectDelegate;
+
+// This class filters out incoming Chrome-specific IPC messages for the renderer
+// process on the IPC thread.
+class AtomRenderMessageFilter : public content::BrowserMessageFilter {
+ public:
+  AtomRenderMessageFilter(int render_process_id,
+                          Profile* profile,
+                          int number_of_sockets_to_preconnect);
+
+  // content::BrowserMessageFilter methods:
+  bool OnMessageReceived(const IPC::Message& message) override;
+
+ private:
+  friend class content::BrowserThread;
+  friend class base::DeleteHelper<AtomRenderMessageFilter>;
+
+  ~AtomRenderMessageFilter() override;
+
+  void OnPreconnect(const GURL& url, bool allow_credentials, int count);
+
+  const int render_process_id_;
+
+  // The PreconnectManager for the associated Profile. This must only be
+  // accessed on the UI thread.
+  predictors::PreconnectManager* preconnect_manager_;
+
+  int number_of_sockets_to_preconnect_;
+
+  DISALLOW_COPY_AND_ASSIGN(AtomRenderMessageFilter);
+};
+
+#endif  // ATOM_BROWSER_RENDERER_HOST_ATOM_RENDER_MESSAGE_FILTER_H_


### PR DESCRIPTION
#### Description of Change
Added HTTP preconnect hint support.

Using the parameter numSocketsToPreconnect in BrowserWindow you can control how many sockets will be open.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
