### PR TITLE
build: copy chromedriver.zip to proper directory for release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -451,6 +451,7 @@ step-electron-chromedriver-build: &step-electron-chromedriver-build
       ninja -C out/chromedriver electron:electron_chromedriver -j $NUMBER_OF_NINJA_PROCESSES
       electron/script/strip-binaries.py --target-cpu="$TARGET_ARCH" --file $PWD/out/chromedriver/chromedriver
       ninja -C out/chromedriver electron:electron_chromedriver_zip
+      cp out/chromedriver/chromedriver.zip out/Default/chromedriver
 
 step-electron-chromedriver-store: &step-electron-chromedriver-store
   store_artifacts:


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
#22033 broke the release because it changed the location of chromedriver.zip.  This PR copies chromedriver.zip to the location that the release expects it to be in.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
