### PR TITLE
build: missing include in windows release builds

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -85,3 +85,4 @@ feat_unset_window_aspect_ratio_on_linux.patch
 fix_ambiguous_reference_to_data.patch
 backport_fix_msstl_compat_in_ui_events.patch
 build_win_fix_msstl_compatibility_for_pdf.patch
+fix_missing_algorithm_include.patch

--- a/patches/chromium/feat_unset_window_aspect_ratio_on_linux.patch
+++ b/patches/chromium/feat_unset_window_aspect_ratio_on_linux.patch
@@ -7,7 +7,7 @@ Electron has exposed methods to allow setting the aspect ratio
 for a given window, and as a part of that needed to allow users to
 reset the aspect ratio. On macOS, we can do this with existing APIs,
 but on Linux this was not possible using currently exposed APIs without
-this patch. 
+this patch.
 
 Upstreamed at https://chromium-review.googlesource.com/c/chromium/src/+/1895789.
 

--- a/patches/chromium/fix_missing_algorithm_include.patch
+++ b/patches/chromium/fix_missing_algorithm_include.patch
@@ -1,0 +1,76 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Thu, 7 Nov 2019 16:49:03 -0800
+Subject: fix: missing algorithm include
+
+This file had an include-what-you-use issue leading to release build
+failures, as it was unable to find max in the std namespace.
+
+Upstreamed at https://chromium-review.googlesource.com/c/chromium/src/+/1904823.
+
+diff --git a/media/base/byte_queue.cc b/media/base/byte_queue.cc
+index 245fafa668568fd308e5a2806dafc1c5f0bf3dbd..f9cd0c214ac6210d4332bad47b56ef8130be67a2 100644
+--- a/media/base/byte_queue.cc
++++ b/media/base/byte_queue.cc
+@@ -4,6 +4,8 @@
+ 
+ #include "media/base/byte_queue.h"
+ 
++#include <algorithm>
++
+ #include "base/logging.h"
+ #include "base/numerics/checked_math.h"
+ 
+diff --git a/third_party/blink/public/platform/web_time_range.h b/third_party/blink/public/platform/web_time_range.h
+index 2c17f7c8ce58f1255994e9e6fd74f70fa1a22b1c..4b0a59bf3308b49d2c4ffd86120759417094cb21 100644
+--- a/third_party/blink/public/platform/web_time_range.h
++++ b/third_party/blink/public/platform/web_time_range.h
+@@ -31,6 +31,8 @@
+ #ifndef THIRD_PARTY_BLINK_PUBLIC_PLATFORM_WEB_TIME_RANGE_H_
+ #define THIRD_PARTY_BLINK_PUBLIC_PLATFORM_WEB_TIME_RANGE_H_
+ 
++#include <algorithm>
++
+ #include "third_party/blink/public/platform/web_vector.h"
+ 
+ namespace blink {
+diff --git a/third_party/blink/renderer/core/layout/min_max_size.h b/third_party/blink/renderer/core/layout/min_max_size.h
+index c3fdbde6e4bf585351b3fc8d0ce2bd2673a82b5e..4233e6c79a1d67dd6c1ca33929d0beedbf9a1116 100644
+--- a/third_party/blink/renderer/core/layout/min_max_size.h
++++ b/third_party/blink/renderer/core/layout/min_max_size.h
+@@ -5,6 +5,8 @@
+ #ifndef THIRD_PARTY_BLINK_RENDERER_CORE_LAYOUT_MIN_MAX_SIZE_H_
+ #define THIRD_PARTY_BLINK_RENDERER_CORE_LAYOUT_MIN_MAX_SIZE_H_
+ 
++#include <algorithm>
++
+ #include "third_party/blink/renderer/core/core_export.h"
+ #include "third_party/blink/renderer/platform/geometry/layout_unit.h"
+ 
+diff --git a/third_party/blink/renderer/core/layout/ng/geometry/ng_margin_strut.h b/third_party/blink/renderer/core/layout/ng/geometry/ng_margin_strut.h
+index 50f699428acf8251f14411dc30caa750cfac88bf..8236afa14ee99b5f61e6c785721abf62299cbaed 100644
+--- a/third_party/blink/renderer/core/layout/ng/geometry/ng_margin_strut.h
++++ b/third_party/blink/renderer/core/layout/ng/geometry/ng_margin_strut.h
+@@ -5,6 +5,8 @@
+ #ifndef THIRD_PARTY_BLINK_RENDERER_CORE_LAYOUT_NG_GEOMETRY_NG_MARGIN_STRUT_H_
+ #define THIRD_PARTY_BLINK_RENDERER_CORE_LAYOUT_NG_GEOMETRY_NG_MARGIN_STRUT_H_
+ 
++#include <algorithm>
++
+ #include "third_party/blink/renderer/core/core_export.h"
+ #include "third_party/blink/renderer/platform/geometry/layout_unit.h"
+ 
+diff --git a/third_party/blink/renderer/core/style/style_difference.h b/third_party/blink/renderer/core/style/style_difference.h
+index 91292961f1f02e53c58653f72297ea05d78fc07b..517fbb8f5a7aa549373e3806aaec4b3d1f0ec13f 100644
+--- a/third_party/blink/renderer/core/style/style_difference.h
++++ b/third_party/blink/renderer/core/style/style_difference.h
+@@ -5,7 +5,9 @@
+ #ifndef THIRD_PARTY_BLINK_RENDERER_CORE_STYLE_STYLE_DIFFERENCE_H_
+ #define THIRD_PARTY_BLINK_RENDERER_CORE_STYLE_STYLE_DIFFERENCE_H_
+ 
++#include <algorithm>
+ #include <iosfwd>
++
+ #include "third_party/blink/renderer/core/core_export.h"
+ #include "third_party/blink/renderer/platform/wtf/allocator/allocator.h"
+ #include "third_party/blink/renderer/platform/wtf/assertions.h"


### PR DESCRIPTION
#### Description of Change

Fixes an error whereby release builds are failing on Windows due to several missing `#include <algorithm>`s.

cc @deepak1556 @nornagon @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
