### PR TITLE
fix: reduce clipboard flakiness on Windows on Arm

### DIFF
--- a/patches/common/chromium/.patches
+++ b/patches/common/chromium/.patches
@@ -81,3 +81,4 @@ cross_site_document_resource_handler.patch
 frame_host_manager.patch
 crashpad_pid_check.patch
 chore_add_debounce_on_the_updatewebcontentsvisibility_method_to.patch
+fix_speculative_workaround_for_clipboard_failures.patch

--- a/patches/common/chromium/fix_speculative_workaround_for_clipboard_failures.patch
+++ b/patches/common/chromium/fix_speculative_workaround_for_clipboard_failures.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Richard Townsend <Richard.Townsend@arm.com>
+Date: Sun, 21 Jul 2019 17:54:36 +0100
+Subject: fix: speculative workaround for clipboard failures
+
+
+diff --git a/remoting/host/clipboard_win.cc b/remoting/host/clipboard_win.cc
+index bcad28431bce60bae9b10f14ef890212993efd9b..95de872dfdfbf671106d8d4bc9a12dd330a8b395 100644
+--- a/remoting/host/clipboard_win.cc
++++ b/remoting/host/clipboard_win.cc
+@@ -43,7 +43,7 @@ class ScopedClipboard {
+   }
+
+   bool Init(HWND owner) {
+-    const int kMaxAttemptsToOpenClipboard = 5;
++    const int kMaxAttemptsToOpenClipboard = 30;
+     const base::TimeDelta kSleepTimeBetweenAttempts =
+         base::TimeDelta::FromMilliseconds(5);
+


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

We've noticed that the clipboard tests (which attempt to put stuff onto the system clipboard and retrieve it later) seem to fail on Windows on Arm more often than on x86. We suspect that this is due to system software increasing contention for the clipboard. This patch adds a chromium-based workaround that increases the retry count when acquiring the clipboard. This seems to reduce the number of times the test spuriously fails. We don't expect any impact on other systems (where the clipboard has less contention) and we don't expect this to negatively impact user experience (i.e. when the device is not under test). 

If we agree that this is an issue worth fixing, we will contribute a fix for the issue upstream in time for Electron 7. 

CC @jkleinsc 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: no-notes <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
