### PR TITLE
fix: Do not ignore electron exit signals in cli.js wrapper

### DIFF
--- a/npm/cli.js
+++ b/npm/cli.js
@@ -5,7 +5,11 @@ var electron = require('./')
 var proc = require('child_process')
 
 var child = proc.spawn(electron, process.argv.slice(2), { stdio: 'inherit', windowsHide: false })
-child.on('close', function (code) {
+child.on('close', function (code, signal) {
+  if (code === null) {
+    console.error(electron, 'exited with signal', signal)
+    process.exit(1)
+  }
   process.exit(code)
 })
 


### PR DESCRIPTION
#### Description of Change

When the electron child process exits with a signal, the close event handler receives code `null` and the cli wrapper would silently exit successfully.  Fix it to log a message and exit with a nonzero code in this case.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
