### PR TITLE
fix: ensure that reloads retain modified window background colors

### DIFF
--- a/shell/browser/api/atom_api_browser_window.cc
+++ b/shell/browser/api/atom_api_browser_window.cc
@@ -302,6 +302,16 @@ void BrowserWindow::SetBackgroundColor(const std::string& color_name) {
   auto* view = web_contents()->GetRenderWidgetHostView();
   if (view)
     view->SetBackgroundColor(ParseHexColor(color_name));
+  // Also update the web preferences object otherwise the view will be reset on
+  // the next load URL call
+  if (api_web_contents_) {
+    auto* web_preferences =
+        WebContentsPreferences::From(api_web_contents_->web_contents());
+    if (web_preferences) {
+      web_preferences->preference()->SetStringKey(options::kBackgroundColor,
+                                                  color_name);
+    }
+  }
 }
 
 void BrowserWindow::SetBrowserView(v8::Local<v8::Value> value) {


### PR DESCRIPTION
We reset the host views background color on every `LoadURL` call from the saved web preferences, we should store the new background color in web preferences in order to not lose the new color.

Notes: Fixed issue where reloading the window after calling `setBackgroundColor` would result in using an older background color setting.