### PR TITLE
build: fix missing pdf dep in chromium_src

### DIFF
--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -263,6 +263,7 @@ source_set("plugins") {
     "//chrome/browser/renderer_host/pepper/pepper_isolated_file_system_message_filter.h",
   ]
   deps += [
+    "//components/pdf/browser",
     "//media:media_buildflags",
     "//ppapi/buildflags",
     "//ppapi/proxy:ipc",
@@ -315,6 +316,7 @@ source_set("plugins") {
     ]
   }
   deps += [
+    "//components/pdf/renderer",
     "//components/strings",
     "//media:media_buildflags",
     "//ppapi/host",


### PR DESCRIPTION
#### Description of Change
Fixes e.g.

```
In file included from ../../chrome/renderer/pepper/chrome_renderer_pepper_host_factory.cc:18:
../..\components/pdf/renderer/pepper_pdf_host.h(17,10): fatal error: 'components/pdf/common/pdf.mojom.h' file not found
#include "components/pdf/common/pdf.mojom.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Notes: none