### PR TITLE
fix: add patch to fix linux arm build

### DIFF
--- a/patches/config.json
+++ b/patches/config.json
@@ -5,5 +5,7 @@
 
   "src/electron/patches/v8":  "src/v8",
 
-  "src/electron/patches/node": "src/third_party/electron_node"
+  "src/electron/patches/node": "src/third_party/electron_node",
+
+  "src/electron/patches/swiftshader": "src/third_party/swiftshader"
 }

--- a/patches/swiftshader/.patches
+++ b/patches/swiftshader/.patches
@@ -1,0 +1,1 @@
+marl_arm.patch

--- a/patches/swiftshader/marl_arm.patch
+++ b/patches/swiftshader/marl_arm.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Wed, 4 Mar 2020 14:23:28 -0700
+Subject: fix: linux arm build
+
+Fix Linux ARM build error caused by compiler update.
+
+This means to be a quick fix, we should choose other solution once we
+get an answer at:
+https://bugs.chromium.org/p/chromium/issues/detail?id=1058107
+
+diff --git a/third_party/marl/src/osfiber_asm_arm.S b/third_party/marl/src/osfiber_asm_arm.S
+index d276ac806..b2be5face 100644
+--- a/third_party/marl/src/osfiber_asm_arm.S
++++ b/third_party/marl/src/osfiber_asm_arm.S
+@@ -22,6 +22,7 @@
+ // x1: to
+ .text
+ .global marl_fiber_swap
++.type marl_fiber_swap, %function
+ .align 4
+ marl_fiber_swap:
+ 


### PR DESCRIPTION
Somehow the arm compiler failed to automatically set the function's symbol to `STT_FUNC`, it is probably caused by Chromium upgrading its toolchain and this problem might be gone in future, but anyway explicitly set `.type marl_fiber_swap, %function` can fix the problem for now.

We should remove this patch once it is solved in Chromium https://bugs.chromium.org/p/chromium/issues/detail?id=1058107.

Notes: no-notes