### PR TITLE
build: speed up linux CI even more

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,6 +378,9 @@ step-persist-data-for-tests: &step-persist-data-for-tests
       - src/out/Default/mksnapshot.zip
       - src/out/Default/gen/node_headers
       - src/out/ffmpeg/ffmpeg.zip
+      - src/electron
+      - src/third_party/electron_node
+      - src/third_party/nan
 
 step-electron-dist-unzip: &step-electron-dist-unzip
   run:
@@ -1138,7 +1141,8 @@ jobs:
       <<: *env-debug-build
       <<: *env-enable-sccache
       <<: *env-ninja-status
-    <<: *steps-electron-build
+      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
+    <<: *steps-electron-build-with-inline-checkout-for-tests
 
   linux-x64-debug-gn-check:
     <<: *machine-linux-medium
@@ -1210,7 +1214,8 @@ jobs:
       <<: *env-debug-build
       <<: *env-enable-sccache
       <<: *env-ninja-status
-    <<: *steps-electron-build
+      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
+    <<: *steps-electron-build-with-inline-checkout-for-tests
 
   linux-ia32-testing:
     <<: *machine-linux-2xlarge
@@ -1261,7 +1266,8 @@ jobs:
       <<: *env-debug-build
       <<: *env-enable-sccache
       <<: *env-ninja-status
-    <<: *steps-electron-build
+      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
+    <<: *steps-electron-build-with-inline-checkout-for-tests
 
   linux-arm-testing:
     <<: *machine-linux-2xlarge
@@ -1313,7 +1319,8 @@ jobs:
       <<: *env-debug-build
       <<: *env-enable-sccache
       <<: *env-ninja-status
-    <<: *steps-electron-build
+      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
+    <<: *steps-electron-build-with-inline-checkout-for-tests
 
   linux-arm64-debug-gn-check:
     <<: *machine-linux-medium
@@ -1757,9 +1764,7 @@ workflows:
       - linux-checkout-fast
       - linux-checkout-and-save-cache
 
-      - linux-x64-debug:
-          requires:
-            - linux-checkout-fast
+      - linux-x64-debug
       - linux-x64-debug-gn-check:
           requires:
             - linux-checkout-fast
@@ -1778,9 +1783,7 @@ workflows:
           requires:
             - linux-x64-testing
 
-      - linux-ia32-debug:
-          requires:
-            - linux-checkout-fast
+      - linux-ia32-debug
       - linux-ia32-testing
       - linux-ia32-testing-tests:
           requires:
@@ -1792,22 +1795,14 @@ workflows:
           requires:
             - linux-ia32-testing
 
-      - linux-arm-debug:
-          requires:
-            - linux-checkout-fast
-      - linux-arm-testing:
-          requires:
-            - linux-checkout-fast
+      - linux-arm-debug
+      - linux-arm-testing
 
-      - linux-arm64-debug:
-          requires:
-            - linux-checkout-fast
+      - linux-arm64-debug
       - linux-arm64-debug-gn-check:
           requires:
             - linux-checkout-fast
-      - linux-arm64-testing:
-          requires:
-            - linux-checkout-fast
+      - linux-arm64-testing
       - linux-arm64-testing-gn-check:
           requires:
             - linux-checkout-fast

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ machine-mac-large: &machine-mac-large
 # Build configurations options.
 env-debug-build: &env-debug-build
   GN_CONFIG: //electron/build/args/debug.gn
+  SKIP_DIST_ZIP: '1'
 
 env-testing-build: &env-testing-build
   GN_CONFIG: //electron/build/args/testing.gn
@@ -301,28 +302,30 @@ step-electron-dist-build: &step-electron-dist-build
     name: Build dist.zip
     command: |
       cd src
-      ninja -C out/Default electron:electron_dist_zip
-      if [ "$CHECK_DIST_MANIFEST" == "1" ]; then
-        if [ "`uname`" == "Darwin" ]; then
-          target_os=mac
-          target_cpu=x64
-          if [ x"$MAS_BUILD" == x"true" ]; then
-            target_os=mac_mas
-          fi
-        elif [ "`uname`" == "Linux" ]; then
-          target_os=linux
-          if [ x"$TARGET_ARCH" == x ]; then
+      if [ "$SKIP_DIST_ZIP" != "1" ]; then
+        ninja -C out/Default electron:electron_dist_zip
+        if [ "$CHECK_DIST_MANIFEST" == "1" ]; then
+          if [ "`uname`" == "Darwin" ]; then
+            target_os=mac
             target_cpu=x64
-          elif [ "$TARGET_ARCH" == "ia32" ]; then
-            target_cpu=x86
+            if [ x"$MAS_BUILD" == x"true" ]; then
+              target_os=mac_mas
+            fi
+          elif [ "`uname`" == "Linux" ]; then
+            target_os=linux
+            if [ x"$TARGET_ARCH" == x ]; then
+              target_cpu=x64
+            elif [ "$TARGET_ARCH" == "ia32" ]; then
+              target_cpu=x86
+            else
+              target_cpu="$TARGET_ARCH"
+            fi
           else
-            target_cpu="$TARGET_ARCH"
+            echo "Unknown system: `uname`"
+            exit 1
           fi
-        else
-          echo "Unknown system: `uname`"
-          exit 1
+          electron/script/zip_manifests/check-zip-manifest.py out/Default/dist.zip electron/script/zip_manifests/dist_zip.$target_os.$target_cpu.manifest
         fi
-        electron/script/zip_manifests/check-zip-manifest.py out/Default/dist.zip electron/script/zip_manifests/dist_zip.$target_os.$target_cpu.manifest
       fi
 
 step-electron-dist-store: &step-electron-dist-store
@@ -468,7 +471,9 @@ step-mksnapshot-build: &step-mksnapshot-build
           electron/script/strip-binaries.py --file $PWD/out/Default/mksnapshot
         fi
       fi
-      ninja -C out/Default electron:electron_mksnapshot_zip -j $NUMBER_OF_NINJA_PROCESSES
+      if [ "$SKIP_DIST_ZIP" != "1" ]; then
+        ninja -C out/Default electron:electron_mksnapshot_zip -j $NUMBER_OF_NINJA_PROCESSES
+      fi
 
 step-mksnapshot-store: &step-mksnapshot-store
   store_artifacts:
@@ -753,26 +758,6 @@ steps-electron-gn-check: &steps-electron-gn-check
     - *step-gn-check
 
 steps-electron-build: &steps-electron-build
-  steps:
-    - attach_workspace:
-        at: .
-    - *step-depot-tools-add-to-path
-    - *step-setup-env-for-build
-    - *step-gn-gen-default
-
-    # Electron app
-    - *step-electron-build
-    - *step-electron-dist-build
-    - *step-electron-dist-store
-    - *step-ninja-summary
-
-    # Node.js headers
-    - *step-nodejs-headers-build
-    - *step-nodejs-headers-store
-
-    - *step-show-sccache-stats
-
-steps-electron-build-for-tests: &steps-electron-build-for-tests
   steps:
     - attach_workspace:
         at: .
@@ -1196,7 +1181,7 @@ jobs:
       <<: *env-enable-sccache
       <<: *env-send-slack-notifications
       <<: *env-ninja-status
-    <<: *steps-electron-build-for-tests
+    <<: *steps-electron-build
 
   linux-x64-publish:
     <<: *machine-linux-2xlarge
@@ -1247,7 +1232,7 @@ jobs:
       <<: *env-enable-sccache
       <<: *env-send-slack-notifications
       <<: *env-ninja-status
-    <<: *steps-electron-build-for-tests
+    <<: *steps-electron-build
 
   linux-ia32-publish:
     <<: *machine-linux-2xlarge
@@ -1300,7 +1285,7 @@ jobs:
       <<: *env-enable-sccache
       <<: *env-send-slack-notifications
       <<: *env-ninja-status
-    <<: *steps-electron-build-for-tests
+    <<: *steps-electron-build
 
   linux-arm-publish:
     <<: *machine-linux-2xlarge
@@ -1369,7 +1354,7 @@ jobs:
       <<: *env-enable-sccache
       <<: *env-send-slack-notifications
       <<: *env-ninja-status
-    <<: *steps-electron-build-for-tests
+    <<: *steps-electron-build
 
   linux-arm64-publish:
     <<: *machine-linux-2xlarge
@@ -1387,7 +1372,7 @@ jobs:
       <<: *env-testing-build
       <<: *env-enable-sccache
       <<: *env-ninja-status
-    <<: *steps-electron-build-for-tests
+    <<: *steps-electron-build
 
   osx-debug:
     <<: *machine-mac-large
@@ -1396,7 +1381,7 @@ jobs:
       <<: *env-debug-build
       <<: *env-enable-sccache
       <<: *env-ninja-status
-    <<: *steps-electron-build-for-tests    
+    <<: *steps-electron-build
 
   osx-debug-gn-check:
     <<: *machine-mac
@@ -1428,7 +1413,7 @@ jobs:
       <<: *env-release-build
       <<: *env-enable-sccache
       <<: *env-ninja-status
-    <<: *steps-electron-build-for-tests
+    <<: *steps-electron-build
 
   osx-publish:
     <<: *machine-mac-large
@@ -1446,7 +1431,7 @@ jobs:
       <<: *env-testing-build
       <<: *env-enable-sccache
       <<: *env-ninja-status
-    <<: *steps-electron-build-for-tests
+    <<: *steps-electron-build
 
   mas-debug:
     <<: *machine-mac-large
@@ -1456,7 +1441,7 @@ jobs:
       <<: *env-debug-build
       <<: *env-enable-sccache
       <<: *env-ninja-status
-    <<: *steps-electron-build-for-tests
+    <<: *steps-electron-build
 
   mas-debug-gn-check:
     <<: *machine-mac
@@ -1491,7 +1476,7 @@ jobs:
       <<: *env-release-build
       <<: *env-enable-sccache
       <<: *env-ninja-status      
-    <<: *steps-electron-build-for-tests
+    <<: *steps-electron-build
 
   mas-publish:
     <<: *machine-mac-large

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -817,6 +817,76 @@ steps-electron-build-for-tests: &steps-electron-build-for-tests
 
     - *step-maybe-notify-slack-failure
 
+steps-electron-build-with-inline-checkout-for-tests: &steps-electron-build-with-inline-checkout-for-tests
+  steps:
+    # Checkout - Copied ffrom steps-checkout
+    - *step-checkout-electron
+    - *step-depot-tools-get
+    - *step-depot-tools-add-to-path
+    - *step-restore-brew-cache
+    - *step-get-more-space-on-mac
+    - *step-install-gnutar-on-mac
+    - *step-generate-deps-hash
+    - *step-touch-sync-done
+    - *step-maybe-restore-src-cache
+    - *step-maybe-restore-git-cache
+    - *step-set-git-cache-path
+    # This sync call only runs if .circle-sync-done is an EMPTY file
+    - *step-gclient-sync
+    # These next few steps reset Electron to the correct commit regardless of which cache was restored
+    - run:
+        name: Wipe Electron
+        command: rm -rf src/electron
+    - *step-checkout-electron
+    - *step-run-electron-only-hooks
+    - *step-generate-deps-hash-cleanly
+    - *step-mark-sync-done
+    - *step-minimize-workspace-size-from-checkout
+    
+    - *step-depot-tools-add-to-path
+    - *step-setup-env-for-build
+    - *step-restore-brew-cache
+    - *step-get-more-space-on-mac
+    - *step-install-npm-deps-on-mac
+    - *step-fix-sync-on-mac
+    - *step-gn-gen-default
+    - *step-delete-git-directories
+
+    # Electron app
+    - *step-electron-build
+    - *step-maybe-electron-dist-strip
+    - *step-electron-dist-build
+    - *step-electron-dist-store
+    - *step-ninja-summary
+
+    # Node.js headers
+    - *step-nodejs-headers-build
+    - *step-nodejs-headers-store
+
+    - *step-show-sccache-stats
+
+    # mksnapshot
+    - *step-mksnapshot-build
+    - *step-mksnapshot-store
+    - *step-maybe-cross-arch-snapshot
+    - *step-maybe-cross-arch-snapshot-store
+
+    # ffmpeg
+    - *step-ffmpeg-gn-gen
+    - *step-ffmpeg-build
+    - *step-ffmpeg-store
+
+    # Save all data needed for a further tests run.
+    - *step-persist-data-for-tests
+
+    - *step-maybe-generate-breakpad-symbols
+    - *step-maybe-zip-symbols
+
+    # Trigger tests on arm hardware if needed
+    - *step-maybe-trigger-arm-test
+
+    - *step-maybe-notify-slack-failure
+
 steps-electron-build-for-publish: &steps-electron-build-for-publish
   steps:
     - *step-checkout-electron
@@ -1084,7 +1154,8 @@ jobs:
       <<: *env-testing-build
       <<: *env-enable-sccache
       <<: *env-ninja-status
-    <<: *steps-electron-build-for-tests
+      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
+    <<: *steps-electron-build-with-inline-checkout-for-tests
 
   linux-x64-testing-no-run-as-node:
     <<: *machine-linux-2xlarge
@@ -1094,7 +1165,8 @@ jobs:
       <<: *env-enable-sccache
       <<: *env-ninja-status
       <<: *env-disable-run-as-node
-    <<: *steps-electron-build-for-tests
+      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
+    <<: *steps-electron-build-with-inline-checkout-for-tests
 
   linux-x64-testing-gn-check:
     <<: *machine-linux-medium
@@ -1148,7 +1220,8 @@ jobs:
       <<: *env-testing-build
       <<: *env-enable-sccache
       <<: *env-ninja-status
-    <<: *steps-electron-build-for-tests
+      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
+    <<: *steps-electron-build-with-inline-checkout-for-tests
 
   linux-ia32-chromedriver:
     <<: *machine-linux-medium
@@ -1199,7 +1272,8 @@ jobs:
       <<: *env-enable-sccache
       <<: *env-ninja-status
       TRIGGER_ARM_TEST: true
-    <<: *steps-electron-build-for-tests
+      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
+    <<: *steps-electron-build-with-inline-checkout-for-tests
 
   linux-arm-chromedriver:
     <<: *machine-linux-medium
@@ -1258,7 +1332,8 @@ jobs:
       <<: *env-enable-sccache
       <<: *env-ninja-status
       TRIGGER_ARM_TEST: true
-    <<: *steps-electron-build-for-tests
+      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
+    <<: *steps-electron-build-with-inline-checkout-for-tests
 
   linux-arm64-testing-gn-check:
     <<: *machine-linux-medium
@@ -1688,12 +1763,8 @@ workflows:
       - linux-x64-debug-gn-check:
           requires:
             - linux-checkout-fast
-      - linux-x64-testing:
-          requires:
-            - linux-checkout-fast
-      - linux-x64-testing-no-run-as-node:
-          requires:
-            - linux-checkout-fast
+      - linux-x64-testing
+      - linux-x64-testing-no-run-as-node
       - linux-x64-testing-gn-check:
           requires:
             - linux-checkout-fast
@@ -1710,9 +1781,7 @@ workflows:
       - linux-ia32-debug:
           requires:
             - linux-checkout-fast
-      - linux-ia32-testing:
-          requires:
-            - linux-checkout-fast
+      - linux-ia32-testing
       - linux-ia32-testing-tests:
           requires:
             - linux-ia32-testing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,6 +495,8 @@ step-maybe-zip-symbols: &step-maybe-zip-symbols
     command: |
       cd src
       export BUILD_PATH="$PWD/out/Default"
+      ninja -C out/Default electron:licenses
+      ninja -C out/Default electron:electron_version
       electron/script/zip-symbols.py -b $BUILD_PATH
 
 step-maybe-cross-arch-snapshot: &step-maybe-cross-arch-snapshot


### PR DESCRIPTION
After much late-night thinking, I have come to the conclusion that We Can Go Faster.  Putting up this PR now while I figure out the last few things.  Linux CI appears to be down at around ~15 minutes though so that's cool.  Previous average was anywhere from 23-30 minutes.  Expecting this to be around 15 - 20 on average.  The graphs will prove it though 😄 

Notes: no-notes