### PR TITLE
fix: webRequest module should work with file:// protocol (7-2-x)

### DIFF
--- a/shell/browser/api/atom_api_protocol_ns.h
+++ b/shell/browser/api/atom_api_protocol_ns.h
@@ -43,8 +43,12 @@ class ProtocolNS : public mate::TrackableObject<ProtocolNS> {
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype);
 
+  using URLLoaderFactoryType =
+      content::ContentBrowserClient::URLLoaderFactoryType;
+
   // Used by AtomBrowserClient for creating URLLoaderFactory.
   void RegisterURLLoaderFactories(
+      URLLoaderFactoryType type,
       content::ContentBrowserClient::NonNetworkURLLoaderFactoryMap* factories);
 
   const HandlersMap& intercept_handlers() const { return intercept_handlers_; }

--- a/shell/browser/api/atom_api_web_request_ns.cc
+++ b/shell/browser/api/atom_api_web_request_ns.cc
@@ -292,11 +292,12 @@ int WebRequestNS::OnHeadersReceived(
     const net::HttpResponseHeaders* original_response_headers,
     scoped_refptr<net::HttpResponseHeaders>* override_response_headers,
     GURL* allowed_unsafe_redirect_url) {
+  const std::string& status_line =
+      original_response_headers ? original_response_headers->GetStatusLine()
+                                : std::string();
   return HandleResponseEvent(
       kOnHeadersReceived, info, std::move(callback),
-      std::make_pair(override_response_headers,
-                     original_response_headers->GetStatusLine()),
-      request);
+      std::make_pair(override_response_headers, status_line), request);
 }
 
 void WebRequestNS::OnSendHeaders(extensions::WebRequestInfo* info,

--- a/shell/browser/atom_browser_client.cc
+++ b/shell/browser/atom_browser_client.cc
@@ -962,8 +962,10 @@ void AtomBrowserClient::RegisterNonNetworkNavigationURLLoaderFactories(
       content::WebContents::FromFrameTreeNodeId(frame_tree_node_id);
   api::ProtocolNS* protocol = api::ProtocolNS::FromWrappedClass(
       v8::Isolate::GetCurrent(), web_contents->GetBrowserContext());
-  if (protocol)
-    protocol->RegisterURLLoaderFactories(factories);
+  if (protocol) {
+    protocol->RegisterURLLoaderFactories(URLLoaderFactoryType::kNavigation,
+                                         factories);
+  }
 }
 
 void AtomBrowserClient::RegisterNonNetworkSubresourceURLLoaderFactories(
@@ -978,8 +980,10 @@ void AtomBrowserClient::RegisterNonNetworkSubresourceURLLoaderFactories(
   if (web_contents) {
     api::ProtocolNS* protocol = api::ProtocolNS::FromWrappedClass(
         v8::Isolate::GetCurrent(), web_contents->GetBrowserContext());
-    if (protocol)
-      protocol->RegisterURLLoaderFactories(factories);
+    if (protocol) {
+      protocol->RegisterURLLoaderFactories(
+          URLLoaderFactoryType::kDocumentSubResource, factories);
+    }
   }
 }
 

--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -727,8 +727,11 @@ void ProxyingURLLoaderFactory::CreateLoaderAndStart(
     return;
   }
 
-  // Intercept file:// protocol to support asar archives.
-  if (request.url.SchemeIsFile()) {
+  // The loader of ServiceWorker forbids loading scripts from file:// URLs, and
+  // Chromium does not provide a way to override this behavior. So in order to
+  // make ServiceWorker work with file:// URLs, we have to intercept its
+  // requests here.
+  if (IsForServiceWorkerScript() && request.url.SchemeIsFile()) {
     asar::CreateAsarURLLoader(request, std::move(loader), std::move(client),
                               new net::HttpResponseHeaders(""));
     return;

--- a/spec-main/api-web-request-spec.ts
+++ b/spec-main/api-web-request-spec.ts
@@ -124,16 +124,16 @@ describe('webRequest module', () => {
       expect(data).to.equal('/redirect')
     })
 
-    it('works with file:// protocol', (done) => {
+    it('works with file:// protocol', async () => {
       ses.webRequest.onBeforeRequest((details, callback) => {
         callback({ cancel: true })
-        done()
       })
-      ajax(url.format({
+      const fileURL = url.format({
         pathname: path.join(fixturesPath, 'blank.html').replace(/\\/g, '/'),
         protocol: 'file',
         slashes: true
-      }))
+      })
+      await expect(ajax(fileURL)).to.eventually.be.rejectedWith('404')
     })
   })
 
@@ -186,22 +186,24 @@ describe('webRequest module', () => {
       await ajax(defaultURL)
     })
 
-    it('works with file:// protocol', (done) => {
+    it('works with file:// protocol', async () => {
       const requestHeaders = {
         Test: 'header'
       }
+      let onSendHeadersCalled = false
       ses.webRequest.onBeforeSendHeaders((details, callback) => {
         callback({ requestHeaders: requestHeaders })
       })
       ses.webRequest.onSendHeaders((details) => {
         expect(details.requestHeaders).to.deep.equal(requestHeaders)
-        done()
+        onSendHeadersCalled = true
       })
-      ajax(url.format({
-        pathname: path.join(fixturesPath, 'blank.html').replace(/\\/g, '/'),
+      await ajax(url.format({
+        pathname: path.join(fixturesPath, 'pages', 'blank.html').replace(/\\/g, '/'),
         protocol: 'file',
         slashes: true
       }))
+      expect(onSendHeadersCalled).to.be.true()
     })
   })
 


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/22903.

Notes: Fix `webRequest` module not working with `file://` protocol.