### PR TITLE
docs: improve EventEmitter md formatting

### DIFF
--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -6,6 +6,8 @@ Process: [Main](../glossary.md#main-process)
 
 **See also: [A detailed guide about how to implement updates in your application](../tutorial/updates.md).**
 
+`autoUpdater` is an [EventEmitter][event-emitter].
+
 ## Platform Notices
 
 Currently, only macOS and Windows are supported. There is no built-in support
@@ -136,3 +138,4 @@ application starts.
 [installer-lib]: https://github.com/electron/windows-installer
 [electron-forge-lib]: https://github.com/electron-userland/electron-forge
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
+[event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -131,8 +131,7 @@ state is `hidden` in order to minimize power consumption.
 
 Process: [Main](../glossary.md#main-process)
 
-`BrowserWindow` is an
-[EventEmitter](https://nodejs.org/api/events.html#events_class_events_eventemitter).
+`BrowserWindow` is an [EventEmitter][event-emitter].
 
 It creates a new `BrowserWindow` with native properties as set by the `options`.
 
@@ -1737,3 +1736,4 @@ removed in future Electron releases.
 [vibrancy-docs]: https://developer.apple.com/documentation/appkit/nsvisualeffectview?preferredLanguage=objc
 [window-levels]: https://developer.apple.com/documentation/appkit/nswindow/level
 [chrome-content-scripts]: https://developer.chrome.com/extensions/content_scripts#execution-environment
+[event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter

--- a/docs/api/client-request.md
+++ b/docs/api/client-request.md
@@ -5,7 +5,7 @@
 Process: [Main](../glossary.md#main-process)
 
 `ClientRequest` implements the [Writable Stream](https://nodejs.org/api/stream.html#stream_writable_streams)
-interface and is therefore an [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter).
+interface and is therefore an [EventEmitter][event-emitter].
 
 ### `new ClientRequest(options)`
 
@@ -229,3 +229,5 @@ no other properties will be set
 
 You can use this method in conjunction with `POST` requests to get the progress
 of a file upload or other data transfer.
+
+[event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter

--- a/docs/api/download-item.md
+++ b/docs/api/download-item.md
@@ -4,7 +4,7 @@
 
 Process: [Main](../glossary.md#main-process)
 
-`DownloadItem` is an `EventEmitter` that represents a download item in Electron.
+`DownloadItem` is an [EventEmitter][event-emitter] that represents a download item in Electron.
 It is used in `will-download` event of `Session` class, and allows users to
 control the download item.
 
@@ -195,3 +195,5 @@ A `String` property that determines the save file path of the download item.
 The property is only available in session's `will-download` callback function.
 If user doesn't set the save path via the property, Electron will use the original
 routine to determine the save path; this usually prompts a save dialog.
+
+[event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter

--- a/docs/api/incoming-message.md
+++ b/docs/api/incoming-message.md
@@ -5,7 +5,7 @@
 Process: [Main](../glossary.md#main-process)
 
 `IncomingMessage` implements the [Readable Stream](https://nodejs.org/api/stream.html#stream_readable_streams)
-interface and is therefore an [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter).
+interface and is therefore an [EventEmitter][event-emitter].
 
 ### Instance Events
 
@@ -72,3 +72,5 @@ An `Integer` indicating the HTTP protocol major version number.
 #### `response.httpVersionMinor`
 
 An `Integer` indicating the HTTP protocol minor version number.
+
+[event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter

--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -4,8 +4,7 @@
 
 Process: [Main](../glossary.md#main-process)
 
-The `ipcMain` module is an instance of the
-[EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) class. When used in the main
+The `ipcMain` module is an [Event Emitter][event-emitter]. When used in the main
 process, it handles asynchronous and synchronous messages sent from a renderer
 process (web page). Messages sent from a renderer will be emitted to this
 module.
@@ -146,3 +145,5 @@ in the [`ipc-main-event`](structures/ipc-main-event.md) structure docs.
 The documentation for the `event` object passed to `handle` callbacks can be
 found in the [`ipc-main-invoke-event`](structures/ipc-main-invoke-event.md)
 structure docs.
+
+[event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter

--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -4,8 +4,7 @@
 
 Process: [Renderer](../glossary.md#renderer-process)
 
-The `ipcRenderer` module is an instance of the
-[EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) class. It provides a few
+The `ipcRenderer` module is an  [EventEmitter][event-emitter]. It provides a few
 methods so you can send synchronous and asynchronous messages from the render
 process (web page) to the main process. You can also receive replies from the
 main process.
@@ -128,3 +127,5 @@ the host page instead of the main process.
 
 The documentation for the `event` object passed to the `callback` can be found
 in the [`ipc-renderer-event`](structures/ipc-renderer-event.md) structure docs.
+
+[event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -14,8 +14,7 @@ If you want to show Notifications from a renderer process you should use the [HT
 
 Process: [Main](../glossary.md#main-process)
 
-`Notification` is an
-[EventEmitter](https://nodejs.org/api/events.html#events_class_events_eventemitter).
+`Notification` is an [EventEmitter][event-emitter].
 
 It creates a new `Notification` with native properties as set by the `options`.
 
@@ -125,3 +124,5 @@ or one of the following locations:
 * `/System/Library/Sounds`
 
 See the [`NSSound`](https://developer.apple.com/documentation/appkit/nssound) docs for more information.
+
+[event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter

--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -7,7 +7,7 @@ Process: [Main](../glossary.md#main-process)
 This module cannot be used until the `ready` event of the `app`
 module is emitted.
 
-`screen` is an [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter).
+`screen` is an [EventEmitter][event-emitter].
 
 **Note:** In the renderer / DevTools, `window.screen` is a reserved DOM
 property, so writing `let { screen } = require('electron')` will not work.
@@ -152,3 +152,5 @@ Returns [`Rectangle`](structures/rectangle.md)
 Converts a screen DIP rect to a screen physical rect.
 The DPI scale is performed relative to the display nearest to `window`.
 If `window` is null, scaling will be performed to the display nearest to `rect`.
+
+[event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -4,8 +4,7 @@
 
 Process: [Main](../glossary.md#main-process)
 
-`webContents` is an
-[EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter).
+`webContents` is an [EventEmitter][event-emitter].
 It is responsible for rendering and controlling a web page and is a property of
 the [`BrowserWindow`](browser-window.md) object. An example of accessing the
 `webContents` object:
@@ -1813,3 +1812,4 @@ when the DevTools has been closed.
 A [`Debugger`](debugger.md) instance for this webContents.
 
 [keyboardevent]: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
+[event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Build cross platform desktop apps with JavaScript, HTML, and CSS",
   "devDependencies": {
     "@electron/docs-parser": "^0.3.0",
-    "@electron/typescript-definitions": "^8.3.1",
+    "@electron/typescript-definitions": "^8.3.5",
     "@octokit/rest": "^16.3.2",
     "@primer/octicons": "^9.1.1",
     "@types/chai": "^4.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,10 +55,10 @@
     ora "^3.4.0"
     pretty-ms "^5.0.0"
 
-"@electron/typescript-definitions@^8.3.1":
-  version "8.3.4"
-  resolved "https://registry.yarnpkg.com/@electron/typescript-definitions/-/typescript-definitions-8.3.4.tgz#2345e4058e66677792f1bc11662b13e6ccc9a17e"
-  integrity sha512-hh2ls04hvsW6i7B/x2cHJLyB5jQAzzr8IFsEaTqTFsi+tOmQVbeaao87ffLbZdiHI3Jh2Ll+o0zWa13dcV5Txw==
+"@electron/typescript-definitions@^8.3.5":
+  version "8.3.5"
+  resolved "https://registry.yarnpkg.com/@electron/typescript-definitions/-/typescript-definitions-8.3.5.tgz#02bbeea578bf3ef44f57297ba9e101df57270dbd"
+  integrity sha512-kKxNdWmw+zy2ENECrDjNdzDTATezTQEHmx0OHccbb/JOuL/tLpQXlVEiieCVQ2XJ+SY3FHRuZCrBUo3VEyR2uA==
   dependencies:
     "@electron/docs-parser" "^0.2.1"
     "@types/node" "^11.13.7"


### PR DESCRIPTION
#### Description of Change

Pending deps update roll from https://github.com/electron/typescript-definitions/pull/148 once it's merged and released.

Improves markdown formatting for classes and modules that extend `NodeJS.EventEmitter`. This is a precursor to allowing our docs parser to infer EventEmitter status from docs itself and not from a hardcoded list.

cc @MarshallOfSound @electron/wg-docs-tools 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
