### PR TITLE
fix: building with enable_run_as_node disabled

### DIFF
--- a/atom/common/crash_reporter/crash_reporter.cc
+++ b/atom/common/crash_reporter/crash_reporter.cc
@@ -25,8 +25,13 @@ const char kCrashpadProcess[] = "crash-handler";
 const char kCrashesDirectoryKey[] = "crashes-directory";
 
 CrashReporter::CrashReporter() {
-  std::unique_ptr<base::Environment> env = base::Environment::Create();
-  if (env->HasVar(atom::kRunAsNode)) {
+#if BUILDFLAG(ENABLE_RUN_AS_NODE)
+  bool run_as_node = base::Environment::Create()->HasVar(atom::kRunAsNode);
+#else
+  bool run_as_node = false;
+#endif
+
+  if (run_as_node) {
     process_type_ = "node";
   } else {
     auto* cmd = base::CommandLine::ForCurrentProcess();


### PR DESCRIPTION
#### Description of Change
Fix `error: no member named 'kRunAsNode' in namespace 'atom'`. Regressed in #18483.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed building with `enable_run_as_node` disabled.