### PR TITLE
refactor: ginify Cookies

### DIFF
--- a/lib/browser/api/session.js
+++ b/lib/browser/api/session.js
@@ -2,7 +2,7 @@
 
 const { EventEmitter } = require('events');
 const { app, deprecate } = require('electron');
-const { fromPartition, Session, Cookies, Protocol } = process.electronBinding('session');
+const { fromPartition, Session, Protocol } = process.electronBinding('session');
 
 // Public API.
 Object.defineProperties(exports, {
@@ -16,7 +16,6 @@ Object.defineProperties(exports, {
   }
 });
 
-Object.setPrototypeOf(Cookies.prototype, EventEmitter.prototype);
 Object.setPrototypeOf(Session.prototype, EventEmitter.prototype);
 
 Session.prototype._init = function () {

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -305,7 +305,6 @@ Session::~Session() {
   // TODO(zcbenz): Now since URLRequestContextGetter is gone, is this still
   // needed?
   // Refs https://github.com/electron/electron/pull/12305.
-  DestroyGlobalHandle(isolate(), cookies_);
   DestroyGlobalHandle(isolate(), protocol_);
   g_sessions.erase(weak_map_id());
 }
@@ -1053,9 +1052,6 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.Set(
       "Session",
       Session::GetConstructor(isolate)->GetFunction(context).ToLocalChecked());
-  dict.Set(
-      "Cookies",
-      Cookies::GetConstructor(isolate)->GetFunction(context).ToLocalChecked());
   dict.Set(
       "Protocol",
       Protocol::GetConstructor(isolate)->GetFunction(context).ToLocalChecked());


### PR DESCRIPTION
#### Description of Change
This refactors Cookies to use `gin::Wrappable` instead of `TrackableObject`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none