### PR TITLE
chore: use ScopedPumpMessagesInPrivateModes in tray

### DIFF
--- a/shell/browser/api/atom_api_menu.h
+++ b/shell/browser/api/atom_api_menu.h
@@ -63,7 +63,7 @@ class Menu : public mate::TrackableObject<Menu>,
                        const base::Closure& callback) = 0;
   virtual void ClosePopupAt(int32_t window_id) = 0;
 
-  scoped_refptr<AtomMenuModel> model_;
+  std::unique_ptr<AtomMenuModel> model_;
   Menu* parent_ = nullptr;
 
   // Observable:

--- a/shell/browser/ui/atom_menu_model.cc
+++ b/shell/browser/ui/atom_menu_model.cc
@@ -15,7 +15,7 @@ bool AtomMenuModel::Delegate::GetAcceleratorForCommandId(
 }
 
 AtomMenuModel::AtomMenuModel(Delegate* delegate)
-    : ui::SimpleMenuModel(delegate), delegate_(delegate) {}
+    : ui::SimpleMenuModel(delegate), delegate_(delegate), weak_factory_(this) {}
 
 AtomMenuModel::~AtomMenuModel() {}
 

--- a/shell/browser/ui/atom_menu_model.cc
+++ b/shell/browser/ui/atom_menu_model.cc
@@ -15,7 +15,7 @@ bool AtomMenuModel::Delegate::GetAcceleratorForCommandId(
 }
 
 AtomMenuModel::AtomMenuModel(Delegate* delegate)
-    : ui::SimpleMenuModel(delegate), delegate_(delegate), weak_factory_(this) {}
+    : ui::SimpleMenuModel(delegate), delegate_(delegate) {}
 
 AtomMenuModel::~AtomMenuModel() {}
 

--- a/shell/browser/ui/atom_menu_model.h
+++ b/shell/browser/ui/atom_menu_model.h
@@ -68,17 +68,11 @@ class AtomMenuModel : public ui::SimpleMenuModel {
   using SimpleMenuModel::GetSubmenuModelAt;
   AtomMenuModel* GetSubmenuModelAt(int index);
 
-  base::WeakPtr<AtomMenuModel> GetWeakPtr() {
-    return weak_factory_.GetWeakPtr();
-  }
-
  private:
   Delegate* delegate_;  // weak ref.
 
   std::map<int, base::string16> roles_;  // command id -> role
   base::ObserverList<Observer> observers_;
-
-  base::WeakPtrFactory<AtomMenuModel> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomMenuModel);
 };

--- a/shell/browser/ui/atom_menu_model.h
+++ b/shell/browser/ui/atom_menu_model.h
@@ -13,8 +13,7 @@
 
 namespace electron {
 
-class AtomMenuModel : public ui::SimpleMenuModel,
-                      public base::RefCounted<AtomMenuModel> {
+class AtomMenuModel : public ui::SimpleMenuModel {
  public:
   class Delegate : public ui::SimpleMenuModel::Delegate {
    public:
@@ -49,6 +48,7 @@ class AtomMenuModel : public ui::SimpleMenuModel,
   };
 
   explicit AtomMenuModel(Delegate* delegate);
+  ~AtomMenuModel() override;
 
   void AddObserver(Observer* obs) { observers_.AddObserver(obs); }
   void RemoveObserver(Observer* obs) { observers_.RemoveObserver(obs); }
@@ -68,14 +68,17 @@ class AtomMenuModel : public ui::SimpleMenuModel,
   using SimpleMenuModel::GetSubmenuModelAt;
   AtomMenuModel* GetSubmenuModelAt(int index);
 
- private:
-  friend class base::RefCounted<AtomMenuModel>;
-  ~AtomMenuModel() override;
+  base::WeakPtr<AtomMenuModel> GetWeakPtr() {
+    return weak_factory_.GetWeakPtr();
+  }
 
+ private:
   Delegate* delegate_;  // weak ref.
 
   std::map<int, base::string16> roles_;  // command id -> role
   base::ObserverList<Observer> observers_;
+
+  base::WeakPtrFactory<AtomMenuModel> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomMenuModel);
 };

--- a/shell/browser/ui/tray_icon_cocoa.h
+++ b/shell/browser/ui/tray_icon_cocoa.h
@@ -30,7 +30,7 @@ class TrayIconCocoa : public TrayIcon, public AtomMenuModel::Observer {
   void SetHighlightMode(TrayIcon::HighlightMode mode) override;
   void SetIgnoreDoubleClickEvents(bool ignore) override;
   bool GetIgnoreDoubleClickEvents() override;
-  void PopUpOnUI(base::WeakPtr<AtomMenuModel> menu_model);
+  void PopUpOnUI(AtomMenuModel* menu_model);
   void PopUpContextMenu(const gfx::Point& pos,
                         AtomMenuModel* menu_model) override;
   void SetContextMenu(AtomMenuModel* menu_model) override;
@@ -49,6 +49,8 @@ class TrayIconCocoa : public TrayIcon, public AtomMenuModel::Observer {
 
   // Used for unregistering observer.
   AtomMenuModel* menu_model_ = nullptr;  // weak ref.
+
+  base::WeakPtrFactory<TrayIconCocoa> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(TrayIconCocoa);
 };

--- a/shell/browser/ui/tray_icon_cocoa.h
+++ b/shell/browser/ui/tray_icon_cocoa.h
@@ -30,7 +30,7 @@ class TrayIconCocoa : public TrayIcon, public AtomMenuModel::Observer {
   void SetHighlightMode(TrayIcon::HighlightMode mode) override;
   void SetIgnoreDoubleClickEvents(bool ignore) override;
   bool GetIgnoreDoubleClickEvents() override;
-  void PopUpOnUI(scoped_refptr<AtomMenuModel> menu_model);
+  void PopUpOnUI(base::WeakPtr<AtomMenuModel> menu_model);
   void PopUpContextMenu(const gfx::Point& pos,
                         AtomMenuModel* menu_model) override;
   void SetContextMenu(AtomMenuModel* menu_model) override;

--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -337,7 +337,12 @@ const CGFloat kVerticalTitleMargin = 2;
 }
 
 - (void)popUpContextMenu:(electron::AtomMenuModel*)menu_model {
+  // Make sure events can be pumped while the menu is up.
   base::MessageLoopCurrent::ScopedNestableTaskAllower allow;
+
+  // Ensure the UI can update while the menu is fading out.
+  base::ScopedPumpMessagesInPrivateModes pump_private;
+
   // Show a custom menu.
   if (menu_model) {
     base::scoped_nsobject<AtomMenuController> menuController(
@@ -346,7 +351,6 @@ const CGFloat kVerticalTitleMargin = 2;
     forceHighlight_ = YES;  // Should highlight when showing menu.
     [self setNeedsDisplay:YES];
 
-    base::mac::ScopedSendingEvent sendingEventScoper;
     [statusItem_ popUpStatusItemMenu:[menuController menu]];
     forceHighlight_ = NO;
     [self setNeedsDisplay:YES];
@@ -357,7 +361,6 @@ const CGFloat kVerticalTitleMargin = 2;
     // Redraw the tray icon to show highlight if it is enabled.
     [self setNeedsDisplay:YES];
 
-    base::mac::ScopedSendingEvent sendingEventScoper;
     [statusItem_ popUpStatusItemMenu:[menuController_ menu]];
     // The popUpStatusItemMenu returns only after the showing menu is closed.
     // When it returns, we need to redraw the tray icon to not show highlight.

--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -501,7 +501,7 @@ bool TrayIconCocoa::GetIgnoreDoubleClickEvents() {
   return [status_item_view_ getIgnoreDoubleClickEvents];
 }
 
-void TrayIconCocoa::PopUpOnUI(scoped_refptr<AtomMenuModel> menu_model) {
+void TrayIconCocoa::PopUpOnUI(base::WeakPtr<AtomMenuModel> menu_model) {
   if (auto* model = menu_model.get())
     [status_item_view_ popUpContextMenu:model];
 }
@@ -511,7 +511,7 @@ void TrayIconCocoa::PopUpContextMenu(const gfx::Point& pos,
   base::PostTaskWithTraits(
       FROM_HERE, {content::BrowserThread::UI},
       base::BindOnce(&TrayIconCocoa::PopUpOnUI, base::Unretained(this),
-                     base::WrapRefCounted(menu_model)));
+                     menu_model->GetWeakPtr()));
 }
 
 void TrayIconCocoa::SetContextMenu(AtomMenuModel* menu_model) {

--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -459,7 +459,7 @@ const CGFloat kVerticalTitleMargin = 2;
 
 namespace electron {
 
-TrayIconCocoa::TrayIconCocoa() {
+TrayIconCocoa::TrayIconCocoa() : weak_factory_(this) {
   status_item_view_.reset([[StatusItemView alloc] initWithIcon:this]);
 }
 
@@ -501,17 +501,16 @@ bool TrayIconCocoa::GetIgnoreDoubleClickEvents() {
   return [status_item_view_ getIgnoreDoubleClickEvents];
 }
 
-void TrayIconCocoa::PopUpOnUI(base::WeakPtr<AtomMenuModel> menu_model) {
-  if (auto* model = menu_model.get())
-    [status_item_view_ popUpContextMenu:model];
+void TrayIconCocoa::PopUpOnUI(AtomMenuModel* menu_model) {
+  [status_item_view_ popUpContextMenu:menu_model];
 }
 
 void TrayIconCocoa::PopUpContextMenu(const gfx::Point& pos,
                                      AtomMenuModel* menu_model) {
   base::PostTaskWithTraits(
       FROM_HERE, {content::BrowserThread::UI},
-      base::BindOnce(&TrayIconCocoa::PopUpOnUI, base::Unretained(this),
-                     menu_model->GetWeakPtr()));
+      base::BindOnce(&TrayIconCocoa::PopUpOnUI, weak_factory_.GetWeakPtr(),
+                     base::Unretained(menu_model)));
 }
 
 void TrayIconCocoa::SetContextMenu(AtomMenuModel* menu_model) {


### PR DESCRIPTION
#### Description of Change

This is a follow-up of https://github.com/electron/electron/pull/18880 to use `base::ScopedPumpMessagesInPrivateModes` in the Tray's `popUpContextMenu` implementation. I considered using `electron::UnresponsiveSuppressor suppressor` so that we don't emit unresponsive event when showing the Tray menu, but i don't think that's something that would occur enough to warrant its being added at this time.

I also removed `base::mac::ScopedSendingEvent sendingEventScoper`, which i originally included in that I was concerned about pumping through `window.close()`, but windows aren't coupled to Trays in the way that context menus are so i no longer believe that to be necessary.

cc @deepak1556 @ckerr @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
