### PR TITLE
docs: New fiddle example 'Window Crash'

### DIFF
--- a/docs/fiddles/windows/crashes-and-hangs/crash/index.html
+++ b/docs/fiddles/windows/crashes-and-hangs/crash/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html><head><style>
+  body {
+    padding: 20px;
+    font-family: system, -apple-system, '.SFNSText-Regular', 'SF UI Text', 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif;
+    color: #fff;
+    background-color: #8aba87;
+    text-align: center;
+    font-size: 40px;
+  }
+
+  #crash {
+    color: white;
+    opacity: 0.7;
+    position: absolute;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 12px;
+    text-decoration: none;
+  }
+</style>
+
+</head><body><p>Click the text below to crash and then reload this process.</p>
+<a id="crash" href="javascript:process.crash()" >Crash this process</a>
+</body></html>

--- a/docs/fiddles/windows/crashes-and-hangs/crash/index.html
+++ b/docs/fiddles/windows/crashes-and-hangs/crash/index.html
@@ -1,26 +1,8 @@
 <!DOCTYPE html>
-<html><head><style>
-  body {
-    padding: 20px;
-    font-family: system, -apple-system, '.SFNSText-Regular', 'SF UI Text', 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif;
-    color: #fff;
-    background-color: #8aba87;
-    text-align: center;
-    font-size: 40px;
-  }
-
-  #crash {
-    color: white;
-    opacity: 0.7;
-    position: absolute;
-    bottom: 20px;
-    left: 50%;
-    transform: translateX(-50%);
-    font-size: 12px;
-    text-decoration: none;
-  }
-</style>
-
-</head><body><p>Click the text below to crash and then reload this process.</p>
-<a id="crash" href="javascript:process.crash()" >Crash this process</a>
-</body></html>
+<html>
+  <head> </head>
+  <body>
+    <p>Click the text below to crash and then reload this process.</p>
+    <a id="crash" href="javascript:process.crash()">Crash this process</a>
+  </body>
+</html>

--- a/docs/fiddles/windows/crashes-and-hangs/crash/main.js
+++ b/docs/fiddles/windows/crashes-and-hangs/crash/main.js
@@ -1,0 +1,48 @@
+// Modules to control application life and create native browser window
+const {app, BrowserWindow, dialog} = require('electron')
+
+// Keep a global reference of the window object, if you don't, the window will
+// be closed automatically when the JavaScript object is garbage collected.
+let mainWindow
+
+function createWindow () {
+  // Create the browser window.
+  mainWindow = new BrowserWindow({
+    width: 400,
+    height: 320,
+    webPreferences: {
+      nodeIntegration: true
+    }
+  })
+
+  // and load the index.html of the app.
+  mainWindow.loadFile('index.html')
+
+  // Emitted when the window is closed.
+  mainWindow.on('closed', function () {
+    // Dereference the window object, usually you would store windows
+    // in an array if your app supports multi windows, this is the time
+    // when you should delete the corresponding element.
+    mainWindow = null
+  })
+
+  // Event listener for a window crash
+  mainWindow.webContents.on('crashed', () => {
+    const options = {
+      type: 'info',
+      title: 'Renderer Process Crashed',
+      message: 'This process has crashed.',
+      buttons: ['Reload', 'Close']
+    }
+
+    dialog.showMessageBox(options, (index) => {
+      if (index === 0) {
+        app.relaunch()
+        createWindow()
+      }
+      else app.quit()
+    })
+  })
+}
+
+app.on('ready', createWindow)

--- a/docs/fiddles/windows/crashes-and-hangs/crash/main.js
+++ b/docs/fiddles/windows/crashes-and-hangs/crash/main.js
@@ -35,8 +35,9 @@ function createWindow () {
       buttons: ['Reload', 'Close']
     }
 
-    dialog.showMessageBox(options, (index) => {
-      if (index === 0) {
+    dialog.showMessageBox(options)
+    .then((messageBoxReturn) => {
+      if (messageBoxReturn.response === 0) {
         app.relaunch()
         createWindow()
       }


### PR DESCRIPTION
#### Description of Change
Added a fiddle example for window crash handling. Based off of code from [electron-api-demos](https://github.com/electron/electron-api-demos)

For: #20442 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added "Relaunch window after process crashes" fiddle example to docs
