### PR TITLE
chore: cherry-pick db71a0afc1d0 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -99,3 +99,4 @@ allow_restricted_clock_nanosleep_in_linux_sandbox.patch
 move_readablestream_requests_onto_the_stack_before_iteration.patch
 streams_convert_state_dchecks_to_checks.patch
 cherry-pick-fd211b44535c.patch
+cherry-pick-db71a0afc1d0.patch

--- a/patches/chromium/cherry-pick-db71a0afc1d0.patch
+++ b/patches/chromium/cherry-pick-db71a0afc1d0.patch
@@ -1,0 +1,120 @@
+From db71a0afc1d0803d6d0827fb4fa175689df8200c Mon Sep 17 00:00:00 2001
+From: Raymond Toy <rtoy@chromium.org>
+Date: Thu, 19 Mar 2020 21:54:36 +0000
+Subject: [PATCH] Clear context from orphan handlers when BaseAudioContext is
+ going away
+
+When preparing to collect a BaseAudioContext, go through all the
+rendering_orphan_handlers_ and deletable_orphan_handlers_ and remove
+the context from the handler.  This ensures that these handlers no
+longer have references to the context when the BaseAudioContext is
+destroyed because in some cases, these orphan handlers will get pulled
+and access the context, which is already gone.
+
+Clearing these in a prefinalizer ensures these orphan handlers don't
+try to touch the context.
+
+Manually verified that the repro case no longer reproduces.
+
+Bug: 1062247
+Change-Id: I50d083743903eb9544e09aa1ee912fc880331501
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2107806
+Reviewed-by: Kentaro Hara <haraken@chromium.org>
+Reviewed-by: Hongchan Choi <hongchan@chromium.org>
+Commit-Queue: Raymond Toy <rtoy@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#751814}
+---
+ .../modules/webaudio/base_audio_context.cc     |  6 ++++++
+ .../modules/webaudio/base_audio_context.h      |  3 +++
+ .../modules/webaudio/deferred_task_handler.cc  | 18 ++++++++++++++----
+ .../modules/webaudio/deferred_task_handler.h   |  3 +++
+ 4 files changed, 26 insertions(+), 4 deletions(-)
+
+diff --git a/third_party/blink/renderer/modules/webaudio/base_audio_context.cc b/third_party/blink/renderer/modules/webaudio/base_audio_context.cc
+index 719d682d69ed2..8d008c2143088 100644
+--- a/third_party/blink/renderer/modules/webaudio/base_audio_context.cc
++++ b/third_party/blink/renderer/modules/webaudio/base_audio_context.cc
+@@ -178,6 +178,12 @@ void BaseAudioContext::Uninitialize() {
+   DCHECK_EQ(resume_resolvers_.size(), 0u);
+ }
+ 
++void BaseAudioContext::Dispose() {
++  // BaseAudioContext is going away, so remove the context from the orphan
++  // handlers.
++  GetDeferredTaskHandler().ClearContextFromOrphanHandlers();
++}
++
+ void BaseAudioContext::ContextLifecycleStateChanged(
+     mojom::FrameLifecycleState state) {
+   // Don't need to do anything for an offline context.
+diff --git a/third_party/blink/renderer/modules/webaudio/base_audio_context.h b/third_party/blink/renderer/modules/webaudio/base_audio_context.h
+index 206c2dd21eaca..4a253013fe353 100644
+--- a/third_party/blink/renderer/modules/webaudio/base_audio_context.h
++++ b/third_party/blink/renderer/modules/webaudio/base_audio_context.h
+@@ -96,6 +96,7 @@ class MODULES_EXPORT BaseAudioContext
+       public InspectorHelperMixin {
+   USING_GARBAGE_COLLECTED_MIXIN(BaseAudioContext);
+   DEFINE_WRAPPERTYPEINFO();
++  USING_PRE_FINALIZER(BaseAudioContext, Dispose);
+ 
+  public:
+   // The state of an audio context.  On creation, the state is Suspended. The
+@@ -115,6 +116,8 @@ class MODULES_EXPORT BaseAudioContext
+     return dest ? dest->GetAudioDestinationHandler().IsInitialized() : false;
+   }
+ 
++  void Dispose();
++
+   // Document notification
+   void ContextLifecycleStateChanged(mojom::FrameLifecycleState) override;
+   void ContextDestroyed() override;
+diff --git a/third_party/blink/renderer/modules/webaudio/deferred_task_handler.cc b/third_party/blink/renderer/modules/webaudio/deferred_task_handler.cc
+index 00bfc7b8d624b..09e88ac41d00d 100644
+--- a/third_party/blink/renderer/modules/webaudio/deferred_task_handler.cc
++++ b/third_party/blink/renderer/modules/webaudio/deferred_task_handler.cc
+@@ -302,10 +302,7 @@ void DeferredTaskHandler::HandleDeferredTasks() {
+ }
+ 
+ void DeferredTaskHandler::ContextWillBeDestroyed() {
+-  for (auto& handler : rendering_orphan_handlers_)
+-    handler->ClearContext();
+-  for (auto& handler : deletable_orphan_handlers_)
+-    handler->ClearContext();
++  ClearContextFromOrphanHandlers();
+   ClearHandlersToBeDeleted();
+   // Some handlers might live because of their cross thread tasks.
+ }
+@@ -374,6 +371,19 @@ void DeferredTaskHandler::ClearHandlersToBeDeleted() {
+   active_source_handlers_.clear();
+ }
+ 
++void DeferredTaskHandler::ClearContextFromOrphanHandlers() {
++  DCHECK(IsMainThread());
++
++  // |rendering_orphan_handlers_| and |deletable_orphan_handlers_| can
++  // be modified on the audio thread.
++  GraphAutoLocker locker(*this);
++
++  for (auto& handler : rendering_orphan_handlers_)
++    handler->ClearContext();
++  for (auto& handler : deletable_orphan_handlers_)
++    handler->ClearContext();
++}
++
+ void DeferredTaskHandler::SetAudioThreadToCurrentThread() {
+   DCHECK(!IsMainThread());
+   audio_thread_.store(CurrentThread(), std::memory_order_relaxed);
+diff --git a/third_party/blink/renderer/modules/webaudio/deferred_task_handler.h b/third_party/blink/renderer/modules/webaudio/deferred_task_handler.h
+index 49cbf6977ddfc..0530c7fc12724 100644
+--- a/third_party/blink/renderer/modules/webaudio/deferred_task_handler.h
++++ b/third_party/blink/renderer/modules/webaudio/deferred_task_handler.h
+@@ -111,6 +111,9 @@ class MODULES_EXPORT DeferredTaskHandler final
+   void RequestToDeleteHandlersOnMainThread();
+   void ClearHandlersToBeDeleted();
+ 
++  // Clear the context from the rendering and deletable orphan handlers.
++  void ClearContextFromOrphanHandlers();
++
+   bool AcceptsTailProcessing() const { return accepts_tail_processing_; }
+   void StopAcceptingTailProcessing() { accepts_tail_processing_ = false; }
+ 


### PR DESCRIPTION
Clear context from orphan handlers when BaseAudioContext is going away

When preparing to collect a BaseAudioContext, go through all the
rendering_orphan_handlers_ and deletable_orphan_handlers_ and remove
the context from the handler.  This ensures that these handlers no
longer have references to the context when the BaseAudioContext is
destroyed because in some cases, these orphan handlers will get pulled
and access the context, which is already gone.

Clearing these in a prefinalizer ensures these orphan handlers don't
try to touch the context.

Manually verified that the repro case no longer reproduces.

Bug: 1062247
Change-Id: I50d083743903eb9544e09aa1ee912fc880331501
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2107806
Reviewed-by: Kentaro Hara <haraken@chromium.org>
Reviewed-by: Hongchan Choi <hongchan@chromium.org>
Commit-Queue: Raymond Toy <rtoy@chromium.org>
Cr-Commit-Position: refs/heads/master@{#751814}

Notes: none