### PR TITLE
fix: override the timers module impls to activate the uv loop

### DIFF
--- a/lib/common/init.js
+++ b/lib/common/init.js
@@ -30,16 +30,20 @@ function wrap (func, wrapper) {
 
 process.nextTick = wrapWithActivateUvLoop(process.nextTick)
 
-global.setImmediate = wrapWithActivateUvLoop(timers.setImmediate)
+global.setImmediate = timers.setImmediate = wrapWithActivateUvLoop(timers.setImmediate)
 global.clearImmediate = timers.clearImmediate
 
+// setTimeout needs to update the polling timeout of the event loop, when
+// called under Chromium's event loop the node's event loop won't get a chance
+// to update the timeout, so we have to force the node's event loop to
+// recalculate the timeout in browser process.
+timers.setTimeout = wrapWithActivateUvLoop(timers.setTimeout)
+timers.setInterval = wrapWithActivateUvLoop(timers.setInterval)
+
+// Only override the global setTimeout/setInterval impls in the browser process
 if (process.type === 'browser') {
-  // setTimeout needs to update the polling timeout of the event loop, when
-  // called under Chromium's event loop the node's event loop won't get a chance
-  // to update the timeout, so we have to force the node's event loop to
-  // recalculate the timeout in browser process.
-  global.setTimeout = wrapWithActivateUvLoop(timers.setTimeout)
-  global.setInterval = wrapWithActivateUvLoop(timers.setInterval)
+  global.setTimeout = timers.setTimeout
+  global.setInterval = timers.setInterval
 }
 
 if (process.platform === 'win32') {


### PR DESCRIPTION
Backport of #18948.

See that PR for details

Notes: Fixed issue where `require('timers').setTimeout` would sometimes never fire in the renderer process