### PR TITLE
chore: [extensions] support old APIs with enable_electron_extensions

### DIFF
--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -247,6 +247,7 @@ auto_filenames = {
     "lib/browser/api/views/text-field.js",
     "lib/browser/api/web-contents-view.js",
     "lib/browser/api/web-contents.js",
+    "lib/browser/chrome-extension-shim.js",
     "lib/browser/chrome-extension.js",
     "lib/browser/crash-reporter-init.js",
     "lib/browser/default-menu.ts",

--- a/lib/browser/chrome-extension-shim.js
+++ b/lib/browser/chrome-extension-shim.js
@@ -1,0 +1,37 @@
+'use strict'
+
+// This is a temporary shim to aid in transition from the old
+// BrowserWindow-based extensions stuff to the new native-backed extensions
+// API.
+
+if (!process.electronBinding('features').isExtensionsEnabled()) {
+  throw new Error('Attempted to load JS chrome-extension shim without //extensions support enabled')
+}
+
+const { app, session, BrowserWindow, deprecate } = require('electron')
+
+app.once('ready', function () {
+  const addExtension = function (srcDirectory) {
+    return session.defaultSession.loadExtension(srcDirectory)
+  }
+
+  const removeExtension = function (name) {
+    const extension = session.defaultSession.getAllExtensions().find(e => e.name === name)
+    if (extension) { session.defaultSession.removeExtension(extension.id) }
+  }
+
+  const getExtensions = function () {
+    const extensions = {}
+    session.defaultSession.getAllExtensions().forEach(e => {
+      extensions[e.name] = e
+    })
+    return extensions
+  }
+
+  BrowserWindow.addExtension = deprecate.moveAPI(addExtension, 'BrowserWindow.addExtension', 'session.loadExtension')
+  BrowserWindow.removeExtension = deprecate.moveAPI(removeExtension, 'BrowserWindow.removeExtension', 'session.removeExtension')
+  BrowserWindow.getExtensions = deprecate.moveAPI(getExtensions, 'BrowserWindow.getExtensions', 'session.getAllExtensions')
+  BrowserWindow.addDevToolsExtension = deprecate.moveAPI(addExtension, 'BrowserWindow.addDevToolsExtension', 'session.loadExtension')
+  BrowserWindow.removeDevToolsExtension = deprecate.moveAPI(removeExtension, 'BrowserWindow.removeDevToolsExtension', 'session.removeExtension')
+  BrowserWindow.getDevToolsExtensions = deprecate.moveAPI(getExtensions, 'BrowserWindow.getDevToolsExtensions', 'session.getAllExtensions')
+})

--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -154,7 +154,9 @@ require('@electron/internal/browser/devtools')
 const features = process.electronBinding('features')
 
 // Load the chrome extension support.
-if (!features.isExtensionsEnabled()) {
+if (features.isExtensionsEnabled()) {
+  require('@electron/internal/browser/chrome-extension-shim')
+} else {
   require('@electron/internal/browser/chrome-extension')
 }
 

--- a/shell/common/gin_converters/extension_converter.cc
+++ b/shell/common/gin_converters/extension_converter.cc
@@ -15,6 +15,8 @@ v8::Local<v8::Value> Converter<const extensions::Extension*>::ToV8(
     const extensions::Extension* extension) {
   auto dict = gin::Dictionary::CreateEmpty(isolate);
   dict.Set("id", extension->id());
+  dict.Set("name", extension->name());
+  dict.Set("version", extension->VersionString());
   return gin::ConvertToV8(isolate, dict);
 }
 

--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -210,6 +210,39 @@ ifdescribe(process.electronBinding('features').isExtensionsEnabled())('chrome ex
       await emittedOnce(ipcMain, 'winning')
     })
   })
+
+  describe('deprecation shims', () => {
+    afterEach(() => {
+      (session.defaultSession as any).getAllExtensions().forEach((e: any) => {
+        (session.defaultSession as any).removeExtension(e.id)
+      })
+    })
+
+    it('loads an extension through BrowserWindow.addExtension', async () => {
+      BrowserWindow.addExtension(path.join(fixtures, 'extensions', 'red-bg'))
+      const w = new BrowserWindow({ show: false })
+      await w.loadURL(url)
+      const bg = await w.webContents.executeJavaScript('document.documentElement.style.backgroundColor')
+      expect(bg).to.equal('red')
+    })
+
+    it('loads an extension through BrowserWindow.addDevToolsExtension', async () => {
+      BrowserWindow.addDevToolsExtension(path.join(fixtures, 'extensions', 'red-bg'))
+      const w = new BrowserWindow({ show: false })
+      await w.loadURL(url)
+      const bg = await w.webContents.executeJavaScript('document.documentElement.style.backgroundColor')
+      expect(bg).to.equal('red')
+    })
+
+    it('removes an extension through BrowserWindow.removeExtension', async () => {
+      await (BrowserWindow.addExtension(path.join(fixtures, 'extensions', 'red-bg')) as any)
+      BrowserWindow.removeExtension('red-bg')
+      const w = new BrowserWindow({ show: false })
+      await w.loadURL(url)
+      const bg = await w.webContents.executeJavaScript('document.documentElement.style.backgroundColor')
+      expect(bg).to.equal('')
+    })
+  })
 })
 
 ifdescribe(!process.electronBinding('features').isExtensionsEnabled())('chrome extensions', () => {


### PR DESCRIPTION
#### Description of Change
This allows for a deprecation phase-out of the old `BrowserWindow.*Extension` APIs when we cut over to the new extensions implementation.

See #21809 for the docs.

Ref #19447

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none