### PR TITLE
fix: fall back to default logs path in getPath('logs')

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -31,6 +31,7 @@
 #include "base/environment.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
+#include "base/optional.h"
 #include "base/path_service.h"
 #include "base/system/sys_info.h"
 #include "chrome/browser/browser_process.h"
@@ -835,14 +836,14 @@ void App::SetAppPath(const base::FilePath& app_path) {
 }
 
 #if !defined(OS_MACOSX)
-void App::SetAppLogsPath(mate::Arguments* args) {
-  base::FilePath custom_path;
-  if (args->GetNext(&custom_path)) {
-    if (!custom_path.IsAbsolute()) {
+void App::SetAppLogsPath(base::Optional<base::FilePath> custom_path,
+                         mate::Arguments* args) {
+  if (custom_path.has_value()) {
+    if (!custom_path->IsAbsolute()) {
       args->ThrowError("Path must be absolute");
       return;
     }
-    base::PathService::Override(DIR_APP_LOGS, custom_path);
+    base::PathService::Override(DIR_APP_LOGS, custom_path.value());
   } else {
     base::FilePath path;
     if (base::PathService::Get(DIR_USER_DATA, &path)) {
@@ -857,17 +858,21 @@ void App::SetAppLogsPath(mate::Arguments* args) {
 base::FilePath App::GetPath(mate::Arguments* args, const std::string& name) {
   bool succeed = false;
   base::FilePath path;
+
   int key = GetPathConstant(name);
-  if (key >= 0)
+  if (key >= 0) {
     succeed = base::PathService::Get(key, &path);
-  if (!succeed) {
-    if (name == "logs") {
-      args->ThrowError("Failed to get '" + name +
-                       "' path: setAppLogsPath() must be called first.");
-    } else {
-      args->ThrowError("Failed to get '" + name + "' path");
+    // If users try to get the logs path before setting a logs path,
+    // set the path to a sensible default and then try to get it again
+    if (!succeed && name == "logs") {
+      base::ThreadRestrictions::ScopedAllowIO allow_io;
+      SetAppLogsPath(base::Optional<base::FilePath>(), args);
+      succeed = base::PathService::Get(key, &path);
     }
   }
+
+  if (!succeed)
+    args->ThrowError("Failed to get '" + name + "' path");
 
   return path;
 }

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -847,7 +847,6 @@ void App::SetAppLogsPath(base::Optional<base::FilePath> custom_path,
   } else {
     base::FilePath path;
     if (base::PathService::Get(DIR_USER_DATA, &path)) {
-      path = path.Append(base::FilePath::FromUTF8Unsafe(GetApplicationName()));
       path = path.Append(base::FilePath::FromUTF8Unsafe("logs"));
       base::PathService::Override(DIR_APP_LOGS, path);
     }

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -176,7 +176,8 @@ class App : public AtomBrowserClient::Delegate,
   void ChildProcessLaunched(int process_type, base::ProcessHandle handle);
   void ChildProcessDisconnected(base::ProcessId pid);
 
-  void SetAppLogsPath(mate::Arguments* args);
+  void SetAppLogsPath(base::Optional<base::FilePath> custom_path,
+                      mate::Arguments* args);
 
   // Get/Set the pre-defined path in PathService.
   base::FilePath GetPath(mate::Arguments* args, const std::string& name);

--- a/atom/browser/api/atom_api_app_mac.mm
+++ b/atom/browser/api/atom_api_app_mac.mm
@@ -13,14 +13,14 @@ namespace atom {
 
 namespace api {
 
-void App::SetAppLogsPath(mate::Arguments* args) {
-  base::FilePath custom_path;
-  if (args->GetNext(&custom_path)) {
-    if (!custom_path.IsAbsolute()) {
+void App::SetAppLogsPath(base::Optional<base::FilePath> custom_path,
+                         mate::Arguments* args) {
+  if (custom_path.has_value()) {
+    if (!custom_path->IsAbsolute()) {
       args->ThrowError("Path must be absolute");
       return;
     }
-    base::PathService::Override(DIR_APP_LOGS, custom_path);
+    base::PathService::Override(DIR_APP_LOGS, custom_path.value());
   } else {
     NSString* bundle_name =
         [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleName"];

--- a/atom/common/native_mate_converters/value_converter.h
+++ b/atom/common/native_mate_converters/value_converter.h
@@ -7,6 +7,8 @@
 
 #include "native_mate/converter.h"
 
+#include "base/optional.h"
+
 namespace base {
 class DictionaryValue;
 class ListValue;
@@ -31,6 +33,29 @@ struct Converter<base::Value> {
                      base::Value* out);
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const base::Value& val);
+};
+
+template <typename T>
+struct Converter<base::Optional<T>> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     base::Optional<T>* out) {
+    if (val->IsNull() || val->IsUndefined()) {
+      return true;
+    }
+    T converted;
+    if (Converter<T>::FromV8(isolate, val, &converted)) {
+      return true;
+    }
+    out->emplace(converted);
+    return true;
+  }
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const base::Optional<T>& val) {
+    if (val.has_value())
+      return Converter<T>::ToV8(val.value());
+    return v8::Undefined(isolate);
+  }
 };
 
 template <>

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -578,7 +578,7 @@ them.
 
 Sets or creates a directory your app's logs which can then be manipulated with `app.getPath()` or `app.setPath(pathName, newPath)`.
 
-Calling `app.setAppLogsPath()` without a `path` parameter will result in this directory being set to `/Library/Logs/YourAppName` on _macOS_, and inside the `userData` directory on _Linux_ and _Windows_.
+Calling `app.setAppLogsPath()` without a `path` parameter will result in this directory being set to `~/Library/Logs/YourAppName` on _macOS_, and inside the `userData` directory on _Linux_ and _Windows_.
 
 ### `app.getAppPath()`
 
@@ -611,6 +611,8 @@ You can request the following paths by the name:
 * `videos` Directory for a user's videos.
 * `logs` Directory for your app's log folder.
 * `pepperFlashSystemPlugin` Full path to the system version of the Pepper Flash plugin.
+
+If `app.getPath('logs')` is called without called `app.setAppLogsPath()` being called first, a default log directory will be created equivalent to calling `app.setAppLogsPath()` without a `path` parameter.
 
 ### `app.getFileIcon(path[, options], callback)`
 

--- a/native_mate/native_mate/arguments.h
+++ b/native_mate/native_mate/arguments.h
@@ -6,6 +6,7 @@
 #define NATIVE_MATE_ARGUMENTS_H_
 
 #include "base/macros.h"
+#include "base/optional.h"
 #include "native_mate/converter.h"
 
 namespace mate {
@@ -33,7 +34,18 @@ class Arguments {
     return ConvertFromV8(isolate_, info_->Data(), out);
   }
 
-  template<typename T>
+  template <typename T>
+  bool GetNext(base::Optional<T>* out) {
+    if (next_ >= info_->Length())
+      return true;
+    v8::Local<v8::Value> val = (*info_)[next_];
+    bool success = ConvertFromV8(isolate_, val, out);
+    if (success)
+      next_++;
+    return success;
+  }
+
+  template <typename T>
   bool GetNext(T* out) {
     if (next_ >= info_->Length()) {
       insufficient_arguments_ = true;

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -675,8 +675,8 @@ describe('app module', () => {
   describe('getPath("logs")', () => {
     const logsPaths = {
       'darwin': path.resolve(homedir(), 'Library', 'Logs'),
-      'linux': path.resolve(homedir(), 'AppData', app.name),
-      'win32': path.resolve(homedir(), 'AppData', app.name),
+      'linux': path.resolve(homedir(), 'AppData', app.getName()),
+      'win32': path.resolve(homedir(), 'AppData', app.getName()),
     }
 
     it('has no logs directory by default', () => {

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -673,17 +673,18 @@ describe('app module', () => {
   })
 
   describe('getPath("logs")', () => {
+          // this won't be deterministic except on CI
+    before(function () {
+      if (!isCI) this.skip()
+    })
+  
     const logsPaths = {
-      'darwin': path.resolve(homedir(), 'Library', 'Logs'),
-      'linux': path.resolve(homedir(), 'AppData', app.getName()),
-      'win32': path.resolve(homedir(), 'AppData', app.getName()),
+      'darwin': path.resolve(homedir(),'Library', 'Logs', 'Electron'),
+      'linux': path.resolve(app.getPath('userData'), 'logs'),
+      'win32': path.resolve(app.getPath('userData'), 'logs'),
     }
 
     it('has no logs directory by default', () => {
-      // this won't be deterministic except on CI since
-      // users may or may not have this dir
-      if (!isCI) return
-
       const osLogPath = (logsPaths as any)[process.platform]
       expect(fs.existsSync(osLogPath)).to.be.false
     })
@@ -693,6 +694,8 @@ describe('app module', () => {
 
       const osLogPath = (logsPaths as any)[process.platform]
       expect(fs.existsSync(osLogPath)).to.be.true
+
+      if (isCI) fs.rmdirSync(osLogPath)
     })
   })
 

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -5,6 +5,7 @@ import * as https from 'https'
 import * as net from 'net'
 import * as fs from 'fs'
 import * as path from 'path'
+import { homedir } from 'os'
 import split = require('split')
 import { app, BrowserWindow, Menu } from 'electron'
 import { emittedOnce } from './events-helpers';
@@ -668,6 +669,30 @@ describe('app module', () => {
     it('works for files', async () => {
       const { appPath } = await runTestApp('app-path/lib/index.js')
       expect(appPath).to.equal(path.resolve(fixturesPath, 'api/app-path/lib'))
+    })
+  })
+
+  describe('getPath("logs")', () => {
+    const logsPaths = {
+      'darwin': path.resolve(homedir(), 'Library', 'Logs'),
+      'linux': path.resolve(homedir(), 'AppData', app.name),
+      'win32': path.resolve(homedir(), 'AppData', app.name),
+    }
+
+    it('has no logs directory by default', () => {
+      // this won't be deterministic except on CI since
+      // users may or may not have this dir
+      if (!isCI) return
+
+      const osLogPath = (logsPaths as any)[process.platform]
+      expect(fs.existsSync(osLogPath)).to.be.false
+    })
+
+    it('creates a new logs directory if one does not exist', () => {
+      expect(() => { app.getPath('logs') }).to.not.throw()
+
+      const osLogPath = (logsPaths as any)[process.platform]
+      expect(fs.existsSync(osLogPath)).to.be.true
     })
   })
 


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/19653.

Notes: Fixed an issue where `app.getPath('logs')` would throw an error if the logs path was not previously set.
