### PR TITLE
fix: use rounded scaling for window sizing on Windows

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -77,3 +77,4 @@ picture-in-picture.patch
 disable_compositor_recycling.patch
 allow_new_privileges_in_unsandboxed_child_processes.patch
 expose_setuseragent_on_networkcontext.patch
+win-window-scaling.patch

--- a/patches/chromium/win-window-scaling.patch
+++ b/patches/chromium/win-window-scaling.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Heilig Benedek <benecene@gmail.com>
+Date: Thu, 29 Aug 2019 22:17:17 +0200
+Subject: fix: use rounded scaling for window sizing on Windows
+
+Chromium uses ceiled sizes when translating between DIP coordinates and screen
+coordinates to ensure that content of native widgets isn't cut off ever. This
+however has some side effects, mostly that window sizing behaves very weirdly
+when using fractional scaling (1.25 for example) - if you set the bounds of a
+window, you might not get the same bounds back when you query the window for it.
+This patch exposes a couple of things so we can override this behaviour in our
+code.
+
+diff --git a/ui/display/win/screen_win.h b/ui/display/win/screen_win.h
+index e47db8c64fce4cee9f5af282229aef7de4093a7a..f4a3f70f4bc464a5526940e13b8dc6c6efce0f81 100644
+--- a/ui/display/win/screen_win.h
++++ b/ui/display/win/screen_win.h
+@@ -148,7 +148,7 @@ class DISPLAY_EXPORT ScreenWin : public Screen,
+   // Returns the NativeView associated with the HWND.
+   virtual gfx::NativeWindow GetNativeWindowFromHWND(HWND hwnd) const;
+ 
+- protected:
++ // protected:
+   ScreenWin(bool initialize);
+ 
+   // Screen:
+@@ -183,7 +183,7 @@ class DISPLAY_EXPORT ScreenWin : public Screen,
+   virtual HWND GetRootWindow(HWND hwnd) const;
+   virtual int GetSystemMetrics(int metric) const;
+ 
+- private:
++ // private:
+   void Initialize();
+   void OnWndProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam);
+   void UpdateAllDisplaysAndNotify();
+diff --git a/ui/views/widget/desktop_aura/desktop_window_tree_host_win.h b/ui/views/widget/desktop_aura/desktop_window_tree_host_win.h
+index 335db0db49bbfba35b064c93d75b2dd7ae8e79f9..719180a5990b756a5fffe9908fcb76f47fa6080d 100644
+--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_win.h
++++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_win.h
+@@ -230,7 +230,7 @@ class VIEWS_EXPORT DesktopWindowTreeHostWin
+   const Widget* GetWidget() const;
+   HWND GetHWND() const;
+ 
+- private:
++ // private:
+   friend class ::views::test::DesktopWindowTreeHostWinTestApi;
+ 
+   void SetWindowTransparency();

--- a/shell/browser/ui/win/atom_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/atom_desktop_window_tree_host_win.cc
@@ -4,7 +4,68 @@
 
 #include "shell/browser/ui/win/atom_desktop_window_tree_host_win.h"
 
+#include "ui/aura/client/aura_constants.h"
+#include "ui/base/win/shell.h"
+#include "ui/display/win/screen_win.h"
+#include "ui/display/win/screen_win_display.h"
+#include "ui/views/widget/widget_hwnd_utils.h"
+#include "ui/views/win/hwnd_message_handler.h"
+
+using display::win::ScreenWin;
+using display::win::ScreenWinDisplay;
+
 namespace electron {
+
+namespace {
+
+gfx::Size GetExpandedWindowSize(bool is_translucent, gfx::Size size) {
+  if (!is_translucent || !ui::win::IsAeroGlassEnabled())
+    return size;
+
+  // Some AMD drivers can't display windows that are less than 64x64 pixels,
+  // so expand them to be at least that size. http://crbug.com/286609
+  gfx::Size expanded(std::max(size.width(), 64), std::max(size.height(), 64));
+  return expanded;
+}
+
+void InsetBottomRight(gfx::Rect* rect, const gfx::Vector2d& vector) {
+  rect->Inset(0, 0, vector.x(), vector.y());
+}
+
+gfx::Rect DIPToScreenRect(HWND hwnd, const gfx::Rect& dip_bounds) {
+  const ScreenWinDisplay screen_win_display =
+      hwnd ? display::win::ScreenWin::GetScreenWinDisplayVia(
+                 &ScreenWin::GetScreenWinDisplayNearestHWND, hwnd)
+           : display::win::ScreenWin::GetScreenWinDisplayVia(
+                 &ScreenWin::GetScreenWinDisplayNearestDIPRect, dip_bounds);
+  float scale_factor = screen_win_display.display().device_scale_factor();
+  return ScaleToRoundedRect(dip_bounds, scale_factor);
+}
+
+gfx::Rect ScreenToDIPRect(HWND hwnd, const gfx::Rect& pixel_bounds) {
+  const ScreenWinDisplay screen_win_display =
+      hwnd
+          ? display::win::ScreenWin::GetScreenWinDisplayVia(
+                &ScreenWin::GetScreenWinDisplayNearestHWND, hwnd)
+          : display::win::ScreenWin::GetScreenWinDisplayVia(
+                &ScreenWin::GetScreenWinDisplayNearestScreenRect, pixel_bounds);
+  float scale_factor = screen_win_display.display().device_scale_factor();
+  return ScaleToRoundedRect(pixel_bounds, 1.0f / scale_factor);
+}
+
+gfx::Size DIPToScreenSize(HWND hwnd, const gfx::Size& dip_size) {
+  float scale_factor = display::win::ScreenWin::GetScaleFactorForHWND(hwnd);
+  return ScaleToRoundedSize(dip_size, scale_factor);
+}
+
+gfx::Rect DIPToScreenRectInWindow(gfx::NativeView view,
+                                  const gfx::Rect& dip_rect) {
+  auto* screen = display::Screen::GetScreen();
+  float scale = screen->GetDisplayNearestView(view).device_scale_factor();
+  return ScaleToRoundedRect(dip_rect, scale);
+}
+
+}  // namespace
 
 AtomDesktopWindowTreeHostWin::AtomDesktopWindowTreeHostWin(
     NativeWindowViews* native_window_view,
@@ -14,6 +75,114 @@ AtomDesktopWindowTreeHostWin::AtomDesktopWindowTreeHostWin(
       native_window_view_(native_window_view) {}
 
 AtomDesktopWindowTreeHostWin::~AtomDesktopWindowTreeHostWin() {}
+
+void AtomDesktopWindowTreeHostWin::Init(
+    const views::Widget::InitParams& params) {
+  wants_mouse_events_when_inactive_ = params.wants_mouse_events_when_inactive;
+
+  wm::SetAnimationHost(content_window(), this);
+  if (params.type == views::Widget::InitParams::TYPE_WINDOW &&
+      !params.remove_standard_frame)
+    content_window()->SetProperty(aura::client::kAnimationsDisabledKey, true);
+
+  ConfigureWindowStyles(message_handler_.get(), params,
+                        GetWidget()->widget_delegate(),
+                        native_widget_delegate_);
+
+  HWND parent_hwnd = nullptr;
+  if (params.parent && params.parent->GetHost())
+    parent_hwnd = params.parent->GetHost()->GetAcceleratedWidget();
+
+  remove_standard_frame_ = params.remove_standard_frame;
+  has_non_client_view_ = views::Widget::RequiresNonClientView(params.type);
+  z_order_ = params.EffectiveZOrderLevel();
+
+  // We don't have an HWND yet, so scale relative to the nearest screen.
+  gfx::Rect pixel_bounds = DIPToScreenRect(nullptr, params.bounds);
+  message_handler_->Init(parent_hwnd, pixel_bounds);
+  CreateCompositor(viz::FrameSinkId(), params.force_software_compositing);
+  OnAcceleratedWidgetAvailable();
+  InitHost();
+  window()->Show();
+}
+
+void AtomDesktopWindowTreeHostWin::Show(ui::WindowShowState show_state,
+                                        const gfx::Rect& restore_bounds) {
+  if (compositor())
+    compositor()->SetVisible(true);
+
+  gfx::Rect pixel_restore_bounds;
+  if (show_state == ui::SHOW_STATE_MAXIMIZED) {
+    pixel_restore_bounds = DIPToScreenRect(GetHWND(), restore_bounds);
+  }
+  message_handler_->Show(show_state, pixel_restore_bounds);
+
+  content_window()->Show();
+}
+
+void AtomDesktopWindowTreeHostWin::SetSize(const gfx::Size& size) {
+  gfx::Size size_in_pixels = electron::DIPToScreenSize(GetHWND(), size);
+  gfx::Size expanded =
+      GetExpandedWindowSize(message_handler_->is_translucent(), size_in_pixels);
+  window_enlargement_ =
+      gfx::Vector2d(expanded.width() - size_in_pixels.width(),
+                    expanded.height() - size_in_pixels.height());
+  message_handler_->SetSize(expanded);
+}
+
+void AtomDesktopWindowTreeHostWin::SetBoundsInDIP(const gfx::Rect& bounds) {
+  aura::Window* root = AsWindowTreeHost()->window();
+  const gfx::Rect bounds_in_pixels =
+      electron::DIPToScreenRectInWindow(root, bounds);
+  AsWindowTreeHost()->SetBoundsInPixels(bounds_in_pixels);
+}
+
+void AtomDesktopWindowTreeHostWin::CenterWindow(const gfx::Size& size) {
+  gfx::Size size_in_pixels = electron::DIPToScreenSize(GetHWND(), size);
+  gfx::Size expanded_size;
+  expanded_size =
+      GetExpandedWindowSize(message_handler_->is_translucent(), size_in_pixels);
+  window_enlargement_ =
+      gfx::Vector2d(expanded_size.width() - size_in_pixels.width(),
+                    expanded_size.height() - size_in_pixels.height());
+  message_handler_->CenterWindow(expanded_size);
+}
+
+void AtomDesktopWindowTreeHostWin::GetWindowPlacement(
+    gfx::Rect* bounds,
+    ui::WindowShowState* show_state) const {
+  message_handler_->GetWindowPlacement(bounds, show_state);
+  InsetBottomRight(bounds, window_enlargement_);
+  *bounds = electron::ScreenToDIPRect(GetHWND(), *bounds);
+}
+
+gfx::Rect AtomDesktopWindowTreeHostWin::GetWindowBoundsInScreen() const {
+  gfx::Rect pixel_bounds = message_handler_->GetWindowBoundsInScreen();
+  InsetBottomRight(&pixel_bounds, window_enlargement_);
+  return electron::ScreenToDIPRect(GetHWND(), pixel_bounds);
+}
+
+gfx::Rect AtomDesktopWindowTreeHostWin::GetClientAreaBoundsInScreen() const {
+  gfx::Rect pixel_bounds = message_handler_->GetClientAreaBoundsInScreen();
+  InsetBottomRight(&pixel_bounds, window_enlargement_);
+  return electron::ScreenToDIPRect(GetHWND(), pixel_bounds);
+}
+
+gfx::Rect AtomDesktopWindowTreeHostWin::GetRestoredBounds() const {
+  gfx::Rect pixel_bounds = message_handler_->GetRestoredBounds();
+  InsetBottomRight(&pixel_bounds, window_enlargement_);
+  return electron::ScreenToDIPRect(GetHWND(), pixel_bounds);
+}
+
+gfx::Rect AtomDesktopWindowTreeHostWin::GetWorkAreaBoundsInScreen() const {
+  MONITORINFO monitor_info;
+  monitor_info.cbSize = sizeof(monitor_info);
+  GetMonitorInfo(
+      MonitorFromWindow(message_handler_->hwnd(), MONITOR_DEFAULTTONEAREST),
+      &monitor_info);
+  gfx::Rect pixel_bounds = gfx::Rect(monitor_info.rcWork);
+  return electron::ScreenToDIPRect(GetHWND(), pixel_bounds);
+}
 
 bool AtomDesktopWindowTreeHostWin::PreHandleMSG(UINT message,
                                                 WPARAM w_param,

--- a/shell/browser/ui/win/atom_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/atom_desktop_window_tree_host_win.cc
@@ -4,6 +4,8 @@
 
 #include "shell/browser/ui/win/atom_desktop_window_tree_host_win.h"
 
+#include <algorithm>
+
 #include "ui/aura/client/aura_constants.h"
 #include "ui/base/win/shell.h"
 #include "ui/display/win/screen_win.h"

--- a/shell/browser/ui/win/atom_desktop_window_tree_host_win.h
+++ b/shell/browser/ui/win/atom_desktop_window_tree_host_win.h
@@ -19,6 +19,19 @@ class AtomDesktopWindowTreeHostWin : public views::DesktopWindowTreeHostWin {
       views::DesktopNativeWidgetAura* desktop_native_widget_aura);
   ~AtomDesktopWindowTreeHostWin() override;
 
+  void Init(const views::Widget::InitParams& params) override;
+  void Show(ui::WindowShowState show_state,
+            const gfx::Rect& restore_bounds) override;
+  void SetSize(const gfx::Size& size) override;
+  void SetBoundsInDIP(const gfx::Rect& bounds) override;
+  void CenterWindow(const gfx::Size& size) override;
+  void GetWindowPlacement(gfx::Rect* bounds,
+                          ui::WindowShowState* show_state) const override;
+  gfx::Rect GetWindowBoundsInScreen() const override;
+  gfx::Rect GetClientAreaBoundsInScreen() const override;
+  gfx::Rect GetRestoredBounds() const override;
+  gfx::Rect GetWorkAreaBoundsInScreen() const override;
+
  protected:
   bool PreHandleMSG(UINT message,
                     WPARAM w_param,


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Chromium uses ceiled sizes when translating between DIP coordinates and screen coordinates to ensure that content of native widgets isn't cut off ever. This however has some side effects, mostly that window sizing behaves very weirdly when using fractional scaling (1.25 for example) - if you set the bounds of a window, you might not get the same bounds back when you query the window for it.

This can also lead to weird behaviour where you set the `x` coordinate of a window and you end up with a window that has:
 - the incorrect `x` coordinate
 - different size than before you set the `x` coordinate

Fixes #19769.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a bug where window bounds didn't match the set values on Windows.<!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
