### PR TITLE
fix: window.print() only working once

### DIFF
--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -63,7 +63,7 @@ index ebffdb08d080eceb0ea9e96ee3ca7db627cfaf5e..bc00a7a00626cee17e5f5ea976f8248f
  }
  
 diff --git a/chrome/browser/printing/print_view_manager_base.cc b/chrome/browser/printing/print_view_manager_base.cc
-index 155d86fe79b99989c3f604aeaab13782f8e6631c..6fd44945ea44ac80fb123456792f9622abdd316b 100644
+index 155d86fe79b99989c3f604aeaab13782f8e6631c..f801bb8010240bc9ddb35cac921170345f86b8d0 100644
 --- a/chrome/browser/printing/print_view_manager_base.cc
 +++ b/chrome/browser/printing/print_view_manager_base.cc
 @@ -27,10 +27,7 @@
@@ -183,16 +183,20 @@ index 155d86fe79b99989c3f604aeaab13782f8e6631c..6fd44945ea44ac80fb123456792f9622
        NOTREACHED();
        break;
      }
-@@ -552,8 +569,6 @@ bool PrintViewManagerBase::CreateNewPrintJob(
+@@ -552,8 +569,10 @@ bool PrintViewManagerBase::CreateNewPrintJob(
    DCHECK(!quit_inner_loop_);
    DCHECK(query);
  
 -  // Disconnect the current |print_job_|.
 -  DisconnectFromCurrentPrintJob();
++  if (callback_.is_null()) {
++    // Disconnect the current |print_job_| only when calling window.print()
++    DisconnectFromCurrentPrintJob();
++  }
  
    // We can't print if there is no renderer.
    if (!web_contents()->GetRenderViewHost() ||
-@@ -568,8 +583,6 @@ bool PrintViewManagerBase::CreateNewPrintJob(
+@@ -568,8 +587,6 @@ bool PrintViewManagerBase::CreateNewPrintJob(
    print_job_->SetSource(PrintJob::Source::PRINT_PREVIEW, /*source_id=*/"");
  #endif  // defined(OS_CHROMEOS)
  
@@ -201,7 +205,7 @@ index 155d86fe79b99989c3f604aeaab13782f8e6631c..6fd44945ea44ac80fb123456792f9622
    printing_succeeded_ = false;
    return true;
  }
-@@ -618,14 +631,22 @@ void PrintViewManagerBase::ReleasePrintJob() {
+@@ -618,14 +635,22 @@ void PrintViewManagerBase::ReleasePrintJob() {
    content::RenderFrameHost* rfh = printing_rfh_;
    printing_rfh_ = nullptr;
  
@@ -226,6 +230,15 @@ index 155d86fe79b99989c3f604aeaab13782f8e6631c..6fd44945ea44ac80fb123456792f9622
    // Don't close the worker thread.
    print_job_ = nullptr;
  }
+@@ -661,7 +686,7 @@ bool PrintViewManagerBase::RunInnerMessageLoop() {
+ }
+ 
+ bool PrintViewManagerBase::OpportunisticallyCreatePrintJob(int cookie) {
+-  if (print_job_)
++  if (print_job_ && print_job_->document())
+     return true;
+ 
+   if (!cookie) {
 diff --git a/chrome/browser/printing/print_view_manager_base.h b/chrome/browser/printing/print_view_manager_base.h
 index 3d434244927aca5e5dbec8d7c1cd212c5c260c71..9d62c903bf08fa8cfa8c425d430c5e995a04f7fc 100644
 --- a/chrome/browser/printing/print_view_manager_base.h


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/21397.

We should be disconnecting from the current print job for `window.print()`, unlike for `webContents.print()`. This ensures that happens by gating the disconnect call with `callback.is_null()`; the callback member is only non-null for `webContents.print()`.

Tested with https://gist.github.com/0f0e776b138452d6815ef4efc16aa0d1 for the following:
- `webContents.print()` and `window.print()` do not crash
- `webContents.print()` and `window.print()` can be called multiple times without failing
- The DOM is responsive after `webContents.print()` or `window.print()` is called
- Correct settings are sent to `webContents.print()` when it is not called in silent mode

cc @deepak1556 @nornagon @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `window.print()` only worked once on a single `BrowserWindow`.
