### PR TITLE
docs: better explain supported release line levels

### DIFF
--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -37,6 +37,16 @@ The latest three major versions are supported by the Electron team.
 For example, if the latest release is 5.0.x, then the 4.x.y series
 is supported, as are the two previous release series 3.x.y and 2.x.y.
 
+The latest stable release unilaterally receives all fixes from `master`,
+and the version prior to that receives the vast majority of those fixes
+as time and bandwidth warrants. The oldest supported release line will receive
+only security fixes directly.
+
+All supported release lines will accept external pull requests to backport
+fixes previously merged to `master`, though this may be on a case-by-case
+basis for some older supported lines. All contested decisions around release
+line backports will be resolved by the [Releases Working Group](https://github.com/electron/governance/tree/master/wg-releases) as an agenda item at their weekly meeting the week the backport PR is raised.
+
 ### Currently supported versions
 - 5.x
 - 4.x


### PR DESCRIPTION
#### Description of Change

This PR better explains the differing support levels we ascribe to each of our currently supported release lines.

Feedback welcome!

cc @electron/wg-releases 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
