### PR TITLE
feat: remove deprecated base::Value-based serialization

### DIFF
--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -28,6 +28,22 @@ Electron 8.x, and has been removed in Electron 9.x. The layout zoom level limits
 are now fixed at a minimum of 0.25 and a maximum of 5.0, as defined
 [here](https://chromium.googlesource.com/chromium/src/+/938b37a6d2886bf8335fc7db792f1eb46c65b2ae/third_party/blink/common/page/page_zoom.cc#11).
 
+### Sending non-JS objects over IPC now throws an exception
+
+In Electron 8.0, IPC was changed to use the Structured Clone Algorithm,
+bringing significant performance improvements. To help ease the transition, the
+old IPC serialization algorithm was kept and used for some objects that aren't
+serializable with Structured Clone. In particular, DOM objects (e.g. `Element`,
+`Location` and `DOMMatrix`), Node.js objects backed by C++ classes (e.g.
+`process.env`, some members of `Stream`), and Electron objects backed by C++
+classes (e.g. `WebContents`, `BrowserWindow` and `WebFrame`) are not
+serializable with Structured Clone. Whenever the old algorithm was invoked, a
+deprecation warning was printed.
+
+In Electron 9.0, the old serialization algorithm has been removed, and sending
+such non-serializable objects will now throw an "object could not be cloned"
+error.
+
 ## Planned Breaking API Changes (8.0)
 
 ### Values sent over IPC are now serialized with Structured Clone Algorithm

--- a/spec-main/api-ipc-renderer-spec.ts
+++ b/spec-main/api-ipc-renderer-spec.ts
@@ -52,22 +52,15 @@ describe('ipcRenderer module', () => {
       expect(Buffer.from(data).equals(received)).to.be.true()
     })
 
-    // TODO(nornagon): Change this test to expect an exception to be thrown in
-    // Electron 9.
-    it('can send objects with DOM class prototypes', async () => {
-      w.webContents.executeJavaScript(`{
+    it('throws when sending objects with DOM class prototypes', async () => {
+      await expect(w.webContents.executeJavaScript(`{
         const { ipcRenderer } = require('electron')
         ipcRenderer.send('message', document.location)
-      }`)
-      const [, value] = await emittedOnce(ipcMain, 'message')
-      expect(value.protocol).to.equal('about:')
-      expect(value.hostname).to.equal('')
+      }`)).to.eventually.be.rejected()
     })
 
-    // TODO(nornagon): Change this test to expect an exception to be thrown in
-    // Electron 9.
     it('does not crash when sending external objects', async () => {
-      w.webContents.executeJavaScript(`{
+      await expect(w.webContents.executeJavaScript(`{
         const { ipcRenderer } = require('electron')
         const http = require('http')
 
@@ -75,10 +68,7 @@ describe('ipcRenderer module', () => {
         const stream = request.agent.sockets['127.0.0.1:5000:'][0]._handle._externalStream
 
         ipcRenderer.send('message', stream)
-      }`)
-      const [, externalStreamValue] = await emittedOnce(ipcMain, 'message')
-
-      expect(externalStreamValue).to.be.null()
+      }`)).to.eventually.be.rejected()
     })
 
     it('can send objects that both reference the same object', async () => {

--- a/spec-main/api-remote-spec.ts
+++ b/spec-main/api-remote-spec.ts
@@ -48,11 +48,12 @@ function makeWindow () {
   before(async () => {
     w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, enableRemoteModule: true } })
     await w.loadURL('about:blank')
-    await w.webContents.executeJavaScript(`
+    await w.webContents.executeJavaScript(`{
       const chai_1 = window.chai_1 = require('chai')
       chai_1.use(require('chai-as-promised'))
       chai_1.use(require('dirty-chai'))
-    `)
+      null
+    }`)
   })
   after(closeAllWindows)
   return () => w
@@ -63,11 +64,12 @@ function makeEachWindow () {
   beforeEach(async () => {
     w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, enableRemoteModule: true } })
     await w.loadURL('about:blank')
-    await w.webContents.executeJavaScript(`
+    await w.webContents.executeJavaScript(`{
       const chai_1 = window.chai_1 = require('chai')
       chai_1.use(require('chai-as-promised'))
       chai_1.use(require('dirty-chai'))
-    `)
+      null
+    }`)
   })
   afterEach(closeAllWindows)
   return () => w

--- a/spec-main/modules-spec.ts
+++ b/spec-main/modules-spec.ts
@@ -20,7 +20,7 @@ describe('modules support', () => {
       it('can be required in renderer', async () => {
         const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true } })
         w.loadURL('about:blank')
-        await expect(w.webContents.executeJavaScript(`{ require('echo') }`)).to.be.fulfilled()
+        await expect(w.webContents.executeJavaScript(`{ require('echo'); null }`)).to.be.fulfilled()
       })
 
       ifit(features.isRunAsNodeEnabled())('can be required in node binary', function (done) {


### PR DESCRIPTION
#### Description of Change
This was included as a transitional measure when we moved IPC to using Structured Clone. The old behavior was deprecated in 8.x, and this removes it for 9.x.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Objects not serializable using Structured Clone will now cause an error to be thrown when attempting to send them across IPC.