### PR TITLE
feat: #20442 adds fiddle for opening external links...

### DIFF
--- a/docs/fiddles/native-ui/external-links-file-manager/external-links/index.html
+++ b/docs/fiddles/native-ui/external-links-file-manager/external-links/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Open external links</title>
+  </head>
+  <body>
+    <div class="demo">
+      <div class="demo-wrapper">
+        <div class="demo-box">
+          <div class="demo-controls">
+            <button class="demo-button" id="open-ex-links">View Demo</button>
+          </div>
+          <p>
+            If you do not want your app to open website links
+            <em>within</em> the app, you can use the <code>shell</code> module
+            to open them externally. When clicked, the links will open outside
+            of your app and in the user's default web browser.
+          </p>
+          <p>
+            When the demo button is clicked, the electron website will open in
+            your browser.
+          </p>
+          <p></p>
+          <h5>Renderer Process</h5>
+          <pre><code>
+                const { shell } = require('electron')
+                const exLinksBtn = document.getElementById('open-ex-links')
+                exLinksBtn.addEventListener('click', (event) => {
+                shell.openExternal('http://electron.atom.io')
+                }) 
+            </code></pre>
+
+          <div class="demo-protip">
+            <h2>ProTip</h2>
+            <strong>Open all outbound links externally.</strong>
+            <p>
+              You may want to open all <code>http</code> and
+              <code>https</code> links outside of your app. To do this, query
+              the document and loop through each link and add a listener. This
+              app uses the code below which is located in
+              <code>assets/ex-links.js</code>.
+            </p>
+            <h5>Renderer Process</h5>
+            <pre><code>
+                const { shell } = require('electron')
+                const links = document.querySelectorAll('a[href]')
+                Array.prototype.forEach.call(links, (link) => {
+                    const url = link.getAttribute('href')
+                    if (url.indexOf('http') === 0) {
+                    link.addEventListener('click', (e) => {
+                        e.preventDefault()
+                        shell.openExternal(url)
+                    })
+                }})
+            </code></pre>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      // You can also require other files to run in this process
+      require("./renderer.js");
+    </script>
+  </body>
+</html>

--- a/docs/fiddles/native-ui/external-links-file-manager/external-links/main.js
+++ b/docs/fiddles/native-ui/external-links-file-manager/external-links/main.js
@@ -1,0 +1,25 @@
+const { app, BrowserWindow } = require('electron')
+
+let mainWindow = null
+
+function createWindow () {
+  const windowOptions = {
+    width: 600,
+    height: 400,
+    title: 'Open External Links',
+    webPreferences: {
+      nodeIntegration: true
+    }
+  }
+
+  mainWindow = new BrowserWindow(windowOptions)
+  mainWindow.loadFile('index.html')
+
+  mainWindow.on('closed', () => {
+    mainWindow = null
+  })
+}
+
+app.on('ready', () => {
+  createWindow()
+})

--- a/docs/fiddles/native-ui/external-links-file-manager/external-links/renderer.js
+++ b/docs/fiddles/native-ui/external-links-file-manager/external-links/renderer.js
@@ -1,0 +1,21 @@
+const { shell } = require('electron')
+
+const exLinksBtn = document.getElementById('open-ex-links')
+
+exLinksBtn.addEventListener('click', (event) => {
+  shell.openExternal('http://electron.atom.io')
+})
+
+const OpenAllOutboundLinks = () => {
+  const links = document.querySelectorAll('a[href]')
+
+  Array.prototype.forEach.call(links, (link) => {
+    const url = link.getAttribute('href')
+    if (url.indexOf('http') === 0) {
+      link.addEventListener('click', (e) => {
+        e.preventDefault()
+        shell.openExternal(url)
+      })
+    }
+  })
+}


### PR DESCRIPTION
…and the pro version of opening all outbound links

#### Description of Change
Adds the 'Open External Links' fiddle as part of `Native User Interface` / `Open external links and the file manager` / `Open external links` requierment

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: adds a fiddle to demo how to open external links and how to open all outbound links