### PR TITLE
docs: fix GPU infoType typings

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1023,7 +1023,7 @@ Returns [`GPUFeatureStatus`](structures/gpu-feature-status.md) - The Graphics Fe
 
 ### `app.getGPUInfo(infoType)`
 
-* `infoType` String - Values can be either `basic` for basic info or `complete` for complete info.
+* `infoType` String - Can be `basic` or `complete`.
 
 Returns `Promise<unknown>`
 
@@ -1227,7 +1227,7 @@ systems Application folder. Use in combination with `app.moveToApplicationsFolde
 
 * `options` Object (optional)
   * `conflictHandler` Function<Boolean> (optional) - A handler for potential conflict in move failure.
-    * `conflictType` String - the type of move conflict encountered by the handler; can be `exists` or `existsAndRunning`, where `exists` means that an app of the same name is present in the Applications directory and `existsAndRunning` means both that it exists and that it's presently running.
+    * `conflictType` String - The type of move conflict encountered by the handler; can be `exists` or `existsAndRunning`, where `exists` means that an app of the same name is present in the Applications directory and `existsAndRunning` means both that it exists and that it's presently running.
 
 Returns `Boolean` - Whether the move was successful. Please note that if
 the move is successful, your application will quit and relaunch.

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -1058,7 +1058,7 @@ describe('app module', () => {
     it('fails for invalid info_type', () => {
       const invalidType = 'invalid'
       const expectedErrorMessage = "Invalid info type. Use 'basic' or 'complete'"
-      return expect(app.getGPUInfo(invalidType)).to.eventually.be.rejectedWith(expectedErrorMessage)
+      return expect(app.getGPUInfo(invalidType as any)).to.eventually.be.rejectedWith(expectedErrorMessage)
     })
   })
 


### PR DESCRIPTION
#### Description of Change

Corrects typing for the `infoType` parameter  of `getGPUInfo()` to be a string literal. Also updates test accordingly.

cc @MarshallOfSound @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
