### PR TITLE
fix: use correct constants for tray icon messages

### DIFF
--- a/shell/browser/ui/win/notify_icon_host.cc
+++ b/shell/browser/ui/win/notify_icon_host.cc
@@ -146,15 +146,15 @@ LRESULT CALLBACK NotifyIconHost::WndProc(HWND hwnd,
       return TRUE;
 
     switch (lparam) {
-      case TB_CHECKBUTTON:
+      case NIN_BALLOONSHOW:
         win_icon->NotifyBalloonShow();
         return TRUE;
 
-      case TB_INDETERMINATE:
+      case NIN_BALLOONUSERCLICK:
         win_icon->NotifyBalloonClicked();
         return TRUE;
 
-      case TB_HIDEBUTTON:
+      case NIN_BALLOONTIMEOUT:
         win_icon->NotifyBalloonClosed();
         return TRUE;
 


### PR DESCRIPTION
#### Description of Change
We are using incorrect constants for tray icon messages. They happen to have the same values, but make the code confusing.

`#define NIN_BALLOONSHOW         (WM_USER + 2)`
`#define NIN_BALLOONTIMEOUT      (WM_USER + 4)`
`#define NIN_BALLOONUSERCLICK    (WM_USER + 5)`

`#define TB_CHECKBUTTON          (WM_USER + 2)`
`#define TB_HIDEBUTTON           (WM_USER + 4)`
`#define TB_INDETERMINATE        (WM_USER + 5)`

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes