### PR TITLE
fix: send ELECTRON_BROWSER_CONTEXT_RELEASE asynchronously

### DIFF
--- a/lib/browser/remote/objects-registry.ts
+++ b/lib/browser/remote/objects-registry.ts
@@ -127,6 +127,10 @@ class ObjectsRegistry {
         this.clear(webContents, contextId)
       }
     }
+    // Note that the "render-view-deleted" event may not be emitted on time when
+    // the renderer process get destroyed because of navigation, we rely on the
+    // renderer process to send "ELECTRON_BROWSER_CONTEXT_RELEASE" message to
+    // guard this situation.
     webContents.on('render-view-deleted' as any, listener)
   }
 }

--- a/lib/browser/remote/server.ts
+++ b/lib/browser/remote/server.ts
@@ -529,7 +529,6 @@ handleRemoteCommand('ELECTRON_BROWSER_DEREFERENCE', function (event, contextId, 
 
 handleRemoteCommand('ELECTRON_BROWSER_CONTEXT_RELEASE', (event, contextId) => {
   objectsRegistry.clear(event.sender, contextId)
-  return null
 })
 
 handleRemoteCommand('ELECTRON_BROWSER_GUEST_WEB_CONTENTS', function (event, contextId, guestInstanceId, stack) {

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -19,7 +19,7 @@ const contextId = v8Util.getHiddenValue(global, 'contextId')
 // to guard that situation.
 process.on('exit', () => {
   const command = 'ELECTRON_BROWSER_CONTEXT_RELEASE'
-  ipcRendererInternal.sendSync(command, contextId)
+  ipcRendererInternal.send(command, contextId)
 })
 
 // Convert the arguments object into an array of meta data.

--- a/spec-main/fixtures/api/send-on-exit.html
+++ b/spec-main/fixtures/api/send-on-exit.html
@@ -1,0 +1,11 @@
+<html>
+<body>
+<script type="text/javascript" charset="utf-8">
+  const {ipcRenderer} = require('electron')
+
+  process.on('exit', () => {
+    ipcRenderer.send('SENT_ON_EXIT')
+  })
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### Description of Change
Fixes parts of #20086 by sending `ELECTRON_BROWSER_CONTEXT_RELEASE` asynchronously.
The synchronous send was added in #9389, which was necessary back then as we didn't have a unique identifier for each JS context.

Fixing `ipcRenderer.sendSync()` to not hang when the mojo connection is lost is also important, but more complicated.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed hang when closing a scriptable popup window using the `remote` module.