### PR TITLE
chore: roll node to fix http2 memory leak

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@ vars = {
   'chromium_version':
     'f200986dfaabd6aad6a4b37dad7aae42fec349e9',
   'node_version':
-    '229bd3245b2f54c12ea9ad0abcadbc209f8023dc',
+    '0a300f60bce0c8f0cb3d846fcb0e1f55f26013ee',
   'nan_version':
     '960dd6c70fc9eb136efdf37b4bef18fadbc3436f',
 


### PR DESCRIPTION
Fixes #18817

Does what it says on the tin, was a clean cherry-pick

Notes: Backported [a patch](https://github.com/nodejs/node/commit/b84b4d8c7dc957dd630a66ee372c6f29e173e98d) from node that fixes an http/2 memory leak: 