### PR TITLE
build: enable vaapi support by default

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -24,3 +24,8 @@ is_cfi = false
 # TODO: Remove this and update CI to contain 10.14 SDK once
 # crbug.com/986701 is fixed.
 mac_sdk_min = "10.13"
+
+# This will build electron with vaapi support in order to enable hardware
+# acceleration - however, it will need to be enabled intentionally by using
+# the --ignore-gpu-blacklist flag and installing necessary dependencies.
+use_vaapi = true


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

As a result of this conversation: https://github.com/electron/electron/issues/18942 I would like to propose that `use_vaapi = true` is added as a build flag to Electron builds so that Linux users can have hardware acceleration if they choose.

This does not change the default behavior of Electron, but compiles Chromium with the ability to use VAAPI drivers which can be enabled on Linux systems by using the `--ignore-gpu-blacklist` flag at runtime, as well as by installing any necessary dependencies (in that conversation, I mention Ubunutu specific deps that must be installed to work).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added use_vaapi as a build time flag to enable hardware acceleration for Linux builds