### PR TITLE
fix: serialize messages being sent over chrome message ports

### DIFF
--- a/lib/renderer/chrome-api.js
+++ b/lib/renderer/chrome-api.js
@@ -34,7 +34,7 @@ class Port {
     })
     ipcRenderer.on(`CHROME_PORT_POSTMESSAGE_${portId}`, (event, message) => {
       const sendResponse = function () { console.error('sendResponse is not implemented') }
-      this.onMessage.emit(message, this.sender, sendResponse)
+      this.onMessage.emit(JSON.parse(message), this.sender, sendResponse)
     })
   }
 
@@ -46,7 +46,7 @@ class Port {
   }
 
   postMessage (message) {
-    ipcRenderer.sendToAll(this.tabId, `CHROME_PORT_POSTMESSAGE_${this.portId}`, message)
+    ipcRenderer.sendToAll(this.tabId, `CHROME_PORT_POSTMESSAGE_${this.portId}`, JSON.stringify(message))
   }
 
   _onDisconnect () {


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/19104.

See that PR for more details.

Notes: Uint8Array and Uint16Array can now be sent correctly in Chrome Extension MessagePort instances