### PR TITLE
fix: disable LayoutNG to prevent random crashes in selection calcuations

### DIFF
--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -212,8 +212,7 @@ void AtomBrowserMainParts::InitializeFeatureList() {
       std::string(",") + features::kSpareRendererForSitePerProcess.name;
   // Disable LayoutNG as it still isn't fully enabled in Chrome and currently
   // is still causing crashes during every day use such as text selection.
-  disable_features +=
-      std::string(",") + blink::features::kLayoutNG.name;
+  disable_features += std::string(",") + blink::features::kLayoutNG.name;
   auto feature_list = std::make_unique<base::FeatureList>();
   feature_list->InitializeFromCommandLine(enable_features, disable_features);
   base::FeatureList::SetInstance(std::move(feature_list));

--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -48,6 +48,7 @@
 #include "services/device/public/mojom/constants.mojom.h"
 #include "services/network/public/cpp/features.h"
 #include "services/service_manager/public/cpp/connector.h"
+#include "third_party/blink/public/common/features.h"
 #include "ui/base/idle/idle.h"
 #include "ui/base/material_design/material_design_controller.h"
 #include "ui/base/ui_base_switches.h"
@@ -209,6 +210,10 @@ void AtomBrowserMainParts::InitializeFeatureList() {
   // when node integration is enabled.
   disable_features +=
       std::string(",") + features::kSpareRendererForSitePerProcess.name;
+  // Disable LayoutNG as it still isn't fully enabled in Chrome and currently
+  // is still causing crashes during every day use such as text selection.
+  disable_features +=
+      std::string(",") + blink::features::kLayoutNG.name;
   auto feature_list = std::make_unique<base::FeatureList>();
   feature_list->InitializeFromCommandLine(enable_features, disable_features);
   base::FeatureList::SetInstance(std::move(feature_list));


### PR DESCRIPTION
Upstream Bug: https://bugs.chromium.org/p/chromium/issues/detail?id=992929
CL that caused it: https://chromium-review.googlesource.com/c/chromium/src/+/1598319

Even Chrome doesn't have LayoutNG enabled in C76 and if you try to turn it on Chrome violently crashes so I think we're right to turn this off.

In particular LayoutNG causes a crash when selecting "wbr" elements in certain fonts under certain layout conditions.  (I can't be much more specific or do a repro outside of a Slack specific message).

Notes: Fixed occasional crashes while selecting text