### PR TITLE
fix: crash when restoring minimized hidden window

### DIFF
--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -275,6 +275,9 @@ class NativeWindowViews : public NativeWindow,
 
   // Set to true if the window is always on top and behind the task bar.
   bool behind_task_bar_ = false;
+
+  // Whether to block Chromium from handling window messages.
+  bool block_chromium_message_handler_ = false;
 #endif
 
   // Handles unhandled keyboard messages coming back from the renderer process.

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -180,6 +180,14 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
                                      LRESULT* result) {
   NotifyWindowMessage(message, w_param, l_param);
 
+  // See code below for why blocking Chromium from handling messages.
+  if (block_chromium_message_handler_) {
+    // Handle the message with default proc.
+    *result = DefWindowProc(GetAcceleratedWidget(), message, w_param, l_param);
+    // Tell Chromium to ignore this message.
+    return true;
+  }
+
   switch (message) {
     // Screen readers send WM_GETOBJECT in order to get the accessibility
     // object, so take this opportunity to push Chromium into accessible
@@ -222,7 +230,18 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
       if (!last_normal_placement_bounds_.IsEmpty() &&
           GetWindowPlacement(GetAcceleratedWidget(), &wp)) {
         wp.rcNormalPosition = last_normal_placement_bounds_.ToRECT();
+
+        // When calling SetWindowPlacement, Chromium would do window messages
+        // handling. But since we are already in PreHandleMSG this would cause
+        // crash in Chromium under some cases.
+        //
+        // We work around the crash by prevent Chromium from handling window
+        // messages until the SetWindowPlacement call is done.
+        //
+        // See https://github.com/electron/electron/issues/21614 for more.
+        block_chromium_message_handler_ = true;
         SetWindowPlacement(GetAcceleratedWidget(), &wp);
+        block_chromium_message_handler_ = false;
 
         last_normal_placement_bounds_ = gfx::Rect();
       }

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -2858,6 +2858,13 @@ describe('BrowserWindow module', () => {
       w.restore()
       expectBoundsEqual(w.getSize(), initialSize)
     })
+
+    it('does not crash when restoring hidden minimized window', () => {
+      const w = new BrowserWindow({})
+      w.minimize()
+      w.hide()
+      w.show()
+    })
   })
 
   describe('BrowserWindow.unmaximize()', () => {


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/21614.

When invoking `SetWindowPlacement` in `PreHandleMSG` it would trigger window message proc in Chromium, and then crash under some cases because Chromium does not expect its window message proc to be called in the `PreHandleMSG` hook.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix crash when restoring minimized hidden window on Windows.