### PR TITLE
fix: pass safeDialogs preference to dialog properly

### DIFF
--- a/shell/browser/electron_javascript_dialog_manager.cc
+++ b/shell/browser/electron_javascript_dialog_manager.cc
@@ -93,6 +93,7 @@ void ElectronJavaScriptDialogManager::RunJavaScriptDialog(
 
   electron::MessageBoxSettings settings;
   settings.parent_window = window;
+  settings.checkbox_label = checkbox;
   settings.buttons = buttons;
   settings.default_id = default_id;
   settings.cancel_id = cancel_id;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/22350.

The `safeDialog` value was not being properly set in the `MessageBoxSettings` struct. This fixes that.

cc @zcbenz @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue with `safeDialog` preferences not being passed properly.
