### PR TITLE
build: ensure that we bundle the correct version of @types/node

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@electron/get": "^1.0.1",
-    "@types/node": "^10.12.18",
+    "@types/node": "^12.0.12",
     "extract-zip": "^1.0.3"
   },
   "engines": {

--- a/spec-main/types-spec.ts
+++ b/spec-main/types-spec.ts
@@ -1,0 +1,10 @@
+import { expect } from 'chai'
+
+describe('bundled @types/node', () => {
+  it('should match the major version of bundled node', () => {
+    expect(require('../npm/package.json').dependencies).to.have.property('@types/node')
+    const range = require('../npm/package.json').dependencies['@types/node']
+    expect(range).to.match(/^\^.+/, 'should allow any type dep in a major range')
+    expect(range.slice(1).split('.')[0]).to.equal(process.versions.node.split('.')[0])
+  })
+})


### PR DESCRIPTION
Noticed we weren't bundling the right major version of the `@types/node` package.  Updated the dependency and added a test to ensure that when we bump node in the future we are using the right types dependency

Notes: no-notes