### PR TITLE
test: clean up and augment Tray module spec

### DIFF
--- a/spec-main/api-tray-spec.ts
+++ b/spec-main/api-tray-spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai'
 import { Menu, Tray, nativeImage } from 'electron'
+import { ifdescribe, ifit } from './spec-helpers'
 
 describe('tray module', () => {
   let tray: Tray;
@@ -12,26 +13,22 @@ describe('tray module', () => {
     tray = null as any
   })
 
-  describe('tray get/set ignoreDoubleClickEvents', () => {
-    before(function () {
-      if (process.platform !== 'darwin') this.skip()
-    })
-
+  ifdescribe(process.platform === 'darwin')('tray get/set ignoreDoubleClickEvents', () => {
     it('returns false by default', () => {
       const ignored = tray.getIgnoreDoubleClickEvents()
-      expect(ignored).to.be.false
+      expect(ignored).to.be.false('ignored')
     })
 
     it('can be set to true', () => {
       tray.setIgnoreDoubleClickEvents(true)
 
       const ignored = tray.getIgnoreDoubleClickEvents()
-      expect(ignored).to.be.true
+      expect(ignored).to.be.true('not ignored')
     })
   })
 
   describe('tray.setContextMenu(menu)', () => {
-    it ('accepts both null and Menu as parameters', () => {
+    it('accepts both null and Menu as parameters', () => {
       expect(() => { tray.setContextMenu(new Menu()) }).to.not.throw()
       expect(() => { tray.setContextMenu(null) }).to.not.throw()
 
@@ -49,26 +46,21 @@ describe('tray module', () => {
   })
 
   describe('tray.popUpContextMenu()', () => {
-    it('can be called when menu is showing', function (done) {
-      if (process.platform !== 'win32') this.skip()
-
+    ifit(process.platform === 'win32')('can be called when menu is showing', function (done) {
       tray.setContextMenu(Menu.buildFromTemplate([{ label: 'Test' }]))
       setTimeout(() => {
         tray.popUpContextMenu()
+        tray.destroy()
         done()
       })
       tray.popUpContextMenu()
-
-      tray.destroy()
     })
   })
 
   describe('tray.getBounds()', () => {
     afterEach(() => { tray.destroy() })
 
-    it ('returns a bounds object', function () {
-      if (process.platform === 'linux') this.skip()
-
+    ifit(process.platform !== 'linux') ('returns a bounds object', function () {
       const bounds = tray.getBounds()
       expect(bounds).to.be.an('object').and.to.have.all.keys('x', 'y', 'width', 'height');
     })
@@ -90,11 +82,7 @@ describe('tray module', () => {
     })
   })
 
-  describe('tray get/set title', () => {
-    before(function () {
-      if (process.platform !== 'darwin') this.skip()
-    })
-
+  ifdescribe(process.platform === 'darwin')('tray get/set title', () => {
     afterEach(() => { tray.destroy() })
 
     it('sets/gets non-empty title', () => {

--- a/spec-main/api-tray-spec.ts
+++ b/spec-main/api-tray-spec.ts
@@ -12,17 +12,30 @@ describe('tray module', () => {
     tray = null as any
   })
 
-  describe('tray.setContextMenu', () => {
-    afterEach(() => {
+  describe('tray get/set ignoreDoubleClickEvents', () => {
+    before(function () {
+      if (process.platform !== 'darwin') this.skip()
+    })
+
+    it('returns false by default', () => {
+      const ignored = tray.getIgnoreDoubleClickEvents()
+      expect(ignored).to.be.false
+    })
+
+    it('can be set to true', () => {
+      tray.setIgnoreDoubleClickEvents(true)
+
+      const ignored = tray.getIgnoreDoubleClickEvents()
+      expect(ignored).to.be.true
+    })
+  })
+
+  describe('tray.setContextMenu(menu)', () => {
+    it ('accepts both null and Menu as parameters', () => {
+      expect(() => { tray.setContextMenu(new Menu()) }).to.not.throw()
+      expect(() => { tray.setContextMenu(null) }).to.not.throw()
+
       tray.destroy()
-    })
-
-    it('accepts menu instance', () => {
-      tray.setContextMenu(new Menu())
-    })
-
-    it('accepts null', () => {
-      tray.setContextMenu(null)
     })
   })
 
@@ -35,26 +48,33 @@ describe('tray module', () => {
     })
   })
 
-  describe('tray.popUpContextMenu', () => {
-    afterEach(() => {
-      tray.destroy()
-    })
-
-    before(function () {
+  describe('tray.popUpContextMenu()', () => {
+    it('can be called when menu is showing', function (done) {
       if (process.platform !== 'win32') this.skip()
-    })
 
-    it('can be called when menu is showing', (done) => {
       tray.setContextMenu(Menu.buildFromTemplate([{ label: 'Test' }]))
       setTimeout(() => {
         tray.popUpContextMenu()
         done()
       })
       tray.popUpContextMenu()
+
+      tray.destroy()
     })
   })
 
-  describe('tray.setImage', () => {
+  describe('tray.getBounds()', () => {
+    afterEach(() => { tray.destroy() })
+
+    it ('returns a bounds object', function () {
+      if (process.platform === 'linux') this.skip()
+
+      const bounds = tray.getBounds()
+      expect(bounds).to.be.an('object').and.to.have.all.keys('x', 'y', 'width', 'height');
+    })
+  })
+
+  describe('tray.setImage(image)', () => {
     it('accepts empty image', () => {
       tray.setImage(nativeImage.createEmpty())
 
@@ -62,7 +82,7 @@ describe('tray module', () => {
     })
   })
 
-  describe('tray.setPressedImage', () => {
+  describe('tray.setPressedImage(image)', () => {
     it('accepts empty image', () => {
       tray.setPressedImage(nativeImage.createEmpty())
 
@@ -70,14 +90,12 @@ describe('tray module', () => {
     })
   })
 
-  describe('tray title get/set', () => {
+  describe('tray get/set title', () => {
     before(function () {
       if (process.platform !== 'darwin') this.skip()
     })
 
-    afterEach(() => {
-      tray.destroy()
-    })
+    afterEach(() => { tray.destroy() })
 
     it('sets/gets non-empty title', () => {
       const title = 'Hello World!'

--- a/spec-main/api-tray-spec.ts
+++ b/spec-main/api-tray-spec.ts
@@ -5,11 +5,10 @@ import { ifdescribe, ifit } from './spec-helpers'
 describe('tray module', () => {
   let tray: Tray;
 
-  beforeEach(() => {
-    tray = new Tray(nativeImage.createEmpty())
-  })
+  beforeEach(() => { tray = new Tray(nativeImage.createEmpty()) })
 
   afterEach(() => {
+    tray.destroy()
     tray = null as any
   })
 
@@ -31,8 +30,6 @@ describe('tray module', () => {
     it('accepts both null and Menu as parameters', () => {
       expect(() => { tray.setContextMenu(new Menu()) }).to.not.throw()
       expect(() => { tray.setContextMenu(null) }).to.not.throw()
-
-      tray.destroy()
     })
   })
 
@@ -50,7 +47,6 @@ describe('tray module', () => {
       tray.setContextMenu(Menu.buildFromTemplate([{ label: 'Test' }]))
       setTimeout(() => {
         tray.popUpContextMenu()
-        tray.destroy()
         done()
       })
       tray.popUpContextMenu()
@@ -69,22 +65,16 @@ describe('tray module', () => {
   describe('tray.setImage(image)', () => {
     it('accepts empty image', () => {
       tray.setImage(nativeImage.createEmpty())
-
-      tray.destroy()
     })
   })
 
   describe('tray.setPressedImage(image)', () => {
     it('accepts empty image', () => {
       tray.setPressedImage(nativeImage.createEmpty())
-
-      tray.destroy()
     })
   })
 
   ifdescribe(process.platform === 'darwin')('tray get/set title', () => {
-    afterEach(() => { tray.destroy() })
-
     it('sets/gets non-empty title', () => {
       const title = 'Hello World!'
       tray.setTitle(title)


### PR DESCRIPTION
#### Description of Change

This PR cleans up the formatting for and adds some new specs for the Tray module.

Tests have been added for `get/set ignoreDoubleClickEvents` as well as for `tray.getBounds()`.

cc @miniak @nornagon @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
