### PR TITLE
fix: deprecation warnings in Electron code

### DIFF
--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -33,7 +33,7 @@ BrowserWindow.prototype._init = function () {
 
   // Hide the auto-hide menu when webContents is focused.
   this.webContents.on('activate', () => {
-    if (process.platform !== 'darwin' && this.isMenuBarAutoHide() && this.isMenuBarVisible()) {
+    if (process.platform !== 'darwin' && this.autoHideMenuBar && this.isMenuBarVisible()) {
       this.setMenuBarVisibility(false)
     }
   })

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -200,7 +200,7 @@ const attachGuest = function (event, embedderFrameId, elementInstanceId, guestIn
     nodeIntegrationInSubFrames: params.nodeintegrationinsubframes != null ? params.nodeintegrationinsubframes : false,
     enableRemoteModule: params.enableremotemodule,
     plugins: params.plugins,
-    zoomFactor: embedder.getZoomFactor(),
+    zoomFactor: embedder.zoomFactor,
     disablePopups: !params.allowpopups,
     webSecurity: !params.disablewebsecurity,
     enableBlinkFeatures: params.blinkfeatures,


### PR DESCRIPTION
#### Description of Change
Fixes #20685
https://github.com/electron/electron/blob/b6246dcf122e584c672566877cb60d33dbc4705e/lib/browser/guest-view-manager.js#L203

Fixes #20698
https://github.com/electron/electron/blob/b6246dcf122e584c672566877cb60d33dbc4705e/lib/browser/api/browser-window.js#L36

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed several deprecation warnings in Electron code.