### PR TITLE
fix: enforce parent-child relationship in custom postMessage() handler

### DIFF
--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -317,6 +317,11 @@ ipcMainInternal.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', function 
   // The W3C does not seem to have word on how postMessage should work when the
   // origins do not match, so we do not do |canAccessWindow| check here since
   // postMessage across origins is useful and not harmful.
+  if (!isRelatedWindow(event.sender, guestContents)) {
+    console.error(`Blocked ${event.sender.getURL()} from calling postMessage.`)
+    return
+  }
+
   if (targetOrigin === '*' || isSameOrigin(guestContents.getURL(), targetOrigin)) {
     const sourceId = event.sender.id
     guestContents._sendInternal('ELECTRON_GUEST_WINDOW_POSTMESSAGE', sourceId, message, sourceOrigin)


### PR DESCRIPTION
Backport of #21496

See that PR for details.

Notes: no-notes