### PR TITLE
docs: menuItem.registerAccelerator not available on macOS

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -28,7 +28,7 @@ See [`Menu`](menu.md) for examples.
   * `visible` Boolean (optional) - If false, the menu item will be entirely hidden.
   * `checked` Boolean (optional) - Should only be specified for `checkbox` or `radio` type
     menu items.
-  * `registerAccelerator` Boolean (optional) - If false, the accelerator won't be registered
+  * `registerAccelerator` Boolean (optional) _Linux_ _Windows_ - If false, the accelerator won't be registered
     with the system, but it will still be displayed. Defaults to true.
   * `submenu` (MenuItemConstructorOptions[] | [Menu](menu.md)) (optional) - Should be specified
     for `submenu` type menu items. If `submenu` is specified, the `type: 'submenu'` can be omitted.


### PR DESCRIPTION
#### Description of Change
Follow-up to #18295. Until either we can find a better solution or until Apple allows us greater `NSMenuItem` granularity, the `registerAccelerator` property only works on Windows and Linux. This should be stated in the docs.

cc @codebytere @erickzhao 

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none