### PR TITLE
fix: screen module should still be creatable if the first create is before the ready event

### DIFF
--- a/shell/browser/api/electron_api_screen.cc
+++ b/shell/browser/api/electron_api_screen.cc
@@ -14,6 +14,7 @@
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_converters/gfx_converter.h"
 #include "shell/common/gin_converters/native_window_converter.h"
+#include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
 #include "ui/display/display.h"
@@ -184,8 +185,8 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   v8::Isolate* isolate = context->GetIsolate();
-  gin::Dictionary dict(isolate, exports);
-  dict.Set("createScreen", base::BindRepeating(&Screen::Create));
+  gin_helper::Dictionary dict(isolate, exports);
+  dict.SetMethod("createScreen", base::BindRepeating(&Screen::Create));
   dict.Set(
       "Screen",
       Screen::GetConstructor(isolate)->GetFunction(context).ToLocalChecked());


### PR DESCRIPTION
`Set` uses the callback converter which is `useOnce`.  `SetMethod` will actually make a re-usable method.

Fixes #22853

Notes: Accessing the `screen` module before the ready event no longer makes it impossible to access the `screen` module