### PR TITLE
fix: use coordinate offsets in ShowAutofillPopup

### DIFF
--- a/shell/browser/atom_autofill_driver.cc
+++ b/shell/browser/atom_autofill_driver.cc
@@ -51,7 +51,7 @@ void AutofillDriver::ShowAutofillPopup(
 
   autofill_popup_->CreateView(render_frame_host_, embedder_frame_host, osr,
                               web_contents->owner_window()->content_view(),
-                              bounds);
+                              popup_bounds);
   autofill_popup_->SetItems(values, labels);
 }
 

--- a/shell/browser/atom_autofill_driver.cc
+++ b/shell/browser/atom_autofill_driver.cc
@@ -45,7 +45,7 @@ void AutofillDriver::ShowAutofillPopup(
     auto* view = web_contents->web_contents()->GetMainFrame()->GetView();
     auto offset = view->GetViewBounds().origin() -
                   embedder_view->GetViewBounds().origin();
-    popup_bounds.Offset(offset.x(), offset.y());
+    popup_bounds.Offset(offset);
     embedder_frame_host = embedder->web_contents()->GetMainFrame();
   }
 


### PR DESCRIPTION
#### Description of Change

 * Fix a popup positioning regression that caused the embed offset to be lost. Looks like this regression is pretty new from #18760 and doesn't need any backport. :tada: 
 * Silence a minor clang-tidy warning about implicit type narrowing from int to float. This isn't a big deal, but the changed code is also easier to read.

CC @brenca 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed the position of popups being created over embedded content.