### PR TITLE
test: check actual output generated from printToPDF

### DIFF
--- a/spec-main/api-deprecate-spec.ts
+++ b/spec-main/api-deprecate-spec.ts
@@ -2,9 +2,16 @@ import { expect } from 'chai'
 import { deprecate } from 'electron'
 
 describe('deprecate', () => {
+  let throwing: boolean
+
   beforeEach(() => {
+    throwing = process.throwDeprecation
     deprecate.setHandler(null)
     process.throwDeprecation = true
+  })
+
+  afterEach(() => {
+    process.throwDeprecation = throwing
   })
 
   it('allows a deprecation handler function to be specified', () => {

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -9,6 +9,7 @@ import { emittedOnce } from './events-helpers'
 import { closeAllWindows } from './window-helpers'
 import { ifdescribe, ifit } from './spec-helpers'
 
+const pdfjs = require('pdfjs-dist')
 const fixturesPath = path.resolve(__dirname, '..', 'spec', 'fixtures')
 const features = process.electronBinding('features')
 
@@ -1445,6 +1446,31 @@ describe('webContents module', () => {
     it('can print to PDF', async () => {
       const data = await w.webContents.printToPDF({})
       expect(data).to.be.an.instanceof(Buffer).that.is.not.empty()
+    })
+
+    it('respects custom settings', (done) => {
+      w.loadURL('https://github.com')
+      w.webContents.on('did-finish-load', async () => {
+        const data = await w.webContents.printToPDF({
+          pageRanges: {
+            from: 0,
+            to: 2
+          },
+          landscape: true
+        })
+
+        const doc = await pdfjs.getDocument(data)
+
+        // Check that correct # of pages are rendered.
+        expect(doc.numPages).to.equal(3)
+
+        // Check that PDF is generated in landscape mode.
+        const firstPage = await doc.getPage(1)
+        const { width, height } = firstPage.getViewport({ scale: 100 })
+        expect(width).to.be.greaterThan(height)
+
+        done()
+      })
     })
 
     it('does not crash when called multiple times', async () => {

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -1448,29 +1448,27 @@ describe('webContents module', () => {
       expect(data).to.be.an.instanceof(Buffer).that.is.not.empty()
     })
 
-    it('respects custom settings', (done) => {
-      w.loadURL('https://github.com')
-      w.webContents.on('did-finish-load', async () => {
-        const data = await w.webContents.printToPDF({
-          pageRanges: {
-            from: 0,
-            to: 2
-          },
-          landscape: true
-        })
+    it('respects custom settings', async () => {
+      w.loadFile(path.join(__dirname, 'fixtures', 'api', 'print-to-pdf.html'))
+      await emittedOnce(w.webContents, 'did-finish-load')
 
-        const doc = await pdfjs.getDocument(data)
-
-        // Check that correct # of pages are rendered.
-        expect(doc.numPages).to.equal(3)
-
-        // Check that PDF is generated in landscape mode.
-        const firstPage = await doc.getPage(1)
-        const { width, height } = firstPage.getViewport({ scale: 100 })
-        expect(width).to.be.greaterThan(height)
-
-        done()
+      const data = await w.webContents.printToPDF({
+        pageRanges: {
+          from: 0,
+          to: 2
+        },
+        landscape: true
       })
+
+      const doc = await pdfjs.getDocument(data).promise
+
+      // Check that correct # of pages are rendered.
+      expect(doc.numPages).to.equal(3)
+
+      // Check that PDF is generated in landscape mode.
+      const firstPage = await doc.getPage(1)
+      const { width, height } = firstPage.getViewport({ scale: 100 })
+      expect(width).to.be.greaterThan(height)
     })
 
     it('does not crash when called multiple times', async () => {

--- a/spec-main/fixtures/api/print-to-pdf.html
+++ b/spec-main/fixtures/api/print-to-pdf.html
@@ -1,0 +1,1297 @@
+
+
+
+
+
+
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  <link rel="dns-prefetch" href="https://github.githubassets.com">
+  <link rel="dns-prefetch" href="https://avatars0.githubusercontent.com">
+  <link rel="dns-prefetch" href="https://avatars1.githubusercontent.com">
+  <link rel="dns-prefetch" href="https://avatars2.githubusercontent.com">
+  <link rel="dns-prefetch" href="https://avatars3.githubusercontent.com">
+  <link rel="dns-prefetch" href="https://github-cloud.s3.amazonaws.com">
+  <link rel="dns-prefetch" href="https://user-images.githubusercontent.com/">
+
+
+
+  <link crossorigin="anonymous" media="all" integrity="sha512-ouI5UScWVQasLY7xrTyxOmvoOYEdJ7Mr2jttdNrXlazKaQP8ODIVxoAZQvTYh8kn0PmonJfuY6TOSepXEblj+w==" rel="stylesheet" href="https://github.githubassets.com/assets/frameworks-a2e2395127165506ac2d8ef1ad3cb13a.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-g21F4+kgHHkLt2gKOW8LVYqEHJvwst15TKxjcHjdqCWEUrjePR4nuT2xgO7GuRBwLFviAKvNrioPbD265kW2eg==" rel="stylesheet" href="https://github.githubassets.com/assets/site-836d45e3e9201c790bb7680a396f0b55.css" />
+    <link crossorigin="anonymous" media="all" integrity="sha512-fEnp6pumxSdCs1jaMloe1xeyLg4cLSVneWhWIF5g60oCZ1piCiiAqDJzi9XSVpkFn7QTGWt5JuRmx97jlhHxdA==" rel="stylesheet" href="https://github.githubassets.com/assets/github-7c49e9ea9ba6c52742b358da325a1ed7.css" />
+    
+    
+    
+    
+
+
+  <meta name="viewport" content="width=device-width">
+  
+  <title>The world’s leading software development platform · GitHub</title>
+    <meta name="description" content="GitHub brings together the world’s largest community of developers to discover, share, and build better software. From open source projects to private team repositories, we’re your all-in-one platform for collaborative development.">
+    <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
+  <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
+  <meta property="fb:app_id" content="1401488693436528">
+
+    <meta property="og:url" content="https://github.com">
+    <meta property="og:site_name" content="GitHub">
+    <meta property="og:title" content="Build software better, together">
+    <meta property="og:description" content="GitHub is where people build software. More than 40 million people use GitHub to discover, fork, and contribute to over 100 million projects.">
+    <meta property="og:image" content="https://github.githubassets.com/images/modules/open_graph/github-logo.png">
+    <meta property="og:image:type" content="image/png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="1200">
+    <meta property="og:image" content="https://github.githubassets.com/images/modules/open_graph/github-mark.png">
+    <meta property="og:image:type" content="image/png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="620">
+    <meta property="og:image" content="https://github.githubassets.com/images/modules/open_graph/github-octocat.png">
+    <meta property="og:image:type" content="image/png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="620">
+
+    <meta property="twitter:site" content="github">
+    <meta property="twitter:site:id" content="13334762">
+    <meta property="twitter:creator" content="github">
+    <meta property="twitter:creator:id" content="13334762">
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:title" content="GitHub">
+    <meta property="twitter:description" content="GitHub is where people build software. More than 40 million people use GitHub to discover, fork, and contribute to over 100 million projects.">
+    <meta property="twitter:image:src" content="https://github.githubassets.com/images/modules/open_graph/github-logo.png">
+    <meta property="twitter:image:width" content="1200">
+    <meta property="twitter:image:height" content="1200">
+
+  <link rel="assets" href="https://github.githubassets.com/">
+  
+  
+
+    <meta name="request-id" content="C5EA:1C59:619F6:7F59A:5E30EF0C" data-pjax-transient="true" /><meta name="html-safe-nonce" content="2b7a13f9de79ffdcddc5d764d632712b03205c63" data-pjax-transient="true" /><meta name="visitor-payload" content="eyJyZWZlcnJlciI6bnVsbCwicmVxdWVzdF9pZCI6IkM1RUE6MUM1OTo2MTlGNjo3RjU5QTo1RTMwRUYwQyIsInZpc2l0b3JfaWQiOjc5MzA0MDU0NjI5MjA0NTc5OTYsInJlZ2lvbl9lZGdlIjoic2VhIiwicmVnaW9uX3JlbmRlciI6ImlhZCJ9" data-pjax-transient="true" /><meta name="visitor-hmac" content="931801d1e1ee8c25f2fb2308799bc00ac0696eb15b751d04dcf8780169e5723d" data-pjax-transient="true" />
+
+
+    <meta name="page-subject" content="GitHub">
+
+  
+
+  <meta name="selected-link" value="/" data-pjax-transient>
+
+      <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
+    <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
+    <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
+
+  <meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="github" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-ga_id" content="" class="js-octo-ga-id" />
+
+
+
+
+
+
+<meta class="js-ga-set" name="dimension1" content="Logged Out">
+
+
+
+  
+
+      <meta name="hostname" content="github.com">
+    <meta name="user-login" content="">
+
+      <meta name="expected-hostname" content="github.com">
+
+
+    <meta name="enabled-features" content="MARKETPLACE_FEATURED_BLOG_POSTS,MARKETPLACE_INVOICED_BILLING,MARKETPLACE_SOCIAL_PROOF_CUSTOMERS,MARKETPLACE_TRENDING_SOCIAL_PROOF,MARKETPLACE_RECOMMENDATIONS,MARKETPLACE_PENDING_INSTALLATIONS">
+
+  <meta http-equiv="x-pjax-version" content="604e98d520202cb5c0935eebf1003af8">
+  
+
+      <link crossorigin="anonymous" media="all" integrity="sha512-g21F4+kgHHkLt2gKOW8LVYqEHJvwst15TKxjcHjdqCWEUrjePR4nuT2xgO7GuRBwLFviAKvNrioPbD265kW2eg==" rel="stylesheet" href="https://github.githubassets.com/assets/site-836d45e3e9201c790bb7680a396f0b55.css" />
+
+
+    <link rel="canonical" href="https://github.com/" data-pjax-transient>
+
+
+  <meta name="browser-stats-url" content="https://api.github.com/_private/browser/stats">
+
+  <meta name="browser-errors-url" content="https://api.github.com/_private/browser/errors">
+
+  <link rel="mask-icon" href="https://github.githubassets.com/pinned-octocat.svg" color="#000000">
+  <link rel="icon" type="image/x-icon" class="js-site-favicon" href="https://github.githubassets.com/favicon.ico">
+
+<meta name="theme-color" content="#1e2327">
+
+
+  <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
+
+  </head>
+
+  <body class="logged-out env-production emoji-size-boost page-responsive f4">
+    
+
+  <div class="position-relative js-header-wrapper ">
+    <a href="#start-of-content" tabindex="1" class="px-2 py-4 bg-blue text-white show-on-focus js-skip-to-content">Skip to content</a>
+    <span class="Progress progress-pjax-loader position-fixed width-full js-pjax-loader-bar">
+      <span class="progress-pjax-loader-bar top-0 left-0" style="width: 0%;"></span>
+    </span>
+
+    
+    
+    
+
+
+        <header class="Header-old header-logged-out js-details-container Details position-relative f4 py-2" role="banner">
+  <div class="container-xl d-lg-flex flex-items-center p-responsive">
+    <div class="d-flex flex-justify-between flex-items-center">
+        <a class="mr-4" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark">
+          <svg height="32" class="octicon octicon-mark-github text-white" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+        </a>
+
+          <div class="d-lg-none css-truncate css-truncate-target width-fit p-2">
+            
+
+          </div>
+
+        <div class="d-flex flex-items-center">
+            <a href="/join?source=header-home"
+              class="d-inline-block d-lg-none f5 text-white no-underline border border-gray-dark rounded-2 px-2 py-1 mr-3 mr-sm-5"
+              data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;client_id&quot;:null,&quot;originating_url&quot;:&quot;https://github.com/&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="a7a8d553330b1b4521bcec7052ec4d85e11e1fe8dc5cb4c15af3a3a70bc19e02"
+              data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up">
+              Sign&nbsp;up
+            </a>
+
+          <button class="btn-link d-lg-none mt-1 js-details-target" type="button" aria-label="Toggle navigation" aria-expanded="false">
+            <svg height="24" class="octicon octicon-three-bars text-white" viewBox="0 0 12 16" version="1.1" width="18" aria-hidden="true"><path fill-rule="evenodd" d="M11.41 9H.59C0 9 0 8.59 0 8c0-.59 0-1 .59-1H11.4c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zm0-4H.59C0 5 0 4.59 0 4c0-.59 0-1 .59-1H11.4c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM.59 11H11.4c.59 0 .59.41.59 1 0 .59 0 1-.59 1H.59C0 13 0 12.59 0 12c0-.59 0-1 .59-1z"/></svg>
+          </button>
+        </div>
+    </div>
+
+    <div class="HeaderMenu HeaderMenu--logged-out position-fixed top-0 right-0 bottom-0 height-fit position-lg-relative d-lg-flex flex-justify-between flex-items-center flex-auto">
+      <div class="d-flex d-lg-none flex-justify-end border-bottom bg-gray-light p-3">
+        <button class="btn-link js-details-target" type="button" aria-label="Toggle navigation" aria-expanded="false">
+          <svg height="24" class="octicon octicon-x text-gray" viewBox="0 0 12 16" version="1.1" width="18" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+        </button>
+      </div>
+
+        <nav class="mt-0 px-3 px-lg-0 mb-5 mb-lg-0" aria-label="Global">
+          <ul class="d-lg-flex list-style-none">
+              <li class="d-block d-lg-flex flex-lg-nowrap flex-lg-items-center border-bottom border-lg-bottom-0 mr-0 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap d-block d-lg-inline-block">
+                    Why GitHub?
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-absolute position-lg-relative">
+                      <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 mt-0 pb-4 p-lg-4 position-relative position-lg-absolute left-0 left-lg-n4">
+                    <a href="/features" class="py-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Features">Features <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a>
+                    <ul class="list-style-none f5 pb-3">
+                      <li class="edge-item-fix"><a href="/features/code-review/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Code review">Code review</a></li>
+                      <li class="edge-item-fix"><a href="/features/project-management/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Project management">Project management</a></li>
+                      <li class="edge-item-fix"><a href="/features/integrations" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Integrations">Integrations</a></li>
+                      <li class="edge-item-fix"><a href="/features/actions" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Actions">Actions</a></li>
+                          <li class="edge-item-fix"><a href="/features/packages" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to GitHub Packages">Packages</a></li>
+                      <li class="edge-item-fix"><a href="/features/security" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Security">Security</a></li>
+                      <li class="edge-item-fix"><a href="/features#team-management" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Team management">Team management</a></li>
+                      <li class="edge-item-fix"><a href="/features#hosting" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Code hosting">Hosting</a></li>
+                    </ul>
+
+                    <ul class="list-style-none mb-0 border-lg-top pt-lg-3">
+                      <li class="edge-item-fix"><a href="/customer-stories" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Customer stories">Customer stories <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="/security" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Security">Security <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+              <li class="border-bottom border-lg-bottom-0 mr-0 mr-lg-3">
+                <a href="/enterprise" class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-ga-click="(Logged out) Header, go to Enterprise">Enterprise</a>
+              </li>
+
+              <li class="d-block d-lg-flex flex-lg-nowrap flex-lg-items-center border-bottom border-lg-bottom-0 mr-0 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap d-block d-lg-inline-block">
+                    Explore
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-absolute position-lg-relative">
+                      <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
+
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-0 mt-0 pb-4 p-lg-4 position-relative position-lg-absolute left-0 left-lg-n4">
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/explore" class="py-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Explore">Explore GitHub <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+
+                    <h4 class="text-gray-light text-normal text-mono f5 mb-2 border-lg-top pt-lg-3">Learn &amp; contribute</h4>
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/topics" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Topics">Topics</a></li>
+                        <li class="edge-item-fix"><a href="/collections" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Collections">Collections</a></li>
+                      <li class="edge-item-fix"><a href="/trending" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Trending">Trending</a></li>
+                      <li class="edge-item-fix"><a href="https://lab.github.com/" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Learning lab">Learning Lab</a></li>
+                      <li class="edge-item-fix"><a href="https://opensource.guide" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Open source guides">Open source guides</a></li>
+                    </ul>
+
+                    <h4 class="text-gray-light text-normal text-mono f5 mb-2 border-lg-top pt-lg-3">Connect with others</h4>
+                    <ul class="list-style-none mb-0">
+                      <li class="edge-item-fix"><a href="https://github.com/events" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Events">Events</a></li>
+                      <li class="edge-item-fix"><a href="https://github.community" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Community forum">Community forum</a></li>
+                      <li class="edge-item-fix"><a href="https://education.github.com" class="py-2 pb-0 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to GitHub Education">GitHub Education</a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+
+              <li class="border-bottom border-lg-bottom-0 mr-0 mr-lg-3">
+                <a href="/marketplace" class="HeaderMenu-link no-underline py-3 d-block d-lg-inline-block" data-ga-click="(Logged out) Header, go to Marketplace">Marketplace</a>
+              </li>
+
+              <li class="d-block d-lg-flex flex-lg-nowrap flex-lg-items-center border-bottom border-lg-bottom-0 mr-0 mr-lg-3 edge-item-fix position-relative flex-wrap flex-justify-between d-flex flex-items-center ">
+                <details class="HeaderMenu-details details-overlay details-reset width-full">
+                  <summary class="HeaderMenu-summary HeaderMenu-link px-0 py-3 border-0 no-wrap d-block d-lg-inline-block">
+                    Pricing
+                    <svg x="0px" y="0px" viewBox="0 0 14 8" xml:space="preserve" fill="none" class="icon-chevon-down-mktg position-absolute position-lg-relative">
+                       <path d="M1,1l6.2,6L13,1"></path>
+                    </svg>
+                  </summary>
+
+                  <div class="dropdown-menu flex-auto rounded-1 bg-white px-0 pt-2 pb-4 mt-0 p-lg-4 position-relative position-lg-absolute left-0 left-lg-n4">
+                    <a href="/pricing" class="pb-2 lh-condensed-ultra d-block link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Pricing">Plans <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a>
+
+                    <ul class="list-style-none mb-3">
+                      <li class="edge-item-fix"><a href="/pricing#feature-comparison" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Compare plans">Compare plans</a></li>
+                      <li class="edge-item-fix"><a href="https://enterprise.github.com/contact" class="py-2 lh-condensed-ultra d-block link-gray no-underline f5" data-ga-click="(Logged out) Header, go to Contact Sales">Contact Sales</a></li>
+                    </ul>
+
+                    <ul class="list-style-none mb-0 border-lg-top pt-lg-3">
+                      <li class="edge-item-fix"><a href="/nonprofit" class="py-2 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover" data-ga-click="(Logged out) Header, go to Nonprofits">Nonprofit <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                      <li class="edge-item-fix"><a href="https://education.github.com" class="py-2 pb-0 lh-condensed-ultra d-block no-underline link-gray-dark no-underline h5 Bump-link--hover"  data-ga-click="(Logged out) Header, go to Education">Education <span class="Bump-link-symbol float-right text-normal text-gray-light">&rarr;</span></a></li>
+                    </ul>
+                  </div>
+                </details>
+              </li>
+          </ul>
+        </nav>
+
+      <div class="d-lg-flex flex-items-center px-3 px-lg-0 text-center text-lg-left">
+          <div class="d-lg-flex mb-3 mb-lg-0">
+            <div class="header-search flex-self-stretch flex-lg-self-auto mr-0 mr-lg-3 mb-3 mb-lg-0   js-site-search position-relative js-jump-to"
+  role="combobox"
+  aria-owns="jump-to-results"
+  aria-label="Search or jump to"
+  aria-haspopup="listbox"
+  aria-expanded="false"
+>
+  <div class="position-relative">
+    <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-site-search-form" role="search" aria-label="Site" data-unscoped-search-url="/search" action="/search" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+      <label class="form-control input-sm header-search-wrapper p-0 header-search-wrapper-jump-to position-relative d-flex flex-justify-between flex-items-center js-chromeless-input-container">
+        <input type="text"
+          class="form-control input-sm header-search-input jump-to-field js-jump-to-field js-site-search-focus "
+          data-hotkey="s,/"
+          name="q"
+          value=""
+          placeholder="Search GitHub"
+          data-unscoped-placeholder="Search GitHub"
+          data-scoped-placeholder="Search"
+          autocapitalize="off"
+          aria-autocomplete="list"
+          aria-controls="jump-to-results"
+          aria-label="Search GitHub"
+          data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations"
+          spellcheck="false"
+          autocomplete="off"
+          >
+            <input type="hidden" value="FiK1LkMtUrrEtOg71XIXVVs+cyWAONk8e7Rf5kH4i3hVBjpV6URlXFeH3AqnxPdyEVEVWP1JBFAurYMj2dzDTg==" data-csrf="true" class="js-data-jump-to-suggestions-path-csrf" />
+          <input type="hidden" class="js-site-search-type-field" name="type" >
+            <img src="https://github.githubassets.com/images/search-key-slash.svg" alt="" class="mr-2 header-search-key-slash">
+
+            <div class="Box position-absolute overflow-hidden d-none jump-to-suggestions js-jump-to-suggestions-container">
+              
+<ul class="d-none js-jump-to-suggestions-template-container">
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-suggestion" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 00-1 1v14a1 1 0 001 1h13a1 1 0 001-1V1a1 1 0 00-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0013 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 000-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in all of GitHub">
+        Search
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+</ul>
+
+<ul class="d-none js-jump-to-no-results-template-container">
+  <li class="d-flex flex-justify-center flex-items-center f5 d-none js-jump-to-suggestion p-2">
+    <span class="text-gray">No suggested jump to results</span>
+  </li>
+</ul>
+
+<ul id="jump-to-results" role="listbox" class="p-0 m-0 js-navigation-container jump-to-suggestions-results-container js-jump-to-suggestions-results-container">
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-scoped-search d-none" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 00-1 1v14a1 1 0 001 1h13a1 1 0 001-1V1a1 1 0 00-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0013 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 000-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in all of GitHub">
+        Search
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+  
+
+<li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item js-jump-to-global-search d-none" role="option">
+  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open p-2" href="">
+    <div class="jump-to-octicon js-jump-to-octicon flex-shrink-0 mr-2 text-center d-none">
+      <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-octicon-repo d-none" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-octicon-project d-none" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 00-1 1v14a1 1 0 001 1h13a1 1 0 001-1V1a1 1 0 00-1-1z"/></svg>
+      <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-octicon-search d-none" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0013 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 000-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+    </div>
+
+    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar d-none" alt="" aria-label="Team" src="" width="28" height="28">
+
+    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden text-left no-wrap css-truncate css-truncate-target">
+    </div>
+
+    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in all of GitHub">
+        Search
+      </span>
+      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+        All GitHub
+      </span>
+      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+
+    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+      Jump to
+      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+    </div>
+  </a>
+</li>
+
+
+</ul>
+
+            </div>
+      </label>
+</form>  </div>
+</div>
+
+          </div>
+
+        <a href="/login"
+          class="HeaderMenu-link no-underline mr-3"
+          data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header menu&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;client_id&quot;:null,&quot;originating_url&quot;:&quot;https://github.com/&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="cc4879cdc6e51ef707cecb65894fa525b5b31054ffb50c3c342a953b52879b02"
+          data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">
+          Sign&nbsp;in
+        </a>
+          <a href="/join?source=header-home"
+            class="HeaderMenu-link d-inline-block no-underline border border-gray-dark rounded-1 px-2 py-1"
+            data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header menu&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;client_id&quot;:null,&quot;originating_url&quot;:&quot;https://github.com/&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="cc4879cdc6e51ef707cecb65894fa525b5b31054ffb50c3c342a953b52879b02"
+            data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up">
+            Sign&nbsp;up
+          </a>
+      </div>
+    </div>
+  </div>
+</header>
+
+  </div>
+
+  <div id="start-of-content" class="show-on-focus"></div>
+
+
+    <div id="js-flash-container">
+
+</div>
+
+
+
+  <div class="application-main " data-commit-hovercards-enabled>
+        <main>
+
+<div class="py-6 py-sm-8 jumbotron-codelines">
+  <div class="container-lg p-responsive position-relative">
+    <div class="d-md-flex flex-items-center gutter-md-spacious">
+      <div class="col-md-7 text-center text-md-left ">
+          <h1 class="h000-mktg text-white lh-condensed-ultra mb-3">Built for developers</h1>
+          <p class="lead-mktg mb-4">
+            GitHub is a development platform inspired by the way you work. From <a href="/open-source" class="text-white jumbotron-link">open source</a> to <a href="/business" class="text-white jumbotron-link">business</a>, you can host and review code, manage projects, and build software alongside 40 million&nbsp;developers.
+          </p>
+      </div>
+        <div class="mx-auto col-sm-8 col-md-6 hide-sm">
+  <div class="rounded-1 text-gray bg-gray-light py-4 px-4 px-md-3 px-lg-4" >
+    <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="home-hero-signup text-gray-dark js-signup-form" autocomplete="off" action="/join" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="JEtx+lkRzcLUi/5A4AxD2y4YM4KKIcg9AK+o6V+tceNX+B0Vse03DRH+x9ba4N7R1++lE0jNNmkplAdHrQdmEQ==" />      <input type="hidden" name="ga_id" class="js-octo-ga-id-input">
+      <auto-check src="/signup_check/username?source=homepage&amp;suggest_usernames=true">
+        <dl class="form-group mt-0">
+          <dt class="input-label">
+            <label class="form-label h5" for="user[login]">Username</label>
+          </dt>
+          <dd>
+            <input type="text" name="user[login]" id="user[login]" class="form-control form-control-lg input-block">
+          </dd>
+        </dl>
+        <input type="hidden" value="NxTyAsW6Mtdbp6F2J7iFzXvqFo8yCUOkKrLpgZEK8IWTpwHyHDkSsjBgNAwbiolJcrwhGgcY4sQPmw9l9egb+Q==" data-csrf="true" />
+      </auto-check>
+      <auto-check src="/signup_check/email">
+        <dl class="form-group">
+          <dt class="input-label">
+            <label class="form-label h5" for="user[email]">Email</label>
+          </dt>
+          <dd>
+            <input type="text" name="user[email]" id="user[email]" class="form-control form-control-lg input-block js-email-notice-trigger">
+          </dd>
+        </dl>
+        <input type="hidden" value="JHitoeC9xzoq7+mnVZ44ePpWMuD02A10QvBasneQMjzb1eRj5dH7iljZHv9wPbukad2WJIBB9KTSX71pZQ4q5Q==" data-csrf="true" />
+      </auto-check>
+      <password-strength
+        minimum-character-count="8"
+        passphrase-length="15"
+        invalid-message="Password is invalid."
+        error-class="text-red text-bold"
+        pass-class="text-green"
+      >
+        <dl class="form-group">
+          <dt class="input-label">
+            <label class="form-label h5" for="user[password]">Password</label>
+          </dt>
+          <dd>
+            <input type="password" name="user[password]" id="user[password]" class="form-control form-control-lg input-block">
+            <p class="form-control-note text-gray-dark">Make sure it&#39;s <span data-more-than-n-chars="">at least 15 characters</span> OR <span data-min-chars="">at least 8 characters</span> <span data-number-requirement="">including a number</span> <span data-letter-requirement="">and a lowercase letter</span>. <a href="https://help.github.com/articles/creating-a-strong-password" class="tooltipped tooltipped-s" aria-label="Learn more about strong passwords">Learn more</a>.</p>
+          </dd>
+        </dl>
+      </password-strength>
+
+      <input type="hidden" name="source" class="js-signup-source" value="form-home">
+      <input type="text" name="required_field_c400" hidden="hidden" class="form-control" />
+<input type="hidden" name="timestamp" value="1580265228888" class="form-control" />
+<input type="hidden" name="timestamp_secret" value="d479d70f61f210862ce5ee2f4a8d4413c3e83cf68cd312c53c5c17659dbb0779" class="form-control" />
+
+      <button class="btn-mktg btn-primary-mktg btn-large-mktg f4 btn-block my-3" type="submit" data-ga-click="Signup, Attempt, location:home hero">Sign up for GitHub</button>
+      <p class="form-control-note mb-0 mt-3">
+        By clicking &ldquo;Sign up for GitHub&rdquo;, you agree to our
+        <a class="" href="https://help.github.com/terms" target="_blank">Terms of Service</a> and
+        <a class="" href="https://help.github.com/privacy" target="_blank">Privacy Statement</a>. <span class="js-email-notice">We’ll occasionally send you account related emails.</span>
+      </p>
+</form>  </div>
+</div>
+<div class="d-sm-none text-center">
+  <a rel="nofollow" class="btn-mktg btn-primary-mktg btn-large-mktg" data-ga-click="Signup, Attempt, location:home hero mobile" href="/join?source=button-home">Sign up for GitHub</a>
+</div>
+
+    </div>
+  </div>
+</div>
+
+
+<!-- Enterprise CTA options including Cloud Trial -->
+<div class="p-responsive pt-7 pt-md-12 pb-6 pb-md-9 home-enterprise-wrapper">
+  <div class="container-xl px-lg-4">
+    <div class="d-lg-flex mx-auto p-4 p-md-7 bg-white rounded-2 box-shadow-large home-enterprise">
+      <div class="d-none d-md-block position-absolute right-0 top-0 z-3" style="width: 450px; transform: translateY(-85%);">
+        <svg xmlns="http://www.w3.org/2000/svg" version="1.1" id="Layer_1" x="0" y="0" viewBox="0 0 890.5 375.3" xml:space="preserve"><style>.st0{fill:#d1d5da}.st2{fill:#959da4}.st3{fill:#586069}.st4{fill:#6a737d}.st5{fill:#dca82d}.st6{fill:#b18621}.st7{fill:#ffdd6a}.st8{fill:#ffe888}.st9{fill:#c6e2fd}.st10{fill:#fac237}.st12{fill:#ffd050}.st16{fill:#77bafc}.st17{fill:#036ad2}.st18{fill:#178cfa}.st19{fill:#daeefe}.st27{fill:#92989d}.st28{fill:#b9bdc1}.st30{fill:#686868}.st31{fill:#fafbfc}.st32{fill:#e1e4e8}.st40{fill:none;stroke:#036ad2;stroke-width:2;stroke-miterlimit:10}</style><path class="st0" d="M318.9 315.3l-34 33 3 4.7 2.9.3 32.1-35.3-4-2.7z"></path><path d="M308.9 362.3l-7.3-1.3-1.5-3.7 44.3-40-.8 7.3-34.7 37.7z" fill="#3d3d3d"></path><path class="st2" d="M322.3 315.1l-34 33.2 2.5 5 34.8-35-3.3-3.2z"></path><path class="st3" d="M300 357.3l8 1 27.2-26.5-6-2.5-29.2 28z"></path><path class="st4" d="M331.6 310.7L302 337.5l11.2 9.5 33.1-33.1c-4.3-3.2-12.1-5.2-14.7-3.2z"></path><path class="st3" d="M346.5 313.9L313.3 347l4.7 4c13-9 20.5-23.2 29.9-36-.4-.4-.8-.7-1.3-1l-.1-.1z"></path><path class="st4" d="M347.9 315c-9.3 12.7-16.9 27-29.9 36l6.5 5.5 26.8-30.3.2-.3c2-2.7.4-7.3-3.6-10.9z"></path><path class="st2" d="M302.1 337.5c3.4-2.7 10.2-1.7 16.1 2.7 6.5 4.9 9.5 12 6.6 15.9l-.3.4c-3.1 3.5-10.5 2.7-16.8-2-6.5-4.9-9.5-12-6.6-15.9.2-.4.6-.8 1-1.1z"></path><path class="st5" d="M366.6 304.4L337 321.6l3.2 20.2 27.8 13 .6-.7c-3.6-15.6-5.8-34.1-2-49.7z"></path><path class="st6" d="M413.3 277.3l-46.7 27.1c-3.8 15.6-1.6 34 2 49.7l45.6-56.5-.9-20.3z"></path><path d="M317.4 342.2c-4.4-3.3-9.5-4-12.1-2-.3.2-.5.5-.8.8-1.5 2-.9 5.2 1.2 8.2 5.1-.3 9.9-1.9 14.2-4.7-.8-.9-1.6-1.7-2.5-2.3z"></path><path class="st4" d="M319.9 344.4c-4.3 2.7-9.1 4.3-14.2 4.7 1 1.4 2.3 2.7 3.8 3.8 4.7 3.5 10.3 4.1 12.6 1.5l.2-.3c1.7-2.4.6-6.3-2.4-9.7z"></path><path class="st7" d="M355.3 274.1c-1.5-.5-3-1.1-4.4-1.6l-11.9 8.7 7.1 2.7c2.9-3.4 6-6.7 9.2-9.8z"></path><path class="st8" d="M384.8 298l8.5-9.3c-4.4-1.5-8.7-3.2-13-4.9-3.5 3-7.1 5.9-10.6 8.9 5 1.7 10 3.5 15.1 5.3z"></path><path class="st7" d="M346.1 283.9c7.8 3 15.7 5.9 23.6 8.8 3.5-3 7.1-5.9 10.6-8.9-8.3-3.2-16.6-6.6-24.9-9.7-3.3 3.1-6.4 6.4-9.3 9.8zm4.8-11.4c-2.6-.9-5.2-1.8-7.9-2.6l-11.3 8.6 7.2 2.7 12-8.7z"></path><path class="st8" d="M375.8 253.8l-.8-.2-8.2-1.8-23.8 18c2.6.8 5.3 1.7 7.9 2.6 8.4-6 16.7-12.2 24.9-18.6z"></path><path class="st7" d="M377.4 254.1l-1.6-.4c-8.2 6.4-16.5 12.6-24.9 18.7 1.5.5 3 1.1 4.4 1.6 7.1-6.9 14.6-13.4 22.1-19.9z"></path><path class="st9" d="M393.3 288.7l22.7-24.9c-1.6-.6-4.7-1.4-8.5-2.4-9.2 7.4-18.3 14.9-27.3 22.4 4.4 1.7 8.7 3.3 13.1 4.9z"></path><path class="st8" d="M355.3 274.1c8.4 3.1 16.6 6.5 24.9 9.7 9-7.5 18.1-14.9 27.3-22.4-9.9-2.6-24.4-6-30.1-7.3-7.5 6.5-15 13-22.1 20z"></path><path class="st7" d="M377 306.5l7.8-8.5c-5.1-1.7-10.1-3.5-15.2-5.4l-8 6.7c5.2 2.3 10.3 4.7 15.4 7.2zm-37-15.2c7.4 2.2 14.6 4.8 21.6 8l8-6.7c-7.9-2.9-15.7-5.8-23.6-8.8-2 2.5-4.1 5-6 7.5z"></path><path class="st9" d="M368.3 316.1l8.8-9.6c-5.1-2.4-10.2-4.9-15.4-7.1l-10 8.4c5.5 2.8 11 5.6 16.6 8.3z"></path><path class="st7" d="M346.1 283.9l-7.1-2.7c-5.2 3.9-10.5 7.7-15.7 11.7 9.5 4.9 18.9 10 28.4 14.9l10-8.4c-7-3.2-14.2-5.8-21.6-8 1.8-2.6 3.9-5.1 6-7.5z"></path><path class="st9" d="M331.7 278.4L317 289.6c2.1 1.1 4.2 2.2 6.3 3.2 5.2-4 10.4-7.8 15.7-11.7l-7.3-2.7z"></path><path class="st7" d="M308.8 295.9c-.9.5-3.2 2.4-3.2 2.4l7.4 2.6c3.4-2.7 6.8-5.4 10.3-8-2.1-1.1-4.2-2.2-6.3-3.2l-8.2 6.2zm56.7 23.2l2.8-3c-5.6-2.7-11.1-5.5-16.6-8.3l-5.5 4.6 19.3 6.7z"></path><path class="st8" d="M313 300.8l33.2 11.5 5.5-4.6c-9.5-4.9-18.9-10-28.4-14.9-3.5 2.7-6.9 5.3-10.3 8z"></path><path class="st10" d="M305.6 298.2c0 2.7.6 13.7.9 16.8 6.6 2.8 53.9 19.5 60.8 22-.8-6-1.5-12-1.9-18l-59.8-20.8z"></path><path class="st8" d="M416.5 281.6c0-5.6.3-11-.5-17.8L365.5 319h-.1c.4 6 1 12 1.9 18l.2.1c5.5-5.4 46.3-51.5 49-55.5z"></path><path d="M370 294.6l-.3-14.9-30.6-.3-4.3 14.8c0 .2-.1.3-.1.5 0 2.9 7.9 5.3 17.6 5.3s17.7-2.5 17.7-5.4z" opacity=".3" fill="#e55b22"></path><path class="st12" d="M369.7 279.6c0 2.2-6.9 4-15.3 4s-15.3-1.8-15.3-4v-.3c.6-2.1 7.2-3.7 15.3-3.7 8.4.1 15.2 1.9 15.3 4z"></path><path class="st5" d="M377.5 270.3l.1-6.7 12.1-.1 1.7 6.6v.2c0 1.3-3.1 2.4-7 2.4s-6.9-1.1-6.9-2.4z"></path><path class="st12" d="M377.6 263.6c0 1 2.7 1.8 6.1 1.8s6.1-.8 6.1-1.8v-.1c-.2-.9-2.9-1.7-6.1-1.7-3.3 0-6 .8-6.1 1.8z"></path><path d="M438.9 292l-28.5 11.4.4 8.2 35.5 44.2.8-.4c.9-21.1-1.2-42.3-8.2-63.4z" fill="#014486"></path><path d="M553 290.3l-40-28-74.1 29.7c7.1 21.1 9.1 42.3 8.2 63.4L549.3 302l3.7-11.7z" fill="#0260c1"></path><path d="M556.5 308.3l-11-6.2-90.5 45-2 4.8 8.5 14.8 61.8-34.1-3.3-5.8 3.6-1.8 2.9 5.8 25.5-14.1 4.5-8.4z" fill="#71603b"></path><path class="st16" d="M410.4 303.4c.3.4 1.6 1.9 3.5 4.1 2.2-1.1 4.4-2.2 6.6-3.4-1.4-1.3-2.8-2.7-4.2-4-2.3 1.2-4.3 2.3-5.9 3.3z"></path><path class="st16" d="M416.1 300.1c1.4 1.3 2.8 2.7 4.2 4l4.2-2.1c-1.4-1.4-2.9-2.8-4.3-4.1-1.4.8-2.8 1.6-4.1 2.2z"></path><path class="st16" d="M420.2 298c1.5 1.4 2.9 2.7 4.3 4.1 4.4-2.2 8.9-4.4 13.4-6.5-1.7-1.3-3.4-2.5-5.1-3.7-4.5 2.1-8.8 4.2-12.6 6.1zM432.9 291.9c1.7 1.2 3.4 2.5 5.1 3.7l5.7-2.7-4.4-4c-2.2 1.1-4.3 2.1-6.4 3z"></path><path class="st16" d="M439.3 289c1.5 1.3 2.9 2.7 4.4 4 5.7-2.7 11.5-5.3 17.3-7.8-1.2-1.4-2.3-2.7-3.4-4.1-6.3 2.6-12.4 5.3-18.3 7.9zm18.2-7.9c1.1 1.4 2.3 2.7 3.4 4.1l2.1-.9c-1.2-1.3-2.3-2.7-3.5-4l-2 .8zM459.5 280.2c1.2 1.4 2.3 2.7 3.5 4 6-2.7 12.1-5.3 18.2-7.8-1.1-1.3-2.2-2.6-3.2-3.9-5.9 2.5-12.2 5.1-18.5 7.7z"></path><path class="st16" d="M480.2 271.6l-2.2.9c1.1 1.3 2.1 2.6 3.2 3.9l2.6-1.1c-1.1-1.2-2.3-2.4-3.6-3.7z"></path><path class="st16" d="M480.2 271.6c1.2 1.2 2.4 2.5 3.6 3.7 5-2.1 10.1-4.2 15.1-6.3l-4.1-3.4c-4.4 1.9-9.3 3.9-14.6 6z"></path><path class="st16" d="M494.9 265.7l4.1 3.4 2.9-1.1-4.1-3.4-2.9 1.1z"></path><path class="st16" d="M515.3 257.6c-.8.4-7.6 3-17.5 7l4.1 3.4c5.7-2.4 11.5-4.7 17.2-7l-3.8-3.4zm-101.5 49.9l4.7 5.5 7.1-3.7c-1.7-1.7-3.4-3.4-5.2-5.1l-6.6 3.3z"></path><path class="st16" d="M420.4 304.2c1.8 1.7 3.5 3.4 5.2 5.1l4.1-2.1c-1.6-1.7-3.3-3.4-5-5.1-1.5.7-2.9 1.4-4.3 2.1z"></path><path class="st17" d="M424.6 302.1c1.7 1.7 3.4 3.4 5 5.1 4.7-2.4 9.3-4.8 13.9-7.2-1.8-1.5-3.7-2.9-5.6-4.3-4.4 2.1-8.9 4.2-13.3 6.4z"></path><path class="st16" d="M438 295.6c1.9 1.4 3.7 2.9 5.6 4.3l4.9-2.5-4.8-4.5c-1.9 1-3.8 1.8-5.7 2.7z"></path><path class="st16" d="M443.7 293l4.8 4.5c5.3-2.7 10.7-5.4 16.1-8.1l-3.6-4.2c-5.8 2.5-11.6 5.1-17.3 7.8zm17.3-7.8l3.6 4.2 2.2-1c-1.2-1.4-2.5-2.7-3.7-4.1-.7.3-1.5.6-2.1.9z"></path><path class="st18" d="M463 284.3c1.2 1.4 2.5 2.7 3.7 4.1 5.8-2.8 11.7-5.6 17.5-8.2l-3-3.7c-6 2.5-12.1 5.1-18.2 7.8z"></path><path class="st16" d="M483.9 275.4l3.3 3.4c5.1-2.3 10.3-4.5 15.5-6.7l-3.7-3c-5.1 2.1-10.1 4.2-15.1 6.3z"></path><path class="st17" d="M519.1 260.9c-5.8 2.3-11.5 4.6-17.2 7l3.7 3c5.7-2.3 11.5-4.6 17.3-6.7l-3.8-3.3z"></path><path class="st16" d="M499 269.1l3.7 3 2.8-1.1-3.7-3-2.8 1.1zm-15.1 6.3l-2.6 1.1 3 3.7 2.9-1.3-3.3-3.5zM418.5 313c2 2.4 4.3 5 6.7 7.8l8-3.7c-2.5-2.7-5-5.3-7.6-7.9l-7.1 3.8z"></path><path class="st16" d="M425.5 309.3c2.6 2.6 5.1 5.2 7.6 7.9l4-1.8c-2.5-2.8-5-5.5-7.6-8.1l-4 2zm18.1-9.3c3.3 2.6 6.5 5.3 9.6 8.1l4.1-1.9c-2.9-2.9-5.9-5.8-8.8-8.7l-4.9 2.5z"></path><path class="st17" d="M448.5 297.5c3 2.9 5.9 5.8 8.8 8.7l15.5-7.1c-2.7-3.2-5.5-6.4-8.2-9.6-5.4 2.6-10.8 5.2-16.1 8z"></path><path class="st5" d="M464.6 289.4c2.7 3.2 5.5 6.4 8.2 9.6l2.8-1.3c-3-3.1-5.9-6.2-8.8-9.4l-2.2 1.1z"></path><path class="st16" d="M466.8 288.4c2.9 3.2 5.9 6.3 8.8 9.4l16.9-7.8c-2.7-3.3-5.5-6.6-8.3-9.9-5.8 2.7-11.7 5.4-17.4 8.3z"></path><path class="st19" d="M484.3 280.1c2.8 3.3 5.5 6.6 8.3 9.9l3.6-1.6c-2.9-3.2-5.9-6.4-9-9.6l-2.9 1.3z"></path><path class="st17" d="M487.2 278.8l9 9.6 17-7.8c-3.5-2.9-6.9-5.7-10.4-8.5-5.3 2.2-10.5 4.4-15.6 6.7z"></path><path class="st16" d="M502.7 272.1c3.5 2.8 7 5.7 10.4 8.5l2.6-1.2c-3.4-2.9-6.8-5.7-10.2-8.5l-2.8 1.2z"></path><path class="st18" d="M522.8 264.2c-5.8 2.1-11.6 4.4-17.3 6.7 3.4 2.8 6.8 5.6 10.2 8.5l16-7.3-8.9-7.9z"></path><path class="st16" d="M429.6 307.2c2.6 2.7 5.1 5.4 7.6 8.1l16-7.3-9.6-8.1c-4.7 2.5-9.3 4.9-14 7.3z"></path><path class="st17" d="M425.1 320.8c2.9 3.4 5.9 6.9 8.7 10.2l8-4.6-8.7-9.3-8 3.7z"></path><path class="st16" d="M433.2 317.2l8.7 9.3 3.4-1.9c-2.6-3.1-5.3-6.2-8-9.2l-4.1 1.8z"></path><path class="st18" d="M437.2 315.3c2.7 3 5.4 6.1 8 9.2 5.4-3.1 10.8-6.2 16.1-9.3l-8.1-7.2-16 7.3z"></path><path class="st16" d="M453.2 308l8.1 7.2 3.1-1.8c-2.4-2.4-4.8-4.9-7.2-7.3l-4 1.9z"></path><path class="st5" d="M472.8 299.1c1.8 2.2 3.6 4.3 5.5 6.5l3.2-1.8c-2-2-4-4-5.9-6l-2.8 1.3z"></path><path class="st18" d="M475.6 297.8c2 2 3.9 4 5.9 6 5.1-2.9 10.2-5.7 15.4-8.5-1.4-1.8-2.9-3.5-4.4-5.3l-16.9 7.8z"></path><path d="M492.5 290c1.5 1.8 2.9 3.5 4.4 5.3 1.2-.7 2.5-1.3 3.8-2-1.5-1.6-3-3.3-4.5-4.9l-3.7 1.6z" opacity=".3" fill="#f6f8fa"></path><path class="st18" d="M496.1 288.4c1.5 1.6 3 3.3 4.5 4.9 5.7-3 11.4-5.9 17.1-8.8-1.5-1.3-3.1-2.6-4.6-3.9l-17 7.8z"></path><path class="st16" d="M513.1 280.6c1.6 1.3 3.1 2.6 4.6 3.9.8-.4 1.7-.8 2.5-1.2l-4.5-3.9-2.6 1.2zM531.8 272.1l-16 7.3 4.5 3.9c5.2-2.5 10.5-5 15.8-7.4l-4.3-3.8z"></path><path class="st19" d="M457.3 306.2c2.4 2.4 4.8 4.8 7.2 7.3 4.6-2.7 9.2-5.3 13.8-7.9-1.8-2.2-3.6-4.4-5.5-6.5l-15.5 7.1z"></path><path class="st5" d="M441.9 326.5l3.5 3.8 3.3-1.6c-1.2-1.4-2.3-2.8-3.5-4.1l-3.3 1.9z"></path><path class="st16" d="M445.2 324.5c1.2 1.4 2.3 2.7 3.5 4.1 6-2.9 12-5.8 18.1-8.5-1.8-1.7-3.6-3.3-5.4-4.9l-16.2 9.3zm19.3-11.1l5.3 5.4c4.7-2.1 9.4-4.2 14.1-6.2-1.8-2.4-3.7-4.7-5.6-7l-13.8 7.8z"></path><path class="st5" d="M478.3 305.6c1.9 2.3 3.8 4.7 5.6 7l4.6-2-6.9-6.9-3.3 1.9z"></path><path class="st16" d="M481.5 303.8l6.9 6.9c5.1-2.2 10.3-4.4 15.4-6.6-2.3-3-4.6-5.9-6.9-8.8-5.2 2.8-10.3 5.6-15.4 8.5z"></path><path class="st19" d="M496.9 295.3c2.3 2.9 4.7 5.8 6.9 8.8l4.7-2c-2.6-2.9-5.2-5.8-7.9-8.7-1.2.6-2.5 1.3-3.7 1.9z"></path><path class="st16" d="M500.6 293.3c2.6 2.9 5.3 5.8 7.9 8.7l19.5-8.4c-3.3-3.1-6.8-6.1-10.3-9.1-5.7 2.9-11.4 5.8-17.1 8.8z"></path><path class="st16" d="M517.8 284.5c3.5 3 6.9 6 10.3 9.1l2.5-1.1c-3.4-3.2-6.8-6.2-10.3-9.2-.8.4-1.7.8-2.5 1.2z"></path><path class="st5" d="M540.9 280.1l-4.8-4.2c-5.3 2.4-10.6 4.8-15.8 7.4 3.5 3 6.9 6.1 10.3 9.2 5.5-2.4 10.9-4.8 16.3-7.3l-6-5.1z"></path><path class="st16" d="M461.3 315.2c1.8 1.6 3.6 3.3 5.4 4.9l3-1.3-5.3-5.4-3.1 1.8zM433.9 331l3 3.5c2.8-1.5 5.6-2.9 8.5-4.3l-3.5-3.8-8 4.6z"></path><path class="st17" d="M436.9 334.6c5 5.8 9.1 10.5 10.8 12.4l8.6-4.6c-3.6-4-7.3-8-11-12.1-2.8 1.4-5.6 2.8-8.4 4.3z"></path><path class="st19" d="M445.4 330.3c3.7 4 7.3 8 11 12.1l2.5-1.4-10.2-12.3-3.3 1.6z"></path><path class="st18" d="M448.7 328.7l10.2 12.3 19.5-10.4c-3.9-3.4-7.7-6.9-11.5-10.4-6.2 2.7-12.2 5.5-18.2 8.5z"></path><path class="st16" d="M469.8 318.8l-3 1.3c3.8 3.5 7.7 7 11.5 10.4l2.1-1.1c-3.5-3.5-7.1-7-10.6-10.6z"></path><path class="st17" d="M469.8 318.8c3.5 3.6 7.1 7.1 10.6 10.6l11.2-6c-2.5-3.7-5.1-7.3-7.8-10.8-4.6 2.1-9.3 4.1-14 6.2z"></path><path class="st16" d="M483.9 312.6c2.7 3.5 5.3 7.1 7.8 10.8l6.4-3.5c-3.2-3.1-6.5-6.2-9.7-9.3l-4.5 2z"></path><path class="st16" d="M488.4 310.7c3.2 3.1 6.4 6.2 9.7 9.3l12.5-6.7c-2.2-3.1-4.5-6.1-6.8-9.1-5.1 2.1-10.2 4.3-15.4 6.5zm42.2-18.2l-2.5 1.1c2.3 2.1 4.6 4.3 6.8 6.5l2.3-1.3c-2.2-2-4.4-4.2-6.6-6.3z"></path><path class="st16" d="M546.9 285.2c-5.4 2.5-10.9 4.9-16.3 7.3 2.2 2.1 4.4 4.2 6.6 6.4l15.8-8.6-6.1-5.1z"></path><path class="st17" d="M508.5 302.1c2.5 2.8 4.9 5.5 7.4 8.3l12.7-6.8 6.2-3.4c-2.2-2.2-4.4-4.4-6.8-6.5-6.4 2.8-12.9 5.6-19.5 8.4z"></path><path class="st16" d="M503.8 304.1c2.3 3 4.6 6 6.8 9.1l5.3-2.9c-2.5-2.8-5-5.6-7.4-8.3l-4.7 2.1z"></path><path class="st10" d="M455 347.1l7.8 11.8 5.4-2.8c-2.7-3.8-5.3-7.7-7.8-11.8l-5.4 2.8zm11.4-6c2.2 4.1 4.3 8.3 6.7 12.5l11.3-5.7c-2.5-4.1-4.7-8.3-7.1-12.4l-10.9 5.6z"></path><path class="st6" d="M509.6 318.5l-1.9 1c2.4 4.3 4.6 8.7 6.8 13l2.1-1.1c-2.5-4.2-5-8.5-7-12.9z"></path><path class="st10" d="M523.9 311l-14.3 7.5c2 4.4 4.5 8.6 7 13l4.7-2.4-3.8-3.5 5.2-3.5 4 4 5.8-3.5c-2.8-3.8-5.7-7.7-8.6-11.6z"></path><path class="st6" d="M525.4 310.2l-1.5.8c2.8 3.9 5.7 7.8 8.7 11.6l2.1-1.2c-2.8-4-5.9-7.7-9.3-11.2z"></path><path class="st10" d="M537 304.2l-11.6 6.1c3.4 3.4 6.6 7.1 9.3 11.1l11.2-6.7c-2.8-3.6-5.8-7.2-8.9-10.5z"></path><path class="st6" d="M538.5 303.4l-1.5.8c3.2 3.4 6.1 6.9 9 10.5l3-1.8c-3.4-3.3-6.9-6.5-10.5-9.5z"></path><path class="st10" d="M545.8 299.6l-7.3 3.8c3.6 3 7.1 6.2 10.5 9.4l7.5-4.5-10.7-8.7z"></path><path class="st6" d="M494.8 326.3l-2.8 1.5c2.9 3.9 5.8 7.9 8.7 11.8l2.3-1.2c-2.9-3.9-5.7-7.9-8.2-12.1z"></path><path class="st10" d="M507.7 319.5l-13 6.8c2.5 4.2 5.3 8.2 8.2 12.1l11.5-5.9c-2.1-4.3-4.3-8.7-6.7-13zm-15.7 8.2l-12.8 6.7c2.2 4.2 4.5 8.4 7 12.5l14.5-7.4c-3-3.9-5.9-7.9-8.7-11.8z"></path><path class="st6" d="M477.3 335.4c2.4 4.1 4.6 8.3 7.1 12.4l1.9-1c-2.5-4.1-4.9-8.3-7-12.5l-2 1.1zm-13.4 7c2.4 4 4.9 8.1 7.3 12.1l1.8-.9c-2.4-4.1-4.5-8.4-6.7-12.5l-2.4 1.3zM463.9 342.4l-3.6 1.9c2.5 4 5.1 8 7.8 11.8l3-1.5c-2.3-4.1-4.8-8.1-7.2-12.2z"></path><path d="M404.8 343.3l24.2-12.8" fill="none" stroke="#fac237" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10"></path><path d="M427.1 335.4l-.8.5c-1.4.8-1.9 2.6-1.1 4.1.5.9 1.5 1.5 2.6 1.5.5 0 1-.1 1.5-.4l1.6-.9c-.4-2.3-1.3-4.3-3.8-4.8z" fill="#ffcfaf"></path><path class="st17" d="M435.1 334.4c-.8-1.4-2.7-1.9-4.1-1.1l-2 1.2c3.3.4 3.5 2.7 3.3 5l1.7-1c1.4-.9 1.9-2.7 1.1-4.1z"></path><path class="st10" d="M429 334.4l-1.9 1c2.5.5 3.4 2.5 3.7 4.8l1.4-.8c.3-2.3.1-4.6-3.2-5z"></path><path d="M448.8 351.8l14.8 23" fill="none" stroke="#0260c1" stroke-linecap="round" stroke-miterlimit="10"></path><path d="M471.6 358.3l9.9 11.6" fill="none" stroke="#71603b" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10"></path><path class="st2" d="M325.6 179.8c-.1-1.5-.6-5-.6-6 9.6-2.7 13.6 1.4 15.3 3.5 4-1.2 20.4-5.5 24-7 2.1-10.1 13.4-8.5 15.6-4.9 2.5-.7 5.4-1.6 6.9-1.9.7 2.3 1.3 4.6 1.6 7-1.8.5-4.8 1.2-5.9 1.5-.2 5.8-9.3 11.4-16.6 5-2.5.8-20.2 5.5-23 6.3.8 5.6-5.2 12.1-9.4 13.7-1-1.2-2.8-3.9-3.9-5.1 7.3-3.2 10.3-13.9-4-12.1zm48.3-12.6c-2 0-3.7 1.6-3.7 3.6s1.6 3.7 3.6 3.7 3.7-1.6 3.7-3.6c0-2.1-1.6-3.7-3.6-3.7z"></path><path class="st0" d="M325.3 177.5c-.1-1.5-.6-5-.6-6 9.6-2.7 13.6 1.4 15.3 3.5 4-1.2 20.4-5.5 24-7 2.1-10.1 13.4-8.5 15.6-4.9 2.5-.6 5.4-1.6 6.9-1.9.8 2.3 1.3 4.7 1.6 7.1-1.8.5-4.8 1.2-5.9 1.5-.2 5.8-9.3 11.4-16.6 5-2.5.8-20.2 5.5-23 6.3.8 5.6-5.2 12.1-9.4 13.7-1-1.2-2.8-3.9-3.9-5.1 7.3-3.3 10.2-14-4-12.2zm48.2-12.7c-2 0-3.7 1.6-3.7 3.6s1.6 3.7 3.6 3.7 3.7-1.6 3.7-3.6-1.6-3.7-3.6-3.7z"></path><path d="M873.7 116.3l-41.9 47" fill="none" stroke="#b9bdc1" stroke-width="5" stroke-linecap="round" stroke-miterlimit="10"></path><path d="M854.7 124.3l-23.2 26.5" fill="none" stroke="#92989d" stroke-width="3" stroke-linecap="round" stroke-miterlimit="10"></path><path class="st27" d="M644.8 52.7s7.7-1 10 5.1 2 10.2-4.3 13.7l-2.5-.6s6.7-3.6 4.8-9.5-4.7-7.4-8-8.7zm72.3 211.5c1.1 2.3 3.2 4 6.2 5.2 8.5 3.4 24.1 2.2 68.9-14.3l-24.5-39.5c-45.6 25.5-54.5 40.2-50.6 48.6z"></path><path class="st28" d="M734.5 262.9c-2.8.1-5.6-.5-8.3-1.6-2-.9-3.2-2-3.6-3.3-.8-2.4-1.5-15.1 50.4-42.5l18.6 33c-27.2 9.9-45.8 14.6-57.1 14.4zm23.1 24.2l36.1 62.5c5.1 8.8 30.6 3.5 57.1-11.8 1.8-1.1 3.6-2.1 5.3-3.2-12.9-26.4-24.7-53.4-37.6-79.9l-60.9 32.4zm132 7.2l-34.1-59.1-23.1 12.2c13.4 24.9 27.2 49.7 42.3 73.5 12-10.6 18.2-20.9 14.9-26.6z"></path><path class="st27" d="M832.4 247.5l-13.8 7.3c12.9 26.5 24.7 53.5 37.6 79.9 6.5-4.1 12.7-8.7 18.5-13.7-15.1-23.9-28.9-48.6-42.3-73.5z"></path><path class="st27" d="M863.4 217.7l12.3 23.4s-9.7 23.1-62.3 42.6c-49.1 18.2-73.7 20-73.7 20l4.7-20 119-66z"></path><path class="st0" d="M830.3 130.3l-56.2 27.3c11.9 9.6 23.4 19.4 35.9 29.7 12 10 26 16 39 26 9 6.7 16.8 14.7 24.6 22.5 2.3-2.8 4.3-5.7 6.1-8.8l-49.4-96.7z"></path><path class="st28" d="M849 213.3c-13-10-27-16-39-26-12.5-10.3-23.9-20.1-35.9-29.7L746.5 171c2.5 3.1 5.3 5.9 8.5 8.2 11 8 25 13 31 25 13.4 25.5 35.3 42.9 60.3 54.4 10.6-6.8 20.3-14.4 27.3-22.9-7.8-7.7-15.6-15.6-24.6-22.4z"></path><path class="st0" d="M716.6 262l-.3-1c.1.3.2.7.3 1z"></path><path class="st27" d="M705.4 191.1c3.3 7.1 6.8 14 9.6 21.3 2.5 6.8 4.8 13.7 7.1 20.6 3.8-.8 7.8-1.9 12.1-3.2-6.7-14.3-12.9-28.8-18.7-43.5l-10.1 4.8z"></path><path d="M753.6 208.3l-17.2 9.2 15.8 34.4H773l-19.4-43.6z" fill="#adb1b4"></path><path class="st30" d="M748.5 229.2l.5 3.4s3.2 1.9 4.9 1.2-1.6-4.4-1.6-4.4c-1.5-1.2-2.5-1.3-3.8-.2z"></path><path class="st2" d="M765.9 201.6l-12.3 6.6 19.4 43.7 15.3-15.3-22.4-35zm-8 32.5l-1.4-2.8h-2.4c0-.1-.1-.2-.1-.3-1.2-2.6-3.4-4.1-4.8-3.5-1 .5-1.4 2-1.1 3.7h-3l1.4 2.8h2.7c1.3 2.2 3.2 3.4 4.5 2.8.8-.4 1.2-1.5 1.2-2.8h3zm-5.4.9c-.8.4-2.1-.6-2.9-2.1s-.8-3.2.1-3.6 2.1.6 2.9 2.1.7 3.2-.1 3.6z"></path><path class="st27" d="M734.6 268.5c3.6 9.3 7.9 18.3 12.8 27 6.9-.4 13.7-1.4 20.4-3-5.3-8.7-10.3-17.5-15.2-26.4-5.9 1.3-11.9 2.1-18 2.4z"></path><path class="st0" d="M846.3 258.8c-25-11.6-46.9-28.9-60.3-54.4-6-12-20-17-31-25-3.2-2.3-6.1-5.1-8.5-8.2l-31 15.1c5.8 14.7 12 29.2 18.7 43.5 11.6-3.7 22.8-8.4 33.5-14l24.5 39.5c-12.9 4.5-26.2 8.2-39.6 11.1 4.8 8.9 9.9 17.7 15.2 26.4 2.7-.6 5.6-1.4 8.6-2.2-.1-.3 38.8-12 69.9-31.8zM725 292.3c2.1 1 4.3 1.8 6.6 2.2-4-10.2-8.7-20.2-14.2-29.7l7.6 27.5z"></path><path class="st31" d="M716.6 262l.8 2.8c5.5 9.5 10.2 19.5 14.2 29.7 1.7.4 3.4.6 5.2.8-3.8-9.2-7.6-18.4-11.9-27.4-4.2-.9-7.2-2.8-8.3-5.9z"></path><path class="st0" d="M747.4 295.6c-4.9-8.7-9.2-17.7-12.8-27-3.3.2-6.5-.1-9.8-.7 4.3 9 8.1 18.2 11.9 27.4 3.6.4 7.1.4 10.7.3zm-57.2-97.1l-3.9 1.9V235c3.4.7 6.8 1 10.2.9-1.5-2.7-2.7-5.6-3.5-8.6-.5-10.1-1.1-19.6-2.8-28.8zm14.6 37.1c5.8-.5 11.6-1.4 17.3-2.7-2.3-6.9-4.6-13.8-7.1-20.6-2.8-7.3-6.3-14.2-9.6-21.3l-10.6 5.2c.5 13.7.2 27.6 7.2 36.1 1 1.1 1.9 2.2 2.8 3.3z"></path><path class="st31" d="M702 232.3c-7-8.5-6.8-22.4-7.2-36.1l-4.6 2.2c1.7 9.3 2.3 18.8 2.8 28.9.8 3 2 5.9 3.5 8.6 2.4 0 5.1 0 8.2-.3-.8-1.1-1.7-2.2-2.7-3.3z"></path><path class="st28" d="M819 68.3c-2.1-6.7-4.8-13.3-7.9-19.7-9.8 1.6-19.5 4-29 7.1 1.8 5.8 2.3 11.9-.1 18.5-2 6-9 9-11 14-13.8 36.9-35.9 70.1-64.4 97.3 19.6-7 38.5-15.9 56.5-26.3 16.1-9.3 31.5-19.8 46-31.5 10.4-18.1 16.2-37.9 9.9-59.4z"></path><path class="st32" d="M852.6 57.6c-5.4-9.4-20.7-12.1-41.5-8.9 3.1 6.4 5.7 12.9 7.9 19.7 6.3 21.5.5 41.3-9.9 59.4 24.2-19.7 40.4-39.5 44.5-54.6 1.7-6.1 1.5-11.4-1-15.6z"></path><path class="st31" d="M782 74.3c2.5-6.7 2-12.7.1-18.5-19.1 6.2-40.6 15.8-62.3 28.3-30.2 17.4-55.2 37.2-71.4 55.4 1.7 2.7 3.9 5.1 6.6 6.9 23.5 14.8 50.9 12.9 77.4 10.9 16.3-20.9 29.3-44.1 38.6-68.9 2-5.1 9-8.1 11-14.1z"></path><path class="st32" d="M655 146.3c-2.7-1.8-4.9-4.1-6.6-6.9-16.8 18.8-24.2 35.8-18.1 46.3 2.1 3.7 5.8 6.4 10.7 8 13.8 4.8 37.7 1.6 65.7-8.2 9.3-8.8 17.9-18.3 25.7-28.4-26.5 2.1-53.8 4-77.4-10.8z"></path><path class="st27" d="M828 131.7l-24.7-36.3-130.5 50.9 9.5 54.4c67.4-12.1 104.2-27.6 145.7-69z"></path><path class="st0" d="M701 135.3c16.4-14.3 32.5-28.2 49.4-41.2-6.8 1.9-13.5 4.1-20.1 6.7-34.7 13.5-59.6 33.4-57.5 45.5.1.5.2 1 .4 1.5 1.5 3.9 6.2 6.4 13 7.4 6-4.2 11.9-8.8 16.8-14.9 2-2-3-3-2-5z"></path><path class="st32" d="M787.2 89.2c-9.7-.6-22.5 1-36.8 4.9-16.9 13-33 27-49.4 41.2-1 2 4 3 2 5-4.9 6.1-10.7 10.7-16.8 14.9 13.8 2.1 36.7-1.8 60.9-11.2 2.7-1 5.3-2.1 7.8-3.2.1-.5.1-1 .1-1.5-.8-21.3 16.5-36.4 32.2-50.1z"></path><path class="st0" d="M804.2 97c-.2-.6-.5-1.1-.8-1.6-2.5-3.7-8.2-5.7-16.1-6.2-15.7 13.8-33 28.9-32.2 50.2 0 .5 0 1-.1 1.5 31.9-13.9 53.5-32.8 49.2-43.9z"></path><path class="st28" d="M728 129.3L679.3 28.8l3-1.5 60.8 96c1.3 2.6-14 8.2-15.1 6zm59 52c-3.3-12.7-2.7-24.9-.4-36.8-7.4 5-15.2 10-23.5 14.7-50.5 29.1-99.6 42.3-122.2 34.6l48.1 16.5c41.9-1.6 72.6-7.5 97.3-21.9 1-2.2 1.3-4.7.7-7.1z"></path><path class="st0" d="M825.6 113.2c-12.1 11.5-25.1 22-39 31.3-2.3 11.9-2.9 24.1.4 36.8.6 2.4.3 4.9-.7 7.1 5.6-3.3 10.9-7 15.9-11.1 2.8-9.4 4.8-18.9 8.8-26.9 5.8-12 10.7-24.5 14.6-37.2z"></path><path class="st28" d="M825.6 113.2c-3.9 12.7-8.7 25.2-14.6 37.1-4 8-6 17.6-8.8 26.9 12.6-10.4 23.6-23.8 34.1-40.9l17.3-63.2c-3 11.4-13 25.5-28 40.1zm-98.6-1.9l-51 13s-4.5 2.5-7.5-5-20.5-47-20.5-47l3.4-2.1 23.1 47.1 48-13.5 4.5 7.5z"></path><path class="st27" d="M731 129.3L681 28.1l3-1.5 62 96.8c1.4 2.5-13.9 8.1-15 5.9z"></path><path class="st27" d="M728.5 108.8l-51 13s-4.5 2.5-7.5-5-20.5-47-20.5-47l3.2-2.5 23.2 47.5 48-13.5 4.6 7.5z"></path><path class="st32" d="M655.5 57.3c-2.7-5.1-9-7-14.1-4.3s-7 9-4.3 14.1c2.7 5 8.9 7 13.9 4.4 5.2-2.7 7.2-9 4.5-14.2zm-2.7 11.9c-3 1.5-7.2-.7-9.4-5s-1.5-9 1.5-10.5 7.2.7 9.4 5 1.5 9-1.5 10.5z"></path><path class="st5" d="M848 208.3c8 .5 16 .8 24.1.5l-2.8-46.5-26.3 2.2c-.3 0-.5.1-.8.1-9.2 1.7-13.6 19.7-9.8 40.2.2 1.2.5 2.4.8 3.5 5.3.4 10.9-.6 14.8 0zm-4 17c-1.6 0-3.6-.9-5.6-1.7 4.9 10.1 11.6 16.4 17.6 15.2.6-.1 1.1-.3 1.6-.5l15.8-6.7-.2-4.1c-9.6-2.1-19.4-2.9-29.2-2.2z"></path><path class="st6" d="M873.2 227.6l-1.1-18.7c-8 .2-16 0-24.1-.5-3.9-.6-9.5.4-14.9.1 1.2 5.3 2.9 10.4 5.3 15.2 2.1.8 4 1.7 5.6 1.7 9.8-.8 19.7 0 29.2 2.2z"></path><path class="st28" d="M887 197.3c0 16.9-5.8 31-13.5 34.3-1.1.5-2.3.7-3.5.7-9.4 0-17-15.7-17-35 0-18.8 7.2-34.2 16.3-35h.7c9.4 0 17 15.7 17 35z"></path><path class="st6" d="M832.3 202.3s-34.4 25.9-36.2 28.2-5.2 5.8.2 7.8c5.8 2.3 15.2-2.5 21-8.5s23.7-27.2 23.7-27.2l-8.7-.3z"></path><path class="st5" d="M803 226.8c16.5-3.5 38-24.2 38-24.2l7 21.5s-17.2 18-37.5 25-24-18.8-7.5-22.3z"></path><path class="st6" d="M870 171.6h-.5c-2.2.3-4.1 1.4-5.5 3.1.7.8 1.4 1.7 2 2.6 5 9 7 18 4 28-1.1 4-2.9 10.2-6.1 14.5 1.8 2.1 3.9 3.3 6.1 3.3.9 0 1.7-.2 2.5-.5 5.7-2.4 10-12.8 10-25.2 0-14.3-5.6-25.8-12.5-25.8z"></path><path class="st27" d="M866 177.3c-.6-.9-1.3-1.8-2-2.6-3.9 4.4-6.5 12.9-6.5 22.6s2.6 18.1 6.4 22.5c3.2-4.3 5-10.5 6.1-14.5 3-10 1-19-4-28zM676.8 2.8c9.2 3.5 14 20.5-2 26.2 0 .7 12.8 4 16.3-10 3.2-12.7-13.4-20.9-14.3-16.2z"></path><path class="st32" d="M676.9 0c-8.5.1-15.4 7-15.4 15.6 0 1.3.2 2.6.5 3.9 3.7.5 7.2 1.5 10.6 3-.7-1.9-1-3.9-1-5.9 0-7.1 4-12.8 9-12.8s9 5.7 9 12.8-4 12.8-9 12.8c-2.3-.1-4.4-1.2-5.8-3-2.4 1.4-5.5 1.1-8.5.6 2.8 2.7 6.6 4.3 10.5 4.2 8.5-.1 15.4-7 15.4-15.6.2-8.5-6.7-15.5-15.3-15.6.1 0 .1 0 0 0z"></path><path class="st0" d="M674.9 26.3c-1-1.2-1.7-2.5-2.2-3.9-3.4-1.5-7-2.5-10.6-3 .7 2.9 2.2 5.4 4.3 7.5 3 .5 6.1.8 8.5-.6z"></path><path d="M528.8 185.1c-.1-.6-.1-1.1-.1-1.7 0-12.8 16.7-7.8 22.3-23.7" fill="none" stroke="#f86324" stroke-width="2" stroke-miterlimit="10"></path><path d="M508 151.3c7.4-3.3 14.4-3.4 20.9-8.5" fill="none" stroke="#178cfa" stroke-width="3" stroke-miterlimit="10"></path><path d="M524 173.1c2.9-1.8 5.6-3 8.7-3 5.8 0 8.3 4 12.2 4 4.8 0 4.5-11.2 8.4-15.2" fill="none" stroke="#022f60" stroke-width="2" stroke-miterlimit="10"></path><path d="M545 142.5c-3.8-3-8.1-4-9.9-2.5l-15 13.3 14.1 12.1 15-13.3.3-.3c1.5-1.9-.5-6.1-4.5-9.3z" fill="#494949"></path><path class="st6" d="M524.7 141.7l30.4 25.3 36.7-36.2 1.1-7.9-31.8-10.9-38 23.7 1.6 6z"></path><path class="st7" d="M543.2 144.8c-2.9-2.6-5.7-5.3-8.6-7.9l-4.9 3.9 9.8 7.7 3.7-3.7z"></path><path class="st7" d="M543.2 144.8l-3.6 3.7 7.9 6.2 3.3-3c-2.6-2.3-5.1-4.6-7.6-6.9z"></path><path class="st7" d="M547.5 154.7l7.2 5.6 3-2.9c-2.3-1.9-4.6-3.8-6.9-5.8-1.1 1-2.2 2-3.3 3.1z"></path><path class="st12" d="M534.6 136.9l-6.3-5.7-5.1 4.4 6.5 5.1 4.9-3.8z"></path><path class="st12" d="M544.6 128.9c-2.6-1.7-5.2-3.3-7.9-4.8l-8.3 7.2 6.3 5.7c3.2-2.7 6.6-5.4 9.9-8.1z"></path><path class="st7" d="M550.8 151.6c2.2 2 4.5 3.9 6.9 5.8l10.5-10.3c-2-1.8-4.1-3.5-6.2-5.3-3.8 3.3-7.5 6.5-11.2 9.8z"></path><path class="st12" d="M553.2 134.9c-3.3 3.3-6.7 6.6-10 9.9 2.5 2.3 5 4.6 7.6 6.8 3.7-3.3 7.4-6.6 11.1-9.8-2.8-2.3-5.8-4.7-8.7-6.9z"></path><path class="st7" d="M553.2 134.9c-2.8-2.1-5.6-4.1-8.6-6-3.3 2.7-6.7 5.4-10 8.1 2.9 2.6 5.7 5.3 8.6 7.9 3.3-3.4 6.6-6.7 10-10z"></path><path class="st12" d="M555.5 120c-2.3-2.1-4.5-4.2-6.9-6.3L536.7 124c2.7 1.5 5.3 3.2 7.9 4.8l10.9-8.8z"></path><path class="st5" d="M562 126.3c-2.2-2.1-4.3-4.3-6.5-6.3l-10.9 8.9c2.9 1.9 5.8 3.9 8.6 6 2.9-2.9 5.8-5.7 8.8-8.6z"></path><path class="st7" d="M562 126.3c-3 2.8-5.9 5.7-8.9 8.6 3 2.2 5.9 4.6 8.8 6.9 2.8-2.4 5.5-4.7 8.3-7-2.6-2.9-5.4-5.7-8.2-8.5zM561.9 141.8c2.1 1.7 4.2 3.5 6.2 5.3l7-6.9c-1.6-1.8-3.2-3.6-4.9-5.4-2.7 2.3-5.5 4.7-8.3 7zm10.4-35.5l-7.8-6.3-4.8 4.2c2.8 1.8 5.6 3.7 8.4 5.6 1.4-1.2 2.8-2.4 4.2-3.5z"></path><path class="st7" d="M578.3 111.1l-6-4.8c-1.4 1.1-2.8 2.3-4.2 3.4 2.2 1.5 4.5 3.1 6.7 4.7 1.1-1.1 2.3-2.2 3.5-3.3z"></path><path class="st7" d="M578.3 111.1c-1.2 1.1-2.4 2.2-3.5 3.3 3.6 2.6 7.2 5.1 10.8 7.7l3.2-2.6-10.5-8.4zm7.3 11l4.6 3.3 2.7-2.6-4.1-3.3-3.2 2.6zm-17.5-12.4c-2.8-1.9-5.5-3.7-8.4-5.6l-5.2 4.5c2.6 2 5.2 3.9 7.8 5.8 1.9-1.5 3.8-3.1 5.8-4.7z"></path><path class="st7" d="M574.8 114.4c-2.2-1.6-4.5-3.1-6.7-4.7-1.9 1.6-3.8 3.1-5.8 4.7 2.4 1.7 4.8 3.3 7.2 4.9 1.7-1.6 3.5-3.3 5.3-4.9zm5.4 12.1c1.8 1.2 3.5 2.3 5.3 3.5l4.7-4.6-4.6-3.3-5.4 4.4z"></path><path class="st7" d="M574.8 114.4c-1.8 1.7-3.6 3.3-5.3 5l10.8 7.2 5.3-4.4c-3.6-2.7-7.2-5.3-10.8-7.8zm-12.5 0c-2.7-1.9-5.3-3.8-7.8-5.8l-5.8 5c2.3 2.1 4.6 4.1 6.9 6.3l6.7-5.5zm7.1 4.9c-2.4-1.6-4.8-3.2-7.2-4.9l-6.8 5.6c2.2 2.1 4.4 4.2 6.5 6.3 2.6-2.3 5.1-4.6 7.5-7z"></path><path d="M569.4 119.3c-2.5 2.3-4.9 4.7-7.4 7 2.8 2.8 5.5 5.6 8.2 8.5 3.3-2.8 6.7-5.5 10-8.3l-10.8-7.2z" fill="#fffadf"></path><path class="st7" d="M570.3 134.8c1.7 1.8 3.3 3.6 4.9 5.4l10.3-10.2c-1.7-1.2-3.5-2.3-5.3-3.5-3.3 2.8-6.6 5.6-9.9 8.3z"></path><path d="M520.1 153.4c1.8-1.6 6.1-.6 9.9 2.5 4.1 3.2 6.1 7.4 4.5 9.4l-.3.3c-1.8 1.6-6.1.6-9.9-2.5-4-3.2-6.1-7.4-4.5-9.4.1-.2.2-.3.3-.3z" fill="#7e7e7e"></path><path d="M532.8 160.1c-.9-1.4-2-2.7-3.3-3.7-3.2-2.5-6.7-3.3-8.2-2l-.2.2c-.9 1.1-.4 3 1 5 3.3 1.6 6.9 1.2 10.7.5z" fill="#4b4b4b"></path><path class="st30" d="M522.1 159.6c.8 1 1.7 2 2.7 2.8 3.2 2.5 6.7 3.3 8.2 2l.2-.2c.7-.9.5-2.5-.4-4.1-3.7.7-7.4 1.1-10.7-.5z"></path><g><circle class="st40" cx="241.2" cy="225.9" r="64.4"></circle><path class="st40" d="M160.3 270.1c-2.8-.2-54.8.7-61.8-.8-7.5-1.6-11.7-8.9-10.4-24 .3-4-1.8-7-8.7-6-10.7 1.6-23.5-1.6-12.6-15.7 9.2-11.9 25.1-20.4 35.8-22.3 21.5-3.8 10.5 30.4 15 39 1.5 2.8 18.5 1.8 20.8 1.8m-38 84.7c2.3-10.7 0-13.8 8.6-19.2s39.8-23.3 51.2-25.7 19.1-3 30.4 2.7 76.8 30.8 87.7 32.3c10.5 1.5 24.1-2.9 27.9-6.6"></path><path class="st40" d="M177.4 215.1c-2.3 1.1-38.2 19.7-40.8 21.5 1.5 3.3 8.3 18.5 9.3 20.7 3.5.9 39.9 1.4 40.2 1.9m-49.6-21.5l41.3.8m100.7 69.8c-.4-29.7 41-60.5 57-18M65.1 326.2c.9-7.5 2.2-14.9 3.9-22.2 1-3.8 2.7-5.8 6.7-8.1 7.1-4.2 46.8-25.7 47.8-25.7m-19.1 9.7c-2.8 6.3-1.1 23.8 7.2 25.8M91.1 264c.4-15 20.8-26.1 25.9-25m91.3 87.2c-.5-4.6-1-33.2-.7-34.4m32.3 34.4c-2.1-3.6-11-21.8-11-25.2m30.3-13c3 .7 22.3 3.2 23.6 3m51.6-34c-4.2.3-36.4.6-37.6.6m-54.4-57.7c1.8-8-.9-18.9-3.6-18.9-8.6-.1-24.8 13.8-27.6 23.4m65.5 5.9c6.1-6 17.4-8.1 20.1-7.1 1.9.7 1 11.6-1.5 18.4m36.2 43.2c6.5-23.8 38.6-35.8 43.5-9.7"></path><path class="st40" d="M341.5 264.8c3.4.4 24.5 4.6 34.5-2.6 6.5-4.7.4-9.2-6.8-5.7m-68.3 15.7c-2.6 0-9.3-.6-13.9-1.1m37.7 2.9c2 .2 11.2 1.1 12.6 1.1m-40.5-71.9c-1.6-3.6-16-9.5-22.8-7.5 0 0-11.6-11.8-32.7-11.7m51.5 32.3c13.5 20.3-1.8 37.3-8.1 53.1m64.4-3.5c-2.4 2.1-15.9 11.9-18.8 14.2m-49.5 37.1c10.1-1.8 12.2-23.6 16-26.2s12.3 7.5 18.8 9c10.3 2.4 18.6-.3 22.9-4.1 3.5-3.1.5-8-9.2-4.9m-90.5-110c-4-1-20.3-1.1-29.3 10.7-31.7 11.5-32.4 66.8-9.9 83.4"></path><path class="st40" d="M206.4 280.1c-3.1-5.5 1.1-9 1.9-10.6 2.6-5.7.1-15.3 3.2-21.1 5.4-10.3 23-8.9 31.5-3.2 17.9 12.1 30.4 7.4 38.5 1.5 7.6-5.6 11.7-5.2 9.3 2.5-1.9 6.4-6.9 11.8-6.2 15.7s-.2 8.8-3.4 11.5"></path><ellipse transform="matrix(.9975 -.07115 .07115 .9975 -19.154 18.685)" class="st40" cx="252.7" cy="278.2" rx="4.3" ry="3.1"></ellipse><path class="st40" d="M266.1 313.6c-2.8-7.9 5.7-23 11.7-23m45.6-17.6c-1.8-6.6 1.3-13.8 4.7-15.8m-119.8 65.1c3.8-5.1 21.9-8.8 27.4-4.3"></path><circle class="st40" cx="451.5" cy="208.3" r="59.3"></circle><path class="st40" d="M413.1 253.6c-8.6-12.9-11.1-32-2.8-51.8 2-4.7 5.3-8.8 9.6-11.6 3.3-7.7 10.9-10.5 14.7-11.2 4.2 1.8 7.7 8.3 8.2 12.7m-19.1 4.1c.4-3.2 3.9-11.5 11-16.8m53.7 75.8c2.6-2.2 7.8-10.4 5.1-16.6-2.9-6.7 6.4-32-4.5-38.8.6-4.6 1.2-11.3-1.3-15.3-4.4-1.3-12.2 2.3-16 4.8-7.8-3.7-16.3-6.7-31-4.8m33.3 10.7c3.2-6 12.1-11.6 13.7-10.8"></path><path class="st40" d="M422.6 260.1c-4.1-5.3-2.7-9.5-1.4-13.1s-2.8-12.3-1.3-19.2c2.1-9.6 12.5-12.4 18.3-12.4 7.8 0 22.1 7.2 28.5 6.7 6.4-.7 12.7-2.7 18.3-5.8 4.7-2.6 7.3 2.8 5.8 9.5-2.3 10.5 3.6 10.6 3.3 17m-17.5 26c3.4 5.1 18.9 13 33.4 8.1 15.6-5.3 2.8-11.1-6.6-7.5m-31.1 5.2c7.3-33 36.2-27.1 40.5-6.3m-96.2 30.1c1.9-33.2 37.2-24.6 33-1.8m14.5-25.2c1.3.4 4 2.3 4 5"></path><path class="st40" d="M429.2 263.3c-.3 3.1 2.2 5.3 4.6 6.8 3.8 2.8 22.5 7.4 30.8.9 1.9-1.6 3.6-4.2 3.6-5.9m-49.5 31.6c3 4 18 11.6 30.9 7 11.7-4.2 1.9-9.7-7.4-5.7M431 268.3c-4.7 1.8-8.6 9.9-8.7 13.5m176.3-4.3c-32.7-.7-58.8-27.7-58.1-60.5s27.7-58.8 60.5-58.1c32.7.7 58.8 27.7 58.1 60.5-.3 13-4.8 25.5-12.8 35.7"></path><path class="st40" d="M669.3 273.6c-.4-5.1-1.2-18.4-2.2-23.5-5.1.7-43.5 11.2-48 13.5-2.7 5-5 10.2-7 15.5 3 5.4 19.2 37.9 20.2 40.6 4.5-1.6 36.4-17.1 38.1-17.6 0-.9.3-3.7.3-5.1"></path><path class="st40" d="M632.3 319.7l3.4-7-16.7-49.1m50.9 33.9L635.6 313m-4.7-47.5c1-.5 15.6-5.5 17.5-6 1 2.3 3.9 11 4.5 13-1.5.8-14.8 6.7-16 7.2-1.8-3.8-6.2-14.6-6-14.2zm55.7 60.8c1-10.5-4.6-29.9-21.6-30.2-8.2-3.5-5.9-17.5 4-19.1 25.2 1.4 48.6 25.8 45.8 50.2"></path><path class="st40" d="M670.7 276.5c0-1.9-2.4-4.9-7.3-4.9-17.2 0-18 26.5-4.3 28.6 4.7.7 7.9-2.1 9.9-3.6m7.8 3.7c-2.2-5.9 4.2-16.6 13.6-16.6m-4 35.5c4-11 23.9-10.4 27.2-6.3m-39.9 14.3c-3.2-3.8-7.7-19.4-7.7-23.1m-48.8 21.5c-1.1-4-8.1-31.9-7.3-34.9-3.8 11.4-11.1 29.6-35.5 29.6-37 0-48.5-15.1-51.8-30.9-1.1-5.2-.2-11.8 8.3-9.6 13.7-3.4 25 7.9 27.5 11.9"></path><path class="st40" d="M615.1 271.6c-4.3-3.9-12.6-2.9-17.5 8.2-2 4.6-9.8 17.3-14.4 18.1-5.7 1.1-24.7-6.2-29.8-7.2m39.5-13.7c5.9-22.1 43.8-31.5 55-24.1m-74.3 43.7c-6 .9-13.5 17.4-6.6 23.4"></path><ellipse class="st40" cx="464.1" cy="250.7" rx="4" ry="1.9"></ellipse><path class="st40" d="M641.8 250.1c21.9-27-4.1-88.6-61.1-58.5-6.3-3.9-13.7-5.4-21-4.2-6.4 4.4-7 20.8-7 24.9"></path><path class="st40" d="M597.4 185.1c2.5-3.3 7-7.6 10.5-8.8 6.2 1.6 11.8 5.1 16 10m-67.4 20.8c-2.4 2.2-9.7 12.8-5.7 22.8s10.4 22.6 11 28.5c.6 5.9 8.8 11.3 12.6 13.5"></path></g></svg>
+
+      </div>
+
+      <div class="col-lg-4 text-center text-lg-left my-3">
+        <h2 class="h1-mktg lh-condensed mb-3">Get started with GitHub&nbsp;Enterprise</h2>
+        <p class="f3 text-gray mr-lg-6">
+        Take collaboration to the next level with security and administrative features built for&nbsp;teams.
+        </p>
+      </div>
+      <div class="d-flex flex-wrap flex-md-nowrap flex-justify-end col-lg-8">
+        <div class="col-sm-6 col-md-5 d-flex flex-column flex-justify-between flex-items-center text-center p-3">
+          <div>
+            <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 48 49" fill="none" class="mb-2">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M21.6797 36.9274V34.3863C21.6797 34.3863 21.6724 33.7008 22.0494 33.1215C21.5238 33.0825 18.21 32.751 18.21 28.8196C18.21 27.3001 19.1252 26.3431 19.1252 26.3431C19.1252 26.3431 18.8805 25.4767 18.9788 24.4822C19.1095 23.1602 21.5564 24.6609 21.5564 24.6609C21.5564 24.6609 23.471 23.9548 26.281 24.6609C26.5293 24.3575 28.7146 22.9573 28.9395 24.3929C29.009 24.8369 28.8458 26.3431 28.8458 26.3431C28.8458 26.3431 29.6206 27.1288 29.626 28.8442C29.6369 32.2357 25.8261 33.1215 25.8261 33.1215C25.8261 33.1215 26.1856 33.7757 26.172 34.3863C26.1585 34.997 26.172 37 26.172 37C26.172 37 29.8169 35.8847 31.5674 33.0498C32.4044 31.6944 33 30.1179 33 28.1846C33 25.2995 31.8249 23.2014 30.5001 21.7971C28.7136 19.9033 26.2658 19 24 19C21.7525 19 19.2387 19.9239 17.4121 21.8971C16.0278 23.3925 15 25.507 15 28.1846C15 30.2112 15.7011 32.1298 16.7732 33.5648C18.6151 36.0301 21.6797 36.9274 21.6797 36.9274Z" stroke="#2088FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+<path d="M11 48H3C1.89543 48 1 47.1046 1 46V20C1 18.8954 1.89543 18 3 18H6L11 18" stroke="#79B8FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+<path d="M5.01172 23H10.0117" stroke="#79B8FF" stroke-width="2" stroke-linecap="round"></path>
+<path d="M5.01367 28H10.0137" stroke="#79B8FF" stroke-width="2" stroke-linecap="round"></path>
+<path d="M34 36.9989C34 36.4466 33.5523 35.9989 33 35.9989C32.4477 35.9989 32 36.4466 32 36.9989H34ZM33 48V49C33.5523 49 34 48.5523 34 48H33ZM27 48H26C26 48.5523 26.4477 49 27 49V48ZM27 44.8636H28C28 44.3114 27.5523 43.8636 27 43.8636V44.8636ZM21 44.8636V43.8636C20.4477 43.8636 20 44.3114 20 44.8636H21ZM21 48V49C21.5523 49 22 48.5523 22 48H21ZM15 48H14C14 48.5523 14.4477 49 15 49V48ZM16 37.0243C16 36.472 15.5523 36.0243 15 36.0243C14.4477 36.0243 14 36.472 14 37.0243H16ZM14 19.0122C14 19.5645 14.4477 20.0122 15 20.0122C15.5523 20.0122 16 19.5645 16 19.0122H14ZM18 9.22727L18.4262 10.1319C18.4447 10.1232 18.463 10.1139 18.4809 10.104L18 9.22727ZM33 1H34C34 0.646647 33.8135 0.319526 33.5095 0.139506C33.2054 -0.0405132 32.8289 -0.0467031 32.5191 0.123224L33 1ZM32 19.0219C32 19.5741 32.4477 20.0219 33 20.0219C33.5523 20.0219 34 19.5741 34 19.0219H32ZM32 36.9989V48H34V36.9989H32ZM33 47H27V49H33V47ZM28 48V44.8636H26V48H28ZM27 43.8636H21V45.8636H27V43.8636ZM20 44.8636V48H22V44.8636H20ZM21 47H15V49H21V47ZM16 48V37.0243H14V48H16ZM16 19.0122V14.4545H14V19.0122H16ZM16 14.4545C16 12.4615 17.1989 10.7101 18.4262 10.1319L17.5738 8.32265C15.5679 9.2677 14 11.7773 14 14.4545H16ZM18.4809 10.104L33.4809 1.87678L32.5191 0.123224L17.5191 8.3505L18.4809 10.104ZM32 1V19.0219H34V1H32Z" fill="#2088FF"></path>
+<path d="M36 21L37.0597 20.2052L40 18L47 24V46C47 47.1046 46.1046 48 45 48H37" stroke="#79B8FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+<path d="M38.0137 30.0078H43.0137" stroke="#79B8FF" stroke-width="2" stroke-linecap="round"></path>
+<path d="M38.0156 35.0078H43.0156" stroke="#79B8FF" stroke-width="2" stroke-linecap="round"></path>
+</svg>
+
+            <h3 class="h4-mktg">Enterprise</h3>
+            <p class="f5 text-gray">Deploy to your environment or the cloud.</p>
+          </div>
+          <a class="btn-mktg mb-1 d-block d-md-inline-block text-center mt-2" href="/organizations/enterprise_plan" data-ga-click="Home Enterprise prompt, click, text:Start a free trial">Start a free trial</a>
+        </div>
+        <div class="col-sm-6 col-md-5 d-flex flex-column flex-justify-between flex-items-center text-center p-3">
+          <div>
+            <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" fill="none" class="mb-2"><path d="M10 8.572c-.79 0-1.429.64-1.429 1.429v25.714c0 .789.64 1.428 1.429 1.428h8.571c.282 0 .558.084.792.24l6.35 4.234v-3.045c0-.789.64-1.429 1.43-1.429h4.285a1.429 1.429 0 0 1 0 2.858h-2.857v4.285a1.429 1.429 0 0 1-2.221 1.189L18.138 40H10a4.286 4.286 0 0 1-4.286-4.286V10A4.286 4.286 0 0 1 10 5.715h47.142A4.286 4.286 0 0 1 61.428 10v14.285a1.429 1.429 0 0 1-2.857 0V10.001c0-.79-.64-1.429-1.429-1.429H10zM44.77 37.915a14.238 14.238 0 0 1 9.515-3.629c3.662 0 7.005 1.38 9.532 3.645a1.429 1.429 0 0 1-1.907 2.128 11.38 11.38 0 0 0-7.625-2.916 11.381 11.381 0 0 0-7.61 2.903 1.428 1.428 0 1 1-1.904-2.13zM67.05 64.707a1.428 1.428 0 0 1 2.017.105c1.982 2.2 3.334 4.873 3.774 7.81a1.429 1.429 0 0 1-2.826.423c-.348-2.33-1.427-4.496-3.07-6.32a1.429 1.429 0 0 1 .105-2.017zM63.947 55.745c.528.586.481 1.49-.105 2.017a14.238 14.238 0 0 1-9.557 3.667h-.003c-.914 0-1.812.069-2.685.2-6.79 1.022-12.035 5.786-13.048 11.48a1.429 1.429 0 0 1-2.813-.502c1.059-5.948 5.707-10.788 11.755-12.894a14.324 14.324 0 0 1-2.726-1.918 1.429 1.429 0 0 1 1.905-2.13 11.38 11.38 0 0 0 7.614 2.907h.001c2.94 0 5.619-1.109 7.645-2.933a1.428 1.428 0 0 1 2.017.105z" fill="#79B8FF"></path><path d="M36.168 14.326a1.429 1.429 0 0 1 .956 1.78L32.817 30.43a1.428 1.428 0 1 1-2.736-.823l4.307-14.324a1.429 1.429 0 0 1 1.78-.957zM25.296 17.562a1.429 1.429 0 0 1 0 2.02l-3.276 3.276 3.276 3.275a1.429 1.429 0 1 1-2.02 2.02l-4.286-4.285a1.429 1.429 0 0 1 0-2.02l4.285-4.286a1.429 1.429 0 0 1 2.02 0z" fill="#2188FF"></path><path fill-rule="evenodd" clip-rule="evenodd" d="M40.28 40.01c.752.048 1.548.277 2.075.984.49.656.498 1.451.502 1.808v.06c-.003 1.02-.002 2.65 0 4.291v.012c.001 1.598.003 3.206 0 4.268v.044c-.001.174-.002.438-.036.695-.037.29-.128.693-.393 1.08-.593.863-1.584 1.037-2.431 1.034-3.792-.002-7.14-3.178-7.14-7.143 0-2.798 1.668-5.203 3.982-6.377 2.6-7.114 9.429-12.194 17.447-12.194 8.017 0 14.845 5.08 17.447 12.194 2.314 1.174 3.981 3.58 3.981 6.377 0 2.798-1.667 5.203-3.981 6.377-2.293 6.271-7.869 10.96-14.65 11.985A2.144 2.144 0 0 1 52.857 65v-.928c0-.67.544-1.215 1.214-1.215h.215c.223 0 .446-.004.667-.013 5.824-.243 10.832-3.658 13.337-8.564-.777-.037-1.62-.26-2.146-1.028a2.437 2.437 0 0 1-.394-1.08 5.674 5.674 0 0 1-.036-.695v-.044c-.003-1.064-.001-2.676 0-4.278.002-1.641.004-3.272 0-4.293v-.06c.005-.357.013-1.152.502-1.808.527-.707 1.323-.936 2.076-.984-2.6-5.094-7.897-8.581-14.007-8.581-6.109 0-11.406 3.487-14.006 8.581zm-.29 2.848c-2.253.005-4.276 1.943-4.276 4.285 0 2.346 2.029 4.286 4.286 4.286v-.006c.003-.99.001-2.617 0-4.242v-.005c-.002-1.674-.003-3.344 0-4.312v-.006h-.01zm28.591 0c2.254.005 4.276 1.943 4.276 4.285 0 2.346-2.028 4.286-4.286 4.286v-.006c-.002-.99-.001-2.62 0-4.247v-.012c.002-1.67.003-3.334 0-4.3v-.006h.01z" fill="#2188FF"></path><path d="M41.847 19.582a1.429 1.429 0 0 1 2.02-2.02l4.286 4.285a1.429 1.429 0 0 1 0 2.02l-4.286 4.286a1.429 1.429 0 0 1-2.02-2.02l3.275-3.275-3.275-3.276z" fill="#2188FF"></path></svg>
+
+            <h3 class="h4-mktg">Talk to us</h3>
+            <p class="f5 text-gray">Need help?</p>
+          </div>
+          <a class="btn-mktg btn-outline-mktg mb-1 d-block d-md-inline-block text-center mt-2 Bump-link" href="https://enterprise.github.com/contact" data-ga-click="Home Enterprise prompt, click, text:Contact Sales">Contact Sales <span class="Bump-link-symbol">&rarr;</span></a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+
+  <div class="container-xl px-3 px-sm-6 px-xl-4" data-ga-load="(Logged out) Home, view, GitHub Universe Explore launches">
+    <div class="d-lg-flex flex-row flex-justify-between p-5 p-md-7 text-white text-center text-lg-left rounded-2 box-shadow-extra-large" style="background: #1B1F23 url(https://github.githubassets.com/images/modules/site/universe19.png) bottom right no-repeat; background-size: contain;">
+      <div class="col-lg-6">
+        <h2 class="h1-mktg lh-condensed">See what launched at Universe</h2>
+        <p class="mt-4 mt-lg-3 text-mono text-white-fade f5">Say hello to our new GitHub for mobile experience, get more from GitHub Actions and Packages, and learn how we’re shaping the future of software, together.</p>
+      </div>
+      <div class="d-lg-flex flex-items-center pr-lg-4 pr-xl-8">
+        <a class="btn-mktg box-shadow-medium Bump-link my-5 my-lg-0 text-mono" href="http://github.blog/2019-11-13-universe-day-one" data-ga-click="(Logged out) Home, click, GitHub Universe Explore launches">Explore the launches <span class="Bump-link-symbol"><img src="https://github.githubassets.com/images/modules/site/icons/arrow-universe.svg" alt="→" style="margin-bottom: -3px"></span></a>
+      </div>
+    </div>
+  </div>
+
+
+<div class="container-lg p-responsive">
+  <div class="text-center py-7 py-md-8 py-lg-9 ">
+    <h3 class="h3-mktg text-normal text-gray-light mb-4 lh-condensed">
+      More than 2.1 million businesses and organizations use GitHub
+    </h3>
+    <ul class="d-flex flex-justify-center flex-items-center flex-wrap list-style-none mt-2 mt-md-3 grayscale">
+      <li><img alt="Airbnb" class="logo-img-sm px-2 px-sm-4 px-md-5 my-md-3" src="https://github.githubassets.com/images/modules/site/logos/airbnb-logo.png" /></li>
+      <li><img alt="SAP" class="logo-img-sm px-2 px-sm-4 px-md-5 my-md-3" src="https://github.githubassets.com/images/modules/site/logos/sap-logo.png" /></li>
+      <li><img alt="IBM" class="logo-img-sm px-2 px-sm-4 px-md-5 my-md-3" src="https://github.githubassets.com/images/modules/site/logos/ibm-logo.png" /></li>
+      <li><img alt="Google" class="logo-img-sm px-2 px-sm-4 px-md-5 my-md-3" src="https://github.githubassets.com/images/modules/site/logos/google-logo.png" /></li>
+      <li><img alt="PayPal" class="logo-img-sm px-2 px-sm-4 px-md-5 my-md-3" src="https://github.githubassets.com/images/modules/site/logos/paypal-logo.png" /></li>
+      <li><img alt="Bloomberg" class="logo-img-sm px-2 px-sm-4 px-md-5 my-md-3" src="https://github.githubassets.com/images/modules/site/logos/bloomberg-logo.png" /></li>
+      <li><img alt="Spotify" class="logo-img-sm px-2 px-sm-4 px-md-5 my-md-3" src="https://github.githubassets.com/images/modules/site/logos/spotify-logo.png" /></li>
+      <li><img alt="Swift" class="logo-img-sm px-2 px-sm-4 px-md-5 my-md-3" src="https://github.githubassets.com/images/modules/site/logos/swift-logo.png" /></li>
+      <li><img alt="Facebook" class="logo-img-sm px-2 px-sm-4 px-md-5 my-md-3" src="https://github.githubassets.com/images/modules/site/logos/facebook-logo.png" /></li>
+      <li><img alt="Node.js" class="logo-img-sm px-2 px-sm-4 px-md-5 my-md-3" src="https://github.githubassets.com/images/modules/site/logos/node-logo.png" /></li>
+      <li><img alt="NASA" class="logo-img-sm px-2 px-sm-4 px-md-5 my-md-3" src="https://github.githubassets.com/images/modules/site/logos/nasa-logo.png" /></li>
+      <li><img alt="Walmart" class="logo-img-sm px-2 px-sm-4 px-md-5 my-md-3" src="https://github.githubassets.com/images/modules/site/logos/walmart-logo.png" /></li>
+    </ul>
+  </div>
+</div>
+
+<div class="py-7 py-md-8 py-lg-9">
+  <div class="container-lg p-responsive pb-6">
+    <h2 class="h4 text-mono text-normal text-gray text-center">
+      GitHub for teams
+    </h2>
+    <p class="h00-mktg lh-condensed mt-3 mb-2 text-center">
+      A better way to work together
+    </p>
+    <p class="lead-mktg text-gray text-center col-md-8 mx-auto mb-4">
+      GitHub brings teams together to work through problems, move ideas forward, and learn from each other along&nbsp;the&nbsp;way.
+    </p>
+    <div class="text-center">
+        <a href="/join?plan=business&amp;setup_organization=true&amp;source=home"
+          class="btn-mktg btn-large-mktg btn-outline-mktg Bump-link"
+          data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;sign up your team&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;client_id&quot;:null,&quot;originating_url&quot;:&quot;https://github.com/&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="99b68a298fc9898d5c508fff8fb46c2a59aa3008b8f0e4d00f59fc8a34cc72e1"
+          data-ga-click="Signup, Attempt, text:Sign up your team">
+          Sign up your team <span class="Bump-link-symbol">&rarr;</span>
+        </a>
+    </div>
+  </div>
+
+  <div class="container-xl p-responsive">
+    <div class="position-relative overflow-hidden d-lg-flex pt-6">
+      <div class="col-10 col-sm-7 mx-auto mx-lg-6 mb-sm-3">
+        <img src="https://github.githubassets.com/images/modules/site/home-illo-team.svg" alt="" class="d-block width-fit mx-auto">
+      </div>
+      <div class="col-lg-5">
+        <a href="/features/code-review" class="summarylink">
+          <div class="summarylink-illustration">
+            <img src="https://github.githubassets.com/images/modules/site/home-illo-team-code.svg" alt="" class="width-fit mx-auto">
+          </div>
+          <div class="summarylink-btn d-flex flex-justify-between flex-items-center f5 text-gray-dark rounded-1 p-sm-4 my-4 my-sm-0">
+            <div class="col-10">
+              <h3 class="h3-mktg text-normal mb-1">Write better code</h3>
+              <p class="mb-0">Collaboration makes perfect. The conversations and code reviews that happen in pull requests help your team share the weight of your work and improve the software you build. <span class="link-mktg text-blue">Learn about code review.</span></p>
+            </div>
+            <svg class="octicon octicon-triangle-right text-blue" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 14l6-6-6-6v12z"/></svg>
+          </div>
+        </a>
+        <a href="/features/project-management" class="summarylink">
+          <div class="summarylink-illustration">
+            <img src="https://github.githubassets.com/images/modules/site/home-illo-team-chaos.svg" alt="" class="width-fit mx-auto">
+          </div>
+          <div class="summarylink-btn d-flex flex-justify-between flex-items-center f5 text-gray-dark rounded-1 p-sm-4 my-4 my-sm-0">
+            <div class="col-10">
+              <h3 class="h3-mktg text-normal mb-1">Manage your chaos</h3>
+              <p class="mb-0">Take a deep breath. On GitHub, project management happens in issues and project boards, right alongside your code. All you have to do is mention a teammate to get them involved. <span class="link-mktg text-blue">Learn about project management.</span></p>
+            </div>
+            <svg class="octicon octicon-triangle-right text-blue" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 14l6-6-6-6v12z"/></svg>
+          </div>
+        </a>
+        <a href="/features/integrations" class="summarylink">
+          <div class="summarylink-illustration">
+            <img src="https://github.githubassets.com/images/modules/site/home-illo-team-tools.svg" alt="" class="width-fit mx-auto">
+          </div>
+          <div class="summarylink-btn d-flex flex-justify-between flex-items-center f5 text-gray-dark rounded-1 p-sm-4 my-4 my-sm-0">
+            <div class="col-10">
+              <h3 class="h3-mktg text-normal mb-1">Find the right tools</h3>
+              <p class="mb-0">Browse and buy apps from GitHub Marketplace with your GitHub account. Find the tools you like or discover new favorites—then start using them in minutes. <span class="link-mktg text-blue">Learn about integrations.</span></p>
+            </div>
+            <svg class="octicon octicon-triangle-right text-blue" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 14l6-6-6-6v12z"/></svg>
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+
+    <h3 class="lead-mktg text-gray text-center col-md-8 mt-6 mx-auto">
+      See how the world's leading companies use GitHub Enterprise.
+    </h3>
+    <div class="d-flex flex-wrap flex-items-stretch flex-justify-center container-xl gutter-sm-condensed gutter-md mx-auto p-responsive">
+        <article class="col-12 col-sm-6 col-md-4 col-lg-3 d-flex flex-column py-2 py-md-3">
+  <a
+    href="/customer-stories/mgm-resorts"
+    class="Bump-link customer-story-card bg-white rounded-1 px-3 pt-3 no-underline d-flex flex-column position-relative height-full"
+  >
+    <div
+      class="customer-story-card-hero position-relative rounded-1"
+      style="background-image: url(https://customer-stories-feed.github.com/customer_stories/mgm-resorts/hero.jpg);"
+    >
+      <div class="customer-story-btn position-absolute top-0 right-0 mt-2 mr-2" role="button">
+        <span class="btn-mktg mx-auto py-2 px-3" role="button">
+          <span class="f2">&nearr;</span>
+        </span>
+      </div>
+
+    </div>
+
+    <div class="pt-3 d-flex flex-column flex-auto">
+      <h1 class="h4-mktg text-gray-dark mb-1">MGM Resorts International</h1>
+
+      <p class="text-gray f6 flex-auto">
+          <span class="d-block mb-2">
+            Hospitality
+          </span>
+      </p>
+
+      <div class="d-flex width-full f5 border-top flex-justify-between py-3 text-blue-mktg">
+        <span>Read more</span>
+        <span class="Bump-link-symbol">&rarr;</span>
+      </div>
+    </div>
+  </a>
+</article>
+
+        <article class="col-12 col-sm-6 col-md-4 col-lg-3 d-flex flex-column py-2 py-md-3">
+  <a
+    href="/customer-stories/nationwide"
+    class="Bump-link customer-story-card bg-white rounded-1 px-3 pt-3 no-underline d-flex flex-column position-relative height-full"
+  >
+    <div
+      class="customer-story-card-hero position-relative rounded-1"
+      style="background-image: url(https://customer-stories-feed.github.com/customer_stories/nationwide/nw_hero.jpg);"
+    >
+      <div class="customer-story-btn position-absolute top-0 right-0 mt-2 mr-2" role="button">
+        <span class="btn-mktg mx-auto py-2 px-3" role="button">
+          <span class="f2">&nearr;</span>
+        </span>
+      </div>
+
+    </div>
+
+    <div class="pt-3 d-flex flex-column flex-auto">
+      <h1 class="h4-mktg text-gray-dark mb-1">Nationwide</h1>
+
+      <p class="text-gray f6 flex-auto">
+          <span class="d-block mb-2">
+            Insurance
+          </span>
+      </p>
+
+      <div class="d-flex width-full f5 border-top flex-justify-between py-3 text-blue-mktg">
+        <span>Read more</span>
+        <span class="Bump-link-symbol">&rarr;</span>
+      </div>
+    </div>
+  </a>
+</article>
+
+        <article class="col-12 col-sm-6 col-md-4 col-lg-3 d-flex flex-column py-2 py-md-3">
+  <a
+    href="/customer-stories/sap"
+    class="Bump-link customer-story-card bg-white rounded-1 px-3 pt-3 no-underline d-flex flex-column position-relative height-full"
+  >
+    <div
+      class="customer-story-card-hero position-relative rounded-1"
+      style="background-image: url(https://customer-stories-feed.github.com/customer_stories/sap/sap6.jpg);"
+    >
+      <div class="customer-story-btn position-absolute top-0 right-0 mt-2 mr-2" role="button">
+        <span class="btn-mktg mx-auto py-2 px-3" role="button">
+          <span class="f2">&nearr;</span>
+        </span>
+      </div>
+
+    </div>
+
+    <div class="pt-3 d-flex flex-column flex-auto">
+      <h1 class="h4-mktg text-gray-dark mb-1">SAP</h1>
+
+      <p class="text-gray f6 flex-auto">
+          <span class="d-block mb-2">
+            Business Software
+          </span>
+      </p>
+
+      <div class="d-flex width-full f5 border-top flex-justify-between py-3 text-blue-mktg">
+        <span>Read more</span>
+        <span class="Bump-link-symbol">&rarr;</span>
+      </div>
+    </div>
+  </a>
+</article>
+
+        <article class="col-12 col-sm-6 col-md-4 col-lg-3 d-flex flex-column py-2 py-md-3">
+  <a
+    href="/customer-stories/spotify"
+    class="Bump-link customer-story-card bg-white rounded-1 px-3 pt-3 no-underline d-flex flex-column position-relative height-full"
+  >
+    <div
+      class="customer-story-card-hero position-relative rounded-1"
+      style="background-image: url(https://customer-stories-feed.github.com/customer_stories/spotify/spotifyhero.jpg);"
+    >
+      <div class="customer-story-btn position-absolute top-0 right-0 mt-2 mr-2" role="button">
+        <span class="btn-mktg mx-auto py-2 px-3" role="button">
+          <span class="f2">&nearr;</span>
+        </span>
+      </div>
+
+    </div>
+
+    <div class="pt-3 d-flex flex-column flex-auto">
+      <h1 class="h4-mktg text-gray-dark mb-1">Spotify</h1>
+
+      <p class="text-gray f6 flex-auto">
+          <span class="d-block mb-2">
+            Technology / Streaming
+          </span>
+      </p>
+
+      <div class="d-flex width-full f5 border-top flex-justify-between py-3 text-blue-mktg">
+        <span>Read more</span>
+        <span class="Bump-link-symbol">&rarr;</span>
+      </div>
+    </div>
+  </a>
+</article>
+
+    </div>
+</div>
+
+<div class="py-7 py-md-8 py-lg-9">
+  <div class="container-lg p-responsive">
+    <h2 class="h4 text-mono text-normal text-gray text-center">
+      Security and administration
+    </h2>
+    <p class="h00-mktg mt-3 mb-2 text-center">
+      Your business needs, met
+    </p>
+    <p class="lead-mktg text-gray text-center col-md-8 mx-auto mb-4">
+       From flexible hosting to granular access controls, we’ve got your security requirements&nbsp;covered.
+    </p>
+    <p class="text-center mb-5">
+      <a href="/enterprise" class="btn-mktg btn-large-mktg btn-outline-mktg mx-auto Bump-link" data-ga-click="Home Enterprise, click, text:Learn how GitHub Enterprise works">
+        <span class="d-sm-none">How GitHub Enterprise works <span class="Bump-link-symbol">&rarr;</span></span>
+        <span class="d-none d-sm-inline">Learn how GitHub Enterprise works <span class="Bump-link-symbol">&rarr;</span></span>
+      </a>
+    </p>
+
+    <div class="d-md-flex flex-items-center flex-row-reverse mt-6 mb-3">
+      <div class="col-md-6 mx-auto px-5 pr-md-0 text-center">
+        <img src="https://github.githubassets.com/images/modules/site/home-illo-business.png" alt="Security and administration" class="width-fit mb-4">
+      </div>
+      <div class="col-md-6 mx-auto text-md-left f5 p-sm-6">
+        <h3 class="h3-mktg text-normal mb-1">Code security</h3>
+        <p class="text-gray mb-3 mb-md-5">
+          Prevent problems before they happen. Protected branches, signed commits, and required status checks protect your work and help you maintain a high standard for your code.
+        </p>
+        <h3 class="h3-mktg text-normal mb-1 mt-sm-6">Access controlled</h3>
+        <p class="text-gray mb-3 mb-md-5">
+          Encourage teams to work together while limiting access to those who need it with granular permissions and authentication through SAML/SSO and LDAP.
+        </p>
+      </div>
+    </div>
+
+    <div class="col-md-7 mx-auto Tile Tile--dots clearfix p-4 border pt-5 bg-white" style="min-height: 0">
+      <div class="float-left">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" class="mr-4" width="64px"><path d="M27 13h-9a1 1 0 0 0 0 2h9a1 1 0 0 0 0-2zm15-1a1 1 0 0 0-1 1v2a1 1 0 0 0 2 0v-2a1 1 0 0 0-1-1zm4 0a1 1 0 0 0-1 1v2a1 1 0 0 0 2 0v-2a1 1 0 0 0-1-1zM27 28h-9a1 1 0 0 0 0 2h9a1 1 0 0 0 0-2zm15 3a1 1 0 0 0 1-1v-2a1 1 0 0 0-2 0v2a1 1 0 0 0 1 1zm4 0a1 1 0 0 0 1-1v-2a1 1 0 0 0-2 0v2a1 1 0 0 0 1 1z" fill="#23292f"></path><path d="M50 44h-1a13 13 0 0 0-4.68-9H48a3 3 0 0 0 3-3v-6a3 3 0 0 0-3-3h-5v-3h5a3 3 0 0 0 3-3v-6a3 3 0 0 0-3-3H16a3 3 0 0 0-3 3v6a3 3 0 0 0 3 3h5v3h-5a3 3 0 0 0-3 3v6a3 3 0 0 0 3 3h11.72a13 13 0 0 0-3.79 5.21A7 7 0 0 0 13.28 44 6 6 0 0 0 14 56h36a6 6 0 0 0 0-12zM15 17v-6a1 1 0 0 1 1-1h32a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1H16a1 1 0 0 1-1-1zm8 3h18v3H23zm-7 13a1 1 0 0 1-1-1v-6a1 1 0 0 1 1-1h32a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1h-7a12.9 12.9 0 0 0-10 0H16zm34 21H14a4 4 0 1 1 .09-8 1 1 0 0 0 1-.83 5 5 0 0 1 8.6-2.55 1 1 0 0 0 1.7-.42A11 11 0 0 1 47 45a1 1 0 0 0 1 1h2a4 4 0 0 1 0 8z" fill="#23292f"></path></svg>
+
+      </div>
+      <div class="overflow-hidden">
+        <h3 class="h4-mktg">Hosted where you need it</h3>
+        <p class="f5 text-gray mr-2">Securely and reliably host your work on GitHub using GitHub Enterprise Cloud. Or deploy GitHub Enterprise Server in your own data centers or in a private cloud using Amazon Web Services, Azure, or Google Cloud Platform.</p>
+
+        <a href="/pricing" class="d-block no-underline Bump-link" data-ga-click="Home Enterprise, click, text:Compare plans">Compare plans <span class="Bump-link-symbol">&rarr;</span></a>
+        <a href="https://enterprise.github.com/contact" class="d-block no-underline Bump-link" data-ga-click="Home Enterprise, click, text:Contact Sales for more information">Contact Sales for more information <span class="Bump-link-symbol">&rarr;</span></a>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<div class="py-7 py-md-8 py-lg-9">
+  <div class="container-lg p-responsive text-center">
+    <div class="col-md-8 py-md-6 mx-auto">
+      <h2 class="h4 text-mono text-normal text-gray">
+        Integrations
+      </h2>
+      <p class="h00-mktg lh-condensed mt-3 mb-2">
+        Build on GitHub
+      </p>
+      <p class="lead-mktg text-gray mb-4 px-md-3">
+        Customize your process with GitHub apps and an intuitive API. Integrate the tools you already use or discover new favorites to create a happier, more efficient way of working.
+      </p>
+      <p class="f4 text-center mb-6">
+        <a href="/features/integrations" class="btn-mktg btn-large-mktg btn-outline-mktg mx-auto Bump-link">Learn about integrations <span class="Bump-link-symbol">&rarr;</span></a>
+      </p>
+    </div>
+
+    <div class="apps-cluster d-flex flex-wrap flex-justify-center pb-6">
+      <div class="CircleBadge CircleBadge--medium CircleBadge--feature tooltipped tooltipped-s tooltipped-no-delay" style="background-color: #4A154B;" aria-label="Slack"><img src="https://github.githubassets.com/images/modules/site/integrators/slackhq.png" alt="Slack" class="CircleBadge-icon"></div>
+      <div class="CircleBadge CircleBadge--medium CircleBadge--feature tooltipped tooltipped-s tooltipped-no-delay" style="background-color: #364e98;" aria-label="ZenHub"><img src="https://github.githubassets.com/images/modules/site/integrators/zenhubio.png" alt="ZenHub" class="CircleBadge-icon"></div>
+      <div class="CircleBadge CircleBadge--medium CircleBadge--feature tooltipped tooltipped-s tooltipped-no-delay" style="background-color: #eff9f9;" aria-label="Travis CI"><img src="https://github.githubassets.com/images/modules/site/integrators/travis-ci.png" alt="Travis CI" class="CircleBadge-icon"></div>
+      <div class="CircleBadge CircleBadge--medium CircleBadge--feature tooltipped tooltipped-s tooltipped-no-delay" style="background-color: #5fb57d;" aria-label="Atom"><img src="https://github.githubassets.com/images/modules/site/integrators/atom.png" alt="Atom" class="CircleBadge-icon"></div>
+      <div class="CircleBadge CircleBadge--medium CircleBadge--feature tooltipped tooltipped-s tooltipped-no-delay" style="background-color: #022531;" aria-label="Circle CI"><img src="https://github.githubassets.com/images/modules/site/integrators/circleci.png" alt="Circle CI" class="CircleBadge-icon"></div>
+      <div class="CircleBadge CircleBadge--medium CircleBadge--feature tooltipped tooltipped-s tooltipped-no-delay" style="background-color: #f2f2f2;" aria-label="Google"><img src="https://github.githubassets.com/images/modules/site/integrators/google.png" alt="Google" class="CircleBadge-icon"></div>
+      <div class="CircleBadge CircleBadge--medium CircleBadge--feature hide-sm tooltipped tooltipped-s tooltipped-no-delay" style="background-color: #303030;" aria-label="Code Climate"><img src="https://github.githubassets.com/images/modules/site/integrators/codeclimate.png" alt="Code Climate" class="CircleBadge-icon"></div>
+    </div>
+
+    <div class="col-md-8 py-md-6 mx-auto">
+      <p class="my-2 f5 col-sm-8 col-md-6 mx-auto text-gray">
+        Sometimes, there’s more than one tool for the job. Why not try something new?
+      </p>
+      <p>
+        <a href="/marketplace" class="no-underline Bump-link" data-ga-click="Marketplace, click, text:Browse GitHub Marketplace">
+          Browse GitHub Marketplace <span class="Bump-link-symbol">&rarr;</span>
+        </a>
+      </p>
+    </div>
+  </div>
+</div>
+
+<div class="py-7 py-md-8 py-lg-9">
+  <div class="container-lg p-responsive">
+    <h2 class="h4 text-mono text-normal text-gray text-center">
+      Community
+    </h2>
+    <p class="h00-mktg mt-3 mb-4 lh-condensed text-center">
+      Welcome home, <br>developers
+    </p>
+      <p class="lead-mktg text-gray text-center col-md-8 mx-auto">
+        GitHub is home to the world’s largest community of developers and their&nbsp;projects...
+      </p>
+  </div>
+
+    <div class="d-flex flex-wrap flex-items-stretch flex-justify-center container-xl gutter-sm-condensed gutter-md mx-auto mb-3 p-responsive">
+        <article class="col-12 col-sm-6 col-md-4 col-lg-3 d-flex flex-column py-2 py-md-3">
+  <a
+    href="/customer-stories/freakboy3742"
+    class="Bump-link customer-story-card bg-white rounded-1 px-3 pt-3 no-underline d-flex flex-column position-relative height-full"
+  >
+    <div
+      class="customer-story-card-hero position-relative rounded-1"
+      style="background-image: url(https://customer-stories-feed.github.com/customer_stories/freakboy3742/hero.jpg);"
+    >
+      <div class="customer-story-btn position-absolute top-0 right-0 mt-2 mr-2" role="button">
+        <span class="btn-mktg mx-auto py-2 px-3" role="button">
+          <span class="f2">&nearr;</span>
+        </span>
+      </div>
+
+    </div>
+
+    <div class="pt-3 d-flex flex-column flex-auto">
+      <h1 class="h4-mktg text-gray-dark mb-1">Russell Keith-Magee</h1>
+
+      <p class="text-gray f6 flex-auto">
+          Russell Keith-Magee created BeeWare to fill a gap in his own process. Today, BeeWare is the go-to project for supporting Python on every platform.
+      </p>
+
+      <div class="d-flex width-full f5 border-top flex-justify-between py-3 text-blue-mktg">
+        <span>Read more</span>
+        <span class="Bump-link-symbol">&rarr;</span>
+      </div>
+    </div>
+  </a>
+</article>
+
+        <article class="col-12 col-sm-6 col-md-4 col-lg-3 d-flex flex-column py-2 py-md-3">
+  <a
+    href="/customer-stories/kris-nova"
+    class="Bump-link customer-story-card bg-white rounded-1 px-3 pt-3 no-underline d-flex flex-column position-relative height-full"
+  >
+    <div
+      class="customer-story-card-hero position-relative rounded-1"
+      style="background-image: url(https://customer-stories-feed.github.com/customer_stories/kris-nova/hero.jpg);"
+    >
+      <div class="customer-story-btn position-absolute top-0 right-0 mt-2 mr-2" role="button">
+        <span class="btn-mktg mx-auto py-2 px-3" role="button">
+          <span class="f2">&nearr;</span>
+        </span>
+      </div>
+
+    </div>
+
+    <div class="pt-3 d-flex flex-column flex-auto">
+      <h1 class="h4-mktg text-gray-dark mb-1">Kris Nova</h1>
+
+      <p class="text-gray f6 flex-auto">
+          Kris Nova quickly developed a passion for open source software. Now she gets to work on open source tooling at her day job, which includes maintaining Kubernetes Operations (kops).
+      </p>
+
+      <div class="d-flex width-full f5 border-top flex-justify-between py-3 text-blue-mktg">
+        <span>Read more</span>
+        <span class="Bump-link-symbol">&rarr;</span>
+      </div>
+    </div>
+  </a>
+</article>
+
+        <article class="col-12 col-sm-6 col-md-4 col-lg-3 d-flex flex-column py-2 py-md-3">
+  <a
+    href="/customer-stories/yyx990803"
+    class="Bump-link customer-story-card bg-white rounded-1 px-3 pt-3 no-underline d-flex flex-column position-relative height-full"
+  >
+    <div
+      class="customer-story-card-hero position-relative rounded-1"
+      style="background-image: url(https://customer-stories-feed.github.com/customer_stories/yyx990803/hero.jpg);"
+    >
+      <div class="customer-story-btn position-absolute top-0 right-0 mt-2 mr-2" role="button">
+        <span class="btn-mktg mx-auto py-2 px-3" role="button">
+          <span class="f2">&nearr;</span>
+        </span>
+      </div>
+
+    </div>
+
+    <div class="pt-3 d-flex flex-column flex-auto">
+      <h1 class="h4-mktg text-gray-dark mb-1">Evan You</h1>
+
+      <p class="text-gray f6 flex-auto">
+          In 2013, Evan You founded Vue, a Javascript framework funded by the community on Patreon. In 2016, Vue reached 2,000,000 downloads.
+      </p>
+
+      <div class="d-flex width-full f5 border-top flex-justify-between py-3 text-blue-mktg">
+        <span>Read more</span>
+        <span class="Bump-link-symbol">&rarr;</span>
+      </div>
+    </div>
+  </a>
+</article>
+
+        <article class="col-12 col-sm-6 col-md-4 col-lg-3 d-flex flex-column py-2 py-md-3">
+  <a
+    href="/customer-stories/jessfraz"
+    class="Bump-link customer-story-card bg-white rounded-1 px-3 pt-3 no-underline d-flex flex-column position-relative height-full"
+  >
+    <div
+      class="customer-story-card-hero position-relative rounded-1"
+      style="background-image: url(https://customer-stories-feed.github.com/customer_stories/jessfraz/hero.jpg);"
+    >
+      <div class="customer-story-btn position-absolute top-0 right-0 mt-2 mr-2" role="button">
+        <span class="btn-mktg mx-auto py-2 px-3" role="button">
+          <span class="f2">&nearr;</span>
+        </span>
+      </div>
+
+    </div>
+
+    <div class="pt-3 d-flex flex-column flex-auto">
+      <h1 class="h4-mktg text-gray-dark mb-1">Jess Frazelle</h1>
+
+      <p class="text-gray f6 flex-auto">
+          Jess Frazelle works on Kubernetes full-time. Previously she maintained Docker, a software containerization platform used by thousands of teams.
+      </p>
+
+      <div class="d-flex width-full f5 border-top flex-justify-between py-3 text-blue-mktg">
+        <span>Read more</span>
+        <span class="Bump-link-symbol">&rarr;</span>
+      </div>
+    </div>
+  </a>
+</article>
+
+    </div>
+
+  <div class="container-lg p-responsive">
+      <p class="lead-mktg text-gray text-center col-md-8 mx-auto pb-md-6">
+        ...whether you’re making your first commit or sending a Rover to Mars, there’s room for you here, too.
+      </p>
+
+    <div class="gutter-md">
+      <div class="communitystats position-relative">
+        <a href="/open-source" class="d-inline-block summarylink">
+          <div class="circle summary-circle d-flex flex-column flex-justify-center text-center p-4 mx-auto mt-6 mb-3 m-md-3 bg-orange box-shadow-extra-large">
+            <span class="d-block h0-mktg text-normal text-white lh-condensed-ultra mb-1">100M<sup class="f2-light">*</sup></span>
+            <span class="h5 text-white lh-condensed">repositories worldwide</span>
+          </div>
+          <div class="summarylink-btn d-flex flex-justify-between flex-items-center f5 text-gray-dark rounded-1 p-sm-4">
+            <p class="col-10 mb-0">GitHub’s users create and maintain influential technologies alongside the world’s largest <span class="text-orange">open source&nbsp;community</span>.</p>
+            <svg class="octicon octicon-triangle-right text-orange-light" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 14l6-6-6-6v12z"/></svg>
+          </div>
+        </a>
+
+        <a href="/personal" class="d-inline-block summarylink">
+          <div class="circle summary-circle d-flex flex-column flex-justify-center text-center p-4 mx-auto mt-6 mb-3 m-md-3 bg-blue box-shadow-extra-large">
+            <span class="d-block h0-mktg text-normal text-white lh-condensed-ultra mb-1">40M<sup class="f2-light">*</sup></span>
+            <span class="h5 text-white lh-condensed">developers worldwide</span>
+          </div>
+          <div class="summarylink-btn d-flex flex-justify-between flex-items-center f5 text-gray-dark rounded-1 p-sm-4">
+            <p class="col-10 mb-0"><span class="text-blue">Developers</span> use GitHub for personal projects, from experimenting with new programming languages to hosting their life’s work.</p>
+            <svg class="octicon octicon-triangle-right text-blue" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 14l6-6-6-6v12z"/></svg>
+          </div>
+        </a>
+
+        <a href="/business" class="d-inline-block summarylink">
+          <div class="circle summary-circle d-flex flex-column flex-justify-center text-center p-4 mx-auto mt-6 mb-3 m-md-3 bg-purple box-shadow-extra-large">
+            <span class="d-block h1-mktg text-normal text-white lh-condensed-ultra my-1">2.1M<sup class="f3-light">*</sup></span>
+            <span class="h5 text-white lh-condensed">businesses & organizations worldwide</span>
+          </div>
+          <div class="summarylink-btn d-flex flex-justify-between flex-items-center f5 text-gray-dark rounded-1 p-sm-4">
+            <p class="col-10 mb-0"><span class="text-purple">Businesses</span> of all sizes use GitHub to support their development process and to securely build software.</p>
+            <svg class="octicon octicon-triangle-right text-purple" viewBox="0 0 6 16" version="1.1" width="6" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 14l6-6-6-6v12z"/></svg>
+          </div>
+        </a>
+
+        <div class="mt-6 ml-md-4 text-gray-light f6">
+          * As of August 2019
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+  <div class="py-7 py-md-8 py-lg-9 bg-gray-dark">
+    <div class="container-lg p-responsive text-white text-center">
+      <h2 class="h1-mktg text-normal">
+        Get started for free &mdash; join the millions of developers already using GitHub to share their code, work together, and build amazing things.
+      </h2>
+    </div>
+    <div class="container-xl p-responsive py-6 mt-lg-6">
+      <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="home-hero-signup js-signup-form" autocomplete="off" aria-label="Sign up" action="/join" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="WfKt31yqoe1vwV+6LJluiGNEJDlUYJ0QBtEVcShRwDAqQcEwtFZbIqq0ZiwWdfOCmrOyqJaMY0Qv6rrf2vvXwg==" />        <input type="hidden" name="ga_id" class="js-octo-ga-id-input">
+        <div class="d-lg-flex flex-wrap flex-lg-nowrap flex-justify-between">
+          <auto-check src="/signup_check/username" class="form-group col-12 col-sm-8 col-lg-3 mx-auto mt-0 mx-lg-0 mb-3 mb-lg-0 px-3">
+            <dl class="m-0">
+              <dt class="input-label">
+                <label class="form-label text-white f5" for="user[login]-footer">Username</label>
+              </dt>
+              <dd>
+                <input type="text" name="user[login]" id="user[login]-footer" class="form-control form-control-lg input-block input-lg" placeholder="Pick a username">
+              </dd>
+            </dl>
+            <input type="hidden" value="FVkQDFJkb2WPDWN5IkqlbbX8LIEPKVcCyRPr88AaNJax6uP8i+dPAOTK9gMeeKnpvKobFDo49mLsOg0XpPjf6g==" data-csrf="true" />
+          </auto-check>
+
+          <auto-check src="/signup_check/email" class="form-group col-12 col-sm-8 col-lg-3 mx-auto mt-0 mx-lg-0 mb-3 mb-lg-0 px-3">
+            <dl class="m-0">
+              <dt class="input-label">
+                <label class="form-label text-white f5" for="user[email]-footer">Email</label>
+              </dt>
+              <dd>
+                <input type="text" name="user[email]" id="user[email]-footer" class="form-control form-control-lg input-block input-lg js-email-notice-trigger" placeholder="Your email address">
+              </dd>
+            </dl>
+            <input type="hidden" value="+sINo4UwUA85yIzQE799JLY2UpXEqB3fG1dKTOhdreQFb0RhgFxsv0v+e4g2HP74Jb32UbAx5A+L+K2X+sO1PQ==" data-csrf="true" />
+          </auto-check>
+
+          <dl class="form-group col-12 col-sm-8 col-lg-3 mx-auto mt-0 mx-lg-0 mb-3 mb-lg-0 px-3">
+            <dt class="input-label">
+              <label class="form-label text-white f5" for="user[password]-footer">Password</label>
+            </dt>
+            <dd>
+              <input type="password" name="user[password]" id="user[password]-footer" class="form-control form-control-lg input-block input-lg" placeholder="Create a password">
+            </dd>
+          </dl>
+
+          <input type="hidden" name="source" class="js-signup-source" value="form-home">
+          <input type="text" name="required_field_f05f" hidden="hidden" class="form-control" />
+<input type="hidden" name="timestamp" value="1580265228916" class="form-control" />
+<input type="hidden" name="timestamp_secret" value="3f0a83abefaa12b7ebadf9cbd23c33fa4d8df549a77879918b5abb9d6d397613" class="form-control" />
+
+          <div class="col-12 col-sm-8 col-lg-3 mx-auto mx-lg-0 mb-3 mb-lg-0 px-3 mt-4">
+            <button class="btn-mktg btn-primary-mktg btn-block mt-n1" type="submit" data-ga-click="Signup, Attempt, location:teams;">Sign up for GitHub</button>
+          </div>
+        </div>
+
+        <p class="form-control-note text-center mt-6">
+          By clicking &ldquo;Sign up for GitHub&rdquo;, you agree to our
+          <a class="text-white" href="https://help.github.com/terms" target="_blank">terms of service</a> and
+          <a class="text-white" href="https://help.github.com/privacy" target="_blank">privacy statement</a>. <span class="js-email-notice">We’ll occasionally send you account related emails.</span>
+        </p>
+</form>    </div>
+  </div>
+
+</main>
+
+  </div>
+
+          <footer class="footer mt-6">
+  <div class="container-xl p-responsive">
+    <div class="d-flex flex-wrap py-5 mb-5">
+      <div class="col-12 col-lg-4 mb-5">
+        <a href="/" data-ga-click="Footer, go to home, text:home" class="text-gray-dark" aria-label="Go to GitHub homepage">
+          <svg height="30" class="octicon octicon-logo-github" viewBox="0 0 45 16" version="1.1" width="84" aria-hidden="true"><path fill-rule="evenodd" d="M18.53 12.03h-.02c.009 0 .015.01.024.011h.006l-.01-.01zm.004.011c-.093.001-.327.05-.574.05-.78 0-1.05-.36-1.05-.83V8.13h1.59c.09 0 .16-.08.16-.19v-1.7c0-.09-.08-.17-.16-.17h-1.59V3.96c0-.08-.05-.13-.14-.13h-2.16c-.09 0-.14.05-.14.13v2.17s-1.09.27-1.16.28c-.08.02-.13.09-.13.17v1.36c0 .11.08.19.17.19h1.11v3.28c0 2.44 1.7 2.69 2.86 2.69.53 0 1.17-.17 1.27-.22.06-.02.09-.09.09-.16v-1.5a.177.177 0 00-.146-.18zM42.23 9.84c0-1.81-.73-2.05-1.5-1.97-.6.04-1.08.34-1.08.34v3.52s.49.34 1.22.36c1.03.03 1.36-.34 1.36-2.25zm2.43-.16c0 3.43-1.11 4.41-3.05 4.41-1.64 0-2.52-.83-2.52-.83s-.04.46-.09.52c-.03.06-.08.08-.14.08h-1.48c-.1 0-.19-.08-.19-.17l.02-11.11c0-.09.08-.17.17-.17h2.13c.09 0 .17.08.17.17v3.77s.82-.53 2.02-.53l-.01-.02c1.2 0 2.97.45 2.97 3.88zm-8.72-3.61h-2.1c-.11 0-.17.08-.17.19v5.44s-.55.39-1.3.39-.97-.34-.97-1.09V6.25c0-.09-.08-.17-.17-.17h-2.14c-.09 0-.17.08-.17.17v5.11c0 2.2 1.23 2.75 2.92 2.75 1.39 0 2.52-.77 2.52-.77s.05.39.08.45c.02.05.09.09.16.09h1.34c.11 0 .17-.08.17-.17l.02-7.47c0-.09-.08-.17-.19-.17zm-23.7-.01h-2.13c-.09 0-.17.09-.17.2v7.34c0 .2.13.27.3.27h1.92c.2 0 .25-.09.25-.27V6.23c0-.09-.08-.17-.17-.17zm-1.05-3.38c-.77 0-1.38.61-1.38 1.38 0 .77.61 1.38 1.38 1.38.75 0 1.36-.61 1.36-1.38 0-.77-.61-1.38-1.36-1.38zm16.49-.25h-2.11c-.09 0-.17.08-.17.17v4.09h-3.31V2.6c0-.09-.08-.17-.17-.17h-2.13c-.09 0-.17.08-.17.17v11.11c0 .09.09.17.17.17h2.13c.09 0 .17-.08.17-.17V8.96h3.31l-.02 4.75c0 .09.08.17.17.17h2.13c.09 0 .17-.08.17-.17V2.6c0-.09-.08-.17-.17-.17zM8.81 7.35v5.74c0 .04-.01.11-.06.13 0 0-1.25.89-3.31.89-2.49 0-5.44-.78-5.44-5.92S2.58 1.99 5.1 2c2.18 0 3.06.49 3.2.58.04.05.06.09.06.14L7.94 4.5c0 .09-.09.2-.2.17-.36-.11-.9-.33-2.17-.33-1.47 0-3.05.42-3.05 3.73s1.5 3.7 2.58 3.7c.92 0 1.25-.11 1.25-.11v-2.3H4.88c-.11 0-.19-.08-.19-.17V7.35c0-.09.08-.17.19-.17h3.74c.11 0 .19.08.19.17z"/></svg>
+        </a>
+
+
+      </div>
+      <div class="col-6 col-sm-3 col-lg-2 mb-6 mb-md-2 pr-3 pr-lg-0 pl-lg-4">
+        <h2 class="h5 mb-3 text-mono text-gray-light text-normal">Product</h2>
+        <ul class="list-style-none text-gray f5">
+          <li class="lh-condensed mb-3"><a href="/features" data-ga-click="Footer, go to features, text:features" class="link-gray">Features</a></li>
+          <li class="lh-condensed mb-3"><a href="/security" data-ga-click="Footer, go to security, text:security" class="link-gray">Security</a></li>
+          <li class="lh-condensed mb-3"><a href="/enterprise" data-ga-click="Footer, go to enterprise, text:enterprise" class="link-gray">Enterprise</a></li>
+          <li class="lh-condensed mb-3"><a href="/customer-stories" data-ga-click="Footer, go to customer stories, text:customer stories" class="link-gray">Customer stories</a></li>
+          <li class="lh-condensed mb-3"><a href="/pricing" data-ga-click="Footer, go to pricing, text:pricing" class="link-gray">Pricing</a></li>
+          <li class="lh-condensed mb-3"><a href="https://resources.github.com" data-ga-click="Footer, go to resources, text:resources" class="link-gray">Resources</a></li>
+        </ul>
+      </div>
+      <div class="col-6 col-sm-3 col-lg-2 mb-6 mb-md-2 pr-3 pr-md-0 pl-md-4">
+        <h2 class="h5 mb-3 text-mono text-gray-light text-normal">Platform</h2>
+        <ul class="list-style-none f5">
+          <li class="lh-condensed mb-3"><a href="https://developer.github.com" data-ga-click="Footer, go to api, text:api" class="link-gray">Developer API</a></li>
+          <li class="lh-condensed mb-3"><a href="http://partner.github.com/" data-ga-click="Footer, go to partner, text:partner" class="link-gray ">Partners</a></li>
+          <li class="lh-condensed mb-3"><a href="https://atom.io" data-ga-click="Footer, go to atom, text:atom" class="link-gray ">Atom</a></li>
+          <li class="lh-condensed mb-3"><a href="http://electron.atom.io/" data-ga-click="Footer, go to electron, text:electron" class="link-gray ">Electron</a></li>
+          <li class="lh-condensed mb-3"><a href="https://desktop.github.com/" data-ga-click="Footer, go to desktop, text:desktop" class="link-gray ">GitHub Desktop</a></li>
+        </ul>
+      </div>
+      <div class="col-6 col-sm-3 col-lg-2 mb-6 mb-md-2 pr-3 pr-md-0 pl-md-4">
+        <h2 class="h5 mb-3 text-mono text-gray-light text-normal">Support</h2>
+        <ul class="list-style-none f5">
+          <li class="lh-condensed mb-3"><a data-ga-click="Footer, go to help, text:help" class="link-gray " href="https://help.github.com">Help</a></li>
+          <li class="lh-condensed mb-3"><a href="https://github.community" data-ga-click="Footer, go to community, text:community" class="link-gray ">Community Forum</a></li>
+          <li class="lh-condensed mb-3"><a href="https://services.github.com/" data-ga-click="Footer, go to professional services, text:professional services" class="link-gray ">Professional Services</a></li>
+          <li class="lh-condensed mb-3"><a href="https://lab.github.com/" data-ga-click="Footer, go to learning lab, text:learning lab" class="link-gray ">Learning Lab</a></li>
+          <li class="lh-condensed mb-3"><a href="https://githubstatus.com/" data-ga-click="Footer, go to status, text:status" class="link-gray ">Status</a></li>
+          <li class="lh-condensed mb-3"><a data-ga-click="Footer, go to contact, text:contact" class="link-gray " href="https://github.com/contact">Contact GitHub</a></li>
+        </ul>
+      </div>
+      <div class="col-6 col-sm-3 col-lg-2 mb-6 mb-md-2 pr-3 pr-md-0 pl-md-4">
+        <h2 class="h5 mb-3 text-mono text-gray-light text-normal">Company</h2>
+        <ul class="list-style-none f5">
+          <li class="lh-condensed mb-3"><a data-ga-click="Footer, go to about, text:about" class="link-gray " href="https://github.com/about">About</a></li>
+          <li class="lh-condensed mb-3"><a href="https://github.blog" data-ga-click="Footer, go to blog, text:blog" class="link-gray ">Blog</a></li>
+          <li class="lh-condensed mb-3"><a href="/about/careers" data-ga-click="Footer, go to careers, text:careers" class="link-gray">Careers</a></li>
+          <li class="lh-condensed mb-3"><a href="/about/press" data-ga-click="Footer, go to press, text:press" class="link-gray">Press</a></li>
+          <li class="lh-condensed mb-3"><a href="https://shop.github.com" data-ga-click="Footer, go to shop, text:shop" class="link-gray">Shop</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div class="bg-gray-light">
+    <div class="container-xl p-responsive f6 py-4 d-sm-flex flex-justify-between flex-row-reverse flex-items-center">
+      <ul class="list-style-none d-flex flex-items-center mb-3 mb-sm-0 lh-condensed-ultra">
+        <li class="mr-3"><a href="https://twitter.com/github" data-ga-click="Footer, go to Twitter, text:twitter" title="GitHub on Twitter" style="color: #959da5;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 273.5 222.3" class="d-block" height="18"><path d="M273.5 26.3a109.77 109.77 0 0 1-32.2 8.8 56.07 56.07 0 0 0 24.7-31 113.39 113.39 0 0 1-35.7 13.6 56.1 56.1 0 0 0-97 38.4 54 54 0 0 0 1.5 12.8A159.68 159.68 0 0 1 19.1 10.3a56.12 56.12 0 0 0 17.4 74.9 56.06 56.06 0 0 1-25.4-7v.7a56.11 56.11 0 0 0 45 55 55.65 55.65 0 0 1-14.8 2 62.39 62.39 0 0 1-10.6-1 56.24 56.24 0 0 0 52.4 39 112.87 112.87 0 0 1-69.7 24 119 119 0 0 1-13.4-.8 158.83 158.83 0 0 0 86 25.2c103.2 0 159.6-85.5 159.6-159.6 0-2.4-.1-4.9-.2-7.3a114.25 114.25 0 0 0 28.1-29.1" fill="currentColor"></path></svg>
+</a></li>
+        <li class="mr-3"><a href="https://www.facebook.com/GitHub" data-ga-click="Footer, go to Facebook, text:facebook" title="GitHub on Facebook" style="color: #959da5;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15.3 15.4" class="d-block" height="18"><path d="M14.5 0H.8a.88.88 0 0 0-.8.9v13.6a.88.88 0 0 0 .8.9h7.3v-6h-2V7.1h2V5.4a2.87 2.87 0 0 1 2.5-3.1h.5a10.87 10.87 0 0 1 1.8.1v2.1h-1.3c-1 0-1.1.5-1.1 1.1v1.5h2.3l-.3 2.3h-2v5.9h3.9a.88.88 0 0 0 .9-.8V.8a.86.86 0 0 0-.8-.8z" fill="currentColor"></path></svg>
+</a></li>
+        <li class="mr-3"><a href="https://www.youtube.com/github" data-ga-click="Footer, go to YouTube, text:youtube" title="GitHub on YouTube" style="color: #959da5;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 19.17 13.6" class="d-block" height="16"><path d="M18.77 2.13A2.4 2.4 0 0 0 17.09.42C15.59 0 9.58 0 9.58 0a57.55 57.55 0 0 0-7.5.4A2.49 2.49 0 0 0 .39 2.13 26.27 26.27 0 0 0 0 6.8a26.15 26.15 0 0 0 .39 4.67 2.43 2.43 0 0 0 1.69 1.71c1.52.42 7.5.42 7.5.42a57.69 57.69 0 0 0 7.51-.4 2.4 2.4 0 0 0 1.68-1.71 25.63 25.63 0 0 0 .4-4.67 24 24 0 0 0-.4-4.69zM7.67 9.71V3.89l5 2.91z" fill="currentColor"></path></svg>
+</a></li>
+        <li class="mr-3 flex-self-start"><a href="https://www.linkedin.com/company/github" data-ga-click="Footer, go to Linkedin, text:linkedin" title="GitHub on Linkedin" style="color: #959da5;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 19 18" class="d-block" height="18"><path d="M3.94 2A2 2 0 1 1 2 0a2 2 0 0 1 1.94 2zM4 5.48H0V18h4zm6.32 0H6.34V18h3.94v-6.57c0-3.66 4.77-4 4.77 0V18H19v-7.93c0-6.17-7.06-5.94-8.72-2.91z" fill="currentColor"></path></svg>
+</a></li>
+        <li><a href="https://github.com/github" data-ga-click="Footer, go to github's org, text:github" title="GitHub's organization" style="color: #959da5;"><svg height="20" class="octicon octicon-mark-github d-block" alt="GitHub" viewBox="0 0 16 16" version="1.1" width="20" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a></li>
+      </ul>
+      <ul class="list-style-none d-flex text-gray">
+        <li class="mr-3">&copy; 2020 GitHub, Inc.</li>
+        <li class="mr-3"><a href="/site/terms" data-ga-click="Footer, go to terms, text:terms" class="link-gray">Terms</a></li>
+        <li><a href="/site/privacy" data-ga-click="Footer, go to privacy, text:privacy" class="link-gray">Privacy</a></li>
+      </ul>
+    </div>
+  </div>
+</footer>
+
+
+
+
+  <div id="ajax-error-message" class="ajax-error-message flash flash-error">
+    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 000 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 00.01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"/></svg>
+    <button type="button" class="flash-close js-ajax-error-dismiss" aria-label="Dismiss error">
+      <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+    </button>
+    You can’t perform that action at this time.
+  </div>
+
+
+    <script crossorigin="anonymous" async="async" integrity="sha512-44n3wlGLuUccx54xJCLuPnISUrN43Yp0sjk/Hv2yNTT0J0Cpt/pwdOoBajrT0yBBx7R2yqHMx2GeyvewiI1b1g==" type="application/javascript" id="js-conditional-compat" data-src="https://github.githubassets.com/assets/compat-bootstrap-e389f7c2.js"></script>
+    <script crossorigin="anonymous" integrity="sha512-puq6CBneH2gfjBc9mGVtNag5s43e1vf8I6rH5XI4tsGzX1+L//g/lcAgu783UKPnUspy+N2o0XPjfKRbP7Gllg==" type="application/javascript" src="https://github.githubassets.com/assets/frameworks-a6eaba08.js"></script>
+    
+    <script crossorigin="anonymous" async="async" integrity="sha512-wGfSkHDbGFTmcR6Hl2DebTDRv/ZR4NKtA1HsLHAIVCQkvfqp7LDe4Itogn8BeOko0ZrdH2V8v3AGS7fpmyIazQ==" type="application/javascript" src="https://github.githubassets.com/assets/github-bootstrap-c067d290.js"></script>
+    
+    
+    
+  <div class="js-stale-session-flash flash flash-warn flash-banner" hidden
+    >
+    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 000 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 00.01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"/></svg>
+    <span class="js-stale-session-flash-signed-in" hidden>You signed in with another tab or window. <a href="">Reload</a> to refresh your session.</span>
+    <span class="js-stale-session-flash-signed-out" hidden>You signed out in another tab or window. <a href="">Reload</a> to refresh your session.</span>
+  </div>
+  <template id="site-details-dialog">
+  <details class="details-reset details-overlay details-overlay-dark lh-default text-gray-dark hx_rsm" open>
+    <summary role="button" aria-label="Close dialog"></summary>
+    <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast hx_rsm-dialog hx_rsm-modal">
+      <button class="Box-btn-octicon m-0 btn-octicon position-absolute right-0 top-0" type="button" aria-label="Close dialog" data-close-dialog>
+        <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+      </button>
+      <div class="octocat-spinner my-6 js-details-dialog-spinner"></div>
+    </details-dialog>
+  </details>
+</template>
+
+  <div class="Popover js-hovercard-content position-absolute" style="display: none; outline: none;" tabindex="0">
+  <div class="Popover-message Popover-message--bottom-left Popover-message--large Box box-shadow-large" style="width:360px;">
+  </div>
+</div>
+
+  
+  <div class="js-notification-shelf-not-found-error" hidden></div>
+
+  <div aria-live="polite" class="js-global-screen-reader-notice sr-only"></div>
+
+  </body>
+</html>
+

--- a/spec-main/package.json
+++ b/spec-main/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "chai-as-promised": "^7.1.1",
-    "dirty-chai": "^2.0.1"
+    "dirty-chai": "^2.0.1",
+    "pdfjs-dist": "^2.2.228"
   }
 }

--- a/spec-main/yarn.lock
+++ b/spec-main/yarn.lock
@@ -2,6 +2,26 @@
 # yarn lockfile v1
 
 
+ajv-keywords@^3.1.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
+  integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
+
+ajv@^6.1.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.11.0.tgz#c3607cbc8ae392d8a5a536f25b21f8e5f3f87fe9"
+  integrity sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+big.js@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
+  integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
+
 chai-as-promised@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
@@ -22,7 +42,89 @@ dirty-chai@^2.0.1:
 "echo@file:fixtures/native-addon/echo":
   version "0.0.1"
 
+emojis-list@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
+  integrity sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
+
+fast-deep-equal@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
+  integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
+  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
+  dependencies:
+    minimist "^1.2.0"
+
+loader-utils@^1.0.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
+  integrity sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^2.0.0"
+    json5 "^1.0.1"
+
+minimist@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
+
+node-ensure@^0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/node-ensure/-/node-ensure-0.0.0.tgz#ecae764150de99861ec5c810fd5d096b183932a7"
+  integrity sha1-7K52QVDemYYexcgQ/V0Jaxg5Mqc=
+
+pdfjs-dist@^2.2.228:
+  version "2.2.228"
+  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.2.228.tgz#777b068a0a16c96418433303807c183058b47aaa"
+  integrity sha512-W5LhYPMS2UKX0ELIa4u+CFCMoox5qQNQElt0bAK2mwz1V8jZL0rvLao+0tBujce84PK6PvWG36Nwr7agCCWFGQ==
+  dependencies:
+    node-ensure "^0.0.0"
+    worker-loader "^2.0.0"
+
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
 q@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
+
+schema-utils@^0.4.0:
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
+  integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
+  dependencies:
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+
+uri-js@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  dependencies:
+    punycode "^2.1.0"
+
+worker-loader@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-2.0.0.tgz#45fda3ef76aca815771a89107399ee4119b430ac"
+  integrity sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==
+  dependencies:
+    loader-utils "^1.0.0"
+    schema-utils "^0.4.0"


### PR DESCRIPTION
#### Description of Change

In the interest of better testing our printing code, we should be testing some of the actual substance of the output of `printToPDF`, not just that it throws correct errors for incorrect parameters.

This PR adds one new dependency in `spec-main`, `pdfjs-dist`, which is Mozilla's PDF library in order to test that parameters passed to `contents.printToPDF()` take the desired effect. This will provide a far better alarm for potential upstream breakages to functionality in `contents.printToPDF()`.

cc @ckerr @nornagon @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
