### PR TITLE
build: use a lower process count for publish builds with no sccache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,12 +92,18 @@ env-linux-medium: &env-linux-medium
 
 env-linux-2xlarge: &env-linux-2xlarge
   NUMBER_OF_NINJA_PROCESSES: 34
+  
+env-linux-2xlarge-release: &env-linux-2xlarge-release
+  NUMBER_OF_NINJA_PROCESSES: 16
 
 env-machine-mac: &env-machine-mac
   NUMBER_OF_NINJA_PROCESSES: 6
 
 env-mac-large: &env-mac-large
   NUMBER_OF_NINJA_PROCESSES: 18
+
+env-mac-large-release: &env-mac-large-release
+  NUMBER_OF_NINJA_PROCESSES: 8
 
 env-disable-crash-reporter-tests: &env-disable-crash-reporter-tests
   DISABLE_CRASH_REPORTER_TESTS: true
@@ -1119,7 +1125,7 @@ jobs:
   linux-x64-publish:
     <<: *machine-linux-2xlarge
     environment:
-      <<: *env-linux-2xlarge
+      <<: *env-linux-2xlarge-release
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_boto=True --custom-var=checkout_requests=True'
       <<: *env-release-build
     <<: *steps-electron-build-for-publish
@@ -1168,7 +1174,7 @@ jobs:
   linux-ia32-publish:
     <<: *machine-linux-2xlarge
     environment:
-      <<: *env-linux-2xlarge
+      <<: *env-linux-2xlarge-release
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_boto=True --custom-var=checkout_requests=True'
       <<: *env-ia32
       <<: *env-release-build
@@ -1219,7 +1225,7 @@ jobs:
   linux-arm-publish:
     <<: *machine-linux-2xlarge
     environment:
-      <<: *env-linux-2xlarge
+      <<: *env-linux-2xlarge-release
       <<: *env-arm
       <<: *env-release-build
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_boto=True --custom-var=checkout_requests=True'
@@ -1286,7 +1292,7 @@ jobs:
   linux-arm64-publish:
     <<: *machine-linux-2xlarge
     environment:
-      <<: *env-linux-2xlarge
+      <<: *env-linux-2xlarge-release
       <<: *env-arm64
       <<: *env-release-build
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm64=True --custom-var=checkout_boto=True --custom-var=checkout_requests=True'
@@ -1345,7 +1351,7 @@ jobs:
   osx-publish:
     <<: *machine-mac-large
     environment:
-      <<: *env-mac-large
+      <<: *env-mac-large-release
       <<: *env-release-build
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_boto=True --custom-var=checkout_requests=True'
     <<: *steps-electron-build-for-publish
@@ -1408,7 +1414,7 @@ jobs:
   mas-publish:
     <<: *machine-mac-large
     environment:
-      <<: *env-mac-large
+      <<: *env-mac-large-release
       <<: *env-mas
       <<: *env-release-build
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_boto=True --custom-var=checkout_requests=True'


### PR DESCRIPTION
Release builds are failing with the core count change. Error included for future-us if it happens again.

```
ian_sid_amd64-sysroot -fvisibility-inlines-hidden -c gen/content/browser/browser_jumbo_15.cc -o obj/content/browser/browser/browser_jumbo_15.o
clang++: error: unable to execute command: Killed
clang++: error: clang frontend command failed due to signal (use -v to see invocation)
clang version 9.0.0 (https://github.com/llvm/llvm-project/ f7e52fbdb5a7af8ea0808e98458b497125a5eca1)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: ../../third_party/llvm-build/Release+Asserts/bin
clang++: note: diagnostic msg: PLEASE submit a bug report to https://crbug.com and run tools/clang/scripts/process_crashreports.py (only works inside Google) which will upload a report and include the crash backtrace, preprocessed source, and associated run script.
clang++: note: diagnostic msg: 
********************

PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
Preprocessed source(s) and associated run script(s) are located at:
clang++: note: diagnostic msg: ../../tools/clang/crashreports/browser_jumbo_15-bd6113.cpp
clang++: note: diagnostic msg: ../../tools/clang/crashreports/browser_jumbo_15-bd6113.sh
clang++: note: diagnostic msg: 

********************
```

Notes: no-notes