### PR TITLE
fix: crash on custom printing margins

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1807,18 +1807,21 @@ void WebContents::Print(gin_helper::Arguments* args) {
     settings.SetIntKey(printing::kSettingMarginsType, margin_type);
 
     if (margin_type == printing::CUSTOM_MARGINS) {
+      base::Value custom_margins(base::Value::Type::DICTIONARY);
       int top = 0;
       margins.Get("top", &top);
-      settings.SetIntKey(printing::kSettingMarginTop, top);
+      custom_margins.SetIntKey(printing::kSettingMarginTop, top);
       int bottom = 0;
       margins.Get("bottom", &bottom);
-      settings.SetIntKey(printing::kSettingMarginBottom, bottom);
+      custom_margins.SetIntKey(printing::kSettingMarginBottom, bottom);
       int left = 0;
       margins.Get("left", &left);
-      settings.SetIntKey(printing::kSettingMarginLeft, left);
+      custom_margins.SetIntKey(printing::kSettingMarginLeft, left);
       int right = 0;
       margins.Get("right", &right);
-      settings.SetIntKey(printing::kSettingMarginRight, right);
+      custom_margins.SetIntKey(printing::kSettingMarginRight, right);
+      settings.SetPath(printing::kSettingMarginsCustom,
+                       std::move(custom_margins));
     }
   } else {
     settings.SetIntKey(printing::kSettingMarginsType,

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -135,9 +135,18 @@ describe('webContents module', () => {
       }).to.throw('Unsupported pageSize: i-am-a-bad-pagesize')
     })
 
-    it('does not crash', () => {
+    it('does not crash with custom margins', () => {
       expect(() => {
-        w.webContents.print({ silent: true })
+        w.webContents.print({
+          silent: true,
+          margins: {
+            marginType: 'custom',
+            top: 1,
+            bottom: 1,
+            left: 1,
+            right: 1
+          }
+        })
       }).to.not.throw()
     })
   })


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/21167.

Chromium changed their margin key settings such that custom margins should be set as their own dictionary, and without that will fail conversion validation and crash. This fixes that.

cc @zcbenz @deepak1556 @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash in `webContents.print()` with custom print margins.
