### PR TITLE
fix: add default media usage strings to info.plist

### DIFF
--- a/shell/browser/resources/mac/Info.plist
+++ b/shell/browser/resources/mac/Info.plist
@@ -34,5 +34,9 @@
     <false/>
     <key>NSQuitAlwaysKeepsWindows</key>
     <false/>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>This app needs access to the microphone</string>
+    <key>NSCameraUsageDescription</key>
+    <string>This app needs access to the camera</string>
   </dict>
 </plist>


### PR DESCRIPTION
#### Description of Change

This PR adds default keys to Info.plist for `NSMicrophoneUsageDescription` and `NSCameraUsageDescription`. This is required for media access api usage in macOS Catalina.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added default `NSMicrophoneUsageDescription` and `NSCameraUsageDescription` strings to info.plist.
