### PR TITLE
fix: avoid contextBridge crash when RenderFrame address is reused

### DIFF
--- a/shell/renderer/api/atom_api_context_bridge.cc
+++ b/shell/renderer/api/atom_api_context_bridge.cc
@@ -47,20 +47,12 @@ content::RenderFrame* GetRenderFrame(const v8::Local<v8::Object>& value) {
   return content::RenderFrame::FromWebFrame(frame);
 }
 
-std::map<content::RenderFrame*, context_bridge::RenderFramePersistenceStore*>&
-GetStoreMap() {
-  static base::NoDestructor<std::map<
-      content::RenderFrame*, context_bridge::RenderFramePersistenceStore*>>
-      store_map;
-  return *store_map;
-}
-
 context_bridge::RenderFramePersistenceStore* GetOrCreateStore(
     content::RenderFrame* render_frame) {
-  auto it = GetStoreMap().find(render_frame);
-  if (it == GetStoreMap().end()) {
+  auto it = context_bridge::GetStoreMap().find(render_frame->GetRoutingID());
+  if (it == context_bridge::GetStoreMap().end()) {
     auto* store = new context_bridge::RenderFramePersistenceStore(render_frame);
-    GetStoreMap().emplace(render_frame, store);
+    context_bridge::GetStoreMap().emplace(render_frame->GetRoutingID(), store);
     return store;
   }
   return it->second;

--- a/shell/renderer/api/context_bridge/render_frame_context_bridge_store.cc
+++ b/shell/renderer/api/context_bridge/render_frame_context_bridge_store.cc
@@ -66,6 +66,12 @@ class CachedProxyLifeMonitor final : public ObjectLifeMonitor {
 
 }  // namespace
 
+std::map<int32_t, RenderFramePersistenceStore*>& GetStoreMap() {
+  static base::NoDestructor<std::map<int32_t, RenderFramePersistenceStore*>>
+      store_map;
+  return *store_map;
+}
+
 WeakGlobalPairNode::WeakGlobalPairNode(WeakGlobalPair pair) {
   this->pair = std::move(pair);
 }
@@ -78,11 +84,13 @@ WeakGlobalPairNode::~WeakGlobalPairNode() {
 
 RenderFramePersistenceStore::RenderFramePersistenceStore(
     content::RenderFrame* render_frame)
-    : content::RenderFrameObserver(render_frame) {}
+    : content::RenderFrameObserver(render_frame),
+      routing_id_(render_frame->GetRoutingID()) {}
 
 RenderFramePersistenceStore::~RenderFramePersistenceStore() = default;
 
 void RenderFramePersistenceStore::OnDestruct() {
+  GetStoreMap().erase(routing_id_);
   delete this;
 }
 

--- a/shell/renderer/api/context_bridge/render_frame_context_bridge_store.h
+++ b/shell/renderer/api/context_bridge/render_frame_context_bridge_store.h
@@ -58,7 +58,7 @@ class RenderFramePersistenceStore final : public content::RenderFrameObserver {
   // proxy maps are weak globals, i.e. these are not retained beyond
   // there normal JS lifetime.  You must check IsEmpty()
 
-  int32_t routing_id_;
+  const int32_t routing_id_;
 
   // object_identity ==> [from_value, proxy_value]
   std::map<int, WeakGlobalPairNode*> proxy_map_;

--- a/shell/renderer/api/context_bridge/render_frame_context_bridge_store.h
+++ b/shell/renderer/api/context_bridge/render_frame_context_bridge_store.h
@@ -58,10 +58,14 @@ class RenderFramePersistenceStore final : public content::RenderFrameObserver {
   // proxy maps are weak globals, i.e. these are not retained beyond
   // there normal JS lifetime.  You must check IsEmpty()
 
+  int32_t routing_id_;
+
   // object_identity ==> [from_value, proxy_value]
   std::map<int, WeakGlobalPairNode*> proxy_map_;
   base::WeakPtrFactory<RenderFramePersistenceStore> weak_factory_{this};
 };
+
+std::map<int32_t, RenderFramePersistenceStore*>& GetStoreMap();
 
 }  // namespace context_bridge
 


### PR DESCRIPTION
#### Description of Change
Fix a crash that was happening because 
a) the RenderFramePersistenceStore map was keyed on a pointer, which are not guaranteed to be unique in the process and
b) the RenderFramePersistanceStore was not removing itself from the map when it was released, causing a bad access exception.

h/t @nornagon for help debugging.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed contextBridge crash when opening and closing many windows.
