### PR TITLE
fix: correctly convert MessageBoxType

### DIFF
--- a/shell/common/native_mate_converters/message_box_converter.cc
+++ b/shell/common/native_mate_converters/message_box_converter.cc
@@ -20,7 +20,7 @@ bool Converter<electron::MessageBoxSettings>::FromV8(
   if (!ConvertFromV8(isolate, val, &dict))
     return false;
   dict.Get("window", &out->parent_window);
-  dict.Get("type", &type);
+  dict.Get("messageBoxType", &type);
   out->type = static_cast<electron::MessageBoxType>(type);
   dict.Get("buttons", &out->buttons);
   dict.Get("defaultId", &out->default_id);


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/19348.

When we changed setting to be a struct and passed params through a converter, we used `messageBoxType` as the dialog type index, which didn't match the `type` arg we then looked for in the converter. This corrects that error.

Tested with:
```js
const { app, dialog } = require("electron")
app.on("ready", async () => {
  await dialog.showMessageBox({
    message: 'message',
    detail: 'hellllloooooo',
    type: 'error'
  })
```

cc @DeerMichel 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed incorrect passing of dialog MessageBox type.
