### PR TITLE
feat: add mouse-down & mouse-up to Tray

### DIFF
--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -143,6 +143,26 @@ Emitted when a drag operation exits the tray icon.
 
 Emitted when a drag operation ends on the tray or ends at another location.
 
+#### Event: 'mouse-up' _macOS_
+
+Returns:
+
+* `event` [KeyboardEvent](structures/keyboard-event.md)
+* `position` [Point](structures/point.md) - The position of the event.
+
+Emitted when the mouse is released from clicking the tray icon.
+
+Note: This will not be emitted if you have set a context menu for your Tray using `tray.setContextMenu`, as a result of macOS-level constraints.
+
+#### Event: 'mouse-down' _macOS_
+
+Returns:
+
+* `event` [KeyboardEvent](structures/keyboard-event.md)
+* `position` [Point](structures/point.md) - The position of the event.
+
+Emitted when the mouse clicks the tray icon.
+
 #### Event: 'mouse-enter' _macOS_
 
 Returns:

--- a/shell/browser/api/atom_api_tray.cc
+++ b/shell/browser/api/atom_api_tray.cc
@@ -125,6 +125,14 @@ void Tray::OnMouseMoved(const gfx::Point& location, int modifiers) {
   EmitWithFlags("mouse-move", modifiers, location);
 }
 
+void Tray::OnMouseUp(const gfx::Point& location, int modifiers) {
+  EmitWithFlags("mouse-up", modifiers, location);
+}
+
+void Tray::OnMouseDown(const gfx::Point& location, int modifiers) {
+  EmitWithFlags("mouse-down", modifiers, location);
+}
+
 void Tray::OnDragEntered() {
   Emit("drag-enter");
 }

--- a/shell/browser/api/atom_api_tray.h
+++ b/shell/browser/api/atom_api_tray.h
@@ -60,6 +60,8 @@ class Tray : public gin_helper::TrackableObject<Tray>, public TrayIconObserver {
   void OnDragEntered() override;
   void OnDragExited() override;
   void OnDragEnded() override;
+  void OnMouseUp(const gfx::Point& location, int modifiers) override;
+  void OnMouseDown(const gfx::Point& location, int modifiers) override;
   void OnMouseEntered(const gfx::Point& location, int modifiers) override;
   void OnMouseExited(const gfx::Point& location, int modifiers) override;
   void OnMouseMoved(const gfx::Point& location, int modifiers) override;

--- a/shell/browser/ui/tray_icon.cc
+++ b/shell/browser/ui/tray_icon.cc
@@ -74,6 +74,16 @@ void TrayIcon::NotifyDropText(const std::string& text) {
     observer.OnDropText(text);
 }
 
+void TrayIcon::NotifyMouseUp(const gfx::Point& location, int modifiers) {
+  for (TrayIconObserver& observer : observers_)
+    observer.OnMouseUp(location, modifiers);
+}
+
+void TrayIcon::NotifyMouseDown(const gfx::Point& location, int modifiers) {
+  for (TrayIconObserver& observer : observers_)
+    observer.OnMouseDown(location, modifiers);
+}
+
 void TrayIcon::NotifyMouseEntered(const gfx::Point& location, int modifiers) {
   for (TrayIconObserver& observer : observers_)
     observer.OnMouseEntered(location, modifiers);

--- a/shell/browser/ui/tray_icon.h
+++ b/shell/browser/ui/tray_icon.h
@@ -105,6 +105,10 @@ class TrayIcon {
   void NotifyDragEntered();
   void NotifyDragExited();
   void NotifyDragEnded();
+  void NotifyMouseUp(const gfx::Point& location = gfx::Point(),
+                     int modifiers = 0);
+  void NotifyMouseDown(const gfx::Point& location = gfx::Point(),
+                       int modifiers = 0);
   void NotifyMouseEntered(const gfx::Point& location = gfx::Point(),
                           int modifiers = 0);
   void NotifyMouseExited(const gfx::Point& location = gfx::Point(),

--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -131,6 +131,10 @@
 }
 
 - (void)mouseDown:(NSEvent*)event {
+  trayIcon_->NotifyMouseDown(
+      gfx::ScreenPointFromNSPoint([event locationInWindow]),
+      ui::EventFlagsFromModifiers([event modifierFlags]));
+
   // Pass click to superclass to show menu. Custom mouseUp handler won't be
   // invoked.
   if (menuController_) {
@@ -142,6 +146,10 @@
 
 - (void)mouseUp:(NSEvent*)event {
   [[statusItem_ button] highlight:NO];
+
+  trayIcon_->NotifyMouseUp(
+      gfx::ScreenPointFromNSPoint([event locationInWindow]),
+      ui::EventFlagsFromModifiers([event modifierFlags]));
 
   // If we are ignoring double click events, we should ignore the `clickCount`
   // value and immediately emit a click event.

--- a/shell/browser/ui/tray_icon_observer.h
+++ b/shell/browser/ui/tray_icon_observer.h
@@ -33,6 +33,8 @@ class TrayIconObserver : public base::CheckedObserver {
   virtual void OnDragEntered() {}
   virtual void OnDragExited() {}
   virtual void OnDragEnded() {}
+  virtual void OnMouseUp(const gfx::Point& location, int modifiers) {}
+  virtual void OnMouseDown(const gfx::Point& location, int modifiers) {}
   virtual void OnMouseEntered(const gfx::Point& location, int modifiers) {}
   virtual void OnMouseExited(const gfx::Point& location, int modifiers) {}
   virtual void OnMouseMoved(const gfx::Point& location, int modifiers) {}


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/21764.

This PR adds two new events to the Tray module: `mouse-down` and `mouse-up`. Previously this was made difficult by our old Tray menu logic, but after Micha's refactor in https://github.com/electron/electron/pull/18981 this is now a much more feasible request. The referenced issue provides several compelling use-cases for these events, including but not limited to: 

- Updating/animating the tray icon with a new image for an 'active' state (while the mouse button is pressed).
- Showing an application window on mouse-down. 
- Enabling some temporary state while they hold their mouse button down on a menubar icon, such as enabling microphone input briefly, or muting an audio track briefly.

As such, this is relatively straightforward to implement and adds very little maintenance burden.

cc @zcbenz @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `mouse-down` and `mouse-up` events to the Tray on macOS.
