### PR TITLE
[wip] fix: crash when failed to get devices in desktopCapturer

### DIFF
--- a/atom/browser/api/atom_api_desktop_capturer.cc
+++ b/atom/browser/api/atom_api_desktop_capturer.cc
@@ -164,8 +164,12 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
       std::vector<std::string> device_names;
       // Crucially, this list of device names will be in the same order as
       // |media_list_sources|.
-      webrtc::DxgiDuplicatorController::Instance()->GetDeviceNames(
-          &device_names);
+      if (!webrtc::DxgiDuplicatorController::Instance()->GetDeviceNames(
+              &device_names)) {
+        Emit("error", "Failed to get sources.");
+        return;
+      }
+
       int device_name_index = 0;
       for (auto& source : screen_sources) {
         const auto& device_name = device_names[device_name_index++];

--- a/lib/browser/desktop-capturer.js
+++ b/lib/browser/desktop-capturer.js
@@ -23,7 +23,6 @@ ipcMain.on(electronSources, (event, captureWindow, captureScreen, thumbnailSize,
   }
 
   const request = {
-    id,
     options: {
       captureWindow,
       captureScreen,
@@ -48,6 +47,11 @@ desktopCapturer.emit = (event, name, sources, fetchWindowIcons) => {
   // Receiving sources result from main process, now send them back to renderer.
   const handledRequest = requestsQueue.shift()
   const unhandledRequestsQueue = []
+
+  if (name === 'error') {
+    const error = sources
+    throw error
+  }
 
   const result = sources.map(source => {
     return {


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/17557.

See that PR for more details.

Notes: Fixed a crash when failed to get devices in desktopCapturer on Windows.