### PR TITLE
refactor: always initialize api::Protocol

### DIFF
--- a/shell/browser/api/atom_api_session.cc
+++ b/shell/browser/api/atom_api_session.cc
@@ -226,6 +226,8 @@ Session::Session(v8::Isolate* isolate, AtomBrowserContext* browser_context)
 
   new SessionPreferences(browser_context);
 
+  protocol_.Reset(isolate, Protocol::Create(isolate, browser_context).ToV8());
+
   Init(isolate);
   AttachAsUserData(browser_context);
 }
@@ -609,11 +611,6 @@ v8::Local<v8::Value> Session::Cookies(v8::Isolate* isolate) {
 }
 
 v8::Local<v8::Value> Session::Protocol(v8::Isolate* isolate) {
-  if (protocol_.IsEmpty()) {
-    v8::Local<v8::Value> handle;
-    handle = Protocol::Create(isolate, browser_context()).ToV8();
-    protocol_.Reset(isolate, handle);
-  }
   return v8::Local<v8::Value>::New(isolate, protocol_);
 }
 


### PR DESCRIPTION
#### Description of Change
Since we now depend on `api::Protocol` existing in order to call `LoadURL` (it's required in `AtomBrowserClient::WillCreateURLLoaderFactory`), we might as well create it unconditionally. Currently it's already created unconditionally by [this line](https://github.com/electron/electron/blob/e5ba6c5406910875b6e7be818856a5643871de2f/lib/browser/chrome-extension.js#L435), which is somewhat surprising. This makes it explicit.

This also fixes a crash when using `enable_electron_extensions`, which disables the above code, and as such also disables the creation of the `api::Protocol` object, leading to a crash when calling `LoadURL`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
