### PR TITLE
feat: add env variable to skip binary download on npm install (backport)

### DIFF
--- a/docs/tutorial/installation.md
+++ b/docs/tutorial/installation.md
@@ -97,6 +97,17 @@ a text file. A typical cache might look like this:
 ├── SHASUMS256.txt-1.8.2-beta.3
 ```
 
+## Skip binary download
+When installing the `electron` NPM package, it automatically downloads the electron binary.
+
+This can sometimes be unnecessary, e.g. in a CI environment, when testing another component.
+
+To prevent the binary from being downloaded when you install all npm dependencies you can set the environment variable `ELECTRON_SKIP_BINARY_DOWNLOAD`.
+E.g.:
+```sh
+ELECTRON_SKIP_BINARY_DOWNLOAD=1 npm install
+```
+
 ## Troubleshooting
 
 When running `npm install electron`, some users occasionally encounter

--- a/npm/install.js
+++ b/npm/install.js
@@ -15,6 +15,10 @@ try {
   // do nothing
 }
 
+if (process.env.ELECTRON_SKIP_BINARY_DOWNLOAD) {
+  process.exit(0)
+}
+
 var platformPath = getPlatformPath()
 
 var electronPath = process.env.ELECTRON_OVERRIDE_DIST_PATH || path.join(__dirname, 'dist', platformPath)


### PR DESCRIPTION
#### Description of Change
Backporting of ["feat: add env variable to skip binary download on npm install"](https://github.com/electron/electron/pull/17627) (see [request](https://github.com/electron/electron/pull/17627#issuecomment-538626232)).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Set the ELECTRON_SKIP_BINARY_DOWNLOAD=1 environment variable to skip electron binary download.
