### PR TITLE
fix: dark mode tray opacity on Mojave

### DIFF
--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -625,7 +625,7 @@ void SystemPreferences::RemoveUserDefault(const std::string& name) {
 }
 
 bool SystemPreferences::IsDarkMode() {
-  if (@available(macOS 10.14, *)) {
+  if (@available(macOS 10.15, *)) {
     return [[NSApplication sharedApplication].effectiveAppearance.name
         isEqualToString:NSAppearanceNameDarkAqua];
   }

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -145,7 +145,7 @@ const CGFloat kVerticalTitleMargin = 2;
 }
 
 - (BOOL)isDarkMode {
-  if (@available(macOS 10.14, *)) {
+  if (@available(macOS 10.15, *)) {
     return [[NSApplication sharedApplication].effectiveAppearance.name
         isEqualToString:NSAppearanceNameDarkAqua];
   }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/19009
Closes https://github.com/electron/electron/issues/19006.

Fixes an issue which is fixed in `master` as a result of this [Chromium CL](https://chromium-review.googlesource.com/c/chromium/src/+/1240172).

Previously Chromium forward-declared `NSAppearanceNameDarkAqua` name as an `NSString*`, so our updated functions in https://github.com/electron/electron/pull/18666 would never believe themselves to be in dark mode.

This fixes that issue by removing Chromium's older forward declarations and adding them in ourselves.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the Tray icon would never believe itself to be in dark mode.