### PR TITLE
fix: throw error on invalid URLs when setting cookie

### DIFF
--- a/atom/browser/api/atom_api_cookies.cc
+++ b/atom/browser/api/atom_api_cookies.cc
@@ -195,13 +195,13 @@ void FlushCookieStoreOnIOThread(
 void SetCookieOnIO(scoped_refptr<net::URLRequestContextGetter> getter,
                    std::unique_ptr<base::DictionaryValue> details,
                    const Cookies::SetCallback& callback) {
-  std::string url, name, value, domain, path;
+  std::string url_string, name, value, domain, path;
   bool secure = false;
   bool http_only = false;
   double creation_date;
   double expiration_date;
   double last_access_date;
-  details->GetString("url", &url);
+  details->GetString("url", &url_string);
   details->GetString("name", &name);
   details->GetString("value", &value);
   details->GetString("domain", &domain);
@@ -229,22 +229,22 @@ void SetCookieOnIO(scoped_refptr<net::URLRequestContextGetter> getter,
                            ? base::Time::UnixEpoch()
                            : base::Time::FromDoubleT(last_access_date);
   }
-
-  std::unique_ptr<net::CanonicalCookie> canonical_cookie(
-      net::CanonicalCookie::CreateSanitizedCookie(
-          GURL(url), name, value, domain, path, creation_time, expiration_time,
-          last_access_time, secure, http_only,
-          net::CookieSameSite::DEFAULT_MODE, net::COOKIE_PRIORITY_DEFAULT));
   auto completion_callback = base::BindOnce(OnSetCookie, callback);
-  if (!canonical_cookie || !canonical_cookie->IsCanonical()) {
-    std::move(completion_callback).Run(false);
-    return;
-  }
-  if (url.empty()) {
+  GURL url(url_string);
+  if (!url.is_valid()) {
     std::move(completion_callback).Run(false);
     return;
   }
   if (name.empty()) {
+    std::move(completion_callback).Run(false);
+    return;
+  }
+  std::unique_ptr<net::CanonicalCookie> canonical_cookie(
+      net::CanonicalCookie::CreateSanitizedCookie(
+          url, name, value, domain, path, creation_time, expiration_time,
+          last_access_time, secure, http_only,
+          net::CookieSameSite::DEFAULT_MODE, net::COOKIE_PRIORITY_DEFAULT));
+  if (!canonical_cookie || !canonical_cookie->IsCanonical()) {
     std::move(completion_callback).Run(false);
     return;
   }

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -91,9 +91,28 @@ describe('session module', () => {
       })
     })
 
+    it('sets cookies', (done) => {
+      const { cookies } = session.defaultSession
+      const name = '1'
+      const value = '1'
+      cookies.set({ url, name, value }, (error, list) => done(error))
+    })
+
     it('calls back with an error when setting a cookie with missing required fields', (done) => {
       session.defaultSession.cookies.set({
         url: '',
+        name: '1',
+        value: '1'
+      }, (error) => {
+        assert(error, 'Should have an error')
+        assert.strictEqual(error.message, 'Setting cookie failed')
+        done()
+      })
+    })
+
+    it('yields an error when setting a cookie with an invalid URL', (done) => {
+      session.defaultSession.cookies.set({
+        url: 'asdf',
         name: '1',
         value: '1'
       }, (error) => {

--- a/spec/api-session-spec.js
+++ b/spec/api-session-spec.js
@@ -91,13 +91,6 @@ describe('session module', () => {
       })
     })
 
-    it('sets cookies', (done) => {
-      const { cookies } = session.defaultSession
-      const name = '1'
-      const value = '1'
-      cookies.set({ url, name, value }, (error, list) => done(error))
-    })
-
     it('calls back with an error when setting a cookie with missing required fields', (done) => {
       session.defaultSession.cookies.set({
         url: '',


### PR DESCRIPTION
#### Description of Change
Backport of #18756
See that PR for details.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added check for invalid URLs upon setting cookies
