### PR TITLE
refactor: auto generate Info.plist to avoid bumping during releases

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -687,7 +687,7 @@ if (is_mac) {
 
     electron_version = read_file("ELECTRON_VERSION", "trim string")
     extra_substitutions = [
-      "ATOM_BUNDLE_ID=$electron_mac_bundle_id.framework",
+      "ELECTRON_BUNDLE_ID=$electron_mac_bundle_id.framework",
       "ELECTRON_VERSION=$electron_version",
     ]
 
@@ -738,7 +738,8 @@ if (is_mac) {
     sources += [ "atom/common/atom_constants.cc" ]
     include_dirs = [ "." ]
     info_plist = "atom/renderer/resources/mac/Info.plist"
-    extra_substitutions = [ "ATOM_BUNDLE_ID=$electron_mac_bundle_id.helper" ]
+    extra_substitutions =
+        [ "ELECTRON_BUNDLE_ID=$electron_mac_bundle_id.helper" ]
     ldflags = [
       "-rpath",
       "@executable_path/../../..",
@@ -779,7 +780,7 @@ if (is_mac) {
     libs = [ "AppKit.framework" ]
     info_plist = "atom/app/resources/mac/loginhelper-Info.plist"
     extra_substitutions =
-        [ "ATOM_BUNDLE_ID=$electron_mac_bundle_id.loginhelper" ]
+        [ "ELECTRON_BUNDLE_ID=$electron_mac_bundle_id.loginhelper" ]
   }
 
   bundle_data("electron_login_helper_app") {
@@ -851,7 +852,11 @@ if (is_mac) {
       deps += [ ":electron_login_helper_app" ]
     }
     info_plist = "atom/browser/resources/mac/Info.plist"
-    extra_substitutions = [ "ATOM_BUNDLE_ID=$electron_mac_bundle_id" ]
+    electron_version = read_file("ELECTRON_VERSION", "trim string")
+    extra_substitutions = [
+      "ELECTRON_BUNDLE_ID=$electron_mac_bundle_id",
+      "ELECTRON_VERSION=$electron_version",
+    ]
     ldflags = [
       "-rpath",
       "@executable_path/../Frameworks",

--- a/atom/app/resources/mac/loginhelper-Info.plist
+++ b/atom/app/resources/mac/loginhelper-Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleIdentifier</key>
-	<string>${ATOM_BUNDLE_ID}</string>
+	<string>${ELECTRON_BUNDLE_ID}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundleExecutable</key>

--- a/atom/browser/resources/mac/Info.plist
+++ b/atom/browser/resources/mac/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleExecutable</key>
     <string>${PRODUCT_NAME}</string>
     <key>CFBundleIdentifier</key>
-    <string>${ATOM_BUNDLE_ID}</string>
+    <string>${ELECTRON_BUNDLE_ID}</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleName</key>
@@ -17,9 +17,9 @@
     <key>CFBundleIconFile</key>
     <string>electron.icns</string>
     <key>CFBundleVersion</key>
-    <string>7.0.0-nightly.20190616</string>
+    <string>${ELECTRON_VERSION}</string>
     <key>CFBundleShortVersionString</key>
-    <string>7.0.0-nightly.20190616</string>
+    <string>${ELECTRON_VERSION}</string>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.developer-tools</string>
     <key>LSMinimumSystemVersion</key>

--- a/atom/common/resources/mac/Info.plist
+++ b/atom/common/resources/mac/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleIdentifier</key>
-	<string>${ATOM_BUNDLE_ID}</string>
+	<string>${ELECTRON_BUNDLE_ID}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundleExecutable</key>

--- a/atom/renderer/resources/mac/Info.plist
+++ b/atom/renderer/resources/mac/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
   <key>CFBundleIdentifier</key>
-  <string>${ATOM_BUNDLE_ID}</string>
+  <string>${ELECTRON_BUNDLE_ID}</string>
   <key>CFBundleName</key>
   <string>${PRODUCT_NAME}</string>
   <key>CFBundlePackageType</key>

--- a/script/bump-version.js
+++ b/script/bump-version.js
@@ -56,7 +56,6 @@ async function main () {
   // update all version-related files
   await Promise.all([
     updateVersion(version),
-    updateInfoPlist(version),
     updatePackageJSON(version),
     updateVersionH(components),
     updateWinRC(components)
@@ -117,18 +116,6 @@ async function updatePackageJSON (version) {
     file.version = version
     await writeFile(filePath, JSON.stringify(file, null, 2))
   })
-}
-
-// update CFBundle version information and overwrite pre-existing file
-// TODO(codebytere): provide these version fields at GN build time
-async function updateInfoPlist (version) {
-  const filePath = path.resolve(__dirname, '..', 'atom', 'browser', 'resources', 'mac', 'Info.plist')
-  const file = plist.parse(await readFile(filePath, { encoding: 'utf8' }))
-
-  file.CFBundleVersion = version
-  file.CFBundleShortVersionString = version
-
-  await writeFile(filePath, plist.build(file))
 }
 
 // push bump commit to release branch


### PR DESCRIPTION
This was already possible (we were doing it for a different plist file).  Now we can remove a step in the bump version script 👍 

Notes: no-notes