### PR TITLE
fix: crash on window.print()

### DIFF
--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -46,7 +46,7 @@ index 63f432b58371cfa0f8079fa78a51c8865a00c183..7b39523e0b8b840191ea517d5f5e8eda
  
  void PrintJobWorker::GetSettingsWithUI(int document_page_count,
 diff --git a/chrome/browser/printing/print_view_manager_base.cc b/chrome/browser/printing/print_view_manager_base.cc
-index c4e0992f6265b34659514ef5f15eb8d78645161c..e95f62c0761d1a5829cc4403434fd643e45a0a69 100644
+index c4e0992f6265b34659514ef5f15eb8d78645161c..1aca2f88da5d8e96a0f16a667a8a86a7873dfdf9 100644
 --- a/chrome/browser/printing/print_view_manager_base.cc
 +++ b/chrome/browser/printing/print_view_manager_base.cc
 @@ -27,10 +27,7 @@
@@ -188,16 +188,19 @@ index c4e0992f6265b34659514ef5f15eb8d78645161c..e95f62c0761d1a5829cc4403434fd643
    if (!print_job_)
      return;
  
-@@ -607,7 +619,7 @@ void PrintViewManagerBase::ReleasePrintJob() {
+@@ -606,8 +618,9 @@ void PrintViewManagerBase::ReleasePrintJob() {
+     rfh->Send(msg.release());
    }
  
-   registrar_.Remove(this, chrome::NOTIFICATION_PRINT_JOB_EVENT,
+-  registrar_.Remove(this, chrome::NOTIFICATION_PRINT_JOB_EVENT,
 -                    content::Source<PrintJob>(print_job_.get()));
-+                    content::NotificationService::AllSources());
++  if (!callback_.is_null())
++    registrar_.Remove(this, chrome::NOTIFICATION_PRINT_JOB_EVENT,
++                      content::NotificationService::AllSources());
    // Don't close the worker thread.
    print_job_ = nullptr;
  }
-@@ -677,6 +689,9 @@ bool PrintViewManagerBase::PrintNowInternal(
+@@ -677,6 +690,9 @@ bool PrintViewManagerBase::PrintNowInternal(
    // Don't print / print preview interstitials or crashed tabs.
    if (web_contents()->ShowingInterstitialPage() || web_contents()->IsCrashed())
      return false;


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/19539.

`window.print()` doesn't invoke `PrintViewManagerBase::PrintNowInternal`, so when we moved 

```
  registrar_.Add(this, chrome::NOTIFICATION_PRINT_JOB_EVENT,
                content::NotificationService::AllSources());
```

into that function from `PrintViewManagerBase::CreateNewPrintJob()` we inadvertently created a side-effect wherein in `PrintViewManagerBase::ReleasePrintJob()` it would try to unregister a notification listener which wasn't registered, and would therefore CHECK on ` found != registered_.end()`. 

This fixes that by guarding the unregistration with a null check on `callback_`, which would only be non-null when in the call chain of our `webContents.print()` implementation, since `callback_` is a member we patched in ourselves as part of that method.

cc @jkleinsc @PalmerAL @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash in `window.print()`.
