### PR TITLE
chore: revert key -> main change in window delegate listener

### DIFF
--- a/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -88,11 +88,11 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
   return frame;
 }
 
-- (void)windowDidBecomeKey:(NSNotification*)notification {
+- (void)windowDidBecomeMain:(NSNotification*)notification {
   shell_->NotifyWindowFocus();
 }
 
-- (void)windowDidResignKey:(NSNotification*)notification {
+- (void)windowDidResignMain:(NSNotification*)notification {
   shell_->NotifyWindowBlur();
 }
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1305,6 +1305,7 @@ describe('BrowserWindow module', () => {
   })
 
   // temporarily removing test due to regression
+  // uncomment when https://github.com/electron/electron/issues/18502 is fixed
 
   // describe('focus event', () => {
   //   it('should not emit if focusing on a main window with a modal open', (done) => {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1304,33 +1304,35 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('focus event', () => {
-    it('should not emit if focusing on a main window with a modal open', (done) => {
-      const childWindowClosed = false
-      const child = new BrowserWindow({
-        parent: w,
-        modal: true,
-        show: false
-      })
+  // temporarily removing test due to regression
 
-      child.once('ready-to-show', () => {
-        child.show()
-      })
+  // describe('focus event', () => {
+  //   it('should not emit if focusing on a main window with a modal open', (done) => {
+  //     const childWindowClosed = false
+  //     const child = new BrowserWindow({
+  //       parent: w,
+  //       modal: true,
+  //       show: false
+  //     })
 
-      child.on('show', () => {
-        w.once('focus', () => {
-          expect(child.isDestroyed()).to.equal(true)
-          done()
-        })
-        w.focus() // this should not trigger the above listener
-        child.close()
-      })
+  //     child.once('ready-to-show', () => {
+  //       child.show()
+  //     })
 
-      // act
-      child.loadURL(server.url)
-      w.show()
-    })
-  })
+  //     child.on('show', () => {
+  //       w.once('focus', () => {
+  //         expect(child.isDestroyed()).to.equal(true)
+  //         done()
+  //       })
+  //       w.focus() // this should not trigger the above listener
+  //       child.close()
+  //     })
+
+  //     // act
+  //     child.loadURL(server.url)
+  //     w.show()
+  //   })
+  // })
 
   describe('sheet-begin event', () => {
     let sheet = null

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1304,37 +1304,6 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  // temporarily removing test due to regression
-  // uncomment when https://github.com/electron/electron/issues/18502 is fixed
-
-  // describe('focus event', () => {
-  //   it('should not emit if focusing on a main window with a modal open', (done) => {
-  //     const childWindowClosed = false
-  //     const child = new BrowserWindow({
-  //       parent: w,
-  //       modal: true,
-  //       show: false
-  //     })
-
-  //     child.once('ready-to-show', () => {
-  //       child.show()
-  //     })
-
-  //     child.on('show', () => {
-  //       w.once('focus', () => {
-  //         expect(child.isDestroyed()).to.equal(true)
-  //         done()
-  //       })
-  //       w.focus() // this should not trigger the above listener
-  //       child.close()
-  //     })
-
-  //     // act
-  //     child.loadURL(server.url)
-  //     w.show()
-  //   })
-  // })
-
   describe('sheet-begin event', () => {
     let sheet = null
 


### PR DESCRIPTION
#### Description of Change
Fixes #19124 

Reverts #18995, which caused a regression (#19124). According to our discussion in https://github.com/electron/electron/pull/19128#issuecomment-509439237, it would be best to revert the fix for now, especially since this regression has already been backported into 4.2.X, 5.0.X, and 6.0.X.

For now, the test that I wrote in #18995 has also been commented out.

cc @codebytere @zcbenz @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Reverted change to focus behavior that broke Character Viewer support on macOS.
