### PR TITLE
refactor: omit duplicates from app's x11 icon list

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1288,7 +1288,7 @@ void NativeWindowViews::SetIcon(HICON window_icon, HICON app_icon) {
 void NativeWindowViews::SetIcon(const gfx::ImageSkia& icon) {
   auto* tree_host = views::DesktopWindowTreeHostLinux::GetHostForWidget(
       GetAcceleratedWidget());
-  tree_host->SetWindowIcons(icon, icon);
+  tree_host->SetWindowIcons(icon, {});
 }
 #endif
 


### PR DESCRIPTION
#### Description of Change

Change the X11 version of `NativeWindowViews::SetIcon()` in `shell/browser/native_window_views.cc` to pass the user-provided icon to `SetWindowIcons()` once instead of twice.

On X11, [`SetWindowIcons()`](https://source.chromium.org/chromium/chromium/src/+/master:ui/platform_window/x11/x11_window.cc;l=432?q=SetWindowIcons&sq=&ss=chromium&originalUrl=https:%2F%2Fcs.chromium.org%2F) is implemented with [`XWindow::setXWindowIcons()`](https://source.chromium.org/chromium/chromium/src/+/master:ui/base/x/x11_window.cc;l=780?q=XWindow::SetXWindowIcons&sq=&ss=chromium&originalUrl=https:%2F%2Fcs.chromium.org%2F), which serializes both icons and sets the X11 property `
_NET_WM_ICON` with that serialized data. [`_NET_WM_ICON`](https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html#idm46041655311616) is just an array of icons, so including the same icon twice has no benefit. It also doubles the serialization time and keeps an extra icon in memory.

This change sends an empty ImageSkia as the second icon, which is skipped by [`SetXWindowIcons`](https://source.chromium.org/chromium/chromium/src/+/master:ui/base/x/x11_window.cc;l=795?q=XWindow::SetXWindowIcons&ss=chromium&originalUrl=https:%2F%2Fcs.chromium.org%2F)

No particular stakeholder; reviews welcomed from anyone :slightly_smiling_face: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Made setting window icons slightly faster on Linux.