### PR TITLE
build: preserve timestamps when stripping files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -406,7 +406,7 @@ step-maybe-electron-dist-strip: &step-maybe-electron-dist-strip
         fi
         cd src
         electron/script/copy-debug-symbols.py --target-cpu="$target_cpu" --out-dir=out/Default/debug --compress
-        electron/script/strip-binaries.py -v --target-cpu="$target_cpu"
+        electron/script/strip-binaries.py --target-cpu="$target_cpu"
         electron/script/add-debug-link.py --target-cpu="$target_cpu" --debug-dir=out/Default/debug
       fi
 
@@ -470,7 +470,7 @@ step-electron-chromedriver-build: &step-electron-chromedriver-build
         export CHROMEDRIVER_DIR="out/Default"
       fi
       ninja -C $CHROMEDRIVER_DIR electron:electron_chromedriver -j $NUMBER_OF_NINJA_PROCESSES
-      electron/script/strip-binaries.py -v --target-cpu="$TARGET_ARCH" --file $PWD/$CHROMEDRIVER_DIR/chromedriver
+      electron/script/strip-binaries.py --target-cpu="$TARGET_ARCH" --file $PWD/$CHROMEDRIVER_DIR/chromedriver
       ninja -C $CHROMEDRIVER_DIR electron:electron_chromedriver_zip
       if [ "$TARGET_ARCH" == "arm" ] || [ "$TARGET_ARCH" == "arm64" ]; then
         cp out/chromedriver/chromedriver.zip out/Default
@@ -632,12 +632,12 @@ step-mksnapshot-build: &step-mksnapshot-build
       gn desc out/Default v8:run_mksnapshot_default args > out/Default/mksnapshot_args
       if [ "`uname`" != "Darwin" ]; then
         if [ "$TARGET_ARCH" == "arm" ]; then
-          electron/script/strip-binaries.py -v --file $PWD/out/Default/clang_x86_v8_arm/mksnapshot
+          electron/script/strip-binaries.py --file $PWD/out/Default/clang_x86_v8_arm/mksnapshot
         elif [ "$TARGET_ARCH" == "arm64" ]; then
-          electron/script/strip-binaries.py -v --file $PWD/out/Default/clang_x64_v8_arm64/mksnapshot
+          electron/script/strip-binaries.py --file $PWD/out/Default/clang_x64_v8_arm64/mksnapshot
         else
-          electron/script/strip-binaries.py -v --file $PWD/out/Default/mksnapshot
-          electron/script/strip-binaries.py -v --file $PWD/out/Default/v8_context_snapshot_generator
+          electron/script/strip-binaries.py --file $PWD/out/Default/mksnapshot
+          electron/script/strip-binaries.py --file $PWD/out/Default/v8_context_snapshot_generator
         fi
       fi
       if [ "$SKIP_DIST_ZIP" != "1" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -470,7 +470,9 @@ step-electron-chromedriver-build: &step-electron-chromedriver-build
         export CHROMEDRIVER_DIR="out/Default"
       fi
       ninja -C $CHROMEDRIVER_DIR electron:electron_chromedriver -j $NUMBER_OF_NINJA_PROCESSES
-      electron/script/strip-binaries.py --target-cpu="$TARGET_ARCH" --file $PWD/$CHROMEDRIVER_DIR/chromedriver
+      if [ "`uname`" == "Linux" ]; then
+        electron/script/strip-binaries.py --target-cpu="$TARGET_ARCH" --file $PWD/$CHROMEDRIVER_DIR/chromedriver
+      fi
       ninja -C $CHROMEDRIVER_DIR electron:electron_chromedriver_zip
       if [ "$TARGET_ARCH" == "arm" ] || [ "$TARGET_ARCH" == "arm64" ]; then
         cp out/chromedriver/chromedriver.zip out/Default

--- a/script/strip-binaries.py
+++ b/script/strip-binaries.py
@@ -22,7 +22,7 @@ def strip_binary(binary_path, target_cpu):
     strip = 'mips64el-redhat-linux-strip'
   else:
     strip = 'strip'
-  execute([strip, '-p', binary_path])
+  execute([strip, '--preserve-dates', binary_path])
 
 def main():
   args = parse_args()

--- a/script/strip-binaries.py
+++ b/script/strip-binaries.py
@@ -22,7 +22,7 @@ def strip_binary(binary_path, target_cpu):
     strip = 'mips64el-redhat-linux-strip'
   else:
     strip = 'strip'
-  execute([strip, binary_path])
+  execute([strip, '-p' binary_path])
 
 def main():
   args = parse_args()

--- a/script/strip-binaries.py
+++ b/script/strip-binaries.py
@@ -22,7 +22,7 @@ def strip_binary(binary_path, target_cpu):
     strip = 'mips64el-redhat-linux-strip'
   else:
     strip = 'strip'
-  execute([strip, '-p' binary_path])
+  execute([strip, '-p', binary_path])
 
 def main():
   args = parse_args()


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
In investigating issues with our release builds I discovered that mksnapshot.zip on x64-linux was rather large (~1.4gb) because the executables in it were not getting stripped.  Actually they were getting stripped but doing so caused the mksnapshot zip target to think that the binaries needed to be recompiled.  This PR resolves that issue by preserving the timestamp on the stripped files.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
