### PR TITLE
fix: call SetCanActivate in setFocusable

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -950,6 +950,7 @@ void NativeWindowViews::SetContentProtection(bool enable) {
 }
 
 void NativeWindowViews::SetFocusable(bool focusable) {
+  widget()->widget_delegate()->SetCanActivate(focusable);
 #if defined(OS_WIN)
   LONG ex_style = ::GetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE);
   if (focusable)

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -651,6 +651,16 @@ describe('BrowserWindow module', () => {
       })
     })
 
+    describe('BrowserWindow.setFocusable()', () => {
+      it('can set unfocusable window to focusable', async () => {
+        const w2 = new BrowserWindow({ focusable: false })
+        const w2Focused = emittedOnce(w2, 'focus')
+        w2.setFocusable(true)
+        w2.focus()
+        await w2Focused
+        await closeWindow(w2, { assertNotWindows: false })
+      })
+    })
   })
 
   describe('sizing', () => {


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/21846.

Notes: Fixed  `BrowserWindow.setFocusable(true)` not working on Windows.