### PR TITLE
fix: potential crash in crashReporter.getUploadedReports

### DIFF
--- a/shell/common/crash_reporter/crash_reporter_crashpad.cc
+++ b/shell/common/crash_reporter/crash_reporter_crashpad.cc
@@ -109,7 +109,7 @@ CrashReporterCrashpad::GetUploadedReports(const base::FilePath& crashes_dir) {
 
   auto sort_by_time = [](const UploadReportResult& a,
                          const UploadReportResult& b) {
-    return a.first >= b.first;
+    return a.first > b.first;
   };
   std::sort(uploaded_reports.begin(), uploaded_reports.end(), sort_by_time);
   return uploaded_reports;


### PR DESCRIPTION
#### Description of Change
This fixes a buffer overflow that could occur when calling `crashReporter.getUploadedReports` in certain situations. `std::sort` requires that its comparator meet the [Compare](https://en.cppreference.com/w/cpp/named_req/Compare) requirements, one of which is that:
> For all `a`, `comp(a,a)==false`

I found this crash by running the crashReporter tests with ASan. Report:

```
==67882==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x61100055b2c0 at pc 0x00010de7a807 bp 0x7ffeebfa4310 sp 0x7ffeebfa4308
READ of size 4 at 0x61100055b2c0 thread T0
    #0 0x10de7a806 in void std::__1::__sort<crash_reporter::CrashReporterCrashpad::GetUploadedReports(base::FilePath const&)::$_0&, std::__1::pair<int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >*>(std::__1::pair<int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >*, std::__1::pair<int, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >*, crash_reporter::CrashReporterCrashpad::GetUploadedReports(base::FilePath const&)::$_0&) crash_reporter_crashpad.cc:112
    #1 0x10de76a8f in crash_reporter::CrashReporterCrashpad::GetUploadedReports(base::FilePath const&) crash_reporter_crashpad.cc:114
[...]
```

I think the violation of the Compare rules was causing `std::sort` to access memory beyond the end of the array in certain situations.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash that could occur when calling `crashReporter.getUploadedReports`.
