### PR TITLE
refactor: run clang-tidy

### DIFF
--- a/chromium_src/chrome/browser/certificate_manager_model.cc
+++ b/chromium_src/chrome/browser/certificate_manager_model.cc
@@ -86,7 +86,7 @@ CertificateManagerModel::CertificateManagerModel(
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
 }
 
-CertificateManagerModel::~CertificateManagerModel() {}
+CertificateManagerModel::~CertificateManagerModel() = default;
 
 int CertificateManagerModel::ImportFromPKCS12(
     PK11SlotInfo* slot_info,

--- a/chromium_src/chrome/browser/process_singleton_posix.cc
+++ b/chromium_src/chrome/browser/process_singleton_posix.cc
@@ -185,7 +185,7 @@ int WaitSocketForRead(int fd, const base::TimeDelta& timeout) {
   FD_ZERO(&read_fds);
   FD_SET(fd, &read_fds);
 
-  return HANDLE_EINTR(select(fd + 1, &read_fds, NULL, NULL, &tv));
+  return HANDLE_EINTR(select(fd + 1, &read_fds, nullptr, nullptr, &tv));
 }
 
 // Read a message from a socket fd, with an optional timeout.

--- a/native_mate/native_mate/converter.cc
+++ b/native_mate/native_mate/converter.cc
@@ -159,7 +159,7 @@ bool Converter<std::string>::FromV8(v8::Isolate* isolate,
   v8::Local<v8::String> str = v8::Local<v8::String>::Cast(val);
   int length = str->Utf8Length(isolate);
   out->resize(length);
-  str->WriteUtf8(isolate, &(*out)[0], length, NULL,
+  str->WriteUtf8(isolate, &(*out)[0], length, nullptr,
                  v8::String::NO_NULL_TERMINATION);
   return true;
 }

--- a/shell/app/atom_content_client.cc
+++ b/shell/app/atom_content_client.cc
@@ -179,9 +179,9 @@ void AppendDelimitedSwitchToVector(const base::StringPiece cmd_switch,
 
 }  // namespace
 
-AtomContentClient::AtomContentClient() {}
+AtomContentClient::AtomContentClient() = default;
 
-AtomContentClient::~AtomContentClient() {}
+AtomContentClient::~AtomContentClient() = default;
 
 base::string16 AtomContentClient::GetLocalizedString(int message_id) {
   return l10n_util::GetStringUTF16(message_id);

--- a/shell/app/atom_main_delegate.cc
+++ b/shell/app/atom_main_delegate.cc
@@ -283,12 +283,12 @@ void AtomMainDelegate::PreCreateMainMessageLoop() {
 }
 
 content::ContentBrowserClient* AtomMainDelegate::CreateContentBrowserClient() {
-  browser_client_.reset(new AtomBrowserClient);
+  browser_client_ = std::make_unique<AtomBrowserClient>();
   return browser_client_.get();
 }
 
 content::ContentGpuClient* AtomMainDelegate::CreateContentGpuClient() {
-  gpu_client_.reset(new AtomGpuClient);
+  gpu_client_ = std::make_unique<AtomGpuClient>();
   return gpu_client_.get();
 }
 
@@ -297,16 +297,16 @@ AtomMainDelegate::CreateContentRendererClient() {
   auto* command_line = base::CommandLine::ForCurrentProcess();
 
   if (IsSandboxEnabled(command_line)) {
-    renderer_client_.reset(new AtomSandboxedRendererClient);
+    renderer_client_ = std::make_unique<AtomSandboxedRendererClient>();
   } else {
-    renderer_client_.reset(new AtomRendererClient);
+    renderer_client_ = std::make_unique<AtomRendererClient>();
   }
 
   return renderer_client_.get();
 }
 
 content::ContentUtilityClient* AtomMainDelegate::CreateContentUtilityClient() {
-  utility_client_.reset(new AtomContentUtilityClient);
+  utility_client_ = std::make_unique<AtomContentUtilityClient>();
   return utility_client_.get();
 }
 

--- a/shell/app/atom_main_delegate.cc
+++ b/shell/app/atom_main_delegate.cc
@@ -126,9 +126,9 @@ void LoadResourceBundle(const std::string& locale) {
 #endif  // BUILDFLAG(ENABLE_PDF_VIEWER)
 }
 
-AtomMainDelegate::AtomMainDelegate() {}
+AtomMainDelegate::AtomMainDelegate() = default;
 
-AtomMainDelegate::~AtomMainDelegate() {}
+AtomMainDelegate::~AtomMainDelegate() = default;
 
 bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
   auto* command_line = base::CommandLine::ForCurrentProcess();

--- a/shell/browser/api/atom_api_app.cc
+++ b/shell/browser/api/atom_api_app.cc
@@ -941,9 +941,9 @@ std::string App::GetLocaleCountryCode() {
                      kCFStringEncodingUTF8);
   region = temporaryCString;
 #else
-  const char* locale_ptr = setlocale(LC_TIME, NULL);
+  const char* locale_ptr = setlocale(LC_TIME, nullptr);
   if (!locale_ptr)
-    locale_ptr = setlocale(LC_NUMERIC, NULL);
+    locale_ptr = setlocale(LC_NUMERIC, nullptr);
   if (locale_ptr) {
     std::string locale = locale_ptr;
     std::string::size_type rpos = locale.find('.');

--- a/shell/browser/api/atom_api_app.cc
+++ b/shell/browser/api/atom_api_app.cc
@@ -4,6 +4,8 @@
 
 #include "shell/browser/api/atom_api_app.h"
 
+#include <memory>
+
 #include <string>
 #include <vector>
 
@@ -977,8 +979,8 @@ bool App::RequestSingleInstanceLock() {
 
   auto cb = base::BindRepeating(&App::OnSecondInstance, base::Unretained(this));
 
-  process_singleton_.reset(new ProcessSingleton(
-      user_dir, base::BindRepeating(NotificationCallbackWrapper, cb)));
+  process_singleton_ = std::make_unique<ProcessSingleton>(
+      user_dir, base::BindRepeating(NotificationCallbackWrapper, cb));
 
   switch (process_singleton_->NotifyOtherProcessOrCreate()) {
     case ProcessSingleton::NotifyResult::LOCK_ERROR:

--- a/shell/browser/api/atom_api_cookies.cc
+++ b/shell/browser/api/atom_api_cookies.cc
@@ -167,7 +167,7 @@ Cookies::Cookies(v8::Isolate* isolate, AtomBrowserContext* browser_context)
                               base::Unretained(this)));
 }
 
-Cookies::~Cookies() {}
+Cookies::~Cookies() = default;
 
 v8::Local<v8::Promise> Cookies::Get(const base::DictionaryValue& filter) {
   util::Promise<net::CookieList> promise(isolate());

--- a/shell/browser/api/atom_api_debugger.cc
+++ b/shell/browser/api/atom_api_debugger.cc
@@ -27,7 +27,7 @@ Debugger::Debugger(v8::Isolate* isolate, content::WebContents* web_contents)
   Init(isolate);
 }
 
-Debugger::~Debugger() {}
+Debugger::~Debugger() = default;
 
 void Debugger::AgentHostClosed(DevToolsAgentHost* agent_host) {
   DCHECK(agent_host == agent_host_);

--- a/shell/browser/api/atom_api_desktop_capturer.cc
+++ b/shell/browser/api/atom_api_desktop_capturer.cc
@@ -90,18 +90,18 @@ void DesktopCapturer::StartHandling(bool capture_window,
     // Initialize the source list.
     // Apply the new thumbnail size and restart capture.
     if (capture_window) {
-      window_capturer_.reset(new NativeDesktopMediaList(
+      window_capturer_ = std::make_unique<NativeDesktopMediaList>(
           content::DesktopMediaID::TYPE_WINDOW,
-          content::desktop_capture::CreateWindowCapturer()));
+          content::desktop_capture::CreateWindowCapturer());
       window_capturer_->SetThumbnailSize(thumbnail_size);
       window_capturer_->AddObserver(this);
       window_capturer_->StartUpdating();
     }
 
     if (capture_screen) {
-      screen_capturer_.reset(new NativeDesktopMediaList(
+      screen_capturer_ = std::make_unique<NativeDesktopMediaList>(
           content::DesktopMediaID::TYPE_SCREEN,
-          content::desktop_capture::CreateScreenCapturer()));
+          content::desktop_capture::CreateScreenCapturer());
       screen_capturer_->SetThumbnailSize(thumbnail_size);
       screen_capturer_->AddObserver(this);
       screen_capturer_->StartUpdating();

--- a/shell/browser/api/atom_api_desktop_capturer.cc
+++ b/shell/browser/api/atom_api_desktop_capturer.cc
@@ -62,7 +62,7 @@ DesktopCapturer::DesktopCapturer(v8::Isolate* isolate) {
   Init(isolate);
 }
 
-DesktopCapturer::~DesktopCapturer() {}
+DesktopCapturer::~DesktopCapturer() = default;
 
 void DesktopCapturer::StartHandling(bool capture_window,
                                     bool capture_screen,

--- a/shell/browser/api/atom_api_menu_views.cc
+++ b/shell/browser/api/atom_api_menu_views.cc
@@ -51,7 +51,7 @@ void MenuViews::PopupAt(TopLevelWindow* window,
   menu_runners_[window_id] =
       std::make_unique<MenuRunner>(model(), flags, close_callback);
   menu_runners_[window_id]->RunMenuAt(
-      native_window->widget(), NULL, gfx::Rect(location, gfx::Size()),
+      native_window->widget(), nullptr, gfx::Rect(location, gfx::Size()),
       views::MenuAnchorPosition::kTopLeft, ui::MENU_SOURCE_MOUSE);
 }
 

--- a/shell/browser/api/atom_api_net.cc
+++ b/shell/browser/api/atom_api_net.cc
@@ -19,7 +19,7 @@ Net::Net(v8::Isolate* isolate) {
   Init(isolate);
 }
 
-Net::~Net() {}
+Net::~Net() = default;
 
 // static
 v8::Local<v8::Value> Net::Create(v8::Isolate* isolate) {

--- a/shell/browser/api/atom_api_power_save_blocker.cc
+++ b/shell/browser/api/atom_api_power_save_blocker.cc
@@ -49,7 +49,7 @@ PowerSaveBlocker::PowerSaveBlocker(v8::Isolate* isolate)
     : current_lock_type_(device::mojom::WakeLockType::kPreventAppSuspension),
       is_wake_lock_active_(false) {}
 
-PowerSaveBlocker::~PowerSaveBlocker() {}
+PowerSaveBlocker::~PowerSaveBlocker() = default;
 
 void PowerSaveBlocker::UpdatePowerSaveBlocker() {
   if (wake_lock_types_.empty()) {

--- a/shell/browser/api/atom_api_url_request_ns.cc
+++ b/shell/browser/api/atom_api_url_request_ns.cc
@@ -183,7 +183,7 @@ URLRequestNS::URLRequestNS(mate::Arguments* args) : weak_factory_(this) {
   InitWith(args->isolate(), args->GetThis());
 }
 
-URLRequestNS::~URLRequestNS() {}
+URLRequestNS::~URLRequestNS() = default;
 
 bool URLRequestNS::NotStarted() const {
   return request_state_ == 0;

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -387,8 +387,8 @@ WebContents::WebContents(v8::Isolate* isolate, const mate::Dictionary& options)
                                             GURL("chrome-guest://fake-host"));
     content::WebContents::CreateParams params(session->browser_context(),
                                               site_instance);
-    guest_delegate_.reset(
-        new WebViewGuestDelegate(embedder_->web_contents(), this));
+    guest_delegate_ =
+        std::make_unique<WebViewGuestDelegate>(embedder_->web_contents(), this);
     params.guest_delegate = guest_delegate_.get();
 
 #if BUILDFLAG(ENABLE_OSR)
@@ -828,7 +828,7 @@ std::unique_ptr<content::BluetoothChooser> WebContents::RunBluetoothChooser(
 content::JavaScriptDialogManager* WebContents::GetJavaScriptDialogManager(
     content::WebContents* source) {
   if (!dialog_manager_)
-    dialog_manager_.reset(new AtomJavaScriptDialogManager(this));
+    dialog_manager_ = std::make_unique<AtomJavaScriptDialogManager>(this);
 
   return dialog_manager_.get();
 }
@@ -2038,8 +2038,8 @@ void WebContents::BeginFrameSubscription(mate::Arguments* args) {
     return;
   }
 
-  frame_subscriber_.reset(
-      new FrameSubscriber(web_contents(), callback, only_dirty));
+  frame_subscriber_ =
+      std::make_unique<FrameSubscriber>(web_contents(), callback, only_dirty);
 }
 
 void WebContents::EndFrameSubscription() {

--- a/shell/browser/api/atom_api_web_contents_view.cc
+++ b/shell/browser/api/atom_api_web_contents_view.cc
@@ -22,7 +22,7 @@ namespace {
 class WebContentsViewRelay
     : public content::WebContentsUserData<WebContentsViewRelay> {
  public:
-  ~WebContentsViewRelay() override {}
+  ~WebContentsViewRelay() override = default;
 
  private:
   explicit WebContentsViewRelay(content::WebContents* contents) {}

--- a/shell/browser/api/event.cc
+++ b/shell/browser/api/event.cc
@@ -15,7 +15,7 @@ Event::Event(v8::Isolate* isolate) {
   Init(isolate);
 }
 
-Event::~Event() {}
+Event::~Event() = default;
 
 void Event::SetCallback(base::Optional<MessageSyncCallback> callback) {
   DCHECK(!callback_);

--- a/shell/browser/api/gpu_info_enumerator.cc
+++ b/shell/browser/api/gpu_info_enumerator.cc
@@ -11,7 +11,7 @@ namespace electron {
 GPUInfoEnumerator::GPUInfoEnumerator()
     : value_stack(), current(std::make_unique<base::DictionaryValue>()) {}
 
-GPUInfoEnumerator::~GPUInfoEnumerator() {}
+GPUInfoEnumerator::~GPUInfoEnumerator() = default;
 
 void GPUInfoEnumerator::AddInt64(const char* name, int64_t value) {
   current->SetInteger(name, value);

--- a/shell/browser/api/save_page_handler.cc
+++ b/shell/browser/api/save_page_handler.cc
@@ -20,7 +20,7 @@ SavePageHandler::SavePageHandler(content::WebContents* web_contents,
                                  util::Promise<void*> promise)
     : web_contents_(web_contents), promise_(std::move(promise)) {}
 
-SavePageHandler::~SavePageHandler() {}
+SavePageHandler::~SavePageHandler() = default;
 
 void SavePageHandler::OnDownloadCreated(content::DownloadManager* manager,
                                         download::DownloadItem* item) {

--- a/shell/browser/api/trackable_object.cc
+++ b/shell/browser/api/trackable_object.cc
@@ -35,7 +35,7 @@ TrackableObjectBase::TrackableObjectBase() : weak_factory_(this) {
       GetDestroyClosure());
 }
 
-TrackableObjectBase::~TrackableObjectBase() {}
+TrackableObjectBase::~TrackableObjectBase() = default;
 
 base::OnceClosure TrackableObjectBase::GetDestroyClosure() {
   return base::BindOnce(&TrackableObjectBase::Destroy,

--- a/shell/browser/atom_autofill_driver.cc
+++ b/shell/browser/atom_autofill_driver.cc
@@ -20,7 +20,7 @@ AutofillDriver::AutofillDriver(
   binding_.Bind(std::move(request));
 }
 
-AutofillDriver::~AutofillDriver() {}
+AutofillDriver::~AutofillDriver() = default;
 
 void AutofillDriver::ShowAutofillPopup(
     const gfx::RectF& bounds,

--- a/shell/browser/atom_autofill_driver.cc
+++ b/shell/browser/atom_autofill_driver.cc
@@ -4,6 +4,8 @@
 
 #include "shell/browser/atom_autofill_driver.h"
 
+#include <memory>
+
 #include <utility>
 
 #include "content/public/browser/render_widget_host_view.h"
@@ -16,7 +18,7 @@ AutofillDriver::AutofillDriver(
     content::RenderFrameHost* render_frame_host,
     mojom::ElectronAutofillDriverAssociatedRequest request)
     : render_frame_host_(render_frame_host), binding_(this) {
-  autofill_popup_.reset(new AutofillPopup());
+  autofill_popup_ = std::make_unique<AutofillPopup>();
   binding_.Bind(std::move(request));
 }
 

--- a/shell/browser/atom_autofill_driver_factory.cc
+++ b/shell/browser/atom_autofill_driver_factory.cc
@@ -28,7 +28,7 @@ std::unique_ptr<AutofillDriver> CreateDriver(
 
 }  // namespace
 
-AutofillDriverFactory::~AutofillDriverFactory() {}
+AutofillDriverFactory::~AutofillDriverFactory() = default;
 
 // static
 void AutofillDriverFactory::BindAutofillDriver(

--- a/shell/browser/atom_browser_client.cc
+++ b/shell/browser/atom_browser_client.cc
@@ -896,7 +896,7 @@ content::PlatformNotificationService*
 AtomBrowserClient::GetPlatformNotificationService(
     content::BrowserContext* browser_context) {
   if (!notification_service_) {
-    notification_service_.reset(new PlatformNotificationService(this));
+    notification_service_ = std::make_unique<PlatformNotificationService>(this);
   }
   return notification_service_.get();
 }

--- a/shell/browser/atom_browser_context.cc
+++ b/shell/browser/atom_browser_context.cc
@@ -4,6 +4,8 @@
 
 #include "shell/browser/atom_browser_context.h"
 
+#include <memory>
+
 #include <utility>
 
 #include "base/command_line.h"
@@ -205,13 +207,13 @@ int AtomBrowserContext::GetMaxCacheSize() const {
 
 content::ResourceContext* AtomBrowserContext::GetResourceContext() {
   if (!resource_context_)
-    resource_context_.reset(new content::ResourceContext);
+    resource_context_ = std::make_unique<content::ResourceContext>();
   return resource_context_.get();
 }
 
 std::string AtomBrowserContext::GetMediaDeviceIDSalt() {
   if (!media_device_id_salt_.get())
-    media_device_id_salt_.reset(new MediaDeviceIDSalt(prefs_.get()));
+    media_device_id_salt_ = std::make_unique<MediaDeviceIDSalt>(prefs_.get());
   return media_device_id_salt_->GetSalt();
 }
 
@@ -228,22 +230,22 @@ content::DownloadManagerDelegate*
 AtomBrowserContext::GetDownloadManagerDelegate() {
   if (!download_manager_delegate_.get()) {
     auto* download_manager = content::BrowserContext::GetDownloadManager(this);
-    download_manager_delegate_.reset(
-        new AtomDownloadManagerDelegate(download_manager));
+    download_manager_delegate_ =
+        std::make_unique<AtomDownloadManagerDelegate>(download_manager);
   }
   return download_manager_delegate_.get();
 }
 
 content::BrowserPluginGuestManager* AtomBrowserContext::GetGuestManager() {
   if (!guest_manager_)
-    guest_manager_.reset(new WebViewManager);
+    guest_manager_ = std::make_unique<WebViewManager>();
   return guest_manager_.get();
 }
 
 content::PermissionControllerDelegate*
 AtomBrowserContext::GetPermissionControllerDelegate() {
   if (!permission_manager_.get())
-    permission_manager_.reset(new AtomPermissionManager);
+    permission_manager_ = std::make_unique<AtomPermissionManager>();
   return permission_manager_.get();
 }
 
@@ -257,7 +259,8 @@ std::string AtomBrowserContext::GetUserAgent() const {
 
 predictors::PreconnectManager* AtomBrowserContext::GetPreconnectManager() {
   if (!preconnect_manager_.get()) {
-    preconnect_manager_.reset(new predictors::PreconnectManager(nullptr, this));
+    preconnect_manager_ =
+        std::make_unique<predictors::PreconnectManager>(nullptr, this);
   }
   return preconnect_manager_.get();
 }

--- a/shell/browser/atom_browser_main_parts.cc
+++ b/shell/browser/atom_browser_main_parts.cc
@@ -4,6 +4,8 @@
 
 #include "shell/browser/atom_browser_main_parts.h"
 
+#include <memory>
+
 #include <utility>
 
 #if defined(OS_LINUX)
@@ -289,13 +291,13 @@ void AtomBrowserMainParts::PostEarlyInitialization() {
 
   // The ProxyResolverV8 has setup a complete V8 environment, in order to
   // avoid conflicts we only initialize our V8 environment after that.
-  js_env_.reset(new JavascriptEnvironment(node_bindings_->uv_loop()));
+  js_env_ = std::make_unique<JavascriptEnvironment>(node_bindings_->uv_loop());
 
   node_bindings_->Initialize();
   // Create the global environment.
   node::Environment* env = node_bindings_->CreateEnvironment(
       js_env_->context(), js_env_->platform(), false);
-  node_env_.reset(new NodeEnvironment(env));
+  node_env_ = std::make_unique<NodeEnvironment>(env);
 
   /**
    * 🚨  🚨  🚨  🚨  🚨  🚨  🚨  🚨  🚨
@@ -316,7 +318,7 @@ void AtomBrowserMainParts::PostEarlyInitialization() {
    */
 
   // Enable support for v8 inspector
-  node_debugger_.reset(new NodeDebugger(env));
+  node_debugger_ = std::make_unique<NodeDebugger>(env);
   node_debugger_->Start();
 
   // Only run the node bootstrapper after we have initialized the inspector
@@ -362,7 +364,7 @@ int AtomBrowserMainParts::PreCreateThreads() {
 #endif
 
   if (!views::LayoutProvider::Get())
-    layout_provider_.reset(new views::LayoutProvider());
+    layout_provider_ = std::make_unique<views::LayoutProvider>();
 
   // Initialize the app locale.
   fake_browser_process_->SetApplicationLocale(
@@ -403,7 +405,7 @@ void AtomBrowserMainParts::ToolkitInitialized() {
 #endif
 
 #if defined(USE_AURA)
-  wm_state_.reset(new wm::WMState);
+  wm_state_ = std::make_unique<wm::WMState>();
 #endif
 
 #if defined(OS_WIN)
@@ -418,7 +420,7 @@ void AtomBrowserMainParts::ToolkitInitialized() {
 #if defined(OS_MACOSX)
   views_delegate_.reset(new ViewsDelegateMac);
 #else
-  views_delegate_.reset(new ViewsDelegate);
+  views_delegate_ = std::make_unique<ViewsDelegate>();
 #endif
 }
 
@@ -557,7 +559,7 @@ AtomBrowserMainParts::GetGeolocationControl() {
 IconManager* AtomBrowserMainParts::GetIconManager() {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
   if (!icon_manager_.get())
-    icon_manager_.reset(new IconManager);
+    icon_manager_ = std::make_unique<IconManager>();
   return icon_manager_.get();
 }
 

--- a/shell/browser/atom_navigation_throttle.cc
+++ b/shell/browser/atom_navigation_throttle.cc
@@ -13,7 +13,7 @@ AtomNavigationThrottle::AtomNavigationThrottle(
     content::NavigationHandle* navigation_handle)
     : content::NavigationThrottle(navigation_handle) {}
 
-AtomNavigationThrottle::~AtomNavigationThrottle() {}
+AtomNavigationThrottle::~AtomNavigationThrottle() = default;
 
 const char* AtomNavigationThrottle::GetNameForLogging() {
   return "AtomNavigationThrottle";

--- a/shell/browser/atom_permission_manager.cc
+++ b/shell/browser/atom_permission_manager.cc
@@ -89,9 +89,9 @@ class AtomPermissionManager::PendingRequest {
   size_t remaining_results_;
 };
 
-AtomPermissionManager::AtomPermissionManager() {}
+AtomPermissionManager::AtomPermissionManager() = default;
 
-AtomPermissionManager::~AtomPermissionManager() {}
+AtomPermissionManager::~AtomPermissionManager() = default;
 
 void AtomPermissionManager::SetPermissionRequestHandler(
     const RequestHandler& handler) {

--- a/shell/browser/atom_quota_permission_context.cc
+++ b/shell/browser/atom_quota_permission_context.cc
@@ -6,9 +6,9 @@
 
 namespace electron {
 
-AtomQuotaPermissionContext::AtomQuotaPermissionContext() {}
+AtomQuotaPermissionContext::AtomQuotaPermissionContext() = default;
 
-AtomQuotaPermissionContext::~AtomQuotaPermissionContext() {}
+AtomQuotaPermissionContext::~AtomQuotaPermissionContext() = default;
 
 void AtomQuotaPermissionContext::RequestQuotaPermission(
     const content::StorageQuotaParams& params,

--- a/shell/browser/atom_speech_recognition_manager_delegate.cc
+++ b/shell/browser/atom_speech_recognition_manager_delegate.cc
@@ -11,9 +11,11 @@
 
 namespace electron {
 
-AtomSpeechRecognitionManagerDelegate::AtomSpeechRecognitionManagerDelegate() {}
+AtomSpeechRecognitionManagerDelegate::AtomSpeechRecognitionManagerDelegate() =
+    default;
 
-AtomSpeechRecognitionManagerDelegate::~AtomSpeechRecognitionManagerDelegate() {}
+AtomSpeechRecognitionManagerDelegate::~AtomSpeechRecognitionManagerDelegate() =
+    default;
 
 void AtomSpeechRecognitionManagerDelegate::OnRecognitionStart(int session_id) {}
 

--- a/shell/browser/atom_web_ui_controller_factory.cc
+++ b/shell/browser/atom_web_ui_controller_factory.cc
@@ -32,9 +32,9 @@ AtomWebUIControllerFactory* AtomWebUIControllerFactory::GetInstance() {
   return base::Singleton<AtomWebUIControllerFactory>::get();
 }
 
-AtomWebUIControllerFactory::AtomWebUIControllerFactory() {}
+AtomWebUIControllerFactory::AtomWebUIControllerFactory() = default;
 
-AtomWebUIControllerFactory::~AtomWebUIControllerFactory() {}
+AtomWebUIControllerFactory::~AtomWebUIControllerFactory() = default;
 
 content::WebUI::TypeID AtomWebUIControllerFactory::GetWebUIType(
     content::BrowserContext* browser_context,

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -167,7 +167,7 @@ void Browser::DidFinishLaunching(const base::DictionaryValue& launch_info) {
 
 const util::Promise<void*>& Browser::WhenReady(v8::Isolate* isolate) {
   if (!ready_promise_) {
-    ready_promise_.reset(new util::Promise<void*>(isolate));
+    ready_promise_ = std::make_unique<util::Promise<void*>>(isolate);
     if (is_ready()) {
       ready_promise_->Resolve();
     }

--- a/shell/browser/browser_process_impl.cc
+++ b/shell/browser/browser_process_impl.cc
@@ -4,6 +4,8 @@
 
 #include "shell/browser/browser_process_impl.h"
 
+#include <memory>
+
 #include <utility>
 
 #include "chrome/common/chrome_switches.h"
@@ -282,7 +284,7 @@ const std::string& BrowserProcessImpl::GetApplicationLocale() {
 printing::PrintJobManager* BrowserProcessImpl::print_job_manager() {
 #if BUILDFLAG(ENABLE_PRINTING)
   if (!print_job_manager_)
-    print_job_manager_.reset(new printing::PrintJobManager());
+    print_job_manager_ = std::make_unique<printing::PrintJobManager>();
   return print_job_manager_.get();
 #else
   return nullptr;

--- a/shell/browser/common_web_contents_delegate.cc
+++ b/shell/browser/common_web_contents_delegate.cc
@@ -309,7 +309,8 @@ void CommonWebContentsDelegate::RunFileChooser(
     std::unique_ptr<content::FileSelectListener> listener,
     const blink::mojom::FileChooserParams& params) {
   if (!web_dialog_helper_)
-    web_dialog_helper_.reset(new WebDialogHelper(owner_window(), offscreen_));
+    web_dialog_helper_ =
+        std::make_unique<WebDialogHelper>(owner_window(), offscreen_);
   web_dialog_helper_->RunFileChooser(render_frame_host, std::move(listener),
                                      params);
 }
@@ -319,7 +320,8 @@ void CommonWebContentsDelegate::EnumerateDirectory(
     std::unique_ptr<content::FileSelectListener> listener,
     const base::FilePath& path) {
   if (!web_dialog_helper_)
-    web_dialog_helper_.reset(new WebDialogHelper(owner_window(), offscreen_));
+    web_dialog_helper_ =
+        std::make_unique<WebDialogHelper>(owner_window(), offscreen_);
   web_dialog_helper_->EnumerateDirectory(guest, std::move(listener), path);
 }
 

--- a/shell/browser/common_web_contents_delegate.cc
+++ b/shell/browser/common_web_contents_delegate.cc
@@ -68,7 +68,7 @@ namespace {
 const char kRootName[] = "<root>";
 
 struct FileSystem {
-  FileSystem() {}
+  FileSystem() = default;
   FileSystem(const std::string& type,
              const std::string& file_system_name,
              const std::string& root_url,
@@ -182,7 +182,7 @@ CommonWebContentsDelegate::CommonWebContentsDelegate()
           base::CreateSequencedTaskRunnerWithTraits({base::MayBlock()})),
       weak_factory_(this) {}
 
-CommonWebContentsDelegate::~CommonWebContentsDelegate() {}
+CommonWebContentsDelegate::~CommonWebContentsDelegate() = default;
 
 void CommonWebContentsDelegate::InitWithWebContents(
     content::WebContents* web_contents,

--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -4,6 +4,8 @@
 
 #include "shell/browser/javascript_environment.h"
 
+#include <memory>
+
 #include <string>
 
 #include "base/command_line.h"
@@ -66,7 +68,7 @@ v8::Isolate* JavascriptEnvironment::Initialize(uv_loop_t* event_loop) {
 
 void JavascriptEnvironment::OnMessageLoopCreated() {
   DCHECK(!microtasks_runner_);
-  microtasks_runner_.reset(new MicrotasksRunner(isolate()));
+  microtasks_runner_ = std::make_unique<MicrotasksRunner>(isolate());
   base::MessageLoopCurrent::Get()->AddTaskObserver(microtasks_runner_.get());
 }
 

--- a/shell/browser/lib/bluetooth_chooser.cc
+++ b/shell/browser/lib/bluetooth_chooser.cc
@@ -44,7 +44,7 @@ BluetoothChooser::BluetoothChooser(api::WebContents* contents,
                                    const EventHandler& event_handler)
     : api_web_contents_(contents), event_handler_(event_handler) {}
 
-BluetoothChooser::~BluetoothChooser() {}
+BluetoothChooser::~BluetoothChooser() = default;
 
 void BluetoothChooser::SetAdapterPresence(AdapterPresence presence) {
   switch (presence) {

--- a/shell/browser/login_handler.cc
+++ b/shell/browser/login_handler.cc
@@ -46,7 +46,7 @@ LoginHandler::LoginHandler(net::URLRequest* request,
                      base::RetainedRef(this), std::move(request_details)));
 }
 
-LoginHandler::~LoginHandler() {}
+LoginHandler::~LoginHandler() = default;
 
 void LoginHandler::Login(const base::string16& username,
                          const base::string16& password) {

--- a/shell/browser/media/media_capture_devices_dispatcher.cc
+++ b/shell/browser/media/media_capture_devices_dispatcher.cc
@@ -40,7 +40,7 @@ MediaCaptureDevicesDispatcher::MediaCaptureDevicesDispatcher()
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
 }
 
-MediaCaptureDevicesDispatcher::~MediaCaptureDevicesDispatcher() {}
+MediaCaptureDevicesDispatcher::~MediaCaptureDevicesDispatcher() = default;
 
 const blink::MediaStreamDevices&
 MediaCaptureDevicesDispatcher::GetAudioCaptureDevices() {

--- a/shell/browser/native_browser_view.cc
+++ b/shell/browser/native_browser_view.cc
@@ -15,7 +15,7 @@ NativeBrowserView::NativeBrowserView(
     InspectableWebContents* inspectable_web_contents)
     : inspectable_web_contents_(inspectable_web_contents) {}
 
-NativeBrowserView::~NativeBrowserView() {}
+NativeBrowserView::~NativeBrowserView() = default;
 
 InspectableWebContentsView* NativeBrowserView::GetInspectableWebContentsView() {
   return inspectable_web_contents_->GetView();

--- a/shell/browser/native_browser_view_views.cc
+++ b/shell/browser/native_browser_view_views.cc
@@ -15,7 +15,7 @@ NativeBrowserViewViews::NativeBrowserViewViews(
     InspectableWebContents* inspectable_web_contents)
     : NativeBrowserView(inspectable_web_contents) {}
 
-NativeBrowserViewViews::~NativeBrowserViewViews() {}
+NativeBrowserViewViews::~NativeBrowserViewViews() = default;
 
 void NativeBrowserViewViews::SetAutoResizeFlags(uint8_t flags) {
   auto_resize_flags_ = flags;

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -209,7 +209,7 @@ NativeWindowViews::NativeWindowViews(const mate::Dictionary& options,
 
 #if defined(USE_X11)
   // Start monitoring window states.
-  window_state_watcher_.reset(new WindowStateWatcher(this));
+  window_state_watcher_ = std::make_unique<WindowStateWatcher>(this);
 
   // Set _GTK_THEME_VARIANT to dark if we have "dark-theme" option set.
   bool use_dark_theme = false;
@@ -477,7 +477,7 @@ void NativeWindowViews::SetEnabledInternal(bool enable) {
     tree_host->RemoveEventRewriter(event_disabler_.get());
     event_disabler_.reset();
   } else {
-    event_disabler_.reset(new EventDisabler);
+    event_disabler_ = std::make_unique<EventDisabler>();
     tree_host->AddEventRewriter(event_disabler_.get());
   }
 #endif
@@ -997,7 +997,7 @@ void NativeWindowViews::SetMenu(AtomMenuModel* menu_model) {
   }
 
   if (!global_menu_bar_ && ShouldUseGlobalMenuBar())
-    global_menu_bar_.reset(new GlobalMenuBarX11(this));
+    global_menu_bar_ = std::make_unique<GlobalMenuBarX11>(this);
 
   // Use global application menu bar when possible.
   if (global_menu_bar_ && global_menu_bar_->IsServerStarted()) {

--- a/shell/browser/net/network_context_service_factory.cc
+++ b/shell/browser/net/network_context_service_factory.cc
@@ -24,7 +24,7 @@ NetworkContextServiceFactory::NetworkContextServiceFactory()
           "ElectronNetworkContextService",
           BrowserContextDependencyManager::GetInstance()) {}
 
-NetworkContextServiceFactory::~NetworkContextServiceFactory() {}
+NetworkContextServiceFactory::~NetworkContextServiceFactory() = default;
 
 KeyedService* NetworkContextServiceFactory::BuildServiceInstanceFor(
     content::BrowserContext* context) const {

--- a/shell/browser/net/system_network_context_manager.cc
+++ b/shell/browser/net/system_network_context_manager.cc
@@ -102,7 +102,7 @@ class SystemNetworkContextManager::URLLoaderFactoryForSystem
 
  private:
   friend class base::RefCounted<URLLoaderFactoryForSystem>;
-  ~URLLoaderFactoryForSystem() override {}
+  ~URLLoaderFactoryForSystem() override = default;
 
   SEQUENCE_CHECKER(sequence_checker_);
   SystemNetworkContextManager* manager_;

--- a/shell/browser/node_debugger.cc
+++ b/shell/browser/node_debugger.cc
@@ -20,7 +20,7 @@ namespace electron {
 
 NodeDebugger::NodeDebugger(node::Environment* env) : env_(env) {}
 
-NodeDebugger::~NodeDebugger() {}
+NodeDebugger::~NodeDebugger() = default;
 
 void NodeDebugger::Start() {
   auto* inspector = env_->inspector_agent();

--- a/shell/browser/notifications/linux/notification_presenter_linux.cc
+++ b/shell/browser/notifications/linux/notification_presenter_linux.cc
@@ -16,9 +16,9 @@ NotificationPresenter* NotificationPresenter::Create() {
   return new NotificationPresenterLinux;
 }
 
-NotificationPresenterLinux::NotificationPresenterLinux() {}
+NotificationPresenterLinux::NotificationPresenterLinux() = default;
 
-NotificationPresenterLinux::~NotificationPresenterLinux() {}
+NotificationPresenterLinux::~NotificationPresenterLinux() = default;
 
 Notification* NotificationPresenterLinux::CreateNotificationObject(
     NotificationDelegate* delegate) {

--- a/shell/browser/notifications/notification_presenter.cc
+++ b/shell/browser/notifications/notification_presenter.cc
@@ -10,7 +10,7 @@
 
 namespace electron {
 
-NotificationPresenter::NotificationPresenter() {}
+NotificationPresenter::NotificationPresenter() = default;
 
 NotificationPresenter::~NotificationPresenter() {
   for (Notification* notification : notifications_)

--- a/shell/browser/notifications/platform_notification_service.cc
+++ b/shell/browser/notifications/platform_notification_service.cc
@@ -75,7 +75,7 @@ PlatformNotificationService::PlatformNotificationService(
     AtomBrowserClient* browser_client)
     : browser_client_(browser_client) {}
 
-PlatformNotificationService::~PlatformNotificationService() {}
+PlatformNotificationService::~PlatformNotificationService() = default;
 
 void PlatformNotificationService::DisplayNotification(
     content::RenderProcessHost* render_process_host,

--- a/shell/browser/osr/osr_host_display_client.cc
+++ b/shell/browser/osr/osr_host_display_client.cc
@@ -82,7 +82,7 @@ OffScreenHostDisplayClient::OffScreenHostDisplayClient(
     gfx::AcceleratedWidget widget,
     OnPaintCallback callback)
     : viz::HostDisplayClient(widget), callback_(callback) {}
-OffScreenHostDisplayClient::~OffScreenHostDisplayClient() {}
+OffScreenHostDisplayClient::~OffScreenHostDisplayClient() = default;
 
 void OffScreenHostDisplayClient::SetActive(bool active) {
   active_ = active;

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -281,9 +281,9 @@ OffScreenRenderWidgetHostView::~OffScreenRenderWidgetHostView() {
         content::DelegatedFrameHost::HiddenCause::kOther);
   delegated_frame_host_->DetachFromCompositor();
 
-  delegated_frame_host_.reset(nullptr);
-  compositor_.reset(nullptr);
-  root_layer_.reset(nullptr);
+  delegated_frame_host_.reset();
+  compositor_.reset();
+  root_layer_.reset();
 }
 
 content::BrowserAccessibilityManager*

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -280,9 +280,9 @@ OffScreenRenderWidgetHostView::~OffScreenRenderWidgetHostView() {
         content::DelegatedFrameHost::HiddenCause::kOther);
   delegated_frame_host_->DetachFromCompositor();
 
-  delegated_frame_host_.reset(NULL);
-  compositor_.reset(NULL);
-  root_layer_.reset(NULL);
+  delegated_frame_host_.reset(nullptr);
+  compositor_.reset(nullptr);
+  root_layer_.reset(nullptr);
 }
 
 content::BrowserAccessibilityManager*
@@ -539,7 +539,7 @@ void OffScreenRenderWidgetHostView::Destroy() {
   if (!is_destroyed_) {
     is_destroyed_ = true;
 
-    if (parent_host_view_ != NULL) {
+    if (parent_host_view_ != nullptr) {
       CancelWidget();
     } else {
       if (popup_host_view_)
@@ -674,14 +674,14 @@ void OffScreenRenderWidgetHostView::CancelWidget() {
 
   if (parent_host_view_) {
     if (parent_host_view_->popup_host_view_ == this) {
-      parent_host_view_->set_popup_host_view(NULL);
+      parent_host_view_->set_popup_host_view(nullptr);
     } else if (parent_host_view_->child_host_view_ == this) {
-      parent_host_view_->set_child_host_view(NULL);
+      parent_host_view_->set_child_host_view(nullptr);
       parent_host_view_->Show();
     } else {
       parent_host_view_->RemoveGuestHostView(this);
     }
-    parent_host_view_ = NULL;
+    parent_host_view_ = nullptr;
   }
 
   if (render_widget_host_ && !is_destroyed_) {

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -126,10 +126,10 @@ class AtomBeginFrameTimer : public viz::DelayBasedTimeSourceClient {
   AtomBeginFrameTimer(int frame_rate_threshold_us,
                       const base::Closure& callback)
       : callback_(callback) {
-    time_source_.reset(new viz::DelayBasedTimeSource(
+    time_source_ = std::make_unique<viz::DelayBasedTimeSource>(
         base::CreateSingleThreadTaskRunnerWithTraits(
             {content::BrowserThread::UI})
-            .get()));
+            .get());
     time_source_->SetTimebaseAndInterval(
         base::TimeTicks(),
         base::TimeDelta::FromMicroseconds(frame_rate_threshold_us));
@@ -232,13 +232,14 @@ OffScreenRenderWidgetHostView::OffScreenRenderWidgetHostView(
   compositor_allocation_ =
       compositor_allocator_.GetCurrentLocalSurfaceIdAllocation();
 
-  delegated_frame_host_client_.reset(new AtomDelegatedFrameHostClient(this));
+  delegated_frame_host_client_ =
+      std::make_unique<AtomDelegatedFrameHostClient>(this);
   delegated_frame_host_ = std::make_unique<content::DelegatedFrameHost>(
       AllocateFrameSinkId(is_guest_view_hack),
       delegated_frame_host_client_.get(),
       true /* should_register_frame_sink_id */);
 
-  root_layer_.reset(new ui::Layer(ui::LAYER_SOLID_COLOR));
+  root_layer_ = std::make_unique<ui::Layer>(ui::LAYER_SOLID_COLOR);
 
   bool opaque = SkColorGetA(background_color_) == SK_AlphaOPAQUE;
   GetRootLayer()->SetFillsBoundsOpaquely(opaque);
@@ -249,11 +250,11 @@ OffScreenRenderWidgetHostView::OffScreenRenderWidgetHostView(
 
   ui::ContextFactoryPrivate* context_factory_private =
       factory->GetContextFactoryPrivate();
-  compositor_.reset(
-      new ui::Compositor(context_factory_private->AllocateFrameSinkId(),
-                         content::GetContextFactory(), context_factory_private,
-                         base::ThreadTaskRunnerHandle::Get(),
-                         false /* enable_pixel_canvas */, this));
+  compositor_ = std::make_unique<ui::Compositor>(
+      context_factory_private->AllocateFrameSinkId(),
+      content::GetContextFactory(), context_factory_private,
+      base::ThreadTaskRunnerHandle::Get(), false /* enable_pixel_canvas */,
+      this);
   compositor_->SetAcceleratedWidget(gfx::kNullAcceleratedWidget);
   compositor_->SetRootLayer(root_layer_.get());
 
@@ -264,9 +265,9 @@ OffScreenRenderWidgetHostView::OffScreenRenderWidgetHostView(
   InstallTransparency();
 
   if (content::GpuDataManager::GetInstance()->HardwareAccelerationEnabled()) {
-    video_consumer_.reset(new OffScreenVideoConsumer(
+    video_consumer_ = std::make_unique<OffScreenVideoConsumer>(
         this, base::BindRepeating(&OffScreenRenderWidgetHostView::OnPaint,
-                                  weak_ptr_factory_.GetWeakPtr())));
+                                  weak_ptr_factory_.GetWeakPtr()));
     video_consumer_->SetActive(IsPainting());
     video_consumer_->SetFrameRate(GetFrameRate());
   }
@@ -759,7 +760,7 @@ bool OffScreenRenderWidgetHostView::UpdateNSViewAndDisplay() {
 
 void OffScreenRenderWidgetHostView::OnPaint(const gfx::Rect& damage_rect,
                                             const SkBitmap& bitmap) {
-  backing_.reset(new SkBitmap());
+  backing_ = std::make_unique<SkBitmap>();
   backing_->allocN32Pixels(bitmap.width(), bitmap.height(), !transparent_);
   bitmap.readPixels(backing_->pixmap());
 
@@ -1063,11 +1064,11 @@ void OffScreenRenderWidgetHostView::SetupFrameRate(bool force) {
   if (begin_frame_timer_.get()) {
     begin_frame_timer_->SetFrameRateThresholdUs(frame_rate_threshold_us_);
   } else {
-    begin_frame_timer_.reset(new AtomBeginFrameTimer(
+    begin_frame_timer_ = std::make_unique<AtomBeginFrameTimer>(
         frame_rate_threshold_us_,
         base::BindRepeating(
             &OffScreenRenderWidgetHostView::OnBeginFrameTimerTick,
-            weak_ptr_factory_.GetWeakPtr())));
+            weak_ptr_factory_.GetWeakPtr()));
   }
 }
 

--- a/shell/browser/osr/osr_view_proxy.cc
+++ b/shell/browser/osr/osr_view_proxy.cc
@@ -4,10 +4,12 @@
 
 #include "shell/browser/osr/osr_view_proxy.h"
 
+#include <memory>
+
 namespace electron {
 
 OffscreenViewProxy::OffscreenViewProxy(views::View* view) : view_(view) {
-  view_bitmap_.reset(new SkBitmap);
+  view_bitmap_ = std::make_unique<SkBitmap>();
 }
 
 OffscreenViewProxy::~OffscreenViewProxy() {
@@ -34,7 +36,7 @@ const SkBitmap* OffscreenViewProxy::GetBitmap() const {
 void OffscreenViewProxy::SetBitmap(const SkBitmap& bitmap) {
   if (view_bounds_.width() == bitmap.width() &&
       view_bounds_.height() == bitmap.height() && observer_) {
-    view_bitmap_.reset(new SkBitmap(bitmap));
+    view_bitmap_ = std::make_unique<SkBitmap>(bitmap);
     observer_->OnProxyViewPaint(view_bounds_);
   }
 }

--- a/shell/browser/renderer_host/electron_render_message_filter.cc
+++ b/shell/browser/renderer_host/electron_render_message_filter.cc
@@ -48,7 +48,7 @@ ElectronRenderMessageFilter::ElectronRenderMessageFilter(
                            base::size(kRenderFilteredMessageClasses)),
       browser_context_(browser_context) {}
 
-ElectronRenderMessageFilter::~ElectronRenderMessageFilter() {}
+ElectronRenderMessageFilter::~ElectronRenderMessageFilter() = default;
 
 bool ElectronRenderMessageFilter::OnMessageReceived(
     const IPC::Message& message) {

--- a/shell/browser/session_preferences.cc
+++ b/shell/browser/session_preferences.cc
@@ -13,7 +13,7 @@ SessionPreferences::SessionPreferences(content::BrowserContext* context) {
   context->SetUserData(&kLocatorKey, base::WrapUnique(this));
 }
 
-SessionPreferences::~SessionPreferences() {}
+SessionPreferences::~SessionPreferences() = default;
 
 // static
 SessionPreferences* SessionPreferences::FromBrowserContext(

--- a/shell/browser/special_storage_policy.cc
+++ b/shell/browser/special_storage_policy.cc
@@ -9,9 +9,9 @@
 
 namespace electron {
 
-SpecialStoragePolicy::SpecialStoragePolicy() {}
+SpecialStoragePolicy::SpecialStoragePolicy() = default;
 
-SpecialStoragePolicy::~SpecialStoragePolicy() {}
+SpecialStoragePolicy::~SpecialStoragePolicy() = default;
 
 bool SpecialStoragePolicy::IsStorageProtected(const GURL& origin) {
   return true;

--- a/shell/browser/ui/atom_menu_model.cc
+++ b/shell/browser/ui/atom_menu_model.cc
@@ -17,7 +17,7 @@ bool AtomMenuModel::Delegate::GetAcceleratorForCommandId(
 AtomMenuModel::AtomMenuModel(Delegate* delegate)
     : ui::SimpleMenuModel(delegate), delegate_(delegate) {}
 
-AtomMenuModel::~AtomMenuModel() {}
+AtomMenuModel::~AtomMenuModel() = default;
 
 void AtomMenuModel::SetToolTip(int index, const base::string16& toolTip) {
   int command_id = GetCommandIdAt(index);

--- a/shell/browser/ui/autofill_popup.cc
+++ b/shell/browser/ui/autofill_popup.cc
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 #include <algorithm>
+#include <memory>
+
 #include <utility>
 #include <vector>
 
@@ -79,7 +81,7 @@ void AutofillPopup::CreateView(content::RenderFrameHost* frame_host,
     }
 
     auto* osr_rwhv = static_cast<OffScreenRenderWidgetHostView*>(rwhv);
-    view_->view_proxy_.reset(new OffscreenViewProxy(view_));
+    view_->view_proxy_ = std::make_unique<OffscreenViewProxy>(view_);
     osr_rwhv->AddViewProxy(view_->view_proxy_.get());
   }
 #endif

--- a/shell/browser/ui/devtools_manager_delegate.cc
+++ b/shell/browser/ui/devtools_manager_delegate.cc
@@ -92,9 +92,9 @@ void DevToolsManagerDelegate::StartHttpHandler() {
       CreateSocketFactory(), user_dir, base::FilePath());
 }
 
-DevToolsManagerDelegate::DevToolsManagerDelegate() {}
+DevToolsManagerDelegate::DevToolsManagerDelegate() = default;
 
-DevToolsManagerDelegate::~DevToolsManagerDelegate() {}
+DevToolsManagerDelegate::~DevToolsManagerDelegate() = default;
 
 void DevToolsManagerDelegate::Inspect(content::DevToolsAgentHost* agent_host) {}
 

--- a/shell/browser/ui/devtools_ui.cc
+++ b/shell/browser/ui/devtools_ui.cc
@@ -54,8 +54,8 @@ std::string GetMimeTypeForPath(const std::string& path) {
 
 class BundledDataSource : public content::URLDataSource {
  public:
-  BundledDataSource() {}
-  ~BundledDataSource() override {}
+  BundledDataSource() = default;
+  ~BundledDataSource() override = default;
 
   // content::URLDataSource implementation.
   std::string GetSource() override { return kChromeUIDevToolsHost; }

--- a/shell/browser/ui/file_dialog_gtk.cc
+++ b/shell/browser/ui/file_dialog_gtk.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <memory>
+
 #include "shell/browser/ui/file_dialog.h"
 #include "shell/browser/ui/util_gtk.h"
 
@@ -140,15 +142,17 @@ class FileChooserDialog {
 
   void RunSaveAsynchronous(
       electron::util::Promise<gin_helper::Dictionary> promise) {
-    save_promise_.reset(new electron::util::Promise<gin_helper::Dictionary>(
-        std::move(promise)));
+    save_promise_ =
+        std::make_unique<electron::util::Promise<gin_helper::Dictionary>>(
+            std::move(promise));
     RunAsynchronous();
   }
 
   void RunOpenAsynchronous(
       electron::util::Promise<gin_helper::Dictionary> promise) {
-    open_promise_.reset(new electron::util::Promise<gin_helper::Dictionary>(
-        std::move(promise)));
+    open_promise_ =
+        std::make_unique<electron::util::Promise<gin_helper::Dictionary>>(
+            std::move(promise));
     RunAsynchronous();
   }
 

--- a/shell/browser/ui/file_dialog_gtk.cc
+++ b/shell/browser/ui/file_dialog_gtk.cc
@@ -57,7 +57,7 @@ class FileChooserDialog {
       confirm_text = gtk_util::kSaveLabel;
 
     dialog_ = gtk_file_chooser_dialog_new(
-        settings.title.c_str(), NULL, action, gtk_util::kCancelLabel,
+        settings.title.c_str(), nullptr, action, gtk_util::kCancelLabel,
         GTK_RESPONSE_CANCEL, confirm_text, GTK_RESPONSE_ACCEPT, NULL);
     if (parent_) {
       parent_->SetEnabled(false);
@@ -162,7 +162,7 @@ class FileChooserDialog {
   std::vector<base::FilePath> GetFileNames() const {
     std::vector<base::FilePath> paths;
     auto* filenames = gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(dialog_));
-    for (auto* iter = filenames; iter != NULL; iter = iter->next) {
+    for (auto* iter = filenames; iter != nullptr; iter = iter->next) {
       auto* filename = static_cast<char*>(iter->data);
       paths.emplace_back(filename);
       g_free(filename);

--- a/shell/browser/ui/tray_icon.cc
+++ b/shell/browser/ui/tray_icon.cc
@@ -8,9 +8,9 @@ namespace electron {
 
 TrayIcon::BalloonOptions::BalloonOptions() = default;
 
-TrayIcon::TrayIcon() {}
+TrayIcon::TrayIcon() = default;
 
-TrayIcon::~TrayIcon() {}
+TrayIcon::~TrayIcon() = default;
 
 void TrayIcon::SetPressedImage(ImageType image) {}
 

--- a/shell/browser/ui/tray_icon_gtk.cc
+++ b/shell/browser/ui/tray_icon_gtk.cc
@@ -13,9 +13,9 @@
 
 namespace electron {
 
-TrayIconGtk::TrayIconGtk() {}
+TrayIconGtk::TrayIconGtk() = default;
 
-TrayIconGtk::~TrayIconGtk() {}
+TrayIconGtk::~TrayIconGtk() = default;
 
 void TrayIconGtk::SetImage(const gfx::Image& image) {
   if (icon_) {

--- a/shell/browser/ui/views/atom_views_delegate.cc
+++ b/shell/browser/ui/views/atom_views_delegate.cc
@@ -30,9 +30,9 @@ bool IsDesktopEnvironmentUnity() {
 
 namespace electron {
 
-ViewsDelegate::ViewsDelegate() {}
+ViewsDelegate::ViewsDelegate() = default;
 
-ViewsDelegate::~ViewsDelegate() {}
+ViewsDelegate::~ViewsDelegate() = default;
 
 void ViewsDelegate::SaveWindowPlacement(const views::Widget* window,
                                         const std::string& window_name,

--- a/shell/browser/ui/views/atom_views_delegate.cc
+++ b/shell/browser/ui/views/atom_views_delegate.cc
@@ -70,13 +70,13 @@ bool ViewsDelegate::IsWindowInMetro(gfx::NativeWindow window) const {
 
 #elif defined(OS_LINUX) && !defined(OS_CHROMEOS)
 gfx::ImageSkia* ViewsDelegate::GetDefaultWindowIcon() const {
-  return NULL;
+  return nullptr;
 }
 #endif
 
 views::NonClientFrameView* ViewsDelegate::CreateDefaultNonClientFrameView(
     views::Widget* widget) {
-  return NULL;
+  return nullptr;
 }
 
 void ViewsDelegate::AddRef() {}

--- a/shell/browser/ui/views/autofill_popup_view.cc
+++ b/shell/browser/ui/views/autofill_popup_view.cc
@@ -245,7 +245,7 @@ void AutofillPopupView::OnPaint(gfx::Canvas* canvas) {
   if (view_proxy_.get()) {
     bitmap.allocN32Pixels(popup_->popup_bounds_in_view().width(),
                           popup_->popup_bounds_in_view().height(), true);
-    paint_canvas.reset(new cc::SkiaPaintCanvas(bitmap));
+    paint_canvas = std::make_unique<cc::SkiaPaintCanvas>(bitmap);
     draw_canvas = new gfx::Canvas(paint_canvas.get(), 1.0);
   }
 #endif

--- a/shell/browser/ui/views/frameless_view.cc
+++ b/shell/browser/ui/views/frameless_view.cc
@@ -22,9 +22,9 @@ const int kResizeAreaCornerSize = 16;
 // static
 const char FramelessView::kViewClassName[] = "FramelessView";
 
-FramelessView::FramelessView() {}
+FramelessView::FramelessView() = default;
 
-FramelessView::~FramelessView() {}
+FramelessView::~FramelessView() = default;
 
 void FramelessView::Init(NativeWindowViews* window, views::Widget* frame) {
   window_ = window;

--- a/shell/browser/ui/views/global_menu_bar_x11.cc
+++ b/shell/browser/ui/views/global_menu_bar_x11.cc
@@ -58,21 +58,21 @@ namespace {
 // Retrieved functions from libdbusmenu-glib.
 
 // DbusmenuMenuItem methods:
-dbusmenu_menuitem_new_func menuitem_new = NULL;
-dbusmenu_menuitem_new_with_id_func menuitem_new_with_id = NULL;
-dbusmenu_menuitem_get_id_func menuitem_get_id = NULL;
-dbusmenu_menuitem_get_children_func menuitem_get_children = NULL;
-dbusmenu_menuitem_get_children_func menuitem_take_children = NULL;
-dbusmenu_menuitem_child_append_func menuitem_child_append = NULL;
-dbusmenu_menuitem_property_set_func menuitem_property_set = NULL;
+dbusmenu_menuitem_new_func menuitem_new = nullptr;
+dbusmenu_menuitem_new_with_id_func menuitem_new_with_id = nullptr;
+dbusmenu_menuitem_get_id_func menuitem_get_id = nullptr;
+dbusmenu_menuitem_get_children_func menuitem_get_children = nullptr;
+dbusmenu_menuitem_get_children_func menuitem_take_children = nullptr;
+dbusmenu_menuitem_child_append_func menuitem_child_append = nullptr;
+dbusmenu_menuitem_property_set_func menuitem_property_set = nullptr;
 dbusmenu_menuitem_property_set_variant_func menuitem_property_set_variant =
-    NULL;
-dbusmenu_menuitem_property_set_bool_func menuitem_property_set_bool = NULL;
-dbusmenu_menuitem_property_set_int_func menuitem_property_set_int = NULL;
+    nullptr;
+dbusmenu_menuitem_property_set_bool_func menuitem_property_set_bool = nullptr;
+dbusmenu_menuitem_property_set_int_func menuitem_property_set_int = nullptr;
 
 // DbusmenuServer methods:
-dbusmenu_server_new_func server_new = NULL;
-dbusmenu_server_set_root_func server_set_root = NULL;
+dbusmenu_server_new_func server_new = nullptr;
+dbusmenu_server_set_root_func server_set_root = nullptr;
 
 // Properties that we set on menu items:
 const char kPropertyEnabled[] = "enabled";
@@ -141,7 +141,7 @@ AtomMenuModel* ModelForMenuItem(DbusmenuMenuitem* item) {
 
 bool GetMenuItemID(DbusmenuMenuitem* item, int* id) {
   gpointer id_ptr = g_object_get_data(G_OBJECT(item), "menu-id");
-  if (id_ptr != NULL) {
+  if (id_ptr != nullptr) {
     *id = GPOINTER_TO_INT(id_ptr) - 1;
     return true;
   }
@@ -326,7 +326,7 @@ void GlobalMenuBarX11::OnSubMenuShow(DbusmenuMenuitem* item) {
 
   // Clear children.
   GList* children = menuitem_take_children(item);
-  g_list_foreach(children, reinterpret_cast<GFunc>(g_object_unref), NULL);
+  g_list_foreach(children, reinterpret_cast<GFunc>(g_object_unref), nullptr);
   g_list_free(children);
 
   // Build children.

--- a/shell/browser/ui/views/inspectable_web_contents_view_views.cc
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.cc
@@ -4,6 +4,8 @@
 
 #include "shell/browser/ui/views/inspectable_web_contents_view_views.h"
 
+#include <memory>
+
 #include <utility>
 
 #include "base/strings/utf_string_conversions.h"
@@ -176,7 +178,7 @@ void InspectableWebContentsViewViews::SetIsDocked(bool docked, bool activate) {
   CloseDevTools();
 
   if (!docked) {
-    devtools_window_.reset(new views::Widget);
+    devtools_window_ = std::make_unique<views::Widget>();
     devtools_window_web_view_ = new views::WebView(nullptr);
     devtools_window_delegate_ = new DevToolsWindowDelegate(
         this, devtools_window_web_view_, devtools_window_.get());

--- a/shell/browser/ui/views/inspectable_web_contents_view_views.cc
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.cc
@@ -154,7 +154,7 @@ void InspectableWebContentsViewViews::CloseDevTools() {
     devtools_window_delegate_ = nullptr;
   } else {
     devtools_web_view_->SetVisible(false);
-    devtools_web_view_->SetWebContents(NULL);
+    devtools_web_view_->SetWebContents(nullptr);
     Layout();
   }
 }
@@ -177,7 +177,7 @@ void InspectableWebContentsViewViews::SetIsDocked(bool docked, bool activate) {
 
   if (!docked) {
     devtools_window_.reset(new views::Widget);
-    devtools_window_web_view_ = new views::WebView(NULL);
+    devtools_window_web_view_ = new views::WebView(nullptr);
     devtools_window_delegate_ = new DevToolsWindowDelegate(
         this, devtools_window_web_view_, devtools_window_.get());
 

--- a/shell/browser/ui/views/inspectable_web_contents_view_views.cc
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.cc
@@ -36,7 +36,7 @@ class DevToolsWindowDelegate : public views::ClientView,
     if (shell->GetDelegate())
       icon_ = shell->GetDelegate()->GetDevToolsWindowIcon();
   }
-  ~DevToolsWindowDelegate() override {}
+  ~DevToolsWindowDelegate() override = default;
 
   // views::WidgetDelegate:
   void DeleteDelegate() override { delete this; }

--- a/shell/browser/ui/views/menu_bar.cc
+++ b/shell/browser/ui/views/menu_bar.cc
@@ -39,7 +39,7 @@ const char MenuBar::kViewClassName[] = "ElectronMenuBar";
 MenuBarColorUpdater::MenuBarColorUpdater(MenuBar* menu_bar)
     : menu_bar_(menu_bar) {}
 
-MenuBarColorUpdater::~MenuBarColorUpdater() {}
+MenuBarColorUpdater::~MenuBarColorUpdater() = default;
 
 void MenuBarColorUpdater::OnDidChangeFocus(views::View* focused_before,
                                            views::View* focused_now) {

--- a/shell/browser/ui/views/menu_delegate.cc
+++ b/shell/browser/ui/views/menu_delegate.cc
@@ -19,7 +19,7 @@ namespace electron {
 MenuDelegate::MenuDelegate(MenuBar* menu_bar)
     : menu_bar_(menu_bar), id_(-1), hold_first_switch_(false) {}
 
-MenuDelegate::~MenuDelegate() {}
+MenuDelegate::~MenuDelegate() = default;
 
 void MenuDelegate::RunMenu(AtomMenuModel* model,
                            views::Button* button,

--- a/shell/browser/ui/views/menu_delegate.cc
+++ b/shell/browser/ui/views/menu_delegate.cc
@@ -4,6 +4,8 @@
 
 #include "shell/browser/ui/views/menu_delegate.h"
 
+#include <memory>
+
 #include "base/task/post_task.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
@@ -35,14 +37,13 @@ void MenuDelegate::RunMenu(AtomMenuModel* model,
   }
 
   id_ = button->tag();
-  adapter_.reset(new MenuModelAdapter(model));
+  adapter_ = std::make_unique<MenuModelAdapter>(model);
 
   views::MenuItemView* item = new views::MenuItemView(this);
   static_cast<MenuModelAdapter*>(adapter_.get())->BuildMenu(item);
 
-  menu_runner_.reset(new views::MenuRunner(
-      item,
-      views::MenuRunner::CONTEXT_MENU | views::MenuRunner::HAS_MNEMONICS));
+  menu_runner_ = std::make_unique<views::MenuRunner>(
+      item, views::MenuRunner::CONTEXT_MENU | views::MenuRunner::HAS_MNEMONICS);
   menu_runner_->RunMenuAt(
       button->GetWidget()->GetTopLevelWidget(),
       static_cast<views::MenuButton*>(button)->button_controller(), bounds,

--- a/shell/browser/ui/views/menu_model_adapter.cc
+++ b/shell/browser/ui/views/menu_model_adapter.cc
@@ -9,7 +9,7 @@ namespace electron {
 MenuModelAdapter::MenuModelAdapter(AtomMenuModel* menu_model)
     : views::MenuModelAdapter(menu_model), menu_model_(menu_model) {}
 
-MenuModelAdapter::~MenuModelAdapter() {}
+MenuModelAdapter::~MenuModelAdapter() = default;
 
 bool MenuModelAdapter::GetAccelerator(int id,
                                       ui::Accelerator* accelerator) const {

--- a/shell/browser/ui/views/root_view.cc
+++ b/shell/browser/ui/views/root_view.cc
@@ -4,6 +4,8 @@
 
 #include "shell/browser/ui/views/root_view.h"
 
+#include <memory>
+
 #include "content/public/browser/native_web_keyboard_event.h"
 #include "shell/browser/native_window.h"
 #include "shell/browser/ui/views/menu_bar.h"
@@ -60,7 +62,7 @@ void RootView::SetMenu(AtomMenuModel* menu_model) {
     return;
 
   if (!menu_bar_) {
-    menu_bar_.reset(new MenuBar(this));
+    menu_bar_ = std::make_unique<MenuBar>(this);
     menu_bar_->set_owned_by_client();
     if (!menu_bar_autohide_)
       SetMenuBarVisibility(true);

--- a/shell/browser/ui/views/root_view.cc
+++ b/shell/browser/ui/views/root_view.cc
@@ -41,7 +41,7 @@ RootView::RootView(NativeWindow* window)
   set_owned_by_client();
 }
 
-RootView::~RootView() {}
+RootView::~RootView() = default;
 
 void RootView::SetMenu(AtomMenuModel* menu_model) {
   if (menu_model == nullptr) {

--- a/shell/browser/ui/views/submenu_button.cc
+++ b/shell/browser/ui/views/submenu_button.cc
@@ -41,7 +41,7 @@ SubmenuButton::SubmenuButton(const base::string16& title,
       color_utils::BlendTowardMaxContrast(background_color_, 0x81));
 }
 
-SubmenuButton::~SubmenuButton() {}
+SubmenuButton::~SubmenuButton() = default;
 
 std::unique_ptr<views::InkDropRipple> SubmenuButton::CreateInkDropRipple()
     const {

--- a/shell/browser/ui/views/submenu_button.cc
+++ b/shell/browser/ui/views/submenu_button.cc
@@ -22,8 +22,9 @@ namespace electron {
 SubmenuButton::SubmenuButton(const base::string16& title,
                              views::MenuButtonListener* menu_button_listener,
                              const SkColor& background_color)
-    : views::MenuButton(gfx::RemoveAcceleratorChar(title, '&', NULL, NULL),
-                        menu_button_listener),
+    : views::MenuButton(
+          gfx::RemoveAcceleratorChar(title, '&', nullptr, nullptr),
+          menu_button_listener),
       background_color_(background_color) {
 #if defined(OS_LINUX)
   // Dont' use native style border.

--- a/shell/browser/ui/x/event_disabler.cc
+++ b/shell/browser/ui/x/event_disabler.cc
@@ -8,9 +8,9 @@
 
 namespace electron {
 
-EventDisabler::EventDisabler() {}
+EventDisabler::EventDisabler() = default;
 
-EventDisabler::~EventDisabler() {}
+EventDisabler::~EventDisabler() = default;
 
 ui::EventRewriteStatus EventDisabler::RewriteEvent(
     const ui::Event& event,

--- a/shell/browser/ui/x/x_window_utils.cc
+++ b/shell/browser/ui/x/x_window_utils.cc
@@ -70,7 +70,7 @@ bool ShouldUseGlobalMenuBar() {
   }
 
   dbus::MessageReader reader(response.get());
-  dbus::MessageReader array_reader(NULL);
+  dbus::MessageReader array_reader(nullptr);
   if (!reader.PopArray(&array_reader)) {
     bus->ShutdownAndBlock();
     return false;

--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -62,7 +62,7 @@ WebContentsPermissionHelper::WebContentsPermissionHelper(
     content::WebContents* web_contents)
     : web_contents_(web_contents) {}
 
-WebContentsPermissionHelper::~WebContentsPermissionHelper() {}
+WebContentsPermissionHelper::~WebContentsPermissionHelper() = default;
 
 void WebContentsPermissionHelper::RequestPermission(
     content::PermissionType permission,

--- a/shell/browser/web_contents_zoom_controller.cc
+++ b/shell/browser/web_contents_zoom_controller.cc
@@ -24,7 +24,7 @@ WebContentsZoomController::WebContentsZoomController(
   host_zoom_map_ = content::HostZoomMap::GetForWebContents(web_contents);
 }
 
-WebContentsZoomController::~WebContentsZoomController() {}
+WebContentsZoomController::~WebContentsZoomController() = default;
 
 void WebContentsZoomController::AddObserver(
     WebContentsZoomController::Observer* observer) {

--- a/shell/browser/web_dialog_helper.cc
+++ b/shell/browser/web_dialog_helper.cc
@@ -77,7 +77,7 @@ class FileSelectHelper : public base::RefCounted<FileSelectHelper>,
  private:
   friend class base::RefCounted<FileSelectHelper>;
 
-  ~FileSelectHelper() override {}
+  ~FileSelectHelper() override = default;
 
   // net::DirectoryLister::DirectoryListerDelegate
   void OnListFile(
@@ -294,7 +294,7 @@ namespace electron {
 WebDialogHelper::WebDialogHelper(NativeWindow* window, bool offscreen)
     : window_(window), offscreen_(offscreen), weak_factory_(this) {}
 
-WebDialogHelper::~WebDialogHelper() {}
+WebDialogHelper::~WebDialogHelper() = default;
 
 void WebDialogHelper::RunFileChooser(
     content::RenderFrameHost* render_frame_host,

--- a/shell/browser/web_dialog_helper.cc
+++ b/shell/browser/web_dialog_helper.cc
@@ -4,6 +4,8 @@
 
 #include "shell/browser/web_dialog_helper.h"
 
+#include <memory>
+
 #include <string>
 #include <utility>
 #include <vector>
@@ -106,8 +108,8 @@ class FileSelectHelper : public base::RefCounted<FileSelectHelper>,
     DCHECK(!lister_base_dir_.empty());
     DCHECK(lister_paths_.empty());
 
-    lister_.reset(new net::DirectoryLister(
-        lister_base_dir_, net::DirectoryLister::NO_SORT_RECURSIVE, this));
+    lister_ = std::make_unique<net::DirectoryLister>(
+        lister_base_dir_, net::DirectoryLister::NO_SORT_RECURSIVE, this);
     lister_->Start();
     // It is difficult for callers to know how long to keep a reference to
     // this instance.  We AddRef() here to keep the instance alive after we

--- a/shell/browser/web_view_manager.cc
+++ b/shell/browser/web_view_manager.cc
@@ -11,9 +11,9 @@
 
 namespace electron {
 
-WebViewManager::WebViewManager() {}
+WebViewManager::WebViewManager() = default;
 
-WebViewManager::~WebViewManager() {}
+WebViewManager::~WebViewManager() = default;
 
 void WebViewManager::AddGuest(int guest_instance_id,
                               int element_instance_id,

--- a/shell/browser/window_list.cc
+++ b/shell/browser/window_list.cc
@@ -96,8 +96,8 @@ void WindowList::DestroyAllWindows() {
     window->CloseImmediately();  // e.g. Destroy()
 }
 
-WindowList::WindowList() {}
+WindowList::WindowList() = default;
 
-WindowList::~WindowList() {}
+WindowList::~WindowList() = default;
 
 }  // namespace electron

--- a/shell/browser/zoom_level_delegate.cc
+++ b/shell/browser/zoom_level_delegate.cc
@@ -50,7 +50,7 @@ ZoomLevelDelegate::ZoomLevelDelegate(PrefService* pref_service,
   partition_key_ = GetHash(partition_path);
 }
 
-ZoomLevelDelegate::~ZoomLevelDelegate() {}
+ZoomLevelDelegate::~ZoomLevelDelegate() = default;
 
 void ZoomLevelDelegate::SetDefaultZoomLevelPref(double level) {
   if (content::ZoomValuesEqual(level, host_zoom_map_->GetDefaultZoomLevel()))

--- a/shell/common/api/locker.cc
+++ b/shell/common/api/locker.cc
@@ -4,11 +4,13 @@
 
 #include "shell/common/api/locker.h"
 
+#include <memory>
+
 namespace mate {
 
 Locker::Locker(v8::Isolate* isolate) {
   if (IsBrowserProcess())
-    locker_.reset(new v8::Locker(isolate));
+    locker_ = std::make_unique<v8::Locker>(isolate);
 }
 
 Locker::~Locker() = default;

--- a/shell/common/api/locker.cc
+++ b/shell/common/api/locker.cc
@@ -11,6 +11,6 @@ Locker::Locker(v8::Isolate* isolate) {
     locker_.reset(new v8::Locker(isolate));
 }
 
-Locker::~Locker() {}
+Locker::~Locker() = default;
 
 }  // namespace mate

--- a/shell/common/api/remote_callback_freer.cc
+++ b/shell/common/api/remote_callback_freer.cc
@@ -32,7 +32,7 @@ RemoteCallbackFreer::RemoteCallbackFreer(v8::Isolate* isolate,
       context_id_(context_id),
       object_id_(object_id) {}
 
-RemoteCallbackFreer::~RemoteCallbackFreer() {}
+RemoteCallbackFreer::~RemoteCallbackFreer() = default;
 
 void RemoteCallbackFreer::RunDestructor() {
   auto* channel = "ELECTRON_RENDERER_RELEASE_CALLBACK";

--- a/shell/common/api/remote_object_freer.cc
+++ b/shell/common/api/remote_object_freer.cc
@@ -57,7 +57,7 @@ RemoteObjectFreer::RemoteObjectFreer(v8::Isolate* isolate,
   }
 }
 
-RemoteObjectFreer::~RemoteObjectFreer() {}
+RemoteObjectFreer::~RemoteObjectFreer() = default;
 
 void RemoteObjectFreer::RunDestructor() {
   content::RenderFrame* render_frame =

--- a/shell/common/asar/scoped_temporary_file.cc
+++ b/shell/common/asar/scoped_temporary_file.cc
@@ -11,7 +11,7 @@
 
 namespace asar {
 
-ScopedTemporaryFile::ScopedTemporaryFile() {}
+ScopedTemporaryFile::ScopedTemporaryFile() = default;
 
 ScopedTemporaryFile::~ScopedTemporaryFile() {
   if (!path_.empty()) {

--- a/shell/common/crash_reporter/crash_reporter.cc
+++ b/shell/common/crash_reporter/crash_reporter.cc
@@ -40,7 +40,7 @@ CrashReporter::CrashReporter() {
   // process_type_ will be empty for browser process
 }
 
-CrashReporter::~CrashReporter() {}
+CrashReporter::~CrashReporter() = default;
 
 bool CrashReporter::IsInitialized() {
   return is_initialized_;

--- a/shell/common/crash_reporter/crash_reporter_linux.cc
+++ b/shell/common/crash_reporter/crash_reporter_linux.cc
@@ -38,7 +38,7 @@ static const off_t kMaxMinidumpFileSize = 1258291;
 CrashReporterLinux::CrashReporterLinux() : pid_(getpid()) {
   // Set the base process start time value.
   struct timeval tv;
-  if (!gettimeofday(&tv, NULL)) {
+  if (!gettimeofday(&tv, nullptr)) {
     uint64_t ret = tv.tv_sec;
     ret *= 1000;
     ret += tv.tv_usec / 1000;
@@ -91,7 +91,7 @@ void CrashReporterLinux::EnableCrashDumping(const base::FilePath& crashes_dir) {
   MinidumpDescriptor minidump_descriptor(crashes_dir.value());
   minidump_descriptor.set_size_limit(kMaxMinidumpFileSize);
 
-  breakpad_.reset(new ExceptionHandler(minidump_descriptor, NULL, CrashDone,
+  breakpad_.reset(new ExceptionHandler(minidump_descriptor, nullptr, CrashDone,
                                        this,
                                        true,  // Install handlers.
                                        -1));

--- a/shell/common/crash_reporter/crash_reporter_linux.cc
+++ b/shell/common/crash_reporter/crash_reporter_linux.cc
@@ -49,7 +49,7 @@ CrashReporterLinux::CrashReporterLinux() : pid_(getpid()) {
   base::SetLinuxDistro(base::GetLinuxDistro());
 }
 
-CrashReporterLinux::~CrashReporterLinux() {}
+CrashReporterLinux::~CrashReporterLinux() = default;
 
 void CrashReporterLinux::Init(const std::string& product_name,
                               const std::string& company_name,

--- a/shell/common/crash_reporter/crash_reporter_linux.cc
+++ b/shell/common/crash_reporter/crash_reporter_linux.cc
@@ -8,6 +8,8 @@
 #include <sys/time.h>
 #include <unistd.h>
 
+#include <memory>
+
 #include <string>
 
 #include "base/debug/crash_logging.h"
@@ -62,7 +64,7 @@ void CrashReporterLinux::Init(const std::string& product_name,
   upload_url_ = submit_url;
   upload_to_server_ = upload_to_server;
 
-  crash_keys_.reset(new CrashKeyStorage());
+  crash_keys_ = std::make_unique<CrashKeyStorage>();
   for (StringMap::const_iterator iter = upload_parameters_.begin();
        iter != upload_parameters_.end(); ++iter)
     crash_keys_->SetKeyValue(iter->first.c_str(), iter->second.c_str());
@@ -91,10 +93,10 @@ void CrashReporterLinux::EnableCrashDumping(const base::FilePath& crashes_dir) {
   MinidumpDescriptor minidump_descriptor(crashes_dir.value());
   minidump_descriptor.set_size_limit(kMaxMinidumpFileSize);
 
-  breakpad_.reset(new ExceptionHandler(minidump_descriptor, nullptr, CrashDone,
-                                       this,
-                                       true,  // Install handlers.
-                                       -1));
+  breakpad_ = std::make_unique<ExceptionHandler>(minidump_descriptor, nullptr,
+                                                 CrashDone, this,
+                                                 true,  // Install handlers.
+                                                 -1);
 }
 
 bool CrashReporterLinux::CrashDone(const MinidumpDescriptor& minidump,

--- a/shell/common/crash_reporter/linux/crash_dump_handler.cc
+++ b/shell/common/crash_reporter/linux/crash_dump_handler.cc
@@ -349,12 +349,12 @@ void ExecUploadProcessOrTerminate(const BreakpadInfo& info,
 
   static const char kWgetBinary[] = "/usr/bin/wget";
   const char* args[] = {
-      kWgetBinary,    header, post_file, info.upload_url,
+      kWgetBinary,    header,  post_file, info.upload_url,
       "--timeout=60",  // Set a timeout so we don't hang forever.
       "--tries=1",     // Don't retry if the upload fails.
       "--quiet",       // Be silent.
       "-O",            // output reply to /dev/null.
-      "/dev/fd/3",    NULL,
+      "/dev/fd/3",    nullptr,
   };
   static const char msg[] =
       "Cannot upload crash dump: cannot exec "
@@ -437,7 +437,7 @@ void HandleCrashReportId(const char* buf,
 
   // Write crash dump id to crash log as: seconds_since_epoch,crash_id
   struct kernel_timeval tv;
-  if (!sys_gettimeofday(&tv, NULL)) {
+  if (!sys_gettimeofday(&tv, nullptr)) {
     uint64_t time = kernel_timeval_to_ms(&tv) / 1000;
     char time_str[kUint64StringSize];
     const unsigned time_len = my_uint64_len(time);
@@ -465,7 +465,7 @@ void HandleCrashDump(const BreakpadInfo& info) {
   size_t dump_size;
   uint8_t* dump_data;
   google_breakpad::PageAllocator allocator;
-  const char* exe_buf = NULL;
+  const char* exe_buf = nullptr;
 
   if (info.fd != -1) {
     // Dump is provided with an open FD.
@@ -614,7 +614,7 @@ void HandleCrashDump(const BreakpadInfo& info) {
 
   if (info.process_start_time > 0) {
     struct kernel_timeval tv;
-    if (!sys_gettimeofday(&tv, NULL)) {
+    if (!sys_gettimeofday(&tv, nullptr)) {
       uint64_t time = kernel_timeval_to_ms(&tv);
       if (time > info.process_start_time) {
         time -= info.process_start_time;
@@ -723,7 +723,7 @@ void HandleCrashDump(const BreakpadInfo& info) {
             WaitForCrashReportUploadProcess(fds[0], kCrashIdLength, id_buf);
         HandleCrashReportId(id_buf, bytes_read, kCrashIdLength);
 
-        if (sys_waitpid(upload_child, NULL, WNOHANG) == 0) {
+        if (sys_waitpid(upload_child, nullptr, WNOHANG) == 0) {
           // Upload process is still around, kill it.
           sys_kill(upload_child, SIGKILL);
         }
@@ -739,7 +739,7 @@ void HandleCrashDump(const BreakpadInfo& info) {
   // Main browser process.
   if (child <= 0)
     return;
-  (void)HANDLE_EINTR(sys_waitpid(child, NULL, 0));
+  (void)HANDLE_EINTR(sys_waitpid(child, nullptr, 0));
 }
 
 size_t WriteLog(const char* buf, size_t nbytes) {

--- a/shell/common/crash_reporter/linux/crash_dump_handler.cc
+++ b/shell/common/crash_reporter/linux/crash_dump_handler.cc
@@ -166,7 +166,7 @@ class MimeWriter {
 MimeWriter::MimeWriter(int fd, const char* const mime_boundary)
     : fd_(fd), mime_boundary_(mime_boundary) {}
 
-MimeWriter::~MimeWriter() {}
+MimeWriter::~MimeWriter() = default;
 
 void MimeWriter::AddBoundary() {
   AddString(mime_boundary_);

--- a/shell/common/gin_helper/callback.cc
+++ b/shell/common/gin_helper/callback.cc
@@ -102,10 +102,9 @@ class RefCountedGlobal
 SafeV8Function::SafeV8Function(v8::Isolate* isolate, v8::Local<v8::Value> value)
     : v8_function_(new RefCountedGlobal<v8::Function>(isolate, value)) {}
 
-SafeV8Function::SafeV8Function(const SafeV8Function& other)
-    : v8_function_(other.v8_function_) {}
+SafeV8Function::SafeV8Function(const SafeV8Function& other) = default;
 
-SafeV8Function::~SafeV8Function() {}
+SafeV8Function::~SafeV8Function() = default;
 
 bool SafeV8Function::IsAlive() const {
   return v8_function_.get() && v8_function_->IsAlive();

--- a/shell/common/native_mate_converters/callback_converter_deprecated.cc
+++ b/shell/common/native_mate_converters/callback_converter_deprecated.cc
@@ -106,10 +106,9 @@ class RefCountedGlobal
 SafeV8Function::SafeV8Function(v8::Isolate* isolate, v8::Local<v8::Value> value)
     : v8_function_(new RefCountedGlobal<v8::Function>(isolate, value)) {}
 
-SafeV8Function::SafeV8Function(const SafeV8Function& other)
-    : v8_function_(other.v8_function_) {}
+SafeV8Function::SafeV8Function(const SafeV8Function& other) = default;
 
-SafeV8Function::~SafeV8Function() {}
+SafeV8Function::~SafeV8Function() = default;
 
 bool SafeV8Function::IsAlive() const {
   return v8_function_.get() && v8_function_->IsAlive();

--- a/shell/common/native_mate_converters/v8_value_converter.cc
+++ b/shell/common/native_mate_converters/v8_value_converter.cc
@@ -386,7 +386,7 @@ std::unique_ptr<base::Value> V8ValueConverter::FromV8Array(
   // that context, but change back after val is converted.
   if (!val->CreationContext().IsEmpty() &&
       val->CreationContext() != isolate->GetCurrentContext())
-    scope.reset(new v8::Context::Scope(val->CreationContext()));
+    scope = std::make_unique<v8::Context::Scope>(val->CreationContext());
 
   std::unique_ptr<base::ListValue> result(new base::ListValue());
 
@@ -442,7 +442,7 @@ std::unique_ptr<base::Value> V8ValueConverter::FromV8Object(
   // that context, but change back after val is converted.
   if (!val->CreationContext().IsEmpty() &&
       val->CreationContext() != isolate->GetCurrentContext())
-    scope.reset(new v8::Context::Scope(val->CreationContext()));
+    scope = std::make_unique<v8::Context::Scope>(val->CreationContext());
 
   auto result = std::make_unique<base::DictionaryValue>();
   v8::Local<v8::Array> property_names;

--- a/shell/common/native_mate_converters/v8_value_converter.cc
+++ b/shell/common/native_mate_converters/v8_value_converter.cc
@@ -122,7 +122,7 @@ class V8ValueConverter::ScopedUniquenessGuard {
   DISALLOW_COPY_AND_ASSIGN(ScopedUniquenessGuard);
 };
 
-V8ValueConverter::V8ValueConverter() {}
+V8ValueConverter::V8ValueConverter() = default;
 
 void V8ValueConverter::SetRegExpAllowed(bool val) {
   reg_exp_allowed_ = val;

--- a/shell/common/node_bindings_linux.cc
+++ b/shell/common/node_bindings_linux.cc
@@ -17,7 +17,7 @@ NodeBindingsLinux::NodeBindingsLinux(BrowserEnvironment browser_env)
   epoll_ctl(epoll_, EPOLL_CTL_ADD, backend_fd, &ev);
 }
 
-NodeBindingsLinux::~NodeBindingsLinux() {}
+NodeBindingsLinux::~NodeBindingsLinux() = default;
 
 void NodeBindingsLinux::RunMessageLoop() {
   // Get notified when libuv's watcher queue changes.

--- a/shell/renderer/api/atom_api_spell_check_client.cc
+++ b/shell/renderer/api/atom_api_spell_check_client.cc
@@ -55,7 +55,7 @@ class SpellCheckClient::SpellcheckRequest {
       const base::string16& text,
       std::unique_ptr<blink::WebTextCheckingCompletion> completion)
       : text_(text), completion_(std::move(completion)) {}
-  ~SpellcheckRequest() {}
+  ~SpellcheckRequest() = default;
 
   const base::string16& text() const { return text_; }
   blink::WebTextCheckingCompletion* completion() { return completion_.get(); }

--- a/shell/renderer/api/atom_api_spell_check_client.cc
+++ b/shell/renderer/api/atom_api_spell_check_client.cc
@@ -5,6 +5,8 @@
 #include "shell/renderer/api/atom_api_spell_check_client.h"
 
 #include <map>
+#include <memory>
+
 #include <set>
 #include <unordered_set>
 #include <utility>
@@ -105,8 +107,8 @@ void SpellCheckClient::RequestCheckingOfText(
     pending_request_param_->completion()->DidCancelCheckingText();
   }
 
-  pending_request_param_.reset(
-      new SpellcheckRequest(text, std::move(completionCallback)));
+  pending_request_param_ =
+      std::make_unique<SpellcheckRequest>(text, std::move(completionCallback));
 
   base::ThreadTaskRunnerHandle::Get()->PostTask(
       FROM_HERE,

--- a/shell/renderer/api/atom_api_web_frame.cc
+++ b/shell/renderer/api/atom_api_web_frame.cc
@@ -100,7 +100,7 @@ class RenderFrameStatus final : public content::RenderFrameObserver {
  public:
   explicit RenderFrameStatus(content::RenderFrame* render_frame)
       : content::RenderFrameObserver(render_frame) {}
-  ~RenderFrameStatus() final {}
+  ~RenderFrameStatus() final = default;
 
   bool is_ok() { return render_frame() != nullptr; }
 
@@ -113,7 +113,7 @@ class ScriptExecutionCallback : public blink::WebScriptExecutionCallback {
   explicit ScriptExecutionCallback(
       electron::util::Promise<v8::Local<v8::Value>> promise)
       : promise_(std::move(promise)) {}
-  ~ScriptExecutionCallback() override {}
+  ~ScriptExecutionCallback() override = default;
 
   void Completed(
       const blink::WebVector<v8::Local<v8::Value>>& result) override {

--- a/shell/renderer/atom_sandboxed_renderer_client.cc
+++ b/shell/renderer/atom_sandboxed_renderer_client.cc
@@ -125,7 +125,7 @@ AtomSandboxedRendererClient::AtomSandboxedRendererClient() {
   metrics_ = base::ProcessMetrics::CreateCurrentProcessMetrics();
 }
 
-AtomSandboxedRendererClient::~AtomSandboxedRendererClient() {}
+AtomSandboxedRendererClient::~AtomSandboxedRendererClient() = default;
 
 void AtomSandboxedRendererClient::InitializeBindings(
     v8::Local<v8::Object> binding,

--- a/shell/renderer/content_settings_observer.cc
+++ b/shell/renderer/content_settings_observer.cc
@@ -17,7 +17,7 @@ ContentSettingsObserver::ContentSettingsObserver(
   render_frame->GetWebFrame()->SetContentSettingsClient(this);
 }
 
-ContentSettingsObserver::~ContentSettingsObserver() {}
+ContentSettingsObserver::~ContentSettingsObserver() = default;
 
 bool ContentSettingsObserver::AllowDatabase() {
   blink::WebFrame* frame = render_frame()->GetWebFrame();

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -106,7 +106,7 @@ RendererClientBase::RendererClientBase() {
       command_line->GetSwitchValueASCII(::switches::kRendererClientId);
 }
 
-RendererClientBase::~RendererClientBase() {}
+RendererClientBase::~RendererClientBase() = default;
 
 void RendererClientBase::DidCreateScriptContext(
     v8::Handle<v8::Context> context,

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -200,8 +200,8 @@ void RendererClientBase::RenderThreadStarted() {
   blink::WebSecurityPolicy::RegisterURLSchemeAsAllowingServiceWorkers("file");
   blink::SchemeRegistry::RegisterURLSchemeAsSupportingFetchAPI("file");
 
-  prescient_networking_dispatcher_.reset(
-      new network_hints::PrescientNetworkingDispatcher());
+  prescient_networking_dispatcher_ =
+      std::make_unique<network_hints::PrescientNetworkingDispatcher>();
 
 #if defined(OS_WIN)
   // Set ApplicationUserModelID in renderer process.

--- a/shell/utility/atom_content_utility_client.cc
+++ b/shell/utility/atom_content_utility_client.cc
@@ -67,7 +67,7 @@ AtomContentUtilityClient::AtomContentUtilityClient() : elevated_(false) {
 #endif
 }
 
-AtomContentUtilityClient::~AtomContentUtilityClient() {}
+AtomContentUtilityClient::~AtomContentUtilityClient() = default;
 
 // The guts of this came from the chromium implementation
 // https://cs.chromium.org/chromium/src/chrome/utility/


### PR DESCRIPTION
#### Description of Change

All changes in this PR are generated by clang-tidy and shouldn't include any functional changes.

This PR is a followup to #20172. As discussed there, checks were selected from [this spreadsheet](https://docs.google.com/spreadsheets/d/16_z3pQFvTEzQocfWpch54GSykziTxVJMEcaDb5xW0YA/comment#gid=0) where Chromium maintainers discussed what made sense for Chromium. The checks from that spreadsheet that generated changes in Electron were `modernize-make-unique`, `modernize-use-equals-default` and `modernize-use-nullptr`.

Note 1: That spreadsheet lists the `make_unique` test as a 'maybe use' rather than 'use' because it generated changes that failed to compile. This may have been an older version of clang-tidy because the Electron changes WfM.

Note 2: the `bugprone-*` tests also seem to be used at times, e.g. [these](https://chromium-review.googlesource.com/c/chromium/src/+/1440126) [two](https://chromium-review.googlesource.com/c/chromium/src/+/1511974) patches appear to have been found by `bugprone-suspicious-missing-comma`. The `bugprone-*` checks also found some Electron warnings. Since those require manual fixes, I'll include them in a separate PR.

CC @deepak1556 @miniak 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes