### PR TITLE
refactor: move file path gin converter to new file

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -515,6 +515,7 @@ filenames = {
     "shell/common/gin_converters/message_box_converter.cc",
     "shell/common/gin_converters/message_box_converter.h",
     "shell/common/gin_converters/net_converter_gin_adapter.h",
+    "shell/common/gin_converters/string16_converter.h",
     "shell/common/gin_util.h",
     "shell/common/heap_snapshot.cc",
     "shell/common/heap_snapshot.h",

--- a/filenames.gni
+++ b/filenames.gni
@@ -510,6 +510,7 @@ filenames = {
     "shell/common/crash_reporter/win/crash_service_main.cc",
     "shell/common/crash_reporter/win/crash_service_main.h",
     "shell/common/gin_converters/file_dialog_converter_gin_adapter.h",
+    "shell/common/gin_converters/file_path_converter.h",
     "shell/common/gin_converters/image_converter_gin_adapter.h",
     "shell/common/gin_converters/message_box_converter.cc",
     "shell/common/gin_converters/message_box_converter.h",

--- a/shell/common/gin_converters/file_path_converter.h
+++ b/shell/common/gin_converters/file_path_converter.h
@@ -5,11 +5,8 @@
 #ifndef SHELL_COMMON_GIN_CONVERTERS_FILE_PATH_CONVERTER_H_
 #define SHELL_COMMON_GIN_CONVERTERS_FILE_PATH_CONVERTER_H_
 
-// #include <string>
-
 #include "base/files/file_path.h"
-// #include "shell/common/gin_converters/string16_converter.h" //
-// TODO(deermichel): check windows
+#include "shell/common/gin_converters/string16_converter.h"
 
 namespace gin {
 

--- a/shell/common/gin_converters/file_path_converter.h
+++ b/shell/common/gin_converters/file_path_converter.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_COMMON_GIN_CONVERTERS_FILE_PATH_CONVERTER_H_
+#define SHELL_COMMON_GIN_CONVERTERS_FILE_PATH_CONVERTER_H_
+
+// #include <string>
+
+#include "base/files/file_path.h"
+// #include "shell/common/gin_converters/string16_converter.h" //
+// TODO(deermichel): check windows
+
+namespace gin {
+
+template <>
+struct Converter<base::FilePath> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const base::FilePath& val) {
+    return Converter<base::FilePath::StringType>::ToV8(isolate, val.value());
+  }
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     base::FilePath* out) {
+    if (val->IsNull())
+      return true;
+
+    base::FilePath::StringType path;
+    if (Converter<base::FilePath::StringType>::FromV8(isolate, val, &path)) {
+      *out = base::FilePath(path);
+      return true;
+    } else {
+      return false;
+    }
+  }
+};
+
+}  // namespace gin
+
+#endif  // SHELL_COMMON_GIN_CONVERTERS_FILE_PATH_CONVERTER_H_

--- a/shell/common/gin_converters/string16_converter.h
+++ b/shell/common/gin_converters/string16_converter.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_COMMON_GIN_CONVERTERS_STRING16_CONVERTER_H_
+#define SHELL_COMMON_GIN_CONVERTERS_STRING16_CONVERTER_H_
+
+#include "base/strings/string16.h"
+#include "gin/converter.h"
+
+namespace gin {
+
+template <>
+struct Converter<base::string16> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const base::string16& val) {
+    return v8::String::NewFromTwoByte(
+               isolate, reinterpret_cast<const uint16_t*>(val.data()),
+               v8::NewStringType::kNormal, val.size())
+        .ToLocalChecked();
+  }
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     base::string16* out) {
+    if (!val->IsString())
+      return false;
+
+    v8::String::Value s(isolate, val);
+    out->assign(reinterpret_cast<const base::char16*>(*s), s.length());
+    return true;
+  }
+};
+
+inline v8::Local<v8::String> StringToV8(v8::Isolate* isolate,
+                                        const base::string16& input) {
+  return ConvertToV8(isolate, input).As<v8::String>();
+}
+
+}  // namespace gin
+
+#endif  // SHELL_COMMON_GIN_CONVERTERS_STRING16_CONVERTER_H_

--- a/shell/common/native_mate_converters/file_path_converter.h
+++ b/shell/common/native_mate_converters/file_path_converter.h
@@ -5,36 +5,7 @@
 #ifndef SHELL_COMMON_NATIVE_MATE_CONVERTERS_FILE_PATH_CONVERTER_H_
 #define SHELL_COMMON_NATIVE_MATE_CONVERTERS_FILE_PATH_CONVERTER_H_
 
-#include <string>
-
-#include "base/files/file_path.h"
-#include "shell/common/native_mate_converters/string16_converter.h"
-
-namespace gin {
-
-template <>
-struct Converter<base::FilePath> {
-  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   const base::FilePath& val) {
-    return Converter<base::FilePath::StringType>::ToV8(isolate, val.value());
-  }
-  static bool FromV8(v8::Isolate* isolate,
-                     v8::Local<v8::Value> val,
-                     base::FilePath* out) {
-    if (val->IsNull())
-      return true;
-
-    base::FilePath::StringType path;
-    if (Converter<base::FilePath::StringType>::FromV8(isolate, val, &path)) {
-      *out = base::FilePath(path);
-      return true;
-    } else {
-      return false;
-    }
-  }
-};
-
-}  // namespace gin
+#include "shell/common/gin_converters/file_path_converter.h"
 
 namespace mate {
 

--- a/shell/common/native_mate_converters/string16_converter.h
+++ b/shell/common/native_mate_converters/string16_converter.h
@@ -5,39 +5,8 @@
 #ifndef SHELL_COMMON_NATIVE_MATE_CONVERTERS_STRING16_CONVERTER_H_
 #define SHELL_COMMON_NATIVE_MATE_CONVERTERS_STRING16_CONVERTER_H_
 
-#include "base/strings/string16.h"
-#include "gin/converter.h"
 #include "native_mate/converter.h"
-
-namespace gin {
-
-template <>
-struct Converter<base::string16> {
-  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   const base::string16& val) {
-    return v8::String::NewFromTwoByte(
-               isolate, reinterpret_cast<const uint16_t*>(val.data()),
-               v8::NewStringType::kNormal, val.size())
-        .ToLocalChecked();
-  }
-  static bool FromV8(v8::Isolate* isolate,
-                     v8::Local<v8::Value> val,
-                     base::string16* out) {
-    if (!val->IsString())
-      return false;
-
-    v8::String::Value s(isolate, val);
-    out->assign(reinterpret_cast<const base::char16*>(*s), s.length());
-    return true;
-  }
-};
-
-inline v8::Local<v8::String> StringToV8(v8::Isolate* isolate,
-                                        const base::string16& input) {
-  return ConvertToV8(isolate, input).As<v8::String>();
-}
-
-}  // namespace gin
+#include "shell/common/gin_converters/string16_converter.h"
 
 namespace mate {
 


### PR DESCRIPTION
#### Description of Change
[Beginning of an endless PR series]

This converter was already implemented in `gin` and simply adapted to `mate` - however, now that we'll migrate completely, it deserves its own file.

cc @MarshallOfSound @deepak1556 @codebytere 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none
