### PR TITLE
docs: UploadData does not have contentType

### DIFF
--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -229,9 +229,7 @@ should be called with either a `String` or an object that has the `data`,
       * `url` String
       * `method` String (optional)
       * `session` Object (optional)
-      * `uploadData` Object (optional)
-        * `contentType` String - MIME type of the content.
-        * `data` String - Content to be sent.
+      * `uploadData` [ProtocolResponseUploadData](structures/protocol-response-upload-data.md) (optional)
 * `completion` Function (optional)
   * `error` Error
 

--- a/docs/api/structures/protocol-response-upload-data.md
+++ b/docs/api/structures/protocol-response-upload-data.md
@@ -1,0 +1,4 @@
+# ProtocolResponseUploadData Object
+
+* `contentType` String - MIME type of the content.
+* `data` String - Content to be sent.

--- a/docs/api/structures/protocol-response.md
+++ b/docs/api/structures/protocol-response.md
@@ -28,9 +28,7 @@
 * `session` Session (optional) - The session used for requesting URL, by default
   the HTTP request will reuse the current session. Setting `session` to `null`
   would use a random independent session. This is only used for URL responses.
-* `uploadData` Object (optional) - The data used as upload data. This is only
+* `uploadData` ProtocolResponseUploadData (optional) - The data used as upload data. This is only
   used for URL responses when `method` is `"POST"`.
-  * `contentType` String - MIME type of the content.
-  * `data` String - Content to be sent.
 
 [net-error]: https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h

--- a/docs/api/structures/upload-data.md
+++ b/docs/api/structures/upload-data.md
@@ -1,6 +1,5 @@
 # UploadData Object
 
-* `contentType` String (optional) - Content type of the content to be sent.
 * `bytes` Buffer - Content being sent.
 * `file` String (optional) - Path of file being uploaded.
 * `blobUUID` String (optional) - UUID of blob data. Use [ses.getBlobData](../session.md#sesgetblobdataidentifier) method

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -95,6 +95,7 @@ auto_filenames = {
     "docs/api/structures/process-metric.md",
     "docs/api/structures/product.md",
     "docs/api/structures/protocol-request.md",
+    "docs/api/structures/protocol-response-upload-data.md",
     "docs/api/structures/protocol-response.md",
     "docs/api/structures/rectangle.md",
     "docs/api/structures/referrer.md",


### PR DESCRIPTION
#### Description of Change

The `UploadData` type which is used as the type of `request.uploadData` of protocol handlers, does not have `contentType` property defined. The `contentType` property is only used by `redirectRequest.uploadData` of `protocol.interceptHttpProtocol`.

The two `uploadData` properties have the same name, but not the same type.

This fixes the CI failure on master.

#### Release Notes

Notes: no-notes