### PR TITLE
feat: webNavigation.onCommitted and browser.tabs.reload chrome extension apis added

### DIFF
--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -239,8 +239,6 @@ ipcMainInternal.handle('CHROME_TABS_RELOAD', async function (event, tabId, exten
   } else {
     contents.reload()
   }
-
-  return true
 })
 
 const getLanguage = () => {

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -226,6 +226,23 @@ ipcMainInternal.handle('CHROME_TABS_SEND_MESSAGE', async function (event, tabId,
   return ipcMainUtils.invokeInWebContents(contents, true, `CHROME_RUNTIME_ONMESSAGE_${extensionId}`, senderTabId, message)
 })
 
+ipcMainInternal.handle('CHROME_TABS_RELOAD', async function (event, tabId, extensionId, reloadProperties) {
+  const contents = webContents.fromId(tabId)
+
+  if (!contents) {
+    throw new Error(`Sending message to unknown tab ${tabId}`)
+  }
+  const shouldByPassCache = reloadProperties.bypassCache ? true : false;
+
+  if (shouldByPassCache) {
+    contents.reloadIgnoringCache();
+  } else {
+    contents.reload();
+  }
+
+  return true;
+})
+
 const getLanguage = () => {
   return app.getLocale().replace(/-.*$/, '').toLowerCase()
 }

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -232,15 +232,15 @@ ipcMainInternal.handle('CHROME_TABS_RELOAD', async function (event, tabId, exten
   if (!contents) {
     throw new Error(`Sending message to unknown tab ${tabId}`)
   }
-  const shouldByPassCache = reloadProperties.bypassCache ? true : false;
+  const shouldByPassCache = !!reloadProperties.bypassCache
 
   if (shouldByPassCache) {
-    contents.reloadIgnoringCache();
+    contents.reloadIgnoringCache()
   } else {
-    contents.reload();
+    contents.reload()
   }
 
-  return true;
+  return true
 })
 
 const getLanguage = () => {

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -142,6 +142,17 @@ const hookWebContentsEvents = function (webContents) {
     })
   })
 
+  webContents.on('did-start-loading', (event, url) => {
+    sendToBackgroundPages('CHROME_WEBNAVIGATION_ONCOMMITTED', {
+      frameId: 0,
+      parentFrameId: -1,
+      processId: webContents.getProcessId(),
+      tabId: tabId,
+      timeStamp: Date.now(),
+      url: url
+    })
+  })
+
   webContents.on('did-navigate', (event, url) => {
     sendToBackgroundPages('CHROME_WEBNAVIGATION_ONCOMPLETED', {
       frameId: 0,

--- a/lib/renderer/chrome-api.ts
+++ b/lib/renderer/chrome-api.ts
@@ -186,6 +186,15 @@ export function injectTo (extensionId: string, context: any) {
       ipcRendererInternal.invoke('CHROME_TABS_SEND_MESSAGE', tabId, extensionId, message).then(responseCallback)
     },
 
+    // https://developer.chrome.com/extensions/tabs#method-reload
+    reload (
+      tabId: number,
+      reloadProperties: Chrome.Tabs.reloadProperties,
+      responseCallback: Chrome.Tabs.SendMessageCallback = () => {}
+    ) {
+      ipcRendererInternal.invoke('CHROME_TABS_RELOAD', tabId, extensionId, reloadProperties).then(responseCallback)
+    },
+
     onUpdated: new Event(),
     onCreated: new Event(),
     onRemoved: new Event()

--- a/lib/renderer/extensions/web-navigation.ts
+++ b/lib/renderer/extensions/web-navigation.ts
@@ -4,6 +4,7 @@ import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-in
 class WebNavigation {
   private onBeforeNavigate = new Event()
   private onCompleted = new Event()
+  private onCommitted = new Event()
 
   constructor () {
     ipcRendererInternal.on('CHROME_WEBNAVIGATION_ONBEFORENAVIGATE', (event: Electron.IpcRendererEvent, details: any) => {
@@ -12,6 +13,10 @@ class WebNavigation {
 
     ipcRendererInternal.on('CHROME_WEBNAVIGATION_ONCOMPLETED', (event: Electron.IpcRendererEvent, details: any) => {
       this.onCompleted.emit(details)
+    })
+
+    ipcRendererInternal.on('CHROME_WEBNAVIGATION_ONCOMMITTED', (event: Electron.IpcRendererEvent, details: any) => {
+      this.onCommitted.emit(details)
     })
   }
 }


### PR DESCRIPTION
#### Description of Change
This PR maps the chrome extensions api `webNavigation.onCommitted` to the webContents `did-start-loading` event, and the `browser.tabs.reload` api to the `webContents.reload` and `webContents.reloadIgnoringCache` calls, depending on the options in `browser.tabs.reload`.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

I don't think we have documentation for the chrome extension api stuff, and I can't get the tests to run so very much WIP.

#### Release Notes

Notes: webNavigation.onCommitted and browser.tabs.reload chrome extension apis added
