### PR TITLE
docs: Update 'no-notes' reference

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,4 +18,4 @@ Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTIN
 
 #### Release Notes
 
-Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
+Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `Notes: none` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->


### PR DESCRIPTION
#### Description of Change

The tiniest of changes: The PR template mentions `no-notes`, but it's actually `Notes: none`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

`no-notes`