### PR TITLE
feat: custom positioning for traffic light buttons

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -229,6 +229,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       unless hovered over in the top left of the window. These custom buttons prevent
       issues with mouse events that occur with the standard window toolbar buttons.
       **Note:** This option is currently experimental.
+  * `trafficLightOffsetX` Number (optional) - Set a custom the x-position for the traffic light buttons. Default is `0`. Can only be used with `titleBarStyle` set to `hidden`
+  * `trafficLightOffsetY` Number (optional) - Set a custom the y-position for the traffic light buttons. Default is `0`. Can only be used with `titleBarStyle` set to `hidden`
   * `fullscreenWindowTitle` Boolean (optional) - Shows the title in the
     title bar in full screen mode on macOS for all `titleBarStyle` options.
     Default is `false`.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -229,8 +229,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       unless hovered over in the top left of the window. These custom buttons prevent
       issues with mouse events that occur with the standard window toolbar buttons.
       **Note:** This option is currently experimental.
-  * `trafficLightOffsetX` Number (optional) - Set a custom the x-position for the traffic light buttons. Default is `0`. Can only be used with `titleBarStyle` set to `hidden`
-  * `trafficLightOffsetY` Number (optional) - Set a custom the y-position for the traffic light buttons. Default is `0`. Can only be used with `titleBarStyle` set to `hidden`
+  * `trafficLightPosition` [Point](structures/point.md) (optional) - Set a custom position for the traffic light buttons. Can only be used with `titleBarStyle` set to `hidden`
   * `fullscreenWindowTitle` Boolean (optional) - Shows the title in the
     title bar in full screen mode on macOS for all `titleBarStyle` options.
     Default is `false`.

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -204,8 +204,7 @@ class NativeWindowMac : public NativeWindow {
   bool fullscreen_window_title_ = false;
   bool resizable_ = true;
   bool exiting_fullscreen_ = false;
-  double traffic_light_offsetX_ = 0;
-  double traffic_light_offsetY_ = 0;
+  gfx::Point traffic_light_position_;
 
   NSInteger attention_request_id_ = 0;  // identifier from requestUserAttention
 

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -152,7 +152,6 @@ class NativeWindowMac : public NativeWindow {
   // Custom traffic light positioning
   void RepositionTrafficLights();
   void SetExitingFullScreen(bool flag);
-  void SetEnteringFullScreen(bool flag);
 
   enum class TitleBarStyle {
     NORMAL,
@@ -167,7 +166,6 @@ class NativeWindowMac : public NativeWindow {
   bool zoom_to_page_width() const { return zoom_to_page_width_; }
   bool fullscreen_window_title() const { return fullscreen_window_title_; }
   bool always_simple_fullscreen() const { return always_simple_fullscreen_; }
-  bool entering_fullscreen() const { return entering_fullscreen_; }
   bool exiting_fullscreen() const { return exiting_fullscreen_; }
 
  protected:
@@ -205,7 +203,6 @@ class NativeWindowMac : public NativeWindow {
   bool zoom_to_page_width_ = false;
   bool fullscreen_window_title_ = false;
   bool resizable_ = true;
-  bool entering_fullscreen_ = false;
   bool exiting_fullscreen_ = false;
   double traffic_light_offsetX_ = 0;
   double traffic_light_offsetY_ = 0;

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -149,6 +149,11 @@ class NativeWindowMac : public NativeWindow {
   void SetCollectionBehavior(bool on, NSUInteger flag);
   void SetWindowLevel(int level);
 
+  // Custom traffic light positioning
+  void RepositionTrafficLights();
+  void SetExitingFullScreen(bool flag);
+  void SetEnteringFullScreen(bool flag);
+
   enum class TitleBarStyle {
     NORMAL,
     HIDDEN,
@@ -162,6 +167,8 @@ class NativeWindowMac : public NativeWindow {
   bool zoom_to_page_width() const { return zoom_to_page_width_; }
   bool fullscreen_window_title() const { return fullscreen_window_title_; }
   bool always_simple_fullscreen() const { return always_simple_fullscreen_; }
+  bool entering_fullscreen() const { return entering_fullscreen_; }
+  bool exiting_fullscreen() const { return exiting_fullscreen_; }
 
  protected:
   // views::WidgetDelegate:
@@ -198,6 +205,10 @@ class NativeWindowMac : public NativeWindow {
   bool zoom_to_page_width_ = false;
   bool fullscreen_window_title_ = false;
   bool resizable_ = true;
+  bool entering_fullscreen_ = false;
+  bool exiting_fullscreen_ = false;
+  double traffic_light_offsetX_ = 0;
+  double traffic_light_offsetY_ = 0;
 
   NSInteger attention_request_id_ = 0;  // identifier from requestUserAttention
 

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -669,10 +669,6 @@ bool NativeWindowMac::IsVisible() {
   return [window_ isVisible] && !occluded && !IsMinimized();
 }
 
-void NativeWindowMac::SetEnteringFullScreen(bool flag) {
-  entering_fullscreen_ = flag;
-}
-
 void NativeWindowMac::SetExitingFullScreen(bool flag) {
   exiting_fullscreen_ = flag;
 }

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -513,7 +513,6 @@ NativeWindowMac::~NativeWindowMac() {
 
 void NativeWindowMac::RepositionTrafficLights() {
   if (!traffic_light_offsetX_ && !traffic_light_offsetY_) {
-    NSLog(@"in here");
     return;
   }
 
@@ -664,9 +663,6 @@ void NativeWindowMac::Hide() {
 bool NativeWindowMac::IsVisible() {
   bool occluded = [window_ occlusionState] == NSWindowOcclusionStateVisible;
 
-  if (title_bar_style_ == TitleBarStyle::HIDDEN && !entering_fullscreen()) {
-    RepositionTrafficLights();
-  }
   // For a window to be visible, it must be visible to the user in the
   // foreground of the app, which means that it should not be minimized or
   // occluded

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -28,6 +28,7 @@
 #include "shell/browser/ui/inspectable_web_contents_view.h"
 #include "shell/browser/window_list.h"
 #include "shell/common/deprecate_util.h"
+#include "shell/common/gin_converters/gfx_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/options_switches.h"
 #include "skia/ext/skia_utils_mac.h"
@@ -335,8 +336,7 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   options.Get(options::kZoomToPageWidth, &zoom_to_page_width_);
   options.Get(options::kFullscreenWindowTitle, &fullscreen_window_title_);
   options.Get(options::kSimpleFullScreen, &always_simple_fullscreen_);
-  options.Get(options::kTrafficLightOffsetX, &traffic_light_offsetX_);
-  options.Get(options::kTrafficLightOffsetY, &traffic_light_offsetY_);
+  options.Get(options::kTrafficLightPosition, &traffic_light_position_);
 
   bool minimizable = true;
   options.Get(options::kMinimizable, &minimizable);
@@ -512,7 +512,7 @@ NativeWindowMac::~NativeWindowMac() {
 }
 
 void NativeWindowMac::RepositionTrafficLights() {
-  if (!traffic_light_offsetX_ && !traffic_light_offsetY_) {
+  if (!traffic_light_position_.x() && !traffic_light_position_.y()) {
     return;
   }
 
@@ -532,7 +532,7 @@ void NativeWindowMac::RepositionTrafficLights() {
 
   [titleBarContainerView setHidden:NO];
   CGFloat buttonHeight = [close frame].size.height;
-  CGFloat titleBarFrameHeight = buttonHeight + traffic_light_offsetY_;
+  CGFloat titleBarFrameHeight = buttonHeight + traffic_light_position_.y();
   CGRect titleBarRect = titleBarContainerView.frame;
   titleBarRect.size.height = titleBarFrameHeight;
   titleBarRect.origin.y = window.frame.size.height - titleBarFrameHeight;
@@ -544,7 +544,7 @@ void NativeWindowMac::RepositionTrafficLights() {
   for (NSUInteger i = 0; i < windowButtons.count; i++) {
     NSView* view = [windowButtons objectAtIndex:i];
     CGRect rect = [view frame];
-    rect.origin.x = traffic_light_offsetX_ + (i * space_between);
+    rect.origin.x = traffic_light_position_.x() + (i * space_between);
     rect.origin.y = (titleBarFrameHeight - rect.size.height) / 2;
     [view setFrameOrigin:rect.origin];
   }

--- a/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -136,6 +136,9 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
 - (void)windowDidResize:(NSNotification*)notification {
   [super windowDidResize:notification];
   shell_->NotifyWindowResize();
+  if (shell_->title_bar_style() == TitleBarStyle::HIDDEN) {
+    shell_->RepositionTrafficLights();
+  }
 }
 
 - (void)windowWillMove:(NSNotification*)notification {
@@ -202,6 +205,7 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
     NSWindow* window = shell_->GetNativeWindow().GetNativeNSWindow();
     [window setToolbar:nil];
   }
+  shell_->SetEnteringFullScreen(true);
 }
 
 - (void)windowDidEnterFullScreen:(NSNotification*)notification {
@@ -249,11 +253,20 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
     shell_->SetStyleMask(false, NSWindowStyleMaskFullSizeContentView);
     [window setTitlebarAppearsTransparent:YES];
   }
+  shell_->SetExitingFullScreen(true);
+  if (shell_->title_bar_style() == TitleBarStyle::HIDDEN) {
+    shell_->RepositionTrafficLights();
+  }
 }
 
 - (void)windowDidExitFullScreen:(NSNotification*)notification {
   shell_->SetResizable(is_resizable_);
   shell_->NotifyWindowLeaveFullScreen();
+  shell_->SetEnteringFullScreen(false);
+  shell_->SetExitingFullScreen(false);
+  if (shell_->title_bar_style() == TitleBarStyle::HIDDEN) {
+    shell_->RepositionTrafficLights();
+  }
 }
 
 - (void)windowWillClose:(NSNotification*)notification {

--- a/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/atom_ns_window_delegate.mm
@@ -205,7 +205,6 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
     NSWindow* window = shell_->GetNativeWindow().GetNativeNSWindow();
     [window setToolbar:nil];
   }
-  shell_->SetEnteringFullScreen(true);
 }
 
 - (void)windowDidEnterFullScreen:(NSNotification*)notification {
@@ -262,7 +261,6 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
 - (void)windowDidExitFullScreen:(NSNotification*)notification {
   shell_->SetResizable(is_resizable_);
   shell_->NotifyWindowLeaveFullScreen();
-  shell_->SetEnteringFullScreen(false);
   shell_->SetExitingFullScreen(false);
   if (shell_->title_bar_style() == TitleBarStyle::HIDDEN) {
     shell_->RepositionTrafficLights();

--- a/shell/common/options_switches.cc
+++ b/shell/common/options_switches.cc
@@ -28,6 +28,8 @@ const char kMaximizable[] = "maximizable";
 const char kFullScreenable[] = "fullscreenable";
 const char kClosable[] = "closable";
 const char kFullscreen[] = "fullscreen";
+const char kTrafficLightOffsetX[] = "trafficLightOffsetX";
+const char kTrafficLightOffsetY[] = "trafficLightOffsetY";
 
 // Whether the window should show in taskbar.
 const char kSkipTaskbar[] = "skipTaskbar";

--- a/shell/common/options_switches.cc
+++ b/shell/common/options_switches.cc
@@ -28,8 +28,7 @@ const char kMaximizable[] = "maximizable";
 const char kFullScreenable[] = "fullscreenable";
 const char kClosable[] = "closable";
 const char kFullscreen[] = "fullscreen";
-const char kTrafficLightOffsetX[] = "trafficLightOffsetX";
-const char kTrafficLightOffsetY[] = "trafficLightOffsetY";
+const char kTrafficLightPosition[] = "trafficLightPosition";
 
 // Whether the window should show in taskbar.
 const char kSkipTaskbar[] = "skipTaskbar";

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -54,6 +54,8 @@ extern const char kOpacity[];
 extern const char kFocusable[];
 extern const char kWebPreferences[];
 extern const char kVibrancyType[];
+extern const char kTrafficLightOffsetX[];
+extern const char kTrafficLightOffsetY[];
 
 // WebPreferences.
 extern const char kZoomFactor[];

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -54,8 +54,7 @@ extern const char kOpacity[];
 extern const char kFocusable[];
 extern const char kWebPreferences[];
 extern const char kVibrancyType[];
-extern const char kTrafficLightOffsetX[];
-extern const char kTrafficLightOffsetY[];
+extern const char kTrafficLightPosition[];
 
 // WebPreferences.
 extern const char kZoomFactor[];


### PR DESCRIPTION
#### Description of Change
[There seems to be a high demand for custom inset traffic light buttons in Electron](https://github.com/electron/electron/issues/8237). 

- I added a new option in `BrowserWindow`, `trafficLightPosition` which sets the `(x,y)` position of the traffic light buttons. 
- It needs to be used in conjunction with `titleBarStyle: 'hidden'` to work. 
- Default to a value of (0, 0), which results in the standard default position, identical to the regular placement in `titleBarStyle: 'hidden'`. 

e.g.
```
titleBarStyle: 'hidden'
trafficLightPosition: {x: 12, y: 42}
```
![image](https://user-images.githubusercontent.com/16580702/72395511-9188cf00-36ee-11ea-87b0-8eecb54a82d2.png)


#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: add `trafficLightPosition` option in `BrowserWindow` API to allow custom positioning of traffic lights
