### PR TITLE
refactor: use C++11 member initializers in native_mate

### DIFF
--- a/native_mate/native_mate/arguments.cc
+++ b/native_mate/native_mate/arguments.cc
@@ -24,16 +24,12 @@ std::string V8TypeAsString(v8::Isolate* isolate, v8::Local<v8::Value> value) {
 
 }  // namespace
 
-Arguments::Arguments()
-    : isolate_(NULL), info_(NULL), next_(0), insufficient_arguments_(false) {}
+Arguments::Arguments() = default;
 
 Arguments::Arguments(const v8::FunctionCallbackInfo<v8::Value>& info)
-    : isolate_(info.GetIsolate()),
-      info_(&info),
-      next_(0),
-      insufficient_arguments_(false) {}
+    : isolate_(info.GetIsolate()), info_(&info) {}
 
-Arguments::~Arguments() {}
+Arguments::~Arguments() = default;
 
 v8::Local<v8::Value> Arguments::PeekNext() const {
   if (next_ >= info_->Length())

--- a/native_mate/native_mate/arguments.h
+++ b/native_mate/native_mate/arguments.h
@@ -95,10 +95,10 @@ class Arguments {
   v8::Isolate* isolate() const { return isolate_; }
 
  private:
-  v8::Isolate* isolate_;
-  const v8::FunctionCallbackInfo<v8::Value>* info_;
-  int next_;
-  bool insufficient_arguments_;
+  v8::Isolate* isolate_ = nullptr;
+  const v8::FunctionCallbackInfo<v8::Value>* info_ = nullptr;
+  int next_ = 0;
+  bool insufficient_arguments_ = false;
 };
 
 }  // namespace mate

--- a/native_mate/native_mate/dictionary.cc
+++ b/native_mate/native_mate/dictionary.cc
@@ -6,7 +6,7 @@
 
 namespace mate {
 
-Dictionary::Dictionary() : isolate_(NULL) {}
+Dictionary::Dictionary() = default;
 
 Dictionary::Dictionary(v8::Isolate* isolate, v8::Local<v8::Object> object)
     : isolate_(isolate), object_(object) {}

--- a/native_mate/native_mate/dictionary.h
+++ b/native_mate/native_mate/dictionary.h
@@ -125,7 +125,7 @@ class Dictionary {
   v8::Isolate* isolate() const { return isolate_; }
 
  protected:
-  v8::Isolate* isolate_;
+  v8::Isolate* isolate_ = nullptr;
 
  private:
   v8::Local<v8::Object> object_;

--- a/native_mate/native_mate/function_template.h
+++ b/native_mate/native_mate/function_template.h
@@ -83,10 +83,10 @@ class CallbackHolder : public CallbackHolderBase {
                  int flags)
       : CallbackHolderBase(isolate), callback(callback), flags(flags) {}
   base::Callback<Sig> callback;
-  int flags;
+  int flags = 0;
 
  private:
-  virtual ~CallbackHolder() {}
+  virtual ~CallbackHolder() = default;
 
   DISALLOW_COPY_AND_ASSIGN(CallbackHolder);
 };
@@ -162,9 +162,9 @@ struct ArgumentHolder {
   using ArgLocalType = typename CallbackParamTraits<ArgType>::LocalType;
 
   ArgLocalType value;
-  bool ok;
+  bool ok = false;
 
-  ArgumentHolder(Arguments* args, int create_flags) : ok(false) {
+  ArgumentHolder(Arguments* args, int create_flags) {
     if (index == 0 && (create_flags & HolderIsFirstArgument) &&
         Destroyable::IsDestroyed(args)) {
       args->ThrowError("Object has been destroyed");

--- a/native_mate/native_mate/handle.h
+++ b/native_mate/native_mate/handle.h
@@ -16,7 +16,7 @@ namespace mate {
 template <typename T>
 class Handle {
  public:
-  Handle() : object_(NULL) {}
+  Handle() = default;
 
   Handle(v8::Local<v8::Object> wrapper, T* object)
       : wrapper_(wrapper), object_(object) {}
@@ -34,7 +34,7 @@ class Handle {
 
  private:
   v8::Local<v8::Object> wrapper_;
-  T* object_;
+  T* object_ = nullptr;
 };
 
 template <typename T>

--- a/native_mate/native_mate/object_template_builder.cc
+++ b/native_mate/native_mate/object_template_builder.cc
@@ -11,7 +11,7 @@ ObjectTemplateBuilder::ObjectTemplateBuilder(
     v8::Local<v8::ObjectTemplate> templ)
     : isolate_(isolate), template_(templ) {}
 
-ObjectTemplateBuilder::~ObjectTemplateBuilder() {}
+ObjectTemplateBuilder::~ObjectTemplateBuilder() = default;
 
 ObjectTemplateBuilder& ObjectTemplateBuilder::SetImpl(base::StringPiece name,
                                                       v8::Local<v8::Data> val) {

--- a/native_mate/native_mate/persistent_dictionary.cc
+++ b/native_mate/native_mate/persistent_dictionary.cc
@@ -6,7 +6,7 @@
 
 namespace mate {
 
-PersistentDictionary::PersistentDictionary() {}
+PersistentDictionary::PersistentDictionary() = default;
 
 PersistentDictionary::PersistentDictionary(v8::Isolate* isolate,
                                            v8::Local<v8::Object> object)
@@ -17,7 +17,7 @@ PersistentDictionary::PersistentDictionary(v8::Isolate* isolate,
 PersistentDictionary::PersistentDictionary(const PersistentDictionary& other) =
     default;
 
-PersistentDictionary::~PersistentDictionary() {}
+PersistentDictionary::~PersistentDictionary() = default;
 
 v8::Local<v8::Object> PersistentDictionary::GetHandle() const {
   return handle_->NewHandle();

--- a/native_mate/native_mate/promise.cc
+++ b/native_mate/native_mate/promise.cc
@@ -6,13 +6,13 @@
 
 namespace mate {
 
-Promise::Promise() : isolate_(NULL) {}
+Promise::Promise() = default;
 
 Promise::Promise(v8::Isolate* isolate) : isolate_(isolate) {
   resolver_ = v8::Promise::Resolver::New(isolate);
 }
 
-Promise::~Promise() {}
+Promise::~Promise() = default;
 
 Promise Promise::Create(v8::Isolate* isolate) {
   return Promise(isolate);

--- a/native_mate/native_mate/promise.h
+++ b/native_mate/native_mate/promise.h
@@ -37,7 +37,7 @@ class Promise {
   void RejectWithErrorMessage(const std::string& error);
 
  protected:
-  v8::Isolate* isolate_;
+  v8::Isolate* isolate_ = nullptr;
 
  private:
   v8::Local<v8::Promise::Resolver> resolver_;

--- a/native_mate/native_mate/scoped_persistent.h
+++ b/native_mate/native_mate/scoped_persistent.h
@@ -54,7 +54,7 @@ class ScopedPersistent {
   v8::Isolate* isolate() const { return isolate_; }
 
  private:
-  v8::Isolate* isolate_;
+  v8::Isolate* isolate_ = nullptr;
   v8::Persistent<T> handle_;
 
   DISALLOW_COPY_AND_ASSIGN(ScopedPersistent);
@@ -64,7 +64,7 @@ template <typename T>
 class RefCountedPersistent : public ScopedPersistent<T>,
                              public base::RefCounted<RefCountedPersistent<T>> {
  public:
-  RefCountedPersistent() {}
+  RefCountedPersistent() = default;
 
   RefCountedPersistent(v8::Isolate* isolate, v8::Local<v8::Value> handle)
       : ScopedPersistent<T>(isolate, handle) {}
@@ -72,7 +72,7 @@ class RefCountedPersistent : public ScopedPersistent<T>,
  protected:
   friend class base::RefCounted<RefCountedPersistent<T>>;
 
-  ~RefCountedPersistent() {}
+  ~RefCountedPersistent() = default;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(RefCountedPersistent);

--- a/native_mate/native_mate/wrappable.cc
+++ b/native_mate/native_mate/wrappable.cc
@@ -10,7 +10,7 @@
 
 namespace mate {
 
-WrappableBase::WrappableBase() : isolate_(nullptr) {}
+WrappableBase::WrappableBase() = default;
 
 WrappableBase::~WrappableBase() {
   if (wrapper_.IsEmpty())

--- a/native_mate/native_mate/wrappable.h
+++ b/native_mate/native_mate/wrappable.h
@@ -21,7 +21,7 @@ void* FromV8Impl(v8::Isolate* isolate, v8::Local<v8::Value> val);
 template <typename T>
 class Wrappable : public WrappableBase {
  public:
-  Wrappable() {}
+  Wrappable() = default;
 
   template <typename Sig>
   static void SetConstructor(v8::Isolate* isolate,

--- a/native_mate/native_mate/wrappable_base.h
+++ b/native_mate/native_mate/wrappable_base.h
@@ -55,7 +55,7 @@ class WrappableBase {
   static void SecondWeakCallback(
       const v8::WeakCallbackInfo<WrappableBase>& data);
 
-  v8::Isolate* isolate_;
+  v8::Isolate* isolate_ = nullptr;
   v8::Global<v8::Object> wrapper_;  // Weak
 
   DISALLOW_COPY_AND_ASSIGN(WrappableBase);


### PR DESCRIPTION
#### Description of Change
Modernizes the code a bit and removes some duplicates.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes