### PR TITLE
build: change to download sysroots from the new sysroot bucket

### DIFF
--- a/patches/chromium/sysroot.patch
+++ b/patches/chromium/sysroot.patch
@@ -20,7 +20,7 @@ index 165551a2948b74c024459be42d1a9a3d96878a10..5c9272a512e22dfe2e90f6665083f53f
 -URL_PREFIX = 'https://commondatastorage.googleapis.com'
 -URL_PATH = 'chrome-linux-sysroot/toolchain'
 +URL_PREFIX = 'http://s3.amazonaws.com'
-+URL_PATH = 'gh-contractor-zcbenz/toolchain'
++URL_PATH = 'electronjs-sysroots/toolchain'
  
  VALID_ARCHS = ('arm', 'arm64', 'i386', 'amd64', 'mips', 'mips64el')
  

--- a/script/generate-deps-hash.js
+++ b/script/generate-deps-hash.js
@@ -8,7 +8,9 @@ const HASH_VERSION = 1
 // Base files to hash
 const filesToHash = [
   path.resolve(__dirname, '../DEPS'),
-  path.resolve(__dirname, '../yarn.lock')
+  path.resolve(__dirname, '../yarn.lock'),
+  path.resolve(__dirname, '../script/external-binaries.json'),
+  path.resolve(__dirname, '../script/sysroots.json')
 ]
 
 const addAllFiles = (dir) => {

--- a/script/sysroots.json
+++ b/script/sysroots.json
@@ -1,31 +1,36 @@
 {
     "sid_amd64": {
-        "Sha1Sum": "b1b67071a9850ecba2ee8de0762e0edc0981a1cb",
+        "Sha1Sum": "b472247c6d72cd18da0ac03a9682b57b55b9667c",
         "SysrootDir": "debian_sid_amd64-sysroot",
         "Tarball": "debian_sid_amd64_sysroot.tar.xz"
     },
     "sid_arm": {
-        "Sha1Sum": "947372fe8669d2ceb4560550b13a99761b40772b",
+        "Sha1Sum": "d5b819fcd4a51f47dc97f027384a78dd763dcddb",
         "SysrootDir": "debian_sid_arm-sysroot",
         "Tarball": "debian_sid_arm_sysroot.tar.xz"
     },
     "sid_arm64": {
-        "Sha1Sum": "2961cef580d6be189c506843e3b585216394a7c2",
+        "Sha1Sum": "4e2cf6ab005dc9bbf6aefdfc55131995d5166219",
         "SysrootDir": "debian_sid_arm64-sysroot",
         "Tarball": "debian_sid_arm64_sysroot.tar.xz"
     },
+    "sid_armel": {
+        "Sha1Sum": "8af2d50934f2ec6e1f4c1103a2c44be82cf96a1e",
+        "SysrootDir": "debian_sid_armel-sysroot",
+        "Tarball": "debian_sid_armel_sysroot.tar.xz"
+    },
     "sid_i386": {
-        "Sha1Sum": "87c33fef40aa9d7b35961eecb489ecee83e2dc39",
+        "Sha1Sum": "e7c331998a7f0bca822031f255028a388dd44400",
         "SysrootDir": "debian_sid_i386-sysroot",
         "Tarball": "debian_sid_i386_sysroot.tar.xz"
     },
     "sid_mips": {
-        "Sha1Sum": "436fc9638e2a435fa824d2f27dacc9e39d5ba667",
+        "Sha1Sum": "35ef4bf25103bf716437815d7f0aa3607264f766",
         "SysrootDir": "debian_sid_mips-sysroot",
         "Tarball": "debian_sid_mips_sysroot.tar.xz"
     },
     "sid_mips64el": {
-        "Sha1Sum": "4dce782d88fa115c9503944f5d3af649ce35a593",
+        "Sha1Sum": "049f728b9617575d493504f6c2cabbc7f7350a42",
         "SysrootDir": "debian_sid_mips64el-sysroot",
         "Tarball": "debian_sid_mips64el_sysroot.tar.xz"
     }

--- a/script/sysroots.json
+++ b/script/sysroots.json
@@ -1,36 +1,36 @@
 {
     "sid_amd64": {
-        "Sha1Sum": "b472247c6d72cd18da0ac03a9682b57b55b9667c",
+        "Sha1Sum": "6861827d4063f8792d691252981d515522c6cb6c",
         "SysrootDir": "debian_sid_amd64-sysroot",
         "Tarball": "debian_sid_amd64_sysroot.tar.xz"
     },
     "sid_arm": {
-        "Sha1Sum": "d5b819fcd4a51f47dc97f027384a78dd763dcddb",
+        "Sha1Sum": "20d8e848cde8d656d0fff55ed2b48c78d64f1933",
         "SysrootDir": "debian_sid_arm-sysroot",
         "Tarball": "debian_sid_arm_sysroot.tar.xz"
     },
     "sid_arm64": {
-        "Sha1Sum": "4e2cf6ab005dc9bbf6aefdfc55131995d5166219",
+        "Sha1Sum": "1494a55afc3186ea0073ae9cc76d3121e81caccb",
         "SysrootDir": "debian_sid_arm64-sysroot",
         "Tarball": "debian_sid_arm64_sysroot.tar.xz"
     },
     "sid_armel": {
-        "Sha1Sum": "8af2d50934f2ec6e1f4c1103a2c44be82cf96a1e",
+        "Sha1Sum": "60689376d06a4c613f031ddb6e4e6d192bcc03a7",
         "SysrootDir": "debian_sid_armel-sysroot",
         "Tarball": "debian_sid_armel_sysroot.tar.xz"
     },
     "sid_i386": {
-        "Sha1Sum": "e7c331998a7f0bca822031f255028a388dd44400",
+        "Sha1Sum": "eb4f827ec5b643ae60136417f3777888e8a81322",
         "SysrootDir": "debian_sid_i386-sysroot",
         "Tarball": "debian_sid_i386_sysroot.tar.xz"
     },
     "sid_mips": {
-        "Sha1Sum": "35ef4bf25103bf716437815d7f0aa3607264f766",
+        "Sha1Sum": "3b91b58c733ecc2de9989d98e00b010625d77c6c",
         "SysrootDir": "debian_sid_mips-sysroot",
         "Tarball": "debian_sid_mips_sysroot.tar.xz"
     },
     "sid_mips64el": {
-        "Sha1Sum": "049f728b9617575d493504f6c2cabbc7f7350a42",
+        "Sha1Sum": "240d0ee7151061574e06fe69d45894e36c57c5bf",
         "SysrootDir": "debian_sid_mips64el-sysroot",
         "Tarball": "debian_sid_mips64el_sysroot.tar.xz"
     }


### PR DESCRIPTION
I did some work over in our sysroot builder to remove out dependency (and over-use) of the `gh-contractor-zcbenz` S3 bucket.  These are new sysroots generated with the latest Chromium sysroot scripts.

Notes: no-notes