### PR TITLE
build: fix build with Visual Studio 2019 (7-0-x)

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -1,0 +1,1 @@
+gles2_use_constant_initialization_for_g_mutex.patch

--- a/patches/angle/gles2_use_constant_initialization_for_g_mutex.patch
+++ b/patches/angle/gles2_use_constant_initialization_for_g_mutex.patch
@@ -1,0 +1,60 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jaime Bernardo <jaime@janeasystems.com>
+Date: Mon, 30 Sep 2019 17:53:56 +0100
+Subject: GLES2: Use require_constant_initialization for g_Mutex
+
+A static assert to verify that the global mutex g_Mutex is trivially
+constructed fails to compile with clang when using the STL shipped
+with Visual Studio 2019.
+
+Use __attribute__((require_constant_initialization)) instead to verify
+for constant initialization.
+
+BUG=angleproject:3936
+
+Change-Id: I5969762ad5a99033143513d7c4992344da276b1a
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/1832164
+Reviewed-by: Jamie Madill <jmadill@chromium.org>
+Reviewed-by: Geoff Lang <geofflang@chromium.org>
+Commit-Queue: Geoff Lang <geofflang@chromium.org>
+
+diff --git a/AUTHORS b/AUTHORS
+index ab39ee01a47c15da57b531d2c711649f1685091b..7a0f3b32b101b34195c57637b227062d9b173d6a 100644
+--- a/AUTHORS
++++ b/AUTHORS
+@@ -58,3 +58,4 @@ Jérôme Duval
+ Thomas Miller
+ Till Rathmann
+ Nick Shaforostov
++Jaime Bernardo
+diff --git a/src/common/angleutils.h b/src/common/angleutils.h
+index 131d5796da4399df1144bc349c506cde8220973a..3a1391e29b72e7ec356e44c7ced202cc29773fb3 100644
+--- a/src/common/angleutils.h
++++ b/src/common/angleutils.h
+@@ -345,4 +345,10 @@ std::string ToString(const T &value)
+ #    define ANGLE_MAYBE_UNUSED
+ #endif  // __has_cpp_attribute(maybe_unused)
+ 
++#if __has_cpp_attribute(require_constant_initialization)
++#    define ANGLE_REQUIRE_CONSTANT_INIT [[require_constant_initialization]]
++#else
++#    define ANGLE_REQUIRE_CONSTANT_INIT
++#endif  // __has_cpp_attribute(require_constant_initialization)
++
+ #endif  // COMMON_ANGLEUTILS_H_
+diff --git a/src/libGLESv2/global_state.cpp b/src/libGLESv2/global_state.cpp
+index 8ea912eea045c912ef64dfedcfd8f07db4337a9d..c8c9a732fbad5cc50ed2a7fc4b5387a30274435b 100644
+--- a/src/libGLESv2/global_state.cpp
++++ b/src/libGLESv2/global_state.cpp
+@@ -35,9 +35,8 @@ namespace
+ {
+ static TLSIndex threadTLS = TLS_INVALID_INDEX;
+ Debug *g_Debug            = nullptr;
+-std::atomic<std::mutex *> g_Mutex;
+-static_assert(std::is_trivially_constructible<decltype(g_Mutex)>::value,
+-              "global mutex is not trivially constructible");
++
++ANGLE_REQUIRE_CONSTANT_INIT std::atomic<std::mutex *> g_Mutex(nullptr);
+ static_assert(std::is_trivially_destructible<decltype(g_Mutex)>::value,
+               "global mutex is not trivially destructible");
+ 

--- a/patches/config.json
+++ b/patches/config.json
@@ -1,6 +1,8 @@
 {
   "src/electron/patches/chromium": "src",
 
+  "src/electron/patches/angle": "src/third_party/angle",
+
   "src/electron/patches/boringssl": "src/third_party/boringssl/src",
 
   "src/electron/patches/v8":  "src/v8",

--- a/patches/config.json
+++ b/patches/config.json
@@ -3,6 +3,8 @@
 
   "src/electron/patches/angle": "src/third_party/angle",
 
+  "src/electron/patches/quiche": "src/net/third_party/quiche/src",
+
   "src/electron/patches/boringssl": "src/third_party/boringssl/src",
 
   "src/electron/patches/perfetto": "src/third_party/perfetto",

--- a/patches/config.json
+++ b/patches/config.json
@@ -5,6 +5,8 @@
 
   "src/electron/patches/boringssl": "src/third_party/boringssl/src",
 
+  "src/electron/patches/perfetto": "src/third_party/perfetto",
+
   "src/electron/patches/v8":  "src/v8",
 
   "src/electron/patches/node": "src/third_party/electron_node"

--- a/patches/perfetto/.patches
+++ b/patches/perfetto/.patches
@@ -1,0 +1,1 @@
+metatrace_remove_memset_and_trivial_ctor_assumption.patch

--- a/patches/perfetto/metatrace_remove_memset_and_trivial_ctor_assumption.patch
+++ b/patches/perfetto/metatrace_remove_memset_and_trivial_ctor_assumption.patch
@@ -1,0 +1,80 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Primiano Tucci <primiano@google.com>
+Date: Thu, 3 Oct 2019 16:24:52 +0100
+Subject: metatrace: remove memset and trivial-ctor assumption
+
+Turns out that on MSVC std::atomic<int> is not trivially constructible
+(although I think is still a plain old int, it just fails the check).
+Fall back on resetting each element individually.
+Thankfully the compiler can see through and eventually figures out
+it can do a memset: https://godbolt.org/z/wMre8O
+
+Bug: chromium:1010616
+Change-Id: I971ff888306d6bdbaf6e6b886f9ca506ddc1b30a
+
+diff --git a/include/perfetto/ext/base/metatrace.h b/include/perfetto/ext/base/metatrace.h
+index 3858f68ec5eaf130aafa7d33f52a00e370395204..2c587c3fc63093f71a05e4c757def5c6384bf703 100644
+--- a/include/perfetto/ext/base/metatrace.h
++++ b/include/perfetto/ext/base/metatrace.h
+@@ -116,22 +116,33 @@ struct Record {
+     timestamp_ns_high = static_cast<uint16_t>(diff >> 32);
+   }
+ 
++  // We can't just memset() this class because on MSVC std::atomic<> is not
++  // trivially constructible anymore. Also std::atomic<> has a deleted copy
++  // constructor so we cant just do "*this = Record()" either.
++  // See http://bit.ly/339Jlzd .
++  void clear() {
++    this->~Record();
++    new (this) Record();
++  }
++
+   // This field holds the type (counter vs event) in the MSB and event ID (as
+   // defined in metatrace_events.h) in the lowest 15 bits. It is also used also
+   // as a linearization point: this is always written after all the other
+   // fields with a release-store. This is so the reader can determine whether it
+   // can safely process the other event fields after a load-acquire.
+-  std::atomic<uint16_t> type_and_id;
++  std::atomic<uint16_t> type_and_id{};
+ 
+   // Timestamp is stored as a 48-bits value diffed against g_enabled_timestamp.
+   // This gives us 78 hours from Enabled().
+-  uint16_t timestamp_ns_high;
+-  uint32_t timestamp_ns_low;
++  uint16_t timestamp_ns_high = 0;
++  uint32_t timestamp_ns_low = 0;
+ 
+-  uint32_t thread_id;
++  uint32_t thread_id = 0;
+ 
+   union {
+-    uint32_t duration_ns;   // If type == event.
++    // Only one of the two elements can be zero initialized, clang complains
++    // about "initializing multiple members of union" otherwise.
++    uint32_t duration_ns = 0;  // If type == event.
+     int32_t counter_value;  // If type == counter.
+   };
+ };
+diff --git a/src/base/metatrace.cc b/src/base/metatrace.cc
+index 9ef2c68777c5d497d92b12d52df4df2454feda02..67d167c8d07bc8701d261c56d11ba17afcb6ec8a 100644
+--- a/src/base/metatrace.cc
++++ b/src/base/metatrace.cc
+@@ -84,15 +84,9 @@ void Disable() {
+ 
+ // static
+ void RingBuffer::Reset() {
+-  static_assert(PERFETTO_IS_TRIVIALLY_CONSTRUCTIBLE(Record) &&
+-                    std::is_trivially_destructible<Record>::value,
+-                "Record must be trivial");
+-  // Cast pointers to void* to suppress "-Wclass-memaccess" from gcc, which
+-  // triggers as we're doing a raw memory set for a class (Record) that doesn't
+-  // have a copy assignment operator (due to the atomic |type_and_id|).
+-  memset(static_cast<void*>(records_.data()), 0, sizeof(records_));
+-  memset(static_cast<void*>(&bankruptcy_record_), 0,
+-         sizeof(bankruptcy_record_));
++  bankruptcy_record_.clear();
++  for (Record& record : records_)
++    record.clear();
+   wr_index_ = 0;
+   rd_index_ = 0;
+   has_overruns_ = false;

--- a/patches/quiche/.patches
+++ b/patches/quiche/.patches
@@ -1,0 +1,1 @@
+include_ostream_in_quic_ip_address_h.patch

--- a/patches/quiche/include_ostream_in_quic_ip_address_h.patch
+++ b/patches/quiche/include_ostream_in_quic_ip_address_h.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: vasilvv <vasilvv@google.com>
+Date: Thu, 3 Oct 2019 09:37:10 -0700
+Subject: [build] Include ostream in quic_ip_address.h
+
+Explicitly #include <ostream> in quic/platform/api/quic_ip_address.h, since std::ostream is referenced in it. In the C++ STL shipped with Visual Studio 2019, none of the headers included in quic_ip_address.h ends up including the required templates, which caused a compile error.
+
+Patch by Jaime Bernardo <jaime@janeasystems.com>: https://quiche-review.googlesource.com/c/quiche/+/10280
+
+gfe-relnote: n/a (no functional change)
+PiperOrigin-RevId: 272678937
+Change-Id: I304ed7ad7f114924268ef832551fb2ddcba73402
+
+diff --git a/quic/platform/api/quic_ip_address.h b/quic/platform/api/quic_ip_address.h
+index e1a1076cbcbd0bfe72e69b4c0fefe2b21ec4426c..3585970d9d50f2b026616e758576dd466044c39b 100644
+--- a/quic/platform/api/quic_ip_address.h
++++ b/quic/platform/api/quic_ip_address.h
+@@ -15,6 +15,7 @@
+ #include <sys/types.h>
+ #endif
+ 
++#include <ostream>
+ #include <string>
+ 
+ #include "net/third_party/quiche/src/quic/platform/api/quic_export.h"

--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -6,3 +6,4 @@ dcheck.patch
 export_symbols_needed_for_windows_build.patch
 workaround_an_undefined_symbol_error.patch
 do_not_export_private_v8_symbols_on_windows.patch
+include_string_in_v8_h.patch

--- a/patches/v8/include_string_in_v8_h.patch
+++ b/patches/v8/include_string_in_v8_h.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jaime Bernardo <jaime@janeasystems.com>
+Date: Tue, 1 Oct 2019 20:06:03 +0100
+Subject: Include string in v8.h
+
+Explicitly #include<string> in v8.h, since std::string is referenced
+in it. In the C++ STL shipped with Visual Studio 2019, none of the
+headers included in v8.h ends up including the C++ string header, which
+caused a compile error.
+
+Bug: v8:9793
+Change-Id: I84a133dd10dd6dcc7b70287af393e82cf0dc97df
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/1834321
+Reviewed-by: Adam Klein <adamk@chromium.org>
+Commit-Queue: Adam Klein <adamk@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#64074}
+
+diff --git a/include/v8.h b/include/v8.h
+index f0c47907292b9da438347276ac240541577899ad..a8010f4dadef1636697d08888a4c5e2da68f884a 100644
+--- a/include/v8.h
++++ b/include/v8.h
+@@ -19,6 +19,7 @@
+ #include <stdint.h>
+ #include <stdio.h>
+ #include <memory>
++#include <string>
+ #include <type_traits>
+ #include <utility>
+ #include <vector>


### PR DESCRIPTION
#### Description of Change

Manual backport of https://github.com/electron/electron/pull/20465 to `7-0-x`.

Applies the patches necessary for Electron to build with Visual Studio 2019.

Each commit in this PR patches a dependency with a commit that has already been merged upstream into a master branch to fix building that dependency with the Visual Studio 2019 build tools:
- [angle](https://chromium.googlesource.com/angle/angle/+/755417dd79071d6149c81418e1404b0c61d19672)
- [v8](https://chromium.googlesource.com/v8/v8/+/53e62affd33ad036a169eff7d6c1d50b0adcd21a)
- [perfetto](https://android.googlesource.com/platform/external/perfetto/+/f10b2053be67439539968c9f391f63664de779d4)
- [quiche](https://quiche.googlesource.com/quiche/+/c1e9121f16559b084bb80afc6922f0316d082160)

After applying these fixes, electron builds using the Visual Studio 2019 C++ build tools.

Fixes https://github.com/electron/electron/issues/20346 on `7-0-x` too.

cc @codebytere 
cc @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes
