### PR TITLE
fix: restore POST forms that open a new window with target=_blank

### DIFF
--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -256,14 +256,22 @@ v8::Local<v8::Value> Converter<network::ResourceRequestBody>::ToV8(
     gin::Dictionary upload_data(isolate, v8::Object::New(isolate));
     switch (element.type()) {
       case network::mojom::DataElementType::kFile:
+        upload_data.Set("type", "file");
         upload_data.Set("file", element.path().value());
+        upload_data.Set("filePath", base::Value(element.path().AsUTF8Unsafe()));
+        upload_data.Set("offset", static_cast<int>(element.offset()));
+        upload_data.Set("length", static_cast<int>(element.length()));
+        upload_data.Set("modificationTime",
+                        element.expected_modification_time().ToDoubleT());
         break;
       case network::mojom::DataElementType::kBytes:
+        upload_data.Set("type", "rawData");
         upload_data.Set("bytes", node::Buffer::Copy(isolate, element.bytes(),
                                                     element.length())
                                      .ToLocalChecked());
         break;
       case network::mojom::DataElementType::kDataPipe: {
+        upload_data.Set("type", "blob");
         // TODO(zcbenz): After the NetworkService refactor, the old blobUUID API
         // becomes unecessarily complex, we should deprecate the getBlobData API
         // and return the DataPipeHolder wrapper directly.

--- a/spec/fixtures/pages/form-with-data.html
+++ b/spec/fixtures/pages/form-with-data.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+  <form id="form" method="post">
+    <input name="greeting" value="hello">
+    <input type="submit" value="submit">
+  </form>
+</body>
+</html>


### PR DESCRIPTION
#### Description of Change
Fix a regression introduced in #20719 that caused HTML form submissions to not actually POST data when using `target=_blank`. The original implementation in that PR was in `shell/common/native_mate_converters/network_converter.cc`. Not sure if the removal of those fields was intentional or an oversight. @zcbenz to advise.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed POST-ing HTML forms with target=_blank.
