### PR TITLE
fix: properly free IsolateData in NodeMain

### DIFF
--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -79,9 +79,14 @@ int NodeMain(int argc, char* argv[]) {
     // Initialize gin::IsolateHolder.
     JavascriptEnvironment gin_env(loop);
 
-    node::Environment* env = node::CreateEnvironment(
-        node::CreateIsolateData(gin_env.isolate(), loop, gin_env.platform()),
-        gin_env.context(), argc, argv, exec_argc, exec_argv, false);
+    node::IsolateData* isolate_data =
+        node::CreateIsolateData(gin_env.isolate(), loop, gin_env.platform());
+    CHECK_NE(nullptr, isolate_data);
+
+    node::Environment* env =
+        node::CreateEnvironment(isolate_data, gin_env.context(), argc, argv,
+                                exec_argc, exec_argv, false);
+    CHECK_NE(nullptr, env);
 
     // Enable support for v8 inspector.
     NodeDebugger node_debugger(env);
@@ -135,6 +140,7 @@ int NodeMain(int argc, char* argv[]) {
 
     v8::Isolate* isolate = env->isolate();
     node::FreeEnvironment(env);
+    node::FreeIsolateData(isolate_data);
 
     gin_env.platform()->DrainTasks(isolate);
     gin_env.platform()->CancelPendingDelayedTasks(isolate);


### PR DESCRIPTION
#### Description of Change

We were calling `node::CreateIsolateData` within `node::CreateEnvironment`, which meant that while we properly deallocated the `Environment` we created, we were never properly deallocating the `IsolateData`. This remedies that issue and also adds in some `CHECK`s for extra safety to prevent unexpected `nullptr`s from crashing things down the line.

cc @deepak1556 @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
