### PR TITLE
docs: MessageBoxOptions.icon should allow type string

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -242,7 +242,7 @@ expanding and collapsing the dialog.
     include a checkbox with the given label.
   * `checkboxChecked` Boolean (optional) - Initial checked state of the
     checkbox. `false` by default.
-  * `icon` [NativeImage](native-image.md) (optional)
+  * `icon` ([NativeImage](native-image.md) | String) (optional)
   * `cancelId` Integer (optional) - The index of the button to be used to cancel the dialog, via
     the `Esc` key. By default this is assigned to the first button with "cancel" or "no" as the
     label. If no such labeled buttons exist and this option is not set, `0` will be used as the


### PR DESCRIPTION
#### Description of Change
In the `dialog` documentation (and the generated typings in `electron.d.ts`), it is mentionned that the `icon` property only supports `NativeImage`, but the `nativeImage` documentation says that:

```
In Electron, for the APIs that take images, you can pass either file paths or NativeImage
```
This PR adds support for the type `string` through a change in the documentation to match `BrowserWindowConstructorOptions.icon?: (NativeImage) | (string);` from `electron.d.ts`. This change should result in `MessageBoxOptions.icon?: NativeImage;` becoming `MessageBoxOptions.icon?: (NativeImage) | (string);`

Related documentation:
https://electronjs.org/docs/api/dialog#dialogshowmessageboxbrowserwindow-options
https://electronjs.org/docs/api/browser-window#new-browserwindowoptions
https://electronjs.org/docs/api/native-image#nativeimage

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Allowed `string` as type on `MessageBoxOptions.icon` to support file paths as mentioned in `NativeImage` documentation
