### PR TITLE
feat: app.moveToApplicationsFolder conflict handling

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1248,11 +1248,11 @@ For example:
 ```js
 app.moveToApplicationsFolder(conflictType => {
   if (conflictType === 'exists') {
-    dialog.showMessageBox({
-    type: 'question',
-    buttons: ['Halt Move', 'Continue Move'],
-    defaultId: 0,
-    message: 'An app of this name already exists',
+    dialog.showMessageBoxSync({
+      type: 'question',
+      buttons: ['Halt Move', 'Continue Move'],
+      defaultId: 0,
+      message: 'An app of this name already exists'
     }, response => response)
   }
 })

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1223,7 +1223,10 @@ This method can only be called before app is ready.
 Returns `Boolean` - Whether the application is currently running from the
 systems Application folder. Use in combination with `app.moveToApplicationsFolder()`
 
-### `app.moveToApplicationsFolder()` _macOS_
+### `app.moveToApplicationsFolder([handler])` _macOS_
+
+* `handler` Function (optional) - A handler for potential conflict in move failure.
+  * `conflictType` String - the type of move conflict encountered by the handler; can be `exists` or `existsAndRunning`, where `exists` means that an app of the same name is present in the Applications directory and `existsAndRunning` means both that it exists and that it's presently running.
 
 Returns `Boolean` - Whether the move was successful. Please note that if
 the move is successful, your application will quit and relaunch.
@@ -1236,7 +1239,26 @@ the user to confirm the operation, you may do so using the
 move to fail. For instance if the user cancels the authorization dialog, this
 method returns false. If we fail to perform the copy, then this method will
 throw an error. The message in the error should be informative and tell
-you exactly what went wrong
+you exactly what went wrong.
+
+By default, if an app of the same name as the one being moved exists in the Applications directory and is _not_ running, the existing app will be trashed and the active app moved into its place. If it _is_ running, the pre-existing running app will assume focus and the the previously active app will quit itself. This behavior can be changed by invoking the optional callback handler, where the boolean returned by the handler determines whether or not the move proceeds with its default behavior.
+
+For example:
+
+```js
+app.moveToApplicationsFolder(conflictType => {
+  if (conflictType === 'exists') {
+    dialog.showMessageBox({
+    type: 'question',
+    buttons: ['Halt Move', 'Continue Move'],
+    defaultId: 0,
+    message: 'An app of this name already exists',
+    }, response => response)
+  }
+})
+```
+
+Would mean that if an app already exists in the user directory, if the user chooses to 'Continue Move' then the function would continue with its default behavior and the existing app will be trashed and the active app moved into its place.
 
 ## Properties
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1226,7 +1226,7 @@ systems Application folder. Use in combination with `app.moveToApplicationsFolde
 ### `app.moveToApplicationsFolder([options])` _macOS_
 
 * `options` Object (optional)
-  * `conflictHandler` Function (optional) - A handler for potential conflict in move failure.
+  * `conflictHandler` Function<Boolean> (optional) - A handler for potential conflict in move failure.
     * `conflictType` String - the type of move conflict encountered by the handler; can be `exists` or `existsAndRunning`, where `exists` means that an app of the same name is present in the Applications directory and `existsAndRunning` means both that it exists and that it's presently running.
 
 Returns `Boolean` - Whether the move was successful. Please note that if
@@ -1242,7 +1242,7 @@ method returns false. If we fail to perform the copy, then this method will
 throw an error. The message in the error should be informative and tell
 you exactly what went wrong.
 
-By default, if an app of the same name as the one being moved exists in the Applications directory and is _not_ running, the existing app will be trashed and the active app moved into its place. If it _is_ running, the pre-existing running app will assume focus and the the previously active app will quit itself. This behavior can be changed by invoking the optional callback handler, where the boolean returned by the handler determines whether or not the move proceeds with its default behavior.
+By default, if an app of the same name as the one being moved exists in the Applications directory and is _not_ running, the existing app will be trashed and the active app moved into its place. If it _is_ running, the pre-existing running app will assume focus and the the previously active app will quit itself. This behavior can be changed by providing the optional conflict handler, where the boolean returned by the handler determines whether or not the move conflict is resolved with default behavior.  i.e. returning `false` will ensure no further action is taken, returning `true` will result in the default behavior and the method continuing.
 
 For example:
 
@@ -1250,12 +1250,12 @@ For example:
 app.moveToApplicationsFolder({
   conflictHandler: (conflictType) => {
     if (conflictType === 'exists') {
-      dialog.showMessageBoxSync({
+      return dialog.showMessageBoxSync({
         type: 'question',
         buttons: ['Halt Move', 'Continue Move'],
         defaultId: 0,
         message: 'An app of this name already exists'
-      }, response => response)
+      }) === 1
     }
   })
 })

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1223,10 +1223,11 @@ This method can only be called before app is ready.
 Returns `Boolean` - Whether the application is currently running from the
 systems Application folder. Use in combination with `app.moveToApplicationsFolder()`
 
-### `app.moveToApplicationsFolder([handler])` _macOS_
+### `app.moveToApplicationsFolder([options])` _macOS_
 
-* `handler` Function (optional) - A handler for potential conflict in move failure.
-  * `conflictType` String - the type of move conflict encountered by the handler; can be `exists` or `existsAndRunning`, where `exists` means that an app of the same name is present in the Applications directory and `existsAndRunning` means both that it exists and that it's presently running.
+* `options` Object (optional)
+  * `conflictHandler` Function (optional) - A handler for potential conflict in move failure.
+    * `conflictType` String - the type of move conflict encountered by the handler; can be `exists` or `existsAndRunning`, where `exists` means that an app of the same name is present in the Applications directory and `existsAndRunning` means both that it exists and that it's presently running.
 
 Returns `Boolean` - Whether the move was successful. Please note that if
 the move is successful, your application will quit and relaunch.
@@ -1246,15 +1247,17 @@ By default, if an app of the same name as the one being moved exists in the Appl
 For example:
 
 ```js
-app.moveToApplicationsFolder(conflictType => {
-  if (conflictType === 'exists') {
-    dialog.showMessageBoxSync({
-      type: 'question',
-      buttons: ['Halt Move', 'Continue Move'],
-      defaultId: 0,
-      message: 'An app of this name already exists'
-    }, response => response)
-  }
+app.moveToApplicationsFolder({
+  conflictHandler: (conflictType) => {
+    if (conflictType === 'exists') {
+      dialog.showMessageBoxSync({
+        type: 'question',
+        buttons: ['Halt Move', 'Continue Move'],
+        defaultId: 0,
+        message: 'An app of this name already exists'
+      }, response => response)
+    }
+  })
 })
 ```
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1257,7 +1257,7 @@ app.moveToApplicationsFolder({
         message: 'An app of this name already exists'
       }) === 1
     }
-  })
+  }
 })
 ```
 

--- a/shell/browser/api/atom_api_app.cc
+++ b/shell/browser/api/atom_api_app.cc
@@ -1429,7 +1429,6 @@ void App::BuildPrototype(v8::Isolate* isolate,
                  base::BindRepeating(&Browser::ResignCurrentActivity, browser))
       .SetMethod("updateCurrentActivity",
                  base::BindRepeating(&Browser::UpdateCurrentActivity, browser))
-      // TODO(juturu): Remove in 2.0, deprecate before then with warnings
       .SetMethod("moveToApplicationsFolder", &App::MoveToApplicationsFolder)
       .SetMethod("isInApplicationsFolder", &App::IsInApplicationsFolder)
 #endif

--- a/shell/browser/ui/cocoa/atom_bundle_mover.h
+++ b/shell/browser/ui/cocoa/atom_bundle_mover.h
@@ -12,7 +12,7 @@
 namespace electron {
 
 // Possible bundle movement conflicts
-enum class ConflictType { EXISTS, EXISTS_AND_RUNNING };
+enum class BundlerMoverConflictType { EXISTS, EXISTS_AND_RUNNING };
 
 namespace ui {
 
@@ -24,7 +24,8 @@ class AtomBundleMover {
   static bool IsCurrentAppInApplicationsFolder();
 
  private:
-  static bool ShouldContinueMove(ConflictType type, mate::Arguments* args);
+  static bool ShouldContinueMove(BundlerMoverConflictType type,
+                                 mate::Arguments* args);
   static bool IsInApplicationsFolder(NSString* bundlePath);
   static NSString* ContainingDiskImageDevice(NSString* bundlePath);
   static void Relaunch(NSString* destinationPath);

--- a/shell/browser/ui/cocoa/atom_bundle_mover.h
+++ b/shell/browser/ui/cocoa/atom_bundle_mover.h
@@ -11,6 +11,9 @@
 
 namespace electron {
 
+// Possible bundle movement conflicts
+enum class ConflictType { EXISTS, EXISTS_AND_RUNNING };
+
 namespace ui {
 
 namespace cocoa {

--- a/shell/browser/ui/cocoa/atom_bundle_mover.h
+++ b/shell/browser/ui/cocoa/atom_bundle_mover.h
@@ -24,6 +24,7 @@ class AtomBundleMover {
   static bool IsCurrentAppInApplicationsFolder();
 
  private:
+  static bool ShouldContinueMove(ConflictType type, mate::Arguments* args);
   static bool IsInApplicationsFolder(NSString* bundlePath);
   static NSString* ContainingDiskImageDevice(NSString* bundlePath);
   static void Relaunch(NSString* destinationPath);

--- a/shell/browser/ui/cocoa/atom_bundle_mover.mm
+++ b/shell/browser/ui/cocoa/atom_bundle_mover.mm
@@ -361,11 +361,7 @@ bool AtomBundleMover::CopyBundle(NSString* srcPath, NSString* dstPath) {
   NSFileManager* fileManager = [NSFileManager defaultManager];
   NSError* error = nil;
 
-  if ([fileManager copyItemAtPath:srcPath toPath:dstPath error:&error]) {
-    return true;
-  } else {
-    return false;
-  }
+  return [fileManager copyItemAtPath:srcPath toPath:dstPath error:&error];
 }
 
 NSString* AtomBundleMover::ShellQuotedString(NSString* string) {

--- a/shell/browser/ui/cocoa/atom_bundle_mover.mm
+++ b/shell/browser/ui/cocoa/atom_bundle_mover.mm
@@ -98,7 +98,6 @@ bool AtomBundleMover::Move(mate::Arguments* args) {
       if (IsApplicationAtPathRunning(destinationPath)) {
         // Check for callback handler and get user choice for open/quit
         if (args->GetNext(&conflict_cb)) {
-          return false;
           bool maybeQuit =
               std::move(conflict_cb).Run(ConflictType::EXISTS_AND_RUNNING);
           if (!maybeQuit)

--- a/shell/browser/ui/cocoa/atom_bundle_mover.mm
+++ b/shell/browser/ui/cocoa/atom_bundle_mover.mm
@@ -33,6 +33,16 @@ struct Converter<electron::ConflictType> {
   }
 };
 
+template <>
+struct Converter<v8::MaybeLocal<v8::Value>> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     v8::MaybeLocal<v8::Value>* out) {
+    *out = v8::MaybeLocal<v8::Value>(val);
+    return true;
+  }
+};
+
 }  // namespace mate
 
 namespace electron {

--- a/shell/browser/ui/cocoa/atom_bundle_mover.mm
+++ b/shell/browser/ui/cocoa/atom_bundle_mover.mm
@@ -90,6 +90,8 @@ bool AtomBundleMover::Move(mate::Arguments* args) {
       }
     }
   } else {
+    mate::Dictionary options;
+    bool hasOptions = args->GetNext(&options);
     base::OnceCallback<bool(ConflictType)> conflict_cb;
 
     // If a copy already exists in the Applications folder, put it in the Trash
@@ -97,7 +99,7 @@ bool AtomBundleMover::Move(mate::Arguments* args) {
       // But first, make sure that it's not running
       if (IsApplicationAtPathRunning(destinationPath)) {
         // Check for callback handler and get user choice for open/quit
-        if (args->GetNext(&conflict_cb)) {
+        if (hasOptions && options.Get("conflictHandler", &conflict_cb)) {
           bool maybeQuit =
               std::move(conflict_cb).Run(ConflictType::EXISTS_AND_RUNNING);
           if (!maybeQuit)
@@ -114,7 +116,7 @@ bool AtomBundleMover::Move(mate::Arguments* args) {
         return true;
       } else {
         // Check callback handler and get user choice for app trashing
-        if (args->GetNext(&conflict_cb)) {
+        if (hasOptions && options.Get("conflictHandler", &conflict_cb)) {
           bool maybeTrash = std::move(conflict_cb).Run(ConflictType::EXISTS);
           if (!maybeTrash)
             return false;

--- a/shell/browser/ui/cocoa/atom_bundle_mover.mm
+++ b/shell/browser/ui/cocoa/atom_bundle_mover.mm
@@ -53,7 +53,10 @@ bool AtomBundleMover::ShouldContinueMove(BundlerMoverConflictType type,
     if (value->IsBoolean()) {
       if (!value.As<v8::Boolean>()->Value())
         return false;
-    } else {
+    } else if (!value->IsUndefined()) {
+      // we only want to throw an error if a user has returned a non-boolean
+      // value; this allows for client-side error handling should something in
+      // the handler throw
       args->ThrowError("Invalid conflict handler return type.");
     }
   }

--- a/shell/browser/ui/cocoa/atom_bundle_mover.mm
+++ b/shell/browser/ui/cocoa/atom_bundle_mover.mm
@@ -55,13 +55,12 @@ bool AtomBundleMover::ShouldContinueMove(BundlerMoverConflictType type,
                                          mate::Arguments* args) {
   mate::Dictionary options;
   bool hasOptions = args->GetNext(&options);
-  base::OnceCallback<v8::MaybeLocal<v8::Value>(BundlerMoverConflictType)>
+  base::OnceCallback<v8::Local<v8::Value>(BundlerMoverConflictType)>
       conflict_cb;
 
   if (hasOptions && options.Get("conflictHandler", &conflict_cb)) {
-    v8::MaybeLocal<v8::Value> maybe = std::move(conflict_cb).Run(type);
-    v8::Local<v8::Value> value;
-    if (maybe.ToLocal(&value) && value->IsBoolean()) {
+    v8::Local<v8::Value> value = std::move(conflict_cb).Run(type);
+    if (value->IsBoolean()) {
       if (!value.As<v8::Boolean>()->Value())
         return false;
     } else {

--- a/shell/browser/ui/cocoa/atom_bundle_mover.mm
+++ b/shell/browser/ui/cocoa/atom_bundle_mover.mm
@@ -19,13 +19,13 @@
 namespace mate {
 
 template <>
-struct Converter<electron::ConflictType> {
+struct Converter<electron::BundlerMoverConflictType> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   electron::ConflictType value) {
+                                   electron::BundlerMoverConflictType value) {
     switch (value) {
-      case electron::ConflictType::EXISTS:
+      case electron::BundlerMoverConflictType::EXISTS:
         return mate::StringToV8(isolate, "exists");
-      case electron::ConflictType::EXISTS_AND_RUNNING:
+      case electron::BundlerMoverConflictType::EXISTS_AND_RUNNING:
         return mate::StringToV8(isolate, "existsAndRunning");
       default:
         return mate::StringToV8(isolate, "");
@@ -51,11 +51,12 @@ namespace ui {
 
 namespace cocoa {
 
-bool AtomBundleMover::ShouldContinueMove(ConflictType type,
+bool AtomBundleMover::ShouldContinueMove(BundlerMoverConflictType type,
                                          mate::Arguments* args) {
   mate::Dictionary options;
   bool hasOptions = args->GetNext(&options);
-  base::OnceCallback<v8::MaybeLocal<v8::Value>(ConflictType)> conflict_cb;
+  base::OnceCallback<v8::MaybeLocal<v8::Value>(BundlerMoverConflictType)>
+      conflict_cb;
 
   if (hasOptions && options.Get("conflictHandler", &conflict_cb)) {
     v8::MaybeLocal<v8::Value> maybe = std::move(conflict_cb).Run(type);
@@ -124,7 +125,8 @@ bool AtomBundleMover::Move(mate::Arguments* args) {
       // But first, make sure that it's not running
       if (IsApplicationAtPathRunning(destinationPath)) {
         // Check for callback handler and get user choice for open/quit
-        if (!ShouldContinueMove(ConflictType::EXISTS_AND_RUNNING, args))
+        if (!ShouldContinueMove(BundlerMoverConflictType::EXISTS_AND_RUNNING,
+                                args))
           return false;
 
         // Unless explicitly denied, give running app focus and terminate self
@@ -137,7 +139,7 @@ bool AtomBundleMover::Move(mate::Arguments* args) {
         return true;
       } else {
         // Check callback handler and get user choice for app trashing
-        if (!ShouldContinueMove(ConflictType::EXISTS, args))
+        if (!ShouldContinueMove(BundlerMoverConflictType::EXISTS, args))
           return false;
 
         // Unless explicitly denied, attempt to trash old app

--- a/shell/browser/ui/cocoa/atom_bundle_mover.mm
+++ b/shell/browser/ui/cocoa/atom_bundle_mover.mm
@@ -33,16 +33,6 @@ struct Converter<electron::BundlerMoverConflictType> {
   }
 };
 
-template <>
-struct Converter<v8::MaybeLocal<v8::Value>> {
-  static bool FromV8(v8::Isolate* isolate,
-                     v8::Local<v8::Value> val,
-                     v8::MaybeLocal<v8::Value>* out) {
-    *out = v8::MaybeLocal<v8::Value>(val);
-    return true;
-  }
-};
-
 }  // namespace mate
 
 namespace electron {


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/18805.

We want to keep default move conflict handling behavior in that it's still what most users would expect, but there exist edge cases in which users may not want to be forced into that behavior.

This thus introduces an optional conflict handler that allows developers access to more granular move actions. They could now allow the user to choose whether to delete an existing app in favor of the current one being moved, or whether to quit the current app and focus on the existing one should it both exist _and_ be running. I added a fair amount of new documentation outlining this behavior, but if there are things users may benefit from seeing examples of or nuances that should be added please leave feedback!

cc @MarshallOfSound @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added an optional conflict handling callback to `app.moveToApplicationsFolder`.
