### PR TITLE
ci: save pdb files for testing builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -103,6 +103,11 @@ build_script:
       if ($env:GN_CONFIG -eq 'release') {
         python electron\script\zip-symbols.py
         appveyor PushArtifact out/Default/symbols.zip
+      } else {
+        # It's useful to have pdb files when debugging testing builds that are
+        # built on CI.
+        7z a pdb.zip out\Default\*.pdb
+        appveyor PushArtifact pdb.zip
       }
   - python electron/script/zip_manifests/check-zip-manifest.py out/Default/dist.zip electron/script/zip_manifests/dist_zip.win.%TARGET_ARCH%.manifest
 test_script:


### PR DESCRIPTION
#### Description of Change
I downloaded dist.zip for a testing build and tried to debug it, but I didn't have the .pdb file so there were no symbols. Seems we don't save pdbs for non-release builds. now we do!

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none