### PR TITLE
ci: do not run WOA builds on older versions of Electron

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,9 @@ environment:
   ELECTRON_OUT_DIR: Default
 build_script:
   - ps: >-
+      if($env:APPVEYOR_PROJECT_NAME -eq "electron-woa-testing") {
+        Write-warning "WOA builds not supported on older versions of Electron"; Exit-AppveyorBuild
+      }
       if(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {
         Write-warning "Skipping PR build for branch"; Exit-AppveyorBuild
       }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
This is a followup to #20031.  On older branches we don't want to run WOA builds.  This PR shortcuts those builds on older branches.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
