### PR TITLE
fix: properly free remote objects (7-0-x)

### DIFF
--- a/shell/common/api/remote_object_freer.cc
+++ b/shell/common/api/remote_object_freer.cc
@@ -8,7 +8,9 @@
 #include "base/values.h"
 #include "content/public/renderer/render_frame.h"
 #include "electron/shell/common/api/api.mojom.h"
-#include "third_party/blink/public/common/associated_interfaces/associated_interface_provider.h"
+#include "electron/shell/common/native_mate_converters/blink_converter.h"
+#include "electron/shell/common/native_mate_converters/value_converter.h"
+#include "services/service_manager/public/cpp/interface_provider.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 
 using blink::WebLocalFrame;
@@ -76,8 +78,8 @@ void RemoteObjectFreer::RunDestructor() {
   if (ref_mapper_[context_id_].empty())
     ref_mapper_.erase(context_id_);
 
-  mojom::ElectronBrowserAssociatedPtr electron_ptr;
-  render_frame->GetRemoteAssociatedInterfaces()->GetInterface(
+  mojom::ElectronBrowserPtr electron_ptr;
+  render_frame->GetRemoteInterfaces()->GetInterface(
       mojo::MakeRequest(&electron_ptr));
   electron_ptr->Message(true, channel, args.Clone());
 }

--- a/shell/common/api/remote_object_freer.cc
+++ b/shell/common/api/remote_object_freer.cc
@@ -8,8 +8,6 @@
 #include "base/values.h"
 #include "content/public/renderer/render_frame.h"
 #include "electron/shell/common/api/api.mojom.h"
-#include "electron/shell/common/native_mate_converters/blink_converter.h"
-#include "electron/shell/common/native_mate_converters/value_converter.h"
 #include "services/service_manager/public/cpp/interface_provider.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 


### PR DESCRIPTION
Backport of #20671. See that change for details.

Notes: Fixed an issue where objects referenced by `remote` could sometimes not be correctly freed.