### PR TITLE
refactor: implement GetResourcesPath using MainApplicationBundlePath on Mac

### DIFF
--- a/shell/common/mac/main_application_bundle.h
+++ b/shell/common/mac/main_application_bundle.h
@@ -6,7 +6,11 @@
 #ifndef SHELL_COMMON_MAC_MAIN_APPLICATION_BUNDLE_H_
 #define SHELL_COMMON_MAC_MAIN_APPLICATION_BUNDLE_H_
 
+#ifdef __OBJC__
 @class NSBundle;
+#else
+struct NSBundle;
+#endif
 
 namespace base {
 class FilePath;

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -34,7 +34,6 @@ class NodeBindings {
   static NodeBindings* Create(BrowserEnvironment browser_env);
   static void RegisterBuiltinModules();
   static bool IsInitialized();
-  static base::FilePath::StringType GetHelperResourcesPath();
 
   virtual ~NodeBindings();
 


### PR DESCRIPTION
#### Description of Change
Re-use existing logic in `MainApplicationBundlePath` to avoid duplicating similar code.
Also remove leftover `NodeBindings::GetHelperResourcesPath()` after #15701.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes
