### PR TITLE
docs: fix typo in 5-0-x api docs

### DIFF
--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -1,4 +1,4 @@
-# Breaking Chnages
+# Breaking Changes
 
 Breaking changes will be documented here, and deprecation warnings added to JS code where possible, at least [one major version](../tutorial/electron-versioning.md#semver) before the change is made.
 


### PR DESCRIPTION
#### Description of Change
Fixing a typo found in the 5-0-x API docs.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines]

#### Release Notes

Notes: no-notes
