### PR TITLE
refactor: pass base::Value by value in JS API implementations 

### DIFF
--- a/shell/browser/api/atom_api_cookies.cc
+++ b/shell/browser/api/atom_api_cookies.cc
@@ -230,7 +230,7 @@ v8::Local<v8::Promise> Cookies::Remove(const GURL& url,
   return handle;
 }
 
-v8::Local<v8::Promise> Cookies::Set(const base::DictionaryValue& details) {
+v8::Local<v8::Promise> Cookies::Set(base::DictionaryValue details) {
   util::Promise<void*> promise(isolate());
   v8::Local<v8::Promise> handle = promise.GetHandle();
 

--- a/shell/browser/api/atom_api_cookies.h
+++ b/shell/browser/api/atom_api_cookies.h
@@ -47,7 +47,7 @@ class Cookies : public gin_helper::TrackableObject<Cookies> {
   ~Cookies() override;
 
   v8::Local<v8::Promise> Get(const gin_helper::Dictionary& filter);
-  v8::Local<v8::Promise> Set(const base::DictionaryValue& details);
+  v8::Local<v8::Promise> Set(base::DictionaryValue details);
   v8::Local<v8::Promise> Remove(const GURL& url, const std::string& name);
   v8::Local<v8::Promise> FlushStore();
 

--- a/shell/browser/api/atom_api_session.cc
+++ b/shell/browser/api/atom_api_session.cc
@@ -665,19 +665,19 @@ gin::Handle<Session> Session::CreateFrom(v8::Isolate* isolate,
 }
 
 // static
-gin::Handle<Session> Session::FromPartition(
-    v8::Isolate* isolate,
-    const std::string& partition,
-    const base::DictionaryValue& options) {
+gin::Handle<Session> Session::FromPartition(v8::Isolate* isolate,
+                                            const std::string& partition,
+                                            base::DictionaryValue options) {
   scoped_refptr<AtomBrowserContext> browser_context;
   if (partition.empty()) {
-    browser_context = AtomBrowserContext::From("", false, options);
+    browser_context = AtomBrowserContext::From("", false, std::move(options));
   } else if (base::StartsWith(partition, kPersistPrefix,
                               base::CompareCase::SENSITIVE)) {
     std::string name = partition.substr(8);
-    browser_context = AtomBrowserContext::From(name, false, options);
+    browser_context = AtomBrowserContext::From(name, false, std::move(options));
   } else {
-    browser_context = AtomBrowserContext::From(partition, true, options);
+    browser_context =
+        AtomBrowserContext::From(partition, true, std::move(options));
   }
   return CreateFrom(isolate, browser_context.get());
 }
@@ -743,7 +743,8 @@ v8::Local<v8::Value> FromPartition(const std::string& partition,
   }
   base::DictionaryValue options;
   args->GetNext(&options);
-  return Session::FromPartition(args->isolate(), partition, options).ToV8();
+  return Session::FromPartition(args->isolate(), partition, std::move(options))
+      .ToV8();
 }
 
 void Initialize(v8::Local<v8::Object> exports,

--- a/shell/browser/api/atom_api_session.h
+++ b/shell/browser/api/atom_api_session.h
@@ -47,7 +47,7 @@ class Session : public gin_helper::TrackableObject<Session>,
   static gin::Handle<Session> FromPartition(
       v8::Isolate* isolate,
       const std::string& partition,
-      const base::DictionaryValue& options = base::DictionaryValue());
+      base::DictionaryValue options = base::DictionaryValue());
 
   AtomBrowserContext* browser_context() const { return browser_context_.get(); }
 

--- a/shell/browser/api/atom_api_system_preferences.h
+++ b/shell/browser/api/atom_api_system_preferences.h
@@ -62,24 +62,22 @@ class SystemPreferences : public gin_helper::EventEmitter<SystemPreferences>
   void OnFinishLaunching(const base::DictionaryValue& launch_info) override;
 
 #elif defined(OS_MACOSX)
-  using NotificationCallback =
-      base::RepeatingCallback<void(const std::string&,
-                                   const base::DictionaryValue&,
-                                   const std::string&)>;
+  using NotificationCallback = base::RepeatingCallback<
+      void(const std::string&, base::DictionaryValue, const std::string&)>;
 
   void PostNotification(const std::string& name,
-                        const base::DictionaryValue& user_info,
+                        base::DictionaryValue user_info,
                         gin_helper::Arguments* args);
   int SubscribeNotification(const std::string& name,
                             const NotificationCallback& callback);
   void UnsubscribeNotification(int id);
   void PostLocalNotification(const std::string& name,
-                             const base::DictionaryValue& user_info);
+                             base::DictionaryValue user_info);
   int SubscribeLocalNotification(const std::string& name,
                                  const NotificationCallback& callback);
   void UnsubscribeLocalNotification(int request_id);
   void PostWorkspaceNotification(const std::string& name,
-                                 const base::DictionaryValue& user_info);
+                                 base::DictionaryValue user_info);
   int SubscribeWorkspaceNotification(const std::string& name,
                                      const NotificationCallback& callback);
   void UnsubscribeWorkspaceNotification(int request_id);

--- a/shell/browser/api/atom_api_system_preferences_mac.mm
+++ b/shell/browser/api/atom_api_system_preferences_mac.mm
@@ -121,7 +121,7 @@ std::string ConvertAuthorizationStatus(AVAuthorizationStatusMac status) {
 }  // namespace
 
 void SystemPreferences::PostNotification(const std::string& name,
-                                         const base::DictionaryValue& user_info,
+                                         base::DictionaryValue user_info,
                                          gin_helper::Arguments* args) {
   bool immediate = false;
   args->GetNext(&immediate);
@@ -145,9 +145,8 @@ void SystemPreferences::UnsubscribeNotification(int request_id) {
   DoUnsubscribeNotification(request_id, kNSDistributedNotificationCenter);
 }
 
-void SystemPreferences::PostLocalNotification(
-    const std::string& name,
-    const base::DictionaryValue& user_info) {
+void SystemPreferences::PostLocalNotification(const std::string& name,
+                                              base::DictionaryValue user_info) {
   NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
   [center postNotificationName:base::SysUTF8ToNSString(name)
                         object:nil
@@ -166,7 +165,7 @@ void SystemPreferences::UnsubscribeLocalNotification(int request_id) {
 
 void SystemPreferences::PostWorkspaceNotification(
     const std::string& name,
-    const base::DictionaryValue& user_info) {
+    base::DictionaryValue user_info) {
   NSNotificationCenter* center =
       [[NSWorkspace sharedWorkspace] notificationCenter];
   [center postNotificationName:base::SysUTF8ToNSString(name)

--- a/shell/browser/api/atom_api_system_preferences_mac.mm
+++ b/shell/browser/api/atom_api_system_preferences_mac.mm
@@ -210,17 +210,15 @@ int SystemPreferences::DoSubscribeNotification(
                   object:nil
                    queue:nil
               usingBlock:^(NSNotification* notification) {
-                std::unique_ptr<base::DictionaryValue> user_info =
-                    NSDictionaryToDictionaryValue(notification.userInfo);
-
                 std::string object = "";
                 if ([notification.object isKindOfClass:[NSString class]]) {
                   object = base::SysNSStringToUTF8(notification.object);
                 }
 
-                if (user_info) {
+                if (notification.userInfo) {
                   copied_callback.Run(
-                      base::SysNSStringToUTF8(notification.name), *user_info,
+                      base::SysNSStringToUTF8(notification.name),
+                      NSDictionaryToDictionaryValue(notification.userInfo),
                       object);
                 } else {
                   copied_callback.Run(
@@ -275,17 +273,11 @@ v8::Local<v8::Value> SystemPreferences::GetUserDefault(
     return gin::ConvertToV8(isolate(),
                             net::GURLWithNSURL([defaults URLForKey:key]));
   } else if (type == "array") {
-    std::unique_ptr<base::ListValue> list =
-        NSArrayToListValue([defaults arrayForKey:key]);
-    if (list == nullptr)
-      list.reset(new base::ListValue());
-    return gin::ConvertToV8(isolate(), *list);
+    return gin::ConvertToV8(isolate(),
+                            NSArrayToListValue([defaults arrayForKey:key]));
   } else if (type == "dictionary") {
-    std::unique_ptr<base::DictionaryValue> dictionary =
-        NSDictionaryToDictionaryValue([defaults dictionaryForKey:key]);
-    if (dictionary == nullptr)
-      dictionary.reset(new base::DictionaryValue());
-    return gin::ConvertToV8(isolate(), *dictionary);
+    return gin::ConvertToV8(isolate(), NSDictionaryToDictionaryValue(
+                                           [defaults dictionaryForKey:key]));
   } else {
     return v8::Undefined(isolate());
   }

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -1863,12 +1863,11 @@ std::vector<printing::PrinterBasicInfo> WebContents::GetPrinterList() {
   return printers;
 }
 
-v8::Local<v8::Promise> WebContents::PrintToPDF(
-    const base::DictionaryValue& settings) {
+v8::Local<v8::Promise> WebContents::PrintToPDF(base::DictionaryValue settings) {
   util::Promise<v8::Local<v8::Value>> promise(isolate());
   v8::Local<v8::Promise> handle = promise.GetHandle();
   PrintPreviewMessageHandler::FromWebContents(web_contents())
-      ->PrintToPDF(settings, std::move(promise));
+      ->PrintToPDF(std::move(settings), std::move(promise));
   return handle;
 }
 #endif

--- a/shell/browser/api/atom_api_web_contents.h
+++ b/shell/browser/api/atom_api_web_contents.h
@@ -186,7 +186,7 @@ class WebContents : public gin_helper::TrackableObject<WebContents>,
   void Print(gin_helper::Arguments* args);
   std::vector<printing::PrinterBasicInfo> GetPrinterList();
   // Print current page as PDF.
-  v8::Local<v8::Promise> PrintToPDF(const base::DictionaryValue& settings);
+  v8::Local<v8::Promise> PrintToPDF(base::DictionaryValue settings);
 #endif
 
   // DevTools workspace api.

--- a/shell/browser/atom_browser_context.cc
+++ b/shell/browser/atom_browser_context.cc
@@ -81,7 +81,7 @@ AtomBrowserContext::BrowserContextMap AtomBrowserContext::browser_context_map_;
 
 AtomBrowserContext::AtomBrowserContext(const std::string& partition,
                                        bool in_memory,
-                                       const base::DictionaryValue& options)
+                                       base::DictionaryValue options)
     : base::RefCountedDeleteOnSequence<AtomBrowserContext>(
           base::ThreadTaskRunnerHandle::Get()),
       in_memory_pref_store_(nullptr),
@@ -358,13 +358,14 @@ ResolveProxyHelper* AtomBrowserContext::GetResolveProxyHelper() {
 scoped_refptr<AtomBrowserContext> AtomBrowserContext::From(
     const std::string& partition,
     bool in_memory,
-    const base::DictionaryValue& options) {
+    base::DictionaryValue options) {
   PartitionKey key(partition, in_memory);
   auto* browser_context = browser_context_map_[key].get();
   if (browser_context)
     return scoped_refptr<AtomBrowserContext>(browser_context);
 
-  auto* new_context = new AtomBrowserContext(partition, in_memory, options);
+  auto* new_context =
+      new AtomBrowserContext(partition, in_memory, std::move(options));
   browser_context_map_[key] = new_context->GetWeakPtr();
   return scoped_refptr<AtomBrowserContext>(new_context);
 }

--- a/shell/browser/atom_browser_context.h
+++ b/shell/browser/atom_browser_context.h
@@ -79,7 +79,7 @@ class AtomBrowserContext
   static scoped_refptr<AtomBrowserContext> From(
       const std::string& partition,
       bool in_memory,
-      const base::DictionaryValue& options = base::DictionaryValue());
+      base::DictionaryValue options = base::DictionaryValue());
 
   static BrowserContextMap browser_context_map() {
     return browser_context_map_;
@@ -142,7 +142,7 @@ class AtomBrowserContext
  protected:
   AtomBrowserContext(const std::string& partition,
                      bool in_memory,
-                     const base::DictionaryValue& options);
+                     base::DictionaryValue options);
   ~AtomBrowserContext() override;
 
  private:

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -151,7 +151,7 @@ void Browser::WillFinishLaunching() {
     observer.OnWillFinishLaunching();
 }
 
-void Browser::DidFinishLaunching(const base::DictionaryValue& launch_info) {
+void Browser::DidFinishLaunching(base::DictionaryValue launch_info) {
   // Make sure the userData directory is created.
   base::ThreadRestrictions::ScopedAllowIO allow_io;
   base::FilePath user_data;

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -125,7 +125,7 @@ class Browser : public WindowListObserver {
 
   // Creates an activity and sets it as the one currently in use.
   void SetUserActivity(const std::string& type,
-                       const base::DictionaryValue& user_info,
+                       base::DictionaryValue user_info,
                        gin_helper::Arguments* args);
 
   // Returns the type name of the current user activity.
@@ -140,7 +140,7 @@ class Browser : public WindowListObserver {
 
   // Updates the current user activity
   void UpdateCurrentActivity(const std::string& type,
-                             const base::DictionaryValue& user_info);
+                             base::DictionaryValue user_info);
 
   // Indicates that an user activity is about to be resumed.
   bool WillContinueUserActivity(const std::string& type);
@@ -151,15 +151,15 @@ class Browser : public WindowListObserver {
 
   // Resumes an activity via hand-off.
   bool ContinueUserActivity(const std::string& type,
-                            const base::DictionaryValue& user_info);
+                            base::DictionaryValue user_info);
 
   // Indicates that an activity was continued on another device.
   void UserActivityWasContinued(const std::string& type,
-                                const base::DictionaryValue& user_info);
+                                base::DictionaryValue user_info);
 
   // Gives an oportunity to update the Handoff payload.
   bool UpdateUserActivityState(const std::string& type,
-                               const base::DictionaryValue& user_info);
+                               base::DictionaryValue user_info);
 
   // Bounce the dock icon.
   enum class BounceType{
@@ -190,7 +190,7 @@ class Browser : public WindowListObserver {
 #endif  // defined(OS_MACOSX)
 
   void ShowAboutPanel();
-  void SetAboutPanelOptions(const base::DictionaryValue& options);
+  void SetAboutPanelOptions(base::DictionaryValue options);
 
 #if defined(OS_MACOSX) || defined(OS_WIN)
   void ShowEmojiPanel();
@@ -244,7 +244,7 @@ class Browser : public WindowListObserver {
 
   // Tell the application the loading has been done.
   void WillFinishLaunching();
-  void DidFinishLaunching(const base::DictionaryValue& launch_info);
+  void DidFinishLaunching(base::DictionaryValue launch_info);
 
   void OnAccessibilitySupportChanged();
 

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -216,8 +216,8 @@ void Browser::ShowAboutPanel() {
   gtk_widget_destroy(dialogWidget);
 }
 
-void Browser::SetAboutPanelOptions(const base::DictionaryValue& options) {
-  about_panel_options_ = options.Clone();
+void Browser::SetAboutPanelOptions(base::DictionaryValue options) {
+  about_panel_options_ = std::move(options);
 }
 
 }  // namespace electron

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -141,7 +141,7 @@ bool Browser::SetBadgeCount(int count) {
 }
 
 void Browser::SetUserActivity(const std::string& type,
-                              const base::DictionaryValue& user_info,
+                              base::DictionaryValue user_info,
                               gin_helper::Arguments* args) {
   std::string url_string;
   args->GetNext(&url_string);
@@ -167,7 +167,7 @@ void Browser::ResignCurrentActivity() {
 }
 
 void Browser::UpdateCurrentActivity(const std::string& type,
-                                    const base::DictionaryValue& user_info) {
+                                    base::DictionaryValue user_info) {
   [[AtomApplication sharedApplication]
       updateCurrentActivity:base::SysUTF8ToNSString(type)
                withUserInfo:DictionaryValueToNSDictionary(user_info)];
@@ -187,7 +187,7 @@ void Browser::DidFailToContinueUserActivity(const std::string& type,
 }
 
 bool Browser::ContinueUserActivity(const std::string& type,
-                                   const base::DictionaryValue& user_info) {
+                                   base::DictionaryValue user_info) {
   bool prevent_default = false;
   for (BrowserObserver& observer : observers_)
     observer.OnContinueUserActivity(&prevent_default, type, user_info);
@@ -195,13 +195,13 @@ bool Browser::ContinueUserActivity(const std::string& type,
 }
 
 void Browser::UserActivityWasContinued(const std::string& type,
-                                       const base::DictionaryValue& user_info) {
+                                       base::DictionaryValue user_info) {
   for (BrowserObserver& observer : observers_)
     observer.OnUserActivityWasContinued(type, user_info);
 }
 
 bool Browser::UpdateUserActivityState(const std::string& type,
-                                      const base::DictionaryValue& user_info) {
+                                      base::DictionaryValue user_info) {
   bool prevent_default = false;
   for (BrowserObserver& observer : observers_)
     observer.OnUpdateUserActivityState(&prevent_default, type, user_info);
@@ -373,15 +373,15 @@ void Browser::ShowAboutPanel() {
       orderFrontStandardAboutPanelWithOptions:options];
 }
 
-void Browser::SetAboutPanelOptions(const base::DictionaryValue& options) {
+void Browser::SetAboutPanelOptions(base::DictionaryValue options) {
   about_panel_options_.Clear();
 
-  for (const auto& pair : options) {
-    std::string key = pair.first;
-    const auto& val = pair.second;
+  for (auto& pair : options) {
+    std::string& key = pair.first;
+    std::unique_ptr<base::Value>& val = pair.second;
     if (!key.empty() && val->is_string()) {
       key[0] = base::ToUpperASCII(key[0]);
-      about_panel_options_.SetString(key, val->GetString());
+      about_panel_options_.Set(key, std::move(val));
     }
   }
 }

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -378,10 +378,9 @@ void Browser::SetAboutPanelOptions(base::DictionaryValue options) {
 
   for (auto& pair : options) {
     std::string& key = pair.first;
-    std::unique_ptr<base::Value>& val = pair.second;
-    if (!key.empty() && val->is_string()) {
+    if (!key.empty() && pair.second->is_string()) {
       key[0] = base::ToUpperASCII(key[0]);
-      about_panel_options_.Set(key, std::move(val));
+      about_panel_options_.Set(key, std::move(pair.second));
     }
   }
 }

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -407,8 +407,8 @@ void Browser::ShowAboutPanel() {
   electron::ShowMessageBoxSync(settings);
 }
 
-void Browser::SetAboutPanelOptions(const base::DictionaryValue& options) {
-  about_panel_options_ = options.Clone();
+void Browser::SetAboutPanelOptions(base::DictionaryValue options) {
+  about_panel_options_ = std::move(options);
 }
 
 }  // namespace electron

--- a/shell/browser/mac/atom_application.mm
+++ b/shell/browser/mac/atom_application.mm
@@ -117,12 +117,14 @@ inline void dispatch_sync_main(dispatch_block_t block) {
   dispatch_sync_main(^{
     std::string activity_type(
         base::SysNSStringToUTF8(userActivity.activityType));
-    std::unique_ptr<base::DictionaryValue> user_info =
+    base::DictionaryValue user_info =
         electron::NSDictionaryToDictionaryValue(userActivity.userInfo);
 
     electron::Browser* browser = electron::Browser::Get();
     shouldWait =
-        browser->UpdateUserActivityState(activity_type, *user_info) ? YES : NO;
+        browser->UpdateUserActivityState(activity_type, std::move(user_info))
+            ? YES
+            : NO;
   });
 
   if (shouldWait) {
@@ -144,11 +146,11 @@ inline void dispatch_sync_main(dispatch_block_t block) {
   dispatch_async(dispatch_get_main_queue(), ^{
     std::string activity_type(
         base::SysNSStringToUTF8(userActivity.activityType));
-    std::unique_ptr<base::DictionaryValue> user_info =
+    base::DictionaryValue user_info =
         electron::NSDictionaryToDictionaryValue(userActivity.userInfo);
 
     electron::Browser* browser = electron::Browser::Get();
-    browser->UserActivityWasContinued(activity_type, *user_info);
+    browser->UserActivityWasContinued(activity_type, std::move(user_info));
   });
   [userActivity setNeedsSave:YES];
 }

--- a/shell/browser/mac/atom_application_delegate.mm
+++ b/shell/browser/mac/atom_application_delegate.mm
@@ -60,10 +60,9 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
   NSUserNotification* user_notification =
       [notify userInfo][(id) @"NSApplicationLaunchUserNotificationKey"];
 
-  if (user_notification.userInfo != nil) {
-    std::unique_ptr<base::DictionaryValue> launch_info =
-        electron::NSDictionaryToDictionaryValue(user_notification.userInfo);
-    electron::Browser::Get()->DidFinishLaunching(*launch_info);
+  if (user_notification.userInfo) {
+    electron::Browser::Get()->DidFinishLaunching(
+        electron::NSDictionaryToDictionaryValue(user_notification.userInfo));
   } else {
     electron::Browser::Get()->DidFinishLaunching(base::DictionaryValue());
   }
@@ -108,13 +107,15 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
 #endif
               restorationHandler {
   std::string activity_type(base::SysNSStringToUTF8(userActivity.activityType));
-  std::unique_ptr<base::DictionaryValue> user_info =
-      electron::NSDictionaryToDictionaryValue(userActivity.userInfo);
-  if (!user_info)
+  if (!userActivity.userInfo)
     return NO;
 
   electron::Browser* browser = electron::Browser::Get();
-  return browser->ContinueUserActivity(activity_type, *user_info) ? YES : NO;
+  return browser->ContinueUserActivity(
+             activity_type,
+             electron::NSDictionaryToDictionaryValue(userActivity.userInfo))
+             ? YES
+             : NO;
 }
 
 - (BOOL)application:(NSApplication*)application

--- a/shell/browser/mac/dict_util.h
+++ b/shell/browser/mac/dict_util.h
@@ -5,8 +5,6 @@
 #ifndef SHELL_BROWSER_MAC_DICT_UTIL_H_
 #define SHELL_BROWSER_MAC_DICT_UTIL_H_
 
-#include <memory>
-
 #import <Foundation/Foundation.h>
 
 namespace base {
@@ -17,13 +15,9 @@ class DictionaryValue;
 namespace electron {
 
 NSArray* ListValueToNSArray(const base::ListValue& value);
-
-std::unique_ptr<base::ListValue> NSArrayToListValue(NSArray* arr);
-
+base::ListValue NSArrayToListValue(NSArray* arr);
 NSDictionary* DictionaryValueToNSDictionary(const base::DictionaryValue& value);
-
-std::unique_ptr<base::DictionaryValue> NSDictionaryToDictionaryValue(
-    NSDictionary* dict);
+base::DictionaryValue NSDictionaryToDictionaryValue(NSDictionary* dict);
 
 }  // namespace electron
 

--- a/shell/browser/mac/dict_util.mm
+++ b/shell/browser/mac/dict_util.mm
@@ -4,9 +4,7 @@
 
 #include "shell/browser/mac/dict_util.h"
 
-#include <memory>
 #include <string>
-#include <utility>
 
 #include "base/json/json_writer.h"
 #include "base/strings/sys_string_conversions.h"
@@ -27,39 +25,30 @@ NSArray* ListValueToNSArray(const base::ListValue& value) {
   return obj;
 }
 
-std::unique_ptr<base::ListValue> NSArrayToListValue(NSArray* arr) {
+base::ListValue NSArrayToListValue(NSArray* arr) {
+  base::ListValue result;
   if (!arr)
-    return nullptr;
+    return result;
 
-  auto result = std::make_unique<base::ListValue>();
   for (id value in arr) {
     if ([value isKindOfClass:[NSString class]]) {
-      result->AppendString(base::SysNSStringToUTF8(value));
+      result.AppendString(base::SysNSStringToUTF8(value));
     } else if ([value isKindOfClass:[NSNumber class]]) {
       const char* objc_type = [value objCType];
       if (strcmp(objc_type, @encode(BOOL)) == 0 ||
           strcmp(objc_type, @encode(char)) == 0)
-        result->AppendBoolean([value boolValue]);
+        result.AppendBoolean([value boolValue]);
       else if (strcmp(objc_type, @encode(double)) == 0 ||
                strcmp(objc_type, @encode(float)) == 0)
-        result->AppendDouble([value doubleValue]);
+        result.AppendDouble([value doubleValue]);
       else
-        result->AppendInteger([value intValue]);
+        result.AppendInteger([value intValue]);
     } else if ([value isKindOfClass:[NSArray class]]) {
-      std::unique_ptr<base::ListValue> sub_arr = NSArrayToListValue(value);
-      if (sub_arr)
-        result->Append(std::move(sub_arr));
-      else
-        result->Append(std::make_unique<base::Value>());
+      result.Append(NSArrayToListValue(value));
     } else if ([value isKindOfClass:[NSDictionary class]]) {
-      std::unique_ptr<base::DictionaryValue> sub_dict =
-          NSDictionaryToDictionaryValue(value);
-      if (sub_dict)
-        result->Append(std::move(sub_dict));
-      else
-        result->Append(std::make_unique<base::Value>());
+      result.Append(NSDictionaryToDictionaryValue(value));
     } else {
-      result->AppendString(base::SysNSStringToUTF8([value description]));
+      result.AppendString(base::SysNSStringToUTF8([value description]));
     }
   }
 
@@ -80,47 +69,35 @@ NSDictionary* DictionaryValueToNSDictionary(
   return obj;
 }
 
-std::unique_ptr<base::DictionaryValue> NSDictionaryToDictionaryValue(
-    NSDictionary* dict) {
+base::DictionaryValue NSDictionaryToDictionaryValue(NSDictionary* dict) {
+  base::DictionaryValue result;
   if (!dict)
-    return nullptr;
+    return result;
 
-  auto result = std::make_unique<base::DictionaryValue>();
   for (id key in dict) {
     std::string str_key = base::SysNSStringToUTF8(
         [key isKindOfClass:[NSString class]] ? key : [key description]);
 
     id value = [dict objectForKey:key];
     if ([value isKindOfClass:[NSString class]]) {
-      result->SetKey(str_key, base::Value(base::SysNSStringToUTF8(value)));
+      result.SetKey(str_key, base::Value(base::SysNSStringToUTF8(value)));
     } else if ([value isKindOfClass:[NSNumber class]]) {
       const char* objc_type = [value objCType];
       if (strcmp(objc_type, @encode(BOOL)) == 0 ||
           strcmp(objc_type, @encode(char)) == 0)
-        result->SetKey(str_key, base::Value([value boolValue]));
+        result.SetKey(str_key, base::Value([value boolValue]));
       else if (strcmp(objc_type, @encode(double)) == 0 ||
                strcmp(objc_type, @encode(float)) == 0)
-        result->SetKey(str_key, base::Value([value doubleValue]));
+        result.SetKey(str_key, base::Value([value doubleValue]));
       else
-        result->SetKey(str_key, base::Value([value intValue]));
+        result.SetKey(str_key, base::Value([value intValue]));
     } else if ([value isKindOfClass:[NSArray class]]) {
-      std::unique_ptr<base::ListValue> sub_arr = NSArrayToListValue(value);
-      if (sub_arr)
-        result->SetWithoutPathExpansion(str_key, std::move(sub_arr));
-      else
-        result->SetWithoutPathExpansion(str_key,
-                                        std::make_unique<base::Value>());
+      result.SetKey(str_key, NSArrayToListValue(value));
     } else if ([value isKindOfClass:[NSDictionary class]]) {
-      std::unique_ptr<base::DictionaryValue> sub_dict =
-          NSDictionaryToDictionaryValue(value);
-      if (sub_dict)
-        result->SetWithoutPathExpansion(str_key, std::move(sub_dict));
-      else
-        result->SetWithoutPathExpansion(str_key,
-                                        std::make_unique<base::Value>());
+      result.SetKey(str_key, NSDictionaryToDictionaryValue(value));
     } else {
-      result->SetKey(str_key,
-                     base::Value(base::SysNSStringToUTF8([value description])));
+      result.SetKey(str_key,
+                    base::Value(base::SysNSStringToUTF8([value description])));
     }
   }
 

--- a/shell/browser/printing/print_preview_message_handler.cc
+++ b/shell/browser/printing/print_preview_message_handler.cc
@@ -143,7 +143,7 @@ void PrintPreviewMessageHandler::OnPrintPreviewCancelled(
 }
 
 void PrintPreviewMessageHandler::PrintToPDF(
-    const base::DictionaryValue& options,
+    base::DictionaryValue options,
     electron::util::Promise<v8::Local<v8::Value>> promise) {
   int request_id;
   options.GetInteger(printing::kPreviewRequestID, &request_id);

--- a/shell/browser/printing/print_preview_message_handler.h
+++ b/shell/browser/printing/print_preview_message_handler.h
@@ -31,7 +31,7 @@ class PrintPreviewMessageHandler
  public:
   ~PrintPreviewMessageHandler() override;
 
-  void PrintToPDF(const base::DictionaryValue& options,
+  void PrintToPDF(base::DictionaryValue options,
                   util::Promise<v8::Local<v8::Value>> promise);
 
  protected:

--- a/shell/common/api/atom_api_native_image.cc
+++ b/shell/common/api/atom_api_native_image.cc
@@ -259,9 +259,8 @@ float NativeImage::GetAspectRatio() {
     return static_cast<float>(size.width()) / static_cast<float>(size.height());
 }
 
-gin::Handle<NativeImage> NativeImage::Resize(
-    v8::Isolate* isolate,
-    const base::DictionaryValue& options) {
+gin::Handle<NativeImage> NativeImage::Resize(v8::Isolate* isolate,
+                                             base::DictionaryValue options) {
   gfx::Size size = GetSize();
   int width = size.width();
   int height = size.height();

--- a/shell/common/api/atom_api_native_image.h
+++ b/shell/common/api/atom_api_native_image.h
@@ -87,7 +87,7 @@ class NativeImage : public mate::Wrappable<NativeImage> {
   v8::Local<v8::Value> GetBitmap(gin::Arguments* args);
   v8::Local<v8::Value> GetNativeHandle(gin_helper::ErrorThrower thrower);
   gin::Handle<NativeImage> Resize(v8::Isolate* isolate,
-                                  const base::DictionaryValue& options);
+                                  base::DictionaryValue options);
   gin::Handle<NativeImage> Crop(v8::Isolate* isolate, const gfx::Rect& rect);
   std::string ToDataURL(gin::Arguments* args);
   bool IsEmpty();

--- a/shell/common/asar/archive.cc
+++ b/shell/common/asar/archive.cc
@@ -194,7 +194,7 @@ bool Archive::Init() {
 
   header_size_ = 8 + size;
   header_ = base::DictionaryValue::From(
-      std::make_unique<base::Value>(value->Clone()));
+      base::Value::ToUniquePtrValue(std::move(*value)));
   return true;
 }
 

--- a/shell/common/gin_helper/function_template.h
+++ b/shell/common/gin_helper/function_template.h
@@ -216,7 +216,8 @@ class Invoker<IndicesHolder<indices...>, ArgTypes...>
   void DispatchToCallback(base::Callback<ReturnType(ArgTypes...)> callback) {
     v8::MicrotasksScope script_scope(args_->isolate(),
                                      v8::MicrotasksScope::kRunMicrotasks);
-    args_->Return(callback.Run(ArgumentHolder<indices, ArgTypes>::value...));
+    args_->Return(
+        callback.Run(std::move(ArgumentHolder<indices, ArgTypes>::value)...));
   }
 
   // In C++, you can declare the function foo(void), but you can't pass a void
@@ -225,7 +226,7 @@ class Invoker<IndicesHolder<indices...>, ArgTypes...>
   void DispatchToCallback(base::Callback<void(ArgTypes...)> callback) {
     v8::MicrotasksScope script_scope(args_->isolate(),
                                      v8::MicrotasksScope::kRunMicrotasks);
-    callback.Run(ArgumentHolder<indices, ArgTypes>::value...);
+    callback.Run(std::move(ArgumentHolder<indices, ArgTypes>::value)...);
   }
 
  private:

--- a/shell/common/native_mate_converters/value_converter.cc
+++ b/shell/common/native_mate_converters/value_converter.cc
@@ -5,6 +5,7 @@
 #include "shell/common/native_mate_converters/value_converter.h"
 
 #include <memory>
+#include <utility>
 
 #include "base/values.h"
 #include "shell/common/native_mate_converters/v8_value_converter.h"
@@ -39,7 +40,7 @@ bool Converter<base::Value>::FromV8(v8::Isolate* isolate,
   std::unique_ptr<base::Value> value(
       converter.FromV8Value(val, isolate->GetCurrentContext()));
   if (value) {
-    *out = value->Clone();
+    *out = std::move(*value);
     return true;
   } else {
     return false;


### PR DESCRIPTION
#### Description of Change

There are a few cases that the passed `base::Value` has to be cloned because they are passed by const references. 

For JS API implementations, the callees actually own the passed `base::Value`s, and by passing them by value we can eliminate unnecessary clones.

Note that `base::Value` is move-only so there would be no accidental copies.

This PR is needed for removing some native_mate classes.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes