### PR TITLE
feat: set urgency on linux notifications

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -280,6 +280,7 @@ if (is_linux) {
       "notify_notification_add_action",
       "notify_notification_set_image_from_pixbuf",
       "notify_notification_set_timeout",
+      "notify_notification_set_urgency",
       "notify_notification_set_hint_string",
       "notify_notification_show",
       "notify_notification_close",

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -149,7 +149,7 @@ A `Boolean` property representing whether the notification has a reply action.
 
 A `String` property representing the urgency level of the notification. Can be 'normal', 'critical', or 'low'.
 
-Default is 'low' - see [NotifyUrgency](https://developer.gnome.org/libnotify/unstable/NotifyNotification.html#notify-notification-set-urgency) for more information.
+Default is 'low' - see [NotifyUrgency](https://developer.gnome.org/notification-spec/#urgency-levels) for more information.
 
 #### `notification.actions`
 

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -37,6 +37,7 @@ Returns `Boolean` - Whether or not desktop notifications are supported on the cu
   * `hasReply` Boolean (optional) _macOS_ - Whether or not to add an inline reply option to the notification.
   * `replyPlaceholder` String (optional) _macOS_ - The placeholder to write in the inline reply input field.
   * `sound` String (optional) _macOS_ - The name of the sound file to play when the notification is shown.
+  * `urgency` String (optional) _Linux_ - The urgency level of the notification. Can be 'normal', 'critical', or 'low'.
   * `actions` [NotificationAction[]](structures/notification-action.md) (optional) _macOS_ - Actions to add to the notification. Please read the available actions and limitations in the `NotificationAction` documentation.
   * `closeButtonText` String (optional) _macOS_ - A custom title for the close button of an alert. An empty string will cause the default localized text to be used.
 
@@ -143,6 +144,12 @@ A `Boolean` property representing whether the notification is silent.
 #### `notification.hasReply`
 
 A `Boolean` property representing whether the notification has a reply action.
+
+#### `notification.urgency` _Linux_
+
+A `String` property representing the urgency level of the notification. Can be 'normal', 'critical', or 'low'.
+
+Default is 'low' - see [NotifyUrgency](https://developer.gnome.org/libnotify/unstable/NotifyNotification.html#notify-notification-set-urgency) for more information.
 
 #### `notification.actions`
 

--- a/shell/browser/api/atom_api_notification.cc
+++ b/shell/browser/api/atom_api_notification.cc
@@ -68,6 +68,7 @@ Notification::Notification(v8::Isolate* isolate,
     }
     opts.Get("silent", &silent_);
     opts.Get("replyPlaceholder", &reply_placeholder_);
+    opts.Get("urgency", &urgency_);
     opts.Get("hasReply", &has_reply_);
     opts.Get("actions", &actions_);
     opts.Get("sound", &sound_);
@@ -118,6 +119,10 @@ base::string16 Notification::GetSound() const {
   return sound_;
 }
 
+base::string16 Notification::GetUrgency() const {
+  return urgency_;
+}
+
 std::vector<electron::NotificationAction> Notification::GetActions() const {
   return actions_;
 }
@@ -153,6 +158,10 @@ void Notification::SetReplyPlaceholder(const base::string16& new_placeholder) {
 
 void Notification::SetSound(const base::string16& new_sound) {
   sound_ = new_sound;
+}
+
+void Notification::SetUrgency(const base::string16& new_urgency) {
+  urgency_ = new_urgency;
 }
 
 void Notification::SetActions(
@@ -211,6 +220,7 @@ void Notification::Show() {
       options.actions = actions_;
       options.sound = sound_;
       options.close_button_text = close_button_text_;
+      options.urgency = urgency_;
       notification_->Show(options);
     }
   }
@@ -238,6 +248,8 @@ void Notification::BuildPrototype(v8::Isolate* isolate,
                    &Notification::SetHasReply)
       .SetProperty("replyPlaceholder", &Notification::GetReplyPlaceholder,
                    &Notification::SetReplyPlaceholder)
+      .SetProperty("urgency", &Notification::GetUrgency,
+                   &Notification::SetUrgency)
       .SetProperty("sound", &Notification::GetSound, &Notification::SetSound)
       .SetProperty("actions", &Notification::GetActions,
                    &Notification::SetActions)

--- a/shell/browser/api/atom_api_notification.h
+++ b/shell/browser/api/atom_api_notification.h
@@ -54,6 +54,7 @@ class Notification : public mate::TrackableObject<Notification>,
   bool GetSilent() const;
   bool GetHasReply() const;
   base::string16 GetReplyPlaceholder() const;
+  base::string16 GetUrgency() const;
   base::string16 GetSound() const;
   std::vector<electron::NotificationAction> GetActions() const;
   base::string16 GetCloseButtonText() const;
@@ -64,6 +65,7 @@ class Notification : public mate::TrackableObject<Notification>,
   void SetBody(const base::string16& new_body);
   void SetSilent(bool new_silent);
   void SetHasReply(bool new_has_reply);
+  void SetUrgency(const base::string16& new_urgency);
   void SetReplyPlaceholder(const base::string16& new_reply_placeholder);
   void SetSound(const base::string16& sound);
   void SetActions(const std::vector<electron::NotificationAction>& actions);
@@ -80,6 +82,7 @@ class Notification : public mate::TrackableObject<Notification>,
   bool has_reply_ = false;
   base::string16 reply_placeholder_;
   base::string16 sound_;
+  base::string16 urgency_;
   std::vector<electron::NotificationAction> actions_;
   base::string16 close_button_text_;
 

--- a/shell/browser/notifications/linux/libnotify_notification.cc
+++ b/shell/browser/notifications/linux/libnotify_notification.cc
@@ -100,6 +100,16 @@ void LibnotifyNotification::Show(const NotificationOptions& options) {
         nullptr);
   }
 
+  NotifyUrgency urgency = NOTIFY_URGENCY_NORMAL;
+  if (options.urgency == base::ASCIIToUTF16("critical")) {
+    urgency = NOTIFY_URGENCY_CRITICAL;
+  } else if (options.urgency == base::ASCIIToUTF16("low")) {
+    urgency = NOTIFY_URGENCY_LOW;
+  }
+
+  // Set the urgency level of the notification.
+  libnotify_loader_.notify_notification_set_urgency(notification_, urgency);
+
   if (!options.icon.drawsNothing()) {
     GdkPixbuf* pixbuf = libgtkui::GdkPixbufFromSkBitmap(options.icon);
     libnotify_loader_.notify_notification_set_image_from_pixbuf(notification_,

--- a/shell/browser/notifications/notification.h
+++ b/shell/browser/notifications/notification.h
@@ -34,6 +34,7 @@ struct NotificationOptions {
   bool has_reply;
   base::string16 reply_placeholder;
   base::string16 sound;
+  base::string16 urgency;  // Linux
   std::vector<NotificationAction> actions;
   base::string16 close_button_text;
 

--- a/spec-main/api-notification-dbus-spec.ts
+++ b/spec-main/api-notification-dbus-spec.ts
@@ -116,7 +116,8 @@ ifdescribe(!skip)('Notification module (dbus)', () => {
         actions: [],
         hints: {
           'append': 'true',
-          'desktop-entry': appName
+          'desktop-entry': appName,
+          'urgency': 1
         }
       })
     })


### PR DESCRIPTION
#### Description of Change

Enable users to customize the [`urgency`](https://developer.gnome.org/libnotify/unstable/NotifyNotification.html#notify-notification-set-urgency) levels of Linux notifications. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added an `urgency` property to allow customization of Linux-based notifications.
