### PR TITLE
test: remove ffi specs

### DIFF
--- a/spec/modules-spec.js
+++ b/spec/modules-spec.js
@@ -54,26 +54,6 @@ describe('modules support', () => {
       }
     })
 
-    // TODO(alexeykuzmin): Disabled during the Chromium 62 (Node.js 9) upgrade.
-    // Enable it back when "ffi" module supports Node.js 9.
-    // https://github.com/electron/electron/issues/11274
-    xdescribe('ffi', () => {
-      before(function () {
-        if (!nativeModulesEnabled || process.platform === 'win32' ||
-            process.arch === 'arm64') {
-          this.skip()
-        }
-      })
-
-      it('does not crash', () => {
-        const ffi = require('ffi')
-        const libm = ffi.Library('libm', {
-          ceil: ['double', ['double']]
-        })
-        expect(libm.ceil(1.5)).to.equal(2)
-      })
-    })
-
     describe('q', () => {
       const Q = require('q')
       describe('Q.when', () => {


### PR DESCRIPTION
#### Description of Change

Removes broken `ffi` specs, which have been disabled for two years. The ffi module does now support Node.js 9, but we're on Node.js v12, and there is no support for that either in the main module or its transitive dependency `ref`, which doesn't use a V8 version compatible with the one bundled into 12 and so dies rather violently when one attempts to install it locally.

The [issue](https://github.com/electron/electron/issues/11274) can remain open but for now, version control exists, and so here we are.

cc @alexeykuzmin

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
