### PR TITLE
fix: tray.displayBalloon() does not work with custom icon on Windows

### DIFF
--- a/shell/browser/api/atom_api_tray.cc
+++ b/shell/browser/api/atom_api_tray.cc
@@ -199,7 +199,7 @@ void Tray::DisplayBalloon(mate::Arguments* args,
 
 #if defined(OS_WIN)
   tray_icon_->DisplayBalloon(
-      icon.IsEmpty() ? NULL : icon->GetHICON(GetSystemMetrics(SM_CXSMICON)),
+      icon.IsEmpty() ? NULL : icon->GetHICON(GetSystemMetrics(SM_CXICON)),
       title, content);
 #else
   tray_icon_->DisplayBalloon(icon.IsEmpty() ? gfx::Image() : icon->image(),


### PR DESCRIPTION
#### Description of Change
According to the [NIIF_LARGE_ICON](https://docs.microsoft.com/en-us/windows/win32/api/shellapi/ns-shellapi-_notifyicondataa#niif_large_icon-0x00000020) documentation:
> NIIF_LARGE_ICON (0x00000020)
0x00000020. Windows Vista and later. The large version of the icon should be used as the notification icon. This corresponds to the icon with dimensions SM_CXICON x SM_CYICON. If this flag is not set, the icon with dimensions SM_CXSMICON x SM_CYSMICON is used.

The other option would be to keep the `SM_CXSMICON` size, but to drop the `NIIF_LARGE_ICON` flag.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed `tray.displayBalloon()` not working with custom icon on Windows.