### PR TITLE
docs: update public electron timeline

### DIFF
--- a/docs/tutorial/electron-timelines.md
+++ b/docs/tutorial/electron-timelines.md
@@ -1,54 +1,16 @@
 # Electron Release Timelines
 
-### Notes
-
-* The `-beta.1` and `stable` dates are our *concrete* release dates.
+* The `-beta.1` and `stable` dates are our solid release dates.
 * We strive for weekly beta releases, however we often release more betas than scheduled.
 * All dates are our goals but there may be reasons for adjusting the stable deadline, such as security bugs.
+* Take a look at the [5.0.0 Timeline blog post](https://electronjs.org/blog/electron-5-0-timeline) for info about publicizing our release dates.
 
-## 5.0.0 Release Schedule
-
-*Includes: Chromium M73 and Node v12.0*
-
-Take a look at 5.0.0 Timeline [blog post](https://electronjs.org/blog/electron-5-0-timeline) for info about publicizing our release dates.
-
-| Date/Week Of    | Release      | Comments       |
-| --------------- | ------------ | -------------- |
-| Tue, 2019-Jan-22 | 5.0.0-beta.1 |🔥 |
-| Tue, 2019-Jan-29 | 5.0.0-beta.x ||
-| Tue, 2019-Feb-05 | 5.0.0-beta.x |Last Date to Join [AFP](https://electronjs.org/blog/app-feedback-program)|
-| Tue, 2019-Feb-12 | 5.0.0-beta.x ||
-| Tue, 2019-Feb-19 | none | Maintainers Summit |
-| Tue, 2019-Feb-26 | 5.0.0-beta.x ||
-| Tue, 2019-Mar-05 | 5.0.0-beta.x | halfway mark |
-| Tue, 2019-Mar-12 | 5.0.0-beta.x ||
-| Tue, 2019-Mar-19 | 5.0.0-beta.x ||
-| Tue, 2019-Mar-26 | 5.0.0-beta.x ||
-| Tue, 2019-Apr-02 | 5.0.0-beta.x ||
-| Tue, 2019-Apr-09 | 5.0.0-beta.x ||
-| Tue, 2019-Apr-16 | none | quiet period - stable prep |
-| Tue, 2019-Apr-23 | 5.0.0 |✨stable ✨|
-
-## 6.0.0 Release Schedule
-*Includes: Chromium M76 and Node v12.0*
-
-| Date/Week Of    | Release      | Comments       |
-| --------------- | ------------ | -------------- |
-| Tue, 2019-Apr-30 | 6.0.0-beta.1 | 🔥 |
-| Tue, 2019-May-07 | 6.0.0-beta.x | |
-| Tue, 2019-May-14 | 6.0.0-beta.x | |
-| Tue, 2019-May-21 | 6.0.0-beta.x | |
-| Tue, 2019-May-28 | 6.0.0-beta.x | |
-| Tue, 2019-Jun-04 | 6.0.0-beta.x | |
-| Tue, 2019-Jun-11 | 6.0.0-beta.x | halfway mark |
-| Tue, 2019-Jun-18 | 6.0.0-beta.x | |
-| Tue, 2019-Jun-25 | 6.0.0-beta.x | |
-| Tue, 2019-Jul-02 | 6.0.0-beta.x | |
-| Tue, 2019-Jul-09 | 6.0.0-beta.x | |
-| Tue, 2019-Jul-16 | 6.0.0-beta.x | |
-| Tue, 2019-Jul-23 | 6.0.0-beta.x | 🚧 quiet period - stable prep 🚧 |
-| Tue, 2019-Jul-30 | 6.0.0 | ✨ stable ✨ |
-
-## 7.0.0 Release Schedule
-
-TBD
+| Version | -beta.1 | Stable | Chrome | Node |
+| ------- | ------- | ------ | ------ | ---- |
+| 2.0.0 | 2018-02-21 | 2018-05-01 | M61 | v8 |
+| 3.0.0 | 2018-06-21 | 2018-09-18 | M66 | v10 |
+| 4.0.0 | 2018-10-11 | 2018-12-20 | M69 | v10 |
+| 5.0.0 | 2019-01-22 | 2019-04-24 | M73 | v12 |
+| 6.0.0 | 2019-05-01 | 2019-07-30 | M76 | v12 |
+| 7.0.0 | 2019-08-01 | 2019-10-22 | M78 | v12 |
+| 8.0.0 | TBD | TBD | TBD | TBD |


### PR DESCRIPTION
#### Description of Change
Decluttering our public release timeline doc. I've moved our internal releases schedule to the governance repo [here](https://github.com/electron/governance/blob/master/wg-releases/major-version-release-schedule.md)

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes