### PR TITLE
feat: macOS removal fallback when moveItemToTrash fails

### DIFF
--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -43,11 +43,12 @@ Returns `Promise<void>`
 
 Open the given external protocol URL in the desktop's default manner. (For example, mailto: URLs in the user's default mail agent).
 
-### `shell.moveItemToTrash(fullPath)`
+### `shell.moveItemToTrash(fullPath[, deleteOnFail])`
 
 * `fullPath` String
+* `deleteOnFail` Boolean (optional) - Whether or not to unilaterally remove the item if the Trash is disabled or unsupported on the volume. _macOS_
 
-Returns `Boolean` - Whether the item was successfully moved to the trash.
+Returns `Boolean` - Whether the item was successfully moved to the trash or otherwise deleted.
 
 Move the given file to trash and returns a boolean status for the operation.
 

--- a/shell/common/api/atom_api_shell.cc
+++ b/shell/common/api/atom_api_shell.cc
@@ -71,6 +71,13 @@ v8::Local<v8::Promise> OpenExternal(const GURL& url, mate::Arguments* args) {
   return handle;
 }
 
+bool MoveItemToTrash(const base::FilePath& full_path, mate::Arguments* args) {
+  bool delete_on_fail = false;
+  args->GetNext(&delete_on_fail);
+
+  return platform_util::MoveItemToTrash(full_path, delete_on_fail);
+}
+
 #if defined(OS_WIN)
 bool WriteShortcutLink(const base::FilePath& shortcut_path,
                        mate::Arguments* args) {
@@ -134,7 +141,7 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("showItemInFolder", &platform_util::ShowItemInFolder);
   dict.SetMethod("openItem", &platform_util::OpenItem);
   dict.SetMethod("openExternal", &OpenExternal);
-  dict.SetMethod("moveItemToTrash", &platform_util::MoveItemToTrash);
+  dict.SetMethod("moveItemToTrash", &MoveItemToTrash);
   dict.SetMethod("beep", &platform_util::Beep);
 #if defined(OS_WIN)
   dict.SetMethod("writeShortcutLink", &WriteShortcutLink);

--- a/shell/common/api/atom_api_shell.cc
+++ b/shell/common/api/atom_api_shell.cc
@@ -71,7 +71,10 @@ v8::Local<v8::Promise> OpenExternal(const GURL& url, mate::Arguments* args) {
   return handle;
 }
 
-bool MoveItemToTrash(const base::FilePath& full_path, mate::Arguments* args) {
+bool MoveItemToTrash(mate::Arguments* args) {
+  base::FilePath full_path;
+  args->GetNext(&full_path);
+
   bool delete_on_fail = false;
   args->GetNext(&delete_on_fail);
 

--- a/shell/common/platform_util.h
+++ b/shell/common/platform_util.h
@@ -10,7 +10,6 @@
 #include "base/callback_forward.h"
 #include "base/files/file_path.h"
 #include "build/build_config.h"
-#include "native_mate/arguments.h"
 
 #if defined(OS_WIN)
 #include "base/strings/string16.h"
@@ -42,7 +41,7 @@ void OpenExternal(const GURL& url,
                   OpenExternalCallback callback);
 
 // Move a file to trash.
-bool MoveItemToTrash(const base::FilePath& full_path, mate::Arguments* args);
+bool MoveItemToTrash(const base::FilePath& full_path, bool delete_on_fail);
 
 void Beep();
 

--- a/shell/common/platform_util.h
+++ b/shell/common/platform_util.h
@@ -10,6 +10,7 @@
 #include "base/callback_forward.h"
 #include "base/files/file_path.h"
 #include "build/build_config.h"
+#include "native_mate/arguments.h"
 
 #if defined(OS_WIN)
 #include "base/strings/string16.h"
@@ -41,7 +42,7 @@ void OpenExternal(const GURL& url,
                   OpenExternalCallback callback);
 
 // Move a file to trash.
-bool MoveItemToTrash(const base::FilePath& full_path);
+bool MoveItemToTrash(const base::FilePath& full_path, mate::Arguments* args);
 
 void Beep();
 

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -82,7 +82,7 @@ void OpenExternal(const GURL& url,
     std::move(callback).Run(XDGOpen(url.spec(), false) ? "" : "Failed to open");
 }
 
-bool MoveItemToTrash(const base::FilePath& full_path, mate::Arguments* args) {
+bool MoveItemToTrash(const base::FilePath& full_path, bool delete_on_fail) {
   std::unique_ptr<base::Environment> env(base::Environment::Create());
 
   // find the trash method

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -82,7 +82,7 @@ void OpenExternal(const GURL& url,
     std::move(callback).Run(XDGOpen(url.spec(), false) ? "" : "Failed to open");
 }
 
-bool MoveItemToTrash(const base::FilePath& full_path) {
+bool MoveItemToTrash(const base::FilePath& full_path, mate::Arguments* args) {
   std::unique_ptr<base::Environment> env(base::Environment::Create());
 
   // find the trash method

--- a/shell/common/platform_util_mac.mm
+++ b/shell/common/platform_util_mac.mm
@@ -115,10 +115,10 @@ void OpenExternal(const GURL& url,
                  });
 }
 
-bool MoveItemToTrash(const base::FilePath& full_path, mate::Arguments* args) {
+bool MoveItemToTrash(const base::FilePath& full_path, bool delete_on_fail) {
   NSString* path_string = base::SysUTF8ToNSString(full_path.value());
   if (!path_string) {
-    args->ThrowError("moveItemToTrash(): Invalid path.");
+    LOG(WARNING) << "Invalid file path " << full_path.value();
     return false;
   }
 
@@ -128,8 +128,7 @@ bool MoveItemToTrash(const base::FilePath& full_path, mate::Arguments* args) {
                                                  resultingItemURL:nil
                                                             error:&err];
 
-  bool delete_on_fail = false;
-  if (args->GetNext(&delete_on_fail) && delete_on_fail) {
+  if (delete_on_fail) {
     // Some volumes may not support a Trash folder or it may be disabled
     // so these methods will report failure by returning NO or nil and
     // an NSError with NSFeatureUnsupportedError.

--- a/shell/common/platform_util_mac.mm
+++ b/shell/common/platform_util_mac.mm
@@ -115,16 +115,36 @@ void OpenExternal(const GURL& url,
                  });
 }
 
-bool MoveItemToTrash(const base::FilePath& full_path) {
+bool MoveItemToTrash(const base::FilePath& full_path, mate::Arguments* args) {
   NSString* path_string = base::SysUTF8ToNSString(full_path.value());
-  BOOL status = [[NSFileManager defaultManager]
-        trashItemAtURL:[NSURL fileURLWithPath:path_string]
-      resultingItemURL:nil
-                 error:nil];
-  if (!path_string || !status)
+  if (!path_string) {
+    args->ThrowError("moveItemToTrash(): Invalid path.");
+    return false;
+  }
+
+  NSURL* url = [NSURL fileURLWithPath:path_string];
+  NSError* err = nil;
+  BOOL did_trash = [[NSFileManager defaultManager] trashItemAtURL:url
+                                                 resultingItemURL:nil
+                                                            error:&err];
+
+  bool delete_on_fail = false;
+  if (args->GetNext(&delete_on_fail) && delete_on_fail) {
+    // Some volumes may not support a Trash folder or it may be disabled
+    // so these methods will report failure by returning NO or nil and
+    // an NSError with NSFeatureUnsupportedError.
+    // Handle this by deleting the item as a fallback.
+    if (!did_trash && [err code] == NSFeatureUnsupportedError) {
+      did_trash = [[NSFileManager defaultManager] removeItemAtURL:url
+                                                            error:nil];
+    }
+  }
+
+  if (!did_trash)
     LOG(WARNING) << "NSWorkspace failed to move file " << full_path.value()
                  << " to trash";
-  return status;
+
+  return did_trash;
 }
 
 void Beep() {

--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -335,7 +335,7 @@ void OpenExternal(const GURL& url,
       std::move(callback));
 }
 
-bool MoveItemToTrash(const base::FilePath& path, mate::Arguments* args) {
+bool MoveItemToTrash(const base::FilePath& path, bool delete_on_fail) {
   base::win::ScopedCOMInitializer com_initializer;
   if (!com_initializer.Succeeded())
     return false;

--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -335,7 +335,7 @@ void OpenExternal(const GURL& url,
       std::move(callback));
 }
 
-bool MoveItemToTrash(const base::FilePath& path) {
+bool MoveItemToTrash(const base::FilePath& path, mate::Arguments* args) {
   base::win::ScopedCOMInitializer com_initializer;
   if (!com_initializer.Succeeded())
     return false;


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/4974.

Some macOS volumes may not support a Trash folder or it may be disabled, so these methods will report failure by returning NO or `nil` and an `NSError` with `NSFeatureUnsupportedError`.

This enables consumers to handle this by optionally passing a boolean `deleteOnFail` value to indicate whether or not the item should be unilaterally deleted if the `NSFileManager` fails to execute `trashItemAtURL`.

cc @miniak @ckerr @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Enable macOS users to fallback to item removal when when `shell.moveItemToTrash` fails.
