### PR TITLE
build: fix nightly version bumping

### DIFF
--- a/script/release/version-utils.js
+++ b/script/release/version-utils.js
@@ -72,7 +72,7 @@ async function nextNightly (v) {
 
 async function getLastMajorForMaster () {
   let branchNames
-  const result = await GitProcess.exec(['branch', '-a', '--remote', '--list', 'origin/[0-9]-[0-9]-x'], ELECTRON_DIR)
+  const result = await GitProcess.exec(['branch', '-a', '--remote', '--list', 'origin/[0-9]*-x-y'], ELECTRON_DIR)
   if (result.exitCode === 0) {
     branchNames = result.stdout.trim().split('\n')
     const filtered = branchNames.map(b => b.replace('origin/', ''))
@@ -83,7 +83,7 @@ async function getLastMajorForMaster () {
 }
 
 function getNextReleaseBranch (branches) {
-  const converted = branches.map(b => b.replace(/-/g, '.').replace('x', '0'))
+  const converted = branches.map(b => b.replace(/-/g, '.').replace('x', '0').replace('y', '0'))
   return converted.reduce((v1, v2) => semver.gt(v1, v2) ? v1 : v2)
 }
 

--- a/spec-main/version-bump-spec.ts
+++ b/spec-main/version-bump-spec.ts
@@ -67,11 +67,10 @@ describe('version-bumper', () => {
       const matches = next.match(nightlyPattern)
       expect(matches).to.have.lengthOf(1)
     })
-    
+
     it('bumps to a nightly version above our switch from N-0-x to N-x-y branch names', async () => {
       const version = 'v2.0.0-nightly.19950901'
       const next = await nextVersion('nightly', version)
-      const matches = next.match(nightlyPattern)
       // If it starts with v8 then we didn't bump above the 8-x-y branch
       expect(next.startsWith('v8')).to.equal(false)
     })

--- a/spec-main/version-bump-spec.ts
+++ b/spec-main/version-bump-spec.ts
@@ -67,6 +67,14 @@ describe('version-bumper', () => {
       const matches = next.match(nightlyPattern)
       expect(matches).to.have.lengthOf(1)
     })
+    
+    it('bumps to a nightly version above our switch from N-0-x to N-x-y branch names', async () => {
+      const version = 'v2.0.0-nightly.19950901'
+      const next = await nextVersion('nightly', version)
+      const matches = next.match(nightlyPattern)
+      // If it starts with v8 then we didn't bump above the 8-x-y branch
+      expect(next.startsWith('v8')).to.equal(false)
+    })
 
     it('throws error when bumping to beta from stable', () => {
       const version = 'v2.0.0'


### PR DESCRIPTION
Makes it so that the version bumper for nightlies knows that `N-x-y` is a thing

Notes: no-notes