### PR TITLE
fix: avoid white flash when foregrounding occluded windows

### DIFF
--- a/shell/browser/api/atom_api_browser_window.cc
+++ b/shell/browser/api/atom_api_browser_window.cc
@@ -440,7 +440,7 @@ void BrowserWindow::OnWindowShow() {
 }
 
 void BrowserWindow::OnWindowHide() {
-  web_contents()->WasHidden();
+  web_contents()->WasOccluded();
   TopLevelWindow::OnWindowHide();
 }
 


### PR DESCRIPTION
#### Description of Change
Fixes #21189
Regressed in #19988

It's not super clear to me how Chrome manages this itself, as there are a bunch of layers of indirection (as usual), but this bit makes it clear that, at least some of the time, we're using the "hidden" path when we should be using the "occluded" path.

[source](https://cs.chromium.org/chromium/src/content/public/browser/visibility.h?type=cs&g=0&l=10-22)
```
enum class Visibility {
  // The view is not part of any window (e.g. a non-active tab) or is part of a
  // window that is minimized or hidden (Cmd+H).
  HIDDEN,
  // The view is not visible on any screen despite not being HIDDEN. This can be
  // because it is covered by other windows and/or because it is outside the
  // bounds of the screen.
  OCCLUDED,
  // The view is visible on the screen.
  VISIBLE,
  // Note: Users may see HIDDEN/OCCLUDED views via capture (e.g. screenshots,
  // mirroring).
};
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed white flash when foregrounding an occluded window.
