### PR TITLE
fix: enforce parent-child relationship in custom postMessage() handler

### DIFF
--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -289,8 +289,8 @@ const handleMessageSync = function (channel, handler) {
   ipcMainUtils.handleSync(channel, makeSafeHandler(handler))
 }
 
-const assertCanAccessWindow = function (contents, guestContents) {
-  if (!canAccessWindow(contents, guestContents)) {
+const securityCheck = function (contents, guestContents, check) {
+  if (!check(contents, guestContents)) {
     console.error(`Blocked ${contents.getURL()} from accessing guestId: ${guestContents.id}`)
     throw new Error(`Access denied to guestId: ${guestContents.id}`)
   }
@@ -303,7 +303,7 @@ const windowMethods = new Set([
 ])
 
 handleMessage('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_METHOD', (event, guestContents, method, ...args) => {
-  assertCanAccessWindow(event.sender, guestContents)
+  securityCheck(event.sender, guestContents, canAccessWindow)
 
   if (!windowMethods.has(method)) {
     console.error(`Blocked ${event.sender.getURL()} from calling method: ${method}`)
@@ -321,6 +321,8 @@ handleMessage('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', (event, guestC
   // The W3C does not seem to have word on how postMessage should work when the
   // origins do not match, so we do not do |canAccessWindow| check here since
   // postMessage across origins is useful and not harmful.
+  securityCheck(event.sender, guestContents, isRelatedWindow)
+
   if (targetOrigin === '*' || isSameOrigin(guestContents.getURL(), targetOrigin)) {
     const sourceId = event.sender.id
     guestContents._sendInternal('ELECTRON_GUEST_WINDOW_POSTMESSAGE', sourceId, message, sourceOrigin)
@@ -334,7 +336,7 @@ const webContentsMethodsAsync = new Set([
 ])
 
 handleMessage('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', (event, guestContents, method, ...args) => {
-  assertCanAccessWindow(event.sender, guestContents)
+  securityCheck(event.sender, guestContents, canAccessWindow)
 
   if (!webContentsMethodsAsync.has(method)) {
     console.error(`Blocked ${event.sender.getURL()} from calling method: ${method}`)
@@ -349,7 +351,7 @@ const webContentsMethodsSync = new Set([
 ])
 
 handleMessageSync('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', (event, guestContents, method, ...args) => {
-  assertCanAccessWindow(event.sender, guestContents)
+  securityCheck(event.sender, guestContents, canAccessWindow)
 
   if (!webContentsMethodsSync.has(method)) {
     console.error(`Blocked ${event.sender.getURL()} from calling method: ${method}`)


### PR DESCRIPTION
#### Description of Change
Adding missing child-parent relationship enforcement in the `ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE` handler.

Follow-up to #19077

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes