### PR TITLE
chore: update build_bring_back_node_with_ltcg_configuration.patch

### DIFF
--- a/patches/node/build_bring_back_node_with_ltcg_configuration.patch
+++ b/patches/node/build_bring_back_node_with_ltcg_configuration.patch
@@ -10,9 +10,18 @@ THe fix for this should land in node-gyp as discussed in above issue,
 landing this as temporary patch.
 
 diff --git a/common.gypi b/common.gypi
-index f07e65f719a1a5939997dfcae7bc787ee6391f4d..69b5439a5c19230e5568450c3aca9ce27661d77c 100644
+index bde7d7300f44596abe5cdfac0639ecb1bb4d885f..85fda5d97c6cb7257f1ffc14ec8dbe3cc68b51cb 100644
 --- a/common.gypi
 +++ b/common.gypi
+@@ -19,7 +19,7 @@
+     'node_use_v8_platform%': 'true',
+     'node_use_bundled_v8%': 'true',
+     'node_module_version%': '',
+-    'node_with_ltcg%': '',
++    'node_with_ltcg%': 'true',
+     'node_shared_openssl%': 'false',
+ 
+     'node_tag%': '',
 @@ -180,6 +180,26 @@
              'cflags': [ '-fPIE' ],
              'ldflags': [ '-fPIE', '-pie' ]

--- a/patches/node/build_bring_back_node_with_ltcg_configuration.patch
+++ b/patches/node/build_bring_back_node_with_ltcg_configuration.patch
@@ -10,7 +10,7 @@ THe fix for this should land in node-gyp as discussed in above issue,
 landing this as temporary patch.
 
 diff --git a/common.gypi b/common.gypi
-index bde7d7300f44596abe5cdfac0639ecb1bb4d885f..85fda5d97c6cb7257f1ffc14ec8dbe3cc68b51cb 100644
+index bde7d7300f44596abe5cdfac0639ecb1bb4d885f..412f613e7cfcf563fa6a000b932723166ab567da 100644
 --- a/common.gypi
 +++ b/common.gypi
 @@ -19,7 +19,7 @@
@@ -22,7 +22,7 @@ index bde7d7300f44596abe5cdfac0639ecb1bb4d885f..85fda5d97c6cb7257f1ffc14ec8dbe3c
      'node_shared_openssl%': 'false',
  
      'node_tag%': '',
-@@ -180,6 +180,26 @@
+@@ -240,6 +240,26 @@
              'cflags': [ '-fPIE' ],
              'ldflags': [ '-fPIE', '-pie' ]
            }],


### PR DESCRIPTION
#### Description of Change

Follow up https://github.com/electron/electron/pull/20614

Set default value for node_with_ltcg=true, and moves the definition to `Release` configuration.

Thanks to @miniak for spotting the regression.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix native module size increase on windows, follow up fix to https://github.com/electron/electron/pull/20614

