### PR TITLE
chore: use base::Environment in Linux MoveItemToTrash()

### DIFF
--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -85,7 +85,7 @@ void OpenExternal(const GURL& url,
 bool MoveItemToTrash(const base::FilePath& full_path) {
   std::unique_ptr<base::Environment> env(base::Environment::Create());
 
-  // find the trash cmd
+  // find the trash method
   std::string trash;
   if (!env->GetVar(ELECTRON_TRASH, &trash)) {
     // Determine desktop environment and set accordingly.

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -89,7 +89,7 @@ bool MoveItemToTrash(const base::FilePath& full_path) {
   std::string trash;
   if (!env->GetVar(ELECTRON_TRASH, &trash)) {
     // Determine desktop environment and set accordingly.
-    const auto& desktop_env(base::nix::GetDesktopEnvironment(env.get()));
+    const auto desktop_env(base::nix::GetDesktopEnvironment(env.get()));
     if (desktop_env == base::nix::DESKTOP_ENVIRONMENT_KDE4 ||
         desktop_env == base::nix::DESKTOP_ENVIRONMENT_KDE5) {
       trash = "kioclient5";

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -19,7 +19,7 @@
 
 namespace {
 
-bool XDGUtilV(const std::vector<std::string>& argv, const bool wait_for_exit) {
+bool XDGUtil(const std::vector<std::string>& argv, const bool wait_for_exit) {
   base::LaunchOptions options;
   options.allow_new_privs = true;
   // xdg-open can fall back on mailcap which eventually might plumb through
@@ -43,22 +43,12 @@ bool XDGUtilV(const std::vector<std::string>& argv, const bool wait_for_exit) {
   return true;
 }
 
-bool XDGUtil(const std::string& util,
-             const std::string& arg,
-             const bool wait_for_exit) {
-  std::vector<std::string> argv;
-  argv.push_back(util);
-  argv.push_back(arg);
-
-  return XDGUtilV(argv, wait_for_exit);
-}
-
 bool XDGOpen(const std::string& path, const bool wait_for_exit) {
-  return XDGUtil("xdg-open", path, wait_for_exit);
+  return XDGUtil({"xdg-open", path}, wait_for_exit);
 }
 
 bool XDGEmail(const std::string& email, const bool wait_for_exit) {
-  return XDGUtil("xdg-email", email, wait_for_exit);
+  return XDGUtil({"xdg-email", email}, wait_for_exit);
 }
 
 }  // namespace
@@ -121,7 +111,7 @@ bool MoveItemToTrash(const base::FilePath& full_path) {
     argv = {"gio", "trash", filename};
   }
 
-  return XDGUtilV(argv, true);
+  return XDGUtil(argv, true);
 }
 
 void Beep() {


### PR DESCRIPTION
#### Description of Change

A small cleanup / code consistency PR. No change in functionality.

The wart that prompted this PR is the prior code called `::getenv()` to sniff the `ELECTRON_TRASH` environment variable, then immediately used `base::Environment` to sniff the desktop environment. This PR constructs the `base::Environment` first so that it can be used in both places.

Also removes an unnecessary function wrapper and makes the trash argv builder easier to read.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes