### PR TITLE
fix: throw an error if bw width/height aren't ints

### DIFF
--- a/shell/browser/api/electron_api_top_level_window.cc
+++ b/shell/browser/api/electron_api_top_level_window.cc
@@ -92,15 +92,22 @@ TopLevelWindow::TopLevelWindow(v8::Isolate* isolate,
   }
 #endif
 
+#if defined(TOOLKIT_VIEWS)
+  // Sets the window icon.
+  gin::Handle<NativeImage> icon;
+  options.Get(options::kIcon, &icon);
+#endif
+
   // Creates NativeWindow.
   window_.reset(NativeWindow::Create(
       options, parent.IsEmpty() ? nullptr : parent->window_.get()));
   window_->AddObserver(this);
 
 #if defined(TOOLKIT_VIEWS)
-  // Sets the window icon.
-  gin::Handle<NativeImage> icon;
-  if (options.Get(options::kIcon, &icon) && !icon.IsEmpty())
+  // We do this separate from conversion to ensure that no JS is run
+  // when there are pending exceptions thrown during native window creation.
+  // TODO(codebytere): make "options" a typed struct with a converter?
+  if (!icon.IsEmpty())
     SetIcon(icon);
 #endif
 }

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -330,8 +330,17 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   ui::NativeTheme::GetInstanceForNativeUi()->AddObserver(this);
 
   int width = 800, height = 600;
-  options.Get(options::kWidth, &width);
-  options.Get(options::kHeight, &height);
+  gin_helper::ErrorThrower thrower(options.isolate());
+  if (options.Has(options::kWidth) && !options.Get(options::kWidth, &width)) {
+    thrower.ThrowTypeError("'width' parameter must be an integer");
+    return;
+  }
+
+  if (options.Has(options::kHeight) &&
+      !options.Get(options::kHeight, &height)) {
+    thrower.ThrowTypeError("'height' parameter must be an integer");
+    return;
+  }
 
   NSRect main_screen_rect = [[[NSScreen screens] firstObject] frame];
   gfx::Rect bounds(round((NSWidth(main_screen_rect) - width) / 2),

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -159,8 +159,18 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
         gfx::Size(), gfx::Size(INT_MAX / 10, INT_MAX / 10)));
 
   int width = 800, height = 600;
-  options.Get(options::kWidth, &width);
-  options.Get(options::kHeight, &height);
+  gin_helper::ErrorThrower thrower(options.isolate());
+  if (options.Has(options::kWidth) && !options.Get(options::kWidth, &width)) {
+    thrower.ThrowTypeError("'width' parameter must be an integer.");
+    return;
+  }
+
+  if (options.Has(options::kHeight) &&
+      !options.Get(options::kHeight, &height)) {
+    thrower.ThrowTypeError("'height' parameter must be an integer.");
+    return;
+  }
+
   gfx::Rect bounds(0, 0, width, height);
   widget_size_ = bounds.size();
 

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1081,6 +1081,22 @@ describe('BrowserWindow module', () => {
       })
     })
 
+    describe('new BrowserWindow() default sizing', () => {
+      it('throws an error for non-integer height values', () => {
+        expect(() => {
+          /* eslint-disable no-new */
+          new BrowserWindow({ height: 10.5 })
+        }).to.throw(`'height' parameter must be an integer`)
+      })
+
+      it('throws an error for non-integer width values', () => {
+        expect(() => {
+          /* eslint-disable no-new */
+          new BrowserWindow({ width: 10.5 })
+        }).to.throw(`'width' parameter must be an integer`)
+      })
+    })
+
     describe('BrowserWindow.addTabbedWindow()', () => {
       it('does not throw', async () => {
         const tabbedWindow = new BrowserWindow({})


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/22528.

We should be typechecking a little better for incorrect types - this would mysteriously be ignored instead of throwing a descriptive error, which it now does.

cc @MarshallOfSound @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where incorrect width and height values were ignore and didn't properly error.
