### PR TITLE
fix: normalize behavior of `win.setOpacity()` for invalid number values across operating systems

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -22,6 +22,7 @@
 #include "atom/common/options_switches.h"
 #include "base/mac/mac_util.h"
 #include "base/mac/scoped_cftyperef.h"
+#include "base/numerics/ranges.h"
 #include "base/strings/sys_string_conversions.h"
 #include "components/remote_cocoa/app_shim/bridged_native_widget_impl.h"
 #include "content/public/browser/browser_accessibility_state.h"
@@ -1047,7 +1048,8 @@ bool NativeWindowMac::HasShadow() {
 }
 
 void NativeWindowMac::SetOpacity(const double opacity) {
-  [window_ setAlphaValue:opacity];
+  const double boundedOpacity = base::ClampToRange(opacity, 0.0, 1.0);
+  [window_ setAlphaValue:boundedOpacity];
 }
 
 double NativeWindowMac::GetOpacity() {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1214,10 +1214,12 @@ describe('BrowserWindow module', () => {
   })
 
   describe('BrowserWindow.setOpacity(opacity)', () => {
-    describe('Windows and Mac', function () {
-      if (process.platform === 'linux') {
-        this.skip()
-      }
+    describe('Windows and Mac', () => {
+      before(function () {
+        if (process.platform !== 'linux') {
+          this.skip()
+        }
+      })
 
       it('make window with initial opacity', () => {
         const w = new BrowserWindow({ show: false, opacity: 0.5 })
@@ -1245,10 +1247,12 @@ describe('BrowserWindow module', () => {
       })
     })
 
-    describe('Linux', function () {
-      if (process.platform !== 'linux') {
-        this.skip()
-      }
+    describe('Linux', () => {
+      before(function () {
+        if (process.platform !== 'linux') {
+          this.skip()
+        }
+      })
 
       it('sets 1 regardless of parameter', () => {
         const w = new BrowserWindow({ show: false })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1221,27 +1221,27 @@ describe('BrowserWindow module', () => {
 
       it('make window with initial opacity', () => {
         const w = new BrowserWindow({ show: false, opacity: 0.5 })
-        expect(w.getOpacity()).to.equal(0.5)
+        assert.strictEqual(w.getOpacity(), 0.5)
       })
 
       it('allows setting the opacity', () => {
         const w = new BrowserWindow({ show: false })
         expect(() => {
           w.setOpacity(0.0)
-          expect(w.getOpacity()).to.equal(0.0)
+          assert.strictEqual(w.getOpacity(), 0.0)
           w.setOpacity(0.5)
-          expect(w.getOpacity()).to.equal(0.5)
+          assert.strictEqual(w.getOpacity(), 0.5)
           w.setOpacity(1.0)
-          expect(w.getOpacity()).to.equal(1.0)
+          assert.strictEqual(w.getOpacity(), 1.0)
         }).to.not.throw()
       })
 
       it('clamps opacity to [0.0...1.0]', () => {
         const w = new BrowserWindow({ show: false, opacity: 0.5 })
         w.setOpacity(100)
-        expect(w.getOpacity()).to.equal(1.0)
+        assert.strictEqual(w.getOpacity(), 1.0)
         w.setOpacity(-100)
-        expect(w.getOpacity()).to.equal(0.0)
+        assert.strictEqual(w.getOpacity(), 0.0)
       })
     })
 
@@ -1253,9 +1253,9 @@ describe('BrowserWindow module', () => {
       it('sets 1 regardless of parameter', () => {
         const w = new BrowserWindow({ show: false })
         w.setOpacity(0)
-        expect(w.getOpacity()).to.equal(1.0)
+        assert.strictEqual(w.getOpacity(), 1.0)
         w.setOpacity(0.5)
-        expect(w.getOpacity()).to.equal(1.0)
+        assert.strictEqual(w.getOpacity(), 1.0)
       })
     })
   })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1216,7 +1216,7 @@ describe('BrowserWindow module', () => {
   describe('BrowserWindow.setOpacity(opacity)', () => {
     describe('Windows and Mac', () => {
       before(function () {
-        if (process.platform !== 'linux') {
+        if (process.platform === 'linux') {
           this.skip()
         }
       })

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1226,14 +1226,14 @@ describe('BrowserWindow module', () => {
 
       it('allows setting the opacity', () => {
         const w = new BrowserWindow({ show: false })
-        expect(() => {
+        assert.doesNotThrow(() => {
           w.setOpacity(0.0)
           assert.strictEqual(w.getOpacity(), 0.0)
           w.setOpacity(0.5)
           assert.strictEqual(w.getOpacity(), 0.5)
           w.setOpacity(1.0)
           assert.strictEqual(w.getOpacity(), 1.0)
-        }).to.not.throw()
+        })
       })
 
       it('clamps opacity to [0.0...1.0]', () => {

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1221,13 +1221,13 @@ describe('BrowserWindow module', () => {
         }
       })
 
-      it('make window with initial opacity', () => {
-        const w = new BrowserWindow({ show: false, opacity: 0.5 })
+      it('makes a window with initial opacity', () => {
+        w.destroy()
+        w = new BrowserWindow({ show: false, opacity: 0.5 })
         assert.strictEqual(w.getOpacity(), 0.5)
       })
 
       it('allows setting the opacity', () => {
-        const w = new BrowserWindow({ show: false })
         assert.doesNotThrow(() => {
           w.setOpacity(0.0)
           assert.strictEqual(w.getOpacity(), 0.0)
@@ -1239,7 +1239,6 @@ describe('BrowserWindow module', () => {
       })
 
       it('clamps opacity to [0.0...1.0]', () => {
-        const w = new BrowserWindow({ show: false, opacity: 0.5 })
         w.setOpacity(100)
         assert.strictEqual(w.getOpacity(), 1.0)
         w.setOpacity(-100)
@@ -1255,7 +1254,8 @@ describe('BrowserWindow module', () => {
       })
 
       it('sets 1 regardless of parameter', () => {
-        const w = new BrowserWindow({ show: false })
+        w.destroy()
+        w = new BrowserWindow({ show: false, opacity: 0.5 })
         w.setOpacity(0)
         assert.strictEqual(w.getOpacity(), 1.0)
         w.setOpacity(0.5)

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -1214,24 +1214,48 @@ describe('BrowserWindow module', () => {
   })
 
   describe('BrowserWindow.setOpacity(opacity)', () => {
-    it('make window with initial opacity', () => {
-      w.destroy()
-      w = new BrowserWindow({
-        show: false,
-        width: 400,
-        height: 400,
-        opacity: 0.5
+    describe('Windows and Mac', function () {
+      if (process.platform === 'linux') {
+        this.skip()
+      }
+
+      it('make window with initial opacity', () => {
+        const w = new BrowserWindow({ show: false, opacity: 0.5 })
+        expect(w.getOpacity()).to.equal(0.5)
       })
-      assert.strictEqual(w.getOpacity(), 0.5)
+
+      it('allows setting the opacity', () => {
+        const w = new BrowserWindow({ show: false })
+        expect(() => {
+          w.setOpacity(0.0)
+          expect(w.getOpacity()).to.equal(0.0)
+          w.setOpacity(0.5)
+          expect(w.getOpacity()).to.equal(0.5)
+          w.setOpacity(1.0)
+          expect(w.getOpacity()).to.equal(1.0)
+        }).to.not.throw()
+      })
+
+      it('clamps opacity to [0.0...1.0]', () => {
+        const w = new BrowserWindow({ show: false, opacity: 0.5 })
+        w.setOpacity(100)
+        expect(w.getOpacity()).to.equal(1.0)
+        w.setOpacity(-100)
+        expect(w.getOpacity()).to.equal(0.0)
+      })
     })
-    it('allows setting the opacity', () => {
-      assert.doesNotThrow(() => {
-        w.setOpacity(0.0)
-        assert.strictEqual(w.getOpacity(), 0.0)
+
+    describe('Linux', function () {
+      if (process.platform !== 'linux') {
+        this.skip()
+      }
+
+      it('sets 1 regardless of parameter', () => {
+        const w = new BrowserWindow({ show: false })
+        w.setOpacity(0)
+        expect(w.getOpacity()).to.equal(1.0)
         w.setOpacity(0.5)
-        assert.strictEqual(w.getOpacity(), 0.5)
-        w.setOpacity(1.0)
-        assert.strictEqual(w.getOpacity(), 1.0)
+        expect(w.getOpacity()).to.equal(1.0)
       })
     })
   })


### PR DESCRIPTION
Backport of #19535.

See that PR for more details.

Notes: Normalized out-of-bound value behavior for the `setOpacity()` API in `BrowserWindow`.