### PR TITLE
fix: throw better error on getPath('logs')

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -860,8 +860,15 @@ base::FilePath App::GetPath(mate::Arguments* args, const std::string& name) {
   int key = GetPathConstant(name);
   if (key >= 0)
     succeed = base::PathService::Get(key, &path);
-  if (!succeed)
-    args->ThrowError("Failed to get '" + name + "' path");
+  if (!succeed) {
+    if (name == "logs") {
+      args->ThrowError("Failed to get '" + name +
+                       "' path: setAppLogsPath() must be called first.");
+    } else {
+      args->ThrowError("Failed to get '" + name + "' path");
+    }
+  }
+
   return path;
 }
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -578,7 +578,7 @@ them.
 
 Sets or creates a directory your app's logs which can then be manipulated with `app.getPath()` or `app.setPath(pathName, newPath)`.
 
-On _macOS_, this directory will be set by deafault to `/Library/Logs/YourAppName`, and on _Linux_ and _Windows_ it will be placed inside your `userData` directory.
+Calling `app.setAppLogsPath()` without a `path` parameter will result in this directory being set to `/Library/Logs/YourAppName` on _macOS_, and inside the `userData` directory on _Linux_ and _Windows_.
 
 ### `app.getAppPath()`
 


### PR DESCRIPTION
Backport of .https://github.com/electron/electron/pull/19514.

See that PR for more details.

Notes: `getPath('logs')` now throws better error when it fails to find the logs path.