### PR TITLE
docs: remove implicit 'any' and 'Object' types from the docs

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -32,7 +32,7 @@ In most cases, you should do everything in the `ready` event handler.
 
 Returns:
 
-* `launchInfo` Object _macOS_
+* `launchInfo` unknown _macOS_
 
 Emitted when Electron has finished initializing. On macOS, `launchInfo` holds
 the `userInfo` of the `NSUserNotification` that was used to open the application,
@@ -146,7 +146,7 @@ Returns:
 * `event` Event
 * `type` String - A string identifying the activity. Maps to
   [`NSUserActivity.activityType`][activity-type].
-* `userInfo` Object - Contains app-specific state stored by the activity on
+* `userInfo` unknown - Contains app-specific state stored by the activity on
   another device.
 
 Emitted during [Handoff][handoff] when an activity from a different device wants
@@ -189,7 +189,7 @@ Returns:
 * `event` Event
 * `type` String - A string identifying the activity. Maps to
   [`NSUserActivity.activityType`][activity-type].
-* `userInfo` Object - Contains app-specific state stored by the activity.
+* `userInfo` unknown - Contains app-specific state stored by the activity.
 
 Emitted during [Handoff][handoff] after an activity from this device was successfully
 resumed on another one.
@@ -201,7 +201,7 @@ Returns:
 * `event` Event
 * `type` String - A string identifying the activity. Maps to
   [`NSUserActivity.activityType`][activity-type].
-* `userInfo` Object - Contains app-specific state stored by the activity.
+* `userInfo` unknown - Contains app-specific state stored by the activity.
 
 Emitted when [Handoff][handoff] is about to be resumed on another device. If you need to update the state to be transferred, you should call `event.preventDefault()` immediately, construct a new `userInfo` dictionary and call `app.updateCurrentActiviy()` in a timely manner. Otherwise, the operation will fail and `continue-activity-error` will be called.
 
@@ -949,7 +949,7 @@ allow multiple instances of the application to once again run side by side.
 
 * `type` String - Uniquely identifies the activity. Maps to
   [`NSUserActivity.activityType`][activity-type].
-* `userInfo` Object - App-specific state to store for use by another device.
+* `userInfo` any - App-specific state to store for use by another device.
 * `webpageURL` String (optional) - The webpage to load in a browser if no suitable app is
   installed on the resuming device. The scheme must be `http` or `https`.
 
@@ -972,7 +972,7 @@ Marks the current [Handoff][handoff] user activity as inactive without invalidat
 
 * `type` String - Uniquely identifies the activity. Maps to
   [`NSUserActivity.activityType`][activity-type].
-* `userInfo` Object - App-specific state to store for use by another device.
+* `userInfo` any - App-specific state to store for use by another device.
 
 Updates the current activity if its type matches `type`, merging the entries from
 `userInfo` into its current `userInfo` dictionary.

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -103,7 +103,7 @@ The `autoUpdater` object has the following methods:
 
 * `options` Object
   * `url` String
-  * `headers` Object (optional) _macOS_ - HTTP request headers.
+  * `headers` Record<String, String> (optional) _macOS_ - HTTP request headers.
   * `serverType` String (optional) _macOS_ - Either `json` or `default`, see the [Squirrel.Mac][squirrel-mac]
     README for more information.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -691,7 +691,7 @@ is emitted.
 
 #### `BrowserWindow.getExtensions()`
 
-Returns `Object` - The keys are the extension names and each value is
+Returns `Record<String, ExtensionInfo>` - The keys are the extension names and each value is
 an Object containing `name` and `version` properties.
 
 **Note:** This API cannot be called before the `ready` event of the `app` module
@@ -724,7 +724,7 @@ is emitted.
 
 #### `BrowserWindow.getDevToolsExtensions()`
 
-Returns `Object` - The keys are the extension names and each value is
+Returns `Record<string, ExtensionInfo>` - The keys are the extension names and each value is
 an Object containing `name` and `version` properties.
 
 To check if a DevTools extension is installed you can run the following:
@@ -1381,7 +1381,7 @@ win.loadURL('http://localhost:8000/post', {
 
 * `filePath` String
 * `options` Object (optional)
-  * `query` Object (optional) - Passed to `url.format()`.
+  * `query` Record<String, String> (optional) - Passed to `url.format()`.
   * `search` String (optional) - Passed to `url.format()`.
   * `hash` String (optional) - Passed to `url.format()`.
 

--- a/docs/api/client-request.md
+++ b/docs/api/client-request.md
@@ -16,7 +16,7 @@ following properties:
 method.
   * `url` String (optional) - The request URL. Must be provided in the absolute
 form with the protocol scheme specified as http or https.
-  * `session` Object (optional) - The [`Session`](session.md) instance with
+  * `session` Session (optional) - The [`Session`](session.md) instance with
 which the request is associated.
   * `partition` String (optional) - The name of the [`partition`](session.md)
   with which the request is associated. Defaults to the empty string. The
@@ -134,7 +134,7 @@ Returns:
 * `statusCode` Integer
 * `method` String
 * `redirectUrl` String
-* `responseHeaders` Object
+* `responseHeaders` Record<String, String[]>
 
 Emitted when there is redirection and the mode is `manual`. Calling
 [`request.followRedirect`](#requestfollowredirect) will continue with the redirection.
@@ -158,7 +158,7 @@ internally buffered inside Electron process memory.
 #### `request.setHeader(name, value)`
 
 * `name` String - An extra HTTP header name.
-* `value` Object - An extra HTTP header value.
+* `value` String - An extra HTTP header value.
 
 Adds an extra HTTP header. The header name will be issued as-is without
 lowercasing. It can be called only before first write. Calling this method after
@@ -169,7 +169,7 @@ the first write will throw an error. If the passed value is not a `String`, its
 
 * `name` String - Specify an extra header name.
 
-Returns `Object` - The value of a previously set extra header name.
+Returns `String` - The value of a previously set extra header name.
 
 #### `request.removeHeader(name)`
 

--- a/docs/api/content-tracing.md
+++ b/docs/api/content-tracing.md
@@ -74,6 +74,9 @@ will be returned in the promise.
 
 Returns `Promise<Object>` - Resolves with an object containing the `value` and `percentage` of trace buffer maximum usage
 
+* `value` Number
+* `percentage` Number
+
 Get the maximum usage across processes of trace buffer as a percentage of the
 full state.
 

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -48,7 +48,7 @@ The `crashReporter` module has the following methods:
   * `productName` String (optional) - Defaults to `app.name`.
   * `uploadToServer` Boolean (optional) - Whether crash reports should be sent to the server. Default is `true`.
   * `ignoreSystemCrashHandler` Boolean (optional) - Default is `false`.
-  * `extra` Object (optional) - An object you can define that will be sent along with the
+  * `extra` Record<String, String> (optional) - An object you can define that will be sent along with the
     report. Only string properties are sent correctly. Nested objects are not
     supported. When using Windows, the property names and values must be fewer than 64 characters.
   * `crashesDirectory` String (optional) - Directory to store the crash reports temporarily (only used when the crash reporter is started via `process.crashReporter.start`).

--- a/docs/api/debugger.md
+++ b/docs/api/debugger.md
@@ -50,7 +50,7 @@ Returns:
 
 * `event` Event
 * `method` String - Method name.
-* `params` Object - Event parameters defined by the 'parameters'
+* `params` unknown - Event parameters defined by the 'parameters'
    attribute in the remote debugging protocol.
 
 Emitted whenever the debugging target issues an instrumentation event.
@@ -78,7 +78,7 @@ Detaches the debugger from the `webContents`.
 
 * `method` String - Method name, should be one of the methods defined by the
    [remote debugging protocol][rdp].
-* `commandParams` Object (optional) - JSON object with request parameters.
+* `commandParams` any (optional) - JSON object with request parameters.
 
 Returns `Promise<any>` - A promise that resolves with the response defined by
 the 'returns' attribute of the command description in the remote debugging protocol

--- a/docs/api/incoming-message.md
+++ b/docs/api/incoming-message.md
@@ -51,7 +51,7 @@ A `String` representing the HTTP status message.
 
 #### `response.headers`
 
-An `Object` representing the response HTTP headers. The `headers` object is
+An `Record<string, string[]>` representing the response HTTP headers. The `headers` object is
 formatted as follows:
 
 * All header names are lowercased.

--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -90,7 +90,7 @@ Removes listeners of the specified `channel`.
 ### `ipcMain.handle(channel, listener)`
 
 * `channel` String
-* `listener` Function<Promise> | Function<any>
+* `listener` Function<Promise<void> | any>
   * `event` IpcMainInvokeEvent
   * `...args` any[]
 
@@ -122,7 +122,7 @@ WebContents is the source of the invoke request.
 ### `ipcMain.handleOnce(channel, listener)`
 
 * `channel` String
-* `listener` Function<Promise> | Function<any>
+* `listener` Function<Promise<void> | any>
   * `event` IpcMainInvokeEvent
   * `...args` any[]
 

--- a/docs/api/net.md
+++ b/docs/api/net.md
@@ -54,7 +54,7 @@ The `net` module has the following methods:
 
 ### `net.request(options)`
 
-* `options` (Object | String) - The `ClientRequest` constructor options.
+* `options` (ClientRequestConstructorOptions | String) - The `ClientRequest` constructor options.
 
 Returns [`ClientRequest`](./client-request.md)
 

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -228,7 +228,7 @@ should be called with either a `String` or an object that has the `data`,
     * `redirectRequest` Object
       * `url` String
       * `method` String (optional)
-      * `session` Object (optional)
+      * `session` Session | null (optional)
       * `uploadData` [ProtocolResponseUploadData](structures/protocol-response-upload-data.md) (optional)
 * `completion` Function (optional)
   * `error` Error
@@ -388,7 +388,7 @@ which sends a `Buffer` as a response.
     * `redirectRequest` Object
       * `url` String
       * `method` String (optional)
-      * `session` Object | null (optional)
+      * `session` Session | null (optional)
       * `uploadData` Object (optional)
         * `contentType` String - MIME type of the content.
         * `data` String - Content to be sent.

--- a/docs/api/structures/extension-info.md
+++ b/docs/api/structures/extension-info.md
@@ -1,0 +1,4 @@
+# ExtensionInfo Object
+
+* `name` String
+* `version` String

--- a/docs/api/structures/trace-config.md
+++ b/docs/api/structures/trace-config.md
@@ -19,7 +19,7 @@
   include in the trace. If not specified, trace all processes.
 * `histogram_names` String[] (optional) - a list of [histogram][] names to report
   with the trace.
-* `memory_dump_config` Object (optional) - if the
+* `memory_dump_config` Record<String, any> (optional) - if the
   `disabled-by-default-memory-infra` category is enabled, this contains
   optional additional configuration for data collection. See the [Chromium
   memory-infra docs][memory-infra docs] for more information.

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -56,7 +56,7 @@ Returns `Boolean` - Whether the Swipe between pages setting is on.
 ### `systemPreferences.postNotification(event, userInfo[, deliverImmediately])` _macOS_
 
 * `event` String
-* `userInfo` Object
+* `userInfo` Record<String, any>
 * `deliverImmediately` Boolean (optional) - `true` to post notifications immediately even when the subscribing app is inactive.
 
 Posts `event` as native notifications of macOS. The `userInfo` is an Object
@@ -65,7 +65,7 @@ that contains the user information dictionary sent along with the notification.
 ### `systemPreferences.postLocalNotification(event, userInfo)` _macOS_
 
 * `event` String
-* `userInfo` Object
+* `userInfo` Record<String, any>
 
 Posts `event` as native notifications of macOS. The `userInfo` is an Object
 that contains the user information dictionary sent along with the notification.
@@ -73,7 +73,7 @@ that contains the user information dictionary sent along with the notification.
 ### `systemPreferences.postWorkspaceNotification(event, userInfo)` _macOS_
 
 * `event` String
-* `userInfo` Object
+* `userInfo` Record<String, any>
 
 Posts `event` as native notifications of macOS. The `userInfo` is an Object
 that contains the user information dictionary sent along with the notification.
@@ -83,7 +83,7 @@ that contains the user information dictionary sent along with the notification.
 * `event` String
 * `callback` Function
   * `event` String
-  * `userInfo` Object
+  * `userInfo` Record<String, unknown>
   * `object` String
 
 Returns `Number` - The ID of this subscription
@@ -110,7 +110,7 @@ example values of `event` are:
 * `event` String
 * `callback` Function
   * `event` String
-  * `userInfo` Object
+  * `userInfo` Record<String, unknown>
   * `object` String
 
 Returns `Number` - The ID of this subscription
@@ -123,7 +123,7 @@ This is necessary for events such as `NSUserDefaultsDidChangeNotification`.
 * `event` String
 * `callback` Function
   * `event` String
-  * `userInfo` Object
+  * `userInfo` Record<String, unknown>
   * `object` String
 
 Same as `subscribeNotification`, but uses `NSWorkspace.sharedWorkspace.notificationCenter`.
@@ -149,7 +149,7 @@ Same as `unsubscribeNotification`, but removes the subscriber from `NSWorkspace.
 
 ### `systemPreferences.registerDefaults(defaults)` _macOS_
 
-* `defaults` Object - a dictionary of (`key: value`) user defaults
+* `defaults` Record<String, String | Boolean | Number> - a dictionary of (`key: value`) user defaults
 
 Add the specified defaults to your application's `NSUserDefaults`.
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -481,7 +481,7 @@ Returns:
   * `requestId` Integer
   * `activeMatchOrdinal` Integer - Position of the active match.
   * `matches` Integer - Number of Matches.
-  * `selectionArea` Object - Coordinates of first match region.
+  * `selectionArea` Rectangle - Coordinates of first match region.
   * `finalUpdate` Boolean
 
 Emitted when a result is available for
@@ -842,7 +842,7 @@ webContents.loadURL('https://github.com', options)
 
 * `filePath` String
 * `options` Object (optional)
-  * `query` Object (optional) - Passed to `url.format()`.
+  * `query` Record<String, String> (optional) - Passed to `url.format()`.
   * `search` String (optional) - Passed to `url.format()`.
   * `hash` String (optional) - Passed to `url.format()`.
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -143,7 +143,7 @@ Returns:
 * `frameName` String
 * `disposition` String - Can be `default`, `foreground-tab`, `background-tab`,
   `new-window`, `save-to-disk` and `other`.
-* `options` Object - The options which will be used for creating the new
+* `options` BrowserWindowConstructorOptions - The options which will be used for creating the new
   [`BrowserWindow`](browser-window.md).
 * `additionalFeatures` String[] - The non-standard features (features not handled
   by Chromium or Electron) given to `window.open()`.
@@ -669,10 +669,10 @@ Emitted when the devtools window instructs the webContents to reload
 Returns:
 
 * `event` Event
-* `webPreferences` Object - The web preferences that will be used by the guest
+* `webPreferences` WebPreferences - The web preferences that will be used by the guest
   page. This object can be modified to adjust the preferences for the guest
   page.
-* `params` Object - The other `<webview>` parameters such as the `src` URL.
+* `params` Record<string, string> - The other `<webview>` parameters such as the `src` URL.
   This object can be modified to adjust the parameters of the guest page.
 
 Emitted when a `<webview>`'s web contents is being attached to this web
@@ -1563,13 +1563,6 @@ Disable device emulation enabled by `webContents.enableDeviceEmulation`.
 #### `contents.sendInputEvent(inputEvent)`
 
 * `inputEvent` [MouseInputEvent](structures/mouse-input-event.md) | [MouseWheelInputEvent](structures/mouse-wheel-input-event.md) | [KeyboardInputEvent](structures/keyboard-input-event.md)
-  * `type` String (**required**) - The type of the event, can be `mouseDown`,
-    `mouseUp`, `mouseEnter`, `mouseLeave`, `contextMenu`, `mouseWheel`,
-    `mouseMove`, `keyDown`, `keyUp` or `char`.
-  * `modifiers` String[] - An array of modifiers of the event, can
-    include `shift`, `control`, `alt`, `meta`, `isKeypad`, `isAutoRepeat`,
-    `leftButtonDown`, `middleButtonDown`, `rightButtonDown`, `capsLock`,
-    `numLock`, `left`, `right`.
 
 Sends an input `event` to the page.
 **Note:** The [`BrowserWindow`](browser-window.md) containing the contents needs to be focused for

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -767,7 +767,7 @@ Returns:
   * `requestId` Integer
   * `activeMatchOrdinal` Integer - Position of the active match.
   * `matches` Integer - Number of Matches.
-  * `selectionArea` Object - Coordinates of first match region.
+  * `selectionArea` Rectangle - Coordinates of first match region.
   * `finalUpdate` Boolean
 
 Fired when a result is available for
@@ -791,7 +791,7 @@ Returns:
 * `frameName` String
 * `disposition` String - Can be `default`, `foreground-tab`, `background-tab`,
   `new-window`, `save-to-disk` and `other`.
-* `options` Object - The options which should be used for creating the new
+* `options` BrowserWindowConstructorOptions - The options which should be used for creating the new
   [`BrowserWindow`](browser-window.md).
 
 Fired when the guest page attempts to open a new browser window.

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -593,7 +593,7 @@ examples.
 
 ### `<webview>.sendInputEvent(event)`
 
-* `event` Object
+* `event`  [MouseInputEvent](structures/mouse-input-event.md) | [MouseWheelInputEvent](structures/mouse-wheel-input-event.md) | [KeyboardInputEvent](structures/keyboard-input-event.md)
 
 Returns `Promise<void>`
 
@@ -872,7 +872,7 @@ webview.addEventListener('close', () => {
 Returns:
 
 * `channel` String
-* `args` Array
+* `args` any[]
 
 Fired when the guest page has sent an asynchronous message to embedder page.
 

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -76,6 +76,7 @@ auto_filenames = {
     "docs/api/structures/desktop-capturer-source.md",
     "docs/api/structures/display.md",
     "docs/api/structures/event.md",
+    "docs/api/structures/extension-info.md",
     "docs/api/structures/file-filter.md",
     "docs/api/structures/file-path-with-headers.md",
     "docs/api/structures/gpu-feature-status.md",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "repository": "https://github.com/electron/electron",
   "description": "Build cross platform desktop apps with JavaScript, HTML, and CSS",
   "devDependencies": {
-    "@electron/docs-parser": "^0.4.1",
-    "@electron/typescript-definitions": "^8.5.0",
+    "@electron/docs-parser": "^0.4.2",
+    "@electron/typescript-definitions": "^8.6.1",
     "@octokit/rest": "^16.3.2",
     "@primer/octicons": "^9.1.1",
     "@types/chai": "^4.1.7",

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1714,7 +1714,7 @@ describe('BrowserWindow module', () => {
           }
         })
         w.webContents.once('new-window', (event, url, frameName, disposition, options) => {
-          options.webPreferences.preload = preload
+          options.webPreferences!.preload = preload
         })
         const htmlPath = path.join(fixtures, 'api', 'sandbox.html?window-open')
         const pageUrl = 'file://' + htmlPath
@@ -1742,7 +1742,7 @@ describe('BrowserWindow module', () => {
         })
 
         w.webContents.once('new-window', (event, url, frameName, disposition, options) => {
-          options.webPreferences.preload = preload
+          options.webPreferences!.preload = preload
         })
         w.loadFile(
           path.join(fixtures, 'api', 'sandbox.html'),
@@ -1800,7 +1800,7 @@ describe('BrowserWindow module', () => {
 
         const preloadPath = path.join(fixtures, 'api', 'new-window-preload.js')
         w.webContents.once('new-window', (event, url, frameName, disposition, options) => {
-          options.webPreferences.preload = preloadPath
+          options.webPreferences!.preload = preloadPath
         })
         w.loadFile(path.join(fixtures, 'api', 'new-window.html'))
         const [, args] = await emittedOnce(ipcMain, 'answer')
@@ -1817,8 +1817,9 @@ describe('BrowserWindow module', () => {
 
         const preloadPath = path.join(fixtures, 'api', 'new-window-preload.js')
         w.webContents.once('new-window', (event, url, frameName, disposition, options) => {
-          options.webPreferences.preload = preloadPath
-          options.webPreferences.foo = 'bar'
+          options.webPreferences!.preload = preloadPath
+          const prefs = options.webPreferences as any
+          prefs.foo = 'bar'
         })
         w.loadFile(path.join(fixtures, 'api', 'new-window.html'))
         const [, , webPreferences] = await emittedOnce(ipcMain, 'answer')
@@ -1835,8 +1836,8 @@ describe('BrowserWindow module', () => {
         })
         let childWc: WebContents | null = null
         w.webContents.on('new-window', (event, url, frameName, disposition, options) => {
-          options.webPreferences.preload = preload
-          childWc = options.webContents
+          options.webPreferences!.preload = preload
+          childWc = (options as any).webContents
           expect(w.webContents).to.not.equal(childWc)
         })
         ipcMain.once('parent-ready', function (event) {
@@ -1954,7 +1955,7 @@ describe('BrowserWindow module', () => {
           }
         })
         w.webContents.once('new-window', (event, url, frameName, disposition, options) => {
-          options.webPreferences.preload = preload
+          options.webPreferences!.preload = preload
         })
 
         w.loadFile(path.join(fixtures, 'api', 'sandbox.html'), { search: 'reload-remote-child' })
@@ -2119,7 +2120,7 @@ describe('BrowserWindow module', () => {
       it('should inherit the nativeWindowOpen setting in opened windows', async () => {
         const preloadPath = path.join(fixtures, 'api', 'new-window-preload.js')
         w.webContents.once('new-window', (event, url, frameName, disposition, options) => {
-          options.webPreferences.preload = preloadPath
+          options.webPreferences!.preload = preloadPath
         })
         w.loadFile(path.join(fixtures, 'api', 'new-window.html'))
         const [, args] = await emittedOnce(ipcMain, 'answer')
@@ -2128,8 +2129,9 @@ describe('BrowserWindow module', () => {
       it('should open windows with the options configured via new-window event listeners', async () => {
         const preloadPath = path.join(fixtures, 'api', 'new-window-preload.js')
         w.webContents.once('new-window', (event, url, frameName, disposition, options) => {
-          options.webPreferences.preload = preloadPath
-          options.webPreferences.foo = 'bar'
+          options.webPreferences!.preload = preloadPath
+          const prefs = options.webPreferences! as any
+          prefs.foo = 'bar'
         })
         w.loadFile(path.join(fixtures, 'api', 'new-window.html'))
         const [, , webPreferences] = await emittedOnce(ipcMain, 'answer')
@@ -2185,7 +2187,7 @@ describe('BrowserWindow module', () => {
           })
 
           w.webContents.once('new-window', (event, url, frameName, disposition, options) => {
-            options.webPreferences.preload = path.join(fixtures, 'api', 'window-open-preload.js')
+            options.webPreferences!.preload = path.join(fixtures, 'api', 'window-open-preload.js')
           })
           w.loadFile(path.join(fixtures, 'api', 'window-open-location-open.html'))
           const [, args, typeofProcess] = await emittedOnce(ipcMain, 'answer')
@@ -2205,7 +2207,7 @@ describe('BrowserWindow module', () => {
           })
 
           w.webContents.once('new-window', (event, url, frameName, disposition, options) => {
-            options.webPreferences.preload = path.join(fixtures, 'api', 'window-open-preload.js')
+            options.webPreferences!.preload = path.join(fixtures, 'api', 'window-open-preload.js')
           })
           w.loadFile(path.join(fixtures, 'api', 'window-open-location-open.html'))
           const [, , , windowOpenerIsNull] = await emittedOnce(ipcMain, 'answer')

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -307,7 +307,7 @@ describe('net module', () => {
             done()
           })
         })
-        urlRequest.setHeader(customHeaderName, customHeaderValue)
+        urlRequest.setHeader(customHeaderName, customHeaderValue as any)
         expect(urlRequest.getHeader(customHeaderName)).to.equal(customHeaderValue)
         expect(urlRequest.getHeader(customHeaderName.toLowerCase())).to.equal(customHeaderValue)
         urlRequest.write('')
@@ -975,7 +975,7 @@ describe('net module', () => {
       expect(() => {
         net.request({
           url: 'https://foo',
-          session: 1
+          session: 1 as any
         })
       }).to.throw("`session` should be an instance of the Session class")
     })
@@ -984,7 +984,7 @@ describe('net module', () => {
       expect(() => {
         net.request({
           url: 'https://foo',
-          partition: 1
+          partition: 1 as any
         })
       }).to.throw("`partition` should be a string")
     })
@@ -1001,7 +1001,7 @@ describe('net module', () => {
       }).then(serverUrlUnparsed => {
         const serverUrl = url.parse(serverUrlUnparsed)
         const options = {
-          port: serverUrl.port,
+          port: serverUrl.port ? parseInt(serverUrl.port, 10) : undefined,
           hostname: '127.0.0.1',
           headers: { [customHeaderName]: customHeaderValue }
         }

--- a/spec-main/api-system-preferences-spec.ts
+++ b/spec-main/api-system-preferences-spec.ts
@@ -52,7 +52,7 @@ describe('systemPreferences module', () => {
 
       for (const badDefault of badDefaults) {
         expect(() => {
-          systemPreferences.registerDefaults(badDefault)
+          systemPreferences.registerDefaults(badDefault as any)
         }).to.throw('Invalid userDefault data provided')
       }
     })

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -129,7 +129,7 @@ app.on('ready', () => {
     console.log('Debugger detached due to : ', reason)
   })
 
-  mainWindow.webContents.debugger.on('message', function (event, method, params) {
+  mainWindow.webContents.debugger.on('message', function (event, method, params: any) {
     if (method === 'Network.requestWillBeSent') {
       if (params.request.url === 'https://www.github.com') {
         mainWindow.webContents.debugger.detach()

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,10 +25,10 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@electron/docs-parser@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@electron/docs-parser/-/docs-parser-0.4.1.tgz#e6557a6a3899ca1168b9f2d70ad24d9ba924e4a9"
-  integrity sha512-mn4ofEvH8HNdzRMb++cUbiTkO88BAKwM0yjED3KrQ07yEl7CU1lK13qSMVSRhDzNkbg4kFTqBDjaJ57fdHlkxQ==
+"@electron/docs-parser@^0.4.1", "@electron/docs-parser@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@electron/docs-parser/-/docs-parser-0.4.2.tgz#1d5feb0376363435b2f6833b60271ee90c26f952"
+  integrity sha512-BdEW2So0Qg7lxIET9q84DceavC1v/EyYF9PXU8vRRiwFebGPyEaJS4uqxhStAxmZslQAT4JjQc9jTd12IbG6BQ==
   dependencies:
     "@types/markdown-it" "^0.0.7"
     chai "^4.2.0"
@@ -40,10 +40,10 @@
     ora "^3.4.0"
     pretty-ms "^5.0.0"
 
-"@electron/typescript-definitions@^8.5.0":
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/@electron/typescript-definitions/-/typescript-definitions-8.5.0.tgz#8be8d90e2245478368180795b3632db02e90ccdc"
-  integrity sha512-sq7tTIyQyGMxrSbmCsbpyfV5Yc68Pb74rp5cbpaS3Kopi5sAL2nIi4TdTakVE7Pp4cye75i8HqDUBhsMpt+TvA==
+"@electron/typescript-definitions@^8.6.1":
+  version "8.6.1"
+  resolved "https://registry.yarnpkg.com/@electron/typescript-definitions/-/typescript-definitions-8.6.1.tgz#7d7b506c21d6667f9e53e5930e3b70a9c1d4ccf3"
+  integrity sha512-lv6tj76wnhWzTHuxryhTV329AWHPoOn+VUpCzsz3XVCKm+FO+ldttdgFv+1lA7YGOsi+ttiaX678g+iBGZDlTQ==
   dependencies:
     "@electron/docs-parser" "^0.4.1"
     "@types/node" "^11.13.7"
@@ -57,7 +57,6 @@
     mkdirp "^0.5.1"
     ora "^3.4.0"
     pretty-ms "^5.0.0"
-    rimraf "^2.5.4"
     typescript "^3.4.5"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
@@ -226,9 +225,9 @@
   integrity sha512-rp7La3m845mSESCgsJePNL/JQyhkOJA6G4vcwvVgkDAwHhGdq5GCumxmPjEk1MZf+8p5ZQAUE7tqgQRQTXN7uQ==
 
 "@types/node@^11.13.7":
-  version "11.13.17"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.17.tgz#2e7efbfe5253561087812571e5e6a1e4b1d6295b"
-  integrity sha512-7W3kSMa8diVH6s24a8Qrmvwu+vG3ahOC/flMHFdWSdnPYoQI0yPO84h5zOWYXAha2Npn3Pw3SSuQSwBUfaniyQ==
+  version "11.13.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.18.tgz#758ec2bf26339d3cc83da22676b64777d0c2befe"
+  integrity sha512-sMHdXLccscaxI+Hlzz58yLQue3lQyXP+6aQniDRi5oju3n0123kcjhicVGF20WF7cHiwJ2vxMbXc4skOclosoA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -3871,9 +3870,9 @@ levn@^0.3.0, levn@~0.3.0:
     type-check "~0.3.2"
 
 linkify-it@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.1.0.tgz#c4caf38a6cd7ac2212ef3c7d2bde30a91561f9db"
-  integrity sha512-4REs8/062kV2DSHxNfq5183zrqXMl7WP0WzABH9IeJI+NLm429FgE1PDecltYfnOoFDFlZGh2T8PfZn0r+GTRg==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.2.0.tgz#e3b54697e78bf915c70a38acd78fd09e0058b1cf"
+  integrity sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==
   dependencies:
     uc.micro "^1.0.1"
 
@@ -4067,12 +4066,12 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.0:
+lodash@^4.0.0, lodash@^4.17.11:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
+lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==


### PR DESCRIPTION
Previously if the typescript generator saw a type it didn't understand, was incomplete or was invalid it just defaulted to "any".  This was good for a while but it results in worse docs over time, a recent change to the parser (included in this PR) now enforces every single type is valid and will throw an error if anything is wrong rather than falling back to `any`.

The PR explicitly types a few things to fix these new errors 👍 

Notes: no-notes