### PR TITLE
fix: remote.protocol.{register|intercept}StreamProtocol can work now under certain conditions

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -15,6 +15,7 @@ const ipcMainUtils = require('@electron/internal/browser/ipc-main-internal-utils
 const objectsRegistry = require('@electron/internal/browser/objects-registry')
 const guestViewManager = require('@electron/internal/browser/guest-view-manager')
 const bufferUtils = require('@electron/internal/common/buffer-utils')
+const streamUtils = require('@electron/internal/common/readable-stream-utils')
 const errorUtils = require('@electron/internal/common/error-utils')
 const clipboardUtils = require('@electron/internal/common/clipboard-utils')
 const { isPromise } = require('@electron/internal/common/is-promise')
@@ -188,6 +189,8 @@ const unwrapArgs = function (sender, frameId, contextId, args) {
         return unwrapArgs(sender, frameId, contextId, meta.value)
       case 'buffer':
         return bufferUtils.metaToBuffer(meta.value)
+      case 'readable-stream':
+        return streamUtils.metaToReadableStream(meta.value)
       case 'date':
         return new Date(meta.value)
       case 'promise':

--- a/lib/common/readable-stream-utils.ts
+++ b/lib/common/readable-stream-utils.ts
@@ -1,4 +1,4 @@
-import { Readable, PassThrough, Duplex, Transform } from 'stream';
+import { Readable, PassThrough, Duplex, Transform } from 'stream'
 
 type ReadableStreamLike = Readable | Duplex | Transform | PassThrough
 type Base64String = string
@@ -8,10 +8,11 @@ export function isReadableStream (value: ReadableStreamLike): boolean {
 }
 
 export function readableStreamToMeta (value: ReadableStreamLike): Base64String {
-  let buffer = Buffer.from('');
-  let chunk;
-  while (chunk = value.read()) {
+  let buffer = Buffer.from('')
+  let chunk = value.read()
+  while (chunk) {
     buffer = Buffer.concat([buffer, chunk])
+    chunk = value.read()
   }
   return buffer.toString('base64')
 }

--- a/lib/common/readable-stream-utils.ts
+++ b/lib/common/readable-stream-utils.ts
@@ -1,0 +1,24 @@
+import { Readable, PassThrough, Duplex, Transform } from 'stream';
+
+type ReadableStreamLike = Readable | Duplex | Transform | PassThrough
+type Base64String = string
+
+export function isReadableStream (value: ReadableStreamLike): boolean {
+  return value instanceof Readable && value.readable
+}
+
+export function readableStreamToMeta (value: ReadableStreamLike): Base64String {
+  let buffer = Buffer.from('');
+  let chunk;
+  while (chunk = value.read()) {
+    buffer = Buffer.concat([buffer, chunk])
+  }
+  return buffer.toString('base64')
+}
+
+export function metaToReadableStream (value: Base64String): ReadableStreamLike {
+  const stream = new PassThrough()
+  stream.push(Buffer.from(value, 'base64'))
+  stream.push(null)
+  return stream
+}

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -4,6 +4,7 @@ const v8Util = process.electronBinding('v8_util')
 
 const { CallbacksRegistry } = require('@electron/internal/renderer/callbacks-registry')
 const bufferUtils = require('@electron/internal/common/buffer-utils')
+const streamUtils = require('@electron/internal/common/readable-stream-utils')
 const errorUtils = require('@electron/internal/common/error-utils')
 const { isPromise } = require('@electron/internal/common/is-promise')
 const { ipcRendererInternal } = require('@electron/internal/renderer/ipc-renderer-internal')
@@ -46,6 +47,11 @@ function wrapArgs (args, visited = new Set()) {
       return {
         type: 'buffer',
         value: bufferUtils.bufferToMeta(value)
+      }
+    } else if (streamUtils.isReadableStream(value)) {
+      return {
+        type: 'readable-stream',
+        value: streamUtils.readableStreamToMeta(value)
       }
     } else if (value instanceof Date) {
       return {


### PR DESCRIPTION
#### Description of Change
For issue #17059
`remote.protocol.{register|intercept}StreamProtocol` not work.
This commit wont fix all the case because the `remote ipc` is sync but `stream` is async.
At least `remote.{register|intercept}StreamProtocol` can work under certain conditions now.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed remote stream protocol now working
