### PR TITLE
 test: run all tests on arm linux platforms

### DIFF
--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:16.04
+FROM arm64v8/ubuntu:18.04
 
 RUN groupadd --gid 1000 builduser \
   && useradd --uid 1000 --gid builduser --shell /bin/bash --create-home builduser
@@ -41,7 +41,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
  nano \
  python-setuptools \
  python-pip \
- python-dbusmock \
  sudo \
  unzip \
  wget \
@@ -55,6 +54,9 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
 
 # crcmod is required by gsutil, which is used for filling the gclient git cache
 RUN pip install -U crcmod
+
+# dbusmock is needed for Electron tests
+RUN pip install python-dbusmock
 
 ADD tools/xvfb-init.sh /etc/init.d/xvfb
 RUN chmod a+x /etc/init.d/xvfb

--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -150,8 +150,8 @@ async function installSpecModules () {
     cwd: path.resolve(__dirname, '../spec'),
     stdio: 'inherit'
   })
-  if (status !== 0) {
-    throw new Error('Failed to npm install in the spec folder')
+  if (status !== 0 && !process.env.IGNORE_YARN_INSTALL_ERROR) {
+    throw new Error('Failed to yarn install in the spec folder')
   }
 }
 

--- a/vsts-arm-test-steps.yml
+++ b/vsts-arm-test-steps.yml
@@ -53,14 +53,6 @@ steps:
   env:
     CIRCLE_TOKEN: $(CIRCLECI_TOKEN)
 
-
-- bash: |
-    cd src
-    export npm_config_nodedir=$PWD/out/Default/gen/node_headers
-    cd electron/spec
-    node ../script/yarn.js install --frozen-lockfile
-  displayName: Install test modules
-
 - bash: |
     sh -e /etc/init.d/xvfb start
   displayName: Setup for headless testing
@@ -68,21 +60,21 @@ steps:
     DISPLAY: ":99.0"
 
 - bash: |
-   cd src
-   ./out/Default/electron electron/spec --ci --enable-logging
+    cd src
+    export ELECTRON_OUT_DIR=Default
+    (cd electron && node script/yarn test -- --ci --enable-logging)
   displayName: 'Run Electron tests'
-  timeoutInMinutes: 10
+  timeoutInMinutes: 20
   env:
-    ELECTRON_DISABLE_SANDBOX: 1
     ELECTRON_DISABLE_SECURITY_WARNINGS: 1
+    IGNORE_YARN_INSTALL_ERROR: 1
+    ELECTRON_TEST_RESULTS_DIR: junit
 
 - bash: |
     cd src
     python electron/script/verify-ffmpeg.py --source-root "$PWD" --build-dir out/Default --ffmpeg-path out/ffmpeg
   displayName: Verify non proprietary ffmpeg
   timeoutInMinutes: 5
-  env:
-    ELECTRON_DISABLE_SANDBOX: 1
 
 - bash: |
     cd src
@@ -90,9 +82,6 @@ steps:
     python electron/script/verify-mksnapshot.py --source-root "$PWD" --build-dir out/Default --snapshot-files-dir $PWD/out/Default/cross-arch-snapshots
   displayName: Verify cross arch snapshot
   timeoutInMinutes: 5
-  env:
-    ELECTRON_DISABLE_SANDBOX: 1
-  condition: and(succeeded(), eq(variables['RUN_NATIVE_MKSNAPSHOT'], 'true'))
 
 - task: PublishTestResults@2
   displayName: 'Publish Test Results'

--- a/vsts-arm64v8.yml
+++ b/vsts-arm64v8.yml
@@ -3,8 +3,6 @@ resources:
   - container: arm64v8-test-container
     image: electronbuilds/arm64v8:0.0.4
     options: --shm-size 128m
-    env:
-      RUN_NATIVE_MKSNAPSHOT: true
 
 jobs:
 - job: Test_Arm64

--- a/vsts-arm64v8.yml
+++ b/vsts-arm64v8.yml
@@ -1,7 +1,7 @@
 resources:
   containers:
   - container: arm64v8-test-container
-    image: electronbuilds/arm64v8:0.0.4
+    image: electronbuilds/arm64v8:0.0.5
     options: --shm-size 128m
 
 jobs:


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
When we started splitting out tests (eg #17325) we never accomodated for the arm CI which wasn't using `script/spec-runner.js` because there are (acceptable) failures that happen during yarn/npm install but that script fails if yarn/npm install fails.

This PR updates `script/spec-runner.js` to look for an environment variable, `IGNORE_YARN_INSTALL_ERROR` which will allow the spec runner to continue even if there were errors during yarn install.

Running all the tests on arm/arm64 revealed a couple of additional issues that we resolved by modifying our Azure Pipelines agents so that the user that runs the test is now a non-root user.  

Additionally arm64 CI was updated to use ubuntu:18.04 instead of ubuntu:16.04 to be consistent with the rest of our linux CI.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
