### PR TITLE
chore: ShowItemInFolder should use COMSTA

### DIFF
--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -318,7 +318,7 @@ std::string OpenPathOnThread(const base::FilePath& full_path) {
 namespace platform_util {
 
 void ShowItemInFolder(const base::FilePath& full_path) {
-  base::ThreadPool::CreateSingleThreadTaskRunner(
+  base::ThreadPool::CreateCOMSTATaskRunner(
       {base::MayBlock(), base::TaskPriority::USER_BLOCKING})
       ->PostTask(FROM_HERE,
                  base::BindOnce(&ShowItemInFolderOnWorkerThread, full_path));


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/22611#issuecomment-596743364.

`shell.showItemInFolder()` should use COMSTA task runner and not single threaded task runner.

cc @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none