### PR TITLE
[wip] chore: make the C++ linter happy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -533,6 +533,11 @@ steps-lint: &steps-lint
 
           echo 'export CHROMIUM_BUILDTOOLS_PATH="'"$PWD"'/buildtools"' >> $BASH_ENV
     - run:
+        name: clang-format info
+        command: |
+          which clang-format
+          clang-format --version
+    - run:
         name: Run Lint
         command: |
           # gn.py tries to find a gclient root folder starting from the current dir.

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -99,13 +99,14 @@ namespace {
 void stop_and_close_uv_loop(uv_loop_t* loop) {
   // Close any active handles
   uv_stop(loop);
-  uv_walk(loop,
-          [](uv_handle_t* handle, void*) {
-            if (!uv_is_closing(handle)) {
-              uv_close(handle, nullptr);
-            }
-          },
-          nullptr);
+  uv_walk(
+      loop,
+      [](uv_handle_t* handle, void*) {
+        if (!uv_is_closing(handle)) {
+          uv_close(handle, nullptr);
+        }
+      },
+      nullptr);
 
   // Run the loop to let it finish all the closing handles
   // NB: after uv_stop(), uv_run(UV_RUN_DEFAULT) returns 0 when that's done

--- a/script/run-clang-format.py
+++ b/script/run-clang-format.py
@@ -104,7 +104,7 @@ def run_clang_format_diff(args, file_name):
             original = f.readlines()
     except IOError as exc:
         raise DiffError(str(exc))
-    invocation = [args.clang_format_executable, file_name]
+    invocation = [args.clang_format_executable, '--version']
     if args.fix:
         invocation.append('-i')
     try:


### PR DESCRIPTION
#### Description of Change
Related to #18687.

_The linter seems to be already happy =/_


```diff
node script/lint.js --cc
========================== Starting Command Output ===========================
[command]/bin/bash --noprofile --norc /Users/vsts/agent/2.153.2/work/_temp/0d18a97d-0216-4214-bf43-74cc8dbe3ffb.sh
--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -99,13 +99,14 @@
 void stop_and_close_uv_loop(uv_loop_t* loop) {
   // Close any active handles
   uv_stop(loop);
-  uv_walk(loop,
-          [](uv_handle_t* handle, void*) {
-            if (!uv_is_closing(handle)) {
-              uv_close(handle, nullptr);
-            }
-          },
-          nullptr);
+  uv_walk(
+      loop,
+      [](uv_handle_t* handle, void*) {
+        if (!uv_is_closing(handle)) {
+          uv_close(handle, nullptr);
+        }
+      },
+      nullptr);
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes