### PR TITLE
feat: add force option to app.focus()

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -554,10 +554,15 @@ Returns `Promise<void>` - fulfilled when Electron is initialized.
 May be used as a convenient alternative to checking `app.isReady()`
 and subscribing to the `ready` event if the app is not ready yet.
 
-### `app.focus()`
+### `app.focus([force])`
+
+* `force` String (optional) _macOS_ - Make the receiver the active app even if another app is
+currently active.
 
 On Linux, focuses on the first visible window. On macOS, makes the application
 the active app. On Windows, focuses on the application's first window.
+
+On macOS, you should seek to use the `force` option as sparingly as possible.
 
 ### `app.hide()` _macOS_
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -554,15 +554,16 @@ Returns `Promise<void>` - fulfilled when Electron is initialized.
 May be used as a convenient alternative to checking `app.isReady()`
 and subscribing to the `ready` event if the app is not ready yet.
 
-### `app.focus([force])`
+### `app.focus([options])`
 
-* `force` String (optional) _macOS_ - Make the receiver the active app even if another app is
-currently active.
+* `options` Object (optional)
+  * `steal` Boolean _macOS_ - Make the receiver the active app even if another app is
+  currently active.
 
 On Linux, focuses on the first visible window. On macOS, makes the application
 the active app. On Windows, focuses on the application's first window.
 
-On macOS, you should seek to use the `force` option as sparingly as possible.
+You should seek to use the `steal` option as sparingly as possible.
 
 ### `app.hide()` _macOS_
 

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -57,7 +57,7 @@ class Browser : public WindowListObserver {
   void Shutdown();
 
   // Focus the application.
-  void Focus();
+  void Focus(gin_helper::Arguments* args);
 
   // Returns the version of the executable (or bundle).
   std::string GetVersion() const;

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -84,7 +84,7 @@ bool SetDefaultWebClient(const std::string& protocol) {
   return ran_ok && exit_code == EXIT_SUCCESS;
 }
 
-void Browser::Focus() {
+void Browser::Focus(gin_helper::Arguments* args) {
   // Focus on the first visible window.
   for (auto* const window : WindowList::GetWindows()) {
     if (window->IsVisible()) {

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -21,6 +21,8 @@
 #include "shell/browser/window_list.h"
 #include "shell/common/application_info.h"
 #include "shell/common/gin_helper/arguments.h"
+#include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/platform_util.h"
 #include "ui/gfx/image/image.h"
@@ -33,9 +35,19 @@ void Browser::SetShutdownHandler(base::Callback<bool()> handler) {
 }
 
 void Browser::Focus(gin_helper::Arguments* args) {
-  bool force_focus = false;
-  args->GetNext(&force_focus);
-  [[AtomApplication sharedApplication] activateIgnoringOtherApps:force_focus];
+  gin_helper::Dictionary opts;
+  bool steal_focus = false;
+
+  if (args->GetNext(&opts)) {
+    gin_helper::ErrorThrower thrower(args->isolate());
+    if (!opts.Get("steal", &steal_focus)) {
+      thrower.ThrowError(
+          "Expected options object to contain a 'steal' boolean property");
+      return;
+    }
+  }
+
+  [[AtomApplication sharedApplication] activateIgnoringOtherApps:steal_focus];
 }
 
 void Browser::Hide() {

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -32,8 +32,10 @@ void Browser::SetShutdownHandler(base::Callback<bool()> handler) {
   [[AtomApplication sharedApplication] setShutdownHandler:std::move(handler)];
 }
 
-void Browser::Focus() {
-  [[AtomApplication sharedApplication] activateIgnoringOtherApps:NO];
+void Browser::Focus(gin_helper::Arguments* args) {
+  bool force_focus = false;
+  args->GetNext(&force_focus);
+  [[AtomApplication sharedApplication] activateIgnoringOtherApps:force_focus];
 }
 
 void Browser::Hide() {

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -163,7 +163,7 @@ Browser::UserTask::UserTask() = default;
 Browser::UserTask::UserTask(const UserTask&) = default;
 Browser::UserTask::~UserTask() = default;
 
-void Browser::Focus() {
+void Browser::Focus(gin_helper::Arguments* args) {
   // On Windows we just focus on the first window found for this process.
   DWORD pid = GetCurrentProcessId();
   EnumWindows(&WindowsEnumerationHandler, reinterpret_cast<LPARAM>(&pid));


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/22554. 

Adds a new optional `force` parameter to `app.focus()`, which allows for apps to make themselves active even if other apps are active.

cc @MarshallOfSound @nornagon @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Add a new `force` parameter to `app.focus()` on macOS to allow apps to forcefully take focus.
