### PR TITLE
fix: clearRecentDocuments role on Windows

### DIFF
--- a/atom/browser/browser_win.cc
+++ b/atom/browser/browser_win.cc
@@ -95,9 +95,6 @@ void Browser::Focus() {
 }
 
 void Browser::AddRecentDocument(const base::FilePath& path) {
-  if (base::win::GetVersion() < base::win::VERSION_WIN7)
-    return;
-
   CComPtr<IShellItem> item;
   HRESULT hr = SHCreateItemFromParsingName(path.value().c_str(), NULL,
                                            IID_PPV_ARGS(&item));
@@ -110,13 +107,7 @@ void Browser::AddRecentDocument(const base::FilePath& path) {
 }
 
 void Browser::ClearRecentDocuments() {
-  CComPtr<IApplicationDestinations> destinations;
-  if (FAILED(destinations.CoCreateInstance(CLSID_ApplicationDestinations, NULL,
-                                           CLSCTX_INPROC_SERVER)))
-    return;
-  if (FAILED(destinations->SetAppID(GetAppUserModelID())))
-    return;
-  destinations->RemoveAllDestinations();
+  SHAddToRecentDocs(SHARD_APPIDINFO, nullptr);
 }
 
 void Browser::SetAppUserModelID(const base::string16& name) {


### PR DESCRIPTION
Backport of #19599

See that PR for details.


Notes: Fixed the `clearRecentDocuments` MenuItem role on Windows.
