### PR TITLE
fix: propagate preferred color scheme to the renderer

### DIFF
--- a/shell/browser/api/electron_api_native_theme.cc
+++ b/shell/browser/api/electron_api_native_theme.cc
@@ -23,14 +23,16 @@ namespace electron {
 
 namespace api {
 
-NativeTheme::NativeTheme(v8::Isolate* isolate, ui::NativeTheme* theme)
-    : theme_(theme) {
-  theme_->AddObserver(this);
+NativeTheme::NativeTheme(v8::Isolate* isolate,
+                         ui::NativeTheme* ui_theme,
+                         ui::NativeTheme* web_theme)
+    : ui_theme_(ui_theme), web_theme_(web_theme) {
+  ui_theme_->AddObserver(this);
   Init(isolate);
 }
 
 NativeTheme::~NativeTheme() {
-  theme_->RemoveObserver(this);
+  ui_theme_->RemoveObserver(this);
 }
 
 void NativeTheme::OnNativeThemeUpdatedOnUI() {
@@ -44,7 +46,8 @@ void NativeTheme::OnNativeThemeUpdated(ui::NativeTheme* theme) {
 }
 
 void NativeTheme::SetThemeSource(ui::NativeTheme::ThemeSource override) {
-  theme_->set_theme_source(override);
+  ui_theme_->set_theme_source(override);
+  web_theme_->set_theme_source(override);
 #if defined(OS_MACOSX)
   // Update the macOS appearance setting for this new override value
   UpdateMacOSAppearanceForOverrideValue(override);
@@ -59,15 +62,15 @@ void NativeTheme::SetThemeSource(ui::NativeTheme::ThemeSource override) {
 }
 
 ui::NativeTheme::ThemeSource NativeTheme::GetThemeSource() const {
-  return theme_->theme_source();
+  return ui_theme_->theme_source();
 }
 
 bool NativeTheme::ShouldUseDarkColors() {
-  return theme_->ShouldUseDarkColors();
+  return ui_theme_->ShouldUseDarkColors();
 }
 
 bool NativeTheme::ShouldUseHighContrastColors() {
-  return theme_->UsesHighContrastColors();
+  return ui_theme_->UsesHighContrastColors();
 }
 
 #if defined(OS_MACOSX)
@@ -92,8 +95,11 @@ bool NativeTheme::ShouldUseInvertedColorScheme() {
 
 // static
 v8::Local<v8::Value> NativeTheme::Create(v8::Isolate* isolate) {
-  ui::NativeTheme* theme = ui::NativeTheme::GetInstanceForNativeUi();
-  return gin::CreateHandle(isolate, new NativeTheme(isolate, theme)).ToV8();
+  ui::NativeTheme* ui_theme = ui::NativeTheme::GetInstanceForNativeUi();
+  ui::NativeTheme* web_theme = ui::NativeTheme::GetInstanceForWeb();
+  return gin::CreateHandle(isolate,
+                           new NativeTheme(isolate, ui_theme, web_theme))
+      .ToV8();
 }
 
 // static

--- a/shell/browser/api/electron_api_native_theme.h
+++ b/shell/browser/api/electron_api_native_theme.h
@@ -22,7 +22,9 @@ class NativeTheme : public gin_helper::EventEmitter<NativeTheme>,
                              v8::Local<v8::FunctionTemplate> prototype);
 
  protected:
-  NativeTheme(v8::Isolate* isolate, ui::NativeTheme* theme);
+  NativeTheme(v8::Isolate* isolate,
+              ui::NativeTheme* ui_theme,
+              ui::NativeTheme* web_theme);
   ~NativeTheme() override;
 
   void SetThemeSource(ui::NativeTheme::ThemeSource override);
@@ -40,7 +42,8 @@ class NativeTheme : public gin_helper::EventEmitter<NativeTheme>,
   void OnNativeThemeUpdatedOnUI();
 
  private:
-  ui::NativeTheme* theme_;
+  ui::NativeTheme* ui_theme_;
+  ui::NativeTheme* web_theme_;
 
   DISALLOW_COPY_AND_ASSIGN(NativeTheme);
 };

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -524,6 +524,11 @@ void ElectronBrowserClient::OverrideWebkitPrefs(
   prefs->picture_in_picture_enabled = false;
 #endif
 
+  ui::NativeTheme* native_theme = ui::NativeTheme::GetInstanceForNativeUi();
+  prefs->preferred_color_scheme = native_theme->ShouldUseDarkColors()
+                                      ? blink::PreferredColorScheme::kDark
+                                      : blink::PreferredColorScheme::kLight;
+
   SetFontDefaults(prefs);
 
   // Custom preferences of guest page.

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -198,6 +198,7 @@ class NativeWindow : public base::SupportsUserData,
 #if defined(OS_MACOSX)
   virtual void SetTrafficLightPosition(const gfx::Point& position) = 0;
   virtual gfx::Point GetTrafficLightPosition() const = 0;
+  virtual void RedrawTrafficLights() = 0;
 #endif
 
   // Touchbar API

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -150,7 +150,7 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
   void SetWindowLevel(int level);
 
   // Custom traffic light positioning
-  void RedrawTrafficLights();
+  void RedrawTrafficLights() override;
   void SetExitingFullScreen(bool flag);
   void SetTrafficLightPosition(const gfx::Point& position) override;
   gfx::Point GetTrafficLightPosition() const override;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -700,9 +700,9 @@ void NativeWindowMac::SetExitingFullScreen(bool flag) {
 }
 
 void NativeWindowMac::OnNativeThemeUpdated(ui::NativeTheme* observed_theme) {
-  base::PostTask(FROM_HERE, {content::BrowserThread::UI},
-                 base::BindOnce(&NativeWindowMac::RedrawTrafficLights,
-                                base::Unretained(this)));
+  base::PostTask(
+      FROM_HERE, {content::BrowserThread::UI},
+      base::BindOnce(&NativeWindow::RedrawTrafficLights, GetWeakPtr()));
 }
 
 bool NativeWindowMac::IsEnabled() {


### PR DESCRIPTION
Fixes #22846

This regressed in a recent Chromium upgrade:

https://github.com/electron/electron/commit/032552df574008047b4672b49e70556524601c4f#diff-8a19e7f384ba27f625eb0e55641ee5feL414-L418

This PR fixes the issue and adds a test to ensure it does not regress by accident in the future.  It also fixes a crash that was revealed by the test I wrote.  If you close a window as the native theme updates, only possible if you do this with `nativeTheme` directly but fixed it 👍 

It also updates our `native_theme` implementation to override both `web` and `native_ui` themes that Chromium uses.  Currently Chromium doesn't use webUI and we opt to use native for everything, but there's no harm overriding and it might help us in the future with edge cases.

Notes: Fixed issue where `prefers-color-scheme` would not be updated / set correctly when your OS was in dark mode