### PR TITLE
refactor: use NativeTheme dark mode detection on macOS 10.14+

### DIFF
--- a/shell/browser/api/atom_api_system_preferences_mac.mm
+++ b/shell/browser/api/atom_api_system_preferences_mac.mm
@@ -28,6 +28,7 @@
 #include "shell/browser/ui/cocoa/NSColor+Hex.h"
 #include "shell/common/native_mate_converters/gurl_converter.h"
 #include "shell/common/native_mate_converters/value_converter.h"
+#include "ui/native_theme/native_theme.h"
 
 namespace mate {
 template <>
@@ -636,8 +637,7 @@ void SystemPreferences::RemoveUserDefault(const std::string& name) {
 
 bool SystemPreferences::IsDarkMode() {
   if (@available(macOS 10.14, *)) {
-    return [[NSApplication sharedApplication].effectiveAppearance.name
-        isEqualToString:NSAppearanceNameDarkAqua];
+    return ui::NativeTheme::GetInstanceForNativeUi()->SystemDarkModeEnabled();
   }
   NSString* mode = [[NSUserDefaults standardUserDefaults]
       stringForKey:@"AppleInterfaceStyle"];

--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -20,6 +20,7 @@
 #include "ui/events/cocoa/cocoa_event_utils.h"
 #include "ui/gfx/image/image.h"
 #include "ui/gfx/mac/coordinate_conversion.h"
+#include "ui/native_theme/native_theme.h"
 
 namespace {
 
@@ -153,8 +154,7 @@ const CGFloat kVerticalTitleMargin = 2;
 
 - (BOOL)isDarkMode {
   if (@available(macOS 10.14, *)) {
-    return [[NSApplication sharedApplication].effectiveAppearance.name
-        isEqualToString:NSAppearanceNameDarkAqua];
+    return ui::NativeTheme::GetInstanceForNativeUi()->SystemDarkModeEnabled();
   }
   NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
   NSString* mode = [defaults stringForKey:@"AppleInterfaceStyle"];


### PR DESCRIPTION
#### Description of Change
In order to keep dark mode detection working on Catalina with the high contrast setting enabled, this PR removes our manual detection code in favor of using Chromium's `NativeTheme` API.

##### open q: I'm unsure whether I have to change the [converters](https://github.com/electron/electron/blob/841b74acc0ad044972f2c27848c6cd0deed02765/shell/browser/api/atom_api_system_preferences_mac.mm#L53-L75) as well? 

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
