### PR TITLE
refactor: add Error to isSerializableObject()

### DIFF
--- a/lib/common/remote/type-utils.ts
+++ b/lib/common/remote/type-utils.ts
@@ -16,6 +16,7 @@ const serializableTypes = [
   Number,
   String,
   Date,
+  Error,
   RegExp,
   ArrayBuffer
 ]

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -64,11 +64,6 @@ function wrapArgs (args, visited = new Set()) {
           type: 'remote-object',
           id: v8Util.getHiddenValue(value, 'atomId')
         }
-      } else if (value instanceof Error) {
-        return {
-          type: 'value',
-          value
-        }
       }
 
       const meta = {


### PR DESCRIPTION
#### Description of Change
When sending `Error` from main to renderer in the `remote` we handle it first to preserve custom properties, so this change is safe:
https://github.com/electron/electron/blob/f0b0614dd79f741b5018c3187a438c24571c722e/lib/browser/remote/server.ts#L129-L132

Follow-up to #20427

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes