### PR TITLE
fix: About Panel credits should be dark mode aware

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1191,8 +1191,9 @@ Show the app's about panel options. These options can be overridden with `app.se
   * `website` String (optional) _Linux_ - The app's website.
   * `iconPath` String (optional) _Linux_ _Windows_ - Path to the app's icon. On Linux, will be shown as 64x64 pixels while retaining aspect ratio.
 
-Set the about panel options. This will override the values defined in the app's
-`.plist` file on MacOS. See the [Apple docs][about-panel-options] for more details. On Linux, values must be set in order to be shown; there are no defaults.
+Set the about panel options. This will override the values defined in the app's `.plist` file on MacOS. See the [Apple docs][about-panel-options] for more details. On Linux, values must be set in order to be shown; there are no defaults.
+
+If you do not set `credits` but still wish to surface them in your app, AppKit will look for a file named "Credits.html", "Credits.rtf", and "Credits.rtfd", in that order, in the bundle returned by the NSBundle class method main. The first file found is used, and if none is found, the info area is left blank. See Apple [documentation](https://developer.apple.com/documentation/appkit/nsaboutpaneloptioncredits?language=objc) for more information.
 
 ### `app.isEmojiPanelSupported()`
 

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -379,20 +379,16 @@ void Browser::ShowAboutPanel() {
   // Credits must be a NSAttributedString instead of NSString
   NSString* credits = (NSString*)options[@"Credits"];
   if (credits != nil) {
-    // Check if app is running in dark mode
-    NSString* mode = [[NSUserDefaults standardUserDefaults]
-        stringForKey:@"AppleInterfaceStyle"];
-    BOOL isDarkMode = [mode isEqualToString:@"Dark"];
+    base::scoped_nsobject<NSMutableDictionary> mutable_options(
+        [options mutableCopy]);
+    base::scoped_nsobject<NSAttributedString> creditString(
+        [[NSAttributedString alloc]
+            initWithString:credits
+                attributes:@{
+                  NSForegroundColorAttributeName : [NSColor textColor]
+                }]);
 
-    // Set color of credits depending on if we're in dark mode or not.
-    NSColor* color = isDarkMode ? [NSColor whiteColor] : [NSColor blackColor];
-    NSAttributedString* creditString = [[NSAttributedString alloc]
-        initWithString:credits
-            attributes:@{NSForegroundColorAttributeName : color}];
-
-    // Cast back to NSDictionary with updated options
-    NSMutableDictionary* mutable_options = [options mutableCopy];
-    mutable_options[@"Credits"] = creditString;
+    [mutable_options setValue:creditString forKey:@"Credits"];
     options = [NSDictionary dictionaryWithDictionary:mutable_options];
   }
 

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -377,11 +377,22 @@ void Browser::ShowAboutPanel() {
   NSDictionary* options = DictionaryValueToNSDictionary(about_panel_options_);
 
   // Credits must be a NSAttributedString instead of NSString
-  id credits = options[@"Credits"];
+  NSString* credits = (NSString*)options[@"Credits"];
   if (credits != nil) {
+    // Check if app is running in dark mode
+    NSString* mode = [[NSUserDefaults standardUserDefaults]
+        stringForKey:@"AppleInterfaceStyle"];
+    BOOL isDarkMode = [mode isEqualToString:@"Dark"];
+
+    // Set color of credits depending on if we're in dark mode or not.
+    NSColor* color = isDarkMode ? [NSColor whiteColor] : [NSColor blackColor];
+    NSAttributedString* creditString = [[NSAttributedString alloc]
+        initWithString:credits
+            attributes:@{NSForegroundColorAttributeName : color}];
+
+    // Cast back to NSDictionary with updated options
     NSMutableDictionary* mutable_options = [options mutableCopy];
-    mutable_options[@"Credits"] = [[[NSAttributedString alloc]
-        initWithString:(NSString*)credits] autorelease];
+    mutable_options[@"Credits"] = creditString;
     options = [NSDictionary dictionaryWithDictionary:mutable_options];
   }
 


### PR DESCRIPTION
#### Description of Change

Fixes an issue surfaced by @bnb where by the Credits option in `app.showAboutPanel()` did not appropriately adapt to dark mode.

Before:
<img width="396" alt="Screen Shot 2020-01-23 at 3 04 34 PM" src="https://user-images.githubusercontent.com/2036040/73031809-fda3bb00-3df1-11ea-8456-8ffa94ecf66b.png">

After:
<img width="396" alt="Screen Shot 2020-01-23 at 3 04 22 PM" src="https://user-images.githubusercontent.com/2036040/73031813-009eab80-3df2-11ea-8f93-9f316f881aa8.png">

cc @MarshallOfSound @zcbenz @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the credits set in About Panel credits were not dark mode aware on macOS.
