### PR TITLE
fix: do not initialize extension system in in-memory sessions

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -820,24 +820,26 @@ void ElectronBrowserClient::SiteInstanceGotProcess(
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   auto* browser_context =
       static_cast<ElectronBrowserContext*>(site_instance->GetBrowserContext());
-  extensions::ExtensionRegistry* registry =
-      extensions::ExtensionRegistry::Get(browser_context);
-  const extensions::Extension* extension =
-      registry->enabled_extensions().GetExtensionOrAppByURL(
-          site_instance->GetSiteURL());
-  if (!extension)
-    return;
+  if (!browser_context->IsOffTheRecord()) {
+    extensions::ExtensionRegistry* registry =
+        extensions::ExtensionRegistry::Get(browser_context);
+    const extensions::Extension* extension =
+        registry->enabled_extensions().GetExtensionOrAppByURL(
+            site_instance->GetSiteURL());
+    if (!extension)
+      return;
 
-  extensions::ProcessMap::Get(browser_context)
-      ->Insert(extension->id(), site_instance->GetProcess()->GetID(),
-               site_instance->GetId());
+    extensions::ProcessMap::Get(browser_context)
+        ->Insert(extension->id(), site_instance->GetProcess()->GetID(),
+                 site_instance->GetId());
 
-  base::PostTask(
-      FROM_HERE, {BrowserThread::IO},
-      base::BindOnce(&extensions::InfoMap::RegisterExtensionProcess,
-                     browser_context->extension_system()->info_map(),
-                     extension->id(), site_instance->GetProcess()->GetID(),
-                     site_instance->GetId()));
+    base::PostTask(
+        FROM_HERE, {BrowserThread::IO},
+        base::BindOnce(&extensions::InfoMap::RegisterExtensionProcess,
+                       browser_context->extension_system()->info_map(),
+                       extension->id(), site_instance->GetProcess()->GetID(),
+                       site_instance->GetId()));
+  }
 #endif  // BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 }
 
@@ -902,25 +904,27 @@ void ElectronBrowserClient::SiteInstanceDeleting(
 
   auto* browser_context =
       static_cast<ElectronBrowserContext*>(site_instance->GetBrowserContext());
-  // If this isn't an extension renderer there's nothing to do.
-  extensions::ExtensionRegistry* registry =
-      extensions::ExtensionRegistry::Get(browser_context);
-  const extensions::Extension* extension =
-      registry->enabled_extensions().GetExtensionOrAppByURL(
-          site_instance->GetSiteURL());
-  if (!extension)
-    return;
+  if (!browser_context->IsOffTheRecord()) {
+    // If this isn't an extension renderer there's nothing to do.
+    extensions::ExtensionRegistry* registry =
+        extensions::ExtensionRegistry::Get(browser_context);
+    const extensions::Extension* extension =
+        registry->enabled_extensions().GetExtensionOrAppByURL(
+            site_instance->GetSiteURL());
+    if (!extension)
+      return;
 
-  extensions::ProcessMap::Get(browser_context)
-      ->Remove(extension->id(), site_instance->GetProcess()->GetID(),
-               site_instance->GetId());
+    extensions::ProcessMap::Get(browser_context)
+        ->Remove(extension->id(), site_instance->GetProcess()->GetID(),
+                 site_instance->GetId());
 
-  base::PostTask(
-      FROM_HERE, {BrowserThread::IO},
-      base::BindOnce(&extensions::InfoMap::UnregisterExtensionProcess,
-                     browser_context->extension_system()->info_map(),
-                     extension->id(), site_instance->GetProcess()->GetID(),
-                     site_instance->GetId()));
+    base::PostTask(
+        FROM_HERE, {BrowserThread::IO},
+        base::BindOnce(&extensions::InfoMap::UnregisterExtensionProcess,
+                       browser_context->extension_system()->info_map(),
+                       extension->id(), site_instance->GetProcess()->GetID(),
+                       site_instance->GetId()));
+  }
 #endif
 }
 

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -138,6 +138,8 @@ class ElectronBrowserContext
   }
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
+  // Guard usages of extension_system() with !IsOffTheRecord()
+  // There is no extension system for in-memory sessions
   extensions::ElectronExtensionSystem* extension_system() {
     return extension_system_;
   }

--- a/spec-main/crash-spec.ts
+++ b/spec-main/crash-spec.ts
@@ -1,0 +1,54 @@
+import { expect } from 'chai'
+import * as cp from 'child_process'
+import * as fs from 'fs'
+import * as path from 'path'
+
+const fixturePath = path.resolve(__dirname, 'fixtures', 'crash-cases')
+
+let children: cp.ChildProcessWithoutNullStreams[] = []
+
+const runFixtureAndEnsureCleanExit = (args: string[]) => {
+  let out = ''
+  const child = cp.spawn(process.execPath, args)
+  children.push(child)
+  child.stdout.on('data', (chunk: Buffer) => {
+    out += chunk.toString()
+  })
+  child.stderr.on('data', (chunk: Buffer) => {
+    out += chunk.toString()
+  })
+  return new Promise((resolve) => {
+    child.on('exit', (code, signal) => {
+      if (code !== 0 || signal !== null) {
+        console.error(out)
+      }
+      expect(signal).to.equal(null, 'exit signal should be null')
+      expect(code).to.equal(0, 'should have exited with code 0')
+      children = children.filter(c => c !== child)
+      resolve()
+    })
+  })
+}
+
+describe('crash cases', () => {
+  afterEach(() => {
+    for (const child of children) {
+      child.kill()
+    }
+    expect(children).to.have.lengthOf(0, 'all child processes should have exited cleanly')
+    children.length = 0
+  })
+  const cases = fs.readdirSync(fixturePath)
+
+  for (const crashCase of cases) {
+    it(`the "${crashCase}" case should not crash`, () => {
+      const fixture = path.resolve(fixturePath, crashCase)
+      const argsFile = path.resolve(fixture, 'electron.args')
+      const args = [fixture]
+      if (fs.existsSync(argsFile)) {
+        args.push(...fs.readFileSync(argsFile, 'utf8').trim().split('\n'))
+      }
+      return runFixtureAndEnsureCleanExit(args)
+    })
+  }
+})

--- a/spec-main/fixtures/crash-cases/early-in-memory-session-create/index.js
+++ b/spec-main/fixtures/crash-cases/early-in-memory-session-create/index.js
@@ -1,0 +1,6 @@
+const { app, session } = require('electron')
+
+app.on('ready', () => {
+  session.fromPartition('in-memory')
+  process.exit(0)
+})


### PR DESCRIPTION
Fixes #22414

Some parts of Chrome in the extension logic expect at least one persistent (not off the record) BrowserContext to exist even when creating an off-the-record context.  This change ensures we don't initialize extensions in a context that does not meet that expectation.  It also adds some handy new infra in our test suite to make it really easy to test crash regressions in the future 👍 

Notes: fixed crash that could occur when calling `session.fromPartition` inside the ready event