### PR TITLE
build: actually save the brew cache on macOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -953,7 +953,6 @@ steps-checkout-and-save-cache: &steps-checkout-and-save-cache
           sudo chown -R $(id -u):$(id -g) /portal
           mv ./src /portal
     - *step-save-src-cache
-    - *step-save-brew-cache
 
 steps-electron-gn-check: &steps-electron-gn-check
   steps:
@@ -1349,6 +1348,7 @@ commands:
                 at: .
       - *step-restore-brew-cache
       - *step-install-gnutar-on-mac
+      - *step-save-brew-cache
       - when:
           condition: << parameters.checkout-and-assume-cache >>
           steps:


### PR DESCRIPTION
This should save ~4 minutes from our build (again) by actually saving the cache correctly.  I think I broke this when I was moving things around before.

Notes: no-notes