### PR TITLE
refactor: simplify intentional-crash code

### DIFF
--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -35,11 +35,6 @@ namespace electron {
 
 namespace {
 
-// Dummy class type that used for crashing the program.
-struct DummyClass {
-  bool crash;
-};
-
 // Called when there is a fatal error in V8, we just crash the process here so
 // we can get the stack trace.
 void FatalErrorCallback(const char* location, const char* message) {
@@ -152,7 +147,8 @@ void ElectronBindings::Log(const base::string16& message) {
 
 // static
 void ElectronBindings::Crash() {
-  static_cast<DummyClass*>(nullptr)->crash = true;
+  volatile int* zero = nullptr;
+  *zero = 0;
 }
 
 // static


### PR DESCRIPTION
#### Description of Change
Inspired by https://chromium.googlesource.com/chromium/src/+/76.0.3809.20/content/renderer/crash_helpers.cc#22

Decided not to add the additional `base::debug::Alias` complexity because it seemed unnecessary.

I couldn't find a helper in `//base` that does this, unfortunately.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none