### PR TITLE
fix: don't handle browser messages before document element is created

### DIFF
--- a/shell/renderer/electron_api_service_impl.cc
+++ b/shell/renderer/electron_api_service_impl.cc
@@ -106,6 +106,7 @@ ElectronApiServiceImpl::ElectronApiServiceImpl(
 
 void ElectronApiServiceImpl::BindTo(
     mojom::ElectronRendererAssociatedRequest request) {
+  // Note: BindTo might be called for multiple times.
   if (binding_.is_bound())
     binding_.Unbind();
 

--- a/shell/renderer/electron_api_service_impl.cc
+++ b/shell/renderer/electron_api_service_impl.cc
@@ -120,6 +120,10 @@ void ElectronApiServiceImpl::CreateMojoService(
   new ElectronApiServiceImpl(render_frame, renderer_client, std::move(request));
 }
 
+void ElectronApiServiceImpl::DidCreateDocumentElement() {
+  document_created_ = true;
+}
+
 void ElectronApiServiceImpl::OnDestruct() {
   delete this;
 }
@@ -129,6 +133,25 @@ void ElectronApiServiceImpl::Message(bool internal,
                                      const std::string& channel,
                                      base::Value arguments,
                                      int32_t sender_id) {
+  // Don't handle browser messages before document element is created.
+  //
+  // Note: It is probably better to save the message and then replay it after
+  // document is ready, but current behavior has been there since the first
+  // day of Electron, and no one has complained so far.
+  //
+  // Reason 1:
+  // When we receive a message from the browser, we try to transfer it
+  // to a web page, and when we do that Blink creates an empty
+  // document element if it hasn't been created yet, and it makes our init
+  // script to run while `window.location` is still "about:blank".
+  // (See https://github.com/electron/electron/pull/1044.)
+  //
+  // Reason 2:
+  // The libuv message loop integration would be broken for unkown reasons.
+  // (See https://github.com/electron/electron/issues/19368.)
+  if (!document_created_)
+    return;
+
   blink::WebLocalFrame* frame = render_frame_->GetWebFrame();
   if (!frame)
     return;

--- a/shell/renderer/electron_api_service_impl.h
+++ b/shell/renderer/electron_api_service_impl.h
@@ -40,7 +40,11 @@ class ElectronApiServiceImpl : public mojom::ElectronRenderer,
                          mojom::ElectronRendererAssociatedRequest request);
 
   // RenderFrameObserver implementation.
+  void DidCreateDocumentElement() override;
   void OnDestruct() override;
+
+  // Whether the DOM document element has been created.
+  bool document_created_ = false;
 
   mojo::AssociatedBinding<mojom::ElectronRenderer> binding_;
 

--- a/shell/renderer/electron_api_service_impl.h
+++ b/shell/renderer/electron_api_service_impl.h
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "base/memory/weak_ptr.h"
 #include "content/public/renderer/render_frame.h"
 #include "content/public/renderer/render_frame_observer.h"
 #include "electron/shell/common/api/api.mojom.h"
@@ -19,10 +20,10 @@ class RendererClientBase;
 class ElectronApiServiceImpl : public mojom::ElectronRenderer,
                                public content::RenderFrameObserver {
  public:
-  static void CreateMojoService(
-      content::RenderFrame* render_frame,
-      RendererClientBase* renderer_client,
-      mojom::ElectronRendererAssociatedRequest request);
+  ElectronApiServiceImpl(content::RenderFrame* render_frame,
+                         RendererClientBase* renderer_client);
+
+  void BindTo(mojom::ElectronRendererAssociatedRequest request);
 
   void Message(bool internal,
                bool send_to_all,
@@ -33,23 +34,26 @@ class ElectronApiServiceImpl : public mojom::ElectronRenderer,
   void TakeHeapSnapshot(mojo::ScopedHandle file,
                         TakeHeapSnapshotCallback callback) override;
 
+  base::WeakPtr<ElectronApiServiceImpl> GetWeakPtr() {
+    return weak_factory_.GetWeakPtr();
+  }
+
  private:
   ~ElectronApiServiceImpl() override;
-  ElectronApiServiceImpl(content::RenderFrame* render_frame,
-                         RendererClientBase* renderer_client,
-                         mojom::ElectronRendererAssociatedRequest request);
 
   // RenderFrameObserver implementation.
   void DidCreateDocumentElement() override;
   void OnDestruct() override;
+
+  void OnConnectionError();
 
   // Whether the DOM document element has been created.
   bool document_created_ = false;
 
   mojo::AssociatedBinding<mojom::ElectronRenderer> binding_;
 
-  content::RenderFrame* render_frame_;
   RendererClientBase* renderer_client_;
+  base::WeakPtrFactory<ElectronApiServiceImpl> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(ElectronApiServiceImpl);
 };

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -235,9 +235,10 @@ void RendererClientBase::RenderFrameCreated(
   // it is possible to trigger the preload script before the document is ready
   // through this interface, we should delay adding it to the registry until
   // the document is ready.
+  auto* service = new ElectronApiServiceImpl(render_frame, this);
   render_frame->GetAssociatedInterfaceRegistry()->AddInterface(
-      base::BindRepeating(&ElectronApiServiceImpl::CreateMojoService,
-                          render_frame, this));
+      base::BindRepeating(&ElectronApiServiceImpl::BindTo,
+                          service->GetWeakPtr()));
 
 #if BUILDFLAG(ENABLE_PDF_VIEWER)
   // Allow access to file scheme from pdf viewer.

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -227,14 +227,8 @@ void RendererClientBase::RenderFrameCreated(
       std::make_unique<electron::PrintRenderFrameHelperDelegate>());
 #endif
 
-  // TODO(nornagon): it might be possible for an IPC message sent to this
-  // service to trigger v8 context creation before the page has begun loading.
-  // However, it's unclear whether such a timing is possible to trigger, and we
-  // don't have any test to confirm it. Add a test that confirms that a
-  // main->renderer IPC can't cause the preload script to be executed twice. If
-  // it is possible to trigger the preload script before the document is ready
-  // through this interface, we should delay adding it to the registry until
-  // the document is ready.
+  // Note: ElectronApiServiceImpl has to be created now to capture the
+  // DidCreateDocumentElement event.
   auto* service = new ElectronApiServiceImpl(render_frame, this);
   render_frame->GetAssociatedInterfaceRegistry()->AddInterface(
       base::BindRepeating(&ElectronApiServiceImpl::BindTo,

--- a/spec/fixtures/pages/send-after-node.html
+++ b/spec/fixtures/pages/send-after-node.html
@@ -1,0 +1,9 @@
+<html>
+<body>
+<script type="text/javascript" charset="utf-8">
+  require('fs').readdir(process.cwd(), () => {
+    require('electron').ipcRenderer.send('async-node-api-done');
+  })
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/19368.

This test was introduced by https://github.com/electron/electron/pull/1044 but then lost when migrating IPC module to mojo. This PR adds the fix back.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix async Node APIs not working after received IPC message.