### PR TITLE
fix: conversion of NativeImage from path

### DIFF
--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -2155,23 +2155,10 @@ void WebContents::StartDrag(const mate::Dictionary& item,
   }
 
   mate::Handle<NativeImage> icon;
-  if (!item.Get("icon", &icon) && !file.empty()) {
-    // TODO(zcbenz): Set default icon from file.
-  }
-
-  // Error checking.
-  if (icon.IsEmpty()) {
-    args->ThrowError("Must specify 'icon' option");
-    return;
-  }
-
-#if defined(OS_MACOSX)
-  // NSWindow.dragImage requires a non-empty NSImage
-  if (icon->image().IsEmpty()) {
+  if (!item.Get("icon", &icon)) {
     args->ThrowError("Must specify non-empty 'icon' option");
     return;
   }
-#endif
 
   // Start dragging.
   if (!files.empty()) {

--- a/shell/common/api/atom_api_native_image.cc
+++ b/shell/common/api/atom_api_native_image.cc
@@ -526,32 +526,32 @@ void NativeImage::BuildPrototype(v8::Isolate* isolate,
 
 namespace gin {
 
-v8::Local<v8::Value> Converter<mate::Handle<electron::api::NativeImage>>::ToV8(
+v8::Local<v8::Value> Converter<electron::api::NativeImage*>::ToV8(
     v8::Isolate* isolate,
-    const mate::Handle<electron::api::NativeImage>& val) {
-  return val.ToV8();
+    electron::api::NativeImage* val) {
+  if (val)
+    return val->GetWrapper();
+  else
+    return v8::Null(isolate);
 }
 
-bool Converter<mate::Handle<electron::api::NativeImage>>::FromV8(
+bool Converter<electron::api::NativeImage*>::FromV8(
     v8::Isolate* isolate,
     v8::Local<v8::Value> val,
-    mate::Handle<electron::api::NativeImage>* out) {
+    electron::api::NativeImage** out) {
   // Try converting from file path.
   base::FilePath path;
   if (ConvertFromV8(isolate, val, &path)) {
-    *out = electron::api::NativeImage::CreateFromPath(isolate, path);
+    *out = electron::api::NativeImage::CreateFromPath(isolate, path).get();
     // Should throw when failed to initialize from path.
     return !(*out)->image().IsEmpty();
   }
 
-  auto* wrapper = static_cast<mate::WrappableBase*>(
-      mate::internal::FromV8Impl(isolate, val));
-  if (!wrapper)
-    return false;
+  *out = static_cast<electron::api::NativeImage*>(
+      static_cast<mate::WrappableBase*>(
+          mate::internal::FromV8Impl(isolate, val)));
 
-  *out = mate::CreateHandle(isolate,
-                            static_cast<electron::api::NativeImage*>(wrapper));
-  return true;
+  return *out != nullptr;
 }
 
 }  // namespace gin

--- a/shell/common/api/atom_api_native_image.cc
+++ b/shell/common/api/atom_api_native_image.cc
@@ -259,7 +259,7 @@ float NativeImage::GetAspectRatio() {
     return static_cast<float>(size.width()) / static_cast<float>(size.height());
 }
 
-mate::Handle<NativeImage> NativeImage::Resize(
+gin::Handle<NativeImage> NativeImage::Resize(
     v8::Isolate* isolate,
     const base::DictionaryValue& options) {
   gfx::Size size = GetSize();
@@ -290,16 +290,16 @@ mate::Handle<NativeImage> NativeImage::Resize(
 
   gfx::ImageSkia resized = gfx::ImageSkiaOperations::CreateResizedImage(
       image_.AsImageSkia(), method, size);
-  return mate::CreateHandle(isolate,
-                            new NativeImage(isolate, gfx::Image(resized)));
+  return gin::CreateHandle(isolate,
+                           new NativeImage(isolate, gfx::Image(resized)));
 }
 
-mate::Handle<NativeImage> NativeImage::Crop(v8::Isolate* isolate,
-                                            const gfx::Rect& rect) {
+gin::Handle<NativeImage> NativeImage::Crop(v8::Isolate* isolate,
+                                           const gfx::Rect& rect) {
   gfx::ImageSkia cropped =
       gfx::ImageSkiaOperations::ExtractSubset(image_.AsImageSkia(), rect);
-  return mate::CreateHandle(isolate,
-                            new NativeImage(isolate, gfx::Image(cropped)));
+  return gin::CreateHandle(isolate,
+                           new NativeImage(isolate, gfx::Image(cropped)));
 }
 
 void NativeImage::AddRepresentation(const gin_helper::Dictionary& options) {
@@ -350,48 +350,48 @@ bool NativeImage::IsTemplateImage() {
 #endif
 
 // static
-mate::Handle<NativeImage> NativeImage::CreateEmpty(v8::Isolate* isolate) {
-  return mate::CreateHandle(isolate, new NativeImage(isolate, gfx::Image()));
+gin::Handle<NativeImage> NativeImage::CreateEmpty(v8::Isolate* isolate) {
+  return gin::CreateHandle(isolate, new NativeImage(isolate, gfx::Image()));
 }
 
 // static
-mate::Handle<NativeImage> NativeImage::Create(v8::Isolate* isolate,
-                                              const gfx::Image& image) {
-  return mate::CreateHandle(isolate, new NativeImage(isolate, image));
+gin::Handle<NativeImage> NativeImage::Create(v8::Isolate* isolate,
+                                             const gfx::Image& image) {
+  return gin::CreateHandle(isolate, new NativeImage(isolate, image));
 }
 
 // static
-mate::Handle<NativeImage> NativeImage::CreateFromPNG(v8::Isolate* isolate,
-                                                     const char* buffer,
-                                                     size_t length) {
+gin::Handle<NativeImage> NativeImage::CreateFromPNG(v8::Isolate* isolate,
+                                                    const char* buffer,
+                                                    size_t length) {
   gfx::Image image = gfx::Image::CreateFrom1xPNGBytes(
       reinterpret_cast<const unsigned char*>(buffer), length);
   return Create(isolate, image);
 }
 
 // static
-mate::Handle<NativeImage> NativeImage::CreateFromJPEG(v8::Isolate* isolate,
-                                                      const char* buffer,
-                                                      size_t length) {
+gin::Handle<NativeImage> NativeImage::CreateFromJPEG(v8::Isolate* isolate,
+                                                     const char* buffer,
+                                                     size_t length) {
   gfx::Image image = gfx::ImageFrom1xJPEGEncodedData(
       reinterpret_cast<const unsigned char*>(buffer), length);
   return Create(isolate, image);
 }
 
 // static
-mate::Handle<NativeImage> NativeImage::CreateFromPath(
+gin::Handle<NativeImage> NativeImage::CreateFromPath(
     v8::Isolate* isolate,
     const base::FilePath& path) {
   base::FilePath image_path = NormalizePath(path);
 #if defined(OS_WIN)
   if (image_path.MatchesExtension(FILE_PATH_LITERAL(".ico"))) {
-    return mate::CreateHandle(isolate, new NativeImage(isolate, image_path));
+    return gin::CreateHandle(isolate, new NativeImage(isolate, image_path));
   }
 #endif
   gfx::ImageSkia image_skia;
   electron::util::PopulateImageSkiaRepsFromPath(&image_skia, image_path);
   gfx::Image image(image_skia);
-  mate::Handle<NativeImage> handle = Create(isolate, image);
+  gin::Handle<NativeImage> handle = Create(isolate, image);
 #if defined(OS_MACOSX)
   if (IsTemplateFilename(image_path))
     handle->SetTemplateImage(true);
@@ -400,13 +400,13 @@ mate::Handle<NativeImage> NativeImage::CreateFromPath(
 }
 
 // static
-mate::Handle<NativeImage> NativeImage::CreateFromBitmap(
+gin::Handle<NativeImage> NativeImage::CreateFromBitmap(
     gin_helper::ErrorThrower thrower,
     v8::Local<v8::Value> buffer,
     const gin_helper::Dictionary& options) {
   if (!node::Buffer::HasInstance(buffer)) {
     thrower.ThrowError("buffer must be a node Buffer");
-    return mate::Handle<NativeImage>();
+    return gin::Handle<NativeImage>();
   }
 
   unsigned int width = 0;
@@ -415,12 +415,12 @@ mate::Handle<NativeImage> NativeImage::CreateFromBitmap(
 
   if (!options.Get("width", &width)) {
     thrower.ThrowError("width is required");
-    return mate::Handle<NativeImage>();
+    return gin::Handle<NativeImage>();
   }
 
   if (!options.Get("height", &height)) {
     thrower.ThrowError("height is required");
-    return mate::Handle<NativeImage>();
+    return gin::Handle<NativeImage>();
   }
 
   auto info = SkImageInfo::MakeN32(width, height, kPremul_SkAlphaType);
@@ -428,7 +428,7 @@ mate::Handle<NativeImage> NativeImage::CreateFromBitmap(
 
   if (size_bytes != node::Buffer::Length(buffer)) {
     thrower.ThrowError("invalid buffer size");
-    return mate::Handle<NativeImage>();
+    return gin::Handle<NativeImage>();
   }
 
   options.Get("scaleFactor", &scale_factor);
@@ -448,13 +448,13 @@ mate::Handle<NativeImage> NativeImage::CreateFromBitmap(
 }
 
 // static
-mate::Handle<NativeImage> NativeImage::CreateFromBuffer(
+gin::Handle<NativeImage> NativeImage::CreateFromBuffer(
     gin_helper::ErrorThrower thrower,
     v8::Local<v8::Value> buffer,
     gin::Arguments* args) {
   if (!node::Buffer::HasInstance(buffer)) {
     thrower.ThrowError("buffer must be a node Buffer");
-    return mate::Handle<NativeImage>();
+    return gin::Handle<NativeImage>();
   }
 
   int width = 0;
@@ -476,8 +476,8 @@ mate::Handle<NativeImage> NativeImage::CreateFromBuffer(
 }
 
 // static
-mate::Handle<NativeImage> NativeImage::CreateFromDataURL(v8::Isolate* isolate,
-                                                         const GURL& url) {
+gin::Handle<NativeImage> NativeImage::CreateFromDataURL(v8::Isolate* isolate,
+                                                        const GURL& url) {
   std::string mime_type, charset, data;
   if (net::DataURL::Parse(url, &mime_type, &charset, &data)) {
     if (mime_type == "image/png")
@@ -490,7 +490,7 @@ mate::Handle<NativeImage> NativeImage::CreateFromDataURL(v8::Isolate* isolate,
 }
 
 #if !defined(OS_MACOSX)
-mate::Handle<NativeImage> NativeImage::CreateFromNamedImage(
+gin::Handle<NativeImage> NativeImage::CreateFromNamedImage(
     gin::Arguments* args,
     const std::string& name) {
   return CreateEmpty(args->isolate());

--- a/shell/common/api/atom_api_native_image.h
+++ b/shell/common/api/atom_api_native_image.h
@@ -119,13 +119,12 @@ namespace gin {
 
 // A custom converter that allows converting path to NativeImage.
 template <>
-struct Converter<mate::Handle<electron::api::NativeImage>> {
-  static v8::Local<v8::Value> ToV8(
-      v8::Isolate* isolate,
-      const mate::Handle<electron::api::NativeImage>& val);
+struct Converter<electron::api::NativeImage*> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   electron::api::NativeImage* val);
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
-                     mate::Handle<electron::api::NativeImage>* out);
+                     electron::api::NativeImage** out);
 };
 
 }  // namespace gin

--- a/shell/common/api/atom_api_native_image.h
+++ b/shell/common/api/atom_api_native_image.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "base/values.h"
+#include "gin/handle.h"
 #include "native_mate/handle.h"
 #include "native_mate/wrappable.h"
 #include "shell/common/gin_helper/error_thrower.h"
@@ -40,30 +41,29 @@ namespace api {
 
 class NativeImage : public mate::Wrappable<NativeImage> {
  public:
-  static mate::Handle<NativeImage> CreateEmpty(v8::Isolate* isolate);
-  static mate::Handle<NativeImage> Create(v8::Isolate* isolate,
-                                          const gfx::Image& image);
-  static mate::Handle<NativeImage> CreateFromPNG(v8::Isolate* isolate,
+  static gin::Handle<NativeImage> CreateEmpty(v8::Isolate* isolate);
+  static gin::Handle<NativeImage> Create(v8::Isolate* isolate,
+                                         const gfx::Image& image);
+  static gin::Handle<NativeImage> CreateFromPNG(v8::Isolate* isolate,
+                                                const char* buffer,
+                                                size_t length);
+  static gin::Handle<NativeImage> CreateFromJPEG(v8::Isolate* isolate,
                                                  const char* buffer,
                                                  size_t length);
-  static mate::Handle<NativeImage> CreateFromJPEG(v8::Isolate* isolate,
-                                                  const char* buffer,
-                                                  size_t length);
-  static mate::Handle<NativeImage> CreateFromPath(v8::Isolate* isolate,
-                                                  const base::FilePath& path);
-  static mate::Handle<NativeImage> CreateFromBitmap(
+  static gin::Handle<NativeImage> CreateFromPath(v8::Isolate* isolate,
+                                                 const base::FilePath& path);
+  static gin::Handle<NativeImage> CreateFromBitmap(
       gin_helper::ErrorThrower thrower,
       v8::Local<v8::Value> buffer,
       const gin_helper::Dictionary& options);
-  static mate::Handle<NativeImage> CreateFromBuffer(
+  static gin::Handle<NativeImage> CreateFromBuffer(
       gin_helper::ErrorThrower thrower,
       v8::Local<v8::Value> buffer,
       gin::Arguments* args);
-  static mate::Handle<NativeImage> CreateFromDataURL(v8::Isolate* isolate,
-                                                     const GURL& url);
-  static mate::Handle<NativeImage> CreateFromNamedImage(
-      gin::Arguments* args,
-      const std::string& name);
+  static gin::Handle<NativeImage> CreateFromDataURL(v8::Isolate* isolate,
+                                                    const GURL& url);
+  static gin::Handle<NativeImage> CreateFromNamedImage(gin::Arguments* args,
+                                                       const std::string& name);
 
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype);
@@ -87,9 +87,9 @@ class NativeImage : public mate::Wrappable<NativeImage> {
   v8::Local<v8::Value> ToBitmap(gin::Arguments* args);
   v8::Local<v8::Value> GetBitmap(gin::Arguments* args);
   v8::Local<v8::Value> GetNativeHandle(gin_helper::ErrorThrower thrower);
-  mate::Handle<NativeImage> Resize(v8::Isolate* isolate,
-                                   const base::DictionaryValue& options);
-  mate::Handle<NativeImage> Crop(v8::Isolate* isolate, const gfx::Rect& rect);
+  gin::Handle<NativeImage> Resize(v8::Isolate* isolate,
+                                  const base::DictionaryValue& options);
+  gin::Handle<NativeImage> Crop(v8::Isolate* isolate, const gfx::Rect& rect);
   std::string ToDataURL(gin::Arguments* args);
   bool IsEmpty();
   gfx::Size GetSize();
@@ -135,15 +135,14 @@ namespace mate {
 //
 // TODO(zcbenz): Remove this after removing native_mate.
 template <>
-struct Converter<mate::Handle<electron::api::NativeImage>> {
-  static v8::Local<v8::Value> ToV8(
-      v8::Isolate* isolate,
-      const mate::Handle<electron::api::NativeImage>& val) {
+struct Converter<electron::api::NativeImage*> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   electron::api::NativeImage* val) {
     return gin::ConvertToV8(isolate, val);
   }
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
-                     mate::Handle<electron::api::NativeImage>* out) {
+                     electron::api::NativeImage** out) {
     return gin::ConvertFromV8(isolate, val, out);
   }
 };

--- a/shell/common/api/atom_api_native_image_mac.mm
+++ b/shell/common/api/atom_api_native_image_mac.mm
@@ -33,7 +33,7 @@ double safeShift(double in, double def) {
   return def;
 }
 
-mate::Handle<NativeImage> NativeImage::CreateFromNamedImage(
+gin::Handle<NativeImage> NativeImage::CreateFromNamedImage(
     gin::Arguments* args,
     const std::string& name) {
   @autoreleasepool {

--- a/shell/common/gin_converters/image_converter.cc
+++ b/shell/common/gin_converters/image_converter.cc
@@ -27,9 +27,8 @@ bool Converter<gfx::Image>::FromV8(v8::Isolate* isolate,
   if (val->IsNull())
     return true;
 
-  // TODO(deermichel): remove mate:: after dropping mate
-  mate::Handle<electron::api::NativeImage> native_image;
-  if (!mate::ConvertFromV8(isolate, val, &native_image))
+  gin::Handle<electron::api::NativeImage> native_image;
+  if (!gin::ConvertFromV8(isolate, val, &native_image))
     return false;
 
   *out = native_image->image();
@@ -38,7 +37,8 @@ bool Converter<gfx::Image>::FromV8(v8::Isolate* isolate,
 
 v8::Local<v8::Value> Converter<gfx::Image>::ToV8(v8::Isolate* isolate,
                                                  const gfx::Image& val) {
-  return ConvertToV8(isolate, electron::api::NativeImage::Create(isolate, val));
+  return gin::ConvertToV8(isolate,
+                          electron::api::NativeImage::Create(isolate, val));
 }
 
 }  // namespace gin

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -689,13 +689,11 @@ describe('webContents module', () => {
 
       expect(() => {
         w.webContents.startDrag({ file: __filename } as any)
-      }).to.throw(`Must specify 'icon' option`)
+      }).to.throw(`Must specify non-empty 'icon' option`)
 
-      if (process.platform === 'darwin') {
-        expect(() => {
-          w.webContents.startDrag({ file: __filename, icon: __filename })
-        }).to.throw(`Must specify non-empty 'icon' option`)
-      }
+      expect(() => {
+        w.webContents.startDrag({ file: __filename, icon: __filename })
+      }).to.throw(`Must specify non-empty 'icon' option`)
     })
   })
 


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/21154.
Refs https://github.com/electron/electron/pull/20719.

In the gin migration process, the `NativeImage` converter from path got mangled slightly and caused conversion errors. This pulls back [the commit](https://github.com/electron/electron/pull/20719/commits/d35b5c5cedac84b736d4327a5ceb19bb2d90f8a8) which fixes that.

Tested to work locally with the repro provided in the original above linked issue; and since the commit which i pulled this from is already on master there is only a need for this PR directly to the `8-x-y` branch.

cc @zcbenz @deepak1556 @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where Tray icons couldn't be created from paths.
