### PR TITLE
test: report hexadecimal status codes on windows

### DIFF
--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -123,7 +123,8 @@ async function runRemoteBasedElectronTests () {
     stdio: 'inherit'
   })
   if (status !== 0) {
-    throw new Error(`Electron tests failed with code ${status}.`)
+    const textStatus = process.platform === 'win32' ? `0x${status.toString(16)}` : status.toString()
+    throw new Error(`Electron tests failed with code ${textStatus}.`)
   }
 }
 
@@ -135,7 +136,8 @@ async function runMainProcessElectronTests () {
     stdio: 'inherit'
   })
   if (status !== 0) {
-    throw new Error(`Electron tests failed with code ${status}.`)
+    const textStatus = process.platform === 'win32' ? `0x${status.toString(16)}` : status.toString()
+    throw new Error(`Electron tests failed with code ${textStatus}.`)
   }
 }
 


### PR DESCRIPTION
#### Description of Change
Because 3221226356 isn't really googleable but 0xc0000374 is

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none