### PR TITLE
docs: add return value description to BrowserWindow#get(Content)Bounds

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -986,7 +986,7 @@ console.log(win.getBounds())
 
 #### `win.getBounds()`
 
-Returns [`Rectangle`](structures/rectangle.md)
+Returns [`Rectangle`](structures/rectangle.md) - The `bounds` of the window as `Object`.
 
 #### `win.setContentBounds(bounds[, animate])`
 
@@ -998,7 +998,7 @@ the supplied bounds.
 
 #### `win.getContentBounds()`
 
-Returns [`Rectangle`](structures/rectangle.md)
+Returns [`Rectangle`](structures/rectangle.md) - The `bounds` of the window's client area as `Object`.
 
 #### `win.getNormalBounds()`
 


### PR DESCRIPTION
#### Description of Change
Follow-up to https://github.com/electron/electron/pull/19370#discussion_r306459583. 

I tried to make it look as consistent as possible - but i'm still not happy about the consistency within the BrowserWindow docs (e.g. upper/lowercase, dot vs no dot, 🙈).

For now it's fine, but can we integrate a markdown/docs linter _in futere_?

cc @codebytere 

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none
