### PR TITLE
chore: DCHECK for correct thread in EventEmitter::EmitWithSender

### DIFF
--- a/shell/browser/api/event_emitter.h
+++ b/shell/browser/api/event_emitter.h
@@ -85,6 +85,7 @@ class EventEmitter : public Wrappable<T> {
       base::Optional<electron::mojom::ElectronBrowser::MessageSyncCallback>
           callback,
       Args&&... args) {
+    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
     v8::Locker locker(isolate());
     v8::HandleScope handle_scope(isolate());
     v8::Local<v8::Object> wrapper = GetWrapper();


### PR DESCRIPTION
#### Description of Change
We were already DCHECKING here, but somewhat too late in some cases.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none