### PR TITLE
fix: send ELECTRON_BROWSER_CONTEXT_RELEASE asynchronously

### DIFF
--- a/lib/browser/objects-registry.js
+++ b/lib/browser/objects-registry.js
@@ -127,6 +127,10 @@ class ObjectsRegistry {
         this.clear(webContents, contextId)
       }
     }
+    // Note that the "render-view-deleted" event may not be emitted on time when
+    // the renderer process get destroyed because of navigation, we rely on the
+    // renderer process to send "ELECTRON_BROWSER_CONTEXT_RELEASE" message to
+    // guard this situation.
     webContents.on('render-view-deleted', listener)
   }
 }

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -444,7 +444,6 @@ handleRemoteCommand('ELECTRON_BROWSER_DEREFERENCE', function (event, contextId, 
 
 handleRemoteCommand('ELECTRON_BROWSER_CONTEXT_RELEASE', (event, contextId) => {
   objectsRegistry.clear(event.sender, contextId)
-  return null
 })
 
 handleRemoteCommand('ELECTRON_BROWSER_GUEST_WEB_CONTENTS', function (event, contextId, guestInstanceId) {

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -20,7 +20,7 @@ const contextId = v8Util.getHiddenValue(global, 'contextId')
 // to guard that situation.
 process.on('exit', () => {
   const command = 'ELECTRON_BROWSER_CONTEXT_RELEASE'
-  ipcRendererInternal.sendSync(command, contextId)
+  ipcRendererInternal.send(command, contextId)
 })
 
 // Convert the arguments object into an array of meta data.

--- a/spec-main/api-remote-spec.ts
+++ b/spec-main/api-remote-spec.ts
@@ -1,15 +1,18 @@
+import * as path from 'path'
 import { expect } from 'chai'
 import { closeWindow } from './window-helpers'
 
-import { BrowserWindow } from 'electron'
+import { ipcMain, BrowserWindow } from 'electron'
 
 describe('remote module', () => {
+  const fixtures = path.join(__dirname, 'fixtures')
+
   let w = null as unknown as BrowserWindow
-  before(async () => {
+  beforeEach(async () => {
     w = new BrowserWindow({show: false, webPreferences: {nodeIntegration: true}})
     await w.loadURL('about:blank')
   })
-  after(async () => {
+  afterEach(async () => {
     await closeWindow(w)
   })
 
@@ -107,6 +110,27 @@ describe('remote module', () => {
         event.preventDefault()
       })
       await expect(remotely(`require('electron').remote.getCurrentWebContents()`)).to.eventually.be.rejected(`Blocked remote.getCurrentWebContents()`)
+    })
+  })
+
+  describe('remote references', () => {
+    it('render-view-deleted is sent when page is destroyed', (done) => {
+      w.webContents.once('render-view-deleted' as any, () => {
+        done()
+      })
+      w.destroy()
+    })
+
+    // The ELECTRON_BROWSER_CONTEXT_RELEASE message relies on this to work.
+    it('message can be sent on exit when page is being navigated', (done) => {
+      after(() => { ipcMain.removeAllListeners('SENT_ON_EXIT') })
+      ipcMain.once('SENT_ON_EXIT', () => {
+        done()
+      })
+      w.webContents.once('did-finish-load', () => {
+        w.webContents.loadURL('about:blank')
+      })
+      w.loadFile(path.join(fixtures, 'api', 'send-on-exit.html'))
     })
   })
 })

--- a/spec-main/fixtures/api/send-on-exit.html
+++ b/spec-main/fixtures/api/send-on-exit.html
@@ -1,0 +1,11 @@
+<html>
+<body>
+<script type="text/javascript" charset="utf-8">
+  const {ipcRenderer} = require('electron')
+
+  process.on('exit', () => {
+    ipcRenderer.send('SENT_ON_EXIT')
+  })
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### Description of Change
Backport of #20632

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed hang when closing a scriptable popup window using the `remote` module.