### PR TITLE
docs: Adds Desktop notifications Fiddle example

### DIFF
--- a/docs/fiddles/native-ui/notifications/index.html
+++ b/docs/fiddles/native-ui/notifications/index.html
@@ -5,7 +5,7 @@
     <title>Desktop notifications</title>
   </head>
   <body>
-    <div class="section-wrapper">
+    <div>
       <h1>Desktop notifications</h1>
       <h3>
         The <code>notification</code> module in Electron allows you to add basic
@@ -14,9 +14,8 @@
 
       <p>
         Electron conveniently allows developers to send notifications with the
-        <a href="https://notifications.spec.whatwg.org/"
-          >HTML5 Notification API</a
-        >, using the currently running operating system’s native notification
+        <a href="https://notifications.spec.whatwg.org/">HTML5 Notification API</a>, 
+        using the currently running operating system’s native notification
         APIs to display it.
       </p>
 
@@ -27,34 +26,31 @@
 
       <p>
         Open the
-        <a
-          href="https://electron.atom.io/docs/all/#notifications-windows-linux-macos"
-          >full API documentation<span class="u-visible-to-screen-reader"
-            >(opens in new window)</span
-          ></a
-        >
+        <a href="https://electron.atom.io/docs/all/#notifications-windows-linux-macos">
+          full API documentation<span>(opens in new window)</span>
+        </a>
         in your browser.
       </p>
     </div>
 
-    <div class="demo">
-      <div class="demo-wrapper">
+    <div>
+      <div>
         <h2>Basic notification</h2>
-        <div class="demo-box">
-          <div class="demo-controls">
-            <button class="demo-button" id="basic-noti">View demo</button>
+        <div>
+          <div>
+            <button id="basic-noti">View demo</button>
           </div>
           <p>This demo demonstrates a basic notification. Text only.</p>
         </div>
       </div>
     </div>
 
-    <div class="demo">
-      <div class="demo-wrapper">
+    <div>
+      <div>
         <h2>Notification with image</h2>
-        <div class="demo-box">
-          <div class="demo-controls">
-            <button class="demo-button" id="advanced-noti">View demo</button>
+        <div>
+          <div>
+            <button id="advanced-noti">View demo</button>
           </div>
           <p>
             This demo demonstrates a basic notification. Both text and a image

--- a/docs/fiddles/native-ui/notifications/index.html
+++ b/docs/fiddles/native-ui/notifications/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Desktop notifications</title>
+  </head>
+  <body>
+    <div class="section-wrapper">
+      <h1>Desktop notifications</h1>
+      <h3>
+        The <code>notification</code> module in Electron allows you to add basic
+        desktop notifications.
+      </h3>
+
+      <p>
+        Electron conveniently allows developers to send notifications with the
+        <a href="https://notifications.spec.whatwg.org/"
+          >HTML5 Notification API</a
+        >, using the currently running operating system’s native notification
+        APIs to display it.
+      </p>
+
+      <p>
+        <b>Note:</b> Since this is an HTML5 API it is only available in the
+        renderer process.
+      </p>
+
+      <p>
+        Open the
+        <a
+          href="https://electron.atom.io/docs/all/#notifications-windows-linux-macos"
+          >full API documentation<span class="u-visible-to-screen-reader"
+            >(opens in new window)</span
+          ></a
+        >
+        in your browser.
+      </p>
+    </div>
+
+    <div class="demo">
+      <div class="demo-wrapper">
+        <h2>Basic notification</h2>
+        <div class="demo-box">
+          <div class="demo-controls">
+            <button class="demo-button" id="basic-noti">View demo</button>
+          </div>
+          <p>This demo demonstrates a basic notification. Text only.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo">
+      <div class="demo-wrapper">
+        <h2>Notification with image</h2>
+        <div class="demo-box">
+          <div class="demo-controls">
+            <button class="demo-button" id="advanced-noti">View demo</button>
+          </div>
+          <p>
+            This demo demonstrates a basic notification. Both text and a image
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      // You can also require other files to run in this process
+      require("./renderer.js");
+    </script>
+  </body>
+</html>

--- a/docs/fiddles/native-ui/notifications/main.js
+++ b/docs/fiddles/native-ui/notifications/main.js
@@ -1,0 +1,56 @@
+// Modules to control application life and create native browser window
+const { app, BrowserWindow } = require('electron')
+
+// Keep a global reference of the window object, if you don't, the window will
+// be closed automatically when the JavaScript object is garbage collected.
+let mainWindow
+
+function createWindow () {
+  // Create the browser window.
+  mainWindow = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      nodeIntegration: true
+    }
+  })
+
+  // and load the index.html of the app.
+  mainWindow.loadFile('index.html')
+
+  // Open the DevTools.
+  // mainWindow.webContents.openDevTools()
+
+  // Emitted when the window is closed.
+  mainWindow.on('closed', function () {
+    // Dereference the window object, usually you would store windows
+    // in an array if your app supports multi windows, this is the time
+    // when you should delete the corresponding element.
+    mainWindow = null
+  })
+}
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.on('ready', createWindow)
+
+// Quit when all windows are closed.
+app.on('window-all-closed', function () {
+  // On OS X it is common for applications and their menu bar
+  // to stay active until the user quits explicitly with Cmd + Q
+  if (process.platform !== 'darwin') {
+    app.quit()
+  }
+})
+
+app.on('activate', function () {
+  // On OS X it's common to re-create a window in the app when the
+  // dock icon is clicked and there are no other windows open.
+  if (mainWindow === null) {
+    createWindow()
+  }
+})
+
+// In this file you can include the rest of your app's specific main process
+// code. You can also put them in separate files and require them here.

--- a/docs/fiddles/native-ui/notifications/renderer.js
+++ b/docs/fiddles/native-ui/notifications/renderer.js
@@ -1,0 +1,29 @@
+const basicNotification = {
+  title: 'Basic Notification',
+  body: 'Short message part'
+}
+
+const notification = {
+  title: 'Notification with image',
+  body: 'Short message plus a custom image',
+  icon: 'https://via.placeholder.com/150'
+}
+
+const basicNotificationButton = document.getElementById('basic-noti')
+const notificationButton = document.getElementById('advanced-noti')
+
+notificationButton.addEventListener('click', () => {
+  const myNotification = new window.Notification(notification.title, notification)
+
+  myNotification.onclick = () => {
+    console.log('Notification clicked')
+  }
+})
+
+basicNotificationButton.addEventListener('click', () => {
+  const myNotification = new window.Notification(basicNotification.title, basicNotification)
+
+  myNotification.onclick = () => {
+    console.log('Notification clicked')
+  }
+})


### PR DESCRIPTION
#### Description of Change

Refs #20442

Adds the Desktop notifications example from `electron-api-demos` into a runnable Fiddle example.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `standard` linter passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: Added Desktop notifications example from `electron-api-demos` into a runnable Fiddle example.