### PR TITLE
build: fix nightly install command in release notes

### DIFF
--- a/script/release/prepare-release.js
+++ b/script/release/prepare-release.js
@@ -90,7 +90,7 @@ async function createRelease (branchToTarget, isBeta) {
       releaseBody = `Note: This is a nightly release.  Please file new issues ` +
         `for any bugs you find in it.\n \n This release is published to npm ` +
         `under the nightly tag and can be installed via npm install electron@nightly, ` +
-        `or npm i electron@${newVersion.substr(1)}.\n \n ${releaseNotes.text}`
+        `or npm i electron-nightly@${newVersion.substr(1)}.\n \n ${releaseNotes.text}`
     } else {
       releaseBody = `Note: This is a beta release.  Please file new issues ` +
         `for any bugs you find in it.\n \n This release is published to npm ` +


### PR DESCRIPTION
We publish nightlies to `electron-nightly` nowadays

Notes: no-notes