### PR TITLE
docs: make the dialog example work out of the box on all 3 platforms

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -4,11 +4,11 @@
 
 Process: [Main](../glossary.md#main-process)
 
-An example of showing a dialog to select multiple files and directories:
+An example of showing a dialog to select multiple files:
 
 ```javascript
 const { dialog } = require('electron')
-console.log(dialog.showOpenDialog({ properties: ['openFile', 'openDirectory', 'multiSelections'] }))
+console.log(dialog.showOpenDialog({ properties: ['openFile', 'multiSelections'] }))
 ```
 
 The Dialog is opened from Electron's main thread. If you want to use the dialog


### PR DESCRIPTION
This example doesn't work out-of-the-box on linux/windows because they don'ts support simultaneous `openFile` and `openDirectory`.

Closes #19050

Notes: no-notes