### PR TITLE
fix: some websites using WebComponents V0 not loading

### DIFF
--- a/shell/browser/feature_list.cc
+++ b/shell/browser/feature_list.cc
@@ -27,6 +27,13 @@ void InitializeFeatureList() {
   // when node integration is enabled.
   disable_features +=
       std::string(",") + features::kSpareRendererForSitePerProcess.name;
+
+  // https://www.polymer-project.org/blog/2018-10-02-webcomponents-v0-deprecations
+  // https://chromium-review.googlesource.com/c/chromium/src/+/1869562
+  // Any website which uses older WebComponents will fail in without this
+  // enabled, since Electron does not support origin trials.
+  enable_features += std::string(",") + "WebComponentsV0Enabled";
+
 #if !BUILDFLAG(ENABLE_PICTURE_IN_PICTURE)
   disable_features += std::string(",") + media::kPictureInPicture.name;
 #endif


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/21596.
Refs: https://chromium-review.googlesource.com/c/chromium/src/+/1869562

Fixes an issue where any website using Polymer 2.x would not load, as Polymer 2.x [still uses HTML Imports as a loading mechanism](https://www.polymer-project.org/blog/2018-10-02-webcomponents-v0-deprecations). This adds the flag to enable them back for the time being, since Electron does not support origin trials and so wouldn't respect individual sites enabling them. 

Another potential approach to this would be to add `HTMLImports` to the `enableBlinkFeatures` defaults, since that's more granular. Finally, we may choose to simply force consumers to work around the issue themselves, but I would say that for now I personally am in favor of leaving this enabled while it affects a nontrivial number of sites.

cc @nornagon @deepak1556 @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where sites using `ShadowDOMV0`, `CustomElementsV0`, or `HTMLImports` would not load properly.
