### PR TITLE
build: update our nan reference to point at the upstream

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -14,7 +14,7 @@ vars = {
   'node_version':
     '0a300f60bce0c8f0cb3d846fcb0e1f55f26013ee',
   'nan_version':
-    '960dd6c70fc9eb136efdf37b4bef18fadbc3436f',
+    '2ee313aaca52e2b478965ac50eb5082520380d1b',
 
   'boto_version': 'f7574aa6cc2c819430c1f05e9a1a1a666ef8169b',
   'pyyaml_version': '3.12',
@@ -23,8 +23,7 @@ vars = {
   'boto_git': 'https://github.com/boto',
   'chromium_git': 'https://chromium.googlesource.com',
   'electron_git': 'https://github.com/electron',
-  # FIXME: Once https://github.com/nodejs/nan/pull/857 lands this should point at nodejs/nan
-  'nodejs_git': 'https://github.com/marshallofsound',
+  'nodejs_git': 'https://github.com/nodejs',
   'requests_git': 'https://github.com/kennethreitz',
   'yaml_git': 'https://github.com/yaml',
 


### PR DESCRIPTION
The [required fix](https://github.com/nodejs/nan/pull/857) has landed, let's target upstream

Notes: no-notes
