### PR TITLE
feat: expose the chromium validated certificate in the certificate verify prox

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -272,6 +272,7 @@ the original network configuration.
   * `request` Object
     * `hostname` String
     * `certificate` [Certificate](structures/certificate.md)
+    * `validatedCertificate` [Certificate](structures/certificate.md)
     * `verificationResult` String - Verification result from chromium.
     * `errorCode` Integer - Error code.
   * `callback` Function

--- a/shell/browser/net/cert_verifier_client.cc
+++ b/shell/browser/net/cert_verifier_client.cc
@@ -32,6 +32,7 @@ void CertVerifierClient::Verify(
   params.default_result = net::ErrorToString(default_error);
   params.error_code = default_error;
   params.certificate = certificate;
+  params.validated_certificate = default_result.verified_cert;
   cert_verify_proc_.Run(
       params,
       base::AdaptCallbackForRepeating(base::BindOnce(

--- a/shell/browser/net/cert_verifier_client.h
+++ b/shell/browser/net/cert_verifier_client.h
@@ -17,6 +17,7 @@ struct VerifyRequestParams {
   std::string default_result;
   int error_code;
   scoped_refptr<net::X509Certificate> certificate;
+  scoped_refptr<net::X509Certificate> validated_certificate;
 
   VerifyRequestParams();
   VerifyRequestParams(const VerifyRequestParams&);

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -364,6 +364,7 @@ v8::Local<v8::Value> Converter<electron::VerifyRequestParams>::ToV8(
   gin::Dictionary dict = gin::Dictionary::CreateEmpty(isolate);
   dict.Set("hostname", val.hostname);
   dict.Set("certificate", val.certificate);
+  dict.Set("validatedCertificate", val.validated_certificate);
   dict.Set("verificationResult", val.default_result);
   dict.Set("errorCode", val.error_code);
   return ConvertToV8(isolate, dict);


### PR DESCRIPTION
Fixes #19751
Refs https://github.com/dialogs/electron-ssl-pinning/issues/3

As in notes, pretty straight forward, just exposing another certificate in this proc.

Notes: added `validatedCertificate` to the `setCertificateVerifyProc` callback to assist with certificate pinning implementations