### PR TITLE
docs: reorganize application distribution links in table of contents

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -66,7 +66,7 @@ an issue:
 * Packaging
   * [Code Signing](tutorial/code-signing.md)
 * [Distribution](tutorial/application-distribution.md)
-  * [Support](tutorial/support.md)
+  * [Supported Platforms](tutorial/support.md#supported-platforms)
   * [Mac App Store](tutorial/mac-app-store-submission-guide.md)
   * [Windows Store](tutorial/windows-store-guide.md)
   * [Snapcraft](tutorial/snapcraft.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,10 +63,9 @@ an issue:
   * [Testing on Headless CI Systems (Travis, Jenkins)](tutorial/testing-on-headless-ci.md)
   * [DevTools Extension](tutorial/devtools-extension.md)
   * [Automated Testing with a Custom Driver](tutorial/automated-testing-with-a-custom-driver.md)
-* Packaging
-  * [Code Signing](tutorial/code-signing.md)
 * [Distribution](tutorial/application-distribution.md)
   * [Supported Platforms](tutorial/support.md#supported-platforms)
+  * [Code Signing](tutorial/code-signing.md)
   * [Mac App Store](tutorial/mac-app-store-submission-guide.md)
   * [Windows Store](tutorial/windows-store-guide.md)
   * [Snapcraft](tutorial/snapcraft.md)


### PR DESCRIPTION
#### Description of Change

* Fix the title/link for "supported platforms", which got lost in a previous TOC reorg.
* Move "Code signing" under "Application Distribution", because it's unclear what the difference between "Packaging" and "Distribution" is, and also this was the only item under "Packaging".

CC: @electron/wg-docs-tools 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
