### PR TITLE
build: use newer version of xcode/macOS sdk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,12 +65,12 @@ machine-linux-2xlarge: &machine-linux-2xlarge
 
 machine-mac: &machine-mac
   macos:
-    xcode: "10.3.0"
+    xcode: "11.1.0"
 
 machine-mac-large: &machine-mac-large
   resource_class: large
   macos:
-    xcode: "10.3.0"
+    xcode: "11.1.0"
 
 # Build configurations options.
 env-testing-build: &env-testing-build


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
This PR updates our CI to use a newer version of Xcode and the macOS SDK.  This resolves an out of disk space issue we are having with macOS release builds.  
This updates our CI to Xcode 11.1/macOS SDK 10.15.  Full details of the image here: https://circle-macos-docs.s3.amazonaws.com/image-manifest/v1989/index.html
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
