### PR TITLE
feat: add `toolTip` property for MenuItem (macOS)

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -20,6 +20,7 @@ See [`Menu`](menu.md) for examples.
     `radio`.
   * `label` String (optional)
   * `sublabel` String (optional)
+  * `toolTip` String (optional) _macOS_ - Hover text for this menu item.
   * `accelerator` [Accelerator](accelerator.md) (optional)
   * `icon` ([NativeImage](native-image.md) | String) (optional)
   * `enabled` Boolean (optional) - If false, the menu item will be greyed out and
@@ -165,6 +166,10 @@ item's icon, if set.
 #### `menuItem.sublabel`
 
 A `String` indicating the item's sublabel, this property can be dynamically changed.
+
+#### `menuItem.toolTip` _macOS_
+
+A `String` indicating the item's hover text.
 
 #### `menuItem.enabled`
 

--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -33,6 +33,7 @@ const MenuItem = function (options) {
 
   this.overrideProperty('label', roles.getDefaultLabel(this.role))
   this.overrideProperty('sublabel', '')
+  this.overrideProperty('toolTip', '')
   this.overrideProperty('enabled', true)
   this.overrideProperty('visible', true)
   this.overrideProperty('checked', false)

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -121,6 +121,7 @@ Menu.prototype.insert = function (pos, item) {
 
   // set item properties
   if (item.sublabel) this.setSublabel(pos, item.sublabel)
+  if (item.toolTip) this.setToolTip(pos, item.toolTip)
   if (item.icon) this.setIcon(pos, item.icon)
   if (item.role) this.setRole(pos, item.role)
 

--- a/shell/browser/api/atom_api_menu.cc
+++ b/shell/browser/api/atom_api_menu.cc
@@ -141,6 +141,10 @@ void Menu::SetSublabel(int index, const base::string16& sublabel) {
   model_->SetSublabel(index, sublabel);
 }
 
+void Menu::SetToolTip(int index, const base::string16& toolTip) {
+  model_->SetToolTip(index, toolTip);
+}
+
 void Menu::SetRole(int index, const base::string16& role) {
   model_->SetRole(index, role);
 }
@@ -167,6 +171,10 @@ base::string16 Menu::GetLabelAt(int index) const {
 
 base::string16 Menu::GetSublabelAt(int index) const {
   return model_->GetSublabelAt(index);
+}
+
+base::string16 Menu::GetToolTipAt(int index) const {
+  return model_->GetToolTipAt(index);
 }
 
 base::string16 Menu::GetAcceleratorTextAt(int index) const {
@@ -212,6 +220,7 @@ void Menu::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("insertSubMenu", &Menu::InsertSubMenuAt)
       .SetMethod("setIcon", &Menu::SetIcon)
       .SetMethod("setSublabel", &Menu::SetSublabel)
+      .SetMethod("setToolTip", &Menu::SetToolTip)
       .SetMethod("setRole", &Menu::SetRole)
       .SetMethod("clear", &Menu::Clear)
       .SetMethod("getIndexOfCommandId", &Menu::GetIndexOfCommandId)
@@ -219,6 +228,7 @@ void Menu::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("getCommandIdAt", &Menu::GetCommandIdAt)
       .SetMethod("getLabelAt", &Menu::GetLabelAt)
       .SetMethod("getSublabelAt", &Menu::GetSublabelAt)
+      .SetMethod("getToolTipAt", &Menu::GetToolTipAt)
       .SetMethod("getAcceleratorTextAt", &Menu::GetAcceleratorTextAt)
       .SetMethod("isItemCheckedAt", &Menu::IsItemCheckedAt)
       .SetMethod("isEnabledAt", &Menu::IsEnabledAt)

--- a/shell/browser/api/atom_api_menu.h
+++ b/shell/browser/api/atom_api_menu.h
@@ -86,6 +86,7 @@ class Menu : public mate::TrackableObject<Menu>,
                        Menu* menu);
   void SetIcon(int index, const gfx::Image& image);
   void SetSublabel(int index, const base::string16& sublabel);
+  void SetToolTip(int index, const base::string16& toolTip);
   void SetRole(int index, const base::string16& role);
   void Clear();
   int GetIndexOfCommandId(int command_id);
@@ -93,6 +94,7 @@ class Menu : public mate::TrackableObject<Menu>,
   int GetCommandIdAt(int index) const;
   base::string16 GetLabelAt(int index) const;
   base::string16 GetSublabelAt(int index) const;
+  base::string16 GetToolTipAt(int index) const;
   base::string16 GetAcceleratorTextAt(int index) const;
   bool IsItemCheckedAt(int index) const;
   bool IsEnabledAt(int index) const;

--- a/shell/browser/ui/atom_menu_model.cc
+++ b/shell/browser/ui/atom_menu_model.cc
@@ -19,6 +19,19 @@ AtomMenuModel::AtomMenuModel(Delegate* delegate)
 
 AtomMenuModel::~AtomMenuModel() {}
 
+void AtomMenuModel::SetToolTip(int index, const base::string16& toolTip) {
+  int command_id = GetCommandIdAt(index);
+  toolTips_[command_id] = toolTip;
+}
+
+base::string16 AtomMenuModel::GetToolTipAt(int index) {
+  int command_id = GetCommandIdAt(index);
+  if (base::Contains(toolTips_, command_id))
+    return toolTips_[command_id];
+  else
+    return base::string16();
+}
+
 void AtomMenuModel::SetRole(int index, const base::string16& role) {
   int command_id = GetCommandIdAt(index);
   roles_[command_id] = role;

--- a/shell/browser/ui/atom_menu_model.h
+++ b/shell/browser/ui/atom_menu_model.h
@@ -53,6 +53,8 @@ class AtomMenuModel : public ui::SimpleMenuModel {
   void AddObserver(Observer* obs) { observers_.AddObserver(obs); }
   void RemoveObserver(Observer* obs) { observers_.RemoveObserver(obs); }
 
+  void SetToolTip(int index, const base::string16& toolTip);
+  base::string16 GetToolTipAt(int index);
   void SetRole(int index, const base::string16& role);
   base::string16 GetRoleAt(int index);
   bool GetAcceleratorAtWithParams(int index,
@@ -71,7 +73,8 @@ class AtomMenuModel : public ui::SimpleMenuModel {
  private:
   Delegate* delegate_;  // weak ref.
 
-  std::map<int, base::string16> roles_;  // command id -> role
+  std::map<int, base::string16> toolTips_;  // command id -> tooltip
+  std::map<int, base::string16> roles_;     // command id -> role
   base::ObserverList<Observer> observers_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomMenuModel);

--- a/shell/browser/ui/cocoa/atom_menu_controller.mm
+++ b/shell/browser/ui/cocoa/atom_menu_controller.mm
@@ -233,6 +233,9 @@ static base::scoped_nsobject<NSMenu> recentDocumentsMenuSwap_;
   if (model->GetIconAt(index, &icon) && !icon.IsEmpty())
     [item setImage:icon.ToNSImage()];
 
+  base::string16 toolTip = model->GetToolTipAt(index);
+  [item setToolTip:base::SysUTF16ToNSString(toolTip)];
+
   base::string16 role = model->GetRoleAt(index);
   electron::AtomMenuModel::ItemType type = model->GetTypeAt(index);
 
@@ -344,8 +347,8 @@ static base::scoped_nsobject<NSMenu> recentDocumentsMenuSwap_;
   DCHECK(model);
   if (model) {
     NSEvent* event = [NSApp currentEvent];
-    model->ActivatedAt(modelIndex,
-                       ui::EventFlagsFromNSEventWithModifiers(event, [event modifierFlags]));
+    model->ActivatedAt(modelIndex, ui::EventFlagsFromNSEventWithModifiers(
+                                       event, [event modifierFlags]));
   }
 }
 


### PR DESCRIPTION
#### Description of Change
Resolves #17016.

This PR adds the `toolTip` property to `MenuItem` which indicates the item's hover text. Currently, this is macOS-only, but as soon as i get my hands on a Win/Linux machine, I'll investigate it there as well.

cc @codebytere @erickzhao 

#### Discussion
Tbh, I've never seen a native app using tooltips on menu items and wouldn't consider it as good style to do so. However, Apple allows it (wondering why ^^) - so we could add it to our API.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added a property to set tooltips for MenuItems on macOS.
