### PR TITLE
fix: use a WeakPtr so we do not UAF the store in FunctionLifetimeMonitor

### DIFF
--- a/shell/renderer/api/context_bridge/render_frame_context_bridge_store.h
+++ b/shell/renderer/api/context_bridge/render_frame_context_bridge_store.h
@@ -50,6 +50,10 @@ class RenderFramePersistenceStore final : public content::RenderFrameObserver {
                           v8::Local<v8::Value> proxy_value);
   v8::MaybeLocal<v8::Value> GetCachedProxiedObject(v8::Local<v8::Value> from);
 
+  base::WeakPtr<RenderFramePersistenceStore> GetWeakPtr() {
+    return weak_factory_.GetWeakPtr();
+  }
+
  private:
   // func_id ==> { function, owning_context }
   std::map<size_t, FunctionContextPair> functions_;


### PR DESCRIPTION
We already did this for the ObjectLifeMonitor, should also do it for the FunctionLifetimeMonitor

Notes: Fixed issue where renderers could crash during GC when using the `contextBridge` module