### PR TITLE
feat: add property to accessible BrowserWindow window title

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -826,7 +826,9 @@ Menu.setApplicationMenu(menu)
 
 #### `win.accessibleTitle`
 
-A `String` property that defines a part of window title which is visible for the screen readers only.
+A `String` property that defines an alternative title provided only to
+accessibility tools such as screen readers. This string is not directly
+visible to users.
 
 ### Instance Methods
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -379,8 +379,9 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     * `disableHtmlFullscreenWindowResize` Boolean (optional) - Whether to
       prevent the window from resizing when entering HTML Fullscreen. Default
       is `false`.
-    * `accessibleTitle` String (optional) - a part of Window title visible for
-      the screen readers only.
+    * `accessibleTitle` String (optional) - An alternative title string provided only
+      to accessibility tools such as screen readers. This string is not directly
+      visible to users.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1227,6 +1227,16 @@ Returns `String` - The title of the native window.
 **Note:** The title of the web page can be different from the title of the native
 window.
 
+#### `win.setAccessibleTitle(title)`
+
+* `title` String
+
+Changes the accessible title of native window to `title`.
+
+#### `win.getAccessibleTitle()`
+
+Returns `String` - The accessible title of native window (or an empty string if none).
+
 #### `win.setSheetOffset(offsetY[, offsetX])` _macOS_
 
 * `offsetY` Float

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -379,6 +379,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     * `disableHtmlFullscreenWindowResize` Boolean (optional) - Whether to
       prevent the window from resizing when entering HTML Fullscreen. Default
       is `false`.
+    * `accessibleTitle` String (optional) - a part of Window title visible for
+      the screen readers only.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from
@@ -821,6 +823,10 @@ const menu = Menu.buildFromTemplate(template)
 Menu.setApplicationMenu(menu)
 ```
 
+#### `win.accessibleTitle`
+
+A `String` property that defines a part of window title which is visible for the screen readers only.
+
 ### Instance Methods
 
 Objects created with `new BrowserWindow` have the following instance methods:
@@ -1226,16 +1232,6 @@ Returns `String` - The title of the native window.
 
 **Note:** The title of the web page can be different from the title of the native
 window.
-
-#### `win.setAccessibleTitle(title)`
-
-* `title` String
-
-Changes the accessible title of native window to `title`.
-
-#### `win.getAccessibleTitle()`
-
-Returns `String` - The accessible title of native window (or an empty string if none).
 
 #### `win.setSheetOffset(offsetY[, offsetX])` _macOS_
 

--- a/shell/browser/api/atom_api_top_level_window.cc
+++ b/shell/browser/api/atom_api_top_level_window.cc
@@ -565,6 +565,14 @@ std::string TopLevelWindow::GetTitle() {
   return window_->GetTitle();
 }
 
+void TopLevelWindow::SetAccessibleTitle(const std::string& title) {
+  window_->SetAccessibleTitle(title);
+}
+
+std::string TopLevelWindow::GetAccessibleTitle() {
+  return window_->GetAccessibleTitle();
+}
+
 void TopLevelWindow::FlashFrame(bool flash) {
   window_->FlashFrame(flash);
 }
@@ -1108,6 +1116,8 @@ void TopLevelWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("getPosition", &TopLevelWindow::GetPosition)
       .SetMethod("setTitle", &TopLevelWindow::SetTitle)
       .SetMethod("getTitle", &TopLevelWindow::GetTitle)
+      .SetMethod("setAccessibleTitle", &TopLevelWindow::SetAccessibleTitle)
+      .SetMethod("getAccessibleTitle", &TopLevelWindow::GetAccessibleTitle)
       .SetMethod("flashFrame", &TopLevelWindow::FlashFrame)
       .SetMethod("setSkipTaskbar", &TopLevelWindow::SetSkipTaskbar)
       .SetMethod("setSimpleFullScreen", &TopLevelWindow::SetSimpleFullScreen)

--- a/shell/browser/api/atom_api_top_level_window.cc
+++ b/shell/browser/api/atom_api_top_level_window.cc
@@ -1116,8 +1116,8 @@ void TopLevelWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("getPosition", &TopLevelWindow::GetPosition)
       .SetMethod("setTitle", &TopLevelWindow::SetTitle)
       .SetMethod("getTitle", &TopLevelWindow::GetTitle)
-      .SetMethod("setAccessibleTitle", &TopLevelWindow::SetAccessibleTitle)
-      .SetMethod("getAccessibleTitle", &TopLevelWindow::GetAccessibleTitle)
+      .SetProperty("accessibleTitle", &TopLevelWindow::GetAccessibleTitle,
+                   &TopLevelWindow::SetAccessibleTitle)
       .SetMethod("flashFrame", &TopLevelWindow::FlashFrame)
       .SetMethod("setSkipTaskbar", &TopLevelWindow::SetSkipTaskbar)
       .SetMethod("setSimpleFullScreen", &TopLevelWindow::SetSimpleFullScreen)

--- a/shell/browser/api/atom_api_top_level_window.h
+++ b/shell/browser/api/atom_api_top_level_window.h
@@ -144,6 +144,8 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
   std::vector<int> GetPosition();
   void SetTitle(const std::string& title);
   std::string GetTitle();
+  void SetAccessibleTitle(const std::string& title);
+  std::string GetAccessibleTitle();
   void FlashFrame(bool flash);
   void SetSkipTaskbar(bool skip);
   void SetExcludedFromShownWindowsMenu(bool excluded);

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -587,15 +587,15 @@ base::string16 NativeWindow::GetAccessibleWindowTitle() const {
     return views::WidgetDelegate::GetAccessibleWindowTitle();
   }
 
-  return base::UTF8ToUTF16(accessible_title_);
+  return accessible_title_;
 }
 
 void NativeWindow::SetAccessibleTitle(const std::string& title) {
-  accessible_title_ = title;
+  accessible_title_ = base::UTF8ToUTF16(title);
 }
 
 std::string NativeWindow::GetAccessibleTitle() {
-  return accessible_title_;
+  return base::UTF16ToUTF8(accessible_title_);
 }
 
 // static

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -582,6 +582,22 @@ const views::Widget* NativeWindow::GetWidget() const {
   return widget();
 }
 
+base::string16 NativeWindow::GetAccessibleWindowTitle() const {
+  if (accessible_title_.empty()) {
+    return views::WidgetDelegate::GetAccessibleWindowTitle();
+  }
+
+  return base::UTF8ToUTF16(accessible_title_);
+}
+
+void NativeWindow::SetAccessibleTitle(const std::string& title) {
+  accessible_title_ = title;
+}
+
+std::string NativeWindow::GetAccessibleTitle() {
+  return accessible_title_;
+}
+
 // static
 void NativeWindowRelay::CreateForWebContents(
     content::WebContents* web_contents,

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -132,6 +132,12 @@ class NativeWindow : public base::SupportsUserData,
   virtual void Invalidate() = 0;
   virtual void SetTitle(const std::string& title) = 0;
   virtual std::string GetTitle() = 0;
+
+  // Ability to augment the window title for the screen readers.
+  base::string16 GetAccessibleWindowTitle() const override;
+  void SetAccessibleTitle(const std::string& title);
+  std::string GetAccessibleTitle();
+
   virtual void FlashFrame(bool flash) = 0;
   virtual void SetSkipTaskbar(bool skip) = 0;
   virtual void SetExcludedFromShownWindowsMenu(bool excluded) = 0;
@@ -351,6 +357,9 @@ class NativeWindow : public base::SupportsUserData,
 
   // Observers of this window.
   base::ObserverList<NativeWindowObserver> observers_;
+
+  // Accessible title.
+  std::string accessible_title_;
 
   base::WeakPtrFactory<NativeWindow> weak_factory_;
 

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -134,7 +134,6 @@ class NativeWindow : public base::SupportsUserData,
   virtual std::string GetTitle() = 0;
 
   // Ability to augment the window title for the screen readers.
-  base::string16 GetAccessibleWindowTitle() const override;
   void SetAccessibleTitle(const std::string& title);
   std::string GetAccessibleTitle();
 
@@ -304,6 +303,7 @@ class NativeWindow : public base::SupportsUserData,
   // views::WidgetDelegate:
   views::Widget* GetWidget() override;
   const views::Widget* GetWidget() const override;
+  base::string16 GetAccessibleWindowTitle() const override;
 
   void set_content_view(views::View* view) { content_view_ = view; }
 

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -359,7 +359,7 @@ class NativeWindow : public base::SupportsUserData,
   base::ObserverList<NativeWindowObserver> observers_;
 
   // Accessible title.
-  std::string accessible_title_;
+  base::string16 accessible_title_;
 
   base::WeakPtrFactory<NativeWindow> weak_factory_;
 


### PR DESCRIPTION
#### Description of Change

Sometimes it's necessary to convey more information about the window to the screen reader users only (simply putting everything to the window title might be unnecessarily noisy).

For example, Chromium uses that technique to tell the screen reader users that the window is in incognito mode (the incognito window looks differently and doesn't have «incognito» in the title, but for the blind users the screen reader will announce that it's incognito).

Chromium has GetAccessibleWindowTitle() method internally. This PR exposes a way to customize the accessible title via Electron API.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `win.accessibleTitle property` to be able to augment the window title for the screen readers.