### PR TITLE
test: make getPath(logs) spec more idempotent

### DIFF
--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -673,26 +673,29 @@ describe('app module', () => {
   })
 
   describe('getPath("logs")', () => {
+    // this won't be deterministic except on CI
+    before(function () {
+      if (!isCI) this.skip()
+    })
+  
     const logsPaths = {
-      'darwin': path.resolve(homedir(), 'Library', 'Logs'),
-      'linux': path.resolve(homedir(), 'AppData', app.name),
-      'win32': path.resolve(homedir(), 'AppData', app.name),
+      'darwin': path.resolve(homedir(),'Library', 'Logs', 'Electron'),
+      'linux': path.resolve(app.getPath('userData'), app.name, 'logs'),
+      'win32': path.resolve(app.getPath('userData'), app.name, 'logs'),
     }
 
     it('has no logs directory by default', () => {
-      // this won't be deterministic except on CI since
-      // users may or may not have this dir
-      if (!isCI) return
-
       const osLogPath = (logsPaths as any)[process.platform]
-      expect(fs.existsSync(osLogPath)).to.be.false
+      expect(fs.existsSync(osLogPath)).to.be.false(`${osLogPath} exists`)
     })
 
     it('creates a new logs directory if one does not exist', () => {
       expect(() => { app.getPath('logs') }).to.not.throw()
 
       const osLogPath = (logsPaths as any)[process.platform]
-      expect(fs.existsSync(osLogPath)).to.be.true
+      expect(fs.existsSync(osLogPath)).to.be.true(`${osLogPath} does not exist`)
+
+      if (isCI) fs.rmdirSync(osLogPath)
     })
   })
 


### PR DESCRIPTION
#### Description of Change

Improve granularity of `getPath('logs')` spec by checking the specific folder that the logs path would be created as. Also makes the test more idempotent by removing the created directory once the test has completed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
