### PR TITLE
test: remove unneeded console.log from the web contents spec

### DIFF
--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -1119,7 +1119,7 @@ describe('webContents module', () => {
       it(`should not crash when invoked synchronously inside ${e.name} handler`, async () => {
         const contents = (webContents as any).create() as WebContents
         const originalEmit = contents.emit.bind(contents)
-        contents.emit = (...args) => { console.log(args); return originalEmit(...args) }
+        contents.emit = (...args) => { return originalEmit(...args) }
         contents.once(e.name as any, () => (contents as any).destroy())
         const destroyed = emittedOnce(contents, 'destroyed')
         contents.loadURL(serverUrl + e.url)


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Removes extraneous `console.log` from the web contents spec.  This was accidentally left in #20099.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
