### PR TITLE
build: upload windows toolchain profile

### DIFF
--- a/script/release/release.js
+++ b/script/release/release.js
@@ -149,7 +149,10 @@ function assetsForVersion (version, validatingRelease) {
     `mksnapshot-${version}-mas-x64.zip`,
     `mksnapshot-${version}-win32-ia32.zip`,
     `mksnapshot-${version}-win32-x64.zip`,
-    `mksnapshot-${version}-win32-arm64-x64.zip`
+    `mksnapshot-${version}-win32-arm64-x64.zip`,
+    `toolchain-profile-${version}-win32-ia32.zip`,
+    `toolchain-profile-${version}-win32-x64.zip`,
+    `toolchain-profile-${version}-win32-arm64.zip`
   ]
   if (!validatingRelease) {
     patterns.push('SHASUMS256.txt')

--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -16,6 +16,7 @@ sys.path.append(
   os.path.abspath(os.path.dirname(os.path.abspath(__file__)) + "/../.."))
 
 from io import StringIO
+from zipfile import ZipFile
 from lib.config import PLATFORM, get_target_arch,  get_env_var, s3_config, \
                        get_zip_name
 from lib.util import get_electron_branding, execute, get_electron_version, \
@@ -36,6 +37,7 @@ SYMBOLS_NAME = get_zip_name(PROJECT_NAME, ELECTRON_VERSION, 'symbols')
 DSYM_NAME = get_zip_name(PROJECT_NAME, ELECTRON_VERSION, 'dsym')
 PDB_NAME = get_zip_name(PROJECT_NAME, ELECTRON_VERSION, 'pdb')
 DEBUG_NAME = get_zip_name(PROJECT_NAME, ELECTRON_VERSION, 'debug')
+TOOLCHAIN_PROFILE_NAME = get_zip_name(PROJECT_NAME, ELECTRON_VERSION, 'toolchain-profile')
 
 
 def main():
@@ -121,6 +123,12 @@ def main():
     run_python_upload_script('upload-symbols.py')
     if PLATFORM == 'win32':
       run_python_upload_script('upload-node-headers.py', '-v', args.version)
+
+  if PLATFORM == 'win32':
+    toolchain_profile_zip = os.path.join(OUT_DIR, TOOLCHAIN_PROFILE_NAME)
+    with ZipFile(toolchain_profile_zip, 'w') as myzip:
+      myzip.write(os.path.join(OUT_DIR, 'windows_toolchain_profile.json'), 'toolchain_profile.json')
+    upload_electron(release, toolchain_profile_zip, args)
 
 
 def parse_args():


### PR DESCRIPTION
#### Description of Change

This commit uploads the output of the windows toolchain profiler.
The windows toolchain profiler is aimed at allowing the compilation
of electron release artifacts using the same windows toolchain on user
builder. This combined with the ability of electron of outputting
deterministic build should allow in future to check electron build
artifacts against CI artifacts.

See: 97959b5e5c38e4353bf91f68a958784945937ec9 include windows toolchain profiler (contd #20949)

Cc: @nornagon @felixrieseberg @ikkisoft 

#### Checklist

- [X] PR description included and stakeholders cc'd
- [X] relevant documentation is changed or added
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes