### PR TITLE
fix: don't allow window to go behind menu bar on mac

### DIFF
--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -89,11 +89,11 @@ bool ScopedDisableResize::disable_resize_ = false;
   if (electron::ScopedDisableResize::IsResizeDisabled())
     return [self frame];
 
+  NSRect result = [super constrainFrameRect:frameRect toScreen:screen];
   // Enable the window to be larger than screen.
   if ([self enableLargerThanScreen])
-    return frameRect;
-  else
-    return [super constrainFrameRect:frameRect toScreen:screen];
+    result.size = frameRect.size;
+  return result;
 }
 
 - (void)setFrame:(NSRect)windowFrame display:(BOOL)displayViews {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1598,9 +1598,15 @@ describe('BrowserWindow module', () => {
     afterEach(closeAllWindows);
     it('can move the window out of screen', () => {
       const w = new BrowserWindow({ show: true, enableLargerThanScreen: true });
+      w.setPosition(-10, 50);
+      const after = w.getPosition();
+      expect(after).to.deep.equal([-10, 50]);
+    });
+    it('cannot move the window behind menu bar', () => {
+      const w = new BrowserWindow({ show: true, enableLargerThanScreen: true });
       w.setPosition(-10, -10);
       const after = w.getPosition();
-      expect(after).to.deep.equal([-10, -10]);
+      expect(after[1]).to.be.at.least(0);
     });
     it('without it, cannot move the window out of screen', () => {
       const w = new BrowserWindow({ show: true, enableLargerThanScreen: false });


### PR DESCRIPTION
This change fixes #22667.

Notes: don't allow window to go behind menu bar on mac
