### PR TITLE
chore: remove deprecated <webview>.getWebContents()

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -485,18 +485,6 @@ Emitted when `remote.getCurrentWebContents()` is called in the renderer process 
 Calling `event.preventDefault()` will prevent the object from being returned.
 Custom value can be returned by setting `event.returnValue`.
 
-### Event: 'remote-get-guest-web-contents'
-
-Returns:
-
-* `event` Event
-* `webContents` [WebContents](web-contents.md)
-* `guestWebContents` [WebContents](web-contents.md)
-
-Emitted when `<webview>.getWebContents()` is called in the renderer process of `webContents`.
-Calling `event.preventDefault()` will prevent the object from being returned.
-Custom value can be returned by setting `event.returnValue`.
-
 ## Methods
 
 The `app` object has the following methods:

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -6,6 +6,20 @@ Breaking changes will be documented here, and deprecation warnings added to JS c
 
 The `FIXME` string is used in code comments to denote things that should be fixed for future releases. See https://github.com/electron/electron/search?q=fixme
 
+## Planned Breaking API Changes (9.0)
+
+### `<webview>.getWebContents()`
+
+This API, which was deprecated in Electron 8.0, is now removed.
+
+```js
+// Removed in Electron 9.0
+webview.getWebContents()
+// Replace with
+const { remote } = require('electron')
+remote.webContents.fromId(webview.getWebContentsId())
+```
+
 ## Planned Breaking API Changes (8.0)
 
 ### Values sent over IPC are now serialized with Structured Clone Algorithm

--- a/docs/api/command-line-switches.md
+++ b/docs/api/command-line-switches.md
@@ -190,7 +190,6 @@ Enables caller stack logging for the following APIs (filtering events):
 - `remote.getBuiltin()` / `remote-get-global`
 - `remote.getCurrentWindow()` / `remote-get-current-window`
 - `remote.getCurrentWebContents()` / `remote-get-current-web-contents`
-- `remote.getGuestWebContents()` / `remote-get-guest-web-contents`
 
 ## --no-sandbox
 

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -648,14 +648,6 @@ Sets the maximum and minimum layout-based (i.e. non-visual) zoom level.
 
 Shows pop-up dictionary that searches the selected word on the page.
 
-### `<webview>.getWebContents()` _Deprecated_
-
-Returns [`WebContents`](web-contents.md) - The web contents associated with
-this `webview`.
-
-It depends on the [`remote`](remote.md) module,
-it is therefore not available when this module is disabled.
-
 ### `<webview>.getWebContentsId()`
 
 Returns `Number` - The WebContents ID of this `webview`.

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -826,10 +826,6 @@ app.on('remote-get-current-window', (event, webContents) => {
 app.on('remote-get-current-web-contents', (event, webContents) => {
   event.preventDefault()
 })
-
-app.on('remote-get-guest-web-contents', (event, webContents, guestWebContents) => {
-  event.preventDefault()
-})
 ```
 
 ## 17) Use a current version of Electron

--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -347,10 +347,6 @@ handleMessage('ELECTRON_GUEST_VIEW_MANAGER_CREATE_GUEST', function (event, param
   return createGuest(event.sender, params)
 })
 
-handleMessageSync('ELECTRON_GUEST_VIEW_MANAGER_CREATE_GUEST', function (event, params) {
-  return createGuest(event.sender, params)
-})
-
 handleMessage('ELECTRON_GUEST_VIEW_MANAGER_ATTACH_GUEST', function (event, embedderFrameId, elementInstanceId, guestInstanceId, params) {
   try {
     attachGuest(event, embedderFrameId, elementInstanceId, guestInstanceId, params)
@@ -411,5 +407,4 @@ const getEmbedder = function (guestInstanceId) {
   if (guestInstance != null) return guestInstance.embedder
 }
 
-exports.getGuestForWebContents = getGuestForWebContents
 exports.isWebViewTagEnabled = isWebViewTagEnabled

--- a/lib/browser/remote/server.ts
+++ b/lib/browser/remote/server.ts
@@ -4,7 +4,6 @@ import * as electron from 'electron'
 import { EventEmitter } from 'events'
 import objectsRegistry from './objects-registry'
 import { ipcMainInternal } from '../ipc-main-internal'
-import * as guestViewManager from '@electron/internal/browser/guest-view-manager'
 import { isPromise, isSerializableObject } from '@electron/internal/common/remote/type-utils'
 
 const v8Util = process.electronBinding('v8_util')
@@ -541,23 +540,6 @@ handleRemoteCommand('ELECTRON_BROWSER_DEREFERENCE', function (event, contextId, 
 
 handleRemoteCommand('ELECTRON_BROWSER_CONTEXT_RELEASE', (event, contextId) => {
   objectsRegistry.clear(event.sender, contextId)
-})
-
-handleRemoteCommand('ELECTRON_BROWSER_GUEST_WEB_CONTENTS', function (event, contextId, guestInstanceId, stack) {
-  logStack(event.sender, 'remote.getGuestWebContents()', stack)
-  const guest = guestViewManager.getGuestForWebContents(guestInstanceId, event.sender)
-
-  const customEvent = emitCustomEvent(event.sender, 'remote-get-guest-web-contents', guest)
-
-  if (customEvent.returnValue === undefined) {
-    if (customEvent.defaultPrevented) {
-      throw new Error(`Blocked remote.getGuestWebContents()`)
-    } else {
-      customEvent.returnValue = guest
-    }
-  }
-
-  return valueToMeta(event.sender, contextId, customEvent.returnValue)
 })
 
 module.exports = {

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -342,13 +342,6 @@ exports.createFunctionWithReturnValue = (returnValue) => {
   return func
 }
 
-// Get the guest WebContents from guestInstanceId.
-exports.getGuestWebContents = (guestInstanceId) => {
-  const command = 'ELECTRON_BROWSER_GUEST_WEB_CONTENTS'
-  const meta = ipcRendererInternal.sendSync(command, contextId, guestInstanceId, getCurrentStack())
-  return metaToValue(meta)
-}
-
 const addBuiltinProperty = (name) => {
   Object.defineProperty(exports, name, {
     get: () => exports.getBuiltin(name)

--- a/lib/renderer/web-view/guest-view-internal.ts
+++ b/lib/renderer/web-view/guest-view-internal.ts
@@ -1,6 +1,5 @@
 import { webFrame, IpcMessageEvent } from 'electron'
 import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal'
-import * as ipcRendererUtils from '@electron/internal/renderer/ipc-renderer-internal-utils'
 
 import { WebViewImpl } from '@electron/internal/renderer/web-view/web-view-impl'
 
@@ -96,10 +95,6 @@ export function createGuest (params: Record<string, any>): Promise<number> {
   return ipcRendererInternal.invoke('ELECTRON_GUEST_VIEW_MANAGER_CREATE_GUEST', params)
 }
 
-export function createGuestSync (params: Record<string, any>): number {
-  return ipcRendererUtils.invokeSync('ELECTRON_GUEST_VIEW_MANAGER_CREATE_GUEST', params)
-}
-
 export function attachGuest (
   elementInstanceId: number, guestInstanceId: number, params: Record<string, any>, contentWindow: Window
 ) {
@@ -113,6 +108,5 @@ export function attachGuest (
 export const guestViewInternalModule = {
   deregisterEvents,
   createGuest,
-  createGuestSync,
   attachGuest
 }

--- a/lib/renderer/web-view/web-view-impl.ts
+++ b/lib/renderer/web-view/web-view-impl.ts
@@ -115,11 +115,6 @@ export class WebViewImpl {
     })
   }
 
-  createGuestSync () {
-    this.beforeFirstNavigation = false
-    this.attachGuestInstance(guestViewInternal.createGuestSync(this.buildParams()))
-  }
-
   dispatchEvent (webViewEvent: Electron.Event) {
     this.webviewNode.dispatchEvent(webViewEvent)
   }
@@ -223,26 +218,6 @@ export const setupMethods = (WebViewElement: typeof ElectronInternal.WebViewElem
     }
     return internal.guestInstanceId
   }
-
-  // WebContents associated with this webview.
-  WebViewElement.prototype.getWebContents = function () {
-    const remote = electron.remote as Electron.RemoteInternal
-    if (!remote) {
-      throw new Error('getGuestWebContents requires remote, which is not enabled')
-    }
-    const internal = v8Util.getHiddenValue<WebViewImpl>(this, 'internal')
-    if (!internal.guestInstanceId) {
-      internal.createGuestSync()
-    }
-
-    return remote.getGuestWebContents(internal.guestInstanceId!)
-  }
-
-  WebViewElement.prototype.getWebContents = electron.deprecate.moveAPI(
-    WebViewElement.prototype.getWebContents,
-    'webview.getWebContents()',
-    'remote.webContents.fromId(webview.getWebContentsId())'
-  ) as any
 
   // Focusing the webview should move page focus to the underlying iframe.
   WebViewElement.prototype.focus = function () {

--- a/spec/ts-smoke/electron/renderer.ts
+++ b/spec/ts-smoke/electron/renderer.ts
@@ -257,7 +257,6 @@ webview.capturePage().then(image => { console.log(image) })
 {
   const opened: boolean = webview.isDevToolsOpened()
   const focused: boolean = webview.isDevToolsFocused()
-  const focused2: boolean = webview.getWebContents().isFocused()
 }
 
 // In guest page.

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1018,36 +1018,7 @@ describe('<webview> tag', function () {
       const src = 'about:blank'
       await loadWebView(webview, { src })
 
-      expect(webview.getWebContentsId()).to.be.equal(webview.getWebContents().id)
-    })
-  })
-
-  describe('<webview>.getWebContents', () => {
-    it('can return the webcontents associated', async () => {
-      const src = 'about:blank'
-      await loadWebView(webview, { src })
-
-      const webviewContents = webview.getWebContents()
-      expect(webviewContents).to.be.an('object')
-      expect(webviewContents.getURL()).to.equal(src)
-    })
-  })
-
-  describe('<webview>.getWebContents filtering', () => {
-    it('can return custom value', async () => {
-      const src = 'about:blank'
-      await loadWebView(webview, { src })
-
-      ipcRenderer.send('handle-next-remote-get-guest-web-contents', 'Hello World!')
-      expect(webview.getWebContents()).to.be.equal('Hello World!')
-    })
-
-    it('throws when no returnValue set', async () => {
-      const src = 'about:blank'
-      await loadWebView(webview, { src })
-
-      ipcRenderer.send('handle-next-remote-get-guest-web-contents')
-      expect(() => webview.getWebContents()).to.throw('Blocked remote.getGuestWebContents()')
+      expect(webview.getWebContentsId()).to.be.a('number')
     })
   })
 

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -67,10 +67,6 @@ declare namespace Electron {
     sendToAll(webContentsId: number, channel: string, ...args: any[]): void
   }
 
-  interface RemoteInternal extends Electron.Remote {
-    getGuestWebContents(guestInstanceId: number): Electron.WebContents;
-  }
-
   interface WebContentsInternal extends Electron.WebContents {
     _sendInternal(channel: string, ...args: any[]): void;
     _sendInternalToAll(channel: string, ...args: any[]): void;
@@ -165,7 +161,6 @@ declare namespace ElectronInternal {
     public disconnectedCallback(): void;
 
     // Created in web-view-impl
-    public getWebContents(): Electron.WebContents;
     public getWebContentsId(): number;
   }
 }


### PR DESCRIPTION
#### Description of Change
Remove `<webview>.getWebContents()` deprecated in #20726.
The issue described in #18462 can no longer happen.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Removed deprecated `<webview>.getWebContents()`.