### PR TITLE
refactor: add DisplayBalloonOptions to allow adding new options easily

### DIFF
--- a/shell/browser/api/atom_api_tray.cc
+++ b/shell/browser/api/atom_api_tray.cc
@@ -189,22 +189,26 @@ bool Tray::GetIgnoreDoubleClickEvents() {
 
 void Tray::DisplayBalloon(mate::Arguments* args,
                           const mate::Dictionary& options) {
-  mate::Handle<NativeImage> icon;
-  options.Get("icon", &icon);
-  base::string16 title, content;
-  if (!options.Get("title", &title) || !options.Get("content", &content)) {
+  TrayIcon::BalloonOptions balloon_options;
+
+  if (!options.Get("title", &balloon_options.title) ||
+      !options.Get("content", &balloon_options.content)) {
     args->ThrowError("'title' and 'content' must be defined");
     return;
   }
 
+  mate::Handle<NativeImage> icon;
+  options.Get("icon", &icon);
+
+  if (!icon.IsEmpty()) {
 #if defined(OS_WIN)
-  tray_icon_->DisplayBalloon(
-      icon.IsEmpty() ? NULL : icon->GetHICON(GetSystemMetrics(SM_CXICON)),
-      title, content);
+    balloon_options.icon = icon->GetHICON(GetSystemMetrics(SM_CXICON));
 #else
-  tray_icon_->DisplayBalloon(icon.IsEmpty() ? gfx::Image() : icon->image(),
-                             title, content);
+    balloon_options.icon = icon->image();
 #endif
+  }
+
+  tray_icon_->DisplayBalloon(balloon_options);
 }
 
 void Tray::PopUpContextMenu(mate::Arguments* args) {

--- a/shell/browser/ui/tray_icon.cc
+++ b/shell/browser/ui/tray_icon.cc
@@ -14,9 +14,7 @@ void TrayIcon::SetPressedImage(ImageType image) {}
 
 void TrayIcon::SetHighlightMode(TrayIcon::HighlightMode mode) {}
 
-void TrayIcon::DisplayBalloon(ImageType icon,
-                              const base::string16& title,
-                              const base::string16& contents) {}
+void TrayIcon::DisplayBalloon(const BalloonOptions& options) {}
 
 void TrayIcon::PopUpContextMenu(const gfx::Point& pos,
                                 AtomMenuModel* menu_model) {}

--- a/shell/browser/ui/tray_icon.h
+++ b/shell/browser/ui/tray_icon.h
@@ -57,11 +57,19 @@ class TrayIcon {
   virtual std::string GetTitle() = 0;
 #endif
 
+  struct BalloonOptions {
+#if defined(OS_WIN)
+    HICON icon = nullptr;
+#else
+    gfx::Image icon;
+#endif
+    base::string16 title;
+    base::string16 content;
+  };
+
   // Displays a notification balloon with the specified contents.
   // Depending on the platform it might not appear by the icon tray.
-  virtual void DisplayBalloon(ImageType icon,
-                              const base::string16& title,
-                              const base::string16& contents);
+  virtual void DisplayBalloon(const BalloonOptions& options);
 
   // Popups the menu.
   virtual void PopUpContextMenu(const gfx::Point& pos,

--- a/shell/browser/ui/win/notify_icon.cc
+++ b/shell/browser/ui/win/notify_icon.cc
@@ -120,17 +120,15 @@ void NotifyIcon::SetToolTip(const std::string& tool_tip) {
     LOG(WARNING) << "Unable to set tooltip for status tray icon";
 }
 
-void NotifyIcon::DisplayBalloon(HICON icon,
-                                const base::string16& title,
-                                const base::string16& contents) {
+void NotifyIcon::DisplayBalloon(const BalloonOptions& options) {
   NOTIFYICONDATA icon_data;
   InitIconData(&icon_data);
   icon_data.uFlags |= NIF_INFO;
   icon_data.dwInfoFlags = NIIF_INFO;
-  wcsncpy_s(icon_data.szInfoTitle, title.c_str(), _TRUNCATE);
-  wcsncpy_s(icon_data.szInfo, contents.c_str(), _TRUNCATE);
+  wcsncpy_s(icon_data.szInfoTitle, options.title.c_str(), _TRUNCATE);
+  wcsncpy_s(icon_data.szInfo, options.contents.c_str(), _TRUNCATE);
   icon_data.uTimeout = 0;
-  icon_data.hBalloonIcon = icon;
+  icon_data.hBalloonIcon = options.icon;
   icon_data.dwInfoFlags = NIIF_USER | NIIF_LARGE_ICON;
 
   BOOL result = Shell_NotifyIcon(NIM_MODIFY, &icon_data);

--- a/shell/browser/ui/win/notify_icon.h
+++ b/shell/browser/ui/win/notify_icon.h
@@ -58,9 +58,7 @@ class NotifyIcon : public TrayIcon {
   void SetImage(HICON image) override;
   void SetPressedImage(HICON image) override;
   void SetToolTip(const std::string& tool_tip) override;
-  void DisplayBalloon(HICON icon,
-                      const base::string16& title,
-                      const base::string16& contents) override;
+  void DisplayBalloon(const BalloonOptions& options) override;
   void PopUpContextMenu(const gfx::Point& pos,
                         AtomMenuModel* menu_model) override;
   void SetContextMenu(AtomMenuModel* menu_model) override;


### PR DESCRIPTION
#### Description of Change
I am planning to add some new options to `tray.displayBalloon()`, refactoring the code first to make it easier.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes