### PR TITLE
docs: clarify that we support the latest minor for the stable lines we support

### DIFF
--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -37,7 +37,7 @@ The latest three *stable* major versions are supported by the Electron team.
 For example, if the latest release is 6.1.x, then the 5.0.x as well
 as the 4.2.x series are supported.  We only support the latest minor release
 for each stable release series.  This means that in the case of a security fix
-6.1.x will receive the fix, we will not release a new version of 6.0.x.
+6.1.x will receive the fix, but we will not release a new version of 6.0.x.
 
 The latest stable release unilaterally receives all fixes from `master`,
 and the version prior to that receives the vast majority of those fixes

--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -34,8 +34,10 @@ tools and resources.
 ## Supported Versions
 
 The latest three *stable* major versions are supported by the Electron team.
-For example, if the latest release is 6.x.y, then the 5.x.y as well
-as the 4.x.y series are supported.
+For example, if the latest release is 6.1.x, then the 5.0.x as well
+as the 4.2.x series are supported.  We only support the latest minor release
+for each stable release series.  This means that in the case of a security fix
+6.1.x will receive the fix, we will not release a new version of 6.0.x.
 
 The latest stable release unilaterally receives all fixes from `master`,
 and the version prior to that receives the vast majority of those fixes
@@ -48,9 +50,9 @@ basis for some older supported lines. All contested decisions around release
 line backports will be resolved by the [Releases Working Group](https://github.com/electron/governance/tree/master/wg-releases) as an agenda item at their weekly meeting the week the backport PR is raised.
 
 ### Currently supported versions
-- 8.x.y
-- 7.x.y
-- 6.x.y
+- 8.1.x
+- 7.1.x
+- 6.1.x
 
 ### End-of-life
 


### PR DESCRIPTION
As discussed wg-releases --> https://github.com/electron/governance/blob/master/wg-releases/meeting-notes/2020-03-04.md#agenda

Notes: no-notes