### PR TITLE
fix: make run-gn-format work properly on Windows

### DIFF
--- a/script/run-gn-format.py
+++ b/script/run-gn-format.py
@@ -15,6 +15,7 @@ def main():
   for gn_file in sys.argv[1:]:
     subprocess.check_call(
       ['gn', 'format', gn_file],
+      shell=True,
       env=new_env
     )
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Pretty much what the title says, `run-gn-format.py` didn't work for me locally in `PowerShell` because of a missing `shell=True`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes<!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
