### PR TITLE
fix: keep references to active menus created by api Menu

### DIFF
--- a/shell/browser/api/atom_api_menu.cc
+++ b/shell/browser/api/atom_api_menu.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/api/atom_api_menu.h"
 
+#include <map>
 #include <utility>
 
 #include "native_mate/constructor.h"
@@ -15,6 +16,13 @@
 #include "shell/common/native_mate_converters/once_callback.h"
 #include "shell/common/native_mate_converters/string16_converter.h"
 #include "shell/common/node_includes.h"
+
+namespace {
+// We need this map to keep references to currently opened menus.
+// Without this menus would be destroyed by js garbage collector
+// even when they are still displayed.
+std::map<uint32_t, v8::Global<v8::Object>> g_menus;
+}  // unnamed namespace
 
 namespace electron {
 
@@ -202,10 +210,12 @@ bool Menu::WorksWhenHiddenAt(int index) const {
 }
 
 void Menu::OnMenuWillClose() {
+  g_menus.erase(weak_map_id());
   Emit("menu-will-close");
 }
 
 void Menu::OnMenuWillShow() {
+  g_menus[weak_map_id()] = v8::Global<v8::Object>(isolate(), GetWrapper());
   Emit("menu-will-show");
 }
 


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/19427.

See that PR for more details.

Notes: Fix a potential issue with active Menu garbage collection.