### PR TITLE
build: disable `strip_absolute_paths_from_debug_symbols` on debug.gn

### DIFF
--- a/build/args/debug.gn
+++ b/build/args/debug.gn
@@ -2,6 +2,8 @@ import("all.gn")
 is_debug = true
 is_component_build = true
 
+strip_absolute_paths_from_debug_symbols = false
+
 # This may be guarded behind is_chrome_branded alongside
 # proprietary_codecs https://webrtc-review.googlesource.com/c/src/+/36321,
 # explicitly override here to build OpenH264 encoder/FFmpeg decoder.


### PR DESCRIPTION
#### Description of Change
We can't set breakpoints directly in the Chromium source on XCode, Because from [this commit](https://chromium.googlesource.com/chromium/src/+/87a677dfe577d9411be85d08b466a03f53c480c5%5E%21/#F0) it was set strip_absolute_paths_from_debug_symbols default to true. This PR make strip_absolute_paths_from_debug_symbols to false in debug/build.gn.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->Make strip_absolute_paths_from_debug_symbols to false in debug.gn