### PR TITLE
fix: crash on exit in aura platforms with webview

### DIFF
--- a/shell/browser/web_view_manager.cc
+++ b/shell/browser/web_view_manager.cc
@@ -62,10 +62,14 @@ content::WebContents* WebViewManager::GetGuestByInstanceID(
 
 bool WebViewManager::ForEachGuest(content::WebContents* embedder_web_contents,
                                   const GuestCallback& callback) {
-  for (auto& item : web_contents_embedder_map_)
-    if (item.second.embedder == embedder_web_contents &&
-        callback.Run(item.second.web_contents))
+  for (auto& item : web_contents_embedder_map_) {
+    if (item.second.embedder != embedder_web_contents)
+      continue;
+
+    auto* guest_web_contents = item.second.web_contents;
+    if (guest_web_contents && callback.Run(guest_web_contents))
       return true;
+  }
   return false;
 }
 


### PR DESCRIPTION
#### Description of Change

Don't have a solid test case for this as it seems to be a race, this was found when upgrading to electron 7 https://github.com/microsoft/vscode/pull/83796

The following crash was reliable in that branch

```
Received signal 11 SEGV_MAPERR fffffffd5336c6c6
#4 0x55992ace5d97 content::BrowserPluginEmbedder::DidSendScreenRectsCallback()
#5 0x55992862aad4 electron::WebViewManager::ForEachGuest()
#6 0x55992ace5e2e content::BrowserPluginEmbedder::DidSendScreenRects()
#7 0x55992b2c5930 content::WebContentsImpl::SendScreenRects()
#8 0x55992ca5a2ed aura::Window::NotifyWindowHierarchyChangeAtReceiver()
#9 0x55992ca5a085 aura::Window::NotifyWindowHierarchyChangeDown()
#10 0x55992ca5a0ab aura::Window::NotifyWindowHierarchyChangeDown()
#11 0x55992ca5a0ab aura::Window::NotifyWindowHierarchyChangeDown()
#12 0x55992ca55fcd aura::Window::RemoveChild()
#13 0x55992ca55deb aura::Window::RemoveOrDestroyChildren()
#14 0x55992ca557f6 aura::Window::~Window()
#15 0x55992ca560fe aura::Window::~Window()
#16 0x55992ca55e1d aura::Window::RemoveOrDestroyChildren()
#17 0x55992ca557f6 aura::Window::~Window()
#18 0x55992ca560fe aura::Window::~Window()
#19 0x55992ca67d98 aura::WindowTreeHost::DestroyDispatcher()
#20 0x55992f4ec77d views::DesktopWindowTreeHostPlatform::~DesktopWindowTreeHostPlatform()
#21 0x55992f4e3b1e views::DesktopWindowTreeHostX11::~DesktopWindowTreeHostX11()
#22 0x55992f4dbd05 views::DesktopNativeWidgetAura::OnHostClosed()
#23 0x55992f4e915f views::DesktopWindowTreeHostX11::OnClosed()
#24 0x55992f4ed9d8 views::DesktopWindowTreeHostPlatform::CloseNow()
#25 0x55992f4bf937 views::Widget::CloseNow()
#26 0x55992862b8ba electron::WindowList::DestroyAllWindows()
#27 0x5599285e0da5 electron::Browser::Exit()
#28 0x559928551bed mate::internal::Dispatcher<>::DispatchToCallback()
#29 0x559929796499 v8::internal::FunctionCallbackArguments::Call()
#30 0x559929732711 v8::internal::(anonymous namespace)::HandleApiCallHelper<>()
#31 0x559929730bf6 v8::internal::Builtin_Impl_HandleApiCall()
#32 0x5599297305ad v8::internal::Builtin_HandleApiCall()
```

`WebViewManager` has a lifetime of `BrowserContext` and when it tries to iterate over the guest webcontents during exit, it doesn't check for the validity of the guest contents nor does the `BrowserPluginEmbedder` which leads to UAF scenario. This PR addresses it.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix crash on exit in aura platforms with webview
