### PR TITLE
test: no need to loadURL in menu test

### DIFF
--- a/spec-main/fixtures/api/test-menu-null/main.js
+++ b/spec-main/fixtures/api/test-menu-null/main.js
@@ -3,7 +3,6 @@ const { app, BrowserWindow } = require('electron')
 let win
 app.whenReady().then(function () {
   win = new BrowserWindow({})
-  win.loadURL('about:blank')
   win.setMenu(null)
 
   setTimeout(() => {

--- a/spec-main/fixtures/api/test-menu-visibility/main.js
+++ b/spec-main/fixtures/api/test-menu-visibility/main.js
@@ -3,7 +3,6 @@ const { app, BrowserWindow } = require('electron')
 let win
 app.whenReady().then(function () {
   win = new BrowserWindow({})
-  win.loadURL('about:blank')
   win.setMenuBarVisibility(false)
 
   setTimeout(() => {


### PR DESCRIPTION
There is no need to call `loadURL` when testing window menus. This should be able to make the `app.setApplicationMenu` tests less flaky.

#### Release Notes

Notes: no-notes
