### PR TITLE
feat: expose new vibrancy types

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -234,9 +234,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     Windows, which adds standard window frame. Setting it to `false` will remove
     window shadow and window animations. Default is `true`.
   * `vibrancy` String (optional) - Add a type of vibrancy effect to the window, only on
-    macOS. Can be `appearance-based`, `light`, `dark`, `titlebar`, `selection`, `menu`,
-    `popover`, `sidebar`, `medium-light` or `ultra-dark`.  Please note that using `frame: false` in combination with a vibrancy value requires that you use a non-default `titleBarStyle` as well.
-    Also note that `appearance-based`, `light`, `dark`, `medium-light`, and `ultra-dark` have been deprecated and will be removed in an upcoming version of macOS.
+    macOS. Can be `appearance-based`, `light`, `dark`, `titlebar`, `selection`,
+    `menu`, `popover`, `sidebar`, `medium-light`, `ultra-dark`, `header`, `sheet`, `window`, `hud`, `fullscreen-ui`, `tooltip`, `content`, `under-window`, or `under-page`.  Please note that using `frame: false` in combination with a vibrancy value requires that you use a non-default `titleBarStyle` as well. Also note that `appearance-based`, `light`, `dark`, `medium-light`, and `ultra-dark` have been deprecated and will be removed in an upcoming version of macOS.
   * `zoomToPageWidth` Boolean (optional) - Controls the behavior on macOS when
     option-clicking the green stoplight button on the toolbar or by clicking the
     Window > Zoom menu item. If `true`, the window will grow to the preferred
@@ -1620,7 +1619,7 @@ Adds a window as a tab on this window, after the tab for the window instance.
 #### `win.setVibrancy(type)` _macOS_
 
 * `type` String | null - Can be `appearance-based`, `light`, `dark`, `titlebar`,
-  `selection`, `menu`, `popover`, `sidebar`, `medium-light` or `ultra-dark`. See
+  `selection`, `menu`, `popover`, `sidebar`, `medium-light`, `ultra-dark`, `header`, `sheet`, `window`, `hud`, `fullscreen-ui`, `tooltip`, `content`, `under-window`, or `under-page`. See
   the [macOS documentation][vibrancy-docs] for more details.
 
 Adds a vibrancy effect to the browser window. Passing `null` or an empty string

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1347,6 +1347,37 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
     }
   }
 
+  if (@available(macOS 10.14, *)) {
+    if (type == "header") {
+      // NSVisualEffectMaterialHeaderView
+      vibrancyType = static_cast<NSVisualEffectMaterial>(10);
+    } else if (type == "sheet") {
+      // NSVisualEffectMaterialSheet
+      vibrancyType = static_cast<NSVisualEffectMaterial>(11);
+    } else if (type == "window") {
+      // NSVisualEffectMaterialWindowBackground
+      vibrancyType = static_cast<NSVisualEffectMaterial>(12);
+    } else if (type == "hud") {
+      // NSVisualEffectMaterialHUDWindow
+      vibrancyType = static_cast<NSVisualEffectMaterial>(13);
+    } else if (type == "fullscreen-ui") {
+      // NSVisualEffectMaterialFullScreenUI
+      vibrancyType = static_cast<NSVisualEffectMaterial>(16);
+    } else if (type == "tooltip") {
+      // NSVisualEffectMaterialToolTip
+      vibrancyType = static_cast<NSVisualEffectMaterial>(17);
+    } else if (type == "content") {
+      // NSVisualEffectMaterialContentBackground
+      vibrancyType = static_cast<NSVisualEffectMaterial>(18);
+    } else if (type == "under-window") {
+      // NSVisualEffectMaterialUnderWindowBackground
+      vibrancyType = static_cast<NSVisualEffectMaterial>(21);
+    } else if (type == "under-page") {
+      // NSVisualEffectMaterialUnderPageBackground
+      vibrancyType = static_cast<NSVisualEffectMaterial>(22);
+    }
+  }
+
   if (vibrancyType)
     [effect_view setMaterial:vibrancyType];
 }


### PR DESCRIPTION
#### Description of Change

In macOS Mojave, Apple added a host of new [`NSVisualEffectMaterials`](https://developer.apple.com/documentation/appkit/nsvisualeffectmaterial?language=objc). This PR enabled developers to use those new types by adding them to options for new `BrowserWindow`s and when invoking the `setVibrancy` API on `BrowserWindow` instances.

cc @MarshallOfSound @nornagon @miniak 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added support for NSVisualEffectMaterials vibrancy types added in macOS Mojave.
