### PR TITLE
docs: specify possible values for ProcessMetric.type

### DIFF
--- a/docs/api/structures/process-metric.md
+++ b/docs/api/structures/process-metric.md
@@ -1,7 +1,16 @@
 # ProcessMetric Object
 
 * `pid` Integer - Process id of the process.
-* `type` String - Process type (Browser or Tab or GPU etc).
+* `type` String - Process type. One of the following values:
+  * `Browser`
+  * `Tab`
+  * `Utility`
+  * `Zygote`
+  * `Sandbox helper`
+  * `GPU`
+  * `Pepper Plugin`
+  * `Pepper Plugin Broker`
+  * `Unknown`
 * `cpu` [CPUUsage](cpu-usage.md) - CPU usage of the process.
 * `creationTime` Number - Creation time for this process.
     The time is represented as number of milliseconds since epoch.


### PR DESCRIPTION
#### Description of Change
The list of values is taken from [GetProcessTypeNameInEnglish](https://cs.chromium.org/chromium/src/content/common/process_type.cc?type=cs&q=GetProcessTypeNameInEnglish&sq=package:chromium&g=0&l=12-33)
```diff
--- a/electron.old.d.ts
+++ b/electron.new.d.ts
@@ -5106,9 +5106,9 @@ Calculate system idle time in seconds.
      */
     sandboxed?: boolean;
     /**
-     * Process type (Browser or Tab or GPU etc).
+     * Process type. One of the following values:
      */
-    type: string;
+    type: ('Browser' | 'Tab' | 'Utility' | 'Zygote' | 'Sandbox helper' | 'GPU' | 'Pepper Plugin' | 'Pepper Plugin Broker' | 'Unknown');
   }
```

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added possible values for `ProcessMetric.type` to `electron.d.ts`