### PR TITLE
docs: clarify VS installation instructions for Windows builds

### DIFF
--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -5,8 +5,9 @@ Follow the guidelines below for building Electron on Windows.
 ## Prerequisites
 
 * Windows 10 / Server 2012 R2 or higher
-* Visual Studio 2017 15.7.2 or higher - [download VS 2017 Community Edition for
+* Visual Studio 2017 15.7.2 or higher - [download VS 2019 Community Edition for
   free](https://www.visualstudio.com/vs/)
+  * Ensure that the "Desktop development with C++" workload is included in your installation, as it contains the required build toolchains.
 * [Python 2.7.10 or higher](http://www.python.org/download/releases/2.7/)
   * Contrary to the `depot_tools` setup instructions linked below, you will need
   to use your locally installed Python with at least version 2.7.10 (with

--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -7,7 +7,12 @@ Follow the guidelines below for building Electron on Windows.
 * Windows 10 / Server 2012 R2 or higher
 * Visual Studio 2017 15.7.2 or higher - [download VS 2019 Community Edition for
   free](https://www.visualstudio.com/vs/)
-  * Ensure that the "Desktop development with C++" workload is included in your installation, as it contains the required build toolchains.
+  * Ensure that the "Desktop development with C++" workload is included in your installation,
+  as it contains the required build toolchains.
+  * If your Visual Studio is installed in a directory other than the default, you'll need to
+  set a few environment variables to point the toolchains to your installation path.
+    * `vs2019_install = DRIVE:\path\to\Microsoft Visual Studio\2019\Community` (replace `2019` and `Community` with your installed versions)
+    * `WINDOWSSDKDIR = DRIVE:\path\to\Windows Kits\10`
 * [Python 2.7.10 or higher](http://www.python.org/download/releases/2.7/)
   * Contrary to the `depot_tools` setup instructions linked below, you will need
   to use your locally installed Python with at least version 2.7.10 (with
@@ -49,7 +54,7 @@ building with Visual Studio will come in the future.
 
 See [Build Instructions: GN](build-instructions-gn.md)
 
-## 32bit Build
+## 32bit Build 
 
 To build for the 32bit target, you need to pass `target_cpu = "x86"` as a GN
 arg. You can build the 32bit target alongside the 64bit target by using a

--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -7,8 +7,8 @@ Follow the guidelines below for building Electron on Windows.
 * Windows 10 / Server 2012 R2 or higher
 * Visual Studio 2017 15.7.2 or higher - [download VS 2019 Community Edition for
   free](https://www.visualstudio.com/vs/)
-  * Ensure that the "Desktop development with C++" workload is included in your installation,
-  as it contains the required build toolchains.
+  * See [the Chromium build documentation](https://chromium.googlesource.com/chromium/src/+/master/docs/windows_build_instructions.md#visual-studio) for more details on which Visual Studio
+  components are required.
   * If your Visual Studio is installed in a directory other than the default, you'll need to
   set a few environment variables to point the toolchains to your installation path.
     * `vs2019_install = DRIVE:\path\to\Microsoft Visual Studio\2019\Community`

--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -11,7 +11,8 @@ Follow the guidelines below for building Electron on Windows.
   as it contains the required build toolchains.
   * If your Visual Studio is installed in a directory other than the default, you'll need to
   set a few environment variables to point the toolchains to your installation path.
-    * `vs2019_install = DRIVE:\path\to\Microsoft Visual Studio\2019\Community` (replace `2019` and `Community` with your installed versions)
+    * `vs2019_install = DRIVE:\path\to\Microsoft Visual Studio\2019\Community`
+       (replace `2019` and `Community` with your installed versions)
     * `WINDOWSSDKDIR = DRIVE:\path\to\Windows Kits\10`
 * [Python 2.7.10 or higher](http://www.python.org/download/releases/2.7/)
   * Contrary to the `depot_tools` setup instructions linked below, you will need
@@ -54,7 +55,7 @@ building with Visual Studio will come in the future.
 
 See [Build Instructions: GN](build-instructions-gn.md)
 
-## 32bit Build 
+## 32bit Build
 
 To build for the 32bit target, you need to pass `target_cpu = "x86"` as a GN
 arg. You can build the 32bit target alongside the 64bit target by using a


### PR DESCRIPTION
#### Description of Change
These might help newbies who aren't familiar with Visual Studio! 😄 

##### Note required workload
Although I had installed Visual Studio Community 2019, I was getting errors related to missing SDKs while running `gclient sync`. Installing the "Desktop development with C++" workload made it work. When reading the docs, it wasn't obvious to me that I had to include additional components.

##### Custom install directory
I installed Visual Studio outside of my `C:\` drive for storage space reasons. This made it so that the `build/vs_toolchain.py` script from Chromium ([link here](https://chromium.googlesource.com/chromium/src/+/master/build/vs_toolchain.py)) was unable to find my install directory.

Digging through the code, it seems like you need to add `vs2019_install` and `WINDOWSSDKDIR` environment variables so that your VS installation could be detected.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes
