### PR TITLE
fix: execute JS function via blink in renderer process (7-1-x)

### DIFF
--- a/shell/renderer/electron_api_service_impl.cc
+++ b/shell/renderer/electron_api_service_impl.cc
@@ -46,7 +46,8 @@ v8::Local<v8::Object> GetIpcObject(v8::Local<v8::Context> context) {
   return value->ToObject(context).ToLocalChecked();
 }
 
-void InvokeIpcCallback(v8::Local<v8::Context> context,
+void InvokeIpcCallback(blink::WebLocalFrame* frame,
+                       v8::Local<v8::Context> context,
                        const std::string& callback_name,
                        std::vector<v8::Local<v8::Value>> args) {
   TRACE_EVENT0("devtools.timeline", "FunctionCall");
@@ -56,24 +57,19 @@ void InvokeIpcCallback(v8::Local<v8::Context> context,
   if (ipcNative.IsEmpty())
     return;
 
-  // Only set up the node::CallbackScope if there's a node environment.
-  // Sandboxed renderers don't have a node environment.
-  node::Environment* env = node::Environment::GetCurrent(context);
-  std::unique_ptr<node::CallbackScope> callback_scope;
-  if (env) {
-    callback_scope.reset(new node::CallbackScope(isolate, ipcNative, {0, 0}));
-  }
-
   auto callback_key = mate::ConvertToV8(isolate, callback_name)
                           ->ToString(context)
                           .ToLocalChecked();
   auto callback_value = ipcNative->Get(context, callback_key).ToLocalChecked();
   DCHECK(callback_value->IsFunction());  // set by init.ts
   auto callback = v8::Local<v8::Function>::Cast(callback_value);
-  ignore_result(callback->Call(context, ipcNative, args.size(), args.data()));
+
+  frame->RequestExecuteV8Function(context, callback, ipcNative, args.size(),
+                                  args.data(), nullptr);
 }
 
-void EmitIPCEvent(v8::Local<v8::Context> context,
+void EmitIPCEvent(blink::WebLocalFrame* frame,
+                  v8::Local<v8::Context> context,
                   bool internal,
                   const std::string& channel,
                   const std::vector<base::Value>& args,
@@ -89,7 +85,7 @@ void EmitIPCEvent(v8::Local<v8::Context> context,
       mate::ConvertToV8(isolate, internal), mate::ConvertToV8(isolate, channel),
       mate::ConvertToV8(isolate, args), mate::ConvertToV8(isolate, sender_id)};
 
-  InvokeIpcCallback(context, "onMessage", argv);
+  InvokeIpcCallback(frame, context, "onMessage", argv);
 }
 
 }  // namespace
@@ -161,7 +157,8 @@ void ElectronApiServiceImpl::Message(bool internal,
 
   v8::Local<v8::Context> context = renderer_client_->GetContext(frame, isolate);
 
-  EmitIPCEvent(context, internal, channel, arguments.GetList(), sender_id);
+  EmitIPCEvent(frame, context, internal, channel, arguments.GetList(),
+               sender_id);
 
   // Also send the message to all sub-frames.
   // TODO(MarshallOfSound): Completely move this logic to the main process
@@ -169,10 +166,11 @@ void ElectronApiServiceImpl::Message(bool internal,
     for (blink::WebFrame* child = frame->FirstChild(); child;
          child = child->NextSibling())
       if (child->IsWebLocalFrame()) {
+        blink::WebLocalFrame* child_local = child->ToWebLocalFrame();
         v8::Local<v8::Context> child_context =
-            renderer_client_->GetContext(child->ToWebLocalFrame(), isolate);
-        EmitIPCEvent(child_context, internal, channel, arguments.GetList(),
-                     sender_id);
+            renderer_client_->GetContext(child_local, isolate);
+        EmitIPCEvent(child_local, child_context, internal, channel,
+                     arguments.GetList(), sender_id);
       }
   }
 }


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/21351.

Notes: Fix crash when debugging async/await code.