### PR TITLE
docs: update type and description of IncomingMessage.headers

### DIFF
--- a/docs/api/incoming-message.md
+++ b/docs/api/incoming-message.md
@@ -51,7 +51,7 @@ A `String` representing the HTTP status message.
 
 #### `response.headers`
 
-An `Record<string, string | string[]>` representing the response HTTP headers. The `headers` object is
+A `Record<string, string | string[]>` representing the HTTP response headers. The `headers` object is
 formatted as follows:
 
 * All header names are lowercased.

--- a/docs/api/incoming-message.md
+++ b/docs/api/incoming-message.md
@@ -51,12 +51,17 @@ A `String` representing the HTTP status message.
 
 #### `response.headers`
 
-An `Record<string, string[]>` representing the response HTTP headers. The `headers` object is
+An `Record<string, string | string[]>` representing the response HTTP headers. The `headers` object is
 formatted as follows:
 
 * All header names are lowercased.
-* Each header name produces an array-valued property on the headers object.
-* Each header value is pushed into the array associated with its header name.
+* Duplicates of `age`, `authorization`, `content-length`, `content-type`,
+`etag`, `expires`, `from`, `host`, `if-modified-since`, `if-unmodified-since`,
+`last-modified`, `location`, `max-forwards`, `proxy-authorization`, `referer`,
+`retry-after`, `server`, or `user-agent` are discarded.
+* `set-cookie` is always an array. Duplicates are added to the array.
+* For duplicate `cookie` headers, the values are joined together with '; '.
+* For all other headers, the values are joined together with ', '.
 
 #### `response.httpVersion`
 


### PR DESCRIPTION
Fixes #22521

Updates the docs for IncomingMessage.headers to match the changes made in #17517

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed type and documentation of IncomingMessage.headers
