### PR TITLE
fix: properly register custom open-url evt handling

### DIFF
--- a/shell/browser/atom_browser_main_parts.cc
+++ b/shell/browser/atom_browser_main_parts.cc
@@ -537,6 +537,7 @@ void AtomBrowserMainParts::PreMainMessageLoopStart() {
 void AtomBrowserMainParts::PreMainMessageLoopStartCommon() {
 #if defined(OS_MACOSX)
   InitializeEmptyApplicationMenu();
+  RegisterURLHandler();
 #endif
   media::SetLocalizedStringProvider(MediaStringProvider);
 }

--- a/shell/browser/atom_browser_main_parts.h
+++ b/shell/browser/atom_browser_main_parts.h
@@ -105,6 +105,7 @@ class AtomBrowserMainParts : public content::BrowserMainParts {
 
 #if defined(OS_MACOSX)
   void FreeAppDelegate();
+  void RegisterURLHandler();
   void InitializeEmptyApplicationMenu();
 #endif
 

--- a/shell/browser/atom_browser_main_parts_mac.mm
+++ b/shell/browser/atom_browser_main_parts_mac.mm
@@ -5,6 +5,7 @@
 #include "shell/browser/atom_browser_main_parts.h"
 
 #include "shell/browser/atom_paths.h"
+#import "shell/browser/mac/atom_application.h"
 #include "shell/browser/mac/atom_application_delegate.h"
 
 namespace electron {
@@ -70,6 +71,10 @@ void AtomBrowserMainParts::PreMainMessageLoopStart() {
 void AtomBrowserMainParts::FreeAppDelegate() {
   [[NSApp delegate] release];
   [NSApp setDelegate:nil];
+}
+
+void AtomBrowserMainParts::RegisterURLHandler() {
+  [[AtomApplication sharedApplication] registerURLHandler];
 }
 
 void AtomBrowserMainParts::InitializeEmptyApplicationMenu() {

--- a/shell/browser/mac/atom_application.h
+++ b/shell/browser/mac/atom_application.h
@@ -97,6 +97,7 @@ typedef NS_ENUM(NSInteger, AVAuthorizationStatusMac) {
 + (AtomApplication*)sharedApplication;
 
 - (void)setShutdownHandler:(base::Callback<bool()>)handler;
+- (void)registerURLHandler;
 
 // CrAppProtocol:
 - (BOOL)isHandlingSendEvent;

--- a/shell/browser/mac/atom_application.mm
+++ b/shell/browser/mac/atom_application.mm
@@ -153,7 +153,7 @@ inline void dispatch_sync_main(dispatch_block_t block) {
   [userActivity setNeedsSave:YES];
 }
 
-- (void)awakeFromNib {
+- (void)registerURLHandler {
   [[NSAppleEventManager sharedAppleEventManager]
       setEventHandler:self
           andSelector:@selector(handleURLEvent:withReplyEvent:)


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/20181.

When we removed our use of `MainMenu.xib` in [this chromium roll commit](https://github.com/electron/electron/pull/18626/commits/44ee1f4de23fe634a794cc3bddf3a4acc0624809), we inadvertently made it such that `awakeFromNib` defined in `atom_application.mm` was no longer called, and as such our custom handler for urls would no longer be registered and fired.

This fixes that issue by moving the url registration logic into a new method `registerURLHandler()` and ensuring that it's called in `PreMainMessageLoopStartCommon()`, at the same point in startup flow where this logic was previously being invoked.

cc @MarshallOfSound @jkleinsc @nornagon

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the `open-url` event was not properly being fired on macOS.
