### PR TITLE
chore: remove native_mate (Part 6)

### DIFF
--- a/shell/browser/api/atom_api_native_theme.cc
+++ b/shell/browser/api/atom_api_native_theme.cc
@@ -9,8 +9,10 @@
 #include "base/task/post_task.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
-#include "native_mate/dictionary.h"
-#include "native_mate/object_template_builder_deprecated.h"
+#include "gin/handle.h"
+#include "shell/common/gin_converters/std_converter.h"
+#include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
 #include "ui/gfx/color_utils.h"
 #include "ui/native_theme/native_theme.h"
@@ -84,14 +86,14 @@ bool NativeTheme::ShouldUseInvertedColorScheme() {
 // static
 v8::Local<v8::Value> NativeTheme::Create(v8::Isolate* isolate) {
   ui::NativeTheme* theme = ui::NativeTheme::GetInstanceForNativeUi();
-  return mate::CreateHandle(isolate, new NativeTheme(isolate, theme)).ToV8();
+  return gin::CreateHandle(isolate, new NativeTheme(isolate, theme)).ToV8();
 }
 
 // static
 void NativeTheme::BuildPrototype(v8::Isolate* isolate,
                                  v8::Local<v8::FunctionTemplate> prototype) {
-  prototype->SetClassName(mate::StringToV8(isolate, "NativeTheme"));
-  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
+  prototype->SetClassName(gin::StringToV8(isolate, "NativeTheme"));
+  gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetProperty("shouldUseDarkColors", &NativeTheme::ShouldUseDarkColors)
       .SetProperty("themeSource", &NativeTheme::GetThemeSource,
                    &NativeTheme::SetThemeSource)
@@ -112,7 +114,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  mate::Dictionary dict(isolate, exports);
+  gin::Dictionary dict(isolate, exports);
   dict.Set("nativeTheme", electron::api::NativeTheme::Create(isolate));
   dict.Set("NativeTheme", electron::api::NativeTheme::GetConstructor(isolate)
                               ->GetFunction(context)
@@ -121,19 +123,19 @@ void Initialize(v8::Local<v8::Object> exports,
 
 }  // namespace
 
-namespace mate {
+namespace gin {
 
 v8::Local<v8::Value> Converter<ui::NativeTheme::ThemeSource>::ToV8(
     v8::Isolate* isolate,
     const ui::NativeTheme::ThemeSource& val) {
   switch (val) {
     case ui::NativeTheme::ThemeSource::kForcedDark:
-      return mate::ConvertToV8(isolate, "dark");
+      return ConvertToV8(isolate, "dark");
     case ui::NativeTheme::ThemeSource::kForcedLight:
-      return mate::ConvertToV8(isolate, "light");
+      return ConvertToV8(isolate, "light");
     case ui::NativeTheme::ThemeSource::kSystem:
     default:
-      return mate::ConvertToV8(isolate, "system");
+      return ConvertToV8(isolate, "system");
   }
 }
 
@@ -142,7 +144,7 @@ bool Converter<ui::NativeTheme::ThemeSource>::FromV8(
     v8::Local<v8::Value> val,
     ui::NativeTheme::ThemeSource* out) {
   std::string theme_source;
-  if (mate::ConvertFromV8(isolate, val, &theme_source)) {
+  if (ConvertFromV8(isolate, val, &theme_source)) {
     if (theme_source == "dark") {
       *out = ui::NativeTheme::ThemeSource::kForcedDark;
     } else if (theme_source == "light") {
@@ -157,6 +159,6 @@ bool Converter<ui::NativeTheme::ThemeSource>::FromV8(
   return false;
 }
 
-}  // namespace mate
+}  // namespace gin
 
 NODE_LINKED_MODULE_CONTEXT_AWARE(atom_common_native_theme, Initialize)

--- a/shell/browser/api/atom_api_native_theme.h
+++ b/shell/browser/api/atom_api_native_theme.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_API_ATOM_API_NATIVE_THEME_H_
 #define SHELL_BROWSER_API_ATOM_API_NATIVE_THEME_H_
 
-#include "native_mate/handle.h"
 #include "shell/browser/api/event_emitter.h"
 #include "ui/native_theme/native_theme.h"
 #include "ui/native_theme/native_theme_observer.h"
@@ -50,7 +49,7 @@ class NativeTheme : public mate::EventEmitter<NativeTheme>,
 
 }  // namespace electron
 
-namespace mate {
+namespace gin {
 
 template <>
 struct Converter<ui::NativeTheme::ThemeSource> {
@@ -61,6 +60,20 @@ struct Converter<ui::NativeTheme::ThemeSource> {
                      ui::NativeTheme::ThemeSource* out);
 };
 
-}  // namespace mate
+// TODO(zcbenz): Remove this after converting NativeTheme to gin::Wrapper.
+template <>
+struct Converter<electron::api::NativeTheme*> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     electron::api::NativeTheme** out) {
+    return mate::ConvertFromV8(isolate, val, out);
+  }
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   electron::api::NativeTheme* in) {
+    return mate::ConvertToV8(isolate, in);
+  }
+};
+
+}  // namespace gin
 
 #endif  // SHELL_BROWSER_API_ATOM_API_NATIVE_THEME_H_

--- a/shell/browser/api/atom_api_notification.h
+++ b/shell/browser/api/atom_api_notification.h
@@ -10,12 +10,15 @@
 #include <vector>
 
 #include "base/strings/utf_string_conversions.h"
-#include "native_mate/handle.h"
 #include "shell/browser/api/trackable_object.h"
 #include "shell/browser/notifications/notification.h"
 #include "shell/browser/notifications/notification_delegate.h"
 #include "shell/browser/notifications/notification_presenter.h"
 #include "ui/gfx/image/image.h"
+
+namespace gin {
+class Arguments;
+}
 
 namespace electron {
 
@@ -39,9 +42,7 @@ class Notification : public mate::TrackableObject<Notification>,
   void NotificationClosed() override;
 
  protected:
-  Notification(v8::Isolate* isolate,
-               v8::Local<v8::Object> wrapper,
-               mate::Arguments* args);
+  Notification(v8::Local<v8::Object> wrapper, gin::Arguments* args);
   ~Notification() override;
 
   void Show();
@@ -96,5 +97,23 @@ class Notification : public mate::TrackableObject<Notification>,
 }  // namespace api
 
 }  // namespace electron
+
+namespace gin {
+
+// TODO(zcbenz): Remove this after converting Notification to gin::Wrapper.
+template <>
+struct Converter<electron::api::Notification*> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     electron::api::Notification** out) {
+    return mate::ConvertFromV8(isolate, val, out);
+  }
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   electron::api::Notification* in) {
+    return mate::ConvertToV8(isolate, in);
+  }
+};
+
+}  // namespace gin
 
 #endif  // SHELL_BROWSER_API_ATOM_API_NOTIFICATION_H_

--- a/shell/common/gin_converters/std_converter.h
+++ b/shell/common/gin_converters/std_converter.h
@@ -39,7 +39,7 @@ struct Converter<const char*> {
 };
 
 template <size_t n>
-struct Converter<const char[n]> {
+struct Converter<char[n]> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, const char* val) {
     return v8::String::NewFromUtf8(isolate, val, v8::NewStringType::kNormal,
                                    n - 1)

--- a/shell/common/gin_helper/object_template_builder.h
+++ b/shell/common/gin_helper/object_template_builder.h
@@ -53,7 +53,7 @@ class ObjectTemplateBuilder {
                                      const U& setter) {
     return SetPropertyImpl(name,
                            CallbackTraits<T>::CreateTemplate(isolate_, getter),
-                           CallbackTraits<T>::CreateTemplate(isolate_, setter));
+                           CallbackTraits<U>::CreateTemplate(isolate_, setter));
   }
 
  private:


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/16443.

Remove more uses of `native_mate/object_template_builder_deprecated.h`. 

#### Release Notes

Notes: no-notes