### PR TITLE
chore: clean up and improve thrown errors

### DIFF
--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -197,7 +197,7 @@ class ClientRequest extends EventEmitter {
 
     const redirectPolicy = options.redirect || 'follow'
     if (!['follow', 'error', 'manual'].includes(redirectPolicy)) {
-      throw new Error('redirect mode should be one of follow, error or manual')
+      throw new TypeError(`Redirect mode must be either 'follow', 'error' or 'manual'`)
     }
 
     const urlRequestOptions = {

--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -197,7 +197,7 @@ class ClientRequest extends EventEmitter {
 
     const redirectPolicy = options.redirect || 'follow'
     if (!['follow', 'error', 'manual'].includes(redirectPolicy)) {
-      throw new TypeError(`Redirect mode must be either 'follow', 'error' or 'manual'`)
+      throw new TypeError(`Redirect mode must be either 'follow', 'error', or 'manual'.`)
     }
 
     const urlRequestOptions = {

--- a/native_mate/native_mate/constructor.h
+++ b/native_mate/native_mate/constructor.h
@@ -125,7 +125,7 @@ void InvokeNew(const base::Callback<Sig>& factory,
                v8::Isolate* isolate,
                Arguments* args) {
   if (!args->IsConstructCall()) {
-    args->ThrowError("Requires constructor call");
+    args->ThrowError("Constructor call is required.");
     return;
   }
 

--- a/native_mate/native_mate/function_template.h
+++ b/native_mate/native_mate/function_template.h
@@ -156,7 +156,7 @@ struct ArgumentHolder {
   ArgumentHolder(Arguments* args, int create_flags) : ok(false) {
     if (index == 0 && (create_flags & HolderIsFirstArgument) &&
         Destroyable::IsDestroyed(args)) {
-      args->ThrowError("Object has been destroyed");
+      args->ThrowError("Object has been destroyed.");
       return;
     }
     ok = GetNextArgument(args, create_flags, index == 0, &value);

--- a/shell/browser/api/atom_api_app.cc
+++ b/shell/browser/api/atom_api_app.cc
@@ -471,7 +471,9 @@ void OnClientCertificateSelected(
 
   mate::Dictionary cert_data;
   if (!mate::ConvertFromV8(isolate, val, &cert_data)) {
-    args->ThrowError("Valid certificate object parameter required.");
+    args->ThrowError(
+        "Valid certificate object parameter required in the "
+        "'select-client-certificate' event callback.");
     return;
   }
 
@@ -850,7 +852,7 @@ void App::SetAppLogsPath(mate::Arguments* args) {
   base::FilePath custom_path;
   if (args->GetNext(&custom_path)) {
     if (!custom_path.IsAbsolute()) {
-      args->ThrowError("Path must be absolute.");
+      args->ThrowError("Path provided to setAppLogsPath must be absolute.");
       return;
     }
     base::PathService::Override(DIR_APP_LOGS, custom_path);
@@ -887,7 +889,7 @@ void App::SetPath(mate::Arguments* args,
                   const std::string& name,
                   const base::FilePath& path) {
   if (!path.IsAbsolute()) {
-    args->ThrowError("Path must be absolute.");
+    args->ThrowError("Path provided to setPath must be absolute.");
     return;
   }
 
@@ -1130,7 +1132,9 @@ JumpListResult App::SetJumpList(v8::Local<v8::Value> val,
   bool delete_jump_list = val->IsNull();
   if (!delete_jump_list &&
       !mate::ConvertFromV8(args->isolate(), val, &categories)) {
-    args->ThrowTypeError("Argument must be null or an array of categories.");
+    args->ThrowTypeError(
+        "First argument provided to setJumpList must be null or an array of "
+        "categories.");
     return JumpListResult::ARGUMENT_ERROR;
   }
 

--- a/shell/browser/api/atom_api_app.cc
+++ b/shell/browser/api/atom_api_app.cc
@@ -471,7 +471,7 @@ void OnClientCertificateSelected(
 
   mate::Dictionary cert_data;
   if (!mate::ConvertFromV8(isolate, val, &cert_data)) {
-    args->ThrowError("Must pass valid certificate object.");
+    args->ThrowError("Valid certificate object parameter required.");
     return;
   }
 
@@ -850,7 +850,7 @@ void App::SetAppLogsPath(mate::Arguments* args) {
   base::FilePath custom_path;
   if (args->GetNext(&custom_path)) {
     if (!custom_path.IsAbsolute()) {
-      args->ThrowError("Path must be absolute");
+      args->ThrowError("Path must be absolute.");
       return;
     }
     base::PathService::Override(DIR_APP_LOGS, custom_path);
@@ -876,7 +876,7 @@ base::FilePath App::GetPath(mate::Arguments* args, const std::string& name) {
       args->ThrowError("Failed to get '" + name +
                        "' path: setAppLogsPath() must be called first.");
     } else {
-      args->ThrowError("Failed to get '" + name + "' path");
+      args->ThrowError("Failed to get '" + name + "' path.");
     }
   }
 
@@ -887,7 +887,7 @@ void App::SetPath(mate::Arguments* args,
                   const std::string& name,
                   const base::FilePath& path) {
   if (!path.IsAbsolute()) {
-    args->ThrowError("Path must be absolute");
+    args->ThrowError("Path must be absolute.");
     return;
   }
 
@@ -897,7 +897,7 @@ void App::SetPath(mate::Arguments* args,
     succeed =
         base::PathService::OverrideAndCreateIfNeeded(key, path, true, false);
   if (!succeed)
-    args->ThrowError("Failed to set path");
+    args->ThrowError("Failed to set path.");
 }
 
 void App::SetDesktopName(const std::string& desktop_name) {
@@ -1030,7 +1030,7 @@ void App::DisableHardwareAcceleration(mate::Arguments* args) {
   if (Browser::Get()->is_ready()) {
     args->ThrowError(
         "app.disableHardwareAcceleration() can only be called "
-        "before app is ready");
+        "before app is ready.");
     return;
   }
   content::GpuDataManager::GetInstance()->DisableHardwareAcceleration();
@@ -1040,7 +1040,7 @@ void App::DisableDomainBlockingFor3DAPIs(mate::Arguments* args) {
   if (Browser::Get()->is_ready()) {
     args->ThrowError(
         "app.disableDomainBlockingFor3DAPIs() can only be called "
-        "before app is ready");
+        "before app is ready.");
     return;
   }
   content::GpuDataManagerImpl::GetInstance()
@@ -1056,7 +1056,7 @@ void App::SetAccessibilitySupportEnabled(bool enabled, mate::Arguments* args) {
   if (!Browser::Get()->is_ready()) {
     args->ThrowError(
         "app.setAccessibilitySupportEnabled() can only be called "
-        "after app is ready");
+        "after app is ready.");
     return;
   }
 
@@ -1130,7 +1130,7 @@ JumpListResult App::SetJumpList(v8::Local<v8::Value> val,
   bool delete_jump_list = val->IsNull();
   if (!delete_jump_list &&
       !mate::ConvertFromV8(args->isolate(), val, &categories)) {
-    args->ThrowError("Argument must be null or an array of categories");
+    args->ThrowTypeError("Argument must be null or an array of categories.");
     return JumpListResult::ARGUMENT_ERROR;
   }
 
@@ -1312,7 +1312,7 @@ void App::EnableSandbox(mate::Arguments* args) {
   if (Browser::Get()->is_ready()) {
     args->ThrowError(
         "app.enableSandbox() can only be called "
-        "before app is ready");
+        "before app is ready.");
     return;
   }
 

--- a/shell/browser/api/atom_api_app_mac.mm
+++ b/shell/browser/api/atom_api_app_mac.mm
@@ -17,7 +17,7 @@ void App::SetAppLogsPath(mate::Arguments* args) {
   base::FilePath custom_path;
   if (args->GetNext(&custom_path)) {
     if (!custom_path.IsAbsolute()) {
-      args->ThrowError("Path must be absolute.");
+      args->ThrowError("Path provided to setAppLogsPath must be absolute.");
       return;
     }
     base::PathService::Override(DIR_APP_LOGS, custom_path);

--- a/shell/browser/api/atom_api_app_mac.mm
+++ b/shell/browser/api/atom_api_app_mac.mm
@@ -17,7 +17,7 @@ void App::SetAppLogsPath(mate::Arguments* args) {
   base::FilePath custom_path;
   if (args->GetNext(&custom_path)) {
     if (!custom_path.IsAbsolute()) {
-      args->ThrowError("Path must be absolute");
+      args->ThrowError("Path must be absolute.");
       return;
     }
     base::PathService::Override(DIR_APP_LOGS, custom_path);

--- a/shell/browser/api/atom_api_app_mas.mm
+++ b/shell/browser/api/atom_api_app_mas.mm
@@ -46,7 +46,7 @@ base::RepeatingCallback<void()> App::StartAccessingSecurityScopedResource(
   }
 
   if (isStale) {
-    args->ThrowError("bookmarkDataIsStale - try recreating the bookmark");
+    args->ThrowError("bookmarkDataIsStale - try recreating the bookmark.");
   }
 
   if (error == nil && isStale == false) {

--- a/shell/browser/api/atom_api_browser_view.cc
+++ b/shell/browser/api/atom_api_browser_view.cc
@@ -98,7 +98,7 @@ void BrowserView::WebContentsDestroyed() {
 // static
 mate::WrappableBase* BrowserView::New(mate::Arguments* args) {
   if (!Browser::Get()->is_ready()) {
-    args->ThrowError("Cannot create BrowserView before app is ready");
+    args->ThrowError("BrowserView can't be created before app is ready.");
     return nullptr;
   }
 

--- a/shell/browser/api/atom_api_browser_view.cc
+++ b/shell/browser/api/atom_api_browser_view.cc
@@ -98,7 +98,7 @@ void BrowserView::WebContentsDestroyed() {
 // static
 mate::WrappableBase* BrowserView::New(mate::Arguments* args) {
   if (!Browser::Get()->is_ready()) {
-    args->ThrowError("BrowserView can't be created before app is ready.");
+    args->ThrowError("BrowserView can only be created after app is ready.");
     return nullptr;
   }
 

--- a/shell/browser/api/atom_api_browser_window.cc
+++ b/shell/browser/api/atom_api_browser_window.cc
@@ -415,7 +415,7 @@ void BrowserWindow::Cleanup() {
 // static
 mate::WrappableBase* BrowserWindow::New(mate::Arguments* args) {
   if (!Browser::Get()->is_ready()) {
-    args->ThrowError("Cannot create BrowserWindow before app is ready");
+    args->ThrowError("BrowserWindow can't be created before app is ready.");
     return nullptr;
   }
 

--- a/shell/browser/api/atom_api_browser_window.cc
+++ b/shell/browser/api/atom_api_browser_window.cc
@@ -415,7 +415,7 @@ void BrowserWindow::Cleanup() {
 // static
 mate::WrappableBase* BrowserWindow::New(mate::Arguments* args) {
   if (!Browser::Get()->is_ready()) {
-    args->ThrowError("BrowserWindow can't be created before app is ready.");
+    args->ThrowError("BrowserWindow can only be created after app is ready.");
     return nullptr;
   }
 

--- a/shell/browser/api/atom_api_debugger.cc
+++ b/shell/browser/api/atom_api_debugger.cc
@@ -98,7 +98,7 @@ void Debugger::Attach(mate::Arguments* args) {
   args->GetNext(&protocol_version);
 
   if (agent_host_) {
-    args->ThrowError("Debugger is already attached to the target.");
+    args->ThrowError("Debugger is already attached to the target webContents.");
     return;
   }
 

--- a/shell/browser/api/atom_api_debugger.cc
+++ b/shell/browser/api/atom_api_debugger.cc
@@ -98,19 +98,19 @@ void Debugger::Attach(mate::Arguments* args) {
   args->GetNext(&protocol_version);
 
   if (agent_host_) {
-    args->ThrowError("Debugger is already attached to the target");
+    args->ThrowError("Debugger is already attached to the target.");
     return;
   }
 
   if (!protocol_version.empty() &&
       !DevToolsAgentHost::IsSupportedProtocolVersion(protocol_version)) {
-    args->ThrowError("Requested protocol version is not supported");
+    args->ThrowError("Requested protocol version is not supported.");
     return;
   }
 
   agent_host_ = DevToolsAgentHost::GetOrCreateFor(web_contents_);
   if (!agent_host_) {
-    args->ThrowError("No target available");
+    args->ThrowError("No target available.");
     return;
   }
 

--- a/shell/browser/api/atom_api_net_log.cc
+++ b/shell/browser/api/atom_api_net_log.cc
@@ -116,7 +116,9 @@ v8::Local<v8::Promise> NetLog::StartLogging(base::FilePath log_path,
   }
 
   if (net_log_exporter_) {
-    args->ThrowError("There is already a net log running.");
+    args->ThrowError(
+        "There is already a net log running. Only one net log may be running "
+        "at a time.");
     return v8::Local<v8::Promise>();
   }
 

--- a/shell/browser/api/atom_api_net_log.cc
+++ b/shell/browser/api/atom_api_net_log.cc
@@ -88,7 +88,7 @@ NetLog::~NetLog() = default;
 v8::Local<v8::Promise> NetLog::StartLogging(base::FilePath log_path,
                                             mate::Arguments* args) {
   if (log_path.empty()) {
-    args->ThrowError("The first parameter must be a valid string");
+    args->ThrowError("The 'path' parameter must be a valid string.");
     return v8::Local<v8::Promise>();
   }
 
@@ -116,7 +116,7 @@ v8::Local<v8::Promise> NetLog::StartLogging(base::FilePath log_path,
   }
 
   if (net_log_exporter_) {
-    args->ThrowError("There is already a net log running");
+    args->ThrowError("There is already a net log running.");
     return v8::Local<v8::Promise>();
   }
 

--- a/shell/browser/api/atom_api_notification.cc
+++ b/shell/browser/api/atom_api_notification.cc
@@ -83,7 +83,7 @@ Notification::~Notification() {
 // static
 mate::WrappableBase* Notification::New(mate::Arguments* args) {
   if (!Browser::Get()->is_ready()) {
-    args->ThrowError("Notification can't be created before app is ready.");
+    args->ThrowError("Notification can only be created after app is ready.");
     return nullptr;
   }
   return new Notification(args->isolate(), args->GetThis(), args);

--- a/shell/browser/api/atom_api_notification.cc
+++ b/shell/browser/api/atom_api_notification.cc
@@ -83,7 +83,7 @@ Notification::~Notification() {
 // static
 mate::WrappableBase* Notification::New(mate::Arguments* args) {
   if (!Browser::Get()->is_ready()) {
-    args->ThrowError("Notification can only be created after app is ready.");
+    args->ThrowError("Notifications can only be created after app is ready.");
     return nullptr;
   }
   return new Notification(args->isolate(), args->GetThis(), args);

--- a/shell/browser/api/atom_api_notification.cc
+++ b/shell/browser/api/atom_api_notification.cc
@@ -83,7 +83,7 @@ Notification::~Notification() {
 // static
 mate::WrappableBase* Notification::New(mate::Arguments* args) {
   if (!Browser::Get()->is_ready()) {
-    args->ThrowError("Cannot create Notification before app is ready");
+    args->ThrowError("Notification can't be created before app is ready.");
     return nullptr;
   }
   return new Notification(args->isolate(), args->GetThis(), args);

--- a/shell/browser/api/atom_api_protocol.cc
+++ b/shell/browser/api/atom_api_protocol.cc
@@ -86,7 +86,8 @@ void RegisterSchemesAsPrivileged(v8::Local<v8::Value> val,
                                  mate::Arguments* args) {
   std::vector<CustomScheme> custom_schemes;
   if (!mate::ConvertFromV8(args->isolate(), val, &custom_schemes)) {
-    args->ThrowError("Argument must be an array of custom schemes.");
+    args->ThrowTypeError(
+        "'schemes' parameter must be an array of custom schemes.");
     return;
   }
 
@@ -295,7 +296,7 @@ void RegisterSchemesAsPrivileged(v8::Local<v8::Value> val,
   if (electron::Browser::Get()->is_ready()) {
     args->ThrowError(
         "protocol.registerSchemesAsPrivileged should be called before "
-        "app is ready");
+        "app is ready.");
     return;
   }
 

--- a/shell/browser/api/atom_api_session.cc
+++ b/shell/browser/api/atom_api_session.cc
@@ -468,7 +468,8 @@ void Session::SetCertVerifyProc(v8::Local<v8::Value> val,
                                 mate::Arguments* args) {
   ElectronCertVerifierClient::CertVerifyProc proc;
   if (!(val->IsNull() || mate::ConvertFromV8(args->isolate(), val, &proc))) {
-    args->ThrowTypeError("Must pass null or a function.");
+    args->ThrowTypeError(
+        "setCertVerifyProc() parameter must be a function or null.");
     return;
   }
 
@@ -505,7 +506,8 @@ void Session::SetPermissionRequestHandler(v8::Local<v8::Value> val,
   }
   auto handler = std::make_unique<AtomPermissionManager::RequestHandler>();
   if (!mate::ConvertFromV8(args->isolate(), val, handler.get())) {
-    args->ThrowTypeError("Must pass null or a function.");
+    args->ThrowTypeError(
+        "setPermissionRequestHandler() parameter must be a function or null.");
     return;
   }
   permission_manager->SetPermissionRequestHandler(base::BindRepeating(
@@ -525,7 +527,8 @@ void Session::SetPermissionCheckHandler(v8::Local<v8::Value> val,
                                         mate::Arguments* args) {
   AtomPermissionManager::CheckHandler handler;
   if (!(val->IsNull() || mate::ConvertFromV8(args->isolate(), val, &handler))) {
-    args->ThrowTypeError("Must pass null or a function.");
+    args->ThrowTypeError(
+        "setPermissionCheckHandler() parameter must be a function or null.");
     return;
   }
   auto* permission_manager = static_cast<AtomPermissionManager*>(

--- a/shell/browser/api/atom_api_session.cc
+++ b/shell/browser/api/atom_api_session.cc
@@ -780,7 +780,7 @@ using electron::api::Session;
 v8::Local<v8::Value> FromPartition(const std::string& partition,
                                    mate::Arguments* args) {
   if (!electron::Browser::Get()->is_ready()) {
-    args->ThrowError("Session can't be received until app is ready.");
+    args->ThrowError("Session can only be received after app is ready.");
     return v8::Null(args->isolate());
   }
   base::DictionaryValue options;

--- a/shell/browser/api/atom_api_session.cc
+++ b/shell/browser/api/atom_api_session.cc
@@ -468,7 +468,7 @@ void Session::SetCertVerifyProc(v8::Local<v8::Value> val,
                                 mate::Arguments* args) {
   ElectronCertVerifierClient::CertVerifyProc proc;
   if (!(val->IsNull() || mate::ConvertFromV8(args->isolate(), val, &proc))) {
-    args->ThrowError("Must pass null or function");
+    args->ThrowTypeError("Must pass null or a function.");
     return;
   }
 
@@ -505,7 +505,7 @@ void Session::SetPermissionRequestHandler(v8::Local<v8::Value> val,
   }
   auto handler = std::make_unique<AtomPermissionManager::RequestHandler>();
   if (!mate::ConvertFromV8(args->isolate(), val, handler.get())) {
-    args->ThrowError("Must pass null or function");
+    args->ThrowTypeError("Must pass null or a function.");
     return;
   }
   permission_manager->SetPermissionRequestHandler(base::BindRepeating(
@@ -525,7 +525,7 @@ void Session::SetPermissionCheckHandler(v8::Local<v8::Value> val,
                                         mate::Arguments* args) {
   AtomPermissionManager::CheckHandler handler;
   if (!(val->IsNull() || mate::ConvertFromV8(args->isolate(), val, &handler))) {
-    args->ThrowError("Must pass null or function");
+    args->ThrowTypeError("Must pass null or a function.");
     return;
   }
   auto* permission_manager = static_cast<AtomPermissionManager*>(
@@ -780,7 +780,7 @@ using electron::api::Session;
 v8::Local<v8::Value> FromPartition(const std::string& partition,
                                    mate::Arguments* args) {
   if (!electron::Browser::Get()->is_ready()) {
-    args->ThrowError("Session can only be received when app is ready");
+    args->ThrowError("Session can't be received until app is ready.");
     return v8::Null(args->isolate());
   }
   base::DictionaryValue options;

--- a/shell/browser/api/atom_api_system_preferences_mac.mm
+++ b/shell/browser/api/atom_api_system_preferences_mac.mm
@@ -294,20 +294,20 @@ void SystemPreferences::RegisterDefaults(mate::Arguments* args) {
   base::DictionaryValue value;
 
   if (!args->GetNext(&value)) {
-    args->ThrowError("Invalid userDefault data provided");
+    args->ThrowTypeError("Invalid userDefault data.");
   } else {
     @try {
       NSDictionary* dict = DictionaryValueToNSDictionary(value);
       for (id key in dict) {
         id value = [dict objectForKey:key];
         if ([value isKindOfClass:[NSNull class]] || value == nil) {
-          args->ThrowError("Invalid userDefault data provided");
+          args->ThrowTypeError("Invalid userDefault data.");
           return;
         }
       }
       [[NSUserDefaults standardUserDefaults] registerDefaults:dict];
     } @catch (NSException* exception) {
-      args->ThrowError("Invalid userDefault data provided");
+      args->ThrowTypeError("Invalid userDefault data.");
     }
   }
 }
@@ -392,7 +392,7 @@ void SystemPreferences::SetUserDefault(const std::string& name,
       [defaults setObject:dict forKey:key];
     }
   } else {
-    args->ThrowError("Invalid type: " + type);
+    args->ThrowTypeError("Invalid type: " + type);
     return;
   }
 }
@@ -599,7 +599,7 @@ std::string SystemPreferences::GetMediaAccessStatus(
       return ConvertAuthorizationStatus(AVAuthorizationStatusAuthorizedMac);
     }
   } else {
-    args->ThrowError("Invalid media type");
+    args->ThrowTypeError("Invalid media type provided.");
     return std::string();
   }
 }
@@ -672,7 +672,7 @@ void SystemPreferences::SetAppLevelAppearance(mate::Arguments* args) {
     if (args->GetNext(&appearance)) {
       [[NSApplication sharedApplication] setAppearance:appearance];
     } else {
-      args->ThrowError("Invalid app appearance provided as first argument");
+      args->ThrowTypeError("Invalid app appearance type provided.");
     }
   }
 }

--- a/shell/browser/api/atom_api_system_preferences_mac.mm
+++ b/shell/browser/api/atom_api_system_preferences_mac.mm
@@ -294,20 +294,22 @@ void SystemPreferences::RegisterDefaults(mate::Arguments* args) {
   base::DictionaryValue value;
 
   if (!args->GetNext(&value)) {
-    args->ThrowTypeError("Invalid userDefault data.");
+    args->ThrowTypeError("registerDefaults() parameter 'defaults' is invalid.");
   } else {
     @try {
       NSDictionary* dict = DictionaryValueToNSDictionary(value);
       for (id key in dict) {
         id value = [dict objectForKey:key];
         if ([value isKindOfClass:[NSNull class]] || value == nil) {
-          args->ThrowTypeError("Invalid userDefault data.");
+          args->ThrowTypeError(
+              "registerDefaults() parameter 'defaults' is invalid.");
           return;
         }
       }
       [[NSUserDefaults standardUserDefaults] registerDefaults:dict];
     } @catch (NSException* exception) {
-      args->ThrowTypeError("Invalid userDefault data.");
+      args->ThrowTypeError(
+          "registerDefaults() parameter 'defaults' is invalid.");
     }
   }
 }
@@ -392,7 +394,8 @@ void SystemPreferences::SetUserDefault(const std::string& name,
       [defaults setObject:dict forKey:key];
     }
   } else {
-    args->ThrowTypeError("Invalid type: " + type);
+    args->ThrowTypeError("setUserDefault() parameter 'type' is invalid: '" +
+                         type + "'.");
     return;
   }
 }
@@ -599,8 +602,8 @@ std::string SystemPreferences::GetMediaAccessStatus(
       return ConvertAuthorizationStatus(AVAuthorizationStatusAuthorizedMac);
     }
   } else {
-    args->ThrowTypeError(
-        "Invalid media type provided: expected 'camera' or 'microphone'.");
+    args->ThrowTypeError("getMediaAccessStatus() parameter 'mediaType' is "
+                         "invalid: expected 'camera' or 'microphone'.");
     return std::string();
   }
 }
@@ -674,8 +677,8 @@ void SystemPreferences::SetAppLevelAppearance(mate::Arguments* args) {
     if (args->GetNext(&appearance)) {
       [[NSApplication sharedApplication] setAppearance:appearance];
     } else {
-      args->ThrowTypeError(
-          "Invalid app appearance type provided: expected 'light' or 'dark'.");
+      args->ThrowTypeError("setAppLevelAppearance() parameter 'appearance' is "
+                           "invalid: expected 'light' or 'dark'.");
     }
   }
 }

--- a/shell/browser/api/atom_api_system_preferences_mac.mm
+++ b/shell/browser/api/atom_api_system_preferences_mac.mm
@@ -599,7 +599,8 @@ std::string SystemPreferences::GetMediaAccessStatus(
       return ConvertAuthorizationStatus(AVAuthorizationStatusAuthorizedMac);
     }
   } else {
-    args->ThrowTypeError("Invalid media type provided.");
+    args->ThrowTypeError(
+        "Invalid media type provided: expected 'camera' or 'microphone'.");
     return std::string();
   }
 }
@@ -624,7 +625,8 @@ v8::Local<v8::Promise> SystemPreferences::AskForMediaAccess(
       promise.Resolve(true);
     }
   } else {
-    promise.RejectWithErrorMessage("Invalid media type");
+    promise.RejectWithErrorMessage(
+        "Invalid media type: expected 'camera' or 'microphone'.");
   }
 
   return handle;
@@ -672,7 +674,8 @@ void SystemPreferences::SetAppLevelAppearance(mate::Arguments* args) {
     if (args->GetNext(&appearance)) {
       [[NSApplication sharedApplication] setAppearance:appearance];
     } else {
-      args->ThrowTypeError("Invalid app appearance type provided.");
+      args->ThrowTypeError(
+          "Invalid app appearance type provided: expected 'light' or 'dark'.");
     }
   }
 }

--- a/shell/browser/api/atom_api_top_level_window.cc
+++ b/shell/browser/api/atom_api_top_level_window.cc
@@ -679,7 +679,7 @@ void TopLevelWindow::RemoveMenu() {
 void TopLevelWindow::SetParentWindow(v8::Local<v8::Value> value,
                                      mate::Arguments* args) {
   if (IsModal()) {
-    args->ThrowError("SetParentWindow can't be called for modal windows.");
+    args->ThrowError("setParentWindow is not supported for modal windows.");
     return;
   }
 
@@ -821,14 +821,14 @@ void TopLevelWindow::ToggleTabBar() {
 void TopLevelWindow::AddTabbedWindow(NativeWindow* window,
                                      mate::Arguments* args) {
   if (!window_->AddTabbedWindow(window))
-    args->ThrowError("AddTabbedWindow cannot be called by a window on itself.");
+    args->ThrowError("addTabbedWindow cannot be called by a window on itself.");
 }
 
 void TopLevelWindow::SetWindowButtonVisibility(bool visible,
                                                mate::Arguments* args) {
   if (!window_->SetWindowButtonVisibility(visible)) {
     args->ThrowError(
-        "SetWindowButtonVisibility is not supported for this window.");
+        "setWindowButtonVisibility is not supported for this window.");
   }
 }
 
@@ -894,8 +894,8 @@ v8::Local<v8::Value> TopLevelWindow::GetBrowserView(
     return v8::Local<v8::Value>::New(isolate(), (*first_view).second);
   } else {
     args->ThrowError(
-        "This BrowserWindow has multiple BrowserViews, "
-        "Use getBrowserViews() instead.");
+        "This BrowserWindow has more than one BrowserView: use "
+        "getBrowserViews() instead.");
     return v8::Null(isolate());
   }
 }

--- a/shell/browser/api/atom_api_top_level_window.cc
+++ b/shell/browser/api/atom_api_top_level_window.cc
@@ -679,7 +679,7 @@ void TopLevelWindow::RemoveMenu() {
 void TopLevelWindow::SetParentWindow(v8::Local<v8::Value> value,
                                      mate::Arguments* args) {
   if (IsModal()) {
-    args->ThrowError("Can not be called for modal window");
+    args->ThrowError("SetParentWindow can't be called for modal windows.");
     return;
   }
 
@@ -694,7 +694,7 @@ void TopLevelWindow::SetParentWindow(v8::Local<v8::Value> value,
     window_->SetParentWindow(parent->window_.get());
     parent->child_windows_.Set(isolate(), weak_map_id(), GetWrapper());
   } else {
-    args->ThrowError("Must pass TopLevelWindow instance or null");
+    args->ThrowError("TopLevelWindow instance or null parameter required.");
   }
 }
 
@@ -827,7 +827,8 @@ void TopLevelWindow::AddTabbedWindow(NativeWindow* window,
 void TopLevelWindow::SetWindowButtonVisibility(bool visible,
                                                mate::Arguments* args) {
   if (!window_->SetWindowButtonVisibility(visible)) {
-    args->ThrowError("Not supported for this window");
+    args->ThrowError(
+        "SetWindowButtonVisibility is not supported for this window.");
   }
 }
 
@@ -893,8 +894,8 @@ v8::Local<v8::Value> TopLevelWindow::GetBrowserView(
     return v8::Local<v8::Value>::New(isolate(), (*first_view).second);
   } else {
     args->ThrowError(
-        "BrowserWindow have multiple BrowserViews, "
-        "Use getBrowserViews() instead");
+        "This BrowserWindow has multiple BrowserViews, "
+        "Use getBrowserViews() instead.");
     return v8::Null(isolate());
   }
 }

--- a/shell/browser/api/atom_api_top_level_window.cc
+++ b/shell/browser/api/atom_api_top_level_window.cc
@@ -679,7 +679,7 @@ void TopLevelWindow::RemoveMenu() {
 void TopLevelWindow::SetParentWindow(v8::Local<v8::Value> value,
                                      mate::Arguments* args) {
   if (IsModal()) {
-    args->ThrowError("setParentWindow is not supported for modal windows.");
+    args->ThrowError("setParentWindow() is not supported for modal windows.");
     return;
   }
 

--- a/shell/browser/api/atom_api_tray.cc
+++ b/shell/browser/api/atom_api_tray.cc
@@ -66,7 +66,7 @@ Tray::~Tray() = default;
 mate::WrappableBase* Tray::New(mate::Handle<NativeImage> image,
                                mate::Arguments* args) {
   if (!Browser::Get()->is_ready()) {
-    args->ThrowError("Cannot create Tray before app is ready");
+    args->ThrowError("Tray can't be created before app is ready.");
     return nullptr;
   }
   return new Tray(args->isolate(), args->GetThis(), image);
@@ -193,7 +193,7 @@ void Tray::DisplayBalloon(mate::Arguments* args,
   options.Get("icon", &icon);
   base::string16 title, content;
   if (!options.Get("title", &title) || !options.Get("content", &content)) {
-    args->ThrowError("'title' and 'content' must be defined");
+    args->ThrowError("'title' and 'content' must be defined.");
     return;
   }
 

--- a/shell/browser/api/atom_api_tray.cc
+++ b/shell/browser/api/atom_api_tray.cc
@@ -66,7 +66,7 @@ Tray::~Tray() = default;
 mate::WrappableBase* Tray::New(mate::Handle<NativeImage> image,
                                mate::Arguments* args) {
   if (!Browser::Get()->is_ready()) {
-    args->ThrowError("Tray can't be created before app is ready.");
+    args->ThrowError("Tray can only be created after app is ready.");
     return nullptr;
   }
   return new Tray(args->isolate(), args->GetThis(), image);

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -1592,12 +1592,12 @@ void WebContents::Print(mate::Arguments* args) {
   mate::Dictionary options = mate::Dictionary::CreateEmpty(args->isolate());
   base::DictionaryValue settings;
   if (args->Length() >= 1 && !args->GetNext(&options)) {
-    args->ThrowError("Invalid print settings specified");
+    args->ThrowError("Invalid print settings specified.");
     return;
   }
   printing::CompletionCallback callback;
   if (args->Length() == 2 && !args->GetNext(&callback)) {
-    args->ThrowError("Invalid optional callback provided");
+    args->ThrowTypeError("Invalid optional callback.");
     return;
   }
 
@@ -1755,7 +1755,7 @@ v8::Local<v8::Promise> WebContents::PrintToPDF(
 void WebContents::AddWorkSpace(mate::Arguments* args,
                                const base::FilePath& path) {
   if (path.empty()) {
-    args->ThrowError("path cannot be empty");
+    args->ThrowError("'path' parameter can't be empty.");
     return;
   }
   DevToolsAddFileSystem(std::string(), path);
@@ -1764,7 +1764,7 @@ void WebContents::AddWorkSpace(mate::Arguments* args,
 void WebContents::RemoveWorkSpace(mate::Arguments* args,
                                   const base::FilePath& path) {
   if (path.empty()) {
-    args->ThrowError("path cannot be empty");
+    args->ThrowError("'path' parameter can't be empty.");
     return;
   }
   DevToolsRemoveFileSystem(path);
@@ -1817,7 +1817,7 @@ void WebContents::ReplaceMisspelling(const base::string16& word) {
 uint32_t WebContents::FindInPage(mate::Arguments* args) {
   base::string16 search_text;
   if (!args->GetNext(&search_text) || search_text.empty()) {
-    args->ThrowError("Must provide a non-empty search content");
+    args->ThrowError("Non-empty search text parameter required.");
     return 0;
   }
 
@@ -2024,14 +2024,14 @@ void WebContents::StartDrag(const mate::Dictionary& item,
 
   // Error checking.
   if (icon.IsEmpty()) {
-    args->ThrowError("Must specify 'icon' option");
+    args->ThrowError("'icon' parameter is required.");
     return;
   }
 
 #if defined(OS_MACOSX)
   // NSWindow.dragImage requires a non-empty NSImage
   if (icon->image().IsEmpty()) {
-    args->ThrowError("Must specify non-empty 'icon' option");
+    args->ThrowError("Non-empty 'icon' parameter is required.");
     return;
   }
 #endif
@@ -2041,7 +2041,7 @@ void WebContents::StartDrag(const mate::Dictionary& item,
     base::MessageLoopCurrent::ScopedNestableTaskAllower allow;
     DragFileItems(files, icon->image(), web_contents()->GetNativeView());
   } else {
-    args->ThrowError("Must specify either 'file' or 'files' option");
+    args->ThrowError("Must specify either 'file' or 'files' parameter.");
   }
 }
 

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -1592,12 +1592,13 @@ void WebContents::Print(mate::Arguments* args) {
   mate::Dictionary options = mate::Dictionary::CreateEmpty(args->isolate());
   base::DictionaryValue settings;
   if (args->Length() >= 1 && !args->GetNext(&options)) {
-    args->ThrowError("Invalid print settings specified.");
+    args->ThrowError("webContents.print() parameter 'settings' is invalid.");
     return;
   }
   printing::CompletionCallback callback;
   if (args->Length() == 2 && !args->GetNext(&callback)) {
-    args->ThrowTypeError("Invalid optional callback.");
+    args->ThrowTypeError(
+        "webContents.print() optional parameter 'callback' is invalid.");
     return;
   }
 
@@ -1755,7 +1756,7 @@ v8::Local<v8::Promise> WebContents::PrintToPDF(
 void WebContents::AddWorkSpace(mate::Arguments* args,
                                const base::FilePath& path) {
   if (path.empty()) {
-    args->ThrowError("'path' parameter can't be empty.");
+    args->ThrowError("addWorkSpace() parameter 'path' cannot be empty.");
     return;
   }
   DevToolsAddFileSystem(std::string(), path);
@@ -1764,7 +1765,7 @@ void WebContents::AddWorkSpace(mate::Arguments* args,
 void WebContents::RemoveWorkSpace(mate::Arguments* args,
                                   const base::FilePath& path) {
   if (path.empty()) {
-    args->ThrowError("'path' parameter can't be empty.");
+    args->ThrowError("removeWorkSpace() parameter 'path' cannot be empty.");
     return;
   }
   DevToolsRemoveFileSystem(path);
@@ -1817,7 +1818,7 @@ void WebContents::ReplaceMisspelling(const base::string16& word) {
 uint32_t WebContents::FindInPage(mate::Arguments* args) {
   base::string16 search_text;
   if (!args->GetNext(&search_text) || search_text.empty()) {
-    args->ThrowError("Non-empty search text parameter required.");
+    args->ThrowError("findInPage() parameter 'text' cannot be empty.");
     return 0;
   }
 
@@ -2022,16 +2023,17 @@ void WebContents::StartDrag(const mate::Dictionary& item,
     // TODO(zcbenz): Set default icon from file.
   }
 
-  // Error checking.
   if (icon.IsEmpty()) {
-    args->ThrowError("'icon' parameter is required.");
+    args->ThrowError(
+        "startDrag() parameter 'item' must have a nonempty property 'icon'.");
     return;
   }
 
 #if defined(OS_MACOSX)
   // NSWindow.dragImage requires a non-empty NSImage
   if (icon->image().IsEmpty()) {
-    args->ThrowError("Non-empty 'icon' parameter is required.");
+    args->ThrowError(
+        "startDrag() parameter 'item' must have a nonempty property 'icon'.");
     return;
   }
 #endif
@@ -2041,7 +2043,8 @@ void WebContents::StartDrag(const mate::Dictionary& item,
     base::MessageLoopCurrent::ScopedNestableTaskAllower allow;
     DragFileItems(files, icon->image(), web_contents()->GetNativeView());
   } else {
-    args->ThrowError("Must specify either 'file' or 'files' parameter.");
+    args->ThrowError(
+        "startDrag() parameter 'item' must have a nonempty property 'file'.");
   }
 }
 

--- a/shell/browser/api/atom_api_web_request.cc
+++ b/shell/browser/api/atom_api_web_request.cc
@@ -93,7 +93,7 @@ void WebRequest::SetListener(Method method, Event type, mate::Arguments* args) {
   Listener listener;
   if (!args->GetNext(&listener) &&
       !(args->GetNext(&value) && value->IsNull())) {
-    args->ThrowError("Must pass null or a Function");
+    args->ThrowTypeError("Must pass null or a function.");
     return;
   }
 

--- a/shell/browser/api/stream_subscriber.cc
+++ b/shell/browser/api/stream_subscriber.cc
@@ -68,7 +68,7 @@ void StreamSubscriber::OnData(mate::Arguments* args) {
   v8::Local<v8::Value> buf;
   args->GetNext(&buf);
   if (!node::Buffer::HasInstance(buf)) {
-    args->ThrowError("data must be Buffer");
+    args->ThrowTypeError("Buffer must be a Node.js Buffer.");
     return;
   }
 

--- a/shell/browser/api/views/atom_api_button.cc
+++ b/shell/browser/api/views/atom_api_button.cc
@@ -26,7 +26,7 @@ void Button::ButtonPressed(views::Button* sender, const ui::Event& event) {
 
 // static
 mate::WrappableBase* Button::New(mate::Arguments* args) {
-  args->ThrowError("Button can not be created directly");
+  args->ThrowError("Button can't be created directly.");
   return nullptr;
 }
 

--- a/shell/browser/api/views/atom_api_layout_manager.cc
+++ b/shell/browser/api/views/atom_api_layout_manager.cc
@@ -31,7 +31,7 @@ std::unique_ptr<views::LayoutManager> LayoutManager::TakeOver() {
 
 // static
 mate::WrappableBase* LayoutManager::New(mate::Arguments* args) {
-  args->ThrowError("LayoutManager can not be created directly");
+  args->ThrowError("LayoutManager can't be created directly.");
   return nullptr;
 }
 

--- a/shell/browser/auto_updater_mac.mm
+++ b/shell/browser/auto_updater_mac.mm
@@ -61,8 +61,7 @@ void AutoUpdater::SetFeedURL(mate::Arguments* args) {
   } else if (args->GetNext(&feed)) {
     args->GetNext(&requestHeaders);
   } else {
-    args->ThrowError(
-        "Expected an options object with a 'url' property to be provided.");
+    args->ThrowError("Expected an options object with a 'url' property.");
     return;
   }
 

--- a/shell/browser/auto_updater_mac.mm
+++ b/shell/browser/auto_updater_mac.mm
@@ -47,21 +47,22 @@ void AutoUpdater::SetFeedURL(mate::Arguments* args) {
   std::string serverType = "default";
   if (args->GetNext(&opts)) {
     if (!opts.Get("url", &feed)) {
-      args->ThrowError(
-          "Expected options object to contain a 'url' string property in "
-          "setFeedUrl call.");
+      args->ThrowError("setFeedURL() parameter 'options' must have a nonempty "
+                       "property 'url'.");
       return;
     }
     opts.Get("headers", &requestHeaders);
     opts.Get("serverType", &serverType);
     if (serverType != "default" && serverType != "json") {
-      args->ThrowTypeError("Invalid 'serverType' parameter provided.");
+      args->ThrowTypeError("setFeedURL() property 'serverType' in 'options' is "
+                           "invalid: must be default' or 'json'.");
       return;
     }
   } else if (args->GetNext(&feed)) {
     args->GetNext(&requestHeaders);
   } else {
-    args->ThrowError("Expected an options object with a 'url' property.");
+    args->ThrowError("setFeedURL() parameter 'options' must have a nonempty "
+                     "property 'url'.");
     return;
   }
 

--- a/shell/browser/auto_updater_mac.mm
+++ b/shell/browser/auto_updater_mac.mm
@@ -49,20 +49,20 @@ void AutoUpdater::SetFeedURL(mate::Arguments* args) {
     if (!opts.Get("url", &feed)) {
       args->ThrowError(
           "Expected options object to contain a 'url' string property in "
-          "setFeedUrl call");
+          "setFeedUrl call.");
       return;
     }
     opts.Get("headers", &requestHeaders);
     opts.Get("serverType", &serverType);
     if (serverType != "default" && serverType != "json") {
-      args->ThrowError("Expected serverType to be 'default' or 'json'");
+      args->ThrowTypeError("Invalid 'serverType' parameter provided.");
       return;
     }
   } else if (args->GetNext(&feed)) {
     args->GetNext(&requestHeaders);
   } else {
     args->ThrowError(
-        "Expected an options object with a 'url' property to be provided");
+        "Expected an options object with a 'url' property to be provided.");
     return;
   }
 

--- a/shell/browser/net/url_request_async_asar_job.cc
+++ b/shell/browser/net/url_request_async_asar_job.cc
@@ -44,8 +44,8 @@ void BeforeStartInUI(base::WeakPtr<URLRequestAsyncAsarJob> job,
     if (headersDict) {
       for (const auto& iter : headersDict->DictItems()) {
         if (!iter.second.is_string()) {
-          args->ThrowError("Value of '" + iter.first +
-                           "' header has to be a string");
+          args->ThrowTypeError("Value of '" + iter.first +
+                               "' header must be a string.");
           return;
         }
       }

--- a/shell/browser/ui/cocoa/atom_bundle_mover.mm
+++ b/shell/browser/ui/cocoa/atom_bundle_mover.mm
@@ -57,7 +57,7 @@ bool AtomBundleMover::ShouldContinueMove(BundlerMoverConflictType type,
       // we only want to throw an error if a user has returned a non-boolean
       // value; this allows for client-side error handling should something in
       // the handler throw
-      args->ThrowError("Invalid conflict handler return type.");
+      args->ThrowTypeError("Invalid conflict handler return type.");
     }
   }
   return true;
@@ -103,11 +103,11 @@ bool AtomBundleMover::Move(mate::Arguments* args) {
                            &authorizationCanceled)) {
       if (authorizationCanceled) {
         // User rejected the authorization request
-        args->ThrowError("User rejected the authorization request");
+        args->ThrowError("User rejected the authorization request.");
         return false;
       } else {
-        args->ThrowError(
-            "Failed to copy to applications directory even with authorization");
+        args->ThrowError("Failed to copy to applications directory even with "
+                         "authorization.");
         return false;
       }
     }

--- a/shell/common/api/atom_api_clipboard.cc
+++ b/shell/common/api/atom_api_clipboard.cc
@@ -62,7 +62,7 @@ void Clipboard::WriteBuffer(const std::string& format,
                             const v8::Local<v8::Value> buffer,
                             mate::Arguments* args) {
   if (!node::Buffer::HasInstance(buffer)) {
-    args->ThrowError("buffer must be a node Buffer");
+    args->ThrowTypeError("Buffer must be a Node.js Buffer.");
     return;
   }
 

--- a/shell/common/api/atom_api_native_image.cc
+++ b/shell/common/api/atom_api_native_image.cc
@@ -404,7 +404,8 @@ mate::Handle<NativeImage> NativeImage::CreateFromBitmap(
     v8::Local<v8::Value> buffer,
     const mate::Dictionary& options) {
   if (!node::Buffer::HasInstance(buffer)) {
-    args->ThrowTypeError("Buffer must be a Node.js Buffer.");
+    args->ThrowTypeError(
+        "createFromBitmap() parameter 'buffer' must be a Node.js Buffer.");
     return mate::Handle<NativeImage>();
   }
 
@@ -413,12 +414,15 @@ mate::Handle<NativeImage> NativeImage::CreateFromBitmap(
   double scale_factor = 1.;
 
   if (!options.Get("width", &width)) {
-    args->ThrowError("'width' parameter is required.");
+    args->ThrowError(
+        "createFromBitmap() parameter 'options' must have a property 'width'.");
     return mate::Handle<NativeImage>();
   }
 
   if (!options.Get("height", &height)) {
-    args->ThrowError("'height' parameter is required.");
+    args->ThrowError(
+        "createFromBitmap() parameter 'options' must have a property "
+        "'height'.");
     return mate::Handle<NativeImage>();
   }
 
@@ -451,7 +455,8 @@ mate::Handle<NativeImage> NativeImage::CreateFromBuffer(
     mate::Arguments* args,
     v8::Local<v8::Value> buffer) {
   if (!node::Buffer::HasInstance(buffer)) {
-    args->ThrowTypeError("Buffer must be a Node.js Buffer.");
+    args->ThrowTypeError(
+        "createFromBuffer() parameter 'buffer' must be a Node.js Buffer.");
     return mate::Handle<NativeImage>();
   }
 

--- a/shell/common/api/atom_api_native_image.cc
+++ b/shell/common/api/atom_api_native_image.cc
@@ -237,7 +237,7 @@ v8::Local<v8::Value> NativeImage::GetNativeHandle(v8::Isolate* isolate,
                             sizeof(void*))
       .ToLocalChecked();
 #else
-  args->ThrowError("Not implemented");
+  args->ThrowError("Not implemented.");
   return v8::Undefined(isolate);
 #endif
 }
@@ -404,7 +404,7 @@ mate::Handle<NativeImage> NativeImage::CreateFromBitmap(
     v8::Local<v8::Value> buffer,
     const mate::Dictionary& options) {
   if (!node::Buffer::HasInstance(buffer)) {
-    args->ThrowError("buffer must be a node Buffer");
+    args->ThrowTypeError("Buffer must be a Node.js Buffer.");
     return mate::Handle<NativeImage>();
   }
 
@@ -413,12 +413,12 @@ mate::Handle<NativeImage> NativeImage::CreateFromBitmap(
   double scale_factor = 1.;
 
   if (!options.Get("width", &width)) {
-    args->ThrowError("width is required");
+    args->ThrowError("'width' parameter is required.");
     return mate::Handle<NativeImage>();
   }
 
   if (!options.Get("height", &height)) {
-    args->ThrowError("height is required");
+    args->ThrowError("'height' parameter is required.");
     return mate::Handle<NativeImage>();
   }
 
@@ -426,7 +426,7 @@ mate::Handle<NativeImage> NativeImage::CreateFromBitmap(
   auto size_bytes = info.computeMinByteSize();
 
   if (size_bytes != node::Buffer::Length(buffer)) {
-    args->ThrowError("invalid buffer size");
+    args->ThrowError("Invalid buffer size.");
     return mate::Handle<NativeImage>();
   }
 
@@ -451,7 +451,7 @@ mate::Handle<NativeImage> NativeImage::CreateFromBuffer(
     mate::Arguments* args,
     v8::Local<v8::Value> buffer) {
   if (!node::Buffer::HasInstance(buffer)) {
-    args->ThrowError("buffer must be a node Buffer");
+    args->ThrowTypeError("Buffer must be a Node.js Buffer.");
     return mate::Handle<NativeImage>();
   }
 

--- a/shell/common/api/atom_api_shell.cc
+++ b/shell/common/api/atom_api_shell.cc
@@ -112,7 +112,7 @@ v8::Local<v8::Value> ReadShortcutLink(mate::Arguments* args,
   base::win::ShortcutProperties properties;
   if (!base::win::ResolveShortcutProperties(
           path, ShortcutProperties::PROPERTIES_ALL, &properties)) {
-    args->ThrowError("Failed to read shortcut link");
+    args->ThrowError("Failed to read shortcut link.");
     return v8::Null(args->isolate());
   }
   options.Set("target", properties.target);

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -203,7 +203,7 @@ v8::Local<v8::Value> ElectronBindings::GetSystemMemoryInfo(
     mate::Arguments* args) {
   base::SystemMemoryInfoKB mem_info;
   if (!base::GetSystemMemoryInfo(&mem_info)) {
-    args->ThrowError("Unable to retrieve system memory information");
+    args->ThrowError("Unable to retrieve system memory information.");
     return v8::Undefined(isolate);
   }
 

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -203,7 +203,7 @@ v8::Local<v8::Value> ElectronBindings::GetSystemMemoryInfo(
     mate::Arguments* args) {
   base::SystemMemoryInfoKB mem_info;
   if (!base::GetSystemMemoryInfo(&mem_info)) {
-    args->ThrowError("Unable to retrieve system memory information.");
+    args->ThrowError("getSystemMemoryInfo() failed.");
     return v8::Undefined(isolate);
   }
 

--- a/shell/common/native_mate_converters/callback.cc
+++ b/shell/common/native_mate_converters/callback.cc
@@ -52,7 +52,7 @@ void CallTranslater(v8::Local<v8::External> external,
   if (one_time) {
     auto called_symbol = mate::StringToSymbol(isolate, "called");
     if (state->Has(context, called_symbol).ToChecked()) {
-      args->ThrowError("callback can only be called for once");
+      args->ThrowError("Callback can only be called once.");
       return;
     } else {
       state->Set(context, called_symbol, v8::Boolean::New(isolate, true))

--- a/shell/renderer/api/atom_api_web_frame.cc
+++ b/shell/renderer/api/atom_api_web_frame.cc
@@ -312,7 +312,9 @@ void SetSpellCheckProvider(mate::Arguments* args,
   auto context = args->isolate()->GetCurrentContext();
   if (!provider->Has(context, mate::StringToV8(args->isolate(), "spellCheck"))
            .ToChecked()) {
-    args->ThrowError("\"spellCheck\" not defined.");
+    args->ThrowError(
+        "setSpellCheckProvider() parameter 'provider' must have a property "
+        "'spellCheck'.");
     return;
   }
 

--- a/shell/renderer/api/atom_api_web_frame.cc
+++ b/shell/renderer/api/atom_api_web_frame.cc
@@ -312,7 +312,7 @@ void SetSpellCheckProvider(mate::Arguments* args,
   auto context = args->isolate()->GetCurrentContext();
   if (!provider->Has(context, mate::StringToV8(args->isolate(), "spellCheck"))
            .ToChecked()) {
-    args->ThrowError("\"spellCheck\" has to be defined");
+    args->ThrowError("\"spellCheck\" not defined.");
     return;
   }
 
@@ -445,7 +445,7 @@ void SetIsolatedWorldInfo(v8::Local<v8::Value> window,
 
   if (!security_policy.empty() && origin_url.empty()) {
     args->ThrowError(
-        "If csp is specified, securityOrigin should also be specified");
+        "If csp is specified, securityOrigin should also be specified.");
     return;
   }
 

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -190,7 +190,7 @@ describe('BrowserWindow module', () => {
       await new Promise(setImmediate)
       expect(() => {
         contents.getProcessId()
-      }).to.throw('Object has been destroyed')
+      }).to.throw('Object has been destroyed.')
     })
     it('should not crash when destroying windows with pending events', () => {
       const focusListener = () => {}
@@ -1136,7 +1136,7 @@ describe('BrowserWindow module', () => {
           frame: false
         })
         w.setWindowButtonVisibility(true)
-      }).to.throw('Not supported for this window')
+      }).to.throw('SetWindowButtonVisibility is not supported for this window.')
     })
   })
 

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -801,7 +801,7 @@ describe('net module', () => {
           url: 'https://test',
           redirect: 'custom'
         })
-      }).to.throw(`Redirect mode must be either 'follow', 'error' or 'manual'`)
+      }).to.throw(`Redirect mode must be either 'follow', 'error', or 'manual'.`)
     })
 
     it('should throw when calling getHeader without a name', () => {

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -801,7 +801,7 @@ describe('net module', () => {
           url: 'https://test',
           redirect: 'custom'
         })
-      }).to.throw('redirect mode should be one of follow, error or manual')
+      }).to.throw(`Redirect mode must be either 'follow', 'error' or 'manual'`)
     })
 
     it('should throw when calling getHeader without a name', () => {

--- a/spec-main/api-protocol-spec.ts
+++ b/spec-main/api-protocol-spec.ts
@@ -228,7 +228,7 @@ describe('protocol module', () => {
         expect(() => callback({
           path: filePath,
           headers: { 'X-Great-Header': (42 as any) }
-        })).to.throw(Error, `Value of 'X-Great-Header' header has to be a string`)
+        })).to.throw(Error, `Value of 'X-Great-Header' header must be a string.`)
         done()
       }).then(() => {
         ajax(protocolName + '://fake-host')

--- a/spec-main/api-system-preferences-spec.ts
+++ b/spec-main/api-system-preferences-spec.ts
@@ -53,7 +53,7 @@ describe('systemPreferences module', () => {
       for (const badDefault of badDefaults) {
         expect(() => {
           systemPreferences.registerDefaults(badDefault)
-        }).to.throw('Invalid userDefault data provided')
+        }).to.throw('Invalid userDefault data.')
       }
     })
   })

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -119,7 +119,7 @@ describe('clipboard module', () => {
     it('throws an error when a non-Buffer is specified', () => {
       expect(() => {
         clipboard.writeBuffer('public.utf8-plain-text', 'hello')
-      }).to.throw(/buffer must be a node Buffer/)
+      }).to.throw(/Buffer must be a Node.js Buffer/)
     })
   })
 

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -171,11 +171,11 @@ describe('nativeImage module', () => {
     })
 
     it('throws on invalid arguments', () => {
-      expect(() => nativeImage.createFromBitmap(null, {})).to.throw('buffer must be a node Buffer')
-      expect(() => nativeImage.createFromBitmap([12, 14, 124, 12], {})).to.throw('buffer must be a node Buffer')
-      expect(() => nativeImage.createFromBitmap(Buffer.from([]), {})).to.throw('width is required')
-      expect(() => nativeImage.createFromBitmap(Buffer.from([]), { width: 1 })).to.throw('height is required')
-      expect(() => nativeImage.createFromBitmap(Buffer.from([]), { width: 1, height: 1 })).to.throw('invalid buffer size')
+      expect(() => nativeImage.createFromBitmap(null, {})).to.throw('Buffer must be a Node.js Buffer.')
+      expect(() => nativeImage.createFromBitmap([12, 14, 124, 12], {})).to.throw('Buffer must be a Node.js Buffer.')
+      expect(() => nativeImage.createFromBitmap(Buffer.from([]), {})).to.throw(`width' parameter is required.`)
+      expect(() => nativeImage.createFromBitmap(Buffer.from([]), { width: 1 })).to.throw(`'height' parameter is required.`)
+      expect(() => nativeImage.createFromBitmap(Buffer.from([]), { width: 1, height: 1 })).to.throw('Invalid buffer size.')
     })
   })
 
@@ -224,8 +224,8 @@ describe('nativeImage module', () => {
     })
 
     it('throws on invalid arguments', () => {
-      expect(() => nativeImage.createFromBuffer(null)).to.throw('buffer must be a node Buffer')
-      expect(() => nativeImage.createFromBuffer([12, 14, 124, 12])).to.throw('buffer must be a node Buffer')
+      expect(() => nativeImage.createFromBuffer(null)).to.throw('Buffer must be a Node.js Buffer.')
+      expect(() => nativeImage.createFromBuffer([12, 14, 124, 12])).to.throw('Buffer must be a Node.js Buffer.')
     })
   })
 

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -537,16 +537,16 @@ describe('webContents module', () => {
     it('throws errors for a missing file or a missing/empty icon', () => {
       expect(() => {
         w.webContents.startDrag({ icon: path.join(fixtures, 'assets', 'logo.png') })
-      }).to.throw(`Must specify either 'file' or 'files' option`)
+      }).to.throw(`Must specify either 'file' or 'files' parameter.`)
 
       expect(() => {
         w.webContents.startDrag({ file: __filename })
-      }).to.throw(`Must specify 'icon' option`)
+      }).to.throw(`'icon' parameter is required.`)
 
       if (process.platform === 'darwin') {
         expect(() => {
           w.webContents.startDrag({ file: __filename, icon: __filename })
-        }).to.throw(`Must specify non-empty 'icon' option`)
+        }).to.throw(`Non-empty 'icon' parameter is required.`)
       }
     })
   })


### PR DESCRIPTION
#### Description of Change

Standardizes formatting and punctuation style in our natively thrown errors. `native_mate` (gin) also gives us the ability to throw `TypeErrors` natively, so i've also changed `ThrowError` to `ThrowTypeError` where applicable. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
