### PR TITLE
fix: default printer if none is provided

### DIFF
--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -615,27 +615,6 @@ index a432a1e007111d6c13c76255aa445d05b869e46c..3f66fd39345998fd11d0fd383b4262cc
  
  #if BUILDFLAG(ENABLE_PRINT_PREVIEW)
    // Set options for print preset from source PDF document.
-diff --git a/printing/print_settings_conversion.cc b/printing/print_settings_conversion.cc
-index e01d195261a4c993dddb77d7a355481bf02067cc..2e533a6981c86387f892f8a3aaed99478f6079ef 100644
---- a/printing/print_settings_conversion.cc
-+++ b/printing/print_settings_conversion.cc
-@@ -186,12 +186,14 @@ bool PrintSettingsFromJobSettings(const base::Value& job_settings,
- 
-   settings->set_dpi_xy(dpi_horizontal.value(), dpi_vertical.value());
- #endif
-+  const std::string* device_name =
-+      job_settings.FindStringKey(kSettingDeviceName);
-+  if (!device_name->empty())
-+    settings->set_device_name(base::UTF8ToUTF16(*device_name));
- 
-   settings->set_collate(collate.value());
-   settings->set_copies(copies.value());
-   settings->SetOrientation(landscape.value());
--  settings->set_device_name(
--      base::UTF8ToUTF16(*job_settings.FindStringKey(kSettingDeviceName)));
-   settings->set_duplex_mode(static_cast<DuplexMode>(duplex_mode.value()));
-   settings->set_color(static_cast<ColorModel>(color.value()));
-   settings->set_scale_factor(static_cast<double>(scale_factor.value()) / 100.0);
 diff --git a/printing/printing_context.cc b/printing/printing_context.cc
 index 73940192472b1576a701cad3abbb92f2d72aa77e..bc0d39ccd113306691ae532e9fbc5b64c9aa0a33 100644
 --- a/printing/printing_context.cc

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -118,15 +118,6 @@
 #include "ui/gfx/font_render_params.h"
 #endif
 
-#if BUILDFLAG(ENABLE_PRINTING)
-#include "chrome/browser/printing/print_view_manager_basic.h"
-#include "components/printing/common/print_messages.h"
-
-#if defined(OS_WIN)
-#include "printing/backend/win_helper.h"
-#endif
-#endif
-
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 #include "shell/browser/extensions/atom_extension_web_contents_observer.h"
 #endif
@@ -371,6 +362,17 @@ bool IsDeviceNameValid(const base::string16& device_name) {
   return printer.OpenPrinterWithName(device_name.c_str());
 #endif
   return true;
+}
+
+base::string16 GetDefaultPrinterAsync() {
+  base::ScopedBlockingCall scoped_blocking_call(FROM_HERE,
+                                                base::BlockingType::MAY_BLOCK);
+
+  scoped_refptr<printing::PrintBackend> backend =
+      printing::PrintBackend::CreateInstance(
+          nullptr, g_browser_process->GetApplicationLocale());
+  std::string printer_name = backend->GetDefaultPrinterName();
+  return base::UTF8ToUTF16(printer_name);
 }
 #endif
 
@@ -1729,6 +1731,27 @@ bool WebContents::IsCurrentlyAudible() {
 }
 
 #if BUILDFLAG(ENABLE_PRINTING)
+void WebContents::OnGetDefaultPrinter(
+    base::Value print_settings,
+    printing::CompletionCallback print_callback,
+    base::string16 device_name,
+    bool silent,
+    base::string16 default_printer) {
+  base::string16 printer_name =
+      device_name.empty() ? default_printer : device_name;
+  print_settings.SetStringKey(printing::kSettingDeviceName, printer_name);
+
+  auto* print_view_manager =
+      printing::PrintViewManagerBasic::FromWebContents(web_contents());
+  auto* focused_frame = web_contents()->GetFocusedFrame();
+  auto* rfh = focused_frame && focused_frame->HasSelection()
+                  ? focused_frame
+                  : web_contents()->GetMainFrame();
+
+  print_view_manager->PrintNow(rfh, silent, std::move(print_settings),
+                               std::move(print_callback));
+}
+
 void WebContents::Print(mate::Arguments* args) {
   mate::Dictionary options = mate::Dictionary::CreateEmpty(args->isolate());
   base::Value settings(base::Value::Type::DICTIONARY);
@@ -1791,8 +1814,8 @@ void WebContents::Print(mate::Arguments* args) {
   options.Get("landscape", &landscape);
   settings.SetBoolKey(printing::kSettingLandscape, landscape);
 
-  // We set the default to empty string here and only update
-  // if at the Chromium level if it's non-empty
+  // We set the default to the system's default printer and only update
+  // if at the Chromium level if the user overrides.
   // Printer device name as opened by the OS.
   base::string16 device_name;
   options.Get("deviceName", &device_name);
@@ -1800,7 +1823,6 @@ void WebContents::Print(mate::Arguments* args) {
     args->ThrowError("webContents.print(): Invalid deviceName provided.");
     return;
   }
-  settings.SetStringKey(printing::kSettingDeviceName, device_name);
 
   int scale_factor = 100;
   options.Get("scaleFactor", &scale_factor);
@@ -1880,14 +1902,13 @@ void WebContents::Print(mate::Arguments* args) {
     settings.SetIntKey(printing::kSettingDpiVertical, dpi);
   }
 
-  auto* print_view_manager =
-      printing::PrintViewManagerBasic::FromWebContents(web_contents());
-  auto* focused_frame = web_contents()->GetFocusedFrame();
-  auto* rfh = focused_frame && focused_frame->HasSelection()
-                  ? focused_frame
-                  : web_contents()->GetMainFrame();
-  print_view_manager->PrintNow(rfh, silent, std::move(settings),
-                               std::move(callback));
+  base::PostTaskAndReplyWithResult(
+      FROM_HERE,
+      {base::ThreadPool(), base::MayBlock(), base::TaskPriority::USER_BLOCKING},
+      base::BindOnce(&GetDefaultPrinterAsync),
+      base::BindOnce(&WebContents::OnGetDefaultPrinter,
+                     weak_factory_.GetWeakPtr(), std::move(settings),
+                     std::move(callback), device_name, silent));
 }
 
 std::vector<printing::PrinterBasicInfo> WebContents::GetPrinterList() {

--- a/shell/browser/api/atom_api_web_contents.h
+++ b/shell/browser/api/atom_api_web_contents.h
@@ -32,8 +32,14 @@
 #include "ui/gfx/image/image.h"
 
 #if BUILDFLAG(ENABLE_PRINTING)
+#include "chrome/browser/printing/print_view_manager_basic.h"
+#include "components/printing/common/print_messages.h"
 #include "printing/backend/print_backend.h"
 #include "shell/browser/printing/print_preview_message_handler.h"
+
+#if defined(OS_WIN)
+#include "printing/backend/win_helper.h"
+#endif
 #endif
 
 namespace blink {
@@ -187,6 +193,11 @@ class WebContents : public mate::TrackableObject<WebContents>,
   bool IsBeingCaptured();
 
 #if BUILDFLAG(ENABLE_PRINTING)
+  void OnGetDefaultPrinter(base::Value print_settings,
+                           printing::CompletionCallback print_callback,
+                           base::string16 device_name,
+                           bool silent,
+                           base::string16 default_printer);
   void Print(mate::Arguments* args);
   std::vector<printing::PrinterBasicInfo> GetPrinterList();
   // Print current page as PDF.


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/21956.

See that PR for details.

Notes: Use system default printer if none is provided.