### PR TITLE
test: unskip webview.printToPDF

### DIFF
--- a/shell/browser/api/electron_api_system_preferences.h
+++ b/shell/browser/api/electron_api_system_preferences.h
@@ -99,8 +99,6 @@ class SystemPreferences : public gin_helper::EventEmitter<SystemPreferences>
 
   static bool IsTrustedAccessibilityClient(bool prompt);
 
-  // TODO(codebytere): Write tests for these methods once we
-  // are running tests on a Mojave machine
   std::string GetMediaAccessStatus(const std::string& media_type,
                                    gin_helper::Arguments* args);
   v8::Local<v8::Promise> AskForMediaAccess(v8::Isolate* isolate,

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1010,14 +1010,35 @@ describe('<webview> tag', function () {
   })
 
   describe('<webview>.printToPDF()', () => {
-    before(function () {
+    before(() => {
       if (!features.isPrintingEnabled()) {
         this.skip()
       }
     })
 
-    // TODO(deepak1556): Fix and enable after upgrade.
-    it.skip('can print to PDF', async () => {
+    it('rejects on incorrectly typed parameters', async () => {
+      const badTypes = {
+        marginsType: 'terrible',
+        scaleFactor: 'not-a-number',
+        landscape: [],
+        pageRanges: { 'oops': 'im-not-the-right-key' },
+        headerFooter: '123',
+        printSelectionOnly: 1,
+        printBackground: 2,
+        pageSize: 'IAmAPageSize'
+      }
+
+      // These will hard crash in Chromium unless we type-check
+      for (const [key, value] of Object.entries(badTypes)) {
+        const param = { [key]: value }
+
+        const src = 'data:text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E'
+        await loadWebView(webview, { src })
+        await expect(webview.printToPDF(param)).to.eventually.be.rejected()
+      }
+    })
+
+    it('can print to PDF', async () => {
       const src = 'data:text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E'
       await loadWebView(webview, { src })
 


### PR DESCRIPTION
#### Description of Change

Unskips a PDF print test that was disabled in an older roll and which I forgot to re-enable after i fixed the underlying functionality.

cc @deepak1556 @nornagon @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
