### PR TITLE
[wip] feat: add `systemPreferences.isShellDarkMode()` on Windows

### DIFF
--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -45,9 +45,13 @@ Returns:
 
 ### `systemPreferences.isDarkMode()` _macOS_ _Windows_
 
-Returns `Boolean` - Whether the system is in Dark Mode.
+Returns `Boolean` - Whether the app should be displayed in Dark Mode.
 
 **Note:** On macOS 10.15 Catalina in order for this API to return the correct value when in the "automatic" dark mode setting you must either have `NSRequiresAquaSystemAppearance=false` in your `Info.plist` or be on Electron `>=7.0.0`.  See the [dark mode guide](../tutorial/mojave-dark-mode-guide.md) for more information.
+
+### `systemPreferences.isShellDarkMode()` _Windows_
+
+Returns `Boolean` - Whether the Windows shell is displayed in Dark Mode.
 
 ### `systemPreferences.isSwipeTrackingFromScrollEventsEnabled()` _macOS_
 

--- a/shell/browser/api/atom_api_system_preferences.cc
+++ b/shell/browser/api/atom_api_system_preferences.cc
@@ -75,6 +75,7 @@ void SystemPreferences::BuildPrototype(
 
 #if defined(OS_WIN)
       .SetMethod("isAeroGlassEnabled", &SystemPreferences::IsAeroGlassEnabled)
+      .SetMethod("isShellDarkMode", &SystemPreferences::IsShellDarkMode)
 #elif defined(OS_MACOSX)
       .SetMethod("postNotification", &SystemPreferences::PostNotification)
       .SetMethod("subscribeNotification",

--- a/shell/browser/api/atom_api_system_preferences.h
+++ b/shell/browser/api/atom_api_system_preferences.h
@@ -55,6 +55,7 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
 #endif
 #if defined(OS_WIN)
   bool IsAeroGlassEnabled();
+  bool IsShellDarkMode();
 
   void InitializeWindow();
 

--- a/shell/browser/api/atom_api_system_preferences_win.cc
+++ b/shell/browser/api/atom_api_system_preferences_win.cc
@@ -7,6 +7,7 @@
 
 #include "shell/browser/api/atom_api_system_preferences.h"
 
+#include "base/win/registry.h"
 #include "base/win/wrapped_window_proc.h"
 #include "shell/common/color_util.h"
 #include "ui/base/win/shell.h"

--- a/shell/browser/api/atom_api_system_preferences_win.cc
+++ b/shell/browser/api/atom_api_system_preferences_win.cc
@@ -28,6 +28,15 @@ bool SystemPreferences::IsAeroGlassEnabled() {
   return ui::win::IsAeroGlassEnabled();
 }
 
+bool SystemPreferences::IsShellDarkMode() {
+  base::string16 keyPath =
+      L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
+  base::win::RegKey key(HKEY_CURRENT_USER, keyPath.c_str(), KEY_ALL_ACCESS);
+  DWORD value = 0;  // defaults to dark theme if registry entry does not exist
+  key.ReadValueDW(L"SystemUseLightTheme", &value);
+  return (value != 1);
+}
+
 std::string hexColorDWORDToRGBA(DWORD color) {
   DWORD rgba = color << 8 | color >> 24;
   std::ostringstream stream;

--- a/spec-main/api-system-preferences-spec.ts
+++ b/spec-main/api-system-preferences-spec.ts
@@ -3,6 +3,12 @@ import { systemPreferences } from 'electron'
 import { ifdescribe } from './spec-helpers'
 
 describe('systemPreferences module', () => {
+  ifdescribe(process.platform === 'win32')('systemPreferences.isAeroGlassEnabled()', () => {
+    it('returns a boolean', () => {
+      expect(systemPreferences.isAeroGlassEnabled()).to.be.a('boolean')
+    })
+  })
+
   ifdescribe(process.platform === 'win32')('systemPreferences.getAccentColor', () => {
     it('should return a non-empty string', () => {
       const accentColor = systemPreferences.getAccentColor()
@@ -147,6 +153,18 @@ describe('systemPreferences module', () => {
 
     it('does not throw for missing keys', () => {
       systemPreferences.removeUserDefault('some-missing-key')
+    })
+  })
+
+  describe('systemPreferences.isDarkMode()', () => {
+    it('returns a boolean', () => {
+      expect(systemPreferences.isDarkMode()).to.be.a('boolean')
+    })
+  })
+
+  ifdescribe(process.platform === 'win32')('systemPreferences.isShellDarkMode()', () => {
+    it('returns a boolean', () => {
+      expect(systemPreferences.isShellDarkMode()).to.be.a('boolean')
     })
   })
 


### PR DESCRIPTION
#### Description of Change
Closes #19729. 

Windows 10 1903 introduced separate dark mode settings for apps and the system shell. While `sysPrefs.isDarkMode` reflects the app setting, this one adds support to detect the system shell setting.

![image](https://user-images.githubusercontent.com/8472721/62966067-1cba0d80-bdbb-11e9-8e11-4589457efc91.png)

####  Used Approach
Whether the system uses dark or light theme is derived from following registry key: 
```
HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize\SystemUseLightTheme 
  | value 1   = light
  | otherwise = dark
```

cc @MarshallOfSound @miniak @codebytere

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `systemPreferences.isShellDarkMode()` API on Windows.