### PR TITLE
fix: reposition traffic lights on theme change

### DIFF
--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -14,6 +14,7 @@
 
 #include "base/mac/scoped_nsobject.h"
 #include "shell/browser/native_window.h"
+#include "ui/native_theme/native_theme_observer.h"
 #include "ui/views/controls/native/native_view_host.h"
 
 @class ElectronNSWindow;
@@ -26,7 +27,7 @@ namespace electron {
 
 class RootViewMac;
 
-class NativeWindowMac : public NativeWindow {
+class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
  public:
   NativeWindowMac(const gin_helper::Dictionary& options, NativeWindow* parent);
   ~NativeWindowMac() override;
@@ -152,6 +153,7 @@ class NativeWindowMac : public NativeWindow {
   // Custom traffic light positioning
   void RepositionTrafficLights();
   void SetExitingFullScreen(bool flag);
+  void OnNativeThemeUpdated(ui::NativeTheme* observed_theme) override;
 
   enum class TitleBarStyle {
     NORMAL,

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -16,8 +16,11 @@
 #include "base/mac/scoped_cftyperef.h"
 #include "base/numerics/ranges.h"
 #include "base/strings/sys_string_conversions.h"
+#include "base/task/post_task.h"
 #include "components/remote_cocoa/app_shim/native_widget_ns_window_bridge.h"
 #include "content/public/browser/browser_accessibility_state.h"
+#include "content/public/browser/browser_task_traits.h"
+#include "content/public/browser/browser_thread.h"
 #include "content/public/browser/desktop_media_id.h"
 #include "shell/browser/native_browser_view_mac.h"
 #include "shell/browser/ui/cocoa/electron_native_widget_mac.h"
@@ -324,6 +327,8 @@ void ViewDidMoveToSuperview(NSView* self, SEL _cmd) {
 NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
                                  NativeWindow* parent)
     : NativeWindow(options, parent), root_view_(new RootViewMac(this)) {
+  ui::NativeTheme::GetInstanceForNativeUi()->AddObserver(this);
+
   int width = 800, height = 600;
   options.Get(options::kWidth, &width);
   options.Get(options::kHeight, &height);
@@ -509,6 +514,7 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
 }
 
 NativeWindowMac::~NativeWindowMac() {
+  ui::NativeTheme::GetInstanceForNativeUi()->RemoveObserver(this);
   if (wheel_event_monitor_)
     [NSEvent removeMonitor:wheel_event_monitor_];
 }
@@ -698,6 +704,12 @@ bool NativeWindowMac::IsVisible() {
 
 void NativeWindowMac::SetExitingFullScreen(bool flag) {
   exiting_fullscreen_ = flag;
+}
+
+void NativeWindowMac::OnNativeThemeUpdated(ui::NativeTheme* observed_theme) {
+  base::PostTask(FROM_HERE, {content::BrowserThread::UI},
+                 base::BindOnce(&NativeWindowMac::RepositionTrafficLights,
+                                base::Unretained(this)));
 }
 
 bool NativeWindowMac::IsEnabled() {


### PR DESCRIPTION
This is delayed a tick as the "native theme changed" event is dispatched by macOS before the UI changes happen.  There is no flicker do to the clever way macOS transitions the views in during the theme change.

Notes: Fixed issue where repositioned traffic lights would be in the wrong position after the user switches OS theme