### PR TITLE
docs: update documentation under tutorials

### DIFF
--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -28,7 +28,7 @@ see [SECURITY.md](https://github.com/electron/electron/tree/master/SECURITY.md)
 ## Chromium Security Issues and Upgrades
 
 Electron keeps up to date with the latest stable Chromium release. For more information,
-see the [Electron blog](https://electronjs.org/blog/12-week-cadence).
+see the [Electron Release Cadence blog post](https://electronjs.org/blog/12-week-cadence).
 
 ## Security Is Everyone's Responsibility
 

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -27,7 +27,7 @@ see [SECURITY.md](https://github.com/electron/electron/tree/master/SECURITY.md)
 
 ## Chromium Security Issues and Upgrades
 
-Electron is now up to date with the latest chromium release. For more information, 
+Electron is now up to date with the latest chromium release. For more information,
 see the [Electron blog](https://electronjs.org/blog/12-week-cadence).
 
 We are interested in hearing more about specific use cases from the people that 

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -27,17 +27,11 @@ see [SECURITY.md](https://github.com/electron/electron/tree/master/SECURITY.md)
 
 ## Chromium Security Issues and Upgrades
 
-While Electron strives to support new versions of Chromium as soon as possible,
-developers should be aware that upgrading is a serious undertaking - involving
-hand-editing dozens or even hundreds of files. Given the resources and
-contributions available today, Electron will often not be on the very latest
-version of Chromium, lagging behind by several weeks or a few months.
+Electron is now up to date with the latest chromium release. For more information, 
+see the [Electron blog](https://electronjs.org/blog/12-week-cadence).
 
-We feel that our current system of updating the Chromium component strikes an
-appropriate balance between the resources we have available and the needs of
-the majority of applications built on top of the framework. We definitely are
-interested in hearing more about specific use cases from the people that build
-things on top of Electron. Pull requests and contributions supporting this
+We are interested in hearing more about specific use cases from the people that 
+build things on top of Electron. Pull requests and contributions supporting this
 effort are always very welcome.
 
 ## Security Is Everyone's Responsibility

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -27,7 +27,7 @@ see [SECURITY.md](https://github.com/electron/electron/tree/master/SECURITY.md)
 
 ## Chromium Security Issues and Upgrades
 
-Electron keeps up to date with the latest stable Chromium release. For more information,
+Electron keeps up to date with alternating Chromium releases. For more information,
 see the [Electron Release Cadence blog post](https://electronjs.org/blog/12-week-cadence).
 
 ## Security Is Everyone's Responsibility

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -27,7 +27,7 @@ see [SECURITY.md](https://github.com/electron/electron/tree/master/SECURITY.md)
 
 ## Chromium Security Issues and Upgrades
 
-Electron is now up to date with the latest chromium release. For more information,
+Electron keeps up to date with the latest stable Chromium release. For more information,
 see the [Electron blog](https://electronjs.org/blog/12-week-cadence).
 
 We are interested in hearing more about specific use cases from the people that 

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -30,10 +30,6 @@ see [SECURITY.md](https://github.com/electron/electron/tree/master/SECURITY.md)
 Electron keeps up to date with the latest stable Chromium release. For more information,
 see the [Electron blog](https://electronjs.org/blog/12-week-cadence).
 
-We are interested in hearing more about specific use cases from the people that 
-build things on top of Electron. Pull requests and contributions supporting this
-effort are always very welcome.
-
 ## Security Is Everyone's Responsibility
 
 It is important to remember that the security of your Electron application is


### PR DESCRIPTION
#### Description of Change
Change the documentation to reflect the fact that Electron is now kept up to date with Chromium.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] relevant documentation is changed or added

#### Release Notes
notes: Update documentation to reflect that Electron is now up to date with a stable version of Chromium.
