### PR TITLE
fix: no-arg console.log is undefined

### DIFF
--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -18,8 +18,10 @@ require('@electron/internal/common/init')
 if (process.platform === 'win32') {
   // Redirect node's console to use our own implementations, since node can not
   // handle console output when running as GUI program.
-  const consoleLog = (format: any, ...args: any[]) => {
-    return process.log(util.format(format, ...args) + '\n')
+  const consoleLog = (...args: any[]) => {
+    // @ts-ignore this typing is incorrect; 'format' is an optional parameter
+    // See https://nodejs.org/api/util.html#util_util_format_format_args
+    return process.log(util.format(...args) + '\n')
   }
   const streamWrite: NodeJS.WritableStream['write'] = function (chunk: Buffer | string, encoding?: any, callback?: Function) {
     if (Buffer.isBuffer(chunk)) {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/22108.

`@types/node` incorrectly [types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/6a3064cc7408b4e71d0d0feb6f92457d4c22e15c/types/node/util.d.ts#L3) the signature for `util.format()`; it should in fact  per [documentation](https://nodejs.org/api/util.html#util_util_format_format_args) be:

```js
function format(format?: any, ...param: any[]): string;
```

This corrects the error and fixed the undefined behavior. I'll also try to open a PR to the upstream `@types/node` repo.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue where `undefined` was printed from `console.log` on Window when no arguments were passed.
