### PR TITLE
refactor: make savePath a property on DownloadItem

### DIFF
--- a/docs/api/download-item.md
+++ b/docs/api/download-item.md
@@ -80,13 +80,17 @@ The `downloadItem` object has the following methods:
 
 The API is only available in session's `will-download` callback function.
 If user doesn't set the save path via the API, Electron will use the original
-routine to determine the save path(Usually prompts a save dialog).
+routine to determine the save path; this usually prompts a save dialog.
+
+**[Deprecated](modernization/property-updates.md): use the `savePath` property instead.**
 
 #### `downloadItem.getSavePath()`
 
 Returns `String` - The save path of the download item. This will be either the path
 set via `downloadItem.setSavePath(path)` or the path selected from the shown
 save dialog.
+
+**[Deprecated](modernization/property-updates.md): use the `savePath` property instead.**
 
 #### `downloadItem.setSaveDialogOptions(options)`
 
@@ -97,9 +101,13 @@ This API allows the user to set custom options for the save dialog that opens
 for the download item by default.
 The API is only available in session's `will-download` callback function.
 
+**[Deprecated](modernization/property-updates.md): use the `saveDialogOptions` property instead.**
+
 #### `downloadItem.getSaveDialogOptions()`
 
 Returns `SaveDialogOptions` - Returns the object previously set by `downloadItem.setSaveDialogOptions(options)`.
+
+**[Deprecated](modernization/property-updates.md): use the `saveDialogOptions` property instead.**
 
 #### `downloadItem.pause()`
 
@@ -181,3 +189,22 @@ Returns `String` - ETag header value.
 
 Returns `Double` - Number of seconds since the UNIX epoch when the download was
 started.
+
+### Properties
+
+#### `downloadItem.saveDialogProperties`
+
+An `Object` property that determines the save file dialog options. The object passed is should have the same
+properties as the `options` parameter of [`dialog.showSaveDialog()`](dialog.md).
+
+This property allows the user to set custom options for the save dialog that opens
+for the download item by default.
+The API is only available in session's `will-download` callback function.
+
+#### `downloadItem.savePath`
+
+A `String` property that determines the save file path of the download item.
+
+The property is only available in session's `will-download` callback function.
+If user doesn't set the save path via the property, Electron will use the original
+routine to determine the save path; this usually prompts a save dialog.

--- a/docs/api/download-item.md
+++ b/docs/api/download-item.md
@@ -101,13 +101,9 @@ This API allows the user to set custom options for the save dialog that opens
 for the download item by default.
 The API is only available in session's `will-download` callback function.
 
-**[Deprecated](modernization/property-updates.md): use the `saveDialogOptions` property instead.**
-
 #### `downloadItem.getSaveDialogOptions()`
 
 Returns `SaveDialogOptions` - Returns the object previously set by `downloadItem.setSaveDialogOptions(options)`.
-
-**[Deprecated](modernization/property-updates.md): use the `saveDialogOptions` property instead.**
 
 #### `downloadItem.pause()`
 
@@ -190,16 +186,7 @@ Returns `String` - ETag header value.
 Returns `Double` - Number of seconds since the UNIX epoch when the download was
 started.
 
-### Properties
-
-#### `downloadItem.saveDialogProperties`
-
-An `Object` property that determines the save file dialog options. The object passed is should have the same
-properties as the `options` parameter of [`dialog.showSaveDialog()`](dialog.md).
-
-This property allows the user to set custom options for the save dialog that opens
-for the download item by default.
-The API is only available in session's `will-download` callback function.
+### Instance Properties
 
 #### `downloadItem.savePath`
 

--- a/docs/api/modernization/property-updates.md
+++ b/docs/api/modernization/property-updates.md
@@ -46,7 +46,6 @@ The Electron team is currently undergoing an initiative to convert separate gett
   * `name`
 * `DownloadItem` class
   * `savePath`
-  * `paused`
 * `BrowserWindow` module
   * `autohideMenuBar`
   * `resizable`

--- a/docs/api/modernization/property-updates.md
+++ b/docs/api/modernization/property-updates.md
@@ -20,9 +20,6 @@ The Electron team is currently undergoing an initiative to convert separate gett
   * `visibleOnAllWorkspaces`
 * `crashReporter` module
   * `uploadToServer`
-* `DownloadItem` class
-  * `savePath`
-  * `paused`
 * `Session` module
   * `preloads`
 * `webContents` module
@@ -47,6 +44,9 @@ The Electron team is currently undergoing an initiative to convert separate gett
   * `applicationMenu`
   * `badgeCount`
   * `name`
+* `DownloadItem` class
+  * `savePath`
+  * `paused`
 * `BrowserWindow` module
   * `autohideMenuBar`
   * `resizable`

--- a/shell/browser/api/atom_api_download_item.cc
+++ b/shell/browser/api/atom_api_download_item.cc
@@ -209,8 +209,12 @@ void DownloadItem::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("isDone", &DownloadItem::IsDone)
       .SetMethod("setSavePath", &DownloadItem::SetSavePath)
       .SetMethod("getSavePath", &DownloadItem::GetSavePath)
+      .SetProperty("savePath", &DownloadItem::GetSavePath,
+                   &DownloadItem::SetSavePath)
       .SetMethod("setSaveDialogOptions", &DownloadItem::SetSaveDialogOptions)
       .SetMethod("getSaveDialogOptions", &DownloadItem::GetSaveDialogOptions)
+      .SetProperty("saveDialogOptions", &DownloadItem::GetSaveDialogOptions,
+                   &DownloadItem::SetSaveDialogOptions)
       .SetMethod("getLastModifiedTime", &DownloadItem::GetLastModifiedTime)
       .SetMethod("getETag", &DownloadItem::GetETag)
       .SetMethod("getStartTime", &DownloadItem::GetStartTime);

--- a/shell/browser/api/atom_api_download_item.cc
+++ b/shell/browser/api/atom_api_download_item.cc
@@ -213,8 +213,6 @@ void DownloadItem::BuildPrototype(v8::Isolate* isolate,
                    &DownloadItem::SetSavePath)
       .SetMethod("setSaveDialogOptions", &DownloadItem::SetSaveDialogOptions)
       .SetMethod("getSaveDialogOptions", &DownloadItem::GetSaveDialogOptions)
-      .SetProperty("saveDialogOptions", &DownloadItem::GetSaveDialogOptions,
-                   &DownloadItem::SetSaveDialogOptions)
       .SetMethod("getLastModifiedTime", &DownloadItem::GetLastModifiedTime)
       .SetMethod("getETag", &DownloadItem::GetETag)
       .SetMethod("getStartTime", &DownloadItem::GetStartTime);

--- a/spec-main/api-session-spec.js
+++ b/spec-main/api-session-spec.js
@@ -659,7 +659,6 @@ describe('session module', () => {
       w.webContents.downloadURL(`${url}:${port}/?testFilename`)
     })
 
-    // TODO(codebytere): remove in Electron v8.0.0 after propertyification  completes
     it('can set options for the save dialog', (done) => {
       const filePath = path.join(__dirname, 'fixtures', 'mock.pdf')
       const port = downloadServer.address().port
@@ -684,37 +683,6 @@ describe('session module', () => {
         item.setSaveDialogOptions(options)
         item.on('done', function (e, state) {
           expect(item.getSaveDialogOptions()).to.deep.equal(options)
-          done()
-        })
-        item.cancel()
-      })
-      w.webContents.downloadURL(`${url}:${port}`)
-    })
-    
-    it('can set options for the save dialog (property)', (done) => {
-      const filePath = path.join(__dirname, 'fixtures', 'mock.pdf')
-      const port = downloadServer.address().port
-      const options = {
-        window: null,
-        title: 'title',
-        message: 'message',
-        buttonLabel: 'buttonLabel',
-        nameFieldLabel: 'nameFieldLabel',
-        defaultPath: '/',
-        filters: [{
-          name: '1', extensions: ['.1', '.2']
-        }, {
-          name: '2', extensions: ['.3', '.4', '.5']
-        }],
-        showsTagField: true,
-        securityScopedBookmarks: true
-      }
-
-      w.webContents.session.once('will-download', function (e, item) {
-        item.savePath = filePath
-        item.saveDialogOptions = options
-        item.on('done', function (e, state) {
-          expect(item.saveDialogOptions).to.deep.equal(options)
           done()
         })
         item.cancel()

--- a/spec-main/api-session-spec.js
+++ b/spec-main/api-session-spec.js
@@ -552,8 +552,8 @@ describe('session module', () => {
     const assertDownload = (state, item, isCustom = false) => {
       expect(state).to.equal('completed')
       expect(item.getFilename()).to.equal('mock.pdf')
-      expect(path.isAbsolute(item.getSavePath())).to.equal(true)
-      expect(isPathEqual(item.getSavePath(), downloadFilePath)).to.equal(true)
+      expect(path.isAbsolute(item.savePath)).to.equal(true)
+      expect(isPathEqual(item.savePath, downloadFilePath)).to.equal(true)
       if (isCustom) {
         expect(item.getURL()).to.equal(`${protocolName}://item`)
       } else {
@@ -570,7 +570,7 @@ describe('session module', () => {
     it('can download using WebContents.downloadURL', (done) => {
       const port = downloadServer.address().port
       w.webContents.session.once('will-download', function (e, item) {
-        item.setSavePath(downloadFilePath)
+        item.savePath = downloadFilePath
         item.on('done', function (e, state) {
           assertDownload(state, item)
           done()
@@ -588,7 +588,7 @@ describe('session module', () => {
       protocol.registerHttpProtocol(protocolName, handler, (error) => {
         if (error) return done(error)
         w.webContents.session.once('will-download', function (e, item) {
-          item.setSavePath(downloadFilePath)
+          item.savePath = downloadFilePath
           item.on('done', function (e, state) {
             assertDownload(state, item, true)
             done()
@@ -611,7 +611,7 @@ describe('session module', () => {
       }
       const done = new Promise(resolve => {
         w.webContents.session.once('will-download', function (e, item) {
-          item.setSavePath(downloadFilePath)
+          item.savePath = downloadFilePath
           item.on('done', function (e, state) {
             resolve([state, item])
           })
@@ -625,7 +625,7 @@ describe('session module', () => {
     it('can cancel download', (done) => {
       const port = downloadServer.address().port
       w.webContents.session.once('will-download', function (e, item) {
-        item.setSavePath(downloadFilePath)
+        item.savePath = downloadFilePath
         item.on('done', function (e, state) {
           expect(state).to.equal('cancelled')
           expect(item.getFilename()).to.equal('mock.pdf')
@@ -649,7 +649,7 @@ describe('session module', () => {
 
       const port = downloadServer.address().port
       w.webContents.session.once('will-download', function (e, item) {
-        item.setSavePath(downloadFilePath)
+        item.savePath = downloadFilePath
         item.on('done', function (e, state) {
           expect(item.getFilename()).to.equal('download.pdf')
           done()
@@ -659,6 +659,7 @@ describe('session module', () => {
       w.webContents.downloadURL(`${url}:${port}/?testFilename`)
     })
 
+    // TODO(codebytere): remove in Electron v8.0.0 after propertyification  completes
     it('can set options for the save dialog', (done) => {
       const filePath = path.join(__dirname, 'fixtures', 'mock.pdf')
       const port = downloadServer.address().port
@@ -689,11 +690,42 @@ describe('session module', () => {
       })
       w.webContents.downloadURL(`${url}:${port}`)
     })
+    
+    it('can set options for the save dialog (property)', (done) => {
+      const filePath = path.join(__dirname, 'fixtures', 'mock.pdf')
+      const port = downloadServer.address().port
+      const options = {
+        window: null,
+        title: 'title',
+        message: 'message',
+        buttonLabel: 'buttonLabel',
+        nameFieldLabel: 'nameFieldLabel',
+        defaultPath: '/',
+        filters: [{
+          name: '1', extensions: ['.1', '.2']
+        }, {
+          name: '2', extensions: ['.3', '.4', '.5']
+        }],
+        showsTagField: true,
+        securityScopedBookmarks: true
+      }
+
+      w.webContents.session.once('will-download', function (e, item) {
+        item.savePath = filePath
+        item.saveDialogOptions = options
+        item.on('done', function (e, state) {
+          expect(item.saveDialogOptions).to.deep.equal(options)
+          done()
+        })
+        item.cancel()
+      })
+      w.webContents.downloadURL(`${url}:${port}`)
+    })
 
     describe('when a save path is specified and the URL is unavailable', () => {
       it('does not display a save dialog and reports the done state as interrupted', (done) => {
         w.webContents.session.once('will-download', function (e, item) {
-          item.setSavePath(downloadFilePath)
+          item.savePath = downloadFilePath
           if (item.getState() === 'interrupted') {
             item.resume()
           }
@@ -724,7 +756,7 @@ describe('session module', () => {
         expect(item.getMimeType()).to.equal(options.mimeType)
         expect(item.getReceivedBytes()).to.equal(options.offset)
         expect(item.getTotalBytes()).to.equal(options.length)
-        expect(item.getSavePath()).to.equal(downloadFilePath)
+        expect(item.savePath).to.equal(downloadFilePath)
         done()
       })
       w.webContents.session.createInterruptedDownload(options)
@@ -755,7 +787,7 @@ describe('session module', () => {
         expect(item.getState()).to.equal('cancelled')
 
         const options = {
-          path: item.getSavePath(),
+          path: item.savePath,
           urlChain: item.getURLChain(),
           mimeType: item.getMimeType(),
           offset: item.getReceivedBytes(),
@@ -777,7 +809,7 @@ describe('session module', () => {
         const completedItem = await downloadResumed
         expect(completedItem.getState()).to.equal('completed')
         expect(completedItem.getFilename()).to.equal('logo.png')
-        expect(completedItem.getSavePath()).to.equal(downloadFilePath)
+        expect(completedItem.savePath).to.equal(downloadFilePath)
         expect(completedItem.getURL()).to.equal(downloadUrl)
         expect(completedItem.getMimeType()).to.equal('image/png')
         expect(completedItem.getReceivedBytes()).to.equal(14022)


### PR DESCRIPTION
#### Description of Change

Converted `item.savePath` on DownloadItem to a bespoke property.

cc @miniak @zcbenz

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Converted `savePath` accessor to a property on DownloadItem instances.
