### PR TITLE
chore: add ability to log native deprecation warnings

### DIFF
--- a/atom/common/deprecate_util.cc
+++ b/atom/common/deprecate_util.cc
@@ -2,12 +2,12 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include <string>
-
 #include "atom/common/deprecate_util.h"
 
 namespace atom {
 
+// msg/type/code arguments match Node's process.emitWarning() method. See
+// https://nodejs.org/api/process.html#process_process_emitwarning_warning_type_code_ctor
 v8::Maybe<bool> EmitDeprecationWarning(node::Environment* env,
                                        std::string warning_msg,
                                        std::string warning_type = "",
@@ -38,17 +38,14 @@ v8::Maybe<bool> EmitDeprecationWarning(node::Environment* env,
     return v8::Nothing<bool>();
   }
   if (type != nullptr) {
-    if (!v8::String::NewFromOneByte(env->isolate(),
-                                    reinterpret_cast<const uint8_t*>(type),
-                                    v8::NewStringType::kNormal)
+    if (!v8::String::NewFromUtf8(env->isolate(), type,
+                                 v8::NewStringType::kNormal)
              .ToLocal(&args[argc++])) {
       return v8::Nothing<bool>();
     }
-    if (code != nullptr &&
-        !v8::String::NewFromOneByte(env->isolate(),
-                                    reinterpret_cast<const uint8_t*>(code),
-                                    v8::NewStringType::kNormal)
-             .ToLocal(&args[argc++])) {
+    if (code != nullptr && !v8::String::NewFromUtf8(env->isolate(), code,
+                                                    v8::NewStringType::kNormal)
+                                .ToLocal(&args[argc++])) {
       return v8::Nothing<bool>();
     }
   }

--- a/atom/common/deprecate_util.cc
+++ b/atom/common/deprecate_util.cc
@@ -9,11 +9,15 @@
 namespace atom {
 
 v8::Maybe<bool> EmitDeprecationWarning(node::Environment* env,
-                                       const char* warning,
-                                       const char* type = nullptr,
-                                       const char* code = nullptr) {
+                                       std::string warning_msg,
+                                       std::string warning_type = "",
+                                       std::string warning_code = "") {
   v8::HandleScope handle_scope(env->isolate());
   v8::Context::Scope context_scope(env->context());
+
+  const char* warning = warning_msg.empty() ? nullptr : warning_msg.c_str();
+  const char* type = warning_type.empty() ? nullptr : warning_type.c_str();
+  const char* code = warning_code.empty() ? nullptr : warning_code.c_str();
 
   v8::Local<v8::Object> process = env->process_object();
   v8::Local<v8::Value> emit_warning;
@@ -49,8 +53,6 @@ v8::Maybe<bool> EmitDeprecationWarning(node::Environment* env,
     }
   }
 
-  // MakeCallback() unneeded because emitWarning is internal code, it calls
-  // process.emit('warning', ...), but does so on the nextTick.
   if (emit_warning.As<v8::Function>()
           ->Call(env->context(), process, argc, args)
           .IsEmpty()) {

--- a/atom/common/deprecate_util.cc
+++ b/atom/common/deprecate_util.cc
@@ -1,0 +1,62 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include <string>
+
+#include "atom/common/deprecate_util.h"
+
+namespace atom {
+
+v8::Maybe<bool> EmitDeprecationWarning(node::Environment* env,
+                                       const char* warning,
+                                       const char* type = nullptr,
+                                       const char* code = nullptr) {
+  v8::HandleScope handle_scope(env->isolate());
+  v8::Context::Scope context_scope(env->context());
+
+  v8::Local<v8::Object> process = env->process_object();
+  v8::Local<v8::Value> emit_warning;
+  if (!process->Get(env->context(), env->emit_warning_string())
+           .ToLocal(&emit_warning)) {
+    return v8::Nothing<bool>();
+  }
+
+  if (!emit_warning->IsFunction())
+    return v8::Just(false);
+
+  int argc = 0;
+  v8::Local<v8::Value> args[3];  // warning, type, code
+
+  if (!v8::String::NewFromUtf8(env->isolate(), warning,
+                               v8::NewStringType::kNormal)
+           .ToLocal(&args[argc++])) {
+    return v8::Nothing<bool>();
+  }
+  if (type != nullptr) {
+    if (!v8::String::NewFromOneByte(env->isolate(),
+                                    reinterpret_cast<const uint8_t*>(type),
+                                    v8::NewStringType::kNormal)
+             .ToLocal(&args[argc++])) {
+      return v8::Nothing<bool>();
+    }
+    if (code != nullptr &&
+        !v8::String::NewFromOneByte(env->isolate(),
+                                    reinterpret_cast<const uint8_t*>(code),
+                                    v8::NewStringType::kNormal)
+             .ToLocal(&args[argc++])) {
+      return v8::Nothing<bool>();
+    }
+  }
+
+  // MakeCallback() unneeded because emitWarning is internal code, it calls
+  // process.emit('warning', ...), but does so on the nextTick.
+  if (emit_warning.As<v8::Function>()
+          ->Call(env->context(), process, argc, args)
+          .IsEmpty()) {
+    return v8::Nothing<bool>();
+  }
+  return v8::Just(true);
+}
+
+}  // namespace atom

--- a/atom/common/deprecate_util.h
+++ b/atom/common/deprecate_util.h
@@ -12,9 +12,9 @@
 namespace atom {
 
 v8::Maybe<bool> EmitDeprecationWarning(node::Environment* env,
-                                       const char* warning,
-                                       const char* type,
-                                       const char* code);
+                                       std::string warning_msg,
+                                       std::string warning_type,
+                                       std::string warning_code);
 
 }  // namespace atom
 

--- a/atom/common/deprecate_util.h
+++ b/atom/common/deprecate_util.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_COMMON_DEPRECATE_UTIL_H_
+#define ATOM_COMMON_DEPRECATE_UTIL_H_
+
+#include <string>
+
+#include "atom/common/node_includes.h"
+
+namespace atom {
+
+v8::Maybe<bool> EmitDeprecationWarning(node::Environment* env,
+                                       const char* warning,
+                                       const char* type,
+                                       const char* code);
+
+}  // namespace atom
+
+#endif  // ATOM_COMMON_DEPRECATE_UTIL_H_

--- a/atom/common/deprecate_util.h
+++ b/atom/common/deprecate_util.h
@@ -11,10 +11,9 @@
 
 namespace atom {
 
-v8::Maybe<bool> EmitDeprecationWarning(node::Environment* env,
-                                       std::string warning_msg,
-                                       std::string warning_type,
-                                       std::string warning_code);
+void EmitDeprecationWarning(node::Environment* env,
+                            const std::string& warning_msg,
+                            const std::string& warning_type);
 
 }  // namespace atom
 

--- a/filenames.gni
+++ b/filenames.gni
@@ -511,6 +511,8 @@ filenames = {
     "atom/common/key_weak_map.h",
     "atom/common/keyboard_util.cc",
     "atom/common/keyboard_util.h",
+    "atom/common/deprecate_util.cc",
+    "atom/common/deprecate_util.h",
     "atom/common/mouse_util.cc",
     "atom/common/mouse_util.h",
     "atom/common/mac/main_application_bundle.h",


### PR DESCRIPTION
#### Description of Change

This PR seeks to ameliorate an issue by which we're currently incapable of logging bespoke deprecation warnings in native-land, which is something that we've hit in the past and worked around by simply not logging and instead just relying on documentation deprecation to get the job done. In service to users, i'd love to ensure that we're logging warnings in all possible places.

I felt it was overkill to expose this to JS, so it's taken form as a utility that you would pass a deprecation warning to, like so:

```
atom::EmitDeprecationWarning(env, "the thing you are using has been deprecated.", "electron");|
```

which would output:
```
(electron) the thing you are using has been deprecated.
```

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
