### PR TITLE
feat: migrate webRequest module to NetworkService (Part 1)

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -105,6 +105,8 @@ filenames = {
     "shell/browser/api/atom_api_web_contents_view.h",
     "shell/browser/api/atom_api_web_request.cc",
     "shell/browser/api/atom_api_web_request.h",
+    "shell/browser/api/atom_api_web_request_ns.cc",
+    "shell/browser/api/atom_api_web_request_ns.h",
     "shell/browser/api/atom_api_web_view_manager.cc",
     "shell/browser/api/atom_api_browser_window.cc",
     "shell/browser/api/atom_api_browser_window.h",

--- a/shell/browser/api/atom_api_session.cc
+++ b/shell/browser/api/atom_api_session.cc
@@ -48,6 +48,7 @@
 #include "shell/browser/api/atom_api_protocol.h"
 #include "shell/browser/api/atom_api_protocol_ns.h"
 #include "shell/browser/api/atom_api_web_request.h"
+#include "shell/browser/api/atom_api_web_request_ns.h"
 #include "shell/browser/atom_browser_context.h"
 #include "shell/browser/atom_browser_main_parts.h"
 #include "shell/browser/atom_permission_manager.h"
@@ -659,8 +660,12 @@ v8::Local<v8::Value> Session::Protocol(v8::Isolate* isolate) {
 
 v8::Local<v8::Value> Session::WebRequest(v8::Isolate* isolate) {
   if (web_request_.IsEmpty()) {
-    auto handle = electron::api::WebRequest::Create(isolate, browser_context());
-    web_request_.Reset(isolate, handle.ToV8());
+    v8::Local<v8::Value> handle;
+    if (base::FeatureList::IsEnabled(network::features::kNetworkService))
+      handle = WebRequestNS::Create(isolate, browser_context()).ToV8();
+    else
+      handle = WebRequest::Create(isolate, browser_context()).ToV8();
+    web_request_.Reset(isolate, handle);
   }
   return v8::Local<v8::Value>::New(isolate, web_request_);
 }

--- a/shell/browser/api/atom_api_web_request_ns.cc
+++ b/shell/browser/api/atom_api_web_request_ns.cc
@@ -1,0 +1,38 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/api/atom_api_web_request_ns.h"
+
+#include "shell/browser/atom_browser_context.h"
+
+namespace electron {
+
+namespace api {
+
+WebRequestNS::WebRequestNS(v8::Isolate* isolate,
+                           AtomBrowserContext* browser_context) {
+  Init(isolate);
+  AttachAsUserData(browser_context);
+}
+
+WebRequestNS::~WebRequestNS() = default;
+
+// static
+mate::Handle<WebRequestNS> WebRequestNS::Create(
+    v8::Isolate* isolate,
+    AtomBrowserContext* browser_context) {
+  return mate::CreateHandle(isolate,
+                            new WebRequestNS(isolate, browser_context));
+}
+
+// static
+void WebRequestNS::BuildPrototype(v8::Isolate* isolate,
+                                  v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(mate::StringToV8(isolate, "WebRequest"));
+  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate());
+}
+
+}  // namespace api
+
+}  // namespace electron

--- a/shell/browser/api/atom_api_web_request_ns.h
+++ b/shell/browser/api/atom_api_web_request_ns.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_BROWSER_API_ATOM_API_WEB_REQUEST_NS_H_
+#define SHELL_BROWSER_API_ATOM_API_WEB_REQUEST_NS_H_
+
+#include "native_mate/dictionary.h"
+#include "native_mate/handle.h"
+#include "shell/browser/api/trackable_object.h"
+
+namespace electron {
+
+class AtomBrowserContext;
+
+namespace api {
+
+class WebRequestNS : public mate::TrackableObject<WebRequestNS> {
+ public:
+  static mate::Handle<WebRequestNS> Create(v8::Isolate* isolate,
+                                           AtomBrowserContext* browser_context);
+
+  static void BuildPrototype(v8::Isolate* isolate,
+                             v8::Local<v8::FunctionTemplate> prototype);
+
+ private:
+  WebRequestNS(v8::Isolate* isolate, AtomBrowserContext* browser_context);
+  ~WebRequestNS() override;
+};
+
+}  // namespace api
+
+}  // namespace electron
+
+#endif  // SHELL_BROWSER_API_ATOM_API_WEB_REQUEST_NS_H_


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Refs https://github.com/electron/electron/issues/15791.

This PR initializes an empty object for `webRequest` module when NetworkService is enabled, so Electron would throw JS exceptions instead of hard crash when `webRequest` module is used.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes