### PR TITLE
fix: override the timers module impls to activate the uv loop

### DIFF
--- a/lib/common/init.ts
+++ b/lib/common/init.ts
@@ -1,7 +1,8 @@
-import * as timers from 'timers'
 import * as util from 'util'
 
 import { electronBindingSetup } from '@electron/internal/common/electron-binding-setup'
+
+const timers = require('timers')
 
 process.electronBinding = electronBindingSetup(process._linkedBinding, process.type)
 
@@ -38,16 +39,20 @@ function wrap <T extends AnyFn> (func: T, wrapper: (fn: AnyFn) => T) {
 
 process.nextTick = wrapWithActivateUvLoop(process.nextTick)
 
-global.setImmediate = wrapWithActivateUvLoop(timers.setImmediate)
+global.setImmediate = timers.setImmediate = wrapWithActivateUvLoop(timers.setImmediate)
 global.clearImmediate = timers.clearImmediate
 
+// setTimeout needs to update the polling timeout of the event loop, when
+// called under Chromium's event loop the node's event loop won't get a chance
+// to update the timeout, so we have to force the node's event loop to
+// recalculate the timeout in browser process.
+timers.setTimeout = wrapWithActivateUvLoop(timers.setTimeout)
+timers.setInterval = wrapWithActivateUvLoop(timers.setInterval)
+
+// Only override the global setTimeout/setInterval impls in the browser process
 if (process.type === 'browser') {
-  // setTimeout needs to update the polling timeout of the event loop, when
-  // called under Chromium's event loop the node's event loop won't get a chance
-  // to update the timeout, so we have to force the node's event loop to
-  // recalculate the timeout in browser process.
-  global.setTimeout = wrapWithActivateUvLoop(timers.setTimeout)
-  global.setInterval = wrapWithActivateUvLoop(timers.setInterval)
+  global.setTimeout = timers.setTimeout
+  global.setInterval = timers.setInterval
 }
 
 if (process.platform === 'win32') {

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -212,6 +212,16 @@ describe('node feature', () => {
       })
     })
 
+    describe('setTimeout called under blink env in renderer process', () => {
+      it('can be scheduled in time', (done) => {
+        setTimeout(done, 10)
+      })
+
+      it('works from the timers module', (done) => {
+        require('timers').setTimeout(done, 10)
+      })
+    })
+
     describe('setInterval called under Chromium event loop in browser process', () => {
       it('can be scheduled in time', (done) => {
         let interval = null
@@ -227,6 +237,40 @@ describe('node feature', () => {
           done()
         }
         interval = remote.getGlobal('setInterval')(clear, 10)
+      })
+    })
+
+    describe('setInterval called under blink env in renderer process', () => {
+      it('can be scheduled in time', (done) => {
+        let interval = null
+        let clearing = false
+        const clear = () => {
+          if (interval === null || clearing) return
+
+          // interval might trigger while clearing (remote is slow sometimes)
+          clearing = true
+          clearInterval(interval)
+          clearing = false
+          interval = null
+          done()
+        }
+        interval = setInterval(clear, 10)
+      })
+
+      it('can be scheduled in time from timers module', (done) => {
+        let interval = null
+        let clearing = false
+        const clear = () => {
+          if (interval === null || clearing) return
+
+          // interval might trigger while clearing (remote is slow sometimes)
+          clearing = true
+          require('timers').clearInterval(interval)
+          clearing = false
+          interval = null
+          done()
+        }
+        interval = require('timers').setInterval(clear, 10)
       })
     })
   })


### PR DESCRIPTION
Fixes #18938

Notes: Fixed issue where `require('timers').setTimeout` would sometimes never fire in the renderer process