### PR TITLE
feat: warn when remote is used without enableRemoteModule: true

### DIFF
--- a/lib/browser/remote/server.ts
+++ b/lib/browser/remote/server.ts
@@ -321,7 +321,7 @@ const unwrapArgs = function (sender: electron.WebContents, frameId: number, cont
 
 const isRemoteModuleEnabledImpl = function (contents: electron.WebContents) {
   const webPreferences = (contents as any).getLastWebPreferences() || {}
-  return !!webPreferences.enableRemoteModule
+  return webPreferences.enableRemoteModule != null ? !!webPreferences.enableRemoteModule : true
 }
 
 const isRemoteModuleEnabledCache = new WeakMap()

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -13,6 +13,15 @@ const remoteObjectCache = v8Util.createIDWeakMap()
 // An unique ID that can represent current context.
 const contextId = v8Util.getHiddenValue(global, 'contextId')
 
+ipcRendererInternal.invoke('ELECTRON_BROWSER_GET_LAST_WEB_PREFERENCES').then(preferences => {
+  console.log(preferences)
+  if (!preferences.enableRemoteModule) {
+    console.warn('%cElectron Deprecation Warning', 'font-weight: bold', "The 'remote' module is deprecated and will be disabled by default in a future version of Electron. To ensure a smooth upgrade and silence this warning, specify {enableRemoteModule: true} in the WebPreferences for this window.")
+  }
+}, (err) => {
+  console.error('Failed to get web preferences:', err)
+})
+
 // Notify the main process when current context is going to be released.
 // Note that when the renderer process is destroyed, the message may not be
 // sent, we also listen to the "render-view-deleted" event in the main process

--- a/lib/renderer/security-warnings.ts
+++ b/lib/renderer/security-warnings.ts
@@ -268,7 +268,9 @@ const warnAboutAllowedPopups = function () {
 // Logs a warning message about the remote module
 
 const warnAboutRemoteModuleWithRemoteContent = function (webPreferences?: Electron.WebPreferences) {
-  if (!webPreferences || !webPreferences.enableRemoteModule || isLocalhost()) return
+  if (!webPreferences || isLocalhost()) return
+  const remoteModuleEnabled = webPreferences.enableRemoteModule != null ? !!webPreferences.enableRemoteModule : true
+  if (!remoteModuleEnabled) return
 
   if (getIsRemoteProtocol()) {
     const warning = `This renderer process has "enableRemoteModule" enabled

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -174,10 +174,6 @@ WebContentsPreferences::~WebContentsPreferences() {
 }
 
 void WebContentsPreferences::SetDefaults() {
-#if BUILDFLAG(ENABLE_REMOTE_MODULE)
-  SetDefaultBoolIfUndefined(options::kEnableRemoteModule, true);
-#endif
-
   if (IsEnabled(options::kSandbox)) {
     SetBool(options::kNativeWindowOpen, true);
   }
@@ -331,7 +327,7 @@ void WebContentsPreferences::AppendCommandLineSwitches(
 
 #if BUILDFLAG(ENABLE_REMOTE_MODULE)
   // Whether to enable the remote module
-  if (IsEnabled(options::kEnableRemoteModule))
+  if (IsEnabled(options::kEnableRemoteModule, true))
     command_line->AppendSwitch(switches::kEnableRemoteModule);
 #endif
 


### PR DESCRIPTION
#### Description of Change
This is the first step of #21408, issuing a warning when using the 'remote' module without `enableRemoteModule: true`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Began issuing a deprecation warning when the 'remote' module is used when enableRemoteModule: true isn't explicitly specified. See https://github.com/electron/electron/issue/21408 for more details.
