### PR TITLE
feat: flesh out the api for //extensions

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -474,6 +474,8 @@ filenames = {
     "shell/common/gin_converters/callback_converter.h",
     "shell/common/gin_converters/content_converter.cc",
     "shell/common/gin_converters/content_converter.h",
+    "shell/common/gin_converters/extension_converter.cc",
+    "shell/common/gin_converters/extension_converter.h",
     "shell/common/gin_converters/file_dialog_converter.cc",
     "shell/common/gin_converters/file_dialog_converter.h",
     "shell/common/gin_converters/file_path_converter.h",

--- a/shell/browser/api/atom_api_session.cc
+++ b/shell/browser/api/atom_api_session.cc
@@ -634,14 +634,6 @@ void Session::RemoveExtension(const std::string& extension_id) {
   extension_system->RemoveExtension(extension_id);
 }
 
-void Session::EnableExtension(const std::string& extension_id) {
-  NOTIMPLEMENTED() << "TODO(nornagon)";
-}
-
-void Session::DisableExtension(const std::string& extension_id) {
-  NOTIMPLEMENTED() << "TODO(nornagon)";
-}
-
 v8::Local<v8::Value> Session::GetExtension(const std::string& extension_id) {
   auto* registry = extensions::ExtensionRegistry::Get(browser_context());
   const extensions::Extension* extension =
@@ -850,8 +842,6 @@ void Session::BuildPrototype(v8::Isolate* isolate,
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
       .SetMethod("loadExtension", &Session::LoadExtension)
       .SetMethod("removeExtension", &Session::RemoveExtension)
-      .SetMethod("enableExtension", &Session::EnableExtension)
-      .SetMethod("disableExtension", &Session::DisableExtension)
       .SetMethod("getExtension", &Session::GetExtension)
       .SetMethod("getAllExtensions", &Session::GetAllExtensions)
 #endif

--- a/shell/browser/api/atom_api_session.cc
+++ b/shell/browser/api/atom_api_session.cc
@@ -609,7 +609,7 @@ std::vector<base::FilePath::StringType> Session::GetPreloads() const {
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 v8::Local<v8::Promise> Session::LoadExtension(
-    const base::FilePath extension_path) {
+    const base::FilePath& extension_path) {
   gin_helper::Promise<const extensions::Extension*> promise(isolate());
   v8::Local<v8::Promise> handle = promise.GetHandle();
 

--- a/shell/browser/api/atom_api_session.cc
+++ b/shell/browser/api/atom_api_session.cc
@@ -653,7 +653,7 @@ v8::Local<v8::Value> Session::GetExtension(const std::string& extension_id) {
   }
 }
 
-v8::Local<v8::Value> Session::GetLoadedExtensions() {
+v8::Local<v8::Value> Session::GetAllExtensions() {
   auto* registry = extensions::ExtensionRegistry::Get(browser_context());
   auto installed_extensions = registry->GenerateInstalledExtensionsSet();
   std::vector<const extensions::Extension*> extensions_vector;
@@ -853,7 +853,7 @@ void Session::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("enableExtension", &Session::EnableExtension)
       .SetMethod("disableExtension", &Session::DisableExtension)
       .SetMethod("getExtension", &Session::GetExtension)
-      .SetMethod("getLoadedExtensions", &Session::GetLoadedExtensions)
+      .SetMethod("getAllExtensions", &Session::GetAllExtensions)
 #endif
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
       .SetMethod("getSpellCheckerLanguages", &Session::GetSpellCheckerLanguages)

--- a/shell/browser/api/atom_api_session.cc
+++ b/shell/browser/api/atom_api_session.cc
@@ -66,7 +66,9 @@
 #include "ui/base/l10n/l10n_util.h"
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
+#include "extensions/browser/extension_registry.h"
 #include "shell/browser/extensions/atom_extension_system.h"
+#include "shell/common/gin_converters/extension_converter.h"
 #endif
 
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
@@ -606,10 +608,59 @@ std::vector<base::FilePath::StringType> Session::GetPreloads() const {
 }
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-void Session::LoadChromeExtension(const base::FilePath extension_path) {
+v8::Local<v8::Promise> Session::LoadExtension(
+    const base::FilePath extension_path) {
+  gin_helper::Promise<const extensions::Extension*> promise(isolate());
+  v8::Local<v8::Promise> handle = promise.GetHandle();
+
   auto* extension_system = static_cast<extensions::AtomExtensionSystem*>(
       extensions::ExtensionSystem::Get(browser_context()));
-  extension_system->LoadExtension(extension_path);
+  // TODO(nornagon): make LoadExtension() asynchronous.
+  auto* extension = extension_system->LoadExtension(extension_path);
+
+  if (extension) {
+    promise.Resolve(extension);
+  } else {
+    // TODO(nornagon): plumb through error message from extension loader.
+    promise.RejectWithErrorMessage("Failed to load extension");
+  }
+
+  return handle;
+}
+
+void Session::RemoveExtension(const std::string& extension_id) {
+  auto* extension_system = static_cast<extensions::AtomExtensionSystem*>(
+      extensions::ExtensionSystem::Get(browser_context()));
+  extension_system->RemoveExtension(extension_id);
+}
+
+void Session::EnableExtension(const std::string& extension_id) {
+  NOTIMPLEMENTED() << "TODO(nornagon)";
+}
+
+void Session::DisableExtension(const std::string& extension_id) {
+  NOTIMPLEMENTED() << "TODO(nornagon)";
+}
+
+v8::Local<v8::Value> Session::GetExtension(const std::string& extension_id) {
+  auto* registry = extensions::ExtensionRegistry::Get(browser_context());
+  const extensions::Extension* extension =
+      registry->GetInstalledExtension(extension_id);
+  if (extension) {
+    return gin::ConvertToV8(isolate(), extension);
+  } else {
+    return v8::Null(isolate());
+  }
+}
+
+v8::Local<v8::Value> Session::GetLoadedExtensions() {
+  auto* registry = extensions::ExtensionRegistry::Get(browser_context());
+  auto installed_extensions = registry->GenerateInstalledExtensionsSet();
+  std::vector<const extensions::Extension*> extensions_vector;
+  for (const auto& extension : *installed_extensions) {
+    extensions_vector.emplace_back(extension.get());
+  }
+  return gin::ConvertToV8(isolate(), extensions_vector);
 }
 #endif
 
@@ -797,7 +848,12 @@ void Session::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setPreloads", &Session::SetPreloads)
       .SetMethod("getPreloads", &Session::GetPreloads)
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-      .SetMethod("loadChromeExtension", &Session::LoadChromeExtension)
+      .SetMethod("loadExtension", &Session::LoadExtension)
+      .SetMethod("removeExtension", &Session::RemoveExtension)
+      .SetMethod("enableExtension", &Session::EnableExtension)
+      .SetMethod("disableExtension", &Session::DisableExtension)
+      .SetMethod("getExtension", &Session::GetExtension)
+      .SetMethod("getLoadedExtensions", &Session::GetLoadedExtensions)
 #endif
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
       .SetMethod("getSpellCheckerLanguages", &Session::GetSpellCheckerLanguages)

--- a/shell/browser/api/atom_api_session.h
+++ b/shell/browser/api/atom_api_session.h
@@ -96,7 +96,7 @@ class Session : public gin_helper::TrackableObject<Session>,
 #endif
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-  v8::Local<v8::Promise> LoadExtension(const base::FilePath extension_path);
+  v8::Local<v8::Promise> LoadExtension(const base::FilePath& extension_path);
   void RemoveExtension(const std::string& extension_id);
   v8::Local<v8::Value> GetExtension(const std::string& extension_id);
   v8::Local<v8::Value> GetAllExtensions();

--- a/shell/browser/api/atom_api_session.h
+++ b/shell/browser/api/atom_api_session.h
@@ -96,7 +96,12 @@ class Session : public gin_helper::TrackableObject<Session>,
 #endif
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-  void LoadChromeExtension(const base::FilePath extension_path);
+  v8::Local<v8::Promise> LoadExtension(const base::FilePath extension_path);
+  void RemoveExtension(const std::string& extension_id);
+  void EnableExtension(const std::string& extension_id);
+  void DisableExtension(const std::string& extension_id);
+  v8::Local<v8::Value> GetExtension(const std::string& extension_id);
+  v8::Local<v8::Value> GetLoadedExtensions();
 #endif
 
  protected:

--- a/shell/browser/api/atom_api_session.h
+++ b/shell/browser/api/atom_api_session.h
@@ -101,7 +101,7 @@ class Session : public gin_helper::TrackableObject<Session>,
   void EnableExtension(const std::string& extension_id);
   void DisableExtension(const std::string& extension_id);
   v8::Local<v8::Value> GetExtension(const std::string& extension_id);
-  v8::Local<v8::Value> GetLoadedExtensions();
+  v8::Local<v8::Value> GetAllExtensions();
 #endif
 
  protected:

--- a/shell/browser/api/atom_api_session.h
+++ b/shell/browser/api/atom_api_session.h
@@ -98,8 +98,6 @@ class Session : public gin_helper::TrackableObject<Session>,
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   v8::Local<v8::Promise> LoadExtension(const base::FilePath extension_path);
   void RemoveExtension(const std::string& extension_id);
-  void EnableExtension(const std::string& extension_id);
-  void DisableExtension(const std::string& extension_id);
   v8::Local<v8::Value> GetExtension(const std::string& extension_id);
   v8::Local<v8::Value> GetAllExtensions();
 #endif

--- a/shell/browser/extensions/atom_extension_loader.cc
+++ b/shell/browser/extensions/atom_extension_loader.cc
@@ -77,7 +77,7 @@ const Extension* AtomExtensionLoader::LoadExtension(
   return extension.get();
 }
 
-void AtomExtensionLoader::ReloadExtension(ExtensionId extension_id) {
+void AtomExtensionLoader::ReloadExtension(const ExtensionId& extension_id) {
   const Extension* extension = ExtensionRegistry::Get(browser_context_)
                                    ->GetInstalledExtension(extension_id);
   // We shouldn't be trying to reload extensions that haven't been added.
@@ -93,8 +93,14 @@ void AtomExtensionLoader::ReloadExtension(ExtensionId extension_id) {
     return;
 }
 
+void AtomExtensionLoader::UnloadExtension(
+    const ExtensionId& extension_id,
+    extensions::UnloadedExtensionReason reason) {
+  extension_registrar_.RemoveExtension(extension_id, reason);
+}
+
 void AtomExtensionLoader::FinishExtensionReload(
-    const ExtensionId old_extension_id,
+    const ExtensionId& old_extension_id,
     scoped_refptr<const Extension> extension) {
   if (extension) {
     extension_registrar_.AddExtension(extension);

--- a/shell/browser/extensions/atom_extension_loader.h
+++ b/shell/browser/extensions/atom_extension_loader.h
@@ -41,12 +41,15 @@ class AtomExtensionLoader : public ExtensionRegistrar::Delegate {
   // reloading.
   // This may invalidate references to the old Extension object, so it takes the
   // ID by value.
-  void ReloadExtension(ExtensionId extension_id);
+  void ReloadExtension(const ExtensionId& extension_id);
+
+  void UnloadExtension(const ExtensionId& extension_id,
+                       extensions::UnloadedExtensionReason reason);
 
  private:
   // If the extension loaded successfully, enables it. If it's an app, launches
   // it. If the load failed, updates ShellKeepAliveRequester.
-  void FinishExtensionReload(const ExtensionId old_extension_id,
+  void FinishExtensionReload(const ExtensionId& old_extension_id,
                              scoped_refptr<const Extension> extension);
 
   // ExtensionRegistrar::Delegate:

--- a/shell/browser/extensions/atom_extension_system.cc
+++ b/shell/browser/extensions/atom_extension_system.cc
@@ -49,7 +49,7 @@ const Extension* AtomExtensionSystem::LoadExtension(
 }
 
 const Extension* AtomExtensionSystem::LoadApp(const base::FilePath& app_dir) {
-  CHECK(false);  // Should never call LoadApp
+  NOTIMPLEMENTED() << "Attempted to load platform app in Electron";
   return nullptr;
 }
 
@@ -64,6 +64,11 @@ void AtomExtensionSystem::FinishInitialization() {
 
 void AtomExtensionSystem::ReloadExtension(const ExtensionId& extension_id) {
   extension_loader_->ReloadExtension(extension_id);
+}
+
+void AtomExtensionSystem::RemoveExtension(const ExtensionId& extension_id) {
+  extension_loader_->UnloadExtension(
+      extension_id, extensions::UnloadedExtensionReason::UNINSTALL);
 }
 
 void AtomExtensionSystem::Shutdown() {

--- a/shell/browser/extensions/atom_extension_system.h
+++ b/shell/browser/extensions/atom_extension_system.h
@@ -53,6 +53,8 @@ class AtomExtensionSystem : public ExtensionSystem {
   // Reloads the extension with id |extension_id|.
   void ReloadExtension(const ExtensionId& extension_id);
 
+  void RemoveExtension(const ExtensionId& extension_id);
+
   // KeyedService implementation:
   void Shutdown() override;
 

--- a/shell/common/gin_converters/extension_converter.cc
+++ b/shell/common/gin_converters/extension_converter.cc
@@ -1,0 +1,22 @@
+// Copyright (c) 2019 Slack Technologies, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/common/gin_converters/extension_converter.h"
+
+#include "extensions/common/extension.h"
+#include "gin/dictionary.h"
+
+namespace gin {
+
+// static
+v8::Local<v8::Value> Converter<const extensions::Extension*>::ToV8(
+    v8::Isolate* isolate,
+    const extensions::Extension* extension) {
+  auto dict = gin::Dictionary::CreateEmpty(isolate);
+  dict.Set("id", extension->id());
+  // TODO
+  return gin::ConvertToV8(isolate, dict);
+}
+
+}  // namespace gin

--- a/shell/common/gin_converters/extension_converter.cc
+++ b/shell/common/gin_converters/extension_converter.cc
@@ -15,7 +15,6 @@ v8::Local<v8::Value> Converter<const extensions::Extension*>::ToV8(
     const extensions::Extension* extension) {
   auto dict = gin::Dictionary::CreateEmpty(isolate);
   dict.Set("id", extension->id());
-  // TODO
   return gin::ConvertToV8(isolate, dict);
 }
 

--- a/shell/common/gin_converters/extension_converter.h
+++ b/shell/common/gin_converters/extension_converter.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2019 Slack Technologies, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_COMMON_GIN_CONVERTERS_EXTENSION_CONVERTER_H_
+#define SHELL_COMMON_GIN_CONVERTERS_EXTENSION_CONVERTER_H_
+
+#include <string>
+
+#include "gin/converter.h"
+
+namespace extensions {
+class Extension;
+}  // namespace extensions
+
+namespace gin {
+
+template <>
+struct Converter<const extensions::Extension*> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const extensions::Extension* val);
+};
+
+}  // namespace gin
+
+#endif  // SHELL_COMMON_GIN_CONVERTERS_NET_CONVERTER_H_

--- a/shell/common/gin_converters/extension_converter.h
+++ b/shell/common/gin_converters/extension_converter.h
@@ -23,4 +23,4 @@ struct Converter<const extensions::Extension*> {
 
 }  // namespace gin
 
-#endif  // SHELL_COMMON_GIN_CONVERTERS_NET_CONVERTER_H_
+#endif  // SHELL_COMMON_GIN_CONVERTERS_EXTENSION_CONVERTER_H_

--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -32,16 +32,48 @@ ifdescribe(process.electronBinding('features').isExtensionsEnabled())('chrome ex
     // extension in an in-memory session results in it being installed in the
     // default session.
     const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
-    (customSession as any).loadChromeExtension(path.join(fixtures, 'extensions', 'red-bg'))
+    (customSession as any).loadExtension(path.join(fixtures, 'extensions', 'red-bg'))
     const w = new BrowserWindow({ show: false, webPreferences: { session: customSession } })
     await w.loadURL(url)
     const bg = await w.webContents.executeJavaScript('document.documentElement.style.backgroundColor')
     expect(bg).to.equal('red')
   })
 
+  it('removes an extension', async () => {
+    const customSession = session.fromPartition(`persist:${require('uuid').v4()}`)
+    const { id } = await (customSession as any).loadExtension(path.join(fixtures, 'extensions', 'red-bg'))
+    {
+      const w = new BrowserWindow({ show: false, webPreferences: { session: customSession } })
+      await w.loadURL(url)
+      const bg = await w.webContents.executeJavaScript('document.documentElement.style.backgroundColor')
+      expect(bg).to.equal('red')
+    }
+    (customSession as any).removeExtension(id)
+    {
+      const w = new BrowserWindow({ show: false, webPreferences: { session: customSession } })
+      await w.loadURL(url)
+      const bg = await w.webContents.executeJavaScript('document.documentElement.style.backgroundColor')
+      expect(bg).to.equal('')
+    }
+  })
+
+  it('lists loaded extensions in getLoadedExtensions', async () => {
+    const customSession = session.fromPartition(`persist:${require('uuid').v4()}`)
+    const e = await (customSession as any).loadExtension(path.join(fixtures, 'extensions', 'red-bg'))
+    expect((customSession as any).getLoadedExtensions()).to.deep.equal([e]);
+    (customSession as any).removeExtension(e.id)
+    expect((customSession as any).getLoadedExtensions()).to.deep.equal([])
+  })
+
+  it('gets an extension by id', async () => {
+    const customSession = session.fromPartition(`persist:${require('uuid').v4()}`)
+    const e = await (customSession as any).loadExtension(path.join(fixtures, 'extensions', 'red-bg'))
+    expect((customSession as any).getExtension(e.id)).to.deep.equal(e)
+  })
+
   it('confines an extension to the session it was loaded in', async () => {
     const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
-    (customSession as any).loadChromeExtension(path.join(fixtures, 'extensions', 'red-bg'))
+    (customSession as any).loadExtension(path.join(fixtures, 'extensions', 'red-bg'))
     const w = new BrowserWindow({ show: false }) // not in the session
     await w.loadURL(url)
     const bg = await w.webContents.executeJavaScript('document.documentElement.style.backgroundColor')
@@ -52,7 +84,7 @@ ifdescribe(process.electronBinding('features').isExtensionsEnabled())('chrome ex
     let content: any
     before(async () => {
       const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
-      (customSession as any).loadChromeExtension(path.join(fixtures, 'extensions', 'chrome-runtime'))
+      (customSession as any).loadExtension(path.join(fixtures, 'extensions', 'chrome-runtime'))
       const w = new BrowserWindow({ show: false, webPreferences: { session: customSession } })
       try {
         await w.loadURL(url)
@@ -76,7 +108,7 @@ ifdescribe(process.electronBinding('features').isExtensionsEnabled())('chrome ex
   describe('chrome.storage', () => {
     it('stores and retrieves a key', async () => {
       const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
-      (customSession as any).loadChromeExtension(path.join(fixtures, 'extensions', 'chrome-storage'))
+      (customSession as any).loadExtension(path.join(fixtures, 'extensions', 'chrome-storage'))
       const w = new BrowserWindow({ show: false, webPreferences: { session: customSession, nodeIntegration: true } })
       try {
         const p = emittedOnce(ipcMain, 'storage-success')

--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -57,12 +57,12 @@ ifdescribe(process.electronBinding('features').isExtensionsEnabled())('chrome ex
     }
   })
 
-  it('lists loaded extensions in getLoadedExtensions', async () => {
+  it('lists loaded extensions in getAllExtensions', async () => {
     const customSession = session.fromPartition(`persist:${require('uuid').v4()}`)
     const e = await (customSession as any).loadExtension(path.join(fixtures, 'extensions', 'red-bg'))
-    expect((customSession as any).getLoadedExtensions()).to.deep.equal([e]);
+    expect((customSession as any).getAllExtensions()).to.deep.equal([e]);
     (customSession as any).removeExtension(e.id)
-    expect((customSession as any).getLoadedExtensions()).to.deep.equal([])
+    expect((customSession as any).getAllExtensions()).to.deep.equal([])
   })
 
   it('gets an extension by id', async () => {


### PR DESCRIPTION
#### Description of Change
This adds a few more APIs to the //extensions system, which is still behind the `enable_electron_extensions` build flag.

No release notes because none of these features are available in released versions of Electron yet.

Ref #19447

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none