### PR TITLE
fix: return proper values for WM_GETMINMAXINFO

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1205,11 +1205,13 @@ gfx::Rect NativeWindowViews::ContentBoundsToWindowBounds(
 
   gfx::Rect window_bounds(bounds);
 #if defined(OS_WIN)
-  HWND hwnd = GetAcceleratedWidget();
-  gfx::Rect dpi_bounds = DIPToScreenRect(hwnd, bounds);
-  window_bounds = ScreenToDIPRect(
-      hwnd,
-      widget()->non_client_view()->GetWindowBoundsForClientBounds(dpi_bounds));
+  if (widget()->non_client_view()) {
+    HWND hwnd = GetAcceleratedWidget();
+    gfx::Rect dpi_bounds = DIPToScreenRect(hwnd, bounds);
+    window_bounds = ScreenToDIPRect(
+        hwnd, widget()->non_client_view()->GetWindowBoundsForClientBounds(
+                  dpi_bounds));
+  }
 #endif
 
   if (root_view_->HasMenu() && root_view_->IsMenuBarVisible()) {

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -356,14 +356,18 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
           display::Screen::GetScreen()->GetDisplayNearestPoint(
               last_normal_placement_bounds_.origin());
 
+      const gfx::Size widget_min_size = widget()->GetMinimumSize();
+      const gfx::Size widget_max_size = widget()->GetMaximumSize();
       gfx::Size min_size = gfx::ScaleToCeiledSize(
-          widget()->GetMinimumSize(), display.device_scale_factor());
+          ContentBoundsToWindowBounds(gfx::Rect(widget_min_size)).size(),
+          display.device_scale_factor());
       gfx::Size max_size = gfx::ScaleToCeiledSize(
-          widget()->GetMaximumSize(), display.device_scale_factor());
+          ContentBoundsToWindowBounds(gfx::Rect(widget_max_size)).size(),
+          display.device_scale_factor());
 
       info->ptMinTrackSize.x = min_size.width();
       info->ptMinTrackSize.y = min_size.height();
-      if (max_size.width() || max_size.height()) {
+      if (widget_max_size.width() || widget_max_size.height()) {
         if (!max_size.width())
           max_size.set_width(GetSystemMetrics(SM_CXMAXTRACK));
         if (!max_size.height())


### PR DESCRIPTION
When BrowserWindow has set constraints for width (max or min) it
won't behave correctly during first attempt of resizing it. When
maxWidth is defined and maxWidth equals its width it will shrink
rapidly when user tries to expand its width. On the other hand
when minWidth is defined and minWidth equals its width it's
possible to decrease its width with a few pixels.

Here is a sample app which can be used to reproduce the problem:
```
const { app, BrowserWindow } = require('electron')

async function createWindow() {
  let win = new BrowserWindow({
    width: 800,
    height: 600,
    maxWidth: 800
  });
  win.loadURL('http://www.example.com');
}

app.on('ready', createWindow)
```

There is also third problem. When minWidth is set and starting width is bigger than
minWidth when window's size is decreased to minWidth it's very hard to grab
resize edge again: it seems it's very thin and resize icon doesn't show when mouse
pointer is on top of it.

Notes: Fixed improper behaviour of window with width constraint set during resize.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
