### PR TITLE
feat: convert shell.openItem to async shell.openPath

### DIFF
--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -24,11 +24,14 @@ The `shell` module has the following methods:
 
 Show the given file in a file manager. If possible, select the file.
 
-### `shell.openItem(fullPath)`
+### `shell.openPath(path)`
 
-* `fullPath` String
+* `path` String
 
-Returns `Boolean` - Whether the item was successfully opened.
+Returns `Promise<Object>` - Resolve with an object containing the following:
+
+* `success` Boolean - whether or not the path was successfully opened in the desktop's default manner.
+* `errorMessage` String (optional) - The error message corresponding to the failure if a failure occurred, otherwise empty string.
 
 Open the given file in the desktop's default manner.
 

--- a/shell/browser/ui/inspectable_web_contents_impl.cc
+++ b/shell/browser/ui/inspectable_web_contents_impl.cc
@@ -559,7 +559,9 @@ void InspectableWebContentsImpl::ShowItemInFolder(
     return;
 
   base::FilePath path = base::FilePath::FromUTF8Unsafe(file_system_path);
-  platform_util::OpenItem(path);
+
+  // Pass empty callback here; we can ignore errors
+  platform_util::OpenPath(path, platform_util::OpenCallback());
 }
 
 void InspectableWebContentsImpl::SaveToFile(const std::string& url,

--- a/shell/common/platform_util.h
+++ b/shell/common/platform_util.h
@@ -19,7 +19,7 @@ class GURL;
 
 namespace platform_util {
 
-typedef base::OnceCallback<void(const std::string&)> OpenExternalCallback;
+typedef base::OnceCallback<void(const std::string&)> OpenCallback;
 
 // Show the given file in a file manager. If possible, select the file.
 // Must be called from the UI thread.
@@ -27,7 +27,7 @@ void ShowItemInFolder(const base::FilePath& full_path);
 
 // Open the given file in the desktop's default manner.
 // Must be called from the UI thread.
-bool OpenItem(const base::FilePath& full_path);
+void OpenPath(const base::FilePath& full_path, OpenCallback callback);
 
 struct OpenExternalOptions {
   bool activate = true;
@@ -38,7 +38,7 @@ struct OpenExternalOptions {
 // (For example, mailto: URLs in the default mail user agent.)
 void OpenExternal(const GURL& url,
                   const OpenExternalOptions& options,
-                  OpenExternalCallback callback);
+                  OpenCallback callback);
 
 // Move a file to trash.
 bool MoveItemToTrash(const base::FilePath& full_path, bool delete_on_fail);

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -19,7 +19,25 @@
 
 namespace {
 
-bool XDGUtil(const std::vector<std::string>& argv, const bool wait_for_exit) {
+// Descriptions pulled from https://linux.die.net/man/1/xdg-open
+std::string GetErrorDescription(int error_code) {
+  switch (error_code) {
+    case 1:
+      return "Error in command line syntax";
+    case 2:
+      return "The item does not exist";
+    case 3:
+      return "A required tool could not be found";
+    case 4:
+      return "The action failed";
+    default:
+      return "";
+  }
+}
+
+bool XDGUtil(const std::vector<std::string>& argv,
+             const bool wait_for_exit,
+             platform_util::OpenCallback callback) {
   base::LaunchOptions options;
   options.allow_new_privs = true;
   // xdg-open can fall back on mailcap which eventually might plumb through
@@ -34,52 +52,56 @@ bool XDGUtil(const std::vector<std::string>& argv, const bool wait_for_exit) {
 
   if (wait_for_exit) {
     int exit_code = -1;
-    if (!process.WaitForExit(&exit_code))
-      return false;
-    return (exit_code == 0);
+    bool success = process.WaitForExit(&exit_code);
+    if (!callback.is_null())
+      std::move(callback).Run(GetErrorDescription(exit_code));
+    return success ? (exit_code == 0) : false;
   }
 
   base::EnsureProcessGetsReaped(std::move(process));
   return true;
 }
 
-bool XDGOpen(const std::string& path, const bool wait_for_exit) {
-  return XDGUtil({"xdg-open", path}, wait_for_exit);
+bool XDGOpen(const std::string& path,
+             const bool wait_for_exit,
+             platform_util::OpenCallback callback) {
+  return XDGUtil({"xdg-open", path}, wait_for_exit, std::move(callback));
 }
 
 bool XDGEmail(const std::string& email, const bool wait_for_exit) {
-  return XDGUtil({"xdg-email", email}, wait_for_exit);
+  return XDGUtil({"xdg-email", email}, wait_for_exit,
+                 platform_util::OpenCallback());
 }
 
 }  // namespace
 
 namespace platform_util {
 
-// TODO(estade): It would be nice to be able to select the file in the file
-// manager, but that probably requires extending xdg-open. For now just
-// show the folder.
 void ShowItemInFolder(const base::FilePath& full_path) {
   base::FilePath dir = full_path.DirName();
   if (!base::DirectoryExists(dir))
     return;
 
-  XDGOpen(dir.value(), false);
+  XDGOpen(dir.value(), false, platform_util::OpenCallback());
 }
 
-bool OpenItem(const base::FilePath& full_path) {
-  return XDGOpen(full_path.value(), false);
+void OpenPath(const base::FilePath& full_path, OpenCallback callback) {
+  // This is async, so we don't care about the return value.
+  XDGOpen(full_path.value(), true, std::move(callback));
 }
 
 void OpenExternal(const GURL& url,
                   const OpenExternalOptions& options,
-                  OpenExternalCallback callback) {
+                  OpenCallback callback) {
   // Don't wait for exit, since we don't want to wait for the browser/email
   // client window to close before returning
-  if (url.SchemeIs("mailto"))
-    std::move(callback).Run(XDGEmail(url.spec(), false) ? ""
-                                                        : "Failed to open");
-  else
-    std::move(callback).Run(XDGOpen(url.spec(), false) ? "" : "Failed to open");
+  if (url.SchemeIs("mailto")) {
+    bool success = XDGEmail(url.spec(), false);
+    std::move(callback).Run(success ? "" : "Failed to open path");
+  } else {
+    bool success = XDGOpen(url.spec(), false, platform_util::OpenCallback());
+    std::move(callback).Run(success ? "" : "Failed to open path");
+  }
 }
 
 bool MoveItemToTrash(const base::FilePath& full_path, bool delete_on_fail) {
@@ -111,7 +133,7 @@ bool MoveItemToTrash(const base::FilePath& full_path, bool delete_on_fail) {
     argv = {"gio", "trash", filename};
   }
 
-  return XDGUtil(argv, true);
+  return XDGUtil(argv, true, platform_util::OpenCallback());
 }
 
 void Beep() {

--- a/shell/common/platform_util_mac.mm
+++ b/shell/common/platform_util_mac.mm
@@ -58,6 +58,23 @@ NSString* GetLoginHelperBundleIdentifier() {
       stringByAppendingString:@".loginhelper"];
 }
 
+std::string OpenPathOnThread(const base::FilePath& full_path) {
+  NSString* path_string = base::SysUTF8ToNSString(full_path.value());
+  NSURL* url = [NSURL fileURLWithPath:path_string];
+  if (!url)
+    return "Invalid path";
+
+  const NSWorkspaceLaunchOptions launch_options =
+      NSWorkspaceLaunchAsync | NSWorkspaceLaunchWithErrorPresentation;
+  BOOL success = [[NSWorkspace sharedWorkspace] openURLs:@[ url ]
+                                 withAppBundleIdentifier:nil
+                                                 options:launch_options
+                          additionalEventParamDescriptor:nil
+                                       launchIdentifiers:NULL];
+
+  return success ? "" : "Failed to open path";
+}
+
 }  // namespace
 
 namespace platform_util {
@@ -75,28 +92,13 @@ void ShowItemInFolder(const base::FilePath& path) {
   }
 }
 
-bool OpenItem(const base::FilePath& full_path) {
-  DCHECK([NSThread isMainThread]);
-  NSString* path_string = base::SysUTF8ToNSString(full_path.value());
-  if (!path_string)
-    return false;
-
-  NSURL* url = [NSURL fileURLWithPath:path_string];
-  if (!url)
-    return false;
-
-  const NSWorkspaceLaunchOptions launch_options =
-      NSWorkspaceLaunchAsync | NSWorkspaceLaunchWithErrorPresentation;
-  return [[NSWorkspace sharedWorkspace] openURLs:@[ url ]
-                         withAppBundleIdentifier:nil
-                                         options:launch_options
-                  additionalEventParamDescriptor:nil
-                               launchIdentifiers:NULL];
+void OpenPath(const base::FilePath& full_path, OpenCallback callback) {
+  std::move(callback).Run(OpenPathOnThread(full_path));
 }
 
 void OpenExternal(const GURL& url,
                   const OpenExternalOptions& options,
-                  OpenExternalCallback callback) {
+                  OpenCallback callback) {
   DCHECK([NSThread isMainThread]);
   NSURL* ns_url = net::NSURLWithGURL(url);
   if (!ns_url) {
@@ -105,7 +107,7 @@ void OpenExternal(const GURL& url,
   }
 
   bool activate = options.activate;
-  __block OpenExternalCallback c = std::move(callback);
+  __block OpenCallback c = std::move(callback);
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),
                  ^{
                    __block std::string error = OpenURL(ns_url, activate);

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -1055,8 +1055,11 @@ app.on('ready', () => {
 // https://github.com/atom/electron/blob/master/docs/api/shell.md
 
 shell.showItemInFolder('/home/user/Desktop/test.txt')
-shell.openItem('/home/user/Desktop/test.txt')
 shell.moveItemToTrash('/home/user/Desktop/test.txt')
+
+shell.openPath('/home/user/Desktop/test.txt').then(err => {
+  if (err) console.log(err)
+})
 
 shell.openExternal('https://github.com', {
   activate: false


### PR DESCRIPTION
#### Description of Change

BREAKING CHANGE.

Resolves https://github.com/electron/electron/issues/20606.
Resolves https://github.com/electron/electron/issues/7210.

Implements an asynchronous version of `shell.openItem(path)` as a new method `shell.openPath(path)`.

Adheres to [this spec](https://github.com/electron/governance/blob/master/wg-api/RFCs/shell-openitem.md).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Split `shell.openItem(path)` into synchronous and asynchronous methods.