### PR TITLE
docs: Update selenium with webdriverIO docs

### DIFF
--- a/docs/tutorial/using-selenium-and-webdriver.md
+++ b/docs/tutorial/using-selenium-and-webdriver.md
@@ -139,7 +139,7 @@ const options = {
   port: 9515, // "9515" is the port opened by chrome driver.
   desiredCapabilities: {
     browserName: 'chrome',
-    chromeOptions: {
+    'goog:chromeOptions': {
       binary: '/Path-to-Your-App/electron', // Path to your Electron binary.
       args: [/* cli arguments */] // Optional, perhaps 'app=' + /path/to/your/app/
     }


### PR DESCRIPTION
#### Description of Change
I was getting this error when trying to run webDriverIO directly with Electron 
`worker error { name: 'invalid argument',
  message: 'invalid argument: unrecognized capability: chromeOptions',`

After digging around wdio's docs I saw  [this example](https://github.com/webdriverio/webdriverio/blob/master/e2e/wdio/wdio.conf.js) of a `wdio.conf.js` and saw they call the property `'goog:chromeOptions'` instead. Making that change fixed the error and I was able to successfully spin up our Electron app.
 
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
(https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
notes: no-notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
