### PR TITLE
feat: add tray.closeContextMenu()

### DIFF
--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -257,6 +257,10 @@ be shown instead of the tray icon's context menu.
 
 The `position` is only available on Windows, and it is (0, 0) by default.
 
+#### `tray.closeContextMenu()` _macOS_ _Windows_
+
+Closes an open context menu, as set by `tray.setContextMenu()`.
+
 #### `tray.setContextMenu(menu)`
 
 * `menu` Menu | null

--- a/shell/browser/api/atom_api_tray.cc
+++ b/shell/browser/api/atom_api_tray.cc
@@ -231,6 +231,10 @@ void Tray::PopUpContextMenu(gin_helper::Arguments* args) {
   tray_icon_->PopUpContextMenu(pos, menu.IsEmpty() ? nullptr : menu->model());
 }
 
+void Tray::CloseContextMenu() {
+  tray_icon_->CloseContextMenu();
+}
+
 void Tray::SetContextMenu(gin_helper::ErrorThrower thrower,
                           v8::Local<v8::Value> arg) {
   gin::Handle<Menu> menu;
@@ -268,6 +272,7 @@ void Tray::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("removeBalloon", &Tray::RemoveBalloon)
       .SetMethod("focus", &Tray::Focus)
       .SetMethod("popUpContextMenu", &Tray::PopUpContextMenu)
+      .SetMethod("closeContextMenu", &Tray::CloseContextMenu)
       .SetMethod("setContextMenu", &Tray::SetContextMenu)
       .SetMethod("getBounds", &Tray::GetBounds);
 }

--- a/shell/browser/api/atom_api_tray.h
+++ b/shell/browser/api/atom_api_tray.h
@@ -76,6 +76,7 @@ class Tray : public gin_helper::TrackableObject<Tray>, public TrayIconObserver {
   void RemoveBalloon();
   void Focus();
   void PopUpContextMenu(gin_helper::Arguments* args);
+  void CloseContextMenu();
   void SetContextMenu(gin_helper::ErrorThrower thrower,
                       v8::Local<v8::Value> arg);
   gfx::Rect GetBounds();

--- a/shell/browser/ui/tray_icon.cc
+++ b/shell/browser/ui/tray_icon.cc
@@ -23,6 +23,8 @@ void TrayIcon::Focus() {}
 void TrayIcon::PopUpContextMenu(const gfx::Point& pos,
                                 AtomMenuModel* menu_model) {}
 
+void TrayIcon::CloseContextMenu() {}
+
 gfx::Rect TrayIcon::GetBounds() {
   return gfx::Rect();
 }

--- a/shell/browser/ui/tray_icon.h
+++ b/shell/browser/ui/tray_icon.h
@@ -81,6 +81,8 @@ class TrayIcon {
   virtual void PopUpContextMenu(const gfx::Point& pos,
                                 AtomMenuModel* menu_model);
 
+  virtual void CloseContextMenu();
+
   // Set the context menu for this icon.
   virtual void SetContextMenu(AtomMenuModel* menu_model) = 0;
 

--- a/shell/browser/ui/tray_icon_cocoa.h
+++ b/shell/browser/ui/tray_icon_cocoa.h
@@ -32,6 +32,7 @@ class TrayIconCocoa : public TrayIcon {
   void PopUpOnUI(AtomMenuModel* menu_model);
   void PopUpContextMenu(const gfx::Point& pos,
                         AtomMenuModel* menu_model) override;
+  void CloseContextMenu() override;
   void SetContextMenu(AtomMenuModel* menu_model) override;
   gfx::Rect GetBounds() override;
 

--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -186,6 +186,12 @@
   }
 }
 
+- (void)closeContextMenu {
+  if (menuController_) {
+    [menuController_ cancel];
+  }
+}
+
 - (void)rightMouseUp:(NSEvent*)event {
   trayIcon_->NotifyRightClicked(
       gfx::ScreenRectFromNSRect(event.window.frame),
@@ -305,6 +311,10 @@ void TrayIconCocoa::PopUpContextMenu(const gfx::Point& pos,
       FROM_HERE, {content::BrowserThread::UI},
       base::BindOnce(&TrayIconCocoa::PopUpOnUI, weak_factory_.GetWeakPtr(),
                      base::Unretained(menu_model)));
+}
+
+void TrayIconCocoa::CloseContextMenu() {
+  [status_item_view_ closeContextMenu];
 }
 
 void TrayIconCocoa::SetContextMenu(AtomMenuModel* menu_model) {

--- a/shell/browser/ui/win/notify_icon.cc
+++ b/shell/browser/ui/win/notify_icon.cc
@@ -199,8 +199,7 @@ void NotifyIcon::PopUpContextMenu(const gfx::Point& pos,
     return;
 
   // Cancel current menu if there is one.
-  if (menu_runner_ && menu_runner_->IsRunning())
-    menu_runner_->Cancel();
+  CloseContextMenu();
 
   // Show menu at mouse's position by default.
   gfx::Rect rect(pos, gfx::Size());
@@ -229,6 +228,12 @@ void NotifyIcon::PopUpContextMenu(const gfx::Point& pos,
   menu_runner_->RunMenuAt(widget_.get(), NULL, rect,
                           views::MenuAnchorPosition::kTopLeft,
                           ui::MENU_SOURCE_MOUSE);
+}
+
+void NotifyIcon::CloseContextMenu() {
+  if (menu_runner_ && menu_runner_->IsRunning()) {
+    menu_runner_->Cancel();
+  }
 }
 
 void NotifyIcon::SetContextMenu(AtomMenuModel* menu_model) {

--- a/shell/browser/ui/win/notify_icon.h
+++ b/shell/browser/ui/win/notify_icon.h
@@ -63,6 +63,7 @@ class NotifyIcon : public TrayIcon {
   void Focus() override;
   void PopUpContextMenu(const gfx::Point& pos,
                         AtomMenuModel* menu_model) override;
+  void CloseContextMenu() override;
   void SetContextMenu(AtomMenuModel* menu_model) override;
   gfx::Rect GetBounds() override;
 

--- a/spec-main/api-tray-spec.ts
+++ b/spec-main/api-tray-spec.ts
@@ -63,6 +63,18 @@ describe('tray module', () => {
     })
   })
 
+  describe('tray.closeContextMenu()', () => {
+    ifit(process.platform === 'win32')('does not crash when called more than once', function (done) {
+      tray.setContextMenu(Menu.buildFromTemplate([{ label: 'Test' }]))
+      setTimeout(() => {
+        tray.closeContextMenu()
+        tray.closeContextMenu()
+        done()
+      })
+      tray.popUpContextMenu()
+    })
+  })
+
   describe('tray.getBounds()', () => {
     afterEach(() => { tray.destroy() })
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/11683.

We allow closing menus with `menu.closePopup()`, and it stands to reason that, given tray menus are menus, this functionality should also be accessible from the `Tray` module to menus set with `tray.setContextMenu(menu)`.

cc @ckerr @MarshallOfSound @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `tray.closeContextMenu()` to allow programmatic closure of Tray menus.
