### PR TITLE
fix: crash on custom printing margins

### DIFF
--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -1728,18 +1728,21 @@ void WebContents::Print(mate::Arguments* args) {
     settings.SetInteger(printing::kSettingMarginsType, margin_type);
 
     if (margin_type == printing::CUSTOM_MARGINS) {
+      auto custom_margins = std::make_unique<base::DictionaryValue>();
       int top = 0;
       margins.Get("top", &top);
-      settings.SetInteger(printing::kSettingMarginTop, top);
+      custom_margins->SetInteger(printing::kSettingMarginTop, top);
       int bottom = 0;
       margins.Get("bottom", &bottom);
-      settings.SetInteger(printing::kSettingMarginBottom, bottom);
+      custom_margins->SetInteger(printing::kSettingMarginBottom, bottom);
       int left = 0;
       margins.Get("left", &left);
-      settings.SetInteger(printing::kSettingMarginLeft, left);
+      custom_margins->SetInteger(printing::kSettingMarginLeft, left);
       int right = 0;
       margins.Get("right", &right);
-      settings.SetInteger(printing::kSettingMarginRight, right);
+      custom_margins->SetInteger(printing::kSettingMarginRight, right);
+      settings.SetDictionary(printing::kSettingMarginsCustom,
+                             std::move(custom_margins));
     }
   } else {
     settings.SetInteger(printing::kSettingMarginsType,

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -130,9 +130,18 @@ describe('webContents module', () => {
       }).to.throw('webContents.print(): Invalid deviceName provided.')
     })
 
-    it('does not crash', () => {
+    it('does not crash with custom margins', () => {
       expect(() => {
-        w.webContents.print({ silent: true })
+        w.webContents.print({
+          silent: true,
+          margins: {
+            marginType: 'custom',
+            top: 1,
+            bottom: 1,
+            left: 1,
+            right: 1
+          }
+        })
       }).to.not.throw()
     })
   })


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/22164.

See that PR for details.

Notes: Fixed a crash in `webContents.print()` with custom print margins.