### PR TITLE
fix: return property enum type in open/save dialogs

### DIFF
--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -66,6 +66,8 @@ const setupDialogProperties = (type, properties) => {
       dialogProperties |= dialogPropertiesTypes[prop]
     }
   }
+
+  return dialogProperties
 }
 
 const saveDialog = (sync, window, options) => {


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/19779.

This was returning `undefined` instead of a number, owing to a refactor which did not return the final int value. This fixes that.

Tested with Dialog Show-Me in Fiddle.

cc @DeerMichel 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue with open and save dialogs selecting properties.
