### PR TITLE
feat: migrate webRequest module to NetworkService (Part 2)

### DIFF
--- a/shell/browser/atom_browser_client.cc
+++ b/shell/browser/atom_browser_client.cc
@@ -998,9 +998,16 @@ bool AtomBrowserClient::WillCreateURLLoaderFactory(
   auto proxied_request = std::move(*factory_request);
   network::mojom::URLLoaderFactoryPtrInfo target_factory_info;
   *factory_request = mojo::MakeRequest(&target_factory_info);
-  new ProxyingURLLoaderFactory(protocol->intercept_handlers(),
-                               std::move(proxied_request),
-                               std::move(target_factory_info));
+
+  network::mojom::TrustedURLLoaderHeaderClientRequest header_client_request;
+  if (header_client)
+    header_client_request = mojo::MakeRequest(header_client);
+
+  new ProxyingURLLoaderFactory(
+      protocol->intercept_handlers(), std::move(proxied_request),
+      std::move(target_factory_info), std::move(header_client_request));
+
+  *bypass_redirect_checks = true;
   return true;
 }
 

--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -241,7 +241,8 @@ void ProxyingURLLoaderFactory::InProgressRequest::OnComplete(
   target_client_->OnComplete(status);
   // TODO(zcbenz): Call webRequest.onCompleted.
 
-  // TODO(zcbenz): Deletes |this|.
+  // TODO(zcbenz): Disassociate from factory.
+  delete this;
 }
 
 void ProxyingURLLoaderFactory::InProgressRequest::OnLoaderCreated(
@@ -611,7 +612,8 @@ void ProxyingURLLoaderFactory::InProgressRequest::OnRequestError(
     // TODO(zcbenz): Call webRequest.onErrorOccurred.
   }
 
-  // TODO(zcbenz): Deletes |this|.
+  // TODO(zcbenz): Disassociate from factory.
+  delete this;
 }
 
 ProxyingURLLoaderFactory::ProxyingURLLoaderFactory(
@@ -665,6 +667,8 @@ void ProxyingURLLoaderFactory::CreateLoaderAndStart(
   target_factory_->CreateLoaderAndStart(std::move(loader), routing_id,
                                         request_id, options, request,
                                         std::move(client), traffic_annotation);
+
+  // TODO(zcbenz): Create InProgressRequest.
 }
 
 void ProxyingURLLoaderFactory::Clone(

--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -7,22 +7,213 @@
 #include <utility>
 
 #include "mojo/public/cpp/bindings/binding.h"
-#include "services/network/public/mojom/url_loader.mojom.h"
 #include "shell/browser/net/asar/asar_url_loader.h"
 
 namespace electron {
 
+ProxyingURLLoaderFactory::InProgressRequest::FollowRedirectParams::
+    FollowRedirectParams() = default;
+ProxyingURLLoaderFactory::InProgressRequest::FollowRedirectParams::
+    ~FollowRedirectParams() = default;
+
+ProxyingURLLoaderFactory::InProgressRequest::InProgressRequest(
+    ProxyingURLLoaderFactory* factory,
+    // int32_t routing_id,
+    int32_t network_service_request_id,
+    // uint32_t options,
+    const network::ResourceRequest& request,
+    const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
+    network::mojom::URLLoaderRequest loader_request,
+    network::mojom::URLLoaderClientPtr client)
+    : factory_(factory),
+      request_(request),
+      original_initiator_(request.request_initiator),
+      // routing_id_(routing_id),
+      network_service_request_id_(network_service_request_id),
+      // options_(options),
+      traffic_annotation_(traffic_annotation),
+      proxied_loader_binding_(this, std::move(loader_request)),
+      target_client_(std::move(client)),
+      proxied_client_binding_(this),
+      // TODO(zcbenz): We should always use "extraHeaders" mode to be compatible
+      // with old APIs.
+      // has_any_extra_headers_listeners_(false),
+      header_client_binding_(this) {
+  // If there is a client error, clean up the request.
+  target_client_.set_connection_error_handler(base::BindOnce(
+      &ProxyingURLLoaderFactory::InProgressRequest::OnRequestError,
+      weak_factory_.GetWeakPtr(),
+      network::URLLoaderCompletionStatus(net::ERR_ABORTED)));
+}
+
+ProxyingURLLoaderFactory::InProgressRequest::~InProgressRequest() {}
+
+void ProxyingURLLoaderFactory::InProgressRequest::Restart() {
+  UpdateRequestInfo();
+  RestartInternal();
+}
+
+void ProxyingURLLoaderFactory::InProgressRequest::UpdateRequestInfo() {
+  current_request_uses_header_client_ =
+      factory_->url_loader_header_client_binding_ &&
+      request_.url.SchemeIsHTTPOrHTTPS() && network_service_request_id_ != 0 &&
+      false /* HasExtraHeadersListenerForRequest */;
+}
+
+void ProxyingURLLoaderFactory::InProgressRequest::RestartInternal() {
+  // TODO(zcbenz): Implement me.
+}
+
+void ProxyingURLLoaderFactory::InProgressRequest::FollowRedirect(
+    const std::vector<std::string>& removed_headers,
+    const net::HttpRequestHeaders& modified_headers,
+    const base::Optional<GURL>& new_url) {
+  if (new_url)
+    request_.url = new_url.value();
+
+  for (const std::string& header : removed_headers)
+    request_.headers.RemoveHeader(header);
+  request_.headers.MergeFrom(modified_headers);
+
+  // Call this before checking |current_request_uses_header_client_| as it
+  // calculates it.
+  UpdateRequestInfo();
+
+  if (target_loader_.is_bound()) {
+    // If header_client_ is used, then we have to call FollowRedirect now as
+    // that's what triggers the network service calling back to
+    // OnBeforeSendHeaders(). Otherwise, don't call FollowRedirect now. Wait for
+    // the onBeforeSendHeaders callback(s) to run as these may modify request
+    // headers and if so we'll pass these modifications to FollowRedirect.
+    if (current_request_uses_header_client_) {
+      target_loader_->FollowRedirect(removed_headers, modified_headers,
+                                     new_url);
+    } else {
+      auto params = std::make_unique<FollowRedirectParams>();
+      params->removed_headers = removed_headers;
+      params->modified_headers = modified_headers;
+      params->new_url = new_url;
+      pending_follow_redirect_params_ = std::move(params);
+    }
+  }
+
+  RestartInternal();
+}
+
+void ProxyingURLLoaderFactory::InProgressRequest::ProceedWithResponse() {
+  if (target_loader_.is_bound())
+    target_loader_->ProceedWithResponse();
+}
+
+void ProxyingURLLoaderFactory::InProgressRequest::SetPriority(
+    net::RequestPriority priority,
+    int32_t intra_priority_value) {
+  if (target_loader_.is_bound())
+    target_loader_->SetPriority(priority, intra_priority_value);
+}
+
+void ProxyingURLLoaderFactory::InProgressRequest::PauseReadingBodyFromNet() {
+  if (target_loader_.is_bound())
+    target_loader_->PauseReadingBodyFromNet();
+}
+
+void ProxyingURLLoaderFactory::InProgressRequest::ResumeReadingBodyFromNet() {
+  if (target_loader_.is_bound())
+    target_loader_->ResumeReadingBodyFromNet();
+}
+
+void ProxyingURLLoaderFactory::InProgressRequest::OnReceiveResponse(
+    const network::ResourceResponseHead& head) {
+  // TODO(zcbenz): Implement me.
+}
+
+void ProxyingURLLoaderFactory::InProgressRequest::OnReceiveRedirect(
+    const net::RedirectInfo& redirect_info,
+    const network::ResourceResponseHead& head) {
+  // TODO(zcbenz): Implement me.
+}
+
+void ProxyingURLLoaderFactory::InProgressRequest::OnUploadProgress(
+    int64_t current_position,
+    int64_t total_size,
+    OnUploadProgressCallback callback) {
+  target_client_->OnUploadProgress(current_position, total_size,
+                                   std::move(callback));
+}
+
+void ProxyingURLLoaderFactory::InProgressRequest::OnReceiveCachedMetadata(
+    mojo_base::BigBuffer data) {
+  target_client_->OnReceiveCachedMetadata(std::move(data));
+}
+
+void ProxyingURLLoaderFactory::InProgressRequest::OnTransferSizeUpdated(
+    int32_t transfer_size_diff) {
+  target_client_->OnTransferSizeUpdated(transfer_size_diff);
+}
+
+void ProxyingURLLoaderFactory::InProgressRequest::OnStartLoadingResponseBody(
+    mojo::ScopedDataPipeConsumerHandle body) {
+  target_client_->OnStartLoadingResponseBody(std::move(body));
+}
+
+void ProxyingURLLoaderFactory::InProgressRequest::OnComplete(
+    const network::URLLoaderCompletionStatus& status) {
+  // TODO(zcbenz): Implement me.
+}
+
+void ProxyingURLLoaderFactory::InProgressRequest::OnLoaderCreated(
+    network::mojom::TrustedHeaderClientRequest request) {
+  header_client_binding_.Bind(std::move(request));
+}
+
+void ProxyingURLLoaderFactory::InProgressRequest::OnBeforeSendHeaders(
+    const net::HttpRequestHeaders& headers,
+    OnBeforeSendHeadersCallback callback) {
+  if (!current_request_uses_header_client_) {
+    std::move(callback).Run(net::OK, base::nullopt);
+    return;
+  }
+
+  // TODO(zcbenz): Implement me.
+}
+
+void ProxyingURLLoaderFactory::InProgressRequest::OnHeadersReceived(
+    const std::string& headers,
+    OnHeadersReceivedCallback callback) {
+  if (!current_request_uses_header_client_) {
+    std::move(callback).Run(net::OK, base::nullopt, GURL());
+    return;
+  }
+
+  // TODO(zcbenz): Implement me.
+}
+
+void ProxyingURLLoaderFactory::InProgressRequest::OnRequestError(
+    const network::URLLoaderCompletionStatus& status) {
+  if (!request_completed_) {
+    target_client_->OnComplete(status);
+    // TODO(zcbenz): Report error.
+  }
+
+  // TODO(zcbenz): Deletes |this|.
+}
+
 ProxyingURLLoaderFactory::ProxyingURLLoaderFactory(
     const HandlersMap& intercepted_handlers,
     network::mojom::URLLoaderFactoryRequest loader_request,
-    network::mojom::URLLoaderFactoryPtrInfo target_factory_info)
-    : intercepted_handlers_(intercepted_handlers) {
+    network::mojom::URLLoaderFactoryPtrInfo target_factory_info,
+    network::mojom::TrustedURLLoaderHeaderClientRequest header_client_request)
+    : intercepted_handlers_(intercepted_handlers),
+      url_loader_header_client_binding_(this) {
   target_factory_.Bind(std::move(target_factory_info));
   target_factory_.set_connection_error_handler(base::BindOnce(
       &ProxyingURLLoaderFactory::OnTargetFactoryError, base::Unretained(this)));
   proxy_bindings_.AddBinding(this, std::move(loader_request));
   proxy_bindings_.set_connection_error_handler(base::BindRepeating(
       &ProxyingURLLoaderFactory::OnProxyBindingError, base::Unretained(this)));
+
+  if (header_client_request)
+    url_loader_header_client_binding_.Bind(std::move(header_client_request));
 }
 
 ProxyingURLLoaderFactory::~ProxyingURLLoaderFactory() = default;
@@ -63,6 +254,12 @@ void ProxyingURLLoaderFactory::CreateLoaderAndStart(
 void ProxyingURLLoaderFactory::Clone(
     network::mojom::URLLoaderFactoryRequest loader_request) {
   proxy_bindings_.AddBinding(this, std::move(loader_request));
+}
+
+void ProxyingURLLoaderFactory::OnLoaderCreated(
+    int32_t request_id,
+    network::mojom::TrustedHeaderClientRequest request) {
+  // TODO(zcbenz): Call |OnLoaderCreated| for |InProgressRequest|.
 }
 
 void ProxyingURLLoaderFactory::OnTargetFactoryError() {

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -5,6 +5,11 @@
 #ifndef SHELL_BROWSER_NET_PROXYING_URL_LOADER_FACTORY_H_
 #define SHELL_BROWSER_NET_PROXYING_URL_LOADER_FACTORY_H_
 
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
 #include "base/optional.h"
 #include "services/network/public/cpp/resource_request.h"
 #include "services/network/public/cpp/resource_response.h"
@@ -14,6 +19,12 @@
 
 namespace electron {
 
+// This class is responsible for following tasks when NetworkService is enabled:
+// 1. handling intercepted protocols;
+// 2. implementing webRequest module;
+//
+// For the task #2, the code is referenced from the
+// extensions::WebRequestProxyingURLLoaderFactory class.
 class ProxyingURLLoaderFactory
     : public network::mojom::URLLoaderFactory,
       public network::mojom::TrustedURLLoaderHeaderClient {

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -77,6 +77,7 @@ class ProxyingURLLoaderFactory
                                int error_code);
     void ContinueToStartRequest(int error_code);
     void ContinueToHandleOverrideHeaders(int error_code);
+    void ContinueToResponseStarted(int error_code);
     void ContinueToBeforeRedirect(const net::RedirectInfo& redirect_info,
                                   int error_code);
     void HandleBeforeRequestRedirect();

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -12,7 +12,7 @@ namespace electron {
 class ProxyingURLLoaderFactory : public network::mojom::URLLoaderFactory {
  public:
   ProxyingURLLoaderFactory(
-      const HandlersMap& handlers,
+      const HandlersMap& intercepted_handlers,
       network::mojom::URLLoaderFactoryRequest loader_request,
       network::mojom::URLLoaderFactoryPtrInfo target_factory_info);
   ~ProxyingURLLoaderFactory() override;
@@ -39,7 +39,7 @@ class ProxyingURLLoaderFactory : public network::mojom::URLLoaderFactory {
   // reference is guarenteed to be valid.
   //
   // In this way we can avoid using code from api namespace in this file.
-  const HandlersMap& handlers_;
+  const HandlersMap& intercepted_handlers_;
 
   mojo::BindingSet<network::mojom::URLLoaderFactory> proxy_bindings_;
   network::mojom::URLLoaderFactoryPtr target_factory_;

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -5,16 +5,127 @@
 #ifndef SHELL_BROWSER_NET_PROXYING_URL_LOADER_FACTORY_H_
 #define SHELL_BROWSER_NET_PROXYING_URL_LOADER_FACTORY_H_
 
+#include "base/optional.h"
+#include "services/network/public/cpp/resource_request.h"
+#include "services/network/public/cpp/resource_response.h"
+#include "services/network/public/mojom/network_context.mojom.h"
+#include "services/network/public/mojom/url_loader.mojom.h"
 #include "shell/browser/net/atom_url_loader_factory.h"
 
 namespace electron {
 
-class ProxyingURLLoaderFactory : public network::mojom::URLLoaderFactory {
+class ProxyingURLLoaderFactory
+    : public network::mojom::URLLoaderFactory,
+      public network::mojom::TrustedURLLoaderHeaderClient {
  public:
+  class InProgressRequest : public network::mojom::URLLoader,
+                            public network::mojom::URLLoaderClient,
+                            public network::mojom::TrustedHeaderClient {
+   public:
+    InProgressRequest(
+        ProxyingURLLoaderFactory* factory,
+        // int32_t routing_id,
+        int32_t network_service_request_id,
+        // uint32_t options,
+        const network::ResourceRequest& request,
+        const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
+        network::mojom::URLLoaderRequest loader_request,
+        network::mojom::URLLoaderClientPtr client);
+    ~InProgressRequest() override;
+
+    void Restart();
+
+    // network::mojom::URLLoader:
+    void FollowRedirect(const std::vector<std::string>& removed_headers,
+                        const net::HttpRequestHeaders& modified_headers,
+                        const base::Optional<GURL>& new_url) override;
+    void ProceedWithResponse() override;
+    void SetPriority(net::RequestPriority priority,
+                     int32_t intra_priority_value) override;
+    void PauseReadingBodyFromNet() override;
+    void ResumeReadingBodyFromNet() override;
+
+    // network::mojom::URLLoaderClient:
+    void OnReceiveResponse(const network::ResourceResponseHead& head) override;
+    void OnReceiveRedirect(const net::RedirectInfo& redirect_info,
+                           const network::ResourceResponseHead& head) override;
+    void OnUploadProgress(int64_t current_position,
+                          int64_t total_size,
+                          OnUploadProgressCallback callback) override;
+    void OnReceiveCachedMetadata(mojo_base::BigBuffer data) override;
+    void OnTransferSizeUpdated(int32_t transfer_size_diff) override;
+    void OnStartLoadingResponseBody(
+        mojo::ScopedDataPipeConsumerHandle body) override;
+    void OnComplete(const network::URLLoaderCompletionStatus& status) override;
+
+    void OnLoaderCreated(network::mojom::TrustedHeaderClientRequest request);
+
+    // network::mojom::TrustedHeaderClient:
+    void OnBeforeSendHeaders(const net::HttpRequestHeaders& headers,
+                             OnBeforeSendHeadersCallback callback) override;
+    void OnHeadersReceived(const std::string& headers,
+                           OnHeadersReceivedCallback callback) override;
+
+   private:
+    // These two methods combined form the implementation of Restart().
+    void UpdateRequestInfo();
+    void RestartInternal();
+
+    void OnRequestError(const network::URLLoaderCompletionStatus& status);
+
+    ProxyingURLLoaderFactory* factory_;
+    network::ResourceRequest request_;
+    const base::Optional<url::Origin> original_initiator_;
+    // const int32_t routing_id_;
+    const int32_t network_service_request_id_;
+    // const uint32_t options_;
+    const net::MutableNetworkTrafficAnnotationTag traffic_annotation_;
+    mojo::Binding<network::mojom::URLLoader> proxied_loader_binding_;
+    network::mojom::URLLoaderClientPtr target_client_;
+
+    mojo::Binding<network::mojom::URLLoaderClient> proxied_client_binding_;
+    network::mojom::URLLoaderPtr target_loader_;
+
+    bool request_completed_ = false;
+
+    // If |has_any_extra_headers_listeners_| is set to true, the request will be
+    // sent with the network::mojom::kURLLoadOptionUseHeaderClient option, and
+    // we expect events to come through the
+    // network::mojom::TrustedURLLoaderHeaderClient binding on the factory. This
+    // is only set to true if there is a listener that needs to view or modify
+    // headers set in the network process.
+    // bool has_any_extra_headers_listeners_ = false;
+    bool current_request_uses_header_client_ = false;
+    // OnBeforeSendHeadersCallback on_before_send_headers_callback_;
+    // OnHeadersReceivedCallback on_headers_received_callback_;
+    mojo::Binding<network::mojom::TrustedHeaderClient> header_client_binding_;
+
+    // If |has_any_extra_headers_listeners_| is set to false and a redirect is
+    // in progress, this stores the parameters to FollowRedirect that came from
+    // the client. That way we can combine it with any other changes that
+    // extensions made to headers in their callbacks.
+    struct FollowRedirectParams {
+      FollowRedirectParams();
+      ~FollowRedirectParams();
+      std::vector<std::string> removed_headers;
+      net::HttpRequestHeaders modified_headers;
+      base::Optional<GURL> new_url;
+
+      DISALLOW_COPY_AND_ASSIGN(FollowRedirectParams);
+    };
+    std::unique_ptr<FollowRedirectParams> pending_follow_redirect_params_;
+
+    base::WeakPtrFactory<InProgressRequest> weak_factory_{this};
+
+    DISALLOW_COPY_AND_ASSIGN(InProgressRequest);
+  };
+
   ProxyingURLLoaderFactory(
       const HandlersMap& intercepted_handlers,
       network::mojom::URLLoaderFactoryRequest loader_request,
-      network::mojom::URLLoaderFactoryPtrInfo target_factory_info);
+      network::mojom::URLLoaderFactoryPtrInfo target_factory_info,
+      network::mojom::TrustedURLLoaderHeaderClientRequest
+          header_client_request);
   ~ProxyingURLLoaderFactory() override;
 
   // network::mojom::URLLoaderFactory:
@@ -27,6 +138,11 @@ class ProxyingURLLoaderFactory : public network::mojom::URLLoaderFactory {
                             const net::MutableNetworkTrafficAnnotationTag&
                                 traffic_annotation) override;
   void Clone(network::mojom::URLLoaderFactoryRequest request) override;
+
+  // network::mojom::TrustedURLLoaderHeaderClient:
+  void OnLoaderCreated(
+      int32_t request_id,
+      network::mojom::TrustedHeaderClientRequest request) override;
 
  private:
   void OnTargetFactoryError();
@@ -43,6 +159,8 @@ class ProxyingURLLoaderFactory : public network::mojom::URLLoaderFactory {
 
   mojo::BindingSet<network::mojom::URLLoaderFactory> proxy_bindings_;
   network::mojom::URLLoaderFactoryPtr target_factory_;
+  mojo::Binding<network::mojom::TrustedURLLoaderHeaderClient>
+      url_loader_header_client_binding_;
 
   DISALLOW_COPY_AND_ASSIGN(ProxyingURLLoaderFactory);
 };

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -24,9 +24,9 @@ class ProxyingURLLoaderFactory
    public:
     InProgressRequest(
         ProxyingURLLoaderFactory* factory,
-        // int32_t routing_id,
+        int32_t routing_id,
         int32_t network_service_request_id,
-        // uint32_t options,
+        uint32_t options,
         const network::ResourceRequest& request,
         const net::MutableNetworkTrafficAnnotationTag& traffic_annotation,
         network::mojom::URLLoaderRequest loader_request,
@@ -71,14 +71,19 @@ class ProxyingURLLoaderFactory
     void UpdateRequestInfo();
     void RestartInternal();
 
+    void ContinueToBeforeSendHeaders(int error_code);
+    void ContinueToSendHeaders(const std::set<std::string>& removed_headers,
+                               const std::set<std::string>& set_headers,
+                               int error_code);
+    void ContinueToStartRequest(int error_code);
     void OnRequestError(const network::URLLoaderCompletionStatus& status);
 
     ProxyingURLLoaderFactory* factory_;
     network::ResourceRequest request_;
     const base::Optional<url::Origin> original_initiator_;
-    // const int32_t routing_id_;
+    const int32_t routing_id_;
     const int32_t network_service_request_id_;
-    // const uint32_t options_;
+    const uint32_t options_;
     const net::MutableNetworkTrafficAnnotationTag traffic_annotation_;
     mojo::Binding<network::mojom::URLLoader> proxied_loader_binding_;
     network::mojom::URLLoaderClientPtr target_client_;
@@ -94,10 +99,10 @@ class ProxyingURLLoaderFactory
     // network::mojom::TrustedURLLoaderHeaderClient binding on the factory. This
     // is only set to true if there is a listener that needs to view or modify
     // headers set in the network process.
-    // bool has_any_extra_headers_listeners_ = false;
+    bool has_any_extra_headers_listeners_ = false;
     bool current_request_uses_header_client_ = false;
-    // OnBeforeSendHeadersCallback on_before_send_headers_callback_;
-    // OnHeadersReceivedCallback on_headers_received_callback_;
+    OnBeforeSendHeadersCallback on_before_send_headers_callback_;
+    OnHeadersReceivedCallback on_headers_received_callback_;
     mojo::Binding<network::mojom::TrustedHeaderClient> header_client_binding_;
 
     // If |has_any_extra_headers_listeners_| is set to false and a redirect is

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -76,6 +76,12 @@ class ProxyingURLLoaderFactory
                                const std::set<std::string>& set_headers,
                                int error_code);
     void ContinueToStartRequest(int error_code);
+    void ContinueToHandleOverrideHeaders(int error_code);
+    void ContinueToBeforeRedirect(const net::RedirectInfo& redirect_info,
+                                  int error_code);
+    void HandleBeforeRequestRedirect();
+    void HandleResponseOrRedirectHeaders(
+        net::CompletionOnceCallback continuation);
     void OnRequestError(const network::URLLoaderCompletionStatus& status);
 
     ProxyingURLLoaderFactory* factory_;
@@ -87,6 +93,10 @@ class ProxyingURLLoaderFactory
     const net::MutableNetworkTrafficAnnotationTag traffic_annotation_;
     mojo::Binding<network::mojom::URLLoader> proxied_loader_binding_;
     network::mojom::URLLoaderClientPtr target_client_;
+
+    network::ResourceResponseHead current_response_;
+    scoped_refptr<net::HttpResponseHeaders> override_headers_;
+    GURL redirect_url_;
 
     mojo::Binding<network::mojom::URLLoaderClient> proxied_client_binding_;
     network::mojom::URLLoaderPtr target_loader_;


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/15791.

This PR implements `InProgressRequest`, which can hijack URL loader requests and provide hooks for events. The code is referenced from `extensions::WebRequestProxyingURLLoaderFactory`.

Note that currently `InProgressRequest` is not being used, and existing behaviors are not affected. The migration will be done with following steps:
1. implement the JS `webRequest` APIs;
2. connect JS `webRequest` APIs to `InProgressRequest`;
3. actually hijack the URL loader requests with `InProgressRequest`. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes