### PR TITLE
docs: Fix `process.enablePromiseAPI` typo in promisification.md

### DIFF
--- a/docs/api/modernization/promisification.md
+++ b/docs/api/modernization/promisification.md
@@ -2,7 +2,7 @@
 
 The Electron team is currently undergoing an initiative to convert callback-based functions in Electron to return Promises. During this transition period, both the callback and Promise-based versions of these functions will work correctly, and will both be documented.
 
-To enable deprecation warnings for these updated functions, use the [`process.enablePromiseAPIs` runtime flag](https://github.com/electron/electron/blob/master/docs/api/process.md#processenablepromiseapis).
+To enable deprecation warnings for these updated functions, use the [`process.enablePromiseAPIs` runtime flag](../process.md#processenablepromiseapis).
 
 When a majority of affected functions are migrated, this flag will be enabled by default and all developers will be able to see these deprecation warnings. At that time, the callback-based versions will also be removed from documentation. This document will be continuously updated as more functions are converted.
 

--- a/docs/api/modernization/promisification.md
+++ b/docs/api/modernization/promisification.md
@@ -2,7 +2,7 @@
 
 The Electron team is currently undergoing an initiative to convert callback-based functions in Electron to return Promises. During this transition period, both the callback and Promise-based versions of these functions will work correctly, and will both be documented.
 
-To enable deprecation warnings for these updated functions, use the `process.enablePromiseAPI` runtime flag.
+To enable deprecation warnings for these updated functions, use the [`process.enablePromiseAPIs` runtime flag](https://github.com/electron/electron/blob/master/docs/api/process.md#processenablepromiseapis).
 
 When a majority of affected functions are migrated, this flag will be enabled by default and all developers will be able to see these deprecation warnings. At that time, the callback-based versions will also be removed from documentation. This document will be continuously updated as more functions are converted.
 


### PR DESCRIPTION
#### Description of Change
The docs indicate that you can use `process.enablePromiseAPI`, but the actual API seems to be `process.enablePromiseAPIs`. Fixed and a link added.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes