### PR TITLE
docs: Little fix in Goma docs

### DIFF
--- a/docs/development/goma.md
+++ b/docs/development/goma.md
@@ -18,14 +18,14 @@ gn gen out/Testing --args="import(\"//electron/build/args/testing.gn\") import(\
 ```
 
 You must ensure that you do not have `cc_wrapper` configured, this means you
-can't use `sccache` or similar technology.
+can't use `sccache` or similar technology. 
 
 Before you can use goma to build Electron you need to authenticate against
 the Goma service.  You only need to do this once per-machine.
 
 ```bash
 cd electron/external_binaries/goma
-goma_auth.py login
+./goma_auth.py login
 ```
 
 Once authenticated you need to make sure the goma daemon is running on your
@@ -33,7 +33,7 @@ machine.
 
 ```bash
 cd electron/external_binaries/goma
-goma_ctl.py ensure_start
+./goma_ctl.py ensure_start
 ```
 
 ## Building with Goma

--- a/docs/development/goma.md
+++ b/docs/development/goma.md
@@ -18,7 +18,7 @@ gn gen out/Testing --args="import(\"//electron/build/args/testing.gn\") import(\
 ```
 
 You must ensure that you do not have `cc_wrapper` configured, this means you
-can't use `sccache` or similar technology. 
+can't use `sccache` or similar technology.
 
 Before you can use goma to build Electron you need to authenticate against
 the Goma service.  You only need to do this once per-machine.


### PR DESCRIPTION
#### Description of Change

Barely worth the PR, but if I don't make this change now, I'll forget about it. Most shells will require that a `py` script is invoked with the qualified path, so adding a `./` in front of it will do the trick.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes