### PR TITLE
feat: implement `will-move` event on macOS

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -516,14 +516,14 @@ Note that this is only emitted when the window is being resized manually. Resizi
 
 Emitted after the window has been resized.
 
-#### Event: 'will-move' _Windows_
+#### Event: 'will-move' _macOS_ _Windows_
 
 Returns:
 
 * `event` Event
 * `newBounds` [`Rectangle`](structures/rectangle.md) - Location the window is being moved to.
 
-Emitted before the window is moved. Calling `event.preventDefault()` will prevent the window from being moved.
+Emitted before the window is moved. On Windows, calling `event.preventDefault()` will prevent the window from being moved.
 
 Note that this is only emitted when the window is being resized manually. Resizing the window with `setBounds`/`setSize` will not emit this event.
 

--- a/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -139,14 +139,14 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
 }
 
 - (void)windowWillMove:(NSNotification*)notification {
-  NSWindow* window = shell_->GetNativeWindow().GetNativeNSWindow();
+  NSWindow* window = [notification object];
   NSSize size = [[window contentView] frame].size;
   gfx::Rect new_bounds(gfx::Point(window.frame.origin), gfx::Size(size));
   bool prevent_default = false;
 
   shell_->NotifyWindowWillMove(new_bounds, &prevent_default);
   if (prevent_default) {
-    [window setMovable:false];
+    // prevent sefault somehow
   }
 }
 

--- a/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -146,7 +146,8 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
 
   shell_->NotifyWindowWillMove(new_bounds, &prevent_default);
   if (prevent_default) {
-    // prevent sefault somehow
+    // doesn't work
+    [window setMovable:NO];
   }
 }
 

--- a/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -141,11 +141,13 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
 - (void)windowWillMove:(NSNotification*)notification {
   NSWindow* window = [notification object];
   NSSize size = [[window contentView] frame].size;
-  gfx::Rect new_bounds(gfx::Point(window.frame.origin), gfx::Size(size));
+  NSRect new_bounds = NSMakeRect(window.frame.origin.x, window.frame.origin.y,
+                                 size.width, size.height);
   bool prevent_default = false;
 
   // prevent_default has no effect
-  shell_->NotifyWindowWillMove(new_bounds, &prevent_default);
+  shell_->NotifyWindowWillMove(gfx::ScreenRectFromNSRect(new_bounds),
+                               &prevent_default);
 }
 
 - (void)windowDidMove:(NSNotification*)notification {

--- a/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -138,6 +138,18 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
   shell_->NotifyWindowResize();
 }
 
+- (void)windowWillMove:(NSNotification*)notification {
+  NSWindow* window = shell_->GetNativeWindow().GetNativeNSWindow();
+  NSSize size = [[window contentView] frame].size;
+  gfx::Rect new_bounds(gfx::Point(window.frame.origin), gfx::Size(size));
+  bool prevent_default = false;
+
+  shell_->NotifyWindowWillMove(new_bounds, &prevent_default);
+  if (prevent_default) {
+    [window setMovable:false];
+  }
+}
+
 - (void)windowDidMove:(NSNotification*)notification {
   [super windowDidMove:notification];
   // TODO(zcbenz): Remove the alias after figuring out a proper

--- a/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -144,11 +144,8 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
   gfx::Rect new_bounds(gfx::Point(window.frame.origin), gfx::Size(size));
   bool prevent_default = false;
 
+  // prevent_default has no effect
   shell_->NotifyWindowWillMove(new_bounds, &prevent_default);
-  if (prevent_default) {
-    // doesn't work
-    [window setMovable:NO];
-  }
 }
 
 - (void)windowDidMove:(NSNotification*)notification {


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/19613.

Implements the `will-move` event for `BrowserWindow` on macOS. However, due to limitations in AppKit, I have yet to find a solution that will properly implement `event.preventDefault()`.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Implemented 'will-move' event on BrowserWindow on macOS.
