### PR TITLE
fix: hiding window menu should work on startup

### DIFF
--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -195,13 +195,14 @@ app.on('window-all-closed', () => {
   }
 })
 
-Promise.all([
-  import('@electron/internal/browser/default-menu'),
-  app.whenReady()
-]).then(([{ setDefaultApplicationMenu }]) => {
-  // Create default menu
-  setDefaultApplicationMenu()
-})
+const { setDefaultApplicationMenu } = require('@electron/internal/browser/default-menu')
+
+// Create default menu.
+//
+// Note that the task must be added before loading any app, so we can make sure
+// the call is maded before any user window is created, otherwise the default
+// menu may show even when user explicitly hides the menu.
+app.once('ready', setDefaultApplicationMenu)
 
 if (packagePath) {
   // Finally load app's main.js and transfer control to C++.

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1002,20 +1002,22 @@ void NativeWindowViews::SetFocusable(bool focusable) {
 
 void NativeWindowViews::SetMenu(AtomMenuModel* menu_model) {
 #if defined(USE_X11)
-  if (menu_model == nullptr) {
+  // Remove global menu bar.
+  if (global_menu_bar_ && menu_model == nullptr) {
     global_menu_bar_.reset();
     root_view_->UnregisterAcceleratorsWithFocusManager();
     return;
   }
 
-  if (!global_menu_bar_ && ShouldUseGlobalMenuBar())
-    global_menu_bar_ = std::make_unique<GlobalMenuBarX11>(this);
-
   // Use global application menu bar when possible.
-  if (global_menu_bar_ && global_menu_bar_->IsServerStarted()) {
-    root_view_->RegisterAcceleratorsWithFocusManager(menu_model);
-    global_menu_bar_->SetMenu(menu_model);
-    return;
+  if (ShouldUseGlobalMenuBar()) {
+    if (!global_menu_bar_)
+      global_menu_bar_ = std::make_unique<GlobalMenuBarX11>(this);
+    if (global_menu_bar_->IsServerStarted()) {
+      root_view_->RegisterAcceleratorsWithFocusManager(menu_model);
+      global_menu_bar_->SetMenu(menu_model);
+      return;
+    }
   }
 #endif
 

--- a/spec-main/api-menu-spec.ts
+++ b/spec-main/api-menu-spec.ts
@@ -4,6 +4,7 @@ import { expect } from 'chai'
 import { BrowserWindow, Menu, MenuItem } from 'electron'
 import { sortMenuItems } from '../lib/browser/api/menu-utils'
 import { emittedOnce } from './events-helpers'
+import { ifit } from './spec-helpers'
 import { closeWindow } from './window-helpers'
 
 const fixturesPath = path.resolve(__dirname, 'fixtures')
@@ -870,7 +871,7 @@ describe('Menu module', function () {
       expect(Menu.getApplicationMenu()).to.be.null('application menu')
     })
 
-    it('does not override menu visibility on startup', async () => {
+    ifit(process.platform !== 'darwin')('does not override menu visibility on startup', async () => {
       const appPath = path.join(fixturesPath, 'api', 'test-menu-visibility')
       const appProcess = cp.spawn(process.execPath, [appPath])
 
@@ -881,7 +882,7 @@ describe('Menu module', function () {
       expect(output).to.include('Window has no menu')
     })
 
-    it('does not override null menu on startup', async () => {
+    ifit(process.platform !== 'darwin')('does not override null menu on startup', async () => {
       const appPath = path.join(fixturesPath, 'api', 'test-menu-null')
       const appProcess = cp.spawn(process.execPath, [appPath])
 

--- a/spec-main/api-menu-spec.ts
+++ b/spec-main/api-menu-spec.ts
@@ -880,5 +880,16 @@ describe('Menu module', function () {
       await emittedOnce(appProcess, 'close')
       expect(output).to.include('Window has no menu')
     })
+
+    it('does not override null menu on startup', async () => {
+      const appPath = path.join(fixturesPath, 'api', 'test-menu-null')
+      const appProcess = cp.spawn(process.execPath, [appPath])
+
+      let output = ''
+      appProcess.stdout.on('data', data => { output += data })
+
+      await emittedOnce(appProcess, 'close')
+      expect(output).to.include('Window has no menu')
+    })
   })
 })

--- a/spec-main/api-menu-spec.ts
+++ b/spec-main/api-menu-spec.ts
@@ -1,7 +1,12 @@
+import * as cp from 'child_process'
+import * as path from 'path'
 import { expect } from 'chai'
 import { BrowserWindow, Menu, MenuItem } from 'electron'
 import { sortMenuItems } from '../lib/browser/api/menu-utils'
+import { emittedOnce } from './events-helpers'
 import { closeWindow } from './window-helpers'
+
+const fixturesPath = path.resolve(__dirname, 'fixtures')
 
 describe('Menu module', function () {
   this.timeout(5000)
@@ -863,6 +868,17 @@ describe('Menu module', function () {
     it('unsets a menu with null', () => {
       Menu.setApplicationMenu(null)
       expect(Menu.getApplicationMenu()).to.be.null('application menu')
+    })
+
+    it('does not override menu visibility on startup', async () => {
+      const appPath = path.join(fixturesPath, 'api', 'test-menu-visibility')
+      const appProcess = cp.spawn(process.execPath, [appPath])
+
+      let output = ''
+      appProcess.stdout.on('data', data => { output += data })
+
+      await emittedOnce(appProcess, 'close')
+      expect(output).to.include('Window has no menu')
     })
   })
 })

--- a/spec-main/fixtures/api/test-menu-null/main.js
+++ b/spec-main/fixtures/api/test-menu-null/main.js
@@ -1,0 +1,17 @@
+const { app, BrowserWindow } = require('electron')
+
+let win
+app.on('ready', function () {
+  win = new BrowserWindow({})
+  win.loadURL('about:blank')
+  win.setMenu(null)
+
+  setTimeout(() => {
+    if (win.isMenuBarVisible()) {
+      console.log('Window has a menu')
+    } else {
+      console.log('Window has no menu')
+    }
+    app.quit()
+  })
+})

--- a/spec-main/fixtures/api/test-menu-null/package.json
+++ b/spec-main/fixtures/api/test-menu-null/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "electron-test-menu",
+  "main": "main.js"
+}

--- a/spec-main/fixtures/api/test-menu-visibility/main.js
+++ b/spec-main/fixtures/api/test-menu-visibility/main.js
@@ -1,0 +1,17 @@
+const { app, BrowserWindow } = require('electron')
+
+let win
+app.on('ready', function () {
+  win = new BrowserWindow({})
+  win.loadURL('about:blank')
+  win.setMenuBarVisibility(false)
+
+  setTimeout(() => {
+    if (win.isMenuBarVisible()) {
+      console.log('Window has a menu')
+    } else {
+      console.log('Window has no menu')
+    }
+    app.quit()
+  })
+})

--- a/spec-main/fixtures/api/test-menu-visibility/package.json
+++ b/spec-main/fixtures/api/test-menu-visibility/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "electron-test-menu",
+  "main": "main.js"
+}


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/21088.

This PR fixes 2 problems:
* `setDefaultApplicationMenu` was called too late and it overwrote the menu set by users.
* `setMenu(null)` was not working on Linux when global menubar is not used.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix window menu unable to hide on startup.