### PR TITLE
fix: backgroundThrottling to throttle render view

### DIFF
--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -844,9 +844,8 @@ void WebContents::BeforeUnloadFired(bool proceed,
 }
 
 void WebContents::RenderViewCreated(content::RenderViewHost* render_view_host) {
-  auto* const impl = content::RenderWidgetHostImpl::FromID(
-      render_view_host->GetProcess()->GetID(),
-      render_view_host->GetRoutingID());
+  auto* impl = static_cast<content::RenderWidgetHostImpl*>(
+      render_view_host->GetWidget());
   if (impl)
     impl->disable_hidden_ = !background_throttling_;
 }


### PR DESCRIPTION
#### Description of Change

* Previously when a render view was created the corresponding RenderWidgetHost was fetched with the wrong routing ID which caused that the `backgroundThrottling` option could not be set for the RWH, which meant that various throttle mechanisms, could not be disabled (e.g. throttling a video stream being sent through WebRTC). This PR fixes this fetching therefore making the `backgroundThrottling` option having an effect.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fixes `backgroundThrottling: false` not having an effect.
