### PR TITLE
fix: backport fix for icu crash

### DIFF
--- a/patches/icu/.patches
+++ b/patches/icu/.patches
@@ -1,2 +1,3 @@
 date_time_generator_default_locale.patch
 posix_util_invalid_locale.patch
+cherrypick_fix_for_segv_maperr.patch

--- a/patches/icu/cherrypick_fix_for_segv_maperr.patch
+++ b/patches/icu/cherrypick_fix_for_segv_maperr.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jeremy Apthorp <nornagon@nornagon.net>
+Date: Thu, 27 Feb 2020 10:24:00 -0800
+Subject: Cherrypick fix for SEGV_MAPERR
+
+Avoid int32_t overflow in length addition
+
+See
+https://bugs.chromium.org/p/chromium/issues/detail?id=1044570
+https://unicode-org.atlassian.net/browse/ICU-20958
+https://github.com/unicode-org/icu/pull/971
+
+diff --git a/source/common/unistr.cpp b/source/common/unistr.cpp
+index 8f065158654e0c8ad69a921df627a9cef1019324..61f471da40e01251ad02092ead72c9e1bc53e541 100644
+--- a/source/common/unistr.cpp
++++ b/source/common/unistr.cpp
+@@ -1563,7 +1563,11 @@ UnicodeString::doAppend(const UChar *srcChars, int32_t srcStart, int32_t srcLeng
+   }
+ 
+   int32_t oldLength = length();
+-  int32_t newLength = oldLength + srcLength;
++  int32_t newLength;
++  if (uprv_add32_overflow(oldLength, srcLength, &newLength)) {
++    setToBogus();
++    return *this;
++  }
+ 
+   // Check for append onto ourself
+   const UChar* oldArray = getArrayStart();

--- a/patches/icu/date_time_generator_default_locale.patch
+++ b/patches/icu/date_time_generator_default_locale.patch
@@ -1,7 +1,7 @@
-From 3da02cadcd589bc1b660179860e2125b4277ceca Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jeff Genovy <29107334+jefgen@users.noreply.github.com>
 Date: Wed, 24 Apr 2019 14:02:06 -0700
-Subject: [PATCH] ICU-20558 Fix regression in DateTimePatternGenerator
+Subject: ICU-20558 Fix regression in DateTimePatternGenerator
 
 This fixes a regression introduced by commit
 b12a927c9365bb38831afbf76fdd0999f8f33deb for issue ICU-13778.

--- a/patches/icu/posix_util_invalid_locale.patch
+++ b/patches/icu/posix_util_invalid_locale.patch
@@ -1,7 +1,7 @@
-From 974193d9ea7ea14544538c85fdb04dd5fd6ac216 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: "Steven R. Loomis" <srloomis@us.ibm.com>
 Date: Thu, 25 Apr 2019 10:40:28 -0700
-Subject: [PATCH] ICU-20575 fix broken default locale mapping for C.UTF-8
+Subject: ICU-20575 fix broken default locale mapping for C.UTF-8
 
 Regression was in 1afef30549d93c17bb966c6803d5d943cf055925
 PR #418 [ICU-20187]
@@ -18,7 +18,7 @@ PR #418 [ICU-20187]
   (incorrectly doubled __BB)
 
 diff --git a/source/common/putil.cpp b/source/common/putil.cpp
-index 532a0903cdd..289a8aaa141 100644
+index 532a0903cdd6ef74e3a1637ee24559ce961eaff7..289a8aaa14108877cd0a8c891d05717a372c62be 100644
 --- a/source/common/putil.cpp
 +++ b/source/common/putil.cpp
 @@ -1560,6 +1560,10 @@ static const char *uprv_getPOSIXIDForCategory(int category)


### PR DESCRIPTION
#### Description of Change
This backports a fix from Chromium for a crash in ICU. See https://bugs.chromium.org/p/chromium/issues/detail?id=1044570

#### Release Notes

Notes: Fixed an integer overflow crash in ICU (https://crbug.com/1044570).