### PR TITLE
build: use yarn to install arm modules

### DIFF
--- a/vsts-arm-test-steps.yml
+++ b/vsts-arm-test-steps.yml
@@ -6,8 +6,8 @@ steps:
 
 - bash: |
     cd src/electron
-    npm install --verbose
-  displayName: 'NPM install'
+    node script/yarn.js install --frozen-lockfile
+  displayName: 'Yarn install'
 
 - bash: |
     export ZIP_DEST=$PWD/src/out/Default
@@ -58,7 +58,7 @@ steps:
     cd src
     export npm_config_nodedir=$PWD/out/Default/gen/node_headers
     cd electron/spec
-    npm install --verbose
+    node ../script/yarn.js install --frozen-lockfile
   displayName: Install test modules
 
 - bash: |


### PR DESCRIPTION
Yeah, so this was doing fun things.... The lockfile should be used for All The Builds

Notes: no-notes