### PR TITLE
fix: missing HandleScope in WebDialogHelper

### DIFF
--- a/shell/browser/web_dialog_helper.cc
+++ b/shell/browser/web_dialog_helper.cc
@@ -58,6 +58,7 @@ class FileSelectHelper : public base::RefCounted<FileSelectHelper>,
 
   void ShowOpenDialog(const file_dialog::DialogSettings& settings) {
     v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::HandleScope scope(isolate);
     gin_helper::Promise<gin_helper::Dictionary> promise(isolate);
 
     auto callback = base::BindOnce(&FileSelectHelper::OnOpenDialogDone, this);
@@ -68,6 +69,7 @@ class FileSelectHelper : public base::RefCounted<FileSelectHelper>,
 
   void ShowSaveDialog(const file_dialog::DialogSettings& settings) {
     v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::HandleScope scope(isolate);
     gin_helper::Promise<gin_helper::Dictionary> promise(isolate);
 
     auto callback = base::BindOnce(&FileSelectHelper::OnSaveDialogDone, this);


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/22531.

Fixes a crash when using `<input type="file" />`; the WebDialogHelper was missing a HandleScope when invoking `ShowOpenDialog`  and `ShowSaveDialog` and crashing with the following:

<details>

```sh
[84247:0325/190323.499423:ERROR:electron_bindings.cc(40)] Fatal error in V8: v8::HandleScope::CreateHandle() Cannot create a handle without a HandleScope
Received signal 11 SEGV_MAPERR 000000000000
0   Electron Framework                  0x0000000122c631e9 base::debug::CollectStackTrace(void**, unsigned long) + 9
1   Electron Framework                  0x00000001228b5cc3 base::debug::StackTrace::StackTrace() + 19
2   Electron Framework                  0x0000000122c62883 base::debug::(anonymous namespace)::StackDumpSignalHandler(int, __siginfo*, void*) + 3507
3   libsystem_platform.dylib            0x00007fff7e92ab5d _sigtramp + 29
4   ???                                 0x00007ffee5ca3dc0 0x0 + 140732753657280
5   Electron Framework                  0x000000011a1907df v8::Utils::ReportApiFailure(char const*, char const*) + 239
6   Electron Framework                  0x000000011a8c2e1d v8::internal::HandleScope::Extend(v8::internal::Isolate*) + 189
7   Electron Framework                  0x000000011a185eb4 v8::internal::HandleScope::CreateHandle(v8::internal::Isolate*, unsigned long) + 132
8   Electron Framework                  0x000000011a1c69ba v8::Isolate::GetCurrentContext() + 442
9   Electron Framework                  0x0000000113faa549 gin_helper::PromiseBase::PromiseBase(v8::Isolate*) + 25
10  Electron Framework                  0x0000000113ed5dcb electron::WebDialogHelper::RunFileChooser(content::RenderFrameHost*, std::__1::unique_ptr<content::FileSelectListener, std::__1::default_delete<content::FileSelectListener> >, blink::mojom::FileChooserParams const&) + 16939
11  Electron Framework                  0x0000000113cf90e7 electron::CommonWebContentsDelegate::RunFileChooser(content::RenderFrameHost*, std::__1::unique_ptr<content::FileSelectListener, std::__1::default_delete<content::FileSelectListener> >, blink::mojom::FileChooserParams const&) + 519
12  Electron Framework                  0x000000011fc1650e content::WebContentsImpl::RunFileChooser(content::RenderFrameHost*, std::__1::unique_ptr<content::FileChooserImpl::FileSelectListenerImpl, std::__1::default_delete<content::FileChooserImpl::FileSelectListenerImpl> >, blink::mojom::FileChooserParams const&) + 526
13  Electron Framework                  0x000000011eb07b7a content::FileChooserImpl::OpenFileChooser(mojo::StructPtr<blink::mojom::FileChooserParams>, base::OnceCallback<void (mojo::StructPtr<blink::mojom::FileChooserResult>)>) + 1818
14  Electron Framework                  0x0000000117e680b6 blink::mojom::FileChooserStubDispatch::AcceptWithResponder(blink::mojom::FileChooser*, mojo::Message*, std::__1::unique_ptr<mojo::MessageReceiverWithStatus, std::__1::default_delete<mojo::MessageReceiverWithStatus> >) + 3366
15  Electron Framework                  0x000000011eb097f1 blink::mojom::FileChooserStub<mojo::RawPtrImplRefTraits<blink::mojom::FileChooser> >::AcceptWithResponder(mojo::Message*, std::__1::unique_ptr<mojo::MessageReceiverWithStatus, std::__1::default_delete<mojo::MessageReceiverWithStatus> >) + 289
16  Electron Framework                  0x00000001237e7de4 mojo::InterfaceEndpointClient::HandleValidatedMessage(mojo::Message*) + 2852
17  Electron Framework                  0x00000001237f596e mojo::MessageDispatcher::Accept(mojo::Message*) + 942
```
</details>

cc @zcbenz @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash when using `<input type="file" />`.
