### PR TITLE
fix: bundle swiftshader and ANGLE libraries on mac

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -21,6 +21,7 @@ import("filenames.gni")
 if (is_mac) {
   import("//build/config/mac/rules.gni")
   import("//third_party/icu/config.gni")
+  import("//ui/gl/features.gni")
   import("//v8/gni/v8.gni")
 }
 
@@ -651,6 +652,50 @@ if (is_mac) {
     group("electron_framework_libraries") {
     }
   }
+  if (use_egl) {
+    # Add the ANGLE .dylibs in the Libraries directory of the Framework.
+    bundle_data("electron_angle_binaries") {
+      sources = [
+        "$root_out_dir/egl_intermediates/libEGL.dylib",
+        "$root_out_dir/egl_intermediates/libGLESv2.dylib",
+      ]
+      outputs = [
+        "{{bundle_contents_dir}}/Libraries/{{source_file_part}}",
+      ]
+      public_deps = [
+        "//ui/gl:angle_library_copy",
+      ]
+    }
+
+    # Add the SwiftShader .dylibs in the Libraries directory of the Framework.
+    bundle_data("electron_swiftshader_binaries") {
+      sources = [
+        "$root_out_dir/egl_intermediates/libswiftshader_libEGL.dylib",
+        "$root_out_dir/egl_intermediates/libswiftshader_libGLESv2.dylib",
+      ]
+      outputs = [
+        "{{bundle_contents_dir}}/Libraries/{{source_file_part}}",
+      ]
+      public_deps = [
+        "//ui/gl:swiftshader_library_copy",
+      ]
+    }
+  }
+  group("electron_angle_library") {
+    if (use_egl) {
+      deps = [
+        ":electron_angle_binaries",
+      ]
+    }
+  }
+
+  group("electron_swiftshader_library") {
+    if (use_egl) {
+      deps = [
+        ":electron_swiftshader_binaries",
+      ]
+    }
+  }
 
   bundle_data("electron_crashpad_helper") {
     sources = [
@@ -677,8 +722,10 @@ if (is_mac) {
       ":electron_lib",
     ]
     deps = [
+      ":electron_angle_library",
       ":electron_framework_libraries",
       ":electron_framework_resources",
+      ":electron_swiftshader_library",
     ]
     if (!is_mas_build) {
       deps += [ ":electron_crashpad_helper" ]

--- a/script/dist_zip.mac.x64.manifest
+++ b/script/dist_zip.mac.x64.manifest
@@ -9,7 +9,11 @@ Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/
+Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libEGL.dylib
+Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libGLESv2.dylib
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libffmpeg.dylib
+Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libswiftshader_libEGL.dylib
+Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libswiftshader_libGLESv2.dylib
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/Info.plist
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/am.lproj/

--- a/script/dist_zip.mac_mas.x64.manifest
+++ b/script/dist_zip.mac_mas.x64.manifest
@@ -9,7 +9,11 @@ Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/
+Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libEGL.dylib
+Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libGLESv2.dylib
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libffmpeg.dylib
+Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libswiftshader_libEGL.dylib
+Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libswiftshader_libGLESv2.dylib
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/Info.plist
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/am.lproj/


### PR DESCRIPTION
#### Description of Change
Fixes #18639. Not sure what exactly caused this to start breaking now, but these libraries appeared in https://chromium-review.googlesource.com/c/chromium/src/+/955949/ and got enabled by default on mac here https://chromium-review.googlesource.com/c/chromium/src/+/1005017/. The call during gpu process startup that was causing this crash was added here https://chromium-review.googlesource.com/c/chromium/src/+/1599993.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed crash when starting with `--disable-gpu`.