### PR TITLE
fix: use WeakPtr to detect deletion to avoid crash on application menu

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -77,3 +77,4 @@ put_back_deleted_colors_for_autofill.patch
 build_win_disable_zc_twophase.patch
 disable_color_correct_rendering.patch
 add_contentgpuclient_precreatemessageloop_callback.patch
+fix_use_weakptr_to_detect_deletion.patch

--- a/patches/chromium/fix_use_weakptr_to_detect_deletion.patch
+++ b/patches/chromium/fix_use_weakptr_to_detect_deletion.patch
@@ -1,0 +1,76 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: John Kleinschmidt <kleinschmidtorama@gmail.com>
+Date: Wed, 31 Jul 2019 14:36:27 -0400
+Subject: fix: use WeakPtr to detect deletion
+
+
+diff --git a/ui/compositor/callback_layer_animation_observer.cc b/ui/compositor/callback_layer_animation_observer.cc
+index 639caf4d1411b867a31ce29e6c6ec4ae846359a8..6296afa55e38494cf0232f8bcd05811bfd4ebe38 100644
+--- a/ui/compositor/callback_layer_animation_observer.cc
++++ b/ui/compositor/callback_layer_animation_observer.cc
+@@ -38,22 +38,18 @@ CallbackLayerAnimationObserver::CallbackLayerAnimationObserver(
+           &CallbackLayerAnimationObserver::DummyAnimationStartedCallback)),
+       animation_ended_callback_(animation_ended_callback) {}
+ 
+-CallbackLayerAnimationObserver::~CallbackLayerAnimationObserver() {
+-  if (destroyed_)
+-    *destroyed_ = true;
+-}
++CallbackLayerAnimationObserver::~CallbackLayerAnimationObserver() {}
+ 
+ void CallbackLayerAnimationObserver::SetActive() {
+   active_ = true;
+ 
+-  bool destroyed = false;
+-  destroyed_ = &destroyed;
++  base::WeakPtr<CallbackLayerAnimationObserver> weak_this =
++      weak_factory_.GetWeakPtr();
+ 
+   CheckAllSequencesStarted();
+ 
+-  if (destroyed)
++  if (!weak_this)
+     return;
+-  destroyed_ = nullptr;
+ 
+   CheckAllSequencesCompleted();
+ }
+@@ -110,19 +106,17 @@ void CallbackLayerAnimationObserver::CheckAllSequencesStarted() {
+ void CallbackLayerAnimationObserver::CheckAllSequencesCompleted() {
+   if (active_ && GetNumSequencesCompleted() == attached_sequence_count_) {
+     active_ = false;
+-    bool destroyed = false;
+-    destroyed_ = &destroyed;
+-
++    base::WeakPtr<CallbackLayerAnimationObserver> weak_this =
++        weak_factory_.GetWeakPtr();
+     bool should_delete = animation_ended_callback_.Run(*this);
+ 
+-    if (destroyed) {
++    if (!weak_this) {
+       if (should_delete)
+         LOG(WARNING) << "CallbackLayerAnimationObserver was explicitly "
+                         "destroyed AND was requested to be destroyed via the "
+                         "AnimationEndedCallback's return value.";
+       return;
+     }
+-    destroyed_ = nullptr;
+ 
+     if (should_delete)
+       delete this;
+diff --git a/ui/compositor/callback_layer_animation_observer.h b/ui/compositor/callback_layer_animation_observer.h
+index fc631cc21ccc83a74955cd1af8bf43b879b6bc80..9b3448eecbc6a9bc75719c8df08586fe8870fa96 100644
+--- a/ui/compositor/callback_layer_animation_observer.h
++++ b/ui/compositor/callback_layer_animation_observer.h
+@@ -167,9 +167,8 @@ class COMPOSITOR_EXPORT CallbackLayerAnimationObserver
+   // The callback to invoke once all the animation sequences have finished.
+   AnimationEndedCallback animation_ended_callback_;
+ 
+-  // Set to true in the destructor (if non-NULL). Used to detect deletion while
+-  // calling out.
+-  bool* destroyed_ = nullptr;
++  // Used to detect deletion while calling out.
++  base::WeakPtrFactory<CallbackLayerAnimationObserver> weak_factory_{this};
+ 
+   DISALLOW_COPY_AND_ASSIGN(CallbackLayerAnimationObserver);
+ };


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Fixes #18436.  This PR resolves a `heap-use-after-free` issue found by the AddressSanitizer.  This issue happens when interacting with the Application Menu.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->Fixed crashes when using the application menu.
