### PR TITLE
test: fix flakiness of test BrowserWindow.moveTop

### DIFF
--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -606,8 +606,10 @@ describe('BrowserWindow module', () => {
 
         const otherWindow = new BrowserWindow({ show: false, title: 'otherWindow' })
         const otherWindowShown = emittedOnce(otherWindow, 'show')
+        const otherWindowFocused = emittedOnce(otherWindow, 'focus')
         otherWindow.show()
         await otherWindowShown
+        await otherWindowFocused
         expect(otherWindow.isFocused()).to.equal(true)
 
         w.moveTop()


### PR DESCRIPTION

#### Description of Change
BrowserWindow.show gives focus to the window but there is
a moment where the window is shown but does not have the
focus yet. And the test was failing at this moment.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix flakiness of BrowserWindow.moveTop test