### PR TITLE
refactor: ginify session.netLog

### DIFF
--- a/docs/api/net-log.md
+++ b/docs/api/net-log.md
@@ -40,7 +40,7 @@ Starts recording network events to `path`.
 
 ### `netLog.stopLogging()`
 
-Returns `Promise<String>` - resolves with a file path to which network logs were recorded.
+Returns `Promise<void>` - resolves when the net log has been flushed to disk.
 
 Stops recording network events. If not called, net logging will automatically end when app quits.
 
@@ -48,8 +48,4 @@ Stops recording network events. If not called, net logging will automatically en
 
 ### `netLog.currentlyLogging` _Readonly_
 
-A `Boolean` property that indicates whether network logs are recorded.
-
-### `netLog.currentlyLoggingPath` _Readonly_ _Deprecated_
-
-A `String` property that returns the path to the current log file.
+A `Boolean` property that indicates whether network logs are currently being recorded.

--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -2,7 +2,7 @@
 
 const { EventEmitter } = require('events')
 const { app, deprecate } = require('electron')
-const { fromPartition, Session, Cookies, NetLog, Protocol, ServiceWorkerContext } = process.electronBinding('session')
+const { fromPartition, Session, Cookies, Protocol, ServiceWorkerContext } = process.electronBinding('session')
 
 // Public API.
 Object.defineProperties(exports, {
@@ -23,32 +23,3 @@ Object.setPrototypeOf(Session.prototype, EventEmitter.prototype)
 Session.prototype._init = function () {
   app.emit('session-created', this)
 }
-
-const _originalStartLogging = NetLog.prototype.startLogging
-NetLog.prototype.startLogging = function (path, ...args) {
-  this._currentlyLoggingPath = path
-  try {
-    return _originalStartLogging.call(this, path, ...args)
-  } catch (e) {
-    this._currentlyLoggingPath = null
-    throw e
-  }
-}
-
-const _originalStopLogging = NetLog.prototype.stopLogging
-NetLog.prototype.stopLogging = function () {
-  const logPath = this._currentlyLoggingPath
-  this._currentlyLoggingPath = null
-  return _originalStopLogging.call(this).then(() => logPath)
-}
-
-const currentlyLoggingPathDeprecated = deprecate.warnOnce('currentlyLoggingPath')
-Object.defineProperties(NetLog.prototype, {
-  currentlyLoggingPath: {
-    enumerable: true,
-    get () {
-      currentlyLoggingPathDeprecated()
-      return this._currentlyLoggingPath == null ? '' : this._currentlyLoggingPath
-    }
-  }
-})

--- a/shell/browser/api/electron_api_net_log.h
+++ b/shell/browser/api/electron_api_net_log.h
@@ -13,9 +13,13 @@
 #include "base/optional.h"
 #include "base/values.h"
 #include "gin/handle.h"
+#include "gin/wrappable.h"
 #include "services/network/public/mojom/net_log.mojom.h"
 #include "shell/common/gin_helper/promise.h"
-#include "shell/common/gin_helper/trackable_object.h"
+
+namespace gin {
+class Arguments;
+}
 
 namespace electron {
 
@@ -23,18 +27,21 @@ class ElectronBrowserContext;
 
 namespace api {
 
-class NetLog : public gin_helper::TrackableObject<NetLog> {
+class NetLog : public gin::Wrappable<NetLog> {
  public:
   static gin::Handle<NetLog> Create(v8::Isolate* isolate,
                                     ElectronBrowserContext* browser_context);
 
-  static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::FunctionTemplate> prototype);
-
   v8::Local<v8::Promise> StartLogging(base::FilePath log_path,
-                                      gin_helper::Arguments* args);
-  v8::Local<v8::Promise> StopLogging(gin_helper::Arguments* args);
+                                      gin::Arguments* args);
+  v8::Local<v8::Promise> StopLogging(gin::Arguments* args);
   bool IsCurrentlyLogging() const;
+
+  // gin::Wrappable
+  static gin::WrapperInfo kWrapperInfo;
+  gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
+      v8::Isolate* isolate) override;
+  const char* GetTypeName() override;
 
  protected:
   explicit NetLog(v8::Isolate* isolate,

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -307,7 +307,6 @@ Session::~Session() {
   // Refs https://github.com/electron/electron/pull/12305.
   DestroyGlobalHandle(isolate(), cookies_);
   DestroyGlobalHandle(isolate(), protocol_);
-  DestroyGlobalHandle(isolate(), net_log_);
   g_sessions.erase(weak_map_id());
 }
 
@@ -1029,7 +1028,6 @@ void Session::BuildPrototype(v8::Isolate* isolate,
 namespace {
 
 using electron::api::Cookies;
-using electron::api::NetLog;
 using electron::api::Protocol;
 using electron::api::ServiceWorkerContext;
 using electron::api::Session;
@@ -1058,9 +1056,6 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.Set(
       "Cookies",
       Cookies::GetConstructor(isolate)->GetFunction(context).ToLocalChecked());
-  dict.Set(
-      "NetLog",
-      NetLog::GetConstructor(isolate)->GetFunction(context).ToLocalChecked());
   dict.Set(
       "Protocol",
       Protocol::GetConstructor(isolate)->GetFunction(context).ToLocalChecked());

--- a/spec-main/api-net-log-spec.ts
+++ b/spec-main/api-net-log-spec.ts
@@ -69,10 +69,7 @@ describe('netLog module', () => {
 
     expect(testNetLog().currentlyLogging).to.be.true('currently logging')
 
-    expect(testNetLog().currentlyLoggingPath).to.equal(dumpFileDynamic)
-
-    const path = await testNetLog().stopLogging()
-    expect(path).to.equal(dumpFileDynamic)
+    await testNetLog().stopLogging()
 
     expect(fs.existsSync(dumpFileDynamic)).to.be.true('currently logging')
   })


### PR DESCRIPTION
#### Description of Change
This refactors `netLog` to use `gin::Wrappable` instead of `gin_helper::TrackableObject`.

Additionally, it removes the deprecated `currentlyLoggingPath` and the `String` return value of `netLog.stopLogging`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Removed the deprecated `currentlyLoggingPath` property of `netLog`. Additionally, `netLog.stopLogging` no longer returns the path to the recorded log.
