### PR TITLE
build: add gn-check to precommit linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,8 +114,8 @@
       "remark -qf"
     ],
     "*.{gn,gni}": [
-      "python script/run-gn-format.py",
       "npm run gn-check",
+      "python script/run-gn-format.py",
       "git add"
     ],
     "*.py": [

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "create-typescript-definitions": "npm run create-api-json && electron-typescript-definitions --api=electron-api.json && node spec/ts-smoke/runner.js",
     "gn-typescript-definitions": "npm run create-typescript-definitions && shx cp electron.d.ts",
     "pre-flight": "pre-flight",
+    "gn-check": "node ./script/gn-check.js",
     "preinstall": "node -e 'process.exit(0)'",
     "prepack": "check-for-leaks",
     "repl": "node ./script/start.js --interactive",
@@ -114,6 +115,7 @@
     ],
     "*.{gn,gni}": [
       "python script/run-gn-format.py",
+      "npm run gn-check",
       "git add"
     ],
     "*.py": [

--- a/script/gn-check.js
+++ b/script/gn-check.js
@@ -1,21 +1,16 @@
 const sh = require('shelljs')
-const path = require('path')
-const fs = require('fs')
 
-const SRC_DIR = path.resolve(__dirname, '..', '..')
-let GN_CHECK_DIR
+const { getOutDir } = require('./lib/utils')
 
-if (process.env.ELECTRON_OUT_DIR) {
-  GN_CHECK_DIR = `../out/${process.env.ELECTRON_OUT_DIR}`
-} else {
-  for (const buildType of ['Debug', 'Testing', 'Release']) {
-    const outPath = path.resolve(SRC_DIR, 'out', buildType)
-    if (fs.existsSync(outPath)) {
-      GN_CHECK_DIR = `../out/${buildType}`
-      break
-    }
-  }
+const OUT_DIR = getOutDir()
+if (!OUT_DIR) {
+  throw new Error(`No viable out dir: one of Debug, Testing, or Release must exist.`)
 }
 
-const gnCheckString = `gn check ${GN_CHECK_DIR} //electron:electron_lib`
+const gnCheckString = `
+gn check ../out/${OUT_DIR} //electron:electron_lib &&
+gn check ../out/${OUT_DIR} //electron:electron_app &&
+gn check ../out/${OUT_DIR} //electron:manifests &&
+gn check ../out/${OUT_DIR} //electron/shell/common/api:mojo
+`
 sh.exit(sh.exec(gnCheckString).code)

--- a/script/gn-check.js
+++ b/script/gn-check.js
@@ -1,0 +1,21 @@
+const sh = require('shelljs')
+const path = require('path')
+const fs = require('fs')
+
+const SRC_DIR = path.resolve(__dirname, '..', '..')
+let GN_CHECK_DIR
+
+if (process.env.ELECTRON_OUT_DIR) {
+  GN_CHECK_DIR = `../out/${process.env.ELECTRON_OUT_DIR}`
+} else {
+  for (const buildType of ['Debug', 'Testing', 'Release']) {
+    const outPath = path.resolve(SRC_DIR, 'out', buildType)
+    if (fs.existsSync(outPath)) {
+      GN_CHECK_DIR = `../out/${buildType}`
+      break
+    }
+  }
+}
+
+const gnCheckString = `gn check ${GN_CHECK_DIR} //electron:electron_lib`
+sh.exit(sh.exec(gnCheckString).code)

--- a/script/gn-check.js
+++ b/script/gn-check.js
@@ -27,7 +27,7 @@ const gnCheckDirs = [
 
 for (const dir of gnCheckDirs) {
   const args = ['check', `../out/${OUT_DIR}`, dir]
-  const result = cp.spawnSync('gn', args, { stdio: 'inherit' })
+  const result = cp.spawnSync('gn', args, { env, stdio: 'inherit' })
   if (result.status !== 0) process.exit(result.status)
 }
 

--- a/script/gn-check.js
+++ b/script/gn-check.js
@@ -1,4 +1,5 @@
 const sh = require('shelljs')
+const cp = require('child_process')
 
 const { getOutDir } = require('./lib/utils')
 
@@ -7,10 +8,17 @@ if (!OUT_DIR) {
   throw new Error(`No viable out dir: one of Debug, Testing, or Release must exist.`)
 }
 
-const gnCheckString = `
-gn check ../out/${OUT_DIR} //electron:electron_lib &&
-gn check ../out/${OUT_DIR} //electron:electron_app &&
-gn check ../out/${OUT_DIR} //electron:manifests &&
-gn check ../out/${OUT_DIR} //electron/shell/common/api:mojo
-`
-sh.exit(sh.exec(gnCheckString).code)
+const gnCheckDirs = [
+  '//electron:electron_lib',
+  '//electron:electron_app',
+  '//electron:manifests',
+  '//electron/shell/common/api:mojo'
+]
+
+for (const dir of gnCheckDirs) {
+  const args = ['check', `../out/${OUT_DIR}`, dir]
+  const result = cp.spawnSync('gn', args, { stdio: 'inherit' })
+  if (result.status !== 0) sh.exit(result.status)
+}
+
+sh.exit(0)

--- a/script/gn-check.js
+++ b/script/gn-check.js
@@ -1,12 +1,22 @@
-const sh = require('shelljs')
 const cp = require('child_process')
+const path = require('path')
 
 const { getOutDir } = require('./lib/utils')
 
+const SOURCE_ROOT = path.normalize(path.dirname(__dirname))
+const DEPOT_TOOLS = path.resolve(SOURCE_ROOT, '..', 'third_party', 'depot_tools')
 const OUT_DIR = getOutDir()
+
 if (!OUT_DIR) {
   throw new Error(`No viable out dir: one of Debug, Testing, or Release must exist.`)
 }
+
+const env = Object.assign({
+  CHROMIUM_BUILDTOOLS_PATH: path.resolve(SOURCE_ROOT, '..', 'buildtools'),
+  DEPOT_TOOLS_WIN_TOOLCHAIN: '0'
+}, process.env)
+// Users may not have depot_tools in PATH.
+env.PATH = `${env.PATH}${path.delimiter}${DEPOT_TOOLS}`
 
 const gnCheckDirs = [
   '//electron:electron_lib',
@@ -18,7 +28,7 @@ const gnCheckDirs = [
 for (const dir of gnCheckDirs) {
   const args = ['check', `../out/${OUT_DIR}`, dir]
   const result = cp.spawnSync('gn', args, { stdio: 'inherit' })
-  if (result.status !== 0) sh.exit(result.status)
+  if (result.status !== 0) process.exit(result.status)
 }
 
-sh.exit(0)
+process.exit(0)


### PR DESCRIPTION
#### Description of Change

This PR adds the GN check step to `lint-staged` for changes to `*.{gn,gni}` files. This is intended to prevent changes to the GN file which cause errors in CI on the `gn-check` step that could easily have been caught had they been tested locally first.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
