### PR TITLE
Don't allow @node/types 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/express": "^4.16.1",
     "@types/fs-extra": "^5.0.5",
     "@types/mocha": "^5.2.6",
-    "@types/node": "^12.0.10",
+    "@types/node": "~12.0.10",
     "@types/semver": "^6.0.1",
     "@types/send": "^0.14.5",
     "@types/split": "^1.0.0",


### PR DESCRIPTION
Electron 7 and 8 rely on Node 12.  In node 13, NodeJS.EventEmitter becomes an interface, leading to the following failures:

```
node_modules/electron/electron.d.ts:1649:31 - error TS2689: Cannot extend an interface 'NodeJS.EventEmitter'. Did you mean 'implements'?

1649   class BrowserWindow extends NodeJS.EventEmitter {
                                   ~~~~~~

node_modules/electron/electron.d.ts:3007:31 - error TS2689: Cannot extend an interface 'NodeJS.EventEmitter'. Did you mean 'implements'?

3007   class ClientRequest extends NodeJS.EventEmitter {
                                   ~~~~~~

node_modules/electron/electron.d.ts:3435:25 - error TS2689: Cannot extend an interface 'NodeJS.EventEmitter'. Did you mean 'implements'?

3435   class Cookies extends NodeJS.EventEmitter {
                             ~~~~~~

node_modules/electron/electron.d.ts:3588:26 - error TS2689: Cannot extend an interface 'NodeJS.EventEmitter'. Did you mean 'implements'?

3588   class Debugger extends NodeJS.EventEmitter {
                              ~~~~~~

node_modules/electron/electron.d.ts:4113:30 - error TS2689: Cannot extend an interface 'NodeJS.EventEmitter'. Did you mean 'implements'?

4113   class DownloadItem extends NodeJS.EventEmitter {
                                  ~~~~~~

node_modules/electron/electron.d.ts:4482:33 - error TS2689: Cannot extend an interface 'NodeJS.EventEmitter'. Did you mean 'implements'?

4482   class IncomingMessage extends NodeJS.EventEmitter {
                                     ~~~~~~

node_modules/electron/electron.d.ts:5334:30 - error TS2689: Cannot extend an interface 'NodeJS.EventEmitter'. Did you mean 'implements'?

5334   class Notification extends NodeJS.EventEmitter {
                                  ~~~~~~

node_modules/electron/electron.d.ts:6179:25 - error TS2689: Cannot extend an interface 'NodeJS.EventEmitter'. Did you mean 'implements'?

6179   class Session extends NodeJS.EventEmitter {
                             ~~~~~~

node_modules/electron/electron.d.ts:7104:37 - error TS2689: Cannot extend an interface 'NodeJS.EventEmitter'. Did you mean 'implements'?

7104   class TouchBarColorPicker extends NodeJS.EventEmitter {
                                         ~~~~~~

node_modules/electron/electron.d.ts:7116:31 - error TS2689: Cannot extend an interface 'NodeJS.EventEmitter'. Did you mean 'implements'?

7116   class TouchBarGroup extends NodeJS.EventEmitter {
                                   ~~~~~~

node_modules/electron/electron.d.ts:7126:31 - error TS2689: Cannot extend an interface 'NodeJS.EventEmitter'. Did you mean 'implements'?

7126   class TouchBarLabel extends NodeJS.EventEmitter {
                                   ~~~~~~

node_modules/electron/electron.d.ts:7138:33 - error TS2689: Cannot extend an interface 'NodeJS.EventEmitter'. Did you mean 'implements'?

7138   class TouchBarPopover extends NodeJS.EventEmitter {
                                     ~~~~~~

node_modules/electron/electron.d.ts:7150:34 - error TS2689: Cannot extend an interface 'NodeJS.EventEmitter'. Did you mean 'implements'?

7150   class TouchBarScrubber extends NodeJS.EventEmitter {
                                      ~~~~~~

node_modules/electron/electron.d.ts:7166:42 - error TS2689: Cannot extend an interface 'NodeJS.EventEmitter'. Did you mean 'implements'?

7166   class TouchBarSegmentedControl extends NodeJS.EventEmitter {
                                              ~~~~~~

node_modules/electron/electron.d.ts:7179:32 - error TS2689: Cannot extend an interface 'NodeJS.EventEmitter'. Did you mean 'implements'?

7179   class TouchBarSlider extends NodeJS.EventEmitter {
                                    ~~~~~~

node_modules/electron/electron.d.ts:7193:32 - error TS2689: Cannot extend an interface 'NodeJS.EventEmitter'. Did you mean 'implements'?

7193   class TouchBarSpacer extends NodeJS.EventEmitter {
                                    ~~~~~~

node_modules/electron/electron.d.ts:7314:22 - error TS2689: Cannot extend an interface 'NodeJS.EventEmitter'. Did you mean 'implements'?

7314   class Tray extends NodeJS.EventEmitter {
                          ~~~~~~

node_modules/electron/electron.d.ts:7749:29 - error TS2689: Cannot extend an interface 'NodeJS.EventEmitter'. Did you mean 'implements'?

7749   class WebContents extends NodeJS.EventEmitter {
                                 ~~~~~~
Found 18 errors.
```

Since Electron doesn't need node 13 anyways, we should only allow minor and patch changes above @types/node 12

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
