### PR TITLE
refactor: declare KeyWeakMap<K, V> returned by createIDWeakMap() / createDoubleIDWeakMap()

### DIFF
--- a/lib/browser/remote/server.ts
+++ b/lib/browser/remote/server.ts
@@ -23,7 +23,7 @@ const FUNCTION_PROPERTIES = [
 
 // The remote functions in renderer processes.
 // id => Function
-const rendererFunctions = v8Util.createDoubleIDWeakMap()
+const rendererFunctions = v8Util.createDoubleIDWeakMap<(...args: any[]) => void>()
 
 type ObjectMember = {
   name: string,
@@ -289,7 +289,7 @@ const unwrapArgs = function (sender: electron.WebContents, frameId: number, cont
       case 'function': {
         // Merge contextId and meta.id, since meta.id can be the same in
         // different webContents.
-        const objectId = [contextId, meta.id]
+        const objectId: [string, number] = [contextId, meta.id]
 
         // Cache the callbacks in renderer.
         if (rendererFunctions.has(objectId)) {
@@ -373,12 +373,12 @@ const logStack = function (contents: electron.WebContents, code: string, stack: 
 }
 
 handleRemoteCommand('ELECTRON_BROWSER_WRONG_CONTEXT_ERROR', function (event, contextId, passedContextId, id) {
-  const objectId = [passedContextId, id]
+  const objectId: [string, number] = [passedContextId, id]
   if (!rendererFunctions.has(objectId)) {
     // Do nothing if the error has already been reported before.
     return
   }
-  removeRemoteListenersAndLogWarning(event.sender, rendererFunctions.get(objectId))
+  removeRemoteListenersAndLogWarning(event.sender, rendererFunctions.get(objectId)!)
 })
 
 handleRemoteCommand('ELECTRON_BROWSER_REQUIRE', function (event, contextId, moduleName, stack) {

--- a/spec-main/api-menu-spec.ts
+++ b/spec-main/api-menu-spec.ts
@@ -829,7 +829,7 @@ describe('Menu module', function () {
 
       // Keep a weak reference to the menu.
       const v8Util = process.electronBinding('v8_util')
-      const map = (v8Util as any).createIDWeakMap() as any
+      const map = v8Util.createIDWeakMap<Electron.Menu>()
       map.set(0, menu)
 
       setTimeout(() => {
@@ -839,7 +839,7 @@ describe('Menu module', function () {
         setTimeout(() => {
           // Try to receive menu from weak reference.
           if (map.has(0)) {
-            map.get(0).closePopup()
+            map.get(0)!.closePopup()
             done()
           } else {
             done('Menu is garbage-collected while popuping')

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -29,7 +29,8 @@ declare namespace NodeJS {
     setHiddenValue<T>(obj: any, key: string, value: T): void;
     deleteHiddenValue(obj: any, key: string): void;
     requestGarbageCollectionForTesting(): void;
-    createDoubleIDWeakMap(): any;
+    createIDWeakMap<V>(): ElectronInternal.KeyWeakMap<number, V>;
+    createDoubleIDWeakMap<V>(): ElectronInternal.KeyWeakMap<[string, number], V>;
     setRemoteCallbackFreer(fn: Function, frameId: number, contextId: String, id: number, sender: any): void
   }
 

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -112,6 +112,13 @@ declare namespace ElectronInternal {
     appIcon: string | null;
   }
 
+  interface KeyWeakMap<K, V> {
+    set(key: K, value: V): void;
+    get(key: K): V | undefined;
+    has(key: K): boolean;
+    remove(key: K): void;
+  }
+
   // Internal IPC has _replyInternal and NO reply method
   interface IpcMainInternalEvent extends Omit<Electron.IpcMainEvent, 'reply'> {
     _replyInternal(...args: any[]): void;


### PR DESCRIPTION
#### Description of Change
Improves type safety

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes