### PR TITLE
fix: return correct bounds on will-resize

### DIFF
--- a/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -12,6 +12,7 @@
 #include "shell/browser/native_window_mac.h"
 #include "shell/browser/ui/cocoa/atom_preview_item.h"
 #include "shell/browser/ui/cocoa/atom_touch_bar.h"
+#include "ui/gfx/mac/coordinate_conversion.h"
 #include "ui/views/cocoa/native_widget_mac_ns_window_host.h"
 #include "ui/views/widget/native_widget_mac.h"
 
@@ -120,8 +121,10 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
 
   {
     bool prevent_default = false;
-    gfx::Rect new_bounds(gfx::Point(sender.frame.origin), gfx::Size(newSize));
-    shell_->NotifyWindowWillResize(new_bounds, &prevent_default);
+    NSRect new_bounds = NSMakeRect(sender.frame.origin.x, sender.frame.origin.y,
+                                   newSize.width, newSize.height);
+    shell_->NotifyWindowWillResize(gfx::ScreenRectFromNSRect(new_bounds),
+                                   &prevent_default);
     if (prevent_default) {
       return sender.frame.size;
     }


### PR DESCRIPTION
#### Description of Change
Fixes #19611.

Use `gfx::ScreenRectFromNSRect` to refer to the window's top-left corner as origin instead of the bottom-left one.

No tests since `will-resize` cannot be triggered programmatically - correct me if i'm wrong :)

cc @codebytere @pmkary

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed BrowserWindow's `will-resize` event returning wrong bounds on macOS.
