### PR TITLE
fix: throw better error on getPath('logs')

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -582,7 +582,7 @@ them.
 
 Sets or creates a directory your app's logs which can then be manipulated with `app.getPath()` or `app.setPath(pathName, newPath)`.
 
-On _macOS_, this directory will be set by default to `/Library/Logs/YourAppName`, and on _Linux_ and _Windows_ it will be placed inside your `userData` directory.
+Calling `app.setAppLogsPath()` without a `path` parameter will result in this directory being set to `/Library/Logs/YourAppName` on _macOS_, and inside the `userData` directory on _Linux_ and _Windows_.
 
 ### `app.getAppPath()`
 

--- a/shell/browser/api/atom_api_app.cc
+++ b/shell/browser/api/atom_api_app.cc
@@ -871,8 +871,15 @@ base::FilePath App::GetPath(mate::Arguments* args, const std::string& name) {
   int key = GetPathConstant(name);
   if (key >= 0)
     succeed = base::PathService::Get(key, &path);
-  if (!succeed)
-    args->ThrowError("Failed to get '" + name + "' path");
+  if (!succeed) {
+    if (name == "logs") {
+      args->ThrowError("Failed to get '" + name +
+                       "' path: setAppLogsPath() must be called first.");
+    } else {
+      args->ThrowError("Failed to get '" + name + "' path");
+    }
+  }
+
   return path;
 }
 


### PR DESCRIPTION
#### Description of Change

Clarifies what default path is created and set when `setAppLogsPath()` is called with no `path` parameter. Also throws a more specific error when `getPath('logs')` is called and `setAppLogsPath()` has not yet been called.

cc @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: `getPath('logs')` now throws better error when it fails to find the logs path.
