### PR TITLE
docs: correct the usage of China mirror

### DIFF
--- a/docs/tutorial/installation.md
+++ b/docs/tutorial/installation.md
@@ -66,7 +66,8 @@ url = ELECTRON_MIRROR + ELECTRON_CUSTOM_DIR + '/' + ELECTRON_CUSTOM_FILENAME
 For instance, to use the China mirror:
 
 ```plaintext
-ELECTRON_MIRROR="https://cdn.npm.taobao.org/dist/electron/"
+ELECTRON_MIRROR="https://npm.taobao.org/mirrors/electron/"
+ELECTRON_CUSTOM_DIR="7.1.11"
 ```
 
 #### Cache


### PR DESCRIPTION
#### Description of Change

Change the mirror URL to the newest.

And also, because of the electron version dirs in Taobao mirror doesn't with a **`v`** prefix. Refer to the handling method of `electronic/get`:

https://github.com/electron/get/blob/ba2119f4b15e33f64f11b054add51d8491d1264a/src/utils.ts#L32

```ts
export function normalizeVersion(version: string) {
  if (!version.startsWith('v')) {
    return `v${version}`;
  }
  return version;
}
```

This will make `electron/get` can't find the corresponding download link. So, it's needed to specific ELECTRON_CUSTOM_DIR to which version you want to use.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Correct the usage of the China mirror.
