### PR TITLE
fix: avoid context bridge crash when window closes

### DIFF
--- a/shell/renderer/api/context_bridge/render_frame_context_bridge_store.cc
+++ b/shell/renderer/api/context_bridge/render_frame_context_bridge_store.cc
@@ -20,7 +20,7 @@ class CachedProxyLifeMonitor final : public ObjectLifeMonitor {
  public:
   static void BindTo(v8::Isolate* isolate,
                      v8::Local<v8::Object> target,
-                     RenderFramePersistenceStore* store,
+                     base::WeakPtr<RenderFramePersistenceStore> store,
                      WeakGlobalPairNode* node,
                      int hash) {
     new CachedProxyLifeMonitor(isolate, target, store, node, hash);
@@ -29,7 +29,7 @@ class CachedProxyLifeMonitor final : public ObjectLifeMonitor {
  protected:
   CachedProxyLifeMonitor(v8::Isolate* isolate,
                          v8::Local<v8::Object> target,
-                         RenderFramePersistenceStore* store,
+                         base::WeakPtr<RenderFramePersistenceStore> store,
                          WeakGlobalPairNode* node,
                          int hash)
       : ObjectLifeMonitor(isolate, target),
@@ -38,6 +38,9 @@ class CachedProxyLifeMonitor final : public ObjectLifeMonitor {
         hash_(hash) {}
 
   void RunDestructor() override {
+    if (!store_)
+      return;
+
     if (node_->detached) {
       delete node_;
     }
@@ -55,7 +58,7 @@ class CachedProxyLifeMonitor final : public ObjectLifeMonitor {
   }
 
  private:
-  RenderFramePersistenceStore* store_;
+  base::WeakPtr<RenderFramePersistenceStore> store_;
   WeakGlobalPairNode* node_;
   int hash_;
 };
@@ -97,11 +100,11 @@ void RenderFramePersistenceStore::CacheProxiedObject(
     auto iter = proxy_map_.find(hash);
     auto* node = new WeakGlobalPairNode(
         std::make_tuple(std::move(global_from), std::move(global_proxy)));
-    CachedProxyLifeMonitor::BindTo(v8::Isolate::GetCurrent(), obj, this, node,
-                                   hash);
+    CachedProxyLifeMonitor::BindTo(v8::Isolate::GetCurrent(), obj,
+                                   weak_factory_.GetWeakPtr(), node, hash);
     CachedProxyLifeMonitor::BindTo(v8::Isolate::GetCurrent(),
                                    v8::Local<v8::Object>::Cast(proxy_value),
-                                   this, node, hash);
+                                   weak_factory_.GetWeakPtr(), node, hash);
     if (iter == proxy_map_.end()) {
       proxy_map_.emplace(hash, node);
     } else {

--- a/shell/renderer/api/context_bridge/render_frame_context_bridge_store.h
+++ b/shell/renderer/api/context_bridge/render_frame_context_bridge_store.h
@@ -60,6 +60,7 @@ class RenderFramePersistenceStore final : public content::RenderFrameObserver {
 
   // object_identity ==> [from_value, proxy_value]
   std::map<int, WeakGlobalPairNode*> proxy_map_;
+  base::WeakPtrFactory<RenderFramePersistenceStore> weak_factory_{this};
 };
 
 }  // namespace context_bridge


### PR DESCRIPTION
#### Description of Change
Fix a bad access crash that happens when a render frame is deleted (window closed) and garbage collection runs afterward.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed contextBridge crash when closing a window.
