### PR TITLE
feat: add app.enableRendererCodeIntegrity()

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1220,6 +1220,12 @@ Enables full sandbox mode on the app.
 
 This method can only be called before app is ready.
 
+### `app.enableRendererCodeIntegrity()` _Windows_
+
+Enables "Renderer Code Integrity" for sandboxed renderers, which prevents third party code from being injected.
+
+This method can only be called before app is ready.
+
 ### `app.isInApplicationsFolder()` _macOS_
 
 Returns `Boolean` - Whether the application is currently running from the

--- a/shell/browser/api/atom_api_app.cc
+++ b/shell/browser/api/atom_api_app.cc
@@ -1335,6 +1335,20 @@ void App::EnableSandbox(gin_helper::ErrorThrower thrower) {
   command_line->AppendSwitch(switches::kEnableSandbox);
 }
 
+#if defined(OS_WIN)
+void App::EnableRendererCodeIntegrity() {
+  if (Browser::Get()->is_ready()) {
+    thrower.ThrowError(
+        "app.enableRendererCodeIntegrity() can only be called "
+        "before app is ready");
+    return;
+  }
+
+  static_cast<AtomBrowserClient*>(AtomBrowserClient::Get())
+      ->EnableRendererCodeIntegrity();
+}
+#endif
+
 void App::SetUserAgentFallback(const std::string& user_agent) {
   AtomBrowserClient::Get()->SetUserAgent(user_agent);
 }
@@ -1536,6 +1550,10 @@ void App::BuildPrototype(v8::Isolate* isolate,
       .SetProperty("userAgentFallback", &App::GetUserAgentFallback,
                    &App::SetUserAgentFallback)
       .SetMethod("enableSandbox", &App::EnableSandbox)
+#if defined(OS_WIN)
+      .SetMethod("enableRendererCodeIntegrity",
+                 &App::EnableRendererCodeIntegrity)
+#endif
       .SetProperty("allowRendererProcessReuse",
                    &App::CanBrowserClientUseCustomSiteInstance,
                    &App::SetBrowserClientCanUseCustomSiteInstance);

--- a/shell/browser/api/atom_api_app.h
+++ b/shell/browser/api/atom_api_app.h
@@ -201,6 +201,9 @@ class App : public AtomBrowserClient::Delegate,
   v8::Local<v8::Promise> GetGPUInfo(v8::Isolate* isolate,
                                     const std::string& info_type);
   void EnableSandbox(gin_helper::ErrorThrower thrower);
+#if defined(OS_WIN)
+  void EnableRendererCodeIntegrity(gin_helper::ErrorThrower thrower);
+#endif
   void SetUserAgentFallback(const std::string& user_agent);
   std::string GetUserAgentFallback();
   void SetBrowserClientCanUseCustomSiteInstance(bool should_disable);

--- a/shell/browser/atom_browser_client.cc
+++ b/shell/browser/atom_browser_client.cc
@@ -1070,6 +1070,14 @@ bool AtomBrowserClient::BindAssociatedReceiverFromFrame(
   return false;
 }
 
+void AtomBrowserClient::EnableRendererCodeIntegrity() {
+  enable_renderer_code_integrity_ = true;
+}
+
+bool AtomBrowserClient::IsRendererCodeIntegrityEnabled() {
+  return enable_renderer_code_integrity_;
+}
+
 std::string AtomBrowserClient::GetApplicationLocale() {
   if (BrowserThread::CurrentlyOn(BrowserThread::IO))
     return g_io_thread_application_locale.Get();

--- a/shell/browser/atom_browser_client.h
+++ b/shell/browser/atom_browser_client.h
@@ -55,6 +55,8 @@ class AtomBrowserClient : public content::ContentBrowserClient,
   void WebNotificationAllowed(int render_process_id,
                               base::OnceCallback<void(bool, bool)> callback);
 
+  void EnableRendererCodeIntegrity();
+
   // content::NavigatorDelegate
   std::vector<std::unique_ptr<content::NavigationThrottle>>
   CreateThrottlesForNavigation(content::NavigationHandle* handle) override;
@@ -190,6 +192,7 @@ class AtomBrowserClient : public content::ContentBrowserClient,
 #if defined(OS_WIN)
   bool PreSpawnRenderer(sandbox::TargetPolicy* policy,
                         RendererSpawnFlags flags) override;
+  bool IsRendererCodeIntegrityEnabled() override;
 #endif
   bool BindAssociatedReceiverFromFrame(
       content::RenderFrameHost* render_frame_host,
@@ -268,6 +271,7 @@ class AtomBrowserClient : public content::ContentBrowserClient,
   std::string user_agent_override_ = "";
 
   bool disable_process_restart_tricks_ = false;
+  bool enable_renderer_code_integrity_ = false;
 
   DISALLOW_COPY_AND_ASSIGN(AtomBrowserClient);
 };


### PR DESCRIPTION
#### Description of Change
This allows to opt-in into this security feature introduced in Chromium 78.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `app.enableRendererCodeIntegrity()`, which allows to opt-in into the security mitigation, which prevents third party code from being injected to sandboxed renderers.