### PR TITLE
feat: implement net module with NetworkService

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -93,6 +93,8 @@ filenames = {
     "shell/browser/api/atom_api_tray.h",
     "shell/browser/api/atom_api_url_request.cc",
     "shell/browser/api/atom_api_url_request.h",
+    "shell/browser/api/atom_api_url_request_ns.cc",
+    "shell/browser/api/atom_api_url_request_ns.h",
     "shell/browser/api/atom_api_view.cc",
     "shell/browser/api/atom_api_view.h",
     "shell/browser/api/atom_api_web_contents.cc",

--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -5,7 +5,7 @@ const { EventEmitter } = require('events')
 const { Readable } = require('stream')
 const { app } = require('electron')
 const { Session } = process.electronBinding('session')
-const { net, Net, isNetworkServiceEnabled } = process.electronBinding('net')
+const { net, Net } = process.electronBinding('net')
 const { URLRequest } = net
 
 // Net is an EventEmitter.
@@ -345,11 +345,10 @@ class ClientRequest extends EventEmitter {
 
     // Headers are assumed to be sent on first call to _writeBuffer,
     // i.e. after the first call to write or end.
-    const result = this.urlRequest.write(chunk, isLast, callback)
+    const result = this.urlRequest.write(chunk, isLast)
 
-    // For the non-NetworkService implementation, the write callback is fired
-    // asynchronously to mimic Node.js.
-    if (!isNetworkServiceEnabled && callback) {
+    // The write callback is fired asynchronously to mimic Node.js.
+    if (callback) {
       process.nextTick(callback)
     }
 

--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -5,7 +5,7 @@ const { EventEmitter } = require('events')
 const { Readable } = require('stream')
 const { app } = require('electron')
 const { Session } = process.electronBinding('session')
-const { net, Net } = process.electronBinding('net')
+const { net, Net, isNetworkServiceEnabled } = process.electronBinding('net')
 const { URLRequest } = net
 
 // Net is an EventEmitter.
@@ -345,10 +345,11 @@ class ClientRequest extends EventEmitter {
 
     // Headers are assumed to be sent on first call to _writeBuffer,
     // i.e. after the first call to write or end.
-    const result = this.urlRequest.write(chunk, isLast)
+    const result = this.urlRequest.write(chunk, isLast, callback)
 
-    // The write callback is fired asynchronously to mimic Node.js.
-    if (callback) {
+    // For the non-NetworkService implementation, the write callback is fired
+    // asynchronously to mimic Node.js.
+    if (!isNetworkServiceEnabled && callback) {
       process.nextTick(callback)
     }
 

--- a/shell/browser/api/atom_api_net.cc
+++ b/shell/browser/api/atom_api_net.cc
@@ -3,8 +3,12 @@
 // found in the LICENSE file.
 
 #include "shell/browser/api/atom_api_net.h"
+
 #include "native_mate/dictionary.h"
+#include "services/network/public/cpp/features.h"
 #include "shell/browser/api/atom_api_url_request.h"
+#include "shell/browser/api/atom_api_url_request_ns.h"
+
 #include "shell/common/node_includes.h"
 
 namespace electron {
@@ -31,8 +35,12 @@ void Net::BuildPrototype(v8::Isolate* isolate,
 }
 
 v8::Local<v8::Value> Net::URLRequest(v8::Isolate* isolate) {
-  return URLRequest::GetConstructor(isolate)
-      ->GetFunction(isolate->GetCurrentContext())
+  v8::Local<v8::FunctionTemplate> constructor;
+  if (base::FeatureList::IsEnabled(network::features::kNetworkService))
+    constructor = URLRequestNS::GetConstructor(isolate);
+  else
+    constructor = URLRequest::GetConstructor(isolate);
+  return constructor->GetFunction(isolate->GetCurrentContext())
       .ToLocalChecked();
 }
 

--- a/shell/browser/api/atom_api_net.cc
+++ b/shell/browser/api/atom_api_net.cc
@@ -52,6 +52,7 @@ namespace {
 
 using electron::api::Net;
 using electron::api::URLRequest;
+using electron::api::URLRequestNS;
 
 void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Value> unused,
@@ -59,12 +60,18 @@ void Initialize(v8::Local<v8::Object> exports,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
 
-  URLRequest::SetConstructor(isolate, base::BindRepeating(URLRequest::New));
+  if (base::FeatureList::IsEnabled(network::features::kNetworkService))
+    URLRequestNS::SetConstructor(isolate,
+                                 base::BindRepeating(URLRequestNS::New));
+  else
+    URLRequest::SetConstructor(isolate, base::BindRepeating(URLRequest::New));
 
   mate::Dictionary dict(isolate, exports);
   dict.Set("net", Net::Create(isolate));
   dict.Set("Net",
            Net::GetConstructor(isolate)->GetFunction(context).ToLocalChecked());
+  dict.Set("isNetworkServiceEnabled",
+           base::FeatureList::IsEnabled(network::features::kNetworkService));
 }
 
 }  // namespace

--- a/shell/browser/api/atom_api_url_request.h
+++ b/shell/browser/api/atom_api_url_request.h
@@ -25,7 +25,6 @@ class AtomURLRequest;
 
 namespace api {
 
-//
 // The URLRequest class implements the V8 binding between the JavaScript API
 // and Chromium native net library. It is responsible for handling HTTP/HTTPS
 // requests.
@@ -114,7 +113,7 @@ class URLRequest : public mate::EventEmitter<URLRequest> {
   mate::Dictionary GetUploadProgress(v8::Isolate* isolate);
 
  protected:
-  explicit URLRequest(v8::Isolate* isolate, v8::Local<v8::Object> wrapper);
+  URLRequest(v8::Isolate* isolate, v8::Local<v8::Object> wrapper);
   ~URLRequest() override;
 
  private:

--- a/shell/browser/api/atom_api_url_request_ns.cc
+++ b/shell/browser/api/atom_api_url_request_ns.cc
@@ -4,23 +4,156 @@
 
 #include "shell/browser/api/atom_api_url_request_ns.h"
 
+#include "content/public/browser/storage_partition.h"
+#include "native_mate/dictionary.h"
 #include "native_mate/object_template_builder.h"
+#include "shell/browser/api/atom_api_session.h"
+#include "shell/browser/atom_browser_context.h"
+#include "shell/common/native_mate_converters/gurl_converter.h"
 
 namespace electron {
 
 namespace api {
 
-URLRequestNS::URLRequestNS(v8::Isolate* isolate,
-                           v8::Local<v8::Object> wrapper) {
-  InitWith(isolate, wrapper);
+namespace {
+
+enum State {
+  STATE_STARTED = 1 << 0,
+  STATE_FINISHED = 1 << 1,
+  STATE_CANCELED = 1 << 2,
+  STATE_FAILED = 1 << 3,
+  STATE_CLOSED = 1 << 4,
+};
+
+const net::NetworkTrafficAnnotationTag kAnnotation =
+    net::DefineNetworkTrafficAnnotation("electron_net_module", R"(
+        semantics {
+          sender: "Electron Net module"
+          description:
+            "Issue HTTP/HTTPS requests using Chromium's native networking "
+            "library."
+          trigger: "Using the Net module"
+          data: "Anything the user wants to send."
+          destination: OTHER
+        }
+        policy {
+          cookies_allowed: YES
+          cookies_store: "user"
+          setting: "This feature cannot be disabled."
+        })");
+
+}  // namespace
+
+URLRequestNS::URLRequestNS(mate::Arguments* args) {
+  auto request = std::make_unique<network::ResourceRequest>();
+  request_ = request.get();  // ownership of |request| will be transferred.
+
+  mate::Dictionary dict;
+  if (args->GetNext(&dict)) {
+    dict.Get("method", &request_->method);
+    dict.Get("url", &request_->url);
+  }
+
+  std::string partition;
+  mate::Handle<api::Session> session;
+  if (!dict.Get("session", &session)) {
+    if (dict.Get("partition", &partition))
+      session = Session::FromPartition(args->isolate(), partition);
+    else  // default session
+      session = Session::FromPartition(args->isolate(), "");
+  }
+
+  auto* browser_context = session->browser_context();
+  url_loader_factory_ =
+      content::BrowserContext::GetDefaultStoragePartition(browser_context)
+          ->GetURLLoaderFactoryForBrowserProcess();
+  loader_ = network::SimpleURLLoader::Create(std::move(request), kAnnotation);
+
+  InitWith(args->isolate(), args->GetThis());
 }
 
 URLRequestNS::~URLRequestNS() {}
 
+bool URLRequestNS::NotStarted() const {
+  return request_state_ == 0;
+}
+
+bool URLRequestNS::Finished() const {
+  return request_state_ & STATE_FINISHED;
+}
+
+bool URLRequestNS::Canceled() const {
+  return request_state_ & STATE_CANCELED;
+}
+
+bool URLRequestNS::Failed() const {
+  return request_state_ & STATE_FAILED;
+}
+
+void URLRequestNS::Cancel() {
+  // TODO(zcbenz): Implement this.
+}
+
+void URLRequestNS::Close() {
+  // TODO(zcbenz): Implement this.
+}
+
+bool URLRequestNS::Write(const std::string& data, bool is_last) {
+  // TODO(zcbenz): Implement this.
+  return false;
+}
+
+void URLRequestNS::FollowRedirect() {
+  if (request_state_ & (STATE_CANCELED | STATE_CLOSED))
+    return;
+  // TODO(zcbenz): Implement this.
+}
+
+bool URLRequestNS::SetExtraHeader(const std::string& name,
+                                  const std::string& value) {
+  if (!request_)
+    return false;
+  if (!net::HttpUtil::IsValidHeaderName(name))
+    return false;
+  if (!net::HttpUtil::IsValidHeaderValue(value))
+    return false;
+  request_->headers.SetHeader(name, value);
+  return true;
+}
+
+void URLRequestNS::RemoveExtraHeader(const std::string& name) {
+  if (request_)
+    request_->headers.RemoveHeader(name);
+}
+
+void URLRequestNS::SetChunkedUpload(bool is_chunked_upload) {
+  // TODO(zcbenz): Implement this.
+}
+
+void URLRequestNS::SetLoadFlags(int flags) {
+  // TODO(zcbenz): Implement this.
+}
+
+void URLRequestNS::OnDataReceived(base::StringPiece string_piece,
+                                  base::OnceClosure resume) {}
+
+void URLRequestNS::OnRetry(base::OnceClosure start_retry) {}
+
+void URLRequestNS::OnComplete(bool success) {}
+
+void URLRequestNS::Pin() {
+  if (wrapper_.IsEmpty()) {
+    wrapper_.Reset(isolate(), GetWrapper());
+  }
+}
+
+void URLRequestNS::Unpin() {
+  wrapper_.Reset();
+}
+
 // static
 mate::WrappableBase* URLRequestNS::New(mate::Arguments* args) {
-  auto* url_request = new URLRequestNS(args->isolate(), args->GetThis());
-  return url_request;
+  return new URLRequestNS(args);
 }
 
 // static

--- a/shell/browser/api/atom_api_url_request_ns.cc
+++ b/shell/browser/api/atom_api_url_request_ns.cc
@@ -307,10 +307,6 @@ void URLRequestNS::SetChunkedUpload(bool is_chunked_upload) {
     is_chunked_upload_ = is_chunked_upload;
 }
 
-void URLRequestNS::SetLoadFlags(int flags) {
-  // TODO(zcbenz): Implement this.
-}
-
 mate::Dictionary URLRequestNS::GetUploadProgress() {
   mate::Dictionary progress = mate::Dictionary::CreateEmpty(isolate());
   // TODO(zcbenz): Implement this.
@@ -491,7 +487,6 @@ void URLRequestNS::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("removeExtraHeader", &URLRequestNS::RemoveExtraHeader)
       .SetMethod("setChunkedUpload", &URLRequestNS::SetChunkedUpload)
       .SetMethod("followRedirect", &URLRequestNS::FollowRedirect)
-      .SetMethod("_setLoadFlags", &URLRequestNS::SetLoadFlags)
       .SetMethod("getUploadProgress", &URLRequestNS::GetUploadProgress)
       .SetProperty("notStarted", &URLRequestNS::NotStarted)
       .SetProperty("finished", &URLRequestNS::Finished)

--- a/shell/browser/api/atom_api_url_request_ns.cc
+++ b/shell/browser/api/atom_api_url_request_ns.cc
@@ -19,19 +19,19 @@
 namespace mate {
 
 template <>
-struct Converter<network::mojom::FetchRedirectMode> {
+struct Converter<network::mojom::RedirectMode> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
-                     network::mojom::FetchRedirectMode* out) {
+                     network::mojom::RedirectMode* out) {
     std::string mode;
     if (!ConvertFromV8(isolate, val, &mode))
       return false;
     if (mode == "follow")
-      *out = network::mojom::FetchRedirectMode::kFollow;
+      *out = network::mojom::RedirectMode::kFollow;
     else if (mode == "error")
-      *out = network::mojom::FetchRedirectMode::kError;
+      *out = network::mojom::RedirectMode::kError;
     else if (mode == "manual")
-      *out = network::mojom::FetchRedirectMode::kManual;
+      *out = network::mojom::RedirectMode::kManual;
     else
       return false;
     return true;
@@ -164,7 +164,7 @@ URLRequestNS::URLRequestNS(mate::Arguments* args) : weak_factory_(this) {
     dict.Get("method", &request_->method);
     dict.Get("url", &request_->url);
     dict.Get("redirect", &redirect_mode_);
-    request_->fetch_redirect_mode = redirect_mode_;
+    request_->redirect_mode = redirect_mode_;
   }
 
   std::string partition;
@@ -420,12 +420,12 @@ void URLRequestNS::OnRedirect(
   }
 
   switch (redirect_mode_) {
-    case network::mojom::FetchRedirectMode::kError:
+    case network::mojom::RedirectMode::kError:
       EmitError(
           EventType::kRequest,
           "Request cannot follow redirect with the current redirect mode");
       break;
-    case network::mojom::FetchRedirectMode::kManual:
+    case network::mojom::RedirectMode::kManual:
       // When redirect mode is "manual", the user has to explicitly call the
       // FollowRedirect method to continue redirecting, otherwise the request
       // would be cancelled.
@@ -440,7 +440,7 @@ void URLRequestNS::OnRedirect(
       if (!follow_redirect_)
         Cancel();
       break;
-    case network::mojom::FetchRedirectMode::kFollow:
+    case network::mojom::RedirectMode::kFollow:
       EmitEvent(EventType::kRequest, false, "redirect",
                 redirect_info.status_code, redirect_info.new_method,
                 redirect_info.new_url, response_head.headers.get());

--- a/shell/browser/api/atom_api_url_request_ns.cc
+++ b/shell/browser/api/atom_api_url_request_ns.cc
@@ -405,12 +405,11 @@ void URLRequestNS::OnRedirect(
       EmitRequestError(
           "Request cannot follow redirect with the current redirect mode");
       break;
+    case network::mojom::FetchRedirectMode::kFollow:
     case network::mojom::FetchRedirectMode::kManual:
       EmitRequestEvent(false, "redirect", redirect_info.status_code,
                        redirect_info.new_method, redirect_info.new_url,
                        response_head.headers.get());
-      break;
-    default:
       break;
   }
 }

--- a/shell/browser/api/atom_api_url_request_ns.cc
+++ b/shell/browser/api/atom_api_url_request_ns.cc
@@ -1,0 +1,36 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/api/atom_api_url_request_ns.h"
+
+#include "native_mate/object_template_builder.h"
+
+namespace electron {
+
+namespace api {
+
+URLRequestNS::URLRequestNS(v8::Isolate* isolate,
+                           v8::Local<v8::Object> wrapper) {
+  InitWith(isolate, wrapper);
+}
+
+URLRequestNS::~URLRequestNS() {}
+
+// static
+mate::WrappableBase* URLRequestNS::New(mate::Arguments* args) {
+  auto* url_request = new URLRequestNS(args->isolate(), args->GetThis());
+  return url_request;
+}
+
+// static
+void URLRequestNS::BuildPrototype(v8::Isolate* isolate,
+                                  v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "URLRequest"));
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
+      .MakeDestroyable();
+}
+
+}  // namespace api
+
+}  // namespace electron

--- a/shell/browser/api/atom_api_url_request_ns.h
+++ b/shell/browser/api/atom_api_url_request_ns.h
@@ -93,9 +93,13 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
   scoped_refptr<net::HttpResponseHeaders> response_headers_;
 
-  // Weak ref to the |request_|, which is transferred to |loader_| after first
-  // write.
-  network::ResourceRequest* request_ref_ = nullptr;
+  // Redirect mode.
+  //
+  // Note that we store it ourselves instead of reading from the one stored in
+  // |request_|, this is because with multiple redirections, the original one
+  // might be modified.
+  network::mojom::FetchRedirectMode redirect_mode_ =
+      network::mojom::FetchRedirectMode::kFollow;
 
   // The DataPipeGetter passed to reader.
   bool is_chunked_upload_ = false;

--- a/shell/browser/api/atom_api_url_request_ns.h
+++ b/shell/browser/api/atom_api_url_request_ns.h
@@ -22,7 +22,6 @@ namespace electron {
 namespace api {
 
 class UploadDataPipeGetter;
-class UploadChunkedDataPipeGetter;
 
 class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
                      public network::SimpleURLLoaderStreamConsumer {
@@ -65,7 +64,6 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
 
  private:
   friend class UploadDataPipeGetter;
-  friend class UploadChunkedDataPipeGetter;
 
   struct WriteData {
     WriteData(bool is_last,
@@ -100,10 +98,9 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
   scoped_refptr<net::HttpResponseHeaders> response_headers_;
 
-  // Upload data pipe.
+  // The DataPipeGetter passed to reader.
   bool is_chunked_upload_ = false;
-  std::unique_ptr<UploadDataPipeGetter> upload_data_pipe_getter_;
-  std::unique_ptr<UploadChunkedDataPipeGetter> upload_chunked_data_pipe_getter_;
+  std::unique_ptr<UploadDataPipeGetter> data_pipe_getter_;
 
   // Passed from DataPipeGetter for streaming data.
   std::unique_ptr<mojo::StringDataPipeProducer> producer_;

--- a/shell/browser/api/atom_api_url_request_ns.h
+++ b/shell/browser/api/atom_api_url_request_ns.h
@@ -13,11 +13,14 @@
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "services/network/public/cpp/simple_url_loader.h"
 #include "services/network/public/cpp/simple_url_loader_stream_consumer.h"
+#include "services/network/public/mojom/data_pipe_getter.mojom.h"
 #include "shell/browser/api/event_emitter.h"
 
 namespace electron {
 
 namespace api {
+
+class UploadDataPipeGetter;
 
 class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
                      public network::SimpleURLLoaderStreamConsumer {
@@ -59,6 +62,8 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
   void OnRetry(base::OnceClosure start_retry) override;
 
  private:
+  friend class UploadDataPipeGetter;
+
   struct WriteData {
     WriteData(bool is_last,
               std::string data,
@@ -87,11 +92,14 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
   template <typename... Args>
   void EmitResponseEvent(Args... args);
 
-  std::unique_ptr<mojo::StringDataPipeProducer> producer_;
   std::unique_ptr<network::ResourceRequest> request_;
   std::unique_ptr<network::SimpleURLLoader> loader_;
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
   scoped_refptr<net::HttpResponseHeaders> response_headers_;
+
+  // Upload data pipe.
+  std::unique_ptr<UploadDataPipeGetter> upload_data_pipe_getter_;
+  std::unique_ptr<mojo::StringDataPipeProducer> producer_;
 
   // Current status.
   int request_state_ = 0;

--- a/shell/browser/api/atom_api_url_request_ns.h
+++ b/shell/browser/api/atom_api_url_request_ns.h
@@ -92,6 +92,10 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
   scoped_refptr<net::HttpResponseHeaders> response_headers_;
 
+  // Weak ref to the |request_|, which is transferred to |loader_| after first
+  // write.
+  network::ResourceRequest* request_ref_ = nullptr;
+
   // The DataPipeGetter passed to reader.
   bool is_chunked_upload_ = false;
   std::unique_ptr<UploadDataPipeGetter> data_pipe_getter_;

--- a/shell/browser/api/atom_api_url_request_ns.h
+++ b/shell/browser/api/atom_api_url_request_ns.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_BROWSER_API_ATOM_API_URL_REQUEST_NS_H_
+#define SHELL_BROWSER_API_ATOM_API_URL_REQUEST_NS_H_
+
+#include "shell/browser/api/event_emitter.h"
+
+namespace electron {
+
+namespace api {
+
+class URLRequestNS : public mate::EventEmitter<URLRequestNS> {
+ public:
+  static mate::WrappableBase* New(mate::Arguments* args);
+
+  static void BuildPrototype(v8::Isolate* isolate,
+                             v8::Local<v8::FunctionTemplate> prototype);
+
+ protected:
+  URLRequestNS(v8::Isolate* isolate, v8::Local<v8::Object> wrapper);
+  ~URLRequestNS() override;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(URLRequestNS);
+};
+
+}  // namespace api
+
+}  // namespace electron
+
+#endif  // SHELL_BROWSER_API_ATOM_API_URL_REQUEST_NS_H_

--- a/shell/browser/api/atom_api_url_request_ns.h
+++ b/shell/browser/api/atom_api_url_request_ns.h
@@ -5,13 +5,18 @@
 #ifndef SHELL_BROWSER_API_ATOM_API_URL_REQUEST_NS_H_
 #define SHELL_BROWSER_API_ATOM_API_URL_REQUEST_NS_H_
 
+#include "mojo/public/cpp/system/string_data_pipe_producer.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+#include "services/network/public/cpp/simple_url_loader.h"
+#include "services/network/public/cpp/simple_url_loader_stream_consumer.h"
 #include "shell/browser/api/event_emitter.h"
 
 namespace electron {
 
 namespace api {
 
-class URLRequestNS : public mate::EventEmitter<URLRequestNS> {
+class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
+                     public network::SimpleURLLoaderStreamConsumer {
  public:
   static mate::WrappableBase* New(mate::Arguments* args);
 
@@ -19,10 +24,48 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS> {
                              v8::Local<v8::FunctionTemplate> prototype);
 
  protected:
-  URLRequestNS(v8::Isolate* isolate, v8::Local<v8::Object> wrapper);
+  explicit URLRequestNS(mate::Arguments* args);
   ~URLRequestNS() override;
 
+  bool NotStarted() const;
+  bool Finished() const;
+  bool Canceled() const;
+  bool Failed() const;
+
+  void Cancel();
+  void Close();
+
+  bool Write(const std::string& data, bool is_last);
+  void FollowRedirect();
+  bool SetExtraHeader(const std::string& name, const std::string& value);
+  void RemoveExtraHeader(const std::string& name);
+  void SetChunkedUpload(bool is_chunked_upload);
+  void SetLoadFlags(int flags);
+
+  // SimpleURLLoaderStreamConsumer:
+  void OnDataReceived(base::StringPiece string_piece,
+                      base::OnceClosure resume) override;
+  void OnComplete(bool success) override;
+  void OnRetry(base::OnceClosure start_retry) override;
+
  private:
+  void Pin();
+  void Unpin();
+
+  std::unique_ptr<mojo::StringDataPipeProducer> producer_;
+  std::unique_ptr<network::SimpleURLLoader> loader_;
+  scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
+
+  // Current status.
+  int request_state_ = 0;
+  int response_state_ = 0;
+
+  // Weak ref to request, which is managed by loader_.
+  network::ResourceRequest* request_;
+
+  // Used by pin/unpin to manage lifetime.
+  v8::Global<v8::Object> wrapper_;
+
   DISALLOW_COPY_AND_ASSIGN(URLRequestNS);
 };
 

--- a/shell/browser/api/atom_api_url_request_ns.h
+++ b/shell/browser/api/atom_api_url_request_ns.h
@@ -68,6 +68,7 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
   void OnRedirect(const net::RedirectInfo& redirect_info,
                   const network::ResourceResponseHead& response_head,
                   std::vector<std::string>* to_be_removed_headers);
+  void OnUploadProgress(uint64_t position, uint64_t total);
   void OnWrite(MojoResult result);
 
   // Write the first data of |pending_writes_|.
@@ -106,6 +107,10 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
 
   // Whether request.end() has been called.
   bool last_chunk_written_ = false;
+
+  // Upload progress.
+  uint64_t upload_position_ = 0;
+  uint64_t upload_total_ = 0;
 
   // Current status.
   int request_state_ = 0;

--- a/shell/browser/api/atom_api_url_request_ns.h
+++ b/shell/browser/api/atom_api_url_request_ns.h
@@ -82,6 +82,7 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
   void Unpin();
 
   // Emit events.
+  void EmitRequestError(base::StringPiece error);
   template <typename... Args>
   void EmitRequestEvent(Args... args);
   template <typename... Args>

--- a/shell/browser/api/atom_api_url_request_ns.h
+++ b/shell/browser/api/atom_api_url_request_ns.h
@@ -47,7 +47,6 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
   bool SetExtraHeader(const std::string& name, const std::string& value);
   void RemoveExtraHeader(const std::string& name);
   void SetChunkedUpload(bool is_chunked_upload);
-  void SetLoadFlags(int flags);
   mate::Dictionary GetUploadProgress();
   int StatusCode() const;
   std::string StatusMessage() const;

--- a/shell/browser/api/atom_api_url_request_ns.h
+++ b/shell/browser/api/atom_api_url_request_ns.h
@@ -104,7 +104,13 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
   bool is_chunked_upload_ = false;
   std::unique_ptr<UploadDataPipeGetter> upload_data_pipe_getter_;
   std::unique_ptr<UploadChunkedDataPipeGetter> upload_chunked_data_pipe_getter_;
+
+  // Passed from DataPipeGetter for streaming data.
   std::unique_ptr<mojo::StringDataPipeProducer> producer_;
+  network::mojom::DataPipeGetter::ReadCallback finish_callback_;
+
+  // Uploaded data size.
+  size_t upload_size_ = 0;
 
   // Current status.
   int request_state_ = 0;

--- a/shell/browser/api/atom_api_url_request_ns.h
+++ b/shell/browser/api/atom_api_url_request_ns.h
@@ -100,8 +100,8 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
   // Note that we store it ourselves instead of reading from the one stored in
   // |request_|, this is because with multiple redirections, the original one
   // might be modified.
-  network::mojom::FetchRedirectMode redirect_mode_ =
-      network::mojom::FetchRedirectMode::kFollow;
+  network::mojom::RedirectMode redirect_mode_ =
+      network::mojom::RedirectMode::kFollow;
 
   // The DataPipeGetter passed to reader.
   bool is_chunked_upload_ = false;

--- a/shell/browser/api/atom_api_url_request_ns.h
+++ b/shell/browser/api/atom_api_url_request_ns.h
@@ -78,6 +78,9 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
 
   void OnResponseStarted(const GURL& final_url,
                          const network::ResourceResponseHead& response_head);
+  void OnRedirect(const net::RedirectInfo& redirect_info,
+                  const network::ResourceResponseHead& response_head,
+                  std::vector<std::string>* to_be_removed_headers);
   void OnWrite(MojoResult result);
 
   // Write the first data of |pending_writes_|.

--- a/shell/browser/api/atom_api_url_request_ns.h
+++ b/shell/browser/api/atom_api_url_request_ns.h
@@ -82,11 +82,13 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
   void Unpin();
 
   // Emit events.
-  void EmitRequestError(base::StringPiece error);
+  enum class EventType {
+    kRequest,
+    kResponse,
+  };
+  void EmitError(EventType type, base::StringPiece error);
   template <typename... Args>
-  void EmitRequestEvent(Args... args);
-  template <typename... Args>
-  void EmitResponseEvent(Args... args);
+  void EmitEvent(EventType type, Args... args);
 
   std::unique_ptr<network::ResourceRequest> request_;
   std::unique_ptr<network::SimpleURLLoader> loader_;

--- a/shell/browser/api/atom_api_url_request_ns.h
+++ b/shell/browser/api/atom_api_url_request_ns.h
@@ -43,6 +43,11 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
   void SetChunkedUpload(bool is_chunked_upload);
   void SetLoadFlags(int flags);
   mate::Dictionary GetUploadProgress();
+  int StatusCode() const;
+  std::string StatusMessage() const;
+  net::HttpResponseHeaders* RawResponseHeaders() const;
+  uint32_t ResponseHttpVersionMajor() const;
+  uint32_t ResponseHttpVersionMinor() const;
 
   // SimpleURLLoaderStreamConsumer:
   void OnDataReceived(base::StringPiece string_piece,
@@ -51,6 +56,8 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
   void OnRetry(base::OnceClosure start_retry) override;
 
  private:
+  void OnResponseStarted(const GURL& final_url,
+                         const network::ResourceResponseHead& response_head);
   void OnWrite(bool is_last,
                base::OnceCallback<void(v8::Local<v8::Value>)> callback,
                MojoResult result);
@@ -67,6 +74,7 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
   std::unique_ptr<network::ResourceRequest> request_;
   std::unique_ptr<network::SimpleURLLoader> loader_;
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
+  scoped_refptr<net::HttpResponseHeaders> response_headers_;
 
   // Current status.
   int request_state_ = 0;

--- a/shell/browser/api/atom_api_url_request_ns.h
+++ b/shell/browser/api/atom_api_url_request_ns.h
@@ -108,6 +108,9 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
   // Whether request.end() has been called.
   bool last_chunk_written_ = false;
 
+  // Whether the redirect should be followed.
+  bool follow_redirect_ = true;
+
   // Upload progress.
   uint64_t upload_position_ = 0;
   uint64_t upload_total_ = 0;

--- a/shell/browser/api/atom_api_url_request_ns.h
+++ b/shell/browser/api/atom_api_url_request_ns.h
@@ -6,6 +6,7 @@
 #define SHELL_BROWSER_API_ATOM_API_URL_REQUEST_NS_H_
 
 #include <list>
+#include <memory>
 #include <string>
 
 #include "mojo/public/cpp/system/string_data_pipe_producer.h"
@@ -21,6 +22,7 @@ namespace electron {
 namespace api {
 
 class UploadDataPipeGetter;
+class UploadChunkedDataPipeGetter;
 
 class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
                      public network::SimpleURLLoaderStreamConsumer {
@@ -63,6 +65,7 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
 
  private:
   friend class UploadDataPipeGetter;
+  friend class UploadChunkedDataPipeGetter;
 
   struct WriteData {
     WriteData(bool is_last,
@@ -98,7 +101,9 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
   scoped_refptr<net::HttpResponseHeaders> response_headers_;
 
   // Upload data pipe.
+  bool is_chunked_upload_ = false;
   std::unique_ptr<UploadDataPipeGetter> upload_data_pipe_getter_;
+  std::unique_ptr<UploadChunkedDataPipeGetter> upload_chunked_data_pipe_getter_;
   std::unique_ptr<mojo::StringDataPipeProducer> producer_;
 
   // Current status.


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/15791.

This PR adds NetworkService implementation for `net` module, all tests are passing with NetworkService enabled.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes