### PR TITLE
build: fix build without built-in spellchecker (#22594)

### DIFF
--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -9,13 +9,16 @@
 #include <vector>
 
 #include "base/values.h"
-#include "chrome/browser/spellchecker/spellcheck_hunspell_dictionary.h"
 #include "content/public/browser/download_manager.h"
 #include "electron/buildflags/buildflags.h"
 #include "gin/handle.h"
 #include "shell/browser/net/resolve_proxy_helper.h"
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/gin_helper/trackable_object.h"
+
+#if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
+#include "chrome/browser/spellchecker/spellcheck_hunspell_dictionary.h"  // nogncheck
+#endif
 
 class GURL;
 
@@ -38,8 +41,10 @@ class ElectronBrowserContext;
 namespace api {
 
 class Session : public gin_helper::TrackableObject<Session>,
-                public content::DownloadManager::Observer,
-                public SpellcheckHunspellDictionary::Observer {
+#if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
+                public SpellcheckHunspellDictionary::Observer,
+#endif
+                public content::DownloadManager::Observer {
  public:
   // Gets or creates Session from the |browser_context|.
   static gin::Handle<Session> CreateFrom(
@@ -118,6 +123,7 @@ class Session : public gin_helper::TrackableObject<Session>,
   void OnDownloadCreated(content::DownloadManager* manager,
                          download::DownloadItem* item) override;
 
+#if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
   // SpellcheckHunspellDictionary::Observer
   void OnHunspellDictionaryInitialized(const std::string& language) override;
   void OnHunspellDictionaryDownloadBegin(const std::string& language) override;
@@ -125,6 +131,7 @@ class Session : public gin_helper::TrackableObject<Session>,
       const std::string& language) override;
   void OnHunspellDictionaryDownloadFailure(
       const std::string& language) override;
+#endif
 
  private:
   // Cached gin_helper::Wrappable objects.


### PR DESCRIPTION
#### Description of Change
Backport of #22594

Builds with `enable_builtin_spellchecker = false`:
- https://ci.appveyor.com/project/electron-bot/electron-ia32-testing/builds/31348198
- https://ci.appveyor.com/project/electron-bot/electron-ldhmv/builds/31348200
- https://ci.appveyor.com/project/electron-bot/electron-ljo26/builds/31348196
- https://app.circleci.com/pipelines/github/electron/electron/21587/workflows/e05ec0f8-86d8-4e44-82ea-cab8885fbf6c
- https://app.circleci.com/pipelines/github/electron/electron/21587/workflows/28021c14-ed45-47ae-8a74-bce063d90f19

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
