### PR TITLE
fix: disable private macOS APIs in MAS build except for CAContext/CALayerHost (7-1-x)

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -38,6 +38,7 @@ mas-lssetapplicationlaunchservicesserverconnectionstatus.patch
 ignore_rc_check.patch
 mas_disable_remote_accessibility.patch
 mas_disable_custom_window_frame.patch
+mas_disable_spi_file_type_mappings.patch
 chrome_key_systems.patch
 allow_nested_error_trackers.patch
 blink_initialization_order.patch

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -37,6 +37,7 @@ mas-audiodeviceduck.patch
 mas-lssetapplicationlaunchservicesserverconnectionstatus.patch
 ignore_rc_check.patch
 mas_disable_remote_accessibility.patch
+mas_disable_custom_window_frame.patch
 chrome_key_systems.patch
 allow_nested_error_trackers.patch
 blink_initialization_order.patch

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -36,6 +36,7 @@ mas-cgdisplayusesforcetogray.patch
 mas-audiodeviceduck.patch
 mas-lssetapplicationlaunchservicesserverconnectionstatus.patch
 ignore_rc_check.patch
+mas_disable_remote_accessibility.patch
 chrome_key_systems.patch
 allow_nested_error_trackers.patch
 blink_initialization_order.patch

--- a/patches/chromium/mas_disable_custom_window_frame.patch
+++ b/patches/chromium/mas_disable_custom_window_frame.patch
@@ -1,0 +1,146 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Thu, 20 Sep 2018 17:48:49 -0700
+Subject: mas_disable_custom_window_frame.patch
+
+Disable private window frame APIs (NSNextStepFrame and NSThemeFrame) for MAS
+build.
+
+diff --git a/components/remote_cocoa/app_shim/browser_native_widget_window_mac.mm b/components/remote_cocoa/app_shim/browser_native_widget_window_mac.mm
+index 1ffb647e85e0..439cc6df5e0c 100644
+--- a/components/remote_cocoa/app_shim/browser_native_widget_window_mac.mm
++++ b/components/remote_cocoa/app_shim/browser_native_widget_window_mac.mm
+@@ -9,6 +9,7 @@
+ #include "components/remote_cocoa/app_shim/native_widget_ns_window_bridge.h"
+ #include "components/remote_cocoa/common/native_widget_ns_window_host.mojom.h"
+ 
++#ifndef MAS_BUILD
+ @interface NSWindow (PrivateBrowserNativeWidgetAPI)
+ + (Class)frameViewClassForStyleMask:(NSUInteger)windowStyle;
+ @end
+@@ -69,10 +70,13 @@ - (NSRect)_draggableFrame NS_DEPRECATED_MAC(10_10, 10_11) {
+ 
+ @end
+ 
++#endif  // MAS_BUILD
++
+ @implementation BrowserNativeWidgetWindow
+ 
+ // NSWindow (PrivateAPI) overrides.
+ 
++#ifndef MAS_BUILD
+ + (Class)frameViewClassForStyleMask:(NSUInteger)windowStyle {
+   // - NSThemeFrame and its subclasses will be nil if it's missing at runtime.
+   if ([BrowserWindowFrame class])
+@@ -87,6 +91,8 @@ - (BOOL)_usesCustomDrawing {
+   return NO;
+ }
+ 
++#endif  // MAS_BUILD
++
+ // Handle "Move focus to the window toolbar" configured in System Preferences ->
+ // Keyboard -> Shortcuts -> Keyboard. Usually Ctrl+F5. The argument (|unknown|)
+ // tends to just be nil.
+diff --git a/components/remote_cocoa/app_shim/native_widget_mac_frameless_nswindow.mm b/components/remote_cocoa/app_shim/native_widget_mac_frameless_nswindow.mm
+index 8416c7c6e052..cd356beda023 100644
+--- a/components/remote_cocoa/app_shim/native_widget_mac_frameless_nswindow.mm
++++ b/components/remote_cocoa/app_shim/native_widget_mac_frameless_nswindow.mm
+@@ -4,6 +4,8 @@
+ 
+ #import "components/remote_cocoa/app_shim/native_widget_mac_frameless_nswindow.h"
+ 
++#ifndef MAS_BUILD
++
+ @interface NSWindow (PrivateAPI)
+ + (Class)frameViewClassForStyleMask:(NSUInteger)windowStyle;
+ @end
+@@ -18,8 +20,12 @@ - (CGFloat)_titlebarHeight {
+ }
+ @end
+ 
++#endif  // MAS_BUILD
++
+ @implementation NativeWidgetMacFramelessNSWindow
+ 
++#ifndef MAS_BUILD
++
+ + (Class)frameViewClassForStyleMask:(NSUInteger)windowStyle {
+   if ([NativeWidgetMacFramelessNSWindowFrame class]) {
+     return [NativeWidgetMacFramelessNSWindowFrame class];
+@@ -27,4 +33,6 @@ + (Class)frameViewClassForStyleMask:(NSUInteger)windowStyle {
+   return [super frameViewClassForStyleMask:windowStyle];
+ }
+ 
++#endif  // MAS_BUILD
++
+ @end
+diff --git a/components/remote_cocoa/app_shim/native_widget_mac_nswindow.h b/components/remote_cocoa/app_shim/native_widget_mac_nswindow.h
+index e03bbc724cfd..783745b11365 100644
+--- a/components/remote_cocoa/app_shim/native_widget_mac_nswindow.h
++++ b/components/remote_cocoa/app_shim/native_widget_mac_nswindow.h
+@@ -17,6 +17,7 @@ class NativeWidgetNSWindowBridge;
+ 
+ @protocol WindowTouchBarDelegate;
+ 
++#ifndef MAS_BUILD
+ // Weak lets Chrome launch even if a future macOS doesn't have the below classes
+ WEAK_IMPORT_ATTRIBUTE
+ @interface NSNextStepFrame : NSView
+@@ -33,6 +34,7 @@ REMOTE_COCOA_APP_SHIM_EXPORT
+ REMOTE_COCOA_APP_SHIM_EXPORT
+ @interface NativeWidgetMacNSWindowTitledFrame : NSThemeFrame
+ @end
++#endif
+ 
+ // The NSWindow used by BridgedNativeWidget. Provides hooks into AppKit that
+ // can only be accomplished by overriding methods.
+diff --git a/components/remote_cocoa/app_shim/native_widget_mac_nswindow.mm b/components/remote_cocoa/app_shim/native_widget_mac_nswindow.mm
+index bf4cd6d24635..6955d3975183 100644
+--- a/components/remote_cocoa/app_shim/native_widget_mac_nswindow.mm
++++ b/components/remote_cocoa/app_shim/native_widget_mac_nswindow.mm
+@@ -15,7 +15,9 @@
+ #import "ui/base/cocoa/window_size_constants.h"
+ 
+ @interface NSWindow (Private)
++#ifndef MAS_BUILD
+ + (Class)frameViewClassForStyleMask:(NSWindowStyleMask)windowStyle;
++#endif
+ - (BOOL)hasKeyAppearance;
+ - (long long)_resizeDirectionForMouseLocation:(CGPoint)location;
+ 
+@@ -56,6 +58,8 @@ - (void)cr_mouseDownOnFrameView:(NSEvent*)event {
+ }
+ @end
+ 
++#ifndef MAS_BUILD
++
+ @implementation NativeWidgetMacNSWindowTitledFrame
+ - (void)mouseDown:(NSEvent*)event {
+   if (self.window.isMovable)
+@@ -77,6 +81,8 @@ - (BOOL)usesCustomDrawing {
+ }
+ @end
+ 
++#endif  // MAS_BUILD
++
+ @implementation NativeWidgetMacNSWindow {
+  @private
+   base::scoped_nsobject<CommandDispatcher> commandDispatcher_;
+@@ -154,6 +160,8 @@ - (BOOL)hasViewsMenuActive {
+ 
+ // NSWindow overrides.
+ 
++#ifndef MAS_BUILD
++
+ + (Class)frameViewClassForStyleMask:(NSWindowStyleMask)windowStyle {
+   if (windowStyle & NSWindowStyleMaskTitled) {
+     if (Class customFrame = [NativeWidgetMacNSWindowTitledFrame class])
+@@ -165,6 +173,8 @@ + (Class)frameViewClassForStyleMask:(NSWindowStyleMask)windowStyle {
+   return [super frameViewClassForStyleMask:windowStyle];
+ }
+ 
++#endif
++
+ - (BOOL)_isTitleHidden {
+   bool shouldShowWindowTitle = YES;
+   if (bridge_)

--- a/patches/chromium/mas_disable_remote_accessibility.patch
+++ b/patches/chromium/mas_disable_remote_accessibility.patch
@@ -1,0 +1,283 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Thu, 20 Sep 2018 17:48:49 -0700
+Subject: mas_disable_remote_accessibility.patch
+
+Disable remote accessibility APIs (NSAccessibilityRemoteUIElement) for MAS
+build.
+
+diff --git a/components/remote_cocoa/app_shim/application_bridge.mm b/components/remote_cocoa/app_shim/application_bridge.mm
+index 628196e20d2b..28dbc7f300dc 100644
+--- a/components/remote_cocoa/app_shim/application_bridge.mm
++++ b/components/remote_cocoa/app_shim/application_bridge.mm
+@@ -44,6 +44,7 @@
+ 
+   // NativeWidgetNSWindowHostHelper:
+   id GetNativeViewAccessible() override {
++#ifndef MAS_BUILD
+     if (!remote_accessibility_element_) {
+       int64_t browser_pid = 0;
+       std::vector<uint8_t> element_token;
+@@ -54,6 +55,9 @@ id GetNativeViewAccessible() override {
+           ui::RemoteAccessibility::GetRemoteElementFromToken(element_token);
+     }
+     return remote_accessibility_element_.get();
++#else
++    return nil;
++#endif
+   }
+   void DispatchKeyEvent(ui::KeyEvent* event) override {
+     bool event_handled = false;
+@@ -91,8 +95,10 @@ void GetWordAt(const gfx::Point& location_in_content,
+   mojom::TextInputHostAssociatedPtr text_input_host_ptr_;
+ 
+   std::unique_ptr<NativeWidgetNSWindowBridge> bridge_;
++#ifndef MAS_BUILD
+   base::scoped_nsobject<NSAccessibilityRemoteUIElement>
+       remote_accessibility_element_;
++#endif
+ };
+ 
+ }  // namespace
+diff --git a/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm b/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
+index 6fc744210179..3db03e957c03 100644
+--- a/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
++++ b/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
+@@ -554,10 +554,12 @@ NSUInteger CountBridgedWindows(NSArray* child_windows) {
+   // this should be treated as an error and caught early.
+   CHECK(bridged_view_);
+ 
++#ifndef MAS_BUILD
+   // Send the accessibility tokens for the NSView now that it exists.
+   host_->SetRemoteAccessibilityTokens(
+       ui::RemoteAccessibility::GetTokenForLocalElement(window_),
+       ui::RemoteAccessibility::GetTokenForLocalElement(bridged_view_));
++#endif
+ 
+   // Beware: This view was briefly removed (in favor of a bare CALayer) in
+   // crrev/c/1236675. The ordering of unassociated layers relative to NSView
+diff --git a/content/app_shim_remote_cocoa/ns_view_bridge_factory_impl.mm b/content/app_shim_remote_cocoa/ns_view_bridge_factory_impl.mm
+index 938854358e5b..c79ee1552668 100644
+--- a/content/app_shim_remote_cocoa/ns_view_bridge_factory_impl.mm
++++ b/content/app_shim_remote_cocoa/ns_view_bridge_factory_impl.mm
+@@ -61,8 +61,10 @@ id GetFocusedBrowserAccessibilityElement() override {
+     return nil;
+   }
+   void SetAccessibilityWindow(NSWindow* window) override {
++#ifndef MAS_BUILD
+     host_->SetRemoteAccessibilityWindowToken(
+         ui::RemoteAccessibility::GetTokenForLocalElement(window));
++#endif
+   }
+ 
+   void ForwardKeyboardEvent(const content::NativeWebKeyboardEvent& key_event,
+@@ -121,8 +123,10 @@ void SmartMagnify(const blink::WebGestureEvent& web_event) override {
+ 
+   mojom::RenderWidgetHostNSViewHostAssociatedPtr host_;
+   std::unique_ptr<RenderWidgetHostNSViewBridge> bridge_;
++#ifndef MAS_BUILD
+   base::scoped_nsobject<NSAccessibilityRemoteUIElement>
+       remote_accessibility_element_;
++#endif
+ 
+   DISALLOW_COPY_AND_ASSIGN(RenderWidgetHostNSViewBridgeOwner);
+ };
+diff --git a/content/browser/renderer_host/render_widget_host_view_mac.h b/content/browser/renderer_host/render_widget_host_view_mac.h
+index 0bf2a269abf7..dde6064a25b6 100644
+--- a/content/browser/renderer_host/render_widget_host_view_mac.h
++++ b/content/browser/renderer_host/render_widget_host_view_mac.h
+@@ -45,7 +45,9 @@ class ScopedPasswordInputEnabler;
+ 
+ @protocol RenderWidgetHostViewMacDelegate;
+ 
++#ifndef MAS_BUILD
+ @class NSAccessibilityRemoteUIElement;
++#endif
+ @class RenderWidgetHostViewCocoa;
+ 
+ namespace content {
+@@ -645,10 +647,12 @@ class CONTENT_EXPORT RenderWidgetHostViewMac
+   // EnsureSurfaceSynchronizedForWebTest().
+   uint32_t latest_capture_sequence_number_ = 0u;
+ 
++#ifndef MAS_BUILD
+   // Remote accessibility objects corresponding to the NSWindow that this is
+   // displayed to the user in.
+   base::scoped_nsobject<NSAccessibilityRemoteUIElement>
+       remote_window_accessible_;
++#endif
+ 
+   // Used to force the NSApplication's focused accessibility element to be the
+   // content::BrowserAccessibilityCocoa accessibility tree when the NSView for
+diff --git a/content/browser/renderer_host/render_widget_host_view_mac.mm b/content/browser/renderer_host/render_widget_host_view_mac.mm
+index 9f36053c15a9..6a9f9c466a45 100644
+--- a/content/browser/renderer_host/render_widget_host_view_mac.mm
++++ b/content/browser/renderer_host/render_widget_host_view_mac.mm
+@@ -245,8 +245,10 @@
+ void RenderWidgetHostViewMac::MigrateNSViewBridge(
+     remote_cocoa::mojom::Application* remote_cocoa_application,
+     uint64_t parent_ns_view_id) {
++#ifndef MAS_BUILD
+   // Destroy the previous remote accessibility element.
+   remote_window_accessible_.reset();
++#endif
+ 
+   // Disconnect from the previous bridge (this will have the effect of
+   // destroying the associated bridge), and close the binding (to allow it
+@@ -1383,8 +1385,10 @@ void CombineTextNodesAndMakeCallback(SpeechCallback callback,
+ 
+ gfx::NativeViewAccessible
+ RenderWidgetHostViewMac::AccessibilityGetNativeViewAccessibleForWindow() {
++#ifndef MAS_BUILD
+   if (remote_window_accessible_)
+     return remote_window_accessible_.get();
++#endif
+   return [GetInProcessNSView() window];
+ }
+ 
+@@ -1424,9 +1428,11 @@ void CombineTextNodesAndMakeCallback(SpeechCallback callback,
+ }
+ 
+ void RenderWidgetHostViewMac::SetAccessibilityWindow(NSWindow* window) {
++#ifndef MAS_BUILD
+   // When running in-process, just use the NSView's NSWindow as its own
+   // accessibility element.
+   remote_window_accessible_.reset();
++#endif
+ }
+ 
+ bool RenderWidgetHostViewMac::SyncIsWidgetForMainFrame(
+@@ -1907,12 +1913,14 @@ void CombineTextNodesAndMakeCallback(SpeechCallback callback,
+ 
+ void RenderWidgetHostViewMac::SetRemoteAccessibilityWindowToken(
+     const std::vector<uint8_t>& window_token) {
++#ifndef MAS_BUILD
+   if (window_token.empty()) {
+     remote_window_accessible_.reset();
+   } else {
+     remote_window_accessible_ =
+         ui::RemoteAccessibility::GetRemoteElementFromToken(window_token);
+   }
++#endif
+ }
+ 
+ ///////////////////////////////////////////////////////////////////////////////
+diff --git a/ui/base/BUILD.gn b/ui/base/BUILD.gn
+index 0a3994cebd4a..6a9162808bd0 100644
+--- a/ui/base/BUILD.gn
++++ b/ui/base/BUILD.gn
+@@ -286,6 +286,13 @@ jumbo_component("base") {
+     "window_open_disposition.h",
+   ]
+ 
++  if (is_mas_build) {
++    sources -= [
++      "cocoa/remote_accessibility_api.h",
++      "cocoa/remote_accessibility_api.mm",
++    ]
++  }
++
+   if (is_posix) {
+     sources += [ "l10n/l10n_util_posix.cc" ]
+   }
+diff --git a/ui/base/cocoa/remote_accessibility_api.h b/ui/base/cocoa/remote_accessibility_api.h
+index 2a58aebabb23..3424b6011e80 100644
+--- a/ui/base/cocoa/remote_accessibility_api.h
++++ b/ui/base/cocoa/remote_accessibility_api.h
+@@ -11,6 +11,8 @@
+ #include "base/mac/scoped_nsobject.h"
+ #include "ui/base/ui_base_export.h"
+ 
++#ifndef MAS_BUILD
++
+ @interface NSAccessibilityRemoteUIElement : NSObject
+ + (void)registerRemoteUIProcessIdentifier:(int)pid;
+ + (NSData*)remoteTokenForLocalUIElement:(id)element;
+@@ -32,4 +34,6 @@ class UI_BASE_EXPORT RemoteAccessibility {
+ 
+ }  // namespace ui
+ 
++#endif  // MAS_BUILD
++
+ #endif  // UI_BASE_COCOA_REMOTE_ACCESSIBILITY_API_H_
+diff --git a/ui/views/cocoa/native_widget_mac_ns_window_host.h b/ui/views/cocoa/native_widget_mac_ns_window_host.h
+index 5058eb6048a6..b73c6993b46c 100644
+--- a/ui/views/cocoa/native_widget_mac_ns_window_host.h
++++ b/ui/views/cocoa/native_widget_mac_ns_window_host.h
+@@ -28,7 +28,9 @@
+ #include "ui/views/window/dialog_observer.h"
+ 
+ @class NativeWidgetMacNSWindow;
++#ifndef MAS_BUILD
+ @class NSAccessibilityRemoteUIElement;
++#endif
+ @class NSView;
+ 
+ namespace remote_cocoa {
+@@ -409,11 +411,13 @@ class VIEWS_EXPORT NativeWidgetMacNSWindowHost
+   // process.
+   remote_cocoa::mojom::NativeWidgetNSWindowAssociatedPtr remote_ns_window_ptr_;
+ 
++#ifndef MAS_BUILD
+   // Remote accessibility objects corresponding to the NSWindow and its root
+   // NSView.
+   base::scoped_nsobject<NSAccessibilityRemoteUIElement>
+       remote_window_accessible_;
+   base::scoped_nsobject<NSAccessibilityRemoteUIElement> remote_view_accessible_;
++#endif
+ 
+   // Used to force the NSApplication's focused accessibility element to be the
+   // views::Views accessibility tree when the NSView for this is focused.
+diff --git a/ui/views/cocoa/native_widget_mac_ns_window_host.mm b/ui/views/cocoa/native_widget_mac_ns_window_host.mm
+index 89eb028e840b..b85cf12286d6 100644
+--- a/ui/views/cocoa/native_widget_mac_ns_window_host.mm
++++ b/ui/views/cocoa/native_widget_mac_ns_window_host.mm
+@@ -351,14 +351,22 @@ void UpdateCALayerParams(gfx::CALayerParams* ca_layer_params) {
+ NativeWidgetMacNSWindowHost::GetNativeViewAccessibleForNSView() const {
+   if (in_process_ns_window_bridge_)
+     return in_process_ns_window_bridge_->ns_view();
++#ifndef MAS_BUILD
+   return remote_view_accessible_.get();
++#else
++  return nullptr;
++#endif
+ }
+ 
+ gfx::NativeViewAccessible
+ NativeWidgetMacNSWindowHost::GetNativeViewAccessibleForNSWindow() const {
+   if (in_process_ns_window_bridge_)
+     return in_process_ns_window_bridge_->ns_window();
++#ifndef MAS_BUILD
+   return remote_window_accessible_.get();
++#else
++  return nullptr;
++#endif
+ }
+ 
+ remote_cocoa::mojom::NativeWidgetNSWindow*
+@@ -1194,6 +1202,7 @@ void UpdateCALayerParams(gfx::CALayerParams* ca_layer_params) {
+ void NativeWidgetMacNSWindowHost::SetRemoteAccessibilityTokens(
+     const std::vector<uint8_t>& window_token,
+     const std::vector<uint8_t>& view_token) {
++#ifndef MAS_BUILD
+   remote_window_accessible_ =
+       ui::RemoteAccessibility::GetRemoteElementFromToken(window_token);
+   remote_view_accessible_ =
+@@ -1201,14 +1210,17 @@ void UpdateCALayerParams(gfx::CALayerParams* ca_layer_params) {
+   [remote_view_accessible_ setWindowUIElement:remote_window_accessible_.get()];
+   [remote_view_accessible_
+       setTopLevelUIElement:remote_window_accessible_.get()];
++#endif
+ }
+ 
+ bool NativeWidgetMacNSWindowHost::GetRootViewAccessibilityToken(
+     int64_t* pid,
+     std::vector<uint8_t>* token) {
++#ifndef MAS_BUILD
+   *pid = getpid();
+   id element_id = GetNativeViewAccessible();
+   *token = ui::RemoteAccessibility::GetTokenForLocalElement(element_id);
++#endif
+   return true;
+ }
+ 

--- a/patches/chromium/mas_disable_spi_file_type_mappings.patch
+++ b/patches/chromium/mas_disable_spi_file_type_mappings.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Thu, 20 Sep 2018 17:48:49 -0700
+Subject: mas_disable_spi_file_type_mappings.patch
+
+Disable NSURLFileTypeMappings API for MAS build.
+
+diff --git a/net/base/platform_mime_util_mac.mm b/net/base/platform_mime_util_mac.mm
+index a510c87ea7d9..b5f8ed974402 100644
+--- a/net/base/platform_mime_util_mac.mm
++++ b/net/base/platform_mime_util_mac.mm
+@@ -18,7 +18,7 @@
+ #include <CoreServices/CoreServices.h>
+ #endif  // defined(OS_IOS)
+ 
+-#if !defined(OS_IOS)
++#if !defined(OS_IOS) && !defined(MAS_BUILD)
+ // SPI declaration; see the commentary in GetPlatformExtensionsForMimeType.
+ // iOS must not use any private API, per Apple guideline.
+ 
+@@ -26,7 +26,7 @@ @interface NSURLFileTypeMappings : NSObject
+ + (NSURLFileTypeMappings*)sharedMappings;
+ - (NSArray*)extensionsForMIMEType:(NSString*)mimeType;
+ @end
+-#endif  // !defined(OS_IOS)
++#endif  // !defined(OS_IOS) && !defined(MAS_BUILD)
+ 
+ namespace net {
+ 
+@@ -75,7 +75,7 @@ - (NSArray*)extensionsForMIMEType:(NSString*)mimeType;
+ void PlatformMimeUtil::GetPlatformExtensionsForMimeType(
+     const std::string& mime_type,
+     std::unordered_set<base::FilePath::StringType>* extensions) const {
+-#if defined(OS_IOS)
++#if defined(OS_IOS) || defined(MAS_BUILD)
+   NSArray* extensions_list = nil;
+ #else
+   // There is no API for this that uses UTIs. The WebKitSystemInterface call
+@@ -90,7 +90,7 @@ - (NSArray*)extensionsForMIMEType:(NSString*)mimeType;
+   NSArray* extensions_list =
+       [[NSURLFileTypeMappings sharedMappings]
+           extensionsForMIMEType:base::SysUTF8ToNSString(mime_type)];
+-#endif  // defined(OS_IOS)
++#endif  // defined(OS_IOS)  || defined(MAS_BUILD)
+ 
+   if (extensions_list) {
+     for (NSString* extension in extensions_list)


### PR DESCRIPTION
#### Description of Change

Refs #20027.

This PR is split from https://github.com/electron/electron/pull/20967 to only include patches that are safe to merge.

#### Release Notes

Notes: no-notes