### PR TITLE
Notifications. Error passing values to notifications object.

### DIFF
--- a/docs/tutorial/notifications.md
+++ b/docs/tutorial/notifications.md
@@ -10,7 +10,8 @@ you want to show Notifications in the main process please check out the
 [Notification](../api/notification.md) module.
 
 ```javascript
-let myNotification = new Notification('Title', {
+let myNotification = new Notification({
+  title: 'Title',
   body: 'Lorem Ipsum Dolor Sit Amet'
 })
 


### PR DESCRIPTION
This way it didn't work for me:

    let myNotification = new Notification ('Title', {
        body: 'Lorem Ipsum Dolor Sit Amet'
    })

It only worked when I decided to try changing the code to:

    let myNotification = new Notification ({
        title: 'Title',
        body: 'Lorem Ipsum Dolor Sit Amet'
    })

I hope this helps someone.
