### PR TITLE
docs: remove string literal type from window events

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -517,7 +517,7 @@ Emitted when the window is restored from a minimized state.
 Returns:
 
 * `event` Event
-* `newBounds` [`Rectangle`](structures/rectangle.md) - Size the window is being resized to.
+* `newBounds` [Rectangle](structures/rectangle.md) - Size the window is being resized to.
 
 Emitted before the window is resized. Calling `event.preventDefault()` will prevent the window from being resized.
 
@@ -532,7 +532,7 @@ Emitted after the window has been resized.
 Returns:
 
 * `event` Event
-* `newBounds` [`Rectangle`](structures/rectangle.md) - Location the window is being moved to.
+* `newBounds` [Rectangle](structures/rectangle.md) - Location the window is being moved to.
 
 Emitted before the window is moved. On Windows, calling `event.preventDefault()` will prevent the window from being moved.
 


### PR DESCRIPTION
Fixes #21203

Notes: no-notes