### PR TITLE
docs: menu item labels are not dynamic

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -130,8 +130,7 @@ dynamically changed.
 
 #### `menuItem.label`
 
-A `String` indicating the item's visible label, this property can be
-dynamically changed.
+A `String` indicating the item's visible label.
 
 #### `menuItem.click`
 
@@ -165,7 +164,7 @@ item's icon, if set.
 
 #### `menuItem.sublabel`
 
-A `String` indicating the item's sublabel, this property can be dynamically changed.
+A `String` indicating the item's sublabel.
 
 #### `menuItem.toolTip` _macOS_
 
@@ -197,7 +196,9 @@ You can add a `click` function for additional behavior.
 #### `menuItem.registerAccelerator`
 
 A `Boolean` indicating if the accelerator should be registered with the
-system or just displayed, this property can be dynamically changed.
+system or just displayed.
+
+This property can be dynamically changed.
 
 #### `menuItem.commandId`
 


### PR DESCRIPTION
#### Description of Change

What it says on the tin. See https://github.com/electron/electron/issues/12633.

cc @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
