### PR TITLE
docs: clarify `app.setName()` effects

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -669,7 +669,7 @@ preferred over `name` by Electron.
 
 **[Deprecated](modernization/property-updates.md)**
 
-### `app.setName(name)`
+### `app.setName(name)` _Linux_ _Windows_
 
 * `name` String
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -669,11 +669,13 @@ preferred over `name` by Electron.
 
 **[Deprecated](modernization/property-updates.md)**
 
-### `app.setName(name)` _Linux_ _Windows_
+### `app.setName(name)`
 
 * `name` String
 
 Overrides the current application's name.
+
+**Note:** This overrides the name used internally by Electron, it does not affect the name that the OS uses.
 
 **[Deprecated](modernization/property-updates.md)**
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -675,7 +675,7 @@ preferred over `name` by Electron.
 
 Overrides the current application's name.
 
-**Note:** This overrides the name used internally by Electron, it does not affect the name that the OS uses.
+**Note:** This function overrides the name used internally by Electron; it does not affect the name that the OS uses.
 
 **[Deprecated](modernization/property-updates.md)**
 


### PR DESCRIPTION
#### Description of Change

See: #19892 

I suggest adding the Windows and Linux tags to the `app.setName()` method in the API docs? This would make it a bit easier for us devs to recognise that it doesn't work on Mac.

Notes: none