### PR TITLE
fix: <webview> not working in scriptable popups

### DIFF
--- a/atom/browser/web_contents_preferences.cc
+++ b/atom/browser/web_contents_preferences.cc
@@ -146,8 +146,6 @@ WebContentsPreferences::WebContentsPreferences(
   SetDefaultBoolIfUndefined(options::kOffscreen, false);
 
   SetDefaults();
-
-  last_preference_ = preference_.Clone();
 }
 
 WebContentsPreferences::~WebContentsPreferences() {
@@ -159,6 +157,8 @@ void WebContentsPreferences::SetDefaults() {
   if (IsEnabled(options::kSandbox)) {
     SetBool(options::kNativeWindowOpen, true);
   }
+
+  last_preference_ = preference_.Clone();
 }
 
 bool WebContentsPreferences::SetDefaultBoolIfUndefined(

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -2034,6 +2034,27 @@ describe('BrowserWindow module', () => {
         })
         w.loadFile(path.join(fixtures, 'api', 'native-window-open-native-addon.html'))
       })
+      it('<webview> works in a scriptable popup', (done) => {
+        const preload = path.join(fixtures, 'api', 'new-window-webview-preload.js')
+
+        w.destroy()
+        w = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            nodeIntegrationInSubFrames: true,
+            nativeWindowOpen: true,
+            webviewTag: true,
+            preload
+          }
+        })
+
+        ipcRenderer.send('set-options-on-next-new-window', w.webContents.id, 'show', false)
+
+        ipcMain.once('webview-loaded', () => {
+          done()
+        })
+        w.loadFile(path.join(fixtures, 'api', 'new-window-webview.html'))
+      })
       it('should inherit the nativeWindowOpen setting in opened windows', (done) => {
         w.destroy()
         w = new BrowserWindow({

--- a/spec/fixtures/api/new-window-webview-preload.js
+++ b/spec/fixtures/api/new-window-webview-preload.js
@@ -1,0 +1,3 @@
+const { ipcRenderer } = require('electron')
+
+window.ipcRenderer = ipcRenderer

--- a/spec/fixtures/api/new-window-webview.html
+++ b/spec/fixtures/api/new-window-webview.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title></title>
+  </head>
+  <body>
+    <script type="text/javascript">
+      const code = `
+var webview = document.createElement('webview')
+webview.src = 'about:blank'
+webview.addEventListener('did-finish-load', () => {
+  ipcRenderer.send('webview-loaded')
+}, {once: true})
+document.body.appendChild(webview)
+`
+      open('about:blank').eval(code)
+    </script>
+  </body>
+</html>

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -340,6 +340,12 @@ ipcMain.on('prevent-next-new-window', (event, id) => {
   webContents.fromId(id).once('new-window', event => event.preventDefault())
 })
 
+ipcMain.on('set-options-on-next-new-window', (event, id, key, value) => {
+  webContents.fromId(id).once('new-window', (event, url, frameName, disposition, options) => {
+    options[key] = value
+  })
+})
+
 ipcMain.on('set-web-preferences-on-next-new-window', (event, id, key, value) => {
   webContents.fromId(id).once('new-window', (event, url, frameName, disposition, options) => {
     options.webPreferences[key] = value


### PR DESCRIPTION
#### Description of Change
Backport of #19198

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed `<webview>` not working in scriptable popups when `nativeWindowOpen` is enabled.