### PR TITLE
docs: fix invalid code block language tags

### DIFF
--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -64,7 +64,7 @@ If you want to support displays with different DPI densities at the same time,
 you can put images with different sizes in the same folder and use the filename
 without DPI suffixes. For example:
 
-```text
+```plaintext
 images/
 ├── icon.png
 ├── icon@2x.png

--- a/docs/tutorial/application-distribution.md
+++ b/docs/tutorial/application-distribution.md
@@ -20,7 +20,7 @@ below.
 
 On macOS:
 
-```text
+```plaintext
 electron/Electron.app/Contents/Resources/app/
 ├── package.json
 ├── main.js
@@ -29,7 +29,7 @@ electron/Electron.app/Contents/Resources/app/
 
 On Windows and Linux:
 
-```text
+```plaintext
 electron/resources/app
 ├── package.json
 ├── main.js
@@ -52,14 +52,14 @@ below, and Electron will then try to read the archive and start from it.
 
 On macOS:
 
-```text
+```plaintext
 electron/Electron.app/Contents/Resources/
 └── app.asar
 ```
 
 On Windows and Linux:
 
-```text
+```plaintext
 electron/resources/
 └── app.asar
 ```
@@ -91,7 +91,7 @@ file's name.
 
 The structure of a renamed app would be like:
 
-```text
+```plaintext
 MyApp.app/Contents
 ├── Info.plist
 ├── MacOS/

--- a/docs/tutorial/electron-versioning.md
+++ b/docs/tutorial/electron-versioning.md
@@ -93,7 +93,7 @@ Specifically, the above means:
 
 For each major and minor bump, you should expect to see something like the following:
 
-```text
+```plaintext
 2.0.0-beta.1
 2.0.0-beta.2
 2.0.0-beta.3

--- a/docs/tutorial/first-app.md
+++ b/docs/tutorial/first-app.md
@@ -17,7 +17,7 @@ Node.js application. The starting point is a `package.json` that is identical
 to that of a Node.js module. A most basic Electron app would have the following
 folder structure:
 
-```text
+```plaintext
 your-app/
 ├── package.json
 ├── main.js

--- a/docs/tutorial/installation.md
+++ b/docs/tutorial/installation.md
@@ -55,13 +55,13 @@ You can use environment variables to override the base URL, the path at which to
 look for Electron binaries, and the binary filename. The url used by `electron-download`
 is composed as follows:
 
-```txt
+```plaintext
 url = ELECTRON_MIRROR + ELECTRON_CUSTOM_DIR + '/' + ELECTRON_CUSTOM_FILENAME
 ```
 
 For instance, to use the China mirror:
 
-```txt
+```plaintext
 ELECTRON_MIRROR="https://npm.taobao.org/mirrors/electron/"
 ```
 

--- a/docs/tutorial/linux-desktop-actions.md
+++ b/docs/tutorial/linux-desktop-actions.md
@@ -13,7 +13,7 @@ Generally speaking, shortcuts are added by providing a `Name` and `Exec`
 property for each entry in the shortcuts menu. Unity will execute the
 `Exec` field once clicked by the user. The format is as follows:
 
-```text
+```plaintext
 Actions=PlayPause;Next;Previous
 
 [Desktop Action PlayPause]

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -391,7 +391,7 @@ easy way to improve your application's security.
 The following CSP will allow Electron to execute scripts from the current
 website and from `apis.example.com`.
 
-```txt
+```plaintext
 // Bad
 Content-Security-Policy: '*'
 

--- a/docs/tutorial/snapcraft.md
+++ b/docs/tutorial/snapcraft.md
@@ -49,7 +49,7 @@ your application's size.
 
 The output should look roughly like this:
 
-```text
+```plaintext
 .
 └── dist
     └── app-linux-x64

--- a/docs/tutorial/using-native-node-modules.md
+++ b/docs/tutorial/using-native-node-modules.md
@@ -122,7 +122,7 @@ is built with another system, you'll need to ensure that you build with a
 delay-load hook installed in the main `.node` file. Your `link.exe` invocation
 should look like this:
 
-```text
+```plaintext
  link.exe /OUT:"foo.node" "...\node.lib" delayimp.lib /DELAYLOAD:node.exe /DLL
      "my_addon.obj" "win_delay_load_hook.obj"
 ```

--- a/docs/tutorial/windows-store-guide.md
+++ b/docs/tutorial/windows-store-guide.md
@@ -48,7 +48,7 @@ any module you don't actually need will increase your application's size.
 
 The output should look roughly like this:
 
-```text
+```plaintext
 ├── Ghost.exe
 ├── LICENSE
 ├── content_resources_200_percent.pak


### PR DESCRIPTION
#### Description of Change
After updating `e/hubdown` at `e/i18n`, the syntax highlighting step of our docs generation [fails](https://github.com/electron/i18n/pull/775/checks?check_run_id=180007046) on `text` and `txt` lang tags. The highlighting library seems to got pickier on invalid languages. However, we could use `plaintext` instead - see [supported lang tags](https://github.com/highlightjs/highlight.js/blob/master/docs/css-classes-reference.rst#language-names-and-aliases).

To avoid touching docs of older versions, we'll add a temporary transformer to `e/i18n` which replaces `text`/`txt` tags with `plaintext`.

cc @HashimotoYT @codebytere 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none
