### PR TITLE
fix: allow reading body from non-2xx responses in net.request

### DIFF
--- a/shell/browser/api/atom_api_url_request.cc
+++ b/shell/browser/api/atom_api_url_request.cc
@@ -286,6 +286,8 @@ bool URLRequest::Write(v8::Local<v8::Value> data, bool is_last) {
     network::ResourceRequest* request_ref = request_.get();
     loader_ = network::SimpleURLLoader::Create(std::move(request_),
                                                kTrafficAnnotation);
+
+    loader_->SetAllowHttpErrorResults(true);
     loader_->SetOnResponseStartedCallback(
         base::Bind(&URLRequest::OnResponseStarted, weak_factory_.GetWeakPtr()));
     loader_->SetOnRedirectCallback(

--- a/spec-main/api-session-spec.ts
+++ b/spec-main/api-session-spec.ts
@@ -511,12 +511,19 @@ describe('session module', () => {
       const fetch = (url: string) => new Promise((resolve, reject) => {
         const request = net.request({ url, session: ses })
         request.on('response', (response) => {
-          let data = ''
+          let data: string | null = null
           response.on('data', (chunk) => {
+            if (!data) {
+              data = ''
+            }
             data += chunk
           })
           response.on('end', () => {
-            resolve(data)
+            if (!data) {
+              reject(new Error('Empty response'))
+            } else {
+              resolve(data)
+            }
           })
           response.on('error', (error: any) => { reject(new Error(error)) })
         })


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Context: https://cs.chromium.org/chromium/src/services/network/public/cpp/simple_url_loader.h?dr=C&g=0&l=262-276

`SimpleURLLoader` by default do not allow non-2xx http response as results, raises `ERR_HTTP_RESPONSE_CODE_FAILURE` and it makes attempt to read response body for those response not possible in net module's clientrequest.

This PR changes urlloader configuration to allow - this behavior matches to previous `net` module implementation, as well as browser native like `fetch`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed net module request raises error when non-2xx response received.
