### PR TITLE
fix: don't assign NSAlert to window which is not visible

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -269,6 +269,7 @@ Shows a message box, it will block the process until the message box is closed.
 It returns the index of the clicked button.
 
 The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal.
+If `browserWindow` is not shown dialog will not be attached to it. In such case It will be displayed as independed window.
 
 ### `dialog.showMessageBox([browserWindow, ]options)`
 

--- a/shell/browser/ui/message_box_mac.mm
+++ b/shell/browser/ui/message_box_mac.mm
@@ -97,7 +97,9 @@ int ShowMessageBoxSync(const MessageBoxSettings& settings) {
   NSAlert* alert = CreateNSAlert(settings);
 
   // Use runModal for synchronous alert without parent, since we don't have a
-  // window to wait for.
+  // window to wait for. Also use it when window is provided but it is not
+  // shown as it would be impossible to dismiss the alert if it is connected
+  // to invisible window (see #22671).
   if (!settings.parent_window || !settings.parent_window->IsVisible())
     return [[alert autorelease] runModal];
 

--- a/shell/browser/ui/message_box_mac.mm
+++ b/shell/browser/ui/message_box_mac.mm
@@ -98,7 +98,7 @@ int ShowMessageBoxSync(const MessageBoxSettings& settings) {
 
   // Use runModal for synchronous alert without parent, since we don't have a
   // window to wait for.
-  if (!settings.parent_window)
+  if (!settings.parent_window || !settings.parent_window->IsVisible())
     return [[alert autorelease] runModal];
 
   __block int ret_code = -1;


### PR DESCRIPTION
Closes #22671.

Fixes an issue with possible creation of a messageBox which cannot be dismissed on macOS.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue with possible creation of a messageBox which cannot be dismissed on macOS.
