### PR TITLE
docs: add exemplary fiddle for `launch in fiddle` feat

### DIFF
--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -14,7 +14,7 @@ property, so writing `let { screen } = require('electron')` will not work.
 
 An example of creating a window that fills the whole screen:
 
-```javascript fiddle='electron/master/docs/fiddles/screen/fit-screen'
+```javascript fiddle='screen/fit-screen'
 const { app, BrowserWindow, screen } = require('electron')
 
 let win

--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -14,7 +14,7 @@ property, so writing `let { screen } = require('electron')` will not work.
 
 An example of creating a window that fills the whole screen:
 
-```javascript fiddle='screen/fit-screen'
+```javascript fiddle='docs/fiddles/screen/fit-screen'
 const { app, BrowserWindow, screen } = require('electron')
 
 let win

--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -14,7 +14,7 @@ property, so writing `let { screen } = require('electron')` will not work.
 
 An example of creating a window that fills the whole screen:
 
-```javascript
+```javascript fiddle='electron/master/docs/fiddles/screen/fit-screen'
 const { app, BrowserWindow, screen } = require('electron')
 
 let win

--- a/docs/fiddles/screen/fit-screen/main.js
+++ b/docs/fiddles/screen/fit-screen/main.js
@@ -1,0 +1,20 @@
+// Retrieve information about screen size, displays, cursor position, etc.
+//
+// For more info, see:
+// https://electronjs.org/docs/api/screen
+
+const { app, BrowserWindow } = require('electron')
+
+let mainWindow = null
+
+app.on('ready', () => {
+  // We cannot require the screen module until the app is ready.
+  const { screen } = require('electron')
+
+  // Create a window that fills the screen's available work area.
+  const primaryDisplay = screen.getPrimaryDisplay()
+  const { width, height } = primaryDisplay.workAreaSize
+
+  mainWindow = new BrowserWindow({ width, height })
+  mainWindow.loadURL('https://electronjs.org')
+})


### PR DESCRIPTION
#### Description of Change
Adds a simple fiddle to demonstrate the `screen` module. 

Used to verify the `Launch in Fiddle` feat on [electronjs.org](https://electronjs.org/).

ref https://github.com/electron/electronjs.org/pull/2848

cc @MarshallOfSound @codebytere @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none