### PR TITLE
build: allow custom node-spec-runner options

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1193,7 +1193,7 @@ steps-test-node: &steps-test-node
         name: Run Node Tests
         command: |
           cd src
-          node electron/script/node-spec-runner.js junit
+          node electron/script/node-spec-runner.js --default --jUnitDir=junit
     - store_test_results:
         path: src/junit
 


### PR DESCRIPTION
#### Description of Change

Allow passing custom options to `node-spec-runner`. Right now the alternative is just to run:

```sh
$ e node [options]
```

but the issue with that is that it doesn't allow for handling tests that pattern-match to stdout redirects. This allows for use of Node.js's actual spec runner in a less painful way from the Electron dir by allowing the user to pass any number of arguments recognized by Node.js' test runner.

Local testing of failing Node.js tests then becomes much nicer:

```sh
$ node script/node-spec-runner.js --verbose test/message/throw_undefined_traced.js
```

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
