### PR TITLE
fix: don't call SetBounds on restore

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -305,7 +305,6 @@ NativeWindowViews::NativeWindowViews(const mate::Dictionary& options,
     last_window_state_ = ui::SHOW_STATE_FULLSCREEN;
   else
     last_window_state_ = ui::SHOW_STATE_NORMAL;
-  last_normal_bounds_ = GetBounds();
 #endif
 
 #if defined(OS_LINUX)

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -246,23 +246,6 @@ class NativeWindowViews : public NativeWindow,
 
   gfx::Rect last_normal_placement_bounds_;
 
-  // There's an issue with restore on Windows, that sometimes causes the Window
-  // to receive the wrong size (#2498). To circumvent that, we keep tabs on the
-  // size of the window while in the normal state (not maximized, minimized or
-  // fullscreen), so we restore it correctly.
-  gfx::Rect last_normal_bounds_;
-  gfx::Rect last_normal_bounds_before_move_;
-
-  // last_normal_bounds_ may or may not require update on WM_MOVE. When a
-  // window is maximized, it is moved (WM_MOVE) to maximum size first and then
-  // sized (WM_SIZE). In this case, last_normal_bounds_ should not update. We
-  // keep last_normal_bounds_candidate_ as a candidate which will become valid
-  // last_normal_bounds_ if the moves are consecutive with no WM_SIZE event in
-  // between.
-  gfx::Rect last_normal_bounds_candidate_;
-
-  bool consecutive_moves_;
-
   // In charge of running taskbar related APIs.
   TaskbarHost taskbar_host_;
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

This is a revert of #8047, the issues mentioned there are not reproducible after the revert (in fact #7951 resurfaced, and this fixes that). Since the issue mentioned in the comments (#2498) is about frameless window sizing and the PR I created to improve that landed in `6-0-x`, I'm only backporting until that to make sure not to re-introduce the original bug.

Fixes #13043.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix a bug where an unresizable window would shrink when restored after being minimized on Windows.<!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
