### PR TITLE
fix: crash when destroying WebContentsView during GC

### DIFF
--- a/spec-main/api-web-contents-view-spec.ts
+++ b/spec-main/api-web-contents-view-spec.ts
@@ -40,4 +40,29 @@ describe('WebContentsView', () => {
       expect(code).to.equal(0)
     })
   })
+
+  function triggerGCByAllocation () {
+    const arr = []
+    for (let i = 0; i < 1000000; i++) {
+      arr.push([])
+    }
+    return arr
+  }
+
+  it(`doesn't crash when GCed during allocation`, (done) => {
+    const web = (webContents as any).create({})
+    // eslint-disable-next-line no-new
+    new WebContentsView(web)
+    setTimeout(() => {
+      // NB. the crash we're testing for is the lack of a current `v8::Context`
+      // when emitting an event in WebContents's destructor. V8 is inconsistent
+      // about whether or not there's a current context during garbage
+      // collection, and it seems that `v8Util.requestGarbageCollectionForTesting`
+      // causes a GC in which there _is_ a current context, so the crash isn't
+      // triggered. Thus, we force a GC by other means: namely, by allocating a
+      // bunch of stuff.
+      triggerGCByAllocation()
+      done()
+    })
+  })
 })


### PR DESCRIPTION
#### Description of Change
This fixes a crash that could happen when garbage-collecting a WebContentsView when the GC was run during allocation. V8 is inconsistent about whether there's a current context during GC, so this crash was intermittent.

The stack trace this fixes is:
```
[447:0311/192732.605977:FATAL:event_emitter.cc(41)] Check failed: !context.IsEmpty(). 
#0 0x556c5fff2c99 base::debug::CollectStackTrace()
#1 0x556c5ff18bd3 base::debug::StackTrace::StackTrace()
#2 0x556c5ff2ef54 logging::LogMessage::~LogMessage()
#3 0x556c5c88b4ef gin_helper::internal::CreateEvent()
#4 0x556c5c7a5d3f gin_helper::EventEmitter<>::Emit<>()
#5 0x556c5c7a59c2 electron::api::WebContents::DestroyWebContents()
#6 0x556c5c7c77c0 electron::api::WebContentsView::~WebContentsView()
#7 0x556c5dbc3848 v8::internal::GlobalHandles::InvokeSecondPassPhantomCallbacks()
#8 0x556c5dc27929 v8::internal::Heap::CollectGarbage()
#9 0x556c5dc36914 v8::internal::Heap::AllocateRawWithLightRetrySlowPath()
#10 0x556c5dc36ae5 v8::internal::Heap::AllocateRawWithRetryOrFailSlowPath()
#11 0x556c5dbeb39a v8::internal::Factory::NewFillerObject()
#12 0x556c5e0dc812 v8::internal::__RT_impl_Runtime_AllocateInYoungGeneration()
#13 0x556c5e9a80bf Builtins_CEntry_Return1_DontSaveFPRegs_ArgvOnStack_NoBuiltinExit
```

We fix this by delaying the destruction of the related WebContents until the next tick, which was [previously being done by `gin_helper::WrappableBase`](https://github.com/electron/electron/pull/22531/files#diff-a10a5bf543debfed05cb27a201dac729R76), but which I think is better done on a case-by-case basis, because (a) we should have a way ensure that Wrappable objects are synchronously destroyed during GC, if needed, (b) it's easy to end up in double-free scenarios when delaying destruction, and (c) `gin::Wrappable` destroys the object synchronously, and it's nice to be as close to `gin::Wrappable` as possible.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none