### PR TITLE
refactor: use [Sync,NoDeadlockPrevention] in for MessageSync

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -81,3 +81,4 @@ ui_views_fix_jumbo_build.patch
 export_fetchapi_mojo_traits_to_fix_component_build.patch
 build_fix_when_building_with_enable_plugins_false.patch
 add_zoom_limit_setters_to_webcontents.patch
+add_nodeadlockprevention_mojo_flag.patch

--- a/patches/chromium/add_nodeadlockprevention_mojo_flag.patch
+++ b/patches/chromium/add_nodeadlockprevention_mojo_flag.patch
@@ -5,56 +5,62 @@ Subject: add [NoDeadlockPrevention] mojo flag
 
 
 diff --git a/ipc/ipc_mojo_bootstrap.cc b/ipc/ipc_mojo_bootstrap.cc
-index 8817d8e23d72d6a60cdd4ece5809ac0a6d2f59fa..5e45ebe9c763b4ce78d1c5d93621f4822c51d891 100644
+index 8817d8e23d72d6a60cdd4ece5809ac0a6d2f59fa..fa3322b4698f84d68e81d7e38e4efe73f16c6636 100644
 --- a/ipc/ipc_mojo_bootstrap.cc
 +++ b/ipc/ipc_mojo_bootstrap.cc
-@@ -857,7 +857,7 @@ class ChannelAssociatedGroupController
+@@ -857,7 +857,8 @@ class ChannelAssociatedGroupController
        // runs or else it's programmer error.
        DCHECK(proxy_task_runner_);
  
 -      if (message->has_flag(mojo::Message::kFlagIsSync)) {
-+      if (message->has_flag(mojo::Message::kFlagIsSync) && !message->has_flag(mojo::Message::kFlagNoDeadlockPrevention)) {
++      if (message->has_flag(mojo::Message::kFlagIsSync) &&
++          !message->has_flag(mojo::Message::kFlagNoDeadlockPrevention)) {
          MessageWrapper message_wrapper(this, std::move(*message));
          // Sync messages may need to be handled by the endpoint if it's blocking
          // on a sync reply. We pass ownership of the message to the endpoint's
-@@ -913,7 +913,7 @@ class ChannelAssociatedGroupController
+@@ -913,7 +914,8 @@ class ChannelAssociatedGroupController
      DCHECK(endpoint->task_runner()->RunsTasksInCurrentSequence());
  
      // Sync messages should never make their way to this method.
 -    DCHECK(!message.has_flag(mojo::Message::kFlagIsSync));
-+    DCHECK(!message.has_flag(mojo::Message::kFlagIsSync) || message.has_flag(mojo::Message::kFlagNoDeadlockPrevention));
++    DCHECK(!message.has_flag(mojo::Message::kFlagIsSync) ||
++           message.has_flag(mojo::Message::kFlagNoDeadlockPrevention));
  
      bool result = false;
      {
 diff --git a/mojo/public/cpp/bindings/lib/multiplex_router.cc b/mojo/public/cpp/bindings/lib/multiplex_router.cc
-index 9da1f0aa620ff512f40adc224e7e4f8908e72433..82c9c984840f6ae65f02d9f5ebab00816719604d 100644
+index 9da1f0aa620ff512f40adc224e7e4f8908e72433..83ab3008cf7f5f9d455de2a05977397d09e84f17 100644
 --- a/mojo/public/cpp/bindings/lib/multiplex_router.cc
 +++ b/mojo/public/cpp/bindings/lib/multiplex_router.cc
-@@ -605,7 +605,7 @@ bool MultiplexRouter::Accept(Message* message) {
+@@ -605,7 +605,9 @@ bool MultiplexRouter::Accept(Message* message) {
      tasks_.push_back(Task::CreateMessageTask(std::move(message_wrapper)));
      Task* task = tasks_.back().get();
  
 -    if (task->message_wrapper.value().has_flag(Message::kFlagIsSync)) {
-+    if (task->message_wrapper.value().has_flag(Message::kFlagIsSync) && !task->message_wrapper.value().has_flag(Message::kFlagNoDeadlockPrevention)) {
++    if (task->message_wrapper.value().has_flag(Message::kFlagIsSync) &&
++        !task->message_wrapper.value().has_flag(
++            Message::kFlagNoDeadlockPrevention)) {
        InterfaceId id = task->message_wrapper.value().interface_id();
        sync_message_tasks_[id].push_back(task);
        InterfaceEndpoint* endpoint = FindEndpoint(id);
-@@ -697,7 +697,8 @@ void MultiplexRouter::ProcessTasks(
+@@ -697,7 +699,9 @@ void MultiplexRouter::ProcessTasks(
      InterfaceId id = kInvalidInterfaceId;
      bool sync_message =
          task->IsMessageTask() && !task->message_wrapper.value().IsNull() &&
 -        task->message_wrapper.value().has_flag(Message::kFlagIsSync);
 +        task->message_wrapper.value().has_flag(Message::kFlagIsSync) &&
-+        !task->message_wrapper.value().has_flag(Message::kFlagNoDeadlockPrevention);
++        !task->message_wrapper.value().has_flag(
++            Message::kFlagNoDeadlockPrevention);
      if (sync_message) {
        id = task->message_wrapper.value().interface_id();
        auto& sync_message_queue = sync_message_tasks_[id];
-@@ -847,7 +848,7 @@ bool MultiplexRouter::ProcessIncomingMessage(
+@@ -847,7 +851,8 @@ bool MultiplexRouter::ProcessIncomingMessage(
    }
  
    bool can_direct_call;
 -  if (message->has_flag(Message::kFlagIsSync)) {
-+  if (message->has_flag(Message::kFlagIsSync) && !message->has_flag(Message::kFlagNoDeadlockPrevention)) {
++  if (message->has_flag(Message::kFlagIsSync) &&
++      !message->has_flag(Message::kFlagNoDeadlockPrevention)) {
      can_direct_call = client_call_behavior != NO_DIRECT_CLIENT_CALLS &&
                        endpoint->task_runner()->RunsTasksInCurrentSequence();
    } else {
@@ -130,7 +136,7 @@ index 0d6407f64a96471f3fd4022548952c6a782821c0..7d880a4137b596ea4af6c57901f0bcc0
        message_name, "in_%s", response_params_struct,
        response_params_description, "kFlags", "message")}}
 diff --git a/mojo/public/tools/bindings/generators/cpp_templates/interface_macros.tmpl b/mojo/public/tools/bindings/generators/cpp_templates/interface_macros.tmpl
-index 67940021e200adbeaaa658bcf9cf02aba3cce5c2..3f1680c560adec9d07664f4ef4b213ee7c5ddc2e 100644
+index 67940021e200adbeaaa658bcf9cf02aba3cce5c2..ab6af02ce1ac12becb44b564d4b8e95a343a5121 100644
 --- a/mojo/public/tools/bindings/generators/cpp_templates/interface_macros.tmpl
 +++ b/mojo/public/tools/bindings/generators/cpp_templates/interface_macros.tmpl
 @@ -36,14 +36,15 @@ base::OnceCallback<void(
@@ -163,10 +169,9 @@ index 67940021e200adbeaaa658bcf9cf02aba3cce5c2..3f1680c560adec9d07664f4ef4b213ee
        {{declare_params("param_", parameters)}}
  {%-   endif %}) {
  
--    {{build_message_flags(is_response, "is_sync", "expects_response",
+     {{build_message_flags(is_response, "is_sync", "expects_response",
 -                          "kFlags")}}
-+    {{build_message_flags(is_response, "is_sync", "is_nodeadlockprevention",
-+                          "expects_response", "kFlags")}}
++                          "is_nodeadlockprevention", "kFlags")}}
  
      if (!serialize) {
        return mojo::Message(std::make_unique<{{message_typename}}>(

--- a/patches/chromium/add_nodeadlockprevention_mojo_flag.patch
+++ b/patches/chromium/add_nodeadlockprevention_mojo_flag.patch
@@ -1,0 +1,196 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jeremy Apthorp <nornagon@nornagon.net>
+Date: Mon, 21 Oct 2019 12:43:26 -0700
+Subject: add [NoDeadlockPrevention] mojo flag
+
+
+diff --git a/ipc/ipc_mojo_bootstrap.cc b/ipc/ipc_mojo_bootstrap.cc
+index 8817d8e23d72d6a60cdd4ece5809ac0a6d2f59fa..5e45ebe9c763b4ce78d1c5d93621f4822c51d891 100644
+--- a/ipc/ipc_mojo_bootstrap.cc
++++ b/ipc/ipc_mojo_bootstrap.cc
+@@ -857,7 +857,7 @@ class ChannelAssociatedGroupController
+       // runs or else it's programmer error.
+       DCHECK(proxy_task_runner_);
+ 
+-      if (message->has_flag(mojo::Message::kFlagIsSync)) {
++      if (message->has_flag(mojo::Message::kFlagIsSync) && !message->has_flag(mojo::Message::kFlagNoDeadlockPrevention)) {
+         MessageWrapper message_wrapper(this, std::move(*message));
+         // Sync messages may need to be handled by the endpoint if it's blocking
+         // on a sync reply. We pass ownership of the message to the endpoint's
+@@ -913,7 +913,7 @@ class ChannelAssociatedGroupController
+     DCHECK(endpoint->task_runner()->RunsTasksInCurrentSequence());
+ 
+     // Sync messages should never make their way to this method.
+-    DCHECK(!message.has_flag(mojo::Message::kFlagIsSync));
++    DCHECK(!message.has_flag(mojo::Message::kFlagIsSync) || message.has_flag(mojo::Message::kFlagNoDeadlockPrevention));
+ 
+     bool result = false;
+     {
+diff --git a/mojo/public/cpp/bindings/lib/multiplex_router.cc b/mojo/public/cpp/bindings/lib/multiplex_router.cc
+index 9da1f0aa620ff512f40adc224e7e4f8908e72433..82c9c984840f6ae65f02d9f5ebab00816719604d 100644
+--- a/mojo/public/cpp/bindings/lib/multiplex_router.cc
++++ b/mojo/public/cpp/bindings/lib/multiplex_router.cc
+@@ -605,7 +605,7 @@ bool MultiplexRouter::Accept(Message* message) {
+     tasks_.push_back(Task::CreateMessageTask(std::move(message_wrapper)));
+     Task* task = tasks_.back().get();
+ 
+-    if (task->message_wrapper.value().has_flag(Message::kFlagIsSync)) {
++    if (task->message_wrapper.value().has_flag(Message::kFlagIsSync) && !task->message_wrapper.value().has_flag(Message::kFlagNoDeadlockPrevention)) {
+       InterfaceId id = task->message_wrapper.value().interface_id();
+       sync_message_tasks_[id].push_back(task);
+       InterfaceEndpoint* endpoint = FindEndpoint(id);
+@@ -697,7 +697,8 @@ void MultiplexRouter::ProcessTasks(
+     InterfaceId id = kInvalidInterfaceId;
+     bool sync_message =
+         task->IsMessageTask() && !task->message_wrapper.value().IsNull() &&
+-        task->message_wrapper.value().has_flag(Message::kFlagIsSync);
++        task->message_wrapper.value().has_flag(Message::kFlagIsSync) &&
++        !task->message_wrapper.value().has_flag(Message::kFlagNoDeadlockPrevention);
+     if (sync_message) {
+       id = task->message_wrapper.value().interface_id();
+       auto& sync_message_queue = sync_message_tasks_[id];
+@@ -847,7 +848,7 @@ bool MultiplexRouter::ProcessIncomingMessage(
+   }
+ 
+   bool can_direct_call;
+-  if (message->has_flag(Message::kFlagIsSync)) {
++  if (message->has_flag(Message::kFlagIsSync) && !message->has_flag(Message::kFlagNoDeadlockPrevention)) {
+     can_direct_call = client_call_behavior != NO_DIRECT_CLIENT_CALLS &&
+                       endpoint->task_runner()->RunsTasksInCurrentSequence();
+   } else {
+diff --git a/mojo/public/cpp/bindings/message.h b/mojo/public/cpp/bindings/message.h
+index 1d359526357033e2ac95203cb42f417c6b5b345a..95d42788e4f4c4c5f5a3b6b88c9f9831729bc921 100644
+--- a/mojo/public/cpp/bindings/message.h
++++ b/mojo/public/cpp/bindings/message.h
+@@ -42,6 +42,7 @@ class COMPONENT_EXPORT(MOJO_CPP_BINDINGS_BASE) Message {
+   static const uint32_t kFlagExpectsResponse = 1 << 0;
+   static const uint32_t kFlagIsResponse = 1 << 1;
+   static const uint32_t kFlagIsSync = 1 << 2;
++  static const uint32_t kFlagNoDeadlockPrevention = 1 << 3;
+ 
+   // Constructs an uninitialized Message object.
+   Message();
+diff --git a/mojo/public/tools/bindings/generators/cpp_templates/interface_definition.tmpl b/mojo/public/tools/bindings/generators/cpp_templates/interface_definition.tmpl
+index 0d6407f64a96471f3fd4022548952c6a782821c0..7d880a4137b596ea4af6c57901f0bcc027293b2d 100644
+--- a/mojo/public/tools/bindings/generators/cpp_templates/interface_definition.tmpl
++++ b/mojo/public/tools/bindings/generators/cpp_templates/interface_definition.tmpl
+@@ -123,16 +123,21 @@ bool {{proxy_name}}::{{method.name}}(
+ #endif
+   const bool kExpectsResponse = true;
+   const bool kIsSync = true;
++{%-   if method.no_deadlock_prevention %}
++  const bool kNoDeadlockPrevention = true;
++{%-   else %}
++  const bool kNoDeadlockPrevention = false;
++{%-   endif %}
+ {%-   if method|method_supports_lazy_serialization %}
+   const bool kSerialize = receiver_->PrefersSerializedMessages();
+   auto message = {{message_typename}}::Build(
+-      kSerialize, kExpectsResponse, kIsSync
++      kSerialize, kExpectsResponse, kIsSync, kNoDeadlockPrevention
+ {%-     for param in method.parameters -%}
+       , std::move(param_{{param.name}})
+ {%-     endfor %});
+ {%-   else %}
+   {{interface_macros.build_message_flags(False, "kIsSync", "kExpectsResponse",
+-                                         "kFlags")}}
++                                         "kNoDeadlockPrevention", "kFlags")}}
+   {{interface_macros.build_serialized_message(
+       message_name, "param_%s", params_struct, params_description, "kFlags",
+       "message")}}
+@@ -169,13 +174,13 @@ void {{proxy_name}}::{{method.name}}(
+ {%-   if method|method_supports_lazy_serialization %}
+   const bool kSerialize = receiver_->PrefersSerializedMessages();
+   auto message = {{message_typename}}::Build(
+-      kSerialize, kExpectsResponse, kIsSync
++      kSerialize, kExpectsResponse, kIsSync, false /* no_deadlock_prevention */
+ {%-     for param in method.parameters -%}
+       , std::move(in_{{param.name}})
+ {%-     endfor %});
+ {%-   else %}
+   {{interface_macros.build_message_flags(False, "kIsSync", "kExpectsResponse",
+-                                         "kFlags")}}
++                                         "false", "kFlags")}}
+   {{interface_macros.build_serialized_message(
+       message_name, "in_%s", params_struct, params_description, "kFlags",
+       "message")}}
+@@ -314,12 +319,12 @@ void {{class_name}}_{{method.name}}_ProxyToResponder::Run(
+     {{interface_macros.declare_params("in_", method.response_parameters)}}) {
+ {%-   if method|method_supports_lazy_serialization %}
+   const bool kSerialize = responder_->PrefersSerializedMessages();
+-  auto message = {{response_message_typename}}::Build(kSerialize, is_sync_
++  auto message = {{response_message_typename}}::Build(kSerialize, is_sync_, false
+ {%-     for param in method.response_parameters -%}
+       , std::move(in_{{param.name}})
+ {%-     endfor %});
+ {%-   else %}
+-  {{interface_macros.build_message_flags(True, "is_sync_", "false", "kFlags")}}
++  {{interface_macros.build_message_flags(True, "is_sync_", "false", "false", "kFlags")}}
+   {{interface_macros.build_serialized_message(
+       message_name, "in_%s", response_params_struct,
+       response_params_description, "kFlags", "message")}}
+diff --git a/mojo/public/tools/bindings/generators/cpp_templates/interface_macros.tmpl b/mojo/public/tools/bindings/generators/cpp_templates/interface_macros.tmpl
+index 67940021e200adbeaaa658bcf9cf02aba3cce5c2..3f1680c560adec9d07664f4ef4b213ee7c5ddc2e 100644
+--- a/mojo/public/tools/bindings/generators/cpp_templates/interface_macros.tmpl
++++ b/mojo/public/tools/bindings/generators/cpp_templates/interface_macros.tmpl
+@@ -36,14 +36,15 @@ base::OnceCallback<void(
+ {%- endmacro -%}
+ 
+ {%- macro build_message_flags(is_response, is_sync_text, expects_response_text,
+-                              flags_name) %}
++                              is_nodeadlockprevention_text, flags_name) %}
+ {%-   if is_response %}
+   const uint32_t kFlags = mojo::Message::kFlagIsResponse |
+       (({{is_sync_text}}) ? mojo::Message::kFlagIsSync : 0);
+ {%-   else %}
+   const uint32_t kFlags =
+       (({{expects_response_text}}) ? mojo::Message::kFlagExpectsResponse : 0) |
+-      (({{is_sync_text}}) ? mojo::Message::kFlagIsSync : 0);
++      (({{is_sync_text}}) ? mojo::Message::kFlagIsSync : 0) |
++      (({{is_nodeadlockprevention_text}}) ? mojo::Message::kFlagNoDeadlockPrevention : 0);
+ {%-   endif %}
+ {%- endmacro %}
+ 
+@@ -95,14 +96,15 @@ class {{message_typename}}
+ {%-   if not is_response %}
+       bool expects_response,
+ {%-   endif %}
+-      bool is_sync
++      bool is_sync,
++      bool is_nodeadlockprevention
+ {%-   if parameters -%}
+       ,
+       {{declare_params("param_", parameters)}}
+ {%-   endif %}) {
+ 
+-    {{build_message_flags(is_response, "is_sync", "expects_response",
+-                          "kFlags")}}
++    {{build_message_flags(is_response, "is_sync", "is_nodeadlockprevention",
++                          "expects_response", "kFlags")}}
+ 
+     if (!serialize) {
+       return mojo::Message(std::make_unique<{{message_typename}}>(
+diff --git a/mojo/public/tools/bindings/pylib/mojom/generate/module.py b/mojo/public/tools/bindings/pylib/mojom/generate/module.py
+index 5c6cf45d1b4530a6af9c82a8e4e4b5b00cdc2e0e..a4b9748f232ffd8ab5802e614d32d07564741725 100644
+--- a/mojo/public/tools/bindings/pylib/mojom/generate/module.py
++++ b/mojo/public/tools/bindings/pylib/mojom/generate/module.py
+@@ -219,6 +219,7 @@ PRIMITIVES = (
+ ATTRIBUTE_MIN_VERSION = 'MinVersion'
+ ATTRIBUTE_EXTENSIBLE = 'Extensible'
+ ATTRIBUTE_SYNC = 'Sync'
++ATTRIBUTE_NO_DEADLOCK_PREVENTION = 'NoDeadlockPrevention'
+ 
+ 
+ class NamedValue(object):
+@@ -655,6 +656,11 @@ class Method(object):
+     return self.attributes.get(ATTRIBUTE_SYNC) \
+         if self.attributes else None
+ 
++  @property
++  def no_deadlock_prevention(self):
++    return self.attributes.get(ATTRIBUTE_NO_DEADLOCK_PREVENTION) \
++        if self.attributes else None
++
+ 
+ class Interface(ReferenceKind):
+   ReferenceKind.AddSharedProperty('mojom_name')

--- a/shell/common/api/api.mojom
+++ b/shell/common/api/api.mojom
@@ -55,10 +55,6 @@ interface ElectronBrowser {
 
   // Emits an event on |channel| from the ipcMain JavaScript object in the main
   // process, and waits synchronously for a response.
-  //
-  // NB. this is not marked [Sync] because mojo synchronous methods can be
-  // reordered with respect to asynchronous methods on the same channel.
-  // Instead, callers can manually block on the response to this method.
   [Sync,NoDeadlockPrevention]
   MessageSync(
     bool internal,

--- a/shell/common/api/api.mojom
+++ b/shell/common/api/api.mojom
@@ -59,6 +59,7 @@ interface ElectronBrowser {
   // NB. this is not marked [Sync] because mojo synchronous methods can be
   // reordered with respect to asynchronous methods on the same channel.
   // Instead, callers can manually block on the response to this method.
+  [Sync,NoDeadlockPrevention]
   MessageSync(
     bool internal,
     string channel,

--- a/shell/renderer/api/atom_api_renderer_ipc.cc
+++ b/shell/renderer/api/atom_api_renderer_ipc.cc
@@ -41,19 +41,12 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer> {
     return gin::CreateHandle(isolate, new IPCRenderer(isolate));
   }
 
-  explicit IPCRenderer(v8::Isolate* isolate)
-      : task_runner_(base::CreateSingleThreadTaskRunner({base::ThreadPool()})) {
+  explicit IPCRenderer(v8::Isolate* isolate) {
     RenderFrame* render_frame = GetCurrentRenderFrame();
     DCHECK(render_frame);
 
-    // Bind the interface on the background runner. All accesses will be via
-    // the thread-safe pointer. This is to support our "fake-sync"
-    // MessageSync() hack; see the comment in IPCRenderer::SendSync.
-    electron::mojom::ElectronBrowserPtrInfo info;
-    render_frame->GetRemoteInterfaces()->GetInterface(mojo::MakeRequest(&info));
-    electron_browser_ptr_ =
-        electron::mojom::ThreadSafeElectronBrowserPtr::Create(std::move(info),
-                                                              task_runner_);
+    render_frame->GetRemoteInterfaces()->GetInterface(
+        mojo::MakeRequest(&electron_browser_ptr_));
   }
 
   // gin::Wrappable:
@@ -78,8 +71,7 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer> {
     if (!mate::ConvertFromV8(isolate, arguments, &message)) {
       return;
     }
-    electron_browser_ptr_->get()->Message(internal, channel,
-                                          std::move(message));
+    electron_browser_ptr_->Message(internal, channel, std::move(message));
   }
 
   v8::Local<v8::Promise> Invoke(v8::Isolate* isolate,
@@ -93,7 +85,7 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer> {
     electron::util::Promise<blink::CloneableMessage> p(isolate);
     auto handle = p.GetHandle();
 
-    electron_browser_ptr_->get()->Invoke(
+    electron_browser_ptr_->Invoke(
         internal, channel, std::move(message),
         base::BindOnce(
             [](electron::util::Promise<blink::CloneableMessage> p,
@@ -113,8 +105,8 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer> {
     if (!mate::ConvertFromV8(isolate, arguments, &message)) {
       return;
     }
-    electron_browser_ptr_->get()->MessageTo(
-        internal, send_to_all, web_contents_id, channel, std::move(message));
+    electron_browser_ptr_->MessageTo(internal, send_to_all, web_contents_id,
+                                     channel, std::move(message));
   }
 
   void SendToHost(v8::Isolate* isolate,
@@ -124,7 +116,7 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer> {
     if (!mate::ConvertFromV8(isolate, arguments, &message)) {
       return;
     }
-    electron_browser_ptr_->get()->MessageHost(channel, std::move(message));
+    electron_browser_ptr_->MessageHost(channel, std::move(message));
   }
 
   blink::CloneableMessage SendSync(v8::Isolate* isolate,
@@ -135,91 +127,14 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer> {
     if (!mate::ConvertFromV8(isolate, arguments, &message)) {
       return blink::CloneableMessage();
     }
-    // We aren't using a true synchronous mojo call here. We're calling an
-    // asynchronous method and blocking on the result. The reason we're doing
-    // this is a little complicated, so buckle up.
-    //
-    // Mojo has a concept of synchronous calls. However, synchronous calls are
-    // dangerous. In particular, it's quite possible for two processes to call
-    // synchronous methods on each other and cause a deadlock. Mojo has a
-    // mechanism to avoid this kind of deadlock: if a process is waiting on the
-    // result of a synchronous call, and it receives an incoming call for a
-    // synchronous method, it will process that request immediately, even
-    // though it's currently blocking. However, if it receives an incoming
-    // request for an _asynchronous_ method, that can't cause a deadlock, so it
-    // stashes the request on a queue to be processed once the synchronous
-    // thing it's waiting on returns.
-    //
-    // This behavior is useful for preventing deadlocks, but it is inconvenient
-    // here because it can result in messages being reordered. If the main
-    // process is awaiting the result of a synchronous call (which it does only
-    // very rarely, since it's bad to block the main process), and we send
-    // first an asynchronous message to the main process, followed by a
-    // synchronous message, then the main process will process the synchronous
-    // one first.
-    //
-    // It turns out, Electron has some dependency on message ordering,
-    // especially during window shutdown, and getting messages out of order can
-    // result in, for example, remote objects disappearing unexpectedly. To
-    // avoid these issues and guarantee consistent message ordering, we send
-    // all messages to the main process as asynchronous messages. This causes
-    // them to always be queued and processed in the same order they were
-    // received, even if they were received while the main process was waiting
-    // on a synchronous call.
-    //
-    // However, in the calling process, we still need to block on the result,
-    // because the caller is expecting a result synchronously. So we do a bit
-    // of a trick: we pass the Mojo handle over to a worker thread, send the
-    // asynchronous message from that thread, and then block on the result.
-    // It's important that we pass the handle over to the worker thread,
-    // because that allows Mojo to process incoming messages (most importantly,
-    // the response to our request) on that thread. If we didn't pass it to a
-    // worker thread, and instead sent the call from the main thread, we would
-    // never receive a response because Mojo wouldn't be able to run its
-    // message handling code, because the main thread would be tied up blocking
-    // on the WaitableEvent.
-    //
-    // Phew. If you got this far, here's a gold star: ⭐️
 
     blink::CloneableMessage result;
-
-    // A task is posted to a worker thread to execute the request so that
-    // this thread may block on a waitable event. It is safe to pass raw
-    // pointers to |result| and |response_received_event| as this stack frame
-    // will survive until the request is complete.
-
-    base::WaitableEvent response_received_event;
-    task_runner_->PostTask(
-        FROM_HERE, base::BindOnce(&IPCRenderer::SendMessageSyncOnWorkerThread,
-                                  base::Unretained(this),
-                                  base::Unretained(&response_received_event),
-                                  base::Unretained(&result), internal, channel,
-                                  std::move(message)));
-    response_received_event.Wait();
+    electron_browser_ptr_->MessageSync(internal, channel, std::move(message),
+                                       &result);
     return result;
   }
 
-  void SendMessageSyncOnWorkerThread(base::WaitableEvent* event,
-                                     blink::CloneableMessage* result,
-                                     bool internal,
-                                     const std::string& channel,
-                                     blink::CloneableMessage arguments) {
-    electron_browser_ptr_->get()->MessageSync(
-        internal, channel, std::move(arguments),
-        base::BindOnce(&IPCRenderer::ReturnSyncResponseToMainThread,
-                       base::Unretained(event), base::Unretained(result)));
-  }
-
-  static void ReturnSyncResponseToMainThread(base::WaitableEvent* event,
-                                             blink::CloneableMessage* result,
-                                             blink::CloneableMessage response) {
-    *result = std::move(response);
-    event->Signal();
-  }
-
-  scoped_refptr<base::SequencedTaskRunner> task_runner_;
-  scoped_refptr<electron::mojom::ThreadSafeElectronBrowserPtr>
-      electron_browser_ptr_;
+  electron::mojom::ElectronBrowserPtr electron_browser_ptr_;
 };
 
 gin::WrapperInfo IPCRenderer::kWrapperInfo = {gin::kEmbedderNativeGin};


### PR DESCRIPTION
#### Description of Change
This removes a bunch of hacks we have to pretend that the `ElectronBrowser.Message` mojo function is asynchronous, by adding a new `[NoDeadlockPrevention]` flag to Mojo.

Some background: Mojo already has the functionality to be able to send synchronous messages; i.e. messages on which the sender will block until a response is received. In order to prevent a situation in which two processes are waiting for each other (or other deadlock situations), if process (A) sends a synchronous message to (B) and is waiting on the result, and then process (A) receives a synchronous request from process (C), it will process it immediately (even though it's still waiting for the response to its first message). This can result in synchronous messages being received out-of-order with respect to asynchronous messages.

There are some IPC messages in Electron which rely on strict ordering between synchronous and asynchronous messages. Most of the time, the main process doesn't send any synchronous IPC messages and `[Sync]` would work just fine (because the reordering only kicks in if a process receives a synchronous message while it's waiting for a response to a synchronous message that it sent). However, there are a few cases in window shutdown where the main process _does_ send a synchronous message, resulting in out-of-order message delivery.

This new `[NoDeadlockPrevention]` flag disables the deadlock-breaking feature for the method, meaning that correct ordering will be guaranteed w.r.t. other asynchronous messages sent on the same channel. The sending side still sees the message as synchronous, but the receiving side won't reorder the message on receipt if it's in the middle of making a synchronous request itself.

The main reason to do this is that our existing approach with `ThreadSafeElectronBrowserPtr` cannot listen for channel errors, since the `ThreadSafeInterfacePtr` class doesn't have that functionality, resulting in a possible issue where the process issues a request and then blocks waiting for a response which it will never receive, because the remote end has hung up. This PR doesn't fix that issue, but it does make it _possible_ to fix.

Upstream CL: https://chromium-review.googlesource.com/c/chromium/src/+/1872981

Ref #20086 #20547 #20632

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
