### PR TITLE
build: use python3 to download external binaries

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -114,7 +114,7 @@ hooks = [
     'pattern': 'src/electron/script/update-external-binaries.py',
     'condition': 'download_external_binaries',
     'action': [
-      'python',
+      'python3',
       'src/electron/script/update-external-binaries.py',
     ],
   },

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -21,6 +21,7 @@ BASE_URL = os.getenv('LIBCHROMIUMCONTENT_MIRROR') or \
 PLATFORM = {
   'cygwin': 'win32',
   'darwin': 'darwin',
+  'linux': 'linux',
   'linux2': 'linux',
   'win32': 'win32',
 }[sys.platform]

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -16,7 +16,11 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-import urllib2
+# Python 3 / 2 compat import
+try:
+  from urllib.request import urlopen
+except ImportError:
+  from urllib2 import urlopen
 import zipfile
 
 from lib.config import is_verbose_mode, PLATFORM
@@ -69,8 +73,12 @@ def download(text, url, path):
       ssl._create_default_https_context = ssl._create_unverified_context
 
     print("Downloading %s to %s" % (url, path))
-    web_file = urllib2.urlopen(url)
-    file_size = int(web_file.info().getheaders("Content-Length")[0])
+    web_file = urlopen(url)
+    info = web_file.info()
+    if hasattr(info, 'getheader'):
+      file_size = int(info.getheaders("Content-Length")[0])
+    else:
+      file_size = int(info.get("Content-Length")[0])
     downloaded_size = 0
     block_size = 4096
 


### PR DESCRIPTION
On master, on macOS the version of `vpython` chrome ships in depot tools does not have a new enough version of openssl to download things from github.  This updates our script to work in both python 2 and python 3 and updates our DEPS file to use python 3 to download the external binaries.

This fixes the issue with nightlies not releasing.

Notes: no-notes