### PR TITLE
fix: ensure child_process.fork() doesn't modify main process env

### DIFF
--- a/patches/node/inherit_electron_crashpad_pipe_name_in_child_process.patch
+++ b/patches/node/inherit_electron_crashpad_pipe_name_in_child_process.patch
@@ -6,11 +6,11 @@ Subject: Inherit ELECTRON_CRASHPAD_PIPE_NAME in child process
 This is required for crashReporter to work correctly in node process.
 
 diff --git a/lib/child_process.js b/lib/child_process.js
-index ec429a082b081f0289507c15aa9ecc5305345ca2..7c231993e60278d3946745cba15c458962556581 100644
+index 2f478625c8220fc86c34876c17c8f532d88ba922..9a79e06555b6bf5d970f96bedb2c2146d2c74a48 100644
 --- a/lib/child_process.js
 +++ b/lib/child_process.js
-@@ -108,6 +108,10 @@ function fork(modulePath /* , args, options */) {
- 
+@@ -107,6 +107,10 @@ function fork(modulePath /* , args, options */) {
+   options.env = Object.create(options.env || process.env)
    options.env.ELECTRON_RUN_AS_NODE = 1;
  
 +  if (process.platform === 'win32') {

--- a/patches/node/refactor_alter_child_process_fork_to_use_execute_script_with.patch
+++ b/patches/node/refactor_alter_child_process_fork_to_use_execute_script_with.patch
@@ -7,17 +7,16 @@ Subject: refactor: alter child_process.fork to use execute script with
 When forking a child script, we setup a special environment to make the Electron binary run like the upstream node. On Mac, we use the helper app as node binary.
 
 diff --git a/lib/child_process.js b/lib/child_process.js
-index 43257e53dfe0319d6c110e94529cbc991c2bcfb3..ec429a082b081f0289507c15aa9ecc5305345ca2 100644
+index 43257e53dfe0319d6c110e94529cbc991c2bcfb3..2f478625c8220fc86c34876c17c8f532d88ba922 100644
 --- a/lib/child_process.js
 +++ b/lib/child_process.js
-@@ -102,6 +102,16 @@ function fork(modulePath /* , args, options */) {
+@@ -102,6 +102,15 @@ function fork(modulePath /* , args, options */) {
      throw new ERR_CHILD_PROCESS_IPC_REQUIRED('options.stdio');
    }
  
-+  if (!options.env) {
-+    options.env = Object.create(process.env);
-+  }
-+
++  // When forking a child script, we setup a special environment to make
++  // the electron binary run like upstream Node.js
++  options.env = Object.create(options.env || process.env)
 +  options.env.ELECTRON_RUN_AS_NODE = 1;
 +
 +  if (!options.execPath && process.type && process.platform == 'darwin') {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/19738.

As stated in the issue, `ELECTRON_RUN_AS_NODE` is set in the Electron main `process.env` after `calling child_process.fork()`, passing in `process.env` directly as options.env. This means that the value for `ELECTRON_RUN_AS_NODE` is actually changed in the main process env, which causes unwanted side effects.

This PR remedies that by making a new `process.env` object using the existing one as a prototype
to avoid changing the main process env. 

Verified with https://gist.github.com/cdc803312b25b151d53629d0c13bc896:

```sh
Before fork, ELECTRON_RUN_AS_NODE is  undefined
After fork, ELECTRON_RUN_AS_NODE is  undefined
```

cc @MarshallOfSound

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where a call to `child_process.fork()` would set `ELECTRON_RUN_AS_NODE` in the main process.
