### PR TITLE
fix: Disable compositor recycling only for attached views

### DIFF
--- a/patches/chromium/disable_compositor_recycling.patch
+++ b/patches/chromium/disable_compositor_recycling.patch
@@ -5,16 +5,20 @@ Subject: fix: disabling compositor recycling
 
 Compositor recycling is useful for Chrome because there can be many tabs and spinning up a compositor for each one would be costly. In practice, Chrome uses the parent compositor code path of browser_compositor_view_mac.mm; the NSView of each tab is detached when it's hidden and attached when it's shown. For Electron, there is no parent compositor, so we're forced into the "own compositor" code path, which seems to be non-optimal and pretty ruthless in terms of the release of resources. Electron has no real concept of multiple tabs per window, so it should be okay to disable this ruthless recycling altogether in Electron.
 
-diff --git a/content/browser/renderer_host/browser_compositor_view_mac.mm b/content/browser/renderer_host/browser_compositor_view_mac.mm
-index 8ddd790decc43af9820c97121a3b359e7cbb49ee..41269301e92d96757066229842333c8981994234 100644
---- a/content/browser/renderer_host/browser_compositor_view_mac.mm
-+++ b/content/browser/renderer_host/browser_compositor_view_mac.mm
-@@ -203,7 +203,7 @@
+diff --git a/content/browser/renderer_host/render_widget_host_view_mac.mm b/content/browser/renderer_host/render_widget_host_view_mac.mm
+index de722efe61cb6823e62f1101b5aa3447f6795687..b258bbb12b5c607e3fec600fbc7bcb376eb00c72 100644
+--- a/content/browser/renderer_host/render_widget_host_view_mac.mm
++++ b/content/browser/renderer_host/render_widget_host_view_mac.mm
+@@ -486,7 +486,11 @@
+     return;
+ 
+   host()->WasHidden();
+-  browser_compositor_->SetRenderWidgetHostIsHidden(true);
++  // Consider the RWHV occluded only if it is not attached to a window
++  // (e.g. unattached BrowserView). Otherwise we treat it as visible to
++  // prevent unnecessary compositor recycling.
++  const bool unattached = ![GetInProcessNSView() window];
++  browser_compositor_->SetRenderWidgetHostIsHidden(unattached);
  }
  
- void BrowserCompositorMac::SetRenderWidgetHostIsHidden(bool hidden) {
--  render_widget_host_is_hidden_ = hidden;
-+  render_widget_host_is_hidden_ = false;
-   UpdateState();
- }
- 
+ void RenderWidgetHostViewMac::SetSize(const gfx::Size& size) {


### PR DESCRIPTION
In #19873, we completely disabled compositor recycling. This has adverse
effects in our tabbed app where switching tabs (i.e. `BrowserView`s) now
results in a flicker because we now also switch compositors.

To fix this without regressing the original fix, we now recycle the
compositor when the view is removed from a window or explicitly marked
as hidden. These can only happen with `BrowserView`s so `BrowserWindow`s
are unaffected.

Notes: Fix flicker when switching between `BrowserView`s