### PR TITLE
fix: use i18nized strings in gtk dialog buttons

### DIFF
--- a/atom/browser/ui/file_dialog_gtk.cc
+++ b/atom/browser/ui/file_dialog_gtk.cc
@@ -4,8 +4,6 @@
 
 #include "atom/browser/ui/file_dialog.h"
 
-#include <glib/gi18n.h>  // _() macro
-
 #include "atom/browser/native_window_views.h"
 #include "atom/browser/unresponsive_suppressor.h"
 #include "base/callback.h"
@@ -22,6 +20,27 @@ DialogSettings::DialogSettings(const DialogSettings&) = default;
 DialogSettings::~DialogSettings() = default;
 
 namespace {
+
+// Copied from L40-L55 in
+// https://cs.chromium.org/chromium/src/chrome/browser/ui/libgtkui/select_file_dialog_impl_gtk.cc
+#if GTK_CHECK_VERSION(3, 90, 0)
+// GTK stock items have been deprecated.  The docs say to switch to using the
+// strings "_Open", etc.  However this breaks i18n.  We could supply our own
+// internationalized strings, but the "_" in these strings is significant: it's
+// the keyboard shortcut to select these actions.  TODO(thomasanderson): Provide
+// internationalized strings when GTK provides support for it.
+const char kCancelLabel[] = "_Cancel";
+const char kOkLabel[] = "_OK";
+const char kOpenLabel[] = "_Open";
+const char kSaveLabel[] = "_Save";
+#else
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+const char* const kCancelLabel = GTK_STOCK_CANCEL;
+const char* const kOkLabel = GTK_STOCK_OK;
+const char* const kOpenLabel = GTK_STOCK_OPEN;
+const char* const kSaveLabel = GTK_STOCK_SAVE;
+G_GNUC_END_IGNORE_DEPRECATIONS
+#endif
 
 static const int kPreviewWidth = 256;
 static const int kPreviewHeight = 512;
@@ -46,17 +65,17 @@ class FileChooserDialog {
   FileChooserDialog(GtkFileChooserAction action, const DialogSettings& settings)
       : parent_(static_cast<atom::NativeWindowViews*>(settings.parent_window)),
         filters_(settings.filters) {
-    const char* confirm_text = _("_OK");
+    const char* confirm_text = kOkLabel;
 
     if (!settings.button_label.empty())
       confirm_text = settings.button_label.c_str();
     else if (action == GTK_FILE_CHOOSER_ACTION_SAVE)
-      confirm_text = _("_Save");
+      confirm_text = kSaveLabel;
     else if (action == GTK_FILE_CHOOSER_ACTION_OPEN)
-      confirm_text = _("_Open");
+      confirm_text = kOpenLabel;
 
     dialog_ = gtk_file_chooser_dialog_new(
-        settings.title.c_str(), NULL, action, _("_Cancel"), GTK_RESPONSE_CANCEL,
+        settings.title.c_str(), NULL, action, kCancelLabel, GTK_RESPONSE_CANCEL,
         confirm_text, GTK_RESPONSE_ACCEPT, NULL);
     if (parent_) {
       parent_->SetEnabled(false);


### PR DESCRIPTION
Backport of #19756

See that PR for details.

NB: trop failed so this is a manual backport.

CC @codebytere 

#### Release Notes

Notes: Fixed i18n of GTK dialog buttons.