### PR TITLE
ci: Use Windows VM initialized via script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@
 
 version: 1.0.{build}
 build_cloud: libcc-20
-image: vs2019-16.3-10.0.18362
+image: vs2019bt-16.4.0
 environment:
   GIT_CACHE_PATH: C:\Users\electron\libcc_cache
   ELECTRON_OUT_DIR: Default

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,8 +88,17 @@ build_script:
         if (Test-Path -Path $zipfile) {
           # file exists, unzip and then gclient sync
           7z x -y $zipfile -mmt=30 -aoa
-          # update external binaries
-          python src/electron/script/update-external-binaries.py
+          if (-not (Test-Path -Path "src\buildtools")) {
+            # the zip file must be corrupt - resync
+            $env:RUN_GCLIENT_SYNC="true"
+            if ($env:TARGET_ARCH -ne 'ia32') {
+              # only save on x64/woa to avoid contention saving
+              $env:SAVE_GCLIENT_SRC="true"
+            }
+          } else {
+            # update external binaries
+            python src/electron/script/update-external-binaries.py
+          }
         } else {    
           # file does not exist, gclient sync, then zip
           $env:RUN_GCLIENT_SYNC="true"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -122,7 +122,7 @@ build_script:
   - gn check out/Default //electron:manifests
   - gn check out/Default //electron/shell/common/api:mojo
   - if DEFINED RAW_GOMA_AUTH (ninja -j 300 -C out/Default electron:electron_app) else (ninja -C out/Default electron:electron_app)
-  - if "%GN_CONFIG%"=="testing" ( python C:\Users\electron\depot_tools\post_build_ninja_summary.py -C out\Default )
+  - if "%GN_CONFIG%"=="testing" ( python C:\depot_tools\post_build_ninja_summary.py -C out\Default )
   - gn gen out/ffmpeg "--args=import(\"//electron/build/args/ffmpeg.gn\") %GN_EXTRA_ARGS%"
   - ninja -C out/ffmpeg electron:electron_ffmpeg_zip
   - ninja -C out/Default electron:electron_dist_zip

--- a/script/setup-win-for-dev.bat
+++ b/script/setup-win-for-dev.bat
@@ -69,7 +69,7 @@ set chocolateyUseWindowsCompression='true'
 SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 
 REM Install nodejs python git and yarn needed dependencies
-choco install -y nodejs python2 git yarn vcredist140 windbg
+choco install -y nodejs python2 git yarn vcredist140 windows-sdk-10-version-1903-windbg
 cmd /c refreshenv
 SET PATH=C:\Python27\;C:\Python27\Scripts;%PATH%
 

--- a/script/setup-win-for-dev.bat
+++ b/script/setup-win-for-dev.bat
@@ -1,0 +1,84 @@
+REM Parameters vs_buildtools.exe download link and wsdk version
+@ECHO OFF
+
+SET buildtools_link=https://download.visualstudio.microsoft.com/download/pr/d7691cc1-82e6-434f-8e9f-a612f85b4b76/c62179f8cbbb58d4af22c21e8d4e122165f21615f529c94fad5cc7e012f1ef08/vs_BuildTools.exe
+SET wsdk10_link=https://go.microsoft.com/fwlink/p/?LinkId=845298
+SET wsdk=10SDK.18362
+
+REM Check for disk space
+Rem        543210987654321
+Set "Blank=               "
+Set "GB100=   107374182400"
+
+for /f "tokens=2" %%A in (
+  'wmic LogicalDisk Get DeviceID^,FreeSpace ^| find /i "C:"'
+) Do Set "FreeSpace=%Blank%%%A"
+Set "FreeSpace=%FreeSpace:~-15%"
+
+Echo FreeSpace="%FreeSpace%"
+Echo    100 GB="%GB100%"
+
+If "%FreeSpace%" gtr "%GB100%" (
+  Echo yes enough free space
+) else (
+  Echo not enough free space - 100GB
+  exit 5
+)
+
+REM Interpret arguments
+:loop
+IF NOT "%1"=="" (
+    IF "%1"=="-buildtools_link" (
+        SET buildtools_link=%2
+        SHIFT
+    )
+    IF "%1"=="-wsdk" (
+        SET wsdk=%2
+        SHIFT
+    )
+    SHIFT
+    GOTO :loop
+)
+
+@ECHO ON
+
+if not exist "C:\TEMP\" mkdir C:\TEMP
+
+REM Download vs_buildtools.exe to C:\TEMP\vs_buildtools.exe
+powershell -command "& { iwr %buildtools_link% -OutFile C:\TEMP\vs_buildtools.exe }"
+
+REM Install Visual Studio Toolchain
+C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache ^
+    --installPath "%ProgramFiles(x86)%/Microsoft Visual Studio/2019/Community" ^
+    --add Microsoft.VisualStudio.Workload.NativeDesktop ^
+    --add Microsoft.VisualStudio.Component.VC.ATLMFC ^
+    --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 ^
+    --add Microsoft.VisualStudio.Component.VC.MFC.ARM64 ^
+    --add Microsoft.VisualStudio.Component.Windows%wsdk% ^
+    --includeRecommended
+
+REM Install Windows SDK
+powershell -command "& { iwr %wsdk10_link% -OutFile C:\TEMP\wsdk10.exe }"
+C:\TEMP\wsdk10.exe /features /quiet
+
+REM Install chocolatey to further install dependencies
+set chocolateyUseWindowsCompression='true'
+@"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" ^
+    -NoProfile -InputFormat None -ExecutionPolicy Bypass ^
+    -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
+SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
+
+REM Install nodejs python git and yarn needed dependencies
+choco install -y nodejs python2 git yarn vcredist140 windbg
+cmd /c refreshenv
+SET PATH=C:\Python27\;C:\Python27\Scripts;%PATH%
+
+pip install pywin32
+rename C:\Python38\python.exe python3.exe
+rename C:\Python38\pythonw.exe pythonw3.exe
+cmd /c refreshenv
+pip2 install pywin32
+
+REM Setup Depot Tools
+git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git C:\depot_tools
+SET PATH=%PATH%;C:\depot_tools\


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
In order to better support reproducible builds on Windows, this PR changes our Windows CI to use a Windows VM that was initialized by the included script, ` script/setup-win-for-dev.bat`.  Developers can use this script to setup a Windows install with the same exact tooling used by our CI.

Also, I fixed an issue using the source cache on Appveyor.  It turns out that because we kill running builds if a new commit comes in for that branch and the job running is trying to save the source to the cache, we end up in a situation where the source archive is corrupt - eg https://ci.appveyor.com/project/electron-bot/electron-ldhmv/builds/30321997.  I changed the appveyor script to check if the unzip of the archive was successful and if not, it will do a fresh fetch of the source.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
