### PR TITLE
fix: don't execute preload scripts for internal <iframe> in <webview> when nodeIntegrationInSubFrames is enabled

### DIFF
--- a/atom/renderer/atom_render_frame_observer.cc
+++ b/atom/renderer/atom_render_frame_observer.cc
@@ -111,7 +111,8 @@ void AtomRenderFrameObserver::DidCreateScriptContext(
 
   if (should_create_isolated_context) {
     CreateIsolatedWorldContext();
-    renderer_client_->SetupMainWorldOverrides(context, render_frame_);
+    if (!renderer_client_->IsWebViewFrame(context, render_frame_))
+      renderer_client_->SetupMainWorldOverrides(context, render_frame_);
   }
 }
 

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -91,7 +91,8 @@ void AtomRendererClient::DidCreateScriptContext(
       base::CommandLine::ForCurrentProcess()->HasSwitch(
           switches::kNodeIntegrationInSubFrames);
   bool should_load_node =
-      is_main_frame || is_devtools || allow_node_in_subframes;
+      (is_main_frame || is_devtools || allow_node_in_subframes) &&
+      !IsWebViewFrame(context, render_frame);
   if (!should_load_node) {
     return;
   }

--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -190,7 +190,8 @@ void AtomSandboxedRendererClient::DidCreateScriptContext(
       base::CommandLine::ForCurrentProcess()->HasSwitch(
           switches::kNodeIntegrationInSubFrames);
   bool should_load_preload =
-      is_main_frame || is_devtools || allow_node_in_sub_frames;
+      (is_main_frame || is_devtools || allow_node_in_sub_frames) &&
+      !IsWebViewFrame(context, render_frame);
   if (!should_load_preload)
     return;
 

--- a/atom/renderer/renderer_client_base.cc
+++ b/atom/renderer/renderer_client_base.cc
@@ -314,4 +314,28 @@ v8::Local<v8::Value> RendererClientBase::RunScript(
   return script->Run(context).ToLocalChecked();
 }
 
+bool RendererClientBase::IsWebViewFrame(
+    v8::Handle<v8::Context> context,
+    content::RenderFrame* render_frame) const {
+  auto* isolate = context->GetIsolate();
+
+  if (render_frame->IsMainFrame())
+    return false;
+
+  mate::Dictionary window_dict(
+      isolate, GetContext(render_frame->GetWebFrame(), isolate)->Global());
+
+  v8::Local<v8::Object> frame_element;
+  if (!window_dict.Get("frameElement", &frame_element))
+    return false;
+
+  mate::Dictionary frame_element_dict(isolate, frame_element);
+
+  v8::Local<v8::Object> internal;
+  if (!frame_element_dict.GetHidden("internal", &internal))
+    return false;
+
+  return !internal.IsEmpty();
+}
+
 }  // namespace atom

--- a/atom/renderer/renderer_client_base.h
+++ b/atom/renderer/renderer_client_base.h
@@ -44,6 +44,10 @@ class RendererClientBase : public content::ContentRendererClient {
   static v8::Local<v8::Value> RunScript(v8::Local<v8::Context> context,
                                         v8::Local<v8::String> source);
 
+  // v8Util.getHiddenValue(window.frameElement, 'internal')
+  bool IsWebViewFrame(v8::Handle<v8::Context> context,
+                      content::RenderFrame* render_frame) const;
+
  protected:
   void AddRenderBindings(v8::Isolate* isolate,
                          v8::Local<v8::Object> binding_object);

--- a/spec/fixtures/sub-frames/webview-iframe-preload.js
+++ b/spec/fixtures/sub-frames/webview-iframe-preload.js
@@ -1,0 +1,14 @@
+const { ipcRenderer } = require('electron')
+
+if (process.isMainFrame) {
+  window.addEventListener('DOMContentLoaded', () => {
+    const webview = document.createElement('webview')
+    webview.src = 'about:blank'
+    webview.addEventListener('did-finish-load', () => {
+      ipcRenderer.send('webview-loaded')
+    }, { once: true })
+    document.body.appendChild(webview)
+  })
+} else {
+  ipcRenderer.send('preload-in-frame')
+}


### PR DESCRIPTION
#### Description of Change
Backport of #19260

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Preload scripts for internal `<iframe>` in `<webview>` are not longer executed when `nodeIntegrationInSubFrames` is enabled.