### PR TITLE
fix: preserve zoom button state on macOS when alwaysOnTop is set

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -853,7 +853,12 @@ void NativeWindowMac::SetAlwaysOnTop(bool top,
 
   NSInteger newLevel = windowLevel + relativeLevel;
   if (newLevel >= minWindowLevel && newLevel <= maxWindowLevel) {
+    was_maximizable_ = IsMaximizable();
     [window_ setLevel:newLevel];
+    // Set level will make the zoom button revert to default, probably
+    // a bug of Cocoa or macOS.
+    [[window_ standardWindowButton:NSWindowZoomButton]
+        setEnabled:was_maximizable_];
   } else {
     *error = std::string([[NSString
         stringWithFormat:@"relativeLevel must be between %d and %d",


### PR DESCRIPTION
#### Description of Change
Fixes #19306. 

When the `maximizable` property on `BrowserWindow` is set false, the zoom button should be disabled on macOS. However, using the `alwaysOnTop` property led to a reset of the button's state due to calling `NSWindow.setLevel`. This might be a Cocoa or macOS bug and there are already other occurrences of this workaround in the `native_window_mac` file.

cc @miniak @codebytere  

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
