### PR TITLE
test: add specs for custom dictionary API

### DIFF
--- a/spec-main/spellchecker-spec.ts
+++ b/spec-main/spellchecker-spec.ts
@@ -62,9 +62,9 @@ describe('spellchecker', () => {
       ses = session.fromPartition(`persist:customdictionary-test-${Date.now()}`)
     })
 
-    afterEach(() => {
+    afterEach(async () => {
       if (ses) {
-        ses.clearStorageData({})
+        await ses.clearStorageData()
         ses.destroy()
       }
     })

--- a/spec-main/spellchecker-spec.ts
+++ b/spec-main/spellchecker-spec.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow } from 'electron'
+import { BrowserWindow, Session, session } from 'electron'
 
 import { expect } from 'chai'
 import * as path from 'path'
@@ -52,5 +52,70 @@ describe('spellchecker', () => {
     const contextMenuParams: Electron.ContextMenuParams = (await contextMenuPromise)[1]
     expect(contextMenuParams.misspelledWord).to.eq('Beautifulllll')
     expect(contextMenuParams.dictionarySuggestions).to.have.length.of.at.least(1)
+  })
+
+  describe('custom dictionary word list API', () => {
+    let ses: Session
+
+    beforeEach(async () => {
+      ses = session.fromPartition(`persist:customdictionary-test-${Date.now()}`)
+    })
+
+    afterEach(() => {
+      if (ses) {
+        ses.clearStorageData({})
+        ses.destroy()
+      }
+    })
+
+    describe('ses.listWordsFromSpellCheckerDictionary', () => {
+      it('should successfully list words in custom dictionary', async () => {
+        const words = ['foo', 'bar', 'baz']
+        const results = words.map(word => ses.addWordToSpellCheckerDictionary(word))
+        expect(results).to.eql([true, true, true])
+
+        const wordList = await ses.listWordsInSpellCheckerDictionary()
+        expect(wordList).to.have.deep.members(words)
+      })
+
+      it('should return an empty array if no words are added', async () => {
+        const wordList = await ses.listWordsInSpellCheckerDictionary()
+        expect(wordList).to.have.length(0)
+      })
+    })
+
+    describe('ses.addWordToSpellCheckerDictionary', () => {
+      it('should successfully add word to custom dictionary', async () => {
+        const result = ses.addWordToSpellCheckerDictionary('foobar')
+        expect(result).to.equal(true)
+        const wordList = await ses.listWordsInSpellCheckerDictionary()
+        expect(wordList).to.eql(['foobar'])
+      })
+
+      it('should fail for an empty string', async () => {
+        const result = ses.addWordToSpellCheckerDictionary('')
+        expect(result).to.equal(false)
+        const wordList = await ses.listWordsInSpellCheckerDictionary
+        expect(wordList).to.have.length(0)
+      })
+    })
+
+    describe('ses.removeWordFromSpellCheckerDictionary', () => {
+      it('should successfully remove words to custom dictionary', async () => {
+        const result1 = ses.addWordToSpellCheckerDictionary('foobar')
+        expect(result1).to.equal(true)
+        const wordList1 = await ses.listWordsInSpellCheckerDictionary()
+        expect(wordList1).to.eql(['foobar'])
+        const result2 = ses.removeWordFromSpellCheckerDictionary('foobar')
+        expect(result2).to.equal(true)
+        const wordList2 = await ses.listWordsInSpellCheckerDictionary()
+        expect(wordList2).to.have.length(0)
+      })
+
+      it('should fail for words not in custom dictionary', () => {
+        const result2 = ses.removeWordFromSpellCheckerDictionary('foobar')
+        expect(result2).to.equal(false)
+      })
+    })
   })
 })

--- a/spec-main/spellchecker-spec.ts
+++ b/spec-main/spellchecker-spec.ts
@@ -58,6 +58,7 @@ describe('spellchecker', () => {
     let ses: Session
 
     beforeEach(async () => {
+      // ensure a new session runs on each test run
       ses = session.fromPartition(`persist:customdictionary-test-${Date.now()}`)
     })
 


### PR DESCRIPTION
#### Description of Change
Adds JS-level unit tests for the following `session` spellchecker APIs:

* `addWordToSpellCheckerDictionary()`
* `removeWordFromSpellCheckerDictionary()`
* `listWordsFromSpellCheckerDictionary()`

Needed to have all 3 to be able to test them together.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
