### PR TITLE
fix: fire close event upon closing modal BrowserWindow in macOS

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -545,6 +545,8 @@ void NativeWindowMac::Close() {
   // When this is a sheet showing, performClose won't work.
   if (is_modal() && parent() && IsVisible()) {
     [parent()->GetNativeWindow().GetNativeNSWindow() endSheet:window_];
+    // Manually emit close event (not triggered from close fn)
+    NotifyWindowCloseButtonClicked();
     CloseImmediately();
     return;
   }


### PR DESCRIPTION
#### Description of Change
Backport of #19014.

Seems like I forgot to backport this fix months ago.

See that PR for details.

Notes: Fixed bug where the close event would not emit upon closing modal window on macOS.