### PR TITLE
chore: proxy_config_monitor_ is no longer used in BrowserContext

### DIFF
--- a/script/generate-deps-hash.js
+++ b/script/generate-deps-hash.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const path = require('path')
 
 // Fallback to blow away old cache keys
-const HASH_VERSION = 2
+const HASH_VERSION = 3
 
 // Base files to hash
 const filesToHash = [

--- a/shell/browser/api/electron_api_url_loader.cc
+++ b/shell/browser/api/electron_api_url_loader.cc
@@ -15,6 +15,7 @@
 #include "gin/handle.h"
 #include "gin/object_template_builder.h"
 #include "gin/wrappable.h"
+#include "mojo/public/cpp/bindings/remote.h"
 #include "mojo/public/cpp/system/data_pipe_producer.h"
 #include "services/network/public/cpp/resource_request.h"
 #include "services/network/public/cpp/simple_url_loader.h"

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -12,7 +12,6 @@
 
 #include "base/memory/ref_counted_delete_on_sequence.h"
 #include "base/memory/weak_ptr.h"
-#include "chrome/browser/net/proxy_config_monitor.h"
 #include "chrome/browser/predictors/preconnect_manager.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/resource_context.h"
@@ -127,9 +126,6 @@ class ElectronBrowserContext
   CookieChangeNotifier* cookie_change_notifier() const {
     return cookie_change_notifier_.get();
   }
-  ProxyConfigMonitor* proxy_config_monitor() {
-    return proxy_config_monitor_.get();
-  }
   PrefService* prefs() const { return prefs_.get(); }
   void set_in_memory_pref_store(ValueMapPrefStore* pref_store) {
     in_memory_pref_store_ = pref_store;
@@ -177,10 +173,6 @@ class ElectronBrowserContext
   std::unique_ptr<MediaDeviceIDSalt> media_device_id_salt_;
   scoped_refptr<ResolveProxyHelper> resolve_proxy_helper_;
   scoped_refptr<storage::SpecialStoragePolicy> storage_policy_;
-
-  // Tracks the ProxyConfig to use, and passes any updates to a NetworkContext
-  // ProxyConfigClient.
-  std::unique_ptr<ProxyConfigMonitor> proxy_config_monitor_;
 
   std::unique_ptr<predictors::PreconnectManager> preconnect_manager_;
 


### PR DESCRIPTION
Removes unused code.

Notes: no-notes.