### PR TITLE
ci: handle network drive not being available

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -96,7 +96,9 @@ build_script:
           if ($env:TARGET_ARCH -ne 'ia32') {
             # archive current source for future use 
             # only run on x64/woa to avoid contention saving
-            7z a $zipfile src -xr!android_webview -xr!electron -xr'!*\.git' -xr!third_party\WebKit\LayoutTests! -xr!third_party\blink\web_tests -xr!third_party\blink\perf_tests -slp -t7z -mmt=30
+            if ($(7z a $zipfile src -xr!android_webview -xr!electron -xr'!*\.git' -xr!third_party\WebKit\LayoutTests! -xr!third_party\blink\web_tests -xr!third_party\blink\perf_tests -slp -t7z -mmt=30;$LASTEXITCODE -ne 0)) {
+              Write-warning "Could not save source to shared drive; continuing anyway"
+            }
           }
         }
       }


### PR DESCRIPTION
#### Description of Change

Cherry-picks https://github.com/electron/electron/pull/21000/commits/16564518e5899021b1df9894adf522446de70796 to `master`.

Fixes `The system cannot find the path specified` error when trying to save source to shared network drive.

cc @jkleinsc 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
