### PR TITLE
build: fix ffmpeg gn gen

### DIFF
--- a/build/args/ffmpeg.gn
+++ b/build/args/ffmpeg.gn
@@ -4,3 +4,4 @@ is_component_ffmpeg = true
 is_official_build = true
 proprietary_codecs = false
 ffmpeg_branding = "Chromium"
+enable_dsyms = false

--- a/script/run-gn-format.py
+++ b/script/run-gn-format.py
@@ -15,7 +15,6 @@ def main():
   for gn_file in sys.argv[1:]:
     subprocess.check_call(
       ['gn', 'format', gn_file],
-      shell=True,
       env=new_env
     )
 


### PR DESCRIPTION
#### Description of Change
Somehow #19042 broke non proprietary ffmpeg GN gen.  This PR fixes that.  It also reverts #18993 because that PR introduced a security hole and prevented commits on linux and mac.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes