### PR TITLE
docs: update link in screen doc to match fiddle file

### DIFF
--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -21,7 +21,7 @@ let win
 app.on('ready', () => {
   const { width, height } = screen.getPrimaryDisplay().workAreaSize
   win = new BrowserWindow({ width, height })
-  win.loadURL('https://github.com')
+  win.loadURL('https://electronjs.org')
 })
 ```
 
@@ -43,7 +43,7 @@ app.on('ready', () => {
       x: externalDisplay.bounds.x + 50,
       y: externalDisplay.bounds.y + 50
     })
-    win.loadURL('https://github.com')
+    win.loadURL('https://electronjs.org')
   }
 })
 ```


### PR DESCRIPTION
#### Description of Change

This change needed to update the source file in the Crowdin for verifying fixing of this issue: https://github.com/electron/i18n/issues/836. This file doesn't change after adding a fiddle link.

As one more context, these PR updates link to match the fiddle file where used Electron website instead of GitHub.

/cc @electron/wg-ecosystem 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
