### PR TITLE
fix: prevent urlrequest exception when upload

### DIFF
--- a/shell/browser/api/atom_api_url_request.cc
+++ b/shell/browser/api/atom_api_url_request.cc
@@ -260,6 +260,8 @@ void URLRequest::Cancel() {
 }
 
 void URLRequest::Close() {
+  // When write called for is_last for upload, last_chunk_written is set already
+  // with pending bytes
   if (!pending_writes_.empty() && last_chunk_written_) {
     request_state_ |= STATE_PENDING_CLOSE;
     return;
@@ -572,6 +574,10 @@ void URLRequest::EmitError(EventType type, base::StringPiece message) {
 }
 
 void URLRequest::EmitFinished() {
+  // Finish only once.
+  if (request_state_ & (STATE_FINISHED))
+    return;
+
   request_state_ |= STATE_FINISHED;
   EmitEvent(EventType::kRequest, true, "finish");
 }

--- a/shell/browser/api/atom_api_url_request.cc
+++ b/shell/browser/api/atom_api_url_request.cc
@@ -260,7 +260,7 @@ void URLRequest::Cancel() {
 }
 
 void URLRequest::Close() {
-  if (!pending_writes_.empty() && !(request_state_ & STATE_CANCELED)) {
+  if (!pending_writes_.empty() && last_chunk_written_) {
     request_state_ |= STATE_PENDING_CLOSE;
     return;
   }

--- a/shell/browser/api/atom_api_url_request.h
+++ b/shell/browser/api/atom_api_url_request.h
@@ -98,6 +98,7 @@ class URLRequest : public gin_helper::EventEmitter<URLRequest>,
     kResponse,
   };
   void EmitError(EventType type, base::StringPiece error);
+  void EmitFinished();
   template <typename... Args>
   void EmitEvent(EventType type, Args&&... args);
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

- closes #21151 .

Context: https://cs.chromium.org/chromium/src/services/network/public/mojom/chunked_data_pipe_getter.mojom?type=cs&sq=package:chromium&g=0&l=30-31

`ChunkedDataPipeGetter::StartReading()` is gauranteed to be called after `ChunkedDataPipeGetter::GetSize()`, but not gauranteed _when_. In result, depends on size of file / timing of stream closes, when `Write(_data, is_last:true)` synchronously calls `StartWriting`, `producer_` is not gauranteed to exist.

This PR changes logic to trigger last part writing,  let DataPipeGetter callback handles writing and emit event necessarily. It required to change some of event emission like close event as well, as DataPipeGetter callback can be called after close. For those case, set state to pending to close and let emit once writing is done.

It's bit unclear how to add test cases for this, as these are intermittent, timing involved.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix clientrequest crashes intermittently when uploading