### PR TITLE
build: fix broken Views build

### DIFF
--- a/shell/browser/api/views/electron_api_box_layout.cc
+++ b/shell/browser/api/views/electron_api_box_layout.cc
@@ -9,9 +9,10 @@
 #include "shell/browser/api/electron_api_view.h"
 #include "shell/common/gin_helper/constructor.h"
 #include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
 
-namespace mate {
+namespace gin {
 
 template <>
 struct Converter<views::BoxLayout::Orientation> {
@@ -31,7 +32,7 @@ struct Converter<views::BoxLayout::Orientation> {
   }
 };
 
-}  // namespace mate
+}  // namespace gin
 
 namespace electron {
 
@@ -52,14 +53,14 @@ gin_helper::WrappableBase* BoxLayout::New(
     gin_helper::Arguments* args,
     views::BoxLayout::Orientation orientation) {
   auto* layout = new BoxLayout(orientation);
-  layout->InitWith(args->isolate(), args->GetThis());
+  layout->InitWithArgs(args);
   return layout;
 }
 
 // static
 void BoxLayout::BuildPrototype(v8::Isolate* isolate,
                                v8::Local<v8::FunctionTemplate> prototype) {
-  prototype->SetClassName(gin_helper::StringTov8(isolate, "BoxLayout"));
+  prototype->SetClassName(gin::StringToV8(isolate, "BoxLayout"));
   gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("setFlexForView", &BoxLayout::SetFlexForView);
 }

--- a/shell/browser/api/views/electron_api_button.cc
+++ b/shell/browser/api/views/electron_api_button.cc
@@ -33,7 +33,7 @@ gin_helper::WrappableBase* Button::New(gin_helper::Arguments* args) {
 // static
 void Button::BuildPrototype(v8::Isolate* isolate,
                             v8::Local<v8::FunctionTemplate> prototype) {
-  prototype->SetClassName(gin_helper::StringTov8(isolate, "Button"));
+  prototype->SetClassName(gin::StringToV8(isolate, "Button"));
 }
 
 }  // namespace api

--- a/shell/browser/api/views/electron_api_label_button.cc
+++ b/shell/browser/api/views/electron_api_label_button.cc
@@ -7,6 +7,7 @@
 #include "base/strings/utf_string_conversions.h"
 #include "shell/common/gin_helper/constructor.h"
 #include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
 
 namespace electron {
@@ -29,7 +30,7 @@ void LabelButton::SetText(const base::string16& text) {
 }
 
 bool LabelButton::IsDefault() const {
-  return label_button()->is_default();
+  return label_button()->GetIsDefault();
 }
 
 void LabelButton::SetIsDefault(bool is_default) {
@@ -41,14 +42,14 @@ gin_helper::WrappableBase* LabelButton::New(gin_helper::Arguments* args,
                                             const std::string& text) {
   // Constructor call.
   auto* view = new LabelButton(text);
-  view->InitWith(args->isolate(), args->GetThis());
+  view->InitWithArgs(args);
   return view;
 }
 
 // static
 void LabelButton::BuildPrototype(v8::Isolate* isolate,
                                  v8::Local<v8::FunctionTemplate> prototype) {
-  prototype->SetClassName(gin_helper::StringTov8(isolate, "LabelButton"));
+  prototype->SetClassName(gin::StringToV8(isolate, "LabelButton"));
   gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("getText", &LabelButton::GetText)
       .SetMethod("setText", &LabelButton::SetText)

--- a/shell/browser/api/views/electron_api_md_text_button.cc
+++ b/shell/browser/api/views/electron_api_md_text_button.cc
@@ -14,7 +14,8 @@ namespace electron {
 namespace api {
 
 MdTextButton::MdTextButton(const std::string& text)
-    : LabelButton(views::MdTextButton::Create(this, base::UTF8ToUTF16(text))) {}
+    : LabelButton(
+          views::MdTextButton::Create(this, base::UTF8ToUTF16(text)).get()) {}
 
 MdTextButton::~MdTextButton() {}
 
@@ -23,14 +24,14 @@ gin_helper::WrappableBase* MdTextButton::New(gin_helper::Arguments* args,
                                              const std::string& text) {
   // Constructor call.
   auto* view = new MdTextButton(text);
-  view->InitWith(args->isolate(), args->GetThis());
+  view->InitWithArgs(args);
   return view;
 }
 
 // static
 void MdTextButton::BuildPrototype(v8::Isolate* isolate,
                                   v8::Local<v8::FunctionTemplate> prototype) {
-  prototype->SetClassName(gin_helper::StringTov8(isolate, "MdTextButton"));
+  prototype->SetClassName(gin::StringToV8(isolate, "MdTextButton"));
 }
 
 }  // namespace api

--- a/shell/browser/api/views/electron_api_resize_area.cc
+++ b/shell/browser/api/views/electron_api_resize_area.cc
@@ -26,14 +26,14 @@ void ResizeArea::OnResize(int resize_amount, bool done_resizing) {
 gin_helper::WrappableBase* ResizeArea::New(gin_helper::Arguments* args) {
   // Constructor call.
   auto* view = new ResizeArea();
-  view->InitWith(args->isolate(), args->GetThis());
+  view->InitWithArgs(args);
   return view;
 }
 
 // static
 void ResizeArea::BuildPrototype(v8::Isolate* isolate,
                                 v8::Local<v8::FunctionTemplate> prototype) {
-  prototype->SetClassName(gin_helper::StringTov8(isolate, "ResizeArea"));
+  prototype->SetClassName(gin::StringToV8(isolate, "ResizeArea"));
 }
 
 }  // namespace api

--- a/shell/browser/api/views/electron_api_text_field.cc
+++ b/shell/browser/api/views/electron_api_text_field.cc
@@ -6,6 +6,7 @@
 
 #include "shell/common/gin_helper/constructor.h"
 #include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
 
 namespace electron {
@@ -23,21 +24,21 @@ void TextField::SetText(const base::string16& new_text) {
 }
 
 base::string16 TextField::GetText() const {
-  return text_field()->text();
+  return text_field()->GetText();
 }
 
 // static
 gin_helper::WrappableBase* TextField::New(gin_helper::Arguments* args) {
   // Constructor call.
   auto* view = new TextField();
-  view->InitWith(args->isolate(), args->GetThis());
+  view->InitWithArgs(args);
   return view;
 }
 
 // static
 void TextField::BuildPrototype(v8::Isolate* isolate,
                                v8::Local<v8::FunctionTemplate> prototype) {
-  prototype->SetClassName(gin_helper::StringTov8(isolate, "TextField"));
+  prototype->SetClassName(gin::StringToV8(isolate, "TextField"));
   gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
       .SetMethod("setText", &TextField::SetText)
       .SetMethod("getText", &TextField::GetText);


### PR DESCRIPTION
#### Description of Change

I went to test something with the Views APIs and discovered that they extremely did not build. Now they do. I turned off the flag to demonstrate such but will turn it back off before merging this PR.

cc @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed broken Views API builds.
