### PR TITLE
chore: lint docs on precommit

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
       "git add"
     ],
     "*.md": [
-      "remark -qf"
+      "npm run lint:docs"
     ],
     "*.{gn,gni}": [
       "npm run gn-check",


### PR DESCRIPTION
It's annoying to wait until CI to find out i didn't put spaces around my curly brackets in an example snippet

Notes: none