### PR TITLE
build: preserve timestamps when stripping files

### DIFF
--- a/script/strip-binaries.py
+++ b/script/strip-binaries.py
@@ -22,7 +22,7 @@ def strip_binary(binary_path, target_cpu):
     strip = 'mips64el-redhat-linux-strip'
   else:
     strip = 'strip'
-  execute([strip, binary_path])
+  execute([strip, '--preserve-dates', binary_path])
 
 def main():
   args = parse_args()


### PR DESCRIPTION
Backport of #22094

See that PR for details.

Resolves #22224

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
