### PR TITLE
[wip] refactor: parse printing options in js

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1309,8 +1309,12 @@ win.webContents.print(options, (success, errorType) => {
     * `title` String - The title for the PDF header.
     * `url` String - the url for the PDF footer.
   * `landscape` Boolean (optional) - `true` for landscape, `false` for portrait.
-  * `marginsType` Integer (optional) - Specifies the type of margins to use. Uses 0 for
-    default margin, 1 for no margin, and 2 for minimum margin.
+  * `margins` Object (optional)
+    * `marginType` String (optional) - Can be `default`, `none`, `printableArea`, or `custom`. If `custom` is chosen, you will also need to specify `top`, `bottom`, `left`, and `right`.
+    * `top` Number (optional) - The top margin of the printed web page, in pixels.
+    * `bottom` Number (optional) - The bottom margin of the printed web page, in pixels.
+    * `left` Number (optional) - The left margin of the printed web page, in pixels.
+    * `right` Number (optional) - The right margin of the printed web page, in pixels.
     and `width` in microns.
   * `scaleFactor` Number (optional) - The scale factor of the web page. Can range from 0 to 100.
   * `pageRanges` Record<string, number> (optional) - The page range to print.
@@ -1357,7 +1361,7 @@ win.webContents.on('did-finish-load', () => {
   win.webContents.printToPDF({}).then(data => {
     fs.writeFile('/tmp/print.pdf', data, (error) => {
       if (error) throw error
-      console.log('Write PDF successfully.')
+      console.log('Wrote PDF successfully.')
     })
   }).catch(error => {
     console.log(error)

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -583,8 +583,12 @@ Prints `webview`'s web page. Same as `webContents.print([options])`.
     * `title` String - The title for the PDF header.
     * `url` String - the url for the PDF footer.
   * `landscape` Boolean (optional) - `true` for landscape, `false` for portrait.
-  * `marginsType` Integer (optional) - Specifies the type of margins to use. Uses 0 for
-    default margin, 1 for no margin, and 2 for minimum margin.
+  * `margins` Object (optional)
+    * `marginType` String (optional) - Can be `default`, `none`, `printableArea`, or `custom`. If `custom` is chosen, you will also need to specify `top`, `bottom`, `left`, and `right`.
+    * `top` Number (optional) - The top margin of the printed web page, in pixels.
+    * `bottom` Number (optional) - The bottom margin of the printed web page, in pixels.
+    * `left` Number (optional) - The left margin of the printed web page, in pixels.
+    * `right` Number (optional) - The right margin of the printed web page, in pixels.
     and `width` in microns.
   * `scaleFactor` Number (optional) - The scale factor of the web page. Can range from 0 to 100.
   * `pageRanges` Record<string, number> (optional) - The page range to print.

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -259,6 +259,7 @@ auto_filenames = {
     "lib/browser/ipc-main-internal-utils.ts",
     "lib/browser/ipc-main-internal.ts",
     "lib/browser/navigation-controller.js",
+    "lib/browser/printing.ts",
     "lib/browser/remote/objects-registry.ts",
     "lib/browser/remote/server.ts",
     "lib/browser/rpc-server.js",

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -11,6 +11,7 @@ const { internalWindowOpen } = require('@electron/internal/browser/guest-window-
 const NavigationController = require('@electron/internal/browser/navigation-controller')
 const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
 const ipcMainUtils = require('@electron/internal/browser/ipc-main-internal-utils')
+const { updatePrintSettings } = require('@electron/internal/browser/printing')
 
 // session is not used here, the purpose is to make sure session is initalized
 // before the webContents module.
@@ -206,134 +207,12 @@ WebContents.prototype.executeJavaScriptInIsolatedWorld = async function (code, h
   return ipcMainUtils.invokeInWebContents(this, false, 'ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD', 'executeJavaScriptInIsolatedWorld', code, hasUserGesture)
 }
 
-// Translate the options of printToPDF.
-WebContents.prototype.printToPDF = function (options) {
-  const printSettings = {
-    ...defaultPrintingSetting,
-    requestID: getNextId()
-  }
-
-  if (options.landscape !== undefined) {
-    if (typeof options.landscape !== 'boolean') {
-      const error = new Error('landscape must be a Boolean')
-      return Promise.reject(error)
-    }
-    printSettings.landscape = options.landscape
-  }
-
-  if (options.scaleFactor !== undefined) {
-    if (typeof options.scaleFactor !== 'number') {
-      const error = new Error('scaleFactor must be a Number')
-      return Promise.reject(error)
-    }
-    printSettings.scaleFactor = options.scaleFactor
-  }
-
-  if (options.marginsType !== undefined) {
-    if (typeof options.marginsType !== 'number') {
-      const error = new Error('marginsType must be a Number')
-      return Promise.reject(error)
-    }
-    printSettings.marginsType = options.marginsType
-  }
-
-  if (options.printSelectionOnly !== undefined) {
-    if (typeof options.printSelectionOnly !== 'boolean') {
-      const error = new Error('printSelectionOnly must be a Boolean')
-      return Promise.reject(error)
-    }
-    printSettings.shouldPrintSelectionOnly = options.printSelectionOnly
-  }
-
-  if (options.printBackground !== undefined) {
-    if (typeof options.printBackground !== 'boolean') {
-      const error = new Error('printBackground must be a Boolean')
-      return Promise.reject(error)
-    }
-    printSettings.shouldPrintBackgrounds = options.printBackground
-  }
-
-  if (options.pageRanges !== undefined) {
-    const pageRanges = options.pageRanges
-    if (!pageRanges.hasOwnProperty('from') || !pageRanges.hasOwnProperty('to')) {
-      const error = new Error(`pageRanges must be an Object with 'from' and 'to' properties`)
-      return Promise.reject(error)
-    }
-
-    if (typeof pageRanges.from !== 'number') {
-      const error = new Error('pageRanges.from must be a Number')
-      return Promise.reject(error)
-    }
-
-    if (typeof pageRanges.to !== 'number') {
-      const error = new Error('pageRanges.to must be a Number')
-      return Promise.reject(error)
-    }
-
-    // Chromium uses 1-based page ranges, so increment each by 1.
-    printSettings.pageRange = [{
-      from: pageRanges.from + 1,
-      to: pageRanges.to + 1
-    }]
-  }
-
-  if (options.headerFooter !== undefined) {
-    const headerFooter = options.headerFooter
-    printSettings.headerFooterEnabled = true
-    if (typeof headerFooter === 'object') {
-      if (!headerFooter.url || !headerFooter.title) {
-        const error = new Error('url and title properties are required for headerFooter')
-        return Promise.reject(error)
-      }
-      if (typeof headerFooter.title !== 'string') {
-        const error = new Error('headerFooter.title must be a String')
-        return Promise.reject(error)
-      }
-      printSettings.title = headerFooter.title
-
-      if (typeof headerFooter.url !== 'string') {
-        const error = new Error('headerFooter.url must be a String')
-        return Promise.reject(error)
-      }
-      printSettings.url = headerFooter.url
-    } else {
-      const error = new Error('headerFooter must be an Object')
-      return Promise.reject(error)
-    }
-  }
-
-  // Optionally set size for PDF.
-  if (options.pageSize !== undefined) {
-    const pageSize = options.pageSize
-    if (typeof pageSize === 'object') {
-      if (!pageSize.height || !pageSize.width) {
-        const error = new Error('height and width properties are required for pageSize')
-        return Promise.reject(error)
-      }
-      // Dimensions in Microns
-      // 1 meter = 10^6 microns
-      printSettings.mediaSize = {
-        name: 'CUSTOM',
-        custom_display_name: 'Custom',
-        height_microns: Math.ceil(pageSize.height),
-        width_microns: Math.ceil(pageSize.width)
-      }
-    } else if (PDFPageSizes[pageSize]) {
-      printSettings.mediaSize = PDFPageSizes[pageSize]
-    } else {
-      const error = new Error(`Unsupported pageSize: ${pageSize}`)
-      return Promise.reject(error)
-    }
-  } else {
-    printSettings.mediaSize = PDFPageSizes['A4']
-  }
-
-  // Chromium expects this in a 0-100 range number, not as float
-  printSettings.scaleFactor = Math.ceil(printSettings.scaleFactor) % 100
-  // PrinterType enum from //printing/print_job_constants.h
-  printSettings.printerType = 2
+WebContents.prototype.printToPDF = function (options = {}) {
   if (features.isPrintingEnabled()) {
-    return this._printToPDF(printSettings)
+    const { error, settings } = updatePrintSettings(options, 'PDF')
+    if (error) return Promise.reject(error)
+    console.log(settings)
+    return this._printToPDF(settings)
   } else {
     const error = new Error('Printing feature is disabled')
     return Promise.reject(error)
@@ -341,39 +220,17 @@ WebContents.prototype.printToPDF = function (options) {
 }
 
 WebContents.prototype.print = function (options = {}, callback) {
-  // TODO(codebytere): deduplicate argument sanitization by moving rest of
-  // print param logic into new file shared between printToPDF and print
-  if (typeof options === 'object') {
-    // Optionally set size for PDF.
-    if (options.pageSize !== undefined) {
-      const pageSize = options.pageSize
-      if (typeof pageSize === 'object') {
-        if (!pageSize.height || !pageSize.width) {
-          throw new Error('height and width properties are required for pageSize')
-        }
-        // Dimensions in Microns - 1 meter = 10^6 microns
-        options.mediaSize = {
-          name: 'CUSTOM',
-          custom_display_name: 'Custom',
-          height_microns: Math.ceil(pageSize.height),
-          width_microns: Math.ceil(pageSize.width)
-        }
-      } else if (PDFPageSizes[pageSize]) {
-        options.mediaSize = PDFPageSizes[pageSize]
-      } else {
-        throw new Error(`Unsupported pageSize: ${pageSize}`)
-      }
-    }
-  }
-
   if (features.isPrintingEnabled()) {
+    const { error, settings } = updatePrintSettings(options, 'REGULAR')
+    if (error) throw error
+
     if (callback) {
-      this._print(options, callback)
+      this._print(settings, callback)
     } else {
-      this._print(options)
+      this._print(settings)
     }
   } else {
-    console.error('Error: Printing feature is disabled.')
+    console.error('Error: Printing feature is disabled')
   }
 }
 

--- a/lib/browser/printing.ts
+++ b/lib/browser/printing.ts
@@ -1,0 +1,337 @@
+enum PrintType {
+  PDF = 'PDF',
+  REGULAR = 'REGULAR'
+}
+
+const marginValues: Record<string, (0 | 1 | 2 | 3)> = {
+  default: 0,
+  none: 1,
+  printableArea: 2,
+  custom: 3
+}
+
+const duplexValues: Record<string, (0 | 1 | 2)> = {
+  simplex: 0,
+  longEdge: 1,
+  shortEdge: 2
+}
+
+// Stock page sizes
+const PDFPageSizes: Record<string, PageSize> = {
+  A5: {
+    custom_display_name: 'A5',
+    height_microns: 210000,
+    name: 'ISO_A5',
+    width_microns: 148000
+  },
+  A4: {
+    custom_display_name: 'A4',
+    height_microns: 297000,
+    name: 'ISO_A4',
+    is_default: 'true',
+    width_microns: 210000
+  },
+  A3: {
+    custom_display_name: 'A3',
+    height_microns: 420000,
+    name: 'ISO_A3',
+    width_microns: 297000
+  },
+  Legal: {
+    custom_display_name: 'Legal',
+    height_microns: 355600,
+    name: 'NA_LEGAL',
+    width_microns: 215900
+  },
+  Letter: {
+    custom_display_name: 'Letter',
+    height_microns: 279400,
+    name: 'NA_LETTER',
+    width_microns: 215900
+  },
+  Tabloid: {
+    height_microns: 431800,
+    name: 'NA_LEDGER',
+    width_microns: 279400,
+    custom_display_name: 'Tabloid'
+  }
+}
+
+let nextId = 0
+const getNextId = () => ++nextId
+
+// Default printing setting
+const defaultPrintSettings: PrintSettings = {
+  pageRange: [] as any as PageRange[],
+  mediaSize: PDFPageSizes['A4'],
+  landscape: false,
+  generateDraftData: true,
+  headerFooterEnabled: false,
+  marginsType: 0,
+  scaleFactor: 100,
+  shouldPrintBackgrounds: false,
+  shouldPrintSelectionOnly: false,
+  printWithCloudPrint: false,
+  printWithPrivet: false,
+  printWithExtension: false,
+  pagesPerSheet: 1,
+  // True if this is the first preview request.
+  isFirstRequest: false,
+  // Unique ID to identify a print preview UI.
+  previewUIID: 0,
+  previewModifiable: true,
+  dpiHorizontal: 72,
+  dpiVertical: 72,
+  // Whether to rasterize the PDF for printing.
+  rasterizePDF: false,
+  duplex: 0,
+  copies: 1,
+  color: 2,
+  silent: false,
+  collate: true
+}
+
+export function updatePrintSettings (settings: PrintSettings, type: PrintType) {
+  const printSettings: PrintSettings = { ...defaultPrintSettings }
+
+  settings.printToPDF = type === PrintType.PDF
+
+  // Page orientation (true for landscape, false for portrait).
+  if (settings.landscape !== undefined) {
+    if (typeof settings.landscape !== 'boolean') {
+      const error = new Error('landscape must be a Boolean')
+      return { error }
+    }
+    printSettings.landscape = settings.landscape
+  }
+
+  // Scaling factor of the page (0-100).
+  if (settings.scaleFactor !== undefined) {
+    if (typeof settings.scaleFactor !== 'number') {
+      const error = new Error('scaleFactor must be a Number')
+      return { error }
+    }
+    printSettings.scaleFactor = settings.scaleFactor
+  }
+
+  // Chromium expects this as a 0-100 range number & not float, so ensure that.
+  printSettings.scaleFactor = Math.ceil(printSettings.scaleFactor) % 100
+
+  // See DuplexMode in //printing/print_job_constants.h.
+  // Default is `simplex` -> 0.
+  if (settings.duplexMode !== undefined) {
+    if (!['simplex', 'longEdge', 'shortEdge'].includes(settings.duplexMode)) {
+      const error = new Error(`duplexMode must be one of simplex', 'longEdge', or 'shortEdge'.`)
+      return { error }
+    }
+    printSettings.duplex = duplexValues[settings.duplexMode]
+  }
+
+  // See ColorModel in //printing/print_job_constants.h.
+  // Default is `true` -> 2 (color) and `false` -> 1 (gray)
+  if (!settings.color !== undefined) {
+    if (typeof settings.color !== 'boolean') {
+      const error = new Error('color must be a Boolean')
+      return { error }
+    }
+    printSettings.color = settings.color ? 2 : 1
+  }
+
+  // See MarginType in //printing/print_job_constants.h.
+  if (settings.margins !== undefined) {
+    const margins = settings.margins
+    if (typeof margins !== 'object') {
+      const error = new Error('margins must be an Object')
+      return { error }
+    }
+
+    if (!Object.keys(marginValues).includes(margins.marginType)) {
+      const error = new Error(`marginsType must be one of 'default', 'none', 'printableArea', or 'custom'.`)
+      return { error }
+    }
+
+    // If 'custom' is specified, users must specify margin for all directions.
+    if (margins.marginType === 'custom') {
+      const { top, bottom, left, right } = margins
+      if (![top, bottom, left, right].every(d => d !== undefined)) {
+        const error = new Error(`marginsType 'custom' must define 'top', 'bottom', 'left', and 'right'.`)
+        return { error }
+      }
+      printSettings.top = margins.top
+      printSettings.bottom = margins.bottom
+      printSettings.left = margins.left
+      printSettings.right = margins.right
+    } else {
+      printSettings.marginsType = marginValues[margins.marginType]
+    }
+  }
+
+  // Whether to print selection only.
+  if (settings.printSelectionOnly !== undefined) {
+    if (typeof settings.printSelectionOnly !== 'boolean') {
+      const error = new Error('printSelectionOnly must be a Boolean')
+      return { error }
+    }
+    printSettings.shouldPrintSelectionOnly = settings.printSelectionOnly
+  }
+
+  // Whether to print CSS backgrounds.
+  if (settings.printBackground !== undefined) {
+    if (typeof settings.printBackground !== 'boolean') {
+      const error = new Error('printBackground must be a Boolean')
+      return { error }
+    }
+    printSettings.shouldPrintBackgrounds = settings.printBackground
+  }
+
+  // Number of pages per sheet.
+  if (settings.pagesPerSheet !== undefined) {
+    if (typeof settings.pagesPerSheet !== 'boolean') {
+      const error = new Error('pagesPerSheet must be a Number')
+      return { error }
+    }
+    printSettings.pagesPerSheet = settings.pagesPerSheet
+  }
+
+  // Whether to collate (organize) the composited pages.
+  if (settings.collate !== undefined) {
+    if (typeof settings.collate !== 'boolean') {
+      const error = new Error('collate must be a Boolean')
+      return { error }
+    }
+    printSettings.collate = settings.collate
+  }
+
+  // The number of individual copies to print.
+  if (settings.copies !== undefined) {
+    if (typeof settings.copies !== 'boolean') {
+      const error = new Error('copies must be a Boolean')
+      return { error }
+    }
+    printSettings.copies = settings.copies
+  }
+
+  // The page ranges to print.
+  if (settings.pageRanges !== undefined) {
+    const pageRanges: PageRange = settings.pageRanges as any as PageRange
+    if (!pageRanges.hasOwnProperty('from') || !pageRanges.hasOwnProperty('to')) {
+      const error = new Error(`pageRanges must be an Object with 'from' and 'to' properties`)
+      return { error }
+    }
+
+    if (typeof pageRanges.from !== 'number') {
+      const error = new Error('pageRanges.from must be a Number')
+      return { error }
+    }
+
+    if (typeof pageRanges.to !== 'number') {
+      const error = new Error('pageRanges.to must be a Number')
+      return { error }
+    }
+
+    // Chromium uses 1-based page ranges, so increment each by 1.
+    printSettings.pageRange = [{
+      // The first page of a page range. (1-based)
+      from: pageRanges.from + 1,
+      // The last page of a page range. (1-based)
+      to: pageRanges.to + 1
+    }]
+  }
+
+  // The name of the printer to print to.
+  if (settings.deviceName !== undefined) {
+    if (typeof settings.deviceName !== 'string') {
+      const error = new Error('deviceName must be a string')
+      return { error }
+    }
+    printSettings.deviceName = settings.deviceName
+  }
+
+  // The horizontal and vertical dots per inch (dpi) setting.
+  if (settings.dpi !== undefined) {
+    const dpi = settings.dpi
+    if (typeof dpi === 'object') {
+      if (!dpi.vertical || !dpi.horizontal) {
+        const error = new Error('vertical and horizontal properties are required for dpi')
+        return { error }
+      }
+    } else {
+      const error = new Error('dpi must be an Object')
+      return { error }
+    }
+  }
+
+  // The header and footer to specify for the printed document.
+  if (settings.headerFooter !== undefined) {
+    const headerFooter = settings.headerFooter
+    printSettings.headerFooterEnabled = true
+    if (typeof headerFooter === 'object') {
+      if (!headerFooter.url || !headerFooter.title) {
+        const error = new Error('url and title properties are required for headerFooter')
+        return { error }
+      }
+      if (typeof headerFooter.title !== 'string') {
+        const error = new Error('headerFooter.title must be a String')
+        return { error }
+      }
+      printSettings.title = headerFooter.title
+
+      if (typeof headerFooter.url !== 'string') {
+        const error = new Error('headerFooter.url must be a String')
+        return { error }
+      }
+      printSettings.url = headerFooter.url
+    } else {
+      const error = new Error('headerFooter must be an Object')
+      return { error }
+    }
+  }
+
+  // Specifies the requested media size - see PDFPageSizes.
+  if (settings.pageSize !== undefined) {
+    const pageSize = settings.pageSize
+    if (typeof pageSize === 'object') {
+      if (!pageSize.height || !pageSize.width) {
+        const error = new Error('height and width properties are required for pageSize')
+        return { error }
+      }
+      // Dimensions in Microns (1 meter = 10^6 microns)
+      printSettings.mediaSize = {
+        name: 'CUSTOM',
+        custom_display_name: 'Custom',
+        height_microns: Math.ceil(pageSize.height),
+        width_microns: Math.ceil(pageSize.width)
+      }
+    } else if (PDFPageSizes[pageSize]) {
+      printSettings.mediaSize = PDFPageSizes[pageSize]
+    } else {
+      const error = new Error(`Unsupported pageSize: ${pageSize}`)
+      return { error }
+    }
+  }
+
+  // PDF-Specific Settings
+  if (type === PrintType.PDF) {
+    // Unique ID sent along every preview request.
+    printSettings.requestID = getNextId()
+
+    // Chromium-specified device name when printing to PDF.
+    printSettings.deviceName = 'Save as PDF'
+
+    // Set printing to Local Printer.
+    printSettings.printerType = 2
+  }
+
+  // Regular print-specific settings
+  if (type === PrintType.REGULAR) {
+    if (printSettings.silent !== undefined) {
+      if (typeof printSettings.silent !== 'boolean') {
+        const error = new Error('silent must be a Boolean')
+        return { error }
+      }
+      printSettings.silent = settings.silent
+    }
+  }
+
+  return { settings: printSettings }
+}

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -135,58 +135,6 @@ struct Converter<printing::PrinterBasicInfo> {
   }
 };
 
-template <>
-struct Converter<printing::MarginType> {
-  static bool FromV8(v8::Isolate* isolate,
-                     v8::Local<v8::Value> val,
-                     printing::MarginType* out) {
-    std::string type;
-    if (ConvertFromV8(isolate, val, &type)) {
-      if (type == "default") {
-        *out = printing::DEFAULT_MARGINS;
-        return true;
-      }
-      if (type == "none") {
-        *out = printing::NO_MARGINS;
-        return true;
-      }
-      if (type == "printableArea") {
-        *out = printing::PRINTABLE_AREA_MARGINS;
-        return true;
-      }
-      if (type == "custom") {
-        *out = printing::CUSTOM_MARGINS;
-        return true;
-      }
-    }
-    return false;
-  }
-};
-
-template <>
-struct Converter<printing::DuplexMode> {
-  static bool FromV8(v8::Isolate* isolate,
-                     v8::Local<v8::Value> val,
-                     printing::DuplexMode* out) {
-    std::string mode;
-    if (ConvertFromV8(isolate, val, &mode)) {
-      if (mode == "simplex") {
-        *out = printing::SIMPLEX;
-        return true;
-      }
-      if (mode == "longEdge") {
-        *out = printing::LONG_EDGE;
-        return true;
-      }
-      if (mode == "shortEdge") {
-        *out = printing::SHORT_EDGE;
-        return true;
-      }
-    }
-    return false;
-  }
-};
-
 #endif
 
 template <>
@@ -1781,141 +1729,16 @@ void WebContents::Print(gin_helper::Arguments* args) {
   bool silent = false;
   options.Get("silent", &silent);
 
-  bool print_background = false;
-  options.Get("printBackground", &print_background);
-  settings.SetBoolKey(printing::kSettingShouldPrintBackgrounds,
-                      print_background);
-
-  // Set custom margin settings
-  gin_helper::Dictionary margins =
-      gin::Dictionary::CreateEmpty(args->isolate());
-  if (options.Get("margins", &margins)) {
-    printing::MarginType margin_type = printing::DEFAULT_MARGINS;
-    margins.Get("marginType", &margin_type);
-    settings.SetIntKey(printing::kSettingMarginsType, margin_type);
-
-    if (margin_type == printing::CUSTOM_MARGINS) {
-      int top = 0;
-      margins.Get("top", &top);
-      settings.SetIntKey(printing::kSettingMarginTop, top);
-      int bottom = 0;
-      margins.Get("bottom", &bottom);
-      settings.SetIntKey(printing::kSettingMarginBottom, bottom);
-      int left = 0;
-      margins.Get("left", &left);
-      settings.SetIntKey(printing::kSettingMarginLeft, left);
-      int right = 0;
-      margins.Get("right", &right);
-      settings.SetIntKey(printing::kSettingMarginRight, right);
-    }
-  } else {
-    settings.SetIntKey(printing::kSettingMarginsType,
-                       printing::DEFAULT_MARGINS);
-  }
-
-  // Set whether to print color or greyscale
-  bool print_color = true;
-  options.Get("color", &print_color);
-  int color_setting = print_color ? printing::COLOR : printing::GRAY;
-  settings.SetIntKey(printing::kSettingColor, color_setting);
-
-  // Is the orientation landscape or portrait.
-  bool landscape = false;
-  options.Get("landscape", &landscape);
-  settings.SetBoolKey(printing::kSettingLandscape, landscape);
-
-  // We set the default to the system's default printer and only update
-  // if at the Chromium level if the user overrides.
-  // Printer device name as opened by the OS.
+  // Printer device name as opened by the OS; we set the default to the system's
+  // default printer and only update at the Chromium level if the user overrides
+  // it. We *must* check this here even though it was sanitized on the JS level
+  // because Chromium will crash unless the printer actually exists on the
+  // network.
   base::string16 device_name;
   options.Get("deviceName", &device_name);
   if (!device_name.empty() && !IsDeviceNameValid(device_name)) {
     args->ThrowError("webContents.print(): Invalid deviceName provided.");
     return;
-  }
-
-  int scale_factor = 100;
-  options.Get("scaleFactor", &scale_factor);
-  settings.SetIntKey(printing::kSettingScaleFactor, scale_factor);
-
-  int pages_per_sheet = 1;
-  options.Get("pagesPerSheet", &pages_per_sheet);
-  settings.SetIntKey(printing::kSettingPagesPerSheet, pages_per_sheet);
-
-  // True if the user wants to print with collate.
-  bool collate = true;
-  options.Get("collate", &collate);
-  settings.SetBoolKey(printing::kSettingCollate, collate);
-
-  // The number of individual copies to print
-  int copies = 1;
-  options.Get("copies", &copies);
-  settings.SetIntKey(printing::kSettingCopies, copies);
-
-  // Strings to be printed as headers and footers if requested by the user.
-  std::string header;
-  options.Get("header", &header);
-  std::string footer;
-  options.Get("footer", &footer);
-
-  if (!(header.empty() && footer.empty())) {
-    settings.SetBoolKey(printing::kSettingHeaderFooterEnabled, true);
-
-    settings.SetStringKey(printing::kSettingHeaderFooterTitle, header);
-    settings.SetStringKey(printing::kSettingHeaderFooterURL, footer);
-  } else {
-    settings.SetBoolKey(printing::kSettingHeaderFooterEnabled, false);
-  }
-
-  // We don't want to allow the user to enable these settings
-  // but we need to set them or a CHECK is hit.
-  settings.SetIntKey(printing::kSettingPrinterType, printing::kLocalPrinter);
-  settings.SetBoolKey(printing::kSettingShouldPrintSelectionOnly, false);
-  settings.SetBoolKey(printing::kSettingRasterizePdf, false);
-
-  // Set custom page ranges to print
-  std::vector<gin_helper::Dictionary> page_ranges;
-  if (options.Get("pageRanges", &page_ranges)) {
-    base::Value page_range_list(base::Value::Type::LIST);
-    for (auto& range : page_ranges) {
-      int from, to;
-      if (range.Get("from", &from) && range.Get("to", &to)) {
-        base::Value range(base::Value::Type::DICTIONARY);
-        range.SetIntKey(printing::kSettingPageRangeFrom, from);
-        range.SetIntKey(printing::kSettingPageRangeTo, to);
-        page_range_list.Append(std::move(range));
-      } else {
-        continue;
-      }
-    }
-    if (page_range_list.GetList().size() > 0)
-      settings.SetPath(printing::kSettingPageRange, std::move(page_range_list));
-  }
-
-  // Duplex type user wants to use.
-  printing::DuplexMode duplex_mode;
-  options.Get("duplexMode", &duplex_mode);
-  settings.SetIntKey(printing::kSettingDuplexMode, duplex_mode);
-
-  // We've already done necessary parameter sanitization at the
-  // JS level, so we can simply pass this through.
-  base::Value media_size(base::Value::Type::DICTIONARY);
-  if (options.Get("mediaSize", &media_size))
-    settings.SetKey(printing::kSettingMediaSize, std::move(media_size));
-
-  // Set custom dots per inch (dpi)
-  gin_helper::Dictionary dpi_settings;
-  int dpi = 72;
-  if (options.Get("dpi", &dpi_settings)) {
-    int horizontal = 72;
-    dpi_settings.Get("horizontal", &horizontal);
-    settings.SetIntKey(printing::kSettingDpiHorizontal, horizontal);
-    int vertical = 72;
-    dpi_settings.Get("vertical", &vertical);
-    settings.SetIntKey(printing::kSettingDpiVertical, vertical);
-  } else {
-    settings.SetIntKey(printing::kSettingDpiHorizontal, dpi);
-    settings.SetIntKey(printing::kSettingDpiVertical, dpi);
   }
 
   base::PostTaskAndReplyWithResult(

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -1446,7 +1446,7 @@ describe('webContents module', () => {
 
     it('rejects on incorrectly typed parameters', async () => {
       const badTypes = {
-        marginsType: 'terrible',
+        margins: 'terrible',
         scaleFactor: 'not-a-number',
         landscape: [],
         pageRanges: { 'oops': 'im-not-the-right-key' },

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -86,7 +86,9 @@ app.whenReady().then(() => {
   mainWindow.webContents.print()
 
   mainWindow.webContents.printToPDF({
-    marginsType: 1,
+    margins: {
+      marginType: 'default',
+    },
     pageSize: 'A3',
     printBackground: true,
     printSelectionOnly: true,

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -79,6 +79,72 @@ interface ContextMenuItem {
   subItems: ContextMenuItem[];
 }
 
+interface PageSize {
+  custom_display_name: string;
+  height_microns: number;
+  name: string;
+  is_default?: string;
+  width_microns: number;
+}
+
+interface MarginType {
+  marginType: 'default' | 'none' | 'printableArea' | 'custom';
+  top?: number;
+  bottom?: number;
+  left?: number;
+  right?: number;
+}
+
+type PageRange = {from: number, to: number};
+type Size = { width: number, height: number};
+
+interface PrintSettings {
+  // Sent to Chromium
+  bottom?: number;
+  collate: boolean;
+  color: 1 | 2;
+  copies: number;
+  deviceName?: string;
+  dpiHorizontal: number;
+  dpiVertical: number;
+  duplex: 0 | 1 | 2;
+  generateDraftData: boolean;
+  headerFooterEnabled: boolean;
+  isFirstRequest: boolean;
+  landscape: boolean;
+  left?: number;
+  marginsType: 0 | 1 | 2 | 3;
+  mediaSize: PageSize;
+  pageRanges?: PageRange[];
+  pagesPerSheet: 1,
+  previewModifiable: boolean;
+  previewUIID: number;
+  printerType?: 0 | 1 | 2 | 3 | 4;
+  printWithCloudPrint: boolean;
+  printWithExtension: boolean;
+  printWithPrivet: boolean;
+  rasterizePDF: boolean;
+  requestID?: number;
+  right?: number;
+  scaleFactor: number;
+  shouldPrintBackgrounds: boolean;
+  shouldPrintSelectionOnly: boolean;
+  silent?: boolean;
+  title?: string;
+  top?: number;
+  url?: string;
+  // Used internally only
+  dpi?: {horizontal: number, vertical: number}
+  duplexMode?: 'simplex' | 'longEdge' | 'shortEdge';
+  headerFooter?: {title: string, url: string};
+  pageSize?: Size | string;
+  printBackground?: boolean;
+  printSelectionOnly?: boolean;
+  printToPDF?: boolean;
+  pageRange?: PageRange[];
+  margins?: MarginType;
+}
+
 declare interface Window {
   ELECTRON_DISABLE_SECURITY_WARNINGS?: boolean;
   ELECTRON_ENABLE_SECURITY_WARNINGS?: boolean;


### PR DESCRIPTION
#### Description of Change

_Here there be dragons. 🐉 🐉 Not yet ready for review._

This PR coalesces all parameter sanitization into JavaScript for `contents.print()` and `contents.printToPDF()`. This is necessary for several reasons:
* It's easier to test faulty options at this later
* We have significant code sprawl for essentially the same parameters across the C++ and JS layer, which opened the door for more bugs and less consistent checks.
* Notable code de-duplication.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
