### PR TITLE
fix: prevent silent failure when DOM storage quota exceeded

### DIFF
--- a/patches/chromium/dom_storage_limits.patch
+++ b/patches/chromium/dom_storage_limits.patch
@@ -1,80 +1,46 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jacob Quant <jacobq@gmail.com>
-Date: Tue, 6 Nov 2018 15:26:00 -0600
+Date: Thu, 31 Oct 2019 14:00:00 -0500
 Subject: dom_storage_limits.patch
 
-This patch circumvents the restriction on DOM storage objects,
-namely `localStorage` and `sessionStorage`, which chromium otherwise
-limits to approximately 10MiB.
+This patch increases the DOM storage (e.g. `localStorage`
+and `sessionStorage`) size quota from 10MiB to 100MiB.
+Previous versions of this patch attempted to circumvent
+the restriction altogether.
+However, this can lead to other problems, such as crashing
+the Dev Tools when attempting to read or write values that exceed
+`IPC::Channel::kMaximumMessageSize` (128MiB).
 
-That restriction originates from a recommendation
-[in the Web Storage API specification](https://html.spec.whatwg.org/multipage/webstorage.html#disk-space-2)
-that is motivated by the concern that hostile code could abuse this
-feature to exhaust available storage capacity.
-However, in the case of  Electron, where the application developers
-have control over all of the code being executed,
-this safety precaution becomes a hindrance that does not add much value.
-For example, if a malicious developer wanted to consume disk space
-on a victim's machine they could do so via Node's native file system API.
-
-By disabling this restriction or increasing the quota,
-electron application developers can use `localStorage`
-as their application's "back end", without being having
-to limit the amount of data stored to 10MiB.
-
-There may still be some benefit to keeping this restriction for applications that load remote content.
-Although all remote data should be from a trusted source and transferred using
-a secure channel, it is nevertheless advisable to include additional layers of protection
-to mitigate risks associated with potential compromise of those other technologies.
-With that in mind, an acceptable alternative to disabling the limit at compile-time
-(as this patch currently does) would be to instead allow it to be disabled at run-time
-for a given `BrowserWindow` via a `webPreferences` option,
-similar to [`nodeIntegration`](https://electronjs.org/docs/tutorial/security#2-disable-nodejs-integration-for-remote-content).
+Increasing the quota rather than bypassing it reduces the
+amount of chromium code that needs to be changed for Electron
+as well as keeps these storage areas limited to a bounded
+size meanwhile giving application developers more space to work with.
 
 diff --git a/content/browser/dom_storage/dom_storage_types.h b/content/browser/dom_storage/dom_storage_types.h
-index 6c0b831ebaaa2c1749bbc7436ce1025656588310..b67767751cadc6072c133297c7a6cdcc6bfd0c98 100644
+index 6c0b831ebaaa2c1749bbc7436ce1025656588310..96d1c73adb09d33cf591ca569f46de9b21f9a4df 100644
 --- a/content/browser/dom_storage/dom_storage_types.h
 +++ b/content/browser/dom_storage/dom_storage_types.h
-@@ -21,6 +21,7 @@ typedef std::map<base::string16, base::NullableString16> DOMStorageValuesMap;
+@@ -21,7 +21,8 @@ typedef std::map<base::string16, base::NullableString16> DOMStorageValuesMap;
  
  // The quota for each storage area.
  // This value is enforced in renderer processes and the browser process.
-+// However, Electron's dom_storage_limits.patch removes the code that checks this limit.
- const size_t kPerStorageAreaQuota = 10 * 1024 * 1024;
+-const size_t kPerStorageAreaQuota = 10 * 1024 * 1024;
++// Electron's dom_storage_limits.patch increased this value from 10MiB to 100MiB
++const size_t kPerStorageAreaQuota = 100 * 1024 * 1024;
  
  // In the browser process we allow some overage to
-diff --git a/third_party/blink/renderer/modules/storage/cached_storage_area.cc b/third_party/blink/renderer/modules/storage/cached_storage_area.cc
-index d91fdc2a7d52307126bc04d44167edadb8c743a8..630acfca527aaec44742d45e47ce29d7754e3385 100644
---- a/third_party/blink/renderer/modules/storage/cached_storage_area.cc
-+++ b/third_party/blink/renderer/modules/storage/cached_storage_area.cc
-@@ -107,11 +107,13 @@ bool CachedStorageArea::SetItem(const String& key,
-                                 Source* source) {
-   DCHECK(areas_->Contains(source));
+ // accomodate concurrent writes from different renderers
+diff --git a/third_party/blink/public/mojom/dom_storage/storage_area.mojom b/third_party/blink/public/mojom/dom_storage/storage_area.mojom
+index 1f1b2c6fa109aa52c4e7c7f5fcaac91beb538449..d8f15eed9be83340ffd1f2400df08558e9554710 100644
+--- a/third_party/blink/public/mojom/dom_storage/storage_area.mojom
++++ b/third_party/blink/public/mojom/dom_storage/storage_area.mojom
+@@ -40,7 +40,8 @@ interface StorageAreaGetAllCallback {
+ interface StorageArea {
+   // The quota for each storage area.
+   // This value is enforced in renderer processes and the browser process.
+-  const uint32 kPerStorageAreaQuota = 10485760; // 10 MiB
++  // Electron's dom_storage_limits.patch increased this value from 10MiB to 100MiB
++  const uint32 kPerStorageAreaQuota = 104857600; // 100 MiB
  
-+#if 0
-   // A quick check to reject obviously overbudget items to avoid priming the
-   // cache.
-   if ((key.length() + value.length()) * 2 >
-       mojom::blink::StorageArea::kPerStorageAreaQuota)
-     return false;
-+#endif
- 
-   EnsureLoaded();
-   String old_value;
-diff --git a/third_party/blink/renderer/modules/storage/storage_area_map.cc b/third_party/blink/renderer/modules/storage/storage_area_map.cc
-index 0da8a1e891edad60355792c40b7d15e90c1086e8..df71418d598d5bdf41e9a8a4340999d9d277aeef 100644
---- a/third_party/blink/renderer/modules/storage/storage_area_map.cc
-+++ b/third_party/blink/renderer/modules/storage/storage_area_map.cc
-@@ -113,10 +113,12 @@ bool StorageAreaMap::SetItemInternal(const String& key,
-   size_t new_quota_used = quota_used_ - old_item_size + new_item_size;
-   size_t new_memory_used = memory_used_ - old_item_memory + new_item_memory;
- 
-+#if 0
-   // Only check quota if the size is increasing, this allows
-   // shrinking changes to pre-existing files that are over budget.
-   if (check_quota && new_item_size > old_item_size && new_quota_used > quota_)
-     return false;
-+#endif
- 
-   keys_values_.Set(key, value);
-   ResetKeyIterator();
+   // In the browser process we allow some overage to
+   // accommodate concurrent writes from different renderers


### PR DESCRIPTION
#### Description of Change
This PR modifies [`dom_storage_limits.patch`](https://github.com/electron/electron/blob/ba85d4c3bbbaddb53795340053c273dfdf51aca1/patches/chromium/dom_storage_limits.patch) so that instead of (incompletely / incorrectly) circumventing the enforcement of the DOM storage quota, it is simply increased (from 10MiB to 100MiB). The primary motivation for this change is that the previous patch (see PR #15596) does not actually work properly ([example](https://github.com/jacobq/electron-quick-start/tree/storageLimit)). 

As described in the [updated patch notes](https://github.com/electron/electron/pull/20899/files#diff-557eb2fa2d8baedff18ed8d626af55c4), bypassing the [maximum size enforcement in
`StorageAreaImpl::Put`](https://github.com/chromium/chromium/blob/62521aaefdef5b345dd470f14eef6e44732ccf23/content/browser/dom_storage/storage_area_impl.cc#L306-L315) partially resolves the problem but can lead to undesirable side-effects (e.g. instability / poor performance). 

**Cc:**
@deepak1556 
@alexeykuzmin 
@nornagon 

#### Checklist
- [X] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [X] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [X] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: DOM storage quota enforcement re-enabled, but limit changed from 10MiB to 100MiB
