### PR TITLE
fix: properly pass openExternal activate option (6-0-x)

### DIFF
--- a/atom/common/platform_util_mac.mm
+++ b/atom/common/platform_util_mac.mm
@@ -108,14 +108,15 @@ void OpenExternal(const GURL& url,
     return;
   }
 
+  bool activate = options.activate;
   __block OpenExternalCallback c = std::move(callback);
-  dispatch_async(
-      dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        __block std::string error = OpenURL(ns_url, options.activate);
-        dispatch_async(dispatch_get_main_queue(), ^{
-          std::move(c).Run(error);
-        });
-      });
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),
+                 ^{
+                   __block std::string error = OpenURL(ns_url, activate);
+                   dispatch_async(dispatch_get_main_queue(), ^{
+                     std::move(c).Run(error);
+                   });
+                 });
 }
 
 bool MoveItemToTrash(const base::FilePath& full_path) {


### PR DESCRIPTION
backport of #18657 to 6-0-x

#### Description of Change
A reference to an `OpenExternalOptions` structure was being captured by an Objective-C block that outlived the object that was being referenced (added in https://github.com/electron/electron/pull/15065). This caused the default browser window to not be activated when passing a URL on macOS when the default browser is Safari or Firefox. Fixes https://github.com/electron/electron/issues/18293.

cc @codebytere 

#### Release Notes
Notes: Fixed issue where `shell.openExternal` would not activate opened window on macOS.
