### PR TITLE
fix: correctly emit BrowserWindow alwaysOnTop status in change event

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -756,9 +756,7 @@ void NativeWindowViews::SetAlwaysOnTop(ui::ZOrderLevel z_order,
                                        const std::string& level,
                                        int relativeLevel,
                                        std::string* error) {
-  if (z_order != widget()->GetZOrderLevel())
-    NativeWindow::NotifyWindowAlwaysOnTopChanged();
-
+  bool level_changed = z_order != widget()->GetZOrderLevel();
   widget()->SetZOrderLevel(z_order);
 
 #if defined(OS_WIN)
@@ -773,6 +771,11 @@ void NativeWindowViews::SetAlwaysOnTop(ui::ZOrderLevel z_order,
   }
 #endif
   MoveBehindTaskBarIfNeeded();
+
+  // This must be notified at the very end or IsAlwaysOnTop
+  // will not yet have been updated to reflect the new status
+  if (level_changed)
+    NativeWindow::NotifyWindowAlwaysOnTopChanged();
 }
 
 ui::ZOrderLevel NativeWindowViews::GetZOrderLevel() {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1040,22 +1040,24 @@ describe('BrowserWindow module', () => {
 
   describe('BrowserWindow.setAlwaysOnTop(flag, level)', () => {
     let w = null as unknown as BrowserWindow
+
     beforeEach(() => {
       w = new BrowserWindow({show: false})
     })
+
     afterEach(async () => {
       await closeWindow(w)
       w = null as unknown as BrowserWindow
     })
 
     it('sets the window as always on top', () => {
-      expect(w.isAlwaysOnTop()).to.equal(false)
+      expect(w.isAlwaysOnTop()).to.be.false('is alwaysOnTop')
       w.setAlwaysOnTop(true, 'screen-saver')
-      expect(w.isAlwaysOnTop()).to.equal(true)
+      expect(w.isAlwaysOnTop()).to.be.true('is not alwaysOnTop')
       w.setAlwaysOnTop(false)
-      expect(w.isAlwaysOnTop()).to.equal(false)
+      expect(w.isAlwaysOnTop()).to.be.false('is alwaysOnTop')
       w.setAlwaysOnTop(true)
-      expect(w.isAlwaysOnTop()).to.equal(true)
+      expect(w.isAlwaysOnTop()).to.be.true('is not alwaysOnTop')
     })
 
     ifit(process.platform === 'darwin')('raises an error when relativeLevel is out of bounds', () => {
@@ -1069,13 +1071,23 @@ describe('BrowserWindow module', () => {
     })
 
     ifit(process.platform === 'darwin')('resets the windows level on minimize', () => {
-      expect(w.isAlwaysOnTop()).to.equal(false)
+      expect(w.isAlwaysOnTop()).to.be.false('is alwaysOnTop')
       w.setAlwaysOnTop(true, 'screen-saver')
-      expect(w.isAlwaysOnTop()).to.equal(true)
+      expect(w.isAlwaysOnTop()).to.be.true('is not alwaysOnTop')
       w.minimize()
-      expect(w.isAlwaysOnTop()).to.equal(false)
+      expect(w.isAlwaysOnTop()).to.be.false('is alwaysOnTop')
       w.restore()
-      expect(w.isAlwaysOnTop()).to.equal(true)
+      expect(w.isAlwaysOnTop()).to.be.true('is not alwaysOnTop')
+    })
+
+    ifit(process.platform !== 'darwin')('causes the right value to be emitted on `always-on-top-changed`', (done) => {
+      w.on('always-on-top-changed', (e, alwaysOnTop) => {
+        expect(alwaysOnTop).to.be.true('is not alwaysOnTop')
+        done()
+      })
+
+      expect(w.isAlwaysOnTop()).to.be.false('is alwaysOnTop')
+      w.setAlwaysOnTop(true)
     })
   })
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/19453.

Previously, `alwaysOnTop` status was being calculated dynamically and emitted at the top of `NativeWindowViews::SetAlwaysOnTop`, which meant that it had not yet been changed at the operating system level. Consequently, when the event itself called `IsAlwaysOnTop()` it would return the inverse of what it should be.

To fix this, I determined whether the level has been changed at the top of `SetAlwaysOnTop`, and then moved the actual event emission itself to the bottom of the method so that it would pick up the correct new `alwaysOnTop` status. Tests have been added to verify this behavior.

cc @ckerr @MarshallOfSound @DeerMichel  

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed inverted `alwaysOnTop` status returned when `always-on-top-changed` was emitted on Linux and Windows.