### PR TITLE
docs: fix heading level for power-monitor docs

### DIFF
--- a/docs/api/power-monitor.md
+++ b/docs/api/power-monitor.md
@@ -59,7 +59,7 @@ Emitted as soon as the systems screen is unlocked.
 
 The `powerMonitor` module has the following methods:
 
-#### `powerMonitor.querySystemIdleState(idleThreshold, callback)` _(Deprecated)_
+### `powerMonitor.querySystemIdleState(idleThreshold, callback)` _(Deprecated)_
 
 * `idleThreshold` Integer
 * `callback` Function
@@ -70,14 +70,14 @@ before considered idle. `callback` will be called synchronously on some systems
 and with an `idleState` argument that describes the system's state. `locked` is
 available on supported systems only.
 
-#### `powerMonitor.querySystemIdleTime(callback)` _(Deprecated)_
+### `powerMonitor.querySystemIdleTime(callback)` _(Deprecated)_
 
 * `callback` Function
   * `idleTime` Integer - Idle time in seconds
 
 Calculate system idle time in seconds.
 
-#### `powerMonitor.getSystemIdleState(idleThreshold)`
+### `powerMonitor.getSystemIdleState(idleThreshold)`
 
 * `idleThreshold` Integer
 
@@ -86,7 +86,7 @@ Returns `String` - The system's current state. Can be `active`, `idle`, `locked`
 Calculate the system idle state. `idleThreshold` is the amount of time (in seconds)
 before considered idle.  `locked` is available on supported systems only.
 
-#### `powerMonitor.getSystemIdleTime()`
+### `powerMonitor.getSystemIdleTime()`
 
 Returns `Integer` - Idle time in seconds
 


### PR DESCRIPTION
Fixes #18975 

Fixes the type definitions for Power Monitor.

Notes: no-notes