### PR TITLE
feat(view-api): add ImageView

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -606,6 +606,8 @@ source_set("electron_lib") {
       "shell/browser/api/views/electron_api_box_layout.h",
       "shell/browser/api/views/electron_api_button.cc",
       "shell/browser/api/views/electron_api_button.h",
+      "shell/browser/api/views/electron_api_image_view.cc",
+      "shell/browser/api/views/electron_api_image_view.h",
       "shell/browser/api/views/electron_api_label_button.cc",
       "shell/browser/api/views/electron_api_label_button.h",
       "shell/browser/api/views/electron_api_layout_manager.cc",

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -244,6 +244,7 @@ auto_filenames = {
     "lib/browser/api/view.js",
     "lib/browser/api/views/box-layout.js",
     "lib/browser/api/views/button.js",
+    "lib/browser/api/views/image-view.js",
     "lib/browser/api/views/label-button.js",
     "lib/browser/api/views/layout-manager.js",
     "lib/browser/api/views/md-text-button.js",

--- a/lib/browser/api/module-list.ts
+++ b/lib/browser/api/module-list.ts
@@ -39,6 +39,7 @@ if (features.isViewApiEnabled()) {
   browserModuleList.push(
     { name: 'BoxLayout', loader: () => require('./views/box-layout') },
     { name: 'Button', loader: () => require('./views/button') },
+    { name: 'ImageView', loader: () => require('./views/image-view') },
     { name: 'LabelButton', loader: () => require('./views/label-button') },
     { name: 'LayoutManager', loader: () => require('./views/layout-manager') },
     { name: 'MdTextButton', loader: () => require('./views/md-text-button') },

--- a/lib/browser/api/views/image-view.js
+++ b/lib/browser/api/views/image-view.js
@@ -1,0 +1,13 @@
+const electron = require('electron');
+
+const { View } = electron;
+const { ImageView } = process.electronBinding('image_view');
+
+Object.setPrototypeOf(ImageView.prototype, View.prototype);
+
+ImageView.prototype._init = function () {
+  // Call parent class's _init.
+  View.prototype._init.call(this);
+};
+
+module.exports = ImageView;

--- a/shell/browser/api/views/electron_api_image_view.cc
+++ b/shell/browser/api/views/electron_api_image_view.cc
@@ -1,0 +1,63 @@
+// Copyright (c) 2020 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/api/views/electron_api_image_view.h"
+
+#include "shell/common/gin_converters/image_converter.h"
+#include "shell/common/gin_helper/constructor.h"
+#include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/object_template_builder.h"
+#include "shell/common/node_includes.h"
+
+namespace electron {
+
+namespace api {
+
+ImageView::ImageView() : View(new views::ImageView()) {
+  view()->set_owned_by_client();
+}
+
+ImageView::~ImageView() {}
+
+void ImageView::SetImage(const gfx::Image& image) {
+  image_view()->SetImage(image.AsImageSkia());
+}
+
+// static
+gin_helper::WrappableBase* ImageView::New(gin_helper::Arguments* args) {
+  // Constructor call.
+  auto* view = new ImageView();
+  view->InitWithArgs(args);
+  return view;
+}
+
+// static
+void ImageView::BuildPrototype(v8::Isolate* isolate,
+                               v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(gin::StringToV8(isolate, "ImageView"));
+  gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
+      .SetMethod("setImage", &ImageView::SetImage);
+}
+
+}  // namespace api
+
+}  // namespace electron
+
+namespace {
+
+using electron::api::ImageView;
+
+void Initialize(v8::Local<v8::Object> exports,
+                v8::Local<v8::Value> unused,
+                v8::Local<v8::Context> context,
+                void* priv) {
+  v8::Isolate* isolate = context->GetIsolate();
+  gin_helper::Dictionary dict(isolate, exports);
+  dict.Set("ImageView", gin_helper::CreateConstructor<ImageView>(
+                            isolate, base::BindRepeating(&ImageView::New)));
+}
+
+}  // namespace
+
+NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_image_view, Initialize)

--- a/shell/browser/api/views/electron_api_image_view.h
+++ b/shell/browser/api/views/electron_api_image_view.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2020 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_BROWSER_API_VIEWS_ELECTRON_API_IMAGE_VIEW_H_
+#define SHELL_BROWSER_API_VIEWS_ELECTRON_API_IMAGE_VIEW_H_
+
+#include "gin/handle.h"
+#include "shell/browser/api/electron_api_view.h"
+#include "ui/gfx/image/image.h"
+#include "ui/views/controls/image_view.h"
+
+namespace electron {
+
+namespace api {
+
+class ImageView : public View {
+ public:
+  static gin_helper::WrappableBase* New(gin_helper::Arguments* args);
+
+  static void BuildPrototype(v8::Isolate* isolate,
+                             v8::Local<v8::FunctionTemplate> prototype);
+
+  void SetImage(const gfx::Image& image);
+
+ protected:
+  ImageView();
+  ~ImageView() override;
+
+  views::ImageView* image_view() const {
+    return static_cast<views::ImageView*>(view());
+  }
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(ImageView);
+};
+
+}  // namespace api
+
+}  // namespace electron
+
+#endif  // SHELL_BROWSER_API_VIEWS_ELECTRON_API_IMAGE_VIEW_H_

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -76,6 +76,7 @@
 #define ELECTRON_VIEW_MODULES(V)     \
   V(electron_browser_box_layout)     \
   V(electron_browser_button)         \
+  V(electron_browser_image_view)     \
   V(electron_browser_label_button)   \
   V(electron_browser_layout_manager) \
   V(electron_browser_md_text_button) \


### PR DESCRIPTION
#### Description of Change

This PR adds a simple `ImageView` with a single `setImage` method, this class is hidden under the `enable_view_api` build flag.

One use of this class, is to show a splash image when the window is created, and then replace the image view with WebContents once after the page is loaded. I have a written a simple demo:
https://gist.github.com/zcbenz/e0048264a2890c2b9e85fa91e5682b76

Once this is merged, I will start working on an RFC to make parts of the view APIs public, which would be a minimum set of APIs to enable implementing loading screens for apps (i.e. the APIs used by the demo above).

The feature of `ImageView` is currently rather limited, and I'll start improving it after the RFC is accepted.

Note that this PR does not touch our public API. 

#### Release Notes

Notes: no-notes