### PR TITLE
chore: wrap process restart flag in renderer process reuse check

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1504,17 +1504,23 @@ void WebContents::Stop() {
 }
 
 void WebContents::GoBack() {
-  electron::ElectronBrowserClient::SuppressRendererProcessRestartForOnce();
+  if (!ElectronBrowserClient::Get()->CanUseCustomSiteInstance()) {
+    electron::ElectronBrowserClient::SuppressRendererProcessRestartForOnce();
+  }
   web_contents()->GetController().GoBack();
 }
 
 void WebContents::GoForward() {
-  electron::ElectronBrowserClient::SuppressRendererProcessRestartForOnce();
+  if (!ElectronBrowserClient::Get()->CanUseCustomSiteInstance()) {
+    electron::ElectronBrowserClient::SuppressRendererProcessRestartForOnce();
+  }
   web_contents()->GetController().GoForward();
 }
 
 void WebContents::GoToOffset(int offset) {
-  electron::ElectronBrowserClient::SuppressRendererProcessRestartForOnce();
+  if (!ElectronBrowserClient::Get()->CanUseCustomSiteInstance()) {
+    electron::ElectronBrowserClient::SuppressRendererProcessRestartForOnce();
+  }
   web_contents()->GetController().GoToOffset(offset);
 }
 


### PR DESCRIPTION
This is in preparation for the removal of our process hacks.  Make it clearer what logic is required / runs under the two states of this flag.

Refs: #18397

Notes: no-notes