### PR TITLE
fix: handle edge behavior for about panel on Linux

### DIFF
--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -147,60 +147,62 @@ bool Browser::IsEmojiPanelSupported() {
 }
 
 void Browser::ShowAboutPanel() {
+  const auto& opts = about_panel_options_;
+
+  if (!opts.is_dict()) {
+    LOG(WARNING) << "Called showAboutPanel(), but didn't use "
+                    "setAboutPanelSettings() first";
+    return;
+  }
+
   GtkWidget* dialogWidget = gtk_about_dialog_new();
   GtkAboutDialog* dialog = GTK_ABOUT_DIALOG(dialogWidget);
 
-  const auto& opts = about_panel_options_;
   const std::string* str;
   const base::Value* val;
 
-  if ((opts.is_dict())) {
-    if ((str = opts.FindStringKey("applicationName"))) {
-      gtk_about_dialog_set_program_name(dialog, str->c_str());
-    }
-    if ((str = opts.FindStringKey("applicationVersion"))) {
-      gtk_about_dialog_set_version(dialog, str->c_str());
-    }
-    if ((str = opts.FindStringKey("copyright"))) {
-      gtk_about_dialog_set_copyright(dialog, str->c_str());
-    }
-    if ((str = opts.FindStringKey("website"))) {
-      gtk_about_dialog_set_website(dialog, str->c_str());
-    }
-    if ((str = opts.FindStringKey("iconPath"))) {
-      GError* error = nullptr;
-      constexpr int width = 64;   // width of about panel icon in pixels
-      constexpr int height = 64;  // height of about panel icon in pixels
+  if ((str = opts.FindStringKey("applicationName"))) {
+    gtk_about_dialog_set_program_name(dialog, str->c_str());
+  }
+  if ((str = opts.FindStringKey("applicationVersion"))) {
+    gtk_about_dialog_set_version(dialog, str->c_str());
+  }
+  if ((str = opts.FindStringKey("copyright"))) {
+    gtk_about_dialog_set_copyright(dialog, str->c_str());
+  }
+  if ((str = opts.FindStringKey("website"))) {
+    gtk_about_dialog_set_website(dialog, str->c_str());
+  }
+  if ((str = opts.FindStringKey("iconPath"))) {
+    GError* error = nullptr;
+    constexpr int width = 64;   // width of about panel icon in pixels
+    constexpr int height = 64;  // height of about panel icon in pixels
 
-      // set preserve_aspect_ratio to true
-      GdkPixbuf* icon =
-          gdk_pixbuf_new_from_file_at_size(str->c_str(), width, height, &error);
-      if (error != nullptr) {
-        g_warning("%s", error->message);
-        g_clear_error(&error);
-      } else {
-        gtk_about_dialog_set_logo(dialog, icon);
-        g_clear_object(&icon);
-      }
+    // set preserve_aspect_ratio to true
+    GdkPixbuf* icon =
+        gdk_pixbuf_new_from_file_at_size(str->c_str(), width, height, &error);
+    if (error != nullptr) {
+      g_warning("%s", error->message);
+      g_clear_error(&error);
+    } else {
+      gtk_about_dialog_set_logo(dialog, icon);
+      g_clear_object(&icon);
     }
+  }
 
-    if ((val = opts.FindListKey("authors"))) {
-      std::vector<const char*> cstrs;
-      for (const auto& authorVal : val->GetList()) {
-        if (authorVal.is_string()) {
-          cstrs.push_back(authorVal.GetString().c_str());
-        }
-      }
-      if (cstrs.empty()) {
-        LOG(WARNING) << "No author strings found in 'authors' array";
-      } else {
-        cstrs.push_back(nullptr);  // null-terminated char* array
-        gtk_about_dialog_set_authors(dialog, cstrs.data());
+  if ((val = opts.FindListKey("authors"))) {
+    std::vector<const char*> cstrs;
+    for (const auto& authorVal : val->GetList()) {
+      if (authorVal.is_string()) {
+        cstrs.push_back(authorVal.GetString().c_str());
       }
     }
-  } else {
-    LOG(WARNING) << "Called showAboutPanel(), but didn't use "
-                    "setAboutPanelSettings() first";
+    if (cstrs.empty()) {
+      LOG(WARNING) << "No author strings found in 'authors' array";
+    } else {
+      cstrs.push_back(nullptr);  // null-terminated char* array
+      gtk_about_dialog_set_authors(dialog, cstrs.data());
+    }
   }
 
   gtk_dialog_run(GTK_DIALOG(dialog));

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -147,58 +147,64 @@ bool Browser::IsEmojiPanelSupported() {
 }
 
 void Browser::ShowAboutPanel() {
-  GtkAboutDialog* dialog = GTK_ABOUT_DIALOG(gtk_about_dialog_new());
+  GtkWidget* dialogWidget = gtk_about_dialog_new();
+  GtkAboutDialog* dialog = GTK_ABOUT_DIALOG(dialogWidget);
 
   const auto& opts = about_panel_options_;
   const std::string* str;
   const base::Value* val;
 
-  if ((str = opts.FindStringKey("applicationName"))) {
-    gtk_about_dialog_set_program_name(dialog, str->c_str());
-  }
-  if ((str = opts.FindStringKey("applicationVersion"))) {
-    gtk_about_dialog_set_version(dialog, str->c_str());
-  }
-  if ((str = opts.FindStringKey("copyright"))) {
-    gtk_about_dialog_set_copyright(dialog, str->c_str());
-  }
-  if ((str = opts.FindStringKey("website"))) {
-    gtk_about_dialog_set_website(dialog, str->c_str());
-  }
-  if ((str = opts.FindStringKey("iconPath"))) {
-    GError* error = nullptr;
-    constexpr int width = 64;   // width of about panel icon in pixels
-    constexpr int height = 64;  // height of about panel icon in pixels
-
-    // set preserve_aspect_ratio to true
-    GdkPixbuf* icon =
-        gdk_pixbuf_new_from_file_at_size(str->c_str(), width, height, &error);
-    if (error != nullptr) {
-      g_warning("%s", error->message);
-      g_clear_error(&error);
-    } else {
-      gtk_about_dialog_set_logo(dialog, icon);
-      g_clear_object(&icon);
+  if ((opts.is_dict())) {
+    if ((str = opts.FindStringKey("applicationName"))) {
+      gtk_about_dialog_set_program_name(dialog, str->c_str());
     }
-  }
+    if ((str = opts.FindStringKey("applicationVersion"))) {
+      gtk_about_dialog_set_version(dialog, str->c_str());
+    }
+    if ((str = opts.FindStringKey("copyright"))) {
+      gtk_about_dialog_set_copyright(dialog, str->c_str());
+    }
+    if ((str = opts.FindStringKey("website"))) {
+      gtk_about_dialog_set_website(dialog, str->c_str());
+    }
+    if ((str = opts.FindStringKey("iconPath"))) {
+      GError* error = nullptr;
+      constexpr int width = 64;   // width of about panel icon in pixels
+      constexpr int height = 64;  // height of about panel icon in pixels
 
-  if ((val = opts.FindListKey("authors"))) {
-    std::vector<const char*> cstrs;
-    for (const auto& authorVal : val->GetList()) {
-      if (authorVal.is_string()) {
-        cstrs.push_back(authorVal.GetString().c_str());
+      // set preserve_aspect_ratio to true
+      GdkPixbuf* icon =
+          gdk_pixbuf_new_from_file_at_size(str->c_str(), width, height, &error);
+      if (error != nullptr) {
+        g_warning("%s", error->message);
+        g_clear_error(&error);
+      } else {
+        gtk_about_dialog_set_logo(dialog, icon);
+        g_clear_object(&icon);
       }
     }
-    if (cstrs.empty()) {
-      LOG(WARNING) << "No author strings found in 'authors' array";
-    } else {
-      cstrs.push_back(nullptr);  // null-terminated char* array
-      gtk_about_dialog_set_authors(dialog, cstrs.data());
+
+    if ((val = opts.FindListKey("authors"))) {
+      std::vector<const char*> cstrs;
+      for (const auto& authorVal : val->GetList()) {
+        if (authorVal.is_string()) {
+          cstrs.push_back(authorVal.GetString().c_str());
+        }
+      }
+      if (cstrs.empty()) {
+        LOG(WARNING) << "No author strings found in 'authors' array";
+      } else {
+        cstrs.push_back(nullptr);  // null-terminated char* array
+        gtk_about_dialog_set_authors(dialog, cstrs.data());
+      }
     }
+  } else {
+    LOG(WARNING) << "Called showAboutPanel(), but didn't use "
+                    "setAboutPanelSettings() first";
   }
 
   gtk_dialog_run(GTK_DIALOG(dialog));
-  g_clear_object(&dialog);
+  gtk_widget_destroy(dialogWidget);
 }
 
 void Browser::SetAboutPanelOptions(const base::DictionaryValue& options) {


### PR DESCRIPTION
#### Description of Change
This PR fixes two small issues:
* If `app.showAboutPanel()` would be called before `app.setAboutPanelOptions()`, the app would crash. This PR handles this edge case gracefully by skipping the option logic if none are there and logging a warning to the user.
* Upon closing the About dialog, there were previously warnings from GTK stemming from the `g_clear_object(&dialog)` call.
![Screenshot from 2019-08-01 18-49-47](https://user-images.githubusercontent.com/8472721/62338409-4acf5180-b48d-11e9-94c6-d128c6f69c04.png)
This has now been replaced with a call to destroy the `GtkWidget` after closing the About dialog.


cc @codebytere @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed bug where app would crash if `app.showAboutPanel()` was called before setting any About panel options on Linux.
