### PR TITLE
perf: only access remote module when <webview>.getWebContents() is called

### DIFF
--- a/lib/renderer/web-view/web-view-impl.ts
+++ b/lib/renderer/web-view/web-view-impl.ts
@@ -1,10 +1,11 @@
-import { remote, webFrame } from 'electron'
+import * as electron from 'electron'
 
 import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal'
 import * as ipcRendererUtils from '@electron/internal/renderer/ipc-renderer-internal-utils'
 import * as guestViewInternal from '@electron/internal/renderer/web-view/guest-view-internal'
 import { WEB_VIEW_CONSTANTS } from '@electron/internal/renderer/web-view/web-view-constants'
 import { syncMethods, asyncMethods } from '@electron/internal/common/web-view-methods'
+const { webFrame } = electron
 
 const v8Util = process.electronBinding('v8_util')
 
@@ -225,6 +226,7 @@ export const setupMethods = (WebViewElement: typeof ElectronInternal.WebViewElem
 
   // WebContents associated with this webview.
   WebViewElement.prototype.getWebContents = function () {
+    const remote = electron.remote as Electron.RemoteInternal
     if (!remote) {
       throw new Error('getGuestWebContents requires remote, which is not enabled')
     }
@@ -233,7 +235,7 @@ export const setupMethods = (WebViewElement: typeof ElectronInternal.WebViewElem
       internal.createGuestSync()
     }
 
-    return (remote as Electron.RemoteInternal).getGuestWebContents(internal.guestInstanceId!)
+    return remote.getGuestWebContents(internal.guestInstanceId!)
   }
 
   // Focusing the webview should move page focus to the underlying iframe.


### PR DESCRIPTION
#### Description of Change
Fixes small performance regression introduced in #17200, where the `remote` module was imported unconditionally even though it's only used to implement `<webview>.getWebContents()`.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes