### PR TITLE
docs: WebContents console-message event is emitted for offscreen windows

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -705,8 +705,7 @@ Returns:
 * `line` Integer
 * `sourceId` String
 
-Emitted when the associated window logs a console message. Will not be emitted
-for windows with *offscreen rendering* enabled.
+Emitted when the associated window logs a console message.
 
 #### Event: 'preload-error'
 


### PR DESCRIPTION
#### Description of Change

WebContents console-message event is emitted for offscreen windows since c3d11a51cc03ec5e891ab6d86e8f6f2abe56cf58

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


notes: no-notes
