### PR TITLE
fix: extra space in security warning message causing list misalignment

### DIFF
--- a/lib/renderer/security-warnings.ts
+++ b/lib/renderer/security-warnings.ts
@@ -101,7 +101,7 @@ const warnAboutInsecureResources = function () {
 
   const warning = `This renderer process loads resources using insecure
   protocols. This exposes users of this app to unnecessary security risks.
-  Consider loading the following resources over HTTPS or FTPS. \n ${resources}
+  Consider loading the following resources over HTTPS or FTPS. \n${resources}
   \n ${moreInformation}`
 
   console.warn('%cElectron Security Warning (Insecure Resources)',

--- a/lib/renderer/security-warnings.ts
+++ b/lib/renderer/security-warnings.ts
@@ -75,7 +75,7 @@ const isUnsafeEvalEnabled = function () {
 }
 
 const moreInformation = `\nFor more information and help, consult
-https://electronjs.org/docs/tutorial/security.\n This warning will not show up
+https://electronjs.org/docs/tutorial/security.\nThis warning will not show up
 once the app is packaged.`
 
 /**

--- a/lib/renderer/security-warnings.ts
+++ b/lib/renderer/security-warnings.ts
@@ -102,7 +102,7 @@ const warnAboutInsecureResources = function () {
   const warning = `This renderer process loads resources using insecure
   protocols. This exposes users of this app to unnecessary security risks.
   Consider loading the following resources over HTTPS or FTPS. \n${resources}
-  \n ${moreInformation}`
+  \n${moreInformation}`
 
   console.warn('%cElectron Security Warning (Insecure Resources)',
     'font-weight: bold;', warning)
@@ -120,7 +120,7 @@ const warnAboutNodeWithRemoteContent = function (nodeIntegration: boolean) {
   if (getIsRemoteProtocol()) {
     const warning = `This renderer process has Node.js integration enabled
     and attempted to load remote content from '${window.location}'. This
-    exposes users of this app to severe security risks.\n ${moreInformation}`
+    exposes users of this app to severe security risks.\n${moreInformation}`
 
     console.warn('%cElectron Security Warning (Node.js Integration with Remote Content)',
       'font-weight: bold;', warning)
@@ -142,7 +142,7 @@ const warnAboutDisabledWebSecurity = function (webPreferences?: Electron.WebPref
   if (!webPreferences || webPreferences.webSecurity !== false) return
 
   const warning = `This renderer process has "webSecurity" disabled. This
-  exposes users of this app to severe security risks.\n ${moreInformation}`
+  exposes users of this app to severe security risks.\n${moreInformation}`
 
   console.warn('%cElectron Security Warning (Disabled webSecurity)',
     'font-weight: bold;', warning)
@@ -160,7 +160,7 @@ const warnAboutInsecureCSP = function () {
 
     const warning = `This renderer process has either no Content Security
     Policy set or a policy with "unsafe-eval" enabled. This exposes users of
-    this app to unnecessary security risks.\n ${moreInformation}`
+    this app to unnecessary security risks.\n${moreInformation}`
 
     console.warn('%cElectron Security Warning (Insecure Content-Security-Policy)',
       'font-weight: bold;', warning)
@@ -195,7 +195,7 @@ const warnAboutExperimentalFeatures = function (webPreferences?: Electron.WebPre
 
   const warning = `This renderer process has "experimentalFeatures" enabled.
   This exposes users of this app to some security risk. If you do not need
-  this feature, you should disable it.\n ${moreInformation}`
+  this feature, you should disable it.\n${moreInformation}`
 
   console.warn('%cElectron Security Warning (experimentalFeatures)',
     'font-weight: bold;', warning)
@@ -215,7 +215,7 @@ const warnAboutEnableBlinkFeatures = function (webPreferences?: Electron.WebPref
 
   const warning = `This renderer process has additional "enableBlinkFeatures"
   enabled. This exposes users of this app to some security risk. If you do not
-  need this feature, you should disable it.\n ${moreInformation}`
+  need this feature, you should disable it.\n${moreInformation}`
 
   console.warn('%cElectron Security Warning (enableBlinkFeatures)',
     'font-weight: bold;', warning)

--- a/lib/renderer/security-warnings.ts
+++ b/lib/renderer/security-warnings.ts
@@ -259,7 +259,7 @@ const warnAboutRemoteModuleWithRemoteContent = function (webPreferences?: Electr
   if (getIsRemoteProtocol()) {
     const warning = `This renderer process has "enableRemoteModule" enabled
     and attempted to load remote content from '${window.location}'. This
-    exposes users of this app to unnecessary security risks.\n ${moreInformation}`
+    exposes users of this app to unnecessary security risks.\n${moreInformation}`
 
     console.warn('%cElectron Security Warning (enableRemoteModule)',
       'font-weight: bold;', warning)


### PR DESCRIPTION
#### Description of Change
This PR removes an extra space in the "warn about insecure resources" warning
string so the list of insecure resources are properly aligned.

Update: also removed whitespaces after newlines since they mess up the indentation.

<img width="1081" alt="Screen Shot 2019-06-15 at 2 29 52 AM" src="https://user-images.githubusercontent.com/18181641/59549741-e8d77e80-8f16-11e9-88d1-25316099a468.png">

#### Checklist
- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes (having trouble with setting up the project, I'll leave it up to CI)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes