### PR TITLE
fix: Notification crash in destructor on app quit

### DIFF
--- a/shell/browser/api/atom_api_notification.cc
+++ b/shell/browser/api/atom_api_notification.cc
@@ -205,6 +205,7 @@ void Notification::NotificationClosed() {
 void Notification::Close() {
   if (notification_) {
     notification_->Dismiss();
+    notification_->set_delegate(nullptr);
     notification_.reset();
   }
 }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/19842.
Closes https://github.com/electron/electron/issues/18701.

Previously, when you close the api notification, that notification forgets about the platform notification. As such, when it is destroyed it will not call [`set_delegate(nullptr)`](https://github.com/electron/electron/blob/0fe6767d6b8992d0ac3036d553ead1e529b854f3/shell/browser/api/atom_api_notification.cc#L77-L80). The notification can be reset [here](https://github.com/electron/electron/blob/0fe6767d6b8992d0ac3036d553ead1e529b854f3/shell/browser/api/atom_api_notification.cc#L205-L210) without the delegate having been reset, which creates the conditions necessary for this crash. This PR fixes that by ensuring that the delegate is _always_ set to `nullptr` before the notification is reset.

cc @MarshallOfSound @nornagon  

h/t to @charlag for great work investigating this!

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash that would occur when Notifications were closed in concert with app termination.
