### PR TITLE
build: disable `strip_absolute_paths_from_debug_symbols` on debug.gn(ref #20775)

### DIFF
--- a/build/args/testing.gn
+++ b/build/args/testing.gn
@@ -6,6 +6,8 @@ is_official_build = false
 dcheck_always_on = true
 symbol_level = 1
 
+strip_absolute_paths_from_debug_symbols = false
+
 # This may be guarded behind is_chrome_branded alongside
 # proprietary_codecs https://webrtc-review.googlesource.com/c/src/+/36321,
 # explicitly override here to build OpenH264 encoder/FFmpeg decoder.


### PR DESCRIPTION
#### Description of Change
This PR is same as #20775, but it will merge into master branch.  @jkleinsc

We can't set breakpoints directly in the Chromium source on XCode, Because from [this commit](https://chromium.googlesource.com/chromium/src/+/87a677dfe577d9411be85d08b466a03f53c480c5%5E%21/#F0) it was set strip_absolute_paths_from_debug_symbols default to true. This PR make strip_absolute_paths_from_debug_symbols to false in debug/build.gn.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Make strip_absolute_paths_from_debug_symbols to false in debug.gn