### PR TITLE
fix: proper l10n on Linux dialog buttons

### DIFF
--- a/shell/browser/ui/file_dialog_gtk.cc
+++ b/shell/browser/ui/file_dialog_gtk.cc
@@ -4,8 +4,6 @@
 
 #include "shell/browser/ui/file_dialog.h"
 
-#include <glib/gi18n.h>  // _() macro
-
 #include "base/callback.h"
 #include "base/files/file_util.h"
 #include "base/strings/string_util.h"
@@ -13,6 +11,8 @@
 #include "shell/browser/native_window_views.h"
 #include "shell/browser/unresponsive_suppressor.h"
 #include "ui/base/glib/glib_signal.h"
+#include "ui/base/l10n/l10n_util.h"
+#include "ui/strings/grit/ui_strings.h"
 #include "ui/views/widget/desktop_aura/x11_desktop_handler.h"
 
 namespace file_dialog {
@@ -47,17 +47,20 @@ class FileChooserDialog {
       : parent_(
             static_cast<electron::NativeWindowViews*>(settings.parent_window)),
         filters_(settings.filters) {
-    const char* confirm_text = _("_OK");
+    const char* confirm_text = l10n_util::GetStringUTF8(IDS_APP_OK).c_str();
 
-    if (!settings.button_label.empty())
+    if (!settings.button_label.empty()) {
       confirm_text = settings.button_label.c_str();
-    else if (action == GTK_FILE_CHOOSER_ACTION_SAVE)
-      confirm_text = _("_Save");
-    else if (action == GTK_FILE_CHOOSER_ACTION_OPEN)
-      confirm_text = _("_Open");
+    } else if (action == GTK_FILE_CHOOSER_ACTION_SAVE) {
+      confirm_text = l10n_util::GetStringUTF8(IDS_SAVE_AS_DIALOG_TITLE).c_str();
+    } else if (action == GTK_FILE_CHOOSER_ACTION_OPEN) {
+      confirm_text =
+          l10n_util::GetStringUTF8(IDS_OPEN_FILE_DIALOG_TITLE).c_str();
+    }
 
     dialog_ = gtk_file_chooser_dialog_new(
-        settings.title.c_str(), NULL, action, _("_Cancel"), GTK_RESPONSE_CANCEL,
+        settings.title.c_str(), NULL, action,
+        l10n_util::GetStringUTF8(IDS_APP_CANCEL).c_str(), GTK_RESPONSE_CANCEL,
         confirm_text, GTK_RESPONSE_ACCEPT, NULL);
     if (parent_) {
       parent_->SetEnabled(false);

--- a/shell/browser/ui/file_dialog_gtk.cc
+++ b/shell/browser/ui/file_dialog_gtk.cc
@@ -55,7 +55,8 @@ class FileChooserDialog {
       confirm_text = l10n_util::GetStringUTF8(IDS_SAVE_AS_DIALOG_TITLE).c_str();
     } else if (action == GTK_FILE_CHOOSER_ACTION_OPEN) {
       confirm_text =
-          l10n_util::GetStringUTF8(IDS_OPEN_FILE_DIALOG_TITLE).c_str();
+          l10n_util::GetStringUTF8(IDS_SEND_TAB_TO_SELF_INFOBAR_MESSAGE_URL)
+              .c_str();
     }
 
     dialog_ = gtk_file_chooser_dialog_new(


### PR DESCRIPTION
#### Description of Change
Closes #19663 in a roundabout way. Leverages Chromium's UI strings to apply proper labels to dialog buttons.

Previously, we were attempting to use GNU gettext, but it wasn't really working. I don't have too much context on that, but I think it's because we didn't have manual translations.

##### Screenshots:

Fiddle's Dialog show-me and my Linux system set to French.

Before:
![Capture d'écran 2019-08-12 17:53:28](https://user-images.githubusercontent.com/16010076/62907931-63135c00-bd2a-11e9-909e-df3bc405c30d.png)

After:
![Capture d'écran 2019-08-12 17:55:14](https://user-images.githubusercontent.com/16010076/62907944-6dcdf100-bd2a-11e9-99d1-b5ebd079c6ad.png)
![ccc](https://user-images.githubusercontent.com/16010076/62907948-76bec280-bd2a-11e9-87ec-0c0cace73ea3.png)


##### Limitations:
* Some strings borrowed from Chromium are not exactly used properly. They seemed to be OK for usage in English and French, but I'm not sure if they don't match up in other languages.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Localized dialog button text on Linux.
