### PR TITLE
refactor: use NativeTheme dark mode detection on macOS 10.15+

### DIFF
--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -25,6 +25,7 @@
 #include "base/values.h"
 #include "native_mate/object_template_builder.h"
 #include "net/base/mac/url_conversions.h"
+#include "ui/native_theme/native_theme.h"
 
 namespace mate {
 template <>
@@ -626,8 +627,7 @@ void SystemPreferences::RemoveUserDefault(const std::string& name) {
 
 bool SystemPreferences::IsDarkMode() {
   if (@available(macOS 10.15, *)) {
-    return [[NSApplication sharedApplication].effectiveAppearance.name
-        isEqualToString:NSAppearanceNameDarkAqua];
+    return ui::NativeTheme::GetInstanceForNativeUi()->SystemDarkModeEnabled();
   }
   NSString* mode = [[NSUserDefaults standardUserDefaults]
       stringForKey:@"AppleInterfaceStyle"];

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -17,6 +17,7 @@
 #include "ui/events/cocoa/cocoa_event_utils.h"
 #include "ui/gfx/image/image.h"
 #include "ui/gfx/mac/coordinate_conversion.h"
+#include "ui/native_theme/native_theme.h"
 
 namespace {
 
@@ -150,8 +151,7 @@ const CGFloat kVerticalTitleMargin = 2;
 
 - (BOOL)isDarkMode {
   if (@available(macOS 10.15, *)) {
-    return [[NSApplication sharedApplication].effectiveAppearance.name
-        isEqualToString:NSAppearanceNameDarkAqua];
+    return ui::NativeTheme::GetInstanceForNativeUi()->SystemDarkModeEnabled();
   }
   NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
   NSString* mode = [defaults stringForKey:@"AppleInterfaceStyle"];


### PR DESCRIPTION
Backport of #19288.

See that PR for more details.

Notes: none