### PR TITLE
fix: append network switches to network service process

### DIFF
--- a/shell/browser/atom_browser_client.cc
+++ b/shell/browser/atom_browser_client.cc
@@ -580,6 +580,16 @@ void AtomBrowserClient::AdjustUtilityServiceProcessCommandLine(
   if (identity.name() == audio::mojom::kServiceName)
     command_line->AppendSwitch(::switches::kMessageLoopTypeUi);
 #endif
+  if (identity.name() == content::mojom::kNetworkServiceName) {
+    // Copy following switches to network service process.
+    static const char* const kCommonSwitchNames[] = {
+        switches::kStandardSchemes,  switches::kSecureSchemes,
+        switches::kBypassCSPSchemes, switches::kCORSSchemes,
+        switches::kFetchSchemes,     switches::kServiceWorkerSchemes};
+    command_line->CopySwitchesFrom(*base::CommandLine::ForCurrentProcess(),
+                                   kCommonSwitchNames,
+                                   base::size(kCommonSwitchNames));
+  }
 }
 
 void AtomBrowserClient::DidCreatePpapiPlugin(content::BrowserPpapiHost* host) {


### PR DESCRIPTION
#### Description of Change

Forward switches related to privileged schemes in network service process, otherwise will lead to service crash <-> restart infinite loop. Gets rid of the error message `VALIDATION_ERROR_DESERIALIZATION_FAILED` we have been seeing since the service was enabled.

Thanks to @nornagon who helped with debugging this issue.

Fixes https://github.com/electron/electron/issues/20517

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix memory leak when using protocol.registerSchemeAsPrivileged api
