### PR TITLE
fix: crashes when calling webContents.printToPDF() multiple times

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -71,7 +71,6 @@ const defaultPrintingSetting = {
   headerFooterEnabled: false,
   marginsType: 0,
   isFirstRequest: false,
-  requestID: getNextId(),
   previewUIID: 0,
   previewModifiable: true,
   printToPDF: true,
@@ -204,7 +203,10 @@ WebContents.prototype.executeJavaScript = function (code, hasUserGesture) {
 
 // Translate the options of printToPDF.
 WebContents.prototype.printToPDF = function (options) {
-  const printingSetting = Object.assign({}, defaultPrintingSetting)
+  const printingSetting = {
+    ...defaultPrintingSetting,
+    requestID: getNextId()
+  }
   if (options.landscape) {
     printingSetting.landscape = options.landscape
   }

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -1400,6 +1400,19 @@ describe('webContents module', () => {
       const data = await w.webContents.printToPDF({})
       expect(data).to.be.an.instanceof(Buffer).that.is.not.empty()
     })
+
+    it('does not crash when called multiple times', async () => {
+      const w = new BrowserWindow({ show: false, webPreferences: { sandbox: true } })
+      await w.loadURL('data:text/html,<h1>Hello, World!</h1>')
+      const promises = []
+      for (let i = 0; i < 2; i++) {
+        promises.push(w.webContents.printToPDF({}))
+      }
+      const results = await Promise.all(promises)
+      for (const data of results) {
+        expect(data).to.be.an.instanceof(Buffer).that.is.not.empty()
+      }
+    })
   })
 
   describe('PictureInPicture video', () => {


### PR DESCRIPTION
#### Description of Change
Fixes #20367

The same `requestID` was being used from `defaultPrintingSetting` instead of a new one being generated every time. The promise to be resolved / rejected was therefore being overwritten in the map with the same key:
https://github.com/electron/electron/blob/d0cdd1252111044ca4c76920082e2c1c63e8dee5/shell/browser/printing/print_preview_message_handler.cc#L145-L157
and later it wasn't found anymore for the other `printToPDF()` invocations: https://github.com/electron/electron/blob/d0cdd1252111044ca4c76920082e2c1c63e8dee5/shell/browser/printing/print_preview_message_handler.cc#L159-L168

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed crashes when calling `webContents.printToPDF()` multiple times.