### PR TITLE
build: remove GConf and dconf dependencies on linux

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -19,8 +19,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
  libcap-dev \
  libcups2-dev \
  libdbus-1-dev \
- libgconf-2-4 \
- libgconf2-dev \
  libgnome-keyring-dev \
  libgtk2.0-0 \
  libgtk2.0-dev \

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -22,8 +22,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
  libcap-dev \
  libcups2-dev \
  libdbus-1-dev \
- libgconf-2-4 \
- libgconf2-dev \
  libgnome-keyring-dev \
  libgtk2.0-0 \
  libgtk2.0-dev \

--- a/build/install-build-deps.sh
+++ b/build/install-build-deps.sh
@@ -255,16 +255,10 @@ backwards_compatible_list="\
   libappindicator-dev
   libappindicator1
   libappindicator3-1:i386
-  libdconf-dev
-  libdconf-dev:i386
-  libdconf1
-  libdconf1:i386
   libexif-dev
   libexif12
   libexif12:i386
   libgbm-dev
-  libgconf-2-4:i386
-  libgconf2-dev
   libgl1-mesa-dev
   libgl1-mesa-glx:i386
   libgles2-mesa-dev

--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -31,7 +31,7 @@ On Ubuntu, install the following libraries:
 
 ```sh
 $ sudo apt-get install build-essential clang libdbus-1-dev libgtk-3-dev \
-                       libnotify-dev libgnome-keyring-dev libgconf2-dev \
+                       libnotify-dev libgnome-keyring-dev \
                        libasound2-dev libcap-dev libcups2-dev libxtst-dev \
                        libxss1 libnss3-dev gcc-multilib g++-multilib curl \
                        gperf bison python-dbusmock openjdk-8-jre
@@ -43,7 +43,7 @@ On RHEL / CentOS, install the following libraries:
 $ sudo yum install clang dbus-devel gtk3-devel libnotify-devel \
                    libgnome-keyring-devel xorg-x11-server-utils libcap-devel \
                    cups-devel libXtst-devel alsa-lib-devel libXrandr-devel \
-                   GConf2-devel nss-devel python-dbusmock openjdk-8-jre
+                   nss-devel python-dbusmock openjdk-8-jre
 ```
 
 On Fedora, install the following libraries:
@@ -52,7 +52,7 @@ On Fedora, install the following libraries:
 $ sudo dnf install clang dbus-devel gtk3-devel libnotify-devel \
                    libgnome-keyring-devel xorg-x11-server-utils libcap-devel \
                    cups-devel libXtst-devel alsa-lib-devel libXrandr-devel \
-                   GConf2-devel nss-devel python-dbusmock openjdk-8-jre
+                   nss-devel python-dbusmock openjdk-8-jre
 ```
 
 Other distributions may offer similar packages for installation via package

--- a/docs/tutorial/snapcraft.md
+++ b/docs/tutorial/snapcraft.md
@@ -128,7 +128,6 @@ parts:
       - desktop-gtk3
     stage-packages:
       - libasound2
-      - libgconf2-4
       - libnotify4
       - libnspr4
       - libnss3


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

`GConf` and `dconf` are no longer required by chromium since around version 66 ([chromium#768027](https://bugs.chromium.org/p/chromium/issues/detail?id=768027)).

Since Electron is not depending on these libraries directly (e.g.: they were transitive dependencies coming from chromium) *I think* it's safe to remove them from the Dockerfiles and from the Linux build instructions documentation.

Related discussion: https://github.com/electron/electron/issues/2727

Resolves #2727

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> Removed GConf and dconf dependencies on Linux.
