### PR TITLE
fix: avoid double-free in TrackableObject (9-x-y)

### DIFF
--- a/shell/common/gin_helper/trackable_object.h
+++ b/shell/common/gin_helper/trackable_object.h
@@ -58,6 +58,7 @@ class TrackableObject : public TrackableObjectBase, public EventEmitter<T> {
     v8::Local<v8::Object> wrapper = gin_helper::Wrappable<T>::GetWrapper();
     if (!wrapper.IsEmpty()) {
       wrapper->SetAlignedPointerInInternalField(0, nullptr);
+      gin_helper::WrappableBase::wrapper_.ClearWeak();
     }
   }
 

--- a/shell/common/gin_helper/wrappable_base.h
+++ b/shell/common/gin_helper/wrappable_base.h
@@ -52,6 +52,8 @@ class WrappableBase {
   // Helper to init with arguments.
   void InitWithArgs(gin::Arguments* args);
 
+  v8::Global<v8::Object> wrapper_;  // Weak
+
  private:
   static void FirstWeakCallback(
       const v8::WeakCallbackInfo<WrappableBase>& data);
@@ -59,7 +61,6 @@ class WrappableBase {
       const v8::WeakCallbackInfo<WrappableBase>& data);
 
   v8::Isolate* isolate_ = nullptr;
-  v8::Global<v8::Object> wrapper_;  // Weak
 
   DISALLOW_COPY_AND_ASSIGN(WrappableBase);
 };


### PR DESCRIPTION
#### Description of Change

This cherry-picks the double-free fix in https://github.com/electron/electron/pull/22531 to `9-x-y` as the same error is now happening there.

#### Release Notes

Notes: no-notes