### PR TITLE
fix: handle no env in externsion world set up

### DIFF
--- a/shell/renderer/atom_renderer_client.cc
+++ b/shell/renderer/atom_renderer_client.cc
@@ -202,8 +202,11 @@ void AtomRendererClient::SetupMainWorldOverrides(
       node::FIXED_ONE_BYTE_STRING(isolate, "nodeProcess"),
       node::FIXED_ONE_BYTE_STRING(isolate, "isolatedWorld")};
 
+  auto* env = GetEnvironment(render_frame);
+  DCHECK(env);
+
   std::vector<v8::Local<v8::Value>> isolated_bundle_args = {
-      GetEnvironment(render_frame)->process_object(),
+      env->process_object(),
       GetContext(render_frame->GetWebFrame(), isolate)->Global()};
 
   node::per_process::native_module_loader.CompileAndCall(
@@ -222,8 +225,12 @@ void AtomRendererClient::SetupExtensionWorldOverrides(
       node::FIXED_ONE_BYTE_STRING(isolate, "isolatedWorld"),
       node::FIXED_ONE_BYTE_STRING(isolate, "worldId")};
 
+  auto* env = GetEnvironment(render_frame);
+  if (!env)
+    return;
+
   std::vector<v8::Local<v8::Value>> isolated_bundle_args = {
-      GetEnvironment(render_frame)->process_object(),
+      env->process_object(),
       GetContext(render_frame->GetWebFrame(), isolate)->Global(),
       v8::Integer::New(isolate, world_id)};
 


### PR DESCRIPTION
Previously when GetEnvironment returned null this extension setup crashed.

Also added a DCHECK to the `SetupMainWorldOverrides` to ensure it is set to make that more trackable because finding this one was annoying 👍 I'd love to add a test for this but the best repro I had was "launch app on my machine and it crashes" so this is the best I've got 👍 

Notes: Fixed crash that could occur while certain chrome devtools extensions were loaded.