### PR TITLE
fix: properly free remote objects (6-1-x)

### DIFF
--- a/atom/common/api/remote_object_freer.cc
+++ b/atom/common/api/remote_object_freer.cc
@@ -9,7 +9,7 @@
 #include "base/values.h"
 #include "content/public/renderer/render_frame.h"
 #include "electron/atom/common/api/api.mojom.h"
-#include "third_party/blink/public/common/associated_interfaces/associated_interface_provider.h"
+#include "services/service_manager/public/cpp/interface_provider.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 
 using blink::WebLocalFrame;
@@ -77,8 +77,8 @@ void RemoteObjectFreer::RunDestructor() {
   if (ref_mapper_[context_id_].empty())
     ref_mapper_.erase(context_id_);
 
-  mojom::ElectronBrowserAssociatedPtr electron_ptr;
-  render_frame->GetRemoteAssociatedInterfaces()->GetInterface(
+  mojom::ElectronBrowserPtr electron_ptr;
+  render_frame->GetRemoteInterfaces()->GetInterface(
       mojo::MakeRequest(&electron_ptr));
   electron_ptr->Message(true, channel, args.Clone());
 }


### PR DESCRIPTION
Backport of #20671. See that change for details.

Notes: Fixed an issue where objects referenced by `remote` could sometimes not be correctly freed.