### PR TITLE
chore: shrink BoringSSL key gen patch

### DIFF
--- a/patches/node/fix_key_gen_apis_are_not_available_in_boringssl.patch
+++ b/patches/node/fix_key_gen_apis_are_not_available_in_boringssl.patch
@@ -6,7 +6,7 @@ Subject: fix: key gen APIs are not available in BoringSSL
 This will make Node's key pair generation APIs fail.
 
 diff --git a/src/node_crypto.cc b/src/node_crypto.cc
-index e0684d9b410c2423d805dd076330b79d22356f35..7950c68f52050b7c9a6798b653a9c831256b21b5 100644
+index e0684d9b410c2423d805dd076330b79d22356f35..e33a5d11ddbf900b26c1baa62f65bae49cdbaa24 100644
 --- a/src/node_crypto.cc
 +++ b/src/node_crypto.cc
 @@ -290,24 +290,14 @@ Maybe<bool> Decorate(Environment* env, Local<Object> obj,
@@ -34,35 +34,7 @@ index e0684d9b410c2423d805dd076330b79d22356f35..7950c68f52050b7c9a6798b653a9c831
      V(USER)                                                                   \
  
  #define V(name) case ERR_LIB_##name: lib = #name "_"; break;
-@@ -2560,8 +2550,11 @@ void SSLWrap<Base>::GetEphemeralKeyInfo(
-             .Check();
-         break;
-       case EVP_PKEY_EC:
-+      // FIXME(zcbenz): This is not available in BoringSSL.
-+#ifndef OPENSSL_IS_BORINGSSL
-       case EVP_PKEY_X25519:
-       case EVP_PKEY_X448:
-+#endif
-         {
-           const char* curve_name;
-           if (kid == EVP_PKEY_EC) {
-@@ -3909,12 +3902,15 @@ Local<Value> KeyObject::GetAsymmetricKeyType() const {
-     return env()->crypto_ec_string();
-   case EVP_PKEY_ED25519:
-     return env()->crypto_ed25519_string();
-+  // FIXME(zcbenz): This is not available in BoringSSL.
-+#ifndef OPENSSL_IS_BORINGSSL
-   case EVP_PKEY_ED448:
-     return env()->crypto_ed448_string();
-   case EVP_PKEY_X25519:
-     return env()->crypto_x25519_string();
-   case EVP_PKEY_X448:
-     return env()->crypto_x448_string();
-+#endif
-   default:
-     return Undefined(env()->isolate());
-   }
-@@ -6552,6 +6548,8 @@ class DSAKeyPairGenerationConfig : public KeyPairGenerationConfig {
+@@ -6552,6 +6542,8 @@ class DSAKeyPairGenerationConfig : public KeyPairGenerationConfig {
      if (EVP_PKEY_paramgen_init(param_ctx.get()) <= 0)
        return nullptr;
  
@@ -71,7 +43,7 @@ index e0684d9b410c2423d805dd076330b79d22356f35..7950c68f52050b7c9a6798b653a9c831
      if (EVP_PKEY_CTX_set_dsa_paramgen_bits(param_ctx.get(), modulus_bits_) <= 0)
        return nullptr;
  
-@@ -6571,6 +6569,8 @@ class DSAKeyPairGenerationConfig : public KeyPairGenerationConfig {
+@@ -6571,6 +6563,8 @@ class DSAKeyPairGenerationConfig : public KeyPairGenerationConfig {
  
      EVPKeyCtxPointer key_ctx(EVP_PKEY_CTX_new(params.get(), nullptr));
      return key_ctx;
@@ -80,16 +52,3 @@ index e0684d9b410c2423d805dd076330b79d22356f35..7950c68f52050b7c9a6798b653a9c831
    }
  
   private:
-@@ -7251,9 +7251,12 @@ void Initialize(Local<Object> target,
-   env->SetMethod(target, "generateKeyPairEC", GenerateKeyPairEC);
-   env->SetMethod(target, "generateKeyPairNid", GenerateKeyPairNid);
-   NODE_DEFINE_CONSTANT(target, EVP_PKEY_ED25519);
-+  // FIXME(zcbenz): This is not available in BoringSSL.
-+#ifndef OPENSSL_IS_BORINGSSL
-   NODE_DEFINE_CONSTANT(target, EVP_PKEY_ED448);
-   NODE_DEFINE_CONSTANT(target, EVP_PKEY_X25519);
-   NODE_DEFINE_CONSTANT(target, EVP_PKEY_X448);
-+#endif
-   NODE_DEFINE_CONSTANT(target, OPENSSL_EC_NAMED_CURVE);
-   NODE_DEFINE_CONSTANT(target, OPENSSL_EC_EXPLICIT_CURVE);
-   NODE_DEFINE_CONSTANT(target, kKeyEncodingPKCS1);


### PR DESCRIPTION
#### Description of Change

These have been defined as of https://boringssl-review.googlesource.com/c/boringssl/+/39724 and so while they won't _work_, we no longer need to patch them out.

cc @zcbenz @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
