### PR TITLE
test: don't run codesigning spec on forks

### DIFF
--- a/spec-main/api-autoupdater-darwin-spec.ts
+++ b/spec-main/api-autoupdater-darwin-spec.ts
@@ -22,7 +22,9 @@ describeFn('autoUpdater behavior', function () {
   beforeEach(function () {
     const result = cp.spawnSync(path.resolve(__dirname, '../script/codesign/get-trusted-identity.sh'))
     if (result.status !== 0 || result.stdout.toString().trim().length === 0)  {
-      if (isCI) {
+      // Per https://circleci.com/docs/2.0/env-vars:
+      // CIRCLE_PR_NUMBER is only present on forked PRs
+      if (isCI && !process.env.CIRCLE_PR_NUMBER) {
         throw new Error('No valid signing identity available to run autoUpdater specs')
       }
       this.skip()


### PR DESCRIPTION
#### Description of Change

Resolves long-running flake:

<img width="573" alt="Screen Shot 2019-07-23 at 7 09 00 PM" src="https://user-images.githubusercontent.com/2036040/61759467-5cbe3f80-ad7d-11e9-8555-b2a61c3a40ca.png">

This PR takes advantage of the CircleCI env var `CIRCLE_PR_NUMBER`, which is only set on forked PRs to skip the test if it's run from a forked PR.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
