### PR TITLE
fix: bug when repositioning traffic lights in RTL mode

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -542,17 +542,27 @@ void NativeWindowMac::RepositionTrafficLights() {
   CGFloat buttonHeight = [close frame].size.height;
   CGFloat titleBarFrameHeight = buttonHeight + traffic_light_position_.y();
   CGRect titleBarRect = titleBarContainerView.frame;
+  CGFloat titleBarWidth = NSWidth(titleBarRect);
   titleBarRect.size.height = titleBarFrameHeight;
   titleBarRect.origin.y = window.frame.size.height - titleBarFrameHeight;
   [titleBarContainerView setFrame:titleBarRect];
 
+  BOOL isRTL = [titleBarContainerView userInterfaceLayoutDirection] ==
+               NSUserInterfaceLayoutDirectionRightToLeft;
   NSArray* windowButtons = @[ close, miniaturize, zoom ];
   const CGFloat space_between =
       [miniaturize frame].origin.x - [close frame].origin.x;
   for (NSUInteger i = 0; i < windowButtons.count; i++) {
     NSView* view = [windowButtons objectAtIndex:i];
     CGRect rect = [view frame];
-    rect.origin.x = traffic_light_position_.x() + (i * space_between);
+    if (isRTL) {
+      CGFloat buttonWidth = NSWidth(rect);
+      // origin is always top-left, even in RTL
+      rect.origin.x = titleBarWidth - traffic_light_position_.x() +
+                      (i * space_between) - buttonWidth;
+    } else {
+      rect.origin.x = traffic_light_position_.x() + (i * space_between);
+    }
     rect.origin.y = (titleBarFrameHeight - rect.size.height) / 2;
     [view setFrameOrigin:rect.origin];
   }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Follow-up to #21781 and #22016, there is a bug when using the new `trafficLightPosition` API when the system is in RTL mode. cc @mohitsud @seshrs 

Using `trafficLightPosition: {x: 1, y: 1}`:

Bug: 
![image](https://user-images.githubusercontent.com/16580702/74205030-5f558900-4c2a-11ea-9c96-f06012ab1ef4.png)

Fixed:
![image](https://user-images.githubusercontent.com/16580702/74205095-b4919a80-4c2a-11ea-8b93-0391da7ca4e5.png)


Bug is due to the fact that the x-position is always calculated from the top left of the screen when using `trafficLightPosition`, but in RTL mode we should calculate the offset from the right.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed bug that occurred when using trafficLightPosition API in RTL mode 
