### PR TITLE
fix: free screen capturers after usage ends

### DIFF
--- a/patches/chromium/desktop_media_list.patch
+++ b/patches/chromium/desktop_media_list.patch
@@ -133,7 +133,7 @@ index 47401abc984e6fe26c7f4c5399aa565c687060b0..ca6a527ffac877c27aac94337ec5a7b5
   protected:
    virtual ~DesktopMediaListObserver() {}
 diff --git a/chrome/browser/media/webrtc/native_desktop_media_list.cc b/chrome/browser/media/webrtc/native_desktop_media_list.cc
-index b2005c70acbc1c05c59bb2059b190ab78fb63a68..1a7188e2df76672d66da3206d4448df35a065754 100644
+index b2005c70acbc1c05c59bb2059b190ab78fb63a68..6cfc3007549b2e7992334b708e4e71a00974c2a3 100644
 --- a/chrome/browser/media/webrtc/native_desktop_media_list.cc
 +++ b/chrome/browser/media/webrtc/native_desktop_media_list.cc
 @@ -8,14 +8,15 @@
@@ -153,3 +153,12 @@ index b2005c70acbc1c05c59bb2059b190ab78fb63a68..1a7188e2df76672d66da3206d4448df3
  #include "media/base/video_util.h"
  #include "third_party/libyuv/include/libyuv/scale_argb.h"
  #include "third_party/skia/include/core/SkBitmap.h"
+@@ -218,6 +219,8 @@ void NativeDesktopMediaList::Worker::RefreshThumbnails(
+       FROM_HERE, {BrowserThread::UI},
+       base::BindOnce(&NativeDesktopMediaList::UpdateNativeThumbnailsFinished,
+                      media_list_));
++
++  capturer_.reset();
+ }
+ 
+ void NativeDesktopMediaList::Worker::OnCaptureResult(

--- a/shell/browser/api/atom_api_desktop_capturer.cc
+++ b/shell/browser/api/atom_api_desktop_capturer.cc
@@ -144,7 +144,6 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
     }
     std::move(window_sources.begin(), window_sources.end(),
               std::back_inserter(captured_sources_));
-    window_capturer_.reset();
   }
 
   if (capture_screen_ &&
@@ -195,7 +194,6 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
     // individual screen support is added.
     std::move(screen_sources.begin(), screen_sources.end(),
               std::back_inserter(captured_sources_));
-    screen_capturer_.reset();
   }
 
   if (!capture_window_ && !capture_screen_)

--- a/shell/browser/api/atom_api_desktop_capturer.cc
+++ b/shell/browser/api/atom_api_desktop_capturer.cc
@@ -144,6 +144,7 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
     }
     std::move(window_sources.begin(), window_sources.end(),
               std::back_inserter(captured_sources_));
+    window_capturer_.reset();
   }
 
   if (capture_screen_ &&
@@ -194,6 +195,7 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
     // individual screen support is added.
     std::move(screen_sources.begin(), screen_sources.end(),
               std::back_inserter(captured_sources_));
+    screen_capturer_.reset();
   }
 
   if (!capture_window_ && !capture_screen_)


### PR DESCRIPTION
#### Description of Change

Backport of https://github.com/electron/electron/pull/20156.

See that PR for more details.

cc @electron/wg-releases 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed desktopCapturer leak.