### PR TITLE
feat: allow macOS tray visibility changes

### DIFF
--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -274,3 +274,13 @@ The `bounds` of this tray icon as `Object`.
 Returns `Boolean` - Whether the tray icon is destroyed.
 
 [event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter
+
+### Instance Properties
+
+The following properties are available on instances of `Tray`:
+
+#### `tray.visible` _macOS_
+
+A `Boolean` property indicating if the menu bar currently displays the status item.
+
+This property is only available on macOS 10.12 or later.

--- a/shell/browser/api/atom_api_tray.cc
+++ b/shell/browser/api/atom_api_tray.cc
@@ -188,6 +188,20 @@ bool Tray::GetIgnoreDoubleClickEvents() {
 #endif
 }
 
+void Tray::SetVisible(bool visible) {
+#if defined(OS_MACOSX)
+  tray_icon_->SetVisible(visible);
+#endif
+}
+
+bool Tray::GetVisible() {
+#if defined(OS_MACOSX)
+  return tray_icon_->GetVisible();
+#else
+  return false;
+#endif
+}
+
 void Tray::DisplayBalloon(mate::Arguments* args,
                           const mate::Dictionary& options) {
   TrayIcon::BalloonOptions balloon_options;
@@ -253,6 +267,7 @@ void Tray::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setToolTip", &Tray::SetToolTip)
       .SetMethod("setTitle", &Tray::SetTitle)
       .SetMethod("getTitle", &Tray::GetTitle)
+      .SetProperty("visible", &Tray::GetVisible, &Tray::SetVisible)
       .SetMethod("setIgnoreDoubleClickEvents",
                  &Tray::SetIgnoreDoubleClickEvents)
       .SetMethod("getIgnoreDoubleClickEvents",

--- a/shell/browser/api/atom_api_tray.cc
+++ b/shell/browser/api/atom_api_tray.cc
@@ -189,17 +189,11 @@ bool Tray::GetIgnoreDoubleClickEvents() {
 }
 
 void Tray::SetVisible(bool visible) {
-#if defined(OS_MACOSX)
   tray_icon_->SetVisible(visible);
-#endif
 }
 
 bool Tray::GetVisible() {
-#if defined(OS_MACOSX)
   return tray_icon_->GetVisible();
-#else
-  return false;
-#endif
 }
 
 void Tray::DisplayBalloon(mate::Arguments* args,
@@ -267,7 +261,9 @@ void Tray::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setToolTip", &Tray::SetToolTip)
       .SetMethod("setTitle", &Tray::SetTitle)
       .SetMethod("getTitle", &Tray::GetTitle)
+#if defined(OS_MACOSX)
       .SetProperty("visible", &Tray::GetVisible, &Tray::SetVisible)
+#endif
       .SetMethod("setIgnoreDoubleClickEvents",
                  &Tray::SetIgnoreDoubleClickEvents)
       .SetMethod("getIgnoreDoubleClickEvents",

--- a/shell/browser/api/atom_api_tray.h
+++ b/shell/browser/api/atom_api_tray.h
@@ -72,6 +72,8 @@ class Tray : public mate::TrackableObject<Tray>, public TrayIconObserver {
   std::string GetTitle();
   void SetIgnoreDoubleClickEvents(bool ignore);
   bool GetIgnoreDoubleClickEvents();
+  void SetVisible(bool visible);
+  bool GetVisible();
   void DisplayBalloon(mate::Arguments* args, const mate::Dictionary& options);
   void RemoveBalloon();
   void Focus();

--- a/shell/browser/ui/tray_icon.h
+++ b/shell/browser/ui/tray_icon.h
@@ -44,6 +44,9 @@ class TrayIcon {
   virtual void SetIgnoreDoubleClickEvents(bool ignore) = 0;
   virtual bool GetIgnoreDoubleClickEvents() = 0;
 
+  virtual void SetVisible(bool visible) = 0;
+  virtual bool GetVisible() = 0;
+
   // Set/Get title displayed next to status icon in the status bar.
   virtual void SetTitle(const std::string& title) = 0;
   virtual std::string GetTitle() = 0;

--- a/shell/browser/ui/tray_icon_cocoa.h
+++ b/shell/browser/ui/tray_icon_cocoa.h
@@ -29,6 +29,8 @@ class TrayIconCocoa : public TrayIcon {
   std::string GetTitle() override;
   void SetIgnoreDoubleClickEvents(bool ignore) override;
   bool GetIgnoreDoubleClickEvents() override;
+  void SetVisible(bool visible) override;
+  bool GetVisible() override;
   void PopUpOnUI(AtomMenuModel* menu_model);
   void PopUpContextMenu(const gfx::Point& pos,
                         AtomMenuModel* menu_model) override;

--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -121,6 +121,17 @@
   [self updateDimensions];
 }
 
+- (void)setVisible:(BOOL)visible {
+  if (@available(macOS 10.12, *))
+    [statusItem_ setVisible:visible];
+}
+
+- (BOOL)getVisible {
+  if (@available(macOS 10.12, *))
+    return [statusItem_ isVisible];
+  return true;
+}
+
 - (NSString*)title {
   return [statusItem_ button].title;
 }
@@ -293,6 +304,14 @@ void TrayIconCocoa::SetIgnoreDoubleClickEvents(bool ignore) {
 
 bool TrayIconCocoa::GetIgnoreDoubleClickEvents() {
   return [status_item_view_ getIgnoreDoubleClickEvents];
+}
+
+void TrayIconCocoa::SetVisible(bool visible) {
+  [status_item_view_ setVisible:visible];
+}
+
+bool TrayIconCocoa::GetVisible() {
+  return [status_item_view_ getVisible];
 }
 
 void TrayIconCocoa::PopUpOnUI(AtomMenuModel* menu_model) {

--- a/spec-main/api-tray-spec.ts
+++ b/spec-main/api-tray-spec.ts
@@ -91,4 +91,13 @@ describe('tray module', () => {
       expect(newTitle).to.equal(title)
     })
   })
+
+  ifdescribe(process.platform === 'darwin')('tray icon visibility', () => {
+    it('sets/gets tray icon visibility', () => {
+      expect(tray.visible).to.equal(true)
+      
+      tray.visible = false
+      expect(tray.visible).to.equal(false)
+    })
+  })
 })

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -935,6 +935,8 @@ app.on('ready', () => {
     title: 'Hello World!',
     content: 'This the the balloon content.'
   })
+
+  appIcon.visible = true;
 })
 
 // clipboard


### PR DESCRIPTION
#### Description of Change

Introduces `tray.visible` instance property, which is a  `Boolean` property indicating if the menu bar currently displays the status item. This allows users to show and hide a given Tray icon at will on `macOS` without having to create and destroy them.

cc @miniak @nornagon @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `tray.visible` instance property allowing users to show and hide a given Tray icon in the status bar on macOS.
