### PR TITLE
build: handle arm64 node headers

### DIFF
--- a/script/release/uploaders/upload-node-headers.py
+++ b/script/release/uploaders/upload-node-headers.py
@@ -56,7 +56,7 @@ def upload_node(bucket, access_key, secret_key, version):
       iojs_lib = os.path.join(DIST_DIR, 'win-x86', 'iojs.lib')
       v4_node_lib = os.path.join(DIST_DIR, 'win-x86', 'node.lib')
     elif get_target_arch() == 'arm64':
-      node_lib = os.path.join(DIST_DIR, 'node.lib')
+      node_lib = os.path.join(DIST_DIR, 'arm64', 'node.lib')
       iojs_lib = os.path.join(DIST_DIR, 'win-arm64', 'iojs.lib')
       v4_node_lib = os.path.join(DIST_DIR, 'win-arm64', 'node.lib')   
     else:

--- a/script/release/uploaders/upload-node-headers.py
+++ b/script/release/uploaders/upload-node-headers.py
@@ -55,6 +55,10 @@ def upload_node(bucket, access_key, secret_key, version):
       node_lib = os.path.join(DIST_DIR, 'node.lib')
       iojs_lib = os.path.join(DIST_DIR, 'win-x86', 'iojs.lib')
       v4_node_lib = os.path.join(DIST_DIR, 'win-x86', 'node.lib')
+    elif get_target_arch() == 'arm64':
+      node_lib = os.path.join(DIST_DIR, 'node.lib')
+      iojs_lib = os.path.join(DIST_DIR, 'win-arm64', 'iojs.lib')
+      v4_node_lib = os.path.join(DIST_DIR, 'win-arm64', 'node.lib')   
     else:
       node_lib = os.path.join(DIST_DIR, 'x64', 'node.lib')
       iojs_lib = os.path.join(DIST_DIR, 'win-x64', 'iojs.lib')


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Make sure arm64 node headers get put in the right directories and do not override windows x64 files.  Resolves #20185

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->Fix node.lib linking issue
