### PR TITLE
feat: add stack trace log to preload script error handling

### DIFF
--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -197,8 +197,7 @@ for (const preloadScript of preloadScripts) {
     Module._load(preloadScript)
   } catch (error) {
     console.error(`Unable to load preload script: ${preloadScript}`)
-    console.error(`${error}`)
-    console.trace();
+    console.error(error)
 
     ipcRendererInternal.send('ELECTRON_BROWSER_PRELOAD_ERROR', preloadScript, errorUtils.serialize(error))
   }

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -198,6 +198,7 @@ for (const preloadScript of preloadScripts) {
   } catch (error) {
     console.error(`Unable to load preload script: ${preloadScript}`)
     console.error(`${error}`)
+    console.trace();
 
     ipcRendererInternal.send('ELECTRON_BROWSER_PRELOAD_ERROR', preloadScript, errorUtils.serialize(error))
   }

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -166,7 +166,7 @@ for (const { preloadPath, preloadSrc, preloadError } of preloadScripts) {
     }
   } catch (error) {
     console.error(`Unable to load preload script: ${preloadPath}`)
-    console.error(`${error}`)
+    console.error(error)
 
     ipcRendererInternal.send('ELECTRON_BROWSER_PRELOAD_ERROR', preloadPath, errorUtils.serialize(error))
   }


### PR DESCRIPTION
#### Description of Change
Adds `console.trace` to log the stack trace when intercepting errors in preload scripts. Resolves #18901.

#### Checklist
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: no-notes
