### PR TITLE
fix: emit `will-navigate` event when sandbox is enabled

### DIFF
--- a/shell/renderer/atom_renderer_client.cc
+++ b/shell/renderer/atom_renderer_client.cc
@@ -43,12 +43,6 @@ AtomRendererClient::~AtomRendererClient() {
   asar::ClearArchives();
 }
 
-void AtomRendererClient::RenderFrameCreated(
-    content::RenderFrame* render_frame) {
-  new AtomRenderFrameObserver(render_frame, this);
-  RendererClientBase::RenderFrameCreated(render_frame);
-}
-
 void AtomRendererClient::RunScriptsAtDocumentStart(
     content::RenderFrame* render_frame) {
   RendererClientBase::RunScriptsAtDocumentStart(render_frame);
@@ -178,18 +172,6 @@ void AtomRendererClient::WillReleaseScriptContext(
 
   // ElectronBindings is tracking node environments.
   electron_bindings_->EnvironmentDestroyed(env);
-}
-
-bool AtomRendererClient::ShouldFork(blink::WebLocalFrame* frame,
-                                    const GURL& url,
-                                    const std::string& http_method,
-                                    bool is_initial_navigation,
-                                    bool is_server_redirect) {
-  // Handle all the navigations and reloads in browser.
-  // FIXME We only support GET here because http method will be ignored when
-  // the OpenURLFromTab is triggered, which means form posting would not work,
-  // we should solve this by patching Chromium in future.
-  return http_method == "GET";
 }
 
 void AtomRendererClient::DidInitializeWorkerContextOnWorkerThread(

--- a/shell/renderer/atom_renderer_client.h
+++ b/shell/renderer/atom_renderer_client.h
@@ -39,14 +39,9 @@ class AtomRendererClient : public RendererClientBase {
 
  private:
   // content::ContentRendererClient:
-  void RenderFrameCreated(content::RenderFrame*) override;
   void RunScriptsAtDocumentStart(content::RenderFrame* render_frame) override;
   void RunScriptsAtDocumentEnd(content::RenderFrame* render_frame) override;
-  bool ShouldFork(blink::WebLocalFrame* frame,
-                  const GURL& url,
-                  const std::string& http_method,
-                  bool is_initial_navigation,
-                  bool is_server_redirect) override;
+
   void DidInitializeWorkerContextOnWorkerThread(
       v8::Local<v8::Context> context) override;
   void WillDestroyWorkerContextOnWorkerThread(

--- a/shell/renderer/atom_sandboxed_renderer_client.cc
+++ b/shell/renderer/atom_sandboxed_renderer_client.cc
@@ -153,17 +153,6 @@ void AtomSandboxedRendererClient::InitializeBindings(
           command_line->GetSwitchValueASCII(switches::kGuestInstanceID));
 }
 
-void AtomSandboxedRendererClient::RenderFrameCreated(
-    content::RenderFrame* render_frame) {
-  new AtomRenderFrameObserver(render_frame, this);
-  RendererClientBase::RenderFrameCreated(render_frame);
-}
-
-void AtomSandboxedRendererClient::RenderViewCreated(
-    content::RenderView* render_view) {
-  RendererClientBase::RenderViewCreated(render_view);
-}
-
 void AtomSandboxedRendererClient::RunScriptsAtDocumentStart(
     content::RenderFrame* render_frame) {
   RendererClientBase::RunScriptsAtDocumentStart(render_frame);

--- a/shell/renderer/atom_sandboxed_renderer_client.h
+++ b/shell/renderer/atom_sandboxed_renderer_client.h
@@ -1,6 +1,7 @@
 // Copyright (c) 2016 GitHub, Inc.
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
+
 #ifndef SHELL_RENDERER_ATOM_SANDBOXED_RENDERER_CLIENT_H_
 #define SHELL_RENDERER_ATOM_SANDBOXED_RENDERER_CLIENT_H_
 
@@ -32,13 +33,12 @@ class AtomSandboxedRendererClient : public RendererClientBase {
   void SetupExtensionWorldOverrides(v8::Handle<v8::Context> context,
                                     content::RenderFrame* render_frame,
                                     int world_id) override;
+
+ private:
   // content::ContentRendererClient:
-  void RenderFrameCreated(content::RenderFrame*) override;
-  void RenderViewCreated(content::RenderView*) override;
   void RunScriptsAtDocumentStart(content::RenderFrame* render_frame) override;
   void RunScriptsAtDocumentEnd(content::RenderFrame* render_frame) override;
 
- private:
   std::unique_ptr<base::ProcessMetrics> metrics_;
 
   // Getting main script context from web frame would lazily initializes

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -217,6 +217,8 @@ void RendererClientBase::RenderThreadStarted() {
 
 void RendererClientBase::RenderFrameCreated(
     content::RenderFrame* render_frame) {
+  new AtomRenderFrameObserver(render_frame, this);
+
 #if defined(TOOLKIT_VIEWS)
   new AutofillAgent(render_frame,
                     render_frame->GetAssociatedInterfaceRegistry());
@@ -345,6 +347,18 @@ void RendererClientBase::RunScriptsAtDocumentEnd(
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   extensions_renderer_client_.get()->RunScriptsAtDocumentEnd(render_frame);
 #endif
+}
+
+bool RendererClientBase::ShouldFork(blink::WebLocalFrame* frame,
+                                    const GURL& url,
+                                    const std::string& http_method,
+                                    bool is_initial_navigation,
+                                    bool is_server_redirect) {
+  // Handle all the navigations and reloads in browser.
+  // FIXME We only support GET here because http method will be ignored when
+  // the OpenURLFromTab is triggered, which means form posting would not work,
+  // we should solve this by patching Chromium in future.
+  return http_method == "GET";
 }
 
 v8::Local<v8::Context> RendererClientBase::GetContext(

--- a/shell/renderer/renderer_client_base.h
+++ b/shell/renderer/renderer_client_base.h
@@ -86,6 +86,11 @@ class RendererClientBase : public content::ContentRendererClient {
   void RunScriptsAtDocumentStart(content::RenderFrame* render_frame) override;
   void RunScriptsAtDocumentEnd(content::RenderFrame* render_frame) override;
   void RunScriptsAtDocumentIdle(content::RenderFrame* render_frame) override;
+  bool ShouldFork(blink::WebLocalFrame* frame,
+                  const GURL& url,
+                  const std::string& http_method,
+                  bool is_initial_navigation,
+                  bool is_server_redirect) override;
 
  protected:
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -2009,8 +2009,7 @@ describe('BrowserWindow module', () => {
             'did-finish-load',
             'did-frame-finish-load',
             'did-navigate-in-page',
-            // TODO(nornagon): sandboxed pages should also emit will-navigate
-            // 'will-navigate',
+            'will-navigate',
             'did-start-loading',
             'did-stop-loading',
             'did-frame-finish-load',


### PR DESCRIPTION
#### Description of Change
`will-navigate` events were not being delivered when `sandbox` was
enabled. This is because the `AtomSandboxedRendererClient` did not
override the `ShouldFork` method found in `ContentRendererClient` while
the `AtomRendererClient` did.

Fixes #8841

CC @codebytere 

#### Checklist
- [X] PR description included and stakeholders cc'd
- [X] `npm test` passes
- [X] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [X] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed delivery of `will-navigate` events when sandbox is enabled.
