### PR TITLE
 ci: cleanup extraneous release tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1103,18 +1103,6 @@ steps-verify-ffmpeg: &steps-verify-ffmpeg
     - *step-verify-ffmpeg
     - *step-maybe-notify-slack-failure
 
-steps-verify-mksnapshot: &steps-verify-mksnapshot
-  steps:
-    - attach_workspace:
-        at: .
-    - *step-depot-tools-add-to-path
-    - *step-electron-dist-unzip
-    - *step-mksnapshot-unzip
-    - *step-setup-linux-for-headless-testing
-
-    - *step-verify-mksnapshot
-    - *step-maybe-notify-slack-failure
-
 steps-verify-chromedriver: &steps-verify-chromedriver
   steps:
     - attach_workspace:
@@ -1999,14 +1987,6 @@ jobs:
       <<: *env-testing-build
     <<: *steps-electron-gn-check
 
-  mas-chromedriver:
-    <<: *machine-mac
-    environment:
-      <<: *env-machine-mac
-      <<: *env-release-build
-      <<: *env-send-slack-notifications
-    <<: *steps-chromedriver-build
-
   mas-release:
     <<: *machine-mac-large
     environment:
@@ -2126,22 +2106,6 @@ jobs:
       <<: *env-send-slack-notifications
     <<: *steps-verify-ffmpeg
 
-  linux-x64-verify-mksnapshot:
-    <<: *machine-linux-medium
-    environment:
-      <<: *env-linux-medium
-      <<: *env-headless-testing
-      <<: *env-send-slack-notifications
-    <<: *steps-verify-mksnapshot
-
-  linux-x64-verify-chromedriver:
-    <<: *machine-linux-medium
-    environment:
-      <<: *env-linux-medium
-      <<: *env-headless-testing
-      <<: *env-send-slack-notifications
-    <<: *steps-verify-chromedriver
-
   linux-ia32-testing-tests:
     <<: *machine-linux-medium
     environment:
@@ -2188,23 +2152,6 @@ jobs:
       <<: *env-send-slack-notifications
     <<: *steps-verify-ffmpeg
 
-  linux-ia32-verify-mksnapshot:
-    <<: *machine-linux-medium
-    environment:
-      <<: *env-linux-medium
-      <<: *env-ia32
-      <<: *env-headless-testing
-      <<: *env-send-slack-notifications
-    <<: *steps-verify-mksnapshot
-
-  linux-ia32-verify-chromedriver:
-    <<: *machine-linux-medium
-    environment:
-      <<: *env-linux-medium
-      <<: *env-headless-testing
-      <<: *env-send-slack-notifications
-    <<: *steps-verify-chromedriver
-
   osx-testing-tests:
     <<: *machine-mac-large
     environment:
@@ -2228,20 +2175,6 @@ jobs:
       <<: *env-send-slack-notifications
     <<: *steps-verify-ffmpeg
 
-  osx-verify-mksnapshot:
-    <<: *machine-mac
-    environment:
-      <<: *env-machine-mac
-      <<: *env-send-slack-notifications
-    <<: *steps-verify-mksnapshot
-
-  osx-verify-chromedriver:
-    <<: *machine-mac
-    environment:
-      <<: *env-machine-mac
-      <<: *env-send-slack-notifications
-    <<: *steps-verify-chromedriver
-
   mas-testing-tests:
     <<: *machine-mac-large
     environment:
@@ -2264,20 +2197,6 @@ jobs:
       <<: *env-machine-mac
       <<: *env-send-slack-notifications
     <<: *steps-verify-ffmpeg
-
-  mas-verify-mksnapshot:
-    <<: *machine-mac
-    environment:
-      <<: *env-machine-mac
-      <<: *env-send-slack-notifications
-    <<: *steps-verify-mksnapshot
-
-  mas-verify-chromedriver:
-    <<: *machine-mac
-    environment:
-      <<: *env-machine-mac
-      <<: *env-send-slack-notifications
-    <<: *steps-verify-chromedriver
 
   # Layer 4: Summary.
   linux-x64-release-summary:
@@ -2497,67 +2416,37 @@ workflows:
       - linux-x64-release-tests:
           requires:
             - linux-x64-release
-      - linux-x64-chromedriver:
-          requires:
-            - linux-checkout-fast
       - linux-x64-verify-ffmpeg:
           requires:
             - linux-x64-release
-      - linux-x64-verify-mksnapshot:
-          requires:
-            - linux-x64-release
-      - linux-x64-verify-chromedriver:
-          requires:
-            - linux-x64-release
-            - linux-x64-chromedriver
       - linux-x64-release-summary:
           requires:
             - linux-x64-release
             - linux-x64-release-tests
             - linux-x64-verify-ffmpeg
-            - linux-x64-chromedriver
 
       - linux-ia32-release
       - linux-ia32-release-tests:
           requires:
             - linux-ia32-release
-      - linux-ia32-chromedriver:
-          requires:
-            - linux-checkout-fast
       - linux-ia32-verify-ffmpeg:
           requires:
             - linux-ia32-release
-      - linux-ia32-verify-mksnapshot:
-          requires:
-            - linux-ia32-release
-      - linux-x64-verify-chromedriver:
-          requires:
-            - linux-ia32-release
-            - linux-ia32-chromedriver
       - linux-ia32-release-summary:
           requires:
             - linux-ia32-release
             - linux-ia32-release-tests
             - linux-ia32-verify-ffmpeg
-            - linux-ia32-chromedriver
 
       - linux-arm-release
-      - linux-arm-chromedriver:
-          requires:
-            - linux-checkout-fast
       - linux-arm-release-summary:
           requires:
             - linux-arm-release
-            - linux-arm-chromedriver
 
       - linux-arm64-release
-      - linux-arm64-chromedriver:
-          requires:
-            - linux-checkout-fast
       - linux-arm64-release-summary:
           requires:
             - linux-arm64-release
-            - linux-arm64-chromedriver
 
   nightly-mac-release-test:
     triggers:
@@ -2578,25 +2467,14 @@ workflows:
       - osx-release-tests:
           requires:
             - osx-release
-      - osx-chromedriver:
-          requires:
-            - mac-checkout-fast
       - osx-verify-ffmpeg:
           requires:
             - osx-release
-      - osx-verify-mksnapshot:
-          requires:
-            - osx-release
-      - osx-verify-chromedriver:
-          requires:
-            - osx-release
-            - osx-chromedriver
       - osx-release-summary:
           requires:
           - osx-release
           - osx-release-tests
           - osx-verify-ffmpeg
-          - osx-chromedriver
 
       - mas-release:
           requires:
@@ -2604,25 +2482,14 @@ workflows:
       - mas-release-tests:
           requires:
             - mas-release
-      - mas-chromedriver:
-          requires:
-            - mac-checkout-fast
       - mas-verify-ffmpeg:
           requires:
             - mas-release
-      - mas-verify-mksnapshot:
-          requires:
-            - mas-release
-      - mas-verify-chromedriver:
-          requires:
-            - mas-release
-            - mas-chromedriver
       - mas-release-summary:
           requires:
           - mas-release
           - mas-release-tests
           - mas-verify-ffmpeg
-          - mas-chromedriver
 
   # Various slow and non-essential checks we run only nightly.
   # Sanitizer jobs should be added here.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,14 +49,6 @@ parameters:
     type: boolean
     default: false
 
-  run-linux-release:
-    type: boolean
-    default: false
-
-  run-macos-release:
-    type: boolean
-    default: false
-
 # The config expects the following environment variables to be set:
 #  - "SLACK_WEBHOOK" Slack hook URL to send notifications.
 #
@@ -2408,7 +2400,14 @@ workflows:
             - mas-testing
 
   nightly-linux-release-test:
-    when: << pipeline.parameters.run-linux-release >>
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+                - *chromium-upgrade-branches
     jobs:
       - linux-checkout-fast
       - linux-checkout-and-save-cache
@@ -2450,7 +2449,14 @@ workflows:
             - linux-arm64-release
 
   nightly-mac-release-test:
-    when: << pipeline.parameters.run-macos-release >>
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+                - *chromium-upgrade-branches
     jobs:
       - mac-checkout-fast
       - mac-checkout-and-save-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,14 @@ parameters:
     type: boolean
     default: false
 
+  run-linux-release:
+    type: boolean
+    default: false
+
+  run-macos-release:
+    type: boolean
+    default: false
+
 # The config expects the following environment variables to be set:
 #  - "SLACK_WEBHOOK" Slack hook URL to send notifications.
 #
@@ -2400,14 +2408,7 @@ workflows:
             - mas-testing
 
   nightly-linux-release-test:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
-                - *chromium-upgrade-branches
+    when: << pipeline.parameters.run-linux-release >>
     jobs:
       - linux-checkout-fast
       - linux-checkout-and-save-cache
@@ -2449,14 +2450,7 @@ workflows:
             - linux-arm64-release
 
   nightly-mac-release-test:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
-                - *chromium-upgrade-branches
+    when: << pipeline.parameters.run-macos-release >>
     jobs:
       - mac-checkout-fast
       - mac-checkout-and-save-cache


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Our nightly release tests were failing on `linux-x64-chromedriver`, `linux-ia32-chromedriver`, `osx-chromedriver`, and `mas-chromedriver` builds.  After further investigation, I realized these builds were unnecessary because we build and test chromedriver elsewhere in the nightly tests.  

I ran the nightly tests with this new config here:
https://app.circleci.com/pipelines/github/electron/electron/22401/workflows/e743b0c3-d2ea-42ec-9b18-0dececc049a1
and here:
https://app.circleci.com/pipelines/github/electron/electron/22402/workflows/505093dc-7407-48ca-9e8e-9738f7f1ad35
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
