### PR TITLE
fix: correctly crash when there is no crashReporter

### DIFF
--- a/shell/common/crash_reporter/crash_reporter_win.cc
+++ b/shell/common/crash_reporter/crash_reporter_win.cc
@@ -28,9 +28,17 @@ namespace {
 #if defined(_WIN64)
 int CrashForException(EXCEPTION_POINTERS* info) {
   auto* reporter = crash_reporter::CrashReporterWin::GetInstance();
-  if (reporter->IsInitialized())
+  if (reporter->IsInitialized()) {
     reporter->GetCrashpadClient().DumpAndCrash(info);
-  return EXCEPTION_CONTINUE_SEARCH;
+    return EXCEPTION_CONTINUE_SEARCH;
+  }
+
+  // When there is exception and we do not have crashReporter set up, we just
+  // let the execution continue and crash, which is the default behavior.
+  //
+  // We must not return EXCEPTION_CONTINUE_SEARCH here, as it would end up with
+  // busy loop when there is no exception handler in the program.
+  return EXCEPTION_CONTINUE_EXECUTION;
 }
 #endif
 

--- a/spec/api-crash-reporter-spec.js
+++ b/spec/api-crash-reporter-spec.js
@@ -415,6 +415,16 @@ describe('crashReporter module', () => {
       expect(crashReporter.getParameters()).to.not.have.a.property('hello')
     })
   })
+
+  describe('when not started', () => {
+    it('does not prevent process from crashing', (done) => {
+      const appPath = path.join(fixtures, 'api', 'cookie-app')
+      const appProcess = childProcess.spawn(process.execPath, [appPath])
+      appProcess.once('close', () => {
+        done()
+      })
+    })
+  })
 })
 
 const waitForCrashReport = () => {

--- a/spec/fixtures/crash-app/main.js
+++ b/spec/fixtures/crash-app/main.js
@@ -1,0 +1,5 @@
+const { app } = require('electron')
+
+app.on('ready', () => {
+  process.crash()
+})

--- a/spec/fixtures/crash-app/package.json
+++ b/spec/fixtures/crash-app/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "electron-crash-app",
+  "main": "main.js"
+}


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/20233.

When there is exception and we do not have crashReporter set up, we should let the execution continue and crash, which is the default behavior of Windows programs.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix process taking 100% CPU when crashed with no crashReporter set up on Windows x64.