### PR TITLE
ci: add a space at the end of NINJA_STATUS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ env-disable-crash-reporter-tests: &env-disable-crash-reporter-tests
   DISABLE_CRASH_REPORTER_TESTS: true
 
 env-ninja-status: &env-ninja-status
-  NINJA_STATUS: "[%r processes, %f/%t @ %o/s : %es]"
+  NINJA_STATUS: "[%r processes, %f/%t @ %o/s : %es] "
 
 # Individual (shared) steps.
 step-maybe-notify-slack-failure: &step-maybe-notify-slack-failure


### PR DESCRIPTION
#### Description of Change
<img width="445" alt="Continuous_Integration_and_Deployment" src="https://user-images.githubusercontent.com/172800/59727888-80292400-91ec-11e9-8e4c-124cd6438b6a.png">

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none