### PR TITLE
chore: deprecate `Tray.setHighlightMode`

### DIFF
--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -152,6 +152,17 @@ app.enableMixedSandbox()
 
 Mixed-sandbox mode is now enabled by default.
 
+### `Tray`
+
+Under macOS Catalina our former Tray implementation breaks.
+Apple's native substitute doesn't support changing the highlighting behavior.
+
+```js
+// Deprecated
+tray.setHighlightMode(mode)
+// API will be removed in v7.0 without replacement.
+```
+
 ## Planned Breaking API Changes (5.0)
 
 ### `new BrowserWindow({ webPreferences })`

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -216,6 +216,8 @@ Returns `String` - the title displayed next to the tray icon in the status bar
 
 Sets when the tray's icon background becomes highlighted (in blue).
 
+**[Deprecated](breaking-changes.md#tray)**
+
 **Note:** You can use `highlightMode` with a [`BrowserWindow`](browser-window.md)
 by toggling between `'never'` and `'always'` modes when the window visibility
 changes.

--- a/lib/browser/api/tray.js
+++ b/lib/browser/api/tray.js
@@ -1,8 +1,12 @@
 'use strict'
 
 const { EventEmitter } = require('events')
+const { deprecate } = require('electron')
 const { Tray } = process.electronBinding('tray')
 
 Object.setPrototypeOf(Tray.prototype, EventEmitter.prototype)
+
+// Deprecations
+Tray.prototype.setHighlightMode = deprecate.removeFunction(Tray.prototype.setHighlightMode, 'setHighlightMode')
 
 module.exports = Tray


### PR DESCRIPTION
#### Description of Change
According to [this verdict](https://github.com/electron/governance/blob/master/wg-releases/meeting-notes/2019-06-26.md#agenda) we deprecate `Tray.setHighlightMode` in v6 and remove it in v7. This is necessary bc v7 will ship with a new Tray implementation on macOS which doesn't support changing the highlighting behavior anymore (see #18981 for details).

cc @codebytere @miniak 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Deprecated `Tray.setHighlightMode` (will be removed in v7 without replacement).
