### PR TITLE
fix: serialize messages being sent over chrome message ports

### DIFF
--- a/lib/renderer/chrome-api.ts
+++ b/lib/renderer/chrome-api.ts
@@ -40,10 +40,10 @@ class Port {
     })
 
     ipcRendererInternal.on(`CHROME_PORT_POSTMESSAGE_${portId}`, (
-      _event: Electron.Event, message: string
+      _event: Electron.Event, message: any
     ) => {
       const sendResponse = function () { console.error('sendResponse is not implemented') }
-      this.onMessage.emit(message, this.sender, sendResponse)
+      this.onMessage.emit(JSON.parse(message), this.sender, sendResponse)
     })
   }
 
@@ -54,8 +54,8 @@ class Port {
     this._onDisconnect()
   }
 
-  postMessage (message: string) {
-    ipcRendererInternal.sendToAll(this.tabId, `CHROME_PORT_POSTMESSAGE_${this.portId}`, message)
+  postMessage (message: any) {
+    ipcRendererInternal.sendToAll(this.tabId, `CHROME_PORT_POSTMESSAGE_${this.portId}`, JSON.stringify(message))
   }
 
   _onDisconnect () {


### PR DESCRIPTION
Chrome appears to serialize these messages (see #19070) so we should as well to be consistent and to avoid bugs with Uint8/16 arrays

Fixes #19070

Notes: `Uint8Array` and `Uint16Array` can now be sent correctly in Chrome Extension `MessagePort` instances