### PR TITLE
fix: load window-setup in sandboxed renderer

### DIFF
--- a/atom/renderer/atom_sandboxed_renderer_client.cc
+++ b/atom/renderer/atom_sandboxed_renderer_client.cc
@@ -145,12 +145,6 @@ void AtomSandboxedRendererClient::InitializeBindings(
   process.SetReadOnly("sandboxed", true);
   process.SetReadOnly("type", "renderer");
   process.SetReadOnly("isMainFrame", is_main_frame);
-
-  // Pass in CLI flags needed to setup the renderer
-  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  if (command_line->HasSwitch(switches::kGuestInstanceID))
-    b.Set(options::kGuestInstanceID,
-          command_line->GetSwitchValueASCII(switches::kGuestInstanceID));
 }
 
 void AtomSandboxedRendererClient::RenderFrameCreated(

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -145,6 +145,7 @@ auto_filenames = {
     "lib/renderer/web-view/web-view-element.ts",
     "lib/renderer/web-view/web-view-impl.ts",
     "lib/renderer/web-view/web-view-init.ts",
+    "lib/renderer/window-setup.ts",
     "lib/sandboxed_renderer/api/exports/electron.js",
     "lib/sandboxed_renderer/api/module-list.js",
     "lib/sandboxed_renderer/init.js",

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -74,8 +74,10 @@ const mergeBrowserWindowOptions = function (embedder, options) {
     }
   }
 
-  // Sets correct openerId here to give correct options to 'new-window' event handler
-  options.webPreferences.openerId = embedder.id
+  if (!webPreferences.nativeWindowOpen) {
+    // Sets correct openerId here to give correct options to 'new-window' event handler
+    options.webPreferences.openerId = embedder.id
+  }
 
   return options
 }

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -517,10 +517,14 @@ ipcMainUtils.handle('ELECTRON_BROWSER_SANDBOX_LOAD', async function (event) {
     event.sender._getPreloadPath()
   ]
 
+  const webPreferences = event.sender.getLastWebPreferences() || {}
+
   return {
     preloadScripts: await Promise.all(preloadPaths.map(path => getPreloadScript(path))),
     isRemoteModuleEnabled: isRemoteModuleEnabled(event.sender),
     isWebViewTagEnabled: guestViewManager.isWebViewTagEnabled(event.sender),
+    guestInstanceId: webPreferences.guestInstanceId,
+    openerId: webPreferences.openerId,
     process: {
       arch: process.arch,
       platform: process.platform,

--- a/lib/renderer/window-setup.ts
+++ b/lib/renderer/window-setup.ts
@@ -168,7 +168,7 @@ class BrowserWindowProxy {
 export const windowSetup = (
   guestInstanceId: number, openerId: number, isHiddenPage: boolean, usesNativeWindowOpen: boolean
 ) => {
-  if (guestInstanceId == null) {
+  if (!process.sandboxed && guestInstanceId == null) {
     // Override default window.close.
     window.close = function () {
       ipcRendererInternal.sendSync('ELECTRON_BROWSER_WINDOW_CLOSE')
@@ -188,10 +188,10 @@ export const windowSetup = (
         return null
       }
     }
+  }
 
-    if (openerId != null) {
-      window.opener = getOrCreateProxy(openerId)
-    }
+  if (openerId != null) {
+    window.opener = getOrCreateProxy(openerId)
   }
 
   // But we do not support prompt().
@@ -199,42 +199,46 @@ export const windowSetup = (
     throw new Error('prompt() is and will not be supported.')
   }
 
-  ipcRendererInternal.on('ELECTRON_GUEST_WINDOW_POSTMESSAGE', function (
-    _event, sourceId: number, message: any, sourceOrigin: string
-  ) {
-    // Manually dispatch event instead of using postMessage because we also need to
-    // set event.source.
-    //
-    // Why any? We can't construct a MessageEvent and we can't
-    // use `as MessageEvent` because you're not supposed to override
-    // data, origin, and source
-    const event: any = document.createEvent('Event')
-    event.initEvent('message', false, false)
+  if (!usesNativeWindowOpen || openerId != null) {
+    ipcRendererInternal.on('ELECTRON_GUEST_WINDOW_POSTMESSAGE', function (
+      _event, sourceId: number, message: any, sourceOrigin: string
+    ) {
+      // Manually dispatch event instead of using postMessage because we also need to
+      // set event.source.
+      //
+      // Why any? We can't construct a MessageEvent and we can't
+      // use `as MessageEvent` because you're not supposed to override
+      // data, origin, and source
+      const event: any = document.createEvent('Event')
+      event.initEvent('message', false, false)
 
-    event.data = message
-    event.origin = sourceOrigin
-    event.source = getOrCreateProxy(sourceId)
+      event.data = message
+      event.origin = sourceOrigin
+      event.source = getOrCreateProxy(sourceId)
 
-    window.dispatchEvent(event as MessageEvent)
-  })
-
-  window.history.back = function () {
-    ipcRendererInternal.send('ELECTRON_NAVIGATION_CONTROLLER_GO_BACK')
+      window.dispatchEvent(event as MessageEvent)
+    })
   }
 
-  window.history.forward = function () {
-    ipcRendererInternal.send('ELECTRON_NAVIGATION_CONTROLLER_GO_FORWARD')
-  }
-
-  window.history.go = function (offset: number) {
-    ipcRendererInternal.send('ELECTRON_NAVIGATION_CONTROLLER_GO_TO_OFFSET', +offset)
-  }
-
-  defineProperty(window.history, 'length', {
-    get: function () {
-      return ipcRendererInternal.sendSync('ELECTRON_NAVIGATION_CONTROLLER_LENGTH')
+  if (!process.sandboxed) {
+    window.history.back = function () {
+      ipcRendererInternal.send('ELECTRON_NAVIGATION_CONTROLLER_GO_BACK')
     }
-  })
+
+    window.history.forward = function () {
+      ipcRendererInternal.send('ELECTRON_NAVIGATION_CONTROLLER_GO_FORWARD')
+    }
+
+    window.history.go = function (offset: number) {
+      ipcRendererInternal.send('ELECTRON_NAVIGATION_CONTROLLER_GO_TO_OFFSET', +offset)
+    }
+
+    defineProperty(window.history, 'length', {
+      get: function () {
+        return ipcRendererInternal.sendSync('ELECTRON_NAVIGATION_CONTROLLER_LENGTH')
+      }
+    })
+  }
 
   if (guestInstanceId != null) {
     // Webview `document.visibilityState` tracks window visibility (and ignores

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -30,7 +30,12 @@ const { ipcRendererInternal } = require('@electron/internal/renderer/ipc-rendere
 const ipcRendererUtils = require('@electron/internal/renderer/ipc-renderer-internal-utils')
 
 const {
-  preloadScripts, isRemoteModuleEnabled, isWebViewTagEnabled, process: processProps
+  preloadScripts,
+  isRemoteModuleEnabled,
+  isWebViewTagEnabled,
+  guestInstanceId,
+  openerId,
+  process: processProps
 } = ipcRendererUtils.invokeSync('ELECTRON_BROWSER_SANDBOX_LOAD')
 
 process.isRemoteModuleEnabled = isRemoteModuleEnabled
@@ -107,6 +112,11 @@ function preloadRequire (module) {
 const { hasSwitch } = process.electronBinding('command_line')
 
 const contextIsolation = hasSwitch('context-isolation')
+const isHiddenPage = hasSwitch('hidden-page')
+const usesNativeWindowOpen = true
+
+// The arguments to be passed to isolated world.
+const isolatedWorldArgs = { ipcRendererInternal, guestInstanceId, isHiddenPage, openerId, usesNativeWindowOpen }
 
 switch (window.location.protocol) {
   case 'devtools:': {
@@ -123,17 +133,24 @@ switch (window.location.protocol) {
     break
   }
   default: {
+    // Override default web functions.
+    const { windowSetup } = require('@electron/internal/renderer/window-setup')
+    windowSetup(guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
+
     // Inject content scripts.
     require('@electron/internal/renderer/content-scripts-injector')(binding.getRenderProcessPreferences)
   }
 }
 
-const guestInstanceId = binding.guestInstanceId && parseInt(binding.guestInstanceId)
-
 // Load webview tag implementation.
 if (process.isMainFrame) {
   const { webViewInit } = require('@electron/internal/renderer/web-view/web-view-init')
   webViewInit(contextIsolation, isWebViewTagEnabled, guestInstanceId)
+}
+
+// Pass the arguments to isolatedWorld.
+if (contextIsolation) {
+  v8Util.setHiddenValue(global, 'isolated-world-args', isolatedWorldArgs)
 }
 
 const errorUtils = require('@electron/internal/common/error-utils')


### PR DESCRIPTION
Backport of #21416

See that PR for details.

Notes: Fixed an issue that could prevent communication between a sandboxed child window opened with `nativeWindowOpen: false` and an unsandboxed parent window. Also fixed `document.visibilityState` not working in sandboxed `<webview>`.