### PR TITLE
build: free up macos disk space on Mac publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -445,6 +445,9 @@ step-electron-publish: &step-electron-publish
   run:
     name: Publish Electron Dist
     command: |
+      if [ "`uname`" == "Darwin" ]; then
+        rm -rf src/out/Default/obj
+      fi
       cd src/electron
       if [ "$UPLOAD_TO_S3" == "1" ]; then
         echo 'Uploading Electron release distribution to S3'


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Resolves issue running out of disk space when publishing a MacOS build (eg https://circleci.com/gh/electron/electron/426851)
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
