### PR TITLE
chore: fix branch trimming for blast-off releases

### DIFF
--- a/script/lib/utils.js
+++ b/script/lib/utils.js
@@ -26,8 +26,7 @@ function getAbsoluteElectronExec () {
 async function handleGitCall (args, gitDir) {
   const details = await GitProcess.exec(args, gitDir)
   if (details.exitCode === 0) {
-    const output = details.stdout.replace(/^\*|\s+|\s+$/, '')
-    return output.trim()
+    return details.stdout.replace(/^\*|\s+|\s+$/, '')
   } else {
     const error = GitProcess.parseError(details.stderr)
     console.log(`${fail} couldn't parse git process call: `, error)
@@ -46,7 +45,7 @@ async function getCurrentBranch (gitDir) {
       process.exit(1)
     }
   }
-  return branch
+  return branch.trim()
 }
 
 module.exports = {


### PR DESCRIPTION
Fixes branch trimming on blasted releases.

Before: `'  4-2-x'`
After: `4-2-x`

cc @MarshallOfSound 

Notes: none
