### PR TITLE
[experiment] refactor: replace getLastWebPreferences() with getWebPreferences()

### DIFF
--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -144,7 +144,7 @@ const createGuest = function (embedder, params) {
   // Forward internal web contents event to embedder to handle
   // native window.open setup
   guest.on('-add-new-contents', (...args) => {
-    if (guest.getLastWebPreferences().nativeWindowOpen === true) {
+    if (guest.getWebPreferences().nativeWindowOpen === true) {
       const embedder = getEmbedder(guestInstanceId)
       if (embedder != null) {
         embedder.emit('-add-new-contents', ...args)
@@ -236,7 +236,7 @@ const attachGuest = function (event, embedderFrameId, elementInstanceId, guestIn
   ])
 
   // Inherit certain option values from embedder
-  const lastWebPreferences = embedder.getLastWebPreferences()
+  const lastWebPreferences = embedder.getWebPreferences()
   for (const [name, value] of inheritedWebPreferences) {
     if (lastWebPreferences[name] === value) {
       webPreferences[name] = value
@@ -318,7 +318,7 @@ const isWebViewTagEnabledCache = new WeakMap()
 
 const isWebViewTagEnabled = function (contents) {
   if (!isWebViewTagEnabledCache.has(contents)) {
-    const webPreferences = contents.getLastWebPreferences() || {}
+    const webPreferences = contents.getWebPreferences() || {}
     isWebViewTagEnabledCache.set(contents, !!webPreferences.webviewTag)
   }
 

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -62,11 +62,11 @@ const mergeBrowserWindowOptions = function (embedder, options) {
     mergeOptions(options, parentOptions)
   } else {
     // Or only inherit webPreferences if it is a webview.
-    mergeOptions(options.webPreferences, embedder.getLastWebPreferences())
+    mergeOptions(options.webPreferences, embedder.getWebPreferences())
   }
 
   // Inherit certain option values from parent window
-  const webPreferences = embedder.getLastWebPreferences()
+  const webPreferences = embedder.getWebPreferences()
   for (const [name, value] of inheritedWebPreferences) {
     if (webPreferences[name] === value) {
       options.webPreferences[name] = value
@@ -157,7 +157,7 @@ const getGuestWindow = function (guestContents) {
 }
 
 const isChildWindow = function (sender, target) {
-  return target.getLastWebPreferences().openerId === sender.id
+  return target.getWebPreferences().openerId === sender.id
 }
 
 const isRelatedWindow = function (sender, target) {
@@ -169,7 +169,7 @@ const isScriptableWindow = function (sender, target) {
 }
 
 const isNodeIntegrationEnabled = function (sender) {
-  return sender.getLastWebPreferences().nodeIntegration === true
+  return sender.getWebPreferences().nodeIntegration === true
 }
 
 // Checks whether |sender| can access the |target|:
@@ -251,7 +251,7 @@ ipcMainInternal.on('ELECTRON_GUEST_WINDOW_MANAGER_INTERNAL_WINDOW_OPEN', functio
   options = mergeBrowserWindowOptions(event.sender, options)
   event.sender.emit('new-window', event, url, frameName, disposition, options, additionalFeatures, referrer)
   const { newGuest } = event
-  if ((event.sender.getType() === 'webview' && event.sender.getLastWebPreferences().disablePopups) || event.defaultPrevented) {
+  if ((event.sender.getType() === 'webview' && event.sender.getWebPreferences().disablePopups) || event.defaultPrevented) {
     if (newGuest != null) {
       if (options.webContents === newGuest.webContents) {
         // the webContents is not changed, so set defaultPrevented to false to

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -476,8 +476,8 @@ ipcMainUtils.handle('ELECTRON_CRASH_REPORTER_INIT', function (event, options) {
   return crashReporterInit(options)
 })
 
-ipcMainUtils.handle('ELECTRON_BROWSER_GET_LAST_WEB_PREFERENCES', function (event) {
-  return event.sender.getLastWebPreferences()
+ipcMainUtils.handle('ELECTRON_BROWSER_GET_WEB_PREFERENCES', function (event) {
+  return event.sender.getWebPreferences()
 })
 
 // Methods not listed in this set are called directly in the renderer process.

--- a/lib/renderer/security-warnings.ts
+++ b/lib/renderer/security-warnings.ts
@@ -299,9 +299,9 @@ const logSecurityWarnings = function (
 
 const getWebPreferences = async function () {
   try {
-    return invoke<Electron.WebPreferences>('ELECTRON_BROWSER_GET_LAST_WEB_PREFERENCES')
+    return invoke<Electron.WebPreferences>('ELECTRON_BROWSER_GET_WEB_PREFERENCES')
   } catch (error) {
-    console.warn(`getLastWebPreferences() failed: ${error}`)
+    console.warn(`getWebPreferences() failed: ${error}`)
   }
 }
 

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -2228,14 +2228,6 @@ v8::Local<v8::Value> WebContents::GetWebPreferences(
   return mate::ConvertToV8(isolate, *web_preferences->preference());
 }
 
-v8::Local<v8::Value> WebContents::GetLastWebPreferences(
-    v8::Isolate* isolate) const {
-  auto* web_preferences = WebContentsPreferences::From(web_contents());
-  if (!web_preferences)
-    return v8::Null(isolate);
-  return mate::ConvertToV8(isolate, *web_preferences->last_preference());
-}
-
 bool WebContents::IsRemoteModuleEnabled() const {
   if (web_contents()->GetVisibleURL().SchemeIs("devtools")) {
     return false;
@@ -2453,7 +2445,6 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("getType", &WebContents::GetType)
       .SetMethod("_getPreloadPaths", &WebContents::GetPreloadPaths)
       .SetMethod("getWebPreferences", &WebContents::GetWebPreferences)
-      .SetMethod("getLastWebPreferences", &WebContents::GetLastWebPreferences)
       .SetMethod("_isRemoteModuleEnabled", &WebContents::IsRemoteModuleEnabled)
       .SetMethod("getOwnerBrowserWindow", &WebContents::GetOwnerBrowserWindow)
       .SetMethod("inspectServiceWorker", &WebContents::InspectServiceWorker)

--- a/shell/browser/api/atom_api_web_contents.h
+++ b/shell/browser/api/atom_api_web_contents.h
@@ -289,7 +289,6 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
   // Returns the web preferences of current WebContents.
   v8::Local<v8::Value> GetWebPreferences(v8::Isolate* isolate) const;
-  v8::Local<v8::Value> GetLastWebPreferences(v8::Isolate* isolate) const;
 
   bool IsRemoteModuleEnabled() const;
 

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -165,8 +165,6 @@ WebContentsPreferences::WebContentsPreferences(
       }
     }
   }
-
-  last_preference_ = preference_.Clone();
 }
 
 WebContentsPreferences::~WebContentsPreferences() {
@@ -414,11 +412,6 @@ void WebContentsPreferences::AppendCommandLineSwitches(
 
   if (IsEnabled(options::kNodeIntegrationInSubFrames))
     command_line->AppendSwitch(switches::kNodeIntegrationInSubFrames);
-
-  // We are appending args to a webContents so let's save the current state
-  // of our preferences object so that during the lifetime of the WebContents
-  // we can fetch the options used to initally configure the WebContents
-  last_preference_ = preference_.Clone();
 }
 
 void WebContentsPreferences::OverrideWebkitPrefs(

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -67,7 +67,6 @@ class WebContentsPreferences
 
   // Returns the web preferences.
   base::Value* preference() { return &preference_; }
-  base::Value* last_preference() { return &last_preference_; }
 
  private:
   friend class content::WebContentsUserData<WebContentsPreferences>;
@@ -87,7 +86,6 @@ class WebContentsPreferences
   content::WebContents* web_contents_;
 
   base::Value preference_ = base::Value(base::Value::Type::DICTIONARY);
-  base::Value last_preference_ = base::Value(base::Value::Type::DICTIONARY);
 
   WEB_CONTENTS_USER_DATA_KEY_DECL();
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -2888,7 +2888,7 @@ describe('BrowserWindow module', () => {
       const browserWindowCreated = emittedOnce(app, 'browser-window-created')
       iw.loadFile(path.join(fixtures, 'pages', 'window-open.html'))
       const [, window] = await browserWindowCreated
-      expect(window.webContents.getLastWebPreferences().contextIsolation).to.be.true()
+      expect(window.webContents.getWebPreferences().contextIsolation).to.be.true()
     })
     it('separates the page context from the Electron/preload context with sandbox on', async () => {
       const p = emittedOnce(ipcMain, 'isolated-world')

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -397,7 +397,7 @@ describe('chromium feature', () => {
       app.once('web-contents-created', (event, contents) => {
         contents.once('did-finish-load', () => {
           app.once('browser-window-created', (event, window) => {
-            const preferences = window.webContents.getLastWebPreferences()
+            const preferences = window.webContents.getWebPreferences()
             expect(preferences.javascript).to.be.false()
             window.destroy()
             b.close()


### PR DESCRIPTION
#### Description of Change
**!!! THIS IS AN EXPERIMENT, DON'T MERGE !!!**
It would reintroduce https://electronjs.org/blog/webview-fix

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
