### PR TITLE
fix: call SetCanActivate in setFocusable

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -922,6 +922,7 @@ void NativeWindowViews::SetContentProtection(bool enable) {
 }
 
 void NativeWindowViews::SetFocusable(bool focusable) {
+  widget()->widget_delegate()->SetCanActivate(focusable);
 #if defined(OS_WIN)
   LONG ex_style = ::GetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE);
   if (focusable)


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/21846.

Notes: Fix` BrowserWindow.setFocusable(true)` not working on Windows.