### PR TITLE
fix: ensure no node globals passively leak when nodeIntegration is disabled

### DIFF
--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -192,6 +192,8 @@ if (nodeIntegration) {
       delete global.setImmediate
       delete global.clearImmediate
       delete global.global
+      delete global.root
+      delete global.GLOBAL
     })
   }
 }

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1543,6 +1543,37 @@ describe('BrowserWindow module', () => {
         sandbox: true,
         contextIsolation: true
       })
+      it('does not leak any node globals on the window object with nodeIntegration is disabled', async () => {
+        let w = new BrowserWindow({
+          webPreferences: {
+            contextIsolation: false,
+            nodeIntegration: false,
+            preload: path.resolve(fixtures, 'module', 'empty.js')
+          },
+          show: false
+        })
+        w.loadFile(path.join(fixtures, 'api', 'globals.html'))
+        const [, notIsolated] = await emittedOnce(ipcMain, 'leak-result')
+        expect(notIsolated).to.have.property('globals')
+
+        w.destroy()
+        w = new BrowserWindow({
+          webPreferences: {
+            contextIsolation: true,
+            nodeIntegration: false,
+            preload: path.resolve(fixtures, 'module', 'empty.js')
+          },
+          show: false
+        })
+        w.loadFile(path.join(fixtures, 'api', 'globals.html'))
+        const [, isolated] = await emittedOnce(ipcMain, 'leak-result')
+        expect(isolated).to.have.property('globals')
+        const notIsolatedGlobals = new Set(notIsolated.globals)
+        for (const isolatedGlobal of isolated.globals) {
+          notIsolatedGlobals.delete(isolatedGlobal)
+        }
+        expect([...notIsolatedGlobals]).to.deep.equal([], 'non-isoalted renderer should have no additional globals')
+      })
 
       it('loads the script before other scripts in window', async () => {
         const preload = path.join(fixtures, 'module', 'set-global.js')

--- a/spec/fixtures/api/globals.html
+++ b/spec/fixtures/api/globals.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Document</title>
+</head>
+<body>
+  <script>
+  window.postMessage({
+    globals: Object.keys(Object.getOwnPropertyDescriptors(window))
+  })
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This deletes two extra globals, both of which were recursive references to the original `global` object.  I.e. `window.root === window`.  This also adds a test so any new globals are caught appropriately.

Notes: `window.root` and `window.GLOBAL` are both now undefined when `nodeIntegration` is disabled as expected.