### PR TITLE
feat: add APIs for accessing NSUserDefaults in the given domain

### DIFF
--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -165,7 +165,7 @@ Add the specified defaults to your application's `NSUserDefaults`.
 * `type` String - Can be `string`, `boolean`, `integer`, `float`, `double`,
   `url`, `array` or `dictionary`.
 
-Returns `any` - The value of `key` in `NSUserDefaults`.
+Returns `any` - The value of `key` in `NSUserDefaults` for the app and current user.
 
 Some popular `key` and `type`s are:
 
@@ -177,13 +177,22 @@ Some popular `key` and `type`s are:
 * `NSPreferredWebServices`: `dictionary`
 * `NSUserDictionaryReplacementItems`: `array`
 
+### `systemPreferences.getUserDefaultInDomain(domain, key, type)` _macOS_
+
+* `domain` String
+* `key` String
+* `type` String - Can be `string`, `boolean`, `integer`, `float`, `double`,
+  `url`, `array` or `dictionary`.
+
+Returns `any` - The value of `key` in `NSUserDefaults` for the given `domain`.
+
 ### `systemPreferences.setUserDefault(key, type, value)` _macOS_
 
 * `key` String
 * `type` String - Can be `string`, `boolean`, `integer`, `float`, `double`, `url`, `array` or `dictionary`.
 * `value` String
 
-Set the value of `key` in `NSUserDefaults`.
+Set the value of `key` in `NSUserDefaults` for the app and current user.
 
 Note that `type` should match actual type of `value`. An exception is thrown
 if they don't.
@@ -192,12 +201,31 @@ Some popular `key` and `type`s are:
 
 * `ApplePressAndHoldEnabled`: `boolean`
 
+### `systemPreferences.setUserDefaultInDomain(domain, key, type, value)` _macOS_
+
+* `domain` String
+* `key` String
+* `type` String - See [`getUserDefault`](#systempreferencesgetuserdefaultkey-type-macos).
+* `value` String
+
+Set the value of `key` in `NSUserDefaults` for the given `domain`.
+
+Note that `type` should match actual type of `value`. An exception is thrown
+if they don't.
+
 ### `systemPreferences.removeUserDefault(key)` _macOS_
 
 * `key` String
 
-Removes the `key` in `NSUserDefaults`. This can be used to restore the default
-or global value of a `key` previously set with `setUserDefault`.
+Removes the `key` in `NSUserDefaults` for the app and current user.
+This can be used to restore the default or global value of a `key` previously set with `setUserDefault`.
+
+### `systemPreferences.removeUserDefaultInDomain(domain, key)` _macOS_
+
+* `domain` String
+* `key` String
+
+Removes the `key` in `NSUserDefaults` for the given `domain`.
 
 ### `systemPreferences.isAeroGlassEnabled()` _Windows_
 

--- a/shell/browser/api/electron_api_system_preferences.cc
+++ b/shell/browser/api/electron_api_system_preferences.cc
@@ -97,8 +97,14 @@ void SystemPreferences::BuildPrototype(
                  &SystemPreferences::UnsubscribeWorkspaceNotification)
       .SetMethod("registerDefaults", &SystemPreferences::RegisterDefaults)
       .SetMethod("getUserDefault", &SystemPreferences::GetUserDefault)
+      .SetMethod("getUserDefaultInDomain",
+                 &SystemPreferences::GetUserDefaultInDomain)
       .SetMethod("setUserDefault", &SystemPreferences::SetUserDefault)
+      .SetMethod("setUserDefaultInDomain",
+                 &SystemPreferences::SetUserDefaultInDomain)
       .SetMethod("removeUserDefault", &SystemPreferences::RemoveUserDefault)
+      .SetMethod("removeUserDefaultInDomain",
+                 &SystemPreferences::RemoveUserDefaultInDomain)
       .SetMethod("isSwipeTrackingFromScrollEventsEnabled",
                  &SystemPreferences::IsSwipeTrackingFromScrollEventsEnabled)
       .SetMethod("getEffectiveAppearance",

--- a/shell/browser/api/electron_api_system_preferences.h
+++ b/shell/browser/api/electron_api_system_preferences.h
@@ -81,13 +81,22 @@ class SystemPreferences : public gin_helper::EventEmitter<SystemPreferences>
   int SubscribeWorkspaceNotification(const std::string& name,
                                      const NotificationCallback& callback);
   void UnsubscribeWorkspaceNotification(int request_id);
-  v8::Local<v8::Value> GetUserDefault(const std::string& name,
+  v8::Local<v8::Value> GetUserDefault(const std::string& key,
                                       const std::string& type);
+  v8::Local<v8::Value> GetUserDefaultInDomain(const std::string& domain,
+                                              const std::string& key,
+                                              const std::string& type);
   void RegisterDefaults(gin_helper::Arguments* args);
-  void SetUserDefault(const std::string& name,
+  void SetUserDefault(const std::string& key,
                       const std::string& type,
                       gin_helper::Arguments* args);
-  void RemoveUserDefault(const std::string& name);
+  void SetUserDefaultInDomain(const std::string& domain,
+                              const std::string& key,
+                              const std::string& type,
+                              gin_helper::Arguments* args);
+  void RemoveUserDefault(const std::string& key);
+  void RemoveUserDefaultInDomain(const std::string& domain,
+                                 const std::string& key);
   bool IsSwipeTrackingFromScrollEventsEnabled();
 
   std::string GetSystemColor(gin_helper::ErrorThrower thrower,


### PR DESCRIPTION
#### Description of Change
Add APIs requested in #17031:
- `systemPreferences.getUserDefaultInDomain(domain, key, type)`
- `systemPreferences.setUserDefaultInDomain(domain, key, type, value)`
- `systemPreferences.removeUserDefaultInDomain(domain, key)`

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added APIs for accessing `NSUserDefaults` in the given domain on macOS.