### PR TITLE
docs: fix app.on('session-created' example

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -390,7 +390,7 @@ Emitted when Electron has created a new `session`.
 ```javascript
 const { app } = require('electron')
 
-app.on('session-created', (event, session) => {
+app.on('session-created', (session) => {
   console.log(session)
 })
 ```


### PR DESCRIPTION
It does not have the 'event' argument.

Refs: https://github.com/electron/electron/pull/12123, https://github.com/electron/electron/pull/15236, https://github.com/electron/electron/issues/15203.

/cc @JakeH, @ckerr, @MarshallOfSound 

#### Description of Change

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes
