### PR TITLE
fix: avoid Electron.dsym files in the main app bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ env-release-build: &env-release-build
   GN_CONFIG: //electron/build/args/release.gn
   STRIP_BINARIES: true
   GENERATE_SYMBOLS: true
+  CHECK_DIST_MANIFEST: '1'
 
 env-headless-testing: &env-headless-testing
   DISPLAY: ':99.0'

--- a/build/zip.py
+++ b/build/zip.py
@@ -16,6 +16,10 @@ PATHS_TO_SKIP = [
   './libVkICD_mock_', #Skipping because these are outputs that we don't need
   './VkICD_mock_', #Skipping because these are outputs that we don't need
 
+  # Skipping because its an output of create_bundle from //build/config/mac/rules.gni
+  # that we don't need
+  'Electron.dSYM',
+
   # //chrome/browser:resources depends on this via
   # //chrome/browser/resources/ssl/ssl_error_assistant, but we don't need to
   # ship it.
@@ -51,14 +55,13 @@ def main(argv):
   with open(runtime_deps) as f:
     for dep in f.readlines():
       dep = dep.strip()
-      dist_files.add(dep)
+      if not skip_path(dep, dist_zip, target_cpu):
+        dist_files.add(dep)
   if sys.platform == 'darwin':
     execute(['zip', '-r', '-y', dist_zip] + list(dist_files))
   else:
     with zipfile.ZipFile(dist_zip, 'w', zipfile.ZIP_DEFLATED, allowZip64=True) as z:
       for dep in dist_files:
-        if skip_path(dep, dist_zip, target_cpu):
-          continue
         if os.path.isdir(dep):
           for root, dirs, files in os.walk(dep):
             for file in files:


### PR DESCRIPTION
#### Description of Change

Backports https://github.com/electron/electron/pull/21447

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: remove Electron.dsym from macOS application zip