### PR TITLE
feat: add tray.removeBalloon()

### DIFF
--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -261,6 +261,10 @@ Returns `Boolean` - Whether double click events will be ignored.
 
 Displays a tray balloon.
 
+#### `tray.removeBalloon()` _Windows_
+
+Removes a tray balloon.
+
 #### `tray.popUpContextMenu([menu, position])` _macOS_ _Windows_
 
 * `menu` Menu (optional)

--- a/shell/browser/api/atom_api_tray.cc
+++ b/shell/browser/api/atom_api_tray.cc
@@ -207,6 +207,10 @@ void Tray::DisplayBalloon(mate::Arguments* args,
 #endif
 }
 
+void Tray::RemoveBalloon() {
+  tray_icon_->RemoveBalloon();
+}
+
 void Tray::PopUpContextMenu(mate::Arguments* args) {
   mate::Handle<Menu> menu;
   args->GetNext(&menu);
@@ -241,6 +245,7 @@ void Tray::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("getIgnoreDoubleClickEvents",
                  &Tray::GetIgnoreDoubleClickEvents)
       .SetMethod("displayBalloon", &Tray::DisplayBalloon)
+      .SetMethod("removeBalloon", &Tray::RemoveBalloon)
       .SetMethod("popUpContextMenu", &Tray::PopUpContextMenu)
       .SetMethod("setContextMenu", &Tray::SetContextMenu)
       .SetMethod("getBounds", &Tray::GetBounds);

--- a/shell/browser/api/atom_api_tray.h
+++ b/shell/browser/api/atom_api_tray.h
@@ -74,6 +74,7 @@ class Tray : public mate::TrackableObject<Tray>, public TrayIconObserver {
   void SetIgnoreDoubleClickEvents(bool ignore);
   bool GetIgnoreDoubleClickEvents();
   void DisplayBalloon(mate::Arguments* args, const mate::Dictionary& options);
+  void RemoveBalloon();
   void PopUpContextMenu(mate::Arguments* args);
   void SetContextMenu(v8::Isolate* isolate, mate::Handle<Menu> menu);
   gfx::Rect GetBounds();

--- a/shell/browser/ui/tray_icon.cc
+++ b/shell/browser/ui/tray_icon.cc
@@ -18,6 +18,8 @@ void TrayIcon::DisplayBalloon(ImageType icon,
                               const base::string16& title,
                               const base::string16& contents) {}
 
+void TrayIcon::RemoveBalloon() {}
+
 void TrayIcon::PopUpContextMenu(const gfx::Point& pos,
                                 AtomMenuModel* menu_model) {}
 

--- a/shell/browser/ui/tray_icon.h
+++ b/shell/browser/ui/tray_icon.h
@@ -63,6 +63,9 @@ class TrayIcon {
                               const base::string16& title,
                               const base::string16& contents);
 
+  // Removes the notification balloon.
+  virtual void RemoveBalloon();
+
   // Popups the menu.
   virtual void PopUpContextMenu(const gfx::Point& pos,
                                 AtomMenuModel* menu_model);

--- a/shell/browser/ui/win/notify_icon.cc
+++ b/shell/browser/ui/win/notify_icon.cc
@@ -138,6 +138,16 @@ void NotifyIcon::DisplayBalloon(HICON icon,
     LOG(WARNING) << "Unable to create status tray balloon.";
 }
 
+void NotifyIcon::RemoveBalloon() {
+  NOTIFYICONDATA icon_data;
+  InitIconData(&icon_data);
+  icon_data.uFlags |= NIF_INFO;
+
+  BOOL result = Shell_NotifyIcon(NIM_MODIFY, &icon_data);
+  if (!result)
+    LOG(WARNING) << "Unable to remove status tray balloon.";
+}
+
 void NotifyIcon::PopUpContextMenu(const gfx::Point& pos,
                                   AtomMenuModel* menu_model) {
   // Returns if context menu isn't set.

--- a/shell/browser/ui/win/notify_icon.h
+++ b/shell/browser/ui/win/notify_icon.h
@@ -61,6 +61,7 @@ class NotifyIcon : public TrayIcon {
   void DisplayBalloon(HICON icon,
                       const base::string16& title,
                       const base::string16& contents) override;
+  void RemoveBalloon() override;
   void PopUpContextMenu(const gfx::Point& pos,
                         AtomMenuModel* menu_model) override;
   void SetContextMenu(AtomMenuModel* menu_model) override;


### PR DESCRIPTION
#### Description of Change
Add missing method to remove a balloon notification, which is already displayed.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `tray.removeBalloon()`, which removes an already displayed balloon notification.