### PR TITLE
feat: allow setting capture mode and max file size in netLog API

### DIFF
--- a/docs/api/net-log.md
+++ b/docs/api/net-log.md
@@ -28,9 +28,9 @@ of the `app` module gets emitted.
 * `options` Object (optional)
   * `captureMode` String (optional) - What kinds of data should be captured. By
     default, only metadata about requests will be captured. Setting this to
-    `includePrivacyInfo` will include cookies and authentication data. Setting
+    `includeSensitive` will include cookies and authentication data. Setting
     it to `everything` will include all bytes transferred on sockets. Can be
-    `default`, `includePrivacyInfo` or `everything`.
+    `default`, `includeSensitive` or `everything`.
   * `maxFileSize` Number (optional) - When the log grows beyond this size,
     logging will automatically stop. Defaults to unlimited.
 

--- a/docs/api/net-log.md
+++ b/docs/api/net-log.md
@@ -30,7 +30,7 @@ of the `app` module gets emitted.
     default, only metadata about requests will be captured. Setting this to
     `includePrivacyInfo` will include cookies and authentication data. Setting
     it to `everything` will include all bytes transferred on sockets. Can be
-    `default`, `includePrivacyInfo`, or `everything`.
+    `default`, `includePrivacyInfo` or `everything`.
   * `maxFileSize` Number (optional) - When the log grows beyond this size,
     logging will automatically stop. Defaults to unlimited.
 

--- a/docs/api/net-log.md
+++ b/docs/api/net-log.md
@@ -22,9 +22,17 @@ of the `app` module gets emitted.
 
 ## Methods
 
-### `netLog.startLogging(path)`
+### `netLog.startLogging(path[, options])`
 
 * `path` String - File path to record network logs.
+* `options` Object
+  * `captureMode` String (optional) - What kinds of data should be captured. By
+    default, only metadata about requests will be captured. Setting this to
+    `includePrivacyInfo` will include cookies and authentication data. Setting
+    it to `everything` will include all bytes transferred on sockets. Can be
+    `default`, `includePrivacyInfo`, or `everything`.
+  * `maxFileSize` Number (optional) - When the log grows beyond this size,
+    logging will automatically stop. Defaults to unlimited.
 
 Returns `Promise<void>` - resolves when the net log has begun recording.
 

--- a/docs/api/net-log.md
+++ b/docs/api/net-log.md
@@ -25,7 +25,7 @@ of the `app` module gets emitted.
 ### `netLog.startLogging(path[, options])`
 
 * `path` String - File path to record network logs.
-* `options` Object
+* `options` Object (optional)
   * `captureMode` String (optional) - What kinds of data should be captured. By
     default, only metadata about requests will be captured. Setting this to
     `includePrivacyInfo` will include cookies and authentication data. Setting

--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -24,10 +24,10 @@ Session.prototype._init = function () {
 }
 
 const _originalStartLogging = NetLog.prototype.startLogging
-NetLog.prototype.startLogging = function (path) {
+NetLog.prototype.startLogging = function (path, ...args) {
   this._currentlyLoggingPath = path
   try {
-    return _originalStartLogging.call(this, path)
+    return _originalStartLogging.call(this, path, ...args)
   } catch (e) {
     this._currentlyLoggingPath = null
     throw e

--- a/shell/browser/api/atom_api_net_log.cc
+++ b/shell/browser/api/atom_api_net_log.cc
@@ -92,7 +92,7 @@ v8::Local<v8::Promise> NetLog::StartLogging(base::FilePath log_path,
     return v8::Local<v8::Promise>();
   }
 
-  net::NetLogCaptureMode capture_mode = net::NetLogCaptureMode::Default();
+  net::NetLogCaptureMode capture_mode = net::NetLogCaptureMode::kDefault;
   uint64_t max_file_size = network::mojom::NetLogExporter::kUnlimitedFileSize;
 
   mate::Dictionary dict;

--- a/shell/browser/api/atom_api_net_log.cc
+++ b/shell/browser/api/atom_api_net_log.cc
@@ -11,6 +11,7 @@
 #include "components/net_log/chrome_net_log.h"
 #include "content/public/browser/storage_partition.h"
 #include "electron/electron_version.h"
+#include "native_mate/converter.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/handle.h"
 #include "net/url_request/url_request_context_getter.h"
@@ -19,6 +20,30 @@
 #include "shell/common/native_mate_converters/callback.h"
 #include "shell/common/native_mate_converters/file_path_converter.h"
 #include "shell/common/node_includes.h"
+
+namespace mate {
+
+template <>
+struct Converter<net::NetLogCaptureMode> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     net::NetLogCaptureMode* out) {
+    std::string type;
+    if (!ConvertFromV8(isolate, val, &type))
+      return false;
+    if (type == "default")
+      *out = net::NetLogCaptureMode::Default();
+    else if (type == "includePrivacyInfo")
+      *out = net::NetLogCaptureMode::IncludeCookiesAndCredentials();
+    else if (type == "everything")
+      *out = net::NetLogCaptureMode::IncludeSocketBytes();
+    else
+      return false;
+    return true;
+  }
+};
+
+}  // namespace mate
 
 namespace electron {
 
@@ -60,11 +85,34 @@ NetLog::NetLog(v8::Isolate* isolate, AtomBrowserContext* browser_context)
 
 NetLog::~NetLog() = default;
 
-v8::Local<v8::Promise> NetLog::StartLogging(mate::Arguments* args) {
-  base::FilePath log_path;
-  if (!args->GetNext(&log_path) || log_path.empty()) {
+v8::Local<v8::Promise> NetLog::StartLogging(base::FilePath log_path,
+                                            mate::Arguments* args) {
+  if (log_path.empty()) {
     args->ThrowError("The first parameter must be a valid string");
     return v8::Local<v8::Promise>();
+  }
+
+  net::NetLogCaptureMode capture_mode = net::NetLogCaptureMode::Default();
+  uint64_t max_file_size = network::mojom::NetLogExporter::kUnlimitedFileSize;
+
+  mate::Dictionary dict;
+  if (args->GetNext(&dict)) {
+    v8::Local<v8::Value> capture_mode_v8;
+    if (dict.Get("captureMode", &capture_mode_v8)) {
+      if (!mate::ConvertFromV8(args->isolate(), capture_mode_v8,
+                               &capture_mode)) {
+        args->ThrowError("Invalid value for captureMode");
+        return v8::Local<v8::Promise>();
+      }
+    }
+    v8::Local<v8::Value> max_file_size_v8;
+    if (dict.Get("maxFileSize", &max_file_size_v8)) {
+      if (!mate::ConvertFromV8(args->isolate(), max_file_size_v8,
+                               &max_file_size)) {
+        args->ThrowError("Invalid value for maxFileSize");
+        return v8::Local<v8::Promise>();
+      }
+    }
   }
 
   if (net_log_exporter_) {
@@ -89,11 +137,6 @@ v8::Local<v8::Promise> NetLog::StartLogging(mate::Arguments* args) {
   network_context->CreateNetLogExporter(mojo::MakeRequest(&net_log_exporter_));
   net_log_exporter_.set_connection_error_handler(
       base::BindOnce(&NetLog::OnConnectionError, base::Unretained(this)));
-
-  // TODO(deepak1556): Provide more flexibility to this module
-  // by allowing customizations on the capturing options.
-  auto capture_mode = net::NetLogCaptureMode::kDefault;
-  auto max_file_size = network::mojom::NetLogExporter::kUnlimitedFileSize;
 
   base::PostTaskAndReplyWithResult(
       file_task_runner_.get(), FROM_HERE,

--- a/shell/browser/api/atom_api_net_log.cc
+++ b/shell/browser/api/atom_api_net_log.cc
@@ -32,11 +32,11 @@ struct Converter<net::NetLogCaptureMode> {
     if (!ConvertFromV8(isolate, val, &type))
       return false;
     if (type == "default")
-      *out = net::NetLogCaptureMode::Default();
-    else if (type == "includePrivacyInfo")
-      *out = net::NetLogCaptureMode::IncludeCookiesAndCredentials();
+      *out = net::NetLogCaptureMode::kDefault;
+    else if (type == "includeSensitive")
+      *out = net::NetLogCaptureMode::kIncludeSensitive;
     else if (type == "everything")
-      *out = net::NetLogCaptureMode::IncludeSocketBytes();
+      *out = net::NetLogCaptureMode::kEverything;
     else
       return false;
     return true;

--- a/shell/browser/api/atom_api_net_log.h
+++ b/shell/browser/api/atom_api_net_log.h
@@ -31,7 +31,8 @@ class NetLog : public mate::TrackableObject<NetLog> {
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype);
 
-  v8::Local<v8::Promise> StartLogging(mate::Arguments* args);
+  v8::Local<v8::Promise> StartLogging(base::FilePath log_path,
+                                      mate::Arguments* args);
   v8::Local<v8::Promise> StopLogging(mate::Arguments* args);
   bool IsCurrentlyLogging() const;
 

--- a/spec-main/api-net-log-spec.js
+++ b/spec-main/api-net-log-spec.js
@@ -88,7 +88,7 @@ describe('netLog module', () => {
   })
 
   it('should include cookies when requested', async () => {
-    await testNetLog().startLogging(dumpFileDynamic, {captureMode: "includePrivacyInfo"})
+    await testNetLog().startLogging(dumpFileDynamic, {captureMode: "includeSensitive"})
     const unique = require('uuid').v4()
     await new Promise((resolve) => {
       const req = net.request(server.url)

--- a/spec-main/api-net-log-spec.js
+++ b/spec-main/api-net-log-spec.js
@@ -5,7 +5,7 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 const ChildProcess = require('child_process')
-const {session} = require('electron')
+const {session, net} = require('electron')
 const appPath = path.join(__dirname, 'fixtures', 'api', 'net-log')
 const dumpFile = path.join(os.tmpdir(), 'net_log.json')
 const dumpFileDynamic = path.join(os.tmpdir(), 'net_log_dynamic.json')
@@ -83,6 +83,43 @@ describe('netLog module', () => {
     expect(() => testNetLog().startLogging('')).to.throw()
     expect(() => testNetLog().startLogging(null)).to.throw()
     expect(() => testNetLog().startLogging([])).to.throw()
+    expect(() => testNetLog().startLogging('aoeu', {captureMode: 'aoeu'})).to.throw()
+    expect(() => testNetLog().startLogging('aoeu', {maxFileSize: null})).to.throw()
+  })
+
+  it('should include cookies when requested', async () => {
+    await testNetLog().startLogging(dumpFileDynamic, {captureMode: "includePrivacyInfo"})
+    const unique = require('uuid').v4()
+    await new Promise((resolve) => {
+      const req = net.request(server.url)
+      req.setHeader('Cookie', `foo=${unique}`)
+      req.on('response', (response) => {
+        response.on('data', () => {})  // https://github.com/electron/electron/issues/19214
+        response.on('end', () => resolve())
+      })
+      req.end()
+    })
+    await testNetLog().stopLogging()
+    expect(fs.existsSync(dumpFileDynamic)).to.be.true('dump file exists')
+    const dump = fs.readFileSync(dumpFileDynamic, 'utf8')
+    expect(dump).to.contain(`foo=${unique}`)
+  })
+
+  it('should include socket bytes when requested', async () => {
+    await testNetLog().startLogging(dumpFileDynamic, {captureMode: "everything"})
+    const unique = require('uuid').v4()
+    await new Promise((resolve) => {
+      const req = net.request({method: 'POST', url: server.url})
+      req.on('response', (response) => {
+        response.on('data', () => {})  // https://github.com/electron/electron/issues/19214
+        response.on('end', () => resolve())
+      })
+      req.end(Buffer.from(unique))
+    })
+    await testNetLog().stopLogging()
+    expect(fs.existsSync(dumpFileDynamic)).to.be.true('dump file exists')
+    const dump = fs.readFileSync(dumpFileDynamic, 'utf8')
+    expect(JSON.parse(dump).events.some(x => x.params && x.params.bytes && Buffer.from(x.params.bytes, 'base64').includes(unique))).to.be.true('uuid present in dump')
   })
 
   it('should begin and end logging automatically when --log-net-log is passed', done => {


### PR DESCRIPTION
#### Description of Change
Adds two new options to `netLog.startLogging`: `maxFileSize` and `captureMode`.

NB. the names of the capture modes changed recently: https://chromium-review.googlesource.com/c/chromium/src/+/1685684. This PR uses the new names, and depends on that PR to fix the decoding of the "EVERYTHING" capture mode, which until that PR was decoded on the receiving mojo end as if it were the "INCLUDE_PRIVACY_INFO" capture mode.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `captureMode` and `maxFileSize` options to the netLog API.