### PR TITLE
fix: make sure that menu bar gets focus even when you click an item to focus it first

### DIFF
--- a/shell/browser/ui/views/menu_bar.cc
+++ b/shell/browser/ui/views/menu_bar.cc
@@ -268,6 +268,12 @@ void MenuBar::OnMenuButtonClicked(views::Button* source,
   if (!window_->HasFocus())
     window_->RequestFocus();
 
+  // This ensures that if you focus the menubar by clicking on an item, you can
+  // still use the arrow keys to move around
+  if (GetPaneFocusTraversable() == nullptr) {
+    SetPaneFocus(source);
+  }
+
   int id = source->tag();
   AtomMenuModel::ItemType type = menu_model_->GetTypeAt(id);
   if (type != AtomMenuModel::TYPE_SUBMENU) {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Pretty much what the title says, right now, if you click on the menu bar and hit `Esc`, you can't use the arrow keys to navigate because the menu bar itself never got focus. This fixes that.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a bug where you couldn't navigate the menu bar with the keyboard if you used the mouse to focus it.<!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
