### PR TITLE
feat: allow multi language spellcheckprovider

### DIFF
--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -65,6 +65,15 @@ Sets the maximum and minimum layout-based (i.e. non-visual) zoom level.
 
 ### `webFrame.setSpellCheckProvider(language, provider)`
 
+* `language` String[]
+* `provider` Object
+  * `spellCheck` Function
+    * `words` Record<String, String[]>
+    * `callback` Function
+      * `misspeltWords` String[]
+
+### `webFrame.setSpellCheckProvider(language, provider)`
+
 * `language` String
 * `provider` Object
   * `spellCheck` Function
@@ -75,7 +84,8 @@ Sets the maximum and minimum layout-based (i.e. non-visual) zoom level.
 Sets a provider for spell checking in input fields and text areas.
 
 The `provider` must be an object that has a `spellCheck` method that accepts
-an array of individual words for spellchecking.
+an array of individual words for spellchecking for single language,
+or an object for multiple languages.
 The `spellCheck` function runs asynchronously and calls the `callback` function
 with an array of misspelt words when complete.
 
@@ -84,12 +94,26 @@ An example of using [node-spellchecker][spellchecker] as provider:
 ```javascript
 const { webFrame } = require('electron')
 const spellChecker = require('spellchecker')
+
+// check spelling for single language
 webFrame.setSpellCheckProvider('en-US', {
   spellCheck (words, callback) {
     setTimeout(() => {
       const spellchecker = require('spellchecker')
       const misspelled = words.filter(x => spellchecker.isMisspelled(x))
       callback(misspelled)
+    }, 0)
+  }
+})
+
+// check spelling for multiple languages
+webFrame.setSpellCheckProvider(['en-US', 'ko-KR'], {
+  spellCheck (words, callback) {
+    setTimeout(() => {
+      const spellchecker = require('spellchecker')
+      const en = words['en-US'].filter(x => spellchecker.isMisspelled(x))
+      const kr = words['ko-KR'].filter(x => spellchecker.isMisspelled(x))
+      callback(en.concat(kr))
     }, 0)
   }
 })

--- a/filenames.gni
+++ b/filenames.gni
@@ -557,6 +557,8 @@ filenames = {
     "shell/renderer/api/atom_api_renderer_ipc.cc",
     "shell/renderer/api/atom_api_spell_check_client.cc",
     "shell/renderer/api/atom_api_spell_check_client.h",
+    "shell/renderer/api/atom_spell_check_language.cc",
+    "shell/renderer/api/atom_spell_check_language.h",
     "shell/renderer/api/atom_api_web_frame.cc",
     "shell/renderer/atom_autofill_agent.cc",
     "shell/renderer/atom_autofill_agent.h",

--- a/shell/renderer/api/atom_api_spell_check_client.cc
+++ b/shell/renderer/api/atom_api_spell_check_client.cc
@@ -19,10 +19,26 @@
 #include "native_mate/converter.h"
 #include "native_mate/dictionary.h"
 #include "native_mate/function_template.h"
+#include "shell/common/native_mate_converters/map_converter.h"
 #include "shell/common/native_mate_converters/string16_converter.h"
 #include "third_party/blink/public/web/web_text_checking_completion.h"
 #include "third_party/blink/public/web/web_text_checking_result.h"
 #include "third_party/icu/source/common/unicode/uscript.h"
+
+namespace gin {
+
+template <>
+struct Converter<electron::SpellcheckLanguage::Word> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   electron::SpellcheckLanguage::Word value) {
+    return v8::String::NewFromTwoByte(
+               isolate, reinterpret_cast<const uint16_t*>(value.text.data()),
+               v8::NewStringType::kNormal, value.text.size())
+        .ToLocalChecked();
+  }
+};
+
+}  // namespace gin
 
 namespace electron {
 
@@ -43,13 +59,9 @@ bool HasWordCharacters(const base::string16& text, int index) {
   return false;
 }
 
-struct Word {
-  blink::WebTextCheckingResult result;
-  base::string16 text;
-  std::vector<base::string16> contraction_words;
-};
-
 }  // namespace
+
+using Word = electron::SpellcheckLanguage::Word;
 
 class SpellCheckClient::SpellcheckRequest {
  public:
@@ -61,18 +73,21 @@ class SpellCheckClient::SpellcheckRequest {
 
   const base::string16& text() const { return text_; }
   blink::WebTextCheckingCompletion* completion() { return completion_.get(); }
-  std::vector<Word>& wordlist() { return word_list_; }
+  std::vector<blink::WebTextCheckingResult>* misspelled_words() {
+    return &results_;
+  }
 
  private:
-  base::string16 text_;          // Text to be checked in this task.
-  std::vector<Word> word_list_;  // List of Words found in text
+  base::string16 text_;  // Text to be checked in this task.
+  // std::unordered_set<Word> word_list_;  // List of Words found in text
   // The interface to send the misspelled ranges to WebKit.
   std::unique_ptr<blink::WebTextCheckingCompletion> completion_;
+  std::vector<blink::WebTextCheckingResult> results_;
 
   DISALLOW_COPY_AND_ASSIGN(SpellcheckRequest);
 };
 
-SpellCheckClient::SpellCheckClient(const std::string& language,
+SpellCheckClient::SpellCheckClient(const std::vector<std::string>& languages,
                                    v8::Isolate* isolate,
                                    v8::Local<v8::Object> provider)
     : pending_request_param_(nullptr),
@@ -80,8 +95,9 @@ SpellCheckClient::SpellCheckClient(const std::string& language,
       context_(isolate, isolate->GetCurrentContext()),
       provider_(isolate, provider) {
   DCHECK(!context_.IsEmpty());
-
-  character_attributes_.SetDefaultLanguage(language);
+  for (const auto& language : languages) {
+    AddSpellcheckLanguage(language);
+  }
 
   // Persistent the method.
   mate::Dictionary dict(isolate, provider);
@@ -128,6 +144,11 @@ bool SpellCheckClient::IsShowingSpellingUI() {
 void SpellCheckClient::UpdateSpellingUIWithMisspelledWord(
     const blink::WebString& word) {}
 
+void SpellCheckClient::AddSpellcheckLanguage(const std::string& language) {
+  languages_.push_back(std::make_unique<SpellcheckLanguage>());
+  languages_.back()->Init(language);
+}
+
 void SpellCheckClient::SpellCheckText() {
   const auto& text = pending_request_param_->text();
   if (text.empty() || spell_check_.IsEmpty()) {
@@ -135,131 +156,65 @@ void SpellCheckClient::SpellCheckText() {
     pending_request_param_ = nullptr;
     return;
   }
-
-  if (!text_iterator_.IsInitialized() &&
-      !text_iterator_.Initialize(&character_attributes_, true)) {
-    // We failed to initialize text_iterator_, return as spelled correctly.
-    VLOG(1) << "Failed to initialize SpellcheckWordIterator";
-    return;
-  }
-
-  if (!contraction_iterator_.IsInitialized() &&
-      !contraction_iterator_.Initialize(&character_attributes_, false)) {
-    // We failed to initialize the word iterator, return as spelled correctly.
-    VLOG(1) << "Failed to initialize contraction_iterator_";
-    return;
-  }
-
-  text_iterator_.SetText(text.c_str(), text.size());
-
   SpellCheckScope scope(*this);
-  base::string16 word;
-  size_t word_start;
-  size_t word_length;
-  std::set<base::string16> words;
-  auto& word_list = pending_request_param_->wordlist();
-  Word word_entry;
-  for (;;) {  // Run until end of text
-    const auto status =
-        text_iterator_.GetNextWord(&word, &word_start, &word_length);
-    if (status == SpellcheckWordIterator::IS_END_OF_TEXT)
-      break;
-    if (status == SpellcheckWordIterator::IS_SKIPPABLE)
-      continue;
-
-    word_entry.result.location = base::checked_cast<int>(word_start);
-    word_entry.result.length = base::checked_cast<int>(word_length);
-    word_entry.text = word;
-    word_entry.contraction_words.clear();
-
-    word_list.push_back(word_entry);
-    words.insert(word);
-    // If the given word is a concatenated word of two or more valid words
-    // (e.g. "hello:hello"), we should treat it as a valid word.
-    if (IsContraction(scope, word, &word_entry.contraction_words)) {
-      for (const auto& w : word_entry.contraction_words) {
-        words.insert(w);
-      }
-    }
+  std::map<std::string, std::vector<Word>> lang_words;
+  for (const auto& language : languages_) {
+    auto words = language->SpellCheckText(text);
+    lang_words[language->GetLanguageString()] = words;
   }
-
   // Send out all the words data to the spellchecker to check
-  SpellCheckWords(scope, words);
+  SpellCheckWords(scope, lang_words);
 }
 
 void SpellCheckClient::OnSpellCheckDone(
+    const std::map<std::string, std::vector<Word>>& lang_words,
     const std::vector<base::string16>& misspelled_words) {
   std::vector<blink::WebTextCheckingResult> results;
   std::unordered_set<base::string16> misspelled(misspelled_words.begin(),
                                                 misspelled_words.end());
+  for (const auto& entry : lang_words) {
+    const auto& word_list = entry.second;
 
-  auto& word_list = pending_request_param_->wordlist();
-
-  for (const auto& word : word_list) {
-    if (misspelled.find(word.text) != misspelled.end()) {
-      // If this is a contraction, iterate through parts and accept the word
-      // if none of them are misspelled
-      if (!word.contraction_words.empty()) {
-        auto all_correct = true;
-        for (const auto& contraction_word : word.contraction_words) {
-          if (misspelled.find(contraction_word) != misspelled.end()) {
-            all_correct = false;
-            break;
+    for (auto word = word_list.begin(); word != word_list.end(); ++word) {
+      if (misspelled.find(word->text) != misspelled.end()) {
+        // If this is a contraction, iterate through parts and accept the word
+        // if none of them are misspelled
+        if (!word->contraction_words.empty()) {
+          auto all_correct = true;
+          for (const auto& contraction_word : word->contraction_words) {
+            if (misspelled.find(contraction_word) != misspelled.end()) {
+              all_correct = false;
+              break;
+            }
           }
+          if (all_correct)
+            continue;
         }
-        if (all_correct)
-          continue;
+        results.push_back(word->result);
       }
-      results.push_back(word.result);
     }
   }
+
   pending_request_param_->completion()->DidFinishCheckingText(results);
   pending_request_param_ = nullptr;
 }
 
-void SpellCheckClient::SpellCheckWords(const SpellCheckScope& scope,
-                                       const std::set<base::string16>& words) {
+void SpellCheckClient::SpellCheckWords(
+    const SpellCheckScope& scope,
+    const std::map<std::string, std::vector<Word>>& lang_words) {
   DCHECK(!scope.spell_check_.IsEmpty());
 
   v8::Local<v8::FunctionTemplate> templ = mate::CreateFunctionTemplate(
       isolate_,
-      base::BindRepeating(&SpellCheckClient::OnSpellCheckDone, AsWeakPtr()));
+      base::Bind(&SpellCheckClient::OnSpellCheckDone, AsWeakPtr(), lang_words));
 
   auto context = isolate_->GetCurrentContext();
-  v8::Local<v8::Value> args[] = {mate::ConvertToV8(isolate_, words),
-                                 templ->GetFunction(context).ToLocalChecked()};
+  v8::Local<v8::Value> args[] = {
+      gin::Converter<std::map<std::string, std::vector<Word>>>::ToV8(
+          isolate_, lang_words),
+      templ->GetFunction(context).ToLocalChecked()};
   // Call javascript with the words and the callback function
   scope.spell_check_->Call(context, scope.provider_, 2, args).IsEmpty();
-}
-
-// Returns whether or not the given string is a contraction.
-// This function is a fall-back when the SpellcheckWordIterator class
-// returns a concatenated word which is not in the selected dictionary
-// (e.g. "in'n'out") but each word is valid.
-// Output variable contraction_words will contain individual
-// words in the contraction.
-bool SpellCheckClient::IsContraction(
-    const SpellCheckScope& scope,
-    const base::string16& contraction,
-    std::vector<base::string16>* contraction_words) {
-  DCHECK(contraction_iterator_.IsInitialized());
-
-  contraction_iterator_.SetText(contraction.c_str(), contraction.length());
-
-  base::string16 word;
-  size_t word_start;
-  size_t word_length;
-  for (auto status =
-           contraction_iterator_.GetNextWord(&word, &word_start, &word_length);
-       status != SpellcheckWordIterator::IS_END_OF_TEXT;
-       status = contraction_iterator_.GetNextWord(&word, &word_start,
-                                                  &word_length)) {
-    if (status == SpellcheckWordIterator::IS_SKIPPABLE)
-      continue;
-
-    contraction_words->push_back(word);
-  }
-  return contraction_words->size() > 1;
 }
 
 SpellCheckClient::SpellCheckScope::SpellCheckScope(

--- a/shell/renderer/api/atom_api_spell_check_client.h
+++ b/shell/renderer/api/atom_api_spell_check_client.h
@@ -5,6 +5,7 @@
 #ifndef SHELL_RENDERER_API_ATOM_API_SPELL_CHECK_CLIENT_H_
 #define SHELL_RENDERER_API_ATOM_API_SPELL_CHECK_CLIENT_H_
 
+#include <map>
 #include <memory>
 #include <set>
 #include <string>
@@ -21,11 +22,6 @@
 #include "third_party/blink/public/web/web_text_checking_completion.h"
 #include "third_party/blink/public/web/web_text_checking_result.h"
 
-namespace blink {
-// struct WebTextCheckingResult;
-// class WebTextCheckingCompletion;
-}  // namespace blink
-
 namespace electron {
 
 namespace api {
@@ -36,7 +32,8 @@ class SpellCheckClient : public blink::WebSpellCheckPanelHostClient,
  public:
   SpellCheckClient(const std::vector<std::string>& languages,
                    v8::Isolate* isolate,
-                   v8::Local<v8::Object> provider);
+                   v8::Local<v8::Object> provider,
+                   bool is_single_language);
   ~SpellCheckClient() override;
 
  private:
@@ -62,8 +59,6 @@ class SpellCheckClient : public blink::WebSpellCheckPanelHostClient,
     explicit SpellCheckScope(const SpellCheckClient& client);
     ~SpellCheckScope();
   };
-
-  void AddSpellcheckLanguage(const std::string& language);
 
   // Run through the word iterator and send out requests
   // to the JS API for checking spellings of words in the current
@@ -97,6 +92,7 @@ class SpellCheckClient : public blink::WebSpellCheckPanelHostClient,
   v8::Persistent<v8::Context> context_;
   mate::ScopedPersistent<v8::Object> provider_;
   mate::ScopedPersistent<v8::Function> spell_check_;
+  bool is_multi_lang_spell_check_;
 
   DISALLOW_COPY_AND_ASSIGN(SpellCheckClient);
 };

--- a/shell/renderer/api/atom_api_web_frame.cc
+++ b/shell/renderer/api/atom_api_web_frame.cc
@@ -305,7 +305,7 @@ int GetWebFrameId(v8::Local<v8::Value> window,
 
 void SetSpellCheckProvider(mate::Arguments* args,
                            v8::Local<v8::Value> window,
-                           const std::string& language,
+                           const std::vector<std::string>& languages,
                            v8::Local<v8::Object> provider) {
   auto context = args->isolate()->GetCurrentContext();
   if (!provider->Has(context, mate::StringToV8(args->isolate(), "spellCheck"))
@@ -323,7 +323,7 @@ void SetSpellCheckProvider(mate::Arguments* args,
   // Set spellchecker for all live frames in the same process or
   // in the sandbox mode for all live sub frames to this WebFrame.
   auto spell_check_client =
-      std::make_unique<SpellCheckClient>(language, args->isolate(), provider);
+      std::make_unique<SpellCheckClient>(languages, args->isolate(), provider);
   FrameSetSpellChecker spell_checker(spell_check_client.get(), render_frame);
 
   // Attach the spell checker to RenderFrame.

--- a/shell/renderer/api/atom_spell_check_language.cc
+++ b/shell/renderer/api/atom_spell_check_language.cc
@@ -1,0 +1,119 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/renderer/api/atom_spell_check_language.h"
+
+#include <utility>
+
+#include "base/logging.h"
+#include "components/spellcheck/renderer/spellcheck_worditerator.h"
+#include "components/spellcheck/renderer/spelling_engine.h"
+
+namespace electron {
+
+SpellcheckLanguage::Word::Word() = default;
+
+SpellcheckLanguage::Word::Word(const Word& word) = default;
+
+SpellcheckLanguage::Word::~Word() = default;
+
+SpellcheckLanguage::SpellcheckLanguage() {}
+
+SpellcheckLanguage::~SpellcheckLanguage() {}
+
+void SpellcheckLanguage::Init(const std::string& language) {
+  character_attributes_.SetDefaultLanguage(language);
+  text_iterator_.Reset();
+  contraction_iterator_.Reset();
+  language_ = language;
+}
+
+bool SpellcheckLanguage::InitializeIfNeeded() {
+  return true;
+}
+
+std::vector<SpellcheckLanguage::Word> SpellcheckLanguage::SpellCheckText(
+    const base::string16& text) {
+  if (!text_iterator_.IsInitialized() &&
+      !text_iterator_.Initialize(&character_attributes_, true)) {
+    // We failed to initialize text_iterator_, return as spelled correctly.
+    VLOG(1) << "Failed to initialize SpellcheckWordIterator";
+    return std::vector<Word>();
+  }
+
+  if (!contraction_iterator_.IsInitialized() &&
+      !contraction_iterator_.Initialize(&character_attributes_, false)) {
+    // We failed to initialize the word iterator, return as spelled correctly.
+    VLOG(1) << "Failed to initialize contraction_iterator_";
+    return std::vector<Word>();
+  }
+
+  text_iterator_.SetText(text.c_str(), text.size());
+
+  base::string16 word;
+  size_t word_start;
+  size_t word_length;
+  std::vector<Word> words;
+  Word word_entry;
+  for (;;) {  // Run until end of text
+    const auto status =
+        text_iterator_.GetNextWord(&word, &word_start, &word_length);
+    if (status == SpellcheckWordIterator::IS_END_OF_TEXT)
+      break;
+    if (status == SpellcheckWordIterator::IS_SKIPPABLE)
+      continue;
+
+    word_entry.result.location = base::checked_cast<int>(word_start);
+    word_entry.result.length = base::checked_cast<int>(word_length);
+    word_entry.text = word;
+    word_entry.contraction_words.clear();
+    words.push_back(word_entry);
+    // If the given word is a concatenated word of two or more valid words
+    // (e.g. "hello:hello"), we should treat it as a valid word.
+    if (IsContraction(word_entry.text, &word_entry.contraction_words)) {
+      for (const auto& w : word_entry.contraction_words) {
+        Word cw;
+        cw.text = w;
+        cw.result = word_entry.result;
+        words.push_back(cw);
+      }
+    }
+  }
+  return words;
+}
+
+// Returns whether or not the given string is a contraction.
+// This function is a fall-back when the SpellcheckWordIterator class
+// returns a concatenated word which is not in the selected dictionary
+// (e.g. "in'n'out") but each word is valid.
+// Output variable contraction_words will contain individual
+// words in the contraction.
+bool SpellcheckLanguage::IsContraction(
+    const base::string16& contraction,
+    std::vector<base::string16>* contraction_words) {
+  DCHECK(contraction_iterator_.IsInitialized());
+
+  contraction_iterator_.SetText(contraction.c_str(), contraction.length());
+
+  base::string16 word;
+  size_t word_start;
+  size_t word_length;
+  for (auto status =
+           contraction_iterator_.GetNextWord(&word, &word_start, &word_length);
+       status != SpellcheckWordIterator::IS_END_OF_TEXT;
+       status = contraction_iterator_.GetNextWord(&word, &word_start,
+                                                  &word_length)) {
+    if (status == SpellcheckWordIterator::IS_SKIPPABLE)
+      continue;
+
+    contraction_words->push_back(word);
+  }
+  return contraction_words->size() > 1;
+}
+
+bool SpellcheckLanguage::IsEnabled() {
+  return true;
+}
+
+}  // namespace electron

--- a/shell/renderer/api/atom_spell_check_language.cc
+++ b/shell/renderer/api/atom_spell_check_language.cc
@@ -18,20 +18,14 @@ SpellcheckLanguage::Word::Word(const Word& word) = default;
 
 SpellcheckLanguage::Word::~Word() = default;
 
-SpellcheckLanguage::SpellcheckLanguage() {}
-
-SpellcheckLanguage::~SpellcheckLanguage() {}
-
-void SpellcheckLanguage::Init(const std::string& language) {
+SpellcheckLanguage::SpellcheckLanguage(const std::string& language) {
   character_attributes_.SetDefaultLanguage(language);
   text_iterator_.Reset();
   contraction_iterator_.Reset();
   language_ = language;
 }
 
-bool SpellcheckLanguage::InitializeIfNeeded() {
-  return true;
-}
+SpellcheckLanguage::~SpellcheckLanguage() {}
 
 std::vector<SpellcheckLanguage::Word> SpellcheckLanguage::SpellCheckText(
     const base::string16& text) {
@@ -110,10 +104,6 @@ bool SpellcheckLanguage::IsContraction(
     contraction_words->push_back(word);
   }
   return contraction_words->size() > 1;
-}
-
-bool SpellcheckLanguage::IsEnabled() {
-  return true;
 }
 
 }  // namespace electron

--- a/shell/renderer/api/atom_spell_check_language.h
+++ b/shell/renderer/api/atom_spell_check_language.h
@@ -1,0 +1,72 @@
+// Copyright (c) 2019 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_RENDERER_API_ATOM_API_SPELL_CHECK_LANGUAGE_H_
+#define SHELL_RENDERER_API_ATOM_API_SPELL_CHECK_LANGUAGE_H_
+
+#include <memory>
+#include <queue>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "base/files/file.h"
+#include "base/macros.h"
+#include "base/strings/string16.h"
+#include "components/spellcheck/renderer/spellcheck_worditerator.h"
+#include "third_party/blink/public/web/web_text_checking_result.h"
+
+namespace electron {
+
+class SpellcheckLanguage {
+ public:
+  struct Word {
+    blink::WebTextCheckingResult result;
+    base::string16 text;
+    std::vector<base::string16> contraction_words;
+    Word();
+    Word(const Word&);
+    ~Word();
+  };
+
+  explicit SpellcheckLanguage();
+  ~SpellcheckLanguage();
+
+  void Init(const std::string& language);
+
+  std::vector<Word> SpellCheckText(const base::string16& text);
+
+  // Initialize |spellcheck_| if that hasn't happened yet.
+  bool InitializeIfNeeded();
+
+  // Return true if the underlying spellcheck engine is enabled.
+  bool IsEnabled();
+  std::string GetLanguageString() { return language_; }
+
+ private:
+  // Returns whether or not the given word is a contraction of valid words
+  // (e.g. "word:word").
+  // Output variable contraction_words will contain individual
+  // words in the contraction.
+  bool IsContraction(const base::string16& word,
+                     std::vector<base::string16>* contraction_words);
+
+  // Represents character attributes used for filtering out characters which
+  // are not supported by this SpellCheck object.
+  SpellcheckCharAttribute character_attributes_;
+
+  // Represents word iterators used in this spellchecker. The |text_iterator_|
+  // splits text provided by WebKit into words, contractions, or concatenated
+  // words. The |contraction_iterator_| splits a concatenated word extracted by
+  // |text_iterator_| into word components so we can treat a concatenated word
+  // consisting only of correct words as a correct word.
+  SpellcheckWordIterator text_iterator_;
+  SpellcheckWordIterator contraction_iterator_;
+  std::string language_;
+  DISALLOW_COPY_AND_ASSIGN(SpellcheckLanguage);
+};
+
+}  // namespace electron
+
+#endif  // SHELL_RENDERER_API_ATOM_API_SPELL_CHECK_LANGUAGE_H_

--- a/shell/renderer/api/atom_spell_check_language.h
+++ b/shell/renderer/api/atom_spell_check_language.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#ifndef SHELL_RENDERER_API_ATOM_API_SPELL_CHECK_LANGUAGE_H_
-#define SHELL_RENDERER_API_ATOM_API_SPELL_CHECK_LANGUAGE_H_
+#ifndef SHELL_RENDERER_API_ATOM_SPELL_CHECK_LANGUAGE_H_
+#define SHELL_RENDERER_API_ATOM_SPELL_CHECK_LANGUAGE_H_
 
 #include <memory>
 #include <queue>
@@ -30,18 +30,11 @@ class SpellcheckLanguage {
     ~Word();
   };
 
-  explicit SpellcheckLanguage();
+  explicit SpellcheckLanguage(const std::string& language);
   ~SpellcheckLanguage();
-
-  void Init(const std::string& language);
 
   std::vector<Word> SpellCheckText(const base::string16& text);
 
-  // Initialize |spellcheck_| if that hasn't happened yet.
-  bool InitializeIfNeeded();
-
-  // Return true if the underlying spellcheck engine is enabled.
-  bool IsEnabled();
   std::string GetLanguageString() { return language_; }
 
  private:
@@ -69,4 +62,4 @@ class SpellcheckLanguage {
 
 }  // namespace electron
 
-#endif  // SHELL_RENDERER_API_ATOM_API_SPELL_CHECK_LANGUAGE_H_
+#endif  // SHELL_RENDERER_API_ATOM_SPELL_CHECK_LANGUAGE_H_

--- a/spec-main/api-web-frame-spec.ts
+++ b/spec-main/api-web-frame-spec.ts
@@ -35,6 +35,36 @@ describe('webFrame module', () => {
     }
     const [words, callbackDefined] = await spellCheckerFeedback
     expect(words.sort()).to.deep.equal(['spleling', 'test', `you're`, 'you', 're'].sort())
-    expect(callbackDefined).to.be.true()
+    expect(callbackDefined).to.be.true
+  })
+
+  it('calls a spellcheck provider with multiple languages', async () => {
+    const w = new BrowserWindow({
+      show: false,
+      webPreferences: {
+        nodeIntegration: true
+      }
+    })
+    await w.loadFile(path.join(fixtures, 'pages', 'webframe-spell-check-multi-lang.html'))
+    w.focus()
+    await w.webContents.executeJavaScript('document.querySelector("input").focus()', true)
+
+    const spellCheckerFeedback =
+      new Promise<[string[], boolean]>(resolve => {
+        ipcMain.on('spec-spell-check', (e, words, callbackDefined) => {
+          if (words.length === 8) {
+            // The API calls the provider after every completed word.
+            // The promise is resolved only after this event is received with all words.
+            resolve([words.map((word: string) => word.normalize()), callbackDefined])
+          }
+        })
+      })
+    const inputText = `spleling test you're 틀란 햔글 입럭`
+    for (const keyCode of inputText) {
+      w.webContents.sendInputEvent({ type: 'char', keyCode })
+    }
+    const [words, callbackDefined] = await spellCheckerFeedback
+    expect(words.sort()).to.deep.equal(['spleling', 'test', `you're`, 'you', 're', '틀란', '햔글', '입럭'].sort())
+    expect(callbackDefined).to.be.true
   })
 })

--- a/spec/fixtures/pages/webframe-spell-check-multi-lang.html
+++ b/spec/fixtures/pages/webframe-spell-check-multi-lang.html
@@ -1,0 +1,15 @@
+<html>
+<body>
+<script type="text/javascript" charset="utf-8">
+  const {ipcRenderer, webFrame} = require('electron')
+  webFrame.setSpellCheckProvider(['en-US', 'ko-KR'], {
+    spellCheck: (words, callback) => {
+      const multiLangWords = Object.values(words).reduce((acc, value) => acc.concat(value), [])
+      callback(multiLangWords)
+      ipcRenderer.send('spec-spell-check', multiLangWords, callback != undefined)
+    }
+  })
+</script>
+<input autofocus />
+</body>
+</html>

--- a/spec/ts-smoke/electron/renderer.ts
+++ b/spec/ts-smoke/electron/renderer.ts
@@ -69,6 +69,16 @@ webFrame.setSpellCheckProvider('en-US', {
   }
 })
 
+webFrame.setSpellCheckProvider(['en-US'], {
+  spellCheck (words, callback) {
+    setTimeout(() => {
+      const spellchecker = require('spellchecker')
+      const misspelled = words['en-US'].filter(x => spellchecker.isMisspelled(x))
+      callback(misspelled)
+    }, 0)
+  }
+})
+
 webFrame.insertText('text')
 
 webFrame.executeJavaScript('return true;').then((v: boolean) => console.log(v))


### PR DESCRIPTION
#### Description of Change
- Relates to #15202, #7244

This PR attempts to expand `setSpellCheckProvider` to support multi-language spellchecker. Consumer of interface can opt-in by specifying multiple languages when initializing spellcheck provider. SpellcheckClient will create wordIterator per each language specified, will call provider function with object have language as keys, and word to check spell as its values.

Marking misspelling logic is not changed, as long as async callback returns word, it'll be marked as error. It's up to consumer's decision as same as before.
 
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: `webFrame.setSpellcheckerProvider` supports multiple languages.
