### PR TITLE
test: correct fake tests in api-protocol-spec

### DIFF
--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -112,7 +112,7 @@ describe('protocol module', () => {
 
     it('sends error when callback is called with nothing', async () => {
       await registerBufferProtocol(protocolName, emptyHandler)
-      await expect(ajax(protocolName + '://fake-host')).to.be.eventually.rejectedWith(404)
+      await expect(ajax(protocolName + '://fake-host')).to.be.eventually.rejectedWith(Error, '404')
     })
 
     it('does not crash when callback is called in next tick', async () => {
@@ -159,11 +159,12 @@ describe('protocol module', () => {
       expect(r.data).to.equal(text)
     })
 
-    it('fails when sending object other than string', async () => {
-      const handler = (request, callback) => callback(new Date())
-      await registerStringProtocol(protocolName, handler)
-      expect(ajax(protocolName + '://fake-host')).to.be.eventually.rejectedWith(Error)
-    })
+    // TODO: fake test
+    // it.only('fails when sending object other than string', async () => {
+    //   const handler = (request, callback) => callback(new Date())
+    //   await registerStringProtocol(protocolName, handler)
+    //   expect(ajax(protocolName + '://fake-host')).to.be.eventually.rejectedWith(Error)
+    // })
   })
 
   describe('protocol.registerBufferProtocol', () => {
@@ -195,11 +196,12 @@ describe('protocol module', () => {
       expect(r.data).to.equal(text)
     })
 
-    it('fails when sending string', async () => {
-      const handler = (request, callback) => callback(text)
-      await registerBufferProtocol(protocolName, handler)
-      expect(ajax(protocolName + '://fake-host')).to.be.eventually.rejectedWith(Error)
-    })
+    // TODO: fake test
+    // it.only('fails when sending string', async () => {
+    //   const handler = (request, callback) => callback(text)
+    //   await registerBufferProtocol(protocolName, handler)
+    //   expect(ajax(protocolName + '://fake-host')).to.be.eventually.rejectedWith(Error)
+    // })
   })
 
   describe('protocol.registerFileProtocol', () => {
@@ -252,13 +254,13 @@ describe('protocol module', () => {
       const fakeFilePath = path.join(fixtures, 'asar', 'a.asar', 'not-exist')
       const handler = (request, callback) => callback(fakeFilePath)
       await registerFileProtocol(protocolName, handler)
-      await expect(ajax(protocolName + '://fake-host')).to.be.eventually.rejectedWith(404)
+      await expect(ajax(protocolName + '://fake-host')).to.be.eventually.rejectedWith(Error, '404')
     })
 
     it('fails when sending unsupported content', async () => {
       const handler = (request, callback) => callback(new Date())
       await registerFileProtocol(protocolName, handler)
-      await expect(ajax(protocolName + '://fake-host')).to.be.eventually.rejectedWith(404)
+      await expect(ajax(protocolName + '://fake-host')).to.be.eventually.rejectedWith(Error, '404')
     })
   })
 
@@ -282,13 +284,13 @@ describe('protocol module', () => {
     it('fails when sending invalid url', async () => {
       const handler = (request, callback) => callback({ url: 'url' })
       await registerHttpProtocol(protocolName, handler)
-      await expect(ajax(protocolName + '://fake-host')).to.be.eventually.rejectedWith(404)
+      await expect(ajax(protocolName + '://fake-host')).to.be.eventually.rejectedWith(Error, '404')
     })
 
     it('fails when sending unsupported content', async () => {
       const handler = (request, callback) => callback(new Date())
       await registerHttpProtocol(protocolName, handler)
-      await expect(ajax(protocolName + '://fake-host')).to.be.eventually.rejectedWith(404)
+      await expect(ajax(protocolName + '://fake-host')).to.be.eventually.rejectedWith(Error, '404')
     })
 
     it('works when target URL redirects', async () => {
@@ -478,7 +480,7 @@ describe('protocol module', () => {
 
     it('sends error when callback is called with nothing', async () => {
       await interceptStringProtocol('http', emptyHandler)
-      await expect(ajax('http://fake-host')).to.be.eventually.rejectedWith(404)
+      await expect(ajax('http://fake-host')).to.be.eventually.rejectedWith(Error, '404')
     })
   })
 

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -196,12 +196,11 @@ describe('protocol module', () => {
       expect(r.data).to.equal(text)
     })
 
-    // TODO: fake test
-    // it.only('fails when sending string', async () => {
-    //   const handler = (request, callback) => callback(text)
-    //   await registerBufferProtocol(protocolName, handler)
-    //   expect(ajax(protocolName + '://fake-host')).to.be.eventually.rejectedWith(Error)
-    // })
+    it('fails when sending string', async () => {
+      const handler = (request, callback) => callback(text)
+      await registerBufferProtocol(protocolName, handler)
+      await expect(ajax(protocolName + '://fake-host')).to.be.eventually.rejectedWith(Error, '404')
+    })
   })
 
   describe('protocol.registerFileProtocol', () => {

--- a/spec/api-protocol-spec.js
+++ b/spec/api-protocol-spec.js
@@ -159,12 +159,12 @@ describe('protocol module', () => {
       expect(r.data).to.equal(text)
     })
 
-    // TODO: fake test
-    // it.only('fails when sending object other than string', async () => {
-    //   const handler = (request, callback) => callback(new Date())
-    //   await registerStringProtocol(protocolName, handler)
-    //   expect(ajax(protocolName + '://fake-host')).to.be.eventually.rejectedWith(Error)
-    // })
+    it('fails when sending object other than string', async () => {
+      const notAString = () => {}
+      const handler = (request, callback) => callback(notAString)
+      await registerStringProtocol(protocolName, handler)
+      await expect(ajax(protocolName + '://fake-host')).to.be.eventually.rejectedWith(Error, '404')
+    })
   })
 
   describe('protocol.registerBufferProtocol', () => {

--- a/spec/fixtures/pages/jquery.html
+++ b/spec/fixtures/pages/jquery.html
@@ -12,7 +12,7 @@
         resolve({data, status: request.status, headers: request.getAllResponseHeaders()})
       }
       options.error = (xhr, errorType, error) => {
-        reject(error ? error : xhr.status)
+        reject(error ? error : new Error(`${xhr.status}`))
       }
       $.ajax(options)
     })


### PR DESCRIPTION
#### Description of Change
When I wrote tests for the protocol API in #18854, I came across some other protocol API tests which were expecting errors to be thrown. However, they werent testing anything because with or without errors, they succeeded. This PR corrects them to fail when no error is thrown.

cc @nornagon @codebytere @erickzhao 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
