### PR TITLE
fix: don't package resources/inspector in dist.zip

### DIFF
--- a/build/zip.py
+++ b/build/zip.py
@@ -17,6 +17,9 @@ PATHS_TO_SKIP = [
   # //chrome/browser/resources/ssl/ssl_error_assistant, but we don't need to
   # ship it.
   'pyproto',
+
+  # https://github.com/electron/electron/issues/19075
+  'resources/inspector',
 ]
 
 def skip_path(dep, dist_zip, target_cpu):


### PR DESCRIPTION
#### Description of Change
Fixes #19075

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Removed inadvertently included resources/inspector from electron.zip on Windows and Linux.