### PR TITLE
fix: silent printing mode

### DIFF
--- a/patches/chromium/crashpad_pid_check.patch
+++ b/patches/chromium/crashpad_pid_check.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Cheng Zhao <zcbenz@gmail.com>
-Date: Tue Jun 4 11:30:12 JST 2019
+Date: Tue, 4 Jun 2019 11:30:12 +0900
 Subject: crashpad_pid_check.patch
 
 When both browser process and renderer process are connecting to the pipe,
@@ -16,7 +16,7 @@ https://github.com/electron/electron/pull/18483#discussion_r292703588
 https://github.com/electron/electron/pull/18483#issuecomment-501090683
 
 diff --git a/third_party/crashpad/crashpad/util/win/exception_handler_server.cc b/third_party/crashpad/crashpad/util/win/exception_handler_server.cc
-index 2593ff2de032..e89b8ff675be 100644
+index 2593ff2de0327c393c30cae9962a329c5e27b64e..e89b8ff675bed2fa65263ea451d40995e0b010b7 100644
 --- a/third_party/crashpad/crashpad/util/win/exception_handler_server.cc
 +++ b/third_party/crashpad/crashpad/util/win/exception_handler_server.cc
 @@ -448,9 +448,16 @@ bool ExceptionHandlerServer::ServiceClientConnection(

--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -355,10 +355,18 @@ index 1802034a6e15a6ad8b0d9591cfb79ba5873dc982..a827091facdb4f6b1d74ce826c3492ce
  // Like PrintMsg_PrintPages, but using the print preview document's frame/node.
  IPC_MESSAGE_ROUTED0(PrintMsg_PrintForSystemDialog)
 diff --git a/components/printing/renderer/print_render_frame_helper.cc b/components/printing/renderer/print_render_frame_helper.cc
-index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..2910edeefff446c2f178123185ee01c199df80be 100644
+index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..d842180c0d69b993971b50d5a1dcf8ad336dd7a9 100644
 --- a/components/printing/renderer/print_render_frame_helper.cc
 +++ b/components/printing/renderer/print_render_frame_helper.cc
-@@ -1115,7 +1115,9 @@ void PrintRenderFrameHelper::ScriptedPrint(bool user_initiated) {
+@@ -37,6 +37,7 @@
+ #include "net/base/registry_controlled_domains/registry_controlled_domain.h"
+ #include "printing/buildflags/buildflags.h"
+ #include "printing/metafile_skia.h"
++#include "printing/print_settings.h"
+ #include "printing/units.h"
+ #include "third_party/blink/public/common/frame/frame_owner_element_type.h"
+ #include "third_party/blink/public/common/frame/sandbox_flags.h"
+@@ -1115,7 +1116,9 @@ void PrintRenderFrameHelper::ScriptedPrint(bool user_initiated) {
      web_frame->DispatchBeforePrintEvent();
      if (!weak_this)
        return;
@@ -369,7 +377,7 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..2910edeefff446c2f178123185ee01c1
      if (weak_this)
        web_frame->DispatchAfterPrintEvent();
    }
-@@ -1163,7 +1165,10 @@ void PrintRenderFrameHelper::OnDestruct() {
+@@ -1163,7 +1166,10 @@ void PrintRenderFrameHelper::OnDestruct() {
    delete this;
  }
  
@@ -381,7 +389,7 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..2910edeefff446c2f178123185ee01c1
    if (ipc_nesting_level_ > 1)
      return;
  
-@@ -1176,7 +1181,8 @@ void PrintRenderFrameHelper::OnPrintPages() {
+@@ -1176,7 +1182,8 @@ void PrintRenderFrameHelper::OnPrintPages() {
    // If we are printing a PDF extension frame, find the plugin node and print
    // that instead.
    auto plugin = delegate_->GetPdfElement(frame);
@@ -391,7 +399,7 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..2910edeefff446c2f178123185ee01c1
    if (weak_this)
      frame->DispatchAfterPrintEvent();
    // WARNING: |this| may be gone at this point. Do not do any more work here and
-@@ -1193,7 +1199,7 @@ void PrintRenderFrameHelper::OnPrintForSystemDialog() {
+@@ -1193,7 +1200,7 @@ void PrintRenderFrameHelper::OnPrintForSystemDialog() {
    }
    auto weak_this = weak_ptr_factory_.GetWeakPtr();
    Print(frame, print_preview_context_.source_node(),
@@ -400,7 +408,7 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..2910edeefff446c2f178123185ee01c1
    if (weak_this)
      frame->DispatchAfterPrintEvent();
    // WARNING: |this| may be gone at this point. Do not do any more work here and
-@@ -1229,6 +1235,8 @@ void PrintRenderFrameHelper::OnPrintPreview(
+@@ -1229,6 +1236,8 @@ void PrintRenderFrameHelper::OnPrintPreview(
    if (ipc_nesting_level_ > 1)
      return;
  
@@ -409,7 +417,7 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..2910edeefff446c2f178123185ee01c1
    print_preview_context_.OnPrintPreview();
  
    UMA_HISTOGRAM_ENUMERATION("PrintPreview.PreviewEvent",
-@@ -1621,7 +1629,10 @@ void PrintRenderFrameHelper::PrintNode(const blink::WebNode& node) {
+@@ -1621,7 +1630,10 @@ void PrintRenderFrameHelper::PrintNode(const blink::WebNode& node) {
  
      auto self = weak_ptr_factory_.GetWeakPtr();
      Print(duplicate_node.GetDocument().GetFrame(), duplicate_node,
@@ -421,7 +429,7 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..2910edeefff446c2f178123185ee01c1
      // Check if |this| is still valid.
      if (!self)
        return;
-@@ -1632,7 +1643,10 @@ void PrintRenderFrameHelper::PrintNode(const blink::WebNode& node) {
+@@ -1632,7 +1644,10 @@ void PrintRenderFrameHelper::PrintNode(const blink::WebNode& node) {
  
  void PrintRenderFrameHelper::Print(blink::WebLocalFrame* frame,
                                     const blink::WebNode& node,
@@ -433,7 +441,7 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..2910edeefff446c2f178123185ee01c1
    // If still not finished with earlier print request simply ignore.
    if (prep_frame_view_)
      return;
-@@ -1640,7 +1654,7 @@ void PrintRenderFrameHelper::Print(blink::WebLocalFrame* frame,
+@@ -1640,7 +1655,7 @@ void PrintRenderFrameHelper::Print(blink::WebLocalFrame* frame,
    FrameReference frame_ref(frame);
  
    int expected_page_count = 0;
@@ -442,19 +450,21 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..2910edeefff446c2f178123185ee01c1
      DidFinishPrinting(FAIL_PRINT_INIT);
      return;  // Failed to init print page settings.
    }
-@@ -1660,8 +1674,9 @@ void PrintRenderFrameHelper::Print(blink::WebLocalFrame* frame,
+@@ -1660,8 +1675,11 @@ void PrintRenderFrameHelper::Print(blink::WebLocalFrame* frame,
  
      PrintMsg_PrintPages_Params print_settings;
      auto self = weak_ptr_factory_.GetWeakPtr();
 -    GetPrintSettingsFromUser(frame_ref.GetFrame(), node, expected_page_count,
 -                             print_request_type, &print_settings);
-+    if (!silent)
++    if (silent)
++      print_settings = *print_pages_params_.get();
++    else
 +      GetPrintSettingsFromUser(frame_ref.GetFrame(), node, expected_page_count,
-+                              print_request_type, &print_settings);
++                               print_request_type, &print_settings);
      // Check if |this| is still valid.
      if (!self)
        return;
-@@ -1671,6 +1686,7 @@ void PrintRenderFrameHelper::Print(blink::WebLocalFrame* frame,
+@@ -1671,6 +1689,7 @@ void PrintRenderFrameHelper::Print(blink::WebLocalFrame* frame,
              ? blink::kWebPrintScalingOptionSourceSize
              : scaling_option;
      SetPrintPagesParams(print_settings);
@@ -462,7 +472,7 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..2910edeefff446c2f178123185ee01c1
      if (print_settings.params.dpi.IsEmpty() ||
          !print_settings.params.document_cookie) {
        DidFinishPrinting(OK);  // Release resources and fail silently on failure.
-@@ -1859,10 +1875,24 @@ std::vector<int> PrintRenderFrameHelper::GetPrintedPages(
+@@ -1859,10 +1878,24 @@ std::vector<int> PrintRenderFrameHelper::GetPrintedPages(
    return printed_pages;
  }
  
@@ -490,7 +500,7 @@ index 74f26daa76a22c749007f06a7f4eeeafb8bb297b..2910edeefff446c2f178123185ee01c1
    // Check if the printer returned any settings, if the settings is empty, we
    // can safely assume there are no printer drivers configured. So we safely
    // terminate.
-@@ -1882,12 +1912,14 @@ bool PrintRenderFrameHelper::InitPrintSettings(bool fit_to_paper_size) {
+@@ -1882,12 +1915,14 @@ bool PrintRenderFrameHelper::InitPrintSettings(bool fit_to_paper_size) {
    return result;
  }
  


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/18123.

Previously, printing settings weren't set if printing was silent, and so it would appear to do nothing because subsequent action relied on those being set properly.

cc @brenca 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed silent printing across platforms.
