### PR TITLE
fix: correctly emplace optional values in the value converter

### DIFF
--- a/shell/common/native_mate_converters/value_converter.h
+++ b/shell/common/native_mate_converters/value_converter.h
@@ -44,7 +44,7 @@ struct Converter<base::Optional<T>> {
       return true;
     }
     T converted;
-    if (Converter<T>::FromV8(isolate, val, &converted)) {
+    if (!Converter<T>::FromV8(isolate, val, &converted)) {
       return true;
     }
     out->emplace(converted);

--- a/shell/common/native_mate_converters/value_converter.h
+++ b/shell/common/native_mate_converters/value_converter.h
@@ -41,10 +41,12 @@ struct Converter<base::Optional<T>> {
                      v8::Local<v8::Value> val,
                      base::Optional<T>* out) {
     if (val->IsNull() || val->IsUndefined()) {
+      *out = base::nullopt;
       return true;
     }
     T converted;
     if (!Converter<T>::FromV8(isolate, val, &converted)) {
+      *out = base::nullopt;
       return true;
     }
     out->emplace(converted);


### PR DESCRIPTION
I don't wanna talk about it....

Fixes #20941

Will follow up with a test for master, we do not need to fix anything in master as the gin converter migration fixed this by accident

Notes: Fixed issue where `app.setAppLogsPath` did not work when you provided a valid path