### PR TITLE
fix: prevent in-memory sessions from writing to custom spellchecker dictionary

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -540,7 +540,8 @@ Resolves when the full dictionary is loaded from disk.
 
 * `word` String - The word you want to add to the dictionary
 
-Returns `Boolean` - Whether the word was successfully written to the custom dictionary.
+Returns `Boolean` - Whether the word was successfully written to the custom dictionary. This API
+will not work on non-persistent (in-memory) sessions.
 
 **Note:** On macOS and Windows 10 this word will be written to the OS custom dictionary as well
 
@@ -548,7 +549,8 @@ Returns `Boolean` - Whether the word was successfully written to the custom dict
 
 * `word` String - The word you want to remove from the dictionary
 
-Returns `Boolean` - Whether the word was successfully removed from the custom dictionary.
+Returns `Boolean` - Whether the word was successfully removed from the custom dictionary. This API
+will not work on non-persistent (in-memory) sessions.
 
 **Note:** On macOS and Windows 10 this word will be removed from the OS custom dictionary as well
 

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -876,6 +876,12 @@ v8::Local<v8::Promise> Session::ListWordsInSpellCheckerDictionary() {
 }
 
 bool Session::AddWordToSpellCheckerDictionary(const std::string& word) {
+  // don't let in-memory sessions add spellchecker words
+  // because files will persist unintentionally
+  bool is_in_memory = browser_context_->IsOffTheRecord();
+  if (is_in_memory)
+    return false;
+
   SpellcheckService* spellcheck =
       SpellcheckServiceFactory::GetForContext(browser_context_.get());
   if (!spellcheck)
@@ -892,6 +898,12 @@ bool Session::AddWordToSpellCheckerDictionary(const std::string& word) {
 }
 
 bool Session::RemoveWordFromSpellCheckerDictionary(const std::string& word) {
+  // don't let in-memory sessions remove spellchecker words
+  // because files will persist unintentionally
+  bool is_in_memory = browser_context_->IsOffTheRecord();
+  if (is_in_memory)
+    return false;
+
   SpellcheckService* service =
       SpellcheckServiceFactory::GetForContext(browser_context_.get());
   if (!service)

--- a/spec-main/spellchecker-spec.ts
+++ b/spec-main/spellchecker-spec.ts
@@ -61,6 +61,13 @@ describe('spellchecker', () => {
         const wordList = await ses.listWordsInSpellCheckerDictionary
         expect(wordList).to.have.length(0)
       })
+
+      // remove API will always return false because we can't add words
+      it('should fail for non-persistent sessions', async () => {
+        const tempSes = session.fromPartition('temporary')
+        const result = tempSes.addWordToSpellCheckerDictionary('foobar')
+        expect(result).to.equal(false)
+      })
     })
 
     describe('ses.removeWordFromSpellCheckerDictionary', () => {


### PR DESCRIPTION
Backport of #22157

See that PR for details.

Notes: Limited manipulation of custom spellchecker dictionary words to persistent sessions.