### PR TITLE
docs: fix platform location for params

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1179,10 +1179,10 @@ Show the app's about panel options. These options can be overridden with `app.se
   * `applicationVersion` String (optional) - The app's version.
   * `copyright` String (optional) - Copyright information.
   * `version` String (optional) - The app's build version number.
-  * `credits` String (optional) - Credit information. _macOS_
-  * `authors` String[] (optional) - List of app authors. _Linux_
-  * `website` String (optional) - The app's website. _Linux_
-  * `iconPath` String (optional) - Path to the app's icon. Will be shown as 64x64 pixels while retaining aspect ratio. _Linux_
+  * `credits` String (optional) _macOS_ - Credit information.
+  * `authors` String[] (optional) _Linux_ - List of app authors.
+  * `website` String (optional) _Linux_ - The app's website.
+  * `iconPath` String (optional) _Linux_ - Path to the app's icon. Will be shown as 64x64 pixels while retaining aspect ratio.
 
 Set the about panel options. This will override the values defined in the app's
 `.plist` file on MacOS. See the [Apple docs][about-panel-options] for more details. On Linux, values must be set in order to be shown; there are no defaults.

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -24,7 +24,7 @@ See [`Menu`](menu.md) for examples.
   * `icon` ([NativeImage](native-image.md) | String) (optional)
   * `enabled` Boolean (optional) - If false, the menu item will be greyed out and
     unclickable.
-  * `acceleratorWorksWhenHidden` Boolean (optional) - default is `true`, and when `false` will prevent the accelerator from triggering the item if the item is not visible`. _macOS_
+  * `acceleratorWorksWhenHidden` Boolean (optional) _macOS_ - default is `true`, and when `false` will prevent the accelerator from triggering the item if the item is not visible`.
   * `visible` Boolean (optional) - If false, the menu item will be entirely hidden.
   * `checked` Boolean (optional) - Should only be specified for `checkbox` or `radio` type
     menu items.

--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -36,9 +36,8 @@ Open the given file in the desktop's default manner.
 
 * `url` String - Max 2081 characters on windows.
 * `options` Object (optional)
-  * `activate` Boolean (optional) - `true` to bring the opened application to the
-    foreground. The default is `true`. _macOS_
-  * `workingDirectory` String (optional) - The working directory. _Windows_
+  * `activate` Boolean (optional) _macOS_ - `true` to bring the opened application to the foreground. The default is `true`.
+  * `workingDirectory` String (optional) _Windows_ - The working directory.
 
 Returns `Promise<void>`
 

--- a/docs/api/structures/process-memory-info.md
+++ b/docs/api/structures/process-memory-info.md
@@ -1,8 +1,7 @@
 # ProcessMemoryInfo Object
 
-* `residentSet` Integer - _Linux_ and _Windows_ - The amount of memory
+* `residentSet` Integer _Linux_ _Windows_ - The amount of memory
 currently pinned to actual physical RAM in Kilobytes.
-* `private` Integer - The amount of memory not shared by other processes, such as
-  JS heap or HTML content in Kilobytes.
+* `private` Integer - The amount of memory not shared by other processes, such as JS heap or HTML content in Kilobytes.
 * `shared` Integer - The amount of memory shared between processes, typically
   memory consumed by the Electron code itself in Kilobytes.


### PR DESCRIPTION
#### Description of Change

Most of our argument platform specifiers follow the optionality specifier, so this standardizes those that don't to fit that existing pattern.

cc @DeerMichel, who brought this to my attention 🙇‍♀ 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
