### PR TITLE
test: move dialog spec to main process

### DIFF
--- a/spec-main/api-dialog-spec.ts
+++ b/spec-main/api-dialog-spec.ts
@@ -80,7 +80,8 @@ describe('dialog module', () => {
     afterEach(closeAllWindows);
 
     // parentless message boxes are synchronous on macOS
-    ifit(process.platform !== 'darwin')('should not throw for a parentless message box', () => {
+    // dangling message boxes on windows cause a DCHECK: https://cs.chromium.org/chromium/src/base/win/message_window.cc?l=68&rcl=7faa4bf236a866d007dc5672c9ce42660e67a6a6
+    ifit(process.platform !== 'darwin' && process.platform !== 'win32')('should not throw for a parentless message box', () => {
       expect(() => {
         dialog.showMessageBox({ message: 'i am message' })
       }).to.not.throw()

--- a/spec-main/api-dialog-spec.ts
+++ b/spec-main/api-dialog-spec.ts
@@ -1,136 +1,120 @@
-const { expect } = require('chai')
-const { closeWindow } = require('./window-helpers')
-const { remote } = require('electron')
-const { BrowserWindow, dialog } = remote
-const isCI = remote.getGlobal('isCi')
+import { expect } from 'chai'
+import { dialog, BrowserWindow } from 'electron'
+import { closeAllWindows } from './window-helpers';
 
 describe('dialog module', () => {
   describe('showOpenDialog', () => {
+    afterEach(closeAllWindows)
     it('should not throw for valid cases', () => {
-      // Blocks the main process and can't be run in CI
-      if (isCI) return
-
-      let w
-
       expect(() => {
         dialog.showOpenDialog({ title: 'i am title' })
       }).to.not.throw()
 
       expect(() => {
-        w = new BrowserWindow()
+        const w = new BrowserWindow()
         dialog.showOpenDialog(w, { title: 'i am title' })
       }).to.not.throw()
-
-      closeWindow(w).then(() => { w = null })
     })
 
     it('throws errors when the options are invalid', () => {
       expect(() => {
-        dialog.showOpenDialog({ properties: false })
+        dialog.showOpenDialog({ properties: false as any })
       }).to.throw(/Properties must be an array/)
 
       expect(() => {
-        dialog.showOpenDialog({ title: 300 })
+        dialog.showOpenDialog({ title: 300 as any })
       }).to.throw(/Title must be a string/)
 
       expect(() => {
-        dialog.showOpenDialog({ buttonLabel: [] })
+        dialog.showOpenDialog({ buttonLabel: [] as any })
       }).to.throw(/Button label must be a string/)
 
       expect(() => {
-        dialog.showOpenDialog({ defaultPath: {} })
+        dialog.showOpenDialog({ defaultPath: {} as any })
       }).to.throw(/Default path must be a string/)
 
       expect(() => {
-        dialog.showOpenDialog({ message: {} })
+        dialog.showOpenDialog({ message: {} as any })
       }).to.throw(/Message must be a string/)
     })
   })
 
   describe('showSaveDialog', () => {
+    afterEach(closeAllWindows)
     it('should not throw for valid cases', () => {
-      // Blocks the main process and can't be run in CI
-      if (isCI) return
-
-      let w
-
       expect(() => {
         dialog.showSaveDialog({ title: 'i am title' })
       }).to.not.throw()
 
       expect(() => {
-        w = new BrowserWindow()
+        const w = new BrowserWindow()
         dialog.showSaveDialog(w, { title: 'i am title' })
       }).to.not.throw()
-
-      closeWindow(w).then(() => { w = null })
     })
 
     it('throws errors when the options are invalid', () => {
       expect(() => {
-        dialog.showSaveDialog({ title: 300 })
+        dialog.showSaveDialog({ title: 300 as any })
       }).to.throw(/Title must be a string/)
 
       expect(() => {
-        dialog.showSaveDialog({ buttonLabel: [] })
+        dialog.showSaveDialog({ buttonLabel: [] as any })
       }).to.throw(/Button label must be a string/)
 
       expect(() => {
-        dialog.showSaveDialog({ defaultPath: {} })
+        dialog.showSaveDialog({ defaultPath: {} as any })
       }).to.throw(/Default path must be a string/)
 
       expect(() => {
-        dialog.showSaveDialog({ message: {} })
+        dialog.showSaveDialog({ message: {} as any })
       }).to.throw(/Message must be a string/)
 
       expect(() => {
-        dialog.showSaveDialog({ nameFieldLabel: {} })
+        dialog.showSaveDialog({ nameFieldLabel: {} as any })
       }).to.throw(/Name field label must be a string/)
     })
   })
 
   describe('showMessageBox', () => {
+    afterEach(closeAllWindows);
+
+    // parentless message boxes are synchronous on macOS
+    (process.platform === 'darwin' ? it.skip : it)('should not throw for a parentless message box', () => {
+      expect(() => {
+        dialog.showMessageBox({ message: 'i am message' })
+      }).to.not.throw()
+    })
+
     it('should not throw for valid cases', () => {
-      // Blocks the main process and can't be run in CI
-      if (isCI) return
-
-      let w
-
       expect(() => {
-        dialog.showMessageBox({ title: 'i am title' })
+        const w = new BrowserWindow()
+        dialog.showMessageBox(w, { message: 'i am message' })
       }).to.not.throw()
-
-      expect(() => {
-        w = new BrowserWindow()
-        dialog.showMessageBox(w, { title: 'i am title' })
-      }).to.not.throw()
-
-      closeWindow(w).then(() => { w = null })
     })
 
     it('throws errors when the options are invalid', () => {
       expect(() => {
-        dialog.showMessageBox(undefined, { type: 'not-a-valid-type' })
+        dialog.showMessageBox(undefined as any, { type: 'not-a-valid-type', message: '' })
       }).to.throw(/Invalid message box type/)
 
       expect(() => {
-        dialog.showMessageBox(null, { buttons: false })
+        dialog.showMessageBox(null as any, { buttons: false as any, message: '' })
       }).to.throw(/Buttons must be an array/)
 
       expect(() => {
-        dialog.showMessageBox({ title: 300 })
+        dialog.showMessageBox({ title: 300 as any, message: '' })
       }).to.throw(/Title must be a string/)
 
       expect(() => {
-        dialog.showMessageBox({ message: [] })
+        dialog.showMessageBox({ message: [] as any })
       }).to.throw(/Message must be a string/)
 
       expect(() => {
-        dialog.showMessageBox({ detail: 3.14 })
+        dialog.showMessageBox({ detail: 3.14 as any, message: '' })
       }).to.throw(/Detail must be a string/)
 
       expect(() => {
-        dialog.showMessageBox({ checkboxLabel: false })
+        dialog.showMessageBox({ checkboxLabel: false as any, message: '' })
       }).to.throw(/checkboxLabel must be a string/)
     })
   })
@@ -138,15 +122,15 @@ describe('dialog module', () => {
   describe('showErrorBox', () => {
     it('throws errors when the options are invalid', () => {
       expect(() => {
-        dialog.showErrorBox()
+        (dialog.showErrorBox as any)()
       }).to.throw(/Insufficient number of arguments/)
 
       expect(() => {
-        dialog.showErrorBox(3, 'four')
+        dialog.showErrorBox(3 as any, 'four')
       }).to.throw(/Error processing argument at index 0/)
 
       expect(() => {
-        dialog.showErrorBox('three', 4)
+        dialog.showErrorBox('three', 4 as any)
       }).to.throw(/Error processing argument at index 1/)
     })
   })
@@ -154,15 +138,15 @@ describe('dialog module', () => {
   describe('showCertificateTrustDialog', () => {
     it('throws errors when the options are invalid', () => {
       expect(() => {
-        dialog.showCertificateTrustDialog()
+        (dialog.showCertificateTrustDialog as any)()
       }).to.throw(/options must be an object/)
 
       expect(() => {
-        dialog.showCertificateTrustDialog({})
+        dialog.showCertificateTrustDialog({} as any)
       }).to.throw(/certificate must be an object/)
 
       expect(() => {
-        dialog.showCertificateTrustDialog({ certificate: {}, message: false })
+        dialog.showCertificateTrustDialog({ certificate: {} as any, message: false as any })
       }).to.throw(/message must be a string/)
     })
   })

--- a/spec-main/api-dialog-spec.ts
+++ b/spec-main/api-dialog-spec.ts
@@ -1,11 +1,12 @@
 import { expect } from 'chai'
 import { dialog, BrowserWindow } from 'electron'
-import { closeAllWindows } from './window-helpers';
+import { closeAllWindows } from './window-helpers'
+import { ifit } from './spec-helpers'
 
 describe('dialog module', () => {
   describe('showOpenDialog', () => {
     afterEach(closeAllWindows)
-    it('should not throw for valid cases', () => {
+    ifit(process.platform !== 'win32')('should not throw for valid cases', () => {
       expect(() => {
         dialog.showOpenDialog({ title: 'i am title' })
       }).to.not.throw()
@@ -41,7 +42,7 @@ describe('dialog module', () => {
 
   describe('showSaveDialog', () => {
     afterEach(closeAllWindows)
-    it('should not throw for valid cases', () => {
+    ifit(process.platform !== 'win32')('should not throw for valid cases', () => {
       expect(() => {
         dialog.showSaveDialog({ title: 'i am title' })
       }).to.not.throw()
@@ -79,13 +80,13 @@ describe('dialog module', () => {
     afterEach(closeAllWindows);
 
     // parentless message boxes are synchronous on macOS
-    (process.platform === 'darwin' ? it.skip : it)('should not throw for a parentless message box', () => {
+    ifit(process.platform !== 'darwin')('should not throw for a parentless message box', () => {
       expect(() => {
         dialog.showMessageBox({ message: 'i am message' })
       }).to.not.throw()
     })
 
-    it('should not throw for valid cases', () => {
+    ifit(process.platform !== 'win32')('should not throw for valid cases', () => {
       expect(() => {
         const w = new BrowserWindow()
         dialog.showMessageBox(w, { message: 'i am message' })


### PR DESCRIPTION
#### Description of Change
Moves the dialog spec to the main process. Also re-enable the tests that actually create dialogs, as they're no longer synchronous.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none