### PR TITLE
chore: remove native_mate (Part 10)

### DIFF
--- a/shell/browser/api/atom_api_app.cc
+++ b/shell/browser/api/atom_api_app.cc
@@ -28,9 +28,7 @@
 #include "content/public/browser/gpu_data_manager.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/common/content_switches.h"
-#include "gin/arguments.h"
 #include "media/audio/audio_manager.h"
-#include "native_mate/object_template_builder_deprecated.h"
 #include "net/ssl/client_cert_identity.h"
 #include "net/ssl/ssl_cert_request_info.h"
 #include "services/service_manager/sandbox/switches.h"
@@ -45,15 +43,14 @@
 #include "shell/browser/relauncher.h"
 #include "shell/common/application_info.h"
 #include "shell/common/atom_command_line.h"
+#include "shell/common/gin_converters/callback_converter.h"
+#include "shell/common/gin_converters/file_path_converter.h"
+#include "shell/common/gin_converters/gurl_converter.h"
+#include "shell/common/gin_converters/image_converter.h"
+#include "shell/common/gin_converters/net_converter.h"
+#include "shell/common/gin_converters/value_converter_gin_adapter.h"
 #include "shell/common/gin_helper/dictionary.h"
-#include "shell/common/native_mate_converters/callback_converter_deprecated.h"
-#include "shell/common/native_mate_converters/file_path_converter.h"
-#include "shell/common/native_mate_converters/gurl_converter.h"
-#include "shell/common/native_mate_converters/image_converter.h"
-#include "shell/common/native_mate_converters/net_converter.h"
-#include "shell/common/native_mate_converters/network_converter.h"
-#include "shell/common/native_mate_converters/once_callback.h"
-#include "shell/common/native_mate_converters/value_converter.h"
+#include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/options_switches.h"
 #include "ui/gfx/image/image.h"
@@ -70,7 +67,7 @@
 
 using electron::Browser;
 
-namespace mate {
+namespace gin {
 
 #if defined(OS_WIN)
 template <>
@@ -79,15 +76,15 @@ struct Converter<electron::ProcessIntegrityLevel> {
                                    electron::ProcessIntegrityLevel value) {
     switch (value) {
       case electron::ProcessIntegrityLevel::Untrusted:
-        return mate::StringToV8(isolate, "untrusted");
+        return StringToV8(isolate, "untrusted");
       case electron::ProcessIntegrityLevel::Low:
-        return mate::StringToV8(isolate, "low");
+        return StringToV8(isolate, "low");
       case electron::ProcessIntegrityLevel::Medium:
-        return mate::StringToV8(isolate, "medium");
+        return StringToV8(isolate, "medium");
       case electron::ProcessIntegrityLevel::High:
-        return mate::StringToV8(isolate, "high");
+        return StringToV8(isolate, "high");
       default:
-        return mate::StringToV8(isolate, "unknown");
+        return StringToV8(isolate, "unknown");
     }
   }
 };
@@ -97,7 +94,7 @@ struct Converter<Browser::UserTask> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      Browser::UserTask* out) {
-    mate::Dictionary dict;
+    gin_helper::Dictionary dict;
     if (!ConvertFromV8(isolate, val, &dict))
       return false;
     if (!dict.Get("program", &(out->program)) ||
@@ -154,7 +151,7 @@ struct Converter<JumpListItem::Type> {
         item_type = "file";
         break;
     }
-    return mate::ConvertToV8(isolate, item_type);
+    return gin::ConvertToV8(isolate, item_type);
   }
 };
 
@@ -163,7 +160,7 @@ struct Converter<JumpListItem> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      JumpListItem* out) {
-    mate::Dictionary dict;
+    gin_helper::Dictionary dict;
     if (!ConvertFromV8(isolate, val, &dict))
       return false;
 
@@ -198,7 +195,7 @@ struct Converter<JumpListItem> {
 
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const JumpListItem& val) {
-    mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
+    gin_helper::Dictionary dict = gin::Dictionary::CreateEmpty(isolate);
     dict.Set("type", val.type);
 
     switch (val.type) {
@@ -266,7 +263,7 @@ struct Converter<JumpListCategory::Type> {
         category_type = "custom";
         break;
     }
-    return mate::ConvertToV8(isolate, category_type);
+    return gin::ConvertToV8(isolate, category_type);
   }
 };
 
@@ -275,7 +272,7 @@ struct Converter<JumpListCategory> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      JumpListCategory* out) {
-    mate::Dictionary dict;
+    gin_helper::Dictionary dict;
     if (!ConvertFromV8(isolate, val, &dict))
       return false;
 
@@ -339,7 +336,7 @@ struct Converter<Browser::LoginItemSettings> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      Browser::LoginItemSettings* out) {
-    mate::Dictionary dict;
+    gin_helper::Dictionary dict;
     if (!ConvertFromV8(isolate, val, &dict))
       return false;
 
@@ -352,7 +349,7 @@ struct Converter<Browser::LoginItemSettings> {
 
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    Browser::LoginItemSettings val) {
-    mate::Dictionary dict = mate::Dictionary::CreateEmpty(isolate);
+    gin_helper::Dictionary dict = gin::Dictionary::CreateEmpty(isolate);
     dict.Set("openAtLogin", val.open_at_login);
     dict.Set("openAsHidden", val.open_as_hidden);
     dict.Set("restoreState", val.restore_state);
@@ -376,7 +373,7 @@ struct Converter<content::CertificateRequestResultType> {
   }
 };
 
-}  // namespace mate
+}  // namespace gin
 
 namespace electron {
 
@@ -460,7 +457,7 @@ void OnClientCertificateSelected(
     v8::Isolate* isolate,
     std::shared_ptr<content::ClientCertificateDelegate> delegate,
     std::shared_ptr<net::ClientCertIdentityList> identities,
-    mate::Arguments* args) {
+    gin_helper::Arguments* args) {
   if (args->Length() == 2) {
     delegate->ContinueWithCertificate(nullptr, nullptr);
     return;
@@ -473,8 +470,8 @@ void OnClientCertificateSelected(
     return;
   }
 
-  mate::Dictionary cert_data;
-  if (!mate::ConvertFromV8(isolate, val, &cert_data)) {
+  gin_helper::Dictionary cert_data;
+  if (!gin::ConvertFromV8(isolate, val, &cert_data)) {
     args->ThrowError("Must pass valid certificate object.");
     return;
   }
@@ -499,7 +496,7 @@ void OnClientCertificateSelected(
 }
 
 void PassLoginInformation(scoped_refptr<LoginHandler> login_handler,
-                          mate::Arguments* args) {
+                          gin_helper::Arguments* args) {
   base::string16 username, password;
   if (args->GetNext(&username) && args->GetNext(&password))
     login_handler->Login(username, password);
@@ -537,7 +534,7 @@ int ImportIntoCertStore(CertificateManagerModel* model,
 
 void OnIconDataAvailable(util::Promise<gfx::Image> promise, gfx::Image icon) {
   if (!icon.IsEmpty()) {
-    promise.Resolve(icon);
+    promise.ResolveWithGin(icon);
   } else {
     promise.RejectWithErrorMessage("Failed to get file icon.");
   }
@@ -1001,13 +998,13 @@ void App::ReleaseSingleInstanceLock() {
   }
 }
 
-bool App::Relaunch(mate::Arguments* js_args) {
+bool App::Relaunch(gin_helper::Arguments* js_args) {
   // Parse parameters.
   bool override_argv = false;
   base::FilePath exec_path;
   relauncher::StringVector args;
 
-  mate::Dictionary options;
+  gin_helper::Dictionary options;
   if (js_args->GetNext(&options)) {
     if (options.Get("execPath", &exec_path) | options.Get("args", &args))
       override_argv = true;
@@ -1078,7 +1075,8 @@ void App::SetAccessibilitySupportEnabled(gin_helper::ErrorThrower thrower,
   Browser::Get()->OnAccessibilitySupportChanged();
 }
 
-Browser::LoginItemSettings App::GetLoginItemSettings(mate::Arguments* args) {
+Browser::LoginItemSettings App::GetLoginItemSettings(
+    gin_helper::Arguments* args) {
   Browser::LoginItemSettings options;
   args->GetNext(&options);
   return Browser::Get()->GetLoginItemSettings(options);
@@ -1127,18 +1125,18 @@ v8::Local<v8::Value> App::GetJumpListSettings() {
     LOG(ERROR) << "Failed to begin Jump List transaction.";
   }
 
-  auto dict = mate::Dictionary::CreateEmpty(isolate());
+  gin_helper::Dictionary dict = gin::Dictionary::CreateEmpty(isolate());
   dict.Set("minItems", min_items);
-  dict.Set("removedItems", mate::ConvertToV8(isolate(), removed_items));
+  dict.Set("removedItems", gin::ConvertToV8(isolate(), removed_items));
   return dict.GetHandle();
 }
 
 JumpListResult App::SetJumpList(v8::Local<v8::Value> val,
-                                mate::Arguments* args) {
+                                gin_helper::Arguments* args) {
   std::vector<JumpListCategory> categories;
   bool delete_jump_list = val->IsNull();
   if (!delete_jump_list &&
-      !mate::ConvertFromV8(args->isolate(), val, &categories)) {
+      !gin::ConvertFromV8(args->isolate(), val, &categories)) {
     args->ThrowError("Argument must be null or an array of categories");
     return JumpListResult::ARGUMENT_ERROR;
   }
@@ -1171,13 +1169,13 @@ JumpListResult App::SetJumpList(v8::Local<v8::Value> val,
 #endif  // defined(OS_WIN)
 
 v8::Local<v8::Promise> App::GetFileIcon(const base::FilePath& path,
-                                        mate::Arguments* args) {
+                                        gin_helper::Arguments* args) {
   util::Promise<gfx::Image> promise(isolate());
   v8::Local<v8::Promise> handle = promise.GetHandle();
   base::FilePath normalized_path = path.NormalizePathSeparators();
 
   IconLoader::IconSize icon_size;
-  mate::Dictionary options;
+  gin_helper::Dictionary options;
   if (!args->GetNext(&options)) {
     icon_size = IconLoader::IconSize::NORMAL;
   } else {
@@ -1190,7 +1188,7 @@ v8::Local<v8::Promise> App::GetFileIcon(const base::FilePath& path,
   gfx::Image* icon =
       icon_manager->LookupIconFromFilepath(normalized_path, icon_size);
   if (icon) {
-    promise.Resolve(*icon);
+    promise.ResolveWithGin(*icon);
   } else {
     icon_manager->LoadIcon(
         normalized_path, icon_size,
@@ -1200,14 +1198,14 @@ v8::Local<v8::Promise> App::GetFileIcon(const base::FilePath& path,
   return handle;
 }
 
-std::vector<mate::Dictionary> App::GetAppMetrics(v8::Isolate* isolate) {
-  std::vector<mate::Dictionary> result;
+std::vector<gin_helper::Dictionary> App::GetAppMetrics(v8::Isolate* isolate) {
+  std::vector<gin_helper::Dictionary> result;
   result.reserve(app_metrics_.size());
   int processor_count = base::SysInfo::NumberOfProcessors();
 
   for (const auto& process_metric : app_metrics_) {
-    mate::Dictionary pid_dict = mate::Dictionary::CreateEmpty(isolate);
-    mate::Dictionary cpu_dict = mate::Dictionary::CreateEmpty(isolate);
+    gin_helper::Dictionary pid_dict = gin::Dictionary::CreateEmpty(isolate);
+    gin_helper::Dictionary cpu_dict = gin::Dictionary::CreateEmpty(isolate);
 
     // TODO(zcbenz): Just call SetHidden when this file is converted to gin.
     gin_helper::Dictionary(isolate, pid_dict.GetHandle())
@@ -1240,7 +1238,7 @@ std::vector<mate::Dictionary> App::GetAppMetrics(v8::Isolate* isolate) {
 #if !defined(OS_LINUX)
     auto memory_info = process_metric.second->GetMemoryInfo();
 
-    mate::Dictionary memory_dict = mate::Dictionary::CreateEmpty(isolate);
+    gin_helper::Dictionary memory_dict = gin::Dictionary::CreateEmpty(isolate);
     // TODO(zcbenz): Just call SetHidden when this file is converted to gin.
     gin_helper::Dictionary(isolate, memory_dict.GetHandle())
         .SetHidden("simple", true);
@@ -1276,7 +1274,7 @@ std::vector<mate::Dictionary> App::GetAppMetrics(v8::Isolate* isolate) {
 v8::Local<v8::Value> App::GetGPUFeatureStatus(v8::Isolate* isolate) {
   auto status = content::GetFeatureStatus();
   base::DictionaryValue temp;
-  return mate::ConvertToV8(isolate, status ? *status : temp);
+  return gin::ConvertToV8(isolate, status ? *status : temp);
 }
 
 v8::Local<v8::Promise> App::GetGPUInfo(v8::Isolate* isolate,
@@ -1352,16 +1350,15 @@ bool App::CanBrowserClientUseCustomSiteInstance() {
 
 #if defined(OS_MACOSX)
 bool App::MoveToApplicationsFolder(gin_helper::ErrorThrower thrower,
-                                   mate::Arguments* args) {
-  gin::Arguments gin_args(args->info());
-  return AtomBundleMover::Move(thrower, &gin_args);
+                                   gin::Arguments* args) {
+  return AtomBundleMover::Move(thrower, args);
 }
 
 bool App::IsInApplicationsFolder() {
   return AtomBundleMover::IsCurrentAppInApplicationsFolder();
 }
 
-int DockBounce(mate::Arguments* args) {
+int DockBounce(gin_helper::Arguments* args) {
   int request_id = -1;
   std::string type = "informational";
   args->GetNext(&type);
@@ -1382,7 +1379,7 @@ v8::Local<v8::Value> App::GetDockAPI(v8::Isolate* isolate) {
     // Initialize the Dock API, the methods are bound to "dock" which exists
     // for the lifetime of "app"
     auto browser = base::Unretained(Browser::Get());
-    mate::Dictionary dock_obj = mate::Dictionary::CreateEmpty(isolate);
+    gin_helper::Dictionary dock_obj = gin::Dictionary::CreateEmpty(isolate);
     dock_obj.SetMethod("bounce", &DockBounce);
     dock_obj.SetMethod(
         "cancelBounce",
@@ -1411,16 +1408,16 @@ v8::Local<v8::Value> App::GetDockAPI(v8::Isolate* isolate) {
 #endif
 
 // static
-mate::Handle<App> App::Create(v8::Isolate* isolate) {
-  return mate::CreateHandle(isolate, new App(isolate));
+gin::Handle<App> App::Create(v8::Isolate* isolate) {
+  return gin::CreateHandle(isolate, new App(isolate));
 }
 
 // static
 void App::BuildPrototype(v8::Isolate* isolate,
                          v8::Local<v8::FunctionTemplate> prototype) {
-  prototype->SetClassName(mate::StringToV8(isolate, "App"));
+  prototype->SetClassName(gin::StringToV8(isolate, "App"));
   auto browser = base::Unretained(Browser::Get());
-  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
+  gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("quit", base::BindRepeating(&Browser::Quit, browser))
       .SetMethod("exit", base::BindRepeating(&Browser::Exit, browser))
       .SetMethod("focus", base::BindRepeating(&Browser::Focus, browser))
@@ -1552,7 +1549,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  mate::Dictionary dict(isolate, exports);
+  gin_helper::Dictionary dict(isolate, exports);
   dict.Set("App", electron::api::App::GetConstructor(isolate)
                       ->GetFunction(context)
                       .ToLocalChecked());

--- a/shell/browser/api/atom_api_app.h
+++ b/shell/browser/api/atom_api_app.h
@@ -17,17 +17,18 @@
 #include "content/public/browser/browser_child_process_observer.h"
 #include "content/public/browser/gpu_data_manager_observer.h"
 #include "content/public/browser/render_process_host.h"
-#include "native_mate/dictionary.h"
-#include "native_mate/handle.h"
+#include "gin/handle.h"
+#include "native_mate/wrappable.h"
 #include "net/base/completion_once_callback.h"
 #include "net/base/completion_repeating_callback.h"
 #include "net/ssl/client_cert_identity.h"
-#include "shell/browser/api/event_emitter_deprecated.h"
 #include "shell/browser/api/process_metric.h"
 #include "shell/browser/atom_browser_client.h"
 #include "shell/browser/browser.h"
 #include "shell/browser/browser_observer.h"
+#include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/error_thrower.h"
+#include "shell/common/gin_helper/event_emitter.h"
 #include "shell/common/promise_util.h"
 
 #if defined(USE_NSS_CERTS)
@@ -38,10 +39,6 @@ namespace base {
 class FilePath;
 }
 
-namespace mate {
-class Arguments;
-}  // namespace mate
-
 namespace electron {
 
 #if defined(OS_WIN)
@@ -51,7 +48,7 @@ enum class JumpListResult : int;
 namespace api {
 
 class App : public AtomBrowserClient::Delegate,
-            public mate::EventEmitter<App>,
+            public gin_helper::EventEmitter<mate::Wrappable<App>>,
             public BrowserObserver,
             public content::GpuDataManagerObserver,
             public content::BrowserChildProcessObserver {
@@ -59,7 +56,7 @@ class App : public AtomBrowserClient::Delegate,
   using FileIconCallback =
       base::RepeatingCallback<void(v8::Local<v8::Value>, const gfx::Image&)>;
 
-  static mate::Handle<App> Create(v8::Isolate* isolate);
+  static gin::Handle<App> Create(v8::Isolate* isolate);
 
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype);
@@ -182,21 +179,21 @@ class App : public AtomBrowserClient::Delegate,
   bool HasSingleInstanceLock() const;
   bool RequestSingleInstanceLock();
   void ReleaseSingleInstanceLock();
-  bool Relaunch(mate::Arguments* args);
+  bool Relaunch(gin_helper::Arguments* args);
   void DisableHardwareAcceleration(gin_helper::ErrorThrower thrower);
   void DisableDomainBlockingFor3DAPIs(gin_helper::ErrorThrower thrower);
   bool IsAccessibilitySupportEnabled();
   void SetAccessibilitySupportEnabled(gin_helper::ErrorThrower thrower,
                                       bool enabled);
-  Browser::LoginItemSettings GetLoginItemSettings(mate::Arguments* args);
+  Browser::LoginItemSettings GetLoginItemSettings(gin_helper::Arguments* args);
 #if defined(USE_NSS_CERTS)
   void ImportCertificate(const base::DictionaryValue& options,
                          net::CompletionRepeatingCallback callback);
 #endif
   v8::Local<v8::Promise> GetFileIcon(const base::FilePath& path,
-                                     mate::Arguments* args);
+                                     gin_helper::Arguments* args);
 
-  std::vector<mate::Dictionary> GetAppMetrics(v8::Isolate* isolate);
+  std::vector<gin_helper::Dictionary> GetAppMetrics(v8::Isolate* isolate);
   v8::Local<v8::Value> GetGPUFeatureStatus(v8::Isolate* isolate);
   v8::Local<v8::Promise> GetGPUInfo(v8::Isolate* isolate,
                                     const std::string& info_type);
@@ -207,8 +204,7 @@ class App : public AtomBrowserClient::Delegate,
   bool CanBrowserClientUseCustomSiteInstance();
 
 #if defined(OS_MACOSX)
-  bool MoveToApplicationsFolder(gin_helper::ErrorThrower,
-                                mate::Arguments* args);
+  bool MoveToApplicationsFolder(gin_helper::ErrorThrower, gin::Arguments* args);
   bool IsInApplicationsFolder();
   v8::Local<v8::Value> GetDockAPI(v8::Isolate* isolate);
   v8::Global<v8::Value> dock_;
@@ -216,7 +212,7 @@ class App : public AtomBrowserClient::Delegate,
 
 #if defined(MAS_BUILD)
   base::RepeatingCallback<void()> StartAccessingSecurityScopedResource(
-      mate::Arguments* args);
+      gin_helper::Arguments* args);
 #endif
 
 #if defined(OS_WIN)
@@ -224,7 +220,8 @@ class App : public AtomBrowserClient::Delegate,
   v8::Local<v8::Value> GetJumpListSettings();
 
   // Set or remove a custom Jump List for the application.
-  JumpListResult SetJumpList(v8::Local<v8::Value> val, mate::Arguments* args);
+  JumpListResult SetJumpList(v8::Local<v8::Value> val,
+                             gin_helper::Arguments* args);
 #endif  // defined(OS_WIN)
 
   std::unique_ptr<ProcessSingleton> process_singleton_;

--- a/shell/browser/api/atom_api_app_mac.mm
+++ b/shell/browser/api/atom_api_app_mac.mm
@@ -5,7 +5,6 @@
 #include "base/path_service.h"
 #include "shell/browser/api/atom_api_app.h"
 #include "shell/browser/atom_paths.h"
-#include "shell/common/native_mate_converters/file_path_converter.h"
 
 #import <Cocoa/Cocoa.h>
 

--- a/shell/browser/api/atom_api_app_mas.mm
+++ b/shell/browser/api/atom_api_app_mas.mm
@@ -22,7 +22,7 @@ void OnStopAccessingSecurityScopedResource(NSURL* bookmarkUrl) {
 
 // Get base64 encoded NSData, create a bookmark for it and start accessing it.
 base::RepeatingCallback<void()> App::StartAccessingSecurityScopedResource(
-    mate::Arguments* args) {
+    gin_helper::Arguments* args) {
   std::string data;
   args->GetNext(&data);
   NSString* base64str = base::SysUTF8ToNSString(data);

--- a/shell/browser/api/atom_api_event.cc
+++ b/shell/browser/api/atom_api_event.cc
@@ -2,28 +2,25 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "native_mate/dictionary.h"
-#include "shell/browser/api/event_emitter_deprecated.h"
+#include "shell/browser/api/event.h"
+#include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/event_emitter.h"
 #include "shell/common/node_includes.h"
 
 namespace {
 
 v8::Local<v8::Object> CreateWithSender(v8::Isolate* isolate,
                                        v8::Local<v8::Object> sender) {
-  return mate::internal::CreateJSEvent(isolate, sender, nullptr, base::nullopt);
-}
-
-v8::Local<v8::Object> CreateEmpty(v8::Isolate* isolate) {
-  return mate::internal::CreateEmptyJSEvent(isolate);
+  return gin_helper::internal::CreateEvent(isolate, sender);
 }
 
 void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Value> unused,
                 v8::Local<v8::Context> context,
                 void* priv) {
-  mate::Dictionary dict(context->GetIsolate(), exports);
+  gin_helper::Dictionary dict(context->GetIsolate(), exports);
   dict.SetMethod("createWithSender", &CreateWithSender);
-  dict.SetMethod("createEmpty", &CreateEmpty);
+  dict.SetMethod("createEmpty", &mate::Event::Create);
 }
 
 }  // namespace

--- a/shell/browser/api/atom_api_native_theme.h
+++ b/shell/browser/api/atom_api_native_theme.h
@@ -5,7 +5,8 @@
 #ifndef SHELL_BROWSER_API_ATOM_API_NATIVE_THEME_H_
 #define SHELL_BROWSER_API_ATOM_API_NATIVE_THEME_H_
 
-#include "shell/browser/api/event_emitter_deprecated.h"
+#include "native_mate/wrappable.h"
+#include "shell/common/gin_helper/event_emitter.h"
 #include "ui/native_theme/native_theme.h"
 #include "ui/native_theme/native_theme_observer.h"
 
@@ -13,8 +14,9 @@ namespace electron {
 
 namespace api {
 
-class NativeTheme : public mate::EventEmitter<NativeTheme>,
-                    public ui::NativeThemeObserver {
+class NativeTheme
+    : public gin_helper::EventEmitter<mate::Wrappable<NativeTheme>>,
+      public ui::NativeThemeObserver {
  public:
   static v8::Local<v8::Value> Create(v8::Isolate* isolate);
 

--- a/shell/browser/api/atom_api_net.cc
+++ b/shell/browser/api/atom_api_net.cc
@@ -4,10 +4,11 @@
 
 #include "shell/browser/api/atom_api_net.h"
 
-#include "native_mate/dictionary.h"
-#include "native_mate/handle.h"
+#include "gin/handle.h"
 #include "services/network/public/cpp/features.h"
 #include "shell/browser/api/atom_api_url_request.h"
+#include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/object_template_builder.h"
 
 #include "shell/common/node_includes.h"
 
@@ -23,14 +24,14 @@ Net::~Net() = default;
 
 // static
 v8::Local<v8::Value> Net::Create(v8::Isolate* isolate) {
-  return mate::CreateHandle(isolate, new Net(isolate)).ToV8();
+  return gin::CreateHandle(isolate, new Net(isolate)).ToV8();
 }
 
 // static
 void Net::BuildPrototype(v8::Isolate* isolate,
                          v8::Local<v8::FunctionTemplate> prototype) {
-  prototype->SetClassName(mate::StringToV8(isolate, "Net"));
-  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
+  prototype->SetClassName(gin::StringToV8(isolate, "Net"));
+  gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetProperty("URLRequest", &Net::URLRequest);
 }
 
@@ -58,7 +59,7 @@ void Initialize(v8::Local<v8::Object> exports,
 
   URLRequest::SetConstructor(isolate, base::BindRepeating(URLRequest::New));
 
-  mate::Dictionary dict(isolate, exports);
+  gin_helper::Dictionary dict(isolate, exports);
   dict.Set("net", Net::Create(isolate));
   dict.Set("Net",
            Net::GetConstructor(isolate)->GetFunction(context).ToLocalChecked());

--- a/shell/browser/api/atom_api_net.h
+++ b/shell/browser/api/atom_api_net.h
@@ -5,13 +5,13 @@
 #ifndef SHELL_BROWSER_API_ATOM_API_NET_H_
 #define SHELL_BROWSER_API_ATOM_API_NET_H_
 
-#include "shell/browser/api/event_emitter_deprecated.h"
+#include "native_mate/wrappable.h"
 
 namespace electron {
 
 namespace api {
 
-class Net : public mate::EventEmitter<Net> {
+class Net : public mate::Wrappable<Net> {
  public:
   static v8::Local<v8::Value> Create(v8::Isolate* isolate);
 

--- a/shell/browser/api/atom_api_system_preferences.cc
+++ b/shell/browser/api/atom_api_system_preferences.cc
@@ -4,10 +4,10 @@
 
 #include "shell/browser/api/atom_api_system_preferences.h"
 
-#include "native_mate/dictionary.h"
+#include "shell/common/gin_converters/callback_converter.h"
+#include "shell/common/gin_converters/value_converter_gin_adapter.h"
 #include "shell/common/gin_helper/dictionary.h"
-#include "shell/common/native_mate_converters/callback_converter_deprecated.h"
-#include "shell/common/native_mate_converters/value_converter.h"
+#include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
 #include "ui/gfx/animation/animation.h"
 #include "ui/gfx/color_utils.h"
@@ -58,17 +58,16 @@ v8::Local<v8::Value> SystemPreferences::GetAnimationSettings(
 }
 
 // static
-mate::Handle<SystemPreferences> SystemPreferences::Create(
-    v8::Isolate* isolate) {
-  return mate::CreateHandle(isolate, new SystemPreferences(isolate));
+gin::Handle<SystemPreferences> SystemPreferences::Create(v8::Isolate* isolate) {
+  return gin::CreateHandle(isolate, new SystemPreferences(isolate));
 }
 
 // static
 void SystemPreferences::BuildPrototype(
     v8::Isolate* isolate,
     v8::Local<v8::FunctionTemplate> prototype) {
-  prototype->SetClassName(mate::StringToV8(isolate, "SystemPreferences"));
-  mate::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
+  prototype->SetClassName(gin::StringToV8(isolate, "SystemPreferences"));
+  gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
 #if defined(OS_WIN) || defined(OS_MACOSX)
       .SetMethod("getColor", &SystemPreferences::GetColor)
       .SetMethod("getAccentColor", &SystemPreferences::GetAccentColor)
@@ -142,7 +141,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  mate::Dictionary dict(isolate, exports);
+  gin_helper::Dictionary dict(isolate, exports);
   dict.Set("systemPreferences", SystemPreferences::Create(isolate));
   dict.Set("SystemPreferences", SystemPreferences::GetConstructor(isolate)
                                     ->GetFunction(context)

--- a/shell/browser/api/atom_api_system_preferences.h
+++ b/shell/browser/api/atom_api_system_preferences.h
@@ -8,12 +8,10 @@
 #include <memory>
 #include <string>
 
-#include "base/callback.h"
-#include "base/values.h"
-#include "native_mate/handle.h"
-#include "shell/browser/api/event_emitter_deprecated.h"
+#include "gin/handle.h"
+#include "native_mate/wrappable.h"
 #include "shell/common/gin_helper/error_thrower.h"
-#include "shell/common/node_includes.h"
+#include "shell/common/gin_helper/event_emitter.h"
 #include "shell/common/promise_util.h"
 
 #if defined(OS_WIN)
@@ -38,15 +36,16 @@ enum NotificationCenterKind {
 };
 #endif
 
-class SystemPreferences : public mate::EventEmitter<SystemPreferences>
+class SystemPreferences
+    : public gin_helper::EventEmitter<mate::Wrappable<SystemPreferences>>
 #if defined(OS_WIN)
     ,
-                          public BrowserObserver,
-                          public gfx::SysColorChangeListener
+      public BrowserObserver,
+      public gfx::SysColorChangeListener
 #endif
 {
  public:
-  static mate::Handle<SystemPreferences> Create(v8::Isolate* isolate);
+  static gin::Handle<SystemPreferences> Create(v8::Isolate* isolate);
 
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype);
@@ -75,7 +74,7 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
 
   void PostNotification(const std::string& name,
                         const base::DictionaryValue& user_info,
-                        mate::Arguments* args);
+                        gin_helper::Arguments* args);
   int SubscribeNotification(const std::string& name,
                             const NotificationCallback& callback);
   void UnsubscribeNotification(int id);
@@ -91,10 +90,10 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
   void UnsubscribeWorkspaceNotification(int request_id);
   v8::Local<v8::Value> GetUserDefault(const std::string& name,
                                       const std::string& type);
-  void RegisterDefaults(mate::Arguments* args);
+  void RegisterDefaults(gin_helper::Arguments* args);
   void SetUserDefault(const std::string& name,
                       const std::string& type,
-                      mate::Arguments* args);
+                      gin_helper::Arguments* args);
   void RemoveUserDefault(const std::string& name);
   bool IsSwipeTrackingFromScrollEventsEnabled();
 
@@ -110,7 +109,7 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
   // TODO(codebytere): Write tests for these methods once we
   // are running tests on a Mojave machine
   std::string GetMediaAccessStatus(const std::string& media_type,
-                                   mate::Arguments* args);
+                                   gin_helper::Arguments* args);
   v8::Local<v8::Promise> AskForMediaAccess(v8::Isolate* isolate,
                                            const std::string& media_type);
 
@@ -118,7 +117,7 @@ class SystemPreferences : public mate::EventEmitter<SystemPreferences>
   // are running tests on a Mojave machine
   v8::Local<v8::Value> GetEffectiveAppearance(v8::Isolate* isolate);
   v8::Local<v8::Value> GetAppLevelAppearance(v8::Isolate* isolate);
-  void SetAppLevelAppearance(mate::Arguments* args);
+  void SetAppLevelAppearance(gin_helper::Arguments* args);
 #endif
   bool IsDarkMode();
   bool IsInvertedColorScheme();

--- a/shell/browser/api/atom_api_url_request.h
+++ b/shell/browser/api/atom_api_url_request.h
@@ -13,11 +13,12 @@
 #include "gin/arguments.h"
 #include "gin/dictionary.h"
 #include "mojo/public/cpp/system/data_pipe_producer.h"
+#include "native_mate/wrappable.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "services/network/public/cpp/simple_url_loader.h"
 #include "services/network/public/cpp/simple_url_loader_stream_consumer.h"
 #include "services/network/public/mojom/data_pipe_getter.mojom.h"
-#include "shell/browser/api/event_emitter_deprecated.h"
+#include "shell/common/gin_helper/event_emitter.h"
 
 namespace electron {
 
@@ -25,7 +26,7 @@ namespace api {
 
 class UploadDataPipeGetter;
 
-class URLRequest : public mate::EventEmitter<URLRequest>,
+class URLRequest : public gin_helper::EventEmitter<mate::Wrappable<URLRequest>>,
                    public network::SimpleURLLoaderStreamConsumer {
  public:
   static mate::WrappableBase* New(gin::Arguments* args);

--- a/shell/browser/api/event_emitter_deprecated.cc
+++ b/shell/browser/api/event_emitter_deprecated.cc
@@ -67,13 +67,6 @@ v8::Local<v8::Object> CreateJSEvent(
   return event;
 }
 
-v8::Local<v8::Object> CreateEmptyJSEvent(v8::Isolate* isolate) {
-  mate::Handle<mate::Event> native_event = mate::Event::Create(isolate);
-  v8::Local<v8::Object> event =
-      v8::Local<v8::Object>::Cast(native_event.ToV8());
-  return event;
-}
-
 v8::Local<v8::Object> CreateCustomEvent(v8::Isolate* isolate,
                                         v8::Local<v8::Object> object,
                                         v8::Local<v8::Object> custom_event) {

--- a/shell/browser/api/event_emitter_deprecated.h
+++ b/shell/browser/api/event_emitter_deprecated.h
@@ -28,7 +28,6 @@ v8::Local<v8::Object> CreateJSEvent(
     content::RenderFrameHost* sender,
     base::Optional<electron::mojom::ElectronBrowser::MessageSyncCallback>
         callback);
-v8::Local<v8::Object> CreateEmptyJSEvent(v8::Isolate* isolate);
 v8::Local<v8::Object> CreateCustomEvent(v8::Isolate* isolate,
                                         v8::Local<v8::Object> object,
                                         v8::Local<v8::Object> event);

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -22,6 +22,7 @@
 #include "shell/browser/native_window.h"
 #include "shell/browser/window_list.h"
 #include "shell/common/application_info.h"
+#include "shell/common/gin_helper/arguments.h"
 
 namespace electron {
 
@@ -57,7 +58,7 @@ void Browser::Quit() {
     electron::WindowList::CloseAllWindows();
 }
 
-void Browser::Exit(mate::Arguments* args) {
+void Browser::Exit(gin_helper::Arguments* args) {
   int code = 0;
   args->GetNext(&code);
 
@@ -165,14 +166,14 @@ void Browser::DidFinishLaunching(const base::DictionaryValue& launch_info) {
     observer.OnFinishLaunching(launch_info);
 }
 
-const util::Promise<void*>& Browser::WhenReady(v8::Isolate* isolate) {
+v8::Local<v8::Value> Browser::WhenReady(v8::Isolate* isolate) {
   if (!ready_promise_) {
     ready_promise_ = std::make_unique<util::Promise<void*>>(isolate);
     if (is_ready()) {
       ready_promise_->Resolve();
     }
   }
-  return *ready_promise_;
+  return ready_promise_->GetHandle();
 }
 
 void Browser::OnAccessibilitySupportChanged() {

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -14,7 +14,6 @@
 #include "base/observer_list.h"
 #include "base/strings/string16.h"
 #include "base/values.h"
-#include "native_mate/arguments.h"
 #include "shell/browser/browser_observer.h"
 #include "shell/browser/window_list_observer.h"
 #include "shell/common/promise_util.h"
@@ -30,6 +29,10 @@ class FilePath;
 
 namespace gfx {
 class Image;
+}
+
+namespace gin_helper {
+class Arguments;
 }
 
 namespace electron {
@@ -48,7 +51,7 @@ class Browser : public WindowListObserver {
   void Quit();
 
   // Exit the application immediately and set exit code.
-  void Exit(mate::Arguments* args);
+  void Exit(gin_helper::Arguments* args);
 
   // Cleanup everything and shutdown the application gracefully.
   void Shutdown();
@@ -79,15 +82,15 @@ class Browser : public WindowListObserver {
 
   // Remove the default protocol handler registry key
   bool RemoveAsDefaultProtocolClient(const std::string& protocol,
-                                     mate::Arguments* args);
+                                     gin_helper::Arguments* args);
 
   // Set as default handler for a protocol.
   bool SetAsDefaultProtocolClient(const std::string& protocol,
-                                  mate::Arguments* args);
+                                  gin_helper::Arguments* args);
 
   // Query the current state of default handler for a protocol.
   bool IsDefaultProtocolClient(const std::string& protocol,
-                               mate::Arguments* args);
+                               gin_helper::Arguments* args);
 
   // Set/Get the badge count.
   bool SetBadgeCount(int count);
@@ -123,7 +126,7 @@ class Browser : public WindowListObserver {
   // Creates an activity and sets it as the one currently in use.
   void SetUserActivity(const std::string& type,
                        const base::DictionaryValue& user_info,
-                       mate::Arguments* args);
+                       gin_helper::Arguments* args);
 
   // Returns the type name of the current user activity.
   std::string GetCurrentActivityType();
@@ -262,7 +265,7 @@ class Browser : public WindowListObserver {
   bool is_shutting_down() const { return is_shutdown_; }
   bool is_quiting() const { return is_quiting_; }
   bool is_ready() const { return is_ready_; }
-  const util::Promise<void*>& WhenReady(v8::Isolate* isolate);
+  v8::Local<v8::Value> WhenReady(v8::Isolate* isolate);
 
  protected:
   // Returns the version of application bundle or executable file.

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -76,12 +76,12 @@ void Browser::ClearRecentDocuments() {}
 void Browser::SetAppUserModelID(const base::string16& name) {}
 
 bool Browser::SetAsDefaultProtocolClient(const std::string& protocol,
-                                         mate::Arguments* args) {
+                                         gin_helper::Arguments* args) {
   return SetDefaultWebClient(protocol);
 }
 
 bool Browser::IsDefaultProtocolClient(const std::string& protocol,
-                                      mate::Arguments* args) {
+                                      gin_helper::Arguments* args) {
   std::unique_ptr<base::Environment> env(base::Environment::Create());
 
   if (protocol.empty())
@@ -109,7 +109,7 @@ bool Browser::IsDefaultProtocolClient(const std::string& protocol,
 
 // Todo implement
 bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
-                                            mate::Arguments* args) {
+                                            gin_helper::Arguments* args) {
   return false;
 }
 

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -20,6 +20,7 @@
 #include "shell/browser/native_window.h"
 #include "shell/browser/window_list.h"
 #include "shell/common/application_info.h"
+#include "shell/common/gin_helper/arguments.h"
 #include "shell/common/platform_util.h"
 #include "shell/common/promise_util.h"
 #include "ui/gfx/image/image.h"
@@ -58,7 +59,7 @@ void Browser::ClearRecentDocuments() {
 }
 
 bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
-                                            mate::Arguments* args) {
+                                            gin_helper::Arguments* args) {
   NSString* identifier = [base::mac::MainBundle() bundleIdentifier];
   if (!identifier)
     return false;
@@ -93,7 +94,7 @@ bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
 }
 
 bool Browser::SetAsDefaultProtocolClient(const std::string& protocol,
-                                         mate::Arguments* args) {
+                                         gin_helper::Arguments* args) {
   if (protocol.empty())
     return false;
 
@@ -108,7 +109,7 @@ bool Browser::SetAsDefaultProtocolClient(const std::string& protocol,
 }
 
 bool Browser::IsDefaultProtocolClient(const std::string& protocol,
-                                      mate::Arguments* args) {
+                                      gin_helper::Arguments* args) {
   if (protocol.empty())
     return false;
 
@@ -141,7 +142,7 @@ bool Browser::SetBadgeCount(int count) {
 
 void Browser::SetUserActivity(const std::string& type,
                               const base::DictionaryValue& user_info,
-                              mate::Arguments* args) {
+                              gin_helper::Arguments* args) {
   std::string url_string;
   args->GetNext(&url_string);
 

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -25,7 +25,7 @@
 #include "shell/browser/ui/message_box.h"
 #include "shell/browser/ui/win/jump_list.h"
 #include "shell/common/application_info.h"
-#include "shell/common/native_mate_converters/string16_converter.h"
+#include "shell/common/gin_helper/arguments.h"
 #include "shell/common/skia_util.h"
 #include "ui/events/keycodes/keyboard_code_conversion_win.h"
 
@@ -56,7 +56,7 @@ bool GetProcessExecPath(base::string16* exe) {
   return true;
 }
 
-bool GetProtocolLaunchPath(mate::Arguments* args, base::string16* exe) {
+bool GetProtocolLaunchPath(gin_helper::Arguments* args, base::string16* exe) {
   if (!args->GetNext(exe) && !GetProcessExecPath(exe)) {
     return false;
   }
@@ -153,7 +153,7 @@ bool Browser::SetUserTasks(const std::vector<UserTask>& tasks) {
 }
 
 bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
-                                            mate::Arguments* args) {
+                                            gin_helper::Arguments* args) {
   if (protocol.empty())
     return false;
 
@@ -215,7 +215,7 @@ bool Browser::RemoveAsDefaultProtocolClient(const std::string& protocol,
 }
 
 bool Browser::SetAsDefaultProtocolClient(const std::string& protocol,
-                                         mate::Arguments* args) {
+                                         gin_helper::Arguments* args) {
   // HKEY_CLASSES_ROOT
   //    $PROTOCOL
   //       (Default) = "URL:$NAME"
@@ -259,7 +259,7 @@ bool Browser::SetAsDefaultProtocolClient(const std::string& protocol,
 }
 
 bool Browser::IsDefaultProtocolClient(const std::string& protocol,
-                                      mate::Arguments* args) {
+                                      gin_helper::Arguments* args) {
   if (protocol.empty())
     return false;
 

--- a/shell/common/gin_converters/std_converter.h
+++ b/shell/common/gin_converters/std_converter.h
@@ -24,10 +24,18 @@ v8::Local<v8::Value> ConvertToV8(v8::Isolate* isolate, T&& input) {
 template <>
 struct Converter<unsigned long> {  // NOLINT(runtime/int)
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   unsigned long val);  // NOLINT(runtime/int)
+                                   unsigned long val) {  // NOLINT(runtime/int)
+    return v8::Integer::New(isolate, val);
+  }
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
-                     unsigned long* out);  // NOLINT(runtime/int)
+                     unsigned long* out) {  // NOLINT(runtime/int)
+    auto maybe = val->IntegerValue(isolate->GetCurrentContext());
+    if (maybe.IsNothing())
+      return false;
+    *out = maybe.FromJust();
+    return true;
+  }
 };
 #endif
 

--- a/shell/common/gin_helper/event_emitter.h
+++ b/shell/common/gin_helper/event_emitter.h
@@ -86,7 +86,8 @@ class EventEmitter : public Base {
     v8::Locker locker(isolate);
     v8::HandleScope handle_scope(isolate);
     auto context = isolate->GetCurrentContext();
-    EmitEvent(isolate, GetWrapper(), name, event, std::forward<Args>(args)...);
+    gin_helper::EmitEvent(isolate, GetWrapper(), name, event,
+                          std::forward<Args>(args)...);
     v8::Local<v8::Value> defaultPrevented;
     if (event->Get(context, gin::StringToV8(isolate, "defaultPrevented"))
             .ToLocal(&defaultPrevented)) {

--- a/shell/common/gin_helper/event_emitter.h
+++ b/shell/common/gin_helper/event_emitter.h
@@ -16,10 +16,10 @@ namespace gin_helper {
 
 namespace internal {
 
-v8::Local<v8::Object> CreateEventObject(v8::Isolate* isolate);
-v8::Local<v8::Object> CreateCustomEvent(v8::Isolate* isolate,
-                                        v8::Local<v8::Object> object,
-                                        v8::Local<v8::Object> event);
+v8::Local<v8::Object> CreateEvent(
+    v8::Isolate* isolate,
+    v8::Local<v8::Object> sender = v8::Local<v8::Object>(),
+    v8::Local<v8::Object> custom_event = v8::Local<v8::Object>());
 v8::Local<v8::Object> CreateEventFromFlags(v8::Isolate* isolate, int flags);
 
 }  // namespace internal
@@ -45,9 +45,9 @@ class EventEmitter : public Base {
   bool EmitCustomEvent(base::StringPiece name,
                        v8::Local<v8::Object> event,
                        Args&&... args) {
-    return EmitWithEvent(
-        name, internal::CreateCustomEvent(isolate(), GetWrapper(), event),
-        std::forward<Args>(args)...);
+    return EmitWithEvent(name,
+                         internal::CreateEvent(isolate(), GetWrapper(), event),
+                         std::forward<Args>(args)...);
   }
 
   // this.emit(name, new Event(flags), args...);
@@ -67,11 +67,7 @@ class EventEmitter : public Base {
     if (wrapper.IsEmpty()) {
       return false;
     }
-    v8::Local<v8::Object> event = internal::CreateEventObject(isolate());
-    event
-        ->Set(isolate()->GetCurrentContext(),
-              gin::StringToV8(isolate(), "sender"), wrapper)
-        .IsJust();
+    v8::Local<v8::Object> event = internal::CreateEvent(isolate(), wrapper);
     return EmitWithEvent(name, event, std::forward<Args>(args)...);
   }
 

--- a/shell/common/gin_helper/function_template.h
+++ b/shell/common/gin_helper/function_template.h
@@ -5,8 +5,11 @@
 #ifndef SHELL_COMMON_GIN_HELPER_FUNCTION_TEMPLATE_H_
 #define SHELL_COMMON_GIN_HELPER_FUNCTION_TEMPLATE_H_
 
+#include <utility>
+
 #include "base/bind.h"
 #include "base/callback.h"
+#include "base/optional.h"
 #include "gin/arguments.h"
 #include "shell/common/gin_helper/arguments.h"
 #include "shell/common/gin_helper/destroyable.h"
@@ -88,6 +91,19 @@ bool GetNextArgument(gin::Arguments* args,
   } else {
     return args->GetNext(result);
   }
+}
+
+// Support base::Optional as output, which always advances the counter no
+// matter whether the conversion succeeds.
+template <typename T>
+bool GetNextArgument(gin::Arguments* args,
+                     int create_flags,
+                     bool is_first,
+                     base::Optional<T>* result) {
+  T converted;
+  if (args->GetNext(&converted))
+    result->emplace(converted);
+  return true;
 }
 
 // For advanced use cases, we allow callers to request the unparsed Arguments

--- a/shell/common/gin_helper/function_template.h
+++ b/shell/common/gin_helper/function_template.h
@@ -93,16 +93,17 @@ bool GetNextArgument(gin::Arguments* args,
   }
 }
 
-// Support base::Optional as output, which always advances the counter no
-// matter whether the conversion succeeds.
+// Support base::Optional as output, which would be empty and do not throw error
+// when convertion to T fails.
 template <typename T>
 bool GetNextArgument(gin::Arguments* args,
                      int create_flags,
                      bool is_first,
                      base::Optional<T>* result) {
   T converted;
+  // Use gin::Arguments::GetNext which always advances |next| counter.
   if (args->GetNext(&converted))
-    result->emplace(converted);
+    result->emplace(std::move(converted));
   return true;
 }
 

--- a/shell/common/promise_util.h
+++ b/shell/common/promise_util.h
@@ -228,4 +228,16 @@ struct Converter<electron::util::Promise<T>> {
 
 }  // namespace mate
 
+namespace gin {
+
+template <typename T>
+struct Converter<electron::util::Promise<T>> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const electron::util::Promise<T>& val) {
+    return mate::ConvertToV8(isolate, val);
+  }
+};
+
+}  // namespace gin
+
 #endif  // SHELL_COMMON_PROMISE_UTIL_H_


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/16443.

This PR removes direct descendants of `mate::EventEmitter`.

The `TrackableObject` class and its descendants are stilling depending on `mate::EventEmitter`, and I'll remove the dependency in another PR.

#### Release Notes

Notes: no-notes