### PR TITLE
fix: Disable compositor recycling only for attached views (6-1-x)

### DIFF
--- a/patches/common/chromium/fix_disabling_compositor_recycling.patch
+++ b/patches/common/chromium/fix_disabling_compositor_recycling.patch
@@ -5,16 +5,21 @@ Subject: fix: disabling compositor recycling
 
 Compositor recycling is useful for Chrome because there can be many tabs and spinning up a compositor for each one would be costly. In practice, Chrome uses the parent compositor code path of browser_compositor_view_mac.mm; the NSView of each tab is detached when it's hidden and attached when it's shown. For Electron, there is no parent compositor, so we're forced into the "own compositor" code path, which seems to be non-optimal and pretty ruthless in terms of the release of resources. Electron has no real concept of multiple tabs per window, so it should be okay to disable this ruthless recycling altogether in Electron.
 
-diff --git a/content/browser/renderer_host/browser_compositor_view_mac.mm b/content/browser/renderer_host/browser_compositor_view_mac.mm
-index 59e58d693c971742951434f6582140d9179235f2..135e7a384a560f55e5201f108fe1ac2db621fbca 100644
---- a/content/browser/renderer_host/browser_compositor_view_mac.mm
-+++ b/content/browser/renderer_host/browser_compositor_view_mac.mm
-@@ -209,7 +209,7 @@
+diff --git a/content/browser/renderer_host/render_widget_host_view_mac.mm b/content/browser/renderer_host/render_widget_host_view_mac.mm
+index a1138408c0985efc1334c9a92f7e875680b69a4a..913c1c7cb541fd0f6f400beafbe9796b9cfcda96 100644
+--- a/content/browser/renderer_host/render_widget_host_view_mac.mm
++++ b/content/browser/renderer_host/render_widget_host_view_mac.mm
+@@ -483,7 +483,12 @@
+ 
+ void RenderWidgetHostViewMac::WasOccluded() {
+   host()->WasHidden();
+-  browser_compositor_->SetRenderWidgetHostIsHidden(true);
++
++  // Consider the RWHV occluded only if it is not attached to a window
++  // (e.g. unattached BrowserView). Otherwise we treat it as visible to
++  // prevent unnecessary compositor recycling.
++  const bool unattached = ![cocoa_view() window];
++  browser_compositor_->SetRenderWidgetHostIsHidden(unattached);
  }
  
- void BrowserCompositorMac::SetRenderWidgetHostIsHidden(bool hidden) {
--  render_widget_host_is_hidden_ = hidden;
-+  render_widget_host_is_hidden_ = false;
-   UpdateState();
- }
- 
+ void RenderWidgetHostViewMac::SetSize(const gfx::Size& size) {


### PR DESCRIPTION
Backport of #20829

Notes: Fix flicker when switching between `BrowserView`s