### PR TITLE
fix: make child windows not crash when ipc messages are received

### DIFF
--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -34,7 +34,7 @@ const mergeOptions = function (child, parent, visited) {
     if (key in child && key !== 'webPreferences') continue
 
     const value = parent[key]
-    if (typeof value === 'object') {
+    if (typeof value === 'object' && !Array.isArray(value)) {
       child[key] = mergeOptions(child[key] || {}, value, visited)
     } else {
       child[key] = value

--- a/shell/common/options_switches.cc
+++ b/shell/common/options_switches.cc
@@ -234,6 +234,7 @@ const char kNativeWindowOpen[] = "native-window-open";
 const char kWebviewTag[] = "webview-tag";
 const char kDisableElectronSiteInstanceOverrides[] =
     "disable-electron-site-instance-overrides";
+const char kEnableNodeLeakageInRenderers[] = "enable-node-leakage-in-renderers";
 
 // Command switch passed to renderer process to control nodeIntegration.
 const char kNodeIntegrationInWorker[] = "node-integration-in-worker";

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -118,6 +118,7 @@ extern const char kNodeIntegrationInWorker[];
 extern const char kWebviewTag[];
 extern const char kNodeIntegrationInSubFrames[];
 extern const char kDisableElectronSiteInstanceOverrides[];
+extern const char kEnableNodeLeakageInRenderers[];
 
 extern const char kWidevineCdmPath[];
 extern const char kWidevineCdmVersion[];

--- a/shell/renderer/atom_renderer_client.cc
+++ b/shell/renderer/atom_renderer_client.cc
@@ -78,11 +78,11 @@ void AtomRendererClient::DidCreateScriptContext(
 
   auto* command_line = base::CommandLine::ForCurrentProcess();
 
-  // Do not load node if we're aren't a main frame or a devtools extension
+   // Only load node if we are a main frame or a devtools extension
   // unless node support has been explicitly enabled for sub frames
   bool reuse_renderer_processes_enabled =
       command_line->HasSwitch(switches::kDisableElectronSiteInstanceOverrides);
-  // Considered the window not "opened" if it does not have an Opener, or if a
+  // Consider the window not "opened" if it does not have an Opener, or if a
   // user has manually opted in to leaking node in the renderer
   bool is_not_opened =
       !render_frame->GetWebFrame()->Opener() ||

--- a/shell/renderer/atom_renderer_client.cc
+++ b/shell/renderer/atom_renderer_client.cc
@@ -76,14 +76,26 @@ void AtomRendererClient::DidCreateScriptContext(
   // TODO(zcbenz): Do not create Node environment if node integration is not
   // enabled.
 
+  auto* command_line = base::CommandLine::ForCurrentProcess();
+
   // Do not load node if we're aren't a main frame or a devtools extension
   // unless node support has been explicitly enabled for sub frames
-  bool is_main_frame =
-      render_frame->IsMainFrame() && !render_frame->GetWebFrame()->Opener();
+  bool reuse_renderer_processes_enabled =
+      command_line->HasSwitch(switches::kDisableElectronSiteInstanceOverrides);
+  // Considered the window not "opened" if it does not have an Opener, or if a
+  // user has manually opted in to leaking node in the renderer
+  bool is_not_opened =
+      !render_frame->GetWebFrame()->Opener() ||
+      command_line->HasSwitch(switches::kEnableNodeLeakageInRenderers);
+  // Consider this the main frame if it is both a Main Frame and it wasn't
+  // opened.  We allow an opened main frame to have node if renderer process
+  // reuse is enabled as that will correctly free node environments prevent a
+  // leak in child windows.
+  bool is_main_frame = render_frame->IsMainFrame() &&
+                       (is_not_opened || reuse_renderer_processes_enabled);
   bool is_devtools = IsDevToolsExtension(render_frame);
   bool allow_node_in_subframes =
-      base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kNodeIntegrationInSubFrames);
+      command_line->HasSwitch(switches::kNodeIntegrationInSubFrames);
   bool should_load_node =
       (is_main_frame || is_devtools || allow_node_in_subframes) &&
       !IsWebViewFrame(renderer_context, render_frame);
@@ -111,7 +123,6 @@ void AtomRendererClient::DidCreateScriptContext(
   DCHECK(!context.IsEmpty());
   node::Environment* env =
       node_bindings_->CreateEnvironment(context, nullptr, true);
-  auto* command_line = base::CommandLine::ForCurrentProcess();
   // If we have disabled the site instance overrides we should prevent loading
   // any non-context aware native module
   if (command_line->HasSwitch(switches::kDisableElectronSiteInstanceOverrides))

--- a/shell/renderer/atom_renderer_client.cc
+++ b/shell/renderer/atom_renderer_client.cc
@@ -78,7 +78,7 @@ void AtomRendererClient::DidCreateScriptContext(
 
   auto* command_line = base::CommandLine::ForCurrentProcess();
 
-   // Only load node if we are a main frame or a devtools extension
+  // Only load node if we are a main frame or a devtools extension
   // unless node support has been explicitly enabled for sub frames
   bool reuse_renderer_processes_enabled =
       command_line->HasSwitch(switches::kDisableElectronSiteInstanceOverrides);


### PR DESCRIPTION
This also adds a path forward for apps using child windows with nodeIntegration to migrate into a non-leaky way of doing it.

1. Ensure that if ipcNative is missing we don't crash rather log that it is missing
2. Add a hidden option `--enable-node-leakage-in-renderers` (temporary measure) to allow app devs to opt in to leaking node in child windows
3. Bypasses the Opener() check if renderer process reuse is enabled (which would prevent the leak anyway)

So the path forward is: it no longer crashes --> folks use the hidden option --> folks opt in to renderer process reuse.

Please note that this path is required for some apps to adopt Electron 6 👍 

Notes: Fixed case where sending IPC to a child window (opened with `window.open`) could cause a crash