### PR TITLE
docs: Improve wording of setBrowserView and getBrowserView

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1739,14 +1739,14 @@ removed in future Electron releases.
 
 #### `win.setBrowserView(browserView)` _Experimental_
 
-* `browserView` [BrowserView](browser-view.md) | null - Attach browserView to win.
-If there is some other browserViews was attached they will be removed from
+* `browserView` [BrowserView](browser-view.md) | null - Attach `browserView` to `win`.
+If there are other `BrowserView`s attached, they will be removed from
 this window.
 
 #### `win.getBrowserView()` _Experimental_
 
-Returns `BrowserView | null` - an BrowserView what is attached. Returns `null`
-if none is attached. Throw error if multiple BrowserViews is attached.
+Returns `BrowserView | null` - The `BrowserView` attached to `win`. Returns `null`
+if none is attached. Throws an error if multiple `BrowserView`s are attached.
 
 #### `win.addBrowserView(browserView)` _Experimental_
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1746,7 +1746,7 @@ this window.
 #### `win.getBrowserView()` _Experimental_
 
 Returns `BrowserView | null` - The `BrowserView` attached to `win`. Returns `null`
-if none is attached. Throws an error if multiple `BrowserView`s are attached.
+if one is not attached. Throws an error if multiple `BrowserView`s are attached.
 
 #### `win.addBrowserView(browserView)` _Experimental_
 


### PR DESCRIPTION
#### Description of Change
Improving the wording in the description of `setBrowserView` and `getBrowserView`

cc: @codebytere, @zcbenz, @MarshallOfSound. cc'ing you folks only because you seem to be a few of the recent committers. 

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

notes: no-notes
