### PR TITLE
fix: extern Parse impl for Windows debug builds (#19876)

### DIFF
--- a/patches/node/fix_extern_the_nativemoduleenv_and_options_parser_for_debug_builds.patch
+++ b/patches/node/fix_extern_the_nativemoduleenv_and_options_parser_for_debug_builds.patch
@@ -39,3 +39,16 @@ index c79b08ad09c183ad24faf864fb8ba4692b527c70..a116b2fdaad590c8999142d18b9b81da
    StringVector* const args, StringVector* const exec_args,
    StringVector* const v8_args, OptionsType* const options,
    OptionEnvvarSettings required_env_settings, StringVector* const errors);
+diff --git a/src/node_options.cc b/src/node_options.cc
+index 4689a3e405be5fbbe3bb960940b48276669d8bc6..099daaa37da8e8374f28a05b3cf39f8898129802 100644
+--- a/src/node_options.cc
++++ b/src/node_options.cc
+@@ -219,7 +219,7 @@ const DebugOptionsParser _dop_instance{};
+ const EnvironmentOptionsParser _eop_instance{_dop_instance};
+
+ template <>
+-void Parse(
++void NODE_EXTERN Parse(
+   StringVector* const args, StringVector* const exec_args,
+   StringVector* const v8_args,
+   DebugOptions* const options,


### PR DESCRIPTION
#### Description of Change
Manual backport of https://github.com/electron/electron/pull/19876 to `6-0-x`, since an automatic backport was not possible.

Applies a patch to node.
Externs node::options_parser::Parse implementation for
node::DebugOptions to fix the Windows Debug build.

This fixes https://github.com/electron/electron/issues/19291 for `6-0-x` too, allowing Debug builds on Windows.

cc @codebytere 
cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes