### PR TITLE
ci: make sure mksnapshot is invoked with proper args.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -570,7 +570,6 @@ step-mksnapshot-build: &step-mksnapshot-build
       cd src
       ninja -C out/Default electron:electron_mksnapshot -j $NUMBER_OF_NINJA_PROCESSES
       gn desc out/Default v8:run_mksnapshot_default args > out/Default/mksnapshot_args
-      cat out/Default/mksnapshot_args
       if [ "`uname`" != "Darwin" ]; then
         if [ "$TARGET_ARCH" == "arm" ]; then
           electron/script/strip-binaries.py --file $PWD/out/Default/clang_x86_v8_arm/mksnapshot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -569,6 +569,8 @@ step-mksnapshot-build: &step-mksnapshot-build
     command: |
       cd src
       ninja -C out/Default electron:electron_mksnapshot -j $NUMBER_OF_NINJA_PROCESSES
+      gn desc out/Default v8:run_mksnapshot_default args > out/Default/mksnapshot_args
+      cat out/Default/mksnapshot_args
       if [ "`uname`" != "Darwin" ]; then
         if [ "$TARGET_ARCH" == "arm" ]; then
           electron/script/strip-binaries.py --file $PWD/out/Default/clang_x86_v8_arm/mksnapshot
@@ -581,7 +583,6 @@ step-mksnapshot-build: &step-mksnapshot-build
       fi
       if [ "$SKIP_DIST_ZIP" != "1" ]; then
         ninja -C out/Default electron:electron_mksnapshot_zip -j $NUMBER_OF_NINJA_PROCESSES
-        gn desc out/Default v8:run_mksnapshot_default args > out/Default/mksnapshot_args
         (cd out/Default; zip mksnapshot.zip mksnapshot_args)
       fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -583,7 +583,7 @@ step-mksnapshot-build: &step-mksnapshot-build
       fi
       if [ "$SKIP_DIST_ZIP" != "1" ]; then
         ninja -C out/Default electron:electron_mksnapshot_zip -j $NUMBER_OF_NINJA_PROCESSES
-        (cd out/Default; zip mksnapshot.zip mksnapshot_args)
+        (cd out/Default; zip mksnapshot.zip mksnapshot_args gen/v8/embedded.S)
       fi
 
 step-mksnapshot-store: &step-mksnapshot-store

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -581,6 +581,8 @@ step-mksnapshot-build: &step-mksnapshot-build
       fi
       if [ "$SKIP_DIST_ZIP" != "1" ]; then
         ninja -C out/Default electron:electron_mksnapshot_zip -j $NUMBER_OF_NINJA_PROCESSES
+        gn desc out/Default v8:run_mksnapshot_default args > out/Default/mksnapshot_args
+        (cd out/Default; zip mksnapshot.zip mksnapshot_args)
       fi
 
 step-mksnapshot-store: &step-mksnapshot-store

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -187,7 +187,8 @@ test_script:
   - if "%RUN_TESTS%"=="true" ( echo Running test suite & node script/yarn test -- --enable-logging)
   - cd ..
   - if "%RUN_TESTS%"=="true" ( echo Verifying non proprietary ffmpeg & python electron\script\verify-ffmpeg.py --build-dir out\Default --source-root %cd% --ffmpeg-path out\ffmpeg )
-  - echo "About to verify mksnapshot"
+  - echo "About to verify mksnapshot"  
+  - if "%RUN_TESTS%"=="true" ( gn desc out\Default v8:run_mksnapshot_default args > out\Default\mksnapshot_args )
   - if "%RUN_TESTS%"=="true" ( echo Verifying mksnapshot & python electron\script\verify-mksnapshot.py --build-dir out\Default --source-root %cd% )
   - echo "Done verifying mksnapshot"
 deploy_script:

--- a/script/verify-mksnapshot.py
+++ b/script/verify-mksnapshot.py
@@ -30,7 +30,7 @@ def main():
           mkargs = f.readlines()
         print(mkargs, sep = ", ")
         subprocess.check_call(mkargs + [ SNAPSHOT_SOURCE ], cwd=app_path)
-        print 'ok mksnapshot successfully created snapshot_blob.bin.'
+        print('ok mksnapshot successfully created snapshot_blob.bin.')
         context_snapshot = 'v8_context_snapshot.bin'
         context_snapshot_path = os.path.join(app_path, context_snapshot)
         gen_binary = get_binary_path('v8_context_snapshot_generator', \

--- a/script/verify-mksnapshot.py
+++ b/script/verify-mksnapshot.py
@@ -28,7 +28,7 @@ def main():
       if args.snapshot_files_dir is None:
         with open(os.path.join(app_path, 'mksnapshot_args')) as f:
           mkargs = f.readlines()
-        print mkargs
+        print(mkargs, sep = ", ")
         subprocess.check_call(mkargs + [ SNAPSHOT_SOURCE ], cwd=app_path)
         print 'ok mksnapshot successfully created snapshot_blob.bin.'
         context_snapshot = 'v8_context_snapshot.bin'

--- a/script/verify-mksnapshot.py
+++ b/script/verify-mksnapshot.py
@@ -27,7 +27,7 @@ def main():
     with scoped_cwd(app_path):
       if args.snapshot_files_dir is None:
         with open(os.path.join(app_path, 'mksnapshot_args')) as f:
-          mkargs = f.readlines()
+          mkargs = file.read().splitlines()
         print(mkargs, sep = ", ")
         subprocess.check_call(mkargs + [ SNAPSHOT_SOURCE ], cwd=app_path)
         print('ok mksnapshot successfully created snapshot_blob.bin.')

--- a/script/verify-mksnapshot.py
+++ b/script/verify-mksnapshot.py
@@ -28,6 +28,7 @@ def main():
       if args.snapshot_files_dir is None:
         with open(os.path.join(app_path, 'mksnapshot_args')) as f:
           mkargs = f.readlines()
+        print mkargs
         subprocess.check_call(mkargs + [ SNAPSHOT_SOURCE ], cwd=app_path)
         print 'ok mksnapshot successfully created snapshot_blob.bin.'
         context_snapshot = 'v8_context_snapshot.bin'

--- a/script/verify-mksnapshot.py
+++ b/script/verify-mksnapshot.py
@@ -27,7 +27,7 @@ def main():
     with scoped_cwd(app_path):
       if args.snapshot_files_dir is None:
         with open(os.path.join(app_path, 'mksnapshot_args')) as f:
-          mkargs = file.read().splitlines()
+          mkargs = f.read().splitlines()
         print(mkargs, sep = ", ")
         subprocess.check_call(mkargs + [ SNAPSHOT_SOURCE ], cwd=app_path)
         print('ok mksnapshot successfully created snapshot_blob.bin.')

--- a/script/verify-mksnapshot.py
+++ b/script/verify-mksnapshot.py
@@ -26,13 +26,10 @@ def main():
   try:
     with scoped_cwd(app_path):
       if args.snapshot_files_dir is None:
-        mkargs = [ get_binary_path('mksnapshot', app_path), \
-                    SNAPSHOT_SOURCE, '--startup_blob', 'snapshot_blob.bin', \
-                    '--no-native-code-counters', '--turbo_instruction_scheduling' ]
-        if get_target_arch() == 'ia32':
-          mkargs.append('--target_arch=x86')
-        subprocess.check_call(mkargs)
-        print('ok mksnapshot successfully created snapshot_blob.bin.')
+        with open(os.path.join(app_path, 'mksnapshot_args')) as f:
+          mkargs = f.readlines()
+        subprocess.check_call(mkargs + [ SNAPSHOT_SOURCE ], cwd=app_path)
+        print 'ok mksnapshot successfully created snapshot_blob.bin.'
         context_snapshot = 'v8_context_snapshot.bin'
         context_snapshot_path = os.path.join(app_path, context_snapshot)
         gen_binary = get_binary_path('v8_context_snapshot_generator', \

--- a/script/verify-mksnapshot.py
+++ b/script/verify-mksnapshot.py
@@ -28,7 +28,6 @@ def main():
       if args.snapshot_files_dir is None:
         with open(os.path.join(app_path, 'mksnapshot_args')) as f:
           mkargs = f.read().splitlines()
-        print(mkargs, sep = ", ")
         subprocess.check_call(mkargs + [ SNAPSHOT_SOURCE ], cwd=app_path)
         print('ok mksnapshot successfully created snapshot_blob.bin.')
         context_snapshot = 'v8_context_snapshot.bin'


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
This is a continuation of the work started in #17870.
mksnapshot must be run with the same arguments that generated the original mksnapshot, otherwise crashes happen. We currently ensure that these are the same by hand. This makes them the same by definition.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
