### PR TITLE
fix: backport fix for icu crash

### DIFF
--- a/patches/common/config.json
+++ b/patches/common/config.json
@@ -7,5 +7,7 @@
 
   "src/electron/patches/common/v8":  "src/v8",
 
+  "src/electron/patches/common/icu":  "src/third_party/icu",
+
   "src/electron/patches/node": "src/third_party/electron_node"
 }

--- a/patches/common/icu/.patches
+++ b/patches/common/icu/.patches
@@ -1,0 +1,1 @@
+cherrypick_fix_for_segv_maperr.patch

--- a/patches/common/icu/cherrypick_fix_for_segv_maperr.patch
+++ b/patches/common/icu/cherrypick_fix_for_segv_maperr.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jeremy Apthorp <nornagon@nornagon.net>
+Date: Thu, 27 Feb 2020 10:44:02 -0800
+Subject: Cherrypick fix for SEGV_MAPERR
+
+Avoid int32_t overflow in length addition
+
+See
+https://bugs.chromium.org/p/chromium/issues/detail?id=1044570
+https://unicode-org.atlassian.net/browse/ICU-20958
+https://github.com/unicode-org/icu/pull/971
+
+diff --git a/source/common/unistr.cpp b/source/common/unistr.cpp
+index 8f065158654e0c8ad69a921df627a9cef1019324..61f471da40e01251ad02092ead72c9e1bc53e541 100644
+--- a/source/common/unistr.cpp
++++ b/source/common/unistr.cpp
+@@ -1563,7 +1563,11 @@ UnicodeString::doAppend(const UChar *srcChars, int32_t srcStart, int32_t srcLeng
+   }
+ 
+   int32_t oldLength = length();
+-  int32_t newLength = oldLength + srcLength;
++  int32_t newLength;
++  if (uprv_add32_overflow(oldLength, srcLength, &newLength)) {
++    setToBogus();
++    return *this;
++  }
+ 
+   // Check for append onto ourself
+   const UChar* oldArray = getArrayStart();


### PR DESCRIPTION
#### Description of Change
This backports a fix from Chromium for a crash in ICU. See https://bugs.chromium.org/p/chromium/issues/detail?id=1044570

#### Release Notes

Notes: Fixed an integer overflow crash in ICU (https://crbug.com/1044570).