### PR TITLE
feat: add support for net requests to use the session cookie store

### DIFF
--- a/docs/api/client-request.md
+++ b/docs/api/client-request.md
@@ -22,6 +22,9 @@ which the request is associated.
   with which the request is associated. Defaults to the empty string. The
 `session` option prevails on `partition`. Thus if a `session` is explicitly
 specified, `partition` is ignored.
+  * `useSessionCookies` Boolean (optional) - Whether to send cookies with this
+    request from the provided session.  This will make the `net` request's
+    cookie behavior match a `fetch` request. Default is `false`.
   * `protocol` String (optional) - The protocol scheme in the form 'scheme:'.
 Currently supported values are 'http:' or 'https:'. Defaults to 'http:'.
   * `host` String (optional) - The server host provided as a concatenation of

--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -236,7 +236,8 @@ function parseOptions (options) {
     method: method,
     url: urlStr,
     redirectPolicy,
-    extraHeaders: options.headers || {}
+    extraHeaders: options.headers || {},
+    useSessionCookies: options.useSessionCookies || false
   };
   for (const [name, value] of Object.entries(urlLoaderOptions.extraHeaders)) {
     if (!_isValidHeaderName(name)) {

--- a/shell/browser/api/electron_api_url_loader.cc
+++ b/shell/browser/api/electron_api_url_loader.cc
@@ -17,6 +17,7 @@
 #include "gin/wrappable.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "mojo/public/cpp/system/data_pipe_producer.h"
+#include "net/base/load_flags.h"
 #include "services/network/public/cpp/resource_request.h"
 #include "services/network/public/cpp/simple_url_loader.h"
 #include "services/network/public/mojom/chunked_data_pipe_getter.mojom.h"
@@ -356,6 +357,12 @@ gin_helper::WrappableBase* SimpleURLLoaderWrapper::New(gin::Arguments* args) {
       }
       request->headers.SetHeader(it.first, it.second);
     }
+  }
+
+  bool use_session_cookies = false;
+  opts.Get("useSessionCookies", &use_session_cookies);
+  if (!use_session_cookies) {
+    request->load_flags |= net::LOAD_DO_NOT_SEND_COOKIES;
   }
 
   // Chromium filters headers using browser rules, while for net module we have


### PR DESCRIPTION
Closes #8891
Fixes #22541

There is a common use case for wanting to send a `fetch`-like request from the main process.  The `net` module is designed to serve this use case but it unfortunately lacks support for using cookies the same way `fetch` would.  This leads to hacks and insecure direct usage of the `Cookies` header.

This new flag makes any `net` request use Chromium's internal cookie store logic.

Comes with tests and stuff 👍 

Notes: Added new `useSessionCookies` flag to `net` requests to allow them to use the session cookie store.