### PR TITLE
fix: dialog fails to show after modal close

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -597,28 +597,18 @@ void NativeWindowMac::SetContentView(views::View* view) {
 }
 
 void NativeWindowMac::Close() {
-  // When this is a sheet showing, performClose won't work.
-  if (is_modal() && parent() && IsVisible()) {
-    NSWindow* window = parent()->GetNativeWindow().GetNativeNSWindow();
-    if (NSWindow* sheetParent = [window sheetParent]) {
-      base::ThreadTaskRunnerHandle::Get()->PostTask(
-          FROM_HERE, base::BindOnce(base::RetainBlock(^{
-            [sheetParent endSheet:window];
-          })));
-    }
-
-    // Manually emit close event (not triggered from close fn)
-    NotifyWindowCloseButtonClicked();
-    CloseImmediately();
-    return;
-  }
-
   if (!IsClosable()) {
     WindowList::WindowCloseCancelled(this);
     return;
   }
 
   [window_ performClose:nil];
+
+  // Closing a sheet doesn't trigger windowShouldClose,
+  // so we need to manually call it ourselves here.
+  if (is_modal() && parent() && IsVisible()) {
+    NotifyWindowCloseButtonClicked();
+  }
 }
 
 void NativeWindowMac::CloseImmediately() {
@@ -655,9 +645,9 @@ bool NativeWindowMac::IsFocused() {
 
 void NativeWindowMac::Show() {
   if (is_modal() && parent()) {
+    NSWindow* window = parent()->GetNativeWindow().GetNativeNSWindow();
     if ([window_ sheetParent] == nil)
-      [parent()->GetNativeWindow().GetNativeNSWindow()
-                 beginSheet:window_
+      [window beginSheet:window_
           completionHandler:^(NSModalResponse){
           }];
     return;

--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -192,6 +192,10 @@ bool ScopedDisableResize::disable_resize_ = false;
         return;
     }
     [self close];
+  } else if (shell_->is_modal() && shell_->parent() && shell_->IsVisible()) {
+    // We don't want to actually call [window close] here since
+    // we've already called endSheet on the modal sheet.
+    return;
   } else {
     [super performClose:sender];
   }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/22833.

The solution to https://github.com/electron/electron/issues/17558 unfortunately created a new issue, whereby native dialogs sometimes failed to open after modal close.

This PR fixes this by shifting the modal handling case logic to our delegate as [Chromium does](https://cs.chromium.org/chromium/src/components/remote_cocoa/app_shim/views_nswindow_delegate.mm?type=cs&q=retainblock&sq=package:chromium&g=0&l=137-148).

Tested with:
- https://gist.github.com/c38df808f0ebd23f65e0c5e287d084cd
- https://gist.github.com/8ff50362409e14fceb3e28bddbbdbfc4

cc @zcbenz @nornagon @kenpowers-signal

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where native macOS dialogs sometimes failed to show after modal close.
