### PR TITLE
fix: reloadIgnoringCache() should ignore the cache

### DIFF
--- a/lib/browser/navigation-controller.js
+++ b/lib/browser/navigation-controller.js
@@ -152,7 +152,8 @@ const NavigationController = (function () {
   NavigationController.prototype.reloadIgnoringCache = function () {
     this.pendingIndex = this.currentIndex
     return this.webContents._loadURL(this.getURL(), {
-      extraHeaders: 'pragma: no-cache\n'
+      extraHeaders: 'pragma: no-cache\n',
+      reloadIgnoringCache: true
     })
   }
 

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -1355,6 +1355,12 @@ void WebContents::LoadURL(const GURL& url, const mate::Dictionary& options) {
     params.load_type = content::NavigationController::LOAD_TYPE_DATA;
   }
 
+  bool reload_ignoring_cache = false;
+  if (options.Get("reloadIgnoringCache", &reload_ignoring_cache) &&
+      reload_ignoring_cache) {
+    params.reload_type = content::ReloadType::BYPASSING_CACHE;
+  }
+
   params.transition_type = ui::PAGE_TRANSITION_TYPED;
   params.should_clear_history_list = true;
   params.override_user_agent = content::NavigationController::UA_OVERRIDE_TRUE;


### PR DESCRIPTION
Backport of #21263

See that PR for details.

Notes: `webContents.reloadIgnoringCache()` will now forcefully ignore all caches, including service workers