### PR TITLE
fix: throw on invalid webRequest filters

### DIFF
--- a/docs/api/web-request.md
+++ b/docs/api/web-request.md
@@ -68,6 +68,21 @@ The `uploadData` is an array of `UploadData` objects.
 
 The `callback` has to be called with an `response` object.
 
+Some examples of valid `urls`:
+
+```js
+'http://foo:1234/'
+'http://foo.com/'
+'http://foo:1234/bar'
+'*://*/*'
+'*://example.com/*'
+'*://example.com/foo/*'
+'http://*.foo:1234/'
+'file://foo:1234/bar'
+'http://foo:*/'
+'*://www.foo.com/'
+```
+
 #### `webRequest.onBeforeSendHeaders([filter, ]listener)`
 
 * `filter` Object (optional)

--- a/spec/api-net-spec.js
+++ b/spec/api-net-spec.js
@@ -890,6 +890,22 @@ describe('net module', () => {
       urlRequest.end()
     })
 
+    it('Should throw when invalid filters are passed to a request', () => {
+      expect(() => {
+        session.defaultSession.webRequest.onBeforeRequest(
+          { urls: ['*://www.googleapis.com'] },
+          (details, callback) => { callback({ cancel: false }) }
+        )
+      }).to.throw('Invalid url pattern *://www.googleapis.com: Empty path.')
+
+      expect(() => {
+        session.defaultSession.webRequest.onBeforeRequest(
+          { urls: [ '*://www.googleapis.com/', '*://blahblah.dev' ] },
+          (details, callback) => { callback({ cancel: false }) }
+        )
+      }).to.throw('Invalid url pattern *://blahblah.dev: Empty path.')
+    })
+
     it('should to able to create and intercept a request using a custom session object', (done) => {
       const requestUrl = '/requestUrl'
       const redirectUrl = '/redirectUrl'


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/19337.

See that PR for more details.

Notes: Fixed error throwing on invalid `webRequest` url pattern filtering in `onBeforeRequest`.