### PR TITLE
refactor: throw an error for getLastCrashReport if crashReporter not started

### DIFF
--- a/lib/common/crash-reporter.js
+++ b/lib/common/crash-reporter.js
@@ -54,7 +54,12 @@ class CrashReporter {
   }
 
   getUploadedReports () {
-    return binding.getUploadedReports(this.getCrashesDirectory())
+    const crashDir = this.getCrashesDirectory()
+    if (!crashDir) {
+      throw new Error('crashReporter has not been started')
+    }
+
+    return binding.getUploadedReports(crashDir)
   }
 
   getCrashesDirectory () {


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/21619.

Previously, if you tried to call `crashReporter.getLastCrashReport()` without starting the crash reporter, it would fail with a very unhelpful error for end users:

![before](https://user-images.githubusercontent.com/2036040/71602653-3069d480-2b0e-11ea-9126-e83c810ce560.png)

This PR refactors the error to now show: 

![after](https://user-images.githubusercontent.com/2036040/71602657-3364c500-2b0e-11ea-9830-e5710df1b667.png)

Which more clearly indicates to the user what the underlying issue is and the steps they need to take to remedy it.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Updated `crashReporter` to throw an error for `getLastCrashReport` if `crashReporter` not started.