### PR TITLE
fix: disable private macOS APIs in MAS build except for CAContext/CALayerHost

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -33,6 +33,7 @@ mas-cfisobjc.patch
 mas-cgdisplayusesforcetogray.patch
 mas-audiodeviceduck.patch
 mas_disable_remote_accessibility.patch
+mas_disable_custom_window_frame.patch
 chrome_key_systems.patch
 allow_nested_error_trackers.patch
 blink_initialization_order.patch

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -32,6 +32,7 @@ scroll_bounce_flag.patch
 mas-cfisobjc.patch
 mas-cgdisplayusesforcetogray.patch
 mas-audiodeviceduck.patch
+mas_disable_remote_accessibility.patch
 chrome_key_systems.patch
 allow_nested_error_trackers.patch
 blink_initialization_order.patch

--- a/patches/chromium/mas_disable_custom_window_frame.patch
+++ b/patches/chromium/mas_disable_custom_window_frame.patch
@@ -1,0 +1,146 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Thu, 20 Sep 2018 17:48:49 -0700
+Subject: mas_disable_custom_window_frame.patch
+
+Disable private window frame APIs (NSNextStepFrame and NSThemeFrame) for MAS
+build.
+
+diff --git a/components/remote_cocoa/app_shim/browser_native_widget_window_mac.mm b/components/remote_cocoa/app_shim/browser_native_widget_window_mac.mm
+index 1ffb647e85e0..439cc6df5e0c 100644
+--- a/components/remote_cocoa/app_shim/browser_native_widget_window_mac.mm
++++ b/components/remote_cocoa/app_shim/browser_native_widget_window_mac.mm
+@@ -9,6 +9,7 @@
+ #include "components/remote_cocoa/app_shim/native_widget_ns_window_bridge.h"
+ #include "components/remote_cocoa/common/native_widget_ns_window_host.mojom.h"
+ 
++#ifndef MAS_BUILD
+ @interface NSWindow (PrivateBrowserNativeWidgetAPI)
+ + (Class)frameViewClassForStyleMask:(NSUInteger)windowStyle;
+ @end
+@@ -69,10 +70,13 @@ - (NSRect)_draggableFrame NS_DEPRECATED_MAC(10_10, 10_11) {
+ 
+ @end
+ 
++#endif  // MAS_BUILD
++
+ @implementation BrowserNativeWidgetWindow
+ 
+ // NSWindow (PrivateAPI) overrides.
+ 
++#ifndef MAS_BUILD
+ + (Class)frameViewClassForStyleMask:(NSUInteger)windowStyle {
+   // - NSThemeFrame and its subclasses will be nil if it's missing at runtime.
+   if ([BrowserWindowFrame class])
+@@ -87,6 +91,8 @@ - (BOOL)_usesCustomDrawing {
+   return NO;
+ }
+ 
++#endif  // MAS_BUILD
++
+ // Handle "Move focus to the window toolbar" configured in System Preferences ->
+ // Keyboard -> Shortcuts -> Keyboard. Usually Ctrl+F5. The argument (|unknown|)
+ // tends to just be nil.
+diff --git a/components/remote_cocoa/app_shim/native_widget_mac_frameless_nswindow.mm b/components/remote_cocoa/app_shim/native_widget_mac_frameless_nswindow.mm
+index 8416c7c6e052..cd356beda023 100644
+--- a/components/remote_cocoa/app_shim/native_widget_mac_frameless_nswindow.mm
++++ b/components/remote_cocoa/app_shim/native_widget_mac_frameless_nswindow.mm
+@@ -4,6 +4,8 @@
+ 
+ #import "components/remote_cocoa/app_shim/native_widget_mac_frameless_nswindow.h"
+ 
++#ifndef MAS_BUILD
++
+ @interface NSWindow (PrivateAPI)
+ + (Class)frameViewClassForStyleMask:(NSUInteger)windowStyle;
+ @end
+@@ -18,8 +20,12 @@ - (CGFloat)_titlebarHeight {
+ }
+ @end
+ 
++#endif  // MAS_BUILD
++
+ @implementation NativeWidgetMacFramelessNSWindow
+ 
++#ifndef MAS_BUILD
++
+ + (Class)frameViewClassForStyleMask:(NSUInteger)windowStyle {
+   if ([NativeWidgetMacFramelessNSWindowFrame class]) {
+     return [NativeWidgetMacFramelessNSWindowFrame class];
+@@ -27,4 +33,6 @@ + (Class)frameViewClassForStyleMask:(NSUInteger)windowStyle {
+   return [super frameViewClassForStyleMask:windowStyle];
+ }
+ 
++#endif  // MAS_BUILD
++
+ @end
+diff --git a/components/remote_cocoa/app_shim/native_widget_mac_nswindow.h b/components/remote_cocoa/app_shim/native_widget_mac_nswindow.h
+index e03bbc724cfd..783745b11365 100644
+--- a/components/remote_cocoa/app_shim/native_widget_mac_nswindow.h
++++ b/components/remote_cocoa/app_shim/native_widget_mac_nswindow.h
+@@ -17,6 +17,7 @@ class NativeWidgetNSWindowBridge;
+ 
+ @protocol WindowTouchBarDelegate;
+ 
++#ifndef MAS_BUILD
+ // Weak lets Chrome launch even if a future macOS doesn't have the below classes
+ WEAK_IMPORT_ATTRIBUTE
+ @interface NSNextStepFrame : NSView
+@@ -33,6 +34,7 @@ REMOTE_COCOA_APP_SHIM_EXPORT
+ REMOTE_COCOA_APP_SHIM_EXPORT
+ @interface NativeWidgetMacNSWindowTitledFrame : NSThemeFrame
+ @end
++#endif
+ 
+ // The NSWindow used by BridgedNativeWidget. Provides hooks into AppKit that
+ // can only be accomplished by overriding methods.
+diff --git a/components/remote_cocoa/app_shim/native_widget_mac_nswindow.mm b/components/remote_cocoa/app_shim/native_widget_mac_nswindow.mm
+index 3786db1f2fa8..64e84b91236b 100644
+--- a/components/remote_cocoa/app_shim/native_widget_mac_nswindow.mm
++++ b/components/remote_cocoa/app_shim/native_widget_mac_nswindow.mm
+@@ -15,7 +15,9 @@
+ #import "ui/base/cocoa/window_size_constants.h"
+ 
+ @interface NSWindow (Private)
++#ifndef MAS_BUILD
+ + (Class)frameViewClassForStyleMask:(NSWindowStyleMask)windowStyle;
++#endif
+ - (BOOL)hasKeyAppearance;
+ - (long long)_resizeDirectionForMouseLocation:(CGPoint)location;
+ - (BOOL)_isConsideredOpenForPersistentState;
+@@ -57,6 +59,8 @@ - (void)cr_mouseDownOnFrameView:(NSEvent*)event {
+ }
+ @end
+ 
++#ifndef MAS_BUILD
++
+ @implementation NativeWidgetMacNSWindowTitledFrame
+ - (void)mouseDown:(NSEvent*)event {
+   if (self.window.isMovable)
+@@ -78,6 +82,8 @@ - (BOOL)usesCustomDrawing {
+ }
+ @end
+ 
++#endif  // MAS_BUILD
++
+ @implementation NativeWidgetMacNSWindow {
+  @private
+   base::scoped_nsobject<CommandDispatcher> _commandDispatcher;
+@@ -159,6 +165,8 @@ - (BOOL)hasViewsMenuActive {
+ 
+ // NSWindow overrides.
+ 
++#ifndef MAS_BUILD
++
+ + (Class)frameViewClassForStyleMask:(NSWindowStyleMask)windowStyle {
+   if (windowStyle & NSWindowStyleMaskTitled) {
+     if (Class customFrame = [NativeWidgetMacNSWindowTitledFrame class])
+@@ -170,6 +178,8 @@ + (Class)frameViewClassForStyleMask:(NSWindowStyleMask)windowStyle {
+   return [super frameViewClassForStyleMask:windowStyle];
+ }
+ 
++#endif
++
+ - (BOOL)_isTitleHidden {
+   bool shouldShowWindowTitle = YES;
+   if (_bridge)

--- a/patches/chromium/mas_disable_remote_accessibility.patch
+++ b/patches/chromium/mas_disable_remote_accessibility.patch
@@ -1,0 +1,290 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Thu, 20 Sep 2018 17:48:49 -0700
+Subject: mas_disable_remote_accessibility.patch
+
+Disable remote accessibility APIs (NSAccessibilityRemoteUIElement) for MAS
+build.
+
+According to ccameron:
+
+NSAccessibilityRemoteUIElement is unnecessary for Electron's use-case. We use it
+for progressive web apps (where the AXTree is in the browser process, but macOS
+needs to think it's coming from the PWA process). I think it can just be chopped
+out -- if there are any side-effects, we should be able to work around them.
+
+diff --git a/components/remote_cocoa/app_shim/application_bridge.mm b/components/remote_cocoa/app_shim/application_bridge.mm
+index 9ddda9116e72..e846091ad99b 100644
+--- a/components/remote_cocoa/app_shim/application_bridge.mm
++++ b/components/remote_cocoa/app_shim/application_bridge.mm
+@@ -49,6 +49,7 @@
+ 
+   // NativeWidgetNSWindowHostHelper:
+   id GetNativeViewAccessible() override {
++#ifndef MAS_BUILD
+     if (!remote_accessibility_element_) {
+       int64_t browser_pid = 0;
+       std::vector<uint8_t> element_token;
+@@ -59,6 +60,9 @@ id GetNativeViewAccessible() override {
+           ui::RemoteAccessibility::GetRemoteElementFromToken(element_token);
+     }
+     return remote_accessibility_element_.get();
++#else
++    return nil;
++#endif
+   }
+   void DispatchKeyEvent(ui::KeyEvent* event) override {
+     bool event_handled = false;
+@@ -96,8 +100,10 @@ void GetWordAt(const gfx::Point& location_in_content,
+   mojo::AssociatedRemote<mojom::TextInputHost> text_input_host_remote_;
+ 
+   std::unique_ptr<NativeWidgetNSWindowBridge> bridge_;
++#ifndef MAS_BUILD
+   base::scoped_nsobject<NSAccessibilityRemoteUIElement>
+       remote_accessibility_element_;
++#endif
+ };
+ 
+ }  // namespace
+diff --git a/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm b/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
+index 53659a048396..1fbdc2980386 100644
+--- a/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
++++ b/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
+@@ -556,10 +556,12 @@ NSUInteger CountBridgedWindows(NSArray* child_windows) {
+   // this should be treated as an error and caught early.
+   CHECK(bridged_view_);
+ 
++#ifndef MAS_BUILD
+   // Send the accessibility tokens for the NSView now that it exists.
+   host_->SetRemoteAccessibilityTokens(
+       ui::RemoteAccessibility::GetTokenForLocalElement(window_),
+       ui::RemoteAccessibility::GetTokenForLocalElement(bridged_view_));
++#endif
+ 
+   // Beware: This view was briefly removed (in favor of a bare CALayer) in
+   // crrev/c/1236675. The ordering of unassociated layers relative to NSView
+diff --git a/content/app_shim_remote_cocoa/ns_view_bridge_factory_impl.mm b/content/app_shim_remote_cocoa/ns_view_bridge_factory_impl.mm
+index a8e5c8888cb7..d01468fe7770 100644
+--- a/content/app_shim_remote_cocoa/ns_view_bridge_factory_impl.mm
++++ b/content/app_shim_remote_cocoa/ns_view_bridge_factory_impl.mm
+@@ -66,8 +66,10 @@ id GetFocusedBrowserAccessibilityElement() override {
+     return nil;
+   }
+   void SetAccessibilityWindow(NSWindow* window) override {
++#ifndef MAS_BUILD
+     host_->SetRemoteAccessibilityWindowToken(
+         ui::RemoteAccessibility::GetTokenForLocalElement(window));
++#endif
+   }
+ 
+   void ForwardKeyboardEvent(const content::NativeWebKeyboardEvent& key_event,
+@@ -126,8 +128,10 @@ void SmartMagnify(const blink::WebGestureEvent& web_event) override {
+ 
+   mojo::AssociatedRemote<mojom::RenderWidgetHostNSViewHost> host_;
+   std::unique_ptr<RenderWidgetHostNSViewBridge> bridge_;
++#ifndef MAS_BUILD
+   base::scoped_nsobject<NSAccessibilityRemoteUIElement>
+       remote_accessibility_element_;
++#endif
+ 
+   DISALLOW_COPY_AND_ASSIGN(RenderWidgetHostNSViewBridgeOwner);
+ };
+diff --git a/content/browser/renderer_host/render_widget_host_view_mac.h b/content/browser/renderer_host/render_widget_host_view_mac.h
+index fb8589fe372d..d12dabad6211 100644
+--- a/content/browser/renderer_host/render_widget_host_view_mac.h
++++ b/content/browser/renderer_host/render_widget_host_view_mac.h
+@@ -46,7 +46,9 @@ class ScopedPasswordInputEnabler;
+ 
+ @protocol RenderWidgetHostViewMacDelegate;
+ 
++#ifndef MAS_BUILD
+ @class NSAccessibilityRemoteUIElement;
++#endif
+ @class RenderWidgetHostViewCocoa;
+ 
+ namespace content {
+@@ -628,10 +630,12 @@ class CONTENT_EXPORT RenderWidgetHostViewMac
+   // EnsureSurfaceSynchronizedForWebTest().
+   uint32_t latest_capture_sequence_number_ = 0u;
+ 
++#ifndef MAS_BUILD
+   // Remote accessibility objects corresponding to the NSWindow that this is
+   // displayed to the user in.
+   base::scoped_nsobject<NSAccessibilityRemoteUIElement>
+       remote_window_accessible_;
++#endif
+ 
+   // Used to force the NSApplication's focused accessibility element to be the
+   // content::BrowserAccessibilityCocoa accessibility tree when the NSView for
+diff --git a/content/browser/renderer_host/render_widget_host_view_mac.mm b/content/browser/renderer_host/render_widget_host_view_mac.mm
+index 275caf58aa73..df9c85c458d2 100644
+--- a/content/browser/renderer_host/render_widget_host_view_mac.mm
++++ b/content/browser/renderer_host/render_widget_host_view_mac.mm
+@@ -238,8 +238,10 @@
+ void RenderWidgetHostViewMac::MigrateNSViewBridge(
+     remote_cocoa::mojom::Application* remote_cocoa_application,
+     uint64_t parent_ns_view_id) {
++#ifndef MAS_BUILD
+   // Destroy the previous remote accessibility element.
+   remote_window_accessible_.reset();
++#endif
+ 
+   // Disconnect from the previous bridge (this will have the effect of
+   // destroying the associated bridge), and close the receiver (to allow it
+@@ -1372,8 +1374,10 @@ void CombineTextNodesAndMakeCallback(SpeechCallback callback,
+ 
+ gfx::NativeViewAccessible
+ RenderWidgetHostViewMac::AccessibilityGetNativeViewAccessibleForWindow() {
++#ifndef MAS_BUILD
+   if (remote_window_accessible_)
+     return remote_window_accessible_.get();
++#endif
+   return [GetInProcessNSView() window];
+ }
+ 
+@@ -1405,9 +1409,11 @@ void CombineTextNodesAndMakeCallback(SpeechCallback callback,
+ }
+ 
+ void RenderWidgetHostViewMac::SetAccessibilityWindow(NSWindow* window) {
++#ifndef MAS_BUILD
+   // When running in-process, just use the NSView's NSWindow as its own
+   // accessibility element.
+   remote_window_accessible_.reset();
++#endif
+ }
+ 
+ bool RenderWidgetHostViewMac::SyncIsWidgetForMainFrame(
+@@ -1888,12 +1894,14 @@ void CombineTextNodesAndMakeCallback(SpeechCallback callback,
+ 
+ void RenderWidgetHostViewMac::SetRemoteAccessibilityWindowToken(
+     const std::vector<uint8_t>& window_token) {
++#ifndef MAS_BUILD
+   if (window_token.empty()) {
+     remote_window_accessible_.reset();
+   } else {
+     remote_window_accessible_ =
+         ui::RemoteAccessibility::GetRemoteElementFromToken(window_token);
+   }
++#endif
+ }
+ 
+ ///////////////////////////////////////////////////////////////////////////////
+diff --git a/ui/base/BUILD.gn b/ui/base/BUILD.gn
+index 224ced89a428..83ef52259530 100644
+--- a/ui/base/BUILD.gn
++++ b/ui/base/BUILD.gn
+@@ -306,6 +306,13 @@ jumbo_component("base") {
+     ]
+   }
+ 
++  if (is_mas_build) {
++    sources -= [
++      "cocoa/remote_accessibility_api.h",
++      "cocoa/remote_accessibility_api.mm",
++    ]
++  }
++
+   if (is_posix) {
+     sources += [ "l10n/l10n_util_posix.cc" ]
+   }
+diff --git a/ui/base/cocoa/remote_accessibility_api.h b/ui/base/cocoa/remote_accessibility_api.h
+index 2a58aebabb23..3424b6011e80 100644
+--- a/ui/base/cocoa/remote_accessibility_api.h
++++ b/ui/base/cocoa/remote_accessibility_api.h
+@@ -11,6 +11,8 @@
+ #include "base/mac/scoped_nsobject.h"
+ #include "ui/base/ui_base_export.h"
+ 
++#ifndef MAS_BUILD
++
+ @interface NSAccessibilityRemoteUIElement : NSObject
+ + (void)registerRemoteUIProcessIdentifier:(int)pid;
+ + (NSData*)remoteTokenForLocalUIElement:(id)element;
+@@ -32,4 +34,6 @@ class UI_BASE_EXPORT RemoteAccessibility {
+ 
+ }  // namespace ui
+ 
++#endif  // MAS_BUILD
++
+ #endif  // UI_BASE_COCOA_REMOTE_ACCESSIBILITY_API_H_
+diff --git a/ui/views/cocoa/native_widget_mac_ns_window_host.h b/ui/views/cocoa/native_widget_mac_ns_window_host.h
+index 7697f06aa481..cf7ee1014a9e 100644
+--- a/ui/views/cocoa/native_widget_mac_ns_window_host.h
++++ b/ui/views/cocoa/native_widget_mac_ns_window_host.h
+@@ -29,7 +29,9 @@
+ #include "ui/views/window/dialog_observer.h"
+ 
+ @class NativeWidgetMacNSWindow;
++#ifndef MAS_BUILD
+ @class NSAccessibilityRemoteUIElement;
++#endif
+ @class NSView;
+ 
+ namespace remote_cocoa {
+@@ -425,11 +427,13 @@ class VIEWS_EXPORT NativeWidgetMacNSWindowHost
+   mojo::AssociatedRemote<remote_cocoa::mojom::NativeWidgetNSWindow>
+       remote_ns_window_remote_;
+ 
++#ifndef MAS_BUILD
+   // Remote accessibility objects corresponding to the NSWindow and its root
+   // NSView.
+   base::scoped_nsobject<NSAccessibilityRemoteUIElement>
+       remote_window_accessible_;
+   base::scoped_nsobject<NSAccessibilityRemoteUIElement> remote_view_accessible_;
++#endif
+ 
+   // Used to force the NSApplication's focused accessibility element to be the
+   // views::Views accessibility tree when the NSView for this is focused.
+diff --git a/ui/views/cocoa/native_widget_mac_ns_window_host.mm b/ui/views/cocoa/native_widget_mac_ns_window_host.mm
+index dd9e195a4fd0..205910ac9a3f 100644
+--- a/ui/views/cocoa/native_widget_mac_ns_window_host.mm
++++ b/ui/views/cocoa/native_widget_mac_ns_window_host.mm
+@@ -296,14 +296,22 @@ bool PositionWindowInScreenCoordinates(Widget* widget,
+ NativeWidgetMacNSWindowHost::GetNativeViewAccessibleForNSView() const {
+   if (in_process_ns_window_bridge_)
+     return in_process_ns_window_bridge_->ns_view();
++#ifndef MAS_BUILD
+   return remote_view_accessible_.get();
++#else
++  return nullptr;
++#endif
+ }
+ 
+ gfx::NativeViewAccessible
+ NativeWidgetMacNSWindowHost::GetNativeViewAccessibleForNSWindow() const {
+   if (in_process_ns_window_bridge_)
+     return in_process_ns_window_bridge_->ns_window();
++#ifndef MAS_BUILD
+   return remote_window_accessible_.get();
++#else
++  return nullptr;
++#endif
+ }
+ 
+ remote_cocoa::mojom::NativeWidgetNSWindow*
+@@ -1177,6 +1185,7 @@ bool PositionWindowInScreenCoordinates(Widget* widget,
+ void NativeWidgetMacNSWindowHost::SetRemoteAccessibilityTokens(
+     const std::vector<uint8_t>& window_token,
+     const std::vector<uint8_t>& view_token) {
++#ifndef MAS_BUILD
+   remote_window_accessible_ =
+       ui::RemoteAccessibility::GetRemoteElementFromToken(window_token);
+   remote_view_accessible_ =
+@@ -1184,14 +1193,17 @@ bool PositionWindowInScreenCoordinates(Widget* widget,
+   [remote_view_accessible_ setWindowUIElement:remote_window_accessible_.get()];
+   [remote_view_accessible_
+       setTopLevelUIElement:remote_window_accessible_.get()];
++#endif
+ }
+ 
+ bool NativeWidgetMacNSWindowHost::GetRootViewAccessibilityToken(
+     int64_t* pid,
+     std::vector<uint8_t>* token) {
++#ifndef MAS_BUILD
+   *pid = getpid();
+   id element_id = GetNativeViewAccessible();
+   *token = ui::RemoteAccessibility::GetTokenForLocalElement(element_id);
++#endif
+   return true;
+ }
+ 


### PR DESCRIPTION
#### Description of Change

Refs #20027.

This PR is split from https://github.com/electron/electron/pull/20965 to only include patches that are safe to merge.

Note that Chromium has removed uses of `NSURLFileTypeMappings` so we are able to have one less patch.

#### Release Notes

Notes: no-notes