### PR TITLE
chore: remove some trop permissions

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -29,13 +29,11 @@ firstPRMergeComment: >
 # Users authorized to run manual trop backports
 authorizedUsers:
   - alexeykuzmin
-  - BinaryMuse
   - ckerr
   - codebytere
   - deepak1556
   - jkleinsc
   - MarshallOfSound
   - miniak
-  - nitsakh
   - nornagon
   - zcbenz


### PR DESCRIPTION
#### Description of Change

Remove trop permissions for @nitsakh and @BinaryMuse, as they have moved away from full-time Electron work :)

cc @electron/wg-releases as trop owners.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
