### PR TITLE
feat: allow GUID parameter to avoid systray demotion on Windows 

### DIFF
--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -58,9 +58,10 @@ If you want to keep exact same behaviors on all platforms, you should not
 rely on the `click` event and always attach a context menu to the tray icon.
 
 
-### `new Tray(image)`
+### `new Tray(image, [guid])`
 
 * `image` ([NativeImage](native-image.md) | String)
+* `guid` String (optional) _Windows_ - Assigns a GUID to the tray icon. If the executable is signed and the signature contains an organization in the subject line then the GUID is permanently associated with that signature. OS level settings like the position of the tray icon in the system tray will persist even if the path to the executable changes. If the executable is not code-signed then the GUID is permanently associated with the path to the executable. Changing the path to the executable will break the creation of the tray icon and a new GUID must be used. However, it is highly recommended to use the GUID parameter only in conjunction with code-signed executable. If an App defines multiple tray icons then each icon must use a separate GUID.
 
 Creates a new tray icon associated with the `image`.
 

--- a/shell/browser/api/atom_api_tray.cc
+++ b/shell/browser/api/atom_api_tray.cc
@@ -77,10 +77,12 @@ gin_helper::WrappableBase* Tray::New(gin_helper::ErrorThrower thrower,
     return nullptr;
   }
 
+#if defined(OS_WIN)
   if (!guid.has_value() && args->Length() > 1) {
     thrower.ThrowError("Invalid GUID format");
     return nullptr;
   }
+#endif
 
   return new Tray(image, guid, args);
 }

--- a/shell/browser/api/atom_api_tray.h
+++ b/shell/browser/api/atom_api_tray.h
@@ -5,6 +5,7 @@
 #ifndef SHELL_BROWSER_API_ATOM_API_TRAY_H_
 #define SHELL_BROWSER_API_ATOM_API_TRAY_H_
 
+#include <rpc.h>
 #include <memory>
 #include <string>
 #include <vector>
@@ -36,13 +37,16 @@ class Tray : public gin_helper::TrackableObject<Tray>, public TrayIconObserver {
  public:
   static gin_helper::WrappableBase* New(gin_helper::ErrorThrower thrower,
                                         gin::Handle<NativeImage> image,
+                                        base::Optional<UUID> guid,
                                         gin_helper::Arguments* args);
 
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype);
 
  protected:
-  Tray(gin::Handle<NativeImage> image, gin_helper::Arguments* args);
+  Tray(gin::Handle<NativeImage> image,
+       base::Optional<UUID> guid,
+       gin_helper::Arguments* args);
   ~Tray() override;
 
   // TrayIconObserver:

--- a/shell/browser/api/atom_api_tray.h
+++ b/shell/browser/api/atom_api_tray.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_API_ATOM_API_TRAY_H_
 #define SHELL_BROWSER_API_ATOM_API_TRAY_H_
 
-#include <rpc.h>
 #include <memory>
 #include <string>
 #include <vector>
@@ -13,6 +12,7 @@
 #include "gin/handle.h"
 #include "shell/browser/ui/tray_icon.h"
 #include "shell/browser/ui/tray_icon_observer.h"
+#include "shell/common/gin_converters/guid_converter.h"
 #include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/trackable_object.h"
 

--- a/shell/browser/ui/tray_icon.h
+++ b/shell/browser/ui/tray_icon.h
@@ -5,6 +5,7 @@
 #ifndef SHELL_BROWSER_UI_TRAY_ICON_H_
 #define SHELL_BROWSER_UI_TRAY_ICON_H_
 
+#include <rpc.h>
 #include <string>
 #include <vector>
 
@@ -17,7 +18,7 @@ namespace electron {
 
 class TrayIcon {
  public:
-  static TrayIcon* Create();
+  static TrayIcon* Create(base::Optional<UUID> guid);
 
 #if defined(OS_WIN)
   using ImageType = HICON;

--- a/shell/browser/ui/tray_icon.h
+++ b/shell/browser/ui/tray_icon.h
@@ -5,13 +5,13 @@
 #ifndef SHELL_BROWSER_UI_TRAY_ICON_H_
 #define SHELL_BROWSER_UI_TRAY_ICON_H_
 
-#include <rpc.h>
 #include <string>
 #include <vector>
 
 #include "base/observer_list.h"
 #include "shell/browser/ui/atom_menu_model.h"
 #include "shell/browser/ui/tray_icon_observer.h"
+#include "shell/common/gin_converters/guid_converter.h"
 #include "ui/gfx/geometry/rect.h"
 
 namespace electron {

--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -323,7 +323,7 @@ gfx::Rect TrayIconCocoa::GetBounds() {
 }
 
 // static
-TrayIcon* TrayIcon::Create() {
+TrayIcon* TrayIcon::Create(base::Optional<UUID> guid) {
   return new TrayIconCocoa;
 }
 

--- a/shell/browser/ui/tray_icon_gtk.cc
+++ b/shell/browser/ui/tray_icon_gtk.cc
@@ -65,7 +65,7 @@ bool TrayIconGtk::HasClickAction() {
 }
 
 // static
-TrayIcon* TrayIcon::Create() {
+TrayIcon* TrayIcon::Create(base::Optional<UUID> guid) {
   return new TrayIconGtk;
 }
 

--- a/shell/browser/ui/tray_icon_win.cc
+++ b/shell/browser/ui/tray_icon_win.cc
@@ -8,9 +8,9 @@
 namespace electron {
 
 // static
-TrayIcon* TrayIcon::Create() {
+TrayIcon* TrayIcon::Create(base::Optional<UUID> guid) {
   static NotifyIconHost host;
-  return host.CreateNotifyIcon();
+  return host.CreateNotifyIcon(guid);
 }
 
 }  // namespace electron

--- a/shell/browser/ui/win/notify_icon.cc
+++ b/shell/browser/ui/win/notify_icon.cc
@@ -62,7 +62,6 @@ NotifyIcon::NotifyIcon(NotifyIconHost* host,
   icon_data.uFlags |= NIF_MESSAGE;
   icon_data.uCallbackMessage = message_id_;
   BOOL result = Shell_NotifyIcon(NIM_ADD, &icon_data);
-
   // This can happen if the explorer process isn't running when we try to
   // create the icon for some reason (for example, at startup).
   if (!result)
@@ -150,8 +149,7 @@ void NotifyIcon::SetToolTip(const std::string& tool_tip) {
   wcsncpy_s(icon_data.szTip, base::UTF8ToUTF16(tool_tip).c_str(), _TRUNCATE);
   BOOL result = Shell_NotifyIcon(NIM_MODIFY, &icon_data);
   if (!result)
-    LOG(WARNING) << "Unable to set tooltip for status tray icon. If a guid is "
-                    "provided then ensure the calling binary is code signed.";
+    LOG(WARNING) << "Unable to set tooltip for status tray icon";
 }
 
 void NotifyIcon::DisplayBalloon(const BalloonOptions& options) {
@@ -175,8 +173,7 @@ void NotifyIcon::DisplayBalloon(const BalloonOptions& options) {
 
   BOOL result = Shell_NotifyIcon(NIM_MODIFY, &icon_data);
   if (!result)
-    LOG(WARNING) << "Unable to create status tray balloon. If a guid is "
-                    "provided then ensure teh calling binary is code signed.";
+    LOG(WARNING) << "Unable to create status tray balloon.";
 }
 
 void NotifyIcon::RemoveBalloon() {
@@ -186,8 +183,7 @@ void NotifyIcon::RemoveBalloon() {
 
   BOOL result = Shell_NotifyIcon(NIM_MODIFY, &icon_data);
   if (!result)
-    LOG(WARNING) << "Unable to remove status tray balloon. If a guid is "
-                    "provided then ensure the calling binary is code signed.";
+    LOG(WARNING) << "Unable to remove status tray balloon.";
 }
 
 void NotifyIcon::Focus() {
@@ -196,8 +192,7 @@ void NotifyIcon::Focus() {
 
   BOOL result = Shell_NotifyIcon(NIM_SETFOCUS, &icon_data);
   if (!result)
-    LOG(WARNING) << "Unable to focus tray icon. If a guid is provided then "
-                    "ensure the calling binary is code signed.";
+    LOG(WARNING) << "Unable to focus tray icon.";
 }
 
 void NotifyIcon::PopUpContextMenu(const gfx::Point& pos,
@@ -251,16 +246,15 @@ void NotifyIcon::SetContextMenu(AtomMenuModel* menu_model) {
 gfx::Rect NotifyIcon::GetBounds() {
   NOTIFYICONIDENTIFIER icon_id;
   memset(&icon_id, 0, sizeof(NOTIFYICONIDENTIFIER));
+  icon_id.uID = icon_id_;
   icon_id.hWnd = window_;
   icon_id.cbSize = sizeof(NOTIFYICONIDENTIFIER);
-  icon_id.uID = icon_id_;
   if (is_using_guid_) {
     icon_id.guidItem = guid_;
   }
 
   RECT rect = {0};
   Shell_NotifyIconGetRect(&icon_id, &rect);
-
   return display::win::ScreenWin::ScreenToDIPRect(window_, gfx::Rect(rect));
 }
 

--- a/shell/browser/ui/win/notify_icon.cc
+++ b/shell/browser/ui/win/notify_icon.cc
@@ -5,7 +5,6 @@
 #include "shell/browser/ui/win/notify_icon.h"
 
 #include <objbase.h>
-#include <rpc.h>
 #include <utility>
 
 #include "base/strings/string_number_conversions.h"

--- a/shell/browser/ui/win/notify_icon.h
+++ b/shell/browser/ui/win/notify_icon.h
@@ -7,7 +7,6 @@
 
 #include <windows.h>  // windows.h must be included first
 
-#include <rpc.h>
 #include <shellapi.h>
 
 #include <memory>
@@ -59,7 +58,7 @@ class NotifyIcon : public TrayIcon {
   UINT icon_id() const { return icon_id_; }
   HWND window() const { return window_; }
   UINT message_id() const { return message_id_; }
-  UUID guid() const { return guid_; }
+  GUID guid() const { return guid_; }
 
   // Overridden from TrayIcon:
   void SetImage(HICON image) override;
@@ -96,7 +95,7 @@ class NotifyIcon : public TrayIcon {
   AtomMenuModel* menu_model_ = nullptr;
 
   // An optional GUID used for identifying tray entries on Windows
-  UUID guid_ = GUID_DEFAULT;
+  GUID guid_ = GUID_DEFAULT;
 
   // indicates whether the tray entry is associated with a guid
   bool is_using_guid_ = false;

--- a/shell/browser/ui/win/notify_icon.h
+++ b/shell/browser/ui/win/notify_icon.h
@@ -7,6 +7,7 @@
 
 #include <windows.h>  // windows.h must be included first
 
+#include <rpc.h>
 #include <shellapi.h>
 
 #include <memory>
@@ -17,6 +18,7 @@
 #include "base/memory/weak_ptr.h"
 #include "base/win/scoped_gdi_object.h"
 #include "shell/browser/ui/tray_icon.h"
+#include "shell/browser/ui/win/notify_icon_host.h"
 
 namespace gfx {
 class Point;
@@ -34,7 +36,11 @@ class NotifyIconHost;
 class NotifyIcon : public TrayIcon {
  public:
   // Constructor which provides this icon's unique ID and messaging window.
-  NotifyIcon(NotifyIconHost* host, UINT id, HWND window, UINT message);
+  NotifyIcon(NotifyIconHost* host,
+             UINT id,
+             HWND window,
+             UINT message,
+             GUID guid);
   ~NotifyIcon() override;
 
   // Handles a click event from the user - if |left_button_click| is true and
@@ -53,6 +59,7 @@ class NotifyIcon : public TrayIcon {
   UINT icon_id() const { return icon_id_; }
   HWND window() const { return window_; }
   UINT message_id() const { return message_id_; }
+  UUID guid() const { return guid_; }
 
   // Overridden from TrayIcon:
   void SetImage(HICON image) override;
@@ -87,6 +94,12 @@ class NotifyIcon : public TrayIcon {
 
   // The context menu.
   AtomMenuModel* menu_model_ = nullptr;
+
+  // An optional GUID used for identifying tray entries on Windows
+  UUID guid_ = GUID_DEFAULT;
+
+  // indicates whether the tray entry is associated with a guid
+  bool is_using_guid_ = false;
 
   // Context menu associated with this icon (if any).
   std::unique_ptr<views::MenuRunner> menu_runner_;

--- a/shell/browser/ui/win/notify_icon_host.cc
+++ b/shell/browser/ui/win/notify_icon_host.cc
@@ -5,7 +5,6 @@
 #include "shell/browser/ui/win/notify_icon_host.h"
 
 #include <commctrl.h>
-#include <rpc.h>
 #include <winuser.h>
 
 #include "base/bind.h"
@@ -99,6 +98,7 @@ NotifyIcon* NotifyIconHost::CreateNotifyIcon(base::Optional<UUID> guid) {
   NotifyIcon* notify_icon =
       new NotifyIcon(this, NextIconId(), window_, kNotifyIconMessage,
                      guid.has_value() ? guid.value() : GUID_DEFAULT);
+
   notify_icons_.push_back(notify_icon);
   return notify_icon;
 }

--- a/shell/browser/ui/win/notify_icon_host.cc
+++ b/shell/browser/ui/win/notify_icon_host.cc
@@ -5,6 +5,7 @@
 #include "shell/browser/ui/win/notify_icon_host.h"
 
 #include <commctrl.h>
+#include <rpc.h>
 #include <winuser.h>
 
 #include "base/bind.h"
@@ -83,9 +84,21 @@ NotifyIconHost::~NotifyIconHost() {
     delete ptr;
 }
 
-NotifyIcon* NotifyIconHost::CreateNotifyIcon() {
+NotifyIcon* NotifyIconHost::CreateNotifyIcon(base::Optional<UUID> guid) {
+  if (guid.has_value()) {
+    for (NotifyIcons::const_iterator i(notify_icons_.begin());
+         i != notify_icons_.end(); ++i) {
+      NotifyIcon* current_win_icon = static_cast<NotifyIcon*>(*i);
+      if (current_win_icon->guid() == guid.value()) {
+        LOG(WARNING)
+            << "Guid already in use. Existing tray entry will be replaced.";
+      }
+    }
+  }
+
   NotifyIcon* notify_icon =
-      new NotifyIcon(this, NextIconId(), window_, kNotifyIconMessage);
+      new NotifyIcon(this, NextIconId(), window_, kNotifyIconMessage,
+                     guid.has_value() ? guid.value() : GUID_DEFAULT);
   notify_icons_.push_back(notify_icon);
   return notify_icon;
 }

--- a/shell/browser/ui/win/notify_icon_host.h
+++ b/shell/browser/ui/win/notify_icon_host.h
@@ -5,15 +5,15 @@
 #ifndef SHELL_BROWSER_UI_WIN_NOTIFY_ICON_HOST_H_
 #define SHELL_BROWSER_UI_WIN_NOTIFY_ICON_HOST_H_
 
-#include <rpc.h>
 #include <windows.h>
 
 #include <vector>
 
 #include "base/macros.h"
 #include "base/optional.h"
+#include "shell/common/gin_converters/guid_converter.h"
 
-const UUID GUID_DEFAULT = {0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0}};
+const GUID GUID_DEFAULT = {0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0}};
 
 namespace electron {
 

--- a/shell/browser/ui/win/notify_icon_host.h
+++ b/shell/browser/ui/win/notify_icon_host.h
@@ -5,11 +5,15 @@
 #ifndef SHELL_BROWSER_UI_WIN_NOTIFY_ICON_HOST_H_
 #define SHELL_BROWSER_UI_WIN_NOTIFY_ICON_HOST_H_
 
+#include <rpc.h>
 #include <windows.h>
 
 #include <vector>
 
 #include "base/macros.h"
+#include "base/optional.h"
+
+const UUID GUID_DEFAULT = {0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0}};
 
 namespace electron {
 
@@ -20,7 +24,7 @@ class NotifyIconHost {
   NotifyIconHost();
   ~NotifyIconHost();
 
-  NotifyIcon* CreateNotifyIcon();
+  NotifyIcon* CreateNotifyIcon(base::Optional<UUID> guid);
   void Remove(NotifyIcon* notify_icon);
 
  private:

--- a/shell/common/gin_converters/guid_converter.h
+++ b/shell/common/gin_converters/guid_converter.h
@@ -2,10 +2,22 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#ifndef SHELL_COMMON_GIN_CONVERTERS_FILE_PATH_CONVERTER_H_
-#define SHELL_COMMON_GIN_CONVERTERS_FILE_PATH_CONVERTER_H_
+#ifndef SHELL_COMMON_GIN_CONVERTERS_GUID_CONVERTER_H_
+#define SHELL_COMMON_GIN_CONVERTERS_GUID_CONVERTER_H_
+
+#if defined(OS_WIN)
+#include <rpc.h>
+#endif
+#include <string>
 
 #include "gin/converter.h"
+
+#if defined(OS_WIN)
+typedef GUID UUID;
+#else
+typedef struct {
+} UUID;
+#endif
 
 namespace gin {
 
@@ -14,6 +26,7 @@ struct Converter<UUID> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      UUID* out) {
+#if defined(OS_WIN)
     std::string guid;
     if (!gin::ConvertFromV8(isolate, val, &guid))
       return false;
@@ -31,9 +44,12 @@ struct Converter<UUID> {
       }
     }
     return false;
+#else
+    return false;
+#endif
   }
 };
 
 }  // namespace gin
 
-#endif  // SHELL_COMMON_GIN_CONVERTERS_UUID_H_
+#endif  // SHELL_COMMON_GIN_CONVERTERS_GUID_CONVERTER_H_

--- a/shell/common/gin_converters/guid_converter.h
+++ b/shell/common/gin_converters/guid_converter.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2020 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_COMMON_GIN_CONVERTERS_FILE_PATH_CONVERTER_H_
+#define SHELL_COMMON_GIN_CONVERTERS_FILE_PATH_CONVERTER_H_
+
+#include "gin/converter.h"
+
+namespace gin {
+
+template <>
+struct Converter<UUID> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     UUID* out) {
+    std::string guid;
+    if (!gin::ConvertFromV8(isolate, val, &guid))
+      return false;
+
+    UUID uid;
+
+    if (guid.length() > 0) {
+      unsigned char* uid_cstr = (unsigned char*)guid.c_str();
+      RPC_STATUS result = UuidFromStringA(uid_cstr, &uid);
+      if (result == RPC_S_INVALID_STRING_UUID) {
+        return false;
+      } else {
+        *out = uid;
+        return true;
+      }
+    }
+    return false;
+  }
+};
+
+}  // namespace gin
+
+#endif  // SHELL_COMMON_GIN_CONVERTERS_UUID_H_

--- a/spec-main/api-tray-spec.ts
+++ b/spec-main/api-tray-spec.ts
@@ -20,6 +20,18 @@ describe('tray module', () => {
         tray = new Tray(badPath)
       }).to.throw(/Image could not be created from .*/)
     })
+
+    it('throws a descriptive error if an invlaid guid is given', () => {
+      expect(() => {
+        tray = new Tray(nativeImage.createEmpty(), 'I am not a guid')
+      }).to.throw('Invalid GUID format')
+    })
+
+    it('accepts a valid guid', () => {
+      expect(() => {
+        tray = new Tray(nativeImage.createEmpty(), '0019A433-3526-48BA-A66C-676742C0FEFB')
+      }).to.not.throw();
+    })
   })
 
   ifdescribe(process.platform === 'darwin')('tray get/set ignoreDoubleClickEvents', () => {

--- a/spec-main/api-tray-spec.ts
+++ b/spec-main/api-tray-spec.ts
@@ -21,16 +21,16 @@ describe('tray module', () => {
       }).to.throw(/Image could not be created from .*/)
     })
 
-    it('throws a descriptive error if an invlaid guid is given', () => {
+    ifit(process.platform === 'win32')('throws a descriptive error if an invlaid guid is given', () => {
       expect(() => {
         tray = new Tray(nativeImage.createEmpty(), 'I am not a guid')
       }).to.throw('Invalid GUID format')
     })
 
-    it('accepts a valid guid', () => {
+    ifit(process.platform === 'win32')('accepts a valid guid', () => {
       expect(() => {
         tray = new Tray(nativeImage.createEmpty(), '0019A433-3526-48BA-A66C-676742C0FEFB')
-      }).to.not.throw();
+      }).to.not.throw()
     })
   })
 


### PR DESCRIPTION
#### Description of Change
Enhances the Tray API on Windows to avoid demotion of the icon position in the system tray. With normal usage of the Windows API https://docs.microsoft.com/en-us/windows/win32/api/shellapi/ns-shellapi-notifyicondataa a user customized position of the icon is linked to the absolute file path of the executable. If the path changes, mostly by updater frameworks such Squirrel.Windows, the position is lost, and the icon will be placed back in the overflow area.
However, the combination of a code signed binary and GUID parameter can make the positioning of the icon persistent even if the path to the executable changes.
The use of the GUID parameter also fixes a behavior where the position of a second or third icon will be lost on each restart of the App. Even if the path has not changed. 

I’m aware of a previous attempt https://github.com/electron/electron/pull/2328  to introduce the GUID parameter. The reason why it failed and had to be rolled back is bases on Microsofts somewhat  incomplete/confusing documentation. A couple of gotchas:

- The GUID is not a replacement/alternative for the uID. The uID parameter is still needed to identify the icon via Hwnd messages. 
- The GUID parameter is no global Id for the app that seeks to create icons in the system tray. Each icon needs its own GUID if multiple icons are created.
- The GUID is best used in combination with a code signed binary. Once it is used with code signature, the GUID is permanently bound to it.
- The code signature has to contain CN, OU, O in the subject line. 
- The GUID parameter can be used with none code signed binary. However, now the GUID is permanently bound to the path of the binary. If the path changes and the same GUID is used the creation the Tray icon will fail. Since the GUID was statically derived from the AppUserModelId, PR 2328 had to be reverted because it broke all Apps without code signature when they updated and changed there executable path.

Based on above behaviors of the Windows API its best to make this an opt-in. The developer has to be aware of the behavior/requirements using the GUID parameter. It also allows the mitigation of unexpected problems with the Tray creation by providing a new GUID.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [X] `npm test` passes
- [X] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [X] relevant documentation is changed or added
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added GUID parameter to Tray API to avoid system tray icon demotion on Windows  <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
