### PR TITLE
chore: emit the document-start and document-end events in a sandboxed renderers

### DIFF
--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -94,6 +94,8 @@ Object.defineProperty(preloadProcess, 'noDeprecation', {
 
 process.on('loaded', () => preloadProcess.emit('loaded'))
 process.on('exit', () => preloadProcess.emit('exit'))
+process.on('document-start', () => preloadProcess.emit('document-start'))
+process.on('document-end', () => preloadProcess.emit('document-end'))
 
 // This is the `require` function that will be visible to the preload script
 function preloadRequire (module) {


### PR DESCRIPTION
These events are undocumented (we should consider documenting them).  But folks trying to use sandbox mode that rely on them will find themselves stuck.

This just proxies the events, nice and clean 👍 

Closes #20256

Notes: no-notes