### PR TITLE
refactor: make browserViews a property on BrowserWindows

### DIFF
--- a/atom/browser/api/atom_api_top_level_window.cc
+++ b/atom/browser/api/atom_api_top_level_window.cc
@@ -692,6 +692,7 @@ void TopLevelWindow::SetParentWindow(v8::Local<v8::Value> value,
   }
 }
 
+// TODO(codebytere): remove in Electron v8.0.0
 void TopLevelWindow::SetBrowserView(v8::Local<v8::Value> value) {
   ResetBrowserViews();
   AddBrowserView(value);
@@ -890,6 +891,13 @@ v8::Local<v8::Value> TopLevelWindow::GetBrowserView(
         "BrowserWindow have multiple BrowserViews, "
         "Use getBrowserViews() instead");
     return v8::Null(isolate());
+  }
+}
+
+void TopLevelWindow::SetBrowserViews(std::vector<v8::Local<v8::Value>> views) {
+  ResetBrowserViews();
+  for (auto const& view : views) {
+    AddBrowserView(view);
   }
 }
 
@@ -1126,8 +1134,15 @@ void TopLevelWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setMenu", &TopLevelWindow::SetMenu)
       .SetMethod("removeMenu", &TopLevelWindow::RemoveMenu)
       .SetMethod("setParentWindow", &TopLevelWindow::SetParentWindow)
-      .SetMethod("setBrowserView", &TopLevelWindow::SetBrowserView)
       .SetMethod("addBrowserView", &TopLevelWindow::AddBrowserView)
+      // TODO(codebytere): remove getter/setter in Electron v8.0.0
+      .SetMethod("getBrowserView", &TopLevelWindow::GetBrowserView)
+      .SetMethod("setBrowserView", &TopLevelWindow::SetBrowserView)
+      // TODO(codebytere): remove getter/setter in Electron v8.0.0
+      .SetMethod("_getBrowserViews", &TopLevelWindow::GetBrowserViews)
+      .SetMethod("_setBrowserViews", &TopLevelWindow::GetBrowserViews)
+      .SetProperty("browserViews", &TopLevelWindow::GetBrowserViews,
+                   &TopLevelWindow::SetBrowserViews)
       .SetMethod("removeBrowserView", &TopLevelWindow::RemoveBrowserView)
       .SetMethod("getNativeWindowHandle",
                  &TopLevelWindow::GetNativeWindowHandle)
@@ -1169,8 +1184,6 @@ void TopLevelWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("getContentView", &TopLevelWindow::GetContentView)
       .SetMethod("getParentWindow", &TopLevelWindow::GetParentWindow)
       .SetMethod("getChildWindows", &TopLevelWindow::GetChildWindows)
-      .SetMethod("getBrowserView", &TopLevelWindow::GetBrowserView)
-      .SetMethod("getBrowserViews", &TopLevelWindow::GetBrowserViews)
       .SetMethod("isModal", &TopLevelWindow::IsModal)
       .SetMethod("setThumbarButtons", &TopLevelWindow::SetThumbarButtons)
 #if defined(TOOLKIT_VIEWS)

--- a/atom/browser/api/atom_api_top_level_window.h
+++ b/atom/browser/api/atom_api_top_level_window.h
@@ -167,9 +167,11 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   void SetMenu(v8::Isolate* isolate, v8::Local<v8::Value> menu);
   void RemoveMenu();
   void SetParentWindow(v8::Local<v8::Value> value, mate::Arguments* args);
+  // TODO(codebytere): remove in Electron v8.0.0
   virtual void SetBrowserView(v8::Local<v8::Value> value);
   virtual void AddBrowserView(v8::Local<v8::Value> value);
   virtual void RemoveBrowserView(v8::Local<v8::Value> value);
+  virtual void SetBrowserViews(std::vector<v8::Local<v8::Value>> views);
   virtual std::vector<v8::Local<v8::Value>> GetBrowserViews() const;
   virtual void ResetBrowserViews();
   v8::Local<v8::Value> GetNativeWindowHandle();

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1635,13 +1635,17 @@ removed in future Electron releases.
 #### `win.setBrowserView(browserView)` _Experimental_
 
 * `browserView` [BrowserView](browser-view.md) - Attach browserView to win.
-If there is some other browserViews was attached they will be removed from
+If there are other BrowserViews attached previously, they will be removed from
 this window.
+
+**[Deprecated](modernization/property-updates.md): Use `win.browserViews` property instead**
 
 #### `win.getBrowserView()` _Experimental_
 
-Returns `BrowserView | null` - an BrowserView what is attached. Returns `null`
-if none is attached. Throw error if multiple BrowserViews is attached.
+Returns `BrowserView | null` - a BrowserView that is attached. Returns `null`
+if none is attached. Throws an error if multiple BrowserViews are attached.
+
+**[Deprecated](modernization/property-updates.md): Use `win.browserViews` property instead**
 
 #### `win.addBrowserView(browserView)` _Experimental_
 
@@ -1661,6 +1665,8 @@ or setBrowserView.
 **Note:** The BrowserView API is currently experimental and may change or be
 removed in future Electron releases.
 
+**[Deprecated](modernization/property-updates.md): Use `win.browserViews` property instead**
+
 [runtime-enabled-features]: https://cs.chromium.org/chromium/src/third_party/blink/renderer/platform/runtime_enabled_features.json5?l=70
 [page-visibility-api]: https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
 [quick-look]: https://en.wikipedia.org/wiki/Quick_Look
@@ -1669,6 +1675,22 @@ removed in future Electron releases.
 [chrome-content-scripts]: https://developer.chrome.com/extensions/content_scripts#execution-environment
 
 ### Properties
+
+#### `win.browserViews`
+
+A `BrowserView[]` property that determines the BrowserViews currently attached to the window. Returns an empty array
+if no BrowserViews are attached.
+
+```js
+const win = new BrowserWindow({ height: 600, width: 600 })
+
+const view1 = new BrowserView()
+const view2 = new BrowserView()
+
+win.browserViews = [view1, view2]
+
+console.log(win.browserViews.length) // 2
+```
 
 #### `win.autoHideMenuBar`
 

--- a/docs/api/modernization/property-updates.md
+++ b/docs/api/modernization/property-updates.md
@@ -49,6 +49,7 @@ The Electron team is currently undergoing an initiative to convert separate gett
   * `name`
 * `BrowserWindow` module
   * `autohideMenuBar`
+  * `browserViews`
   * `resizable`
   * `maximizable`
   * `minimizable`

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -121,7 +121,7 @@ BrowserWindow.fromWebContents = (webContents) => {
 
 BrowserWindow.fromBrowserView = (browserView) => {
   for (const window of BrowserWindow.getAllWindows()) {
-    if (window.getBrowserView() === browserView) return window
+    if (window.browserView === browserView) return window
   }
 
   return null
@@ -199,5 +199,6 @@ deprecate.fnToProperty(BrowserWindow.prototype, 'resizable', '_isResizable', '_s
 deprecate.fnToProperty(BrowserWindow.prototype, 'fullScreenable', '_isFullScreenable', '_setFullScreenable')
 deprecate.fnToProperty(BrowserWindow.prototype, 'closable', '_isClosable', '_setClosable')
 deprecate.fnToProperty(BrowserWindow.prototype, 'movable', '_isMovable', '_setMovable')
+deprecate.fnToProperty(BrowserWindow.prototype, 'browserViews', '_getBrowserViews', '_setBrowserViews')
 
 module.exports = BrowserWindow

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -121,9 +121,8 @@ BrowserWindow.fromWebContents = (webContents) => {
 
 BrowserWindow.fromBrowserView = (browserView) => {
   for (const window of BrowserWindow.getAllWindows()) {
-    if (window.browserView === browserView) return window
+    if (window.browserViews[0] === browserView) return window
   }
-
   return null
 }
 

--- a/spec/api-browser-view-spec.js
+++ b/spec/api-browser-view-spec.js
@@ -101,6 +101,48 @@ describe('BrowserView module', () => {
     })
   })
 
+  describe('BrowserWindow.browserViews property', () => {
+    it('does not throw for valid args', () => {
+      view = new BrowserView()
+      w.browserViews = [view]
+    })
+
+    it('does not throw if called multiple times with same view', () => {
+      view = new BrowserView()
+      w.browserViews = [view]
+      w.browserViews = [view]
+      w.browserViews = [view]
+    })
+
+    it('returns the set view', () => {
+      view = new BrowserView()
+      w.browserViews = [view]
+      expect(view.id).to.not.be.null()
+
+      const view2 = w.getBrowserView()
+      expect(view2.webContents.id).to.equal(view.webContents.id)
+    })
+
+    it('returns multiple set views', () => {
+      const v1 = new BrowserView()
+      const v2 = new BrowserView()
+      w.browserViews = [v1, v2]
+
+      expect(v1.id).to.not.be.null()
+      expect(v2.id).to.not.be.null()
+
+      const views = w.browserViews
+      expect(views[0].webContents.id).to.equal(v1.webContents.id)
+      expect(views[1].webContents.id).to.equal(v2.webContents.id)
+    })
+
+    it('returns null if none is set', () => {
+      const views = w.browserViews
+      expect(views).to.be.an('array').that.is.empty()
+    })
+  })
+
+  // TODO(codebytere): remove when propertyification is complete
   describe('BrowserWindow.setBrowserView()', () => {
     it('does not throw for valid args', () => {
       view = new BrowserView()
@@ -115,6 +157,7 @@ describe('BrowserView module', () => {
     })
   })
 
+  // TODO(codebytere): remove when propertyification is complete
   describe('BrowserWindow.getBrowserView()', () => {
     it('returns the set view', () => {
       view = new BrowserView()

--- a/spec/api-browser-view-spec.js
+++ b/spec/api-browser-view-spec.js
@@ -119,21 +119,47 @@ describe('BrowserView module', () => {
       w.browserViews = [view]
       expect(view.id).to.not.be.null()
 
-      const view2 = w.getBrowserView()
-      expect(view2.webContents.id).to.equal(view.webContents.id)
+      const views = w.browserViews
+      expect(views[0].webContents.id).to.equal(view.webContents.id)
+    })
+
+    it('returns same views as were added', () => {
+      let v1 = new BrowserView()
+      w.addBrowserView(v1)
+      let v2 = new BrowserView()
+      w.addBrowserView(v2)
+
+      expect(v1.id).to.not.be.null()
+      expect(v2.id).to.not.be.null()
+
+      const views = w.browserViews
+      expect(views).to.have.lengthOf(2)
+      expect(views[0].webContents.id).to.equal(v1.webContents.id)
+      expect(views[1].webContents.id).to.equal(v2.webContents.id)
+
+      v1.destroy()
+      v1 = null
+      v2.destroy()
+      v2 = null
     })
 
     it('returns multiple set views', () => {
-      const v1 = new BrowserView()
-      const v2 = new BrowserView()
+      let v1 = new BrowserView()
+      let v2 = new BrowserView()
       w.browserViews = [v1, v2]
 
       expect(v1.id).to.not.be.null()
       expect(v2.id).to.not.be.null()
 
       const views = w.browserViews
+      expect(views).to.have.lengthOf(2)
       expect(views[0].webContents.id).to.equal(v1.webContents.id)
       expect(views[1].webContents.id).to.equal(v2.webContents.id)
+
+      v1.destroy()
+      v1 = null
+      v2.destroy()
+      v2 = null
     })
 
     it('returns null if none is set', () => {
@@ -202,6 +228,7 @@ describe('BrowserView module', () => {
     })
   })
 
+  // TODO(codebytere): remove in Electron v8.0.0
   describe('BrowserWindow.getBrowserViews()', () => {
     it('returns same views as was added', () => {
       let view1 = new BrowserView()
@@ -227,10 +254,10 @@ describe('BrowserView module', () => {
       view = new BrowserView()
       expect(view.webContents.getOwnerBrowserWindow()).to.be.null()
 
-      w.setBrowserView(view)
+      w.browserViews = [view]
       expect(view.webContents.getOwnerBrowserWindow()).to.equal(w)
 
-      w.setBrowserView(null)
+      w.browserViews = [null]
       expect(view.webContents.getOwnerBrowserWindow()).to.be.null()
     })
   })
@@ -238,7 +265,7 @@ describe('BrowserView module', () => {
   describe('BrowserView.fromId()', () => {
     it('returns the view with given id', () => {
       view = new BrowserView()
-      w.setBrowserView(view)
+      w.browserViews = [view]
       expect(view.id).to.not.be.null()
 
       const view2 = BrowserView.fromId(view.id)
@@ -249,7 +276,7 @@ describe('BrowserView module', () => {
   describe('BrowserView.fromWebContents()', () => {
     it('returns the view with given id', () => {
       view = new BrowserView()
-      w.setBrowserView(view)
+      w.browserViews = [view]
       expect(view.id).to.not.be.null()
 
       const view2 = BrowserView.fromWebContents(view.webContents)
@@ -260,7 +287,7 @@ describe('BrowserView module', () => {
   describe('BrowserView.getAllViews()', () => {
     it('returns all views', () => {
       view = new BrowserView()
-      w.setBrowserView(view)
+      w.browserViews = [view]
       expect(view.id).to.not.be.null()
 
       const views = BrowserView.getAllViews()
@@ -282,7 +309,7 @@ describe('BrowserView module', () => {
   describe('window.open()', () => {
     it('works in BrowserView', (done) => {
       view = new BrowserView()
-      w.setBrowserView(view)
+      w.browserViews = [view]
       view.webContents.once('new-window', (e, url, frameName, disposition, options, additionalFeatures) => {
         e.preventDefault()
         expect(url).to.equal('http://host/')

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -787,11 +787,11 @@ describe('BrowserWindow module', () => {
 
     beforeEach(() => {
       bv = new BrowserView()
-      w.setBrowserView(bv)
+      w.browserViews = [bv]
     })
 
     afterEach(() => {
-      w.setBrowserView(null)
+      w.browserViews = [null]
       bv.destroy()
     })
 
@@ -800,7 +800,7 @@ describe('BrowserWindow module', () => {
     })
 
     it('returns undefined if not attached', () => {
-      w.setBrowserView(null)
+      w.browserViews = [null]
       expect(BrowserWindow.fromBrowserView(bv)).to.be.null()
     })
   })


### PR DESCRIPTION
#### Description of Change

Convert getters and setters for `browserView` to make browserView a bespoke property on BrowserWindows instances.

cc @miniak @zcbenz

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Converted `browserViews` to a property on BrowserWindow instances
