### PR TITLE
docs: fixed incorrect Notification example

### DIFF
--- a/docs/tutorial/notifications.md
+++ b/docs/tutorial/notifications.md
@@ -10,7 +10,8 @@ you want to show Notifications in the main process please check out the
 [Notification](../api/notification.md) module.
 
 ```javascript
-let myNotification = new Notification('Title', {
+let myNotification = new Notification({
+  title: 'Title',
   body: 'Lorem Ipsum Dolor Sit Amet'
 })
 


### PR DESCRIPTION
Fixed incorrect Notification example in docs.

notes: none