### PR TITLE
fix: explicitly specify `typeRoots` to avoid crawling parent directories

### DIFF
--- a/spec/ts-smoke/tsconfig.json
+++ b/spec/ts-smoke/tsconfig.json
@@ -5,6 +5,7 @@
           "es6",
           "dom"
       ],
+      "typeRoots" : ["../../node_modules/@types"],
       "noImplicitAny": true,
       "noImplicitThis": true,
       "strictNullChecks": false,


### PR DESCRIPTION
#### Description of Change

When electron is nested in a subdirectory of another project with a top-level `node_modules` the contents of that completely unrelated `node_modules` directory can cause issues running ts smoke tests. The default behavior of `tsc` is to find `node_modules/@types` in all directories up the chain until the file system root but we can override that by specifying `typeRoots` to explicitly point at the desired `electron/node_modules/@types` folder.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes