### PR TITLE
fix: set nativeWindowOpen when sandboxed

### DIFF
--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -440,11 +440,6 @@ bool AtomBrowserClient::CanCreateWindow(
 
   int opener_render_process_id = opener->GetProcess()->GetID();
 
-  if (IsRendererSandboxed(opener_render_process_id)) {
-    *no_javascript_access = false;
-    return true;
-  }
-
   if (RendererUsesNativeWindowOpen(opener_render_process_id)) {
     if (RendererDisablesPopups(opener_render_process_id)) {
       // <webview> without allowpopups attribute should return

--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -79,12 +79,20 @@ WebContentsPreferences::WebContentsPreferences(
 #endif
   SetDefaultBoolIfUndefined(options::kOffscreen, false);
 
+  SetDefaults();
+
   last_dict_ = std::move(*dict_.CreateDeepCopy());
 }
 
 WebContentsPreferences::~WebContentsPreferences() {
   instances_.erase(std::remove(instances_.begin(), instances_.end(), this),
                    instances_.end());
+}
+
+void WebContentsPreferences::SetDefaults() {
+  if (IsEnabled(options::kSandbox)) {
+    SetBool(options::kNativeWindowOpen, true);
+  }
 }
 
 bool WebContentsPreferences::SetDefaultBoolIfUndefined(
@@ -98,6 +106,10 @@ bool WebContentsPreferences::SetDefaultBoolIfUndefined(
   return existing;
 }
 
+void WebContentsPreferences::SetBool(const base::StringPiece& key, bool value) {
+  dict_.SetKey(key, base::Value(value));
+}
+
 bool WebContentsPreferences::IsEnabled(const base::StringPiece& name,
                                        bool default_value) {
   bool bool_value = default_value;
@@ -107,6 +119,8 @@ bool WebContentsPreferences::IsEnabled(const base::StringPiece& name,
 
 void WebContentsPreferences::Merge(const base::DictionaryValue& extend) {
   dict_.MergeDictionary(&extend);
+
+  SetDefaults();
 }
 
 bool WebContentsPreferences::GetPreloadPath(

--- a/atom/browser/web_contents_preferences.h
+++ b/atom/browser/web_contents_preferences.h
@@ -36,6 +36,9 @@ class WebContentsPreferences
                          const mate::Dictionary& web_preferences);
   ~WebContentsPreferences() override;
 
+  // Set WebPreferences defaults onto the JS object.
+  void SetDefaults();
+
   // A simple way to know whether a Boolean property is enabled.
   bool IsEnabled(const base::StringPiece& name, bool default_value = false);
 
@@ -65,6 +68,9 @@ class WebContentsPreferences
 
   // Set preference value to given bool if user did not provide value
   bool SetDefaultBoolIfUndefined(const base::StringPiece& key, bool val);
+
+  // Set preference value to given bool
+  void SetBool(const base::StringPiece& key, bool value);
 
   // Get preferences value as integer possibly coercing it from a string
   bool GetInteger(const base::StringPiece& attribute_name, int* val);

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -112,7 +112,6 @@ const createGuest = function (embedder, params) {
       }
       this.loadURL(params.src, opts)
     }
-    guest.allowPopups = params.allowpopups
     embedder.emit('did-attach-webview', event, guest)
   })
 
@@ -210,6 +209,7 @@ const attachGuest = function (event, embedderFrameId, elementInstanceId, guestIn
     nodeIntegration: params.nodeintegration != null ? params.nodeintegration : false,
     plugins: params.plugins,
     zoomFactor: embedder._getZoomFactor(),
+    disablePopups: !params.allowpopups,
     webSecurity: !params.disablewebsecurity,
     enableBlinkFeatures: params.blinkfeatures,
     disableBlinkFeatures: params.disableblinkfeatures
@@ -229,11 +229,6 @@ const attachGuest = function (event, embedderFrameId, elementInstanceId, guestIn
 
   if (params.preload) {
     webPreferences.preloadURL = params.preload
-  }
-
-  // Return null from native window.open if allowpopups is unset
-  if (webPreferences.nativeWindowOpen === true && !params.allowpopups) {
-    webPreferences.disablePopups = true
   }
 
   // Security options that guest will always inherit from embedder

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -256,7 +256,7 @@ ipcMain.on('ELECTRON_GUEST_WINDOW_MANAGER_INTERNAL_WINDOW_OPEN', function (event
   options = mergeBrowserWindowOptions(event.sender, options)
   event.sender.emit('new-window', event, url, frameName, disposition, options, additionalFeatures, referrer)
   const {newGuest} = event
-  if ((event.sender.isGuest() && !event.sender.allowPopups) || event.defaultPrevented) {
+  if ((event.sender.isGuest() && event.sender.getLastWebPreferences().disablePopups) || event.defaultPrevented) {
     if (newGuest != null) {
       if (options.webContents === newGuest.webContents) {
         // the webContents is not changed, so set defaultPrevented to false to

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -464,20 +464,30 @@ describe('<webview> tag', function () {
   })
 
   describe('allowpopups attribute', () => {
-    it('can not open new window when not set', async () => {
-      const message = await startLoadingWebViewAndWaitForMessage(webview, {
-        src: `file://${fixtures}/pages/window-open-hide.html`
-      })
-      expect(message).to.equal('null')
-    })
+    const generateSpecs = (description, webpreferences = '') => {
+      describe(description, () => {
+        it('can not open new window when not set', async () => {
+          const message = await startLoadingWebViewAndWaitForMessage(webview, {
+            webpreferences,
+            src: `file://${fixtures}/pages/window-open-hide.html`
+          })
+          expect(message).to.equal('null')
+        })
 
-    it('can open new window when set', async () => {
-      const message = await startLoadingWebViewAndWaitForMessage(webview, {
-        allowpopups: 'on',
-        src: `file://${fixtures}/pages/window-open-hide.html`
+        it('can open new window when set', async () => {
+          const message = await startLoadingWebViewAndWaitForMessage(webview, {
+            webpreferences,
+            allowpopups: 'on',
+            src: `file://${fixtures}/pages/window-open-hide.html`
+          })
+          expect(message).to.equal('window')
+        })
       })
-      expect(message).to.equal('window')
-    })
+    }
+
+    generateSpecs('without sandbox')
+    generateSpecs('with sandbox', 'sandbox=yes')
+    generateSpecs('with nativeWindowOpen', 'nativeWindowOpen=yes')
   })
 
   describe('webpreferences attribute', () => {


### PR DESCRIPTION
#### Description of Change
Backport of: #18273

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes:
* Fixed issues with popups created from sandboxed `<webview>`: 
* Clicking link with `target="_blank"` not emitting `'new-window'` event.
* `window.open()` not returning `null` when `allowpopups` is not set.