### PR TITLE
chore: add missing pdfTwoUpViewEnabled status

### DIFF
--- a/shell/browser/extensions/api/resources_private/resources_private_api.cc
+++ b/shell/browser/extensions/api/resources_private/resources_private_api.cc
@@ -51,6 +51,8 @@ void AddStringsForPdf(base::DictionaryValue* dict) {
       {"tooltipPrint", IDS_PDF_TOOLTIP_PRINT},
       {"tooltipFitToPage", IDS_PDF_TOOLTIP_FIT_PAGE},
       {"tooltipFitToWidth", IDS_PDF_TOOLTIP_FIT_WIDTH},
+      {"tooltipTwoUpViewDisable", IDS_PDF_TOOLTIP_TWO_UP_VIEW_DISABLE},
+      {"tooltipTwoUpViewEnable", IDS_PDF_TOOLTIP_TWO_UP_VIEW_ENABLE},
       {"tooltipZoomIn", IDS_PDF_TOOLTIP_ZOOM_IN},
       {"tooltipZoomOut", IDS_PDF_TOOLTIP_ZOOM_OUT},
   };
@@ -69,6 +71,9 @@ void AddAdditionalDataForPdf(base::DictionaryValue* dict) {
   dict->SetKey("pdfAnnotationsEnabled",
                base::Value(base::FeatureList::IsEnabled(
                    chrome_pdf::features::kPDFAnnotations)));
+  dict->SetKey("pdfTwoUpViewEnabled",
+               base::Value(base::FeatureList::IsEnabled(
+                   chrome_pdf::features::kPDFTwoUpView)));
 
   // TODO(nornagon): enable printing once it works.
   bool enable_printing = false;


### PR DESCRIPTION
#### Description of Change

Fixes the following console error when loading any PDF:

```
"Unexpected condition on chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai/index.html: Could not find value for pdfTwoUpViewEnabled", source: chrome://resources/js/load_time_data.m.js (222)
"Unexpected condition on chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai/index.html: [undefined] (pdfTwoUpViewEnabled) is not a boolean", source: chrome://resources/js/load_time_data.m.js (222)
```

Added to Chromium in [this CL](https://chromium-review.googlesource.com/c/chromium/src/+/2012837).

cc @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
