### PR TITLE
feat: add getBounds() method for BrowserView

### DIFF
--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -94,6 +94,12 @@ Returns `Boolean` - Whether the view is destroyed.
 
 Resizes and moves the view to the supplied bounds relative to the window.
 
+#### `view.getBounds()` _Experimental_
+
+Returns [`Rectangle`](structures/rectangle.md)
+
+The `bounds` of this BrowserView instance as `Object`.
+
 #### `view.setBackgroundColor(color)` _Experimental_
 
 * `color` String - Color in `#aarrggbb` or `#argb` form. The alpha channel is

--- a/shell/browser/api/atom_api_browser_view.cc
+++ b/shell/browser/api/atom_api_browser_view.cc
@@ -127,6 +127,10 @@ void BrowserView::SetBounds(const gfx::Rect& bounds) {
   view_->SetBounds(bounds);
 }
 
+gfx::Rect BrowserView::GetBounds() {
+  return view_->GetBounds();
+}
+
 void BrowserView::SetBackgroundColor(const std::string& color_name) {
   view_->SetBackgroundColor(ParseHexColor(color_name));
 }
@@ -147,6 +151,7 @@ void BrowserView::BuildPrototype(v8::Isolate* isolate,
       .MakeDestroyable()
       .SetMethod("setAutoResize", &BrowserView::SetAutoResize)
       .SetMethod("setBounds", &BrowserView::SetBounds)
+      .SetMethod("getBounds", &BrowserView::GetBounds)
       .SetMethod("setBackgroundColor", &BrowserView::SetBackgroundColor)
       .SetProperty("webContents", &BrowserView::GetWebContents)
       .SetProperty("id", &BrowserView::ID);

--- a/shell/browser/api/atom_api_browser_view.h
+++ b/shell/browser/api/atom_api_browser_view.h
@@ -59,6 +59,7 @@ class BrowserView : public mate::TrackableObject<BrowserView>,
 
   void SetAutoResize(AutoResizeFlags flags);
   void SetBounds(const gfx::Rect& bounds);
+  gfx::Rect GetBounds();
   void SetBackgroundColor(const std::string& color_name);
 
   v8::Local<v8::Value> GetWebContents();

--- a/shell/browser/native_browser_view.h
+++ b/shell/browser/native_browser_view.h
@@ -43,6 +43,7 @@ class NativeBrowserView {
 
   virtual void SetAutoResizeFlags(uint8_t flags) = 0;
   virtual void SetBounds(const gfx::Rect& bounds) = 0;
+  virtual gfx::Rect GetBounds() = 0;
   virtual void SetBackgroundColor(SkColor color) = 0;
 
   // Called when the window needs to update its draggable region.

--- a/shell/browser/native_browser_view_mac.h
+++ b/shell/browser/native_browser_view_mac.h
@@ -21,6 +21,7 @@ class NativeBrowserViewMac : public NativeBrowserView {
 
   void SetAutoResizeFlags(uint8_t flags) override;
   void SetBounds(const gfx::Rect& bounds) override;
+  gfx::Rect GetBounds() override;
   void SetBackgroundColor(SkColor color) override;
 
   void UpdateDraggableRegions(

--- a/shell/browser/native_browser_view_mac.mm
+++ b/shell/browser/native_browser_view_mac.mm
@@ -10,6 +10,7 @@
 #include "shell/browser/ui/inspectable_web_contents_view.h"
 #include "skia/ext/skia_utils_mac.h"
 #include "ui/gfx/geometry/rect.h"
+#include "ui/gfx/mac/coordinate_conversion.h"
 
 // Match view::Views behavior where the view sticks to the top-left origin.
 const NSAutoresizingMaskOptions kDefaultAutoResizingMask =
@@ -199,6 +200,17 @@ void NativeBrowserViewMac::SetBounds(const gfx::Rect& bounds) {
   view.frame =
       NSMakeRect(bounds.x(), superview_height - bounds.y() - bounds.height(),
                  bounds.width(), bounds.height());
+}
+
+gfx::Rect NativeBrowserViewMac::GetBounds() {
+  NSView* view =
+      GetInspectableWebContentsView()->GetNativeView().GetNativeNSView();
+  const int superview_height =
+      (view.superview) ? view.superview.frame.size.height : 0;
+  return gfx::Rect(
+      view.frame.origin.x,
+      superview_height - view.frame.origin.y - view.frame.size.height,
+      view.frame.size.width, view.frame.size.height);
 }
 
 void NativeBrowserViewMac::SetBackgroundColor(SkColor color) {

--- a/shell/browser/native_browser_view_mac.mm
+++ b/shell/browser/native_browser_view_mac.mm
@@ -10,7 +10,6 @@
 #include "shell/browser/ui/inspectable_web_contents_view.h"
 #include "skia/ext/skia_utils_mac.h"
 #include "ui/gfx/geometry/rect.h"
-#include "ui/gfx/mac/coordinate_conversion.h"
 
 // Match view::Views behavior where the view sticks to the top-left origin.
 const NSAutoresizingMaskOptions kDefaultAutoResizingMask =

--- a/shell/browser/native_browser_view_views.cc
+++ b/shell/browser/native_browser_view_views.cc
@@ -97,6 +97,10 @@ void NativeBrowserViewViews::SetBounds(const gfx::Rect& bounds) {
   ResetAutoResizeProportions();
 }
 
+gfx::Rect NativeBrowserViewViews::GetBounds() {
+  return GetInspectableWebContentsView()->GetView()->bounds();
+}
+
 void NativeBrowserViewViews::SetBackgroundColor(SkColor color) {
   auto* view = GetInspectableWebContentsView()->GetView();
   view->SetBackground(views::CreateSolidBackground(color));

--- a/shell/browser/native_browser_view_views.h
+++ b/shell/browser/native_browser_view_views.h
@@ -24,6 +24,7 @@ class NativeBrowserViewViews : public NativeBrowserView {
   // NativeBrowserView:
   void SetAutoResizeFlags(uint8_t flags) override;
   void SetBounds(const gfx::Rect& bounds) override;
+  gfx::Rect GetBounds() override;
   void SetBackgroundColor(SkColor color) override;
 
  private:

--- a/spec-main/api-browser-view-spec.ts
+++ b/spec-main/api-browser-view-spec.ts
@@ -92,6 +92,15 @@ describe('BrowserView module', () => {
     })
   })
 
+  describe('BrowserView.getBounds()', () => {
+    it('returns the current bounds', () => {
+      view = new BrowserView()
+      const bounds = { x: 10, y: 20, width: 30, height: 40 }
+      view.setBounds(bounds)
+      expect(view.getBounds()).to.deep.equal(bounds)
+    })
+  })
+
   describe('BrowserWindow.setBrowserView()', () => {
     it('does not throw for valid args', () => {
       view = new BrowserView()


### PR DESCRIPTION
#### Description of Change
Closes #18734. 

This PR extends the functionality of our experimental `BrowserView` API by adding a `getBounds()` method to get the current size & position.

cc @codebytere @erickzhao 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `getBounds()` method for BrowserView.
