### PR TITLE
fix: resolve crash loading file based serviceworkers

### DIFF
--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -695,7 +695,7 @@ void ProxyingURLLoaderFactory::CreateLoaderAndStart(
   // Intercept file:// protocol to support asar archives.
   if (request.url.SchemeIsFile()) {
     asar::CreateAsarURLLoader(request, std::move(loader), std::move(client),
-                              nullptr);
+                              new net::HttpResponseHeaders(""));
     return;
   }
 

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -194,8 +194,7 @@ describe('chromium feature', () => {
     })
   })
 
-  // FIXME(robo/nornagon): re-enable these once service workers work
-  describe.skip('navigator.serviceWorker', () => {
+  describe('navigator.serviceWorker', () => {
     it('should register for file scheme', (done) => {
       w = new BrowserWindow({
         show: false,


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Followup for #19602 for ServiceWorkers. The test `chromium feature navigator.serviceWorker should register for file scheme` was failing because there was a crash when loading a ServiceWorker via the `file://` protocol.  This PR fixes that crash.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->fixed crash loading file based ServiceWorkers.
