### PR TITLE
feat: migrate webRequest module to NetworkService (Part 6)

### DIFF
--- a/shell/browser/api/atom_api_web_request_ns.cc
+++ b/shell/browser/api/atom_api_web_request_ns.cc
@@ -123,8 +123,11 @@ int WebRequestNS::OnBeforeRequest(extensions::WebRequestInfo* request,
 int WebRequestNS::OnBeforeSendHeaders(extensions::WebRequestInfo* request,
                                       BeforeSendHeadersCallback callback,
                                       net::HttpRequestHeaders* headers) {
-  // TODO(zcbenz): Figure out how to handle this generally.
-  return net::OK;
+  return HandleResponseEvent(
+      kOnBeforeSendHeaders, request,
+      base::BindOnce(std::move(callback), std::set<std::string>(),
+                     std::set<std::string>()),
+      headers, *headers);
 }
 
 int WebRequestNS::OnHeadersReceived(

--- a/shell/browser/api/atom_api_web_request_ns.h
+++ b/shell/browser/api/atom_api_web_request_ns.h
@@ -101,9 +101,9 @@ class WebRequestNS : public gin::Wrappable<WebRequestNS>, public WebRequestAPI {
   };
 
   using SimpleListener = base::RepeatingCallback<void(v8::Local<v8::Value>)>;
-  using ResponseCallback = base::OnceCallback<void(const base::Value&)>;
+  using ResponseCallback = base::OnceCallback<void(v8::Local<v8::Value>)>;
   using ResponseListener =
-      base::RepeatingCallback<void(const base::Value&, ResponseCallback)>;
+      base::RepeatingCallback<void(v8::Local<v8::Value>, ResponseCallback)>;
 
   template <SimpleEvent event>
   void SetSimpleListener(gin::Arguments* args);
@@ -122,6 +122,9 @@ class WebRequestNS : public gin::Wrappable<WebRequestNS>, public WebRequestAPI {
                           net::CompletionOnceCallback callback,
                           Out out,
                           Args... args);
+
+  template <typename T>
+  void OnListenerResult(uint64_t id, T out, v8::Local<v8::Value> response);
 
   struct SimpleListenerInfo {
     std::set<URLPattern> url_patterns;

--- a/shell/browser/api/atom_api_web_request_ns.h
+++ b/shell/browser/api/atom_api_web_request_ns.h
@@ -57,26 +57,35 @@ class WebRequestNS : public gin::Wrappable<WebRequestNS>, public WebRequestAPI {
   ~WebRequestNS() override;
 
   // WebRequestAPI:
-  int OnBeforeRequest(extensions::WebRequestInfo* request,
+  int OnBeforeRequest(extensions::WebRequestInfo* info,
+                      const network::ResourceRequest& request,
                       net::CompletionOnceCallback callback,
                       GURL* new_url) override;
-  int OnBeforeSendHeaders(extensions::WebRequestInfo* request,
+  int OnBeforeSendHeaders(extensions::WebRequestInfo* info,
+                          const network::ResourceRequest& request,
                           BeforeSendHeadersCallback callback,
                           net::HttpRequestHeaders* headers) override;
   int OnHeadersReceived(
-      extensions::WebRequestInfo* request,
+      extensions::WebRequestInfo* info,
+      const network::ResourceRequest& request,
       net::CompletionOnceCallback callback,
       const net::HttpResponseHeaders* original_response_headers,
       scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
       GURL* allowed_unsafe_redirect_url) override;
-  void OnSendHeaders(extensions::WebRequestInfo* request,
+  void OnSendHeaders(extensions::WebRequestInfo* info,
+                     const network::ResourceRequest& request,
                      const net::HttpRequestHeaders& headers) override;
-  void OnBeforeRedirect(extensions::WebRequestInfo* request,
+  void OnBeforeRedirect(extensions::WebRequestInfo* info,
+                        const network::ResourceRequest& request,
                         const GURL& new_location) override;
-  void OnResponseStarted(extensions::WebRequestInfo* request) override;
-  void OnErrorOccurred(extensions::WebRequestInfo* request,
+  void OnResponseStarted(extensions::WebRequestInfo* info,
+                         const network::ResourceRequest& request) override;
+  void OnErrorOccurred(extensions::WebRequestInfo* info,
+                       const network::ResourceRequest& request,
                        int net_error) override;
-  void OnCompleted(extensions::WebRequestInfo* request, int net_error) override;
+  void OnCompleted(extensions::WebRequestInfo* info,
+                   const network::ResourceRequest& request,
+                   int net_error) override;
 
   enum SimpleEvent {
     kOnSendHeaders,
@@ -91,7 +100,7 @@ class WebRequestNS : public gin::Wrappable<WebRequestNS>, public WebRequestAPI {
     kOnHeadersReceived,
   };
 
-  using SimpleListener = base::RepeatingCallback<void(const base::Value&)>;
+  using SimpleListener = base::RepeatingCallback<void(v8::Local<v8::Value>)>;
   using ResponseCallback = base::OnceCallback<void(const base::Value&)>;
   using ResponseListener =
       base::RepeatingCallback<void(const base::Value&, ResponseCallback)>;
@@ -105,11 +114,13 @@ class WebRequestNS : public gin::Wrappable<WebRequestNS>, public WebRequestAPI {
 
   template <typename... Args>
   void HandleSimpleEvent(SimpleEvent event,
-                         extensions::WebRequestInfo* request,
+                         extensions::WebRequestInfo* info,
+                         const network::ResourceRequest& request,
                          Args... args);
   template <typename Out, typename... Args>
   int HandleResponseEvent(ResponseEvent event,
-                          extensions::WebRequestInfo* request,
+                          extensions::WebRequestInfo* info,
+                          const network::ResourceRequest& request,
                           net::CompletionOnceCallback callback,
                           Out out,
                           Args... args);

--- a/shell/browser/api/atom_api_web_request_ns.h
+++ b/shell/browser/api/atom_api_web_request_ns.h
@@ -115,12 +115,10 @@ class WebRequestNS : public gin::Wrappable<WebRequestNS>, public WebRequestAPI {
   template <typename... Args>
   void HandleSimpleEvent(SimpleEvent event,
                          extensions::WebRequestInfo* info,
-                         const network::ResourceRequest& request,
                          Args... args);
   template <typename Out, typename... Args>
   int HandleResponseEvent(ResponseEvent event,
                           extensions::WebRequestInfo* info,
-                          const network::ResourceRequest& request,
                           net::CompletionOnceCallback callback,
                           Out out,
                           Args... args);

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -31,26 +31,34 @@ class WebRequestAPI {
                               const std::set<std::string>& set_headers,
                               int error_code)>;
 
-  virtual int OnBeforeRequest(extensions::WebRequestInfo* request,
+  virtual int OnBeforeRequest(extensions::WebRequestInfo* info,
+                              const network::ResourceRequest& request,
                               net::CompletionOnceCallback callback,
                               GURL* new_url) = 0;
-  virtual int OnBeforeSendHeaders(extensions::WebRequestInfo* request,
+  virtual int OnBeforeSendHeaders(extensions::WebRequestInfo* info,
+                                  const network::ResourceRequest& request,
                                   BeforeSendHeadersCallback callback,
                                   net::HttpRequestHeaders* headers) = 0;
   virtual int OnHeadersReceived(
-      extensions::WebRequestInfo* request,
+      extensions::WebRequestInfo* info,
+      const network::ResourceRequest& request,
       net::CompletionOnceCallback callback,
       const net::HttpResponseHeaders* original_response_headers,
       scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
       GURL* allowed_unsafe_redirect_url) = 0;
-  virtual void OnSendHeaders(extensions::WebRequestInfo* request,
+  virtual void OnSendHeaders(extensions::WebRequestInfo* info,
+                             const network::ResourceRequest& request,
                              const net::HttpRequestHeaders& headers) = 0;
-  virtual void OnBeforeRedirect(extensions::WebRequestInfo* request,
+  virtual void OnBeforeRedirect(extensions::WebRequestInfo* info,
+                                const network::ResourceRequest& request,
                                 const GURL& new_location) = 0;
-  virtual void OnResponseStarted(extensions::WebRequestInfo* request) = 0;
-  virtual void OnErrorOccurred(extensions::WebRequestInfo* request,
+  virtual void OnResponseStarted(extensions::WebRequestInfo* info,
+                                 const network::ResourceRequest& request) = 0;
+  virtual void OnErrorOccurred(extensions::WebRequestInfo* info,
+                               const network::ResourceRequest& request,
                                int net_error) = 0;
-  virtual void OnCompleted(extensions::WebRequestInfo* request,
+  virtual void OnCompleted(extensions::WebRequestInfo* info,
+                           const network::ResourceRequest& request,
                            int net_error) = 0;
 };
 

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -236,6 +236,22 @@ v8::Local<v8::Value> Converter<net::HttpRequestHeaders>::ToV8(
 }
 
 // static
+bool Converter<net::HttpRequestHeaders>::FromV8(v8::Isolate* isolate,
+                                                v8::Local<v8::Value> val,
+                                                net::HttpRequestHeaders* out) {
+  base::DictionaryValue dict;
+  if (!ConvertFromV8(isolate, val, &dict))
+    return false;
+  for (base::DictionaryValue::Iterator it(dict); !it.IsAtEnd(); it.Advance()) {
+    if (it.value().is_string()) {
+      std::string value = it.value().GetString();
+      out->SetHeader(it.key(), value);
+    }
+  }
+  return true;
+}
+
+// static
 v8::Local<v8::Value> Converter<network::ResourceRequest>::ToV8(
     v8::Isolate* isolate,
     const network::ResourceRequest& val) {

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -226,6 +226,16 @@ bool Converter<net::HttpResponseHeaders*>::FromV8(
 }
 
 // static
+v8::Local<v8::Value> Converter<net::HttpRequestHeaders>::ToV8(
+    v8::Isolate* isolate,
+    const net::HttpRequestHeaders& val) {
+  gin::Dictionary headers(isolate, v8::Object::New(isolate));
+  for (net::HttpRequestHeaders::Iterator it(val); it.GetNext();)
+    headers.Set(it.name(), it.value());
+  return ConvertToV8(isolate, headers);
+}
+
+// static
 v8::Local<v8::Value> Converter<network::ResourceRequest>::ToV8(
     v8::Isolate* isolate,
     const network::ResourceRequest& val) {
@@ -233,10 +243,7 @@ v8::Local<v8::Value> Converter<network::ResourceRequest>::ToV8(
   dict.Set("method", val.method);
   dict.Set("url", val.url.spec());
   dict.Set("referrer", val.referrer.spec());
-  gin::Dictionary headers(isolate, v8::Object::New(isolate));
-  for (net::HttpRequestHeaders::Iterator it(val.headers); it.GetNext();)
-    headers.Set(it.name(), it.value());
-  dict.Set("headers", headers);
+  dict.Set("headers", val.headers);
   if (val.request_body) {
     const auto& elements = *val.request_body->elements();
     v8::Local<v8::Array> arr = v8::Array::New(isolate, elements.size());

--- a/shell/common/gin_converters/net_converter.h
+++ b/shell/common/gin_converters/net_converter.h
@@ -64,6 +64,9 @@ template <>
 struct Converter<net::HttpRequestHeaders> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const net::HttpRequestHeaders& headers);
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     net::HttpRequestHeaders* out);
 };
 
 template <>

--- a/shell/common/gin_converters/net_converter.h
+++ b/shell/common/gin_converters/net_converter.h
@@ -61,6 +61,12 @@ struct Converter<net::HttpResponseHeaders*> {
 };
 
 template <>
+struct Converter<net::HttpRequestHeaders> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const net::HttpRequestHeaders& headers);
+};
+
+template <>
 struct Converter<network::ResourceRequest> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const network::ResourceRequest& val);


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/15791.
Refs https://github.com/electron/electron/issues/19602.

This PR implements the part that passes information to listener and reads the responses.

#### Release Notes

Notes: no-notes