### PR TITLE
docs: fix missing import, explicitly use nativeTheme api

### DIFF
--- a/docs/tutorial/mojave-dark-mode-guide.md
+++ b/docs/tutorial/mojave-dark-mode-guide.md
@@ -2,10 +2,10 @@
 
 In macOS 10.14 Mojave, Apple introduced a new [system-wide dark mode](https://developer.apple.com/design/human-interface-guidelines/macos/visual-design/dark-mode/)
 for all macOS computers.  If your app does have a dark mode, you can make your Electron app
-follow the system-wide dark mode setting.
+follow the system-wide dark mode setting using [the nativeTheme api](/docs/api/native-theme).
 
 In macOS 10.15 Catalina, Apple introduced a new "automatic" dark mode option for all macOS computers. In order
-for the `isDarkMode` and `Tray` APIs to work correctly in this mode on Catalina you need to either have `NSRequiresAquaSystemAppearance` set to `false` in your `Info.plist` file or be on Electron `>=7.0.0`.
+for the `nativeTheme.shouldUseDarkColors` and `Tray` APIs to work correctly in this mode on Catalina you need to either have `NSRequiresAquaSystemAppearance` set to `false` in your `Info.plist` file or be on Electron `>=7.0.0`.
 
 ## Automatically updating the native interfaces
 
@@ -21,7 +21,7 @@ If your app has its own dark mode you should toggle it on and off in sync with t
 this by listening for the theme changed event on Electron's `systemPreferences` module.  E.g.
 
 ```js
-const { nativeTheme } = require('electron')
+const { nativeTheme, systemPreferences } = require('electron')
 
 systemPreferences.subscribeNotification(
   'AppleInterfaceThemeChangedNotification',

--- a/docs/tutorial/mojave-dark-mode-guide.md
+++ b/docs/tutorial/mojave-dark-mode-guide.md
@@ -2,7 +2,7 @@
 
 In macOS 10.14 Mojave, Apple introduced a new [system-wide dark mode](https://developer.apple.com/design/human-interface-guidelines/macos/visual-design/dark-mode/)
 for all macOS computers.  If your app does have a dark mode, you can make your Electron app
-follow the system-wide dark mode setting using [the nativeTheme api](/docs/api/native-theme).
+follow the system-wide dark mode setting using [the nativeTheme api](../api/native-theme.md).
 
 In macOS 10.15 Catalina, Apple introduced a new "automatic" dark mode option for all macOS computers. In order
 for the `nativeTheme.shouldUseDarkColors` and `Tray` APIs to work correctly in this mode on Catalina you need to either have `NSRequiresAquaSystemAppearance` set to `false` in your `Info.plist` file or be on Electron `>=7.0.0`.

--- a/docs/tutorial/mojave-dark-mode-guide.md
+++ b/docs/tutorial/mojave-dark-mode-guide.md
@@ -18,15 +18,12 @@ out of this theming.
 ## Automatically updating your own interfaces
 
 If your app has its own dark mode you should toggle it on and off in sync with the system's dark mode setting.  You can do
-this by listening for the theme changed event on Electron's `systemPreferences` module.  E.g.
+this by listening for the theme updated event on Electron's `nativeTheme` module.  E.g.
 
 ```js
-const { nativeTheme, systemPreferences } = require('electron')
+const { nativeTheme } = require('electron')
 
-systemPreferences.subscribeNotification(
-  'AppleInterfaceThemeChangedNotification',
-  function theThemeHasChanged () {
-    updateMyAppTheme(nativeTheme.shouldUseDarkColors)
-  }
-)
+nativeTheme.on('updated', function theThemeHasChanged () {
+  updateMyAppTheme(nativeTheme.shouldUseDarkColors)
+})
 ```


### PR DESCRIPTION
#### Description of Change
Code example missed an import, and there were still references to `isDarkMode` rather than `shouldUseDarkColors`

#### Release Notes

Notes: no-notes
