### PR TITLE
fix: crash on invalid zoomFactor

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1060,10 +1060,12 @@ Returns `Boolean` - Whether audio is currently playing.
 
 #### `contents.setZoomFactor(factor)`
 
-* `factor` Number - Zoom factor.
+* `factor` Double - Zoom factor; default is 1.0.
 
 Changes the zoom factor to the specified factor. Zoom factor is
 zoom percent divided by 100, so 300% = 3.0.
+
+The factor must be greater than 0.0.
 
 #### `contents.getZoomFactor()`
 

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -22,10 +22,12 @@ The `WebFrame` class has the following instance methods:
 
 ### `webFrame.setZoomFactor(factor)`
 
-* `factor` Number - Zoom factor.
+* `factor` Double - Zoom factor; default is 1.0.
 
 Changes the zoom factor to the specified factor. Zoom factor is
 zoom percent divided by 100, so 300% = 3.0.
+
+The factor must be greater than 0.0.
 
 ### `webFrame.getZoomFactor()`
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/api/electron_api_web_contents.h"
 
+#include <limits>
 #include <memory>
 #include <set>
 #include <string>
@@ -2489,7 +2490,13 @@ double WebContents::GetZoomLevel() const {
   return zoom_controller_->GetZoomLevel();
 }
 
-void WebContents::SetZoomFactor(double factor) {
+void WebContents::SetZoomFactor(gin_helper::ErrorThrower thrower,
+                                double factor) {
+  if (factor < std::numeric_limits<double>::epsilon()) {
+    thrower.ThrowError("'zoomFactor' must be a double greater than 0.0");
+    return;
+  }
+
   auto level = blink::PageZoomFactorToZoomLevel(factor);
   SetZoomLevel(level);
 }

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -297,7 +297,7 @@ class WebContents : public gin_helper::TrackableObject<WebContents>,
   // Methods for zoom handling.
   void SetZoomLevel(double level);
   double GetZoomLevel() const;
-  void SetZoomFactor(double factor);
+  void SetZoomFactor(gin_helper::ErrorThrower thrower, double factor);
   double GetZoomFactor() const;
 
   // Callback triggered on permission response.

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <limits>
 #include <memory>
 #include <string>
 #include <utility>
@@ -275,7 +276,14 @@ double GetZoomLevel(v8::Local<v8::Value> window) {
   return result;
 }
 
-void SetZoomFactor(v8::Local<v8::Value> window, double factor) {
+void SetZoomFactor(gin_helper::ErrorThrower thrower,
+                   v8::Local<v8::Value> window,
+                   double factor) {
+  if (factor < std::numeric_limits<double>::epsilon()) {
+    thrower.ThrowError("'zoomFactor' must be a double greater than 0.0");
+    return;
+  }
+
   SetZoomLevel(window, blink::PageZoomFactorToZoomLevel(factor));
 }
 

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -846,6 +846,19 @@ describe('webContents module', () => {
 
     afterEach(closeAllWindows)
 
+    it('throws on an invalid zoomFactor', async () => {
+      const w = new BrowserWindow({ show: false })
+      await w.loadURL('about:blank')
+
+      expect(() => {
+        w.webContents.setZoomFactor(0.0)
+      }).to.throw(/'zoomFactor' must be a double greater than 0.0/)
+
+      expect(() => {
+        w.webContents.setZoomFactor(-2.0)
+      }).to.throw(/'zoomFactor' must be a double greater than 0.0/)
+    })
+
     it('can set the correct zoom level (functions)', async () => {
       const w = new BrowserWindow({ show: false })
       try {


### PR DESCRIPTION
#### Description of Change

This PR fixes a crash caused by passing a value of `0.0` to `webContents.setZoomFactor()`, seen below:

```console
[38965:0312/111238.132477:FATAL:values.cc(211)] Check failed: false. Non-finite (i.e. NaN or positive/negative infinity) values cannot be represented in JSON
0   Electron Framework                  0x0000000117ce2839 base::debug::CollectStackTrace(void**, unsigned long) + 9
1   Electron Framework                  0x0000000117badb13 base::debug::StackTrace::StackTrace() + 19
2   Electron Framework                  0x0000000117bcc639 logging::LogMessage::~LogMessage() + 249
3   Electron Framework                  0x0000000117cd11c9 base::Value::Value(double) + 153
4   Electron Framework                  0x0000000112b2f420 electron::ZoomLevelDelegate::OnZoomLevelChanged(content::HostZoomMap::ZoomLevelChange const&) + 768
5   Electron Framework                  0x0000000116e79548 void base::CallbackList<void (content::HostZoomMap::ZoomLevelChange const&)>::Notify<content::HostZoomMap::ZoomLevelChange&>(content::HostZoomMap::ZoomLevelChange&) + 56
```

It will now throw a descriptive error informing the user that values must be greater than 0.0. Also corrects docs which incorrectly stated that the zoomFactor was a Number and not a Double.

cc @MarshallOfSound @jkleinsc @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a potential crash on invalid `zoomFactor` values when setting the zoom factor of a webpage.
