### PR TITLE
fix: prevent menu gc during popup

### DIFF
--- a/shell/browser/api/atom_api_menu.h
+++ b/shell/browser/api/atom_api_menu.h
@@ -13,6 +13,7 @@
 #include "shell/browser/api/atom_api_top_level_window.h"
 #include "shell/browser/api/trackable_object.h"
 #include "shell/browser/ui/atom_menu_model.h"
+#include "shell/common/api/locker.h"
 
 namespace electron {
 

--- a/shell/browser/api/atom_api_menu_mac.mm
+++ b/shell/browser/api/atom_api_menu_mac.mm
@@ -56,6 +56,9 @@ void MenuMac::PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
                         int y,
                         int positioning_item,
                         base::Closure callback) {
+  mate::Locker locker(isolate());
+  v8::HandleScope handle_scope(isolate());
+
   if (!native_window)
     return;
   NSWindow* nswindow = native_window->GetNativeWindow().GetNativeNSWindow();

--- a/shell/browser/api/atom_api_menu_views.cc
+++ b/shell/browser/api/atom_api_menu_views.cc
@@ -25,6 +25,9 @@ void MenuViews::PopupAt(TopLevelWindow* window,
                         int y,
                         int positioning_item,
                         const base::Closure& callback) {
+  mate::Locker locker(isolate());
+  v8::HandleScope handle_scope(isolate());
+
   auto* native_window = static_cast<NativeWindowViews*>(window->window());
   if (!native_window)
     return;


### PR DESCRIPTION
#### Description of Change

Backport of https://github.com/electron/electron/pull/20745.

#### Release Notes

Notes: Fixed a crash in Menus related to `menu.popup()`.
