### PR TITLE
fix: i18n of gtk msgbox buttons

### DIFF
--- a/atom/browser/ui/file_dialog_gtk.cc
+++ b/atom/browser/ui/file_dialog_gtk.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "atom/browser/ui/file_dialog.h"
+#include "atom/browser/ui/util_gtk.h"
 
 #include "atom/browser/native_window_views.h"
 #include "atom/browser/unresponsive_suppressor.h"
@@ -20,27 +21,6 @@ DialogSettings::DialogSettings(const DialogSettings&) = default;
 DialogSettings::~DialogSettings() = default;
 
 namespace {
-
-// Copied from L40-L55 in
-// https://cs.chromium.org/chromium/src/chrome/browser/ui/libgtkui/select_file_dialog_impl_gtk.cc
-#if GTK_CHECK_VERSION(3, 90, 0)
-// GTK stock items have been deprecated.  The docs say to switch to using the
-// strings "_Open", etc.  However this breaks i18n.  We could supply our own
-// internationalized strings, but the "_" in these strings is significant: it's
-// the keyboard shortcut to select these actions.  TODO(thomasanderson): Provide
-// internationalized strings when GTK provides support for it.
-const char kCancelLabel[] = "_Cancel";
-const char kOkLabel[] = "_OK";
-const char kOpenLabel[] = "_Open";
-const char kSaveLabel[] = "_Save";
-#else
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-const char* const kCancelLabel = GTK_STOCK_CANCEL;
-const char* const kOkLabel = GTK_STOCK_OK;
-const char* const kOpenLabel = GTK_STOCK_OPEN;
-const char* const kSaveLabel = GTK_STOCK_SAVE;
-G_GNUC_END_IGNORE_DEPRECATIONS
-#endif
 
 // Makes sure that .jpg also shows .JPG.
 gboolean FileFilterCaseInsensitive(const GtkFileFilterInfo* file_info,
@@ -62,18 +42,18 @@ class FileChooserDialog {
   FileChooserDialog(GtkFileChooserAction action, const DialogSettings& settings)
       : parent_(static_cast<atom::NativeWindowViews*>(settings.parent_window)),
         filters_(settings.filters) {
-    const char* confirm_text = kOkLabel;
+    const char* confirm_text = util_gtk::kOkLabel;
 
     if (!settings.button_label.empty())
       confirm_text = settings.button_label.c_str();
     else if (action == GTK_FILE_CHOOSER_ACTION_SAVE)
-      confirm_text = kSaveLabel;
+      confirm_text = util_gtk::kSaveLabel;
     else if (action == GTK_FILE_CHOOSER_ACTION_OPEN)
-      confirm_text = kOpenLabel;
+      confirm_text = util_gtk::kOpenLabel;
 
     dialog_ = gtk_file_chooser_dialog_new(
-        settings.title.c_str(), NULL, action, kCancelLabel, GTK_RESPONSE_CANCEL,
-        confirm_text, GTK_RESPONSE_ACCEPT, NULL);
+        settings.title.c_str(), NULL, action, util_gtk::kCancelLabel,
+        GTK_RESPONSE_CANCEL, confirm_text, GTK_RESPONSE_ACCEPT, NULL);
     if (parent_) {
       parent_->SetEnabled(false);
       libgtkui::SetGtkTransientForAura(dialog_, parent_->GetNativeWindow());

--- a/atom/browser/ui/message_box_gtk.cc
+++ b/atom/browser/ui/message_box_gtk.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "atom/browser/ui/message_box.h"
+#include "atom/browser/ui/util_gtk.h"
 
 #include <glib/gi18n.h>
 
@@ -127,13 +128,13 @@ class GtkMessageBox : public NativeWindowObserver {
   const char* TranslateToStock(int id, const std::string& text) {
     const std::string lower = base::ToLowerASCII(text);
     if (lower == "cancel")
-      return _("_Cancel");
+      return util_gtk::kCancelLabel;
     if (lower == "no")
-      return _("_No");
+      return util_gtk::kNoLabel;
     if (lower == "ok")
-      return _("_OK");
+      return util_gtk::kOkLabel;
     if (lower == "yes")
-      return _("_Yes");
+      return util_gtk::kYesLabel;
     return text.c_str();
   }
 
@@ -237,8 +238,8 @@ void ShowMessageBox(NativeWindow* parent,
 
 void ShowErrorBox(const base::string16& title, const base::string16& content) {
   if (Browser::Get()->is_ready()) {
-    GtkMessageBox(nullptr, MESSAGE_BOX_TYPE_ERROR, {"OK"}, -1, 0, "Error",
-                  base::UTF16ToUTF8(title).c_str(),
+    GtkMessageBox(nullptr, MESSAGE_BOX_TYPE_ERROR, {util_gtk::kOkLabel}, -1, 0,
+                  "Error", base::UTF16ToUTF8(title).c_str(),
                   base::UTF16ToUTF8(content).c_str(), "", false,
                   gfx::ImageSkia())
         .RunSynchronous();

--- a/atom/browser/ui/message_box_gtk.cc
+++ b/atom/browser/ui/message_box_gtk.cc
@@ -3,13 +3,13 @@
 // found in the LICENSE file.
 
 #include "atom/browser/ui/message_box.h"
-#include "atom/browser/ui/util_gtk.h"
 
 #include <glib/gi18n.h>
 
 #include "atom/browser/browser.h"
 #include "atom/browser/native_window_observer.h"
 #include "atom/browser/native_window_views.h"
+#include "atom/browser/ui/util_gtk.h"
 #include "atom/browser/unresponsive_suppressor.h"
 #include "base/callback.h"
 #include "base/strings/string_util.h"

--- a/atom/browser/ui/util_gtk.cc
+++ b/atom/browser/ui/util_gtk.cc
@@ -1,0 +1,36 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/browser/ui/util_gtk.h"
+
+#include <gtk/gtk.h>
+
+namespace util_gtk {
+
+// Copied from L40-L55 in
+// https://cs.chromium.org/chromium/src/chrome/browser/ui/libgtkui/select_file_dialog_impl_gtk.cc
+#if GTK_CHECK_VERSION(3, 90, 0)
+// GTK stock items have been deprecated.  The docs say to switch to using the
+// strings "_Open", etc.  However this breaks i18n.  We could supply our own
+// internationalized strings, but the "_" in these strings is significant: it's
+// the keyboard shortcut to select these actions.  TODO: Provide
+// internationalized strings when GTK provides support for it.
+const char* const kCancelLabel = "_Cancel";
+const char* const kNoLabel = "_No";
+const char* const kOkLabel = "_OK";
+const char* const kOpenLabel = "_Open";
+const char* const kSaveLabel = "_Save";
+const char* const kYesLabel = "_Yes";
+#else
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+const char* const kCancelLabel = GTK_STOCK_CANCEL;
+const char* const kNoLabel = GTK_STOCK_NO;
+const char* const kOkLabel = GTK_STOCK_OK;
+const char* const kOpenLabel = GTK_STOCK_OPEN;
+const char* const kSaveLabel = GTK_STOCK_SAVE;
+const char* const kYesLabel = GTK_STOCK_YES;
+G_GNUC_END_IGNORE_DEPRECATIONS
+#endif
+
+}  // namespace util_gtk

--- a/atom/browser/ui/util_gtk.h
+++ b/atom/browser/ui/util_gtk.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_BROWSER_UI_UTIL_GTK_H_
+#define SHELL_BROWSER_UI_UTIL_GTK_H_
+
+namespace util_gtk {
+
+/* These are `const char*` rather than the project-preferred `const char[]`
+   because they must fit the type of an external dependency */
+extern const char* const kCancelLabel;
+extern const char* const kNoLabel;
+extern const char* const kOkLabel;
+extern const char* const kOpenLabel;
+extern const char* const kSaveLabel;
+extern const char* const kYesLabel;
+
+}  // namespace util_gtk
+
+#endif  // SHELL_BROWSER_UI_UTIL_GTK_H_

--- a/atom/browser/ui/util_gtk.h
+++ b/atom/browser/ui/util_gtk.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#ifndef SHELL_BROWSER_UI_UTIL_GTK_H_
-#define SHELL_BROWSER_UI_UTIL_GTK_H_
+#ifndef ATOM_BROWSER_UI_UTIL_GTK_H_
+#define ATOM_BROWSER_UI_UTIL_GTK_H_
 
 namespace util_gtk {
 
@@ -18,4 +18,4 @@ extern const char* const kYesLabel;
 
 }  // namespace util_gtk
 
-#endif  // SHELL_BROWSER_UI_UTIL_GTK_H_
+#endif  // ATOM_BROWSER_UI_UTIL_GTK_H_

--- a/filenames.gni
+++ b/filenames.gni
@@ -454,6 +454,8 @@ filenames = {
     "atom/browser/ui/tray_icon_cocoa.mm",
     "atom/browser/ui/tray_icon_observer.h",
     "atom/browser/ui/tray_icon_win.cc",
+    "atom/browser/ui/util_gtk.cc",
+    "atom/browser/ui/util_gtk.h",
     "atom/browser/ui/views/atom_views_delegate.cc",
     "atom/browser/ui/views/atom_views_delegate.h",
     "atom/browser/ui/views/autofill_popup_view.cc",


### PR DESCRIPTION
Manually backport #19904.

See that PR for details.

Notes: Fixed i18n of GTK messageboxes' stock buttons.