### PR TITLE
test: attempt to fix flaky webview.clearHistory test

### DIFF
--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -917,11 +917,12 @@ describe('<webview> tag', function () {
 
   describe('<webview>.clearHistory()', () => {
     it('should clear the navigation history', async () => {
-      loadWebView(webview, {
+      const message = waitForEvent(webview, 'ipc-message')
+      await loadWebView(webview, {
         nodeintegration: 'on',
         src: `file://${fixtures}/pages/history.html`
       })
-      const event = await waitForEvent(webview, 'ipc-message')
+      const event = await message
 
       expect(event.channel).to.equal('history')
       expect(event.args[0]).to.equal(2)


### PR DESCRIPTION
#### Description of Change
I think sometimes the ipc message was getting sent before the load was fully complete, so the history didn't contain everything it should have? Maybe?

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none