### PR TITLE
feat: add memory to app.getAppMetrics()

### DIFF
--- a/docs/api/structures/memory-info.md
+++ b/docs/api/structures/memory-info.md
@@ -1,0 +1,9 @@
+# MemoryInfo Object
+
+* `workingSetSize` Integer - The amount of memory currently pinned to actual physical RAM.
+* `peakWorkingSetSize` Integer - The maximum amount of memory that has ever been pinned
+  to actual physical RAM.
+* `privateBytes` Integer (optional) _Windows_ - The amount of memory not shared by other processes, such as
+  JS heap or HTML content.
+
+Note that all statistics are reported in Kilobytes.

--- a/docs/api/structures/process-metric.md
+++ b/docs/api/structures/process-metric.md
@@ -7,6 +7,7 @@
     The time is represented as number of milliseconds since epoch.
     Since the `pid` can be reused after a process dies,
     it is useful to use both the `pid` and the `creationTime` to uniquely identify a process.
+* `memory` [MemoryInfo](memory-info.md) - Memory information for the process.
 * `sandboxed` Boolean (optional) _macOS_ _Windows_ - Whether the process is sandboxed on OS level.
 * `integrityLevel` String (optional) _Windows_ - One of the following values:
   * `untrusted`

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -86,6 +86,7 @@ auto_filenames = {
     "docs/api/structures/jump-list-category.md",
     "docs/api/structures/jump-list-item.md",
     "docs/api/structures/keyboard-event.md",
+    "docs/api/structures/memory-info.md",
     "docs/api/structures/memory-usage-details.md",
     "docs/api/structures/mime-typed-buffer.md",
     "docs/api/structures/notification-action.md",

--- a/shell/browser/api/atom_api_app.cc
+++ b/shell/browser/api/atom_api_app.cc
@@ -1218,6 +1218,25 @@ std::vector<mate::Dictionary> App::GetAppMetrics(v8::Isolate* isolate) {
     pid_dict.Set("creationTime",
                  process_metric.second->process.CreationTime().ToJsTime());
 
+#if !defined(OS_LINUX)
+    auto memory_info = process_metric.second->GetMemoryInfo();
+
+    mate::Dictionary memory_dict = mate::Dictionary::CreateEmpty(isolate);
+    memory_dict.SetHidden("simple", true);
+    memory_dict.Set("workingSetSize",
+                    static_cast<double>(memory_info.working_set_size >> 10));
+    memory_dict.Set(
+        "peakWorkingSetSize",
+        static_cast<double>(memory_info.peak_working_set_size >> 10));
+
+#if defined(OS_WIN)
+    memory_dict.Set("privateBytes",
+                    static_cast<double>(memory_info.private_bytes >> 10));
+#endif
+
+    pid_dict.Set("memory", memory_dict);
+#endif
+
 #if defined(OS_MACOSX)
     pid_dict.Set("sandboxed", process_metric.second->IsSandboxed());
 #elif defined(OS_WIN)

--- a/shell/browser/api/process_metric.h
+++ b/shell/browser/api/process_metric.h
@@ -13,6 +13,16 @@
 
 namespace electron {
 
+#if !defined(OS_LINUX)
+struct ProcessMemoryInfo {
+  size_t working_set_size = 0;
+  size_t peak_working_set_size = 0;
+#if defined(OS_WIN)
+  size_t private_bytes = 0;
+#endif
+};
+#endif
+
 #if defined(OS_WIN)
 enum class ProcessIntegrityLevel {
   Unknown,
@@ -32,6 +42,10 @@ struct ProcessMetric {
                 base::ProcessHandle handle,
                 std::unique_ptr<base::ProcessMetrics> metrics);
   ~ProcessMetric();
+
+#if !defined(OS_LINUX)
+  ProcessMemoryInfo GetMemoryInfo() const;
+#endif
 
 #if defined(OS_WIN)
   ProcessIntegrityLevel GetIntegrityLevel() const;

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -966,6 +966,13 @@ describe('app module', () => {
         expect(entry.cpu).to.have.ownProperty('percentCPUUsage').that.is.a('number')
         expect(entry.cpu).to.have.ownProperty('idleWakeupsPerSecond').that.is.a('number')
 
+        expect(entry.memory).to.have.property('workingSetSize').that.is.greaterThan(0)
+        expect(entry.memory).to.have.property('peakWorkingSetSize').that.is.greaterThan(0)
+
+        if (process.platform === 'win32') {
+          expect(entry.memory).to.have.property('privateBytes').that.is.greaterThan(0)
+        }
+
         if (process.platform !== 'linux') {
           expect(entry.sandboxed).to.be.a('boolean')
         }


### PR DESCRIPTION
#### Description of Change
Bring back memory info per process returned by `app.getAppMetrics()`. Follow-up to #18718.
It does not depend on Chromium internals, it’s calling the OS API directly.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `memory` to `app.getAppMetrics()`.