### PR TITLE
fix: disable animation for win.setSimpleFullScreen on 4.x

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -952,7 +952,13 @@ void NativeWindowMac::SetSimpleFullScreen(bool simple_fullscreen) {
       [[window standardWindowButton:NSWindowCloseButton] setHidden:YES];
     }
 
-    [window setFrame:fullscreenFrame display:YES animate:YES];
+    // There is a bug with Chromium that, after setting window style, calling
+    // setFrame with animation immediately would block window rendering for
+    // a few seconds.
+    // This Chromium bug is fixed in later versions, but it is hard to find
+    // out how to backport the fix or how to work around it, disabling the
+    // animation is the easist fix and most users would not even notice it.
+    [window setFrame:fullscreenFrame display:YES animate:NO];
 
     // Fullscreen windows can't be resized, minimized, maximized, or moved
     SetMinimizable(false);
@@ -976,7 +982,7 @@ void NativeWindowMac::SetSimpleFullScreen(bool simple_fullscreen) {
     [[window standardWindowButton:NSWindowCloseButton]
         setHidden:window_button_hidden];
 
-    [window setFrame:original_frame_ display:YES animate:YES];
+    [window setFrame:original_frame_ display:YES animate:NO];
     window.level = original_level_;
 
     [NSApp setPresentationOptions:simple_fullscreen_options_];


### PR DESCRIPTION
#### Description of Change

This PR fixes the bug described in https://github.com/microsoft/vscode/issues/75054.

There is a bug with Chromium that, after setting window style, calling setFrame with animation immediately would block window rendering for a few seconds.

This Chromium bug is fixed in later versions, but it is hard to find out how to backport the fix or how to work around it, disabling the animation is the easist fix and most users would not even notice it.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix toggling simple fullscreen being very slow.