### PR TITLE
docs: windows don't need to be retained

### DIFF
--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -15,12 +15,9 @@ relative to its owning window. It is meant to be an alternative to the
 // In the main process.
 const { BrowserView, BrowserWindow } = require('electron')
 
-let win = new BrowserWindow({ width: 800, height: 600 })
-win.on('closed', () => {
-  win = null
-})
+const win = new BrowserWindow({ width: 800, height: 600 })
 
-let view = new BrowserView()
+const view = new BrowserView()
 win.setBrowserView(view)
 view.setBounds({ x: 0, y: 0, width: 300, height: 300 })
 view.webContents.loadURL('https://electronjs.org')

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -11,10 +11,7 @@ const { BrowserWindow } = require('electron')
 // Or use `remote` from the renderer process.
 // const { BrowserWindow } = require('electron').remote
 
-let win = new BrowserWindow({ width: 800, height: 600 })
-win.on('closed', () => {
-  win = null
-})
+const win = new BrowserWindow({ width: 800, height: 600 })
 
 // Load a remote URL
 win.loadURL('https://github.com')

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -64,9 +64,9 @@ require('electron').remote.getGlobal('sharedObject').someProperty = 'new value'
 console.log(require('electron').remote.getGlobal('sharedObject').someProperty)
 ```
 
-## My app's window/tray disappeared after a few minutes.
+## My app's tray disappeared after a few minutes.
 
-This happens when the variable which is used to store the window/tray gets
+This happens when the variable which is used to store the tray gets
 garbage collected.
 
 If you encounter this problem, the following articles may prove helpful:

--- a/docs/tutorial/first-app.md
+++ b/docs/tutorial/first-app.md
@@ -132,13 +132,9 @@ windows on macOS if the user clicks on the app's icon in the dock.
 ```javascript
 const { app, BrowserWindow } = require('electron')
 
-// Keep a global reference of the window object, if you don't, the window will
-// be closed automatically when the JavaScript object is garbage collected.
-let win
-
 function createWindow () {
   // Create the browser window.
-  win = new BrowserWindow({
+  const win = new BrowserWindow({
     width: 800,
     height: 600,
     webPreferences: {
@@ -151,14 +147,6 @@ function createWindow () {
 
   // Open the DevTools.
   win.webContents.openDevTools()
-
-  // Emitted when the window is closed.
-  win.on('closed', () => {
-    // Dereference the window object, usually you would store windows
-    // in an array if your app supports multi windows, this is the time
-    // when you should delete the corresponding element.
-    win = null
-  })
 }
 
 // This method will be called when Electron has finished
@@ -178,7 +166,7 @@ app.on('window-all-closed', () => {
 app.on('activate', () => {
   // On macOS it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
-  if (win === null) {
+  if (BrowserWindow.getAllWindows().length === 0) {
     createWindow()
   }
 })


### PR DESCRIPTION
#### Description of Change
BrowserWindows retain references to themselves at least until they're closed, so this isn't an issue for windows.

It remains an issue for Tray, at least for now, though I think that's something we should address if possible.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none