### PR TITLE
test: refactor net tests

### DIFF
--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -1109,8 +1109,7 @@ describe('net module', () => {
       const urlRequest = net.request(serverUrl)
       urlRequest.end(randomBuffer(kOneMegaByte))
       const [error] = await emittedOnce(urlRequest, 'error')
-      const expectedErrorMessage = process.platform === 'win32' ? 'net::ERR_CONNECTION_ABORTED' : 'net::ERR_CONNECTION_RESET'
-      expect(error.message).to.equal(expectedErrorMessage)
+      expect(error.message).to.be.oneOf(['net::ERR_CONNECTION_RESET', 'net::ERR_CONNECTION_ABORTED'])
     })
 
     it('should not emit any event after close', async () => {

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -1109,7 +1109,8 @@ describe('net module', () => {
       const urlRequest = net.request(serverUrl)
       urlRequest.end(randomBuffer(kOneMegaByte))
       const [error] = await emittedOnce(urlRequest, 'error')
-      expect(error.message).to.equal('net::ERR_CONNECTION_RESET')
+      const expectedErrorMessage = process.platform === 'win32' ? 'net::ERR_CONNECTION_ABORTED' : 'net::ERR_CONNECTION_RESET'
+      expect(error.message).to.equal(expectedErrorMessage)
     })
 
     it('should not emit any event after close', async () => {


### PR DESCRIPTION
#### Description of Change
This pulls out the test-refactoring part of #21244.

This relaxes a few things that the old tests were checking for, particularly around event ordering. I'm inclined to think that's _probably_ okay, since I don't think the existing ordering was particularly well-considered? Open to other arguments though!

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none
