### PR TITLE
doc: correct Windows value for DesktopCapturerSource's id

### DIFF
--- a/docs/api/structures/desktop-capturer-source.md
+++ b/docs/api/structures/desktop-capturer-source.md
@@ -4,6 +4,7 @@
   `chromeMediaSourceId` constraint when calling
   [`navigator.webkitGetUserMedia`]. The format of the identifier will be
   `window:XX` or `screen:XX`, where `XX` is a random generated number.
+  In Windows, `XX` of `window:XX` is a windows handle to the window.
 * `name` String - A screen source will be named either `Entire Screen` or
   `Screen <index>`, while the name of a window source will match the window
   title.


### PR DESCRIPTION
#### Description of Change
I updated Markdown Documentation about DesktopCapturerSource. DesktopCapturerSource's Id is not just a random generated number, it is a handle number to the window.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Add accurate info of DesktopCapturerSource's Id
Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->

You can test it with [`EnumWindows` API](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enumwindows).
[Here is the source code in C# which can show current visible windows](https://github.com/skatpgusskat/overview/issues/3#issuecomment-509158945)

![image](https://user-images.githubusercontent.com/3580430/60960481-0ac0f700-a345-11e9-8df4-08ac0ee936ed.png)


In addition, the id is not just `window:XX`, but it is `window:XX:YY`. I have no idea about YY yet.