### PR TITLE
feat: add session.downloadURL()

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -408,6 +408,17 @@ Returns `String` - The user agent for this session.
 
 Returns `Promise<Buffer>` - resolves with blob data.
 
+#### `ses.downloadURL(url)`
+
+* `url` String
+
+Initiates a download of the resource at `url`.
+The API will generate a [DownloadItem](download-item.md) that can be accessed
+with the [will-download](#event-will-download) event.
+
+**Note:** This does not perform any security checks that relate to a page's origin,
+unlike [`webContents.downloadURL`](web-contents.md#contentsdownloadurlurl).
+
 #### `ses.createInterruptedDownload(options)`
 
 * `options` Object

--- a/shell/browser/api/atom_api_session.cc
+++ b/shell/browser/api/atom_api_session.cc
@@ -19,6 +19,7 @@
 #include "chrome/browser/browser_process.h"
 #include "chrome/common/pref_names.h"
 #include "components/download/public/common/download_danger_type.h"
+#include "components/download/public/common/download_url_parameters.h"
 #include "components/prefs/pref_service.h"
 #include "components/prefs/value_map_pref_store.h"
 #include "components/proxy_config/proxy_config_dictionary.h"
@@ -510,6 +511,14 @@ v8::Local<v8::Promise> Session::GetBlobData(v8::Isolate* isolate,
   return handle;
 }
 
+void Session::DownloadURL(const GURL& url) {
+  auto* download_manager =
+      content::BrowserContext::GetDownloadManager(browser_context());
+  auto download_params = std::make_unique<download::DownloadUrlParameters>(
+      url, MISSING_TRAFFIC_ANNOTATION);
+  download_manager->DownloadUrl(std::move(download_params));
+}
+
 void Session::CreateInterruptedDownload(const mate::Dictionary& options) {
   int64_t offset = 0, length = 0;
   double start_time = 0.0;
@@ -694,6 +703,7 @@ void Session::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setUserAgent", &Session::SetUserAgent)
       .SetMethod("getUserAgent", &Session::GetUserAgent)
       .SetMethod("getBlobData", &Session::GetBlobData)
+      .SetMethod("downloadURL", &Session::DownloadURL)
       .SetMethod("createInterruptedDownload",
                  &Session::CreateInterruptedDownload)
       .SetMethod("setPreloads", &Session::SetPreloads)

--- a/shell/browser/api/atom_api_session.h
+++ b/shell/browser/api/atom_api_session.h
@@ -79,6 +79,7 @@ class Session : public mate::TrackableObject<Session>,
   std::string GetUserAgent();
   v8::Local<v8::Promise> GetBlobData(v8::Isolate* isolate,
                                      const std::string& uuid);
+  void DownloadURL(const GURL& url);
   void CreateInterruptedDownload(const mate::Dictionary& options);
   void SetPreloads(const std::vector<base::FilePath::StringType>& preloads);
   std::vector<base::FilePath::StringType> GetPreloads() const;

--- a/spec-main/api-session-spec.ts
+++ b/spec-main/api-session-spec.ts
@@ -588,6 +588,18 @@ describe('session module', () => {
       fs.unlinkSync(downloadFilePath)
     }
 
+    it('can download using session.downloadURL', (done) => {
+      const port = address.port
+      session.defaultSession.once('will-download', function (e, item) {
+        item.savePath = downloadFilePath
+        item.on('done', function (e, state) {
+          assertDownload(state, item)
+          done()
+        })
+      })
+      session.defaultSession.downloadURL(`${url}:${port}`)
+    })
+
     it('can download using WebContents.downloadURL', (done) => {
       const port = address.port
       w.webContents.session.once('will-download', function (e, item) {


### PR DESCRIPTION
#### Description of Change
Add `session.downloadURL()` allowing to trigger downloads without a `BrowserWindow`

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `session.downloadURL()` allowing to trigger downloads without a `BrowserWindow`.