### PR TITLE
revert: notification handle reset on dismissal

### DIFF
--- a/brightray/browser/mac/cocoa_notification.mm
+++ b/brightray/browser/mac/cocoa_notification.mm
@@ -115,8 +115,6 @@ void CocoaNotification::Dismiss() {
   NotificationDismissed();
 
   this->LogAction("dismissed");
-
-  notification_.reset(nil);
 }
 
 void CocoaNotification::NotificationDisplayed() {


### PR DESCRIPTION
Fixes #19081 

This PR reverts the #17796 which is a fix for #17758 but it was reported for `4.1.0` 

CC: @codebytere @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> Fix notification crash on `3-1-x`
