### PR TITLE
refactor: apply some 'clang-tidy -fix' changes

### DIFF
--- a/shell/app/atom_content_client.cc
+++ b/shell/app/atom_content_client.cc
@@ -101,29 +101,27 @@ content::PepperPluginInfo CreatePepperFlashInfo(const base::FilePath& path,
   std::vector<std::string> flash_version_numbers = base::SplitString(
       version, ".", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
   if (flash_version_numbers.empty())
-    flash_version_numbers.push_back("11");
+    flash_version_numbers.emplace_back("11");
   // |SplitString()| puts in an empty string given an empty string. :(
   else if (flash_version_numbers[0].empty())
     flash_version_numbers[0] = "11";
   if (flash_version_numbers.size() < 2)
-    flash_version_numbers.push_back("2");
+    flash_version_numbers.emplace_back("2");
   if (flash_version_numbers.size() < 3)
-    flash_version_numbers.push_back("999");
+    flash_version_numbers.emplace_back("999");
   if (flash_version_numbers.size() < 4)
-    flash_version_numbers.push_back("999");
+    flash_version_numbers.emplace_back("999");
   // E.g., "Shockwave Flash 10.2 r154":
   plugin.description = plugin.name + " " + flash_version_numbers[0] + "." +
                        flash_version_numbers[1] + " r" +
                        flash_version_numbers[2];
   plugin.version = base::JoinString(flash_version_numbers, ".");
-  content::WebPluginMimeType swf_mime_type(content::kFlashPluginSwfMimeType,
-                                           content::kFlashPluginSwfExtension,
-                                           content::kFlashPluginSwfDescription);
-  plugin.mime_types.push_back(swf_mime_type);
-  content::WebPluginMimeType spl_mime_type(content::kFlashPluginSplMimeType,
-                                           content::kFlashPluginSplExtension,
-                                           content::kFlashPluginSplDescription);
-  plugin.mime_types.push_back(spl_mime_type);
+  plugin.mime_types.emplace_back(content::kFlashPluginSwfMimeType,
+                                 content::kFlashPluginSwfExtension,
+                                 content::kFlashPluginSwfDescription);
+  plugin.mime_types.emplace_back(content::kFlashPluginSplMimeType,
+                                 content::kFlashPluginSplExtension,
+                                 content::kFlashPluginSplDescription);
 
   return plugin;
 }
@@ -219,8 +217,8 @@ void AtomContentClient::AddAdditionalSchemes(Schemes* schemes) {
   AppendDelimitedSwitchToVector(switches::kCORSSchemes,
                                 &schemes->cors_enabled_schemes);
 
-  schemes->service_worker_schemes.push_back(url::kFileScheme);
-  schemes->standard_schemes.push_back("chrome-extension");
+  schemes->service_worker_schemes.emplace_back(url::kFileScheme);
+  schemes->standard_schemes.emplace_back("chrome-extension");
 }
 
 void AtomContentClient::AddPepperPlugins(

--- a/shell/browser/api/atom_api_app.cc
+++ b/shell/browser/api/atom_api_app.cc
@@ -751,7 +751,7 @@ base::OnceClosure App::SelectClientCertificate(
   // to avoid changes in the API.
   auto client_certs = net::CertificateList();
   for (const std::unique_ptr<net::ClientCertIdentity>& identity : identities)
-    client_certs.push_back(identity->certificate());
+    client_certs.emplace_back(identity->certificate());
 
   auto shared_identities =
       std::make_shared<net::ClientCertIdentityList>(std::move(identities));

--- a/shell/browser/api/atom_api_screen.cc
+++ b/shell/browser/api/atom_api_screen.cc
@@ -42,13 +42,13 @@ typename T::iterator FindById(T* container, int id) {
 std::vector<std::string> MetricsToArray(uint32_t metrics) {
   std::vector<std::string> array;
   if (metrics & display::DisplayObserver::DISPLAY_METRIC_BOUNDS)
-    array.push_back("bounds");
+    array.emplace_back("bounds");
   if (metrics & display::DisplayObserver::DISPLAY_METRIC_WORK_AREA)
-    array.push_back("workArea");
+    array.emplace_back("workArea");
   if (metrics & display::DisplayObserver::DISPLAY_METRIC_DEVICE_SCALE_FACTOR)
-    array.push_back("scaleFactor");
+    array.emplace_back("scaleFactor");
   if (metrics & display::DisplayObserver::DISPLAY_METRIC_ROTATION)
-    array.push_back("rotation");
+    array.emplace_back("rotation");
   return array;
 }
 

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -1719,9 +1719,9 @@ void WebContents::Print(mate::Arguments* args) {
   std::vector<mate::Dictionary> page_ranges;
   if (options.Get("pageRanges", &page_ranges)) {
     std::unique_ptr<base::ListValue> page_range_list(new base::ListValue());
-    for (size_t i = 0; i < page_ranges.size(); ++i) {
+    for (auto& range : page_ranges) {
       int from, to;
-      if (page_ranges[i].Get("from", &from) && page_ranges[i].Get("to", &to)) {
+      if (range.Get("from", &from) && range.Get("to", &to)) {
         std::unique_ptr<base::DictionaryValue> range(
             new base::DictionaryValue());
         range->SetInteger(printing::kSettingPageRangeFrom, from);

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -248,7 +248,7 @@ struct Converter<electron::api::WebContents::Type> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    electron::api::WebContents::Type val) {
     using Type = electron::api::WebContents::Type;
-    std::string type = "";
+    std::string type;
     switch (val) {
       case Type::BACKGROUND_PAGE:
         type = "backgroundPage";

--- a/shell/browser/atom_javascript_dialog_manager.cc
+++ b/shell/browser/atom_javascript_dialog_manager.cc
@@ -67,7 +67,7 @@ void AtomJavaScriptDialogManager::RunJavaScriptDialog(
 
   std::vector<std::string> buttons = {"OK"};
   if (dialog_type == JavaScriptDialogType::JAVASCRIPT_DIALOG_TYPE_CONFIRM) {
-    buttons.push_back("Cancel");
+    buttons.emplace_back("Cancel");
     // First button is default, second button is cancel
     default_id = 0;
     cancel_id = 1;

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -32,7 +32,7 @@ bool LaunchXdgUtility(const std::vector<std::string>& argv, int* exit_code) {
     return false;
 
   base::LaunchOptions options;
-  options.fds_to_remap.push_back(std::make_pair(devnull, STDIN_FILENO));
+  options.fds_to_remap.emplace_back(devnull, STDIN_FILENO);
 
   base::Process process = base::LaunchProcess(argv, options);
   close(devnull);
@@ -46,10 +46,10 @@ bool SetDefaultWebClient(const std::string& protocol) {
   std::unique_ptr<base::Environment> env(base::Environment::Create());
 
   std::vector<std::string> argv;
-  argv.push_back(kXdgSettings);
-  argv.push_back("set");
+  argv.emplace_back(kXdgSettings);
+  argv.emplace_back("set");
   if (!protocol.empty()) {
-    argv.push_back(kXdgSettingsDefaultSchemeHandler);
+    argv.emplace_back(kXdgSettingsDefaultSchemeHandler);
     argv.push_back(protocol);
   }
   argv.push_back(libgtkui::GetDesktopName(env.get()));
@@ -88,9 +88,9 @@ bool Browser::IsDefaultProtocolClient(const std::string& protocol,
     return false;
 
   std::vector<std::string> argv;
-  argv.push_back(kXdgSettings);
-  argv.push_back("check");
-  argv.push_back(kXdgSettingsDefaultSchemeHandler);
+  argv.emplace_back(kXdgSettings);
+  argv.emplace_back("check");
+  argv.emplace_back(kXdgSettingsDefaultSchemeHandler);
   argv.push_back(protocol);
   argv.push_back(libgtkui::GetDesktopName(env.get()));
 

--- a/shell/browser/lib/bluetooth_chooser.cc
+++ b/shell/browser/lib/bluetooth_chooser.cc
@@ -117,6 +117,7 @@ void BluetoothChooser::AddOrUpdateDevice(const std::string& device_id,
 std::vector<electron::BluetoothChooser::DeviceInfo>
 BluetoothChooser::GetDeviceList() {
   std::vector<electron::BluetoothChooser::DeviceInfo> vec;
+  vec.reserve(device_map_.size());
   for (const auto& it : device_map_) {
     DeviceInfo info = {it.first, it.second};
     vec.push_back(info);

--- a/shell/browser/media/media_stream_devices_controller.cc
+++ b/shell/browser/media/media_stream_devices_controller.cc
@@ -170,19 +170,19 @@ void MediaStreamDevicesController::HandleUserMediaRequest() {
 
   if (request_.audio_type ==
       blink::mojom::MediaStreamType::GUM_TAB_AUDIO_CAPTURE) {
-    devices.push_back(blink::MediaStreamDevice(
-        blink::mojom::MediaStreamType::GUM_TAB_AUDIO_CAPTURE, "", ""));
+    devices.emplace_back(blink::mojom::MediaStreamType::GUM_TAB_AUDIO_CAPTURE,
+                         "", "");
   }
   if (request_.video_type ==
       blink::mojom::MediaStreamType::GUM_TAB_VIDEO_CAPTURE) {
-    devices.push_back(blink::MediaStreamDevice(
-        blink::mojom::MediaStreamType::GUM_TAB_VIDEO_CAPTURE, "", ""));
+    devices.emplace_back(blink::mojom::MediaStreamType::GUM_TAB_VIDEO_CAPTURE,
+                         "", "");
   }
   if (request_.audio_type ==
       blink::mojom::MediaStreamType::GUM_DESKTOP_AUDIO_CAPTURE) {
-    devices.push_back(blink::MediaStreamDevice(
+    devices.emplace_back(
         blink::mojom::MediaStreamType::GUM_DESKTOP_AUDIO_CAPTURE, "loopback",
-        "System Audio"));
+        "System Audio");
   }
   if (request_.video_type ==
       blink::mojom::MediaStreamType::GUM_DESKTOP_VIDEO_CAPTURE) {
@@ -197,9 +197,9 @@ void MediaStreamDevicesController::HandleUserMediaRequest() {
           content::DesktopMediaID::Parse(request_.requested_video_device_id);
     }
 
-    devices.push_back(blink::MediaStreamDevice(
+    devices.emplace_back(
         blink::mojom::MediaStreamType::GUM_DESKTOP_VIDEO_CAPTURE,
-        screen_id.ToString(), "Screen"));
+        screen_id.ToString(), "Screen");
   }
 
   std::move(callback_).Run(

--- a/shell/browser/net/resolve_proxy_helper.cc
+++ b/shell/browser/net/resolve_proxy_helper.cc
@@ -33,7 +33,7 @@ void ResolveProxyHelper::ResolveProxy(const GURL& url,
                                       ResolveProxyCallback callback) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
   // Enqueue the pending request.
-  pending_requests_.push_back(PendingRequest(url, std::move(callback)));
+  pending_requests_.emplace_back(url, std::move(callback));
 
   // If nothing is in progress, start.
   if (!binding_.is_bound()) {

--- a/shell/browser/relauncher_linux.cc
+++ b/shell/browser/relauncher_linux.cc
@@ -61,8 +61,8 @@ int LaunchProgram(const StringVector& relauncher_args,
   base::LaunchOptions options;
   options.allow_new_privs = true;
   options.new_process_group = true;  // detach
-  options.fds_to_remap.push_back(std::make_pair(devnull.get(), STDERR_FILENO));
-  options.fds_to_remap.push_back(std::make_pair(devnull.get(), STDOUT_FILENO));
+  options.fds_to_remap.emplace_back(devnull.get(), STDERR_FILENO);
+  options.fds_to_remap.emplace_back(devnull.get(), STDOUT_FILENO);
 
   base::Process process = base::LaunchProcess(argv, options);
   return process.IsValid() ? 0 : 1;

--- a/shell/browser/ui/drag_util_views.cc
+++ b/shell/browser/ui/drag_util_views.cc
@@ -28,6 +28,7 @@ void DragFileItems(const std::vector<base::FilePath>& files,
       *views::Widget::GetTopLevelWidgetForNativeView(view), data.get());
 
   std::vector<ui::FileInfo> file_infos;
+  file_infos.reserve(files.size());
   for (const base::FilePath& file : files) {
     file_infos.push_back(ui::FileInfo(file, base::FilePath()));
   }

--- a/shell/browser/ui/drag_util_views.cc
+++ b/shell/browser/ui/drag_util_views.cc
@@ -30,7 +30,7 @@ void DragFileItems(const std::vector<base::FilePath>& files,
   std::vector<ui::FileInfo> file_infos;
   file_infos.reserve(files.size());
   for (const base::FilePath& file : files) {
-    file_infos.push_back(ui::FileInfo(file, base::FilePath()));
+    file_infos.emplace_back(file, base::FilePath());
   }
   data->SetFilenames(file_infos);
 

--- a/shell/browser/ui/file_dialog_gtk.cc
+++ b/shell/browser/ui/file_dialog_gtk.cc
@@ -229,13 +229,11 @@ void FileChooserDialog::OnFileDialogResponse(GtkWidget* widget, int response) {
 }
 
 void FileChooserDialog::AddFilters(const Filters& filters) {
-  for (size_t i = 0; i < filters.size(); ++i) {
-    const Filter& filter = filters[i];
+  for (const auto& filter : filters) {
     GtkFileFilter* gtk_filter = gtk_file_filter_new();
 
-    for (size_t j = 0; j < filter.second.size(); ++j) {
-      auto file_extension =
-          std::make_unique<std::string>("." + filter.second[j]);
+    for (const auto& extension : filter.second) {
+      auto file_extension = std::make_unique<std::string>("." + extension);
       gtk_file_filter_add_custom(
           gtk_filter, GTK_FILE_FILTER_FILENAME,
           reinterpret_cast<GtkFileFilterFunc>(FileFilterCaseInsensitive),

--- a/shell/browser/ui/file_dialog_win.cc
+++ b/shell/browser/ui/file_dialog_win.cc
@@ -48,16 +48,14 @@ void ConvertFilters(const Filters& filters,
   }
 
   buffer->reserve(filters.size() * 2);
-  for (size_t i = 0; i < filters.size(); ++i) {
-    const Filter& filter = filters[i];
-
+  for (const Filter& filter : filters) {
     COMDLG_FILTERSPEC spec;
     buffer->push_back(base::UTF8ToWide(filter.first));
     spec.pszName = buffer->back().c_str();
 
     std::vector<std::string> extensions(filter.second);
-    for (size_t j = 0; j < extensions.size(); ++j)
-      extensions[j].insert(0, "*.");
+    for (std::string& extension : extensions)
+      extension.insert(0, "*.");
     buffer->push_back(base::UTF8ToWide(base::JoinString(extensions, ";")));
     spec.pszSpec = buffer->back().c_str();
 

--- a/shell/browser/ui/views/menu_bar.cc
+++ b/shell/browser/ui/views/menu_bar.cc
@@ -159,9 +159,8 @@ bool MenuBar::AcceleratorPressed(const ui::Accelerator& accelerator) {
           views::FocusManager::FocusChangeReason::kFocusTraversal);
       return true;
     default: {
-      auto children = GetChildrenInZOrder();
-      for (int i = 0, n = children.size(); i < n; ++i) {
-        auto* button = static_cast<SubmenuButton*>(children[i]);
+      for (auto* child : GetChildrenInZOrder()) {
+        auto* button = static_cast<SubmenuButton*>(child);
         bool shifted = false;
         auto keycode =
             electron::KeyboardCodeFromCharCode(button->accelerator(), &shifted);
@@ -204,10 +203,9 @@ bool MenuBar::SetPaneFocus(views::View* initial_focus) {
   bool result = views::AccessiblePaneView::SetPaneFocus(initial_focus);
 
   if (result) {
-    auto children = GetChildrenInZOrder();
     std::set<ui::KeyboardCode> reg;
-    for (int i = 0, n = children.size(); i < n; ++i) {
-      auto* button = static_cast<SubmenuButton*>(children[i]);
+    for (auto* child : GetChildrenInZOrder()) {
+      auto* button = static_cast<SubmenuButton*>(child);
       bool shifted = false;
       auto keycode =
           electron::KeyboardCodeFromCharCode(button->accelerator(), &shifted);
@@ -235,10 +233,9 @@ void MenuBar::RemovePaneFocus() {
   views::AccessiblePaneView::RemovePaneFocus();
   SetAcceleratorVisibility(false);
 
-  auto children = GetChildrenInZOrder();
   std::set<ui::KeyboardCode> unreg;
-  for (int i = 0, n = children.size(); i < n; ++i) {
-    auto* button = static_cast<SubmenuButton*>(children[i]);
+  for (auto* child : GetChildrenInZOrder()) {
+    auto* button = static_cast<SubmenuButton*>(child);
     bool shifted = false;
     auto keycode =
         electron::KeyboardCodeFromCharCode(button->accelerator(), &shifted);

--- a/shell/browser/web_dialog_helper.cc
+++ b/shell/browser/web_dialog_helper.cc
@@ -282,7 +282,7 @@ file_dialog::Filters GetFileTypesFromAcceptType(
   // Allow all files when extension is specified.
   filters.push_back(file_dialog::Filter());
   filters.back().first = "All Files";
-  filters.back().second.push_back("*");
+  filters.back().second.emplace_back("*");
 
   return filters;
 }

--- a/shell/common/crash_reporter/crash_reporter.cc
+++ b/shell/common/crash_reporter/crash_reporter.cc
@@ -93,8 +93,7 @@ CrashReporter::GetUploadedReports(const base::FilePath& crashes_dir) {
       int report_time = 0;
       if (report_item.size() >= 2 &&
           base::StringToInt(report_item[0], &report_time)) {
-        result.push_back(
-            CrashReporter::UploadReportResult(report_time, report_item[1]));
+        result.emplace_back(report_time, report_item[1]);
       }
     }
   }

--- a/shell/common/native_mate_converters/content_converter.cc
+++ b/shell/common/native_mate_converters/content_converter.cc
@@ -66,6 +66,7 @@ v8::Local<v8::Value> MenuToV8(v8::Isolate* isolate,
                               const content::CustomContextMenuContext& context,
                               const std::vector<content::MenuItem>& menu) {
   std::vector<v8::Local<v8::Value>> v8_menu;
+  v8_menu.reserve(menu.size());
   for (const auto& menu_item : menu)
     v8_menu.push_back(MenuItemToV8(isolate, web_contents, context, menu_item));
   return mate::ConvertToV8(isolate, v8_menu);

--- a/shell/renderer/api/atom_api_web_frame.cc
+++ b/shell/renderer/api/atom_api_web_frame.cc
@@ -96,7 +96,7 @@ content::RenderFrame* GetRenderFrame(v8::Local<v8::Value> value) {
   return content::RenderFrame::FromWebFrame(frame);
 }
 
-class RenderFrameStatus : public content::RenderFrameObserver {
+class RenderFrameStatus final : public content::RenderFrameObserver {
  public:
   explicit RenderFrameStatus(content::RenderFrame* render_frame)
       : content::RenderFrameObserver(render_frame) {}
@@ -165,7 +165,7 @@ class FrameSetSpellChecker : public content::RenderFrameVisitor {
   DISALLOW_COPY_AND_ASSIGN(FrameSetSpellChecker);
 };
 
-class SpellCheckerHolder : public content::RenderFrameObserver {
+class SpellCheckerHolder final : public content::RenderFrameObserver {
  public:
   // Find existing holder for the |render_frame|.
   static SpellCheckerHolder* FromRenderFrame(

--- a/shell/renderer/atom_autofill_agent.cc
+++ b/shell/renderer/atom_autofill_agent.cc
@@ -43,9 +43,9 @@ void TrimStringVectorForIPC(std::vector<base::string16>* strings) {
     strings->resize(kMaxListSize);
 
   // Limit the size of the strings in the vector.
-  for (size_t i = 0; i < strings->size(); ++i) {
-    if ((*strings)[i].length() > kMaxDataLength)
-      (*strings)[i].resize(kMaxDataLength);
+  for (auto& str : *strings) {
+    if (str.length() > kMaxDataLength)
+      str.resize(kMaxDataLength);
   }
 }
 }  // namespace


### PR DESCRIPTION
#### Description of Change

I spent some time on the plane experimenting with getting Chromium's clang-tidy runner working. This PR applies the fixes generated by running a handful of clang-tidy checks on Electron. There is some amount of human intervention, e.g. clang-tidy made this change, e.g.:

```diff
-    for (size_t j = 0; j < filter.second.size(); ++j) { // original line
+    for (const auto & j : filter.second) {              // clang-tidy's version
+    for (const auto& extension : filter.second) {       // PR version
```
clang-tidy checks in this PR:
 - performance-inefficient-vector-operation
 - modernize-use-emplace
 - modernize-loop-convert
 - readability-redundant-string-init

clang-tidy has more checks in this same vein, so I'd welcome feedback from maintainers on whether there's interest in these kinds of refactors or whether they're too linty.

CC'ing @codebytere since clang-tidy's `modernize-` checks may be tangentally interesting to her.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes