### PR TITLE
refactor: implement sublabel fns in MenuModel

### DIFF
--- a/shell/browser/ui/atom_menu_model.cc
+++ b/shell/browser/ui/atom_menu_model.cc
@@ -41,6 +41,17 @@ base::string16 AtomMenuModel::GetRoleAt(int index) {
   return iter == std::end(roles_) ? base::string16() : iter->second;
 }
 
+void AtomMenuModel::SetSublabel(int index, const base::string16& sublabel) {
+  int command_id = GetCommandIdAt(index);
+  sublabels_[command_id] = sublabel;
+}
+
+base::string16 AtomMenuModel::GetSublabelAt(int index) const {
+  int command_id = GetCommandIdAt(index);
+  const auto iter = sublabels_.find(command_id);
+  return iter == std::end(sublabels_) ? base::string16() : iter->second;
+}
+
 bool AtomMenuModel::GetAcceleratorAtWithParams(
     int index,
     bool use_default_accelerator,

--- a/shell/browser/ui/atom_menu_model.h
+++ b/shell/browser/ui/atom_menu_model.h
@@ -57,6 +57,8 @@ class AtomMenuModel : public ui::SimpleMenuModel {
   base::string16 GetToolTipAt(int index);
   void SetRole(int index, const base::string16& role);
   base::string16 GetRoleAt(int index);
+  void SetSublabel(int index, const base::string16& sublabel);
+  base::string16 GetSublabelAt(int index) const override;
   bool GetAcceleratorAtWithParams(int index,
                                   bool use_default_accelerator,
                                   ui::Accelerator* accelerator) const;
@@ -73,8 +75,9 @@ class AtomMenuModel : public ui::SimpleMenuModel {
  private:
   Delegate* delegate_;  // weak ref.
 
-  std::map<int, base::string16> toolTips_;  // command id -> tooltip
-  std::map<int, base::string16> roles_;     // command id -> role
+  std::map<int, base::string16> toolTips_;   // command id -> tooltip
+  std::map<int, base::string16> roles_;      // command id -> role
+  std::map<int, base::string16> sublabels_;  // command id -> sublabel
   base::ObserverList<Observer> observers_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomMenuModel);


### PR DESCRIPTION
#### Description of Change

Implements `SetSublabel` and `GetSublabelAt` in preparation for their upstream removal in [1764883](https://chromium-review.googlesource.com/c/chromium/src/+/1764883). We can just remove their overrides once the CL is rolled.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
