### PR TITLE
refactor: move gurl converter to gin

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -479,6 +479,7 @@ filenames = {
     "shell/common/crash_reporter/win/crash_service_main.h",
     "shell/common/gin_converters/file_dialog_converter_gin_adapter.h",
     "shell/common/gin_converters/file_path_converter.h",
+    "shell/common/gin_converters/gurl_converter.h",
     "shell/common/gin_converters/image_converter_gin_adapter.h",
     "shell/common/gin_converters/message_box_converter.cc",
     "shell/common/gin_converters/message_box_converter.h",

--- a/shell/common/gin_converters/gurl_converter.h
+++ b/shell/common/gin_converters/gurl_converter.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_COMMON_GIN_CONVERTERS_GURL_CONVERTER_H_
+#define SHELL_COMMON_GIN_CONVERTERS_GURL_CONVERTER_H_
+
+#include <string>
+
+#include "gin/converter.h"
+#include "url/gurl.h"
+
+namespace gin {
+
+template <>
+struct Converter<GURL> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, const GURL& val) {
+    return ConvertToV8(isolate, val.spec());
+  }
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     GURL* out) {
+    std::string url;
+    if (Converter<std::string>::FromV8(isolate, val, &url)) {
+      *out = GURL(url);
+      return true;
+    } else {
+      return false;
+    }
+  }
+};
+
+}  // namespace gin
+
+#endif  // SHELL_COMMON_GIN_CONVERTERS_GURL_CONVERTER_H_

--- a/shell/common/native_mate_converters/gurl_converter.h
+++ b/shell/common/native_mate_converters/gurl_converter.h
@@ -5,28 +5,20 @@
 #ifndef SHELL_COMMON_NATIVE_MATE_CONVERTERS_GURL_CONVERTER_H_
 #define SHELL_COMMON_NATIVE_MATE_CONVERTERS_GURL_CONVERTER_H_
 
-#include <string>
-
 #include "native_mate/converter.h"
-#include "url/gurl.h"
+#include "shell/common/gin_converters/gurl_converter.h"
 
 namespace mate {
 
 template <>
 struct Converter<GURL> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, const GURL& val) {
-    return ConvertToV8(isolate, val.spec());
+    return gin::ConvertToV8(isolate, val);
   }
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      GURL* out) {
-    std::string url;
-    if (Converter<std::string>::FromV8(isolate, val, &url)) {
-      *out = GURL(url);
-      return true;
-    } else {
-      return false;
-    }
+    return gin::ConvertFromV8(isolate, val, out);
   }
 };
 


### PR DESCRIPTION
#### Description of Change
[Continuation of an endless PR series]

Prerequisite for moving `net_converter` to `gin`.

cc @nornagon @deepak1556 @codebytere 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none