### PR TITLE
docs: fix links to SECURITY and CONTRIBUTING files

### DIFF
--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -3,7 +3,7 @@
 ## Finding Support
 
 If you have a security concern,
-please see the [security document](../../SECURITY.md).
+please see the [security document](https://github.com/electron/electron/tree/master/SECURITY.md).
 
 If you're looking for programming help,
 for answers to questions,
@@ -22,7 +22,7 @@ forums
 - [`electron-pl`](https://electronpl.github.io) *(Poland)*
 
 If you'd like to contribute to Electron,
-see the [contributing document](../../CONTRIBUTING.md).
+see the [contributing document](https://github.com/electron/electron/blob/master/CONTRIBUTING.md).
 
 If you've found a bug in a [supported version](#supported-versions) of Electron,
 please report it with the [issue tracker](../development/issues.md).


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electronjs.org/issues/3430.

* From what I can gather, all the relative `.md` file links in the docs are converted to webpage URLs when building the website.
* However, it seems like `SECURITY.md` and `CONTRIBUTING.md` are not converted into web pages.
* This PR changes the relative `.md` links to absolute links to the SECURITY and CONTRIBUTING docs.
* I believe this is the correct way to do this, as the electronjs.org footer also links the SECURITY page in this manner ([link here](https://github.com/electron/electronjs.org/blob/208b07e006064891ef69c2570b762fc5c968fac8/views/partials/footer.html#L10-L12)).

cc @electron/wg-ecosystem 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
