### PR TITLE
docs: fix spelling and grammar errors

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -122,7 +122,7 @@ Returns:
 * `url` String
 
 Emitted when the user wants to open a URL with the application. Your application's
-`Info.plist` file must define the url scheme within the `CFBundleURLTypes` key, and
+`Info.plist` file must define the URL scheme within the `CFBundleURLTypes` key, and
 set `NSPrincipalClass` to `AtomApplication`.
 
 You should call `event.preventDefault()` if you want to handle this event.
@@ -354,7 +354,7 @@ Returns:
 * `event` Event
 * `killed` Boolean
 
-Emitted when the gpu process crashes or is killed.
+Emitted when the GPU process crashes or is killed.
 
 ### Event: 'renderer-process-crashed'
 
@@ -582,7 +582,7 @@ them.
 
 Sets or creates a directory your app's logs which can then be manipulated with `app.getPath()` or `app.setPath(pathName, newPath)`.
 
-On _macOS_, this directory will be set by deafault to `/Library/Logs/YourAppName`, and on _Linux_ and _Windows_ it will be placed inside your `userData` directory.
+On _macOS_, this directory will be set by default to `/Library/Logs/YourAppName`, and on _Linux_ and _Windows_ it will be placed inside your `userData` directory.
 
 ### `app.getAppPath()`
 
@@ -662,7 +662,7 @@ executable is returned.
 Returns `String` - The current application's name, which is the name in the application's
 `package.json` file.
 
-Usually the `name` field of `package.json` is a short lowercased name, according
+Usually the `name` field of `package.json` is a short lowercase name, according
 to the npm modules spec. You should usually also specify a `productName`
 field, which is your application's full capitalized name, and which will be
 preferred over `name` by Electron.
@@ -772,7 +772,7 @@ The API uses the Windows Registry and LSCopyDefaultHandlerForURLScheme internall
 
 * `tasks` [Task[]](structures/task.md) - Array of `Task` objects
 
-Adds `tasks` to the [Tasks][tasks] category of the JumpList on Windows.
+Adds `tasks` to the [Tasks][tasks] category of the Jump List on Windows.
 
 `tasks` is an array of [`Task`](structures/task.md) objects.
 
@@ -1013,7 +1013,7 @@ This method can only be called before app is ready.
 
 ### `app.getAppMetrics()`
 
-Returns [`ProcessMetric[]`](structures/process-metric.md): Array of `ProcessMetric` objects that correspond to memory and cpu usage statistics of all the processes associated with the app.
+Returns [`ProcessMetric[]`](structures/process-metric.md): Array of `ProcessMetric` objects that correspond to memory and CPU usage statistics of all the processes associated with the app.
 
 ### `app.getGPUFeatureStatus()`
 
@@ -1294,7 +1294,7 @@ A `Boolean` property that returns  `true` if the app is packaged, `false` otherw
 
 A `String` property that indicates the current application's name, which is the name in the application's `package.json` file.
 
-Usually the `name` field of `package.json` is a short lowercased name, according
+Usually the `name` field of `package.json` is a short lowercase name, according
 to the npm modules spec. You should usually also specify a `productName`
 field, which is your application's full capitalized name, and which will be
 preferred over `name` by Electron.

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -12,7 +12,7 @@ The `FIXME` string is used in code comments to denote things that should be fixe
 
 This is the URL specified as `disturl` in a `.npmrc` file or as the `--dist-url`
 command line flag when building native Node modules.  Both will be supported for
-the forseeable future but it is reccomened that you switch.
+the foreseeable future but it is recommended that you switch.
 
 Deprecated: https://atom.io/download/electron
 
@@ -524,7 +524,7 @@ to clarify to users which ARM version it supports, and to disambiguate it from
 future armv6l and arm64 assets that may be produced.
 
 The file _without the prefix_ is still being published to avoid breaking any
-setups that may be consuming it. Starting at 2.0, the un-prefixed file will
+setups that may be consuming it. Starting at 2.0, the unprefixed file will
 no longer be published.
 
 For details, see

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -84,9 +84,9 @@ Returns `Boolean` - Whether the view is destroyed.
   * `height` Boolean - If `true`, the view's height will grow and shrink
     together with the window. `false` by default.
   * `horizontal` Boolean - If `true`, the view's x position and width will grow
-    and shrink proportionly with the window. `false` by default.
+    and shrink proportionally with the window. `false` by default.
   * `vertical` Boolean - If `true`, the view's y position and height will grow
-    and shrink proportinaly with the window. `false` by default.
+    and shrink proportionally with the window. `false` by default.
 
 #### `view.setBounds(bounds)` _Experimental_
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -256,7 +256,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       enabled in web workers. Default is `false`. More about this can be found
       in [Multithreading](../tutorial/multithreading.md).
     * `nodeIntegrationInSubFrames` Boolean (optional) - Experimental option for
-      enabling NodeJS support in sub-frames such as iframes. All your preloads will load for
+      enabling Node.js support in sub-frames such as iframes. All your preloads will load for
       every iframe, you can use `process.isMainFrame` to determine if you are
       in the main frame or not.
     * `preload` String (optional) - Specifies a script that will be loaded before other
@@ -418,7 +418,7 @@ Returns:
 
 Emitted when the document changed its title, calling `event.preventDefault()`
 will prevent the native window's title from changing.
-`explicitSet` is false when title is synthesized from file url.
+`explicitSet` is false when title is synthesized from file URL.
 
 #### Event: 'close'
 
@@ -1257,11 +1257,11 @@ Captures a snapshot of the page within `rect`. Omitting `rect` will capture the 
 
 * `url` String
 * `options` Object (optional)
-  * `httpReferrer` (String | [Referrer](structures/referrer.md)) (optional) - An HTTP Referrer url.
+  * `httpReferrer` (String | [Referrer](structures/referrer.md)) (optional) - An HTTP Referrer URL.
   * `userAgent` String (optional) - A user agent originating the request.
   * `extraHeaders` String (optional) - Extra headers separated by "\n"
   * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadBlob[]](structures/upload-blob.md)) (optional)
-  * `baseURLForDataURL` String (optional) - Base url (with trailing path separator) for files to be loaded by the data url. This is needed only if the specified `url` is a data url and needs to load other files.
+  * `baseURLForDataURL` String (optional) - Base URL (with trailing path separator) for files to be loaded by the data URL. This is needed only if the specified `url` is a data URL and needs to load other files.
 
 Returns `Promise<void>` - the promise will resolve when the page has finished loading
 (see [`did-finish-load`](web-contents.md#event-did-finish-load)), and rejects

--- a/docs/api/chrome-command-line-switches.md
+++ b/docs/api/chrome-command-line-switches.md
@@ -46,14 +46,14 @@ Forces the maximum disk space to be used by the disk cache, in bytes.
 
 ## --js-flags=`flags`
 
-Specifies the flags passed to the Node JS engine. It has to be passed when starting
+Specifies the flags passed to the Node.js engine. It has to be passed when starting
 Electron if you want to enable the `flags` in the main process.
 
 ```sh
 $ electron --js-flags="--harmony_proxies --harmony_collections" your-app
 ```
 
-See the [Node documentation][node-cli] or run `node --help` in your terminal for a list of available flags. Additionally, run `node --v8-options` to see a list of flags that specifically refer to Node's V8 JavaScript engine.
+See the [Node.js documentation][node-cli] or run `node --help` in your terminal for a list of available flags. Additionally, run `node --v8-options` to see a list of flags that specifically refer to Node.js's V8 JavaScript engine.
 
 ## --proxy-server=`address:port`
 
@@ -122,12 +122,12 @@ For example:
 ```
 
 then any `url` ending with `example.com`, `foobar.com`, `baz` will be considered
-for integrated authentication. Without `*` prefix the url has to match exactly.
+for integrated authentication. Without `*` prefix the URL has to match exactly.
 
 ## --auth-negotiate-delegate-whitelist=`url`
 
 A comma-separated list of servers for which delegation of user credentials is required.
-Without `*` prefix the url has to match exactly.
+Without `*` prefix the URL has to match exactly.
 
 ## --ignore-certificate-errors
 

--- a/docs/api/client-request.md
+++ b/docs/api/client-request.md
@@ -160,7 +160,7 @@ internally buffered inside Electron process memory.
 * `name` String - An extra HTTP header name.
 * `value` Object - An extra HTTP header value.
 
-Adds an extra HTTP header. The header name will issued as it is without
+Adds an extra HTTP header. The header name will be issued as-is without
 lowercasing. It can be called only before first write. Calling this method after
 the first write will throw an error. If the passed value is not a `String`, its
 `toString()` method will be called to obtain the final value.

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -172,7 +172,7 @@ Writes the `buffer` into the clipboard as `format`.
   * `html` String (optional)
   * `image` [NativeImage](native-image.md) (optional)
   * `rtf` String (optional)
-  * `bookmark` String (optional) - The title of the url at `text`.
+  * `bookmark` String (optional) - The title of the URL at `text`.
 * `type` String (optional) - Can be `selection` or `clipboard`. `selection` is only available on Linux.
 
 ```javascript

--- a/docs/api/cookies.md
+++ b/docs/api/cookies.md
@@ -68,7 +68,7 @@ The following methods are available on instances of `Cookies`:
 
 * `filter` Object
   * `url` String (optional) - Retrieves cookies which are associated with
-    `url`. Empty implies retrieving cookies of all urls.
+    `url`. Empty implies retrieving cookies of all URLs.
   * `name` String (optional) - Filters cookies by name.
   * `domain` String (optional) - Retrieves cookies whose domains match or are
     subdomains of `domains`.
@@ -84,7 +84,7 @@ the response.
 #### `cookies.set(details)`
 
 * `details` Object
-  * `url` String - The url to associate the cookie with. The promise will be rejected if the url is invalid.
+  * `url` String - The URL to associate the cookie with. The promise will be rejected if the URL is invalid.
   * `name` String (optional) - The name of the cookie. Empty by default if omitted.
   * `value` String (optional) - The value of the cookie. Empty by default if omitted.
   * `domain` String (optional) - The domain of the cookie; this will be normalized with a preceding dot so that it's also valid for subdomains. Empty by default if omitted.

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -51,7 +51,7 @@ The `crashReporter` module has the following methods:
   * `extra` Object (optional) - An object you can define that will be sent along with the
     report. Only string properties are sent correctly. Nested objects are not
     supported. When using Windows, the property names and values must be fewer than 64 characters.
-  * `crashesDirectory` String (optional) - Directory to store the crashreports temporarily (only used when the crash reporter is started via `process.crashReporter.start`).
+  * `crashesDirectory` String (optional) - Directory to store the crash reports temporarily (only used when the crash reporter is started via `process.crashReporter.start`).
 
 You are required to call this method before using any other `crashReporter` APIs
 and in each process (main/renderer) from which you want to collect crash reports.

--- a/docs/api/download-item.md
+++ b/docs/api/download-item.md
@@ -125,7 +125,7 @@ Cancels the download operation.
 
 #### `downloadItem.getURL()`
 
-Returns `String` - The origin url where the item is downloaded from.
+Returns `String` - The origin URL where the item is downloaded from.
 
 #### `downloadItem.getMimeType()`
 
@@ -167,7 +167,7 @@ Returns `String` - The current state. Can be `progressing`, `completed`, `cancel
 
 #### `downloadItem.getURLChain()`
 
-Returns `String[]` - The complete url chain of the item including any redirects.
+Returns `String[]` - The complete URL chain of the item including any redirects.
 
 #### `downloadItem.getLastModifiedTime()`
 

--- a/docs/api/structures/cpu-usage.md
+++ b/docs/api/structures/cpu-usage.md
@@ -2,6 +2,6 @@
 
 * `percentCPUUsage` Number - Percentage of CPU used since the last call to getCPUUsage.
   First call returns 0.
-* `idleWakeupsPerSecond` Number - The number of average idle cpu wakeups per second
+* `idleWakeupsPerSecond` Number - The number of average idle CPU wakeups per second
   since the last call to getCPUUsage. First call returns 0. Will always return 0 on
   Windows.

--- a/docs/api/structures/ipc-main-event.md
+++ b/docs/api/structures/ipc-main-event.md
@@ -1,7 +1,7 @@
 # IpcMainEvent Object extends `Event`
 
 * `frameId` Integer - The ID of the renderer frame that sent this message
-* `returnValue` any - Set this to the value to be returned in a syncronous message
+* `returnValue` any - Set this to the value to be returned in a synchronous message
 * `sender` WebContents - Returns the `webContents` that sent the message
-* `reply` Function - A function that will send an IPC message to the renderer frame that sent the original message that you are currently handling.  You should use this method to "reply" to the sent message in order to guaruntee the reply will go to the correct process and frame.
+* `reply` Function - A function that will send an IPC message to the renderer frame that sent the original message that you are currently handling.  You should use this method to "reply" to the sent message in order to guarantee the reply will go to the correct process and frame.
   * `...args` any[]

--- a/docs/api/structures/trace-config.md
+++ b/docs/api/structures/trace-config.md
@@ -21,7 +21,7 @@
   with the trace.
 * `memory_dump_config` Object (optional) - if the
   `disabled-by-default-memory-infra` category is enabled, this contains
-  optional additional configuration for data callection. See the [Chromium
+  optional additional configuration for data collection. See the [Chromium
   memory-infra docs][memory-infra docs] for more information.
 
 An example TraceConfig that roughly matches what Chrome DevTools records:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -168,7 +168,7 @@ is very likely you are using the module in the wrong process. For example
 `electron.app` can only be used in the main process, while `electron.webFrame`
 is only available in renderer processes.
 
-## The font looks blurry, what is this and what can i do?
+## The font looks blurry, what is this and what can I do?
 
 If [sub-pixel anti-aliasing](http://alienryderflex.com/sub_pixel/) is deactivated, then fonts on LCD screens can look blurry. Example:
 
@@ -185,7 +185,7 @@ let win = new BrowserWindow({
 })
 ```
 
-The effect is visible only on (some?) LCD screens. Even if you dont see a difference, some of your users may. It is best to always set the background this way, unless you have reasons not to do so.
+The effect is visible only on (some?) LCD screens. Even if you don't see a difference, some of your users may. It is best to always set the background this way, unless you have reasons not to do so.
 
 Notice that just setting the background in the CSS does not have the desired effect.
 

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -1,4 +1,4 @@
-# Electron Documentation Styleguide
+# Electron Documentation Style Guide
 
 These are the guidelines for writing Electron documentation.
 

--- a/docs/tutorial/automated-testing-with-a-custom-driver.md
+++ b/docs/tutorial/automated-testing-with-a-custom-driver.md
@@ -2,7 +2,7 @@
 
 To write automated tests for your Electron app, you will need a way to "drive" your application. [Spectron](https://electronjs.org/spectron) is a commonly-used solution which lets you emulate user actions via [WebDriver](http://webdriver.io/). However, it's also possible to write your own custom driver using node's builtin IPC-over-STDIO. The benefit of a custom driver is that it tends to require less overhead than Spectron, and lets you expose custom methods to your test suite.
 
-To create a custom driver, we'll use nodejs' [child_process](https://nodejs.org/api/child_process.html) API. The test suite will spawn the Electron process, then establish a simple messaging protocol:
+To create a custom driver, we'll use Node.js' [child_process](https://nodejs.org/api/child_process.html) API. The test suite will spawn the Electron process, then establish a simple messaging protocol:
 
 ```js
 var childProcess = require('child_process')
@@ -22,7 +22,7 @@ appProcess.on('message', (msg) => {
 appProcess.send({ my: 'message' })
 ```
 
-From within the Electron app, you can listen for messages and send replies using the nodejs [process](https://nodejs.org/api/process.html) API:
+From within the Electron app, you can listen for messages and send replies using the Node.js [process](https://nodejs.org/api/process.html) API:
 
 ```js
 // listen for IPC messages from the test suite

--- a/docs/tutorial/boilerplates-and-clis.md
+++ b/docs/tutorial/boilerplates-and-clis.md
@@ -1,6 +1,6 @@
 # Boilerplates and CLIs
 
-Electron development is un-opinionated - there is no "one true way" to develop,
+Electron development is unopinionated - there is no "one true way" to develop,
 build, package, or release an Electron application. Additional features for
 Electron, both for build- and run-time, can usually be found on
 [npm](https://www.npmjs.com/search?q=electron) in individual packages, allowing developers to build both

--- a/docs/tutorial/testing-on-headless-ci.md
+++ b/docs/tutorial/testing-on-headless-ci.md
@@ -14,13 +14,13 @@ It's a virtual framebuffer, implementing the X11 display server protocol -
 it performs all graphical operations in memory without showing any screen output,
 which is exactly what we need.
 
-Then, create a virtual xvfb screen and export an environment variable
+Then, create a virtual Xvfb screen and export an environment variable
 called DISPLAY that points to it. Chromium in Electron will automatically look
 for `$DISPLAY`, so no further configuration of your app is required.
 This step can be automated with Paul Betts's
 [xvfb-maybe](https://github.com/paulcbetts/xvfb-maybe): Prepend your test
 commands with `xvfb-maybe` and the little tool will automatically configure
-xvfb, if required by the current system. On Windows or macOS, it will
+Xvfb, if required by the current system. On Windows or macOS, it will
 do nothing.
 
 ```sh
@@ -51,8 +51,8 @@ For Jenkins, a [Xvfb plugin is available](https://wiki.jenkins-ci.org/display/JE
 
 ### Circle CI
 
-Circle CI is awesome and has xvfb and `$DISPLAY`
-[already setup, so no further configuration is required](https://circleci.com/docs/environment#browsers).
+Circle CI is awesome and has Xvfb and `$DISPLAY`
+[already set up, so no further configuration is required](https://circleci.com/docs/environment#browsers).
 
 ### AppVeyor
 


### PR DESCRIPTION
#### Description of Change

Fixes some documentation typos and capitalization errors. Inspired by #18899, which got me wondering if a spellchecker could sniff out any other errors in the docs.

What's changed:
 * Fixed some spelling errors (e.g. 'reccomened' -> 'recommended')
 * Capitalization for some acronyms (e.g. 'cpu' -> 'CPU')
 * Prefer 'Node.js' over 'nodejs'

The tool I used (mdspell) had trouble with some of our docs and so this is a low-hanging-fruit PR and not a complete scan.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes