### PR TITLE
fix: set size of GTK about panel icon

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1182,7 +1182,7 @@ Show the app's about panel options. These options can be overridden with `app.se
   * `credits` String (optional) - Credit information. _macOS_
   * `authors` String[] (optional) - List of app authors. _Linux_
   * `website` String (optional) - The app's website. _Linux_
-  * `iconPath` String (optional) - Path to the app's icon. _Linux_
+  * `iconPath` String (optional) - Path to the app's icon. Will be shown as 64x64 pixels while retaining aspect ratio. _Linux_
 
 Set the about panel options. This will override the values defined in the app's
 `.plist` file on MacOS. See the [Apple docs][about-panel-options] for more details. On Linux, values must be set in order to be shown; there are no defaults.

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -167,7 +167,12 @@ void Browser::ShowAboutPanel() {
   }
   if ((str = opts.FindStringKey("iconPath"))) {
     GError* error = nullptr;
-    GdkPixbuf* icon = gdk_pixbuf_new_from_file(str->c_str(), &error);
+    constexpr int width = 64;   // width of about panel icon in pixels
+    constexpr int height = 64;  // height of about panel icon in pixels
+
+    // set preserve_aspect_ratio to true
+    GdkPixbuf* icon =
+        gdk_pixbuf_new_from_file_at_size(str->c_str(), width, height, &error);
     if (error != nullptr) {
       g_warning("%s", error->message);
       g_clear_error(&error);


### PR DESCRIPTION
#### Description of Change

Refs #3 on https://github.com/electron/electron/issues/18918.

Previously, we unconditionally passed through whatever icon was at the `iconPath` passed to a new Linux about panel. On other platforms, it's standardized, and so this PR changes previous behavior such that any icon can be passed in and will be automatically resized to 64x64 pixels while retaining the aspect ratio.

cc @ckerr @sindresorhus @MarshallOfSound  

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Standardized the about panel icon size on Linux.
