### PR TITLE
feat: add 'screen' to systemPreferences.getMediaAccessStatus()

### DIFF
--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -32,6 +32,8 @@ static_library("chrome") {
     "//chrome/browser/icon_loader_win.cc",
     "//chrome/browser/icon_manager.cc",
     "//chrome/browser/icon_manager.h",
+    "//chrome/browser/media/webrtc/system_media_capture_permissions_mac.h",
+    "//chrome/browser/media/webrtc/system_media_capture_permissions_mac.mm",
     "//chrome/browser/net/chrome_mojo_proxy_resolver_factory.cc",
     "//chrome/browser/net/chrome_mojo_proxy_resolver_factory.h",
     "//chrome/browser/net/proxy_config_monitor.cc",

--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -91,7 +91,11 @@ The `desktopCapturer` module has the following methods:
 
 Returns `Promise<DesktopCapturerSource[]>` - Resolves with an array of [`DesktopCapturerSource`](structures/desktop-capturer-source.md) objects, each `DesktopCapturerSource` represents a screen or an individual window that can be captured.
 
+**Note** Capturing the screen contents requires user consent on macOS 10.15 Catalina or higher,
+which can detected by [`systemPreferences.getMediaAccessStatus`].
+
 [`navigator.mediaDevices.getUserMedia`]: https://developer.mozilla.org/en/docs/Web/API/MediaDevices/getUserMedia
+[`systemPreferences.getMediaAccessStatus`]: system-preferences.md#systempreferencesgetmediaaccessstatusmediatype-macos
 
 ## Caveats
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -434,11 +434,13 @@ Returns `Boolean` - `true` if the current process is a trusted accessibility cli
 
 ### `systemPreferences.getMediaAccessStatus(mediaType)` _macOS_
 
-* `mediaType` String - `microphone` or `camera`.
+* `mediaType` String - `microphone`, `camera` or `screen`.
 
 Returns `String` - Can be `not-determined`, `granted`, `denied`, `restricted` or `unknown`.
 
-This user consent was not required until macOS 10.14 Mojave, so this method will always return `granted` if your system is running 10.13 High Sierra or lower.
+This user consent was not required on macOS 10.13 High Sierra or lower so this method will always return `granted`.
+macOS 10.14 Mojave or higher requires consent for `microphone` and `camera` access.
+macOS 10.15 Catalina or higher requires consent for `screen` access.
 
 ### `systemPreferences.askForMediaAccess(mediaType)` _macOS_
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -434,7 +434,7 @@ Returns `Boolean` - `true` if the current process is a trusted accessibility cli
 
 ### `systemPreferences.getMediaAccessStatus(mediaType)` _macOS_
 
-* `mediaType` String - `microphone`, `camera` or `screen`.
+* `mediaType` String - Can be `microphone`, `camera` or `screen`.
 
 Returns `String` - Can be `not-determined`, `granted`, `denied`, `restricted` or `unknown`.
 

--- a/spec-main/api-system-preferences-spec.ts
+++ b/spec-main/api-system-preferences-spec.ts
@@ -246,6 +246,11 @@ describe('systemPreferences module', () => {
       const microphoneStatus = systemPreferences.getMediaAccessStatus('microphone')
       expect(statuses).to.include(microphoneStatus)
     })
+
+    it('returns an access status for a screen access request', () => {
+      const screenStatus = systemPreferences.getMediaAccessStatus('screen')
+      expect(statuses).to.include(screenStatus)
+    })
   })
 
   describe('systemPreferences.getAnimationSettings()', () => {


### PR DESCRIPTION
#### Description of Change
Adding `screen` to `systemPreferences.getMediaAccessStatus()` as macOS 10.15 Catalina requires consent for capturing the screen contents. Related to #20242.

This permission can only be granted manually in the System Preferences. Therefore `systemPreferences.askForMediaAccess()` cannot be extended in the same way.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `screen` to `systemPreferences.getMediaAccessStatus()` for detecting the new macOS Catalina permissions.