### PR TITLE
fix: swapped labels on open/save gtkdialog

### DIFF
--- a/shell/browser/ui/file_dialog_gtk.cc
+++ b/shell/browser/ui/file_dialog_gtk.cc
@@ -54,9 +54,9 @@ class FileChooserDialog {
     if (!settings.button_label.empty())
       confirm_text = settings.button_label.c_str();
     else if (action == GTK_FILE_CHOOSER_ACTION_SAVE)
-      confirm_text = gtk_util::kOpenLabel;
-    else if (action == GTK_FILE_CHOOSER_ACTION_OPEN)
       confirm_text = gtk_util::kSaveLabel;
+    else if (action == GTK_FILE_CHOOSER_ACTION_OPEN)
+      confirm_text = gtk_util::kOpenLabel;
 
     dialog_ = gtk_file_chooser_dialog_new(
         settings.title.c_str(), nullptr, action, gtk_util::kCancelLabel,


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/20795.

Fixes accidentally swapped labels on localized GTK dialog strings.

cc @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a label mismatch on open and save dialogs on GTK.
