### PR TITLE
fix: add executable to ChromeDriver's rpath for electron 8+

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -803,6 +803,10 @@ if (is_mac) {
         "@executable_path/../../../../../..",
       ]
     }
+    ldflags += [
+      "-rpath",
+      "@executable_path/.",
+    ]
   }
 
   template("electron_helper_app") {
@@ -1240,11 +1244,29 @@ dist_zip("electron_ffmpeg_zip") {
   outputs = [ "$root_build_dir/ffmpeg.zip" ]
 }
 
+executable("erick-chromedriver") {
+  testonly = true
+  sources = [ "//chrome/test/chromedriver/server/chromedriver_server.cc" ]
+  deps = [
+    "//build/win:default_exe_manifest",
+    "//chrome/test/chromedriver:lib",
+    "//mojo/core/embedder",
+
+    # "//net/server:http_server",
+    "//net/traffic_annotation:test_support",
+    "//services/network/public/mojom",
+  ]
+  ldflags = [
+    "-rpath",
+    "@executable_path/.",
+  ]
+}
+
 dist_zip("electron_chromedriver_zip") {
   testonly = true
   data_deps = [
+    ":erick-chromedriver",
     ":licenses",
-    "//chrome/test/chromedriver",
   ]
   outputs = [ "$root_build_dir/chromedriver.zip" ]
 }

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -803,10 +803,6 @@ if (is_mac) {
         "@executable_path/../../../../../..",
       ]
     }
-    ldflags += [
-      "-rpath",
-      "@executable_path/.",
-    ]
   }
 
   template("electron_helper_app") {
@@ -1244,29 +1240,11 @@ dist_zip("electron_ffmpeg_zip") {
   outputs = [ "$root_build_dir/ffmpeg.zip" ]
 }
 
-executable("erick-chromedriver") {
-  testonly = true
-  sources = [ "//chrome/test/chromedriver/server/chromedriver_server.cc" ]
-  deps = [
-    "//build/win:default_exe_manifest",
-    "//chrome/test/chromedriver:lib",
-    "//mojo/core/embedder",
-
-    # "//net/server:http_server",
-    "//net/traffic_annotation:test_support",
-    "//services/network/public/mojom",
-  ]
-  ldflags = [
-    "-rpath",
-    "@executable_path/.",
-  ]
-}
-
 dist_zip("electron_chromedriver_zip") {
   testonly = true
   data_deps = [
-    ":erick-chromedriver",
     ":licenses",
+    "//chrome/test/chromedriver",
   ]
   outputs = [ "$root_build_dir/chromedriver.zip" ]
 }

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -80,3 +80,4 @@ add_trustedauthclient_to_urlloaderfactory.patch
 feat_allow_disabling_blink_scheduler_throttling_per_renderview.patch
 accessible_pane_view.patch
 fixme_grit_conflicts.patch
+fix_add_executable_to_chromedriver_s_rpath_for_electron_8.patch

--- a/patches/chromium/fix_add_executable_to_chromedriver_s_rpath_for_electron_8.patch
+++ b/patches/chromium/fix_add_executable_to_chromedriver_s_rpath_for_electron_8.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Erick Zhao <ezhao@slack-corp.com>
+Date: Wed, 29 Jan 2020 14:21:15 -0800
+Subject: fix: add executable to chromedriver's rpath for electron 8+
+
+Chromedriver errors on startup for Electron 8+ because FFmpeg
+is not included. Adding the executable path to rpath fixes the
+issue.
+
+This is in patch form rather than copying the executable command
+in Electron's BUILD.gn because one of Chromedriver's deps
+(//net/server:http_server) hsa a visibility list that Electron
+is not on.
+
+diff --git a/chrome/test/chromedriver/BUILD.gn b/chrome/test/chromedriver/BUILD.gn
+index 1ce029a1ba3ec9da3527008d8c2b38446ab4b2f3..de2cc3074fef3d75f041ec8230bd18d3827192cc 100644
+--- a/chrome/test/chromedriver/BUILD.gn
++++ b/chrome/test/chromedriver/BUILD.gn
+@@ -330,6 +330,13 @@ executable("chromedriver") {
+     "//net/traffic_annotation:test_support",
+     "//services/network/public/mojom",
+   ]
++  # Fixes bad rpath on Electron 8+
++  if (is_mac) {
++    ldflags = [
++      "-rpath",
++      "@executable_path/.",
++    ]
++  }
+ }
+ 
+ python_library("chromedriver_py_tests") {


### PR DESCRIPTION
#### Description of Change
Fixes #21881.

Chromedriver errors on startup for Electron 8+ because FFmpeg is not included. Adding the executable path to rpath fixes the issue.

This is in patch form rather than copying the executable command in Electron's BUILD.gn because one of Chromedriver's deps `//net/server:http_server` has a visibility list that Electron is not on.

Testing the output of `e build chromedriver` locally gives a good ✅ output.

```console
☁  Testing  ./chromedriver       
Starting ChromeDriver 81.0.4041.0 (98538fdd28c4b6692e4cc2839729bb7ac009586a-refs/heads/master@{#735355}) on port 9515
Only local connections are allowed.
Please protect ports used by ChromeDriver and related test frameworks to prevent access by malicious code.
```

cc @MarshallOfSound (thanks for the help!)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] ~tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)~ Not sure if relevant?
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed build issue where ChromeDriver would fail to start
