### PR TITLE
fix: menu not updating with Tray.setContextMenu

### DIFF
--- a/shell/browser/ui/tray_icon_gtk.cc
+++ b/shell/browser/ui/tray_icon_gtk.cc
@@ -38,8 +38,8 @@ void TrayIconGtk::SetToolTip(const std::string& tool_tip) {
 }
 
 void TrayIconGtk::SetContextMenu(AtomMenuModel* menu_model) {
-  icon_->UpdatePlatformContextMenu(menu_model_);
   menu_model_ = menu_model;
+  icon_->UpdatePlatformContextMenu(menu_model_);
 }
 
 const gfx::ImageSkia& TrayIconGtk::GetImage() const {


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/21499.

Fix `Tray.setContextMenu` not updating the menu on Linux. This bug was introduced by a Chromium upgrade.

Test case is rather difficult to write since it requires manually clicking the DBus tray menu, so I have omitted it.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix `Tray.setContextMenu` not updating the menu on Linux.
