### PR TITLE
refactor: don't use NSClassFromString in TouchBar code

### DIFF
--- a/shell/browser/ui/cocoa/atom_touch_bar.mm
+++ b/shell/browser/ui/cocoa/atom_touch_bar.mm
@@ -54,8 +54,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 }
 
 - (NSTouchBar*)touchBarFromItemIdentifiers:(NSMutableArray*)items {
-  base::scoped_nsobject<NSTouchBar> bar(
-      [[NSClassFromString(@"NSTouchBar") alloc] init]);
+  base::scoped_nsobject<NSTouchBar> bar([[NSTouchBar alloc] init]);
   [bar setDelegate:delegate_];
   [bar setDefaultItemIdentifiers:items];
   return bar.autorelease();
@@ -341,8 +340,8 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
     return nil;
 
   mate::PersistentDictionary settings = settings_[s_id];
-  base::scoped_nsobject<NSCustomTouchBarItem> item([[NSClassFromString(
-      @"NSCustomTouchBarItem") alloc] initWithIdentifier:identifier]);
+  base::scoped_nsobject<NSCustomTouchBarItem> item(
+      [[NSCustomTouchBarItem alloc] initWithIdentifier:identifier]);
   NSButton* button = [NSButton buttonWithTitle:@""
                                         target:self
                                         action:@selector(buttonAction:)];
@@ -391,8 +390,8 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
     return nil;
 
   mate::PersistentDictionary settings = settings_[s_id];
-  base::scoped_nsobject<NSCustomTouchBarItem> item([[NSClassFromString(
-      @"NSCustomTouchBarItem") alloc] initWithIdentifier:identifier]);
+  base::scoped_nsobject<NSCustomTouchBarItem> item(
+      [[NSCustomTouchBarItem alloc] initWithIdentifier:identifier]);
   [item setView:[NSTextField labelWithString:@""]];
   [self updateLabel:item withSettings:settings];
   return item.autorelease();
@@ -421,8 +420,8 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
     return nil;
 
   mate::PersistentDictionary settings = settings_[s_id];
-  base::scoped_nsobject<NSColorPickerTouchBarItem> item([[NSClassFromString(
-      @"NSColorPickerTouchBarItem") alloc] initWithIdentifier:identifier]);
+  base::scoped_nsobject<NSColorPickerTouchBarItem> item(
+      [[NSColorPickerTouchBarItem alloc] initWithIdentifier:identifier]);
   [item setTarget:self];
   [item setAction:@selector(colorPickerAction:)];
   [self updateColorPicker:item withSettings:settings];
@@ -456,8 +455,8 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
     return nil;
 
   mate::PersistentDictionary settings = settings_[s_id];
-  base::scoped_nsobject<NSSliderTouchBarItem> item([[NSClassFromString(
-      @"NSSliderTouchBarItem") alloc] initWithIdentifier:identifier]);
+  base::scoped_nsobject<NSSliderTouchBarItem> item(
+      [[NSSliderTouchBarItem alloc] initWithIdentifier:identifier]);
   [item setTarget:self];
   [item setAction:@selector(sliderAction:)];
   [self updateSlider:item withSettings:settings];
@@ -489,8 +488,8 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
     return nil;
 
   mate::PersistentDictionary settings = settings_[s_id];
-  base::scoped_nsobject<NSPopoverTouchBarItem> item([[NSClassFromString(
-      @"NSPopoverTouchBarItem") alloc] initWithIdentifier:identifier]);
+  base::scoped_nsobject<NSPopoverTouchBarItem> item(
+      [[NSPopoverTouchBarItem alloc] initWithIdentifier:identifier]);
   [self updatePopover:item withSettings:settings];
   return item.autorelease();
 }
@@ -544,9 +543,8 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
       }
     }
   }
-  return [NSClassFromString(@"NSGroupTouchBarItem")
-      groupItemWithIdentifier:identifier
-                        items:generatedItems];
+  return [NSGroupTouchBarItem groupItemWithIdentifier:identifier
+                                                items:generatedItems];
 }
 
 - (void)updateGroup:(NSGroupTouchBarItem*)item
@@ -571,8 +569,8 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
     return nil;
 
   mate::PersistentDictionary settings = settings_[s_id];
-  base::scoped_nsobject<NSCustomTouchBarItem> item([[NSClassFromString(
-      @"NSCustomTouchBarItem") alloc] initWithIdentifier:identifier]);
+  base::scoped_nsobject<NSCustomTouchBarItem> item(
+      [[NSCustomTouchBarItem alloc] initWithIdentifier:identifier]);
 
   NSSegmentedControl* control = [NSSegmentedControl
       segmentedControlWithLabels:[NSMutableArray array]
@@ -656,15 +654,15 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
     return nil;
 
   mate::PersistentDictionary settings = settings_[s_id];
-  base::scoped_nsobject<NSCustomTouchBarItem> item([[NSClassFromString(
-      @"NSCustomTouchBarItem") alloc] initWithIdentifier:identifier]);
+  base::scoped_nsobject<NSCustomTouchBarItem> item(
+      [[NSCustomTouchBarItem alloc] initWithIdentifier:identifier]);
 
-  NSScrubber* scrubber = [[[NSClassFromString(@"NSScrubber") alloc]
-      initWithFrame:NSZeroRect] autorelease];
+  NSScrubber* scrubber =
+      [[[NSScrubber alloc] initWithFrame:NSZeroRect] autorelease];
 
-  [scrubber registerClass:NSClassFromString(@"NSScrubberTextItemView")
+  [scrubber registerClass:[NSScrubberTextItemView class]
         forItemIdentifier:TextScrubberItemIdentifier];
-  [scrubber registerClass:NSClassFromString(@"NSScrubberImageItemView")
+  [scrubber registerClass:[NSScrubberImageItemView class]
         forItemIdentifier:ImageScrubberItemIdentifier];
 
   scrubber.delegate = self;
@@ -693,20 +691,20 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 
   if (selectedStyle == "outline") {
     scrubber.selectionBackgroundStyle =
-        [NSClassFromString(@"NSScrubberSelectionStyle") outlineOverlayStyle];
+        [NSScrubberSelectionStyle outlineOverlayStyle];
   } else if (selectedStyle == "background") {
     scrubber.selectionBackgroundStyle =
-        [NSClassFromString(@"NSScrubberSelectionStyle") roundedBackgroundStyle];
+        [NSScrubberSelectionStyle roundedBackgroundStyle];
   } else {
     scrubber.selectionBackgroundStyle = nil;
   }
 
   if (overlayStyle == "outline") {
     scrubber.selectionOverlayStyle =
-        [NSClassFromString(@"NSScrubberSelectionStyle") outlineOverlayStyle];
+        [NSScrubberSelectionStyle outlineOverlayStyle];
   } else if (overlayStyle == "background") {
     scrubber.selectionOverlayStyle =
-        [NSClassFromString(@"NSScrubberSelectionStyle") roundedBackgroundStyle];
+        [NSScrubberSelectionStyle roundedBackgroundStyle];
   } else {
     scrubber.selectionOverlayStyle = nil;
   }


### PR DESCRIPTION
#### Description of Change
No need to use `NSClassFromString`. These classes are now weakly linked by the SDK.
Tested on macOS 10.10 to make sure it does not crash when trying to use the TouchBar APIs.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes