### PR TITLE
feat: enhance PrinterInfo object values

### DIFF
--- a/docs/api/structures/printer-info.md
+++ b/docs/api/structures/printer-info.md
@@ -1,9 +1,13 @@
 # PrinterInfo Object
 
-* `name` String
-* `description` String
-* `status` Number
-* `isDefault` Boolean
+* `name` String - the name of the printer as understood by the OS.
+* `displayName` String - the name of the printer as shown in Print Preview.
+* `description` String - a longer description of the printer's type.
+* `status` Number - the current status of the printer.
+* `isDefault` Boolean - whether or not a given printer is set as the default printer on the OS.
+* `options` Object - an object containing a variable number of platform-specific printer information.
+
+The number represented by `status` means different things on different platforms: on Windows it's potential values can be found [here](https://docs.microsoft.com/en-us/windows/win32/printdocs/printer-info-2), and on Linux and macOS they can be found [here](https://www.cups.org/doc/cupspm.html).
 
 ## Example
 
@@ -12,13 +16,14 @@ may be different on each platform.
 
 ```javascript
 {
-  name: 'Zebra_LP2844',
-  description: 'Zebra LP2844',
+  name: 'Austin_4th_Floor_Printer___C02XK13BJHD4',
+  displayName: 'Austin 4th Floor Printer @ C02XK13BJHD4',
+  description: 'TOSHIBA ColorMFP',
   status: 3,
   isDefault: false,
   options: {
     copies: '1',
-    'device-uri': 'usb://Zebra/LP2844?location=14200000',
+    'device-uri': 'dnssd://Austin%204th%20Floor%20Printer%20%40%20C02XK13BJHD4._ipps._tcp.local./?uuid=71687f1e-1147-3274-6674-22de61b110bd',
     finishings: '3',
     'job-cancel-after': '10800',
     'job-hold-until': 'no-hold',
@@ -26,18 +31,19 @@ may be different on each platform.
     'job-sheets': 'none,none',
     'marker-change-time': '0',
     'number-up': '1',
-    'printer-commands': 'none',
-    'printer-info': 'Zebra LP2844',
+    'printer-commands': 'ReportLevels,PrintSelfTestPage,com.toshiba.ColourProfiles.update,com.toshiba.EFiling.update,com.toshiba.EFiling.checkPassword',
+    'printer-info': 'Austin 4th Floor Printer @ C02XK13BJHD4',
     'printer-is-accepting-jobs': 'true',
-    'printer-is-shared': 'true',
+    'printer-is-shared': 'false',
+    'printer-is-temporary': 'false',
     'printer-location': '',
-    'printer-make-and-model': 'Zebra EPL2 Label Printer',
+    'printer-make-and-model': 'TOSHIBA ColorMFP',
     'printer-state': '3',
-    'printer-state-change-time': '1484872644',
-    'printer-state-reasons': 'offline-report',
-    'printer-type': '36932',
-    'printer-uri-supported': 'ipp://localhost/printers/Zebra_LP2844',
-    system_driverinfo: 'Z'
+    'printer-state-change-time': '1573472937',
+    'printer-state-reasons': 'offline-report,com.toshiba.snmp.failed',
+    'printer-type': '10531038',
+    'printer-uri-supported': 'ipp://localhost/printers/Austin_4th_Floor_Printer___C02XK13BJHD4',
+    system_driverinfo: 'T'
   }
 }
 ```

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -131,6 +131,7 @@ struct Converter<printing::PrinterBasicInfo> {
                                    const printing::PrinterBasicInfo& val) {
     gin_helper::Dictionary dict = gin::Dictionary::CreateEmpty(isolate);
     dict.Set("name", val.printer_name);
+    dict.Set("displayName", val.display_name);
     dict.Set("description", val.printer_description);
     dict.Set("status", val.printer_status);
     dict.Set("isDefault", val.is_default ? true : false);


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/21058.

Improves both documentation and returned object data for `webContents.getPrinters()` in the following ways:
1) Adds a `displayName` field to distinguish the name of the printer as understood by the OS from the name of the printer as shown in Print Preview.
2) Adds descriptions for `PrinterInfo` structure data.

cc @miniak @nornagon @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Improved the returned types and descriptions for the `PrinterInfo` API structure returned by `webContents.getPrinters`.
