### PR TITLE
fix: use binding.ipc instead of binding.sendTo which is undefined

### DIFF
--- a/lib/renderer/ipc-renderer-internal.ts
+++ b/lib/renderer/ipc-renderer-internal.ts
@@ -14,9 +14,9 @@ ipcRendererInternal.sendSync = function (channel, ...args) {
 }
 
 ipcRendererInternal.sendTo = function (webContentsId, channel, ...args) {
-  return binding.sendTo(internal, false, webContentsId, channel, args)
+  return binding.ipc.sendTo(internal, false, webContentsId, channel, args)
 }
 
 ipcRendererInternal.sendToAll = function (webContentsId, channel, ...args) {
-  return binding.sendTo(internal, true, webContentsId, channel, args)
+  return binding.ipc.sendTo(internal, true, webContentsId, channel, args)
 }


### PR DESCRIPTION
Found while investigating #19070.  `binding.sendTo` is not a thing, `binding.ipc.sendTo`, that's a thing 😄 

Notes: Fixed some chrome extension communication (`MessagePort.postMessage`) not working