### PR TITLE
fix: Windows checkboxChecked edge case

### DIFF
--- a/shell/browser/ui/message_box_win.cc
+++ b/shell/browser/ui/message_box_win.cc
@@ -183,8 +183,7 @@ DialogResult ShowTaskDialogUTF16(NativeWindow* parent,
   else
     button_id = cancel_id;
 
-  return std::make_pair(button_id,
-                        checkbox_checked ? verificationFlagChecked : false);
+  return std::make_pair(button_id, verificationFlagChecked);
 }
 
 DialogResult ShowTaskDialogUTF8(const MessageBoxSettings& settings) {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/21831.

Most of the checkbox plumbing was fixed earlier, but one edge case remained; if you started with checkbox_checked `false`, and then checked `true`. This final bit: `checkbox_checked ? verificationFlagChecked : false` led to the following logic flow:

`checkboxChecked: false` -> user leaved unchecked -> `checkboxChecked === false` (correct ✅) 
`checkboxChecked: true` -> user unchecks -> `checkboxChecked === false` (correct ✅) 
`checkboxChecked: false` -> user checks -> `checkboxChecked === false` (incorrect 🔴 ) 
`checkboxChecked: true` -> user leaves checked -> `checkboxChecked === true` (correct ✅) 

We shouldn't be gating the final return value on `checkbox_checked`; it only reflects the initial checked state. We simply need to return `verificationFlagChecked`, as it defaults to false anyway.

cc @nornagon @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an edge case in checkbox logic on Windows.
