### PR TITLE
fix: allow loading preload scripts from node_modules used by the app

### DIFF
--- a/default_app/main.ts
+++ b/default_app/main.ts
@@ -85,6 +85,7 @@ function loadApplicationPackage (packagePath: string) {
     // Override app name and version.
     packagePath = path.resolve(packagePath)
     const packageJsonPath = path.join(packagePath, 'package.json')
+    let appPath
     if (fs.existsSync(packageJsonPath)) {
       let packageJson
       try {
@@ -102,11 +103,12 @@ function loadApplicationPackage (packagePath: string) {
       } else if (packageJson.name) {
         app.name = packageJson.name
       }
-      app._setDefaultAppPaths(packagePath)
+      appPath = packagePath
     }
 
     try {
-      Module._resolveFilename(packagePath, module, true)
+      const filePath = Module._resolveFilename(packagePath, module, true)
+      app._setDefaultAppPaths(appPath || path.dirname(filePath))
     } catch (e) {
       showErrorMessage(`Unable to find Electron app at ${packagePath}\n\n${e.message}`)
       return

--- a/lib/browser/api/app.ts
+++ b/lib/browser/api/app.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs'
 import * as path from 'path'
 
 import { deprecate, Menu } from 'electron'
@@ -48,7 +49,7 @@ app._setDefaultAppPaths = (packagePath) => {
   // Set the user path according to application's name.
   app.setPath('userData', path.join(app.getPath('appData'), app.name!))
   app.setPath('userCache', path.join(app.getPath('cache'), app.name!))
-  app.setAppPath(packagePath)
+  app.setAppPath(fs.realpathSync(packagePath))
 
   // Add support for --user-data-dir=
   if (app.commandLine.hasSwitch('user-data-dir')) {

--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -146,7 +146,7 @@ if (packageJson.v8Flags != null) {
   require('v8').setFlagsFromString(packageJson.v8Flags)
 }
 
-app._setDefaultAppPaths(packagePath)
+app._setDefaultAppPaths(packagePath!)
 
 // Load the chrome devtools support.
 require('@electron/internal/browser/devtools')

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -20,7 +20,7 @@ const guestViewManager = require('@electron/internal/browser/guest-view-manager'
 const bufferUtils = require('@electron/internal/common/buffer-utils')
 const errorUtils = require('@electron/internal/common/error-utils')
 const clipboardUtils = require('@electron/internal/common/clipboard-utils')
-const { isParentDir } = require('@electron/internal/common/path-utils')
+const { isPreloadAllowed } = require('@electron/internal/common/path-utils')
 
 const hasProp = {}.hasOwnProperty
 
@@ -517,20 +517,12 @@ if (features.isDesktopCapturerEnabled()) {
   })
 }
 
-let absoluteAppPath
-const getAppPath = async function () {
-  if (absoluteAppPath === undefined) {
-    absoluteAppPath = await fs.promises.realpath(electron.app.getAppPath())
-  }
-  return absoluteAppPath
-}
-
 const getPreloadScript = async function (preloadPath) {
   let preloadSrc = null
   let preloadError = null
   if (preloadPath) {
     try {
-      if (!isParentDir(await getAppPath(), await fs.promises.realpath(preloadPath))) {
+      if (!isPreloadAllowed(electron.app.getAppPath(), await fs.promises.realpath(preloadPath))) {
         throw new Error('Preload scripts outside of app path are not allowed')
       }
       preloadSrc = (await fs.promises.readFile(preloadPath)).toString()

--- a/lib/common/path-utils.ts
+++ b/lib/common/path-utils.ts
@@ -1,6 +1,27 @@
 import * as path from 'path'
+const Module = require('module')
 
-export const isParentDir = function (parent: string, dir: string) {
+const isParentDir = function (parent: string, dir: string) {
   const relative = path.relative(parent, dir)
   return !!relative && !relative.startsWith('..') && !path.isAbsolute(relative)
+}
+
+const isPreloadAllowedImpl = function (appPath: string, preloadPath: string) {
+  if (isParentDir(appPath, preloadPath)) {
+    return true
+  }
+
+  // allow node_modules to use their preload scripts
+  const nodeModulePaths = Module._nodeModulePaths(appPath) as string[]
+  return nodeModulePaths.some(nodeModulePath => isParentDir(nodeModulePath, preloadPath))
+}
+
+const cache = new Map<string, boolean>()
+
+export const isPreloadAllowed = function (appPath: string, preloadPath: string) {
+  if (!cache.has(preloadPath)) {
+    cache.set(preloadPath, isPreloadAllowedImpl(appPath, preloadPath))
+  }
+
+  return cache.get(preloadPath)
 }

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from 'events'
-import * as fs from 'fs'
 import * as path from 'path'
 
 const Module = require('module')
@@ -189,20 +188,12 @@ if (nodeIntegration) {
 }
 
 const errorUtils = require('@electron/internal/common/error-utils')
-const { isParentDir } = require('@electron/internal/common/path-utils')
-
-let absoluteAppPath: string
-const getAppPath = function () {
-  if (absoluteAppPath === undefined) {
-    absoluteAppPath = fs.realpathSync(appPath!)
-  }
-  return absoluteAppPath
-}
+const { isPreloadAllowed } = require('@electron/internal/common/path-utils')
 
 // Load the preload scripts.
 for (const preloadScript of preloadScripts) {
   try {
-    if (!isParentDir(getAppPath(), fs.realpathSync(preloadScript))) {
+    if (!isPreloadAllowed(appPath, Module._resolveFilename(preloadScript, null, true))) {
       throw new Error('Preload scripts outside of app path are not allowed')
     }
     Module._load(preloadScript)

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -645,6 +645,28 @@ describe('app module', () => {
     })
   })
 
+  describe('getAppPath', () => {
+    it('works for directories with package.json', async () => {
+      const { appPath } = await runTestApp('app-path')
+      expect(appPath).to.equal(path.resolve(fixturesPath, 'api/app-path'))
+    })
+
+    it('works for directories with index.js', async () => {
+      const { appPath } = await runTestApp('app-path/lib')
+      expect(appPath).to.equal(path.resolve(fixturesPath, 'api/app-path/lib'))
+    })
+
+    it('works for files without extension', async () => {
+      const { appPath } = await runTestApp('app-path/lib/index')
+      expect(appPath).to.equal(path.resolve(fixturesPath, 'api/app-path/lib'))
+    })
+
+    it('works for files', async () => {
+      const { appPath } = await runTestApp('app-path/lib/index.js')
+      expect(appPath).to.equal(path.resolve(fixturesPath, 'api/app-path/lib'))
+    })
+  })
+
   describe('getPath(name)', () => {
     it('returns paths that exist', () => {
       const paths = [

--- a/spec/fixtures/api/app-path/lib/index.js
+++ b/spec/fixtures/api/app-path/lib/index.js
@@ -1,0 +1,10 @@
+const { app } = require('electron')
+
+const payload = {
+  appPath: app.getAppPath()
+}
+
+process.stdout.write(JSON.stringify(payload))
+process.stdout.end()
+
+process.exit()

--- a/spec/fixtures/api/app-path/package.json
+++ b/spec/fixtures/api/app-path/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "app-path",
+  "main": "lib/index.js"
+}

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -13,10 +13,10 @@ declare namespace Electron {
   }
 
   interface App {
-    _setDefaultAppPaths(packagePath: string | null): void;
+    _setDefaultAppPaths(packagePath: string): void;
     setVersion(version: string): void;
     setDesktopName(name: string): void;
-    setAppPath(path: string | null): void;
+    setAppPath(path: string): void;
   }
 
   interface SerializedError {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
