### PR TITLE
fix: dictionaries download path should be in userdata

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -880,6 +880,9 @@ void App::SetPath(gin_helper::ErrorThrower thrower,
     if (key == DIR_USER_DATA) {
       succeed |= base::PathService::OverrideAndCreateIfNeeded(
           chrome::DIR_USER_DATA, path, true, false);
+      succeed |= base::PathService::Override(
+          chrome::DIR_APP_DICTIONARIES,
+          path.Append(base::FilePath::FromUTF8Unsafe("Dictionaries")));
     }
   }
   if (!succeed)

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -119,6 +119,9 @@ ElectronBrowserContext::ElectronBrowserContext(const std::string& partition,
     path_ = path_.Append(base::FilePath::FromUTF8Unsafe(GetApplicationName()));
     base::PathService::Override(DIR_USER_DATA, path_);
     base::PathService::Override(chrome::DIR_USER_DATA, path_);
+    base::PathService::Override(
+        chrome::DIR_APP_DICTIONARIES,
+        path_.Append(base::FilePath::FromUTF8Unsafe("Dictionaries")));
   }
 
   if (!in_memory && !partition.empty())


### PR DESCRIPTION
There is a default for `DIR_APP_DICTIONARIES` which means it isn't recalculated based on `DIR_USER_DATA`.  This sets the value for it in the appropriate places so that dictionary files are downloaded to the right folders

Notes: Fixed issue where dictionary files for the spellchecker would be downloaded to the app install directory instead of the user data directory