### PR TITLE
docs: improve documentation on spellchecker download URL

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -483,6 +483,10 @@ behavior you can use this API to point the dictionary downloader at your own hos
 dictionaries.  We publish a `hunspell_dictionaries.zip` file with each release which contains the files you need
 to host here.
 
+If the files present in `hunspell_dictionaries.zip` are available at `https://example.com/dictionaries/language-code.bdic`
+then you should call this api with `ses.setSpellCheckerDictionaryDownloadURL('https://example.com/dictionaries/')`.  Please
+note the trailing slash.  The URL to the dictionaries is formed as `${baseURL}${filename}`.
+
 **Note:** On macOS the OS spellchecker is used and therefore we do not download any dictionary files.  This API is a no-op on macOS.
 
 #### `ses.listWordsInSpellCheckerDictionary()`

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -485,7 +485,7 @@ to host here.
 
 If the files present in `hunspell_dictionaries.zip` are available at `https://example.com/dictionaries/language-code.bdic`
 then you should call this api with `ses.setSpellCheckerDictionaryDownloadURL('https://example.com/dictionaries/')`.  Please
-note the trailing slash.  The URL to the dictionaries is formed as `${baseURL}${filename}`.
+note the trailing slash.  The URL to the dictionaries is formed as `${url}${filename}`.
 
 **Note:** On macOS the OS spellchecker is used and therefore we do not download any dictionary files.  This API is a no-op on macOS.
 


### PR DESCRIPTION
Had to explain this in an issue, so it makes sense that the documentation is more clear about what this URL is and how it is used.

Notes: no-notes