### PR TITLE
fix: crash with --inspect-brk when running under ELECTRON_RUN_AS_NODE

### DIFF
--- a/atom/app/node_main.cc
+++ b/atom/app/node_main.cc
@@ -47,15 +47,6 @@ int NodeMain(int argc, char* argv[]) {
     feature_list->InitializeFromCommandLine("", "");
     base::FeatureList::SetInstance(std::move(feature_list));
 
-    gin::V8Initializer::LoadV8Snapshot(
-        gin::V8Initializer::V8SnapshotFileType::kWithAdditionalContext);
-    gin::V8Initializer::LoadV8Natives();
-
-    // V8 requires a task scheduler apparently
-    base::ThreadPoolInstance::CreateAndStartWithDefaultParams("Electron");
-
-    // Initialize gin::IsolateHolder.
-    JavascriptEnvironment gin_env(loop);
 #if defined(_WIN64)
     crash_reporter::CrashReporterWin::SetUnhandledExceptionFilter();
 #endif
@@ -66,6 +57,16 @@ int NodeMain(int argc, char* argv[]) {
     int exec_argc;
     const char** exec_argv;
     node::Init(&argc, const_cast<const char**>(argv), &exec_argc, &exec_argv);
+
+    gin::V8Initializer::LoadV8Snapshot(
+        gin::V8Initializer::V8SnapshotFileType::kWithAdditionalContext);
+    gin::V8Initializer::LoadV8Natives();
+
+    // V8 requires a task scheduler apparently
+    base::ThreadPoolInstance::CreateAndStartWithDefaultParams("Electron");
+
+    // Initialize gin::IsolateHolder.
+    JavascriptEnvironment gin_env(loop);
 
     node::Environment* env = node::CreateEnvironment(
         node::CreateIsolateData(gin_env.isolate(), loop, gin_env.platform()),
@@ -112,12 +113,15 @@ int NodeMain(int argc, char* argv[]) {
 
     node_debugger.Stop();
     exit_code = node::EmitExit(env);
+    env->set_can_call_into_js(false);
     node::RunAtExit(env);
-    gin_env.platform()->DrainTasks(env->isolate());
-    gin_env.platform()->CancelPendingDelayedTasks(env->isolate());
-    gin_env.platform()->UnregisterIsolate(env->isolate());
 
+    v8::Isolate* isolate = env->isolate();
     node::FreeEnvironment(env);
+
+    gin_env.platform()->DrainTasks(isolate);
+    gin_env.platform()->CancelPendingDelayedTasks(isolate);
+    gin_env.platform()->UnregisterIsolate(isolate);
   }
 
   // According to "src/gin/shell/gin_main.cc":

--- a/atom/app/node_main.cc
+++ b/atom/app/node_main.cc
@@ -69,11 +69,13 @@ int NodeMain(int argc, char* argv[]) {
 
     node::Environment* env = node::CreateEnvironment(
         node::CreateIsolateData(gin_env.isolate(), loop, gin_env.platform()),
-        gin_env.context(), argc, argv, exec_argc, exec_argv);
+        gin_env.context(), argc, argv, exec_argc, exec_argv, false);
 
     // Enable support for v8 inspector.
     NodeDebugger node_debugger(env);
     node_debugger.Start();
+
+    node::BootstrapEnvironment(env);
 
     mate::Dictionary process(gin_env.isolate(), env->process_object());
 #if defined(OS_WIN)

--- a/atom/browser/node_debugger.cc
+++ b/atom/browser/node_debugger.cc
@@ -60,8 +60,10 @@ void NodeDebugger::Start() {
 
 void NodeDebugger::Stop() {
   auto* inspector = env_->inspector_agent();
-  if (inspector && inspector->IsListening())
+  if (inspector && inspector->IsListening()) {
+    inspector->WaitForDisconnect();
     inspector->Stop();
+  }
 }
 
 }  // namespace atom

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -390,6 +390,7 @@ describe('node feature', () => {
             const connection = new WebSocket(socketMatch[0])
             connection.onopen = () => {
               child.send('plz-quit')
+              connection.close()
               done()
             }
           }

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -311,13 +311,20 @@ describe('node feature', () => {
         output += data
         if (output.trim().startsWith('Debugger listening on ws://')) {
           cleanup()
-          done()
+          child.kill('SIGTERM')
         }
       }
       function outDataHandler (data) {
         cleanup()
         done(new Error(`Unexpected output: ${data.toString()}`))
       }
+      child.on('close', (code, signal) => {
+        if (signal !== 'SIGTERM') {
+          done(new Error(`Unexpected termination with code: ${code} and signal: ${signal}`))
+        } else {
+          done()
+        }
+      })
       child.stderr.on('data', errorDataListener)
       child.stdout.on('data', outDataHandler)
     })


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/19316

Backports from https://github.com/electron/electron/pull/19403

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix crash with `--inspect-brk` under ELECTRON_RUN_AS_NODE flag
