### PR TITLE
chore: remove teams without write access from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,19 +3,9 @@
 # https://help.github.com/articles/about-codeowners
 # https://git-scm.com/docs/gitignore
 
-# Most stuff in here is owned by the Community & Safety WG...
-/.github/*                              @electron/wg-community
-
-# ...except the Admin WG maintains this file.
-/.github/CODEOWNERS                     @electron/wg-admin
-
 # Upgrades WG
 /patches/                               @electron/wg-upgrades
 DEPS                                    @electron/wg-upgrades
-
-# Ecosystem WG
-/default_app/                           @electron/wg-ecosystem
-/docs/                                  @electron/wg-ecosystem
 
 # Releases WG
 /npm/                                   @electron/wg-releases

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,9 +13,9 @@
 /patches/                               @electron/wg-upgrades
 DEPS                                    @electron/wg-upgrades
 
-# Docs & Tooling WG
-/default_app/ @electron/wg-docs-tools
-/docs/                                  @electron/wg-docs-tools
+# Ecosystem WG
+/default_app/                           @electron/wg-ecosystem
+/docs/                                  @electron/wg-ecosystem
 
 # Releases WG
 /npm/                                   @electron/wg-releases


### PR DESCRIPTION
#### Description of Change

[GitHub docs](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) state that: 
> The people you choose as code owners must have write permissions for the repository. **When the code owner is a team, that team must have write permissions**, even if all the individual members of the team already have write permissions directly, through organization membership, or through another team membership.

This PR removes teams without write access from the `CODEOWNERS` file, to avoid confusion as to why they aren't pinged for review in certain PRs.

cc @electron/wg-admin @electron/wg-ecosystem @electron/wg-community-safety 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes