### PR TITLE
fix: macOS getColor inconsistencies

### DIFF
--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -291,7 +291,7 @@ This API is only available on macOS 10.14 Mojave or newer.
     * `window-frame` - Window frame.
     * `window-text` - Text in windows.
   * On **macOS**
-    * `alternate-selected-control-text` - The text on a selected surface in a list or table.
+    * `alternate-selected-control-text` - The text on a selected surface in a list or table. _deprecated_
     * `control-background` - The background of a large interface element, such as a browser or table.
     * `control` - The surface of a control.
     * `control-text` -The text of a control that isn’t disabled.
@@ -310,7 +310,7 @@ This API is only available on macOS 10.14 Mojave or newer.
     * `selected-content-background` - The background for selected content in a key window or view.
     * `selected-control` - The surface of a selected control.
     * `selected-control-text` - The text of a selected control.
-    * `selected-menu-item` - The text of a selected menu.
+    * `selected-menu-item-text` - The text of a selected menu.
     * `selected-text-background` - The background of selected text.
     * `selected-text` - Selected text.
     * `separator` - A separator between different sections of content.
@@ -327,6 +327,8 @@ This API is only available on macOS 10.14 Mojave or newer.
 
 Returns `String` - The system color setting in RGB hexadecimal form (`#ABCDEF`).
 See the [Windows docs][windows-colors] and the [MacOS docs][macos-colors] for more details.
+
+The following colors are only available on macOS 10.14: `find-highlight`, `selected-content-background`, `separator`, `unemphasized-selected-content-background`, `unemphasized-selected-text-background`, and `unemphasized-selected-text`.
 
 [windows-colors]:https://msdn.microsoft.com/en-us/library/windows/desktop/ms724371(v=vs.85).aspx
 [macos-colors]:https://developer.apple.com/design/human-interface-guidelines/macos/visual-design/color#dynamic-system-colors

--- a/shell/browser/api/atom_api_system_preferences.h
+++ b/shell/browser/api/atom_api_system_preferences.h
@@ -13,6 +13,7 @@
 #include "native_mate/handle.h"
 #include "shell/browser/api/event_emitter_deprecated.h"
 #include "shell/common/gin_helper/error_thrower.h"
+#include "shell/common/node_includes.h"
 #include "shell/common/promise_util.h"
 
 #if defined(OS_WIN)
@@ -52,7 +53,8 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
 
 #if defined(OS_WIN) || defined(OS_MACOSX)
   std::string GetAccentColor();
-  std::string GetColor(const std::string& color, mate::Arguments* args);
+  std::string GetColor(gin_helper::ErrorThrower thrower,
+                       const std::string& color);
 #endif
 #if defined(OS_WIN)
   bool IsAeroGlassEnabled();

--- a/shell/browser/api/atom_api_system_preferences_mac.mm
+++ b/shell/browser/api/atom_api_system_preferences_mac.mm
@@ -509,9 +509,11 @@ std::string SystemPreferences::GetColor(gin_helper::ErrorThrower thrower,
   NSColor* sysColor = nil;
   if (color == "alternate-selected-control-text") {
     sysColor = [NSColor alternateSelectedControlTextColor];
-    EmitDeprecationWarning(node::Environment::GetCurrent(thrower.isolate()),
-                           "Use selected-content-background instead.",
-                           "electron");
+    EmitDeprecationWarning(
+        node::Environment::GetCurrent(thrower.isolate()),
+        "'alternate-selected-control-text' is deprecated as an input to "
+        "getColor.  Use 'selected-content-background' instead.",
+        "electron");
   } else if (color == "control-background") {
     sysColor = [NSColor controlBackgroundColor];
   } else if (color == "control") {
@@ -520,9 +522,6 @@ std::string SystemPreferences::GetColor(gin_helper::ErrorThrower thrower,
     sysColor = [NSColor controlTextColor];
   } else if (color == "disabled-control-text") {
     sysColor = [NSColor disabledControlTextColor];
-    EmitDeprecationWarning(node::Environment::GetCurrent(thrower.isolate()),
-                           "Use a color that matches the semantics being used.",
-                           "electron");
   } else if (color == "find-highlight") {
     if (@available(macOS 10.14, *))
       sysColor = [NSColor findHighlightColor];

--- a/shell/browser/api/atom_api_system_preferences_win.cc
+++ b/shell/browser/api/atom_api_system_preferences_win.cc
@@ -46,8 +46,8 @@ std::string SystemPreferences::GetAccentColor() {
   return hexColorDWORDToRGBA(color);
 }
 
-std::string SystemPreferences::GetColor(const std::string& color,
-                                        mate::Arguments* args) {
+std::string SystemPreferences::GetColor(gin_helper::ErrorThrower thrower,
+                                        const std::string& color) {
   int id;
   if (color == "3d-dark-shadow") {
     id = COLOR_3DDKSHADOW;
@@ -110,7 +110,7 @@ std::string SystemPreferences::GetColor(const std::string& color,
   } else if (color == "window-text") {
     id = COLOR_WINDOWTEXT;
   } else {
-    args->ThrowError("Unknown color: " + color);
+    thrower.ThrowError("Unknown color: " + color);
     return "";
   }
 

--- a/spec-main/api-system-preferences-spec.ts
+++ b/spec-main/api-system-preferences-spec.ts
@@ -134,6 +134,58 @@ describe('systemPreferences module', () => {
     })
   })
 
+  ifdescribe(process.platform === 'darwin')('systemPreferences.getColor(color)', () => {
+    it('throws on invalid colors', () => {
+      const color = 'bad-color'
+      expect(() => {
+        systemPreferences.getColor(color as any)
+      }).to.throw(`Unknown color: ${color}`)
+    })
+  
+    it('returns a valid color', () => {
+      const colors = [
+        'alternate-selected-control-text',
+        'control-background',
+        'control',
+        'control-text',
+        'disabled-control-text',
+        'find-highlight',
+        'grid',
+        'header-text',
+        'highlight',
+        'keyboard-focus-indicator',
+        'label',
+        'link',
+        'placeholder-text',
+        'quaternary-label',
+        'scrubber-textured-background',
+        'secondary-label',
+        'selected-content-background',
+        'selected-control',
+        'selected-control-text',
+        'selected-menu-item-text',
+        'selected-text-background',
+        'selected-text',
+        'separator',
+        'shadow',
+        'tertiary-label',
+        'text-background',
+        'text',
+        'under-page-background',
+        'unemphasized-selected-content-background',
+        'unemphasized-selected-text-background',
+        'unemphasized-selected-text',
+        'window-background',
+        'window-frame-text'
+      ]
+      
+      colors.forEach(color => {
+        const sysColor = systemPreferences.getColor(color as any)
+        expect(sysColor).to.be.a('string')
+      })
+    })
+  })
+
   ifdescribe(process.platform === 'darwin')('systemPreferences.appLevelAppearance', () => {
     it('has an appLevelAppearance property', () => {
       expect(systemPreferences).to.have.property('appLevelAppearance')


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/20599.

Updates documentation to reflect macOS 10.14 specific colors and fixes a mistyped color. Also notes a deprecated color.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixes some `systemPreferences.getColor()` inconsistencies on macOS.