### PR TITLE
docs: responseHeaders should be Record<string, string[]>

### DIFF
--- a/docs/api/web-request.md
+++ b/docs/api/web-request.md
@@ -146,7 +146,7 @@ response are visible by the time this listener is fired.
     * `timestamp` Double
     * `statusLine` String
     * `statusCode` Integer
-    * `responseHeaders` Record<string, string> (optional)
+    * `responseHeaders` Record<string, string[]> (optional)
   * `callback` Function
     * `headersReceivedResponse` Object
       * `cancel` Boolean (optional)
@@ -175,7 +175,7 @@ The `callback` has to be called with a `response` object.
     * `resourceType` String
     * `referrer` String
     * `timestamp` Double
-    * `responseHeaders` Record<string, string> (optional)
+    * `responseHeaders` Record<string, string[]> (optional)
     * `fromCache` Boolean - Indicates whether the response was fetched from disk
       cache.
     * `statusCode` Integer
@@ -205,7 +205,7 @@ and response headers are available.
     * `ip` String (optional) - The server IP address that the request was
       actually sent to.
     * `fromCache` Boolean
-    * `responseHeaders` Record<string, string> (optional)
+    * `responseHeaders` Record<string, string[]> (optional)
 
 The `listener` will be called with `listener(details)` when a server initiated
 redirect is about to occur.
@@ -224,7 +224,7 @@ redirect is about to occur.
     * `resourceType` String
     * `referrer` String
     * `timestamp` Double
-    * `responseHeaders` Record<string, string> (optional)
+    * `responseHeaders` Record<string, string[]> (optional)
     * `fromCache` Boolean
     * `statusCode` Integer
     * `statusLine` String


### PR DESCRIPTION
#### Description of Change
The values in `responseHeaders` are received as arrays as can be seen by running this code:
```js
session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
  console.log('onHeadersReceived', details)
  callback({ responseHeaders: details.responseHeaders });
})

session.defaultSession.webRequest.onResponseStarted((details) => {
  console.log('onResponseStarted', details)    
})

session.defaultSession.webRequest.onCompleted((details) => {
  console.log('onCompleted', details)    
})
```
outputs
```js
onHeadersReceived {
  id: 1,
  url: 'https://www.example.com/',
  method: 'GET',
  timestamp: 1578667512665.565,
  resourceType: 'mainFrame',
  fromCache: false,
  statusLine: 'HTTP/1.1 200',
  statusCode: 200,
  responseHeaders: {
    'accept-ranges': [ 'bytes' ],
    'cache-control': [ 'max-age=604800' ],
    'content-encoding': [ 'gzip' ],
    'content-length': [ '648' ],
    'content-type': [ 'text/html; charset=UTF-8' ],
    date: [ 'Fri, 10 Jan 2020 14:34:06 GMT' ],
    etag: [ '"3147526947"' ],
    expires: [ 'Fri, 17 Jan 2020 14:34:06 GMT' ],
    'last-modified': [ 'Thu, 17 Oct 2019 07:18:26 GMT' ],
    server: [ 'ECS (bsa/EB20)' ],
    status: [ '200' ],
    vary: [ 'Accept-Encoding' ],
    'x-cache': [ 'HIT' ]
  },
  webContentsId: 1,
  referrer: ''
}

onResponseStarted {
  id: 1,
  url: 'https://www.example.com/',
  method: 'GET',
  timestamp: 1578667512682.504,
  resourceType: 'mainFrame',
  ip: '2606:2800:220:1:248:1893:25c8:1946',
  fromCache: true,
  statusLine: 'HTTP/1.1 200',
  statusCode: 200,
  responseHeaders: {
    'accept-ranges': [ 'bytes' ],
    'cache-control': [ 'max-age=604800' ],
    'content-encoding': [ 'gzip' ],
    'content-length': [ '648' ],
    'content-type': [ 'text/html; charset=UTF-8' ],
    date: [ 'Fri, 10 Jan 2020 14:34:06 GMT' ],
    etag: [ '"3147526947"' ],
    expires: [ 'Fri, 17 Jan 2020 14:34:06 GMT' ],
    'last-modified': [ 'Thu, 17 Oct 2019 07:18:26 GMT' ],
    server: [ 'ECS (bsa/EB20)' ],
    status: [ '200' ],
    vary: [ 'Accept-Encoding' ],
    'x-cache': [ 'HIT' ]
  },
  webContentsId: 1,
  referrer: ''
}

onCompleted {
  id: 1,
  url: 'https://www.example.com/',
  method: 'GET',
  timestamp: 1578667512683.189,
  resourceType: 'mainFrame',
  ip: '2606:2800:220:1:248:1893:25c8:1946',
  fromCache: true,
  statusLine: 'HTTP/1.1 200',
  statusCode: 200,
  responseHeaders: {
    'accept-ranges': [ 'bytes' ],
    'cache-control': [ 'max-age=604800' ],
    'content-encoding': [ 'gzip' ],
    'content-length': [ '648' ],
    'content-type': [ 'text/html; charset=UTF-8' ],
    date: [ 'Fri, 10 Jan 2020 14:34:06 GMT' ],
    etag: [ '"3147526947"' ],
    expires: [ 'Fri, 17 Jan 2020 14:34:06 GMT' ],
    'last-modified': [ 'Thu, 17 Oct 2019 07:18:26 GMT' ],
    server: [ 'ECS (bsa/EB20)' ],
    status: [ '200' ],
    vary: [ 'Accept-Encoding' ],
    'x-cache': [ 'HIT' ]
  },
  webContentsId: 1,
  referrer: '',
  error: 'net::OK'
}
```
Follow-up to #18302

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed `responseHeaders` types in `electron.d.ts`