### PR TITLE
fix: [extensions] load extensions on the IO thread

### DIFF
--- a/shell/browser/extensions/atom_extension_loader.cc
+++ b/shell/browser/extensions/atom_extension_loader.cc
@@ -4,6 +4,8 @@
 
 #include "shell/browser/extensions/atom_extension_loader.h"
 
+#include <utility>
+
 #include "base/auto_reset.h"
 #include "base/bind.h"
 #include "base/files/file_path.h"

--- a/shell/browser/extensions/atom_extension_loader.h
+++ b/shell/browser/extensions/atom_extension_loader.h
@@ -34,7 +34,9 @@ class AtomExtensionLoader : public ExtensionRegistrar::Delegate {
 
   // Loads an unpacked extension from a directory synchronously. Returns the
   // extension on success, or nullptr otherwise.
-  const Extension* LoadExtension(const base::FilePath& extension_dir);
+  void LoadExtension(
+      const base::FilePath& extension_dir,
+      base::OnceCallback<void(const Extension* extension)> loaded);
 
   // Starts reloading the extension. A keep-alive is maintained until the
   // reload succeeds/fails. If the extension is an app, it will be launched upon
@@ -51,6 +53,9 @@ class AtomExtensionLoader : public ExtensionRegistrar::Delegate {
   // it. If the load failed, updates ShellKeepAliveRequester.
   void FinishExtensionReload(const ExtensionId& old_extension_id,
                              scoped_refptr<const Extension> extension);
+
+  void FinishExtensionLoad(base::OnceCallback<void(const Extension*)> loaded,
+                           scoped_refptr<const Extension> extension);
 
   // ExtensionRegistrar::Delegate:
   void PreAddExtension(const Extension* extension,

--- a/shell/browser/extensions/atom_extension_system.cc
+++ b/shell/browser/extensions/atom_extension_system.cc
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "base/bind.h"
 #include "base/files/file_path.h"

--- a/shell/browser/extensions/atom_extension_system.cc
+++ b/shell/browser/extensions/atom_extension_system.cc
@@ -43,14 +43,10 @@ AtomExtensionSystem::AtomExtensionSystem(BrowserContext* browser_context)
 
 AtomExtensionSystem::~AtomExtensionSystem() = default;
 
-const Extension* AtomExtensionSystem::LoadExtension(
-    const base::FilePath& extension_dir) {
-  return extension_loader_->LoadExtension(extension_dir);
-}
-
-const Extension* AtomExtensionSystem::LoadApp(const base::FilePath& app_dir) {
-  NOTIMPLEMENTED() << "Attempted to load platform app in Electron";
-  return nullptr;
+void AtomExtensionSystem::LoadExtension(
+    const base::FilePath& extension_dir,
+    base::OnceCallback<void(const Extension*)> loaded) {
+  extension_loader_->LoadExtension(extension_dir, std::move(loaded));
 }
 
 void AtomExtensionSystem::FinishInitialization() {

--- a/shell/browser/extensions/atom_extension_system.h
+++ b/shell/browser/extensions/atom_extension_system.h
@@ -39,13 +39,8 @@ class AtomExtensionSystem : public ExtensionSystem {
 
   // Loads an unpacked extension from a directory. Returns the extension on
   // success, or nullptr otherwise.
-  const Extension* LoadExtension(const base::FilePath& extension_dir);
-
-  // Loads an unpacked platform app from a directory. Returns the extension on
-  // success, or nullptr otherwise.
-  // Currently this just calls LoadExtension, as apps are not loaded differently
-  // than other extensions. Use LaunchApp() to actually launch the loaded app.
-  const Extension* LoadApp(const base::FilePath& app_dir);
+  void LoadExtension(const base::FilePath& extension_dir,
+                     base::OnceCallback<void(const Extension*)> loaded);
 
   // Finish initialization for the shell extension system.
   void FinishInitialization();


### PR DESCRIPTION
#### Description of Change
The sync loading on the UI thread was temporary.

Ref #19447

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none