### PR TITLE
chore: update PR template to suggest 'none' instead of no-notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,4 +18,4 @@ Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTIN
 
 #### Release Notes
 
-Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
+Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->


### PR DESCRIPTION
#### Description of Change
'none' is easier to remember & write. also, replace the backticks with single quotes to hopefully reduce the occurrence of folks writing literally \`no-notes\`, which the parser doesn't understand.

#### Release Notes

Notes: none