### PR TITLE
fix: check parent-child relationship in canAccessWindow

### DIFF
--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -156,20 +156,27 @@ const getGuestWindow = function (guestContents) {
   return guestWindow
 }
 
+const isChildWindow = function (sender, target) {
+  return target.getLastWebPreferences().openerId === sender.id
+}
+
+const isRelatedWindow = function (sender, target) {
+  return isChildWindow(sender, target) || isChildWindow(target, sender)
+}
+
+const isScriptableWindow = function (sender, target) {
+  return isRelatedWindow(sender, target) && isSameOrigin(sender.getURL(), target.getURL())
+}
+
+const isNodeIntegrationEnabled = function (sender) {
+  return sender.getLastWebPreferences().nodeIntegration === true
+}
+
 // Checks whether |sender| can access the |target|:
-// 1. Check whether |sender| is the parent of |target|.
-// 2. Check whether |sender| has node integration, if so it is allowed to
-//    do anything it wants.
-// 3. Check whether the origins match.
-//
-// However it allows a child window without node integration but with same
-// origin to do anything it wants, when its opener window has node integration.
-// The W3C does not have anything on this, but from my understanding of the
-// security model of |window.opener|, this should be fine.
 const canAccessWindow = function (sender, target) {
-  return (target.getLastWebPreferences().openerId === sender.id) ||
-         (sender.getLastWebPreferences().nodeIntegration === true) ||
-         isSameOrigin(sender.getURL(), target.getURL())
+  return isChildWindow(sender, target) ||
+         isScriptableWindow(sender, target) ||
+         isNodeIntegrationEnabled(sender)
 }
 
 // Routed window.open messages with raw options


### PR DESCRIPTION
#### Description of Change
The following IPC messages implementing `BrowserWindowProxy` do not validate the sender/target properly, allowing access to unrelated windows (no child-parent relationship) just because they have the same origin:
- `ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_CLOSE`
- `ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD`
- `ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD`
- `ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD_SYNC`

Related to #16252 and #15919

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes