### PR TITLE
feat: remove deprecated setLayoutZoomLevelLimits

### DIFF
--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -20,6 +20,14 @@ const { remote } = require('electron')
 remote.webContents.fromId(webview.getWebContentsId())
 ```
 
+### `webFrame.setLayoutZoomLevelLimits()`
+
+Chromium has removed support for changing the layout zoom level limits, and it
+is beyond Electron's capacity to maintain it. The function was deprecated in
+Electron 8.x, and has been removed in Electron 9.x. The layout zoom level limits
+are now fixed at a minimum of 0.25 and a maximum of 5.0, as defined
+[here](https://chromium.googlesource.com/chromium/src/+/938b37a6d2886bf8335fc7db792f1eb46c65b2ae/third_party/blink/common/page/page_zoom.cc#11).
+
 ## Planned Breaking API Changes (8.0)
 
 ### Values sent over IPC are now serialized with Structured Clone Algorithm

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1113,17 +1113,6 @@ Sets the maximum and minimum pinch-to-zoom level.
 > contents.setVisualZoomLevelLimits(1, 3)
 > ```
 
-#### `contents.setLayoutZoomLevelLimits(minimumLevel, maximumLevel)` _Deprecated_
-
-* `minimumLevel` Number
-* `maximumLevel` Number
-
-Returns `Promise<void>`
-
-Sets the maximum and minimum layout-based (i.e. non-visual) zoom level.
-
-**Deprecated:** This API is no longer supported by Chromium.
-
 #### `contents.undo()`
 
 Executes the editing command `undo` in web page.

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -56,15 +56,6 @@ Sets the maximum and minimum pinch-to-zoom level.
 > webFrame.setVisualZoomLevelLimits(1, 3)
 > ```
 
-### `webFrame.setLayoutZoomLevelLimits(minimumLevel, maximumLevel)` _Deprecated_
-
-* `minimumLevel` Number
-* `maximumLevel` Number
-
-Sets the maximum and minimum layout-based (i.e. non-visual) zoom level.
-
-**Deprecated:** This API is no longer supported by Chromium.
-
 ### `webFrame.setSpellCheckProvider(language, provider)`
 
 * `language` String

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -635,17 +635,6 @@ Returns `Promise<void>`
 
 Sets the maximum and minimum pinch-to-zoom level.
 
-### `<webview>.setLayoutZoomLevelLimits(minimumLevel, maximumLevel)` _Deprecated_
-
-* `minimumLevel` Number
-* `maximumLevel` Number
-
-Returns `Promise<void>`
-
-Sets the maximum and minimum layout-based (i.e. non-visual) zoom level.
-
-**Deprecated:** This API is no longer supported by Chromium.
-
 ### `<webview>.showDefinitionForSelection()` _macOS_
 
 Shows pop-up dictionary that searches the selected word on the page.

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -173,7 +173,6 @@ const webFrameMethods = [
   'insertCSS',
   'insertText',
   'removeInsertedCSS',
-  'setLayoutZoomLevelLimits',
   'setVisualZoomLevelLimits'
 ]
 

--- a/lib/renderer/api/web-frame.ts
+++ b/lib/renderer/api/web-frame.ts
@@ -1,9 +1,6 @@
 import { EventEmitter } from 'events'
-import { deprecate } from 'electron'
 
 const binding = process.electronBinding('web_frame')
-
-const setLayoutZoomLevelLimitsWarning = deprecate.warnOnce('setLayoutZoomLevelLimits')
 
 class WebFrame extends EventEmitter {
   constructor (public context: Window) {
@@ -47,10 +44,6 @@ class WebFrame extends EventEmitter {
 
   get routingId () {
     return binding._getRoutingId(this.context)
-  }
-
-  setLayoutZoomLevelLimits () {
-    setLayoutZoomLevelLimitsWarning()
   }
 }
 


### PR DESCRIPTION
This was deprecated in 8.x, so removing it for the 9.x line.

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


Notes: Removed the deprecated 'setLayoutZoomLevelLimits' method.