### PR TITLE
fix: cannot access nativeTheme via electron.remote

### DIFF
--- a/lib/browser/api/module-keys.js
+++ b/lib/browser/api/module-keys.js
@@ -21,6 +21,7 @@ module.exports = [
   { name: 'inAppPurchase' },
   { name: 'Menu' },
   { name: 'MenuItem' },
+  { name: 'nativeTheme' },
   { name: 'net' },
   { name: 'netLog' },
   { name: 'Notification' },

--- a/spec/api-remote-spec.js
+++ b/spec/api-remote-spec.js
@@ -155,10 +155,10 @@ ifdescribe(features.isRemoteModuleEnabled())('remote module', () => {
   })
 
   describe('remote modules', () => {
-    it('includes browser process modules as properties', () => {
-      expect(remote.app.getPath).to.be.a('function')
-      expect(remote.webContents.getFocusedWebContents).to.be.a('function')
-      expect(remote.clipboard.readText).to.be.a('function')
+    it('includes browser process modules as properties', async () => {
+      const mainModules = await ipcRenderer.invoke('get-modules')
+      const remoteModules = mainModules.filter(name => remote[name])
+      expect(remoteModules).to.be.deep.equal(mainModules)
     })
 
     it('returns toString() of original function via toString()', () => {

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -42,6 +42,7 @@ ipcMain.on('message', function (event, ...args) {
   event.sender.send('message', ...args)
 })
 
+ipcMain.handle('get-modules', () => Object.keys(electron))
 ipcMain.handle('get-temp-dir', () => app.getPath('temp'))
 ipcMain.handle('ping', () => null)
 


### PR DESCRIPTION
#### Description of Change
Fixes #20900

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed `nativeTheme` not accessible via the `remote` module.