### PR TITLE
ci: fix build failure on doc only changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -884,7 +884,7 @@ step-ts-compile: &step-ts-compile
     command: |
       cd src
       ninja -C out/Default electron:default_app_js -j $NUMBER_OF_NINJA_PROCESSES
-      ninja -C out/Default electron:atom_js2c -j $NUMBER_OF_NINJA_PROCESSES
+      ninja -C out/Default electron:electron_js2c -j $NUMBER_OF_NINJA_PROCESSES
 
 # Lists of steps.
 steps-lint: &steps-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -848,7 +848,7 @@ step-check-for-doc-only-change: &step-check-for-doc-only-change
     command: |
       cd src/electron
       node script/yarn install --frozen-lockfile
-      if node script/doc-only-change.js --prNumber=$CIRCLE_PR_NUMBER --prURL=$CIRCLE_PULL_REQUEST; then
+      if node script/doc-only-change.js --prNumber=$CIRCLE_PR_NUMBER --prURL=$CIRCLE_PULL_REQUEST --prBranch=$CIRCLE_BRANCH; then
         #PR is doc only change; save file with value true to indicate doc only change
         echo "true" > .skip-ci-build
       else

--- a/script/doc-only-change.js
+++ b/script/doc-only-change.js
@@ -9,7 +9,11 @@ async function checkIfDocOnlyChange () {
     try {
       let pullRequestNumber = args.prNumber
       if (!pullRequestNumber || isNaN(pullRequestNumber)) {
-        if (args.prBranch) {
+        if (args.prURL) {
+          // CircleCI doesn't provide the PR number for branch builds, but it does provide the PR URL
+          const pullRequestParts = args.prURL.split('/')
+          pullRequestNumber = pullRequestParts[pullRequestParts.length - 1]
+        } else if (args.prBranch) {
           // AppVeyor doesn't provide a PR number for branch builds - figure it out from the branch
           const prsForBranch = await octokit.pulls.list({
             owner: 'electron',
@@ -23,10 +27,6 @@ async function checkIfDocOnlyChange () {
             // If there are 0 PRs or more than one PR on a branch, just assume that this is more than a doc change
             process.exit(1)
           }
-        } else if (args.prURL) {
-          // CircleCI doesn't provide the PR number for branch builds, but it does provide the PR URL
-          const pullRequestParts = args.prURL.split('/')
-          pullRequestNumber = pullRequestParts[pullRequestParts.length - 1]
         }
       }
       const filesChanged = await octokit.pulls.listFiles({


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Doc only PRs were failing CI due to the changes made in #21986.  Eg: https://circleci.com/gh/electron/electron/459499.  This PR fixes that issue.

Additionally, this fixes an issue where CircleCI was incorrectly considering a doc only change as a full change when the change is made on a branch and CI fires before a PR is created.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
