### PR TITLE
feat: add contents.getOSProcessIdForFrame()

### DIFF
--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -136,6 +136,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void SetBackgroundThrottling(bool allowed);
   int GetProcessID() const;
   base::ProcessId GetOSProcessID() const;
+  base::ProcessId GetOSProcessIdForFrame(int frame_id) const;
   Type GetType() const;
   bool Equal(const WebContents* web_contents) const;
   void LoadURL(const GURL& url, const mate::Dictionary& options);
@@ -473,6 +474,8 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
  private:
   AtomBrowserContext* GetBrowserContext() const;
+
+  content::RenderFrameHost* GetFrameByRoutingID(int frame_id) const;
 
   // Binds the given request for the ElectronBrowser API. When the
   // RenderFrameHost is destroyed, all related bindings will be removed.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1657,7 +1657,14 @@ more details.
 #### `contents.getOSProcessId()`
 
 Returns `Integer` - The operating system `pid` of the associated renderer
-process.
+process hosting the main frame.
+
+#### `contents.getOSProcessIdForFrame(frameId)`
+
+* `frameId` Integer - The ID of the renderer frame.
+
+Returns `Integer` - The operating system `pid` of the associated renderer
+process hosting `frameId`.
 
 #### `contents.getProcessId()`
 

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -559,7 +559,7 @@ describe('webContents module', () => {
   })
 
   describe('getOSProcessId()', () => {
-    it('returns a valid procress id', async () => {
+    it('returns a valid process id', async () => {
       expect(w.webContents.getOSProcessId()).to.equal(0)
 
       await w.loadURL('about:blank')
@@ -588,7 +588,7 @@ describe('webContents module', () => {
 
     const preload = path.join(fixtures, 'module', 'preload-pid.js')
 
-    it('returns a valid procress id', async () => {
+    it('returns a valid process id', async () => {
       w.destroy()
       w = new BrowserWindow({
         show: false,

--- a/spec/fixtures/module/preload-pid.js
+++ b/spec/fixtures/module/preload-pid.js
@@ -1,0 +1,7 @@
+const { ipcRenderer } = require('electron')
+
+if (process.isMainFrame) {
+  ipcRenderer.send('pid-main', process.pid)
+} else {
+  ipcRenderer.send('pid-frame', process.pid)
+}


### PR DESCRIPTION
#### Description of Change
Added `webContents.getOSProcessIdForFrame()`. This allows getting the pid of renderers hosting cross-origin frames.

Required for tests in #18650

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `webContents.getOSProcessIdForFrame()`. This allows getting the pid of renderers hosting cross-origin frames.