### PR TITLE
fix: use GetAuraColor to get theme dependant menu bg color

### DIFF
--- a/shell/browser/ui/views/menu_bar.cc
+++ b/shell/browser/ui/views/menu_bar.cc
@@ -12,6 +12,7 @@
 #include "shell/common/keyboard_util.h"
 #include "ui/aura/window.h"
 #include "ui/base/models/menu_model.h"
+#include "ui/native_theme/common_theme.h"
 #include "ui/views/background.h"
 #include "ui/views/layout/box_layout.h"
 #include "ui/views/widget/widget.h"
@@ -297,12 +298,9 @@ void MenuBar::RefreshColorCache() {
         "GtkMenuBar#menubar GtkMenuItem#menuitem:disabled GtkLabel");
 #else
     background_color_ =
-        theme->GetSystemColor(ui::NativeTheme::kColorId_MenuBackgroundColor);
+        ui::GetAuraColor(ui::NativeTheme::kColorId_MenuBackgroundColor, theme);
 #endif
   }
-#if defined(OS_WIN)
-  background_color_ = color_utils::GetSysSkColor(COLOR_MENUBAR);
-#endif
 }
 
 void MenuBar::OnThemeChanged() {


### PR DESCRIPTION
Easiest to explain with pictures

Before:
![image](https://user-images.githubusercontent.com/6634592/61910647-0fabac00-aeea-11e9-92bc-b67a4eac1016.png)

After:
![image](https://user-images.githubusercontent.com/6634592/61910669-1cc89b00-aeea-11e9-92cf-4d0bbbfac723.png)


Notes: Fixed window menu background color when in dark mode on Windows 10