### PR TITLE
[wip] feat: refresh in-app receipts when fetching products

### DIFF
--- a/shell/browser/mac/in_app_purchase_product.mm
+++ b/shell/browser/mac/in_app_purchase_product.mm
@@ -55,12 +55,20 @@
  * @param productIDs - The products' id to fetch.
  */
 - (void)getProducts:(NSSet*)productIDs {
-  SKProductsRequest* productsRequest;
-  productsRequest =
+  SKProductsRequest* productsRequest =
       [[SKProductsRequest alloc] initWithProductIdentifiers:productIDs];
 
   productsRequest.delegate = self;
   [productsRequest start];
+}
+
+/**
+ * Refresh the receipt for a given product.
+ */
+- (void)refreshReceipt {
+  SKReceiptRefreshRequest* request = [[SKReceiptRefreshRequest alloc] init];
+  [request setDelegate:self];
+  [request start];
 }
 
 /**
@@ -171,6 +179,9 @@ void GetProducts(const std::vector<std::string>& productIDs,
                  InAppPurchaseProductsCallback callback) {
   auto* iapProduct =
       [[InAppPurchaseProduct alloc] initWithCallback:std::move(callback)];
+
+  // Refresh the app's receipts
+  [iapProduct refreshReceipt];
 
   // Convert the products' id to NSSet.
   NSMutableSet* productsIDSet =


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/21435.

This change ensures that in-app-purchase App Store receipts for macOS are refreshed when a user calls `inAppPurchase.getProducts`.

cc @MarshallOfSound @miniak 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Ensured that in-app receipts are refreshed when fetching products on macOS.
