### PR TITLE
fix: HTML fullscreen request for sub frames

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -824,6 +824,10 @@ void WebContents::OnInterfaceRequestFromFrame(
   registry_.TryBindInterface(interface_name, interface_pipe, render_frame_host);
 }
 
+void WebContents::DidAcquireFullscreen(content::RenderFrameHost* rfh) {
+  set_fullscreen_frame(rfh);
+}
+
 void WebContents::DocumentLoadedInFrame(
     content::RenderFrameHost* render_frame_host) {
   if (!render_frame_host->GetParent())

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -457,6 +457,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
       content::RenderFrameHost* render_frame_host,
       const std::string& interface_name,
       mojo::ScopedMessagePipeHandle* interface_pipe) override;
+  void DidAcquireFullscreen(content::RenderFrameHost* rfh) override;
 
   // InspectableWebContentsDelegate:
   void DevToolsReloadPage() override;

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -328,9 +328,12 @@ void CommonWebContentsDelegate::EnterFullscreenModeForTab(
     const blink::WebFullscreenOptions& options) {
   if (!owner_window_)
     return;
+  if (IsFullscreenForTabOrPending(source)) {
+    DCHECK_EQ(fullscreen_frame_, source->GetFocusedFrame());
+    return;
+  }
   SetHtmlApiFullscreen(true);
   owner_window_->NotifyWindowEnterHtmlFullScreen();
-  source->GetRenderViewHost()->GetWidget()->SynchronizeVisualProperties();
 }
 
 void CommonWebContentsDelegate::ExitFullscreenModeForTab(
@@ -339,7 +342,6 @@ void CommonWebContentsDelegate::ExitFullscreenModeForTab(
     return;
   SetHtmlApiFullscreen(false);
   owner_window_->NotifyWindowLeaveHtmlFullScreen();
-  source->GetRenderViewHost()->GetWidget()->SynchronizeVisualProperties();
 }
 
 bool CommonWebContentsDelegate::IsFullscreenForTabOrPending(

--- a/atom/browser/common_web_contents_delegate.h
+++ b/atom/browser/common_web_contents_delegate.h
@@ -68,6 +68,10 @@ class CommonWebContentsDelegate : public content::WebContentsDelegate,
 
   bool is_html_fullscreen() const { return html_fullscreen_; }
 
+  void set_fullscreen_frame(content::RenderFrameHost* rfh) {
+    fullscreen_frame_ = rfh;
+  }
+
  protected:
 #if BUILDFLAG(ENABLE_OSR)
   virtual OffScreenWebContentsView* GetOffScreenWebContentsView() const;
@@ -202,6 +206,9 @@ class CommonWebContentsDelegate : public content::WebContentsDelegate,
   DevToolsIndexingJobsMap devtools_indexing_jobs_;
 
   scoped_refptr<base::SequencedTaskRunner> file_task_runner_;
+
+  // Stores the frame thats currently in fullscreen, nullptr if there is none.
+  content::RenderFrameHost* fullscreen_frame_ = nullptr;
 
   base::WeakPtrFactory<CommonWebContentsDelegate> weak_factory_;
 


### PR DESCRIPTION
#### Description of Change

Don't re-enter fullscreen if there is a pending operation, for subframe fullscreen request `EnterFullScreenModeForTab` will be called for both the frame in question as well as the outer webContents hosting it.

Fixes #18188 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix exiting html fullscreen mode for embedded contents
