### PR TITLE
fix: do not close windows when the opener window closed

### DIFF
--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -82,20 +82,7 @@ const mergeBrowserWindowOptions = function (embedder, options) {
 
 // Setup a new guest with |embedder|
 const setupGuest = function (embedder, frameName, guest, options) {
-  // When |embedder| is destroyed we should also destroy attached guest, and if
-  // guest is closed by user then we should prevent |embedder| from double
-  // closing guest.
   const guestId = guest.webContents.id
-  const closedByEmbedder = function () {
-    guest.removeListener('closed', closedByUser)
-    guest.destroy()
-  }
-  const closedByUser = function () {
-    embedder._sendInternal('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_CLOSED_' + guestId)
-    embedder.removeListener('current-render-view-deleted', closedByEmbedder)
-  }
-  embedder.once('current-render-view-deleted', closedByEmbedder)
-  guest.once('closed', closedByUser)
   if (frameName) {
     frameToGuest.set(frameName, guest)
     guest.frameName = frameName


### PR DESCRIPTION
#### Description of Change
Prevents the closing of windows when the opener window closes.
(This affects all electron versions)
Fixes: https://github.com/electron/electron/issues/11128

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [X] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Do not close windows when the opener window closed (https://github.com/electron/electron/issues/11128)
