### PR TITLE
refactor: improve function deprecation module

### DIFF
--- a/lib/common/api/deprecate.ts
+++ b/lib/common/api/deprecate.ts
@@ -39,13 +39,11 @@ const deprecate: ElectronInternal.DeprecationUtil = {
     // if the function has already been removed, warn about it
     if (!fn) {
       deprecate.log(`Unable to remove function '${removedName}' from an object that lacks it.`)
-      return function (this: any) {
-        deprecate.log(`'${removedName} function' has been removed. See release notes for further information.`)
-      }
+      throw Error(`'${removedName} function' has been removed. See release notes for further information.`)
     }
 
     // wrap the deprecated function to warn user
-    const warn = warnOnce(`${removedName} function`)
+    const warn = warnOnce(`${fn.name} function`)
     return function (this: any) {
       warn()
       fn.apply(this, arguments)

--- a/lib/common/api/deprecate.ts
+++ b/lib/common/api/deprecate.ts
@@ -43,6 +43,24 @@ const deprecate: ElectronInternal.DeprecationUtil = {
     }
   },
 
+  // remove a function with no replacement
+  removeFunction: (fn, name) => {
+    // if the function has already been removed, warn about it
+    if (!fn) {
+      deprecate.log(`Unable to remove function '${name}' from an object that lacks it.`)
+      return function (this: any) {
+        deprecate.log(`'${name} function' has been removed. See release notes for further information.`)
+      }
+    }
+
+    // wrap the deprecated function to warn user
+    const warn = warnOnce(`${name} function`)
+    return function (this: any) {
+      warn()
+      fn.apply(this, arguments)
+    }
+  },
+
   // change the name of an event
   event: (emitter, oldName, newName) => {
     const warn = newName.startsWith('-') /* internal event */

--- a/lib/common/api/deprecate.ts
+++ b/lib/common/api/deprecate.ts
@@ -34,27 +34,27 @@ const deprecate: ElectronInternal.DeprecationUtil = {
     }
   },
 
-  // change the name of a function
-  function: (fn, newName) => {
-    const warn = warnOnce(fn.name, newName)
+  // remove a function with no replacement
+  removeFunction: (fn, removedName) => {
+    // if the function has already been removed, warn about it
+    if (!fn) {
+      deprecate.log(`Unable to remove function '${removedName}' from an object that lacks it.`)
+      return function (this: any) {
+        deprecate.log(`'${removedName} function' has been removed. See release notes for further information.`)
+      }
+    }
+
+    // wrap the deprecated function to warn user
+    const warn = warnOnce(`${removedName} function`)
     return function (this: any) {
       warn()
       fn.apply(this, arguments)
     }
   },
 
-  // remove a function with no replacement
-  removeFunction: (fn, name) => {
-    // if the function has already been removed, warn about it
-    if (!fn) {
-      deprecate.log(`Unable to remove function '${name}' from an object that lacks it.`)
-      return function (this: any) {
-        deprecate.log(`'${name} function' has been removed. See release notes for further information.`)
-      }
-    }
-
-    // wrap the deprecated function to warn user
-    const warn = warnOnce(`${name} function`)
+  // change the name of a function
+  renameFunction: (fn, newName) => {
+    const warn = warnOnce(`${fn.name} function`, `${newName} function`)
     return function (this: any) {
       warn()
       fn.apply(this, arguments)

--- a/lib/common/api/deprecate.ts
+++ b/lib/common/api/deprecate.ts
@@ -36,11 +36,7 @@ const deprecate: ElectronInternal.DeprecationUtil = {
 
   // remove a function with no replacement
   removeFunction: (fn, removedName) => {
-    // if the function has already been removed, warn about it
-    if (!fn) {
-      deprecate.log(`Unable to remove function '${removedName}' from an object that lacks it.`)
-      throw Error(`'${removedName} function' has been removed. See release notes for further information.`)
-    }
+    if (!fn) { throw Error(`'${removedName} function' is invalid or does not exist.`) }
 
     // wrap the deprecated function to warn user
     const warn = warnOnce(`${fn.name} function`)

--- a/spec/api-deprecate-spec.js
+++ b/spec/api-deprecate-spec.js
@@ -87,7 +87,7 @@ describe('deprecate', () => {
     deprecate.setHandler(m => { msg = m })
 
     function oldFn () { return 'hello' }
-    const deprecatedFn = deprecate.function(oldFn)
+    const deprecatedFn = deprecate.removeFunction(oldFn, 'oldFn')
     deprecatedFn()
 
     expect(msg).to.be.a('string')
@@ -100,7 +100,7 @@ describe('deprecate', () => {
 
     function oldFn () { return 'hello' }
     function newFn () { return 'goodbye' }
-    const deprecatedFn = deprecate.function(oldFn, newFn)
+    const deprecatedFn = deprecate.renameFunction(oldFn, newFn)
     deprecatedFn()
 
     expect(msg).to.be.a('string')

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -76,8 +76,8 @@ declare namespace ElectronInternal {
     getHandler(): DeprecationHandler | null;
     warn(oldName: string, newName: string): void;
     log(message: string): void;
-    function(fn: Function, newName: string): Function;
-    removeFunction(fn: Function, name: string): Function;
+    removeFunction(fn: Function, removedName: string): Function;
+    renameFunction(fn: Function, newName: string): Function;
     event(emitter: NodeJS.EventEmitter, oldName: string, newName: string): void;
     fnToProperty(module: any, prop: string, getter: string, setter: string): void;
     removeProperty<T, K extends (keyof T & string)>(object: T, propertyName: K): T;

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -77,6 +77,7 @@ declare namespace ElectronInternal {
     warn(oldName: string, newName: string): void;
     log(message: string): void;
     function(fn: Function, newName: string): Function;
+    removeFunction(fn: Function, name: string): Function;
     event(emitter: NodeJS.EventEmitter, oldName: string, newName: string): void;
     fnToProperty(module: any, prop: string, getter: string, setter: string): void;
     removeProperty<T, K extends (keyof T & string)>(object: T, propertyName: K): T;


### PR DESCRIPTION
#### Description of Change
Previously, functions could be marked for renaming or removal using the single method `deprecate.function`. I split that functionality into two separate methods. 

cc @codebytere 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none