### PR TITLE
fix: emit 'crashed' event asynchronously

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -374,8 +374,11 @@ WebContents.prototype._init = function () {
     })
   })
 
-  this.on('crashed', (event, ...args) => {
-    app.emit('renderer-process-crashed', event, this, ...args)
+  this.on('-crashed', (event, ...args) => {
+    process.nextTick(() => {
+      this.emit('crashed', event, ...args)
+      app.emit('renderer-process-crashed', event, this, ...args)
+    })
   })
 
   // The devtools requests the webContents to reload.

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -894,7 +894,7 @@ void WebContents::RenderViewDeleted(content::RenderViewHost* render_view_host) {
 }
 
 void WebContents::RenderProcessGone(base::TerminationStatus status) {
-  Emit("crashed", status == base::TERMINATION_STATUS_PROCESS_WAS_KILLED);
+  Emit("-crashed", status == base::TERMINATION_STATUS_PROCESS_WAS_KILLED);
 }
 
 void WebContents::PluginCrashed(const base::FilePath& plugin_path,

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -322,6 +322,24 @@ describe('webContents module', () => {
     })
   })
 
+  describe('reload() API', () => {
+    afterEach(closeAllWindows)
+    it('does not crash when called in crashed event handler', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      })
+      await w.loadURL('about:blank')
+      w.webContents.once('crashed', () => {
+        w.webContents.reload()
+      })
+      w.webContents.executeJavaScript('process.crash()')
+      await emittedOnce(w.webContents, 'did-finish-load')
+    })
+  })
+
   describe('getFocusedWebContents() API', () => {
     afterEach(closeAllWindows)
 


### PR DESCRIPTION
#### Description of Change
Fixes #19887

#### Checklist
- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed main process crashing when `webContents.reload()` is called in the `crashed` event handler.