### PR TITLE
fix: ensure child_process.fork() doesn't modify main process env

### DIFF
--- a/patches/node/inherit_electron_crashpad_pipe_name_in_child_process.patch
+++ b/patches/node/inherit_electron_crashpad_pipe_name_in_child_process.patch
@@ -6,11 +6,11 @@ Subject: Inherit ELECTRON_CRASHPAD_PIPE_NAME in child process
 This is required for crashReporter to work correctly in node process.
 
 diff --git a/lib/child_process.js b/lib/child_process.js
-index 8934a90f8d5c0557689eba80512802a38a8072ec..a60985173b5b1b7937cd32e69f5cce2128b5af66 100644
+index e489b75262928c5c3ff53676fc49e7005df43376..6d2b0a5448957325e7df330e0b26c96c4100a429 100644
 --- a/lib/child_process.js
 +++ b/lib/child_process.js
-@@ -108,6 +108,10 @@ function fork(modulePath /* , args, options */) {
- 
+@@ -107,6 +107,10 @@ function fork(modulePath /* , args, options */) {
+   options.env = Object.create(options.env || process.env)
    options.env.ELECTRON_RUN_AS_NODE = 1;
  
 +  if (process.platform === 'win32') {

--- a/patches/node/refactor_alter_child_process_fork_to_use_execute_script_with.patch
+++ b/patches/node/refactor_alter_child_process_fork_to_use_execute_script_with.patch
@@ -7,17 +7,16 @@ Subject: refactor: alter child_process.fork to use execute script with
 When forking a child script, we setup a special environment to make the Electron binary run like the upstream node. On Mac, we use the helper app as node binary.
 
 diff --git a/lib/child_process.js b/lib/child_process.js
-index 66be7611dc958721aa67603396ac9dcc0b9737b0..8934a90f8d5c0557689eba80512802a38a8072ec 100644
+index 66be7611dc958721aa67603396ac9dcc0b9737b0..e489b75262928c5c3ff53676fc49e7005df43376 100644
 --- a/lib/child_process.js
 +++ b/lib/child_process.js
-@@ -102,6 +102,16 @@ function fork(modulePath /* , args, options */) {
+@@ -102,6 +102,15 @@ function fork(modulePath /* , args, options */) {
      throw new ERR_CHILD_PROCESS_IPC_REQUIRED('options.stdio');
    }
  
-+  if (!options.env) {
-+    options.env = Object.create(process.env);
-+  }
-+
++  // When forking a child script, we setup a special environment to make
++  // the electron binary run like upstream Node.js
++  options.env = Object.create(options.env || process.env)
 +  options.env.ELECTRON_RUN_AS_NODE = 1;
 +
 +  if (!options.execPath && process.type && process.platform == 'darwin') {


### PR DESCRIPTION
Backport of #19742

See that PR for details.


Notes: Fixed an issue where a call to `child_process.fork()` would set `ELECTRON_RUN_AS_NODE` in the main process.
