### PR TITLE
fix: restore --ignore-connections-limit functionality

### DIFF
--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -250,6 +250,8 @@ class ProxyingURLLoaderFactory
   void RemoveRequest(int32_t network_service_request_id, uint64_t request_id);
   void MaybeDeleteThis();
 
+  bool ShouldIgnoreConnectionsLimit(const network::ResourceRequest& request);
+
   // Passed from api::WebRequest.
   WebRequestAPI* web_request_api_;
 
@@ -278,6 +280,8 @@ class ProxyingURLLoaderFactory
   // A mapping from the network stack's notion of request ID to our own
   // internally generated request ID for the same request.
   std::map<int32_t, uint64_t> network_request_id_to_web_request_id_;
+
+  std::vector<std::string> ignore_connections_limit_domains_;
 
   DISALLOW_COPY_AND_ASSIGN(ProxyingURLLoaderFactory);
 };


### PR DESCRIPTION
#### Description of Change
This restores the [inadvertently removed](https://github.com/electron/electron/pull/19644/files#diff-8c1eed0d78f8872226e8dd910fccb551L245) `--ignore-connections-limit` functionality.

Fixes #21255.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed `--ignore-connections-limit`, ironically, being ignored.