### PR TITLE
chore: add error throwing utility

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -490,6 +490,8 @@ filenames = {
     "shell/common/keyboard_util.h",
     "shell/common/deprecate_util.cc",
     "shell/common/deprecate_util.h",
+    "shell/common/error_util.cc",
+    "shell/common/error_util.h",
     "shell/common/mouse_util.cc",
     "shell/common/mouse_util.h",
     "shell/common/mac/main_application_bundle.h",

--- a/native_mate/native_mate/function_template.h
+++ b/native_mate/native_mate/function_template.h
@@ -5,6 +5,7 @@
 #ifndef NATIVE_MATE_NATIVE_MATE_FUNCTION_TEMPLATE_H_
 #define NATIVE_MATE_NATIVE_MATE_FUNCTION_TEMPLATE_H_
 
+#include "../shell/common/error_util.h"
 #include "base/callback.h"
 #include "base/logging.h"
 #include "native_mate/arguments.h"
@@ -125,6 +126,16 @@ inline bool GetNextArgument(Arguments* args,
                             bool is_first,
                             v8::Isolate** result) {
   *result = args->isolate();
+  return true;
+}
+
+// Allow clients to pass a util::Error to throw errors if they
+// don't need the full mate::Arguments
+inline bool GetNextArgument(Arguments* args,
+                            int create_flags,
+                            bool is_first,
+                            electron::util::Error* result) {
+  *result = electron::util::Error(args->isolate());
   return true;
 }
 

--- a/native_mate/native_mate/function_template.h
+++ b/native_mate/native_mate/function_template.h
@@ -134,8 +134,8 @@ inline bool GetNextArgument(Arguments* args,
 inline bool GetNextArgument(Arguments* args,
                             int create_flags,
                             bool is_first,
-                            electron::util::Error* result) {
-  *result = electron::util::Error(args->isolate());
+                            electron::util::ErrorThrower* result) {
+  *result = electron::util::ErrorThrower(args->isolate());
   return true;
 }
 

--- a/shell/browser/api/atom_api_system_preferences.h
+++ b/shell/browser/api/atom_api_system_preferences.h
@@ -96,7 +96,8 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
   void RemoveUserDefault(const std::string& name);
   bool IsSwipeTrackingFromScrollEventsEnabled();
 
-  std::string GetSystemColor(util::Error error, const std::string& color);
+  std::string GetSystemColor(util::ErrorThrower thrower,
+                             const std::string& color);
 
   bool CanPromptTouchID();
   v8::Local<v8::Promise> PromptTouchID(v8::Isolate* isolate,

--- a/shell/browser/api/atom_api_system_preferences.h
+++ b/shell/browser/api/atom_api_system_preferences.h
@@ -12,6 +12,7 @@
 #include "base/values.h"
 #include "native_mate/handle.h"
 #include "shell/browser/api/event_emitter.h"
+#include "shell/common/error_util.h"
 #include "shell/common/promise_util.h"
 
 #if defined(OS_WIN)
@@ -95,7 +96,7 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
   void RemoveUserDefault(const std::string& name);
   bool IsSwipeTrackingFromScrollEventsEnabled();
 
-  std::string GetSystemColor(const std::string& color, mate::Arguments* args);
+  std::string GetSystemColor(util::Error error, const std::string& color);
 
   bool CanPromptTouchID();
   v8::Local<v8::Promise> PromptTouchID(v8::Isolate* isolate,

--- a/shell/browser/api/atom_api_system_preferences_mac.mm
+++ b/shell/browser/api/atom_api_system_preferences_mac.mm
@@ -405,7 +405,7 @@ std::string SystemPreferences::GetAccentColor() {
   return base::SysNSStringToUTF8([sysColor RGBAValue]);
 }
 
-std::string SystemPreferences::GetSystemColor(util::Error error,
+std::string SystemPreferences::GetSystemColor(util::ErrorThrower thrower,
                                               const std::string& color) {
   NSColor* sysColor = nil;
   if (color == "blue") {
@@ -427,7 +427,7 @@ std::string SystemPreferences::GetSystemColor(util::Error error,
   } else if (color == "yellow") {
     sysColor = [NSColor systemYellowColor];
   } else {
-    error.ThrowError("Unknown system color: " + color);
+    thrower.ThrowError("Unknown system color: " + color);
     return "";
   }
 

--- a/shell/browser/api/atom_api_system_preferences_mac.mm
+++ b/shell/browser/api/atom_api_system_preferences_mac.mm
@@ -405,8 +405,8 @@ std::string SystemPreferences::GetAccentColor() {
   return base::SysNSStringToUTF8([sysColor RGBAValue]);
 }
 
-std::string SystemPreferences::GetSystemColor(const std::string& color,
-                                              mate::Arguments* args) {
+std::string SystemPreferences::GetSystemColor(util::Error error,
+                                              const std::string& color) {
   NSColor* sysColor = nil;
   if (color == "blue") {
     sysColor = [NSColor systemBlueColor];
@@ -427,7 +427,7 @@ std::string SystemPreferences::GetSystemColor(const std::string& color,
   } else if (color == "yellow") {
     sysColor = [NSColor systemYellowColor];
   } else {
-    args->ThrowError("Unknown system color: " + color);
+    error.ThrowError("Unknown system color: " + color);
     return "";
   }
 

--- a/shell/common/error_util.cc
+++ b/shell/common/error_util.cc
@@ -21,38 +21,23 @@ ErrorThrower::ErrorThrower() : isolate_(v8::Isolate::GetCurrent()) {}
 ErrorThrower::~ErrorThrower() = default;
 
 void ErrorThrower::ThrowError(const std::string& err_msg) {
-  v8::Local<v8::Value> exception =
-      v8::Exception::Error(mate::StringToV8(isolate_, err_msg));
-  if (!isolate_->IsExecutionTerminating())
-    isolate_->ThrowException(exception);
+  Throw(v8::Exception::Error, err_msg);
 }
 
 void ErrorThrower::ThrowTypeError(const std::string& err_msg) {
-  v8::Local<v8::Value> exception =
-      v8::Exception::TypeError(mate::StringToV8(isolate_, err_msg));
-  if (!isolate_->IsExecutionTerminating())
-    isolate_->ThrowException(exception);
+  Throw(v8::Exception::TypeError, err_msg);
 }
 
 void ErrorThrower::ThrowRangeError(const std::string& err_msg) {
-  v8::Local<v8::Value> exception =
-      v8::Exception::RangeError(mate::StringToV8(isolate_, err_msg));
-  if (!isolate_->IsExecutionTerminating())
-    isolate_->ThrowException(exception);
+  Throw(v8::Exception::RangeError, err_msg);
 }
 
 void ErrorThrower::ThrowReferenceError(const std::string& err_msg) {
-  v8::Local<v8::Value> exception =
-      v8::Exception::ReferenceError(mate::StringToV8(isolate_, err_msg));
-  if (!isolate_->IsExecutionTerminating())
-    isolate_->ThrowException(exception);
+  Throw(v8::Exception::ReferenceError, err_msg);
 }
 
 void ErrorThrower::ThrowSyntaxError(const std::string& err_msg) {
-  v8::Local<v8::Value> exception =
-      v8::Exception::SyntaxError(mate::StringToV8(isolate_, err_msg));
-  if (!isolate_->IsExecutionTerminating())
-    isolate_->ThrowException(exception);
+  Throw(v8::Exception::SyntaxError, err_msg);
 }
 
 }  // namespace util

--- a/shell/common/error_util.cc
+++ b/shell/common/error_util.cc
@@ -1,0 +1,60 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include <string>
+
+#include "native_mate/converter.h"
+#include "shell/common/error_util.h"
+
+namespace electron {
+
+namespace util {
+
+Error::Error(v8::Isolate* isolate) : isolate_(isolate) {}
+
+// This constructor should be rarely if ever used, since
+// v8::Isolate::GetCurrent() uses atomic loads and is thus a bit
+// costly to invoke
+Error::Error() : isolate_(v8::Isolate::GetCurrent()) {}
+
+Error::~Error() = default;
+
+void Error::ThrowError(const std::string& err_msg) {
+  v8::Local<v8::Value> exception =
+      v8::Exception::Error(mate::StringToV8(isolate_, err_msg));
+  if (!isolate_->IsExecutionTerminating())
+    isolate_->ThrowException(exception);
+}
+
+void Error::ThrowTypeError(const std::string& err_msg) {
+  v8::Local<v8::Value> exception =
+      v8::Exception::TypeError(mate::StringToV8(isolate_, err_msg));
+  if (!isolate_->IsExecutionTerminating())
+    isolate_->ThrowException(exception);
+}
+
+void Error::ThrowRangeError(const std::string& err_msg) {
+  v8::Local<v8::Value> exception =
+      v8::Exception::RangeError(mate::StringToV8(isolate_, err_msg));
+  if (!isolate_->IsExecutionTerminating())
+    isolate_->ThrowException(exception);
+}
+
+void Error::ThrowReferenceError(const std::string& err_msg) {
+  v8::Local<v8::Value> exception =
+      v8::Exception::ReferenceError(mate::StringToV8(isolate_, err_msg));
+  if (!isolate_->IsExecutionTerminating())
+    isolate_->ThrowException(exception);
+}
+
+void Error::ThrowSyntaxError(const std::string& err_msg) {
+  v8::Local<v8::Value> exception =
+      v8::Exception::SyntaxError(mate::StringToV8(isolate_, err_msg));
+  if (!isolate_->IsExecutionTerminating())
+    isolate_->ThrowException(exception);
+}
+
+}  // namespace util
+
+}  // namespace electron

--- a/shell/common/error_util.cc
+++ b/shell/common/error_util.cc
@@ -11,44 +11,44 @@ namespace electron {
 
 namespace util {
 
-Error::Error(v8::Isolate* isolate) : isolate_(isolate) {}
+ErrorThrower::ErrorThrower(v8::Isolate* isolate) : isolate_(isolate) {}
 
 // This constructor should be rarely if ever used, since
 // v8::Isolate::GetCurrent() uses atomic loads and is thus a bit
 // costly to invoke
-Error::Error() : isolate_(v8::Isolate::GetCurrent()) {}
+ErrorThrower::ErrorThrower() : isolate_(v8::Isolate::GetCurrent()) {}
 
-Error::~Error() = default;
+ErrorThrower::~ErrorThrower() = default;
 
-void Error::ThrowError(const std::string& err_msg) {
+void ErrorThrower::ThrowError(const std::string& err_msg) {
   v8::Local<v8::Value> exception =
       v8::Exception::Error(mate::StringToV8(isolate_, err_msg));
   if (!isolate_->IsExecutionTerminating())
     isolate_->ThrowException(exception);
 }
 
-void Error::ThrowTypeError(const std::string& err_msg) {
+void ErrorThrower::ThrowTypeError(const std::string& err_msg) {
   v8::Local<v8::Value> exception =
       v8::Exception::TypeError(mate::StringToV8(isolate_, err_msg));
   if (!isolate_->IsExecutionTerminating())
     isolate_->ThrowException(exception);
 }
 
-void Error::ThrowRangeError(const std::string& err_msg) {
+void ErrorThrower::ThrowRangeError(const std::string& err_msg) {
   v8::Local<v8::Value> exception =
       v8::Exception::RangeError(mate::StringToV8(isolate_, err_msg));
   if (!isolate_->IsExecutionTerminating())
     isolate_->ThrowException(exception);
 }
 
-void Error::ThrowReferenceError(const std::string& err_msg) {
+void ErrorThrower::ThrowReferenceError(const std::string& err_msg) {
   v8::Local<v8::Value> exception =
       v8::Exception::ReferenceError(mate::StringToV8(isolate_, err_msg));
   if (!isolate_->IsExecutionTerminating())
     isolate_->ThrowException(exception);
 }
 
-void Error::ThrowSyntaxError(const std::string& err_msg) {
+void ErrorThrower::ThrowSyntaxError(const std::string& err_msg) {
   v8::Local<v8::Value> exception =
       v8::Exception::SyntaxError(mate::StringToV8(isolate_, err_msg));
   if (!isolate_->IsExecutionTerminating())

--- a/shell/common/error_util.h
+++ b/shell/common/error_util.h
@@ -29,6 +29,14 @@ class ErrorThrower {
  private:
   v8::Isolate* isolate() const { return isolate_; }
 
+  using ErrorGenerator =
+      v8::Local<v8::Value> (*)(v8::Local<v8::String> err_msg);
+  void Throw(ErrorGenerator gen, const std::string& err_msg) {
+    v8::Local<v8::Value> exception = gen(mate::StringToV8(isolate_, err_msg));
+    if (!isolate_->IsExecutionTerminating())
+      isolate_->ThrowException(exception);
+  }
+
   v8::Isolate* isolate_;
 };
 

--- a/shell/common/error_util.h
+++ b/shell/common/error_util.h
@@ -6,25 +6,19 @@
 #define SHELL_COMMON_ERROR_UTIL_H_
 
 #include <string>
-#include <utility>
 
 #include "native_mate/converter.h"
-#include "third_party/blink/renderer/platform/bindings/v8_throw_exception.h"
 
 namespace electron {
 
 namespace util {
 
-// A wrapper around V8ThrowException.
-
-class Error {
+class ErrorThrower {
  public:
-  Error(v8::Isolate* isolate);
-  Error();
+  explicit ErrorThrower(v8::Isolate* isolate);
+  ErrorThrower();
 
-  ~Error();
-
-  v8::Isolate* isolate() const { return isolate_; }
+  ~ErrorThrower();
 
   void ThrowError(const std::string& err_msg);
   void ThrowTypeError(const std::string& err_msg);
@@ -33,6 +27,8 @@ class Error {
   void ThrowSyntaxError(const std::string& err_msg);
 
  private:
+  v8::Isolate* isolate() const { return isolate_; }
+
   v8::Isolate* isolate_;
 };
 

--- a/shell/common/error_util.h
+++ b/shell/common/error_util.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_COMMON_ERROR_UTIL_H_
+#define SHELL_COMMON_ERROR_UTIL_H_
+
+#include <string>
+#include <utility>
+
+#include "native_mate/converter.h"
+#include "third_party/blink/renderer/platform/bindings/v8_throw_exception.h"
+
+namespace electron {
+
+namespace util {
+
+// A wrapper around V8ThrowException.
+
+class Error {
+ public:
+  Error(v8::Isolate* isolate);
+  Error();
+
+  ~Error();
+
+  v8::Isolate* isolate() const { return isolate_; }
+
+  void ThrowError(const std::string& err_msg);
+  void ThrowTypeError(const std::string& err_msg);
+  void ThrowRangeError(const std::string& err_msg);
+  void ThrowReferenceError(const std::string& err_msg);
+  void ThrowSyntaxError(const std::string& err_msg);
+
+ private:
+  v8::Isolate* isolate_;
+};
+
+}  // namespace util
+
+}  // namespace electron
+
+#endif  // SHELL_COMMON_ERROR_UTIL_H_

--- a/spec-main/api-system-preferences-spec.ts
+++ b/spec-main/api-system-preferences-spec.ts
@@ -117,6 +117,13 @@ describe('systemPreferences module', () => {
   })
 
   ifdescribe(process.platform === 'darwin')('systemPreferences.getSystemColor(color)', () => {
+    it('throws on invalid system colors', () => {
+      const color = 'bad-color'
+      expect(() => {
+        systemPreferences.getSystemColor(color as any)
+      }).to.throw(`Unknown system color: ${color}`)
+    })
+  
     it('returns a valid system color', () => {
       const colors = ['blue', 'brown', 'gray', 'green', 'orange', 'pink', 'purple', 'red', 'yellow']
       


### PR DESCRIPTION
#### Description of Change

This PR introduces a new error utility that is intended to solve a problem present in varying places around the codebase - namely, passing `mate::Arguments*` for no other purpose than to throw errors to JS. This aims to solve that problem with a new `util::ErrorThrower` class, whose sole purpose is to throw one of a set of descriptive errors, and to do that **only**. I included a proof-of-concept conversion to this new pattern in `SystemPreferences::GetSystemColor`, which is tested to work on macOS. 

It increases ease of readability for parameters, since it's often unclear _why_ we're passing `mate::Arguments*` to a given function since `mate::Arguments*` is basically analogous to 'anything'. In a follow-up PR, I plan to introduce the ability to return a thrown error so that we no longer need to do:

```cpp
thrower.ThrowError("oh no you did a bad thing");
return std::string();
```

and can instead cleanly reduce LoC with:

```cpp
return thrower.ThrowError("oh no you did a bad thing");
```

independent of the caller fn's return type.

cc @ckerr @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
