### PR TITLE
fix: Revert "fix: make sure that menu bar gets focus even when you click an item to focus it first"

### DIFF
--- a/shell/browser/ui/views/menu_bar.cc
+++ b/shell/browser/ui/views/menu_bar.cc
@@ -270,12 +270,6 @@ void MenuBar::OnMenuButtonClicked(views::Button* source,
   if (!window_->HasFocus())
     window_->RequestFocus();
 
-  // This ensures that if you focus the menubar by clicking on an item, you can
-  // still use the arrow keys to move around
-  if (GetPaneFocusTraversable() == nullptr) {
-    SetPaneFocus(source);
-  }
-
   int id = source->tag();
   AtomMenuModel::ItemType type = menu_model_->GetTypeAt(id);
   if (type != AtomMenuModel::TYPE_SUBMENU) {


### PR DESCRIPTION
Reverts electron/electron#19710

As outlined in comments in that PR this is re-causing issues where when you open the menu the webContents loses focus and it is never restored.  This breaks things like "copy", "paste" and the `webContents.getFocusedWebContents()` method.

Notes: Fixed issue where using the menu on Linux would un-focus the webContents