### PR TITLE
chore: remove native_mate (Part 5)

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -494,6 +494,8 @@ filenames = {
     "shell/common/gin_helper/event_emitter_caller.h",
     "shell/common/gin_helper/function_template.cc",
     "shell/common/gin_helper/function_template.h",
+    "shell/common/gin_helper/object_template_builder.cc",
+    "shell/common/gin_helper/object_template_builder.h",
     "shell/common/heap_snapshot.cc",
     "shell/common/heap_snapshot.h",
     "shell/common/key_weak_map.h",

--- a/filenames.gni
+++ b/filenames.gni
@@ -476,6 +476,7 @@ filenames = {
     "shell/common/gin_converters/gurl_converter.h",
     "shell/common/gin_converters/image_converter.cc",
     "shell/common/gin_converters/image_converter.h",
+    "shell/common/gin_converters/native_mate_handle_converter.h",
     "shell/common/gin_converters/message_box_converter.cc",
     "shell/common/gin_converters/message_box_converter.h",
     "shell/common/gin_converters/native_window_converter.h",

--- a/native_mate/BUILD.gn
+++ b/native_mate/BUILD.gn
@@ -23,7 +23,7 @@ source_set("native_mate") {
     "native_mate/function_template.h",
     "native_mate/handle.h",
     "native_mate/object_template_builder.cc",
-    "native_mate/object_template_builder.h",
+    "native_mate/object_template_builder_deprecated.h",
     "native_mate/persistent_dictionary.cc",
     "native_mate/persistent_dictionary.h",
     "native_mate/scoped_persistent.h",

--- a/native_mate/README.md
+++ b/native_mate/README.md
@@ -45,7 +45,7 @@ void Initialize(v8::Handle<v8::Object> exports) {
   types. You can define your own by specializing `Converter`.
 * `function_template.h` - Create JavaScript functions that dispatch to any C++
   function, member function pointer, or `base::Callback`.
-* `object_template_builder.h` - A handy utility for creation of `v8::ObjectTemplate`.
+* `object_template_builder_deprecated.h` - A handy utility for creation of `v8::ObjectTemplate`.
 * `wrappable.h` - Base class for C++ classes that want to be owned by the V8 GC.
   Wrappable objects are automatically deleted when GC discovers that nothing in
   the V8 heap refers to them. This is also an easy way to expose C++ objects to

--- a/native_mate/native_mate/dictionary.h
+++ b/native_mate/native_mate/dictionary.h
@@ -6,7 +6,7 @@
 #define NATIVE_MATE_NATIVE_MATE_DICTIONARY_H_
 
 #include "native_mate/converter.h"
-#include "native_mate/object_template_builder.h"
+#include "native_mate/object_template_builder_deprecated.h"
 
 namespace mate {
 

--- a/native_mate/native_mate/object_template_builder.cc
+++ b/native_mate/native_mate/object_template_builder.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE.chromium file.
 
-#include "native_mate/object_template_builder.h"
+#include "native_mate/object_template_builder_deprecated.h"
 
 namespace mate {
 

--- a/native_mate/native_mate/object_template_builder_deprecated.h
+++ b/native_mate/native_mate/object_template_builder_deprecated.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE.chromium file.
 
-#ifndef NATIVE_MATE_NATIVE_MATE_OBJECT_TEMPLATE_BUILDER_H_
-#define NATIVE_MATE_NATIVE_MATE_OBJECT_TEMPLATE_BUILDER_H_
+#ifndef NATIVE_MATE_NATIVE_MATE_OBJECT_TEMPLATE_BUILDER_DEPRECATED_H_
+#define NATIVE_MATE_NATIVE_MATE_OBJECT_TEMPLATE_BUILDER_DEPRECATED_H_
 
 #include "base/bind.h"
 #include "base/callback.h"
@@ -117,4 +117,4 @@ class ObjectTemplateBuilder {
 
 }  // namespace mate
 
-#endif  // NATIVE_MATE_NATIVE_MATE_OBJECT_TEMPLATE_BUILDER_H_
+#endif  // NATIVE_MATE_NATIVE_MATE_OBJECT_TEMPLATE_BUILDER_DEPRECATED_H_

--- a/native_mate/native_mate/wrappable.cc
+++ b/native_mate/native_mate/wrappable.cc
@@ -6,7 +6,7 @@
 
 #include "base/logging.h"
 #include "native_mate/dictionary.h"
-#include "native_mate/object_template_builder.h"
+#include "native_mate/object_template_builder_deprecated.h"
 
 namespace mate {
 

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -17,6 +17,7 @@ web_contents.patch
 webview_cross_drag.patch
 disable_user_gesture_requirement_for_beforeunload_dialogs.patch
 gin_enable_disable_v8_platform.patch
+gin_with_namespace.patch
 blink-worker-enable-csp-in-file-scheme.patch
 disable-redraw-lock.patch
 v8_context_snapshot_generator.patch

--- a/patches/chromium/gin_with_namespace.patch
+++ b/patches/chromium/gin_with_namespace.patch
@@ -1,0 +1,83 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Thu, 20 Sep 2018 17:47:44 -0700
+Subject: gin_with_namespace.patch
+
+When using gin with native_mate together we may have C++ confused with
+finding the correct ConvertFromV8. We add gin:: namespace explicitly in
+those calls to work around the ambiguous compilation error.
+
+Note that this is only a work around to make it easier to remove
+native_mate, and we should remove this patch once native_mate is erased
+from Electron.
+
+diff --git a/gin/arguments.h b/gin/arguments.h
+index eaded13e2991..03e1495566d1 100644
+--- a/gin/arguments.h
++++ b/gin/arguments.h
+@@ -28,14 +28,14 @@ class GIN_EXPORT Arguments {
+     v8::Local<v8::Object> holder = is_for_property_
+                                        ? info_for_property_->Holder()
+                                        : info_for_function_->Holder();
+-    return ConvertFromV8(isolate_, holder, out);
++    return gin::ConvertFromV8(isolate_, holder, out);
+   }
+ 
+   template<typename T>
+   bool GetData(T* out) {
+     v8::Local<v8::Value> data = is_for_property_ ? info_for_property_->Data()
+                                                  : info_for_function_->Data();
+-    return ConvertFromV8(isolate_, data, out);
++    return gin::ConvertFromV8(isolate_, data, out);
+   }
+ 
+   template<typename T>
+@@ -45,7 +45,7 @@ class GIN_EXPORT Arguments {
+       return false;
+     }
+     v8::Local<v8::Value> val = (*info_for_function_)[next_++];
+-    return ConvertFromV8(isolate_, val, out);
++    return gin::ConvertFromV8(isolate_, val, out);
+   }
+ 
+   template<typename T>
+@@ -58,7 +58,7 @@ class GIN_EXPORT Arguments {
+     out->resize(remaining);
+     for (int i = 0; i < remaining; ++i) {
+       v8::Local<v8::Value> val = (*info_for_function_)[next_++];
+-      if (!ConvertFromV8(isolate_, val, &out->at(i)))
++      if (!gin::ConvertFromV8(isolate_, val, &out->at(i)))
+         return false;
+     }
+     return true;
+@@ -80,7 +80,7 @@ class GIN_EXPORT Arguments {
+   template<typename T>
+   void Return(T val) {
+     v8::Local<v8::Value> v8_value;
+-    if (!TryConvertToV8(isolate_, val, &v8_value))
++    if (!gin::TryConvertToV8(isolate_, val, &v8_value))
+       return;
+     (is_for_property_ ? info_for_property_->GetReturnValue()
+                       : info_for_function_->GetReturnValue())
+diff --git a/gin/converter.h b/gin/converter.h
+index 27b4d0acd016..b19209a8534a 100644
+--- a/gin/converter.h
++++ b/gin/converter.h
+@@ -250,7 +250,7 @@ std::enable_if_t<ToV8ReturnsMaybe<T>::value, bool> TryConvertToV8(
+     v8::Isolate* isolate,
+     const T& input,
+     v8::Local<v8::Value>* output) {
+-  return ConvertToV8(isolate, input).ToLocal(output);
++  return gin::ConvertToV8(isolate, input).ToLocal(output);
+ }
+ 
+ template <typename T>
+@@ -258,7 +258,7 @@ std::enable_if_t<!ToV8ReturnsMaybe<T>::value, bool> TryConvertToV8(
+     v8::Isolate* isolate,
+     const T& input,
+     v8::Local<v8::Value>* output) {
+-  *output = ConvertToV8(isolate, input);
++  *output = gin::ConvertToV8(isolate, input);
+   return true;
+ }
+ 

--- a/shell/browser/api/atom_api_app.cc
+++ b/shell/browser/api/atom_api_app.cc
@@ -30,7 +30,7 @@
 #include "content/public/common/content_switches.h"
 #include "gin/arguments.h"
 #include "media/audio/audio_manager.h"
-#include "native_mate/object_template_builder.h"
+#include "native_mate/object_template_builder_deprecated.h"
 #include "net/ssl/client_cert_identity.h"
 #include "net/ssl/ssl_cert_request_info.h"
 #include "services/service_manager/sandbox/switches.h"

--- a/shell/browser/api/atom_api_auto_updater.cc
+++ b/shell/browser/api/atom_api_auto_updater.cc
@@ -6,7 +6,7 @@
 
 #include "base/time/time.h"
 #include "native_mate/dictionary.h"
-#include "native_mate/object_template_builder.h"
+#include "native_mate/object_template_builder_deprecated.h"
 #include "shell/browser/browser.h"
 #include "shell/browser/native_window.h"
 #include "shell/browser/window_list.h"

--- a/shell/browser/api/atom_api_menu.cc
+++ b/shell/browser/api/atom_api_menu.cc
@@ -6,24 +6,22 @@
 
 #include <map>
 
-#include "gin/dictionary.h"
 #include "native_mate/constructor.h"
-#include "native_mate/object_template_builder_deprecated.h"
 #include "shell/browser/native_window.h"
 #include "shell/common/gin_converters/callback_converter.h"
+#include "shell/common/gin_converters/image_converter.h"
+#include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/native_mate_converters/accelerator_converter.h"
-#include "shell/common/native_mate_converters/image_converter.h"
-#include "shell/common/native_mate_converters/string16_converter.h"
 #include "shell/common/node_includes.h"
 
-// TODO(zcbenz): Remove this after removing mate::ObjectTemplateBuilder.
-#include "shell/common/native_mate_converters/callback_converter_deprecated.h"
-
 namespace {
+
 // We need this map to keep references to currently opened menus.
 // Without this menus would be destroyed by js garbage collector
 // even when they are still displayed.
 std::map<uint32_t, v8::Global<v8::Object>> g_menus;
+
 }  // unnamed namespace
 
 namespace electron {
@@ -224,9 +222,9 @@ void Menu::OnMenuWillShow() {
 // static
 void Menu::BuildPrototype(v8::Isolate* isolate,
                           v8::Local<v8::FunctionTemplate> prototype) {
-  prototype->SetClassName(mate::StringToV8(isolate, "Menu"));
+  prototype->SetClassName(gin::StringToV8(isolate, "Menu"));
   gin_helper::Destroyable::MakeDestroyable(isolate, prototype);
-  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
+  gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("insertItem", &Menu::InsertItemAt)
       .SetMethod("insertCheckItem", &Menu::InsertCheckItemAt)
       .SetMethod("insertRadioItem", &Menu::InsertRadioItemAt)
@@ -267,7 +265,7 @@ void Initialize(v8::Local<v8::Object> exports,
   v8::Isolate* isolate = context->GetIsolate();
   Menu::SetConstructor(isolate, base::BindRepeating(&Menu::New));
 
-  mate::Dictionary dict(isolate, exports);
+  gin_helper::Dictionary dict(isolate, exports);
   dict.Set(
       "Menu",
       Menu::GetConstructor(isolate)->GetFunction(context).ToLocalChecked());

--- a/shell/browser/api/atom_api_menu.cc
+++ b/shell/browser/api/atom_api_menu.cc
@@ -8,7 +8,7 @@
 
 #include "gin/dictionary.h"
 #include "native_mate/constructor.h"
-#include "native_mate/object_template_builder.h"
+#include "native_mate/object_template_builder_deprecated.h"
 #include "shell/browser/native_window.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/native_mate_converters/accelerator_converter.h"

--- a/shell/browser/api/atom_api_menu.h
+++ b/shell/browser/api/atom_api_menu.h
@@ -155,6 +155,20 @@ struct Converter<electron::AtomMenuModel*> {
   }
 };
 
+// TODO(zcbenz): Remove this after converting Menu to gin::Wrapper.
+template <>
+struct Converter<electron::api::Menu*> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     electron::api::Menu** out) {
+    return mate::ConvertFromV8(isolate, val, out);
+  }
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   electron::api::Menu* in) {
+    return mate::ConvertToV8(isolate, in);
+  }
+};
+
 }  // namespace gin
 
 #endif  // SHELL_BROWSER_API_ATOM_API_MENU_H_

--- a/shell/browser/api/atom_api_native_theme.cc
+++ b/shell/browser/api/atom_api_native_theme.cc
@@ -10,7 +10,7 @@
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "native_mate/dictionary.h"
-#include "native_mate/object_template_builder.h"
+#include "native_mate/object_template_builder_deprecated.h"
 #include "shell/common/node_includes.h"
 #include "ui/gfx/color_utils.h"
 #include "ui/native_theme/native_theme.h"

--- a/shell/browser/api/atom_api_notification.cc
+++ b/shell/browser/api/atom_api_notification.cc
@@ -8,7 +8,7 @@
 #include "base/strings/utf_string_conversions.h"
 #include "native_mate/constructor.h"
 #include "native_mate/dictionary.h"
-#include "native_mate/object_template_builder.h"
+#include "native_mate/object_template_builder_deprecated.h"
 #include "shell/browser/api/atom_api_menu.h"
 #include "shell/browser/atom_browser_client.h"
 #include "shell/browser/browser.h"

--- a/shell/browser/api/atom_api_screen.cc
+++ b/shell/browser/api/atom_api_screen.cc
@@ -9,7 +9,7 @@
 
 #include "base/bind.h"
 #include "gin/dictionary.h"
-#include "native_mate/object_template_builder.h"
+#include "native_mate/object_template_builder_deprecated.h"
 #include "shell/browser/browser.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/native_mate_converters/gfx_converter.h"

--- a/shell/browser/api/atom_api_screen.cc
+++ b/shell/browser/api/atom_api_screen.cc
@@ -9,9 +9,9 @@
 
 #include "base/bind.h"
 #include "gin/dictionary.h"
-#include "native_mate/object_template_builder_deprecated.h"
 #include "shell/browser/browser.h"
 #include "shell/common/gin_converters/callback_converter.h"
+#include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/native_mate_converters/gfx_converter.h"
 #include "shell/common/native_mate_converters/native_window_converter.h"
 #include "shell/common/node_includes.h"
@@ -134,22 +134,22 @@ void Screen::OnDisplayMetricsChanged(const display::Display& display,
 }
 
 // static
-v8::Local<v8::Value> Screen::Create(v8::Isolate* isolate) {
+v8::Local<v8::Value> Screen::Create(gin_helper::ErrorThrower error_thrower) {
   if (!Browser::Get()->is_ready()) {
-    isolate->ThrowException(v8::Exception::Error(mate::StringToV8(
-        isolate,
-        "The 'screen' module can't be used before the app 'ready' event")));
-    return v8::Null(isolate);
+    error_thrower.ThrowError(
+        "The 'screen' module can't be used before the app 'ready' event");
+    return v8::Null(error_thrower.isolate());
   }
 
   display::Screen* screen = display::Screen::GetScreen();
   if (!screen) {
-    isolate->ThrowException(v8::Exception::Error(
-        mate::StringToV8(isolate, "Failed to get screen information")));
-    return v8::Null(isolate);
+    error_thrower.ThrowError("Failed to get screen information");
+    return v8::Null(error_thrower.isolate());
   }
 
-  return mate::CreateHandle(isolate, new Screen(isolate, screen)).ToV8();
+  return mate::CreateHandle(error_thrower.isolate(),
+                            new Screen(error_thrower.isolate(), screen))
+      .ToV8();
 }
 
 // static

--- a/shell/browser/api/atom_api_screen.h
+++ b/shell/browser/api/atom_api_screen.h
@@ -7,8 +7,8 @@
 
 #include <vector>
 
-#include "native_mate/handle.h"
 #include "shell/browser/api/event_emitter.h"
+#include "shell/common/gin_helper/error_thrower.h"
 #include "ui/display/display_observer.h"
 #include "ui/display/screen.h"
 
@@ -25,7 +25,7 @@ namespace api {
 class Screen : public mate::EventEmitter<Screen>,
                public display::DisplayObserver {
  public:
-  static v8::Local<v8::Value> Create(v8::Isolate* isolate);
+  static v8::Local<v8::Value> Create(gin_helper::ErrorThrower error_thrower);
 
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype);

--- a/shell/browser/api/atom_api_session.cc
+++ b/shell/browser/api/atom_api_session.cc
@@ -33,7 +33,7 @@
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/self_owned_receiver.h"
 #include "native_mate/dictionary.h"
-#include "native_mate/object_template_builder.h"
+#include "native_mate/object_template_builder_deprecated.h"
 #include "net/base/completion_repeating_callback.h"
 #include "net/base/load_flags.h"
 #include "net/http/http_auth_handler_factory.h"

--- a/shell/browser/api/atom_api_session.h
+++ b/shell/browser/api/atom_api_session.h
@@ -121,4 +121,22 @@ class Session : public mate::TrackableObject<Session>,
 
 }  // namespace electron
 
+namespace gin {
+
+// TODO(zcbenz): Remove this after converting Session to gin::Wrapper.
+template <>
+struct Converter<electron::api::Session*> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     electron::api::Session** out) {
+    return mate::ConvertFromV8(isolate, val, out);
+  }
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   electron::api::Session* in) {
+    return mate::ConvertToV8(isolate, in);
+  }
+};
+
+}  // namespace gin
+
 #endif  // SHELL_BROWSER_API_ATOM_API_SESSION_H_

--- a/shell/browser/api/atom_api_system_preferences_mac.mm
+++ b/shell/browser/api/atom_api_system_preferences_mac.mm
@@ -21,7 +21,7 @@
 #include "base/strings/sys_string_conversions.h"
 #include "base/threading/sequenced_task_runner_handle.h"
 #include "base/values.h"
-#include "native_mate/object_template_builder.h"
+#include "native_mate/object_template_builder_deprecated.h"
 #include "net/base/mac/url_conversions.h"
 #include "shell/browser/mac/atom_application.h"
 #include "shell/browser/mac/dict_util.h"

--- a/shell/browser/api/atom_api_top_level_window.h
+++ b/shell/browser/api/atom_api_top_level_window.h
@@ -266,4 +266,22 @@ class TopLevelWindow : public mate::TrackableObject<TopLevelWindow>,
 
 }  // namespace electron
 
+namespace gin {
+
+// TODO(zcbenz): Remove this after converting TopLevelWindow to gin::Wrapper.
+template <>
+struct Converter<electron::api::TopLevelWindow*> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     electron::api::TopLevelWindow** out) {
+    return mate::ConvertFromV8(isolate, val, out);
+  }
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   electron::api::TopLevelWindow* in) {
+    return mate::ConvertToV8(isolate, in);
+  }
+};
+
+}  // namespace gin
+
 #endif  // SHELL_BROWSER_API_ATOM_API_TOP_LEVEL_WINDOW_H_

--- a/shell/browser/api/atom_api_url_request_ns.cc
+++ b/shell/browser/api/atom_api_url_request_ns.cc
@@ -9,11 +9,12 @@
 #include "mojo/public/cpp/bindings/receiver_set.h"
 #include "mojo/public/cpp/system/string_data_source.h"
 #include "native_mate/dictionary.h"
-#include "native_mate/object_template_builder_deprecated.h"
 #include "net/http/http_util.h"
 #include "services/network/public/mojom/chunked_data_pipe_getter.mojom.h"
 #include "shell/browser/api/atom_api_session.h"
 #include "shell/browser/atom_browser_context.h"
+#include "shell/common/gin_helper/event_emitter_caller.h"
+#include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/native_mate_converters/gurl_converter.h"
 #include "shell/common/native_mate_converters/net_converter.h"
 
@@ -312,8 +313,8 @@ void URLRequestNS::SetChunkedUpload(bool is_chunked_upload) {
     is_chunked_upload_ = is_chunked_upload;
 }
 
-mate::Dictionary URLRequestNS::GetUploadProgress() {
-  mate::Dictionary progress = mate::Dictionary::CreateEmpty(isolate());
+gin::Dictionary URLRequestNS::GetUploadProgress() {
+  gin::Dictionary progress = gin::Dictionary::CreateEmpty(isolate());
   if (loader_) {
     if (request_)
       progress.Set("started", false);
@@ -504,7 +505,7 @@ void URLRequestNS::EmitError(EventType type, base::StringPiece message) {
   else
     response_state_ |= STATE_FAILED;
   v8::HandleScope handle_scope(isolate());
-  auto error = v8::Exception::Error(mate::StringToV8(isolate(), message));
+  auto error = v8::Exception::Error(gin::StringToV8(isolate(), message));
   EmitEvent(type, false, "error", error);
 }
 
@@ -513,7 +514,7 @@ void URLRequestNS::EmitEvent(EventType type, Args... args) {
   const char* method =
       type == EventType::kRequest ? "_emitRequestEvent" : "_emitResponseEvent";
   v8::HandleScope handle_scope(isolate());
-  mate::CustomEmit(isolate(), GetWrapper(), method, args...);
+  gin_helper::CustomEmit(isolate(), GetWrapper(), method, args...);
 }
 
 // static
@@ -524,9 +525,9 @@ mate::WrappableBase* URLRequestNS::New(mate::Arguments* args) {
 // static
 void URLRequestNS::BuildPrototype(v8::Isolate* isolate,
                                   v8::Local<v8::FunctionTemplate> prototype) {
-  prototype->SetClassName(mate::StringToV8(isolate, "URLRequest"));
+  prototype->SetClassName(gin::StringToV8(isolate, "URLRequest"));
   gin_helper::Destroyable::MakeDestroyable(isolate, prototype);
-  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
+  gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("write", &URLRequestNS::Write)
       .SetMethod("cancel", &URLRequestNS::Cancel)
       .SetMethod("setExtraHeader", &URLRequestNS::SetExtraHeader)

--- a/shell/browser/api/atom_api_url_request_ns.cc
+++ b/shell/browser/api/atom_api_url_request_ns.cc
@@ -9,7 +9,7 @@
 #include "mojo/public/cpp/bindings/receiver_set.h"
 #include "mojo/public/cpp/system/string_data_source.h"
 #include "native_mate/dictionary.h"
-#include "native_mate/object_template_builder.h"
+#include "native_mate/object_template_builder_deprecated.h"
 #include "net/http/http_util.h"
 #include "services/network/public/mojom/chunked_data_pipe_getter.mojom.h"
 #include "shell/browser/api/atom_api_session.h"

--- a/shell/browser/api/atom_api_url_request_ns.h
+++ b/shell/browser/api/atom_api_url_request_ns.h
@@ -10,8 +10,9 @@
 #include <string>
 #include <vector>
 
+#include "gin/arguments.h"
+#include "gin/dictionary.h"
 #include "mojo/public/cpp/system/data_pipe_producer.h"
-#include "native_mate/dictionary.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "services/network/public/cpp/simple_url_loader.h"
 #include "services/network/public/cpp/simple_url_loader_stream_consumer.h"
@@ -47,7 +48,7 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
   bool SetExtraHeader(const std::string& name, const std::string& value);
   void RemoveExtraHeader(const std::string& name);
   void SetChunkedUpload(bool is_chunked_upload);
-  mate::Dictionary GetUploadProgress();
+  gin::Dictionary GetUploadProgress();
   int StatusCode() const;
   std::string StatusMessage() const;
   net::HttpResponseHeaders* RawResponseHeaders() const;
@@ -139,5 +140,23 @@ class URLRequestNS : public mate::EventEmitter<URLRequestNS>,
 }  // namespace api
 
 }  // namespace electron
+
+namespace gin {
+
+// TODO(zcbenz): Remove this after converting URLRequestNS to gin::Wrapper.
+template <>
+struct Converter<electron::api::URLRequestNS*> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     electron::api::URLRequestNS** out) {
+    return mate::ConvertFromV8(isolate, val, out);
+  }
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   electron::api::URLRequestNS* in) {
+    return mate::ConvertToV8(isolate, in);
+  }
+};
+
+}  // namespace gin
 
 #endif  // SHELL_BROWSER_API_ATOM_API_URL_REQUEST_NS_H_

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -46,7 +46,7 @@
 #include "mojo/public/cpp/system/platform_handle.h"
 #include "native_mate/converter.h"
 #include "native_mate/dictionary.h"
-#include "native_mate/object_template_builder.h"
+#include "native_mate/object_template_builder_deprecated.h"
 #include "shell/browser/api/atom_api_browser_window.h"
 #include "shell/browser/api/atom_api_debugger.h"
 #include "shell/browser/api/atom_api_session.h"

--- a/shell/browser/api/event.cc
+++ b/shell/browser/api/event.cc
@@ -6,7 +6,7 @@
 
 #include <utility>
 
-#include "native_mate/object_template_builder.h"
+#include "native_mate/object_template_builder_deprecated.h"
 #include "shell/common/native_mate_converters/value_converter.h"
 
 namespace mate {

--- a/shell/browser/api/event_emitter.cc
+++ b/shell/browser/api/event_emitter.cc
@@ -9,7 +9,7 @@
 #include "content/public/browser/render_frame_host.h"
 #include "native_mate/arguments.h"
 #include "native_mate/dictionary.h"
-#include "native_mate/object_template_builder.h"
+#include "native_mate/object_template_builder_deprecated.h"
 #include "shell/browser/api/event.h"
 #include "shell/common/node_includes.h"
 #include "ui/events/event_constants.h"

--- a/shell/browser/api/trackable_object.h
+++ b/shell/browser/api/trackable_object.h
@@ -9,7 +9,7 @@
 
 #include "base/bind.h"
 #include "base/memory/weak_ptr.h"
-#include "native_mate/object_template_builder.h"
+#include "native_mate/object_template_builder_deprecated.h"
 #include "shell/browser/api/event_emitter.h"
 #include "shell/common/key_weak_map.h"
 

--- a/shell/common/api/atom_api_asar.cc
+++ b/shell/common/api/atom_api_asar.cc
@@ -7,7 +7,7 @@
 #include <vector>
 
 #include "native_mate/arguments.h"
-#include "native_mate/object_template_builder.h"
+#include "native_mate/object_template_builder_deprecated.h"
 #include "native_mate/wrappable.h"
 #include "shell/common/asar/archive.h"
 #include "shell/common/gin_converters/callback_converter.h"

--- a/shell/common/api/atom_api_key_weak_map.h
+++ b/shell/common/api/atom_api_key_weak_map.h
@@ -6,7 +6,7 @@
 #define SHELL_COMMON_API_ATOM_API_KEY_WEAK_MAP_H_
 
 #include "native_mate/handle.h"
-#include "native_mate/object_template_builder.h"
+#include "native_mate/object_template_builder_deprecated.h"
 #include "native_mate/wrappable.h"
 #include "shell/common/key_weak_map.h"
 

--- a/shell/common/api/atom_api_key_weak_map.h
+++ b/shell/common/api/atom_api_key_weak_map.h
@@ -6,8 +6,9 @@
 #define SHELL_COMMON_API_ATOM_API_KEY_WEAK_MAP_H_
 
 #include "native_mate/handle.h"
-#include "native_mate/object_template_builder_deprecated.h"
 #include "native_mate/wrappable.h"
+#include "shell/common/gin_converters/std_converter.h"
+#include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/key_weak_map.h"
 
 namespace electron {
@@ -23,8 +24,8 @@ class KeyWeakMap : public mate::Wrappable<KeyWeakMap<K>> {
 
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype) {
-    prototype->SetClassName(mate::StringToV8(isolate, "KeyWeakMap"));
-    mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
+    prototype->SetClassName(gin::StringToV8(isolate, "KeyWeakMap"));
+    gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
         .SetMethod("set", &KeyWeakMap<K>::Set)
         .SetMethod("get", &KeyWeakMap<K>::Get)
         .SetMethod("has", &KeyWeakMap<K>::Has)
@@ -59,5 +60,23 @@ class KeyWeakMap : public mate::Wrappable<KeyWeakMap<K>> {
 }  // namespace api
 
 }  // namespace electron
+
+namespace gin {
+
+// TODO(zcbenz): Remove this after converting KeyWeakMap to gin::Wrapper.
+template <typename T>
+struct Converter<electron::api::KeyWeakMap<T>*> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     electron::api::KeyWeakMap<T>** out) {
+    return mate::ConvertFromV8(isolate, val, out);
+  }
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   electron::api::KeyWeakMap<T>* in) {
+    return mate::ConvertToV8(isolate, in);
+  }
+};
+
+}  // namespace gin
 
 #endif  // SHELL_COMMON_API_ATOM_API_KEY_WEAK_MAP_H_

--- a/shell/common/api/atom_api_native_image.cc
+++ b/shell/common/api/atom_api_native_image.cc
@@ -13,7 +13,7 @@
 #include "base/strings/pattern.h"
 #include "base/strings/string_util.h"
 #include "base/threading/thread_restrictions.h"
-#include "native_mate/object_template_builder.h"
+#include "native_mate/object_template_builder_deprecated.h"
 #include "net/base/data_url.h"
 #include "shell/common/asar/asar_util.h"
 #include "shell/common/native_mate_converters/file_path_converter.h"

--- a/shell/common/gin_converters/native_mate_handle_converter.h
+++ b/shell/common/gin_converters/native_mate_handle_converter.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_COMMON_GIN_CONVERTERS_NATIVE_MATE_HANDLE_CONVERTER_H_
+#define SHELL_COMMON_GIN_CONVERTERS_NATIVE_MATE_HANDLE_CONVERTER_H_
+
+#include "gin/converter.h"
+#include "native_mate/handle.h"
+
+namespace gin {
+
+// TODO(zcbenz): Remove this converter after native_mate is removed.
+
+template <typename T>
+struct Converter<mate::Handle<T>> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const mate::Handle<T>& in) {
+    return mate::ConvertToV8(isolate, in);
+  }
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     mate::Handle<T>* out) {
+    return mate::ConvertFromV8(isolate, val, out);
+  }
+};
+
+}  // namespace gin
+
+#endif  // SHELL_COMMON_GIN_CONVERTERS_NATIVE_MATE_HANDLE_CONVERTER_H_

--- a/shell/common/gin_converters/std_converter.h
+++ b/shell/common/gin_converters/std_converter.h
@@ -63,6 +63,22 @@ struct Converter<v8::Local<v8::Array>> {
   }
 };
 
+template <>
+struct Converter<v8::Local<v8::String>> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   v8::Local<v8::String> val) {
+    return val;
+  }
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     v8::Local<v8::String>* out) {
+    if (!val->IsString())
+      return false;
+    *out = v8::Local<v8::String>::Cast(val);
+    return true;
+  }
+};
+
 template <typename T>
 struct Converter<std::set<T>> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,

--- a/shell/common/gin_converters/value_converter_gin_adapter.h
+++ b/shell/common/gin_converters/value_converter_gin_adapter.h
@@ -26,6 +26,19 @@ struct Converter<base::DictionaryValue> {
 };
 
 template <>
+struct Converter<base::ListValue> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     base::ListValue* out) {
+    return mate::ConvertFromV8(isolate, val, out);
+  }
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const base::ListValue& val) {
+    return mate::ConvertToV8(isolate, val);
+  }
+};
+
+template <>
 struct Converter<base::Value> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,

--- a/shell/common/gin_helper/function_template.h
+++ b/shell/common/gin_helper/function_template.h
@@ -5,6 +5,7 @@
 #ifndef SHELL_COMMON_GIN_HELPER_FUNCTION_TEMPLATE_H_
 #define SHELL_COMMON_GIN_HELPER_FUNCTION_TEMPLATE_H_
 
+#include "base/bind.h"
 #include "base/callback.h"
 #include "gin/arguments.h"
 #include "shell/common/gin_helper/destroyable.h"
@@ -257,6 +258,43 @@ v8::Local<v8::FunctionTemplate> CreateFunctionTemplate(
                                    gin::ConvertToV8<v8::Local<v8::External>>(
                                        isolate, holder->GetHandle(isolate)));
 }
+
+// Base template - used only for non-member function pointers. Other types
+// either go to one of the below specializations, or go here and fail to compile
+// because of base::Bind().
+template <typename T, typename Enable = void>
+struct CallbackTraits {
+  static v8::Local<v8::FunctionTemplate> CreateTemplate(v8::Isolate* isolate,
+                                                        T callback) {
+    return CreateFunctionTemplate(isolate, base::BindRepeating(callback));
+  }
+};
+
+// Specialization for base::Callback.
+template <typename T>
+struct CallbackTraits<base::Callback<T>> {
+  static v8::Local<v8::FunctionTemplate> CreateTemplate(
+      v8::Isolate* isolate,
+      const base::RepeatingCallback<T>& callback) {
+    return CreateFunctionTemplate(isolate, callback);
+  }
+};
+
+// Specialization for member function pointers. We need to handle this case
+// specially because the first parameter for callbacks to MFP should typically
+// come from the the JavaScript "this" object the function was called on, not
+// from the first normal parameter.
+template <typename T>
+struct CallbackTraits<
+    T,
+    typename std::enable_if<std::is_member_function_pointer<T>::value>::type> {
+  static v8::Local<v8::FunctionTemplate> CreateTemplate(v8::Isolate* isolate,
+                                                        T callback) {
+    int flags = HolderIsFirstArgument;
+    return CreateFunctionTemplate(isolate, base::BindRepeating(callback),
+                                  flags);
+  }
+};
 
 }  // namespace gin_helper
 

--- a/shell/common/gin_helper/function_template.h
+++ b/shell/common/gin_helper/function_template.h
@@ -266,7 +266,8 @@ template <typename T, typename Enable = void>
 struct CallbackTraits {
   static v8::Local<v8::FunctionTemplate> CreateTemplate(v8::Isolate* isolate,
                                                         T callback) {
-    return CreateFunctionTemplate(isolate, base::BindRepeating(callback));
+    return gin_helper::CreateFunctionTemplate(isolate,
+                                              base::BindRepeating(callback));
   }
 };
 
@@ -276,7 +277,7 @@ struct CallbackTraits<base::Callback<T>> {
   static v8::Local<v8::FunctionTemplate> CreateTemplate(
       v8::Isolate* isolate,
       const base::RepeatingCallback<T>& callback) {
-    return CreateFunctionTemplate(isolate, callback);
+    return gin_helper::CreateFunctionTemplate(isolate, callback);
   }
 };
 
@@ -291,8 +292,8 @@ struct CallbackTraits<
   static v8::Local<v8::FunctionTemplate> CreateTemplate(v8::Isolate* isolate,
                                                         T callback) {
     int flags = HolderIsFirstArgument;
-    return CreateFunctionTemplate(isolate, base::BindRepeating(callback),
-                                  flags);
+    return gin_helper::CreateFunctionTemplate(
+        isolate, base::BindRepeating(callback), flags);
   }
 };
 

--- a/shell/common/gin_helper/object_template_builder.cc
+++ b/shell/common/gin_helper/object_template_builder.cc
@@ -1,0 +1,32 @@
+// Copyright (c) 2019 GitHub, Inc. All rights reserved.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/common/gin_helper/object_template_builder.h"
+
+namespace gin_helper {
+
+ObjectTemplateBuilder::ObjectTemplateBuilder(
+    v8::Isolate* isolate,
+    v8::Local<v8::ObjectTemplate> templ)
+    : isolate_(isolate), template_(templ) {}
+
+ObjectTemplateBuilder::~ObjectTemplateBuilder() = default;
+
+ObjectTemplateBuilder& ObjectTemplateBuilder::SetImpl(
+    const base::StringPiece& name,
+    v8::Local<v8::Data> val) {
+  template_->Set(gin::StringToSymbol(isolate_, name), val);
+  return *this;
+}
+
+ObjectTemplateBuilder& ObjectTemplateBuilder::SetPropertyImpl(
+    const base::StringPiece& name,
+    v8::Local<v8::FunctionTemplate> getter,
+    v8::Local<v8::FunctionTemplate> setter) {
+  template_->SetAccessorProperty(gin::StringToSymbol(isolate_, name), getter,
+                                 setter);
+  return *this;
+}
+
+}  // namespace gin_helper

--- a/shell/common/gin_helper/object_template_builder.h
+++ b/shell/common/gin_helper/object_template_builder.h
@@ -1,0 +1,72 @@
+// Copyright (c) 2019 GitHub, Inc. All rights reserved.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_COMMON_GIN_HELPER_OBJECT_TEMPLATE_BUILDER_H_
+#define SHELL_COMMON_GIN_HELPER_OBJECT_TEMPLATE_BUILDER_H_
+
+#include "shell/common/gin_helper/function_template.h"
+
+namespace gin_helper {
+
+// This class works like gin::ObjectTemplateBuilder, but operates on existing
+// prototype template instead of creating a new one.
+//
+// It also uses gin_helper::CreateFunctionTemplate for function templates to
+// support gin_helper types.
+class ObjectTemplateBuilder {
+ public:
+  ObjectTemplateBuilder(v8::Isolate* isolate,
+                        v8::Local<v8::ObjectTemplate> templ);
+  ~ObjectTemplateBuilder();
+
+  // It's against Google C++ style to return a non-const ref, but we take some
+  // poetic license here in order that all calls to Set() can be via the '.'
+  // operator and line up nicely.
+  template <typename T>
+  ObjectTemplateBuilder& SetValue(const base::StringPiece& name, T val) {
+    return SetImpl(name, ConvertToV8(isolate_, val));
+  }
+
+  // In the following methods, T and U can be function pointer, member function
+  // pointer, base::Callback, or v8::FunctionTemplate. Most clients will want to
+  // use one of the first two options. Also see gin::CreateFunctionTemplate()
+  // for creating raw function templates.
+  template <typename T>
+  ObjectTemplateBuilder& SetMethod(const base::StringPiece& name,
+                                   const T& callback) {
+    return SetImpl(name, CallbackTraits<T>::CreateTemplate(isolate_, callback));
+  }
+  template <typename T>
+  ObjectTemplateBuilder& SetProperty(const base::StringPiece& name,
+                                     const T& getter) {
+    return SetPropertyImpl(name,
+                           CallbackTraits<T>::CreateTemplate(isolate_, getter),
+                           v8::Local<v8::FunctionTemplate>());
+  }
+  template <typename T, typename U>
+  ObjectTemplateBuilder& SetProperty(const base::StringPiece& name,
+                                     const T& getter,
+                                     const U& setter) {
+    return SetPropertyImpl(name,
+                           CallbackTraits<T>::CreateTemplate(isolate_, getter),
+                           CallbackTraits<T>::CreateTemplate(isolate_, setter));
+  }
+
+ private:
+  ObjectTemplateBuilder& SetImpl(const base::StringPiece& name,
+                                 v8::Local<v8::Data> val);
+  ObjectTemplateBuilder& SetPropertyImpl(
+      const base::StringPiece& name,
+      v8::Local<v8::FunctionTemplate> getter,
+      v8::Local<v8::FunctionTemplate> setter);
+
+  v8::Isolate* isolate_;
+
+  // ObjectTemplateBuilder should only be used on the stack.
+  v8::Local<v8::ObjectTemplate> template_;
+};
+
+}  // namespace gin_helper
+
+#endif  // SHELL_COMMON_GIN_HELPER_OBJECT_TEMPLATE_BUILDER_H_

--- a/shell/common/gin_helper/object_template_builder.h
+++ b/shell/common/gin_helper/object_template_builder.h
@@ -14,6 +14,9 @@ namespace gin_helper {
 //
 // It also uses gin_helper::CreateFunctionTemplate for function templates to
 // support gin_helper types.
+//
+// TODO(zcbenz): We should patch gin::ObjectTemplateBuilder to provide the same
+// functionality after removing gin_helper/function_template.h.
 class ObjectTemplateBuilder {
  public:
   ObjectTemplateBuilder(v8::Isolate* isolate,

--- a/shell/renderer/api/atom_api_renderer_ipc.cc
+++ b/shell/renderer/api/atom_api_renderer_ipc.cc
@@ -7,14 +7,13 @@
 #include "base/task/post_task.h"
 #include "base/values.h"
 #include "content/public/renderer/render_frame.h"
-#include "electron/shell/common/api/api.mojom.h"
-#include "native_mate/arguments.h"
-#include "native_mate/dictionary.h"
-#include "native_mate/handle.h"
-#include "native_mate/object_template_builder_deprecated.h"
-#include "native_mate/wrappable.h"
+#include "gin/dictionary.h"
+#include "gin/handle.h"
+#include "gin/object_template_builder.h"
+#include "gin/wrappable.h"
 #include "services/service_manager/public/cpp/interface_provider.h"
-#include "shell/common/native_mate_converters/value_converter.h"
+#include "shell/common/api/api.mojom.h"
+#include "shell/common/gin_converters/value_converter_gin_adapter.h"
 #include "shell/common/node_bindings.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/promise_util.h"
@@ -33,11 +32,16 @@ RenderFrame* GetCurrentRenderFrame() {
   return RenderFrame::FromWebFrame(frame);
 }
 
-class IPCRenderer : public mate::Wrappable<IPCRenderer> {
+class IPCRenderer : public gin::Wrappable<IPCRenderer> {
  public:
+  static gin::WrapperInfo kWrapperInfo;
+
+  static gin::Handle<IPCRenderer> Create(v8::Isolate* isolate) {
+    return gin::CreateHandle(isolate, new IPCRenderer(isolate));
+  }
+
   explicit IPCRenderer(v8::Isolate* isolate)
       : task_runner_(base::CreateSingleThreadTaskRunner({base::ThreadPool()})) {
-    Init(isolate);
     RenderFrame* render_frame = GetCurrentRenderFrame();
     DCHECK(render_frame);
 
@@ -51,10 +55,10 @@ class IPCRenderer : public mate::Wrappable<IPCRenderer> {
                                                               task_runner_);
   }
 
-  static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::FunctionTemplate> prototype) {
-    prototype->SetClassName(mate::StringToV8(isolate, "IPCRenderer"));
-    mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
+  // gin::Wrappable:
+  gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
+      v8::Isolate* isolate) override {
+    return gin::Wrappable<IPCRenderer>::GetObjectTemplateBuilder(isolate)
         .SetMethod("send", &IPCRenderer::Send)
         .SetMethod("sendSync", &IPCRenderer::SendSync)
         .SetMethod("sendTo", &IPCRenderer::SendTo)
@@ -62,27 +66,26 @@ class IPCRenderer : public mate::Wrappable<IPCRenderer> {
         .SetMethod("invoke", &IPCRenderer::Invoke);
   }
 
-  static mate::Handle<IPCRenderer> Create(v8::Isolate* isolate) {
-    return mate::CreateHandle(isolate, new IPCRenderer(isolate));
-  }
+  const char* GetTypeName() override { return "IPCRenderer"; }
 
+ private:
   void Send(bool internal,
             const std::string& channel,
             const base::ListValue& arguments) {
     electron_browser_ptr_->get()->Message(internal, channel, arguments.Clone());
   }
 
-  v8::Local<v8::Promise> Invoke(mate::Arguments* args,
+  v8::Local<v8::Promise> Invoke(v8::Isolate* isolate,
                                 bool internal,
                                 const std::string& channel,
                                 const base::Value& arguments) {
-    electron::util::Promise<base::Value> p(args->isolate());
+    electron::util::Promise<base::Value> p(isolate);
     auto handle = p.GetHandle();
 
     electron_browser_ptr_->get()->Invoke(
         internal, channel, arguments.Clone(),
         base::BindOnce([](electron::util::Promise<base::Value> p,
-                          base::Value result) { p.Resolve(result); },
+                          base::Value result) { p.ResolveWithGin(result); },
                        std::move(p)));
 
     return handle;
@@ -169,7 +172,6 @@ class IPCRenderer : public mate::Wrappable<IPCRenderer> {
     return result;
   }
 
- private:
   void SendMessageSyncOnWorkerThread(base::WaitableEvent* event,
                                      base::Value* result,
                                      bool internal,
@@ -180,6 +182,7 @@ class IPCRenderer : public mate::Wrappable<IPCRenderer> {
         base::BindOnce(&IPCRenderer::ReturnSyncResponseToMainThread,
                        base::Unretained(event), base::Unretained(result)));
   }
+
   static void ReturnSyncResponseToMainThread(base::WaitableEvent* event,
                                              base::Value* result,
                                              base::Value response) {
@@ -192,11 +195,13 @@ class IPCRenderer : public mate::Wrappable<IPCRenderer> {
       electron_browser_ptr_;
 };
 
+gin::WrapperInfo IPCRenderer::kWrapperInfo = {gin::kEmbedderNativeGin};
+
 void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context,
                 void* priv) {
-  mate::Dictionary dict(context->GetIsolate(), exports);
+  gin::Dictionary dict(context->GetIsolate(), exports);
   dict.Set("ipc", IPCRenderer::Create(context->GetIsolate()));
 }
 

--- a/shell/renderer/api/atom_api_renderer_ipc.cc
+++ b/shell/renderer/api/atom_api_renderer_ipc.cc
@@ -11,7 +11,7 @@
 #include "native_mate/arguments.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/handle.h"
-#include "native_mate/object_template_builder.h"
+#include "native_mate/object_template_builder_deprecated.h"
 #include "native_mate/wrappable.h"
 #include "services/service_manager/public/cpp/interface_provider.h"
 #include "shell/common/native_mate_converters/value_converter.h"


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/16443.

This PR removes some uses of `mate::ObjectTemplateBuilder`, which is a major blocker to convert class methods to `gin`.

More uses will be removed in the next PR.

#### Release Notes

Notes: no-notes