### PR TITLE
test: fix BrowserWindow spec to await its result

### DIFF
--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -348,7 +348,7 @@ describe('BrowserWindow module', () => {
     })
 
     it('should return a promise that resolves', async () => {
-      expect(w.loadURL('about:blank')).to.eventually.be.fulfilled
+      await expect(w.loadURL('about:blank')).to.eventually.be.fulfilled()
     })
 
     it('should return a promise that rejects on a load failure', async () => {


### PR DESCRIPTION
#### Description of Change
the `eventually` api in chai-as-promised returns a promise, which needs to be awaited to get its result.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none