### PR TITLE
docs: remove redundant 'set origin' section

### DIFF
--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -38,17 +38,6 @@ $ mkdir -p "${GIT_CACHE_PATH}"
 # This will use about 16G.
 ```
 
-> **NOTE**: the git cache will set the `origin` of the `src/electron`
-> repository to point to the local cache, instead of the upstream git
-> repository. This is undesirable when running `git push` — you probably
-> want to push to github, not your local cache. To fix this, from the
-> `src/electron` directory, run:
-
-```sh
-$ git remote set-url origin https://github.com/electron/electron
-$ git remote set-url --push origin https://github.com/electron/electron
-```
-
 ### sccache
 
 Thousands of files must be compiled to build Chromium and Electron.

--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -40,12 +40,13 @@ $ mkdir -p "${GIT_CACHE_PATH}"
 
 > **NOTE**: the git cache will set the `origin` of the `src/electron`
 > repository to point to the local cache, instead of the upstream git
-> repository. This is undesirable when running `git push`—you probably want to
-> push to github, not your local cache. To fix this, from the `src/electron`
-> directory, run:
+> repository. This is undesirable when running `git push` — you probably
+> want to push to github, not your local cache. To fix this, from the
+> `src/electron` directory, run:
 
 ```sh
 $ git remote set-url origin https://github.com/electron/electron
+$ git remote set-url --push origin https://github.com/electron/electron
 ```
 
 ### sccache


### PR DESCRIPTION
#### Description of Change

The GN build instructions currently show two different ways to change the remote origin from the local cache to github. The one in the 'Getting the Source Code' section is better, so this PR keeps that and gets rid of the redundant one in the 'Cached Builds' section.

(The reason I say the one in 'Getting the Source Code' is better is that the other one only changes the fetch origin. `git remote set-url --push origin` would also be needed to change the push origin.)

#### Checklist

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes