### PR TITLE
docs: BrowserWindow transparency limitation on Windows

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -209,7 +209,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     transparent) and 1.0 (fully opaque). This is only implemented on Windows and macOS.
   * `darkTheme` Boolean (optional) - Forces using dark theme for the window, only works on
     some GTK+3 desktop environments. Default is `false`.
-  * `transparent` Boolean (optional) - Makes the window [transparent](frameless-window.md##transparent-window).
+  * `transparent` Boolean (optional) - Makes the window [transparent](frameless-window.md#transparent-window).
     Default is `false`. On Windows, does not work unless the window is frameless.
   * `type` String (optional) - The type of window, default is normal window. See more about
     this below.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -209,8 +209,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     transparent) and 1.0 (fully opaque). This is only implemented on Windows and macOS.
   * `darkTheme` Boolean (optional) - Forces using dark theme for the window, only works on
     some GTK+3 desktop environments. Default is `false`.
-  * `transparent` Boolean (optional) - Makes the window [transparent](frameless-window.md).
-    Default is `false`.
+  * `transparent` Boolean (optional) - Makes the window [transparent](frameless-window.md##transparent-window).
+    Default is `false`. On Windows, does not work unless the window is frameless.
   * `type` String (optional) - The type of window, default is normal window. See more about
     this below.
   * `titleBarStyle` String (optional) - The style of window title bar.


### PR DESCRIPTION
#### Description of Change

Adds documentation to show that on Windows, the `transparent` option will not work unless `frame: false` is enabled. Also changes the link in the explanation to `frameless-window.md#transparent-window` instead of just `frameless-window.md`.

Not sure if this comment should have been added to `frameless-window.md#transparent-window`, though.

cc @nornagon 

Tested on Win10.
Fiddle: https://gist.github.com/40c9edc073dca2067a298bddd5f9a7df

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes