### PR TITLE
fix: allow persistent media salts

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -872,6 +872,14 @@ bool ElectronBrowserClient::ShouldUseProcessPerSite(
 #endif
 }
 
+bool ElectronBrowserClient::ArePersistentMediaDeviceIDsAllowed(
+    content::BrowserContext* browser_context,
+    const GURL& scope,
+    const GURL& site_for_cookies,
+    const base::Optional<url::Origin>& top_frame_origin) {
+  return true;
+}
+
 void ElectronBrowserClient::SiteInstanceDeleting(
     content::SiteInstance* site_instance) {
   // We are storing weak_ptr, is it fundamental to maintain the map up-to-date

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -246,6 +246,11 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
       int frame_tree_node_id) override;
   base::flat_set<std::string> GetPluginMimeTypesWithExternalHandlers(
       content::BrowserContext* browser_context) override;
+  bool ArePersistentMediaDeviceIDsAllowed(
+      content::BrowserContext* browser_context,
+      const GURL& scope,
+      const GURL& site_for_cookies,
+      const base::Optional<url::Origin>& top_frame_origin) override;
 
   // content::RenderProcessHostObserver:
   void RenderProcessHostDestroyed(content::RenderProcessHost* host) override;

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -694,6 +694,21 @@ describe('chromium features', () => {
       expect(labels.some((l: any) => l)).to.be.false()
     })
 
+    it('returns the same device ids across reloads', async () => {
+      const ses = session.fromPartition('persist:media-device-id')
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true,
+          session: ses
+        }
+      })
+      w.loadFile(path.join(fixturesPath, 'pages', 'media-id-reset.html'))
+      const [, firstDeviceIds] = await emittedOnce(ipcMain, 'deviceIds')
+      const [, secondDeviceIds] = await emittedOnce(ipcMain, 'deviceIds', () => w.webContents.reload())
+      expect(firstDeviceIds).to.deep.equal(secondDeviceIds)
+    })
+
     it('can return new device id when cookie storage is cleared', async () => {
       const ses = session.fromPartition('persist:media-device-id')
       const w = new BrowserWindow({
@@ -706,8 +721,7 @@ describe('chromium features', () => {
       w.loadFile(path.join(fixturesPath, 'pages', 'media-id-reset.html'))
       const [, firstDeviceIds] = await emittedOnce(ipcMain, 'deviceIds')
       await ses.clearStorageData({ storages: ['cookies'] })
-      w.webContents.reload()
-      const [, secondDeviceIds] = await emittedOnce(ipcMain, 'deviceIds')
+      const [, secondDeviceIds] = await emittedOnce(ipcMain, 'deviceIds', () => w.webContents.reload())
       expect(firstDeviceIds).to.not.deep.equal(secondDeviceIds)
     })
   })


### PR DESCRIPTION
Backport of #22386.

See that PR for details.

#### Release Notes

Notes: deviceId from navigator.mediaDevices.enumerateDevices is now consistent across reloads
