### PR TITLE
test: remove 'remote' usage from process tests

### DIFF
--- a/spec/api-process-spec.js
+++ b/spec/api-process-spec.js
@@ -1,4 +1,4 @@
-const { remote } = require('electron')
+const { ipcRenderer } = require('electron')
 const fs = require('fs')
 const path = require('path')
 
@@ -89,8 +89,8 @@ describe('process module', () => {
   })
 
   describe('process.takeHeapSnapshot()', () => {
-    it('returns true on success', () => {
-      const filePath = path.join(remote.app.getPath('temp'), 'test.heapsnapshot')
+    it('returns true on success', async () => {
+      const filePath = path.join(await ipcRenderer.invoke('get-temp-dir'), 'test.heapsnapshot')
 
       const cleanup = () => {
         try {

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -42,6 +42,8 @@ ipcMain.on('message', function (event, ...args) {
   event.sender.send('message', ...args)
 })
 
+ipcMain.handle('get-temp-dir', () => app.getPath('temp'))
+
 // Set productName so getUploadedReports() uses the right directory in specs
 if (process.platform !== 'darwin') {
   crashReporter.productName = 'Zombies'


### PR DESCRIPTION
#### Description of Change
Just one usage, quite straightforward.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none