### PR TITLE
fix: app.getAppPath() returning default-app path when no package.json found

### DIFF
--- a/default_app/main.js
+++ b/default_app/main.js
@@ -86,6 +86,7 @@ function loadApplicationPackage (packagePath) {
     // Override app name and version.
     packagePath = path.resolve(packagePath)
     const packageJsonPath = path.join(packagePath, 'package.json')
+    let appPath
     if (fs.existsSync(packageJsonPath)) {
       let packageJson
       try {
@@ -105,11 +106,12 @@ function loadApplicationPackage (packagePath) {
       }
       app.setPath('userData', path.join(app.getPath('appData'), app.getName()))
       app.setPath('userCache', path.join(app.getPath('cache'), app.getName()))
-      app.setAppPath(packagePath)
+      appPath = packagePath
     }
 
     try {
-      Module._resolveFilename(packagePath, module, true)
+      const filePath = Module._resolveFilename(packagePath, module, true)
+      app.setAppPath(appPath || path.dirname(filePath))
     } catch (e) {
       showErrorMessage(`Unable to find Electron app at ${packagePath}\n\n${e.message}`)
       return

--- a/spec/fixtures/api/app-path/lib/index.js
+++ b/spec/fixtures/api/app-path/lib/index.js
@@ -1,0 +1,10 @@
+const { app } = require('electron')
+
+const payload = {
+  appPath: app.getAppPath()
+}
+
+process.stdout.write(JSON.stringify(payload))
+process.stdout.end()
+
+process.exit()

--- a/spec/fixtures/api/app-path/package.json
+++ b/spec/fixtures/api/app-path/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "app-path",
+  "main": "lib/index.js"
+}


### PR DESCRIPTION
#### Description of Change
Backport of #18763

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed `app.getAppPath()` returning default-app path when running `electron app` with no package.json or `electron app/index.js`. Now the directory containing the executed file is returned.