### PR TITLE
fix: Add ContentsView to AXChildren

### DIFF
--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -121,7 +121,18 @@ bool ScopedDisableResize::disable_resize_ = false;
                           [NSButtonCell class], @"RenderWidgetHostViewCocoa"];
 
   NSArray* children = [super accessibilityAttributeValue:attribute];
-  return [children filteredArrayUsingPredicate:predicate];
+  NSMutableArray* mutableChildren = [[children mutableCopy] autorelease];
+  [mutableChildren filterUsingPredicate:predicate];
+
+  // We need to add the web contents: Without us doing so, VoiceOver
+  // users will be able to navigate up the a11y tree, but not back down.
+  // The content view contains the "web contents", which VoiceOver
+  // immediately understands.
+  NSView* contentView =
+      [shell_->GetNativeWindow().GetNativeNSWindow() contentView];
+  [mutableChildren addObject:contentView];
+
+  return mutableChildren;
 }
 
 - (NSString*)accessibilityTitle {


### PR DESCRIPTION
#### Description of Change

The native window on macOS has only three elements in its `AXChildren`: The close, maximize, and minimize button. In practice, that means that a VoiceOver user won't be able to navigate from the window into the web contents, therefore unable to interact with anything that's actually happening in the window.

In this PR, I'm manually editing the `AXChildren` array and adding the `ContentsView` back in. I have to admit that I have little experience with accessibility work in Cocoa, but I believe that it fixes the issue. I _also_ have no idea how we could write a test for this, but I'm open to ideas!

Closes #17207

#### Before

<img width="450" alt="Screen Shot 2020-02-26 at 11 41 57 AM" src="https://user-images.githubusercontent.com/1426799/75381117-0a9e4900-588d-11ea-8f91-6e2d197101a5.png">


#### After

<img width="420" alt="Screen Shot 2020-02-26 at 11 40 36 AM" src="https://user-images.githubusercontent.com/1426799/75381027-dfb3f500-588c-11ea-860a-247a566c9e78.png">


#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: macOS VoiceOver is now able to find its way back into web contents after it navigated "out" of an application.