### PR TITLE
feat: add disableDialogs option to WebPreferences

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -369,6 +369,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       consecutive dialog protection is triggered. If not defined the default
       message would be used, note that currently the default message is in
       English and not localized.
+    * `disableDialogs` Boolean (optional) - Whether to disable dialogs
+      completely. Overrides `safeDialogs`. Default is `false`.
     * `navigateOnDragDrop` Boolean (optional) - Whether dragging and dropping a
       file or link onto the page causes a navigation. Default is `false`.
     * `autoplayPolicy` String (optional) - Autoplay policy to apply to

--- a/shell/browser/electron_javascript_dialog_manager.cc
+++ b/shell/browser/electron_javascript_dialog_manager.cc
@@ -61,6 +61,12 @@ void ElectronJavaScriptDialogManager::RunJavaScriptDialog(
     return;
   }
 
+  auto* web_preferences = WebContentsPreferences::From(web_contents);
+
+  if (web_preferences && web_preferences->IsEnabled("disableDialogs")) {
+    return std::move(callback).Run(false, base::string16());
+  }
+
   // No default button
   int default_id = -1;
   int cancel_id = 0;
@@ -75,7 +81,6 @@ void ElectronJavaScriptDialogManager::RunJavaScriptDialog(
 
   origin_counts_[origin]++;
 
-  auto* web_preferences = WebContentsPreferences::From(web_contents);
   std::string checkbox;
   if (origin_counts_[origin] > 1 && web_preferences &&
       web_preferences->IsEnabled("safeDialogs") &&


### PR DESCRIPTION
#### Description of Change
Backport of #22395.

Doing a manual backport, refs: https://github.com/electron/electron/pull/22395#issuecomment-593665991.
This doesn't have any conflicts though, and is just a cherry-pick.

cc @codebytere @zcbenz

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `disableDialogs` option to WebPreferences.
