### PR TITLE
test: do not trigger unhandled promise rejections

### DIFF
--- a/spec-main/api-web-request-spec.ts
+++ b/spec-main/api-web-request-spec.ts
@@ -135,16 +135,16 @@ describe('webRequest module', () => {
       await ajax(defaultURL + 'serverRedirect');
     });
 
-    it('works with file:// protocol', (done) => {
+    it('works with file:// protocol', async () => {
       ses.webRequest.onBeforeRequest((details, callback) => {
         callback({ cancel: true });
-        done();
       });
-      ajax(url.format({
+      const fileURL = url.format({
         pathname: path.join(fixturesPath, 'blank.html').replace(/\\/g, '/'),
         protocol: 'file',
         slashes: true
-      }));
+      });
+      await expect(ajax(fileURL)).to.eventually.be.rejectedWith('404');
     });
   });
 
@@ -207,22 +207,24 @@ describe('webRequest module', () => {
       await ajax(defaultURL);
     });
 
-    it('works with file:// protocol', (done) => {
+    it('works with file:// protocol', async () => {
       const requestHeaders = {
         Test: 'header'
       };
+      let onSendHeadersCalled = false;
       ses.webRequest.onBeforeSendHeaders((details, callback) => {
         callback({ requestHeaders: requestHeaders });
       });
       ses.webRequest.onSendHeaders((details) => {
         expect(details.requestHeaders).to.deep.equal(requestHeaders);
-        done();
+        onSendHeadersCalled = true;
       });
-      ajax(url.format({
+      await ajax(url.format({
         pathname: path.join(fixturesPath, 'blank.html').replace(/\\/g, '/'),
         protocol: 'file',
         slashes: true
       }));
+      expect(onSendHeadersCalled).to.be.true();
     });
   });
 


### PR DESCRIPTION
Fix the tests of https://github.com/electron/electron/pull/22903 so they do not throw unhandled promise rejections.

I have included this commit in the backports of https://github.com/electron/electron/pull/22903.

Notes: none