### PR TITLE
chore: improve nativeImage path converter error

### DIFF
--- a/spec-main/api-tray-spec.ts
+++ b/spec-main/api-tray-spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
 import { Menu, Tray, nativeImage } from 'electron'
 import { ifdescribe, ifit } from './spec-helpers'
+import * as path from 'path'
 
 describe('tray module', () => {
   let tray: Tray
@@ -10,6 +11,15 @@ describe('tray module', () => {
   afterEach(() => {
     tray.destroy()
     tray = null as any
+  })
+
+  describe('new Tray', () => {
+    it('throws a descriptive error for a missing file', () => {
+      const badPath = path.resolve('I', 'Do', 'Not', 'Exist')
+      expect(() => {
+        tray = new Tray(badPath)
+      }).to.throw(/Image could not be created from .*/)
+    })
   })
 
   ifdescribe(process.platform === 'darwin')('tray get/set ignoreDoubleClickEvents', () => {


### PR DESCRIPTION
#### Description of Change

In fixing the Tray-from-path issue earlier, I realized that we don't throw a very intuitive error if there are conversion failures originating from files actually not existing on disk. This PR thus adds a check for the `base::FilePath` not actually being a valid path and throws a more user-friendly error should that be the case.

Before:
<img width="532" alt="Screen Shot 2019-11-21 at 9 43 39 AM" src="https://user-images.githubusercontent.com/2036040/69362839-2538a480-0c44-11ea-86f5-3ba1b4a79661.png">

After:
<img width="532" alt="Screen Shot 2019-11-22 at 8 37 02 AM" src="https://user-images.githubusercontent.com/2036040/69443533-6e9bf900-0d03-11ea-8fc4-3e7241f00a3a.png">

cc @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
