### PR TITLE
build: fix build without built-in spellchecker

### DIFF
--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -76,7 +76,6 @@
 
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
 #include "chrome/browser/spellchecker/spellcheck_factory.h"  // nogncheck
-#include "chrome/browser/spellchecker/spellcheck_hunspell_dictionary.h"  // nogncheck
 #include "chrome/browser/spellchecker/spellcheck_service.h"  // nogncheck
 #include "components/spellcheck/browser/pref_names.h"
 #include "components/spellcheck/common/spellcheck_common.h"
@@ -228,6 +227,7 @@ void DestroyGlobalHandle(v8::Isolate* isolate,
   }
 }
 
+#if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
 class DictionaryObserver final : public SpellcheckCustomDictionary::Observer {
  private:
   std::unique_ptr<gin_helper::Promise<std::set<std::string>>> promise_;
@@ -263,6 +263,7 @@ class DictionaryObserver final : public SpellcheckCustomDictionary::Observer {
     // noop
   }
 };
+#endif  // BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
 
 }  // namespace
 
@@ -280,22 +281,27 @@ Session::Session(v8::Isolate* isolate, ElectronBrowserContext* browser_context)
   Init(isolate);
   AttachAsUserData(browser_context);
 
+#if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
   SpellcheckService* service =
       SpellcheckServiceFactory::GetForContext(browser_context_.get());
   if (service) {
     service->SetHunspellObserver(this);
   }
+#endif
 }
 
 Session::~Session() {
   content::BrowserContext::GetDownloadManager(browser_context())
       ->RemoveObserver(this);
 
+#if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
   SpellcheckService* service =
       SpellcheckServiceFactory::GetForContext(browser_context_.get());
   if (service) {
     service->SetHunspellObserver(nullptr);
   }
+#endif
+
   // TODO(zcbenz): Now since URLRequestContextGetter is gone, is this still
   // needed?
   // Refs https://github.com/electron/electron/pull/12305.
@@ -324,6 +330,7 @@ void Session::OnDownloadCreated(content::DownloadManager* manager,
   }
 }
 
+#if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
 void Session::OnHunspellDictionaryInitialized(const std::string& language) {
   Emit("spellcheck-dictionary-initialized", language);
 }
@@ -336,6 +343,7 @@ void Session::OnHunspellDictionaryDownloadSuccess(const std::string& language) {
 void Session::OnHunspellDictionaryDownloadFailure(const std::string& language) {
   Emit("spellcheck-dictionary-download-failure", language);
 }
+#endif
 
 v8::Local<v8::Promise> Session::ResolveProxy(gin_helper::Arguments* args) {
   v8::Isolate* isolate = args->isolate();
@@ -908,7 +916,7 @@ bool Session::RemoveWordFromSpellCheckerDictionary(const std::string& word) {
 #endif
   return service->GetCustomDictionary()->RemoveWord(word);
 }
-#endif
+#endif  // BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
 
 // static
 gin::Handle<Session> Session::CreateFrom(

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -9,13 +9,16 @@
 #include <vector>
 
 #include "base/values.h"
-#include "chrome/browser/spellchecker/spellcheck_hunspell_dictionary.h"
 #include "content/public/browser/download_manager.h"
 #include "electron/buildflags/buildflags.h"
 #include "gin/handle.h"
 #include "shell/browser/net/resolve_proxy_helper.h"
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/gin_helper/trackable_object.h"
+
+#if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
+#include "chrome/browser/spellchecker/spellcheck_hunspell_dictionary.h"  // nogncheck
+#endif
 
 class GURL;
 
@@ -38,8 +41,10 @@ class ElectronBrowserContext;
 namespace api {
 
 class Session : public gin_helper::TrackableObject<Session>,
-                public content::DownloadManager::Observer,
-                public SpellcheckHunspellDictionary::Observer {
+#if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
+                public SpellcheckHunspellDictionary::Observer,
+#endif
+                public content::DownloadManager::Observer {
  public:
   // Gets or creates Session from the |browser_context|.
   static gin::Handle<Session> CreateFrom(
@@ -118,6 +123,7 @@ class Session : public gin_helper::TrackableObject<Session>,
   void OnDownloadCreated(content::DownloadManager* manager,
                          download::DownloadItem* item) override;
 
+#if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
   // SpellcheckHunspellDictionary::Observer
   void OnHunspellDictionaryInitialized(const std::string& language) override;
   void OnHunspellDictionaryDownloadBegin(const std::string& language) override;
@@ -125,6 +131,7 @@ class Session : public gin_helper::TrackableObject<Session>,
       const std::string& language) override;
   void OnHunspellDictionaryDownloadFailure(
       const std::string& language) override;
+#endif
 
  private:
   // Cached gin_helper::Wrappable objects.

--- a/shell/common/api/features.cc
+++ b/shell/common/api/features.cc
@@ -9,6 +9,10 @@
 
 namespace {
 
+bool IsBuiltinSpellCheckerEnabled() {
+  return BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER);
+}
+
 bool IsDesktopCapturerEnabled() {
   return BUILDFLAG(ENABLE_DESKTOP_CAPTURER);
 }
@@ -66,6 +70,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   gin_helper::Dictionary dict(context->GetIsolate(), exports);
+  dict.SetMethod("isBuiltinSpellCheckerEnabled", &IsBuiltinSpellCheckerEnabled);
   dict.SetMethod("isDesktopCapturerEnabled", &IsDesktopCapturerEnabled);
   dict.SetMethod("isOffscreenRenderingEnabled", &IsOffscreenRenderingEnabled);
   dict.SetMethod("isRemoteModuleEnabled", &IsRemoteModuleEnabled);

--- a/spec-main/spellchecker-spec.ts
+++ b/spec-main/spellchecker-spec.ts
@@ -4,9 +4,11 @@ import { expect } from 'chai'
 import * as path from 'path'
 import { closeWindow } from './window-helpers'
 import { emittedOnce } from './events-helpers'
-import { ifit } from './spec-helpers'
+import { ifit, ifdescribe } from './spec-helpers'
 
-describe('spellchecker', () => {
+const features = process.electronBinding('features')
+
+ifdescribe(features.isBuiltinSpellCheckerEnabled())('spellchecker', () => {
   let w: BrowserWindow
 
   beforeEach(async () => {

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -2,6 +2,7 @@ declare var internalBinding: any;
 
 declare namespace NodeJS {
   interface FeaturesBinding {
+    isBuiltinSpellCheckerEnabled(): boolean;
     isDesktopCapturerEnabled(): boolean;
     isOffscreenRenderingEnabled(): boolean;
     isRemoteModuleEnabled(): boolean;


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Fix building with `enable_builtin_spellchecker = false`.

Here are green builds with `enable_builtin_spellchecker = false`:
- linux https://app.circleci.com/pipelines/github/electron/electron/21566/workflows/01f21fac-bbbb-428a-a0e6-b78f694641b9
- mac https://app.circleci.com/pipelines/github/electron/electron/21566/workflows/3ba54a5e-89fe-4900-a553-be5e1da00d37
- windows CI is broken at the moment, but there's nothing Windows-specific in the PR

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
