### PR TITLE
docs: added Version Info example from electron-api-demos

### DIFF
--- a/docs/fiddles/system/system-information/version-information/index.html
+++ b/docs/fiddles/system/system-information/version-information/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+  </head>
+  <body>
+    <div>
+      <div>
+        <h1>Get version information</h1>
+        <i>Supports: Win, macOS, Linux <span>|</span> Process: Both</i>
+        <div>
+          <p>The <code>process</code> module is built into Node.js (therefore you can use this in both the main and renderer processes) and in Electron apps this object has a few more useful properties on it.</p>
+          <p>The example below gets the version of Electron in use by the app.</p>
+          <p>See the <a href="http://electron.atom.io/docs/api/process">process documentation<span class="u-visible-to-screen-reader">(opens in new window)</span></a> for more.</p>
+          <div>
+            <button class="demo-button" id="version-info">View Demo</button>
+            <span class="demo-response" id="got-version-info"></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+  <script>
+    require('./renderer.js')
+  </script>
+</html>

--- a/docs/fiddles/system/system-information/version-information/main.js
+++ b/docs/fiddles/system/system-information/version-information/main.js
@@ -1,0 +1,25 @@
+const { app, BrowserWindow } = require('electron')
+
+let mainWindow = null
+
+function createWindow () {
+  const windowOptions = {
+    width: 600,
+    height: 400,
+    title: 'Get version information',
+    webPreferences: {
+      nodeIntegration: true
+    }
+  }
+
+  mainWindow = new BrowserWindow(windowOptions)
+  mainWindow.loadFile('index.html')
+
+  mainWindow.on('closed', () => {
+    mainWindow = null
+  })
+}
+
+app.on('ready', () => {
+  createWindow()
+})

--- a/docs/fiddles/system/system-information/version-information/renderer.js
+++ b/docs/fiddles/system/system-information/version-information/renderer.js
@@ -1,0 +1,8 @@
+const versionInfoBtn = document.getElementById('version-info')
+
+const electronVersion = process.versions.electron
+
+versionInfoBtn.addEventListener('click', () => {
+  const message = `This app is using Electron version: ${electronVersion}`
+  document.getElementById('got-version-info').innerHTML = message
+})


### PR DESCRIPTION
#### Description of Change

This adds the Get Version Information example from [electron-api-demos](https://github.com/electron/electron-api-demos/blob/master/sections/system/app-sys-information.html) to a Fiddle

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR is merging into master branch.
- [x] File structure adheres to the requirements above.
- [x] Code in PR runs successfully in Electron Fiddle with the latest release of Electron 6.
- [x] Code in PR passes a linting check with Standard.
