### PR TITLE
fix: use is_valid for cookie url validation

### DIFF
--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -258,7 +258,7 @@ v8::Local<v8::Promise> Cookies::Set(const base::DictionaryValue& details) {
                                     : base::Time::UnixEpoch();
 
   GURL url(url_string ? *url_string : "");
-  if (url.is_valid()) {
+  if (!url.is_valid()) {
     promise.RejectWithErrorMessage(InclusionStatusToString(
         net::CanonicalCookie::CookieInclusionStatus::EXCLUDE_INVALID_DOMAIN));
     return handle;

--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -258,7 +258,7 @@ v8::Local<v8::Promise> Cookies::Set(const base::DictionaryValue& details) {
                                     : base::Time::UnixEpoch();
 
   GURL url(url_string ? *url_string : "");
-  if (url.is_empty()) {
+  if (url.is_valid()) {
     promise.RejectWithErrorMessage(InclusionStatusToString(
         net::CanonicalCookie::CookieInclusionStatus::EXCLUDE_INVALID_DOMAIN));
     return handle;

--- a/docs/api/cookies.md
+++ b/docs/api/cookies.md
@@ -84,7 +84,7 @@ the response.
 #### `cookies.set(details)`
 
 * `details` Object
-  * `url` String - The url to associate the cookie with. An error is thrown if the url is invalid.
+  * `url` String - The url to associate the cookie with. The promise will be rejected if the url is invalid.
   * `name` String (optional) - The name of the cookie. Empty by default if omitted.
   * `value` String (optional) - The value of the cookie. Empty by default if omitted.
   * `domain` String (optional) - The domain of the cookie; this will be normalized with a preceding dot so that it's also valid for subdomains. Empty by default if omitted.


### PR DESCRIPTION
#### Description of Change

- Use `is_valid` instead of `is_empty` to validate url on `cookies.set()`. (same behavior as in 5.x)
- Adjust docs to match 5.x docs according to #18756.

cc @codebytere @ckerr 

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes

Notes: none
