### PR TITLE
feat: Add OtherItemsProxy TouchBar item

### DIFF
--- a/docs/api/touch-bar-other-items-proxy.md
+++ b/docs/api/touch-bar-other-items-proxy.md
@@ -1,0 +1,12 @@
+## Class: TouchBarOtherItemsProxy
+
+> Instantiates a special "other items proxy", which nests TouchBar elements inherited
+> from Chromium at the space indicated by the proxy. By default, this proxy is added
+> to each TouchBar at the end of the input. For more information, see the AppKit docs on
+> [NSTouchBarItemIdentifierOtherItemsProxy](https://developer.apple.com/documentation/appkit/nstouchbaritemidentifierotheritemsproxy)
+>
+> Note: Only one instance of this class can be added per TouchBar.
+
+Process: [Main](../tutorial/application-architecture.md#main-and-renderer-processes)
+
+### `new TouchBarOtherItemsProxy()` _Experimental_

--- a/docs/api/touch-bar.md
+++ b/docs/api/touch-bar.md
@@ -58,6 +58,10 @@ A [`typeof TouchBarSlider`](./touch-bar-slider.md) reference to the `TouchBarSli
 
 A [`typeof TouchBarSpacer`](./touch-bar-spacer.md) reference to the `TouchBarSpacer` class.
 
+#### `TouchBarOtherItemsProxy`
+
+A [`typeof TouchBarOtherItemsProxy`](./touch-bar-other-items-proxy.md) reference to the `TouchBarOtherItemsProxy` class.
+
 ### Instance Properties
 
 The following properties are available on instances of `TouchBar`:

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -55,6 +55,7 @@ auto_filenames = {
     "docs/api/touch-bar-color-picker.md",
     "docs/api/touch-bar-group.md",
     "docs/api/touch-bar-label.md",
+    "docs/api/touch-bar-other-items-proxy.md",
     "docs/api/touch-bar-popover.md",
     "docs/api/touch-bar-scrubber.md",
     "docs/api/touch-bar-segmented-control.md",

--- a/lib/browser/api/touch-bar.js
+++ b/lib/browser/api/touch-bar.js
@@ -51,10 +51,22 @@ class TouchBar extends EventEmitter {
         item.child.ordereredItems.forEach(registerItem)
       }
     }
+
+    let hasOtherItemsProxy = false
     items.forEach((item) => {
       if (!(item instanceof TouchBarItem)) {
         throw new Error('Each item must be an instance of TouchBarItem')
       }
+
+      // only allow one OtherItemsProxy per touchbar
+      if (item.type === 'other_items_proxy') {
+        if (!hasOtherItemsProxy) {
+          hasOtherItemsProxy = true
+        } else {
+          throw new Error('Must only have one OtherItemsProxy per TouchBar')
+        }
+      }
+
       this.ordereredItems.push(item)
       registerItem(item)
     })
@@ -331,6 +343,14 @@ TouchBar.TouchBarScrubber = class TouchBarScrubber extends TouchBarItem {
         }
       })
     }
+  }
+}
+
+TouchBar.TouchBarOtherItemsProxy = class TouchBarOtherItemsProxy extends TouchBarItem {
+  constructor (config) {
+    super()
+    if (config == null) config = {} // no config options anyways
+    this._addImmutableProperty('type', 'other_items_proxy')
   }
 }
 

--- a/lib/browser/api/touch-bar.js
+++ b/lib/browser/api/touch-bar.js
@@ -58,7 +58,6 @@ class TouchBar extends EventEmitter {
         throw new Error('Each item must be an instance of TouchBarItem')
       }
 
-      // only allow one OtherItemsProxy per touchbar
       if (item.type === 'other_items_proxy') {
         if (!hasOtherItemsProxy) {
           hasOtherItemsProxy = true
@@ -66,10 +65,13 @@ class TouchBar extends EventEmitter {
           throw new Error('Must only have one OtherItemsProxy per TouchBar')
         }
       }
+    })
 
+    // register in separate loop after all items are validated
+    for (const item of items) {
       this.ordereredItems.push(item)
       registerItem(item)
-    })
+    }
   }
 
   set escapeItem (item) {
@@ -349,7 +351,6 @@ TouchBar.TouchBarScrubber = class TouchBarScrubber extends TouchBarItem {
 TouchBar.TouchBarOtherItemsProxy = class TouchBarOtherItemsProxy extends TouchBarItem {
   constructor (config) {
     super()
-    if (config == null) config = {} // no config options anyways
     this._addImmutableProperty('type', 'other_items_proxy')
   }
 }

--- a/shell/browser/ui/cocoa/electron_touch_bar.mm
+++ b/shell/browser/ui/cocoa/electron_touch_bar.mm
@@ -64,6 +64,8 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
     (const std::vector<gin_helper::PersistentDictionary>&)dicts {
   NSMutableArray* identifiers = [NSMutableArray array];
 
+  bool has_other_items_proxy = false;
+
   if (@available(macOS 10.12.2, *)) {
     for (const auto& item : dicts) {
       std::string type;
@@ -80,6 +82,9 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
           } else {
             identifier = NSTouchBarItemIdentifierFixedSpaceSmall;
           }
+        } else if (type == "other_items_proxy") {
+          identifier = NSTouchBarItemIdentifierOtherItemsProxy;
+          has_other_items_proxy = true;
         } else {
           identifier = [self identifierFromID:item_id type:type];
         }
@@ -90,7 +95,8 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
         }
       }
     }
-    [identifiers addObject:NSTouchBarItemIdentifierOtherItemsProxy];
+    if (!has_other_items_proxy)
+      [identifiers addObject:NSTouchBarItemIdentifierOtherItemsProxy];
   }
 
   return identifiers;

--- a/spec-main/api-touch-bar-spec.ts
+++ b/spec-main/api-touch-bar-spec.ts
@@ -3,7 +3,7 @@ import { BrowserWindow, TouchBar } from 'electron'
 import { closeWindow } from './window-helpers'
 import { expect } from 'chai'
 
-const { TouchBarButton, TouchBarColorPicker, TouchBarGroup, TouchBarLabel, TouchBarPopover, TouchBarScrubber, TouchBarSegmentedControl, TouchBarSlider, TouchBarSpacer } = TouchBar
+const { TouchBarButton, TouchBarColorPicker, TouchBarGroup, TouchBarLabel, TouchBarOtherItemsProxy, TouchBarPopover, TouchBarScrubber, TouchBarSegmentedControl, TouchBarSlider, TouchBarSpacer } = TouchBar
 
 describe('TouchBar module', () => {
   it('throws an error when created without an options object', () => {
@@ -32,6 +32,13 @@ describe('TouchBar module', () => {
     }).to.throw('Escape item must be an instance of TouchBarItem')
   })
 
+  it('throws an error if multiple OtherItemProxy items are added', () => {
+    expect(() => {
+      const touchBar = new TouchBar({ items: [new TouchBarOtherItemsProxy(), new TouchBarOtherItemsProxy()] })
+      touchBar.toString()
+    }).to.throw('Must only have one OtherItemsProxy per TouchBar')
+  })
+
   describe('BrowserWindow behavior', () => {
     let window: BrowserWindow
 
@@ -47,32 +54,35 @@ describe('TouchBar module', () => {
 
     it('can be added to and removed from a window', () => {
       const label = new TouchBarLabel({ label: 'bar' })
-      const touchBar = new TouchBar({ items: [
-        new TouchBarButton({ label: 'foo', backgroundColor: '#F00', click: () => {} }),
-        new TouchBarButton({
-          icon: path.join(__dirname, 'fixtures', 'assets', 'logo.png'),
-          iconPosition: 'right',
-          click: () => {}
-        }),
-        new TouchBarColorPicker({ selectedColor: '#F00', change: () => {} }),
-        new TouchBarGroup({ items: new TouchBar({ items: [new TouchBarLabel({ label: 'hello' })] }) }),
-        label,
-        new TouchBarPopover({ items: new TouchBar({ items: [new TouchBarButton({ label: 'pop' })] }) }),
-        new TouchBarSlider({ label: 'slide', value: 5, minValue: 2, maxValue: 75, change: () => {} }),
-        new TouchBarSpacer({ size: 'large' }),
-        new TouchBarSegmentedControl({
-          segmentStyle: 'capsule',
-          segments: [{ label: 'baz', enabled: false }],
-          selectedIndex: 5
-        }),
-        new TouchBarSegmentedControl({ segments: [] }),
-        new TouchBarScrubber({
-          items: [{ label: 'foo' }, { label: 'bar' }, { label: 'baz' }],
-          selectedStyle: 'outline',
-          mode: 'fixed',
-          showArrowButtons: true
-        })
-      ] })
+      const touchBar = new TouchBar({
+        items: [
+          new TouchBarButton({ label: 'foo', backgroundColor: '#F00', click: () => { } }),
+          new TouchBarButton({
+            icon: path.join(__dirname, 'fixtures', 'assets', 'logo.png'),
+            iconPosition: 'right',
+            click: () => { }
+          }),
+          new TouchBarColorPicker({ selectedColor: '#F00', change: () => { } }),
+          new TouchBarGroup({ items: new TouchBar({ items: [new TouchBarLabel({ label: 'hello' })] }) }),
+          label,
+          new TouchBarOtherItemsProxy(),
+          new TouchBarPopover({ items: new TouchBar({ items: [new TouchBarButton({ label: 'pop' })] }) }),
+          new TouchBarSlider({ label: 'slide', value: 5, minValue: 2, maxValue: 75, change: () => { } }),
+          new TouchBarSpacer({ size: 'large' }),
+          new TouchBarSegmentedControl({
+            segmentStyle: 'capsule',
+            segments: [{ label: 'baz', enabled: false }],
+            selectedIndex: 5
+          }),
+          new TouchBarSegmentedControl({ segments: [] }),
+          new TouchBarScrubber({
+            items: [{ label: 'foo' }, { label: 'bar' }, { label: 'baz' }],
+            selectedStyle: 'outline',
+            mode: 'fixed',
+            showArrowButtons: true
+          })
+        ]
+      })
       const escapeButton = new TouchBarButton({ label: 'foo' })
       window.setTouchBar(touchBar)
       touchBar.escapeItem = escapeButton


### PR DESCRIPTION
#### Description of Change

Adds a new `TouchBarOtherItemsProxy` class that inherits from `TouchBarItem`. This allows Electron developers to customize the positioning of touch bars inherited from Chromium using an `NSTouchBarItemIdentifierOtherItemsProxy`.

By default, we used to have this proxy enabled at the end of each touch bar instance. It still defaults to that position if not manually defined.

Also, you can't add more than one of these per touch bar. I've added a guard to catch this at the JS level.

See: https://developer.apple.com/documentation/appkit/nstouchbaritemidentifierotheritemsproxy

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: The position of nested touch bars inherited from Chromium can now be customized (macOS).
