### PR TITLE
feat: add new options to tray.displayBalloon()

### DIFF
--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -222,11 +222,19 @@ Returns `Boolean` - Whether double click events will be ignored.
 #### `tray.displayBalloon(options)` _Windows_
 
 * `options` Object
-  * `icon` ([NativeImage](native-image.md) | String) (optional) -
+  * `icon` ([NativeImage](native-image.md) | String) (optional) - Icon to use when `iconType` is `custom`.
+  * `iconType` String (optional) - Can be `none`, `info`, `warning`, `error` or `custom`. Default is `custom`.
   * `title` String
   * `content` String
+  * `largeIcon` Boolean (optional) - The large version of the icon should be used. Default is `true`. Maps to [`NIIF_LARGE_ICON`][NIIF_LARGE_ICON].
+  * `noSound` Boolean (optional) - Do not play the associated sound. Default is `false`. Maps to [`NIIF_NOSOUND`][NIIF_NOSOUND].
+  * `respectQuietTime` Boolean (optional) - Do not display the balloon notification if the current user is in "quiet time". Default is `false`. Maps to [`NIIF_RESPECT_QUIET_TIME`][NIIF_RESPECT_QUIET_TIME].
 
 Displays a tray balloon.
+
+[NIIF_NOSOUND]: https://docs.microsoft.com/en-us/windows/win32/api/shellapi/ns-shellapi-notifyicondataa#niif_nosound-0x00000010
+[NIIF_LARGE_ICON]: https://docs.microsoft.com/en-us/windows/win32/api/shellapi/ns-shellapi-notifyicondataa#niif_large_icon-0x00000020
+[NIIF_RESPECT_QUIET_TIME]: https://docs.microsoft.com/en-us/windows/win32/api/shellapi/ns-shellapi-notifyicondataa#niif_respect_quiet_time-0x00000080
 
 #### `tray.removeBalloon()` _Windows_
 

--- a/shell/browser/ui/tray_icon.cc
+++ b/shell/browser/ui/tray_icon.cc
@@ -6,15 +6,15 @@
 
 namespace electron {
 
+TrayIcon::BalloonOptions::BalloonOptions() = default;
+
 TrayIcon::TrayIcon() {}
 
 TrayIcon::~TrayIcon() {}
 
 void TrayIcon::SetPressedImage(ImageType image) {}
 
-void TrayIcon::DisplayBalloon(ImageType icon,
-                              const base::string16& title,
-                              const base::string16& contents) {}
+void TrayIcon::DisplayBalloon(const BalloonOptions& options) {}
 
 void TrayIcon::RemoveBalloon() {}
 

--- a/shell/browser/ui/tray_icon.h
+++ b/shell/browser/ui/tray_icon.h
@@ -49,11 +49,27 @@ class TrayIcon {
   virtual std::string GetTitle() = 0;
 #endif
 
+  enum class IconType { None, Info, Warning, Error, Custom };
+
+  struct BalloonOptions {
+    IconType icon_type = IconType::Custom;
+#if defined(OS_WIN)
+    HICON icon = nullptr;
+#else
+    gfx::Image icon;
+#endif
+    base::string16 title;
+    base::string16 content;
+    bool large_icon = true;
+    bool no_sound = false;
+    bool respect_quiet_time = false;
+
+    BalloonOptions();
+  };
+
   // Displays a notification balloon with the specified contents.
   // Depending on the platform it might not appear by the icon tray.
-  virtual void DisplayBalloon(ImageType icon,
-                              const base::string16& title,
-                              const base::string16& contents);
+  virtual void DisplayBalloon(const BalloonOptions& options);
 
   // Removes the notification balloon.
   virtual void RemoveBalloon();

--- a/shell/browser/ui/win/notify_icon.cc
+++ b/shell/browser/ui/win/notify_icon.cc
@@ -17,6 +17,28 @@
 #include "ui/views/controls/menu/menu_runner.h"
 #include "ui/views/widget/widget.h"
 
+namespace {
+
+UINT ConvertIconType(electron::TrayIcon::IconType type) {
+  using IconType = electron::TrayIcon::IconType;
+  switch (type) {
+    case IconType::None:
+      return NIIF_NONE;
+    case IconType::Info:
+      return NIIF_INFO;
+    case IconType::Warning:
+      return NIIF_WARNING;
+    case IconType::Error:
+      return NIIF_ERROR;
+    case IconType::Custom:
+      return NIIF_USER;
+    default:
+      NOTREACHED() << "Invalid icon type";
+  }
+}
+
+}  // namespace
+
 namespace electron {
 
 NotifyIcon::NotifyIcon(NotifyIconHost* host, UINT id, HWND window, UINT message)
@@ -120,18 +142,24 @@ void NotifyIcon::SetToolTip(const std::string& tool_tip) {
     LOG(WARNING) << "Unable to set tooltip for status tray icon";
 }
 
-void NotifyIcon::DisplayBalloon(HICON icon,
-                                const base::string16& title,
-                                const base::string16& contents) {
+void NotifyIcon::DisplayBalloon(const BalloonOptions& options) {
   NOTIFYICONDATA icon_data;
   InitIconData(&icon_data);
   icon_data.uFlags |= NIF_INFO;
-  icon_data.dwInfoFlags = NIIF_INFO;
-  wcsncpy_s(icon_data.szInfoTitle, title.c_str(), _TRUNCATE);
-  wcsncpy_s(icon_data.szInfo, contents.c_str(), _TRUNCATE);
+  wcsncpy_s(icon_data.szInfoTitle, options.title.c_str(), _TRUNCATE);
+  wcsncpy_s(icon_data.szInfo, options.content.c_str(), _TRUNCATE);
   icon_data.uTimeout = 0;
-  icon_data.hBalloonIcon = icon;
-  icon_data.dwInfoFlags = NIIF_USER | NIIF_LARGE_ICON;
+  icon_data.hBalloonIcon = options.icon;
+  icon_data.dwInfoFlags = ConvertIconType(options.icon_type);
+
+  if (options.large_icon)
+    icon_data.dwInfoFlags |= NIIF_LARGE_ICON;
+
+  if (options.no_sound)
+    icon_data.dwInfoFlags |= NIIF_NOSOUND;
+
+  if (options.respect_quiet_time)
+    icon_data.dwInfoFlags |= NIIF_RESPECT_QUIET_TIME;
 
   BOOL result = Shell_NotifyIcon(NIM_MODIFY, &icon_data);
   if (!result)

--- a/shell/browser/ui/win/notify_icon.h
+++ b/shell/browser/ui/win/notify_icon.h
@@ -58,9 +58,7 @@ class NotifyIcon : public TrayIcon {
   void SetImage(HICON image) override;
   void SetPressedImage(HICON image) override;
   void SetToolTip(const std::string& tool_tip) override;
-  void DisplayBalloon(HICON icon,
-                      const base::string16& title,
-                      const base::string16& contents) override;
+  void DisplayBalloon(const BalloonOptions& options) override;
   void RemoveBalloon() override;
   void PopUpContextMenu(const gfx::Point& pos,
                         AtomMenuModel* menu_model) override;


### PR DESCRIPTION
#### Description of Change
Adds new options to `tray.displayBalloon()`:
```diff
--- a/electron.old.d.ts
+++ b/electron.new.d.ts
@@ -10846,9 +10846,30 @@ See webContents.sendInputEvent for detailed description of `event` object.
   }
 
   interface DisplayBalloonOptions {
+    /**
+     * Icon to use when `iconType` is `custom`.
+     */
     icon?: (NativeImage) | (string);
+    /**
+     * Can be `none`, `info`, `warning`, `error` or `custom`. Default is `custom`.
+     */
+    iconType?: ('none' | 'info' | 'warning' | 'error' | 'custom');
     title: string;
     content: string;
+    /**
+     * The large version of the icon should be used. Default is `true`. Maps to
+     * `NIIF_LARGE_ICON`.
+     */
+    largeIcon?: boolean;
+    /**
+     * Do not play the associated sound. Default is `false`. Maps to `NIIF_NOSOUND`.
+     */
+    noSound?: boolean;
+    /**
+     * Do not display the balloon notification if the current user is in "quiet time".
+     * Default is `false`. Maps to `NIIF_RESPECT_QUIET_TIME`.
+     */
+    respectQuietTime?: boolean;
   }
```

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: New options added to `tray.displayBalloon()`: `iconType`, `largeIcon`, `noSound` and `respectQuietTime`.