### PR TITLE
test: move BrowserView specs to main process

### DIFF
--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -79,13 +79,13 @@ Returns `Boolean` - Whether the view is destroyed.
 #### `view.setAutoResize(options)` _Experimental_
 
 * `options` Object
-  * `width` Boolean - If `true`, the view's width will grow and shrink together
+  * `width` Boolean (optional) - If `true`, the view's width will grow and shrink together
     with the window. `false` by default.
-  * `height` Boolean - If `true`, the view's height will grow and shrink
+  * `height` Boolean (optional) - If `true`, the view's height will grow and shrink
     together with the window. `false` by default.
-  * `horizontal` Boolean - If `true`, the view's x position and width will grow
+  * `horizontal` Boolean (optional) - If `true`, the view's x position and width will grow
     and shrink proportionally with the window. `false` by default.
-  * `vertical` Boolean - If `true`, the view's y position and height will grow
+  * `vertical` Boolean (optional) - If `true`, the view's y position and height will grow
     and shrink proportionally with the window. `false` by default.
 
 #### `view.setBounds(bounds)` _Experimental_

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1703,7 +1703,7 @@ removed in future Electron releases.
 
 #### `win.setBrowserView(browserView)` _Experimental_
 
-* `browserView` [BrowserView](browser-view.md) - Attach browserView to win.
+* `browserView` [BrowserView](browser-view.md) | null - Attach browserView to win.
 If there is some other browserViews was attached they will be removed from
 this window.
 
@@ -1724,8 +1724,8 @@ Replacement API for setBrowserView supporting work with multi browser views.
 
 #### `win.getBrowserViews()` _Experimental_
 
-Returns array of `BrowserView` what was an attached with addBrowserView
-or setBrowserView.
+Returns `BrowserView[]` - an array of all BrowserViews that have been attached
+with `addBrowserView` or `setBrowserView`.
 
 **Note:** The BrowserView API is currently experimental and may change or be
 removed in future Electron releases.

--- a/spec-main/ambient.d.ts
+++ b/spec-main/ambient.d.ts
@@ -12,4 +12,8 @@ declare namespace Electron {
   interface MenuItem {
     getDefaultRoleAccelerator(): Accelerator | undefined;
   }
+
+  interface WebContents {
+    getOwnerBrowserWindow(): BrowserWindow;
+  }
 }

--- a/spec-main/api-browser-view-spec.ts
+++ b/spec-main/api-browser-view-spec.ts
@@ -1,23 +1,15 @@
-'use strict'
-
-const chai = require('chai')
-const ChildProcess = require('child_process')
-const dirtyChai = require('dirty-chai')
-const path = require('path')
-const { emittedOnce } = require('./events-helpers')
-const { closeWindow } = require('./window-helpers')
-
-const { remote } = require('electron')
-const { BrowserView, BrowserWindow } = remote
-
-const { expect } = chai
-chai.use(dirtyChai)
+import { expect } from 'chai'
+import * as ChildProcess from 'child_process'
+import * as path from 'path'
+import { emittedOnce } from './events-helpers'
+import { BrowserView, BrowserWindow } from 'electron'
+import { closeWindow } from './window-helpers';
 
 describe('BrowserView module', () => {
-  const fixtures = path.resolve(__dirname, 'fixtures')
+  const fixtures = path.resolve(__dirname, '..', 'spec', 'fixtures')
 
-  let w = null
-  let view = null
+  let w: BrowserWindow
+  let view: BrowserView
 
   beforeEach(() => {
     w = new BrowserWindow({
@@ -30,13 +22,12 @@ describe('BrowserView module', () => {
     })
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     if (view) {
       view.destroy()
-      view = null
     }
 
-    return closeWindow(w).then(() => { w = null })
+    await closeWindow(w)
   })
 
   describe('BrowserView.destroy()', () => {
@@ -49,9 +40,9 @@ describe('BrowserView module', () => {
   describe('BrowserView.isDestroyed()', () => {
     it('returns correct value', () => {
       view = new BrowserView()
-      expect(view.isDestroyed()).to.be.false()
+      expect(view.isDestroyed()).to.be.false('view is destroyed')
       view.destroy()
-      expect(view.isDestroyed()).to.be.true()
+      expect(view.isDestroyed()).to.be.true('view is destroyed')
     })
   })
 
@@ -64,7 +55,7 @@ describe('BrowserView module', () => {
     it('throws for invalid args', () => {
       view = new BrowserView()
       expect(() => {
-        view.setBackgroundColor(null)
+        view.setBackgroundColor(null as any)
       }).to.throw(/conversion failure/)
     })
   })
@@ -79,7 +70,7 @@ describe('BrowserView module', () => {
     it('throws for invalid args', () => {
       view = new BrowserView()
       expect(() => {
-        view.setAutoResize(null)
+        view.setAutoResize(null as any)
       }).to.throw(/conversion failure/)
     })
   })
@@ -93,10 +84,10 @@ describe('BrowserView module', () => {
     it('throws for invalid args', () => {
       view = new BrowserView()
       expect(() => {
-        view.setBounds(null)
+        view.setBounds(null as any)
       }).to.throw(/conversion failure/)
       expect(() => {
-        view.setBounds({})
+        view.setBounds({} as any)
       }).to.throw(/conversion failure/)
     })
   })
@@ -119,28 +110,26 @@ describe('BrowserView module', () => {
     it('returns the set view', () => {
       view = new BrowserView()
       w.setBrowserView(view)
-      expect(view.id).to.not.be.null()
+      expect(view.id).to.not.be.null('view id')
 
       const view2 = w.getBrowserView()
-      expect(view2.webContents.id).to.equal(view.webContents.id)
+      expect(view2!.webContents.id).to.equal(view.webContents.id)
     })
 
     it('returns null if none is set', () => {
       const view = w.getBrowserView()
-      expect(view).to.be.null()
+      expect(view).to.be.null('view')
     })
   })
 
   describe('BrowserWindow.addBrowserView()', () => {
     it('does not throw for valid args', () => {
-      let view1 = new BrowserView()
+      const view1 = new BrowserView()
       w.addBrowserView(view1)
-      let view2 = new BrowserView()
+      const view2 = new BrowserView()
       w.addBrowserView(view2)
       view1.destroy()
-      view1 = null
       view2.destroy()
-      view2 = null
     })
     it('does not throw if called multiple times with same view', () => {
       view = new BrowserView()
@@ -161,34 +150,32 @@ describe('BrowserView module', () => {
 
   describe('BrowserWindow.getBrowserViews()', () => {
     it('returns same views as was added', () => {
-      let view1 = new BrowserView()
+      const view1 = new BrowserView()
       w.addBrowserView(view1)
-      let view2 = new BrowserView()
+      const view2 = new BrowserView()
       w.addBrowserView(view2)
 
-      expect(view1.id).to.be.not.null()
+      expect(view1.id).to.be.not.null('view id')
       const views = w.getBrowserViews()
       expect(views).to.have.lengthOf(2)
       expect(views[0].webContents.id).to.equal(view1.webContents.id)
       expect(views[1].webContents.id).to.equal(view2.webContents.id)
 
       view1.destroy()
-      view1 = null
       view2.destroy()
-      view2 = null
     })
   })
 
   describe('BrowserView.webContents.getOwnerBrowserWindow()', () => {
     it('points to owning window', () => {
       view = new BrowserView()
-      expect(view.webContents.getOwnerBrowserWindow()).to.be.null()
+      expect(view.webContents.getOwnerBrowserWindow()).to.be.null('owner browser window')
 
       w.setBrowserView(view)
       expect(view.webContents.getOwnerBrowserWindow()).to.equal(w)
 
       w.setBrowserView(null)
-      expect(view.webContents.getOwnerBrowserWindow()).to.be.null()
+      expect(view.webContents.getOwnerBrowserWindow()).to.be.null('owner browser window')
     })
   })
 
@@ -196,7 +183,7 @@ describe('BrowserView module', () => {
     it('returns the view with given id', () => {
       view = new BrowserView()
       w.setBrowserView(view)
-      expect(view.id).to.not.be.null()
+      expect(view.id).to.not.be.null('view id')
 
       const view2 = BrowserView.fromId(view.id)
       expect(view2.webContents.id).to.equal(view.webContents.id)
@@ -207,10 +194,10 @@ describe('BrowserView module', () => {
     it('returns the view with given id', () => {
       view = new BrowserView()
       w.setBrowserView(view)
-      expect(view.id).to.not.be.null()
+      expect(view.id).to.not.be.null('view id')
 
       const view2 = BrowserView.fromWebContents(view.webContents)
-      expect(view2.webContents.id).to.equal(view.webContents.id)
+      expect(view2!.webContents.id).to.equal(view.webContents.id)
     })
   })
 
@@ -218,7 +205,7 @@ describe('BrowserView module', () => {
     it('returns all views', () => {
       view = new BrowserView()
       w.setBrowserView(view)
-      expect(view.id).to.not.be.null()
+      expect(view.id).to.not.be.null('view id')
 
       const views = BrowserView.getAllViews()
       expect(views).to.be.an('array').that.has.lengthOf(1)
@@ -229,7 +216,7 @@ describe('BrowserView module', () => {
   describe('new BrowserView()', () => {
     it('does not crash on exit', async () => {
       const appPath = path.join(fixtures, 'api', 'leak-exit-browserview.js')
-      const electronPath = remote.getGlobal('process').execPath
+      const electronPath = process.execPath
       const appProcess = ChildProcess.spawn(electronPath, [appPath])
       const [code] = await emittedOnce(appProcess, 'close')
       expect(code).to.equal(0)


### PR DESCRIPTION
#### Description of Change
BrowserView specs gettin' on the spec-main train 🚋 🚋 🚋

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none