### PR TITLE
docs: fix missing possibleValues

### DIFF
--- a/docs/api/client-request.md
+++ b/docs/api/client-request.md
@@ -22,8 +22,9 @@ which the request is associated.
   with which the request is associated. Defaults to the empty string. The
 `session` option prevails on `partition`. Thus if a `session` is explicitly
 specified, `partition` is ignored.
-  * `protocol` String (optional) - The protocol scheme in the form 'scheme:'.
-Currently supported values are 'http:' or 'https:'. Defaults to 'http:'.
+  * `protocol` String (optional) - The protocol scheme in the form `scheme:`.
+    * `http:`
+    * `https:` - The default value.
   * `host` String (optional) - The server host provided as a concatenation of
 the hostname and the port number 'hostname:port'.
   * `hostname` String (optional) - The server host name.

--- a/docs/api/client-request.md
+++ b/docs/api/client-request.md
@@ -30,10 +30,10 @@ the hostname and the port number 'hostname:port'.
   * `hostname` String (optional) - The server host name.
   * `port` Integer (optional) - The server's listening port number.
   * `path` String (optional) - The path part of the request URL.
-  * `redirect` String (optional) - The redirect mode for this request. Should be
-one of `follow`, `error` or `manual`. Defaults to `follow`. When mode is `error`,
-any redirection will be aborted. When mode is `manual` the redirection will be
-deferred until [`request.followRedirect`](#requestfollowredirect) is invoked. Listen for the [`redirect`](#event-redirect) event in
+  * `redirect` String (optional) - The redirect mode for this request.
+    * `follow` - The default value.
+    * `error` - Redirection will be aborted.
+    * `manual` - Redirection will be deferred until [`request.followRedirect`](#requestfollowredirect) is invoked. Listen for the [`redirect`](#event-redirect) event in
 this mode to get more details about the redirect request.
 
 `options` properties such as `protocol`, `host`, `hostname`, `port` and `path`

--- a/docs/api/client-request.md
+++ b/docs/api/client-request.md
@@ -9,48 +9,8 @@ interface and is therefore an [EventEmitter][event-emitter].
 
 ### `new ClientRequest(options)`
 
-* `options` (Object | String) - If `options` is a String, it is interpreted as
-the request URL. If it is an object, it is expected to fully specify an HTTP request via the
-following properties:
-  * `method` String (optional) - The HTTP request method. Defaults to the GET
-method.
-  * `url` String (optional) - The request URL. Must be provided in the absolute
-form with the protocol scheme specified as http or https.
-  * `session` Object (optional) - The [`Session`](session.md) instance with
-which the request is associated.
-  * `partition` String (optional) - The name of the [`partition`](session.md)
-  with which the request is associated. Defaults to the empty string. The
-`session` option prevails on `partition`. Thus if a `session` is explicitly
-specified, `partition` is ignored.
-  * `protocol` String (optional) - The protocol scheme in the form `scheme:`.
-    * `http:`
-    * `https:` - The default value.
-  * `host` String (optional) - The server host provided as a concatenation of
-the hostname and the port number 'hostname:port'.
-  * `hostname` String (optional) - The server host name.
-  * `port` Integer (optional) - The server's listening port number.
-  * `path` String (optional) - The path part of the request URL.
-  * `redirect` String (optional) - The redirect mode for this request.
-    * `follow` - The default value.
-    * `error` - Redirection will be aborted.
-    * `manual` - Redirection will be deferred until [`request.followRedirect`](#requestfollowredirect) is invoked. Listen for the [`redirect`](#event-redirect) event in
-this mode to get more details about the redirect request.
-
-`options` properties such as `protocol`, `host`, `hostname`, `port` and `path`
-strictly follow the Node.js model as described in the
-[URL](https://nodejs.org/api/url.html) module.
-
-For instance, we could have created the same request to 'github.com' as follows:
-
-```JavaScript
-const request = net.request({
-  method: 'GET',
-  protocol: 'https:',
-  hostname: 'github.com',
-  port: 443,
-  path: '/'
-})
-```
+* `options` (ClientRequestConstructorOptions | String) - If `options` is a String,
+  it is interpreted as the request URL.
 
 ### Instance Events
 

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -295,7 +295,7 @@ Returns `NativeImage` - The cropped image.
   * `width` Integer (optional) - Defaults to the image's width.
   * `height` Integer (optional) - Defaults to the image's height.
   * `quality` String (optional) - The desired quality of the resize image.
-    Possible values are `good`, `better` or `best`. The default is `best`.
+    Can be `good`, `better` or `best`. The default is `best`.
     These values express a desired quality/speed tradeoff. They are translated
     into an algorithm-specific method that depends on the capabilities
     (CPU, GPU) of the underlying platform. It is possible for all three methods

--- a/docs/api/structures/client-request-constructor-options.md
+++ b/docs/api/structures/client-request-constructor-options.md
@@ -4,7 +4,7 @@
 method.
 * `url` String (optional) - The request URL. Must be provided in the absolute
 form with the protocol scheme specified as http or https.
-* `session` Object (optional) - The [`Session`](session.md) instance with
+* `session` Session (optional) - The [`Session`](session.md) instance with
 which the request is associated.
 * `partition` String (optional) - The name of the [`partition`](session.md)
   with which the request is associated. Defaults to the empty string. The

--- a/docs/api/structures/client-request-constructor-options.md
+++ b/docs/api/structures/client-request-constructor-options.md
@@ -1,0 +1,42 @@
+# ClientRequestConstructorOptions Object
+
+* `method` String (optional) - The HTTP request method. Defaults to the GET
+method.
+* `url` String (optional) - The request URL. Must be provided in the absolute
+form with the protocol scheme specified as http or https.
+* `session` Object (optional) - The [`Session`](session.md) instance with
+which the request is associated.
+* `partition` String (optional) - The name of the [`partition`](session.md)
+  with which the request is associated. Defaults to the empty string. The
+  `session` option prevails on `partition`. Thus if a `session` is explicitly
+  specified, `partition` is ignored.
+* `host` String (optional) - The server host provided as a concatenation of
+  the hostname and the port number 'hostname:port'.
+* `hostname` String (optional) - The server host name.
+* `port` Integer (optional) - The server's listening port number.
+* `path` String (optional) - The path part of the request URL.
+* `protocol` String (optional) - The protocol scheme in the form `scheme:`.
+  * `http:`
+  * `https:` - The default value.
+* `redirect` String (optional) - The redirect mode for this request.
+  * `follow` - The default value.
+  * `error` - Redirection will be aborted.
+  * `manual` - Defer redirection until [`request.followRedirect`](#requestfollowredirect)
+    is invoked. Listen for the [`redirect`](#event-redirect) event in
+    this mode to get more details about the redirect request.
+
+Properties such as `protocol`, `host`, `hostname`, `port` and `path` strictly
+follow the Node.js model as described in the [URL](https://nodejs.org/api/url.html)
+module.
+
+For instance, we could have created the same request to 'github.com' as follows:
+
+```JavaScript
+const request = net.request({
+  method: 'GET',
+  protocol: 'https:',
+  hostname: 'github.com',
+  port: 443,
+  path: '/'
+})
+```

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -990,7 +990,9 @@ Returns `String` - The user agent for this web page.
 
 * `css` String
 * `options` Object (optional)
-  * `cssOrigin` String (optional) - Can be either 'user' or 'author'; Specifying 'user' enables you to prevent websites from overriding the CSS you insert. Default is 'author'.
+  * `cssOrigin` String (optional)
+    * `user` - enables you to prevent websites from overriding the CSS you insert.
+    * `author` - default value.
 
 Returns `Promise<String>` - A promise that resolves with a key for the inserted CSS that can later be used to remove the CSS via `contents.removeInsertedCSS(key)`.
 

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -1,6 +1,7 @@
 # THIS FILE IS AUTO-GENERATED, PLEASE DO NOT EDIT BY HAND
 auto_filenames = {
   api_docs = [
+    "docs/api/.menu-item.md.swp",
     "docs/api/accelerator.md",
     "docs/api/app.md",
     "docs/api/auto-updater.md",
@@ -69,6 +70,7 @@ auto_filenames = {
     "docs/api/structures/bluetooth-device.md",
     "docs/api/structures/certificate-principal.md",
     "docs/api/structures/certificate.md",
+    "docs/api/structures/client-request-constructor-options.md",
     "docs/api/structures/cookie.md",
     "docs/api/structures/cpu-usage.md",
     "docs/api/structures/crash-report.md",


### PR DESCRIPTION
#### Description of Change

Inspired by https://github.com/electron/electron/pull/19448. Tweaks the docs so that proper `possibleValues` will be generated for:

 * contents.insertCSS()'s `options` parameter's `cssOrigin` property
 * image.resize()'s `options` parameter's `quality` property
 * new ClientRequest()'s `options` parameter's `protocol` property
 * new ClientRequest()'s `options` parameter's `redirect` property

CC @MarshallOfSound @codebytere 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes