### PR TITLE
fix: correctly emit BrowserWindow alwaysOnTop status

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -825,6 +825,7 @@ void NativeWindowMac::SetAlwaysOnTop(bool top,
                                      int relativeLevel,
                                      std::string* error) {
   int windowLevel = NSNormalWindowLevel;
+  bool level_changed = top != widget()->IsAlwaysOnTop();
   CGWindowLevel maxWindowLevel = CGWindowLevelForKey(kCGMaximumWindowLevelKey);
   CGWindowLevel minWindowLevel = CGWindowLevelForKey(kCGMinimumWindowLevelKey);
 
@@ -857,6 +858,11 @@ void NativeWindowMac::SetAlwaysOnTop(bool top,
         stringWithFormat:@"relativeLevel must be between %d and %d",
                          minWindowLevel, maxWindowLevel] UTF8String]);
   }
+
+  // This must be notified at the very end or IsAlwaysOnTop
+  // will not yet have been updated to reflect the new status
+  if (level_changed)
+    NativeWindow::NotifyWindowAlwaysOnTopChanged();
 }
 
 bool NativeWindowMac::IsAlwaysOnTop() {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -754,10 +754,14 @@ void NativeWindowViews::SetAlwaysOnTop(bool top,
                                        const std::string& level,
                                        int relativeLevel,
                                        std::string* error) {
-  if (top != widget()->IsAlwaysOnTop())
-    NativeWindow::NotifyWindowAlwaysOnTopChanged();
+  bool level_changed = top != widget()->IsAlwaysOnTop();
 
   widget()->SetAlwaysOnTop(top);
+
+  // This must be notified at the very end or IsAlwaysOnTop
+  // will not yet have been updated to reflect the new status
+  if (level_changed)
+    NativeWindow::NotifyWindowAlwaysOnTopChanged();
 }
 
 bool NativeWindowViews::IsAlwaysOnTop() {

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -555,7 +555,7 @@ Emitted when the window enters a full-screen state triggered by HTML API.
 
 Emitted when the window leaves a full-screen state triggered by HTML API.
 
-#### Event: 'always-on-top-changed' _macOS_
+#### Event: 'always-on-top-changed'
 
 Returns:
 

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -916,6 +916,16 @@ describe('BrowserWindow module', () => {
         w.setAlwaysOnTop(true, '', 2147483632)
       })
     })
+
+    it('causes the right value to be emitted on `always-on-top-changed`', (done) => {
+      w.on('always-on-top-changed', (e, alwaysOnTop) => {
+        assert.strictEqual(alwaysOnTop, true)
+        done()
+      })
+
+      assert.strictEqual(w.isAlwaysOnTop(), false)
+      w.setAlwaysOnTop(true)
+    })
   })
 
   describe('BrowserWindow.alwaysOnTop() resets level on minimize', () => {


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/19463.

See that PR for more details.

Notes:  Fixed inverted `alwaysOnTop` status returned when `always-on-top-changed` was emitted.