### PR TITLE
fix: prevent menu gc during popup

### DIFF
--- a/shell/browser/api/atom_api_menu.h
+++ b/shell/browser/api/atom_api_menu.h
@@ -12,6 +12,7 @@
 #include "gin/arguments.h"
 #include "shell/browser/api/atom_api_top_level_window.h"
 #include "shell/browser/ui/atom_menu_model.h"
+#include "shell/common/api/locker.h"
 #include "shell/common/gin_helper/trackable_object.h"
 
 namespace electron {

--- a/shell/browser/api/atom_api_menu_mac.mm
+++ b/shell/browser/api/atom_api_menu_mac.mm
@@ -56,6 +56,9 @@ void MenuMac::PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
                         int y,
                         int positioning_item,
                         base::Closure callback) {
+  mate::Locker locker(isolate());
+  v8::HandleScope handle_scope(isolate());
+
   if (!native_window)
     return;
   NSWindow* nswindow = native_window->GetNativeWindow().GetNativeNSWindow();

--- a/shell/browser/api/atom_api_menu_views.cc
+++ b/shell/browser/api/atom_api_menu_views.cc
@@ -25,6 +25,9 @@ void MenuViews::PopupAt(TopLevelWindow* window,
                         int y,
                         int positioning_item,
                         const base::Closure& callback) {
+  mate::Locker locker(isolate());
+  v8::HandleScope handle_scope(isolate());
+
   auto* native_window = static_cast<NativeWindowViews*>(window->window());
   if (!native_window)
     return;


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/20737.

Ensures that the garbage collector will track the object stored in the handle and they won't get gc'd accidentally while they're open.

cc @MarshallOfSound @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash in Menus related to `menu.popup()`.
