### PR TITLE
fix: implement login event for WebContents

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -314,10 +314,8 @@ Returns:
 
 * `event` Event
 * `webContents` [WebContents](web-contents.md)
-* `request` Object
-  * `method` String
+* `authenticationResponseDetails` Object
   * `url` URL
-  * `referrer` URL
 * `authInfo` Object
   * `isProxy` Boolean
   * `scheme` String
@@ -337,7 +335,7 @@ should prevent the default behavior with `event.preventDefault()` and call
 ```javascript
 const { app } = require('electron')
 
-app.on('login', (event, webContents, request, authInfo, callback) => {
+app.on('login', (event, webContents, details, authInfo, callback) => {
   event.preventDefault()
   callback('username', 'secret')
 })

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -454,10 +454,8 @@ The usage is the same with [the `select-client-certificate` event of
 Returns:
 
 * `event` Event
-* `request` Object
-  * `method` String
+* `authenticationResponseDetails` Object
   * `url` URL
-  * `referrer` URL
 * `authInfo` Object
   * `isProxy` Boolean
   * `scheme` String

--- a/lib/browser/api/app.ts
+++ b/lib/browser/api/app.ts
@@ -105,9 +105,9 @@ if (process.platform === 'linux') {
 }
 
 // Routes the events to webContents.
-const events = ['login', 'certificate-error', 'select-client-certificate']
+const events = ['certificate-error', 'select-client-certificate']
 for (const name of events) {
-  app.on(name as 'login', (event, webContents, ...args: any[]) => {
+  app.on(name as 'certificate-error', (event, webContents, ...args: any[]) => {
     webContents.emit(name, event, ...args)
   })
 }

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -415,6 +415,10 @@ WebContents.prototype._init = function () {
     })
   }
 
+  this.on('login', (event, ...args) => {
+    app.emit('login', event, this, ...args)
+  })
+
   const event = process.electronBinding('event').createEmpty()
   app.emit('web-contents-created', event, this)
 }

--- a/shell/browser/api/atom_api_app.cc
+++ b/shell/browser/api/atom_api_app.cc
@@ -495,15 +495,6 @@ void OnClientCertificateSelected(
   }
 }
 
-void PassLoginInformation(scoped_refptr<LoginHandler> login_handler,
-                          mate::Arguments* args) {
-  base::string16 username, password;
-  if (args->GetNext(&username) && args->GetNext(&password))
-    login_handler->Login(username, password);
-  else
-    login_handler->CancelAuth();
-}
-
 #if defined(USE_NSS_CERTS)
 int ImportIntoCertStore(CertificateManagerModel* model,
                         const base::DictionaryValue& options) {
@@ -665,25 +656,6 @@ void App::OnNewWindowForTab() {
   Emit("new-window-for-tab");
 }
 #endif
-
-void App::OnLogin(scoped_refptr<LoginHandler> login_handler,
-                  const base::DictionaryValue& request_details) {
-  v8::Locker locker(isolate());
-  v8::HandleScope handle_scope(isolate());
-  bool prevent_default = false;
-  content::WebContents* web_contents = login_handler->GetWebContents();
-  if (web_contents) {
-    prevent_default =
-        Emit("login", WebContents::FromOrCreate(isolate(), web_contents),
-             request_details, *login_handler->auth_info(),
-             base::BindOnce(&PassLoginInformation,
-                            base::RetainedRef(login_handler)));
-  }
-
-  // Default behavior is to always cancel the auth.
-  if (!prevent_default)
-    login_handler->CancelAuth();
-}
 
 bool App::CanCreateWindow(
     content::RenderFrameHost* opener,

--- a/shell/browser/api/atom_api_app.h
+++ b/shell/browser/api/atom_api_app.h
@@ -90,8 +90,6 @@ class App : public AtomBrowserClient::Delegate,
   void OnActivate(bool has_visible_windows) override;
   void OnWillFinishLaunching() override;
   void OnFinishLaunching(const base::DictionaryValue& launch_info) override;
-  void OnLogin(scoped_refptr<LoginHandler> login_handler,
-               const base::DictionaryValue& request_details) override;
   void OnAccessibilitySupportChanged() override;
   void OnPreMainMessageLoopRun() override;
 #if defined(OS_MACOSX)

--- a/shell/browser/atom_browser_client.cc
+++ b/shell/browser/atom_browser_client.cc
@@ -1077,4 +1077,18 @@ bool AtomBrowserClient::ShouldEnableStrictSiteIsolation() {
   return true;
 }
 
+std::unique_ptr<content::LoginDelegate> AtomBrowserClient::CreateLoginDelegate(
+    const net::AuthChallengeInfo& auth_info,
+    content::WebContents* web_contents,
+    const content::GlobalRequestID& request_id,
+    bool is_main_frame,
+    const GURL& url,
+    scoped_refptr<net::HttpResponseHeaders> response_headers,
+    bool first_auth_attempt,
+    LoginAuthRequiredCallback auth_required_callback) {
+  return std::make_unique<LoginHandler>(
+      auth_info, web_contents, is_main_frame, url, response_headers,
+      first_auth_attempt, std::move(auth_required_callback));
+}
+
 }  // namespace electron

--- a/shell/browser/atom_browser_client.h
+++ b/shell/browser/atom_browser_client.h
@@ -201,6 +201,15 @@ class AtomBrowserClient : public content::ContentBrowserClient,
       ui::PageTransition page_transition,
       bool has_user_gesture,
       network::mojom::URLLoaderFactoryPtr* out_factory) override;
+  std::unique_ptr<content::LoginDelegate> CreateLoginDelegate(
+      const net::AuthChallengeInfo& auth_info,
+      content::WebContents* web_contents,
+      const content::GlobalRequestID& request_id,
+      bool is_main_frame,
+      const GURL& url,
+      scoped_refptr<net::HttpResponseHeaders> response_headers,
+      bool first_auth_attempt,
+      LoginAuthRequiredCallback auth_required_callback) override;
 
   // content::RenderProcessHostObserver:
   void RenderProcessHostDestroyed(content::RenderProcessHost* host) override;

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -180,13 +180,6 @@ void Browser::OnAccessibilitySupportChanged() {
     observer.OnAccessibilitySupportChanged();
 }
 
-void Browser::RequestLogin(
-    scoped_refptr<LoginHandler> login_handler,
-    std::unique_ptr<base::DictionaryValue> request_details) {
-  for (BrowserObserver& observer : observers_)
-    observer.OnLogin(login_handler, *(request_details.get()));
-}
-
 void Browser::PreMainMessageLoopRun() {
   for (BrowserObserver& observer : observers_) {
     observer.OnPreMainMessageLoopRun();

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -247,10 +247,6 @@ class Browser : public WindowListObserver {
 
   void OnAccessibilitySupportChanged();
 
-  // Request basic auth login.
-  void RequestLogin(scoped_refptr<LoginHandler> login_handler,
-                    std::unique_ptr<base::DictionaryValue> request_details);
-
   void PreMainMessageLoopRun();
 
   // Stores the supplied |quit_closure|, to be run when the last Browser

--- a/shell/browser/browser_observer.h
+++ b/shell/browser/browser_observer.h
@@ -49,10 +49,6 @@ class BrowserObserver : public base::CheckedObserver {
   virtual void OnWillFinishLaunching() {}
   virtual void OnFinishLaunching(const base::DictionaryValue& launch_info) {}
 
-  // The browser requests HTTP login.
-  virtual void OnLogin(scoped_refptr<LoginHandler> login_handler,
-                       const base::DictionaryValue& request_details) {}
-
   // The browser's accessibility suppport has changed.
   virtual void OnAccessibilitySupportChanged() {}
 

--- a/shell/browser/login_handler.cc
+++ b/shell/browser/login_handler.cc
@@ -10,7 +10,7 @@
 #include <vector>
 
 #include "base/callback.h"
-#include "mate/dictionary.h"
+#include "native_mate/dictionary.h"
 #include "shell/browser/api/atom_api_web_contents.h"
 #include "shell/common/gin_converters/callback_converter_gin_adapter.h"
 #include "shell/common/gin_converters/net_converter_gin_adapter.h"

--- a/shell/browser/login_handler.cc
+++ b/shell/browser/login_handler.cc
@@ -10,7 +10,7 @@
 #include <vector>
 
 #include "base/callback.h"
-#include "gin/dictionary.h"
+#include "mate/dictionary.h"
 #include "shell/browser/api/atom_api_web_contents.h"
 #include "shell/common/gin_converters/callback_converter_gin_adapter.h"
 #include "shell/common/gin_converters/net_converter_gin_adapter.h"
@@ -33,8 +33,8 @@ LoginHandler::LoginHandler(
       auth_required_callback_(std::move(auth_required_callback)) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
 
-  base::PostTask(
-      FROM_HERE, {base::CurrentThread()},
+  base::PostTaskWithTraits(
+      FROM_HERE, {BrowserThread::UI},
       base::BindOnce(&LoginHandler::EmitEvent, weak_factory_.GetWeakPtr(),
                      auth_info, is_main_frame, url, response_headers,
                      first_auth_attempt));
@@ -56,7 +56,7 @@ void LoginHandler::EmitEvent(
 
   v8::HandleScope scope(isolate);
 
-  auto details = gin::Dictionary::CreateEmpty(isolate);
+  auto details = mate::Dictionary::CreateEmpty(isolate);
   details.Set("url", url.spec());
 
   // These parameters aren't documented, and I'm not sure that they're useful,

--- a/shell/browser/login_handler.cc
+++ b/shell/browser/login_handler.cc
@@ -70,7 +70,7 @@ void LoginHandler::EmitEvent(
       api_web_contents->Emit("login", std::move(details), auth_info,
                              base::BindOnce(&LoginHandler::CallbackFromJS,
                                             weak_factory_.GetWeakPtr()));
-  if (!default_prevented) {
+  if (!default_prevented && auth_required_callback_) {
     std::move(auth_required_callback_).Run(base::nullopt);
   }
 }
@@ -79,8 +79,10 @@ LoginHandler::~LoginHandler() = default;
 
 void LoginHandler::CallbackFromJS(base::string16 username,
                                   base::string16 password) {
-  std::move(auth_required_callback_)
-      .Run(net::AuthCredentials(username, password));
+  if (auth_required_callback_) {
+    std::move(auth_required_callback_)
+        .Run(net::AuthCredentials(username, password));
+  }
 }
 
 }  // namespace electron

--- a/shell/browser/login_handler.cc
+++ b/shell/browser/login_handler.cc
@@ -12,9 +12,9 @@
 #include "base/callback.h"
 #include "gin/dictionary.h"
 #include "shell/browser/api/atom_api_web_contents.h"
-#include "shell/common/gin_converters/callback_converter.h"
-#include "shell/common/gin_converters/net_converter.h"
-#include "shell/common/gin_converters/value_converter.h"
+#include "shell/common/gin_converters/callback_converter_gin_adapter.h"
+#include "shell/common/gin_converters/net_converter_gin_adapter.h"
+#include "shell/common/gin_converters/value_converter_gin_adapter.h"
 
 using content::BrowserThread;
 

--- a/shell/browser/login_handler.cc
+++ b/shell/browser/login_handler.cc
@@ -5,96 +5,82 @@
 #include "shell/browser/login_handler.h"
 
 #include <memory>
+#include <string>
 #include <utility>
+#include <vector>
 
-#include "base/task/post_task.h"
-#include "base/values.h"
-#include "content/public/browser/browser_task_traits.h"
-#include "content/public/browser/browser_thread.h"
-#include "content/public/browser/web_contents.h"
-#include "net/base/auth.h"
-#include "shell/browser/browser.h"
-#include "shell/common/native_mate_converters/net_converter.h"
+#include "base/callback.h"
+#include "gin/dictionary.h"
+#include "shell/browser/api/atom_api_web_contents.h"
+#include "shell/common/gin_converters/callback_converter.h"
+#include "shell/common/gin_converters/net_converter.h"
+#include "shell/common/gin_converters/value_converter.h"
 
 using content::BrowserThread;
 
 namespace electron {
 
-LoginHandler::LoginHandler(net::URLRequest* request,
-                           const net::AuthChallengeInfo& auth_info,
-                           net::NetworkDelegate::AuthCallback callback,
-                           net::AuthCredentials* credentials)
-    : credentials_(credentials),
-      auth_info_(std::make_unique<net::AuthChallengeInfo>(auth_info)),
-      auth_callback_(std::move(callback)),
-      weak_factory_(this) {
-  DCHECK_CURRENTLY_ON(BrowserThread::IO);
+LoginHandler::LoginHandler(
+    const net::AuthChallengeInfo& auth_info,
+    content::WebContents* web_contents,
+    bool is_main_frame,
+    const GURL& url,
+    scoped_refptr<net::HttpResponseHeaders> response_headers,
+    bool first_auth_attempt,
+    LoginAuthRequiredCallback auth_required_callback)
 
-  std::unique_ptr<base::DictionaryValue> request_details(
-      new base::DictionaryValue);
-  FillRequestDetails(request_details.get(), request);
-
-  // TODO(deepak1556): fix with network service
-  // tracking issue: #19602
-  CHECK(false) << "fix with network service";
-  // web_contents_getter_ =
-  //     resource_request_info->GetWebContentsGetterForRequest();
-
-  base::PostTaskWithTraits(
-      FROM_HERE, {BrowserThread::UI},
-      base::BindOnce(&Browser::RequestLogin, base::Unretained(Browser::Get()),
-                     base::RetainedRef(this), std::move(request_details)));
-}
-
-LoginHandler::~LoginHandler() {}
-
-void LoginHandler::Login(const base::string16& username,
-                         const base::string16& password) {
+    : WebContentsObserver(web_contents),
+      auth_required_callback_(std::move(auth_required_callback)) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
 
-  base::PostTaskWithTraits(
-      FROM_HERE, {BrowserThread::IO},
-      base::BindOnce(&LoginHandler::DoLogin, weak_factory_.GetWeakPtr(),
-                     username, password));
+  base::PostTask(
+      FROM_HERE, {base::CurrentThread()},
+      base::BindOnce(&LoginHandler::EmitEvent, weak_factory_.GetWeakPtr(),
+                     auth_info, is_main_frame, url, response_headers,
+                     first_auth_attempt));
 }
 
-void LoginHandler::CancelAuth() {
-  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+void LoginHandler::EmitEvent(
+    net::AuthChallengeInfo auth_info,
+    bool is_main_frame,
+    const GURL& url,
+    scoped_refptr<net::HttpResponseHeaders> response_headers,
+    bool first_auth_attempt) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
 
-  base::PostTaskWithTraits(
-      FROM_HERE, {BrowserThread::IO},
-      base::BindOnce(&LoginHandler::DoCancelAuth, weak_factory_.GetWeakPtr()));
-}
-
-void LoginHandler::NotifyRequestDestroyed() {
-  auth_callback_.Reset();
-  credentials_ = nullptr;
-  weak_factory_.InvalidateWeakPtrs();
-}
-
-content::WebContents* LoginHandler::GetWebContents() const {
-  DCHECK_CURRENTLY_ON(BrowserThread::UI);
-  // TODO(deepak1556): fix with network service
-  // tracking issue: #19602
-  CHECK(false) << "fix with network service";
-  return web_contents_getter_.Run();
-}
-
-void LoginHandler::DoCancelAuth() {
-  DCHECK_CURRENTLY_ON(BrowserThread::IO);
-  if (!auth_callback_.is_null())
-    std::move(auth_callback_)
-        .Run(net::NetworkDelegate::AUTH_REQUIRED_RESPONSE_CANCEL_AUTH);
-}
-
-void LoginHandler::DoLogin(const base::string16& username,
-                           const base::string16& password) {
-  DCHECK_CURRENTLY_ON(BrowserThread::IO);
-  if (!auth_callback_.is_null()) {
-    credentials_->Set(username, password);
-    std::move(auth_callback_)
-        .Run(net::NetworkDelegate::AUTH_REQUIRED_RESPONSE_SET_AUTH);
+  auto api_web_contents = api::WebContents::From(isolate, web_contents());
+  if (api_web_contents.IsEmpty()) {
+    std::move(auth_required_callback_).Run(base::nullopt);
+    return;
   }
+
+  v8::HandleScope scope(isolate);
+
+  auto details = gin::Dictionary::CreateEmpty(isolate);
+  details.Set("url", url.spec());
+
+  // These parameters aren't documented, and I'm not sure that they're useful,
+  // but we might as well stick 'em on the details object. If it turns out they
+  // are useful, we can add them to the docs :)
+  details.Set("isMainFrame", is_main_frame);
+  details.Set("firstAuthAttempt", first_auth_attempt);
+  details.Set("responseHeaders", response_headers.get());
+
+  bool default_prevented =
+      api_web_contents->Emit("login", std::move(details), auth_info,
+                             base::BindOnce(&LoginHandler::CallbackFromJS,
+                                            weak_factory_.GetWeakPtr()));
+  if (!default_prevented) {
+    std::move(auth_required_callback_).Run(base::nullopt);
+  }
+}
+
+LoginHandler::~LoginHandler() = default;
+
+void LoginHandler::CallbackFromJS(base::string16 username,
+                                  base::string16 password) {
+  std::move(auth_required_callback_)
+      .Run(net::AuthCredentials(username, password));
 }
 
 }  // namespace electron

--- a/shell/browser/login_handler.h
+++ b/shell/browser/login_handler.h
@@ -5,15 +5,11 @@
 #ifndef SHELL_BROWSER_LOGIN_HANDLER_H_
 #define SHELL_BROWSER_LOGIN_HANDLER_H_
 
-#include <memory>
-
-#include "base/callback.h"
-#include "base/memory/ref_counted.h"
-#include "base/memory/weak_ptr.h"
-#include "base/sequenced_task_runner_helpers.h"
 #include "base/strings/string16.h"
-#include "content/public/browser/web_contents.h"
-#include "net/base/network_delegate.h"
+#include "base/values.h"
+#include "content/public/browser/content_browser_client.h"
+#include "content/public/browser/login_delegate.h"
+#include "content/public/browser/web_contents_observer.h"
 
 namespace content {
 class WebContents;
@@ -21,52 +17,30 @@ class WebContents;
 
 namespace electron {
 
-// Handles the HTTP basic auth, must be created on IO thread.
-class LoginHandler : public base::RefCountedThreadSafe<LoginHandler> {
+// Handles HTTP basic auth.
+class LoginHandler : public content::LoginDelegate,
+                     public content::WebContentsObserver {
  public:
-  LoginHandler(net::URLRequest* request,
-               const net::AuthChallengeInfo& auth_info,
-               net::NetworkDelegate::AuthCallback callback,
-               net::AuthCredentials* credentials);
-
-  // The auth is cancelled, must be called on UI thread.
-  void CancelAuth();
-
-  // The URLRequest associated with the auth is destroyed.
-  void NotifyRequestDestroyed();
-
-  // Login with |username| and |password|, must be called on UI thread.
-  void Login(const base::string16& username, const base::string16& password);
-
-  // Returns the WebContents associated with the request, must be called on UI
-  // thread.
-  content::WebContents* GetWebContents() const;
-
-  const net::AuthChallengeInfo* auth_info() const { return auth_info_.get(); }
+  LoginHandler(const net::AuthChallengeInfo& auth_info,
+               content::WebContents* web_contents,
+               bool is_main_frame,
+               const GURL& url,
+               scoped_refptr<net::HttpResponseHeaders> response_headers,
+               bool first_auth_attempt,
+               LoginAuthRequiredCallback auth_required_callback);
+  ~LoginHandler() override;
 
  private:
-  friend class base::RefCountedThreadSafe<LoginHandler>;
-  friend class base::DeleteHelper<LoginHandler>;
+  void EmitEvent(net::AuthChallengeInfo auth_info,
+                 bool is_main_frame,
+                 const GURL& url,
+                 scoped_refptr<net::HttpResponseHeaders> response_headers,
+                 bool first_auth_attempt);
+  void CallbackFromJS(base::string16 username, base::string16 password);
 
-  ~LoginHandler();
+  LoginAuthRequiredCallback auth_required_callback_;
 
-  // Must be called on IO thread.
-  void DoCancelAuth();
-  void DoLogin(const base::string16& username, const base::string16& password);
-
-  // Credentials to be used for the auth.
-  net::AuthCredentials* credentials_;
-
-  // Who/where/what asked for the authentication.
-  std::unique_ptr<const net::AuthChallengeInfo> auth_info_;
-
-  // WebContents associated with the login request.
-  content::WebContents::Getter web_contents_getter_;
-
-  // Called with preferred value of net::NetworkDelegate::AuthRequiredResponse.
-  net::NetworkDelegate::AuthCallback auth_callback_;
-
-  base::WeakPtrFactory<LoginHandler> weak_factory_;
+  base::WeakPtrFactory<LoginHandler> weak_factory_{this};
 
   DISALLOW_COPY_AND_ASSIGN(LoginHandler);
 };

--- a/spec-main/api-session-spec.js
+++ b/spec-main/api-session-spec.js
@@ -319,11 +319,6 @@ describe('session module', () => {
 
     beforeEach(async () => {
       customSession = session.fromPartition('proxyconfig')
-      // FIXME(deepak1556): This is just a hack to force
-      // creation of request context which in turn initializes
-      // the network context, can be removed with network
-      // service enabled.
-      await customSession.clearHostResolverCache()
     })
 
     afterEach(() => {

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -287,7 +287,7 @@ describe('webContents module', () => {
       const body = await w.webContents.executeJavaScript(`document.documentElement.textContent`)
       expect(body).to.equal(`Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`)
       expect(eventRequest.url).to.equal(serverUrl + '/')
-      expect(eventAuthInfo.isProxy).to.be.false()
+      expect(eventAuthInfo.isProxy).to.be.false('is proxy')
       expect(eventAuthInfo.scheme).to.equal('basic')
       expect(eventAuthInfo.host).to.equal('127.0.0.1')
       expect(eventAuthInfo.port).to.equal(serverPort)
@@ -296,7 +296,7 @@ describe('webContents module', () => {
 
     it('is emitted when a proxy requests authorization', async () => {
       const customSession = session.fromPartition(`${Math.random()}`)
-      await customSession.setProxy({ proxyRules: `127.0.0.1:${proxyServerPort}`, proxyBypassRules: '<-loopback>' })
+      await customSession.setProxy({ proxyRules: `127.0.0.1:${proxyServerPort}`, proxyBypassRules: '<-loopback>' } as any)
       const [user, pass] = ['user', 'pass']
       const w = new BrowserWindow({ show: false, webPreferences: { session: customSession } })
       let eventRequest: any
@@ -311,7 +311,7 @@ describe('webContents module', () => {
       const body = await w.webContents.executeJavaScript(`document.documentElement.textContent`)
       expect(body).to.equal(`Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`)
       expect(eventRequest.url).to.equal(`${serverUrl}/no-auth`)
-      expect(eventAuthInfo.isProxy).to.be.true()
+      expect(eventAuthInfo.isProxy).to.be.true('is proxy')
       expect(eventAuthInfo.scheme).to.equal('basic')
       expect(eventAuthInfo.host).to.equal('127.0.0.1')
       expect(eventAuthInfo.port).to.equal(proxyServerPort)

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -223,4 +223,99 @@ describe('webContents module', () => {
       })
     })
   })
+
+  describe('login event', () => {
+    afterEach(closeAllWindows)
+
+    let server: http.Server
+    let serverUrl: string
+    let serverPort: number
+    let proxyServer: http.Server
+    let proxyServerPort: number
+
+    before((done) => {
+      server = http.createServer((request, response) => {
+        if (request.url === '/no-auth') {
+          return response.end('ok')
+        }
+        if (request.headers.authorization) {
+          response.writeHead(200, { 'Content-type': 'text/plain' })
+          return response.end(request.headers.authorization)
+        }
+        response
+          .writeHead(401, { 'WWW-Authenticate': 'Basic realm="Foo"' })
+          .end()
+      }).listen(0, '127.0.0.1', () => {
+        serverPort = (server.address() as AddressInfo).port
+        serverUrl = `http://127.0.0.1:${serverPort}`
+        done()
+      })
+    })
+
+    before((done) => {
+      proxyServer = http.createServer((request, response) => {
+        if (request.headers['proxy-authorization']) {
+          response.writeHead(200, { 'Content-type': 'text/plain' })
+          return response.end(request.headers['proxy-authorization'])
+        }
+        response
+          .writeHead(407, { 'Proxy-Authenticate': 'Basic realm="Foo"' })
+          .end()
+      }).listen(0, '127.0.0.1', () => {
+        proxyServerPort = (proxyServer.address() as AddressInfo).port
+        done()
+      })
+    })
+
+    after(() => {
+      server.close()
+      proxyServer.close()
+    })
+
+    it('is emitted when navigating', async () => {
+      const [user, pass] = ['user', 'pass']
+      const w = new BrowserWindow({ show: false })
+      let eventRequest: any
+      let eventAuthInfo: any
+      w.webContents.on('login', (event, request, authInfo, cb) => {
+        eventRequest = request
+        eventAuthInfo = authInfo
+        event.preventDefault()
+        cb(user, pass)
+      })
+      await w.loadURL(serverUrl)
+      const body = await w.webContents.executeJavaScript(`document.documentElement.textContent`)
+      expect(body).to.equal(`Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`)
+      expect(eventRequest.url).to.equal(serverUrl + '/')
+      expect(eventAuthInfo.isProxy).to.be.false()
+      expect(eventAuthInfo.scheme).to.equal('basic')
+      expect(eventAuthInfo.host).to.equal('127.0.0.1')
+      expect(eventAuthInfo.port).to.equal(serverPort)
+      expect(eventAuthInfo.realm).to.equal('Foo')
+    })
+
+    it('is emitted when a proxy requests authorization', async () => {
+      const customSession = session.fromPartition(`${Math.random()}`)
+      await customSession.setProxy({ proxyRules: `127.0.0.1:${proxyServerPort}`, proxyBypassRules: '<-loopback>' })
+      const [user, pass] = ['user', 'pass']
+      const w = new BrowserWindow({ show: false, webPreferences: { session: customSession } })
+      let eventRequest: any
+      let eventAuthInfo: any
+      w.webContents.on('login', (event, request, authInfo, cb) => {
+        eventRequest = request
+        eventAuthInfo = authInfo
+        event.preventDefault()
+        cb(user, pass)
+      })
+      await w.loadURL(`${serverUrl}/no-auth`)
+      const body = await w.webContents.executeJavaScript(`document.documentElement.textContent`)
+      expect(body).to.equal(`Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`)
+      expect(eventRequest.url).to.equal(`${serverUrl}/no-auth`)
+      expect(eventAuthInfo.isProxy).to.be.true()
+      expect(eventAuthInfo.scheme).to.equal('basic')
+      expect(eventAuthInfo.host).to.equal('127.0.0.1')
+      expect(eventAuthInfo.port).to.equal(proxyServerPort)
+      expect(eventAuthInfo.realm).to.equal('Foo')
+    })
+  })
 })

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -3,7 +3,7 @@ import { AddressInfo } from 'net'
 import * as chaiAsPromised from 'chai-as-promised'
 import * as path from 'path'
 import * as http from 'http'
-import { BrowserWindow, ipcMain, webContents } from 'electron'
+import { BrowserWindow, ipcMain, webContents, session } from 'electron'
 import { emittedOnce } from './events-helpers';
 import { closeAllWindows } from './window-helpers';
 import { ifdescribe } from './spec-helpers';


### PR DESCRIPTION
Backport of #20954. See that PR for details.

Notes: Fixed the 'login' event not being emitted when HTTP Basic auth was requested from a WebContents.