### PR TITLE
refactor: make util::Promise type safe when chaining in native

### DIFF
--- a/shell/browser/api/atom_api_app.cc
+++ b/shell/browser/api/atom_api_app.cc
@@ -531,7 +531,7 @@ int ImportIntoCertStore(CertificateManagerModel* model,
 }
 #endif
 
-void OnIconDataAvailable(util::Promise promise, gfx::Image icon) {
+void OnIconDataAvailable(util::Promise<gfx::Image> promise, gfx::Image icon) {
   if (!icon.IsEmpty()) {
     promise.Resolve(icon);
   } else {
@@ -1162,7 +1162,7 @@ JumpListResult App::SetJumpList(v8::Local<v8::Value> val,
 
 v8::Local<v8::Promise> App::GetFileIcon(const base::FilePath& path,
                                         mate::Arguments* args) {
-  util::Promise promise(isolate());
+  util::Promise<gfx::Image> promise(isolate());
   v8::Local<v8::Promise> handle = promise.GetHandle();
   base::FilePath normalized_path = path.NormalizePathSeparators();
 
@@ -1267,7 +1267,7 @@ v8::Local<v8::Value> App::GetGPUFeatureStatus(v8::Isolate* isolate) {
 v8::Local<v8::Promise> App::GetGPUInfo(v8::Isolate* isolate,
                                        const std::string& info_type) {
   auto* const gpu_data_manager = content::GpuDataManagerImpl::GetInstance();
-  util::Promise promise(isolate);
+  util::Promise<base::DictionaryValue> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
   if (info_type != "basic" && info_type != "complete") {
     promise.RejectWithErrorMessage(

--- a/shell/browser/api/atom_api_debugger.cc
+++ b/shell/browser/api/atom_api_debugger.cc
@@ -65,7 +65,8 @@ void Debugger::DispatchProtocolMessage(DevToolsAgentHost* agent_host,
     if (it == pending_requests_.end())
       return;
 
-    electron::util::Promise promise = std::move(it->second);
+    electron::util::Promise<base::DictionaryValue> promise =
+        std::move(it->second);
     pending_requests_.erase(it);
 
     base::DictionaryValue* error = nullptr;
@@ -129,7 +130,7 @@ void Debugger::Detach() {
 }
 
 v8::Local<v8::Promise> Debugger::SendCommand(mate::Arguments* args) {
-  electron::util::Promise promise(isolate());
+  electron::util::Promise<base::DictionaryValue> promise(isolate());
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
   if (!agent_host_) {

--- a/shell/browser/api/atom_api_debugger.h
+++ b/shell/browser/api/atom_api_debugger.h
@@ -54,7 +54,8 @@ class Debugger : public mate::TrackableObject<Debugger>,
                               content::RenderFrameHost* new_rfh) override;
 
  private:
-  using PendingRequestMap = std::map<int, electron::util::Promise>;
+  using PendingRequestMap =
+      std::map<int, electron::util::Promise<base::DictionaryValue>>;
 
   void Attach(mate::Arguments* args);
   bool IsAttached();

--- a/shell/browser/api/atom_api_dialog.cc
+++ b/shell/browser/api/atom_api_dialog.cc
@@ -24,7 +24,7 @@ int ShowMessageBoxSync(const electron::MessageBoxSettings& settings) {
   return electron::ShowMessageBoxSync(settings);
 }
 
-void ResolvePromiseObject(electron::util::Promise promise,
+void ResolvePromiseObject(electron::util::Promise<gin::Dictionary> promise,
                           int result,
                           bool checkbox_checked) {
   v8::Isolate* isolate = promise.isolate();
@@ -33,14 +33,14 @@ void ResolvePromiseObject(electron::util::Promise promise,
   dict.Set("response", result);
   dict.Set("checkboxChecked", checkbox_checked);
 
-  promise.Resolve(gin::ConvertToV8(isolate, dict));
+  promise.ResolveWithGin(dict);
 }
 
 v8::Local<v8::Promise> ShowMessageBox(
     const electron::MessageBoxSettings& settings,
     gin::Arguments* args) {
   v8::Isolate* isolate = args->isolate();
-  electron::util::Promise promise(isolate);
+  electron::util::Promise<gin::Dictionary> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
   electron::ShowMessageBox(
@@ -59,7 +59,7 @@ void ShowOpenDialogSync(const file_dialog::DialogSettings& settings,
 v8::Local<v8::Promise> ShowOpenDialog(
     const file_dialog::DialogSettings& settings,
     gin::Arguments* args) {
-  electron::util::Promise promise(args->isolate());
+  electron::util::Promise<mate::Dictionary> promise(args->isolate());
   v8::Local<v8::Promise> handle = promise.GetHandle();
   file_dialog::ShowOpenDialog(settings, std::move(promise));
   return handle;
@@ -75,7 +75,7 @@ void ShowSaveDialogSync(const file_dialog::DialogSettings& settings,
 v8::Local<v8::Promise> ShowSaveDialog(
     const file_dialog::DialogSettings& settings,
     gin::Arguments* args) {
-  electron::util::Promise promise(args->isolate());
+  electron::util::Promise<mate::Dictionary> promise(args->isolate());
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
   file_dialog::ShowSaveDialog(settings, std::move(promise));

--- a/shell/browser/api/atom_api_in_app_purchase.cc
+++ b/shell/browser/api/atom_api_in_app_purchase.cc
@@ -104,7 +104,7 @@ v8::Local<v8::Promise> InAppPurchase::PurchaseProduct(
     const std::string& product_id,
     mate::Arguments* args) {
   v8::Isolate* isolate = args->isolate();
-  electron::util::Promise promise(isolate);
+  electron::util::Promise<bool> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
   int quantity = 1;
@@ -112,7 +112,7 @@ v8::Local<v8::Promise> InAppPurchase::PurchaseProduct(
 
   in_app_purchase::PurchaseProduct(
       product_id, quantity,
-      base::BindOnce(electron::util::Promise::ResolvePromise<bool>,
+      base::BindOnce(electron::util::Promise<bool>::ResolvePromise,
                      std::move(promise)));
 
   return handle;
@@ -122,13 +122,15 @@ v8::Local<v8::Promise> InAppPurchase::GetProducts(
     const std::vector<std::string>& productIDs,
     mate::Arguments* args) {
   v8::Isolate* isolate = args->isolate();
-  electron::util::Promise promise(isolate);
+  electron::util::Promise<std::vector<in_app_purchase::Product>> promise(
+      isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
   in_app_purchase::GetProducts(
-      productIDs, base::BindOnce(electron::util::Promise::ResolvePromise<
-                                     std::vector<in_app_purchase::Product>>,
-                                 std::move(promise)));
+      productIDs,
+      base::BindOnce(electron::util::Promise<
+                         std::vector<in_app_purchase::Product>>::ResolvePromise,
+                     std::move(promise)));
 
   return handle;
 }

--- a/shell/browser/api/atom_api_net_log.cc
+++ b/shell/browser/api/atom_api_net_log.cc
@@ -64,7 +64,7 @@ base::File OpenFileForWriting(base::FilePath path) {
                     base::File::FLAG_CREATE_ALWAYS | base::File::FLAG_WRITE);
 }
 
-void ResolvePromiseWithNetError(util::Promise promise, int32_t error) {
+void ResolvePromiseWithNetError(util::Promise<void*> promise, int32_t error) {
   if (error == net::OK) {
     promise.Resolve();
   } else {
@@ -119,7 +119,7 @@ v8::Local<v8::Promise> NetLog::StartLogging(base::FilePath log_path,
     return v8::Local<v8::Promise>();
   }
 
-  pending_start_promise_ = base::make_optional<util::Promise>(isolate());
+  pending_start_promise_ = base::make_optional<util::Promise<void*>>(isolate());
   v8::Local<v8::Promise> handle = pending_start_promise_->GetHandle();
 
   auto command_line_string =
@@ -189,7 +189,7 @@ bool NetLog::IsCurrentlyLogging() const {
 }
 
 v8::Local<v8::Promise> NetLog::StopLogging(mate::Arguments* args) {
-  util::Promise promise(isolate());
+  util::Promise<void*> promise(isolate());
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
   if (net_log_exporter_) {
@@ -199,7 +199,7 @@ v8::Local<v8::Promise> NetLog::StopLogging(mate::Arguments* args) {
     net_log_exporter_->Stop(
         base::Value(base::Value::Type::DICTIONARY),
         base::BindOnce(
-            [](network::mojom::NetLogExporterPtr, util::Promise promise,
+            [](network::mojom::NetLogExporterPtr, util::Promise<void*> promise,
                int32_t error) {
               ResolvePromiseWithNetError(std::move(promise), error);
             },

--- a/shell/browser/api/atom_api_net_log.h
+++ b/shell/browser/api/atom_api_net_log.h
@@ -53,7 +53,7 @@ class NetLog : public mate::TrackableObject<NetLog> {
 
   network::mojom::NetLogExporterPtr net_log_exporter_;
 
-  base::Optional<util::Promise> pending_start_promise_;
+  base::Optional<util::Promise<void*>> pending_start_promise_;
 
   scoped_refptr<base::TaskRunner> file_task_runner_;
 

--- a/shell/browser/api/atom_api_protocol_ns.cc
+++ b/shell/browser/api/atom_api_protocol_ns.cc
@@ -232,18 +232,17 @@ v8::Local<v8::Promise> ProtocolNS::IsProtocolHandled(const std::string& scheme,
       "protocol.isProtocolRegistered or protocol.isProtocolIntercepted "
       "instead.",
       "ProtocolDeprecateIsProtocolHandled");
-  util::Promise promise(isolate());
-  promise.Resolve(IsProtocolRegistered(scheme) ||
-                  IsProtocolIntercepted(scheme) ||
-                  // The |isProtocolHandled| should return true for builtin
-                  // schemes, however with NetworkService it is impossible to
-                  // know which schemes are registered until a real network
-                  // request is sent.
-                  // So we have to test against a hard-coded builtin schemes
-                  // list make it work with old code. We should deprecate this
-                  // API with the new |isProtocolRegistered| API.
-                  base::Contains(kBuiltinSchemes, scheme));
-  return promise.GetHandle();
+  return util::Promise<bool>::ResolvedPromise(
+      isolate(), IsProtocolRegistered(scheme) ||
+                     IsProtocolIntercepted(scheme) ||
+                     // The |isProtocolHandled| should return true for builtin
+                     // schemes, however with NetworkService it is impossible to
+                     // know which schemes are registered until a real network
+                     // request is sent.
+                     // So we have to test against a hard-coded builtin schemes
+                     // list make it work with old code. We should deprecate
+                     // this API with the new |isProtocolRegistered| API.
+                     base::Contains(kBuiltinSchemes, scheme));
 }
 
 void ProtocolNS::HandleOptionalCallback(mate::Arguments* args,

--- a/shell/browser/api/gpuinfo_manager.cc
+++ b/shell/browser/api/gpuinfo_manager.cc
@@ -61,7 +61,8 @@ void GPUInfoManager::OnGpuInfoUpdate() {
 }
 
 // Should be posted to the task runner
-void GPUInfoManager::CompleteInfoFetcher(util::Promise promise) {
+void GPUInfoManager::CompleteInfoFetcher(
+    util::Promise<base::DictionaryValue> promise) {
   complete_info_promise_set_.emplace_back(std::move(promise));
 
   if (NeedsCompleteGpuInfoCollection()) {
@@ -71,7 +72,8 @@ void GPUInfoManager::CompleteInfoFetcher(util::Promise promise) {
   }
 }
 
-void GPUInfoManager::FetchCompleteInfo(util::Promise promise) {
+void GPUInfoManager::FetchCompleteInfo(
+    util::Promise<base::DictionaryValue> promise) {
   base::ThreadTaskRunnerHandle::Get()->PostTask(
       FROM_HERE, base::BindOnce(&GPUInfoManager::CompleteInfoFetcher,
                                 base::Unretained(this), std::move(promise)));
@@ -79,7 +81,8 @@ void GPUInfoManager::FetchCompleteInfo(util::Promise promise) {
 
 // This fetches the info synchronously, so no need to post to the task queue.
 // There cannot be multiple promises as they are resolved synchronously.
-void GPUInfoManager::FetchBasicInfo(util::Promise promise) {
+void GPUInfoManager::FetchBasicInfo(
+    util::Promise<base::DictionaryValue> promise) {
   gpu::GPUInfo gpu_info;
   CollectBasicGraphicsInfo(&gpu_info);
   promise.Resolve(*EnumerateGPUInfo(gpu_info));

--- a/shell/browser/api/gpuinfo_manager.h
+++ b/shell/browser/api/gpuinfo_manager.h
@@ -25,8 +25,8 @@ class GPUInfoManager : public content::GpuDataManagerObserver {
   GPUInfoManager();
   ~GPUInfoManager() override;
   bool NeedsCompleteGpuInfoCollection() const;
-  void FetchCompleteInfo(util::Promise promise);
-  void FetchBasicInfo(util::Promise promise);
+  void FetchCompleteInfo(util::Promise<base::DictionaryValue> promise);
+  void FetchBasicInfo(util::Promise<base::DictionaryValue> promise);
   void OnGpuInfoUpdate() override;
 
  private:
@@ -34,12 +34,12 @@ class GPUInfoManager : public content::GpuDataManagerObserver {
       gpu::GPUInfo gpu_info) const;
 
   // These should be posted to the task queue
-  void CompleteInfoFetcher(util::Promise promise);
+  void CompleteInfoFetcher(util::Promise<base::DictionaryValue> promise);
   void ProcessCompleteInfo();
 
   // This set maintains all the promises that should be fulfilled
   // once we have the complete information data
-  std::vector<util::Promise> complete_info_promise_set_;
+  std::vector<util::Promise<base::DictionaryValue>> complete_info_promise_set_;
   content::GpuDataManager* gpu_data_manager_;
 
   DISALLOW_COPY_AND_ASSIGN(GPUInfoManager);

--- a/shell/browser/api/save_page_handler.cc
+++ b/shell/browser/api/save_page_handler.cc
@@ -17,7 +17,7 @@ namespace electron {
 namespace api {
 
 SavePageHandler::SavePageHandler(content::WebContents* web_contents,
-                                 util::Promise promise)
+                                 util::Promise<void*> promise)
     : web_contents_(web_contents), promise_(std::move(promise)) {}
 
 SavePageHandler::~SavePageHandler() {}

--- a/shell/browser/api/save_page_handler.h
+++ b/shell/browser/api/save_page_handler.h
@@ -30,7 +30,7 @@ class SavePageHandler : public content::DownloadManager::Observer,
                         public download::DownloadItem::Observer {
  public:
   SavePageHandler(content::WebContents* web_contents,
-                  electron::util::Promise promise);
+                  electron::util::Promise<void*> promise);
   ~SavePageHandler() override;
 
   bool Handle(const base::FilePath& full_path,
@@ -47,7 +47,7 @@ class SavePageHandler : public content::DownloadManager::Observer,
   void OnDownloadUpdated(download::DownloadItem* item) override;
 
   content::WebContents* web_contents_;  // weak
-  electron::util::Promise promise_;
+  electron::util::Promise<void*> promise_;
 };
 
 }  // namespace api

--- a/shell/browser/atom_blob_reader.cc
+++ b/shell/browser/atom_blob_reader.cc
@@ -27,7 +27,9 @@ void FreeNodeBufferData(char* data, void* hint) {
   delete[] data;
 }
 
-void RunPromiseInUI(util::Promise promise, char* blob_data, int size) {
+void RunPromiseInUI(util::Promise<v8::Local<v8::Value>> promise,
+                    char* blob_data,
+                    int size) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
   v8::Isolate* isolate = promise.isolate();
 
@@ -52,13 +54,13 @@ AtomBlobReader::AtomBlobReader(content::ChromeBlobStorageContext* blob_context)
 AtomBlobReader::~AtomBlobReader() {}
 
 void AtomBlobReader::StartReading(const std::string& uuid,
-                                  util::Promise promise) {
+                                  util::Promise<v8::Local<v8::Value>> promise) {
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
 
   auto blob_data_handle = blob_context_->context()->GetBlobDataFromUUID(uuid);
   if (!blob_data_handle) {
-    util::Promise::RejectPromise(std::move(promise),
-                                 "Could not get blob data handle");
+    util::Promise<v8::Local<v8::Value>>::RejectPromise(
+        std::move(promise), "Could not get blob data handle");
     return;
   }
 

--- a/shell/browser/atom_blob_reader.h
+++ b/shell/browser/atom_blob_reader.h
@@ -39,7 +39,8 @@ class AtomBlobReader {
   explicit AtomBlobReader(content::ChromeBlobStorageContext* blob_context);
   ~AtomBlobReader();
 
-  void StartReading(const std::string& uuid, electron::util::Promise promise);
+  void StartReading(const std::string& uuid,
+                    electron::util::Promise<v8::Local<v8::Value>> promise);
 
  private:
   // A self-destroyed helper class to read the blob data.

--- a/shell/browser/atom_download_manager_delegate.cc
+++ b/shell/browser/atom_download_manager_delegate.cc
@@ -122,7 +122,7 @@ void AtomDownloadManagerDelegate::OnDownloadPathGenerated(
     settings.force_detached = offscreen;
 
     v8::Isolate* isolate = v8::Isolate::GetCurrent();
-    electron::util::Promise dialog_promise(isolate);
+    electron::util::Promise<mate::Dictionary> dialog_promise(isolate);
     auto dialog_callback =
         base::BindOnce(&AtomDownloadManagerDelegate::OnDownloadSaveDialogDone,
                        base::Unretained(this), download_id, callback);

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -165,9 +165,9 @@ void Browser::DidFinishLaunching(const base::DictionaryValue& launch_info) {
     observer.OnFinishLaunching(launch_info);
 }
 
-const util::Promise& Browser::WhenReady(v8::Isolate* isolate) {
+const util::Promise<void*>& Browser::WhenReady(v8::Isolate* isolate) {
   if (!ready_promise_) {
-    ready_promise_.reset(new util::Promise(isolate));
+    ready_promise_.reset(new util::Promise<void*>(isolate));
     if (is_ready()) {
       ready_promise_->Resolve();
     }

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -262,7 +262,7 @@ class Browser : public WindowListObserver {
   bool is_shutting_down() const { return is_shutdown_; }
   bool is_quiting() const { return is_quiting_; }
   bool is_ready() const { return is_ready_; }
-  const util::Promise& WhenReady(v8::Isolate* isolate);
+  const util::Promise<void*>& WhenReady(v8::Isolate* isolate);
 
  protected:
   // Returns the version of application bundle or executable file.
@@ -301,7 +301,7 @@ class Browser : public WindowListObserver {
 
   int badge_count_ = 0;
 
-  std::unique_ptr<util::Promise> ready_promise_;
+  std::unique_ptr<util::Promise<void*>> ready_promise_;
 
 #if defined(OS_LINUX) || defined(OS_WIN)
   base::Value about_panel_options_;

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -313,7 +313,7 @@ bool Browser::DockIsVisible() {
 }
 
 v8::Local<v8::Promise> Browser::DockShow(v8::Isolate* isolate) {
-  util::Promise promise(isolate);
+  util::Promise<void*> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
   BOOL active = [[NSRunningApplication currentApplication] isActive];
@@ -327,7 +327,7 @@ v8::Local<v8::Promise> Browser::DockShow(v8::Isolate* isolate) {
       [app activateWithOptions:NSApplicationActivateIgnoringOtherApps];
       break;
     }
-    __block util::Promise p = std::move(promise);
+    __block util::Promise<void*> p = std::move(promise);
     dispatch_time_t one_ms = dispatch_time(DISPATCH_TIME_NOW, USEC_PER_SEC);
     dispatch_after(one_ms, dispatch_get_main_queue(), ^{
       TransformProcessType(&psn, kProcessTransformToForegroundApplication);

--- a/shell/browser/printing/print_preview_message_handler.h
+++ b/shell/browser/printing/print_preview_message_handler.h
@@ -31,7 +31,8 @@ class PrintPreviewMessageHandler
  public:
   ~PrintPreviewMessageHandler() override;
 
-  void PrintToPDF(const base::DictionaryValue& options, util::Promise promise);
+  void PrintToPDF(const base::DictionaryValue& options,
+                  util::Promise<v8::Local<v8::Value>> promise);
 
  protected:
   // content::WebContentsObserver implementation.
@@ -55,13 +56,14 @@ class PrintPreviewMessageHandler
   void OnPrintPreviewCancelled(int document_cookie,
                                const PrintHostMsg_PreviewIds& ids);
 
-  util::Promise GetPromise(int request_id);
+  util::Promise<v8::Local<v8::Value>> GetPromise(int request_id);
 
   void ResolvePromise(int request_id,
                       scoped_refptr<base::RefCountedMemory> data_bytes);
   void RejectPromise(int request_id);
 
-  using PromiseMap = std::map<int, electron::util::Promise>;
+  using PromiseMap =
+      std::map<int, electron::util::Promise<v8::Local<v8::Value>>>;
   PromiseMap promise_map_;
 
   base::WeakPtrFactory<PrintPreviewMessageHandler> weak_ptr_factory_;

--- a/shell/browser/ui/certificate_trust_mac.mm
+++ b/shell/browser/ui/certificate_trust_mac.mm
@@ -19,7 +19,7 @@
 
 @interface TrustDelegate : NSObject {
  @private
-  std::unique_ptr<electron::util::Promise> promise_;
+  std::unique_ptr<electron::util::Promise<void*>> promise_;
   SFCertificateTrustPanel* panel_;
   scoped_refptr<net::X509Certificate> cert_;
   SecTrustRef trust_;
@@ -27,7 +27,7 @@
   SecPolicyRef sec_policy_;
 }
 
-- (id)initWithPromise:(electron::util::Promise)promise
+- (id)initWithPromise:(electron::util::Promise<void*>)promise
                 panel:(SFCertificateTrustPanel*)panel
                  cert:(const scoped_refptr<net::X509Certificate>&)cert
                 trust:(SecTrustRef)trust
@@ -51,14 +51,14 @@
   [super dealloc];
 }
 
-- (id)initWithPromise:(electron::util::Promise)promise
+- (id)initWithPromise:(electron::util::Promise<void*>)promise
                 panel:(SFCertificateTrustPanel*)panel
                  cert:(const scoped_refptr<net::X509Certificate>&)cert
                 trust:(SecTrustRef)trust
             certChain:(CFArrayRef)certChain
             secPolicy:(SecPolicyRef)secPolicy {
   if ((self = [super init])) {
-    promise_.reset(new electron::util::Promise(std::move(promise)));
+    promise_.reset(new electron::util::Promise<void*>(std::move(promise)));
     panel_ = panel;
     cert_ = cert;
     trust_ = trust;
@@ -90,7 +90,7 @@ v8::Local<v8::Promise> ShowCertificateTrust(
     const scoped_refptr<net::X509Certificate>& cert,
     const std::string& message) {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
-  electron::util::Promise promise(isolate);
+  electron::util::Promise<void*> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
   auto* sec_policy = SecPolicyCreateBasicX509();

--- a/shell/browser/ui/certificate_trust_win.cc
+++ b/shell/browser/ui/certificate_trust_win.cc
@@ -61,7 +61,7 @@ v8::Local<v8::Promise> ShowCertificateTrust(
     const scoped_refptr<net::X509Certificate>& cert,
     const std::string& message) {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
-  electron::util::Promise promise(isolate);
+  electron::util::Promise<void*> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
   PCCERT_CHAIN_CONTEXT chain_context;

--- a/shell/browser/ui/file_dialog.h
+++ b/shell/browser/ui/file_dialog.h
@@ -66,12 +66,12 @@ bool ShowOpenDialogSync(const DialogSettings& settings,
                         std::vector<base::FilePath>* paths);
 
 void ShowOpenDialog(const DialogSettings& settings,
-                    electron::util::Promise promise);
+                    electron::util::Promise<mate::Dictionary> promise);
 
 bool ShowSaveDialogSync(const DialogSettings& settings, base::FilePath* path);
 
 void ShowSaveDialog(const DialogSettings& settings,
-                    electron::util::Promise promise);
+                    electron::util::Promise<mate::Dictionary> promise);
 
 }  // namespace file_dialog
 

--- a/shell/browser/ui/file_dialog_gtk.cc
+++ b/shell/browser/ui/file_dialog_gtk.cc
@@ -227,7 +227,7 @@ void FileChooserDialog::OnFileDialogResponse(GtkWidget* widget, int response) {
       dict.Set("canceled", true);
       dict.Set("filePath", base::FilePath());
     }
-    save_promise_->Resolve(dict.GetHandle());
+    save_promise_->Resolve(dict);
   } else if (open_promise_) {
     mate::Dictionary dict =
         mate::Dictionary::CreateEmpty(open_promise_->isolate());
@@ -238,7 +238,7 @@ void FileChooserDialog::OnFileDialogResponse(GtkWidget* widget, int response) {
       dict.Set("canceled", true);
       dict.Set("filePaths", std::vector<base::FilePath>());
     }
-    open_promise_->Resolve(dict.GetHandle());
+    open_promise_->Resolve(dict);
   }
   delete this;
 }

--- a/shell/browser/ui/file_dialog_gtk.cc
+++ b/shell/browser/ui/file_dialog_gtk.cc
@@ -157,13 +157,15 @@ class FileChooserDialog {
     gtk_window_present_with_time(GTK_WINDOW(dialog_), time);
   }
 
-  void RunSaveAsynchronous(electron::util::Promise promise) {
-    save_promise_.reset(new electron::util::Promise(std::move(promise)));
+  void RunSaveAsynchronous(electron::util::Promise<mate::Dictionary> promise) {
+    save_promise_.reset(
+        new electron::util::Promise<mate::Dictionary>(std::move(promise)));
     RunAsynchronous();
   }
 
-  void RunOpenAsynchronous(electron::util::Promise promise) {
-    open_promise_.reset(new electron::util::Promise(std::move(promise)));
+  void RunOpenAsynchronous(electron::util::Promise<mate::Dictionary> promise) {
+    open_promise_.reset(
+        new electron::util::Promise<mate::Dictionary>(std::move(promise)));
     RunAsynchronous();
   }
 
@@ -204,8 +206,8 @@ class FileChooserDialog {
   GtkWidget* preview_;
 
   Filters filters_;
-  std::unique_ptr<electron::util::Promise> save_promise_;
-  std::unique_ptr<electron::util::Promise> open_promise_;
+  std::unique_ptr<electron::util::Promise<mate::Dictionary>> save_promise_;
+  std::unique_ptr<electron::util::Promise<mate::Dictionary>> open_promise_;
 
   // Callback for when we update the preview for the selection.
   CHROMEG_CALLBACK_0(FileChooserDialog, void, OnUpdatePreview, GtkWidget*);
@@ -312,7 +314,7 @@ bool ShowOpenDialogSync(const DialogSettings& settings,
 }
 
 void ShowOpenDialog(const DialogSettings& settings,
-                    electron::util::Promise promise) {
+                    electron::util::Promise<mate::Dictionary> promise) {
   GtkFileChooserAction action = GTK_FILE_CHOOSER_ACTION_OPEN;
   if (settings.properties & OPEN_DIALOG_OPEN_DIRECTORY)
     action = GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER;
@@ -335,7 +337,7 @@ bool ShowSaveDialogSync(const DialogSettings& settings, base::FilePath* path) {
 }
 
 void ShowSaveDialog(const DialogSettings& settings,
-                    electron::util::Promise promise) {
+                    electron::util::Promise<mate::Dictionary> promise) {
   FileChooserDialog* save_dialog =
       new FileChooserDialog(GTK_FILE_CHOOSER_ACTION_SAVE, settings);
   save_dialog->RunSaveAsynchronous(std::move(promise));

--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -300,7 +300,7 @@ bool ShowOpenDialogSync(const DialogSettings& settings,
 void OpenDialogCompletion(int chosen,
                           NSOpenPanel* dialog,
                           bool security_scoped_bookmarks,
-                          electron::util::Promise promise) {
+                          electron::util::Promise<mate::Dictionary> promise) {
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(promise.isolate());
   if (chosen == NSFileHandlingPanelCancelButton) {
     dict.Set("canceled", true);
@@ -308,7 +308,7 @@ void OpenDialogCompletion(int chosen,
 #if defined(MAS_BUILD)
     dict.Set("bookmarks", std::vector<std::string>());
 #endif
-    promise.Resolve(dict.GetHandle());
+    promise.Resolve(dict);
   } else {
     std::vector<base::FilePath> paths;
     dict.Set("canceled", false);
@@ -324,12 +324,12 @@ void OpenDialogCompletion(int chosen,
     ReadDialogPaths(dialog, &paths);
     dict.Set("filePaths", paths);
 #endif
-    promise.Resolve(dict.GetHandle());
+    promise.Resolve(dict);
   }
 }
 
 void ShowOpenDialog(const DialogSettings& settings,
-                    electron::util::Promise promise) {
+                    electron::util::Promise<mate::Dictionary> promise) {
   NSOpenPanel* dialog = [NSOpenPanel openPanel];
 
   SetupDialog(dialog, settings);
@@ -339,7 +339,7 @@ void ShowOpenDialog(const DialogSettings& settings,
   // and pass it to the completion handler.
   bool security_scoped_bookmarks = settings.security_scoped_bookmarks;
 
-  __block electron::util::Promise p = std::move(promise);
+  __block electron::util::Promise<mate::Dictionary> p = std::move(promise);
 
   if (!settings.parent_window || !settings.parent_window->GetNativeWindow() ||
       settings.force_detached) {
@@ -377,7 +377,7 @@ bool ShowSaveDialogSync(const DialogSettings& settings, base::FilePath* path) {
 void SaveDialogCompletion(int chosen,
                           NSSavePanel* dialog,
                           bool security_scoped_bookmarks,
-                          electron::util::Promise promise) {
+                          electron::util::Promise<mate::Dictionary> promise) {
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(promise.isolate());
   if (chosen == NSFileHandlingPanelCancelButton) {
     dict.Set("canceled", true);
@@ -397,11 +397,11 @@ void SaveDialogCompletion(int chosen,
     }
 #endif
   }
-  promise.Resolve(dict.GetHandle());
+  promise.Resolve(dict);
 }
 
 void ShowSaveDialog(const DialogSettings& settings,
-                    electron::util::Promise promise) {
+                    electron::util::Promise<mate::Dictionary> promise) {
   NSSavePanel* dialog = [NSSavePanel savePanel];
 
   SetupDialog(dialog, settings);
@@ -412,7 +412,7 @@ void ShowSaveDialog(const DialogSettings& settings,
   // and pass it to the completion handler.
   bool security_scoped_bookmarks = settings.security_scoped_bookmarks;
 
-  __block electron::util::Promise p = std::move(promise);
+  __block electron::util::Promise<mate::Dictionary> p = std::move(promise);
 
   if (!settings.parent_window || !settings.parent_window->GetNativeWindow() ||
       settings.force_detached) {

--- a/shell/browser/ui/file_dialog_win.cc
+++ b/shell/browser/ui/file_dialog_win.cc
@@ -81,7 +81,7 @@ bool CreateDialogThread(RunState* run_state) {
   return true;
 }
 
-void OnDialogOpened(electron::util::Promise promise,
+void OnDialogOpened(electron::util::Promise<mate::Dictionary> promise,
                     bool canceled,
                     std::vector<base::FilePath> paths) {
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(promise.isolate());
@@ -90,9 +90,10 @@ void OnDialogOpened(electron::util::Promise promise,
   promise.Resolve(dict.GetHandle());
 }
 
-void RunOpenDialogInNewThread(const RunState& run_state,
-                              const DialogSettings& settings,
-                              electron::util::Promise promise) {
+void RunOpenDialogInNewThread(
+    const RunState& run_state,
+    const DialogSettings& settings,
+    electron::util::Promise<mate::Dictionary> promise) {
   std::vector<base::FilePath> paths;
   bool result = ShowOpenDialogSync(settings, &paths);
   run_state.ui_task_runner->PostTask(
@@ -101,7 +102,7 @@ void RunOpenDialogInNewThread(const RunState& run_state,
   run_state.ui_task_runner->DeleteSoon(FROM_HERE, run_state.dialog_thread);
 }
 
-void OnSaveDialogDone(electron::util::Promise promise,
+void OnSaveDialogDone(electron::util::Promise<mate::Dictionary> promise,
                       bool canceled,
                       const base::FilePath path) {
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(promise.isolate());
@@ -110,9 +111,10 @@ void OnSaveDialogDone(electron::util::Promise promise,
   promise.Resolve(dict.GetHandle());
 }
 
-void RunSaveDialogInNewThread(const RunState& run_state,
-                              const DialogSettings& settings,
-                              electron::util::Promise promise) {
+void RunSaveDialogInNewThread(
+    const RunState& run_state,
+    const DialogSettings& settings,
+    electron::util::Promise<mate::Dictionary> promise) {
   base::FilePath path;
   bool result = ShowSaveDialogSync(settings, &path);
   run_state.ui_task_runner->PostTask(
@@ -274,7 +276,7 @@ bool ShowOpenDialogSync(const DialogSettings& settings,
 }
 
 void ShowOpenDialog(const DialogSettings& settings,
-                    electron::util::Promise promise) {
+                    electron::util::Promise<mate::Dictionary> promise) {
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(promise.isolate());
   RunState run_state;
   if (!CreateDialogThread(&run_state)) {
@@ -324,7 +326,7 @@ bool ShowSaveDialogSync(const DialogSettings& settings, base::FilePath* path) {
 }
 
 void ShowSaveDialog(const DialogSettings& settings,
-                    electron::util::Promise promise) {
+                    electron::util::Promise<mate::Dictionary> promise) {
   RunState run_state;
   if (!CreateDialogThread(&run_state)) {
     mate::Dictionary dict = mate::Dictionary::CreateEmpty(promise.isolate());

--- a/shell/browser/ui/file_dialog_win.cc
+++ b/shell/browser/ui/file_dialog_win.cc
@@ -282,7 +282,7 @@ void ShowOpenDialog(const DialogSettings& settings,
   if (!CreateDialogThread(&run_state)) {
     dict.Set("canceled", true);
     dict.Set("filePaths", std::vector<base::FilePath>());
-    promise.Resolve(dict));
+    promise.Resolve(dict);
   } else {
     run_state.dialog_thread->task_runner()->PostTask(
         FROM_HERE, base::BindOnce(&RunOpenDialogInNewThread, run_state,
@@ -332,7 +332,7 @@ void ShowSaveDialog(const DialogSettings& settings,
     mate::Dictionary dict = mate::Dictionary::CreateEmpty(promise.isolate());
     dict.Set("canceled", true);
     dict.Set("filePath", base::FilePath());
-    promise.Resolve(dict));
+    promise.Resolve(dict);
   } else {
     run_state.dialog_thread->task_runner()->PostTask(
         FROM_HERE, base::BindOnce(&RunSaveDialogInNewThread, run_state,

--- a/shell/browser/ui/file_dialog_win.cc
+++ b/shell/browser/ui/file_dialog_win.cc
@@ -87,7 +87,7 @@ void OnDialogOpened(electron::util::Promise<mate::Dictionary> promise,
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(promise.isolate());
   dict.Set("canceled", canceled);
   dict.Set("filePaths", paths);
-  promise.Resolve(dict.GetHandle());
+  promise.Resolve(dict);
 }
 
 void RunOpenDialogInNewThread(
@@ -108,7 +108,7 @@ void OnSaveDialogDone(electron::util::Promise<mate::Dictionary> promise,
   mate::Dictionary dict = mate::Dictionary::CreateEmpty(promise.isolate());
   dict.Set("canceled", canceled);
   dict.Set("filePath", path);
-  promise.Resolve(dict.GetHandle());
+  promise.Resolve(dict);
 }
 
 void RunSaveDialogInNewThread(
@@ -282,7 +282,7 @@ void ShowOpenDialog(const DialogSettings& settings,
   if (!CreateDialogThread(&run_state)) {
     dict.Set("canceled", true);
     dict.Set("filePaths", std::vector<base::FilePath>());
-    promise.Resolve(dict.GetHandle());
+    promise.Resolve(dict));
   } else {
     run_state.dialog_thread->task_runner()->PostTask(
         FROM_HERE, base::BindOnce(&RunOpenDialogInNewThread, run_state,
@@ -332,7 +332,7 @@ void ShowSaveDialog(const DialogSettings& settings,
     mate::Dictionary dict = mate::Dictionary::CreateEmpty(promise.isolate());
     dict.Set("canceled", true);
     dict.Set("filePath", base::FilePath());
-    promise.Resolve(dict.GetHandle());
+    promise.Resolve(dict));
   } else {
     run_state.dialog_thread->task_runner()->PostTask(
         FROM_HERE, base::BindOnce(&RunSaveDialogInNewThread, run_state,

--- a/shell/browser/web_dialog_helper.cc
+++ b/shell/browser/web_dialog_helper.cc
@@ -54,7 +54,7 @@ class FileSelectHelper : public base::RefCounted<FileSelectHelper>,
 
   void ShowOpenDialog(const file_dialog::DialogSettings& settings) {
     v8::Isolate* isolate = v8::Isolate::GetCurrent();
-    electron::util::Promise promise(isolate);
+    electron::util::Promise<mate::Dictionary> promise(isolate);
 
     auto callback = base::BindOnce(&FileSelectHelper::OnOpenDialogDone, this);
     ignore_result(promise.Then(std::move(callback)));
@@ -65,7 +65,7 @@ class FileSelectHelper : public base::RefCounted<FileSelectHelper>,
   void ShowSaveDialog(const file_dialog::DialogSettings& settings) {
     v8::Isolate* isolate = v8::Isolate::GetCurrent();
     v8::Local<v8::Context> context = isolate->GetCurrentContext();
-    electron::util::Promise promise(isolate);
+    electron::util::Promise<mate::Dictionary> promise(isolate);
     v8::Local<v8::Promise> handle = promise.GetHandle();
 
     file_dialog::ShowSaveDialog(settings, std::move(promise));

--- a/shell/common/api/atom_api_shell.cc
+++ b/shell/common/api/atom_api_shell.cc
@@ -44,7 +44,7 @@ struct Converter<base::win::ShortcutOperation> {
 
 namespace {
 
-void OnOpenExternalFinished(electron::util::Promise promise,
+void OnOpenExternalFinished(electron::util::Promise<void*> promise,
                             const std::string& error) {
   if (error.empty())
     promise.Resolve();
@@ -53,7 +53,7 @@ void OnOpenExternalFinished(electron::util::Promise promise,
 }
 
 v8::Local<v8::Promise> OpenExternal(const GURL& url, mate::Arguments* args) {
-  electron::util::Promise promise(args->isolate());
+  electron::util::Promise<void*> promise(args->isolate());
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
   platform_util::OpenExternalOptions options;

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -232,7 +232,7 @@ v8::Local<v8::Value> ElectronBindings::GetSystemMemoryInfo(
 // static
 v8::Local<v8::Promise> ElectronBindings::GetProcessMemoryInfo(
     v8::Isolate* isolate) {
-  util::Promise promise(isolate);
+  util::Promise<mate::Dictionary> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
   if (mate::Locker::IsBrowserProcess() && !Browser::Get()->is_ready()) {
@@ -266,7 +266,7 @@ v8::Local<v8::Value> ElectronBindings::GetBlinkMemoryInfo(
 // static
 void ElectronBindings::DidReceiveMemoryDump(
     v8::Global<v8::Context> context,
-    util::Promise promise,
+    util::Promise<mate::Dictionary> promise,
     bool success,
     std::unique_ptr<memory_instrumentation::GlobalMemoryDump> global_dump) {
   v8::Isolate* isolate = promise.isolate();
@@ -293,7 +293,7 @@ void ElectronBindings::DidReceiveMemoryDump(
 #endif
       dict.Set("private", osdump.private_footprint_kb);
       dict.Set("shared", osdump.shared_footprint_kb);
-      promise.Resolve(dict.GetHandle());
+      promise.Resolve(dict);
       resolved = true;
       break;
     }

--- a/shell/common/api/electron_bindings.h
+++ b/shell/common/api/electron_bindings.h
@@ -71,7 +71,7 @@ class ElectronBindings {
 
   static void DidReceiveMemoryDump(
       v8::Global<v8::Context> context,
-      util::Promise promise,
+      util::Promise<mate::Dictionary> promise,
       bool success,
       std::unique_ptr<memory_instrumentation::GlobalMemoryDump> dump);
 

--- a/shell/common/promise_util.cc
+++ b/shell/common/promise_util.cc
@@ -2,71 +2,21 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include <string>
-
-#include "shell/common/api/locker.h"
 #include "shell/common/promise_util.h"
-
-namespace electron {
-
-namespace util {
-
-Promise::Promise(v8::Isolate* isolate)
-    : Promise(isolate,
-              v8::Promise::Resolver::New(isolate->GetCurrentContext())
-                  .ToLocalChecked()) {}
-
-Promise::Promise(v8::Isolate* isolate, v8::Local<v8::Promise::Resolver> handle)
-    : isolate_(isolate),
-      context_(isolate, isolate->GetCurrentContext()),
-      resolver_(isolate, handle) {}
-
-Promise::~Promise() = default;
-
-Promise::Promise(Promise&&) = default;
-Promise& Promise::operator=(Promise&&) = default;
-
-v8::Maybe<bool> Promise::RejectWithErrorMessage(const std::string& string) {
-  v8::HandleScope handle_scope(isolate());
-  v8::MicrotasksScope script_scope(isolate(),
-                                   v8::MicrotasksScope::kRunMicrotasks);
-  v8::Context::Scope context_scope(
-      v8::Local<v8::Context>::New(isolate(), GetContext()));
-
-  v8::Local<v8::String> error_message =
-      v8::String::NewFromUtf8(isolate(), string.c_str(),
-                              v8::NewStringType::kNormal,
-                              static_cast<int>(string.size()))
-          .ToLocalChecked();
-  v8::Local<v8::Value> error = v8::Exception::Error(error_message);
-  return Reject(error);
-}
-
-v8::Local<v8::Promise> Promise::GetHandle() const {
-  return GetInner()->GetPromise();
-}
-
-CopyablePromise::CopyablePromise(const Promise& promise)
-    : isolate_(promise.isolate()), handle_(isolate_, promise.GetInner()) {}
-
-CopyablePromise::CopyablePromise(const CopyablePromise&) = default;
-
-CopyablePromise::~CopyablePromise() = default;
-
-Promise CopyablePromise::GetPromise() const {
-  return Promise(isolate_,
-                 v8::Local<v8::Promise::Resolver>::New(isolate_, handle_));
-}
-
-}  // namespace util
-
-}  // namespace electron
 
 namespace mate {
 
-v8::Local<v8::Value> mate::Converter<electron::util::Promise>::ToV8(
+template <typename T>
+v8::Local<v8::Value> mate::Converter<electron::util::Promise<T>>::ToV8(
     v8::Isolate*,
-    const electron::util::Promise& val) {
+    const electron::util::Promise<T>& val) {
+  return val.GetHandle();
+}
+
+template <>
+v8::Local<v8::Value> mate::Converter<electron::util::Promise<void*>>::ToV8(
+    v8::Isolate*,
+    const electron::util::Promise<void*>& val) {
   return val.GetHandle();
 }
 

--- a/shell/renderer/api/atom_api_renderer_ipc.cc
+++ b/shell/renderer/api/atom_api_renderer_ipc.cc
@@ -75,12 +75,12 @@ class IPCRenderer : public mate::Wrappable<IPCRenderer> {
   v8::Local<v8::Promise> Invoke(mate::Arguments* args,
                                 const std::string& channel,
                                 const base::Value& arguments) {
-    electron::util::Promise p(args->isolate());
+    electron::util::Promise<base::Value> p(args->isolate());
     auto handle = p.GetHandle();
 
     electron_browser_ptr_->get()->Invoke(
         channel, arguments.Clone(),
-        base::BindOnce([](electron::util::Promise p,
+        base::BindOnce([](electron::util::Promise<base::Value> p,
                           base::Value result) { p.Resolve(result); },
                        std::move(p)));
 

--- a/shell/renderer/api/atom_api_web_frame.cc
+++ b/shell/renderer/api/atom_api_web_frame.cc
@@ -113,7 +113,8 @@ class RenderFrameStatus : public content::RenderFrameObserver {
 
 class ScriptExecutionCallback : public blink::WebScriptExecutionCallback {
  public:
-  explicit ScriptExecutionCallback(electron::util::Promise promise)
+  explicit ScriptExecutionCallback(
+      electron::util::Promise<v8::Local<v8::Value>> promise)
       : promise_(std::move(promise)) {}
   ~ScriptExecutionCallback() override {}
 
@@ -137,7 +138,7 @@ class ScriptExecutionCallback : public blink::WebScriptExecutionCallback {
   }
 
  private:
-  electron::util::Promise promise_;
+  electron::util::Promise<v8::Local<v8::Value>> promise_;
 
   DISALLOW_COPY_AND_ASSIGN(ScriptExecutionCallback);
 };
@@ -376,7 +377,7 @@ v8::Local<v8::Promise> ExecuteJavaScript(mate::Arguments* args,
                                          v8::Local<v8::Value> window,
                                          const base::string16& code) {
   v8::Isolate* isolate = args->isolate();
-  util::Promise promise(isolate);
+  util::Promise<v8::Local<v8::Value>> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
   bool has_user_gesture = false;
@@ -395,7 +396,7 @@ v8::Local<v8::Promise> ExecuteJavaScriptInIsolatedWorld(
     int world_id,
     const std::vector<mate::Dictionary>& scripts) {
   v8::Isolate* isolate = args->isolate();
-  util::Promise promise(isolate);
+  util::Promise<v8::Local<v8::Value>> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
   std::vector<blink::WebScriptSource> sources;


### PR DESCRIPTION
This solves a long-standing TODO whereby using `util::Promise::Then` is **not** type safe (in cpp I know) and could result in nasty issues like this one --> https://github.com/electron/electron/pull/18288 where cpp compiles but throws an uncatchable promise rejection internally because the two types native mate tries to convert between are incompatible.

This quote kinda sums it up:

> So it turns out we've successfully introduced a way to write non-typesafe C++.

This PR makes all `util::Promise` instances templated as `util::Promise<ResolveType>` and adds some helpful static_asserts to ensure the following three things

* You can only chain a `base::Callback` onto ` util::Promise` if the callback takes a single parameter that matches the `util::Promise` resolve type
* You can only resolve promises without a value (`Resolve()`) if the resolve type is `void*`
* You can't resolve promises with a value (`Result(v)`) if the resolve type is `void*`

This PR also removes the unused `CopyablePromise` helper, removes the generic `Reject<T>` method as IMO we should always reject with an error message and nothing was using it.  Also added a new `ResolveWithGin` helper to make the gin migration smoother (it uses gin to convert to v8)

This also IMO makes code involving our promise helper much easier to understand at a glance.  i.e. `util::Promise` before was a wildcard, and now `util::Promise<gfx::Image>` is really obvious what's going on.

Please review this quite well and _question anything that looks off to you_ this entire PR had to be done by hand.

Notes: no-notes