### PR TITLE
docs: clarify uniqueness of WebContents.id, BrowserWindow.id

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -772,7 +772,7 @@ events.
 
 #### `win.id` _Readonly_
 
-A `Integer` property representing the unique ID of the window.
+A `Integer` property representing the unique ID of the window. Each ID is unique among all `BrowserWindow` instances of the entire Electron application.
 
 #### `win.autoHideMenuBar`
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1771,7 +1771,7 @@ Only applicable if *offscreen rendering* is enabled.
 
 #### `contents.id` _Readonly_
 
-A `Integer` representing the unique ID of this WebContents.
+A `Integer` representing the unique ID of this WebContents. Each ID is unique among all `WebContents` instances of the entire Electron application.
 
 #### `contents.session` _Readonly_
 


### PR DESCRIPTION
#### Description of Change
document enhancement:  clarify uniqueness of `WebContents.id`, `BrowserWindow.id`.
Closes https://github.com/electron/electron/issues/21087.

#### Checklist
- [x] PR description included and stakeholders cc'd
(https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes