### PR TITLE
feat: provide the frame URL with permission requests and checks

### DIFF
--- a/atom/browser/atom_permission_manager.cc
+++ b/atom/browser/atom_permission_manager.cc
@@ -175,12 +175,13 @@ int AtomPermissionManager::RequestPermissionsWithDetails(
     const auto callback =
         base::Bind(&AtomPermissionManager::OnPermissionResponse,
                    base::Unretained(this), request_id, i);
-    if (details == nullptr) {
-      request_handler_.Run(web_contents, permission, callback,
-                           base::DictionaryValue());
-    } else {
-      request_handler_.Run(web_contents, permission, callback, *details);
-    }
+    auto mutable_details =
+        details == nullptr ? base::DictionaryValue() : details->Clone();
+    mutable_details.SetStringKey(
+        "requestingUrl", render_frame_host->GetLastCommittedURL().spec());
+    mutable_details.SetBoolKey("isMainFrame",
+                               render_frame_host->GetParent() == nullptr);
+    request_handler_.Run(web_contents, permission, callback, mutable_details);
   }
 
   return request_id;

--- a/atom/browser/atom_permission_manager.h
+++ b/atom/browser/atom_permission_manager.h
@@ -30,7 +30,7 @@ class AtomPermissionManager : public content::PermissionManager {
   using RequestHandler = base::Callback<void(content::WebContents*,
                                              content::PermissionType,
                                              const StatusCallback&,
-                                             const base::DictionaryValue&)>;
+                                             const base::Value&)>;
 
   // Handler to dispatch permission requests in JS.
   void SetPermissionRequestHandler(const RequestHandler& handler);

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -288,13 +288,15 @@ win.webContents.session.setCertificateVerifyProc((request, callback) => {
 #### `ses.setPermissionRequestHandler(handler)`
 
 * `handler` Function | null
-  * `webContents` [WebContents](web-contents.md) - WebContents requesting the permission.
+  * `webContents` [WebContents](web-contents.md) - WebContents requesting the permission.  Please note that if the request comes from a subframe you should use `requestingUrl` to check the request origin.
   * `permission` String - Enum of 'media', 'geolocation', 'notifications', 'midiSysex',
     'pointerLock', 'fullscreen', 'openExternal'.
   * `callback` Function
     * `permissionGranted` Boolean - Allow or deny the permission.
   * `details` Object - Some properties are only available on certain permission types.
     * `externalURL` String - The url of the `openExternal` request.
+    * `requestingUrl` String - The last URL the requesting frame loaded
+    * `isMainFrame` Boolean - Whether the frame making the request is the main frame
 
 Sets the handler which can be used to respond to permission requests for the `session`.
 Calling `callback(true)` will allow the permission and `callback(false)` will reject it.


### PR DESCRIPTION
Backport of #18757

See that PR for details

Notes: Added `requestingUrl` and `isMainFrame` properties to the permission request and permission check handlers details objects so that apps can check the origin of the requesting frame rather than the root frame.