### PR TITLE
test: move tray api tests to main process

### DIFF
--- a/spec-main/api-tray-spec.ts
+++ b/spec-main/api-tray-spec.ts
@@ -31,7 +31,7 @@ describe('tray module', () => {
       expect(tray.isDestroyed()).to.be.false('tray should not be destroyed')
       tray.destroy()
 
-      expect(tray.isDestroyed()).to.be.true('tray is not destroyed')
+      expect(tray.isDestroyed()).to.be.true('tray should be destroyed')
     })
   })
 

--- a/spec-main/api-tray-spec.ts
+++ b/spec-main/api-tray-spec.ts
@@ -28,7 +28,7 @@ describe('tray module', () => {
 
   describe('tray.destroy()', () => {
     it('destroys a tray', () => {
-      expect(tray.isDestroyed()).to.be.false('tray is destroyed')
+      expect(tray.isDestroyed()).to.be.false('tray should not be destroyed')
       tray.destroy()
 
       expect(tray.isDestroyed()).to.be.true('tray is not destroyed')

--- a/spec-main/api-tray-spec.ts
+++ b/spec-main/api-tray-spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { Menu, Tray, nativeImage } from 'electron'
 
-describe.only('tray module', () => {
+describe('tray module', () => {
   let tray: Tray;
 
   beforeEach(() => {

--- a/spec-main/api-tray-spec.ts
+++ b/spec-main/api-tray-spec.ts
@@ -28,10 +28,10 @@ describe('tray module', () => {
 
   describe('tray.destroy()', () => {
     it('destroys a tray', () => {
-      expect(tray.isDestroyed()).to.equal(false)
+      expect(tray.isDestroyed()).to.be.false('tray is destroyed')
       tray.destroy()
 
-      expect(tray.isDestroyed()).to.equal(true)
+      expect(tray.isDestroyed()).to.be.true('tray is not destroyed')
     })
   })
 

--- a/spec-main/api-tray-spec.ts
+++ b/spec-main/api-tray-spec.ts
@@ -1,9 +1,8 @@
-const { remote } = require('electron')
-const { expect } = require('chai')
-const { Menu, Tray, nativeImage } = remote
+import { expect } from 'chai'
+import { Menu, Tray, nativeImage } from 'electron'
 
 describe('tray module', () => {
-  let tray
+  let tray: Tray | null = null
 
   beforeEach(() => {
     tray = new Tray(nativeImage.createEmpty())
@@ -11,32 +10,32 @@ describe('tray module', () => {
 
   describe('tray.setContextMenu', () => {
     afterEach(() => {
-      tray.destroy()
+      tray!.destroy()
       tray = null
     })
 
     it('accepts menu instance', () => {
-      tray.setContextMenu(new Menu())
+      tray!.setContextMenu(new Menu())
     })
 
     it('accepts null', () => {
-      tray.setContextMenu(null)
+      tray!.setContextMenu(null)
     })
   })
 
   describe('tray.destroy()', () => {
     it('destroys a tray', () => {
-      expect(tray.isDestroyed()).to.be.false()
-      tray.destroy()
+      expect(tray!.isDestroyed()).to.equal(false)
+      tray!.destroy()
 
-      expect(tray.isDestroyed()).to.be.true()
+      expect(tray!.isDestroyed()).to.equal(true)
       tray = null
     })
   })
 
   describe('tray.popUpContextMenu', () => {
     afterEach(() => {
-      tray.destroy()
+      tray!.destroy()
       tray = null
     })
 
@@ -45,29 +44,29 @@ describe('tray module', () => {
     })
 
     it('can be called when menu is showing', (done) => {
-      tray.setContextMenu(Menu.buildFromTemplate([{ label: 'Test' }]))
+      tray!.setContextMenu(Menu.buildFromTemplate([{ label: 'Test' }]))
       setTimeout(() => {
-        tray.popUpContextMenu()
+        tray!.popUpContextMenu()
         done()
       })
-      tray.popUpContextMenu()
+      tray!.popUpContextMenu()
     })
   })
 
   describe('tray.setImage', () => {
     it('accepts empty image', () => {
-      tray.setImage(nativeImage.createEmpty())
+      tray!.setImage(nativeImage.createEmpty())
 
-      tray.destroy()
+      tray!.destroy()
       tray = null
     })
   })
 
   describe('tray.setPressedImage', () => {
     it('accepts empty image', () => {
-      tray.setPressedImage(nativeImage.createEmpty())
+      tray!.setPressedImage(nativeImage.createEmpty())
 
-      tray.destroy()
+      tray!.destroy()
       tray = null
     })
   })
@@ -78,22 +77,22 @@ describe('tray module', () => {
     })
 
     afterEach(() => {
-      tray.destroy()
+      tray!.destroy()
       tray = null
     })
 
     it('sets/gets non-empty title', () => {
       const title = 'Hello World!'
-      tray.setTitle(title)
-      const newTitle = tray.getTitle()
+      tray!.setTitle(title)
+      const newTitle = tray!.getTitle()
 
       expect(newTitle).to.equal(title)
     })
 
     it('sets/gets empty title', () => {
       const title = ''
-      tray.setTitle(title)
-      const newTitle = tray.getTitle()
+      tray!.setTitle(title)
+      const newTitle = tray!.getTitle()
 
       expect(newTitle).to.equal(title)
     })

--- a/spec-main/api-tray-spec.ts
+++ b/spec-main/api-tray-spec.ts
@@ -1,42 +1,43 @@
 import { expect } from 'chai'
 import { Menu, Tray, nativeImage } from 'electron'
 
-describe('tray module', () => {
-  let tray: Tray | null = null
+describe.only('tray module', () => {
+  let tray: Tray;
 
   beforeEach(() => {
     tray = new Tray(nativeImage.createEmpty())
   })
 
+  afterEach(() => {
+    tray = null as any
+  })
+
   describe('tray.setContextMenu', () => {
     afterEach(() => {
-      tray!.destroy()
-      tray = null
+      tray.destroy()
     })
 
     it('accepts menu instance', () => {
-      tray!.setContextMenu(new Menu())
+      tray.setContextMenu(new Menu())
     })
 
     it('accepts null', () => {
-      tray!.setContextMenu(null)
+      tray.setContextMenu(null)
     })
   })
 
   describe('tray.destroy()', () => {
     it('destroys a tray', () => {
-      expect(tray!.isDestroyed()).to.equal(false)
-      tray!.destroy()
+      expect(tray.isDestroyed()).to.equal(false)
+      tray.destroy()
 
-      expect(tray!.isDestroyed()).to.equal(true)
-      tray = null
+      expect(tray.isDestroyed()).to.equal(true)
     })
   })
 
   describe('tray.popUpContextMenu', () => {
     afterEach(() => {
-      tray!.destroy()
-      tray = null
+      tray.destroy()
     })
 
     before(function () {
@@ -44,30 +45,28 @@ describe('tray module', () => {
     })
 
     it('can be called when menu is showing', (done) => {
-      tray!.setContextMenu(Menu.buildFromTemplate([{ label: 'Test' }]))
+      tray.setContextMenu(Menu.buildFromTemplate([{ label: 'Test' }]))
       setTimeout(() => {
-        tray!.popUpContextMenu()
+        tray.popUpContextMenu()
         done()
       })
-      tray!.popUpContextMenu()
+      tray.popUpContextMenu()
     })
   })
 
   describe('tray.setImage', () => {
     it('accepts empty image', () => {
-      tray!.setImage(nativeImage.createEmpty())
+      tray.setImage(nativeImage.createEmpty())
 
-      tray!.destroy()
-      tray = null
+      tray.destroy()
     })
   })
 
   describe('tray.setPressedImage', () => {
     it('accepts empty image', () => {
-      tray!.setPressedImage(nativeImage.createEmpty())
+      tray.setPressedImage(nativeImage.createEmpty())
 
-      tray!.destroy()
-      tray = null
+      tray.destroy()
     })
   })
 
@@ -77,22 +76,21 @@ describe('tray module', () => {
     })
 
     afterEach(() => {
-      tray!.destroy()
-      tray = null
+      tray.destroy()
     })
 
     it('sets/gets non-empty title', () => {
       const title = 'Hello World!'
-      tray!.setTitle(title)
-      const newTitle = tray!.getTitle()
+      tray.setTitle(title)
+      const newTitle = tray.getTitle()
 
       expect(newTitle).to.equal(title)
     })
 
     it('sets/gets empty title', () => {
       const title = ''
-      tray!.setTitle(title)
-      const newTitle = tray!.getTitle()
+      tray.setTitle(title)
+      const newTitle = tray.getTitle()
 
       expect(newTitle).to.equal(title)
     })


### PR DESCRIPTION
#### Description of Change
- moved tray api tests from remote to main process
- migrated tests to typescript (no definition changes needed)

_nb:_ i might add some tests after #18981 got merged

cc @nornagon @codebytere 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
