### PR TITLE
docs: add documentation on case insensitive dictionary hosting

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -481,7 +481,8 @@ setting with the current OS locale.  This setting is persisted across restarts.
 By default Electron will download hunspell dictionaries from the Chromium CDN.  If you want to override this
 behavior you can use this API to point the dictionary downloader at your own hosted version of the hunspell
 dictionaries.  We publish a `hunspell_dictionaries.zip` file with each release which contains the files you need
-to host here.
+to host here, the file server must be **case insensitive** you must upload each file twice, once with the case it
+has in the ZIP file and once with the filename as all lower case.
 
 If the files present in `hunspell_dictionaries.zip` are available at `https://example.com/dictionaries/language-code.bdic`
 then you should call this api with `ses.setSpellCheckerDictionaryDownloadURL('https://example.com/dictionaries/')`.  Please


### PR DESCRIPTION
Documenting a gotcha with the spellchecker dictionaries

Closes #22482

Notes: no-notes