### PR TITLE
refactor: use NativeTheme dark mode detection on macOS 10.15+

### DIFF
--- a/atom/browser/api/atom_api_system_preferences_mac.mm
+++ b/atom/browser/api/atom_api_system_preferences_mac.mm
@@ -20,6 +20,7 @@
 #include "base/values.h"
 #include "native_mate/object_template_builder.h"
 #include "net/base/mac/url_conversions.h"
+#include "ui/native_theme/native_theme.h"
 
 namespace mate {
 template <>
@@ -558,8 +559,7 @@ void SystemPreferences::RemoveUserDefault(const std::string& name) {
 
 bool SystemPreferences::IsDarkMode() {
   if (@available(macOS 10.15, *)) {
-    return [[NSApplication sharedApplication].effectiveAppearance.name
-        isEqualToString:NSAppearanceNameDarkAqua];
+    return ui::NativeTheme::GetInstanceForNativeUi()->SystemDarkModeEnabled();
   }
   NSString* mode = [[NSUserDefaults standardUserDefaults]
       stringForKey:@"AppleInterfaceStyle"];

--- a/atom/browser/ui/tray_icon_cocoa.mm
+++ b/atom/browser/ui/tray_icon_cocoa.mm
@@ -17,6 +17,7 @@
 #include "ui/events/cocoa/cocoa_event_utils.h"
 #include "ui/gfx/image/image.h"
 #include "ui/gfx/mac/coordinate_conversion.h"
+#include "ui/native_theme/native_theme.h"
 
 namespace {
 
@@ -150,8 +151,7 @@ const CGFloat kVerticalTitleMargin = 2;
 
 - (BOOL)isDarkMode {
   if (@available(macOS 10.15, *)) {
-    return [[NSApplication sharedApplication].effectiveAppearance.name
-        isEqualToString:NSAppearanceNameDarkAqua];
+    return ui::NativeTheme::GetInstanceForNativeUi()->SystemDarkModeEnabled();
   }
   NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
   NSString* mode = [defaults stringForKey:@"AppleInterfaceStyle"];
@@ -335,9 +335,9 @@ const CGFloat kVerticalTitleMargin = 2;
 
   // Show a custom menu.
   if (menu_model) {
-    base::scoped_nsobject<AtomMenuController> menuController(
-        [[AtomMenuController alloc] initWithModel:menu_model
-                            useDefaultAccelerator:NO]);
+    base::scoped_nsobject<AtomMenuController> menuController([
+        [AtomMenuController alloc] initWithModel:menu_model
+                           useDefaultAccelerator:NO]);
     forceHighlight_ = YES;  // Should highlight when showing menu.
     [self setNeedsDisplay:YES];
 


### PR DESCRIPTION
Backport of #19288.

See that PR for more details.

Notes: none