### PR TITLE
ci: strip mksnapshot binaries on Linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -555,6 +555,7 @@ step-mksnapshot-build: &step-mksnapshot-build
     name: mksnapshot build
     command: |
       cd src
+      ninja -C out/Default electron:electron_mksnapshot -j $NUMBER_OF_NINJA_PROCESSES
       if [ "`uname`" != "Darwin" ]; then
         if [ "$TARGET_ARCH" == "arm" ]; then
           electron/script/strip-binaries.py --file $PWD/out/Default/clang_x86_v8_arm/mksnapshot
@@ -562,6 +563,7 @@ step-mksnapshot-build: &step-mksnapshot-build
           electron/script/strip-binaries.py --file $PWD/out/Default/clang_x64_v8_arm64/mksnapshot
         else
           electron/script/strip-binaries.py --file $PWD/out/Default/mksnapshot
+          electron/script/strip-binaries.py --file $PWD/out/Default/v8_context_snapshot_generator
         fi
       fi
       if [ "$SKIP_DIST_ZIP" != "1" ]; then

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1352,12 +1352,18 @@ dist_zip("electron_chromedriver_zip") {
   ]
 }
 
+mksnapshot_deps = [
+  ":licenses",
+  "//tools/v8_context_snapshot:v8_context_snapshot_generator",
+  "//v8:mksnapshot($v8_snapshot_toolchain)",
+]
+
+group("electron_mksnapshot") {
+  public_deps = mksnapshot_deps
+}
+
 dist_zip("electron_mksnapshot_zip") {
-  data_deps = [
-    "//v8:mksnapshot($v8_snapshot_toolchain)",
-    "//tools/v8_context_snapshot:v8_context_snapshot_generator",
-    ":licenses",
-  ]
+  data_deps = mksnapshot_deps
   outputs = [
     "$root_build_dir/mksnapshot.zip",
   ]


### PR DESCRIPTION
Related to #21086.
Both `master` and `9-x-y` already have this change.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
