### PR TITLE
fix: properly free remote objects

### DIFF
--- a/shell/common/api/remote/remote_object_freer.cc
+++ b/shell/common/api/remote/remote_object_freer.cc
@@ -82,8 +82,8 @@ void RemoteObjectFreer::RunDestructor() {
       ref_mapper_.erase(objects_it);
   }
 
-  mojom::ElectronBrowserAssociatedPtr electron_ptr;
-  render_frame->GetRemoteAssociatedInterfaces()->GetInterface(
+  mojom::ElectronBrowserPtr electron_ptr;
+  render_frame->GetRemoteInterfaces()->GetInterface(
       mojo::MakeRequest(&electron_ptr));
   electron_ptr->DereferenceRemoteJSObject(context_id_, object_id_, ref_count);
 }

--- a/shell/common/api/remote/remote_object_freer.cc
+++ b/shell/common/api/remote/remote_object_freer.cc
@@ -10,7 +10,7 @@
 #include "electron/shell/common/api/api.mojom.h"
 #include "electron/shell/common/native_mate_converters/blink_converter.h"
 #include "electron/shell/common/native_mate_converters/value_converter.h"
-#include "third_party/blink/public/common/associated_interfaces/associated_interface_provider.h"
+#include "services/service_manager/public/cpp/interface_provider.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 
 using blink::WebLocalFrame;


### PR DESCRIPTION
#### Description of Change
This was introduced when switching to mojo; at one point when the mojo change was still in progress the browser interface was an associated interface, but it no longer is, so this was failing silently (!).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where objects referenced by `remote` could sometimes not be correctly freed.