### PR TITLE
docs: add example for taking screenshot

### DIFF
--- a/docs/fiddles/media/screenshot/take-screenshot/index.html
+++ b/docs/fiddles/media/screenshot/take-screenshot/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+  </head>
+  <body>
+    <div>
+      <h3>Take a Screenshot</h3>
+      <i>Supports: Win, macOS, Linux <span>|</span> Process: Renderer</i>
+       <div>
+        <div>
+          <div>
+            <button id="screen-shot">View Demo</button>
+            <span id="screenshot-path"></span>
+          </div>
+          <p>This demo uses the <code>desktopCapturer</code> module to gather screens in use and select the entire screen and take a snapshot of what is visible.</p>
+          <p>Clicking the demo button will take a screenshot of your current screen and open it in your default viewer.</p>
+        </div>
+    </div>
+    <script>
+      // You can also require other files to run in this process
+      require('./renderer.js')
+    </script>
+  </body>
+</html>

--- a/docs/fiddles/media/screenshot/take-screenshot/main.js
+++ b/docs/fiddles/media/screenshot/take-screenshot/main.js
@@ -1,0 +1,25 @@
+const { BrowserWindow, app } = require('electron')
+
+let mainWindow = null
+
+function createWindow () {
+  const windowOptions = {
+    width: 600,
+    height: 300,
+    title: 'Desktop Capturer',
+    webPreferences: {
+      nodeIntegration: true
+    }
+  }
+
+  mainWindow = new BrowserWindow(windowOptions)
+  mainWindow.loadFile('index.html')
+
+  mainWindow.on('closed', () => {
+    mainWindow = null
+  })
+}
+
+app.on('ready', () => {
+  createWindow()
+})

--- a/docs/fiddles/media/screenshot/take-screenshot/renderer.js
+++ b/docs/fiddles/media/screenshot/take-screenshot/renderer.js
@@ -1,0 +1,43 @@
+const { desktopCapturer } = require('electron')
+const { screen, shell } = require('electron').remote
+
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const screenshot = document.getElementById('screen-shot')
+const screenshotMsg = document.getElementById('screenshot-path')
+
+screenshot.addEventListener('click', (event) => {
+  screenshotMsg.textContent = 'Gathering screens...'
+  const thumbSize = determineScreenShotSize()
+  const options = { types: ['screen'], thumbnailSize: thumbSize }
+
+  desktopCapturer.getSources(options, (error, sources) => {
+    if (error) return console.log(error)
+
+    sources.forEach((source) => {
+      const sourceName = source.name.toLowerCase()
+      if (sourceName === 'entire screen' || sourceName === 'screen 1') {
+        const screenshotPath = path.join(os.tmpdir(), 'screenshot.png')
+
+        fs.writeFile(screenshotPath, source.thumbnail.toPNG(), (error) => {
+          if (error) return console.log(error)
+          shell.openExternal(`file://${screenshotPath}`)
+
+          const message = `Saved screenshot to: ${screenshotPath}`
+          screenshotMsg.textContent = message
+        })
+      }
+    })
+  })
+})
+
+function determineScreenShotSize () {
+  const screenSize = screen.getPrimaryDisplay().workAreaSize
+  const maxDimension = Math.max(screenSize.width, screenSize.height)
+  return {
+    width: maxDimension * window.devicePixelRatio,
+    height: maxDimension * window.devicePixelRatio
+  }
+}


### PR DESCRIPTION
#### Description of Change
Refs #20442

Adds the example for taking screenshot from electron-api-demos into runnable Fiddle example.

Gist link to Fiddle (same as code submitted in this PR): 
https://gist.github.com/b528a6d5d920b10fb768c899be9813c5

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `standard` linter passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes

#### Screenshots
![image](https://user-images.githubusercontent.com/5207331/66605372-9f99f180-ebcd-11e9-8895-712f5226212b.png)
