### PR TITLE
test: remove usage of remote in shell.openExternal test

### DIFF
--- a/spec-main/api-shell-spec.ts
+++ b/spec-main/api-shell-spec.ts
@@ -1,0 +1,59 @@
+import { BrowserWindow, shell } from 'electron'
+import { closeAllWindows } from './window-helpers'
+import { emittedOnce } from './events-helpers'
+import * as http from 'http'
+import { AddressInfo } from 'net'
+
+describe('shell module', () => {
+  describe('shell.openExternal()', () => {
+    let envVars: Record<string, string | undefined> = {}
+
+    beforeEach(function () {
+      envVars = {
+        display: process.env.DISPLAY,
+        de: process.env.DE,
+        browser: process.env.BROWSER
+      }
+    })
+
+    afterEach(async () => {
+      // reset env vars to prevent side effects
+      if (process.platform === 'linux') {
+        process.env.DE = envVars.de
+        process.env.BROWSER = envVars.browser
+        process.env.DISPLAY = envVars.display
+      }
+    })
+    afterEach(closeAllWindows)
+
+    it('opens an external link', async () => {
+      let url = 'http://127.0.0.1'
+      let requestReceived
+      if (process.platform === 'linux') {
+        process.env.BROWSER = '/bin/true'
+        process.env.DE = 'generic'
+        process.env.DISPLAY = ''
+        requestReceived = Promise.resolve()
+      } else if (process.platform === 'darwin') {
+        // On the Mac CI machines, Safari tries to ask for a password to the
+        // code signing keychain we set up to test code signing (see
+        // https://github.com/electron/electron/pull/19969#issuecomment-526278890),
+        // so use a blur event as a crude proxy.
+        const w = new BrowserWindow({ show: true })
+        requestReceived = emittedOnce(w, 'blur')
+      } else {
+        const server = http.createServer((req, res) => {
+          res.end()
+        })
+        await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+        requestReceived = new Promise(resolve => server.on('connection', () => resolve()))
+        url = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+      }
+
+      await Promise.all([
+        shell.openExternal(url),
+        requestReceived
+      ])
+    })
+  })
+})

--- a/spec/api-shell-spec.js
+++ b/spec/api-shell-spec.js
@@ -5,8 +5,7 @@ const fs = require('fs')
 const path = require('path')
 const os = require('os')
 const http = require('http')
-const { shell, remote } = require('electron')
-const { BrowserWindow } = remote
+const { shell } = require('electron')
 
 const { closeWindow } = require('./window-helpers')
 const { emittedOnce } = require('./events-helpers')
@@ -25,60 +24,6 @@ describe('shell module', () => {
     icon: 'icon',
     iconIndex: 1
   }
-
-  describe('shell.openExternal()', () => {
-    let envVars = {}
-    let w
-
-    beforeEach(function () {
-      envVars = {
-        display: process.env.DISPLAY,
-        de: process.env.DE,
-        browser: process.env.BROWSER
-      }
-    })
-
-    afterEach(async () => {
-      await closeWindow(w)
-      w = null
-      // reset env vars to prevent side effects
-      if (process.platform === 'linux') {
-        process.env.DE = envVars.de
-        process.env.BROWSER = envVars.browser
-        process.env.DISPLAY = envVars.display
-      }
-    })
-
-    it('opens an external link', async () => {
-      let url = 'http://127.0.0.1'
-      let requestReceived
-      if (process.platform === 'linux') {
-        process.env.BROWSER = '/bin/true'
-        process.env.DE = 'generic'
-        process.env.DISPLAY = ''
-        requestReceived = Promise.resolve()
-      } else if (process.platform === 'darwin') {
-        // On the Mac CI machines, Safari tries to ask for a password to the
-        // code signing keychain we set up to test code signing (see
-        // https://github.com/electron/electron/pull/19969#issuecomment-526278890),
-        // so use a blur event as a crude proxy.
-        w = new BrowserWindow({ show: true })
-        requestReceived = emittedOnce(w, 'blur')
-      } else {
-        const server = http.createServer((req, res) => {
-          res.end()
-        })
-        await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
-        requestReceived = new Promise(resolve => server.on('connection', () => resolve()))
-        url = `http://127.0.0.1:${server.address().port}`
-      }
-
-      await Promise.all([
-        shell.openExternal(url),
-        requestReceived
-      ])
-    })
-  })
 
   describe('shell.readShortcutLink(shortcutPath)', () => {
     beforeEach(function () {


### PR DESCRIPTION
#### Description of Change
This now tests `shell.openExternal` as called from the main process rather than the renderer process, but it's the same implementation either way so I think we're OK.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none