### PR TITLE
fix: ensure standard schemes are registered in nw service process

### DIFF
--- a/shell/app/electron_content_client.cc
+++ b/shell/app/electron_content_client.cc
@@ -15,6 +15,7 @@
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "content/public/common/content_constants.h"
+#include "content/public/common/content_switches.h"
 #include "electron/buildflags/buildflags.h"
 #include "extensions/common/constants.h"
 #include "ppapi/buildflags/buildflags.h"
@@ -231,14 +232,27 @@ base::RefCountedMemory* ElectronContentClient::GetDataResourceBytes(
 }
 
 void ElectronContentClient::AddAdditionalSchemes(Schemes* schemes) {
-  AppendDelimitedSwitchToVector(switches::kServiceWorkerSchemes,
-                                &schemes->service_worker_schemes);
-  AppendDelimitedSwitchToVector(switches::kSecureSchemes,
-                                &schemes->secure_schemes);
-  AppendDelimitedSwitchToVector(switches::kBypassCSPSchemes,
-                                &schemes->csp_bypassing_schemes);
-  AppendDelimitedSwitchToVector(switches::kCORSSchemes,
-                                &schemes->cors_enabled_schemes);
+  auto* command_line = base::CommandLine::ForCurrentProcess();
+  std::string process_type =
+      command_line->GetSwitchValueASCII(::switches::kProcessType);
+  // Browser Process registration happens in
+  // `api::Protocol::RegisterSchemesAsPrivileged`
+  //
+  // Renderer Process registration happens in `RendererClientBase`
+  //
+  // We use this for registration to network utility process
+  if (process_type == ::switches::kUtilityProcess) {
+    AppendDelimitedSwitchToVector(switches::kServiceWorkerSchemes,
+                                  &schemes->service_worker_schemes);
+    AppendDelimitedSwitchToVector(switches::kStandardSchemes,
+                                  &schemes->standard_schemes);
+    AppendDelimitedSwitchToVector(switches::kSecureSchemes,
+                                  &schemes->secure_schemes);
+    AppendDelimitedSwitchToVector(switches::kBypassCSPSchemes,
+                                  &schemes->csp_bypassing_schemes);
+    AppendDelimitedSwitchToVector(switches::kCORSSchemes,
+                                  &schemes->cors_enabled_schemes);
+  }
 
   schemes->service_worker_schemes.emplace_back(url::kFileScheme);
   schemes->standard_schemes.emplace_back(extensions::kExtensionScheme);

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -102,6 +102,11 @@ RendererClientBase::RendererClientBase() {
       ParseSchemesCLISwitch(command_line, switches::kStandardSchemes);
   for (const std::string& scheme : standard_schemes_list)
     url::AddStandardScheme(scheme.c_str(), url::SCHEME_WITH_HOST);
+  // Parse --cors-schemes=scheme1,scheme2
+  std::vector<std::string> cors_schemes_list =
+      ParseSchemesCLISwitch(command_line, switches::kCORSSchemes);
+  for (const std::string& scheme : cors_schemes_list)
+    url::AddCorsEnabledScheme(scheme.c_str());
   isolated_world_ = base::CommandLine::ForCurrentProcess()->HasSwitch(
       switches::kContextIsolation);
   // We rely on the unique process host id which is notified to the

--- a/spec-main/api-protocol-spec.ts
+++ b/spec-main/api-protocol-spec.ts
@@ -642,15 +642,19 @@ describe('protocol module', () => {
     it('does not crash on exit', async () => {
       const appPath = path.join(__dirname, 'fixtures', 'api', 'custom-protocol-shutdown.js');
       const appProcess = ChildProcess.spawn(process.execPath, ['--enable-logging', appPath]);
-      let output = '';
-      appProcess.stdout.on('data', data => { output += data; });
-      appProcess.stderr.on('data', data => { output += data; });
+      let stdout = '';
+      let stderr = '';
+      appProcess.stdout.on('data', data => { stdout += data; });
+      appProcess.stderr.on('data', data => { stderr += data; });
       const [code] = await emittedOnce(appProcess, 'exit');
       if (code !== 0) {
-        console.log(code, output);
+        console.log('Exit code : ', code);
+        console.log('stdout : ', stdout);
+        console.log('stderr : ', stderr);
       }
       expect(code).to.equal(0);
-      expect(output).to.not.contain('VALIDATION_ERROR_DESERIALIZATION_FAILED');
+      expect(stdout).to.not.contain('VALIDATION_ERROR_DESERIALIZATION_FAILED');
+      expect(stderr).to.not.contain('VALIDATION_ERROR_DESERIALIZATION_FAILED');
     });
   });
 

--- a/spec-main/fixtures/api/custom-protocol-shutdown.js
+++ b/spec-main/fixtures/api/custom-protocol-shutdown.js
@@ -1,0 +1,18 @@
+const { app, webContents, protocol, session } = require('electron');
+
+protocol.registerSchemesAsPrivileged([
+  { scheme: 'test', privileges: { standard: true, secure: true } }
+]);
+
+app.whenReady().then(function () {
+  const ses = session.fromPartition('persist:test-standard-shutdown');
+  const web = webContents.create({ session: ses });
+
+  ses.protocol.registerStringProtocol('test', (request, callback) => {
+    callback('Hello World!');
+  });
+
+  web.webContents.loadURL('test://abc/hello.txt');
+
+  web.webContents.on('did-finish-load', () => app.quit());
+});


### PR DESCRIPTION
#### Description of Change

Crash in Network service process due to https://github.com/electron/electron/pull/20546 regressed after https://github.com/electron/electron/pull/22064/commits/f5b9e49be99f2b85c0381d791b381aa400db9751 .

This PR fixes by making a clear indication of how the schemes are registered in respective Browser, Renderer and Network process.

Identified while testing https://github.com/electron/electron/pull/20625 but ci logs in master also show the crash.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix crash in network service process when using protocol.registerSchemeAsPrivileged api
