### PR TITLE
docs: document new extensions APIs

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -705,7 +705,7 @@ Remove a Chrome extension by name.
 is emitted.
 
 **Note:** This method is deprecated. Instead, use
-[`ses.removeExtension(extension_id)`](session.md#sesremoveextensionextension-id).
+[`ses.removeExtension(extension_id)`](session.md#sesremoveextensionextensionid).
 
 #### `BrowserWindow.getExtensions()` _Deprecated_
 
@@ -747,7 +747,7 @@ Remove a DevTools extension by name.
 is emitted.
 
 **Note:** This method is deprecated. Instead, use
-[`ses.removeExtension(extension_id)`](session.md#sesremoveextensionextension-id).
+[`ses.removeExtension(extension_id)`](session.md#sesremoveextensionextensionid).
 
 #### `BrowserWindow.getDevToolsExtensions()` _Deprecated_
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -681,7 +681,7 @@ Returns `BrowserWindow | null` - The window that owns the given `browserView`. I
 
 Returns `BrowserWindow` - The window with the given `id`.
 
-#### `BrowserWindow.addExtension(path)`
+#### `BrowserWindow.addExtension(path)` _Deprecated_
 
 * `path` String
 
@@ -692,7 +692,10 @@ The method will also not return if the extension's manifest is missing or incomp
 **Note:** This API cannot be called before the `ready` event of the `app` module
 is emitted.
 
-#### `BrowserWindow.removeExtension(name)`
+**Note:** This method is deprecated. Instead, use
+[`ses.loadExtension(path)`](session.md#sesloadextensionpath).
+
+#### `BrowserWindow.removeExtension(name)` _Deprecated_
 
 * `name` String
 
@@ -701,7 +704,10 @@ Remove a Chrome extension by name.
 **Note:** This API cannot be called before the `ready` event of the `app` module
 is emitted.
 
-#### `BrowserWindow.getExtensions()`
+**Note:** This method is deprecated. Instead, use
+[`ses.removeExtension(extension_id)`](session.md#sesremoveextensionextension-id).
+
+#### `BrowserWindow.getExtensions()` _Deprecated_
 
 Returns `Record<String, ExtensionInfo>` - The keys are the extension names and each value is
 an Object containing `name` and `version` properties.
@@ -709,7 +715,10 @@ an Object containing `name` and `version` properties.
 **Note:** This API cannot be called before the `ready` event of the `app` module
 is emitted.
 
-#### `BrowserWindow.addDevToolsExtension(path)`
+**Note:** This method is deprecated. Instead, use
+[`ses.getAllExtensions()`](session.md#sesgetallextensions).
+
+#### `BrowserWindow.addDevToolsExtension(path)` _Deprecated_
 
 * `path` String
 
@@ -725,7 +734,10 @@ The method will also not return if the extension's manifest is missing or incomp
 **Note:** This API cannot be called before the `ready` event of the `app` module
 is emitted.
 
-#### `BrowserWindow.removeDevToolsExtension(name)`
+**Note:** This method is deprecated. Instead, use
+[`ses.loadExtension(path)`](session.md#sesloadextensionpath).
+
+#### `BrowserWindow.removeDevToolsExtension(name)` _Deprecated_
 
 * `name` String
 
@@ -734,7 +746,10 @@ Remove a DevTools extension by name.
 **Note:** This API cannot be called before the `ready` event of the `app` module
 is emitted.
 
-#### `BrowserWindow.getDevToolsExtensions()`
+**Note:** This method is deprecated. Instead, use
+[`ses.removeExtension(extension_id)`](session.md#sesremoveextensionextension-id).
+
+#### `BrowserWindow.getDevToolsExtensions()` _Deprecated_
 
 Returns `Record<string, ExtensionInfo>` - The keys are the extension names and each value is
 an Object containing `name` and `version` properties.
@@ -750,6 +765,9 @@ console.log(installed)
 
 **Note:** This API cannot be called before the `ready` event of the `app` module
 is emitted.
+
+**Note:** This method is deprecated. Instead, use
+[`ses.getAllExtensions()`](session.md#sesgetallextensions).
 
 ### Instance Properties
 

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -513,11 +513,11 @@ be remembered for future runs of the application. This is no longer the case:
 extension to be loaded.
 
 ```js
-const { app, session } = require("electron")
-const path = require("path")
+const { app, session } = require('electron')
+const path = require('path')
 
-app.on("ready", async () => {
-  await session.defaultSession.loadExtension(path.join(__dirname, "react-devtools"))
+app.on('ready', async () => {
+  await session.defaultSession.loadExtension(path.join(__dirname, 'react-devtools'))
   // Note that in order to use the React DevTools extension, you'll need to
   // download and unzip a copy of the extension.
 })

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -528,16 +528,18 @@ This API does not support loading packed (.crx) extensions.
 **Note:** This API cannot be called before the `ready` event of the `app` module
 is emitted.
 
-#### `ses.removeExtension(extension_id)`
+#### `ses.removeExtension(extensionId)`
 
-* `extension_id` String - ID of extension to remove
+* `extensionId` String - ID of extension to remove
 
 Unloads an extension.
 
 **Note:** This API cannot be called before the `ready` event of the `app` module
 is emitted.
 
-#### `ses.getExtension(extension_id)`
+#### `ses.getExtension(extensionId)`
+
+* `extensionId` String - ID of extension to query
 
 Returns `Extension` | `null` - The loaded extension with the given ID.
 

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -494,6 +494,63 @@ Returns `Boolean` - Whether the word was successfully written to the custom dict
 
 **Note:** On macOS and Windows 10 this word will be written to the OS custom dictionary as well
 
+#### `ses.loadExtension(path)`
+
+* `path` String - Path to a directory containing an unpacked Chrome extension
+
+Returns `Promise<Extension>` - resolves when the extension is loaded.
+
+This method will raise an exception if the extension could not be loaded. If
+there are warnings when installing the extension (e.g. if the extension
+requests an API that Electron does not support) then they will be logged to the
+console.
+
+Note that Electron does not support the full range of Chrome extensions APIs.
+
+Note that in previous versions of Electron, extensions that were loaded would
+be remembered for future runs of the application. This is no longer the case:
+`loadExtension` must be called on every boot of your app if you want the
+extension to be loaded.
+
+```js
+const { app, session } = require("electron")
+const path = require("path")
+
+app.on("ready", async () => {
+  await session.defaultSession.loadExtension(path.join(__dirname, "react-devtools"))
+  // Note that in order to use the React DevTools extension, you'll need to
+  // download and unzip a copy of the extension.
+})
+```
+
+This API does not support loading packed (.crx) extensions.
+
+**Note:** This API cannot be called before the `ready` event of the `app` module
+is emitted.
+
+#### `ses.removeExtension(extension_id)`
+
+* `extension_id` String - ID of extension to remove
+
+Unloads an extension.
+
+**Note:** This API cannot be called before the `ready` event of the `app` module
+is emitted.
+
+#### `ses.getExtension(extension_id)`
+
+Returns `Extension` | `null` - The loaded extension with the given ID.
+
+**Note:** This API cannot be called before the `ready` event of the `app` module
+is emitted.
+
+#### `ses.getAllExtensions()`
+
+Returns `Extension[]` - A list of all loaded extensions.
+
+**Note:** This API cannot be called before the `ready` event of the `app` module
+is emitted.
+
 ### Instance Properties
 
 The following properties are available on instances of `Session`:

--- a/docs/api/structures/extension.md
+++ b/docs/api/structures/extension.md
@@ -1,0 +1,5 @@
+# Extension Object
+
+* `id` String
+* `name` String
+* `version` String

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -79,6 +79,7 @@ auto_filenames = {
     "docs/api/structures/display.md",
     "docs/api/structures/event.md",
     "docs/api/structures/extension-info.md",
+    "docs/api/structures/extension.md",
     "docs/api/structures/file-filter.md",
     "docs/api/structures/file-path-with-headers.md",
     "docs/api/structures/gpu-feature-status.md",


### PR DESCRIPTION
#### Description of Change
Ref #19447

These APIs aren't yet switched on, but when they are, we should have documentation for them.

I plan to stub out the `BrowserWindow` versions to call `session.defaultSession.*` when `enable_electron_extensions` is turned on.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)


#### Release Notes

Notes: none