### PR TITLE
fix: pass full response headers in net module

### DIFF
--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -53,18 +53,26 @@ class IncomingMessage extends Readable {
 
   get headers () {
     const filteredHeaders = {}
-    const rawHeaders = this._responseHead.headers
-    Object.keys(rawHeaders).forEach(header => {
-      if (header in filteredHeaders && discardableDuplicateHeaders.has(header)) {
+    const { rawHeaders } = this._responseHead
+    rawHeaders.forEach(header => {
+      if (header.key in filteredHeaders && discardableDuplicateHeaders.has(header.key)) {
         // do nothing with discardable duplicate headers
       } else {
-        if (header === 'set-cookie') {
+        if (header.key === 'set-cookie') {
           // keep set-cookie as an array per Node.js rules
           // see https://nodejs.org/api/http.html#http_message_headers
-          filteredHeaders[header] = rawHeaders[header]
+          if (filteredHeaders[header.key]) {
+            filteredHeaders[header.key].push(header.value)
+          } else {
+            filteredHeaders[header.key] = [header.value]
+          }
         } else {
           // for non-cookie headers, the values are joined together with ', '
-          filteredHeaders[header] = rawHeaders[header].join(', ')
+          if (filteredHeaders[header.key]) {
+            filteredHeaders[header.key] += `, ${header.value}`
+          } else {
+            filteredHeaders[header.key] = header.value
+          }
         }
       }
     })

--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -55,20 +55,21 @@ class IncomingMessage extends Readable {
     const filteredHeaders = {}
     const { rawHeaders } = this._responseHead
     rawHeaders.forEach(header => {
-      if (header.key in filteredHeaders && discardableDuplicateHeaders.has(header.key)) {
+      if (Object.prototype.hasOwnProperty.call(filteredHeaders, header.key) &&
+          discardableDuplicateHeaders.has(header.key)) {
         // do nothing with discardable duplicate headers
       } else {
         if (header.key === 'set-cookie') {
           // keep set-cookie as an array per Node.js rules
           // see https://nodejs.org/api/http.html#http_message_headers
-          if (filteredHeaders[header.key]) {
+          if (Object.prototype.hasOwnProperty.call(filteredHeaders, header.key)) {
             filteredHeaders[header.key].push(header.value)
           } else {
             filteredHeaders[header.key] = [header.value]
           }
         } else {
           // for non-cookie headers, the values are joined together with ', '
-          if (filteredHeaders[header.key]) {
+          if (Object.prototype.hasOwnProperty.call(filteredHeaders, header.key)) {
             filteredHeaders[header.key] += `, ${header.value}`
           } else {
             filteredHeaders[header.key] = header.value

--- a/shell/browser/api/atom_api_url_loader.cc
+++ b/shell/browser/api/atom_api_url_loader.cc
@@ -45,6 +45,12 @@ struct Converter<mojo::InlinedStructPtr<network::mojom::HttpRawHeaderPair>> {
 
 }  // namespace gin
 
+namespace electron {
+
+namespace api {
+
+namespace {
+
 class BufferDataSource : public mojo::DataPipeProducer::DataSource {
  public:
   explicit BufferDataSource(base::span<char> buffer) {
@@ -213,12 +219,6 @@ class JSChunkedDataPipeGetter : public gin::Wrappable<JSChunkedDataPipeGetter>,
 
 gin::WrapperInfo JSChunkedDataPipeGetter::kWrapperInfo = {
     gin::kEmbedderNativeGin};
-
-namespace electron {
-
-namespace api {
-
-namespace {
 
 const net::NetworkTrafficAnnotationTag kTrafficAnnotation =
     net::DefineNetworkTrafficAnnotation("electron_net_module", R"(

--- a/shell/browser/api/atom_api_url_loader.cc
+++ b/shell/browser/api/atom_api_url_loader.cc
@@ -29,6 +29,22 @@
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
 
+namespace gin {
+
+template <>
+struct Converter<mojo::InlinedStructPtr<network::mojom::HttpRawHeaderPair>> {
+  static v8::Local<v8::Value> ToV8(
+      v8::Isolate* isolate,
+      const mojo::InlinedStructPtr<network::mojom::HttpRawHeaderPair>& pair) {
+    gin_helper::Dictionary dict = gin::Dictionary::CreateEmpty(isolate);
+    dict.Set("key", base::ToLowerASCII(pair->key));
+    dict.Set("value", pair->value);
+    return dict.GetHandle();
+  }
+};
+
+}  // namespace gin
+
 class BufferDataSource : public mojo::DataPipeProducer::DataSource {
  public:
   explicit BufferDataSource(base::span<char> buffer) {
@@ -341,6 +357,10 @@ gin_helper::WrappableBase* SimpleURLLoaderWrapper::New(gin::Arguments* args) {
     }
   }
 
+  // Chromium filters headers using browser rules, while for net module we have
+  // every header passed.
+  request->report_raw_headers = true;
+
   v8::Local<v8::Value> body;
   v8::Local<v8::Value> chunk_pipe_getter;
   if (opts.Get("body", &body)) {
@@ -415,8 +435,12 @@ void SimpleURLLoaderWrapper::OnResponseStarted(
   gin::Dictionary dict = gin::Dictionary::CreateEmpty(isolate());
   dict.Set("statusCode", response_head.headers->response_code());
   dict.Set("statusMessage", response_head.headers->GetStatusText());
-  dict.Set("headers", response_head.headers.get());
   dict.Set("httpVersion", response_head.headers->GetHttpVersion());
+  // Note that |response_head.headers| are filtered by Chromium and should not
+  // be used here.
+  DCHECK(response_head.raw_request_response_info);
+  dict.Set("rawHeaders",
+           response_head.raw_request_response_info->response_headers);
   Emit("response-started", final_url, dict);
 }
 

--- a/shell/browser/api/atom_api_url_loader.cc
+++ b/shell/browser/api/atom_api_url_loader.cc
@@ -32,10 +32,10 @@
 namespace gin {
 
 template <>
-struct Converter<mojo::InlinedStructPtr<network::mojom::HttpRawHeaderPair>> {
+struct Converter<network::mojom::HttpRawHeaderPairPtr> {
   static v8::Local<v8::Value> ToV8(
       v8::Isolate* isolate,
-      const mojo::InlinedStructPtr<network::mojom::HttpRawHeaderPair>& pair) {
+      const network::mojom::HttpRawHeaderPairPtr& pair) {
     gin_helper::Dictionary dict = gin::Dictionary::CreateEmpty(isolate);
     dict.Set("key", base::ToLowerASCII(pair->key));
     dict.Set("value", pair->value);

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -616,6 +616,23 @@ describe('net module', () => {
       })
     })
 
+    it('should be able to receive cookies', (done) => {
+      const cookie = ['cookie1', 'cookie2']
+      respondOnce.toSingleURL((request, response) => {
+        response.statusCode = 200
+        response.statusMessage = 'OK'
+        response.setHeader('set-cookie', cookie)
+        response.end()
+      }).then(serverUrl => {
+        const urlRequest = net.request(serverUrl)
+        urlRequest.on('response', (response) => {
+          expect(response.headers['set-cookie']).to.have.same.members(cookie)
+          done()
+        })
+        urlRequest.end()
+      })
+    })
+
     it('should be able to abort an HTTP request before first write', async () => {
       const serverUrl = await respondOnce.toSingleURL((request, response) => {
         response.end()


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/20631.

Use raw headers instead of filtered headers in net module. This is a regression caused by network service refactoring.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix `set-cookie` header not passed in net module.