### PR TITLE
fix: return false when name conflict on app move

### DIFF
--- a/atom/browser/ui/cocoa/atom_bundle_mover.mm
+++ b/atom/browser/ui/cocoa/atom_bundle_mover.mm
@@ -74,21 +74,17 @@ bool AtomBundleMover::Move(mate::Arguments* args) {
     if ([fileManager fileExistsAtPath:destinationPath]) {
       // But first, make sure that it's not running
       if (IsApplicationAtPathRunning(destinationPath)) {
-        // Give the running app focus and terminate myself
-        [[NSTask
-            launchedTaskWithLaunchPath:@"/usr/bin/open"
-                             arguments:[NSArray
-                                           arrayWithObject:destinationPath]]
-            waitUntilExit];
-        atom::Browser::Get()->Quit();
-        return true;
+        // We don't know if the app is another app of the same name,
+        // or the same app, so throw an error and leave it to the user
+        // to determine next steps
+        args->ThrowError("An app of the same name appears to already exist in "
+                         "Applications.");
       } else {
         if (!Trash([applicationsDirectory
-                stringByAppendingPathComponent:bundleName])) {
+                stringByAppendingPathComponent:bundleName]))
           args->ThrowError("Failed to delete existing application");
-          return false;
-        }
       }
+      return false;
     }
 
     if (!CopyBundle(bundlePath, destinationPath)) {


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/18805.

Previously, if an app was running of the same name in Applications when `app.moveToApplicationsFolder()` was called, we would assume that meant it was the _same_ app, so we would quit this one and focus the other app, while returning true. Given nontrivial potential for naming clashes, this seems to be a potentially dangerous assumption to make as demonstrated by the above error.

This PR thus changes that behavior to throw an error indicating the naming conflict, and return false to indicate no such move occurred.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `app.moveToApplicationsFolder()` would incorrectly return true and focus the wrong app if an identically named app was present and running in Applications when called.
