### PR TITLE
fix: free screen capturers immediately after we're finished with them

### DIFF
--- a/shell/browser/api/atom_api_desktop_capturer.cc
+++ b/shell/browser/api/atom_api_desktop_capturer.cc
@@ -144,6 +144,7 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
     }
     std::move(window_sources.begin(), window_sources.end(),
               std::back_inserter(captured_sources_));
+    window_capturer_.reset();
   }
 
   if (capture_screen_ &&
@@ -194,6 +195,7 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
     // individual screen support is added.
     std::move(screen_sources.begin(), screen_sources.end(),
               std::back_inserter(captured_sources_));
+    screen_capturer_.reset();
   }
 
   if (!capture_window_ && !capture_screen_)


### PR DESCRIPTION
#### Description of Change
Fixes #17937 and #19908 

Originally fixed in #10223, but regressed in #14835, the fix here is to make sure our one-shot DesktopCapturer class destroys its `DesktopMediaList` instances (which in turn hold the real capturers) after it finishes gathering the thumbnails. If you'll recall, we use `DesktopMediaList` in a way that's different from Chrome; theirs is longer lived and capable of updating the thumbnails, ours is single-use, with the periodic thumbnail update overridden in a patch.

For good hygiene, we now send the reference to the cpp DesktopCapturer out to pasture after we're done with it (although after this change, a leak of DesktopCapturer would be much less costly, given the `DesktopMediaList`s are being reset).
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed desktopCapturer leak.
<!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
