### PR TITLE
feat: allow macOS apps to set activation policies

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -994,6 +994,17 @@ Updates the current activity if its type matches `type`, merging the entries fro
 
 Changes the [Application User Model ID][app-user-model-id] to `id`.
 
+### `app.setActivationPolicy(policy)` _macOS_
+
+* `policy` String - Can be 'regular', 'accessory', or 'prohibited'.
+
+Sets the activation policy for a given app.
+
+Activation policy types:
+* 'regular' - The application is an ordinary app that appears in the Dock and may have a user interface.
+* 'accessory' - The application doesn’t appear in the Dock and doesn’t have a menu bar, but it may be activated programmatically or by clicking on one of its windows.
+* 'prohibited' - The application doesn’t appear in the Dock and may not create windows or be activated.
+
 ### `app.importCertificate(options, callback)` _Linux_
 
 * `options` Object

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1459,6 +1459,7 @@ void App::BuildPrototype(v8::Isolate* isolate,
                  base::BindRepeating(&Browser::UpdateCurrentActivity, browser))
       .SetMethod("moveToApplicationsFolder", &App::MoveToApplicationsFolder)
       .SetMethod("isInApplicationsFolder", &App::IsInApplicationsFolder)
+      .SetMethod("setActivationPolicy", &App::SetActivationPolicy)
 #endif
       .SetMethod("setAboutPanelOptions",
                  base::BindRepeating(&Browser::SetAboutPanelOptions, browser))

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -201,6 +201,8 @@ class App : public ElectronBrowserClient::Delegate,
   bool CanBrowserClientUseCustomSiteInstance();
 
 #if defined(OS_MACOSX)
+  void SetActivationPolicy(gin_helper::ErrorThrower thrower,
+                           const std::string& policy);
   bool MoveToApplicationsFolder(gin_helper::ErrorThrower, gin::Arguments* args);
   bool IsInApplicationsFolder();
   v8::Local<v8::Value> GetDockAPI(v8::Isolate* isolate);

--- a/shell/browser/api/electron_api_app_mac.mm
+++ b/shell/browser/api/electron_api_app_mac.mm
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <string>
+
 #include "base/path_service.h"
 #include "shell/browser/api/electron_api_app.h"
 #include "shell/browser/electron_paths.h"
@@ -30,6 +32,24 @@ void App::SetAppLogsPath(gin_helper::ErrorThrower thrower,
     base::PathService::Override(DIR_APP_LOGS,
                                 base::FilePath([library_path UTF8String]));
   }
+}
+
+void App::SetActivationPolicy(gin_helper::ErrorThrower thrower,
+                              const std::string& policy) {
+  NSApplicationActivationPolicy activation_policy;
+  if (policy == "accessory") {
+    activation_policy = NSApplicationActivationPolicyAccessory;
+  } else if (policy == "prohibited") {
+    activation_policy = NSApplicationActivationPolicyProhibited;
+  } else if (policy == "regular") {
+    activation_policy = NSApplicationActivationPolicyRegular;
+  } else {
+    thrower.ThrowError("Invalid activation policy: must be one of 'regular', "
+                       "'accessory', or 'prohibited'");
+    return;
+  }
+
+  [NSApp setActivationPolicy:activation_policy];
 }
 
 }  // namespace api

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -202,6 +202,14 @@ describe('app module', () => {
     })
   })
 
+  ifdescribe(process.platform === 'darwin')('app.setActivationPolicy', () => {
+    it('throws an error on invalid application policies', () => {
+      expect(() => {
+        app.setActivationPolicy('terrible' as any)
+      }).to.throw(/Invalid activation policy: must be one of 'regular', 'accessory', or 'prohibited'/)
+    })
+  })
+
   describe('app.requestSingleInstanceLock', () => {
     it('prevents the second launch of app', function (done) {
       this.timeout(120000)


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/21970.

Right now, we allow users access to some dock functionality by hooking into pretty low-level components, but that can cause bugs as evidenced [here](https://github.com/electron/electron/issues/19896), [here](https://github.com/electron/electron/issues/16093), and [here](https://github.com/electron/electron/issues/21810). For apps that want to set more clear and understandable app activation policies, this new small function on `app`, `setActivationPolicy`, should allow them to do that without adding much API maintenance or surface area for bugs.

Alternatives considered:
* Apps can set the [`LSUIElement`](https://developer.apple.com/documentation/bundleresources/information_property_list/lsuielement?language=objc) value to indicate that their app is an agent app that runs in the background, but that's not intuitive by comparison

cc @zcbenz @MarshallOfSound @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added the ability to set app activation policy on `macOS`.
