### PR TITLE
docs: fix typos in security.md

### DIFF
--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -241,7 +241,7 @@ prevent the use of Node primitives, `contextIsolation` must also be used.
 
 ### Why?
 
-Context isolation allows each the scripts on running in the renderer to make
+Context isolation allows each of the scripts running in the renderer to make
 changes to its JavaScript environment without worrying about conflicting with
 the scripts in the Electron API or the preload script.
 

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -422,8 +422,6 @@ on a page directly in the markup using a `<meta>` tag:
 <meta http-equiv="Content-Security-Policy" content="default-src 'none'">
 ```
 
-#### `webRequest.onHeadersReceived([filter, ]listener)`
-
 
 ## 7) Do Not Set `allowRunningInsecureContent` to `true`
 


### PR DESCRIPTION
#### Description of Change
Fix ~a~ two small typos I spotted in the security docs

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes