### PR TITLE
docs: add Asynchronous Messages Fiddle example

### DIFF
--- a/docs/fiddles/communication/two-processes/asynchronous-messages/index.html
+++ b/docs/fiddles/communication/two-processes/asynchronous-messages/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+  </head>
+  <body>
+    <div>
+      <div>
+        <h1>Supports: Win, macOS, Linux <span>|</span> Process: Both</h1>
+        <div>
+          <div>
+            <button id="async-msg">Ping</button>
+            <span id="async-reply"></span>
+          </div>
+          <p>Using <code>ipc</code> to send messages between processes asynchronously is the preferred method since it will return when finished without blocking other operations in the same process.</p>
+
+          <p>This example sends a "ping" from this process (renderer) to the main process. The main process then replies with "pong".</p>
+        </div>
+      </div>
+    </div>
+    <script>
+      // You can also require other files to run in this process
+      require('./renderer.js')
+    </script>
+  </body>
+</html>

--- a/docs/fiddles/communication/two-processes/asynchronous-messages/index.html
+++ b/docs/fiddles/communication/two-processes/asynchronous-messages/index.html
@@ -6,7 +6,8 @@
   <body>
     <div>
       <div>
-        <h1>Supports: Win, macOS, Linux <span>|</span> Process: Both</h1>
+        <h1>Asynchronous messages</h1>
+        <i>Supports: Win, macOS, Linux <span>|</span> Process: Both</i>
         <div>
           <div>
             <button id="async-msg">Ping</button>

--- a/docs/fiddles/communication/two-processes/asynchronous-messages/main.js
+++ b/docs/fiddles/communication/two-processes/asynchronous-messages/main.js
@@ -1,0 +1,29 @@
+const { app, BrowserWindow, ipcMain } = require('electron')
+
+let mainWindow = null
+
+function createWindow () {
+  const windowOptions = {
+    width: 600,
+    height: 400,
+    title: 'Asynchronous',
+    webPreferences: {
+      nodeIntegration: true
+    }
+  }
+
+  mainWindow = new BrowserWindow(windowOptions)
+  mainWindow.loadFile('index.html')
+
+  mainWindow.on('closed', () => {
+    mainWindow = null
+  })
+}
+
+app.on('ready', () => {
+  createWindow()
+})
+
+ipcMain.on('asynchronous-message', (event, arg) => {
+  event.sender.send('asynchronous-reply', 'pong')
+})

--- a/docs/fiddles/communication/two-processes/asynchronous-messages/main.js
+++ b/docs/fiddles/communication/two-processes/asynchronous-messages/main.js
@@ -6,7 +6,7 @@ function createWindow () {
   const windowOptions = {
     width: 600,
     height: 400,
-    title: 'Asynchronous',
+    title: 'Asynchronous messages',
     webPreferences: {
       nodeIntegration: true
     }

--- a/docs/fiddles/communication/two-processes/asynchronous-messages/renderer.js
+++ b/docs/fiddles/communication/two-processes/asynchronous-messages/renderer.js
@@ -1,0 +1,12 @@
+const { ipcRenderer } = require('electron')
+
+const asyncMsgBtn = document.getElementById('async-msg')
+
+asyncMsgBtn.addEventListener('click', () => {
+  ipcRenderer.send('asynchronous-message', 'ping')
+})
+
+ipcRenderer.on('asynchronous-reply', (event, arg) => {
+  const message = `Asynchronous message reply: ${arg}`
+  document.getElementById('async-reply').innerHTML = message
+})


### PR DESCRIPTION
#### Description of Change
Refs #20442

Adds the Asynchronous Messages example from `electron-api-demos` into a runnable Fiddle example.

Gist link to Fiddle (same as code submitted in this PR): https://gist.github.com/fc7c008c2a1a8b3140c87c7fb4b5ef1c

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `standard` linter passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
