### PR TITLE
fix: LoggingSettings failure on Windows Debug builds

### DIFF
--- a/shell/app/atom_main_delegate.cc
+++ b/shell/app/atom_main_delegate.cc
@@ -149,7 +149,7 @@ bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
   base::FilePath log_filename;
   base::PathService::Get(base::DIR_EXE, &log_filename);
   log_filename = log_filename.AppendASCII("debug.log");
-  settings.log_file = log_filename.value().c_str();
+  settings.log_file_path = log_filename.value().c_str();
   settings.lock_log = logging::LOCK_LOG_FILE;
   settings.delete_old = logging::DELETE_OLD_LOG_FILE;
 #else


### PR DESCRIPTION
struct LoggingSettings from `src/base/logging.h` has changed. `log_file` is now `log_file_path`.

This PR fixes debug builds on Windows.

#### Checklist
- [X] PR description included and stakeholders cc'd
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes
