### PR TITLE
fix: proper i18n of recentDocuments item

### DIFF
--- a/shell/browser/ui/cocoa/atom_menu_controller.mm
+++ b/shell/browser/ui/cocoa/atom_menu_controller.mm
@@ -128,9 +128,11 @@ static base::scoped_nsobject<NSMenu> recentDocumentsMenuSwap_;
 
   // Locate & retain the recent documents menu item
   if (!recentDocumentsMenuItem_) {
-    recentDocumentsMenuItem_.reset(
-        [[[[[NSApp mainMenu] itemWithTitle:@"Electron"] submenu]
-            itemWithTitle:@"Open Recent"] retain]);
+    base::string16 title = base::ASCIIToUTF16("Open Recent");
+    NSString* openTitle = l10n_util::FixUpWindowsStyleLabel(title);
+
+    recentDocumentsMenuItem_.reset([[[[[NSApp mainMenu]
+        itemWithTitle:@"Electron"] submenu] itemWithTitle:openTitle] retain]);
   }
 
   model_ = model;


### PR DESCRIPTION
#### Description of Change

Properly i18n-ize menu item label. Regressed in https://github.com/electron/electron/pull/20615.

cc @nornagon @MarshallOfSound @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed improper label internationalization for the `recentDocuments` MenuItem.
