### PR TITLE
build: fix beta version bumper logic for betas beyond 10

### DIFF
--- a/script/release/version-utils.js
+++ b/script/release/version-utils.js
@@ -44,7 +44,11 @@ async function nextBeta (v) {
 
   const tagBlob = await GitProcess.exec(['tag', '--list', '-l', `v${next}-beta.*`], ELECTRON_DIR);
   const tags = tagBlob.stdout.split('\n').filter(e => e !== '');
-  tags.sort((t1, t2) => semver.gt(t1, t2));
+  tags.sort((t1, t2) => {
+    const a = parseInt(t1.split('.').pop(), 10);
+    const b = parseInt(t2.split('.').pop(), 10);
+    return a - b;
+  });
 
   // increment the latest existing beta tag or start at beta.1 if it's a new beta line
   return tags.length === 0 ? `${next}-beta.1` : semver.inc(tags.pop(), 'prerelease');

--- a/spec-main/version-bump-spec.ts
+++ b/spec-main/version-bump-spec.ts
@@ -95,6 +95,14 @@ describe('version-bumper', () => {
       expect(next).to.equal('2.0.0-beta.9');
     });
 
+    it('bumps to beta from beta if the previous beta is at least beta.10', async () => {
+      const version = 'v6.0.0-beta.10';
+      const next = await nextVersion('beta', version);
+      // Last 6.0.0 beta we did was beta.15
+      // So we expect a beta.16 here
+      expect(next).to.equal('6.0.0-beta.16');
+    });
+
     it('bumps to stable from beta', async () => {
       const version = 'v2.0.0-beta.1';
       const next = await nextVersion('stable', version);


### PR DESCRIPTION
Manually parse out and sort the pre-release version number as a number instead of as a string to determine the next beta.  Otherwise `10 < 2` which is mathematically, uh, wrong

Notes: no-notes