### PR TITLE
fix: [wc|bw]-created events do not emit an event object

### DIFF
--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -82,7 +82,7 @@ BrowserWindow.prototype._init = function () {
   }
 
   // Notify the creation of the window.
-  const event = process.electronBinding('event').createWithSender(null)
+  const event = process.electronBinding('event').createEmpty()
   app.emit('browser-window-created', event, this)
 
   Object.defineProperty(this, 'devToolsWebContents', {

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -82,7 +82,8 @@ BrowserWindow.prototype._init = function () {
   }
 
   // Notify the creation of the window.
-  app.emit('browser-window-created', {}, this)
+  const event = process.electronBinding('event').createWithSender(null)
+  app.emit('browser-window-created', event, this)
 
   Object.defineProperty(this, 'devToolsWebContents', {
     enumerable: true,

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -413,7 +413,7 @@ WebContents.prototype._init = function () {
     })
   }
 
-  const event = process.electronBinding('event').createWithSender(null)
+  const event = process.electronBinding('event').createEmpty()
   app.emit('web-contents-created', event, this)
 }
 

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -413,7 +413,8 @@ WebContents.prototype._init = function () {
     })
   }
 
-  app.emit('web-contents-created', {}, this)
+  const event = process.electronBinding('event').createWithSender(null)
+  app.emit('web-contents-created', event, this)
 }
 
 // Deprecations

--- a/shell/browser/api/atom_api_event.cc
+++ b/shell/browser/api/atom_api_event.cc
@@ -13,12 +13,17 @@ v8::Local<v8::Object> CreateWithSender(v8::Isolate* isolate,
   return mate::internal::CreateJSEvent(isolate, sender, nullptr, base::nullopt);
 }
 
+v8::Local<v8::Object> CreateEmpty(v8::Isolate* isolate) {
+  return mate::internal::CreateEmptyJSEvent(isolate);
+}
+
 void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context,
                 void* priv) {
   mate::Dictionary dict(context->GetIsolate(), exports);
   dict.SetMethod("createWithSender", &CreateWithSender);
+  dict.SetMethod("createEmpty", &CreateEmpty);
 }
 
 }  // namespace

--- a/shell/browser/api/event_emitter.cc
+++ b/shell/browser/api/event_emitter.cc
@@ -67,6 +67,13 @@ v8::Local<v8::Object> CreateJSEvent(
   return event;
 }
 
+v8::Local<v8::Object> CreateEmptyJSEvent(v8::Isolate* isolate) {
+  mate::Handle<mate::Event> native_event = mate::Event::Create(isolate);
+  v8::Local<v8::Object> event =
+      v8::Local<v8::Object>::Cast(native_event.ToV8());
+  return event;
+}
+
 v8::Local<v8::Object> CreateCustomEvent(v8::Isolate* isolate,
                                         v8::Local<v8::Object> object,
                                         v8::Local<v8::Object> custom_event) {

--- a/shell/browser/api/event_emitter.h
+++ b/shell/browser/api/event_emitter.h
@@ -28,6 +28,7 @@ v8::Local<v8::Object> CreateJSEvent(
     content::RenderFrameHost* sender,
     base::Optional<electron::mojom::ElectronBrowser::MessageSyncCallback>
         callback);
+v8::Local<v8::Object> CreateEmptyJSEvent(v8::Isolate* isolate);
 v8::Local<v8::Object> CreateCustomEvent(v8::Isolate* isolate,
                                         v8::Local<v8::Object> object,
                                         v8::Local<v8::Object> event);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/19455.

Previously, an [empty object](https://github.com/electron/electron/blob/d1292833e924fc80043a937a85fcb8f49cf67c30/lib/browser/api/browser-window.js#L85) was emitted in place of an Event during `browser-window-created` as well as when `web-contents-created` was [emitted](https://github.com/electron/electron/blob/8782d06ed610e346f70862561aa033905c93a86c/lib/browser/api/web-contents.js#L416).

This led to false assumptions about the nature of the object for end-users. Instead, we now create an empty but legitimate Event and emit that instead.

cc @zcbenz @deepak1556 @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: `web-contents-created` and `browser-window-created` no longer emit an empty object in place of Event.
