### PR TITLE
feat: allow http-parser NODE_OPTION in packaged apps

### DIFF
--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -48,6 +48,7 @@ Unsupported options are:
 
 ```sh
 --max-http-header-size
+--http-parser
 ```
 
 ### `GOOGLE_API_KEY`

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -144,7 +144,8 @@ void SetNodeOptions(base::Environment* env) {
       "--force-fips", "--enable-fips"};
 
   // Subset of options allowed in packaged apps
-  const std::set<std::string> allowed_in_packaged = {"--max-http-header-size"};
+  const std::set<std::string> allowed_in_packaged = {"--max-http-header-size",
+                                                     "--http-parser"};
 
   if (env->HasVar("NODE_OPTIONS")) {
     std::string options;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/21693.

Whitelists `--http-parser=parser` for use in packaged apps. As a rule, we only allow `NODE_OPTION`s  in packaged apps on a case by case basis, but as stated in the above linked issue, Node `v11.5.0` changed the default HTTP parser to one that breaks some use cases (see [comment](https://github.com/cypress-io/cypress/issues/5602#issuecomment-571685626)), and so that presents a compelling case for allowing this particular flag.

cc @MarshallOfSound @ckerr @zcbenz

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Changed NODE_OPTIONs to allow `--http-parser` to be used in packaged apps.
