### PR TITLE
chore: do not override history methods when rendererprocessreuse is enabled

### DIFF
--- a/lib/content_script/init.js
+++ b/lib/content_script/init.js
@@ -24,9 +24,9 @@ Object.setPrototypeOf(process, EventEmitter.prototype)
 const isolatedWorldArgs = v8Util.getHiddenValue(isolatedWorld, 'isolated-world-args')
 
 if (isolatedWorldArgs) {
-  const { guestInstanceId, isHiddenPage, openerId, usesNativeWindowOpen } = isolatedWorldArgs
+  const { guestInstanceId, isHiddenPage, openerId, usesNativeWindowOpen, rendererProcessReuseEnabled } = isolatedWorldArgs
   const { windowSetup } = require('@electron/internal/renderer/window-setup')
-  windowSetup(guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
+  windowSetup(guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen, rendererProcessReuseEnabled)
 }
 
 const extensionId = v8Util.getHiddenValue(isolatedWorld, `extension-${worldId}`)

--- a/lib/isolated_renderer/init.js
+++ b/lib/isolated_renderer/init.js
@@ -21,7 +21,7 @@ if (webViewImpl) {
 const isolatedWorldArgs = v8Util.getHiddenValue(isolatedWorld, 'isolated-world-args')
 
 if (isolatedWorldArgs) {
-  const { guestInstanceId, isHiddenPage, openerId, usesNativeWindowOpen } = isolatedWorldArgs
+  const { guestInstanceId, isHiddenPage, openerId, usesNativeWindowOpen, rendererProcessReuseEnabled } = isolatedWorldArgs
   const { windowSetup } = require('@electron/internal/renderer/window-setup')
-  windowSetup(guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
+  windowSetup(guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen, rendererProcessReuseEnabled)
 }

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -77,6 +77,7 @@ const nodeIntegration = hasSwitch('node-integration')
 const webviewTag = hasSwitch('webview-tag')
 const isHiddenPage = hasSwitch('hidden-page')
 const usesNativeWindowOpen = hasSwitch('native-window-open')
+const rendererProcessReuseEnabled = hasSwitch('disable-electron-site-instance-overrides')
 
 const preloadScript = parseOption('preload', null)
 const preloadScripts = parseOption('preload-scripts', [], value => value.split(path.delimiter)) as string[]
@@ -85,7 +86,7 @@ const guestInstanceId = parseOption('guest-instance-id', null, value => parseInt
 const openerId = parseOption('opener-id', null, value => parseInt(value))
 
 // The arguments to be passed to isolated world.
-const isolatedWorldArgs = { ipcRendererInternal, guestInstanceId, isHiddenPage, openerId, usesNativeWindowOpen }
+const isolatedWorldArgs = { ipcRendererInternal, guestInstanceId, isHiddenPage, openerId, usesNativeWindowOpen, rendererProcessReuseEnabled }
 
 // The webContents preload script is loaded after the session preload scripts.
 if (preloadScript) {
@@ -110,7 +111,7 @@ switch (window.location.protocol) {
   default: {
     // Override default web functions.
     const { windowSetup } = require('@electron/internal/renderer/window-setup')
-    windowSetup(guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
+    windowSetup(guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen, rendererProcessReuseEnabled)
 
     // Inject content scripts.
     if (!process.electronBinding('features').isExtensionsEnabled()) {

--- a/lib/renderer/window-setup.ts
+++ b/lib/renderer/window-setup.ts
@@ -175,7 +175,7 @@ class BrowserWindowProxy {
 }
 
 export const windowSetup = (
-  guestInstanceId: number, openerId: number, isHiddenPage: boolean, usesNativeWindowOpen: boolean
+  guestInstanceId: number, openerId: number, isHiddenPage: boolean, usesNativeWindowOpen: boolean, rendererProcessReuseEnabled: boolean
 ) => {
   if (!process.sandboxed && guestInstanceId == null) {
     // Override default window.close.
@@ -229,7 +229,7 @@ export const windowSetup = (
     })
   }
 
-  if (!process.sandboxed) {
+  if (!process.sandboxed && !rendererProcessReuseEnabled) {
     window.history.back = function () {
       ipcRendererInternal.send('ELECTRON_NAVIGATION_CONTROLLER_GO_BACK')
     }

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -116,10 +116,11 @@ const { hasSwitch } = process.electronBinding('command_line')
 
 const contextIsolation = hasSwitch('context-isolation')
 const isHiddenPage = hasSwitch('hidden-page')
+const rendererProcessReuseEnabled = hasSwitch('disable-electron-site-instance-overrides')
 const usesNativeWindowOpen = true
 
 // The arguments to be passed to isolated world.
-const isolatedWorldArgs = { ipcRendererInternal, guestInstanceId, isHiddenPage, openerId, usesNativeWindowOpen }
+const isolatedWorldArgs = { ipcRendererInternal, guestInstanceId, isHiddenPage, openerId, usesNativeWindowOpen, rendererProcessReuseEnabled }
 
 switch (window.location.protocol) {
   case 'devtools:': {
@@ -140,7 +141,7 @@ switch (window.location.protocol) {
   default: {
     // Override default web functions.
     const { windowSetup } = require('@electron/internal/renderer/window-setup')
-    windowSetup(guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen)
+    windowSetup(guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen, rendererProcessReuseEnabled)
 
     // Inject content scripts.
     if (!process.electronBinding('features').isExtensionsEnabled()) {


### PR DESCRIPTION
Stop overriding `window.history.X` methods when rendererprocessreuse is enabled as we no longer need to hack around process restarts

Refs #18397

Notes: no-notes