### PR TITLE
docs: clean up protocol docs

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -749,7 +749,7 @@ protocol (aka URI scheme). If so, it will remove the app as the default handler.
 * `path` String (optional) _Windows_ - Defaults to `process.execPath`
 * `args` String[] (optional) _Windows_ - Defaults to an empty array
 
-Returns `Boolean` - whether the current executable is the default handler for a
+Returns `Boolean` - Whether the current executable is the default handler for a
 protocol (aka URI scheme).
 
 **Note:** On macOS, you can use this method to check if the app has been

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -703,34 +703,34 @@ Clears the recent documents list.
 
 ### `app.setAsDefaultProtocolClient(protocol[, path, args])`
 
-* `protocol` String - The name of your protocol, without `://`. If you want your
-  app to handle `electron://` links, call this method with `electron` as the
-  parameter.
-* `path` String (optional) _Windows_ - Defaults to `process.execPath`
-* `args` String[] (optional) _Windows_ - Defaults to an empty array
+* `protocol` String - The name of your protocol, without `://`. For example,
+  if you want your app to handle `electron://` links, call this method with
+  `electron` as the parameter.
+* `path` String (optional) _Windows_ - The path to the Electron executable.
+  Defaults to `process.execPath`
+* `args` String[] (optional) _Windows_ - Arguments passed to the executable.
+  Defaults to an empty array
 
 Returns `Boolean` - Whether the call succeeded.
 
-This method sets the current executable as the default handler for a protocol
-(aka URI scheme). It allows you to integrate your app deeper into the operating
-system. Once registered, all links with `your-protocol://` will be opened with
-the current executable. The whole link, including protocol, will be passed to
-your application as a parameter.
-
-On Windows, you can provide optional parameters path, the path to your executable,
-and args, an array of arguments to be passed to your executable when it launches.
+Sets the current executable as the default handler for a protocol (aka URI
+scheme). It allows you to integrate your app deeper into the operating system.
+Once registered, all links with `your-protocol://` will be opened with the
+current executable. The whole link, including protocol, will be passed to your
+application as a parameter.
 
 **Note:** On macOS, you can only register protocols that have been added to
-your app's `info.plist`, which can not be modified at runtime. You can however
-change the file with a simple text editor or script during build time.
-Please refer to [Apple's documentation][CFBundleURLTypes] for details.
+your app's `info.plist`, which cannot be modified at runtime. However, you can
+change the file during build time via [Electron Forge][electron-forge],
+[Electron Packager][electron-packager], or by editing `info.plist` with a text
+editor. Please refer to [Apple's documentation][CFBundleURLTypes] for details.
 
 **Note:** In a Windows Store environment (when packaged as an `appx`) this API
 will return `true` for all calls but the registry key it sets won't be accessible
 by other applications.  In order to register your Windows Store application
 as a default protocol handler you must [declare the protocol in your manifest](https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-uap-protocol).
 
-The API uses the Windows Registry and LSSetDefaultHandlerForURLScheme internally.
+The API uses the Windows Registry and `LSSetDefaultHandlerForURLScheme` internally.
 
 ### `app.removeAsDefaultProtocolClient(protocol[, path, args])` _macOS_ _Windows_
 
@@ -749,10 +749,8 @@ protocol (aka URI scheme). If so, it will remove the app as the default handler.
 * `path` String (optional) _Windows_ - Defaults to `process.execPath`
 * `args` String[] (optional) _Windows_ - Defaults to an empty array
 
-Returns `Boolean`
-
-This method checks if the current executable is the default handler for a protocol
-(aka URI scheme). If so, it will return true. Otherwise, it will return false.
+Returns `Boolean` - whether the current executable is the default handler for a
+protocol (aka URI scheme).
 
 **Note:** On macOS, you can use this method to check if the app has been
 registered as the default protocol handler for a protocol. You can also verify
@@ -760,7 +758,7 @@ this by checking `~/Library/Preferences/com.apple.LaunchServices.plist` on the
 macOS machine. Please refer to
 [Apple's documentation][LSCopyDefaultHandlerForURLScheme] for details.
 
-The API uses the Windows Registry and LSCopyDefaultHandlerForURLScheme internally.
+The API uses the Windows Registry and `LSCopyDefaultHandlerForURLScheme` internally.
 
 ### `app.getApplicationNameForProtocol(url)`
 
@@ -1327,6 +1325,8 @@ A `Boolean` property that returns  `true` if the app is packaged, `false` otherw
 [dock-menu]:https://developer.apple.com/macos/human-interface-guidelines/menus/dock-menus/
 [tasks]:https://msdn.microsoft.com/en-us/library/windows/desktop/dd378460(v=vs.85).aspx#tasks
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
+[electron-forge]: https://www.electronforge.io/
+[electron-packager]: https://github.com/electron/electron-packager
 [CFBundleURLTypes]: https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-102207-TPXREF115
 [LSCopyDefaultHandlerForURLScheme]: https://developer.apple.com/library/mac/documentation/Carbon/Reference/LaunchServicesReference/#//apple_ref/c/func/LSCopyDefaultHandlerForURLScheme
 [handoff]: https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/Handoff/HandoffFundamentals/HandoffFundamentals.html


### PR DESCRIPTION
#### Description of Change

I was reading over the protocol docs and made some organizational/grammatical fixes.

CC: @electron/wg-ecosystem 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `yarn lint:docs` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes