### PR TITLE
docs: add links to the issue tracker, to developer/issues

### DIFF
--- a/docs/development/issues.md
+++ b/docs/development/issues.md
@@ -1,17 +1,10 @@
 # Issues In Electron
 
-* [Where to Find and Submit Issues](#where-to-find-and-submit-issues)
 * [How to Contribute to Issues](#how-to-contribute-to-issues)
 * [Asking for General Help](#asking-for-general-help)
 * [Submitting a Bug Report](#submitting-a-bug-report)
 * [Triaging a Bug Report](#triaging-a-bug-report)
 * [Resolving a Bug Report](#resolving-a-bug-report)
-
-## Where to Find and Submit Issues
-
-Issues for `electron/electron` are in the GitHub
-[issue tracker](https://github.com/electron/electronjs.org/issues/).
-
 
 ## How to Contribute to Issues
 
@@ -20,7 +13,7 @@ contribute:
 
 1. By opening the issue for discussion: If you believe that you have found
    a new bug in Electron, you should report it by creating a new issue in
-   the `electron/electron` issue tracker.
+   the [`electron/electron` issue tracker](https://github.com/electron/electron/issues).
 2. By helping to triage the issue: You can do this either by providing
    assistive details (a reproducible test case that demonstrates a bug) or by
    providing suggestions to address the issue.
@@ -38,9 +31,8 @@ contributing, and more. Please use the issue tracker for bugs only!
 ## Submitting a Bug Report
 
 To submit a bug report:
-[open an issue](https://github.com/electron/electronjs.org/issues/new).
 
-When opening a new issue in the `electron/electron` issue tracker, users
+When opening a new issue in the [`electron/electron` issue tracker](https://github.com/electron/electron/issues/new/choose), users
 will be presented with a template that should be filled in.
 
 ```markdown

--- a/docs/development/issues.md
+++ b/docs/development/issues.md
@@ -6,6 +6,12 @@
 * [Triaging a Bug Report](#triaging-a-bug-report)
 * [Resolving a Bug Report](#resolving-a-bug-report)
 
+## Where to Find and Submit Issues
+
+Issues for `electron/electron` are in the GitHub
+[issue tracker](https://github.com/electron/electronjs.org/issues/).
+
+
 ## How to Contribute to Issues
 
 For any issue, there are fundamentally three ways an individual can
@@ -29,6 +35,9 @@ list of resources for getting programming help, reporting security issues,
 contributing, and more. Please use the issue tracker for bugs only!
 
 ## Submitting a Bug Report
+
+To submit a bug report:
+[open an issue](https://github.com/electron/electronjs.org/issues/new).
 
 When opening a new issue in the `electron/electron` issue tracker, users
 will be presented with a template that should be filled in.

--- a/docs/development/issues.md
+++ b/docs/development/issues.md
@@ -1,5 +1,6 @@
 # Issues In Electron
 
+* [Where to Find and Submit Issues](#where-to-find-and-submit-issues)
 * [How to Contribute to Issues](#how-to-contribute-to-issues)
 * [Asking for General Help](#asking-for-general-help)
 * [Submitting a Bug Report](#submitting-a-bug-report)


### PR DESCRIPTION
#### Description of Change
This change adds links to the `electron/electron` issue tracker on the development/issues page, to make it easier to get to the issues.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

I don't know who the stakeholders are or how to cc them, sorry.

#### Release Notes

Notes: 'no-notes'
<!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
