### PR TITLE
fix: pass frameId to v8Util.setRemoteCallbackFreer()

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -231,7 +231,7 @@ const unwrapArgs = function (sender, frameId, contextId, args) {
         v8Util.setHiddenValue(callIntoRenderer, 'location', meta.location)
         Object.defineProperty(callIntoRenderer, 'length', { value: meta.length })
 
-        v8Util.setRemoteCallbackFreer(callIntoRenderer, contextId, meta.id, sender)
+        v8Util.setRemoteCallbackFreer(callIntoRenderer, frameId, contextId, meta.id, sender)
         rendererFunctions.set(objectId, callIntoRenderer)
         return callIntoRenderer
       }

--- a/shell/common/api/remote_callback_freer.h
+++ b/shell/common/api/remote_callback_freer.h
@@ -17,6 +17,7 @@ class RemoteCallbackFreer : public ObjectLifeMonitor,
  public:
   static void BindTo(v8::Isolate* isolate,
                      v8::Local<v8::Object> target,
+                     int frame_id,
                      const std::string& context_id,
                      int object_id,
                      content::WebContents* web_conents);
@@ -24,6 +25,7 @@ class RemoteCallbackFreer : public ObjectLifeMonitor,
  protected:
   RemoteCallbackFreer(v8::Isolate* isolate,
                       v8::Local<v8::Object> target,
+                      int frame_id,
                       const std::string& context_id,
                       int object_id,
                       content::WebContents* web_conents);
@@ -35,6 +37,7 @@ class RemoteCallbackFreer : public ObjectLifeMonitor,
   void RenderViewDeleted(content::RenderViewHost*) override;
 
  private:
+  int frame_id_;
   std::string context_id_;
   int object_id_;
 


### PR DESCRIPTION
#### Description of Change
Backport of #20732

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed memory leaks caused by callbacks not being released when the `remote` module is used in sub-frames (`<iframe>` or scriptable popup).