### PR TITLE
fix: print from PDF viewer not working

### DIFF
--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -242,6 +242,8 @@ static_library("chrome") {
       "//chrome/renderer/extensions/extension_hooks_delegate.h",
       "//chrome/renderer/extensions/tabs_hooks_delegate.cc",
       "//chrome/renderer/extensions/tabs_hooks_delegate.h",
+      "//chrome/renderer/pepper/chrome_pdf_print_client.cc",
+      "//chrome/renderer/pepper/chrome_pdf_print_client.h",
     ]
   }
 }

--- a/shell/browser/extensions/api/resources_private/resources_private_api.cc
+++ b/shell/browser/extensions/api/resources_private/resources_private_api.cc
@@ -74,10 +74,7 @@ void AddAdditionalDataForPdf(base::DictionaryValue* dict) {
   dict->SetKey("pdfTwoUpViewEnabled",
                base::Value(base::FeatureList::IsEnabled(
                    chrome_pdf::features::kPDFTwoUpView)));
-
-  // TODO(nornagon): enable printing once it works.
-  bool enable_printing = false;
-  dict->SetKey("printingEnabled", base::Value(enable_printing));
+  dict->SetKey("printingEnabled", base::Value(true));
 #endif  // BUILDFLAG(ENABLE_PDF)
 }
 

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -68,6 +68,7 @@
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 #include "base/strings/utf_string_conversions.h"
+#include "chrome/renderer/pepper/chrome_pdf_print_client.h"
 #include "content/public/common/webplugininfo.h"
 #include "extensions/common/constants.h"
 #include "extensions/common/extensions_client.h"
@@ -155,6 +156,9 @@ void RendererClientBase::RenderThreadStarted() {
 
   extensions_renderer_client_.reset(new ElectronExtensionsRendererClient);
   extensions::ExtensionsRendererClient::Set(extensions_renderer_client_.get());
+
+  // Enables printing from Chrome PDF viewer.
+  pdf::PepperPDFHost::SetPrintClient(new ChromePDFPrintClient());
 
   thread->AddObserver(extensions_renderer_client_->GetDispatcher());
 #endif


### PR DESCRIPTION
#### Description of Change

Fixes the print button functionality in the PDF viewer.

![pdf-print](https://user-images.githubusercontent.com/2036040/77011251-ac630400-6928-11ea-9d1b-5a75d630f65b.gif)

cc @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed the print button functionality in the PDF viewer extension.
