### PR TITLE
fix: do not wait on promise returned by remote APIs (6-0-x)

### DIFF
--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -277,6 +277,11 @@ webview.addEventListener('dom-ready', () => {
   * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadBlob[]](structures/upload-blob.md)) (optional)
   * `baseURLForDataURL` String (optional) - Base url (with trailing path separator) for files to be loaded by the data url. This is needed only if the specified `url` is a data url and needs to load other files.
 
+Returns `Promise<void>` - The promise will resolve when the page has finished loading
+(see [`did-finish-load`](webview-tag.md#event-did-finish-load)), and rejects
+if the page fails to load (see
+[`did-fail-load`](webview-tag.md#event-did-fail-load)).
+
 Loads the `url` in the webview, the `url` must contain the protocol prefix,
 e.g. the `http://` or `file://`.
 

--- a/lib/common/web-view-methods.js
+++ b/lib/common/web-view-methods.js
@@ -3,7 +3,6 @@
 // Public-facing API methods.
 exports.syncMethods = new Set([
   'getURL',
-  'loadURL',
   'getTitle',
   'isLoading',
   'isLoadingMainFrame',
@@ -64,6 +63,7 @@ exports.asyncCallbackMethods = new Set([
 ])
 
 exports.asyncPromiseMethods = new Set([
+  'loadURL',
   'capturePage',
   'executeJavaScript',
   'printToPDF'

--- a/lib/renderer/web-view/web-view-attributes.ts
+++ b/lib/renderer/web-view/web-view-attributes.ts
@@ -196,7 +196,7 @@ class SrcAttribute extends WebViewAttribute {
     const method = 'loadURL'
     const args = [this.getValue(), opts]
 
-    ipcRendererUtils.invokeSync('ELECTRON_GUEST_VIEW_MANAGER_CALL', guestInstanceId, method, args)
+    ipcRendererUtils.invoke('ELECTRON_GUEST_VIEW_MANAGER_CALL', guestInstanceId, method, args)
   }
 }
 

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -171,6 +171,20 @@ describe('<webview> tag', function () {
         expect(webview.src).to.equal('')
       }
     })
+
+    it('does not wait until loadURL is resolved', async () => {
+      await loadWebView(webview, { src: 'about:blank' })
+
+      const before = Date.now()
+      webview.src = 'https://github.com'
+      const now = Date.now()
+
+      // Setting src is essentially sending a sync IPC message, which should
+      // not exceed more than a few ms.
+      //
+      // This is for testing #18638.
+      expect(now - before).to.be.below(100)
+    })
   })
 
   describe('nodeintegration attribute', () => {


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/18990.

Notes: Fix setting src on `<webview>` being too slow.