### PR TITLE
fix: quit after Chromium is fully started

### DIFF
--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -26,6 +26,23 @@
 
 namespace electron {
 
+namespace {
+
+// Call |quit| after Chromium is fully started.
+//
+// This is important for quitting immediately in the "ready" event, when
+// certain initialization task may still be pending, and quitting at that time
+// could end up with crash on exit.
+void RunQuitClosure(base::OnceClosure quit) {
+  // Consume remaining tasks in message loop.
+  base::RunLoop().RunUntilIdle();
+  // On Linux/Windows the "ready" event is emitted in "PreMainMessageLoopRun",
+  // make sure we quit after message loop has run for once.
+  base::ThreadTaskRunnerHandle::Get()->PostTask(FROM_HERE, std::move(quit));
+}
+
+}  // namespace
+
 Browser::LoginItemSettings::LoginItemSettings() = default;
 Browser::LoginItemSettings::~LoginItemSettings() = default;
 Browser::LoginItemSettings::LoginItemSettings(const LoginItemSettings& other) =
@@ -94,7 +111,7 @@ void Browser::Shutdown() {
     observer.OnQuit();
 
   if (quit_main_message_loop_) {
-    std::move(quit_main_message_loop_).Run();
+    RunQuitClosure(std::move(quit_main_message_loop_));
   } else {
     // There is no message loop available so we are in early stage, wait until
     // the quit_main_message_loop_ is available.
@@ -189,7 +206,7 @@ void Browser::PreMainMessageLoopRun() {
 
 void Browser::SetMainMessageLoopQuitClosure(base::OnceClosure quit_closure) {
   if (is_shutdown_)
-    std::move(quit_closure).Run();
+    RunQuitClosure(std::move(quit_closure));
   else
     quit_main_message_loop_ = std::move(quit_closure);
 }

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -34,8 +34,6 @@ namespace {
 // certain initialization task may still be pending, and quitting at that time
 // could end up with crash on exit.
 void RunQuitClosure(base::OnceClosure quit) {
-  // Consume remaining tasks in message loop.
-  base::RunLoop().RunUntilIdle();
   // On Linux/Windows the "ready" event is emitted in "PreMainMessageLoopRun",
   // make sure we quit after message loop has run for once.
   base::ThreadTaskRunnerHandle::Get()->PostTask(FROM_HERE, std::move(quit));

--- a/spec-main/fixtures/api/leak-exit-webcontentsview.js
+++ b/spec-main/fixtures/api/leak-exit-webcontentsview.js
@@ -3,5 +3,5 @@ app.on('ready', function () {
   const web = webContents.create({})
   new WebContentsView(web)  // eslint-disable-line
 
-  process.nextTick(() => app.quit())
+  app.quit()
 })

--- a/spec/fixtures/api/command-line/main.js
+++ b/spec/fixtures/api/command-line/main.js
@@ -9,7 +9,5 @@ app.on('ready', () => {
   process.stdout.write(JSON.stringify(payload))
   process.stdout.end()
 
-  setImmediate(() => {
-    app.quit()
-  })
+  app.quit()
 })

--- a/spec/fixtures/api/cookie-app/main.js
+++ b/spec/fixtures/api/cookie-app/main.js
@@ -42,8 +42,6 @@ app.on('ready', async function () {
   } finally {
     process.stdout.end()
 
-    setImmediate(() => {
-      app.quit()
-    })
+    app.quit()
   }
 })

--- a/spec/fixtures/api/ipc-main-listeners/main.js
+++ b/spec/fixtures/api/ipc-main-listeners/main.js
@@ -4,7 +4,5 @@ app.on('ready', () => {
   process.stdout.write(JSON.stringify(ipcMain.eventNames()))
   process.stdout.end()
 
-  setImmediate(() => {
-    app.quit()
-  })
+  app.quit()
 })

--- a/spec/fixtures/api/leak-exit-browserview.js
+++ b/spec/fixtures/api/leak-exit-browserview.js
@@ -2,5 +2,5 @@ const { BrowserView, app } = require('electron')
 app.on('ready', function () {
   new BrowserView({})  // eslint-disable-line
 
-  process.nextTick(() => app.quit())
+  app.quit()
 })

--- a/spec/fixtures/api/leak-exit-webcontents.js
+++ b/spec/fixtures/api/leak-exit-webcontents.js
@@ -2,5 +2,5 @@ const { app, webContents } = require('electron')
 app.on('ready', function () {
   webContents.create({})
 
-  process.nextTick(() => app.quit())
+  app.quit()
 })

--- a/spec/fixtures/api/locale-check/main.js
+++ b/spec/fixtures/api/locale-check/main.js
@@ -4,7 +4,5 @@ app.on('ready', () => {
   process.stdout.write(app.getLocale())
   process.stdout.end()
 
-  setImmediate(() => {
-    app.quit()
-  })
+  app.quit()
 })


### PR DESCRIPTION
#### Description of Change

Flush pending tasks before quitting Electron.

This is to fix crash on exit which happens when Electron quits while there are still some initialization work pending in message loop.

This should be able to fix some flaky tests on CI.

This does not completely fix the flaky tests that destroy WebContents, which I believe have other reasons for crashing.

#### Release Notes

Notes: no-notes