### PR TITLE
fix: <webview> not working in scriptable popups

### DIFF
--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -147,8 +147,6 @@ WebContentsPreferences::WebContentsPreferences(
 #endif
   SetDefaultBoolIfUndefined(options::kOffscreen, false);
 
-  SetDefaults();
-
   // If this is a <webview> tag, and the embedder is offscreen-rendered, then
   // this WebContents is also offscreen-rendered.
   int guest_instance_id = 0;
@@ -166,7 +164,7 @@ WebContentsPreferences::WebContentsPreferences(
     }
   }
 
-  last_preference_ = preference_.Clone();
+  SetDefaults();
 }
 
 WebContentsPreferences::~WebContentsPreferences() {
@@ -178,6 +176,8 @@ void WebContentsPreferences::SetDefaults() {
   if (IsEnabled(options::kSandbox)) {
     SetBool(options::kNativeWindowOpen, true);
   }
+
+  last_preference_ = preference_.Clone();
 }
 
 bool WebContentsPreferences::SetDefaultBoolIfUndefined(

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -836,6 +836,27 @@ describe('BrowserWindow module', () => {
         })
         w.loadFile(path.join(fixtures, 'api', 'native-window-open-native-addon.html'))
       })
+      it('<webview> works in a scriptable popup', (done) => {
+        const preload = path.join(fixtures, 'api', 'new-window-webview-preload.js')
+
+        w.destroy()
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            nodeIntegrationInSubFrames: true,
+            nativeWindowOpen: true,
+            webviewTag: true,
+            preload
+          }
+        })
+
+        ipcRenderer.send('set-options-on-next-new-window', w.webContents.id, 'show', false)
+
+        ipcMain.once('webview-loaded', () => {
+          done()
+        })
+        w.loadFile(path.join(fixtures, 'api', 'new-window-webview.html'))
+      })
       it('should inherit the nativeWindowOpen setting in opened windows', (done) => {
         w.destroy()
         w = new BrowserWindow({

--- a/spec/fixtures/api/new-window-webview-preload.js
+++ b/spec/fixtures/api/new-window-webview-preload.js
@@ -1,0 +1,3 @@
+const { ipcRenderer } = require('electron')
+
+window.ipcRenderer = ipcRenderer

--- a/spec/fixtures/api/new-window-webview.html
+++ b/spec/fixtures/api/new-window-webview.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title></title>
+  </head>
+  <body>
+    <script type="text/javascript">
+      const code = `
+var webview = document.createElement('webview')
+webview.src = 'about:blank'
+webview.addEventListener('did-finish-load', () => {
+  ipcRenderer.send('webview-loaded')
+}, {once: true})
+document.body.appendChild(webview)
+`
+      open('about:blank').eval(code)
+    </script>
+  </body>
+</html>

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -231,6 +231,12 @@ ipcMain.on('prevent-next-new-window', (event, id) => {
   webContents.fromId(id).once('new-window', event => event.preventDefault())
 })
 
+ipcMain.on('set-options-on-next-new-window', (event, id, key, value) => {
+  webContents.fromId(id).once('new-window', (event, url, frameName, disposition, options) => {
+    options[key] = value
+  })
+})
+
 ipcMain.on('set-web-preferences-on-next-new-window', (event, id, key, value) => {
   webContents.fromId(id).once('new-window', (event, url, frameName, disposition, options) => {
     options.webPreferences[key] = value


### PR DESCRIPTION
#### Description of Change
In this PR #15859 I've added a check to prevent `<webview>` related IPCs from being handled when `webviewTag` is not enabled for the given sender to increase security. It relies on `getLastWebPreferences()`:
https://github.com/electron/electron/blob/692df804cf8201158e164903bba429a7274509bf/lib/browser/guest-view-manager.js#L319-L326

When a scriptable popup is created, Chromium creates the `webContents` and Electron migrates the `webPreferences`
https://github.com/electron/electron/blob/692df804cf8201158e164903bba429a7274509bf/shell/browser/api/atom_api_browser_window.cc#L51-L66

The `webPreferences` are cloned to be returned by `getLastWebPreferences()` in the constructor of `WebContentsPreferences`. However `Clear` and `Merge` are called afterwards.
https://github.com/electron/electron/blob/692df804cf8201158e164903bba429a7274509bf/shell/browser/web_contents_preferences.cc#L169

In case of cross-origin popup a new renderer process is created and the `webPreferences` are turned into command-line switches in `WebContentsPreferences::AppendCommandLineSwitches()`, which also clones them again (after the `Merge`).
https://github.com/electron/electron/blob/692df804cf8201158e164903bba429a7274509bf/shell/browser/web_contents_preferences.cc#L418-L421

The problem is that in case of scriptable popup, the existing renderer process is reused. Therefore `WebContentsPreferences::AppendCommandLineSwitches()` is not called and the `webPreferences` are not cloned after the merge. Which means that `getLastWebPreferences()` returns incorrect values (with `webviewTag` disabled).

This PR fixes the `<webview>` issue by making sure that `getLastWebPreferences()` returns correct values by cloning the `webPreferences` after the merge.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed `<webview>` not working in scriptable popups when `nativeWindowOpen` is enabled.