### PR TITLE
fix: explicitly cancel redirects when mode is 'error'

### DIFF
--- a/shell/browser/api/atom_api_url_request_ns.cc
+++ b/shell/browser/api/atom_api_url_request_ns.cc
@@ -427,6 +427,7 @@ void URLRequestNS::OnRedirect(
 
   switch (redirect_mode_) {
     case network::mojom::RedirectMode::kError:
+      Cancel();
       EmitError(
           EventType::kRequest,
           "Request cannot follow redirect with the current redirect mode");


### PR DESCRIPTION
#### Description of Change
Without this change, when the redirect mode is 'error' for a net request, an error is thrown but the request continues and follows the redirect.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `net` requests with redirection mode 'error' could incorrectly follow a redirect.