### PR TITLE
fix: set enable_negotiate_port to false in allowNTLMCredentialsForDom…

### DIFF
--- a/shell/browser/api/atom_api_session.cc
+++ b/shell/browser/api/atom_api_session.cc
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/command_line.h"
 #include "base/files/file_path.h"
 #include "base/guid.h"
 #include "base/strings/string_number_conversions.h"
@@ -484,6 +485,9 @@ void Session::AllowNTLMCredentialsForDomains(const std::string& domains) {
   network::mojom::HttpAuthDynamicParamsPtr auth_dynamic_params =
       network::mojom::HttpAuthDynamicParams::New();
   auth_dynamic_params->server_allowlist = domains;
+  auth_dynamic_params->enable_negotiate_port =
+      base::CommandLine::ForCurrentProcess()->HasSwitch(
+          electron::switches::kEnableAuthNegotiatePort);
   content::GetNetworkService()->ConfigureHttpAuthPrefs(
       std::move(auth_dynamic_params));
 }


### PR DESCRIPTION
Backport of #21571. See that change for details.

Notes: Fixed an issue where calling allowNTLMCredentialsForDomains() could cause a change in Kerberos SPN generation behavior.