### PR TITLE
feat: add API to check if session is persistent

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -439,6 +439,13 @@ example `"en-US,fr,de,ko,zh-CN,ja"`.
 This doesn't affect existing `WebContents`, and each `WebContents` can use
 `webContents.setUserAgent` to override the session-wide user agent.
 
+#### `ses.isPersistent()`
+
+Returns `Boolean` - Whether or not this session is a persistent one. The default
+`webContents` session of a `BrowserWindow` is persistent. When creating a session
+from a partition, session prefixed with `persist:` will be persistent, while others
+will be temporary.
+
 #### `ses.getUserAgent()`
 
 Returns `String` - The user agent for this session.

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -607,6 +607,10 @@ std::string Session::GetUserAgent() {
   return browser_context_->GetUserAgent();
 }
 
+bool Session::IsPersistent() {
+  return !browser_context_->IsOffTheRecord();
+}
+
 v8::Local<v8::Promise> Session::GetBlobData(v8::Isolate* isolate,
                                             const std::string& uuid) {
   gin::Handle<DataPipeHolder> holder = DataPipeHolder::From(isolate, uuid);
@@ -961,6 +965,7 @@ void Session::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("clearAuthCache", &Session::ClearAuthCache)
       .SetMethod("allowNTLMCredentialsForDomains",
                  &Session::AllowNTLMCredentialsForDomains)
+      .SetMethod("isPersistent", &Session::IsPersistent)
       .SetMethod("setUserAgent", &Session::SetUserAgent)
       .SetMethod("getUserAgent", &Session::GetUserAgent)
       .SetMethod("getBlobData", &Session::GetBlobData)

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -81,6 +81,7 @@ class Session : public gin_helper::TrackableObject<Session>,
   void AllowNTLMCredentialsForDomains(const std::string& domains);
   void SetUserAgent(const std::string& user_agent, gin_helper::Arguments* args);
   std::string GetUserAgent();
+  bool IsPersistent();
   v8::Local<v8::Promise> GetBlobData(v8::Isolate* isolate,
                                      const std::string& uuid);
   void DownloadURL(const GURL& url);

--- a/spec-main/api-session-spec.ts
+++ b/spec-main/api-session-spec.ts
@@ -898,6 +898,30 @@ describe('session module', () => {
     })
   })
 
+  describe('ses.isPersistent()', () => {
+    afterEach(closeAllWindows)
+
+    it('returns default session as persistent', () => {
+      const w = new BrowserWindow({
+        show: false
+      })
+
+      const ses = w.webContents.session
+
+      expect(ses.isPersistent()).to.be.true()
+    })
+
+    it('returns persist: session as persistent', () => {
+      const ses = session.fromPartition(`persist:${Math.random()}`)
+      expect(ses.isPersistent()).to.be.true()
+    })
+
+    it('returns temporary session as not persistent', () => {
+      const ses = session.fromPartition(`${Math.random()}`)
+      expect(ses.isPersistent()).to.be.false()
+    })
+  })
+
   describe('ses.setUserAgent()', () => {
     afterEach(closeAllWindows)
 


### PR DESCRIPTION
#### Description of Change

Follow-up to https://github.com/electron/electron/pull/22157#pullrequestreview-371553571.

This small API adds the ability to verify if a session is persistent or not by exposing the [`IsOffTheRecord()`](https://source.chromium.org/chromium/chromium/src/+/master:content/shell/browser/shell_browser_context.h;bpv=1;bpt=1;l=51) boolean variable in the Chromium `BrowserContext`.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Can now check if a given `session` is persistent by calling the `ses.isPersistent()` API.
