### PR TITLE
test: close window before destroying browserView

### DIFF
--- a/spec-main/api-browser-view-spec.ts
+++ b/spec-main/api-browser-view-spec.ts
@@ -27,11 +27,11 @@ describe('BrowserView module', () => {
   })
 
   afterEach(async () => {
+    await closeWindow(w)
+
     if (view) {
       view.destroy()
     }
-
-    await closeWindow(w)
   })
 
   describe('BrowserView.destroy()', () => {


### PR DESCRIPTION
#### Description of Change

This PR fixes the flaky Windows CI caused by `BrowserView` tests.

In the `BrowserView` tests, the `browserView` is destroyed before the parent window gets closed, and this may result in the parent window accessing destroyed pointer.

This PR avoids the crash by closing parent window before destroying `browserView`.

A complete fix would be correctly handle the case when an in-use `browserView` gets destroyed, but it is not easy to get right and I don't think it is really necessary for now.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes