### PR TITLE
docs: update hasShadow to show it works on win and linux

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1437,19 +1437,15 @@ screen readers
 Sets a 16 x 16 pixel overlay onto the current taskbar icon, usually used to
 convey some sort of application status or to passively notify the user.
 
-#### `win.setHasShadow(hasShadow)` _macOS_
+#### `win.setHasShadow(hasShadow)`
 
 * `hasShadow` Boolean
 
-Sets whether the window should have a shadow. On Windows and Linux does
-nothing.
+Sets whether the window should have a shadow.
 
-#### `win.hasShadow()` _macOS_
+#### `win.hasShadow()`
 
 Returns `Boolean` - Whether the window has a shadow.
-
-On Windows and Linux always returns
-`true`.
 
 #### `win.setOpacity(opacity)` _Windows_ _macOS_
 

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -3338,21 +3338,27 @@ describe('BrowserWindow module', () => {
     })
 
     describe('hasShadow state', () => {
-      // On Windows there is no shadow by default and it can not be changed
-      // dynamically.
+      it('returns a boolean on all platforms', () => {
+        const w = new BrowserWindow({ show: false })
+        const hasShadow = w.hasShadow()
+        expect(hasShadow).to.be.a('boolean')
+      })
+
+      // On Windows there's no shadow by default & it can't be changed dynamically.
       it('can be changed with hasShadow option', () => {
         const hasShadow = process.platform !== 'darwin'
-        const w = new BrowserWindow({ show: false, hasShadow: hasShadow })
+        const w = new BrowserWindow({ show: false, hasShadow })
         expect(w.hasShadow()).to.equal(hasShadow)
       })
 
-      ifit(process.platform === 'darwin')('can be changed with setHasShadow method', () => {
+      it('can be changed with setHasShadow method', () => {
         const w = new BrowserWindow({ show: false })
-        expect(w.hasShadow()).to.be.true('hasShadow')
         w.setHasShadow(false)
         expect(w.hasShadow()).to.be.false('hasShadow')
         w.setHasShadow(true)
         expect(w.hasShadow()).to.be.true('hasShadow')
+        w.setHasShadow(false)
+        expect(w.hasShadow()).to.be.false('hasShadow')
       })
     })
   })


### PR DESCRIPTION
#### Description of Change

Turns out this has been implemented for [quite some time](https://github.com/electron/electron/commit/239bfe970cfa38ce0c9618977c3ee6b31319d797). I've updated the docs for it and removed some gating on the tests so it's tested cross-platform.

cc @zcbenz @ckerr @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
