### PR TITLE
fix: pass noLink and checkboxChecked correctly on Windows

### DIFF
--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -141,6 +141,7 @@ const messageBox = (sync, window, options) => {
     defaultId = -1,
     detail = '',
     icon = null,
+    noLink = false,
     message = '',
     title = '',
     type = 'none'
@@ -151,11 +152,15 @@ const messageBox = (sync, window, options) => {
   if (!Array.isArray(buttons)) throw new TypeError('Buttons must be an array')
   if (options.normalizeAccessKeys) buttons = buttons.map(normalizeAccessKey)
   if (typeof title !== 'string') throw new TypeError('Title must be a string')
+  if (typeof noLink !== 'boolean') throw new TypeError('noLink must be a boolean')
   if (typeof message !== 'string') throw new TypeError('Message must be a string')
   if (typeof detail !== 'string') throw new TypeError('Detail must be a string')
   if (typeof checkboxLabel !== 'string') throw new TypeError('checkboxLabel must be a string')
 
   checkboxChecked = !!checkboxChecked
+  if (checkboxChecked && !checkboxLabel) {
+    throw new Error('checkboxChecked requires that checkboxLabel also be passed')
+  }
 
   // Choose a default button to get selected when dialog is cancelled.
   if (cancelId == null) {
@@ -170,15 +175,13 @@ const messageBox = (sync, window, options) => {
     }
   }
 
-  const flags = options.noLink ? messageBoxOptions.noLink : 0
-
   const settings = {
     window,
     messageBoxType,
     buttons,
     defaultId,
     cancelId,
-    flags,
+    noLink,
     title,
     message,
     detail,

--- a/shell/browser/ui/message_box.h
+++ b/shell/browser/ui/message_box.h
@@ -6,6 +6,7 @@
 #define SHELL_BROWSER_UI_MESSAGE_BOX_H_
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "base/callback_forward.h"
@@ -24,10 +25,7 @@ enum class MessageBoxType {
   kQuestion,
 };
 
-enum MessageBoxOptions {
-  MESSAGE_BOX_NONE = 0,
-  MESSAGE_BOX_NO_LINK = 1 << 0,
-};
+using DialogResult = std::pair<int, bool>;
 
 struct MessageBoxSettings {
   electron::NativeWindow* parent_window = nullptr;
@@ -35,7 +33,7 @@ struct MessageBoxSettings {
   std::vector<std::string> buttons;
   int default_id;
   int cancel_id;
-  int options = electron::MessageBoxOptions::MESSAGE_BOX_NONE;
+  bool no_link = false;
   std::string title;
   std::string message;
   std::string detail;

--- a/shell/browser/ui/message_box_win.cc
+++ b/shell/browser/ui/message_box_win.cc
@@ -78,18 +78,18 @@ void MapToCommonID(const std::vector<base::string16>& buttons,
   }
 }
 
-int ShowTaskDialogUTF16(NativeWindow* parent,
-                        MessageBoxType type,
-                        const std::vector<base::string16>& buttons,
-                        int default_id,
-                        int cancel_id,
-                        int options,
-                        const base::string16& title,
-                        const base::string16& message,
-                        const base::string16& detail,
-                        const base::string16& checkbox_label,
-                        bool* checkbox_checked,
-                        const gfx::ImageSkia& icon) {
+DialogResult ShowTaskDialogUTF16(NativeWindow* parent,
+                                 MessageBoxType type,
+                                 const std::vector<base::string16>& buttons,
+                                 int default_id,
+                                 int cancel_id,
+                                 bool no_link,
+                                 const base::string16& title,
+                                 const base::string16& message,
+                                 const base::string16& detail,
+                                 const base::string16& checkbox_label,
+                                 bool checkbox_checked,
+                                 const gfx::ImageSkia& icon) {
   TASKDIALOG_FLAGS flags =
       TDF_SIZE_TO_CONTENT |           // Show all content.
       TDF_ALLOW_DIALOG_CANCELLATION;  // Allow canceling the dialog.
@@ -149,16 +149,15 @@ int ShowTaskDialogUTF16(NativeWindow* parent,
   if (!checkbox_label.empty()) {
     config.pszVerificationText = checkbox_label.c_str();
 
-    if (checkbox_checked && *checkbox_checked) {
+    if (checkbox_checked)
       config.dwFlags |= TDF_VERIFICATION_FLAG_CHECKED;
-    }
   }
 
   // Iterate through the buttons, put common buttons in dwCommonButtons
   // and custom buttons in pButtons.
   std::map<int, int> id_map;
   std::vector<TASKDIALOG_BUTTON> dialog_buttons;
-  if (options & MESSAGE_BOX_NO_LINK) {
+  if (no_link) {
     for (size_t i = 0; i < buttons.size(); ++i)
       dialog_buttons.push_back(
           {static_cast<int>(i + kIDStart), buttons[i].c_str()});
@@ -168,26 +167,28 @@ int ShowTaskDialogUTF16(NativeWindow* parent,
   if (dialog_buttons.size() > 0) {
     config.pButtons = &dialog_buttons.front();
     config.cButtons = dialog_buttons.size();
-    if (!(options & MESSAGE_BOX_NO_LINK))
+    if (!no_link)
       config.dwFlags |= TDF_USE_COMMAND_LINKS;  // custom buttons as links.
   }
 
+  int button_id;
   int id = 0;
+
   BOOL verificationFlagChecked = FALSE;
   TaskDialogIndirect(&config, &id, nullptr, &verificationFlagChecked);
-  if (checkbox_checked) {
-    *checkbox_checked = verificationFlagChecked;
-  }
 
   if (id_map.find(id) != id_map.end())  // common button.
-    return id_map[id];
+    button_id = id_map[id];
   else if (id >= kIDStart)  // custom button.
-    return id - kIDStart;
+    button_id = id - kIDStart;
   else
-    return cancel_id;
+    button_id = cancel_id;
+
+  return std::make_pair(button_id,
+                        checkbox_checked ? verificationFlagChecked : false);
 }
 
-int ShowTaskDialogUTF8(const MessageBoxSettings& settings) {
+DialogResult ShowTaskDialogUTF8(const MessageBoxSettings& settings) {
   std::vector<base::string16> utf16_buttons;
   for (const auto& button : settings.buttons)
     utf16_buttons.push_back(base::UTF8ToUTF16(button));
@@ -197,21 +198,20 @@ int ShowTaskDialogUTF8(const MessageBoxSettings& settings) {
   const base::string16 detail_16 = base::UTF8ToUTF16(settings.detail);
   const base::string16 checkbox_label_16 =
       base::UTF8ToUTF16(settings.checkbox_label);
-  bool cb_checked = settings.checkbox_checked;
 
   return ShowTaskDialogUTF16(
       settings.parent_window, settings.type, utf16_buttons, settings.default_id,
-      settings.cancel_id, settings.options, title_16, message_16, detail_16,
-      checkbox_label_16, &cb_checked, settings.icon);
+      settings.cancel_id, settings.no_link, title_16, message_16, detail_16,
+      checkbox_label_16, settings.checkbox_checked, settings.icon);
 }
 
 void RunMessageBoxInNewThread(base::Thread* thread,
                               const MessageBoxSettings& settings,
                               MessageBoxCallback callback) {
-  int result = ShowTaskDialogUTF8(settings);
+  DialogResult result = ShowTaskDialogUTF8(settings);
   base::PostTaskWithTraits(
       FROM_HERE, {content::BrowserThread::UI},
-      base::BindOnce(std::move(callback), result, settings.checkbox_checked));
+      base::BindOnce(std::move(callback), result.first, result.second));
   content::BrowserThread::DeleteSoon(content::BrowserThread::UI, FROM_HERE,
                                      thread);
 }
@@ -220,7 +220,8 @@ void RunMessageBoxInNewThread(base::Thread* thread,
 
 int ShowMessageBoxSync(const MessageBoxSettings& settings) {
   electron::UnresponsiveSuppressor suppressor;
-  return ShowTaskDialogUTF8(settings);
+  DialogResult result = ShowTaskDialogUTF8(settings);
+  return result.first;
 }
 
 void ShowMessageBox(const MessageBoxSettings& settings,
@@ -242,8 +243,8 @@ void ShowMessageBox(const MessageBoxSettings& settings,
 
 void ShowErrorBox(const base::string16& title, const base::string16& content) {
   electron::UnresponsiveSuppressor suppressor;
-  ShowTaskDialogUTF16(nullptr, MessageBoxType::kError, {}, -1, 0, 0, L"Error",
-                      title, content, L"", nullptr, gfx::ImageSkia());
+  ShowTaskDialogUTF16(nullptr, MessageBoxType::kError, {}, -1, 0, false,
+                      L"Error", title, content, L"", false, gfx::ImageSkia());
 }
 
 }  // namespace electron

--- a/shell/common/native_mate_converters/message_box_converter.cc
+++ b/shell/common/native_mate_converters/message_box_converter.cc
@@ -25,11 +25,11 @@ bool Converter<electron::MessageBoxSettings>::FromV8(
   dict.Get("buttons", &out->buttons);
   dict.Get("defaultId", &out->default_id);
   dict.Get("cancelId", &out->cancel_id);
-  dict.Get("options", &out->options);
   dict.Get("title", &out->title);
   dict.Get("message", &out->message);
   dict.Get("detail", &out->detail);
   dict.Get("checkboxLabel", &out->checkbox_label);
+  dict.Get("noLink", &out->no_link);
   dict.Get("checkboxChecked", &out->checkbox_checked);
   dict.Get("icon", &out->icon);
   return true;


### PR DESCRIPTION
#### Description of Change

Backport of https://github.com/electron/electron/pull/21248.
Backport of https://github.com/electron/electron/pull/21386.

See those PRs for more details.

cc @jkleinsc 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed issues where noLink and checkboxChecked were not passed correctly on Windows.
