### PR TITLE
refactor: piggy-back on ELECTRON_BROWSER_SANDBOX_LOAD to get content scripts

### DIFF
--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -312,9 +312,9 @@ ipcMainUtils.handle('CHROME_TABS_EXECUTE_SCRIPT', async function (event, tabId, 
   return ipcMainUtils.invokeInWebContents(contents, false, 'CHROME_TABS_EXECUTE_SCRIPT', extensionId, url, code)
 })
 
-ipcMainUtils.handle('CHROME_GET_CONTENT_SCRIPTS', async (event) => {
+exports.getContentScripts = () => {
   return Object.values(contentScripts)
-})
+}
 
 // Transfer the content scripts to renderer.
 const contentScripts = {}

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -12,6 +12,7 @@ const features = process.electronBinding('features')
 
 const { isPromise } = electron
 
+const { getContentScripts } = require('@electron/internal/browser/chrome-extension')
 const { crashReporterInit } = require('@electron/internal/browser/crash-reporter-init')
 const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
 const ipcMainUtils = require('@electron/internal/browser/ipc-main-internal-utils')
@@ -541,6 +542,8 @@ const getPreloadScript = async function (preloadPath) {
   return { preloadPath, preloadSrc, preloadError }
 }
 
+ipcMainUtils.handle('ELECTRON_GET_CONTENT_SCRIPTS', () => getContentScripts())
+
 ipcMainUtils.handle('ELECTRON_BROWSER_SANDBOX_LOAD', async function (event) {
   const preloadPaths = [
     ...(event.sender.session ? event.sender.session.getPreloads() : []),
@@ -548,6 +551,7 @@ ipcMainUtils.handle('ELECTRON_BROWSER_SANDBOX_LOAD', async function (event) {
   ]
 
   return {
+    contentScripts: getContentScripts(),
     preloadScripts: await Promise.all(preloadPaths.map(path => getPreloadScript(path))),
     isRemoteModuleEnabled: isRemoteModuleEnabled(event.sender),
     isWebViewTagEnabled: guestViewManager.isWebViewTagEnabled(event.sender),

--- a/lib/renderer/content-scripts-injector.ts
+++ b/lib/renderer/content-scripts-injector.ts
@@ -108,13 +108,7 @@ ipcRendererUtils.handle('CHROME_TABS_EXECUTE_SCRIPT', function (
   return runContentScript.call(window, extensionId, url, code)
 })
 
-type ContentScriptEntry = {
-  extensionId: string;
-  contentScripts: Electron.ContentScript[];
-}
-
-module.exports = () => {
-  const entries = ipcRendererUtils.invokeSync<ContentScriptEntry[]>('CHROME_GET_CONTENT_SCRIPTS')
+module.exports = (entries: Electron.ContentScriptEntry[]) => {
   for (const entry of entries) {
     if (entry.contentScripts) {
       for (const script of entry.contentScripts) {

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -54,6 +54,7 @@ v8Util.setHiddenValue(global, 'ipcNative', {
 
 // Use electron module after everything is ready.
 const { ipcRendererInternal } = require('@electron/internal/renderer/ipc-renderer-internal')
+const ipcRendererUtils = require('@electron/internal/renderer/ipc-renderer-internal-utils')
 const { webFrameInit } = require('@electron/internal/renderer/web-frame-init')
 webFrameInit()
 
@@ -111,7 +112,8 @@ switch (window.location.protocol) {
     windowSetup(guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
 
     // Inject content scripts.
-    require('@electron/internal/renderer/content-scripts-injector')()
+    const contentScripts = ipcRendererUtils.invokeSync('ELECTRON_GET_CONTENT_SCRIPTS') as Electron.ContentScriptEntry[]
+    require('@electron/internal/renderer/content-scripts-injector')(contentScripts)
   }
 }
 

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -30,7 +30,7 @@ const { ipcRendererInternal } = require('@electron/internal/renderer/ipc-rendere
 const ipcRendererUtils = require('@electron/internal/renderer/ipc-renderer-internal-utils')
 
 const {
-  preloadScripts, isRemoteModuleEnabled, isWebViewTagEnabled, process: processProps
+  contentScripts, preloadScripts, isRemoteModuleEnabled, isWebViewTagEnabled, process: processProps
 } = ipcRendererUtils.invokeSync('ELECTRON_BROWSER_SANDBOX_LOAD')
 
 process.isRemoteModuleEnabled = isRemoteModuleEnabled
@@ -124,7 +124,7 @@ switch (window.location.protocol) {
   }
   default: {
     // Inject content scripts.
-    require('@electron/internal/renderer/content-scripts-injector')()
+    require('@electron/internal/renderer/content-scripts-injector')(contentScripts)
   }
 }
 

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -47,6 +47,11 @@ declare namespace Electron {
     allFrames: boolean
   }
 
+  type ContentScriptEntry = {
+    extensionId: string;
+    contentScripts: ContentScript[];
+  }
+
   interface IpcRendererInternal extends Electron.IpcRenderer {
     sendToAll(webContentsId: number, channel: string, ...args: any[]): void
   }


### PR DESCRIPTION
#### Description of Change
Follow up to #18532. Re-use existing `ELECTRON_BROWSER_SANDBOX_LOAD` IPC for getting the list of content scripts in sandboxed renderers instead of sending a separate `ELECTRON_GET_CONTENT_SCRIPTS` IPC.

/cc @nornagon

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes