### PR TITLE
docs: fix app.getPath types so that "name" is a string enum

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -598,6 +598,7 @@ Returns `String` - The current application directory.
     * `~/Library/Application Support` on macOS
   * `userData` The directory for storing your app's configuration files, which by
     default it is the `appData` directory appended with your app's name.
+  * `cache`
   * `temp` Temporary directory.
   * `exe` The current executable file.
   * `module` The `libchromiumcontent` library.

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -590,31 +590,28 @@ Returns `String` - The current application directory.
 
 ### `app.getPath(name)`
 
-* `name` String
+* `name` String - You can request the following paths by the name:
+  * `home` User's home directory.
+  * `appData` Per-user application data directory, which by default points to:
+    * `%APPDATA%` on Windows
+    * `$XDG_CONFIG_HOME` or `~/.config` on Linux
+    * `~/Library/Application Support` on macOS
+  * `userData` The directory for storing your app's configuration files, which by
+    default it is the `appData` directory appended with your app's name.
+  * `temp` Temporary directory.
+  * `exe` The current executable file.
+  * `module` The `libchromiumcontent` library.
+  * `desktop` The current user's Desktop directory.
+  * `documents` Directory for a user's "My Documents".
+  * `downloads` Directory for a user's downloads.
+  * `music` Directory for a user's music.
+  * `pictures` Directory for a user's pictures.
+  * `videos` Directory for a user's videos.
+  * `logs` Directory for your app's log folder.
+  * `pepperFlashSystemPlugin` Full path to the system version of the Pepper Flash plugin.
 
 Returns `String` - A path to a special directory or file associated with `name`. On
 failure, an `Error` is thrown.
-
-You can request the following paths by the name:
-
-* `home` User's home directory.
-* `appData` Per-user application data directory, which by default points to:
-  * `%APPDATA%` on Windows
-  * `$XDG_CONFIG_HOME` or `~/.config` on Linux
-  * `~/Library/Application Support` on macOS
-* `userData` The directory for storing your app's configuration files, which by
-  default it is the `appData` directory appended with your app's name.
-* `temp` Temporary directory.
-* `exe` The current executable file.
-* `module` The `libchromiumcontent` library.
-* `desktop` The current user's Desktop directory.
-* `documents` Directory for a user's "My Documents".
-* `downloads` Directory for a user's downloads.
-* `music` Directory for a user's music.
-* `pictures` Directory for a user's pictures.
-* `videos` Directory for a user's videos.
-* `logs` Directory for your app's log folder.
-* `pepperFlashSystemPlugin` Full path to the system version of the Pepper Flash plugin.
 
 ### `app.getFileIcon(path[, options])`
 

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -683,7 +683,7 @@ describe('app module', () => {
 
     it('throws an error when the name is invalid', () => {
       expect(() => {
-        app.getPath('does-not-exist')
+        app.getPath('does-not-exist' as any)
       }).to.throw(/Failed to get 'does-not-exist' path/)
     })
 
@@ -701,7 +701,7 @@ describe('app module', () => {
       app.setPath('music', badPath)
       expect(fs.existsSync(badPath)).to.be.false
 
-      expect(() => { app.getPath(badPath) }).to.throw()
+      expect(() => { app.getPath(badPath as any) }).to.throw()
     })
   })
 


### PR DESCRIPTION
Fixes https://github.com/electron/typescript-definitions/issues/140

Does what it says on the tin

Notes: no-notes