### PR TITLE
docs: clean up dark mode related docs

### DIFF
--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -369,14 +369,6 @@ Returns `String` - Can be `dark`, `light` or `unknown`.
 Gets the macOS appearance setting that is currently applied to your application,
 maps to [NSApplication.effectiveAppearance](https://developer.apple.com/documentation/appkit/nsapplication/2967171-effectiveappearance?language=objc)
 
-Please note that until Electron is built targeting the 10.14 SDK, your application's
-`effectiveAppearance` will default to 'light' and won't inherit the OS preference. In
-the interim in order for your application to inherit the OS preference you must set the
-`NSRequiresAquaSystemAppearance` key in your apps `Info.plist` to `false`.  If you are
-using `electron-packager` or `electron-forge` just set the `enableDarwinDarkMode`
-packager option to `true`.  See the [Electron Packager API](https://github.com/electron/electron-packager/blob/master/docs/api.md#darwindarkmodesupport)
-for more details.
-
 **[Deprecated](modernization/property-updates.md)**
 
 ### `systemPreferences.getAppLevelAppearance()` _macOS_ _Deprecated_
@@ -478,11 +470,3 @@ A `String` property that can be `dark`, `light` or `unknown`.
 
 Returns the macOS appearance setting that is currently applied to your application,
 maps to [NSApplication.effectiveAppearance](https://developer.apple.com/documentation/appkit/nsapplication/2967171-effectiveappearance?language=objc)
-
-Please note that until Electron is built targeting the 10.14 SDK, your application's
-`effectiveAppearance` will default to 'light' and won't inherit the OS preference. In
-the interim in order for your application to inherit the OS preference you must set the
-`NSRequiresAquaSystemAppearance` key in your apps `Info.plist` to `false`.  If you are
-using `electron-packager` or `electron-forge` just set the `enableDarwinDarkMode`
-packager option to `true`.  See the [Electron Packager API](https://github.com/electron/electron-packager/blob/master/docs/api.md#darwindarkmodesupport)
-for more details.


### PR DESCRIPTION
#### Description of Change

Backport of #22489

Electron 8 uses macOS 10.14 SDK, so we can remove paragraphs from the `systemPreferences` API docs.

CC: @electron/wg-ecosystem 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `yarn lint:docs` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
