### PR TITLE
fix: when building with enable_pdf_viewer = false

### DIFF
--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -389,7 +389,11 @@ bool RendererClientBase::IsPluginHandledExternally(
 
 bool RendererClientBase::IsOriginIsolatedPepperPlugin(
     const base::FilePath& plugin_path) {
+#if BUILDFLAG(ENABLE_PDF_VIEWER)
   return plugin_path.value() == kPdfPluginPath;
+#else
+  return false;
+#endif
 }
 
 std::unique_ptr<blink::WebPrescientNetworking>


### PR DESCRIPTION
#### Description of Change
Fix building with `enable_pdf_viewer = false`

`kPdfPluginPath` is only declared when `enable_pdf_viewer = true`
https://github.com/electron/electron/blob/5bffd786317aba0eda1f802f2cb14fe4fa0b622a/shell/common/electron_constants.h#L40-L44

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes