### PR TITLE
fix: crashes when calling webContents.printToPDF() multiple times

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -72,7 +72,6 @@ const defaultPrintingSetting = {
   headerFooterEnabled: false,
   marginsType: 0,
   isFirstRequest: false,
-  requestID: getNextId(),
   previewUIID: 0,
   previewModifiable: true,
   printToPDF: true,
@@ -205,7 +204,10 @@ WebContents.prototype.executeJavaScript = function (code, hasUserGesture) {
 
 // Translate the options of printToPDF.
 WebContents.prototype.printToPDF = function (options) {
-  const printingSetting = Object.assign({}, defaultPrintingSetting)
+  const printingSetting = {
+    ...defaultPrintingSetting,
+    requestID: getNextId()
+  }
   if (options.landscape) {
     printingSetting.landscape = options.landscape
   }

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -1275,6 +1275,25 @@ describe('webContents module', () => {
       const data = await w.webContents.printToPDF({})
       expect(data).to.be.an.instanceof(Buffer).that.is.not.empty()
     })
+
+    it('does not crash when called multiple times', async () => {
+      w.destroy()
+      w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          sandbox: true
+        }
+      })
+      await w.loadURL('data:text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E')
+      const promises = []
+      for (let i = 0; i < 2; i++) {
+        promises.push(w.webContents.printToPDF({}))
+      }
+      const results = await Promise.all(promises)
+      for (const data of results) {
+        expect(data).to.be.an.instanceof(Buffer).that.is.not.empty()
+      }
+    })
   })
 
   describe('PictureInPicture video', () => {


### PR DESCRIPTION
#### Description of Change
Backport of #20769

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed crashes when calling `webContents.printToPDF()` multiple times.