### PR TITLE
docs: add unsafe-inline to csp script-src

### DIFF
--- a/docs/tutorial/first-app.md
+++ b/docs/tutorial/first-app.md
@@ -196,7 +196,7 @@ Finally the `index.html` is the web page you want to show:
     <meta charset="UTF-8">
     <title>Hello World!</title>
     <!-- https://electronjs.org/docs/tutorial/security#csp-meta-tag -->
-    <meta http-equiv="Content-Security-Policy" content="script-src 'self';" />
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline';" />
   </head>
   <body>
     <h1>Hello World!</h1>


### PR DESCRIPTION
I was following https://electronjs.org/docs/tutorial/first-app . At the end of the tutorial the versions didn't show and I was getting errors in the Developer Tools: `Refused to execute inline script because it violates the following Content Security Policy directive: "script-src 'self'"`. The cause is probably that Chrome has implemented extra security since this tutorial was created. Added 'unsafe-inline' and it works.

So sorry if I did something wrong. I just clicked the "Improve this doc" link at the bottom of your documentation pages and ended up here.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
