### PR TITLE
refactor: precache the IsWindowStateEvent() XAtom

### DIFF
--- a/shell/browser/ui/x/window_state_watcher.cc
+++ b/shell/browser/ui/x/window_state_watcher.cc
@@ -9,7 +9,9 @@
 namespace electron {
 
 WindowStateWatcher::WindowStateWatcher(NativeWindowViews* window)
-    : window_(window), widget_(window->GetAcceleratedWidget()) {
+    : window_(window),
+      widget_(window->GetAcceleratedWidget()),
+      window_state_atom_(gfx::GetAtom("_NET_WM_STATE")) {
   ui::X11EventSource::GetInstance()->AddXEventObserver(this);
 }
 
@@ -53,9 +55,8 @@ void WindowStateWatcher::DidProcessXEvent(XEvent* xev) {
   }
 }
 
-bool WindowStateWatcher::IsWindowStateEvent(XEvent* xev) {
-  ::Atom changed_atom = xev->xproperty.atom;
-  return (changed_atom == gfx::GetAtom("_NET_WM_STATE") &&
+bool WindowStateWatcher::IsWindowStateEvent(XEvent* xev) const {
+  return (xev->xproperty.atom == window_state_atom_ &&
           xev->type == PropertyNotify && xev->xproperty.window == widget_);
 }
 

--- a/shell/browser/ui/x/window_state_watcher.h
+++ b/shell/browser/ui/x/window_state_watcher.h
@@ -22,10 +22,11 @@ class WindowStateWatcher : public ui::XEventObserver {
   void DidProcessXEvent(XEvent* xev) override;
 
  private:
-  bool IsWindowStateEvent(XEvent* xev);
+  bool IsWindowStateEvent(XEvent* xev) const;
 
   NativeWindowViews* window_;
   gfx::AcceleratedWidget widget_;
+  const ::XAtom window_state_atom_;
 
   bool was_minimized_ = false;
   bool was_maximized_ = false;


### PR DESCRIPTION
#### Description of Change

Don't look up the `_NET_WM_STATE` XAtom every time we get an XEvent. Instead, get it when the `WindowStateWatcher` is constructed and keep it in a private const field. XEvents are high volume -- for example, moving a mouse across the screen can trigger dozens of XMouseEvents per second -- so looking it up in each event handler call is expensive over time.

Background info: what we're avoiding in each event handler call is a call to [XInternAtom()](https://github.com/mirror/libX11/blob/b676e62377483df77bcb6472d26b24f901323fa9/src/IntAtom.c#L56) which hashes the key, then does a linear walk through a list of interned keys & returns a match when found. 

No particular stakeholder; reviews welcomed from anyone :slightly_smiling_face: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Improved window events handler efficiency on Linux.