### PR TITLE
chore: fix default_app dimensions

### DIFF
--- a/default_app/default_app.ts
+++ b/default_app/default_app.ts
@@ -45,10 +45,10 @@ async function createWindow () {
   await app.whenReady()
 
   const options: Electron.BrowserWindowConstructorOptions = {
-    width: 900,
-    height: 600,
+    width: 960,
+    height: 620,
     autoHideMenuBar: true,
-    backgroundColor: '#FFFFFF',
+    backgroundColor: '#2f3241',
     webPreferences: {
       preload: path.resolve(__dirname, 'preload.js'),
       contextIsolation: true,

--- a/default_app/styles.css
+++ b/default_app/styles.css
@@ -8,7 +8,7 @@ body {
 }
 
 .container {
-  margin: 15px 30px 30px 30px;
+  margin: 15px 30px;
   background-color: #2f3241;
   flex: 1;
   display: flex;


### PR DESCRIPTION
On `master` the nightly version tag is too long for the window and causes text wrapping which makes a scrollbar appear.  It looks a lot nicer without the scrollbar and everything on one line 😄 

This also removes the white flash when showing the window by adjusting it to be the same background color as the page 👍 

Notes: no-notes