### PR TITLE
fix: don't clobber cookie header with session cookies

### DIFF
--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -592,8 +592,9 @@ describe('net module', () => {
           url: `${serverUrl}`,
           name: 'test',
           value: '11111',
-          expirationDate: 0
-        }).then(() => { // resolved
+          expirationDate: new Date().getTime() + 30000
+        }).then(() => customSession.cookies.flushStore()
+        ).then(() => { // resolved
           const urlRequest = net.request({
             method: 'GET',
             url: serverUrl,


### PR DESCRIPTION
Fixes #22541

cc @deepak1556 @nornagon 

#### Description of Change
If a cookie header was added to a net.request, do not send cookies from
the session's cookie jar, and instead respect the explicitly passed in
header.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Stopped overwriting explicit cookie header value with values from the session cookies when making requests using `net`.
