### PR TITLE
fix: incorrect size of windows on differently scaled monitors

### DIFF
--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -355,7 +355,6 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
       // use the proper display to calculate the scale factor to use.
       if (!last_normal_placement_bounds_.IsEmpty() &&
           GetWindowPlacement(GetAcceleratedWidget(), &wp)) {
-        last_normal_placement_bounds_.set_size(gfx::Size(0, 0));
         wp.rcNormalPosition = last_normal_placement_bounds_.ToRECT();
         SetWindowPlacement(GetAcceleratedWidget(), &wp);
 

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -345,35 +345,24 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
       return false;
     }
     case WM_GETMINMAXINFO: {
-      // We need to handle GETMINMAXINFO ourselves because chromium tries to
-      // get the scale factor of the window during it's version of this handler
-      // based on the window position, which is invalid at this point. The
-      // previous method of calling SetWindowPlacement fixed the window
-      // position for the scale factor calculation but broke other things.
-      MINMAXINFO* info = reinterpret_cast<MINMAXINFO*>(l_param);
+      WINDOWPLACEMENT wp;
+      wp.length = sizeof(WINDOWPLACEMENT);
 
-      display::Display display =
-          display::Screen::GetScreen()->GetDisplayNearestPoint(
-              last_normal_placement_bounds_.origin());
+      // We do this to work around a Windows bug, where the minimized Window
+      // would report that the closest display to it is not the one that it was
+      // previously on (but the leftmost one instead). We restore the position
+      // of the window during the restore operation, this way chromium can
+      // use the proper display to calculate the scale factor to use.
+      if (!last_normal_placement_bounds_.IsEmpty() &&
+          GetWindowPlacement(GetAcceleratedWidget(), &wp)) {
+        last_normal_placement_bounds_.set_size(gfx::Size(0, 0));
+        wp.rcNormalPosition = last_normal_placement_bounds_.ToRECT();
+        SetWindowPlacement(GetAcceleratedWidget(), &wp);
 
-      gfx::Size min_size = gfx::ScaleToCeiledSize(
-          widget()->GetMinimumSize(), display.device_scale_factor());
-      gfx::Size max_size = gfx::ScaleToCeiledSize(
-          widget()->GetMaximumSize(), display.device_scale_factor());
-
-      info->ptMinTrackSize.x = min_size.width();
-      info->ptMinTrackSize.y = min_size.height();
-      if (max_size.width() || max_size.height()) {
-        if (!max_size.width())
-          max_size.set_width(GetSystemMetrics(SM_CXMAXTRACK));
-        if (!max_size.height())
-          max_size.set_height(GetSystemMetrics(SM_CYMAXTRACK));
-        info->ptMaxTrackSize.x = max_size.width();
-        info->ptMaxTrackSize.y = max_size.height();
+        last_normal_placement_bounds_ = gfx::Rect();
       }
 
-      *result = 1;
-      return true;
+      return false;
     }
     case WM_NCCALCSIZE: {
       if (!has_frame() && w_param == TRUE) {


### PR DESCRIPTION
#### Description of Change

Backports https://github.com/electron/electron/pull/21100

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix incorrect size of windows on differently scaled monitors