### PR TITLE
build: strip recently added swiftshader/libvulkan.so

### DIFF
--- a/script/strip-binaries.py
+++ b/script/strip-binaries.py
@@ -12,7 +12,8 @@ LINUX_BINARIES_TO_STRIP = [
   'libGLESv2.so',
   'libEGL.so',
   'swiftshader/libGLESv2.so',
-  'swiftshader/libEGL.so'
+  'swiftshader/libEGL.so',
+  'swiftshader/libvulkan.so'
 ]
 
 def strip_binaries(directory, target_cpu):


### PR DESCRIPTION
#### Description of Change
#18648 introduced `swiftshader/libvulkan.so`, which needs to be stripped

[electron-v7.0.0-nightly.20190702-linux-x64.zip](https://github.com/electron/nightlies/releases/download/v7.0.0-nightly.20190702/electron-v7.0.0-nightly.20190702-linux-x64.zip) -> 59.9 MB
[electron-v7.0.0-nightly.20190704-linux-x64.zip](https://github.com/electron/nightlies/releases/download/v7.0.0-nightly.20190704/electron-v7.0.0-nightly.20190704-linux-x64.zip) -> 256 MB

<img width="1025" alt="Screen Shot 2019-07-07 at 1 47 22 PM" src="https://user-images.githubusercontent.com/1281234/60767847-c7088c00-a0bd-11e9-9c4f-9898a07ad8c6.png">

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes