### PR TITLE
build: specific line number(s) with trailing whitespace

### DIFF
--- a/script/check-trailing-whitespace.py
+++ b/script/check-trailing-whitespace.py
@@ -46,10 +46,10 @@ def hasTrailingWhiteSpace(filepath, fix):
     f.close()
 
   fixed_lines = []
-  for line in lines:
+  for num, line in enumerate(lines):
     fixed_lines.append(line.rstrip() + '\n')
     if not fix and line != line.rstrip():
-      print("Trailing whitespace in: " + filepath)
+      print("Trailing whitespace on line {} in file: {}".format(num + 1, filepath))
       return True
   if fix:
     with open(filepath, 'w') as f:


### PR DESCRIPTION
#### Description of Change

Specify the lines with trailing whitespace in a given markdown file. This prevents us from hunting around with a proverbial flashlight in the darkness uselessly struggling to find the One Extra Space.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
