### PR TITLE
fix: do not reposition traffic lights when fullscreened

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -517,6 +517,8 @@ void NativeWindowMac::RepositionTrafficLights() {
   if (!traffic_light_position_.x() && !traffic_light_position_.y()) {
     return;
   }
+  if (IsFullscreen())
+    return;
 
   NSWindow* window = window_;
   NSButton* close = [window standardWindowButton:NSWindowCloseButton];


### PR DESCRIPTION
As in notes

Notes: updating the document title while in fullscreen with custom traffic light positions no longer makes the traffic lights invisible