### PR TITLE
fix: modify new promise object for dialog methods to match old callback api

### DIFF
--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -229,7 +229,7 @@ module.exports = {
   }
 }
 
-module.exports.showMessageBox = deprecate.promisify(module.exports.showMessageBox)
-module.exports.showOpenDialog = deprecate.promisify(module.exports.showOpenDialog)
-module.exports.showSaveDialog = deprecate.promisify(module.exports.showSaveDialog)
+module.exports.showMessageBox = deprecate.promisifyMultiArg(module.exports.showMessageBox, ({ response, checkboxChecked }) => [response, checkboxChecked])
+module.exports.showOpenDialog = deprecate.promisifyMultiArg(module.exports.showOpenDialog, ({ filePaths, bookmarks }) => [filePaths, bookmarks])
+module.exports.showSaveDialog = deprecate.promisifyMultiArg(module.exports.showSaveDialog, ({ filePath, bookmarks }) => [filePath, bookmarks])
 module.exports.showCertificateTrustDialog = deprecate.promisify(module.exports.showCertificateTrustDialog)

--- a/lib/common/api/deprecate.ts
+++ b/lib/common/api/deprecate.ts
@@ -122,9 +122,8 @@ const deprecate: ElectronInternal.DeprecationUtil = {
     } as T
   },
 
-  // convertPromiseValue: Temporarily disabled until it's used
   // deprecate a callback-based function in favor of one returning a Promise
-  promisifyMultiArg: <T extends (...args: any[]) => any>(fn: T /* convertPromiseValue: (v: any) => any */): T => {
+  promisifyMultiArg: <T extends (...args: any[]) => any>(fn: T, convertPromiseValue?: (v: any) => any): T => {
     const fnName = fn.name || 'function'
     const oldName = `${fnName} with callbacks`
     const newName = `${fnName} with Promises`
@@ -140,6 +139,7 @@ const deprecate: ElectronInternal.DeprecationUtil = {
       if (process.enablePromiseAPIs) warn()
       return promise
         .then((res: any) => {
+          if (convertPromiseValue) { res = convertPromiseValue(res) }
           process.nextTick(() => {
             // eslint-disable-next-line standard/no-callback-literal
             cb!.length > 2 ? cb!(null, ...res) : cb!(...res)

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -83,8 +83,7 @@ declare namespace ElectronInternal {
 
     promisify<T extends (...args: any[]) => any>(fn: T): T;
 
-    // convertPromiseValue: Temporarily disabled until it's used
-    promisifyMultiArg<T extends (...args: any[]) => any>(fn: T, /*convertPromiseValue: (v: any) => any*/): T;
+    promisifyMultiArg<T extends (...args: any[]) => any>(fn: T, convertPromiseValue: (v: any) => any): T;
   }
 
   // Internal IPC has _replyInternal and NO reply method


### PR DESCRIPTION
This is directly targeting Electron 6 as the API in question has been removed on master.  This PR revives `convertPromiseValue` in the deprecate module to convert the new promise object value to the old multi-arg syntax.

i.e. `{ a, b}` --> `[a, b]`

Notes: Fixed accidental breaking API change in the deprecated `dialog.*` methods