### PR TITLE
feat: remove visibleOnFullscreen option

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1627,12 +1627,9 @@ can still bring up the menu bar by pressing the single `Alt` key.
 
 Returns `Boolean` - Whether the menu bar is visible.
 
-#### `win.setVisibleOnAllWorkspaces(visible[, options])`
+#### `win.setVisibleOnAllWorkspaces(visible)`
 
 * `visible` Boolean
-* `options` Object (optional)
-  * `visibleOnFullScreen` Boolean (optional) _macOS_ - Sets whether
-    the window should be visible above fullscreen windows
 
 Sets whether the window should be visible on all workspaces.
 

--- a/shell/browser/api/atom_api_top_level_window.cc
+++ b/shell/browser/api/atom_api_top_level_window.cc
@@ -790,13 +790,8 @@ void TopLevelWindow::SetOverlayIcon(const gfx::Image& overlay,
   window_->SetOverlayIcon(overlay, description);
 }
 
-void TopLevelWindow::SetVisibleOnAllWorkspaces(bool visible,
-                                               gin_helper::Arguments* args) {
-  gin_helper::Dictionary options;
-  bool visibleOnFullScreen = false;
-  args->GetNext(&options) &&
-      options.Get("visibleOnFullScreen", &visibleOnFullScreen);
-  return window_->SetVisibleOnAllWorkspaces(visible, visibleOnFullScreen);
+void TopLevelWindow::SetVisibleOnAllWorkspaces(bool visible) {
+  return window_->SetVisibleOnAllWorkspaces(visible);
 }
 
 bool TopLevelWindow::IsVisibleOnAllWorkspaces() {

--- a/shell/browser/api/atom_api_top_level_window.h
+++ b/shell/browser/api/atom_api_top_level_window.h
@@ -181,7 +181,7 @@ class TopLevelWindow : public gin_helper::TrackableObject<TopLevelWindow>,
   void SetProgressBar(double progress, gin_helper::Arguments* args);
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description);
-  void SetVisibleOnAllWorkspaces(bool visible, gin_helper::Arguments* args);
+  void SetVisibleOnAllWorkspaces(bool visible);
   bool IsVisibleOnAllWorkspaces();
   void SetAutoHideCursor(bool auto_hide);
   virtual void SetVibrancy(v8::Isolate* isolate, v8::Local<v8::Value> value);

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -185,8 +185,7 @@ class NativeWindow : public base::SupportsUserData,
                               const std::string& description) = 0;
 
   // Workspace APIs.
-  virtual void SetVisibleOnAllWorkspaces(bool visible,
-                                         bool visibleOnFullScreen = false) = 0;
+  virtual void SetVisibleOnAllWorkspaces(bool visible) = 0;
 
   virtual bool IsVisibleOnAllWorkspaces() = 0;
 

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -117,8 +117,7 @@ class NativeWindowMac : public NativeWindow {
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description) override;
 
-  void SetVisibleOnAllWorkspaces(bool visible,
-                                 bool visibleOnFullScreen) override;
+  void SetVisibleOnAllWorkspaces(bool visible) override;
   bool IsVisibleOnAllWorkspaces() override;
 
   void SetAutoHideCursor(bool auto_hide) override;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1271,11 +1271,8 @@ void NativeWindowMac::SetProgressBar(double progress,
 void NativeWindowMac::SetOverlayIcon(const gfx::Image& overlay,
                                      const std::string& description) {}
 
-void NativeWindowMac::SetVisibleOnAllWorkspaces(bool visible,
-                                                bool visibleOnFullScreen) {
+void NativeWindowMac::SetVisibleOnAllWorkspaces(bool visible) {
   SetCollectionBehavior(visible, NSWindowCollectionBehaviorCanJoinAllSpaces);
-  SetCollectionBehavior(visibleOnFullScreen,
-                        NSWindowCollectionBehaviorFullScreenAuxiliary);
 }
 
 bool NativeWindowMac::IsVisibleOnAllWorkspaces() {

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1156,8 +1156,7 @@ bool NativeWindowViews::IsMenuBarVisible() {
   return root_view_->IsMenuBarVisible();
 }
 
-void NativeWindowViews::SetVisibleOnAllWorkspaces(bool visible,
-                                                  bool visibleOnFullScreen) {
+void NativeWindowViews::SetVisibleOnAllWorkspaces(bool visible) {
   widget()->SetVisibleOnAllWorkspaces(visible);
 }
 

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -123,8 +123,7 @@ class NativeWindowViews : public NativeWindow,
   void SetMenuBarVisibility(bool visible) override;
   bool IsMenuBarVisible() override;
 
-  void SetVisibleOnAllWorkspaces(bool visible,
-                                 bool visibleOnFullScreen) override;
+  void SetVisibleOnAllWorkspaces(bool visible) override;
 
   bool IsVisibleOnAllWorkspaces() override;
 


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/14122.

This was originally added and tested on macOS 10.13.6 High Sierra; unfortunately, however, Apple changed the underlying functionality of `NSWindow`s starting with 10.14 to disallow `NSWindow`s from floating on top of fullscreen apps. The only way to achieve this now is with an `NSPanel`, which we don't utilize within `BrowserWindow`s.

As such, I believe this should be removed for now as it will not work for the majority of macOS users and was a macOS-specific API options as it stood. I also believe this should perhaps target 8, as it simply does not work and thus users stand to gain nothing from having it there to avoid the appearance of a breaking change.

BREAKING CHANGE

cc @electron/wg-api 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Removed the `visibleOnFullscreen` option in `setVisibleOnAllWorkspaces.`