### PR TITLE
test: improve tests for systemPreferences apis

### DIFF
--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -338,6 +338,8 @@ See the [Windows docs][windows-colors] and the [MacOS docs][macos-colors] for mo
   * `red`
   * `yellow`
 
+Returns `String` - The standard system color formatted as `#RRGGBBAA`.
+
 Returns one of several standard system colors that automatically adapt to vibrancy and changes in accessibility settings like 'Increase contrast' and 'Reduce transparency'. See [Apple Documentation](https://developer.apple.com/design/human-interface-guidelines/macos/visual-design/color#system-colors) for  more details.
 
 ### `systemPreferences.isInvertedColorScheme()` _Windows_
@@ -370,6 +372,8 @@ Returns `String` | `null` - Can be `dark`, `light` or `unknown`.
 Gets the macOS appearance setting that you have declared you want for
 your application, maps to [NSApplication.appearance](https://developer.apple.com/documentation/appkit/nsapplication/2967170-appearance?language=objc).
 You can use the `setAppLevelAppearance` API to set this value.
+
+**[Deprecated](modernization/property-updates.md)**
 
 ### `systemPreferences.setAppLevelAppearance(appearance)` _macOS_
 
@@ -451,3 +455,5 @@ your application. This maps to values in: [NSApplication.appearance](https://dev
 system default as well as the value of `getEffectiveAppearance`.
 
 Possible values that can be set are `dark` and `light`, and possible return values are `dark`, `light`, and `unknown`.
+
+This property is only available on macOS 10.14 Mojave or newer.

--- a/spec-main/api-system-preferences-spec.ts
+++ b/spec-main/api-system-preferences-spec.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai'
 import { systemPreferences } from 'electron'
-
-const ifdescribe = (condition: boolean) => (condition ? describe : describe.skip)
+import { ifdescribe } from './spec-helpers'
 
 describe('systemPreferences module', () => {
   ifdescribe(process.platform === 'win32')('systemPreferences.getAccentColor', () => {
@@ -117,6 +116,17 @@ describe('systemPreferences module', () => {
     })
   })
 
+  ifdescribe(process.platform === 'darwin')('systemPreferences.getSystemColor(color)', () => {
+    it('returns a valid system color', () => {
+      const colors = ['blue', 'brown', 'gray', 'green', 'orange', 'pink', 'purple', 'red', 'yellow']
+      
+      colors.forEach(color => {
+        const sysColor = systemPreferences.getSystemColor(color as any)
+        expect(sysColor).to.be.a('string')
+      })
+    })
+  })
+
   ifdescribe(process.platform === 'darwin')('systemPreferences.appLevelAppearance', () => {
     it('has an appLevelAppearance property', () => {
       expect(systemPreferences).to.have.property('appLevelAppearance')
@@ -143,6 +153,39 @@ describe('systemPreferences module', () => {
   describe('systemPreferences.isInvertedColorScheme()', () => {
     it('returns a boolean', () => {
       expect(systemPreferences.isInvertedColorScheme()).to.be.a('boolean')
+    })
+  })
+
+  describe('systemPreferences.isHighContrastColorScheme()', () => {
+    it('returns a boolean', () => {
+      expect(systemPreferences.isHighContrastColorScheme()).to.be.a('boolean')
+    })
+  })
+
+  ifdescribe(process.platform === 'darwin')('systemPreferences.canPromptTouchID()', () => {
+    it('returns a boolean', () => {
+      expect(systemPreferences.canPromptTouchID()).to.be.a('boolean')
+    })
+  })
+
+  ifdescribe(process.platform === 'darwin')('systemPreferences.isTrustedAccessibilityClient(prompt)', () => {
+    it('returns a boolean', () => {
+      const trusted = systemPreferences.isTrustedAccessibilityClient(false)
+      expect(trusted).to.be.a('boolean')
+    })
+  })
+
+  ifdescribe(process.platform === 'darwin')('systemPreferences.getMediaAccessStatus(mediaType)', () => {
+    const statuses = ['not-determined', 'granted', 'denied', 'restricted', 'unknown']
+    
+    it('returns an access status for a camera access request', () => {
+      const cameraStatus = systemPreferences.getMediaAccessStatus('camera')
+      expect(statuses).to.include(cameraStatus)
+    })
+
+    it('returns an access status for a microphone access request', () => {
+      const microphoneStatus = systemPreferences.getMediaAccessStatus('microphone')
+      expect(statuses).to.include(microphoneStatus)
     })
   })
 


### PR DESCRIPTION
#### Description of Change

This PR does the following:
- Corrects return type and adds test for `systemPreferences.getSystemColor(color)`
- Adds tests for:
  - `systemPreferences.isHighContrastColorScheme()`
  - `systemPreferences.getMediaAccessStatus(mediaType)`
  - `systemPreferences.isTrustedAccessibilityClient(prompt)`
  - `systemPreferences.canPromptTouchID()`

cc @nornagon @MarshallOfSound @jkleinsc 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
