### PR TITLE
fix: remote should only mess with its own constructors

### DIFF
--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -22,6 +22,8 @@ process.on('exit', () => {
   ipcRendererInternal.send(command, contextId);
 });
 
+const IS_REMOTE_PROXY = Symbol('is-remote-proxy');
+
 // Convert the arguments object into an array of meta data.
 function wrapArgs (args, visited = new Set()) {
   const valueToMeta = (value) => {
@@ -188,6 +190,7 @@ function proxyFunctionProperties (remoteMemberFunction, metaId, name) {
       return true;
     },
     get: (target, property, receiver) => {
+      if (property === IS_REMOTE_PROXY) return true;
       if (!Object.prototype.hasOwnProperty.call(target, property)) loadRemoteProperties();
       const value = target[property];
       if (property === 'toString' && typeof value === 'function') {
@@ -247,7 +250,9 @@ function metaToValue (meta) {
 
     setObjectMembers(ret, ret, meta.id, meta.members);
     setObjectPrototype(ret, ret, meta.id, meta.proto);
-    Object.defineProperty(ret.constructor, 'name', { value: meta.name });
+    if (ret.constructor && ret.constructor[IS_REMOTE_PROXY]) {
+      Object.defineProperty(ret.constructor, 'name', { value: meta.name });
+    }
 
     // Track delegate obj's lifetime & tell browser to clean up when object is GCed.
     v8Util.setRemoteObjectFreer(ret, contextId, meta.id);


### PR DESCRIPTION
#### Description of Change
This removes a behavior of `remote` that could cause it to erroneously overwrite the name of the `Object` and `Function` constructors in certain situations, and also throw errors when creating objects without constructors (e.g. `gin::Wrappable`-based things.).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue that could cause exceptions in the 'remote' module when accessing objects without constructors.
