### PR TITLE
fix: guard against duplicate TouchBarItem IDs

### DIFF
--- a/lib/browser/api/touch-bar.js
+++ b/lib/browser/api/touch-bar.js
@@ -51,13 +51,25 @@ class TouchBar extends EventEmitter {
         item.child.ordereredItems.forEach(registerItem)
       }
     }
+
+    const idSet = new Set()
     items.forEach((item) => {
       if (!(item instanceof TouchBarItem)) {
         throw new Error('Each item must be an instance of TouchBarItem')
       }
+
+      if (!idSet.has(item.id)) {
+        idSet.add(item.id)
+      } else {
+        throw new Error('Cannot add a single instance of TouchBarItem multiple times in a TouchBar')
+      }
+    })
+
+    // register in separate loop after all items are validated
+    for (const item of items) {
       this.ordereredItems.push(item)
       registerItem(item)
-    })
+    }
   }
 
   set escapeItem (item) {

--- a/spec-main/api-touch-bar-spec.ts
+++ b/spec-main/api-touch-bar-spec.ts
@@ -32,6 +32,14 @@ describe('TouchBar module', () => {
     }).to.throw('Escape item must be an instance of TouchBarItem')
   })
 
+  it('throws an error if the same TouchBarItem is added multiple times', () => {
+    expect(() => {
+      const item = new TouchBarLabel({ label: 'Label' })
+      const touchBar = new TouchBar({ items: [item, item] })
+      touchBar.toString()
+    }).to.throw('Cannot add a single instance of TouchBarItem multiple times in a TouchBar')
+  })
+
   describe('BrowserWindow behavior', () => {
     let window: BrowserWindow
 


### PR DESCRIPTION
Backport of #22272

See that PR for details.

#### Release Notes
Notes: Returns a more graceful error when adding duplicate items to a single TouchBar instance.