### PR TITLE
fix: restore accessibility window title on macOS

### DIFF
--- a/shell/browser/ui/cocoa/atom_ns_window.mm
+++ b/shell/browser/ui/cocoa/atom_ns_window.mm
@@ -103,8 +103,6 @@ bool ScopedDisableResize::disable_resize_ = false;
 }
 
 - (id)accessibilityAttributeValue:(NSString*)attribute {
-  if ([attribute isEqual:NSAccessibilityTitleAttribute])
-    return base::SysUTF8ToNSString(shell_->GetTitle());
   if ([attribute isEqual:NSAccessibilityEnabledAttribute])
     return [NSNumber numberWithBool:YES];
   if (![attribute isEqualToString:@"AXChildren"])
@@ -123,6 +121,10 @@ bool ScopedDisableResize::disable_resize_ = false;
 
   NSArray* children = [super accessibilityAttributeValue:attribute];
   return [children filteredArrayUsingPredicate:predicate];
+}
+
+- (NSString*)accessibilityTitle {
+  return base::SysUTF8ToNSString(shell_->GetTitle());
 }
 
 - (BOOL)canBecomeMainWindow {


### PR DESCRIPTION
#### Description of Change

Electron's `AtomNSWindow` [implements](https://github.com/electron/electron/blob/a6d142a112ccc0cecd33c83ff59479f4485614ba/shell/browser/ui/cocoa/atom_ns_window.mm#L105) `accessibilityAttributeValue` to provide various accessibility info to the OS, including window titles.

Chromium 75 [changed to](https://chromium.googlesource.com/chromium/src/+/69a6b7a326b993bb2faa33ae93ccc80101719d35%5E%21/) Apple's [newer accessibility API](https://developer.apple.com/documentation/appkit/nsaccessibility?language=objc) for window titles in the super class that `AtomNSWindow` inherits from. macOS still supports both the old and new style APIs, but it will prefer the new style if it is implemented. This means the Electron window title is being ignored because the newer API at the Chromium level has taken precedence.

By implementing the newer accessibility API in `AtomNSWindow`, this restores correct accessibility window titles in macOS Electron apps. VS Code is [known to be affected](https://github.com/microsoft/vscode/issues/84195), but presumably all Electron apps have a similar issue.

This is a regression that has been present since Electron 6.0.0 (the first release including the Chromium change above).

It looks like @codebytere has modified these files in the past, potentially they are interested.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed accessibility window title on macOS