### PR TITLE
feat(extensions): add more properties to extension object

### DIFF
--- a/docs/api/structures/extension.md
+++ b/docs/api/structures/extension.md
@@ -1,5 +1,8 @@
 # Extension Object
 
 * `id` String
+* `manifest` any - Copy of the [extension's manifest data](https://developer.chrome.com/extensions/manifest).
 * `name` String
+* `path` String - The extension's file path.
 * `version` String
+* `url` String - The extension's `chrome-extension://` URL.

--- a/shell/common/gin_converters/extension_converter.cc
+++ b/shell/common/gin_converters/extension_converter.cc
@@ -6,6 +6,9 @@
 
 #include "extensions/common/extension.h"
 #include "gin/dictionary.h"
+#include "shell/common/gin_converters/file_path_converter.h"
+#include "shell/common/gin_converters/gurl_converter.h"
+#include "shell/common/gin_converters/value_converter.h"
 
 namespace gin {
 
@@ -16,7 +19,11 @@ v8::Local<v8::Value> Converter<const extensions::Extension*>::ToV8(
   auto dict = gin::Dictionary::CreateEmpty(isolate);
   dict.Set("id", extension->id());
   dict.Set("name", extension->name());
+  dict.Set("path", extension->path());
+  dict.Set("url", extension->url());
   dict.Set("version", extension->VersionString());
+  dict.Set("manifest", *(extension->manifest()->value()));
+
   return gin::ConvertToV8(isolate, dict);
 }
 

--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -39,6 +39,19 @@ ifdescribe(process.electronBinding('features').isExtensionsEnabled())('chrome ex
     expect(bg).to.equal('red')
   })
 
+  it('serializes a loaded extension', async () => {
+    const extensionPath = path.join(fixtures, 'extensions', 'red-bg')
+    const manifest = JSON.parse(fs.readFileSync(path.join(extensionPath, 'manifest.json'), 'utf-8'))
+    const customSession = session.fromPartition(`persist:${require('uuid').v4()}`)
+    const extension = await customSession.loadExtension(extensionPath)
+    expect(extension.id).to.be.a('string')
+    expect(extension.name).to.be.a('string')
+    expect(extension.path).to.be.a('string')
+    expect(extension.version).to.be.a('string')
+    expect(extension.url).to.be.a('string')
+    expect(extension.manifest).to.deep.equal(manifest)
+  })
+
   it('removes an extension', async () => {
     const customSession = session.fromPartition(`persist:${require('uuid').v4()}`)
     const { id } = await customSession.loadExtension(path.join(fixtures, 'extensions', 'red-bg'))


### PR DESCRIPTION
#### Description of Change
Backport of #22244 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added manifest, path, and url properties to the Extension structure.

