### PR TITLE
docs: fix TouchBar related documentation

### DIFF
--- a/docs/api/touch-bar-button.md
+++ b/docs/api/touch-bar-button.md
@@ -11,7 +11,7 @@ Process: [Main](../tutorial/application-architecture.md#main-and-renderer-proces
   * `backgroundColor` String (optional) - Button background color in hex format,
     i.e `#ABCDEF`.
   * `icon` [NativeImage](native-image.md) | String (optional) - Button icon.
-  * `iconPosition` String (optional) - Can be `left`, `right` or `overlay`.
+  * `iconPosition` String (optional) - Can be `left`, `right` or `overlay`. Defaults to `overlay`.
   * `click` Function (optional) - Function to call when the button is clicked.
 
 ### Instance Properties

--- a/docs/api/touch-bar-popover.md
+++ b/docs/api/touch-bar-popover.md
@@ -9,7 +9,7 @@ Process: [Main](../tutorial/application-architecture.md#main-and-renderer-proces
 * `options` Object
   * `label` String (optional) - Popover button text.
   * `icon` [NativeImage](native-image.md) (optional) - Popover button icon.
-  * `items` [TouchBar](touch-bar.md) (optional) - Items to display in the popover.
+  * `items` [TouchBar](touch-bar.md) - Items to display in the popover.
   * `showCloseButton` Boolean (optional) - `true` to display a close button
     on the left of the popover, `false` to not show it. Default is `true`.
 

--- a/docs/api/touch-bar-scrubber.md
+++ b/docs/api/touch-bar-scrubber.md
@@ -12,10 +12,10 @@ Process: [Main](../tutorial/application-architecture.md#main-and-renderer-proces
     * `selectedIndex` Integer - The index of the item the user selected.
   * `highlight` Function (optional) - Called when the user taps any item.
     * `highlightedIndex` Integer - The index of the item the user touched.
-  * `selectedStyle` String (optional) - Selected item style. Defaults to `null`.
-  * `overlayStyle` String (optional) - Selected overlay item style. Defaults to `null`.
+  * `selectedStyle` String (optional) - Selected item style. Can be `background`, `outline` or `none`. Defaults to `none`.
+  * `overlayStyle` String (optional) - Selected overlay item style. Can be `background`, `outline` or `none`. Defaults to `none`.
   * `showArrowButtons` Boolean (optional) - Defaults to `false`.
-  * `mode` String (optional) - Defaults to `free`.
+  * `mode` String (optional) - Can be `fixed` or `free`. The default is `free`.
   * `continuous` Boolean (optional) - Defaults to `true`.
 
 ### Instance Properties
@@ -34,7 +34,7 @@ updates the control in the touch bar. Possible values:
 
 * `background` - Maps to `[NSScrubberSelectionStyle roundedBackgroundStyle]`.
 * `outline` - Maps to `[NSScrubberSelectionStyle outlineOverlayStyle]`.
-* `null` - Actually null, not a string, removes all styles.
+* `none` - Removes all styles.
 
 #### `touchBarScrubber.overlayStyle`
 
@@ -44,7 +44,7 @@ touch bar. Possible values:
 
 * `background` - Maps to `[NSScrubberSelectionStyle roundedBackgroundStyle]`.
 * `outline` - Maps to `[NSScrubberSelectionStyle outlineOverlayStyle]`.
-* `null` - Actually null, not a string, removes all styles.
+* `none` - Removes all styles.
 
 #### `touchBarScrubber.showArrowButtons`
 

--- a/docs/api/touch-bar-segmented-control.md
+++ b/docs/api/touch-bar-segmented-control.md
@@ -10,23 +10,23 @@ Process: [Main](../tutorial/application-architecture.md#main-and-renderer-proces
   * `segmentStyle` String (optional) - Style of the segments:
     * `automatic` - Default. The appearance of the segmented control is
       automatically determined based on the type of window in which the control
-      is displayed and the position within the window.
-    * `rounded` - The control is displayed using the rounded style.
+      is displayed and the position within the window. Maps to `NSSegmentStyleAutomatic`.
+    * `rounded` - The control is displayed using the rounded style. Maps to `NSSegmentStyleRounded`.
     * `textured-rounded` - The control is displayed using the textured rounded
-      style.
-    * `round-rect` - The control is displayed using the round rect style.
+      style. Maps to `NSSegmentStyleTexturedRounded`.
+    * `round-rect` - The control is displayed using the round rect style. Maps to `NSSegmentStyleRoundRect`.
     * `textured-square` - The control is displayed using the textured square
-      style.
-    * `capsule` - The control is displayed using the capsule style.
-    * `small-square` - The control is displayed using the small square style.
+      style. Maps to `NSSegmentStyleTexturedSquare`.
+    * `capsule` - The control is displayed using the capsule style. Maps to `NSSegmentStyleCapsule`.
+    * `small-square` - The control is displayed using the small square style. Maps to `NSSegmentStyleSmallSquare`.
     * `separated` - The segments in the control are displayed very close to each
-      other but not touching.
+      other but not touching. Maps to `NSSegmentStyleSeparated`.
   * `mode` String (optional) - The selection mode of the control:
-    * `single` - Default. One item selected at a time, selecting one deselects the previously selected item.
-    * `multiple` - Multiple items can be selected at a time.
-    * `buttons` - Make the segments act as buttons, each segment can be pressed and released but never marked as active.
+    * `single` - Default. One item selected at a time, selecting one deselects the previously selected item. Maps to `NSSegmentSwitchTrackingSelectOne`.
+    * `multiple` - Multiple items can be selected at a time. Maps to `NSSegmentSwitchTrackingSelectAny`.
+    * `buttons` - Make the segments act as buttons, each segment can be pressed and released but never marked as active. Maps to `NSSegmentSwitchTrackingMomentary`.
   * `segments` [SegmentedControlSegment[]](structures/segmented-control-segment.md) - An array of segments to place in this control.
-  * `selectedIndex` Integer (optional) - The index of the currently selected segment, will update automatically with user interaction. When the mode is multiple it will be the last selected item.
+  * `selectedIndex` Integer (optional) - The index of the currently selected segment, will update automatically with user interaction. When the mode is `multiple` it will be the last selected item.
   * `change` Function (optional) - Called when the user selects a new segment.
     * `selectedIndex` Integer - The index of the segment the user selected.
     * `isSelected` Boolean - Whether as a result of user selection the segment is selected or not.

--- a/docs/api/touch-bar-spacer.md
+++ b/docs/api/touch-bar-spacer.md
@@ -8,6 +8,6 @@ Process: [Main](../tutorial/application-architecture.md#main-and-renderer-proces
 
 * `options` Object
   * `size` String (optional) - Size of spacer, possible values are:
-    * `small` - Small space between items.
-    * `large` - Large space between items.
-    * `flexible` - Take up all available space.
+    * `small` - Small space between items. Maps to `NSTouchBarItemIdentifierFixedSpaceSmall`. This is the default.
+    * `large` - Large space between items. Maps to `NSTouchBarItemIdentifierFixedSpaceLarge`.
+    * `flexible` - Take up all available space. Maps to `NSTouchBarItemIdentifierFlexibleSpace`.


### PR DESCRIPTION
#### Description of Change
- Fixed optionality according to the actual behavior in the code
- Added missing list of values for string based enums
- Added references to macOS SDK constants
- Replaced `null` with `none` in `selectedStyle` and `overlayStyle` as they have the same behavior, but `none` works better with the enum

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed bunch of issues in the documentation for `TouchBar` related APIs.