### PR TITLE
ci: add third_party/angle/.git/HEAD to src archive

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -116,6 +116,12 @@ build_script:
         if ($(7z a $zipfile src -xr!android_webview -xr!electron -xr'!*\.git' -xr!third_party\WebKit\LayoutTests! -xr!third_party\blink\web_tests -xr!third_party\blink\perf_tests -slp -t7z -mmt=30;$LASTEXITCODE -ne 0)) {
           Write-warning "Could not save source to shared drive; continuing anyway"
         }
+        # build time generation of file gen/angle/commit.h depends on
+        # third_party/angle/.git/HEAD.
+        # https://chromium-review.googlesource.com/c/angle/angle/+/2074924
+        if ($(7z a $zipfile third_party\angle\.git\HEAD;$LASTEXITCODE -ne 0)) {
+          Write-warning "Failed to add third_party\angle\.git\HEAD; continuing anyway"
+        }
       }
   - ps: >-
       if ($env:GN_CONFIG -ne 'release') {

--- a/script/generate-deps-hash.js
+++ b/script/generate-deps-hash.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const path = require('path')
 
 // Fallback to blow away old cache keys
-const HASH_VERSION = 1
+const HASH_VERSION = 2
 
 // Base files to hash
 const filesToHash = [


### PR DESCRIPTION
#### Description of Change

We are already doing this for macOS CI in https://github.com/electron/electron/commit/39baf6879011c0fe8cc975c7585567c7ed0aeed8, should do it also for Windows CI.

#### Release Notes

Notes: no-notes