### PR TITLE
build: fix building with enable_builtin_spellchecker = false

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -354,6 +354,7 @@ source_set("electron_lib") {
     ":resources",
     "buildflags",
     "chromium_src:chrome",
+    "chromium_src:chrome_spellchecker",
     "native_mate",
     "shell/common/api:mojo",
     "//base:base_static",
@@ -480,10 +481,6 @@ source_set("electron_lib") {
       "shell/browser/fake_location_provider.cc",
       "shell/browser/fake_location_provider.h",
     ]
-  }
-
-  if (enable_builtin_spellchecker) {
-    deps += [ "chromium_src:chrome_spellchecker" ]
   }
 
   if (is_mac) {

--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -308,44 +308,50 @@ source_set("plugins") {
 # You may have to add new files here during the upgrade if //chrome/browser/spellchecker
 # gets more files
 source_set("chrome_spellchecker") {
-  sources = [
-    "//chrome/browser/spellchecker/spell_check_host_chrome_impl.cc",
-    "//chrome/browser/spellchecker/spell_check_host_chrome_impl.h",
-    "//chrome/browser/spellchecker/spellcheck_custom_dictionary.cc",
-    "//chrome/browser/spellchecker/spellcheck_custom_dictionary.h",
-    "//chrome/browser/spellchecker/spellcheck_factory.cc",
-    "//chrome/browser/spellchecker/spellcheck_factory.h",
-    "//chrome/browser/spellchecker/spellcheck_hunspell_dictionary.cc",
-    "//chrome/browser/spellchecker/spellcheck_hunspell_dictionary.h",
-    "//chrome/browser/spellchecker/spellcheck_language_blacklist_policy_handler.cc",
-    "//chrome/browser/spellchecker/spellcheck_language_blacklist_policy_handler.h",
-    "//chrome/browser/spellchecker/spellcheck_language_policy_handler.cc",
-    "//chrome/browser/spellchecker/spellcheck_language_policy_handler.h",
-    "//chrome/browser/spellchecker/spellcheck_service.cc",
-    "//chrome/browser/spellchecker/spellcheck_service.h",
-    "//chrome/common/pref_names.h",
-  ]
+  sources = []
+  deps = []
+  libs = []
 
-  if (has_spellcheck_panel) {
+  if (enable_builtin_spellchecker) {
     sources += [
-      "//chrome/browser/spellchecker/spell_check_panel_host_impl.cc",
-      "//chrome/browser/spellchecker/spell_check_panel_host_impl.h",
+      "//chrome/browser/spellchecker/spell_check_host_chrome_impl.cc",
+      "//chrome/browser/spellchecker/spell_check_host_chrome_impl.h",
+      "//chrome/browser/spellchecker/spellcheck_custom_dictionary.cc",
+      "//chrome/browser/spellchecker/spellcheck_custom_dictionary.h",
+      "//chrome/browser/spellchecker/spellcheck_factory.cc",
+      "//chrome/browser/spellchecker/spellcheck_factory.h",
+      "//chrome/browser/spellchecker/spellcheck_hunspell_dictionary.cc",
+      "//chrome/browser/spellchecker/spellcheck_hunspell_dictionary.h",
+      "//chrome/browser/spellchecker/spellcheck_language_blacklist_policy_handler.cc",
+      "//chrome/browser/spellchecker/spellcheck_language_blacklist_policy_handler.h",
+      "//chrome/browser/spellchecker/spellcheck_language_policy_handler.cc",
+      "//chrome/browser/spellchecker/spellcheck_language_policy_handler.h",
+      "//chrome/browser/spellchecker/spellcheck_service.cc",
+      "//chrome/browser/spellchecker/spellcheck_service.h",
+      "//chrome/common/pref_names.h",
+    ]
+
+    if (has_spellcheck_panel) {
+      sources += [
+        "//chrome/browser/spellchecker/spell_check_panel_host_impl.cc",
+        "//chrome/browser/spellchecker/spell_check_panel_host_impl.h",
+      ]
+    }
+
+    if (use_browser_spellchecker) {
+      sources += [
+        "//chrome/browser/spellchecker/spelling_request.cc",
+        "//chrome/browser/spellchecker/spelling_request.h",
+      ]
+    }
+
+    deps += [
+      "//base:base_static",
+      "//components/language/core/browser",
+      "//components/spellcheck:buildflags",
+      "//components/sync",
     ]
   }
-
-  if (use_browser_spellchecker) {
-    sources += [
-      "//chrome/browser/spellchecker/spelling_request.cc",
-      "//chrome/browser/spellchecker/spelling_request.h",
-    ]
-  }
-
-  deps = [
-    "//base:base_static",
-    "//components/language/core/browser",
-    "//components/spellcheck:buildflags",
-    "//components/sync",
-  ]
 
   public_deps = [
     "//components/spellcheck/browser",

--- a/shell/browser/api/atom_api_session.cc
+++ b/shell/browser/api/atom_api_session.cc
@@ -69,9 +69,9 @@
 #endif
 
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
-#include "chrome/browser/spellchecker/spellcheck_factory.h"
-#include "chrome/browser/spellchecker/spellcheck_hunspell_dictionary.h"
-#include "chrome/browser/spellchecker/spellcheck_service.h"
+#include "chrome/browser/spellchecker/spellcheck_factory.h"  // nogncheck
+#include "chrome/browser/spellchecker/spellcheck_hunspell_dictionary.h"  // nogncheck
+#include "chrome/browser/spellchecker/spellcheck_service.h"  // nogncheck
 #include "components/spellcheck/browser/pref_names.h"
 #include "components/spellcheck/common/spellcheck_common.h"
 


### PR DESCRIPTION
#### Description of Change
Fixes building with `enable_builtin_spellchecker = false` introduced in #20692

```
Undefined symbols for architecture x86_64:
  "SpellcheckWordIterator::Initialize(SpellcheckCharAttribute const*, bool)", referenced from:
      electron::api::SpellCheckClient::SpellCheckText() in atom_api_spell_check_client.o
  "SpellcheckWordIterator::GetNextWord(std::__1::basic_string<unsigned short, base::string16_internals::string16_char_traits, std::__1::allocator<unsigned short> >*, unsigned long*, unsigned long*)", referenced from:
      electron::api::SpellCheckClient::SpellCheckText() in atom_api_spell_check_client.o
      electron::api::SpellCheckClient::IsContraction(electron::api::SpellCheckClient::SpellCheckScope const&, std::__1::basic_string<unsigned short, base::string16_internals::string16_char_traits, std::__1::allocator<unsigned short> > const&, std::__1::vector<std::__1::basic_string<unsigned short, base::string16_internals::string16_char_traits, std::__1::allocator<unsigned short> >, std::__1::allocator<std::__1::basic_string<unsigned short, base::string16_internals::string16_char_traits, std::__1::allocator<unsigned short> > > >*) in atom_api_spell_check_client.o
  "SpellcheckWordIterator::SetText(unsigned short const*, unsigned long)", referenced from:
      electron::api::SpellCheckClient::SpellCheckText() in atom_api_spell_check_client.o
      electron::api::SpellCheckClient::IsContraction(electron::api::SpellCheckClient::SpellCheckScope const&, std::__1::basic_string<unsigned short, base::string16_internals::string16_char_traits, std::__1::allocator<unsigned short> > const&, std::__1::vector<std::__1::basic_string<unsigned short, base::string16_internals::string16_char_traits, std::__1::allocator<unsigned short> >, std::__1::allocator<std::__1::basic_string<unsigned short, base::string16_internals::string16_char_traits, std::__1::allocator<unsigned short> > > >*) in atom_api_spell_check_client.o
  "SpellcheckWordIterator::SpellcheckWordIterator()", referenced from:
      electron::api::SpellCheckClient::SpellCheckClient(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, v8::Isolate*, v8::Local<v8::Object>) in atom_api_spell_check_client.o
  "SpellcheckWordIterator::~SpellcheckWordIterator()", referenced from:
      electron::api::SpellCheckClient::~SpellCheckClient() in atom_api_spell_check_client.o
  "SpellcheckCharAttribute::SetDefaultLanguage(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)", referenced from:
      electron::api::SpellCheckClient::SpellCheckClient(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, v8::Isolate*, v8::Local<v8::Object>) in atom_api_spell_check_client.o
  "SpellcheckCharAttribute::SpellcheckCharAttribute()", referenced from:
      electron::api::SpellCheckClient::SpellCheckClient(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, v8::Isolate*, v8::Local<v8::Object>) in atom_api_spell_check_client.o
  "SpellcheckCharAttribute::~SpellcheckCharAttribute()", referenced from:
      electron::api::SpellCheckClient::~SpellCheckClient() in atom_api_spell_check_client.o
  "SpellcheckWordIterator::IsInitialized() const", referenced from:
      electron::api::SpellCheckClient::SpellCheckText() in atom_api_spell_check_client.o
      electron::api::SpellCheckClient::IsContraction(electron::api::SpellCheckClient::SpellCheckScope const&, std::__1::basic_string<unsigned short, base::string16_internals::string16_char_traits, std::__1::allocator<unsigned short> > const&, std::__1::vector<std::__1::basic_string<unsigned short, base::string16_internals::string16_char_traits, std::__1::allocator<unsigned short> >, std::__1::allocator<std::__1::basic_string<unsigned short, base::string16_internals::string16_char_traits, std::__1::allocator<unsigned short> > > >*) in atom_api_spell_check_client.o
ld: symbol(s) not found for architecture x86_64
```

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes