### PR TITLE
chore: make converter errors descriptive with a subject to make it easier to debug issues

### DIFF
--- a/shell/common/gin_converters/gurl_converter.h
+++ b/shell/common/gin_converters/gurl_converter.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "gin/converter.h"
+#include "shell/common/gin_helper/error_thrower.h"
 #include "url/gurl.h"
 
 namespace gin {
@@ -25,6 +26,8 @@ struct Converter<GURL> {
       *out = GURL(url);
       return true;
     } else {
+      gin_helper::ErrorThrower(isolate).ThrowConverterError(
+          "Attempted to convert a non-string value to a URL", val);
       return false;
     }
   }

--- a/shell/common/gin_helper/error_thrower.cc
+++ b/shell/common/gin_helper/error_thrower.cc
@@ -5,6 +5,7 @@
 #include "shell/common/gin_helper/error_thrower.h"
 
 #include "gin/converter.h"
+#include "shell/common/gin_helper/dictionary.h"
 
 namespace gin_helper {
 
@@ -35,6 +36,17 @@ void ErrorThrower::ThrowReferenceError(base::StringPiece err_msg) {
 
 void ErrorThrower::ThrowSyntaxError(base::StringPiece err_msg) {
   Throw(v8::Exception::SyntaxError, err_msg);
+}
+
+void ErrorThrower::ThrowConverterError(base::StringPiece err_msg,
+                                       v8::Local<v8::Value> subject) {
+  v8::Local<v8::Value> exception =
+      v8::Exception::Error(gin::StringToV8(isolate_, err_msg));
+  DCHECK(exception->IsObject());
+  gin::Dictionary(isolate_, v8::Local<v8::Object>::Cast(exception))
+      .Set("subject", subject);
+  if (!isolate_->IsExecutionTerminating())
+    isolate_->ThrowException(exception);
 }
 
 void ErrorThrower::Throw(ErrorGenerator gen, base::StringPiece err_msg) {

--- a/shell/common/gin_helper/error_thrower.h
+++ b/shell/common/gin_helper/error_thrower.h
@@ -22,6 +22,8 @@ class ErrorThrower {
   void ThrowRangeError(base::StringPiece err_msg);
   void ThrowReferenceError(base::StringPiece err_msg);
   void ThrowSyntaxError(base::StringPiece err_msg);
+  void ThrowConverterError(base::StringPiece err_msg,
+                           v8::Local<v8::Value> subject);
 
   v8::Isolate* isolate() const { return isolate_; }
 

--- a/shell/common/gin_helper/function_template.h
+++ b/shell/common/gin_helper/function_template.h
@@ -178,12 +178,19 @@ struct ArgumentHolder {
       args->ThrowTypeError("Object has been destroyed");
       return;
     }
-    ok = GetNextArgument(args, create_flags, index == 0, &value);
-    if (!ok) {
-      // Ideally we would include the expected c++ type in the error
-      // message which we can access via typeid(ArgType).name()
-      // however we compile with no-rtti, which disables typeid.
-      args->ThrowError();
+    {
+      v8::TryCatch try_catch(args->isolate());
+      ok = GetNextArgument(args, create_flags, index == 0, &value);
+      if (!ok) {
+        if (try_catch.HasCaught()) {
+          try_catch.ReThrow();
+        } else {
+          // Ideally we would include the expected c++ type in the error
+          // message which we can access via typeid(ArgType).name()
+          // however we compile with no-rtti, which disables typeid.
+          args->ThrowError();
+        }
+      }
     }
   }
 };


### PR DESCRIPTION
This is kind of an experiment / seeking feedback on this idea.  Currently if you call an Electron method with invalid arguments you get the super helper (not really)

> Failed to convert argument at index {n}

This adjusts a function template so that converters can throw errors.  Potential problems:

* Converters have never thrown errors before, this might have unintended side effects in our code base
* Folks may be depending on the error message for things like tests or log filtering

Notes: no-notes