### PR TITLE
docs: enumerate deprecation policy

### DIFF
--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -49,6 +49,12 @@ fixes previously merged to `master`, though this may be on a case-by-case
 basis for some older supported lines. All contested decisions around release
 line backports will be resolved by the [Releases Working Group](https://github.com/electron/governance/tree/master/wg-releases) as an agenda item at their weekly meeting the week the backport PR is raised.
 
+When an API is changed or removed in a way that breaks existing functionality, the
+previous functionality will be supported for a minimum of two major versions when
+possible before being removed. For example, if a function takes three arguments,
+and that number is reduced to two in major version 10, the three-argument version would
+continue to work until, at minimum, major version 12.
+
 ### Currently supported versions
 - 8.1.x
 - 7.1.x

--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -53,7 +53,9 @@ When an API is changed or removed in a way that breaks existing functionality, t
 previous functionality will be supported for a minimum of two major versions when
 possible before being removed. For example, if a function takes three arguments,
 and that number is reduced to two in major version 10, the three-argument version would
-continue to work until, at minimum, major version 12.
+continue to work until, at minimum, major version 12. Past the minimum two-version
+threshold, we will attempt to support backwards compatibility beyond two versions
+until the maintainers feel the maintenance burden is too high to continue doing so.
 
 ### Currently supported versions
 - 8.1.x


### PR DESCRIPTION
#### Description of Change

Enumerate deprecation length, as discussed in the most recent Releases WG meeting.

cc @electron/wg-releases 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
