### PR TITLE
fix: record cpu_profiler data for main process

### DIFF
--- a/shell/app/atom_main_delegate.cc
+++ b/shell/app/atom_main_delegate.cc
@@ -24,6 +24,7 @@
 #include "ipc/ipc_buildflags.h"
 #include "services/service_manager/embedder/switches.h"
 #include "services/service_manager/sandbox/switches.h"
+#include "services/tracing/public/cpp/stack_sampling/tracing_sampler_profiler.h"
 #include "shell/app/atom_content_client.h"
 #include "shell/browser/atom_browser_client.h"
 #include "shell/browser/atom_gpu_client.h"
@@ -181,6 +182,9 @@ bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
 
   if (env->HasVar("ELECTRON_DISABLE_SANDBOX"))
     command_line->AppendSwitch(service_manager::switches::kNoSandbox);
+
+  tracing_sampler_profiler_ =
+      tracing::TracingSamplerProfiler::CreateOnMainThread();
 
   chrome::RegisterPathProvider();
 

--- a/shell/app/atom_main_delegate.h
+++ b/shell/app/atom_main_delegate.h
@@ -11,6 +11,10 @@
 #include "content/public/app/content_main_delegate.h"
 #include "content/public/common/content_client.h"
 
+namespace tracing {
+class TracingSamplerProfiler;
+}
+
 namespace electron {
 
 void LoadResourceBundle(const std::string& locale);
@@ -51,6 +55,7 @@ class AtomMainDelegate : public content::ContentMainDelegate {
   std::unique_ptr<content::ContentGpuClient> gpu_client_;
   std::unique_ptr<content::ContentRendererClient> renderer_client_;
   std::unique_ptr<content::ContentUtilityClient> utility_client_;
+  std::unique_ptr<tracing::TracingSamplerProfiler> tracing_sampler_profiler_;
 
   DISALLOW_COPY_AND_ASSIGN(AtomMainDelegate);
 };

--- a/shell/browser/atom_browser_main_parts.cc
+++ b/shell/browser/atom_browser_main_parts.cc
@@ -32,6 +32,7 @@
 #include "services/device/public/mojom/constants.mojom.h"
 #include "services/network/public/cpp/features.h"
 #include "services/service_manager/public/cpp/connector.h"
+#include "services/tracing/public/cpp/stack_sampling/tracing_sampler_profiler.h"
 #include "shell/app/atom_main_delegate.h"
 #include "shell/browser/api/atom_api_app.h"
 #include "shell/browser/atom_browser_client.h"
@@ -387,6 +388,12 @@ int AtomBrowserMainParts::PreCreateThreads() {
   fake_browser_process_->PreCreateThreads();
 
   return 0;
+}
+
+void AtomBrowserMainParts::PostCreateThreads() {
+  base::PostTask(
+      FROM_HERE, {content::BrowserThread::IO},
+      base::BindOnce(&tracing::TracingSamplerProfiler::CreateOnChildThread));
 }
 
 void AtomBrowserMainParts::PostDestroyThreads() {

--- a/shell/browser/atom_browser_main_parts.h
+++ b/shell/browser/atom_browser_main_parts.h
@@ -92,6 +92,7 @@ class AtomBrowserMainParts : public content::BrowserMainParts {
   void PostMainMessageLoopStart() override;
   void PostMainMessageLoopRun() override;
   void PreMainMessageLoopStart() override;
+  void PostCreateThreads() override;
   void PostDestroyThreads() override;
 
  private:


### PR DESCRIPTION
#### Description of Change
This allows the `contentTracing` module to collect stack samples from the main process by specifying the `disabled-by-default-cpu_profiler` category. Without this fix, traces from the GPU process and renderers are collected, but not from the main process or utility processes.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: The `disabled-by-default-cpu_profiler` tracing category now correctly records stack samples from the main process and utility processes.
