### PR TITLE
docs: clean up dark mode related docs

### DIFF
--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -369,14 +369,6 @@ Returns `String` - Can be `dark`, `light` or `unknown`.
 Gets the macOS appearance setting that is currently applied to your application,
 maps to [NSApplication.effectiveAppearance](https://developer.apple.com/documentation/appkit/nsapplication/2967171-effectiveappearance?language=objc)
 
-Please note that until Electron is built targeting the 10.14 SDK, your application's
-`effectiveAppearance` will default to 'light' and won't inherit the OS preference. In
-the interim, in order for your application to inherit the OS preference, you must set the
-`NSRequiresAquaSystemAppearance` key in your app's `Info.plist` to `false`.  If you are
-using [Electron Packager][electron-packager] or [Electron Forge][electron-forge], set the
-`darwinDarkModeSupport` packager option to `true`.  See the [Electron Packager
-API][packager-darwindarkmode-api] for more details.
-
 **[Deprecated](modernization/property-updates.md)**
 
 ### `systemPreferences.getAppLevelAppearance()` _macOS_ _Deprecated_
@@ -478,15 +470,3 @@ A `String` property that can be `dark`, `light` or `unknown`.
 
 Returns the macOS appearance setting that is currently applied to your application,
 maps to [NSApplication.effectiveAppearance](https://developer.apple.com/documentation/appkit/nsapplication/2967171-effectiveappearance?language=objc)
-
-Please note that until Electron is built targeting the 10.14 SDK, your application's
-`effectiveAppearance` will default to 'light' and won't inherit the OS preference. In
-the interim, in order for your application to inherit the OS preference, you must set the
-`NSRequiresAquaSystemAppearance` key in your app's `Info.plist` to `false`.  If you are
-using [Electron Packager][electron-packager] or [Electron Forge][electron-forge], set the
-`darwinDarkModeSupport` packager option to `true`.  See the [Electron Packager
-API][packager-darwindarkmode-api] for more details.
-
-[electron-forge]: https://www.electronforge.io/
-[electron-packager]: https://github.com/electron/electron-packager
-[packager-darwindarkmode-api]: https://electron.github.io/electron-packager/master/interfaces/electronpackager.options.html#darwindarkmodesupport

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -371,11 +371,11 @@ maps to [NSApplication.effectiveAppearance](https://developer.apple.com/document
 
 Please note that until Electron is built targeting the 10.14 SDK, your application's
 `effectiveAppearance` will default to 'light' and won't inherit the OS preference. In
-the interim in order for your application to inherit the OS preference you must set the
-`NSRequiresAquaSystemAppearance` key in your apps `Info.plist` to `false`.  If you are
-using `electron-packager` or `electron-forge` just set the `enableDarwinDarkMode`
-packager option to `true`.  See the [Electron Packager API](https://github.com/electron/electron-packager/blob/master/docs/api.md#darwindarkmodesupport)
-for more details.
+the interim, in order for your application to inherit the OS preference, you must set the
+`NSRequiresAquaSystemAppearance` key in your app's `Info.plist` to `false`.  If you are
+using [Electron Packager][electron-packager] or [Electron Forge][electron-forge], set the
+`darwinDarkModeSupport` packager option to `true`.  See the [Electron Packager
+API][packager-darwindarkmode-api] for more details.
 
 **[Deprecated](modernization/property-updates.md)**
 
@@ -481,8 +481,12 @@ maps to [NSApplication.effectiveAppearance](https://developer.apple.com/document
 
 Please note that until Electron is built targeting the 10.14 SDK, your application's
 `effectiveAppearance` will default to 'light' and won't inherit the OS preference. In
-the interim in order for your application to inherit the OS preference you must set the
-`NSRequiresAquaSystemAppearance` key in your apps `Info.plist` to `false`.  If you are
-using `electron-packager` or `electron-forge` just set the `enableDarwinDarkMode`
-packager option to `true`.  See the [Electron Packager API](https://github.com/electron/electron-packager/blob/master/docs/api.md#darwindarkmodesupport)
-for more details.
+the interim, in order for your application to inherit the OS preference, you must set the
+`NSRequiresAquaSystemAppearance` key in your app's `Info.plist` to `false`.  If you are
+using [Electron Packager][electron-packager] or [Electron Forge][electron-forge], set the
+`darwinDarkModeSupport` packager option to `true`.  See the [Electron Packager
+API][packager-darwindarkmode-api] for more details.
+
+[electron-forge]: https://www.electronforge.io/
+[electron-packager]: https://github.com/electron/electron-packager
+[packager-darwindarkmode-api]: https://electron.github.io/electron-packager/master/interfaces/electronpackager.options.html#darwindarkmodesupport

--- a/docs/tutorial/mojave-dark-mode-guide.md
+++ b/docs/tutorial/mojave-dark-mode-guide.md
@@ -14,10 +14,11 @@ to automate the `Info.plist` changes during app build time.
 ## Automatically updating the native interfaces
 
 "Native Interfaces" include the file picker, window border, dialogs, context menus and more; basically,
-anything where the UI comes from macOS and not your app. The default behavior as of Electron 7.0.0
-is to opt in to this automatic theming from the OS. If you wish to opt out, you must set the
-`NSRequiresAquaSystemAppearance` key in the `Info.plist` file to `true`.  Please note that once
-Electron starts building against the 10.14 SDK, it will not be possible for you to opt out of this theming.
+anything where the UI comes from macOS and not your app. As of Electron 7.0.0, the default behavior
+is to opt in to this automatic theming from the OS. If you wish to opt out and are using Electron
+&gt; 8.0.0, you must set the `NSRequiresAquaSystemAppearance` key in the `Info.plist` file to `true`.
+Please note that Electron 8.0.0 and above will not let your opt out of this theming, due to the use
+of the macOS 10.14 SDK.
 
 ## Automatically updating your own interfaces
 

--- a/docs/tutorial/mojave-dark-mode-guide.md
+++ b/docs/tutorial/mojave-dark-mode-guide.md
@@ -1,29 +1,39 @@
-# Mojave Dark Mode
+# Supporting macOS Dark Mode
 
 In macOS 10.14 Mojave, Apple introduced a new [system-wide dark mode](https://developer.apple.com/design/human-interface-guidelines/macos/visual-design/dark-mode/)
-for all macOS computers.  If your app does have a dark mode, you can make your Electron app
-follow the system-wide dark mode setting using [the nativeTheme api](../api/native-theme.md).
+for all macOS computers.  If your Electron app has a dark mode, you can make it follow the
+system-wide dark mode setting using [the `nativeTheme` api](../api/native-theme.md).
 
-In macOS 10.15 Catalina, Apple introduced a new "automatic" dark mode option for all macOS computers. In order
-for the `nativeTheme.shouldUseDarkColors` and `Tray` APIs to work correctly in this mode on Catalina you need to either have `NSRequiresAquaSystemAppearance` set to `false` in your `Info.plist` file or be on Electron `>=7.0.0`.
+In macOS 10.15 Catalina, Apple introduced a new "automatic" dark mode option for all macOS computers.
+In order for the `nativeTheme.shouldUseDarkColors` and `Tray` APIs to work correctly in this mode on
+Catalina, you need to either have `NSRequiresAquaSystemAppearance` set to `false` in your
+`Info.plist` file, or be on Electron `>=7.0.0`. Both [Electron Packager][electron-packager] and
+[Electron Forge][electron-forge] have a [`darwinDarkModeSupport` option][packager-darwindarkmode-api]
+to automate the `Info.plist` changes during app build time.
 
 ## Automatically updating the native interfaces
 
-"Native Interfaces" include the file picker, window border, dialogs, context menus and more; basically anything where
-the UI comes from macOS and not your app.  The default behavior as of Electron 7.0.0 is to opt in to this automatic
-theming from the OS.  If you wish to opt out you must set the `NSRequiresAquaSystemAppearance` key in the `Info.plist` file
-to `true`.  Please note that once Electron starts building against the 10.14 SDK it will not be possible for you to opt
-out of this theming.
+"Native Interfaces" include the file picker, window border, dialogs, context menus and more; basically,
+anything where the UI comes from macOS and not your app. The default behavior as of Electron 7.0.0
+is to opt in to this automatic theming from the OS. If you wish to opt out, you must set the
+`NSRequiresAquaSystemAppearance` key in the `Info.plist` file to `true`.  Please note that once
+Electron starts building against the 10.14 SDK, it will not be possible for you to opt out of this theming.
 
 ## Automatically updating your own interfaces
 
-If your app has its own dark mode you should toggle it on and off in sync with the system's dark mode setting.  You can do
-this by listening for the theme updated event on Electron's `nativeTheme` module.  E.g.
+If your app has its own dark mode, you should toggle it on and off in sync with the system's dark
+mode setting. You can do this by listening for the theme updated event on Electron's `nativeTheme` module.
 
-```js
+For example:
+
+```javascript
 const { nativeTheme } = require('electron')
 
 nativeTheme.on('updated', function theThemeHasChanged () {
   updateMyAppTheme(nativeTheme.shouldUseDarkColors)
 })
 ```
+
+[electron-forge]: https://www.electronforge.io/
+[electron-packager]: https://github.com/electron/electron-packager
+[packager-darwindarkmode-api]: https://electron.github.io/electron-packager/master/interfaces/electronpackager.options.html#darwindarkmodesupport


### PR DESCRIPTION
#### Description of Change

For the dark mode guide & the `systemPreferences.effectiveAppearance` docs:

* Grammar fixes
* Add links for Electron Packager & Electron Forge
* Update Packager API links, given https://github.com/electron/electron-packager/pull/1131 _(API docs moved from Markdown to TypeScript definition, & autopublishes to GitHub Pages)_

CC: @electron/wg-ecosystem 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `yarn lint:docs` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes