### PR TITLE
fix: check WebContents in OnGetDefaultPrinter

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1745,6 +1745,14 @@ void WebContents::OnGetDefaultPrinter(
     base::string16 device_name,
     bool silent,
     base::string16 default_printer) {
+  // The content::WebContents might be already deleted at this point, and the
+  // PrintViewManagerBasic class does not do null check.
+  if (!web_contents()) {
+    if (print_callback)
+      std::move(print_callback).Run(false, "failed");
+    return;
+  }
+
   base::string16 printer_name =
       device_name.empty() ? default_printer : device_name;
   print_settings.SetStringKey(printing::kSettingDeviceName, printer_name);


### PR DESCRIPTION
#### Description of Change

This should be able to fix the crash on CI when running printer tests.

#### Release Notes

Notes: no-notes