### PR TITLE
fix: refactoring regression in LocationProxy

### DIFF
--- a/lib/renderer/window-setup.ts
+++ b/lib/renderer/window-setup.ts
@@ -69,19 +69,19 @@ class LocationProxy {
    */
   private static ProxyProperty<T> (target: LocationProxy, propertyKey: LocationProperties) {
     Object.defineProperty(target, propertyKey, {
-      get: function (): T | string {
+      get: function (this: LocationProxy): T | string {
         const guestURL = this.getGuestURL()
         const value = guestURL ? guestURL[propertyKey] : ''
         return value === undefined ? '' : value
       },
-      set: function (newVal: T) {
+      set: function (this: LocationProxy, newVal: T) {
         const guestURL = this.getGuestURL()
         if (guestURL) {
           // TypeScript doesn't want us to assign to read-only variables.
           // It's right, that's bad, but we're doing it anway.
           (guestURL as any)[propertyKey] = newVal
 
-          return this.ipcRenderer.sendSync(
+          return ipcRendererInternal.sendSync(
             'ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD_SYNC',
             this.guestId, 'loadURL', guestURL.toString())
         }

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -520,6 +520,22 @@ describe('chromium feature', () => {
       b = window.open('about:blank')
     })
 
+    it('defines a window.location.href setter', (done) => {
+      let b = null
+      app.once('browser-window-created', (event, { webContents }) => {
+        webContents.once('did-finish-load', () => {
+          // When it loads, redirect
+          b.location.href = `file://${fixtures}/pages/base-page.html`
+          webContents.once('did-finish-load', () => {
+            // After our second redirect, cleanup and callback
+            b.close()
+            done()
+          })
+        })
+      })
+      b = window.open('about:blank')
+    })
+
     it('open a blank page when no URL is specified', async () => {
       const browserWindowCreated = emittedOnce(app, 'browser-window-created')
       const w = window.open()


### PR DESCRIPTION
#### Description of Change
Fixes regression introduced in #17591
<img width="912" alt="Screen Shot 2019-07-28 at 11 51 48 AM" src="https://user-images.githubusercontent.com/1281234/62005080-1cb8dd00-b12e-11e9-99c6-93657f2c1723.png">

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed `popup.location.*` setters when `nativeWindowOpen` is disabled.