### PR TITLE
fix: handle WM_GETMINMAXINFO instead of letting chromium do it

### DIFF
--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -244,8 +244,6 @@ class NativeWindowViews : public NativeWindow,
 
   ui::WindowShowState last_window_state_;
 
-  gfx::Rect last_normal_placement_bounds_;
-
   // There's an issue with restore on Windows, that sometimes causes the Window
   // to receive the wrong size (#2498). To circumvent that, we keep tabs on the
   // size of the window while in the normal state (not maximized, minimized or

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -244,6 +244,8 @@ class NativeWindowViews : public NativeWindow,
 
   ui::WindowShowState last_window_state_;
 
+  gfx::Rect last_normal_placement_bounds_;
+
   // There's an issue with restore on Windows, that sometimes causes the Window
   // to receive the wrong size (#2498). To circumvent that, we keep tabs on the
   // size of the window while in the normal state (not maximized, minimized or

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -335,26 +335,6 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
 
       return false;
     }
-    case WM_GETMINMAXINFO: {
-      WINDOWPLACEMENT wp;
-      wp.length = sizeof(WINDOWPLACEMENT);
-
-      // We do this to work around a Windows bug, where the minimized Window
-      // would report that the closest display to it is not the one that it was
-      // previously on (but the leftmost one instead). We restore the position
-      // of the window during the restore operation, this way chromium can
-      // use the proper display to calculate the scale factor to use.
-      if (!last_normal_placement_bounds_.IsEmpty() &&
-          GetWindowPlacement(GetAcceleratedWidget(), &wp)) {
-        last_normal_placement_bounds_.set_size(gfx::Size(0, 0));
-        wp.rcNormalPosition = last_normal_placement_bounds_.ToRECT();
-        SetWindowPlacement(GetAcceleratedWidget(), &wp);
-
-        last_normal_placement_bounds_ = gfx::Rect();
-      }
-
-      return false;
-    }
     case WM_NCCALCSIZE: {
       if (!has_frame() && w_param == TRUE) {
         NCCALCSIZE_PARAMS* params =
@@ -478,14 +458,6 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
     }
     case SIZE_MINIMIZED:
       last_window_state_ = ui::SHOW_STATE_MINIMIZED;
-
-      WINDOWPLACEMENT wp;
-      wp.length = sizeof(WINDOWPLACEMENT);
-
-      if (GetWindowPlacement(GetAcceleratedWidget(), &wp)) {
-        last_normal_placement_bounds_ = gfx::Rect(wp.rcNormalPosition);
-      }
-
       NotifyWindowMinimize();
       break;
     case SIZE_RESTORED:

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -14,6 +14,7 @@
 #include "ui/display/display.h"
 #include "ui/display/win/screen_win.h"
 #include "ui/gfx/geometry/insets.h"
+#include "ui/gfx/win/msg_util.h"
 #include "ui/views/widget/native_widget_private.h"
 
 // Must be included after other Windows headers.
@@ -335,6 +336,51 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
 
       return false;
     }
+    case WM_GETMINMAXINFO: {
+      // We need to handle GETMINMAXINFO ourselves because chromium tries to
+      // get the scale factor of the window during it's version of this handler
+      // based on the window position, which is invalid at this point. The
+      // previous method of calling SetWindowPlacement fixed the window
+      // position for the scale factor calculation but broke other things.
+      MINMAXINFO* info = reinterpret_cast<MINMAXINFO*>(l_param);
+
+      display::Display display =
+          display::Screen::GetScreen()->GetDisplayNearestPoint(
+              last_normal_placement_bounds_.origin());
+
+      gfx::Size min_size = gfx::ScaleToCeiledSize(
+          widget()->GetMinimumSize(), display.device_scale_factor());
+      gfx::Size max_size = gfx::ScaleToCeiledSize(
+          widget()->GetMaximumSize(), display.device_scale_factor());
+
+      const views::Widget* top_widget = widget()->GetTopLevelWidget();
+      if (IsMaximized() || top_widget->ShouldUseNativeFrame()) {
+        RECT client_rect, window_rect;
+        GetClientRect(GetAcceleratedWidget(), &client_rect);
+        GetWindowRect(GetAcceleratedWidget(), &window_rect);
+        CR_DEFLATE_RECT(&window_rect, &client_rect);
+        min_size.Enlarge(window_rect.right - window_rect.left,
+                         window_rect.bottom - window_rect.top);
+        // Either axis may be zero, so enlarge them independently.
+        if (max_size.width())
+          max_size.Enlarge(window_rect.right - window_rect.left, 0);
+        if (max_size.height())
+          max_size.Enlarge(0, window_rect.bottom - window_rect.top);
+      }
+      info->ptMinTrackSize.x = min_size.width();
+      info->ptMinTrackSize.y = min_size.height();
+      if (max_size.width() || max_size.height()) {
+        if (!max_size.width())
+          max_size.set_width(GetSystemMetrics(SM_CXMAXTRACK));
+        if (!max_size.height())
+          max_size.set_height(GetSystemMetrics(SM_CYMAXTRACK));
+        info->ptMaxTrackSize.x = max_size.width();
+        info->ptMaxTrackSize.y = max_size.height();
+      }
+
+      *result = 1;
+      return true;
+    }
     case WM_NCCALCSIZE: {
       if (!has_frame() && w_param == TRUE) {
         NCCALCSIZE_PARAMS* params =
@@ -458,6 +504,14 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
     }
     case SIZE_MINIMIZED:
       last_window_state_ = ui::SHOW_STATE_MINIMIZED;
+
+      WINDOWPLACEMENT wp;
+      wp.length = sizeof(WINDOWPLACEMENT);
+
+      if (GetWindowPlacement(GetAcceleratedWidget(), &wp)) {
+        last_normal_placement_bounds_ = gfx::Rect(wp.rcNormalPosition);
+      }
+
       NotifyWindowMinimize();
       break;
     case SIZE_RESTORED:
@@ -478,13 +532,6 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
               NotifyWindowEnterFullScreen();
             } else {
               last_window_state_ = ui::SHOW_STATE_NORMAL;
-
-              // When the window is restored we resize it to the previous known
-              // normal size.
-              if (has_frame()) {
-                SetBounds(last_normal_bounds_, false);
-              }
-
               NotifyWindowRestore();
             }
             break;


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

There is a workaround I introduced that's no longer needed and is causing bugs, so this PR removes that. We had that workaround because during the `WM_GETMINMAXINFO` message Windows reports a position that's incorrect (somewhere around -32000 for both coordinates), and the handler in chromium calculates the scale factor for the window based on that position, which will be incorrect if you have more than one monitor (the leftmost will be used).

To work around this, we instead handle the `WM_GETMINMAXINFO` message ourselves, similarly to how chromium does it, but without a size compensation that's not required for us (it compensates for the window frame size, but we expect the minimum and maximum sizes to apply to the window anyway by default, and that compensation code is from 2011, doesn't care about scale factors, and probably should be removed/corrected in chromium anyway).

I'm going to look into upstreaming this new workaround/fix so that we can later remove it altogether.

Depends on #19886. 

Fixes #19423.
Fixes #19816. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a bug where windows would sometimes shrink to 0 size after being restored on Windows. <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
