### PR TITLE
docs: document webkitdirectory breaking change

### DIFF
--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -68,6 +68,40 @@ webFrame.setIsolatedWorldInfo(
 
 This property was removed in Chromium 77, and as such is no longer available.
 
+### `webkitdirectory` attribute for `<input type="file"/>`
+￼
+￼The `webkitdirectory` property on HTML file inputs allows them to select folders.
+￼Previous versions of Electron had an incorrect implementation where the `event.target.files`
+￼of the input returned a `FileList` that returned one `File` corresponding to the selected folder.
+￼
+￼As of Electron 7, that `FileList` is now list of all files contained within
+￼the folder, similarly to Chrome, Firefox, and Edge
+￼([link to MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/webkitdirectory)).
+￼
+￼As an illustration, take a folder with this structure:
+￼```console
+￼folder
+￼├── file1
+￼├── file2
+￼└── file3
+￼```
+￼
+￼In Electron <=6, this would return a `FileList` with a `File` object for:
+￼```console
+￼path/to/folder
+￼```
+￼
+￼In Electron 7, this now returns a `FileList` with a `File` object for:
+￼```console
+￼/path/to/folder/file3
+￼/path/to/folder/file2
+￼/path/to/folder/file1
+￼```
+￼
+￼Note that `webkitdirectory` no longer exposes the path to the selected folder.
+￼If you require the path to the selected folder rather than the folder contents,
+￼see the `dialog.showOpenDialog` API ([link](https://github.com/electron/electron/blob/master/docs/api/dialog.md#dialogshowopendialogbrowserwindow-options)).
+
 ## Planned Breaking API Changes (6.0)
 
 ### `win.setMenu(null)`
@@ -197,7 +231,7 @@ A new API, `protocol.registerSchemesAsPrivileged` has been added and should be u
 ### webFrame Isolated World APIs
 
 ```js
-// Deprecated
+// Removed in Electron 7.0
 webFrame.setIsolatedWorldContentSecurityPolicy(worldId, csp)
 webFrame.setIsolatedWorldHumanReadableName(worldId, name)
 webFrame.setIsolatedWorldSecurityOrigin(worldId, securityOrigin)


### PR DESCRIPTION
#### Description of Change

Manually backport #20934. See that PR for details.

CC @jkleinsc @erickzhao 

#### Checklist

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes