### PR TITLE
build: enable sccache on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,7 +80,7 @@ build_script:
   - gclient sync --with_branch_heads --with_tags --reset
   - cd src
   - ps: $env:BUILD_CONFIG_PATH="//electron/build/args/%GN_CONFIG%.gn"
-  - gn gen out/Default "--args=import(\"%BUILD_CONFIG_PATH%\") %GN_EXTRA_ARGS% cc_wrapper=\\"%SCCACHE_PATH%\\""
+  - gn gen out/Default "--args=import(\"%BUILD_CONFIG_PATH%\") %GN_EXTRA_ARGS% cc_wrapper=\"%SCCACHE_PATH%\""
   - gn check out/Default //electron:electron_lib
   - gn check out/Default //electron:electron_app
   - gn check out/Default //electron:manifests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ build_script:
         node script/yarn.js install --frozen-lockfile
 
         if ($(node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER --prBranch=$env:APPVEYOR_REPO_BRANCH;$LASTEXITCODE -eq 0)) {
-          # Write-warning "Skipping build for doc only change"; Exit-AppveyorBuild
+          Write-warning "Skipping build for doc only change"; Exit-AppveyorBuild
         }
       }
   - echo "Building $env:GN_CONFIG build"
@@ -94,6 +94,7 @@ build_script:
   - ninja -C out/Default electron:electron_mksnapshot_zip
   - ninja -C out/Default electron:electron_chromedriver_zip
   - ninja -C out/Default third_party/electron_node:headers
+  - %SCCACHE_PATH% --show-stats
   - appveyor PushArtifact out/Default/dist.zip
   - appveyor PushArtifact out/Default/shell_browser_ui_unittests.exe
   - appveyor PushArtifact out/Default/chromedriver.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -94,7 +94,7 @@ build_script:
   - ninja -C out/Default electron:electron_mksnapshot_zip
   - ninja -C out/Default electron:electron_chromedriver_zip
   - ninja -C out/Default third_party/electron_node:headers
-  - %SCCACHE_PATH% --show-stats
+  - cmd /C %SCCACHE_PATH% --show-stats
   - appveyor PushArtifact out/Default/dist.zip
   - appveyor PushArtifact out/Default/shell_browser_ui_unittests.exe
   - appveyor PushArtifact out/Default/chromedriver.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ build_script:
         node script/yarn.js install --frozen-lockfile
 
         if ($(node script/doc-only-change.js --prNumber=$env:APPVEYOR_PULL_REQUEST_NUMBER --prBranch=$env:APPVEYOR_REPO_BRANCH;$LASTEXITCODE -eq 0)) {
-          Write-warning "Skipping build for doc only change"; Exit-AppveyorBuild
+          # Write-warning "Skipping build for doc only change"; Exit-AppveyorBuild
         }
       }
   - echo "Building $env:GN_CONFIG build"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,7 @@ environment:
   ELECTRON_ENABLE_STACK_DUMPING: 1
   MOCHA_REPORTER: mocha-multi-reporters
   MOCHA_MULTI_REPORTERS: mocha-appveyor-reporter, tap
+  SCCACHE_BUCKET: electronjs-sccache-ci
 notifications:
   - provider: Webhook
     url: https://electron-mission-control.herokuapp.com/rest/appveyor-hook
@@ -79,7 +80,7 @@ build_script:
   - gclient sync --with_branch_heads --with_tags --reset
   - cd src
   - ps: $env:BUILD_CONFIG_PATH="//electron/build/args/%GN_CONFIG%.gn"
-  - gn gen out/Default "--args=import(\"%BUILD_CONFIG_PATH%\") %GN_EXTRA_ARGS%"
+  - gn gen out/Default "--args=import(\"%BUILD_CONFIG_PATH%\") %GN_EXTRA_ARGS% cc_wrapper=\\"%SCCACHE_PATH%\\""
   - gn check out/Default //electron:electron_lib
   - gn check out/Default //electron:electron_app
   - gn check out/Default //electron:manifests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,6 @@ environment:
   ELECTRON_ENABLE_STACK_DUMPING: 1
   MOCHA_REPORTER: mocha-multi-reporters
   MOCHA_MULTI_REPORTERS: mocha-appveyor-reporter, tap
-  SCCACHE_BUCKET: electronjs-sccache-ci
 notifications:
   - provider: Webhook
     url: https://electron-mission-control.herokuapp.com/rest/appveyor-hook

--- a/script/external-binaries.json
+++ b/script/external-binaries.json
@@ -33,7 +33,7 @@
       "platform": "linux"
     },
     {
-      "url": "sccache-win32-x64.zip",
+      "url": "sccache-win32-x64-v2.zip",
       "platform": "win32"
     }
   ]

--- a/script/external-binaries.json
+++ b/script/external-binaries.json
@@ -1,6 +1,6 @@
 {
   "baseUrl": "https://github.com/electron/electron-frameworks/releases/download",
-  "version": "v1.4.0",
+  "version": "v1.4.1",
   "binaries": [
     {
       "url": "Mantle.zip",
@@ -33,7 +33,7 @@
       "platform": "linux"
     },
     {
-      "url": "sccache-win32-x64-v2.zip",
+      "url": "sccache-win32-x64.zip",
       "platform": "win32"
     }
   ]


### PR DESCRIPTION
As in the title, let's use sccache on windows.  The more recent builds support it.  Using sccache on developer machines is still unsupported due to sccache requirements but it works on CI 👍 

Notes: no-notes