### PR TITLE
fix: HTML5 fullscreen APIs not working in <webview>

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -983,8 +983,7 @@ void WebContents::DevToolsOpened() {
 
   // Inherit owner window in devtools when it doesn't have one.
   auto* devtools = managed_web_contents()->GetDevToolsWebContents();
-  bool has_window =
-      devtools->GetUserData(NativeWindowRelay::kNativeWindowRelayUserDataKey);
+  bool has_window = devtools->GetUserData(NativeWindowRelay::UserDataKey());
   if (owner_window() && !has_window)
     handle->SetOwnerWindow(devtools, owner_window());
 

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -211,8 +211,7 @@ void CommonWebContentsDelegate::SetOwnerWindow(
                                             owner_window->GetWeakPtr());
   } else {
     owner_window_ = nullptr;
-    web_contents->RemoveUserData(
-        NativeWindowRelay::kNativeWindowRelayUserDataKey);
+    web_contents->RemoveUserData(NativeWindowRelay::UserDataKey());
   }
 #if BUILDFLAG(ENABLE_OSR)
   auto* osr_wcv = GetOffScreenWebContentsView();

--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -576,17 +576,14 @@ const views::Widget* NativeWindow::GetWidget() const {
 }
 
 // static
-const void* const NativeWindowRelay::kNativeWindowRelayUserDataKey =
-    &NativeWindowRelay::kNativeWindowRelayUserDataKey;
-
-// static
 void NativeWindowRelay::CreateForWebContents(
     content::WebContents* web_contents,
     base::WeakPtr<NativeWindow> window) {
   DCHECK(web_contents);
-  DCHECK(!web_contents->GetUserData(kNativeWindowRelayUserDataKey));
-  web_contents->SetUserData(kNativeWindowRelayUserDataKey,
-                            base::WrapUnique(new NativeWindowRelay(window)));
+  if (!web_contents->GetUserData(UserDataKey())) {
+    web_contents->SetUserData(UserDataKey(),
+                              base::WrapUnique(new NativeWindowRelay(window)));
+  }
 }
 
 NativeWindowRelay::NativeWindowRelay(base::WeakPtr<NativeWindow> window)

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -354,14 +354,17 @@ class NativeWindow : public base::SupportsUserData,
 class NativeWindowRelay
     : public content::WebContentsUserData<NativeWindowRelay> {
  public:
-  static const void* const kNativeWindowRelayUserDataKey;
-
   static void CreateForWebContents(content::WebContents*,
                                    base::WeakPtr<NativeWindow>);
 
   ~NativeWindowRelay() override;
 
   NativeWindow* GetNativeWindow() const { return native_window_.get(); }
+
+  // UserDataKey() is protected in content::WebContentsUserData<T>
+  static inline const void* UserDataKey() {
+    return content::WebContentsUserData<NativeWindowRelay>::UserDataKey();
+  }
 
  private:
   friend class content::WebContentsUserData<NativeWindow>;


### PR DESCRIPTION
#### Description of Change
Fixes #16428

`NativeWindowRelay::FromWebContents()` was using `UserDataKey()` while `NativeWindowRelay::CreateForWebContents()` was using `kNativeWindowRelayUserDataKey`.
This would lead to the `<webview>` not having an owner window set, which would blow up in `CommonWebContentsDelegate::EnterFullscreenModeForTab()`.

This was fixed in 5-0-x by https://github.com/electron/electron/commit/d5c37c301a66922e13d4cfa5c1ec51b81b3cbd51

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed HTML5 fullscreen APIs not working in `<webview>`.