### PR TITLE
docs: Update Issue Closure in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,9 @@ Issues are created [here](https://github.com/electron/electron/issues/new).
 
 ### Issue Closure
 
-Bug reports will be closed if the issue has been inactive and the latest affected version has been phased out. At the moment, Electron maintains its three latest major versions, with a new major version being released every 12 weeks (for more information, see [this blog post](https://electronjs.org/blog/12-week-cadence)).
+Bug reports will be closed if the issue has been inactive and the latest affected version has been phased out. At the moment, Electron maintains its three latest major versions, with a new major version being released every 12 weeks. (For more information on Electron's release cadence, see [this blog post](https://electronjs.org/blog/12-week-cadence).)
+
+_If an issue has been closed and you still feel it's relevant, feel free to ping a maintainer or add a comment!_
 
 ### Languages
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Issues are created [here](https://github.com/electron/electron/issues/new).
 
 ### Issue Closure
 
-Bug reports will be closed if the issue has been inactive and the latest affected version has been phased out. At the moment, Electron maintains its three latest major versions, with a new major version being released every 12 weeks. (For more information on Electron's release cadence, see [this blog post](https://electronjs.org/blog/12-week-cadence).)
+Bug reports will be closed if the issue has been inactive and the latest affected version no longer receives support. At the moment, Electron maintains its three latest major versions, with a new major version being released every 12 weeks. (For more information on Electron's release cadence, see [this blog post](https://electronjs.org/blog/12-week-cadence).)
 
 _If an issue has been closed and you still feel it's relevant, feel free to ping a maintainer or add a comment!_
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,13 +20,9 @@ Issues are created [here](https://github.com/electron/electron/issues/new).
 * [Triaging a Bug Report](https://electronjs.org/docs/development/issues#triaging-a-bug-report)
 * [Resolving a Bug Report](https://electronjs.org/docs/development/issues#resolving-a-bug-report)
 
-### Issue Maintenance and Closure
-* If an issue is inactive for 45 days (no activity of any kind), it will be
-marked for closure with `stale`.
-* If after this label is applied, no further activity occurs in the next 7 days,
-the issue will be closed.
-  * If an issue has been closed and you still feel it's relevant, feel free to
-  ping a maintainer or add a comment!
+### Issue Closure
+
+Bug reports will be closed if the issue has been inactive and the latest affected version has been phased out. At the moment, Electron maintains its three latest major versions, with a new major version being released every 12 weeks (for more information, see [this blog post](https://electronjs.org/blog/12-week-cadence)).
 
 ### Languages
 


### PR DESCRIPTION
#### Description of Change

Updates the CONTRIBUTING.md to reflect changes to how we close issues.

* Stale is no longer used (#19997)
* Added information about how Releases closes bug reports for `X.Y.Z` after X is phased out (similar to what @sofianguy did when 6.0.x released)

cc @codebytere @malept 
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes