### PR TITLE
build: split static library for 32 bit linux builds

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -354,8 +354,16 @@ template("maybe_split_static_library") {
   }
 }
 
+set_defaults("maybe_split_static_library") {
+  if (is_component_build) {
+    configs = default_shared_library_configs
+  } else {
+    configs = default_compiler_configs
+  }
+}
+
 maybe_split_static_library("electron_lib") {
-  configs = [ "//v8:external_startup_data" ]
+  configs += [ "//v8:external_startup_data" ]
   configs += [ "//third_party/electron_node:node_internals" ]
 
   public_configs = [

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -35,7 +35,7 @@ if (is_mac) {
 
 if (is_linux) {
   import("//build/config/linux/pkg_config.gni")
-  import("//v8/gni/split_static_library.gni")
+  import("//build/split_static_library.gni")
 
   pkg_config("gio_unix") {
     packages = [ "gio-unix-2.0" ]
@@ -344,7 +344,7 @@ template("maybe_split_static_library") {
     _target_type = "split_static_library"
 
     # Split count is only used when calling split_static_library
-    split_count = 2
+    split_count = 4
   } else {
     _target_type = "source_set"
   }

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -35,6 +35,7 @@ if (is_mac) {
 
 if (is_linux) {
   import("//build/config/linux/pkg_config.gni")
+  import("//v8/gni/split_static_library.gni")
 
   pkg_config("gio_unix") {
     packages = [ "gio-unix-2.0" ]
@@ -338,8 +339,23 @@ templated_file("electron_version_header") {
   args_files = get_target_outputs(":electron_version_args")
 }
 
-source_set("electron_lib") {
-  configs += [ "//v8:external_startup_data" ]
+template("maybe_split_static_library") {
+  if (is_linux && (target_cpu == "arm" || target_cpu == "x86")) {
+    _target_type = "split_static_library"
+
+    # Split count is only used when calling split_static_library
+    split_count = 2
+  } else {
+    _target_type = "source_set"
+  }
+  target(_target_type, target_name) {
+    forward_variables_from(invoker, [ "visibility" ])
+    forward_variables_from(invoker, "*", [ "visibility" ])
+  }
+}
+
+maybe_split_static_library("electron_lib") {
+  configs = [ "//v8:external_startup_data" ]
   configs += [ "//third_party/electron_node:node_internals" ]
 
   public_configs = [


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
This PR splits out our static library for 32 bit linux builds in order to get around the issue that our 32 bit release builds are failing during linking due to a > 4gb file.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
