### PR TITLE
test: throw if no valid outDir

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -32,6 +32,12 @@ by coding style rules. `npm run lint-py` will check all Python, using
 
 ## Unit Tests
 
+If you are not using [build-tools](https://github.com/electron/build-tools),
+ensure that that name you have configured for your
+local build of Electron is one of `Testing`, `Release`, `Default`, `Debug`, or
+you have set `process.env.ELECTRON_OUT_DIR`. Without these set, Electron will fail
+to perform some pre-testing steps.
+
 To run all unit tests, run `npm run test`. The unit tests are an Electron
 app (surprise!) that can be found in the `spec` folder. Note that it has
 its own `package.json` and that its dependencies are therefore not defined

--- a/script/lib/utils.js
+++ b/script/lib/utils.js
@@ -27,6 +27,7 @@ function getElectronExec () {
 
 function getOutDir (options = {}) {
   const shouldLog = options.shouldLog || false
+  const presetDirs = ['Testing', 'Release', 'Default', 'Debug']
 
   if (options.outDir || process.env.ELECTRON_OUT_DIR) {
     const outDir = options.outDir || process.env.ELECTRON_OUT_DIR
@@ -41,7 +42,7 @@ function getOutDir (options = {}) {
     // Throw error if user passed/set nonexistent directory.
     throw new Error(`${outDir} directory not configured on your machine.`)
   } else {
-    for (const buildType of ['Testing', 'Release', 'Default', 'Debug']) {
+    for (const buildType of presetDirs) {
       const outPath = path.resolve(SRC_DIR, 'out', buildType)
       if (fs.existsSync(outPath)) {
         if (shouldLog) console.log(`OUT_DIR is: ${buildType}`)
@@ -49,6 +50,10 @@ function getOutDir (options = {}) {
       }
     }
   }
+
+  // If we got here, it means process.env.ELECTRON_OUT_DIR was not
+  // set and none of the preset options could be found in /out, so throw
+  throw new Error(`No valid out directory found; use one of ${presetDirs.join(',')} or set process.env.ELECTRON_OUT_DIR`)
 }
 
 function getAbsoluteElectronExec () {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/22400.

`build-tools` ensures that `process.env.ELECTRON_OUT_DIR` is set, but for those who opt out of it, `getOutDir` can return `undefined` and error in the install step. This ensures a descriptive error is thrown and that a note is added to the testing doc.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
