### PR TITLE
chore: print more logging for failed tests

### DIFF
--- a/spec-main/api-menu-spec.ts
+++ b/spec-main/api-menu-spec.ts
@@ -888,8 +888,12 @@ describe('Menu module', function () {
 
       let output = ''
       appProcess.stdout.on('data', data => { output += data })
+      appProcess.stderr.on('data', data => { output += data })
 
-      await emittedOnce(appProcess, 'exit')
+      const [code] = await emittedOnce(appProcess, 'exit')
+      if (!output.includes('Window has no menu')) {
+        console.log(code, output)
+      }
       expect(output).to.include('Window has no menu')
     })
   })

--- a/spec-main/api-web-contents-view-spec.ts
+++ b/spec-main/api-web-contents-view-spec.ts
@@ -29,8 +29,14 @@ describe('WebContentsView', () => {
     it('does not crash on exit', async () => {
       const appPath = path.join(__dirname, 'fixtures', 'api', 'leak-exit-webcontentsview.js')
       const electronPath = process.execPath
-      const appProcess = ChildProcess.spawn(electronPath, [appPath])
+      const appProcess = ChildProcess.spawn(electronPath, ['--enable-logging', appPath])
+      let output = ''
+      appProcess.stdout.on('data', data => { output += data })
+      appProcess.stderr.on('data', data => { output += data })
       const [code] = await emittedOnce(appProcess, 'exit')
+      if (code !== 0) {
+        console.log(code, output)
+      }
       expect(code).to.equal(0)
     })
   })


### PR DESCRIPTION
#### Description of Change

A few tests are failing frequently on CI and I don't have much idea of the cause since they run child apps and do not have much output.

I have made them print more output so I can find out the cause.

#### Release Notes

Notes: no-notes