### PR TITLE
fix: crash on input file handler dialog

### DIFF
--- a/shell/browser/web_dialog_helper.cc
+++ b/shell/browser/web_dialog_helper.cc
@@ -128,7 +128,9 @@ class FileSelectHelper : public base::RefCounted<FileSelectHelper>,
     // listener is called from the directory enumerator.
     bool ready_to_call_listener = false;
 
-    if (!canceled) {
+    if (canceled) {
+      OnSelectionCancelled();
+    } else {
       std::vector<base::FilePath> paths;
       if (result.Get("filePaths", &paths)) {
         // If we are uploading a folder we need to enumerate its contents
@@ -156,8 +158,6 @@ class FileSelectHelper : public base::RefCounted<FileSelectHelper>,
       // We should only call this if we have not cancelled the dialog
       if (ready_to_call_listener)
         OnFilesSelected(std::move(file_info), lister_base_dir_);
-    } else {
-      OnSelectionCancelled();
     }
   }
 
@@ -166,7 +166,9 @@ class FileSelectHelper : public base::RefCounted<FileSelectHelper>,
     bool canceled = true;
     result.Get("canceled", &canceled);
 
-    if (!canceled) {
+    if (canceled) {
+      OnSelectionCancelled();
+    } else {
       base::FilePath path;
       if (result.Get("filePath", &path)) {
         file_info.push_back(FileChooserFileInfo::NewNativeFile(
@@ -175,8 +177,6 @@ class FileSelectHelper : public base::RefCounted<FileSelectHelper>,
       }
       // We should only call this if we have not cancelled the dialog
       OnFilesSelected(std::move(file_info), base::FilePath());
-    } else {
-      OnSelectionCancelled();
     }
   }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/19795.

This was crashing on the following DCHECK:
```
DCHECK(was_file_select_listener_function_called_)
          << "Should call either FileSelectListener::FileSelected() or "
             "FileSelectListener::FileSelectionCanceled()";
```

We introduced proper support for the webkitdirectory input attr in https://github.com/electron/electron/pull/18343, which required us to override much of the functionality previously [handled by Chromium](https://cs.chromium.org/chromium/src/content/browser/frame_host/render_frame_host_impl.cc). We told the ListenerProxy that files were selected with
```
listener_->FileSelected(std::move(file_info), base_dir, mode_);
```
but when the cancellation button was clicked, we never explicitly told the `ListenerProxy` that the dialog was cancelled and so the DCHECK was hit. This fixes that issue for both save and open dialogs without altering existing functionality.

cc @MarshallOfSound @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash on `<input type="file">` dialog cancellation.
