### PR TITLE
build: make apply_all_patches.py work in both python2 and python3

### DIFF
--- a/script/apply_all_patches.py
+++ b/script/apply_all_patches.py
@@ -11,7 +11,7 @@ from lib.patches import patch_from_dir
 
 def apply_patches(dirs):
   threeway = os.environ.get("ELECTRON_USE_THREE_WAY_MERGE_FOR_PATCHES")
-  for patch_dir, repo in dirs.iteritems():
+  for patch_dir, repo in dirs.items():
     git.import_patches(repo=repo, patch_data=patch_from_dir(patch_dir),
       threeway=threeway is not None,
       committer_name="Electron Scripts", committer_email="scripts@electron")

--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -61,7 +61,7 @@ def am(repo, patch_data, threeway=False, directory=None, exclude=None,
   proc = subprocess.Popen(
       command,
       stdin=subprocess.PIPE)
-  proc.communicate(patch_data)
+  proc.communicate(patch_data.encode('utf-8'))
   if proc.returncode != 0:
     raise RuntimeError("Command {} returned {}".format(command,
       proc.returncode))

--- a/script/lib/patches.py
+++ b/script/lib/patches.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import codecs
 import os
 
 
@@ -7,7 +8,7 @@ def read_patch(patch_dir, patch_filename):
   """Read a patch from |patch_dir/filename| and amend the commit message with
   metadata about the patch file it came from."""
   ret = []
-  with open(os.path.join(patch_dir, patch_filename)) as f:
+  with codecs.open(os.path.join(patch_dir, patch_filename), encoding='utf-8') as f:
     for l in f.readlines():
       if l.startswith('diff -'):
         ret.append('Patch-Filename: {}\n'.format(patch_filename))


### PR DESCRIPTION
#### Description of Change

Update the `script/` so that `apply_all_patches.py` runs in both python2 and python3.

 * when iterating through the directories containers, replace use of `dirs.iteritems()` with `dirs.items()` because the latter exists in both. (Discussion: there are [slightly faster](http://python-future.org/compatible_idioms.html#dictionaries) alternatives to `items()` on python2, but since we're only dealing with a few folders, they're overkill)
 * `Popen.communicate()` takes a byte array in python3, so when using it in `script/lib/git.py`, send `patch_data.encode('utf-8')` rather than `patch_data`). ([Discussion](https://stackoverflow.com/questions/48169667/how-to-handle-subprocess-popen-output-in-both-python-2-and-python-3))
 * When reading patches from a directory, use `codec.open(filename, encoding='utf-8')` to ensure the previous line item's encoding will succeed. ([Discussion](https://stackoverflow.com/questions/10971033/backporting-python-3-openencoding-utf-8-to-python-2))

CC @alexeykuzmin @nornagon 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes