### PR TITLE
fix: crashes when calling webContents.printToPDF() multiple times

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -71,7 +71,6 @@ const defaultPrintingSetting = {
   headerFooterEnabled: false,
   marginsType: 0,
   isFirstRequest: false,
-  requestID: getNextId(),
   previewUIID: 0,
   previewModifiable: true,
   printToPDF: true,
@@ -265,7 +264,10 @@ WebContents.prototype.takeHeapSnapshot = function (filePath) {
 
 // Translate the options of printToPDF.
 WebContents.prototype.printToPDF = function (options, callback) {
-  const printingSetting = Object.assign({}, defaultPrintingSetting)
+  const printingSetting = {
+    ...defaultPrintingSetting,
+    requestID: getNextId()
+  }
   if (options.landscape) {
     printingSetting.landscape = options.landscape
   }

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -1284,5 +1284,30 @@ describe('webContents module', () => {
       })
       w.loadURL('data:text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E')
     })
+
+    it('does not crash when called multiple times', (done) => {
+      w.destroy()
+      w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          sandbox: true
+        }
+      })
+      w.webContents.once('did-finish-load', () => {
+        const count = 2
+        let current = 0
+        for (let i = 0; i < count; i++) {
+          w.webContents.printToPDF({}, function (error, data) {
+            assert.strictEqual(error, null)
+            assert.strictEqual(data instanceof Buffer, true)
+            assert.notStrictEqual(data.length, 0)
+            if (++current === count) {
+              done()
+            }
+          })
+        }
+      })
+      w.loadURL('data:text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E')
+    })
   })
 })


### PR DESCRIPTION
#### Description of Change
Backport of #20769

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed crashes when calling `webContents.printToPDF()` multiple times.