### PR TITLE
chore: add @loc to manual backport config

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -33,6 +33,7 @@ authorizedUsers:
   - codebytere
   - deepak1556
   - jkleinsc
+  - loc
   - MarshallOfSound
   - miniak
   - nornagon


### PR DESCRIPTION
Let @loc run manual backports with trop.

Notes: no-notes