### PR TITLE
feat: Exposing methods required by capturing a hidden webContents

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1225,6 +1225,29 @@ Returns `Promise<NativeImage>` - Resolves with a [NativeImage](native-image.md)
 
 Captures a snapshot of the page within `rect`. Omitting `rect` will capture the whole visible page.
 
+#### `contents.isBeingCaptured()`
+
+Returns `Boolean` - Whether this page is being captured. It returns true when the capturer count
+is large then 0.
+
+#### `contents.incrementCapturerCount([size, stayHidden])`
+
+* `size` [Size](structures/size.md) (optional) - The perferred size for the capturer.
+* `stayHidden` Boolean (optional) -  Keep the page hidden instead of visible.
+
+Increase the capturer count by one. The page is considered visible when its browser window is
+hidden and the capturer count is non-zero. If you would like the page to stay hidden, you should ensure that `stayHidden` is set to true.
+
+This also affects the Page Visibility API.
+
+#### `contents.decrementCapturerCount([stayHidden])`
+
+* `stayHidden` Boolean (optional) -  Keep the page in hidden state instead of visible.
+
+Decrease the capturer count by one. The page will be set to hidden or occluded state when its
+browser window is hidden or occluded and the capturer count reaches zero. If you want to
+decrease the hidden capturer count instead you should set `stayHidden` to true.
+
 #### `contents.getPrinters()`
 
 Get the system printer list.

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -2215,6 +2215,31 @@ v8::Local<v8::Promise> WebContents::CapturePage(gin_helper::Arguments* args) {
   return handle;
 }
 
+void WebContents::IncrementCapturerCount(gin_helper::Arguments* args) {
+  gfx::Size size;
+  bool stay_hidden = false;
+
+  // get size arguments if they exist
+  args->GetNext(&size);
+  // get stayHidden arguments if they exist
+  args->GetNext(&stay_hidden);
+
+  web_contents()->IncrementCapturerCount(size, stay_hidden);
+}
+
+void WebContents::DecrementCapturerCount(gin_helper::Arguments* args) {
+  bool stay_hidden = false;
+
+  // get stayHidden arguments if they exist
+  args->GetNext(&stay_hidden);
+
+  web_contents()->DecrementCapturerCount(stay_hidden);
+}
+
+bool WebContents::IsBeingCaptured() {
+  return web_contents()->IsBeingCaptured();
+}
+
 void WebContents::OnCursorChange(const content::WebCursor& cursor) {
   const content::CursorInfo& info = cursor.info();
 
@@ -2591,6 +2616,9 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setEmbedder", &WebContents::SetEmbedder)
       .SetMethod("setDevToolsWebContents", &WebContents::SetDevToolsWebContents)
       .SetMethod("getNativeView", &WebContents::GetNativeView)
+      .SetMethod("incrementCapturerCount", &WebContents::IncrementCapturerCount)
+      .SetMethod("decrementCapturerCount", &WebContents::DecrementCapturerCount)
+      .SetMethod("isBeingCaptured", &WebContents::IsBeingCaptured)
       .SetMethod("setWebRTCIPHandlingPolicy",
                  &WebContents::SetWebRTCIPHandlingPolicy)
       .SetMethod("getWebRTCIPHandlingPolicy",

--- a/shell/browser/api/atom_api_web_contents.h
+++ b/shell/browser/api/atom_api_web_contents.h
@@ -181,6 +181,9 @@ class WebContents : public gin_helper::TrackableObject<WebContents>,
   void SetEmbedder(const WebContents* embedder);
   void SetDevToolsWebContents(const WebContents* devtools);
   v8::Local<v8::Value> GetNativeView() const;
+  void IncrementCapturerCount(gin_helper::Arguments* args);
+  void DecrementCapturerCount(gin_helper::Arguments* args);
+  bool IsBeingCaptured();
 
 #if BUILDFLAG(ENABLE_PRINTING)
   void Print(gin_helper::Arguments* args);


### PR DESCRIPTION
#### Description of Change
This pull request adds methods required by capturing a hidden webContents. With the IncrementCapturerCount(), it's possible to capture screen shot of BrowserView which attached to
a hidden BrowserWindow. 

```javascript
var hiddenWin = new BrowserWindow({ width: 800, height: 600, show: false })
var view = new BrowserView({ webPreferences: { show: true } })

hiddenWin.addBrowserView(view)
view.setBounds({ x: 0, y: 0, width: 800, height: 600})

// view.webContents.capturePage()  works because the browser view is visible initially.

// show the page in a normal window.
var win = new BrowserWindow({ width: 800, height: 600 })
win.removeBrowserView(view)
win.addBrowserView(view)
win.show()

//  the capturePage() works because the browser window is really visible now.

// close the normal window and add the view back to the hidden window.
view.webContents.incrementCapturerCount()
win.removeBrowserView(view)
hiddenWin.addBrowserView(view)
win.close()

// the capturePage() works here because we ask the webContents to ignore the page
// visibility, it wont work without increasing the capturer count.
```

cc @MarshallOfSound @ckerr @zcbenz

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
notes: Exposing methods required by capturing a hidden webContents。