### PR TITLE
fix: remove cyclic references of BrowserWindow

### DIFF
--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -25,26 +25,6 @@ BrowserWindow.prototype._init = function () {
     nativeSetBounds.call(this, bounds, ...opts)
   }
 
-  // window.resizeTo(...)
-  // window.moveTo(...)
-  this.webContents.on('move', (event, size) => {
-    this.setBounds(size)
-  })
-
-  // Hide the auto-hide menu when webContents is focused.
-  this.webContents.on('activate', () => {
-    if (process.platform !== 'darwin' && this.autoHideMenuBar && this.isMenuBarVisible()) {
-      this.setMenuBarVisibility(false)
-    }
-  })
-
-  // Change window title to page title.
-  this.webContents.on('page-title-updated', (event, title, ...args) => {
-    // Route the event to BrowserWindow.
-    this.emit('page-title-updated', event, title, ...args)
-    if (!this.isDestroyed() && !event.defaultPrevented) this.setTitle(title)
-  })
-
   // Sometimes the webContents doesn't get focus when window is shown, so we
   // have to force focusing on webContents in this case. The safest way is to
   // focus it when we first start to load URL, if we do it earlier it won't

--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -57,6 +57,10 @@ class BrowserWindow : public TopLevelWindow,
   void OnRendererResponsive() override;
   void OnDraggableRegionsUpdated(
       const std::vector<mojom::DraggableRegionPtr>& regions) override;
+  void OnSetContentBounds(const gfx::Rect& rect) override;
+  void OnActivateContents() override;
+  void OnPageTitleUpdated(const base::string16& title,
+                          bool explicit_set) override;
 
   // NativeWindowObserver:
   void RequestPreferredWidth(int* width) override;

--- a/shell/browser/api/electron_api_top_level_window.cc
+++ b/shell/browser/api/electron_api_top_level_window.cc
@@ -120,6 +120,9 @@ TopLevelWindow::~TopLevelWindow() {
   // Destroy the native window in next tick because the native code might be
   // iterating all windows.
   base::ThreadTaskRunnerHandle::Get()->DeleteSoon(FROM_HERE, window_.release());
+
+  // Remove global reference so the JS object can be garbage collected.
+  self_ref_.Reset();
 }
 
 void TopLevelWindow::InitWith(v8::Isolate* isolate,
@@ -135,6 +138,9 @@ void TopLevelWindow::InitWith(v8::Isolate* isolate,
     DCHECK(!parent.IsEmpty());
     parent->child_windows_.Set(isolate, weak_map_id(), wrapper);
   }
+
+  // Reference this object in case it got garbage collected.
+  self_ref_.Reset(isolate, wrapper);
 }
 
 void TopLevelWindow::WillCloseWindow(bool* prevent_default) {

--- a/shell/browser/api/electron_api_top_level_window.h
+++ b/shell/browser/api/electron_api_top_level_window.h
@@ -259,6 +259,9 @@ class TopLevelWindow : public gin_helper::TrackableObject<TopLevelWindow>,
 
   std::unique_ptr<NativeWindow> window_;
 
+  // Reference to JS wrapper to prevent garbage collection.
+  v8::Global<v8::Value> self_ref_;
+
   base::WeakPtrFactory<TopLevelWindow> weak_factory_;
 };
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -705,8 +705,9 @@ void WebContents::BeforeUnloadFired(content::WebContents* tab,
 }
 
 void WebContents::SetContentsBounds(content::WebContents* source,
-                                    const gfx::Rect& pos) {
-  Emit("move", pos);
+                                    const gfx::Rect& rect) {
+  for (ExtendedWebContentsObserver& observer : observers_)
+    observer.OnSetContentBounds(rect);
 }
 
 void WebContents::CloseContents(content::WebContents* source) {
@@ -725,7 +726,8 @@ void WebContents::CloseContents(content::WebContents* source) {
 }
 
 void WebContents::ActivateContents(content::WebContents* source) {
-  Emit("activate");
+  for (ExtendedWebContentsObserver& observer : observers_)
+    observer.OnActivateContents();
 }
 
 void WebContents::UpdateTargetURL(content::WebContents* source,
@@ -1228,6 +1230,8 @@ void WebContents::TitleWasSet(content::NavigationEntry* entry) {
       final_title = title;
     }
   }
+  for (ExtendedWebContentsObserver& observer : observers_)
+    observer.OnPageTitleUpdated(final_title, explicit_set);
   Emit("page-title-updated", final_title, explicit_set);
 }
 

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -81,6 +81,10 @@ class ExtendedWebContentsObserver : public base::CheckedObserver {
   virtual void OnRendererResponsive() {}
   virtual void OnDraggableRegionsUpdated(
       const std::vector<mojom::DraggableRegionPtr>& regions) {}
+  virtual void OnSetContentBounds(const gfx::Rect& rect) {}
+  virtual void OnActivateContents() {}
+  virtual void OnPageTitleUpdated(const base::string16& title,
+                                  bool explicit_set) {}
 
  protected:
   ~ExtendedWebContentsObserver() override {}

--- a/shell/common/api/electron_api_v8_util.cc
+++ b/shell/common/api/electron_api_v8_util.cc
@@ -126,12 +126,12 @@ void Initialize(v8::Local<v8::Object> exports,
                  &electron::RemoteCallbackFreer::BindTo);
   dict.SetMethod("setRemoteObjectFreer", &electron::RemoteObjectFreer::BindTo);
   dict.SetMethod("addRemoteObjectRef", &electron::RemoteObjectFreer::AddRef);
-  dict.SetMethod("createIDWeakMap",
-                 &electron::api::KeyWeakMap<int32_t>::Create);
   dict.SetMethod(
       "createDoubleIDWeakMap",
       &electron::api::KeyWeakMap<std::pair<std::string, int32_t>>::Create);
 #endif
+  dict.SetMethod("createIDWeakMap",
+                 &electron::api::KeyWeakMap<int32_t>::Create);
   dict.SetMethod("requestGarbageCollectionForTesting",
                  &RequestGarbageCollectionForTesting);
   dict.SetMethod("isSameOrigin", &IsSameOrigin);


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/21957.

This PR fixes the cyclic references caused by WebContents referencing the owning window. The fix is implemented with C++, as weak reference would be much more complicated with JavaScript, and it also has the benefit of avoiding exposing internal implementation to public JavaScript.

And in order to align with previous behavior that the window does not get garbage collected when opened, the window is now explicitly referenced by a global map, and explicitly removed from the map when closed.

Note that memory taken by JavaScript objects can only be freed via garbage collection, so even though the native window object is freed when closed, the corresponding JavaScript objects would still be leaked if cyclic references happens, and this fix is required to ensure memory used by the `BrowserWindow` and `WebContents` JavaScript objects are not leaked. 

For the tests, ideally we should have a test to ensure window does get garbage collected when closed, however by inserting the window to a global map, the object would be moved to different garbage collection phase, and it becomes uncertain when it would be garbage collected. Currently I can only manually verify the window would be garbage collected eventually.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix the JavaScript object of `BrowserWindow` not garbage collected when window is closed.