### PR TITLE
build: don't use component_ffmpeg for chromedriver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -432,18 +432,29 @@ step-electron-dist-store: &step-electron-dist-store
     path: src/out/Default/dist.zip
     destination: dist.zip
 
+step-electron-chromedriver-gn-gen: &step-electron-chromedriver-gn-gen
+  run:
+    name: chromedriver GN gen
+    command: |
+      cd src
+      if [ "$USE_GOMA" == "true" ]; then
+        gn gen out/chromedriver --args="import(\"$GN_CONFIG\") import(\"//electron/build/args/goma.gn\") is_component_ffmpeg=false proprietary_codecs=false $GN_EXTRA_ARGS $GN_BUILDFLAG_ARGS"
+      else
+        gn gen out/chromedriver --args="import(\"$GN_CONFIG\") cc_wrapper=\"$SCCACHE_PATH\" is_component_ffmpeg=false proprietary_codecs=false $GN_EXTRA_ARGS $GN_BUILDFLAG_ARGS"
+      fi
+
 step-electron-chromedriver-build: &step-electron-chromedriver-build
   run:
     name: Build chromedriver.zip
     command: |
       cd src
-      ninja -C out/Default chrome/test/chromedriver -j $NUMBER_OF_NINJA_PROCESSES
-      electron/script/strip-binaries.py --target-cpu="$TARGET_ARCH" --file $PWD/out/Default/chromedriver
-      ninja -C out/Default electron:electron_chromedriver_zip
+      ninja -C out/chromedriver chrome/test/chromedriver -j $NUMBER_OF_NINJA_PROCESSES
+      electron/script/strip-binaries.py --target-cpu="$TARGET_ARCH" --file $PWD/out/chromedriver/chromedriver
+      ninja -C out/chromedriver electron:electron_chromedriver_zip
 
 step-electron-chromedriver-store: &step-electron-chromedriver-store
   store_artifacts:
-    path: src/out/Default/chromedriver.zip
+    path: src/out/chromedriver/chromedriver.zip
     destination: chromedriver.zip
 
 step-nodejs-headers-build: &step-nodejs-headers-build
@@ -992,6 +1003,7 @@ steps-electron-build: &steps-electron-build
     - *step-maybe-cross-arch-snapshot-store
 
     # chromedriver
+    - *step-electron-chromedriver-gn-gen
     - *step-electron-chromedriver-build
     - *step-electron-chromedriver-store
 
@@ -1082,6 +1094,7 @@ steps-electron-build-for-publish: &steps-electron-build-for-publish
     - *step-mksnapshot-store
 
     # chromedriver
+    - *step-electron-chromedriver-gn-gen
     - *step-electron-chromedriver-build
     - *step-electron-chromedriver-store
 
@@ -1111,8 +1124,8 @@ steps-chromedriver-build: &steps-chromedriver-build
     - *step-depot-tools-add-to-path
     - *step-setup-env-for-build
     - *step-fix-sync-on-mac
-    - *step-gn-gen-default
 
+    - *step-electron-chromedriver-gn-gen
     - *step-electron-chromedriver-build
     - *step-electron-chromedriver-store
 
@@ -1416,6 +1429,7 @@ commands:
             - *step-maybe-cross-arch-snapshot-store
 
             # chromedriver
+            - *step-electron-chromedriver-gn-gen
             - *step-electron-chromedriver-build
             - *step-electron-chromedriver-store
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -497,7 +497,7 @@ step-persist-data-for-tests: &step-persist-data-for-tests
       # Build artifacts
       - src/out/Default/dist.zip
       - src/out/Default/mksnapshot.zip
-      - src/out/Default/chromedriver.zip
+      - src/out/chromedriver/chromedriver.zip
       - src/out/Default/shell_browser_ui_unittests
       - src/out/Default/gen/node_headers
       - src/out/ffmpeg/ffmpeg.zip
@@ -532,7 +532,7 @@ step-chromedriver-unzip: &step-chromedriver-unzip
   run:
     name: Unzip chromedriver.zip
     command: |
-      cd src/out/Default
+      cd src/out/chromedriver
       unzip -o chromedriver.zip
 
 step-ffmpeg-gn-gen: &step-ffmpeg-gn-gen
@@ -577,7 +577,7 @@ step-verify-chromedriver: &step-verify-chromedriver
     name: Verify ChromeDriver
     command: |
       cd src
-      python electron/script/verify-chromedriver.py --source-root "$PWD" --build-dir out/Default
+      python electron/script/verify-chromedriver.py --source-root "$PWD" --build-dir out/chromedriver
 
 step-setup-linux-for-headless-testing: &step-setup-linux-for-headless-testing
   run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -448,7 +448,7 @@ step-electron-chromedriver-build: &step-electron-chromedriver-build
     name: Build chromedriver.zip
     command: |
       cd src
-      ninja -C out/Default electron:electron_chromedriver -j $NUMBER_OF_NINJA_PROCESSES
+      ninja -C out/chromedriver electron:electron_chromedriver -j $NUMBER_OF_NINJA_PROCESSES
       electron/script/strip-binaries.py --target-cpu="$TARGET_ARCH" --file $PWD/out/chromedriver/chromedriver
       ninja -C out/chromedriver electron:electron_chromedriver_zip
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -448,7 +448,7 @@ step-electron-chromedriver-build: &step-electron-chromedriver-build
     name: Build chromedriver.zip
     command: |
       cd src
-      ninja -C out/chromedriver chrome/test/chromedriver -j $NUMBER_OF_NINJA_PROCESSES
+      ninja -C out/Default electron:electron_chromedriver -j $NUMBER_OF_NINJA_PROCESSES
       electron/script/strip-binaries.py --target-cpu="$TARGET_ARCH" --file $PWD/out/chromedriver/chromedriver
       ninja -C out/chromedriver electron:electron_chromedriver_zip
 

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1238,12 +1238,20 @@ dist_zip("electron_ffmpeg_zip") {
   outputs = [ "$root_build_dir/ffmpeg.zip" ]
 }
 
+electron_chromedriver_deps = [
+  ":licenses",
+  "//chrome/test/chromedriver",
+  "//electron/buildflags",
+]
+
+group("electron_chromedriver") {
+  testonly = true
+  public_deps = electron_chromedriver_deps
+}
+
 dist_zip("electron_chromedriver_zip") {
   testonly = true
-  data_deps = [
-    ":licenses",
-    "//chrome/test/chromedriver",
-  ]
+  data_deps = electron_chromedriver_deps
   outputs = [ "$root_build_dir/chromedriver.zip" ]
 }
 

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -700,14 +700,12 @@ if (is_mac) {
     outputs = [ "{{bundle_resources_dir}}/{{source_file_part}}" ]
   }
 
-  if (!is_component_build) {
+  if (!is_component_build && is_component_ffmpeg) {
     bundle_data("electron_framework_libraries") {
       sources = []
       public_deps = []
-      if (is_component_ffmpeg) {
-        sources += [ "$root_out_dir/libffmpeg.dylib" ]
-        public_deps += [ "//third_party/ffmpeg:ffmpeg" ]
-      }
+      sources += [ "$root_out_dir/libffmpeg.dylib" ]
+      public_deps += [ "//third_party/ffmpeg:ffmpeg" ]
       outputs = [ "{{bundle_contents_dir}}/Libraries/{{source_file_part}}" ]
     }
   } else {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Chromedriver builds were failing on cross arch compiles because they were trying to bring in the wrong ffmpeg component.  We really don't need/use ffmpeg for chromedriver but due to how it is setup in chromium, it gets pulled in.  This PR changes to use the non component version of ffmpeg for the chromedriver build.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
