### PR TITLE
feat: support css origin in frame.insertCSS

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -987,13 +987,13 @@ Returns `String` - The user agent for this web page.
 
 **[Deprecated](modernization/property-updates.md)**
 
-#### `contents.insertCSS(css[, origin])`
+#### `contents.insertCSS(css[, options])`
 
 * `css` String
-* `origin` String (optional) - Can be either 'user' or 'author'; Specifying "user" enables you to prevent websites from overriding the CSS you insert. Default is 'author'.
+* `options` Object (optional)
+  * `cssOrigin` String (optional) - Can be either 'user' or 'author'; Specifying 'user' enables you to prevent websites from overriding the CSS you insert. Default is 'author'.
 
-Returns `Promise<String>` - A promise that resolves with a key for the inserted CSS that can later be used to remove the CSS via
-`contents.removeInsertedCSS(key)`.
+Returns `Promise<String>` - A promise that resolves with a key for the inserted CSS that can later be used to remove the CSS via `contents.removeInsertedCSS(key)`.
 
 Injects CSS into the current web page and returns a unique key for the inserted
 stylesheet.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -987,12 +987,12 @@ Returns `String` - The user agent for this web page.
 
 **[Deprecated](modernization/property-updates.md)**
 
-#### `contents.insertCSS(css)`
+#### `contents.insertCSS(css[, origin])`
 
 * `css` String
+* `origin` String (optional) - Can be either 'user' or 'author'; Specifying "user" enables you to prevent websites from overriding the CSS you insert. Default is 'author'.
 
-Returns `Promise<String>` - A promise that resolves with a key for the inserted
-CSS that can later be used to remove the CSS via
+Returns `Promise<String>` - A promise that resolves with a key for the inserted CSS that can later be used to remove the CSS via
 `contents.removeInsertedCSS(key)`.
 
 Injects CSS into the current web page and returns a unique key for the inserted

--- a/shell/renderer/api/atom_api_web_frame.cc
+++ b/shell/renderer/api/atom_api_web_frame.cc
@@ -61,6 +61,25 @@ struct Converter<blink::WebLocalFrame::ScriptExecutionType> {
   }
 };
 
+template <>
+struct Converter<blink::WebDocument::CSSOrigin> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     blink::WebDocument::CSSOrigin* out) {
+    std::string css_origin;
+    if (!ConvertFromV8(isolate, val, &css_origin))
+      return false;
+    if (css_origin == "user") {
+      *out = blink::WebDocument::CSSOrigin::kUserOrigin;
+    } else if (css_origin == "author") {
+      *out = blink::WebDocument::CSSOrigin::kAuthorOrigin;
+    } else {
+      return false;
+    }
+    return true;
+  }
+};
+
 }  // namespace mate
 
 namespace electron {
@@ -325,12 +344,18 @@ void InsertText(v8::Local<v8::Value> window, const std::string& text) {
   }
 }
 
-base::string16 InsertCSS(v8::Local<v8::Value> window, const std::string& css) {
+base::string16 InsertCSS(v8::Local<v8::Value> window,
+                         const std::string& css,
+                         mate::Arguments* args) {
+  blink::WebDocument::CSSOrigin origin =
+      blink::WebDocument::CSSOrigin::kAuthorOrigin;
+  args->GetNext(&origin);
+
   blink::WebFrame* web_frame = GetRenderFrame(window)->GetWebFrame();
   if (web_frame->IsWebLocalFrame()) {
     return web_frame->ToWebLocalFrame()
         ->GetDocument()
-        .InsertStyleSheet(blink::WebString::FromUTF8(css))
+        .InsertStyleSheet(blink::WebString::FromUTF8(css), nullptr, origin)
         .Utf16();
   }
   return base::string16();

--- a/shell/renderer/api/atom_api_web_frame.cc
+++ b/shell/renderer/api/atom_api_web_frame.cc
@@ -347,15 +347,18 @@ void InsertText(v8::Local<v8::Value> window, const std::string& text) {
 base::string16 InsertCSS(v8::Local<v8::Value> window,
                          const std::string& css,
                          mate::Arguments* args) {
-  blink::WebDocument::CSSOrigin origin =
+  blink::WebDocument::CSSOrigin css_origin =
       blink::WebDocument::CSSOrigin::kAuthorOrigin;
-  args->GetNext(&origin);
+
+  mate::Dictionary options;
+  if (args->GetNext(&options))
+    options.Get("cssOrigin", &css_origin);
 
   blink::WebFrame* web_frame = GetRenderFrame(window)->GetWebFrame();
   if (web_frame->IsWebLocalFrame()) {
     return web_frame->ToWebLocalFrame()
         ->GetDocument()
-        .InsertStyleSheet(blink::WebString::FromUTF8(css), nullptr, origin)
+        .InsertStyleSheet(blink::WebString::FromUTF8(css), nullptr, css_origin)
         .Utf16();
   }
   return base::string16();


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/19256.

Adds support for `cssOrigin` in `webFrame.insertCSS`.

cc @brenca 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added support for CSS `origin` in `webFrame.insertCSS()`.
