### PR TITLE
 fix: use gn/clang-format from src

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -553,11 +553,20 @@ steps-lint: &steps-lint
 
           cipd ensure -ensure-file - -root . <<-CIPD
           \$ServiceURL https://chrome-infra-packages.appspot.com/
-          @Subdir buildtools/linux64
+          @Subdir src/buildtools/linux64
           gn/gn/linux-amd64 $gn_version
           CIPD
 
-          echo 'export CHROMIUM_BUILDTOOLS_PATH="'"$PWD"'/buildtools"' >> $BASH_ENV
+          echo 'export CHROMIUM_BUILDTOOLS_PATH="'"$PWD"'/src/buildtools"' >> $BASH_ENV
+    - run:
+        name: Download clang-format Binary
+        command: |
+          chromium_revision="$(grep -A1 chromium_version src/electron/DEPS | tr -d '\n' | cut -d\' -f4)"
+
+          sha1_path='buildtools/linux64/clang-format.sha1'
+          curl -sL "https://chromium.googlesource.com/chromium/src/+/${chromium_revision}/${sha1_path}?format=TEXT" | base64 -d > "src/${sha1_path}"
+
+          download_from_google_storage.py --no_resume --no_auth --bucket chromium-clang-format -s "src/${sha1_path}"
     - run:
         name: Run Lint
         command: |

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@typescript-eslint/parser": "^1.4.2",
     "asar": "^1.0.0",
     "check-for-leaks": "^1.2.1",
-    "clang-format": "^1.2.3",
     "colors": "^1.1.2",
     "dotenv-safe": "^4.0.4",
     "dugite": "^1.45.0",
@@ -61,7 +60,6 @@
   "scripts": {
     "asar": "asar",
     "check-tls": "python ./script/tls.py",
-    "clang-format": "find atom/ chromium_src/ -iname *.h -o -iname *.cc -o -iname *.mm | xargs clang-format -i",
     "generate-version-json": "node script/generate-version-json.js",
     "lint": "node ./script/lint.js && npm run lint:clang-format && npm run lint:docs",
     "lint:js": "node ./script/lint.js --js",

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -246,3 +246,15 @@ def get_electron_exec():
 
   raise Exception(
       "get_electron_exec: unexpected platform '{0}'".format(sys.platform))
+
+def get_path_in_buildtools(name):
+  buildtools = os.path.realpath(os.path.join(ELECTRON_DIR, '..', 'buildtools'))
+  chromium_platform = {
+    'darwin': 'mac',
+    'linux2': 'linux64',
+    'win32': 'win',
+  }[sys.platform]
+  path = os.path.join(buildtools, chromium_platform, name)
+  if sys.platform == 'win32':
+    path += '.exe'
+  return path

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -247,7 +247,7 @@ def get_electron_exec():
   raise Exception(
       "get_electron_exec: unexpected platform '{0}'".format(sys.platform))
 
-def get_path_in_buildtools(name):
+def get_buildtools_executable(name):
   buildtools = os.path.realpath(os.path.join(ELECTRON_DIR, '..', 'buildtools'))
   chromium_platform = {
     'darwin': 'mac',

--- a/script/run-clang-format.py
+++ b/script/run-clang-format.py
@@ -22,7 +22,7 @@ import traceback
 import tempfile
 
 from functools import partial
-from lib.util import get_path_in_buildtools
+from lib.util import get_buildtools_executable
 
 DEFAULT_EXTENSIONS = 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx,mm'
 
@@ -189,7 +189,7 @@ def main():
         '--clang-format-executable',
         metavar='EXECUTABLE',
         help='path to the clang-format executable',
-        default=get_path_in_buildtools('clang-format'))
+        default=get_buildtools_executable('clang-format'))
     parser.add_argument(
         '--extensions',
         help='comma separated list of file extensions (default: {})'.format(

--- a/script/run-clang-format.py
+++ b/script/run-clang-format.py
@@ -22,6 +22,7 @@ import traceback
 import tempfile
 
 from functools import partial
+from lib.util import get_path_in_buildtools
 
 DEFAULT_EXTENSIONS = 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx,mm'
 
@@ -188,7 +189,7 @@ def main():
         '--clang-format-executable',
         metavar='EXECUTABLE',
         help='path to the clang-format executable',
-        default='clang-format')
+        default=get_path_in_buildtools('clang-format'))
     parser.add_argument(
         '--extensions',
         help='comma separated list of file extensions (default: {})'.format(

--- a/script/run-gn-format.py
+++ b/script/run-gn-format.py
@@ -2,6 +2,8 @@ import os
 import subprocess
 import sys
 
+from lib.util import get_path_in_buildtools
+
 SOURCE_ROOT = os.path.dirname(os.path.dirname(__file__))
 
 # Helper to run gn format on multiple files
@@ -12,9 +14,11 @@ def main():
   new_env['CHROMIUM_BUILDTOOLS_PATH'] = os.path.realpath(
     os.path.join(SOURCE_ROOT, '..', 'buildtools')
   )
+
+  gn_path = get_path_in_buildtools('gn')
   for gn_file in sys.argv[1:]:
     subprocess.check_call(
-      ['gn', 'format', gn_file],
+      [gn_path, 'format', gn_file],
       env=new_env
     )
 

--- a/script/run-gn-format.py
+++ b/script/run-gn-format.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import sys
 
-from lib.util import get_path_in_buildtools
+from lib.util import get_buildtools_executable
 
 SOURCE_ROOT = os.path.dirname(os.path.dirname(__file__))
 
@@ -15,7 +15,7 @@ def main():
     os.path.join(SOURCE_ROOT, '..', 'buildtools')
   )
 
-  gn_path = get_path_in_buildtools('gn')
+  gn_path = get_buildtools_executable('gn')
   for gn_file in sys.argv[1:]:
     subprocess.check_call(
       [gn_path, 'format', gn_file],

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -98,13 +98,14 @@ namespace {
 void stop_and_close_uv_loop(uv_loop_t* loop) {
   // Close any active handles
   uv_stop(loop);
-  uv_walk(loop,
-          [](uv_handle_t* handle, void*) {
-            if (!uv_is_closing(handle)) {
-              uv_close(handle, nullptr);
-            }
-          },
-          nullptr);
+  uv_walk(
+      loop,
+      [](uv_handle_t* handle, void*) {
+        if (!uv_is_closing(handle)) {
+          uv_close(handle, nullptr);
+        }
+      },
+      nullptr);
 
   // Run the loop to let it finish all the closing handles
   // NB: after uv_stop(), uv_run(UV_RUN_DEFAULT) returns 0 when that's done

--- a/yarn.lock
+++ b/yarn.lock
@@ -682,10 +682,6 @@ async-each@^1.0.0, async-each@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
 
-async@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
-
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -1185,14 +1181,6 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
 circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
-
-clang-format@^1.2.3:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/clang-format/-/clang-format-1.2.4.tgz#4bb4b0a98180428deb093cf20982e9fc1af20b6c"
-  dependencies:
-    async "^1.5.2"
-    glob "^7.0.0"
-    resolve "^1.1.6"
 
 class-utils@^0.3.5:
   version "0.3.6"


### PR DESCRIPTION
#### Description of Change

The lint scripts should use the `gn`/`clang-format` binaries inside `src/`, instead of the ones in global environment, so the lint results are deterministic.

This fixes lint errors when switching between different Electron major versions. It also fixes lint scripts on some Windows environments, where python can have trouble searching for `gn`/`clang-format` by name.

This PR also includes a style fix due to the `clang-format` in CI being a different version from the one in Chromium.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes