### PR TITLE
chore: cache URLLoaderFactory per-session

### DIFF
--- a/shell/browser/api/atom_api_url_request_ns.cc
+++ b/shell/browser/api/atom_api_url_request_ns.cc
@@ -6,15 +6,12 @@
 
 #include <utility>
 
-#include "content/public/browser/storage_partition.h"
 #include "mojo/public/cpp/system/string_data_source.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/object_template_builder.h"
 #include "net/http/http_util.h"
-#include "services/network/public/cpp/wrapper_shared_url_loader_factory.h"
 #include "services/network/public/mojom/chunked_data_pipe_getter.mojom.h"
 #include "shell/browser/api/atom_api_session.h"
-#include "shell/browser/atom_browser_client.h"
 #include "shell/browser/atom_browser_context.h"
 #include "shell/common/native_mate_converters/gurl_converter.h"
 #include "shell/common/native_mate_converters/net_converter.h"
@@ -181,37 +178,7 @@ URLRequestNS::URLRequestNS(mate::Arguments* args) : weak_factory_(this) {
       session = Session::FromPartition(args->isolate(), "");
   }
 
-  auto* browser_context = session->browser_context();
-  auto* storage_partition =
-      content::BrowserContext::GetDefaultStoragePartition(browser_context);
-
-  network::mojom::URLLoaderFactoryPtr network_factory;
-  mojo::PendingReceiver<network::mojom::URLLoaderFactory> factory_request =
-      mojo::MakeRequest(&network_factory);
-
-  // Consult the embedder.
-  network::mojom::TrustedURLLoaderHeaderClientPtrInfo header_client;
-  static_cast<content::ContentBrowserClient*>(AtomBrowserClient::Get())
-      ->WillCreateURLLoaderFactory(
-          browser_context, nullptr, -1,
-          content::ContentBrowserClient::URLLoaderFactoryType::kNavigation,
-          url::Origin(), &factory_request, &header_client, nullptr);
-
-  network::mojom::URLLoaderFactoryParamsPtr params =
-      network::mojom::URLLoaderFactoryParams::New();
-  params->header_client = std::move(header_client);
-  params->process_id = network::mojom::kBrowserProcessId;
-  params->is_trusted = true;
-  params->is_corb_enabled = false;
-  // The tests of net module would fail if this setting is true, it seems that
-  // the non-NetworkService implementation always has web security enabled.
-  params->disable_web_security = false;
-
-  storage_partition->GetNetworkContext()->CreateURLLoaderFactory(
-      std::move(factory_request), std::move(params));
-  url_loader_factory_ =
-      base::MakeRefCounted<network::WrapperSharedURLLoaderFactory>(
-          std::move(network_factory));
+  url_loader_factory_ = session->browser_context()->GetURLLoaderFactory();
 
   InitWith(args->isolate(), args->GetThis());
 }

--- a/shell/browser/atom_browser_context.h
+++ b/shell/browser/atom_browser_context.h
@@ -17,11 +17,16 @@
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/resource_context.h"
 #include "electron/buildflags/buildflags.h"
+#include "services/network/public/mojom/url_loader_factory.mojom.h"
 #include "shell/browser/media/media_device_id_salt.h"
 
 class PrefRegistrySimple;
 class PrefService;
 class ValueMapPrefStore;
+
+namespace network {
+class SharedURLLoaderFactory;
+}
 
 namespace storage {
 class SpecialStoragePolicy;
@@ -87,8 +92,8 @@ class AtomBrowserContext
   int GetMaxCacheSize() const;
   AtomBlobReader* GetBlobReader();
   ResolveProxyHelper* GetResolveProxyHelper();
-
   predictors::PreconnectManager* GetPreconnectManager();
+  scoped_refptr<network::SharedURLLoaderFactory> GetURLLoaderFactory();
 
   // content::BrowserContext:
   base::FilePath GetPath() override;
@@ -179,6 +184,9 @@ class AtomBrowserContext
   // Owned by the KeyedService system.
   extensions::AtomExtensionSystem* extension_system_;
 #endif
+
+  // Shared URLLoaderFactory.
+  scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
 
   base::WeakPtrFactory<AtomBrowserContext> weak_factory_;
 

--- a/shell/browser/net/atom_url_loader_factory.cc
+++ b/shell/browser/net/atom_url_loader_factory.cc
@@ -396,12 +396,9 @@ void AtomURLLoaderFactory::StartLoadingHttp(
     }
   }
 
-  scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory =
-      content::BrowserContext::GetDefaultStoragePartition(browser_context.get())
-          ->GetURLLoaderFactoryForBrowserProcess();
   new URLPipeLoader(
-      url_loader_factory, std::move(request), std::move(loader),
-      std::move(client),
+      browser_context->GetURLLoaderFactory(), std::move(request),
+      std::move(loader), std::move(client),
       static_cast<net::NetworkTrafficAnnotationTag>(traffic_annotation),
       std::move(upload_data));
 }


### PR DESCRIPTION
#### Description of Change

Refs #15791.
Refs #19602.

This PR makes `net` and `protocol` module use the same cached `URLLoaderFactory`.

#### Release Notes

Notes: no-notes