### PR TITLE
docs: add clipboard Fiddle examples

### DIFF
--- a/docs/fiddles/system/clipboard/copy/index.html
+++ b/docs/fiddles/system/clipboard/copy/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+  </head>
+  <body>
+    <div>
+      <div>
+        <h1>Supports: Win, macOS, Linux <span>|</span> Process: Both</div>
+        <div>
+          <div>
+            <button id="copy-to">Copy</button>
+            <input id="copy-to-input" aria-label="Click copy" placeholder="Click copy."></input>
+          </div>
+          <p>In this example we copy a phrase to the clipboard. After clicking 'Copy' use the text area to paste (CMD + V or CTRL + V) the phrase from the clipboard.</p>
+        </div>
+      </div>
+    </div>
+  </body>
+  <script>
+    require('./renderer.js')
+  </script>
+</html>

--- a/docs/fiddles/system/clipboard/copy/index.html
+++ b/docs/fiddles/system/clipboard/copy/index.html
@@ -6,7 +6,8 @@
   <body>
     <div>
       <div>
-        <h1>Supports: Win, macOS, Linux <span>|</span> Process: Both</div>
+        <h1>Clipboard copy</h1>
+        <i>Supports: Win, macOS, Linux <span>|</span> Process: Both</i>
         <div>
           <div>
             <button id="copy-to">Copy</button>

--- a/docs/fiddles/system/clipboard/copy/main.js
+++ b/docs/fiddles/system/clipboard/copy/main.js
@@ -1,0 +1,25 @@
+const { app, BrowserWindow } = require('electron')
+
+let mainWindow = null
+
+function createWindow () {
+  const windowOptions = {
+    width: 600,
+    height: 400,
+    title: 'Clipboard copy',
+    webPreferences: {
+      nodeIntegration: true
+    }
+  }
+
+  mainWindow = new BrowserWindow(windowOptions)
+  mainWindow.loadFile('index.html')
+
+  mainWindow.on('closed', () => {
+    mainWindow = null
+  })
+}
+
+app.on('ready', () => {
+  createWindow()
+})

--- a/docs/fiddles/system/clipboard/copy/renderer.js
+++ b/docs/fiddles/system/clipboard/copy/renderer.js
@@ -1,0 +1,10 @@
+const { clipboard } = require('electron')
+
+const copyBtn = document.getElementById('copy-to')
+const copyInput = document.getElementById('copy-to-input')
+
+copyBtn.addEventListener('click', () => {
+  if (copyInput.value !== '') copyInput.value = ''
+  copyInput.placeholder = 'Copied! Paste here to see.'
+  clipboard.writeText('Electron Demo!')
+})

--- a/docs/fiddles/system/clipboard/paste/index.html
+++ b/docs/fiddles/system/clipboard/paste/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+  </head>
+  <body>
+    <div>
+      <div>
+        <h1>Supports: Win, macOS, Linux <span>|</span> Process: Both</div>
+        <div>
+          <div>
+            <button id="paste-to">Paste</button>
+            <span id="paste-from"></span>
+          </div>
+          <p>In this example we copy a string to the clipboard and then paste the results into a message above.</p>
+        </div>
+      </div>
+    </div>
+  </body>
+  <script>
+    require('./renderer.js')
+  </script>
+</html>

--- a/docs/fiddles/system/clipboard/paste/index.html
+++ b/docs/fiddles/system/clipboard/paste/index.html
@@ -6,7 +6,8 @@
   <body>
     <div>
       <div>
-        <h1>Supports: Win, macOS, Linux <span>|</span> Process: Both</div>
+        <h1>Clipboard paste</h1>
+        <i>Supports: Win, macOS, Linux <span>|</span> Process: Both</i>
         <div>
           <div>
             <button id="paste-to">Paste</button>

--- a/docs/fiddles/system/clipboard/paste/main.js
+++ b/docs/fiddles/system/clipboard/paste/main.js
@@ -1,0 +1,25 @@
+const { app, BrowserWindow } = require('electron')
+
+let mainWindow = null
+
+function createWindow () {
+  const windowOptions = {
+    width: 600,
+    height: 400,
+    title: 'Clipboard paste',
+    webPreferences: {
+      nodeIntegration: true
+    }
+  }
+
+  mainWindow = new BrowserWindow(windowOptions)
+  mainWindow.loadFile('index.html')
+
+  mainWindow.on('closed', () => {
+    mainWindow = null
+  })
+}
+
+app.on('ready', () => {
+  createWindow()
+})

--- a/docs/fiddles/system/clipboard/paste/renderer.js
+++ b/docs/fiddles/system/clipboard/paste/renderer.js
@@ -1,0 +1,9 @@
+const { clipboard } = require('electron')
+
+const pasteBtn = document.getElementById('paste-to')
+
+pasteBtn.addEventListener('click', () => {
+  clipboard.writeText('What a demo!')
+  const message = `Clipboard contents: ${clipboard.readText()}`
+  document.getElementById('paste-from').innerHTML = message
+})


### PR DESCRIPTION
#### Description of Change
Refs #20442

Adds the clipboard copy and paste example from `electron-api-demos` into runnable Fiddle examples.

Gist link to Fiddle (same as code submitted in this PR):
- copy: https://gist.github.com/263e01f09c1cb44da8d8bf28f2f726ce
- paste: https://gist.github.com/637f1f47e3427090b3be156da91091a4

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `standard` linter passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes

