### PR TITLE
feat: add rotate gesture for macOS

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -615,7 +615,7 @@ Returns:
 
 Emitted on 3-finger swipe. Possible directions are `up`, `right`, `down`, `left`.
 
-#### Event: 'rotate' _macOS_
+#### Event: 'rotate-gesture' _macOS_
 
 Returns:
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -615,6 +615,19 @@ Returns:
 
 Emitted on 3-finger swipe. Possible directions are `up`, `right`, `down`, `left`.
 
+#### Event: 'rotate' _macOS_
+
+Returns:
+
+* `event` Event
+* `rotation` Float
+
+Emitted on trackpad rotation gesture. Continually emitted until rotation gesture is
+ended. The `rotation` value on each emission is the angle in degrees rotated since
+the last emission. The last emitted event upon a rotation gesture will always be of
+value `0`. Counter-clockwise rotation values are positive, while clockwise ones are
+negative.
+
 #### Event: 'sheet-begin' _macOS_
 
 Emitted when the window opens a sheet.

--- a/shell/browser/api/atom_api_top_level_window.cc
+++ b/shell/browser/api/atom_api_top_level_window.cc
@@ -246,8 +246,8 @@ void TopLevelWindow::OnWindowSwipe(const std::string& direction) {
   Emit("swipe", direction);
 }
 
-void TopLevelWindow::OnWindowRotate(const float rotation) {
-  Emit("rotate", rotation);
+void TopLevelWindow::OnWindowRotateGesture(const float rotation) {
+  Emit("rotate-gesture", rotation);
 }
 
 void TopLevelWindow::OnWindowSheetBegin() {

--- a/shell/browser/api/atom_api_top_level_window.cc
+++ b/shell/browser/api/atom_api_top_level_window.cc
@@ -246,6 +246,10 @@ void TopLevelWindow::OnWindowSwipe(const std::string& direction) {
   Emit("swipe", direction);
 }
 
+void TopLevelWindow::OnWindowRotate(const float rotation) {
+  Emit("rotate", rotation);
+}
+
 void TopLevelWindow::OnWindowSheetBegin() {
   Emit("sheet-begin");
 }

--- a/shell/browser/api/atom_api_top_level_window.cc
+++ b/shell/browser/api/atom_api_top_level_window.cc
@@ -246,7 +246,7 @@ void TopLevelWindow::OnWindowSwipe(const std::string& direction) {
   Emit("swipe", direction);
 }
 
-void TopLevelWindow::OnWindowRotateGesture(const float rotation) {
+void TopLevelWindow::OnWindowRotateGesture(float rotation) {
   Emit("rotate-gesture", rotation);
 }
 

--- a/shell/browser/api/atom_api_top_level_window.h
+++ b/shell/browser/api/atom_api_top_level_window.h
@@ -73,7 +73,7 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   void OnWindowScrollTouchBegin() override;
   void OnWindowScrollTouchEnd() override;
   void OnWindowSwipe(const std::string& direction) override;
-  void OnWindowRotateGesture(const float rotation) override;
+  void OnWindowRotateGesture(float rotation) override;
   void OnWindowSheetBegin() override;
   void OnWindowSheetEnd() override;
   void OnWindowEnterFullScreen() override;

--- a/shell/browser/api/atom_api_top_level_window.h
+++ b/shell/browser/api/atom_api_top_level_window.h
@@ -73,6 +73,7 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   void OnWindowScrollTouchBegin() override;
   void OnWindowScrollTouchEnd() override;
   void OnWindowSwipe(const std::string& direction) override;
+  void OnWindowRotate(const float rotation) override;
   void OnWindowSheetBegin() override;
   void OnWindowSheetEnd() override;
   void OnWindowEnterFullScreen() override;

--- a/shell/browser/api/atom_api_top_level_window.h
+++ b/shell/browser/api/atom_api_top_level_window.h
@@ -73,7 +73,7 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   void OnWindowScrollTouchBegin() override;
   void OnWindowScrollTouchEnd() override;
   void OnWindowSwipe(const std::string& direction) override;
-  void OnWindowRotate(const float rotation) override;
+  void OnWindowRotateGesture(const float rotation) override;
   void OnWindowSheetBegin() override;
   void OnWindowSheetEnd() override;
   void OnWindowEnterFullScreen() override;

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -513,6 +513,11 @@ void NativeWindow::NotifyWindowSwipe(const std::string& direction) {
     observer.OnWindowSwipe(direction);
 }
 
+void NativeWindow::NotifyWindowRotate(const float rotation) {
+  for (NativeWindowObserver& observer : observers_)
+    observer.OnWindowRotate(rotation);
+}
+
 void NativeWindow::NotifyWindowSheetBegin() {
   for (NativeWindowObserver& observer : observers_)
     observer.OnWindowSheetBegin();

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -513,9 +513,9 @@ void NativeWindow::NotifyWindowSwipe(const std::string& direction) {
     observer.OnWindowSwipe(direction);
 }
 
-void NativeWindow::NotifyWindowRotate(const float rotation) {
+void NativeWindow::NotifyWindowRotateGesture(const float rotation) {
   for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowRotate(rotation);
+    observer.OnWindowRotateGesture(rotation);
 }
 
 void NativeWindow::NotifyWindowSheetBegin() {

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -513,7 +513,7 @@ void NativeWindow::NotifyWindowSwipe(const std::string& direction) {
     observer.OnWindowSwipe(direction);
 }
 
-void NativeWindow::NotifyWindowRotateGesture(const float rotation) {
+void NativeWindow::NotifyWindowRotateGesture(float rotation) {
   for (NativeWindowObserver& observer : observers_)
     observer.OnWindowRotateGesture(rotation);
 }

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -256,7 +256,7 @@ class NativeWindow : public base::SupportsUserData,
   void NotifyWindowScrollTouchBegin();
   void NotifyWindowScrollTouchEnd();
   void NotifyWindowSwipe(const std::string& direction);
-  void NotifyWindowRotate(const float rotation);
+  void NotifyWindowRotateGesture(const float rotation);
   void NotifyWindowSheetBegin();
   void NotifyWindowSheetEnd();
   void NotifyWindowEnterFullScreen();

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -256,7 +256,7 @@ class NativeWindow : public base::SupportsUserData,
   void NotifyWindowScrollTouchBegin();
   void NotifyWindowScrollTouchEnd();
   void NotifyWindowSwipe(const std::string& direction);
-  void NotifyWindowRotateGesture(const float rotation);
+  void NotifyWindowRotateGesture(float rotation);
   void NotifyWindowSheetBegin();
   void NotifyWindowSheetEnd();
   void NotifyWindowEnterFullScreen();

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -256,6 +256,7 @@ class NativeWindow : public base::SupportsUserData,
   void NotifyWindowScrollTouchBegin();
   void NotifyWindowScrollTouchEnd();
   void NotifyWindowSwipe(const std::string& direction);
+  void NotifyWindowRotate(const float rotation);
   void NotifyWindowSheetBegin();
   void NotifyWindowSheetEnd();
   void NotifyWindowEnterFullScreen();

--- a/shell/browser/native_window_observer.h
+++ b/shell/browser/native_window_observer.h
@@ -78,7 +78,7 @@ class NativeWindowObserver : public base::CheckedObserver {
   virtual void OnWindowScrollTouchBegin() {}
   virtual void OnWindowScrollTouchEnd() {}
   virtual void OnWindowSwipe(const std::string& direction) {}
-  virtual void OnWindowRotate(const float rotation) {}
+  virtual void OnWindowRotateGesture(const float rotation) {}
   virtual void OnWindowSheetBegin() {}
   virtual void OnWindowSheetEnd() {}
   virtual void OnWindowEnterFullScreen() {}

--- a/shell/browser/native_window_observer.h
+++ b/shell/browser/native_window_observer.h
@@ -78,7 +78,7 @@ class NativeWindowObserver : public base::CheckedObserver {
   virtual void OnWindowScrollTouchBegin() {}
   virtual void OnWindowScrollTouchEnd() {}
   virtual void OnWindowSwipe(const std::string& direction) {}
-  virtual void OnWindowRotateGesture(const float rotation) {}
+  virtual void OnWindowRotateGesture(float rotation) {}
   virtual void OnWindowSheetBegin() {}
   virtual void OnWindowSheetEnd() {}
   virtual void OnWindowEnterFullScreen() {}

--- a/shell/browser/native_window_observer.h
+++ b/shell/browser/native_window_observer.h
@@ -78,6 +78,7 @@ class NativeWindowObserver : public base::CheckedObserver {
   virtual void OnWindowScrollTouchBegin() {}
   virtual void OnWindowScrollTouchEnd() {}
   virtual void OnWindowSwipe(const std::string& direction) {}
+  virtual void OnWindowRotate(const float rotation) {}
   virtual void OnWindowSheetBegin() {}
   virtual void OnWindowSheetEnd() {}
   virtual void OnWindowEnterFullScreen() {}

--- a/shell/browser/ui/cocoa/atom_ns_window.mm
+++ b/shell/browser/ui/cocoa/atom_ns_window.mm
@@ -72,6 +72,10 @@ bool ScopedDisableResize::disable_resize_ = false;
   }
 }
 
+- (void)rotateWithEvent:(NSEvent*)event {
+  shell_->NotifyWindowRotate(event.rotation);
+}
+
 - (NSRect)contentRectForFrameRect:(NSRect)frameRect {
   if (shell_->has_frame())
     return [super contentRectForFrameRect:frameRect];

--- a/shell/browser/ui/cocoa/atom_ns_window.mm
+++ b/shell/browser/ui/cocoa/atom_ns_window.mm
@@ -73,7 +73,7 @@ bool ScopedDisableResize::disable_resize_ = false;
 }
 
 - (void)rotateWithEvent:(NSEvent*)event {
-  shell_->NotifyWindowRotate(event.rotation);
+  shell_->NotifyWindowRotateGesture(event.rotation);
 }
 
 - (NSRect)contentRectForFrameRect:(NSRect)frameRect {


### PR DESCRIPTION
#### Description of Change
Adds `BrowserWindow` event support for the [rotation trackpad gesture on macOS](https://support.apple.com/en-us/HT204895). This event is emitted constantly between the start and the end of the rotation gesture, and has an attached value corresponding to the degree in angles of the current timespan.

See `NSResponder` documentation: https://developer.apple.com/documentation/appkit/nsresponder/1525572-rotatewithevent?language=objc

cc @codebytere 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added support for rotation multi-touch gestures on `BrowserWindow` for macOS.
