### PR TITLE
fix: set size of GTK about panel icon

### DIFF
--- a/atom/browser/browser_linux.cc
+++ b/atom/browser/browser_linux.cc
@@ -161,7 +161,12 @@ void Browser::ShowAboutPanel() {
     gtk_about_dialog_set_website(dialog, website.c_str());
   if (about_panel_options_.GetString("iconPath", &icon_path)) {
     GError* error = nullptr;
-    GdkPixbuf* icon = gdk_pixbuf_new_from_file(icon_path.c_str(), &error);
+    constexpr int width = 64;   // width of about panel icon in pixels
+    constexpr int height = 64;  // height of about panel icon in pixels
+
+    // set preserve_aspect_ratio to true
+    GdkPixbuf* icon = gdk_pixbuf_new_from_file_at_size(icon_path.c_str(), width,
+                                                       height, &error);
     if (error != nullptr) {
       g_warning("%s", error->message);
       g_clear_error(&error);

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1188,7 +1188,7 @@ Show the app's about panel options. These options can be overridden with `app.se
   * `version` String (optional) - The app's build version number. _macOS_
   * `credits` String (optional) - Credit information. _macOS_
   * `website` String (optional) - The app's website. _Linux_
-  * `iconPath` String (optional) - Path to the app's icon. _Linux_
+  * `iconPath` String (optional) - Path to the app's icon. Will be shown as 64x64 pixels while retaining aspect ratio. _Linux_
 
 Set the about panel options. This will override the values defined in the app's
 `.plist` file on MacOS. See the [Apple docs][about-panel-options] for more details. On Linux, values must be set in order to be shown; there are no defaults.


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/18957.

See that PR for more details.

Notes: Standardized the about panel icon size on Linux.