### PR TITLE
feat(extensions): add chrome.cookies API

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -599,6 +599,13 @@ filenames = {
   ]
 
   lib_sources_extensions = [
+    "shell/browser/extensions/api/cookies/cookies_api.cc",
+    "shell/browser/extensions/api/cookies/cookies_api.h",
+    "shell/browser/extensions/api/cookies/cookies_api_constants.cc",
+    "shell/browser/extensions/api/cookies/cookies_api_constants.h",
+    "shell/browser/extensions/api/cookies/cookies_helpers.cc",
+    "shell/browser/extensions/api/cookies/cookies_helpers.h",
+    "shell/browser/extensions/api/cookies/i18n_api.h",
     "shell/browser/extensions/api/resources_private/resources_private_api.cc",
     "shell/browser/extensions/api/resources_private/resources_private_api.h",
     "shell/browser/extensions/api/runtime/electron_runtime_api_delegate.cc",

--- a/filenames.gni
+++ b/filenames.gni
@@ -605,7 +605,6 @@ filenames = {
     "shell/browser/extensions/api/cookies/cookies_api_constants.h",
     "shell/browser/extensions/api/cookies/cookies_helpers.cc",
     "shell/browser/extensions/api/cookies/cookies_helpers.h",
-    "shell/browser/extensions/api/cookies/i18n_api.h",
     "shell/browser/extensions/api/resources_private/resources_private_api.cc",
     "shell/browser/extensions/api/resources_private/resources_private_api.h",
     "shell/browser/extensions/api/runtime/electron_runtime_api_delegate.cc",

--- a/shell/browser/extensions/api/BUILD.gn
+++ b/shell/browser/extensions/api/BUILD.gn
@@ -13,6 +13,7 @@ function_registration("api_registration") {
     "//electron/shell/common/extensions/api/extension.json",
     "//electron/shell/common/extensions/api/resources_private.idl",
     "//electron/shell/common/extensions/api/tabs.json",
+    "//electron/shell/common/extensions/api/cookies.json",
   ]
   impl_dir = "//electron/shell/browser/extensions/api"
   configs = [ "//build/config:precompiled_headers" ]

--- a/shell/browser/extensions/api/cookies/cookies_api.cc
+++ b/shell/browser/extensions/api/cookies/cookies_api.cc
@@ -1,0 +1,591 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Implements the Chrome Extensions Cookies API.
+
+#include "shell/browser/extensions/api/cookies/cookies_api.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+using content::BrowserThread;
+
+namespace extensions {
+
+namespace {
+
+bool ParseUrl(const Extension* extension,
+              const std::string& url_string,
+              GURL* url,
+              bool check_host_permissions,
+              std::string* error) {
+  *url = GURL(url_string);
+  if (!url->is_valid()) {
+    *error = ErrorUtils::FormatErrorMessage(
+        cookies_api_constants::kInvalidUrlError, url_string);
+    return false;
+  }
+  // Check against host permissions if needed.
+  if (check_host_permissions &&
+      !extension->permissions_data()->HasHostPermission(*url)) {
+    *error = ErrorUtils::FormatErrorMessage(
+        cookies_api_constants::kNoHostPermissionsError, url->spec());
+    return false;
+  }
+  return true;
+}
+
+network::mojom::CookieManager* ParseStoreCookieManager(
+    content::BrowserContext* function_context,
+    bool include_incognito,
+    std::string* store_id,
+    std::string* error) {
+  Profile* function_profile = Profile::FromBrowserContext(function_context);
+  Profile* store_profile = nullptr;
+  if (!store_id->empty()) {
+    store_profile = cookies_helpers::ChooseProfileFromStoreId(
+        *store_id, function_profile, include_incognito);
+    if (!store_profile) {
+      *error = ErrorUtils::FormatErrorMessage(
+          cookies_api_constants::kInvalidStoreIdError, *store_id);
+      return nullptr;
+    }
+  } else {
+    store_profile = function_profile;
+    *store_id = cookies_helpers::GetStoreIdFromProfile(store_profile);
+  }
+
+  return content::BrowserContext::GetDefaultStoragePartition(store_profile)
+      ->GetCookieManagerForBrowserProcess();
+}
+
+}  // namespace
+
+CookiesEventRouter::CookieChangeListener::CookieChangeListener(
+    CookiesEventRouter* router,
+    bool otr)
+    : router_(router), otr_(otr) {}
+CookiesEventRouter::CookieChangeListener::~CookieChangeListener() = default;
+
+void CookiesEventRouter::CookieChangeListener::OnCookieChange(
+    const net::CookieChangeInfo& change) {
+  router_->OnCookieChange(otr_, change);
+}
+
+CookiesEventRouter::CookiesEventRouter(content::BrowserContext* context)
+    : profile_(Profile::FromBrowserContext(context)) {
+  MaybeStartListening();
+  BrowserList::AddObserver(this);
+}
+
+CookiesEventRouter::~CookiesEventRouter() {
+  BrowserList::RemoveObserver(this);
+}
+
+void CookiesEventRouter::OnCookieChange(bool otr,
+                                        const net::CookieChangeInfo& change) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+
+  std::unique_ptr<base::ListValue> args(new base::ListValue());
+  std::unique_ptr<base::DictionaryValue> dict(new base::DictionaryValue());
+  dict->SetBoolean(cookies_api_constants::kRemovedKey,
+                   change.cause != net::CookieChangeCause::INSERTED);
+
+  Profile* profile =
+      otr ? profile_->GetOffTheRecordProfile() : profile_->GetOriginalProfile();
+  api::cookies::Cookie cookie = cookies_helpers::CreateCookie(
+      change.cookie, cookies_helpers::GetStoreIdFromProfile(profile));
+  dict->Set(cookies_api_constants::kCookieKey, cookie.ToValue());
+
+  // Map the internal cause to an external string.
+  std::string cause_dict_entry;
+  switch (change.cause) {
+    // Report an inserted cookie as an "explicit" change cause. All other causes
+    // only make sense for deletions.
+    case net::CookieChangeCause::INSERTED:
+    case net::CookieChangeCause::EXPLICIT:
+      cause_dict_entry = cookies_api_constants::kExplicitChangeCause;
+      break;
+
+    case net::CookieChangeCause::OVERWRITE:
+      cause_dict_entry = cookies_api_constants::kOverwriteChangeCause;
+      break;
+
+    case net::CookieChangeCause::EXPIRED:
+      cause_dict_entry = cookies_api_constants::kExpiredChangeCause;
+      break;
+
+    case net::CookieChangeCause::EVICTED:
+      cause_dict_entry = cookies_api_constants::kEvictedChangeCause;
+      break;
+
+    case net::CookieChangeCause::EXPIRED_OVERWRITE:
+      cause_dict_entry = cookies_api_constants::kExpiredOverwriteChangeCause;
+      break;
+
+    case net::CookieChangeCause::UNKNOWN_DELETION:
+      NOTREACHED();
+  }
+  dict->SetString(cookies_api_constants::kCauseKey, cause_dict_entry);
+
+  args->Append(std::move(dict));
+
+  DispatchEvent(profile, events::COOKIES_ON_CHANGED,
+                api::cookies::OnChanged::kEventName, std::move(args),
+                cookies_helpers::GetURLFromCanonicalCookie(change.cookie));
+}
+
+void CookiesEventRouter::OnBrowserAdded(Browser* browser) {
+  // The new browser may be associated with a profile that is the OTR spinoff
+  // of |profile_|, in which case we need to start listening to cookie changes
+  // there. If this is any other kind of new browser, MaybeStartListening() will
+  // be a no op.
+  MaybeStartListening();
+}
+
+void CookiesEventRouter::MaybeStartListening() {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  DCHECK(profile_);
+
+  Profile* original_profile = profile_->GetOriginalProfile();
+  Profile* otr_profile = original_profile->HasOffTheRecordProfile()
+                             ? original_profile->GetOffTheRecordProfile()
+                             : nullptr;
+
+  if (!receiver_.is_bound())
+    BindToCookieManager(&receiver_, original_profile);
+  if (!otr_receiver_.is_bound() && otr_profile)
+    BindToCookieManager(&otr_receiver_, otr_profile);
+}
+
+void CookiesEventRouter::BindToCookieManager(
+    mojo::Receiver<network::mojom::CookieChangeListener>* receiver,
+    Profile* profile) {
+  network::mojom::CookieManager* cookie_manager =
+      content::BrowserContext::GetDefaultStoragePartition(profile)
+          ->GetCookieManagerForBrowserProcess();
+  if (!cookie_manager)
+    return;
+
+  cookie_manager->AddGlobalChangeListener(receiver->BindNewPipeAndPassRemote());
+  receiver->set_disconnect_handler(
+      base::BindOnce(&CookiesEventRouter::OnConnectionError,
+                     base::Unretained(this), receiver));
+}
+
+void CookiesEventRouter::OnConnectionError(
+    mojo::Receiver<network::mojom::CookieChangeListener>* receiver) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+
+  receiver->reset();
+  MaybeStartListening();
+}
+
+void CookiesEventRouter::DispatchEvent(
+    content::BrowserContext* context,
+    events::HistogramValue histogram_value,
+    const std::string& event_name,
+    std::unique_ptr<base::ListValue> event_args,
+    const GURL& cookie_domain) {
+  EventRouter* router = context ? EventRouter::Get(context) : NULL;
+  if (!router)
+    return;
+  auto event = std::make_unique<Event>(histogram_value, event_name,
+                                       std::move(event_args), context);
+  event->event_url = cookie_domain;
+  router->BroadcastEvent(std::move(event));
+}
+
+CookiesGetFunction::CookiesGetFunction() = default;
+CookiesGetFunction::~CookiesGetFunction() = default;
+
+ExtensionFunction::ResponseAction CookiesGetFunction::Run() {
+  parsed_args_ = api::cookies::Get::Params::Create(*args_);
+  EXTENSION_FUNCTION_VALIDATE(parsed_args_.get());
+
+  // Read/validate input parameters.
+  std::string error;
+  if (!ParseUrl(extension(), parsed_args_->details.url, &url_, true, &error))
+    return RespondNow(Error(error));
+
+  std::string store_id = parsed_args_->details.store_id.get()
+                             ? *parsed_args_->details.store_id
+                             : std::string();
+  network::mojom::CookieManager* cookie_manager = ParseStoreCookieManager(
+      browser_context(), include_incognito_information(), &store_id, &error);
+  if (!cookie_manager)
+    return RespondNow(Error(error));
+
+  if (!parsed_args_->details.store_id.get())
+    parsed_args_->details.store_id.reset(new std::string(store_id));
+
+  DCHECK(!url_.is_empty() && url_.is_valid());
+  cookies_helpers::GetCookieListFromManager(
+      cookie_manager, url_,
+      base::BindOnce(&CookiesGetFunction::GetCookieListCallback, this));
+
+  // Will finish asynchronously.
+  return RespondLater();
+}
+
+void CookiesGetFunction::GetCookieListCallback(
+    const net::CookieStatusList& cookie_status_list,
+    const net::CookieStatusList& excluded_cookies) {
+  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+  for (const net::CookieWithStatus& cookie_with_status : cookie_status_list) {
+    // Return the first matching cookie. Relies on the fact that the
+    // CookieManager interface returns them in canonical order (longest path,
+    // then earliest creation time).
+    if (cookie_with_status.cookie.Name() == parsed_args_->details.name) {
+      api::cookies::Cookie api_cookie = cookies_helpers::CreateCookie(
+          cookie_with_status.cookie, *parsed_args_->details.store_id);
+      Respond(ArgumentList(api::cookies::Get::Results::Create(api_cookie)));
+      return;
+    }
+  }
+
+  // The cookie doesn't exist; return null.
+  Respond(OneArgument(std::make_unique<base::Value>()));
+}
+
+CookiesGetAllFunction::CookiesGetAllFunction() {}
+
+CookiesGetAllFunction::~CookiesGetAllFunction() {}
+
+ExtensionFunction::ResponseAction CookiesGetAllFunction::Run() {
+  parsed_args_ = api::cookies::GetAll::Params::Create(*args_);
+  EXTENSION_FUNCTION_VALIDATE(parsed_args_.get());
+
+  std::string error;
+  if (parsed_args_->details.url.get() &&
+      !ParseUrl(extension(), *parsed_args_->details.url, &url_, false,
+                &error)) {
+    return RespondNow(Error(error));
+  }
+
+  std::string store_id = parsed_args_->details.store_id.get()
+                             ? *parsed_args_->details.store_id
+                             : std::string();
+  network::mojom::CookieManager* cookie_manager = ParseStoreCookieManager(
+      browser_context(), include_incognito_information(), &store_id, &error);
+  if (!cookie_manager)
+    return RespondNow(Error(error));
+
+  if (!parsed_args_->details.store_id.get())
+    parsed_args_->details.store_id.reset(new std::string(store_id));
+
+  DCHECK(url_.is_empty() || url_.is_valid());
+  if (url_.is_empty()) {
+    cookies_helpers::GetAllCookiesFromManager(
+        cookie_manager,
+        base::BindOnce(&CookiesGetAllFunction::GetAllCookiesCallback, this));
+  } else {
+    cookies_helpers::GetCookieListFromManager(
+        cookie_manager, url_,
+        base::BindOnce(&CookiesGetAllFunction::GetCookieListCallback, this));
+  }
+
+  return RespondLater();
+}
+
+void CookiesGetAllFunction::GetAllCookiesCallback(
+    const net::CookieList& cookie_list) {
+  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+  ResponseValue response;
+  if (extension()) {
+    std::vector<api::cookies::Cookie> match_vector;
+    cookies_helpers::AppendMatchingCookiesFromCookieListToVector(
+        cookie_list, &parsed_args_->details, extension(), &match_vector);
+
+    response =
+        ArgumentList(api::cookies::GetAll::Results::Create(match_vector));
+  } else {
+    // TODO(devlin): When can |extension()| be null for this function?
+    response = NoArguments();
+  }
+  Respond(std::move(response));
+}
+
+void CookiesGetAllFunction::GetCookieListCallback(
+    const net::CookieStatusList& cookie_status_list,
+    const net::CookieStatusList& excluded_cookies) {
+  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+  ResponseValue response;
+  if (extension()) {
+    std::vector<api::cookies::Cookie> match_vector;
+    cookies_helpers::AppendMatchingCookiesFromCookieStatusListToVector(
+        cookie_status_list, &parsed_args_->details, extension(), &match_vector);
+
+    response =
+        ArgumentList(api::cookies::GetAll::Results::Create(match_vector));
+  } else {
+    // TODO(devlin): When can |extension()| be null for this function?
+    response = NoArguments();
+  }
+  Respond(std::move(response));
+}
+
+CookiesSetFunction::CookiesSetFunction()
+    : state_(NO_RESPONSE), success_(false) {}
+
+CookiesSetFunction::~CookiesSetFunction() {}
+
+ExtensionFunction::ResponseAction CookiesSetFunction::Run() {
+  parsed_args_ = api::cookies::Set::Params::Create(*args_);
+  EXTENSION_FUNCTION_VALIDATE(parsed_args_.get());
+
+  // Read/validate input parameters.
+  std::string error;
+  if (!ParseUrl(extension(), parsed_args_->details.url, &url_, true, &error))
+    return RespondNow(Error(error));
+
+  std::string store_id = parsed_args_->details.store_id.get()
+                             ? *parsed_args_->details.store_id
+                             : std::string();
+  network::mojom::CookieManager* cookie_manager = ParseStoreCookieManager(
+      browser_context(), include_incognito_information(), &store_id, &error);
+  if (!cookie_manager)
+    return RespondNow(Error(error));
+
+  if (!parsed_args_->details.store_id.get())
+    parsed_args_->details.store_id.reset(new std::string(store_id));
+
+  base::Time expiration_time;
+  if (parsed_args_->details.expiration_date.get()) {
+    // Time::FromDoubleT converts double time 0 to empty Time object. So we need
+    // to do special handling here.
+    expiration_time =
+        (*parsed_args_->details.expiration_date == 0)
+            ? base::Time::UnixEpoch()
+            : base::Time::FromDoubleT(*parsed_args_->details.expiration_date);
+  }
+
+  net::CookieSameSite same_site = net::CookieSameSite::UNSPECIFIED;
+  switch (parsed_args_->details.same_site) {
+    case api::cookies::SAME_SITE_STATUS_NO_RESTRICTION:
+      same_site = net::CookieSameSite::NO_RESTRICTION;
+      break;
+    case api::cookies::SAME_SITE_STATUS_LAX:
+      same_site = net::CookieSameSite::LAX_MODE;
+      break;
+    case api::cookies::SAME_SITE_STATUS_STRICT:
+      same_site = net::CookieSameSite::STRICT_MODE;
+      break;
+    // This is the case if the optional sameSite property is given as
+    // "unspecified":
+    case api::cookies::SAME_SITE_STATUS_UNSPECIFIED:
+    // This is the case if the optional sameSite property is left out:
+    case api::cookies::SAME_SITE_STATUS_NONE:
+      same_site = net::CookieSameSite::UNSPECIFIED;
+      break;
+  }
+
+  // clang-format off
+  std::unique_ptr<net::CanonicalCookie> cc(
+      net::CanonicalCookie::CreateSanitizedCookie(
+          url_, parsed_args_->details.name.get() ? *parsed_args_->details.name
+                                                 : std::string(),
+          parsed_args_->details.value.get() ? *parsed_args_->details.value
+                                                 : std::string(),
+          parsed_args_->details.domain.get() ? *parsed_args_->details.domain
+                                             : std::string(),
+          parsed_args_->details.path.get() ? *parsed_args_->details.path
+                                           : std::string(),
+          base::Time(),
+          expiration_time,
+          base::Time(),
+          parsed_args_->details.secure.get() ? *parsed_args_->details.secure
+                                             : false,
+          parsed_args_->details.http_only.get() ?
+              *parsed_args_->details.http_only :
+              false,
+          same_site,
+          net::COOKIE_PRIORITY_DEFAULT));
+  // clang-format on
+  if (!cc) {
+    // Return error through callbacks so that the proper error message
+    // is generated.
+    success_ = false;
+    state_ = SET_COMPLETED;
+    GetCookieListCallback(net::CookieStatusList(), net::CookieStatusList());
+    return AlreadyResponded();
+  }
+
+  // Dispatch the setter, immediately followed by the getter.  This
+  // plus FIFO ordering on the cookie_manager_ pipe means that no
+  // other extension function will affect the get result.
+  net::CookieOptions options;
+  options.set_include_httponly();
+  options.set_same_site_cookie_context(
+      net::CookieOptions::SameSiteCookieContext::SAME_SITE_STRICT);
+  DCHECK(!url_.is_empty() && url_.is_valid());
+  cookie_manager->SetCanonicalCookie(
+      *cc, url_.scheme(), options,
+      base::BindOnce(&CookiesSetFunction::SetCanonicalCookieCallback, this));
+  cookies_helpers::GetCookieListFromManager(
+      cookie_manager, url_,
+      base::BindOnce(&CookiesSetFunction::GetCookieListCallback, this));
+
+  // Will finish asynchronously.
+  return RespondLater();
+}
+
+void CookiesSetFunction::SetCanonicalCookieCallback(
+    net::CanonicalCookie::CookieInclusionStatus set_cookie_result) {
+  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+  DCHECK_EQ(NO_RESPONSE, state_);
+  state_ = SET_COMPLETED;
+  success_ = set_cookie_result.IsInclude();
+}
+
+void CookiesSetFunction::GetCookieListCallback(
+    const net::CookieStatusList& cookie_list,
+    const net::CookieStatusList& excluded_cookies) {
+  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+  DCHECK_EQ(SET_COMPLETED, state_);
+  state_ = GET_COMPLETED;
+
+  if (!success_) {
+    std::string name = parsed_args_->details.name.get()
+                           ? *parsed_args_->details.name
+                           : std::string();
+    Respond(Error(ErrorUtils::FormatErrorMessage(
+        cookies_api_constants::kCookieSetFailedError, name)));
+    return;
+  }
+
+  ResponseValue value;
+  for (const net::CookieWithStatus& cookie_with_status : cookie_list) {
+    // Return the first matching cookie. Relies on the fact that the
+    // CookieMonster returns them in canonical order (longest path, then
+    // earliest creation time).
+    std::string name = parsed_args_->details.name.get()
+                           ? *parsed_args_->details.name
+                           : std::string();
+    if (cookie_with_status.cookie.Name() == name) {
+      api::cookies::Cookie api_cookie = cookies_helpers::CreateCookie(
+          cookie_with_status.cookie, *parsed_args_->details.store_id);
+      value = ArgumentList(api::cookies::Set::Results::Create(api_cookie));
+      break;
+    }
+  }
+
+  Respond(value ? std::move(value) : NoArguments());
+}
+
+CookiesRemoveFunction::CookiesRemoveFunction() {}
+
+CookiesRemoveFunction::~CookiesRemoveFunction() {}
+
+ExtensionFunction::ResponseAction CookiesRemoveFunction::Run() {
+  parsed_args_ = api::cookies::Remove::Params::Create(*args_);
+  EXTENSION_FUNCTION_VALIDATE(parsed_args_.get());
+
+  // Read/validate input parameters.
+  std::string error;
+  if (!ParseUrl(extension(), parsed_args_->details.url, &url_, true, &error))
+    return RespondNow(Error(error));
+
+  std::string store_id = parsed_args_->details.store_id.get()
+                             ? *parsed_args_->details.store_id
+                             : std::string();
+  network::mojom::CookieManager* cookie_manager = ParseStoreCookieManager(
+      browser_context(), include_incognito_information(), &store_id, &error);
+  if (!cookie_manager)
+    return RespondNow(Error(error));
+
+  if (!parsed_args_->details.store_id.get())
+    parsed_args_->details.store_id.reset(new std::string(store_id));
+
+  network::mojom::CookieDeletionFilterPtr filter(
+      network::mojom::CookieDeletionFilter::New());
+  filter->url = url_;
+  filter->cookie_name = parsed_args_->details.name;
+  cookie_manager->DeleteCookies(
+      std::move(filter),
+      base::BindOnce(&CookiesRemoveFunction::RemoveCookieCallback, this));
+
+  // Will return asynchronously.
+  return RespondLater();
+}
+
+void CookiesRemoveFunction::RemoveCookieCallback(uint32_t /* num_deleted */) {
+  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+
+  // Build the callback result
+  api::cookies::Remove::Results::Details details;
+  details.name = parsed_args_->details.name;
+  details.url = url_.spec();
+  details.store_id = *parsed_args_->details.store_id;
+
+  Respond(ArgumentList(api::cookies::Remove::Results::Create(details)));
+}
+
+ExtensionFunction::ResponseAction CookiesGetAllCookieStoresFunction::Run() {
+  Profile* original_profile = Profile::FromBrowserContext(browser_context());
+  DCHECK(original_profile);
+  std::unique_ptr<base::ListValue> original_tab_ids(new base::ListValue());
+  Profile* incognito_profile = NULL;
+  std::unique_ptr<base::ListValue> incognito_tab_ids;
+  if (include_incognito_information() &&
+      original_profile->HasOffTheRecordProfile()) {
+    incognito_profile = original_profile->GetOffTheRecordProfile();
+    if (incognito_profile)
+      incognito_tab_ids.reset(new base::ListValue());
+  }
+  DCHECK(original_profile != incognito_profile);
+
+  // Iterate through all browser instances, and for each browser,
+  // add its tab IDs to either the regular or incognito tab ID list depending
+  // whether the browser is regular or incognito.
+  for (auto* browser : *BrowserList::GetInstance()) {
+    if (browser->profile() == original_profile) {
+      cookies_helpers::AppendToTabIdList(browser, original_tab_ids.get());
+    } else if (incognito_tab_ids.get() &&
+               browser->profile() == incognito_profile) {
+      cookies_helpers::AppendToTabIdList(browser, incognito_tab_ids.get());
+    }
+  }
+  // Return a list of all cookie stores with at least one open tab.
+  std::vector<api::cookies::CookieStore> cookie_stores;
+  if (original_tab_ids->GetSize() > 0) {
+    cookie_stores.push_back(cookies_helpers::CreateCookieStore(
+        original_profile, std::move(original_tab_ids)));
+  }
+  if (incognito_tab_ids.get() && incognito_tab_ids->GetSize() > 0 &&
+      incognito_profile) {
+    cookie_stores.push_back(cookies_helpers::CreateCookieStore(
+        incognito_profile, std::move(incognito_tab_ids)));
+  }
+  return RespondNow(ArgumentList(
+      api::cookies::GetAllCookieStores::Results::Create(cookie_stores)));
+}
+
+CookiesAPI::CookiesAPI(content::BrowserContext* context)
+    : browser_context_(context) {
+  EventRouter::Get(browser_context_)
+      ->RegisterObserver(this, api::cookies::OnChanged::kEventName);
+}
+
+CookiesAPI::~CookiesAPI() = default;
+
+void CookiesAPI::Shutdown() {
+  EventRouter::Get(browser_context_)->UnregisterObserver(this);
+}
+
+static base::LazyInstance<BrowserContextKeyedAPIFactory<CookiesAPI>>::
+    DestructorAtExit g_cookies_api_factory = LAZY_INSTANCE_INITIALIZER;
+
+// static
+BrowserContextKeyedAPIFactory<CookiesAPI>* CookiesAPI::GetFactoryInstance() {
+  return g_cookies_api_factory.Pointer();
+}
+
+void CookiesAPI::OnListenerAdded(const EventListenerInfo& details) {
+  cookies_event_router_.reset(new CookiesEventRouter(browser_context_));
+  EventRouter::Get(browser_context_)->UnregisterObserver(this);
+}
+
+}  // namespace extensions

--- a/shell/browser/extensions/api/cookies/cookies_api.h
+++ b/shell/browser/extensions/api/cookies/cookies_api.h
@@ -1,0 +1,215 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Defines the Chrome Extensions Cookies API functions for accessing internet
+// cookies, as specified in the extension API JSON.
+
+#ifndef CHROME_BROWSER_EXTENSIONS_API_COOKIES_COOKIES_API_H_
+#define CHROME_BROWSER_EXTENSIONS_API_COOKIES_COOKIES_API_H_
+
+#include <memory>
+#include <string>
+
+class Profile;
+
+namespace extensions {
+
+// Observes CookieManager Mojo messages and routes them as events to the
+// extension system.
+class CookiesEventRouter : public BrowserListObserver {
+ public:
+  explicit CookiesEventRouter(content::BrowserContext* context);
+  ~CookiesEventRouter() override;
+
+  // BrowserListObserver:
+  void OnBrowserAdded(Browser* browser) override;
+
+ private:
+  // This helper class connects to the CookieMonster over Mojo, and relays Mojo
+  // messages to the owning CookiesEventRouter. This rather clumsy arrangement
+  // is necessary to differentiate which CookieMonster the Mojo message comes
+  // from (that associated with the incognito profile vs the original profile),
+  // since it's not possible to tell the source from inside OnCookieChange().
+  class CookieChangeListener : public network::mojom::CookieChangeListener {
+   public:
+    CookieChangeListener(CookiesEventRouter* router, bool otr);
+    ~CookieChangeListener() override;
+
+    // network::mojom::CookieChangeListener:
+    void OnCookieChange(const net::CookieChangeInfo& change) override;
+
+   private:
+    CookiesEventRouter* router_;
+    bool otr_;
+
+    DISALLOW_COPY_AND_ASSIGN(CookieChangeListener);
+  };
+
+  void MaybeStartListening();
+  void BindToCookieManager(
+      mojo::Receiver<network::mojom::CookieChangeListener>* receiver,
+      Profile* profile);
+  void OnConnectionError(
+      mojo::Receiver<network::mojom::CookieChangeListener>* receiver);
+  void OnCookieChange(bool otr, const net::CookieChangeInfo& change);
+
+  // This method dispatches events to the extension message service.
+  void DispatchEvent(content::BrowserContext* context,
+                     events::HistogramValue histogram_value,
+                     const std::string& event_name,
+                     std::unique_ptr<base::ListValue> event_args,
+                     const GURL& cookie_domain);
+
+  Profile* profile_;
+
+  // To listen to cookie changes in both the original and the off the record
+  // profiles, we need a pair of bindings, as well as a pair of
+  // CookieChangeListener instances.
+  CookieChangeListener listener_{this, false};
+  mojo::Receiver<network::mojom::CookieChangeListener> receiver_{&listener_};
+
+  CookieChangeListener otr_listener_{this, true};
+  mojo::Receiver<network::mojom::CookieChangeListener> otr_receiver_{
+      &otr_listener_};
+
+  DISALLOW_COPY_AND_ASSIGN(CookiesEventRouter);
+};
+
+// Implements the cookies.get() extension function.
+class CookiesGetFunction : public ExtensionFunction {
+ public:
+  DECLARE_EXTENSION_FUNCTION("cookies.get", COOKIES_GET)
+
+  CookiesGetFunction();
+
+ protected:
+  ~CookiesGetFunction() override;
+
+  // ExtensionFunction:
+  ResponseAction Run() override;
+
+ private:
+  void GetCookieListCallback(const net::CookieStatusList& cookie_status_list,
+                             const net::CookieStatusList& excluded_cookies);
+
+  GURL url_;
+  mojo::Remote<network::mojom::CookieManager> store_browser_cookie_manager_;
+  std::unique_ptr<api::cookies::Get::Params> parsed_args_;
+};
+
+// Implements the cookies.getAll() extension function.
+class CookiesGetAllFunction : public ExtensionFunction {
+ public:
+  DECLARE_EXTENSION_FUNCTION("cookies.getAll", COOKIES_GETALL)
+
+  CookiesGetAllFunction();
+
+ protected:
+  ~CookiesGetAllFunction() override;
+
+  // ExtensionFunction:
+  ResponseAction Run() override;
+
+ private:
+  // For the two different callback signatures for getting cookies for a URL vs
+  // getting all cookies. They do the same thing.
+  void GetAllCookiesCallback(const net::CookieList& cookie_list);
+  void GetCookieListCallback(const net::CookieStatusList& cookie_status_list,
+                             const net::CookieStatusList& excluded_cookies);
+
+  GURL url_;
+  mojo::Remote<network::mojom::CookieManager> store_browser_cookie_manager_;
+  std::unique_ptr<api::cookies::GetAll::Params> parsed_args_;
+};
+
+// Implements the cookies.set() extension function.
+class CookiesSetFunction : public ExtensionFunction {
+ public:
+  DECLARE_EXTENSION_FUNCTION("cookies.set", COOKIES_SET)
+
+  CookiesSetFunction();
+
+ protected:
+  ~CookiesSetFunction() override;
+  ResponseAction Run() override;
+
+ private:
+  void SetCanonicalCookieCallback(
+      net::CanonicalCookie::CookieInclusionStatus set_cookie_result);
+  void GetCookieListCallback(const net::CookieStatusList& cookie_list,
+                             const net::CookieStatusList& excluded_cookies);
+
+  enum { NO_RESPONSE, SET_COMPLETED, GET_COMPLETED } state_;
+  GURL url_;
+  bool success_;
+  mojo::Remote<network::mojom::CookieManager> store_browser_cookie_manager_;
+  std::unique_ptr<api::cookies::Set::Params> parsed_args_;
+};
+
+// Implements the cookies.remove() extension function.
+class CookiesRemoveFunction : public ExtensionFunction {
+ public:
+  DECLARE_EXTENSION_FUNCTION("cookies.remove", COOKIES_REMOVE)
+
+  CookiesRemoveFunction();
+
+ protected:
+  ~CookiesRemoveFunction() override;
+
+  // ExtensionFunction:
+  ResponseAction Run() override;
+
+ private:
+  void RemoveCookieCallback(uint32_t /* num_deleted */);
+
+  GURL url_;
+  mojo::Remote<network::mojom::CookieManager> store_browser_cookie_manager_;
+  std::unique_ptr<api::cookies::Remove::Params> parsed_args_;
+};
+
+// Implements the cookies.getAllCookieStores() extension function.
+class CookiesGetAllCookieStoresFunction : public ExtensionFunction {
+ public:
+  DECLARE_EXTENSION_FUNCTION("cookies.getAllCookieStores",
+                             COOKIES_GETALLCOOKIESTORES)
+
+ protected:
+  ~CookiesGetAllCookieStoresFunction() override {}
+
+  // ExtensionFunction:
+  ResponseAction Run() override;
+};
+
+class CookiesAPI : public BrowserContextKeyedAPI, public EventRouter::Observer {
+ public:
+  explicit CookiesAPI(content::BrowserContext* context);
+  ~CookiesAPI() override;
+
+  // KeyedService implementation.
+  void Shutdown() override;
+
+  // BrowserContextKeyedAPI implementation.
+  static BrowserContextKeyedAPIFactory<CookiesAPI>* GetFactoryInstance();
+
+  // EventRouter::Observer implementation.
+  void OnListenerAdded(const EventListenerInfo& details) override;
+
+ private:
+  friend class BrowserContextKeyedAPIFactory<CookiesAPI>;
+
+  content::BrowserContext* browser_context_;
+
+  // BrowserContextKeyedAPI implementation.
+  static const char* service_name() { return "CookiesAPI"; }
+  static const bool kServiceIsNULLWhileTesting = true;
+
+  // Created lazily upon OnListenerAdded.
+  std::unique_ptr<CookiesEventRouter> cookies_event_router_;
+
+  DISALLOW_COPY_AND_ASSIGN(CookiesAPI);
+};
+
+}  // namespace extensions
+
+#endif  // CHROME_BROWSER_EXTENSIONS_API_COOKIES_COOKIES_API_H_

--- a/shell/browser/extensions/api/cookies/cookies_api_constants.cc
+++ b/shell/browser/extensions/api/cookies/cookies_api_constants.cc
@@ -1,0 +1,36 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/extensions/api/cookies/cookies_api_constants.h"
+
+namespace extensions {
+namespace cookies_api_constants {
+
+// Keys
+const char kCauseKey[] = "cause";
+const char kCookieKey[] = "cookie";
+const char kDomainKey[] = "domain";
+const char kIdKey[] = "id";
+const char kRemovedKey[] = "removed";
+const char kTabIdsKey[] = "tabIds";
+
+// Cause Constants
+const char kEvictedChangeCause[] = "evicted";
+const char kExpiredChangeCause[] = "expired";
+const char kExpiredOverwriteChangeCause[] = "expired_overwrite";
+const char kExplicitChangeCause[] = "explicit";
+const char kOverwriteChangeCause[] = "overwrite";
+
+// Errors
+const char kCookieSetFailedError[] =
+    "Failed to parse or set cookie named \"*\".";
+const char kInvalidStoreIdError[] = "Invalid cookie store id: \"*\".";
+const char kInvalidUrlError[] = "Invalid url: \"*\".";
+const char kNoCookieStoreFoundError[] =
+    "No accessible cookie store found for the current execution context.";
+const char kNoHostPermissionsError[] =
+    "No host permissions for cookies at url: \"*\".";
+
+}  // namespace cookies_api_constants
+}  // namespace extensions

--- a/shell/browser/extensions/api/cookies/cookies_api_constants.h
+++ b/shell/browser/extensions/api/cookies/cookies_api_constants.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Constants used for the Cookies API.
+
+#ifndef CHROME_BROWSER_EXTENSIONS_API_COOKIES_COOKIES_API_CONSTANTS_H_
+#define CHROME_BROWSER_EXTENSIONS_API_COOKIES_COOKIES_API_CONSTANTS_H_
+
+namespace extensions {
+namespace cookies_api_constants {
+
+// Keys.
+extern const char kCauseKey[];
+extern const char kCookieKey[];
+extern const char kDomainKey[];
+extern const char kIdKey[];
+extern const char kRemovedKey[];
+extern const char kTabIdsKey[];
+
+// Cause Constants
+extern const char kEvictedChangeCause[];
+extern const char kExpiredChangeCause[];
+extern const char kExpiredOverwriteChangeCause[];
+extern const char kExplicitChangeCause[];
+extern const char kOverwriteChangeCause[];
+
+// Events.
+extern const char kOnChanged[];
+
+// Errors.
+extern const char kCookieSetFailedError[];
+extern const char kInvalidStoreIdError[];
+extern const char kInvalidUrlError[];
+extern const char kNoCookieStoreFoundError[];
+extern const char kNoHostPermissionsError[];
+
+}  // namespace cookies_api_constants
+}  // namespace extensions
+
+#endif  // CHROME_BROWSER_EXTENSIONS_API_COOKIES_COOKIES_API_CONSTANTS_H_

--- a/shell/browser/extensions/api/cookies/cookies_helpers.cc
+++ b/shell/browser/extensions/api/cookies/cookies_helpers.cc
@@ -8,14 +8,14 @@
 
 #include <stddef.h>
 
+#include <limits>
+#include <utility>
+#include <vector>
+
 #include "shell/browser/extensions/api/cookies/cookies_api_constants.h"
 #include "shell/browser/extensions/extension_tab_util.h"
 #include "shell/common/extensions/api/cookies.h"
 #include "shell/common/url_constants.h"
-
-#include <limits>
-#include <utility>
-#include <vector>
 
 using extensions::api::cookies::Cookie;
 using extensions::api::cookies::CookieStore;

--- a/shell/browser/extensions/api/cookies/cookies_helpers.cc
+++ b/shell/browser/extensions/api/cookies/cookies_helpers.cc
@@ -4,32 +4,18 @@
 
 // Implements common functionality for the Chrome Extensions Cookies API.
 
-#include "chrome/browser/extensions/api/cookies/cookies_helpers.h"
+#include "shell/browser/extensions/api/cookies/cookies_helpers.h"
 
 #include <stddef.h>
+
+#include "shell/browser/extensions/api/cookies/cookies_api_constants.h"
+#include "shell/browser/extensions/extension_tab_util.h"
+#include "shell/common/extensions/api/cookies.h"
+#include "shell/common/url_constants.h"
 
 #include <limits>
 #include <utility>
 #include <vector>
-
-#include "base/logging.h"
-#include "base/strings/string_util.h"
-#include "base/strings/utf_string_conversions.h"
-#include "base/values.h"
-#include "chrome/browser/extensions/api/cookies/cookies_api_constants.h"
-#include "chrome/browser/extensions/extension_tab_util.h"
-#include "chrome/browser/profiles/profile.h"
-#include "chrome/browser/ui/browser.h"
-#include "chrome/browser/ui/tabs/tab_strip_model.h"
-#include "chrome/common/extensions/api/cookies.h"
-#include "chrome/common/url_constants.h"
-#include "content/public/browser/web_contents.h"
-#include "extensions/common/extension.h"
-#include "extensions/common/permissions/permissions_data.h"
-#include "net/cookies/canonical_cookie.h"
-#include "net/cookies/cookie_store.h"
-#include "net/cookies/cookie_util.h"
-#include "url/gurl.h"
 
 using extensions::api::cookies::Cookie;
 using extensions::api::cookies::CookieStore;

--- a/shell/browser/extensions/api/cookies/cookies_helpers.cc
+++ b/shell/browser/extensions/api/cookies/cookies_helpers.cc
@@ -1,0 +1,258 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Implements common functionality for the Chrome Extensions Cookies API.
+
+#include "chrome/browser/extensions/api/cookies/cookies_helpers.h"
+
+#include <stddef.h>
+
+#include <limits>
+#include <utility>
+#include <vector>
+
+#include "base/logging.h"
+#include "base/strings/string_util.h"
+#include "base/strings/utf_string_conversions.h"
+#include "base/values.h"
+#include "chrome/browser/extensions/api/cookies/cookies_api_constants.h"
+#include "chrome/browser/extensions/extension_tab_util.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/common/extensions/api/cookies.h"
+#include "chrome/common/url_constants.h"
+#include "content/public/browser/web_contents.h"
+#include "extensions/common/extension.h"
+#include "extensions/common/permissions/permissions_data.h"
+#include "net/cookies/canonical_cookie.h"
+#include "net/cookies/cookie_store.h"
+#include "net/cookies/cookie_util.h"
+#include "url/gurl.h"
+
+using extensions::api::cookies::Cookie;
+using extensions::api::cookies::CookieStore;
+
+namespace GetAll = extensions::api::cookies::GetAll;
+
+namespace extensions {
+
+namespace {
+
+void AppendCookieToVectorIfMatchAndHasHostPermission(
+    const net::CanonicalCookie cookie,
+    const GetAll::Params::Details* details,
+    const Extension* extension,
+    std::vector<Cookie>* match_vector) {
+  // Ignore any cookie whose domain doesn't match the extension's
+  // host permissions.
+  GURL cookie_domain_url = cookies_helpers::GetURLFromCanonicalCookie(cookie);
+  if (!extension->permissions_data()->HasHostPermission(cookie_domain_url))
+    return;
+  // Filter the cookie using the match filter.
+  cookies_helpers::MatchFilter filter(details);
+  if (filter.MatchesCookie(cookie)) {
+    match_vector->push_back(
+        cookies_helpers::CreateCookie(cookie, *details->store_id));
+  }
+}
+
+}  // namespace
+
+namespace cookies_helpers {
+
+static const char kOriginalProfileStoreId[] = "0";
+static const char kOffTheRecordProfileStoreId[] = "1";
+
+Profile* ChooseProfileFromStoreId(const std::string& store_id,
+                                  Profile* profile,
+                                  bool include_incognito) {
+  DCHECK(profile);
+  bool allow_original = !profile->IsOffTheRecord();
+  bool allow_incognito =
+      profile->IsOffTheRecord() ||
+      (include_incognito && profile->HasOffTheRecordProfile());
+  if (store_id == kOriginalProfileStoreId && allow_original)
+    return profile->GetOriginalProfile();
+  if (store_id == kOffTheRecordProfileStoreId && allow_incognito)
+    return profile->GetOffTheRecordProfile();
+  return NULL;
+}
+
+const char* GetStoreIdFromProfile(Profile* profile) {
+  DCHECK(profile);
+  return profile->IsOffTheRecord() ? kOffTheRecordProfileStoreId
+                                   : kOriginalProfileStoreId;
+}
+
+Cookie CreateCookie(const net::CanonicalCookie& canonical_cookie,
+                    const std::string& store_id) {
+  Cookie cookie;
+
+  // A cookie is a raw byte sequence. By explicitly parsing it as UTF-8, we
+  // apply error correction, so the string can be safely passed to the renderer.
+  cookie.name = base::UTF16ToUTF8(base::UTF8ToUTF16(canonical_cookie.Name()));
+  cookie.value = base::UTF16ToUTF8(base::UTF8ToUTF16(canonical_cookie.Value()));
+  cookie.domain = canonical_cookie.Domain();
+  cookie.host_only =
+      net::cookie_util::DomainIsHostOnly(canonical_cookie.Domain());
+  // A non-UTF8 path is invalid, so we just replace it with an empty string.
+  cookie.path = base::IsStringUTF8(canonical_cookie.Path())
+                    ? canonical_cookie.Path()
+                    : std::string();
+  cookie.secure = canonical_cookie.IsSecure();
+  cookie.http_only = canonical_cookie.IsHttpOnly();
+
+  switch (canonical_cookie.SameSite()) {
+    case net::CookieSameSite::NO_RESTRICTION:
+      cookie.same_site = api::cookies::SAME_SITE_STATUS_NO_RESTRICTION;
+      break;
+    case net::CookieSameSite::LAX_MODE:
+      cookie.same_site = api::cookies::SAME_SITE_STATUS_LAX;
+      break;
+    case net::CookieSameSite::STRICT_MODE:
+      cookie.same_site = api::cookies::SAME_SITE_STATUS_STRICT;
+      break;
+    case net::CookieSameSite::UNSPECIFIED:
+      cookie.same_site = api::cookies::SAME_SITE_STATUS_UNSPECIFIED;
+      break;
+  }
+
+  cookie.session = !canonical_cookie.IsPersistent();
+  if (canonical_cookie.IsPersistent()) {
+    double expiration_date = canonical_cookie.ExpiryDate().ToDoubleT();
+    if (canonical_cookie.ExpiryDate().is_max() ||
+        !std::isfinite(expiration_date)) {
+      expiration_date = std::numeric_limits<double>::max();
+    }
+    cookie.expiration_date = std::make_unique<double>(expiration_date);
+  }
+  cookie.store_id = store_id;
+
+  return cookie;
+}
+
+CookieStore CreateCookieStore(Profile* profile,
+                              std::unique_ptr<base::ListValue> tab_ids) {
+  DCHECK(profile);
+  DCHECK(tab_ids);
+  base::DictionaryValue dict;
+  dict.SetString(cookies_api_constants::kIdKey, GetStoreIdFromProfile(profile));
+  dict.Set(cookies_api_constants::kTabIdsKey, std::move(tab_ids));
+
+  CookieStore cookie_store;
+  bool rv = CookieStore::Populate(dict, &cookie_store);
+  CHECK(rv);
+  return cookie_store;
+}
+
+void GetCookieListFromManager(
+    network::mojom::CookieManager* manager,
+    const GURL& url,
+    network::mojom::CookieManager::GetCookieListCallback callback) {
+  manager->GetCookieList(url, net::CookieOptions::MakeAllInclusive(),
+                         std::move(callback));
+}
+
+void GetAllCookiesFromManager(
+    network::mojom::CookieManager* manager,
+    network::mojom::CookieManager::GetAllCookiesCallback callback) {
+  manager->GetAllCookies(std::move(callback));
+}
+
+GURL GetURLFromCanonicalCookie(const net::CanonicalCookie& cookie) {
+  const std::string& domain_key = cookie.Domain();
+  const std::string scheme =
+      cookie.IsSecure() ? url::kHttpsScheme : url::kHttpScheme;
+  const std::string host =
+      base::StartsWith(domain_key, ".", base::CompareCase::SENSITIVE)
+          ? domain_key.substr(1)
+          : domain_key;
+  return GURL(scheme + url::kStandardSchemeSeparator + host + "/");
+}
+
+void AppendMatchingCookiesFromCookieListToVector(
+    const net::CookieList& all_cookies,
+    const GetAll::Params::Details* details,
+    const Extension* extension,
+    std::vector<Cookie>* match_vector) {
+  for (const net::CanonicalCookie& cookie : all_cookies) {
+    AppendCookieToVectorIfMatchAndHasHostPermission(cookie, details, extension,
+                                                    match_vector);
+  }
+}
+
+void AppendMatchingCookiesFromCookieStatusListToVector(
+    const net::CookieStatusList& all_cookies_with_statuses,
+    const GetAll::Params::Details* details,
+    const Extension* extension,
+    std::vector<Cookie>* match_vector) {
+  for (const net::CookieWithStatus& cookie_with_status :
+       all_cookies_with_statuses) {
+    const net::CanonicalCookie& cookie = cookie_with_status.cookie;
+    AppendCookieToVectorIfMatchAndHasHostPermission(cookie, details, extension,
+                                                    match_vector);
+  }
+}
+
+void AppendToTabIdList(Browser* browser, base::ListValue* tab_ids) {
+  DCHECK(browser);
+  DCHECK(tab_ids);
+  TabStripModel* tab_strip = browser->tab_strip_model();
+  for (int i = 0; i < tab_strip->count(); ++i) {
+    tab_ids->AppendInteger(
+        ExtensionTabUtil::GetTabId(tab_strip->GetWebContentsAt(i)));
+  }
+}
+
+MatchFilter::MatchFilter(const GetAll::Params::Details* details)
+    : details_(details) {
+  DCHECK(details_);
+}
+
+bool MatchFilter::MatchesCookie(const net::CanonicalCookie& cookie) {
+  if (details_->name.get() && *details_->name != cookie.Name())
+    return false;
+
+  if (!MatchesDomain(cookie.Domain()))
+    return false;
+
+  if (details_->path.get() && *details_->path != cookie.Path())
+    return false;
+
+  if (details_->secure.get() && *details_->secure != cookie.IsSecure())
+    return false;
+
+  if (details_->session.get() && *details_->session != !cookie.IsPersistent())
+    return false;
+
+  return true;
+}
+
+bool MatchFilter::MatchesDomain(const std::string& domain) {
+  if (!details_->domain.get())
+    return true;
+
+  // Add a leading '.' character to the filter domain if it doesn't exist.
+  if (net::cookie_util::DomainIsHostOnly(*details_->domain))
+    details_->domain->insert(0, ".");
+
+  std::string sub_domain(domain);
+  // Strip any leading '.' character from the input cookie domain.
+  if (!net::cookie_util::DomainIsHostOnly(sub_domain))
+    sub_domain = sub_domain.substr(1);
+
+  // Now check whether the domain argument is a subdomain of the filter domain.
+  for (sub_domain.insert(0, ".");
+       sub_domain.length() >= details_->domain->length();) {
+    if (sub_domain == *details_->domain)
+      return true;
+    const size_t next_dot = sub_domain.find('.', 1);  // Skip over leading dot.
+    sub_domain.erase(0, next_dot);
+  }
+  return false;
+}
+
+}  // namespace cookies_helpers
+}  // namespace extensions

--- a/shell/browser/extensions/api/cookies/cookies_helpers.h
+++ b/shell/browser/extensions/api/cookies/cookies_helpers.h
@@ -1,0 +1,131 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Defines common functionality used by the implementation of the Chrome
+// Extensions Cookies API implemented in
+// chrome/browser/extensions/api/cookies/cookies_api.cc. This separate interface
+// exposes pieces of the API implementation mainly for unit testing purposes.
+
+#ifndef CHROME_BROWSER_EXTENSIONS_API_COOKIES_COOKIES_HELPERS_H_
+#define CHROME_BROWSER_EXTENSIONS_API_COOKIES_COOKIES_HELPERS_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "chrome/common/extensions/api/cookies.h"
+#include "net/cookies/canonical_cookie.h"
+#include "net/cookies/cookie_monster.h"
+#include "net/cookies/cookie_options.h"
+#include "services/network/public/mojom/cookie_manager.mojom.h"
+
+class Browser;
+class Profile;
+
+namespace base {
+class ListValue;
+}
+
+namespace net {
+class CanonicalCookie;
+}
+
+namespace extensions {
+
+class Extension;
+
+namespace cookies_helpers {
+
+// Returns either the original profile or the incognito profile, based on the
+// given store ID.  Returns NULL if the profile doesn't exist or is not allowed
+// (e.g. if incognito mode is not enabled for the extension).
+Profile* ChooseProfileFromStoreId(const std::string& store_id,
+                                  Profile* profile,
+                                  bool include_incognito);
+
+// Returns the store ID for a particular user profile.
+const char* GetStoreIdFromProfile(Profile* profile);
+
+// Constructs a new Cookie object representing a cookie as defined by the
+// cookies API.
+api::cookies::Cookie CreateCookie(const net::CanonicalCookie& cookie,
+                                  const std::string& store_id);
+
+// Constructs a new CookieStore object as defined by the cookies API.
+api::cookies::CookieStore CreateCookieStore(
+    Profile* profile,
+    std::unique_ptr<base::ListValue> tab_ids);
+
+// Dispatch a request to the CookieManager for cookies associated with
+// |url|.
+void GetCookieListFromManager(
+    network::mojom::CookieManager* manager,
+    const GURL& url,
+    network::mojom::CookieManager::GetCookieListCallback callback);
+
+// Dispatch a request to the CookieManager for all cookies.
+void GetAllCookiesFromManager(
+    network::mojom::CookieManager* manager,
+    network::mojom::CookieManager::GetAllCookiesCallback callback);
+
+// Constructs a URL from a cookie's information for use in checking
+// a cookie against the extension's host permissions. The Secure
+// property of the cookie defines the URL scheme, and the cookie's
+// domain becomes the URL host.
+GURL GetURLFromCanonicalCookie(const net::CanonicalCookie& cookie);
+
+// Looks through all cookies in the given cookie store, and appends to the
+// match vector all the cookies that both match the given URL and cookie details
+// and are allowed by extension host permissions.
+void AppendMatchingCookiesFromCookieListToVector(
+    const net::CookieList& all_cookies,
+    const api::cookies::GetAll::Params::Details* details,
+    const Extension* extension,
+    std::vector<api::cookies::Cookie>* match_vector);
+
+// Same as above except takes a CookieStatusList (and ignores the statuses).
+void AppendMatchingCookiesFromCookieStatusListToVector(
+    const net::CookieStatusList& all_cookies_with_statuses,
+    const api::cookies::GetAll::Params::Details* details,
+    const Extension* extension,
+    std::vector<api::cookies::Cookie>* match_vector);
+
+// Appends the IDs of all tabs belonging to the given browser to the
+// given list.
+void AppendToTabIdList(Browser* browser, base::ListValue* tab_ids);
+
+// A class representing the cookie filter parameters passed into
+// cookies.getAll().
+// This class is essentially a convenience wrapper for the details dictionary
+// passed into the cookies.getAll() API by the user. If the dictionary contains
+// no filter parameters, the MatchFilter will always trivially
+// match all cookies.
+class MatchFilter {
+ public:
+  // Takes the details dictionary argument given by the user as input.
+  // This class does not take ownership of the lifetime of the Details
+  // object.
+  explicit MatchFilter(const api::cookies::GetAll::Params::Details* details);
+
+  // Returns true if the given cookie matches the properties in the match
+  // filter.
+  bool MatchesCookie(const net::CanonicalCookie& cookie);
+
+ private:
+  // Returns true if the given cookie domain string matches the filter's
+  // domain. Any cookie domain which is equal to or is a subdomain of the
+  // filter's domain will be matched; leading '.' characters indicating
+  // host-only domains have no meaning in the match filter domain (for
+  // instance, a match filter domain of 'foo.bar.com' will be treated the same
+  // as '.foo.bar.com', and both will match cookies with domain values of
+  // 'foo.bar.com', '.foo.bar.com', and 'baz.foo.bar.com'.
+  bool MatchesDomain(const std::string& domain);
+
+  const api::cookies::GetAll::Params::Details* details_;
+};
+
+}  // namespace cookies_helpers
+}  // namespace extensions
+
+#endif  // CHROME_BROWSER_EXTENSIONS_API_COOKIES_COOKIES_HELPERS_H_

--- a/shell/browser/extensions/api/cookies/cookies_helpers.h
+++ b/shell/browser/extensions/api/cookies/cookies_helpers.h
@@ -14,10 +14,7 @@
 #include <string>
 #include <vector>
 
-#include "shell/common/extensions/api/cookies.h"
-
 class Browser;
-class Profile;
 
 namespace base {
 class ListValue;

--- a/shell/browser/extensions/api/cookies/cookies_helpers.h
+++ b/shell/browser/extensions/api/cookies/cookies_helpers.h
@@ -14,11 +14,7 @@
 #include <string>
 #include <vector>
 
-#include "chrome/common/extensions/api/cookies.h"
-#include "net/cookies/canonical_cookie.h"
-#include "net/cookies/cookie_monster.h"
-#include "net/cookies/cookie_options.h"
-#include "services/network/public/mojom/cookie_manager.mojom.h"
+#include "shell/common/extensions/api/cookies.h"
 
 class Browser;
 class Profile;

--- a/shell/browser/extensions/electron_extensions_browser_api_provider.cc
+++ b/shell/browser/extensions/electron_extensions_browser_api_provider.cc
@@ -5,6 +5,7 @@
 #include "shell/browser/extensions/electron_extensions_browser_api_provider.h"
 
 #include "extensions/browser/extension_function_registry.h"
+#include "shell/browser/extensions/api/cookies/cookies_api.h"
 #include "shell/browser/extensions/api/generated_api_registration.h"
 #include "shell/browser/extensions/api/tabs/tabs_api.h"
 

--- a/shell/common/extensions/api/BUILD.gn
+++ b/shell/common/extensions/api/BUILD.gn
@@ -39,6 +39,7 @@ generated_json_strings("generated_api_json_strings") {
     "extension.json",
     "resources_private.idl",
     "tabs.json",
+    "cookies.json",
   ]
 
   configs = [ "//build/config:precompiled_headers" ]
@@ -55,6 +56,7 @@ generated_types("generated_api_types") {
   sources = [
     "resources_private.idl",
     "tabs.json",
+    "cookies.json",
   ]
   configs = [ "//build/config:precompiled_headers" ]
   schema_include_rules = "extensions/common/api:extensions::api::%(namespace)s"

--- a/shell/common/extensions/api/_api_features.json
+++ b/shell/common/extensions/api/_api_features.json
@@ -16,6 +16,11 @@
   "extension.getURL": {
     "contexts": ["blessed_extension", "unblessed_extension", "content_script"]
   },
+  "cookies": {
+    "channel": "stable",
+    "extension_types": ["extension"],
+    "contexts": ["blessed_extension"]
+  },
   "mimeHandlerViewGuestInternal": {
     "internal": true,
     "contexts": "all",

--- a/shell/common/extensions/api/cookies.json
+++ b/shell/common/extensions/api/cookies.json
@@ -1,0 +1,214 @@
+// Copyright (c) 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+[
+  {
+    "namespace": "cookies",
+    "description": "Use the <code>chrome.cookies</code> API to query and modify cookies, and to be notified when they change.",
+    "types": [
+      {
+        "id": "SameSiteStatus",
+        "type": "string",
+        "enum": ["no_restriction", "lax", "strict", "unspecified"],
+        "description": "A cookie's 'SameSite' state (https://tools.ietf.org/html/draft-west-first-party-cookies). 'no_restriction' corresponds to a cookie set with 'SameSite=None', 'lax' to 'SameSite=Lax', and 'strict' to 'SameSite=Strict'. 'unspecified' corresponds to a cookie set without the SameSite attribute."
+      },
+      {
+        "id": "Cookie",
+        "type": "object",
+        "description": "Represents information about an HTTP cookie.",
+        "properties": {
+          "name": {"type": "string", "description": "The name of the cookie."},
+          "value": {"type": "string", "description": "The value of the cookie."},
+          "domain": {"type": "string", "description": "The domain of the cookie (e.g. \"www.google.com\", \"example.com\")."},
+          "hostOnly": {"type": "boolean", "description": "True if the cookie is a host-only cookie (i.e. a request's host must exactly match the domain of the cookie)."},
+          "path": {"type": "string", "description": "The path of the cookie."},
+          "secure": {"type": "boolean", "description": "True if the cookie is marked as Secure (i.e. its scope is limited to secure channels, typically HTTPS)."},
+          "httpOnly": {"type": "boolean", "description": "True if the cookie is marked as HttpOnly (i.e. the cookie is inaccessible to client-side scripts)."},
+          "sameSite": {"$ref": "SameSiteStatus", "description": "The cookie's same-site status (i.e. whether the cookie is sent with cross-site requests)."},
+          "session": {"type": "boolean", "description": "True if the cookie is a session cookie, as opposed to a persistent cookie with an expiration date."},
+          "expirationDate": {"type": "number", "optional": true, "description": "The expiration date of the cookie as the number of seconds since the UNIX epoch. Not provided for session cookies."},
+          "storeId": {"type": "string", "description": "The ID of the cookie store containing this cookie, as provided in getAllCookieStores()."}
+        }
+      },
+      {
+        "id": "CookieStore",
+        "type": "object",
+        "description": "Represents a cookie store in the browser. An incognito mode window, for instance, uses a separate cookie store from a non-incognito window.",
+        "properties": {
+          "id": {"type": "string", "description": "The unique identifier for the cookie store."},
+          "tabIds": {"type": "array", "items": {"type": "integer"}, "description": "Identifiers of all the browser tabs that share this cookie store."}
+        }
+      },
+      {
+        "id": "OnChangedCause",
+        "type": "string",
+        "enum": ["evicted", "expired", "explicit", "expired_overwrite", "overwrite"],
+        "description": "The underlying reason behind the cookie's change. If a cookie was inserted, or removed via an explicit call to \"chrome.cookies.remove\", \"cause\" will be \"explicit\". If a cookie was automatically removed due to expiry, \"cause\" will be \"expired\". If a cookie was removed due to being overwritten with an already-expired expiration date, \"cause\" will be set to \"expired_overwrite\".  If a cookie was automatically removed due to garbage collection, \"cause\" will be \"evicted\".  If a cookie was automatically removed due to a \"set\" call that overwrote it, \"cause\" will be \"overwrite\". Plan your response accordingly."
+      }
+    ],
+    "functions": [
+      {
+        "name": "get",
+        "type": "function",
+        "description": "Retrieves information about a single cookie. If more than one cookie of the same name exists for the given URL, the one with the longest path will be returned. For cookies with the same path length, the cookie with the earliest creation time will be returned.",
+        "parameters": [
+          {
+            "type": "object",
+            "name": "details",
+            "description": "Details to identify the cookie being retrieved.",
+            "properties": {
+              "url": {"type": "string", "description": "The URL with which the cookie to retrieve is associated. This argument may be a full URL, in which case any data following the URL path (e.g. the query string) is simply ignored. If host permissions for this URL are not specified in the manifest file, the API call will fail."},
+              "name": {"type": "string", "description": "The name of the cookie to retrieve."},
+              "storeId": {"type": "string", "optional": true, "description": "The ID of the cookie store in which to look for the cookie. By default, the current execution context's cookie store will be used."}
+            }
+          },
+          {
+            "type": "function",
+            "name": "callback",
+            "parameters": [
+              {
+                "name": "cookie", "$ref": "Cookie", "optional": true, "description": "Contains details about the cookie. This parameter is null if no such cookie was found."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "getAll",
+        "type": "function",
+        "description": "Retrieves all cookies from a single cookie store that match the given information.  The cookies returned will be sorted, with those with the longest path first.  If multiple cookies have the same path length, those with the earliest creation time will be first.",
+        "parameters": [
+          {
+            "type": "object",
+            "name": "details",
+            "description": "Information to filter the cookies being retrieved.",
+            "properties": {
+              "url": {"type": "string", "optional": true, "description": "Restricts the retrieved cookies to those that would match the given URL."},
+              "name": {"type": "string", "optional": true, "description": "Filters the cookies by name."},
+              "domain": {"type": "string", "optional": true, "description": "Restricts the retrieved cookies to those whose domains match or are subdomains of this one."},
+              "path": {"type": "string", "optional": true, "description": "Restricts the retrieved cookies to those whose path exactly matches this string."},
+              "secure": {"type": "boolean", "optional": true, "description": "Filters the cookies by their Secure property."},
+              "session": {"type": "boolean", "optional": true, "description": "Filters out session vs. persistent cookies."},
+              "storeId": {"type": "string", "optional": true, "description": "The cookie store to retrieve cookies from. If omitted, the current execution context's cookie store will be used."}
+            }
+          },
+          {
+            "type": "function",
+            "name": "callback",
+            "parameters": [
+              {
+                "name": "cookies", "type": "array", "items": {"$ref": "Cookie"}, "description": "All the existing, unexpired cookies that match the given cookie info."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "set",
+        "type": "function",
+        "description": "Sets a cookie with the given cookie data; may overwrite equivalent cookies if they exist.",
+        "parameters": [
+          {
+            "type": "object",
+            "name": "details",
+            "description": "Details about the cookie being set.",
+            "properties": {
+              "url": {"type": "string", "description": "The request-URI to associate with the setting of the cookie. This value can affect the default domain and path values of the created cookie. If host permissions for this URL are not specified in the manifest file, the API call will fail."},
+              "name": {"type": "string", "optional": true, "description": "The name of the cookie. Empty by default if omitted."},
+              "value": {"type": "string", "optional": true, "description": "The value of the cookie. Empty by default if omitted."},
+              "domain": {"type": "string", "optional": true, "description": "The domain of the cookie. If omitted, the cookie becomes a host-only cookie."},
+              "path": {"type": "string", "optional": true, "description": "The path of the cookie. Defaults to the path portion of the url parameter."},
+              "secure": {"type": "boolean", "optional": true, "description": "Whether the cookie should be marked as Secure. Defaults to false."},
+              "httpOnly": {"type": "boolean", "optional": true, "description": "Whether the cookie should be marked as HttpOnly. Defaults to false."},
+              "sameSite": {"$ref": "SameSiteStatus", "optional": true, "description": "The cookie's same-site status. Defaults to \"unspecified\", i.e., if omitted, the cookie is set without specifying a SameSite attribute."},
+              "expirationDate": {"type": "number", "optional": true, "description": "The expiration date of the cookie as the number of seconds since the UNIX epoch. If omitted, the cookie becomes a session cookie."},
+              "storeId": {"type": "string", "optional": true, "description": "The ID of the cookie store in which to set the cookie. By default, the cookie is set in the current execution context's cookie store."}
+            }
+          },
+          {
+            "type": "function",
+            "name": "callback",
+            "optional": true,
+            "min_version": "11.0.674.0",
+            "parameters": [
+              {
+                "name": "cookie", "$ref": "Cookie", "optional": true, "description": "Contains details about the cookie that's been set.  If setting failed for any reason, this will be \"null\", and \"chrome.runtime.lastError\" will be set."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "remove",
+        "type": "function",
+        "description": "Deletes a cookie by name.",
+        "parameters": [
+          {
+            "type": "object",
+            "name": "details",
+            "description": "Information to identify the cookie to remove.",
+            "properties": {
+              "url": {"type": "string", "description": "The URL associated with the cookie. If host permissions for this URL are not specified in the manifest file, the API call will fail."},
+              "name": {"type": "string", "description": "The name of the cookie to remove."},
+              "storeId": {"type": "string", "optional": true, "description": "The ID of the cookie store to look in for the cookie. If unspecified, the cookie is looked for by default in the current execution context's cookie store."}
+            }
+          },
+          {
+            "type": "function",
+            "name": "callback",
+            "optional": true,
+            "min_version": "11.0.674.0",
+            "parameters": [
+              {
+                "name": "details",
+                "type": "object",
+                "description": "Contains details about the cookie that's been removed.  If removal failed for any reason, this will be \"null\", and \"chrome.runtime.lastError\" will be set.",
+                "optional": true,
+                "properties": {
+                  "url": {"type": "string", "description": "The URL associated with the cookie that's been removed."},
+                  "name": {"type": "string", "description": "The name of the cookie that's been removed."},
+                  "storeId": {"type": "string", "description": "The ID of the cookie store from which the cookie was removed."}
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "getAllCookieStores",
+        "type": "function",
+        "description": "Lists all existing cookie stores.",
+        "parameters": [
+          {
+            "type": "function",
+            "name": "callback",
+            "parameters": [
+              {
+                "name": "cookieStores", "type": "array", "items": {"$ref": "CookieStore"}, "description": "All the existing cookie stores."
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "events": [
+      {
+        "name": "onChanged",
+        "type": "function",
+        "description": "Fired when a cookie is set or removed. As a special case, note that updating a cookie's properties is implemented as a two step process: the cookie to be updated is first removed entirely, generating a notification with \"cause\" of \"overwrite\" .  Afterwards, a new cookie is written with the updated values, generating a second notification with \"cause\" \"explicit\".",
+        "parameters": [
+          {
+            "type": "object",
+            "name": "changeInfo",
+            "properties": {
+              "removed": {"type": "boolean", "description": "True if a cookie was removed."},
+              "cookie": {"$ref": "Cookie", "description": "Information about the cookie that was set or removed."},
+              "cause": {"min_version": "12.0.707.0", "$ref": "OnChangedCause", "description": "The underlying reason behind the cookie's change."}
+            }
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
#### Description of Change
I have no idea what I'm doing here, but I hope this will help in working on `chrome.cookies` API.

Ref #19447 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes