### PR TITLE
fix: stream protocols not completing

### DIFF
--- a/shell/browser/net/node_stream_loader.cc
+++ b/shell/browser/net/node_stream_loader.cc
@@ -102,6 +102,9 @@ void NodeStreamLoader::ReadMore() {
   if (!ret.ToLocal(&buffer) || !node::Buffer::HasInstance(buffer)) {
     readable_ = false;
     is_reading_ = false;
+    if (ended_) {
+      NotifyComplete(result_);
+    }
     return;
   }
 


### PR DESCRIPTION
#### Description of Change
It's possible for NodeStreamLoader to receive the "end" event from the source stream while it's still writing to the network service. When that happens, it doesn't immediately clean itself up; instead it notes that the source stream is finished and waits for the write operation to complete. However, it wasn't correctly calling `NotifyComplete` when finishing the final write operation. This adds that call when appropriate.

Fixes #21018. h/t to @pfrazee for the minimal repro which allowed me to track this down.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where custom stream protocols would sometimes not complete responses when the data stream ended.