### PR TITLE
docs: change invalid `bash session` language tag

### DIFF
--- a/docs/development/patches.md
+++ b/docs/development/patches.md
@@ -41,7 +41,7 @@ To help manage these patch sets, we provide two tools: `git-import-patches` and 
 ### Usage
 
 #### Adding a new patch
-```bash session
+```bash
 $ cd src/third_party/electron_node
 $ vim some/code/file.cc
 $ git commit
@@ -53,7 +53,7 @@ $ ../../electron/script/git-export-patches -o ../../electron/patches/node
 Re-exporting patches will sometimes cause shasums in unrelated patches to change. This is generally harmless and can be ignored (but go ahead and add those changes to your PR, it'll stop them from showing up for other people).
 
 #### Editing an existing patch
-```bash session
+```bash
 $ cd src/v8
 $ vim some/code/file.cc
 $ git log
@@ -64,7 +64,7 @@ $ ../electron/script/git-export-patches -o ../electron/patches/v8
 ```
 
 #### Removing a patch
-```bash session
+```bash
 $ vim src/electron/patches/node/.patches
 # Delete the line with the name of the patch you want to remove
 $ cd src/third_party/electron_node
@@ -78,7 +78,7 @@ Note that `git-import-patches` will mark the commit that was `HEAD` when it was 
 #### Resolving conflicts
 When updating an upstream dependency, patches may fail to apply cleanly. Often, the conflict can be resolved automatically by git with a 3-way merge. You can instruct `git-import-patches` to use the 3-way merge algorithm by passing the `-3` argument:
 
-```bash session
+```bash
 $ cd src/third_party/electron_node
 # If the patch application failed midway through, you can reset it with:
 $ git am --abort


### PR DESCRIPTION
#### Description of Change

Changed invalid `bash session` language tag by `bash` for fixing docs generation.
These change doesn't need backport due development docs takes from master.

// cc @electron/wg-ecosystem 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
