### PR TITLE
fix: A fix/workaround for the desktop capturer crash on windows 10 + Intel…

### DIFF
--- a/atom/browser/api/atom_api_desktop_capturer.cc
+++ b/atom/browser/api/atom_api_desktop_capturer.cc
@@ -163,6 +163,10 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
           &device_names);
       int device_name_index = 0;
       for (auto& source : screen_sources) {
+        if (device_name_index >= device_names.size()) {
+          LOG(ERROR) << "not enough device_names, skip setting display_id";
+          break;
+        }
         const auto& device_name = device_names[device_name_index++];
         std::wstring wide_device_name;
         base::UTF8ToWide(device_name.c_str(), device_name.size(),


### PR DESCRIPTION
…® HD Graphics 620

This is obviously not fixing the root cause, however it does solve the crash. And according to the definition of DesktopCapturer::Source, it should be fine to leave display_id unset.

Related issues:
https://github.com/electron/electron/issues/14772
https://github.com/electron/electron/issues/17551

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed crash in desktopCapturer.getSources.
