### PR TITLE
feat: add creationTime / sandboxed / integrityLevel to app.getAppMetrics()

### DIFF
--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -12,13 +12,12 @@
 #include <vector>
 
 #include "atom/browser/api/event_emitter.h"
+#include "atom/browser/api/process_metric.h"
 #include "atom/browser/atom_browser_client.h"
 #include "atom/browser/browser.h"
 #include "atom/browser/browser_observer.h"
 #include "atom/common/native_mate_converters/callback.h"
 #include "atom/common/promise_util.h"
-#include "base/process/process_iterator.h"
-#include "base/process/process_metrics.h"
 #include "base/task/cancelable_task_tracker.h"
 #include "chrome/browser/icon_manager.h"
 #include "chrome/browser/process_singleton.h"
@@ -48,17 +47,6 @@ namespace atom {
 #if defined(OS_WIN)
 enum class JumpListResult : int;
 #endif
-
-struct ProcessMetric {
-  int type;
-  base::ProcessId pid;
-  std::unique_ptr<base::ProcessMetrics> metrics;
-
-  ProcessMetric(int type,
-                base::ProcessId pid,
-                std::unique_ptr<base::ProcessMetrics> metrics);
-  ~ProcessMetric();
-};
 
 namespace api {
 

--- a/atom/browser/api/process_metric.cc
+++ b/atom/browser/api/process_metric.cc
@@ -1,0 +1,109 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/api/process_metric.h"
+
+#include <memory>
+#include <utility>
+
+#if defined(OS_WIN)
+#include <windows.h>
+#endif
+
+#if defined(OS_MACOSX)
+extern "C" int sandbox_check(pid_t pid, const char* operation, int type, ...);
+#endif
+
+namespace atom {
+
+ProcessMetric::ProcessMetric(int type,
+                             base::ProcessHandle handle,
+                             std::unique_ptr<base::ProcessMetrics> metrics) {
+  this->type = type;
+  this->metrics = std::move(metrics);
+
+#if defined(OS_WIN)
+  HANDLE duplicate_handle = INVALID_HANDLE_VALUE;
+  ::DuplicateHandle(::GetCurrentProcess(), handle, ::GetCurrentProcess(),
+                    &duplicate_handle, 0, false, DUPLICATE_SAME_ACCESS);
+  this->process = base::Process(duplicate_handle);
+#else
+  this->process = base::Process(handle);
+#endif
+}
+
+ProcessMetric::~ProcessMetric() = default;
+
+#if defined(OS_WIN)
+
+ProcessIntegrityLevel ProcessMetric::GetIntegrityLevel() const {
+  HANDLE token = nullptr;
+  if (!::OpenProcessToken(process.Handle(), TOKEN_QUERY, &token)) {
+    return ProcessIntegrityLevel::Unknown;
+  }
+
+  base::win::ScopedHandle token_scoped(token);
+
+  DWORD token_info_length = 0;
+  if (::GetTokenInformation(token, TokenIntegrityLevel, nullptr, 0,
+                            &token_info_length) ||
+      ::GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
+    return ProcessIntegrityLevel::Unknown;
+  }
+
+  auto token_label_bytes = std::make_unique<char[]>(token_info_length);
+  TOKEN_MANDATORY_LABEL* token_label =
+      reinterpret_cast<TOKEN_MANDATORY_LABEL*>(token_label_bytes.get());
+  if (!::GetTokenInformation(token, TokenIntegrityLevel, token_label,
+                             token_info_length, &token_info_length)) {
+    return ProcessIntegrityLevel::Unknown;
+  }
+
+  DWORD integrity_level = *::GetSidSubAuthority(
+      token_label->Label.Sid,
+      static_cast<DWORD>(*::GetSidSubAuthorityCount(token_label->Label.Sid) -
+                         1));
+
+  if (integrity_level >= SECURITY_MANDATORY_UNTRUSTED_RID &&
+      integrity_level < SECURITY_MANDATORY_LOW_RID) {
+    return ProcessIntegrityLevel::Untrusted;
+  }
+
+  if (integrity_level >= SECURITY_MANDATORY_LOW_RID &&
+      integrity_level < SECURITY_MANDATORY_MEDIUM_RID) {
+    return ProcessIntegrityLevel::Low;
+  }
+
+  if (integrity_level >= SECURITY_MANDATORY_MEDIUM_RID &&
+      integrity_level < SECURITY_MANDATORY_HIGH_RID) {
+    return ProcessIntegrityLevel::Medium;
+  }
+
+  if (integrity_level >= SECURITY_MANDATORY_HIGH_RID &&
+      integrity_level < SECURITY_MANDATORY_SYSTEM_RID) {
+    return ProcessIntegrityLevel::High;
+  }
+
+  return ProcessIntegrityLevel::Unknown;
+}
+
+// static
+bool ProcessMetric::IsSandboxed(ProcessIntegrityLevel integrity_level) {
+  return integrity_level > ProcessIntegrityLevel::Unknown &&
+         integrity_level < ProcessIntegrityLevel::Medium;
+}
+
+#elif defined(OS_MACOSX)
+
+bool ProcessMetric::IsSandboxed() const {
+#if defined(MAS_BUILD)
+  return true;
+#else
+  return sandbox_check(process.Pid(), nullptr, 0) != 0;
+#endif
+}
+
+#endif  // defined(OS_MACOSX)
+
+}  // namespace atom

--- a/atom/browser/api/process_metric.h
+++ b/atom/browser/api/process_metric.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_BROWSER_API_PROCESS_METRIC_H_
+#define ATOM_BROWSER_API_PROCESS_METRIC_H_
+
+#include <memory>
+
+#include "base/process/process.h"
+#include "base/process/process_handle.h"
+#include "base/process/process_metrics.h"
+
+namespace atom {
+
+#if defined(OS_WIN)
+enum class ProcessIntegrityLevel {
+  Unknown,
+  Untrusted,
+  Low,
+  Medium,
+  High,
+};
+#endif
+
+struct ProcessMetric {
+  int type;
+  base::Process process;
+  std::unique_ptr<base::ProcessMetrics> metrics;
+
+  ProcessMetric(int type,
+                base::ProcessHandle handle,
+                std::unique_ptr<base::ProcessMetrics> metrics);
+  ~ProcessMetric();
+
+#if defined(OS_WIN)
+  ProcessIntegrityLevel GetIntegrityLevel() const;
+  static bool IsSandboxed(ProcessIntegrityLevel integrity_level);
+#elif defined(OS_MACOSX)
+  bool IsSandboxed() const;
+#endif
+};
+
+}  // namespace atom
+
+#endif  // ATOM_BROWSER_API_PROCESS_METRIC_H_

--- a/docs/api/structures/process-metric.md
+++ b/docs/api/structures/process-metric.md
@@ -3,3 +3,12 @@
 * `pid` Integer - Process id of the process.
 * `type` String - Process type (Browser or Tab or GPU etc).
 * `cpu` [CPUUsage](cpu-usage.md) - CPU usage of the process.
+* `creationTime` Number - Creation time for this process. Since the `pid` can be reused after a process dies,
+    it is useful to use both the `pid` and the `creationTime` to uniquely identify a process.
+* `sandboxed` Boolean (optional) _macOS_ _Windows_ - Whether the process is sandboxed on OS level.
+* `integrityLevel` String (optional) _Windows_ - One of the following values:
+  * `untrusted`
+  * `low`
+  * `medium`
+  * `high`
+  * `unknown`

--- a/docs/api/structures/process-metric.md
+++ b/docs/api/structures/process-metric.md
@@ -3,7 +3,9 @@
 * `pid` Integer - Process id of the process.
 * `type` String - Process type (Browser or Tab or GPU etc).
 * `cpu` [CPUUsage](cpu-usage.md) - CPU usage of the process.
-* `creationTime` Number - Creation time for this process. Since the `pid` can be reused after a process dies,
+* `creationTime` Number - Creation time for this process.
+    The time is represented as number of milliseconds since epoch.
+    Since the `pid` can be reused after a process dies,
     it is useful to use both the `pid` and the `creationTime` to uniquely identify a process.
 * `sandboxed` Boolean (optional) _macOS_ _Windows_ - Whether the process is sandboxed on OS level.
 * `integrityLevel` String (optional) _Windows_ - One of the following values:

--- a/filenames.gni
+++ b/filenames.gni
@@ -122,6 +122,8 @@ filenames = {
     "atom/browser/api/gpu_info_enumerator.h",
     "atom/browser/api/gpuinfo_manager.cc",
     "atom/browser/api/gpuinfo_manager.h",
+    "atom/browser/api/process_metric.cc",
+    "atom/browser/api/process_metric.h",
     "atom/browser/api/save_page_handler.cc",
     "atom/browser/api/save_page_handler.h",
     "atom/browser/auto_updater.cc",

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -931,13 +931,22 @@ describe('app module', () => {
       expect(appMetrics).to.be.an('array').and.have.lengthOf.at.least(1, 'App memory info object is not > 0')
 
       const types = []
-      for (const { pid, type, cpu } of appMetrics) {
-        expect(pid).to.be.above(0, 'pid is not > 0')
-        expect(type).to.be.a('string').that.does.not.equal('')
+      for (const entry of appMetrics) {
+        expect(entry.pid).to.be.above(0, 'pid is not > 0')
+        expect(entry.type).to.be.a('string').that.does.not.equal('')
+        expect(entry.creationTime).to.be.a('number').that.is.greaterThan(0)
 
-        types.push(type)
-        expect(cpu).to.have.ownProperty('percentCPUUsage').that.is.a('number')
-        expect(cpu).to.have.ownProperty('idleWakeupsPerSecond').that.is.a('number')
+        types.push(entry.type)
+        expect(entry.cpu).to.have.ownProperty('percentCPUUsage').that.is.a('number')
+        expect(entry.cpu).to.have.ownProperty('idleWakeupsPerSecond').that.is.a('number')
+
+        if (process.platform !== 'linux') {
+          expect(entry.sandboxed).to.be.a('boolean')
+        }
+
+        if (process.platform === 'win32') {
+          expect(entry.integrityLevel).to.be.a('string')
+        }
       }
 
       if (process.platform === 'darwin') {


### PR DESCRIPTION
#### Description of Change
This is useful for checking which processes are sandboxed on OS level.

Regarding `creationTime`, since the `pid` can be reused after a process dies, it is useful to use both the `pid` and the `creationTime` to uniquely identify a process.

Required for tests in #18650

/cc @MarshallOfSound, @deepak1556

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `creationTime` / `sandboxed` / `integrityLevel` to `app.getAppMetrics()` output.