### PR TITLE
chore: deprecate some NSVisualEffectMaterial types

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -233,10 +233,9 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     Windows, which adds standard window frame. Setting it to `false` will remove
     window shadow and window animations. Default is `true`.
   * `vibrancy` String (optional) - Add a type of vibrancy effect to the window, only on
-    macOS. Can be `appearance-based`, `light`, `dark`, `titlebar`, `selection`,
-    `menu`, `popover`, `sidebar`, `medium-light` or `ultra-dark`.  Please note that
-    using `frame: false` in combination with a vibrancy value requires that you use a
-    non-default `titleBarStyle` as well.
+    macOS. Can be `appearance-based`, `light`, `dark`, `titlebar`, `selection`, `menu`,
+    `popover`, `sidebar`, `medium-light` or `ultra-dark`.  Please note that using `frame: false` in combination with a vibrancy value requires that you use a non-default `titleBarStyle` as well.
+    Also note that `appearance-based`, `light`, `dark`, `medium-light`, and `ultra-dark` have been deprecated and will be removed in an upcoming version of macOS.
   * `zoomToPageWidth` Boolean (optional) - Controls the behavior on macOS when
     option-clicking the green stoplight button on the toolbar or by clicking the
     Window > Zoom menu item. If `true`, the window will grow to the preferred
@@ -1613,11 +1612,14 @@ Adds a window as a tab on this window, after the tab for the window instance.
 #### `win.setVibrancy(type)` _macOS_
 
 * `type` String - Can be `appearance-based`, `light`, `dark`, `titlebar`,
-  `selection`, `menu`, `popover`, `sidebar`, `medium-light` or `ultra-dark`. See
+`selection`, `menu`, `popover`, `sidebar`, `medium-light` or `ultra-dark`. See
   the [macOS documentation][vibrancy-docs] for more details.
 
 Adds a vibrancy effect to the browser window. Passing `null` or an empty string
 will remove the vibrancy effect on the window.
+
+Note that `appearance-based`, `light`, `dark`, `medium-light`, and `ultra-dark` have been
+deprecated and will be removed in an upcoming version of macOS.
 
 #### `win.setTouchBar(touchBar)` _macOS_ _Experimental_
 

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -26,6 +26,7 @@
 #include "shell/browser/ui/inspectable_web_contents.h"
 #include "shell/browser/ui/inspectable_web_contents_view.h"
 #include "shell/browser/window_list.h"
+#include "shell/common/deprecate_util.h"
 #include "shell/common/options_switches.h"
 #include "skia/ext/skia_utils_mac.h"
 #include "ui/gfx/skia_util.h"
@@ -1288,20 +1289,31 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
                            relativeTo:nil];
   }
 
-  NSVisualEffectMaterial vibrancyType = NSVisualEffectMaterialLight;
+  std::string dep_warn =
+      " has been deprecated and will be removed in a future version of macOS.";
+  node::Environment* env =
+      node::Environment::GetCurrent(v8::Isolate::GetCurrent());
+
+  NSVisualEffectMaterial vibrancyType;
 
   if (type == "appearance-based") {
+    EmitDeprecationWarning(
+        env, "NSVisualEffectMaterialAppearanceBased" + dep_warn, "electron");
     vibrancyType = NSVisualEffectMaterialAppearanceBased;
   } else if (type == "light") {
+    EmitDeprecationWarning(env, "NSVisualEffectMaterialLight" + dep_warn,
+                           "electron");
     vibrancyType = NSVisualEffectMaterialLight;
   } else if (type == "dark") {
+    EmitDeprecationWarning(env, "NSVisualEffectMaterialDark" + dep_warn,
+                           "electron");
     vibrancyType = NSVisualEffectMaterialDark;
   } else if (type == "titlebar") {
     vibrancyType = NSVisualEffectMaterialTitlebar;
   }
 
   if (@available(macOS 10.11, *)) {
-    // TODO(kevinsawicki): Use NSVisualEffectMaterial* constants directly once
+    // TODO(codebytere): Use NSVisualEffectMaterial* constants directly once
     // they are available in the minimum SDK version
     if (type == "selection") {
       // NSVisualEffectMaterialSelection
@@ -1317,14 +1329,19 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
       vibrancyType = static_cast<NSVisualEffectMaterial>(7);
     } else if (type == "medium-light") {
       // NSVisualEffectMaterialMediumLight
+      EmitDeprecationWarning(
+          env, "NSVisualEffectMaterialMediumLight" + dep_warn, "electron");
       vibrancyType = static_cast<NSVisualEffectMaterial>(8);
     } else if (type == "ultra-dark") {
       // NSVisualEffectMaterialUltraDark
+      EmitDeprecationWarning(env, "NSVisualEffectMaterialUltraDark" + dep_warn,
+                             "electron");
       vibrancyType = static_cast<NSVisualEffectMaterial>(9);
     }
   }
 
-  [effect_view setMaterial:vibrancyType];
+  if (vibrancyType)
+    [effect_view setMaterial:vibrancyType];
 }
 
 void NativeWindowMac::SetTouchBar(

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -324,8 +324,10 @@ window.setRepresentedFilename('/etc/passwd')
 window.setDocumentEdited(true)
 window.previewFile('/path/to/file')
 window.previewFile('/path/to/file', 'Displayed Name')
-window.setVibrancy('light')
+window.setVibrancy('menu')
 window.setVibrancy('titlebar')
+window.setVibrancy('selection')
+window.setVibrancy('popover')
 
 // Online/Offline Event Detection
 // https://github.com/atom/electron/blob/master/docs/tutorial/online-offline-events.md


### PR DESCRIPTION
#### Description of Change

This PR deprecates a series of `NSVisualEffectMaterial` types that have been removed by Apple in macOS Catalina as per [documentation](https://developer.apple.com/documentation/appkit/nsvisualeffectmaterial?language=objc). Also notes those options as deprecated in our documentation.

cc @MarshallOfSound @miniak @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
