### PR TITLE
chore: revert "fix: activate the uv_loop on incoming IPC messages"

### DIFF
--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -48,7 +48,6 @@ v8Util.setHiddenValue(global, 'ipcNative', {
   onMessage (internal: boolean, channel: string, args: any[], senderId: number) {
     const sender = internal ? ipcInternalEmitter : ipcEmitter
     sender.emit(channel, { sender, senderId }, ...args)
-    process.activateUvLoop()
   }
 })
 


### PR DESCRIPTION
Reverts electron/electron#19449

It did not really fix #19368 and we have a real fix now.

Notes: no-notes