### PR TITLE
build: fix macOS build on 8.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,12 +65,12 @@ machine-linux-2xlarge: &machine-linux-2xlarge
 
 machine-mac: &machine-mac
   macos:
-    xcode: "11.1.0"
+    xcode: "10.3.0"
 
 machine-mac-large: &machine-mac-large
   resource_class: large
   macos:
-    xcode: "11.1.0"
+    xcode: "10.3.0"
 
 # Build configurations options.
 env-debug-build: &env-debug-build

--- a/shell/browser/mac/electron_application_delegate.mm
+++ b/shell/browser/mac/electron_application_delegate.mm
@@ -33,9 +33,8 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
   // not have fatal OOM occur while this method executes, but it is better
   // than crashing when using IME.
   base::allocator::SetCallNewHandlerOnMallocFailure(false);
-  g_swizzle_imk_input_session->InvokeOriginal<
-      void, NSRange, long long, void (^)(void)>(  // NOLINT(runtime/int)
-      self, _cmd, range, attributes, block);
+  g_swizzle_imk_input_session->GetOriginalImplementation()(self, _cmd, range,
+                                                           attributes, block);
   base::allocator::SetCallNewHandlerOnMallocFailure(true);
 }
 @end


### PR DESCRIPTION
Tests on `8-x-y` are failing because it was upgraded to a new SDK while the Chromium version in `8-x-y` was not really ready for it https://github.com/electron/electron/commit/69598ae5c68af53f6b80f023bc8e492b91e85858.

```
process module process.getProcessMemoryInfo() resolves promise successfully with valid data - resolves promise successfully with valid data
/Users/distiller/project/src/electron/spec/api-process-spec.js
AssertionError: expected 0 to be above 0
```

I can't find how the change got into the `8-x-y` branch, seems to be an accidental push. This PR reverts the SDK changes.

Notes: no-notes