### PR TITLE
docs: add notification examples

### DIFF
--- a/docs/fiddles/native-ui/notifications/basic-notification/index.html
+++ b/docs/fiddles/native-ui/notifications/basic-notification/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+  </head>
+  <body>
+    <div>
+      <h3>Basic notification</h3>
+      <i>Supports: Win 7+, macOS, Linux (that supports libnotify)<span>|</span> Process: Renderer</i>
+      <div>
+        <div>
+          <button id="basic-noti">View demo</button>
+        </div>
+        <p>This demo demonstrates a basic notification. Text only.</p>
+      </div>
+    </div>
+    <script>
+      // You can also require other files to run in this process
+      require('./renderer.js')
+    </script>
+  </body>
+</html>

--- a/docs/fiddles/native-ui/notifications/basic-notification/main.js
+++ b/docs/fiddles/native-ui/notifications/basic-notification/main.js
@@ -1,0 +1,25 @@
+const { BrowserWindow, app } = require('electron')
+
+let mainWindow = null
+
+function createWindow () {
+  const windowOptions = {
+    width: 600,
+    height: 300,
+    title: 'Basic Notification',
+    webPreferences: {
+      nodeIntegration: true
+    }
+  }
+
+  mainWindow = new BrowserWindow(windowOptions)
+  mainWindow.loadFile('index.html')
+
+  mainWindow.on('closed', () => {
+    mainWindow = null
+  })
+}
+
+app.on('ready', () => {
+  createWindow()
+})

--- a/docs/fiddles/native-ui/notifications/basic-notification/renderer.js
+++ b/docs/fiddles/native-ui/notifications/basic-notification/renderer.js
@@ -1,0 +1,14 @@
+const notification = {
+  title: 'Basic Notification',
+  body: 'Short message part'
+}
+
+const notificationButton = document.getElementById('basic-noti')
+
+notificationButton.addEventListener('click', () => {
+  const myNotification = new window.Notification(notification.title, notification)
+
+  myNotification.onclick = () => {
+    console.log('Notification clicked')
+  }
+})

--- a/docs/fiddles/native-ui/notifications/notification-with-image/index.html
+++ b/docs/fiddles/native-ui/notifications/notification-with-image/index.html
@@ -11,7 +11,7 @@
         <div>
           <button id="advanced-noti">View demo</button>
         </div>
-        <p>This demo demonstrates a advanced notification. Both text and image.</p>
+        <p>This demo demonstrates an advanced notification. Both text and image.</p>
       </div>
     </div>
     <script>

--- a/docs/fiddles/native-ui/notifications/notification-with-image/index.html
+++ b/docs/fiddles/native-ui/notifications/notification-with-image/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+  </head>
+  <body>
+    <div>
+      <h3>Notification with image</h3>
+      <i>Supports: Win 7+, macOS, Linux (that supports libnotify)<span>|</span> Process: Renderer</i>
+      <div>
+        <div>
+          <button id="advanced-noti">View demo</button>
+        </div>
+        <p>This demo demonstrates a advanced notification. Both text and image.</p>
+      </div>
+    </div>
+    <script>
+      // You can also require other files to run in this process
+      require('./renderer.js')
+    </script>
+  </body>
+</html>

--- a/docs/fiddles/native-ui/notifications/notification-with-image/main.js
+++ b/docs/fiddles/native-ui/notifications/notification-with-image/main.js
@@ -1,0 +1,25 @@
+const { BrowserWindow, app } = require('electron')
+
+let mainWindow = null
+
+function createWindow () {
+  const windowOptions = {
+    width: 600,
+    height: 300,
+    title: 'Advanced Notification',
+    webPreferences: {
+      nodeIntegration: true
+    }
+  }
+
+  mainWindow = new BrowserWindow(windowOptions)
+  mainWindow.loadFile('index.html')
+
+  mainWindow.on('closed', () => {
+    mainWindow = null
+  })
+}
+
+app.on('ready', () => {
+  createWindow()
+})

--- a/docs/fiddles/native-ui/notifications/notification-with-image/renderer.js
+++ b/docs/fiddles/native-ui/notifications/notification-with-image/renderer.js
@@ -1,5 +1,3 @@
-const path = require('path')
-
 const notification = {
   title: 'Notification with image',
   body: 'Short message plus a custom image',

--- a/docs/fiddles/native-ui/notifications/notification-with-image/renderer.js
+++ b/docs/fiddles/native-ui/notifications/notification-with-image/renderer.js
@@ -1,0 +1,16 @@
+const path = require('path')
+
+const notification = {
+  title: 'Notification with image',
+  body: 'Short message plus a custom image',
+  icon: 'https://raw.githubusercontent.com/electron/electron-api-demos/v2.0.2/assets/img/programming.png'
+}
+const notificationButton = document.getElementById('advanced-noti')
+
+notificationButton.addEventListener('click', () => {
+  const myNotification = new window.Notification(notification.title, notification)
+
+  myNotification.onclick = () => {
+    console.log('Notification clicked')
+  }
+})


### PR DESCRIPTION
#### Description of Change
Refs #20442

Adds the basic notification and notification with custom image examples from electron-api-demos into runnable Fiddle examples.

Gist links to Fiddles (same as code submitted in this PR): 
Basic Notification: https://gist.github.com/102945f83f559e7944797175d8fd8af4
Notification with image: https://gist.github.com/2688bf4bfc27ce02f5d74224828eb928

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `standard` linter passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
<!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->

#### Screenshots
##### Basic Notification
![image](https://user-images.githubusercontent.com/5207331/66602656-3794dc80-ebc8-11e9-9ef8-ed2be396f562.png)

##### Notification with custom image
![image](https://user-images.githubusercontent.com/5207331/66602604-17fdb400-ebc8-11e9-85a6-e31a6ad8b52f.png)


