### PR TITLE
fix: persist maximizable state through theme change

### DIFF
--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -151,7 +151,7 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
   void SetWindowLevel(int level);
 
   // Custom traffic light positioning
-  void RepositionTrafficLights();
+  void RedrawTrafficLights();
   void SetExitingFullScreen(bool flag);
   void SetTrafficLightPosition(const gfx::Point& position) override;
   gfx::Point GetTrafficLightPosition() const override;
@@ -221,6 +221,9 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
   // The visibility mode of window button controls when explicitly set through
   // setWindowButtonVisibility().
   base::Optional<bool> window_button_visibility_;
+
+  // Maximizable window state; necessary for persistence through redraws.
+  bool maximizable_ = true;
 
   // Simple (pre-Lion) Fullscreen Settings
   bool always_simple_fullscreen_ = false;

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -137,7 +137,7 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
   [super windowDidResize:notification];
   shell_->NotifyWindowResize();
   if (shell_->title_bar_style() == TitleBarStyle::HIDDEN) {
-    shell_->RepositionTrafficLights();
+    shell_->RedrawTrafficLights();
   }
 }
 
@@ -254,7 +254,7 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
   }
   shell_->SetExitingFullScreen(true);
   if (shell_->title_bar_style() == TitleBarStyle::HIDDEN) {
-    shell_->RepositionTrafficLights();
+    shell_->RedrawTrafficLights();
   }
 }
 
@@ -263,7 +263,7 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
   shell_->NotifyWindowLeaveFullScreen();
   shell_->SetExitingFullScreen(false);
   if (shell_->title_bar_style() == TitleBarStyle::HIDDEN) {
-    shell_->RepositionTrafficLights();
+    shell_->RedrawTrafficLights();
   }
 }
 


### PR DESCRIPTION
#### Description of Change

(Partially) fixes https://github.com/electron/electron/issues/22646.

NSWindows reset their traffic light enabled states on redraw, which happens on theme changes (i.e changing from Light to Dark Mode) and so breaks old maximizable settings set by users. Luckily, we already hook into theme changes to reposition traffic lights, so this was a fairly straightforward fix in that we can use that function to persist maximizable state.

cc @MarshallOfSound @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where changing theme on macOS would break window maximizability state.
