### PR TITLE
chore: don't delete nightly tag after draft

### DIFF
--- a/script/release/release-artifact-cleanup.js
+++ b/script/release/release-artifact-cleanup.js
@@ -44,7 +44,6 @@ async function deleteDraft (releaseId, targetRepo) {
       repo: targetRepo,
       release_id: parseInt(releaseId, 10)
     })
-    console.log(result)
     if (!result.data.draft) {
       console.log(`${fail} published releases cannot be deleted.`)
       return false
@@ -85,15 +84,11 @@ async function cleanReleaseArtifacts () {
 
   if (releaseId) {
     if (isNightly) {
-      const deletedNightlyDraft = await deleteDraft(releaseId, 'nightlies')
+      await deleteDraft(releaseId, 'nightlies')
 
-      // don't delete tag unless draft deleted successfully
-      if (deletedNightlyDraft) {
-        await Promise.all([
-          deleteTag(args.tag, 'electron'),
-          deleteTag(args.tag, 'nightlies')
-        ])
-      }
+      // We only need to delete the Electron tag since the
+      // nightly tag is only created at publish-time.
+      await deleteTag(args.tag, 'electron')
     } else {
       const deletedElectronDraft = await deleteDraft(releaseId, 'electron')
       // don't delete tag unless draft deleted successfully


### PR DESCRIPTION
#### Description of Change

Tags on the nightlies repository are  only created at the time a release is published, so if we delete a draft it will always fail to delete the associated ref as it will not exist yet. We should also always be deleting the electron tag regardless of draft deletion status.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
 