### PR TITLE
feat: support `isHighContrastColorScheme()` on macOS

### DIFF
--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -344,7 +344,7 @@ Returns one of several standard system colors that automatically adapt to vibran
 
 Returns `Boolean` - `true` if an inverted color scheme (a high contrast color scheme with light text and dark backgrounds) is active, `false` otherwise.
 
-### `systemPreferences.isHighContrastColorScheme()` _Windows_
+### `systemPreferences.isHighContrastColorScheme()` _macOS_ _Windows_
 
 Returns `Boolean` - `true` if a high contrast theme is active, `false` otherwise.
 

--- a/shell/browser/api/atom_api_system_preferences.cc
+++ b/shell/browser/api/atom_api_system_preferences.cc
@@ -39,11 +39,9 @@ bool SystemPreferences::IsInvertedColorScheme() {
   return color_utils::IsInvertedColorScheme();
 }
 
-#if !defined(OS_WIN)
 bool SystemPreferences::IsHighContrastColorScheme() {
-  return false;
+  return ui::NativeTheme::GetInstanceForNativeUi()->UsesHighContrastColors();
 }
-#endif  // !defined(OS_WIN)
 
 v8::Local<v8::Value> SystemPreferences::GetAnimationSettings(
     v8::Isolate* isolate) {

--- a/shell/browser/api/atom_api_system_preferences_win.cc
+++ b/shell/browser/api/atom_api_system_preferences_win.cc
@@ -20,30 +20,12 @@ namespace {
 const wchar_t kSystemPreferencesWindowClass[] =
     L"Electron_SystemPreferencesHostWindow";
 
-bool g_is_high_contract_color_scheme = false;
-bool g_is_high_contract_color_scheme_initialized = false;
-
-void UpdateHighContrastColorScheme() {
-  HIGHCONTRAST high_contrast = {0};
-  high_contrast.cbSize = sizeof(HIGHCONTRAST);
-  g_is_high_contract_color_scheme =
-      SystemParametersInfo(SPI_GETHIGHCONTRAST, 0, &high_contrast, 0) &&
-      ((high_contrast.dwFlags & HCF_HIGHCONTRASTON) != 0);
-  g_is_high_contract_color_scheme_initialized = true;
-}
-
 }  // namespace
 
 namespace api {
 
 bool SystemPreferences::IsAeroGlassEnabled() {
   return ui::win::IsAeroGlassEnabled();
-}
-
-bool SystemPreferences::IsHighContrastColorScheme() {
-  if (!g_is_high_contract_color_scheme_initialized)
-    UpdateHighContrastColorScheme();
-  return g_is_high_contract_color_scheme;
 }
 
 std::string hexColorDWORDToRGBA(DWORD color) {
@@ -188,9 +170,6 @@ LRESULT CALLBACK SystemPreferences::WndProc(HWND hwnd,
       Emit("accent-color-changed", hexColorDWORDToRGBA(new_color));
       current_color_ = new_color_string;
     }
-  } else if (message == WM_SYSCOLORCHANGE ||
-             (message == WM_SETTINGCHANGE && wparam == SPI_SETHIGHCONTRAST)) {
-    UpdateHighContrastColorScheme();
   }
   return ::DefWindowProc(hwnd, message, wparam, lparam);
 }


### PR DESCRIPTION
#### Description of Change
This PR removes our custom high contrast color scheme detection in favor of Chromium's `NativeTheme` API. 

As a happy side effect, `systemPreferences.isHighContrastColorScheme()` will now be available on macOS as well.

cc @deepak1556 @erickzhao 

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added support for `systemPreferences.isHighContrastColorScheme()` API on macOS.