### PR TITLE
fix: backport v8 patch for type inference issue

### DIFF
--- a/patches/common/v8/.patches
+++ b/patches/common/v8/.patches
@@ -8,3 +8,4 @@ workaround_an_undefined_symbol_error.patch
 do_not_export_private_v8_symbols_on_windows.patch
 fix_crash_under_lb_lu_locale.patch
 objects_fix_memory_leak_in_prototypeusers_add.patch
+fix_bug_in_receiver_maps_inference.patch

--- a/patches/common/v8/fix_bug_in_receiver_maps_inference.patch
+++ b/patches/common/v8/fix_bug_in_receiver_maps_inference.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Samuel Attard <sattard@slack-corp.com>
+Date: Thu, 27 Feb 2020 11:47:31 -0800
+Subject: Fix bug in receiver maps inference
+
+Refs: https://chromium-review.googlesource.com/c/v8/v8/+/2062404
+
+diff --git a/src/compiler/node-properties.cc b/src/compiler/node-properties.cc
+index f43a348bb2d5b803270e42f64a3c790c52a3581b..ab4ced69ab60d6078aeb27c3d8b97e87400687ce 100644
+--- a/src/compiler/node-properties.cc
++++ b/src/compiler/node-properties.cc
+@@ -386,6 +386,7 @@ NodeProperties::InferReceiverMapsResult NodeProperties::InferReceiverMapsUnsafe(
+           // We reached the allocation of the {receiver}.
+           return kNoReceiverMaps;
+         }
++        result = kUnreliableReceiverMaps;  // JSCreate can have side-effect.
+         break;
+       }
+       case IrOpcode::kJSCreatePromise: {


### PR DESCRIPTION
Backports https://chromium-review.googlesource.com/c/v8/v8/+/2062404

Notes: Backported V8 patch to fix bug in type inference