### PR TITLE
docs: event.newGuest for new-window in WebContents and webContents in BrowsweWindow's constructor

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -190,6 +190,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `paintWhenInitiallyHidden` Boolean (optional) - Whether the renderer should be active when `show` is `false` and it has just been created.  In order for `document.visibilityState` to work correctly on first load with `show: false` you should set this to `false`.  Setting this to `false` will cause the `ready-to-show` event to not fire.  Default is `true`.
   * `frame` Boolean (optional) - Specify `false` to create a
     [Frameless Window](frameless-window.md). Default is `true`.
+  * `webContents` WebContents (optional) - Specify `webContents` if there is any existing one.
   * `parent` BrowserWindow (optional) - Specify parent window. Default is `null`.
   * `modal` Boolean (optional) - Whether this is a modal window. This only works when the
     window is a child window. Default is `false`.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -190,7 +190,6 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `paintWhenInitiallyHidden` Boolean (optional) - Whether the renderer should be active when `show` is `false` and it has just been created.  In order for `document.visibilityState` to work correctly on first load with `show: false` you should set this to `false`.  Setting this to `false` will cause the `ready-to-show` event to not fire.  Default is `true`.
   * `frame` Boolean (optional) - Specify `false` to create a
     [Frameless Window](frameless-window.md). Default is `true`.
-  * `webContents` WebContents (optional) - Specify `webContents` if there is any existing one.
   * `parent` BrowserWindow (optional) - Specify parent window. Default is `null`.
   * `modal` Boolean (optional) - Whether this is a modal window. This only works when the
     window is a child window. Default is `false`.

--- a/docs/api/structures/new-window-event.md
+++ b/docs/api/structures/new-window-event.md
@@ -1,0 +1,4 @@
+# NewWindowEvent Object extends `Event`
+
+* `newGuest` BrowserWindow (optional)
+

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -138,7 +138,7 @@ Emitted when page receives favicon urls.
 
 Returns:
 
-* `event` Event
+* `event` NewWindowEvent
 * `url` String
 * `frameName` String
 * `disposition` String - Can be `default`, `foreground-tab`, `background-tab`,

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -96,6 +96,7 @@ auto_filenames = {
     "docs/api/structures/mime-typed-buffer.md",
     "docs/api/structures/mouse-input-event.md",
     "docs/api/structures/mouse-wheel-input-event.md",
+    "docs/api/structures/new-window-event.md",
     "docs/api/structures/notification-action.md",
     "docs/api/structures/point.md",
     "docs/api/structures/printer-info.md",


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
According to the example codes in the documentation of [`new-window` event](https://electronjs.org/docs/api/web-contents#event-new-window) in `WebContents`, the following properties are both existing but documented:
  - `webContents` in `BrowsweWindow` constructor options
  - `newGuest` in `event` argument of `new-window` handler of `WebContents`

This patch is for adding the related documentations. Also, it provides typescript-definitations for these two properties.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: `newGuest` in `new-window` event of `WebContents` and `webContents` in `BrowsweWindow` constructor were well-documented.
<!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
