### PR TITLE
build: fix building with enable_builtin_spellchecker = false

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -353,6 +353,7 @@ source_set("electron_lib") {
     ":resources",
     "buildflags",
     "chromium_src:chrome",
+    "chromium_src:chrome_spellchecker",
     "native_mate",
     "shell/common/api:mojo",
     "//base:base_static",
@@ -479,10 +480,6 @@ source_set("electron_lib") {
       "shell/browser/fake_location_provider.cc",
       "shell/browser/fake_location_provider.h",
     ]
-  }
-
-  if (enable_builtin_spellchecker) {
-    deps += [ "chromium_src:chrome_spellchecker" ]
   }
 
   if (is_mac) {

--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -235,43 +235,49 @@ static_library("chrome") {
 # You may have to add new files here during the upgrade if //chrome/browser/spellchecker
 # gets more files
 source_set("chrome_spellchecker") {
-  sources = [
-    "//chrome/browser/spellchecker/spell_check_host_chrome_impl.cc",
-    "//chrome/browser/spellchecker/spell_check_host_chrome_impl.h",
-    "//chrome/browser/spellchecker/spellcheck_custom_dictionary.cc",
-    "//chrome/browser/spellchecker/spellcheck_custom_dictionary.h",
-    "//chrome/browser/spellchecker/spellcheck_factory.cc",
-    "//chrome/browser/spellchecker/spellcheck_factory.h",
-    "//chrome/browser/spellchecker/spellcheck_hunspell_dictionary.cc",
-    "//chrome/browser/spellchecker/spellcheck_hunspell_dictionary.h",
-    "//chrome/browser/spellchecker/spellcheck_language_blacklist_policy_handler.cc",
-    "//chrome/browser/spellchecker/spellcheck_language_blacklist_policy_handler.h",
-    "//chrome/browser/spellchecker/spellcheck_language_policy_handler.cc",
-    "//chrome/browser/spellchecker/spellcheck_language_policy_handler.h",
-    "//chrome/browser/spellchecker/spellcheck_service.cc",
-    "//chrome/browser/spellchecker/spellcheck_service.h",
-  ]
+  sources = []
+  deps = []
+  libs = []
 
-  if (has_spellcheck_panel) {
+  if (enable_builtin_spellchecker) {
     sources += [
-      "//chrome/browser/spellchecker/spell_check_panel_host_impl.cc",
-      "//chrome/browser/spellchecker/spell_check_panel_host_impl.h",
+      "//chrome/browser/spellchecker/spell_check_host_chrome_impl.cc",
+      "//chrome/browser/spellchecker/spell_check_host_chrome_impl.h",
+      "//chrome/browser/spellchecker/spellcheck_custom_dictionary.cc",
+      "//chrome/browser/spellchecker/spellcheck_custom_dictionary.h",
+      "//chrome/browser/spellchecker/spellcheck_factory.cc",
+      "//chrome/browser/spellchecker/spellcheck_factory.h",
+      "//chrome/browser/spellchecker/spellcheck_hunspell_dictionary.cc",
+      "//chrome/browser/spellchecker/spellcheck_hunspell_dictionary.h",
+      "//chrome/browser/spellchecker/spellcheck_language_blacklist_policy_handler.cc",
+      "//chrome/browser/spellchecker/spellcheck_language_blacklist_policy_handler.h",
+      "//chrome/browser/spellchecker/spellcheck_language_policy_handler.cc",
+      "//chrome/browser/spellchecker/spellcheck_language_policy_handler.h",
+      "//chrome/browser/spellchecker/spellcheck_service.cc",
+      "//chrome/browser/spellchecker/spellcheck_service.h",
+    ]
+
+    if (has_spellcheck_panel) {
+      sources += [
+        "//chrome/browser/spellchecker/spell_check_panel_host_impl.cc",
+        "//chrome/browser/spellchecker/spell_check_panel_host_impl.h",
+      ]
+    }
+
+    if (use_browser_spellchecker) {
+      sources += [
+        "//chrome/browser/spellchecker/spelling_request.cc",
+        "//chrome/browser/spellchecker/spelling_request.h",
+      ]
+    }
+
+    deps += [
+      "//base:base_static",
+      "//components/language/core/browser",
+      "//components/spellcheck:buildflags",
+      "//components/sync",
     ]
   }
-
-  if (use_browser_spellchecker) {
-    sources += [
-      "//chrome/browser/spellchecker/spelling_request.cc",
-      "//chrome/browser/spellchecker/spelling_request.h",
-    ]
-  }
-
-  deps = [
-    "//base:base_static",
-    "//components/language/core/browser",
-    "//components/spellcheck:buildflags",
-    "//components/sync",
-  ]
 
   public_deps = [
     "//components/spellcheck/browser",

--- a/shell/browser/api/atom_api_session.cc
+++ b/shell/browser/api/atom_api_session.cc
@@ -70,7 +70,7 @@
 #endif
 
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
-#include "chrome/browser/spellchecker/spellcheck_hunspell_dictionary.h"
+#include "chrome/browser/spellchecker/spellcheck_hunspell_dictionary.h"  // nogncheck
 #include "components/spellcheck/browser/pref_names.h"
 #include "components/spellcheck/common/spellcheck_common.h"
 #endif


### PR DESCRIPTION
#### Description of Change

Backports #21334 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
