### PR TITLE
chore: deprecate `Tray.setHighlightMode`

### DIFF
--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -94,6 +94,17 @@ powerMonitor.querySystemIdleTime(callback)
 const idleTime = getSystemIdleTime()
 ```
 
+## `Tray`
+
+Under macOS Catalina our former Tray implementation breaks.
+Apple's native substitute doesn't support changing the highlighting behavior.
+
+```js
+// Deprecated
+tray.setHighlightMode(mode)
+// API will be removed in v7.0 without replacement.
+```
+
 # Planned Breaking API Changes (5.0)
 
 ## `new BrowserWindow({ webPreferences })`

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -202,6 +202,8 @@ Returns `String` - the title displayed next to the tray icon in the status bar
 
 Sets when the tray's icon background becomes highlighted (in blue).
 
+**[Deprecated](breaking-changes.md#tray)**
+
 **Note:** You can use `highlightMode` with a [`BrowserWindow`](browser-window.md)
 by toggling between `'never'` and `'always'` modes when the window visibility
 changes.

--- a/lib/browser/api/tray.js
+++ b/lib/browser/api/tray.js
@@ -1,8 +1,12 @@
 'use strict'
 
 const { EventEmitter } = require('events')
+const { deprecate } = require('electron')
 const { Tray } = process.electronBinding('tray')
 
 Object.setPrototypeOf(Tray.prototype, EventEmitter.prototype)
+
+// Deprecations
+Tray.prototype.setHighlightMode = deprecate.removeFunction(Tray.prototype.setHighlightMode, 'setHighlightMode')
 
 module.exports = Tray


### PR DESCRIPTION
Backport of #19202

See that PR for details.

Notes: none