### PR TITLE
docs: specify macOS-only About Panel option

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1178,7 +1178,7 @@ Show the app's about panel options. These options can be overridden with `app.se
   * `applicationName` String (optional) - The app's name.
   * `applicationVersion` String (optional) - The app's version.
   * `copyright` String (optional) - Copyright information.
-  * `version` String (optional) - The app's build version number.
+  * `version` String (optional) _macOS_ - The app's build version number.
   * `credits` String (optional) _macOS_ - Credit information.
   * `authors` String[] (optional) _Linux_ - List of app authors.
   * `website` String (optional) _Linux_ - The app's website.


### PR DESCRIPTION
#### Description of Change

In #18964, the docs were changed to mark that the `version` tag in `app.setAboutPanelOptions()` was available in Linux as well.

However, the code doesn't reflect that, as `app.showAboutPanel()` never checks for a `version` option.

https://github.com/electron/electron/blob/3c9d714f4c2a0d113131e3f09c8379684da7890e/shell/browser/browser_linux.cc#L149-L197

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes
