### PR TITLE
docs: Added a note about chromium logs on the debugging page

### DIFF
--- a/docs/tutorial/application-debugging.md
+++ b/docs/tutorial/application-debugging.md
@@ -43,20 +43,6 @@ If the V8 context crashes, the DevTools will display this message.
 
 `DevTools was disconnected from the page. Once page is reloaded, DevTools will automatically reconnect.`
 
-Chromium logs can be enabled via an environment variable.
-
-POSIX shell example:
-
-```sh
-$ export ELECTRON_ENABLE_LOGGING=true
-$ electron
-```
-
-Windows console example:
-
-```powershell
-> set ELECTRON_ENABLE_LOGGING=true
-> electron
-```
+Chromium logs can be enabled via the `ELECTRON_ENABLE_LOGGING` environment variable. For more information, see the [environment variables documentation](https://www.electronjs.org/docs/api/environment-variables#electron_enable_logging). 
 
 Alternatively, the command line argument `--enable-logging` can be passed. More information is available in the [command line switches documentation](https://www.electronjs.org/docs/api/command-line-switches#--enable-logging).

--- a/docs/tutorial/application-debugging.md
+++ b/docs/tutorial/application-debugging.md
@@ -43,6 +43,6 @@ If the V8 context crashes, the DevTools will display this message.
 
 `DevTools was disconnected from the page. Once page is reloaded, DevTools will automatically reconnect.`
 
-Chromium logs can be enabled via the `ELECTRON_ENABLE_LOGGING` environment variable. For more information, see the [environment variables documentation](https://www.electronjs.org/docs/api/environment-variables#electron_enable_logging). 
+Chromium logs can be enabled via the `ELECTRON_ENABLE_LOGGING` environment variable. For more information, see the [environment variables documentation](https://www.electronjs.org/docs/api/environment-variables#electron_enable_logging).
 
 Alternatively, the command line argument `--enable-logging` can be passed. More information is available in the [command line switches documentation](https://www.electronjs.org/docs/api/command-line-switches#--enable-logging).

--- a/docs/tutorial/application-debugging.md
+++ b/docs/tutorial/application-debugging.md
@@ -36,3 +36,27 @@ For more information, see the [Debugging the Main Process documentation][main-de
 [node-inspect]: https://nodejs.org/en/docs/inspector/
 [devtools]: https://developer.chrome.com/devtools
 [main-debug]: ./debugging-main-process.md
+
+## V8 Crashes
+
+If the V8 context crashes, the DevTools will display this message.
+
+`DevTools was disconnected from the page. Once page is reloaded, DevTools will automatically reconnect.`
+
+Chromium logs can be enabled via an environment variable.
+
+POSIX shell example:
+
+```sh
+$ export ELECTRON_ENABLE_LOGGING=true
+$ electron
+```
+
+Windows console example:
+
+```powershell
+> set ELECTRON_ENABLE_LOGGING=true
+> electron
+```
+
+Alternatively, the command line argument `--enable-logging` can be passed. More information is available in the [command line switches documentation](https://www.electronjs.org/docs/api/command-line-switches#--enable-logging).


### PR DESCRIPTION
#### Description of Change
Added documentation of the `ELECTRON_ENABLE_LOGGING` environment variable in the application debugging page.

I'm not sure if this is the correct terminology, is v8 the thing that's crashing in this instance? Is it Chromium? 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added documentation of ELECTRON_ENABLE_LOGGING environment variable to the application debugging page.
