### PR TITLE
fix: SimpleURLLoaderWrapper redirects (#21566)

### DIFF
--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -398,7 +398,7 @@ class ClientRequest extends Writable {
           this.emit('redirect', statusCode, newMethod, newUrl, headers)
         } finally {
           this._followRedirectCb = null
-          if (!_followRedirect) {
+          if (!_followRedirect && !this._aborted) {
             this._die(new Error('Redirect was cancelled'))
           }
         }


### PR DESCRIPTION
#### Description of Change

Fix #21566.

PR #21304 regressed `electron-updater` as it raises an error if `request.abort()` is called in a redirect handler. For all apps that shipped with `electron-updater` since 7.1.3+ auto-update is not working and users will be stranded with outdated bits. Fix is to not raise an error if the request was aborted within the handler.

@nornagon @MarshallOfSound, I was unable to build and verify this change (mac stuck for many hours in `gclient sync`). Since you introduced this regression, can you help or commit the correct fix and publish an Electron 7.1.x release including the fix?

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes

@nornagon @MarshallOfSound

Notes: Fixed an issue in the `net` module where aborting a request during a redirect could cause an error to be thrown.