### PR TITLE
refactor: ginify globalShortcut

### DIFF
--- a/shell/browser/api/electron_api_global_shortcut.cc
+++ b/shell/browser/api/electron_api_global_shortcut.cc
@@ -9,11 +9,11 @@
 
 #include "base/stl_util.h"
 #include "base/strings/utf_string_conversions.h"
+#include "gin/dictionary.h"
+#include "gin/object_template_builder.h"
 #include "shell/browser/api/electron_api_system_preferences.h"
 #include "shell/common/gin_converters/accelerator_converter.h"
 #include "shell/common/gin_converters/callback_converter.h"
-#include "shell/common/gin_helper/dictionary.h"
-#include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
 
 #if defined(OS_MACOSX)
@@ -49,9 +49,9 @@ namespace electron {
 
 namespace api {
 
-GlobalShortcut::GlobalShortcut(v8::Isolate* isolate) {
-  Init(isolate);
-}
+gin::WrapperInfo GlobalShortcut::kWrapperInfo = {gin::kEmbedderNativeGin};
+
+GlobalShortcut::GlobalShortcut(v8::Isolate* isolate) {}
 
 GlobalShortcut::~GlobalShortcut() {
   UnregisterAll();
@@ -131,15 +131,18 @@ gin::Handle<GlobalShortcut> GlobalShortcut::Create(v8::Isolate* isolate) {
 }
 
 // static
-void GlobalShortcut::BuildPrototype(v8::Isolate* isolate,
-                                    v8::Local<v8::FunctionTemplate> prototype) {
-  prototype->SetClassName(gin::StringToV8(isolate, "GlobalShortcut"));
-  gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
+gin::ObjectTemplateBuilder GlobalShortcut::GetObjectTemplateBuilder(
+    v8::Isolate* isolate) {
+  return gin::Wrappable<GlobalShortcut>::GetObjectTemplateBuilder(isolate)
       .SetMethod("registerAll", &GlobalShortcut::RegisterAll)
       .SetMethod("register", &GlobalShortcut::Register)
       .SetMethod("isRegistered", &GlobalShortcut::IsRegistered)
       .SetMethod("unregister", &GlobalShortcut::Unregister)
       .SetMethod("unregisterAll", &GlobalShortcut::UnregisterAll);
+}
+
+const char* GlobalShortcut::GetTypeName() {
+  return "GlobalShortcut";
 }
 
 }  // namespace api
@@ -153,7 +156,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  gin_helper::Dictionary dict(isolate, exports);
+  gin::Dictionary dict(isolate, exports);
   dict.Set("globalShortcut", electron::api::GlobalShortcut::Create(isolate));
 }
 

--- a/shell/browser/api/electron_api_global_shortcut.h
+++ b/shell/browser/api/electron_api_global_shortcut.h
@@ -12,7 +12,7 @@
 #include "base/callback.h"
 #include "chrome/browser/extensions/global_shortcut_listener.h"
 #include "gin/handle.h"
-#include "shell/common/gin_helper/trackable_object.h"
+#include "gin/wrappable.h"
 #include "ui/base/accelerators/accelerator.h"
 
 namespace electron {
@@ -20,12 +20,15 @@ namespace electron {
 namespace api {
 
 class GlobalShortcut : public extensions::GlobalShortcutListener::Observer,
-                       public gin_helper::TrackableObject<GlobalShortcut> {
+                       public gin::Wrappable<GlobalShortcut> {
  public:
   static gin::Handle<GlobalShortcut> Create(v8::Isolate* isolate);
 
-  static void BuildPrototype(v8::Isolate* isolate,
-                             v8::Local<v8::FunctionTemplate> prototype);
+  // gin::Wrappable
+  static gin::WrapperInfo kWrapperInfo;
+  gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
+      v8::Isolate* isolate) override;
+  const char* GetTypeName() override;
 
  protected:
   explicit GlobalShortcut(v8::Isolate* isolate);


### PR DESCRIPTION
#### Description of Change
This was an easy one! It's not an EventEmitter so it was straightforward to swap out `TrackableObject` for plain `gin::Wrappable`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none