### PR TITLE
fix: Fix broken globalShortcuts.registerAll() on non-macOS platforms

### DIFF
--- a/shell/browser/api/atom_api_global_shortcut.cc
+++ b/shell/browser/api/atom_api_global_shortcut.cc
@@ -74,19 +74,13 @@ bool GlobalShortcut::RegisterAll(
   std::vector<ui::Accelerator> registered;
 
   for (auto& accelerator : accelerators) {
-#if defined(OS_MACOSX)
-    if (RegisteringMediaKeyForUntrustedClient(accelerator))
-      return false;
-
-    GlobalShortcutListener* listener = GlobalShortcutListener::GetInstance();
-    if (!listener->RegisterAccelerator(accelerator, this)) {
+    if (!Register(accelerator, callback)) {
       // unregister all shortcuts if any failed
       UnregisterSome(registered);
       return false;
     }
-#endif
+
     registered.push_back(accelerator);
-    accelerator_callback_map_[accelerator] = callback;
   }
   return true;
 }


### PR DESCRIPTION
This was a regression in #16125, which unintentionally put
`GlobalShortcutListener::RegisterAccelerator` into a
`#if defined(OS_MACOSX)` block.

Notes: Fix broken `globalShortcut.registerAll()` on Windows and Linux