### PR TITLE
fix: set default dock bounce type

### DIFF
--- a/shell/browser/api/atom_api_app.cc
+++ b/shell/browser/api/atom_api_app.cc
@@ -1338,8 +1338,11 @@ bool App::IsInApplicationsFolder() {
   return ui::cocoa::AtomBundleMover::IsCurrentAppInApplicationsFolder();
 }
 
-int DockBounce(const std::string& type) {
+int DockBounce(mate::Arguments* args) {
   int request_id = -1;
+  std::string type = "informational";
+  args->GetNext(&type);
+
   if (type == "critical")
     request_id = Browser::Get()->DockBounce(Browser::BounceType::CRITICAL);
   else if (type == "informational")


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/19522.

Sets `informational` as the default dock bounce type value once more.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed default dock bounce type on macOS.
