### PR TITLE
ci: skip build on doc only changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -711,7 +711,7 @@ step-check-for-doc-only-change: &step-check-for-doc-only-change
     command: |
       cd src/electron
       node script/yarn install --frozen-lockfile
-      if [ node script/doc-only-change.js --prNumber=$CIRCLE_PR_NUMBER --prURL=$CIRCLE_PULL_REQUEST`" -eq 1 ]; then
+      if [ node script/doc-only-change.js --prNumber=$CIRCLE_PR_NUMBER --prURL=$CIRCLE_PULL_REQUEST -eq 1 ]; then
         echo "true" > .skip-ci-build
       else
         touch .skip-ci-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -704,6 +704,50 @@ step-save-src-cache: &step-save-src-cache
     key: v5-src-cache-{{ arch }}-{{ checksum "src/electron/.depshash" }}
     name: Persisting src cache
 
+# Check for doc only change
+step-check-for-doc-only-change: &step-check-for-doc-only-change
+  run:
+    name: Check if commit is doc only change
+    command: |
+      cd src/electron
+      node script/yarn install --frozen-lockfile
+      export DOC_ONLY_CHANGE="`node script/doc-only-change.js --prNumber=$CIRCLE_PR_NUMBER --prURL=$CIRCLE_PULL_REQUEST`"
+      if [ "$DOC_ONLY_CHANGE" = "true" ]; then
+        echo $DOC_ONLY_CHANGE > .skip-ci-build
+      else
+        touch .skip-ci-build
+      fi
+
+step-persist-doc-only-change: &step-persist-doc-only-change
+  persist_to_workspace:
+    root: .
+    paths:
+      - src/electron/.skip-ci-build
+
+step-maybe-early-exit-doc-only-change: &step-maybe-early-exit-doc-only-change
+  run:
+    name: Shortcircuit build if doc only change
+    command: |
+      if [ -s src/electron/.skip-ci-build ]; then
+        circleci-agent step halt
+      fi
+
+step-maybe-early-exit-no-doc-change: &step-maybe-early-exit-no-doc-change
+  run:
+    name: Shortcircuit job if change is not doc only
+    command: |
+      if [ ! -s src/electron/.skip-ci-build ]; then
+        circleci-agent step halt
+      fi
+
+step-ts-compile: &step-ts-compile
+  run:
+    name: Run TS/JS compile on doc only change
+    command: |
+      cd src
+      ninja -C out/Default electron:default_app_js -j $NUMBER_OF_NINJA_PROCESSES
+      ninja -C out/Default electron:atom_js2c -j $NUMBER_OF_NINJA_PROCESSES
+
 # Lists of steps.
 steps-lint: &steps-lint
   steps:
@@ -752,6 +796,9 @@ steps-lint: &steps-lint
 steps-checkout-fast: &steps-checkout-fast
   steps:
     - *step-checkout-electron
+    - *step-check-for-doc-only-change
+    - *step-persist-doc-only-change
+    - *step-maybe-early-exit-doc-only-change
     - *step-depot-tools-get
     - *step-depot-tools-add-to-path
     - *step-restore-brew-cache
@@ -783,6 +830,9 @@ steps-checkout-fast: &steps-checkout-fast
 steps-checkout-and-save-cache: &steps-checkout-and-save-cache
   steps:
     - *step-checkout-electron
+    - *step-check-for-doc-only-change
+    - *step-persist-doc-only-change
+    - *step-maybe-early-exit-doc-only-change
     - *step-depot-tools-get
     - *step-depot-tools-add-to-path
     - *step-restore-brew-cache
@@ -813,6 +863,7 @@ steps-electron-gn-check: &steps-electron-gn-check
   steps:
     - attach_workspace:
         at: .
+    - *step-maybe-early-exit-doc-only-change
     - *step-depot-tools-add-to-path
     - *step-setup-env-for-build
     - *step-gn-gen-default
@@ -822,6 +873,7 @@ steps-electron-build: &steps-electron-build
   steps:
     - attach_workspace:
         at: .
+    - *step-maybe-early-exit-doc-only-change
     - *step-depot-tools-add-to-path
     - *step-setup-env-for-build
     - *step-restore-brew-cache
@@ -875,6 +927,9 @@ steps-electron-build-with-inline-checkout-for-tests: &steps-electron-build-with-
   steps:
     # Checkout - Copied ffrom steps-checkout
     - *step-checkout-electron
+    - *step-check-for-doc-only-change
+    - *step-persist-doc-only-change
+    - *step-maybe-early-exit-doc-only-change
     - *step-depot-tools-get
     - *step-depot-tools-add-to-path
     - *step-restore-brew-cache
@@ -945,6 +1000,45 @@ steps-electron-build-with-inline-checkout-for-tests: &steps-electron-build-with-
     - *step-maybe-trigger-arm-test
 
     - *step-maybe-notify-slack-failure
+
+steps-electron-ts-compile-for-doc-change: &steps-electron-ts-compile-for-doc-change
+  steps:
+    # Checkout - Copied ffrom steps-checkout
+    - *step-checkout-electron
+    - *step-check-for-doc-only-change
+    - *step-maybe-early-exit-no-doc-change
+    - *step-depot-tools-get
+    - *step-depot-tools-add-to-path
+    - *step-restore-brew-cache
+    - *step-get-more-space-on-mac
+    - *step-install-gnutar-on-mac
+    - *step-generate-deps-hash
+    - *step-touch-sync-done
+    - *step-maybe-restore-src-cache
+    - *step-maybe-restore-git-cache
+    - *step-set-git-cache-path
+    # This sync call only runs if .circle-sync-done is an EMPTY file
+    - *step-gclient-sync
+    # These next few steps reset Electron to the correct commit regardless of which cache was restored
+    - run:
+        name: Wipe Electron
+        command: rm -rf src/electron
+    - *step-checkout-electron
+    - *step-run-electron-only-hooks
+    - *step-generate-deps-hash-cleanly
+    - *step-mark-sync-done
+    - *step-minimize-workspace-size-from-checkout
+
+    - *step-depot-tools-add-to-path
+    - *step-setup-env-for-build
+    - *step-restore-brew-cache
+    - *step-get-more-space-on-mac
+    - *step-install-npm-deps-on-mac
+    - *step-fix-sync-on-mac
+    - *step-gn-gen-default
+
+    #Compile ts/js to verify doc change didn't break anything
+    - *step-ts-compile
 
 steps-electron-build-for-publish: &steps-electron-build-for-publish
   steps:
@@ -1064,6 +1158,7 @@ steps-tests: &steps-tests
   steps:
     - attach_workspace:
         at: .
+    - *step-maybe-early-exit-doc-only-change
     - *step-depot-tools-add-to-path
     - *step-electron-dist-unzip
     - *step-mksnapshot-unzip
@@ -1106,6 +1201,7 @@ steps-test-nan: &steps-test-nan
   steps:
     - attach_workspace:
           at: .
+    - *step-maybe-early-exit-doc-only-change
     - *step-depot-tools-add-to-path
     - *step-electron-dist-unzip
     - *step-setup-linux-for-headless-testing
@@ -1121,6 +1217,7 @@ steps-test-node: &steps-test-node
   steps:
     - attach_workspace:
           at: .
+    - *step-maybe-early-exit-doc-only-change
     - *step-depot-tools-add-to-path
     - *step-electron-dist-unzip
     - *step-setup-linux-for-headless-testing
@@ -1145,6 +1242,13 @@ jobs:
     environment:
       <<: *env-linux-medium
     <<: *steps-lint
+
+  ts-compile-doc-change:
+    <<: *machine-linux-medium
+    environment:
+      <<: *env-linux-medium
+      <<: *env-testing-build
+    <<: *steps-electron-ts-compile-for-doc-change
 
   # Layer 1: Checkout.
   linux-checkout-fast:
@@ -1917,6 +2021,7 @@ workflows:
       - linux-arm64-testing-gn-check:
           requires:
             - linux-checkout-fast
+      - ts-compile-doc-change
 
   build-mac:
     when: << pipeline.parameters.run-build-mac >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -712,11 +712,11 @@ step-check-for-doc-only-change: &step-check-for-doc-only-change
       cd src/electron
       node script/yarn install --frozen-lockfile
       if node script/doc-only-change.js --prNumber=$CIRCLE_PR_NUMBER --prURL=$CIRCLE_PULL_REQUEST; then
-        #PR is not a doc only change; create empty file to indicate check has been done
-        touch .skip-ci-build
-      else
         #PR is doc only change; save file with value true to indicate doc only change
         echo "true" > .skip-ci-build
+      else
+        #PR is not a doc only change; create empty file to indicate check has been done
+        touch .skip-ci-build
       fi
 
 step-persist-doc-only-change: &step-persist-doc-only-change

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -711,10 +711,12 @@ step-check-for-doc-only-change: &step-check-for-doc-only-change
     command: |
       cd src/electron
       node script/yarn install --frozen-lockfile
-      if [ node script/doc-only-change.js --prNumber=$CIRCLE_PR_NUMBER --prURL=$CIRCLE_PULL_REQUEST -eq 1 ]; then
-        echo "true" > .skip-ci-build
-      else
+      if node script/doc-only-change.js --prNumber=$CIRCLE_PR_NUMBER --prURL=$CIRCLE_PULL_REQUEST; then
+        #PR is not a doc only change; create empty file to indicate check has been done
         touch .skip-ci-build
+      else
+        #PR is doc only change; save file with value true to indicate doc only change
+        echo "true" > .skip-ci-build
       fi
 
 step-persist-doc-only-change: &step-persist-doc-only-change

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -711,9 +711,8 @@ step-check-for-doc-only-change: &step-check-for-doc-only-change
     command: |
       cd src/electron
       node script/yarn install --frozen-lockfile
-      export DOC_ONLY_CHANGE="`node script/doc-only-change.js --prNumber=$CIRCLE_PR_NUMBER --prURL=$CIRCLE_PULL_REQUEST`"
-      if [ "$DOC_ONLY_CHANGE" = "true" ]; then
-        echo $DOC_ONLY_CHANGE > .skip-ci-build
+      if [ node script/doc-only-change.js --prNumber=$CIRCLE_PR_NUMBER --prURL=$CIRCLE_PULL_REQUEST`" -eq 1 ]; then
+        echo "true" > .skip-ci-build
       else
         touch .skip-ci-build
       fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,7 @@ build_script:
       } else {
         node script/yarn.js install --frozen-lockfile
 
-        if (node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER --prBranch=$env:APPVEYOR_REPO_BRANCH) {
+        if ($(node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER --prBranch=$env:APPVEYOR_REPO_BRANCH;$LASTEXITCODE)) {
           Write-warning "Skipping build for doc only change"; Exit-AppveyorBuild
         }
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,9 +54,7 @@ build_script:
         npx.cmd yarn@1.15.2 install --frozen-lockfile
 
         if (node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER --prBranch=$env:APPVEYOR_REPO_BRANCH) {
-          Write-warning "Skipping build for doc only change1"; Exit-AppveyorBuild
-        } else {
-          Write-warning "Skipping build for doc only change2"; Exit-AppveyorBuild
+          Write-warning "Skipping build for doc only change"; Exit-AppveyorBuild
         }
       }
   - echo "Building $env:GN_CONFIG build"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,6 +50,14 @@ build_script:
   - ps: >-
       if(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {
         Write-warning "Skipping PR build for branch"; Exit-AppveyorBuild
+      } else {
+        npx.cmd yarn@1.15.2 install --frozen-lockfile
+
+        node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER --prBranch=$env:APPVEYOR_REPO_BRANCH
+        
+        if($DOC_ONLY_CHANGE -eq "true" ) {
+          Write-warning "Skipping build for doc only change"; Exit-AppveyorBuild
+        }
       }
   - echo "Building $env:GN_CONFIG build"
   - git config --global core.longpaths true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,10 +53,10 @@ build_script:
       } else {
         npx.cmd yarn@1.15.2 install --frozen-lockfile
 
-        node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER --prBranch=$env:APPVEYOR_REPO_BRANCH
-        
-        if($DOC_ONLY_CHANGE -eq "true" ) {
-          Write-warning "Skipping build for doc only change"; Exit-AppveyorBuild
+        if (node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER --prBranch=$env:APPVEYOR_REPO_BRANCH) {
+          Write-warning "Skipping build for doc only change1"; Exit-AppveyorBuild
+        } else {
+          Write-warning "Skipping build for doc only change2"; Exit-AppveyorBuild
         }
       }
   - echo "Building $env:GN_CONFIG build"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,7 +51,7 @@ build_script:
       if(($env:APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME -split "/")[0] -eq ($env:APPVEYOR_REPO_NAME -split "/")[0]) {
         Write-warning "Skipping PR build for branch"; Exit-AppveyorBuild
       } else {
-        npx.cmd yarn@1.15.2 install --frozen-lockfile
+        node script/yarn.js install --frozen-lockfile
 
         if (node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER --prBranch=$env:APPVEYOR_REPO_BRANCH) {
           Write-warning "Skipping build for doc only change"; Exit-AppveyorBuild

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,7 @@ build_script:
       } else {
         node script/yarn.js install --frozen-lockfile
 
-        if ($(node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER --prBranch=$env:APPVEYOR_REPO_BRANCH;$LASTEXITCODE)) {
+        if ($(node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER --prBranch=$env:APPVEYOR_REPO_BRANCH;$LASTEXITCODE -eq 0)) {
           Write-warning "Skipping build for doc only change"; Exit-AppveyorBuild
         }
       }

--- a/script/doc-only-change.js
+++ b/script/doc-only-change.js
@@ -21,7 +21,7 @@ async function checkIfDocOnlyChange () {
             pullRequestNumber = prsForBranch.data[0].number
           } else {
             // If there is more than one PR on a branch, just assume that this is more than a doc change
-            console.log('false')
+            process.exit(0)
           }
         } else if (args.prURL) {
           // CircleCI doesn't provide the PR number for branch builds, but it does provide the PR URL
@@ -40,9 +40,9 @@ async function checkIfDocOnlyChange () {
         }
       })
       if (nonDocChange) {
-        console.log('false')
+        process.exit(0)
       } else {
-        console.log('true')
+        process.exit(1)
       }
     } catch (ex) {
       console.error('Error getting list of files changed: ', ex)

--- a/script/doc-only-change.js
+++ b/script/doc-only-change.js
@@ -1,0 +1,58 @@
+const args = require('minimist')(process.argv.slice(2))
+const octokit = require('@octokit/rest')()
+const path = require('path')
+
+const SOURCE_ROOT = path.normalize(path.dirname(__dirname))
+
+async function checkIfDocOnlyChange () {
+  if (args.prNumber || args.prBranch || args.prURL) {
+    try {
+      let pullRequestNumber = args.prNumber
+      if (!pullRequestNumber || isNaN(pullRequestNumber)) {
+        if (args.prBranch) {
+          // AppVeyor doesn't provide a PR number for branch builds - figure it out from the branch
+          const prsForBranch = await octokit.pulls.list({
+            owner: 'electron',
+            repo: 'electron',
+            state: 'open',
+            head: `electron:${args.prBranch}`
+          })
+          if (prsForBranch.data.length === 1) {
+            pullRequestNumber = prsForBranch.data[0].number
+          } else {
+            // If there is more than one PR on a branch, just assume that this is more than a doc change
+            console.log('false')
+          }
+        } else if (args.prURL) {
+          // CircleCI doesn't provide the PR number for branch builds, but it does provide the PR URL
+          const pullRequestParts = args.prURL.split('/')
+          pullRequestNumber = pullRequestParts[pullRequestParts.length - 1]
+        }
+      }
+      const filesChanged = await octokit.pulls.listFiles({
+        owner: 'electron', repo: 'electron', pull_number: pullRequestNumber
+      })
+
+      const nonDocChange = filesChanged.data.find((fileInfo) => {
+        const fileDirs = fileInfo.filename.split('/')
+        if (fileDirs[0] !== 'docs') {
+          return true
+        }
+      })
+      if (nonDocChange) {
+        console.log('false')
+      } else {
+        console.log('true')
+      }
+    } catch (ex) {
+      console.error('Error getting list of files changed: ', ex)
+      process.exit(-1)
+    }
+  } else {
+    console.error(`Check if only the docs were changed for a commit.
+    Usage: doc-only-change.js --prNumber=PR_NUMBER || --prBranch=PR_BRANCH || --prURL=PR_URL`)
+    process.exit(-1)
+  }
+}
+
+checkIfDocOnlyChange()

--- a/script/doc-only-change.js
+++ b/script/doc-only-change.js
@@ -40,9 +40,9 @@ async function checkIfDocOnlyChange () {
         }
       })
       if (nonDocChange) {
-        process.exit(0)
-      } else {
         process.exit(1)
+      } else {
+        process.exit(0)
       }
     } catch (ex) {
       console.error('Error getting list of files changed: ', ex)


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
This PR changes CI to only run lint and not run builds when a commit only contains doc changes.
For CircleCI every job still runs but is short circuited if it is determined that the change is a doc only change.  We may be able to eventually use GitHub actions to be more efficient and not run all jobs, but this gets the job done for now.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
