### PR TITLE
chore: fix IsolateData handling and freeing

### DIFF
--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -328,9 +328,11 @@ node::Environment* NodeBindings::CreateEnvironment(
   args.insert(args.begin() + 1, init_script);
 
   std::unique_ptr<const char*[]> c_argv = StringVectorToArgArray(args);
-  node::Environment* env = node::CreateEnvironment(
-      node::CreateIsolateData(context->GetIsolate(), uv_loop_, platform),
-      context, args.size(), c_argv.get(), 0, nullptr, bootstrap_env);
+  isolate_data_ =
+      node::CreateIsolateData(context->GetIsolate(), uv_loop_, platform);
+  node::Environment* env =
+      node::CreateEnvironment(isolate_data_, context, args.size(), c_argv.get(),
+                              0, nullptr, bootstrap_env);
   DCHECK(env);
 
   // Clean up the global _noBrowserGlobals that we unironically injected into

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -19,6 +19,7 @@ class MessageLoop;
 namespace node {
 class Environment;
 class MultiIsolatePlatform;
+class IsolateData;
 }  // namespace node
 
 namespace electron {
@@ -53,6 +54,8 @@ class NodeBindings {
 
   // Do message loop integration.
   virtual void RunMessageLoop();
+
+  node::IsolateData* isolate_data() const { return isolate_data_; }
 
   // Gets/sets the environment to wrap uv loop.
   void set_uv_env(node::Environment* env) { uv_env_ = env; }
@@ -105,6 +108,9 @@ class NodeBindings {
 
   // Environment that to wrap the uv loop.
   node::Environment* uv_env_ = nullptr;
+
+  // Isolate data used in creating the environment
+  node::IsolateData* isolate_data_ = nullptr;
 
   base::WeakPtrFactory<NodeBindings> weak_factory_;
 

--- a/shell/renderer/atom_renderer_client.cc
+++ b/shell/renderer/atom_renderer_client.cc
@@ -176,8 +176,12 @@ void AtomRendererClient::WillReleaseScriptContext(
   // avoid memory leaks
   auto* command_line = base::CommandLine::ForCurrentProcess();
   if (command_line->HasSwitch(switches::kNodeIntegrationInSubFrames) ||
-      command_line->HasSwitch(switches::kDisableElectronSiteInstanceOverrides))
+      command_line->HasSwitch(
+          switches::kDisableElectronSiteInstanceOverrides)) {
     node::FreeEnvironment(env);
+    if (env == node_bindings_->uv_env())
+      node::FreeIsolateData(node_bindings_->isolate_data());
+  }
 
   // ElectronBindings is tracking node environments.
   electron_bindings_->EnvironmentDestroyed(env);

--- a/shell/renderer/web_worker_observer.cc
+++ b/shell/renderer/web_worker_observer.cc
@@ -38,6 +38,7 @@ WebWorkerObserver::WebWorkerObserver()
 WebWorkerObserver::~WebWorkerObserver() {
   lazy_tls.Pointer()->Set(nullptr);
   node::FreeEnvironment(node_bindings_->uv_env());
+  node::FreeIsolateData(node_bindings_->isolate_data());
   asar::ClearArchives();
 }
 


### PR DESCRIPTION
#### Description of Change

In preparing to see how we might set cli options via flags to Node.js, i came across another instance of us not properly freeing `IsolateData` after creating it in order to pass it to `node::CreateEnvironment`. This pulls out creation of the `IsolateData` and ensures that we're freeing it properly after freeing the environment holding it.

cc @nornagon @deepak1556 @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
