### PR TITLE
docs: update dev docs atom -> shell

### DIFF
--- a/docs/development/debug-instructions-windows.md
+++ b/docs/development/debug-instructions-windows.md
@@ -48,7 +48,7 @@ still set breakpoints - Visual Studio will automatically figure out that the
 source code matches the code running in the attached process and break
 accordingly.
 
-Relevant code files can be found in `./atom/`.
+Relevant code files can be found in `./shell/`.
 
 ### Attaching
 

--- a/docs/development/debugging-instructions-macos.md
+++ b/docs/development/debugging-instructions-macos.md
@@ -46,7 +46,7 @@ this basic introduction, let's assume that you're calling a command from JavaScr
 that isn't behaving correctly - so you'd like to break on that command's C++
 counterpart inside the Electron source.
 
-Relevant code files can be found in `./atom/`.
+Relevant code files can be found in `./shell/`.
 
 Let's assume that you want to debug `app.setName()`, which is defined in `browser.cc`
 as `Browser::SetName()`. Set the breakpoint using the `breakpoint` command, specifying

--- a/docs/development/pull-requests.md
+++ b/docs/development/pull-requests.md
@@ -55,7 +55,7 @@ $ git checkout -b my-branch -t upstream/master
 ### Step 4: Code
 
 Most pull requests opened against the `electron/electron` repository include
-changes to either the C/C++ code in the `atom/` folder,
+changes to either the C/C++ code in the `shell/` folder,
 the JavaScript code in the `lib/` folder, the documentation in `docs/api/`
 or tests in the `spec/` folder.
 


### PR DESCRIPTION
Update some developer docs to reflect the current directory hierarchy.

Notes: none