### PR TITLE
fix: avoid contextBridge double free on garbage collection

### DIFF
--- a/shell/renderer/api/context_bridge/render_frame_context_bridge_store.cc
+++ b/shell/renderer/api/context_bridge/render_frame_context_bridge_store.cc
@@ -78,11 +78,7 @@ WeakGlobalPairNode::WeakGlobalPairNode(WeakGlobalPair pair) {
   this->pair = std::move(pair);
 }
 
-WeakGlobalPairNode::~WeakGlobalPairNode() {
-  if (next) {
-    delete next;
-  }
-}
+WeakGlobalPairNode::~WeakGlobalPairNode() {}
 
 RenderFramePersistenceStore::RenderFramePersistenceStore(
     content::RenderFrame* render_frame)

--- a/shell/renderer/api/context_bridge/render_frame_context_bridge_store.cc
+++ b/shell/renderer/api/context_bridge/render_frame_context_bridge_store.cc
@@ -47,9 +47,11 @@ class CachedProxyLifeMonitor final : public ObjectLifeMonitor {
     }
     if (node_->prev) {
       node_->prev->next = node_->next;
+      node_->prev = nullptr;
     }
     if (node_->next) {
       node_->next->prev = node_->prev;
+      node_->next = nullptr;
     }
     if (!node_->prev && !node_->next) {
       // Must be a single length linked list


### PR DESCRIPTION
#### Description of Change
Speculatively fix a crash in contextBridge. Because the elements in the hash-collided linked list are each subject to an object life monitor, they will free themselves. So it's redundant (and crash-y) to free next in the destructor.

Additionally, while we're at it, correct the pointer resetting of the linked list shuffling in the destructor.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash in contextBridge that happens on garbage collection