### PR TITLE
fix: Correct modal focus behavior on macOS

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -538,8 +538,6 @@ bool NativeWindowMac::IsFocused() {
 
 void NativeWindowMac::Show() {
   if (is_modal() && parent()) {
-    LOG(INFO) << "[LOG] Showing my modal";
-    // parent()->SetFocusable(false);
     if ([window_ sheetParent] == nil)
       [parent()->GetNativeWindow().GetNativeNSWindow()
                  beginSheet:window_

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -538,6 +538,8 @@ bool NativeWindowMac::IsFocused() {
 
 void NativeWindowMac::Show() {
   if (is_modal() && parent()) {
+    LOG(INFO) << "[LOG] Showing my modal";
+    // parent()->SetFocusable(false);
     if ([window_ sheetParent] == nil)
       [parent()->GetNativeWindow().GetNativeNSWindow()
                  beginSheet:window_

--- a/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -88,11 +88,11 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
   return frame;
 }
 
-- (void)windowDidBecomeMain:(NSNotification*)notification {
+- (void)windowDidBecomeKey:(NSNotification*)notification {
   shell_->NotifyWindowFocus();
 }
 
-- (void)windowDidResignMain:(NSNotification*)notification {
+- (void)windowDidResignKey:(NSNotification*)notification {
   shell_->NotifyWindowBlur();
 }
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1639,7 +1639,7 @@ describe('BrowserWindow module', () => {
 
   describe('focus event', () => {
     it('should not emit if focusing on a main window with a modal open', (done) => {
-      let childWindowClosed = false
+      const childWindowClosed = false
       const child = new BrowserWindow({
         parent: w,
         modal: true,
@@ -1652,21 +1652,11 @@ describe('BrowserWindow module', () => {
 
       child.on('show', () => {
         w.once('focus', () => {
-          expect(childWindowClosed).to.equal(true,
-            'Main window should only regain focus once the modal is closed')
+          expect(child.isDestroyed()).to.equal(true)
           done()
         })
         w.focus() // this should not trigger the above listener
         child.close()
-      })
-
-      // trying stuff...
-      child.on('close', () => {
-        childWindowClosed = true
-      })
-
-      child.on('closed', () => {
-        childWindowClosed = true
       })
 
       // act

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1637,6 +1637,44 @@ describe('BrowserWindow module', () => {
     })
   })
 
+  describe('focus event', () => {
+    it('should not emit if focusing on a main window with a modal open', (done) => {
+      let hasMainFocusAfterModalFocus = false
+      const child = new BrowserWindow({
+        parent: w,
+        modal: true,
+        show: false
+      })
+
+      child.once('ready-to-show', () => {
+        child.show()
+      })
+
+      // after child gains focus, attempt to focus on
+      // main window, and set flag if this was successful
+      child.once('focus', () => {
+        w.once('focus', () => {
+          hasMainFocusAfterModalFocus = true
+        })
+        w.focus()
+        // close child to end the spec
+        child.close()
+      })
+
+      // clean up and assert that main window never
+      // regained focus
+      child.once('closed', () => {
+        w.removeAllListeners()
+        w.close()
+        expect(hasMainFocusAfterModalFocus).to.equal(false)
+        done()
+      })
+
+      child.loadURL(server.url)
+      w.show()
+    })
+  })
+
   describe('sheet-begin event', () => {
     let sheet = null
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1639,7 +1639,6 @@ describe('BrowserWindow module', () => {
 
   describe('focus event', () => {
     it('should not emit if focusing on a main window with a modal open', (done) => {
-      let hasMainFocus = false
       let childWindowClosed = false
       const child = new BrowserWindow({
         parent: w,
@@ -1651,27 +1650,20 @@ describe('BrowserWindow module', () => {
         child.show()
       })
 
-      // after child gains focus, attempt to focus on
-      // main window, and set flag if this was successful
-      child.once('focus', () => {
+      child.on('show', () => {
         w.once('focus', () => {
-          hasMainFocus = true
-          expect(childWindowClosed).to.equal(true)
+          expect(childWindowClosed).to.equal(true, 'Main window should only regain focus once the modal is closed')
           done()
         })
-        w.focus()
-        // close child to end the spec
+        w.focus() // this should not trigger the above listener
         child.close()
       })
 
-      // clean up
-      // assert that main window didn't regain focus
-      // assert that main window
-      child.once('closed', () => {
+      child.on('closed', () => {
         childWindowClosed = true
-        expect(hasMainFocus).to.equal(false)
       })
 
+      // act
       child.loadURL(server.url)
       w.show()
     })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1652,11 +1652,17 @@ describe('BrowserWindow module', () => {
 
       child.on('show', () => {
         w.once('focus', () => {
-          expect(childWindowClosed).to.equal(true, 'Main window should only regain focus once the modal is closed')
+          expect(childWindowClosed).to.equal(true,
+            'Main window should only regain focus once the modal is closed')
           done()
         })
         w.focus() // this should not trigger the above listener
         child.close()
+      })
+
+      // trying stuff...
+      child.on('close', () => {
+        childWindowClosed = true
       })
 
       child.on('closed', () => {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1639,7 +1639,8 @@ describe('BrowserWindow module', () => {
 
   describe('focus event', () => {
     it('should not emit if focusing on a main window with a modal open', (done) => {
-      let hasMainFocusAfterModalFocus = false
+      let hasMainFocus = false
+      let childWindowClosed = false
       const child = new BrowserWindow({
         parent: w,
         modal: true,
@@ -1654,20 +1655,21 @@ describe('BrowserWindow module', () => {
       // main window, and set flag if this was successful
       child.once('focus', () => {
         w.once('focus', () => {
-          hasMainFocusAfterModalFocus = true
+          hasMainFocus = true
+          expect(childWindowClosed).to.equal(true)
+          done()
         })
         w.focus()
         // close child to end the spec
         child.close()
       })
 
-      // clean up and assert that main window never
-      // regained focus
+      // clean up
+      // assert that main window didn't regain focus
+      // assert that main window
       child.once('closed', () => {
-        w.removeAllListeners()
-        w.close()
-        expect(hasMainFocusAfterModalFocus).to.equal(false)
-        done()
+        childWindowClosed = true
+        expect(hasMainFocus).to.equal(false)
       })
 
       child.loadURL(server.url)


### PR DESCRIPTION
#### Description of Change
Fixes #18502

This PR changes the `focus` and `blur` events that we emit in Electron to listen to changes in key window rather than main window. It swaps out `windowDidBecomeMain` and `windowDidResignMain` for `windowDidBecomeKey` and `windowDidResignKey`, respectively.

It seems to work as intended now. Also added a new test to test this exact situation. Please let me know if there's a less convoluted way to test this specific case, since it seems like I'm listening to a very specific series of events. Test seems to be working locally on my end, and fails on a downloaded CI build from `master`. ✅ 

##### Context

In our macOS code, the `NativeWindowMac::Show()` function in `native_window_mac.mm` calls this [`beginSheet`](https://developer.apple.com/documentation/appkit/nswindow/1419653-beginsheet) function, which specifies that:
>If the window has no presented sheets, this method displays the specified sheet, **makes it key**, and returns control to the caller. While the sheet remains visible, most events targeted at the receiver are prohibited.

For additional context, see [Apple developer documentation on key and main windows](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/WinPanel/Concepts/ChangingMainKeyWindow.html) here.

Fiddle: https://gist.github.com/c9c19684f6e0d23c102161fb3e86500b

----------------------

cc @codebytere @DeerMichel 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed bug on macOS where the main window could be targeted for a `focus` event when it was disabled behind a modal.
