### PR TITLE
build: dynamically calculate out dir

### DIFF
--- a/script/lib/utils.js
+++ b/script/lib/utils.js
@@ -23,13 +23,16 @@ function getElectronExec () {
   }
 }
 
-function getOutDir () {
+function getOutDir (shouldLog) {
   if (process.env.ELECTRON_OUT_DIR) {
     return process.env.ELECTRON_OUT_DIR
   } else {
     for (const buildType of ['Debug', 'Testing', 'Release']) {
       const outPath = path.resolve(SRC_DIR, 'out', buildType)
-      if (fs.existsSync(outPath)) return buildType
+      if (fs.existsSync(outPath)) {
+        if (shouldLog) console.log(`OUT_DIR is: ${buildType}`)
+        return buildType
+      }
     }
   }
 }

--- a/script/lib/utils.js
+++ b/script/lib/utils.js
@@ -4,13 +4,13 @@ const path = require('path')
 
 const ELECTRON_DIR = path.resolve(__dirname, '..', '..')
 const SRC_DIR = path.resolve(ELECTRON_DIR, '..')
-const OUT_DIR = process.env.ELECTRON_OUT_DIR || 'Debug'
 
 require('colors')
 const pass = '\u2713'.green
 const fail = '\u2717'.red
 
 function getElectronExec () {
+  const OUT_DIR = getOutDir()
   switch (process.platform) {
     case 'darwin':
       return `out/${OUT_DIR}/Electron.app/Contents/MacOS/Electron`
@@ -20,6 +20,17 @@ function getElectronExec () {
       return `out/${OUT_DIR}/electron`
     default:
       throw new Error('Unknown platform')
+  }
+}
+
+function getOutDir () {
+  if (process.env.ELECTRON_OUT_DIR) {
+    return process.env.ELECTRON_OUT_DIR
+  } else {
+    for (const buildType of ['Debug', 'Testing', 'Release']) {
+      const outPath = path.resolve(SRC_DIR, 'out', buildType)
+      if (fs.existsSync(outPath)) return buildType
+    }
   }
 }
 
@@ -62,8 +73,8 @@ async function getCurrentBranch (gitDir) {
 module.exports = {
   getCurrentBranch,
   getElectronExec,
+  getOutDir,
   getAbsoluteElectronExec,
   ELECTRON_DIR,
-  OUT_DIR,
   SRC_DIR
 }

--- a/script/nan-spec-runner.js
+++ b/script/nan-spec-runner.js
@@ -14,7 +14,7 @@ if (!process.mainModule) {
 }
 
 async function main () {
-  const nodeDir = path.resolve(BASE, `out/${utils.getOutDir()}/gen/node_headers`)
+  const nodeDir = path.resolve(BASE, `out/${utils.getOutDir(true)}/gen/node_headers`)
   const env = Object.assign({}, process.env, {
     npm_config_nodedir: nodeDir,
     npm_config_msvs_version: '2017',

--- a/script/nan-spec-runner.js
+++ b/script/nan-spec-runner.js
@@ -14,7 +14,7 @@ if (!process.mainModule) {
 }
 
 async function main () {
-  const nodeDir = path.resolve(BASE, `out/${utils.OUT_DIR}/gen/node_headers`)
+  const nodeDir = path.resolve(BASE, `out/${utils.getOutDir()}/gen/node_headers`)
   const env = Object.assign({}, process.env, {
     npm_config_nodedir: nodeDir,
     npm_config_msvs_version: '2017',

--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -142,7 +142,7 @@ async function runMainProcessElectronTests () {
 }
 
 async function installSpecModules () {
-  const nodeDir = path.resolve(BASE, `out/${utils.getOutDir()}/gen/node_headers`)
+  const nodeDir = path.resolve(BASE, `out/${utils.getOutDir(true)}/gen/node_headers`)
   const env = Object.assign({}, process.env, {
     npm_config_nodedir: nodeDir,
     npm_config_msvs_version: '2017'

--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -142,7 +142,7 @@ async function runMainProcessElectronTests () {
 }
 
 async function installSpecModules () {
-  const nodeDir = path.resolve(BASE, `out/${utils.OUT_DIR}/gen/node_headers`)
+  const nodeDir = path.resolve(BASE, `out/${utils.getOutDir()}/gen/node_headers`)
   const env = Object.assign({}, process.env, {
     npm_config_nodedir: nodeDir,
     npm_config_msvs_version: '2017'


### PR DESCRIPTION
#### Description of Change

This PR updates our `out` directory subfolder calculation in `utils.js` dynamically instead of always falling back to `Debug` if `process.env.ELECTRON_OUT_DIR` is not set. Associated uses of the previous const export `OUT_DIR` haven been updated accordingly.

cc @ckerr @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
