### PR TITLE
[wip] chore: update Node.js to v12.12.0

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -13,7 +13,7 @@ vars = {
   'chromium_version':
     '6c775c358b709f4353bc693623bf58820adf3918',
   'node_version':
-    'v12.10.0',
+    'v12.12.0',
   'nan_version':
     '2ee313aaca52e2b478965ac50eb5082520380d1b',
 

--- a/patches/node/fixme_remove_async_id_assertion_check.patch
+++ b/patches/node/fixme_remove_async_id_assertion_check.patch
@@ -9,7 +9,7 @@ index 52a8da35b671d196331b858ba46be04aecf1e0be..43ccfafd9f2c85e23a9ea6277e88e486
 --- a/src/api/callback.cc
 +++ b/src/api/callback.cc
 @@ -103,12 +103,14 @@ void InternalCallbackScope::Close() {
-     env_->isolate()->RunMicrotasks();
+     MicrotasksScope::PerformCheckpoint(env_->isolate());
    }
  
 +#if 0  // FIXME(codebytere): figure out why this check fails/causes crash

--- a/patches/node/refactor_allow_embedder_overriding_of_internal_fs_calls.patch
+++ b/patches/node/refactor_allow_embedder_overriding_of_internal_fs_calls.patch
@@ -51,12 +51,12 @@ index ffc7fb6fd5857b807198d4d26b7b899e63cde4a1..2a7ffbff213f23536b94664c3ecffa18
    if (statCache !== null) statCache.set(filename, result);
    return result;
  }
-@@ -205,7 +200,7 @@ const packageExportsCache = new SafeMap();
+@@ -233,7 +233,7 @@ function readPackage(requestPath) {
+   const existing = packageJsonCache.get(jsonPath);
+   if (existing !== undefined) return existing;
  
- function readPackageRaw(requestPath) {
-   const jsonPath = path.resolve(requestPath, 'package.json');
 -  const json = internalModuleReadJSON(path.toNamespacedPath(jsonPath));
 +  const json = internalFsBinding.internalModuleReadJSON(path.toNamespacedPath(jsonPath));
- 
    if (json === undefined) {
+     packageJsonCache.set(jsonPath, false);
      return false;


### PR DESCRIPTION
#### Description of Change

Updates Node.js to `v12.12.0.`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Updated Node.js to v12.12.0.
