### PR TITLE
fix: use powerMonitor.on() only after app is ready

### DIFF
--- a/lib/browser/api/power-monitor.ts
+++ b/lib/browser/api/power-monitor.ts
@@ -13,12 +13,13 @@ const powerMonitor = createLazyInstance(createPowerMonitor, PowerMonitor, true)
 if (process.platform === 'linux') {
   /* In order to delay system shutdown when e.preventDefault() is invoked
    * on a powerMonitor 'shutdown' event, we need an org.freedesktop.login1
-   * delay lock. For more details see the "Taking Delay Locks" section of
-   * https://www.freedesktop.org/wiki/Software/systemd/inhibit/
+   * shutdown delay lock. For more details see the "Taking Delay Locks"
+   * section of https://www.freedesktop.org/wiki/Software/systemd/inhibit/
    *
    * So here we watch for 'shutdown' listeners to be added or removed and
    * set or unset our shutdown delay lock accordingly. */
-  const onceReady = (): void => {
+  const { app } = require('electron')
+  app.whenReady().then(() => {
     powerMonitor.on('newListener', (event: string) => {
       // whenever the listener count is incremented to one...
       if (event === 'shutdown' && powerMonitor.listenerCount('shutdown') === 0) {
@@ -31,14 +32,7 @@ if (process.platform === 'linux') {
         powerMonitor.unblockShutdown()
       }
     })
-  }
-
-  const { app } = require('electron')
-  if (app.isReady()) {
-    onceReady()
-  } else {
-    app.once('ready', onceReady)
-  }
+  })
 }
 
 module.exports = powerMonitor

--- a/lib/browser/api/power-monitor.ts
+++ b/lib/browser/api/power-monitor.ts
@@ -18,21 +18,27 @@ if (process.platform === 'linux') {
    *
    * So here we watch for 'shutdown' listeners to be added or removed and
    * set or unset our shutdown delay lock accordingly. */
-  const { app } = require('electron')
-  app.once('ready', (): void => {
+  const onceReady = (): void => {
     powerMonitor.on('newListener', (event: string) => {
-      // if first shutdown listener added
+      // whenever the listener count is incremented to one...
       if (event === 'shutdown' && powerMonitor.listenerCount('shutdown') === 0) {
         powerMonitor.blockShutdown()
       }
     })
     powerMonitor.on('removeListener', (event: string) => {
-      // if last shutdown listener removed
+      // whenever the listener count is decremented to zero...
       if (event === 'shutdown' && powerMonitor.listenerCount('shutdown') === 0) {
         powerMonitor.unblockShutdown()
       }
     })
-  })
+  }
+
+  const { app } = require('electron')
+  if (app.isReady()) {
+    onceReady()
+  } else {
+    app.once('ready', onceReady)
+  }
 }
 
 module.exports = powerMonitor

--- a/lib/browser/api/power-monitor.ts
+++ b/lib/browser/api/power-monitor.ts
@@ -10,18 +10,28 @@ Object.setPrototypeOf(PowerMonitor.prototype, EventEmitter.prototype)
 
 const powerMonitor = createLazyInstance(createPowerMonitor, PowerMonitor, true)
 
-// On Linux we need to call blockShutdown() to subscribe to shutdown event.
 if (process.platform === 'linux') {
-  powerMonitor.on('newListener', (event:string) => {
-    if (event === 'shutdown' && powerMonitor.listenerCount('shutdown') === 0) {
-      powerMonitor.blockShutdown()
-    }
-  })
-
-  powerMonitor.on('removeListener', (event: string) => {
-    if (event === 'shutdown' && powerMonitor.listenerCount('shutdown') === 0) {
-      powerMonitor.unblockShutdown()
-    }
+  /* In order to delay system shutdown when e.preventDefault() is invoked
+   * on a powerMonitor 'shutdown' event, we need an org.freedesktop.login1
+   * delay lock. For more details see the "Taking Delay Locks" section of
+   * https://www.freedesktop.org/wiki/Software/systemd/inhibit/
+   *
+   * So here we watch for 'shutdown' listeners to be added or removed and
+   * set or unset our shutdown delay lock accordingly. */
+  const { app } = require('electron')
+  app.once('ready', (): void => {
+    powerMonitor.on('newListener', (event: string) => {
+      // if first shutdown listener added
+      if (event === 'shutdown' && powerMonitor.listenerCount('shutdown') === 0) {
+        powerMonitor.blockShutdown()
+      }
+    })
+    powerMonitor.on('removeListener', (event: string) => {
+      // if last shutdown listener removed
+      if (event === 'shutdown' && powerMonitor.listenerCount('shutdown') === 0) {
+        powerMonitor.unblockShutdown()
+      }
+    })
   })
 }
 

--- a/lib/browser/api/power-monitor.ts
+++ b/lib/browser/api/power-monitor.ts
@@ -11,13 +11,13 @@ Object.setPrototypeOf(PowerMonitor.prototype, EventEmitter.prototype)
 const powerMonitor = createLazyInstance(createPowerMonitor, PowerMonitor, true)
 
 if (process.platform === 'linux') {
-  /* In order to delay system shutdown when e.preventDefault() is invoked
-   * on a powerMonitor 'shutdown' event, we need an org.freedesktop.login1
-   * shutdown delay lock. For more details see the "Taking Delay Locks"
-   * section of https://www.freedesktop.org/wiki/Software/systemd/inhibit/
-   *
-   * So here we watch for 'shutdown' listeners to be added or removed and
-   * set or unset our shutdown delay lock accordingly. */
+  // In order to delay system shutdown when e.preventDefault() is invoked
+  // on a powerMonitor 'shutdown' event, we need an org.freedesktop.login1
+  // shutdown delay lock. For more details see the "Taking Delay Locks"
+  // section of https://www.freedesktop.org/wiki/Software/systemd/inhibit/
+  //
+  // So here we watch for 'shutdown' listeners to be added or removed and
+  // set or unset our shutdown delay lock accordingly.
   const { app } = require('electron')
   app.whenReady().then(() => {
     powerMonitor.on('newListener', (event: string) => {


### PR DESCRIPTION
#### Description of Change

powerMonitor can't be used until the app is ready; however, on Linux, `powerMonitor.on()` was called as soon as lib/browser/api/power-monitor.ts was loaded.

This patch takes @vladimiry's [suggestion](https://github.com/electron/electron/issues/21716#issuecomment-572701025) of wrapping the calls in an app.on('ready') handler to prevent `powerMonitor.on()` from being called prematurely. It also adds an app.isReady() test in case powerMonitor is imported after the app is ready.

Note about the caveat described there about possible sequencing errors from the lazy loading &mdash; I don't _think_ this is an issue, because `powerMonitor.on()` can't be called by user code before the app is ready, and power-monitor.ts' on-ready-handler is registered as soon as power-monitor.ts is loaded. I'd welcome a second opinion on that though.

Fixes #21716.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed error thrown when importing powerMonitor on Linux before app's 'ready' event.