### PR TITLE
feat: Add BrowserView.visible property

### DIFF
--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -54,11 +54,17 @@ Returns `BrowserView` - The view with the given `id`.
 
 Objects created with `new BrowserView` have the following properties:
 
-#### `view.webContents` _Experimental_
+#### `view.visibile`
+
+A `Boolean` property that controls whether or not the view is shown in the
+currently attached window. Note that this does not check if the window itself
+is visible or if the bounds of the view are visible within the window.
+
+#### `view.webContents` _Readonly_
 
 A [`WebContents`](web-contents.md) object owned by this view.
 
-#### `view.id` _Experimental_
+#### `view.id` _Readonly_
 
 A `Integer` representing the unique ID of the view.
 

--- a/shell/browser/api/atom_api_browser_view.cc
+++ b/shell/browser/api/atom_api_browser_view.cc
@@ -123,6 +123,14 @@ void BrowserView::SetBackgroundColor(const std::string& color_name) {
   view_->SetBackgroundColor(ParseHexColor(color_name));
 }
 
+bool BrowserView::GetVisible() {
+  return view_->GetVisible();
+}
+
+void BrowserView::SetVisible(bool visible) {
+  view_->SetVisible(visible);
+}
+
 v8::Local<v8::Value> BrowserView::GetWebContents() {
   if (web_contents_.IsEmpty()) {
     return v8::Null(isolate());
@@ -141,6 +149,8 @@ void BrowserView::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setBounds", &BrowserView::SetBounds)
       .SetMethod("getBounds", &BrowserView::GetBounds)
       .SetMethod("setBackgroundColor", &BrowserView::SetBackgroundColor)
+      .SetProperty("visible", &BrowserView::GetVisible,
+                   &BrowserView::SetVisible)
       .SetProperty("webContents", &BrowserView::GetWebContents)
       .SetProperty("id", &BrowserView::ID);
 }

--- a/shell/browser/api/atom_api_browser_view.h
+++ b/shell/browser/api/atom_api_browser_view.h
@@ -57,6 +57,9 @@ class BrowserView : public gin_helper::TrackableObject<BrowserView>,
   gfx::Rect GetBounds();
   void SetBackgroundColor(const std::string& color_name);
 
+  bool GetVisible();
+  void SetVisible(bool visible);
+
   v8::Local<v8::Value> GetWebContents();
 
   v8::Global<v8::Value> web_contents_;

--- a/shell/browser/native_browser_view.h
+++ b/shell/browser/native_browser_view.h
@@ -46,6 +46,9 @@ class NativeBrowserView {
   virtual gfx::Rect GetBounds() = 0;
   virtual void SetBackgroundColor(SkColor color) = 0;
 
+  virtual bool GetVisible() = 0;
+  virtual void SetVisible(bool visible) = 0;
+
   // Called when the window needs to update its draggable region.
   virtual void UpdateDraggableRegions(
       const std::vector<gfx::Rect>& system_drag_exclude_areas) {}

--- a/shell/browser/native_browser_view_mac.h
+++ b/shell/browser/native_browser_view_mac.h
@@ -24,6 +24,9 @@ class NativeBrowserViewMac : public NativeBrowserView {
   gfx::Rect GetBounds() override;
   void SetBackgroundColor(SkColor color) override;
 
+  bool GetVisible() override;
+  void SetVisible(bool visible) override;
+
   void UpdateDraggableRegions(
       const std::vector<gfx::Rect>& system_drag_exclude_areas) override;
 

--- a/shell/browser/native_browser_view_mac.mm
+++ b/shell/browser/native_browser_view_mac.mm
@@ -219,6 +219,18 @@ void NativeBrowserViewMac::SetBackgroundColor(SkColor color) {
   view.layer.backgroundColor = skia::CGColorCreateFromSkColor(color);
 }
 
+bool NativeBrowserViewMac::GetVisible() {
+  auto* view =
+      GetInspectableWebContentsView()->GetNativeView().GetNativeNSView();
+  return !view.hidden;
+}
+
+void NativeBrowserViewMac::SetVisible(bool visible) {
+  auto* view =
+      GetInspectableWebContentsView()->GetNativeView().GetNativeNSView();
+  view.hidden = !visible;
+}
+
 void NativeBrowserViewMac::UpdateDraggableRegions(
     const std::vector<gfx::Rect>& drag_exclude_rects) {
   NSView* web_view = GetWebContents()->GetNativeView().GetNativeNSView();

--- a/shell/browser/native_browser_view_views.cc
+++ b/shell/browser/native_browser_view_views.cc
@@ -107,6 +107,16 @@ void NativeBrowserViewViews::SetBackgroundColor(SkColor color) {
   view->SchedulePaint();
 }
 
+bool NativeBrowserView::GetVisible() {
+  auto* view = GetInspectableWebContentsView()->GetView();
+  return view->GetVisible();
+}
+
+void NativeBrowserView::SetVisible(bool visible) {
+  auto* view = GetInspectableWebContentsView()->GetView();
+  view->SetVisible(visible);
+}
+
 // static
 NativeBrowserView* NativeBrowserView::Create(
     InspectableWebContents* inspectable_web_contents) {

--- a/shell/browser/native_browser_view_views.h
+++ b/shell/browser/native_browser_view_views.h
@@ -27,6 +27,9 @@ class NativeBrowserViewViews : public NativeBrowserView {
   gfx::Rect GetBounds() override;
   void SetBackgroundColor(SkColor color) override;
 
+  bool GetVisible() override;
+  void SetVisible(bool visible) override;
+
  private:
   void ResetAutoResizeProportions();
 

--- a/spec-main/api-browser-view-spec.ts
+++ b/spec-main/api-browser-view-spec.ts
@@ -105,6 +105,15 @@ describe('BrowserView module', () => {
     })
   })
 
+  describe('BrowserView.visible', () => {
+    it('returns correct value', () => {
+      view = new BrowserView()
+      expect(view.visible).to.be.true('view is visible')
+      view.visible = false
+      expect(view.visible).to.be.false('view is hidden')
+    })
+  })
+
   describe('BrowserWindow.setBrowserView()', () => {
     it('does not throw for valid args', () => {
       view = new BrowserView()


### PR DESCRIPTION
#### Description of Change

This is useful to control which view(s) are visible when using
`BrowserWindow.addBrowserView`.

#### Checklist

- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Add `BrowserView.visible` property