### PR TITLE
docs: documentation of NetworkService-based protocol module

### DIFF
--- a/docs/api/breaking-changes-ns.md
+++ b/docs/api/breaking-changes-ns.md
@@ -3,12 +3,12 @@
 This document describes changes to Electron APIs after migrating network code
 to NetworkService API.
 
-Currently we don't have an estimate of when will we enable NetworkService by
-default in Electron, but as Chromium is already removing non-NetworkService
-code, the switch may come after a few major version releases.
+We don't currently have an estimate of when we will enable `NetworkService` by
+default in Electron, but as Chromium is already removing non-`NetworkService`
+code, we might switch before Electron 10.
 
-The content of this document should be moved to `breaking-changes.md` after it
-is determined when to enable NetworkService in Electron.
+The content of this document should be moved to `breaking-changes.md` once we have
+determined when to enable `NetworkService` in Electron.
 
 ## Planned Breaking API Changes
 

--- a/docs/api/breaking-changes-ns.md
+++ b/docs/api/breaking-changes-ns.md
@@ -54,7 +54,7 @@ and `protocol.isProtocolIntercepted` instead.
 
 ```javascript
 // Deprecated
-const isHandled = await protocol.isProtocolHandled(scheme)
+protocol.isProtocolHandled(scheme).then(() => { /* ... */ })
 // Replace with
 const isRegistered = protocol.isProtocolRegistered(scheme)
 const isIntercepted = protocol.isProtocolIntercepted(scheme)

--- a/docs/api/breaking-changes-ns.md
+++ b/docs/api/breaking-changes-ns.md
@@ -1,4 +1,4 @@
-# Breaking changes (NetworkService)
+# Breaking changes (NetworkService) (Draft)
 
 This document describes changes to Electron APIs after migrating network code
 to NetworkService API.

--- a/docs/api/breaking-changes-ns.md
+++ b/docs/api/breaking-changes-ns.md
@@ -1,0 +1,61 @@
+# Breaking changes (NetworkService)
+
+This document describes changes to Electron APIs after migrating network code
+to NetworkService API.
+
+Currently we don't have an estimate of when will we enable NetworkService by
+default in Electron, but as Chromium is already removing non-NetworkService
+code, the switch may come after a few major version releases.
+
+The content of this document should be moved to `breaking-changes.md` after it
+is determined when to enable NetworkService in Electron.
+
+## Planned Breaking API Changes
+
+### `protocol.unregisterProtocol`
+### `protocol.uninterceptProtocol`
+
+The APIs are now synchronous and the optional callback is no longer needed.
+
+```javascript
+// Deprecated
+protocol.unregisterProtocol(scheme, () => { /* ... */ })
+// Replace with
+protocol.unregisterProtocol(scheme)
+```
+
+### `protocol.registerFileProtocol`
+### `protocol.registerBufferProtocol`
+### `protocol.registerStringProtocol`
+### `protocol.registerHttpProtocol`
+### `protocol.registerStreamProtocol`
+### `protocol.interceptFileProtocol`
+### `protocol.interceptStringProtocol`
+### `protocol.interceptBufferProtocol`
+### `protocol.interceptHttpProtocol`
+### `protocol.interceptStreamProtocol`
+
+The APIs are now synchronous and the optional callback is no longer needed.
+
+```javascript
+// Deprecated
+protocol.registerFileProtocol(scheme, handler, () => { /* ... */ })
+// Replace with
+protocol.registerFileProtocol(scheme, handler)
+```
+
+The registered or intercepted protocol does not have effect on current page
+until navigation happens.
+
+### `protocol.isProtocolHandled`
+
+This API is deprecated and users should use `protocol.isProtocolRegistered`
+and `protocol.isProtocolIntercepted` instead.
+
+```javascript
+// Deprecated
+const isHandled = await protocol.isProtocolHandled(scheme)
+// Replace with
+const isRegistered = protocol.isProtocolRegistered(scheme)
+const isIntercepted = protocol.isProtocolIntercepted(scheme)
+```

--- a/docs/api/protocol-ns.md
+++ b/docs/api/protocol-ns.md
@@ -2,12 +2,12 @@
 
 This document describes the new protocol APIs based on NetworkService.
 
-Currently we don't have an estimate of when will we enable NetworkService by
-default in Electron, but as Chromium is already removing non-NetworkService
-code, the switch may come after a few major version releases.
+We don't currently have an estimate of when we will enable `NetworkService` by
+default in Electron, but as Chromium is already removing non-`NetworkService`
+code, we might switch before Electron 10.
 
 The content of this document should be moved to `protocol.md` after it is
-determined when to enable NetworkService in Electron.
+determined when to enable `NetworkService` in Electron.
 
 > Register a custom protocol and intercept existing protocol requests.
 
@@ -89,7 +89,7 @@ A standard scheme adheres to what RFC 3986 calls [generic URI
 syntax](https://tools.ietf.org/html/rfc3986#section-3). For example `http` and
 `https` are standard schemes, while `file` is not.
 
-Registering a scheme as standard, will allow relative and absolute resources to
+Registering a scheme as standard allows relative and absolute resources to
 be resolved correctly when served. Otherwise the scheme will behave like the
 `file` protocol, but without the ability to resolve relative URLs.
 

--- a/docs/api/protocol-ns.md
+++ b/docs/api/protocol-ns.md
@@ -126,7 +126,7 @@ an incoming request for the `scheme`.
 
 To handle the `request`, the `callback` should be called with either the file's
 path or an object that has a `path` property, e.g. `callback(filePath)` or
-`callback({ path: filePath })`.
+`callback({ path: filePath })`. The `filePath` must be an absolute path.
 
 By default the `scheme` is treated like `http:`, which is parsed differently
 from protocols that follow the "generic URI syntax" like `file:`.

--- a/docs/api/protocol-ns.md
+++ b/docs/api/protocol-ns.md
@@ -1,0 +1,380 @@
+# protocol (NetworkService)
+
+This document describes the new protocol APIs based on NetworkService.
+
+Currently we don't have an estimate of when will we enable NetworkService by
+default in Electron, but as Chromium is already removing non-NetworkService
+code, the switch may come after a few major version releases.
+
+The content of this document should be moved to `protocol.md` after it is
+determined when to enable NetworkService in Electron.
+
+> Register a custom protocol and intercept existing protocol requests.
+
+Process: [Main](../glossary.md#main-process)
+
+An example of implementing a protocol that has the same effect as the
+`file://` protocol:
+
+```javascript
+const { app, protocol } = require('electron')
+const path = require('path')
+
+app.on('ready', () => {
+  protocol.registerProtocol('atom', (request, callback) => {
+    const url = request.url.substr(7)
+    callback('file', { path: path.normalize(`${__dirname}/${url}`) })
+  })
+})
+```
+
+**Note:** All methods unless specified can only be used after the `ready` event
+of the `app` module gets emitted.
+
+## Using `protocol` with a custom `partition` or `session`
+
+A protocol is registered to a specific Electron [`session`](./session.md)
+object. If you don't specify a session, then your `protocol` will be applied to
+the default session that Electron uses. However, if you define a `partition` or
+`session` on your `browserWindow`'s `webPreferences`, then that window will use
+a different session and your custom protocol will not work if you just use
+`electron.protocol.XXX`.
+
+To have your custom protocol work in combination with a custom session, you need
+to register it to that session explicitly.
+
+```javascript
+const { session, app, protocol } = require('electron')
+const path = require('path')
+
+app.on('ready', () => {
+  const partition = 'persist:example'
+  const ses = session.fromPartition(partition)
+
+  ses.protocol.registerProtocol('atom', (request, callback) => {
+    const url = request.url.substr(7)
+    callback('file', { path: path.normalize(`${__dirname}/${url}`) })
+  })
+
+  mainWindow = new BrowserWindow({ webPreferences: { partition } })
+})
+```
+
+## Methods
+
+The `protocol` module has the following methods:
+
+### `protocol.registerSchemesAsPrivileged(customSchemes)`
+
+* `customSchemes` [CustomScheme[]](structures/custom-scheme.md)
+
+**Note:** This method can only be used before the `ready` event of the `app`
+module gets emitted and can be called only once.
+
+Registers the `scheme` as standard, secure, bypasses content security policy for
+resources, allows registering ServiceWorker and supports fetch API. Specify a
+privilege with the value of `true` to enable the capability.
+
+An example of registering a privileged scheme, with bypassing Content Security
+Policy:
+
+```javascript
+const { protocol } = require('electron')
+protocol.registerSchemesAsPrivileged([
+  { scheme: 'foo', privileges: { bypassCSP: true } }
+])
+```
+
+A standard scheme adheres to what RFC 3986 calls [generic URI
+syntax](https://tools.ietf.org/html/rfc3986#section-3). For example `http` and
+`https` are standard schemes, while `file` is not.
+
+Registering a scheme as standard, will allow relative and absolute resources to
+be resolved correctly when served. Otherwise the scheme will behave like the
+`file` protocol, but without the ability to resolve relative URLs.
+
+For example when you load following page with custom protocol without
+registering it as standard scheme, the image will not be loaded because
+non-standard schemes can not recognize relative URLs:
+
+```html
+<body>
+  <img src='test.png'>
+</body>
+```
+
+Registering a scheme as standard will allow access to files through the
+[FileSystem API][file-system-api]. Otherwise the renderer will throw a security
+error for the scheme.
+
+By default web storage apis (localStorage, sessionStorage, webSQL, indexedDB,
+cookies) are disabled for non standard schemes. So in general if you want to
+register a custom protocol to replace the `http` protocol, you have to register
+it as a standard scheme.
+
+### `protocol.registerFileProtocol(scheme, handler)`
+
+* `scheme` String
+* `handler` Function
+  * `request` Object
+    * `url` String
+    * `referrer` String
+    * `method` String
+    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `callback` Function
+    * `filePath` String (optional)
+
+Registers a protocol of `scheme` that will send the file as a response. The
+`handler` will be called with `handler(request, callback)` when a `request` is
+going to be created with `scheme`.
+
+To handle the `request`, the `callback` should be called with either the file's
+path or an object that has a `path` property, e.g. `callback(filePath)` or
+`callback({ path: filePath })`. The object may also have a `headers` property
+which gives a map of headers to values for the response headers, e.g.
+`callback({ path: filePath, headers: {"Content-Security-Policy": "default-src
+'none'"]})`.
+
+When `callback` is called with nothing, a number, or an object that has an
+`error` property, the `request` will fail with the `error` number you
+specified. For the available error numbers you can use, please see the
+[net error list][net-error].
+
+By default the `scheme` is treated like `http:`, which is parsed differently
+than protocols that follow the "generic URI syntax" like `file:`.
+
+### `protocol.registerBufferProtocol(scheme, handler)`
+
+* `scheme` String
+* `handler` Function
+  * `request` Object
+    * `url` String
+    * `referrer` String
+    * `method` String
+    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `callback` Function
+    * `buffer` (Buffer | [MimeTypedBuffer](structures/mime-typed-buffer.md)) (optional)
+
+Registers a protocol of `scheme` that will send a `Buffer` as a response.
+
+The usage is the same with `registerFileProtocol`, except that the `callback`
+should be called with either a `Buffer` object or an object that has the `data`,
+`mimeType`, and `charset` properties.
+
+Example:
+
+```javascript
+protocol.registerBufferProtocol('atom', (request, callback) => {
+  callback({ mimeType: 'text/html', data: Buffer.from('<h5>Response</h5>') })
+})
+```
+
+### `protocol.registerStringProtocol(scheme, handler)`
+
+* `scheme` String
+* `handler` Function
+  * `request` Object
+    * `url` String
+    * `referrer` String
+    * `method` String
+    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `callback` Function
+    * `data` String (optional)
+
+Registers a protocol of `scheme` that will send a `String` as a response.
+
+The usage is the same with `registerFileProtocol`, except that the `callback`
+should be called with either a `String` or an object that has the `data`,
+`mimeType`, and `charset` properties.
+
+### `protocol.registerHttpProtocol(scheme, handler)`
+
+* `scheme` String
+* `handler` Function
+  * `request` Object
+    * `url` String
+    * `headers` Object
+    * `referrer` String
+    * `method` String
+    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `callback` Function
+    * `redirectRequest` Object
+      * `url` String
+      * `method` String
+      * `session` Object (optional)
+      * `uploadData` Object (optional)
+        * `contentType` String - MIME type of the content.
+        * `data` String - Content to be sent.
+
+Registers a protocol of `scheme` that will send an HTTP request as a response.
+
+The usage is the same with `registerFileProtocol`, except that the `callback`
+should be called with a `redirectRequest` object that has the `url`, `method`,
+`referrer`, `uploadData` and `session` properties.
+
+By default the HTTP request will reuse the current session. If you want the
+request to have a different session you should set `session` to `null`.
+
+For POST requests the `uploadData` object must be provided.
+
+### `protocol.registerStreamProtocol(scheme, handler)`
+
+* `scheme` String
+* `handler` Function
+  * `request` Object
+    * `url` String
+    * `headers` Object
+    * `referrer` String
+    * `method` String
+    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `callback` Function
+    * `stream` (ReadableStream | [StreamProtocolResponse](structures/stream-protocol-response.md)) (optional)
+
+Registers a protocol of `scheme` that will send a `Readable` as a response.
+
+The usage is similar to the other `register{Any}Protocol`, except that the
+`callback` should be called with either a `Readable` object or an object that
+has the `data`, `statusCode`, and `headers` properties.
+
+Example:
+
+```javascript
+const { protocol } = require('electron')
+const { PassThrough } = require('stream')
+
+function createStream (text) {
+  const rv = new PassThrough() // PassThrough is also a Readable stream
+  rv.push(text)
+  rv.push(null)
+  return rv
+}
+
+protocol.registerStreamProtocol('atom', (request, callback) => {
+  callback({
+    statusCode: 200,
+    headers: {
+      'content-type': 'text/html'
+    },
+    data: createStream('<h5>Response</h5>')
+  })
+})
+```
+
+It is possible to pass any object that implements the readable stream API (emits
+`data`/`end`/`error` events). For example, here's how a file could be returned:
+
+```javascript
+protocol.registerStreamProtocol('atom', (request, callback) => {
+  callback(fs.createReadStream('index.html'))
+})
+```
+
+### `protocol.unregisterProtocol(scheme)`
+
+* `scheme` String
+
+Unregisters the custom protocol of `scheme`.
+
+### `protocol.isProtocolRegistered(scheme)`
+
+* `scheme` String
+
+Returns `Boolean` - Whether `scheme` is already registered.
+
+### `protocol.interceptFileProtocol(scheme, handler)`
+
+* `scheme` String
+* `handler` Function
+  * `request` Object
+    * `url` String
+    * `referrer` String
+    * `method` String
+    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `callback` Function
+    * `filePath` String
+
+Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
+which sends a file as a response.
+
+### `protocol.interceptStringProtocol(scheme, handler)`
+
+* `scheme` String
+* `handler` Function
+  * `request` Object
+    * `url` String
+    * `referrer` String
+    * `method` String
+    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `callback` Function
+    * `data` String (optional)
+
+Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
+which sends a `String` as a response.
+
+### `protocol.interceptBufferProtocol(scheme, handler)`
+
+* `scheme` String
+* `handler` Function
+  * `request` Object
+    * `url` String
+    * `referrer` String
+    * `method` String
+    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `callback` Function
+    * `buffer` Buffer (optional)
+
+Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
+which sends a `Buffer` as a response.
+
+### `protocol.interceptHttpProtocol(scheme, handler)`
+
+* `scheme` String
+* `handler` Function
+  * `request` Object
+    * `url` String
+    * `headers` Object
+    * `referrer` String
+    * `method` String
+    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `callback` Function
+    * `redirectRequest` Object
+      * `url` String
+      * `method` String
+      * `session` Object (optional)
+      * `uploadData` Object (optional)
+        * `contentType` String - MIME type of the content.
+        * `data` String - Content to be sent.
+
+Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
+which sends a new HTTP request as a response.
+
+### `protocol.interceptStreamProtocol(scheme, handler)`
+
+* `scheme` String
+* `handler` Function
+  * `request` Object
+    * `url` String
+    * `headers` Object
+    * `referrer` String
+    * `method` String
+    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `callback` Function
+    * `stream` (ReadableStream | [StreamProtocolResponse](structures/stream-protocol-response.md)) (optional)
+
+Same as `protocol.registerStreamProtocol`, except that it replaces an existing
+protocol handler.
+
+### `protocol.uninterceptProtocol(scheme)`
+
+* `scheme` String
+
+Remove the interceptor installed for `scheme` and restore its original handler.
+
+### `protocol.isProtocolIntercepted(scheme)`
+
+* `scheme` String
+
+Returns `Boolean` - Whether `scheme` is already intercepted.
+
+[net-error]: https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h
+[file-system-api]: https://developer.mozilla.org/en-US/docs/Web/API/LocalFileSystem

--- a/docs/api/protocol-ns.md
+++ b/docs/api/protocol-ns.md
@@ -1,13 +1,13 @@
 # protocol (NetworkService) (Draft)
 
-This document describes the new protocol APIs based on NetworkService.
+This document describes the new protocol APIs based on the [NetworkService](https://www.chromium.org/servicification).
 
-We don't currently have an estimate of when we will enable `NetworkService` by
+We don't currently have an estimate of when we will enable the `NetworkService` by
 default in Electron, but as Chromium is already removing non-`NetworkService`
-code, we might switch before Electron 10.
+code, we will probably switch before Electron 10.
 
-The content of this document should be moved to `protocol.md` after it is
-determined when to enable `NetworkService` in Electron.
+The content of this document should be moved to `protocol.md` after we have
+enabled the `NetworkService` by default in Electron.
 
 > Register a custom protocol and intercept existing protocol requests.
 
@@ -75,7 +75,7 @@ Registers the `scheme` as standard, secure, bypasses content security policy for
 resources, allows registering ServiceWorker and supports fetch API. Specify a
 privilege with the value of `true` to enable the capability.
 
-An example of registering a privileged scheme, with bypassing Content Security
+An example of registering a privileged scheme, that bypasses Content Security
 Policy:
 
 ```javascript
@@ -120,9 +120,9 @@ it as a standard scheme.
   * `callback` Function
     * `response` (String | [ProtocolResponse](structures/protocol-response.md))
 
-Registers a protocol of `scheme` that will send the file as a response. The
-`handler` will be called with `handler(request, callback)` when a `request` is
-going to be created with `scheme`.
+Registers a protocol of `scheme` that will send a file as the response. The
+`handler` will be called with `request` and `callback` where `request` is
+an incoming request for the `scheme`.
 
 To handle the `request`, the `callback` should be called with either the file's
 path or an object that has a `path` property, e.g. `callback(filePath)` or
@@ -191,7 +191,7 @@ should be called with an object that has the `url` property.
 Registers a protocol of `scheme` that will send a stream as a response.
 
 The usage is the same with `registerFileProtocol`, except that the
-`callback` should be called with either a `Readable` object or an object that
+`callback` should be called with either a [`ReadableStream`](https://nodejs.org/api/stream.html#stream_class_stream_readable) object or an object that
 has the `data` property.
 
 Example:

--- a/docs/api/protocol-ns.md
+++ b/docs/api/protocol-ns.md
@@ -116,11 +116,7 @@ it as a standard scheme.
 
 * `scheme` String
 * `handler` Function
-  * `request` Object
-    * `url` String
-    * `referrer` String
-    * `method` String
-    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `request` ProtocolRequest
   * `callback` Function
     * `filePath` String (optional)
 
@@ -147,11 +143,7 @@ than protocols that follow the "generic URI syntax" like `file:`.
 
 * `scheme` String
 * `handler` Function
-  * `request` Object
-    * `url` String
-    * `referrer` String
-    * `method` String
-    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `request` ProtocolRequest
   * `callback` Function
     * `buffer` (Buffer | [MimeTypedBuffer](structures/mime-typed-buffer.md)) (optional)
 
@@ -173,11 +165,7 @@ protocol.registerBufferProtocol('atom', (request, callback) => {
 
 * `scheme` String
 * `handler` Function
-  * `request` Object
-    * `url` String
-    * `referrer` String
-    * `method` String
-    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `request` ProtocolRequest
   * `callback` Function
     * `data` String (optional)
 
@@ -191,12 +179,7 @@ should be called with either a `String` or an object that has the `data`,
 
 * `scheme` String
 * `handler` Function
-  * `request` Object
-    * `url` String
-    * `headers` Object
-    * `referrer` String
-    * `method` String
-    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `request` ProtocolRequest
   * `callback` Function
     * `redirectRequest` Object
       * `url` String
@@ -221,12 +204,7 @@ For POST requests the `uploadData` object must be provided.
 
 * `scheme` String
 * `handler` Function
-  * `request` Object
-    * `url` String
-    * `headers` Object
-    * `referrer` String
-    * `method` String
-    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `request` ProtocolRequest
   * `callback` Function
     * `stream` (ReadableStream | [StreamProtocolResponse](structures/stream-protocol-response.md)) (optional)
 
@@ -285,11 +263,7 @@ Returns `Boolean` - Whether `scheme` is already registered.
 
 * `scheme` String
 * `handler` Function
-  * `request` Object
-    * `url` String
-    * `referrer` String
-    * `method` String
-    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `request` ProtocolRequest
   * `callback` Function
     * `filePath` String
 
@@ -300,11 +274,7 @@ which sends a file as a response.
 
 * `scheme` String
 * `handler` Function
-  * `request` Object
-    * `url` String
-    * `referrer` String
-    * `method` String
-    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `request` ProtocolRequest
   * `callback` Function
     * `data` String (optional)
 
@@ -315,11 +285,7 @@ which sends a `String` as a response.
 
 * `scheme` String
 * `handler` Function
-  * `request` Object
-    * `url` String
-    * `referrer` String
-    * `method` String
-    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `request` ProtocolRequest
   * `callback` Function
     * `buffer` Buffer (optional)
 
@@ -330,12 +296,7 @@ which sends a `Buffer` as a response.
 
 * `scheme` String
 * `handler` Function
-  * `request` Object
-    * `url` String
-    * `headers` Object
-    * `referrer` String
-    * `method` String
-    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `request` ProtocolRequest
   * `callback` Function
     * `redirectRequest` Object
       * `url` String
@@ -352,12 +313,7 @@ which sends a new HTTP request as a response.
 
 * `scheme` String
 * `handler` Function
-  * `request` Object
-    * `url` String
-    * `headers` Object
-    * `referrer` String
-    * `method` String
-    * `uploadData` [UploadData[]](structures/upload-data.md)
+  * `request` ProtocolRequest
   * `callback` Function
     * `stream` (ReadableStream | [StreamProtocolResponse](structures/stream-protocol-response.md)) (optional)
 

--- a/docs/api/protocol-ns.md
+++ b/docs/api/protocol-ns.md
@@ -1,4 +1,4 @@
-# protocol (NetworkService)
+# protocolNS
 
 This document describes the new protocol APIs based on NetworkService.
 

--- a/docs/api/protocol-ns.md
+++ b/docs/api/protocol-ns.md
@@ -118,7 +118,7 @@ it as a standard scheme.
 * `handler` Function
   * `request` ProtocolRequest
   * `callback` Function
-    * `response` (String | [ProtocolResponse](protocol-response.md))
+    * `response` (String | [ProtocolResponse](structures/protocol-response.md))
 
 Registers a protocol of `scheme` that will send the file as a response. The
 `handler` will be called with `handler(request, callback)` when a `request` is
@@ -137,7 +137,7 @@ from protocols that follow the "generic URI syntax" like `file:`.
 * `handler` Function
   * `request` ProtocolRequest
   * `callback` Function
-    * `response` (Buffer | [ProtocolResponse](protocol-response.md))
+    * `response` (Buffer | [ProtocolResponse](structures/protocol-response.md))
 
 Registers a protocol of `scheme` that will send a `Buffer` as a response.
 
@@ -159,7 +159,7 @@ protocol.registerBufferProtocol('atom', (request, callback) => {
 * `handler` Function
   * `request` ProtocolRequest
   * `callback` Function
-    * `response` (String | [ProtocolResponse](protocol-response.md))
+    * `response` (String | [ProtocolResponse](structures/protocol-response.md))
 
 Registers a protocol of `scheme` that will send a `String` as a response.
 
@@ -186,7 +186,7 @@ should be called with an object that has the `url` property.
 * `handler` Function
   * `request` ProtocolRequest
   * `callback` Function
-    * `response` (ReadableStream | [ProtocolResponse](protocol-response.md))
+    * `response` (ReadableStream | [ProtocolResponse](structures/protocol-response.md))
 
 Registers a protocol of `scheme` that will send a stream as a response.
 
@@ -245,7 +245,7 @@ Returns `Boolean` - Whether `scheme` is already registered.
 * `handler` Function
   * `request` ProtocolRequest
   * `callback` Function
-    * `response` (String | [ProtocolResponse](protocol-response.md))
+    * `response` (String | [ProtocolResponse](structures/protocol-response.md))
 
 Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
 which sends a file as a response.
@@ -256,7 +256,7 @@ which sends a file as a response.
 * `handler` Function
   * `request` ProtocolRequest
   * `callback` Function
-    * `response` (String | [ProtocolResponse](protocol-response.md))
+    * `response` (String | [ProtocolResponse](structures/protocol-response.md))
 
 Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
 which sends a `String` as a response.
@@ -267,7 +267,7 @@ which sends a `String` as a response.
 * `handler` Function
   * `request` ProtocolRequest
   * `callback` Function
-    * `response` (Buffer | [ProtocolResponse](protocol-response.md))
+    * `response` (Buffer | [ProtocolResponse](structures/protocol-response.md))
 
 Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
 which sends a `Buffer` as a response.
@@ -289,7 +289,7 @@ which sends a new HTTP request as a response.
 * `handler` Function
   * `request` ProtocolRequest
   * `callback` Function
-    * `response` (ReadableStream | [ProtocolResponse](protocol-response.md))
+    * `response` (ReadableStream | [ProtocolResponse](structures/protocol-response.md))
 
 Same as `protocol.registerStreamProtocol`, except that it replaces an existing
 protocol handler.

--- a/docs/api/protocol-ns.md
+++ b/docs/api/protocol-ns.md
@@ -1,4 +1,4 @@
-# protocolNS
+# protocol (NetworkService) (Draft)
 
 This document describes the new protocol APIs based on NetworkService.
 

--- a/docs/api/structures/protocol-request.md
+++ b/docs/api/structures/protocol-request.md
@@ -3,4 +3,4 @@
 * `url` String
 * `referrer` String
 * `method` String
-* `uploadData` [UploadData[]](upload-data.md)
+* `uploadData` [UploadData[]](upload-data.md) (optional)

--- a/docs/api/structures/protocol-request.md
+++ b/docs/api/structures/protocol-request.md
@@ -1,0 +1,6 @@
+# ProtocolRequest Object
+
+* `url` String
+* `referrer` String
+* `method` String
+* `uploadData` [UploadData[]](upload-data.md)

--- a/docs/api/structures/protocol-response.md
+++ b/docs/api/structures/protocol-response.md
@@ -1,0 +1,36 @@
+# ProtocolResponse Object
+
+* `error` Integer (optional) - When assigned, the `request` will fail with the
+  `error` number . For the available error numbers you can use, please see the
+  [net error list][net-error].
+* `statusCode` Number (optional) - The HTTP response code, default is 200.
+* `charset` String (optional) - The charset of response body, default is
+  `"utf-8"`.
+* `mimeType` String (optional) - The MIME type of response body, default is
+  `"text/html"`. Setting `mimeType` would implicitly set the `content-type`
+  header in response, but if `content-type` is already set in `headers`, the
+  `mimeType` would be ignored.
+* `headers` Object (optional) - An object containing the response headers. The
+  keys must be String, and values must be either String or Array of String.
+* `data` (Buffer | String | ReadableStream) (optional) - The response body. When
+  returning stream as response, this is a Node.js readable stream representing
+  the response body. When returning `Buffer` as response, this is a `Buffer`.
+  When returning `String` as response, this is a `String`. This is ignored for
+  other types of responses.
+* `path` String (optional) - Path to the file which would be sent as response
+  body. This is only used for file responses.
+* `url` String (optional) - Download the `url` and pipe the result as response
+  body. This is only used for URL responses.
+* `referrer` String (optional) - The `referrer` URL. This is only used for file
+  and URL responses.
+* `method` String (optional) - The HTTP `method`. This is only used for file
+  and URL responses.
+* `session` Object (optional) - The session used for requesting URL, by default
+  the HTTP request will reuse the current session. Setting `session` to `null`
+  would use a random independent session. This is only used for URL responses.
+* `uploadData` Object (optional) - The data used as upload data. This is only
+  used for URL responses when `method` is `"POST"`.
+  * `contentType` String - MIME type of the content.
+  * `data` String - Content to be sent.
+
+[net-error]: https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h

--- a/docs/api/structures/protocol-response.md
+++ b/docs/api/structures/protocol-response.md
@@ -10,7 +10,7 @@
   `"text/html"`. Setting `mimeType` would implicitly set the `content-type`
   header in response, but if `content-type` is already set in `headers`, the
   `mimeType` would be ignored.
-* `headers` Object (optional) - An object containing the response headers. The
+* `headers` Record<string, string | string[]> (optional) - An object containing the response headers. The
   keys must be String, and values must be either String or Array of String.
 * `data` (Buffer | String | ReadableStream) (optional) - The response body. When
   returning stream as response, this is a Node.js readable stream representing
@@ -25,7 +25,7 @@
   and URL responses.
 * `method` String (optional) - The HTTP `method`. This is only used for file
   and URL responses.
-* `session` Object (optional) - The session used for requesting URL, by default
+* `session` Session (optional) - The session used for requesting URL, by default
   the HTTP request will reuse the current session. Setting `session` to `null`
   would use a random independent session. This is only used for URL responses.
 * `uploadData` Object (optional) - The data used as upload data. This is only

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -1,7 +1,6 @@
 # THIS FILE IS AUTO-GENERATED, PLEASE DO NOT EDIT BY HAND
 auto_filenames = {
   api_docs = [
-    "docs/api/.DS_Store",
     "docs/api/accelerator.md",
     "docs/api/app.md",
     "docs/api/auto-updater.md",

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -94,6 +94,7 @@ auto_filenames = {
     "docs/api/structures/process-memory-info.md",
     "docs/api/structures/process-metric.md",
     "docs/api/structures/product.md",
+    "docs/api/structures/protocol-request.md",
     "docs/api/structures/rectangle.md",
     "docs/api/structures/referrer.md",
     "docs/api/structures/remove-client-certificate.md",

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -1,9 +1,11 @@
 # THIS FILE IS AUTO-GENERATED, PLEASE DO NOT EDIT BY HAND
 auto_filenames = {
   api_docs = [
+    "docs/api/.DS_Store",
     "docs/api/accelerator.md",
     "docs/api/app.md",
     "docs/api/auto-updater.md",
+    "docs/api/breaking-changes-ns.md",
     "docs/api/breaking-changes.md",
     "docs/api/browser-view.md",
     "docs/api/browser-window-proxy.md",
@@ -39,6 +41,7 @@ auto_filenames = {
     "docs/api/power-monitor.md",
     "docs/api/power-save-blocker.md",
     "docs/api/process.md",
+    "docs/api/protocol-ns.md",
     "docs/api/protocol.md",
     "docs/api/remote.md",
     "docs/api/sandbox-option.md",

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -95,6 +95,7 @@ auto_filenames = {
     "docs/api/structures/process-metric.md",
     "docs/api/structures/product.md",
     "docs/api/structures/protocol-request.md",
+    "docs/api/structures/protocol-response.md",
     "docs/api/structures/rectangle.md",
     "docs/api/structures/referrer.md",
     "docs/api/structures/remove-client-certificate.md",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/electron/electron",
   "description": "Build cross platform desktop apps with JavaScript, HTML, and CSS",
   "devDependencies": {
-    "@electron/docs-parser": "^0.2.2",
+    "@electron/docs-parser": "^0.3.0",
     "@electron/typescript-definitions": "^8.3.1",
     "@octokit/rest": "^16.3.2",
     "@types/chai": "^4.1.7",

--- a/shell/browser/api/atom_api_protocol_ns.cc
+++ b/shell/browser/api/atom_api_protocol_ns.cc
@@ -107,8 +107,8 @@ bool ProtocolNS::IsProtocolIntercepted(const std::string& scheme) {
   return base::ContainsKey(intercept_handlers_, scheme);
 }
 
-v8::Local<v8::Promise> ProtocolNS::IsProtocolHandled(
-    const std::string& scheme) {
+v8::Local<v8::Promise> ProtocolNS::IsProtocolHandled(const std::string& scheme,
+                                                     mate::Arguments* args) {
   node::Environment* env = node::Environment::GetCurrent(args->isolate());
   EmitDeprecationWarning(
       env,

--- a/shell/browser/api/atom_api_protocol_ns.cc
+++ b/shell/browser/api/atom_api_protocol_ns.cc
@@ -9,6 +9,7 @@
 
 #include "base/stl_util.h"
 #include "shell/browser/atom_browser_context.h"
+#include "shell/common/deprecate_util.h"
 #include "shell/common/native_mate_converters/net_converter.h"
 #include "shell/common/native_mate_converters/once_callback.h"
 #include "shell/common/promise_util.h"
@@ -108,6 +109,13 @@ bool ProtocolNS::IsProtocolIntercepted(const std::string& scheme) {
 
 v8::Local<v8::Promise> ProtocolNS::IsProtocolHandled(
     const std::string& scheme) {
+  node::Environment* env = node::Environment::GetCurrent(args->isolate());
+  EmitDeprecationWarning(
+      env,
+      "The protocol.isProtocolHandled API is deprecated, use "
+      "protocol.isProtocolRegistered or protocol.isProtocolIntercepted "
+      "instead.",
+      "ProtocolDeprecateIsProtocolHandled");
   util::Promise promise(isolate());
   promise.Resolve(IsProtocolRegistered(scheme) ||
                   IsProtocolIntercepted(scheme) ||
@@ -126,6 +134,11 @@ void ProtocolNS::HandleOptionalCallback(mate::Arguments* args,
                                         ProtocolError error) {
   CompletionCallback callback;
   if (args->GetNext(&callback)) {
+    node::Environment* env = node::Environment::GetCurrent(args->isolate());
+    EmitDeprecationWarning(
+        env,
+        "The callback argument of protocol module APIs is no longer needed.",
+        "ProtocolDeprecateCallback");
     if (error == ProtocolError::OK)
       callback.Run(v8::Null(args->isolate()));
     else

--- a/shell/browser/api/atom_api_protocol_ns.h
+++ b/shell/browser/api/atom_api_protocol_ns.h
@@ -65,7 +65,8 @@ class ProtocolNS : public mate::TrackableObject<ProtocolNS> {
   bool IsProtocolIntercepted(const std::string& scheme);
 
   // Old async version of IsProtocolRegistered.
-  v8::Local<v8::Promise> IsProtocolHandled(const std::string& scheme);
+  v8::Local<v8::Promise> IsProtocolHandled(const std::string& scheme,
+                                           mate::Arguments* args);
 
   // Helper for converting old registration APIs to new RegisterProtocol API.
   template <ProtocolType type>

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,10 +22,25 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@electron/docs-parser@^0.2.1", "@electron/docs-parser@^0.2.2":
+"@electron/docs-parser@^0.2.1":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@electron/docs-parser/-/docs-parser-0.2.2.tgz#7c9acd6cc10559c86a27bb0653ec13df10955f02"
   integrity sha512-FKXktu5i6cHL+AkvWv34j2lpBXNpqfHN7YwhswcBqRFXsj24phpih/sY2NKx6OrFP9R3ReJeg681/luAf/3k8Q==
+  dependencies:
+    "@types/markdown-it" "^0.0.7"
+    chai "^4.2.0"
+    chalk "^2.4.2"
+    fs-extra "^7.0.1"
+    lodash.camelcase "^4.3.0"
+    markdown-it "^8.4.2"
+    minimist "^1.2.0"
+    ora "^3.4.0"
+    pretty-ms "^5.0.0"
+
+"@electron/docs-parser@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@electron/docs-parser/-/docs-parser-0.3.0.tgz#cf8c33ed9cebffe7f3463a1e2d60ccf457b52ec6"
+  integrity sha512-/q2et0q6eMDItzv1ZCAH5ZJZY8AFGFkK1+wfAJfdarMDJOVs29pH8b0HjTXo2k+kLGlbC2TROZfuCHRgx+l/EQ==
   dependencies:
     "@types/markdown-it" "^0.0.7"
     chai "^4.2.0"


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/18125, https://github.com/electron/electron/issues/15791.

This PR documents the changes of NetworkService-based protocol module, the contents are very likely to change as the NetworkService migration continues.

Since currently we don't have an estimate of when will we enable NetworkService by default in Electron, the docs are put in separate files and are not available to users. They should be moved to `breaking-changes.md` and `protocol.md` after it is determined when to enable NetworkService in Electron.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes