### PR TITLE
fix: unset NEXT_ROOT on startup

### DIFF
--- a/shell/app/atom_main_delegate.cc
+++ b/shell/app/atom_main_delegate.cc
@@ -163,6 +163,11 @@ bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
 
   // Only enable logging when --enable-logging is specified.
   auto env = base::Environment::Create();
+
+  // Leaving this might screw up the Apple tools, so remove it.
+  if (env->HasVar("NEXT_ROOT"))
+    env->UnSetVar("NEXT_ROOT");
+
   if (!command_line->HasSwitch(::switches::kEnableLogging) &&
       !env->HasVar("ELECTRON_ENABLE_LOGGING")) {
     settings.logging_dest = logging::LOG_NONE;


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/20477.

Unset the `NEXT_ROOT` env var if it's set, as it screws with apple tooling and causes the following crash:

<details>

```
electron on git:master ❯ e start                                                         2:05PM
Received signal 4 <unknown> 7fff2facd867
0   Electron Framework                  0x0000000115beabc9 base::debug::CollectStackTrace(void**, unsigned long) + 9
1   Electron Framework                  0x0000000115a9a303 base::debug::StackTrace::StackTrace() + 19
2   Electron Framework                  0x0000000115beaa61 base::debug::(anonymous namespace)::StackDumpSignalHandler(int, __siginfo*, void*) + 2385
3   libsystem_platform.dylib            0x00007fff5e216b5d _sigtramp + 29
4   ???                                 0x00000000000009df 0x0 + 2527
5   AppKit                              0x00007fff2facd748 -[NSApplication reportException:] + 916
6   AppKit                              0x00007fff2fb8e0d1 uncaughtErrorProc + 145
7   CoreFoundation                      0x00007fff321fd2e9 __handleUncaughtException + 775
8   libobjc.A.dylib                     0x00007fff5c85fedd _objc_terminate() + 91
9   libc++abi.dylib                     0x00007fff5b2b819e std::__terminate(void (*)()) + 8
10  libc++abi.dylib                     0x00007fff5b2b8213 std::terminate() + 51
11  libdispatch.dylib                   0x00007fff5dfde651 _dispatch_client_callout + 28
12  libdispatch.dylib                   0x00007fff5dfdfd4b _dispatch_once_callout + 20
13  AppKit                              0x00007fff2f6b4b69 +[NSAppearance _initializeCoreUI] + 34
14  AppKit                              0x00007fff2f7abd05 +[NSAppearance _darkAquaAppearance] + 51
15  AppKit                              0x00007fff2f6b44f3 +[NSAppearance appearanceNamed:] + 24
16  AppKit                              0x00007fff2f6b4302 _NSAppearanceCurrentSystemAppearance + 178
17  AppKit                              0x00007fff2f6b40be -[NSSystemAppearanceProxy init] + 81
18  AppKit                              0x00007fff2f6b4064 __38+[NSSystemAppearanceProxy systemProxy]_block_invoke + 24
19  libdispatch.dylib                   0x00007fff5dfde63d _dispatch_client_callout + 8
20  libdispatch.dylib                   0x00007fff5dfdfd4b _dispatch_once_callout + 20
21  AppKit                              0x00007fff2f6b4049 +[NSSystemAppearanceProxy systemProxy] + 41
22  AppKit                              0x00007fff2f6b3f39 -[NSApplication(NSApplicationAppearance_Internal) _registerForAppearanceNotifications] + 34
23  AppKit                              0x00007fff2f6b314c -[NSApplication init] + 697
24  AppKit                              0x00007fff2f6b2ca0 +[NSApplication sharedApplication] + 138
25  Electron Framework                  0x00000001113a43d7 +[AtomApplication sharedApplication] + 39
26  Electron Framework                  0x00000001144ea110 content::ContentMainRunnerImpl::RunServiceManager(content::MainFunctionParams&, bool) + 160
27  Electron Framework                  0x00000001144ea04a content::ContentMainRunnerImpl::Run(bool) + 442
28  Electron Framework                  0x0000000117f88d93 service_manager::Main(service_manager::MainParams const&) + 3139
29  Electron Framework                  0x0000000112784064 content::ContentMain(content::ContentMainParams const&) + 68
30  Electron Framework                  0x00000001112a88d4 AtomMain + 84
31  Electron                            0x0000000105e37c80 main + 240
32  libdyld.dylib                       0x00007fff5e02b3d5 start + 1
33  ???                                 0x0000000000000001 0x0 + 1
[end of stack trace]
/Users/codebytere/build-tools/nix/commands/start.sh: line 8: 80647 Illegal instruction: 4  "$ELECTRON_EXEC" "$@"
```

</details>

Chromium also seems to do this [here](https://cs.chromium.org/chromium/src/chrome/installer/mac/pkg-dmg?type=cs&q=%22NEXT_ROOT%22&sq=package:chromium&g=0&l=436).

cc @nornagon @deepak1556 @miniak 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash when the `NEXT_ROOT` env var is set.
