### PR TITLE
chore: revert key -> main change in window delegate listener

### DIFF
--- a/atom/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/atom/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -84,11 +84,11 @@
   return frame;
 }
 
-- (void)windowDidBecomeKey:(NSNotification*)notification {
+- (void)windowDidBecomeMain:(NSNotification*)notification {
   shell_->NotifyWindowFocus();
 }
 
-- (void)windowDidResignKey:(NSNotification*)notification {
+- (void)windowDidResignMain:(NSNotification*)notification {
   shell_->NotifyWindowBlur();
 }
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -2480,33 +2480,6 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('focus event', () => {
-    it('should not emit if focusing on a main window with a modal open', (done) => {
-      const child = new BrowserWindow({
-        parent: w,
-        modal: true,
-        show: false
-      })
-
-      child.once('ready-to-show', () => {
-        child.show()
-      })
-
-      child.on('show', () => {
-        w.once('focus', () => {
-          expect(child.isDestroyed()).to.equal(true)
-          done()
-        })
-        w.focus() // this should not trigger the above listener
-        child.close()
-      })
-
-      // act
-      child.loadURL(server.url)
-      w.show()
-    })
-  })
-
   describe('sheet-begin event', () => {
     let sheet = null
 


### PR DESCRIPTION
#### Description of Change
Backport of #19213

See that PR for details.

Notes: Reverted change to focus behavior that broke Character Viewer support on macOS.

