### PR TITLE
fix: do not DCHECK non-const methods

### DIFF
--- a/shell/renderer/atom_renderer_client.cc
+++ b/shell/renderer/atom_renderer_client.cc
@@ -121,7 +121,9 @@ void AtomRendererClient::DidCreateScriptContext(
     node::tracing::TraceEventHelper::SetAgent(node::CreateAgent());
 
   // Setup node environment for each window.
-  DCHECK(node::InitializeContext(renderer_context));
+  bool initialized = node::InitializeContext(renderer_context);
+  CHECK(initialized);
+
   node::Environment* env =
       node_bindings_->CreateEnvironment(renderer_context, nullptr, true);
 

--- a/shell/renderer/web_worker_observer.cc
+++ b/shell/renderer/web_worker_observer.cc
@@ -48,7 +48,8 @@ void WebWorkerObserver::ContextCreated(v8::Local<v8::Context> worker_context) {
   node_bindings_->PrepareMessageLoop();
 
   // Setup node environment for each window.
-  DCHECK(node::InitializeContext(worker_context));
+  bool initialized = node::InitializeContext(worker_context);
+  CHECK(initialized);
   node::Environment* env =
       node_bindings_->CreateEnvironment(worker_context, nullptr, true);
 


### PR DESCRIPTION
#### Description of Change

`InitializeContext` was not being properly called in release builds due to the nature of DCHECKS.

cc @MarshallOfSound @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue with Node.js context initialization in renderer processes.
