### PR TITLE
build: allow getOutDir cli argument

### DIFF
--- a/script/gn-check.js
+++ b/script/gn-check.js
@@ -1,12 +1,19 @@
+/*
+Usage:
+
+$ node ./script/gn-check.js [--outDir=dirName]
+*/
+
 const cp = require('child_process')
 const path = require('path')
+const args = require('minimist')(process.argv.slice(2), { string: ['outDir'] })
 
 const { getOutDir } = require('./lib/utils')
 
 const SOURCE_ROOT = path.normalize(path.dirname(__dirname))
 const DEPOT_TOOLS = path.resolve(SOURCE_ROOT, '..', 'third_party', 'depot_tools')
-const OUT_DIR = getOutDir()
 
+const OUT_DIR = getOutDir({ outDir: args.outDir })
 if (!OUT_DIR) {
   throw new Error(`No viable out dir: one of Debug, Testing, or Release must exist.`)
 }

--- a/script/lib/utils.js
+++ b/script/lib/utils.js
@@ -23,11 +23,23 @@ function getElectronExec () {
   }
 }
 
-function getOutDir (shouldLog) {
-  if (process.env.ELECTRON_OUT_DIR) {
-    return process.env.ELECTRON_OUT_DIR
+function getOutDir (options = {}) {
+  const shouldLog = options.shouldLog || false
+
+  if (options.outDir || process.env.ELECTRON_OUT_DIR) {
+    const outDir = options.outDir || process.env.ELECTRON_OUT_DIR
+    const outPath = path.resolve(SRC_DIR, 'out', outDir)
+
+    // Check that user-set variable is a valid/existing directory
+    if (fs.existsSync(outPath)) {
+      if (shouldLog) console.log(`OUT_DIR is: ${outDir}`)
+      return outDir
+    }
+
+    // Throw error if user passed/set nonexistent directory.
+    throw new Error(`${outDir} directory not configured on your machine.`)
   } else {
-    for (const buildType of ['Testing', 'Release', 'Default']) {
+    for (const buildType of ['Testing', 'Release', 'Default', 'Debug']) {
       const outPath = path.resolve(SRC_DIR, 'out', buildType)
       if (fs.existsSync(outPath)) {
         if (shouldLog) console.log(`OUT_DIR is: ${buildType}`)

--- a/script/nan-spec-runner.js
+++ b/script/nan-spec-runner.js
@@ -14,7 +14,7 @@ if (!process.mainModule) {
 }
 
 async function main () {
-  const nodeDir = path.resolve(BASE, `out/${utils.getOutDir(true)}/gen/node_headers`)
+  const nodeDir = path.resolve(BASE, `out/${utils.getOutDir({ shouldLog: true })}/gen/node_headers`)
   const env = Object.assign({}, process.env, {
     npm_config_nodedir: nodeDir,
     npm_config_msvs_version: '2019',

--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -146,7 +146,7 @@ async function runRemoteBasedElectronTests () {
 
 async function runNativeElectronTests () {
   let testTargets = require('./native-test-targets.json')
-  const outDir = `out/${utils.getOutDir(false)}`
+  const outDir = `out/${utils.getOutDir()}`
 
   // If native tests are being run, only one arg would be relevant
   if (args.target && !testTargets.includes(args.target)) {
@@ -216,7 +216,7 @@ async function runMainProcessElectronTests () {
 }
 
 async function installSpecModules (dir) {
-  const nodeDir = path.resolve(BASE, `out/${utils.getOutDir(true)}/gen/node_headers`)
+  const nodeDir = path.resolve(BASE, `out/${utils.getOutDir({ shouldLog: true })}/gen/node_headers`)
   const env = Object.assign({}, process.env, {
     npm_config_nodedir: nodeDir,
     npm_config_msvs_version: '2019'


### PR DESCRIPTION
#### Description of Change

Allow for slightly more granular `outDir`customization in `gn-check`. We can now call

```sh
$ node ./script/gn-check.js [--outDir=dirName]
```
instead of just setting an env var of `ELECTRON_OUT_DIR`. Also adds a few more safety checks for the user-set directory existing before it's returned so that it doesn't fail on nonexistent directory farther down the gn-check process.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
