### PR TITLE
docs: fix undefined isMac in menu example

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -152,7 +152,7 @@ simple template API:
 ```javascript
 const { app, Menu } = require('electron')
 
-const isMac = process.platform === 'darwin';
+const isMac = process.platform === 'darwin'
 
 const template = [
   // { role: 'appMenu' }

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -152,9 +152,11 @@ simple template API:
 ```javascript
 const { app, Menu } = require('electron')
 
+const isMac = process.platform === 'darwin';
+
 const template = [
   // { role: 'appMenu' }
-  ...(process.platform === 'darwin' ? [{
+  ...(isMac ? [{
     label: app.name,
     submenu: [
       { role: 'about' },


### PR DESCRIPTION
#### Description of Change
Fixes the use of an undefined constant isMac by defining it.
See https://electronjs.org/docs/api/menu#main-process

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

notes: no-notes
