### PR TITLE
fix: prevent menu gc during popup

### DIFF
--- a/atom/browser/api/atom_api_menu.h
+++ b/atom/browser/api/atom_api_menu.h
@@ -11,6 +11,7 @@
 #include "atom/browser/api/atom_api_top_level_window.h"
 #include "atom/browser/api/trackable_object.h"
 #include "atom/browser/ui/atom_menu_model.h"
+#include "atom/common/api/locker.h"
 #include "base/callback.h"
 
 namespace atom {

--- a/atom/browser/api/atom_api_menu_mac.mm
+++ b/atom/browser/api/atom_api_menu_mac.mm
@@ -53,15 +53,18 @@ void MenuMac::PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
                         int y,
                         int positioning_item,
                         base::Closure callback) {
+  mate::Locker locker(isolate());
+  v8::HandleScope handle_scope(isolate());
+
   if (!native_window)
     return;
   NSWindow* nswindow = native_window->GetNativeWindow().GetNativeNSWindow();
 
   auto close_callback = base::Bind(
       &MenuMac::OnClosed, weak_factory_.GetWeakPtr(), window_id, callback);
-  popup_controllers_[window_id] = base::scoped_nsobject<AtomMenuController>([
-      [AtomMenuController alloc] initWithModel:model()
-                         useDefaultAccelerator:NO]);
+  popup_controllers_[window_id] = base::scoped_nsobject<AtomMenuController>(
+      [[AtomMenuController alloc] initWithModel:model()
+                          useDefaultAccelerator:NO]);
   NSMenu* menu = [popup_controllers_[window_id] menu];
   NSView* view = [nswindow contentView];
 
@@ -135,9 +138,9 @@ void MenuMac::OnClosed(int32_t window_id, base::Closure callback) {
 // static
 void Menu::SetApplicationMenu(Menu* base_menu) {
   MenuMac* menu = static_cast<MenuMac*>(base_menu);
-  base::scoped_nsobject<AtomMenuController> menu_controller([
-      [AtomMenuController alloc] initWithModel:menu->model_.get()
-                         useDefaultAccelerator:YES]);
+  base::scoped_nsobject<AtomMenuController> menu_controller(
+      [[AtomMenuController alloc] initWithModel:menu->model_.get()
+                          useDefaultAccelerator:YES]);
 
   NSRunLoop* currentRunLoop = [NSRunLoop currentRunLoop];
   [currentRunLoop cancelPerformSelector:@selector(setMainMenu:)

--- a/atom/browser/api/atom_api_menu_views.cc
+++ b/atom/browser/api/atom_api_menu_views.cc
@@ -26,6 +26,9 @@ void MenuViews::PopupAt(TopLevelWindow* window,
                         int y,
                         int positioning_item,
                         const base::Closure& callback) {
+  mate::Locker locker(isolate());
+  v8::HandleScope handle_scope(isolate());
+
   auto* native_window = static_cast<NativeWindowViews*>(window->window());
   if (!native_window)
     return;


### PR DESCRIPTION
#### Description of Change

Backport of https://github.com/electron/electron/pull/20745.

#### Release Notes

Notes: Fixed a crash in Menus related to `menu.popup()`.
