### PR TITLE
chore: support props/fns for BrowserWindow

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1115,15 +1115,11 @@ Returns `Integer[]` - Contains the window's maximum width and height.
 
 * `resizable` Boolean
 
-Sets whether the window can be manually resized by user.
-
-**[Deprecated](modernization/property-updates.md)**
+Sets whether the window can be manually resized by the user.
 
 #### `win.isResizable()`
 
-Returns `Boolean` - Whether the window can be manually resized by user.
-
-**[Deprecated](modernization/property-updates.md)**
+Returns `Boolean` - Whether the window can be manually resized by the user.
 
 #### `win.setMovable(movable)` _macOS_ _Windows_
 
@@ -1131,41 +1127,29 @@ Returns `Boolean` - Whether the window can be manually resized by user.
 
 Sets whether the window can be moved by user. On Linux does nothing.
 
-**[Deprecated](modernization/property-updates.md)**
-
 #### `win.isMovable()` _macOS_ _Windows_
 
 Returns `Boolean` - Whether the window can be moved by user.
 
 On Linux always returns `true`.
 
-**[Deprecated](modernization/property-updates.md)**
-
 #### `win.setMinimizable(minimizable)` _macOS_ _Windows_
 
 * `minimizable` Boolean
 
-Sets whether the window can be manually minimized by user. On Linux does
-nothing.
-
-**[Deprecated](modernization/property-updates.md)**
+Sets whether the window can be manually minimized by user. On Linux does nothing.
 
 #### `win.isMinimizable()` _macOS_ _Windows_
 
-Returns `Boolean` - Whether the window can be manually minimized by user
+Returns `Boolean` - Whether the window can be manually minimized by the user.
 
 On Linux always returns `true`.
-
-**[Deprecated](modernization/property-updates.md)**
 
 #### `win.setMaximizable(maximizable)` _macOS_ _Windows_
 
 * `maximizable` Boolean
 
-Sets whether the window can be manually maximized by user. On Linux does
-nothing.
-
-**[Deprecated](modernization/property-updates.md)**
+Sets whether the window can be manually maximized by user. On Linux does nothing.
 
 #### `win.isMaximizable()` _macOS_ _Windows_
 
@@ -1173,23 +1157,15 @@ Returns `Boolean` - Whether the window can be manually maximized by user.
 
 On Linux always returns `true`.
 
-**[Deprecated](modernization/property-updates.md)**
-
 #### `win.setFullScreenable(fullscreenable)`
 
 * `fullscreenable` Boolean
 
-Sets whether the maximize/zoom window button toggles fullscreen mode or
-maximizes the window.
-
-**[Deprecated](modernization/property-updates.md)**
+Sets whether the maximize/zoom window button toggles fullscreen mode or maximizes the window.
 
 #### `win.isFullScreenable()`
 
-Returns `Boolean` - Whether the maximize/zoom window button toggles fullscreen mode or
-maximizes the window.
-
-**[Deprecated](modernization/property-updates.md)**
+Returns `Boolean` - Whether the maximize/zoom window button toggles fullscreen mode or maximizes the window.
 
 #### `win.setClosable(closable)` _macOS_ _Windows_
 
@@ -1197,15 +1173,11 @@ maximizes the window.
 
 Sets whether the window can be manually closed by user. On Linux does nothing.
 
-**[Deprecated](modernization/property-updates.md)**
-
 #### `win.isClosable()` _macOS_ _Windows_
 
 Returns `Boolean` - Whether the window can be manually closed by user.
 
 On Linux always returns `true`.
-
-**[Deprecated](modernization/property-updates.md)**
 
 #### `win.setAlwaysOnTop(flag[, level][, relativeLevel])`
 
@@ -1618,23 +1590,17 @@ This cannot be called when `titleBarStyle` is set to `customButtonsOnHover`.
 Sets whether the window menu bar should hide itself automatically. Once set the
 menu bar will only show when users press the single `Alt` key.
 
-If the menu bar is already visible, calling `setAutoHideMenuBar(true)` won't
-hide it immediately.
-
-**[Deprecated](modernization/property-updates.md)**
+If the menu bar is already visible, calling `setAutoHideMenuBar(true)` won't hide it immediately.
 
 #### `win.isMenuBarAutoHide()`
 
 Returns `Boolean` - Whether menu bar automatically hides itself.
 
-**[Deprecated](modernization/property-updates.md)**
-
 #### `win.setMenuBarVisibility(visible)` _Windows_ _Linux_
 
 * `visible` Boolean
 
-Sets whether the menu bar should be visible. If the menu bar is auto-hide, users
-can still bring up the menu bar by pressing the single `Alt` key.
+Sets whether the menu bar should be visible. If the menu bar is auto-hide, users can still bring up the menu bar by pressing the single `Alt` key.
 
 #### `win.isMenuBarVisible()`
 

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -72,6 +72,43 @@ BrowserWindow.prototype._init = function () {
       return this.webContents.devToolsWebContents
     }
   })
+
+  // Properties
+
+  Object.defineProperty(this, 'autoHideMenuBar', {
+    get: () => this.isMenuBarAutoHide(),
+    set: (autoHide) => this.setAutoHideMenuBar(autoHide)
+  })
+
+  Object.defineProperty(this, 'minimizable', {
+    get: () => this.isMinimizable(),
+    set: (min) => this.setMinimizable(min)
+  })
+
+  Object.defineProperty(this, 'maximizable', {
+    get: () => this.isMaximizable(),
+    set: (max) => this.setMaximizable(max)
+  })
+
+  Object.defineProperty(this, 'resizable', {
+    get: () => this.isResizable(),
+    set: (res) => this.setResizable(res)
+  })
+
+  Object.defineProperty(this, 'fullScreenable', {
+    get: () => this.isFullScreenable(),
+    set: (full) => this.setFullScreenable(full)
+  })
+
+  Object.defineProperty(this, 'closable', {
+    get: () => this.isClosable(),
+    set: (close) => this.setClosable(close)
+  })
+
+  Object.defineProperty(this, 'movable', {
+    get: () => this.isMovable(),
+    set: (move) => this.setMovable(move)
+  })
 }
 
 const isBrowserWindow = (win) => {
@@ -164,14 +201,5 @@ Object.assign(BrowserWindow.prototype, {
     this.webContents.setBackgroundThrottling(allowed)
   }
 })
-
-// Deprecations
-deprecate.fnToProperty(BrowserWindow.prototype, 'autoHideMenuBar', '_isMenuBarAutoHide', '_setAutoHideMenuBar')
-deprecate.fnToProperty(BrowserWindow.prototype, 'minimizable', '_isMinimizable', '_setMinimizable')
-deprecate.fnToProperty(BrowserWindow.prototype, 'maximizable', '_isMaximizable', '_setMaximizable')
-deprecate.fnToProperty(BrowserWindow.prototype, 'resizable', '_isResizable', '_setResizable')
-deprecate.fnToProperty(BrowserWindow.prototype, 'fullScreenable', '_isFullScreenable', '_setFullScreenable')
-deprecate.fnToProperty(BrowserWindow.prototype, 'closable', '_isClosable', '_setClosable')
-deprecate.fnToProperty(BrowserWindow.prototype, 'movable', '_isMovable', '_setMovable')
 
 module.exports = BrowserWindow

--- a/shell/browser/api/electron_api_top_level_window.cc
+++ b/shell/browser/api/electron_api_top_level_window.cc
@@ -1120,30 +1120,18 @@ void TopLevelWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setSheetOffset", &TopLevelWindow::SetSheetOffset)
       .SetMethod("moveAbove", &TopLevelWindow::MoveAbove)
       .SetMethod("moveTop", &TopLevelWindow::MoveTop)
-      .SetMethod("_setResizable", &TopLevelWindow::SetResizable)
-      .SetMethod("_isResizable", &TopLevelWindow::IsResizable)
-      .SetProperty("resizable", &TopLevelWindow::IsResizable,
-                   &TopLevelWindow::SetResizable)
-      .SetMethod("_setMovable", &TopLevelWindow::SetMovable)
-      .SetMethod("_isMovable", &TopLevelWindow::IsMovable)
-      .SetProperty("movable", &TopLevelWindow::IsMovable,
-                   &TopLevelWindow::SetMovable)
-      .SetMethod("_setMinimizable", &TopLevelWindow::SetMinimizable)
-      .SetMethod("_isMinimizable", &TopLevelWindow::IsMinimizable)
-      .SetProperty("minimizable", &TopLevelWindow::IsMinimizable,
-                   &TopLevelWindow::SetMinimizable)
-      .SetMethod("_setMaximizable", &TopLevelWindow::SetMaximizable)
-      .SetMethod("_isMaximizable", &TopLevelWindow::IsMaximizable)
-      .SetProperty("maximizable", &TopLevelWindow::IsMaximizable,
-                   &TopLevelWindow::SetMaximizable)
-      .SetMethod("_setFullScreenable", &TopLevelWindow::SetFullScreenable)
-      .SetMethod("_isFullScreenable", &TopLevelWindow::IsFullScreenable)
-      .SetProperty("fullScreenable", &TopLevelWindow::IsFullScreenable,
-                   &TopLevelWindow::SetFullScreenable)
-      .SetMethod("_setClosable", &TopLevelWindow::SetClosable)
-      .SetMethod("_isClosable", &TopLevelWindow::IsClosable)
-      .SetProperty("closable", &TopLevelWindow::IsClosable,
-                   &TopLevelWindow::SetClosable)
+      .SetMethod("setResizable", &TopLevelWindow::SetResizable)
+      .SetMethod("isResizable", &TopLevelWindow::IsResizable)
+      .SetMethod("setMovable", &TopLevelWindow::SetMovable)
+      .SetMethod("isMovable", &TopLevelWindow::IsMovable)
+      .SetMethod("setMinimizable", &TopLevelWindow::SetMinimizable)
+      .SetMethod("isMinimizable", &TopLevelWindow::IsMinimizable)
+      .SetMethod("setMaximizable", &TopLevelWindow::SetMaximizable)
+      .SetMethod("isMaximizable", &TopLevelWindow::IsMaximizable)
+      .SetMethod("setFullScreenable", &TopLevelWindow::SetFullScreenable)
+      .SetMethod("isFullScreenable", &TopLevelWindow::IsFullScreenable)
+      .SetMethod("setClosable", &TopLevelWindow::SetClosable)
+      .SetMethod("isClosable", &TopLevelWindow::IsClosable)
       .SetMethod("setAlwaysOnTop", &TopLevelWindow::SetAlwaysOnTop)
       .SetMethod("isAlwaysOnTop", &TopLevelWindow::IsAlwaysOnTop)
       .SetMethod("center", &TopLevelWindow::Center)
@@ -1217,10 +1205,8 @@ void TopLevelWindow::BuildPrototype(v8::Isolate* isolate,
                    &TopLevelWindow::IsExcludedFromShownWindowsMenu,
                    &TopLevelWindow::SetExcludedFromShownWindowsMenu)
 #endif
-      .SetMethod("_setAutoHideMenuBar", &TopLevelWindow::SetAutoHideMenuBar)
-      .SetMethod("_isMenuBarAutoHide", &TopLevelWindow::IsMenuBarAutoHide)
-      .SetProperty("autoHideMenuBar", &TopLevelWindow::IsMenuBarAutoHide,
-                   &TopLevelWindow::SetAutoHideMenuBar)
+      .SetMethod("setAutoHideMenuBar", &TopLevelWindow::SetAutoHideMenuBar)
+      .SetMethod("isMenuBarAutoHide", &TopLevelWindow::IsMenuBarAutoHide)
       .SetMethod("setMenuBarVisibility", &TopLevelWindow::SetMenuBarVisibility)
       .SetMethod("isMenuBarVisible", &TopLevelWindow::IsMenuBarVisible)
       .SetMethod("setAspectRatio", &TopLevelWindow::SetAspectRatio)

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1102,15 +1102,39 @@ describe('BrowserWindow module', () => {
     })
   })
 
-  describe('autoHideMenuBar property', () => {
+  describe('autoHideMenuBar state', () => {
     afterEach(closeAllWindows)
-    it('exists', () => {
-      const w = new BrowserWindow({ show: false })
-      expect(w).to.have.property('autoHideMenuBar')
 
-      // TODO(codebytere): remove when propertyification is complete
-      expect(w.setAutoHideMenuBar).to.be.a('function')
-      expect(w.isMenuBarAutoHide).to.be.a('function')
+    it('for properties', () => {
+      it('can be set with autoHideMenuBar constructor option', () => {
+        const w = new BrowserWindow({ show: false, autoHideMenuBar: true })
+        expect(w.autoHideMenuBar).to.be.true('autoHideMenuBar')
+      })
+
+      it('can be changed', () => {
+        const w = new BrowserWindow({ show: false })
+        expect(w.autoHideMenuBar).to.be.false('autoHideMenuBar')
+        w.autoHideMenuBar = true
+        expect(w.autoHideMenuBar).to.be.true('autoHideMenuBar')
+        w.autoHideMenuBar = false
+        expect(w.autoHideMenuBar).to.be.false('autoHideMenuBar')
+      })
+    })
+
+    it('for functions', () => {
+      it('can be set with autoHideMenuBar constructor option', () => {
+        const w = new BrowserWindow({ show: false, autoHideMenuBar: true })
+        expect(w.isMenuBarAutoHide()).to.be.true('autoHideMenuBar')
+      })
+
+      it('can be changed', () => {
+        const w = new BrowserWindow({ show: false })
+        expect(w.isMenuBarAutoHide()).to.be.false('autoHideMenuBar')
+        w.setAutoHideMenuBar(true)
+        expect(w.isMenuBarAutoHide()).to.be.true('autoHideMenuBar')
+        w.setAutoHideMenuBar(false)
+        expect(w.isMenuBarAutoHide()).to.be.false('autoHideMenuBar')
+      })
     })
   })
 
@@ -3247,32 +3271,44 @@ describe('BrowserWindow module', () => {
     })
 
     describe('resizable state', () => {
-      it('can be changed with resizable option', () => {
-        const w = new BrowserWindow({ show: false, resizable: false })
-        expect(w.resizable).to.be.false('resizable')
+      it('with properties', () => {
+        it('can be set with resizable constructor option', () => {
+          const w = new BrowserWindow({ show: false, resizable: false })
+          expect(w.resizable).to.be.false('resizable')
 
-        if (process.platform === 'darwin') {
-          expect(w.maximizable).to.to.true('maximizable')
-        }
+          if (process.platform === 'darwin') {
+            expect(w.maximizable).to.to.true('maximizable')
+          }
+        })
+
+        it('can be changed', () => {
+          const w = new BrowserWindow({ show: false })
+          expect(w.resizable).to.be.true('resizable')
+          w.resizable = false
+          expect(w.resizable).to.be.false('resizable')
+          w.resizable = true
+          expect(w.resizable).to.be.true('resizable')
+        })
       })
 
-      // TODO(codebytere): remove when propertyification is complete
-      it('can be changed with setResizable method', () => {
-        const w = new BrowserWindow({ show: false })
-        expect(w.isResizable()).to.be.true('resizable')
-        w.setResizable(false)
-        expect(w.isResizable()).to.be.false('resizable')
-        w.setResizable(true)
-        expect(w.isResizable()).to.be.true('resizable')
-      })
+      it('with functions', () => {
+        it('can be set with resizable constructor option', () => {
+          const w = new BrowserWindow({ show: false, resizable: false })
+          expect(w.isResizable()).to.be.false('resizable')
 
-      it('can be changed with resizable property', () => {
-        const w = new BrowserWindow({ show: false })
-        expect(w.resizable).to.be.true('resizable')
-        w.resizable = false
-        expect(w.resizable).to.be.false('resizable')
-        w.resizable = true
-        expect(w.resizable).to.be.true('resizable')
+          if (process.platform === 'darwin') {
+            expect(w.isMaximizable()).to.to.true('maximizable')
+          }
+        })
+
+        it('can be changed', () => {
+          const w = new BrowserWindow({ show: false })
+          expect(w.isResizable()).to.be.true('resizable')
+          w.setResizable(false)
+          expect(w.isResizable()).to.be.false('resizable')
+          w.setResizable(true)
+          expect(w.isResizable()).to.be.true('resizable')
+        })
       })
 
       it('works for a frameless window', () => {
@@ -3361,200 +3397,203 @@ describe('BrowserWindow module', () => {
     // Not implemented on Linux.
     afterEach(closeAllWindows)
 
-    describe('movable state (property)', () => {
-      it('can be changed with movable option', () => {
-        const w = new BrowserWindow({ show: false, movable: false })
-        expect(w.movable).to.be.false('movable')
+    describe('movable state', () => {
+      it('with properties', () => {
+        it('can be set with movable constructor option', () => {
+          const w = new BrowserWindow({ show: false, movable: false })
+          expect(w.movable).to.be.false('movable')
+        })
+
+        it('can be changed', () => {
+          const w = new BrowserWindow({ show: false })
+          expect(w.movable).to.be.true('movable')
+          w.movable = false
+          expect(w.movable).to.be.false('movable')
+          w.movable = true
+          expect(w.movable).to.be.true('movable')
+        })
       })
-      it('can be changed with movable property', () => {
-        const w = new BrowserWindow({ show: false })
-        expect(w.movable).to.be.true('movable')
-        w.movable = false
-        expect(w.movable).to.be.false('movable')
-        w.movable = true
-        expect(w.movable).to.be.true('movable')
+
+      it('with functions', () => {
+        it('can be set with movable constructor option', () => {
+          const w = new BrowserWindow({ show: false, movable: false })
+          expect(w.isMovable()).to.be.false('movable')
+        })
+
+        it('can be changed', () => {
+          const w = new BrowserWindow({ show: false })
+          expect(w.isMovable()).to.be.true('movable')
+          w.setMovable(false)
+          expect(w.isMovable()).to.be.false('movable')
+          w.setMovable(true)
+          expect(w.isMovable()).to.be.true('movable')
+        })
       })
     })
 
-    // TODO(codebytere): remove when propertyification is complete
-    describe('movable state (methods)', () => {
-      it('can be changed with movable option', () => {
-        const w = new BrowserWindow({ show: false, movable: false })
-        expect(w.isMovable()).to.be.false('movable')
-      })
-      it('can be changed with setMovable method', () => {
-        const w = new BrowserWindow({ show: false })
-        expect(w.isMovable()).to.be.true('movable')
-        w.setMovable(false)
-        expect(w.isMovable()).to.be.false('movable')
-        w.setMovable(true)
-        expect(w.isMovable()).to.be.true('movable')
-      })
-    })
+    describe('minimizable state', () => {
+      it('with properties', () => {
+        it('can be set with minimizable constructor option', () => {
+          const w = new BrowserWindow({ show: false, minimizable: false })
+          expect(w.minimizable).to.be.false('minimizable')
+        })
 
-    describe('minimizable state (property)', () => {
-      it('can be changed with minimizable option', () => {
-        const w = new BrowserWindow({ show: false, minimizable: false })
-        expect(w.minimizable).to.be.false('minimizable')
+        it('can be changed', () => {
+          const w = new BrowserWindow({ show: false })
+          expect(w.minimizable).to.be.true('minimizable')
+          w.minimizable = false
+          expect(w.minimizable).to.be.false('minimizable')
+          w.minimizable = true
+          expect(w.minimizable).to.be.true('minimizable')
+        })
       })
 
-      it('can be changed with minimizable property', () => {
-        const w = new BrowserWindow({ show: false })
-        expect(w.minimizable).to.be.true('minimizable')
-        w.minimizable = false
-        expect(w.minimizable).to.be.false('minimizable')
-        w.minimizable = true
-        expect(w.minimizable).to.be.true('minimizable')
-      })
-    })
+      it('with functions', () => {
+        it('can be set with minimizable constructor option', () => {
+          const w = new BrowserWindow({ show: false, minimizable: false })
+          expect(w.isMinimizable()).to.be.false('movable')
+        })
 
-    // TODO(codebytere): remove when propertyification is complete
-    describe('minimizable state (methods)', () => {
-      it('can be changed with minimizable option', () => {
-        const w = new BrowserWindow({ show: false, minimizable: false })
-        expect(w.isMinimizable()).to.be.false('movable')
-      })
-
-      it('can be changed with setMinimizable method', () => {
-        const w = new BrowserWindow({ show: false })
-        expect(w.isMinimizable()).to.be.true('isMinimizable')
-        w.setMinimizable(false)
-        expect(w.isMinimizable()).to.be.false('isMinimizable')
-        w.setMinimizable(true)
-        expect(w.isMinimizable()).to.be.true('isMinimizable')
+        it('can be changed', () => {
+          const w = new BrowserWindow({ show: false })
+          expect(w.isMinimizable()).to.be.true('isMinimizable')
+          w.setMinimizable(false)
+          expect(w.isMinimizable()).to.be.false('isMinimizable')
+          w.setMinimizable(true)
+          expect(w.isMinimizable()).to.be.true('isMinimizable')
+        })
       })
     })
 
     describe('maximizable state (property)', () => {
-      it('can be changed with maximizable option', () => {
-        const w = new BrowserWindow({ show: false, maximizable: false })
-        expect(w.maximizable).to.be.false('maximizable')
+      it('with properties', () => {
+        it('can be set with maximizable constructor option', () => {
+          const w = new BrowserWindow({ show: false, maximizable: false })
+          expect(w.maximizable).to.be.false('maximizable')
+        })
+
+        it('can be changed', () => {
+          const w = new BrowserWindow({ show: false })
+          expect(w.maximizable).to.be.true('maximizable')
+          w.maximizable = false
+          expect(w.maximizable).to.be.false('maximizable')
+          w.maximizable = true
+          expect(w.maximizable).to.be.true('maximizable')
+        })
+
+        it('is not affected when changing other states', () => {
+          const w = new BrowserWindow({ show: false })
+          w.maximizable = false
+          expect(w.maximizable).to.be.false('maximizable')
+          w.minimizable = false
+          expect(w.maximizable).to.be.false('maximizable')
+          w.closable = false
+          expect(w.maximizable).to.be.false('maximizable')
+
+          w.maximizable = true
+          expect(w.maximizable).to.be.true('maximizable')
+          w.closable = true
+          expect(w.maximizable).to.be.true('maximizable')
+          w.fullScreenable = false
+          expect(w.maximizable).to.be.true('maximizable')
+        })
       })
 
-      it('can be changed with maximizable property', () => {
-        const w = new BrowserWindow({ show: false })
-        expect(w.maximizable).to.be.true('maximizable')
-        w.maximizable = false
-        expect(w.maximizable).to.be.false('maximizable')
-        w.maximizable = true
-        expect(w.maximizable).to.be.true('maximizable')
-      })
+      it('with functions', () => {
+        it('can be set with maximizable constructor option', () => {
+          const w = new BrowserWindow({ show: false, maximizable: false })
+          expect(w.isMaximizable()).to.be.false('isMaximizable')
+        })
 
-      it('is not affected when changing other states', () => {
-        const w = new BrowserWindow({ show: false })
-        w.maximizable = false
-        expect(w.maximizable).to.be.false('maximizable')
-        w.minimizable = false
-        expect(w.maximizable).to.be.false('maximizable')
-        w.closable = false
-        expect(w.maximizable).to.be.false('maximizable')
+        it('can be changed', () => {
+          const w = new BrowserWindow({ show: false })
+          expect(w.isMaximizable()).to.be.true('isMaximizable')
+          w.setMaximizable(false)
+          expect(w.isMaximizable()).to.be.false('isMaximizable')
+          w.setMaximizable(true)
+          expect(w.isMaximizable()).to.be.true('isMaximizable')
+        })
 
-        w.maximizable = true
-        expect(w.maximizable).to.be.true('maximizable')
-        w.closable = true
-        expect(w.maximizable).to.be.true('maximizable')
-        w.fullScreenable = false
-        expect(w.maximizable).to.be.true('maximizable')
-      })
-    })
+        it('is not affected when changing other states', () => {
+          const w = new BrowserWindow({ show: false })
+          w.setMaximizable(false)
+          expect(w.isMaximizable()).to.be.false('isMaximizable')
+          w.setMinimizable(false)
+          expect(w.isMaximizable()).to.be.false('isMaximizable')
+          w.setClosable(false)
+          expect(w.isMaximizable()).to.be.false('isMaximizable')
 
-    // TODO(codebytere): remove when propertyification is complete
-    describe('maximizable state (methods)', () => {
-      it('can be changed with maximizable option', () => {
-        const w = new BrowserWindow({ show: false, maximizable: false })
-        expect(w.isMaximizable()).to.be.false('isMaximizable')
-      })
-
-      it('can be changed with setMaximizable method', () => {
-        const w = new BrowserWindow({ show: false })
-        expect(w.isMaximizable()).to.be.true('isMaximizable')
-        w.setMaximizable(false)
-        expect(w.isMaximizable()).to.be.false('isMaximizable')
-        w.setMaximizable(true)
-        expect(w.isMaximizable()).to.be.true('isMaximizable')
-      })
-
-      it('is not affected when changing other states', () => {
-        const w = new BrowserWindow({ show: false })
-        w.setMaximizable(false)
-        expect(w.isMaximizable()).to.be.false('isMaximizable')
-        w.setMinimizable(false)
-        expect(w.isMaximizable()).to.be.false('isMaximizable')
-        w.setClosable(false)
-        expect(w.isMaximizable()).to.be.false('isMaximizable')
-
-        w.setMaximizable(true)
-        expect(w.isMaximizable()).to.be.true('isMaximizable')
-        w.setClosable(true)
-        expect(w.isMaximizable()).to.be.true('isMaximizable')
-        w.setFullScreenable(false)
-        expect(w.isMaximizable()).to.be.true('isMaximizable')
-      })
-    })
-
-    ifdescribe(process.platform === 'win32')('maximizable state (Windows only)', () => {
-      // Only implemented on windows.
-
-      it('is reset to its former state', () => {
-        const w = new BrowserWindow({ show: false })
-        w.maximizable = false
-        w.resizable = false
-        w.resizable = true
-        expect(w.maximizable).to.be.false('maximizable')
-        w.maximizable = true
-        w.resizable = false
-        w.resizable = true
-        expect(w.maximizable).to.be.true('maximizable')
+          w.setMaximizable(true)
+          expect(w.isMaximizable()).to.be.true('isMaximizable')
+          w.setClosable(true)
+          expect(w.isMaximizable()).to.be.true('isMaximizable')
+          w.setFullScreenable(false)
+          expect(w.isMaximizable()).to.be.true('isMaximizable')
+        })
       })
     })
 
-    // TODO(codebytere): remove when propertyification is complete
-    ifdescribe(process.platform === 'win32')('maximizable state (Windows only) (methods)', () => {
-      // Only implemented on windows.
+    ifdescribe(process.platform === 'win32')('maximizable state', () => {
+      it('with properties', () => {
+        it('is reset to its former state', () => {
+          const w = new BrowserWindow({ show: false })
+          w.maximizable = false
+          w.resizable = false
+          w.resizable = true
+          expect(w.maximizable).to.be.false('maximizable')
+          w.maximizable = true
+          w.resizable = false
+          w.resizable = true
+          expect(w.maximizable).to.be.true('maximizable')
+        })
+      })
 
-      it('is reset to its former state', () => {
-        const w = new BrowserWindow({ show: false })
-        w.setMaximizable(false)
-        w.setResizable(false)
-        w.setResizable(true)
-        expect(w.isMaximizable()).to.be.false('isMaximizable')
-        w.setMaximizable(true)
-        w.setResizable(false)
-        w.setResizable(true)
-        expect(w.isMaximizable()).to.be.true('isMaximizable')
+      it('with functions', () => {
+        it('is reset to its former state', () => {
+          const w = new BrowserWindow({ show: false })
+          w.setMaximizable(false)
+          w.setResizable(false)
+          w.setResizable(true)
+          expect(w.isMaximizable()).to.be.false('isMaximizable')
+          w.setMaximizable(true)
+          w.setResizable(false)
+          w.setResizable(true)
+          expect(w.isMaximizable()).to.be.true('isMaximizable')
+        })
       })
     })
 
-    ifdescribe(process.platform === 'darwin')('fullscreenable state (property)', () => {
-      it('can be changed with fullscreenable option', () => {
-        const w = new BrowserWindow({ show: false, fullscreenable: false })
-        expect(w.fullScreenable).to.be.false('fullScreenable')
+    ifdescribe(process.platform === 'darwin')('fullscreenable state', () => {
+      it('with properties', () => {
+        it('can be set with fullscreenable constructor option', () => {
+          const w = new BrowserWindow({ show: false, fullscreenable: false })
+          expect(w.fullScreenable).to.be.false('fullScreenable')
+        })
+
+        it('can be changed', () => {
+          const w = new BrowserWindow({ show: false })
+          expect(w.fullScreenable).to.be.true('fullScreenable')
+          w.fullScreenable = false
+          expect(w.fullScreenable).to.be.false('fullScreenable')
+          w.fullScreenable = true
+          expect(w.fullScreenable).to.be.true('fullScreenable')
+        })
       })
 
-      it('can be changed with fullScreenable property', () => {
-        const w = new BrowserWindow({ show: false })
-        expect(w.fullScreenable).to.be.true('fullScreenable')
-        w.fullScreenable = false
-        expect(w.fullScreenable).to.be.false('fullScreenable')
-        w.fullScreenable = true
-        expect(w.fullScreenable).to.be.true('fullScreenable')
-      })
-    })
+      it('with functions', () => {
+        it('can be set with fullscreenable constructor option', () => {
+          const w = new BrowserWindow({ show: false, fullscreenable: false })
+          expect(w.isFullScreenable()).to.be.false('isFullScreenable')
+        })
 
-    // TODO(codebytere): remove when propertyification is complete
-    ifdescribe(process.platform === 'darwin')('fullscreenable state (methods)', () => {
-      it('can be changed with fullscreenable option', () => {
-        const w = new BrowserWindow({ show: false, fullscreenable: false })
-        expect(w.isFullScreenable()).to.be.false('isFullScreenable')
-      })
-
-      it('can be changed with setFullScreenable method', () => {
-        const w = new BrowserWindow({ show: false })
-        expect(w.isFullScreenable()).to.be.true('isFullScreenable')
-        w.setFullScreenable(false)
-        expect(w.isFullScreenable()).to.be.false('isFullScreenable')
-        w.setFullScreenable(true)
-        expect(w.isFullScreenable()).to.be.true('isFullScreenable')
+        it('can be changed', () => {
+          const w = new BrowserWindow({ show: false })
+          expect(w.isFullScreenable()).to.be.true('isFullScreenable')
+          w.setFullScreenable(false)
+          expect(w.isFullScreenable()).to.be.false('isFullScreenable')
+          w.setFullScreenable(true)
+          expect(w.isFullScreenable()).to.be.true('isFullScreenable')
+        })
       })
     })
 
@@ -3637,36 +3676,37 @@ describe('BrowserWindow module', () => {
       })
     })
 
-    describe('closable state (property)', () => {
-      it('can be changed with closable option', () => {
-        const w = new BrowserWindow({ show: false, closable: false })
-        expect(w.closable).to.be.false('closable')
+    describe('closable state', () => {
+      it('with properties', () => {
+        it('can be set with closable constructor option', () => {
+          const w = new BrowserWindow({ show: false, closable: false })
+          expect(w.closable).to.be.false('closable')
+        })
+
+        it('can be changed', () => {
+          const w = new BrowserWindow({ show: false })
+          expect(w.closable).to.be.true('closable')
+          w.closable = false
+          expect(w.closable).to.be.false('closable')
+          w.closable = true
+          expect(w.closable).to.be.true('closable')
+        })
       })
 
-      it('can be changed with setClosable method', () => {
-        const w = new BrowserWindow({ show: false })
-        expect(w.closable).to.be.true('closable')
-        w.closable = false
-        expect(w.closable).to.be.false('closable')
-        w.closable = true
-        expect(w.closable).to.be.true('closable')
-      })
-    })
+      it('with functions', () => {
+        it('can be set with closable constructor option', () => {
+          const w = new BrowserWindow({ show: false, closable: false })
+          expect(w.isClosable()).to.be.false('isClosable')
+        })
 
-    // TODO(codebytere): remove when propertyification is complete
-    describe('closable state (methods)', () => {
-      it('can be changed with closable option', () => {
-        const w = new BrowserWindow({ show: false, closable: false })
-        expect(w.isClosable()).to.be.false('isClosable')
-      })
-
-      it('can be changed with setClosable method', () => {
-        const w = new BrowserWindow({ show: false })
-        expect(w.isClosable()).to.be.true('isClosable')
-        w.setClosable(false)
-        expect(w.isClosable()).to.be.false('isClosable')
-        w.setClosable(true)
-        expect(w.isClosable()).to.be.true('isClosable')
+        it('can be changed', () => {
+          const w = new BrowserWindow({ show: false })
+          expect(w.isClosable()).to.be.true('isClosable')
+          w.setClosable(false)
+          expect(w.isClosable()).to.be.false('isClosable')
+          w.setClosable(true)
+          expect(w.isClosable()).to.be.true('isClosable')
+        })
       })
     })
 


### PR DESCRIPTION
#### Description of Change

Continuation of decision to dual-support both properties and function for primitive module properties, this time for `BrowserWindows`.

cc @wg-api

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
