### PR TITLE
feat: add nativeTheme.themeSource to allow apps to override Chromiums theme choice

### DIFF
--- a/docs/api/native-theme.md
+++ b/docs/api/native-theme.md
@@ -23,23 +23,24 @@ The `nativeTheme` module has the following properties:
 
 A `Boolean` for if the OS / Chromium currently has a dark mode enabled or is
 being instructed to show a dark-style UI.  If you want to modify this value you
-should use `shouldUseDarkColorsOverride` below.
+should use `themeSource` below.
 
-### `nativeTheme.shouldUseDarkColorsOverride`
+### `nativeTheme.themeSource`
 
-A `Boolean | null` property used to override and supercede the value that Chromium has
-chosen to use internally.  Setting this property to `null` will remove the override and
-everything will be reset to the OS default.  By default `shouldUseDarkColors` tracks the
-OS dark mode setting.
+A `String` property that can be `system`, `light` or `dark`.  It is used to override and supercede
+the value that Chromium has chosen to use internally.
 
-Settings this property to `true` will have the following effects:
+Setting this property to `system` will remove the override and
+everything will be reset to the OS default.  By default `themeSource` is `system`.
+
+Settings this property to `dark` will have the following effects:
 * `nativeTheme.shouldUseDarkColors` will be `true` when accessed
 * Any UI Electron renders on Linux and Windows including context menus, devtools, etc. will use the dark UI.
 * Any UI the OS renders on macOS including menus, window frames, etc. will use the dark UI.
 * The [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) CSS query will match `dark` mode.
 * The `updated` event will be emitted
 
-Settings this property to `false` will have the following effects:
+Settings this property to `light` will have the following effects:
 * `nativeTheme.shouldUseDarkColors` will be `false` when accessed
 * Any UI Electron renders on Linux and Windows including context menus, devtools, etc. will use the light UI.
 * Any UI the OS renders on macOS including menus, window frames, etc. will use the light UI.
@@ -48,9 +49,9 @@ Settings this property to `false` will have the following effects:
 
 The usage of this property should align with a classic "dark mode" state machine in your application
 where the user has three options.
-* `Follow OS` --> `shouldUseDarkColorsOverride = null`
-* `Dark Mode` --> `shouldUseDarkColorsOverride = true`
-* `Light Mode` --> `shouldUseDarkColorsOverride = false`
+* `Follow OS` --> `themeSource = 'system'`
+* `Dark Mode` --> `themeSource = 'dark'`
+* `Light Mode` --> `themeSource = 'light'`
 
 Your application should then always use `shouldUseDarkColors` to determine what CSS to apply.
 

--- a/docs/api/native-theme.md
+++ b/docs/api/native-theme.md
@@ -22,7 +22,37 @@ The `nativeTheme` module has the following properties:
 ### `nativeTheme.shouldUseDarkColors` _Readonly_
 
 A `Boolean` for if the OS / Chromium currently has a dark mode enabled or is
-being instructed to show a dark-style UI.
+being instructed to show a dark-style UI.  If you want to modify this value you
+should use `shouldUseDarkColorsOverride` below.
+
+### `nativeTheme.shouldUseDarkColorsOverride`
+
+A `Boolean | null` property used to override and supercede the value that Chromium has
+chosen to use internally.  Setting this property to `null` will remove the override and
+everything will be reset to the OS default.  By default `shouldUseDarkColors` tracks the
+OS dark mode setting.
+
+Settings this property to `true` will have the following effects:
+* `nativeTheme.shouldUseDarkColors` will be `true` when accessed
+* Any UI Electron renders on Linux and Windows including context menus, devtools, etc. will use the dark UI.
+* Any UI the OS renders on macOS including menus, window frames, etc. will use the dark UI.
+* The [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) CSS query will match `dark` mode.
+* The `updated` event will be emitted
+
+Settings this property to `false` will have the following effects:
+* `nativeTheme.shouldUseDarkColors` will be `false` when accessed
+* Any UI Electron renders on Linux and Windows including context menus, devtools, etc. will use the light UI.
+* Any UI the OS renders on macOS including menus, window frames, etc. will use the light UI.
+* The [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) CSS query will match `light` mode.
+* The `updated` event will be emitted
+
+The usage of this property should align with a classic "dark mode" state machine in your application
+where the user has three options.
+* `Follow OS` --> `shouldUseDarkColorsOverride = null`
+* `Dark Mode` --> `shouldUseDarkColorsOverride = true`
+* `Light Mode` --> `shouldUseDarkColorsOverride = false`
+
+Your application should then always use `shouldUseDarkColors` to determine what CSS to apply.
 
 ### `nativeTheme.shouldUseHighContrastColors` _macOS_ _Windows_ _Readonly_
 

--- a/filenames.gni
+++ b/filenames.gni
@@ -429,6 +429,7 @@ filenames = {
     "shell/common/api/atom_api_native_image_mac.mm",
     "shell/common/api/atom_api_native_theme.cc",
     "shell/common/api/atom_api_native_theme.h",
+    "shell/common/api/atom_api_native_theme_mac.mm",
     "shell/common/api/atom_api_shell.cc",
     "shell/common/api/atom_api_v8_util.cc",
     "shell/common/api/electron_bindings.cc",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/fs-extra": "^5.0.5",
     "@types/mocha": "^5.2.6",
     "@types/node": "^12.0.10",
+    "@types/semver": "^6.0.1",
     "@types/send": "^0.14.5",
     "@types/split": "^1.0.0",
     "@types/webpack": "^4.4.32",

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -77,3 +77,4 @@ picture-in-picture.patch
 disable_compositor_recycling.patch
 allow_new_privileges_in_unsandboxed_child_processes.patch
 expose_setuseragent_on_networkcontext.patch
+feat_add_set_override_should_use_dark_colors_to_allow_apps_to.patch

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -77,4 +77,4 @@ picture-in-picture.patch
 disable_compositor_recycling.patch
 allow_new_privileges_in_unsandboxed_child_processes.patch
 expose_setuseragent_on_networkcontext.patch
-feat_add_set_override_should_use_dark_colors_to_allow_apps_to.patch
+feat_add_set_theme_source_to_allow_apps_to.patch

--- a/patches/chromium/feat_add_set_override_should_use_dark_colors_to_allow_apps_to.patch
+++ b/patches/chromium/feat_add_set_override_should_use_dark_colors_to_allow_apps_to.patch
@@ -1,0 +1,91 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Samuel Attard <sattard@slack-corp.com>
+Date: Mon, 26 Aug 2019 14:32:41 -0700
+Subject: feat: add set_override_should_use_dark_colors to allow apps to
+ override chromiums internal theme choice
+
+
+diff --git a/ui/native_theme/native_theme.cc b/ui/native_theme/native_theme.cc
+index 2370d15332c8c6c7dc7e3403b38891c885704d9f..45511a9319b0e02b9b2c115f7d87d82d35743d96 100644
+--- a/ui/native_theme/native_theme.cc
++++ b/ui/native_theme/native_theme.cc
+@@ -40,6 +40,7 @@ NativeTheme::NativeTheme()
+ NativeTheme::~NativeTheme() = default;
+ 
+ bool NativeTheme::ShouldUseDarkColors() const {
++  HANDLE_OVERRIDDEN_SHOULD_USE_DARK_COLORS
+   return should_use_dark_colors_;
+ }
+ 
+diff --git a/ui/native_theme/native_theme.h b/ui/native_theme/native_theme.h
+index 70389e0245993faa2c17e9deefeb000280ef2368..4d56998a391c1c7508bb911eea0c16cdde443a34 100644
+--- a/ui/native_theme/native_theme.h
++++ b/ui/native_theme/native_theme.h
+@@ -21,6 +21,11 @@
+ #include "ui/native_theme/native_theme_export.h"
+ #include "ui/native_theme/native_theme_observer.h"
+ 
++#define HANDLE_OVERRIDDEN_SHOULD_USE_DARK_COLORS \
++  if (override_should_use_dark_colors() == OverrideShouldUseDarkColors::kForceDarkColorsDisabled) return false; \
++  if (override_should_use_dark_colors() == OverrideShouldUseDarkColors::kForceDarkColorsEnabled) return true;
++
++
+ namespace gfx {
+ class Rect;
+ class Size;
+@@ -429,6 +434,22 @@ class NATIVE_THEME_EXPORT NativeTheme {
+       ColorId color_id,
+       ColorScheme color_scheme = ColorScheme::kDefault) const = 0;
+ 
++  enum OverrideShouldUseDarkColors {
++    kNoOverride,
++    kForceDarkColorsEnabled,
++    kForceDarkColorsDisabled,
++  };
++
++  OverrideShouldUseDarkColors override_should_use_dark_colors() const {
++    return override_should_use_dark_colors_;
++  }
++
++  void set_override_should_use_dark_colors(OverrideShouldUseDarkColors override_should_use_dark_colors) {
++    bool original = ShouldUseDarkColors();
++    override_should_use_dark_colors_ = override_should_use_dark_colors;
++    if (ShouldUseDarkColors() != original) NotifyObservers();
++  }
++
+   // Returns a shared instance of the native theme that should be used for web
+   // rendering. Do not use it in a normal application context (i.e. browser).
+   // The returned object should not be deleted by the caller. This function is
+@@ -547,6 +568,8 @@ class NATIVE_THEME_EXPORT NativeTheme {
+   PreferredColorScheme preferred_color_scheme_ =
+       PreferredColorScheme::kNoPreference;
+ 
++  OverrideShouldUseDarkColors override_should_use_dark_colors_ = OverrideShouldUseDarkColors::kNoOverride;
++
+   DISALLOW_COPY_AND_ASSIGN(NativeTheme);
+ };
+ 
+diff --git a/ui/native_theme/native_theme_dark_aura.cc b/ui/native_theme/native_theme_dark_aura.cc
+index a8fbfee3b13672902aac05fd5a65fa8ee81f9f7e..58ee87151f40229776ea356eaa6adc30eca389be 100644
+--- a/ui/native_theme/native_theme_dark_aura.cc
++++ b/ui/native_theme/native_theme_dark_aura.cc
+@@ -20,6 +20,7 @@ SkColor NativeThemeDarkAura::GetSystemColor(ColorId color_id,
+ }
+ 
+ bool NativeThemeDarkAura::ShouldUseDarkColors() const {
++  HANDLE_OVERRIDDEN_SHOULD_USE_DARK_COLORS
+   return true;
+ }
+ 
+diff --git a/ui/native_theme/native_theme_win.cc b/ui/native_theme/native_theme_win.cc
+index 3003643bfb78cec2f5e84fc9e1471e1ef54aae41..f305ad3c809129a4b583e3bba04a8734931849b0 100644
+--- a/ui/native_theme/native_theme_win.cc
++++ b/ui/native_theme/native_theme_win.cc
+@@ -611,6 +611,7 @@ bool NativeThemeWin::ShouldUseDarkColors() const {
+   // ...unless --force-dark-mode was specified in which case caveat emptor.
+   if (UsesHighContrastColors() && !IsForcedDarkMode())
+     return false;
++  HANDLE_OVERRIDDEN_SHOULD_USE_DARK_COLORS
+   return NativeTheme::ShouldUseDarkColors();
+ }
+ 

--- a/patches/chromium/feat_add_set_theme_source_to_allow_apps_to.patch
+++ b/patches/chromium/feat_add_set_theme_source_to_allow_apps_to.patch
@@ -13,7 +13,7 @@ index 2370d15332c8c6c7dc7e3403b38891c885704d9f..45511a9319b0e02b9b2c115f7d87d82d
  NativeTheme::~NativeTheme() = default;
  
  bool NativeTheme::ShouldUseDarkColors() const {
-+  HANDLE_OVERRIDDEN_SHOULD_USE_DARK_COLORS
++  RETURN_IF_FORCED_THEME
    return should_use_dark_colors_;
  }
  
@@ -25,9 +25,9 @@ index 70389e0245993faa2c17e9deefeb000280ef2368..4d56998a391c1c7508bb911eea0c16cd
  #include "ui/native_theme/native_theme_export.h"
  #include "ui/native_theme/native_theme_observer.h"
  
-+#define HANDLE_OVERRIDDEN_SHOULD_USE_DARK_COLORS \
++#define RETURN_IF_FORCED_THEME do { \
 +  if (theme_source() == ThemeSource::kForcedLight) return false; \
-+  if (theme_source() == ThemeSource::kForcedDark) return true;
++  if (theme_source() == ThemeSource::kForcedDark) return true; } while (0)
 +
 +
  namespace gfx {
@@ -73,7 +73,7 @@ index a8fbfee3b13672902aac05fd5a65fa8ee81f9f7e..58ee87151f40229776ea356eaa6adc30
  }
  
  bool NativeThemeDarkAura::ShouldUseDarkColors() const {
-+  HANDLE_OVERRIDDEN_SHOULD_USE_DARK_COLORS
++  RETURN_IF_FORCED_THEME
    return true;
  }
  
@@ -85,7 +85,7 @@ index 3003643bfb78cec2f5e84fc9e1471e1ef54aae41..f305ad3c809129a4b583e3bba04a8734
    // ...unless --force-dark-mode was specified in which case caveat emptor.
    if (UsesHighContrastColors() && !IsForcedDarkMode())
      return false;
-+  HANDLE_OVERRIDDEN_SHOULD_USE_DARK_COLORS
++  RETURN_IF_FORCED_THEME
    return NativeTheme::ShouldUseDarkColors();
  }
  

--- a/patches/chromium/feat_add_set_theme_source_to_allow_apps_to.patch
+++ b/patches/chromium/feat_add_set_theme_source_to_allow_apps_to.patch
@@ -1,39 +1,35 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Samuel Attard <sattard@slack-corp.com>
 Date: Mon, 26 Aug 2019 14:32:41 -0700
-Subject: feat: add set_theme_source to allow apps to
- override chromiums internal theme choice
+Subject: feat: add set_theme_source to allow apps to override chromiums
+ internal theme choice
 
+This patch is required as Chromium doesn't currently let folks using
+//ui override the theme choice in NativeTheme.  It defaults to
+respecting the OS theme choice and some apps don't always want to do
+that.  With this patch we can override the theme value that Chromium
+uses internally for things like menus and devtools.
+
+We can remove this patch once it has in some shape been upstreamed.
 
 diff --git a/ui/native_theme/native_theme.cc b/ui/native_theme/native_theme.cc
-index 2370d15332c8c6c7dc7e3403b38891c885704d9f..45511a9319b0e02b9b2c115f7d87d82d35743d96 100644
+index 2370d15332c8c6c7dc7e3403b38891c885704d9f..171214379437f319d3feccc289a5d91e74b77f9e 100644
 --- a/ui/native_theme/native_theme.cc
 +++ b/ui/native_theme/native_theme.cc
-@@ -40,6 +40,7 @@ NativeTheme::NativeTheme()
+@@ -40,6 +40,8 @@ NativeTheme::NativeTheme()
  NativeTheme::~NativeTheme() = default;
  
  bool NativeTheme::ShouldUseDarkColors() const {
-+  RETURN_IF_FORCED_THEME
++  if (theme_source() == ThemeSource::kForcedLight) return false;
++  if (theme_source() == ThemeSource::kForcedDark) return true;
    return should_use_dark_colors_;
  }
  
 diff --git a/ui/native_theme/native_theme.h b/ui/native_theme/native_theme.h
-index 70389e0245993faa2c17e9deefeb000280ef2368..4d56998a391c1c7508bb911eea0c16cdde443a34 100644
+index 70389e0245993faa2c17e9deefeb000280ef2368..cef1c0d4706e7e720a4004ca54765a39fc29c5e8 100644
 --- a/ui/native_theme/native_theme.h
 +++ b/ui/native_theme/native_theme.h
-@@ -21,6 +21,11 @@
- #include "ui/native_theme/native_theme_export.h"
- #include "ui/native_theme/native_theme_observer.h"
- 
-+#define RETURN_IF_FORCED_THEME do { \
-+  if (theme_source() == ThemeSource::kForcedLight) return false; \
-+  if (theme_source() == ThemeSource::kForcedDark) return true; } while (0)
-+
-+
- namespace gfx {
- class Rect;
- class Size;
-@@ -429,6 +434,22 @@ class NATIVE_THEME_EXPORT NativeTheme {
+@@ -429,6 +429,22 @@ class NATIVE_THEME_EXPORT NativeTheme {
        ColorId color_id,
        ColorScheme color_scheme = ColorScheme::kDefault) const = 0;
  
@@ -56,7 +52,7 @@ index 70389e0245993faa2c17e9deefeb000280ef2368..4d56998a391c1c7508bb911eea0c16cd
    // Returns a shared instance of the native theme that should be used for web
    // rendering. Do not use it in a normal application context (i.e. browser).
    // The returned object should not be deleted by the caller. This function is
-@@ -547,6 +568,8 @@ class NATIVE_THEME_EXPORT NativeTheme {
+@@ -547,6 +563,8 @@ class NATIVE_THEME_EXPORT NativeTheme {
    PreferredColorScheme preferred_color_scheme_ =
        PreferredColorScheme::kNoPreference;
  
@@ -66,26 +62,28 @@ index 70389e0245993faa2c17e9deefeb000280ef2368..4d56998a391c1c7508bb911eea0c16cd
  };
  
 diff --git a/ui/native_theme/native_theme_dark_aura.cc b/ui/native_theme/native_theme_dark_aura.cc
-index a8fbfee3b13672902aac05fd5a65fa8ee81f9f7e..58ee87151f40229776ea356eaa6adc30eca389be 100644
+index a8fbfee3b13672902aac05fd5a65fa8ee81f9f7e..1be6369acf0b7c02a6f862636c2b2de1fbf8cb5a 100644
 --- a/ui/native_theme/native_theme_dark_aura.cc
 +++ b/ui/native_theme/native_theme_dark_aura.cc
-@@ -20,6 +20,7 @@ SkColor NativeThemeDarkAura::GetSystemColor(ColorId color_id,
+@@ -20,6 +20,8 @@ SkColor NativeThemeDarkAura::GetSystemColor(ColorId color_id,
  }
  
  bool NativeThemeDarkAura::ShouldUseDarkColors() const {
-+  RETURN_IF_FORCED_THEME
++  if (theme_source() == ThemeSource::kForcedLight) return false;
++  if (theme_source() == ThemeSource::kForcedDark) return true;
    return true;
  }
  
 diff --git a/ui/native_theme/native_theme_win.cc b/ui/native_theme/native_theme_win.cc
-index 3003643bfb78cec2f5e84fc9e1471e1ef54aae41..f305ad3c809129a4b583e3bba04a8734931849b0 100644
+index 3003643bfb78cec2f5e84fc9e1471e1ef54aae41..06f2cbc84401958d49445f4ce6acb1b2fef0aa04 100644
 --- a/ui/native_theme/native_theme_win.cc
 +++ b/ui/native_theme/native_theme_win.cc
-@@ -611,6 +611,7 @@ bool NativeThemeWin::ShouldUseDarkColors() const {
+@@ -611,6 +611,8 @@ bool NativeThemeWin::ShouldUseDarkColors() const {
    // ...unless --force-dark-mode was specified in which case caveat emptor.
    if (UsesHighContrastColors() && !IsForcedDarkMode())
      return false;
-+  RETURN_IF_FORCED_THEME
++  if (theme_source() == ThemeSource::kForcedLight) return false;
++  if (theme_source() == ThemeSource::kForcedDark) return true;
    return NativeTheme::ShouldUseDarkColors();
  }
  

--- a/patches/chromium/feat_add_set_theme_source_to_allow_apps_to.patch
+++ b/patches/chromium/feat_add_set_theme_source_to_allow_apps_to.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Samuel Attard <sattard@slack-corp.com>
 Date: Mon, 26 Aug 2019 14:32:41 -0700
-Subject: feat: add set_override_should_use_dark_colors to allow apps to
+Subject: feat: add set_theme_source to allow apps to
  override chromiums internal theme choice
 
 
@@ -26,8 +26,8 @@ index 70389e0245993faa2c17e9deefeb000280ef2368..4d56998a391c1c7508bb911eea0c16cd
  #include "ui/native_theme/native_theme_observer.h"
  
 +#define HANDLE_OVERRIDDEN_SHOULD_USE_DARK_COLORS \
-+  if (override_should_use_dark_colors() == OverrideShouldUseDarkColors::kForceDarkColorsDisabled) return false; \
-+  if (override_should_use_dark_colors() == OverrideShouldUseDarkColors::kForceDarkColorsEnabled) return true;
++  if (theme_source() == ThemeSource::kForcedLight) return false; \
++  if (theme_source() == ThemeSource::kForcedDark) return true;
 +
 +
  namespace gfx {
@@ -37,19 +37,19 @@ index 70389e0245993faa2c17e9deefeb000280ef2368..4d56998a391c1c7508bb911eea0c16cd
        ColorId color_id,
        ColorScheme color_scheme = ColorScheme::kDefault) const = 0;
  
-+  enum OverrideShouldUseDarkColors {
-+    kNoOverride,
-+    kForceDarkColorsEnabled,
-+    kForceDarkColorsDisabled,
++  enum ThemeSource {
++    kSystem,
++    kForcedDark,
++    kForcedLight,
 +  };
 +
-+  OverrideShouldUseDarkColors override_should_use_dark_colors() const {
-+    return override_should_use_dark_colors_;
++  ThemeSource theme_source() const {
++    return theme_source_;
 +  }
 +
-+  void set_override_should_use_dark_colors(OverrideShouldUseDarkColors override_should_use_dark_colors) {
++  void set_theme_source(ThemeSource theme_source) {
 +    bool original = ShouldUseDarkColors();
-+    override_should_use_dark_colors_ = override_should_use_dark_colors;
++    theme_source_ = theme_source;
 +    if (ShouldUseDarkColors() != original) NotifyObservers();
 +  }
 +
@@ -60,7 +60,7 @@ index 70389e0245993faa2c17e9deefeb000280ef2368..4d56998a391c1c7508bb911eea0c16cd
    PreferredColorScheme preferred_color_scheme_ =
        PreferredColorScheme::kNoPreference;
  
-+  OverrideShouldUseDarkColors override_should_use_dark_colors_ = OverrideShouldUseDarkColors::kNoOverride;
++  ThemeSource theme_source_ = ThemeSource::kSystem;
 +
    DISALLOW_COPY_AND_ASSIGN(NativeTheme);
  };

--- a/shell/common/api/atom_api_native_theme.h
+++ b/shell/common/api/atom_api_native_theme.h
@@ -7,6 +7,7 @@
 
 #include "native_mate/handle.h"
 #include "shell/browser/api/event_emitter.h"
+#include "ui/native_theme/native_theme.h"
 #include "ui/native_theme/native_theme_observer.h"
 
 namespace electron {
@@ -25,6 +26,14 @@ class NativeTheme : public mate::EventEmitter<NativeTheme>,
   NativeTheme(v8::Isolate* isolate, ui::NativeTheme* theme);
   ~NativeTheme() override;
 
+  void SetShouldUseDarkColorsOverride(
+      ui::NativeTheme::OverrideShouldUseDarkColors override);
+#if defined(OS_MACOSX)
+  void UpdateMacOSAppearanceForOverrideValue(
+      ui::NativeTheme::OverrideShouldUseDarkColors override);
+#endif
+  ui::NativeTheme::OverrideShouldUseDarkColors GetShouldUseDarkColorsOverride()
+      const;
   bool ShouldUseDarkColors();
   bool ShouldUseHighContrastColors();
   bool ShouldUseInvertedColorScheme();
@@ -41,5 +50,19 @@ class NativeTheme : public mate::EventEmitter<NativeTheme>,
 }  // namespace api
 
 }  // namespace electron
+
+namespace mate {
+
+template <>
+struct Converter<ui::NativeTheme::OverrideShouldUseDarkColors> {
+  static v8::Local<v8::Value> ToV8(
+      v8::Isolate* isolate,
+      const ui::NativeTheme::OverrideShouldUseDarkColors& val);
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     ui::NativeTheme::OverrideShouldUseDarkColors* out);
+};
+
+}  // namespace mate
 
 #endif  // SHELL_COMMON_API_ATOM_API_NATIVE_THEME_H_

--- a/shell/common/api/atom_api_native_theme.h
+++ b/shell/common/api/atom_api_native_theme.h
@@ -26,14 +26,12 @@ class NativeTheme : public mate::EventEmitter<NativeTheme>,
   NativeTheme(v8::Isolate* isolate, ui::NativeTheme* theme);
   ~NativeTheme() override;
 
-  void SetShouldUseDarkColorsOverride(
-      ui::NativeTheme::OverrideShouldUseDarkColors override);
+  void SetThemeSource(ui::NativeTheme::ThemeSource override);
 #if defined(OS_MACOSX)
   void UpdateMacOSAppearanceForOverrideValue(
-      ui::NativeTheme::OverrideShouldUseDarkColors override);
+      ui::NativeTheme::ThemeSource override);
 #endif
-  ui::NativeTheme::OverrideShouldUseDarkColors GetShouldUseDarkColorsOverride()
-      const;
+  ui::NativeTheme::ThemeSource GetThemeSource() const;
   bool ShouldUseDarkColors();
   bool ShouldUseHighContrastColors();
   bool ShouldUseInvertedColorScheme();
@@ -54,13 +52,12 @@ class NativeTheme : public mate::EventEmitter<NativeTheme>,
 namespace mate {
 
 template <>
-struct Converter<ui::NativeTheme::OverrideShouldUseDarkColors> {
-  static v8::Local<v8::Value> ToV8(
-      v8::Isolate* isolate,
-      const ui::NativeTheme::OverrideShouldUseDarkColors& val);
+struct Converter<ui::NativeTheme::ThemeSource> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const ui::NativeTheme::ThemeSource& val);
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
-                     ui::NativeTheme::OverrideShouldUseDarkColors* out);
+                     ui::NativeTheme::ThemeSource* out);
 };
 
 }  // namespace mate

--- a/shell/common/api/atom_api_native_theme_mac.mm
+++ b/shell/common/api/atom_api_native_theme_mac.mm
@@ -4,6 +4,7 @@
 
 #include "shell/common/api/atom_api_native_theme.h"
 
+#include "base/mac/sdk_forward_declarations.h"
 #include "shell/browser/mac/atom_application.h"
 
 namespace electron {

--- a/shell/common/api/atom_api_native_theme_mac.mm
+++ b/shell/common/api/atom_api_native_theme_mac.mm
@@ -1,0 +1,38 @@
+// Copyright (c) 2019 Slack Technologies, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/common/api/atom_api_native_theme.h"
+
+#include "shell/browser/mac/atom_application.h"
+
+namespace electron {
+
+namespace api {
+
+void NativeTheme::UpdateMacOSAppearanceForOverrideValue(
+    ui::NativeTheme::OverrideShouldUseDarkColors override) {
+  if (@available(macOS 10.14, *)) {
+    NSAppearance* new_appearance;
+    switch (override) {
+      case ui::NativeTheme::OverrideShouldUseDarkColors::
+          kForceDarkColorsEnabled:
+        new_appearance =
+            [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua];
+        break;
+      case ui::NativeTheme::OverrideShouldUseDarkColors::
+          kForceDarkColorsDisabled:
+        new_appearance = [NSAppearance appearanceNamed:NSAppearanceNameAqua];
+        break;
+      case ui::NativeTheme::OverrideShouldUseDarkColors::kNoOverride:
+      default:
+        new_appearance = nil;
+        break;
+    }
+    [[NSApplication sharedApplication] setAppearance:new_appearance];
+  }
+}
+
+}  // namespace api
+
+}  // namespace electron

--- a/shell/common/api/atom_api_native_theme_mac.mm
+++ b/shell/common/api/atom_api_native_theme_mac.mm
@@ -12,20 +12,18 @@ namespace electron {
 namespace api {
 
 void NativeTheme::UpdateMacOSAppearanceForOverrideValue(
-    ui::NativeTheme::OverrideShouldUseDarkColors override) {
+    ui::NativeTheme::ThemeSource override) {
   if (@available(macOS 10.14, *)) {
     NSAppearance* new_appearance;
     switch (override) {
-      case ui::NativeTheme::OverrideShouldUseDarkColors::
-          kForceDarkColorsEnabled:
+      case ui::NativeTheme::ThemeSource::kForcedDark:
         new_appearance =
             [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua];
         break;
-      case ui::NativeTheme::OverrideShouldUseDarkColors::
-          kForceDarkColorsDisabled:
+      case ui::NativeTheme::ThemeSource::kForcedLight:
         new_appearance = [NSAppearance appearanceNamed:NSAppearanceNameAqua];
         break;
-      case ui::NativeTheme::OverrideShouldUseDarkColors::kNoOverride:
+      case ui::NativeTheme::ThemeSource::kSystem:
       default:
         new_appearance = nil;
         break;

--- a/spec-main/api-native-theme-spec.ts
+++ b/spec-main/api-native-theme-spec.ts
@@ -1,5 +1,7 @@
 import { expect } from 'chai'
 import { nativeTheme, systemPreferences } from 'electron'
+import * as os from 'os'
+import * as semver from 'semver'
 
 describe('nativeTheme module', () => {
   describe('nativeTheme.shouldUseDarkColors', () => {
@@ -44,9 +46,11 @@ describe('nativeTheme module', () => {
       expect(called).to.equal(false)
     })
 
-    describe('on macOS', () => {
+    describe('on macOS 10.14', () => {
       before(function () {
-        if (process.platform !== 'darwin') this.skip()
+        if (process.platform !== 'darwin') return this.skip()
+        // Darwin 18.0.0 === Mojave 10.14
+        if (semver.lt(os.release(), '18.0.0')) return this.skip()
       })
 
       it('should update appLevelAppearance when set', () => {

--- a/spec-main/api-native-theme-spec.ts
+++ b/spec-main/api-native-theme-spec.ts
@@ -46,7 +46,7 @@ describe('nativeTheme module', () => {
       expect(called).to.equal(false)
     })
 
-    describe('on macOS 10.14', () => {
+    ifdescribe(process.platform === 'darwin' && semver.ge(os.release(), '18.0.0'))('on macOS 10.14', () => {
       before(function () {
         if (process.platform !== 'darwin') return this.skip()
         // Darwin 18.0.0 === Mojave 10.14

--- a/spec-main/api-native-theme-spec.ts
+++ b/spec-main/api-native-theme-spec.ts
@@ -3,6 +3,8 @@ import { nativeTheme, systemPreferences } from 'electron'
 import * as os from 'os'
 import * as semver from 'semver'
 
+import { ifdescribe } from './spec-helpers'
+
 describe('nativeTheme module', () => {
   describe('nativeTheme.shouldUseDarkColors', () => {
     it('returns a boolean', () => {

--- a/spec-main/api-native-theme-spec.ts
+++ b/spec-main/api-native-theme-spec.ts
@@ -46,7 +46,7 @@ describe('nativeTheme module', () => {
       expect(called).to.equal(false)
     })
 
-    ifdescribe(process.platform === 'darwin' && semver.ge(os.release(), '18.0.0'))('on macOS 10.14', () => {
+    ifdescribe(process.platform === 'darwin' && semver.gte(os.release(), '18.0.0'))('on macOS 10.14', () => {
       before(function () {
         if (process.platform !== 'darwin') return this.skip()
         // Darwin 18.0.0 === Mojave 10.14

--- a/spec-main/api-native-theme-spec.ts
+++ b/spec-main/api-native-theme-spec.ts
@@ -47,12 +47,6 @@ describe('nativeTheme module', () => {
     })
 
     ifdescribe(process.platform === 'darwin' && semver.gte(os.release(), '18.0.0'))('on macOS 10.14', () => {
-      before(function () {
-        if (process.platform !== 'darwin') return this.skip()
-        // Darwin 18.0.0 === Mojave 10.14
-        if (semver.lt(os.release(), '18.0.0')) return this.skip()
-      })
-
       it('should update appLevelAppearance when set', () => {
         nativeTheme.themeSource = 'dark'
         expect(systemPreferences.appLevelAppearance).to.equal('dark')

--- a/spec-main/api-native-theme-spec.ts
+++ b/spec-main/api-native-theme-spec.ts
@@ -1,10 +1,60 @@
 import { expect } from 'chai'
-import { nativeTheme } from 'electron'
+import { nativeTheme, systemPreferences } from 'electron'
 
 describe('nativeTheme module', () => {
   describe('nativeTheme.shouldUseDarkColors', () => {
     it('returns a boolean', () => {
       expect(nativeTheme.shouldUseDarkColors).to.be.a('boolean')
+    })
+  })
+
+  describe('nativeTheme.shouldUseDarkColorsOverride', () => {
+    afterEach(() => {
+      nativeTheme.shouldUseDarkColorsOverride = null
+    })
+
+    it('is null by default', () => {
+      expect(nativeTheme.shouldUseDarkColorsOverride).to.equal(null)
+    })
+
+    it('should override the value of shouldUseDarkColors', () => {
+      nativeTheme.shouldUseDarkColorsOverride = true
+      expect(nativeTheme.shouldUseDarkColors).to.equal(true)
+      nativeTheme.shouldUseDarkColorsOverride = false
+      expect(nativeTheme.shouldUseDarkColors).to.equal(false)
+    })
+
+    it('should emit the "updated" event when it is set and the resulting "shouldUseDarkColors" value changes', () => {
+      nativeTheme.shouldUseDarkColorsOverride = true
+      let called = false
+      nativeTheme.once('updated', () => {
+        called = true
+      })
+      nativeTheme.shouldUseDarkColorsOverride = false
+      expect(called).to.equal(true)
+    })
+
+    it('should not emit the "updated" event when it is set and the resulting "shouldUseDarkColors" value is the same', () => {
+      nativeTheme.shouldUseDarkColorsOverride = true
+      let called = false
+      nativeTheme.once('updated', () => {
+        called = true
+      })
+      nativeTheme.shouldUseDarkColorsOverride = true
+      expect(called).to.equal(false)
+    })
+
+    describe('on macOS', () => {
+      before(function () {
+        if (process.platform !== 'darwin') this.skip()
+      })
+
+      it('should update appLevelAppearance when set', () => {
+        nativeTheme.shouldUseDarkColorsOverride = true
+        expect(systemPreferences.appLevelAppearance).to.equal('dark')
+        nativeTheme.shouldUseDarkColorsOverride = false
+        expect(systemPreferences.appLevelAppearance).to.equal('light')
+      })
     })
   })
 

--- a/spec-main/api-native-theme-spec.ts
+++ b/spec-main/api-native-theme-spec.ts
@@ -8,39 +8,39 @@ describe('nativeTheme module', () => {
     })
   })
 
-  describe('nativeTheme.shouldUseDarkColorsOverride', () => {
+  describe('nativeTheme.themeSource', () => {
     afterEach(() => {
-      nativeTheme.shouldUseDarkColorsOverride = null
+      nativeTheme.themeSource = 'system'
     })
 
-    it('is null by default', () => {
-      expect(nativeTheme.shouldUseDarkColorsOverride).to.equal(null)
+    it('is system by default', () => {
+      expect(nativeTheme.themeSource).to.equal('system')
     })
 
     it('should override the value of shouldUseDarkColors', () => {
-      nativeTheme.shouldUseDarkColorsOverride = true
+      nativeTheme.themeSource = 'dark'
       expect(nativeTheme.shouldUseDarkColors).to.equal(true)
-      nativeTheme.shouldUseDarkColorsOverride = false
+      nativeTheme.themeSource = 'light'
       expect(nativeTheme.shouldUseDarkColors).to.equal(false)
     })
 
     it('should emit the "updated" event when it is set and the resulting "shouldUseDarkColors" value changes', () => {
-      nativeTheme.shouldUseDarkColorsOverride = true
+      nativeTheme.themeSource = 'dark'
       let called = false
       nativeTheme.once('updated', () => {
         called = true
       })
-      nativeTheme.shouldUseDarkColorsOverride = false
+      nativeTheme.themeSource = 'light'
       expect(called).to.equal(true)
     })
 
     it('should not emit the "updated" event when it is set and the resulting "shouldUseDarkColors" value is the same', () => {
-      nativeTheme.shouldUseDarkColorsOverride = true
+      nativeTheme.themeSource = 'dark'
       let called = false
       nativeTheme.once('updated', () => {
         called = true
       })
-      nativeTheme.shouldUseDarkColorsOverride = true
+      nativeTheme.themeSource = 'dark'
       expect(called).to.equal(false)
     })
 
@@ -50,9 +50,9 @@ describe('nativeTheme module', () => {
       })
 
       it('should update appLevelAppearance when set', () => {
-        nativeTheme.shouldUseDarkColorsOverride = true
+        nativeTheme.themeSource = 'dark'
         expect(systemPreferences.appLevelAppearance).to.equal('dark')
-        nativeTheme.shouldUseDarkColorsOverride = false
+        nativeTheme.themeSource = 'light'
         expect(systemPreferences.appLevelAppearance).to.equal('light')
       })
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -261,6 +261,11 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
+"@types/semver@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.0.1.tgz#a984b405c702fa5a7ec6abc56b37f2ba35ef5af6"
+  integrity sha512-ffCdcrEE5h8DqVxinQjo+2d1q+FV5z7iNtPofw3JsrltSoSVlOGaW0rY8XxtO9XukdTn8TaCGWmk2VFGhI70mg==
+
 "@types/send@^0.14.5":
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/@types/send/-/send-0.14.5.tgz#653f7d25b93c3f7f51a8994addaf8a229de022a7"


### PR DESCRIPTION
This is Phase 1 of #19932

A lot of the documentation and expected usage of this property has been added to `native-theme.md` so I recommend reviewers read that new documentation.

At a high level this property is added to allow apps to override Chromiums theme choice.  By default Chromium uses light colors unless your OS supports dark mode and has dark mode enabled, in which case it uses dark colors.  Some apps need to be able to override these colors choices for things like menus so that they can implement their own state machine of

* Follow System Mode
* Force Dark Mode
* Force Light Mode

The patch in this PR is deliberately kept minimal (and not the best cpp) to avoid conflicts.  My intention is to upstream this change so we can remove this patch.

Notes: Added `nativeTheme.themeSource` to allow apps to override Chromium and the OS's theme choice
