### PR TITLE
feat: disable the remote module by default

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -16,7 +16,7 @@ Electron 10, the remote module is now disabled by default. To use the remote
 module, `enableRemoteModule: true` must be specified in WebPreferences:
 
 ```js
-new BrowserWindow({
+const w = new BrowserWindow({
   webPreferences: {
     enableRemoteModule: true
   }

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -6,6 +6,26 @@ Breaking changes will be documented here, and deprecation warnings added to JS c
 
 The `FIXME` string is used in code comments to denote things that should be fixed for future releases. See https://github.com/electron/electron/search?q=fixme
 
+## Planned Breaking API Changes (10.0)
+
+### `enableRemoteModule` defaults to `false`
+
+In Electron 9, using the remote module without explicitly enabling it via the
+`enableRemoteModule` WebPreferences option began emitting a warning. In
+Electron 10, the remote module is now disabled by default. To use the remote
+module, `enableRemoteModule: true` must be specified in WebPreferences:
+
+```js
+new BrowserWindow({
+  webPreferences: {
+    enableRemoteModule: true
+  }
+})
+```
+
+We [recommend moving away from the remote
+module](https://medium.com/@nornagon/electrons-remote-module-considered-harmful-70d69500f31).
+
 ## Planned Breaking API Changes (9.0)
 
 ### `<webview>.getWebContents()`

--- a/lib/browser/remote/server.ts
+++ b/lib/browser/remote/server.ts
@@ -321,7 +321,7 @@ const unwrapArgs = function (sender: electron.WebContents, frameId: number, cont
 
 const isRemoteModuleEnabledImpl = function (contents: electron.WebContents) {
   const webPreferences = (contents as any).getLastWebPreferences() || {}
-  return webPreferences.enableRemoteModule != null ? !!webPreferences.enableRemoteModule : true
+  return webPreferences.enableRemoteModule != null ? !!webPreferences.enableRemoteModule : false
 }
 
 const isRemoteModuleEnabledCache = new WeakMap()

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -13,15 +13,6 @@ const remoteObjectCache = v8Util.createIDWeakMap()
 // An unique ID that can represent current context.
 const contextId = v8Util.getHiddenValue(global, 'contextId')
 
-ipcRendererInternal.invoke('ELECTRON_BROWSER_GET_LAST_WEB_PREFERENCES').then(preferences => {
-  console.log(preferences)
-  if (!preferences.enableRemoteModule) {
-    console.warn('%cElectron Deprecation Warning', 'font-weight: bold', "The 'remote' module is deprecated and will be disabled by default in a future version of Electron. To ensure a smooth upgrade and silence this warning, specify {enableRemoteModule: true} in the WebPreferences for this window.")
-  }
-}, (err) => {
-  console.error('Failed to get web preferences:', err)
-})
-
 // Notify the main process when current context is going to be released.
 // Note that when the renderer process is destroyed, the message may not be
 // sent, we also listen to the "render-view-deleted" event in the main process

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -327,7 +327,7 @@ void WebContentsPreferences::AppendCommandLineSwitches(
 
 #if BUILDFLAG(ENABLE_REMOTE_MODULE)
   // Whether to enable the remote module
-  if (IsEnabled(options::kEnableRemoteModule, true))
+  if (IsEnabled(options::kEnableRemoteModule, false))
     command_line->AppendSwitch(switches::kEnableRemoteModule);
 #endif
 

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -457,7 +457,8 @@ describe('app module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
-            nodeIntegration: true
+            nodeIntegration: true,
+            enableRemoteModule: true
           }
         })
         await w.loadURL('about:blank')
@@ -474,7 +475,8 @@ describe('app module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
-            nodeIntegration: true
+            nodeIntegration: true,
+            enableRemoteModule: true
           }
         })
         await w.loadURL('about:blank')
@@ -491,7 +493,8 @@ describe('app module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
-            nodeIntegration: true
+            nodeIntegration: true,
+            enableRemoteModule: true
           }
         })
         await w.loadURL('about:blank')
@@ -508,7 +511,8 @@ describe('app module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
-            nodeIntegration: true
+            nodeIntegration: true,
+            enableRemoteModule: true
           }
         })
         await w.loadURL('about:blank')
@@ -524,7 +528,8 @@ describe('app module', () => {
         w = new BrowserWindow({
           show: false,
           webPreferences: {
-            nodeIntegration: true
+            nodeIntegration: true,
+            enableRemoteModule: true
           }
         })
         await w.loadURL('about:blank')

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1749,7 +1749,7 @@ describe('BrowserWindow module', () => {
         describe(description, () => {
           const preload = path.join(__dirname, 'fixtures', 'module', 'preload-remote.js')
 
-          it('enables the remote module by default', async () => {
+          it('disables the remote module by default', async () => {
             const w = new BrowserWindow({
               show: false,
               webPreferences: {
@@ -1760,7 +1760,7 @@ describe('BrowserWindow module', () => {
             const p = emittedOnce(ipcMain, 'remote')
             w.loadFile(path.join(fixtures, 'api', 'blank.html'))
             const [, remote] = await p
-            expect(remote).to.equal('object')
+            expect(remote).to.equal('undefined')
           })
 
           it('disables the remote module when false', async () => {
@@ -1776,6 +1776,21 @@ describe('BrowserWindow module', () => {
             w.loadFile(path.join(fixtures, 'api', 'blank.html'))
             const [, remote] = await p
             expect(remote).to.equal('undefined')
+          })
+
+          it('enables the remote module when true', async () => {
+            const w = new BrowserWindow({
+              show: false,
+              webPreferences: {
+                preload,
+                sandbox,
+                enableRemoteModule: true
+              }
+            })
+            const p = emittedOnce(ipcMain, 'remote')
+            w.loadFile(path.join(fixtures, 'api', 'blank.html'))
+            const [, remote] = await p
+            expect(remote).to.equal('object')
           })
         })
       }

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1628,6 +1628,7 @@ describe('BrowserWindow module', () => {
           show: false,
           webPreferences: {
             nodeIntegration: true,
+            enableRemoteModule: true,
             preload
           }
         })
@@ -2108,7 +2109,8 @@ describe('BrowserWindow module', () => {
           show: false,
           webPreferences: {
             preload,
-            sandbox: true
+            sandbox: true,
+            enableRemoteModule: true
           }
         })
         w.loadFile(path.join(__dirname, 'fixtures', 'api', 'sandbox.html'), { search: 'reload-remote' })
@@ -2140,7 +2142,8 @@ describe('BrowserWindow module', () => {
           show: false,
           webPreferences: {
             preload,
-            sandbox: true
+            sandbox: true,
+            enableRemoteModule: true
           }
         })
         w.webContents.once('new-window', (event, url, frameName, disposition, options) => {

--- a/spec-main/api-remote-spec.ts
+++ b/spec-main/api-remote-spec.ts
@@ -194,7 +194,8 @@ ifdescribe(features.isRemoteModuleEnabled())('remote module', () => {
       const w = new BrowserWindow({
         show: false,
         webPreferences: {
-          preload
+          preload,
+          enableRemoteModule: true
         }
       })
       w.loadURL('about:blank')
@@ -207,7 +208,8 @@ ifdescribe(features.isRemoteModuleEnabled())('remote module', () => {
       const w = new BrowserWindow({
         show: false,
         webPreferences: {
-          nodeIntegration: true
+          nodeIntegration: true,
+          enableRemoteModule: true
         }
       })
 
@@ -227,7 +229,8 @@ ifdescribe(features.isRemoteModuleEnabled())('remote module', () => {
       const w = new BrowserWindow({
         show: false,
         webPreferences: {
-          nodeIntegration: true
+          nodeIntegration: true,
+          enableRemoteModule: true
         }
       })
       await w.loadFile(path.join(fixtures, 'api', 'remote-event-handler.html'))

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -821,7 +821,7 @@ describe('webContents module', () => {
     })
 
     it('can persist zoom level across navigation', (done) => {
-      const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true } })
+      const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, enableRemoteModule: true } })
       let finalNavigation = false
       ipcMain.on('set-zoom', (e, host) => {
         const zoomLevel = hostZoomMap[host]
@@ -847,7 +847,7 @@ describe('webContents module', () => {
     })
 
     it('can propagate zoom level across same session', (done) => {
-      const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true } })
+      const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, enableRemoteModule: true } })
       const w2 = new BrowserWindow({ show: false })
       w2.webContents.on('did-finish-load', () => {
         const zoomLevel1 = w.webContents.zoomLevel


### PR DESCRIPTION
#### Description of Change
Ref #21408

Using the remote module without explicitly enabling it began [warning in Electron 9](https://github.com/electron/electron/pull/21546). This changes the default value of `enableRemoteModule` to be `false`.

BREAKING CHANGE

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Changed the default value of 'enableRemoteModule' to false.