### PR TITLE
fix: strip chrome-sandbox typo

### DIFF
--- a/script/strip-binaries.py
+++ b/script/strip-binaries.py
@@ -8,7 +8,7 @@ from lib.util import execute, get_out_dir
 
 LINUX_BINARIES_TO_STRIP = [
   'electron',
-  'chrome_sandbox',
+  'chrome-sandbox',
   'libffmpeg.so',
   'libGLESv2.so',
   'libEGL.so',


### PR DESCRIPTION
#### Description of Change
Because of the typo in the script/strip-binaries.py file, we are not able to strip `chrome-sandbox` executable. Fixed the typo in this PR.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
