### PR TITLE
build: get current release branch from commit

### DIFF
--- a/script/lib/utils.js
+++ b/script/lib/utils.js
@@ -25,18 +25,25 @@ function getAbsoluteElectronExec () {
   return path.resolve(__dirname, '../../..', getElectronExec())
 }
 
-async function getCurrentBranch (gitDir) {
-  const gitArgs = ['rev-parse', '--abbrev-ref', 'HEAD']
-  const branchDetails = await GitProcess.exec(gitArgs, gitDir)
-  if (branchDetails.exitCode === 0) {
-    const currentBranch = branchDetails.stdout.trim()
-    console.log(`${pass} current git branch is: ${currentBranch}`)
-    return currentBranch
+async function handleGitCall(args, gitDir) {
+  const details = await GitProcess.exec(args, gitDir)
+  if (details.exitCode === 0) {
+    return details.stdout.trim()
   } else {
-    const error = GitProcess.parseError(branchDetails.stderr)
-    console.log(`${fail} couldn't get details current branch: `, error)
+    const error = GitProcess.parseError(details.stderr)
+    console.log(`${fail} couldn't parse git process call: `, error)
     process.exit(1)
   }
+}
+
+async function getCurrentBranch (gitDir) {
+  let branch = await handleGitCall(['rev-parse', '--abbrev-ref', 'HEAD'], gitDir)
+  if (!branch.match(/[0-9]+-[0-9]+-x/)) {
+    const lastCommit = await handleGitCall(['rev-parse', 'HEAD'], gitDir)
+    const branches = (await handleGitCall(['branch', '--contains', lastCommit], gitDir)).split('\n')
+    branch = branches.filter(b => b.match(/[0-9]+-[0-9]+-x/))[0].trim()
+  }
+  return branch
 }
 
 module.exports = {

--- a/script/lib/utils.js
+++ b/script/lib/utils.js
@@ -25,7 +25,7 @@ function getAbsoluteElectronExec () {
   return path.resolve(__dirname, '../../..', getElectronExec())
 }
 
-async function handleGitCall(args, gitDir) {
+async function handleGitCall (args, gitDir) {
   const details = await GitProcess.exec(args, gitDir)
   if (details.exitCode === 0) {
     return details.stdout.trim()


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/sudowoodo/issues/122.

When we blast off again, we checkout a commit so the current branch ends up being incorrect, and is `HEAD` rather than `X-Y-Z`. This therefore no longer just unilaterally runs `git rev-parse --abbrev-ref HEAD`; it instead checks to ensure that the result of that call matches the release branch pattern. If it doesn't, it fetches the containing branch for the commit.

Since we only ever blast off from bump commits, we can safely assume that only one release branch will ever contain the bump commit and therefore be the one we want to use when tagging the release on npm.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
