### PR TITLE
fix: correct 'Entire screen' to 'Entire Screen'

### DIFF
--- a/electron_strings.grdp
+++ b/electron_strings.grdp
@@ -13,7 +13,7 @@
 
   <!-- Desktop Capturer API -->
   <message name="IDS_DESKTOP_MEDIA_PICKER_SINGLE_SCREEN_NAME" desc="Name for screens in the desktop media picker UI when there is only one monitor.">
-    Entire screen
+    Entire Screen
   </message>
   <message name="IDS_DESKTOP_MEDIA_PICKER_MULTIPLE_SCREEN_NAME" desc="Name for screens in the desktop media picker UI when there are multiple monitors.">
     {SCREEN_INDEX, plural, =1{Screen #} other{Screen #}}


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/20267.

Correct capitalization of 'Entire Screen'.

cc @jkleinsc @nornagon @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
