### PR TITLE
build: we moved goma to build-tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,7 +461,7 @@ step-electron-maybe-chromedriver-gn-gen: &step-electron-maybe-chromedriver-gn-ge
       cd src
       if [ "$TARGET_ARCH" == "arm" ] || [ "$TARGET_ARCH" == "arm64" ]; then
         if [ "$USE_GOMA" == "true" ]; then
-          gn gen out/chromedriver --args="import(\"$GN_CONFIG\") import(\"//electron/build/args/goma.gn\") is_component_ffmpeg=false proprietary_codecs=false $GN_EXTRA_ARGS $GN_BUILDFLAG_ARGS"
+          gn gen out/chromedriver --args="import(\"$GN_CONFIG\") import(\"$GN_GOMA_FILE\") is_component_ffmpeg=false proprietary_codecs=false $GN_EXTRA_ARGS $GN_BUILDFLAG_ARGS"
         else
           gn gen out/chromedriver --args="import(\"$GN_CONFIG\") cc_wrapper=\"$SCCACHE_PATH\" is_component_ffmpeg=false proprietary_codecs=false $GN_EXTRA_ARGS $GN_BUILDFLAG_ARGS"
         fi
@@ -576,7 +576,7 @@ step-ffmpeg-gn-gen: &step-ffmpeg-gn-gen
     command: |
       cd src
       if [ "$USE_GOMA" == "true" ]; then
-        gn gen out/ffmpeg --args="import(\"//electron/build/args/ffmpeg.gn\") import(\"//electron/build/args/goma.gn\") $GN_EXTRA_ARGS"
+        gn gen out/ffmpeg --args="import(\"//electron/build/args/ffmpeg.gn\") import(\"$GN_GOMA_FILE\") $GN_EXTRA_ARGS"
       else
         gn gen out/ffmpeg --args="import(\"//electron/build/args/ffmpeg.gn\") cc_wrapper=\"$SCCACHE_PATH\" $GN_EXTRA_ARGS"
       fi

--- a/build/args/goma.gn
+++ b/build/args/goma.gn
@@ -1,2 +1,0 @@
-goma_dir = rebase_path("//electron/external_binaries/goma")
-use_goma = true

--- a/docs/development/goma.md
+++ b/docs/development/goma.md
@@ -5,49 +5,37 @@
 
 Electron has a deployment of a custom Goma Backend that we make available to
 all Electron Maintainers.  See the [Access](#access) section below for details
-on authentication.
+on authentication.  There is also a `cache-only` goma endpoint that will be
+used by default if you do not have authentication.  Requests to Cache Only
+Goma will not hit our cluster but will read from our cache and should result
+in significantly faster build times.
 
 ## Enabling Goma
 
-Currently Electron Goma supports Windows, Linux, and macOS.  If you are
-on a supported platform you can enable goma by importing the `goma.gn` config
-file when using `gn`.
+Currently the only supported way to use Goma is to use our [Build Tools](https://github.com/electron/build-tools).
+You shouldn't have to do anything extra to use Goma once you are using `build-tools`
+so we reccomend just setting those up.
 
-```bash
-gn gen out/Testing --args="import(\"//electron/build/args/testing.gn\") import(\"//electron/build/args/goma.gn\")"
-```
-
-You must ensure that you do not have `cc_wrapper` configured, this means you
-can't use `sccache` or similar technology.
-
-Before you can use goma to build Electron you need to authenticate against
-the Goma service.  You only need to do this once per-machine.
-
-```bash
-cd electron/external_binaries/goma
-./goma_auth.py login
-```
-
-Once authenticated you need to make sure the goma daemon is running on your
-machine.
-
-```bash
-cd electron/external_binaries/goma
-./goma_ctl.py ensure_start
-```
+If you are a maintainer and have access to our cluster please ensure that you run
+`e init` with `--goma=cluster` in order to configure build-tools to use
+the goma cluster.  If you have an existing config you can just set `"goma": "cluster"`\
+in your config file.
 
 ## Building with Goma
 
 When you are using Goma you can run `ninja` with a substantially higher `j`
 value than would normally be supported by your machine.
 
-Please do not set a value higher than **300** on Windows or Linux and
-**80** on macOS, we monitor the goma system and users found to be abusing
+Please do not set a value higher than **200** on Windows or Linux and
+**50** on macOS, we monitor the goma system and users found to be abusing
 it with unreasonable concurrency will be de-activated.
 
 ```bash
 ninja -C out/Testing electron -j 200
 ```
+
+If you're using `build-tools`, appropriate `-j` values will automatically
+be used for you.
 
 ## Monitoring Goma
 
@@ -56,8 +44,16 @@ machine you can monitor compile jobs as they flow through the goma system.
 
 ## Access
 
-For security and cost reasons access to Electron Goma is currently restricted
+For security and cost reasons access to Electrons Goma Cluster is currently restricted
 to Electron Maintainers.  If you want access please head to `#access-requests` in
 Slack and ping `@goma-squad` to ask for access.  Please be aware that being a
 maintainer does not *automatically* grant access and access is determined on a
 case by case basis.
+
+## Goma is Slow / Down?
+
+We have automated monitoring of our goma cluster and cache at https://status.notgoma.com
+
+We do not provide support for usage of Goma and any issues raised asking for help / having
+issues will _probably_ be closed without much reason, we do not have the capacity to handle
+that kind of support.

--- a/docs/development/goma.md
+++ b/docs/development/goma.md
@@ -5,20 +5,19 @@
 
 Electron has a deployment of a custom Goma Backend that we make available to
 all Electron Maintainers.  See the [Access](#access) section below for details
-on authentication.  There is also a `cache-only` goma endpoint that will be
-used by default if you do not have authentication.  Requests to Cache Only
-Goma will not hit our cluster but will read from our cache and should result
+on authentication.  There is also a `cache-only` Goma endpoint that will be
+used by default if you do not have credentials.  Requests to the cache-only
+Goma will not hit our cluster, but will read from our cache and should result
 in significantly faster build times.
 
 ## Enabling Goma
 
 Currently the only supported way to use Goma is to use our [Build Tools](https://github.com/electron/build-tools).
-You shouldn't have to do anything extra to use Goma once you are using `build-tools`
-so we reccomend just setting those up.
+Goma configuration is automatically included when you set up `build-tools`.
 
-If you are a maintainer and have access to our cluster please ensure that you run
-`e init` with `--goma=cluster` in order to configure build-tools to use
-the goma cluster.  If you have an existing config you can just set `"goma": "cluster"`\
+If you are a maintainer and have access to our cluster, please ensure that you run
+`e init` with `--goma=cluster` in order to configure `build-tools` to use
+the Goma cluster.  If you have an existing config, you can just set `"goma": "cluster"`
 in your config file.
 
 ## Building with Goma
@@ -27,7 +26,7 @@ When you are using Goma you can run `ninja` with a substantially higher `j`
 value than would normally be supported by your machine.
 
 Please do not set a value higher than **200** on Windows or Linux and
-**50** on macOS, we monitor the goma system and users found to be abusing
+**50** on macOS. We monitor Goma system usage, and users found to be abusing
 it with unreasonable concurrency will be de-activated.
 
 ```bash
@@ -44,15 +43,15 @@ machine you can monitor compile jobs as they flow through the goma system.
 
 ## Access
 
-For security and cost reasons access to Electrons Goma Cluster is currently restricted
+For security and cost reasons, access to Electron's Goma cluster is currently restricted
 to Electron Maintainers.  If you want access please head to `#access-requests` in
 Slack and ping `@goma-squad` to ask for access.  Please be aware that being a
 maintainer does not *automatically* grant access and access is determined on a
 case by case basis.
 
-## Goma is Slow / Down?
+## Uptime / Support
 
-We have automated monitoring of our goma cluster and cache at https://status.notgoma.com
+We have automated monitoring of our Goma cluster and cache at https://status.notgoma.com
 
 We do not provide support for usage of Goma and any issues raised asking for help / having
 issues will _probably_ be closed without much reason, we do not have the capacity to handle

--- a/script/external-binaries.json
+++ b/script/external-binaries.json
@@ -30,21 +30,6 @@
       "name": "sccache-win32-x64.zip",
       "platform": "win32",
       "sha": "b6a20fd1c2026f3792e7286bc768a7ebc261847b76449b49f55455e1f841fecd"
-    },
-    {
-      "name": "goma-win.zip",
-      "platform": "win32",
-      "sha": "f97c88aa5d49395ae20387b6329ad406fd019f5fb4aac4ba639ca928b7151f6b"
-    },
-    {
-      "name": "goma-linux.tgz",
-      "platform": "linux",
-      "sha": "1cb3099a40f6200ae57216efa26af795c587b6ac7ae97955d1078d0b1e3011a6"
-    },
-    {
-      "name": "goma-mac.tgz",
-      "platform": "darwin",
-      "sha": "da1e7de82fbf3b99f1a9d0f9bf51b25e75e8778fec180deb72cff873813d717c"
     }
   ]
 }


### PR DESCRIPTION
Remove the `gn` file for goma as we now use / update goma through `build-tools` itself so we can have better control over the build environment and update goma retroactively.

Notes: no-notes