### PR TITLE
fix: expose setMenuBarVisibility again

### DIFF
--- a/shell/browser/api/atom_api_top_level_window.cc
+++ b/shell/browser/api/atom_api_top_level_window.cc
@@ -1168,6 +1168,7 @@ void TopLevelWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("_isMenuBarAutoHide", &TopLevelWindow::IsMenuBarAutoHide)
       .SetProperty("autoHideMenuBar", &TopLevelWindow::IsMenuBarAutoHide,
                    &TopLevelWindow::SetAutoHideMenuBar)
+      .SetMethod("setMenuBarVisibility", &TopLevelWindow::SetMenuBarVisibility)
       .SetMethod("isMenuBarVisible", &TopLevelWindow::IsMenuBarVisible)
       .SetMethod("setAspectRatio", &TopLevelWindow::SetAspectRatio)
       .SetMethod("previewFile", &TopLevelWindow::PreviewFile)


### PR DESCRIPTION
#### Description of Change

Expose `setMenuBarVisibility` again, which I think was inadvertently removed in https://github.com/electron/electron/pull/18555.

/cc @codebytere 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Exposed `setMenuBarVisibility` on `BrowserWindow` again