### PR TITLE
fix: clearing of the backgroundColor property on TouchBarButton

### DIFF
--- a/shell/browser/ui/cocoa/atom_touch_bar.mm
+++ b/shell/browser/ui/cocoa/atom_touch_bar.mm
@@ -357,8 +357,11 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
   NSButton* button = (NSButton*)item.view;
 
   std::string backgroundColor;
-  if (settings.Get("backgroundColor", &backgroundColor)) {
+  if (settings.Get("backgroundColor", &backgroundColor) &&
+      !backgroundColor.empty()) {
     button.bezelColor = [self colorFromHexColorString:backgroundColor];
+  } else {
+    button.bezelColor = nil;
   }
 
   std::string label;


### PR DESCRIPTION
#### Description of Change
The code parsing the `backgroundColor` property simply ignores the value when it's not valid (or `null`) instead of setting the native value to `nil`, which is fine when `TouchBarButton` is being constructed. But if you later want to set the `backgroundColor` to default by setting it to `null`, it does not work.

Use the same pattern as `textColor` on `TouchBarLabel`:
https://github.com/electron/electron/blob/637cfdd9a08a7035c725b28576f288388ffd3849/shell/browser/ui/cocoa/atom_touch_bar.mm#L406-L411

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
(https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed setting the `backgroundColor` property on `TouchBarButton` to default by assigning `null` after the item is constructed.