### PR TITLE
docs: fix process.getSystemVersion() type

### DIFF
--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -217,11 +217,15 @@ that all statistics are reported in Kilobytes.
 
 Returns `String` - The version of the host operating system.
 
-Examples:
+Example:
 
-* `macOS` -> `10.13.6`
-* `Windows` -> `10.0.17763`
-* `Linux` -> `4.15.0-45-generic`
+```js
+const version = process.getSystemVersion()
+console.log(version)
+// On macOS -> '10.13.6'
+// On Windows -> '10.0.17763'
+// On Linux -> '4.15.0-45-generic'
+```
 
 **Note:** It returns the actual operating system version instead of kernel version on macOS unlike `os.release()`.
 


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/20729.

This happened because of the following [assumption](https://github.com/electron/docs-parser/blob/d4d62e1ac0c32f732d0bde55e2ca06116490875b/src/markdown-helpers.ts#L647-L659) made by our docs parser. In the future we might consider changing that assumption, but for now i think it's best to just work around.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
