### PR TITLE
fix: crash when tray popup called twice

### DIFF
--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -340,9 +340,6 @@ const CGFloat kVerticalTitleMargin = 2;
   // Make sure events can be pumped while the menu is up.
   base::MessageLoopCurrent::ScopedNestableTaskAllower allow;
 
-  // Ensure the UI can update while the menu is fading out.
-  base::ScopedPumpMessagesInPrivateModes pump_private;
-
   // Show a custom menu.
   if (menu_model) {
     base::scoped_nsobject<AtomMenuController> menuController(
@@ -358,6 +355,9 @@ const CGFloat kVerticalTitleMargin = 2;
   }
 
   if (menuController_ && ![menuController_ isMenuOpen]) {
+    // Ensure the UI can update while the menu is fading out.
+    base::ScopedPumpMessagesInPrivateModes pump_private;
+
     // Redraw the tray icon to show highlight if it is enabled.
     [self setNeedsDisplay:YES];
 


### PR DESCRIPTION
#### Description of Change

When the Tray popup functionality was made asynchronous, `ScopedPumpMessagesInPrivateModes` was introduced to ensure that the UI can update while the menu is fading out. However, given that we're now asynchronous, there exists a possibility that we can call `popUpContextMenu` more than once and this will cause a crash since we're no longer blocking the main process.

As a result, we only want to call  `ScopedPumpMessagesInPrivateModes` if we're going to open the menu, which means that we first need to ensure that the menu is not already open. This PR thus fixes the aforementioned crash which can be seen in the following code before this PR and is fixed with the code therein.

```js
  tray.setContextMenu(contextMenu)
  tray.popUpContextMenu()
  tray.popUpContextMenu()
```

cc @DeerMichel @miniak 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash on tray popup being called multiple times in a row.
