### PR TITLE
docs: improve and add examples for clipboard

### DIFF
--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -4,18 +4,12 @@
 
 Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process)
 
-The following example shows how to write a string to the clipboard:
-
-```javascript
-const { clipboard } = require('electron')
-clipboard.writeText('Example String')
-```
-
 On Linux, there is also a `selection` clipboard. To manipulate it
 you need to pass `selection` to each method:
 
 ```javascript
 const { clipboard } = require('electron')
+
 clipboard.writeText('Example String', 'selection')
 console.log(clipboard.readText('selection'))
 ```
@@ -28,55 +22,121 @@ The `clipboard` module has the following methods:
 
 ### `clipboard.readText([type])`
 
-* `type` String (optional) - Can be `selection` or `clipboard`. `selection` is only available on Linux.
+* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
 
 Returns `String` - The content in the clipboard as plain text.
+
+```js
+const { clipboard } = require('electron')
+
+clipboard.writeText('hello i am a bit of text!')
+
+const text = clipboard.readText()
+console.log(text)
+// hello i am a bit of text!'
+```
+
+**Note:** `selection` is only available on Linux.
 
 ### `clipboard.writeText(text[, type])`
 
 * `text` String
-* `type` String (optional) - Can be `selection` or `clipboard`. `selection` is only available on Linux.
+* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
 
 Writes the `text` into the clipboard as plain text.
 
+```js
+const { clipboard } = require('electron')
+
+const text = 'hello i am a bit of text!'
+clipboard.writeText(text)
+```
+
+**Note:** `selection` is only available on Linux.
+
 ### `clipboard.readHTML([type])`
 
-* `type` String (optional) - Can be `selection` or `clipboard`. `selection` is only available on Linux.
+* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
 
 Returns `String` - The content in the clipboard as markup.
+
+**Note:** `selection` is only available on Linux.
+
+```js
+const { clipboard } = require('electron')
+
+clipboard.writeHTML('<b>Hi</b>')
+const html = clipboard.readHTML()
+
+console.log(html)
+// <meta charset='utf-8'><b>Hi</b>
+```
 
 ### `clipboard.writeHTML(markup[, type])`
 
 * `markup` String
-* `type` String (optional) - Can be `selection` or `clipboard`. `selection` is only available on Linux.
+* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
 
 Writes `markup` to the clipboard.
 
+**Note:** `selection` is only available on Linux.
+
+```js
+const { clipboard } = require('electron')
+
+clipboard.writeHTML('<b>Hi</b')
+```
+
 ### `clipboard.readImage([type])`
 
-* `type` String (optional) - Can be `selection` or `clipboard`. `selection` is only available on Linux.
+* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
 
 Returns [`NativeImage`](native-image.md) - The image content in the clipboard.
+
+**Note:** `selection` is only available on Linux.
 
 ### `clipboard.writeImage(image[, type])`
 
 * `image` [NativeImage](native-image.md)
-* `type` String (optional) - Can be `selection` or `clipboard`. `selection` is only available on Linux.
+* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
 
 Writes `image` to the clipboard.
 
+**Note:** `selection` is only available on Linux.
+
 ### `clipboard.readRTF([type])`
 
-* `type` String (optional) - Can be `selection` or `clipboard`. `selection` is only available on Linux.
+* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
 
 Returns `String` - The content in the clipboard as RTF.
+
+**Note:** `selection` is only available on Linux.
+
+```js
+const { clipboard } = require('electron')
+
+clipboard.writeRTF('{\\rtf1\\ansi{\\fonttbl\\f0\\fswiss Helvetica;}\\f0\\pard\nThis is some {\\b bold} text.\\par\n}')
+
+const rtf = clipboard.readRTF()
+console.log(rtf)
+// {\\rtf1\\ansi{\\fonttbl\\f0\\fswiss Helvetica;}\\f0\\pard\nThis is some {\\b bold} text.\\par\n}
+```
 
 ### `clipboard.writeRTF(text[, type])`
 
 * `text` String
-* `type` String (optional) - Can be `selection` or `clipboard`. `selection` is only available on Linux.
+* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
 
 Writes the `text` into the clipboard in RTF.
+
+**Note:** `selection` is only available on Linux.
+
+```js
+const { clipboard } = require('electron')
+
+const rtf = '{\\rtf1\\ansi{\\fonttbl\\f0\\fswiss Helvetica;}\\f0\\pard\nThis is some {\\b bold} text.\\par\n}'
+clipboard.writeRTF(rtf)
+```
 
 ### `clipboard.readBookmark()` _macOS_ _Windows_
 
@@ -93,7 +153,7 @@ bookmark is unavailable.
 
 * `title` String
 * `url` String
-* `type` String (optional) - Can be `selection` or `clipboard`. `selection` is only available on Linux.
+* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
 
 Writes the `title` and `url` into the clipboard as a bookmark.
 
@@ -101,8 +161,12 @@ Writes the `title` and `url` into the clipboard as a bookmark.
 you can use `clipboard.write` to write both a bookmark and fallback text to the
 clipboard.
 
+**Note:** `selection` is only available on Linux.
+
 ```js
-clipboard.write({
+const { clipboard } = require('electron')
+
+clipboard.writeBookmark({
   text: 'https://electronjs.org',
   bookmark: 'Electron Homepage'
 })
@@ -110,39 +174,56 @@ clipboard.write({
 
 ### `clipboard.readFindText()` _macOS_
 
-Returns `String` - The text on the find pasteboard. This method uses synchronous
-IPC when called from the renderer process. The cached value is reread from the
-find pasteboard whenever the application is activated.
+Returns `String` - The text on the find pasteboard, which is the pasteboard that holds information about the current state of the active application’s find panel.
+
+This method uses synchronous IPC when called from the renderer process.
+The cached value is reread from the find pasteboard whenever the application is activated.
 
 ### `clipboard.writeFindText(text)` _macOS_
 
 * `text` String
 
-Writes the `text` into the find pasteboard as plain text. This method uses
-synchronous IPC when called from the renderer process.
+Writes the `text` into the find pasteboard (the pasteboard that holds information about the current state of the active application’s find panel) as plain text. This method uses synchronous IPC when called from the renderer process.
 
 ### `clipboard.clear([type])`
 
-* `type` String (optional) - Can be `selection` or `clipboard`. `selection` is only available on Linux.
+* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
 
 Clears the clipboard content.
 
+**Note:** `selection` is only available on Linux.
+
 ### `clipboard.availableFormats([type])`
 
-* `type` String (optional) - Can be `selection` or `clipboard`. `selection` is only available on Linux.
+* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
 
 Returns `String[]` - An array of supported formats for the clipboard `type`.
+
+**Note:** `selection` is only available on Linux.
+
+```js
+const { clipboard } = require('electron')
+
+const formats = clipboard.availableFormats()
+console.log(formats)
+// [ 'text/plain', 'text/html' ]
+```
 
 ### `clipboard.has(format[, type])` _Experimental_
 
 * `format` String
-* `type` String (optional) - Can be `selection` or `clipboard`. `selection` is only available on Linux.
+* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
 
 Returns `Boolean` - Whether the clipboard supports the specified `format`.
 
-```javascript
+**Note:** `selection` is only available on Linux.
+
+```js
 const { clipboard } = require('electron')
-console.log(clipboard.has('<p>selection</p>'))
+
+const hasFormat = clipboard.has('<p>selection</p>')
+console.log(hasFormat)
+// 'true' or 'false
 ```
 
 ### `clipboard.read(format)` _Experimental_
@@ -157,13 +238,36 @@ Returns `String` - Reads `format` type from the clipboard.
 
 Returns `Buffer` - Reads `format` type from the clipboard.
 
+```js
+const { clipboard } = require('electron')
+
+const buffer = Buffer.from('this is binary', 'utf8')
+clipboard.writeBuffer('public.utf8-plain-text', buffer)
+
+const ret =
+```
+
 ### `clipboard.writeBuffer(format, buffer[, type])` _Experimental_
 
 * `format` String
 * `buffer` Buffer
-* `type` String (optional) - Can be `selection` or `clipboard`. `selection` is only available on Linux.
+* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
 
 Writes the `buffer` into the clipboard as `format`.
+
+**Note:** `selection` is only available on Linux.
+
+```js
+const { clipboard } = require('electron')
+
+const buffer = Buffer.from('writeBuffer', 'utf8')
+clipboard.writeBuffer('public.utf8-plain-text', buffer)
+
+const out = clipboard.readBuffer('public.utf8-plain-text')
+
+console.log(buffer.equals(out))
+// true
+```
 
 ### `clipboard.write(data[, type])`
 
@@ -173,10 +277,31 @@ Writes the `buffer` into the clipboard as `format`.
   * `image` [NativeImage](native-image.md) (optional)
   * `rtf` String (optional)
   * `bookmark` String (optional) - The title of the URL at `text`.
-* `type` String (optional) - Can be `selection` or `clipboard`. `selection` is only available on Linux.
+* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
 
-```javascript
-const { clipboard } = require('electron')
-clipboard.write({ text: 'test', html: '<b>test</b>' })
-```
 Writes `data` to the clipboard.
+
+**Note:** `selection` is only available on Linux.
+
+```js
+const { clipboard } = require('electron')
+
+clipboard.write({
+  text: 'test',
+  html: '<b>Hi</b>',
+  rtf: '{\\rtf1\\utf8 text}',
+  bookmark: 'a title',
+})
+
+console.log(clipboard.readText())
+// 'test'
+
+console.log(clipboard.readHTML())
+// <meta charset='utf-8'><b>Hi</b>
+
+console.log(clipboard.readRTF())
+// '{\\rtf1\\utf8 text}'
+
+console.log(clipboard.readBookmark())
+// { title: 'a title', url: 'test' }
+```

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -22,7 +22,7 @@ The `clipboard` module has the following methods:
 
 ### `clipboard.readText([type])`
 
-* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
+* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Returns `String` - The content in the clipboard as plain text.
 
@@ -36,12 +36,10 @@ console.log(text)
 // hello i am a bit of text!'
 ```
 
-**Note:** `selection` is only available on Linux.
-
 ### `clipboard.writeText(text[, type])`
 
 * `text` String
-* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
+* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Writes the `text` into the clipboard as plain text.
 
@@ -52,15 +50,11 @@ const text = 'hello i am a bit of text!'
 clipboard.writeText(text)
 ```
 
-**Note:** `selection` is only available on Linux.
-
 ### `clipboard.readHTML([type])`
 
-* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
+* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Returns `String` - The content in the clipboard as markup.
-
-**Note:** `selection` is only available on Linux.
 
 ```js
 const { clipboard } = require('electron')
@@ -75,11 +69,9 @@ console.log(html)
 ### `clipboard.writeHTML(markup[, type])`
 
 * `markup` String
-* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
+* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Writes `markup` to the clipboard.
-
-**Note:** `selection` is only available on Linux.
 
 ```js
 const { clipboard } = require('electron')
@@ -89,28 +81,22 @@ clipboard.writeHTML('<b>Hi</b')
 
 ### `clipboard.readImage([type])`
 
-* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
+* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Returns [`NativeImage`](native-image.md) - The image content in the clipboard.
-
-**Note:** `selection` is only available on Linux.
 
 ### `clipboard.writeImage(image[, type])`
 
 * `image` [NativeImage](native-image.md)
-* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
+* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Writes `image` to the clipboard.
 
-**Note:** `selection` is only available on Linux.
-
 ### `clipboard.readRTF([type])`
 
-* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
+* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Returns `String` - The content in the clipboard as RTF.
-
-**Note:** `selection` is only available on Linux.
 
 ```js
 const { clipboard } = require('electron')
@@ -125,11 +111,9 @@ console.log(rtf)
 ### `clipboard.writeRTF(text[, type])`
 
 * `text` String
-* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
+* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Writes the `text` into the clipboard in RTF.
-
-**Note:** `selection` is only available on Linux.
 
 ```js
 const { clipboard } = require('electron')
@@ -153,15 +137,13 @@ bookmark is unavailable.
 
 * `title` String
 * `url` String
-* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
+* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Writes the `title` and `url` into the clipboard as a bookmark.
 
 **Note:** Most apps on Windows don't support pasting bookmarks into them so
 you can use `clipboard.write` to write both a bookmark and fallback text to the
 clipboard.
-
-**Note:** `selection` is only available on Linux.
 
 ```js
 const { clipboard } = require('electron')
@@ -187,19 +169,15 @@ Writes the `text` into the find pasteboard (the pasteboard that holds informatio
 
 ### `clipboard.clear([type])`
 
-* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
+* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Clears the clipboard content.
 
-**Note:** `selection` is only available on Linux.
-
 ### `clipboard.availableFormats([type])`
 
-* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
+* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Returns `String[]` - An array of supported formats for the clipboard `type`.
-
-**Note:** `selection` is only available on Linux.
 
 ```js
 const { clipboard } = require('electron')
@@ -212,11 +190,9 @@ console.log(formats)
 ### `clipboard.has(format[, type])` _Experimental_
 
 * `format` String
-* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
+* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Returns `Boolean` - Whether the clipboard supports the specified `format`.
-
-**Note:** `selection` is only available on Linux.
 
 ```js
 const { clipboard } = require('electron')
@@ -244,29 +220,25 @@ const { clipboard } = require('electron')
 const buffer = Buffer.from('this is binary', 'utf8')
 clipboard.writeBuffer('public.utf8-plain-text', buffer)
 
-const ret =
+const ret = clipboard.readBuffer('public.utf8-plain-text')
+
+console.log(buffer.equals(out))
+// true
 ```
 
 ### `clipboard.writeBuffer(format, buffer[, type])` _Experimental_
 
 * `format` String
 * `buffer` Buffer
-* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
+* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Writes the `buffer` into the clipboard as `format`.
-
-**Note:** `selection` is only available on Linux.
 
 ```js
 const { clipboard } = require('electron')
 
 const buffer = Buffer.from('writeBuffer', 'utf8')
 clipboard.writeBuffer('public.utf8-plain-text', buffer)
-
-const out = clipboard.readBuffer('public.utf8-plain-text')
-
-console.log(buffer.equals(out))
-// true
 ```
 
 ### `clipboard.write(data[, type])`
@@ -277,11 +249,9 @@ console.log(buffer.equals(out))
   * `image` [NativeImage](native-image.md) (optional)
   * `rtf` String (optional)
   * `bookmark` String (optional) - The title of the URL at `text`.
-* `type` String (optional) - Can be `selection` or `clipboard`. Default is 'clipboard'.
+* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Writes `data` to the clipboard.
-
-**Note:** `selection` is only available on Linux.
 
 ```js
 const { clipboard } = require('electron')
@@ -290,7 +260,7 @@ clipboard.write({
   text: 'test',
   html: '<b>Hi</b>',
   rtf: '{\\rtf1\\utf8 text}',
-  bookmark: 'a title',
+  bookmark: 'a title'
 })
 
 console.log(clipboard.readText())


### PR DESCRIPTION
#### Description of Change

Most lacked examples and some lacked contextual info. I've added that, and clarified some ambiguous terminology.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
