### PR TITLE
feat: add about panel customization on Windows

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1166,21 +1166,21 @@ This API must be called after the `ready` event is emitted.
 
 **[Deprecated](modernization/property-updates.md)**
 
-### `app.showAboutPanel()` _macOS_ _Linux_
+### `app.showAboutPanel()`
 
 Show the app's about panel options. These options can be overridden with `app.setAboutPanelOptions(options)`.
 
-### `app.setAboutPanelOptions(options)` _macOS_ _Linux_
+### `app.setAboutPanelOptions(options)`
 
 * `options` Object
   * `applicationName` String (optional) - The app's name.
   * `applicationVersion` String (optional) - The app's version.
   * `copyright` String (optional) - Copyright information.
   * `version` String (optional) _macOS_ - The app's build version number.
-  * `credits` String (optional) _macOS_ - Credit information.
+  * `credits` String (optional) _macOS_ _Windows_ - Credit information.
   * `authors` String[] (optional) _Linux_ - List of app authors.
   * `website` String (optional) _Linux_ - The app's website.
-  * `iconPath` String (optional) _Linux_ - Path to the app's icon. Will be shown as 64x64 pixels while retaining aspect ratio.
+  * `iconPath` String (optional) _Linux_ _Windows_ - Path to the app's icon. On Linux, will be shown as 64x64 pixels while retaining aspect ratio.
 
 Set the about panel options. This will override the values defined in the app's
 `.plist` file on MacOS. See the [Apple docs][about-panel-options] for more details. On Linux, values must be set in order to be shown; there are no defaults.

--- a/shell/browser/api/atom_api_app.cc
+++ b/shell/browser/api/atom_api_app.cc
@@ -1459,12 +1459,10 @@ void App::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("moveToApplicationsFolder", &App::MoveToApplicationsFolder)
       .SetMethod("isInApplicationsFolder", &App::IsInApplicationsFolder)
 #endif
-#if defined(OS_MACOSX) || defined(OS_LINUX)
       .SetMethod("setAboutPanelOptions",
                  base::BindRepeating(&Browser::SetAboutPanelOptions, browser))
       .SetMethod("showAboutPanel",
                  base::BindRepeating(&Browser::ShowAboutPanel, browser))
-#endif
 #if defined(OS_MACOSX) || defined(OS_WIN)
       .SetMethod("showEmojiPanel",
                  base::BindRepeating(&Browser::ShowEmojiPanel, browser))

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -186,10 +186,8 @@ class Browser : public WindowListObserver {
 
 #endif  // defined(OS_MACOSX)
 
-#if defined(OS_MACOSX) || defined(OS_LINUX)
   void ShowAboutPanel();
   void SetAboutPanelOptions(const base::DictionaryValue& options);
-#endif
 
 #if defined(OS_MACOSX) || defined(OS_WIN)
   void ShowEmojiPanel();
@@ -305,7 +303,7 @@ class Browser : public WindowListObserver {
 
   std::unique_ptr<util::Promise> ready_promise_;
 
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) || defined(OS_WIN)
   base::Value about_panel_options_;
 #elif defined(OS_MACOSX)
   base::DictionaryValue about_panel_options_;

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -22,6 +22,7 @@
 #include "base/win/win_util.h"
 #include "base/win/windows_version.h"
 #include "electron/electron_version.h"
+#include "shell/browser/ui/message_box.h"
 #include "shell/browser/ui/win/jump_list.h"
 #include "shell/common/application_info.h"
 #include "shell/common/native_mate_converters/string16_converter.h"
@@ -367,6 +368,20 @@ void Browser::ShowEmojiPanel() {
   input[3].ki.wVk = ui::WindowsKeyCodeForKeyboardCode(ui::VKEY_OEM_PERIOD);
   input[3].ki.dwFlags |= KEYEVENTF_KEYUP;
   ::SendInput(4, input, sizeof(INPUT));
+}
+
+void Browser::ShowAboutPanel() {
+  electron::MessageBoxSettings settings = {};
+  settings.title = "About";
+  settings.message = "Testing 123";
+  settings.detail = "Detail?";
+  settings.checkbox_label = "checkbox label";
+  electron::ShowMessageBoxSync(settings);
+  // const auto& opts = about_panel_options_;
+}
+
+void Browser::SetAboutPanelOptions(const base::DictionaryValue& options) {
+  options.Clone();
 }
 
 }  // namespace electron

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -85,6 +85,16 @@ bool FormatCommandLineString(base::string16* exe,
   return true;
 }
 
+std::unique_ptr<FileVersionInfo> FetchFileVersionInfo() {
+  base::FilePath path;
+
+  if (base::PathService::Get(base::FILE_EXE, &path)) {
+    base::ThreadRestrictions::ScopedAllowIO allow_io;
+    return FileVersionInfo::CreateFileVersionInfo(path);
+  }
+  return std::unique_ptr<FileVersionInfo>();
+}
+
 }  // namespace
 
 Browser::UserTask::UserTask() = default;
@@ -335,8 +345,7 @@ std::string Browser::GetExecutableFileVersion() const {
   base::FilePath path;
   if (base::PathService::Get(base::FILE_EXE, &path)) {
     base::ThreadRestrictions::ScopedAllowIO allow_io;
-    std::unique_ptr<FileVersionInfo> version_info(
-        FileVersionInfo::CreateFileVersionInfo(path));
+    std::unique_ptr<FileVersionInfo> version_info = FetchFileVersionInfo();
     return base::UTF16ToUTF8(version_info->product_version());
   }
 
@@ -372,24 +381,32 @@ void Browser::ShowEmojiPanel() {
 }
 
 void Browser::ShowAboutPanel() {
-  const auto& opts = about_panel_options_;
+  base::Value dict(base::Value::Type::DICTIONARY);
   std::string aboutMessage = "";
   gfx::ImageSkia image;
-  const std::string* str;
+
+  // grab defaults from Windows .EXE file
+  std::unique_ptr<FileVersionInfo> exe_info = FetchFileVersionInfo();
+  dict.SetStringKey("applicationName", exe_info->file_description());
+  dict.SetStringKey("applicationVersion", exe_info->product_version());
+
+  if (about_panel_options_.is_dict()) {
+    dict.MergeDictionary(&about_panel_options_);
+  }
+
   std::vector<std::string> stringOptions = {
       "applicationName", "applicationVersion", "copyright", "credits"};
 
-  if (opts.is_dict()) {
-    for (std::string opt : stringOptions) {
-      if ((str = opts.FindStringKey(opt))) {
-        aboutMessage.append(*str).append("\r\n");
-      }
+  const std::string* str;
+  for (std::string opt : stringOptions) {
+    if ((str = dict.FindStringKey(opt))) {
+      aboutMessage.append(*str).append("\r\n");
     }
+  }
 
-    if ((str = opts.FindStringKey("iconPath"))) {
-      base::FilePath path = base::FilePath::FromUTF8Unsafe(*str);
-      electron::util::PopulateImageSkiaRepsFromPath(&image, path);
-    }
+  if ((str = dict.FindStringKey("iconPath"))) {
+    base::FilePath path = base::FilePath::FromUTF8Unsafe(*str);
+    electron::util::PopulateImageSkiaRepsFromPath(&image, path);
   }
 
   electron::MessageBoxSettings settings = {};

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -411,8 +411,6 @@ void Browser::ShowAboutPanel() {
   settings.message = aboutMessage;
   settings.icon = image;
   settings.type = electron::MessageBoxType::kInformation;
-  // TODO(erickzhao): make asynchronous to avoid blocking js code
-  // TODO(erickzhao): add icon (?)
   electron::ShowMessageBoxSync(settings);
 }
 

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -25,12 +25,9 @@
 #include "shell/browser/ui/message_box.h"
 #include "shell/browser/ui/win/jump_list.h"
 #include "shell/common/application_info.h"
-#include "shell/common/asar/asar_util.h"
 #include "shell/common/native_mate_converters/string16_converter.h"
 #include "shell/common/skia_util.h"
 #include "ui/events/keycodes/keyboard_code_conversion_win.h"
-#include "ui/gfx/codec/png_codec.h"
-#include "ui/gfx/image/image_skia.h"
 
 namespace electron {
 

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -386,8 +386,8 @@ void Browser::ShowAboutPanel() {
   electron::MessageBoxSettings settings = {};
   settings.title = "About";
   settings.message = aboutMessage;
-  // TODO: make asynchronous to avoid blocking js code
-  // TODO: add icon (?)
+  // TODO(erickzhao): make asynchronous to avoid blocking js code
+  // TODO(erickzhao): add icon (?)
   electron::ShowMessageBoxSync(settings);
 }
 

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -27,6 +27,7 @@
 #include "shell/common/application_info.h"
 #include "shell/common/asar/asar_util.h"
 #include "shell/common/native_mate_converters/string16_converter.h"
+#include "shell/common/skia_util.h"
 #include "ui/events/keycodes/keyboard_code_conversion_win.h"
 #include "ui/gfx/codec/png_codec.h"
 #include "ui/gfx/image/image_skia.h"
@@ -376,34 +377,22 @@ void Browser::ShowEmojiPanel() {
 void Browser::ShowAboutPanel() {
   const auto& opts = about_panel_options_;
   std::string aboutMessage = "";
+  gfx::ImageSkia image;
   const std::string* str;
   std::vector<std::string> stringOptions = {
       "applicationName", "applicationVersion", "copyright", "credits"};
 
-  for (std::string opt : stringOptions) {
-    if ((str = opts.FindStringKey(opt))) {
-      aboutMessage.append(*str).append("\r\n");
+  if (opts.is_dict()) {
+    for (std::string opt : stringOptions) {
+      if ((str = opts.FindStringKey(opt))) {
+        aboutMessage.append(*str).append("\r\n");
+      }
     }
-  }
 
-  gfx::ImageSkia image;
-  if ((str = opts.FindStringKey("iconPath"))) {
-    base::FilePath path = base::FilePath::FromUTF8Unsafe(*str);
-    std::string file_contents;
-    double scale_factor = 1.0;
-    {
-      base::ThreadRestrictions::ScopedAllowIO allow_io;
-      if (!asar::ReadFileToString(path, &file_contents))
-        return;
+    if ((str = opts.FindStringKey("iconPath"))) {
+      base::FilePath path = base::FilePath::FromUTF8Unsafe(*str);
+      electron::util::PopulateImageSkiaRepsFromPath(&image, path);
     }
-    const unsigned char* data =
-        reinterpret_cast<const unsigned char*>(file_contents.data());
-    size_t size = file_contents.size();
-    SkBitmap bitmap;
-    if (!gfx::PNGCodec::Decode(data, size, &bitmap))
-      return;
-    gfx::ImageSkiaRep rep(bitmap, scale_factor);
-    image.AddRepresentation(rep);
   }
 
   electron::MessageBoxSettings settings = {};

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -371,20 +371,28 @@ void Browser::ShowEmojiPanel() {
 }
 
 void Browser::ShowAboutPanel() {
+  const auto& opts = about_panel_options_;
+  std::string aboutMessage = "";
+  const std::string* str;
+  std::vector<std::string> panelOptions = {
+      "applicationName", "applicationVersion", "copyright", "credits"};
+
+  for (std::string opt : panelOptions) {
+    if ((str = opts.FindStringKey(opt))) {
+      aboutMessage.append(*str);
+    }
+  }
+
   electron::MessageBoxSettings settings = {};
   settings.title = "About";
-  settings.message =
-      "Windows Live Messenger\r\nVersion 8.1 (Build "
-      "6.4.23.1.3.12.00)\r\nCopyright (C) 1997-2006 Microsoft Corporation. All "
-      "rights reserved.";
+  settings.message = aboutMessage;
   // TODO: make asynchronous to avoid blocking js code
-  electron::ShowMessageBox(settings);
-  // TODO: customize options
-  // const auto& opts = about_panel_options_;
+  // TODO: add icon (?)
+  electron::ShowMessageBoxSync(settings);
 }
 
 void Browser::SetAboutPanelOptions(const base::DictionaryValue& options) {
-  options.Clone();
+  about_panel_options_ = options.Clone();
 }
 
 }  // namespace electron

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -393,7 +393,6 @@ void Browser::ShowAboutPanel() {
   }
 
   electron::MessageBoxSettings settings = {};
-  settings.title = "About";
   settings.message = aboutMessage;
   settings.icon = image;
   settings.type = electron::MessageBoxType::kInformation;

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -373,10 +373,13 @@ void Browser::ShowEmojiPanel() {
 void Browser::ShowAboutPanel() {
   electron::MessageBoxSettings settings = {};
   settings.title = "About";
-  settings.message = "Testing 123";
-  settings.detail = "Detail?";
-  settings.checkbox_label = "checkbox label";
-  electron::ShowMessageBoxSync(settings);
+  settings.message =
+      "Windows Live Messenger\r\nVersion 8.1 (Build "
+      "6.4.23.1.3.12.00)\r\nCopyright (C) 1997-2006 Microsoft Corporation. All "
+      "rights reserved.";
+  // TODO: make asynchronous to avoid blocking js code
+  electron::ShowMessageBox(settings);
+  // TODO: customize options
   // const auto& opts = about_panel_options_;
 }
 

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -379,7 +379,7 @@ void Browser::ShowAboutPanel() {
 
   for (std::string opt : panelOptions) {
     if ((str = opts.FindStringKey(opt))) {
-      aboutMessage.append(*str);
+      aboutMessage.append(*str).append("\r\n");
     }
   }
 


### PR DESCRIPTION
#### Description of Change
Closes #15591. Adds support for `showAboutPanel()` and `setAboutPanelOptions()` on Windows.

Windows doesn't have a native About dialog. This PR reuses the `electron::ShowMessageBox` function to generate a dialog with the About Panel information as a string message.

Notes:
* Default settings are the `applicationName` and `applicationVersion` provided by [`/src/base/file_version_info.h`](https://cs.chromium.org/chromium/src/base/file_version_info.h).
* The image path accepts any file types that `NativeImage` API does.
* The About panel is synchronous (same as on Linux).

Fields added (all optional):
* `applicationName`: string
* `applicationVersion`: string
* `copyright`: string
* `credits`: string
* `iconPath`: string

cc @codebytere @ckerr @sindresorhus 

#### Example
![image](https://user-images.githubusercontent.com/16010076/61817387-45299a00-ae03-11e9-8e51-69913a872ae6.png)

#### Additional Reading

Microsoft UX Guidelines for Dialog Boxes: https://docs.microsoft.com/en-us/windows/win32/uxguide/win-dialog-box

Relevant bits:
> * Use an icon in About Box dialogs for application branding.
> ![About Dialog Example](https://docs.microsoft.com/en-us/windows/win32/uxguide/images/win-dialog-box-image23.png)
> In this example, a bitmap is used in the About Box to identify and brand the application.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added about panel customization on Windows.
