### PR TITLE
chore: revert "fix: activate the uv_loop on incoming IPC messages" (6-0-x)

### DIFF
--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -45,12 +45,10 @@ const ipcInternalEmitter = new EventEmitter()
 v8Util.setHiddenValue(global, 'ipc', ipcEmitter)
 v8Util.setHiddenValue(global, 'ipc-internal', ipcInternalEmitter)
 
-const savedProcess = process
 v8Util.setHiddenValue(global, 'ipcNative', {
   onMessage (internal: boolean, channel: string, args: any[], senderId: number) {
     const sender = internal ? ipcInternalEmitter : ipcEmitter
     sender.emit(channel, { sender, senderId }, ...args)
-    savedProcess.activateUvLoop()
   }
 })
 


### PR DESCRIPTION
Reverts electron/electron#19467

Backport of #19727

Notes: no-notes