### PR TITLE
feat: allow fine grain control of BrowserWindow.focus behavior on mac

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -857,7 +857,10 @@ Try to close the window. This has the same effect as a user manually clicking
 the close button of the window. The web page may cancel the close though. See
 the [close event](#event-close).
 
-#### `win.focus()`
+#### `win.focus([options])`
+
+* `options` Object (optional)
+  * `ignoreOtherApps` Boolean (optional) _macOS_ - Controls whether focus should be stolen when other apps are active. Default is `false`.
 
 Focuses on the window.
 

--- a/shell/browser/api/atom_api_browser_window.cc
+++ b/shell/browser/api/atom_api_browser_window.cc
@@ -295,11 +295,13 @@ void BrowserWindow::OnWindowLeaveFullScreen() {
 #endif
 }
 
-void BrowserWindow::Focus() {
-  if (api_web_contents_->IsOffScreen())
+void BrowserWindow::Focus(
+    const base::Optional<gin_helper::Dictionary>& options) {
+  if (api_web_contents_->IsOffScreen()) {
     FocusOnWebView();
-  else
-    TopLevelWindow::Focus();
+  } else {
+    TopLevelWindow::Focus(options);
+  }
 }
 
 void BrowserWindow::Blur() {

--- a/shell/browser/api/atom_api_browser_window.cc
+++ b/shell/browser/api/atom_api_browser_window.cc
@@ -273,7 +273,7 @@ void BrowserWindow::OnWindowFocus() {
     rwhv->SetActive(true);
 #else
   if (!api_web_contents_->IsDevToolsOpened())
-    web_contents()->Focus();
+    web_contents()->Focus(base::nullopt);
 #endif
 
   TopLevelWindow::OnWindowFocus();

--- a/shell/browser/api/atom_api_browser_window.cc
+++ b/shell/browser/api/atom_api_browser_window.cc
@@ -273,7 +273,7 @@ void BrowserWindow::OnWindowFocus() {
     rwhv->SetActive(true);
 #else
   if (!api_web_contents_->IsDevToolsOpened())
-    web_contents()->Focus(base::nullopt);
+    web_contents()->Focus();
 #endif
 
   TopLevelWindow::OnWindowFocus();

--- a/shell/browser/api/atom_api_browser_window.h
+++ b/shell/browser/api/atom_api_browser_window.h
@@ -68,7 +68,7 @@ class BrowserWindow : public TopLevelWindow,
   void OnWindowFocus() override;
   void OnWindowResize() override;
   void OnWindowLeaveFullScreen() override;
-  void Focus() override;
+  void Focus(const base::Optional<gin_helper::Dictionary>& options) override;
   void Blur() override;
   void SetBackgroundColor(const std::string& color_name) override;
   void SetBrowserView(v8::Local<v8::Value> value) override;

--- a/shell/browser/api/atom_api_top_level_window.cc
+++ b/shell/browser/api/atom_api_top_level_window.cc
@@ -307,12 +307,18 @@ void TopLevelWindow::Close() {
   window_->Close();
 }
 
-void TopLevelWindow::Focus() {
-  window_->Focus(true);
+void TopLevelWindow::Focus(
+    const base::Optional<gin_helper::Dictionary>& options) {
+  FocusOptions focusOptions;
+
+  if (options) {
+    options->Get("ignoreOtherApps", &focusOptions.ignoreOtherApps);
+  }
+  window_->Focus(focusOptions);
 }
 
 void TopLevelWindow::Blur() {
-  window_->Focus(false);
+  window_->Blur();
 }
 
 bool TopLevelWindow::IsFocused() {

--- a/shell/browser/api/atom_api_top_level_window.h
+++ b/shell/browser/api/atom_api_top_level_window.h
@@ -91,7 +91,7 @@ class TopLevelWindow : public gin_helper::TrackableObject<TopLevelWindow>,
   // Public APIs of NativeWindow.
   void SetContentView(gin::Handle<View> view);
   void Close();
-  virtual void Focus();
+  virtual void Focus(const base::Optional<gin_helper::Dictionary>& options);
   virtual void Blur();
   bool IsFocused();
   void Show();

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -88,7 +88,8 @@ void Browser::Focus() {
   // Focus on the first visible window.
   for (auto* const window : WindowList::GetWindows()) {
     if (window->IsVisible()) {
-      window->Focus();
+      FocusOptions focusOptions;
+      window->Focus(focusOptions);
       break;
     }
   }

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -88,7 +88,7 @@ void Browser::Focus() {
   // Focus on the first visible window.
   for (auto* const window : WindowList::GetWindows()) {
     if (window->IsVisible()) {
-      window->Focus(true);
+      window->Focus();
       break;
     }
   }

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -53,6 +53,10 @@ typedef NSView* NativeWindowHandle;
 typedef gfx::AcceleratedWidget NativeWindowHandle;
 #endif
 
+struct FocusOptions {
+  bool ignoreOtherApps = false;
+};
+
 class NativeWindow : public base::SupportsUserData,
                      public views::WidgetDelegate {
  public:
@@ -70,7 +74,8 @@ class NativeWindow : public base::SupportsUserData,
   virtual void Close() = 0;
   virtual void CloseImmediately() = 0;
   virtual bool IsClosed() const;
-  virtual void Focus(bool focus) = 0;
+  virtual void Focus(const FocusOptions& options) = 0;
+  virtual void Blur() = 0;
   virtual bool IsFocused() = 0;
   virtual void Show() = 0;
   virtual void ShowInactive() = 0;

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -35,7 +35,8 @@ class NativeWindowMac : public NativeWindow {
   void SetContentView(views::View* view) override;
   void Close() override;
   void CloseImmediately() override;
-  void Focus(bool focus) override;
+  void Focus(const FocusOptions& options) override;
+  void Blur() override;
   bool IsFocused() override;
   void Show() override;
   void ShowInactive() override;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -601,16 +601,21 @@ void NativeWindowMac::CloseImmediately() {
   [window_ close];
 }
 
-void NativeWindowMac::Focus(bool focus) {
+void NativeWindowMac::Focus(const FocusOptions& options) {
   if (!IsVisible())
     return;
 
-  if (focus) {
-    [[NSApplication sharedApplication] activateIgnoringOtherApps:NO];
-    [window_ makeKeyAndOrderFront:nil];
-  } else {
-    [window_ orderBack:nil];
-  }
+  [[NSApplication sharedApplication]
+      activateIgnoringOtherApps:options.ignoreOtherApps];
+
+  [window_ makeKeyAndOrderFront:nil];
+}
+
+void NativeWindowMac::Blur() {
+  if (!IsVisible())
+    return;
+
+  [window_ orderBack:nil];
 }
 
 bool NativeWindowMac::IsFocused() {
@@ -1205,8 +1210,8 @@ void NativeWindowMac::SetContentProtection(bool enable) {
 
 void NativeWindowMac::SetFocusable(bool focusable) {
   // No known way to unfocus the window if it had the focus. Here we do not
-  // want to call Focus(false) because it moves the window to the back, i.e.
-  // at the bottom in term of z-order.
+  // want to call Blur() because it moves the window to the back, i.e. at
+  // the bottom in term of z-order.
   [window_ setDisableKeyOrMainWindow:!focusable];
 }
 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -367,16 +367,20 @@ void NativeWindowViews::CloseImmediately() {
   widget()->CloseNow();
 }
 
-void NativeWindowViews::Focus(bool focus) {
+void NativeWindowViews::Focus(const FocusOptions& options) {
   // For hidden window focus() should do nothing.
   if (!IsVisible())
     return;
 
-  if (focus) {
-    widget()->Activate();
-  } else {
-    widget()->Deactivate();
-  }
+  widget()->Activate();
+}
+
+void NativeWindowViews::Blur() {
+  // For hidden window focus() should do nothing.
+  if (!IsVisible())
+    return;
+
+  widget()->Deactivate();
 }
 
 bool NativeWindowViews::IsFocused() {
@@ -1001,7 +1005,7 @@ void NativeWindowViews::SetFocusable(bool focusable) {
     ex_style |= WS_EX_NOACTIVATE;
   ::SetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE, ex_style);
   SetSkipTaskbar(!focusable);
-  Focus(false);
+  Blur();
 #endif
 }
 
@@ -1348,7 +1352,8 @@ void NativeWindowViews::DeleteDelegate() {
     // Enable parent window after current window gets closed.
     static_cast<NativeWindowViews*>(parent)->DecrementChildModals();
     // Focus on parent window.
-    parent->Focus(true);
+    FocusOptions focusOptions;
+    parent->Focus(focusOptions&);
   }
 
   NotifyWindowClosed();

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1353,7 +1353,7 @@ void NativeWindowViews::DeleteDelegate() {
     static_cast<NativeWindowViews*>(parent)->DecrementChildModals();
     // Focus on parent window.
     FocusOptions focusOptions;
-    parent->Focus(focusOptions&);
+    parent->Focus(focusOptions);
   }
 
   NotifyWindowClosed();

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -45,7 +45,8 @@ class NativeWindowViews : public NativeWindow,
   void SetContentView(views::View* view) override;
   void Close() override;
   void CloseImmediately() override;
-  void Focus(bool focus) override;
+  void Focus(const FocusOptions& options) override;
+  void Blur() override;
   bool IsFocused() override;
   void Show() override;
   void ShowInactive() override;


### PR DESCRIPTION
#### Description of Change

Fixes #19920

Add an optional parameter dictionary to `BrowserWindow.focus(...)` that allows you to control the state of `activateIgnoringOtherApps`. This gives the application creator the option to aggressively steal focus from other applications. The default value is left to to "false" to respect Apple's application development guidelines. I opted for the optional parameter dictionary because a passing a boolean to Focus already has a general meaning (as evidenced by some of the code I replaced) and I felt it could lead to confusion.

I also ended up pushing the concept of `Blur()` a little deeper in the stack, as I thought it improved readability with the mixed set of parameters.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

cc @MarshallOfSound 

#### Release Notes

Notes: Added an optional parameter to `BrowserWindow.focus` providing better control of focus behavior on macOS.
