### PR TITLE
ci: make console.warn work in tests

### DIFF
--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -1471,14 +1471,14 @@ describe('chromium feature', () => {
 
 describe('console functions', () => {
   it('should exist', () => {
-    expect(console.warn).to.be.a('function')
-    expect(console.log).to.be.a('function')
-    expect(console.info).to.be.a('function')
-    expect(console.error).to.be.a('function')
-    expect(console.debug).to.be.a('function')
-    expect(console.trace).to.be.a('function')
-    expect(console.time).to.be.a('function')
-    expect(console.timeEnd).to.be.a('function')
+    expect(console.log, 'log').to.be.a('function')
+    expect(console.error, 'error').to.be.a('function')
+    expect(console.warn, 'warn').to.be.a('function')
+    expect(console.info, 'info').to.be.a('function')
+    expect(console.debug, 'debug').to.be.a('function')
+    expect(console.trace, 'trace').to.be.a('function')
+    expect(console.time, 'time').to.be.a('function')
+    expect(console.timeEnd, 'timeEnd').to.be.a('function')
   })
 })
 

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -32,6 +32,11 @@ describe('chromium feature', () => {
     listener = null
   })
 
+  afterEach(async () => {
+    await closeWindow(w)
+    w = null
+  })
+
   describe('command line switches', () => {
     describe('--lang switch', () => {
       const currentLocale = app.getLocale()
@@ -77,8 +82,6 @@ describe('chromium feature', () => {
       })
     })
   })
-
-  afterEach(() => closeWindow(w).then(() => { w = null }))
 
   describe('heap snapshot', () => {
     it('does not crash', function () {
@@ -1463,6 +1466,19 @@ describe('chromium feature', () => {
         expect(focusedElementId).to.equal('BUTTON-element-3', `focus should've looped back to element-3, it's instead in ${focusedElementId}`)
       })
     })
+  })
+})
+
+describe('console functions', () => {
+  it('should exist', () => {
+    expect(console.warn).to.be.a('function')
+    expect(console.log).to.be.a('function')
+    expect(console.info).to.be.a('function')
+    expect(console.error).to.be.a('function')
+    expect(console.debug).to.be.a('function')
+    expect(console.trace).to.be.a('function')
+    expect(console.time).to.be.a('function')
+    expect(console.timeEnd).to.be.a('function')
   })
 })
 

--- a/spec/static/index.html
+++ b/spec/static/index.html
@@ -39,11 +39,14 @@
 
   // Rediret all output to browser.
   if (isCi) {
-    global.__defineGetter__('console', function () {
-      return {
-        log: (...args) => ipcRenderer.send('console.log', args),
-        error: (...args) => ipcRenderer.send('console.error', args)
+    const fakeConsole = {}
+    for (const k in console) {
+      if (console.hasOwnProperty(k) && k !== 'assert') {
+        fakeConsole[k] = (...args) => ipcRenderer.send('console-call', k, args)
       }
+    }
+    global.__defineGetter__('console', function () {
+      return fakeConsole
     })
   }
 

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -52,16 +52,15 @@ if (process.platform !== 'darwin') {
 
 // Write output to file if OUTPUT_TO_FILE is defined.
 const outputToFile = process.env.OUTPUT_TO_FILE
-const print = function (_, args) {
+const print = function (_, method, args) {
   const output = util.format.apply(null, args)
   if (outputToFile) {
     fs.appendFileSync(outputToFile, output + '\n')
   } else {
-    console.error(output)
+    console[method](output)
   }
 }
-ipcMain.on('console.log', print)
-ipcMain.on('console.error', print)
+ipcMain.on('console-call', print)
 
 ipcMain.on('process.exit', function (event, code) {
   process.exit(code)

--- a/vsts-arm-test-steps.yml
+++ b/vsts-arm-test-steps.yml
@@ -69,7 +69,6 @@ steps:
 
 - bash: |
    cd src
-   export MOCHA_REPORTER=tap
    ./out/Default/electron electron/spec --ci --enable-logging
   displayName: 'Run Electron tests'
   timeoutInMinutes: 10

--- a/vsts-arm-test-steps.yml
+++ b/vsts-arm-test-steps.yml
@@ -69,6 +69,7 @@ steps:
 
 - bash: |
    cd src
+   export MOCHA_REPORTER=tap
    ./out/Default/electron electron/spec --ci --enable-logging
   displayName: 'Run Electron tests'
   timeoutInMinutes: 10


### PR DESCRIPTION
#### Description of Change
Looks like `console.warn` (and many other console functions) have been broken in CI since 2013. This fixes them.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none