### PR TITLE
feat: make async webContents / <webview> methods return a Promise

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -987,6 +987,8 @@ Returns `String` - The user agent for this web page.
 
 * `css` String
 
+Returns `Promise<void>`
+
 Injects CSS into the current web page.
 
 ```js
@@ -1065,6 +1067,8 @@ Returns `Number` - the current zoom level.
 * `minimumLevel` Number
 * `maximumLevel` Number
 
+Returns `Promise<void>`
+
 Sets the maximum and minimum pinch-to-zoom level.
 
 > **NOTE**: Visual zoom is disabled by default in Electron. To re-enable it, call:
@@ -1077,6 +1081,8 @@ Sets the maximum and minimum pinch-to-zoom level.
 
 * `minimumLevel` Number
 * `maximumLevel` Number
+
+Returns `Promise<void>`
 
 Sets the maximum and minimum layout-based (i.e. non-visual) zoom level.
 
@@ -1138,6 +1144,8 @@ Executes the editing command `replaceMisspelling` in web page.
 #### `contents.insertText(text)`
 
 * `text` String
+
+Returns `Promise<void>`
 
 Inserts `text` to the focused element.
 

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -379,6 +379,8 @@ Returns `String` - The user agent for guest page.
 
 * `css` String
 
+Returns `Promise<void>`
+
 Injects CSS into the guest page.
 
 ### `<webview>.executeJavaScript(code[, userGesture])`
@@ -490,6 +492,8 @@ Executes editing command `replaceMisspelling` in page.
 
 * `text` String
 
+Returns `Promise<void>`
+
 Inserts `text` to the focused element.
 
 ### `<webview>.findInPage(text[, options])`
@@ -531,6 +535,8 @@ Stops any `findInPage` request for the `webview` with the provided `action`.
     the web page. Default is `false`.
   * `deviceName` String (optional) - Set the printer device name to use. Default is `''`.
 
+Returns `Promise<void>`
+
 Prints `webview`'s web page. Same as `webContents.print([options])`.
 
 ### `<webview>.printToPDF(options)`
@@ -562,6 +568,8 @@ Captures a snapshot of the page within `rect`. Omitting `rect` will capture the 
 * `channel` String
 * `...args` any[]
 
+Returns `Promise<void>`
+
 Send an asynchronous message to renderer process via `channel`, you can also
 send arbitrary arguments. The renderer process can handle the message by
 listening to the `channel` event with the [`ipcRenderer`](ipc-renderer.md) module.
@@ -572,6 +580,8 @@ examples.
 ### `<webview>.sendInputEvent(event)`
 
 * `event` Object
+
+Returns `Promise<void>`
 
 Sends an input `event` to the page.
 
@@ -607,12 +617,16 @@ Returns `Number` - the current zoom level.
 * `minimumLevel` Number
 * `maximumLevel` Number
 
+Returns `Promise<void>`
+
 Sets the maximum and minimum pinch-to-zoom level.
 
 ### `<webview>.setLayoutZoomLevelLimits(minimumLevel, maximumLevel)`
 
 * `minimumLevel` Number
 * `maximumLevel` Number
+
+Returns `Promise<void>`
 
 Sets the maximum and minimum layout-based (i.e. non-visual) zoom level.
 

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -180,7 +180,7 @@ const webFrameMethods = [
 
 for (const method of webFrameMethods) {
   WebContents.prototype[method] = function (...args) {
-    ipcMainUtils.invokeInWebContents(this, false, 'ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', method, ...args)
+    return ipcMainUtils.invokeInWebContents(this, false, 'ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', method, ...args)
   }
 }
 

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -4,11 +4,7 @@ const { webContents } = require('electron')
 const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
 const ipcMainUtils = require('@electron/internal/browser/ipc-main-internal-utils')
 const parseFeaturesString = require('@electron/internal/common/parse-features-string')
-const {
-  syncMethods,
-  asyncCallbackMethods,
-  asyncPromiseMethods
-} = require('@electron/internal/common/web-view-methods')
+const { syncMethods, asyncMethods } = require('@electron/internal/common/web-view-methods')
 
 // Doesn't exist in early initialization.
 let webViewManager = null
@@ -371,11 +367,7 @@ ipcMainInternal.on('ELECTRON_GUEST_VIEW_MANAGER_FOCUS_CHANGE', function (event, 
   }
 })
 
-const allMethods = new Set([
-  ...syncMethods,
-  ...asyncCallbackMethods,
-  ...asyncPromiseMethods
-])
+const allMethods = new Set([ ...syncMethods, ...asyncMethods ])
 
 handleMessage('ELECTRON_GUEST_VIEW_MANAGER_CALL', function (event, guestInstanceId, method, args) {
   const guest = getGuestForWebContents(guestInstanceId, event.sender)

--- a/lib/common/web-view-methods.js
+++ b/lib/common/web-view-methods.js
@@ -53,18 +53,15 @@ exports.syncMethods = new Set([
   'setZoomLevel'
 ])
 
-exports.asyncCallbackMethods = new Set([
+exports.asyncMethods = new Set([
+  'capturePage',
+  'executeJavaScript',
   'insertCSS',
   'insertText',
   'send',
   'sendInputEvent',
   'setLayoutZoomLevelLimits',
   'setVisualZoomLevelLimits',
-  'print'
-])
-
-exports.asyncPromiseMethods = new Set([
-  'capturePage',
-  'executeJavaScript',
+  'print',
   'printToPDF'
 ])

--- a/lib/renderer/web-view/web-view-impl.ts
+++ b/lib/renderer/web-view/web-view-impl.ts
@@ -3,11 +3,7 @@ import { remote, webFrame } from 'electron'
 import * as ipcRendererUtils from '@electron/internal/renderer/ipc-renderer-internal-utils'
 import * as guestViewInternal from '@electron/internal/renderer/web-view/guest-view-internal'
 import { WEB_VIEW_CONSTANTS } from '@electron/internal/renderer/web-view/web-view-constants'
-import {
-  syncMethods,
-  asyncCallbackMethods,
-  asyncPromiseMethods
-} from '@electron/internal/common/web-view-methods'
+import { syncMethods, asyncMethods } from '@electron/internal/common/web-view-methods'
 
 const v8Util = process.electronBinding('v8_util')
 
@@ -258,22 +254,12 @@ export const setupMethods = (WebViewElement: typeof ElectronInternal.WebViewElem
 
   const createNonBlockHandler = function (method: string) {
     return function (this: ElectronInternal.WebViewElement, ...args: Array<any>) {
-      ipcRendererUtils.invoke('ELECTRON_GUEST_VIEW_MANAGER_CALL', this.getWebContentsId(), method, args)
-    }
-  }
-
-  for (const method of asyncCallbackMethods) {
-    (WebViewElement.prototype as Record<string, any>)[method] = createNonBlockHandler(method)
-  }
-
-  const createPromiseHandler = function (method: string) {
-    return function (this: ElectronInternal.WebViewElement, ...args: Array<any>) {
       return ipcRendererUtils.invoke('ELECTRON_GUEST_VIEW_MANAGER_CALL', this.getWebContentsId(), method, args)
     }
   }
 
-  for (const method of asyncPromiseMethods) {
-    (WebViewElement.prototype as Record<string, any>)[method] = createPromiseHandler(method)
+  for (const method of asyncMethods) {
+    (WebViewElement.prototype as Record<string, any>)[method] = createNonBlockHandler(method)
   }
 }
 


### PR DESCRIPTION
#### Description of Change
Makes it possible to check the success / failure of these APIs:
- `contents.insertCSS()`
- `contents.insertText()`
- `contents.setLayoutZoomLevelLimits()`
- `contents.setVisualZoomLevelLimits()`
- `<webview>.insertCSS()`
- `<webview>.insertText()`
- `<webview>.send()`
- `<webview>.sendInputEvent()`
- `<webview>.setLayoutZoomLevelLimits()`
- `<webview>.setVisualZoomLevelLimits()`
- `<webview>.print()`

It also simplifies the code. This is enabled by the `ipcRendererUtils.invoke()` / `ipcMainUtils.handle()` helpers and the promisification of the APIs.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: All async `webContents` / `<webview>` methods now return a `Promise`.