### PR TITLE
feat: expose executeJavaScriptInIsolatedWorld on webContents

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1033,7 +1033,7 @@ contents.executeJavaScript('fetch("https://jsonplaceholder.typicode.com/users/1"
 
 #### `contents.executeJavaScriptInIsolatedWorld(worldId, scripts[, userGesture])`
 
-* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature.  You can provide any integer here.
+* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electron's `contextIsolation` feature.  You can provide any integer here.
 * `scripts` [WebSource[]](structures/web-source.md)
 * `userGesture` Boolean (optional) - Default is `false`.
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1031,6 +1031,17 @@ contents.executeJavaScript('fetch("https://jsonplaceholder.typicode.com/users/1"
   })
 ```
 
+#### `contents.executeJavaScriptInIsolatedWorld(worldId, scripts[, userGesture])`
+
+* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature.  You can provide any integer here.
+* `scripts` [WebSource[]](structures/web-source.md)
+* `userGesture` Boolean (optional) - Default is `false`.
+
+Returns `Promise<any>` - A promise that resolves with the result of the executed code
+or is rejected if the result of the code is a rejected promise.
+
+Works like `executeJavaScript` but evaluates `scripts` in an isolated context.
+
 #### `contents.setIgnoreMenuShortcuts(ignore)` _Experimental_
 
 * `ignore` Boolean

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -183,22 +183,25 @@ for (const method of webFrameMethods) {
   }
 }
 
-const executeJavaScript = (contents, code, hasUserGesture) => {
-  return ipcMainUtils.invokeInWebContents(contents, false, 'ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', 'executeJavaScript', code, hasUserGesture)
+const waitTillCanExecuteJavaScript = async (webContents) => {
+  if (webContents.getURL() && !webContents.isLoadingMainFrame()) return
+
+  return new Promise((resolve) => {
+    webContents.once('did-stop-loading', () => {
+      resolve()
+    })
+  })
 }
 
 // Make sure WebContents::executeJavaScript would run the code only when the
 // WebContents has been loaded.
-WebContents.prototype.executeJavaScript = function (code, hasUserGesture) {
-  if (this.getURL() && !this.isLoadingMainFrame()) {
-    return executeJavaScript(this, code, hasUserGesture)
-  } else {
-    return new Promise((resolve, reject) => {
-      this.once('did-stop-loading', () => {
-        executeJavaScript(this, code, hasUserGesture).then(resolve, reject)
-      })
-    })
-  }
+WebContents.prototype.executeJavaScript = async function (code, hasUserGesture) {
+  await waitTillCanExecuteJavaScript(this)
+  return ipcMainUtils.invokeInWebContents(this, false, 'ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', 'executeJavaScript', code, hasUserGesture)
+}
+WebContents.prototype.executeJavaScriptInIsolatedWorld = async function (code, hasUserGesture) {
+  await waitTillCanExecuteJavaScript(this)
+  return ipcMainUtils.invokeInWebContents(this, false, 'ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', 'executeJavaScriptInIsolatedWorld', code, hasUserGesture)
 }
 
 // Translate the options of printToPDF.

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -214,6 +214,25 @@ describe('webContents module', () => {
     })
   })
 
+  describe('webContents.executeJavaScriptInIsolatedWorld', () => {
+    let w: BrowserWindow
+
+    before(async () => {
+      w = new BrowserWindow({ show: false, webPreferences: { contextIsolation: true } })
+      await w.loadURL('about:blank')
+    })
+
+    it('resolves the returned promise with the result', async () => {
+      await w.webContents.executeJavaScriptInIsolatedWorld(999, [{ code: 'window.X = 123' }])
+      const isolatedResult = await w.webContents.executeJavaScriptInIsolatedWorld(999, [{ code: 'window.X' }])
+      console.log(isolatedResult)
+      const mainWorldResult = await w.webContents.executeJavaScript('window.X')
+      console.log(mainWorldResult)
+      expect(isolatedResult).to.equal(123)
+      expect(mainWorldResult).to.equal(undefined)
+    })
+  })
+
   describe('loadURL() promise API', () => {
     let w: BrowserWindow
     beforeEach(async () => {

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -225,9 +225,7 @@ describe('webContents module', () => {
     it('resolves the returned promise with the result', async () => {
       await w.webContents.executeJavaScriptInIsolatedWorld(999, [{ code: 'window.X = 123' }])
       const isolatedResult = await w.webContents.executeJavaScriptInIsolatedWorld(999, [{ code: 'window.X' }])
-      console.log(isolatedResult)
       const mainWorldResult = await w.webContents.executeJavaScript('window.X')
-      console.log(mainWorldResult)
       expect(isolatedResult).to.equal(123)
       expect(mainWorldResult).to.equal(undefined)
     })


### PR DESCRIPTION
This exposes `executeJavaScriptInIsolatedWorld` in a similar way to `executeJavaScript` so that folks can call it from the main process.  Also cleans up the code we use for the main-process side `executeJavaScript`

Notes: Exposed `executeJavaScriptInIsolatedWorld` on the `webContents` API