### PR TITLE
docs: initial document for comparing web embeds

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ an issue:
   * [Native File Drag & Drop](tutorial/native-file-drag-drop.md)
   * [Offscreen Rendering](tutorial/offscreen-rendering.md)
   * [Supporting macOS Dark Mode](tutorial/mojave-dark-mode-guide.md)
+  * [Web embeds in Electron](tutorial/web-embeds.md)
 * [Accessibility](tutorial/accessibility.md)
   * [Spectron](tutorial/accessibility.md#spectron)
   * [Devtron](tutorial/accessibility.md#devtron)

--- a/docs/tutorial/web-embeds.md
+++ b/docs/tutorial/web-embeds.md
@@ -8,7 +8,7 @@ Iframes in Electron behave like iframes in regular browsers. An `<iframe>` eleme
 
 ## Webviews
 
-[WebViews](https://electronjs.org/docs/api/webview-tag) are based on Chromium's WebViews and are not explicitly supported by Electron. We do not guarantee that the WebView API will remain available in future versions of Electron. This is why, if you want to use `<webview>` tags, you will need to set `webviewTag` to `true` in the `webPreferences` of your BrowserWindow.
+[WebViews](../api/webview-tag) are based on Chromium's WebViews and are not explicitly supported by Electron. We do not guarantee that the WebView API will remain available in future versions of Electron. This is why, if you want to use `<webview>` tags, you will need to set `webviewTag` to `true` in the `webPreferences` of your `BrowserWindow`.
 
 WebViews are a custom element (`<webview>`) that will only work inside Electron.
 They are implemented as an "out-of-process iframe". This means that all communication with the `<webview>` is done asynchronously using IPC. The `<webview>` element has many custom methods and events, similar to `webContents`, that allow you much greater control over the contents.

--- a/docs/tutorial/web-embeds.md
+++ b/docs/tutorial/web-embeds.md
@@ -6,7 +6,7 @@ If you want to embed (third party) web content in an Electron `BrowserWindow`, t
 
 Iframes in Electron behave like iframes in regular browsers. An `<iframe>` element in your page can show external web pages, provided that their [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) allows it. To limit the amount of capabilities a site in an `<iframe>` tag, it's recommended to use the [`sandbox` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox) and only allow the capabilities you want to support.
 
-## Webviews
+## WebViews
 
 [WebViews](../api/webview-tag) are based on Chromium's WebViews and are not explicitly supported by Electron. We do not guarantee that the WebView API will remain available in future versions of Electron. This is why, if you want to use `<webview>` tags, you will need to set `webviewTag` to `true` in the `webPreferences` of your `BrowserWindow`.
 

--- a/docs/tutorial/web-embeds.md
+++ b/docs/tutorial/web-embeds.md
@@ -13,7 +13,7 @@ Iframes in Electron behave like iframes in regular browsers. An `<iframe>` eleme
 WebViews are a custom element (`<webview>`) that will only work inside Electron.
 They are implemented as an "out-of-process iframe". This means that all communication with the `<webview>` is done asynchronously using IPC. The `<webview>` element has many custom methods and events, similar to `webContents`, that allow you much greater control over the contents.
 
-Compared to an `<iframe>`, `<webview>` tend to be slightly slower but offer much greater control in loading and communicating with the third party content and handling various events.
+Compared to an `<iframe>`, `<webview>` tends to be slightly slower but offers much greater control in loading and communicating with the third party content and handling various events.
 
 ## BrowserViews
 

--- a/docs/tutorial/web-embeds.md
+++ b/docs/tutorial/web-embeds.md
@@ -15,7 +15,7 @@ They are implemented as an "out-of-process iframe". This means that all communic
 
 Compared to an `<iframe>`, `<webview>` tend to be slightly slower but offer much greater control in loading and communicating with the third party content and handling various events.
 
-## Browserviews
+## BrowserViews
 
 Browserviews are not part of your DOM, but are created in your main process and are overlaid on top of your BrowserWindow content. This means they are completely separate from your own BrowserWindow content and their position is not controlled by the DOM and CSS, but by setting the bounds in the main process.
 

--- a/docs/tutorial/web-embeds.md
+++ b/docs/tutorial/web-embeds.md
@@ -1,0 +1,22 @@
+# Web embeds in Electron
+
+If you want to show (third party) web content in Electron, there are three options available to you: iframes, webviews and browserviews. Each one offers slightly different functionality and is useful in different situations. To help you choose between these this guide will explain the differences and capabilities of each.
+
+## Iframes
+
+Iframes in Electron behave like iframes in regular browsers. An <iframe> element in your page can show external web pages, provided that their [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) allows it. To limit the amount of capabilities a site in an iframe, it's recommended to use the [`sandbox` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox) and only allow the capabilities you want to support.
+
+## Webviews
+
+[Webviews](https://electronjs.org/docs/api/webview-tag) are based on Chromium's webviews and are not explicitly supported by Electron, in such way that we do not give guarantees that the Webview api will remain available in future versions of Electron. This is why, if you want to use webviews, you will need to set `webviewTag` to `true` in the `webPreferences` of your BrowserWindow.
+
+Webviews are a custom element(<webview>) that will only work inside Electron.
+They are implemented as an "out-of-process iframe". This means all communication with the webview is done asynchronously using IPC. The webview element has many custom methods and events, similar to webContents, that allow you much greater control over the contents of a webview.
+
+Compared to an iframe, webviews tend to be slightly slower, but offer much greater control in loading and communicating with the third party content and handling various events.
+
+## Browserviews
+
+Browserviews are not part of your DOM, but are created in your main process and are overlaid on top of your BrowserWindow content. This means they are completely separate from your own BrowserWindow content and their position is not controlled by the DOM and CSS, but by setting the bounds in the main process.
+
+Browserviews offer the greatest control over their contents, since they implement the webContents similarly to how a BrowserWindows implements it. However they are not part of your DOM but are overlaid on top of them, which means you will have to manage their position manually.

--- a/docs/tutorial/web-embeds.md
+++ b/docs/tutorial/web-embeds.md
@@ -17,6 +17,6 @@ Compared to an `<iframe>`, `<webview>` tends to be slightly slower but offers mu
 
 ## BrowserViews
 
-[BrowserViews](../api/browser-view) are not part of the DOM - instead, they are created in and controlled by your main process. They are simply another layer of web content on top of your existing window. This means that they are completely separate from your own `BrowserWindow` content and that their position is not controlled by the DOM or CSS but by setting the bounds in the main process.
+[BrowserViews](../api/browser-view.md) are not part of the DOM - instead, they are created in and controlled by your main process. They are simply another layer of web content on top of your existing window. This means that they are completely separate from your own `BrowserWindow` content and that their position is not controlled by the DOM or CSS but by setting the bounds in the main process.
 
 BrowserViews offer the greatest control over their contents, since they implement the `webContents` similarly to how a `BrowserWindow` implements it. However, they are not part of your DOM but are overlaid on top of them, which means you will have to manage their position manually.

--- a/docs/tutorial/web-embeds.md
+++ b/docs/tutorial/web-embeds.md
@@ -13,7 +13,7 @@ Iframes in Electron behave like iframes in regular browsers. An `<iframe>` eleme
 WebViews are a custom element (`<webview>`) that will only work inside Electron.
 They are implemented as an "out-of-process iframe". This means that all communication with the `<webview>` is done asynchronously using IPC. The `<webview>` element has many custom methods and events, similar to `webContents`, that allow you much greater control over the contents.
 
-Compared to an iframe, webviews tend to be slightly slower, but offer much greater control in loading and communicating with the third party content and handling various events.
+Compared to an `<iframe>`, `<webview>` tend to be slightly slower but offer much greater control in loading and communicating with the third party content and handling various events.
 
 ## Browserviews
 

--- a/docs/tutorial/web-embeds.md
+++ b/docs/tutorial/web-embeds.md
@@ -17,6 +17,6 @@ Compared to an `<iframe>`, `<webview>` tend to be slightly slower but offer much
 
 ## BrowserViews
 
-Browserviews are not part of your DOM, but are created in your main process and are overlaid on top of your BrowserWindow content. This means they are completely separate from your own BrowserWindow content and their position is not controlled by the DOM and CSS, but by setting the bounds in the main process.
+Browserviews are not part of the DOM - instead, they are created in and controlled by your main process. They are simply another layer of web content on top of your existing window. This means that they are completely separate from your own BrowserWindow content and that their position is not controlled by the DOM or CSS but by setting the bounds in the main process.
 
 Browserviews offer the greatest control over their contents, since they implement the webContents similarly to how a BrowserWindows implements it. However they are not part of your DOM but are overlaid on top of them, which means you will have to manage their position manually.

--- a/docs/tutorial/web-embeds.md
+++ b/docs/tutorial/web-embeds.md
@@ -4,7 +4,7 @@ If you want to embed (third party) web content in an Electron `BrowserWindow`, t
 
 ## Iframes
 
-Iframes in Electron behave like iframes in regular browsers. An <iframe> element in your page can show external web pages, provided that their [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) allows it. To limit the amount of capabilities a site in an iframe, it's recommended to use the [`sandbox` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox) and only allow the capabilities you want to support.
+Iframes in Electron behave like iframes in regular browsers. An `<iframe>` element in your page can show external web pages, provided that their [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) allows it. To limit the amount of capabilities a site in an `<iframe>` tag, it's recommended to use the [`sandbox` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox) and only allow the capabilities you want to support.
 
 ## Webviews
 

--- a/docs/tutorial/web-embeds.md
+++ b/docs/tutorial/web-embeds.md
@@ -11,7 +11,7 @@ Iframes in Electron behave like iframes in regular browsers. An `<iframe>` eleme
 [WebViews](https://electronjs.org/docs/api/webview-tag) are based on Chromium's WebViews and are not explicitly supported by Electron. We do not guarantee that the WebView API will remain available in future versions of Electron. This is why, if you want to use `<webview>` tags, you will need to set `webviewTag` to `true` in the `webPreferences` of your BrowserWindow.
 
 WebViews are a custom element (`<webview>`) that will only work inside Electron.
-They are implemented as an "out-of-process iframe". This means all communication with the webview is done asynchronously using IPC. The webview element has many custom methods and events, similar to webContents, that allow you much greater control over the contents of a webview.
+They are implemented as an "out-of-process iframe". This means that all communication with the `<webview>` is done asynchronously using IPC. The `<webview>` element has many custom methods and events, similar to `webContents`, that allow you much greater control over the contents.
 
 Compared to an iframe, webviews tend to be slightly slower, but offer much greater control in loading and communicating with the third party content and handling various events.
 

--- a/docs/tutorial/web-embeds.md
+++ b/docs/tutorial/web-embeds.md
@@ -8,7 +8,7 @@ Iframes in Electron behave like iframes in regular browsers. An `<iframe>` eleme
 
 ## WebViews
 
-[WebViews](../api/webview-tag) are based on Chromium's WebViews and are not explicitly supported by Electron. We do not guarantee that the WebView API will remain available in future versions of Electron. This is why, if you want to use `<webview>` tags, you will need to set `webviewTag` to `true` in the `webPreferences` of your `BrowserWindow`.
+[WebViews](../api/webview-tag.md) are based on Chromium's WebViews and are not explicitly supported by Electron. We do not guarantee that the WebView API will remain available in future versions of Electron. This is why, if you want to use `<webview>` tags, you will need to set `webviewTag` to `true` in the `webPreferences` of your `BrowserWindow`.
 
 WebViews are a custom element (`<webview>`) that will only work inside Electron.
 They are implemented as an "out-of-process iframe". This means that all communication with the `<webview>` is done asynchronously using IPC. The `<webview>` element has many custom methods and events, similar to `webContents`, that allow you much greater control over the contents.

--- a/docs/tutorial/web-embeds.md
+++ b/docs/tutorial/web-embeds.md
@@ -17,6 +17,6 @@ Compared to an `<iframe>`, `<webview>` tend to be slightly slower but offer much
 
 ## BrowserViews
 
-Browserviews are not part of the DOM - instead, they are created in and controlled by your main process. They are simply another layer of web content on top of your existing window. This means that they are completely separate from your own BrowserWindow content and that their position is not controlled by the DOM or CSS but by setting the bounds in the main process.
+[BrowserViews](../api/browser-view) are not part of the DOM - instead, they are created in and controlled by your main process. They are simply another layer of web content on top of your existing window. This means that they are completely separate from your own `BrowserWindow` content and that their position is not controlled by the DOM or CSS but by setting the bounds in the main process.
 
 BrowserViews offer the greatest control over their contents, since they implement the `webContents` similarly to how a BrowserWindow implements it. However they are not part of your DOM but are overlaid on top of them, which means you will have to manage their position manually.

--- a/docs/tutorial/web-embeds.md
+++ b/docs/tutorial/web-embeds.md
@@ -8,7 +8,7 @@ Iframes in Electron behave like iframes in regular browsers. An `<iframe>` eleme
 
 ## Webviews
 
-[Webviews](https://electronjs.org/docs/api/webview-tag) are based on Chromium's webviews and are not explicitly supported by Electron, in such way that we do not give guarantees that the Webview api will remain available in future versions of Electron. This is why, if you want to use webviews, you will need to set `webviewTag` to `true` in the `webPreferences` of your BrowserWindow.
+[WebViews](https://electronjs.org/docs/api/webview-tag) are based on Chromium's WebViews and are not explicitly supported by Electron. We do not guarantee that the WebView API will remain available in future versions of Electron. This is why, if you want to use `<webview>` tags, you will need to set `webviewTag` to `true` in the `webPreferences` of your BrowserWindow.
 
 Webviews are a custom element(<webview>) that will only work inside Electron.
 They are implemented as an "out-of-process iframe". This means all communication with the webview is done asynchronously using IPC. The webview element has many custom methods and events, similar to webContents, that allow you much greater control over the contents of a webview.

--- a/docs/tutorial/web-embeds.md
+++ b/docs/tutorial/web-embeds.md
@@ -19,4 +19,4 @@ Compared to an `<iframe>`, `<webview>` tend to be slightly slower but offer much
 
 Browserviews are not part of the DOM - instead, they are created in and controlled by your main process. They are simply another layer of web content on top of your existing window. This means that they are completely separate from your own BrowserWindow content and that their position is not controlled by the DOM or CSS but by setting the bounds in the main process.
 
-Browserviews offer the greatest control over their contents, since they implement the webContents similarly to how a BrowserWindows implements it. However they are not part of your DOM but are overlaid on top of them, which means you will have to manage their position manually.
+BrowserViews offer the greatest control over their contents, since they implement the `webContents` similarly to how a BrowserWindow implements it. However they are not part of your DOM but are overlaid on top of them, which means you will have to manage their position manually.

--- a/docs/tutorial/web-embeds.md
+++ b/docs/tutorial/web-embeds.md
@@ -10,7 +10,7 @@ Iframes in Electron behave like iframes in regular browsers. An `<iframe>` eleme
 
 [WebViews](https://electronjs.org/docs/api/webview-tag) are based on Chromium's WebViews and are not explicitly supported by Electron. We do not guarantee that the WebView API will remain available in future versions of Electron. This is why, if you want to use `<webview>` tags, you will need to set `webviewTag` to `true` in the `webPreferences` of your BrowserWindow.
 
-Webviews are a custom element(<webview>) that will only work inside Electron.
+WebViews are a custom element (`<webview>`) that will only work inside Electron.
 They are implemented as an "out-of-process iframe". This means all communication with the webview is done asynchronously using IPC. The webview element has many custom methods and events, similar to webContents, that allow you much greater control over the contents of a webview.
 
 Compared to an iframe, webviews tend to be slightly slower, but offer much greater control in loading and communicating with the third party content and handling various events.

--- a/docs/tutorial/web-embeds.md
+++ b/docs/tutorial/web-embeds.md
@@ -19,4 +19,4 @@ Compared to an `<iframe>`, `<webview>` tends to be slightly slower but offers mu
 
 [BrowserViews](../api/browser-view) are not part of the DOM - instead, they are created in and controlled by your main process. They are simply another layer of web content on top of your existing window. This means that they are completely separate from your own `BrowserWindow` content and that their position is not controlled by the DOM or CSS but by setting the bounds in the main process.
 
-BrowserViews offer the greatest control over their contents, since they implement the `webContents` similarly to how a BrowserWindow implements it. However they are not part of your DOM but are overlaid on top of them, which means you will have to manage their position manually.
+BrowserViews offer the greatest control over their contents, since they implement the `webContents` similarly to how a `BrowserWindow` implements it. However, they are not part of your DOM but are overlaid on top of them, which means you will have to manage their position manually.

--- a/docs/tutorial/web-embeds.md
+++ b/docs/tutorial/web-embeds.md
@@ -1,6 +1,6 @@
 # Web embeds in Electron
 
-If you want to show (third party) web content in Electron, there are three options available to you: iframes, webviews and browserviews. Each one offers slightly different functionality and is useful in different situations. To help you choose between these this guide will explain the differences and capabilities of each.
+If you want to embed (third party) web content in an Electron `BrowserWindow`, there are three options available to you: `<iframe>` tags, `<webview>` tags, and `BrowserViews`. Each one offers slightly different functionality and is useful in different situations. To help you choose between these, this guide will explain the differences and capabilities of each.
 
 ## Iframes
 


### PR DESCRIPTION
#### Description of Change

Initial documentation to help people choose between web embed options, per the web embeds session at the summit.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
#### Release Notes

Notes: no-notes 