### PR TITLE
feat: migrate protocol module to NetworkService (Part 12)

### DIFF
--- a/atom/browser/net/atom_url_loader_factory.cc
+++ b/atom/browser/net/atom_url_loader_factory.cc
@@ -372,6 +372,10 @@ void AtomURLLoaderFactory::StartLoadingHttp(
   if (!dict.Get("method", &request->method))
     request->method = original_request.method;
 
+  base::DictionaryValue upload_data;
+  if (request->method != "GET" && request->method != "HEAD")
+    dict.Get("uploadData", &upload_data);
+
   scoped_refptr<AtomBrowserContext> browser_context =
       AtomBrowserContext::From("", false);
   v8::Local<v8::Value> value;
@@ -393,7 +397,8 @@ void AtomURLLoaderFactory::StartLoadingHttp(
   new URLPipeLoader(
       url_loader_factory, std::move(request), std::move(loader),
       std::move(client),
-      static_cast<net::NetworkTrafficAnnotationTag>(traffic_annotation));
+      static_cast<net::NetworkTrafficAnnotationTag>(traffic_annotation),
+      std::move(upload_data));
 }
 
 // static

--- a/atom/browser/net/url_pipe_loader.h
+++ b/atom/browser/net/url_pipe_loader.h
@@ -35,14 +35,16 @@ class URLPipeLoader : public network::mojom::URLLoader,
                 std::unique_ptr<network::ResourceRequest> request,
                 network::mojom::URLLoaderRequest loader,
                 network::mojom::URLLoaderClientPtr client,
-                const net::NetworkTrafficAnnotationTag& annotation);
+                const net::NetworkTrafficAnnotationTag& annotation,
+                base::DictionaryValue upload_data);
 
  private:
   ~URLPipeLoader() override;
 
   void Start(scoped_refptr<network::SharedURLLoaderFactory> factory,
              std::unique_ptr<network::ResourceRequest> request,
-             const net::NetworkTrafficAnnotationTag& annotation);
+             const net::NetworkTrafficAnnotationTag& annotation,
+             base::DictionaryValue upload_data);
   void NotifyComplete(int result);
   void OnResponseStarted(const GURL& final_url,
                          const network::ResourceResponseHead& response_head);

--- a/atom/common/native_mate_converters/net_converter.cc
+++ b/atom/common/native_mate_converters/net_converter.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "atom/common/native_mate_converters/gurl_converter.h"
+#include "atom/common/native_mate_converters/string16_converter.h"
 #include "atom/common/native_mate_converters/value_converter.h"
 #include "atom/common/node_includes.h"
 #include "base/strings/string_number_conversions.h"


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/15791.

This PR implements `uploadData` related APIs in protocol module with NetworkService.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes