### PR TITLE
docs: remove references to inaccessible team pages

### DIFF
--- a/docs/development/pull-requests.md
+++ b/docs/development/pull-requests.md
@@ -221,11 +221,12 @@ seem unfamiliar, refer to this
 
 #### Approval and Request Changes Workflow
 
-All pull requests require approval from a [Code Owner](https://github.com/orgs/electron/teams/code-owners) of the area you
-modified in order to land. Whenever a maintainer reviews a pull request they
-may request changes. These may be small, such as fixing a typo, or may involve
-substantive changes. Such requests are intended to be helpful, but at times
-may come across as abrupt or unhelpful, especially if they do not include
+All pull requests require approval from a 
+[Code Owner](https://github.com/electron/electron/blob/master/.github/CODEOWNERS)
+of the area you modified in order to land. Whenever a maintainer reviews a pull
+request they may request changes. These may be small, such as fixing a typo, or
+may involve substantive changes. Such requests are intended to be helpful, but 
+at times may come across as abrupt or unhelpful, especially if they do not include
 concrete suggestions on *how* to change them.
 
 Try not to be discouraged. If you feel that a review is unfair, say so or seek
@@ -254,7 +255,6 @@ platforms or for so-called "flaky" tests to fail ("be red"). Each CI
 failure must be manually inspected to determine the cause.
 
 CI starts automatically when you open a pull request, but only
-[Releasers](https://github.com/orgs/electron/teams/releasers/members)
-can restart a CI run. If you believe CI is giving a false negative,
-ask a Releaser to restart the tests.
+core maintainers can restart a CI run. If you believe CI is giving a
+false negative, ask a maintainer to restart the tests.
 

--- a/docs/development/pull-requests.md
+++ b/docs/development/pull-requests.md
@@ -225,7 +225,7 @@ All pull requests require approval from a
 [Code Owner](https://github.com/electron/electron/blob/master/.github/CODEOWNERS)
 of the area you modified in order to land. Whenever a maintainer reviews a pull
 request they may request changes. These may be small, such as fixing a typo, or
-may involve substantive changes. Such requests are intended to be helpful, but 
+may involve substantive changes. Such requests are intended to be helpful, but
 at times may come across as abrupt or unhelpful, especially if they do not include
 concrete suggestions on *how* to change them.
 

--- a/docs/development/pull-requests.md
+++ b/docs/development/pull-requests.md
@@ -221,7 +221,7 @@ seem unfamiliar, refer to this
 
 #### Approval and Request Changes Workflow
 
-All pull requests require approval from a 
+All pull requests require approval from a
 [Code Owner](https://github.com/electron/electron/blob/master/.github/CODEOWNERS)
 of the area you modified in order to land. Whenever a maintainer reviews a pull
 request they may request changes. These may be small, such as fixing a typo, or


### PR DESCRIPTION
#### Description of Change
Fixes https://github.com/electron/electronjs.org/issues/1312

This documentation pages refers to two GitHub Team pages that aren't accessible to the public:
* `@electron/codeowners`: replaced with a link to the `.github/CODEOWNERS` file.
* `@electron/releasers`: replaced with a mention of "core maintainers". The actual permissions seem to be a bit complicated, so this is hopefully a decent blanket term.

cc @electron/wg-ecosystem 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
