### PR TITLE
refactor: move `gfx::ImageSkia` functions to their own util file

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -568,6 +568,8 @@ filenames = {
     "shell/common/platform_util_win.cc",
     "shell/common/promise_util.h",
     "shell/common/promise_util.cc",
+    "shell/common/skia_util.h",
+    "shell/common/skia_util.cc",
     "shell/renderer/api/atom_api_renderer_ipc.cc",
     "shell/renderer/api/atom_api_spell_check_client.cc",
     "shell/renderer/api/atom_api_spell_check_client.h",

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -369,12 +369,4 @@ void Browser::ShowEmojiPanel() {
   ::SendInput(4, input, sizeof(INPUT));
 }
 
-void Browser::ShowAboutPanel() {
-  const auto& opts = about_panel_options_;
-}
-
-void Browser::SetAboutPanelOptions(const base::DictionaryValue& options) {
-  about_panel_options_ = options.Clone();
-}
-
 }  // namespace electron

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -369,4 +369,12 @@ void Browser::ShowEmojiPanel() {
   ::SendInput(4, input, sizeof(INPUT));
 }
 
+void Browser::ShowAboutPanel() {
+  const auto& opts = about_panel_options_;
+}
+
+void Browser::SetAboutPanelOptions(const base::DictionaryValue& options) {
+  about_panel_options_ = options.Clone();
+}
+
 }  // namespace electron

--- a/shell/common/api/atom_api_native_image.cc
+++ b/shell/common/api/atom_api_native_image.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include "shell/common/api/atom_api_native_image.h"
-#include "base/files/file_util.h"
 
 #include <memory>
 #include <string>

--- a/shell/common/api/atom_api_native_image.cc
+++ b/shell/common/api/atom_api_native_image.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "shell/common/api/atom_api_native_image.h"
+#include "base/files/file_util.h"
 
 #include <memory>
 #include <string>
@@ -21,6 +22,7 @@
 #include "shell/common/native_mate_converters/gurl_converter.h"
 #include "shell/common/native_mate_converters/value_converter.h"
 #include "shell/common/node_includes.h"
+#include "shell/common/skia_util.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "third_party/skia/include/core/SkImageInfo.h"
 #include "third_party/skia/include/core/SkPixelRef.h"
@@ -45,32 +47,6 @@ namespace api {
 
 namespace {
 
-struct ScaleFactorPair {
-  const char* name;
-  float scale;
-};
-
-ScaleFactorPair kScaleFactorPairs[] = {
-    // The "@2x" is put as first one to make scale matching faster.
-    {"@2x", 2.0f},   {"@3x", 3.0f},     {"@1x", 1.0f},     {"@4x", 4.0f},
-    {"@5x", 5.0f},   {"@1.25x", 1.25f}, {"@1.33x", 1.33f}, {"@1.4x", 1.4f},
-    {"@1.5x", 1.5f}, {"@1.8x", 1.8f},   {"@2.5x", 2.5f},
-};
-
-float GetScaleFactorFromPath(const base::FilePath& path) {
-  std::string filename(path.BaseName().RemoveExtension().AsUTF8Unsafe());
-
-  // We don't try to convert string to float here because it is very very
-  // expensive.
-  for (const auto& kScaleFactorPair : kScaleFactorPairs) {
-    if (base::EndsWith(filename, kScaleFactorPair.name,
-                       base::CompareCase::INSENSITIVE_ASCII))
-      return kScaleFactorPair.scale;
-  }
-
-  return 1.0f;
-}
-
 // Get the scale factor from options object at the first argument
 float GetScaleFactorFromOptions(mate::Arguments* args) {
   float scale_factor = 1.0f;
@@ -78,101 +54,6 @@ float GetScaleFactorFromOptions(mate::Arguments* args) {
   if (args->GetNext(&options))
     options.Get("scaleFactor", &scale_factor);
   return scale_factor;
-}
-
-bool AddImageSkiaRepFromPNG(gfx::ImageSkia* image,
-                            const unsigned char* data,
-                            size_t size,
-                            double scale_factor) {
-  SkBitmap bitmap;
-  if (!gfx::PNGCodec::Decode(data, size, &bitmap))
-    return false;
-
-  image->AddRepresentation(gfx::ImageSkiaRep(bitmap, scale_factor));
-  return true;
-}
-
-bool AddImageSkiaRepFromJPEG(gfx::ImageSkia* image,
-                             const unsigned char* data,
-                             size_t size,
-                             double scale_factor) {
-  auto bitmap = gfx::JPEGCodec::Decode(data, size);
-  if (!bitmap)
-    return false;
-
-  // `JPEGCodec::Decode()` doesn't tell `SkBitmap` instance it creates
-  // that all of its pixels are opaque, that's why the bitmap gets
-  // an alpha type `kPremul_SkAlphaType` instead of `kOpaque_SkAlphaType`.
-  // Let's fix it here.
-  // TODO(alexeykuzmin): This workaround should be removed
-  // when the `JPEGCodec::Decode()` code is fixed.
-  // See https://github.com/electron/electron/issues/11294.
-  bitmap->setAlphaType(SkAlphaType::kOpaque_SkAlphaType);
-
-  image->AddRepresentation(gfx::ImageSkiaRep(*bitmap, scale_factor));
-  return true;
-}
-
-bool AddImageSkiaRepFromBuffer(gfx::ImageSkia* image,
-                               const unsigned char* data,
-                               size_t size,
-                               int width,
-                               int height,
-                               double scale_factor) {
-  // Try PNG first.
-  if (AddImageSkiaRepFromPNG(image, data, size, scale_factor))
-    return true;
-
-  // Try JPEG second.
-  if (AddImageSkiaRepFromJPEG(image, data, size, scale_factor))
-    return true;
-
-  if (width == 0 || height == 0)
-    return false;
-
-  auto info = SkImageInfo::MakeN32(width, height, kPremul_SkAlphaType);
-  if (size < info.computeMinByteSize())
-    return false;
-
-  SkBitmap bitmap;
-  bitmap.allocN32Pixels(width, height, false);
-  bitmap.writePixels({info, data, bitmap.rowBytes()});
-
-  image->AddRepresentation(gfx::ImageSkiaRep(bitmap, scale_factor));
-  return true;
-}
-
-bool AddImageSkiaRepFromPath(gfx::ImageSkia* image,
-                             const base::FilePath& path,
-                             double scale_factor) {
-  std::string file_contents;
-  {
-    base::ThreadRestrictions::ScopedAllowIO allow_io;
-    if (!asar::ReadFileToString(path, &file_contents))
-      return false;
-  }
-
-  const unsigned char* data =
-      reinterpret_cast<const unsigned char*>(file_contents.data());
-  size_t size = file_contents.size();
-
-  return AddImageSkiaRepFromBuffer(image, data, size, 0, 0, scale_factor);
-}
-
-bool PopulateImageSkiaRepsFromPath(gfx::ImageSkia* image,
-                                   const base::FilePath& path) {
-  bool succeed = false;
-  std::string filename(path.BaseName().RemoveExtension().AsUTF8Unsafe());
-  if (base::MatchPattern(filename, "*@*x"))
-    // Don't search for other representations if the DPI has been specified.
-    return AddImageSkiaRepFromPath(image, path, GetScaleFactorFromPath(path));
-  else
-    succeed |= AddImageSkiaRepFromPath(image, path, 1.0f);
-
-  for (const ScaleFactorPair& pair : kScaleFactorPairs)
-    succeed |= AddImageSkiaRepFromPath(
-        image, path.InsertBeforeExtensionASCII(pair.name), pair.scale);
-  return succeed;
 }
 
 base::FilePath NormalizePath(const base::FilePath& path) {
@@ -447,18 +328,18 @@ void NativeImage::AddRepresentation(const mate::Dictionary& options) {
   if (options.Get("buffer", &buffer) && node::Buffer::HasInstance(buffer)) {
     auto* data = reinterpret_cast<unsigned char*>(node::Buffer::Data(buffer));
     auto size = node::Buffer::Length(buffer);
-    skia_rep_added = AddImageSkiaRepFromBuffer(&image_skia, data, size, width,
-                                               height, scale_factor);
+    skia_rep_added = electron::util::AddImageSkiaRepFromBuffer(
+        &image_skia, data, size, width, height, scale_factor);
   } else if (options.Get("dataURL", &url)) {
     std::string mime_type, charset, data;
     if (net::DataURL::Parse(url, &mime_type, &charset, &data)) {
       auto* data_ptr = reinterpret_cast<const unsigned char*>(data.c_str());
       if (mime_type == "image/png") {
-        skia_rep_added = AddImageSkiaRepFromPNG(&image_skia, data_ptr,
-                                                data.size(), scale_factor);
+        skia_rep_added = electron::util::AddImageSkiaRepFromPNG(
+            &image_skia, data_ptr, data.size(), scale_factor);
       } else if (mime_type == "image/jpeg") {
-        skia_rep_added = AddImageSkiaRepFromJPEG(&image_skia, data_ptr,
-                                                 data.size(), scale_factor);
+        skia_rep_added = electron::util::AddImageSkiaRepFromJPEG(
+            &image_skia, data_ptr, data.size(), scale_factor);
       }
     }
   }
@@ -518,7 +399,7 @@ mate::Handle<NativeImage> NativeImage::CreateFromPath(
   }
 #endif
   gfx::ImageSkia image_skia;
-  PopulateImageSkiaRepsFromPath(&image_skia, image_path);
+  electron::util::PopulateImageSkiaRepsFromPath(&image_skia, image_path);
   gfx::Image image(image_skia);
   mate::Handle<NativeImage> handle = Create(isolate, image);
 #if defined(OS_MACOSX)
@@ -597,7 +478,7 @@ mate::Handle<NativeImage> NativeImage::CreateFromBuffer(
   }
 
   gfx::ImageSkia image_skia;
-  AddImageSkiaRepFromBuffer(
+  electron::util::AddImageSkiaRepFromBuffer(
       &image_skia, reinterpret_cast<unsigned char*>(node::Buffer::Data(buffer)),
       node::Buffer::Length(buffer), width, height, scale_factor);
   return Create(args->isolate(), gfx::Image(image_skia));

--- a/shell/common/api/atom_api_native_image.cc
+++ b/shell/common/api/atom_api_native_image.cc
@@ -114,7 +114,7 @@ NativeImage::NativeImage(v8::Isolate* isolate, const base::FilePath& hicon_path)
     : hicon_path_(hicon_path) {
   // Use the 256x256 icon as fallback icon.
   gfx::ImageSkia image_skia;
-  ReadImageSkiaFromICO(&image_skia, GetHICON(256));
+  electron::util::ReadImageSkiaFromICO(&image_skia, GetHICON(256));
   image_ = gfx::Image(image_skia);
   Init(isolate);
   if (image_.HasRepresentation(gfx::Image::kImageRepSkia)) {

--- a/shell/common/api/atom_api_native_image.cc
+++ b/shell/common/api/atom_api_native_image.cc
@@ -94,16 +94,6 @@ base::win::ScopedHICON ReadICOFromPath(int size, const base::FilePath& path) {
       static_cast<HICON>(LoadImage(NULL, image_path.value().c_str(), IMAGE_ICON,
                                    size, size, LR_LOADFROMFILE)));
 }
-
-bool ReadImageSkiaFromICO(gfx::ImageSkia* image, HICON icon) {
-  // Convert the icon from the Windows specific HICON to gfx::ImageSkia.
-  SkBitmap bitmap = IconUtil::CreateSkBitmapFromHICON(icon);
-  if (bitmap.isNull())
-    return false;
-
-  image->AddRepresentation(gfx::ImageSkiaRep(bitmap, 1.0f));
-  return true;
-}
 #endif
 
 void Noop(char*, void*) {}

--- a/shell/common/skia_util.cc
+++ b/shell/common/skia_util.cc
@@ -18,10 +18,13 @@
 #include "ui/gfx/codec/jpeg_codec.h"
 #include "ui/gfx/codec/png_codec.h"
 #include "ui/gfx/geometry/size.h"
-#include "ui/gfx/icon_util.h"
 #include "ui/gfx/image/image_skia.h"
 #include "ui/gfx/image/image_skia_operations.h"
 #include "ui/gfx/image/image_util.h"
+
+#if defined(OS_WIN)
+#include "ui/gfx/icon_util.h"
+#endif
 
 namespace electron {
 

--- a/shell/common/skia_util.cc
+++ b/shell/common/skia_util.cc
@@ -1,0 +1,159 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include <string>
+
+#include "base/files/file_util.h"
+#include "base/strings/pattern.h"
+#include "base/strings/string_util.h"
+#include "base/threading/thread_restrictions.h"
+#include "native_mate/dictionary.h"
+#include "native_mate/object_template_builder.h"
+#include "net/base/data_url.h"
+#include "shell/common/asar/asar_util.h"
+#include "shell/common/native_mate_converters/file_path_converter.h"
+#include "shell/common/native_mate_converters/gfx_converter.h"
+#include "shell/common/native_mate_converters/gurl_converter.h"
+#include "shell/common/native_mate_converters/value_converter.h"
+#include "shell/common/node_includes.h"
+#include "third_party/skia/include/core/SkBitmap.h"
+#include "third_party/skia/include/core/SkImageInfo.h"
+#include "third_party/skia/include/core/SkPixelRef.h"
+#include "ui/base/layout.h"
+#include "ui/base/webui/web_ui_util.h"
+#include "ui/gfx/codec/jpeg_codec.h"
+#include "ui/gfx/codec/png_codec.h"
+#include "ui/gfx/geometry/size.h"
+#include "ui/gfx/image/image_skia.h"
+#include "ui/gfx/image/image_skia_operations.h"
+#include "ui/gfx/image/image_util.h"
+
+namespace electron {
+
+namespace util {
+
+struct ScaleFactorPair {
+  const char* name;
+  float scale;
+};
+
+ScaleFactorPair kScaleFactorPairs[] = {
+    // The "@2x" is put as first one to make scale matching faster.
+    {"@2x", 2.0f},   {"@3x", 3.0f},     {"@1x", 1.0f},     {"@4x", 4.0f},
+    {"@5x", 5.0f},   {"@1.25x", 1.25f}, {"@1.33x", 1.33f}, {"@1.4x", 1.4f},
+    {"@1.5x", 1.5f}, {"@1.8x", 1.8f},   {"@2.5x", 2.5f},
+};
+
+float GetScaleFactorFromPath(const base::FilePath& path) {
+  std::string filename(path.BaseName().RemoveExtension().AsUTF8Unsafe());
+
+  // We don't try to convert string to float here because it is very very
+  // expensive.
+  for (const auto& kScaleFactorPair : kScaleFactorPairs) {
+    if (base::EndsWith(filename, kScaleFactorPair.name,
+                       base::CompareCase::INSENSITIVE_ASCII))
+      return kScaleFactorPair.scale;
+  }
+
+  return 1.0f;
+}
+
+bool AddImageSkiaRepFromPNG(gfx::ImageSkia* image,
+                            const unsigned char* data,
+                            size_t size,
+                            double scale_factor) {
+  SkBitmap bitmap;
+  if (!gfx::PNGCodec::Decode(data, size, &bitmap))
+    return false;
+
+  image->AddRepresentation(gfx::ImageSkiaRep(bitmap, scale_factor));
+  return true;
+}
+
+bool AddImageSkiaRepFromJPEG(gfx::ImageSkia* image,
+                             const unsigned char* data,
+                             size_t size,
+                             double scale_factor) {
+  auto bitmap = gfx::JPEGCodec::Decode(data, size);
+  if (!bitmap)
+    return false;
+
+  // `JPEGCodec::Decode()` doesn't tell `SkBitmap` instance it creates
+  // that all of its pixels are opaque, that's why the bitmap gets
+  // an alpha type `kPremul_SkAlphaType` instead of `kOpaque_SkAlphaType`.
+  // Let's fix it here.
+  // TODO(alexeykuzmin): This workaround should be removed
+  // when the `JPEGCodec::Decode()` code is fixed.
+  // See https://github.com/electron/electron/issues/11294.
+  bitmap->setAlphaType(SkAlphaType::kOpaque_SkAlphaType);
+
+  image->AddRepresentation(gfx::ImageSkiaRep(*bitmap, scale_factor));
+  return true;
+}
+
+bool AddImageSkiaRepFromBuffer(gfx::ImageSkia* image,
+                               const unsigned char* data,
+                               size_t size,
+                               int width,
+                               int height,
+                               double scale_factor) {
+  // Try PNG first.
+  if (AddImageSkiaRepFromPNG(image, data, size, scale_factor))
+    return true;
+
+  // Try JPEG second.
+  if (AddImageSkiaRepFromJPEG(image, data, size, scale_factor))
+    return true;
+
+  if (width == 0 || height == 0)
+    return false;
+
+  auto info = SkImageInfo::MakeN32(width, height, kPremul_SkAlphaType);
+  if (size < info.computeMinByteSize())
+    return false;
+
+  SkBitmap bitmap;
+  bitmap.allocN32Pixels(width, height, false);
+  bitmap.writePixels({info, data, bitmap.rowBytes()});
+
+  image->AddRepresentation(gfx::ImageSkiaRep(bitmap, scale_factor));
+  return true;
+}
+
+bool AddImageSkiaRepFromPath(gfx::ImageSkia* image,
+                             const base::FilePath& path,
+                             double scale_factor) {
+  std::string file_contents;
+  {
+    base::ThreadRestrictions::ScopedAllowIO allow_io;
+    if (!asar::ReadFileToString(path, &file_contents))
+      return false;
+  }
+
+  const unsigned char* data =
+      reinterpret_cast<const unsigned char*>(file_contents.data());
+  size_t size = file_contents.size();
+
+  return AddImageSkiaRepFromBuffer(image, data, size, 0, 0, scale_factor);
+}
+
+bool PopulateImageSkiaRepsFromPath(gfx::ImageSkia* image,
+                                   const base::FilePath& path) {
+  bool succeed = false;
+  std::string filename(path.BaseName().RemoveExtension().AsUTF8Unsafe());
+  if (base::MatchPattern(filename, "*@*x"))
+    // Don't search for other representations if the DPI has been specified.
+    return AddImageSkiaRepFromPath(image, path, GetScaleFactorFromPath(path));
+  else
+    succeed |= AddImageSkiaRepFromPath(image, path, 1.0f);
+
+  for (const ScaleFactorPair& pair : kScaleFactorPairs)
+    succeed |= AddImageSkiaRepFromPath(
+        image, path.InsertBeforeExtensionASCII(pair.name), pair.scale);
+  return succeed;
+}
+
+}  // namespace util
+
+}  // namespace electron

--- a/shell/common/skia_util.cc
+++ b/shell/common/skia_util.cc
@@ -8,21 +8,13 @@
 #include "base/strings/pattern.h"
 #include "base/strings/string_util.h"
 #include "base/threading/thread_restrictions.h"
-#include "native_mate/dictionary.h"
-#include "native_mate/object_template_builder.h"
 #include "net/base/data_url.h"
 #include "shell/common/asar/asar_util.h"
-#include "shell/common/native_mate_converters/file_path_converter.h"
-#include "shell/common/native_mate_converters/gfx_converter.h"
-#include "shell/common/native_mate_converters/gurl_converter.h"
-#include "shell/common/native_mate_converters/value_converter.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/skia_util.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "third_party/skia/include/core/SkImageInfo.h"
 #include "third_party/skia/include/core/SkPixelRef.h"
-#include "ui/base/layout.h"
-#include "ui/base/webui/web_ui_util.h"
 #include "ui/gfx/codec/jpeg_codec.h"
 #include "ui/gfx/codec/png_codec.h"
 #include "ui/gfx/geometry/size.h"
@@ -155,6 +147,17 @@ bool PopulateImageSkiaRepsFromPath(gfx::ImageSkia* image,
   return succeed;
 }
 
+#if defined(OS_WIN)
+bool ReadImageSkiaFromICO(gfx::ImageSkia* image, HICON icon) {
+  // Convert the icon from the Windows specific HICON to gfx::ImageSkia.
+  SkBitmap bitmap = IconUtil::CreateSkBitmapFromHICON(icon);
+  if (bitmap.isNull())
+    return false;
+
+  image->AddRepresentation(gfx::ImageSkiaRep(bitmap, 1.0f));
+  return true;
+#endif
+
 }  // namespace util
 
-}  // namespace electron
+}  // namespace util

--- a/shell/common/skia_util.cc
+++ b/shell/common/skia_util.cc
@@ -17,6 +17,7 @@
 #include "shell/common/native_mate_converters/gurl_converter.h"
 #include "shell/common/native_mate_converters/value_converter.h"
 #include "shell/common/node_includes.h"
+#include "shell/common/skia_util.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "third_party/skia/include/core/SkImageInfo.h"
 #include "third_party/skia/include/core/SkPixelRef.h"

--- a/shell/common/skia_util.cc
+++ b/shell/common/skia_util.cc
@@ -146,7 +146,6 @@ bool PopulateImageSkiaRepsFromPath(gfx::ImageSkia* image,
         image, path.InsertBeforeExtensionASCII(pair.name), pair.scale);
   return succeed;
 }
-
 #if defined(OS_WIN)
 bool ReadImageSkiaFromICO(gfx::ImageSkia* image, HICON icon) {
   // Convert the icon from the Windows specific HICON to gfx::ImageSkia.
@@ -156,8 +155,9 @@ bool ReadImageSkiaFromICO(gfx::ImageSkia* image, HICON icon) {
 
   image->AddRepresentation(gfx::ImageSkiaRep(bitmap, 1.0f));
   return true;
+}
 #endif
 
 }  // namespace util
 
-}  // namespace util
+}  // namespace electron

--- a/shell/common/skia_util.cc
+++ b/shell/common/skia_util.cc
@@ -18,6 +18,7 @@
 #include "ui/gfx/codec/jpeg_codec.h"
 #include "ui/gfx/codec/png_codec.h"
 #include "ui/gfx/geometry/size.h"
+#include "ui/gfx/icon_util.h"
 #include "ui/gfx/image/image_skia.h"
 #include "ui/gfx/image/image_skia_operations.h"
 #include "ui/gfx/image/image_util.h"

--- a/shell/common/skia_util.h
+++ b/shell/common/skia_util.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 GitHub, Inc.
+// Copyright (c) 2019 GitHub, Inc.
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 

--- a/shell/common/skia_util.h
+++ b/shell/common/skia_util.h
@@ -2,6 +2,9 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#ifndef SHELL_COMMON_SKIA_UTIL_H_
+#define SHELL_COMMON_SKIA_UTIL_H_
+
 #include <string>
 
 #include "ui/gfx/image/image_skia.h"
@@ -33,3 +36,5 @@ bool AddImageSkiaRepFromPNG(gfx::ImageSkia* image,
 }  // namespace util
 
 }  // namespace electron
+
+#endif  // SHELL_COMMON_SKIA_UTIL_H_

--- a/shell/common/skia_util.h
+++ b/shell/common/skia_util.h
@@ -33,6 +33,10 @@ bool AddImageSkiaRepFromPNG(gfx::ImageSkia* image,
                             size_t size,
                             double scale_factor);
 
+#if defined(OS_WIN)
+bool ReadImageSkiaFromICO(gfx::ImageSkia* image, HICON icon);
+#endif
+
 }  // namespace util
 
 }  // namespace electron

--- a/shell/common/skia_util.h
+++ b/shell/common/skia_util.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include <string>
+
+#include "ui/gfx/image/image_skia.h"
+
+namespace electron {
+
+namespace util {
+
+bool PopulateImageSkiaRepsFromPath(gfx::ImageSkia* image,
+                                   const base::FilePath& path);
+
+bool AddImageSkiaRepFromBuffer(gfx::ImageSkia* image,
+                               const unsigned char* data,
+                               size_t size,
+                               int width,
+                               int height,
+                               double scale_factor);
+
+bool AddImageSkiaRepFromJPEG(gfx::ImageSkia* image,
+                             const unsigned char* data,
+                             size_t size,
+                             double scale_factor);
+
+bool AddImageSkiaRepFromPNG(gfx::ImageSkia* image,
+                            const unsigned char* data,
+                            size_t size,
+                            double scale_factor);
+
+}  // namespace util
+
+}  // namespace electron


### PR DESCRIPTION
#### Description of Change

Inside `atom_api_native_image.cc`, we have a set of functions that are useful for generating `gfx::ImageSkia` representations.

I wanted to use those outside the context of `NativeWindow` in https://github.com/electron/electron/pull/19420, where I am reusing `electron::ShowMessageBoxSync` function to pop up an About dialog for Windows.

For this About Dialog, I am grabbing the message box icon from a file path, like we do in Linux.

Since `gfx::ImageSkia` is used outside of `NativeImage`, I was thinking that it'd be useful to do extract these utility functions into their own shared file instead of keeping them private within the NativeImage API file.

Would like feedback on the usefulness/viability of this!

cc @codebytere @DeerMichel 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes
