### PR TITLE
test: disable IAP tests that hit Apple servers

### DIFF
--- a/spec/api-in-app-purchase-spec.js
+++ b/spec/api-in-app-purchase-spec.js
@@ -38,17 +38,22 @@ describe('inAppPurchase module', function () {
     expect(correctUrlEnd).to.be.true()
   })
 
-  it('purchaseProduct() fails when buying invalid product', async () => {
+  // The following three tests are disabled because they hit Apple servers, and
+  // Apple started blocking requests from AWS IPs (we think), so they fail on
+  // CI.
+  // TODO: find a way to mock out the server requests so we can test these APIs
+  // without relying on a remote service.
+  xit('purchaseProduct() fails when buying invalid product', async () => {
     const success = await inAppPurchase.purchaseProduct('non-exist', 1)
     expect(success).to.be.false()
   })
 
-  it('purchaseProduct() accepts optional arguments', async () => {
+  xit('purchaseProduct() accepts optional arguments', async () => {
     const success = await inAppPurchase.purchaseProduct('non-exist')
     expect(success).to.be.false()
   })
 
-  it('getProducts() returns an empty list when getting invalid product', async () => {
+  xit('getProducts() returns an empty list when getting invalid product', async () => {
     const products = await inAppPurchase.getProducts(['non-exist'])
     expect(products).to.be.an('array').of.length(0)
   })


### PR DESCRIPTION
#### Description of Change
These tests started failing on an unrelated change, and they pass locally, leading us to believe that Apple started blocking requests to the StoreKit servers from AWS. We shouldn't be hitting remote servers in CI anyway, so I'm disabling these tests for now.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none