### PR TITLE
fix: pass startPage url correctly to extensions

### DIFF
--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -57,18 +57,23 @@ const getManifestFromPath = function (srcDirectory) {
   if (!manifestNameMap[manifest.name]) {
     const extensionId = generateExtensionIdFromName(manifest.name)
     manifestMap[extensionId] = manifestNameMap[manifest.name] = manifest
+
+    const extensionURL = url.format({
+      protocol: 'chrome-extension',
+      slashes: true,
+      hostname: extensionId,
+      pathname: manifest.devtools_page
+    })
+
     Object.assign(manifest, {
       srcDirectory: srcDirectory,
       extensionId: extensionId,
-      // We can not use 'file://' directly because all resources in the extension
-      // will be treated as relative to the root in Chrome.
-      startPage: url.format({
-        protocol: 'chrome-extension',
-        slashes: true,
-        hostname: extensionId,
-        pathname: manifest.devtools_page
-      })
+      // Chromium requires that startPage matches '([^:]+:\/\/[^/]*)\/'
+      // We also can't use the file:// protocol here since that would make Chromium
+      // treat all extension resources as being relative to root which we don't want.
+      startPage: `${extensionURL}/`
     })
+
     return manifest
   } else if (manifest && manifest.name) {
     console.warn(`Attempted to load extension "${manifest.name}" that has already been loaded.`)
@@ -389,7 +394,8 @@ const loadDevToolsExtensions = function (win, manifests) {
   })
 
   extensionInfoArray.forEach((extensionInfo) => {
-    win.devToolsWebContents.executeJavaScript(`Extensions.extensionServer._addExtension(${JSON.stringify(extensionInfo)})`)
+    const info = JSON.stringify(extensionInfo)
+    win.devToolsWebContents.executeJavaScript(`Extensions.extensionServer._addExtension(${info})`)
   })
 }
 

--- a/lib/browser/chrome-extension.js
+++ b/lib/browser/chrome-extension.js
@@ -58,20 +58,22 @@ const getManifestFromPath = function (srcDirectory) {
     const extensionId = generateExtensionIdFromName(manifest.name)
     manifestMap[extensionId] = manifestNameMap[manifest.name] = manifest
 
-    const extensionURL = url.format({
+    let extensionURL = url.format({
       protocol: 'chrome-extension',
       slashes: true,
       hostname: extensionId,
       pathname: manifest.devtools_page
     })
 
+    // Chromium requires that startPage matches '([^:]+:\/\/[^/]*)\/'
+    // We also can't use the file:// protocol here since that would make Chromium
+    // treat all extension resources as being relative to root which we don't want.
+    if (!manifest.devtools_page) extensionURL += '/'
+
     Object.assign(manifest, {
       srcDirectory: srcDirectory,
       extensionId: extensionId,
-      // Chromium requires that startPage matches '([^:]+:\/\/[^/]*)\/'
-      // We also can't use the file:// protocol here since that would make Chromium
-      // treat all extension resources as being relative to root which we don't want.
-      startPage: `${extensionURL}/`
+      startPage: extensionURL
     })
 
     return manifest


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/21673.

Chromium requires that the `startPage` url [match this pattern](https://source.chromium.org/chromium/chromium/src/+/master:third_party/devtools-frontend/src/front_end/extensions/ExtensionServer.js;l=706?q=%22Skipping%20extension%20with%20invalid%20URL%22&ss=chromium&originalUrl=https:%2F%2Fcs.chromium.org%2Fsearch%2F):

```js
const urlOriginRegExp = new RegExp('([^:]+:\/\/[^/]*)\/');
```

This PR thus tweaks our `getManifestFromPath` logic to add a trailing slash to the result returned from `url.format` when we add `srcDirectory`, `extensionId,`, and `startPage` to the extension manifest.

cc @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where extension URLs were passing an incorrectly formatted `startPage`.
