### PR TITLE
ci: Use smaller vms with goma

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,10 @@ machine-linux-medium: &machine-linux-medium
   <<: *docker-image
   resource_class: medium
 
+machine-linux-xlarge: &machine-linux-xlarge
+  <<: *docker-image
+  resource_class: xlarge
+
 machine-linux-2xlarge: &machine-linux-2xlarge
   <<: *docker-image
   resource_class: 2xlarge+
@@ -1621,9 +1625,9 @@ jobs:
 
   # Layer 2: Builds.
   linux-x64-testing:
-    <<: *machine-linux-2xlarge
+    <<: *machine-linux-xlarge
     environment:
-      <<: *env-linux-2xlarge
+      <<: *env-global
       <<: *env-testing-build
       <<: *env-ninja-status
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
@@ -1701,9 +1705,9 @@ jobs:
           checkout: false
 
   linux-ia32-testing:
-    <<: *machine-linux-2xlarge
+    <<: *machine-linux-xlarge
     environment:
-      <<: *env-linux-2xlarge
+      <<: *env-global
       <<: *env-ia32
       <<: *env-testing-build
       <<: *env-ninja-status
@@ -1767,9 +1771,9 @@ jobs:
           checkout: false
 
   linux-arm-testing:
-    <<: *machine-linux-2xlarge
+    <<: *machine-linux-xlarge
     environment:
-      <<: *env-linux-2xlarge
+      <<: *env-global
       <<: *env-arm
       <<: *env-testing-build
       <<: *env-ninja-status
@@ -1834,9 +1838,9 @@ jobs:
           checkout: false
 
   linux-arm64-testing:
-    <<: *machine-linux-2xlarge
+    <<: *machine-linux-xlarge
     environment:
-      <<: *env-linux-2xlarge
+      <<: *env-global
       <<: *env-arm64
       <<: *env-testing-build
       <<: *env-ninja-status

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 version: 1.0.{build}
-build_cloud: libcc-20
+build_cloud: electron-16-core
 image: vs2019bt-16.4.0
 environment:
   GIT_CACHE_PATH: C:\Users\electron\libcc_cache

--- a/script/release/ci-release-build.js
+++ b/script/release/ci-release-build.js
@@ -206,7 +206,8 @@ function buildAppVeyor (targetBranch, options) {
 async function callAppVeyor (targetBranch, job, options) {
   console.log(`Triggering AppVeyor to run build job: ${job} on branch: ${targetBranch} with release flag.`);
   const environmentVariables = {
-    ELECTRON_RELEASE: 1
+    ELECTRON_RELEASE: 1,
+    APPVEYOR_BUILD_WORKER_CLOUD: 'libcc-20'
   };
 
   if (!options.ghRelease) {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Now that we are building with goma we can scale back our CI VMs for testing.
This PR changes our Linux builds to use 8-core machines and our Windows builds to use 16-core machines for testing.  Using these sized machines results in builds that complete in about the same time as our current configuration.  I tested using an 8-core machine on Windows but that was too slow due to those jobs running gclient sync/unzipping chromium source.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or `no-notes` if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
