### PR TITLE
fix: pass noLink correctly on Windows

### DIFF
--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -163,6 +163,7 @@ const messageBox = (sync, window, options) => {
     defaultId = -1,
     detail = '',
     icon = null,
+    noLink = false,
     message = '',
     title = '',
     type = 'none'
@@ -173,6 +174,7 @@ const messageBox = (sync, window, options) => {
   if (!Array.isArray(buttons)) throw new TypeError('Buttons must be an array')
   if (options.normalizeAccessKeys) buttons = buttons.map(normalizeAccessKey)
   if (typeof title !== 'string') throw new TypeError('Title must be a string')
+  if (typeof noLink !== 'boolean') throw new TypeError('noLink must be a boolean')
   if (typeof message !== 'string') throw new TypeError('Message must be a string')
   if (typeof detail !== 'string') throw new TypeError('Detail must be a string')
   if (typeof checkboxLabel !== 'string') throw new TypeError('checkboxLabel must be a string')
@@ -195,15 +197,13 @@ const messageBox = (sync, window, options) => {
     }
   }
 
-  const flags = options.noLink ? messageBoxOptions.noLink : 0
-
   const settings = {
     window,
     messageBoxType,
     buttons,
     defaultId,
     cancelId,
-    flags,
+    noLink,
     title,
     message,
     detail,

--- a/shell/browser/ui/message_box.h
+++ b/shell/browser/ui/message_box.h
@@ -25,11 +25,6 @@ enum class MessageBoxType {
   kQuestion,
 };
 
-enum MessageBoxOptions {
-  MESSAGE_BOX_NONE = 0,
-  MESSAGE_BOX_NO_LINK = 1 << 0,
-};
-
 using DialogResult = std::pair<int, bool>;
 
 struct MessageBoxSettings {
@@ -38,7 +33,7 @@ struct MessageBoxSettings {
   std::vector<std::string> buttons;
   int default_id;
   int cancel_id;
-  int options = electron::MessageBoxOptions::MESSAGE_BOX_NONE;
+  bool no_link = false;
   std::string title;
   std::string message;
   std::string detail;

--- a/shell/browser/ui/message_box_win.cc
+++ b/shell/browser/ui/message_box_win.cc
@@ -83,7 +83,7 @@ DialogResult ShowTaskDialogUTF16(NativeWindow* parent,
                                  const std::vector<base::string16>& buttons,
                                  int default_id,
                                  int cancel_id,
-                                 int options,
+                                 bool no_link,
                                  const base::string16& title,
                                  const base::string16& message,
                                  const base::string16& detail,
@@ -156,7 +156,7 @@ DialogResult ShowTaskDialogUTF16(NativeWindow* parent,
   // and custom buttons in pButtons.
   std::map<int, int> id_map;
   std::vector<TASKDIALOG_BUTTON> dialog_buttons;
-  if (options & MESSAGE_BOX_NO_LINK) {
+  if (no_link) {
     for (size_t i = 0; i < buttons.size(); ++i)
       dialog_buttons.push_back(
           {static_cast<int>(i + kIDStart), buttons[i].c_str()});
@@ -166,7 +166,7 @@ DialogResult ShowTaskDialogUTF16(NativeWindow* parent,
   if (dialog_buttons.size() > 0) {
     config.pButtons = &dialog_buttons.front();
     config.cButtons = dialog_buttons.size();
-    if (!(options & MESSAGE_BOX_NO_LINK))
+    if (!no_link)
       config.dwFlags |= TDF_USE_COMMAND_LINKS;  // custom buttons as links.
   }
 
@@ -200,7 +200,7 @@ DialogResult ShowTaskDialogUTF8(const MessageBoxSettings& settings) {
 
   return ShowTaskDialogUTF16(
       settings.parent_window, settings.type, utf16_buttons, settings.default_id,
-      settings.cancel_id, settings.options, title_16, message_16, detail_16,
+      settings.cancel_id, settings.no_link, title_16, message_16, detail_16,
       checkbox_label_16, settings.checkbox_checked, settings.icon);
 }
 
@@ -242,8 +242,8 @@ void ShowMessageBox(const MessageBoxSettings& settings,
 
 void ShowErrorBox(const base::string16& title, const base::string16& content) {
   electron::UnresponsiveSuppressor suppressor;
-  ShowTaskDialogUTF16(nullptr, MessageBoxType::kError, {}, -1, 0, 0, L"Error",
-                      title, content, L"", false, gfx::ImageSkia());
+  ShowTaskDialogUTF16(nullptr, MessageBoxType::kError, {}, -1, 0, false,
+                      L"Error", title, content, L"", false, gfx::ImageSkia());
 }
 
 }  // namespace electron

--- a/shell/common/gin_converters/message_box_converter.cc
+++ b/shell/common/gin_converters/message_box_converter.cc
@@ -24,11 +24,11 @@ bool Converter<electron::MessageBoxSettings>::FromV8(
   dict.Get("buttons", &out->buttons);
   dict.Get("defaultId", &out->default_id);
   dict.Get("cancelId", &out->cancel_id);
-  dict.Get("options", &out->options);
   dict.Get("title", &out->title);
   dict.Get("message", &out->message);
   dict.Get("detail", &out->detail);
   dict.Get("checkboxLabel", &out->checkbox_label);
+  dict.Get("noLink", &out->no_link);
   dict.Get("checkboxChecked", &out->checkbox_checked);
   dict.Get("icon", &out->icon);
   return true;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/20855.

The mechanism for our passing `noLink` down to the Windows message box implementation was confusing, and so I have both fixed the underlying issue as well as plumbed it in a clearer manner to make the conversion clearer at the JS and C++ levels.

cc @ckerr @MarshallOfSound @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `noLink` was working incorrectly on Windows.
