### PR TITLE
fix: npm download failed when define 'npm_config_platform=mas'

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -68,6 +68,7 @@ function getPlatformPath () {
   const platform = process.env.npm_config_platform || os.platform()
 
   switch (platform) {
+    case 'mas':
     case 'darwin':
       return 'Electron.app/Contents/MacOS/Electron'
     case 'freebsd':


### PR DESCRIPTION
To download mas package will be failed.
```shell
npm_config_platform=mas npm i -D electron@latest
```
The crash and failed message:
```shell
throw new Error('Electron builds are not available on platform: ' + platform)
      ^
Error: Electron builds are not available on platform: mas
```
This PR fixed this problem.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> Fixed downloading mas package failed when defined 'npm_config_platform=mas'