### PR TITLE
fix: don't fallback to OpenFolderViaShell

### DIFF
--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -272,19 +272,15 @@ void ShowItemInFolderOnWorkerThread(const base::FilePath& full_path) {
   hr = desktop->ParseDisplayName(NULL, NULL,
                                  const_cast<wchar_t*>(dir.value().c_str()),
                                  NULL, &dir_item, NULL);
-  if (FAILED(hr)) {
-    ui::win::OpenFolderViaShell(dir);
+  if (FAILED(hr))
     return;
-  }
 
   base::win::ScopedCoMem<ITEMIDLIST> file_item;
   hr = desktop->ParseDisplayName(
       NULL, NULL, const_cast<wchar_t*>(full_path.value().c_str()), NULL,
       &file_item, NULL);
-  if (FAILED(hr)) {
-    ui::win::OpenFolderViaShell(dir);
+  if (FAILED(hr))
     return;
-  }
 
   const ITEMIDLIST* highlight[] = {file_item};
   hr = SHOpenFolderAndSelectItems(dir_item, base::size(highlight), highlight,
@@ -299,7 +295,6 @@ void ShowItemInFolderOnWorkerThread(const base::FilePath& full_path) {
       LOG(WARNING) << " " << __func__ << "(): Can't open full_path = \""
                    << full_path.value() << "\""
                    << " hr = " << logging::SystemErrorCodeToString(hr);
-      ui::win::OpenFolderViaShell(dir);
     }
   }
 }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/21663.

This fallback call breaks from Chromium's approach as seen [here](https://source.chromium.org/chromium/chromium/src/+/master:chrome/browser/platform_util_win.cc;l=76-81?q=SHOpenFolderAndSelectItems&ss=chromium&originalUrl=https:%2F%2Fcs.chromium.org%2Fsearch%2F); it was added in [this commit](https://github.com/electron/electron/commit/05aeceeb52eede7d11a1dcfd0761cc8b2e1b6a56) four years ago to account for shortcomings in Chromium's approach which i feel at this point is significantly more robust. This PR thus removes the fallback so that we do not cause unexpected end-user behavior with duplicate popups and lag.

cc @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue with potential duplicate error popups when calling `shell.showItemInFolder` on Windows
