### PR TITLE
fix: allow reading body from non-2xx responses in net.request (#21055)

### DIFF
--- a/shell/browser/api/atom_api_url_request_ns.cc
+++ b/shell/browser/api/atom_api_url_request_ns.cc
@@ -243,6 +243,7 @@ bool URLRequestNS::Write(v8::Local<v8::Value> data, bool is_last) {
     network::ResourceRequest* request_ref = request_.get();
     loader_ = network::SimpleURLLoader::Create(std::move(request_),
                                                kTrafficAnnotation);
+    loader_->SetAllowHttpErrorResults(true);
     loader_->SetOnResponseStartedCallback(base::Bind(
         &URLRequestNS::OnResponseStarted, weak_factory_.GetWeakPtr()));
     loader_->SetOnRedirectCallback(

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -3,6 +3,7 @@ import { net as originalNet, session, ClientRequest } from 'electron'
 import * as http from 'http'
 import * as url from 'url'
 import { AddressInfo } from 'net'
+import { emittedOnce } from './events-helpers'
 
 const outstandingRequests: ClientRequest[] = []
 const net: {request: (typeof originalNet)['request']} = {
@@ -640,6 +641,53 @@ describe('net module', () => {
 
         urlRequest.end(randomString(kOneKiloByte))
       })
+    })
+
+    it('should allow to read response body from non-2xx response', async () => {
+      const bodyData = randomString(kOneKiloByte)
+      const serverUrl = await respondOnce.toSingleURL((request, response) => {
+        response.statusCode = 404
+        response.end(bodyData)
+      })
+
+      let requestResponseEventEmitted = false
+      let responseDataEventEmitted = false
+
+      const urlRequest = net.request(serverUrl)
+      const eventHandlers = Promise.all([
+        emittedOnce(urlRequest, 'response')
+          .then(async (params: any[]) => {
+            const response: Electron.IncomingMessage = params[0]
+            requestResponseEventEmitted = true
+            const statusCode = response.statusCode
+            expect(statusCode).to.equal(404)
+            const buffers: Buffer[] = []
+            response.on('data', (chunk) => {
+              buffers.push(chunk)
+              responseDataEventEmitted = true
+            })
+            await new Promise((resolve, reject) => {
+              response.on('error', () => {
+                reject(new Error('error emitted'))
+              })
+              emittedOnce(response, 'end')
+                .then(() => {
+                  const receivedBodyData = Buffer.concat(buffers)
+                  expect(receivedBodyData.toString()).to.equal(bodyData)
+                })
+                .then(resolve)
+                .catch(reject)
+            })
+          }),
+        emittedOnce(urlRequest, 'close')
+      ])
+
+      urlRequest.end()
+
+      await eventHandlers
+
+      expect(requestResponseEventEmitted).to.equal(true)
+      expect(responseDataEventEmitted).to.equal(true)
     })
 
     describe('webRequest', () => {

--- a/spec-main/api-session-spec.ts
+++ b/spec-main/api-session-spec.ts
@@ -511,12 +511,19 @@ describe('session module', () => {
       const fetch = (url: string) => new Promise((resolve, reject) => {
         const request = net.request({ url, session: ses })
         request.on('response', (response) => {
-          let data = ''
+          let data: string | null = null
           response.on('data', (chunk) => {
+            if (!data) {
+              data = ''
+            }
             data += chunk
           })
           response.on('end', () => {
-            resolve(data)
+            if (!data) {
+              reject(new Error('Empty response'))
+            } else {
+              resolve(data)
+            }
           })
           response.on('error', (error: any) => { reject(new Error(error)) })
         });


### PR DESCRIPTION
Backport of #21055

See that PR for details.

Notes: Net module requests no longer raise errors when non-2xx responses are received.