### PR TITLE
chore: fix duplicate error string

### DIFF
--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -108,8 +108,7 @@ class ScriptExecutionCallback : public blink::WebScriptExecutionCallback {
       } else {
         promise_.RejectWithErrorMessage(
             "Script failed to execute, this normally means an error "
-            "was thrown. Check the renderer console for the error."
-            "was thrown, check the renderer console for the error");
+            "was thrown. Check the renderer console for the error.");
       }
     } else {
       promise_.RejectWithErrorMessage(


### PR DESCRIPTION
#### Description of Change

Fixes an accidentally duplicated string resultant of what i'm fairly certain is a GitHub code review flow issue.

cc @nornagon @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none