### PR TITLE
docs: remind user executeJavaScript will not run immediately.

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1034,6 +1034,8 @@ In the browser window some HTML APIs like `requestFullScreen` can only be
 invoked by a gesture from the user. Setting `userGesture` to `true` will remove
 this limitation.
 
+Code execution will be suspended until web page stop loading.
+
 ```js
 contents.executeJavaScript('fetch("https://jsonplaceholder.typicode.com/users/1").then(resp => resp.json())', true)
   .then((result) => {


### PR DESCRIPTION
Remind user the `contents.executeJavaScript()` will not run their code immediately if the web page still in running.  Without the knowledge, user would think their code not function properly and it's hard to debug because different page have different loading time.

According to  [web-contents.js](https://github.com/electron/electron/blob/731edbe2b6a767ce5dab8b5760bc66c687b749cf/lib/browser/api/web-contents.js#L199)

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

Notes: none
