### PR TITLE
feat: add more options to printToPDF

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1303,21 +1303,21 @@ win.webContents.print(options, (success, errorType) => {
 #### `contents.printToPDF(options)`
 
 * `options` Object
-  * `marginsType` Integer (optional) - Specifies the type of margins to use. Uses 0 for
-    default margin, 1 for no margin, and 2 for minimum margin.
-  * `pageSize` String | Size (optional) - Specify page size of the generated PDF. Can be `A3`,
-    `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height`
-    and `width` in microns.
-  * `printBackground` Boolean (optional) - Whether to print CSS backgrounds.
-  * `printSelectionOnly` Boolean (optional) - Whether to print selection only.
-  * `landscape` Boolean (optional) - `true` for landscape, `false` for portrait.
-  * `scaleFactor` Number (optional) - The scale factor of the web page.
   * `headerFooter` Record<string, string> (optional) - the header and footer for the PDF.
     * `title` String - The title for the PDF header.
     * `url` String - the url for the PDF footer.
+  * `landscape` Boolean (optional) - `true` for landscape, `false` for portrait.
+  * `marginsType` Integer (optional) - Specifies the type of margins to use. Uses 0 for
+    default margin, 1 for no margin, and 2 for minimum margin.
+    and `width` in microns.
+  * `scaleFactor` Number (optional) - The scale factor of the web page. Can range from 0 to 100.
   * `pageRanges` Record<string, number> (optional) - The page range to print.
-    * `from` Number - the start page.
-    * `to` Number - the end page.
+    * `from` Number - the first page to print.
+    * `to` Number - the last page to print (inclusive).
+  * `pageSize` String | Size (optional) - Specify page size of the generated PDF. Can be `A3`,
+  `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height`
+  * `printBackground` Boolean (optional) - Whether to print CSS backgrounds.
+  * `printSelectionOnly` Boolean (optional) - Whether to print selection only.
 
 Returns `Promise<Buffer>` - Resolves with the generated PDF data.
 
@@ -1333,7 +1333,9 @@ By default, an empty `options` will be regarded as:
   marginsType: 0,
   printBackground: false,
   printSelectionOnly: false,
-  landscape: false
+  landscape: false,
+  pageSize: 'A4',
+  scaleFactor: 100
 }
 ```
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1273,9 +1273,11 @@ Returns [`PrinterInfo[]`](structures/printer-info.md)
   * `pagesPerSheet` Number (optional) - The number of pages to print per page sheet.
   * `collate` Boolean (optional) - Whether the web page should be collated.
   * `copies` Number (optional) - The number of copies of the web page to print.
-  * `pageRanges` Record<string, number> (optional) - The page range to print. Should have two keys: `from` and `to`.
+  * `pageRanges` Record<string, number> (optional) - The page range to print.
+    * `from` Number - the start page.
+    * `to` Number - the end page.
   * `duplexMode` String (optional) - Set the duplex mode of the printed web page. Can be `simplex`, `shortEdge`, or `longEdge`.
-  * `dpi` Object (optional)
+  * `dpi` Record<string, number> (optional)
     * `horizontal` Number (optional) - The horizontal dpi.
     * `vertical` Number (optional) - The vertical dpi.
   * `header` String (optional) - String to be printed as page header.
@@ -1309,6 +1311,13 @@ win.webContents.print(options, (success, errorType) => {
   * `printBackground` Boolean (optional) - Whether to print CSS backgrounds.
   * `printSelectionOnly` Boolean (optional) - Whether to print selection only.
   * `landscape` Boolean (optional) - `true` for landscape, `false` for portrait.
+  * `scaleFactor` Number (optional) - The scale factor of the web page.
+  * `headerFooter` Record<string, string> (optional) - the header and footer for the PDF.
+    * `title` String - The title for the PDF header.
+    * `url` String - the url for the PDF footer.
+  * `pageRanges` Record<string, number> (optional) - The page range to print.
+    * `from` Number - the start page.
+    * `to` Number - the end page.
 
 Returns `Promise<Buffer>` - Resolves with the generated PDF data.
 

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -564,6 +564,13 @@ Prints `webview`'s web page. Same as `webContents.print([options])`.
   * `printBackground` Boolean (optional) - Whether to print CSS backgrounds.
   * `printSelectionOnly` Boolean (optional) - Whether to print selection only.
   * `landscape` Boolean (optional) - `true` for landscape, `false` for portrait.
+  * `scaleFactor` Number (optional) - The scale factor of the web page.
+  * `headerFooter` Record<string, string> (optional) - the header and footer for the PDF.
+    * `title` String - The title for the PDF header.
+    * `url` String - the url for the PDF footer.
+  * `pageRanges` Record<string, number> (optional) - The page range to print.
+    * `from` Number - the start page.
+    * `to` Number - the end page.
 
 Returns `Promise<Uint8Array>` - Resolves with the generated PDF data.
 

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -556,21 +556,21 @@ Prints `webview`'s web page. Same as `webContents.print([options])`.
 ### `<webview>.printToPDF(options)`
 
 * `options` Object
-  * `marginsType` Integer (optional) - Specifies the type of margins to use. Uses 0 for
-    default margin, 1 for no margin, and 2 for minimum margin.
-  * `pageSize` String | Size (optional) - Specify page size of the generated PDF. Can be `A3`,
-    `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height`
-    and `width` in microns.
-  * `printBackground` Boolean (optional) - Whether to print CSS backgrounds.
-  * `printSelectionOnly` Boolean (optional) - Whether to print selection only.
-  * `landscape` Boolean (optional) - `true` for landscape, `false` for portrait.
-  * `scaleFactor` Number (optional) - The scale factor of the web page.
   * `headerFooter` Record<string, string> (optional) - the header and footer for the PDF.
     * `title` String - The title for the PDF header.
     * `url` String - the url for the PDF footer.
+  * `landscape` Boolean (optional) - `true` for landscape, `false` for portrait.
+  * `marginsType` Integer (optional) - Specifies the type of margins to use. Uses 0 for
+    default margin, 1 for no margin, and 2 for minimum margin.
+    and `width` in microns.
+  * `scaleFactor` Number (optional) - The scale factor of the web page. Can range from 0 to 100.
   * `pageRanges` Record<string, number> (optional) - The page range to print.
-    * `from` Number - the start page.
-    * `to` Number - the end page.
+    * `from` Number - the first page to print.
+    * `to` Number - the last page to print (inclusive).
+  * `pageSize` String | Size (optional) - Specify page size of the generated PDF. Can be `A3`,
+  `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height`
+  * `printBackground` Boolean (optional) - Whether to print CSS backgrounds.
+  * `printSelectionOnly` Boolean (optional) - Whether to print selection only.
 
 Returns `Promise<Uint8Array>` - Resolves with the generated PDF data.
 

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -90,6 +90,7 @@ const defaultPrintingSetting = {
   rasterizePDF: false,
   duplex: 0,
   copies: 1,
+  // 2 = color - see ColorModel in //printing/print_job_constants.h
   color: 2,
   collate: true
 }
@@ -212,7 +213,7 @@ WebContents.prototype.printToPDF = function (options) {
     requestID: getNextId()
   }
 
-  if (options.landscape) {
+  if (options.landscape !== undefined) {
     if (typeof options.landscape !== 'boolean') {
       const error = new Error('landscape must be a Boolean')
       return Promise.reject(error)
@@ -220,7 +221,7 @@ WebContents.prototype.printToPDF = function (options) {
     printSettings.landscape = options.landscape
   }
 
-  if (options.scaleFactor) {
+  if (options.scaleFactor !== undefined) {
     if (typeof options.scaleFactor !== 'number') {
       const error = new Error('scaleFactor must be a Number')
       return Promise.reject(error)
@@ -228,7 +229,7 @@ WebContents.prototype.printToPDF = function (options) {
     printSettings.scaleFactor = options.scaleFactor
   }
 
-  if (options.marginsType) {
+  if (options.marginsType !== undefined) {
     if (typeof options.marginsType !== 'number') {
       const error = new Error('marginsType must be a Number')
       return Promise.reject(error)
@@ -236,7 +237,7 @@ WebContents.prototype.printToPDF = function (options) {
     printSettings.marginsType = options.marginsType
   }
 
-  if (options.printSelectionOnly) {
+  if (options.printSelectionOnly !== undefined) {
     if (typeof options.printSelectionOnly !== 'boolean') {
       const error = new Error('printSelectionOnly must be a Boolean')
       return Promise.reject(error)
@@ -244,7 +245,7 @@ WebContents.prototype.printToPDF = function (options) {
     printSettings.shouldPrintSelectionOnly = options.printSelectionOnly
   }
 
-  if (options.printBackground) {
+  if (options.printBackground !== undefined) {
     if (typeof options.printBackground !== 'boolean') {
       const error = new Error('printBackground must be a Boolean')
       return Promise.reject(error)
@@ -252,7 +253,7 @@ WebContents.prototype.printToPDF = function (options) {
     printSettings.shouldPrintBackgrounds = options.printBackground
   }
 
-  if (options.pageRanges) {
+  if (options.pageRanges !== undefined) {
     const pageRanges = options.pageRanges
     if (!pageRanges.hasOwnProperty('from') || !pageRanges.hasOwnProperty('to')) {
       const error = new Error(`pageRanges must be an Object with 'from' and 'to' properties`)
@@ -276,7 +277,7 @@ WebContents.prototype.printToPDF = function (options) {
     }]
   }
 
-  if (options.headerFooter) {
+  if (options.headerFooter !== undefined) {
     const headerFooter = options.headerFooter
     printSettings.headerFooterEnabled = true
     if (typeof headerFooter === 'object') {
@@ -302,7 +303,7 @@ WebContents.prototype.printToPDF = function (options) {
   }
 
   // Optionally set size for PDF.
-  if (options.pageSize) {
+  if (options.pageSize !== undefined) {
     const pageSize = options.pageSize
     if (typeof pageSize === 'object') {
       if (!pageSize.height || !pageSize.width) {

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -255,7 +255,7 @@ WebContents.prototype.printToPDF = function (options) {
   if (options.pageRanges) {
     const pageRanges = options.pageRanges
     if (!pageRanges.hasOwnProperty('from') || !pageRanges.hasOwnProperty('to')) {
-      const error = new Error(`pageRange must be an Object with a 'for' and 'to' property`)
+      const error = new Error(`pageRanges must be an Object with 'from' and 'to' properties`)
       return Promise.reject(error)
     }
 

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -65,32 +65,33 @@ const PDFPageSizes = {
 
 // Default printing setting
 const defaultPrintingSetting = {
-  pageRage: [],
+  // Customizable.
+  pageRange: [],
   mediaSize: {},
   landscape: false,
-  color: 2,
   headerFooterEnabled: false,
   marginsType: 0,
-  isFirstRequest: false,
-  previewUIID: 0,
-  previewModifiable: true,
-  printToPDF: true,
+  scaleFactor: 100,
+  shouldPrintBackgrounds: false,
+  shouldPrintSelectionOnly: false,
+  // Non-customizable.
   printWithCloudPrint: false,
   printWithPrivet: false,
   printWithExtension: false,
   pagesPerSheet: 1,
+  isFirstRequest: false,
+  previewUIID: 0,
+  previewModifiable: true,
+  printToPDF: true,
   deviceName: 'Save as PDF',
   generateDraftData: true,
-  fitToPageEnabled: false,
-  scaleFactor: 100,
   dpiHorizontal: 72,
   dpiVertical: 72,
   rasterizePDF: false,
   duplex: 0,
   copies: 1,
-  collate: true,
-  shouldPrintBackgrounds: false,
-  shouldPrintSelectionOnly: false
+  color: 2,
+  collate: true
 }
 
 // JavaScript implementations of WebContents.
@@ -206,60 +207,135 @@ WebContents.prototype.executeJavaScriptInIsolatedWorld = async function (code, h
 
 // Translate the options of printToPDF.
 WebContents.prototype.printToPDF = function (options) {
-  const printingSetting = {
+  const printSettings = {
     ...defaultPrintingSetting,
     requestID: getNextId()
   }
+
   if (options.landscape) {
-    printingSetting.landscape = options.landscape
-  }
-  if (options.fitToPageEnabled) {
-    printingSetting.fitToPageEnabled = options.fitToPageEnabled
-  }
-  if (options.scaleFactor) {
-    printingSetting.scaleFactor = options.scaleFactor
-  }
-  if (options.marginsType) {
-    printingSetting.marginsType = options.marginsType
-  }
-  if (options.printSelectionOnly) {
-    printingSetting.shouldPrintSelectionOnly = options.printSelectionOnly
-  }
-  if (options.printBackground) {
-    printingSetting.shouldPrintBackgrounds = options.printBackground
+    if (typeof options.landscape !== 'boolean') {
+      const error = new Error('landscape must be a Boolean')
+      return Promise.reject(error)
+    }
+    printSettings.landscape = options.landscape
   }
 
+  if (options.scaleFactor) {
+    if (typeof options.scaleFactor !== 'number') {
+      const error = new Error('scaleFactor must be a Number')
+      return Promise.reject(error)
+    }
+    printSettings.scaleFactor = options.scaleFactor
+  }
+
+  if (options.marginsType) {
+    if (typeof options.marginsType !== 'number') {
+      const error = new Error('marginsType must be a Number')
+      return Promise.reject(error)
+    }
+    printSettings.marginsType = options.marginsType
+  }
+
+  if (options.printSelectionOnly) {
+    if (typeof options.printSelectionOnly !== 'boolean') {
+      const error = new Error('printSelectionOnly must be a Boolean')
+      return Promise.reject(error)
+    }
+    printSettings.shouldPrintSelectionOnly = options.printSelectionOnly
+  }
+
+  if (options.printBackground) {
+    if (typeof options.printBackground !== 'boolean') {
+      const error = new Error('printBackground must be a Boolean')
+      return Promise.reject(error)
+    }
+    printSettings.shouldPrintBackgrounds = options.printBackground
+  }
+
+  if (options.pageRanges) {
+    const pageRanges = options.pageRanges
+    if (!pageRanges.hasOwnProperty('from') || !pageRanges.hasOwnProperty('to')) {
+      const error = new Error(`pageRange must be an Object with a 'for' and 'to' property`)
+      return Promise.reject(error)
+    }
+
+    if (typeof pageRanges.from !== 'number') {
+      const error = new Error('pageRanges.from must be a Number')
+      return Promise.reject(error)
+    }
+
+    if (typeof pageRanges.to !== 'number') {
+      const error = new Error('pageRanges.to must be a Number')
+      return Promise.reject(error)
+    }
+
+    // Chromium uses 1-based page ranges, so increment each by 1.
+    printSettings.pageRange = [{
+      from: pageRanges.from + 1,
+      to: pageRanges.to + 1
+    }]
+  }
+
+  if (options.headerFooter) {
+    const headerFooter = options.headerFooter
+    printSettings.headerFooterEnabled = true
+    if (typeof headerFooter === 'object') {
+      if (!headerFooter.url || !headerFooter.title) {
+        const error = new Error('url and title properties are required for headerFooter')
+        return Promise.reject(error)
+      }
+      if (typeof headerFooter.title !== 'string') {
+        const error = new Error('headerFooter.title must be a String')
+        return Promise.reject(error)
+      }
+      printSettings.title = headerFooter.title
+
+      if (typeof headerFooter.url !== 'string') {
+        const error = new Error('headerFooter.url must be a String')
+        return Promise.reject(error)
+      }
+      printSettings.url = headerFooter.url
+    } else {
+      const error = new Error('headerFooter must be an Object')
+      return Promise.reject(error)
+    }
+  }
+
+  // Optionally set size for PDF.
   if (options.pageSize) {
     const pageSize = options.pageSize
     if (typeof pageSize === 'object') {
       if (!pageSize.height || !pageSize.width) {
-        return Promise.reject(new Error('Must define height and width for pageSize'))
+        const error = new Error('height and width properties are required for pageSize')
+        return Promise.reject(error)
       }
       // Dimensions in Microns
       // 1 meter = 10^6 microns
-      printingSetting.mediaSize = {
+      printSettings.mediaSize = {
         name: 'CUSTOM',
         custom_display_name: 'Custom',
         height_microns: Math.ceil(pageSize.height),
         width_microns: Math.ceil(pageSize.width)
       }
     } else if (PDFPageSizes[pageSize]) {
-      printingSetting.mediaSize = PDFPageSizes[pageSize]
+      printSettings.mediaSize = PDFPageSizes[pageSize]
     } else {
-      return Promise.reject(new Error(`Does not support pageSize with ${pageSize}`))
+      const error = new Error(`Unsupported pageSize: ${pageSize}`)
+      return Promise.reject(error)
     }
   } else {
-    printingSetting.mediaSize = PDFPageSizes['A4']
+    printSettings.mediaSize = PDFPageSizes['A4']
   }
 
   // Chromium expects this in a 0-100 range number, not as float
-  printingSetting.scaleFactor = Math.ceil(printingSetting.scaleFactor) % 100
+  printSettings.scaleFactor = Math.ceil(printSettings.scaleFactor) % 100
   // PrinterType enum from //printing/print_job_constants.h
-  printingSetting.printerType = 2
+  printSettings.printerType = 2
   if (features.isPrintingEnabled()) {
-    return this._printToPDF(printingSetting)
+    return this._printToPDF(printSettings)
   } else {
-    return Promise.reject(new Error('Printing feature is disabled'))
+    const error = new Error('Printing feature is disabled')
+    return Promise.reject(error)
   }
 }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/13190.

This PR does the following:
* Allows for customization of `pageRanges`, `scaleFactor`, and `headerFooter` on `contents.printToPDF()`
* Improves existing argument sanitization for options passed to `contents.printToPDF()`
     * Conversion is done deep in Chromium's print conversion code so if it receives the wrong types it will hard crash; we should be type checking ourselves
* Adds a test for the above sanitization changes

Tested with:
```js
  mainWindow.loadURL('https://github.com')
  mainWindow.webContents.on('did-finish-load', () => {
    mainWindow.webContents.printToPDF({pageRanges: {from: 1, to: 3}}).then(data => {
      fs.writeFile('/Users/codebytere/Desktop/print_test.pdf', data, (error) => {
        if (error) throw error
        console.log('Write PDF successfully.')
      })
    }).catch(error => {
      console.log(error)
    })
  })
```

and varying combinations of parameters.

cc @deepak1556 @zcbenz @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Exposed more customizable options for `contents.printToPDF()` and fixed a potential for native crash.
