### PR TITLE
fix: use GTK3 stock i18n strings

### DIFF
--- a/shell/browser/ui/file_dialog_gtk.cc
+++ b/shell/browser/ui/file_dialog_gtk.cc
@@ -4,8 +4,6 @@
 
 #include "shell/browser/ui/file_dialog.h"
 
-#include <glib/gi18n.h>  // _() macro
-
 #include "base/callback.h"
 #include "base/files/file_util.h"
 #include "base/strings/string_util.h"
@@ -31,11 +29,13 @@ namespace {
 // internationalized strings, but the "_" in these strings is significant: it's
 // the keyboard shortcut to select these actions.  TODO(thomasanderson): Provide
 // internationalized strings when GTK provides support for it.
+const char kOkLabel[] = "_Ok";
 const char kCancelLabel[] = "_Cancel";
 const char kOpenLabel[] = "_Open";
 const char kSaveLabel[] = "_Save";
 #else
 G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+const char* const kOkLabel = GTK_STOCK_OK;
 const char* const kCancelLabel = GTK_STOCK_CANCEL;
 const char* const kOpenLabel = GTK_STOCK_OPEN;
 const char* const kSaveLabel = GTK_STOCK_SAVE;
@@ -66,18 +66,18 @@ class FileChooserDialog {
       : parent_(
             static_cast<electron::NativeWindowViews*>(settings.parent_window)),
         filters_(settings.filters) {
-    const char* confirm_text = _("_OK");
+    const char* confirm_text = kOkLabel;
 
     if (!settings.button_label.empty())
       confirm_text = settings.button_label.c_str();
     else if (action == GTK_FILE_CHOOSER_ACTION_SAVE)
-      confirm_text = _(kOpenLabel);
+      confirm_text = kOpenLabel;
     else if (action == GTK_FILE_CHOOSER_ACTION_OPEN)
-      confirm_text = _(kSaveLabel);
+      confirm_text = kSaveLabel;
 
     dialog_ = gtk_file_chooser_dialog_new(
-        settings.title.c_str(), NULL, action, _(kCancelLabel),
-        GTK_RESPONSE_CANCEL, confirm_text, GTK_RESPONSE_ACCEPT, NULL);
+        settings.title.c_str(), NULL, action, kCancelLabel, GTK_RESPONSE_CANCEL,
+        confirm_text, GTK_RESPONSE_ACCEPT, NULL);
     if (parent_) {
       parent_->SetEnabled(false);
       libgtkui::SetGtkTransientForAura(dialog_, parent_->GetNativeWindow());

--- a/shell/browser/ui/file_dialog_gtk.cc
+++ b/shell/browser/ui/file_dialog_gtk.cc
@@ -4,6 +4,8 @@
 
 #include "shell/browser/ui/file_dialog.h"
 
+#include <glib/gi18n.h>  // _() macro
+
 #include "base/callback.h"
 #include "base/files/file_util.h"
 #include "base/strings/string_util.h"
@@ -11,8 +13,6 @@
 #include "shell/browser/native_window_views.h"
 #include "shell/browser/unresponsive_suppressor.h"
 #include "ui/base/glib/glib_signal.h"
-#include "ui/base/l10n/l10n_util.h"
-#include "ui/strings/grit/ui_strings.h"
 #include "ui/views/widget/desktop_aura/x11_desktop_handler.h"
 
 namespace file_dialog {
@@ -47,21 +47,17 @@ class FileChooserDialog {
       : parent_(
             static_cast<electron::NativeWindowViews*>(settings.parent_window)),
         filters_(settings.filters) {
-    const char* confirm_text = l10n_util::GetStringUTF8(IDS_APP_OK).c_str();
+    const char* confirm_text = _("_OK");
 
-    if (!settings.button_label.empty()) {
+    if (!settings.button_label.empty())
       confirm_text = settings.button_label.c_str();
-    } else if (action == GTK_FILE_CHOOSER_ACTION_SAVE) {
-      confirm_text = l10n_util::GetStringUTF8(IDS_SAVE_AS_DIALOG_TITLE).c_str();
-    } else if (action == GTK_FILE_CHOOSER_ACTION_OPEN) {
-      confirm_text =
-          l10n_util::GetStringUTF8(IDS_SEND_TAB_TO_SELF_INFOBAR_MESSAGE_URL)
-              .c_str();
-    }
+    else if (action == GTK_FILE_CHOOSER_ACTION_SAVE)
+      confirm_text = _("_Save");
+    else if (action == GTK_FILE_CHOOSER_ACTION_OPEN)
+      confirm_text = _("_Open");
 
     dialog_ = gtk_file_chooser_dialog_new(
-        settings.title.c_str(), NULL, action,
-        l10n_util::GetStringUTF8(IDS_APP_CANCEL).c_str(), GTK_RESPONSE_CANCEL,
+        settings.title.c_str(), NULL, action, _("_Cancel"), GTK_RESPONSE_CANCEL,
         confirm_text, GTK_RESPONSE_ACCEPT, NULL);
     if (parent_) {
       parent_->SetEnabled(false);

--- a/shell/browser/ui/file_dialog_gtk.cc
+++ b/shell/browser/ui/file_dialog_gtk.cc
@@ -23,6 +23,25 @@ DialogSettings::~DialogSettings() = default;
 
 namespace {
 
+// Copied from L40-L55 in
+// https://cs.chromium.org/chromium/src/chrome/browser/ui/libgtkui/select_file_dialog_impl_gtk.cc
+#if GTK_CHECK_VERSION(3, 90, 0)
+// GTK stock items have been deprecated.  The docs say to switch to using the
+// strings "_Open", etc.  However this breaks i18n.  We could supply our own
+// internationalized strings, but the "_" in these strings is significant: it's
+// the keyboard shortcut to select these actions.  TODO(thomasanderson): Provide
+// internationalized strings when GTK provides support for it.
+const char kCancelLabel[] = "_Cancel";
+const char kOpenLabel[] = "_Open";
+const char kSaveLabel[] = "_Save";
+#else
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+const char* const kCancelLabel = GTK_STOCK_CANCEL;
+const char* const kOpenLabel = GTK_STOCK_OPEN;
+const char* const kSaveLabel = GTK_STOCK_SAVE;
+G_GNUC_END_IGNORE_DEPRECATIONS
+#endif
+
 static const int kPreviewWidth = 256;
 static const int kPreviewHeight = 512;
 
@@ -52,13 +71,13 @@ class FileChooserDialog {
     if (!settings.button_label.empty())
       confirm_text = settings.button_label.c_str();
     else if (action == GTK_FILE_CHOOSER_ACTION_SAVE)
-      confirm_text = _("_Save");
+      confirm_text = _(kOpenLabel);
     else if (action == GTK_FILE_CHOOSER_ACTION_OPEN)
-      confirm_text = _("_Open");
+      confirm_text = _(kSaveLabel);
 
     dialog_ = gtk_file_chooser_dialog_new(
-        settings.title.c_str(), NULL, action, _("_Cancel"), GTK_RESPONSE_CANCEL,
-        confirm_text, GTK_RESPONSE_ACCEPT, NULL);
+        settings.title.c_str(), NULL, action, _(kCancelLabel),
+        GTK_RESPONSE_CANCEL, confirm_text, GTK_RESPONSE_ACCEPT, NULL);
     if (parent_) {
       parent_->SetEnabled(false);
       libgtkui::SetGtkTransientForAura(dialog_, parent_->GetNativeWindow());


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/19755.

We should be using GTK stock labels on GTK3; the translations will be broken for those using GTK4 but it's in our best interest for now to wait and provide internationalized strings when GTK provides support for it.

cc @ckerr @erickzhao 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Correctly internationalize i18n in GTK-based Linux dialogs.
