### PR TITLE
fix: make isDarkMode correctly detect dark mode in the auto setting on catalina

### DIFF
--- a/shell/browser/api/atom_api_system_preferences_mac.mm
+++ b/shell/browser/api/atom_api_system_preferences_mac.mm
@@ -628,6 +628,10 @@ void SystemPreferences::RemoveUserDefault(const std::string& name) {
 }
 
 bool SystemPreferences::IsDarkMode() {
+  if (@available(macOS 10.14, *)) {
+    return [[NSApplication sharedApplication].effectiveAppearance.name
+        isEqualToString:NSAppearanceNameDarkAqua];
+  }
   NSString* mode = [[NSUserDefaults standardUserDefaults]
       stringForKey:@"AppleInterfaceStyle"];
   return [mode isEqualToString:@"Dark"];


### PR DESCRIPTION
Fixes #18913

Similar to the tray icon fix landed a while back

Notes: `systemPreferences.isDarkMode()` now correctly detects dark mode on macOS Catalina