### PR TITLE
fix: exit non-silently when running as root on Linux

### DIFF
--- a/shell/app/atom_main_delegate.cc
+++ b/shell/app/atom_main_delegate.cc
@@ -201,6 +201,14 @@ bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
     base::win::PinUser32();
 #endif
 
+#if defined(OS_LINUX)
+  // Check for --no-sandbox parameter when running as root.
+  if (getuid() == 0 && IsSandboxEnabled(command_line))
+    LOG(FATAL) << "Running as root without --"
+               << service_manager::switches::kNoSandbox
+               << " is not supported. See https://crbug.com/638180.";
+#endif
+
   content_client_ = std::make_unique<AtomContentClient>();
   SetContentClient(content_client_.get());
 


### PR DESCRIPTION
#### Description of Change
Closes #18547. Follow-up to #18903.

In short, this PR adds an error message on Linux when running as root user without `--no-sandbox` flag. This flag is necessary as described in [a Chromium issue](https://crbug.com/638180). Previously, Electron just failed silently and only warned root users if logging has explicitly been enabled. 

cc @erickzhao @codebytere  

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: none