### PR TITLE
fix: don't try to dump swiftshader symbols on mac

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -746,24 +746,6 @@ if (is_mac) {
       ]
     }
 
-    extract_symbols("swiftshader_egl_syms") {
-      binary = "$root_out_dir/libswiftshader_libEGL.dylib"
-      symbol_dir = "$root_out_dir/breakpad_symbols"
-      dsym_file = "$root_out_dir/libswiftshader_libEGL.dylib.dSYM/Contents/Resources/DWARF/libswiftshader_libEGL.dylib"
-      deps = [
-        "//third_party/swiftshader/src/OpenGL/libEGL:swiftshader_libEGL",
-      ]
-    }
-
-    extract_symbols("swiftshader_gles_syms") {
-      binary = "$root_out_dir/libswiftshader_libGLESv2.dylib"
-      symbol_dir = "$root_out_dir/breakpad_symbols"
-      dsym_file = "$root_out_dir/libswiftshader_libGLESv2.dylib.dSYM/Contents/Resources/DWARF/libswiftshader_libGLESv2.dylib"
-      deps = [
-        "//third_party/swiftshader/src/OpenGL/libGLESv2:swiftshader_libGLESv2",
-      ]
-    }
-
     extract_symbols("crashpad_handler_syms") {
       binary = "$root_out_dir/crashpad_handler"
       symbol_dir = "$root_out_dir/breakpad_symbols"
@@ -779,8 +761,6 @@ if (is_mac) {
         ":electron_app_syms",
         ":electron_framework_syms",
         ":electron_helper_syms",
-        ":swiftshader_egl_syms",
-        ":swiftshader_gles_syms",
       ]
     }
   } else {


### PR DESCRIPTION
#### Description of Change
This was breaking release builds with mysterious messages about Pentium 4s. https://circleci.com/gh/electron/electron/261973

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none