### PR TITLE
build: unify YARN_VERSION variable usage and ensure CI uses yarn not npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -553,8 +553,8 @@ steps-lint: &steps-lint
           # but then we would lint its contents (at least gn format), and it doesn't pass it.
 
           cd src/electron
-          npm install
-          npm run lint
+          npx yarn@1.15.2 install --frozen-lockfile
+          npx yarn@1.15.2 lint
 
 steps-checkout: &steps-checkout
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,17 +193,17 @@ step-delete-git-directories: &step-delete-git-directories
         sudo rm -rf src/.git
       fi
 
-# On macOS the npm install command during gclient sync was run on a linux
+# On macOS the yarn install command during gclient sync was run on a linux
 # machine and therefore installed a slightly different set of dependencies
-# Notably "fsevents" is a macOS only dependency, we rerun npm install once
+# Notably "fsevents" is a macOS only dependency, we rerun yarn install once
 # we are on a macOS machine to get the correct state
 step-install-npm-deps-on-mac: &step-install-npm-deps-on-mac
   run:
-    name: Install NPM Dependencies on MacOS
+    name: Install node_modules on MacOS
     command: |
       if [ "`uname`" == "Darwin" ]; then
         cd src/electron
-        npm install
+        node script/yarn install
       fi
 
 # This step handles the differences between the linux "gclient sync"
@@ -509,7 +509,7 @@ step-maybe-generate-typescript-defs: &step-maybe-generate-typescript-defs
     command: |
       if [ "`uname`" == "Darwin" ]; then
         cd src/electron
-        npm run create-typescript-definitions
+        node script/yarn create-typescript-definitions
       fi
 
 step-fix-known-hosts-linux: &step-fix-known-hosts-linux
@@ -553,8 +553,8 @@ steps-lint: &steps-lint
           # but then we would lint its contents (at least gn format), and it doesn't pass it.
 
           cd src/electron
-          npx yarn@1.15.2 install --frozen-lockfile
-          npx yarn@1.15.2 lint
+          node script/yarn install
+          node script/yarn lint
 
 steps-checkout: &steps-checkout
   steps:
@@ -807,7 +807,7 @@ steps-tests: &steps-tests
         command: |
           cd src
           export ELECTRON_OUT_DIR=Default
-          (cd electron && npm run test -- --ci --enable-logging)
+          (cd electron && node script/yarn test -- --ci --enable-logging)
     - run:
         name: Check test results existence
         command: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -97,7 +97,7 @@ test_script:
         echo "Skipping tests for $env:GN_CONFIG build"
       }
   - cd electron
-  - if "%RUN_TESTS%"=="true" ( echo Running test suite & npm run test -- --ci --enable-logging)
+  - if "%RUN_TESTS%"=="true" ( echo Running test suite & node script/yarn test -- --ci --enable-logging)
   - cd ..
   - if "%RUN_TESTS%"=="true" ( echo Verifying non proprietary ffmpeg & python electron\script\verify-ffmpeg.py --build-dir out\Default --source-root %cd% --ffmpeg-path out\ffmpeg )
   - echo "About to verify mksnapshot"

--- a/script/lib/utils.js
+++ b/script/lib/utils.js
@@ -1,7 +1,8 @@
-const OUT_DIR = process.env.ELECTRON_OUT_DIR || 'Debug'
-
 const { GitProcess } = require('dugite')
+const fs = require('fs')
 const path = require('path')
+
+const OUT_DIR = process.env.ELECTRON_OUT_DIR || 'Debug'
 
 require('colors')
 const pass = '\u2713'.green

--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -22,12 +22,11 @@ for (const flag of unknownFlags) {
 }
 
 const utils = require('./lib/utils')
+const { YARN_VERSION } = require('./yarn')
 
 const BASE = path.resolve(__dirname, '../..')
 const NPM_CMD = process.platform === 'win32' ? 'npm.cmd' : 'npm'
 const NPX_CMD = process.platform === 'win32' ? 'npx.cmd' : 'npx'
-// KEEP IN SYNC WITH DEPS FILE
-const YARN_VERSION = '1.15.2'
 
 const specHashPath = path.resolve(__dirname, '../spec/.hash')
 

--- a/script/yarn.js
+++ b/script/yarn.js
@@ -1,0 +1,18 @@
+const cp = require('child_process')
+const fs = require('fs')
+const path = require('path')
+
+const YARN_VERSION = /'yarn_version': '(.+?)'/.exec(fs.readFileSync(path.resolve(__dirname, '../DEPS'), 'utf8'))[1]
+
+exports.YARN_VERSION = YARN_VERSION
+
+// If we are running "node script/yarn" run as the yarn CLI
+if (process.mainModule === module) {
+  const NPX_CMD = process.platform === 'win32' ? 'npx.cmd' : 'npx'
+
+  const child = cp.spawn(NPX_CMD, [`yarn@${YARN_VERSION}`, ...process.argv.slice(2)], {
+    stdio: 'inherit'
+  })
+
+  child.on('exit', code => process.exit(code))
+}


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Manual backport of #18607. The lint job was failing on CI in 6-0-x because we were using npm instead of yarn.  This PR changes our CI lint job to use yarn.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
