### PR TITLE
fix: honor cursor blink rate

### DIFF
--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -100,10 +100,12 @@
 
 #if !defined(OS_MACOSX)
 #include "ui/aura/window.h"
+#else
+#include "ui/base/cocoa/defaults_utils.h"
 #endif
 
-#if defined(OS_MACOSX)
-#include "ui/base/cocoa/defaults_utils.h"
+#if defined(OS_LINUX)
+#include "ui/views/linux_ui/linux_ui.h"
 #endif
 
 #if defined(OS_LINUX) || defined(OS_WIN)
@@ -466,6 +468,10 @@ void WebContents::InitWithSessionAndOptions(
   base::TimeDelta interval;
   if (ui::TextInsertionCaretBlinkPeriod(&interval))
     prefs->caret_blink_interval = interval;
+#elif defined(OS_LINUX)
+  views::LinuxUI* linux_ui = views::LinuxUI::instance();
+  if (linux_ui)
+    prefs->caret_blink_interval = linux_ui->GetCursorBlinkInterval();
 #endif
 
   // Save the preferences in C++.

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -102,6 +102,10 @@
 #include "ui/aura/window.h"
 #endif
 
+#if defined(OS_MACOSX)
+#include "ui/base/cocoa/defaults_utils.h"
+#endif
+
 #if defined(OS_LINUX) || defined(OS_WIN)
 #include "third_party/blink/public/mojom/renderer_preferences.mojom.h"
 #include "ui/gfx/font_render_params.h"
@@ -456,6 +460,12 @@ void WebContents::InitWithSessionAndOptions(
   prefs->use_autohinter = params->autohinter;
   prefs->use_bitmaps = params->use_bitmaps;
   prefs->subpixel_rendering = params->subpixel_rendering;
+#endif
+
+#if defined(OS_MACOSX)
+  base::TimeDelta interval;
+  if (ui::TextInsertionCaretBlinkPeriod(&interval))
+    prefs->caret_blink_interval = interval;
 #endif
 
   // Save the preferences in C++.

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -104,6 +104,10 @@
 #include "ui/base/cocoa/defaults_utils.h"
 #endif
 
+#if defined(TOOLKIT_VIEWS)
+#include "ui/views/controls/textfield/textfield.h"
+#endif
+
 #if defined(OS_LINUX)
 #include "ui/views/linux_ui/linux_ui.h"
 #endif
@@ -472,6 +476,13 @@ void WebContents::InitWithSessionAndOptions(
   views::LinuxUI* linux_ui = views::LinuxUI::instance();
   if (linux_ui)
     prefs->caret_blink_interval = linux_ui->GetCursorBlinkInterval();
+#endif
+
+#if defined(OS_WIN)
+  static const size_t system_value = ::GetCaretBlinkTime();
+  if (system_value != 0 && system_value != INFINITE)
+    prefs->caret_blink_interval =
+        base::TimeDelta::FromMilliseconds(system_value);
 #endif
 
   // Save the preferences in C++.

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -468,6 +468,7 @@ void WebContents::InitWithSessionAndOptions(
   prefs->subpixel_rendering = params->subpixel_rendering;
 #endif
 
+// Honor the system's cursor blink rate settings
 #if defined(OS_MACOSX)
   base::TimeDelta interval;
   if (ui::TextInsertionCaretBlinkPeriod(&interval))
@@ -476,13 +477,14 @@ void WebContents::InitWithSessionAndOptions(
   views::LinuxUI* linux_ui = views::LinuxUI::instance();
   if (linux_ui)
     prefs->caret_blink_interval = linux_ui->GetCursorBlinkInterval();
-#endif
-
-#if defined(OS_WIN)
-  static const size_t system_value = ::GetCaretBlinkTime();
-  if (system_value != 0 && system_value != INFINITE)
+#elif defined(OS_WIN)
+  const auto system_msec = ::GetCaretBlinkTime();
+  if (system_msec != 0) {
     prefs->caret_blink_interval =
-        base::TimeDelta::FromMilliseconds(system_value);
+        (system_msec == INFINITE)
+            ? base::TimeDelta()
+            : base::TimeDelta::FromMilliseconds(system_msec);
+  }
 #endif
 
   // Save the preferences in C++.

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -104,10 +104,6 @@
 #include "ui/base/cocoa/defaults_utils.h"
 #endif
 
-#if defined(TOOLKIT_VIEWS)
-#include "ui/views/controls/textfield/textfield.h"
-#endif
-
 #if defined(OS_LINUX)
 #include "ui/views/linux_ui/linux_ui.h"
 #endif


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/10668.

Ensures that WebPreferences honor the system cursor blink rate on creation.

cc @zcbenz @nornagon @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where cursor blink rate was not honored.
