### PR TITLE
fix: handle edge behavior for about panel on Linux

### DIFF
--- a/atom/browser/browser_linux.cc
+++ b/atom/browser/browser_linux.cc
@@ -149,7 +149,8 @@ bool Browser::IsEmojiPanelSupported() {
 void Browser::ShowAboutPanel() {
   std::string app_name, version, copyright, icon_path, website;
 
-  GtkAboutDialog* dialog = GTK_ABOUT_DIALOG(gtk_about_dialog_new());
+  GtkWidget* dialogWidget = gtk_about_dialog_new();
+  GtkAboutDialog* dialog = GTK_ABOUT_DIALOG(dialogWidget);
 
   if (about_panel_options_.GetString("applicationName", &app_name))
     gtk_about_dialog_set_program_name(dialog, app_name.c_str());
@@ -177,7 +178,7 @@ void Browser::ShowAboutPanel() {
   }
 
   gtk_dialog_run(GTK_DIALOG(dialog));
-  g_clear_object(&dialog);
+  gtk_widget_destroy(dialogWidget);
 }
 
 void Browser::SetAboutPanelOptions(const base::DictionaryValue& options) {


### PR DESCRIPTION
#### Description of Change
Backport of #19586.

Since the first part of the PR was not relevant (bug not present in `6-0-x`), I only fixed the second part:
>Upon closing the About dialog, there were previously warnings from GTK stemming from the `g_clear_object(&dialog)` call.
This has now been replaced with a call to destroy the `GtkWidget` after closing the About dialog.

Since it is only advanced logging that catches this error, there are `no-notes` associated with this backport.

See that PR for details.

#### Release Notes

Notes: no-notes
