### PR TITLE
fix: disable remote layer APIs in MAS build (7-1-x)

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -36,6 +36,7 @@ mas-cgdisplayusesforcetogray.patch
 mas-audiodeviceduck.patch
 mas-lssetapplicationlaunchservicesserverconnectionstatus.patch
 ignore_rc_check.patch
+mas_disable_remote_layer.patch
 mas_disable_remote_accessibility.patch
 mas_disable_custom_window_frame.patch
 mas_disable_spi_file_type_mappings.patch

--- a/patches/chromium/mas_disable_remote_layer.patch
+++ b/patches/chromium/mas_disable_remote_layer.patch
@@ -1,0 +1,185 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Thu, 20 Sep 2018 17:48:49 -0700
+Subject: mas_disable_remote_layer.patch
+
+Disable remote layer APIs (CAContext and CALayerHost) for MAS build.
+
+diff --git a/gpu/ipc/service/image_transport_surface_overlay_mac.h b/gpu/ipc/service/image_transport_surface_overlay_mac.h
+index f343b7e0e04a..d0ecefd4333c 100644
+--- a/gpu/ipc/service/image_transport_surface_overlay_mac.h
++++ b/gpu/ipc/service/image_transport_surface_overlay_mac.h
+@@ -20,7 +20,9 @@
+ #include "ui/gl/gl_surface_egl.h"
+ #endif
+ 
++#ifndef MAS_BUILD
+ @class CAContext;
++#endif
+ @class CALayer;
+ 
+ namespace ui {
+@@ -97,7 +99,9 @@ class ImageTransportSurfaceOverlayMacBase : public BaseClass,
+   base::WeakPtr<ImageTransportSurfaceDelegate> delegate_;
+ 
+   bool use_remote_layer_api_;
++#ifndef MAS_BUILD
+   base::scoped_nsobject<CAContext> ca_context_;
++#endif
+   std::unique_ptr<ui::CALayerTreeCoordinator> ca_layer_tree_coordinator_;
+ 
+   gfx::Size pixel_size_;
+diff --git a/gpu/ipc/service/image_transport_surface_overlay_mac.mm b/gpu/ipc/service/image_transport_surface_overlay_mac.mm
+index 10b345d3727c..b52f03be6351 100644
+--- a/gpu/ipc/service/image_transport_surface_overlay_mac.mm
++++ b/gpu/ipc/service/image_transport_surface_overlay_mac.mm
+@@ -63,6 +63,7 @@
+ template <typename BaseClass>
+ bool ImageTransportSurfaceOverlayMacBase<BaseClass>::Initialize(
+     gl::GLSurfaceFormat format) {
++#ifndef MAS_BUILD
+   // Create the CAContext to send this to the GPU process, and the layer for
+   // the context.
+   if (use_remote_layer_api_) {
+@@ -71,6 +72,7 @@
+         [CAContext contextWithCGSConnection:connection_id options:@{}] retain]);
+     [ca_context_ setLayer:ca_layer_tree_coordinator_->GetCALayerForDisplay()];
+   }
++#endif
+   return true;
+ }
+ 
+@@ -136,7 +138,9 @@
+                          "GLImpl", static_cast<int>(gl::GetGLImplementation()),
+                          "width", pixel_size_.width());
+     if (use_remote_layer_api_) {
++#ifndef MAS_BUILD
+       params.ca_layer_params.ca_context_id = [ca_context_ contextId];
++#endif
+     } else {
+       IOSurfaceRef io_surface =
+           ca_layer_tree_coordinator_->GetIOSurfaceForDisplay();
+diff --git a/ui/accelerated_widget_mac/display_ca_layer_tree.mm b/ui/accelerated_widget_mac/display_ca_layer_tree.mm
+index 60abe639bd9c..c38eed5fbdef 100644
+--- a/ui/accelerated_widget_mac/display_ca_layer_tree.mm
++++ b/ui/accelerated_widget_mac/display_ca_layer_tree.mm
+@@ -98,6 +98,7 @@ - (void)setContentsChanged;
+ }
+ 
+ void DisplayCALayerTree::GotCALayerFrame(uint32_t ca_context_id) {
++#ifndef MAS_BUILD
+   // Early-out if the remote layer has not changed.
+   if ([remote_layer_ contextId] == ca_context_id)
+     return;
+@@ -122,6 +123,9 @@ - (void)setContentsChanged;
+     [io_surface_layer_ removeFromSuperlayer];
+     io_surface_layer_.reset();
+   }
++#else
++  NOTREACHED() << "Remote layer is being used in MAS build";
++#endif
+ }
+ 
+ void DisplayCALayerTree::GotIOSurfaceFrame(
+diff --git a/ui/base/cocoa/remote_layer_api.h b/ui/base/cocoa/remote_layer_api.h
+index 2057fe69d1bb..2aba330fc488 100644
+--- a/ui/base/cocoa/remote_layer_api.h
++++ b/ui/base/cocoa/remote_layer_api.h
+@@ -13,6 +13,7 @@
+ 
+ #include "ui/base/ui_base_export.h"
+ 
++#ifndef MAS_BUILD
+ // The CGSConnectionID is used to create the CAContext in the process that is
+ // going to share the CALayers that it is rendering to another process to
+ // display.
+@@ -50,6 +51,8 @@ typedef uint32_t CAContextID;
+ 
+ #endif // __OBJC__
+ 
++#endif // MAS_BUILD
++
+ namespace ui {
+ 
+ // This function will check if all of the interfaces listed above are supported
+diff --git a/ui/base/cocoa/remote_layer_api.mm b/ui/base/cocoa/remote_layer_api.mm
+index bbaf9f466f49..8c846ce9523a 100644
+--- a/ui/base/cocoa/remote_layer_api.mm
++++ b/ui/base/cocoa/remote_layer_api.mm
+@@ -12,6 +12,7 @@
+ namespace ui {
+ 
+ bool RemoteLayerAPISupported() {
++#ifndef MAS_BUILD
+   static bool disabled_at_command_line =
+       base::CommandLine::ForCurrentProcess()->HasSwitch(
+           switches::kDisableRemoteCoreAnimation);
+@@ -46,6 +47,9 @@ bool RemoteLayerAPISupported() {
+ 
+   // If everything is there, we should be able to use the API.
+   return true;
++#else
++  return false;
++#endif  // MAS_BUILD
+ }
+ 
+ }  // namespace
+diff --git a/ui/views/cocoa/native_widget_mac_ns_window_host.h b/ui/views/cocoa/native_widget_mac_ns_window_host.h
+index 528ec883d226..5058eb6048a6 100644
+--- a/ui/views/cocoa/native_widget_mac_ns_window_host.h
++++ b/ui/views/cocoa/native_widget_mac_ns_window_host.h
+@@ -446,11 +446,13 @@ class VIEWS_EXPORT NativeWidgetMacNSWindowHost
+   // Display link for getting vsync info for |display_|.
+   scoped_refptr<ui::DisplayLinkMac> display_link_;
+ 
++#ifndef MAS_BUILD
+   // Structure to avoid sending IOSurface mach ports over mojo.
+   // https://crbug.com/942213
+   class IOSurfaceToRemoteLayerInterceptor;
+   std::unique_ptr<IOSurfaceToRemoteLayerInterceptor>
+       io_surface_to_remote_layer_interceptor_;
++#endif
+ 
+   // The geometry of the window and its contents view, in screen coordinates.
+   gfx::Rect window_bounds_in_screen_;
+diff --git a/ui/views/cocoa/native_widget_mac_ns_window_host.mm b/ui/views/cocoa/native_widget_mac_ns_window_host.mm
+index 6aa9e71245f1..89eb028e840b 100644
+--- a/ui/views/cocoa/native_widget_mac_ns_window_host.mm
++++ b/ui/views/cocoa/native_widget_mac_ns_window_host.mm
+@@ -213,6 +213,7 @@ bool PositionWindowInScreenCoordinates(Widget* widget,
+ 
+ }  // namespace
+ 
++#ifndef MAS_BUILD
+ // A gfx::CALayerParams may pass the content to be drawn across processes via
+ // either an IOSurface (sent as mach port) or a CAContextID (which is an
+ // integer). For historical reasons, software compositing uses IOSurfaces.
+@@ -267,6 +268,8 @@ void UpdateCALayerParams(gfx::CALayerParams* ca_layer_params) {
+   base::scoped_nsobject<CALayer> io_surface_layer_;
+ };
+ 
++#endif  // MAS_BUILD
++
+ // static
+ NativeWidgetMacNSWindowHost* NativeWidgetMacNSWindowHost::GetFromNativeWindow(
+     gfx::NativeWindow native_window) {
+@@ -1472,6 +1475,7 @@ void UpdateCALayerParams(gfx::CALayerParams* ca_layer_params) {
+   const gfx::CALayerParams* ca_layer_params =
+       compositor_->widget()->GetCALayerParams();
+   if (ca_layer_params) {
++#ifndef MAS_BUILD
+     // Replace IOSurface mach ports with CAContextIDs only when using the
+     // out-of-process bridge (to reduce risk, because this workaround is being
+     // merged to late-life-cycle release branches) and when an IOSurface
+@@ -1488,8 +1492,11 @@ void UpdateCALayerParams(gfx::CALayerParams* ca_layer_params) {
+           &updated_ca_layer_params);
+       remote_ns_window_ptr_->SetCALayerParams(updated_ca_layer_params);
+     } else {
++#endif  // MAS_BUILD
+       GetNSWindowMojo()->SetCALayerParams(*ca_layer_params);
++#ifndef MAS_BUILD
+     }
++#endif  // MAS_BUILD
+   }
+ 
+   // Take this opportunity to update the VSync parameters, if needed.

--- a/shell/app/atom_main_delegate.cc
+++ b/shell/app/atom_main_delegate.cc
@@ -213,6 +213,21 @@ bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
                << " is not supported. See https://crbug.com/638180.";
 #endif
 
+#if defined(MAS_BUILD)
+  // In MAS build we are using --disable-remote-core-animation.
+  //
+  // According to ccameron:
+  // If you're running with --disable-remote-core-animation, you may want to
+  // also run with --disable-gpu-memory-buffer-compositor-resources as well.
+  // That flag makes it so we use regular GL textures instead of IOSurfaces
+  // for compositor resources. IOSurfaces are very heavyweight to
+  // create/destroy, but they can be displayed directly by CoreAnimation (and
+  // --disable-remote-core-animation makes it so we don't use this property,
+  // so they're just heavyweight with no upside).
+  command_line->AppendSwitch(
+      ::switches::kDisableGpuMemoryBufferCompositorResources);
+#endif
+
   content_client_ = std::make_unique<AtomContentClient>();
   SetContentClient(content_client_.get());
 


### PR DESCRIPTION
Backport of #20965.

Notes: Fix Electron apps getting rejected to Mac App Store.