### PR TITLE
feat: add app.getTrackableObjectInstances()

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1057,6 +1057,10 @@ machineModelVersion: '11.5' }
 
 Using `basic` should be preferred if only basic information like `vendorId` or `driverId` is needed.
 
+### `app.getTrackableObjectInstances()`
+
+Returns `Record<string, number>`- The number of instances per object type, which can be useful for debugging memory leaks.
+
 ### `app.setBadgeCount(count)` _Linux_ _macOS_
 
 * `count` Integer

--- a/shell/browser/api/atom_api_app.h
+++ b/shell/browser/api/atom_api_app.h
@@ -203,6 +203,7 @@ class App : public AtomBrowserClient::Delegate,
   std::string GetUserAgentFallback();
   void SetBrowserClientCanUseCustomSiteInstance(bool should_disable);
   bool CanBrowserClientUseCustomSiteInstance();
+  v8::Local<v8::Value> GetTrackableObjectInstances(v8::Isolate* isolate);
 
 #if defined(OS_MACOSX)
   bool MoveToApplicationsFolder(mate::Arguments* args);

--- a/shell/browser/api/trackable_object.h
+++ b/shell/browser/api/trackable_object.h
@@ -100,6 +100,9 @@ class TrackableObject : public TrackableObjectBase,
       return std::vector<v8::Local<v8::Object>>();
   }
 
+  // Returns the number of objects in this class's weak map.
+  static size_t GetCount() { return weak_map_ ? weak_map_->Size() : 0; }
+
   // Removes this instance from the weak map.
   void RemoveFromWeakMap() {
     if (weak_map_ && weak_map_->Has(weak_map_id()))

--- a/shell/common/key_weak_map.h
+++ b/shell/common/key_weak_map.h
@@ -50,6 +50,9 @@ class KeyWeakMap {
   // Whethere there is an object with |key| in this WeakMap.
   bool Has(const K& key) const { return map_.find(key) != map_.end(); }
 
+  // The number of entries
+  size_t Size() const { return map_.size(); }
+
   // Returns all objects.
   std::vector<v8::Local<v8::Object>> Values(v8::Isolate* isolate) const {
     std::vector<v8::Local<v8::Object>> keys;

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -1051,6 +1051,16 @@ describe('app module', () => {
     })
   })
 
+  describe('getTrackableObjectInstances()', () => {
+    it('returns the list of instances, where count > 0', () => {
+      const result = app.getTrackableObjectInstances();
+      expect(result).to.be.an('object')
+      for (const key of Object.keys(result)) {
+        expect(result[key]).to.be.greaterThan(0)
+      }
+    })
+  })
+
   describe('sandbox options', () => {
     let appProcess: cp.ChildProcess = null as any
     let server: net.Server = null as any


### PR DESCRIPTION
#### Description of Change
Returns the number of instances per object type, which can be useful for debugging memory leaks.

Example:
```
{ Menu: 8,
  Protocol: 1,
  Session: 1,
  TopLevelWindow: 1,
  WebContents: 1 }
```

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `app.getTrackableObjectInstances()`, which can be useful for debugging memory leaks.