### PR TITLE
fix: devtools extensions not loading

### DIFF
--- a/lib/renderer/chrome-api.ts
+++ b/lib/renderer/chrome-api.ts
@@ -116,7 +116,11 @@ export function injectTo (extensionId: string, context: any) {
       let targetExtensionId = extensionId
       let connectInfo = { name: '' }
       if (args.length === 1) {
-        targetExtensionId = args[0]
+        if (typeof args[0] === 'string') {
+          targetExtensionId = args[0]
+        } else {
+          connectInfo = args[0]
+        }
       } else if (args.length === 2) {
         [targetExtensionId, connectInfo] = args
       }

--- a/spec/chrome-api-spec.js
+++ b/spec/chrome-api-spec.js
@@ -29,6 +29,20 @@ describe('chrome api', () => {
 
   afterEach(() => closeWindow(w).then(() => { w = null }))
 
+  it('chrome.runtime.connect parses arguments properly', async function () {
+    await w.loadURL('about:blank')
+
+    const promise = emittedOnce(w.webContents, 'console-message')
+
+    const message = { method: 'connect' }
+    w.webContents.executeJavaScript(`window.postMessage('${JSON.stringify(message)}', '*')`)
+
+    const [,, responseString] = await promise
+    const response = JSON.parse(responseString)
+
+    expect(response).to.be.true()
+  })
+
   it('runtime.getManifest returns extension manifest', async () => {
     const actualManifest = (() => {
       const data = fs.readFileSync(path.join(fixtures, 'extensions/chrome-api/manifest.json'), 'utf-8')

--- a/spec/fixtures/extensions/chrome-api/main.js
+++ b/spec/fixtures/extensions/chrome-api/main.js
@@ -5,6 +5,17 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 })
 
 const testMap = {
+  connect () {
+    let success = false
+    try {
+      chrome.runtime.connect(chrome.runtime.id)
+      chrome.runtime.connect(chrome.runtime.id, { name: 'content-script' })
+      chrome.runtime.connect({ name: 'content-script' })
+      success = true
+    } finally {
+      console.log(JSON.stringify(success))
+    }
+  },
   getManifest () {
     const manifest = chrome.runtime.getManifest()
     console.log(JSON.stringify(manifest))


### PR DESCRIPTION
#### Description of Change
Backport of #20791

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed devtools extensions not loading due to "Connect to unknown extension [object Object]" errors.