### PR TITLE
[WIP] fix: avoid blurring window when using Character Viewer pop-up on macOS

### DIFF
--- a/shell/browser/api/atom_api_browser_window.cc
+++ b/shell/browser/api/atom_api_browser_window.cc
@@ -245,22 +245,13 @@ void BrowserWindow::OnWindowClosed() {
 
 void BrowserWindow::OnWindowBlur() {
   web_contents()->StoreFocus();
-#if defined(OS_MACOSX)
-  auto* rwhv = web_contents()->GetRenderWidgetHostView();
-  if (rwhv)
-    rwhv->SetActive(false);
-#endif
 
   TopLevelWindow::OnWindowBlur();
 }
 
 void BrowserWindow::OnWindowFocus() {
   web_contents()->RestoreFocus();
-#if defined(OS_MACOSX)
-  auto* rwhv = web_contents()->GetRenderWidgetHostView();
-  if (rwhv)
-    rwhv->SetActive(true);
-#else
+#if !defined(OS_MACOSX)
   if (!api_web_contents_->IsDevToolsOpened())
     web_contents()->Focus();
 #endif

--- a/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -89,8 +89,6 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
 }
 
 - (void)windowDidBecomeKey:(NSNotification*)notification {
-  // NSWindow* window = notification.object;
-  // LOG(INFO) << window.childWindows.count;
   shell_->NotifyWindowFocus();
 }
 

--- a/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -89,11 +89,31 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
 }
 
 - (void)windowDidBecomeKey:(NSNotification*)notification {
-  shell_->NotifyWindowFocus();
+  NSWindow* window = notification.object;
+  if (window.sheet) {
+    shell_->NotifyWindowFocus();
+  }
 }
 
 - (void)windowDidResignKey:(NSNotification*)notification {
-  shell_->NotifyWindowBlur();
+  NSWindow* window = notification.object;
+  if (window.sheet) {
+    shell_->NotifyWindowBlur();
+  }
+}
+
+- (void)windowDidBecomeMain:(NSNotification*)notification {
+  NSWindow* window = notification.object;
+  if (!window.sheet) {
+    shell_->NotifyWindowFocus();
+  }
+}
+
+- (void)windowDidResignMain:(NSNotification*)notification {
+  NSWindow* window = notification.object;
+  if (!window.sheet) {
+    shell_->NotifyWindowBlur();
+  }
 }
 
 - (NSSize)windowWillResize:(NSWindow*)sender toSize:(NSSize)frameSize {

--- a/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -89,29 +89,19 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
 }
 
 - (void)windowDidBecomeKey:(NSNotification*)notification {
-  NSWindow* window = notification.object;
-  if (window.sheet) {
-    shell_->NotifyWindowFocus();
-  }
+  // NSWindow* window = notification.object;
+  // LOG(INFO) << window.childWindows.count;
+  shell_->NotifyWindowFocus();
 }
 
 - (void)windowDidResignKey:(NSNotification*)notification {
-  NSWindow* window = notification.object;
-  if (window.sheet) {
-    shell_->NotifyWindowBlur();
-  }
-}
-
-- (void)windowDidBecomeMain:(NSNotification*)notification {
-  NSWindow* window = notification.object;
-  if (!window.sheet) {
-    shell_->NotifyWindowFocus();
-  }
-}
-
-- (void)windowDidResignMain:(NSNotification*)notification {
-  NSWindow* window = notification.object;
-  if (!window.sheet) {
+  NSWindow* resigningWindow = notification.object;
+  NSWindow* newKeyWindow = [NSApp keyWindow];
+  // macOS character palette will not be detected as the
+  // app's key window. We don't want to send a blur
+  // event when the palette activates because we don't want
+  // the original window's input to lose focus
+  if (newKeyWindow != resigningWindow) {
     shell_->NotifyWindowBlur();
   }
 }


### PR DESCRIPTION
#### Description of Change

##### Context
In PR #18995, I had submitted a fix such that `focus` and `blur` events were listening for changes in the Key window rather than the Main window.

However, Issue #19124 showed that since a window would lose its Key status when the [macOS Character Viewer](https://support.apple.com/en-us/HT201586) was activated, the `blur` event would make any input on the window lose its focus.

Then, the character selected from the Character Viewer wouldn't be entered into the input.

##### Change

I did not find much documentation regarding the behavior of `NSWindow` with respect to the Character Viewer. After playing around with `windowDidResignKey`, I found that when the Character Viewer appears, the window loses its Key status, but the `[NSApp keyWindow]` variable still referenced the original window.

Thus, I added a conditional check to only apply the `blur` event if the resigning window and the new key window weren't the same.

cc @codebytere @zcbenz @javan 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed bug on macOS that broke input from the Character Viewer popup.
