### PR TITLE
ci: actually kill leftover processes on WOA testing

### DIFF
--- a/azure-pipelines-woa.yml
+++ b/azure-pipelines-woa.yml
@@ -78,7 +78,7 @@ steps:
   displayName: 'Verify ffmpeg'
 
 - powershell: |
-    Get-Process | Where Name –Like "electron.exe*" | Stop-Process
-    Get-Process | Where Name –Like "MicrosoftEdge.exe*" | Stop-Process
+    Get-Process | Where Name –Like "electron*" | Stop-Process
+    Get-Process | Where Name –Like "MicrosoftEdge*" | Stop-Process
   displayName: 'Kill processes left running from last test run'
   condition: always()


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
#20274 changed how we cleanup WOA CI to kill leftover process only if they were running.  However there is a change in usage of the Powershell commands versus the command used before and the new change was not actually killing anything when it ran.  This PR updates the cleanup step to actually kill the processes if they are running.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
