### PR TITLE
docs: add context menu example

### DIFF
--- a/docs/fiddles/menus/customize-menus/context-menu/index.html
+++ b/docs/fiddles/menus/customize-menus/context-menu/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+  </head>
+  <body>
+    <div>
+      <div>
+        <h1>Supports: Win, macOS, Linux <span>|</span> Process: Main</h1>
+        <div>
+          <div>
+            <button id="context-menu">View Demo</button>
+          </div>
+          <p>A context, or right-click, menu can be created with the <code>Menu</code> and <code>MenuItem</code> modules as well. You can right-click anywhere in this app or click the demo button to see an example context menu.</p>
+
+          <p>In this demo we use the <code>ipcRenderer</code> module to show the context menu when explicitly calling it from the renderer process.</p>
+          <p>See the full <a href="http://electron.atom.io/docs/api/web-contents/#event-context-menu">context-menu event documentation</a> for all the available properties.</p>
+        </div>
+    </div>
+    <script>
+      // You can also require other files to run in this process
+      require('./renderer.js')
+    </script>
+  </body>
+</html>

--- a/docs/fiddles/menus/customize-menus/context-menu/main.js
+++ b/docs/fiddles/menus/customize-menus/context-menu/main.js
@@ -1,0 +1,48 @@
+const {
+  BrowserWindow,
+  Menu,
+  MenuItem,
+  ipcMain,
+  app
+} = require('electron')
+
+const menu = new Menu()
+
+menu.append(new MenuItem({ label: 'Hello' }))
+menu.append(new MenuItem({ type: 'separator' }))
+menu.append(new MenuItem({ label: 'Electron', type: 'checkbox', checked: true }))
+
+let mainWindow = null
+
+function createWindow () {
+  const windowOptions = {
+    width: 600,
+    height: 400,
+    title: 'Manage Window State',
+    webPreferences: {
+      nodeIntegration: true
+    }
+  }
+
+  mainWindow = new BrowserWindow(windowOptions)
+  mainWindow.loadFile('index.html')
+
+  mainWindow.on('closed', () => {
+    mainWindow = null
+  })
+}
+
+app.on('ready', () => {
+  createWindow()
+})
+
+app.on('browser-window-created', (event, win) => {
+  win.webContents.on('context-menu', (e, params) => {
+    menu.popup(win, params.x, params.y)
+  })
+})
+
+ipcMain.on('show-context-menu', (event) => {
+  const win = BrowserWindow.fromWebContents(event.sender)
+  menu.popup(win)
+})

--- a/docs/fiddles/menus/customize-menus/context-menu/renderer.js
+++ b/docs/fiddles/menus/customize-menus/context-menu/renderer.js
@@ -1,0 +1,8 @@
+const { ipcRenderer } = require('electron')
+
+// Tell main process to show the menu when demo button is clicked
+const contextMenuBtn = document.getElementById('context-menu')
+
+contextMenuBtn.addEventListener('click', () => {
+  ipcRenderer.send('show-context-menu')
+})


### PR DESCRIPTION
#### Description of Change
Refs #20442

Adds the context menu example from electron-api-demos into a runnable Fiddle example.

Gist link to Fiddle (same as code submitted in this PR): https://gist.github.com/a79d77a8b5d42f6d0563e09d90e107d5

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `standard` linter passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
<!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
