### PR TITLE
fix: strip chrome_sandbox executable

### DIFF
--- a/script/strip-binaries.py
+++ b/script/strip-binaries.py
@@ -8,6 +8,7 @@ from lib.util import execute, get_out_dir
 
 LINUX_BINARIES_TO_STRIP = [
   'electron',
+  'chrome_sandbox',
   'libffmpeg.so',
   'libGLESv2.so',
   'libEGL.so',


### PR DESCRIPTION
#### Description of Change
We weren't correctly stripping the `chrome_sandbox` executable, which was 5MB before stripping, and ~200KB after. Thanks to @pronebird for the report at #17972

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Reduced the size of the chrome-sandbox binary on Linux from ~5MB to ~0.2MB by stripping debug symbols that were inadvertently being included.