### PR TITLE
feat: add tray.focus()

### DIFF
--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -232,6 +232,13 @@ Displays a tray balloon.
 
 Removes a tray balloon.
 
+#### `tray.focus()` _Windows_
+
+Returns focus to the taskbar notification area.
+Notification area icons should use this message when they have completed their UI operation.
+For example, if the icon displays a shortcut menu, but the user presses ESC to cancel it,
+use `tray.focus()` to return focus to the notification area.
+
 #### `tray.popUpContextMenu([menu, position])` _macOS_ _Windows_
 
 * `menu` Menu (optional)

--- a/shell/browser/api/atom_api_tray.cc
+++ b/shell/browser/api/atom_api_tray.cc
@@ -179,6 +179,10 @@ void Tray::RemoveBalloon() {
   tray_icon_->RemoveBalloon();
 }
 
+void Tray::Focus() {
+  tray_icon_->Focus();
+}
+
 void Tray::PopUpContextMenu(mate::Arguments* args) {
   mate::Handle<Menu> menu;
   args->GetNext(&menu);
@@ -213,6 +217,7 @@ void Tray::BuildPrototype(v8::Isolate* isolate,
                  &Tray::GetIgnoreDoubleClickEvents)
       .SetMethod("displayBalloon", &Tray::DisplayBalloon)
       .SetMethod("removeBalloon", &Tray::RemoveBalloon)
+      .SetMethod("focus", &Tray::Focus)
       .SetMethod("popUpContextMenu", &Tray::PopUpContextMenu)
       .SetMethod("setContextMenu", &Tray::SetContextMenu)
       .SetMethod("getBounds", &Tray::GetBounds);

--- a/shell/browser/api/atom_api_tray.h
+++ b/shell/browser/api/atom_api_tray.h
@@ -74,6 +74,7 @@ class Tray : public mate::TrackableObject<Tray>, public TrayIconObserver {
   bool GetIgnoreDoubleClickEvents();
   void DisplayBalloon(mate::Arguments* args, const mate::Dictionary& options);
   void RemoveBalloon();
+  void Focus();
   void PopUpContextMenu(mate::Arguments* args);
   void SetContextMenu(v8::Isolate* isolate, mate::Handle<Menu> menu);
   gfx::Rect GetBounds();

--- a/shell/browser/ui/tray_icon.cc
+++ b/shell/browser/ui/tray_icon.cc
@@ -18,6 +18,8 @@ void TrayIcon::DisplayBalloon(ImageType icon,
 
 void TrayIcon::RemoveBalloon() {}
 
+void TrayIcon::Focus() {}
+
 void TrayIcon::PopUpContextMenu(const gfx::Point& pos,
                                 AtomMenuModel* menu_model) {}
 

--- a/shell/browser/ui/tray_icon.h
+++ b/shell/browser/ui/tray_icon.h
@@ -58,6 +58,9 @@ class TrayIcon {
   // Removes the notification balloon.
   virtual void RemoveBalloon();
 
+  // Returns focus to the taskbar notification area.
+  virtual void Focus();
+
   // Popups the menu.
   virtual void PopUpContextMenu(const gfx::Point& pos,
                                 AtomMenuModel* menu_model);

--- a/shell/browser/ui/win/notify_icon.cc
+++ b/shell/browser/ui/win/notify_icon.cc
@@ -148,6 +148,15 @@ void NotifyIcon::RemoveBalloon() {
     LOG(WARNING) << "Unable to remove status tray balloon.";
 }
 
+void NotifyIcon::Focus() {
+  NOTIFYICONDATA icon_data;
+  InitIconData(&icon_data);
+
+  BOOL result = Shell_NotifyIcon(NIM_SETFOCUS, &icon_data);
+  if (!result)
+    LOG(WARNING) << "Unable to focus tray icon.";
+}
+
 void NotifyIcon::PopUpContextMenu(const gfx::Point& pos,
                                   AtomMenuModel* menu_model) {
   // Returns if context menu isn't set.

--- a/shell/browser/ui/win/notify_icon.h
+++ b/shell/browser/ui/win/notify_icon.h
@@ -62,6 +62,7 @@ class NotifyIcon : public TrayIcon {
                       const base::string16& title,
                       const base::string16& contents) override;
   void RemoveBalloon() override;
+  void Focus() override;
   void PopUpContextMenu(const gfx::Point& pos,
                         AtomMenuModel* menu_model) override;
   void SetContextMenu(AtomMenuModel* menu_model) override;


### PR DESCRIPTION
#### Description of Change
Expose [`NIM_SETFOCUS `](https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shell_notifyicona#nim_setfocus-0x00000003) 
> Returns focus to the taskbar notification area. Notification area icons should use this message when they have completed their UI operation. For example, if the icon displays a shortcut menu, but the user presses ESC to cancel it, use `tray.focus()` to return focus to the notification area.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `tray.focus()`, which returns focus to the taskbar notification area.
