### PR TITLE
[WIP] chore: return absolute paths in script/lib/utils.js' getOutDir(), getElectronExec()

### DIFF
--- a/script/nan-spec-runner.js
+++ b/script/nan-spec-runner.js
@@ -14,7 +14,7 @@ if (!process.mainModule) {
 }
 
 async function main () {
-  const nodeDir = path.resolve(BASE, `out/${utils.getOutDir(true)}/gen/node_headers`)
+  const nodeDir = path.join(utils.getOutPath(true), 'gen', 'node_headers')
   const env = Object.assign({}, process.env, {
     npm_config_nodedir: nodeDir,
     npm_config_msvs_version: '2017',
@@ -45,7 +45,7 @@ async function main () {
     .filter(test => !DISABLED_TESTS.includes(test))
     .map(test => `test/js/${test}`)
 
-  const testChild = cp.spawn(utils.getAbsoluteElectronExec(), ['node_modules/.bin/tap', ...testsToRun], {
+  const testChild = cp.spawn(utils.getElectronExecPath(), ['node_modules/.bin/tap', ...testsToRun], {
     env: {
       ...process.env,
       ELECTRON_RUN_AS_NODE: 'true'

--- a/script/node-spec-runner.js
+++ b/script/node-spec-runner.js
@@ -18,7 +18,7 @@ if (!process.mainModule) {
 async function main () {
   const DISABLED_TESTS = require('./node-disabled-tests.json')
 
-  const testChild = cp.spawn('python', ['tools/test.py', '--verbose', '-p', 'tap', '--logfile', TAP_FILE_NAME, '--mode=debug', 'default', `--skip-tests=${DISABLED_TESTS.join(',')}`, '--shell', utils.getAbsoluteElectronExec(), '-J'], {
+  const testChild = cp.spawn('python', ['tools/test.py', '--verbose', '-p', 'tap', '--logfile', TAP_FILE_NAME, '--mode=debug', 'default', `--skip-tests=${DISABLED_TESTS.join(',')}`, '--shell', utils.getElectronExecPath(), '-J'], {
     env: {
       ...process.env,
       ELECTRON_RUN_AS_NODE: 'true'

--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -24,7 +24,6 @@ for (const flag of unknownFlags) {
 const utils = require('./lib/utils')
 const { YARN_VERSION } = require('./yarn')
 
-const BASE = path.resolve(__dirname, '../..')
 const NPM_CMD = process.platform === 'win32' ? 'npm.cmd' : 'npm'
 const NPX_CMD = process.platform === 'win32' ? 'npx.cmd' : 'npx'
 
@@ -111,7 +110,7 @@ async function runElectronTests () {
 }
 
 async function runRemoteBasedElectronTests () {
-  let exe = path.resolve(BASE, utils.getElectronExec())
+  let exe = utils.getElectronExecPath()
   const runnerArgs = ['electron/spec', ...unknownArgs.slice(2)]
   if (process.platform === 'linux') {
     runnerArgs.unshift(path.resolve(__dirname, 'dbus_mock.py'), exe)
@@ -129,7 +128,7 @@ async function runRemoteBasedElectronTests () {
 }
 
 async function runMainProcessElectronTests () {
-  const exe = path.resolve(BASE, utils.getElectronExec())
+  const exe = utils.getElectronExecPath()
 
   const { status } = childProcess.spawnSync(exe, ['electron/spec-main', ...unknownArgs.slice(2)], {
     cwd: path.resolve(__dirname, '../..'),
@@ -142,7 +141,7 @@ async function runMainProcessElectronTests () {
 }
 
 async function installSpecModules () {
-  const nodeDir = path.resolve(BASE, `out/${utils.getOutDir(true)}/gen/node_headers`)
+  const nodeDir = path.join(utils.getOutPath(true), 'gen', 'headers')
   const env = Object.assign({}, process.env, {
     npm_config_nodedir: nodeDir,
     npm_config_msvs_version: '2017'

--- a/script/start.js
+++ b/script/start.js
@@ -1,6 +1,6 @@
 const cp = require('child_process')
 const utils = require('./lib/utils')
-const electronPath = utils.getAbsoluteElectronExec()
+const electronPath = utils.getElectronExecPath(true)
 
 const child = cp.spawn(electronPath, process.argv.slice(2), { stdio: 'inherit' })
 child.on('close', (code) => process.exit(code))


### PR DESCRIPTION
#### Description of Change

A small refactor in the `script/` directory: every caller of script/lib/utils.js' getOutDir() and getElectronExec() converted their return values to an absolute path. This PR does the work in utils.js so the callers don't have to.

Also adds an optional `shouldLog` argument to getElectronExec().

CC @codebytere @jkleinsc @MarshallOfSound 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes