### PR TITLE
fix: restore rounded window corners for vibrant windows on Mac

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1370,6 +1370,28 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
     [effect_view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
     [effect_view setBlendingMode:NSVisualEffectBlendingModeBehindWindow];
     [effect_view setState:NSVisualEffectStateActive];
+
+    // The default corner radius of a macOS window.
+    CGFloat radius = 5.0f;
+    CGFloat dimension = 2 * radius + 1;
+    NSSize size = NSMakeSize(dimension, dimension);
+    NSImage* maskImage = [[NSImage imageWithSize:size
+                                         flipped:NO
+                                  drawingHandler:^BOOL(NSRect rect) {
+                                    NSBezierPath* bezierPath = [NSBezierPath
+                                        bezierPathWithRoundedRect:rect
+                                                          xRadius:radius
+                                                          yRadius:radius];
+                                    [[NSColor blackColor] set];
+                                    [bezierPath fill];
+                                    return YES;
+                                  }] autorelease];
+    [maskImage setCapInsets:NSEdgeInsetsMake(radius, radius, radius, radius)];
+    [maskImage setResizingMode:NSImageResizingModeStretch];
+
+    [effect_view setMaskImage:maskImage];
+    [window_ setCornerMask:maskImage];
+
     [[window_ contentView] addSubview:effect_view
                            positioned:NSWindowBelow
                            relativeTo:nil];

--- a/shell/browser/ui/cocoa/atom_ns_window.h
+++ b/shell/browser/ui/cocoa/atom_ns_window.h
@@ -36,12 +36,14 @@ class ScopedDisableResize {
 @property BOOL disableAutoHideCursor;
 @property BOOL disableKeyOrMainWindow;
 @property(nonatomic, retain) NSView* vibrantView;
+@property(nonatomic, retain) NSImage* cornerMask;
 - (id)initWithShell:(electron::NativeWindowMac*)shell
           styleMask:(NSUInteger)styleMask;
 - (electron::NativeWindowMac*)shell;
 - (id)accessibilityFocusedUIElement;
 - (NSRect)originalContentRectForFrameRect:(NSRect)frameRect;
 - (void)toggleFullScreenMode:(id)sender;
+- (NSImage*)_cornerMask;
 @end
 
 #endif  // SHELL_BROWSER_UI_COCOA_ATOM_NS_WINDOW_H_

--- a/shell/browser/ui/cocoa/atom_ns_window.mm
+++ b/shell/browser/ui/cocoa/atom_ns_window.mm
@@ -24,6 +24,7 @@ bool ScopedDisableResize::disable_resize_ = false;
 @synthesize disableAutoHideCursor;
 @synthesize disableKeyOrMainWindow;
 @synthesize vibrantView;
+@synthesize cornerMask;
 
 - (id)initWithShell:(electron::NativeWindowMac*)shell
           styleMask:(NSUInteger)styleMask {
@@ -135,6 +136,12 @@ bool ScopedDisableResize::disable_resize_ = false;
 
 - (NSView*)frameView {
   return [[self contentView] superview];
+}
+
+// By overriding this built-in method the corners of the vibrant view (if set)
+// will be smooth.
+- (NSImage*)_cornerMask {
+  return [self cornerMask];
 }
 
 // Quicklook methods


### PR DESCRIPTION
#### Description of Change

I opened this issue a few years ago and finally got around to looking at it again:

https://github.com/electron/electron/issues/10886

I saw a potential solution here:

https://github.com/electron/electron/pull/8354

And so ported this to the current codebase, and tested it successfully on master.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are no change, fixed visual bug

#### Release Notes

Notes: Fixed vibrant windows not properly having rounded corners on Mac.

#### Example

Here's before:

<img width="1196" alt="before" src="https://user-images.githubusercontent.com/12100/64390696-ba8bab80-cffa-11e9-91b9-46c64d116316.png">

And after:

<img width="1196" alt="Screen Shot 2019-09-05 at 4 20 18 PM" src="https://user-images.githubusercontent.com/12100/64390664-992abf80-cffa-11e9-80dd-a5dc8d7ad705.png">


