### PR TITLE
build: fix build without built-in spellchecker (#22594)

### DIFF
--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -9,13 +9,16 @@
 #include <vector>
 
 #include "base/values.h"
-#include "chrome/browser/spellchecker/spellcheck_hunspell_dictionary.h"
 #include "content/public/browser/download_manager.h"
 #include "electron/buildflags/buildflags.h"
 #include "native_mate/handle.h"
 #include "shell/browser/api/trackable_object.h"
 #include "shell/browser/net/resolve_proxy_helper.h"
 #include "shell/common/promise_util.h"
+
+#if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
+#include "chrome/browser/spellchecker/spellcheck_hunspell_dictionary.h"  // nogncheck
+#endif
 
 class GURL;
 
@@ -39,8 +42,10 @@ class ElectronBrowserContext;
 namespace api {
 
 class Session : public mate::TrackableObject<Session>,
-                public content::DownloadManager::Observer,
-                public SpellcheckHunspellDictionary::Observer {
+#if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
+                public SpellcheckHunspellDictionary::Observer,
+#endif
+                public content::DownloadManager::Observer {
  public:
   // Gets or creates Session from the |browser_context|.
   static mate::Handle<Session> CreateFrom(
@@ -111,6 +116,7 @@ class Session : public mate::TrackableObject<Session>,
   void OnDownloadCreated(content::DownloadManager* manager,
                          download::DownloadItem* item) override;
 
+#if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
   // SpellcheckHunspellDictionary::Observer
   void OnHunspellDictionaryInitialized(const std::string& language) override;
   void OnHunspellDictionaryDownloadBegin(const std::string& language) override;
@@ -118,6 +124,7 @@ class Session : public mate::TrackableObject<Session>,
       const std::string& language) override;
   void OnHunspellDictionaryDownloadFailure(
       const std::string& language) override;
+#endif
 
  private:
   // Cached mate::Wrappable objects.


### PR DESCRIPTION
#### Description of Change
Backport of #22594

Builds with `enable_builtin_spellchecker = false`:
- https://ci.appveyor.com/project/electron-bot/electron-ldhmv/builds/31348047
- https://ci.appveyor.com/project/electron-bot/electron-ljo26/builds/31348046
- https://ci.appveyor.com/project/electron-bot/electron-ia32-testing/builds/31348045
- https://app.circleci.com/pipelines/github/electron/electron/21585/workflows/6ca63bd4-7781-45f9-bcf3-2b0b913c5c68
- https://app.circleci.com/pipelines/github/electron/electron/21585/workflows/c360469c-55a5-4d4a-93ec-1400c0edb65e

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes