### PR TITLE
feat: Allow inspection of specific shared workers

### DIFF
--- a/docs/api/structures/shared-worker-info.md
+++ b/docs/api/structures/shared-worker-info.md
@@ -1,0 +1,4 @@
+# WorkerInfo Object
+
+* `id` String - The unique id of the shared worker
+* `url` String - The url of the shared worker

--- a/docs/api/structures/shared-worker-info.md
+++ b/docs/api/structures/shared-worker-info.md
@@ -1,4 +1,4 @@
 # WorkerInfo Object
 
-* `id` String - The unique id of the shared worker
-* `url` String - The url of the shared worker
+* `id` String - The unique id of the shared worker.
+* `url` String - The url of the shared worker.

--- a/docs/api/structures/shared-worker-info.md
+++ b/docs/api/structures/shared-worker-info.md
@@ -1,4 +1,4 @@
-# WorkerInfo Object
+# SharedWorkerInfo Object
 
 * `id` String - The unique id of the shared worker.
 * `url` String - The url of the shared worker.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1461,6 +1461,16 @@ Starts inspecting element at position (`x`, `y`).
 
 Opens the developer tools for the shared worker context.
 
+#### `contents.inspectSharedWorkerById(workerId)`
+
+* `workerId` String
+
+Inspects the shared worker based on its ID.
+
+#### `contents.getAllSharedWorkers()`
+
+Returns `WorkerInfo[]` - An array of WorkerInfo objects of sharedworkers.
+
 #### `contents.inspectServiceWorker()`
 
 Opens the developer tools for the service worker context.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1469,7 +1469,7 @@ Inspects the shared worker based on its ID.
 
 #### `contents.getAllSharedWorkers()`
 
-Returns `WorkerInfo[]` - Information about all Shared Workers. An empty array if there's no Shared Workers.
+Returns [`SharedWorkerInfo[]`](strcutures/shared-worker-info.md) - Information about all Shared Workers. An empty array if there's no Shared Workers.
 
 #### `contents.inspectServiceWorker()`
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1469,7 +1469,7 @@ Inspects the shared worker based on its ID.
 
 #### `contents.getAllSharedWorkers()`
 
-Returns `WorkerInfo[]` - An array of WorkerInfo objects of sharedworkers.
+Returns `WorkerInfo[]` - Information about all Shared Workers. An empty array if there's no Shared Workers.
 
 #### `contents.inspectServiceWorker()`
 

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -110,6 +110,7 @@ auto_filenames = {
     "docs/api/structures/remove-password.md",
     "docs/api/structures/scrubber-item.md",
     "docs/api/structures/segmented-control-segment.md",
+    "docs/api/structures/shared-worker-info.md",
     "docs/api/structures/shortcut-details.md",
     "docs/api/structures/size.md",
     "docs/api/structures/stream-protocol-response.md",

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -8,6 +8,7 @@
 #include <set>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "base/message_loop/message_loop_current.h"
 #include "base/no_destructor.h"
@@ -296,6 +297,18 @@ struct Converter<electron::api::WebContents::Type> {
       return false;
     }
     return true;
+  }
+};
+
+template <>
+struct Converter<scoped_refptr<content::DevToolsAgentHost>> {
+  static v8::Local<v8::Value> ToV8(
+      v8::Isolate* isolate,
+      const scoped_refptr<content::DevToolsAgentHost>& val) {
+    mate::Dictionary dict(isolate, v8::Object::New(isolate));
+    dict.Set("id", val->GetId());
+    dict.Set("url", val->GetURL().spec());
+    return dict.GetHandle();
   }
 };
 
@@ -1547,6 +1560,44 @@ void WebContents::InspectElement(int x, int y) {
   managed_web_contents()->InspectElement(x, y);
 }
 
+void WebContents::InspectSharedWorkerById(const std::string& workerId) {
+  if (type_ == Type::REMOTE)
+    return;
+
+  if (!enable_devtools_)
+    return;
+
+  for (const auto& agent_host : content::DevToolsAgentHost::GetOrCreateAll()) {
+    if (agent_host->GetType() ==
+        content::DevToolsAgentHost::kTypeSharedWorker) {
+      if (agent_host->GetId() == workerId) {
+        OpenDevTools(nullptr);
+        managed_web_contents()->AttachTo(agent_host);
+        break;
+      }
+    }
+  }
+}
+
+std::vector<scoped_refptr<content::DevToolsAgentHost>>
+WebContents::GetAllSharedWorkers() {
+  std::vector<scoped_refptr<content::DevToolsAgentHost>> shared_workers;
+
+  if (type_ == Type::REMOTE)
+    return shared_workers;
+
+  if (!enable_devtools_)
+    return shared_workers;
+
+  for (const auto& agent_host : content::DevToolsAgentHost::GetOrCreateAll()) {
+    if (agent_host->GetType() ==
+        content::DevToolsAgentHost::kTypeSharedWorker) {
+      shared_workers.push_back(agent_host);
+    }
+  }
+  return shared_workers;
+}
+
 void WebContents::InspectSharedWorker() {
   if (type_ == Type::REMOTE)
     return;
@@ -2471,6 +2522,9 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("getOwnerBrowserWindow", &WebContents::GetOwnerBrowserWindow)
       .SetMethod("inspectServiceWorker", &WebContents::InspectServiceWorker)
       .SetMethod("inspectSharedWorker", &WebContents::InspectSharedWorker)
+      .SetMethod("inspectSharedWorkerById",
+                 &WebContents::InspectSharedWorkerById)
+      .SetMethod("getAllSharedWorkers", &WebContents::GetAllSharedWorkers)
 #if BUILDFLAG(ENABLE_PRINTING)
       .SetMethod("_print", &WebContents::Print)
       .SetMethod("_getPrinters", &WebContents::GetPrinterList)

--- a/shell/browser/api/atom_api_web_contents.h
+++ b/shell/browser/api/atom_api_web_contents.h
@@ -13,6 +13,7 @@
 #include "base/observer_list.h"
 #include "base/observer_list_types.h"
 #include "content/common/cursors/webcursor.h"
+#include "content/public/browser/devtools_agent_host.h"
 #include "content/public/browser/keyboard_event_processing_result.h"
 #include "content/public/browser/render_widget_host.h"
 #include "content/public/browser/web_contents.h"
@@ -171,6 +172,8 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void DisableDeviceEmulation();
   void InspectElement(int x, int y);
   void InspectSharedWorker();
+  void InspectSharedWorkerById(const std::string& workerId);
+  std::vector<scoped_refptr<content::DevToolsAgentHost>> GetAllSharedWorkers();
   void InspectServiceWorker();
   void SetIgnoreMenuShortcuts(bool ignore);
   void SetAudioMuted(bool muted);

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -605,7 +605,7 @@ describe('webContents module', () => {
     })
   })
 
-  // FIXME: disable during chromium update due to crash in content::WorkerScriptFetchInitation::CreateScriptLoaderOnIO
+  // FIXME: disable during chromium update due to crash in content::WorkerScriptFetchInitation::CreateScriptLoaderOnIO.
   xdescribe('Shared Workers', () => {
     let worker1
     let worker2

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -609,14 +609,12 @@ describe('webContents module', () => {
   xdescribe('Shared Workers', () => {
     let worker1
     let worker2
-    let workers
 
     before(() => {
       worker1 = new SharedWorker('../fixtures/api/shared-worker/shared-worker1.js')
       worker2 = new SharedWorker('../fixtures/api/shared-worker/shared-worker2.js')
       worker1.port.start()
       worker2.port.start()
-      workers = []
     })
 
     after(() => {
@@ -626,16 +624,16 @@ describe('webContents module', () => {
 
     it('can get multiple shared workers', () => {
       const contents = remote.getCurrentWebContents()
-      workers = contents.getAllSharedWorkers()
+      const sharedWorkers = contents.getAllSharedWorkers()
 
-      expect(workers.length).to.equal(2)
-      expect(workers[0].url).to.contain('shared-worker')
-      expect(workers[1].url).to.contain('shared-worker')
+      expect(sharedWorkers.length).to.equal(2)
+      expect(sharedWorkers[0].url).to.contain('shared-worker')
+      expect(sharedWorkers[1].url).to.contain('shared-worker')
     })
 
     it('can inspect a specific shared worker', (done) => {
       const contents = webContents.getAllWebContents()
-      workers = contents.getAllSharedWorkers()
+      const sharedWorkers = contents.getAllSharedWorkers()
 
       contents.once('devtools-opened', () => {
         contents.closeDevTools()
@@ -643,7 +641,7 @@ describe('webContents module', () => {
       contents.once('devtools-closed', () => {
         done()
       })
-      contents.inspectSharedWorkerById(workers[0].id)
+      contents.inspectSharedWorkerById(sharedWorkers[0].id)
     })
   })
 })

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -616,6 +616,7 @@ describe('webContents module', () => {
       worker2 = new SharedWorker('../fixtures/api/shared-worker/shared-worker2.js')
       worker1.port.start()
       worker2.port.start()
+      vectorOfWorkers = []
     })
 
     after(() => {
@@ -624,8 +625,8 @@ describe('webContents module', () => {
     })
 
     it('can get multiple shared workers', () => {
-      const contents = webContents.getAllWebContents()
-      vectorOfWorkers = contents[0].getAllSharedWorkers()
+      const contents = remote.getCurrentWebContents()
+      vectorOfWorkers = contents.getAllSharedWorkers()
 
       expect(vectorOfWorkers.length).to.equal(2)
       expect(vectorOfWorkers[0].url).to.contain('shared-worker')

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -609,14 +609,14 @@ describe('webContents module', () => {
   xdescribe('Shared Workers', () => {
     let worker1
     let worker2
-    let vectorOfWorkers
+    let workers
 
     before(() => {
       worker1 = new SharedWorker('../fixtures/api/shared-worker/shared-worker1.js')
       worker2 = new SharedWorker('../fixtures/api/shared-worker/shared-worker2.js')
       worker1.port.start()
       worker2.port.start()
-      vectorOfWorkers = []
+      workers = []
     })
 
     after(() => {
@@ -626,22 +626,24 @@ describe('webContents module', () => {
 
     it('can get multiple shared workers', () => {
       const contents = remote.getCurrentWebContents()
-      vectorOfWorkers = contents.getAllSharedWorkers()
+      workers = contents.getAllSharedWorkers()
 
-      expect(vectorOfWorkers.length).to.equal(2)
-      expect(vectorOfWorkers[0].url).to.contain('shared-worker')
-      expect(vectorOfWorkers[1].url).to.contain('shared-worker')
+      expect(workers.length).to.equal(2)
+      expect(workers[0].url).to.contain('shared-worker')
+      expect(workers[1].url).to.contain('shared-worker')
     })
 
     it('can inspect a specific shared worker', (done) => {
       const contents = webContents.getAllWebContents()
-      contents[0].once('devtools-opened', () => {
-        contents[0].closeDevTools()
+      workers = contents.getAllSharedWorkers()
+
+      contents.once('devtools-opened', () => {
+        contents.closeDevTools()
       })
-      contents[0].once('devtools-closed', () => {
+      contents.once('devtools-closed', () => {
         done()
       })
-      contents[0].inspectSharedWorkerById(vectorOfWorkers[0].id)
+      contents.inspectSharedWorkerById(workers[0].id)
     })
   })
 })

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -605,8 +605,7 @@ describe('webContents module', () => {
     })
   })
 
-  // FIXME: disable during chromium update due to crash in content::WorkerScriptFetchInitation::CreateScriptLoaderOnIO.
-  xdescribe('Shared Workers', () => {
+  describe('Shared Workers', () => {
     let worker1
     let worker2
 
@@ -632,7 +631,7 @@ describe('webContents module', () => {
     })
 
     it('can inspect a specific shared worker', (done) => {
-      const contents = webContents.getAllWebContents()
+      const contents = remote.getCurrentWebContents()
       const sharedWorkers = contents.getAllSharedWorkers()
 
       contents.once('devtools-opened', () => {

--- a/spec/fixtures/api/shared-worker/shared-worker1.js
+++ b/spec/fixtures/api/shared-worker/shared-worker1.js
@@ -1,0 +1,6 @@
+self.onconnect = function (e) {
+  const port = e.ports[0]
+  port.onmessage = function (e) {
+
+  }
+}

--- a/spec/fixtures/api/shared-worker/shared-worker2.js
+++ b/spec/fixtures/api/shared-worker/shared-worker2.js
@@ -1,0 +1,7 @@
+self.onconnect = function (e) {
+  const port = e.ports[0]
+
+  port.onmessage = function (e) {
+
+  }
+}


### PR DESCRIPTION
#### Description of Change
Added APIs to allow electron to get a list of shared web workers and then inspect 
a shared worker based on its ID.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [X] `npm test` passes
- [X] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [X] relevant documentation is changed or added
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added ability to inspect specific shared workers <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
