### PR TITLE
chore: use manual invocation of npx yarn

### DIFF
--- a/vsts-arm-test-steps.yml
+++ b/vsts-arm-test-steps.yml
@@ -6,7 +6,7 @@ steps:
 
 - bash: |
     cd src/electron
-    npm install --verbose
+    npx yarn@1.15.2 install --frozen-lockfile --verbose
   displayName: 'NPM install'
 
 - bash: |
@@ -58,7 +58,7 @@ steps:
     cd src
     export npm_config_nodedir=$PWD/out/Default/gen/node_headers
     cd electron/spec
-    npm install --verbose
+    npx yarn@1.15.2 install --frozen-lockfile --verbose
   displayName: Install test modules
 
 - bash: |

--- a/vsts-arm-test-steps.yml
+++ b/vsts-arm-test-steps.yml
@@ -6,8 +6,8 @@ steps:
 
 - bash: |
     cd src/electron
-    node script/yarn.js install --frozen-lockfile
-  displayName: 'Yarn install'
+    npm install --verbose
+  displayName: 'NPM install'
 
 - bash: |
     export ZIP_DEST=$PWD/src/out/Default
@@ -58,7 +58,7 @@ steps:
     cd src
     export npm_config_nodedir=$PWD/out/Default/gen/node_headers
     cd electron/spec
-    node ../script/yarn.js install --frozen-lockfile
+    npm install --verbose
   displayName: Install test modules
 
 - bash: |


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
#18779 was backported to 6-0-x, and 5-0-x, but the script it was using does not exist in 6-0-x or 5-0-x.  This PR fixes arm testing in 6-0-x by performing npx yarn manually.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
