### PR TITLE
fix: avoid losing focus on inputs when opening menu (Windows/Linux)

### DIFF
--- a/shell/browser/ui/views/menu_bar.cc
+++ b/shell/browser/ui/views/menu_bar.cc
@@ -275,9 +275,6 @@ void MenuBar::OnMenuButtonClicked(views::Button* source,
     return;
   }
 
-  // GetFocusManager()->SetFocusedViewWithReason(
-  //     source, views::FocusManager::kReasonFocusTraversal);
-
   // Deleted in MenuDelegate::OnMenuClosed
   MenuDelegate* menu_delegate = new MenuDelegate(this);
   menu_delegate->RunMenu(menu_model_->GetSubmenuModelAt(id), source,

--- a/shell/browser/ui/views/menu_bar.cc
+++ b/shell/browser/ui/views/menu_bar.cc
@@ -275,8 +275,8 @@ void MenuBar::OnMenuButtonClicked(views::Button* source,
     return;
   }
 
-  GetFocusManager()->SetFocusedViewWithReason(
-      source, views::FocusManager::kReasonFocusTraversal);
+  // GetFocusManager()->SetFocusedViewWithReason(
+  //     source, views::FocusManager::kReasonFocusTraversal);
 
   // Deleted in MenuDelegate::OnMenuClosed
   MenuDelegate* menu_delegate = new MenuDelegate(this);


### PR DESCRIPTION
#### Description of Change

Fixes #18745.

Removes a call to give focus to the menu bar upon clicking an item, which was introduced in #15302 to improve menu bar a11y.


cc @brenca @javan 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed bug where inputs would lose focus when opening the menu bar, preventing many menu items (Edit/Copy/Paste/etc.) to be unusable on Windows and Linux.
