### PR TITLE
feat: support fitToPageEnabled and scaleFactor

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -209,6 +209,12 @@ WebContents.prototype.printToPDF = function (options) {
   if (options.landscape) {
     printingSetting.landscape = options.landscape
   }
+  if (options.fitToPageEnabled) {
+    printingSetting.fitToPageEnabled = options.fitToPageEnabled
+  }
+  if (options.scaleFactor) {
+    printingSetting.scaleFactor = options.scaleFactor
+  }
   if (options.marginsType) {
     printingSetting.marginsType = options.marginsType
   }
@@ -243,7 +249,7 @@ WebContents.prototype.printToPDF = function (options) {
   }
 
   // Chromium expects this in a 0-100 range number, not as float
-  printingSetting.scaleFactor *= 100
+  printingSetting.scaleFactor = Math.ceil(printingSetting.scaleFactor) % 100
   if (features.isPrintingEnabled()) {
     return this._printToPDF(printingSetting)
   } else {

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -83,7 +83,7 @@ const defaultPrintingSetting = {
   deviceName: 'Save as PDF',
   generateDraftData: true,
   fitToPageEnabled: false,
-  scaleFactor: 1,
+  scaleFactor: 100,
   dpiHorizontal: 72,
   dpiVertical: 72,
   rasterizePDF: false,


### PR DESCRIPTION

#### Description of Change
Support fitToPageEnabled and scaleFactor in  `WebContents.printToPDF()`, fix #20435 
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

notes:  Added the support of fitToPageEnabled and scaleFactor in  `WebContents.printToPDF()`