### PR TITLE
build: account for remotes in branch parsing

### DIFF
--- a/script/lib/utils.js
+++ b/script/lib/utils.js
@@ -40,12 +40,19 @@ async function getCurrentBranch (gitDir) {
   let branch = await handleGitCall(['rev-parse', '--abbrev-ref', 'HEAD'], gitDir)
   if (branch !== 'master' && !branch.match(/[0-9]+-[0-9]+-x/)) {
     const lastCommit = await handleGitCall(['rev-parse', 'HEAD'], gitDir)
-    const branches = (await handleGitCall(['branch', '--contains', lastCommit], gitDir)).split('\n')
+    const branches = (await handleGitCall([
+      'branch',
+      '--contains',
+      lastCommit,
+      '--remote'
+    ], gitDir)).split('\n')
+
     branch = branches.filter(b => b === 'master' || b.match(/[0-9]+-[0-9]+-x/))[0]
     if (!branch) {
       console.log(`${fail} no release branch exists for this ref`)
       process.exit(1)
     }
+    if (branch.startsWith('origin/')) branch = branch.substr('origin/'.length)
   }
   return branch.trim()
 }


### PR DESCRIPTION
On Heroku, release branches won't be checked out so while we've fetched branches, we need to ensure that the containing branch check accounts for this.

cc @MarshallOfSound 

Notes: none
