### PR TITLE
fix: return path from netLog.stopLogging

### DIFF
--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -36,8 +36,9 @@ NetLog.prototype.startLogging = function (path, ...args) {
 
 const _originalStopLogging = NetLog.prototype.stopLogging
 NetLog.prototype.stopLogging = function () {
+  const logPath = this._currentlyLoggingPath
   this._currentlyLoggingPath = null
-  return _originalStopLogging.call(this)
+  return _originalStopLogging.call(this).then(() => logPath)
 }
 
 const currentlyLoggingPathDeprecated = deprecate.warnOnce('currentlyLoggingPath')

--- a/spec-main/api-net-log-spec.ts
+++ b/spec-main/api-net-log-spec.ts
@@ -71,7 +71,8 @@ describe('netLog module', () => {
 
     expect(testNetLog().currentlyLoggingPath).to.equal(dumpFileDynamic)
 
-    await testNetLog().stopLogging()
+    const path = await testNetLog().stopLogging()
+    expect(path).to.equal(dumpFileDynamic)
 
     expect(fs.existsSync(dumpFileDynamic)).to.be.true('currently logging')
   })


### PR DESCRIPTION
#### Description of Change
The docs say we return a string, so let's do that. This was broken by the refactor in #18289.

It's a bit weird that we save the path on behalf of the user—all we're doing is keeping track of the value they passed in. That should really be the responsibility of the user, not the API, but since that's how it's documented to work, we might as well make it work the way the docs say (and the way it used to work).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed netLog.stopLogging returning undefined instead of the path to the log.