### PR TITLE
fix: backport libuv patch for fs.mkdir/mkdirSync on invalid names

### DIFF
--- a/patches/node/.patches
+++ b/patches/node/.patches
@@ -41,3 +41,4 @@ fix_enable_worker_threads.patch
 fsevents-stop-using-fsevents-to-watch-files.patch
 fsevents-regression-in-watching.patch
 build_bring_back_node_with_ltcg_configuration.patch
+fix_uv_fs_mkdir_for_invalid_names.patch

--- a/patches/node/fix_uv_fs_mkdir_for_invalid_names.patch
+++ b/patches/node/fix_uv_fs_mkdir_for_invalid_names.patch
@@ -1,0 +1,76 @@
+From ecff27857dafe3f5d30a6ab8646ea69a93e4940a Mon Sep 17 00:00:00 2001
+From: Bartosz Sosnowski <bartosz@janeasystems.com>
+Date: Thu, 11 Jul 2019 12:45:38 +0200
+Subject: [PATCH] win, fs: mkdir return UV_EINVAL for invalid names
+
+Makes uv_fs_mkdir return UV_EINVAL for invalid filenames instead of
+UV_ENOENT.
+
+Ref: https://github.com/nodejs/node/issues/28599
+
+PR-URL: https://github.com/libuv/libuv/pull/2375
+Reviewed-By: Anna Henningsen <anna@addaleax.net>
+Reviewed-By: Saúl Ibarra Corretgé <saghul@gmail.com>
+Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
+
+diff --git a/deps/uv/src/win/fs.c b/deps/uv/src/win/fs.c
+index 15094121..31242b51 100644
+--- a/deps/uv/src/win/fs.c
++++ b/deps/uv/src/win/fs.c
+@@ -1180,8 +1180,13 @@ void fs__unlink(uv_fs_t* req) {
+ 
+ void fs__mkdir(uv_fs_t* req) {
+   /* TODO: use req->mode. */
+-  int result = _wmkdir(req->file.pathw);
+-  SET_REQ_RESULT(req, result);
++  req->result = _wmkdir(req->file.pathw);
++  if (req->result == -1) {
++    req->sys_errno_ = _doserrno;
++    req->result = req->sys_errno_ == ERROR_INVALID_NAME
++                ? UV_EINVAL
++                : uv_translate_sys_error(req->sys_errno_);
++  }
+ }
+ 
+ 
+diff --git a/deps/uv/test/test-fs.c b/deps/uv/test/test-fs.c
+index 35a992d8..95f6b5e9 100644
+--- a/deps/uv/test/test-fs.c
++++ b/deps/uv/test/test-fs.c
+@@ -4060,4 +4060,16 @@ TEST_IMPL(fs_fchmod_archive_readonly) {
+ 
+     return 0;
+ }
++
++TEST_IMPL(fs_invalid_mkdir_name) {
++  uv_loop_t* loop;
++  uv_fs_t req;
++  int r;
++
++  loop = uv_default_loop();
++  r = uv_fs_mkdir(loop, &req, "invalid>", 0, NULL);
++  ASSERT(r == UV_EINVAL);
++
++  return 0;
++}
+ #endif
+diff --git a/deps/uv/test/test-list.h b/deps/uv/test/test-list.h
+index 3c5f21b9..ffa7e545 100644
+--- a/deps/uv/test/test-list.h
++++ b/deps/uv/test/test-list.h
+@@ -380,6 +380,7 @@ TEST_DECLARE   (fs_exclusive_sharing_mode)
+ TEST_DECLARE   (fs_file_flag_no_buffering)
+ TEST_DECLARE   (fs_open_readonly_acl)
+ TEST_DECLARE   (fs_fchmod_archive_readonly)
++TEST_DECLARE   (fs_invalid_mkdir_name)
+ #endif
+ TEST_DECLARE   (strscpy)
+ TEST_DECLARE   (threadpool_queue_work_simple)
+@@ -973,6 +974,7 @@ TASK_LIST_START
+   TEST_ENTRY  (fs_file_flag_no_buffering)
+   TEST_ENTRY  (fs_open_readonly_acl)
+   TEST_ENTRY  (fs_fchmod_archive_readonly)
++  TEST_ENTRY  (fs_invalid_mkdir_name)
+ #endif
+   TEST_ENTRY  (get_osfhandle_valid_handle)
+   TEST_ENTRY  (open_osfhandle_valid_handle)

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -623,6 +623,19 @@ describe('node feature', () => {
     })
   })
 
+  describe('fs.mkdir/mkdirSync', () => {
+    it('does not hang with {recursive: true} on invalid names', function (done) {
+      if (process.platform !== 'win32') {
+        return this.skip()
+      }
+      expect(() => fs.mkdirSync('invalid2:', { recursive: true })).to.throw()
+      fs.mkdir('invalid1:', { recursive: true }, (err) => {
+        expect(err).to.not.be.null()
+        done()
+      })
+    })
+  })
+
   it('includes the electron version in process.versions', () => {
     expect(process.versions)
       .to.have.own.property('electron')


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/20588

Backports https://github.com/libuv/libuv/pull/2375

**This should be fixed in master with https://github.com/electron/electron/pull/20584 , hence only targeting release branches.**

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix fs.mkdir/mkdirSync hang with {recursive: true} for invalid names with node 12 on windows