### PR TITLE
docs: rename ELECTRON_CACHE env variable to electron_config_cache

### DIFF
--- a/docs/tutorial/installation.md
+++ b/docs/tutorial/installation.md
@@ -82,7 +82,7 @@ with the network at all.
 On environments that have been using older versions of Electron, you might find the
 cache also in `~/.electron`.
 
-You can also override the local cache location by providing a `ELECTRON_CACHE`
+You can also override the local cache location by providing a `electron_config_cache`
 environment variable.
 
 The cache contains the version's official zip file as well as a checksum, stored as


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Setting `ELECTRON_CACHE` environment variable no longer works. I believe it was broken during migration from `electron-download` to `@electron/get`. Setting `electron_config_cache` works as expected.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: renamed ELECTRON_CACHE environment variable to electron_config_cache in docs