### PR TITLE
fix: remove .pdb from symbol file names

### DIFF
--- a/build/dump_syms.py
+++ b/build/dump_syms.py
@@ -22,7 +22,7 @@ def get_symbol_path(symbol_data):
   if not module_info:
     raise Exception("Couldn't get module info for binary '{}'".format(binary))
   exe_name = module_info.name.replace('.pdb', '')
-  return os.path.join(module_info.name, module_info.hash, module_info.name + ".sym")
+  return os.path.join(module_info.name, module_info.hash, exe_name + ".sym")
 
 def mkdir_p(path):
   """Simulates mkdir -p."""

--- a/build/dump_syms.py
+++ b/build/dump_syms.py
@@ -21,6 +21,7 @@ def get_symbol_path(symbol_data):
   module_info = get_module_info(symbol_data[:symbol_data.index('\n')])
   if not module_info:
     raise Exception("Couldn't get module info for binary '{}'".format(binary))
+  exe_name = module_info.name.replace('.pdb', '')
   return os.path.join(module_info.name, module_info.hash, module_info.name + ".sym")
 
 def mkdir_p(path):


### PR DESCRIPTION
#### Description of Change
Fixes #19475.

This was previously done here: https://github.com/electron/electron/pull/19042/files#diff-30b27691e6dbf02ed1bb6ae968f5ef8dL87, but that logic was inadvertently removed in #19042.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where windows symbol files were changed in a way that was incompatible with some symbolication tools.