### PR TITLE
fix: "TypeError: fn is not a function" crash in release notes generator

### DIFF
--- a/script/release/notes/notes.js
+++ b/script/release/notes/notes.js
@@ -329,7 +329,7 @@ const getPullRequest = async (number, owner, repo) => {
 }
 
 const getComments = async (number, owner, repo) => {
-  const name = `${owner}-${repo}-pull-${number}-comments`
+  const name = `${owner}-${repo}-issue-${number}-comments`
   return checkCache(name, async () => {
     return runRetryable(octokit.issues.listComments({
       number,

--- a/script/release/notes/notes.js
+++ b/script/release/notes/notes.js
@@ -320,13 +320,13 @@ async function runRetryable (fn, maxRetries) {
 const getPullRequest = async (number, owner, repo) => {
   const name = `${owner}-${repo}-pull-${number}`
   const retryableFunc = () => octokit.pulls.get({ pull_number: number, owner, repo })
-  return checkCache(name, async () => runRetryable(retryableFunc, MAX_FAIL_COUNT))
+  return checkCache(name, () => runRetryable(retryableFunc, MAX_FAIL_COUNT))
 }
 
 const getComments = async (number, owner, repo) => {
   const name = `${owner}-${repo}-issue-${number}-comments`
   const retryableFunc = () => octokit.issues.listComments({ issue_number: number, owner, repo, per_page: 100 })
-  return checkCache(name, async () => runRetryable(retryableFunc, MAX_FAIL_COUNT))
+  return checkCache(name, () => runRetryable(retryableFunc, MAX_FAIL_COUNT))
 }
 
 const addRepoToPool = async (pool, repo, from, to) => {

--- a/script/release/notes/notes.js
+++ b/script/release/notes/notes.js
@@ -319,25 +319,14 @@ async function runRetryable (fn, maxRetries) {
 
 const getPullRequest = async (number, owner, repo) => {
   const name = `${owner}-${repo}-pull-${number}`
-  return checkCache(name, async () => {
-    return runRetryable(octokit.pulls.get({
-      pull_number: number,
-      owner,
-      repo
-    }), MAX_FAIL_COUNT)
-  })
+  const retryableFunc = async () => octokit.pulls.get({ pull_number: number, owner, repo })
+  return checkCache(name, async () => runRetryable(retryableFunc, MAX_FAIL_COUNT))
 }
 
 const getComments = async (number, owner, repo) => {
   const name = `${owner}-${repo}-issue-${number}-comments`
-  return checkCache(name, async () => {
-    return runRetryable(octokit.issues.listComments({
-      issue_number: number,
-      owner,
-      repo,
-      per_page: 100
-    }), MAX_FAIL_COUNT)
-  })
+  const retryableFunc = async () => octokit.issues.listComments({ issue_number: number, owner, repo, per_page: 100 })
+  return checkCache(name, async () => runRetryable(retryableFunc, MAX_FAIL_COUNT))
 }
 
 const addRepoToPool = async (pool, repo, from, to) => {

--- a/script/release/notes/notes.js
+++ b/script/release/notes/notes.js
@@ -321,7 +321,7 @@ const getPullRequest = async (number, owner, repo) => {
   const name = `${owner}-${repo}-pull-${number}`
   return checkCache(name, async () => {
     return runRetryable(octokit.pulls.get({
-      number,
+      pull_number: number,
       owner,
       repo
     }), MAX_FAIL_COUNT)
@@ -332,7 +332,7 @@ const getComments = async (number, owner, repo) => {
   const name = `${owner}-${repo}-issue-${number}-comments`
   return checkCache(name, async () => {
     return runRetryable(octokit.issues.listComments({
-      number,
+      issue_number: number,
       owner,
       repo,
       per_page: 100

--- a/script/release/notes/notes.js
+++ b/script/release/notes/notes.js
@@ -319,13 +319,13 @@ async function runRetryable (fn, maxRetries) {
 
 const getPullRequest = async (number, owner, repo) => {
   const name = `${owner}-${repo}-pull-${number}`
-  const retryableFunc = async () => octokit.pulls.get({ pull_number: number, owner, repo })
+  const retryableFunc = () => octokit.pulls.get({ pull_number: number, owner, repo })
   return checkCache(name, async () => runRetryable(retryableFunc, MAX_FAIL_COUNT))
 }
 
 const getComments = async (number, owner, repo) => {
   const name = `${owner}-${repo}-issue-${number}-comments`
-  const retryableFunc = async () => octokit.issues.listComments({ issue_number: number, owner, repo, per_page: 100 })
+  const retryableFunc = () => octokit.issues.listComments({ issue_number: number, owner, repo, per_page: 100 })
   return checkCache(name, async () => runRetryable(retryableFunc, MAX_FAIL_COUNT))
 }
 


### PR DESCRIPTION
#### Description of Change

 * Fix a bug introduced in https://github.com/electron/electron/pull/18085. In that code, the two functions calling `runRetryable(fn)` seem to have always passed in a Promise, rather than a function-which-returns-a-promise, as the retryable function `fn`. It seems this threw a `TypeError: fn is not a function` on every call? :boom: 

Fixed a pair of secondary issues in the related code:

 * octokit has deprecated use of `number` in the `octokit.issues.listComments()` and `octokit.pulls.get()` API, so this PR also uses `issue_number` and `pull_number` instead.

 * minor fix: the cached file names of issue comments mistakenly used the word `pull` rather than `issue`. I don't think this caused any issues, but it's cleaner to use the right name.

CC @codebytere 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes