### PR TITLE
test: disable spellchecker context menu test for arm

### DIFF
--- a/spec-main/spellchecker-spec.ts
+++ b/spec-main/spellchecker-spec.ts
@@ -20,15 +20,18 @@ describe('spellchecker', () => {
     await closeWindow(w)
   })
 
-  // Spellchecker loads slow on ARM CI machines.
-  const waitTime = (process.arch === 'arm' || process.arch === 'arm64') ? 2000 : 500
+  // Context menu test can not run on Windows, and it is not reliable on ARM
+  // CI machines.
+  const shouldRun = process.platform !== 'win32' &&
+                    process.arch !== 'arm' &&
+                    process.arch !== 'arm64'
 
-  ifit(process.platform !== 'win32')('should detect correctly spelled words as correct', async () => {
+  ifit(shouldRun)('should detect correctly spelled words as correct', async () => {
     await w.webContents.executeJavaScript('document.body.querySelector("textarea").value = "Beautiful and lovely"')
     await w.webContents.executeJavaScript('document.body.querySelector("textarea").focus()')
     const contextMenuPromise = emittedOnce(w.webContents, 'context-menu')
     // Wait for spellchecker to load
-    await new Promise(resolve => setTimeout(resolve, waitTime))
+    await new Promise(resolve => setTimeout(resolve, 500))
     w.webContents.sendInputEvent({
       type: 'mouseDown',
       button: 'right',
@@ -40,12 +43,12 @@ describe('spellchecker', () => {
     expect(contextMenuParams.dictionarySuggestions).to.have.lengthOf(0)
   })
 
-  ifit(process.platform !== 'win32')('should detect incorrectly spelled words as incorrect', async () => {
+  ifit(shouldRun)('should detect incorrectly spelled words as incorrect', async () => {
     await w.webContents.executeJavaScript('document.body.querySelector("textarea").value = "Beautifulllll asd asd"')
     await w.webContents.executeJavaScript('document.body.querySelector("textarea").focus()')
     const contextMenuPromise = emittedOnce(w.webContents, 'context-menu')
     // Wait for spellchecker to load
-    await new Promise(resolve => setTimeout(resolve, waitTime))
+    await new Promise(resolve => setTimeout(resolve, 500))
     w.webContents.sendInputEvent({
       type: 'mouseDown',
       button: 'right',


### PR DESCRIPTION
#### Description of Change

The arm linux CI tasks fail at more than 50% rate, and most of them are caused by the spellchecker context menu test.

I have tried to ensure loading dictionary before running test, and increase the wait time (https://github.com/electron/electron/commit/56a75e726325e3db731ad3e0a79b672a2fe8f3f4) , but none works. I don't want to put more time on it, I think we should just disable the test for arm until someone else looks into it.

#### Release Notes

Notes: no-notes