### PR TITLE
fix: webRequest module should work with file:// protocol

### DIFF
--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -292,11 +292,12 @@ int WebRequest::OnHeadersReceived(
     const net::HttpResponseHeaders* original_response_headers,
     scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
     GURL* allowed_unsafe_redirect_url) {
+  const std::string& status_line =
+      original_response_headers ? original_response_headers->GetStatusLine()
+                                : std::string();
   return HandleResponseEvent(
       kOnHeadersReceived, info, std::move(callback),
-      std::make_pair(override_response_headers,
-                     original_response_headers->GetStatusLine()),
-      request);
+      std::make_pair(override_response_headers, status_line), request);
 }
 
 void WebRequest::OnSendHeaders(extensions::WebRequestInfo* info,

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1171,7 +1171,8 @@ void ElectronBrowserClient::RegisterNonNetworkNavigationURLLoaderFactories(
           context, false /* we don't support extensions::WebViewGuest */));
 #endif
   auto* protocol_registry = ProtocolRegistry::FromBrowserContext(context);
-  protocol_registry->RegisterURLLoaderFactories(factories);
+  protocol_registry->RegisterURLLoaderFactories(
+      URLLoaderFactoryType::kNavigation, factories);
 }
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
@@ -1231,7 +1232,8 @@ void ElectronBrowserClient::RegisterNonNetworkSubresourceURLLoaderFactories(
 
   if (web_contents) {
     ProtocolRegistry::FromBrowserContext(web_contents->GetBrowserContext())
-        ->RegisterURLLoaderFactories(factories);
+        ->RegisterURLLoaderFactories(URLLoaderFactoryType::kDocumentSubResource,
+                                     factories);
   }
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   auto factory = extensions::CreateExtensionURLLoaderFactory(render_process_id,

--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -16,6 +16,7 @@
 #include "net/base/load_flags.h"
 #include "net/http/http_util.h"
 #include "services/network/public/cpp/features.h"
+#include "shell/browser/net/asar/asar_url_loader.h"
 #include "shell/common/options_switches.h"
 
 namespace electron {
@@ -821,6 +822,16 @@ void ProxyingURLLoaderFactory::CreateLoaderAndStart(
                                 std::move(loader), routing_id, request_id,
                                 options, request, std::move(client),
                                 traffic_annotation, this, it->second.first));
+    return;
+  }
+
+  // The loader of ServiceWorker forbids loading scripts from file:// URLs, and
+  // Chromium does not provide a way to override this behavior. So in order to
+  // make ServiceWorker work with file:// URLs, we have to intercept its
+  // requests here.
+  if (IsForServiceWorkerScript() && request.url.SchemeIsFile()) {
+    asar::CreateAsarURLLoader(request, std::move(loader), std::move(client),
+                              new net::HttpResponseHeaders(""));
     return;
   }
 

--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -16,7 +16,6 @@
 #include "net/base/load_flags.h"
 #include "net/http/http_util.h"
 #include "services/network/public/cpp/features.h"
-#include "shell/browser/net/asar/asar_url_loader.h"
 #include "shell/common/options_switches.h"
 
 namespace electron {
@@ -822,13 +821,6 @@ void ProxyingURLLoaderFactory::CreateLoaderAndStart(
                                 std::move(loader), routing_id, request_id,
                                 options, request, std::move(client),
                                 traffic_annotation, this, it->second.first));
-    return;
-  }
-
-  // Intercept file:// protocol to support asar archives.
-  if (request.url.SchemeIsFile()) {
-    asar::CreateAsarURLLoader(request, std::move(loader), std::move(client),
-                              new net::HttpResponseHeaders(""));
     return;
   }
 

--- a/shell/browser/protocol_registry.h
+++ b/shell/browser/protocol_registry.h
@@ -22,7 +22,11 @@ class ProtocolRegistry {
 
   static ProtocolRegistry* FromBrowserContext(content::BrowserContext*);
 
+  using URLLoaderFactoryType =
+      content::ContentBrowserClient::URLLoaderFactoryType;
+
   void RegisterURLLoaderFactories(
+      URLLoaderFactoryType type,
       content::ContentBrowserClient::NonNetworkURLLoaderFactoryMap* factories);
 
   const HandlersMap& intercept_handlers() const { return intercept_handlers_; }

--- a/spec-main/api-web-request-spec.ts
+++ b/spec-main/api-web-request-spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import * as http from 'http';
 import * as qs from 'querystring';
 import * as path from 'path';
+import * as url from 'url';
 import * as WebSocket from 'ws';
 import { ipcMain, protocol, session, WebContents, webContents } from 'electron';
 import { AddressInfo } from 'net';
@@ -133,11 +134,24 @@ describe('webRequest module', () => {
       await ajax(defaultURL + 'serverRedirect');
       await ajax(defaultURL + 'serverRedirect');
     });
+
+    it('works with file:// protocol', (done) => {
+      ses.webRequest.onBeforeRequest((details, callback) => {
+        callback({ cancel: true });
+        done();
+      });
+      ajax(url.format({
+        pathname: path.join(fixturesPath, 'blank.html').replace(/\\/g, '/'),
+        protocol: 'file',
+        slashes: true
+      }));
+    });
   });
 
   describe('webRequest.onBeforeSendHeaders', () => {
     afterEach(() => {
       ses.webRequest.onBeforeSendHeaders(null);
+      ses.webRequest.onSendHeaders(null);
     });
 
     it('receives details object', async () => {
@@ -191,6 +205,24 @@ describe('webRequest module', () => {
         expect(details.requestHeaders).to.deep.equal(requestHeaders);
       });
       await ajax(defaultURL);
+    });
+
+    it('works with file:// protocol', (done) => {
+      const requestHeaders = {
+        Test: 'header'
+      };
+      ses.webRequest.onBeforeSendHeaders((details, callback) => {
+        callback({ requestHeaders: requestHeaders });
+      });
+      ses.webRequest.onSendHeaders((details) => {
+        expect(details.requestHeaders).to.deep.equal(requestHeaders);
+        done();
+      });
+      ajax(url.format({
+        pathname: path.join(fixturesPath, 'blank.html').replace(/\\/g, '/'),
+        protocol: 'file',
+        slashes: true
+      }));
     });
   });
 


### PR DESCRIPTION
#### Description of Change

Fix https://github.com/electron/electron/issues/22370.

When supporting asar archives in `file://` URL, overwrite the default `FileURLLoaderFactory` directly instead of intercepting the protocol in `ProxyingURLLoaderFactory`. Otherwise `webRequest` won't be able to proxy the `file://` requests.

This is actually the correct way to override `file://` protocol, previous implementation was essentially a hack.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix `webRequest` module not working with `file://` protocol.