### PR TITLE
feat: emit always-on-top-changed on macOS

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -553,7 +553,7 @@ Emitted when the window enters a full-screen state triggered by HTML API.
 
 Emitted when the window leaves a full-screen state triggered by HTML API.
 
-#### Event: 'always-on-top-changed' _macOS_
+#### Event: 'always-on-top-changed'
 
 Returns:
 
@@ -1182,7 +1182,6 @@ On Linux always returns `true`.
   placed below the Dock on macOS and below the taskbar on Windows. From
   `pop-up-menu` to a higher it is shown above the Dock on macOS and above the
   taskbar on Windows. See the [macOS docs][window-levels] for more details.
-
 * `relativeLevel` Integer (optional) _macOS_ - The number of layers higher to set
   this window relative to the given `level`. The default is `0`. Note that Apple
   discourages setting levels higher than 1 above `screen-saver`.

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -810,6 +810,7 @@ void NativeWindowMac::SetAlwaysOnTop(ui::ZOrderLevel z_order,
                                      int relativeLevel,
                                      std::string* error) {
   int windowLevel = NSNormalWindowLevel;
+  bool level_changed = z_order != widget()->GetZOrderLevel();
   CGWindowLevel maxWindowLevel = CGWindowLevelForKey(kCGMaximumWindowLevelKey);
   CGWindowLevel minWindowLevel = CGWindowLevelForKey(kCGMinimumWindowLevelKey);
 
@@ -847,6 +848,11 @@ void NativeWindowMac::SetAlwaysOnTop(ui::ZOrderLevel z_order,
         stringWithFormat:@"relativeLevel must be between %d and %d",
                          minWindowLevel, maxWindowLevel] UTF8String]);
   }
+
+  // This must be notified at the very end or IsAlwaysOnTop
+  // will not yet have been updated to reflect the new status
+  if (level_changed)
+    NativeWindow::NotifyWindowAlwaysOnTopChanged();
 }
 
 ui::ZOrderLevel NativeWindowMac::GetZOrderLevel() {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1080,7 +1080,7 @@ describe('BrowserWindow module', () => {
       expect(w.isAlwaysOnTop()).to.be.true('is not alwaysOnTop')
     })
 
-    ifit(process.platform !== 'darwin')('causes the right value to be emitted on `always-on-top-changed`', (done) => {
+    it('causes the right value to be emitted on `always-on-top-changed`', (done) => {
       w.on('always-on-top-changed', (e, alwaysOnTop) => {
         expect(alwaysOnTop).to.be.true('is not alwaysOnTop')
         done()


### PR DESCRIPTION
#### Description of Change

The `always-on-top-changed` event  for BrowserWindows showed in documentation as being emitted on `macOS` only, but in fact it was emitted previously on `windows` and `linux` only. This corrects that error so that `always-on-top-changed` is emitted on all platforms.

cc @ckerr @MarshallOfSound @miniak 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `always-on-top-changed` event emission for macOS.
