### PR TITLE
fix: throw on invalid webRequest filters

### DIFF
--- a/docs/api/web-request.md
+++ b/docs/api/web-request.md
@@ -68,6 +68,21 @@ The `uploadData` is an array of `UploadData` objects.
 
 The `callback` has to be called with an `response` object.
 
+Some examples of valid `urls`:
+
+```js
+'http://foo:1234/'
+'http://foo.com/'
+'http://foo:1234/bar'
+'*://*/*'
+'*://example.com/*'
+'*://example.com/foo/*'
+'http://*.foo:1234/'
+'file://foo:1234/bar'
+'http://foo:*/'
+'*://www.foo.com/'
+```
+
 #### `webRequest.onBeforeSendHeaders([filter, ]listener)`
 
 * `filter` Object (optional)

--- a/native_mate/native_mate/dictionary.h
+++ b/native_mate/native_mate/dictionary.h
@@ -40,6 +40,16 @@ class Dictionary {
 
   static Dictionary CreateEmpty(v8::Isolate* isolate);
 
+  bool HasKey(const base::StringPiece& key) const {
+    v8::Local<v8::Context> context = isolate_->GetCurrentContext();
+    v8::Local<v8::String> v8_key = StringToV8(isolate_, key);
+    if (!internal::IsTrue(GetHandle()->Has(context, v8_key)))
+      return false;
+
+    v8::Local<v8::Value> val;
+    return GetHandle()->Get(context, v8_key).ToLocal(&val);
+  }
+
   template <typename T>
   bool Get(const base::StringPiece& key, T* out) const {
     // Check for existence before getting, otherwise this method will always

--- a/native_mate/native_mate/dictionary.h
+++ b/native_mate/native_mate/dictionary.h
@@ -40,16 +40,6 @@ class Dictionary {
 
   static Dictionary CreateEmpty(v8::Isolate* isolate);
 
-  bool HasKey(const base::StringPiece& key) const {
-    v8::Local<v8::Context> context = isolate_->GetCurrentContext();
-    v8::Local<v8::String> v8_key = StringToV8(isolate_, key);
-    if (!internal::IsTrue(GetHandle()->Has(context, v8_key)))
-      return false;
-
-    v8::Local<v8::Value> val;
-    return GetHandle()->Get(context, v8_key).ToLocal(&val);
-  }
-
   template <typename T>
   bool Get(const base::StringPiece& key, T* out) const {
     // Check for existence before getting, otherwise this method will always

--- a/shell/browser/api/atom_api_web_request.cc
+++ b/shell/browser/api/atom_api_web_request.cc
@@ -80,7 +80,7 @@ void WebRequest::SetListener(Method method, Event type, mate::Arguments* args) {
           patterns.insert(pattern);
         } else {
           std::string error_type = URLPattern::GetParseResultString(success);
-          args->ThrowError("Invalid pattern for url " + filter_pattern + ": " +
+          args->ThrowError("Invalid url pattern " + filter_pattern + ": " +
                            error_type);
         }
       }

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -636,10 +636,17 @@ describe('net module', () => {
       it('Should throw when invalid filters are passed', () => {
         expect(() => {
           session.defaultSession.webRequest.onBeforeRequest(
-            { urls: ['*://www.googleapis.com' ] },
+            { urls: ['*://www.googleapis.com'] },
             (details, callback) => { callback({ cancel: false }) }
           )
         }).to.throw('Invalid url pattern *://www.googleapis.com: Empty path.')
+
+        expect(() => {
+          session.defaultSession.webRequest.onBeforeRequest(
+            { urls: [ '*://www.googleapis.com/', '*://blahblah.dev' ] },
+            (details, callback) => { callback({ cancel: false }) }
+          )
+        }).to.throw('Invalid url pattern *://blahblah.dev: Empty path.')
       })
 
       it('Should not throw when valid filters are passed', () => {

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -633,6 +633,24 @@ describe('net module', () => {
         session.defaultSession.webRequest.onBeforeRequest(null)
       })
 
+      it('Should throw when invalid filters are passed', () => {
+        expect(() => {
+          session.defaultSession.webRequest.onBeforeRequest(
+            { urls: ['*://www.googleapis.com' ] },
+            (details, callback) => { callback({ cancel: false }) }
+          )
+        }).to.throw('Invalid url pattern *://www.googleapis.com: Empty path.')
+      })
+
+      it('Should not throw when valid filters are passed', () => {
+        expect(() => {
+          session.defaultSession.webRequest.onBeforeRequest(
+            { urls: ['*://www.googleapis.com/'] },
+            (details, callback) => { callback({ cancel: false }) }
+          )
+        }).to.not.throw()
+      })
+
       it('Requests should be intercepted by webRequest module', (done) => {
         const requestUrl = '/requestUrl'
         const redirectUrl = '/redirectUrl'


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/11371.

Previously, we didn't consider the return value of the `webRequest` `URLPattern` mate converter, which meant that when the pattern wasn't correctly parsed owing to invalid filter specification users would not be made aware of that fact and would just think that the filtering itself had failed. This corrects that error by moving the business logic of url pattern parsing out of the converter and into the function itself so that granular and specific errors can be thrown.

There's also no real reason that i'm aware of not to allow wider breadth of filters by letting users use a wildcard for effective TLD, so I also overrode that (default for the 1-arg `Parse` is not to allow that).

Finally, I added some examples of url filter types for users to reference.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed error throwing on invalid `webRequest` url pattern filtering in `onBeforeRequest`.
