### PR TITLE
fix: adjust window size in NCCALCSIZE instead of adding insets

### DIFF
--- a/atom/browser/ui/views/root_view.cc
+++ b/atom/browser/ui/views/root_view.cc
@@ -175,18 +175,14 @@ void RootView::Layout() {
     return;
 
   const auto menu_bar_bounds =
-      menu_bar_visible_
-          ? gfx::Rect(insets_.left(), insets_.top(),
-                      size().width() - insets_.width(), kMenuBarHeight)
-          : gfx::Rect();
+      menu_bar_visible_ ? gfx::Rect(0, 0, size().width(), kMenuBarHeight)
+                        : gfx::Rect();
   if (menu_bar_)
     menu_bar_->SetBoundsRect(menu_bar_bounds);
 
   window_->content_view()->SetBoundsRect(
-      gfx::Rect(insets_.left(),
-                menu_bar_visible_ ? menu_bar_bounds.bottom() : insets_.top(),
-                size().width() - insets_.width(),
-                size().height() - menu_bar_bounds.height() - insets_.height()));
+      gfx::Rect(0, menu_bar_visible_ ? menu_bar_bounds.bottom() : 0,
+                size().width(), size().height() - menu_bar_bounds.height()));
 }
 
 gfx::Size RootView::GetMinimumSize() const {
@@ -221,13 +217,6 @@ void RootView::UnregisterAcceleratorsWithFocusManager() {
   views::FocusManager* focus_manager = GetFocusManager();
   accelerator_table_.clear();
   focus_manager->UnregisterAccelerators(this);
-}
-
-void RootView::SetInsets(const gfx::Insets& insets) {
-  if (insets != insets_) {
-    insets_ = insets;
-    Layout();
-  }
 }
 
 }  // namespace atom

--- a/atom/browser/ui/views/root_view.h
+++ b/atom/browser/ui/views/root_view.h
@@ -40,8 +40,6 @@ class RootView : public views::View {
   // Register/Unregister accelerators supported by the menu model.
   void RegisterAcceleratorsWithFocusManager(AtomMenuModel* menu_model);
   void UnregisterAcceleratorsWithFocusManager();
-  void SetInsets(const gfx::Insets& insets);
-  gfx::Insets insets() const { return insets_; }
 
   // views::View:
   void Layout() override;
@@ -58,8 +56,6 @@ class RootView : public views::View {
   bool menu_bar_autohide_ = false;
   bool menu_bar_visible_ = false;
   bool menu_bar_alt_pressed_ = false;
-
-  gfx::Insets insets_;
 
   // Map from accelerator to menu item's command id.
   accelerator_util::AcceleratorTable accelerator_table_;


### PR DESCRIPTION
Backport of #19883

See that PR for details.


Notes: Fixed a bug where sometimes a ~10px white border would be added to fullscreen windows on Windows.<!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->