### PR TITLE
test: allow "Yu Gothic" as a Japanese sans-serif font on Windows

### DIFF
--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -1012,9 +1012,9 @@ describe('font fallback', () => {
     const fonts = await getRenderedFonts(html)
     expect(fonts).to.be.an('array')
     expect(fonts).to.have.length(1)
-    expect(fonts[0].familyName).to.equal({
-      'win32': 'Meiryo',
-      'darwin': 'Hiragino Kaku Gothic ProN'
+    expect(fonts[0].familyName).to.be.oneOf({
+      'win32': ['Meiryo', 'Yu Gothic'],
+      'darwin': ['Hiragino Kaku Gothic ProN']
     }[process.platform])
   })
 })


### PR DESCRIPTION
#### Description of Change
The "Meiryo" font is not installed on some Windows versions (namely Windows Server 2019), but "Yu Gothic" [1] is. And "Yu Gothic" being a sans-serif Japanese font it is a valid alternative to "Meiryo".

[1] https://www.fonts.com/font/jiyu-kobo/yu-gothic/story

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes
