### PR TITLE
fix: improve error handling in npm install

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -46,11 +46,7 @@ function isInstalled () {
   
   const electronPath = process.env.ELECTRON_OVERRIDE_DIST_PATH || path.join(__dirname, 'dist', platformPath)
   
-  if (!fs.existsSync(electronPath)) {
-    return false
-  }
-
-  return true
+  return fs.existsSync(electronPath)
 }
 
 // unzips and makes path.txt point at the correct executable

--- a/npm/install.js
+++ b/npm/install.js
@@ -8,22 +8,13 @@ const path = require('path')
 const extract = require('extract-zip')
 const { downloadArtifact } = require('@electron/get')
 
-let installedVersion = null
-try {
-  installedVersion = fs.readFileSync(path.join(__dirname, 'dist', 'version'), 'utf-8').replace(/^v/, '')
-} catch (ignored) {
-  // do nothing
-}
-
 if (process.env.ELECTRON_SKIP_BINARY_DOWNLOAD) {
   process.exit(0)
 }
 
 const platformPath = getPlatformPath()
 
-const electronPath = process.env.ELECTRON_OVERRIDE_DIST_PATH || path.join(__dirname, 'dist', platformPath)
-
-if (installedVersion === version && fs.existsSync(electronPath)) {
+if (isInstalled()) {
   process.exit(0)
 }
 
@@ -35,20 +26,46 @@ downloadArtifact({
   cacheRoot: process.env.electron_config_cache,
   platform: process.env.npm_config_platform || process.platform,
   arch: process.env.npm_config_arch || process.arch
-}).then((zipPath) => extractFile(zipPath)).catch((err) => onerror(err))
+}).then(extractFile).catch(err => {
+  console.error(err.stack)
+  process.exit(1)
+})
+
+function isInstalled () {
+  try {
+    if (fs.readFileSync(path.join(__dirname, 'dist', 'version'), 'utf-8').replace(/^v/, '') !== version) {
+      return false
+    }
+
+    if (fs.readFileSync(path.join(__dirname, 'path.txt'), 'utf-8') !== platformPath) {
+      return false
+    }
+  } catch (ignored) {
+    return false
+  }
+  
+  const electronPath = process.env.ELECTRON_OVERRIDE_DIST_PATH || path.join(__dirname, 'dist', platformPath)
+  
+  if (!fs.existsSync(electronPath)) {
+    return false
+  }
+
+  return true
+}
 
 // unzips and makes path.txt point at the correct executable
 function extractFile (zipPath) {
-  extract(zipPath, { dir: path.join(__dirname, 'dist') }, function (err) {
-    if (err) return onerror(err)
-    fs.writeFile(path.join(__dirname, 'path.txt'), platformPath, function (err) {
-      if (err) return onerror(err)
+  return new Promise((resolve, reject) => {
+    extract(zipPath, { dir: path.join(__dirname, 'dist') }, err => {
+      if (err) return reject(err)
+
+      fs.writeFile(path.join(__dirname, 'path.txt'), platformPath, err => {
+        if (err) return reject(err)
+
+        resolve()
+      })
     })
   })
-}
-
-function onerror (err) {
-  throw err
 }
 
 function getPlatformPath () {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

This improves a couple of current shortcomings in the error handling, namely:
* Any error in `downloadArtifact` (such as a network error or 404) would result in an unhandled promise rejection
* Node still exits with exit code 0 in the case of unhandled promise rejection, so it would look like it succeeded in those cases
* An error during extraction or writing `path.txt` would still be considered 'good install' if you run the script again, leaving things in a state which doesn't self-heal

This PR should fix those issues.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
