### PR TITLE
feat: add session.removeWordFromSpellCheckerDictionary API

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -495,6 +495,14 @@ Returns `Boolean` - Whether the word was successfully written to the custom dict
 
 **Note:** On macOS and Windows 10 this word will be written to the OS custom dictionary as well
 
+#### `ses.removeWordFromSpellCheckerDictionary(word)`
+
+* `word` String - The word you want to remove from the dictionary
+
+Returns `Boolean` - Whether the word was successfully removed from the custom dictionary.
+
+**Note:** On macOS and Windows 10 this word will be removed from the OS custom dictionary as well
+
 #### `ses.loadExtension(path)`
 
 * `path` String - Path to a directory containing an unpacked Chrome extension

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -780,6 +780,20 @@ bool Session::AddWordToSpellCheckerDictionary(const std::string& word) {
 #endif
   return service->GetCustomDictionary()->AddWord(word);
 }
+
+bool Session::RemoveWordFromSpellCheckerDictionary(const std::string& word) {
+#if BUILDFLAG(USE_BROWSER_SPELLCHECKER)
+  if (spellcheck::UseBrowserSpellChecker()) {
+    spellcheck_platform::RemoveWord(base::UTF8ToUTF16(word));
+  }
+#endif
+  SpellcheckService* spellcheck =
+      SpellcheckServiceFactory::GetForContext(browser_context_.get());
+  if (!spellcheck)
+    return false;
+
+  return spellcheck->GetCustomDictionary()->RemoveWord(word);
+}
 #endif
 
 // static
@@ -868,6 +882,8 @@ void Session::BuildPrototype(v8::Isolate* isolate,
                  &SetSpellCheckerDictionaryDownloadURL)
       .SetMethod("addWordToSpellCheckerDictionary",
                  &Session::AddWordToSpellCheckerDictionary)
+      .SetMethod("removeWordFromSpellCheckerDictionary",
+                 &Session::RemoveWordFromSpellCheckerDictionary)
 #endif
       .SetMethod("preconnect", &Session::Preconnect)
       .SetProperty("cookies", &Session::Cookies)

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -782,17 +782,18 @@ bool Session::AddWordToSpellCheckerDictionary(const std::string& word) {
 }
 
 bool Session::RemoveWordFromSpellCheckerDictionary(const std::string& word) {
-#if BUILDFLAG(USE_BROWSER_SPELLCHECKER)
-  if (spellcheck::UseBrowserSpellChecker()) {
-    spellcheck_platform::RemoveWord(base::UTF8ToUTF16(word));
-  }
-#endif
-  SpellcheckService* spellcheck =
+  SpellcheckService* service =
       SpellcheckServiceFactory::GetForContext(browser_context_.get());
-  if (!spellcheck)
+  if (!service)
     return false;
 
-  return spellcheck->GetCustomDictionary()->RemoveWord(word);
+#if BUILDFLAG(USE_BROWSER_SPELLCHECKER)
+  if (spellcheck::UseBrowserSpellChecker()) {
+    spellcheck_platform::RemoveWord(service->platform_spell_checker(),
+                                    base::UTF8ToUTF16(word));
+  }
+#endif
+  return service->GetCustomDictionary()->RemoveWord(word);
 }
 #endif
 

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -96,6 +96,7 @@ class Session : public gin_helper::TrackableObject<Session>,
   void SetSpellCheckerLanguages(gin_helper::ErrorThrower thrower,
                                 const std::vector<std::string>& languages);
   bool AddWordToSpellCheckerDictionary(const std::string& word);
+  bool RemoveWordFromSpellCheckerDictionary(const std::string& word);
 #endif
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)


### PR DESCRIPTION
#### Description of Change

Like #21266, but reversed.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `session.removeWordFromSpellCheckerDictionary` API to remove custom words in the dictionary.
