### PR TITLE
fix: set enable_negotiate_port to false in allowNTLMCredentialsForDomains

### DIFF
--- a/shell/browser/api/atom_api_session.cc
+++ b/shell/browser/api/atom_api_session.cc
@@ -521,6 +521,7 @@ void Session::AllowNTLMCredentialsForDomains(const std::string& domains) {
   network::mojom::HttpAuthDynamicParamsPtr auth_dynamic_params =
       network::mojom::HttpAuthDynamicParams::New();
   auth_dynamic_params->server_allowlist = domains;
+  auth_dynamic_params->enable_negotiate_port = false;
   content::GetNetworkService()->ConfigureHttpAuthPrefs(
       std::move(auth_dynamic_params));
 }

--- a/shell/browser/api/atom_api_session.cc
+++ b/shell/browser/api/atom_api_session.cc
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/command_line.h"
 #include "base/files/file_path.h"
 #include "base/guid.h"
 #include "base/strings/string_number_conversions.h"
@@ -521,7 +522,9 @@ void Session::AllowNTLMCredentialsForDomains(const std::string& domains) {
   network::mojom::HttpAuthDynamicParamsPtr auth_dynamic_params =
       network::mojom::HttpAuthDynamicParams::New();
   auth_dynamic_params->server_allowlist = domains;
-  auth_dynamic_params->enable_negotiate_port = false;
+  auth_dynamic_params->enable_negotiate_port =
+      base::CommandLine::ForCurrentProcess()->HasSwitch(
+          electron::switches::kEnableAuthNegotiatePort);
   content::GetNetworkService()->ConfigureHttpAuthPrefs(
       std::move(auth_dynamic_params));
 }


### PR DESCRIPTION
#### Description of Change
Potential fix for NTLM-related bug uncovered after switching to network service. Ref #18251

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where calling allowNTLMCredentialsForDomains() could cause a change in Kerberos SPN generation behavior.