### PR TITLE
feat: migrate webRequest module to NetworkService (Part 9)

### DIFF
--- a/shell/browser/api/atom_api_url_request_ns.cc
+++ b/shell/browser/api/atom_api_url_request_ns.cc
@@ -202,8 +202,10 @@ URLRequestNS::URLRequestNS(mate::Arguments* args) : weak_factory_(this) {
   params->header_client = std::move(header_client);
   params->process_id = network::mojom::kBrowserProcessId;
   params->is_trusted = true;
-  params->is_corb_enabled = true;
-  params->disable_web_security = true;
+  params->is_corb_enabled = false;
+  // The tests of net module would fail if this setting is true, it seems that
+  // the non-NetworkService implementation always has web security enabled.
+  params->disable_web_security = false;
 
   storage_partition->GetNetworkContext()->CreateURLLoaderFactory(
       std::move(factory_request), std::move(params));

--- a/shell/browser/api/atom_api_url_request_ns.cc
+++ b/shell/browser/api/atom_api_url_request_ns.cc
@@ -11,8 +11,10 @@
 #include "native_mate/dictionary.h"
 #include "native_mate/object_template_builder.h"
 #include "net/http/http_util.h"
+#include "services/network/public/cpp/wrapper_shared_url_loader_factory.h"
 #include "services/network/public/mojom/chunked_data_pipe_getter.mojom.h"
 #include "shell/browser/api/atom_api_session.h"
+#include "shell/browser/atom_browser_client.h"
 #include "shell/browser/atom_browser_context.h"
 #include "shell/common/native_mate_converters/gurl_converter.h"
 #include "shell/common/native_mate_converters/net_converter.h"
@@ -180,9 +182,34 @@ URLRequestNS::URLRequestNS(mate::Arguments* args) : weak_factory_(this) {
   }
 
   auto* browser_context = session->browser_context();
+  auto* storage_partition =
+      content::BrowserContext::GetDefaultStoragePartition(browser_context);
+
+  network::mojom::URLLoaderFactoryPtr network_factory;
+  mojo::PendingReceiver<network::mojom::URLLoaderFactory> factory_request =
+      mojo::MakeRequest(&network_factory);
+
+  // Consult the embedder.
+  network::mojom::TrustedURLLoaderHeaderClientPtrInfo header_client;
+  static_cast<content::ContentBrowserClient*>(AtomBrowserClient::Get())
+      ->WillCreateURLLoaderFactory(
+          browser_context, nullptr, -1,
+          content::ContentBrowserClient::URLLoaderFactoryType::kNavigation,
+          url::Origin(), &factory_request, &header_client, nullptr);
+
+  network::mojom::URLLoaderFactoryParamsPtr params =
+      network::mojom::URLLoaderFactoryParams::New();
+  params->header_client = std::move(header_client);
+  params->process_id = network::mojom::kBrowserProcessId;
+  params->is_trusted = true;
+  params->is_corb_enabled = true;
+  params->disable_web_security = true;
+
+  storage_partition->GetNetworkContext()->CreateURLLoaderFactory(
+      std::move(factory_request), std::move(params));
   url_loader_factory_ =
-      content::BrowserContext::GetDefaultStoragePartition(browser_context)
-          ->GetURLLoaderFactoryForBrowserProcess();
+      base::MakeRefCounted<network::WrapperSharedURLLoaderFactory>(
+          std::move(network_factory));
 
   InitWith(args->isolate(), args->GetThis());
 }

--- a/shell/browser/atom_browser_client.cc
+++ b/shell/browser/atom_browser_client.cc
@@ -988,18 +988,11 @@ bool AtomBrowserClient::WillCreateURLLoaderFactory(
     mojo::PendingReceiver<network::mojom::URLLoaderFactory>* factory_receiver,
     network::mojom::TrustedURLLoaderHeaderClientPtrInfo* header_client,
     bool* bypass_redirect_checks) {
-  content::WebContents* web_contents =
-      content::WebContents::FromRenderFrameHost(frame_host);
-  // For service workers there might be no WebContents.
-  if (!web_contents)
-    return false;
-
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
-  api::ProtocolNS* protocol = api::ProtocolNS::FromWrappedClass(
-      isolate, web_contents->GetBrowserContext());
+  api::ProtocolNS* protocol =
+      api::ProtocolNS::FromWrappedClass(isolate, browser_context);
   DCHECK(protocol);
-  auto web_request = api::WebRequestNS::FromOrCreate(
-      isolate, web_contents->GetBrowserContext());
+  auto web_request = api::WebRequestNS::FromOrCreate(isolate, browser_context);
   DCHECK(web_request.get());
 
   auto proxied_receiver = std::move(*factory_receiver);

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -628,7 +628,7 @@ describe('net module', () => {
       })
     })
 
-    describe.skip('webRequest', () => {
+    describe('webRequest', () => {
       afterEach(() => {
         session.defaultSession.webRequest.onBeforeRequest(null)
       })


### PR DESCRIPTION
#### Description of Change

Refs #15791.
Refs #19602.

This PR makes sure the net module gives embedder a chance to add proxy when creating URLLoaderFactory.

This fixes webRequest tests in net module. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes