### PR TITLE
test: de-flake ses.protocol test

### DIFF
--- a/spec-main/api-session-spec.js
+++ b/spec-main/api-session-spec.js
@@ -265,7 +265,7 @@ describe('session module', () => {
     let customSession = null
     const protocol = session.defaultSession.protocol
     const handler = (ignoredError, callback) => {
-      callback({ data: 'test', mimeType: 'text/html' })
+      callback({ data: `<script>require('electron').ipcRenderer.send('hello')</script>`, mimeType: 'text/html' })
     }
 
     beforeEach(async () => {
@@ -273,7 +273,8 @@ describe('session module', () => {
       w = new BrowserWindow({
         show: false,
         webPreferences: {
-          partition: partitionName
+          partition: partitionName,
+          nodeIntegration: true,
         }
       })
       customSession = session.fromPartition(partitionName)
@@ -294,8 +295,8 @@ describe('session module', () => {
     })
 
     it('handles requests from partition', async () => {
-      await w.loadURL(`${protocolName}://fake-host`)
-      expect(await w.webContents.executeJavaScript('document.body.textContent')).to.equal('test')
+      w.loadURL(`${protocolName}://fake-host`)
+      await emittedOnce(ipcMain, 'hello')
     })
   })
 


### PR DESCRIPTION
#### Description of Change
My hypothesis here is that `executeJavaScript` was occasionally running at a weird time, possibly throwing some sort of error. Hopefully this approach using ipc will be a bit more robust.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none