### PR TITLE
feat: allow specifying pageSize for print

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1282,6 +1282,8 @@ Returns [`PrinterInfo[]`](structures/printer-info.md)
     * `vertical` Number (optional) - The vertical dpi.
   * `header` String (optional) - String to be printed as page header.
   * `footer` String (optional) - String to be printed as page footer.
+  * `pageSize` String | Size (optional) - Specify page size of the printed document. Can be `A3`,
+  `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height`.
 * `callback` Function (optional)
   * `success` Boolean - Indicates success of the print call.
   * `failureReason` String - Called back if the print fails; can be `cancelled` or `failed`.

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -569,6 +569,8 @@ Stops any `findInPage` request for the `webview` with the provided `action`.
     * `vertical` Number (optional) - The vertical dpi.
   * `header` String (optional) - String to be printed as page header.
   * `footer` String (optional) - String to be printed as page footer.
+  * `pageSize` String | Size (optional) - Specify page size of the printed document. Can be `A3`,
+  `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height`.
 
 Returns `Promise<void>`
 

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -340,9 +340,38 @@ WebContents.prototype.printToPDF = function (options) {
   }
 }
 
-WebContents.prototype.print = function (...args) {
+WebContents.prototype.print = function (options = {}, callback) {
+  // TODO(codebytere): deduplicate argument sanitization by moving rest of
+  // print param logic into new file shared between printToPDF and print
+  if (typeof options === 'object') {
+    // Optionally set size for PDF.
+    if (options.pageSize !== undefined) {
+      const pageSize = options.pageSize
+      if (typeof pageSize === 'object') {
+        if (!pageSize.height || !pageSize.width) {
+          throw new Error('height and width properties are required for pageSize')
+        }
+        // Dimensions in Microns - 1 meter = 10^6 microns
+        options.mediaSize = {
+          name: 'CUSTOM',
+          custom_display_name: 'Custom',
+          height_microns: Math.ceil(pageSize.height),
+          width_microns: Math.ceil(pageSize.width)
+        }
+      } else if (PDFPageSizes[pageSize]) {
+        options.mediaSize = PDFPageSizes[pageSize]
+      } else {
+        throw new Error(`Unsupported pageSize: ${pageSize}`)
+      }
+    }
+  }
+
   if (features.isPrintingEnabled()) {
-    this._print(...args)
+    if (callback) {
+      this._print(options, callback)
+    } else {
+      this._print(options)
+    }
   } else {
     console.error('Error: Printing feature is disabled.')
   }

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1897,6 +1897,12 @@ void WebContents::Print(gin_helper::Arguments* args) {
   options.Get("duplexMode", &duplex_mode);
   settings.SetIntKey(printing::kSettingDuplexMode, duplex_mode);
 
+  // We've already done necessary parameter sanitization at the
+  // JS level, so we can simply pass this through.
+  base::Value media_size(base::Value::Type::DICTIONARY);
+  if (options.Get("mediaSize", &media_size))
+    settings.SetKey(printing::kSettingMediaSize, std::move(media_size));
+
   // Set custom dots per inch (dpi)
   gin_helper::Dictionary dpi_settings;
   int dpi = 72;

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -128,6 +128,13 @@ describe('webContents module', () => {
       }).to.throw('webContents.print(): Invalid deviceName provided.')
     })
 
+    it('throws when an invalid pageSize is passed', () => {
+      expect(() => {
+        // @ts-ignore this line is intentionally incorrect
+        w.webContents.print({ pageSize: 'i-am-a-bad-pagesize' }, () => {})
+      }).to.throw('Unsupported pageSize: i-am-a-bad-pagesize')
+    })
+
     it('does not crash', () => {
       expect(() => {
         w.webContents.print({ silent: true })


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/19056.

This PR allows the user to specify page size (`A4`, `Tabloid`, etc) when printing with `webContents.print()`.

The work needed to enable this confirmed my thoughts that the parameter sanitization code needed for `contents.print()` is nearly identical in shape to that needed for `contents.printToPDF`, and is much harder to deal with when done in C++. We can both dedup this logic and better test bad parameters by moving the argument sanitization to JS, which I plan to do in a follow-up PR as noted by my TODO.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added the ability to specify `pageSize` when printing with `webContents.print()`
