### PR TITLE
build: add support for automated minor releases

### DIFF
--- a/script/release/prepare-release.js
+++ b/script/release/prepare-release.js
@@ -23,7 +23,7 @@ const pass = '✓'.green
 const fail = '✗'.red
 
 if (!bumpType && !args.notesOnly) {
-  console.log(`Usage: prepare-release [stable | beta | nightly]` +
+  console.log(`Usage: prepare-release [stable | minor | beta | nightly]` +
      ` (--stable) (--notesOnly) (--automaticRelease) (--branch)`)
   process.exit(1)
 }

--- a/script/release/version-bumper.js
+++ b/script/release/version-bumper.js
@@ -90,6 +90,9 @@ async function nextVersion (bumpType, version) {
         break
       case 'beta':
         throw new Error('Cannot bump to beta from stable.')
+      case 'minor':
+        version = semver.inc(version, 'minor')
+        break
       case 'stable':
         version = semver.inc(version, 'patch')
         break

--- a/spec-main/version-bump-spec.ts
+++ b/spec-main/version-bump-spec.ts
@@ -100,6 +100,12 @@ describe('version-bumper', () => {
       expect(next).to.equal('2.0.1')
     })
 
+    it('bumps to minor from stable', async () => {
+      const version = 'v2.0.0'
+      const next = await nextVersion('minor', version)
+      expect(next).to.equal('2.1.0')
+    })
+
     it('bumps to stable from nightly', async () => {
       const version = 'v2.0.0-nightly.19950901'
       const next = await nextVersion('stable', version)


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Starting with the 8-x series we are going to switch to having an 8-x-y branch from which we can publish 8-0-x releases as well as (if necessary) 8-x-y releases.  This means that if we want to release a minor version we will no longer have to create a new branch for that minor.  

This PR changes our release scripts to allow for minor bumps.  There will need to be corresponding changes made to sudowoodo and trop to support this change.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
