### PR TITLE
docs: missing instructions for installing electron in first-app.md

### DIFF
--- a/docs/tutorial/first-app.md
+++ b/docs/tutorial/first-app.md
@@ -88,6 +88,13 @@ Other means for installing Electron exist. Please consult the
 [installation guide](installation.md) to learn about use with proxies, mirrors,
 and custom caches.
 
+For the next section, you will **also** need to install `electron` globally. To do so,
+run the following command:
+
+```sh
+npm install -g electron
+```
+
 ## Electron Development in a Nutshell
 
 Electron apps are developed in JavaScript using the same principles and methods


### PR DESCRIPTION
#### Description of Change
The 'Electron Development in a Nutshell' section seems to require 
`electron` to be installed globally. I have added instructions to do 
so in the 'Installing Electron' section.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
