### PR TITLE
feat: Implement `webContents.menuShortcutPriority` to control shortcut handling order

### DIFF
--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -6,6 +6,18 @@ Breaking changes will be documented here, and deprecation warnings added to JS c
 
 The `FIXME` string is used in code comments to denote things that should be fixed for future releases. See https://github.com/electron/electron/search?q=fixme
 
+## Planned Breaking API Changes (8.0)
+
+### `contents.setIgnoreMenuShortcuts`
+
+```js
+// Deprecated
+contents.setIgnoreMenuShortcuts(true)
+
+// Replace with
+contents.menuShortcutPriority = 'never' // or 'last'
+```
+
 ## Planned Breaking API Changes (7.0)
 
 ### Node Headers URL

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -376,19 +376,7 @@ Calling `event.preventDefault` will prevent the page `keydown`/`keyup` events
 and the menu shortcuts.
 
 To only prevent the menu shortcuts, use
-[`setIgnoreMenuShortcuts`](#contentssetignoremenushortcutsignore-experimental):
-
-```javascript
-const { BrowserWindow } = require('electron')
-
-let win = new BrowserWindow({ width: 800, height: 600 })
-
-win.webContents.on('before-input-event', (event, input) => {
-  // For example, only enable application menu keyboard shortcuts when
-  // Ctrl/Cmd are down.
-  win.webContents.setIgnoreMenuShortcuts(!input.control && !input.meta)
-})
-```
+[`menuShortcutPriority`](#contentsmenushortcutpriority).
 
 #### Event: 'enter-html-full-screen'
 
@@ -1041,7 +1029,7 @@ contents.executeJavaScript('fetch("https://jsonplaceholder.typicode.com/users/1"
   })
 ```
 
-#### `contents.setIgnoreMenuShortcuts(ignore)` _Experimental_
+#### `contents.setIgnoreMenuShortcuts(ignore)` _Deprecated_
 
 * `ignore` Boolean
 
@@ -1759,6 +1747,14 @@ An `Integer` property that sets the frame rate of the web contents to the specif
 Only values between 1 and 60 are accepted.
 
 Only applicable if *offscreen rendering* is enabled.
+
+#### `contents.menuShortcutPriority`
+
+A `String` property that controls when the application menu shortcuts are handled while this web contents is focused. Can be set to:
+
+* `"first"` to handle menu shortcuts before the web content. If a menu shortcut is triggered, the `before-input-event` event will not fire and the web content will not receive the keyboard event.
+* `"last"` (default) to give the `before-input-event` event and the web content a chance to handle the shortcut before the menu shortcuts. If the web content calls `event.preventDefault()` on the keyboard event, the menu shortcuts will not be checked.
+* `"never"` to completely disable the menu shortcuts.
 
 #### `contents.id` _Readonly_
 

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -425,6 +425,12 @@ deprecate.fnToProperty(WebContents.prototype, 'zoomLevel', '_getZoomLevel', '_se
 deprecate.fnToProperty(WebContents.prototype, 'zoomFactor', '_getZoomFactor', '_setZoomFactor')
 deprecate.fnToProperty(WebContents.prototype, 'frameRate', '_getFrameRate', '_setFrameRate')
 
+WebContents.prototype.setIgnoreMenuShortcuts = deprecate.moveAPI(
+  WebContents.prototype.setIgnoreMenuShortcuts,
+  'webContents.setIgnoreMenuShortcuts()',
+  'webContents.menuShortcutPriority'
+)
+
 // JavaScript wrapper of Debugger.
 const { Debugger } = process.electronBinding('debugger')
 Object.setPrototypeOf(Debugger.prototype, EventEmitter.prototype)

--- a/shell/browser/api/atom_api_web_contents.h
+++ b/shell/browser/api/atom_api_web_contents.h
@@ -176,6 +176,8 @@ class WebContents : public mate::TrackableObject<WebContents>,
   std::vector<scoped_refptr<content::DevToolsAgentHost>> GetAllSharedWorkers();
   void InspectServiceWorker();
   void SetIgnoreMenuShortcuts(bool ignore);
+  MenuShortcutPriority GetMenuShortcutPriority();
+  void SetMenuShortcutPriority(MenuShortcutPriority priority);
   void SetAudioMuted(bool muted);
   bool IsAudioMuted();
   bool IsCurrentlyAudible();

--- a/shell/browser/common_web_contents_delegate.h
+++ b/shell/browser/common_web_contents_delegate.h
@@ -32,6 +32,12 @@ class WebDialogHelper;
 class OffScreenWebContentsView;
 #endif
 
+enum class MenuShortcutPriority {
+  FIRST,
+  LAST,
+  NEVER,
+};
+
 class CommonWebContentsDelegate : public content::WebContentsDelegate,
                                   public InspectableWebContentsDelegate,
                                   public InspectableWebContentsViewDelegate {
@@ -68,6 +74,13 @@ class CommonWebContentsDelegate : public content::WebContentsDelegate,
     fullscreen_frame_ = rfh;
   }
 
+  MenuShortcutPriority menu_shortcut_priority() const {
+    return menu_shortcut_priority_;
+  }
+  void set_menu_shortcut_priority(MenuShortcutPriority priority) {
+    menu_shortcut_priority_ = priority;
+  }
+
  protected:
 #if BUILDFLAG(ENABLE_OSR)
   virtual OffScreenWebContentsView* GetOffScreenWebContentsView() const;
@@ -99,6 +112,9 @@ class CommonWebContentsDelegate : public content::WebContentsDelegate,
       content::WebContents* web_contents,
       content::SecurityStyleExplanations* explanations) override;
   bool TakeFocus(content::WebContents* source, bool reverse) override;
+  content::KeyboardEventProcessingResult PreHandleKeyboardEvent(
+      content::WebContents* source,
+      const content::NativeWebKeyboardEvent& event) override;
   bool HandleKeyboardEvent(
       content::WebContents* source,
       const content::NativeWebKeyboardEvent& event) override;
@@ -166,6 +182,8 @@ class CommonWebContentsDelegate : public content::WebContentsDelegate,
 
   // Whether window is fullscreened by window api.
   bool native_fullscreen_ = false;
+
+  MenuShortcutPriority menu_shortcut_priority_ = MenuShortcutPriority::LAST;
 
   // UI related helper classes.
   std::unique_ptr<WebDialogHelper> web_dialog_helper_;

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -32,11 +32,13 @@
 #include "shell/common/options_switches.h"
 #include "ui/aura/window_tree_host.h"
 #include "ui/base/hit_test.h"
+#include "ui/content_accelerators/accelerator_util.h"
 #include "ui/gfx/image/image.h"
 #include "ui/gfx/native_widget_types.h"
 #include "ui/views/background.h"
 #include "ui/views/controls/webview/unhandled_keyboard_event_handler.h"
 #include "ui/views/controls/webview/webview.h"
+#include "ui/views/focus/focus_manager.h"
 #include "ui/views/widget/native_widget_private.h"
 #include "ui/views/widget/widget.h"
 #include "ui/views/window/client_view.h"
@@ -1418,6 +1420,21 @@ void NativeWindowViews::HandleKeyboardEvent(
   keyboard_event_handler_->HandleKeyboardEvent(event,
                                                root_view_->GetFocusManager());
   root_view_->HandleKeyEvent(event);
+}
+
+bool NativeWindowViews::HandleKeyboardEventForMenu(
+    const content::NativeWebKeyboardEvent& event) {
+  auto* focus_manager = root_view_->GetFocusManager();
+  if (!focus_manager ||
+      event.GetType() != content::NativeWebKeyboardEvent::kRawKeyDown) {
+    return false;
+  }
+
+  // We don't use `keyboard_event_handler_->HandleKeyboardEvent` here because
+  // it does more than processing the registered menu accelerators.
+  ui::Accelerator accelerator =
+      ui::GetAcceleratorFromNativeWebKeyboardEvent(event);
+  return focus_manager->ProcessAccelerator(accelerator);
 }
 
 #if defined(OS_LINUX)

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -127,6 +127,8 @@ class NativeWindowViews : public NativeWindow,
 
   void SetGTKDarkThemeEnabled(bool use_dark_theme) override;
 
+  bool HandleKeyboardEventForMenu(const content::NativeWebKeyboardEvent& event);
+
   content::DesktopMediaID GetDesktopMediaID() const override;
   gfx::AcceleratedWidget GetAcceleratedWidget() const override;
   NativeWindowHandle GetNativeWindowHandle() const override;


### PR DESCRIPTION
This adds the ability to prioritize application menu shortcuts over web
content shortcuts. Previously this was only possible by listening to the
`before-input-event` event and calling `preventDefault()` on the relevant
shortcuts. This also deprecates `webContents.setIgnoreMenuShortcuts` in
favor of the new property.

See added docs for more info.

Notes: Added `webContents.menuShortcutPriority` to control shortcut handling order