### PR TITLE
fix: revert {Atom => Electron}Application rename (#22206)

### DIFF
--- a/shell/app/electron_main_delegate_mac.mm
+++ b/shell/app/electron_main_delegate_mac.mm
@@ -82,7 +82,7 @@ void ElectronMainDelegate::SetUpBundleOverrides() {
 
 void RegisterAtomCrApp() {
   // Force the NSApplication subclass to be used.
-  [ElectronApplication sharedApplication];
+  [AtomApplication sharedApplication];
 }
 
 }  // namespace electron

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -28,20 +28,19 @@
 namespace electron {
 
 void Browser::SetShutdownHandler(base::Callback<bool()> handler) {
-  [[ElectronApplication sharedApplication]
-      setShutdownHandler:std::move(handler)];
+  [[AtomApplication sharedApplication] setShutdownHandler:std::move(handler)];
 }
 
 void Browser::Focus() {
-  [[ElectronApplication sharedApplication] activateIgnoringOtherApps:NO];
+  [[AtomApplication sharedApplication] activateIgnoringOtherApps:NO];
 }
 
 void Browser::Hide() {
-  [[ElectronApplication sharedApplication] hide:nil];
+  [[AtomApplication sharedApplication] hide:nil];
 }
 
 void Browser::Show() {
-  [[ElectronApplication sharedApplication] unhide:nil];
+  [[AtomApplication sharedApplication] unhide:nil];
 }
 
 void Browser::AddRecentDocument(const base::FilePath& path) {
@@ -162,7 +161,7 @@ void Browser::SetUserActivity(const std::string& type,
   std::string url_string;
   args->GetNext(&url_string);
 
-  [[ElectronApplication sharedApplication]
+  [[AtomApplication sharedApplication]
       setCurrentActivity:base::SysUTF8ToNSString(type)
             withUserInfo:DictionaryValueToNSDictionary(user_info)
           withWebpageURL:net::NSURLWithGURL(GURL(url_string))];
@@ -170,21 +169,21 @@ void Browser::SetUserActivity(const std::string& type,
 
 std::string Browser::GetCurrentActivityType() {
   NSUserActivity* userActivity =
-      [[ElectronApplication sharedApplication] getCurrentActivity];
+      [[AtomApplication sharedApplication] getCurrentActivity];
   return base::SysNSStringToUTF8(userActivity.activityType);
 }
 
 void Browser::InvalidateCurrentActivity() {
-  [[ElectronApplication sharedApplication] invalidateCurrentActivity];
+  [[AtomApplication sharedApplication] invalidateCurrentActivity];
 }
 
 void Browser::ResignCurrentActivity() {
-  [[ElectronApplication sharedApplication] resignCurrentActivity];
+  [[AtomApplication sharedApplication] resignCurrentActivity];
 }
 
 void Browser::UpdateCurrentActivity(const std::string& type,
                                     const base::DictionaryValue& user_info) {
-  [[ElectronApplication sharedApplication]
+  [[AtomApplication sharedApplication]
       updateCurrentActivity:base::SysUTF8ToNSString(type)
                withUserInfo:DictionaryValueToNSDictionary(user_info)];
 }
@@ -290,17 +289,16 @@ std::string Browser::GetExecutableFileProductName() const {
 }
 
 int Browser::DockBounce(BounceType type) {
-  return [[ElectronApplication sharedApplication]
+  return [[AtomApplication sharedApplication]
       requestUserAttention:static_cast<NSRequestUserAttentionType>(type)];
 }
 
 void Browser::DockCancelBounce(int request_id) {
-  [[ElectronApplication sharedApplication]
-      cancelUserAttentionRequest:request_id];
+  [[AtomApplication sharedApplication] cancelUserAttentionRequest:request_id];
 }
 
 void Browser::DockSetBadgeText(const std::string& label) {
-  NSDockTile* tile = [[ElectronApplication sharedApplication] dockTile];
+  NSDockTile* tile = [[AtomApplication sharedApplication] dockTile];
   [tile setBadgeLabel:base::SysUTF8ToNSString(label)];
 }
 
@@ -311,7 +309,7 @@ void Browser::DockDownloadFinished(const std::string& filePath) {
 }
 
 std::string Browser::DockGetBadgeText() {
-  NSDockTile* tile = [[ElectronApplication sharedApplication] dockTile];
+  NSDockTile* tile = [[AtomApplication sharedApplication] dockTile];
   return base::SysNSStringToUTF8([tile badgeLabel]);
 }
 
@@ -370,7 +368,7 @@ void Browser::DockSetMenu(ElectronMenuModel* model) {
 }
 
 void Browser::DockSetIcon(const gfx::Image& image) {
-  [[ElectronApplication sharedApplication]
+  [[AtomApplication sharedApplication]
       setApplicationIconImage:image.AsNSImage()];
 }
 
@@ -393,7 +391,7 @@ void Browser::ShowAboutPanel() {
     options = [NSDictionary dictionaryWithDictionary:mutable_options];
   }
 
-  [[ElectronApplication sharedApplication]
+  [[AtomApplication sharedApplication]
       orderFrontStandardAboutPanelWithOptions:options];
 }
 
@@ -411,7 +409,7 @@ void Browser::SetAboutPanelOptions(const base::DictionaryValue& options) {
 }
 
 void Browser::ShowEmojiPanel() {
-  [[ElectronApplication sharedApplication] orderFrontCharacterPalette:nil];
+  [[AtomApplication sharedApplication] orderFrontCharacterPalette:nil];
 }
 
 bool Browser::IsEmojiPanelSupported() {

--- a/shell/browser/electron_browser_main_parts_mac.mm
+++ b/shell/browser/electron_browser_main_parts_mac.mm
@@ -35,7 +35,7 @@ void ElectronBrowserMainParts::FreeAppDelegate() {
 }
 
 void ElectronBrowserMainParts::RegisterURLHandler() {
-  [[ElectronApplication sharedApplication] registerURLHandler];
+  [[AtomApplication sharedApplication] registerURLHandler];
 }
 
 // Replicates NSApplicationMain, but doesn't start a run loop.

--- a/shell/browser/mac/electron_application.h
+++ b/shell/browser/mac/electron_application.h
@@ -9,9 +9,9 @@
 #import <AVFoundation/AVFoundation.h>
 #import <LocalAuthentication/LocalAuthentication.h>
 
-@interface ElectronApplication : NSApplication <CrAppProtocol,
-                                                CrAppControlProtocol,
-                                                NSUserActivityDelegate> {
+@interface AtomApplication : NSApplication <CrAppProtocol,
+                                            CrAppControlProtocol,
+                                            NSUserActivityDelegate> {
  @private
   BOOL handlingSendEvent_;
   base::scoped_nsobject<NSUserActivity> currentActivity_;
@@ -20,7 +20,7 @@
   base::Callback<bool()> shouldShutdown_;
 }
 
-+ (ElectronApplication*)sharedApplication;
++ (AtomApplication*)sharedApplication;
 
 - (void)setShutdownHandler:(base::Callback<bool()>)handler;
 - (void)registerURLHandler;

--- a/shell/browser/mac/electron_application.mm
+++ b/shell/browser/mac/electron_application.mm
@@ -29,16 +29,16 @@ inline void dispatch_sync_main(dispatch_block_t block) {
 
 }  // namespace
 
-@interface ElectronApplication () <NativeEventProcessor> {
+@interface AtomApplication () <NativeEventProcessor> {
   base::ObserverList<content::NativeEventProcessorObserver>::Unchecked
       observers_;
 }
 @end
 
-@implementation ElectronApplication
+@implementation AtomApplication
 
-+ (ElectronApplication*)sharedApplication {
-  return (ElectronApplication*)[super sharedApplication];
++ (AtomApplication*)sharedApplication {
+  return (AtomApplication*)[super sharedApplication];
 }
 
 - (void)terminate:(id)sender {

--- a/shell/browser/resources/mac/Info.plist
+++ b/shell/browser/resources/mac/Info.plist
@@ -27,7 +27,7 @@
     <key>NSMainNibFile</key>
     <string>MainMenu</string>
     <key>NSPrincipalClass</key>
-    <string>ElectronApplication</string>
+    <string>AtomApplication</string>
     <key>NSSupportsAutomaticGraphicsSwitching</key>
     <true/>
     <key>NSHighResolutionCapable</key>

--- a/shell/common/resources/mac/MainMenu.xib
+++ b/shell/common/resources/mac/MainMenu.xib
@@ -24,7 +24,7 @@
 		</object>
 		<array class="NSMutableArray" key="IBDocument.RootObjects" id="1048">
 			<object class="NSCustomObject" id="1021">
-				<string key="NSClassName">ElectronApplication</string>
+				<string key="NSClassName">AtomApplication</string>
 			</object>
 			<object class="NSCustomObject" id="1014">
 				<string key="NSClassName">FirstResponder</string>


### PR DESCRIPTION
Backport of #22206.

Notes: Reverted a change to the name of the NSPrincipalClass, which could cause issues with protocol handlers on macOS (e.g. `my-app://`).