### PR TITLE
spec: move window.open postMessage test to main runner to fix flake

### DIFF
--- a/spec-main/window-helpers.ts
+++ b/spec-main/window-helpers.ts
@@ -39,3 +39,9 @@ export const closeWindow = async (
     }
   }
 }
+
+export async function closeAllWindows() {
+  for (const w of BrowserWindow.getAllWindows()) {
+    await closeWindow(w, {assertNotWindows: false})
+  }
+}

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -721,27 +721,6 @@ describe('chromium feature', () => {
   })
 
   describe('window.postMessage', () => {
-    it('sets the source and origin correctly', (done) => {
-      let b = null
-      listener = (event) => {
-        window.removeEventListener('message', listener)
-        b.close()
-        const message = JSON.parse(event.data)
-        expect(message.data).to.equal('testing')
-        expect(message.origin).to.equal('file://')
-        expect(message.sourceEqualsOpener).to.be.true()
-        expect(event.origin).to.equal('file://')
-        done()
-      }
-      window.addEventListener('message', listener)
-      app.once('browser-window-created', (event, { webContents }) => {
-        webContents.once('did-finish-load', () => {
-          b.postMessage('testing', '*')
-        })
-      })
-      b = window.open(`file://${fixtures}/pages/window-open-postMessage.html`, '', 'show=no')
-    })
-
     it('throws an exception when the targetOrigin cannot be converted to a string', () => {
       const b = window.open('')
       expect(() => {

--- a/spec/fixtures/pages/window-open-postMessage-driver.html
+++ b/spec/fixtures/pages/window-open-postMessage-driver.html
@@ -1,0 +1,10 @@
+<script>
+  const child = window.open(`./window-open-postMessage.html`, '', 'show=no')
+  window.onmessage = (e) => {
+    if (e.data === 'ready') {
+      child.postMessage('testing', '*')
+    } else {
+      require('electron').ipcRenderer.send('complete', {eventOrigin: e.origin, ...JSON.parse(e.data)})
+    }
+  }
+</script>

--- a/spec/fixtures/pages/window-open-postMessage.html
+++ b/spec/fixtures/pages/window-open-postMessage.html
@@ -8,6 +8,7 @@
       sourceEqualsOpener: e.source === window.opener
     }), '*');
   });
+  window.opener.postMessage("ready", "*")
 </script>
 </body>
 </html>


### PR DESCRIPTION
#### Description of Change
There was a race condition where the webContents created by `window.open` and captured by the `app.once('browser-window-created')` event could be loaded before the `did-finish-loading` listener was attached.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none