### PR TITLE
chore: Revert "notes: Adding Github CI to testing documentation"

### DIFF
--- a/docs/tutorial/testing-on-headless-ci.md
+++ b/docs/tutorial/testing-on-headless-ci.md
@@ -1,4 +1,4 @@
-# Testing on Headless CI Systems (Travis CI, Github Actions, Jenkins)
+# Testing on Headless CI Systems (Travis CI, Jenkins)
 
 Being based on Chromium, Electron requires a display driver to function.
 If Chromium can't find a display driver, Electron will fail to launch -
@@ -44,10 +44,6 @@ install:
   - export DISPLAY=':99.0'
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 ```
-
-### Github Actions
-
-For Github Actions, a [Xvfb action is available](https://github.com/marketplace/actions/gabrielbb-xvfb-action).
 
 ### Jenkins
 


### PR DESCRIPTION
#### Description of Change

This reverts commit 385388dd6b9952029a5af2f7a4a371a3a7b9ff4d (ref #21996).

The decision to revert this was made by @electron/wg-ecosystem (see [meeting minutes](https://github.com/electron/governance/blob/master/wg-ecosystem/meeting-notes/2020-02-06.md)).

The plugins mentioned in our docs should be maintained by their respective platforms to ensure future development and maintenance.

Our apologies for the confusion!

cc @GabrielBB @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
