### PR TITLE
fix: reloadIgnoringCache() should ignore the cache

### DIFF
--- a/lib/browser/navigation-controller.js
+++ b/lib/browser/navigation-controller.js
@@ -152,7 +152,8 @@ const NavigationController = (function () {
   NavigationController.prototype.reloadIgnoringCache = function () {
     this.pendingIndex = this.currentIndex
     return this.webContents._loadURL(this.getURL(), {
-      extraHeaders: 'pragma: no-cache\n'
+      extraHeaders: 'pragma: no-cache\n',
+      reloadIgnoringCache: true
     })
   }
 

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -1383,6 +1383,12 @@ void WebContents::LoadURL(const GURL& url,
     params.load_type = content::NavigationController::LOAD_TYPE_DATA;
   }
 
+  bool reload_ignoring_cache = false;
+  if (options.Get("reloadIgnoringCache", &reload_ignoring_cache) &&
+      reload_ignoring_cache) {
+    params.reload_type = content::ReloadType::BYPASSING_CACHE;
+  }
+
   // Calling LoadURLWithParams() can trigger JS which destroys |this|.
   auto weak_this = GetWeakPtr();
 


### PR DESCRIPTION
So as in the title, it would be good if this API actually ignored the cache 😄 

Notes: `webContents.reloadIgnoringCache()` will now forcefully ignore all caches, including service workers