### PR TITLE
fix: don't unnecessarily copy draggable regions

### DIFF
--- a/shell/browser/api/atom_api_browser_window_mac.mm
+++ b/shell/browser/api/atom_api_browser_window_mac.mm
@@ -101,9 +101,11 @@ void BrowserWindow::UpdateDraggableRegions(
 
   // Draggable regions is implemented by having the whole web view draggable
   // (mouseDownCanMoveWindow) and overlaying regions that are not draggable.
-  draggable_regions_.clear();
-  for (const auto& r : regions)
-    draggable_regions_.push_back(r.Clone());
+  if (&draggable_regions_ != &regions) {
+    draggable_regions_.clear();
+    for (const auto& r : regions)
+      draggable_regions_.push_back(r.Clone());
+  }
   std::vector<gfx::Rect> drag_exclude_rects;
   if (regions.empty()) {
     drag_exclude_rects.push_back(gfx::Rect(0, 0, webViewWidth, webViewHeight));


### PR DESCRIPTION
In some calls to `BrowserWindow::UpdateDraggableRegions` the parameter
`regions` points to object's variable `draggable_regions_` which we later
try to update with data received in the parameter. In these cases coping
is unnecessary. Additionally after this code is executed `draggable_regions_`
would be empty and as a result whole window would be undraggable.
In our project which uses Electron it's possible to create frameless window
which doesn't repect css option `webkit-app-region: drag` and is undraggable
because of this problem but it would be hard to create one for clean
Electron.

notes: removed unnecessary and potentially error-prone coping of data
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue that could cause frameless windows to become undraggable in some circumstances.
