### PR TITLE
fix: printToPDF failing to generate PDF

### DIFF
--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -395,7 +395,7 @@ index 34e1cda035c042c8c4c55acd7716cf9473856fcf..199267d873f2343cdf401bb9a335dd75
    // Tells the RenderFrame to switch the CSS to print media type, render every
    // requested page using the print preview document's frame/node, and then
 diff --git a/components/printing/renderer/print_render_frame_helper.cc b/components/printing/renderer/print_render_frame_helper.cc
-index 41f6c6ba9920c7fe2a0cf91458162afb70762c16..7315a2b5962f42b57d04655cea97a938bd61768f 100644
+index 41f6c6ba9920c7fe2a0cf91458162afb70762c16..5c23f9fba61c791365d9c69910ebb12154a6f238 100644
 --- a/components/printing/renderer/print_render_frame_helper.cc
 +++ b/components/printing/renderer/print_render_frame_helper.cc
 @@ -39,6 +39,7 @@
@@ -452,6 +452,26 @@ index 41f6c6ba9920c7fe2a0cf91458162afb70762c16..7315a2b5962f42b57d04655cea97a938
    print_preview_context_.OnPrintPreview();
  
    base::UmaHistogramEnumeration(print_preview_context_.IsForArc()
+@@ -1557,13 +1561,13 @@ bool PrintRenderFrameHelper::FinalizePrintReadyDocument() {
+       print_preview_context_.set_error(PREVIEW_ERROR_METAFILE_CAPTURE_FAILED);
+       return false;
+     }
+-  } else {
+-    if (!CopyMetafileDataToReadOnlySharedMem(*metafile,
++  }
++
++  if (!CopyMetafileDataToReadOnlySharedMem(*metafile,
+                                              &preview_params.content)) {
+-      LOG(ERROR) << "CopyMetafileDataToReadOnlySharedMem failed";
+-      print_preview_context_.set_error(PREVIEW_ERROR_METAFILE_COPY_FAILED);
+-      return false;
+-    }
++    LOG(ERROR) << "CopyMetafileDataToReadOnlySharedMem failed";
++    print_preview_context_.set_error(PREVIEW_ERROR_METAFILE_COPY_FAILED);
++    return false;
+   }
+ 
+   preview_params.document_cookie = print_pages_params_->params.document_cookie;
 @@ -1760,7 +1764,9 @@ void PrintRenderFrameHelper::PrintNode(const blink::WebNode& node) {
  
      auto self = weak_ptr_factory_.GetWeakPtr();

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -1413,17 +1413,16 @@ describe('webContents module', () => {
     })
   })
 
-  // TODO(deepak1556): Fix and enable after upgrade.
   ifdescribe(features.isPrintingEnabled())('printToPDF()', () => {
     afterEach(closeAllWindows)
-    it.skip('can print to PDF', async () => {
+    it('can print to PDF', async () => {
       const w = new BrowserWindow({ show: false, webPreferences: { sandbox: true } })
       await w.loadURL('data:text/html,<h1>Hello, World!</h1>')
       const data = await w.webContents.printToPDF({})
       expect(data).to.be.an.instanceof(Buffer).that.is.not.empty()
     })
 
-    it.skip('does not crash when called multiple times', async () => {
+    it('does not crash when called multiple times', async () => {
       const w = new BrowserWindow({ show: false, webPreferences: { sandbox: true } })
       await w.loadURL('data:text/html,<h1>Hello, World!</h1>')
       const promises = []


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/21708.
Closes https://github.com/electron/electron/issues/21438.

Fixes an issue where `contents.printToPDF` rejected with `[Error: Failed to generate PDF]`. This was caused by a change in Chromium CL [1917685](https://chromium-review.googlesource.com/c/chromium/src/+/1917685): Chromium made a change such that when Skia metafiles were passed to the PDF compositor, the full document PDF would get composited using the same individual page metafile objects as those that are sent to the utility process for composition.

This behavior hinges on access to the Print Preview UI, which we do not make use of within Electron.  More specifically, Chromium stopped copying the correct metafile data to the `metafile_data_region` for our use case, and so when we received the final IPC message that the metafile was ready, it wouldn't have the data we wanted in it. This fixes the issue by ensuring that the metafile data is _always_ copied to the `metafile_data_region`, which both addresses our use case and doesn't interfere with the goal of the referenced CL.

Tested in Fiddle with the following code:

```js
  mainWindow.webContents.once('did-finish-load', async function() {
    try {
      const pdfData = await mainWindow.webContents.printToPDF({})
      const outPath = '/Users/codebytere/Desktop/print_test.pdf'
    fs.writeFile(outPath, pdfData, (error) => {
        if (error) throw error
        console.log(`Wrote PDF to: ${outPath}`)
      })
    } catch(e) {
      console.error(e)
    }
  })
```

and observing that a PDF is successfully created at the target path.

cc @deepak1556 @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `webContents.printToPDF` failed to properly generate the PDF document.
