### PR TITLE
fix: Observer removal from an empty collection causes access violation

### DIFF
--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -293,7 +293,9 @@ class WebContents : public mate::TrackableObject<WebContents>,
     observers_.AddObserver(obs);
   }
   void RemoveObserver(ExtendedWebContentsObserver* obs) {
-    observers_.RemoveObserver(obs);
+    // Trying to remove from an empty collection leads to an access violation
+    if (observers_.might_have_observers())
+      observers_.RemoveObserver(obs);
   }
 
   bool EmitNavigationEvent(const std::string& event,


### PR DESCRIPTION
Closes https://github.com/electron/electron/issues/18988.

Backport of https://github.com/electron/electron/pull/15739.

See that PR for more details.

Notes: none