### PR TITLE
feat: bring back optional callbacks for WebFrame#executeJavaScript* methods

### DIFF
--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -122,13 +122,20 @@ by its key, which is returned from `webFrame.insertCSS(css)`.
 
 Inserts `text` to the focused element.
 
-### `webFrame.executeJavaScript(code[, userGesture])`
+### `webFrame.executeJavaScript(code[, userGesture, callback])`
 
 * `code` String
 * `userGesture` Boolean (optional) - Default is `false`.
+* `callback` Function (optional) - Called after script has been executed. Unless
+  the frame is suspended (e.g. showing a modal alert), execution will be
+  synchronous and the callback will be invoked before the method returns. For
+  compatibility with an older version of this method, the error parameter is
+  second.
+  * `result` Any
+  * `error` Error
 
-Returns `Promise<any>` - A promise that resolves with the result of the executed code
-or is rejected if the result of the code is a rejected promise.
+Returns `Promise<any>` - A promise that resolves with the result of the executed
+code or is rejected if execution throws or results in a rejected promise.
 
 Evaluates `code` in page.
 
@@ -136,14 +143,24 @@ In the browser window some HTML APIs like `requestFullScreen` can only be
 invoked by a gesture from the user. Setting `userGesture` to `true` will remove
 this limitation.
 
-### `webFrame.executeJavaScriptInIsolatedWorld(worldId, scripts[, userGesture])`
+### `webFrame.executeJavaScriptInIsolatedWorld(worldId, scripts[, userGesture, callback])`
 
-* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature.  You can provide any integer here.
+* `worldId` Integer - The ID of the world to run the javascript
+            in, `0` is the default main world (where content runs), `999` is the
+            world used by Electron's `contextIsolation` feature. Accepts values
+            in the range 1..536870911.
 * `scripts` [WebSource[]](structures/web-source.md)
 * `userGesture` Boolean (optional) - Default is `false`.
+* `callback` Function (optional) - Called after script has been executed. Unless
+  the frame is suspended (e.g. showing a modal alert), execution will be
+  synchronous and the callback will be invoked before the method returns.  For
+  compatibility with an older version of this method, the error parameter is
+  second.
+  * `result` Any
+  * `error` Error
 
-Returns `Promise<any>` - A promise that resolves with the result of the executed code
-or is rejected if the result of the code is a rejected promise.
+Returns `Promise<any>` - A promise that resolves with the result of the executed
+code or is rejected if execution throws or results in a rejected promise.
 
 Works like `executeJavaScript` but evaluates `scripts` in an isolated context.
 

--- a/spec/api-web-frame-spec.js
+++ b/spec/api-web-frame-spec.js
@@ -25,4 +25,116 @@ describe('webFrame module', function () {
   it('findFrameByRoutingId() does not crash when not found', () => {
     expect(webFrame.findFrameByRoutingId(-1)).to.be.null()
   })
+
+  describe('executeJavaScript', () => {
+    let childFrameElement, childFrame
+
+    before(() => {
+      childFrameElement = document.createElement('iframe')
+      document.body.appendChild(childFrameElement)
+      childFrame = webFrame.firstChild
+    })
+
+    after(() => {
+      childFrameElement.remove()
+    })
+
+    it('executeJavaScript() yields results via a promise and a sync callback', done => {
+      let callbackResult, callbackError
+
+      childFrame
+        .executeJavaScript('1 + 1', (result, error) => {
+          callbackResult = result
+          callbackError = error
+        })
+        .then(
+          promiseResult => {
+            expect(promiseResult).to.equal(2)
+            done()
+          },
+          promiseError => {
+            done(promiseError)
+          }
+        )
+
+      expect(callbackResult).to.equal(2)
+      expect(callbackError).to.be.undefined()
+    })
+
+    it('executeJavaScriptInIsolatedWorld() yields results via a promise and a sync callback', done => {
+      let callbackResult, callbackError
+
+      childFrame
+        .executeJavaScriptInIsolatedWorld(999, [{ code: '1 + 1' }], (result, error) => {
+          callbackResult = result
+          callbackError = error
+        })
+        .then(
+          promiseResult => {
+            expect(promiseResult).to.equal(2)
+            done()
+          },
+          promiseError => {
+            done(promiseError)
+          }
+        )
+
+      expect(callbackResult).to.equal(2)
+      expect(callbackError).to.be.undefined()
+    })
+
+    it('executeJavaScript() yields errors via a promise and a sync callback', done => {
+      let callbackResult, callbackError
+
+      childFrame
+        .executeJavaScript('thisShouldProduceAnError()', (result, error) => {
+          callbackResult = result
+          callbackError = error
+        })
+        .then(
+          promiseResult => {
+            done(new Error('error is expected'))
+          },
+          promiseError => {
+            expect(promiseError).to.be.an('error')
+            done()
+          }
+        )
+
+      expect(callbackResult).to.be.undefined()
+      expect(callbackError).to.be.an('error')
+    })
+
+    // executeJavaScriptInIsolatedWorld is failing to detect exec errors and is neither
+    // rejecting nor passing the error to the callback. This predates the reintroduction
+    // of the callback so will not be fixed as part of the callback PR
+    // if/when this is fixed the test can be uncommented.
+    //
+    // it('executeJavaScriptInIsolatedWorld() yields errors via a promise and a sync callback', done => {
+    //   let callbackResult, callbackError
+    //
+    //   childFrame
+    //     .executeJavaScriptInIsolatedWorld(999, [{ code: 'thisShouldProduceAnError()' }], (result, error) => {
+    //       callbackResult = result
+    //       callbackError = error
+    //     })
+    //     .then(
+    //       promiseResult => {
+    //         done(new Error('error is expected'))
+    //       },
+    //       promiseError => {
+    //         expect(promiseError).to.be.an('error')
+    //         done()
+    //       }
+    //     )
+    //
+    //   expect(callbackResult).to.be.undefined()
+    //   expect(callbackError).to.be.an('error')
+    // })
+
+    it('executeJavaScript(InIsolatedWorld) can be used without a callback', async () => {
+      expect(await webFrame.executeJavaScript('1 + 1')).to.equal(2)
+      expect(await webFrame.executeJavaScriptInIsolatedWorld(999, [{ code: '1 + 1' }])).to.equal(2)
+    })
+  })
 })


### PR DESCRIPTION
#### Description of Change

Before the promisification (#17312) of `WebFrame#executeJavaScript*` their interface was async (callback) but behavior (with some exceptions, e.g. page being suspended due to a modal alert) was sync (callback called before the methods returned). So they could be used in sync mode.

This PR brings back optional callbacks, which are invoked in addition to promise resolution.

Fixes #19161

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Allow an optional callback parameter for WebFrame.executeJavaScript* methods, which is called synchronously unless the target context is paused.