### PR TITLE
docs: fix simple typo in api for webview-tag

### DIFF
--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -162,7 +162,7 @@ When the guest page doesn't have node integration this script will still have
 access to all Node APIs, but global objects injected by Node will be deleted
 after this script has finished executing.
 
-**Note:** This option will be appear as `preloadURL` (not `preload`) in
+**Note:** This option will appear as `preloadURL` (not `preload`) in
 the `webPreferences` specified to the `will-attach-webview` event.
 
 ### `httpreferrer`


### PR DESCRIPTION
#### Description of Change
this is a simple typo fix in the documentation for the webview-tag api docs

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

notes: no-notes
