### PR TITLE
fix: generate breakpad symbols before stripping

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -953,10 +953,10 @@ steps-electron-build-for-publish: &steps-electron-build-for-publish
 
     # Electron app
     - *step-electron-build
+    - *step-maybe-generate-breakpad-symbols
     - *step-maybe-electron-dist-strip
     - *step-electron-dist-build
     - *step-electron-dist-store
-    - *step-maybe-generate-breakpad-symbols
     - *step-maybe-zip-symbols
 
     # mksnapshot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -553,6 +553,11 @@ step-maybe-zip-symbols: &step-maybe-zip-symbols
       ninja -C out/Default electron:electron_version
       electron/script/zip-symbols.py -b $BUILD_PATH
 
+step-symbols-store: &step-symbols-store
+  store_artifacts:
+    path: src/out/Default/symbols.zip
+    destination: symbols.zip
+
 step-maybe-cross-arch-snapshot: &step-maybe-cross-arch-snapshot
   run:
     name: Generate cross arch snapshot (arm/arm64)
@@ -859,6 +864,7 @@ steps-electron-build: &steps-electron-build
 
     - *step-maybe-generate-breakpad-symbols
     - *step-maybe-zip-symbols
+    - *step-symbols-store
 
     # Trigger tests on arm hardware if needed
     - *step-maybe-trigger-arm-test
@@ -933,6 +939,7 @@ steps-electron-build-with-inline-checkout-for-tests: &steps-electron-build-with-
 
     - *step-maybe-generate-breakpad-symbols
     - *step-maybe-zip-symbols
+    - *step-symbols-store
 
     # Trigger tests on arm hardware if needed
     - *step-maybe-trigger-arm-test
@@ -958,6 +965,7 @@ steps-electron-build-for-publish: &steps-electron-build-for-publish
     - *step-electron-dist-build
     - *step-electron-dist-store
     - *step-maybe-zip-symbols
+    - *step-symbols-store
 
     # mksnapshot
     - *step-mksnapshot-build


### PR DESCRIPTION
#### Description of Change
Looks like at some point we switched the order of strip and generate symbols, meaning we have been producing near-useless Linux symbols for some time now. (Afaict the symbols for Electron v5 are OK, but the v6 ones are broken.)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed debug symbol files on linux not containing private symbols.