### PR TITLE
refactor: session.{clearCache,getCacheSize} nws13n

### DIFF
--- a/atom/browser/api/atom_api_session.h
+++ b/atom/browser/api/atom_api_session.h
@@ -66,6 +66,7 @@ class Session : public mate::TrackableObject<Session>,
                     const ResolveProxyHelper::ResolveProxyCallback& callback);
   template <CacheAction action>
   void DoCacheAction(const net::CompletionCallback& callback);
+  void GetCacheSize(const net::CompletionCallback& callback);
   void ClearStorageData(mate::Arguments* args);
   void FlushStorageData();
   void SetProxy(const mate::Dictionary& options, const base::Closure& callback);


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/17189.

Backport of https://github.com/electron/electron/pull/17969. We haven't promisified this in 5 so this is a callbackified version of that PR.

cc @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix an issue where `session.getCacheSize` would never call its callback.
