### PR TITLE
ci: allow use of .only in ci testing mode

### DIFF
--- a/spec-main/index.js
+++ b/spec-main/index.js
@@ -86,6 +86,6 @@ app.whenReady().then(() => {
         process.exit(runner.failures)
       })
     }
-    const runner = (isCI) ? mocha.forbidOnly().run(cb) : mocha.run(cb)
+    const runner = mocha.run(cb)
   })
 })

--- a/spec/static/index.html
+++ b/spec/static/index.html
@@ -96,21 +96,8 @@
     const runner = mocha.run(() => {
       // Ensure the callback is called after runner is defined
       setTimeout(() => {
-        if (isCi && runner.hasOnly) {
-          try {
-            throw new Error('A spec contains a call to it.only or describe.only and should be reverted.')
-          } catch (error) {
-            console.error(error.stack || error)
-          }
-          ipcRenderer.send('process.exit', 1)
-          return
-        }
-
         Mocha.utils.highlightTags('code')
-
-        if (isCi) {
-          ipcRenderer.send('process.exit', runner.failures)
-        }
+        if (isCi) ipcRenderer.send('process.exit', runner.failures)
       }, 0)
     })
   })


### PR DESCRIPTION
#### Description of Change

It's common to use `--ci` when running tests locally, and often locally we also only want to run a specific subset of tests via `.only`.

This code was initially added to prevent code being committed with `.only` directives, but this is a redundancy now that we use `lint-staged` which also catches instances of `.only` on commit and prevents said commit if they're present.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
