### PR TITLE
docs: Add a CSP meta tag to make the tutorial compiant with the security checklist

### DIFF
--- a/docs/tutorial/first-app.md
+++ b/docs/tutorial/first-app.md
@@ -195,6 +195,8 @@ Finally the `index.html` is the web page you want to show:
   <head>
     <meta charset="UTF-8">
     <title>Hello World!</title>
+    <!-- https://electronjs.org/docs/tutorial/security#csp-meta-tag -->
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self';" />
   </head>
   <body>
     <h1>Hello World!</h1>


### PR DESCRIPTION
I've asked #19775 because I was frustrated with how hard it was to find a way to fix (instead of hide) the CSP warning in Electron and I complained that even the official quick start guide wasn't compliant with the security checklist at https://electronjs.org/docs/tutorial/security. Someone helped me out with a CSP meta tag which I have later noticed is indeed mentioned in the checklist, too: https://electronjs.org/docs/tutorial/security#csp-meta-tag. I have not used the checklist one verbatim because it prevents a `script` tag from working when serving `index.html` through the `file:` protocol as the quick start does. I instead used the one the person in my issue recommended which seems to work well to me. I am not that well versed in CSP so there might be a better policy to include with the quick start, but this is what I've got for now.

notes: no-notes