### PR TITLE
fix: delay handling occlusion events to avoid flicker on macOS

### DIFF
--- a/patches/common/chromium/.patches
+++ b/patches/common/chromium/.patches
@@ -78,3 +78,4 @@ video_capturer_dirty_rect.patch
 unsandboxed_ppapi_processes_skip_zygote.patch
 autofill_size_calculation.patch
 disable_detach_webview_frame.patch
+chore_add_debounce_on_the_updatewebcontentsvisibility_method_to.patch

--- a/patches/common/chromium/chore_add_debounce_on_the_updatewebcontentsvisibility_method_to.patch
+++ b/patches/common/chromium/chore_add_debounce_on_the_updatewebcontentsvisibility_method_to.patch
@@ -1,0 +1,65 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Samuel Attard <sattard@slack-corp.com>
+Date: Wed, 5 Jun 2019 15:11:00 -0700
+Subject: chore: add debounce on the updateWebContentsVisibility method to
+ ensure quick changes in occlusion do not result in flickering
+
+diff --git a/content/app_shim_remote_cocoa/web_contents_view_cocoa.h b/content/app_shim_remote_cocoa/web_contents_view_cocoa.h
+index 230e259f6017310e556d11dec43973b74015f191..ebd19fc31efef50677da417dfd69f0c8cce6c682 100644
+--- a/content/app_shim_remote_cocoa/web_contents_view_cocoa.h
++++ b/content/app_shim_remote_cocoa/web_contents_view_cocoa.h
+@@ -58,6 +58,8 @@ CONTENT_EXPORT
+                        offset:(NSPoint)offset;
+ - (void)clearViewsHostableView;
+ - (void)updateWebContentsVisibility;
++- (remote_cocoa::mojom::Visibility)currentVisibility;
++- (void)notifyWebContentsVisibilityChanged;
+ - (void)viewDidBecomeFirstResponder:(NSNotification*)notification;
+ @end
+ 
+diff --git a/content/app_shim_remote_cocoa/web_contents_view_cocoa.mm b/content/app_shim_remote_cocoa/web_contents_view_cocoa.mm
+index 615fe671d415747cb84f673327629d3dc771039e..6c31ba5b9149161784f5813598ddcf30e2d8af2a 100644
+--- a/content/app_shim_remote_cocoa/web_contents_view_cocoa.mm
++++ b/content/app_shim_remote_cocoa/web_contents_view_cocoa.mm
+@@ -257,9 +257,14 @@ - (void)viewDidBecomeFirstResponder:(NSNotification*)notification {
+   host_->OnBecameFirstResponder(direction);
+ }
+ 
+-- (void)updateWebContentsVisibility {
++- (void)notifyWebContentsVisibilityChanged {
+   if (!host_)
+     return;
++
++  host_->OnWindowVisibilityChanged([self currentVisibility]);
++}
++
++- (Visibility)currentVisibility {
+   Visibility visibility = Visibility::kVisible;
+   if ([self isHiddenOrHasHiddenAncestor] || ![self window])
+     visibility = Visibility::kHidden;
+@@ -267,7 +272,24 @@ - (void)updateWebContentsVisibility {
+     visibility = Visibility::kVisible;
+   else
+     visibility = Visibility::kOccluded;
+-  host_->OnWindowVisibilityChanged(visibility);
++  return visibility;
++}
++
++- (void)updateWebContentsVisibility {
++  if (!host_)
++    return;
++  // Cancel any pending notifications visibility changes, this ensures that the latest incoming change is the only
++  // change that will take affect
++  [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(notifyWebContentsVisibilityChanged) object:nil];
++
++  Visibility visibility = [self currentVisibility];
++
++  // If it's visible, notify immediately to render ASAP
++  if (visibility == Visibility::kVisible)
++    host_->OnWindowVisibilityChanged(visibility);
++  else
++    // If it's occluded queue it for 3 seconds to be sure that it isn't a double kOccluded -> kVisible
++    [self performSelector:@selector(notifyWebContentsVisibilityChanged) withObject:nil afterDelay:3.0];
+ }
+ 
+ - (void)resizeSubviewsWithOldSize:(NSSize)oldBoundsSize {

--- a/patches/common/chromium/chore_add_debounce_on_the_updatewebcontentsvisibility_method_to.patch
+++ b/patches/common/chromium/chore_add_debounce_on_the_updatewebcontentsvisibility_method_to.patch
@@ -4,49 +4,49 @@ Date: Wed, 5 Jun 2019 15:11:00 -0700
 Subject: chore: add debounce on the updateWebContentsVisibility method to
  ensure quick changes in occlusion do not result in flickering
 
-diff --git a/content/app_shim_remote_cocoa/web_contents_view_cocoa.h b/content/app_shim_remote_cocoa/web_contents_view_cocoa.h
-index 230e259f6017310e556d11dec43973b74015f191..ebd19fc31efef50677da417dfd69f0c8cce6c682 100644
---- a/content/app_shim_remote_cocoa/web_contents_view_cocoa.h
-+++ b/content/app_shim_remote_cocoa/web_contents_view_cocoa.h
-@@ -58,6 +58,8 @@ CONTENT_EXPORT
-                        offset:(NSPoint)offset;
- - (void)clearViewsHostableView;
+diff --git a/content/browser/web_contents/web_contents_view_cocoa.h b/content/browser/web_contents/web_contents_view_cocoa.h
+index 5b44f03eba6ff1a960d56d3d8613ccc98c30bf54..6f903c195e58f9e8c9322d92281d53ab130ef82b 100644
+--- a/content/browser/web_contents/web_contents_view_cocoa.h
++++ b/content/browser/web_contents/web_contents_view_cocoa.h
+@@ -64,6 +64,8 @@ CONTENT_EXPORT
+ - (void)clearWebContentsView;
+ - (void)closeTabAfterEvent;
  - (void)updateWebContentsVisibility;
 +- (remote_cocoa::mojom::Visibility)currentVisibility;
 +- (void)notifyWebContentsVisibilityChanged;
  - (void)viewDidBecomeFirstResponder:(NSNotification*)notification;
+ - (content::WebContentsImpl*)webContents;
  @end
- 
-diff --git a/content/app_shim_remote_cocoa/web_contents_view_cocoa.mm b/content/app_shim_remote_cocoa/web_contents_view_cocoa.mm
-index 615fe671d415747cb84f673327629d3dc771039e..6c31ba5b9149161784f5813598ddcf30e2d8af2a 100644
---- a/content/app_shim_remote_cocoa/web_contents_view_cocoa.mm
-+++ b/content/app_shim_remote_cocoa/web_contents_view_cocoa.mm
-@@ -257,9 +257,14 @@ - (void)viewDidBecomeFirstResponder:(NSNotification*)notification {
-   host_->OnBecameFirstResponder(direction);
+diff --git a/content/browser/web_contents/web_contents_view_cocoa.mm b/content/browser/web_contents/web_contents_view_cocoa.mm
+index c34664635626c42667fd8206e790ace9ef01ad54..1ca1a6e8119efcf1d9513c2a59dcac06cee6c1fc 100644
+--- a/content/browser/web_contents/web_contents_view_cocoa.mm
++++ b/content/browser/web_contents/web_contents_view_cocoa.mm
+@@ -282,9 +282,14 @@ - (void)viewDidBecomeFirstResponder:(NSNotification*)notification {
+   client_->OnBecameFirstResponder(direction);
  }
  
 -- (void)updateWebContentsVisibility {
 +- (void)notifyWebContentsVisibilityChanged {
-   if (!host_)
+   if (!client_)
      return;
 +
-+  host_->OnWindowVisibilityChanged([self currentVisibility]);
++  client_->OnWindowVisibilityChanged([self currentVisibility]);
 +}
 +
 +- (Visibility)currentVisibility {
-   Visibility visibility = Visibility::kVisible;
+   content::mojom::Visibility visibility = content::mojom::Visibility::kVisible;
    if ([self isHiddenOrHasHiddenAncestor] || ![self window])
-     visibility = Visibility::kHidden;
-@@ -267,7 +272,24 @@ - (void)updateWebContentsVisibility {
-     visibility = Visibility::kVisible;
+     visibility = content::mojom::Visibility::kHidden;
+@@ -292,7 +297,24 @@ - (void)updateWebContentsVisibility {
+     visibility = content::mojom::Visibility::kVisible;
    else
-     visibility = Visibility::kOccluded;
--  host_->OnWindowVisibilityChanged(visibility);
+     visibility = content::mojom::Visibility::kOccluded;
+-  client_->OnWindowVisibilityChanged(visibility);
 +  return visibility;
 +}
 +
 +- (void)updateWebContentsVisibility {
-+  if (!host_)
++  if (!client_)
 +    return;
 +  // Cancel any pending notifications visibility changes, this ensures that the latest incoming change is the only
 +  // change that will take affect
@@ -56,7 +56,7 @@ index 615fe671d415747cb84f673327629d3dc771039e..6c31ba5b9149161784f5813598ddcf30
 +
 +  // If it's visible, notify immediately to render ASAP
 +  if (visibility == Visibility::kVisible)
-+    host_->OnWindowVisibilityChanged(visibility);
++    client_->OnWindowVisibilityChanged(visibility);
 +  else
 +    // If it's occluded queue it for 3 seconds to be sure that it isn't a double kOccluded -> kVisible
 +    [self performSelector:@selector(notifyWebContentsVisibilityChanged) withObject:nil afterDelay:3.0];

--- a/patches/common/chromium/chore_add_debounce_on_the_updatewebcontentsvisibility_method_to.patch
+++ b/patches/common/chromium/chore_add_debounce_on_the_updatewebcontentsvisibility_method_to.patch
@@ -12,7 +12,7 @@ index 5b44f03eba6ff1a960d56d3d8613ccc98c30bf54..6f903c195e58f9e8c9322d92281d53ab
  - (void)clearWebContentsView;
  - (void)closeTabAfterEvent;
  - (void)updateWebContentsVisibility;
-+- (remote_cocoa::mojom::Visibility)currentVisibility;
++- (content::mojom::Visibility)currentVisibility;
 +- (void)notifyWebContentsVisibilityChanged;
  - (void)viewDidBecomeFirstResponder:(NSNotification*)notification;
  - (content::WebContentsImpl*)webContents;
@@ -33,7 +33,7 @@ index c34664635626c42667fd8206e790ace9ef01ad54..1ca1a6e8119efcf1d9513c2a59dcac06
 +  client_->OnWindowVisibilityChanged([self currentVisibility]);
 +}
 +
-+- (Visibility)currentVisibility {
++- (content::mojom::Visibility)currentVisibility {
    content::mojom::Visibility visibility = content::mojom::Visibility::kVisible;
    if ([self isHiddenOrHasHiddenAncestor] || ![self window])
      visibility = content::mojom::Visibility::kHidden;
@@ -52,10 +52,10 @@ index c34664635626c42667fd8206e790ace9ef01ad54..1ca1a6e8119efcf1d9513c2a59dcac06
 +  // change that will take affect
 +  [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(notifyWebContentsVisibilityChanged) object:nil];
 +
-+  Visibility visibility = [self currentVisibility];
++  content::mojom::Visibility visibility = [self currentVisibility];
 +
 +  // If it's visible, notify immediately to render ASAP
-+  if (visibility == Visibility::kVisible)
++  if (visibility == content::mojom::Visibility::kVisible)
 +    client_->OnWindowVisibilityChanged(visibility);
 +  else
 +    // If it's occluded queue it for 3 seconds to be sure that it isn't a double kOccluded -> kVisible


### PR DESCRIPTION
#### Description of Change
Manual backport of #18661

See that PR for details.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed random flicker that occurred on macOS when performing fullscreen or workspace transitions
