### PR TITLE
fix: ensure popup and closepopup are threaded correctly

### DIFF
--- a/shell/browser/api/atom_api_menu_mac.h
+++ b/shell/browser/api/atom_api_menu_mac.h
@@ -35,6 +35,7 @@ class MenuMac : public Menu {
                  int positioning_item,
                  base::Closure callback);
   void ClosePopupAt(int32_t window_id) override;
+  void ClosePopupOnUI(int32_t window_id);
 
  private:
   friend class Menu;

--- a/shell/browser/api/atom_api_menu_mac.mm
+++ b/shell/browser/api/atom_api_menu_mac.mm
@@ -48,7 +48,7 @@ void MenuMac::PopupAt(TopLevelWindow* window,
       base::BindOnce(&MenuMac::PopupOnUI, weak_factory_.GetWeakPtr(),
                      native_window->GetWeakPtr(), window->weak_map_id(), x, y,
                      positioning_item, callback);
-  base::PostTaskWithTraits(FROM_HERE, {BrowserThread::UI}, std::move(popup));
+  base::SequencedTaskRunnerHandle::Get()->PostTask(FROM_HERE, std::move(popup));
 }
 
 void MenuMac::PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
@@ -117,6 +117,13 @@ void MenuMac::PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
 }
 
 void MenuMac::ClosePopupAt(int32_t window_id) {
+  auto close_popup = base::BindOnce(&MenuMac::ClosePopupOnUI,
+                                    weak_factory_.GetWeakPtr(), window_id);
+  base::SequencedTaskRunnerHandle::Get()->PostTask(FROM_HERE,
+                                                   std::move(close_popup));
+}
+
+void MenuMac::ClosePopupOnUI(int32_t window_id) {
   auto controller = popup_controllers_.find(window_id);
   if (controller != popup_controllers_.end()) {
     // Close the controller for the window.


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/19411.

Previously, we called `base::PostTaskWithTraits` on `menu.popup()`, which meant that we would encounter a race condition with `menu.closePopup()` if it was called too soon after `menu.popup()`; the `window_id` would not yet have been added to `popup_controllers_` and thus it would not be able to find the menu to close.
 
This fixes that race condition by posting `menu.closePopup()` to the current sequence to ensure that the `popup` task had finished running before other tasks are run.

cc @nornagon @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `menu.closePopup()` would have no effect if called too soon after `menu.popup()`.
