### PR TITLE
fix: use is_valid for cookie url validation

### DIFF
--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -291,7 +291,7 @@ void SetCookieOnIO(scoped_refptr<net::URLRequestContextGetter> getter,
                  EXCLUDE_FAILURE_TO_STORE);
     return;
   }
-  if (url.is_empty()) {
+  if (!url.is_valid()) {
     std::move(completion_callback)
         .Run(net::CanonicalCookie::CookieInclusionStatus::
                  EXCLUDE_INVALID_DOMAIN);

--- a/docs/api/cookies.md
+++ b/docs/api/cookies.md
@@ -104,7 +104,7 @@ with `callback(error, cookies)` on complete.
 #### `cookies.set(details)`
 
 * `details` Object
-  * `url` String - The url to associate the cookie with.
+  * `url` String - The url to associate the cookie with. The promise will be rejected if the url is invalid.
   * `name` String (optional) - The name of the cookie. Empty by default if omitted.
   * `value` String (optional) - The value of the cookie. Empty by default if omitted.
   * `domain` String (optional) - The domain of the cookie; this will be normalized with a preceding dot so that it's also valid for subdomains. Empty by default if omitted.


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/18770.

See that PR for more details.

Notes: none