### PR TITLE
refactor: omit redundant map searches

### DIFF
--- a/shell/app/uv_task_runner.cc
+++ b/shell/app/uv_task_runner.cc
@@ -42,12 +42,13 @@ bool UvTaskRunner::PostNonNestableDelayedTask(const base::Location& from_here,
 
 // static
 void UvTaskRunner::OnTimeout(uv_timer_t* timer) {
-  UvTaskRunner* self = static_cast<UvTaskRunner*>(timer->data);
-  if (!base::Contains(self->tasks_, timer))
+  auto& tasks = static_cast<UvTaskRunner*>(timer->data)->tasks_;
+  const auto iter = tasks.find(timer);
+  if (iter == std::end(tasks))
     return;
 
-  std::move(self->tasks_[timer]).Run();
-  self->tasks_.erase(timer);
+  std::move(iter->second).Run();
+  tasks.erase(iter);
   uv_timer_stop(timer);
   uv_close(reinterpret_cast<uv_handle_t*>(timer), UvTaskRunner::OnClose);
 }

--- a/shell/browser/api/atom_api_global_shortcut.cc
+++ b/shell/browser/api/atom_api_global_shortcut.cc
@@ -107,10 +107,10 @@ bool GlobalShortcut::Register(const ui::Accelerator& accelerator,
 }
 
 void GlobalShortcut::Unregister(const ui::Accelerator& accelerator) {
-  if (!base::Contains(accelerator_callback_map_, accelerator))
+  const auto n_removed = accelerator_callback_map_.erase(accelerator);
+  if (n_removed == 0)
     return;
 
-  accelerator_callback_map_.erase(accelerator);
   GlobalShortcutListener::GetInstance()->UnregisterAccelerator(accelerator,
                                                                this);
 }

--- a/shell/browser/api/atom_api_protocol_ns.cc
+++ b/shell/browser/api/atom_api_protocol_ns.cc
@@ -176,8 +176,7 @@ void ProtocolNS::RegisterURLLoaderFactories(
 ProtocolError ProtocolNS::RegisterProtocol(ProtocolType type,
                                            const std::string& scheme,
                                            const ProtocolHandler& handler) {
-  const auto val =
-      base::TryEmplace(handlers_, scheme, std::make_pair(type, handler));
+  const auto val = base::TryEmplace(handlers_, scheme, type, handler);
   const bool already_exists = !val.second;
   return already_exists ? ProtocolError::REGISTERED : ProtocolError::OK;
 }
@@ -197,8 +196,7 @@ bool ProtocolNS::IsProtocolRegistered(const std::string& scheme) {
 ProtocolError ProtocolNS::InterceptProtocol(ProtocolType type,
                                             const std::string& scheme,
                                             const ProtocolHandler& handler) {
-  const auto val = base::TryEmplace(intercept_handlers_, scheme,
-                                    std::make_pair(type, handler));
+  const auto val = base::TryEmplace(intercept_handlers_, scheme, type, handler);
   const bool already_exists = !val.second;
   return already_exists ? ProtocolError::INTERCEPTED : ProtocolError::OK;
 }

--- a/shell/browser/api/atom_api_protocol_ns.cc
+++ b/shell/browser/api/atom_api_protocol_ns.cc
@@ -176,12 +176,10 @@ void ProtocolNS::RegisterURLLoaderFactories(
 ProtocolError ProtocolNS::RegisterProtocol(ProtocolType type,
                                            const std::string& scheme,
                                            const ProtocolHandler& handler) {
-  ProtocolError error = ProtocolError::OK;
-  if (!base::Contains(handlers_, scheme))
-    handlers_[scheme] = std::make_pair(type, handler);
-  else
-    error = ProtocolError::REGISTERED;
-  return error;
+  const auto val =
+      base::TryEmplace(handlers_, scheme, std::make_pair(type, handler));
+  const bool already_exists = !val.second;
+  return already_exists ? ProtocolError::REGISTERED : ProtocolError::OK;
 }
 
 void ProtocolNS::UnregisterProtocol(const std::string& scheme,
@@ -199,12 +197,10 @@ bool ProtocolNS::IsProtocolRegistered(const std::string& scheme) {
 ProtocolError ProtocolNS::InterceptProtocol(ProtocolType type,
                                             const std::string& scheme,
                                             const ProtocolHandler& handler) {
-  ProtocolError error = ProtocolError::OK;
-  if (!base::Contains(intercept_handlers_, scheme))
-    intercept_handlers_[scheme] = std::make_pair(type, handler);
-  else
-    error = ProtocolError::INTERCEPTED;
-  return error;
+  const auto val = base::TryEmplace(intercept_handlers_, scheme,
+                                    std::make_pair(type, handler));
+  const bool already_exists = !val.second;
+  return already_exists ? ProtocolError::INTERCEPTED : ProtocolError::OK;
 }
 
 void ProtocolNS::UninterceptProtocol(const std::string& scheme,

--- a/shell/browser/api/atom_api_protocol_ns.cc
+++ b/shell/browser/api/atom_api_protocol_ns.cc
@@ -186,11 +186,9 @@ ProtocolError ProtocolNS::RegisterProtocol(ProtocolType type,
 
 void ProtocolNS::UnregisterProtocol(const std::string& scheme,
                                     mate::Arguments* args) {
-  ProtocolError error = ProtocolError::OK;
-  if (base::Contains(handlers_, scheme))
-    handlers_.erase(scheme);
-  else
-    error = ProtocolError::NOT_REGISTERED;
+  const auto n_removed = handlers_.erase(scheme);
+  const auto error =
+      n_removed > 0 ? ProtocolError::OK : ProtocolError::NOT_REGISTERED;
   HandleOptionalCallback(args, error);
 }
 
@@ -211,11 +209,9 @@ ProtocolError ProtocolNS::InterceptProtocol(ProtocolType type,
 
 void ProtocolNS::UninterceptProtocol(const std::string& scheme,
                                      mate::Arguments* args) {
-  ProtocolError error = ProtocolError::OK;
-  if (base::Contains(intercept_handlers_, scheme))
-    intercept_handlers_.erase(scheme);
-  else
-    error = ProtocolError::NOT_INTERCEPTED;
+  const auto n_removed = intercept_handlers_.erase(scheme);
+  const auto error =
+      n_removed > 0 ? ProtocolError::OK : ProtocolError::NOT_INTERCEPTED;
   HandleOptionalCallback(args, error);
 }
 

--- a/shell/browser/api/atom_api_top_level_window.cc
+++ b/shell/browser/api/atom_api_top_level_window.cc
@@ -964,9 +964,6 @@ bool TopLevelWindow::HookWindowMessage(UINT message,
 }
 
 void TopLevelWindow::UnhookWindowMessage(UINT message) {
-  if (!base::Contains(messages_callback_map_, message))
-    return;
-
   messages_callback_map_.erase(message);
 }
 

--- a/shell/browser/api/atom_api_web_request_ns.cc
+++ b/shell/browser/api/atom_api_web_request_ns.cc
@@ -443,7 +443,8 @@ template <typename T>
 void WebRequestNS::OnListenerResult(uint64_t id,
                                     T out,
                                     v8::Local<v8::Value> response) {
-  if (!base::Contains(callbacks_, id))
+  const auto iter = callbacks_.find(id);
+  if (iter == std::end(callbacks_))
     return;
 
   int result = net::OK;
@@ -463,7 +464,7 @@ void WebRequestNS::OnListenerResult(uint64_t id,
   // asynchronously, because it used to work on IO thread before NetworkService.
   base::SequencedTaskRunnerHandle::Get()->PostTask(
       FROM_HERE, base::BindOnce(std::move(callbacks_[id]), result));
-  callbacks_.erase(id);
+  callbacks_.erase(iter);
 }
 
 // static

--- a/shell/browser/api/atom_api_web_request_ns.cc
+++ b/shell/browser/api/atom_api_web_request_ns.cc
@@ -396,10 +396,11 @@ template <typename... Args>
 void WebRequestNS::HandleSimpleEvent(SimpleEvent event,
                                      extensions::WebRequestInfo* request_info,
                                      Args... args) {
-  if (!base::Contains(simple_listeners_, event))
+  const auto iter = simple_listeners_.find(event);
+  if (iter == std::end(simple_listeners_))
     return;
 
-  const auto& info = simple_listeners_[event];
+  const auto& info = iter->second;
   if (!MatchesFilterCondition(request_info, info.url_patterns))
     return;
 
@@ -416,10 +417,11 @@ int WebRequestNS::HandleResponseEvent(ResponseEvent event,
                                       net::CompletionOnceCallback callback,
                                       Out out,
                                       Args... args) {
-  if (!base::Contains(response_listeners_, event))
+  const auto iter = response_listeners_.find(event);
+  if (iter == std::end(response_listeners_))
     return net::OK;
 
-  const auto& info = response_listeners_[event];
+  const auto& info = iter->second;
   if (!MatchesFilterCondition(request_info, info.url_patterns))
     return net::OK;
 

--- a/shell/browser/atom_browser_client.cc
+++ b/shell/browser/atom_browser_client.cc
@@ -195,8 +195,9 @@ content::WebContents* AtomBrowserClient::GetWebContentsFromProcessID(
     int process_id) {
   // If the process is a pending process, we should use the web contents
   // for the frame host passed into RegisterPendingProcess.
-  if (base::Contains(pending_processes_, process_id))
-    return pending_processes_[process_id];
+  const auto iter = pending_processes_.find(process_id);
+  if (iter != std::end(pending_processes_))
+    return iter->second;
 
   // Certain render process will be created with no associated render view,
   // for example: ServiceWorker.

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -8,6 +8,7 @@
 #include <wrl/client.h>
 #endif
 
+#include <array>
 #include <memory>
 #include <tuple>
 #include <utility>
@@ -792,9 +793,11 @@ void NativeWindowViews::SetAlwaysOnTop(ui::ZOrderLevel z_order,
   if (z_order != ui::ZOrderLevel::kNormal) {
     // On macOS the window is placed behind the Dock for the following levels.
     // Re-use the same names on Windows to make it easier for the user.
-    static const std::vector<std::string> levels = {
+    static constexpr std::array<base::StringPiece, 5> levels = {
         "floating", "torn-off-menu", "modal-panel", "main-menu", "status"};
-    behind_task_bar_ = base::Contains(levels, level);
+    const bool found = std::find(std::begin(levels), std::end(levels), level) !=
+                       std::end(levels);
+    behind_task_bar_ = found;
   }
 #endif
   MoveBehindTaskBarIfNeeded();

--- a/shell/browser/ui/accelerator_util.cc
+++ b/shell/browser/ui/accelerator_util.cc
@@ -89,8 +89,9 @@ void GenerateAcceleratorTable(AcceleratorTable* table,
 
 bool TriggerAcceleratorTableCommand(AcceleratorTable* table,
                                     const ui::Accelerator& accelerator) {
-  if (base::Contains(*table, accelerator)) {
-    const accelerator_util::MenuItem& item = (*table)[accelerator];
+  const auto iter = table->find(accelerator);
+  if (iter != std::end(*table)) {
+    const accelerator_util::MenuItem& item = iter->second;
     if (item.model->IsEnabledAt(item.position)) {
       const auto event_flags =
           accelerator.MaskOutKeyEventFlags(accelerator.modifiers());

--- a/shell/browser/ui/atom_menu_model.cc
+++ b/shell/browser/ui/atom_menu_model.cc
@@ -25,11 +25,9 @@ void AtomMenuModel::SetToolTip(int index, const base::string16& toolTip) {
 }
 
 base::string16 AtomMenuModel::GetToolTipAt(int index) {
-  int command_id = GetCommandIdAt(index);
-  if (base::Contains(toolTips_, command_id))
-    return toolTips_[command_id];
-  else
-    return base::string16();
+  const int command_id = GetCommandIdAt(index);
+  const auto iter = toolTips_.find(command_id);
+  return iter == std::end(toolTips_) ? base::string16() : iter->second;
 }
 
 void AtomMenuModel::SetRole(int index, const base::string16& role) {
@@ -38,11 +36,9 @@ void AtomMenuModel::SetRole(int index, const base::string16& role) {
 }
 
 base::string16 AtomMenuModel::GetRoleAt(int index) {
-  int command_id = GetCommandIdAt(index);
-  if (base::Contains(roles_, command_id))
-    return roles_[command_id];
-  else
-    return base::string16();
+  const int command_id = GetCommandIdAt(index);
+  const auto iter = roles_.find(command_id);
+  return iter == std::end(roles_) ? base::string16() : iter->second;
 }
 
 bool AtomMenuModel::GetAcceleratorAtWithParams(

--- a/shell/browser/ui/win/taskbar_host.cc
+++ b/shell/browser/ui/win/taskbar_host.cc
@@ -199,8 +199,9 @@ bool TaskbarHost::SetThumbnailToolTip(HWND window, const std::string& tooltip) {
 }
 
 bool TaskbarHost::HandleThumbarButtonEvent(int button_id) {
-  if (base::Contains(callback_map_, button_id)) {
-    auto callback = callback_map_[button_id];
+  const auto iter = callback_map_.find(button_id);
+  if (iter != std::end(callback_map_)) {
+    auto callback = iter->second;
     if (!callback.is_null())
       callback.Run();
     return true;

--- a/shell/browser/web_view_manager.cc
+++ b/shell/browser/web_view_manager.cc
@@ -28,10 +28,9 @@ void WebViewManager::AddGuest(int guest_instance_id,
 }
 
 void WebViewManager::RemoveGuest(int guest_instance_id) {
-  if (!base::Contains(web_contents_embedder_map_, guest_instance_id))
+  const auto n_removed = web_contents_embedder_map_.erase(guest_instance_id);
+  if (n_removed == 0)
     return;
-
-  web_contents_embedder_map_.erase(guest_instance_id);
 
   // Remove the record of element in embedder too.
   for (const auto& element : element_instance_id_to_guest_map_)

--- a/shell/browser/web_view_manager.cc
+++ b/shell/browser/web_view_manager.cc
@@ -41,24 +41,24 @@ void WebViewManager::RemoveGuest(int guest_instance_id) {
 }
 
 content::WebContents* WebViewManager::GetEmbedder(int guest_instance_id) {
-  if (base::Contains(web_contents_embedder_map_, guest_instance_id))
-    return web_contents_embedder_map_[guest_instance_id].embedder;
-  else
-    return nullptr;
+  const auto iter = web_contents_embedder_map_.find(guest_instance_id);
+  return iter == std::end(web_contents_embedder_map_) ? nullptr
+                                                      : iter->second.embedder;
 }
 
 content::WebContents* WebViewManager::GetGuestByInstanceID(
     int owner_process_id,
     int element_instance_id) {
-  ElementInstanceKey key(owner_process_id, element_instance_id);
-  if (!base::Contains(element_instance_id_to_guest_map_, key))
+  const ElementInstanceKey key(owner_process_id, element_instance_id);
+  const auto guest_iter = element_instance_id_to_guest_map_.find(key);
+  if (guest_iter == std::end(element_instance_id_to_guest_map_))
     return nullptr;
 
-  int guest_instance_id = element_instance_id_to_guest_map_[key];
-  if (base::Contains(web_contents_embedder_map_, guest_instance_id))
-    return web_contents_embedder_map_[guest_instance_id].web_contents;
-  else
-    return nullptr;
+  const int guest_instance_id = guest_iter->second;
+  const auto iter = web_contents_embedder_map_.find(guest_instance_id);
+  return iter == std::end(web_contents_embedder_map_)
+             ? nullptr
+             : iter->second.web_contents;
 }
 
 bool WebViewManager::ForEachGuest(content::WebContents* embedder_web_contents,


### PR DESCRIPTION
#### Description of Change

Remove several instances of a usage pattern where we search a map to see if a key is present, then immediately search the map again to get/remove/assign the value paired with that key.

This real code shows a simple example of this pattern. (Most of the rest are more interesting.)

```cpp
 void TopLevelWindow::UnhookWindowMessage(UINT message) {
  if (!base::Contains(messages_callback_map_, message))
    return;
  messages_callback_map_.erase(message);
}
```
STL Iterators can be verbose, so I've tried a few things to keep it readable:

 1. If we want to erase an item and also know if it existed, then instead of calling `base::Contains() + map.erase()`, instead check the `removedCount` return value of `map.erase()`.
 2. If we want to add an item iff there's not already an entry for that key, `base::TryEmplace()` and then check the `bool added` in the call's return value to see if it was added.

This PR shouldn't change any existing functionality.

Reviewers welcomed.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes