### PR TITLE
fix: load window-setup in sandboxed renderer

### DIFF
--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -165,6 +165,7 @@ auto_filenames = {
     "lib/renderer/web-view/web-view-element.ts",
     "lib/renderer/web-view/web-view-impl.ts",
     "lib/renderer/web-view/web-view-init.ts",
+    "lib/renderer/window-setup.ts",
     "lib/sandboxed_renderer/api/exports/electron.ts",
     "lib/sandboxed_renderer/api/module-list.ts",
     "lib/sandboxed_renderer/init.js",

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -75,8 +75,10 @@ const mergeBrowserWindowOptions = function (embedder, options) {
     }
   }
 
-  // Sets correct openerId here to give correct options to 'new-window' event handler
-  options.webPreferences.openerId = embedder.id
+  if (!webPreferences.nativeWindowOpen) {
+    // Sets correct openerId here to give correct options to 'new-window' event handler
+    options.webPreferences.openerId = embedder.id
+  }
 
   return options
 }

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -112,11 +112,15 @@ ipcMainUtils.handleSync('ELECTRON_BROWSER_SANDBOX_LOAD', async function (event) 
     contentScripts = getContentScripts()
   }
 
+  const webPreferences = event.sender.getLastWebPreferences() || {}
+
   return {
     contentScripts,
     preloadScripts: await Promise.all(preloadPaths.map(path => getPreloadScript(path))),
     isRemoteModuleEnabled: isRemoteModuleEnabled(event.sender),
     isWebViewTagEnabled: guestViewManager.isWebViewTagEnabled(event.sender),
+    guestInstanceId: webPreferences.guestInstanceId,
+    openerId: webPreferences.openerId,
     process: {
       arch: process.arch,
       platform: process.platform,

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -30,7 +30,13 @@ const { ipcRendererInternal } = require('@electron/internal/renderer/ipc-rendere
 const ipcRendererUtils = require('@electron/internal/renderer/ipc-renderer-internal-utils')
 
 const {
-  contentScripts, preloadScripts, isRemoteModuleEnabled, isWebViewTagEnabled, process: processProps
+  contentScripts,
+  preloadScripts,
+  isRemoteModuleEnabled,
+  isWebViewTagEnabled,
+  guestInstanceId,
+  openerId,
+  process: processProps
 } = ipcRendererUtils.invokeSync('ELECTRON_BROWSER_SANDBOX_LOAD')
 
 process.isRemoteModuleEnabled = isRemoteModuleEnabled
@@ -109,6 +115,11 @@ function preloadRequire (module) {
 const { hasSwitch } = process.electronBinding('command_line')
 
 const contextIsolation = hasSwitch('context-isolation')
+const isHiddenPage = hasSwitch('hidden-page')
+const usesNativeWindowOpen = true
+
+// The arguments to be passed to isolated world.
+const isolatedWorldArgs = { ipcRendererInternal, guestInstanceId, isHiddenPage, openerId, usesNativeWindowOpen }
 
 switch (window.location.protocol) {
   case 'devtools:': {
@@ -127,6 +138,10 @@ switch (window.location.protocol) {
     break
   }
   default: {
+    // Override default web functions.
+    const { windowSetup } = require('@electron/internal/renderer/window-setup')
+    windowSetup(guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
+
     // Inject content scripts.
     if (!process.electronBinding('features').isExtensionsEnabled()) {
       require('@electron/internal/renderer/content-scripts-injector')(contentScripts)
@@ -134,12 +149,15 @@ switch (window.location.protocol) {
   }
 }
 
-const guestInstanceId = binding.guestInstanceId && parseInt(binding.guestInstanceId)
-
 // Load webview tag implementation.
 if (process.isMainFrame) {
   const { webViewInit } = require('@electron/internal/renderer/web-view/web-view-init')
   webViewInit(contextIsolation, isWebViewTagEnabled, guestInstanceId)
+}
+
+// Pass the arguments to isolatedWorld.
+if (contextIsolation) {
+  v8Util.setHiddenValue(global, 'isolated-world-args', isolatedWorldArgs)
 }
 
 // Wrap the script into a function executed in global scope. It won't have

--- a/shell/renderer/atom_sandboxed_renderer_client.cc
+++ b/shell/renderer/atom_sandboxed_renderer_client.cc
@@ -141,12 +141,6 @@ void AtomSandboxedRendererClient::InitializeBindings(
   process.SetReadOnly("sandboxed", true);
   process.SetReadOnly("type", "renderer");
   process.SetReadOnly("isMainFrame", is_main_frame);
-
-  // Pass in CLI flags needed to setup the renderer
-  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  if (command_line->HasSwitch(switches::kGuestInstanceID))
-    b.Set(options::kGuestInstanceID,
-          command_line->GetSwitchValueASCII(switches::kGuestInstanceID));
 }
 
 void AtomSandboxedRendererClient::RenderFrameCreated(


### PR DESCRIPTION
#### Description of Change
Fixes the following issues in sandboxed renderers:
- `window.opener` is `null` when opened with `nativeWindowOpen: false`
- `window.prompt()` returns `null` instead of throwing an exception
- `document.visibilityState` is broken in sandboxed `<webview>`

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed an issue that could prevent communication between a sandboxed child window opened with `nativeWindowOpen: false` and an unsandboxed parent window. Also fixed `document.visibilityState` not working in sandboxed `<webview>`.