### PR TITLE
docs: fix node.lib download link

### DIFF
--- a/docs/tutorial/windows-arm.md
+++ b/docs/tutorial/windows-arm.md
@@ -71,7 +71,7 @@ If you want to develop your application directly on a Windows on Arm device, sub
 
 By default, `node-gyp` unpacks Electron's node headers and downloads the x86 and x64 versions of `node.lib` into `%APPDATA%\..\Local\node-gyp\Cache`, but it does not download the arm64 version ([a fix for this is in development](https://github.com/nodejs/node-gyp/pull/1875).) To fix this:
 
-1. Download the arm64 `node.lib` from https://atom.io/download/v6.0.9/win-arm64/node.lib
+1. Download the arm64 `node.lib` from https://electronjs.org/headers/v6.0.9/win-arm64/node.lib
 2. Move it to `%APPDATA%\..\Local\node-gyp\Cache\6.0.9\arm64\node.lib`
 
 Substitute `6.0.9` for the version you're using.


### PR DESCRIPTION
#### Description of Change

The documentation is currently pointing to a download link that leads to a 404 for the ARM64 version of `node.lib`. This change updates the link to the correct download for ARM64 `node.lib`.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: No notes.