### PR TITLE
feat: add session.removeWordFromSpellCheckerDictionary API 

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -504,6 +504,14 @@ Returns `Boolean` - Whether the word was successfully written to the custom dict
 
 **Note:** On macOS and Windows 10 this word will be written to the OS custom dictionary as well
 
+#### `ses.removeWordFromSpellCheckerDictionary(word)`
+
+* `word` String - The word you want to remove from the dictionary
+
+Returns `Boolean` - Whether the word was successfully removed from the custom dictionary.
+
+**Note:** On macOS and Windows 10 this word will be removed from the OS custom dictionary as well
+
 #### `ses.loadExtension(path)`
 
 * `path` String - Path to a directory containing an unpacked Chrome extension

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -854,17 +854,18 @@ bool Session::AddWordToSpellCheckerDictionary(const std::string& word) {
 }
 
 bool Session::RemoveWordFromSpellCheckerDictionary(const std::string& word) {
-#if BUILDFLAG(USE_BROWSER_SPELLCHECKER)
-  if (spellcheck::UseBrowserSpellChecker()) {
-    spellcheck_platform::RemoveWord(base::UTF8ToUTF16(word));
-  }
-#endif
-  SpellcheckService* spellcheck =
+  SpellcheckService* service =
       SpellcheckServiceFactory::GetForContext(browser_context_.get());
-  if (!spellcheck)
+  if (!service)
     return false;
 
-  return spellcheck->GetCustomDictionary()->RemoveWord(word);
+#if BUILDFLAG(USE_BROWSER_SPELLCHECKER)
+  if (spellcheck::UseBrowserSpellChecker()) {
+    spellcheck_platform::RemoveWord(service->platform_spell_checker(),
+                                    base::UTF8ToUTF16(word));
+  }
+#endif
+  return service->GetCustomDictionary()->RemoveWord(word);
 }
 #endif
 

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -852,6 +852,20 @@ bool Session::AddWordToSpellCheckerDictionary(const std::string& word) {
 
   return spellcheck->GetCustomDictionary()->AddWord(word);
 }
+
+bool Session::RemoveWordFromSpellCheckerDictionary(const std::string& word) {
+#if BUILDFLAG(USE_BROWSER_SPELLCHECKER)
+  if (spellcheck::UseBrowserSpellChecker()) {
+    spellcheck_platform::RemoveWord(base::UTF8ToUTF16(word));
+  }
+#endif
+  SpellcheckService* spellcheck =
+      SpellcheckServiceFactory::GetForContext(browser_context_.get());
+  if (!spellcheck)
+    return false;
+
+  return spellcheck->GetCustomDictionary()->RemoveWord(word);
+}
 #endif
 
 // static
@@ -942,6 +956,8 @@ void Session::BuildPrototype(v8::Isolate* isolate,
                  &Session::ListWordsInSpellCheckerDictionary)
       .SetMethod("addWordToSpellCheckerDictionary",
                  &Session::AddWordToSpellCheckerDictionary)
+      .SetMethod("removeWordFromSpellCheckerDictionary",
+                 &Session::RemoveWordFromSpellCheckerDictionary)
 #endif
       .SetMethod("preconnect", &Session::Preconnect)
       .SetProperty("cookies", &Session::Cookies)

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -98,6 +98,7 @@ class Session : public gin_helper::TrackableObject<Session>,
                                 const std::vector<std::string>& languages);
   v8::Local<v8::Promise> ListWordsInSpellCheckerDictionary();
   bool AddWordToSpellCheckerDictionary(const std::string& word);
+  bool RemoveWordFromSpellCheckerDictionary(const std::string& word);
 #endif
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)


### PR DESCRIPTION
Backport of #22039

See that PR for details.

Notes: Added session.removeWordFromSpellCheckerDictionary API to remove custom words in the dictionary.