### PR TITLE
test: retry a few more flaky tests

### DIFF
--- a/spec-main/api-menu-spec.ts
+++ b/spec-main/api-menu-spec.ts
@@ -882,7 +882,12 @@ describe('Menu module', function () {
       expect(output).to.include('Window has no menu')
     })
 
-    ifit(process.platform !== 'darwin')('does not override null menu on startup', async () => {
+    ifit(process.platform !== 'darwin')('does not override null menu on startup', async function () {
+      // This test is flaky on WOA.
+      if (process.platform === 'win32' && process.arch === 'arm64') {
+        this.retries(3)
+      }
+
       const appPath = path.join(fixturesPath, 'api', 'test-menu-null')
       const appProcess = cp.spawn(process.execPath, [appPath])
 

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -1089,7 +1089,11 @@ describe('chromium features', () => {
 
   describe('window.history', () => {
     describe('window.history.pushState', () => {
-      it('should push state after calling history.pushState() from the same url', (done) => {
+      it('should push state after calling history.pushState() from the same url', function (done) {
+        // In Electron the navigation history is maintained by listening to
+        // WebContents events, so window.history related tests are flaky.
+        this.retries(3)
+
         const w = new BrowserWindow({ show: false })
         w.webContents.once('did-finish-load', async () => {
           // History should have current page by now.


### PR DESCRIPTION
I have noticed a few constantly flaky tests in recent CI runnings, I think it is safe to retry a few of them.

notes: no-notes