### PR TITLE
fix: don't execute preload scripts for internal <iframe> inside of <webview> when nodeIntegrationInSubFrames is enabled

### DIFF
--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -192,6 +192,12 @@ if (nodeIntegration) {
   }
 }
 
+// Don't execute preload scripts for internal <iframe> inside of <webview>
+// when nodeIntegrationInSubFrames is enabled
+if (window.frameElement && v8Util.getHiddenValue(window.frameElement, 'internal')) {
+  preloadScripts.length = 0
+}
+
 const errorUtils = require('@electron/internal/common/error-utils')
 
 // Load the preload scripts.

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -136,6 +136,12 @@ if (process.isMainFrame) {
   webViewInit(contextIsolation, isWebViewTagEnabled, guestInstanceId)
 }
 
+// Don't execute preload scripts for internal <iframe> inside of <webview>
+// when nodeIntegrationInSubFrames is enabled
+if (window.frameElement && v8Util.getHiddenValue(window.frameElement, 'internal')) {
+  preloadScripts.length = 0
+}
+
 const errorUtils = require('@electron/internal/common/error-utils')
 
 // Wrap the script into a function executed in global scope. It won't have


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
