### PR TITLE
build: enforce frozen lockfile on the lint stage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -577,7 +577,7 @@ steps-lint: &steps-lint
           # but then we would lint its contents (at least gn format), and it doesn't pass it.
 
           cd src/electron
-          node script/yarn install
+          node script/yarn install --frozen-lockfile
           node script/yarn lint
 
 steps-checkout: &steps-checkout


### PR DESCRIPTION
This fixes the edge-case in https://github.com/electron/electron/pull/18863#pullrequestreview-251279266 where all CI would pass even though the yarn lockfile **should** have changed.  In this case the lint stage will now catch this case 👍 

Notes: no-notes