### PR TITLE
fix: crash on invalid zoomFactor

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1066,10 +1066,12 @@ Returns `Boolean` - Whether audio is currently playing.
 
 #### `contents.setZoomFactor(factor)`
 
-* `factor` Number - Zoom factor.
+* `factor` Double - Zoom factor; default is 1.0.
 
 Changes the zoom factor to the specified factor. Zoom factor is
 zoom percent divided by 100, so 300% = 3.0.
+
+The factor must be greater than 0.0.
 
 **[Deprecated](modernization/property-updates.md)**
 

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -22,10 +22,12 @@ The `WebFrame` class has the following instance methods:
 
 ### `webFrame.setZoomFactor(factor)`
 
-* `factor` Number - Zoom factor.
+* `factor` Double - Zoom factor; default is 1.0.
 
 Changes the zoom factor to the specified factor. Zoom factor is
 zoom percent divided by 100, so 300% = 3.0.
+
+The factor must be greater than 0.0.
 
 ### `webFrame.getZoomFactor()`
 

--- a/shell/browser/api/atom_api_web_contents.cc
+++ b/shell/browser/api/atom_api_web_contents.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/api/atom_api_web_contents.h"
 
+#include <limits>
 #include <memory>
 #include <set>
 #include <string>
@@ -2321,7 +2322,12 @@ double WebContents::GetZoomLevel() const {
   return zoom_controller_->GetZoomLevel();
 }
 
-void WebContents::SetZoomFactor(double factor) {
+void WebContents::SetZoomFactor(mate::Arguments* args, double factor) {
+  if (factor < std::numeric_limits<double>::epsilon()) {
+    args->ThrowError("'zoomFactor' must be a double greater than 0.0");
+    return;
+  }
+
   auto level = content::ZoomFactorToZoomLevel(factor);
   SetZoomLevel(level);
 }

--- a/shell/browser/api/atom_api_web_contents.h
+++ b/shell/browser/api/atom_api_web_contents.h
@@ -281,7 +281,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   // Methods for zoom handling.
   void SetZoomLevel(double level);
   double GetZoomLevel() const;
-  void SetZoomFactor(double factor);
+  void SetZoomFactor(mate::Arguments* args, double factor);
   double GetZoomFactor() const;
 
   // Callback triggered on permission response.

--- a/shell/renderer/api/atom_api_web_frame.cc
+++ b/shell/renderer/api/atom_api_web_frame.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include <limits>
 #include <memory>
 #include <string>
 #include <utility>
@@ -250,7 +251,14 @@ double GetZoomLevel(v8::Local<v8::Value> window) {
   return result;
 }
 
-void SetZoomFactor(v8::Local<v8::Value> window, double factor) {
+void SetZoomFactor(mate::Arguments* args,
+                   v8::Local<v8::Value> window,
+                   double factor) {
+  if (factor < std::numeric_limits<double>::epsilon()) {
+    args->ThrowError("'zoomFactor' must be a double greater than 0.0");
+    return;
+  }
+
   SetZoomLevel(window, blink::WebView::ZoomFactorToZoomLevel(factor));
 }
 


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/22673.

See that PR for more details.

Notes: Fixed a potential crash on invalid `zoomFactor` values when setting the zoom factor of a webpage.