### PR TITLE
ci: Fix triggering CircleCI release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1789,7 +1789,6 @@ jobs:
       - *step-maybe-notify-slack-success
 
 workflows:
-  version: 2
 
   # The publish workflows below each contain one job so that they are 
   # compatible with how sudowoodo works today.  If these workflows are

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1789,6 +1789,7 @@ jobs:
       - *step-maybe-notify-slack-success
 
 workflows:
+  version: 2.1
 
   # The publish workflows below each contain one job so that they are 
   # compatible with how sudowoodo works today.  If these workflows are


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Followup to #20245.   The nightly release failed because CircleCI was interpreting booleans we were sending as strings.  This PR fixes that issues.  Supercedes #20273

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
