### PR TITLE
fix: do not manually parse content-type

### DIFF
--- a/shell/browser/net/atom_url_loader_factory.cc
+++ b/shell/browser/net/atom_url_loader_factory.cc
@@ -123,9 +123,8 @@ network::ResourceResponseHead ToResponseHead(const mate::Dictionary& dict) {
       }
       // Some apps are passing content-type via headers, which is not accepted
       // in NetworkService.
-      if (base::ToLowerASCII(iter.first) == "content-type" &&
-          iter.second.is_string()) {
-        head.mime_type = iter.second.GetString();
+      if (base::ToLowerASCII(iter.first) == "content-type") {
+        head.headers->GetMimeTypeAndCharset(&head.mime_type, &head.charset);
         has_content_type = true;
       }
     }

--- a/spec-main/api-protocol-spec.ts
+++ b/spec-main/api-protocol-spec.ts
@@ -469,6 +469,18 @@ describe('protocol module', () => {
       expect(r.data).to.have.property('value').that.is.equal(1)
     })
 
+    it('can set content-type with charset', async () => {
+      await interceptStringProtocol('http', (request, callback) => {
+        callback({
+          mimeType: 'application/json; charset=UTF-8',
+          data: '{"value": 1}'
+        })
+      })
+      const r = await ajax('http://fake-host')
+      expect(r.data).to.be.an('object')
+      expect(r.data).to.have.property('value').that.is.equal(1)
+    })
+
     it('can receive post data', async () => {
       await interceptStringProtocol('http', (request, callback) => {
         const uploadData = request.uploadData[0].bytes.toString()


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/20182.

This PR fixes invalid mime type being set caused by manually parsing the `content-type` header.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix setting `content-type` header with charset breaking `protocol` APIs.