### PR TITLE
fix: ensure tray icon is the proper size on linux

### DIFF
--- a/shell/browser/ui/tray_icon_gtk.cc
+++ b/shell/browser/ui/tray_icon_gtk.cc
@@ -47,8 +47,9 @@ gfx::ImageSkia GetIconFromImage(const gfx::Image& image) {
   if (!size.IsEmpty() &&
       ((size.width() > max_size) || (size.height() > max_size))) {
     const double ratio =
-        max_size / double(std::max(size.width(), size.height()));
-    size = gfx::Size(int(ratio * size.width()), int(ratio * size.height()));
+        max_size / static_cast<double>(std::max(size.width(), size.height()));
+    size = gfx::Size(static_cast<int>(ratio * size.width()),
+                     static_cast<int>(ratio * size.height()));
     icon = gfx::ImageSkiaOperations::CreateResizedImage(
         icon, skia::ImageOperations::RESIZE_BEST, size);
   }

--- a/shell/browser/ui/tray_icon_gtk.cc
+++ b/shell/browser/ui/tray_icon_gtk.cc
@@ -4,9 +4,9 @@
 
 #include "shell/browser/ui/tray_icon_gtk.h"
 
-#include <algorithm>
-
 #include <gtk/gtk.h>
+
+#include <algorithm>
 
 #include "base/optional.h"
 #include "base/strings/stringprintf.h"

--- a/shell/browser/ui/tray_icon_gtk.cc
+++ b/shell/browser/ui/tray_icon_gtk.cc
@@ -6,6 +6,8 @@
 
 #include <algorithm>
 
+#include <gtk/gtk.h>
+
 #include "base/optional.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
@@ -14,8 +16,6 @@
 #include "shell/common/application_info.h"
 #include "ui/gfx/image/image.h"
 #include "ui/gfx/image/image_skia_operations.h"
-
-#include <gtk/gtk.h>
 
 namespace electron {
 

--- a/shell/browser/ui/tray_icon_gtk.cc
+++ b/shell/browser/ui/tray_icon_gtk.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/ui/tray_icon_gtk.h"
 
-#include "base/optional.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "chrome/browser/ui/views/status_icons/status_icon_linux_dbus.h"
@@ -15,9 +14,7 @@
 
 namespace electron {
 
-TrayIconGtk::TrayIconGtk() = default;
-
-TrayIconGtk::~TrayIconGtk() = default;
+namespace {
 
 gfx::ImageSkia GetIconFromImage(const gfx::Image& image) {
   auto icon = image.AsImageSkia();
@@ -38,6 +35,12 @@ gfx::ImageSkia GetIconFromImage(const gfx::Image& image) {
 
   return icon;
 }
+
+}  // namespace
+
+TrayIconGtk::TrayIconGtk() = default;
+
+TrayIconGtk::~TrayIconGtk() = default;
 
 void TrayIconGtk::SetImage(const gfx::Image& image) {
   image_ = GetIconFromImage(image);

--- a/shell/browser/ui/tray_icon_gtk.cc
+++ b/shell/browser/ui/tray_icon_gtk.cc
@@ -4,10 +4,6 @@
 
 #include "shell/browser/ui/tray_icon_gtk.h"
 
-#include <gtk/gtk.h>
-
-#include <algorithm>
-
 #include "base/optional.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"

--- a/shell/browser/ui/tray_icon_gtk.cc
+++ b/shell/browser/ui/tray_icon_gtk.cc
@@ -25,9 +25,8 @@ gfx::ImageSkia GetIconFromImage(const gfx::Image& image) {
 
   // Systray icons are historically 22 pixels tall, e.g. on Ubuntu GNOME,
   // KDE, and xfce. Taller icons are causing incorrect sizing issues -- e.g.
-  // a 1x1 icon -- so fnow, pin the height manually. Recent comments at
-  // https://bugs.chromium.org/p/chromium/issues/detail?id=419673,
-  // indicate this might be an active upstream issue too.
+  // a 1x1 icon -- so for now, pin the height manually. Similar behavior to
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=1042098 ?
   static constexpr int DESIRED_HEIGHT = 22;
   if ((size.height() != 0) && (size.height() != DESIRED_HEIGHT)) {
     const double ratio = DESIRED_HEIGHT / static_cast<double>(size.height());


### PR DESCRIPTION
Fixes #21445.

This solves an issue where icons that are larger than the preferred size are not being rendered correctly. This issue surfaced as a side-effect of gfx's change from using the deprecated AppIndicator to now using KdeStatusNotifierItem over dbus.

More info: https://github.com/electron/electron/pull/21904#discussion_r371510492

#### Description of Change

If the icon is too large for the tray, tries to resize it to the correct size.

@codebytere 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed Linux desktop tray icon size regression introduced in the 8.0 betas.