### PR TITLE
feat: add net.online / net.isOnline()

### DIFF
--- a/docs/api/net.md
+++ b/docs/api/net.md
@@ -8,7 +8,7 @@ The `net` module is a client-side API for issuing HTTP(S) requests. It is
 similar to the [HTTP](https://nodejs.org/api/http.html) and
 [HTTPS](https://nodejs.org/api/https.html) modules of Node.js but uses
 Chromium's native networking library instead of the Node.js implementation,
-offering better support for web proxies.
+offering better support for web proxies. It also supports checking network status.
 
 The following is a non-exhaustive list of why you may consider using the `net`
 module instead of the native Node.js modules:
@@ -62,3 +62,25 @@ Creates a [`ClientRequest`](./client-request.md) instance using the provided
 `options` which are directly forwarded to the `ClientRequest` constructor.
 The `net.request` method would be used to issue both secure and insecure HTTP
 requests according to the specified protocol scheme in the `options` object.
+
+### `net.isOnline()`
+
+Returns `Boolean` - Whether there is currently internet connection.
+
+A return value of `false` is a pretty strong indicator that the user
+won't be able to connect to remote sites. However, a return value of
+`true` is inconclusive; even if some link is up, it is uncertain
+whether a particular connection attempt to a particular remote site
+will be successful.
+
+## Properties
+
+### `net.online` _Readonly_
+
+A `Boolean` property. Whether there is currently internet connection.
+
+A return value of `false` is a pretty strong indicator that the user
+won't be able to connect to remote sites. However, a return value of
+`true` is inconclusive; even if some link is up, it is uncertain
+whether a particular connection attempt to a particular remote site
+will be successful.

--- a/lib/browser/api/net.ts
+++ b/lib/browser/api/net.ts
@@ -4,6 +4,7 @@ import { app } from 'electron/main';
 import type { ClientRequestConstructorOptions, UploadProgress } from 'electron/main';
 
 const {
+  isOnline,
   isValidHeaderName,
   isValidHeaderValue,
   createURLLoader
@@ -516,3 +517,9 @@ export class ClientRequest extends Writable implements Electron.ClientRequest {
 export function request (options: ClientRequestConstructorOptions | string, callback?: (message: IncomingMessage) => void) {
   return new ClientRequest(options, callback);
 }
+
+exports.isOnline = isOnline;
+
+Object.defineProperty(exports, 'online', {
+  get: () => isOnline()
+});

--- a/shell/browser/api/electron_api_net.cc
+++ b/shell/browser/api/electron_api_net.cc
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "gin/handle.h"
+#include "net/base/network_change_notifier.h"
 #include "services/network/public/cpp/features.h"
 #include "shell/browser/api/electron_api_url_loader.h"
 #include "shell/common/gin_helper/dictionary.h"
@@ -13,6 +14,10 @@
 #include "shell/common/node_includes.h"
 
 namespace {
+
+bool IsOnline() {
+  return !net::NetworkChangeNotifier::IsOffline();
+}
 
 bool IsValidHeaderName(std::string header_name) {
   return net::HttpUtil::IsValidHeaderName(header_name);
@@ -31,6 +36,7 @@ void Initialize(v8::Local<v8::Object> exports,
   v8::Isolate* isolate = context->GetIsolate();
 
   gin_helper::Dictionary dict(isolate, exports);
+  dict.SetMethod("isOnline", &IsOnline);
   dict.SetMethod("isValidHeaderName", &IsValidHeaderName);
   dict.SetMethod("isValidHeaderValue", &IsValidHeaderValue);
   dict.SetMethod("createURLLoader", &SimpleURLLoaderWrapper::Create);

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -1500,6 +1500,16 @@ describe('net module', () => {
     });
   });
 
+  describe('net.isOnline', () => {
+    it('getter returns boolean', () => {
+      expect(net.isOnline()).to.be.a('boolean');
+    });
+
+    it('property returns boolean', () => {
+      expect(net.online).to.be.a('boolean');
+    });
+  });
+
   describe('Stability and performance', () => {
     it('should free unreferenced, never-started request objects without crash', (done) => {
       net.request('https://test');

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -194,6 +194,7 @@ declare namespace NodeJS {
       createPair(): { port1: Electron.MessagePortMain, port2: Electron.MessagePortMain };
     };
     _linkedBinding(name: 'electron_browser_net'): {
+      isOnline(): boolean;
       isValidHeaderName: (headerName: string) => boolean;
       isValidHeaderValue: (headerValue: string) => boolean;
       Net: any;


### PR DESCRIPTION
#### Description of Change
It allows the app to tell that the machine is online without creating a `BrowserWindow`, in the main process.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `net.online` for detecting whether there is currently internet connection.