### PR TITLE
feat: add object to subscribe notification callback

### DIFF
--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -90,13 +90,14 @@ that contains the user information dictionary sent along with the notification.
 * `callback` Function
   * `event` String
   * `userInfo` Object
+  * `object` String
 
 Returns `Number` - The ID of this subscription
 
 Subscribes to native notifications of macOS, `callback` will be called with
 `callback(event, userInfo)` when the corresponding `event` happens. The
 `userInfo` is an Object that contains the user information dictionary sent
-along with the notification.
+along with the notification. The `object` is the sender of the notification.
 
 The `id` of the subscriber is returned, which can be used to unsubscribe the
 `event`.
@@ -115,6 +116,7 @@ example values of `event` are:
 * `callback` Function
   * `event` String
   * `userInfo` Object
+  * `object` String
 
 Returns `Number` - The ID of this subscription
 
@@ -127,6 +129,7 @@ This is necessary for events such as `NSUserDefaultsDidChangeNotification`.
 * `callback` Function
   * `event` String
   * `userInfo` Object
+  * `object` String
 
 Same as `subscribeNotification`, but uses `NSWorkspace.sharedWorkspace.notificationCenter`.
 This is necessary for events such as `NSWorkspaceDidActivateApplicationNotification`.

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -97,7 +97,8 @@ Returns `Number` - The ID of this subscription
 Subscribes to native notifications of macOS, `callback` will be called with
 `callback(event, userInfo)` when the corresponding `event` happens. The
 `userInfo` is an Object that contains the user information dictionary sent
-along with the notification. The `object` is the sender of the notification.
+along with the notification. The `object` is the sender of the notification,
+and only supports `NSString` values for now.
 
 The `id` of the subscriber is returned, which can be used to unsubscribe the
 `event`.

--- a/shell/browser/api/atom_api_system_preferences.h
+++ b/shell/browser/api/atom_api_system_preferences.h
@@ -67,7 +67,8 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
 #elif defined(OS_MACOSX)
   using NotificationCallback =
       base::RepeatingCallback<void(const std::string&,
-                                   const base::DictionaryValue&)>;
+                                   const base::DictionaryValue&,
+                                   const std::string&)>;
 
   void PostNotification(const std::string& name,
                         const base::DictionaryValue& user_info,

--- a/shell/browser/api/atom_api_system_preferences_mac.mm
+++ b/shell/browser/api/atom_api_system_preferences_mac.mm
@@ -213,7 +213,7 @@ int SystemPreferences::DoSubscribeNotification(
 
                 std::string object = "";
                 if ([notification.object isKindOfClass:[NSString class]]) {
-                  object = base::SysNSStringToUTF8(notification.object));
+                  object = base::SysNSStringToUTF8(notification.object);
                 }
 
                 if (user_info) {

--- a/shell/browser/api/atom_api_system_preferences_mac.mm
+++ b/shell/browser/api/atom_api_system_preferences_mac.mm
@@ -212,11 +212,14 @@ int SystemPreferences::DoSubscribeNotification(
                     NSDictionaryToDictionaryValue(notification.userInfo);
                 if (user_info) {
                   copied_callback.Run(
-                      base::SysNSStringToUTF8(notification.name), *user_info);
+                      base::SysNSStringToUTF8(notification.name),
+                      *user_info,
+                      base::SysNSStringToUTF8(notification.object));
                 } else {
                   copied_callback.Run(
                       base::SysNSStringToUTF8(notification.name),
-                      base::DictionaryValue());
+                      base::DictionaryValue(),
+                      base::SysNSStringToUTF8(notification.object));
                 }
               }];
   return request_id;

--- a/shell/browser/api/atom_api_system_preferences_mac.mm
+++ b/shell/browser/api/atom_api_system_preferences_mac.mm
@@ -210,16 +210,22 @@ int SystemPreferences::DoSubscribeNotification(
               usingBlock:^(NSNotification* notification) {
                 std::unique_ptr<base::DictionaryValue> user_info =
                     NSDictionaryToDictionaryValue(notification.userInfo);
+
+                std::string object = "";
+                if ([notification.object isKindOfClass:[NSString class]]) {
+                  object = base::SysNSStringToUTF8(notification.object));
+                }
+
                 if (user_info) {
                   copied_callback.Run(
                       base::SysNSStringToUTF8(notification.name),
                       *user_info,
-                      base::SysNSStringToUTF8(notification.object));
+                      object);
                 } else {
                   copied_callback.Run(
                       base::SysNSStringToUTF8(notification.name),
                       base::DictionaryValue(),
-                      base::SysNSStringToUTF8(notification.object));
+                      object);
                 }
               }];
   return request_id;


### PR DESCRIPTION
#### Description of Change

Closes #19097.

This change exposes the `object` property on NSNotification to the callback passed to Electron's `systemPreferences.subscriptionNotification` methods.

I'm cc-ing @zcbenz on this PR as he worked on a very similar feature under #5582.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Exposed the value of NSNotification.object to subscribers of notifications in systemPreferences.