### PR TITLE
fix: throw error on invalid URLs when setting cookie

### DIFF
--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -261,6 +261,7 @@ void SetCookieOnIO(scoped_refptr<net::URLRequestContextGetter> getter,
                            : base::Time::FromDoubleT(last_access_date);
   }
 
+  auto completion_callback = base::BindOnce(OnSetCookie, std::move(promise));
   GURL url(url_string);
   if (url.is_empty()) {
     std::move(completion_callback).Run(false);
@@ -277,7 +278,6 @@ void SetCookieOnIO(scoped_refptr<net::URLRequestContextGetter> getter,
           url, name, value, domain, path, creation_time, expiration_time,
           last_access_time, secure, http_only,
           net::CookieSameSite::DEFAULT_MODE, net::COOKIE_PRIORITY_DEFAULT));
-  auto completion_callback = base::BindOnce(OnSetCookie, std::move(promise));
   if (!canonical_cookie || !canonical_cookie->IsCanonical()) {
     std::move(completion_callback).Run(false);
     return;

--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -263,7 +263,7 @@ void SetCookieOnIO(scoped_refptr<net::URLRequestContextGetter> getter,
 
   auto completion_callback = base::BindOnce(OnSetCookie, std::move(promise));
   GURL url(url_string);
-  if (url.is_empty()) {
+  if (!url.is_valid()) {
     std::move(completion_callback).Run(false);
     return;
   }

--- a/docs/api/cookies.md
+++ b/docs/api/cookies.md
@@ -104,7 +104,7 @@ with `callback(error, cookies)` on complete.
 #### `cookies.set(details)`
 
 * `details` Object
-  * `url` String - The url to associate the cookie with. An error is thrown if the url is invalid.
+  * `url` String - The url to associate the cookie with. The promise will be rejected if the url is invalid.
   * `name` String (optional) - The name of the cookie. Empty by default if omitted.
   * `value` String (optional) - The value of the cookie. Empty by default if omitted.
   * `domain` String (optional) - The domain of the cookie; this will be normalized with a preceding dot so that it's also valid for subdomains. Empty by default if omitted.

--- a/docs/api/cookies.md
+++ b/docs/api/cookies.md
@@ -104,7 +104,7 @@ with `callback(error, cookies)` on complete.
 #### `cookies.set(details)`
 
 * `details` Object
-  * `url` String - The url to associate the cookie with.
+  * `url` String - The url to associate the cookie with. An error is thrown if the url is invalid.
   * `name` String (optional) - The name of the cookie. Empty by default if omitted.
   * `value` String (optional) - The value of the cookie. Empty by default if omitted.
   * `domain` String (optional) - The domain of the cookie; this will be normalized with a preceding dot so that it's also valid for subdomains. Empty by default if omitted.

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -145,6 +145,20 @@ describe('session module', () => {
       expect(error).to.have.property('message').which.equals('Setting cookie failed')
     })
 
+    it('yields an error when setting a cookie with an invalid URL', async () => {
+      let error
+      try {
+        const { cookies } = session.defaultSession
+        const name = '1'
+        const value = '1'
+        await cookies.set({ url: 'asdf', name, value })
+      } catch (e) {
+        error = e
+      }
+      expect(error).is.an('Error')
+      expect(error).to.have.property('message').which.equals('Setting cookie failed')
+    })
+
     it('should overwrite previous cookies', async () => {
       let error
       try {


### PR DESCRIPTION
#### Description of Change

With this PR, invalid inputs to the `url` parameter will throw an error when using `cookie.set()`. This is done by checking if the URL is parseable using `GURL` rather than checking if the URL string being passed in is empty.

Previously, invalid URLs would be able to be added as a cookie, but you would not be able to filter for them or remove them.

See Electron Fiddle gist: https://gist.github.com/d8ae35040d44d426cb40d97d5d77a47e

_N.B. This behavior was fixed in Electron 6, so we based this PR a lot on the changes in the cookies API from 5.0.3 to 6.0.0-beta._

This issue was discovered when playing around with the example from https://github.com/electron/electron/issues/18220.

cc @DeerMichel @codebytere @ckerr 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes(https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: Added check for invalid URLs upon setting cookies
