### PR TITLE
feat: migrate webRequest module to NetworkService (Part 5)

### DIFF
--- a/shell/browser/api/atom_api_session.cc
+++ b/shell/browser/api/atom_api_session.cc
@@ -575,7 +575,7 @@ v8::Local<v8::Value> Session::Protocol(v8::Isolate* isolate) {
 
 v8::Local<v8::Value> Session::WebRequest(v8::Isolate* isolate) {
   if (web_request_.IsEmpty()) {
-    auto handle = WebRequestNS::Create(isolate, browser_context());
+    auto handle = WebRequestNS::FromOrCreate(isolate, browser_context());
     web_request_.Reset(isolate, handle.ToV8());
   }
   return v8::Local<v8::Value>::New(isolate, web_request_);

--- a/shell/browser/api/atom_api_session.cc
+++ b/shell/browser/api/atom_api_session.cc
@@ -577,7 +577,7 @@ v8::Local<v8::Value> Session::Protocol(v8::Isolate* isolate) {
 
 v8::Local<v8::Value> Session::WebRequest(v8::Isolate* isolate) {
   if (web_request_.IsEmpty()) {
-    auto handle = WebRequestNS::FromOrCreate(isolate, browser_context());
+    auto handle = WebRequestNS::Create(isolate, browser_context());
     web_request_.Reset(isolate, handle.ToV8());
   }
   return v8::Local<v8::Value>::New(isolate, web_request_);

--- a/shell/browser/api/atom_api_session.cc
+++ b/shell/browser/api/atom_api_session.cc
@@ -206,8 +206,10 @@ Session::Session(v8::Isolate* isolate, AtomBrowserContext* browser_context)
 Session::~Session() {
   content::BrowserContext::GetDownloadManager(browser_context())
       ->RemoveObserver(this);
+  // TODO(zcbenz): Now since URLRequestContextGetter is gone, is this still
+  // needed?
+  // Refs https://github.com/electron/electron/pull/12305.
   DestroyGlobalHandle(isolate(), cookies_);
-  DestroyGlobalHandle(isolate(), web_request_);
   DestroyGlobalHandle(isolate(), protocol_);
   DestroyGlobalHandle(isolate(), net_log_);
   g_sessions.erase(weak_map_id());

--- a/shell/browser/api/atom_api_session.h
+++ b/shell/browser/api/atom_api_session.h
@@ -100,11 +100,13 @@ class Session : public mate::TrackableObject<Session>,
                          download::DownloadItem* item) override;
 
  private:
-  // Cached object.
+  // Cached mate::Wrappable objects.
   v8::Global<v8::Value> cookies_;
   v8::Global<v8::Value> protocol_;
-  v8::Global<v8::Value> web_request_;
   v8::Global<v8::Value> net_log_;
+
+  // Cached object.
+  v8::Global<v8::Value> web_request_;
 
   // The client id to enable the network throttler.
   base::UnguessableToken network_emulation_token_;

--- a/shell/browser/api/atom_api_web_request_ns.cc
+++ b/shell/browser/api/atom_api_web_request_ns.cc
@@ -81,6 +81,36 @@ const char* WebRequestNS::GetTypeName() {
   return "WebRequest";
 }
 
+int WebRequestNS::OnBeforeRequest(net::CompletionOnceCallback callback,
+                                  GURL* new_url) {
+  return net::OK;
+}
+
+int WebRequestNS::OnBeforeSendHeaders(BeforeSendHeadersCallback callback,
+                                      net::HttpRequestHeaders* headers) {
+  return net::OK;
+}
+
+int WebRequestNS::OnHeadersReceived(
+    net::CompletionOnceCallback callback,
+    const net::HttpResponseHeaders* original_response_headers,
+    scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
+    GURL* allowed_unsafe_redirect_url) {
+  return net::OK;
+}
+
+void WebRequestNS::OnSendHeaders(const net::HttpRequestHeaders& headers) {}
+
+void WebRequestNS::OnBeforeRedirect(const GURL& new_location) {}
+
+void WebRequestNS::OnResponseStarted(int net_error) {}
+
+void WebRequestNS::OnErrorOccurred(int net_error) {}
+
+void WebRequestNS::OnCompleted(int net_error) {}
+
+void WebRequestNS::OnResponseStarted() {}
+
 template <WebRequestNS::SimpleEvent event>
 void WebRequestNS::SetSimpleListener(gin::Arguments* args) {
   SetListener<SimpleListener, SimpleEvent>(event, args);

--- a/shell/browser/api/atom_api_web_request_ns.cc
+++ b/shell/browser/api/atom_api_web_request_ns.cc
@@ -95,17 +95,20 @@ const char* WebRequestNS::GetTypeName() {
   return "WebRequest";
 }
 
-int WebRequestNS::OnBeforeRequest(net::CompletionOnceCallback callback,
+int WebRequestNS::OnBeforeRequest(const network::ResourceRequest& request,
+                                  net::CompletionOnceCallback callback,
                                   GURL* new_url) {
   return net::OK;
 }
 
-int WebRequestNS::OnBeforeSendHeaders(BeforeSendHeadersCallback callback,
+int WebRequestNS::OnBeforeSendHeaders(const network::ResourceRequest& request,
+                                      BeforeSendHeadersCallback callback,
                                       net::HttpRequestHeaders* headers) {
   return net::OK;
 }
 
 int WebRequestNS::OnHeadersReceived(
+    const network::ResourceRequest& request,
     net::CompletionOnceCallback callback,
     const net::HttpResponseHeaders* original_response_headers,
     scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
@@ -113,17 +116,26 @@ int WebRequestNS::OnHeadersReceived(
   return net::OK;
 }
 
-void WebRequestNS::OnSendHeaders(const net::HttpRequestHeaders& headers) {}
+void WebRequestNS::OnSendHeaders(const network::ResourceRequest& request,
+                                 const net::HttpRequestHeaders& headers) {}
 
-void WebRequestNS::OnBeforeRedirect(const GURL& new_location) {}
+void WebRequestNS::OnBeforeRedirect(
+    const network::ResourceRequest& request,
+    const network::ResourceResponseHead& response,
+    const GURL& new_location) {}
 
-void WebRequestNS::OnResponseStarted(int net_error) {}
+void WebRequestNS::OnResponseStarted(
+    const network::ResourceRequest& request,
+    const network::ResourceResponseHead& response) {}
 
-void WebRequestNS::OnErrorOccurred(int net_error) {}
+void WebRequestNS::OnErrorOccurred(
+    const network::ResourceRequest& request,
+    const network::ResourceResponseHead& response,
+    int net_error) {}
 
-void WebRequestNS::OnCompleted(int net_error) {}
-
-void WebRequestNS::OnResponseStarted() {}
+void WebRequestNS::OnCompleted(const network::ResourceRequest& request,
+                               const network::ResourceResponseHead& response,
+                               int net_error) {}
 
 template <WebRequestNS::SimpleEvent event>
 void WebRequestNS::SetSimpleListener(gin::Arguments* args) {

--- a/shell/browser/api/atom_api_web_request_ns.h
+++ b/shell/browser/api/atom_api_web_request_ns.h
@@ -29,10 +29,23 @@ class WebRequestNS : public gin::Wrappable<WebRequestNS>, public WebRequestAPI {
  public:
   static gin::WrapperInfo kWrapperInfo;
 
+  // Return the WebRequest object attached to |browser_context|, create if there
+  // is no one.
+  // Note that the lifetime of WebRequest object is managed by Session, instead
+  // of the caller.
   static gin::Handle<WebRequestNS> FromOrCreate(
       v8::Isolate* isolate,
       content::BrowserContext* browser_context);
-  static WebRequestNS* From(content::BrowserContext* browser_context);
+
+  // Return a new WebRequest object, this should only be called by Session.
+  static gin::Handle<WebRequestNS> Create(
+      v8::Isolate* isolate,
+      content::BrowserContext* browser_context);
+
+  // Find the WebRequest object attached to |browser_context|.
+  static gin::Handle<WebRequestNS> From(
+      v8::Isolate* isolate,
+      content::BrowserContext* browser_context);
 
   // gin::Wrappable:
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(

--- a/shell/browser/api/atom_api_web_request_ns.h
+++ b/shell/browser/api/atom_api_web_request_ns.h
@@ -44,32 +44,26 @@ class WebRequestNS : public gin::Wrappable<WebRequestNS>, public WebRequestAPI {
   ~WebRequestNS() override;
 
   // WebRequestAPI:
-  int OnBeforeRequest(const network::ResourceRequest& request,
+  int OnBeforeRequest(extensions::WebRequestInfo* request,
                       net::CompletionOnceCallback callback,
                       GURL* new_url) override;
-  int OnBeforeSendHeaders(const network::ResourceRequest& request,
+  int OnBeforeSendHeaders(extensions::WebRequestInfo* request,
                           BeforeSendHeadersCallback callback,
                           net::HttpRequestHeaders* headers) override;
   int OnHeadersReceived(
-      const network::ResourceRequest& request,
+      extensions::WebRequestInfo* request,
       net::CompletionOnceCallback callback,
       const net::HttpResponseHeaders* original_response_headers,
       scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
       GURL* allowed_unsafe_redirect_url) override;
-  void OnSendHeaders(const network::ResourceRequest& request,
+  void OnSendHeaders(extensions::WebRequestInfo* request,
                      const net::HttpRequestHeaders& headers) override;
-  void OnBeforeRedirect(const network::ResourceRequest& request,
-                        const network::ResourceResponseHead& response,
+  void OnBeforeRedirect(extensions::WebRequestInfo* request,
                         const GURL& new_location) override;
-  void OnResponseStarted(
-      const network::ResourceRequest& request,
-      const network::ResourceResponseHead& response) override;
-  void OnErrorOccurred(const network::ResourceRequest& request,
-                       const network::ResourceResponseHead& response,
+  void OnResponseStarted(extensions::WebRequestInfo* request) override;
+  void OnErrorOccurred(extensions::WebRequestInfo* request,
                        int net_error) override;
-  void OnCompleted(const network::ResourceRequest& request,
-                   const network::ResourceResponseHead& response,
-                   int net_error) override;
+  void OnCompleted(extensions::WebRequestInfo* request, int net_error) override;
 
   enum SimpleEvent {
     kOnSendHeaders,
@@ -98,11 +92,11 @@ class WebRequestNS : public gin::Wrappable<WebRequestNS>, public WebRequestAPI {
 
   template <typename... Args>
   void HandleSimpleEvent(SimpleEvent event,
-                         const network::ResourceRequest& request,
+                         extensions::WebRequestInfo* request,
                          Args... args);
   template <typename Out, typename... Args>
   int HandleResponseEvent(ResponseEvent event,
-                          const network::ResourceRequest& request,
+                          extensions::WebRequestInfo* request,
                           net::CompletionOnceCallback callback,
                           Out out,
                           Args... args);

--- a/shell/browser/api/atom_api_web_request_ns.h
+++ b/shell/browser/api/atom_api_web_request_ns.h
@@ -39,6 +39,23 @@ class WebRequestNS : public gin::Wrappable<WebRequestNS>, public WebRequestAPI {
   WebRequestNS(v8::Isolate* isolate, content::BrowserContext* browser_context);
   ~WebRequestNS() override;
 
+  // WebRequestAPI:
+  int OnBeforeRequest(net::CompletionOnceCallback callback,
+                      GURL* new_url) override;
+  int OnBeforeSendHeaders(BeforeSendHeadersCallback callback,
+                          net::HttpRequestHeaders* headers) override;
+  int OnHeadersReceived(
+      net::CompletionOnceCallback callback,
+      const net::HttpResponseHeaders* original_response_headers,
+      scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
+      GURL* allowed_unsafe_redirect_url) override;
+  void OnSendHeaders(const net::HttpRequestHeaders& headers) override;
+  void OnBeforeRedirect(const GURL& new_location) override;
+  void OnResponseStarted() override;
+  void OnErrorOccurred(int net_error) override;
+  void OnCompleted(int net_error) override;
+  void OnResponseStarted(int net_error) override;
+
   enum SimpleEvent {
     kOnSendHeaders,
     kOnBeforeRedirect,

--- a/shell/browser/api/atom_api_web_request_ns.h
+++ b/shell/browser/api/atom_api_web_request_ns.h
@@ -44,21 +44,32 @@ class WebRequestNS : public gin::Wrappable<WebRequestNS>, public WebRequestAPI {
   ~WebRequestNS() override;
 
   // WebRequestAPI:
-  int OnBeforeRequest(net::CompletionOnceCallback callback,
+  int OnBeforeRequest(const network::ResourceRequest& request,
+                      net::CompletionOnceCallback callback,
                       GURL* new_url) override;
-  int OnBeforeSendHeaders(BeforeSendHeadersCallback callback,
+  int OnBeforeSendHeaders(const network::ResourceRequest& request,
+                          BeforeSendHeadersCallback callback,
                           net::HttpRequestHeaders* headers) override;
   int OnHeadersReceived(
+      const network::ResourceRequest& request,
       net::CompletionOnceCallback callback,
       const net::HttpResponseHeaders* original_response_headers,
       scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
       GURL* allowed_unsafe_redirect_url) override;
-  void OnSendHeaders(const net::HttpRequestHeaders& headers) override;
-  void OnBeforeRedirect(const GURL& new_location) override;
-  void OnResponseStarted() override;
-  void OnErrorOccurred(int net_error) override;
-  void OnCompleted(int net_error) override;
-  void OnResponseStarted(int net_error) override;
+  void OnSendHeaders(const network::ResourceRequest& request,
+                     const net::HttpRequestHeaders& headers) override;
+  void OnBeforeRedirect(const network::ResourceRequest& request,
+                        const network::ResourceResponseHead& response,
+                        const GURL& new_location) override;
+  void OnResponseStarted(
+      const network::ResourceRequest& request,
+      const network::ResourceResponseHead& response) override;
+  void OnErrorOccurred(const network::ResourceRequest& request,
+                       const network::ResourceResponseHead& response,
+                       int net_error) override;
+  void OnCompleted(const network::ResourceRequest& request,
+                   const network::ResourceResponseHead& response,
+                   int net_error) override;
 
   enum SimpleEvent {
     kOnSendHeaders,

--- a/shell/browser/api/atom_api_web_request_ns.h
+++ b/shell/browser/api/atom_api_web_request_ns.h
@@ -122,6 +122,9 @@ class WebRequestNS : public gin::Wrappable<WebRequestNS>, public WebRequestAPI {
   std::map<SimpleEvent, SimpleListenerInfo> simple_listeners_;
   std::map<ResponseEvent, ResponseListenerInfo> response_listeners_;
   std::map<uint64_t, net::CompletionOnceCallback> callbacks_;
+
+  // Weak-ref, it manages us.
+  content::BrowserContext* browser_context_;
 };
 
 }  // namespace api

--- a/shell/browser/api/atom_api_web_request_ns.h
+++ b/shell/browser/api/atom_api_web_request_ns.h
@@ -96,6 +96,17 @@ class WebRequestNS : public gin::Wrappable<WebRequestNS>, public WebRequestAPI {
   template <typename Listener, typename Listeners, typename Event>
   void SetListener(Event event, Listeners* listeners, gin::Arguments* args);
 
+  template <typename... Args>
+  void HandleSimpleEvent(SimpleEvent event,
+                         const network::ResourceRequest& request,
+                         Args... args);
+  template <typename Out, typename... Args>
+  int HandleResponseEvent(ResponseEvent event,
+                          const network::ResourceRequest& request,
+                          net::CompletionOnceCallback callback,
+                          Out out,
+                          Args... args);
+
   struct SimpleListenerInfo {
     std::set<URLPattern> url_patterns;
     SimpleListener listener;

--- a/shell/browser/api/atom_api_web_request_ns.h
+++ b/shell/browser/api/atom_api_web_request_ns.h
@@ -11,19 +11,24 @@
 #include "gin/wrappable.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/handle.h"
+#include "shell/browser/net/proxying_url_loader_factory.h"
+
+namespace content {
+class BrowserContext;
+}
 
 namespace electron {
 
-class AtomBrowserContext;
-
 namespace api {
 
-class WebRequestNS : public gin::Wrappable<WebRequestNS> {
+class WebRequestNS : public gin::Wrappable<WebRequestNS>, public WebRequestAPI {
  public:
   static gin::WrapperInfo kWrapperInfo;
 
-  static gin::Handle<WebRequestNS> Create(v8::Isolate* isolate,
-                                          AtomBrowserContext* browser_context);
+  static gin::Handle<WebRequestNS> FromOrCreate(
+      v8::Isolate* isolate,
+      content::BrowserContext* browser_context);
+  static WebRequestNS* From(content::BrowserContext* browser_context);
 
   // gin::Wrappable:
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
@@ -31,7 +36,7 @@ class WebRequestNS : public gin::Wrappable<WebRequestNS> {
   const char* GetTypeName() override;
 
  private:
-  WebRequestNS(v8::Isolate* isolate, AtomBrowserContext* browser_context);
+  WebRequestNS(v8::Isolate* isolate, content::BrowserContext* browser_context);
   ~WebRequestNS() override;
 
   enum SimpleEvent {

--- a/shell/browser/api/atom_api_web_request_ns.h
+++ b/shell/browser/api/atom_api_web_request_ns.h
@@ -5,7 +5,11 @@
 #ifndef SHELL_BROWSER_API_ATOM_API_WEB_REQUEST_NS_H_
 #define SHELL_BROWSER_API_ATOM_API_WEB_REQUEST_NS_H_
 
+#include <map>
+#include <set>
+
 #include "base/values.h"
+#include "extensions/common/url_pattern.h"
 #include "gin/arguments.h"
 #include "gin/handle.h"
 #include "gin/wrappable.h"
@@ -78,8 +82,30 @@ class WebRequestNS : public gin::Wrappable<WebRequestNS>, public WebRequestAPI {
   void SetSimpleListener(gin::Arguments* args);
   template <ResponseEvent event>
   void SetResponseListener(gin::Arguments* args);
-  template <typename Listener, typename Event>
-  void SetListener(Event event, gin::Arguments* args);
+  template <typename Listener, typename Listeners, typename Event>
+  void SetListener(Event event, Listeners* listeners, gin::Arguments* args);
+
+  struct SimpleListenerInfo {
+    std::set<URLPattern> url_patterns;
+    SimpleListener listener;
+
+    SimpleListenerInfo(std::set<URLPattern>, SimpleListener);
+    SimpleListenerInfo();
+    ~SimpleListenerInfo();
+  };
+
+  struct ResponseListenerInfo {
+    std::set<URLPattern> url_patterns;
+    ResponseListener listener;
+
+    ResponseListenerInfo(std::set<URLPattern>, ResponseListener);
+    ResponseListenerInfo();
+    ~ResponseListenerInfo();
+  };
+
+  std::map<SimpleEvent, SimpleListenerInfo> simple_listeners_;
+  std::map<ResponseEvent, ResponseListenerInfo> response_listeners_;
+  std::map<uint64_t, net::CompletionOnceCallback> callbacks_;
 };
 
 }  // namespace api

--- a/shell/browser/atom_browser_client.cc
+++ b/shell/browser/atom_browser_client.cc
@@ -980,7 +980,10 @@ bool AtomBrowserClient::WillCreateURLLoaderFactory(
     bool* bypass_redirect_checks) {
   content::WebContents* web_contents =
       content::WebContents::FromRenderFrameHost(frame_host);
-  DCHECK(web_contents);
+  // For service workers there might be no WebContents.
+  if (!web_contents)
+    return false;
+
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   api::ProtocolNS* protocol = api::ProtocolNS::FromWrappedClass(
       isolate, web_contents->GetBrowserContext());

--- a/shell/browser/atom_browser_client.cc
+++ b/shell/browser/atom_browser_client.cc
@@ -998,7 +998,7 @@ bool AtomBrowserClient::WillCreateURLLoaderFactory(
     header_client_request = mojo::MakeRequest(header_client);
 
   new ProxyingURLLoaderFactory(
-      web_request.get(), protocol->intercept_handlers(),
+      web_request.get(), protocol->intercept_handlers(), render_process_id,
       std::move(proxied_receiver), std::move(target_factory_info),
       std::move(header_client_request));
 

--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -620,11 +620,13 @@ void ProxyingURLLoaderFactory::InProgressRequest::OnRequestError(
 }
 
 ProxyingURLLoaderFactory::ProxyingURLLoaderFactory(
+    WebRequestAPI* web_request_api,
     const HandlersMap& intercepted_handlers,
     network::mojom::URLLoaderFactoryRequest loader_request,
     network::mojom::URLLoaderFactoryPtrInfo target_factory_info,
     network::mojom::TrustedURLLoaderHeaderClientRequest header_client_request)
-    : intercepted_handlers_(intercepted_handlers),
+    : web_request_api_(web_request_api),
+      intercepted_handlers_(intercepted_handlers),
       url_loader_header_client_binding_(this) {
   target_factory_.Bind(std::move(target_factory_info));
   target_factory_.set_connection_error_handler(base::BindOnce(

--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -6,6 +6,7 @@
 
 #include <utility>
 
+#include "extensions/browser/extension_navigation_ui_data.h"
 #include "mojo/public/cpp/bindings/binding.h"
 #include "net/base/completion_repeating_callback.h"
 #include "net/http/http_util.h"
@@ -57,7 +58,9 @@ ProxyingURLLoaderFactory::InProgressRequest::InProgressRequest(
       network::URLLoaderCompletionStatus(net::ERR_ABORTED)));
 }
 
-ProxyingURLLoaderFactory::InProgressRequest::~InProgressRequest() {}
+ProxyingURLLoaderFactory::InProgressRequest::~InProgressRequest() {
+  // TODO(zcbenz): Do cleanup here.
+}
 
 void ProxyingURLLoaderFactory::InProgressRequest::Restart() {
   UpdateRequestInfo();
@@ -65,13 +68,27 @@ void ProxyingURLLoaderFactory::InProgressRequest::Restart() {
 }
 
 void ProxyingURLLoaderFactory::InProgressRequest::UpdateRequestInfo() {
+  // Derive a new WebRequestInfo value any time |Restart()| is called, because
+  // the details in |request_| may have changed e.g. if we've been redirected.
+  // |request_initiator| can be modified on redirects, but we keep the original
+  // for |initiator| in the event. See also
+  // https://developer.chrome.com/extensions/webRequest#event-onBeforeRequest.
+  network::ResourceRequest request_for_info = request_;
+  request_for_info.request_initiator = original_initiator_;
+  info_.emplace(extensions::WebRequestInfoInitParams(
+      request_id_, factory_->render_process_id_, request_.render_frame_id,
+      nullptr, routing_id_, request_for_info, false,
+      !(options_ & network::mojom::kURLLoadOptionSynchronous)));
+
   current_request_uses_header_client_ =
       factory_->url_loader_header_client_binding_ &&
       network_service_request_id_ != 0 &&
-      false /* HasExtraHeadersListenerForRequest */;
+      false /* TODO(zcbenz): HasExtraHeadersListenerForRequest */;
 }
 
 void ProxyingURLLoaderFactory::InProgressRequest::RestartInternal() {
+  DCHECK_EQ(info_->url, request_.url)
+      << "UpdateRequestInfo must have been called first";
   request_completed_ = false;
 
   // If the header client will be used, we start the request immediately, and
@@ -88,7 +105,7 @@ void ProxyingURLLoaderFactory::InProgressRequest::RestartInternal() {
   }
   redirect_url_ = GURL();
   int result = factory_->web_request_api()->OnBeforeRequest(
-      request_, continuation, &redirect_url_);
+      &info_.value(), continuation, &redirect_url_);
   if (result == net::ERR_BLOCKED_BY_CLIENT) {
     // The request was cancelled synchronously. Dispatch an error notification
     // and terminate the request.
@@ -242,8 +259,7 @@ void ProxyingURLLoaderFactory::InProgressRequest::OnComplete(
   }
 
   target_client_->OnComplete(status);
-  factory_->web_request_api()->OnCompleted(request_, current_response_,
-                                           status.error_code);
+  factory_->web_request_api()->OnCompleted(&info_.value(), status.error_code);
 
   // Deletes |this|.
   factory_->RemoveRequest(network_service_request_id_, request_id_);
@@ -302,7 +318,7 @@ void ProxyingURLLoaderFactory::InProgressRequest::ContinueToBeforeSendHeaders(
       &InProgressRequest::ContinueToSendHeaders, weak_factory_.GetWeakPtr());
   // Note: In Electron onBeforeSendHeaders is called for all protocols.
   int result = factory_->web_request_api()->OnBeforeSendHeaders(
-      request_, continuation, &request_.headers);
+      &info_.value(), continuation, &request_.headers);
 
   if (result == net::ERR_BLOCKED_BY_CLIENT) {
     // The request was cancelled synchronously. Dispatch an error notification
@@ -369,7 +385,7 @@ void ProxyingURLLoaderFactory::InProgressRequest::ContinueToSendHeaders(
     proxied_client_binding_.ResumeIncomingMethodCallProcessing();
 
   // Note: In Electron onSendHeaders is called for all protocols.
-  factory_->web_request_api()->OnSendHeaders(request_, request_.headers);
+  factory_->web_request_api()->OnSendHeaders(&info_.value(), request_.headers);
 
   if (!current_request_uses_header_client_)
     ContinueToStartRequest(net::OK);
@@ -478,9 +494,11 @@ void ProxyingURLLoaderFactory::InProgressRequest::ContinueToResponseStarted(
     return;
   }
 
+  info_->AddResponseInfoFromResourceResponse(current_response_);
+
   proxied_client_binding_.ResumeIncomingMethodCallProcessing();
 
-  factory_->web_request_api()->OnResponseStarted(request_, current_response_);
+  factory_->web_request_api()->OnResponseStarted(&info_.value());
   target_client_->OnReceiveResponse(current_response_);
 }
 
@@ -492,10 +510,13 @@ void ProxyingURLLoaderFactory::InProgressRequest::ContinueToBeforeRedirect(
     return;
   }
 
+  info_->AddResponseInfoFromResourceResponse(current_response_);
+
   if (proxied_client_binding_.is_bound())
     proxied_client_binding_.ResumeIncomingMethodCallProcessing();
 
-  // TODO(zcbenz): Call WebRequest.onBeforeRedirect.
+  factory_->web_request_api()->OnBeforeRedirect(&info_.value(),
+                                                redirect_info.new_url);
   target_client_->OnReceiveRedirect(redirect_info, current_response_);
   request_.url = redirect_info.new_url;
   request_.method = redirect_info.new_method;
@@ -587,8 +608,9 @@ void ProxyingURLLoaderFactory::InProgressRequest::
 
   net::CompletionRepeatingCallback copyable_callback =
       base::AdaptCallbackForRepeating(std::move(continuation));
+  DCHECK(info_.has_value());
   int result = factory_->web_request_api()->OnHeadersReceived(
-      request_, copyable_callback, current_response_.headers.get(),
+      &info_.value(), copyable_callback, current_response_.headers.get(),
       &override_headers_, &redirect_url_);
   if (result == net::ERR_BLOCKED_BY_CLIENT) {
     OnRequestError(network::URLLoaderCompletionStatus(result));
@@ -614,22 +636,24 @@ void ProxyingURLLoaderFactory::InProgressRequest::OnRequestError(
     const network::URLLoaderCompletionStatus& status) {
   if (!request_completed_) {
     target_client_->OnComplete(status);
-    factory_->web_request_api()->OnErrorOccurred(request_, current_response_,
+    factory_->web_request_api()->OnErrorOccurred(&info_.value(),
                                                  status.error_code);
   }
 
-  // TODO(zcbenz): Disassociate from factory.
-  delete this;
+  // Deletes |this|.
+  factory_->RemoveRequest(network_service_request_id_, request_id_);
 }
 
 ProxyingURLLoaderFactory::ProxyingURLLoaderFactory(
     WebRequestAPI* web_request_api,
     const HandlersMap& intercepted_handlers,
+    int render_process_id,
     network::mojom::URLLoaderFactoryRequest loader_request,
     network::mojom::URLLoaderFactoryPtrInfo target_factory_info,
     network::mojom::TrustedURLLoaderHeaderClientRequest header_client_request)
     : web_request_api_(web_request_api),
       intercepted_handlers_(intercepted_handlers),
+      render_process_id_(render_process_id),
       url_loader_header_client_binding_(this) {
   target_factory_.Bind(std::move(target_factory_info));
   target_factory_.set_connection_error_handler(base::BindOnce(

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -30,21 +30,32 @@ class WebRequestAPI {
                               const std::set<std::string>& set_headers,
                               int error_code)>;
 
-  virtual int OnBeforeRequest(net::CompletionOnceCallback callback,
+  virtual int OnBeforeRequest(const network::ResourceRequest& request,
+                              net::CompletionOnceCallback callback,
                               GURL* new_url) = 0;
-  virtual int OnBeforeSendHeaders(BeforeSendHeadersCallback callback,
+  virtual int OnBeforeSendHeaders(const network::ResourceRequest& request,
+                                  BeforeSendHeadersCallback callback,
                                   net::HttpRequestHeaders* headers) = 0;
   virtual int OnHeadersReceived(
+      const network::ResourceRequest& request,
       net::CompletionOnceCallback callback,
       const net::HttpResponseHeaders* original_response_headers,
       scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
       GURL* allowed_unsafe_redirect_url) = 0;
-  virtual void OnSendHeaders(const net::HttpRequestHeaders& headers) = 0;
-  virtual void OnBeforeRedirect(const GURL& new_location) = 0;
-  virtual void OnResponseStarted(int net_error) = 0;
-  virtual void OnErrorOccurred(int net_error) = 0;
-  virtual void OnCompleted(int net_error) = 0;
-  virtual void OnResponseStarted() = 0;
+  virtual void OnSendHeaders(const network::ResourceRequest& request,
+                             const net::HttpRequestHeaders& headers) = 0;
+  virtual void OnBeforeRedirect(const network::ResourceRequest& request,
+                                const network::ResourceResponseHead& response,
+                                const GURL& new_location) = 0;
+  virtual void OnResponseStarted(
+      const network::ResourceRequest& request,
+      const network::ResourceResponseHead& response) = 0;
+  virtual void OnErrorOccurred(const network::ResourceRequest& request,
+                               const network::ResourceResponseHead& response,
+                               int net_error) = 0;
+  virtual void OnCompleted(const network::ResourceRequest& request,
+                           const network::ResourceResponseHead& response,
+                           int net_error) = 0;
 };
 
 // This class is responsible for following tasks when NetworkService is enabled:

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -20,6 +20,12 @@
 
 namespace electron {
 
+// Defines the interface for WebRequest API, implemented by api::WebRequestNS.
+class WebRequestAPI {
+ public:
+  virtual ~WebRequestAPI() {}
+};
+
 // This class is responsible for following tasks when NetworkService is enabled:
 // 1. handling intercepted protocols;
 // 2. implementing webRequest module;
@@ -150,6 +156,7 @@ class ProxyingURLLoaderFactory
   };
 
   ProxyingURLLoaderFactory(
+      WebRequestAPI* web_request_api,
       const HandlersMap& intercepted_handlers,
       network::mojom::URLLoaderFactoryRequest loader_request,
       network::mojom::URLLoaderFactoryPtrInfo target_factory_info,
@@ -173,11 +180,16 @@ class ProxyingURLLoaderFactory
       int32_t request_id,
       network::mojom::TrustedHeaderClientRequest request) override;
 
+  WebRequestAPI* web_request_api() { return web_request_api_; }
+
  private:
   void OnTargetFactoryError();
   void OnProxyBindingError();
   void RemoveRequest(int32_t network_service_request_id, uint64_t request_id);
   void MaybeDeleteThis();
+
+  // Passed from api::WebRequestNS.
+  WebRequestAPI* web_request_api_;
 
   // This is passed from api::ProtocolNS.
   //

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -24,6 +24,27 @@ namespace electron {
 class WebRequestAPI {
  public:
   virtual ~WebRequestAPI() {}
+
+  using BeforeSendHeadersCallback =
+      base::OnceCallback<void(const std::set<std::string>& removed_headers,
+                              const std::set<std::string>& set_headers,
+                              int error_code)>;
+
+  virtual int OnBeforeRequest(net::CompletionOnceCallback callback,
+                              GURL* new_url) = 0;
+  virtual int OnBeforeSendHeaders(BeforeSendHeadersCallback callback,
+                                  net::HttpRequestHeaders* headers) = 0;
+  virtual int OnHeadersReceived(
+      net::CompletionOnceCallback callback,
+      const net::HttpResponseHeaders* original_response_headers,
+      scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
+      GURL* allowed_unsafe_redirect_url) = 0;
+  virtual void OnSendHeaders(const net::HttpRequestHeaders& headers) = 0;
+  virtual void OnBeforeRedirect(const GURL& new_location) = 0;
+  virtual void OnResponseStarted(int net_error) = 0;
+  virtual void OnErrorOccurred(int net_error) = 0;
+  virtual void OnCompleted(int net_error) = 0;
+  virtual void OnResponseStarted() = 0;
 };
 
 // This class is responsible for following tasks when NetworkService is enabled:


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/15791.
Refs https://github.com/electron/electron/issues/19602.

This PR makes `ProxyingURLLoaderFactory::InProgressRequest` actually invoke the methods of `webRequest` module.

The next step would be actually invoking the listeners.

#### Release Notes

Notes: no-notes