### PR TITLE
fix: don't include breakpad_symbols dir in dsym.zip

### DIFF
--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -120,8 +120,8 @@ def extract_zip(zip_path, destination):
 def make_zip(zip_file_path, files, dirs):
   safe_unlink(zip_file_path)
   if sys.platform == 'darwin':
-    files += dirs
-    execute(['zip', '-r', '-y', zip_file_path] + files)
+    allfiles = files + dirs
+    execute(['zip', '-r', '-y', zip_file_path] + allfiles)
   else:
     zip_file = zipfile.ZipFile(zip_file_path, "w", zipfile.ZIP_DEFLATED,
                                allowZip64=True)


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
There was a bug in the `make_zip` python function on macOS where it was modifying the list of files passed into it to include the directory passed in.  This caused the dsym.zip file to be created with the breakpad_symbols directory because a previous call to make_zip had that directory as an argument, which caused it to get added to the list of license files which are added to dsym.zip.

This PR fixes the issue by changing the `make_zip` function to not modify the passed in arguments so that if those arguments are used downstream they won't be compromised.
 
Resolves #22139
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->Removed unneccessary  breakpad_symbols directory from the dsym zip file.
