### PR TITLE
feat: set app.enableRendererProcessReuse to true by default (#22336)

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -289,7 +289,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       between the web pages even when you specified different values for them,
       including but not limited to `preload`, `sandbox` and `nodeIntegration`.
       So it is suggested to use exact same `webPreferences` for web pages with
-      the same `affinity`. _This property is experimental_
+      the same `affinity`. _Deprecated_
     * `zoomFactor` Number (optional) - The default zoom factor of the page, `3.0` represents
       `300%`. Default is `1.0`.
     * `javascript` Boolean (optional) - Enables JavaScript support. Default is `true`.

--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -203,13 +203,17 @@ async function runMainProcessElectronTests () {
     exe = 'python'
   }
 
-  const { status } = childProcess.spawnSync(exe, runnerArgs, {
+  const { status, signal } = childProcess.spawnSync(exe, runnerArgs, {
     cwd: path.resolve(__dirname, '../..'),
     stdio: 'inherit'
   })
   if (status !== 0) {
-    const textStatus = process.platform === 'win32' ? `0x${status.toString(16)}` : status.toString()
-    console.log(`${fail} Electron tests failed with code ${textStatus}.`)
+    if (status) {
+      const textStatus = process.platform === 'win32' ? `0x${status.toString(16)}` : status.toString()
+      console.log(`${fail} Electron tests failed with code ${textStatus}.`)
+    } else {
+      console.log(`${fail} Electron tests failed with kill signal ${signal}.`)
+    }
     process.exit(1)
   }
   console.log(`${pass} Electron main process tests passed.`)

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -309,7 +309,7 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
 
   std::string user_agent_override_ = "";
 
-  bool disable_process_restart_tricks_ = false;
+  bool disable_process_restart_tricks_ = true;
 
   // Simple shared ID generator, used by ProxyingURLLoaderFactory and
   // ProxyingWebSocket classes.

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -1418,8 +1418,8 @@ describe('default behavior', () => {
   })
 
   describe('app.allowRendererProcessReuse', () => {
-    it('should default to false', () => {
-      expect(app.allowRendererProcessReuse).to.equal(false)
+    it('should default to true', () => {
+      expect(app.allowRendererProcessReuse).to.equal(true)
     })
 
     it('should cause renderer processes to get new PIDs when false', async () => {

--- a/spec-main/api-browser-window-affinity-spec.ts
+++ b/spec-main/api-browser-window-affinity-spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import * as path from 'path'
 
-import { ipcMain, BrowserWindow, WebPreferences } from 'electron'
+import { ipcMain, BrowserWindow, WebPreferences, app } from 'electron'
 import { closeWindow } from './window-helpers'
 
 describe('BrowserWindow with affinity module', () => {
@@ -9,6 +9,14 @@ describe('BrowserWindow with affinity module', () => {
   const myAffinityName = 'myAffinity'
   const myAffinityNameUpper = 'MYAFFINITY'
   const anotherAffinityName = 'anotherAffinity'
+
+  before(() => {
+    app.allowRendererProcessReuse = false
+  })
+
+  after(() => {
+    app.allowRendererProcessReuse = true
+  })
 
   async function createWindowWithWebPrefs (webPrefs: WebPreferences) {
     const w = new BrowserWindow({

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -2372,18 +2372,6 @@ describe('BrowserWindow module', () => {
         const webPreferences = (childWebContents as any).getLastWebPreferences()
         expect(webPreferences.foo).to.equal('bar')
       })
-      it('should have nodeIntegration disabled in child windows', async () => {
-        const w = new BrowserWindow({
-          show: false,
-          webPreferences: {
-            nodeIntegration: true,
-            nativeWindowOpen: true
-          }
-        })
-        w.loadFile(path.join(fixtures, 'api', 'native-window-open-argv.html'))
-        const [, typeofProcess] = await emittedOnce(ipcMain, 'answer')
-        expect(typeofProcess).to.eql('undefined')
-      })
 
       describe('window.location', () => {
         const protocols = [

--- a/spec-main/api-remote-spec.ts
+++ b/spec-main/api-remote-spec.ts
@@ -243,9 +243,17 @@ ifdescribe(features.isRemoteModuleEnabled())('remote module', () => {
       expect(w.webContents.listenerCount('remote-handler')).to.equal(2)
       let warnMessage: string | null = null
       const originalWarn = console.warn
+      let warned: Function
+      const warnPromise = new Promise(resolve => {
+        warned = resolve
+      })
       try {
-        console.warn = (message: string) => { warnMessage = message }
+        console.warn = (message: string) => {
+          warnMessage = message
+          warned()
+        }
         w.webContents.emit('remote-handler', { sender: w.webContents })
+        await warnPromise
       } finally {
         console.warn = originalWarn
       }


### PR DESCRIPTION
Backport of #22336

See that PR for details.

BREAKING CHANGE

Notes: Changed the default value of `app.allowRendererProcessReuse` to `true`, this will prevent loading of non-context-aware native modules in renderer processes.  See #18397 for more information on this change.