### PR TITLE
refactor: remove DereferenceRemoteJSCallback mojo API

### DIFF
--- a/lib/browser/remote/server.ts
+++ b/lib/browser/remote/server.ts
@@ -309,7 +309,7 @@ const unwrapArgs = function (sender: electron.WebContents, frameId: number, cont
         v8Util.setHiddenValue(callIntoRenderer, 'location', meta.location)
         Object.defineProperty(callIntoRenderer, 'length', { value: meta.length })
 
-        v8Util.setRemoteCallbackFreer(callIntoRenderer, frameId, contextId, meta.id, sender)
+        v8Util.setRemoteCallbackFreer(callIntoRenderer, frameId, 'ELECTRON_RENDERER_RELEASE_CALLBACK', [contextId, meta.id], sender)
         rendererFunctions.set(objectId, callIntoRenderer)
         return callIntoRenderer
       }

--- a/shell/common/api/api.mojom
+++ b/shell/common/api/api.mojom
@@ -14,13 +14,6 @@ interface ElectronRenderer {
 
   UpdateCrashpadPipeName(string pipe_name);
 
-  // This is an API specific to the "remote" module, and will ultimately be
-  // replaced by generic IPC once WeakRef is generally available.
-  [EnableIf=enable_remote_module]
-  DereferenceRemoteJSCallback(
-    string context_id,
-    int32 object_id);
-
   TakeHeapSnapshot(handle file) => (bool success);
 };
 

--- a/shell/common/api/remote/remote_callback_freer.h
+++ b/shell/common/api/remote/remote_callback_freer.h
@@ -9,6 +9,7 @@
 
 #include "content/public/browser/web_contents_observer.h"
 #include "shell/common/api/remote/object_life_monitor.h"
+#include "third_party/blink/public/common/messaging/cloneable_message.h"
 
 namespace electron {
 
@@ -18,16 +19,16 @@ class RemoteCallbackFreer : public ObjectLifeMonitor,
   static void BindTo(v8::Isolate* isolate,
                      v8::Local<v8::Object> target,
                      int frame_id,
-                     const std::string& context_id,
-                     int object_id,
+                     const std::string& channel,
+                     v8::Local<v8::Value> args,
                      content::WebContents* web_conents);
 
  protected:
   RemoteCallbackFreer(v8::Isolate* isolate,
                       v8::Local<v8::Object> target,
                       int frame_id,
-                      const std::string& context_id,
-                      int object_id,
+                      const std::string& channel,
+                      blink::CloneableMessage args,
                       content::WebContents* web_conents);
   ~RemoteCallbackFreer() override;
 
@@ -38,8 +39,8 @@ class RemoteCallbackFreer : public ObjectLifeMonitor,
 
  private:
   int frame_id_;
-  std::string context_id_;
-  int object_id_;
+  std::string channel_;
+  blink::CloneableMessage args_;
 
   DISALLOW_COPY_AND_ASSIGN(RemoteCallbackFreer);
 };

--- a/shell/renderer/electron_api_service_impl.cc
+++ b/shell/renderer/electron_api_service_impl.cc
@@ -176,33 +176,6 @@ void ElectronApiServiceImpl::Message(bool internal,
   }
 }
 
-#if BUILDFLAG(ENABLE_REMOTE_MODULE)
-void ElectronApiServiceImpl::DereferenceRemoteJSCallback(
-    const std::string& context_id,
-    int32_t object_id) {
-  const auto* channel = "ELECTRON_RENDERER_RELEASE_CALLBACK";
-  if (!document_created_)
-    return;
-  blink::WebLocalFrame* frame = render_frame()->GetWebFrame();
-  if (!frame)
-    return;
-
-  v8::Isolate* isolate = blink::MainThreadIsolate();
-  v8::HandleScope handle_scope(isolate);
-
-  v8::Local<v8::Context> context = renderer_client_->GetContext(frame, isolate);
-  v8::Context::Scope context_scope(context);
-
-  base::ListValue args;
-  args.AppendString(context_id);
-  args.AppendInteger(object_id);
-
-  v8::Local<v8::Value> v8_args = gin::ConvertToV8(isolate, args);
-  EmitIPCEvent(context, true /* internal */, channel, v8_args,
-               0 /* sender_id */);
-}
-#endif
-
 void ElectronApiServiceImpl::UpdateCrashpadPipeName(
     const std::string& pipe_name) {
 #if defined(OS_WIN)

--- a/shell/renderer/electron_api_service_impl.h
+++ b/shell/renderer/electron_api_service_impl.h
@@ -33,10 +33,6 @@ class ElectronApiServiceImpl : public mojom::ElectronRenderer,
                const std::string& channel,
                blink::CloneableMessage arguments,
                int32_t sender_id) override;
-#if BUILDFLAG(ENABLE_REMOTE_MODULE)
-  void DereferenceRemoteJSCallback(const std::string& context_id,
-                                   int32_t object_id) override;
-#endif
   void UpdateCrashpadPipeName(const std::string& pipe_name) override;
   void TakeHeapSnapshot(mojo::ScopedHandle file,
                         TakeHeapSnapshotCallback callback) override;

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -30,7 +30,7 @@ declare namespace NodeJS {
     deleteHiddenValue(obj: any, key: string): void;
     requestGarbageCollectionForTesting(): void;
     createDoubleIDWeakMap(): any;
-    setRemoteCallbackFreer(fn: Function, frameId: number, contextId: String, id: number, sender: any): void
+    setRemoteCallbackFreer(fn: Function, frameId: number, channel: string, args: any[], sender: Electron.WebContents): void
   }
 
   interface Process {


### PR DESCRIPTION
#### Description of Change
Make `v8Util.setRemoteCallbackFreer()` more generic. Pass the `channel` (`ELECTRON_RENDERER_RELEASE_CALLBACK`) and arguments from JS.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes