### PR TITLE
fix: typo in crash reporter constructor

### DIFF
--- a/lib/common/crash-reporter.js
+++ b/lib/common/crash-reporter.js
@@ -3,7 +3,7 @@
 const binding = process.electronBinding('crash_reporter')
 
 class CrashReporter {
-  contructor () {
+  constructor () {
     this.productName = null
     this.crashesDirectory = null
   }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

This PR includes fix for crashReporter module in electron v8.0.0 and v8.0.1, we get the following error on calling crashReporter.start.

`TypeError: Error processing argument at index 6, conversion failure from 
    at CrashReporterRenderer.start (crash-reporter.js:42)` 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [X] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixes an issue where TypeError occurred on initializing CrashReporter