### PR TITLE
docs: ignore_locks not break_repo_locks

### DIFF
--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -265,8 +265,7 @@ New-ItemProperty -Path "HKLM:\System\CurrentControlSet\Services\Lanmanworkstatio
 
 ### Stale locks in the git cache
 If `gclient sync` is interrupted while using the git cache, it will leave
-the cache locked. To remove the lock, pass the `--break_repo_locks` argument to
-`gclient sync`.
+the cache locked. To remove the lock, pass the `--ignore_locks` argument to `gclient sync`.
 
 ### I'm being asked for a username/password for chromium-internal.googlesource.com
 If you see a prompt for `Username for 'https://chrome-internal.googlesource.com':` when running `gclient sync` on Windows, it's probably because the `DEPOT_TOOLS_WIN_TOOLCHAIN` environment variable is not set to 0. Open `Control Panel` → `System and Security` → `System` → `Advanced system settings` and add a system variable


### PR DESCRIPTION
#### Description of Change

`--break_repo_locks` breaks _repo_ locks and not cache locks. To handle stale locks in the cache, users should instead use `--ignore_locks`

cc @nornagon 

#### Release Notes

Notes: none
