### PR TITLE
docs: app.dock could be undefined

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1303,7 +1303,7 @@ command line arguments that Chromium uses.
 
 ### `app.dock` _macOS_ _Readonly_
 
-A [`Dock`](./dock.md) object that allows you to perform actions on your app icon in the user's
+A [`Dock`](./dock.md) `| undefined` object that allows you to perform actions on your app icon in the user's
 dock on macOS.
 
 ### `app.isPackaged` _Readonly_


### PR DESCRIPTION
`app.dock` could be undefined

#### Description of Change

docs: app.dock could be `undefined`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [X] `npm test` passes
- [X] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [X] relevant documentation is changed or added
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [X] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes