### PR TITLE
fix: Uncaught TypeError: Cannot set property 'innerText' of null in default-app

### DIFF
--- a/default_app/renderer.js
+++ b/default_app/renderer.js
@@ -28,11 +28,18 @@ function initialize () {
     link.addEventListener('auxclick', openLinkExternally)
   }
 
-  document.querySelector('.electron-version').innerText = `Electron v${process.versions.electron}`
-  document.querySelector('.chrome-version').innerText = `Chromium v${process.versions.chrome}`
-  document.querySelector('.node-version').innerText = `Node v${process.versions.node}`
-  document.querySelector('.v8-version').innerText = `v8 v${process.versions.v8}`
-  document.querySelector('.command-example').innerText = `${electronPath} path-to-app`
+  function replaceText (selector, text) {
+    const element = document.querySelector(selector)
+    if (element) {
+      element.innerText = text
+    }
+  }
+
+  replaceText('.electron-version', `Electron v${process.versions.electron}`)
+  replaceText('.chrome-version', `Chromium v${process.versions.chrome}`)
+  replaceText('.node-version', `Node v${process.versions.node}`)
+  replaceText('.v8-version', `v8 v${process.versions.v8}`)
+  replaceText('.command-example', `${electronPath} path-to-app`)
 
   function getOcticonSvg (name) {
     const octiconPath = path.resolve(__dirname, 'node_modules', 'octicons', 'build', 'svg', `${name}.svg`)


### PR DESCRIPTION
#### Description of Change
100% repro when default-app is used to open a website.

The problem is that the code assumes these elements to be present in the DOM, which is not the case if any other page is loaded.
```
    <ul class="versions code">
      <li class="electron-version"></li>
      <li class="chrome-version"></li>
      <li class="node-version"></li>
      <li class="v8-version"></li>
    </ul>
```

Example `electron https://www.example.com/`
<img width="1012" alt="Screen Shot 2019-06-15 at 3 01 50 PM" src="https://user-images.githubusercontent.com/1281234/59551906-ed388180-8f80-11e9-8a95-30dec34be327.png">

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed `Uncaught TypeError: Cannot set property 'innerText' of null` in default-app when opening a website.