### PR TITLE
docs: Added Native User Interface -> Open path in file manager Fiddle example

### DIFF
--- a/docs/fiddles/native-ui/external-links-file-manager/path-in-file-manager/index.html
+++ b/docs/fiddles/native-ui/external-links-file-manager/path-in-file-manager/index.html
@@ -12,7 +12,7 @@
           <p>This demonstrates using the <code>shell</code> module to open the system file manager at a particular location.</p>
           <p>Clicking the demo button will open your file manager at the root.</p>
           <div>
-            <button class="demo-button" id="open-file-manager">View Demo</button>
+            <button id="open-file-manager">View Demo</button>
           </div>
         </div>
       </div>

--- a/docs/fiddles/native-ui/external-links-file-manager/path-in-file-manager/index.html
+++ b/docs/fiddles/native-ui/external-links-file-manager/path-in-file-manager/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+  </head>
+  <body>
+    <div>
+      <div>
+        <h1>Open Path in File Manager</h1>
+        <i>Supports: Win, macOS, Linux <span>|</span> Process: Both</i>
+        <div>
+          <p>This demonstrates using the <code>shell</code> module to open the system file manager at a particular location.</p>
+          <p>Clicking the demo button will open your file manager at the root.</p>
+          <div>
+            <button class="demo-button" id="open-file-manager">View Demo</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+  <script>
+    require('./renderer.js')
+  </script>
+</html>

--- a/docs/fiddles/native-ui/external-links-file-manager/path-in-file-manager/main.js
+++ b/docs/fiddles/native-ui/external-links-file-manager/path-in-file-manager/main.js
@@ -1,0 +1,25 @@
+const { app, BrowserWindow } = require('electron')
+
+let mainWindow = null
+
+function createWindow () {
+  const windowOptions = {
+    width: 600,
+    height: 400,
+    title: 'Open Path in File Manager',
+    webPreferences: {
+      nodeIntegration: true
+    }
+  }
+
+  mainWindow = new BrowserWindow(windowOptions)
+  mainWindow.loadFile('index.html')
+
+  mainWindow.on('closed', () => {
+    mainWindow = null
+  })
+}
+
+app.on('ready', () => {
+  createWindow()
+})

--- a/docs/fiddles/native-ui/external-links-file-manager/path-in-file-manager/renderer.js
+++ b/docs/fiddles/native-ui/external-links-file-manager/path-in-file-manager/renderer.js
@@ -1,0 +1,8 @@
+const { shell } = require('electron')
+const os = require('os')
+
+const fileManagerBtn = document.getElementById('open-file-manager')
+
+fileManagerBtn.addEventListener('click', (event) => {
+  shell.showItemInFolder(os.homedir())
+})


### PR DESCRIPTION
#### Description of Change

This adds the _Open path in file manager_ example from [electron-api-demos](https://github.com/electron/electron-api-demos/blob/master/sections/native-ui/ex-links-file-manager.html) to a Fiddle

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR is merging into master branch.
- [x] File structure adheres to the requirements above.
- [x] Code in PR runs successfully in Electron Fiddle with the latest release of Electron 6.
- [x] Code in PR passes a linting check with Standard.

#### Release Notes
Notes: no-notes