### PR TITLE
chore: fix build with enable_electron_extensions

### DIFF
--- a/shell/browser/extensions/atom_extensions_browser_client.cc
+++ b/shell/browser/extensions/atom_extensions_browser_client.cc
@@ -233,13 +233,14 @@ AtomExtensionsBrowserClient::GetComponentExtensionResourceManager() {
 void AtomExtensionsBrowserClient::BroadcastEventToRenderers(
     extensions::events::HistogramValue histogram_value,
     const std::string& event_name,
-    std::unique_ptr<base::ListValue> args) {
+    std::unique_ptr<base::ListValue> args,
+    bool dispatch_to_off_the_record_profiles) {
   if (!BrowserThread::CurrentlyOn(BrowserThread::UI)) {
     base::PostTask(
         FROM_HERE, {BrowserThread::UI},
         base::BindOnce(&AtomExtensionsBrowserClient::BroadcastEventToRenderers,
                        base::Unretained(this), histogram_value, event_name,
-                       std::move(args)));
+                       std::move(args), dispatch_to_off_the_record_profiles));
     return;
   }
 

--- a/shell/browser/extensions/atom_extensions_browser_client.h
+++ b/shell/browser/extensions/atom_extensions_browser_client.h
@@ -105,7 +105,8 @@ class AtomExtensionsBrowserClient : public extensions::ExtensionsBrowserClient {
   void BroadcastEventToRenderers(
       extensions::events::HistogramValue histogram_value,
       const std::string& event_name,
-      std::unique_ptr<base::ListValue> args) override;
+      std::unique_ptr<base::ListValue> args,
+      bool dispatch_to_off_the_record_profiles) override;
   extensions::ExtensionCache* GetExtensionCache() override;
   bool IsBackgroundUpdateAllowed() override;
   bool IsMinBrowserVersionSupported(const std::string& min_version) override;


### PR DESCRIPTION
#### Description of Change
This broke in an upgrade. //extensions build is currently broken for other reasons at runtime but this at least fixes the FTBFS :)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none