### PR TITLE
fix: add handle scope in dialog's promise callback

### DIFF
--- a/shell/browser/api/electron_api_dialog.cc
+++ b/shell/browser/api/electron_api_dialog.cc
@@ -29,6 +29,7 @@ void ResolvePromiseObject(gin_helper::Promise<gin_helper::Dictionary> promise,
                           int result,
                           bool checkbox_checked) {
   v8::Isolate* isolate = promise.isolate();
+  v8::HandleScope handle_scope(isolate);
   gin_helper::Dictionary dict = gin::Dictionary::CreateEmpty(isolate);
 
   dict.Set("response", result);


### PR DESCRIPTION
Followup of #22531, the `ResolvePromiseObject` callback should have a handle scope.

```
#4 0x55959fe11a3d electron::(anonymous namespace)::FatalErrorCallback()
#5 0x5595a0f168dc v8::Utils::ReportApiFailure()
#6 0x5595a116f0c2 v8::internal::HandleScope::Extend()
#7 0x5595a0f126e7 v8::internal::HandleScope::CreateHandle()
#8 0x5595a0f5f019 v8::Object::New()
#9 0x5595a51282b4 gin::Dictionary::CreateEmpty()
#10 0x55959fd01c50 (anonymous namespace)::ResolvePromiseObject()
#11 0x55959fd01ce3 base::internal::Invoker<>::RunOnce()
#12 0x55959fddea14 electron::(anonymous namespace)::GtkMessageBox::OnResponseDialogThunk()
```

Notes: no-notes.