### PR TITLE
fix: revert use of IPC helpers for history due to failing test

### DIFF
--- a/lib/browser/navigation-controller.js
+++ b/lib/browser/navigation-controller.js
@@ -1,22 +1,22 @@
 'use strict'
 
-const ipcMainUtils = require('@electron/internal/browser/ipc-main-internal-utils')
+const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
 
 // The history operation in renderer is redirected to browser.
-ipcMainUtils.handle('ELECTRON_NAVIGATION_CONTROLLER_GO_BACK', function (event) {
-  return event.sender.goBack()
+ipcMainInternal.on('ELECTRON_NAVIGATION_CONTROLLER_GO_BACK', function (event) {
+  event.sender.goBack()
 })
 
-ipcMainUtils.handle('ELECTRON_NAVIGATION_CONTROLLER_GO_FORWARD', function (event) {
-  return event.sender.goForward()
+ipcMainInternal.on('ELECTRON_NAVIGATION_CONTROLLER_GO_FORWARD', function (event) {
+  event.sender.goForward()
 })
 
-ipcMainUtils.handle('ELECTRON_NAVIGATION_CONTROLLER_GO_TO_OFFSET', function (event, offset) {
-  return event.sender.goToOffset(offset)
+ipcMainInternal.on('ELECTRON_NAVIGATION_CONTROLLER_GO_TO_OFFSET', function (event, offset) {
+  event.sender.goToOffset(offset)
 })
 
-ipcMainUtils.handle('ELECTRON_NAVIGATION_CONTROLLER_LENGTH', function (event) {
-  return event.sender.length()
+ipcMainInternal.on('ELECTRON_NAVIGATION_CONTROLLER_LENGTH', function (event) {
+  event.returnValue = event.sender.length()
 })
 
 // JavaScript implementation of Chromium's NavigationController.

--- a/lib/renderer/window-setup.ts
+++ b/lib/renderer/window-setup.ts
@@ -224,20 +224,20 @@ export const windowSetup = (
   })
 
   window.history.back = function () {
-    ipcRendererUtils.invoke('ELECTRON_NAVIGATION_CONTROLLER_GO_BACK')
+    ipcRendererInternal.send('ELECTRON_NAVIGATION_CONTROLLER_GO_BACK')
   }
 
   window.history.forward = function () {
-    ipcRendererUtils.invoke('ELECTRON_NAVIGATION_CONTROLLER_GO_FORWARD')
+    ipcRendererInternal.send('ELECTRON_NAVIGATION_CONTROLLER_GO_FORWARD')
   }
 
   window.history.go = function (offset: number) {
-    ipcRendererUtils.invoke('ELECTRON_NAVIGATION_CONTROLLER_GO_TO_OFFSET', +offset)
+    ipcRendererInternal.send('ELECTRON_NAVIGATION_CONTROLLER_GO_TO_OFFSET', +offset)
   }
 
   Object.defineProperty(window.history, 'length', {
     get: function () {
-      return ipcRendererUtils.invokeSync('ELECTRON_NAVIGATION_CONTROLLER_LENGTH')
+      return ipcRendererInternal.sendSync('ELECTRON_NAVIGATION_CONTROLLER_LENGTH')
     }
   })
 


### PR DESCRIPTION
#### Description of Change
I've started seeing this test failing after #17948, which could be caused by some timing issue:
```
<webview> tag <webview>.clearHistory() should clear the navigation history
```
Let's revert the history manipulation part for now.
Could also be related to this issue #13249

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes