### PR TITLE
chore: clean up BrowserView/TopLevelWindow New impl

### DIFF
--- a/shell/browser/api/atom_api_browser_view.cc
+++ b/shell/browser/api/atom_api_browser_view.cc
@@ -102,15 +102,8 @@ mate::WrappableBase* BrowserView::New(mate::Arguments* args) {
     return nullptr;
   }
 
-  if (args->Length() > 1) {
-    args->ThrowError("Too many arguments");
-    return nullptr;
-  }
-
-  mate::Dictionary options;
-  if (!(args->Length() == 1 && args->GetNext(&options))) {
-    options = mate::Dictionary::CreateEmpty(args->isolate());
-  }
+  mate::Dictionary options = mate::Dictionary::CreateEmpty(args->isolate());
+  args->GetNext(&options);
 
   return new BrowserView(args->isolate(), args->GetThis(), options);
 }

--- a/shell/browser/api/atom_api_top_level_window.cc
+++ b/shell/browser/api/atom_api_top_level_window.cc
@@ -1024,9 +1024,9 @@ void TopLevelWindow::RemoveFromParentChildWindows() {
 
 // static
 mate::WrappableBase* TopLevelWindow::New(mate::Arguments* args) {
-  mate::Dictionary options;
-  if (!(args->Length() == 1 && args->GetNext(&options)))
-    options = mate::Dictionary::CreateEmpty(args->isolate());
+  mate::Dictionary options = mate::Dictionary::CreateEmpty(args->isolate());
+  args->GetNext(&options);
+
   return new TopLevelWindow(args->isolate(), args->GetThis(), options);
 }
 


### PR DESCRIPTION
#### Description of Change

Idiomatically, JavaScript ignores extra arguments passed to a function if they're not used or needed, and in our `BrowserView::New` impl we threw an error if there were too many. To better align with  behavior that JavaScript users would expect, this PR thus defaults the `options` dict to an empty one, and attempts to get an `options` dict param should it be passed.

Also defaults the options dict in `TopLevelWindow::New` even though we didn't throw an error there. 

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none