### PR TITLE
refactor: make preloads a property on session instances

### DIFF
--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -693,8 +693,9 @@ void Session::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("getBlobData", &Session::GetBlobData)
       .SetMethod("createInterruptedDownload",
                  &Session::CreateInterruptedDownload)
-      .SetMethod("setPreloads", &Session::SetPreloads)
-      .SetMethod("getPreloads", &Session::GetPreloads)
+      .SetMethod("_setPreloads", &Session::SetPreloads)
+      .SetMethod("_getPreloads", &Session::GetPreloads)
+      .SetProperty("preloads", &Session::GetPreloads, &Session::SetPreloads)
       .SetProperty("cookies", &Session::Cookies)
       .SetProperty("netLog", &Session::NetLog)
       .SetProperty("protocol", &Session::Protocol)

--- a/docs/api/modernization/property-updates.md
+++ b/docs/api/modernization/property-updates.md
@@ -23,8 +23,6 @@ The Electron team is currently undergoing an initiative to convert separate gett
 * `DownloadItem` class
   * `savePath`
   * `paused`
-* `Session` module
-  * `preloads`
 * `webContents` module
   * `zoomFactor`
   * `zoomLevel`
@@ -57,5 +55,7 @@ The Electron team is currently undergoing an initiative to convert separate gett
   * `closable`
 * `NativeImage`
   * `isMacTemplateImage`
+* `Session` module
+  * `preloads`
 * `SystemPreferences` module
   * `appLevelAppearance`

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -416,10 +416,14 @@ this session just before normal `preload` scripts run.
 
 **Note:** For security reasons, preload scripts can only be loaded from a subpath of the [app path](app.md#appgetapppath).
 
+**[Deprecated](modernization/property-updates.md): use the `preloads` property instead.**
+
 #### `ses.getPreloads()`
 
 Returns `String[]` an array of paths to preload scripts that have been
 registered.
+
+**[Deprecated](modernization/property-updates.md): use the `preloads` property instead.**
 
 ### Instance Properties
 
@@ -451,6 +455,13 @@ app.on('ready', function () {
   })
 })
 ```
+
+#### `ses.preloads`
+
+A `String[]` property containing absolute paths to preload scripts for this session.
+
+This determines scripts that will be executed on ALL web contents that are associated with
+this session just before normal `preload` scripts run.
 
 #### `ses.netLog`
 

--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -50,3 +50,6 @@ Object.defineProperties(NetLog.prototype, {
     }
   }
 })
+
+// Deprecations
+deprecate.fnToProperty(Session.prototype, 'preloads', '_getPreloads', '_setPreloads')

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -543,7 +543,7 @@ const getPreloadScript = async function (preloadPath) {
 
 ipcMainUtils.handle('ELECTRON_BROWSER_SANDBOX_LOAD', async function (event) {
   const preloadPaths = [
-    ...(event.sender.session ? event.sender.session.getPreloads() : []),
+    ...(event.sender.session ? event.sender.session.preloads : []),
     event.sender._getPreloadPath()
   ]
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1073,15 +1073,15 @@ describe('BrowserWindow module', () => {
       const defaultSession = session.defaultSession
 
       beforeEach(() => {
-        expect(defaultSession.getPreloads()).to.deep.equal([])
-        defaultSession.setPreloads(preloads)
+        expect(defaultSession.preloads).to.deep.equal([])
+        defaultSession.preloads = preloads
       })
       afterEach(() => {
-        defaultSession.setPreloads([])
+        defaultSession.preloads = []
       })
 
       it('can set multiple session preload script', function () {
-        expect(defaultSession.getPreloads()).to.deep.equal(preloads)
+        expect(defaultSession.preloads).to.deep.equal(preloads)
       })
 
       const generateSpecs = (description, sandbox) => {


### PR DESCRIPTION
#### Description of Change

Convert `preloads` to a property on Session instances.

cc @miniak @zcbenz @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Converted `preloads` to a property on Session instances.
