### PR TITLE
ci: Use Visual Studio Build Tools instead of VS Studio for reproducible builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@
 
 version: 1.0.{build}
 build_cloud: libcc-20
-image: vs2019-16.3-10.0.18362
+image: vs2019bt-16.4.0
 environment:
   GIT_CACHE_PATH: C:\Users\electron\libcc_cache
   ELECTRON_OUT_DIR: Default


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
In order to better support reproducible builds on Windows, this PR changes our CI builds to use Visual Studio Build Tools instead of Visual Studio because specific versions of Visual Studio Build tools can be downloaded from here: https://docs.microsoft.com/en-us/visualstudio/releases/2019/history, but specific Community Versions of Visual Studio cannot be downloaded.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
