### PR TITLE
fix: do not wait on promise returned by remote APIs

### DIFF
--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -277,6 +277,11 @@ webview.addEventListener('dom-ready', () => {
   * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadBlob[]](structures/upload-blob.md)) (optional)
   * `baseURLForDataURL` String (optional) - Base url (with trailing path separator) for files to be loaded by the data url. This is needed only if the specified `url` is a data url and needs to load other files.
 
+Returns `Promise<void>` - The promise will resolve when the page has finished loading
+(see [`did-finish-load`](webview-tag.md#event-did-finish-load)), and rejects
+if the page fails to load (see
+[`did-fail-load`](webview-tag.md#event-did-fail-load)).
+
 Loads the `url` in the webview, the `url` must contain the protocol prefix,
 e.g. the `http://` or `file://`.
 

--- a/lib/common/web-view-methods.js
+++ b/lib/common/web-view-methods.js
@@ -3,7 +3,6 @@
 // Public-facing API methods.
 exports.syncMethods = new Set([
   'getURL',
-  'loadURL',
   'getTitle',
   'isLoading',
   'isLoadingMainFrame',
@@ -54,6 +53,7 @@ exports.syncMethods = new Set([
 ])
 
 exports.asyncMethods = new Set([
+  'loadURL',
   'capturePage',
   'executeJavaScript',
   'insertCSS',

--- a/lib/renderer/web-view/web-view-attributes.ts
+++ b/lib/renderer/web-view/web-view-attributes.ts
@@ -196,7 +196,7 @@ class SrcAttribute extends WebViewAttribute {
     const method = 'loadURL'
     const args = [this.getValue(), opts]
 
-    ipcRendererUtils.invokeSync('ELECTRON_GUEST_VIEW_MANAGER_CALL', guestInstanceId, method, args)
+    ipcRendererUtils.invoke('ELECTRON_GUEST_VIEW_MANAGER_CALL', guestInstanceId, method, args)
   }
 }
 

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -170,6 +170,20 @@ describe('<webview> tag', function () {
         expect(webview.src).to.equal('')
       }
     })
+
+    it('does not wait until loadURL is resolved', async () => {
+      await loadWebView(webview, { src: 'about:blank' })
+
+      const before = Date.now()
+      webview.src = 'https://github.com'
+      const now = Date.now()
+
+      // Setting src is essentially sending a sync IPC message, which should
+      // not exceed more than a few ms.
+      //
+      // This is for testing #18638.
+      expect(now - before).to.be.below(100)
+    })
   })
 
   describe('nodeintegration attribute', () => {


### PR DESCRIPTION
#### Description of Change

Close #18638.

This PR fixes the bug in `ipcMainUtils.handle` that, the helper waits on Promise returned by handler when it shouldn't.
 
For the original issue, `ipcMainUtils.handle` waits on the Promised returned by `WebContents.loadURL`, resulting in setting src being blocked until the URL is loaded. 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix setting `src` on `<webview>` being too slow.