### PR TITLE
fix(extensions): set lowest isolated world id

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -556,6 +556,7 @@ filenames = {
     "shell/common/skia_util.h",
     "shell/common/v8_value_converter.cc",
     "shell/common/v8_value_converter.h",
+    "shell/common/world_ids.h",
     "shell/renderer/api/context_bridge/render_frame_context_bridge_store.cc",
     "shell/renderer/api/context_bridge/render_frame_context_bridge_store.h",
     "shell/renderer/api/electron_api_context_bridge.cc",

--- a/shell/common/world_ids.h
+++ b/shell/common/world_ids.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2020 Samuel Maddock
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_COMMON_WORLD_IDS_H_
+#define SHELL_COMMON_WORLD_IDS_H_
+
+#include "third_party/blink/public/platform/web_isolated_world_ids.h"
+
+namespace electron {
+
+enum WorldIDs : int32_t {
+  MAIN_WORLD_ID = 0,
+
+  // Use a high number far away from 0 to not collide with any other world
+  // IDs created internally by Chrome.
+  ISOLATED_WORLD_ID = 999,
+
+  // Numbers for isolated worlds for extensions are set in
+  // lib/renderer/content-script-injector.ts, and are greater than or equal to
+  // this number, up to ISOLATED_WORLD_ID_EXTENSIONS_END.
+  ISOLATED_WORLD_ID_EXTENSIONS = 1 << 20,
+
+  // Last valid isolated world ID.
+  ISOLATED_WORLD_ID_EXTENSIONS_END =
+      blink::IsolatedWorldId::kEmbedderWorldIdLimit - 1
+};
+
+}  // namespace electron
+
+#endif  // SHELL_COMMON_WORLD_IDS_H_

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -20,8 +20,8 @@
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/node_includes.h"
+#include "shell/common/world_ids.h"
 #include "shell/renderer/api/context_bridge/render_frame_context_bridge_store.h"
-#include "shell/renderer/electron_render_frame_observer.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 
 namespace electron {
@@ -477,7 +477,7 @@ void ExposeAPIInMainWorld(const std::string& key,
   }
 
   v8::Local<v8::Context> isolated_context =
-      frame->WorldScriptContext(args->isolate(), World::ISOLATED_WORLD);
+      frame->WorldScriptContext(args->isolate(), WorldIDs::ISOLATED_WORLD_ID);
 
   v8::Context::Scope main_context_scope(main_context);
   {

--- a/shell/renderer/electron_render_frame_observer.cc
+++ b/shell/renderer/electron_render_frame_observer.cc
@@ -20,6 +20,7 @@
 #include "net/grit/net_resources.h"
 #include "services/service_manager/public/cpp/interface_provider.h"
 #include "shell/common/options_switches.h"
+#include "shell/common/world_ids.h"
 #include "third_party/blink/public/platform/web_isolated_world_info.h"
 #include "third_party/blink/public/web/blink.h"
 #include "third_party/blink/public/web/web_document.h"
@@ -90,8 +91,8 @@ void ElectronRenderFrameObserver::DidInstallConditionalFeatures(
   }
 
 #if !BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-  if (world_id >= World::ISOLATED_WORLD_EXTENSIONS &&
-      world_id <= World::ISOLATED_WORLD_EXTENSIONS_END) {
+  if (world_id >= WorldIDs::ISOLATED_WORLD_ID_EXTENSIONS &&
+      world_id <= WorldIDs::ISOLATED_WORLD_ID_EXTENSIONS_END) {
     renderer_client_->SetupExtensionWorldOverrides(context, render_frame_,
                                                    world_id);
   }
@@ -136,19 +137,19 @@ void ElectronRenderFrameObserver::CreateIsolatedWorldContext() {
       blink::WebString::FromUTF8("Electron Isolated Context");
   // Setup document's origin policy in isolated world
   info.security_origin = frame->GetDocument().GetSecurityOrigin();
-  frame->SetIsolatedWorldInfo(World::ISOLATED_WORLD, info);
+  frame->SetIsolatedWorldInfo(WorldIDs::ISOLATED_WORLD_ID, info);
 
   // Create initial script context in isolated world
   blink::WebScriptSource source("void 0");
-  frame->ExecuteScriptInIsolatedWorld(World::ISOLATED_WORLD, source);
+  frame->ExecuteScriptInIsolatedWorld(WorldIDs::ISOLATED_WORLD_ID, source);
 }
 
 bool ElectronRenderFrameObserver::IsMainWorld(int world_id) {
-  return world_id == World::MAIN_WORLD;
+  return world_id == WorldIDs::MAIN_WORLD_ID;
 }
 
 bool ElectronRenderFrameObserver::IsIsolatedWorld(int world_id) {
-  return world_id == World::ISOLATED_WORLD;
+  return world_id == WorldIDs::ISOLATED_WORLD_ID;
 }
 
 bool ElectronRenderFrameObserver::ShouldNotifyClient(int world_id) {

--- a/shell/renderer/electron_render_frame_observer.h
+++ b/shell/renderer/electron_render_frame_observer.h
@@ -11,7 +11,6 @@
 #include "content/public/renderer/render_frame_observer.h"
 #include "ipc/ipc_platform_file.h"
 #include "shell/renderer/renderer_client_base.h"
-#include "third_party/blink/public/platform/web_isolated_world_ids.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 
 namespace base {
@@ -19,23 +18,6 @@ class ListValue;
 }
 
 namespace electron {
-
-enum World {
-  MAIN_WORLD = 0,
-
-  // Use a high number far away from 0 to not collide with any other world
-  // IDs created internally by Chrome.
-  ISOLATED_WORLD = 999,
-
-  // Numbers for isolated worlds for extensions are set in
-  // lib/renderer/content-script-injector.ts, and are greater than or equal to
-  // this number, up to ISOLATED_WORLD_EXTENSIONS_END.
-  ISOLATED_WORLD_EXTENSIONS = 1 << 20,
-
-  // Last valid isolated world ID.
-  ISOLATED_WORLD_EXTENSIONS_END =
-      blink::IsolatedWorldId::kEmbedderWorldIdLimit - 1
-};
 
 // Helper class to forward the messages to the client.
 class ElectronRenderFrameObserver : public content::RenderFrameObserver {

--- a/shell/renderer/extensions/electron_extensions_renderer_client.cc
+++ b/shell/renderer/extensions/electron_extensions_renderer_client.cc
@@ -6,7 +6,7 @@
 
 #include "content/public/renderer/render_thread.h"
 #include "extensions/renderer/dispatcher.h"
-#include "shell/renderer/electron_render_frame_observer.h"
+#include "shell/common/world_ids.h"
 #include "shell/renderer/extensions/electron_extensions_dispatcher_delegate.h"
 
 namespace electron {
@@ -25,7 +25,7 @@ bool ElectronExtensionsRendererClient::IsIncognitoProcess() const {
 }
 
 int ElectronExtensionsRendererClient::GetLowestIsolatedWorldId() const {
-  return World::ISOLATED_WORLD_EXTENSIONS;
+  return WorldIDs::ISOLATED_WORLD_ID_EXTENSIONS;
 }
 
 extensions::Dispatcher* ElectronExtensionsRendererClient::GetDispatcher() {

--- a/shell/renderer/extensions/electron_extensions_renderer_client.cc
+++ b/shell/renderer/extensions/electron_extensions_renderer_client.cc
@@ -6,6 +6,7 @@
 
 #include "content/public/renderer/render_thread.h"
 #include "extensions/renderer/dispatcher.h"
+#include "shell/renderer/electron_render_frame_observer.h"
 #include "shell/renderer/extensions/electron_extensions_dispatcher_delegate.h"
 
 namespace electron {
@@ -24,11 +25,7 @@ bool ElectronExtensionsRendererClient::IsIncognitoProcess() const {
 }
 
 int ElectronExtensionsRendererClient::GetLowestIsolatedWorldId() const {
-  // app_shell doesn't need to reserve world IDs for anything other than
-  // extensions, so we always return 1. Note that 0 is reserved for the global
-  // world.
-  // TODO(samuelmaddock): skip electron worlds
-  return 10;
+  return World::ISOLATED_WORLD_EXTENSIONS;
 }
 
 extensions::Dispatcher* ElectronExtensionsRendererClient::GetDispatcher() {

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -24,11 +24,11 @@
 #include "shell/common/color_util.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/options_switches.h"
+#include "shell/common/world_ids.h"
 #include "shell/renderer/browser_exposed_renderer_interfaces.h"
 #include "shell/renderer/content_settings_observer.h"
 #include "shell/renderer/electron_api_service_impl.h"
 #include "shell/renderer/electron_autofill_agent.h"
-#include "shell/renderer/electron_render_frame_observer.h"
 #include "third_party/blink/public/common/associated_interfaces/associated_interface_registry.h"
 #include "third_party/blink/public/web/blink.h"
 #include "third_party/blink/public/web/web_custom_element.h"  // NOLINT(build/include_alpha)
@@ -424,7 +424,7 @@ v8::Local<v8::Context> RendererClientBase::GetContext(
     blink::WebLocalFrame* frame,
     v8::Isolate* isolate) const {
   if (isolated_world())
-    return frame->WorldScriptContext(isolate, World::ISOLATED_WORLD);
+    return frame->WorldScriptContext(isolate, WorldIDs::ISOLATED_WORLD_ID);
   else
     return frame->MainWorldScriptContext();
 }


### PR DESCRIPTION
#### Description of Change
Extensions now use the lowest isolated world ID previously defined for the JS extension implementation.

Ref #19447

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
