### PR TITLE
build: ninja count should be 2*cores + 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,13 +91,13 @@ env-linux-medium: &env-linux-medium
   NUMBER_OF_NINJA_PROCESSES: 3
 
 env-linux-2xlarge: &env-linux-2xlarge
-  NUMBER_OF_NINJA_PROCESSES: 18
+  NUMBER_OF_NINJA_PROCESSES: 34
 
 env-machine-mac: &env-machine-mac
   NUMBER_OF_NINJA_PROCESSES: 6
 
 env-mac-large: &env-mac-large
-  NUMBER_OF_NINJA_PROCESSES: 10
+  NUMBER_OF_NINJA_PROCESSES: 18
 
 env-disable-crash-reporter-tests: &env-disable-crash-reporter-tests
   DISABLE_CRASH_REPORTER_TESTS: true


### PR DESCRIPTION
Noticed while wondering why macOS CI was going slower than normal, with 8 core machines we should be using 18 processes.  With 16 core machines we should be using 34 processes.

Notes: no-notes