### PR TITLE
ci: only kill WOA processes if they are running

### DIFF
--- a/azure-pipelines-woa.yml
+++ b/azure-pipelines-woa.yml
@@ -77,8 +77,8 @@ steps:
     python electron\script\verify-ffmpeg.py --build-dir out\Default --source-root %cd% --ffmpeg-path out\ffmpeg
   displayName: 'Verify ffmpeg'
 
-- script: |
-    taskkill /F /IM electron.exe
-    taskkill /F /IM MicrosoftEdge.exe
+- powershell: |
+    Get-Process | Where Name –Like "electron.exe*" | Stop-Process
+    Get-Process | Where Name –Like "MicrosoftEdge.exe*" | Stop-Process
   displayName: 'Kill processes left running from last test run'
   condition: always()


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
This PR updates our `electron-woa-testing` CI to not error out if there are no leftover processes running, eg as happened in https://github.visualstudio.com/electron/_build/results?buildId=49977
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
