### PR TITLE
fix: name and expirationDate should be optional when setting cookie

### DIFF
--- a/shell/browser/api/atom_api_cookies.cc
+++ b/shell/browser/api/atom_api_cookies.cc
@@ -265,18 +265,11 @@ v8::Local<v8::Promise> Cookies::Set(base::DictionaryValue details) {
     return handle;
   }
 
-  if (!name || name->empty()) {
-    promise.RejectWithErrorMessage(
-        InclusionStatusToString(net::CanonicalCookie::CookieInclusionStatus(
-            net::CanonicalCookie::CookieInclusionStatus::
-                EXCLUDE_FAILURE_TO_STORE)));
-    return handle;
-  }
-
   auto canonical_cookie = net::CanonicalCookie::CreateSanitizedCookie(
-      url, *name, value ? *value : "", domain ? *domain : "", path ? *path : "",
-      creation_time, expiration_time, last_access_time, secure, http_only,
-      net::CookieSameSite::NO_RESTRICTION, net::COOKIE_PRIORITY_DEFAULT);
+      url, name ? *name : "", value ? *value : "", domain ? *domain : "",
+      path ? *path : "", creation_time, expiration_time, last_access_time,
+      secure, http_only, net::CookieSameSite::NO_RESTRICTION,
+      net::COOKIE_PRIORITY_DEFAULT);
   if (!canonical_cookie || !canonical_cookie->IsCanonical()) {
     promise.RejectWithErrorMessage(
         InclusionStatusToString(net::CanonicalCookie::CookieInclusionStatus(

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -591,7 +591,8 @@ describe('net module', () => {
         customSession.cookies.set({
           url: `${serverUrl}`,
           name: 'test',
-          value: '11111'
+          value: '11111',
+          expirationDate: 0
         }).then(() => { // resolved
           const urlRequest = net.request({
             method: 'GET',

--- a/spec-main/api-session-spec.ts
+++ b/spec-main/api-session-spec.ts
@@ -88,8 +88,10 @@ describe('session module', () => {
       const value = '1'
 
       await cookies.set({ url, name, value, expirationDate: (+new Date()) / 1000 + 120 })
-      const cs = await cookies.get({ url })
-      expect(cs.some(c => c.name === name && c.value === value)).to.equal(true)
+      const c = (await cookies.get({ url }))[0]
+      expect(c.name).to.equal(name)
+      expect(c.value).to.equal(value)
+      expect(c.session).to.equal(false)
     })
 
     it('sets session cookies', async () => {
@@ -98,8 +100,10 @@ describe('session module', () => {
       const value = '1'
 
       await cookies.set({ url, name, value })
-      const cs = await cookies.get({ url })
-      expect(cs.some(c => c.name === name && c.value === value)).to.equal(true)
+      const c = (await cookies.get({ url }))[0]
+      expect(c.name).to.equal(name)
+      expect(c.value).to.equal(value)
+      expect(c.session).to.equal(true)
     })
 
     it('sets cookies without name', async () => {

--- a/spec-main/api-session-spec.ts
+++ b/spec-main/api-session-spec.ts
@@ -83,6 +83,16 @@ describe('session module', () => {
       expect(cs.some(c => c.name === name && c.value === value)).to.equal(true)
     })
 
+    it('sets session cookies', async () => {
+      const { cookies } = session.defaultSession
+      const name = '2'
+      const value = '1'
+
+      await cookies.set({ url, name, value })
+      const cs = await cookies.get({ url })
+      expect(cs.some(c => c.name === name && c.value === value)).to.equal(true)
+    })
+
     it('gets cookies without url', async () => {
       const { cookies } = session.defaultSession
       const name = '1'

--- a/spec-main/api-session-spec.ts
+++ b/spec-main/api-session-spec.ts
@@ -58,6 +58,15 @@ describe('session module', () => {
     const value = '0'
     afterEach(closeAllWindows)
 
+    // Clear cookie of defaultSession after each test.
+    afterEach(async () => {
+      const { cookies } = session.defaultSession
+      const cs = await cookies.get({ url })
+      for (const c of cs) {
+        await cookies.remove(url, c.name)
+      }
+    })
+
     it('should get cookies', async () => {
       const server = http.createServer((req, res) => {
         res.setHeader('Set-Cookie', [`${name}=${value}`])

--- a/spec-main/api-session-spec.ts
+++ b/spec-main/api-session-spec.ts
@@ -111,8 +111,9 @@ describe('session module', () => {
       const value = '3'
 
       await cookies.set({ url, value })
-      const cs = await cookies.get({ url })
-      expect(cs.some(c => c.name === '' && c.value === value)).to.equal(true)
+      const c = (await cookies.get({ url }))[0]
+      expect(c.name).to.be.empty()
+      expect(c.value).to.equal(value)
     })
 
     it('gets cookies without url', async () => {

--- a/spec-main/api-session-spec.ts
+++ b/spec-main/api-session-spec.ts
@@ -93,6 +93,15 @@ describe('session module', () => {
       expect(cs.some(c => c.name === name && c.value === value)).to.equal(true)
     })
 
+    it('sets cookies without name', async () => {
+      const { cookies } = session.defaultSession
+      const value = '3'
+
+      await cookies.set({ url, value })
+      const cs = await cookies.get({ url })
+      expect(cs.some(c => c.name === '' && c.value === value)).to.equal(true)
+    })
+
     it('gets cookies without url', async () => {
       const { cookies } = session.defaultSession
       const name = '1'


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/20688.

According to our docs of cookies API (which is derived from Chrome extension's cookies API), the `name` should be optional.

And for `expirationDate`, it should pass `base::Time()` when the option is omitted:
https://cs.chromium.org/chromium/src/chrome/browser/extensions/api/cookies/cookies_api.cc?sq=package:chromium&g=0&l=384
Otherwise it would set a cookie the expires now instead of setting a session cookie, and as result `cookies.set` API does not work correctly without setting `expirationDate`.

This is a regression since 7.x.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix `cookies.set` not working correctly when `name` or `expirationDate` is omitted.