### PR TITLE
refactor: export internalWindowOpen from guest-window-manager

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -7,6 +7,7 @@ const path = require('path')
 const url = require('url')
 const { app, ipcMain, session, deprecate } = electron
 
+const { internalWindowOpen } = require('@electron/internal/browser/guest-window-manager')
 const NavigationController = require('@electron/internal/browser/navigation-controller')
 const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
 const ipcMainUtils = require('@electron/internal/browser/ipc-main-internal-utils')
@@ -397,9 +398,7 @@ WebContents.prototype._init = function () {
         width: 800,
         height: 600
       }
-      ipcMainInternal.emit('ELECTRON_GUEST_WINDOW_MANAGER_INTERNAL_WINDOW_OPEN',
-        event, url, referrer, frameName, disposition,
-        options, additionalFeatures, postData)
+      internalWindowOpen(event, url, referrer, frameName, disposition, options, additionalFeatures, postData)
     })
 
     // Create a new browser window for the native implementation of
@@ -421,8 +420,7 @@ WebContents.prototype._init = function () {
         webContents
       }
       const referrer = { url: '', policy: 'default' }
-      ipcMainInternal.emit('ELECTRON_GUEST_WINDOW_MANAGER_INTERNAL_WINDOW_OPEN',
-        event, url, referrer, frameName, disposition, options)
+      internalWindowOpen(event, url, referrer, frameName, disposition, options)
     })
   }
 

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { BrowserWindow, webContents } = require('electron')
+const electron = require('electron')
+const { BrowserWindow } = electron
 const { isSameOrigin } = process.electronBinding('v8_util')
 const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
 const ipcMainUtils = require('@electron/internal/browser/ipc-main-internal-utils')
@@ -244,13 +245,11 @@ ipcMainInternal.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', (event, url, fra
   }
 
   const referrer = { url: '', policy: 'default' }
-  ipcMainInternal.emit('ELECTRON_GUEST_WINDOW_MANAGER_INTERNAL_WINDOW_OPEN', event,
-    url, referrer, frameName, disposition, options, additionalFeatures)
+  internalWindowOpen(event, url, referrer, frameName, disposition, options, additionalFeatures)
 })
 
 // Routed window.open messages with fully parsed options
-ipcMainInternal.on('ELECTRON_GUEST_WINDOW_MANAGER_INTERNAL_WINDOW_OPEN', function (event, url, referrer,
-  frameName, disposition, options, additionalFeatures, postData) {
+function internalWindowOpen (event, url, referrer, frameName, disposition, options, additionalFeatures, postData) {
   options = mergeBrowserWindowOptions(event.sender, options)
   event.sender.emit('new-window', event, url, frameName, disposition, options, additionalFeatures, referrer)
   const { newGuest } = event
@@ -268,11 +267,12 @@ ipcMainInternal.on('ELECTRON_GUEST_WINDOW_MANAGER_INTERNAL_WINDOW_OPEN', functio
   } else {
     event.returnValue = createGuest(event.sender, url, referrer, frameName, options, postData)
   }
-})
+}
 
 const makeSafeHandler = function (handler) {
   return (event, guestId, ...args) => {
-    const guestContents = webContents.fromId(guestId)
+    // Access webContents via electron to prevent circular require.
+    const guestContents = electron.webContents.fromId(guestId)
     if (!guestContents) {
       throw new Error(`Invalid guestId: ${guestId}`)
     }
@@ -360,3 +360,5 @@ handleMessageSync('ELECTRON_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', (event, g
 
   return guestContents[method](...args)
 })
+
+exports.internalWindowOpen = internalWindowOpen


### PR DESCRIPTION
#### Description of Change
Remove the `ELECTRON_GUEST_WINDOW_MANAGER_INTERNAL_WINDOW_OPEN` handler to decrease the IPC attack surface.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes