### PR TITLE
build: make //electron:electron_lib a source_set

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -337,7 +337,7 @@ templated_file("electron_version_header") {
   args_files = get_target_outputs(":electron_version_args")
 }
 
-static_library("electron_lib") {
+source_set("electron_lib") {
   configs += [ "//v8:external_startup_data" ]
   configs += [ "//third_party/electron_node:node_internals" ]
 


### PR DESCRIPTION
#### Description of Change
We don't need the `libelectron_lib.a` file for anything so we might as well skip creating it. Should make rebuilds a few seconds faster.

From GN [documentation](https://chromium.googlesource.com/chromium/src/tools/gn/+/48062805e19b4697c5fbd926dc649c78b6aaa138/docs/language.md):

> source_set: A lightweight virtual static library (usually preferrable over a real static library since it will build faster).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none