### PR TITLE
docs: fix bad link in notifications tut

### DIFF
--- a/docs/tutorial/notifications.md
+++ b/docs/tutorial/notifications.md
@@ -36,7 +36,7 @@ Electron is used together with the installation and update framework Squirrel,
 [shortcuts will automatically be set correctly][squirrel-events]. Furthermore,
 Electron will detect that Squirrel was used and will automatically call
 `app.setAppUserModelId()` with the correct value. During development, you may have
-to call [`app.setAppUserModelId()`][[set-app-user-model-id]] yourself.
+to call [`app.setAppUserModelId()`][set-app-user-model-id] yourself.
 
 Furthermore, in Windows 8, the maximum length for the notification body is 250
 characters, with the Windows team recommending that notifications should be kept


### PR DESCRIPTION
#### Description of Change
Fixes a typo. Enforced by https://github.com/electron/i18n/pull/759. 

cc @HashimotoYT @felixrieseberg  

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none
