### PR TITLE
fix: command-line scheme switch values' spillover

### DIFF
--- a/shell/app/atom_content_client.cc
+++ b/shell/app/atom_content_client.cc
@@ -161,14 +161,19 @@ void ComputeBuiltInPlugins(std::vector<content::PepperPluginInfo>* plugins) {
 #endif  // BUILDFLAG(ENABLE_PDF_VIEWER)
 }
 
-void ConvertStringWithSeparatorToVector(std::vector<std::string>* vec,
-                                        const char* separator,
-                                        const char* cmd_switch) {
+void AppendDelimitedSwitchToVector(const base::StringPiece cmd_switch,
+                                   std::vector<std::string>& append_me) {
   auto* command_line = base::CommandLine::ForCurrentProcess();
-  auto string_with_separator = command_line->GetSwitchValueASCII(cmd_switch);
-  if (!string_with_separator.empty())
-    *vec = base::SplitString(string_with_separator, separator,
-                             base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+  auto switch_value = command_line->GetSwitchValueASCII(cmd_switch);
+  if (!switch_value.empty()) {
+    constexpr base::StringPiece delimiter(",", 1);
+    auto tokens =
+        base::SplitString(switch_value, delimiter, base::TRIM_WHITESPACE,
+                          base::SPLIT_WANT_NONEMPTY);
+    append_me.reserve(append_me.size() + tokens.size());
+    std::move(std::begin(tokens), std::end(tokens),
+              std::back_inserter(append_me));
+  }
 }
 
 }  // namespace
@@ -200,30 +205,19 @@ base::RefCountedMemory* AtomContentClient::GetDataResourceBytes(
 }
 
 void AtomContentClient::AddAdditionalSchemes(Schemes* schemes) {
-  std::vector<std::string> splited;
-  ConvertStringWithSeparatorToVector(&splited, ",",
-                                     switches::kServiceWorkerSchemes);
-  for (const std::string& scheme : splited)
-    schemes->service_worker_schemes.push_back(scheme);
+  AppendDelimitedSwitchToVector(switches::kServiceWorkerSchemes,
+                                schemes->service_worker_schemes);
+  AppendDelimitedSwitchToVector(switches::kStandardSchemes,
+                                schemes->standard_schemes);
+  AppendDelimitedSwitchToVector(switches::kSecureSchemes,
+                                schemes->secure_schemes);
+  AppendDelimitedSwitchToVector(switches::kBypassCSPSchemes,
+                                schemes->csp_bypassing_schemes);
+  AppendDelimitedSwitchToVector(switches::kCORSSchemes,
+                                schemes->cors_enabled_schemes);
+
   schemes->service_worker_schemes.push_back(url::kFileScheme);
-
-  ConvertStringWithSeparatorToVector(&splited, ",", switches::kStandardSchemes);
-  for (const std::string& scheme : splited)
-    schemes->standard_schemes.push_back(scheme);
   schemes->standard_schemes.push_back("chrome-extension");
-
-  ConvertStringWithSeparatorToVector(&splited, ",", switches::kSecureSchemes);
-  for (const std::string& scheme : splited)
-    schemes->secure_schemes.push_back(scheme);
-
-  ConvertStringWithSeparatorToVector(&splited, ",",
-                                     switches::kBypassCSPSchemes);
-  for (const std::string& scheme : splited)
-    schemes->csp_bypassing_schemes.push_back(scheme);
-
-  ConvertStringWithSeparatorToVector(&splited, ",", switches::kCORSSchemes);
-  for (const std::string& scheme : splited)
-    schemes->cors_enabled_schemes.push_back(scheme);
 }
 
 void AtomContentClient::AddPepperPlugins(

--- a/shell/app/atom_content_client.cc
+++ b/shell/app/atom_content_client.cc
@@ -5,6 +5,7 @@
 #include "shell/app/atom_content_client.h"
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "base/command_line.h"
@@ -162,7 +163,7 @@ void ComputeBuiltInPlugins(std::vector<content::PepperPluginInfo>* plugins) {
 }
 
 void AppendDelimitedSwitchToVector(const base::StringPiece cmd_switch,
-                                   std::vector<std::string>& append_me) {
+                                   std::vector<std::string>* append_me) {
   auto* command_line = base::CommandLine::ForCurrentProcess();
   auto switch_value = command_line->GetSwitchValueASCII(cmd_switch);
   if (!switch_value.empty()) {
@@ -170,9 +171,9 @@ void AppendDelimitedSwitchToVector(const base::StringPiece cmd_switch,
     auto tokens =
         base::SplitString(switch_value, delimiter, base::TRIM_WHITESPACE,
                           base::SPLIT_WANT_NONEMPTY);
-    append_me.reserve(append_me.size() + tokens.size());
+    append_me->reserve(append_me->size() + tokens.size());
     std::move(std::begin(tokens), std::end(tokens),
-              std::back_inserter(append_me));
+              std::back_inserter(*append_me));
   }
 }
 
@@ -206,15 +207,15 @@ base::RefCountedMemory* AtomContentClient::GetDataResourceBytes(
 
 void AtomContentClient::AddAdditionalSchemes(Schemes* schemes) {
   AppendDelimitedSwitchToVector(switches::kServiceWorkerSchemes,
-                                schemes->service_worker_schemes);
+                                &schemes->service_worker_schemes);
   AppendDelimitedSwitchToVector(switches::kStandardSchemes,
-                                schemes->standard_schemes);
+                                &schemes->standard_schemes);
   AppendDelimitedSwitchToVector(switches::kSecureSchemes,
-                                schemes->secure_schemes);
+                                &schemes->secure_schemes);
   AppendDelimitedSwitchToVector(switches::kBypassCSPSchemes,
-                                schemes->csp_bypassing_schemes);
+                                &schemes->csp_bypassing_schemes);
   AppendDelimitedSwitchToVector(switches::kCORSSchemes,
-                                schemes->cors_enabled_schemes);
+                                &schemes->cors_enabled_schemes);
 
   schemes->service_worker_schemes.push_back(url::kFileScheme);
   schemes->standard_schemes.push_back("chrome-extension");


### PR DESCRIPTION
## Description of Change

Fixes #19911: don't spill command-line switch scheme values into other switches.

In addition, this PR uses move semantics to move the tokens from a temporary container into their destination container.

Verified by adding this temporary code to the end of `AtomContentClient::AddAdditionalSchemes()`:

```cc
#define DUMP_SCHEMES(name) \
  std::cout << #name << std::endl; \
  for (const auto& scheme : schemes->name) std::cout << scheme << ", "; \
  std::cout <<std::endl;

  DUMP_SCHEMES(service_worker_schemes)
  DUMP_SCHEMES(standard_schemes)
  DUMP_SCHEMES(secure_schemes)
  DUMP_SCHEMES(csp_bypassing_schemes)
  DUMP_SCHEMES(cors_enabled_schemes)
```

and invoking Electron with `--standard-schemes=foo,bar,mum`.

Without PR:
```text
service_worker_schemes
file, 
standard_schemes
foo, bar, mum, chrome-extension, 
secure_schemes
foo, bar, mum, 
csp_bypassing_schemes
foo, bar, mum, 
cors_enabled_schemes
foo, bar, mum, 
```

With PR:
```
service_worker_schemes
file, 
standard_schemes
foo, bar, mum, chrome-extension, 
secure_schemes

csp_bypassing_schemes

cors_enabled_schemes
```
(`file` and `chrome-extension` are added automatically and unrelated to this PR).

#### ChecklistAtomContentClient::AddAdditionalSchemes

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed command-line scheme arguments from spilling over into each other.