### PR TITLE
fix: trim branch name before comparing to master (#19853)

### DIFF
--- a/script/lib/utils.js
+++ b/script/lib/utils.js
@@ -38,8 +38,14 @@ async function getCurrentBranch (gitDir) {
   let branch = await handleGitCall(['rev-parse', '--abbrev-ref', 'HEAD'], gitDir)
   if (branch !== 'master' && !branch.match(/[0-9]+-[0-9]+-x/)) {
     const lastCommit = await handleGitCall(['rev-parse', 'HEAD'], gitDir)
-    const branches = (await handleGitCall(['branch', '--contains', lastCommit, '--remote'], gitDir)).split('\n')
-    branch = branches.filter(b => b === 'master' || b.match(/[0-9]+-[0-9]+-x/))[0]
+    const branches = (await handleGitCall([
+      'branch',
+      '--contains',
+      lastCommit,
+      '--remote'
+    ], gitDir)).split('\n')
+
+    branch = branches.filter(b => b.trim() === 'master' || b.match(/[0-9]+-[0-9]+-x/))[0]
     if (!branch) {
       console.log(`${fail} no release branch exists for this ref`)
       process.exit(1)


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Backport of #19853.

See that PR for details.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
