### PR TITLE
test: use exit event to wait for process exit

### DIFF
--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -160,7 +160,7 @@ describe('app module', () => {
       if (appProcess && appProcess.stdout) {
         appProcess.stdout.on('data', data => { output += data })
       }
-      const [code] = await emittedOnce(appProcess, 'close')
+      const [code] = await emittedOnce(appProcess, 'exit')
 
       if (process.platform !== 'win32') {
         expect(output).to.include('Exit event with code: 123')
@@ -173,7 +173,7 @@ describe('app module', () => {
       const electronPath = process.execPath
 
       appProcess = cp.spawn(electronPath, [appPath])
-      const [code, signal] = await emittedOnce(appProcess, 'close')
+      const [code, signal] = await emittedOnce(appProcess, 'exit')
 
       expect(signal).to.equal(null, 'exit signal should be null, if you see this please tag @MarshallOfSound')
       expect(code).to.equal(123, 'exit code should be 123, if you see this please tag @MarshallOfSound')
@@ -194,7 +194,7 @@ describe('app module', () => {
       if (appProcess && appProcess.stdout) {
         appProcess.stdout.on('data', () => appProcess!.kill())
       }
-      const [code, signal] = await emittedOnce(appProcess, 'close')
+      const [code, signal] = await emittedOnce(appProcess, 'exit')
 
       const message = `code:\n${code}\nsignal:\n${signal}`
       expect(code).to.equal(0, message)

--- a/spec-main/api-browser-view-spec.ts
+++ b/spec-main/api-browser-view-spec.ts
@@ -227,7 +227,7 @@ describe('BrowserView module', () => {
       const appPath = path.join(__dirname, 'fixtures', 'api', 'leak-exit-browserview.js')
       const electronPath = process.execPath
       const appProcess = ChildProcess.spawn(electronPath, [appPath])
-      const [code] = await emittedOnce(appProcess, 'close')
+      const [code] = await emittedOnce(appProcess, 'exit')
       expect(code).to.equal(0)
     })
   })

--- a/spec-main/api-crash-reporter-spec.ts
+++ b/spec-main/api-crash-reporter-spec.ts
@@ -340,7 +340,7 @@ ifdescribe(!process.mas && !process.env.DISABLE_CRASH_REPORTER_TESTS && process.
     it('does not prevent process from crashing', (done) => {
       const appPath = path.join(fixtures, 'api', 'cookie-app')
       const appProcess = childProcess.spawn(process.execPath, [appPath])
-      appProcess.once('close', () => {
+      appProcess.once('exit', () => {
         done()
       })
     })

--- a/spec-main/api-menu-spec.ts
+++ b/spec-main/api-menu-spec.ts
@@ -878,7 +878,7 @@ describe('Menu module', function () {
       let output = ''
       appProcess.stdout.on('data', data => { output += data })
 
-      await emittedOnce(appProcess, 'close')
+      await emittedOnce(appProcess, 'exit')
       expect(output).to.include('Window has no menu')
     })
 
@@ -889,7 +889,7 @@ describe('Menu module', function () {
       let output = ''
       appProcess.stdout.on('data', data => { output += data })
 
-      await emittedOnce(appProcess, 'close')
+      await emittedOnce(appProcess, 'exit')
       expect(output).to.include('Window has no menu')
     })
   })

--- a/spec-main/api-net-log-spec.ts
+++ b/spec-main/api-net-log-spec.ts
@@ -161,7 +161,7 @@ describe('netLog module', () => {
         }
       })
 
-    await emittedOnce(appProcess, 'close')
+    await emittedOnce(appProcess, 'exit')
     expect(fs.existsSync(dumpFileDynamic)).to.be.true('dynamic dump file exists')
   })
 })

--- a/spec-main/api-session-spec.ts
+++ b/spec-main/api-session-spec.ts
@@ -234,7 +234,7 @@ describe('session module', () => {
           )
 
           appProcess.stdout.on('data', data => { output += data })
-          appProcess.stdout.on('end', () => {
+          appProcess.on('exit', () => {
             resolve(output.replace(/(\r\n|\n|\r)/gm, ''))
           })
         })

--- a/spec-main/api-web-contents-view-spec.ts
+++ b/spec-main/api-web-contents-view-spec.ts
@@ -30,7 +30,7 @@ describe('WebContentsView', () => {
       const appPath = path.join(__dirname, 'fixtures', 'api', 'leak-exit-webcontentsview.js')
       const electronPath = process.execPath
       const appProcess = ChildProcess.spawn(electronPath, [appPath])
-      const [code] = await emittedOnce(appProcess, 'close')
+      const [code] = await emittedOnce(appProcess, 'exit')
       expect(code).to.equal(0)
     })
   })


### PR DESCRIPTION
#### Description of Change

For tests that wait for child app to exit, use `exit` event instead of `close` event.

On Windows the node pipe for stdio is not working, so the behavior of `close` event is undefined. From my observation, all timeout tests that started child apps were using `close` event instead of `exit`, so it is possible that the tests failed because they received `close` event before receiving all console output, or because the `close` event did not emit at all.

Even if this change does not really fix the flaky tests, using `exit` event would still be the right way.

#### Release Notes

Notes: no-notes
