### PR TITLE
[WIP] fix: don't leak NotifyIcon objects on Windows

### DIFF
--- a/shell/browser/ui/win/notify_icon_host.cc
+++ b/shell/browser/ui/win/notify_icon_host.cc
@@ -89,7 +89,7 @@ NotifyIcon* NotifyIconHost::CreateNotifyIcon() {
 
 void NotifyIconHost::Remove(NotifyIcon* icon) {
   const auto n_removed = notify_icons_.erase(icon->icon_id());
-  DCHECK(n_removed > 0);
+  DCHECK_GT(n_removed, 0);
 }
 
 LRESULT CALLBACK NotifyIconHost::WndProcStatic(HWND hwnd,

--- a/shell/browser/ui/win/notify_icon_host.cc
+++ b/shell/browser/ui/win/notify_icon_host.cc
@@ -84,7 +84,7 @@ NotifyIcon* NotifyIconHost::CreateNotifyIcon() {
   const auto id = NextIconId();
   auto result = base::TryEmplace(notify_icons_, id, this, id, window_,
                                  kNotifyIconMessage);
-  return &*result.first;
+  return &(result.first->second);
 }
 
 void NotifyIconHost::Remove(NotifyIcon* icon) {
@@ -110,7 +110,7 @@ LRESULT CALLBACK NotifyIconHost::WndProc(HWND hwnd,
                                          LPARAM lparam) {
   if (message == taskbar_created_message_) {
     // We need to reset all of our icons because the taskbar went away.
-    for (auto it : notify_icons_) {
+    for (auto& it : notify_icons_) {
       it.second.ResetIcon();
     }
     return TRUE;
@@ -125,7 +125,7 @@ LRESULT CALLBACK NotifyIconHost::WndProc(HWND hwnd,
     if (it == notify_icons_.end())
       return TRUE;
 
-    NotifyIcon& win_icon = it.second;
+    NotifyIcon& win_icon = it->second;
     switch (lparam) {
       case NIN_BALLOONSHOW:
         win_icon.NotifyBalloonShow();

--- a/shell/browser/ui/win/notify_icon_host.cc
+++ b/shell/browser/ui/win/notify_icon_host.cc
@@ -88,7 +88,7 @@ NotifyIcon* NotifyIconHost::CreateNotifyIcon() {
 }
 
 void NotifyIconHost::Remove(NotifyIcon* icon) {
-  const auto n_removed = notify_icons_.erase(icon->icon_id());
+  const int n_removed = notify_icons_.erase(icon->icon_id());
   DCHECK_GT(n_removed, 0);
 }
 

--- a/shell/browser/ui/win/notify_icon_host.h
+++ b/shell/browser/ui/win/notify_icon_host.h
@@ -7,7 +7,7 @@
 
 #include <windows.h>
 
-#include <vector>
+#include <map>
 
 #include "base/macros.h"
 
@@ -24,8 +24,6 @@ class NotifyIconHost {
   void Remove(NotifyIcon* notify_icon);
 
  private:
-  typedef std::vector<NotifyIcon*> NotifyIcons;
-
   // Static callback invoked when a message comes in to our messaging window.
   static LRESULT CALLBACK WndProcStatic(HWND hwnd,
                                         UINT message,
@@ -42,8 +40,8 @@ class NotifyIconHost {
   // The unique icon ID we will assign to the next icon.
   UINT next_icon_id_ = 1;
 
-  // List containing all active NotifyIcons.
-  NotifyIcons notify_icons_;
+  // All active NotifyIcons.
+  std::map<UINT /*icon_id*/, NotifyIcon> notify_icons_;
 
   // The window class of |window_|.
   ATOM atom_ = 0;


### PR DESCRIPTION
#### Description of Change

Don't leak NotifyIcon objects on Windows. Previously we held a vector of NotifyIcon*s allocated with new but never deleted them when removing from the vector.

This refactor also changes the implementation from holding icons in a container to holding them in a map keyed by icon ID, simplifying the icon lookup code.

#### Checklist

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed notification icon memory leak on Windows.