### PR TITLE
fix: use Unicode version of ShellExecute() in OpenExternalOnWorkerThread()

### DIFF
--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -238,14 +238,11 @@ std::string OpenExternalOnWorkerThread(
   // Quote the input scheme to be sure that the command does not have
   // parameters unexpected by the external program. This url should already
   // have been escaped.
-  std::string escaped_url = url.spec();
-  escaped_url.insert(0, "\"");
-  escaped_url += "\"";
-
-  std::string working_dir = options.working_dir.AsUTF8Unsafe();
+  base::string16 escaped_url = L"\"" + base::UTF8ToUTF16(url.spec()) + L"\"";
+  base::string16 working_dir = options.working_dir.value();
 
   if (reinterpret_cast<ULONG_PTR>(
-          ShellExecuteA(nullptr, "open", escaped_url.c_str(), nullptr,
+          ShellExecuteW(nullptr, L"open", escaped_url.c_str(), nullptr,
                         working_dir.empty() ? nullptr : working_dir.c_str(),
                         SW_SHOWNORMAL)) <= 32) {
     return "Failed to open";


### PR DESCRIPTION
#### Description of Change
`ShellExecuteA` and all "ANSI" versions of Windows APIs use the current code page, which is **not UTF-8**. `ShellExecuteW` and Unicode version of Windows APIs must be used everywhere.

https://stackoverflow.com/questions/8831143/windows-api-ansi-functions-and-utf-8

https://en.wikipedia.org/wiki/Unicode_in_Microsoft_Windows
> Most 'A' functions are implemented as a wrapper that translates the text using the current code page to UTF-16 and then calls the 'W' function. 'A' functions that return strings do the opposite conversion, and apparently put a '?' in for characters that don't exist in the current locale.

> Microsoft Windows has a code page designated for UTF-8, code page 65001.[7] Prior to Windows 10 insider build 17035 (November 2017),[8] it was impossible to set the locale code page to 65001, leaving this code page only available for (a) explicit conversion functions such as MultiByteToWideChar and/or (b) the Win32 console command chcp 65001 to translate stdin/out between UTF-8 and UTF-16.

I will be possible in the future though: https://docs.microsoft.com/en-us/windows/uwp/design/globalizing/use-utf8-code-page

Regressed in #17135

/cc @codebytere

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed `shell.openExternal()` option `workingDirectory` not working with Unicode characters.