### PR TITLE
fix: destroy node platform after destroying wrappers

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -486,9 +486,6 @@ void ElectronBrowserMainParts::PostMainMessageLoopRun() {
   ui::SetX11ErrorHandlers(X11EmptyErrorHandler, X11EmptyIOErrorHandler);
 #endif
 
-  node_debugger_->Stop();
-  js_env_->OnMessageLoopDestroying();
-
 #if defined(OS_MACOSX)
   FreeAppDelegate();
 #endif
@@ -504,6 +501,11 @@ void ElectronBrowserMainParts::PostMainMessageLoopRun() {
       std::move(callback).Run();
     ++iter;
   }
+
+  // Destroy node platform after all destructors_ are executed, as they may
+  // invoke Node/V8 APIs inside them.
+  node_debugger_->Stop();
+  js_env_->OnMessageLoopDestroying();
 
   fake_browser_process_->PostMainMessageLoopRun();
 }


### PR DESCRIPTION
#### Description of Change

This fixes a crash caused by `api::WebContents`'s destructor invoking node platform functions after the node platform gets unregistered.

```
#0 0x562d3eeffeb9 base::debug::CollectStackTrace()
#1 0x562d3ee281d3 base::debug::StackTrace::StackTrace()
#2 0x562d3eeff9c5 base::debug::(anonymous namespace)::StackDumpSignalHandler()
#3 0x7f29ccca9890 (/lib/x86_64-linux-gnu/libpthread-2.27.so+0x1288f)
#4 0x7f29c6631e97 gsignal
#5 0x7f29c6633801 abort
#6 0x562d435dd092 node::Abort()
#7 0x562d435dcea1 node::Assert()
node::NodePlatform::GetForegroundTaskRunner()
#9 0x562d3cac8643 v8::internal::GlobalHandles::InvokeOrScheduleSecondPassPhantomCallbacks()
#10 0x562d3cac890a v8::internal::GlobalHandles::PostGarbageCollectionProcessing()
#11 0x562d3cb2b785 v8::internal::Heap::PerformGarbageCollection()
#12 0x562d3cb28bb5 v8::internal::Heap::CollectGarbage()
#13 0x562d3cb38644 v8::internal::Heap::AllocateRawWithLightRetrySlowPath()
#14 0x562d3cb38815 v8::internal::Heap::AllocateRawWithRetryOrFailSlowPath()
#15 0x562d3caf8d3e v8::internal::Factory::CopyJSObjectWithAllocationSite()
#16 0x562d3c85bf21 v8::internal::(anonymous namespace)::InstantiateObject()
#17 0x562d3c85a424 v8::internal::ApiNatives::InstantiateObject()
#18 0x562d3c8a96b3 v8::ObjectTemplate::NewInstance()
#19 0x562d3b782597 gin_helper::internal::CreateEvent()
#20 0x562d3b6aa8e4 gin_helper::EventEmitter<>::Emit<>()
#21 0x562d3b6aa7f4 electron::api::WebContents::RenderViewDeleted()
#22 0x562d3b6a7772 electron::api::WebContents::~WebContents()
#23 0x562d3b6a7f8e electron::api::WebContents::~WebContents()
#24 0x562d3b6488b4 base::internal::Invoker<>::Run()
#25 0x562d3b6ed275 electron::ElectronBrowserMainParts::PostMainMessageLoopRun()
#26 0x562d3dfc39a6 content::BrowserMainLoop::ShutdownThreadsAndCleanUp()
#27 0x562d3dfc5c8f content::BrowserMainRunnerImpl::Shutdown()
```

#### Release Notes

Notes: no-notes