### PR TITLE
docs: clarify requirements for GOOGLE_API_KEY

### DIFF
--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -53,23 +53,23 @@ Unsupported options are:
 
 ### `GOOGLE_API_KEY`
 
-You can provide an API key for making requests to Google Cloud Platform's
-[geolocation webservice](https://developers.google.com/maps/documentation/geolocation/intro).
-To do this, place the following code in your main process file, before opening any browser
-windows that will make geolocation requests:
+Geolocation support in Electron requires the use of Google Cloud Platform's
+geolocation webservice. To enable this feature, acquire a
+[Google API key](https://developers.google.com/maps/documentation/geolocation/get-api-key)
+and place the following code in your main process file, before opening any
+browser windows that will make geolocation requests:
 
 ```javascript
 process.env.GOOGLE_API_KEY = 'YOUR_KEY_HERE'
 ```
 
-For instructions on how to acquire a Google API key, visit
-[this page](https://developers.google.com/maps/documentation/geolocation/get-api-key).
 By default, a newly generated Google API key may not be allowed to make geolocation requests.
 To enable the geolocation webservice for your project, enable it through the
 [API library](https://console.cloud.google.com/apis/library).
 
-N.B. You will need to add a [Billing Account](https://cloud.google.com/billing/docs/how-to/payment-methods#add_a_payment_method) to your project before being able to use your
-API key.
+N.B. You will need to add a
+[Billing Account](https://cloud.google.com/billing/docs/how-to/payment-methods#add_a_payment_method)
+to the project associated to the API key for the geolocation webservice to work.
 
 ### `ELECTRON_NO_ASAR`
 

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -68,7 +68,7 @@ By default, a newly generated Google API key may not be allowed to make geolocat
 To enable the geolocation webservice for your project, enable it through the
 [API library](https://console.cloud.google.com/apis/library).
 
-N.B. You will need to add a Billing Account to your project before being able to use your
+N.B. You will need to add a [Billing Account](https://cloud.google.com/billing/docs/how-to/payment-methods#add_a_payment_method) to your project before being able to use your
 API key. Read more about Billing Accounts and how to set one up on
 [this page](https://cloud.google.com/billing/docs/how-to/payment-methods#add_a_payment_method).
 

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -70,7 +70,6 @@ To enable the geolocation webservice for your project, enable it through the
 
 N.B. You will need to add a [Billing Account](https://cloud.google.com/billing/docs/how-to/payment-methods#add_a_payment_method) to your project before being able to use your
 API key.
-[this page](https://cloud.google.com/billing/docs/how-to/payment-methods#add_a_payment_method).
 
 ### `ELECTRON_NO_ASAR`
 

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -53,16 +53,24 @@ Unsupported options are:
 
 ### `GOOGLE_API_KEY`
 
-You can provide an API key for making requests to Google's geocoding webservice. To do this, place the following code in your main process
-file, before opening any browser windows that will make geocoding requests:
+You can provide an API key for making requests to Google Cloud Platform's
+[geolocation webservice](https://developers.google.com/maps/documentation/geolocation/intro).
+To do this, place the following code in your main process file, before opening any browser
+windows that will make geolocation requests:
 
 ```javascript
 process.env.GOOGLE_API_KEY = 'YOUR_KEY_HERE'
 ```
 
-For instructions on how to acquire a Google API key, visit [this page](https://developers.google.com/maps/documentation/javascript/get-api-key).
-By default, a newly generated Google API key may not be allowed to make
-geocoding requests. To enable geocoding requests, visit [this page](https://developers.google.com/maps/documentation/geocoding/get-api-key).
+For instructions on how to acquire a Google API key, visit
+[this page](https://developers.google.com/maps/documentation/geolocation/get-api-key).
+By default, a newly generated Google API key may not be allowed to make geolocation requests.
+To enable the geolocation webservice for your project, enable it through the
+[API library](https://console.cloud.google.com/apis/library).
+
+N.B. You will need to add a Billing Account to your project before being able to use your
+API key. Read more about Billing Accounts and how to set one up on
+[this page](https://cloud.google.com/billing/docs/how-to/payment-methods#add_a_payment_method).
 
 ### `ELECTRON_NO_ASAR`
 

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -69,7 +69,7 @@ To enable the geolocation webservice for your project, enable it through the
 [API library](https://console.cloud.google.com/apis/library).
 
 N.B. You will need to add a [Billing Account](https://cloud.google.com/billing/docs/how-to/payment-methods#add_a_payment_method) to your project before being able to use your
-API key. Read more about Billing Accounts and how to set one up on
+API key.
 [this page](https://cloud.google.com/billing/docs/how-to/payment-methods#add_a_payment_method).
 
 ### `ELECTRON_NO_ASAR`


### PR DESCRIPTION
#### Description of Change
Closes #22005.

Clarifies how to get a working `GOOGLE_API_KEY`, since I wasn't able to do so with the existing docs. Most importantly:
* mentions that you need a Billing Account for the project associated with your API key
* clarifies that you need to enable the **geolocation** (rather than **geocoding**) API.

To ensure my documentation changes are OK, reviewers can attempt to set up a new API key and then run the following:

```bash session
curl --data "key=YOUR_API_KEY" https://www.googleapis.com/geolocation/v1/geolocate
```

The output should be something like this (👋 from Slack YVR):
``` json
{
  "location": {
    "lat": 49.2695199,
    "lng": -123.12808620000001
  },
  "accuracy": 2312
}
```

This is the underlying API call used by Chromium when using `navigator.geolocation.getCurrentPosition()`.

cc @electron/wg-ecosystem 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
