### PR TITLE
chore: remove unused enum

### DIFF
--- a/atom/browser/api/atom_api_session.h
+++ b/atom/browser/api/atom_api_session.h
@@ -40,11 +40,6 @@ namespace api {
 class Session : public mate::TrackableObject<Session>,
                 public content::DownloadManager::Observer {
  public:
-  enum class CacheAction {
-    CLEAR,
-    STATS,
-  };
-
   // Gets or creates Session from the |browser_context|.
   static mate::Handle<Session> CreateFrom(v8::Isolate* isolate,
                                           AtomBrowserContext* browser_context);


### PR DESCRIPTION
#### Description of Change

Remove enum added in [10e4698b](https://github.com/electron/electron/commit/10e4698baa94ddb0c1a1537385279875c2cccbe8); it is no longer used.

cc @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
