### PR TITLE
fix: BrowserWindow.fromWebContents() can return null

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -664,7 +664,8 @@ Returns `BrowserWindow | null` - The window that is focused in this application,
 
 * `webContents` [WebContents](web-contents.md)
 
-Returns `BrowserWindow` - The window that owns the given `webContents`.
+Returns `BrowserWindow | null` - The window that owns the given `webContents`
+or `null` if the contents are not owned by a window.
 
 #### `BrowserWindow.fromBrowserView(browserView)`
 

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -118,6 +118,8 @@ BrowserWindow.fromWebContents = (webContents) => {
   for (const window of BrowserWindow.getAllWindows()) {
     if (window.webContents.equal(webContents)) return window
   }
+
+  return null
 }
 
 BrowserWindow.fromBrowserView = (browserView) => {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1304,13 +1304,13 @@ describe('BrowserWindow module', () => {
     it('returns the window with the webContents', () => {
       const w = new BrowserWindow({show: false})
       const found = BrowserWindow.fromWebContents(w.webContents)
-      expect(found.id).to.equal(w.id)
+      expect(found!.id).to.equal(w.id)
     })
 
-    it('returns undefined for webContents without a BrowserWindow', () => {
+    it('returns null for webContents without a BrowserWindow', () => {
       const contents = (webContents as any).create({})
       try {
-        expect(BrowserWindow.fromWebContents(contents)).to.be.undefined('BrowserWindow.fromWebContents(contents)')
+        expect(BrowserWindow.fromWebContents(contents)).to.be.null('BrowserWindow.fromWebContents(contents)')
       } finally {
         contents.destroy()
       }


### PR DESCRIPTION
#### Description of Change
Make it consistent with `BrowserView.fromWebContents()`:
https://github.com/electron/electron/blob/26d9ef9403069707b71536ade43d6952b36d0b82/lib/browser/api/browser-view.js#L8-L14

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed `BrowserWindow.fromWebContents()` to return `null` when no window is found for consistency with other APIs.