### PR TITLE
docs: replace electron.atom.io with electronjs.org in docs/fiddles

### DIFF
--- a/docs/fiddles/menus/customize-menus/index.html
+++ b/docs/fiddles/menus/customize-menus/index.html
@@ -21,7 +21,7 @@
 
       <p>
         Open the
-        <a href="http://electron.atom.io/docs/api/menu"
+        <a href="https://electronjs.org/docs/api/menu"
           >full API documentation<span
             >(opens in new window)</span
           ></a
@@ -111,7 +111,7 @@
           <p>
             See the full
             <a
-              href="http://electron.atom.io/docs/api/web-contents/#event-context-menu"
+              href="https://electronjs.org/docs/api/web-contents/#event-context-menu"
               >context-menu event documentation</a
             >
             for all the available properties.

--- a/docs/fiddles/menus/customize-menus/main.js
+++ b/docs/fiddles/menus/customize-menus/main.js
@@ -159,7 +159,7 @@ const template = [
       {
         label: 'Learn More',
         click: () => {
-          shell.openExternal('http://electron.atom.io')
+          shell.openExternal('https://electronjs.org')
         }
       }
     ]

--- a/docs/fiddles/menus/shortcuts/index.html
+++ b/docs/fiddles/menus/shortcuts/index.html
@@ -21,10 +21,10 @@
 
 		<p>
 			Open the full documentation for the
-			<a href="http://electron.atom.io/docs/api/menu">Menu</a>,
-			<a href="http://electron.atom.io/docs/api/accelerator">Accelerator</a>,
+			<a href="https://electronjs.org/docs/api/menu">Menu</a>,
+			<a href="https://electronjs.org/docs/api/accelerator">Accelerator</a>,
 			and
-			<a href="http://electron.atom.io/docs/api/global-shortcut">globalShortcut</a>
+			<a href="https://electronjs.org/docs/api/global-shortcut">globalShortcut</a>
 			APIs in your browser.
 		</p>
 

--- a/docs/fiddles/native-ui/dialogs/error-dialog/index.html
+++ b/docs/fiddles/native-ui/dialogs/error-dialog/index.html
@@ -23,7 +23,7 @@
 
       <p>
         Open the
-        <a href="http://electron.atom.io/docs/api/dialog/">
+        <a href="https://electronjs.org/docs/api/dialog/">
           full API documentation (opens in new window)
           </a>
         in your browser.

--- a/docs/fiddles/native-ui/dialogs/information-dialog/index.html
+++ b/docs/fiddles/native-ui/dialogs/information-dialog/index.html
@@ -23,7 +23,7 @@
 
       <p>
         Open the
-        <a href="http://electron.atom.io/docs/api/dialog/">
+        <a href="https://electronjs.org/docs/api/dialog/">
           full API documentation (opens in new window)
         </a>
         in your browser.

--- a/docs/fiddles/native-ui/dialogs/open-file-or-directory/index.html
+++ b/docs/fiddles/native-ui/dialogs/open-file-or-directory/index.html
@@ -23,7 +23,7 @@
 
       <p>
         Open the
-        <a href="http://electron.atom.io/docs/api/dialog/">
+        <a href="https://electronjs.org/docs/api/dialog/">
           full API documentation (opens in new window)
         </a>
         in your browser.

--- a/docs/fiddles/native-ui/dialogs/save-dialog/index.html
+++ b/docs/fiddles/native-ui/dialogs/save-dialog/index.html
@@ -23,7 +23,7 @@
 
       <p>
         Open the
-        <a href="http://electron.atom.io/docs/api/dialog/">
+        <a href="https://electronjs.org/docs/api/dialog/">
           full API documentation (opens in new window)
         </a>
         in your browser.

--- a/docs/fiddles/native-ui/external-links-file-manager/external-links/index.html
+++ b/docs/fiddles/native-ui/external-links-file-manager/external-links/index.html
@@ -27,7 +27,7 @@
                 const { shell } = require('electron')
                 const exLinksBtn = document.getElementById('open-ex-links')
                 exLinksBtn.addEventListener('click', (event) => {
-                shell.openExternal('http://electron.atom.io')
+                shell.openExternal('https://electronjs.org')
                 }) 
             </code></pre>
 

--- a/docs/fiddles/native-ui/external-links-file-manager/external-links/renderer.js
+++ b/docs/fiddles/native-ui/external-links-file-manager/external-links/renderer.js
@@ -3,7 +3,7 @@ const { shell } = require('electron')
 const exLinksBtn = document.getElementById('open-ex-links')
 
 exLinksBtn.addEventListener('click', (event) => {
-  shell.openExternal('http://electron.atom.io')
+  shell.openExternal('https://electronjs.org')
 })
 
 const OpenAllOutboundLinks = () => {

--- a/docs/fiddles/native-ui/external-links-file-manager/index.html
+++ b/docs/fiddles/native-ui/external-links-file-manager/index.html
@@ -17,7 +17,7 @@
       <p>This module works in both the main and renderer process.</p>
       <p>
         Open the
-        <a href="http://electron.atom.io/docs/api/shell">
+        <a href="https://electronjs.org/docs/api/shell">
           full API documentation (opens in new window)
         </a>
         in your browser.

--- a/docs/fiddles/native-ui/external-links-file-manager/renderer.js
+++ b/docs/fiddles/native-ui/external-links-file-manager/renderer.js
@@ -9,5 +9,5 @@ fileManagerBtn.addEventListener('click', (event) => {
 })
 
 exLinksBtn.addEventListener('click', (event) => {
-  shell.openExternal('http://electron.atom.io')
+  shell.openExternal('https://electronjs.org')
 })

--- a/docs/fiddles/native-ui/notifications/index.html
+++ b/docs/fiddles/native-ui/notifications/index.html
@@ -26,7 +26,7 @@
 
       <p>
         Open the
-        <a href="https://electron.atom.io/docs/all/#notifications-windows-linux-macos">
+        <a href="https://electronjs.org/docs/all/#notifications-windows-linux-macos">
           full API documentation<span>(opens in new window)</span>
         </a>
         in your browser.

--- a/docs/fiddles/native-ui/tray/index.html
+++ b/docs/fiddles/native-ui/tray/index.html
@@ -15,7 +15,7 @@
 
       <p>
         Open the
-        <a href="http://electron.atom.io/docs/api/tray">
+        <a href="https://electronjs.org/docs/api/tray">
           full API documentation (opens in new window)
         </a>
         in your browser.
@@ -108,7 +108,7 @@ ipc.on('tray-removed', function () {
               On Linux distributions that only have app indicator support, users
               will need to install <code>libappindicator1</code> to make the
               tray icon work. See the
-              <a href="http://electron.atom.io/docs/api/tray">
+              <a href="https://electronjs.org/docs/api/tray">
                 full API documentation (opens in new window)
               </a>
               for more details about using Tray on Linux.

--- a/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/index.html
+++ b/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/index.html
@@ -13,7 +13,7 @@
         <h3>The <code>app</code> module provides methods for handling protocols.</h3>
         <p>These methods allow you to set and unset the protocols your app should be the default app for. Similar to when a browser asks to be your default for viewing web pages.</p>
 
-        <p>Open the <a href="http://electron.atom.io/docs/api/app">full app API documentation<span class="u-visible-to-screen-reader">(opens in new window)</span></a> in your browser.</p>
+        <p>Open the <a href="https://electronjs.org/docs/api/app">full app API documentation<span class="u-visible-to-screen-reader">(opens in new window)</span></a> in your browser.</p>
     </header>
 
     <div >

--- a/docs/fiddles/system/system-information/get-version-information/index.html
+++ b/docs/fiddles/system/system-information/get-version-information/index.html
@@ -15,7 +15,7 @@
           </div>
           <p>The <code>process</code> module is built into Node.js (therefore you can use this in both the main and renderer processes) and in Electron apps this object has a few more useful properties on it.</p>
           <p>The example below gets the version of Electron in use by the app.</p>
-          <p>See the <a href="http://electron.atom.io/docs/api/process">process documentation <span>(opens in new window)</span></a> for more.</p>
+          <p>See the <a href="https://electronjs.org/docs/api/process">process documentation <span>(opens in new window)</span></a> for more.</p>
         </div>
       </div>
     </div>

--- a/docs/fiddles/windows/manage-windows/frameless-window/index.html
+++ b/docs/fiddles/windows/manage-windows/frameless-window/index.html
@@ -22,7 +22,7 @@
 
       <p>
         Open the
-        <a href="http://electron.atom.io/docs/api/browser-window">
+        <a href="https://electronjs.org/docs/api/browser-window">
           full API documentation (opens in new window)
         </a>
         in your browser.
@@ -59,7 +59,7 @@
 
           <p>
             For more details, see the
-            <a href="http://electron.atom.io/docs/api/frameless-window/">
+            <a href="https://electronjs.org/docs/api/frameless-window/">
               Frameless Window
             </a>
             documentation.

--- a/docs/fiddles/windows/manage-windows/manage-window-state/index.html
+++ b/docs/fiddles/windows/manage-windows/manage-window-state/index.html
@@ -22,7 +22,7 @@
 
       <p>
         Open the
-        <a href="http://electron.atom.io/docs/api/browser-window">
+        <a href="https://electronjs.org/docs/api/browser-window">
           full API documentation (opens in new window)
         </a>
         in your browser.
@@ -47,7 +47,7 @@
             There are a lot of methods for controlling the state of the window
             such as the size, location, and focus status as well as events to
             listen to for window changes. Visit the
-            <a href="http://electron.atom.io/docs/api/browser-window">
+            <a href="https://electronjs.org/docs/api/browser-window">
               documentation (opens in new window)
             </a>
             for the full list.

--- a/docs/fiddles/windows/manage-windows/new-window/renderer.js
+++ b/docs/fiddles/windows/manage-windows/new-window/renderer.js
@@ -15,5 +15,5 @@ newWindowBtn.addEventListener('click', (event) => {
 
 link.addEventListener('click', (e) => {
   e.preventDefault()
-  shell.openExternal("http://electron.atom.io/docs/api/browser-window")
+  shell.openExternal("https://electronjs.org/docs/api/browser-window")
 })

--- a/docs/fiddles/windows/manage-windows/window-events/index.html
+++ b/docs/fiddles/windows/manage-windows/window-events/index.html
@@ -22,7 +22,7 @@
 
       <p>
         Open the
-        <a href="http://electron.atom.io/docs/api/browser-window">
+        <a href="https://electronjs.org/docs/api/browser-window">
           full API documentation (opens in new window)
         </a>
         in your browser.


### PR DESCRIPTION
electron.atom.io redirects to electronjs.org anyway, might as well skip the middleman.

also http -> https.

Notes: none