### PR TITLE
fix: don't overwrite global constructor names in remote

### DIFF
--- a/lib/browser/remote/server.ts
+++ b/lib/browser/remote/server.ts
@@ -263,7 +263,6 @@ const unwrapArgs = function (sender: electron.WebContents, frameId: number, cont
         })
       case 'object': {
         const ret: any = {}
-        Object.defineProperty(ret.constructor, 'name', { value: meta.name })
 
         for (const { name, value } of meta.members) {
           ret[name] = metaToValue(value)

--- a/lib/browser/remote/server.ts
+++ b/lib/browser/remote/server.ts
@@ -245,6 +245,17 @@ type MetaTypeFromRenderer = {
   length: number
 }
 
+const fakeConstructor = (constructor: Function, name: string) =>
+  new Proxy(Object, {
+    get (target, prop, receiver) {
+      if (prop === 'name') {
+        return name
+      } else {
+        return Reflect.get(target, prop, receiver)
+      }
+    }
+  })
+
 // Convert array of meta data from renderer into array of real values.
 const unwrapArgs = function (sender: electron.WebContents, frameId: number, contextId: string, args: any[]) {
   const metaToValue = function (meta: MetaTypeFromRenderer): any {
@@ -262,7 +273,9 @@ const unwrapArgs = function (sender: electron.WebContents, frameId: number, cont
           then: metaToValue(meta.then)
         })
       case 'object': {
-        const ret: any = {}
+        const ret: any = meta.name !== 'Object' ? Object.create({
+          constructor: fakeConstructor(Object, meta.name)
+        }) : {}
 
         for (const { name, value } of meta.members) {
           ret[name] = metaToValue(value)

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -64,6 +64,11 @@ function wrapArgs (args, visited = new Set()) {
           type: 'remote-object',
           id: v8Util.getHiddenValue(value, 'atomId')
         }
+      } else if (value instanceof Error) {
+        return {
+          type: 'value',
+          value
+        }
       }
 
       const meta = {

--- a/spec/api-remote-spec.js
+++ b/spec/api-remote-spec.js
@@ -498,17 +498,16 @@ ifdescribe(features.isRemoteModuleEnabled())('remote module', () => {
     it('throws errors from the main process', () => {
       expect(() => {
         throwFunction()
-      }).to.throw()
+      }).to.throw(/undefined/)
     })
 
-    it('throws custom errors from the main process', () => {
-      const err = new Error('error')
-      err.cause = new Error('cause')
-      err.prop = 'error prop'
+    it('tracks error cause', () => {
       try {
-        throwFunction(err)
-      } catch (error) {
-        expect(error.cause).to.deep.equal(...resolveGetters(err))
+        throwFunction(new Error('error from main'))
+        expect.fail()
+      } catch (e) {
+        expect(e.message).to.match(/Could not call remote function/)
+        expect(e.cause.message).to.equal('error from main')
       }
     })
   })


### PR DESCRIPTION
#### Description of Change
This was causing an issue where the name of the `Object` constructor could be overwritten to `Error`, causing bizarre behavior like `console.log({})` printing `Error {}`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue in the remote module which could cause the name of the Object constructor to be overwritten globally.