### PR TITLE
fix: fire close event upon closing modal BrowserWindow in macOS

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -511,6 +511,8 @@ void NativeWindowMac::CloseImmediately() {
     [NSEvent removeMonitor:wheel_event_monitor_];
     wheel_event_monitor_ = nil;
   }
+  // Manually emit close event (not triggered from close fn)
+  [window_delegate_ windowShouldClose:window_];
 
   // Retain the child window before closing it. If the last reference to the
   // NSWindow goes away inside -[NSWindow close], then bad stuff can happen.

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -492,6 +492,8 @@ void NativeWindowMac::Close() {
   // When this is a sheet showing, performClose won't work.
   if (is_modal() && parent() && IsVisible()) {
     [parent()->GetNativeWindow().GetNativeNSWindow() endSheet:window_];
+    // Manually emit close event (not triggered from close fn)
+    [window_delegate_ windowShouldClose:window_];
     CloseImmediately();
     return;
   }
@@ -511,8 +513,6 @@ void NativeWindowMac::CloseImmediately() {
     [NSEvent removeMonitor:wheel_event_monitor_];
     wheel_event_monitor_ = nil;
   }
-  // Manually emit close event (not triggered from close fn)
-  [window_delegate_ windowShouldClose:window_];
 
   // Retain the child window before closing it. If the last reference to the
   // NSWindow goes away inside -[NSWindow close], then bad stuff can happen.

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -493,7 +493,7 @@ void NativeWindowMac::Close() {
   if (is_modal() && parent() && IsVisible()) {
     [parent()->GetNativeWindow().GetNativeNSWindow() endSheet:window_];
     // Manually emit close event (not triggered from close fn)
-    [window_delegate_ windowShouldClose:window_];
+    NotifyWindowCloseButtonClicked();
     CloseImmediately();
     return;
   }


### PR DESCRIPTION
#### Description of Change
Fixes #10674. _This bug was originally reported for Electron 1.x.x, but still occurs on `master`. See https://github.com/electron/electron/issues/10674#issuecomment-506382985 for screenshot and Fiddle link._

Adds a small function call to `windowShouldClose(_:)` to emit the `close` event upon closing a modal window.

##### Context

For modals on macOS, we use [`NSWindow close()`](https://developer.apple.com/documentation/appkit/nswindow/1419662-close) instead of [`NSWindow performClose(_:)`](https://developer.apple.com/documentation/appkit/nswindow/1419288-performclose) to close the modal window because the latter doesn't get along with the Sheet implementation of modal windows.

According to the docs:
> The close method differs in two important ways from the `performClose(_:)` method:
> 
> * It does not attempt to send a `windowShouldClose(_:)` message to the window or its delegate.
> 
> * It does not simulate the user clicking the close button by momentarily highlighting the button.

The `windowShouldClose(_:)` function in `atom_ns_window_delegate.mm` eventually triggers an `Emit("close")`.

##### Other information
I added the call manually inside the control flow right before `[window_ close_]`. I also tried adding it into the `CloseImmediately()` function first (see first commit in this branch), but that didn't work.

##### Pings
cc @codebytere @DeerMichel (and @zcbenz who worked on the original lines of code)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed bug where the `close` event would not emit upon closing modal window on macOS.
