### PR TITLE
fix: use legacy base::Value serializers for ipc (7-1-x)

### DIFF
--- a/build/args/goma.gn
+++ b/build/args/goma.gn
@@ -1,2 +1,0 @@
-goma_dir = rebase_path("//electron/external_binaries/goma")
-use_goma = true

--- a/build/args/goma.gn
+++ b/build/args/goma.gn
@@ -1,0 +1,2 @@
+goma_dir = rebase_path("//electron/external_binaries/goma")
+use_goma = true

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -92,3 +92,4 @@ accessible_pane_view.patch
 only_apply_transform_when_outermost_outer_webcontents.patch
 never_let_a_non-zero-size_pixel_snap_to_zero_size.patch
 fix_hi-dpi_transitions_on_catalina.patch
+typemap.patch

--- a/patches/chromium/typemap.patch
+++ b/patches/chromium/typemap.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jeremy Apthorp <nornagon@nornagon.net>
+Date: Mon, 27 Jan 2020 16:02:41 -0800
+Subject: typemap
+
+this adds electron's typemap to the global registry of typemaps. Only
+needed for temporarily supporting the legacy-ipc base::ListValue
+serializers until we switch to using SCA.
+
+diff --git a/mojo/public/tools/bindings/chromium_bindings_configuration.gni b/mojo/public/tools/bindings/chromium_bindings_configuration.gni
+index 6e8bc9e2c4f0edca9f22eac5017b44000e477ea2..a482fdca501ed94ec135c18cd35bc2fe3cf6ed88 100644
+--- a/mojo/public/tools/bindings/chromium_bindings_configuration.gni
++++ b/mojo/public/tools/bindings/chromium_bindings_configuration.gni
+@@ -22,6 +22,7 @@ _typemap_imports = [
+   "//device/bluetooth/public/mojom/typemaps.gni",
+   "//device/bluetooth/public/mojom/test/typemaps.gni",
+   "//device/gamepad/public/cpp/typemaps.gni",
++  "//electron/shell/common/api/typemaps.gni",
+   "//fuchsia/mojom/test_typemaps.gni",
+   "//gpu/ipc/common/typemaps.gni",
+   "//ipc/typemaps.gni",

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -1023,36 +1023,39 @@ void WebContents::OnElectronBrowserConnectionError() {
 
 void WebContents::Message(bool internal,
                           const std::string& channel,
-                          base::Value arguments) {
+                          const base::ListValue& arguments) {
   // webContents.emit('-ipc-message', new Event(), internal, channel,
   // arguments);
   EmitWithSender("-ipc-message", bindings_.dispatch_context(), base::nullopt,
-                 internal, channel, std::move(arguments));
+                 internal, channel,
+                 base::Value(std::move(arguments.GetList())));
 }
 
 void WebContents::Invoke(const std::string& channel,
-                         base::Value arguments,
+                         const base::ListValue& arguments,
                          InvokeCallback callback) {
   // webContents.emit('-ipc-invoke', new Event(), channel, arguments);
   EmitWithSender("-ipc-invoke", bindings_.dispatch_context(),
-                 std::move(callback), channel, std::move(arguments));
+                 std::move(callback), channel,
+                 base::Value(std::move(arguments.GetList())));
 }
 
 void WebContents::MessageSync(bool internal,
                               const std::string& channel,
-                              base::Value arguments,
+                              const base::ListValue& arguments,
                               MessageSyncCallback callback) {
   // webContents.emit('-ipc-message-sync', new Event(sender, message), internal,
   // channel, arguments);
   EmitWithSender("-ipc-message-sync", bindings_.dispatch_context(),
-                 std::move(callback), internal, channel, std::move(arguments));
+                 std::move(callback), internal, channel,
+                 base::Value(std::move(arguments.GetList())));
 }
 
 void WebContents::MessageTo(bool internal,
                             bool send_to_all,
                             int32_t web_contents_id,
                             const std::string& channel,
-                            base::Value arguments) {
+                            const base::ListValue& arguments) {
   auto* web_contents = mate::TrackableObject<WebContents>::FromWeakMapID(
       isolate(), web_contents_id);
 
@@ -1064,10 +1067,11 @@ void WebContents::MessageTo(bool internal,
 }
 
 void WebContents::MessageHost(const std::string& channel,
-                              base::Value arguments) {
+                              const base::ListValue& arguments) {
   // webContents.emit('ipc-message-host', new Event(), channel, args);
   EmitWithSender("ipc-message-host", bindings_.dispatch_context(),
-                 base::nullopt, channel, std::move(arguments));
+                 base::nullopt, channel,
+                 base::Value(std::move(arguments.GetList())));
 }
 
 void WebContents::UpdateDraggableRegions(
@@ -1966,7 +1970,8 @@ bool WebContents::SendIPCMessageWithSender(bool internal,
     mojom::ElectronRendererAssociatedPtr electron_ptr;
     frame_host->GetRemoteAssociatedInterfaces()->GetInterface(
         mojo::MakeRequest(&electron_ptr));
-    electron_ptr->Message(internal, false, channel, args.Clone(), sender_id);
+    electron_ptr->Message(internal, false, channel,
+                          base::ListValue(args.Clone().GetList()), sender_id);
   }
   return true;
 }
@@ -1988,7 +1993,8 @@ bool WebContents::SendIPCMessageToFrame(bool internal,
   mojom::ElectronRendererAssociatedPtr electron_ptr;
   (*iter)->GetRemoteAssociatedInterfaces()->GetInterface(
       mojo::MakeRequest(&electron_ptr));
-  electron_ptr->Message(internal, send_to_all, channel, args.Clone(),
+  electron_ptr->Message(internal, send_to_all, channel,
+                        base::ListValue(args.Clone().GetList()),
                         0 /* sender_id */);
   return true;
 }

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -1027,8 +1027,7 @@ void WebContents::Message(bool internal,
   // webContents.emit('-ipc-message', new Event(), internal, channel,
   // arguments);
   EmitWithSender("-ipc-message", bindings_.dispatch_context(), base::nullopt,
-                 internal, channel,
-                 base::Value(std::move(arguments.GetList())));
+                 internal, channel, arguments);
 }
 
 void WebContents::Invoke(const std::string& channel,
@@ -1036,8 +1035,7 @@ void WebContents::Invoke(const std::string& channel,
                          InvokeCallback callback) {
   // webContents.emit('-ipc-invoke', new Event(), channel, arguments);
   EmitWithSender("-ipc-invoke", bindings_.dispatch_context(),
-                 std::move(callback), channel,
-                 base::Value(std::move(arguments.GetList())));
+                 std::move(callback), channel, arguments);
 }
 
 void WebContents::MessageSync(bool internal,
@@ -1047,8 +1045,7 @@ void WebContents::MessageSync(bool internal,
   // webContents.emit('-ipc-message-sync', new Event(sender, message), internal,
   // channel, arguments);
   EmitWithSender("-ipc-message-sync", bindings_.dispatch_context(),
-                 std::move(callback), internal, channel,
-                 base::Value(std::move(arguments.GetList())));
+                 std::move(callback), internal, channel, arguments);
 }
 
 void WebContents::MessageTo(bool internal,
@@ -1061,8 +1058,7 @@ void WebContents::MessageTo(bool internal,
 
   if (web_contents) {
     web_contents->SendIPCMessageWithSender(internal, send_to_all, channel,
-                                           base::ListValue(arguments.GetList()),
-                                           ID());
+                                           arguments, ID());
   }
 }
 
@@ -1070,8 +1066,7 @@ void WebContents::MessageHost(const std::string& channel,
                               const base::ListValue& arguments) {
   // webContents.emit('ipc-message-host', new Event(), channel, args);
   EmitWithSender("ipc-message-host", bindings_.dispatch_context(),
-                 base::nullopt, channel,
-                 base::Value(std::move(arguments.GetList())));
+                 base::nullopt, channel, arguments);
 }
 
 void WebContents::UpdateDraggableRegions(
@@ -1970,8 +1965,7 @@ bool WebContents::SendIPCMessageWithSender(bool internal,
     mojom::ElectronRendererAssociatedPtr electron_ptr;
     frame_host->GetRemoteAssociatedInterfaces()->GetInterface(
         mojo::MakeRequest(&electron_ptr));
-    electron_ptr->Message(internal, false, channel,
-                          base::ListValue(args.Clone().GetList()), sender_id);
+    electron_ptr->Message(internal, false, channel, args, sender_id);
   }
   return true;
 }
@@ -1993,8 +1987,7 @@ bool WebContents::SendIPCMessageToFrame(bool internal,
   mojom::ElectronRendererAssociatedPtr electron_ptr;
   (*iter)->GetRemoteAssociatedInterfaces()->GetInterface(
       mojo::MakeRequest(&electron_ptr));
-  electron_ptr->Message(internal, send_to_all, channel,
-                        base::ListValue(args.Clone().GetList()),
+  electron_ptr->Message(internal, send_to_all, channel, args,
                         0 /* sender_id */);
   return true;
 }

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -1027,7 +1027,7 @@ void WebContents::Message(bool internal,
   // webContents.emit('-ipc-message', new Event(), internal, channel,
   // arguments);
   EmitWithSender("-ipc-message", bindings_.dispatch_context(), base::nullopt,
-                 internal, channel, arguments);
+                 internal, channel, std::move(arguments));
 }
 
 void WebContents::Invoke(const std::string& channel,
@@ -1035,7 +1035,7 @@ void WebContents::Invoke(const std::string& channel,
                          InvokeCallback callback) {
   // webContents.emit('-ipc-invoke', new Event(), channel, arguments);
   EmitWithSender("-ipc-invoke", bindings_.dispatch_context(),
-                 std::move(callback), channel, arguments);
+                 std::move(callback), channel, std::move(arguments));
 }
 
 void WebContents::MessageSync(bool internal,
@@ -1045,7 +1045,7 @@ void WebContents::MessageSync(bool internal,
   // webContents.emit('-ipc-message-sync', new Event(sender, message), internal,
   // channel, arguments);
   EmitWithSender("-ipc-message-sync", bindings_.dispatch_context(),
-                 std::move(callback), internal, channel, arguments);
+                 std::move(callback), internal, channel, std::move(arguments));
 }
 
 void WebContents::MessageTo(bool internal,
@@ -1066,7 +1066,7 @@ void WebContents::MessageHost(const std::string& channel,
                               base::ListValue arguments) {
   // webContents.emit('ipc-message-host', new Event(), channel, args);
   EmitWithSender("ipc-message-host", bindings_.dispatch_context(),
-                 base::nullopt, channel, arguments);
+                 base::nullopt, channel, std::move(arguments));
 }
 
 void WebContents::UpdateDraggableRegions(
@@ -1967,7 +1967,7 @@ bool WebContents::SendIPCMessageWithSender(bool internal,
     frame_host->GetRemoteAssociatedInterfaces()->GetInterface(
         mojo::MakeRequest(&electron_ptr));
     electron_ptr->Message(internal, false, channel,
-                          base::ListValue(args.GetList()), sender_id);
+                          base::ListValue(args.Clone().GetList()), sender_id);
   }
   return true;
 }

--- a/shell/browser/api/atom_api_web_contents.h
+++ b/shell/browser/api/atom_api_web_contents.h
@@ -217,19 +217,19 @@ class WebContents : public mate::TrackableObject<WebContents>,
   bool SendIPCMessage(bool internal,
                       bool send_to_all,
                       const std::string& channel,
-                      const base::ListValue& args);
+                      base::ListValue args);
 
   bool SendIPCMessageWithSender(bool internal,
                                 bool send_to_all,
                                 const std::string& channel,
-                                const base::ListValue& args,
+                                base::ListValue args,
                                 int32_t sender_id = 0);
 
   bool SendIPCMessageToFrame(bool internal,
                              bool send_to_all,
                              int32_t frame_id,
                              const std::string& channel,
-                             const base::ListValue& args);
+                             base::ListValue args);
 
   // Send WebInputEvent to the page.
   void SendInputEvent(v8::Isolate* isolate, v8::Local<v8::Value> input_event);
@@ -509,21 +509,21 @@ class WebContents : public mate::TrackableObject<WebContents>,
   // mojom::ElectronBrowser
   void Message(bool internal,
                const std::string& channel,
-               const base::ListValue& arguments) override;
+               base::ListValue arguments) override;
   void Invoke(const std::string& channel,
-              const base::ListValue& arguments,
+              base::ListValue arguments,
               InvokeCallback callback) override;
   void MessageSync(bool internal,
                    const std::string& channel,
-                   const base::ListValue& arguments,
+                   base::ListValue arguments,
                    MessageSyncCallback callback) override;
   void MessageTo(bool internal,
                  bool send_to_all,
                  int32_t web_contents_id,
                  const std::string& channel,
-                 const base::ListValue& arguments) override;
+                 base::ListValue arguments) override;
   void MessageHost(const std::string& channel,
-                   const base::ListValue& arguments) override;
+                   base::ListValue arguments) override;
   void UpdateDraggableRegions(
       std::vector<mojom::DraggableRegionPtr> regions) override;
   void SetTemporaryZoomLevel(double level) override;

--- a/shell/browser/api/atom_api_web_contents.h
+++ b/shell/browser/api/atom_api_web_contents.h
@@ -509,20 +509,21 @@ class WebContents : public mate::TrackableObject<WebContents>,
   // mojom::ElectronBrowser
   void Message(bool internal,
                const std::string& channel,
-               base::Value arguments) override;
+               const base::ListValue& arguments) override;
   void Invoke(const std::string& channel,
-              base::Value arguments,
+              const base::ListValue& arguments,
               InvokeCallback callback) override;
   void MessageSync(bool internal,
                    const std::string& channel,
-                   base::Value arguments,
+                   const base::ListValue& arguments,
                    MessageSyncCallback callback) override;
   void MessageTo(bool internal,
                  bool send_to_all,
                  int32_t web_contents_id,
                  const std::string& channel,
-                 base::Value arguments) override;
-  void MessageHost(const std::string& channel, base::Value arguments) override;
+                 const base::ListValue& arguments) override;
+  void MessageHost(const std::string& channel,
+                   const base::ListValue& arguments) override;
   void UpdateDraggableRegions(
       std::vector<mojom::DraggableRegionPtr> regions) override;
   void SetTemporaryZoomLevel(double level) override;

--- a/shell/browser/api/event.cc
+++ b/shell/browser/api/event.cc
@@ -61,7 +61,10 @@ bool Event::SendReply(const base::Value& result) {
   if (!callback_ || sender_ == nullptr)
     return false;
 
-  std::move(*callback_).Run(result.Clone());
+  base::ListValue ret;
+  ret.GetList().push_back(result.Clone());
+
+  std::move(*callback_).Run(std::move(ret));
   callback_.reset();
   return true;
 }

--- a/shell/common/api/BUILD.gn
+++ b/shell/common/api/BUILD.gn
@@ -3,6 +3,7 @@ import("//mojo/public/tools/bindings/mojom.gni")
 mojom("mojo") {
   sources = [
     "api.mojom",
+    "native_types.mojom",
   ]
 
   public_deps = [

--- a/shell/common/api/api.mojom
+++ b/shell/common/api/api.mojom
@@ -39,7 +39,7 @@ interface ElectronBrowser {
   // process, and returns the response.
   Invoke(
       string channel,
-      LegacyListValue arguments) => (mojo_base.mojom.Value result);
+      LegacyListValue arguments) => (LegacyListValue result);
 
   // Emits an event on |channel| from the ipcMain JavaScript object in the main
   // process, and waits synchronously for a response.
@@ -47,7 +47,7 @@ interface ElectronBrowser {
   MessageSync(
     bool internal,
     string channel,
-    LegacyListValue arguments) => (mojo_base.mojom.Value result);
+    LegacyListValue arguments) => (LegacyListValue result);
 
   // Emits an event from the |ipcRenderer| JavaScript object in the target
   // WebContents's main frame, specified by |web_contents_id|.

--- a/shell/common/api/api.mojom
+++ b/shell/common/api/api.mojom
@@ -1,15 +1,16 @@
 module electron.mojom;
 
-import "mojo/public/mojom/base/values.mojom";
 import "mojo/public/mojom/base/string16.mojom";
 import "ui/gfx/geometry/mojom/geometry.mojom";
+import "electron/shell/common/api/native_types.mojom";
+import "mojo/public/mojom/base/values.mojom";
 
 interface ElectronRenderer {
   Message(
       bool internal,
       bool send_to_all,
       string channel,
-      mojo_base.mojom.ListValue arguments,
+      LegacyListValue arguments,
       int32 sender_id);
 
   UpdateCrashpadPipeName(string pipe_name);
@@ -32,13 +33,13 @@ interface ElectronBrowser {
   Message(
       bool internal,
       string channel,
-      mojo_base.mojom.ListValue arguments);
+      LegacyListValue arguments);
 
   // Emits an event on |channel| from the ipcMain JavaScript object in the main
   // process, and returns the response.
   Invoke(
       string channel,
-      mojo_base.mojom.ListValue arguments) => (mojo_base.mojom.Value result);
+      LegacyListValue arguments) => (mojo_base.mojom.Value result);
 
   // Emits an event on |channel| from the ipcMain JavaScript object in the main
   // process, and waits synchronously for a response.
@@ -46,7 +47,7 @@ interface ElectronBrowser {
   MessageSync(
     bool internal,
     string channel,
-    mojo_base.mojom.ListValue arguments) => (mojo_base.mojom.Value result);
+    LegacyListValue arguments) => (mojo_base.mojom.Value result);
 
   // Emits an event from the |ipcRenderer| JavaScript object in the target
   // WebContents's main frame, specified by |web_contents_id|.
@@ -55,11 +56,11 @@ interface ElectronBrowser {
     bool send_to_all,
     int32 web_contents_id,
     string channel,
-    mojo_base.mojom.ListValue arguments);
+    LegacyListValue arguments);
 
   MessageHost(
     string channel,
-    mojo_base.mojom.ListValue arguments);
+    LegacyListValue arguments);
 
   UpdateDraggableRegions(
     array<DraggableRegion> regions);

--- a/shell/common/api/native_types.mojom
+++ b/shell/common/api/native_types.mojom
@@ -1,0 +1,4 @@
+module electron.mojom;
+
+[Native]
+struct LegacyListValue;

--- a/shell/common/api/remote_callback_freer.cc
+++ b/shell/common/api/remote_callback_freer.cc
@@ -55,7 +55,7 @@ void RemoteCallbackFreer::RunDestructor() {
     (*iter)->GetRemoteAssociatedInterfaces()->GetInterface(
         mojo::MakeRequest(&electron_ptr));
     electron_ptr->Message(true /* internal */, false /* send_to_all */, channel,
-                          args.Clone(), sender_id);
+                          base::ListValue(args.Clone().GetList()), sender_id);
   }
 
   Observe(nullptr);

--- a/shell/common/api/remote_callback_freer.cc
+++ b/shell/common/api/remote_callback_freer.cc
@@ -55,7 +55,7 @@ void RemoteCallbackFreer::RunDestructor() {
     (*iter)->GetRemoteAssociatedInterfaces()->GetInterface(
         mojo::MakeRequest(&electron_ptr));
     electron_ptr->Message(true /* internal */, false /* send_to_all */, channel,
-                          args, sender_id);
+                          base::ListValue(args.Clone().GetList()), sender_id);
   }
 
   Observe(nullptr);

--- a/shell/common/api/remote_callback_freer.cc
+++ b/shell/common/api/remote_callback_freer.cc
@@ -55,7 +55,7 @@ void RemoteCallbackFreer::RunDestructor() {
     (*iter)->GetRemoteAssociatedInterfaces()->GetInterface(
         mojo::MakeRequest(&electron_ptr));
     electron_ptr->Message(true /* internal */, false /* send_to_all */, channel,
-                          base::ListValue(args.Clone().GetList()), sender_id);
+                          args, sender_id);
   }
 
   Observe(nullptr);

--- a/shell/common/api/remote_object_freer.cc
+++ b/shell/common/api/remote_object_freer.cc
@@ -79,7 +79,7 @@ void RemoteObjectFreer::RunDestructor() {
   mojom::ElectronBrowserPtr electron_ptr;
   render_frame->GetRemoteInterfaces()->GetInterface(
       mojo::MakeRequest(&electron_ptr));
-  electron_ptr->Message(true, channel, args.Clone());
+  electron_ptr->Message(true, channel, base::ListValue(args.Clone().GetList()));
 }
 
 }  // namespace electron

--- a/shell/common/api/remote_object_freer.cc
+++ b/shell/common/api/remote_object_freer.cc
@@ -79,7 +79,7 @@ void RemoteObjectFreer::RunDestructor() {
   mojom::ElectronBrowserPtr electron_ptr;
   render_frame->GetRemoteInterfaces()->GetInterface(
       mojo::MakeRequest(&electron_ptr));
-  electron_ptr->Message(true, channel, args);
+  electron_ptr->Message(true, channel, std::move(args));
 }
 
 }  // namespace electron

--- a/shell/common/api/remote_object_freer.cc
+++ b/shell/common/api/remote_object_freer.cc
@@ -4,6 +4,8 @@
 
 #include "shell/common/api/remote_object_freer.h"
 
+#include <utility>
+
 #include "base/strings/utf_string_conversions.h"
 #include "base/values.h"
 #include "content/public/renderer/render_frame.h"

--- a/shell/common/api/remote_object_freer.cc
+++ b/shell/common/api/remote_object_freer.cc
@@ -79,7 +79,7 @@ void RemoteObjectFreer::RunDestructor() {
   mojom::ElectronBrowserPtr electron_ptr;
   render_frame->GetRemoteInterfaces()->GetInterface(
       mojo::MakeRequest(&electron_ptr));
-  electron_ptr->Message(true, channel, base::ListValue(args.Clone().GetList()));
+  electron_ptr->Message(true, channel, args);
 }
 
 }  // namespace electron

--- a/shell/common/api/typemaps.gni
+++ b/shell/common/api/typemaps.gni
@@ -1,0 +1,1 @@
+typemaps = [ "//electron/shell/common/native_types.typemap" ]

--- a/shell/common/native_types.typemap
+++ b/shell/common/native_types.typemap
@@ -5,5 +5,5 @@ deps = [
   "//ipc"
 ]
 type_mappings = [
-  "electron.mojom.LegacyListValue=::base::ListValue",
+  "electron.mojom.LegacyListValue=::base::ListValue[move_only]",
 ]

--- a/shell/common/native_types.typemap
+++ b/shell/common/native_types.typemap
@@ -1,0 +1,9 @@
+mojom = "//electron/shell/common/api/native_types.mojom"
+public_headers = []
+traits_headers = [ "//ipc/ipc_message_utils.h" ]
+deps = [
+  "//ipc"
+]
+type_mappings = [
+  "electron.mojom.LegacyListValue=::base::ListValue",
+]

--- a/shell/renderer/api/atom_api_renderer_ipc.cc
+++ b/shell/renderer/api/atom_api_renderer_ipc.cc
@@ -62,7 +62,8 @@ class IPCRenderer : public mate::Wrappable<IPCRenderer> {
   void Send(bool internal,
             const std::string& channel,
             const base::ListValue& arguments) {
-    electron_browser_ptr_->Message(internal, channel, arguments.Clone());
+    electron_browser_ptr_->Message(
+        internal, channel, base::ListValue(arguments.Clone().GetList()));
   }
 
   v8::Local<v8::Promise> Invoke(mate::Arguments* args,
@@ -72,7 +73,7 @@ class IPCRenderer : public mate::Wrappable<IPCRenderer> {
     auto handle = p.GetHandle();
 
     electron_browser_ptr_->Invoke(
-        channel, arguments.Clone(),
+        channel, base::ListValue(arguments.Clone().GetList()),
         base::BindOnce([](electron::util::Promise p,
                           base::Value result) { p.Resolve(result); },
                        std::move(p)));
@@ -85,13 +86,15 @@ class IPCRenderer : public mate::Wrappable<IPCRenderer> {
               int32_t web_contents_id,
               const std::string& channel,
               const base::ListValue& arguments) {
-    electron_browser_ptr_->MessageTo(internal, send_to_all, web_contents_id,
-                                     channel, arguments.Clone());
+    electron_browser_ptr_->MessageTo(
+        internal, send_to_all, web_contents_id, channel,
+        base::ListValue(arguments.Clone().GetList()));
   }
 
   void SendToHost(const std::string& channel,
                   const base::ListValue& arguments) {
-    electron_browser_ptr_->MessageHost(channel, arguments.Clone());
+    electron_browser_ptr_->MessageHost(
+        channel, base::ListValue(arguments.Clone().GetList()));
   }
 
   base::Value SendSync(bool internal,
@@ -99,23 +102,9 @@ class IPCRenderer : public mate::Wrappable<IPCRenderer> {
                        const base::ListValue& arguments) {
     base::Value result;
 
-    electron_browser_ptr_->MessageSync(internal, channel, arguments.Clone(),
-                                       &result);
-
-    // // A task is posted to a worker thread to execute the request so that
-    // // this thread may block on a waitable event. It is safe to pass raw
-    // // pointers to |result| and |response_received_event| as this stack frame
-    // // will survive until the request is complete.
-
-    // base::WaitableEvent response_received_event;
-    // task_runner_->PostTask(
-    //     FROM_HERE,
-    //     base::BindOnce(&IPCRenderer::SendMessageSyncOnWorkerThread,
-    //                               base::Unretained(this),
-    //                               base::Unretained(&response_received_event),
-    //                               base::Unretained(&result), internal,
-    //                               channel, arguments.Clone()));
-    // response_received_event.Wait();
+    electron_browser_ptr_->MessageSync(
+        internal, channel, base::ListValue(arguments.Clone().GetList()),
+        &result);
     return result;
   }
 

--- a/shell/renderer/api/atom_api_renderer_ipc.cc
+++ b/shell/renderer/api/atom_api_renderer_ipc.cc
@@ -62,18 +62,17 @@ class IPCRenderer : public mate::Wrappable<IPCRenderer> {
   void Send(bool internal,
             const std::string& channel,
             const base::ListValue& arguments) {
-    electron_browser_ptr_->Message(
-        internal, channel, base::ListValue(arguments.Clone().GetList()));
+    electron_browser_ptr_->Message(internal, channel, arguments);
   }
 
   v8::Local<v8::Promise> Invoke(mate::Arguments* args,
                                 const std::string& channel,
-                                const base::Value& arguments) {
+                                const base::ListValue& arguments) {
     electron::util::Promise p(args->isolate());
     auto handle = p.GetHandle();
 
     electron_browser_ptr_->Invoke(
-        channel, base::ListValue(arguments.Clone().GetList()),
+        channel, arguments,
         base::BindOnce([](electron::util::Promise p,
                           base::Value result) { p.Resolve(result); },
                        std::move(p)));
@@ -86,15 +85,13 @@ class IPCRenderer : public mate::Wrappable<IPCRenderer> {
               int32_t web_contents_id,
               const std::string& channel,
               const base::ListValue& arguments) {
-    electron_browser_ptr_->MessageTo(
-        internal, send_to_all, web_contents_id, channel,
-        base::ListValue(arguments.Clone().GetList()));
+    electron_browser_ptr_->MessageTo(internal, send_to_all, web_contents_id,
+                                     channel, arguments);
   }
 
   void SendToHost(const std::string& channel,
                   const base::ListValue& arguments) {
-    electron_browser_ptr_->MessageHost(
-        channel, base::ListValue(arguments.Clone().GetList()));
+    electron_browser_ptr_->MessageHost(channel, arguments);
   }
 
   base::Value SendSync(bool internal,
@@ -102,9 +99,7 @@ class IPCRenderer : public mate::Wrappable<IPCRenderer> {
                        const base::ListValue& arguments) {
     base::Value result;
 
-    electron_browser_ptr_->MessageSync(
-        internal, channel, base::ListValue(arguments.Clone().GetList()),
-        &result);
+    electron_browser_ptr_->MessageSync(internal, channel, arguments, &result);
     return result;
   }
 

--- a/shell/renderer/electron_api_service_impl.cc
+++ b/shell/renderer/electron_api_service_impl.cc
@@ -131,7 +131,7 @@ void ElectronApiServiceImpl::OnConnectionError() {
 void ElectronApiServiceImpl::Message(bool internal,
                                      bool send_to_all,
                                      const std::string& channel,
-                                     base::Value arguments,
+                                     const base::ListValue& arguments,
                                      int32_t sender_id) {
   // Don't handle browser messages before document element is created.
   //

--- a/shell/renderer/electron_api_service_impl.cc
+++ b/shell/renderer/electron_api_service_impl.cc
@@ -131,7 +131,7 @@ void ElectronApiServiceImpl::OnConnectionError() {
 void ElectronApiServiceImpl::Message(bool internal,
                                      bool send_to_all,
                                      const std::string& channel,
-                                     const base::ListValue& arguments,
+                                     base::ListValue arguments,
                                      int32_t sender_id) {
   // Don't handle browser messages before document element is created.
   //

--- a/shell/renderer/electron_api_service_impl.h
+++ b/shell/renderer/electron_api_service_impl.h
@@ -28,7 +28,7 @@ class ElectronApiServiceImpl : public mojom::ElectronRenderer,
   void Message(bool internal,
                bool send_to_all,
                const std::string& channel,
-               base::Value arguments,
+               const base::ListValue& arguments,
                int32_t sender_id) override;
   void UpdateCrashpadPipeName(const std::string& pipe_name) override;
   void TakeHeapSnapshot(mojo::ScopedHandle file,

--- a/shell/renderer/electron_api_service_impl.h
+++ b/shell/renderer/electron_api_service_impl.h
@@ -28,7 +28,7 @@ class ElectronApiServiceImpl : public mojom::ElectronRenderer,
   void Message(bool internal,
                bool send_to_all,
                const std::string& channel,
-               const base::ListValue& arguments,
+               base::ListValue arguments,
                int32_t sender_id) override;
   void UpdateCrashpadPipeName(const std::string& pipe_name) override;
   void TakeHeapSnapshot(mojo::ScopedHandle file,


### PR DESCRIPTION
#### Description of Change
This switches the serialization algorithm for base::ListValue values sent over IPC (through `ipcRenderer` / `ipcMain`) to use the legacy serialization algorithm, rather than the new Mojo algorithm. The messages themselves are still sent over Mojo.

Fixes #20334.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where sending complex objects over IPC could in some cases cause the renderer process to be terminated.
