### PR TITLE
feat: move tray primitive getters to properties

### DIFF
--- a/docs/api/modernization/property-updates.md
+++ b/docs/api/modernization/property-updates.md
@@ -45,6 +45,9 @@ The Electron team is currently undergoing an initiative to convert separate gett
   * `isMacTemplateImage`
 * `SystemPreferences` module
   * `appLevelAppearance`
+* `Tray` module
+  * `title`
+  * `ignoreDoubleClickEvents`
 * `webContents` module
   * `audioMuted`
   * `frameRate`

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -202,9 +202,13 @@ Sets the hover text for this tray icon.
 
 Sets the title displayed next to the tray icon in the status bar (Support ANSI colors).
 
+**[Deprecated](modernization/property-updates.md)**
+
 #### `tray.getTitle()` _macOS_
 
-Returns `String` - the title displayed next to the tray icon in the status bar
+Returns `String` - the title displayed next to the tray icon in the status bar.
+
+**[Deprecated](modernization/property-updates.md)**
 
 #### `tray.setIgnoreDoubleClickEvents(ignore)` _macOS_
 
@@ -215,9 +219,13 @@ to detect every individual click of the tray icon.
 
 This value is set to false by default.
 
+**[Deprecated](modernization/property-updates.md)**
+
 #### `tray.getIgnoreDoubleClickEvents()` _macOS_
 
 Returns `Boolean` - Whether double click events will be ignored.
+
+**[Deprecated](modernization/property-updates.md)**
 
 #### `tray.displayBalloon(options)` _Windows_
 
@@ -274,3 +282,18 @@ The `bounds` of this tray icon as `Object`.
 Returns `Boolean` - Whether the tray icon is destroyed.
 
 [event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter
+
+### Instance Properties
+
+The following properties are available on instances of `Tray`:
+
+#### `tray.title`
+
+A `String` property that sets the title displayed next to the tray icon in the status bar.
+
+#### `tray.ignoreDoubleClickEvents` _macOS_
+
+A `Boolean` property that determines whether double click events are ignored. Ignoring these events allows you
+to detect every individual click of the tray icon.
+
+This property is set to false by default.

--- a/lib/browser/api/tray.js
+++ b/lib/browser/api/tray.js
@@ -6,4 +6,7 @@ const { Tray } = process.electronBinding('tray')
 
 Object.setPrototypeOf(Tray.prototype, EventEmitter.prototype)
 
+deprecate.fnToProperty(Tray.prototype, 'title', '_getTitle', '_setTitle')
+deprecate.fnToProperty(Tray.prototype, 'ignoreDoubleClickEvents', '_getIgnoreDoubleClickEvents', '_setIgnoreDoubleClickEvents')
+
 module.exports = Tray

--- a/shell/browser/api/atom_api_tray.cc
+++ b/shell/browser/api/atom_api_tray.cc
@@ -251,12 +251,15 @@ void Tray::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setImage", &Tray::SetImage)
       .SetMethod("setPressedImage", &Tray::SetPressedImage)
       .SetMethod("setToolTip", &Tray::SetToolTip)
-      .SetMethod("setTitle", &Tray::SetTitle)
-      .SetMethod("getTitle", &Tray::GetTitle)
-      .SetMethod("setIgnoreDoubleClickEvents",
+      .SetMethod("_setTitle", &Tray::SetTitle)
+      .SetMethod("_getTitle", &Tray::GetTitle)
+      .SetProperty("title", &Tray::GetTitle, &Tray::SetTitle)
+      .SetMethod("_setIgnoreDoubleClickEvents",
                  &Tray::SetIgnoreDoubleClickEvents)
-      .SetMethod("getIgnoreDoubleClickEvents",
+      .SetMethod("_getIgnoreDoubleClickEvents",
                  &Tray::GetIgnoreDoubleClickEvents)
+      .SetProperty("ignoreDoubleClickEvents", &Tray::GetIgnoreDoubleClickEvents,
+                   &Tray::SetIgnoreDoubleClickEvents)
       .SetMethod("displayBalloon", &Tray::DisplayBalloon)
       .SetMethod("removeBalloon", &Tray::RemoveBalloon)
       .SetMethod("focus", &Tray::Focus)

--- a/spec-main/api-tray-spec.ts
+++ b/spec-main/api-tray-spec.ts
@@ -12,7 +12,7 @@ describe('tray module', () => {
     tray = null as any
   })
 
-  ifdescribe(process.platform === 'darwin')('tray get/set ignoreDoubleClickEvents', () => {
+  ifdescribe(process.platform === 'darwin')('tray get/set ignoreDoubleClickEvents (functions)', () => {
     it('returns false by default', () => {
       const ignored = tray.getIgnoreDoubleClickEvents()
       expect(ignored).to.be.false('ignored')
@@ -22,6 +22,20 @@ describe('tray module', () => {
       tray.setIgnoreDoubleClickEvents(true)
 
       const ignored = tray.getIgnoreDoubleClickEvents()
+      expect(ignored).to.be.true('not ignored')
+    })
+  })
+
+  ifdescribe(process.platform === 'darwin')('tray get/set ignoreDoubleClickEvents', () => {
+    it('returns false by default', () => {
+      const ignored = tray.ignoreDoubleClickEvents
+      expect(ignored).to.be.false('ignored')
+    })
+
+    it('can be set to true', () => {
+      tray.ignoreDoubleClickEvents = true
+
+      const ignored = tray.ignoreDoubleClickEvents
       expect(ignored).to.be.true('not ignored')
     })
   })
@@ -74,7 +88,7 @@ describe('tray module', () => {
     })
   })
 
-  ifdescribe(process.platform === 'darwin')('tray get/set title', () => {
+  ifdescribe(process.platform === 'darwin')('tray get/set title (functions)', () => {
     it('sets/gets non-empty title', () => {
       const title = 'Hello World!'
       tray.setTitle(title)
@@ -89,6 +103,22 @@ describe('tray module', () => {
       const newTitle = tray.getTitle()
 
       expect(newTitle).to.equal(title)
+    })
+  })
+
+  ifdescribe(process.platform === 'darwin')('tray get/set title', () => {
+    it('sets/gets non-empty title', () => {
+      const title = 'Hello World!'
+      tray.title  = title
+
+      expect(tray.title).to.equal(title)
+    })
+
+    it('sets/gets empty title', () => {
+      const title = ''
+      tray.title = title
+
+      expect(tray.title).to.equal(title)
     })
   })
 })


### PR DESCRIPTION
#### Description of Change

Converts primitive tray get/set pairs for `title` and `ignoreDoubleClickEvents` to bespoke properties on Tray instances.

cc @miniak @ckerr

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Converted `title` and `ignoreDoubleClickEvents` to properties on instances of Tray.
