### PR TITLE
feat: prompt expected type in argument type error

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -526,6 +526,7 @@ filenames = {
     "shell/common/gin_helper/promise.h",
     "shell/common/gin_helper/trackable_object.cc",
     "shell/common/gin_helper/trackable_object.h",
+    "shell/common/gin_helper/v8_type_traits.h",
     "shell/common/gin_helper/wrappable.cc",
     "shell/common/gin_helper/wrappable.h",
     "shell/common/gin_helper/wrappable_base.h",

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -15,6 +15,7 @@ web_contents.patch
 webview_cross_drag.patch
 disable_user_gesture_requirement_for_beforeunload_dialogs.patch
 gin_enable_disable_v8_platform.patch
+gin_expose_arguments_members.patch
 blink-worker-enable-csp-in-file-scheme.patch
 disable-redraw-lock.patch
 v8_context_snapshot_generator.patch

--- a/patches/chromium/gin_expose_arguments_members.patch
+++ b/patches/chromium/gin_expose_arguments_members.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Thu, 20 Sep 2018 17:47:44 -0700
+Subject: chore: expose members of gin::Arguments to subclass
+
+Make Electron's gin_helper::Arguments class have access to |next_| pointer.
+
+diff --git a/gin/arguments.h b/gin/arguments.h
+index eaded13e2991..7a94fceacaf8 100644
+--- a/gin/arguments.h
++++ b/gin/arguments.h
+@@ -108,7 +108,7 @@ class GIN_EXPORT Arguments {
+   // and object construction.
+   bool IsConstructCall() const;
+ 
+- private:
++ protected:
+   v8::Isolate* isolate_;
+   union {
+     const v8::FunctionCallbackInfo<v8::Value>* info_for_function_;

--- a/shell/common/gin_converters/callback_converter.h
+++ b/shell/common/gin_converters/callback_converter.h
@@ -14,6 +14,7 @@ namespace gin {
 
 template <typename Sig>
 struct Converter<base::RepeatingCallback<Sig>> {
+  static constexpr const char* type_name = "Function";
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const base::RepeatingCallback<Sig>& val) {
     // We don't use CreateFunctionTemplate here because it creates a new
@@ -38,6 +39,7 @@ struct Converter<base::RepeatingCallback<Sig>> {
 
 template <typename Sig>
 struct Converter<base::OnceCallback<Sig>> {
+  static constexpr const char* type_name = "Function";
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    base::OnceCallback<Sig> in) {
     return gin::ConvertToV8(isolate,

--- a/shell/common/gin_converters/gurl_converter.h
+++ b/shell/common/gin_converters/gurl_converter.h
@@ -14,6 +14,7 @@ namespace gin {
 
 template <>
 struct Converter<GURL> {
+  static constexpr const char* type_name = "URL";
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, const GURL& val) {
     return ConvertToV8(isolate, val.spec());
   }

--- a/shell/common/gin_converters/std_converter.h
+++ b/shell/common/gin_converters/std_converter.h
@@ -23,6 +23,7 @@ v8::Local<v8::Value> ConvertToV8(v8::Isolate* isolate, T&& input) {
 #if !defined(OS_LINUX) && !defined(OS_FREEBSD)
 template <>
 struct Converter<unsigned long> {  // NOLINT(runtime/int)
+  static constexpr const char* type_name = "Integer";
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    unsigned long val) {  // NOLINT(runtime/int)
     return v8::Integer::New(isolate, val);
@@ -41,6 +42,7 @@ struct Converter<unsigned long> {  // NOLINT(runtime/int)
 
 template <>
 struct Converter<std::nullptr_t> {
+  static constexpr const char* type_name = "null";
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, std::nullptr_t val) {
     return v8::Null(isolate);
   }
@@ -48,6 +50,7 @@ struct Converter<std::nullptr_t> {
 
 template <>
 struct Converter<const char*> {
+  static constexpr const char* type_name = "String";
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, const char* val) {
     return v8::String::NewFromUtf8(isolate, val, v8::NewStringType::kNormal)
         .ToLocalChecked();
@@ -56,6 +59,7 @@ struct Converter<const char*> {
 
 template <>
 struct Converter<char[]> {
+  static constexpr const char* type_name = "String";
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, const char* val) {
     return v8::String::NewFromUtf8(isolate, val, v8::NewStringType::kNormal)
         .ToLocalChecked();
@@ -64,6 +68,7 @@ struct Converter<char[]> {
 
 template <size_t n>
 struct Converter<char[n]> {
+  static constexpr const char* type_name = "String";
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, const char* val) {
     return v8::String::NewFromUtf8(isolate, val, v8::NewStringType::kNormal,
                                    n - 1)
@@ -73,6 +78,7 @@ struct Converter<char[n]> {
 
 template <>
 struct Converter<v8::Local<v8::Array>> {
+  static constexpr const char* type_name = "Array";
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    v8::Local<v8::Array> val) {
     return val;
@@ -89,6 +95,7 @@ struct Converter<v8::Local<v8::Array>> {
 
 template <>
 struct Converter<v8::Local<v8::String>> {
+  static constexpr const char* type_name = "String";
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    v8::Local<v8::String> val) {
     return val;
@@ -105,6 +112,7 @@ struct Converter<v8::Local<v8::String>> {
 
 template <typename T>
 struct Converter<std::set<T>> {
+  static constexpr const char* type_name = "Array";
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const std::set<T>& val) {
     v8::Local<v8::Array> result(
@@ -141,6 +149,7 @@ struct Converter<std::set<T>> {
 
 template <typename K, typename V>
 struct Converter<std::map<K, V>> {
+  static constexpr const char* type_name = "Object";
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> value,
                      std::map<K, V>* out) {

--- a/shell/common/gin_helper/arguments.h
+++ b/shell/common/gin_helper/arguments.h
@@ -23,7 +23,7 @@ class Arguments : public gin::Arguments {
       return false;
     if (!gin::ConvertFromV8(isolate(), val, out))
       return false;
-    Skip();
+    ++next_;
     return true;
   }
 
@@ -34,7 +34,7 @@ class Arguments : public gin::Arguments {
     if (val.IsEmpty() || !val->IsBoolean())
       return false;
     *out = val->BooleanValue(isolate());
-    Skip();
+    ++next_;
     return true;
   }
 

--- a/shell/common/gin_helper/arguments.h
+++ b/shell/common/gin_helper/arguments.h
@@ -6,6 +6,7 @@
 #define SHELL_COMMON_GIN_HELPER_ARGUMENTS_H_
 
 #include "gin/arguments.h"
+#include "shell/common/gin_helper/v8_type_traits.h"
 
 namespace gin_helper {
 
@@ -38,11 +39,26 @@ class Arguments : public gin::Arguments {
     return true;
   }
 
-  // Throw error with custom error message.
+  // Throw arguments error.
   void ThrowError() const;
+
+  // Throw arguments error with expected type information.
+  template <typename T>
+  void ThrowErrorWithExpectedType() const {
+    if (is_for_property_ || insufficient_arguments_ ||
+        !V8TypeTraits<T>::has_type_name) {
+      ThrowError();
+      return;
+    }
+    ThrowErrorWithExpectedTypeName(V8TypeTraits<T>::type_name);
+  }
+
+  // Throw error with custom error message.
   void ThrowError(base::StringPiece message) const;
 
  private:
+  void ThrowErrorWithExpectedTypeName(const char* type_name) const;
+
   // MUST NOT ADD ANY DATA MEMBER.
 };
 

--- a/shell/common/gin_helper/callback.cc
+++ b/shell/common/gin_helper/callback.cc
@@ -36,7 +36,7 @@ v8::Persistent<v8::FunctionTemplate> g_call_translater;
 
 void CallTranslater(v8::Local<v8::External> external,
                     v8::Local<v8::Object> state,
-                    gin::Arguments* args) {
+                    gin_helper::Arguments* args) {
   // Whether the callback should only be called once.
   v8::Isolate* isolate = args->isolate();
   auto context = isolate->GetCurrentContext();

--- a/shell/common/gin_helper/callback.h
+++ b/shell/common/gin_helper/callback.h
@@ -113,7 +113,7 @@ struct V8FunctionInvoker<ReturnType(ArgTypes...)> {
 };
 
 // Helper to pass a C++ funtion to JavaScript.
-using Translater = base::Callback<void(gin::Arguments* args)>;
+using Translater = base::Callback<void(gin_helper::Arguments* args)>;
 v8::Local<v8::Value> CreateFunctionFromTranslater(v8::Isolate* isolate,
                                                   const Translater& translater,
                                                   bool one_time);
@@ -130,7 +130,7 @@ struct NativeFunctionInvoker {};
 template <typename ReturnType, typename... ArgTypes>
 struct NativeFunctionInvoker<ReturnType(ArgTypes...)> {
   static void Go(base::Callback<ReturnType(ArgTypes...)> val,
-                 gin::Arguments* args) {
+                 gin_helper::Arguments* args) {
     using Indices = typename IndicesGenerator<sizeof...(ArgTypes)>::type;
     Invoker<Indices, ArgTypes...> invoker(args, 0);
     if (invoker.IsOK())

--- a/shell/common/gin_helper/constructor.h
+++ b/shell/common/gin_helper/constructor.h
@@ -16,14 +16,14 @@ namespace internal {
 // into native types. It relies on the function_template.h to provide helper
 // templates.
 inline WrappableBase* InvokeFactory(
-    gin::Arguments* args,
+    gin_helper::Arguments* args,
     const base::Callback<WrappableBase*()>& callback) {
   return callback.Run();
 }
 
 template <typename P1>
 inline WrappableBase* InvokeFactory(
-    gin::Arguments* args,
+    gin_helper::Arguments* args,
     const base::Callback<WrappableBase*(P1)>& callback) {
   typename CallbackParamTraits<P1>::LocalType a1;
   if (!gin_helper::GetNextArgument(args, 0, true, &a1))
@@ -33,7 +33,7 @@ inline WrappableBase* InvokeFactory(
 
 template <typename P1, typename P2>
 inline WrappableBase* InvokeFactory(
-    gin::Arguments* args,
+    gin_helper::Arguments* args,
     const base::Callback<WrappableBase*(P1, P2)>& callback) {
   typename CallbackParamTraits<P1>::LocalType a1;
   typename CallbackParamTraits<P2>::LocalType a2;
@@ -45,7 +45,7 @@ inline WrappableBase* InvokeFactory(
 
 template <typename P1, typename P2, typename P3>
 inline WrappableBase* InvokeFactory(
-    gin::Arguments* args,
+    gin_helper::Arguments* args,
     const base::Callback<WrappableBase*(P1, P2, P3)>& callback) {
   typename CallbackParamTraits<P1>::LocalType a1;
   typename CallbackParamTraits<P2>::LocalType a2;
@@ -59,7 +59,7 @@ inline WrappableBase* InvokeFactory(
 
 template <typename P1, typename P2, typename P3, typename P4>
 inline WrappableBase* InvokeFactory(
-    gin::Arguments* args,
+    gin_helper::Arguments* args,
     const base::Callback<WrappableBase*(P1, P2, P3, P4)>& callback) {
   typename CallbackParamTraits<P1>::LocalType a1;
   typename CallbackParamTraits<P2>::LocalType a2;
@@ -75,7 +75,7 @@ inline WrappableBase* InvokeFactory(
 
 template <typename P1, typename P2, typename P3, typename P4, typename P5>
 inline WrappableBase* InvokeFactory(
-    gin::Arguments* args,
+    gin_helper::Arguments* args,
     const base::Callback<WrappableBase*(P1, P2, P3, P4, P5)>& callback) {
   typename CallbackParamTraits<P1>::LocalType a1;
   typename CallbackParamTraits<P2>::LocalType a2;
@@ -98,7 +98,7 @@ template <typename P1,
           typename P5,
           typename P6>
 inline WrappableBase* InvokeFactory(
-    gin::Arguments* args,
+    gin_helper::Arguments* args,
     const base::Callback<WrappableBase*(P1, P2, P3, P4, P5, P6)>& callback) {
   typename CallbackParamTraits<P1>::LocalType a1;
   typename CallbackParamTraits<P2>::LocalType a2;

--- a/shell/common/gin_helper/function_template.h
+++ b/shell/common/gin_helper/function_template.h
@@ -179,7 +179,7 @@ struct ArgumentHolder {
     }
     ok = GetNextArgument(args, create_flags, index == 0, &value);
     if (!ok) {
-      args->ThrowError();
+      args->ThrowErrorWithExpectedType<ArgLocalType>();
     }
   }
 };

--- a/shell/common/gin_helper/v8_type_traits.h
+++ b/shell/common/gin_helper/v8_type_traits.h
@@ -1,0 +1,76 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE.chromium file.
+
+#ifndef SHELL_COMMON_GIN_HELPER_V8_TYPE_TRAITS_H_
+#define SHELL_COMMON_GIN_HELPER_V8_TYPE_TRAITS_H_
+
+#include <string>
+#include <vector>
+
+#include "gin/converter.h"
+
+namespace gin_helper {
+
+// Used by gin_helper::Arguments to get the JavaScript type name of a native
+// C++ type when printing errors. All type names must be hard-coded.
+//
+// There a two ways of adding a type name:
+//
+// 1. Add a static "type_name" member in custom gin::Converter.
+//    template <>
+//    struct Converter<GURL> {
+//      static constexpr const char* type_name = "url";
+//      static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, const GURL& val);
+//    };
+//
+// 2. Explicitly define in this class. We should only do this way when adding
+//    type name for preset converters in gin/converter.h.
+
+template <typename T, typename Enable = void>
+struct V8TypeTraits {
+  static constexpr const bool has_type_name = false;
+  static constexpr const char* type_name = "<unknown>";
+};
+
+// Read type information from converter.
+template <typename T>
+struct V8TypeTraits<T,
+                    typename std::enable_if<std::is_pointer<decltype(
+                        gin::Converter<T>::type_name)>::value>::type> {
+  static constexpr const bool has_type_name = true;
+  static constexpr const char* type_name = gin::Converter<T>::type_name;
+};
+
+// Provide type information for types in gin/converter.h.
+#define DEFINE_TYPE_NAME(TYPE, NAME)                  \
+  template <>                                         \
+  struct V8TypeTraits<TYPE> {                         \
+    static constexpr const bool has_type_name = true; \
+    static constexpr const char* type_name = #NAME;   \
+  }
+
+DEFINE_TYPE_NAME(int32_t, Int32);
+DEFINE_TYPE_NAME(uint32_t, UInt32);
+DEFINE_TYPE_NAME(int64_t, Int64);
+DEFINE_TYPE_NAME(uint64_t, UInt64);
+DEFINE_TYPE_NAME(float, Number);
+DEFINE_TYPE_NAME(double, Number);
+DEFINE_TYPE_NAME(std::string, String);
+DEFINE_TYPE_NAME(base::string16, String);
+DEFINE_TYPE_NAME(v8::Local<v8::Function>, Function);
+DEFINE_TYPE_NAME(v8::Local<v8::Object>, Object);
+DEFINE_TYPE_NAME(v8::Local<v8::Promise>, Promise);
+DEFINE_TYPE_NAME(v8::Local<v8::ArrayBuffer>, Buffer);
+
+#undef DEFINE_TYPE_NAME
+
+template <typename T>
+struct V8TypeTraits<std::vector<T>> {
+  static constexpr const bool has_type_name = true;
+  static constexpr const char* type_name = "Array";
+};
+
+}  // namespace gin_helper
+
+#endif  // SHELL_COMMON_GIN_HELPER_V8_TYPE_TRAITS_H_

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -2916,9 +2916,7 @@ describe('BrowserWindow module', () => {
       const w = new BrowserWindow({ show: false })
       expect(() => {
         w.webContents.beginFrameSubscription(true, true as any)
-        // TODO(zcbenz): gin is weak at guessing parameter types, we should
-        // upstream native_mate's implementation to gin.
-      }).to.throw('Error processing argument at index 1, conversion failure from ')
+      }).to.throw(/Error processing argument at index 1, conversion failure from Boolean/)
     })
   })
 


### PR DESCRIPTION
#### Description of Change

Currently when wrong type of argument is passed, an error like this would be thrown:

```
Error processing argument at index 1, conversion failure from 
```

(gin can not recognize most types, so the type is empty above)

With this PR, the error would become:

```
Error processing argument at index 1, conversion failure from Boolean to URL
```

To support this, we only need to add a `type_name` member to custom converters:

```c++
template <>
struct Converter<GURL> {
  static constexpr const char* type_name = "url";
  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, const GURL& val);
};
```

If there is no `type_name` member, the old-style error would be thrown:

```
Error processing argument at index 1, conversion failure from Boolean
```

In this PR I have added  `type_name` member to a few custom gin converters, we should gradually add it to all converters in future.

A patch is added in this PR because we have to be able to access the private `next_` member of `gin::Arguments` to support custom error.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Prompt expected type in argument type error.