### PR TITLE
test: test setPath for errors thrown

### DIFF
--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -712,6 +712,14 @@ describe('app module', () => {
   })
 
   describe('setPath(name, path)', () => {
+    it('throws when a relative path is passed', () => {
+      const badPath = 'hey/hi/hello'
+
+      expect(() => {
+        app.setPath('music', badPath)
+      }).to.throw(/Path must be absolute/)
+    })
+
     it('does not create a new directory by default', () => {
       const badPath = path.join(__dirname, 'music')
 
@@ -720,6 +728,16 @@ describe('app module', () => {
       expect(fs.existsSync(badPath)).to.be.false()
 
       expect(() => { app.getPath(badPath as any) }).to.throw()
+    })
+  })
+
+  describe('setAppLogsPath(path)', () => {
+    it('throws when a relative path is passed', () => {
+      const badPath = 'hey/hi/hello'
+
+      expect(() => {
+        app.setAppLogsPath(badPath)
+      }).to.throw(/Path must be absolute/)
     })
   })
 


### PR DESCRIPTION
#### Description of Change

Adds two new tests to verify error checking behavior of `app.setPath()` and `app.setAppLogsPath()` to ensure that they throw for non-absolute paths.

cc @zcbenz @MarshallOfSound @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
