### PR TITLE
docs: update MD2 link in cryptographic algorithms list

### DIFF
--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -251,7 +251,7 @@ Electron uses following cryptographic algorithms:
 * DSA - [ANSI X9.30](https://webstore.ansi.org/RecordDetail.aspx?sku=ANSI+X9.30-1%3A1997)
 * EC - [SEC 1](http://www.secg.org/sec1-v2.pdf)
 * IDEA - "On the Design and Security of Block Ciphers" book by X. Lai
-* MD2 - [RFC 1319](https://tools.ietf.org/html/rfc1319)
+* MD2 - [RFC 6149](https://tools.ietf.org/html/rfc6149)
 * MD4 - [RFC 6150](https://tools.ietf.org/html/rfc6150)
 * MD5 - [RFC 1321](https://tools.ietf.org/html/rfc1321)
 * MDC2 - [ISO/IEC 10118-2](https://wiki.openssl.org/index.php/Manual:Mdc2(3))


### PR DESCRIPTION
Replace link to MD2 RFC ([RFC 1319](https://tools.ietf.org/html/rfc1319)) with link to [RFC 6149](https://tools.ietf.org/html/rfc6149), which obsoletes and retires the algorithm.

(In addition to providing the most current information on the algorithm, this creates parity with the following entry, MD4, which links to its own obsoleting RFC ([RFC 6150](https://tools.ietf.org/html/rfc6150)), rather than to the original (and now-historical) protocol-defining RFC.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [X] relevant documentation is changed or added
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: no-notes <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
