### PR TITLE
test: fix flaky onbeforeunload tests

### DIFF
--- a/spec/fixtures/api/close-beforeunload-empty-string.html
+++ b/spec/fixtures/api/close-beforeunload-empty-string.html
@@ -13,7 +13,7 @@
       return '';
     }
   }
-  window.close();
+  window.onload = () => window.close();
 </script>
 </body>
 </html>

--- a/spec/fixtures/api/close-beforeunload-false.html
+++ b/spec/fixtures/api/close-beforeunload-false.html
@@ -12,7 +12,8 @@
       return false;
     }
   }
-  window.close();
+  // unload events don't get run unless load events have run.
+  window.onload = () => window.close()
 </script>
 </body>
 </html>

--- a/spec/fixtures/api/close-beforeunload-undefined.html
+++ b/spec/fixtures/api/close-beforeunload-undefined.html
@@ -6,7 +6,7 @@
       require('electron').remote.getCurrentWindow().emit('onbeforeunload');
     }, 0);
   }
-  window.close();
+  window.onload = () => window.close();
 </script>
 </body>
 </html>

--- a/spec/fixtures/api/close.html
+++ b/spec/fixtures/api/close.html
@@ -4,7 +4,7 @@
   window.addEventListener('unload', function (e) {
     require('fs').writeFileSync(__dirname + '/close', 'close');
   }, false);
-  window.close();
+  window.onload = () => window.close();
 </script>
 </body>
 </html>


### PR DESCRIPTION
#### Description of Change
I'm not 100% sure of my reasoning here, but I think that because we replace `window.close` with a custom method that sends an IPC, it's possible we're messing with the unload sequence in a way that's racy—sometimes the `load` event gets emitted before the window's closed, other times not.

I think [this line](https://cs.chromium.org/chromium/src/content/browser/frame_host/render_frame_host_impl.cc?l=4522&rcl=bb0180e9dcd79a3033a5a712326bcf43452b602e) is the cause of our woes. If the RenderFrameHost doesn't yet believe the RenderFrame to be live, then it won't send an unload message. It looks like in our case, it was considering the frame to not be live because it wasn't yet initialized.

Maybe a better fix for this would be to fix how we implement `window.close()` so it shuts down more gracefully. However, this at least fixes our tests for now.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none