### PR TITLE
fix: "TypeError: fn is not a function" crash in release notes generator

### DIFF
--- a/script/release/notes/notes.js
+++ b/script/release/notes/notes.js
@@ -319,25 +319,14 @@ async function runRetryable (fn, maxRetries) {
 
 const getPullRequest = async (number, owner, repo) => {
   const name = `${owner}-${repo}-pull-${number}`
-  return checkCache(name, async () => {
-    return runRetryable(octokit.pulls.get({
-      number,
-      owner,
-      repo
-    }), MAX_FAIL_COUNT)
-  })
+  const retryableFunc = async () => octokit.pulls.get({ pull_number: number, owner, repo })
+  return checkCache(name, async () => runRetryable(retryableFunc, MAX_FAIL_COUNT))
 }
 
 const getComments = async (number, owner, repo) => {
-  const name = `${owner}-${repo}-pull-${number}-comments`
-  return checkCache(name, async () => {
-    return runRetryable(octokit.issues.listComments({
-      number,
-      owner,
-      repo,
-      per_page: 100
-    }), MAX_FAIL_COUNT)
-  })
+  const name = `${owner}-${repo}-issue-${number}-comments`
+  const retryableFunc = async () => octokit.issues.listComments({ issue_number: number, owner, repo, per_page: 100 })
+  return checkCache(name, async () => runRetryable(retryableFunc, MAX_FAIL_COUNT))
 }
 
 const addRepoToPool = async (pool, repo, from, to) => {

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -85,7 +85,7 @@ void OpenExternal(const GURL& url,
 bool MoveItemToTrash(const base::FilePath& full_path) {
   std::unique_ptr<base::Environment> env(base::Environment::Create());
 
-  // find the trash cmd
+  // find the trash method
   std::string trash;
   if (!env->GetVar(ELECTRON_TRASH, &trash)) {
     // Determine desktop environment and set accordingly.

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -19,7 +19,7 @@
 
 namespace {
 
-bool XDGUtilV(const std::vector<std::string>& argv, const bool wait_for_exit) {
+bool XDGUtil(const std::vector<std::string>& argv, const bool wait_for_exit) {
   base::LaunchOptions options;
   options.allow_new_privs = true;
   // xdg-open can fall back on mailcap which eventually might plumb through
@@ -43,22 +43,12 @@ bool XDGUtilV(const std::vector<std::string>& argv, const bool wait_for_exit) {
   return true;
 }
 
-bool XDGUtil(const std::string& util,
-             const std::string& arg,
-             const bool wait_for_exit) {
-  std::vector<std::string> argv;
-  argv.push_back(util);
-  argv.push_back(arg);
-
-  return XDGUtilV(argv, wait_for_exit);
-}
-
 bool XDGOpen(const std::string& path, const bool wait_for_exit) {
-  return XDGUtil("xdg-open", path, wait_for_exit);
+  return XDGUtil({"xdg-open", path}, wait_for_exit);
 }
 
 bool XDGEmail(const std::string& email, const bool wait_for_exit) {
-  return XDGUtil("xdg-email", email, wait_for_exit);
+  return XDGUtil({"xdg-email", email}, wait_for_exit);
 }
 
 }  // namespace
@@ -121,7 +111,7 @@ bool MoveItemToTrash(const base::FilePath& full_path) {
     argv = {"gio", "trash", filename};
   }
 
-  return XDGUtilV(argv, true);
+  return XDGUtil(argv, true);
 }
 
 void Beep() {


### PR DESCRIPTION
#### Description of Change

 * Fix a bug introduced in https://github.com/electron/electron/pull/18085. In that code, the two functions calling `runRetryable(fn)` seem to have always passed in a Promise, rather than a Promise-generating-function, as the retryable function `fn`. It seems this threw a `TypeError: fn is not a function` on every call? :boom: 

Fixed a pair of secondary issues in the related code:

 * octokit has deprecated use of `number` in the `octokit.issues.listComments()` and `octokit.pulls.get()` API, so this PR also uses `issue_number` and `pull_number` instead.

 * minor fix: the cached file names of issue comments mistakenly used the word `pull` rather than `issue`. I don't think this caused any issues, but it's cleaner to use the right name.

CC @codebytere 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes