### PR TITLE
docs: remove reference to electron-updater

### DIFF
--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -40,14 +40,6 @@ If you need to customize your configuration, you can
 or
 [use the update service directly][update.electronjs.org].
 
-## Using `electron-builder`
-
-If your app is packaged with [`electron-builder`][electron-builder-lib] you can use the
-[electron-updater] module, which does not require a server and allows for updates
-from S3, GitHub or any other static file host. This sidesteps Electron's built-in
-update mechanism, meaning that the rest of this documentation will not apply to
-`electron-builder`'s updater.
-
 ## Deploying an Update Server
 
 If you're developing a private Electron application, or if you're not
@@ -140,8 +132,6 @@ autoUpdater.on('error', message => {
 })
 ```
 
-[electron-builder-lib]: https://github.com/electron-userland/electron-builder
-[electron-updater]: https://www.electron.build/auto-update
 [now]: https://zeit.co/now
 [hazel]: https://github.com/zeit/hazel
 [nuts]: https://github.com/GitbookIO/nuts


### PR DESCRIPTION
#### Description of Change

As per the [2020-03-05 Ecosystem WG meeting](https://github.com/electron/governance/blob/master/wg-ecosystem/meeting-notes/2020-03-05.md).

CC: @electron/wg-ecosystem 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `yarn lint:docs` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes