### PR TITLE
docs: document the openItem -> openPath breaking change

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -84,6 +84,11 @@ In Electron 9.0, the old serialization algorithm has been removed, and sending
 such non-serializable objects will now throw an "object could not be cloned"
 error.
 
+### `shell.openItem` --> `shell.openPath`
+
+The `shell.openItem` API has been replaced with an asyncronous `shell.openPath` API.
+You can see the original API proposal and reasoning [here](https://github.com/electron/governance/blob/master/wg-api/spec-documents/shell-openitem.md)
+
 ## Planned Breaking API Changes (8.0)
 
 ### Values sent over IPC are now serialized with Structured Clone Algorithm

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -86,8 +86,8 @@ error.
 
 ### `shell.openItem` --> `shell.openPath`
 
-The `shell.openItem` API has been replaced with an asyncronous `shell.openPath` API.
-You can see the original API proposal and reasoning [here](https://github.com/electron/governance/blob/master/wg-api/spec-documents/shell-openitem.md)
+The `shell.openItem` API has been replaced with an asynchronous `shell.openPath` API.
+You can see the original API proposal and reasoning [here](https://github.com/electron/governance/blob/master/wg-api/spec-documents/shell-openitem.md).
 
 ## Planned Breaking API Changes (8.0)
 


### PR DESCRIPTION
Added info on a breaking change to our breaking changes doc, it was where I went to look for it and it wasn't there 🤷‍♂ 

Notes: no-notes