### PR TITLE
refactor: pass preload script paths to renderer via IPC

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -3,6 +3,7 @@
 const electron = require('electron')
 const { EventEmitter } = require('events')
 const fs = require('fs')
+const path = require('path')
 
 const v8Util = process.electronBinding('v8_util')
 const eventBinding = process.electronBinding('event')
@@ -519,27 +520,45 @@ if (features.isDesktopCapturerEnabled()) {
 const getPreloadScript = async function (preloadPath) {
   let preloadSrc = null
   let preloadError = null
-  if (preloadPath) {
-    try {
-      preloadSrc = (await fs.promises.readFile(preloadPath)).toString()
-    } catch (err) {
-      preloadError = errorUtils.serialize(err)
-    }
+  try {
+    preloadSrc = (await fs.promises.readFile(preloadPath)).toString()
+  } catch (err) {
+    preloadError = errorUtils.serialize(err)
   }
   return { preloadPath, preloadSrc, preloadError }
 }
 
-ipcMainUtils.handle('ELECTRON_GET_CONTENT_SCRIPTS', () => getContentScripts())
+const getPreloadPaths = function (contents) {
+  const result = []
+
+  for (const preload of contents.session ? contents.session.getPreloads() : []) {
+    if (path.isAbsolute(preload)) {
+      result.push(preload)
+    } else {
+      console.error(`preload script must have absolute path: ${preload}`)
+    }
+  }
+
+  const preload = contents._getPreloadPath()
+  if (preload) {
+    result.push(preload)
+  }
+
+  return result
+}
+
+ipcMainUtils.handle('ELECTRON_INIT_RENDERER', function (event) {
+  return {
+    appPath: electron.app.getAppPath(),
+    contentScripts: getContentScripts(),
+    preloadScripts: getPreloadPaths(event.sender)
+  }
+})
 
 ipcMainUtils.handle('ELECTRON_BROWSER_SANDBOX_LOAD', async function (event) {
-  const preloadPaths = [
-    ...(event.sender.session ? event.sender.session.getPreloads() : []),
-    event.sender._getPreloadPath()
-  ]
-
   return {
     contentScripts: getContentScripts(),
-    preloadScripts: await Promise.all(preloadPaths.map(path => getPreloadScript(path))),
+    preloadScripts: await Promise.all(getPreloadPaths(event.sender).map(path => getPreloadScript(path))),
     isRemoteModuleEnabled: isRemoteModuleEnabled(event.sender),
     isWebViewTagEnabled: guestViewManager.isWebViewTagEnabled(event.sender),
     process: {

--- a/shell/browser/atom_browser_client.cc
+++ b/shell/browser/atom_browser_client.cc
@@ -510,11 +510,6 @@ void AtomBrowserClient::AppendExtraCommandLineSwitches(
   }
 #endif
 
-  if (delegate_) {
-    auto app_path = static_cast<api::App*>(delegate_)->GetAppPath();
-    command_line->AppendSwitchPath(switches::kAppPath, app_path);
-  }
-
   content::WebContents* web_contents = GetWebContentsFromProcessID(process_id);
   if (web_contents) {
     if (web_contents->GetVisibleURL().SchemeIs("devtools")) {
@@ -524,8 +519,6 @@ void AtomBrowserClient::AppendExtraCommandLineSwitches(
     if (web_preferences)
       web_preferences->AppendCommandLineSwitches(
           command_line, IsRendererSubFrame(process_id));
-    SessionPreferences::AppendExtraCommandLineSwitches(
-        web_contents->GetBrowserContext(), command_line);
     if (CanUseCustomSiteInstance()) {
       command_line->AppendSwitch(
           switches::kDisableElectronSiteInstanceOverrides);

--- a/shell/browser/session_preferences.cc
+++ b/shell/browser/session_preferences.cc
@@ -4,21 +4,7 @@
 
 #include "shell/browser/session_preferences.h"
 
-#include "base/command_line.h"
-#include "base/memory/ptr_util.h"
-#include "shell/common/options_switches.h"
-
 namespace electron {
-
-namespace {
-
-#if defined(OS_WIN)
-const base::FilePath::CharType kPathDelimiter = FILE_PATH_LITERAL(';');
-#else
-const base::FilePath::CharType kPathDelimiter = FILE_PATH_LITERAL(':');
-#endif
-
-}  // namespace
 
 // static
 int SessionPreferences::kLocatorKey = 0;
@@ -33,29 +19,6 @@ SessionPreferences::~SessionPreferences() {}
 SessionPreferences* SessionPreferences::FromBrowserContext(
     content::BrowserContext* context) {
   return static_cast<SessionPreferences*>(context->GetUserData(&kLocatorKey));
-}
-
-// static
-void SessionPreferences::AppendExtraCommandLineSwitches(
-    content::BrowserContext* context,
-    base::CommandLine* command_line) {
-  SessionPreferences* self = FromBrowserContext(context);
-  if (!self)
-    return;
-
-  base::FilePath::StringType preloads;
-  for (const auto& preload : self->preloads()) {
-    if (!base::FilePath(preload).IsAbsolute()) {
-      LOG(ERROR) << "preload script must have absolute path: " << preload;
-      continue;
-    }
-    if (preloads.empty())
-      preloads = preload;
-    else
-      preloads += kPathDelimiter + preload;
-  }
-  if (!preloads.empty())
-    command_line->AppendSwitchNative(switches::kPreloadScripts, preloads);
 }
 
 }  // namespace electron

--- a/shell/browser/session_preferences.h
+++ b/shell/browser/session_preferences.h
@@ -21,8 +21,6 @@ class SessionPreferences : public base::SupportsUserData::Data {
  public:
   static SessionPreferences* FromBrowserContext(
       content::BrowserContext* context);
-  static void AppendExtraCommandLineSwitches(content::BrowserContext* context,
-                                             base::CommandLine* command_line);
 
   explicit SessionPreferences(content::BrowserContext* context);
   ~SessionPreferences() override;

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -314,11 +314,6 @@ void WebContentsPreferences::AppendCommandLineSwitches(
   if (IsEnabled(options::kNativeWindowOpen))
     command_line->AppendSwitch(switches::kNativeWindowOpen);
 
-  // The preload script.
-  base::FilePath::StringType preload;
-  if (GetPreloadPath(&preload))
-    command_line->AppendSwitchNative(switches::kPreloadScript, preload);
-
   // Custom args for renderer process
   auto* customArgs =
       preference_.FindKeyOfType(options::kCustomArgs, base::Value::Type::LIST);

--- a/shell/common/options_switches.cc
+++ b/shell/common/options_switches.cc
@@ -216,13 +216,8 @@ const char kCORSSchemes[] = "cors-schemes";
 // The browser process app model ID
 const char kAppUserModelId[] = "app-user-model-id";
 
-// The application path
-const char kAppPath[] = "app-path";
-
 // The command line switch versions of the options.
 const char kBackgroundColor[] = "background-color";
-const char kPreloadScript[] = "preload";
-const char kPreloadScripts[] = "preload-scripts";
 const char kNodeIntegration[] = "node-integration";
 const char kDisableRemoteModule[] = "disable-remote-module";
 const char kContextIsolation[] = "context-isolation";

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -101,11 +101,8 @@ extern const char kBypassCSPSchemes[];
 extern const char kFetchSchemes[];
 extern const char kCORSSchemes[];
 extern const char kAppUserModelId[];
-extern const char kAppPath[];
 
 extern const char kBackgroundColor[];
-extern const char kPreloadScript[];
-extern const char kPreloadScripts[];
 extern const char kNodeIntegration[];
 extern const char kDisableRemoteModule[];
 extern const char kContextIsolation[];

--- a/spec/fixtures/api/new-window.html
+++ b/spec/fixtures/api/new-window.html
@@ -7,7 +7,7 @@
   <body>
     <script type="text/javascript">
       setTimeout(function () {
-        window.open('http://localhost')
+        window.open()
       })
     </script>
   </body>

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -52,6 +52,12 @@ declare namespace Electron {
     contentScripts: ContentScript[];
   }
 
+  type InitRendererPayload = {
+    appPath: string;
+    contentScripts: ContentScriptEntry;
+    preloadScripts: string[];
+  }
+
   interface IpcRendererInternal extends Electron.IpcRenderer {
     sendToAll(webContentsId: number, channel: string, ...args: any[]): void
   }


### PR DESCRIPTION
#### Description of Change
Pass the list of preload scripts to be loaded in non-sandboxed renderers via IPC as the command-line is shared when the same renderer process is hosting multiple `BrowserWindows` (scriptable popup with  `nativeWindowOpen: true` for example).

The new `ELECTRON_INIT_RENDERER` IPC replaces `ELECTRON_GET_CONTENT_SCRIPTS` introduced in #18823.

There will be a follow-up PR to pass the remaining options via IPC instead of command-line.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Preload scripts configured for popups when handling the `new-window` event now work properly regardless of whether a new renderer process is hosting the contents (cross-origin) or the same renderer (same-origin).