### PR TITLE
fix: destroy tray on current tick

### DIFF
--- a/atom/browser/api/atom_api_tray.cc
+++ b/atom/browser/api/atom_api_tray.cc
@@ -59,11 +59,7 @@ Tray::Tray(v8::Isolate* isolate,
   InitWith(isolate, wrapper);
 }
 
-Tray::~Tray() {
-  // Destroy the native tray in next tick.
-  base::ThreadTaskRunnerHandle::Get()->DeleteSoon(FROM_HERE,
-                                                  tray_icon_.release());
-}
+Tray::~Tray() = default;
 
 // static
 mate::WrappableBase* Tray::New(mate::Handle<NativeImage> image,

--- a/spec/api-tray-spec.js
+++ b/spec/api-tray-spec.js
@@ -1,4 +1,5 @@
 const { remote } = require('electron')
+const assert = require('assert')
 const { Menu, Tray, nativeImage } = remote
 
 describe('tray module', () => {
@@ -8,12 +9,12 @@ describe('tray module', () => {
     tray = new Tray(nativeImage.createEmpty())
   })
 
-  afterEach(() => {
-    tray.destroy()
-    tray = null
-  })
-
   describe('tray.setContextMenu', () => {
+    afterEach(() => {
+      tray.destroy()
+      tray = null
+    })
+
     it('accepts menu instance', () => {
       tray.setContextMenu(new Menu())
     })
@@ -23,7 +24,22 @@ describe('tray module', () => {
     })
   })
 
+  describe('tray.destroy()', () => {
+    it('destroys a tray', () => {
+      assert.strictEqual(tray.isDestroyed(), false)
+      tray.destroy()
+
+      assert.strictEqual(tray.isDestroyed(), true)
+      tray = null
+    })
+  })
+
   describe('tray.popUpContextMenu', () => {
+    afterEach(() => {
+      tray.destroy()
+      tray = null
+    })
+
     before(function () {
       if (process.platform !== 'win32') {
         this.skip()
@@ -43,22 +59,31 @@ describe('tray module', () => {
   describe('tray.setImage', () => {
     it('accepts empty image', () => {
       tray.setImage(nativeImage.createEmpty())
+
+      tray.destroy()
+      tray = null
     })
   })
 
   describe('tray.setPressedImage', () => {
     it('accepts empty image', () => {
       tray.setPressedImage(nativeImage.createEmpty())
+
+      tray.destroy()
+      tray = null
     })
   })
 
   describe('tray.setTitle', () => {
-    it('accepts non-empty string', () => {
-      tray.setTitle('Hello World!')
+    before(function () {
+      if (process.platform !== 'darwin') this.skip()
     })
 
-    it('accepts empty string', () => {
-      tray.setTitle('')
+    it('accepts non-empty string', () => {
+      tray.setTitle('Hello World!')
+
+      tray.destroy()
+      tray = null
     })
   })
 })


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/18196.

See that PR for more details.

Notes: Fixed an issue where tray.destroy was not working properly on some linux distros.