### PR TITLE
feat: add support for optimizing simple objects and functions over the context bridge

### DIFF
--- a/docs/api/context-bridge.md
+++ b/docs/api/context-bridge.md
@@ -44,7 +44,30 @@ The `contextBridge` module has the following methods:
 ### `contextBridge.exposeInMainWorld(apiKey, api)` _Experimental_
 
 * `apiKey` String - The key to inject the API onto `window` with.  The API will be accessible on `window[apiKey]`.
-* `api` Record<String, any> - Your API object, more information on what this API can be and how it works is available below.
+* `api` Record<String, any> - Your API object, more information on what this API can be and how it works is available [below](#parameter--error--return-type-support)).
+
+### `contextBridge.exposeSimpleObjectInMainWorld(objectKey, object)` _Experimental_
+
+* `objectKey` String - The key to inject the object onto `window` with.  The object will be accessible on `window[objectKey]`.
+* `object` Record<String, any> - Your object, the keys and values of this object must be **simple** data types from the [Type Support](#parameter--error--return-type-support)) table below.
+Non-simple data types will result in an error being thrown.
+
+This method can be used instead of `exposeInMainWorld` if you just want to provide a set of data and not expose any methods.  Sending
+large data structures as "simple" can be around three times faster so if you only want to expose a data structure it can make sense to
+use `exposeSimpleObjectInMainWorld`.
+
+### `contextBridge.prepareSimpleFunction<T extends Function>(func)` _Experimental_
+
+* `func` T - A function that you want to expose over the context bridge.
+
+Returns `T`, a function of the same type as the function that was provided.
+
+This method can be used to omptimize certain functions to be faster when called over the context bridge. The function
+returned from this method will **only** support being called with, and returning, **simple** data types from the
+[Type Support](#parameter--error--return-type-support) table.  Non-simple data types will result in an error being thrown.
+
+Sending large data structures as "simple" can be around three times faster so if you plan on calling this function a lot
+or sending a lot of data it can make sense to wrap it with `prepareSimpleFunction`.
 
 ## Usage
 
@@ -100,12 +123,12 @@ has been included below for completeness:
 | `String` | Simple | ✅ | ✅ | N/A |
 | `Number` | Simple | ✅ | ✅ | N/A |
 | `Boolean` | Simple | ✅ | ✅ | N/A |
-| `Object` | Complex | ✅ | ✅ | Keys must be supported using only "Simple" types in this table.  Values must be supported in this table.  Prototype modifications are dropped.  Sending custom classes will copy values but not the prototype. |
-| `Array` | Complex | ✅ | ✅ | Same limitations as the `Object` type |
+| `Object` | Simple | ✅ | ✅ | Keys must be supported using only "Simple" types in this table.  Values must be supported in this table.  Prototype modifications are dropped.  Sending custom classes will copy values but not the prototype. |
+| `Array` | Simple | ✅ | ✅ | Same limitations as the `Object` type |
+| [Cloneable Types](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) | Simple | ✅ | ✅ | See the linked document on cloneable types |
 | `Error` | Complex | ✅ | ✅ | Errors that are thrown are also copied, this can result in the message and stack trace of the error changing slightly due to being thrown in a different context |
 | `Promise` | Complex | ✅ | ✅ | Promises are only proxied if they are the return value or exact parameter.  Promises nested in arrays or objects will be dropped. |
 | `Function` | Complex | ✅ | ✅ | Prototype modifications are dropped.  Sending classes or constructors will not work. |
-| [Cloneable Types](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) | Simple | ✅ | ✅ | See the linked document on cloneable types |
 | `Symbol` | N/A | ❌ | ❌ | Symbols cannot be copied across contexts so they are dropped |
 
 

--- a/lib/renderer/api/context-bridge.ts
+++ b/lib/renderer/api/context-bridge.ts
@@ -1,5 +1,6 @@
 const { hasSwitch } = process.electronBinding('command_line')
 const binding = process.electronBinding('context_bridge')
+const v8Util = process.electronBinding('v8_util')
 
 const contextIsolationEnabled = hasSwitch('context-isolation')
 
@@ -11,6 +12,18 @@ const contextBridge = {
   exposeInMainWorld: (key: string, api: Record<string, any>) => {
     checkContextIsolationEnabled()
     return binding.exposeAPIInMainWorld(key, api)
+  },
+  exposeSimpleObjectInMainWorld: (key: string, api: Record<string, string>) => {
+    checkContextIsolationEnabled()
+    return binding.exposeObjectInMainWorld(key, api)
+  },
+  prepareSimpleFunction: (fn: any) => {
+    if (typeof fn !== 'function') {
+      throw new Error(`Expected argument to be a function, instead got "${typeof fn}"`)
+    }
+    const wrapped = (...args: any[]) => fn(...args)
+    v8Util.setHiddenValue(wrapped, '_cbSimple', true)
+    return wrapped
   },
   debugGC: () => binding._debugGCMaps({})
 }

--- a/shell/renderer/api/electron_api_context_bridge.h
+++ b/shell/renderer/api/electron_api_context_bridge.h
@@ -18,11 +18,21 @@ namespace api {
 
 namespace context_bridge {
 class RenderFrameFunctionStore;
-}
+
+enum ProxyMode {
+  // Traditionally non-transferable objects will be smartly proxied, this
+  // includes functions and promises
+  kSmart,
+  // Follows classic serialization / de-serialization strategy
+  kSimple
+};
+
+}  // namespace context_bridge
 
 v8::Local<v8::Value> ProxyFunctionWrapper(
     context_bridge::RenderFrameFunctionStore* store,
     size_t func_id,
+    context_bridge::ProxyMode proxy_mode,
     gin_helper::Arguments* args);
 
 v8::MaybeLocal<v8::Object> CreateProxyForAPI(
@@ -31,6 +41,7 @@ v8::MaybeLocal<v8::Object> CreateProxyForAPI(
     const v8::Local<v8::Context>& target_context,
     context_bridge::RenderFrameFunctionStore* store,
     context_bridge::ObjectCache* object_cache,
+    context_bridge::ProxyMode proxy_mode,
     int recursion_depth);
 
 }  // namespace api


### PR DESCRIPTION
The contextBridge clone algorithm is slow (about on par with our `base::Value` converter, but slower than the V8 structured clone algorithm).  This PR adds two new methods to allow apps to force different parts of the context bridge (individual functions and entire objects) to be sent over the bridge in "simple" mode that exclusively uses the structured cloning algorithm.  This can result in upwards of 3x speed improvements for sending large objects over the bridge.

![Screen Shot 2020-03-19 at 11 41 40 AM](https://user-images.githubusercontent.com/6634592/77108619-c3b0f880-69df-11ea-8a62-2251038220fb.png)

Recommend reviewing with [whitespace diff disabled](https://github.com/electron/electron/pull/22774/files?diff=split&w=1), there aren't actually that many changes here.

Notes: Added new `contextBridge.prepareSimpleFunction` and `contextBridge.exposeSimpleObjectInMainWorld` APIs to allow apps to potentially send data over the context bridge faster.