### PR TITLE
build: accidentally inverted a bool

### DIFF
--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -95,7 +95,7 @@ async function runElectronTests () {
 
   const testResultsDir = process.env.ELECTRON_TEST_RESULTS_DIR
   for (const [runnerId, { description, run }] of runners) {
-    if (runnersToRun && runnersToRun.includes(runnerId)) {
+    if (runnersToRun && !runnersToRun.includes(runnerId)) {
       console.info('\nSkipping:', description)
       continue
     }


### PR DESCRIPTION
#### Description of Change

We want it to _run_ the specified runner, not _skip_ it.

cc @MarshallOfSound 

#### Release Notes

Notes: none
