### PR TITLE
feat: default gtk darkTheme option to nativeTheme.shouldUseDarkColors for better platform support

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -207,7 +207,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `opacity` Number (optional) - Set the initial opacity of the window, between 0.0 (fully
     transparent) and 1.0 (fully opaque). This is only implemented on Windows and macOS.
   * `darkTheme` Boolean (optional) - Forces using dark theme for the window, only works on
-    some GTK+3 desktop environments. Default is `false`.
+    some GTK+3 desktop environments. Default is `nativeTheme.shouldUseDarkColors`.
   * `transparent` Boolean (optional) - Makes the window [transparent](frameless-window.md#transparent-window).
     Default is `false`. On Windows, does not work unless the window is frameless.
   * `type` String (optional) - The type of window, default is normal window. See more about

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -207,7 +207,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `opacity` Number (optional) - Set the initial opacity of the window, between 0.0 (fully
     transparent) and 1.0 (fully opaque). This is only implemented on Windows and macOS.
   * `darkTheme` Boolean (optional) - Forces using dark theme for the window, only works on
-    some GTK+3 desktop environments. Default is `nativeTheme.shouldUseDarkColors`.
+    some GTK+3 desktop environments. Default is [`nativeTheme.shouldUseDarkColors`](native-theme.md).
   * `transparent` Boolean (optional) - Makes the window [transparent](frameless-window.md#transparent-window).
     Default is `false`. On Windows, does not work unless the window is frameless.
   * `type` String (optional) - The type of window, default is normal window. See more about

--- a/shell/browser/api/electron_api_native_theme.cc
+++ b/shell/browser/api/electron_api_native_theme.cc
@@ -10,6 +10,7 @@
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "gin/handle.h"
+#include "shell/browser/api/atom_api_top_level_window.h"
 #include "shell/common/gin_converters/std_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/object_template_builder.h"
@@ -47,6 +48,9 @@ void NativeTheme::SetThemeSource(ui::NativeTheme::ThemeSource override) {
   // Update the macOS appearance setting for this new override value
   UpdateMacOSAppearanceForOverrideValue(override);
 #endif
+  for (auto* window : electron::api::TopLevelWindow::GetAllWindows()) {
+    window->SetGTKDarkThemeEnabled(ShouldUseDarkColors());
+  }
   // TODO(MarshallOfSound): Update all existing browsers windows to use GTK dark
   // theme
 }

--- a/shell/browser/api/electron_api_native_theme.cc
+++ b/shell/browser/api/electron_api_native_theme.cc
@@ -48,8 +48,9 @@ void NativeTheme::SetThemeSource(ui::NativeTheme::ThemeSource override) {
   // Update the macOS appearance setting for this new override value
   UpdateMacOSAppearanceForOverrideValue(override);
 #endif
+  const bool dark_enabled = ShouldUseDarkColors();
   for (auto* window : electron::api::TopLevelWindow::GetAllWindows()) {
-    window->SetGTKDarkThemeEnabled(ShouldUseDarkColors());
+    window->SetGTKDarkThemeEnabled(dark_enabled);
   }
   // TODO(MarshallOfSound): Update all existing browsers windows to use GTK dark
   // theme

--- a/shell/browser/api/electron_api_native_theme.cc
+++ b/shell/browser/api/electron_api_native_theme.cc
@@ -10,7 +10,8 @@
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "gin/handle.h"
-#include "shell/browser/api/atom_api_top_level_window.h"
+#include "shell/browser/native_window_views.h"
+#include "shell/browser/window_list.h"
 #include "shell/common/gin_converters/std_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/object_template_builder.h"
@@ -48,12 +49,13 @@ void NativeTheme::SetThemeSource(ui::NativeTheme::ThemeSource override) {
   // Update the macOS appearance setting for this new override value
   UpdateMacOSAppearanceForOverrideValue(override);
 #endif
+#if defined(USE_X11)
   const bool dark_enabled = ShouldUseDarkColors();
-  for (auto* window : electron::api::TopLevelWindow::GetAllWindows()) {
-    window->SetGTKDarkThemeEnabled(dark_enabled);
+  for (auto* window : WindowList::GetWindows()) {
+    static_cast<NativeWindowViews*>(window)->SetGTKDarkThemeEnabled(
+        dark_enabled);
   }
-  // TODO(MarshallOfSound): Update all existing browsers windows to use GTK dark
-  // theme
+#endif
 }
 
 ui::NativeTheme::ThemeSource NativeTheme::GetThemeSource() const {

--- a/shell/browser/api/electron_api_top_level_window.cc
+++ b/shell/browser/api/electron_api_top_level_window.cc
@@ -74,12 +74,12 @@ v8::Local<v8::Value> ToBuffer(v8::Isolate* isolate, void* val, int size) {
 
 }  // namespace
 
-std::vector<TopLevelWindow*> TopLevelWindow::all_windows;
+std::vector<TopLevelWindow*> TopLevelWindow::all_windows_;
 
 TopLevelWindow::TopLevelWindow(v8::Isolate* isolate,
                                const gin_helper::Dictionary& options)
     : weak_factory_(this) {
-  all_windows.push_back(this);
+  all_windows_.push_back(this);
   // The parent window.
   gin::Handle<TopLevelWindow> parent;
   if (options.Get("parent", &parent) && !parent.IsEmpty())
@@ -117,8 +117,9 @@ TopLevelWindow::TopLevelWindow(gin_helper::Arguments* args,
 }
 
 TopLevelWindow::~TopLevelWindow() {
-  all_windows.erase(std::remove(all_windows.begin(), all_windows.end(), this),
-                    all_windows.end());
+  all_windows_.erase(
+      std::remove(all_windows_.begin(), all_windows_.end(), this),
+      all_windows_.end());
   if (!window_->IsClosed())
     window_->CloseImmediately();
 

--- a/shell/browser/api/electron_api_top_level_window.cc
+++ b/shell/browser/api/electron_api_top_level_window.cc
@@ -74,12 +74,9 @@ v8::Local<v8::Value> ToBuffer(v8::Isolate* isolate, void* val, int size) {
 
 }  // namespace
 
-std::vector<TopLevelWindow*> TopLevelWindow::all_windows_;
-
 TopLevelWindow::TopLevelWindow(v8::Isolate* isolate,
                                const gin_helper::Dictionary& options)
     : weak_factory_(this) {
-  all_windows_.push_back(this);
   // The parent window.
   gin::Handle<TopLevelWindow> parent;
   if (options.Get("parent", &parent) && !parent.IsEmpty())
@@ -117,9 +114,6 @@ TopLevelWindow::TopLevelWindow(gin_helper::Arguments* args,
 }
 
 TopLevelWindow::~TopLevelWindow() {
-  all_windows_.erase(
-      std::remove(all_windows_.begin(), all_windows_.end(), this),
-      all_windows_.end());
   if (!window_->IsClosed())
     window_->CloseImmediately();
 
@@ -910,10 +904,6 @@ void TopLevelWindow::PreviewFile(const std::string& path,
 
 void TopLevelWindow::CloseFilePreview() {
   window_->CloseFilePreview();
-}
-
-void TopLevelWindow::SetGTKDarkThemeEnabled(bool use_dark_theme) {
-  window_->SetGTKDarkThemeEnabled(use_dark_theme);
 }
 
 v8::Local<v8::Value> TopLevelWindow::GetContentView() const {

--- a/shell/browser/api/electron_api_top_level_window.cc
+++ b/shell/browser/api/electron_api_top_level_window.cc
@@ -74,9 +74,12 @@ v8::Local<v8::Value> ToBuffer(v8::Isolate* isolate, void* val, int size) {
 
 }  // namespace
 
+std::vector<TopLevelWindow*> TopLevelWindow::all_windows;
+
 TopLevelWindow::TopLevelWindow(v8::Isolate* isolate,
                                const gin_helper::Dictionary& options)
     : weak_factory_(this) {
+  all_windows.push_back(this);
   // The parent window.
   gin::Handle<TopLevelWindow> parent;
   if (options.Get("parent", &parent) && !parent.IsEmpty())
@@ -114,6 +117,8 @@ TopLevelWindow::TopLevelWindow(gin_helper::Arguments* args,
 }
 
 TopLevelWindow::~TopLevelWindow() {
+  all_windows.erase(std::remove(all_windows.begin(), all_windows.end(), this),
+                    all_windows.end());
   if (!window_->IsClosed())
     window_->CloseImmediately();
 

--- a/shell/browser/api/electron_api_top_level_window.h
+++ b/shell/browser/api/electron_api_top_level_window.h
@@ -32,12 +32,15 @@ class TopLevelWindow : public gin_helper::TrackableObject<TopLevelWindow>,
 
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype);
+  static std::vector<TopLevelWindow*> GetAllWindows() { return all_windows; }
 
   base::WeakPtr<TopLevelWindow> GetWeakPtr() {
     return weak_factory_.GetWeakPtr();
   }
 
   NativeWindow* window() const { return window_.get(); }
+
+  void SetGTKDarkThemeEnabled(bool use_dark_theme);
 
  protected:
   // Common constructor.
@@ -208,7 +211,6 @@ class TopLevelWindow : public gin_helper::TrackableObject<TopLevelWindow>,
   void SetAspectRatio(double aspect_ratio, gin_helper::Arguments* args);
   void PreviewFile(const std::string& path, gin_helper::Arguments* args);
   void CloseFilePreview();
-  void SetGTKDarkThemeEnabled(bool use_dark_theme);
 
   // Public getters of NativeWindow.
   v8::Local<v8::Value> GetContentView() const;
@@ -267,6 +269,8 @@ class TopLevelWindow : public gin_helper::TrackableObject<TopLevelWindow>,
 
   // Reference to JS wrapper to prevent garbage collection.
   v8::Global<v8::Value> self_ref_;
+
+  static std::vector<TopLevelWindow*> all_windows;
 
   base::WeakPtrFactory<TopLevelWindow> weak_factory_;
 };

--- a/shell/browser/api/electron_api_top_level_window.h
+++ b/shell/browser/api/electron_api_top_level_window.h
@@ -32,7 +32,7 @@ class TopLevelWindow : public gin_helper::TrackableObject<TopLevelWindow>,
 
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype);
-  static std::vector<TopLevelWindow*> GetAllWindows() { return all_windows; }
+  static std::vector<TopLevelWindow*> GetAllWindows() { return all_windows_; }
 
   base::WeakPtr<TopLevelWindow> GetWeakPtr() {
     return weak_factory_.GetWeakPtr();
@@ -270,7 +270,7 @@ class TopLevelWindow : public gin_helper::TrackableObject<TopLevelWindow>,
   // Reference to JS wrapper to prevent garbage collection.
   v8::Global<v8::Value> self_ref_;
 
-  static std::vector<TopLevelWindow*> all_windows;
+  static std::vector<TopLevelWindow*> all_windows_;
 
   base::WeakPtrFactory<TopLevelWindow> weak_factory_;
 };

--- a/shell/browser/api/electron_api_top_level_window.h
+++ b/shell/browser/api/electron_api_top_level_window.h
@@ -32,15 +32,12 @@ class TopLevelWindow : public gin_helper::TrackableObject<TopLevelWindow>,
 
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype);
-  static std::vector<TopLevelWindow*> GetAllWindows() { return all_windows_; }
 
   base::WeakPtr<TopLevelWindow> GetWeakPtr() {
     return weak_factory_.GetWeakPtr();
   }
 
   NativeWindow* window() const { return window_.get(); }
-
-  void SetGTKDarkThemeEnabled(bool use_dark_theme);
 
  protected:
   // Common constructor.
@@ -269,8 +266,6 @@ class TopLevelWindow : public gin_helper::TrackableObject<TopLevelWindow>,
 
   // Reference to JS wrapper to prevent garbage collection.
   v8::Global<v8::Value> self_ref_;
-
-  static std::vector<TopLevelWindow*> all_windows_;
 
   base::WeakPtrFactory<TopLevelWindow> weak_factory_;
 };

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -232,8 +232,6 @@ class NativeWindow : public base::SupportsUserData,
                            const std::string& display_name);
   virtual void CloseFilePreview();
 
-  virtual void SetGTKDarkThemeEnabled(bool use_dark_theme) = 0;
-
   // Converts between content bounds and window bounds.
   virtual gfx::Rect ContentBoundsToWindowBounds(
       const gfx::Rect& bounds) const = 0;

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -137,7 +137,6 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
       std::vector<gin_helper::PersistentDictionary> items) override;
   void RefreshTouchBarItem(const std::string& item_id) override;
   void SetEscapeTouchBarItem(gin_helper::PersistentDictionary item) override;
-  void SetGTKDarkThemeEnabled(bool use_dark_theme) override {}
 
   gfx::Rect ContentBoundsToWindowBounds(const gfx::Rect& bounds) const override;
   gfx::Rect WindowBoundsToContentBounds(const gfx::Rect& bounds) const override;

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -34,6 +34,7 @@
 #include "ui/base/hit_test.h"
 #include "ui/gfx/image/image.h"
 #include "ui/gfx/native_widget_types.h"
+#include "ui/native_theme/native_theme.h"
 #include "ui/views/background.h"
 #include "ui/views/controls/webview/unhandled_keyboard_event_handler.h"
 #include "ui/views/controls/webview/webview.h"
@@ -212,7 +213,8 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
   window_state_watcher_ = std::make_unique<WindowStateWatcher>(this);
 
   // Set _GTK_THEME_VARIANT to dark if we have "dark-theme" option set.
-  bool use_dark_theme = false;
+  bool use_dark_theme =
+      ui::NativeTheme::GetInstanceForNativeUi()->ShouldUseDarkColors();
   if (options.Get(options::kDarkTheme, &use_dark_theme) && use_dark_theme) {
     SetGTKDarkThemeEnabled(use_dark_theme);
   }

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -215,9 +215,8 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
   // Set _GTK_THEME_VARIANT to dark if we have "dark-theme" option set.
   bool use_dark_theme =
       ui::NativeTheme::GetInstanceForNativeUi()->ShouldUseDarkColors();
-  if (options.Get(options::kDarkTheme, &use_dark_theme) && use_dark_theme) {
-    SetGTKDarkThemeEnabled(use_dark_theme);
-  }
+  options.Get(options::kDarkTheme, &use_dark_theme);
+  SetGTKDarkThemeEnabled(use_dark_theme);
 
   // Before the window is mapped the SetWMSpecState can not work, so we have
   // to manually set the _NET_WM_STATE.

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -326,25 +326,6 @@ NativeWindowViews::~NativeWindowViews() {
 #endif
 }
 
-void NativeWindowViews::SetGTKDarkThemeEnabled(bool use_dark_theme) {
-#if defined(USE_X11)
-  XDisplay* xdisplay = gfx::GetXDisplay();
-  if (use_dark_theme) {
-    XChangeProperty(xdisplay, GetAcceleratedWidget(),
-                    XInternAtom(xdisplay, "_GTK_THEME_VARIANT", x11::False),
-                    XInternAtom(xdisplay, "UTF8_STRING", x11::False), 8,
-                    PropModeReplace,
-                    reinterpret_cast<const unsigned char*>("dark"), 4);
-  } else {
-    XChangeProperty(xdisplay, GetAcceleratedWidget(),
-                    XInternAtom(xdisplay, "_GTK_THEME_VARIANT", x11::False),
-                    XInternAtom(xdisplay, "UTF8_STRING", x11::False), 8,
-                    PropModeReplace,
-                    reinterpret_cast<const unsigned char*>("light"), 5);
-  }
-#endif
-}
-
 void NativeWindowViews::SetContentView(views::View* view) {
   if (content_view()) {
     root_view_->RemoveChildView(content_view());
@@ -1290,6 +1271,25 @@ void NativeWindowViews::SetIcon(const gfx::ImageSkia& icon) {
   auto* tree_host = views::DesktopWindowTreeHostLinux::GetHostForWidget(
       GetAcceleratedWidget());
   tree_host->SetWindowIcons(icon, {});
+}
+#endif
+
+#if defined(USE_X11)
+void NativeWindowViews::SetGTKDarkThemeEnabled(bool use_dark_theme) {
+  XDisplay* xdisplay = gfx::GetXDisplay();
+  if (use_dark_theme) {
+    XChangeProperty(xdisplay, GetAcceleratedWidget(),
+                    XInternAtom(xdisplay, "_GTK_THEME_VARIANT", x11::False),
+                    XInternAtom(xdisplay, "UTF8_STRING", x11::False), 8,
+                    PropModeReplace,
+                    reinterpret_cast<const unsigned char*>("dark"), 4);
+  } else {
+    XChangeProperty(xdisplay, GetAcceleratedWidget(),
+                    XInternAtom(xdisplay, "_GTK_THEME_VARIANT", x11::False),
+                    XInternAtom(xdisplay, "UTF8_STRING", x11::False), 8,
+                    PropModeReplace,
+                    reinterpret_cast<const unsigned char*>("light"), 5);
+  }
 }
 #endif
 

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -127,8 +127,6 @@ class NativeWindowViews : public NativeWindow,
 
   bool IsVisibleOnAllWorkspaces() override;
 
-  void SetGTKDarkThemeEnabled(bool use_dark_theme) override;
-
   content::DesktopMediaID GetDesktopMediaID() const override;
   gfx::AcceleratedWidget GetAcceleratedWidget() const override;
   NativeWindowHandle GetNativeWindowHandle() const override;
@@ -155,6 +153,10 @@ class NativeWindowViews : public NativeWindow,
   void SetIcon(HICON small_icon, HICON app_icon);
 #elif defined(USE_X11)
   void SetIcon(const gfx::ImageSkia& icon);
+#endif
+
+#if defined(USE_X11)
+  void SetGTKDarkThemeEnabled(bool use_dark_theme);
 #endif
 
   SkRegion* draggable_region() const { return draggable_region_.get(); }


### PR DESCRIPTION
This is done so that dark mode / `nativeTheme.themeSource` make everything else Just Work out of the box.

This also updates `darkTheme` when `themeSource` is modified in the `nativeTheme` API to match macOS behavior.

Phase 3 (and almost final phase) of #19932

Notes: BrowserWindow `darkTheme` option now defaults to `nativeTheme.shouldUseDarkColors`