### PR TITLE
fix: don't crash on invalid certs

### DIFF
--- a/shell/browser/api/atom_api_app.cc
+++ b/shell/browser/api/atom_api_app.cc
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#inculde "base/callback_helpers.h"
 #include "base/command_line.h"
 #include "base/environment.h"
 #include "base/files/file_path.h"
@@ -698,15 +699,17 @@ void App::AllowCertificateError(
     bool is_main_frame_request,
     bool strict_enforcement,
     base::OnceCallback<void(content::CertificateRequestResultType)> callback) {
+  auto adapted_callback = base::AdaptCallbackForRepeating(std::move(callback));
   v8::Locker locker(isolate());
   v8::HandleScope handle_scope(isolate());
   bool prevent_default = Emit(
       "certificate-error", WebContents::FromOrCreate(isolate(), web_contents),
-      request_url, net::ErrorToString(cert_error), ssl_info.cert, callback);
+      request_url, net::ErrorToString(cert_error), ssl_info.cert,
+      adapted_callback);
 
   // Deny the certificate by default.
   if (!prevent_default)
-    std::move(callback).Run(content::CERTIFICATE_REQUEST_RESULT_TYPE_DENY);
+    adapted_callback.Run(content::CERTIFICATE_REQUEST_RESULT_TYPE_DENY);
 }
 
 base::OnceClosure App::SelectClientCertificate(

--- a/shell/browser/api/atom_api_app.cc
+++ b/shell/browser/api/atom_api_app.cc
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-#inculde "base/callback_helpers.h"
+#include "base/callback_helpers.h"
 #include "base/command_line.h"
 #include "base/environment.h"
 #include "base/files/file_path.h"
@@ -702,10 +702,10 @@ void App::AllowCertificateError(
   auto adapted_callback = base::AdaptCallbackForRepeating(std::move(callback));
   v8::Locker locker(isolate());
   v8::HandleScope handle_scope(isolate());
-  bool prevent_default = Emit(
-      "certificate-error", WebContents::FromOrCreate(isolate(), web_contents),
-      request_url, net::ErrorToString(cert_error), ssl_info.cert,
-      adapted_callback);
+  bool prevent_default =
+      Emit("certificate-error",
+           WebContents::FromOrCreate(isolate(), web_contents), request_url,
+           net::ErrorToString(cert_error), ssl_info.cert, adapted_callback);
 
   // Deny the certificate by default.
   if (!prevent_default)


### PR DESCRIPTION
#### Description of Change
Fixes #21973.

Looks like this probably got messed up with a Chromium roll. The OnceCallback can't be passed to two places.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash that could occur when visiting HTTPS sites with invalid certificates.