### PR TITLE
fix: prevent in-memory sessions from writing to custom spellchecker dictionary

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -538,7 +538,8 @@ Resolves when the full dictionary is loaded from disk.
 
 * `word` String - The word you want to add to the dictionary
 
-Returns `Boolean` - Whether the word was successfully written to the custom dictionary.
+Returns `Boolean` - Whether the word was successfully written to the custom dictionary. This API
+will not work on non-persistent (in-memory) sessions.
 
 **Note:** On macOS and Windows 10 this word will be written to the OS custom dictionary as well
 
@@ -546,7 +547,8 @@ Returns `Boolean` - Whether the word was successfully written to the custom dict
 
 * `word` String - The word you want to remove from the dictionary
 
-Returns `Boolean` - Whether the word was successfully removed from the custom dictionary.
+Returns `Boolean` - Whether the word was successfully removed from the custom dictionary. This API
+will not work on non-persistent (in-memory) sessions.
 
 **Note:** On macOS and Windows 10 this word will be removed from the OS custom dictionary as well
 

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -868,6 +868,12 @@ v8::Local<v8::Promise> Session::ListWordsInSpellCheckerDictionary() {
 }
 
 bool Session::AddWordToSpellCheckerDictionary(const std::string& word) {
+  // don't let in-memory sessions add spellchecker words
+  // because files will persist unintentionally
+  bool is_in_memory = browser_context_->IsOffTheRecord();
+  if (is_in_memory)
+    return false;
+
   SpellcheckService* service =
       SpellcheckServiceFactory::GetForContext(browser_context_.get());
   if (!service)
@@ -883,6 +889,12 @@ bool Session::AddWordToSpellCheckerDictionary(const std::string& word) {
 }
 
 bool Session::RemoveWordFromSpellCheckerDictionary(const std::string& word) {
+  // don't let in-memory sessions remove spellchecker words
+  // because files will persist unintentionally
+  bool is_in_memory = browser_context_->IsOffTheRecord();
+  if (is_in_memory)
+    return false;
+
   SpellcheckService* service =
       SpellcheckServiceFactory::GetForContext(browser_context_.get());
   if (!service)

--- a/spec-main/spellchecker-spec.ts
+++ b/spec-main/spellchecker-spec.ts
@@ -102,6 +102,13 @@ describe('spellchecker', () => {
         const wordList = await ses.listWordsInSpellCheckerDictionary
         expect(wordList).to.have.length(0)
       })
+
+      // remove API will always return false because we can't add words
+      it('should fail for non-persistent sessions', async () => {
+        const tempSes = session.fromPartition('temporary')
+        const result = tempSes.addWordToSpellCheckerDictionary('foobar')
+        expect(result).to.equal(false)
+      })
     })
 
     describe('ses.removeWordFromSpellCheckerDictionary', () => {


### PR DESCRIPTION
#### Description of Change
Our new `session.addWordToSpellCheckerDictionary()` and `session.removeWordFromSpellCheckerDictionary()` APIs write to a persistent `Custom Dictionary.txt` file.

This is bad for in-memory sessions, as the words outlive the sessions and lead to unintended behavior for users.

Therefore, this PR aims to prevent this by only the APIs to be called from persistent sessions.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Limited manipulation of custom spellchecker dictionary words to persistent sessions.
