### PR TITLE
fix: only override default window.close() in windows opened with nativeWindowOpen: false

### DIFF
--- a/lib/renderer/window-setup.ts
+++ b/lib/renderer/window-setup.ts
@@ -177,13 +177,6 @@ class BrowserWindowProxy {
 export const windowSetup = (
   guestInstanceId: number, openerId: number, isHiddenPage: boolean, usesNativeWindowOpen: boolean
 ) => {
-  if (guestInstanceId == null) {
-    // Override default window.close.
-    window.close = function () {
-      ipcRendererInternal.sendSync('ELECTRON_BROWSER_WINDOW_CLOSE')
-    }
-  }
-
   if (!usesNativeWindowOpen) {
     // Make the browser window or guest view emit "new-window" event.
     (window as any).open = function (url?: string, frameName?: string, features?: string) {
@@ -200,6 +193,11 @@ export const windowSetup = (
 
     if (openerId != null) {
       window.opener = getOrCreateProxy(openerId)
+
+      // Override default window.close.
+      window.close = function () {
+        ipcRendererInternal.sendSync('ELECTRON_BROWSER_WINDOW_CLOSE')
+      }
     }
   }
 


### PR DESCRIPTION
#### Description of Change
Fixes #19194

#### Checklist
- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: `window.close()` does no longer close the window when called in `BrowserView`.