### PR TITLE
build: make CI faster, magic contained within

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ parameters:
 # Build machines configs.
 docker-image: &docker-image
   docker:
-    - image: electronjs/build:697b894f36d127155e020f4e8ad4b2e5f6a09613
+    - image: electronbuilds/electron:0.0.10
 
 machine-linux-medium: &machine-linux-medium
   <<: *docker-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -693,7 +693,7 @@ step-restore-out-cache: &step-restore-out-cache
     paths:
       - ./src/out/Default
     keys:
-      - v6-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
+      - v7-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
     name: Restoring out cache
 
 step-set-git-cache-path: &step-set-git-cache-path
@@ -717,7 +717,7 @@ step-save-out-cache: &step-save-out-cache
   save_cache:
     paths:
       - ./src/out/Default
-    key: v6-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
+    key: v7-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
     name: Persisting out cache
 
 step-run-electron-only-hooks: &step-run-electron-only-hooks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1190,6 +1190,7 @@ chromium-upgrade-branches: &chromium-upgrade-branches
 commands:
   checkout-from-cache:
     steps:
+      - *step-checkout-electron
       - *step-maybe-early-exit-doc-only-change
       - *step-depot-tools-get
       - *step-depot-tools-add-to-path

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -847,40 +847,6 @@ steps-lint: &steps-lint
           node script/yarn install --frozen-lockfile
           node script/yarn lint
 
-steps-checkout-fast: &steps-checkout-fast
-  steps:
-    - *step-checkout-electron
-    - *step-check-for-doc-only-change
-    - *step-persist-doc-only-change
-    - *step-maybe-early-exit-doc-only-change
-    - *step-depot-tools-get
-    - *step-depot-tools-add-to-path
-    - *step-restore-brew-cache
-    - *step-get-more-space-on-mac
-    - *step-install-gnutar-on-mac
-
-    - *step-generate-deps-hash
-    - *step-touch-sync-done
-    - *step-maybe-restore-src-cache
-    - *step-maybe-restore-git-cache
-    - *step-set-git-cache-path
-    # This sync call only runs if .circle-sync-done is an EMPTY file
-    - *step-gclient-sync
-    # These next few steps reset Electron to the correct commit regardless of which cache was restored
-    - run:
-        name: Wipe Electron
-        command: rm -rf src/electron
-    - *step-checkout-electron
-    - *step-run-electron-only-hooks
-    - *step-generate-deps-hash-cleanly
-    - *step-mark-sync-done
-    - *step-minimize-workspace-size-from-checkout
-    - persist_to_workspace:
-        root: .
-        paths:
-          - depot_tools
-          - src
-
 steps-checkout-and-save-cache: &steps-checkout-and-save-cache
   steps:
     - *step-checkout-electron
@@ -1230,9 +1196,21 @@ commands:
       persist:
         type: boolean
         default: true
+      persist-checkout:
+        type: boolean
+        default: false
       checkout:
         type: boolean
         default: true
+      checkout-out-cache-for-workspace:
+        type: boolean
+        default: false
+      build:
+        type: boolean
+        default: true
+      out-cache-attached:
+        type: boolean
+        default: false
     steps:
       - when:
           condition: << parameters.attach >>
@@ -1268,50 +1246,72 @@ commands:
             - *step-generate-deps-hash-cleanly
             - *step-mark-sync-done
             - *step-minimize-workspace-size-from-checkout
+            - when:
+                condition: << parameters.persist-checkout >>
+                steps:
+                  - persist_to_workspace:
+                      root: .
+                      paths:
+                        - depot_tools
+                        - src
+                  - when:
+                      condition: << parameters.checkout-out-cache-for-workspace >>
+                      steps:
+                        - *step-restore-out-cache
+                        - persist_to_workspace:
+                            root: .
+                            paths:
+                              - src/out/Default
 
-      - *step-depot-tools-add-to-path
-      - *step-setup-env-for-build
-      - *step-restore-brew-cache
-      - *step-get-more-space-on-mac
-      - *step-install-npm-deps-on-mac
-      - *step-fix-sync-on-mac
-      - *step-delete-git-directories
-      - *step-gn-gen-default
+      - when:
+          condition: << parameters.build >>
+          steps:
+            - *step-depot-tools-add-to-path
+            - *step-setup-env-for-build
+            - *step-restore-brew-cache
+            - *step-get-more-space-on-mac
+            - *step-install-npm-deps-on-mac
+            - *step-fix-sync-on-mac
+            - *step-delete-git-directories
+            - *step-gn-gen-default
 
-      # Electron app
-      - *step-restore-out-cache
-      - *step-electron-build
-      - *step-save-out-cache
-      - *step-ninja-summary
-      - *step-ninja-report
-      - *step-maybe-electron-dist-strip
-      - *step-electron-dist-build
-      - *step-electron-dist-store
+            # Electron app
+            - when:
+                unless: << parameters.out-cache-attached >>
+                steps:
+                  - *step-restore-out-cache
+            - *step-electron-build
+            - *step-save-out-cache
+            - *step-ninja-summary
+            - *step-ninja-report
+            - *step-maybe-electron-dist-strip
+            - *step-electron-dist-build
+            - *step-electron-dist-store
 
-      # Native test targets
-      - *step-native-unittests-build
-      - *step-native-unittests-store
+            # Native test targets
+            - *step-native-unittests-build
+            - *step-native-unittests-store
 
-      # Node.js headers
-      - *step-nodejs-headers-build
-      - *step-nodejs-headers-store
+            # Node.js headers
+            - *step-nodejs-headers-build
+            - *step-nodejs-headers-store
 
-      - *step-show-sccache-stats
+            - *step-show-sccache-stats
 
-      # mksnapshot
-      - *step-mksnapshot-build
-      - *step-mksnapshot-store
-      - *step-maybe-cross-arch-snapshot
-      - *step-maybe-cross-arch-snapshot-store
+            # mksnapshot
+            - *step-mksnapshot-build
+            - *step-mksnapshot-store
+            - *step-maybe-cross-arch-snapshot
+            - *step-maybe-cross-arch-snapshot-store
 
-      # ffmpeg
-      - *step-ffmpeg-gn-gen
-      - *step-ffmpeg-build
-      - *step-ffmpeg-store
+            # ffmpeg
+            - *step-ffmpeg-gn-gen
+            - *step-ffmpeg-build
+            - *step-ffmpeg-store
 
-      # hunspell
-      - *step-hunspell-build
-      - *step-hunspell-store
+            # hunspell
+            - *step-hunspell-build
+            - *step-hunspell-store
 
       # Save all data needed for a further tests run.
       - when:
@@ -1319,9 +1319,12 @@ commands:
           steps:
             - *step-persist-data-for-tests
 
-      - *step-maybe-generate-breakpad-symbols
-      - *step-maybe-zip-symbols
-      - *step-symbols-store
+      - when:
+          condition: << parameters.build >>
+          steps:
+            - *step-maybe-generate-breakpad-symbols
+            - *step-maybe-zip-symbols
+            - *step-symbols-store
 
       # Trigger tests on arm hardware if needed
       - *step-maybe-trigger-arm-test
@@ -1350,7 +1353,12 @@ jobs:
     environment:
       <<: *env-linux-2xlarge
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
-    <<: *steps-checkout-fast
+    steps:
+      - electron-build:
+          persist: false
+          build: false
+          checkout: true
+          persist-checkout: true
 
   linux-checkout-and-save-cache:
     <<: *machine-linux-2xlarge
@@ -1364,21 +1372,37 @@ jobs:
     environment:
       <<: *env-linux-2xlarge
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_pyyaml=True'
-    <<: *steps-checkout-fast
+    steps:
+      - electron-build:
+          persist: false
+          build: false
+          checkout: true
+          persist-checkout: true
 
   linux-checkout-for-native-tests-with-no-patches:
     <<: *machine-linux-2xlarge
     environment:
       <<: *env-linux-2xlarge
       GCLIENT_EXTRA_ARGS: '--custom-var=apply_patches=False --custom-var=checkout_pyyaml=True'
-    <<: *steps-checkout-fast
+    steps:
+      - electron-build:
+          persist: false
+          build: false
+          checkout: true
+          persist-checkout: true
 
   mac-checkout-fast:
     <<: *machine-linux-2xlarge
     environment:
       <<: *env-linux-2xlarge
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_mac=True --custom-var=host_os=mac'
-    <<: *steps-checkout-fast
+    steps:
+      - electron-build:
+          persist: false
+          build: false
+          checkout: true
+          persist-checkout: true
+          checkout-out-cache-for-workspace: true
 
   mac-checkout-and-save-cache:
     <<: *machine-linux-2xlarge
@@ -1412,7 +1436,7 @@ jobs:
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
     steps:
       - electron-build:
-          persist: true
+          persist: false
           checkout: true
 
   linux-x64-testing-gn-check:
@@ -1613,6 +1637,7 @@ jobs:
           persist: true
           checkout: false
           attach: true
+          out-cache-attached: true
 
   osx-testing-gn-check:
     <<: *machine-mac
@@ -1662,6 +1687,7 @@ jobs:
           persist: true
           checkout: false
           attach: true
+          out-cache-attached: true
 
 
   mas-testing-gn-check:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1658,7 +1658,7 @@ jobs:
           persist: true
           checkout: false
           attach: true
-          need-out-cache: false
+          need-out-cache: true
 
   osx-testing-gn-check:
     <<: *machine-mac
@@ -1708,7 +1708,7 @@ jobs:
           persist: true
           checkout: false
           attach: true
-          need-out-cache: false
+          need-out-cache: true
 
 
   mas-testing-gn-check:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -752,7 +752,7 @@ step-save-src-cache: &step-save-src-cache
   save_cache:
     paths:
       - /portal
-    key: v7-src-cache-{{ checksum "src/electron/.depshash" }}
+    key: v7-src-cache-{{ checksum "/portal/src/electron/.depshash" }}
     name: Persisting src cache
 
 # Check for doc only change
@@ -879,6 +879,7 @@ steps-checkout-and-save-cache: &steps-checkout-and-save-cache
         name: Move src folder to the cross-OS portal
         command: |
           sudo mkdir -p /portal
+          sudo chown -R $(id -u):$(id -g) /portal
           mv ./src /portal
     - *step-save-src-cache
     - *step-save-brew-cache
@@ -1198,6 +1199,7 @@ commands:
           name: Prepare for cross-OS sync restore
           command: |
             sudo mkdir -p /portal
+            sudo chown -R $(id -u):$(id -g) /portal
       - *step-maybe-restore-src-cache
       - run:
           name: Fix the src cache restore point on macOS
@@ -1254,6 +1256,8 @@ commands:
           steps:
             - attach_workspace:
                 at: .
+      - *step-restore-brew-cache
+      - *step-install-gnutar-on-mac
       - when:
           condition: << parameters.checkout-and-assume-cache >>
           steps:
@@ -1268,9 +1272,7 @@ commands:
             - *step-maybe-early-exit-doc-only-change
             - *step-depot-tools-get
             - *step-depot-tools-add-to-path
-            - *step-restore-brew-cache
             - *step-get-more-space-on-mac
-            - *step-install-gnutar-on-mac
             - *step-generate-deps-hash
             - *step-touch-sync-done
             - maybe-restore-portaled-src-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -534,6 +534,7 @@ step-mksnapshot-build: &step-mksnapshot-build
     name: mksnapshot build
     command: |
       cd src
+      ninja -C out/Default electron:electron_mksnapshot -j $NUMBER_OF_NINJA_PROCESSES
       if [ "`uname`" != "Darwin" ]; then
         if [ "$TARGET_ARCH" == "arm" ]; then
           electron/script/strip-binaries.py --file $PWD/out/Default/clang_x86_v8_arm/mksnapshot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -674,7 +674,7 @@ step-maybe-restore-src-cache: &step-maybe-restore-src-cache
     paths:
       - ./src
     keys:
-      - v5-src-cache-{{ arch }}-{{ checksum "src/electron/.depshash" }}
+      - v6-src-cache-{{ checksum "src/electron/.depshash" }}
     name: Restoring src cache
 
 # Restore exact or closest git cache based on the hash of DEPS and .circle-sync-done
@@ -685,8 +685,8 @@ step-maybe-restore-git-cache: &step-maybe-restore-git-cache
     paths:
       - ~/.gclient-cache
     keys:
-      - v2-gclient-cache-{{ arch }}-{{ checksum "src/electron/.circle-sync-done" }}-{{ checksum "src/electron/DEPS" }}
-      - v2-gclient-cache-{{ arch }}-{{ checksum "src/electron/.circle-sync-done" }}
+      - v2-gclient-cache-{{ checksum "src/electron/.circle-sync-done" }}-{{ checksum "src/electron/DEPS" }}
+      - v2-gclient-cache-{{ checksum "src/electron/.circle-sync-done" }}
     name: Conditionally restoring git cache
 
 step-restore-out-cache: &step-restore-out-cache
@@ -711,7 +711,7 @@ step-save-git-cache: &step-save-git-cache
   save_cache:
     paths:
       - ~/.gclient-cache
-    key: v2-gclient-cache-{{ arch }}-{{ checksum "src/electron/.circle-sync-done" }}-{{ checksum "src/electron/DEPS" }}
+    key: v2-gclient-cache-{{ checksum "src/electron/.circle-sync-done" }}-{{ checksum "src/electron/DEPS" }}
     name: Persisting git cache
 
 step-save-out-cache: &step-save-out-cache
@@ -753,7 +753,7 @@ step-save-src-cache: &step-save-src-cache
   save_cache:
     paths:
       - ./src
-    key: v5-src-cache-{{ arch }}-{{ checksum "src/electron/.depshash" }}
+    key: v6-src-cache-{{ checksum "src/electron/.depshash" }}
     name: Persisting src cache
 
 # Check for doc only change
@@ -1610,8 +1610,7 @@ jobs:
     steps:
       - electron-build:
           persist: true
-          checkout: false
-          attach: true
+          checkout: true
 
   osx-testing-gn-check:
     <<: *machine-mac
@@ -1659,8 +1658,7 @@ jobs:
     steps:
       - electron-build:
           persist: true
-          checkout: false
-          attach: true
+          checkout: true
 
   mas-testing-gn-check:
     <<: *machine-mac
@@ -2049,9 +2047,7 @@ workflows:
       - mac-checkout-fast
       - mac-checkout-and-save-cache
 
-      - osx-testing:
-          requires:
-            - mac-checkout-fast
+      - osx-testing
 
       - osx-testing-gn-check:
           requires:
@@ -2061,9 +2057,7 @@ workflows:
           requires:
             - osx-testing
 
-      - mas-testing:
-          requires:
-            - mac-checkout-fast
+      - mas-testing
 
       - mas-testing-gn-check:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1220,38 +1220,44 @@ chromium-upgrade-branches: &chromium-upgrade-branches
 
 # Command Aliases
 commands:
-  electron-build-with-inline-checkout-for-tests: &electron-build-with-inline-checkout-for-tests
+  electron-build: &electron-build
     parameters:
       persist:
         type: boolean
         default: true
+      checkout:
+        type: boolean
+        default: true
     steps:
-      # Checkout - Copied ffrom steps-checkout
-      - *step-checkout-electron
-      - *step-check-for-doc-only-change
-      - *step-persist-doc-only-change
-      - *step-maybe-early-exit-doc-only-change
-      - *step-depot-tools-get
-      - *step-depot-tools-add-to-path
-      - *step-restore-brew-cache
-      - *step-get-more-space-on-mac
-      - *step-install-gnutar-on-mac
-      - *step-generate-deps-hash
-      - *step-touch-sync-done
-      - *step-maybe-restore-src-cache
-      - *step-maybe-restore-git-cache
-      - *step-set-git-cache-path
-      # This sync call only runs if .circle-sync-done is an EMPTY file
-      - *step-gclient-sync
-      # These next few steps reset Electron to the correct commit regardless of which cache was restored
-      - run:
-          name: Wipe Electron
-          command: rm -rf src/electron
-      - *step-checkout-electron
-      - *step-run-electron-only-hooks
-      - *step-generate-deps-hash-cleanly
-      - *step-mark-sync-done
-      - *step-minimize-workspace-size-from-checkout
+      - when:
+          condition: << parameters.checkout >>
+          steps:
+            # Checkout - Copied ffrom steps-checkout
+            - *step-checkout-electron
+            - *step-check-for-doc-only-change
+            - *step-persist-doc-only-change
+            - *step-maybe-early-exit-doc-only-change
+            - *step-depot-tools-get
+            - *step-depot-tools-add-to-path
+            - *step-restore-brew-cache
+            - *step-get-more-space-on-mac
+            - *step-install-gnutar-on-mac
+            - *step-generate-deps-hash
+            - *step-touch-sync-done
+            - *step-maybe-restore-src-cache
+            - *step-maybe-restore-git-cache
+            - *step-set-git-cache-path
+            # This sync call only runs if .circle-sync-done is an EMPTY file
+            - *step-gclient-sync
+            # These next few steps reset Electron to the correct commit regardless of which cache was restored
+            - run:
+                name: Wipe Electron
+                command: rm -rf src/electron
+            - *step-checkout-electron
+            - *step-run-electron-only-hooks
+            - *step-generate-deps-hash-cleanly
+            - *step-mark-sync-done
+            - *step-minimize-workspace-size-from-checkout
 
       - *step-depot-tools-add-to-path
       - *step-setup-env-for-build
@@ -1381,8 +1387,9 @@ jobs:
       <<: *env-ninja-status
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
     steps:
-      - electron-build-with-inline-checkout-for-tests:
+      - electron-build:
           persist: true
+          checkout: true
 
   linux-x64-testing-no-run-as-node:
     <<: *machine-linux-2xlarge
@@ -1394,8 +1401,9 @@ jobs:
       <<: *env-disable-run-as-node
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
     steps:
-      - electron-build-with-inline-checkout-for-tests:
+      - electron-build:
           persist: true
+          checkout: true
 
   linux-x64-testing-gn-check:
     <<: *machine-linux-medium
@@ -1443,8 +1451,9 @@ jobs:
       <<: *env-ninja-status
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
     steps:
-      - electron-build-with-inline-checkout-for-tests:
+      - electron-build:
           persist: true
+          checkout: true
 
   linux-ia32-chromedriver:
     <<: *machine-linux-medium
@@ -1490,8 +1499,9 @@ jobs:
       TRIGGER_ARM_TEST: true
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
     steps:
-      - electron-build-with-inline-checkout-for-tests:
+      - electron-build:
           persist: false
+          checkout: true
 
   linux-arm-chromedriver:
     <<: *machine-linux-medium
@@ -1537,8 +1547,9 @@ jobs:
       TRIGGER_ARM_TEST: true
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
     steps:
-      - electron-build-with-inline-checkout-for-tests:
+      - electron-build:
           persist: false
+          checkout: true
 
   linux-arm64-testing-gn-check:
     <<: *machine-linux-medium
@@ -1587,7 +1598,10 @@ jobs:
       <<: *env-testing-build
       <<: *env-enable-sccache
       <<: *env-ninja-status
-    <<: *steps-electron-build
+    steps:
+      - electron-build:
+          persist: true
+          checkout: false
 
   osx-testing-gn-check:
     <<: *machine-mac
@@ -1632,7 +1646,10 @@ jobs:
       <<: *env-testing-build
       <<: *env-enable-sccache
       <<: *env-ninja-status
-    <<: *steps-electron-build
+    steps:
+      - electron-build:
+          persist: true
+          checkout: false
 
   mas-testing-gn-check:
     <<: *machine-mac

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -979,91 +979,6 @@ steps-electron-build: &steps-electron-build
 
     - *step-maybe-notify-slack-failure
 
-steps-electron-build-with-inline-checkout-for-tests: &steps-electron-build-with-inline-checkout-for-tests
-  steps:
-    # Checkout - Copied ffrom steps-checkout
-    - *step-checkout-electron
-    - *step-check-for-doc-only-change
-    - *step-persist-doc-only-change
-    - *step-maybe-early-exit-doc-only-change
-    - *step-depot-tools-get
-    - *step-depot-tools-add-to-path
-    - *step-restore-brew-cache
-    - *step-get-more-space-on-mac
-    - *step-install-gnutar-on-mac
-    - *step-generate-deps-hash
-    - *step-touch-sync-done
-    - *step-maybe-restore-src-cache
-    - *step-maybe-restore-git-cache
-    - *step-set-git-cache-path
-    # This sync call only runs if .circle-sync-done is an EMPTY file
-    - *step-gclient-sync
-    # These next few steps reset Electron to the correct commit regardless of which cache was restored
-    - run:
-        name: Wipe Electron
-        command: rm -rf src/electron
-    - *step-checkout-electron
-    - *step-run-electron-only-hooks
-    - *step-generate-deps-hash-cleanly
-    - *step-mark-sync-done
-    - *step-minimize-workspace-size-from-checkout
-
-    - *step-depot-tools-add-to-path
-    - *step-setup-env-for-build
-    - *step-restore-brew-cache
-    - *step-get-more-space-on-mac
-    - *step-install-npm-deps-on-mac
-    - *step-fix-sync-on-mac
-    - *step-delete-git-directories
-    - *step-gn-gen-default
-
-    # Electron app
-    - *step-restore-out-cache
-    - *step-electron-build
-    - *step-save-out-cache
-    - *step-ninja-summary
-    - *step-ninja-report
-    - *step-maybe-electron-dist-strip
-    - *step-electron-dist-build
-    - *step-electron-dist-store
-
-    # Native test targets
-    - *step-native-unittests-build
-    - *step-native-unittests-store
-
-    # Node.js headers
-    - *step-nodejs-headers-build
-    - *step-nodejs-headers-store
-
-    - *step-show-sccache-stats
-
-    # mksnapshot
-    - *step-mksnapshot-build
-    - *step-mksnapshot-store
-    - *step-maybe-cross-arch-snapshot
-    - *step-maybe-cross-arch-snapshot-store
-
-    # ffmpeg
-    - *step-ffmpeg-gn-gen
-    - *step-ffmpeg-build
-    - *step-ffmpeg-store
-
-    # hunspell
-    - *step-hunspell-build
-    - *step-hunspell-store
-
-    # Save all data needed for a further tests run.
-    - *step-persist-data-for-tests
-
-    - *step-maybe-generate-breakpad-symbols
-    - *step-maybe-zip-symbols
-    - *step-symbols-store
-
-    # Trigger tests on arm hardware if needed
-    - *step-maybe-trigger-arm-test
-
-    - *step-maybe-notify-slack-failure
-
 steps-electron-ts-compile-for-doc-change: &steps-electron-ts-compile-for-doc-change
   steps:
     # Checkout - Copied ffrom steps-checkout
@@ -1303,6 +1218,100 @@ steps-test-node: &steps-test-node
 chromium-upgrade-branches: &chromium-upgrade-branches
   /chromium\-upgrade\/[0-9]+/
 
+# Command Aliases
+commands:
+  electron-build-with-inline-checkout-for-tests: &electron-build-with-inline-checkout-for-tests
+    parameters:
+      persist:
+        type: boolean
+        default: true
+    steps:
+      # Checkout - Copied ffrom steps-checkout
+      - *step-checkout-electron
+      - *step-check-for-doc-only-change
+      - *step-persist-doc-only-change
+      - *step-maybe-early-exit-doc-only-change
+      - *step-depot-tools-get
+      - *step-depot-tools-add-to-path
+      - *step-restore-brew-cache
+      - *step-get-more-space-on-mac
+      - *step-install-gnutar-on-mac
+      - *step-generate-deps-hash
+      - *step-touch-sync-done
+      - *step-maybe-restore-src-cache
+      - *step-maybe-restore-git-cache
+      - *step-set-git-cache-path
+      # This sync call only runs if .circle-sync-done is an EMPTY file
+      - *step-gclient-sync
+      # These next few steps reset Electron to the correct commit regardless of which cache was restored
+      - run:
+          name: Wipe Electron
+          command: rm -rf src/electron
+      - *step-checkout-electron
+      - *step-run-electron-only-hooks
+      - *step-generate-deps-hash-cleanly
+      - *step-mark-sync-done
+      - *step-minimize-workspace-size-from-checkout
+
+      - *step-depot-tools-add-to-path
+      - *step-setup-env-for-build
+      - *step-restore-brew-cache
+      - *step-get-more-space-on-mac
+      - *step-install-npm-deps-on-mac
+      - *step-fix-sync-on-mac
+      - *step-delete-git-directories
+      - *step-gn-gen-default
+
+      # Electron app
+      - *step-restore-out-cache
+      - *step-electron-build
+      - *step-save-out-cache
+      - *step-ninja-summary
+      - *step-ninja-report
+      - *step-maybe-electron-dist-strip
+      - *step-electron-dist-build
+      - *step-electron-dist-store
+
+      # Native test targets
+      - *step-native-unittests-build
+      - *step-native-unittests-store
+
+      # Node.js headers
+      - *step-nodejs-headers-build
+      - *step-nodejs-headers-store
+
+      - *step-show-sccache-stats
+
+      # mksnapshot
+      - *step-mksnapshot-build
+      - *step-mksnapshot-store
+      - *step-maybe-cross-arch-snapshot
+      - *step-maybe-cross-arch-snapshot-store
+
+      # ffmpeg
+      - *step-ffmpeg-gn-gen
+      - *step-ffmpeg-build
+      - *step-ffmpeg-store
+
+      # hunspell
+      - *step-hunspell-build
+      - *step-hunspell-store
+
+      # Save all data needed for a further tests run.
+      - when:
+          condition: << parameters.persist >>
+          steps:
+            - *step-persist-data-for-tests
+
+      - *step-maybe-generate-breakpad-symbols
+      - *step-maybe-zip-symbols
+      - *step-symbols-store
+
+      # Trigger tests on arm hardware if needed
+      - *step-maybe-trigger-arm-test
+
+      - *step-maybe-notify-slack-failure
+
 # List of all jobs.
 jobs:
   # Layer 0: Lint. Standalone.
@@ -1371,7 +1380,9 @@ jobs:
       <<: *env-enable-sccache
       <<: *env-ninja-status
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
-    <<: *steps-electron-build-with-inline-checkout-for-tests
+    steps:
+      - electron-build-with-inline-checkout-for-tests:
+          persist: true
 
   linux-x64-testing-no-run-as-node:
     <<: *machine-linux-2xlarge
@@ -1382,7 +1393,9 @@ jobs:
       <<: *env-ninja-status
       <<: *env-disable-run-as-node
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
-    <<: *steps-electron-build-with-inline-checkout-for-tests
+    steps:
+      - electron-build-with-inline-checkout-for-tests:
+          persist: true
 
   linux-x64-testing-gn-check:
     <<: *machine-linux-medium
@@ -1429,7 +1442,9 @@ jobs:
       <<: *env-enable-sccache
       <<: *env-ninja-status
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
-    <<: *steps-electron-build-with-inline-checkout-for-tests
+    steps:
+      - electron-build-with-inline-checkout-for-tests:
+          persist: true
 
   linux-ia32-chromedriver:
     <<: *machine-linux-medium
@@ -1474,7 +1489,9 @@ jobs:
       <<: *env-ninja-status
       TRIGGER_ARM_TEST: true
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
-    <<: *steps-electron-build-with-inline-checkout-for-tests
+    steps:
+      - electron-build-with-inline-checkout-for-tests:
+          persist: false
 
   linux-arm-chromedriver:
     <<: *machine-linux-medium
@@ -1519,7 +1536,9 @@ jobs:
       <<: *env-ninja-status
       TRIGGER_ARM_TEST: true
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
-    <<: *steps-electron-build-with-inline-checkout-for-tests
+    steps:
+      - electron-build-with-inline-checkout-for-tests:
+          persist: false
 
   linux-arm64-testing-gn-check:
     <<: *machine-linux-medium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -688,6 +688,14 @@ step-maybe-restore-git-cache: &step-maybe-restore-git-cache
       - v2-gclient-cache-{{ arch }}-{{ checksum "src/electron/.circle-sync-done" }}
     name: Conditionally restoring git cache
 
+step-restore-out-cache: &step-restore-out-cache
+  restore_cache:
+    paths:
+      - ./src/out/Default
+    keys:
+      - v1-out-cache-{{ arch }}-{{ checksum "src/electron/.depshash" }}-{{ .Environment.TARGET_ARCH }}-{{ .Environment.GN_CONFIG }}
+    name: Restoring out cache
+
 step-set-git-cache-path: &step-set-git-cache-path
   run:
     name: Set GIT_CACHE_PATH to make gclient to use the cache
@@ -704,6 +712,13 @@ step-save-git-cache: &step-save-git-cache
       - ~/.gclient-cache
     key: v2-gclient-cache-{{ arch }}-{{ checksum "src/electron/.circle-sync-done" }}-{{ checksum "src/electron/DEPS" }}
     name: Persisting git cache
+
+step-save-out-cache: &step-save-out-cache
+  save_cache:
+    paths:
+      - ./src/out/Default
+    key: v1-out-cache-{{ arch }}-{{ checksum "src/electron/.depshash" }}-{{ .Environment.TARGET_ARCH }}-{{ .Environment.GN_CONFIG }}
+    name: Persisting out cache
 
 step-run-electron-only-hooks: &step-run-electron-only-hooks
   run:
@@ -1003,7 +1018,9 @@ steps-electron-build-with-inline-checkout-for-tests: &steps-electron-build-with-
     - *step-gn-gen-default
 
     # Electron app
+    - *step-restore-out-cache
     - *step-electron-build
+    - *step-save-out-cache
     - *step-ninja-summary
     - *step-ninja-report
     - *step-maybe-electron-dist-strip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1263,13 +1263,21 @@ commands:
                         - *step-restore-out-cache
                         - run:
                             name: Move macOS out cache to the linux directory for workspace persistance
-                            command: mv /Users/distiller/project/src/out/Default src/out/Default
+                            command: |
+                              if [ -d "/Users/distiller/project/src/out/Default" ]; then
+                                mv /Users/distiller/project/src/out/Default src/out/Default
+                              fi
                         # This removes half the size but retains > 70% of the previous build.  Worth it when you add it all up.
                         - run:
                             name: Remove the big things
                             command: |
+                              mkdir -p src/out/Default
                               cd src/out/Default
                               find -type f -size +50M -delete
+                              mkdir -p gen/electron
+                              cd gen/electron
+                              # These files do not seem to like being in a layer, let us remove them
+                              find . -type f -name '*_pkg_info' -delete
                   - persist_to_workspace:
                       root: .
                       paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -694,7 +694,7 @@ step-restore-out-cache: &step-restore-out-cache
     paths:
       - ./src/out/Default
     keys:
-      - v1-out-cache-{{ arch }}-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
+      - v2-out-cache-{{ arch }}-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
     name: Restoring out cache
 
 step-set-git-cache-path: &step-set-git-cache-path
@@ -718,7 +718,7 @@ step-save-out-cache: &step-save-out-cache
   save_cache:
     paths:
       - ./src/out/Default
-    key: v1-out-cache-{{ arch }}-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
+    key: v2-out-cache-{{ arch }}-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
     name: Persisting out cache
 
 step-run-electron-only-hooks: &step-run-electron-only-hooks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1607,6 +1607,7 @@ jobs:
       <<: *env-testing-build
       <<: *env-enable-sccache
       <<: *env-ninja-status
+      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_mac=True --custom-var=host_os=mac'
     steps:
       - electron-build:
           persist: true
@@ -1655,6 +1656,7 @@ jobs:
       <<: *env-testing-build
       <<: *env-enable-sccache
       <<: *env-ninja-status
+      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_mac=True --custom-var=host_os=mac'
     steps:
       - electron-build:
           persist: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -672,10 +672,8 @@ step-touch-sync-done: &step-touch-sync-done
 # If a cache is matched EXACTLY then the .circle-sync-done file contains "done"
 step-maybe-restore-src-cache: &step-maybe-restore-src-cache
   restore_cache:
-    paths:
-      - ./src
     keys:
-      - v6-src-cache-{{ checksum "src/electron/.depshash" }}
+      - v7-src-cache-{{ checksum "src/electron/.depshash" }}
     name: Restoring src cache
 
 # Restore exact or closest git cache based on the hash of DEPS and .circle-sync-done
@@ -753,8 +751,8 @@ step-minimize-workspace-size-from-checkout: &step-minimize-workspace-size-from-c
 step-save-src-cache: &step-save-src-cache
   save_cache:
     paths:
-      - ./src
-    key: v6-src-cache-{{ checksum "src/electron/.depshash" }}
+      - /portal
+    key: v7-src-cache-{{ checksum "src/electron/.depshash" }}
     name: Persisting src cache
 
 # Check for doc only change
@@ -861,7 +859,7 @@ steps-checkout-and-save-cache: &steps-checkout-and-save-cache
 
     - *step-generate-deps-hash
     - *step-touch-sync-done
-    - *step-maybe-restore-src-cache
+    - maybe-restore-portaled-src-cache
     - *step-maybe-restore-git-cache
     - *step-set-git-cache-path
     # This sync call only runs if .circle-sync-done is an EMPTY file
@@ -877,6 +875,11 @@ steps-checkout-and-save-cache: &steps-checkout-and-save-cache
     - *step-mark-sync-done
     - *step-minimize-workspace-size-from-checkout
     - *step-delete-git-directories
+    - run:
+        name: Move src folder to the cross-OS portal
+        command: |
+          mkdir -p /portal
+          mv ./src /portal
     - *step-save-src-cache
     - *step-save-brew-cache
 
@@ -961,7 +964,7 @@ steps-electron-ts-compile-for-doc-change: &steps-electron-ts-compile-for-doc-cha
     - *step-install-gnutar-on-mac
     - *step-generate-deps-hash
     - *step-touch-sync-done
-    - *step-maybe-restore-src-cache
+    - maybe-restore-portaled-src-cache
     - *step-maybe-restore-git-cache
     - *step-set-git-cache-path
     # This sync call only runs if .circle-sync-done is an EMPTY file
@@ -1189,6 +1192,25 @@ chromium-upgrade-branches: &chromium-upgrade-branches
 
 # Command Aliases
 commands:
+  maybe-restore-portaled-src-cache:
+    steps:
+      - run:
+          name: Prepare for cross-OS sync restore
+          command: |
+            if [ "`uname`" == "Darwin" ]; then
+              sudo mkdir -p /portal
+            else
+              mkdir -p /portal
+            fi
+      - *step-maybe-restore-src-cache
+      - run:
+          name: Fix the src cache restore point on macOS
+          command: |
+            if [ -d "/portal/src" ]; then
+              echo Relocating Cache
+              rm -rf src
+              mv /portal/src ./
+            fi
   checkout-from-cache:
     steps:
       - *step-checkout-electron
@@ -1196,21 +1218,7 @@ commands:
       - *step-depot-tools-get
       - *step-depot-tools-add-to-path
       - *step-generate-deps-hash
-      - run:
-          name: Prepare for cross-OS sync restore on macOS
-          command: |
-            if [ "`uname`" == "Darwin" ]; then
-              sudo mkdir -p /home/builduser/project/src
-            fi
-      - *step-maybe-restore-src-cache
-      - run:
-          name: Fix the src cache restore point on macOS
-          command: |
-            if [ "`uname`" == "Darwin" && -d "/home/builduser/project/src" ]; then
-              echo Relocating Cache
-              rm -rf src
-              mv /home/builduser/project/src ./
-            fi
+      - maybe-restore-portaled-src-cache
       - run:
           name: Ensure src checkout worked
           command: |
@@ -1269,7 +1277,7 @@ commands:
             - *step-install-gnutar-on-mac
             - *step-generate-deps-hash
             - *step-touch-sync-done
-            - *step-maybe-restore-src-cache
+            - maybe-restore-portaled-src-cache
             - *step-maybe-restore-git-cache
             - *step-set-git-cache-path
             # This sync call only runs if .circle-sync-done is an EMPTY file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,6 +338,12 @@ step-electron-build: &step-electron-build
     name: Electron build
     no_output_timeout: 30m
     command: |
+      # On arm platforms we generate a cross-arch ffmpeg that ninja does not seem
+      # to realize is not correct / should be rebuilt.  We delete it here so it is
+      # rebuilt
+      if [ "$TRIGGER_ARM_TEST" == "true" ]; then
+        rm -f src/out/Default/libffmpeg.so
+      fi
       cd src
       ninja -C out/Default electron -j $NUMBER_OF_NINJA_PROCESSES
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1223,6 +1223,9 @@ chromium-upgrade-branches: &chromium-upgrade-branches
 commands:
   electron-build: &electron-build
     parameters:
+      attach:
+        type: boolean
+        default: false
       persist:
         type: boolean
         default: true
@@ -1230,6 +1233,11 @@ commands:
         type: boolean
         default: true
     steps:
+      - when:
+          condition: << parameters.attach >>
+          steps:
+            - attach_workspace:
+                at: .
       - when:
           condition: << parameters.checkout >>
           steps:
@@ -1603,6 +1611,7 @@ jobs:
       - electron-build:
           persist: true
           checkout: false
+          attach: true
 
   osx-testing-gn-check:
     <<: *machine-mac
@@ -1651,6 +1660,7 @@ jobs:
       - electron-build:
           persist: true
           checkout: false
+          attach: true
 
   mas-testing-gn-check:
     <<: *machine-mac

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,6 +155,10 @@ env-32bit-release: &env-32bit-release
   # Set symbol level to 1 for 32 bit releases because of https://crbug.com/648948
   GN_BUILDFLAG_ARGS: 'symbol_level = 1'
 
+env-macos-build: &env-macos-build
+  # Disable pre-compiled headers to reduce out size, only useful for rebuilds
+  GN_BUILDFLAG_ARGS: 'enable_precompiled_headers = false'
+
 # Individual (shared) steps.
 step-maybe-notify-slack-failure: &step-maybe-notify-slack-failure
   run:
@@ -1303,9 +1307,7 @@ commands:
           steps:
             - *step-depot-tools-add-to-path
             - *step-setup-env-for-build
-            - *step-restore-brew-cache
             - *step-get-more-space-on-mac
-            - *step-install-npm-deps-on-mac
             - *step-fix-sync-on-mac
             - *step-delete-git-directories
             - *step-gn-gen-default
@@ -1445,6 +1447,7 @@ jobs:
     environment:
       <<: *env-linux-2xlarge
       <<: *env-testing-build
+      <<: *env-macos-build
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_mac=True --custom-var=host_os=mac'
     steps:
       - electron-build:
@@ -1458,6 +1461,7 @@ jobs:
     environment:
       <<: *env-linux-2xlarge
       <<: *env-testing-build
+      <<: *env-macos-build
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_mac=True --custom-var=host_os=mac'
     <<: *steps-checkout-and-save-cache
 
@@ -1682,6 +1686,7 @@ jobs:
       <<: *env-testing-build
       <<: *env-enable-sccache
       <<: *env-ninja-status
+      <<: *env-macos-build
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_mac=True --custom-var=host_os=mac'
     steps:
       - electron-build:
@@ -1733,6 +1738,7 @@ jobs:
       <<: *env-testing-build
       <<: *env-enable-sccache
       <<: *env-ninja-status
+      <<: *env-macos-build
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_mac=True --custom-var=host_os=mac'
     steps:
       - electron-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -695,7 +695,7 @@ step-restore-out-cache: &step-restore-out-cache
     paths:
       - ./src/out/Default
     keys:
-      - v3-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
+      - v4-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
     name: Restoring out cache
 
 step-set-git-cache-path: &step-set-git-cache-path
@@ -719,7 +719,7 @@ step-save-out-cache: &step-save-out-cache
   save_cache:
     paths:
       - ./src/out/Default
-    key: v3-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
+    key: v4-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
     name: Persisting out cache
 
 step-run-electron-only-hooks: &step-run-electron-only-hooks
@@ -1267,17 +1267,6 @@ commands:
                               if [ -d "/Users/distiller/project/src/out/Default" ]; then
                                 mv /Users/distiller/project/src/out/Default src/out/Default
                               fi
-                        # This removes half the size but retains > 70% of the previous build.  Worth it when you add it all up.
-                        - run:
-                            name: Remove the big things
-                            command: |
-                              mkdir -p src/out/Default
-                              cd src/out/Default
-                              find -type f -size +50M -delete
-                              mkdir -p gen/electron
-                              cd gen/electron
-                              # These files do not seem to like being in a layer, let us remove them
-                              find . -type f -name '*_pkg_info' -delete
                   - persist_to_workspace:
                       root: .
                       paths:
@@ -1302,6 +1291,16 @@ commands:
                 steps:
                   - *step-restore-out-cache
             - *step-electron-build
+            - run:
+                name: Remove the big things, this seems to be better on average
+                command: |
+                  mkdir -p src/out/Default
+                  cd src/out/Default
+                  find . -type f -size +50M -delete
+                  mkdir -p gen/electron
+                  cd gen/electron
+                  # These files do not seem to like being in a cache, let us remove them
+                  find . -type f -name '*_pkg_info' -delete
             - *step-save-out-cache
             - *step-ninja-summary
             - *step-ninja-report
@@ -1424,7 +1423,7 @@ jobs:
           build: false
           checkout: true
           persist-checkout: true
-          checkout-mac-out-cache-for-workspace: true
+          checkout-mac-out-cache-for-workspace: false
 
   mac-checkout-and-save-cache:
     <<: *machine-linux-2xlarge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -660,7 +660,7 @@ step-ninja-report: &step-ninja-report
 step-generate-deps-hash: &step-generate-deps-hash
   run:
     name: Generate DEPS Hash
-    command: node src/electron/script/generate-deps-hash.js
+    command: node src/electron/script/generate-deps-hash.js && cat src/electron/.depshash-target
 
 step-touch-sync-done: &step-touch-sync-done
   run:
@@ -730,7 +730,7 @@ step-run-electron-only-hooks: &step-run-electron-only-hooks
 step-generate-deps-hash-cleanly: &step-generate-deps-hash-cleanly
   run:
     name: Generate DEPS Hash
-    command: (cd src/electron && git checkout .) && node src/electron/script/generate-deps-hash.js
+    command: (cd src/electron && git checkout .) && node src/electron/script/generate-deps-hash.js && cat src/electron/.depshash-target
 
 # Mark the sync as done for future cache saving
 step-mark-sync-done: &step-mark-sync-done
@@ -1276,10 +1276,7 @@ commands:
             - *step-gn-gen-default
 
             # Electron app
-            - when:
-                unless: << parameters.out-cache-attached >>
-                steps:
-                  - *step-restore-out-cache
+            - *step-restore-out-cache
             - *step-electron-build
             - *step-save-out-cache
             - *step-ninja-summary

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1661,6 +1661,7 @@ jobs:
       <<: *env-testing-build
       <<: *env-enable-sccache
       <<: *env-ninja-status
+      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_mac=True --custom-var=host_os=mac'
     steps:
       - electron-build:
           persist: true
@@ -1711,6 +1712,7 @@ jobs:
       <<: *env-testing-build
       <<: *env-enable-sccache
       <<: *env-ninja-status
+      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_mac=True --custom-var=host_os=mac'
     steps:
       - electron-build:
           persist: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1607,11 +1607,11 @@ jobs:
       <<: *env-testing-build
       <<: *env-enable-sccache
       <<: *env-ninja-status
-      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_mac=True --custom-var=host_os=mac'
     steps:
       - electron-build:
           persist: true
-          checkout: true
+          checkout: false
+          attach: true
 
   osx-testing-gn-check:
     <<: *machine-mac
@@ -1656,11 +1656,12 @@ jobs:
       <<: *env-testing-build
       <<: *env-enable-sccache
       <<: *env-ninja-status
-      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_mac=True --custom-var=host_os=mac'
     steps:
       - electron-build:
           persist: true
-          checkout: true
+          checkout: false
+          attach: true
+
 
   mas-testing-gn-check:
     <<: *machine-mac
@@ -2049,7 +2050,9 @@ workflows:
       - mac-checkout-fast
       - mac-checkout-and-save-cache
 
-      - osx-testing
+      - osx-testing:
+          requires:
+            - mac-checkout-fast
 
       - osx-testing-gn-check:
           requires:
@@ -2059,7 +2062,9 @@ workflows:
           requires:
             - osx-testing
 
-      - mas-testing
+      - mas-testing:
+          requires:
+            - mac-checkout-fast
 
       - mas-testing-gn-check:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1208,9 +1208,9 @@ commands:
       build:
         type: boolean
         default: true
-      out-cache-attached:
+      need-out-cache:
         type: boolean
-        default: false
+        default: true
     steps:
       - when:
           condition: << parameters.attach >>
@@ -1279,7 +1279,10 @@ commands:
             - *step-gn-gen-default
 
             # Electron app
-            - *step-restore-out-cache
+            - when:
+                condition: << parameters.need-out-cache >>
+                steps:
+                  - *step-restore-out-cache
             - *step-electron-build
             - *step-save-out-cache
             - *step-ninja-summary
@@ -1638,7 +1641,7 @@ jobs:
           persist: true
           checkout: false
           attach: true
-          out-cache-attached: true
+          need-out-cache: false
 
   osx-testing-gn-check:
     <<: *machine-mac
@@ -1688,7 +1691,7 @@ jobs:
           persist: true
           checkout: false
           attach: true
-          out-cache-attached: true
+          need-out-cache: false
 
 
   mas-testing-gn-check:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1202,7 +1202,7 @@ commands:
       checkout:
         type: boolean
         default: true
-      checkout-out-cache-for-workspace:
+      checkout-mac-out-cache-for-workspace:
         type: boolean
         default: false
       build:
@@ -1249,22 +1249,30 @@ commands:
             - when:
                 condition: << parameters.persist-checkout >>
                 steps:
+                  - when:
+                      condition: << parameters.checkout-mac-out-cache-for-workspace >>
+                      steps:
+                        - run:
+                            name: Make Empty Default Folder
+                            command: mkdir -p src/out
+                        - run:
+                            name: Fake the macOS directory structure
+                            command: |
+                              sudo mkdir -p /Users/distiller/project
+                              sudo chmod -R 777 /Users/distiller/project
+                        - *step-restore-out-cache
+                        - run:
+                            name: Move macOS out cache to the linux directory for workspace persistance
+                            command: mv /Users/distiller/project/src/out/Default src/out/Default
+                        - persist_to_workspace:
+                            root: .
+                            paths:
+                              - src/out/Default
                   - persist_to_workspace:
                       root: .
                       paths:
                         - depot_tools
                         - src
-                  - when:
-                      condition: << parameters.checkout-out-cache-for-workspace >>
-                      steps:
-                        - run:
-                            name: Make Empty Default Folder
-                            command: mkdir -p src/out/Default
-                        - *step-restore-out-cache
-                        - persist_to_workspace:
-                            root: .
-                            paths:
-                              - src/out/Default
 
       - when:
           condition: << parameters.build >>
@@ -1406,7 +1414,7 @@ jobs:
           build: false
           checkout: true
           persist-checkout: true
-          checkout-out-cache-for-workspace: true
+          checkout-mac-out-cache-for-workspace: true
 
   mac-checkout-and-save-cache:
     <<: *machine-linux-2xlarge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -695,7 +695,7 @@ step-restore-out-cache: &step-restore-out-cache
     paths:
       - ./src/out/Default
     keys:
-      - v2-out-cache-{{ arch }}-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
+      - v3-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
     name: Restoring out cache
 
 step-set-git-cache-path: &step-set-git-cache-path
@@ -719,7 +719,7 @@ step-save-out-cache: &step-save-out-cache
   save_cache:
     paths:
       - ./src/out/Default
-    key: v2-out-cache-{{ arch }}-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
+    key: v3-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
     name: Persisting out cache
 
 step-run-electron-only-hooks: &step-run-electron-only-hooks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -695,7 +695,7 @@ step-restore-out-cache: &step-restore-out-cache
     paths:
       - ./src/out/Default
     keys:
-      - v5-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
+      - v6-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
     name: Restoring out cache
 
 step-set-git-cache-path: &step-set-git-cache-path
@@ -719,7 +719,7 @@ step-save-out-cache: &step-save-out-cache
   save_cache:
     paths:
       - ./src/out/Default
-    key: v5-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
+    key: v6-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
     name: Persisting out cache
 
 step-run-electron-only-hooks: &step-run-electron-only-hooks
@@ -1188,7 +1188,26 @@ chromium-upgrade-branches: &chromium-upgrade-branches
 
 # Command Aliases
 commands:
-  electron-build: &electron-build
+  checkout-from-cache:
+    steps:
+      - *step-maybe-early-exit-doc-only-change
+      - *step-depot-tools-get
+      - *step-depot-tools-add-to-path
+      - *step-maybe-restore-src-cache
+      - run:
+          name: Ensure src checkout worked
+          command: |
+            if [ ! -d "src/third_party/blink" ]; then
+              echo src cache was not restored for some reason, idk what happened here...
+              exit 1
+            fi
+      - run:
+          name: Wipe Electron
+          command: rm -rf src/electron
+      - *step-checkout-electron
+      - *step-run-electron-only-hooks
+      - *step-generate-deps-hash-cleanly
+  electron-build:
     parameters:
       attach:
         type: boolean
@@ -1202,6 +1221,9 @@ commands:
       checkout:
         type: boolean
         default: true
+      checkout-and-assume-cache:
+        type: boolean
+        default: false
       build:
         type: boolean
         default: true
@@ -1211,6 +1233,10 @@ commands:
           steps:
             - attach_workspace:
                 at: .
+      - when:
+          condition: << parameters.checkout-and-assume-cache >>
+          steps:
+            - checkout-from-cache
       - when:
           condition: << parameters.checkout >>
           steps:
@@ -1265,19 +1291,6 @@ commands:
             - *step-restore-out-cache
             - *step-gn-gen-default
             - *step-electron-build
-            - run:
-                name: Remove the big things on macOS, this seems to be better on average
-                command: |
-                  if [ "`uname`" == "Darwin" ]; then
-                    mkdir -p src/out/Default
-                    cd src/out/Default
-                    find . -type f -size +50M -delete
-                    mkdir -p gen/electron
-                    cd gen/electron
-                    # These files do not seem to like being in a cache, let us remove them
-                    find . -type f -name '*_pkg_info' -delete
-                  fi
-            - *step-save-out-cache
             - *step-ninja-summary
             - *step-ninja-report
             - *step-maybe-electron-dist-strip
@@ -1321,6 +1334,23 @@ commands:
             - *step-maybe-generate-breakpad-symbols
             - *step-maybe-zip-symbols
             - *step-symbols-store
+
+      - when:
+          condition: << parameters.build >>
+          steps:
+            - run:
+                name: Remove the big things on macOS, this seems to be better on average
+                command: |
+                  if [ "`uname`" == "Darwin" ]; then
+                    mkdir -p src/out/Default
+                    cd src/out/Default
+                    find . -type f -size +50M -delete
+                    mkdir -p gen/electron
+                    cd gen/electron
+                    # These files do not seem to like being in a cache, let us remove them
+                    find . -type f -name '*_pkg_info' -delete
+                  fi
+            - *step-save-out-cache
 
       # Trigger tests on arm hardware if needed
       - *step-maybe-trigger-arm-test
@@ -1632,7 +1662,8 @@ jobs:
       - electron-build:
           persist: true
           checkout: false
-          attach: true
+          checkout-and-assume-cache: true
+          attach: false
 
   osx-testing-gn-check:
     <<: *machine-mac
@@ -1681,7 +1712,8 @@ jobs:
       - electron-build:
           persist: true
           checkout: false
-          attach: true
+          checkout-and-assume-cache: true
+          attach: false
 
   mas-testing-gn-check:
     <<: *machine-mac
@@ -2072,7 +2104,7 @@ workflows:
 
       - osx-testing:
           requires:
-            - mac-checkout-fast
+            - mac-checkout-and-save-cache
 
       - osx-testing-gn-check:
           requires:
@@ -2084,7 +2116,7 @@ workflows:
 
       - mas-testing:
           requires:
-            - mac-checkout-fast
+            - mac-checkout-and-save-cache
 
       - mas-testing-gn-check:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ machine-linux-medium: &machine-linux-medium
 
 machine-linux-2xlarge: &machine-linux-2xlarge
   <<: *docker-image
-  resource_class: 2xlarge
+  resource_class: 2xlarge+
 
 machine-mac: &machine-mac
   macos:
@@ -542,6 +542,7 @@ step-mksnapshot-build: &step-mksnapshot-build
           electron/script/strip-binaries.py --file $PWD/out/Default/clang_x64_v8_arm64/mksnapshot
         else
           electron/script/strip-binaries.py --file $PWD/out/Default/mksnapshot
+          electron/script/strip-binaries.py --file $PWD/out/Default/v8_context_snapshot_generator
         fi
       fi
       if [ "$SKIP_DIST_ZIP" != "1" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1257,6 +1257,9 @@ commands:
                   - when:
                       condition: << parameters.checkout-out-cache-for-workspace >>
                       steps:
+                        - run:
+                            name: Make Empty Default Folder
+                            command: mkdir -p src/out/Default
                         - *step-restore-out-cache
                         - persist_to_workspace:
                             root: .
@@ -1392,6 +1395,7 @@ jobs:
     <<: *machine-linux-2xlarge
     environment:
       <<: *env-linux-2xlarge
+      <<: *env-testing-build
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_mac=True --custom-var=host_os=mac'
     steps:
       - electron-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1193,6 +1193,7 @@ commands:
       - *step-maybe-early-exit-doc-only-change
       - *step-depot-tools-get
       - *step-depot-tools-add-to-path
+      - *step-generate-deps-hash
       - *step-maybe-restore-src-cache
       - run:
           name: Ensure src checkout worked

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1264,10 +1264,6 @@ commands:
                         - run:
                             name: Move macOS out cache to the linux directory for workspace persistance
                             command: mv /Users/distiller/project/src/out/Default src/out/Default
-                        - persist_to_workspace:
-                            root: .
-                            paths:
-                              - src/out/Default
                   - persist_to_workspace:
                       root: .
                       paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -876,6 +876,7 @@ steps-checkout-and-save-cache: &steps-checkout-and-save-cache
     - *step-generate-deps-hash-cleanly
     - *step-mark-sync-done
     - *step-minimize-workspace-size-from-checkout
+    - *step-delete-git-directories
     - *step-save-src-cache
     - *step-save-brew-cache
 
@@ -1195,7 +1196,21 @@ commands:
       - *step-depot-tools-get
       - *step-depot-tools-add-to-path
       - *step-generate-deps-hash
+      - run:
+          name: Prepare for cross-OS sync restore on macOS
+          command: |
+            if [ "`uname`" == "Darwin" ]; then
+              sudo mkdir -p /home/builduser/project/src
+            fi
       - *step-maybe-restore-src-cache
+      - run:
+          name: Fix the src cache restore point on macOS
+          command: |
+            if [ "`uname`" == "Darwin" && -d "/home/builduser/project/src" ]; then
+              echo Relocating Cache
+              rm -rf src
+              mv /home/builduser/project/src ./
+            fi
       - run:
           name: Ensure src checkout worked
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -695,7 +695,7 @@ step-restore-out-cache: &step-restore-out-cache
     paths:
       - ./src/out/Default
     keys:
-      - v4-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
+      - v5-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
     name: Restoring out cache
 
 step-set-git-cache-path: &step-set-git-cache-path
@@ -719,7 +719,7 @@ step-save-out-cache: &step-save-out-cache
   save_cache:
     paths:
       - ./src/out/Default
-    key: v4-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
+    key: v5-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
     name: Persisting out cache
 
 step-run-electron-only-hooks: &step-run-electron-only-hooks
@@ -1202,13 +1202,7 @@ commands:
       checkout:
         type: boolean
         default: true
-      checkout-mac-out-cache-for-workspace:
-        type: boolean
-        default: false
       build:
-        type: boolean
-        default: true
-      need-out-cache:
         type: boolean
         default: true
     steps:
@@ -1249,24 +1243,6 @@ commands:
             - when:
                 condition: << parameters.persist-checkout >>
                 steps:
-                  - when:
-                      condition: << parameters.checkout-mac-out-cache-for-workspace >>
-                      steps:
-                        - run:
-                            name: Make Empty Default Folder
-                            command: mkdir -p src/out
-                        - run:
-                            name: Fake the macOS directory structure
-                            command: |
-                              sudo mkdir -p /Users/distiller/project
-                              sudo chmod -R 777 /Users/distiller/project
-                        - *step-restore-out-cache
-                        - run:
-                            name: Move macOS out cache to the linux directory for workspace persistance
-                            command: |
-                              if [ -d "/Users/distiller/project/src/out/Default" ]; then
-                                mv /Users/distiller/project/src/out/Default src/out/Default
-                              fi
                   - persist_to_workspace:
                       root: .
                       paths:
@@ -1286,21 +1262,21 @@ commands:
             - *step-gn-gen-default
 
             # Electron app
-            - when:
-                condition: << parameters.need-out-cache >>
-                steps:
-                  - *step-restore-out-cache
+            - *step-restore-out-cache
+            - *step-gn-gen-default
             - *step-electron-build
             - run:
-                name: Remove the big things, this seems to be better on average
+                name: Remove the big things on macOS, this seems to be better on average
                 command: |
-                  mkdir -p src/out/Default
-                  cd src/out/Default
-                  find . -type f -size +50M -delete
-                  mkdir -p gen/electron
-                  cd gen/electron
-                  # These files do not seem to like being in a cache, let us remove them
-                  find . -type f -name '*_pkg_info' -delete
+                  if [ "`uname`" == "Darwin" ]; then
+                    mkdir -p src/out/Default
+                    cd src/out/Default
+                    find . -type f -size +50M -delete
+                    mkdir -p gen/electron
+                    cd gen/electron
+                    # These files do not seem to like being in a cache, let us remove them
+                    find . -type f -name '*_pkg_info' -delete
+                  fi
             - *step-save-out-cache
             - *step-ninja-summary
             - *step-ninja-report
@@ -1423,7 +1399,6 @@ jobs:
           build: false
           checkout: true
           persist-checkout: true
-          checkout-mac-out-cache-for-workspace: false
 
   mac-checkout-and-save-cache:
     <<: *machine-linux-2xlarge
@@ -1658,7 +1633,6 @@ jobs:
           persist: true
           checkout: false
           attach: true
-          need-out-cache: true
 
   osx-testing-gn-check:
     <<: *machine-mac
@@ -1708,8 +1682,6 @@ jobs:
           persist: true
           checkout: false
           attach: true
-          need-out-cache: true
-
 
   mas-testing-gn-check:
     <<: *machine-mac

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ parameters:
 # Build machines configs.
 docker-image: &docker-image
   docker:
-    - image: electronbuilds/electron:0.0.10
+    - image: electronjs/build:697b894f36d127155e020f4e8ad4b2e5f6a09613
 
 machine-linux-medium: &machine-linux-medium
   <<: *docker-image
@@ -878,7 +878,7 @@ steps-checkout-and-save-cache: &steps-checkout-and-save-cache
     - run:
         name: Move src folder to the cross-OS portal
         command: |
-          mkdir -p /portal
+          sudo mkdir -p /portal
           mv ./src /portal
     - *step-save-src-cache
     - *step-save-brew-cache
@@ -1197,11 +1197,7 @@ commands:
       - run:
           name: Prepare for cross-OS sync restore
           command: |
-            if [ "`uname`" == "Darwin" ]; then
-              sudo mkdir -p /portal
-            else
-              mkdir -p /portal
-            fi
+            sudo mkdir -p /portal
       - *step-maybe-restore-src-cache
       - run:
           name: Fix the src cache restore point on macOS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -693,7 +693,7 @@ step-restore-out-cache: &step-restore-out-cache
     paths:
       - ./src/out/Default
     keys:
-      - v1-out-cache-{{ arch }}-{{ checksum "src/electron/.depshash" }}-{{ .Environment.TARGET_ARCH }}-{{ .Environment.GN_CONFIG }}
+      - v1-out-cache-{{ arch }}-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
     name: Restoring out cache
 
 step-set-git-cache-path: &step-set-git-cache-path
@@ -717,7 +717,7 @@ step-save-out-cache: &step-save-out-cache
   save_cache:
     paths:
       - ./src/out/Default
-    key: v1-out-cache-{{ arch }}-{{ checksum "src/electron/.depshash" }}-{{ .Environment.TARGET_ARCH }}-{{ .Environment.GN_CONFIG }}
+    key: v1-out-cache-{{ arch }}-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
     name: Persisting out cache
 
 step-run-electron-only-hooks: &step-run-electron-only-hooks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1436,6 +1436,7 @@ jobs:
     <<: *machine-linux-2xlarge
     environment:
       <<: *env-linux-2xlarge
+      <<: *env-testing-build
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_mac=True --custom-var=host_os=mac'
     <<: *steps-checkout-and-save-cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1264,6 +1264,12 @@ commands:
                         - run:
                             name: Move macOS out cache to the linux directory for workspace persistance
                             command: mv /Users/distiller/project/src/out/Default src/out/Default
+                        # This removes half the size but retains > 70% of the previous build.  Worth it when you add it all up.
+                        - run:
+                            name: Remove the big things
+                            command: |
+                              cd src/out/Default
+                              find -type f -size +50M -delete
                   - persist_to_workspace:
                       root: .
                       paths:

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ ts-gen
 
 # Used to accelerate CI builds
 .depshash
+.depshash-target

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1376,9 +1376,9 @@ dist_zip("electron_chromedriver_zip") {
 
 group("electron_mksnapshot") {
   public_deps = [
-    "//v8:mksnapshot($v8_snapshot_toolchain)",
-    "//tools/v8_context_snapshot:v8_context_snapshot_generator",
     ":licenses",
+    "//tools/v8_context_snapshot:v8_context_snapshot_generator",
+    "//v8:mksnapshot($v8_snapshot_toolchain)",
   ]
 }
 

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1374,11 +1374,17 @@ dist_zip("electron_chromedriver_zip") {
   ]
 }
 
-dist_zip("electron_mksnapshot_zip") {
-  data_deps = [
+group("electron_mksnapshot") {
+  public_deps = [
     "//v8:mksnapshot($v8_snapshot_toolchain)",
     "//tools/v8_context_snapshot:v8_context_snapshot_generator",
     ":licenses",
+  ]
+}
+
+dist_zip("electron_mksnapshot_zip") {
+  data_deps = [
+    ":electron_mksnapshot",
   ]
   outputs = [
     "$root_build_dir/mksnapshot.zip",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1374,18 +1374,18 @@ dist_zip("electron_chromedriver_zip") {
   ]
 }
 
+mksnapshot_deps = [
+  ":licenses",
+  "//tools/v8_context_snapshot:v8_context_snapshot_generator",
+  "//v8:mksnapshot($v8_snapshot_toolchain)",
+]
+
 group("electron_mksnapshot") {
-  public_deps = [
-    ":licenses",
-    "//tools/v8_context_snapshot:v8_context_snapshot_generator",
-    "//v8:mksnapshot($v8_snapshot_toolchain)",
-  ]
+  public_deps = mksnapshot_deps
 }
 
 dist_zip("electron_mksnapshot_zip") {
-  data_deps = [
-    ":electron_mksnapshot",
-  ]
+  data_deps = mksnapshot_deps
   outputs = [
     "$root_build_dir/mksnapshot.zip",
   ]

--- a/script/generate-deps-hash.js
+++ b/script/generate-deps-hash.js
@@ -39,4 +39,4 @@ hasher.update(process.env.GCLIENT_EXTRA_ARGS || 'no_extra_args')
 
 // Write the hash to disk
 fs.writeFileSync(path.resolve(__dirname, '../.depshash'), hasher.digest('hex'))
-fs.writeFileSync(path.resolve(__dirname, '../.depshash-target'), `${process.platform}\n${process.env.TARGET_ARCH}\n${process.env.GN_CONFIG}\n${process.env.MAS_BUILD}`)
+fs.writeFileSync(path.resolve(__dirname, '../.depshash-target'), `${process.platform}\n${process.env.TARGET_ARCH}\n${process.env.GN_CONFIG}\n${process.env.MAS_BUILD}\n${process.env.GN_EXTRA_ARGS}\n${process.env.GN_BUILDFLAG_ARGS}`)

--- a/script/generate-deps-hash.js
+++ b/script/generate-deps-hash.js
@@ -39,3 +39,4 @@ hasher.update(process.env.GCLIENT_EXTRA_ARGS || 'no_extra_args')
 
 // Write the hash to disk
 fs.writeFileSync(path.resolve(__dirname, '../.depshash'), hasher.digest('hex'))
+fs.writeFileSync(path.resolve(__dirname, '../.depshash-target'), `${process.platform}\n${process.env.TARGET_ARCH}\n${process.env.GN_CONFIG}\n${process.env.MAS_BUILD}`)

--- a/script/generate-deps-hash.js
+++ b/script/generate-deps-hash.js
@@ -35,8 +35,11 @@ for (const file of filesToHash) {
 }
 
 // Add the GCLIENT_EXTRA_ARGS variable to the hash
-hasher.update(process.env.GCLIENT_EXTRA_ARGS || 'no_extra_args')
+const extraArgs = process.env.GCLIENT_EXTRA_ARGS || 'no_extra_args'
+hasher.update(extraArgs)
+
+const effectivePlatform = extraArgs.includes('host_os=mac') ? 'darwin' : process.platform
 
 // Write the hash to disk
 fs.writeFileSync(path.resolve(__dirname, '../.depshash'), hasher.digest('hex'))
-fs.writeFileSync(path.resolve(__dirname, '../.depshash-target'), `${process.platform}\n${process.env.TARGET_ARCH}\n${process.env.GN_CONFIG}\n${process.env.MAS_BUILD}\n${process.env.GN_EXTRA_ARGS}\n${process.env.GN_BUILDFLAG_ARGS}`)
+fs.writeFileSync(path.resolve(__dirname, '../.depshash-target'), `${effectivePlatform}\n${process.env.TARGET_ARCH}\n${process.env.GN_CONFIG}\n${process.env.MAS_BUILD}\n${process.env.GN_EXTRA_ARGS}\n${process.env.GN_BUILDFLAG_ARGS}`)

--- a/script/generate-deps-hash.js
+++ b/script/generate-deps-hash.js
@@ -42,4 +42,4 @@ const effectivePlatform = extraArgs.includes('host_os=mac') ? 'darwin' : process
 
 // Write the hash to disk
 fs.writeFileSync(path.resolve(__dirname, '../.depshash'), hasher.digest('hex'))
-fs.writeFileSync(path.resolve(__dirname, '../.depshash-target'), `${effectivePlatform}\n${process.env.TARGET_ARCH}\n${process.env.GN_CONFIG}\n${process.env.MAS_BUILD}\n${process.env.GN_EXTRA_ARGS}\n${process.env.GN_BUILDFLAG_ARGS}`)
+fs.writeFileSync(path.resolve(__dirname, '../.depshash-target'), `${effectivePlatform}\n${process.env.TARGET_ARCH}\n${process.env.GN_CONFIG}\n${undefined}\n${process.env.GN_EXTRA_ARGS}\n${process.env.GN_BUILDFLAG_ARGS}`)

--- a/script/generate-deps-hash.js
+++ b/script/generate-deps-hash.js
@@ -42,4 +42,11 @@ const effectivePlatform = extraArgs.includes('host_os=mac') ? 'darwin' : process
 
 // Write the hash to disk
 fs.writeFileSync(path.resolve(__dirname, '../.depshash'), hasher.digest('hex'))
-fs.writeFileSync(path.resolve(__dirname, '../.depshash-target'), `${effectivePlatform}\n${process.env.TARGET_ARCH}\n${process.env.GN_CONFIG}\n${undefined}\n${process.env.GN_EXTRA_ARGS}\n${process.env.GN_BUILDFLAG_ARGS}`)
+
+let targetContent = `${effectivePlatform}\n${process.env.TARGET_ARCH}\n${process.env.GN_CONFIG}\n${undefined}\n${process.env.GN_EXTRA_ARGS}\n${process.env.GN_BUILDFLAG_ARGS}`
+const argsDir = path.resolve(__dirname, '../build/args')
+for (const argFile of fs.readdirSync(argsDir).sort()) {
+  targetContent += `\n${argFile}--${crypto.createHash('SHA1').update(fs.readFileSync(path.resolve(argsDir, argFile))).digest('hex')}`
+}
+
+fs.writeFileSync(path.resolve(__dirname, '../.depshash-target'), targetContent)


### PR DESCRIPTION
So I tried a lot of things here, mostly based off of the idea @jkleinsc had around caching and restoring the out directory.  On linux that works really well, on macOS the network speed is lower (appears to be only gigabit) so we have to make trade offs around out size vs cache upload / download time.

I think I found the sweet spot.  Raising this PR for 👀 now, I just reset the cache keys so the first run on this PR will be the old slow path.  The second run will be ultra-fast.

Build time estimates are:
Linux ~13 minutes from start to tests complete
macOS ~28 minutes from start to tests complete

Notes: no-notes