### PR TITLE
chore: remove unused switches::kDisableHtmlFullscreenWindowResize

### DIFF
--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -415,9 +415,6 @@ void WebContentsPreferences::AppendCommandLineSwitches(
   if (IsEnabled(options::kNodeIntegrationInSubFrames))
     command_line->AppendSwitch(switches::kNodeIntegrationInSubFrames);
 
-  if (IsEnabled(options::kDisableHtmlFullscreenWindowResize))
-    command_line->AppendSwitch(switches::kDisableHtmlFullscreenWindowResize);
-
   // We are appending args to a webContents so let's save the current state
   // of our preferences object so that during the lifetime of the WebContents
   // we can fetch the options used to initally configure the WebContents

--- a/shell/common/options_switches.cc
+++ b/shell/common/options_switches.cc
@@ -242,10 +242,6 @@ const char kNodeIntegrationInWorker[] = "node-integration-in-worker";
 // environments will be created in sub-frames.
 const char kNodeIntegrationInSubFrames[] = "node-integration-in-subframes";
 
-// Disable window resizing when HTML Fullscreen API is activated.
-const char kDisableHtmlFullscreenWindowResize[] =
-    "disable-html-fullscreen-window-resize";
-
 // Widevine options
 // Path to Widevine CDM binaries.
 const char kWidevineCdmPath[] = "widevine-cdm-path";

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -117,7 +117,6 @@ extern const char kNativeWindowOpen[];
 extern const char kNodeIntegrationInWorker[];
 extern const char kWebviewTag[];
 extern const char kNodeIntegrationInSubFrames[];
-extern const char kDisableHtmlFullscreenWindowResize[];
 extern const char kDisableElectronSiteInstanceOverrides[];
 
 extern const char kWidevineCdmPath[];


### PR DESCRIPTION
#### Description of Change
`switches::kDisableHtmlFullscreenWindowResize` is not being read anywhere in the renderer process.
It is covered by an existing test `"disableHtmlFullscreenWindowResize" option`.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes
