### PR TITLE
feat: allow customization of print page header and footer

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1264,8 +1264,8 @@ Returns [`PrinterInfo[]`](structures/printer-info.md).
   * `dpi` Object (optional)
     * `horizontal` Number (optional) - The horizontal dpi.
     * `vertical` Number (optional) - The vertical dpi.
-  * `header` String - String to be printed as page header.
-  * `footer` String - String to be printed as page footer.
+  * `header` String (optional) - String to be printed as page header.
+  * `footer` String (optional) - String to be printed as page footer.
 * `callback` Function (optional)
   * `success` Boolean - Indicates success of the print call.
   * `failureReason` String - Called back if the print fails; can be `cancelled` or `failed`.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1264,6 +1264,9 @@ Returns [`PrinterInfo[]`](structures/printer-info.md).
   * `dpi` Object (optional)
     * `horizontal` Number (optional) - The horizontal dpi.
     * `vertical` Number (optional) - The vertical dpi.
+  * `headerFooterInfo` Object (optional)
+    * `header` String - String to be printed as page header.
+    * `footer` String - String to be printed as page footer.
 * `callback` Function (optional)
   * `success` Boolean - Indicates success of the print call.
   * `failureReason` String - Called back if the print fails; can be `cancelled` or `failed`.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1264,9 +1264,8 @@ Returns [`PrinterInfo[]`](structures/printer-info.md).
   * `dpi` Object (optional)
     * `horizontal` Number (optional) - The horizontal dpi.
     * `vertical` Number (optional) - The vertical dpi.
-  * `headerFooterInfo` Object (optional)
-    * `header` String - String to be printed as page header.
-    * `footer` String - String to be printed as page footer.
+  * `header` String - String to be printed as page header.
+  * `footer` String - String to be printed as page footer.
 * `callback` Function (optional)
   * `success` Boolean - Indicates success of the print call.
   * `failureReason` String - Called back if the print fails; can be `cancelled` or `failed`.

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -1637,20 +1637,20 @@ void WebContents::Print(mate::Arguments* args) {
                         printing::DEFAULT_MARGINS);
   }
 
-  settings.SetBoolean(printing::kSettingHeaderFooterEnabled, false);
-
   // Set whether to print color or greyscale
   bool print_color = true;
   options.Get("color", &print_color);
   int color_setting = print_color ? printing::COLOR : printing::GRAY;
   settings.SetInteger(printing::kSettingColor, color_setting);
 
+  // Is the orientation landscape or portrait.
   bool landscape = false;
   options.Get("landscape", &landscape);
   settings.SetBoolean(printing::kSettingLandscape, landscape);
 
   // We set the default to empty string here and only update
   // if at the Chromium level if it's non-empty
+  // Printer device name as opened by the OS.
   base::string16 device_name;
   options.Get("deviceName", &device_name);
   settings.SetString(printing::kSettingDeviceName, device_name);
@@ -1663,15 +1663,31 @@ void WebContents::Print(mate::Arguments* args) {
   options.Get("pagesPerSheet", &pages_per_sheet);
   settings.SetInteger(printing::kSettingPagesPerSheet, pages_per_sheet);
 
+  // True if the user wants to print with collate.
   bool collate = true;
   options.Get("collate", &collate);
   settings.SetBoolean(printing::kSettingCollate, collate);
 
+  // The number of individual copies to print
   int copies = 1;
   options.Get("copies", &copies);
   settings.SetInteger(printing::kSettingCopies, copies);
 
-  // For now we don't want to allow the user to enable these settings
+  // Strings to be printed as headers and footers if requested by the user.
+  mate::Dictionary header_footer;
+  if (options.Get("headerFooterInfo", &header_footer)) {
+    settings.SetBoolean(printing::kSettingHeaderFooterEnabled, true);
+
+    std::string header;
+    header_footer.Get("header", &header);
+    std::string footer;
+    header_footer.Get("footer", &footer);
+
+    settings.SetString(printing::kSettingHeaderFooterTitle, header);
+    settings.SetString(printing::kSettingHeaderFooterURL, footer);
+  }
+
+  // We don't want to allow the user to enable these settings
   // but we need to set them or a CHECK is hit.
   settings.SetBoolean(printing::kSettingPrintToPDF, false);
   settings.SetBoolean(printing::kSettingCloudPrintDialog, false);
@@ -1700,7 +1716,7 @@ void WebContents::Print(mate::Arguments* args) {
       settings.SetList(printing::kSettingPageRange, std::move(page_range_list));
   }
 
-  // Set custom duplex mode
+  // Duplex type user wants to use.
   printing::DuplexMode duplex_mode;
   options.Get("duplexMode", &duplex_mode);
   settings.SetInteger(printing::kSettingDuplexMode, duplex_mode);

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -1674,14 +1674,13 @@ void WebContents::Print(mate::Arguments* args) {
   settings.SetInteger(printing::kSettingCopies, copies);
 
   // Strings to be printed as headers and footers if requested by the user.
-  mate::Dictionary header_footer;
-  if (options.Get("headerFooterInfo", &header_footer)) {
-    settings.SetBoolean(printing::kSettingHeaderFooterEnabled, true);
+  std::string header;
+  options.Get("header", &header);
+  std::string footer;
+  options.Get("footer", &footer);
 
-    std::string header;
-    header_footer.Get("header", &header);
-    std::string footer;
-    header_footer.Get("footer", &footer);
+  if (!(header.empty() && footer.empty())) {
+    settings.SetBoolean(printing::kSettingHeaderFooterEnabled, true);
 
     settings.SetString(printing::kSettingHeaderFooterTitle, header);
     settings.SetString(printing::kSettingHeaderFooterURL, footer);


### PR DESCRIPTION
#### Description of Change

Refs: https://github.com/electron/electron/issues/17523

This PR allows users to customize print settings further by setting a custom header and footer by adding the following to print setting options:

```
  * `headerFooterInfo` Object (optional)
    * `header` String - String to be printed as page header.
    * `footer` String - String to be printed as page footer.
```

Tested to work with the following:

```js
win.webContents.print({
   copies: 2,
   headerFooterInfo: {
      header: 'ALL HAIL BLINI CAT',
      footer: 'https://imgur.com/gallery/jQecn'
   }
}, (success, reason) => {
   console.log(`printing ${success ? 'did' : 'did not'} succeed: ${reason}`)
})
```

and an html page containing one link to [this image](https://user-images.githubusercontent.com/2036040/62734356-b493b200-b9dd-11e9-9471-4246a00dee81.jpg)

cc @deepak1556 @brenca @jkleinsc 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added options to enable customization of print page headers and footers.
