### PR TITLE
test: move contentTracing specs to main process

### DIFF
--- a/spec-main/spec-helpers.ts
+++ b/spec-main/spec-helpers.ts
@@ -1,0 +1,2 @@
+export const ifit = (condition: boolean) => (condition ? it : it.skip)
+export const ifdescribe = (condition: boolean) => (condition ? describe : describe.skip)


### PR DESCRIPTION
#### Description of Change

Moves `contentTracing` specs to main process.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none