### PR TITLE
feat: deprecate <webview>.getWebContents()

### DIFF
--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -59,6 +59,47 @@ these kinds of objects will throw a 'could not be cloned' error.
 
 [SCA]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
 
+### `<webview>.getWebContents()`
+
+This API is implemented using the `remote` module, which has both performance
+and security implications. Therefore its usage should be explicit.
+
+```js
+// Deprecated
+webview.getWebContents()
+// Replace with
+const { remote } = require('electron')
+remote.webContents.fromId(webview.getWebContentsId())
+```
+
+However, it is recommended to avoid using the `remote` module altogether.
+
+```js
+// main
+const { ipcMain, webContents } = require('electron')
+
+const getGuestForWebContents = function (webContentsId, contents) {
+  const guest = webContents.fromId(webContentsId)
+  if (!guest) {
+    throw new Error(`Invalid webContentsId: ${webContentsId}`)
+  }
+  if (guest.hostWebContents !== contents) {
+    throw new Error(`Access denied to webContents`)
+  }
+  return guest
+}
+
+ipcMain.handle('openDevTools', (event, webContentsId) => {
+  const guest = getGuestForWebContents(webContentsId, event.sender)
+  guest.openDevTools()
+})
+
+// renderer
+const { ipcRenderer } = require('electron')
+
+ipcRenderer.invoke('openDevTools', webview.getWebContentsId())
+```
+
 ## Planned Breaking API Changes (7.0)
 
 ### Node Headers URL

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -648,7 +648,7 @@ Sets the maximum and minimum layout-based (i.e. non-visual) zoom level.
 
 Shows pop-up dictionary that searches the selected word on the page.
 
-### `<webview>.getWebContents()`
+### `<webview>.getWebContents()` _Deprecated_
 
 Returns [`WebContents`](web-contents.md) - The web contents associated with
 this `webview`.

--- a/lib/renderer/web-view/web-view-impl.ts
+++ b/lib/renderer/web-view/web-view-impl.ts
@@ -238,6 +238,12 @@ export const setupMethods = (WebViewElement: typeof ElectronInternal.WebViewElem
     return remote.getGuestWebContents(internal.guestInstanceId!)
   }
 
+  WebViewElement.prototype.getWebContents = electron.deprecate.moveAPI(
+    WebViewElement.prototype.getWebContents,
+    'webview.getWebContents()',
+    'remote.webContents.fromId(webview.getWebContentsId())'
+  ) as any
+
   // Focusing the webview should move page focus to the underlying iframe.
   WebViewElement.prototype.focus = function () {
     this.contentWindow.focus()

--- a/spec/fixtures/pages/webview-devtools.html
+++ b/spec/fixtures/pages/webview-devtools.html
@@ -8,7 +8,8 @@
     <script>
         var wv = document.querySelector('webview')
         wv.addEventListener('dom-ready', () => {
-          const webContents = wv.getWebContents()
+          const { remote } = require('electron')
+          const webContents = remote.webContents.fromId(wv.getWebContentsId())
           webContents.on('devtools-opened', function () {
             var showPanelIntevalId = setInterval(function () {
               if (webContents.devToolsWebContents) {


### PR DESCRIPTION
#### Description of Change
- deprecates the `<webview>.getWebContents()` API
- suggests using `remote.webContents.fromId(<webview>.getWebContentsId())` as replacement

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Deprecated `<webview>.getWebContents()` as it depends on the `remote` module.