### PR TITLE
feat: properly serialize NaN and infinite numbers in the remote module

### DIFF
--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -6,6 +6,13 @@ Breaking changes will be documented here, and deprecation warnings added to JS c
 
 The `FIXME` string is used in code comments to denote things that should be fixed for future releases. See https://github.com/electron/electron/search?q=fixme
 
+## Planned Breaking API Changes (8.0)
+
+### Remote module handling of NaN and infinite numbers
+
+`NaN`, `Infinity` and `-Infinity` are now properly serialized by the `remote` module.
+Before the fix, these values were converted to `undefined`.
+
 ## Planned Breaking API Changes (7.0)
 
 ### Node Headers URL

--- a/lib/browser/remote/server.js
+++ b/lib/browser/remote/server.js
@@ -122,6 +122,9 @@ const valueToMeta = function (sender, contextId, value, optimizeSimpleObject = f
     })
   } else if (meta.type === 'date') {
     meta.value = value.getTime()
+  } else if (meta.type === 'number' && (isNaN(value) || !isFinite(value))) {
+    meta.type = 'number'
+    meta.value = `${value}`
   } else {
     meta.type = 'value'
     meta.value = value
@@ -181,6 +184,8 @@ const unwrapArgs = function (sender, frameId, contextId, args) {
     switch (meta.type) {
       case 'value':
         return meta.value
+      case 'number':
+        return Number(meta.value)
       case 'remote-object':
         return objectsRegistry.get(meta.id)
       case 'array':

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -93,6 +93,11 @@ function wrapArgs (args, visited = new Set()) {
         location: v8Util.getHiddenValue(value, 'location'),
         length: value.length
       }
+    } else if (typeof value === 'number' && (isNaN(value) || !isFinite(value))) {
+      return {
+        type: 'number',
+        value: `${value}`
+      }
     } else {
       return {
         type: 'value',
@@ -213,6 +218,7 @@ function proxyFunctionProperties (remoteMemberFunction, metaId, name) {
 function metaToValue (meta) {
   const types = {
     value: () => meta.value,
+    number: () => Number(meta.value),
     array: () => meta.members.map((member) => metaToValue(member)),
     buffer: () => bufferUtils.metaToBuffer(meta.value),
     promise: () => Promise.resolve({ then: metaToValue(meta.then) }),

--- a/spec/api-remote-spec.js
+++ b/spec/api-remote-spec.js
@@ -241,14 +241,19 @@ ifdescribe(features.isRemoteModuleEnabled())('remote module', () => {
     const print = path.join(fixtures, 'module', 'print_name.js')
     const printName = remote.require(print)
 
-    it('converts NaN to undefined', () => {
-      expect(printName.getNaN()).to.be.undefined()
-      expect(printName.echo(NaN)).to.be.undefined()
+    it('preserves NaN', () => {
+      expect(printName.getNaN()).to.be.NaN()
+      expect(printName.echo(NaN)).to.be.NaN()
     })
 
-    it('converts Infinity to undefined', () => {
-      expect(printName.getInfinity()).to.be.undefined()
-      expect(printName.echo(Infinity)).to.be.undefined()
+    it('preserves Infinity', () => {
+      expect(printName.getInfinity()).to.equal(Infinity)
+      expect(printName.echo(Infinity)).to.equal(Infinity)
+    })
+
+    it('preserves -Infinity', () => {
+      expect(printName.getNegativeInfinity()).to.equal(-Infinity)
+      expect(printName.echo(-Infinity)).to.equal(-Infinity)
     })
 
     it('keeps its constructor name for objects', () => {

--- a/spec/fixtures/module/print_name.js
+++ b/spec/fixtures/module/print_name.js
@@ -34,3 +34,7 @@ exports.getNaN = function () {
 exports.getInfinity = function () {
   return Infinity
 }
+
+exports.getNegativeInfinity = function () {
+  return -Infinity
+}


### PR DESCRIPTION
#### Description of Change
`NaN`, `Infinity` and `-Infinity` are now properly serialized by the `remote` module.
Before the fix, these values were converted to `undefined`.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: `NaN`, `Infinity` and `-Infinity` are now properly serialized by the `remote` module.