### PR TITLE
docs: remove out of date <webview> docs warning

### DIFF
--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -1,13 +1,5 @@
 # `<webview>` Tag
 
-## Warning
-
-Electron's `webview` tag is based on [Chromium's `webview`][chrome-webview], which
-is undergoing dramatic architectural changes. This impacts the stability of `webviews`,
-including rendering, navigation, and event routing. We currently recommend to not
-use the `webview` tag and to consider alternatives, like `iframe`, Electron's `BrowserView`,
-or an architecture that avoids embedded content altogether.
-
 ## Enabling
 
 By default the `webview` tag is disabled in Electron >= 5.  You need to enable the tag by


### PR DESCRIPTION
#### Description of Change
Remove the documentation warnings about the stability and longevity of the `<webview>` tag feature.

Originally added via this PR: https://github.com/electron/electron/pull/13835

My impression reading #13869 and the [Out of Process Iframe Docs](https://www.chromium.org/developers/design-documents/oop-iframes) is that the `<webview>` tag became much more stable and better aligned with the long term direction of Chrome by moving it to OOPIF. Even the `<webview>` docs themselves seem to conflict on the nature of its implementation / stability:

> Electron's webview tag is based on Chromium's webview

vs
> Under the hood webview is implemented with Out-of-Process iframes (OOPIFs)

Based on that understanding, it would make sense to remove the warning from the docs.

**Side question:** Was the [default value change in v5](https://github.com/electron/electron/blob/master/docs/api/webview-tag.md#enabling) in an effort to slowly phase out `<webview>` because of its perceived instability?

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
