### PR TITLE
feat: add support for net requests to use the session cookie store

### DIFF
--- a/docs/api/client-request.md
+++ b/docs/api/client-request.md
@@ -22,6 +22,9 @@ which the request is associated.
   with which the request is associated. Defaults to the empty string. The
 `session` option prevails on `partition`. Thus if a `session` is explicitly
 specified, `partition` is ignored.
+  * `useSessionCookies` Boolean (optional) - Whether to send cookies with this
+    request from the provided session.  This will make the `net` request's
+    cookie behavior match a `fetch` request. Default is `false`.
   * `protocol` String (optional) - The protocol scheme in the form 'scheme:'.
 Currently supported values are 'http:' or 'https:'. Defaults to 'http:'.
   * `host` String (optional) - The server host provided as a concatenation of

--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -234,7 +234,8 @@ function parseOptions (options) {
     method: method,
     url: urlStr,
     redirectPolicy,
-    extraHeaders: options.headers || {}
+    extraHeaders: options.headers || {},
+    useSessionCookies: options.useSessionCookies || false
   };
   for (const [name, value] of Object.entries(urlLoaderOptions.extraHeaders)) {
     if (!_isValidHeaderName(name)) {

--- a/shell/browser/api/electron_api_url_loader.cc
+++ b/shell/browser/api/electron_api_url_loader.cc
@@ -344,6 +344,7 @@ gin_helper::WrappableBase* SimpleURLLoaderWrapper::New(gin::Arguments* args) {
     return nullptr;
   }
   auto request = std::make_unique<network::ResourceRequest>();
+  request->attach_same_site_cookies = true;
   opts.Get("method", &request->method);
   opts.Get("url", &request->url);
   std::map<std::string, std::string> extra_headers;

--- a/shell/browser/api/electron_api_url_loader.cc
+++ b/shell/browser/api/electron_api_url_loader.cc
@@ -16,6 +16,7 @@
 #include "gin/object_template_builder.h"
 #include "gin/wrappable.h"
 #include "mojo/public/cpp/system/data_pipe_producer.h"
+#include "net/base/load_flags.h"
 #include "services/network/public/cpp/resource_request.h"
 #include "services/network/public/cpp/simple_url_loader.h"
 #include "services/network/public/mojom/chunked_data_pipe_getter.mojom.h"
@@ -355,6 +356,12 @@ gin_helper::WrappableBase* SimpleURLLoaderWrapper::New(gin::Arguments* args) {
       }
       request->headers.SetHeader(it.first, it.second);
     }
+  }
+
+  bool use_session_cookies = false;
+  opts.Get("useSessionCookies", &use_session_cookies);
+  if (!use_session_cookies) {
+    request->load_flags |= net::LOAD_DO_NOT_SEND_COOKIES;
   }
 
   // Chromium filters headers using browser rules, while for net module we have

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -60,8 +60,10 @@ function respondNTimes (fn: http.RequestListener, n: number): Promise<string> {
     const server = http.createServer((request, response) => {
       fn(request, response);
       // don't close if a redirect was returned
-      n--;
-      if ((response.statusCode < 300 || response.statusCode >= 399) && n <= 0) { server.close(); }
+      if ((response.statusCode < 300 || response.statusCode >= 399) && n <= 0) {
+        n--;
+        server.close();
+      }
     });
     server.listen(0, '127.0.0.1', () => {
       resolve(`http://127.0.0.1:${(server.address() as AddressInfo).port}`);

--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -45,17 +45,17 @@ ifdescribe(process.electronBinding('features').isExtensionsEnabled())('chrome ex
   });
 
   it('serializes a loaded extension', async () => {
-    const extensionPath = path.join(fixtures, 'extensions', 'red-bg')
-    const manifest = JSON.parse(fs.readFileSync(path.join(extensionPath, 'manifest.json'), 'utf-8'))
-    const customSession = session.fromPartition(`persist:${require('uuid').v4()}`)
-    const extension = await customSession.loadExtension(extensionPath)
-    expect(extension.id).to.be.a('string')
-    expect(extension.name).to.be.a('string')
-    expect(extension.path).to.be.a('string')
-    expect(extension.version).to.be.a('string')
-    expect(extension.url).to.be.a('string')
-    expect(extension.manifest).to.deep.equal(manifest)
-  })
+    const extensionPath = path.join(fixtures, 'extensions', 'red-bg');
+    const manifest = JSON.parse(fs.readFileSync(path.join(extensionPath, 'manifest.json'), 'utf-8'));
+    const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
+    const extension = await customSession.loadExtension(extensionPath);
+    expect(extension.id).to.be.a('string');
+    expect(extension.name).to.be.a('string');
+    expect(extension.path).to.be.a('string');
+    expect(extension.version).to.be.a('string');
+    expect(extension.url).to.be.a('string');
+    expect(extension.manifest).to.deep.equal(manifest);
+  });
 
   it('removes an extension', async () => {
     const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);


### PR DESCRIPTION
Backport of #22731
Backport of #22745 
Backport of #22704 
Backport of #22788 

See those PRs for details.

Notes:
* Added new `useSessionCookies` flag to `net` requests to allow them to use the session cookie store.
* Fixed issue where `SameSite` cookies would not be attached to outgoing requests from the `net` module