### PR TITLE
feat(extensions): add chrome.tabs.connect API

### DIFF
--- a/shell/common/extensions/api/tabs.json
+++ b/shell/common/extensions/api/tabs.json
@@ -139,6 +139,37 @@
         ]
       },
       {
+        "name": "connect",
+        "nocompile": true,
+        "type": "function",
+        "description": "Connects to the content script(s) in the specified tab. The $(ref:runtime.onConnect) event is fired in each content script running in the specified tab for the current extension. For more details, see <a href='messaging'>Content Script Messaging</a>.",
+        "parameters": [
+          {
+            "type": "integer",
+            "name": "tabId",
+            "minimum": 0
+          },
+          {
+            "type": "object",
+            "name": "connectInfo",
+            "properties": {
+              "name": { "type": "string", "optional": true, "description": "Is passed into onConnect for content scripts that are listening for the connection event." },
+              "frameId": {
+                "type": "integer",
+                "optional": true,
+                "minimum": 0,
+                "description": "Open a port to a specific <a href='webNavigation#frame_ids'>frame</a> identified by <code>frameId</code> instead of all frames in the tab."
+              }
+            },
+            "optional": true
+          }
+        ],
+        "returns": {
+          "$ref": "runtime.Port",
+          "description": "A port that can be used to communicate with the content scripts running in the specified tab. The port's $(ref:runtime.Port) event is fired if the tab closes or does not exist. "
+        }
+      },
+      {
         "name": "executeScript",
         "type": "function",
         "parameters": [

--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -160,6 +160,21 @@ ifdescribe(process.electronBinding('features').isExtensionsEnabled())('chrome ex
       expect(response).to.equal(3)
     })
 
+    it('connect', async () => {
+      const customSession = session.fromPartition(`persist:${require('uuid').v4()}`)
+      await customSession.loadExtension(path.join(fixtures, 'extensions', 'chrome-api'))
+      const w = new BrowserWindow({ show: false, webPreferences: { session: customSession, nodeIntegration: true } })
+      await w.loadURL(url)
+
+      const portName = require('uuid').v4()
+      const message = { method: 'connectTab', args: [portName] }
+      w.webContents.executeJavaScript(`window.postMessage('${JSON.stringify(message)}', '*')`)
+
+      const [,, responseString] = await emittedOnce(w.webContents, 'console-message')
+
+      expect(responseString).to.equal(portName)
+    })
+
     it('sendMessage receives the response', async function () {
       const customSession = session.fromPartition(`persist:${require('uuid').v4()}`)
       await customSession.loadExtension(path.join(fixtures, 'extensions', 'chrome-api'))

--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -171,8 +171,9 @@ ifdescribe(process.electronBinding('features').isExtensionsEnabled())('chrome ex
       w.webContents.executeJavaScript(`window.postMessage('${JSON.stringify(message)}', '*')`)
 
       const [,, responseString] = await emittedOnce(w.webContents, 'console-message')
-
-      expect(responseString).to.equal(portName)
+      const response = responseString.split(',')
+      expect(response[0]).to.equal(portName)
+      expect(response[1]).to.equal('howdy')
     })
 
     it('sendMessage receives the response', async function () {

--- a/spec-main/fixtures/extensions/chrome-api/background.js
+++ b/spec-main/fixtures/extensions/chrome-api/background.js
@@ -16,6 +16,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       chrome.tabs.executeScript(tabId, { code }, ([result]) => sendResponse(result))
       break
     }
+
+    case 'connectTab': {
+      const [name] = args
+      chrome.tabs.connect(tabId, { name })
+      break
+    }
   }
   // Respond asynchronously
   return true

--- a/spec-main/fixtures/extensions/chrome-api/background.js
+++ b/spec-main/fixtures/extensions/chrome-api/background.js
@@ -19,7 +19,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     case 'connectTab': {
       const [name] = args
-      chrome.tabs.connect(tabId, { name })
+      const port = chrome.tabs.connect(tabId, { name })
+      port.postMessage('howdy')
       break
     }
   }

--- a/spec-main/fixtures/extensions/chrome-api/main.js
+++ b/spec-main/fixtures/extensions/chrome-api/main.js
@@ -32,7 +32,9 @@ const testMap = {
   },
   connectTab (name) {
     chrome.runtime.onConnect.addListener(port => {
-      console.log(port.name)
+      port.onMessage.addListener(message => {
+        console.log([port.name, message].join())
+      })
     })
     chrome.runtime.sendMessage({ method: 'connectTab', args: [name] })
   }

--- a/spec-main/fixtures/extensions/chrome-api/main.js
+++ b/spec-main/fixtures/extensions/chrome-api/main.js
@@ -29,6 +29,12 @@ const testMap = {
     chrome.runtime.sendMessage({ method: 'executeScript', args: [code] }, response => {
       console.log(JSON.stringify(response))
     })
+  },
+  connectTab (name) {
+    chrome.runtime.onConnect.addListener(port => {
+      console.log(port.name)
+    })
+    chrome.runtime.sendMessage({ method: 'connectTab', args: [name] })
   }
 }
 


### PR DESCRIPTION
#### Description of Change
Implements `chrome.tabs.connect` extension API for background pages.

Since Electron extensions already use `//chrome/renderer/extensions/tabs_hooks_delegate.cc` (see #21779), all that was needed for this feature was to copy the function schema into tabs.json.

Electron maintainers, please add the `9-x-y` backport label if you're able to. 🙇 

ref #19447

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
