### PR TITLE
fix: race condition in NodeStreamLoader

### DIFF
--- a/shell/browser/net/node_stream_loader.h
+++ b/shell/browser/net/node_stream_loader.h
@@ -39,6 +39,7 @@ class NodeStreamLoader : public network::mojom::URLLoader {
   using EventCallback = base::RepeatingCallback<void()>;
 
   void Start(network::ResourceResponseHead head);
+  void NotifyReadable();
   void NotifyComplete(int result);
   void ReadMore();
   void DidWrite(MojoResult result);
@@ -67,11 +68,14 @@ class NodeStreamLoader : public network::mojom::URLLoader {
 
   // Whether we are in the middle of write.
   bool is_writing_ = false;
+  bool is_reading_ = false;
 
   // When NotifyComplete is called while writing, we will save the result and
   // quit with it after the write is done.
   bool ended_ = false;
   int result_ = net::OK;
+
+  bool readable_ = false;
 
   // Store the V8 callbacks to unsubscribe them later.
   std::map<std::string, v8::Global<v8::Value>> handlers_;

--- a/shell/browser/net/node_stream_loader.h
+++ b/shell/browser/net/node_stream_loader.h
@@ -68,6 +68,8 @@ class NodeStreamLoader : public network::mojom::URLLoader {
 
   // Whether we are in the middle of write.
   bool is_writing_ = false;
+
+  // Whether we are in the middle of a stream.read().
   bool is_reading_ = false;
 
   // When NotifyComplete is called while writing, we will save the result and
@@ -75,6 +77,9 @@ class NodeStreamLoader : public network::mojom::URLLoader {
   bool ended_ = false;
   int result_ = net::OK;
 
+  // When the stream emits the readable event, we only want to start reading
+  // data if the stream was not readable before, so we store the state in a
+  // flag.
   bool readable_ = false;
 
   // Store the V8 callbacks to unsubscribe them later.


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Currently, it's possible to break the `protocol.registerStreamProtocol` API if you supply data to the stream too quickly (e.g. sending a file as a response), because of how node streams work. The problem specifically was that we listen to the `readable` event, and the [stream emits one right before emitting `end`](https://nodejs.org/api/stream.html#stream_event_readable). This can lead to the `end` event arriving while `NodeStreamLoader::ReadMore` is calling `stream.read()`, but before `is_writing_` is set, which causes a crash, since `NodeStreamLoader` deletes itself in this case.

Another thing that was happening was that `ReadMore` was called from two sources - whenever the stream emitted `readable`, and whenever a `DidWrite` call was successful, which lead to two `ReadMore` calls running at once, which could lead to chunks being sent in the wrong order. This PR fixes that problem as well.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a race condition that occurred when using protocol.registerStreamProtocol.<!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
