### PR TITLE
fix: avert use-after-free crash in contextBridge

### DIFF
--- a/shell/renderer/api/context_bridge/render_frame_context_bridge_store.cc
+++ b/shell/renderer/api/context_bridge/render_frame_context_bridge_store.cc
@@ -40,6 +40,7 @@ class CachedProxyLifeMonitor final : public ObjectLifeMonitor {
   void RunDestructor() override {
     if (node_->detached) {
       delete node_;
+      return;
     }
     if (node_->prev) {
       node_->prev->next = node_->next;


### PR DESCRIPTION
#### Description of Change
Fix a use-after-free memory bug in `contextBridge`.

Without the early return, the destructor continues, in the case of `node_->detached == true` and crashes on the first access at L44.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed contextBridge crash.
<!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
