### PR TITLE
fix: ensure the webContents is not destroyed before communicating

### DIFF
--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -109,7 +109,9 @@ const removeBackgroundPages = function (manifest) {
 
 const sendToBackgroundPages = function (...args) {
   for (const page of Object.values(backgroundPages)) {
-    page.webContents._sendInternalToAll(...args)
+    if (!page.webContents.isDestroyed()) {
+      page.webContents._sendInternalToAll(...args)
+    }
   }
 }
 
@@ -151,9 +153,8 @@ let nextId = 0
 
 ipcMain.on('CHROME_RUNTIME_CONNECT', function (event, extensionId, connectInfo) {
   const page = backgroundPages[extensionId]
-  if (!page) {
-    console.error(`Connect to unknown extension ${extensionId}`)
-    return
+  if (!page || page.webContents.isDestroyed()) {
+    throw new Error(`Connect to unknown extension ${extensionId}`)
   }
 
   const portId = ++nextId
@@ -173,9 +174,8 @@ ipcMain.on('CHROME_I18N_MANIFEST', function (event, extensionId) {
 let resultID = 1
 ipcMain.on('CHROME_RUNTIME_SENDMESSAGE', function (event, extensionId, message, originResultID) {
   const page = backgroundPages[extensionId]
-  if (!page) {
-    console.error(`Connect to unknown extension ${extensionId}`)
-    return
+  if (!page || page.webContents.isDestroyed()) {
+    throw new Error(`Connect to unknown extension ${extensionId}`)
   }
 
   page.webContents._sendInternalToAll(`CHROME_RUNTIME_ONMESSAGE_${extensionId}`, event.sender.id, message, resultID)


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/18467.

See that PR for more details.

Notes: none