### PR TITLE
chore: default to sys printer and prevent bad default crash

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1244,7 +1244,7 @@ Returns [`PrinterInfo[]`](structures/printer-info.md)
   * `silent` Boolean (optional) - Don't ask user for print settings. Default is `false`.
   * `printBackground` Boolean (optional) - Prints the background color and image of
     the web page. Default is `false`.
-  * `deviceName` String (optional) - Set the printer device name to use. Default is `''`.
+  * `deviceName` String (optional) - Set the printer device name to use. Must be the system-defined name and not the 'friendly' name, e.g 'Brother_QL_820NWB' and not 'Brother QL-820NWB'.
   * `color` Boolean (optional) - Set whether the printed web page will be in color or grayscale. Default is `true`.
   * `margins` Object (optional)
     * `marginType` String (optional) - Can be `default`, `none`, `printableArea`, or `custom`. If `custom` is chosen, you will also need to specify `top`, `bottom`, `left`, and `right`.

--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -600,24 +600,6 @@ index 71c0c15217b62cd7a6087c6d9ae50481f9041d5f..18d853d7f808aaf816de86e8c5b82317
  
  #if BUILDFLAG(ENABLE_PRINT_PREVIEW)
    // Set options for print preset from source PDF document.
-diff --git a/printing/print_settings_conversion.cc b/printing/print_settings_conversion.cc
-index 17c363ff9aa2e2262cacd0c9baea3820334bf67b..5b02461c2e9afe254405ddacd904e4bdbddd0b8b 100644
---- a/printing/print_settings_conversion.cc
-+++ b/printing/print_settings_conversion.cc
-@@ -184,11 +184,12 @@ bool PrintSettingsFromJobSettings(const base::Value& job_settings,
- 
-   settings->set_dpi_xy(dpi_horizontal.value(), dpi_vertical.value());
- #endif
-+  if (!device_name->empty())
-+    settings->set_device_name(base::UTF8ToUTF16(*device_name));
- 
-   settings->set_collate(collate.value());
-   settings->set_copies(copies.value());
-   settings->SetOrientation(landscape.value());
--  settings->set_device_name(base::UTF8ToUTF16(*device_name));
-   settings->set_duplex_mode(static_cast<DuplexMode>(duplex_mode.value()));
-   settings->set_color(static_cast<ColorModel>(color.value()));
-   settings->set_scale_factor(static_cast<double>(scale_factor.value()) / 100.0);
 diff --git a/printing/printing_context.cc b/printing/printing_context.cc
 index cd5c27c87df175676504a06b4e1904f6b836dc90..c4f6acf66bc69f1e7db633aa5b3b03a913ffb666 100644
 --- a/printing/printing_context.cc

--- a/shell/browser/api/atom_api_web_contents.h
+++ b/shell/browser/api/atom_api_web_contents.h
@@ -31,8 +31,14 @@
 #include "ui/gfx/image/image.h"
 
 #if BUILDFLAG(ENABLE_PRINTING)
+#include "chrome/browser/printing/print_view_manager_basic.h"
+#include "components/printing/common/print_messages.h"
 #include "printing/backend/print_backend.h"
 #include "shell/browser/printing/print_preview_message_handler.h"
+
+#if defined(OS_WIN)
+#include "printing/backend/win_helper.h"
+#endif
 #endif
 
 namespace blink {
@@ -181,6 +187,11 @@ class WebContents : public mate::TrackableObject<WebContents>,
   v8::Local<v8::Value> GetNativeView() const;
 
 #if BUILDFLAG(ENABLE_PRINTING)
+  void OnGetDefaultPrinter(base::DictionaryValue print_settings,
+                           printing::CompletionCallback print_callback,
+                           base::string16 device_name,
+                           bool silent,
+                           base::string16 default_printer);
   void Print(mate::Arguments* args);
   std::vector<printing::PrinterBasicInfo> GetPrinterList();
   // Print current page as PDF.

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -6,7 +6,7 @@ import * as http from 'http'
 import { BrowserWindow, ipcMain, webContents, session } from 'electron'
 import { emittedOnce } from './events-helpers';
 import { closeAllWindows } from './window-helpers';
-import { ifdescribe } from './spec-helpers';
+import { ifdescribe, ifit } from './spec-helpers';
 
 const { expect } = chai
 
@@ -102,21 +102,35 @@ describe('webContents module', () => {
   })
 
   ifdescribe(features.isPrintingEnabled())('webContents.print()', () => {
+    let w: BrowserWindow
+
+    beforeEach(() => {
+      w = new BrowserWindow({ show: false })
+    })
+
+    afterEach(closeAllWindows)
+
     it('throws when invalid settings are passed', () => {
-      const w = new BrowserWindow({ show: false })
       expect(() => {
         // @ts-ignore this line is intentionally incorrect
         w.webContents.print(true)
       }).to.throw('webContents.print(): Invalid print settings specified.')
+    })
 
+    it('throws when an invalid callback is passed', () => {
       expect(() => {
         // @ts-ignore this line is intentionally incorrect
         w.webContents.print({}, true)
       }).to.throw('webContents.print(): Invalid optional callback provided.')
     })
 
+    ifit(process.platform !== 'linux')('throws when an invalid deviceName is passed', () => {
+      expect(() => {
+        w.webContents.print({ deviceName: 'i-am-a-nonexistent-printer' }, () => {})
+      }).to.throw('webContents.print(): Invalid deviceName provided.')
+    })
+
     it('does not crash', () => {
-      const w = new BrowserWindow({ show: false })
       expect(() => {
         w.webContents.print({ silent: true })
       }).to.not.throw()


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/21946.
Backport of https://github.com/electron/electron/pull/21956

Notes: Fixed a potential crash on faulty `deviceName`s in `webContents.print()`.
