### PR TITLE
feat: add disableDialogs option to WebPreferences

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -369,6 +369,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       consecutive dialog protection is triggered. If not defined the default
       message would be used, note that currently the default message is in
       English and not localized.
+    * `disableDialogs` Boolean (optional) - Whether to disable dialogs
+      completely. Overrides `safeDialogs`. Default is `false`.
     * `navigateOnDragDrop` Boolean (optional) - Whether dragging and dropping a
       file or link onto the page causes a navigation. Default is `false`.
     * `autoplayPolicy` String (optional) - Autoplay policy to apply to

--- a/shell/browser/electron_javascript_dialog_manager.cc
+++ b/shell/browser/electron_javascript_dialog_manager.cc
@@ -61,6 +61,12 @@ void ElectronJavaScriptDialogManager::RunJavaScriptDialog(
     return;
   }
 
+  auto* web_preferences = WebContentsPreferences::From(web_contents);
+
+  if (web_preferences && web_preferences->IsEnabled("disableDialogs")) {
+    return std::move(callback).Run(false, base::string16());
+  }
+
   // No default button
   int default_id = -1;
   int cancel_id = 0;
@@ -75,7 +81,6 @@ void ElectronJavaScriptDialogManager::RunJavaScriptDialog(
 
   origin_counts_[origin]++;
 
-  auto* web_preferences = WebContentsPreferences::From(web_contents);
   std::string checkbox;
   if (origin_counts_[origin] > 1 && web_preferences &&
       web_preferences->IsEnabled("safeDialogs") &&


### PR DESCRIPTION
#### Description of Change

Add `disableDialogs` option to `WebPreferences`.

Allows to disable dialogs completely in a similar way of how `safeDialogs` option can be used.
Overrides `safeDialogs` option. 

cc @codebytere @zcbenz @ckerr (from #22353) 

* Not sure how to add tests for this. This was basically cloned from `safeDialogs`, and that one doesn't have tests.
* `npm test` fails on my machine on master and on this branch, with the same error, which looks unrelated:
   ```
   ok 357 BrowserWindow module document.visibilityState/hidden visibilityState changes when window is hidden
   [388555:0226/143632.389959:FATAL:x11_window.cc(1254)] Check failed: !configure_counter_value_. 
   ```

Example:
```js
const { BrowserWindow, app } = require('electron')
app.on('ready', () => {
  const window = new BrowserWindow({
    webPreferences: {
      disableDialogs: true,
      //safeDialogs: true,
    }
  })
  window.webContents.loadURL('about:blank')
  window.webContents.on('did-finish-load', () => {
    window.webContents.executeJavaScript(`
      document.body.innerText = window.navigator.userAgent // (not required)
      alert(0)
      setTimeout(() => { alert(1) }, 100) // timeout for UA to be shown
    `)
  })
  window.show()
})
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `disableDialogs` option to WebPreferences.