### PR TITLE
refactor: move set_owned_by_client calls to base View

### DIFF
--- a/shell/browser/api/electron_api_view.cc
+++ b/shell/browser/api/electron_api_view.cc
@@ -12,11 +12,11 @@ namespace electron {
 
 namespace api {
 
-View::View(views::View* view) : view_(view) {}
-
-View::View() : view_(new views::View()) {
+View::View(views::View* view) : view_(view) {
   view_->set_owned_by_client();
 }
+
+View::View() : View(new views::View()) {}
 
 View::~View() {
   if (delete_view_)

--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -53,12 +53,11 @@ WebContentsView::WebContentsView(v8::Isolate* isolate,
 #endif
       web_contents_(isolate, web_contents->GetWrapper()),
       api_web_contents_(web_contents.get()) {
-#if defined(OS_MACOSX)
-  // On macOS a View is created to wrap the NSView, and its lifetime is managed
-  // by us.
   view()->set_owned_by_client();
-#else
-  // On other platforms the View is managed by InspectableWebContents.
+#if !defined(OS_MACOSX)
+  // On macOS the View is a newly-created |DelayedNativeViewHost| and it is our
+  // responsibility to delete it. On other platforms the View is created and
+  // managed by InspectableWebContents.
   set_delete_view(false);
 #endif
   WebContentsViewRelay::CreateForWebContents(web_contents->web_contents());

--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -53,7 +53,6 @@ WebContentsView::WebContentsView(v8::Isolate* isolate,
 #endif
       web_contents_(isolate, web_contents->GetWrapper()),
       api_web_contents_(web_contents.get()) {
-  view()->set_owned_by_client();
 #if !defined(OS_MACOSX)
   // On macOS the View is a newly-created |DelayedNativeViewHost| and it is our
   // responsibility to delete it. On other platforms the View is created and

--- a/shell/browser/api/views/electron_api_button.cc
+++ b/shell/browser/api/views/electron_api_button.cc
@@ -13,7 +13,6 @@ namespace electron {
 namespace api {
 
 Button::Button(views::Button* impl) : View(impl) {
-  view()->set_owned_by_client();
   // Make the button focusable as per the platform.
   button()->SetFocusForPlatform();
 }

--- a/shell/browser/api/views/electron_api_resize_area.cc
+++ b/shell/browser/api/views/electron_api_resize_area.cc
@@ -12,9 +12,7 @@ namespace electron {
 
 namespace api {
 
-ResizeArea::ResizeArea() : View(new views::ResizeArea(this)) {
-  view()->set_owned_by_client();
-}
+ResizeArea::ResizeArea() : View(new views::ResizeArea(this)) {}
 
 ResizeArea::~ResizeArea() {}
 

--- a/shell/browser/api/views/electron_api_text_field.cc
+++ b/shell/browser/api/views/electron_api_text_field.cc
@@ -13,9 +13,7 @@ namespace electron {
 
 namespace api {
 
-TextField::TextField() : View(new views::Textfield()) {
-  view()->set_owned_by_client();
-}
+TextField::TextField() : View(new views::Textfield()) {}
 
 TextField::~TextField() {}
 

--- a/shell/browser/ui/views/inspectable_web_contents_view_views.cc
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.cc
@@ -87,8 +87,6 @@ InspectableWebContentsViewViews::InspectableWebContentsViewViews(
       devtools_visible_(false),
       devtools_window_delegate_(nullptr),
       title_(base::ASCIIToUTF16("Developer Tools")) {
-  set_owned_by_client();
-
   if (!inspectable_web_contents_->IsGuest() &&
       inspectable_web_contents_->GetWebContents()->GetNativeView()) {
     views::WebView* contents_web_view = new views::WebView(nullptr);


### PR DESCRIPTION
#### Description of Change

This refactors `View` and its child classes to put all `set_owned_by_client` calls in the base view.

#### Release Notes

Notes: no-notes