### PR TITLE
docs: fix instructions for opting out of dark mode

### DIFF
--- a/docs/tutorial/mojave-dark-mode-guide.md
+++ b/docs/tutorial/mojave-dark-mode-guide.md
@@ -5,14 +5,14 @@ for all macOS computers.  If your app does have a dark mode, you can make your E
 follow the system-wide dark mode setting.
 
 In macOS 10.15 Catalina, Apple introduced a new "automatic" dark mode option for all macOS computers. In order
-for the `isDarkMode` and `Tray` APIs to work correctly in this mode on Catalina you need to either have `NSRequiresAquaSystemAppearance` set to `true` in your `Info.plist` file or be on Electron `>=7.0.0`.
+for the `isDarkMode` and `Tray` APIs to work correctly in this mode on Catalina you need to either have `NSRequiresAquaSystemAppearance` set to `false` in your `Info.plist` file or be on Electron `>=7.0.0`.
 
 ## Automatically updating the native interfaces
 
 "Native Interfaces" include the file picker, window border, dialogs, context menus and more; basically anything where
 the UI comes from macOS and not your app.  The default behavior as of Electron 7.0.0 is to opt in to this automatic
 theming from the OS.  If you wish to opt out you must set the `NSRequiresAquaSystemAppearance` key in the `Info.plist` file
-to `false`.  Please note that once Electron starts building against the 10.14 SDK it will not be possible for you to opt
+to `true`.  Please note that once Electron starts building against the 10.14 SDK it will not be possible for you to opt
 out of this theming.
 
 ## Automatically updating your own interfaces


### PR DESCRIPTION
#### Description of Change
4d8a055 (#19226) introduced incorrect instructions for 'opting out' of dark mode in Electron 7.0.0 and for enabling it on older versions. The boolean values for the `NSRequiresAquaSystemAppearance` key were inverted.
This PR fixes those values.

cc @MarshallOfSound 
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
