### PR TITLE
fix: do not remove node globals when context isolation is enabled

### DIFF
--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -179,14 +179,17 @@ if (nodeIntegration) {
     }
   }
 } else {
-  // Delete Node's symbols after the Environment has been loaded.
-  process.once('loaded', function () {
-    delete global.process
-    delete global.Buffer
-    delete global.setImmediate
-    delete global.clearImmediate
-    delete global.global
-  })
+  // Delete Node's symbols after the Environment has been loaded in a
+  // non context-isolated environment
+  if (!contextIsolation) {
+    process.once('loaded', function () {
+      delete global.process
+      delete global.Buffer
+      delete global.setImmediate
+      delete global.clearImmediate
+      delete global.global
+    })
+  }
 }
 
 const errorUtils = require('@electron/internal/common/error-utils')


### PR DESCRIPTION
Notes: Node.JS globals (`process`, `Buffer`, etc.) are no longer removed from the global scope if you have `contextIsolation` enabled as it is safe for those variables to still exist in their isolated world