### PR TITLE
fix: when building with enable_pepper_flash = false

### DIFF
--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -298,14 +298,18 @@ source_set("plugins") {
     sources += [
       "//chrome/renderer/pepper/pepper_flash_drm_renderer_host.cc",
       "//chrome/renderer/pepper/pepper_flash_drm_renderer_host.h",
-      "//chrome/renderer/pepper/pepper_flash_font_file_host.cc",
-      "//chrome/renderer/pepper/pepper_flash_font_file_host.h",
       "//chrome/renderer/pepper/pepper_flash_fullscreen_host.cc",
       "//chrome/renderer/pepper/pepper_flash_fullscreen_host.h",
       "//chrome/renderer/pepper/pepper_flash_menu_host.cc",
       "//chrome/renderer/pepper/pepper_flash_menu_host.h",
       "//chrome/renderer/pepper/pepper_flash_renderer_host.cc",
       "//chrome/renderer/pepper/pepper_flash_renderer_host.h",
+    ]
+  }
+  if (enable_pepper_flash || enable_pdf_viewer) {
+    sources += [
+      "//chrome/renderer/pepper/pepper_flash_font_file_host.cc",
+      "//chrome/renderer/pepper/pepper_flash_font_file_host.h",
     ]
   }
   deps += [

--- a/patches/chromium/pepper_plugin_support.patch
+++ b/patches/chromium/pepper_plugin_support.patch
@@ -6,6 +6,34 @@ Subject: pepper plugin support
 This tweaks Chrome's pepper flash and PDF plugin support to make it
 usable from Electron.
 
+diff --git a/chrome/browser/renderer_host/pepper/chrome_browser_pepper_host_factory.cc b/chrome/browser/renderer_host/pepper/chrome_browser_pepper_host_factory.cc
+index 2e328c0fb5a6598c3ae911655b3e5016a02b7405..304364f7e02c19d2ad7d16433e92dcfecfc8eb41 100644
+--- a/chrome/browser/renderer_host/pepper/chrome_browser_pepper_host_factory.cc
++++ b/chrome/browser/renderer_host/pepper/chrome_browser_pepper_host_factory.cc
+@@ -11,6 +11,7 @@
+ #include "chrome/browser/renderer_host/pepper/pepper_flash_drm_host.h"
+ #include "chrome/browser/renderer_host/pepper/pepper_isolated_file_system_message_filter.h"
+ #include "content/public/browser/browser_ppapi_host.h"
++#include "electron/buildflags/buildflags.h"
+ #include "ppapi/host/message_filter_host.h"
+ #include "ppapi/host/ppapi_host.h"
+ #include "ppapi/host/resource_host.h"
+@@ -52,6 +53,7 @@ ChromeBrowserPepperHostFactory::CreateResourceHost(
+     }
+   }
+ 
++#if BUILDFLAG(ENABLE_PEPPER_FLASH)
+   // Flash interfaces.
+   if (host_->GetPpapiHost()->permissions().HasPermission(
+           ppapi::PERMISSION_FLASH)) {
+@@ -70,6 +72,7 @@ ChromeBrowserPepperHostFactory::CreateResourceHost(
+             new PepperFlashDRMHost(host_, instance, resource));
+     }
+   }
++#endif
+ 
+   // Permissions for the following interfaces will be checked at the
+   // time of the corresponding instance's methods calls (because
 diff --git a/chrome/browser/renderer_host/pepper/pepper_broker_message_filter.cc b/chrome/browser/renderer_host/pepper/pepper_broker_message_filter.cc
 index d72a867594acee97d50c5f905fc1a4df9aa9352e..8a4cc159cb490ebadbb1b54aa88223c0cbf8ffdb 100644
 --- a/chrome/browser/renderer_host/pepper/pepper_broker_message_filter.cc
@@ -384,7 +412,7 @@ index 56a23e8f41bb418d414f11af5797b30571d4cc2b..6f9f577f16de80dd2ab194b557bbd9ec
    DISALLOW_COPY_AND_ASSIGN(PepperIsolatedFileSystemMessageFilter);
  };
 diff --git a/chrome/renderer/pepper/chrome_renderer_pepper_host_factory.cc b/chrome/renderer/pepper/chrome_renderer_pepper_host_factory.cc
-index d63e90b6c5079ab3237c4bad3d5e63ce2f99c657..f1d4503d1f72df67ffcc73000a8a2ad3e2c93327 100644
+index d63e90b6c5079ab3237c4bad3d5e63ce2f99c657..ec8c1e7cfbaec3e0876325e6b9ebb01581988bee 100644
 --- a/chrome/renderer/pepper/chrome_renderer_pepper_host_factory.cc
 +++ b/chrome/renderer/pepper/chrome_renderer_pepper_host_factory.cc
 @@ -10,8 +10,13 @@
@@ -401,15 +429,45 @@ index d63e90b6c5079ab3237c4bad3d5e63ce2f99c657..f1d4503d1f72df67ffcc73000a8a2ad3
  #include "content/public/renderer/renderer_ppapi_host.h"
  #include "ppapi/host/ppapi_host.h"
  #include "ppapi/host/resource_host.h"
-@@ -86,6 +91,7 @@ ChromeRendererPepperHostFactory::CreateResourceHost(
+@@ -39,6 +44,7 @@ ChromeRendererPepperHostFactory::CreateResourceHost(
+   if (!host_->IsValidInstance(instance))
+     return nullptr;
+ 
++#if BUILDFLAG(ENABLE_PEPPER_FLASH)
+   if (host_->GetPpapiHost()->permissions().HasPermission(
+           ppapi::PERMISSION_FLASH)) {
+     switch (message.type()) {
+@@ -61,10 +67,12 @@ ChromeRendererPepperHostFactory::CreateResourceHost(
+       }
      }
    }
++#endif
+ 
+   // TODO(raymes): PDF also needs access to the FlashFontFileHost currently.
+   // We should either rename PPB_FlashFont_File to PPB_FontFile_Private or get
+   // rid of its use in PDF if possible.
++#if BUILDFLAG(ENABLE_PEPPER_FLASH) || BUILDFLAG(ENABLE_PDF_VIEWER)
+   if (host_->GetPpapiHost()->permissions().HasPermission(
+           ppapi::PERMISSION_FLASH) ||
+       host_->GetPpapiHost()->permissions().HasPermission(
+@@ -80,12 +88,16 @@ ChromeRendererPepperHostFactory::CreateResourceHost(
+         }
+         break;
+       }
++#if BUILDFLAG(ENABLE_PEPPER_FLASH)
+       case PpapiHostMsg_FlashDRM_Create::ID:
+         return std::make_unique<PepperFlashDRMRendererHost>(host_, instance,
+                                                             resource);
++#endif
+     }
+   }
++#endif
  
 +#if BUILDFLAG(ENABLE_PDF_VIEWER)
    if (host_->GetPpapiHost()->permissions().HasPermission(
            ppapi::PERMISSION_PDF)) {
      switch (message.type()) {
-@@ -94,7 +100,9 @@ ChromeRendererPepperHostFactory::CreateResourceHost(
+@@ -94,7 +106,9 @@ ChromeRendererPepperHostFactory::CreateResourceHost(
        }
      }
    }
@@ -419,7 +477,7 @@ index d63e90b6c5079ab3237c4bad3d5e63ce2f99c657..f1d4503d1f72df67ffcc73000a8a2ad3
    // Permissions for the following interfaces will be checked at the
    // time of the corresponding instance's method calls.  Currently these
    // interfaces are available only for whitelisted apps which may not have
-@@ -104,6 +112,7 @@ ChromeRendererPepperHostFactory::CreateResourceHost(
+@@ -104,6 +118,7 @@ ChromeRendererPepperHostFactory::CreateResourceHost(
        return std::make_unique<PepperUMAHost>(host_, instance, resource);
      }
    }


### PR DESCRIPTION
#### Description of Change
Fix building with `enable_pepper_flash = false`

https://cs.chromium.org/chromium/src/chrome/renderer/pepper/chrome_renderer_pepper_host_factory.cc?q=chrome_renderer_pepper_host_factory.cc&sq=package:chromium&g=0&l=65-87
```cpp
  // TODO(raymes): PDF also needs access to the FlashFontFileHost currently.
  // We should either rename PPB_FlashFont_File to PPB_FontFile_Private or get
  // rid of its use in PDF if possible.
  if (host_->GetPpapiHost()->permissions().HasPermission(
          ppapi::PERMISSION_FLASH) ||
      host_->GetPpapiHost()->permissions().HasPermission(
          ppapi::PERMISSION_PDF)) {
    switch (message.type()) {
      case PpapiHostMsg_FlashFontFile_Create::ID: {
        ppapi::proxy::SerializedFontDescription description;
        PP_PrivateFontCharset charset;
        if (ppapi::UnpackMessage<PpapiHostMsg_FlashFontFile_Create>(
                message, &description, &charset)) {
          return std::make_unique<PepperFlashFontFileHost>(
              host_, instance, resource, description, charset);
        }
        break;
      }
      case PpapiHostMsg_FlashDRM_Create::ID:
        return std::make_unique<PepperFlashDRMRendererHost>(host_, instance,
                                                            resource);
    }
  }
```

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes