### PR TITLE
fix: add patch to node for native module size issue on windows

### DIFF
--- a/patches/node/.patches
+++ b/patches/node/.patches
@@ -57,3 +57,4 @@ fix_set_uptime_offset_in_correct_init_method.patch
 fix_enable_worker_threads.patch
 fsevents-stop-using-fsevents-to-watch-files.patch
 fsevents-regression-in-watching.patch
+build_bring_back_node_with_ltcg_configuration.patch

--- a/patches/node/build_bring_back_node_with_ltcg_configuration.patch
+++ b/patches/node/build_bring_back_node_with_ltcg_configuration.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Deepak Mohan <hop2deep@gmail.com>
+Date: Wed, 16 Oct 2019 13:41:12 -0700
+Subject: build: bring back node_with_ltcg configuration
+
+This was moved to code node.gyp as part of https://github.com/nodejs/node/pull/25931
+which caused native modules size increase which were depending on
+this configuration transitively https://github.com/nodejs/node/issues/29501.
+THe fix for this should land in node-gyp as discussed in above issue,
+landing this as temporary patch.
+
+diff --git a/common.gypi b/common.gypi
+index f07e65f719a1a5939997dfcae7bc787ee6391f4d..69b5439a5c19230e5568450c3aca9ce27661d77c 100644
+--- a/common.gypi
++++ b/common.gypi
+@@ -180,6 +180,26 @@
+             'cflags': [ '-fPIE' ],
+             'ldflags': [ '-fPIE', '-pie' ]
+           }],
++          ['node_with_ltcg=="true"', {
++            'msvs_settings': {
++              'VCCLCompilerTool': {
++                'WholeProgramOptimization': 'true' # /GL, whole program optimization, needed for LTCG
++              },
++              'VCLibrarianTool': {
++                'AdditionalOptions': [
++                  '/LTCG:INCREMENTAL', # incremental link-time code generation
++                ]
++              },
++              'VCLinkerTool': {
++                'OptimizeReferences': 2, # /OPT:REF
++                'EnableCOMDATFolding': 2, # /OPT:ICF
++                'LinkIncremental': 1, # disable incremental linking
++                'AdditionalOptions': [
++                  '/LTCG:INCREMENTAL', # incremental link-time code generation
++                ]
++              }
++            }
++          }]
+         ],
+         'msvs_settings': {
+           'VCCLCompilerTool': {


### PR DESCRIPTION
#### Description of Change

Backports #20614

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix native modules size increase with VC++ and node 12 on windows
