### PR TITLE
feat: migrate webRequest module to NetworkService (Part 8)

### DIFF
--- a/shell/browser/api/atom_api_web_request_ns.cc
+++ b/shell/browser/api/atom_api_web_request_ns.cc
@@ -207,7 +207,7 @@ void ReadFromResponse(v8::Isolate* isolate,
   if (!response->Get("statusLine", &status_line))
     status_line = headers.second;
   v8::Local<v8::Value> value;
-  if (response->Get("responseHeaders", &value)) {
+  if (response->Get("responseHeaders", &value) && value->IsObject()) {
     *headers.first = new net::HttpResponseHeaders("");
     (*headers.first)->ReplaceStatusLine(status_line);
     gin::Converter<net::HttpResponseHeaders*>::FromV8(isolate, value,

--- a/shell/browser/api/atom_api_web_request_ns.cc
+++ b/shell/browser/api/atom_api_web_request_ns.cc
@@ -113,15 +113,10 @@ v8::Local<v8::Value> HttpResponseHeadersToV8(
     std::string key;
     std::string value;
     while (headers->EnumerateHeaderLines(&iter, &key, &value)) {
-      if (response_headers.FindKey(key)) {
-        base::ListValue* values = nullptr;
-        if (response_headers.GetList(key, &values))
-          values->AppendString(value);
-      } else {
-        auto values = std::make_unique<base::ListValue>();
-        values->AppendString(value);
-        response_headers.Set(key, std::move(values));
-      }
+      base::Value* values = response_headers.FindListKey(key);
+      if (!values)
+        values = response_headers.SetKey(key, base::ListValue());
+      values->GetList().emplace_back(value);
     }
   }
   return gin::ConvertToV8(v8::Isolate::GetCurrent(), response_headers);

--- a/shell/browser/api/atom_api_web_request_ns.cc
+++ b/shell/browser/api/atom_api_web_request_ns.cc
@@ -127,6 +127,8 @@ void ToDictionary(gin::Dictionary* details, extensions::WebRequestInfo* info) {
 void ToDictionary(gin::Dictionary* details,
                   const network::ResourceRequest& request) {
   details->Set("referrer", request.referrer);
+  if (request.request_body)
+    details->Set("uploadData", *request.request_body);
 }
 
 void ToDictionary(gin::Dictionary* details,

--- a/shell/browser/api/atom_api_web_request_ns.cc
+++ b/shell/browser/api/atom_api_web_request_ns.cc
@@ -167,7 +167,7 @@ void ReadFromResponse(v8::Isolate* isolate,
                       gin::Dictionary* response,
                       net::HttpRequestHeaders* headers) {
   headers->Clear();
-  gin::ConvertFromV8(isolate, gin::ConvertToV8(isolate, *response), headers);
+  response->Get("requestHeaders", headers);
 }
 
 void ReadFromResponse(v8::Isolate* isolate,
@@ -258,7 +258,7 @@ int WebRequestNS::OnBeforeSendHeaders(extensions::WebRequestInfo* info,
       kOnBeforeSendHeaders, info,
       base::BindOnce(std::move(callback), std::set<std::string>(),
                      std::set<std::string>()),
-      headers, request);
+      headers, request, *headers);
 }
 
 int WebRequestNS::OnHeadersReceived(

--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -608,6 +608,8 @@ void ProxyingURLLoaderFactory::InProgressRequest::
   override_headers_ = nullptr;
   redirect_url_ = GURL();
 
+  info_->AddResponseInfoFromResourceResponse(current_response_);
+
   net::CompletionRepeatingCallback copyable_callback =
       base::AdaptCallbackForRepeating(std::move(continuation));
   DCHECK(info_.has_value());

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -160,15 +160,10 @@ v8::Local<v8::Value> Converter<net::HttpResponseHeaders*>::ToV8(
     std::string value;
     while (headers->EnumerateHeaderLines(&iter, &key, &value)) {
       key = base::ToLowerASCII(key);
-      if (response_headers.FindKey(key)) {
-        base::ListValue* values = nullptr;
-        if (response_headers.GetList(key, &values))
-          values->AppendString(value);
-      } else {
-        auto values = std::make_unique<base::ListValue>();
-        values->AppendString(value);
-        response_headers.Set(key, std::move(values));
-      }
+      base::Value* values = response_headers.FindListKey(key);
+      if (!values)
+        values = response_headers.SetKey(key, base::ListValue());
+      values->GetList().emplace_back(value);
     }
   }
   return ConvertToV8(isolate, response_headers);

--- a/shell/common/gin_converters/net_converter.h
+++ b/shell/common/gin_converters/net_converter.h
@@ -70,6 +70,12 @@ struct Converter<net::HttpRequestHeaders> {
 };
 
 template <>
+struct Converter<network::ResourceRequestBody> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const network::ResourceRequestBody& val);
+};
+
+template <>
 struct Converter<network::ResourceRequest> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const network::ResourceRequest& val);

--- a/spec/api-web-request-spec.js
+++ b/spec/api-web-request-spec.js
@@ -12,7 +12,7 @@ chai.use(dirtyChai)
 /* The whole webRequest API doesn't use standard callbacks */
 /* eslint-disable standard/no-callback-literal */
 
-describe.skip('webRequest module', () => {
+describe('webRequest module', () => {
   const ses = session.defaultSession
   const server = http.createServer((req, res) => {
     if (req.url === '/serverRedirect') {


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/15791.
Refs https://github.com/electron/electron/issues/19602.

This PR fixes tests in `api-web-request-spec`.

The tests in `api-net` are still failing, it seems that `webRequest` has some problems with `net` module.

#### Release Notes

Notes: no-notes