### PR TITLE
ci: workaround circleci not working with booleans

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,40 +6,40 @@ parameters:
     default: '1'
   
   run-lint:
-    type: boolean
-    default: true
+    type: string
+    default: 'true'
 
   run-build-linux:
-    type: boolean
-    default: true
+    type: string
+    default: 'true'
 
   run-build-mac:
-    type: boolean
-    default: true
+    type: string
+    default: 'true'
 
   run-linux-x64-publish:
-    type: boolean
-    default: false
+    type: string
+    default: ''
 
   run-linux-ia32-publish:
-    type: boolean
-    default: false
+    type: string
+    default: ''
 
   run-linux-arm-publish:
-    type: boolean
-    default: false
+    type: string
+    default: ''
   
   run-linux-arm64-publish:
-    type: boolean
-    default: false
+    type: string
+    default: ''
   
   run-osx-publish:
-    type: boolean
-    default: false
+    type: string
+    default: ''
 
   run-mas-publish:
-    type: boolean
-    default: false
+    type: string
+    default: ''
 
 # The config expects the following environment variables to be set:
 #  - "SLACK_WEBHOOK" Slack hook URL to send notifications.

--- a/script/release/ci-release-build.js
+++ b/script/release/ci-release-build.js
@@ -61,9 +61,9 @@ async function circleCIcall (targetBranch, job, options) {
   const buildRequest = {
     'branch': targetBranch,
     'parameters': {
-      'run-lint': false,
-      'run-build-linux': false,
-      'run-build-mac': false
+      'run-lint': '',
+      'run-build-linux': '',
+      'run-build-mac': ''
     }
   }
   if (options.ghRelease) {
@@ -71,7 +71,7 @@ async function circleCIcall (targetBranch, job, options) {
   } else {
     buildRequest.parameters['upload-to-s3'] = '1'
   }
-  buildRequest.parameters[`run-${job}`] = true
+  buildRequest.parameters[`run-${job}`] = 'true'
   jobRequestedCount++
   // The logic below expects that the CircleCI workflows for releases each
   // contain only one job in order to maintain compatibility with sudowoodo.


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Followup to #20245.  For some reason, CircleCI isn't reading the boolean parameters we send as booleans.  This PR changes our CircleCI config to use strings instead as a temporary workaround so that nightly releases work.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
