### PR TITLE
test: move inAppPurchase spec

### DIFF
--- a/spec-main/api-in-app-purchase-spec.ts
+++ b/spec-main/api-in-app-purchase-spec.ts
@@ -1,19 +1,10 @@
-'use strict'
-
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-
-const { expect } = chai
-chai.use(dirtyChai)
-
-const { remote } = require('electron')
+import { expect } from 'chai'
+import { inAppPurchase } from 'electron'
 
 describe('inAppPurchase module', function () {
   if (process.platform !== 'darwin') return
 
   this.timeout(3 * 60 * 1000)
-
-  const { inAppPurchase } = remote
 
   it('canMakePayments() does not throw', () => {
     expect(() => {
@@ -34,8 +25,7 @@ describe('inAppPurchase module', function () {
   })
 
   it('getReceiptURL() returns receipt URL', () => {
-    const correctUrlEnd = inAppPurchase.getReceiptURL().endsWith('_MASReceipt/receipt')
-    expect(correctUrlEnd).to.be.true()
+    expect(inAppPurchase.getReceiptURL()).to.match(/_MASReceipt\/receipt$/)
   })
 
   // The following three tests are disabled because they hit Apple servers, and
@@ -45,12 +35,12 @@ describe('inAppPurchase module', function () {
   // without relying on a remote service.
   xit('purchaseProduct() fails when buying invalid product', async () => {
     const success = await inAppPurchase.purchaseProduct('non-exist', 1)
-    expect(success).to.be.false()
+    expect(success).to.be.false('failed to purchase non-existent product')
   })
 
   xit('purchaseProduct() accepts optional arguments', async () => {
     const success = await inAppPurchase.purchaseProduct('non-exist')
-    expect(success).to.be.false()
+    expect(success).to.be.false('failed to purchase non-existent product')
   })
 
   xit('getProducts() returns an empty list when getting invalid product', async () => {


### PR DESCRIPTION
#### Description of Change
Moves the inAppPurchase spec to the main process.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none