### PR TITLE
fix: allow net requests to use Same-Site cookies

### DIFF
--- a/shell/browser/api/electron_api_url_loader.cc
+++ b/shell/browser/api/electron_api_url_loader.cc
@@ -345,6 +345,7 @@ gin_helper::WrappableBase* SimpleURLLoaderWrapper::New(gin::Arguments* args) {
     return nullptr;
   }
   auto request = std::make_unique<network::ResourceRequest>();
+  request->attach_same_site_cookies = true;
   opts.Get("method", &request->method);
   opts.Get("url", &request->url);
   std::map<std::string, std::string> extra_headers;


### PR DESCRIPTION
It's expected that when the `net` module sends cookies, it sends all eligible cookies.  The default behavior of Chromium is to _not_ send same site cookies.  We should so that users can achieve with `net` what they could do with `fetch` 👍 

Currently targeting the `net-cookie-option` branch till that lands as it uses the same testing infrastructure.

Notes: Fixed issue where `SameSite` cookies would not be attached to outgoing requests from the `net` module