### PR TITLE
refactor: use Error util when only throwing errors

### DIFF
--- a/shell/browser/api/atom_api_app.cc
+++ b/shell/browser/api/atom_api_app.cc
@@ -846,11 +846,11 @@ void App::SetAppPath(const base::FilePath& app_path) {
 }
 
 #if !defined(OS_MACOSX)
-void App::SetAppLogsPath(base::Optional<base::FilePath> custom_path,
-                         mate::Arguments* args) {
+void App::SetAppLogsPath(util::ErrorThrower thrower,
+                         base::Optional<base::FilePath> custom_path) {
   if (custom_path.has_value()) {
     if (!custom_path->IsAbsolute()) {
-      args->ThrowError("Path must be absolute");
+      thrower.ThrowError("Path must be absolute");
       return;
     }
     base::PathService::Override(DIR_APP_LOGS, custom_path.value());
@@ -865,7 +865,8 @@ void App::SetAppLogsPath(base::Optional<base::FilePath> custom_path,
 }
 #endif
 
-base::FilePath App::GetPath(mate::Arguments* args, const std::string& name) {
+base::FilePath App::GetPath(util::ErrorThrower thrower,
+                            const std::string& name) {
   bool succeed = false;
   base::FilePath path;
 
@@ -876,22 +877,22 @@ base::FilePath App::GetPath(mate::Arguments* args, const std::string& name) {
     // set the path to a sensible default and then try to get it again
     if (!succeed && name == "logs") {
       base::ThreadRestrictions::ScopedAllowIO allow_io;
-      SetAppLogsPath(base::Optional<base::FilePath>(), args);
+      SetAppLogsPath(thrower, base::Optional<base::FilePath>());
       succeed = base::PathService::Get(key, &path);
     }
   }
 
   if (!succeed)
-    args->ThrowError("Failed to get '" + name + "' path");
+    thrower.ThrowError("Failed to get '" + name + "' path");
 
   return path;
 }
 
-void App::SetPath(mate::Arguments* args,
+void App::SetPath(util::ErrorThrower thrower,
                   const std::string& name,
                   const base::FilePath& path) {
   if (!path.IsAbsolute()) {
-    args->ThrowError("Path must be absolute");
+    thrower.ThrowError("Path must be absolute");
     return;
   }
 
@@ -901,7 +902,7 @@ void App::SetPath(mate::Arguments* args,
     succeed =
         base::PathService::OverrideAndCreateIfNeeded(key, path, true, false);
   if (!succeed)
-    args->ThrowError("Failed to set path");
+    thrower.ThrowError("Failed to set path");
 }
 
 void App::SetDesktopName(const std::string& desktop_name) {
@@ -1030,9 +1031,9 @@ bool App::Relaunch(mate::Arguments* js_args) {
   return relauncher::RelaunchApp(argv);
 }
 
-void App::DisableHardwareAcceleration(mate::Arguments* args) {
+void App::DisableHardwareAcceleration(util::ErrorThrower thrower) {
   if (Browser::Get()->is_ready()) {
-    args->ThrowError(
+    thrower.ThrowError(
         "app.disableHardwareAcceleration() can only be called "
         "before app is ready");
     return;
@@ -1040,9 +1041,9 @@ void App::DisableHardwareAcceleration(mate::Arguments* args) {
   content::GpuDataManager::GetInstance()->DisableHardwareAcceleration();
 }
 
-void App::DisableDomainBlockingFor3DAPIs(mate::Arguments* args) {
+void App::DisableDomainBlockingFor3DAPIs(util::ErrorThrower thrower) {
   if (Browser::Get()->is_ready()) {
-    args->ThrowError(
+    thrower.ThrowError(
         "app.disableDomainBlockingFor3DAPIs() can only be called "
         "before app is ready");
     return;
@@ -1056,9 +1057,10 @@ bool App::IsAccessibilitySupportEnabled() {
   return ax_state->IsAccessibleBrowser();
 }
 
-void App::SetAccessibilitySupportEnabled(bool enabled, mate::Arguments* args) {
+void App::SetAccessibilitySupportEnabled(util::ErrorThrower thrower,
+                                         bool enabled) {
   if (!Browser::Get()->is_ready()) {
-    args->ThrowError(
+    thrower.ThrowError(
         "app.setAccessibilitySupportEnabled() can only be called "
         "after app is ready");
     return;
@@ -1312,9 +1314,9 @@ static void RemoveNoSandboxSwitch(base::CommandLine* command_line) {
   }
 }
 
-void App::EnableSandbox(mate::Arguments* args) {
+void App::EnableSandbox(util::ErrorThrower thrower) {
   if (Browser::Get()->is_ready()) {
-    args->ThrowError(
+    thrower.ThrowError(
         "app.enableSandbox() can only be called "
         "before app is ready");
     return;

--- a/shell/browser/api/atom_api_app.h
+++ b/shell/browser/api/atom_api_app.h
@@ -27,6 +27,7 @@
 #include "shell/browser/atom_browser_client.h"
 #include "shell/browser/browser.h"
 #include "shell/browser/browser_observer.h"
+#include "shell/common/error_util.h"
 #include "shell/common/native_mate_converters/callback.h"
 #include "shell/common/promise_util.h"
 
@@ -164,12 +165,12 @@ class App : public AtomBrowserClient::Delegate,
   void ChildProcessLaunched(int process_type, base::ProcessHandle handle);
   void ChildProcessDisconnected(base::ProcessId pid);
 
-  void SetAppLogsPath(base::Optional<base::FilePath> custom_path,
-                      mate::Arguments* args);
+  void SetAppLogsPath(util::ErrorThrower thrower,
+                      base::Optional<base::FilePath> custom_path);
 
   // Get/Set the pre-defined path in PathService.
-  base::FilePath GetPath(mate::Arguments* args, const std::string& name);
-  void SetPath(mate::Arguments* args,
+  base::FilePath GetPath(util::ErrorThrower thrower, const std::string& name);
+  void SetPath(util::ErrorThrower thrower,
                const std::string& name,
                const base::FilePath& path);
 
@@ -182,10 +183,10 @@ class App : public AtomBrowserClient::Delegate,
   bool RequestSingleInstanceLock();
   void ReleaseSingleInstanceLock();
   bool Relaunch(mate::Arguments* args);
-  void DisableHardwareAcceleration(mate::Arguments* args);
-  void DisableDomainBlockingFor3DAPIs(mate::Arguments* args);
+  void DisableHardwareAcceleration(util::ErrorThrower thrower);
+  void DisableDomainBlockingFor3DAPIs(util::ErrorThrower thrower);
   bool IsAccessibilitySupportEnabled();
-  void SetAccessibilitySupportEnabled(bool enabled, mate::Arguments* args);
+  void SetAccessibilitySupportEnabled(util::ErrorThrower thrower, bool enabled);
   Browser::LoginItemSettings GetLoginItemSettings(mate::Arguments* args);
 #if defined(USE_NSS_CERTS)
   void ImportCertificate(const base::DictionaryValue& options,
@@ -198,7 +199,7 @@ class App : public AtomBrowserClient::Delegate,
   v8::Local<v8::Value> GetGPUFeatureStatus(v8::Isolate* isolate);
   v8::Local<v8::Promise> GetGPUInfo(v8::Isolate* isolate,
                                     const std::string& info_type);
-  void EnableSandbox(mate::Arguments* args);
+  void EnableSandbox(util::ErrorThrower thrower);
   void SetUserAgentFallback(const std::string& user_agent);
   std::string GetUserAgentFallback();
   void SetBrowserClientCanUseCustomSiteInstance(bool should_disable);

--- a/shell/browser/api/atom_api_app_mac.mm
+++ b/shell/browser/api/atom_api_app_mac.mm
@@ -13,11 +13,11 @@ namespace electron {
 
 namespace api {
 
-void App::SetAppLogsPath(base::Optional<base::FilePath> custom_path,
-                         mate::Arguments* args) {
+void App::SetAppLogsPath(util::ErrorThrower thrower,
+                         base::Optional<base::FilePath> custom_path) {
   if (custom_path.has_value()) {
     if (!custom_path->IsAbsolute()) {
-      args->ThrowError("Path must be absolute");
+      thrower.ThrowError("Path must be absolute");
       return;
     }
     base::PathService::Override(DIR_APP_LOGS, custom_path.value());


### PR DESCRIPTION
#### Description of Change

This PR applies abilities conferred by https://github.com/electron/electron/pull/19803 to use a bespoke error throwing utility in `atom_api_app` when a given function is only taking `mate:Arguments` as a parameter to throw arguments. There are not many and specific instances where we were using the previous antipattern, so this change should likely cause minimal churn.

cc @MarshallOfSound @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
