### PR TITLE
feat: add aggregated renderer-crashed event with all affected webContents

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -366,6 +366,20 @@ Returns:
 
 Emitted when the renderer process of `webContents` crashes or is killed.
 
+**Note:** This event is emitted separately for each `webContents` hosted in the same crashed renderer.
+
+**Deprecated:** Should use the new [`renderer-crashed`](#event-renderer-crashed) event.
+
+### Event: 'renderer-crashed'
+
+Returns:
+
+* `event` Event
+* `webContents` [WebContents](web-contents.md)[]
+* `killed` Boolean
+
+Emitted when the renderer process hosting the `webContents` crashes or is killed.
+
 ### Event: 'accessibility-support-changed' _macOS_ _Windows_
 
 Returns:

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -20,6 +20,19 @@ const { remote } = require('electron')
 remote.webContents.fromId(webview.getWebContentsId())
 ```
 
+### `app` event `renderer-process-crashed`
+
+The `renderer-process-crashed` event is now deprecated and will be removed in Electron 9.0.
+
+There is a new replacement event `renderer-crashed`, which is emitted only once per group
+of all `webContents` affected by a renderer process crash.
+
+```js
+// Deprecated
+app.on('renderer-process-crashed', (event, webContents, wasKilled) => { /* listener */ })
+// Replace with
+app.on('renderer-crashed', (event, webContents, wasKilled) => { /* listener */ })
+
 ## Planned Breaking API Changes (8.0)
 
 ### Values sent over IPC are now serialized with Structured Clone Algorithm

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -315,6 +315,8 @@ const addReturnValueToEvent = (event) => {
   })
 }
 
+let crashedWebContents = []
+
 // Add JavaScript wrappers for WebContents class.
 WebContents.prototype._init = function () {
   // The navigation controller.
@@ -374,12 +376,21 @@ WebContents.prototype._init = function () {
     })
   })
 
-  this.on('-crashed', (event, ...args) => {
+  this.on('-crashed', (event, wasKilled) => {
     process.nextTick(() => {
-      this.emit('crashed', event, ...args)
-      app.emit('renderer-process-crashed', event, this, ...args)
+      this.emit('crashed', event, wasKilled)
+      app.emit('renderer-process-crashed', event, this, wasKilled)
     })
+
+    if (crashedWebContents.push(this) === 1) {
+      process.nextTick(() => {
+        app.emit('renderer-crashed', event, crashedWebContents, wasKilled)
+        crashedWebContents = []
+      })
+    }
   })
+
+  deprecate.event(this, 'renderer-process-crashed', 'renderer-crashed')
 
   // The devtools requests the webContents to reload.
   this.on('devtools-reload-page', function () {

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -374,8 +374,11 @@ WebContents.prototype._init = function () {
     })
   })
 
-  this.on('crashed', (event, ...args) => {
-    app.emit('renderer-process-crashed', event, this, ...args)
+  this.on('-crashed', (event, ...args) => {
+    process.nextTick(() => {
+      this.emit('crashed', event, ...args)
+      app.emit('renderer-process-crashed', event, this, ...args)
+    })
   })
 
   // The devtools requests the webContents to reload.

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -894,7 +894,7 @@ void WebContents::RenderViewDeleted(content::RenderViewHost* render_view_host) {
 }
 
 void WebContents::RenderProcessGone(base::TerminationStatus status) {
-  Emit("crashed", status == base::TERMINATION_STATUS_PROCESS_WAS_KILLED);
+  Emit("-crashed", status == base::TERMINATION_STATUS_PROCESS_WAS_KILLED);
 }
 
 void WebContents::PluginCrashed(const base::FilePath& plugin_path,

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -322,6 +322,24 @@ describe('webContents module', () => {
     })
   })
 
+  describe('reload() API', () => {
+    afterEach(closeAllWindows)
+    it('does not crash when called in crashed event handler', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      })
+      await w.loadURL('about:blank')
+      w.webContents.once('crashed', () => {
+        w.webContents.reload()
+      })
+      w.webContents.executeJavaScript('process.crash()')
+      await emittedOnce(w.webContents, 'did-finish-load')
+    })
+  })
+
   describe('getFocusedWebContents() API', () => {
     afterEach(closeAllWindows)
 


### PR DESCRIPTION
#### Description of Change
When a scriptable popup is created, there is another `BrowserWindow` instance, which has its own `webContents`. When the renderer process hosting both the parent and the child crashes, both `webContents` emit the `crashed` event. 

Adding new `renderer-crashed` event on `app` that's only emitted once per single crashed renderer process listing all affected `webContents`.

The implementation is taking advantage of the fact, that all `crashed` events are emitted in the same iteration of the message loop and therefore can be aggregated using `setImmediate()`.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added new `renderer-crashed` event on `app`, which is emitted only once per group of all `webContents` affected by a renderer process crash.