### PR TITLE
test: don't require 'q' until the test that needs it

### DIFF
--- a/spec-main/modules-spec.ts
+++ b/spec-main/modules-spec.ts
@@ -46,9 +46,9 @@ describe('modules support', () => {
     })
 
     describe('q', () => {
-      const Q = require('q')
       describe('Q.when', () => {
         it('emits the fullfil callback', (done) => {
+          const Q = require('q')
           Q(true).then((val: boolean) => {
             expect(val).to.be.true()
             done()


### PR DESCRIPTION
#### Description of Change
This stops a failure to require 'q' from blocking all tests from running.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
