### PR TITLE
refactor: try just using regular [Sync] for MessageSync

### DIFF
--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -116,7 +116,7 @@ BrowserWindow.getFocusedWindow = () => {
 
 BrowserWindow.fromWebContents = (webContents) => {
   for (const window of BrowserWindow.getAllWindows()) {
-    if (window.webContents.equal(webContents)) return window
+    if (window.webContents && window.webContents.equal(webContents)) return window
   }
 }
 

--- a/shell/common/api/api.mojom
+++ b/shell/common/api/api.mojom
@@ -42,10 +42,7 @@ interface ElectronBrowser {
 
   // Emits an event on |channel| from the ipcMain JavaScript object in the main
   // process, and waits synchronously for a response.
-  //
-  // NB. this is not marked [Sync] because mojo synchronous methods can be
-  // reordered with respect to asynchronous methods on the same channel.
-  // Instead, callers can manually block on the response to this method.
+  [Sync]
   MessageSync(
     bool internal,
     string channel,

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -599,13 +599,11 @@ describe('BrowserWindow module', () => {
     })
 
     describe('BrowserWindow.getFocusedWindow()', () => {
-      it('returns the opener window when dev tools window is focused', (done) => {
+      it('returns the opener window when dev tools window is focused', async () => {
         w.show()
-        w.webContents.once('devtools-focused', () => {
-          expect(BrowserWindow.getFocusedWindow()).to.equal(w)
-          done()
-        })
         w.webContents.openDevTools({ mode: 'undocked' })
+        await emittedOnce(w.webContents, 'devtools-focused')
+        expect(BrowserWindow.getFocusedWindow()).to.equal(w)
       })
     })
 


### PR DESCRIPTION
Backport of #20797

See that PR for details.

Notes: fixed potential hang when sending syncronous IPC messages on process shutdown