### PR TITLE
docs: add example on handling the webPrefs change

### DIFF
--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -110,7 +110,17 @@ The following `webPreferences` option default values are deprecated in favor of 
 | `nodeIntegration` | `true` | `false` |
 | `webviewTag` | `nodeIntegration` if set else `true` | `false` |
 
-## `nativeWindowOpen`
+E.g. Re-enabling the webviewTag
+
+```js
+const w = new BrowserWindow({
+  webPreferences: {
+    webviewTag: true
+  }
+})
+```
+
+### `nativeWindowOpen`
 
 Child windows opened with the `nativeWindowOpen` option will always have Node.js integration disabled.
 


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/17971

See that PR for details.

Notes: none