### PR TITLE
feat: add openbsd support in the node module

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -58,6 +58,7 @@ function getPlatformPath () {
     case 'darwin':
       return 'Electron.app/Contents/MacOS/Electron'
     case 'freebsd':
+    case 'openbsd':
     case 'linux':
       return 'electron'
     case 'win32':


### PR DESCRIPTION
#### Description of Change
The following simple change adds support for running electron
on OpenBSD.

#### Checklist

- [X ] `npm test` passes
- [X ] PR title follows semantic [commit guidelines]

#### Release Notes

Notes: no-notes
