### PR TITLE
chore: deprecate visibleOnFullScreen option

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1627,7 +1627,7 @@ Returns `Boolean` - Whether the menu bar is visible.
 * `visible` Boolean
 * `options` Object (optional)
   * `visibleOnFullScreen` Boolean (optional) _macOS_ - Sets whether
-    the window should be visible above fullscreen windows
+    the window should be visible above fullscreen windows _deprecated_
 
 Sets whether the window should be visible on all workspaces.
 

--- a/shell/browser/api/atom_api_top_level_window.cc
+++ b/shell/browser/api/atom_api_top_level_window.cc
@@ -15,6 +15,7 @@
 #include "shell/browser/api/atom_api_view.h"
 #include "shell/browser/api/atom_api_web_contents.h"
 #include "shell/common/color_util.h"
+#include "shell/common/deprecate_util.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_converters/file_path_converter.h"
 #include "shell/common/gin_converters/gfx_converter.h"
@@ -794,6 +795,13 @@ void TopLevelWindow::SetVisibleOnAllWorkspaces(bool visible,
   bool visibleOnFullScreen = false;
   args->GetNext(&options) &&
       options.Get("visibleOnFullScreen", &visibleOnFullScreen);
+  if (visibleOnFullScreen) {
+    node::Environment* env = node::Environment::GetCurrent(args->isolate());
+    EmitDeprecationWarning(
+        env, "visibleOnFullScreen is deprecated and will be removed",
+        "electron");
+  }
+
   return window_->SetVisibleOnAllWorkspaces(visible, visibleOnFullScreen);
 }
 


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/21706.

Deprecate the nonfunctional `visibleOnFullScreen` option within `win.setVisibleOnAllWorkspaces` prior to its removal in the next major release version.

cc @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
