### PR TITLE
fix: clearing of backgroundColor property on TouchBar items

### DIFF
--- a/shell/browser/ui/cocoa/atom_touch_bar.mm
+++ b/shell/browser/ui/cocoa/atom_touch_bar.mm
@@ -357,8 +357,11 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
   NSButton* button = (NSButton*)item.view;
 
   std::string backgroundColor;
-  if (settings.Get("backgroundColor", &backgroundColor)) {
+  if (settings.Get("backgroundColor", &backgroundColor) &&
+      !backgroundColor.empty()) {
     button.bezelColor = [self colorFromHexColorString:backgroundColor];
+  } else {
+    button.bezelColor = nil;
   }
 
   std::string label;
@@ -366,18 +369,17 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
   button.title = base::SysUTF8ToNSString(label);
 
   gfx::Image image;
-  if (settings.Get("icon", &image)) {
-    button.image = image.AsNSImage();
+  settings.Get("icon", &image);
+  button.image = image.AsNSImage();
 
-    std::string iconPosition;
-    settings.Get("iconPosition", &iconPosition);
-    if (iconPosition == "left") {
-      button.imagePosition = NSImageLeft;
-    } else if (iconPosition == "right") {
-      button.imagePosition = NSImageRight;
-    } else {
-      button.imagePosition = NSImageOverlaps;
-    }
+  std::string iconPosition;
+  settings.Get("iconPosition", &iconPosition);
+  if (iconPosition == "left") {
+    button.imagePosition = NSImageLeft;
+  } else if (iconPosition == "right") {
+    button.imagePosition = NSImageRight;
+  } else {
+    button.imagePosition = NSImageOverlaps;
   }
 }
 
@@ -499,9 +501,8 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
   item.collapsedRepresentationLabel = base::SysUTF8ToNSString(label);
 
   gfx::Image image;
-  if (settings.Get("icon", &image)) {
-    item.collapsedRepresentationImage = image.AsNSImage();
-  }
+  settings.Get("icon", &image);
+  item.collapsedRepresentationImage = image.AsNSImage();
 
   bool showCloseButton = true;
   settings.Get("showCloseButton", &showCloseButton);


### PR DESCRIPTION
#### Description of Change
The code parsing some of the properties simply ignores them when the value is not valid (or `null`) instead of setting the native value to `nil`, which is fine when the TouchBar item is being constructed. But if you later want to set the `backgroundColor` to default by setting it to `null`, it does not work.

/cc @codebytere

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
(https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fix clearing of the `backgroundColor` property on `TouchBar` items.