### PR TITLE
fix: properly forward properties to webview

### DIFF
--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -4,7 +4,7 @@ const { webContents } = require('electron')
 const { ipcMainInternal } = require('@electron/internal/browser/ipc-main-internal')
 const ipcMainUtils = require('@electron/internal/browser/ipc-main-internal-utils')
 const parseFeaturesString = require('@electron/internal/common/parse-features-string')
-const { syncMethods, asyncMethods } = require('@electron/internal/common/web-view-methods')
+const { syncMethods, asyncMethods, properties } = require('@electron/internal/common/web-view-methods')
 const { serialize } = require('@electron/internal/common/type-utils')
 
 // Doesn't exist in early initialization.
@@ -382,6 +382,24 @@ handleMessageSync('ELECTRON_GUEST_VIEW_MANAGER_CALL', function (event, guestInst
   }
 
   return guest[method](...args)
+})
+
+handleMessageSync('ELECTRON_GUEST_VIEW_MANAGER_PROPERTY_GET', function (event, guestInstanceId, property) {
+  const guest = getGuestForWebContents(guestInstanceId, event.sender)
+  if (!properties.has(property)) {
+    throw new Error(`Invalid property: ${property}`)
+  }
+
+  return guest[property]
+})
+
+handleMessageSync('ELECTRON_GUEST_VIEW_MANAGER_PROPERTY_SET', function (event, guestInstanceId, property, val) {
+  const guest = getGuestForWebContents(guestInstanceId, event.sender)
+  if (!properties.has(property)) {
+    throw new Error(`Invalid property: ${property}`)
+  }
+
+  guest[property] = val
 })
 
 handleMessage('ELECTRON_GUEST_VIEW_MANAGER_CAPTURE_PAGE', async function (event, guestInstanceId, args) {

--- a/lib/common/web-view-methods.ts
+++ b/lib/common/web-view-methods.ts
@@ -50,6 +50,14 @@ export const syncMethods = new Set([
   'setZoomLevel'
 ])
 
+export const properties = new Set([
+  'audioMuted',
+  'userAgent',
+  'zoomLevel',
+  'zoomFactor',
+  'frameRate'
+])
+
 export const asyncMethods = new Set([
   'loadURL',
   'executeJavaScript',


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/20679

Adds handling for properties so that they are properly forwarded to webviews. Tested with [this gist](https://gist.github.com/HaNdTriX/e80bbbc93d80be9889d8aceb4b8c20a2).

cc @MarshallOfSound @zcbenz @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes some properties not working in webview tags.
