### PR TITLE
build: update release build endpoint from /jobs to /job

### DIFF
--- a/script/release/ci-release-build.js
+++ b/script/release/ci-release-build.js
@@ -126,7 +126,7 @@ async function getCircleCIWorkflowId (pipelineId) {
 }
 
 async function getCircleCIJobNumber (workflowId) {
-  const jobInfoUrl = `https://circleci.com/api/v2/workflow/${workflowId}/jobs`
+  const jobInfoUrl = `https://circleci.com/api/v2/workflow/${workflowId}/job`
   let jobNumber = 0
   while (jobNumber === 0) {
     const jobInfo = await circleCIRequest(jobInfoUrl, 'GET')


### PR DESCRIPTION
This is a breaking change in the CircleCI v2 preview API

Notes: no-notes