### PR TITLE
fix: correct isDownloadable docs to match impl

### DIFF
--- a/atom/browser/api/atom_api_in_app_purchase.cc
+++ b/atom/browser/api/atom_api_in_app_purchase.cc
@@ -61,7 +61,7 @@ struct Converter<in_app_purchase::Product> {
     dict.Set("formattedPrice", val.formattedPrice);
 
     // Downloadable Content Information
-    dict.Set("isDownloadable", val.downloadable);
+    dict.Set("isDownloadable", val.isDownloadable);
 
     return dict.GetHandle();
   }

--- a/atom/browser/mac/in_app_purchase_product.h
+++ b/atom/browser/mac/in_app_purchase_product.h
@@ -29,7 +29,7 @@ struct Product {
   std::string formattedPrice;
 
   // Downloadable Content Information
-  bool downloadable = false;
+  bool isDownloadable = false;
 
   Product(const Product&);
   Product();

--- a/atom/browser/mac/in_app_purchase_product.mm
+++ b/atom/browser/mac/in_app_purchase_product.mm
@@ -150,9 +150,7 @@
   }
 
   // Downloadable Content Information
-  if (product.downloadable == true) {
-    productStruct.downloadable = true;
-  }
+  productStruct.isDownloadable = [product downloadable];
 
   return productStruct;
 }

--- a/docs/api/structures/product.md
+++ b/docs/api/structures/product.md
@@ -7,4 +7,4 @@
 * `contentLengths` Number[] - The total size of the content, in bytes.
 * `price` Number - The cost of the product in the local currency.
 * `formattedPrice` String - The locale formatted price of the product.
-* `downloadable` Boolean - A Boolean value that indicates whether the App Store has downloadable content for this product.
+* `isDownloadable` Boolean - A Boolean value that indicates whether the App Store has downloadable content for this product. `true` if at least one file has been associated with the product.


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/18708.

Corrects product documentation  to match implementation, since the actual instance property for SKProducts is [`isDownloadable`](https://developer.apple.com/documentation/storekit/skproduct/1506161-isdownloadable?language=objc). Also corrects product object nomenclature for consistency and improves the value information a tad.

cc @MarshallOfSound @nornagon @miniak 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
