### PR TITLE
refactor: simplify ShowSaveDialog, make consistent with ShowOpenDialog

### DIFF
--- a/shell/browser/web_dialog_helper.cc
+++ b/shell/browser/web_dialog_helper.cc
@@ -64,16 +64,12 @@ class FileSelectHelper : public base::RefCounted<FileSelectHelper>,
 
   void ShowSaveDialog(const file_dialog::DialogSettings& settings) {
     v8::Isolate* isolate = v8::Isolate::GetCurrent();
-    v8::Local<v8::Context> context = isolate->GetCurrentContext();
     electron::util::Promise<mate::Dictionary> promise(isolate);
-    v8::Local<v8::Promise> handle = promise.GetHandle();
+
+    auto callback = base::BindOnce(&FileSelectHelper::OnSaveDialogDone, this);
+    ignore_result(promise.Then(std::move(callback)));
 
     file_dialog::ShowSaveDialog(settings, std::move(promise));
-    ignore_result(handle->Then(
-        context,
-        v8::Local<v8::Function>::Cast(mate::ConvertToV8(
-            isolate,
-            base::BindOnce(&FileSelectHelper::OnSaveDialogDone, this)))));
   }
 
  private:


### PR DESCRIPTION
#### Description of Change
Use `util::Promise::Then` helper instead of calling `v8::Promise::Then`

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes