### PR TITLE
docs: Document our existing language policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,18 @@ the issue will be closed.
   * If an issue has been closed and you still feel it's relevant, feel free to
   ping a maintainer or add a comment!
 
+### Languages
+
+We accept issues in *any* language.
+When an issue is posted in a language besides english, it is acceptable and encouraged to post an english-translated copy as a reply. 
+Anyone may post the translated reply.
+In most cases, a quick pass through translation software is sufficient.
+Having the original text _as well as_ the translation can help mitigate translation errors.
+
+Responses to posted issues may or may not be in the original language.
+
+**Please note** that using non-english as an attempt to circumvent our [Code of Conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) will be an immediate, and possibly indefinite, ban from the project.
+
 ## [Pull Requests](https://electronjs.org/docs/development/pull-requests)
 
 Pull Requests are the way concrete changes are made to the code, documentation,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Having the original text _as well as_ the translation can help mitigate translat
 
 Responses to posted issues may or may not be in the original language.
 
-**Please note** that using non-english as an attempt to circumvent our [Code of Conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) will be an immediate, and possibly indefinite, ban from the project.
+**Please note** that using non-English as an attempt to circumvent our [Code of Conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) will be an immediate, and possibly indefinite, ban from the project.
 
 ## [Pull Requests](https://electronjs.org/docs/development/pull-requests)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ the issue will be closed.
 ### Languages
 
 We accept issues in *any* language.
-When an issue is posted in a language besides english, it is acceptable and encouraged to post an english-translated copy as a reply. 
+When an issue is posted in a language besides English, it is acceptable and encouraged to post an English-translated copy as a reply. 
 Anyone may post the translated reply.
 In most cases, a quick pass through translation software is sufficient.
 Having the original text _as well as_ the translation can help mitigate translation errors.


### PR DESCRIPTION
Often we receive issues posted in languages other than English. There has been debate about whether or not this is acceptable.

While the maintainers have had an informal policy to accept issues in any language, it has not been documented.

This represents our current informal policy.

#### Release Notes
Notes: no-notes