### PR TITLE
fix: add default media usage strings to info.plist

### DIFF
--- a/shell/browser/resources/mac/Info.plist
+++ b/shell/browser/resources/mac/Info.plist
@@ -32,5 +32,9 @@
     <true/>
     <key>NSRequiresAquaSystemAppearance</key>
     <false/>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>This app needs access to the microphone</string>
+    <key>NSCameraUsageDescription</key>
+    <string>This app needs access to the camera</string>
   </dict>
 </plist>


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/19871.https://github.com/electron/electron/pull/19871

Notes: Added default `NSMicrophoneUsageDescription` and `NSCameraUsageDescription` strings to info.plist.
