### PR TITLE
chore: remove unused BrowserWindow.fromDevToolsWebContents

### DIFF
--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -127,15 +127,6 @@ BrowserWindow.fromBrowserView = (browserView) => {
   return null
 }
 
-BrowserWindow.fromDevToolsWebContents = (webContents) => {
-  for (const window of BrowserWindow.getAllWindows()) {
-    const { devToolsWebContents } = window
-    if (devToolsWebContents != null && devToolsWebContents.equal(webContents)) {
-      return window
-    }
-  }
-}
-
 // Helpers.
 Object.assign(BrowserWindow.prototype, {
   loadURL (...args) {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -233,24 +233,6 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('BrowserWindow.fromDevToolsWebContents(webContents)', () => {
-    let contents = null
-
-    beforeEach(() => { contents = webContents.create({}) })
-
-    afterEach(() => { contents.destroy() })
-
-    it('returns the window with the webContents', (done) => {
-      w.webContents.once('devtools-opened', () => {
-        expect(BrowserWindow.fromDevToolsWebContents(w.devToolsWebContents).id).to.equal(w.id)
-        expect(BrowserWindow.fromDevToolsWebContents(w.webContents)).to.be.undefined()
-        expect(BrowserWindow.fromDevToolsWebContents(contents)).to.be.undefined()
-        done()
-      })
-      w.webContents.openDevTools()
-    })
-  })
-
   describe('BrowserWindow.openDevTools()', () => {
     it('does not crash for frameless window', () => {
       w.destroy()


### PR DESCRIPTION
#### Description of Change
`BrowserWindow.fromDevToolsWebContents` is:
- not documented
- was used last internally in Electron [in 2015](https://github.com/electron/electron/commit/1045bbc861186a566f0d9ed2b4768a7fda23be3f)
- doesn’t appear to have any usages in the first 10 pages of github search
- doesn’t seem useful
- is trivially implementable by a developer using other APIs

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none