### PR TITLE
docs: Adding Github Actions to headless testing documentation

### DIFF
--- a/docs/tutorial/testing-on-headless-ci.md
+++ b/docs/tutorial/testing-on-headless-ci.md
@@ -1,4 +1,4 @@
-# Testing on Headless CI Systems (Travis CI, Jenkins)
+# Testing on Headless CI Systems (Travis CI, Github Actions, Jenkins)
 
 Being based on Chromium, Electron requires a display driver to function.
 If Chromium can't find a display driver, Electron will fail to launch -
@@ -44,6 +44,10 @@ install:
   - export DISPLAY=':99.0'
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 ```
+
+### Github Actions
+
+For Github Actions, a [Xvfb action is available](https://github.com/marketplace/actions/gabrielbb-xvfb-action).
 
 ### Jenkins
 


### PR DESCRIPTION
notes: Adding Github Actions to headless testing documentation

I just published a Github Action to run tests with XVFB. I'm adding it to the documentation since the other CI systems are there