### PR TITLE
fix: stream protocols sometimes flake out

### DIFF
--- a/shell/browser/net/node_stream_loader.cc
+++ b/shell/browser/net/node_stream_loader.cc
@@ -26,10 +26,7 @@ NodeStreamLoader::NodeStreamLoader(network::ResourceResponseHead head,
       base::BindOnce(&NodeStreamLoader::NotifyComplete,
                      weak_factory_.GetWeakPtr(), net::ERR_FAILED));
 
-  // PostTask since it might destruct.
-  base::SequencedTaskRunnerHandle::Get()->PostTask(
-      FROM_HERE, base::BindOnce(&NodeStreamLoader::Start,
-                                weak_factory_.GetWeakPtr(), std::move(head)));
+  Start(std::move(head));
 }
 
 NodeStreamLoader::~NodeStreamLoader() {
@@ -44,10 +41,6 @@ NodeStreamLoader::~NodeStreamLoader() {
     node::MakeCallback(isolate_, emitter_.Get(isolate_), "removeListener",
                        node::arraysize(args), args, {0, 0});
   }
-
-  // Release references.
-  emitter_.Reset();
-  buffer_.Reset();
 }
 
 void NodeStreamLoader::Start(network::ResourceResponseHead head) {


### PR DESCRIPTION
#### Description of Change
Fixes #21018. I'm not exactly sure why, but applying this change locally seems to resolve the problem for me.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where custom protocols registered using `registerStreamProtocol` would sometimes fail to complete the response when the stream ended.