### PR TITLE
refactor: don't send ipcRenderer.sendSync() reply as array

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -301,7 +301,7 @@ const addReplyInternalToEvent = (event) => {
 
 const addReturnValueToEvent = (event) => {
   Object.defineProperty(event, 'returnValue', {
-    set: (value) => event.sendReply([value]),
+    set: (value) => event.sendReply(value),
     get: () => {}
   })
 }

--- a/lib/renderer/api/ipc-renderer.js
+++ b/lib/renderer/api/ipc-renderer.js
@@ -12,7 +12,7 @@ ipcRenderer.send = function (channel, ...args) {
 }
 
 ipcRenderer.sendSync = function (channel, ...args) {
-  return ipc.sendSync(internal, channel, args)[0]
+  return ipc.sendSync(internal, channel, args)
 }
 
 ipcRenderer.sendToHost = function (channel, ...args) {

--- a/lib/renderer/ipc-renderer-internal.ts
+++ b/lib/renderer/ipc-renderer-internal.ts
@@ -10,7 +10,7 @@ ipcRendererInternal.send = function (channel, ...args) {
 }
 
 ipcRendererInternal.sendSync = function (channel, ...args) {
-  return binding.ipc.sendSync(internal, channel, args)[0]
+  return binding.ipc.sendSync(internal, channel, args)
 }
 
 ipcRendererInternal.sendTo = function (webContentsId, channel, ...args) {

--- a/shell/common/native_mate_converters/v8_value_converter.cc
+++ b/shell/common/native_mate_converters/v8_value_converter.cc
@@ -304,6 +304,9 @@ std::unique_ptr<base::Value> V8ValueConverter::FromV8ValueImpl(
   if (val->IsNull())
     return std::make_unique<base::Value>();
 
+  if (val->IsUndefined())
+    return std::make_unique<base::Value>();
+
   auto context = isolate->GetCurrentContext();
 
   if (val->IsBoolean())


### PR DESCRIPTION
#### Description of Change
`event.sendReply()` was refactored to take `base::Value` instead of `base::ListValue` in #18449. We don't need to pass the return value of `ipcRenderer.sendSync()` as an array via `event.sendReply()` anymore.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes