### PR TITLE
feat: support `systemPreferences.isDarkMode()` on Windows

### DIFF
--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -43,7 +43,7 @@ Returns:
 
 ## Methods
 
-### `systemPreferences.isDarkMode()` _macOS_
+### `systemPreferences.isDarkMode()` _macOS_ _Windows_
 
 Returns `Boolean` - Whether the system is in Dark Mode.
 

--- a/shell/browser/api/atom_api_system_preferences.cc
+++ b/shell/browser/api/atom_api_system_preferences.cc
@@ -10,6 +10,7 @@
 #include "shell/common/node_includes.h"
 #include "ui/gfx/animation/animation.h"
 #include "ui/gfx/color_utils.h"
+#include "ui/native_theme/native_theme.h"
 
 namespace electron {
 
@@ -28,9 +29,9 @@ SystemPreferences::~SystemPreferences() {
 #endif
 }
 
-#if defined(OS_LINUX)
+#if !defined(OS_MACOSX)
 bool SystemPreferences::IsDarkMode() {
-  return false;
+  return ui::NativeTheme::GetInstanceForNativeUi()->SystemDarkModeEnabled();
 }
 #endif
 

--- a/shell/browser/api/atom_api_system_preferences.cc
+++ b/shell/browser/api/atom_api_system_preferences.cc
@@ -28,7 +28,7 @@ SystemPreferences::~SystemPreferences() {
 #endif
 }
 
-#if !defined(OS_MACOSX)
+#if defined(OS_LINUX)
 bool SystemPreferences::IsDarkMode() {
   return false;
 }

--- a/shell/browser/api/atom_api_system_preferences_win.cc
+++ b/shell/browser/api/atom_api_system_preferences_win.cc
@@ -7,7 +7,6 @@
 
 #include "shell/browser/api/atom_api_system_preferences.h"
 
-#include "base/win/registry.h"
 #include "base/win/wrapped_window_proc.h"
 #include "shell/common/color_util.h"
 #include "ui/base/win/shell.h"
@@ -45,15 +44,6 @@ bool SystemPreferences::IsHighContrastColorScheme() {
   if (!g_is_high_contract_color_scheme_initialized)
     UpdateHighContrastColorScheme();
   return g_is_high_contract_color_scheme;
-}
-
-bool SystemPreferences::IsDarkMode() {
-  base::string16 keyPath =
-      L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
-  base::win::RegKey key(HKEY_CURRENT_USER, keyPath.c_str(), KEY_ALL_ACCESS);
-  DWORD value = 1;  // defaults to light theme if registry entry does not exist
-  key.ReadValueDW(L"AppsUseLightTheme", &value);
-  return (value == 0);
 }
 
 std::string hexColorDWORDToRGBA(DWORD color) {

--- a/shell/browser/api/atom_api_system_preferences_win.cc
+++ b/shell/browser/api/atom_api_system_preferences_win.cc
@@ -7,6 +7,7 @@
 
 #include "shell/browser/api/atom_api_system_preferences.h"
 
+#include "base/win/registry.h"
 #include "base/win/wrapped_window_proc.h"
 #include "shell/common/color_util.h"
 #include "ui/base/win/shell.h"
@@ -44,6 +45,15 @@ bool SystemPreferences::IsHighContrastColorScheme() {
   if (!g_is_high_contract_color_scheme_initialized)
     UpdateHighContrastColorScheme();
   return g_is_high_contract_color_scheme;
+}
+
+bool SystemPreferences::IsDarkMode() {
+  base::string16 keyPath =
+      L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
+  base::win::RegKey key(HKEY_CURRENT_USER, keyPath.c_str(), KEY_ALL_ACCESS);
+  DWORD value = 1;  // defaults to light theme if registry entry does not exist
+  key.ReadValueDW(L"AppsUseLightTheme", &value);
+  return (value == 0);
 }
 
 std::string hexColorDWORDToRGBA(DWORD color) {


### PR DESCRIPTION
#### Description of Change
Closes #18696. Closes #15316. Adds support for the `systemPreferences.isDarkMode()` API on Windows using Chromium's `NativeTheme` API. 

#### Outdated (not-actually-used) approach
Whether the system uses dark or light theme is derived from following registry key: 
```
HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize\AppsUseLightTheme 
  | value 0  == dark
  | value 1+ == light
```

cc @MarshallOfSound @erickzhao @codebytere 

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added support for `systemPreferences.isDarkMode()` API on Windows.