### PR TITLE
fix: re-enable disabling hardware acceleration

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -77,3 +77,4 @@ frame_host_manager.patch
 cross_site_document_resource_handler.patch
 woa_compiler_workaround.patch
 crashpad_pid_check.patch
+fix_enabled_disabling_hw_acceleration.patch

--- a/patches/chromium/crashpad_pid_check.patch
+++ b/patches/chromium/crashpad_pid_check.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Cheng Zhao <zcbenz@gmail.com>
-Date: Tue Jun 4 11:30:12 JST 2019
+Date: Tue, 4 Jun 2019 11:30:12 +0900
 Subject: crashpad_pid_check.patch
 
 When both browser process and renderer process are connecting to the pipe,
@@ -16,7 +16,7 @@ https://github.com/electron/electron/pull/18483#discussion_r292703588
 https://github.com/electron/electron/pull/18483#issuecomment-501090683
 
 diff --git a/third_party/crashpad/crashpad/util/win/exception_handler_server.cc b/third_party/crashpad/crashpad/util/win/exception_handler_server.cc
-index 2593ff2de032..e89b8ff675be 100644
+index 2593ff2de0327c393c30cae9962a329c5e27b64e..e89b8ff675bed2fa65263ea451d40995e0b010b7 100644
 --- a/third_party/crashpad/crashpad/util/win/exception_handler_server.cc
 +++ b/third_party/crashpad/crashpad/util/win/exception_handler_server.cc
 @@ -448,9 +448,16 @@ bool ExceptionHandlerServer::ServiceClientConnection(

--- a/patches/chromium/fix_enabled_disabling_hw_acceleration.patch
+++ b/patches/chromium/fix_enabled_disabling_hw_acceleration.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Fri, 14 Jun 2019 08:09:35 -0700
+Subject: fix: enabled disabling hw acceleration
+
+Refs Chromium CL https://chromium-review.googlesource.com/c/chromium/src/+/1599993
+broke hardware acceleration. It appears to have been attempting to access shred_context_state_
+before that member variable had been initialized, which caused a memory access crash.
+
+diff --git a/components/viz/service/main/viz_main_impl.cc b/components/viz/service/main/viz_main_impl.cc
+index 53292ae76db018cf6b720dea605e57121bf5e362..e0c59fdd30293f2c456b300d13122c2ad7e2edf3 100644
+--- a/components/viz/service/main/viz_main_impl.cc
++++ b/components/viz/service/main/viz_main_impl.cc
+@@ -263,7 +263,7 @@ void VizMainImpl::CreateFrameSinkManagerInternal(
+       gpu_service_->gpu_channel_manager()->gpu_preferences(),
+       gpu_service_->shared_image_manager(),
+       gpu_service_->gpu_channel_manager()->program_cache(),
+-      gpu_service_->GetContextState());
++      nullptr);
+ 
+   viz_compositor_thread_runner_->CreateFrameSinkManager(
+       std::move(params), task_executor_.get(), gpu_service_.get());


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/18639.

Refs Chromium CL [1599993](https://chromium-review.googlesource.com/c/chromium/src/+/1599993).

This CL injects the `SharedContextState` into `CommandBufferTaskExecutor`
if one is available and use it in InProcessCommandBuffer, which i believe created the crash because it would be trying to access a memory location which did not yet exist. For now, pass a nullptr instead.

cc @deepak1556 @zcbenz  @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash when enabling `app.disableHardwareAcceleration()`.
