### PR TITLE
chore: update Windows on Arm's compiler again

### DIFF
--- a/patches/common/chromium/woa_compiler_workaround.patch
+++ b/patches/common/chromium/woa_compiler_workaround.patch
@@ -13,7 +13,7 @@ removed when Electron's Chromium updates to a compiler unaffected by
 this issue.
 
 diff --git a/tools/clang/scripts/update.py b/tools/clang/scripts/update.py
-index 082dc5ec7ac304109a267456df4660c2cfa672f9..a4b14a8dddb02a9bd3ac7a0967ae6c4c7031d83b 100755
+index 082dc5ec7ac304109a267456df4660c2cfa672f9..92dbadd5dd12fccc44ccf46c00d1d23c8336a4dc 100755
 --- a/tools/clang/scripts/update.py
 +++ b/tools/clang/scripts/update.py
 @@ -40,6 +40,11 @@ CLANG_REVISION = '67510fac36d27b2e22c7cd955fc167136b737b93'
@@ -21,9 +21,9 @@ index 082dc5ec7ac304109a267456df4660c2cfa672f9..a4b14a8dddb02a9bd3ac7a0967ae6c4c
  CLANG_SUB_REVISION = 4
  
 +if os.getenv("ELECTRON_BUILDING_WOA"):
-+    CLANG_REVISION = '56bee1a90a71876cb5067b108bf5715fa1c4e843'
-+    CLANG_SVN_REVISION = '361657'
-+    CLANG_SUB_REVISION = 1
++    CLANG_REVISION = 'f7e52fbdb5a7af8ea0808e98458b497125a5eca1'
++    CLANG_SVN_REVISION = '365097'
++    CLANG_SUB_REVISION = 2
 +
  PACKAGE_VERSION = '%s-%s-%s' % (CLANG_SVN_REVISION, CLANG_REVISION[:8],
                                  CLANG_SUB_REVISION)


### PR DESCRIPTION
#### Description of Change
This change, specific to Windows on Arm, updates the compiler to an even later version which supports emitting CodeView debug information. Whilst the previous compiler didn't have any known code-gen issues, Visual Studio could not display detailed information (like the values of variables) whilst debugging. This version of the compiler also has no known code-gen issues, but makes for a nicer debugging experience.

We've successfully brought up [Visual Studio Code's Electron 6 branch](https://github.com/microsoft/vscode/pull/75802) with this compiler and have been testing it internally, so we're confident that there aren't any remaining issues. This PR is only for the `6-0-x` branch because `master` has already updated to a version of Chromium which includes this compiler.

CC: @jkleinsc 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
