### PR TITLE
fix: highlight buttons correctly when defaultId passed

### DIFF
--- a/shell/browser/ui/message_box_mac.mm
+++ b/shell/browser/ui/message_box_mac.mm
@@ -59,9 +59,11 @@ NSAlert* CreateNSAlert(const MessageBoxSettings& settings) {
   int button_count = static_cast<int>([ns_buttons count]);
 
   if (settings.default_id >= 0 && settings.default_id < button_count) {
-    // Focus the button at default_id if the user opted to do so.
-    // The first button added gets set as the default selected.
-    // So remove that default, and make the requested button the default.
+    // Highlight the button at default_id
+    [[ns_buttons objectAtIndex:settings.default_id] highlight:YES];
+
+    // The first button added gets set as the default selected, so remove
+    // that and set the button @ default_id to be default.
     [[ns_buttons objectAtIndex:0] setKeyEquivalent:@""];
     [[ns_buttons objectAtIndex:settings.default_id] setKeyEquivalent:@"\r"];
   }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/21633.

Fixes button highlighting when `defaultId` is passed.

Before:
<img width="464" alt="Screen Shot 2019-12-30 at 10 52 39 AM" src="https://user-images.githubusercontent.com/2036040/71595969-8f215500-2af2-11ea-8468-c5af28ffa8ef.png">

After:
<img width="459" alt="Screen Shot 2019-12-30 at 10 52 14 AM" src="https://user-images.githubusercontent.com/2036040/71595973-92b4dc00-2af2-11ea-88c1-cfa471e1a754.png">

Tested with:

```js
const {app, BrowserWindow, dialog} = require('electron')

let mainWindow

app.on('ready', () => {
  mainWindow = new BrowserWindow()

  const ok = dialog.showMessageBoxSync(mainWindow, {
    type: 'question',
    message: 'testing',
    buttons: ['Ok', 'Cancel'],
    defaultId: 1,
    cancelId: 1,
  })
})
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed incorrect button highlighting when `defaultId` is passed for dialog message boxes.
