### PR TITLE
docs: add system get version info Fiddle example

### DIFF
--- a/docs/fiddles/system/system-information/get-version-information/index.html
+++ b/docs/fiddles/system/system-information/get-version-information/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+  </head>
+  <body>
+    <div>
+      <div>
+        <h1>Get version information</h1>
+        <i>Supports: Win, macOS, Linux <span>|</span> Process: Both</i>
+        <div>
+          <div>
+            <button id="version-info">View Demo</button>
+            <span id="got-version-info"></span>
+          </div>
+          <p>The <code>process</code> module is built into Node.js (therefore you can use this in both the main and renderer processes) and in Electron apps this object has a few more useful properties on it.</p>
+          <p>The example below gets the version of Electron in use by the app.</p>
+          <p>See the <a href="http://electron.atom.io/docs/api/process">process documentation <span>(opens in new window)</span></a> for more.</p>
+        </div>
+      </div>
+    </div>
+  </body>
+  <script>
+    require('./renderer.js')
+  </script>
+</html>

--- a/docs/fiddles/system/system-information/get-version-information/main.js
+++ b/docs/fiddles/system/system-information/get-version-information/main.js
@@ -1,0 +1,25 @@
+const { app, BrowserWindow } = require('electron')
+
+let mainWindow = null
+
+function createWindow () {
+  const windowOptions = {
+    width: 600,
+    height: 400,
+    title: 'Get version information',
+    webPreferences: {
+      nodeIntegration: true
+    }
+  }
+
+  mainWindow = new BrowserWindow(windowOptions)
+  mainWindow.loadFile('index.html')
+
+  mainWindow.on('closed', () => {
+    mainWindow = null
+  })
+}
+
+app.on('ready', () => {
+  createWindow()
+})

--- a/docs/fiddles/system/system-information/get-version-information/renderer.js
+++ b/docs/fiddles/system/system-information/get-version-information/renderer.js
@@ -1,0 +1,8 @@
+const versionInfoBtn = document.getElementById('version-info')
+
+const electronVersion = process.versions.electron
+
+versionInfoBtn.addEventListener('click', () => {
+  const message = `This app is using Electron version: ${electronVersion}`
+  document.getElementById('got-version-info').innerHTML = message
+})


### PR DESCRIPTION
#### Description of Change
Refs #20442

Adds the system get version info example from `electron-api-demos` into a runnable Fiddle example.

Gist link to Fiddle (same as code submitted in this PR): https://gist.github.com/b023830ff031ab004629b2d348252e4e

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `standard` linter passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
