### PR TITLE
fix: window.print() only working once

### DIFF
--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -63,7 +63,7 @@ index aacffd44658cac701c9683fcb3b20135a64c18bd..01cd31eb174e198724cab082e5056444
  }
  
 diff --git a/chrome/browser/printing/print_view_manager_base.cc b/chrome/browser/printing/print_view_manager_base.cc
-index 3d026cd11aa2c0b009812317995cd4e02161251e..2778bfd64270a2e93153f39e849316ed1ad8dbbf 100644
+index 3d026cd11aa2c0b009812317995cd4e02161251e..99aac7f3932d3a8eb988337cd8dbf5c6965c87a7 100644
 --- a/chrome/browser/printing/print_view_manager_base.cc
 +++ b/chrome/browser/printing/print_view_manager_base.cc
 @@ -27,10 +27,7 @@
@@ -183,16 +183,20 @@ index 3d026cd11aa2c0b009812317995cd4e02161251e..2778bfd64270a2e93153f39e849316ed
        NOTREACHED();
        break;
      }
-@@ -548,8 +565,6 @@ bool PrintViewManagerBase::CreateNewPrintJob(
+@@ -548,8 +565,10 @@ bool PrintViewManagerBase::CreateNewPrintJob(
    DCHECK(!quit_inner_loop_);
    DCHECK(query);
  
 -  // Disconnect the current |print_job_|.
 -  DisconnectFromCurrentPrintJob();
++  if (callback_.is_null()) {
++    // Disconnect the current |print_job_| only when calling window.print()
++    DisconnectFromCurrentPrintJob();
++  }
  
    // We can't print if there is no renderer.
    if (!web_contents()->GetRenderViewHost() ||
-@@ -564,8 +579,6 @@ bool PrintViewManagerBase::CreateNewPrintJob(
+@@ -564,8 +583,6 @@ bool PrintViewManagerBase::CreateNewPrintJob(
    print_job_->SetSource(PrintJob::Source::PRINT_PREVIEW, /*source_id=*/"");
  #endif  // defined(OS_CHROMEOS)
  
@@ -226,6 +230,15 @@ index 3d026cd11aa2c0b009812317995cd4e02161251e..2778bfd64270a2e93153f39e849316ed
    // Don't close the worker thread.
    print_job_ = nullptr;
  }
+@@ -657,7 +684,7 @@ bool PrintViewManagerBase::RunInnerMessageLoop() {
+ }
+ 
+ bool PrintViewManagerBase::OpportunisticallyCreatePrintJob(int cookie) {
+-  if (print_job_)
++  if (print_job_ && print_job_->document())
+     return true;
+ 
+   if (!cookie) {
 diff --git a/chrome/browser/printing/print_view_manager_base.h b/chrome/browser/printing/print_view_manager_base.h
 index af49d3e2f8abaf7dc4d82dc3f9beccdf4fbd9f18..c5ef1a4c1577c509e5fbe0fcf06e6dfdba30c92c 100644
 --- a/chrome/browser/printing/print_view_manager_base.h


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/21893.

See that PR for more details.

Notes: Fixed an issue where `window.print()` only worked once on a single `BrowserWindow`.