### PR TITLE
fix: crash when exiting simple fullscreen on macOS

### DIFF
--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -157,7 +157,7 @@ class NativeWindowMac : public NativeWindow {
   AtomTouchBar* touch_bar() const { return touch_bar_.get(); }
   bool zoom_to_page_width() const { return zoom_to_page_width_; }
   bool fullscreen_window_title() const { return fullscreen_window_title_; }
-  bool simple_fullscreen() const { return always_simple_fullscreen_; }
+  bool always_simple_fullscreen() const { return always_simple_fullscreen_; }
 
  protected:
   // views::WidgetDelegate:

--- a/atom/browser/ui/cocoa/atom_ns_window.mm
+++ b/atom/browser/ui/cocoa/atom_ns_window.mm
@@ -174,8 +174,14 @@ bool ScopedDisableResize::disable_resize_ = false;
 }
 
 - (void)toggleFullScreenMode:(id)sender {
-  if (shell_->simple_fullscreen())
-    shell_->SetSimpleFullScreen(!shell_->IsSimpleFullScreen());
+  bool is_simple_fs = shell_->IsSimpleFullScreen();
+  bool always_simple_fs = shell_->always_simple_fullscreen();
+
+  // If we're in simple fullscreen mode and trying to exit it
+  // we need to ensure we exit it properly to prevent a crash
+  // with NSWindowStyleMaskTitled mode
+  if (is_simple_fs || always_simple_fs)
+    shell_->SetSimpleFullScreen(!is_simple_fs);
   else
     [super toggleFullScreen:sender];
 }

--- a/spec/api-browser-window-spec.js
+++ b/spec/api-browser-window-spec.js
@@ -3090,6 +3090,17 @@ describe('BrowserWindow module', () => {
         w.setFullScreen(true)
       })
 
+      it('does not crash when exiting simpleFullScreen', (done) => {
+        w.destroy()
+        w = new BrowserWindow()
+        w.setSimpleFullScreen(true)
+
+        setTimeout(() => {
+          w.setFullScreen(!w.isFullScreen())
+          done()
+        }, 1000)
+      })
+
       it('should not be changed by setKiosk method', (done) => {
         w.destroy()
         w = new BrowserWindow()


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/20144.

See that PR for more details.

Notes: Fixed a crash when exiting simple fullscreen on macOS.
