### PR TITLE
fix: ensure web_contents is not nullptr in UpdateDraggableRegions

### DIFF
--- a/shell/browser/api/atom_api_browser_window_mac.mm
+++ b/shell/browser/api/atom_api_browser_window_mac.mm
@@ -78,7 +78,7 @@ void BrowserWindow::UpdateDraggableRegions(
     const std::vector<mojom::DraggableRegionPtr>& regions) {
   if (window_->has_frame())
     return;
-  
+
   if (!web_contents())
     return;
 

--- a/shell/browser/api/atom_api_browser_window_mac.mm
+++ b/shell/browser/api/atom_api_browser_window_mac.mm
@@ -78,6 +78,8 @@ void BrowserWindow::UpdateDraggableRegions(
     const std::vector<mojom::DraggableRegionPtr>& regions) {
   if (window_->has_frame())
     return;
+  
+  if (!web_contents()) return;
 
   // All ControlRegionViews should be added as children of the WebContentsView,
   // because WebContentsView will be removed and re-added when entering and

--- a/shell/browser/api/atom_api_browser_window_mac.mm
+++ b/shell/browser/api/atom_api_browser_window_mac.mm
@@ -79,7 +79,8 @@ void BrowserWindow::UpdateDraggableRegions(
   if (window_->has_frame())
     return;
   
-  if (!web_contents()) return;
+  if (!web_contents())
+    return;
 
   // All ControlRegionViews should be added as children of the WebContentsView,
   // because WebContentsView will be removed and re-added when entering and


### PR DESCRIPTION
This is a speculative fix for a crash in `UpdateDraggableRegions` that we've noticed.  No notes because it's speculative.

Ref #21005

Notes: no-notes
