### PR TITLE
test: pass same args to v8_context_snapshot_generator with mksnapshot

### DIFF
--- a/script/verify-mksnapshot.py
+++ b/script/verify-mksnapshot.py
@@ -34,8 +34,8 @@ def main():
         context_snapshot_path = os.path.join(app_path, context_snapshot)
         gen_binary = get_binary_path('v8_context_snapshot_generator', \
                                     app_path)
-        genargs = [ gen_binary, \
-                  '--output_file={0}'.format(context_snapshot_path) ]
+        genargs = [ gen_binary ] +  mkargs[1:] + \
+                  [ '--output_file={0}'.format(context_snapshot_path) ]
         subprocess.check_call(genargs)
         print('ok v8_context_snapshot_generator successfully created ' \
               + context_snapshot)


### PR DESCRIPTION
#### Description of Change

The verify mksnapshot test sometimes fails with this error:

```
#
# Fatal error in ../../v8/src/execution/isolate.cc, line 3511
# The Isolate is incompatible with the embedded blob. This is usually caused by incorrect usage of mksnapshot. When generating custom snapshots, embedders must ensure they pass the same flags as during the V8 build process (e.g.: --turbo-instruction-scheduling).
#
```

This PR tries to fix it by passing the same args to v8_context_snapshot_generator with mksnapshot.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes