### PR TITLE
chore: add deprecation warning for the default of allowRendererProcessReuse

### DIFF
--- a/default_app/default_app.ts
+++ b/default_app/default_app.ts
@@ -3,6 +3,8 @@ import * as path from 'path'
 
 let mainWindow: BrowserWindow | null = null
 
+app.allowRendererProcessReuse = true
+
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {
   app.quit()

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -322,7 +322,7 @@ let warnedAboutRendererProcessReuse = false
 
 // Add JavaScript wrappers for WebContents class.
 WebContents.prototype._init = function () {
-  if (!warnedAboutRendererProcessReuse && app._allowRendererProcessReuseIsDefaultValue) {
+  if (!process.noDeprecation && !warnedAboutRendererProcessReuse && app._allowRendererProcessReuseIsDefaultValue) {
     deprecate.log('The default value of app.allowRendererProcessReuse is deprecated, it is currently "false".  It will change to be "true" in Electron 9.  For more information please check https://github.com/electron/electron/issues/18397')
     warnedAboutRendererProcessReuse = true
   }

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -318,8 +318,14 @@ const addReturnValueToEvent = (event) => {
   })
 }
 
+let warnedAboutRendererProcessReuse = false
+
 // Add JavaScript wrappers for WebContents class.
 WebContents.prototype._init = function () {
+  if (!warnedAboutRendererProcessReuse && app._allowRendererProcessReuseIsDefaultValue) {
+    deprecate.log('The default value of app.allowRendererProcessReuse is deprecated, it is currently "false".  It will change to be "true" in Electron 9.  For more information please check https://github.com/electron/electron/issues/18397')
+    warnedAboutRendererProcessReuse = true
+  }
   // The navigation controller.
   NavigationController.call(this, this)
 

--- a/shell/browser/api/atom_api_app.cc
+++ b/shell/browser/api/atom_api_app.cc
@@ -1326,6 +1326,9 @@ void App::SetBrowserClientCanUseCustomSiteInstance(bool should_disable) {
 bool App::CanBrowserClientUseCustomSiteInstance() {
   return AtomBrowserClient::Get()->CanUseCustomSiteInstance();
 }
+bool App::CanBrowserClientUseCustomSiteInstanceIsDefaultValue() {
+  return AtomBrowserClient::Get()->CanUseCustomSiteInstanceIsDefaultValue();
+}
 
 #if defined(OS_MACOSX)
 bool App::MoveToApplicationsFolder(gin_helper::ErrorThrower thrower,
@@ -1518,7 +1521,9 @@ void App::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("enableSandbox", &App::EnableSandbox)
       .SetProperty("allowRendererProcessReuse",
                    &App::CanBrowserClientUseCustomSiteInstance,
-                   &App::SetBrowserClientCanUseCustomSiteInstance);
+                   &App::SetBrowserClientCanUseCustomSiteInstance)
+      .SetProperty("_allowRendererProcessReuseIsDefaultValue",
+                   &App::CanBrowserClientUseCustomSiteInstanceIsDefaultValue);
 }
 
 }  // namespace api

--- a/shell/browser/api/atom_api_app.h
+++ b/shell/browser/api/atom_api_app.h
@@ -203,6 +203,7 @@ class App : public AtomBrowserClient::Delegate,
   std::string GetUserAgentFallback();
   void SetBrowserClientCanUseCustomSiteInstance(bool should_disable);
   bool CanBrowserClientUseCustomSiteInstance();
+  bool CanBrowserClientUseCustomSiteInstanceIsDefaultValue();
 
 #if defined(OS_MACOSX)
   bool MoveToApplicationsFolder(gin_helper::ErrorThrower,

--- a/shell/browser/atom_browser_client.cc
+++ b/shell/browser/atom_browser_client.cc
@@ -422,10 +422,15 @@ void AtomBrowserClient::OverrideWebkitPrefs(content::RenderViewHost* host,
 
 void AtomBrowserClient::SetCanUseCustomSiteInstance(bool should_disable) {
   disable_process_restart_tricks_ = should_disable;
+  disable_process_restart_tricks_is_default_value_ = false;
 }
 
 bool AtomBrowserClient::CanUseCustomSiteInstance() {
   return disable_process_restart_tricks_;
+}
+
+bool AtomBrowserClient::CanUseCustomSiteInstanceIsDefaultValue() {
+  return disable_process_restart_tricks_is_default_value_;
 }
 
 content::ContentBrowserClient::SiteInstanceForNavigationType

--- a/shell/browser/atom_browser_client.h
+++ b/shell/browser/atom_browser_client.h
@@ -73,6 +73,7 @@ class AtomBrowserClient : public content::ContentBrowserClient,
 
   void SetCanUseCustomSiteInstance(bool should_disable);
   bool CanUseCustomSiteInstance() override;
+  bool CanUseCustomSiteInstanceIsDefaultValue();
 
  protected:
   void RenderProcessWillLaunch(content::RenderProcessHost* host) override;
@@ -283,6 +284,7 @@ class AtomBrowserClient : public content::ContentBrowserClient,
   std::string user_agent_override_ = "";
 
   bool disable_process_restart_tricks_ = false;
+  bool disable_process_restart_tricks_is_default_value_ = true;
 
   DISALLOW_COPY_AND_ASSIGN(AtomBrowserClient);
 };

--- a/spec/fixtures/api/window-all-closed/main.js
+++ b/spec/fixtures/api/window-all-closed/main.js
@@ -1,4 +1,6 @@
 const { app, BrowserWindow } = require('electron')
+// Suppress deprecation logs
+app.allowRendererProcessReuse = true
 
 let handled = false
 


### PR DESCRIPTION
Refs: https://github.com/electron/electron/issues/18397

This is the `8-x-y` step that is required in that issue's timeline.

Notes: Deprecated the default value of `app.allowRendererProcessReuse` (See #18397)