### PR TITLE
fix: crash on custom printing margins

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1785,18 +1785,21 @@ void WebContents::Print(mate::Arguments* args) {
     settings.SetIntKey(printing::kSettingMarginsType, margin_type);
 
     if (margin_type == printing::CUSTOM_MARGINS) {
+      base::Value custom_margins(base::Value::Type::DICTIONARY);
       int top = 0;
       margins.Get("top", &top);
-      settings.SetIntKey(printing::kSettingMarginTop, top);
+      custom_margins.SetIntKey(printing::kSettingMarginTop, top);
       int bottom = 0;
       margins.Get("bottom", &bottom);
-      settings.SetIntKey(printing::kSettingMarginBottom, bottom);
+      custom_margins.SetIntKey(printing::kSettingMarginBottom, bottom);
       int left = 0;
       margins.Get("left", &left);
-      settings.SetIntKey(printing::kSettingMarginLeft, left);
+      custom_margins.SetIntKey(printing::kSettingMarginLeft, left);
       int right = 0;
       margins.Get("right", &right);
-      settings.SetIntKey(printing::kSettingMarginRight, right);
+      custom_margins.SetIntKey(printing::kSettingMarginRight, right);
+      settings.SetPath(printing::kSettingMarginsCustom,
+                       std::move(custom_margins));
     }
   } else {
     settings.SetIntKey(printing::kSettingMarginsType,

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -132,9 +132,18 @@ describe('webContents module', () => {
       }).to.throw('webContents.print(): Invalid deviceName provided.')
     })
 
-    it('does not crash', () => {
+    it('does not crash with custom margins', () => {
       expect(() => {
-        w.webContents.print({ silent: true })
+        w.webContents.print({
+          silent: true,
+          margins: {
+            marginType: 'custom',
+            top: 1,
+            bottom: 1,
+            left: 1,
+            right: 1
+          }
+        })
       }).to.not.throw()
     })
   })


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/22164.

See that PR for details.

Notes: Fixed a crash in `webContents.print()` with custom print margins.