### PR TITLE
fix: don't copy tray image when it's set

### DIFF
--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -87,12 +87,12 @@
 }
 
 - (void)setImage:(NSImage*)image {
-  [[statusItem_ button] setImage:[image copy]];
+  [[statusItem_ button] setImage:image];
   [self updateDimensions];
 }
 
 - (void)setAlternateImage:(NSImage*)image {
-  [[statusItem_ button] setAlternateImage:[image copy]];
+  [[statusItem_ button] setAlternateImage:image];
 }
 
 - (void)setIgnoreDoubleClickEvents:(BOOL)ignore {
@@ -108,7 +108,7 @@
     [[statusItem_ button]
         setAttributedTitle:[title attributedStringParsingANSICodes]];
   } else {
-    [[statusItem_ button] setTitle:[title copy]];
+    [[statusItem_ button] setTitle:title];
   }
 
   // Fix icon margins.


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/20850.

We were making unnecessary copies of NSImage instances, which lead to unnecessary RAM consumption.

Benchmarks for a few minutes of runtime with [this repro](https://github.com/D0miH/electron-bug-repo):

Before:
```js
{                                                                              
  rss: 195792896,
  heapTotal: 6774784,
  heapUsed: 4962656,
  external: 2211750
}
```

After:
```js
{                                                                              
  rss: 155697152,
  heapTotal: 6774784,
  heapUsed: 5315472,
  external: 2211750
}
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a memory leak issue when setting Tray images.
