### PR TITLE
build: upload sentry src bundles to symbol S3 bucket

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -686,6 +686,8 @@ step-maybe-generate-breakpad-symbols: &step-maybe-generate-breakpad-symbols
       if [ "$GENERATE_SYMBOLS" == "true" ]; then
         cd src
         ninja -C out/Default electron:electron_symbols
+        cd out/Default/breakpad_symbols
+        find . -name \*.sym -print0 | xargs -0 npx @sentry/cli@1.51.1 difutil bundle-sources
       fi
 
 step-maybe-zip-symbols: &step-maybe-zip-symbols

--- a/script/release/uploaders/upload-symbols.py
+++ b/script/release/uploaders/upload-symbols.py
@@ -30,7 +30,7 @@ def main():
       run_symstore(pdb, SYMBOLS_DIR, PRODUCT_NAME)
     files = glob.glob(SYMBOLS_DIR + '/*.pdb/*/*.pdb')
   else:
-    files = glob.glob(SYMBOLS_DIR + '/*/*/*.sym')
+    files = glob.glob(SYMBOLS_DIR + '/*/*/*.sym') + glob.glob(SYMBOLS_DIR + '/*/*/*.src.zip')
 
   # The file upload needs to be atom-shell/symbols/:symbol_name/:hash/:symbol
   os.chdir(SYMBOLS_DIR)


### PR DESCRIPTION
This uploads `src.zip` bundles compatible with Sentry's symbol service so that folks using Sentry automatically get inline source code in their crash stacks.

Docs for sentry's supported symbol servers are here https://getsentry.github.io/symbolicator/advanced/symbol-server-compatibility/

These will become available on Electron's symbol server

Notes: no-notes