### PR TITLE
fix: don't export __esModule = true by electron.ts

### DIFF
--- a/lib/browser/api/exports/electron.ts
+++ b/lib/browser/api/exports/electron.ts
@@ -2,5 +2,7 @@ import { defineProperties } from '@electron/internal/common/define-properties'
 import { commonModuleList } from '@electron/internal/common/api/module-list'
 import { browserModuleList } from '@electron/internal/browser/api/module-list'
 
-defineProperties(exports, commonModuleList)
-defineProperties(exports, browserModuleList)
+module.exports = {}
+
+defineProperties(module.exports, commonModuleList)
+defineProperties(module.exports, browserModuleList)

--- a/lib/renderer/api/exports/electron.ts
+++ b/lib/renderer/api/exports/electron.ts
@@ -2,5 +2,7 @@ import { defineProperties } from '@electron/internal/common/define-properties'
 import { commonModuleList } from '@electron/internal/common/api/module-list'
 import { rendererModuleList } from '@electron/internal/renderer/api/module-list'
 
-defineProperties(exports, commonModuleList)
-defineProperties(exports, rendererModuleList)
+module.exports = {}
+
+defineProperties(module.exports, commonModuleList)
+defineProperties(module.exports, rendererModuleList)

--- a/lib/sandboxed_renderer/api/exports/electron.ts
+++ b/lib/sandboxed_renderer/api/exports/electron.ts
@@ -1,4 +1,6 @@
 import { defineProperties } from '@electron/internal/common/define-properties'
 import { moduleList } from '@electron/internal/sandboxed_renderer/api/module-list'
 
-defineProperties(exports, moduleList)
+module.exports = {}
+
+defineProperties(module.exports, moduleList)


### PR DESCRIPTION
#### Description of Change
Fixes #20910

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Removed `__esModule = true` inadvertently exported by the `electron` module.