### PR TITLE
fix: quick follow-up to threadpool PR

### DIFF
--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -328,8 +328,8 @@ void OpenPath(const base::FilePath& full_path, OpenCallback callback) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 
   base::PostTaskAndReplyWithResult(
-      base::ThreadPool::CreateSingleThreadTaskRunner(({base::MayBlock(),
-                                    base::TaskPriority::USER_BLOCKING})
+      base::ThreadPool::CreateCOMSTATaskRunner(
+          {base::MayBlock(), base::TaskPriority::USER_BLOCKING})
           .get(),
       FROM_HERE, base::BindOnce(&OpenPathOnThread, full_path),
       std::move(callback));


### PR DESCRIPTION
#### Description of Change

Follow-up to https://github.com/electron/electron/pull/22555. Build issue was lost behind other Windows build issue whose fix is also up rn.

cc @jkleinsc 
 
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
