### PR TITLE
refactor: ginify desktopCapturer

### DIFF
--- a/shell/browser/api/electron_api_desktop_capturer.h
+++ b/shell/browser/api/electron_api_desktop_capturer.h
@@ -12,13 +12,13 @@
 #include "chrome/browser/media/webrtc/desktop_media_list_observer.h"
 #include "chrome/browser/media/webrtc/native_desktop_media_list.h"
 #include "gin/handle.h"
-#include "shell/common/gin_helper/trackable_object.h"
+#include "gin/wrappable.h"
 
 namespace electron {
 
 namespace api {
 
-class DesktopCapturer : public gin_helper::TrackableObject<DesktopCapturer>,
+class DesktopCapturer : public gin::Wrappable<DesktopCapturer>,
                         public DesktopMediaListObserver {
  public:
   struct Source {
@@ -32,13 +32,16 @@ class DesktopCapturer : public gin_helper::TrackableObject<DesktopCapturer>,
 
   static gin::Handle<DesktopCapturer> Create(v8::Isolate* isolate);
 
-  static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::FunctionTemplate> prototype);
-
   void StartHandling(bool capture_window,
                      bool capture_screen,
                      const gfx::Size& thumbnail_size,
                      bool fetch_window_icons);
+
+  // gin::Wrappable
+  static gin::WrapperInfo kWrapperInfo;
+  gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
+      v8::Isolate* isolate) override;
+  const char* GetTypeName() override;
 
  protected:
   explicit DesktopCapturer(v8::Isolate* isolate);

--- a/shell/common/gin_helper/event_emitter_caller.h
+++ b/shell/common/gin_helper/event_emitter_caller.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "gin/converter.h"
+#include "gin/wrappable.h"
 
 namespace gin_helper {
 
@@ -61,6 +62,28 @@ v8::Local<v8::Value> CustomEmit(v8::Isolate* isolate,
   };
   return internal::CallMethodWithArgs(isolate, object, custom_emit,
                                       &converted_args);
+}
+
+template <typename T, typename... Args>
+v8::Local<v8::Value> CallMethod(v8::Isolate* isolate,
+                                gin::Wrappable<T>* object,
+                                const char* method_name,
+                                Args&&... args) {
+  v8::HandleScope scope(isolate);
+  v8::Local<v8::Object> v8_object;
+  if (object->GetWrapper(isolate).ToLocal(&v8_object))
+    return CustomEmit(isolate, v8_object, method_name,
+                      std::forward<Args>(args)...);
+  else
+    return v8::Local<v8::Value>();
+}
+
+template <typename T, typename... Args>
+v8::Local<v8::Value> CallMethod(gin::Wrappable<T>* object,
+                                const char* method_name,
+                                Args&&... args) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  return CallMethod(isolate, object, method_name, std::forward<Args>(args)...);
 }
 
 }  // namespace gin_helper

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -94,7 +94,8 @@ declare namespace ElectronInternal {
 
   interface DesktopCapturer {
     startHandling(captureWindow: boolean, captureScreen: boolean, thumbnailSize: Electron.Size, fetchWindowIcons: boolean): void;
-    emit: typeof NodeJS.EventEmitter.prototype.emit | null;
+    _onerror: (error: string) => void;
+    _onfinished: (sources: Electron.DesktopCapturerSource[], fetchWindowIcons: boolean) => void;
   }
 
   interface GetSourcesOptions {


### PR DESCRIPTION
#### Description of Change
This refactors the `DesktopCapturer` class to be `gin::Wrappable` instead of `TrackableObject`. It was previously (ab)using EventEmitter to transmit information to JS; I've refactored this into simple method calls by way of a small helper function.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none