### PR TITLE
build: add WOA node headers to checksum file

### DIFF
--- a/script/release/uploaders/upload-node-checksums.py
+++ b/script/release/uploaders/upload-node-checksums.py
@@ -62,7 +62,10 @@ def get_files_list(version):
     { "filename": 'win-x86/iojs.lib', "required": False },
     { "filename": 'win-x64/iojs.lib', "required": False },
     { "filename": 'win-x86/node.lib', "required": False },
-    { "filename": 'win-x64/node.lib', "required": False }
+    { "filename": 'win-x64/node.lib', "required": False },
+    { "filename": 'arm64/node.lib', "required": False },
+    { "filename": 'win-arm64/iojs.lib', "required": False },
+    { "filename": 'win-arm64/node.lib', "required": False }
   ]
 
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
#20192 added support for Windows on Arm node headers but it didn't add those files to the checksums file.  This PR adds those files to the generated checksum file
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->Added Windows on Arm node header files to checksum file.
