### PR TITLE
fix: i18n of gtk msgbox buttons

### DIFF
--- a/shell/browser/ui/message_box_gtk.cc
+++ b/shell/browser/ui/message_box_gtk.cc
@@ -4,8 +4,6 @@
 
 #include "shell/browser/ui/message_box.h"
 
-#include <glib/gi18n.h>
-
 #include "base/callback.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
@@ -32,6 +30,27 @@ MessageBoxSettings::MessageBoxSettings(const MessageBoxSettings&) = default;
 MessageBoxSettings::~MessageBoxSettings() = default;
 
 namespace {
+
+// Copied from L40-L55 in
+// https://cs.chromium.org/chromium/src/chrome/browser/ui/libgtkui/select_file_dialog_impl_gtk.cc
+#if GTK_CHECK_VERSION(3, 90, 0)
+// GTK stock items have been deprecated.  The docs say to switch to using the
+// strings "_Open", etc.  However this breaks i18n.  We could supply our own
+// internationalized strings, but the "_" in these strings is significant: it's
+// the keyboard shortcut to select these actions. TODO: Provide
+// internationalized strings when GTK provides support for it.
+const char kCancelLabel[] = "_Cancel";
+const char kNoLabel[] = "_No";
+const char kOkLabel[] = "_OK";
+const char kYesLabel[] = "_Yes";
+#else
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+const char* kCancelLabel = GTK_STOCK_CANCEL;
+const char* kNoLabel = GTK_STOCK_NO;
+const char* kOkLabel = GTK_STOCK_OK;
+const char* kYesLabel = GTK_STOCK_YES;
+G_GNUC_END_IGNORE_DEPRECATIONS
+#endif
 
 class GtkMessageBox : public NativeWindowObserver {
  public:
@@ -123,13 +142,13 @@ class GtkMessageBox : public NativeWindowObserver {
   const char* TranslateToStock(int id, const std::string& text) {
     const std::string lower = base::ToLowerASCII(text);
     if (lower == "cancel")
-      return _("_Cancel");
+      return kCancelLabel;
     if (lower == "no")
-      return _("_No");
+      return kNoLabel;
     if (lower == "ok")
-      return _("_OK");
+      return kOkLabel;
     if (lower == "yes")
-      return _("_Yes");
+      return kYesLabel;
     return text.c_str();
   }
 


### PR DESCRIPTION
#### Description of Change

Does for GTK messageboxes what #19756 (12df0e8) did for GTK file dialogs: fixes the i18n of the stock buttons in a way that doesn't break the buttons' keyboard shortcuts.

CC @codebytere 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed i18n of GTK messageboxes' stock buttons.