### PR TITLE
feat: add session.listWordsFromSpellCheckerDictionary API

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -487,6 +487,11 @@ to host here.
 
 **Note:** On macOS the OS spellchecker is used and therefore we do not download any dictionary files.  This API is a no-op on macOS.
 
+#### `ses.listWordsInSpellCheckerDictionary()`
+
+Returns `Promise<String[]>` - An array of all words in app's custom dictionary.
+Resolves when the full dictionary is loaded from disk.
+
 #### `ses.addWordToSpellCheckerDictionary(word)`
 
 * `word` String - The word you want to add to the dictionary

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -226,47 +226,39 @@ void DestroyGlobalHandle(v8::Isolate* isolate,
   }
 }
 
-class DictionaryObserver : public SpellcheckCustomDictionary::Observer {
-  //   private:
-  //     base::OnceCallback<std::set<std::string>>& _callback;
+class DictionaryObserver final : public SpellcheckCustomDictionary::Observer {
+ private:
+  std::unique_ptr<gin_helper::Promise<std::set<std::string>>> _promise;
+  base::WeakPtr<SpellcheckService> _spellcheck;
+
  public:
-  DictionaryObserver(base::OnceCallback<void(std::set<std::string>)> callback) {
-    LOG(INFO) << "[ERICK] Observer set up";
-    // _callback = callback;
-    // ERICK: HOW DO I GET BROWSER_CONTEXT_ IN?
-    // SpellcheckService* spellcheck =
-    //   SpellcheckServiceFactory::GetForContext(browser_context_.get());
-    // spellcheck->GetCustomDictionary()->AddObserver(this);
+  DictionaryObserver(
+      std::unique_ptr<gin_helper::Promise<std::set<std::string>>> promise,
+      base::WeakPtr<SpellcheckService> spellcheck)
+      : _spellcheck(spellcheck) {
+    _promise = std::move(promise);
+    if (_spellcheck)
+      _spellcheck->GetCustomDictionary()->AddObserver(this);
   }
 
-  //     // ERICK: SpellcheckCustomDictionary::Observer has no virtual
-  //     destructor
-
-  //     // ~DictionaryObserver() {
-  //     //   // SpellcheckService* spellcheck =
-  //     //   //
-  //     SpellcheckServiceFactory::GetForContext(browser_context_.get());
-  //     //   // spellcheck->GetCustomDictionary()->RemoveObserver(this);
-  //     // }
+  ~DictionaryObserver() {
+    if (_spellcheck)
+      _spellcheck->GetCustomDictionary()->RemoveObserver(this);
+  }
 
   void OnCustomDictionaryLoaded() override {
-    LOG(INFO) << "[ERICK] Custom dictionary loaded!";
-    //       std::set<std::string> st = {};
-    //       // SpellcheckService* spellcheck =
-    //       // SpellcheckServiceFactory::GetForContext(browser_context_.get());
-    //       // if (!spellcheck)
-    //       //   _callback(std::set<std::string>);
-
-    //       // _callback(spellcheck->GetCustomDictionary()->GetWords());
-    //       _callback.Run(std::move(st));
-    //       // delete this;
+    if (_spellcheck) {
+      _promise->Resolve(_spellcheck->GetCustomDictionary()->GetWords());
+    } else {
+      _promise->RejectWithErrorMessage(
+          "Spellcheck in unexpected state: failed to load custom dictionary.");
+    }
+    delete this;
   }
 
   void OnCustomDictionaryChanged(
       const SpellcheckCustomDictionary::Change& dictionary_change) override {
-    //       // noop
-    //       // ERICK: not sure what to do with this since it's mandatory to
-    //       implement in the observer
+    // noop
   }
 };
 
@@ -816,32 +808,24 @@ void SetSpellCheckerDictionaryDownloadURL(gin_helper::ErrorThrower thrower,
 }
 
 v8::Local<v8::Promise> Session::ListWordsInSpellCheckerDictionary() {
-  // Chromium Promise stuff
-  gin_helper::Promise<std::set<std::string>> promise(isolate());
-  v8::Local<v8::Promise> handle = promise.GetHandle();
+  std::unique_ptr<gin_helper::Promise<std::set<std::string>>> promise =
+      std::make_unique<gin_helper::Promise<std::set<std::string>>>(isolate());
+  v8::Local<v8::Promise> handle = promise->GetHandle();
 
-  // spellcheck stuff
   SpellcheckService* spellcheck =
       SpellcheckServiceFactory::GetForContext(browser_context_.get());
 
-  // if no spellcheck service in context, resolve with empty array.
   if (!spellcheck)
-    promise.Resolve(std::set<std::string>());
+    promise->RejectWithErrorMessage(
+        "Spellcheck in unexpected state: failed to load custom dictionary.");
 
-  // check if we've already loaded the custom dictionary from file to cache
   if (spellcheck->GetCustomDictionary()->IsLoaded()) {
-    // can simply return the cached dictionary
-    promise.Resolve(spellcheck->GetCustomDictionary()->GetWords());
+    promise->Resolve(spellcheck->GetCustomDictionary()->GetWords());
   } else {
-    // Create a new observer and add it to the dictionary
-    DictionaryObserver* obs = new DictionaryObserver(base::BindOnce(
-        gin_helper::Promise<std::set<std::string>>::ResolvePromise,
-        std::move(promise)));
-    spellcheck->GetCustomDictionary()->AddObserver(obs);
-
-    // ERICK: Seems like this call is unneeded because the
-    // OnCustomDictionaryLoad() fires regardless.
-    // spellcheck->GetCustomDictionary()->Load();
+    new DictionaryObserver(std::move(promise), spellcheck->GetWeakPtr());
+    // Dictionary loads by default asynchronously,
+    // call the load function anyways just to be sure.
+    spellcheck->GetCustomDictionary()->Load();
   }
 
   return handle;

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -228,29 +229,29 @@ void DestroyGlobalHandle(v8::Isolate* isolate,
 
 class DictionaryObserver final : public SpellcheckCustomDictionary::Observer {
  private:
-  std::unique_ptr<gin_helper::Promise<std::set<std::string>>> _promise;
-  base::WeakPtr<SpellcheckService> _spellcheck;
+  std::unique_ptr<gin_helper::Promise<std::set<std::string>>> promise_;
+  base::WeakPtr<SpellcheckService> spellcheck_;
 
  public:
-  DictionaryObserver(
-      std::unique_ptr<gin_helper::Promise<std::set<std::string>>> promise,
-      base::WeakPtr<SpellcheckService> spellcheck)
-      : _spellcheck(spellcheck) {
-    _promise = std::move(promise);
-    if (_spellcheck)
-      _spellcheck->GetCustomDictionary()->AddObserver(this);
+  DictionaryObserver(gin_helper::Promise<std::set<std::string>> promise,
+                     base::WeakPtr<SpellcheckService> spellcheck)
+      : spellcheck_(spellcheck) {
+    promise_ = std::make_unique<gin_helper::Promise<std::set<std::string>>>(
+        std::move(promise));
+    if (spellcheck_)
+      spellcheck_->GetCustomDictionary()->AddObserver(this);
   }
 
   ~DictionaryObserver() {
-    if (_spellcheck)
-      _spellcheck->GetCustomDictionary()->RemoveObserver(this);
+    if (spellcheck_)
+      spellcheck_->GetCustomDictionary()->RemoveObserver(this);
   }
 
   void OnCustomDictionaryLoaded() override {
-    if (_spellcheck) {
-      _promise->Resolve(_spellcheck->GetCustomDictionary()->GetWords());
+    if (spellcheck_) {
+      promise_->Resolve(spellcheck_->GetCustomDictionary()->GetWords());
     } else {
-      _promise->RejectWithErrorMessage(
+      promise_->RejectWithErrorMessage(
           "Spellcheck in unexpected state: failed to load custom dictionary.");
     }
     delete this;
@@ -808,19 +809,18 @@ void SetSpellCheckerDictionaryDownloadURL(gin_helper::ErrorThrower thrower,
 }
 
 v8::Local<v8::Promise> Session::ListWordsInSpellCheckerDictionary() {
-  std::unique_ptr<gin_helper::Promise<std::set<std::string>>> promise =
-      std::make_unique<gin_helper::Promise<std::set<std::string>>>(isolate());
-  v8::Local<v8::Promise> handle = promise->GetHandle();
+  gin_helper::Promise<std::set<std::string>> promise(isolate());
+  v8::Local<v8::Promise> handle = promise.GetHandle();
 
   SpellcheckService* spellcheck =
       SpellcheckServiceFactory::GetForContext(browser_context_.get());
 
   if (!spellcheck)
-    promise->RejectWithErrorMessage(
+    promise.RejectWithErrorMessage(
         "Spellcheck in unexpected state: failed to load custom dictionary.");
 
   if (spellcheck->GetCustomDictionary()->IsLoaded()) {
-    promise->Resolve(spellcheck->GetCustomDictionary()->GetWords());
+    promise.Resolve(spellcheck->GetCustomDictionary()->GetWords());
   } else {
     new DictionaryObserver(std::move(promise), spellcheck->GetWeakPtr());
     // Dictionary loads by default asynchronously,

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -95,6 +95,7 @@ class Session : public gin_helper::TrackableObject<Session>,
   base::Value GetSpellCheckerLanguages();
   void SetSpellCheckerLanguages(gin_helper::ErrorThrower thrower,
                                 const std::vector<std::string>& languages);
+  v8::Local<v8::Promise> ListWordsInSpellCheckerDictionary();
   bool AddWordToSpellCheckerDictionary(const std::string& word);
 #endif
 


### PR DESCRIPTION
#### Description of Change

Exposes an API that list words added to the custom spellchecker dictionary.

Returns `Promise<String[]>` - An array of all words in app's custom dictionary.
Resolves when the full dictionary is loaded from disk.

ref: #22039, #21266

Once these 3 PRs are merged, we can add unit tests at the JS level to ensure that they operate correctly amongst each other.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `session.listWordsFromSpellCheckerDictionary` API to list custom words in the dictionary.
