### PR TITLE
chore: stop leaking v8 environment in main process

### DIFF
--- a/shell/browser/api/electron_api_event_emitter.cc
+++ b/shell/browser/api/electron_api_event_emitter.cc
@@ -6,6 +6,7 @@
 
 #include "base/bind.h"
 #include "base/callback.h"
+#include "base/no_destructor.h"
 #include "gin/dictionary.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/node_includes.h"
@@ -13,11 +14,14 @@
 
 namespace {
 
-v8::Global<v8::Object> event_emitter_prototype;
+v8::Global<v8::Object>* GetEventEmitterPrototypeReference() {
+  static base::NoDestructor<v8::Global<v8::Object>> event_emitter_prototype;
+  return event_emitter_prototype.get();
+}
 
 void SetEventEmitterPrototype(v8::Isolate* isolate,
                               v8::Local<v8::Object> proto) {
-  event_emitter_prototype.Reset(isolate, proto);
+  GetEventEmitterPrototypeReference()->Reset(isolate, proto);
 }
 
 void Initialize(v8::Local<v8::Object> exports,
@@ -36,8 +40,8 @@ void Initialize(v8::Local<v8::Object> exports,
 namespace electron {
 
 v8::Local<v8::Object> GetEventEmitterPrototype(v8::Isolate* isolate) {
-  CHECK(!event_emitter_prototype.IsEmpty());
-  return event_emitter_prototype.Get(isolate);
+  CHECK(!GetEventEmitterPrototypeReference()->IsEmpty());
+  return GetEventEmitterPrototypeReference()->Get(isolate);
 }
 
 }  // namespace electron

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -227,15 +227,6 @@ ElectronBrowserMainParts::ElectronBrowserMainParts(
 
 ElectronBrowserMainParts::~ElectronBrowserMainParts() {
   asar::ClearArchives();
-  // Leak the JavascriptEnvironment on exit.
-  // This is to work around the bug that V8 would be waiting for background
-  // tasks to finish on exit, while somehow it waits forever in Electron, more
-  // about this can be found at
-  // https://github.com/electron/electron/issues/4767. On the other handle there
-  // is actually no need to gracefully shutdown V8 on exit in the main process,
-  // we already ensured all necessary resources get cleaned up, and it would
-  // make quitting faster.
-  ignore_result(js_env_.release());
 }
 
 // static

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -129,8 +129,8 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   // Pointer to exit code.
   int* exit_code_ = nullptr;
 
-  std::unique_ptr<Browser> browser_;
   std::unique_ptr<JavascriptEnvironment> js_env_;
+  std::unique_ptr<Browser> browser_;
   std::unique_ptr<NodeBindings> node_bindings_;
   std::unique_ptr<ElectronBindings> electron_bindings_;
   std::unique_ptr<NodeEnvironment> node_env_;


### PR DESCRIPTION
#### Description of Change
This changes our shutdown procedure to include cleaning up the v8 Isolate. The bug referenced in the comment appears to no longer be an issue.

Two things broke when I made this change, both discovered via ASan:

1. `Browser` was being destroyed _after_ the Isolate, which meant it was attempting to clean up its `Global` handles, but v8 had already cleaned them up.
2. There were some global variables of type `v8::Global`, which were crashing on shutdown because their destructors were being called during C++'s finalization stage. I've switched those globals to `base::NoDestructor` to prevent those destructors from being called. They might be better stored in `gin::PerIsolateData` or on some other object with a more clearly defined lifetime. However, at present we only ever have a single v8 isolate in the main process, so that problem can be solved another time.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none