### PR TITLE
fix: emit swipe event on macOS

### DIFF
--- a/shell/browser/api/atom_api_browser_window.cc
+++ b/shell/browser/api/atom_api_browser_window.cc
@@ -84,8 +84,7 @@ BrowserWindow::BrowserWindow(v8::Isolate* isolate,
   InitWith(isolate, wrapper);
 
 #if defined(OS_MACOSX)
-  if (!window()->has_frame())
-    OverrideNSWindowContentView(web_contents->managed_web_contents());
+  OverrideNSWindowContentView(web_contents->managed_web_contents());
 #endif
 
   // Init window after everything has been setup.


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/19131.

Previously, we only overrode the `[window_ contentView]` in frameless windows, which came at cost of preventing users from accessing `views::View` APIs. This PR applies that override to framed windows as well, such that we are now unconditionally removing `BridgedContentView` as content view on BrowserWindows.

cc @nornagon @zcbenz @miniak 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed 'swipe' event emission on macoS>
