### PR TITLE
docs: Update setAspectRatio documentation

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -945,12 +945,9 @@ Perhaps there are 15 pixels of controls on the left edge, 25 pixels of controls
 on the right edge and 50 pixels of controls below the player. In order to
 maintain a 16:9 aspect ratio (standard aspect ratio for HD @1920x1080) within
 the player itself we would call this function with arguments of 16/9 and
-[ 40, 50 ]. The second argument doesn't care where the extra width and height
+{ width: 40, height: 50 }. The second argument doesn't care where the extra width and height
 are within the content view--only that they exist. Sum any extra width and
 height areas you have within the overall content view.
-
-Calling this function with a value of `0` will remove any previously set aspect
-ratios.
 
 #### `win.setBackgroundColor(backgroundColor)`
 


### PR DESCRIPTION
#### Description of Change

The documentation suggested that [setAspectRatio](https://electronjs.org/docs/api/browser-window#winsetaspectratioaspectratio-extrasize-macos) `extraSize` took an array of numbers as input, when in fact it's an object with `width` and `height` properties.

Also removed the line below, since it's simply not true. The typescript definition only allows you to send in an object, not a number. Unless it suggests sending `{height: 0, width: 0}`, but in that case the documentation needs to reflect that.

`Calling this function with a value of 0 will remove any previously set aspect
ratios.`

#### Checklist

- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: Changed documentation of `setAspectRation` to reflect that it takes an object instead of an array as `extraSize` input.