### PR TITLE
build: update the ABI version for electron 8 nightlies

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -3,7 +3,7 @@ use_jumbo_build = true
 root_extra_deps = [ "//electron" ]
 
 # Registry of NMVs --> https://github.com/nodejs/node/blob/master/doc/abi_version_registry.json
-node_module_version = 75
+node_module_version = 76
 
 v8_promise_internal_field_count = 1
 v8_typed_array_max_size_in_heap = 0


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/commit/657a78e30a000335fbcf6c6ea02aee11e8939763

Notes: no-notes