### PR TITLE
ci: fix crash on arm testing

### DIFF
--- a/vsts-arm-test-steps.yml
+++ b/vsts-arm-test-steps.yml
@@ -69,6 +69,8 @@ steps:
     DISPLAY: ":99.0"
 
 - bash: |
+    # Next line needed to avoid crash on arm32
+    sudo gdk-pixbuf-query-loaders --update-cache
     cd src
     export ELECTRON_OUT_DIR=Default
     (cd electron && node script/yarn test -- --enable-logging)


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
This resolves the issue on our arm CI where it was crashing with the following error:
```
(electron:541): Gtk-WARNING **: 21:39:57.442: Could not load a pixbuf from 
/org/gtk/libgtk/icons/16x16/status/image-missing.png.
This may indicate that pixbuf loaders or the mime database could not be found.
**
Gtk:ERROR:../../../../gtk/gtkiconhelper.c:494:ensure_surface_for_gicon: assertion failed (error ==
NULL): Failed to load /org/gtk/libgtk/icons/16x16/status/image-missing.png: Unrecognized image 
file format (gdk-pixbuf-error-quark, 3)
```
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
