### PR TITLE
test: fix dirtyChai spec failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@primer/octicons": "^9.1.1",
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.0",
+    "@types/dirty-chai": "^2.0.0",
     "@types/express": "^4.16.1",
     "@types/fs-extra": "^5.0.5",
     "@types/mocha": "^5.2.6",

--- a/spec-main/api-browser-view-spec.ts
+++ b/spec-main/api-browser-view-spec.ts
@@ -1,9 +1,13 @@
-import { expect } from 'chai'
+import * as chai from 'chai'
+import dirtyChai = require('dirty-chai')
 import * as ChildProcess from 'child_process'
 import * as path from 'path'
 import { emittedOnce } from './events-helpers'
 import { BrowserView, BrowserWindow } from 'electron'
 import { closeWindow } from './window-helpers';
+
+const { expect } = chai
+chai.use(dirtyChai)
 
 describe('BrowserView module', () => {
   const fixtures = path.resolve(__dirname, '..', 'spec', 'fixtures')

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1,5 +1,6 @@
 import * as chai from 'chai'
 import * as chaiAsPromised from 'chai-as-promised'
+import dirtyChai = require('dirty-chai')
 import * as path from 'path'
 import * as fs from 'fs'
 import * as os from 'os'
@@ -9,12 +10,12 @@ import { AddressInfo } from 'net'
 import { app, BrowserWindow, BrowserView, ipcMain, OnBeforeSendHeadersListenerDetails, protocol, screen, webContents, session, WebContents } from 'electron'
 import { emittedOnce } from './events-helpers';
 import { closeWindow } from './window-helpers';
+import { ifit, ifdescribe } from './spec-helpers'
+
 const { expect } = chai
 
-const ifit = (condition: boolean) => (condition ? it : it.skip)
-const ifdescribe = (condition: boolean) => (condition ? describe : describe.skip)
-
 chai.use(chaiAsPromised)
+chai.use(dirtyChai)
 
 const fixtures = path.resolve(__dirname, '..', 'spec', 'fixtures')
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -149,6 +149,13 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/chai-as-promised@*":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.1.tgz#004c27a4ac640e9590e25d8b0980cb0a6609bfd8"
+  integrity sha512-dberBxQW/XWv6BMj0su1lV9/C9AUx5Hqu2pisuS6S4YK/Qt6vurcj/BmcbEsobIWWCQzhesNY8k73kIxx4X7Mg==
+  dependencies:
+    "@types/chai" "*"
+
 "@types/chai-as-promised@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.0.tgz#010b04cde78eacfb6e72bfddb3e58fe23c2e78b9"
@@ -167,6 +174,14 @@
   integrity sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==
   dependencies:
     "@types/node" "*"
+
+"@types/dirty-chai@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/dirty-chai/-/dirty-chai-2.0.0.tgz#f0a901f7283bef590087b0be931702da2c57aaae"
+  integrity sha512-ff9dIwiqNQK7yqRkI5E9z1OZbS6KllMyyxSYNvwrQ8G/OHA3xZ/TFc4/wvrQQgyJvsUBxUa6EG1olSPkQHpvfg==
+  dependencies:
+    "@types/chai" "*"
+    "@types/chai-as-promised" "*"
 
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
Fixes spec failures on `master` resultant of missing `dirtyChai` imports after TypeScript conversion.

```
import dirtyChai = require('dirty-chai')
``` 
instead of 
```
import * as dirtyChai from 'dirty-chai'
``` 
is needed owing to this error if the proper syntax is used:

```
This module can only be referenced with ECMAScript imports/exports by turning on the 'esModuleInterop' flag and referencing its default export.
```

cc @MarshallOfSound @jkleinsc 

Notes: none