### PR TITLE
chore: keep references to active menus to prevent gc

### DIFF
--- a/shell/browser/api/atom_api_menu.cc
+++ b/shell/browser/api/atom_api_menu.cc
@@ -4,6 +4,8 @@
 
 #include "shell/browser/api/atom_api_menu.h"
 
+#include <map>
+
 #include "native_mate/constructor.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/object_template_builder.h"
@@ -13,6 +15,13 @@
 #include "shell/common/native_mate_converters/image_converter.h"
 #include "shell/common/native_mate_converters/string16_converter.h"
 #include "shell/common/node_includes.h"
+
+namespace {
+// We need this map to keep references to currently opened menus.
+// Without this menus would be destroyed by js garbage collector
+// even when they are still displayed.
+std::map<uint32_t, v8::Global<v8::Object>> g_menus;
+}  // unnamed namespace
 
 namespace electron {
 
@@ -200,10 +209,12 @@ bool Menu::WorksWhenHiddenAt(int index) const {
 }
 
 void Menu::OnMenuWillClose() {
+  g_menus.erase(weak_map_id());
   Emit("menu-will-close");
 }
 
 void Menu::OnMenuWillShow() {
+  g_menus[weak_map_id()] = v8::Global<v8::Object>(isolate(), GetWrapper());
   Emit("menu-will-show");
 }
 


### PR DESCRIPTION
Fixes https://github.com/electron/electron/issues/19424.

### How to reproduce
Launch this simple application:

```
const { app, BrowserWindow, Menu } = require('electron')

function createWindow () {
  let win = new BrowserWindow({
    width: 800,
    height: 600
  })
  let menu = Menu.buildFromTemplate(
    [
      { label: 'one', accelerator: 'Control+1' },
      { label: 'two', accelerator: 'Control+2' }
    ]
  )
  menu.popup({ "x": 50, "y": 50})
}

app.on('ready', createWindow)
```
After it's started press arrow down to cycle through both menu's entries.

### Expected behavior

Nothing bad happens. 

### Actual behavior

After few seconds - when js's garbage collector is started  - menu is being destroyed. Additionaly crash may occur (~50% reproducibility rate).

<!-- What actually happens? -->

As object `menu` is not kept as global reference in js garbage collector destroys it. It's a matter of debate if that's correct behaviour (on one side object is "local" on js side but on the other menu is active and displayed). The bigger issue is that js object is being destroyed while c++ object is still alive and active. If user interacts with it (like changing focus of current element) when js object is already destroyed crash in v8 will occur. We get notification on c++ side that js object was destroyed by callback but the problem is that - by design - all instances of class `WrappableBase`, like `Menu`, are destroyed in two steps: first `WrappableBase::FirstWeakCallback` is called where we clear wrapper to js object, and after that `WrappableBase::SecondWeakCallback` is called where we destroy c++ object. Crash occurs when there is any call to Menu (like `Menu::GetAcceleratorTextAt` after focused element was changed) after first callback but before second callback was called.

With proposed fix we keep references to all currently displayed menus so garbage collector doesn't destroy active menus. If we decide that this is expected behaviour that popup can be destroyed by js garbage collector even when it's still displayed the solution would be to check if `GetWrapper()` doesn't return empty object in all calls in class `Menu` (e.g. `Menu::IsCommandIdChecked`, `Menu::GetAcceleratorTextAt`, ` Menu::IsCommandIdEnabled` ...).

notes: Don't destroy active menus created as local objects in javascript