### PR TITLE
build: ensure we strip all binaries when zipping up dist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,7 +338,7 @@ step-electron-chromedriver-build: &step-electron-chromedriver-build
     name: Build chromedriver.zip
     command: |
       cd src
-      ninja -C out/Default electron:electron_chromedriver_zip
+      ninja -C out/Default electron:electron_chromedriver_zip -j $NUMBER_OF_NINJA_PROCESSES
 
 step-electron-chromedriver-store: &step-electron-chromedriver-store
   store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,8 +335,6 @@ step-electron-chromedriver-build: &step-electron-chromedriver-build
     name: Build chromedriver.zip
     command: |
       cd src
-      ninja -C out/Default chrome/test/chromedriver -j $NUMBER_OF_NINJA_PROCESSES
-      electron/script/strip-binaries.py --target-cpu="$TARGET_ARCH" --file $PWD/out/Default/chromedriver
       ninja -C out/Default electron:electron_chromedriver_zip
 
 step-electron-chromedriver-store: &step-electron-chromedriver-store
@@ -456,15 +454,6 @@ step-mksnapshot-build: &step-mksnapshot-build
     name: mksnapshot build
     command: |
       cd src
-      if [ "`uname`" != "Darwin" ]; then
-        if [ "$TARGET_ARCH" == "arm" ]; then
-          electron/script/strip-binaries.py --file $PWD/out/Default/clang_x86_v8_arm/mksnapshot
-        elif [ "$TARGET_ARCH" == "arm64" ]; then
-          electron/script/strip-binaries.py --file $PWD/out/Default/clang_x64_v8_arm64/mksnapshot
-        else
-          electron/script/strip-binaries.py --file $PWD/out/Default/mksnapshot
-        fi
-      fi
       ninja -C out/Default electron:electron_mksnapshot_zip -j $NUMBER_OF_NINJA_PROCESSES
 
 step-mksnapshot-store: &step-mksnapshot-store

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1183,6 +1183,8 @@ template("dist_zip") {
       "$root_out_dir/gen.runtime/" + get_label_info(target_name, "dir") + "/" +
       get_label_info(target_name, "name") + ".runtime_deps"
 
+  _strip_binaries_target = "${target_name}__strip"
+
   group(_runtime_deps_target) {
     forward_variables_from(invoker,
                            [
@@ -1194,10 +1196,27 @@ template("dist_zip") {
     write_runtime_deps = _runtime_deps_file
   }
 
+  action(_strip_binaries_target) {
+    forward_variables_from(invoker, [ "testonly" ])
+    script = "//electron/script/strip-binaries.py"
+    deps = [
+      ":$_runtime_deps_target",
+    ]
+    args = [
+      "--directory",
+      rebase_path(root_out_dir),
+      "--target-cpu",
+      target_cpu,
+    ]
+    outputs = [
+      "$target_gen_dir/$_strip_binaries_target/.strip",
+    ]
+  }
+
   action(target_name) {
     script = "//electron/build/zip.py"
     deps = [
-      ":$_runtime_deps_target",
+      ":$_strip_binaries_target",
     ]
     forward_variables_from(invoker,
                            [

--- a/script/strip-binaries.py
+++ b/script/strip-binaries.py
@@ -8,13 +8,20 @@ from lib.util import execute, get_out_dir
 
 LINUX_BINARIES_TO_STRIP = [
   'electron',
+  'chromedriver',
   'chrome_sandbox',
   'libffmpeg.so',
   'libGLESv2.so',
   'libEGL.so',
   'swiftshader/libGLESv2.so',
   'swiftshader/libEGL.so',
-  'swiftshader/libvk_swiftshader.so'
+  'swiftshader/libvk_swiftshader.so',
+  'mksnapshot',
+  'v8_context_snapshot_generator',
+  'clang_x86_v8_arm/mksnapshot',
+  'clang_x86_v8_arm/v8_context_snapshot_generator',
+  'clang_x64_v8_arm64/mksnapshot'
+  'clang_x64_v8_arm64/v8_context_snapshot_generator'
 ]
 
 def strip_binaries(directory, target_cpu):

--- a/script/strip-binaries.py
+++ b/script/strip-binaries.py
@@ -17,7 +17,10 @@ LINUX_BINARIES_TO_STRIP = [
   'swiftshader/libEGL.so',
   'swiftshader/libvk_swiftshader.so',
   'mksnapshot',
-  'v8_context_snapshot_generator',
+  'v8_context_snapshot_generator'
+]
+
+LINUX_ARCH_INDEPENDENT_BINARIES_TO_STRIP = [
   'clang_x86_v8_arm/mksnapshot',
   'clang_x86_v8_arm/v8_context_snapshot_generator',
   'clang_x64_v8_arm64/mksnapshot'
@@ -29,6 +32,11 @@ def strip_binaries(directory, target_cpu):
     binary_path = os.path.join(directory, binary)
     if os.path.isfile(binary_path):
       strip_binary(binary_path, target_cpu)
+  for binary in LINUX_ARCH_INDEPENDENT_BINARIES_TO_STRIP:
+    binary_path = os.path.join(directory, binary)
+    if os.path.isfile(binary_path):
+      # Pretend to be x64 to force "strip" usage
+      strip_binary(binary_path, 'x64')
 
 def strip_binary(binary_path, target_cpu):
   if target_cpu == 'arm':


### PR DESCRIPTION
As part of the [electron/data](https://github.com/electron/data) project I noticed that earlier in the year several of our binaries went up in size including the `mksnapshot` dist and the `ffmpeg` zip file.  See this graph:

![image](https://user-images.githubusercontent.com/6634592/64931745-5e413c80-d7ef-11e9-8d55-9223363c302e.png).  The ones that spiked are the linux binaries

This PR ensures that we strip all binaries during every `dist_zip` generation.  Check CI for the difference but here is a quick proof screenshot.

**Before**
![image](https://user-images.githubusercontent.com/6634592/64931710-1c17fb00-d7ef-11e9-8eaf-b93e3b3b5c69.png)

**After**
![image](https://user-images.githubusercontent.com/6634592/64931722-2cc87100-d7ef-11e9-9c18-65a6b64d6a65.png)

Notes: Reduced size of the `mksnapshot` binary and the secondary `ffmpeg` distribution on linux