### PR TITLE
fix: call focus on native window on call to webContents.focus on mac

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2070,11 +2070,11 @@ void WebContents::CopyImageAt(int x, int y) {
     host->CopyImageAt(x, y);
 }
 
+#if !defined(OS_MACOSX)
 void WebContents::Focus() {
   web_contents()->Focus();
 }
 
-#if !defined(OS_MACOSX)
 bool WebContents::IsFocused() const {
   auto* view = web_contents()->GetRenderWidgetHostView();
   if (!view)

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2070,11 +2070,17 @@ void WebContents::CopyImageAt(int x, int y) {
     host->CopyImageAt(x, y);
 }
 
-#if !defined(OS_MACOSX)
 void WebContents::Focus() {
+  // Focusing on WebContents does not automatically focus the window on macOS,
+  // do it manually to match the behavior on Windows.
+#if defined(OS_MACOSX)
+  if (owner_window())
+    owner_window()->Focus(true);
+#endif
   web_contents()->Focus();
 }
 
+#if !defined(OS_MACOSX)
 bool WebContents::IsFocused() const {
   auto* view = web_contents()->GetRenderWidgetHostView();
   if (!view)

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2071,9 +2071,9 @@ void WebContents::CopyImageAt(int x, int y) {
 }
 
 void WebContents::Focus() {
-  // Focusing on WebContents does not automatically focus the window on macOS,
-  // do it manually to match the behavior on Windows.
-#if defined(OS_MACOSX)
+  // Focusing on WebContents does not automatically focus the window on macOS
+  // and Linux, do it manually to match the behavior on Windows.
+#if defined(OS_MACOSX) || defined(OS_LINUX)
   if (owner_window())
     owner_window()->Focus(true);
 #endif

--- a/shell/browser/api/electron_api_web_contents_mac.mm
+++ b/shell/browser/api/electron_api_web_contents_mac.mm
@@ -11,6 +11,13 @@ namespace electron {
 
 namespace api {
 
+void WebContents::Focus() {
+  if (GetType() != Type::BACKGROUND_PAGE) {
+    auto window = [web_contents()->GetNativeView().GetNativeNSView() window];
+    [window makeKeyAndOrderFront:nil];
+  }
+}
+
 bool WebContents::IsFocused() const {
   auto* view = web_contents()->GetRenderWidgetHostView();
   if (!view)

--- a/shell/browser/api/electron_api_web_contents_mac.mm
+++ b/shell/browser/api/electron_api_web_contents_mac.mm
@@ -11,13 +11,6 @@ namespace electron {
 
 namespace api {
 
-void WebContents::Focus() {
-  if (GetType() != Type::BACKGROUND_PAGE) {
-    auto window = [web_contents()->GetNativeView().GetNativeNSView() window];
-    [window makeKeyAndOrderFront:nil];
-  }
-}
-
 bool WebContents::IsFocused() const {
   auto* view = web_contents()->GetRenderWidgetHostView();
   if (!view)

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -3837,9 +3837,9 @@ describe('BrowserWindow module', () => {
 
   describe('window.webContents.focus()', () => {
     it('focuses window', (done) => {
-      const w1 = new BrowserWindow({ x:100, y: 300, width: 300, height: 200 })
+      const w1 = new BrowserWindow({ x: 100, y: 300, width: 300, height: 200 })
       w1.loadURL('about:blank')
-      const w2 = new BrowserWindow({ x:300, y: 300, width: 300, height: 200 })
+      const w2 = new BrowserWindow({ x: 300, y: 300, width: 300, height: 200 })
       w2.loadURL('about:blank')
       w1.webContents.focus()
       // Give focus some time to switch to w1

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -3835,6 +3835,21 @@ describe('BrowserWindow module', () => {
     })
   })
 
+  describe('window.webContents.focus()', () => {
+    it('focuses window', (done) => {
+      const w1 = new BrowserWindow({ x:100, y: 300, width: 300, height: 200 })
+      w1.loadURL('about:blank')
+      const w2 = new BrowserWindow({ x:300, y: 300, width: 300, height: 200 })
+      w2.loadURL('about:blank')
+      w1.webContents.focus()
+      // Give focus some time to switch to w1
+      setTimeout(() => {
+        expect(w1.webContents.isFocused()).to.be.true('focuses window')
+        done()
+      })
+    })
+  })
+
   const features = process.electronBinding('features')
   ifdescribe(features.isOffscreenRenderingEnabled())('offscreen rendering', () => {
     let w: BrowserWindow

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -3836,6 +3836,7 @@ describe('BrowserWindow module', () => {
   })
 
   describe('window.webContents.focus()', () => {
+    afterEach(closeAllWindows)
     it('focuses window', (done) => {
       const w1 = new BrowserWindow({ x: 100, y: 300, width: 300, height: 200 })
       w1.loadURL('about:blank')


### PR DESCRIPTION
Closes https://github.com/electron/electron/issues/22305.

On mac call to web_contents()->Focus() is not enough so it's
necessary to call it on native window.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed `WebContents.focus` not focusing window on macOS and Linux.
