### PR TITLE
fix: cookies.get should be able to filter domain

### DIFF
--- a/shell/browser/api/atom_api_cookies.h
+++ b/shell/browser/api/atom_api_cookies.h
@@ -19,6 +19,10 @@ namespace base {
 class DictionaryValue;
 }
 
+namespace mate {
+class Dictionary;
+}
+
 namespace net {
 class URLRequestContextGetter;
 }
@@ -42,7 +46,7 @@ class Cookies : public mate::TrackableObject<Cookies> {
   Cookies(v8::Isolate* isolate, AtomBrowserContext* browser_context);
   ~Cookies() override;
 
-  v8::Local<v8::Promise> Get(const base::DictionaryValue& filter);
+  v8::Local<v8::Promise> Get(const mate::Dictionary& filter);
   v8::Local<v8::Promise> Set(const base::DictionaryValue& details);
   v8::Local<v8::Promise> Remove(const GURL& url, const std::string& name);
   v8::Local<v8::Promise> FlushStore();

--- a/spec-main/api-session-spec.ts
+++ b/spec-main/api-session-spec.ts
@@ -83,6 +83,16 @@ describe('session module', () => {
       expect(cs.some(c => c.name === name && c.value === value)).to.equal(true)
     })
 
+    it('gets cookies without url', async () => {
+      const { cookies } = session.defaultSession
+      const name = '1'
+      const value = '1'
+
+      await cookies.set({ url, name, value, expirationDate: (+new Date) / 1000 + 120 })
+      const cs = await cookies.get({ domain: '127.0.0.1' })
+      expect(cs.some(c => c.name === name && c.value === value)).to.equal(true)
+    })
+
     it('yields an error when setting a cookie with missing required fields', async () => {
       const { cookies } = session.defaultSession
       const name = '1'


### PR DESCRIPTION
#### Description of Change

Fix https://github.com/electron/electron/issues/20392.

This PR fixes a bug that wrong API was used when `url` is not specified, this bug was introduced when migrating to NetworkService APIs.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix `cookies.get` not working when `url` is not specified in filter.