### PR TITLE
docs: update Electron Packager links

### DIFF
--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -360,7 +360,7 @@ Please note that until Electron is built targeting the 10.14 SDK, your applicati
 the interim in order for your application to inherit the OS preference you must set the
 `NSRequiresAquaSystemAppearance` key in your apps `Info.plist` to `false`.  If you are
 using `electron-packager` or `electron-forge` just set the `enableDarwinDarkMode`
-packager option to `true`.  See the [Electron Packager API](https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#darwindarkmodesupport)
+packager option to `true`.  See the [Electron Packager API](https://github.com/electron/electron-packager/blob/master/docs/api.md#darwindarkmodesupport)
 for more details.
 
 ### `systemPreferences.getAppLevelAppearance()` _macOS_

--- a/docs/tutorial/application-distribution.md
+++ b/docs/tutorial/application-distribution.md
@@ -4,7 +4,7 @@ To distribute your app with Electron, you need to package and rebrand it. The ea
 
 * [electron-forge](https://github.com/electron-userland/electron-forge)
 * [electron-builder](https://github.com/electron-userland/electron-builder)
-* [electron-packager](https://github.com/electron-userland/electron-packager)
+* [electron-packager](https://github.com/electron/electron-packager)
 
 These tools will take care of all the steps you need to take to end up with a distributable Electron applications, such as packaging your application, rebranding the executable, setting the right icons and optionally creating installers.
 

--- a/docs/tutorial/application-packaging.md
+++ b/docs/tutorial/application-packaging.md
@@ -189,7 +189,7 @@ was created together with the `app.asar` file. It contains the unpacked files
 and should be shipped together with the `app.asar` archive.
 
 [asar]: https://github.com/electron/asar
-[electron-packager]: https://github.com/electron-userland/electron-packager
+[electron-packager]: https://github.com/electron/electron-packager
 [electron-forge]: https://github.com/electron-userland/electron-forge
 [electron-builder]: https://github.com/electron-userland/electron-builder
 

--- a/docs/tutorial/boilerplates-and-clis.md
+++ b/docs/tutorial/boilerplates-and-clis.md
@@ -33,7 +33,7 @@ development.
 
 Forge comes with [ready-to-use templates](https://electronforge.io/templates) for popular
 frameworks like React, Vue, or Angular. It uses the same core modules used by the
-greater Electron community (like [`electron-packager`](https://github.com/electron-userland/electron-packager)) – 
+greater Electron community (like [`electron-packager`](https://github.com/electron/electron-packager)) – 
 changes made by Electron maintainers (like Slack) benefit Forge's users, too.
 
 You can find more information and documentation on [electronforge.io](https://electronforge.io/).

--- a/docs/tutorial/code-signing.md
+++ b/docs/tutorial/code-signing.md
@@ -69,7 +69,7 @@ See the [Windows Store Guide].
 [`electron-builder`]: https://github.com/electron-userland/electron-builder
 [`electron-forge`]: https://github.com/electron-userland/electron-forge
 [`electron-osx-sign`]: https://github.com/electron-userland/electron-osx-sign
-[`electron-packager`]: https://github.com/electron-userland/electron-packager
+[`electron-packager`]: https://github.com/electron/electron-packager
 [`electron-winstaller`]: https://github.com/electron/windows-installer
 [Xcode]: https://developer.apple.com/xcode
 [signing certificates]: https://github.com/electron-userland/electron-osx-sign/wiki/1.-Getting-Started#certificates

--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -266,7 +266,7 @@ Electron uses following cryptographic algorithms:
 [enable-app-sandbox]: https://developer.apple.com/library/ios/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/EnablingAppSandbox.html
 [create-record]: https://developer.apple.com/library/ios/documentation/LanguagesUtilities/Conceptual/iTunesConnect_Guide/Chapters/CreatingiTunesConnectRecord.html
 [electron-osx-sign]: https://github.com/electron-userland/electron-osx-sign
-[electron-packager]: https://github.com/electron-userland/electron-packager
+[electron-packager]: https://github.com/electron/electron-packager
 [submit-for-review]: https://developer.apple.com/library/ios/documentation/LanguagesUtilities/Conceptual/iTunesConnect_Guide/Chapters/SubmittingTheApp.html
 [app-sandboxing]: https://developer.apple.com/app-sandboxing/
 [export-compliance]: https://help.apple.com/app-store-connect/#/devc3f64248f

--- a/docs/tutorial/snapcraft.md
+++ b/docs/tutorial/snapcraft.md
@@ -177,7 +177,7 @@ apps:
 [snapcraft.io]: https://snapcraft.io/
 [snapcraft-store]: https://snapcraft.io/store/
 [snapcraft-syntax]: https://docs.snapcraft.io/build-snaps/syntax
-[electron-packager]: https://github.com/electron-userland/electron-packager
+[electron-packager]: https://github.com/electron/electron-packager
 [electron-forge]: https://github.com/electron-userland/electron-forge
 [electron-builder]: https://github.com/electron-userland/electron-builder
 [electron-installer-debian]: https://github.com/unindented/electron-installer-debian

--- a/docs/tutorial/windows-store-guide.md
+++ b/docs/tutorial/windows-store-guide.md
@@ -152,7 +152,7 @@ Once installation succeeded, you can move on to compiling your Electron app.
 [windows-sdk]: https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk
 [app-converter]: https://docs.microsoft.com/en-us/windows/uwp/porting/desktop-to-uwp-run-desktop-app-converter
 [add-appxpackage]: https://technet.microsoft.com/en-us/library/hh856048.aspx
-[electron-packager]: https://github.com/electron-userland/electron-packager
+[electron-packager]: https://github.com/electron/electron-packager
 [electron-windows-store]: https://github.com/catalystcode/electron-windows-store
 [background-task]: https://github.com/felixrieseberg/electron-uwp-background
 [centennial-campaigns]: https://developer.microsoft.com/en-us/windows/projects/campaigns/desktop-bridge


### PR DESCRIPTION
#### Description of Change

Update the links to Electron Packager in the docs, since it moved orgs.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
