### PR TITLE
docs: add workaround when using mirror address and electron version >= 7

### DIFF
--- a/docs/tutorial/installation.md
+++ b/docs/tutorial/installation.md
@@ -69,6 +69,12 @@ For instance, to use the China mirror:
 ELECTRON_MIRROR="https://cdn.npm.taobao.org/dist/electron/"
 ```
 
+You may need to specify `ELECTRON_CUSTOM_DIR` to avoid url compose problem([#330](https://github.com/electron/electron-quick-start/issues/330#issuecomment-549865511)).
+E.g.:
+```plantext
+ELECTRON_CUSTOM_DIR="7.1.11"
+```
+
 #### Cache
 Alternatively, you can override the local cache. `@electron/get` will cache
 downloaded binaries in a local directory to not stress your network. You can use


### PR DESCRIPTION
#### Description of Change

Add documentation for workaround when using mirror address and electron version >= 7.
See discussion in project `electron-quick-start` [issue#330](https://github.com/electron/electron-quick-start/issues/330#issuecomment-549865511).

cc @felixrieseberg 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes
