### PR TITLE
feat: expose sync js exec interface on WebFrame (try 2)

### DIFF
--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -154,6 +154,24 @@ or is rejected if the result of the code is a rejected promise.
 
 Works like `executeJavaScript` but evaluates `scripts` in an isolated context.
 
+### `webFrame.executeJavaScriptSync(code)`
+
+* `code` String
+
+Returns `any` - The result of the executed code.
+
+Evaluates `code` in page.
+
+### `webFrame.executeJavaScriptInIsolatedWorlSync(worldId, scripts[, userGesture])`
+
+* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature.  You can provide any integer here.
+* `scripts` [WebSource[]](structures/web-source.md)
+* `userGesture` Boolean (optional) - Default is `false`.
+
+Returns `any` - The result of the executed code.
+
+Works like `executeJavaScriptSync` but evaluates `scripts` in an isolated context.
+
 ### `webFrame.setIsolatedWorldInfo(worldId, info)`
 * `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature. Chrome extensions reserve the range of IDs in `[1 << 20, 1 << 29)`. You can provide any integer here.
 * `info` Object


### PR DESCRIPTION
#### Description of Change

Before the promisification (#17312) of `WebFrame#executeJavaScript*` their interface was async (callback) but behavior was sync (callback called before the methods returned). So they could be used in sync code (or async, you could wrap them in a promise yourself).

The switch from a callback to a promise interface made it impossible to use them in sync mode (#19161), which was a breaking change without a workaround.

This PR exposes the sync js exec methods on WebFrame, providing a workaround for code that used the original methods synchronously. In general, a sync in-process js eval makes perfect sense, because it's sync under the hood.

This attempt uses the same underlying methods `WebLocalFrame::RequestExecuteScript*` as the "async" versions.

Fixes #19161

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: add sync javascript execution methods to WebFrame

<!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
