### PR TITLE
chore: more modules to dual prop/fn support

### DIFF
--- a/docs/api/download-item.md
+++ b/docs/api/download-item.md
@@ -82,15 +82,11 @@ The API is only available in session's `will-download` callback function.
 If user doesn't set the save path via the API, Electron will use the original
 routine to determine the save path; this usually prompts a save dialog.
 
-**[Deprecated](modernization/property-updates.md): use the `savePath` property instead.**
-
 #### `downloadItem.getSavePath()`
 
 Returns `String` - The save path of the download item. This will be either the path
 set via `downloadItem.setSavePath(path)` or the path selected from the shown
 save dialog.
-
-**[Deprecated](modernization/property-updates.md): use the `savePath` property instead.**
 
 #### `downloadItem.setSaveDialogOptions(options)`
 

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -276,13 +276,9 @@ Returns [`Size`](structures/size.md)
 
 Marks the image as a template image.
 
-**[Deprecated](modernization/property-updates.md)**
-
 #### `image.isTemplateImage()`
 
 Returns `Boolean` - Whether the image is a template image.
-
-**[Deprecated](modernization/property-updates.md)**
 
 #### `image.crop(rect)`
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -360,7 +360,7 @@ Returns `Boolean` - `true` if an inverted color scheme (a high contrast color sc
 
 Returns `Boolean` - `true` if a high contrast theme is active, `false` otherwise.
 
-**Depreacted:** Should use the new [`nativeTheme.shouldUseHighContrastColors`](native-theme.md#nativethemeshouldusehighcontrastcolors-macos-windows-readonly) API.
+**Deprecated:** Should use the new [`nativeTheme.shouldUseHighContrastColors`](native-theme.md#nativethemeshouldusehighcontrastcolors-macos-windows-readonly) API.
 
 ### `systemPreferences.getEffectiveAppearance()` _macOS_
 
@@ -368,8 +368,6 @@ Returns `String` - Can be `dark`, `light` or `unknown`.
 
 Gets the macOS appearance setting that is currently applied to your application,
 maps to [NSApplication.effectiveAppearance](https://developer.apple.com/documentation/appkit/nsapplication/2967171-effectiveappearance?language=objc)
-
-**[Deprecated](modernization/property-updates.md)**
 
 ### `systemPreferences.getAppLevelAppearance()` _macOS_ _Deprecated_
 
@@ -379,16 +377,12 @@ Gets the macOS appearance setting that you have declared you want for
 your application, maps to [NSApplication.appearance](https://developer.apple.com/documentation/appkit/nsapplication/2967170-appearance?language=objc).
 You can use the `setAppLevelAppearance` API to set this value.
 
-**[Deprecated](modernization/property-updates.md)**
-
 ### `systemPreferences.setAppLevelAppearance(appearance)` _macOS_ _Deprecated_
 
 * `appearance` String | null - Can be `dark` or `light`
 
 Sets the appearance setting for your application, this should override the
 system default and override the value of `getEffectiveAppearance`.
-
-**[Deprecated](modernization/property-updates.md)**
 
 ### `systemPreferences.canPromptTouchID()` _macOS_
 

--- a/lib/browser/api/system-preferences.ts
+++ b/lib/browser/api/system-preferences.ts
@@ -6,21 +6,20 @@ const { systemPreferences, SystemPreferences } = process.electronBinding('system
 Object.setPrototypeOf(SystemPreferences.prototype, EventEmitter.prototype)
 EventEmitter.call(systemPreferences)
 
-if ('appLevelAppearance' in systemPreferences) {
-  deprecate.fnToProperty(
-    SystemPreferences.prototype,
-    'appLevelAppearance',
-    '_getAppLevelAppearance',
-    '_setAppLevelAppearance'
-  )
+if ('getAppLevelAppearance' in systemPreferences) {
+  const nativeALAGetter = systemPreferences.getAppLevelAppearance
+  const nativeALASetter = systemPreferences.setAppLevelAppearance
+  Object.defineProperty(SystemPreferences.prototype, 'appLevelAppearance', {
+    get: () => nativeALAGetter.call(systemPreferences),
+    set: (appearance) => nativeALASetter.call(systemPreferences, appearance)
+  })
 }
 
-if ('effectiveAppearance' in systemPreferences) {
-  deprecate.fnToProperty(
-    SystemPreferences.prototype,
-    'effectiveAppearance',
-    '_getEffectiveAppearance'
-  )
+if ('getEffectiveAppearance' in systemPreferences) {
+  const nativeEAGetter = systemPreferences.getAppLevelAppearance
+  Object.defineProperty(SystemPreferences.prototype, 'effectiveAppearance', {
+    get: () => nativeEAGetter.call(systemPreferences)
+  })
 }
 
 SystemPreferences.prototype.isDarkMode = deprecate.moveAPI(

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -5,7 +5,7 @@ const { EventEmitter } = require('events')
 const electron = require('electron')
 const path = require('path')
 const url = require('url')
-const { app, ipcMain, session, deprecate } = electron
+const { app, ipcMain, session } = electron
 
 const { internalWindowOpen } = require('@electron/internal/browser/guest-window-manager')
 const NavigationController = require('@electron/internal/browser/navigation-controller')

--- a/lib/common/api/native-image.js
+++ b/lib/common/api/native-image.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const { deprecate } = require('electron')
-const { NativeImage, nativeImage } = process.electronBinding('native_image')
-
-deprecate.fnToProperty(NativeImage.prototype, 'isMacTemplateImage', '_isTemplateImage', '_setTemplateImage')
+const { nativeImage } = process.electronBinding('native_image')
 
 module.exports = nativeImage

--- a/shell/browser/api/electron_api_system_preferences.cc
+++ b/shell/browser/api/electron_api_system_preferences.cc
@@ -99,17 +99,12 @@ void SystemPreferences::BuildPrototype(
       .SetMethod("removeUserDefault", &SystemPreferences::RemoveUserDefault)
       .SetMethod("isSwipeTrackingFromScrollEventsEnabled",
                  &SystemPreferences::IsSwipeTrackingFromScrollEventsEnabled)
-      .SetMethod("_getEffectiveAppearance",
+      .SetMethod("getEffectiveAppearance",
                  &SystemPreferences::GetEffectiveAppearance)
-      .SetMethod("_getAppLevelAppearance",
+      .SetMethod("getAppLevelAppearance",
                  &SystemPreferences::GetAppLevelAppearance)
-      .SetMethod("_setAppLevelAppearance",
+      .SetMethod("setAppLevelAppearance",
                  &SystemPreferences::SetAppLevelAppearance)
-      .SetProperty("appLevelAppearance",
-                   &SystemPreferences::GetAppLevelAppearance,
-                   &SystemPreferences::SetAppLevelAppearance)
-      .SetProperty("effectiveAppearance",
-                   &SystemPreferences::GetEffectiveAppearance)
       .SetMethod("getSystemColor", &SystemPreferences::GetSystemColor)
       .SetMethod("canPromptTouchID", &SystemPreferences::CanPromptTouchID)
       .SetMethod("promptTouchID", &SystemPreferences::PromptTouchID)

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -510,8 +510,8 @@ void NativeImage::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("toDataURL", &NativeImage::ToDataURL)
       .SetMethod("isEmpty", &NativeImage::IsEmpty)
       .SetMethod("getSize", &NativeImage::GetSize)
-      .SetMethod("_setTemplateImage", &NativeImage::SetTemplateImage)
-      .SetMethod("_isTemplateImage", &NativeImage::IsTemplateImage)
+      .SetMethod("setTemplateImage", &NativeImage::SetTemplateImage)
+      .SetMethod("isTemplateImage", &NativeImage::IsTemplateImage)
       .SetProperty("isMacTemplateImage", &NativeImage::IsTemplateImage,
                    &NativeImage::SetTemplateImage)
       .SetMethod("resize", &NativeImage::Resize)

--- a/spec-main/api-system-preferences-spec.ts
+++ b/spec-main/api-system-preferences-spec.ts
@@ -187,12 +187,47 @@ describe('systemPreferences module', () => {
   })
 
   ifdescribe(process.platform === 'darwin')('systemPreferences.appLevelAppearance', () => {
-    it('has an appLevelAppearance property', () => {
-      expect(systemPreferences).to.have.property('appLevelAppearance')
+    const options = ['dark', 'light', 'unknown', null]
+    describe('with properties', () => {
+      it('returns a valid appearance', () => {
+        const appearance = systemPreferences.appLevelAppearance
+        expect(options).to.include(appearance)
+      })
 
-      // TODO(codebytere): remove when propertyification is complete
-      expect(systemPreferences.setAppLevelAppearance).to.be.a('function')
-      expect(() => { systemPreferences.getAppLevelAppearance() }).to.not.throw()
+      it('can be changed', () => {
+        systemPreferences.appLevelAppearance = 'dark'
+        expect(systemPreferences.appLevelAppearance).to.eql('dark')
+      })
+    })
+
+    describe('with functions', () => {
+      it('returns a valid appearance', () => {
+        const appearance = systemPreferences.getAppLevelAppearance()
+        expect(options).to.include(appearance)
+      })
+
+      it('can be changed', () => {
+        systemPreferences.setAppLevelAppearance('dark')
+        const appearance = systemPreferences.getAppLevelAppearance()
+        expect(appearance).to.eql('dark')
+      })
+    })
+  })
+
+  ifdescribe(process.platform === 'darwin')('systemPreferences.effectiveAppearance', () => {
+    const options = ['dark', 'light', 'unknown']
+    describe('with properties', () => {
+      it('returns a valid appearance', () => {
+        const appearance = systemPreferences.effectiveAppearance
+        expect(options).to.include(appearance)
+      })
+    })
+
+    describe('with functions', () => {
+      it('returns a valid appearance', () => {
+        const appearance = systemPreferences.getEffectiveAppearance()
+        expect(options).to.include(appearance)
+      })
     })
   })
 

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -2,6 +2,7 @@
 
 const { expect } = require('chai')
 const { nativeImage } = require('electron')
+const { ifdescribe, ifit } = require('./spec-helpers')
 const path = require('path')
 
 describe('nativeImage module', () => {
@@ -101,31 +102,41 @@ describe('nativeImage module', () => {
     return matchingImage
   }
 
-  describe('isMacTemplateImage property', () => {
-    before(function () {
-      if (process.platform !== 'darwin') this.skip()
+  ifdescribe(process.platform === 'darwin')('isMacTemplateImage state', () => {
+    describe('with properties', () => {
+      it('correctly recognizes a template image', () => {
+        const image = nativeImage.createFromPath(path.join(__dirname, 'fixtures', 'assets', 'logo.png'))
+        expect(image.isMacTemplateImage).to.be.false()
+
+        const templateImage = nativeImage.createFromPath(path.join(__dirname, 'fixtures', 'assets', 'logo_Template.png'))
+        expect(templateImage.isMacTemplateImage).to.be.true()
+      })
+
+      it('sets a template image', function () {
+        const image = nativeImage.createFromPath(path.join(__dirname, 'fixtures', 'assets', 'logo.png'))
+        expect(image.isMacTemplateImage).to.be.false()
+
+        image.isMacTemplateImage = true
+        expect(image.isMacTemplateImage).to.be.true()
+      })
     })
 
-    it('returns whether the image is a template image', () => {
-      const image = nativeImage.createFromPath(path.join(__dirname, 'fixtures', 'assets', 'logo.png'))
+    describe('with functions', () => {
+      it('correctly recognizes a template image', () => {
+        const image = nativeImage.createFromPath(path.join(__dirname, 'fixtures', 'assets', 'logo.png'))
+        expect(image.isTemplateImage()).to.be.false()
 
-      expect(image.isMacTemplateImage).to.be.a('boolean')
+        const templateImage = nativeImage.createFromPath(path.join(__dirname, 'fixtures', 'assets', 'logo_Template.png'))
+        expect(templateImage.isTemplateImage()).to.be.true()
+      })
 
-      expect(image.isTemplateImage).to.be.a('function')
-      expect(image.setTemplateImage).to.be.a('function')
-    })
+      it('sets a template image', function () {
+        const image = nativeImage.createFromPath(path.join(__dirname, 'fixtures', 'assets', 'logo.png'))
+        expect(image.isTemplateImage()).to.be.false()
 
-    it('correctly recognizes a template image', () => {
-      const templateImage = nativeImage.createFromPath(path.join(__dirname, 'fixtures', 'assets', 'logo_Template.png'))
-      expect(templateImage.isMacTemplateImage).to.be.true()
-    })
-
-    it('sets a template image', function () {
-      const image = nativeImage.createFromPath(path.join(__dirname, 'fixtures', 'assets', 'logo.png'))
-      expect(image.isMacTemplateImage).to.be.false()
-
-      image.isMacTemplateImage = true
-      expect(image.isMacTemplateImage).to.be.true()
+        image.setTemplateImage(true)
+        expect(image.isTemplateImage()).to.be.true()
+      })
     })
   })
 


### PR DESCRIPTION
#### Description of Change

Ensures dual-support of previously deprecated primitive accessors for:
- `systemPreferences`
- `downloadItem`
- `nativeImage`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
