### PR TITLE
fix: SimpleURLLoaderWrapper redirects (#21566)

### DIFF
--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -398,7 +398,7 @@ class ClientRequest extends Writable {
           this.emit('redirect', statusCode, newMethod, newUrl, headers)
         } finally {
           this._followRedirectCb = null
-          if (!_followRedirect) {
+          if (!_followRedirect && !this._aborted) {
             this._die(new Error('Redirect was cancelled'))
           }
         }


### PR DESCRIPTION
#### Description of Change

Fix #21566. 0476eb6 regressed `electron-updater` as it raises an error if `request.abort()` is called in a `redirect` handler. For all apps that shipped with `electron-updater` since 7.1.3+ auto-update is not working and users will be stranded with outdated bits. Fix is to not raise an error if the request was aborted within the handler.

I was unable to build and verify this change (mac stuck for many hours in `gclient sync`). Can folks (cc) who introduced this regression help or commit the correct fix and publish an Electron release including the fix?

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

cc @nornagon @MarshallOfSound