### PR TITLE
docs: better explain supported release line levels

### DIFF
--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -33,9 +33,26 @@ tools and resources.
 
 ## Supported Versions
 
-The latest three release branches are supported by the Electron team.
-For example, if the latest release is 2.0.x, then the 2-0-x series
-is supported, as are the two previous release series 1-7-x and 1-8-x.
+The latest three major versions are supported by the Electron team.
+For example, if the latest release is 5.0.x, then the 4.x.y series
+is supported, as are the two previous release series 3.x.y and 2.x.y.
+
+The latest stable release unilaterally receives all fixes from `master`,
+and the version prior to that receives the vast majority of those fixes
+as time and bandwidth warrants. The oldest supported release line will receive
+only security fixes directly.
+
+All supported release lines will accept external pull requests to backport
+fixes previously merged to `master`, though this may be on a case-by-case
+basis for some older supported lines. All contested decisions around release
+line backports will be resolved by the [Releases Working Group](https://github.com/electron/governance/tree/master/wg-releases) as an agenda item at their weekly meeting the week the backport PR is raised.
+
+### Currently supported versions
+- 5.x
+- 4.x
+- 3.x
+
+### End-of-life
 
 When a release branch reaches the end of its support cycle, the series
 will be deprecated in NPM and a final end-of-support release will be


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/18800.

See that PR for more details.

Notes: none