### PR TITLE
feat: expose sync js exec methods on WebFrame

### DIFF
--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -154,6 +154,23 @@ or is rejected if the result of the code is a rejected promise.
 
 Works like `executeJavaScript` but evaluates `scripts` in an isolated context.
 
+### `webFrame.executeJavaScriptSync(code)`
+
+* `code` String
+
+Returns `any` - The result of the executed code.
+
+Evaluates `code` in page.
+
+### `webFrame.executeJavaScriptInIsolatedWorldSync(worldId, code)`
+
+* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature.  You can provide any integer here.
+* `code` String
+
+Returns `any` - The result of the executed code.
+
+Works like `executeJavaScriptSync` but evaluates `scripts` in an isolated context.
+
 ### `webFrame.setIsolatedWorldInfo(worldId, info)`
 * `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature. Chrome extensions reserve the range of IDs in `[1 << 20, 1 << 29)`. You can provide any integer here.
 * `info` Object

--- a/shell/renderer/api/atom_api_web_frame.cc
+++ b/shell/renderer/api/atom_api_web_frame.cc
@@ -436,6 +436,24 @@ v8::Local<v8::Promise> ExecuteJavaScriptInIsolatedWorld(
   return handle;
 }
 
+v8::Local<v8::Value> ExecuteJavaScriptSync(gin_helper::Arguments* args,
+                                           v8::Local<v8::Value> window,
+                                           const base::string16& code) {
+  return GetRenderFrame(window)->GetWebFrame()->ExecuteScriptAndReturnValue(
+      blink::WebScriptSource(blink::WebString::FromUTF16(code)));
+}
+
+v8::Local<v8::Value> ExecuteJavaScriptInIsolatedWorldSync(
+    gin_helper::Arguments* args,
+    v8::Local<v8::Value> window,
+    const int world_id,
+    const base::string16& code) {
+  return GetRenderFrame(window)
+      ->GetWebFrame()
+      ->ExecuteScriptInIsolatedWorldAndReturnValue(
+          world_id, blink::WebScriptSource(blink::WebString::FromUTF16(code)));
+}
+
 void SetIsolatedWorldInfo(v8::Local<v8::Value> window,
                           int world_id,
                           const gin_helper::Dictionary& options,
@@ -591,6 +609,9 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("executeJavaScript", &ExecuteJavaScript);
   dict.SetMethod("executeJavaScriptInIsolatedWorld",
                  &ExecuteJavaScriptInIsolatedWorld);
+  dict.SetMethod("executeJavaScriptSync", &ExecuteJavaScriptSync);
+  dict.SetMethod("executeJavaScriptInIsolatedWorldSync",
+                 &ExecuteJavaScriptInIsolatedWorldSync);
   dict.SetMethod("setIsolatedWorldInfo", &SetIsolatedWorldInfo);
   dict.SetMethod("getResourceUsage", &GetResourceUsage);
   dict.SetMethod("clearCache", &ClearCache);


### PR DESCRIPTION
#### Description of Change

Before the promisification (#17312) of `WebFrame#executeJavaScript*` their interface was async (callback) but behavior was sync (callback called before the methods returned). So they could be used in sync code (or async, you could wrap them in a promise yourself). The switch from a callback to a promise interface made it impossible to use them in sync mode (#19161), which was a breaking change without a workaround.

This PR exposes the sync js exec methods on WebFrame, providing a workaround for code that used the original methods synchronously. In general, a sync in-process js eval makes perfect sense, because it's sync under the hood. 

Fixes #19161

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: add sync javascript execution methods to WebFrame

<!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
