### PR TITLE
fix: cannot access nativeTheme via electron.remote

### DIFF
--- a/lib/browser/api/module-keys.js
+++ b/lib/browser/api/module-keys.js
@@ -21,6 +21,7 @@ module.exports = [
   { name: 'inAppPurchase' },
   { name: 'Menu' },
   { name: 'MenuItem' },
+  { name: 'nativeTheme' },
   { name: 'net' },
   { name: 'netLog' },
   { name: 'Notification' },

--- a/spec/api-remote-spec.js
+++ b/spec/api-remote-spec.js
@@ -153,10 +153,10 @@ describe('remote module', () => {
   })
 
   describe('remote modules', () => {
-    it('includes browser process modules as properties', () => {
-      expect(remote.app.getPath).to.be.a('function')
-      expect(remote.webContents.getFocusedWebContents).to.be.a('function')
-      expect(remote.clipboard.readText).to.be.a('function')
+    it('includes browser process modules as properties', async () => {
+      const mainModules = await ipcRenderer.invoke('get-modules')
+      const remoteModules = mainModules.filter(name => remote[name])
+      expect(remoteModules).to.be.deep.equal(mainModules)
     })
 
     it('returns toString() of original function via toString()', () => {

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -42,6 +42,8 @@ ipcMain.on('message', function (event, ...args) {
   event.sender.send('message', ...args)
 })
 
+ipcMain.handle('get-modules', () => Object.keys(electron))
+
 // Set productName so getUploadedReports() uses the right directory in specs
 if (process.platform !== 'darwin') {
   crashReporter.productName = 'Zombies'


### PR DESCRIPTION
Backport of #20938

See that PR for details.

Notes: Fixed `nativeTheme` not accessible via the `remote` module.