### PR TITLE
feat: show optional authors in gtk about panel

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1178,7 +1178,7 @@ Show the app's about panel options. These options can be overridden with `app.se
   * `applicationName` String (optional) - The app's name.
   * `applicationVersion` String (optional) - The app's version.
   * `copyright` String (optional) - Copyright information.
-  * `version` String (optional) - The app's build version number. _macOS_
+  * `version` String (optional) - The app's build version number.
   * `credits` String (optional) - Credit information. _macOS_
   * `authors` String[] (optional) - List of app authors. _Linux_
   * `website` String (optional) - The app's website. _Linux_

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1180,6 +1180,7 @@ Show the app's about panel options. These options can be overridden with `app.se
   * `copyright` String (optional) - Copyright information.
   * `version` String (optional) - The app's build version number. _macOS_
   * `credits` String (optional) - Credit information. _macOS_
+  * `authors` String[] (optional) - List of app authors. _Linux_
   * `website` String (optional) - The app's website. _Linux_
   * `iconPath` String (optional) - Path to the app's icon. _Linux_
 

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -159,9 +159,9 @@ class Browser : public WindowListObserver {
                                const base::DictionaryValue& user_info);
 
   // Bounce the dock icon.
-  enum class BounceType {
-    CRITICAL = 0,        // NSCriticalRequest
-    INFORMATIONAL = 10,  // NSInformationalRequest
+  enum class BounceType{
+      CRITICAL = 0,        // NSCriticalRequest
+      INFORMATIONAL = 10,  // NSInformationalRequest
   };
   int DockBounce(BounceType type);
   void DockCancelBounce(int request_id);
@@ -305,7 +305,9 @@ class Browser : public WindowListObserver {
 
   std::unique_ptr<util::Promise> ready_promise_;
 
-#if defined(OS_LINUX) || defined(OS_MACOSX)
+#if defined(OS_LINUX)
+  base::Value about_panel_options_;
+#elif defined(OS_MACOSX)
   base::DictionaryValue about_panel_options_;
 #endif
 

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -147,30 +147,27 @@ bool Browser::IsEmojiPanelSupported() {
 }
 
 void Browser::ShowAboutPanel() {
-  std::string app_name, version, copyright, icon_path, website;
-  base::ListValue* args;
-
   GtkAboutDialog* dialog = GTK_ABOUT_DIALOG(gtk_about_dialog_new());
 
-  if (about_panel_options_.GetString("applicationName", &app_name))
-    gtk_about_dialog_set_program_name(dialog, app_name.c_str());
-  if (about_panel_options_.GetString("applicationVersion", &version))
-    gtk_about_dialog_set_version(dialog, version.c_str());
-  if (about_panel_options_.GetString("copyright", &copyright))
-    gtk_about_dialog_set_copyright(dialog, copyright.c_str());
-  if (about_panel_options_.GetString("website", &website))
-    gtk_about_dialog_set_website(dialog, website.c_str());
-  if (about_panel_options_.GetList("args", &args)) {
-    std::vector<const char*> cstrs;
-    for (const auto& str : args->GetList()) {
-      cstrs.push_back(str.c_str());
-    }
-    cstrs.push_back(nullptr);
-    gtk_about_dialog_set_authors(dialog, cstrs.data());
+  const auto& opts = about_panel_options_;
+  const std::string* str;
+  const base::Value* val;
+
+  if ((str = opts.FindStringKey("applicationName"))) {
+    gtk_about_dialog_set_program_name(dialog, str->c_str());
   }
-  if (about_panel_options_.GetString("iconPath", &icon_path)) {
+  if ((str = opts.FindStringKey("applicationVersion"))) {
+    gtk_about_dialog_set_version(dialog, str->c_str());
+  }
+  if ((str = opts.FindStringKey("copyright"))) {
+    gtk_about_dialog_set_copyright(dialog, str->c_str());
+  }
+  if ((str = opts.FindStringKey("website"))) {
+    gtk_about_dialog_set_website(dialog, str->c_str());
+  }
+  if ((str = opts.FindStringKey("iconPath"))) {
     GError* error = nullptr;
-    GdkPixbuf* icon = gdk_pixbuf_new_from_file(icon_path.c_str(), &error);
+    GdkPixbuf* icon = gdk_pixbuf_new_from_file(str->c_str(), &error);
     if (error != nullptr) {
       g_warning("%s", error->message);
       g_clear_error(&error);
@@ -180,19 +177,27 @@ void Browser::ShowAboutPanel() {
     }
   }
 
+  if ((val = opts.FindListKey("authors"))) {
+    std::vector<const char*> cstrs;
+    for (const auto& authorVal : val->GetList()) {
+      if (authorVal.is_string()) {
+        cstrs.push_back(authorVal.GetString().c_str());
+      }
+    }
+    if (cstrs.empty()) {
+      LOG(WARNING) << "No author strings found in 'authors' array";
+    } else {
+      cstrs.push_back(nullptr);  // null-terminated char* array
+      gtk_about_dialog_set_authors(dialog, cstrs.data());
+    }
+  }
+
   gtk_dialog_run(GTK_DIALOG(dialog));
   g_clear_object(&dialog);
 }
 
 void Browser::SetAboutPanelOptions(const base::DictionaryValue& options) {
-  about_panel_options_.Clear();
-
-  for (const auto& pair : options) {
-    const std::string& key = pair.first;
-    const auto& val = pair.second;
-    if (!key.empty() && val->is_string())
-      about_panel_options_.SetString(key, val->GetString());
-  }
+  about_panel_options_ = options.Clone();
 }
 
 }  // namespace electron

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -148,6 +148,7 @@ bool Browser::IsEmojiPanelSupported() {
 
 void Browser::ShowAboutPanel() {
   std::string app_name, version, copyright, icon_path, website;
+  base::ListValue* args;
 
   GtkAboutDialog* dialog = GTK_ABOUT_DIALOG(gtk_about_dialog_new());
 
@@ -159,6 +160,14 @@ void Browser::ShowAboutPanel() {
     gtk_about_dialog_set_copyright(dialog, copyright.c_str());
   if (about_panel_options_.GetString("website", &website))
     gtk_about_dialog_set_website(dialog, website.c_str());
+  if (about_panel_options_.GetList("args", &args)) {
+    std::vector<const char*> cstrs;
+    for (const auto& str : args->GetList()) {
+      cstrs.push_back(str.c_str());
+    }
+    cstrs.push_back(nullptr);
+    gtk_about_dialog_set_authors(dialog, cstrs.data());
+  }
   if (about_panel_options_.GetString("iconPath", &icon_path)) {
     GError* error = nullptr;
     GdkPixbuf* icon = gdk_pixbuf_new_from_file(icon_path.c_str(), &error);


### PR DESCRIPTION
#### Description of Change

Refs #2 in https://github.com/electron/electron/issues/18918.

This PR adds the ability to set a list of authors in the native Linux about panel.

I chose not to add this to the existing credits options owing to incompatible parameter types. We could potentially do it, but i felt that the added argument sanitization outweighed the benefit of being able to use a single argument across both platforms for this.

cc @ckerr @sindresorhus 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added the ability to set authors in the Linux implementation of the About panel.
