### PR TITLE
chore: fix current branch fetch on master

### DIFF
--- a/script/lib/utils.js
+++ b/script/lib/utils.js
@@ -28,7 +28,8 @@ function getAbsoluteElectronExec () {
 async function handleGitCall (args, gitDir) {
   const details = await GitProcess.exec(args, gitDir)
   if (details.exitCode === 0) {
-    return details.stdout.trim()
+    const output = details.stdout.replace(/^\*|\s+|\s+$/, '')
+    return output.trim()
   } else {
     const error = GitProcess.parseError(details.stderr)
     console.log(`${fail} couldn't parse git process call: `, error)
@@ -38,10 +39,14 @@ async function handleGitCall (args, gitDir) {
 
 async function getCurrentBranch (gitDir) {
   let branch = await handleGitCall(['rev-parse', '--abbrev-ref', 'HEAD'], gitDir)
-  if (!branch.match(/[0-9]+-[0-9]+-x/)) {
+  if (branch !== 'master' && !branch.match(/[0-9]+-[0-9]+-x/)) {
     const lastCommit = await handleGitCall(['rev-parse', 'HEAD'], gitDir)
     const branches = (await handleGitCall(['branch', '--contains', lastCommit], gitDir)).split('\n')
-    branch = branches.filter(b => b.match(/[0-9]+-[0-9]+-x/))[0].trim()
+    branch = branches.filter(b => b === 'master' || b.match(/[0-9]+-[0-9]+-x/))[0]
+    if (!branch) {
+      console.log(`${fail} no release branch exists for this ref`)
+      process.exit(1)
+    }
   }
   return branch
 }


### PR DESCRIPTION
#### Description of Change

When fetching current branch on a nightly release, we need to account for the fact that `master` doesn't fit the release branch formatting. This fixes that error.

cc @MarshallOfSound 

#### Release Notes

Notes: none
