### PR TITLE
refactor: remove content::WebContentsObserver from Event

### DIFF
--- a/shell/browser/api/event.cc
+++ b/shell/browser/api/event.cc
@@ -6,10 +6,7 @@
 
 #include <utility>
 
-#include "content/public/browser/render_frame_host.h"
-#include "content/public/browser/web_contents.h"
 #include "native_mate/object_template_builder.h"
-#include "shell/common/native_mate_converters/string16_converter.h"
 #include "shell/common/native_mate_converters/value_converter.h"
 
 namespace mate {
@@ -20,34 +17,9 @@ Event::Event(v8::Isolate* isolate) {
 
 Event::~Event() {}
 
-void Event::SetSenderAndMessage(content::RenderFrameHost* sender,
-                                base::Optional<MessageSyncCallback> callback) {
-  DCHECK(!sender_);
+void Event::SetCallback(base::Optional<MessageSyncCallback> callback) {
   DCHECK(!callback_);
-  sender_ = sender;
   callback_ = std::move(callback);
-
-  Observe(content::WebContents::FromRenderFrameHost(sender));
-}
-
-void Event::RenderFrameDeleted(content::RenderFrameHost* rfh) {
-  if (sender_ != rfh)
-    return;
-  sender_ = nullptr;
-  callback_.reset();
-}
-
-void Event::RenderFrameHostChanged(content::RenderFrameHost* old_rfh,
-                                   content::RenderFrameHost* new_rfh) {
-  if (sender_ && sender_ == old_rfh)
-    sender_ = new_rfh;
-}
-
-void Event::FrameDeleted(content::RenderFrameHost* rfh) {
-  if (sender_ != rfh)
-    return;
-  sender_ = nullptr;
-  callback_.reset();
 }
 
 void Event::PreventDefault(v8::Isolate* isolate) {
@@ -58,7 +30,7 @@ void Event::PreventDefault(v8::Isolate* isolate) {
 }
 
 bool Event::SendReply(const base::Value& result) {
-  if (!callback_ || sender_ == nullptr)
+  if (!callback_)
     return false;
 
   std::move(*callback_).Run(result.Clone());

--- a/shell/browser/api/event.h
+++ b/shell/browser/api/event.h
@@ -6,7 +6,6 @@
 #define SHELL_BROWSER_API_EVENT_H_
 
 #include "base/optional.h"
-#include "content/public/browser/web_contents_observer.h"
 #include "electron/shell/common/api/api.mojom.h"
 #include "native_mate/handle.h"
 #include "native_mate/wrappable.h"
@@ -17,7 +16,7 @@ class Message;
 
 namespace mate {
 
-class Event : public Wrappable<Event>, public content::WebContentsObserver {
+class Event : public Wrappable<Event> {
  public:
   using MessageSyncCallback =
       electron::mojom::ElectronBrowser::MessageSyncCallback;
@@ -26,9 +25,8 @@ class Event : public Wrappable<Event>, public content::WebContentsObserver {
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype);
 
-  // Pass the sender and message to be replied.
-  void SetSenderAndMessage(content::RenderFrameHost* sender,
-                           base::Optional<MessageSyncCallback> callback);
+  // Pass the callback to be invoked.
+  void SetCallback(base::Optional<MessageSyncCallback> callback);
 
   // event.PreventDefault().
   void PreventDefault(v8::Isolate* isolate);
@@ -41,15 +39,8 @@ class Event : public Wrappable<Event>, public content::WebContentsObserver {
   explicit Event(v8::Isolate* isolate);
   ~Event() override;
 
-  // content::WebContentsObserver implementations:
-  void RenderFrameDeleted(content::RenderFrameHost* rfh) override;
-  void RenderFrameHostChanged(content::RenderFrameHost* old_rfh,
-                              content::RenderFrameHost* new_rfh) override;
-  void FrameDeleted(content::RenderFrameHost* rfh) override;
-
  private:
   // Replyer for the synchronous messages.
-  content::RenderFrameHost* sender_ = nullptr;
   base::Optional<MessageSyncCallback> callback_;
 
   DISALLOW_COPY_AND_ASSIGN(Event);

--- a/shell/browser/api/event_emitter.cc
+++ b/shell/browser/api/event_emitter.cc
@@ -55,7 +55,7 @@ v8::Local<v8::Object> CreateJSEvent(
 
   if (use_native_event) {
     mate::Handle<mate::Event> native_event = mate::Event::Create(isolate);
-    native_event->SetSenderAndMessage(sender, std::move(callback));
+    native_event->SetCallback(std::move(callback));
     event = v8::Local<v8::Object>::Cast(native_event.ToV8());
   } else {
     event = CreateEventObject(isolate);


### PR DESCRIPTION
#### Description of Change
We no longer need `content::RenderFrameHost` to reply synchronous `sendSync` IPC messages. Invoking mojo callbacks after the frame / webContents is destroyed seems to be fine.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes