### PR TITLE
docs: add custom dir placeholder explainer to installation guide

### DIFF
--- a/docs/tutorial/installation.md
+++ b/docs/tutorial/installation.md
@@ -56,23 +56,32 @@ can do so by either providing a mirror or an existing cache directory.
 
 #### Mirror
 You can use environment variables to override the base URL, the path at which to
-look for Electron binaries, and the binary filename. The url used by `@electron/get`
+look for Electron binaries, and the binary filename. The URL used by `@electron/get`
 is composed as follows:
 
-```plaintext
+```javascript
 url = ELECTRON_MIRROR + ELECTRON_CUSTOM_DIR + '/' + ELECTRON_CUSTOM_FILENAME
 ```
 
-For instance, to use the China mirror:
+For instance, to use the China CDN mirror:
 
-```plaintext
+```shell
 ELECTRON_MIRROR="https://cdn.npm.taobao.org/dist/electron/"
 ```
 
 By default, `ELECTRON_CUSTOM_DIR` is set to `v$VERSION`. To change the format,
 use the `{{ version }}` placeholder. For example, `version-{{ version }}`
 resolves to `version-5.0.0`, `{{ version }}` resolves to `5.0.0`, and
-`v{{ version }}` is equivalent to the default.
+`v{{ version }}` is equivalent to the default. As a more concrete example, to
+use the China non-CDN mirror:
+
+```shell
+ELECTRON_MIRROR="https://npm.taobao.org/mirrors/electron/"
+ELECTRON_CUSTOM_DIR="{{ version }}"
+```
+
+The above configuration will download from URLs such as
+`https://npm.taobao.org/mirrors/electron/8.0.0/electron-v8.0.0-linux-x64.zip`.
 
 #### Cache
 Alternatively, you can override the local cache. `@electron/get` will cache

--- a/docs/tutorial/installation.md
+++ b/docs/tutorial/installation.md
@@ -69,6 +69,11 @@ For instance, to use the China mirror:
 ELECTRON_MIRROR="https://cdn.npm.taobao.org/dist/electron/"
 ```
 
+By default, `ELECTRON_CUSTOM_DIR` is set to `v$VERSION`. To change the format,
+use the `{{ version }}` placeholder. For example, `version-{{ version }}`
+resolves to `version-5.0.0`, `{{ version }}` resolves to `5.0.0`, and
+`v{{ version }}` is equivalent to the default.
+
 #### Cache
 Alternatively, you can override the local cache. `@electron/get` will cache
 downloaded binaries in a local directory to not stress your network. You can use


### PR DESCRIPTION
#### Description of Change

Now that electron/get#143 has been released, the user docs for installing Electron should explain how it works for mirrors.

CC: @electron/wg-ecosystem 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `yarn lint:docs` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
