### PR TITLE
fix: ensure modeL_ exists before calling delegate methods

### DIFF
--- a/shell/browser/ui/cocoa/atom_menu_controller.mm
+++ b/shell/browser/ui/cocoa/atom_menu_controller.mm
@@ -375,7 +375,8 @@ static base::scoped_nsobject<NSMenu> recentDocumentsMenuSwap_;
 - (void)menuDidClose:(NSMenu*)menu {
   if (isMenuOpen_) {
     isMenuOpen_ = NO;
-    model_->MenuWillClose();
+    if (model_)
+      model_->MenuWillClose();
     // Post async task so that itemSelected runs before the close callback
     // deletes the controller from the map which deallocates it
     if (!closeCallback.is_null()) {


### PR DESCRIPTION
This is a speculative fix for a crash we are seeing in `menuDidClose`.  We can't repro the crash but the traces have it happening in this method and just by reading through the impl the only part that jumps out as Might Crash is this `model_` call.  Other methods in the menu controller check `model_` before using it so it probably makes sense to do that here as well.

Setting `no-notes` as I don't want to claim to fix a crash we can't repro.

Notes: no-notes