### PR TITLE
docs: document supported extensions apis

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -112,7 +112,7 @@ These individual tutorials expand on topics discussed in the guide above.
 * [Process Object](api/process.md)
 * [Supported Command Line Switches](api/command-line-switches.md)
 * [Environment Variables](api/environment-variables.md)
-* [Chrome Extensions support](api/extensions.md)
+* [Chrome Extensions Support](api/extensions.md)
 * [Breaking API Changes](breaking-changes.md)
 
 ### Custom DOM Elements:

--- a/docs/README.md
+++ b/docs/README.md
@@ -112,6 +112,7 @@ These individual tutorials expand on topics discussed in the guide above.
 * [Process Object](api/process.md)
 * [Supported Command Line Switches](api/command-line-switches.md)
 * [Environment Variables](api/environment-variables.md)
+* [Chrome Extensions support](api/extensions.md)
 * [Breaking API Changes](breaking-changes.md)
 
 ### Custom DOM Elements:

--- a/docs/api/extensions.md
+++ b/docs/api/extensions.md
@@ -3,7 +3,7 @@
 Electron supports a subset of the [Chrome Extensions
 API][chrome-extensions-api-index], primarily to support DevTools extensions and
 Chromium-internal extensions, but it also happens to support some other
-extension capabilities also.
+extension capabilities.
 
 [chrome-extensions-api-index]: https://developer.chrome.com/extensions/api_index
 
@@ -13,7 +13,7 @@ extension capabilities also.
 
 ## Loading extensions
 
-Electron only supports loading unpacked extensions (i.e. .crx files do not
+Electron only supports loading unpacked extensions (i.e., `.crx` files do not
 work). Extensions are installed per-`session`. To load an extension, call
 [`ses.loadExtension`](session.md#sesloadextensionpath):
 

--- a/docs/api/extensions.md
+++ b/docs/api/extensions.md
@@ -1,0 +1,99 @@
+# Chrome Extension Support
+
+Electron supports a subset of the [Chrome Extensions
+API][chrome-extensions-api-index], primarily to support DevTools extensions and
+Chromium-internal extensions, but it also happens to support some other
+extension capabilities also.
+
+[chrome-extensions-api-index]: https://developer.chrome.com/extensions/api_index
+
+> **Note:** Electron does not support arbitrary Chrome extensions from the
+> store, and it is a **non-goal** of the Electron project to be perfectly
+> compatible with Chrome's implementation of Extensions.
+
+## Loading extensions
+
+Electron only supports loading unpacked extensions (i.e. .crx files do not
+work). Extensions are installed per-`session`. To load an extension, call
+[`ses.loadExtension`](session.md#sesloadextensionpath):
+
+```js
+const { session } = require('electron')
+
+const { id } = await session.loadExtension('path/to/unpacked/extension')
+```
+
+Loaded extensions will not be automatically remembered across exits; if you do
+not call `loadExtension` when the app runs, the extension will not be loaded.
+
+See the [`session`](session.md) documentation for more information about
+loading, unloading, and querying active extensions.
+
+## Supported Extensions APIs
+
+We support the following extensions APIs, with some caveats. Other APIs may
+additionally be supported, but support for any APIs not listed here is
+provisional and may be removed.
+
+### `chrome.devtools.inspectedWindow`
+
+All features of this API are supported.
+
+### `chrome.devtools.network`
+
+All features of this API are supported.
+
+### `chrome.devtools.panels`
+
+All features of this API are supported.
+
+### `chrome.extension`
+
+The following properties of `chrome.extension` are supported:
+
+- `chrome.extension.lastError`
+
+The following methods of `chrome.extension` are supported:
+
+- `chrome.extension.getURL`
+- `chrome.extension.getBackgroundPage`
+
+### `chrome.runtime`
+
+The following properties of `chrome.runtime` are supported:
+
+- `chrome.runtime.lastError`
+- `chrome.runtime.id`
+
+The following methods of `chrome.runtime` are supported:
+
+- `chrome.runtime.getBackgroundPage`
+- `chrome.runtime.getManifest`
+- `chrome.runtime.getURL`
+- `chrome.runtime.connect`
+- `chrome.runtime.sendMessage`
+
+The following events of `chrome.runtime` are supported:
+
+- `chrome.runtime.onStartup`
+- `chrome.runtime.onInstalled`
+- `chrome.runtime.onSuspend`
+- `chrome.runtime.onSuspendCanceled`
+- `chrome.runtime.onConnect`
+- `chrome.runtime.onMessage`
+
+### `chrome.storage`
+
+Only `chrome.storage.local` is supported; `chrome.storage.sync` and
+`chrome.storage.managed` are not.
+
+### `chrome.tabs`
+
+The following methods of `chrome.tabs` are supported:
+
+- `chrome.tabs.sendMessage`
+- `chrome.tabs.executeScript`
+
+> **Note:** In Chrome, passing `-1` as a tab ID signifies the "currently active
+> tab". Since Electron has no such concept, passing `-1` as a tab ID is not
+> supported and will raise an error.

--- a/docs/api/extensions.md
+++ b/docs/api/extensions.md
@@ -20,7 +20,9 @@ work). Extensions are installed per-`session`. To load an extension, call
 ```js
 const { session } = require('electron')
 
-const { id } = await session.loadExtension('path/to/unpacked/extension')
+session.loadExtension('path/to/unpacked/extension').then(({ id }) => {
+  // ...
+})
 ```
 
 Loaded extensions will not be automatically remembered across exits; if you do

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -21,6 +21,7 @@ auto_filenames = {
     "docs/api/dock.md",
     "docs/api/download-item.md",
     "docs/api/environment-variables.md",
+    "docs/api/extensions.md",
     "docs/api/file-object.md",
     "docs/api/frameless-window.md",
     "docs/api/global-shortcut.md",


### PR DESCRIPTION
#### Description of Change
A few folks have asked about what extensions APIs we support. I thought it would make sense to maintain a central list of the "blessed" APIs.

Ref #19447

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none