### PR TITLE
feat: add tracing info to WebContents IPC methods

### DIFF
--- a/docs/api/content-tracing.md
+++ b/docs/api/content-tracing.md
@@ -38,6 +38,9 @@ Get a set of category groups. The category groups can change as new code paths
 are reached. See also the [list of built-in tracing
 categories](https://chromium.googlesource.com/chromium/src/+/master/base/trace_event/builtin_categories.h).
 
+> **NOTE:** Electron adds a non-default tracing category called `"electron"`.
+> This category can be used to capture Electron-specific tracing events.
+
 ### `contentTracing.startRecording(options)`
 
 * `options` ([TraceConfig](structures/trace-config.md) | [TraceCategoriesAndOptions](structures/trace-categories-and-options.md))

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -1035,6 +1035,7 @@ void WebContents::OnElectronBrowserConnectionError() {
 void WebContents::Message(bool internal,
                           const std::string& channel,
                           blink::CloneableMessage arguments) {
+  TRACE_EVENT1("electron", "WebContents::Message", "channel", channel);
   // webContents.emit('-ipc-message', new Event(), internal, channel,
   // arguments);
   EmitWithSender("-ipc-message", bindings_.dispatch_context(), InvokeCallback(),
@@ -1045,6 +1046,7 @@ void WebContents::Invoke(bool internal,
                          const std::string& channel,
                          blink::CloneableMessage arguments,
                          InvokeCallback callback) {
+  TRACE_EVENT1("electron", "WebContents::Invoke", "channel", channel);
   // webContents.emit('-ipc-invoke', new Event(), internal, channel, arguments);
   EmitWithSender("-ipc-invoke", bindings_.dispatch_context(),
                  std::move(callback), internal, channel, std::move(arguments));
@@ -1054,6 +1056,7 @@ void WebContents::MessageSync(bool internal,
                               const std::string& channel,
                               blink::CloneableMessage arguments,
                               MessageSyncCallback callback) {
+  TRACE_EVENT1("electron", "WebContents::MessageSync", "channel", channel);
   // webContents.emit('-ipc-message-sync', new Event(sender, message), internal,
   // channel, arguments);
   EmitWithSender("-ipc-message-sync", bindings_.dispatch_context(),
@@ -1065,6 +1068,7 @@ void WebContents::MessageTo(bool internal,
                             int32_t web_contents_id,
                             const std::string& channel,
                             blink::CloneableMessage arguments) {
+  TRACE_EVENT1("electron", "WebContents::MessageTo", "channel", channel);
   auto* web_contents = gin_helper::TrackableObject<WebContents>::FromWeakMapID(
       isolate(), web_contents_id);
 
@@ -1076,6 +1080,7 @@ void WebContents::MessageTo(bool internal,
 
 void WebContents::MessageHost(const std::string& channel,
                               blink::CloneableMessage arguments) {
+  TRACE_EVENT1("electron", "WebContents::MessageHost", "channel", channel);
   // webContents.emit('ipc-message-host', new Event(), channel, args);
   EmitWithSender("ipc-message-host", bindings_.dispatch_context(),
                  InvokeCallback(), channel, std::move(arguments));


### PR DESCRIPTION
#### Description of Change
This instruments the `Message`, `MessageSync`, etc. calls with tracing info including the channel name. Hopefully will give clues as to when IPC from a renderer is causing lots of work to happen in the main process.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added tracing instrumentation to WebContents IPC methods, available with the contentTracing category "electron".
