### PR TITLE
chore: cherry-pick b5950ad76471 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -99,3 +99,4 @@ allow_restricted_clock_nanosleep_in_linux_sandbox.patch
 move_readablestream_requests_onto_the_stack_before_iteration.patch
 streams_convert_state_dchecks_to_checks.patch
 cherry-pick-fd211b44535c.patch
+cherry-pick-b5950ad76471.patch

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -98,5 +98,5 @@ typemap.patch
 allow_restricted_clock_nanosleep_in_linux_sandbox.patch
 move_readablestream_requests_onto_the_stack_before_iteration.patch
 streams_convert_state_dchecks_to_checks.patch
-cherry-pick-fd211b44535c.patch
-cherry-pick-b5950ad76471.patch
+audiocontext_haspendingactivity_unless_it_s_closed.patch
+protect_automatic_pull_handlers_with_mutex.patch

--- a/patches/chromium/audiocontext_haspendingactivity_unless_it_s_closed.patch
+++ b/patches/chromium/audiocontext_haspendingactivity_unless_it_s_closed.patch
@@ -1,7 +1,7 @@
-From fd211b44535c09af58353f0799a624f076e98dda Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Raymond Toy <rtoy@chromium.org>
 Date: Mon, 16 Dec 2019 17:06:28 +0000
-Subject: [PATCH] AudioContext HasPendingActivity unless it's closed
+Subject: AudioContext HasPendingActivity unless it's closed
 
 An AudioContext is considered to have activity if it's not closed.
 Previously, suspended contexts were considered has having no activity,
@@ -25,15 +25,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/1969044
 Reviewed-by: Raymond Toy <rtoy@chromium.org>
 Cr-Commit-Position: refs/branch-heads/3987@{#158}
 Cr-Branched-From: c4e8da9871cc266be74481e212f3a5252972509d-refs/heads/master@{#722274}
----
- .../blink/renderer/modules/webaudio/audio_context.cc      | 8 +++++---
- 1 file changed, 5 insertions(+), 3 deletions(-)
 
 diff --git a/third_party/blink/renderer/modules/webaudio/audio_context.cc b/third_party/blink/renderer/modules/webaudio/audio_context.cc
-index bd76a6a7deca2..063475274c168 100644
+index 839d8c83973b979a3382464a05c2368eec8a7bae..990fe75f1ddd4ebf9a526a9e416d2ee865afca86 100644
 --- a/third_party/blink/renderer/modules/webaudio/audio_context.cc
 +++ b/third_party/blink/renderer/modules/webaudio/audio_context.cc
-@@ -551,9 +551,11 @@ void AudioContext::ContextDestroyed(ExecutionContext*) {
+@@ -545,9 +545,11 @@ void AudioContext::ContextDestroyed(ExecutionContext*) {
  }
  
  bool AudioContext::HasPendingActivity() const {

--- a/patches/chromium/browser_compositor_mac.patch
+++ b/patches/chromium/browser_compositor_mac.patch
@@ -29,7 +29,7 @@ diff --git a/content/browser/renderer_host/browser_compositor_view_mac.mm b/cont
 index 8ddd790decc43af9820c97121a3b359e7cbb49ee..18019d5794f688ca07b35a665cc9800bb1d3047a 100644
 --- a/content/browser/renderer_host/browser_compositor_view_mac.mm
 +++ b/content/browser/renderer_host/browser_compositor_view_mac.mm
-@@ -80,6 +80,12 @@
+@@ -80,6 +80,12 @@ BrowserCompositorMac::~BrowserCompositorMac() {
    DCHECK_EQ(1u, num_erased);
  }
  

--- a/patches/chromium/cherry-pick-b5950ad76471.patch
+++ b/patches/chromium/cherry-pick-b5950ad76471.patch
@@ -1,0 +1,106 @@
+From b5950ad76471d6aa446af46aee645fb5e32c435d Mon Sep 17 00:00:00 2001
+From: Hongchan Choi <hongchan@chromium.org>
+Date: Fri, 13 Mar 2020 02:52:15 +0000
+Subject: [PATCH] Protect automatic pull handlers with Mutex
+
+In some cases, |rendering_automatic_pull_handlers_| in
+DeferredTaskHandler can be touched from both the main thread and the
+audio rendering thread. This CL adds a lock when it is updated,
+processed, and cleared.
+
+crash on the repro case after 30 min.
+
+Test: Locally confirmed that the ASAN build with this patch does not
+Bug: 1061018
+Change-Id: I5f4440edcdc26e4a3afbfe8fad88492bdb49c323
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2101712
+Commit-Queue: Hongchan Choi <hongchan@chromium.org>
+Reviewed-by: Raymond Toy <rtoy@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#750000}
+---
+ .../modules/webaudio/deferred_task_handler.cc | 26 ++++++++++++++-----
+ .../modules/webaudio/deferred_task_handler.h  |  5 ++++
+ 2 files changed, 25 insertions(+), 6 deletions(-)
+
+diff --git a/third_party/blink/renderer/modules/webaudio/deferred_task_handler.cc b/third_party/blink/renderer/modules/webaudio/deferred_task_handler.cc
+index d02a7f69fe191..00bfc7b8d624b 100644
+--- a/third_party/blink/renderer/modules/webaudio/deferred_task_handler.cc
++++ b/third_party/blink/renderer/modules/webaudio/deferred_task_handler.cc
+@@ -132,6 +132,7 @@ void DeferredTaskHandler::HandleDirtyAudioNodeOutputs() {
+ 
+ void DeferredTaskHandler::AddAutomaticPullNode(
+     scoped_refptr<AudioHandler> node) {
++  DCHECK(IsAudioThread());
+   AssertGraphOwner();
+ 
+   if (!automatic_pull_handlers_.Contains(node)) {
+@@ -151,11 +152,16 @@ void DeferredTaskHandler::RemoveAutomaticPullNode(AudioHandler* node) {
+ }
+ 
+ void DeferredTaskHandler::UpdateAutomaticPullNodes() {
++  DCHECK(IsAudioThread());
+   AssertGraphOwner();
+ 
+   if (automatic_pull_handlers_need_updating_) {
+-    CopyToVector(automatic_pull_handlers_, rendering_automatic_pull_handlers_);
+-    automatic_pull_handlers_need_updating_ = false;
++    MutexTryLocker try_locker(automatic_pull_handlers_lock_);
++    if (try_locker.Locked()) {
++      CopyToVector(automatic_pull_handlers_,
++                   rendering_automatic_pull_handlers_);
++      automatic_pull_handlers_need_updating_ = false;
++    }
+   }
+ }
+ 
+@@ -163,9 +169,12 @@ void DeferredTaskHandler::ProcessAutomaticPullNodes(
+     uint32_t frames_to_process) {
+   DCHECK(IsAudioThread());
+ 
+-  for (unsigned i = 0; i < rendering_automatic_pull_handlers_.size(); ++i) {
+-    rendering_automatic_pull_handlers_[i]->ProcessIfNecessary(
+-        frames_to_process);
++  MutexTryLocker try_locker(automatic_pull_handlers_lock_);
++  if (try_locker.Locked()) {
++    for (auto& rendering_automatic_pull_handler :
++         rendering_automatic_pull_handlers_) {
++      rendering_automatic_pull_handler->ProcessIfNecessary(frames_to_process);
++    }
+   }
+ }
+ 
+@@ -350,12 +359,17 @@ void DeferredTaskHandler::DeleteHandlersOnMainThread() {
+ 
+ void DeferredTaskHandler::ClearHandlersToBeDeleted() {
+   DCHECK(IsMainThread());
++
++  {
++    MutexLocker locker(automatic_pull_handlers_lock_);
++    rendering_automatic_pull_handlers_.clear();
++  }
++
+   GraphAutoLocker locker(*this);
+   tail_processing_handlers_.clear();
+   rendering_orphan_handlers_.clear();
+   deletable_orphan_handlers_.clear();
+   automatic_pull_handlers_.clear();
+-  rendering_automatic_pull_handlers_.clear();
+   finished_source_handlers_.clear();
+   active_source_handlers_.clear();
+ }
+diff --git a/third_party/blink/renderer/modules/webaudio/deferred_task_handler.h b/third_party/blink/renderer/modules/webaudio/deferred_task_handler.h
+index 3cf47ca77a8b1..49cbf6977ddfc 100644
+--- a/third_party/blink/renderer/modules/webaudio/deferred_task_handler.h
++++ b/third_party/blink/renderer/modules/webaudio/deferred_task_handler.h
+@@ -265,6 +265,11 @@ class MODULES_EXPORT DeferredTaskHandler final
+ 
+   // Graph locking.
+   RecursiveMutex context_graph_mutex_;
++
++  // Protects |rendering_automatic_pull_handlers| when updating, processing, and
++  // clearing. (See crbug.com/1061018)
++  mutable Mutex automatic_pull_handlers_lock_;
++
+   std::atomic<base::PlatformThreadId> audio_thread_;
+ };
+ 

--- a/patches/chromium/command-ismediakey.patch
+++ b/patches/chromium/command-ismediakey.patch
@@ -97,7 +97,7 @@ index f4e3126a4efd66f05c4f13e40ba23db10b8cca96..f7e90349ee49f0d79a0443c5a9ec886f
    }
    return VKEY_UNKNOWN;
  }
-@@ -193,7 +200,10 @@ static CGEventRef EventTapCallback(CGEventTapProxy proxy,
+@@ -193,7 +200,10 @@ CGEventRef MediaKeysListenerImpl::EventTapCallback(CGEventTapProxy proxy,
    int key_code = (data1 & 0xFFFF0000) >> 16;
    if (key_code != NX_KEYTYPE_PLAY && key_code != NX_KEYTYPE_NEXT &&
        key_code != NX_KEYTYPE_PREVIOUS && key_code != NX_KEYTYPE_FAST &&
@@ -109,7 +109,7 @@ index f4e3126a4efd66f05c4f13e40ba23db10b8cca96..f7e90349ee49f0d79a0443c5a9ec886f
      return event;
    }
  
-@@ -224,6 +234,7 @@ static CGEventRef EventTapCallback(CGEventTapProxy proxy,
+@@ -224,6 +234,7 @@ std::unique_ptr<MediaKeysListener> MediaKeysListener::Create(
    // For Mac OS 10.12.2 or later, we want to use MPRemoteCommandCenter for
    // getting media keys globally if there is a RemoteCommandCenterDelegate
    // available.
@@ -117,7 +117,7 @@ index f4e3126a4efd66f05c4f13e40ba23db10b8cca96..f7e90349ee49f0d79a0443c5a9ec886f
    if (@available(macOS 10.12.2, *)) {
      if (scope == Scope::kGlobal &&
          now_playing::RemoteCommandCenterDelegate::GetInstance()) {
-@@ -233,7 +244,7 @@ static CGEventRef EventTapCallback(CGEventTapProxy proxy,
+@@ -233,7 +244,7 @@ std::unique_ptr<MediaKeysListener> MediaKeysListener::Create(
        return std::move(listener);
      }
    }

--- a/patches/chromium/fix_disabling_compositor_recycling.patch
+++ b/patches/chromium/fix_disabling_compositor_recycling.patch
@@ -9,7 +9,7 @@ diff --git a/content/browser/renderer_host/render_widget_host_view_mac.mm b/cont
 index 6a9f9c466a45312c190b30e53146b9b303b9f32a..80900b809d7b05a4ab546c6ce0686a261755e82a 100644
 --- a/content/browser/renderer_host/render_widget_host_view_mac.mm
 +++ b/content/browser/renderer_host/render_widget_host_view_mac.mm
-@@ -489,7 +489,11 @@
+@@ -489,7 +489,11 @@ void RenderWidgetHostViewMac::WasOccluded() {
      return;
  
    host()->WasHidden();

--- a/patches/chromium/fix_hi-dpi_transitions_on_catalina.patch
+++ b/patches/chromium/fix_hi-dpi_transitions_on_catalina.patch
@@ -48,7 +48,7 @@ diff --git a/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm 
 index 3db03e957c0325417747a952f2dffb45b3c81916..ab9caba9ba54a6fbe85b3ca2ffac470d9498900d 100644
 --- a/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
 +++ b/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
-@@ -313,9 +313,11 @@ NSUInteger CountBridgedWindows(NSArray* child_windows) {
+@@ -313,9 +313,11 @@ NativeWidgetNSWindowBridge::NativeWidgetNSWindowBridge(
        bridge_mojo_binding_(this) {
    DCHECK(GetIdToWidgetImplMap().find(id_) == GetIdToWidgetImplMap().end());
    GetIdToWidgetImplMap().insert(std::make_pair(id_, this));
@@ -60,7 +60,7 @@ index 3db03e957c0325417747a952f2dffb45b3c81916..ab9caba9ba54a6fbe85b3ca2ffac470d
    // The delegate should be cleared already. Note this enforces the precondition
    // that -[NSWindow close] is invoked on the hosted window before the
    // destructor is called.
-@@ -1098,7 +1100,17 @@ NSUInteger CountBridgedWindows(NSArray* child_windows) {
+@@ -1098,7 +1100,17 @@ DragDropClient* NativeWidgetNSWindowBridge::drag_drop_client() {
  }
  
  ////////////////////////////////////////////////////////////////////////////////
@@ -83,7 +83,7 @@ diff --git a/ui/display/mac/screen_mac.mm b/ui/display/mac/screen_mac.mm
 index 4e0a2cb6991cafa96c1e2077f38ef315544890fc..9f0d860316d2aabc6f344e47a1c5b4d550b6335e 100644
 --- a/ui/display/mac/screen_mac.mm
 +++ b/ui/display/mac/screen_mac.mm
-@@ -32,8 +32,8 @@
+@@ -32,8 +32,8 @@ Boolean CGDisplayUsesForceToGray(void);
  namespace display {
  namespace {
  
@@ -94,7 +94,7 @@ index 4e0a2cb6991cafa96c1e2077f38ef315544890fc..9f0d860316d2aabc6f344e47a1c5b4d5
  const int64_t kConfigureDelayMs = 500;
  
  NSScreen* GetMatchingScreen(const gfx::Rect& match_rect) {
-@@ -159,20 +159,27 @@ CGFloat GetMinimumDistanceToCorner(const NSPoint& point, NSScreen* screen) {
+@@ -159,20 +159,27 @@ class ScreenMac : public Screen {
      CGDisplayRegisterReconfigurationCallback(
          ScreenMac::DisplayReconfigurationCallBack, this);
  
@@ -126,7 +126,7 @@ index 4e0a2cb6991cafa96c1e2077f38ef315544890fc..9f0d860316d2aabc6f344e47a1c5b4d5
  
      CGDisplayRemoveReconfigurationCallback(
          ScreenMac::DisplayReconfigurationCallBack, this);
-@@ -197,16 +204,18 @@ bool IsWindowUnderCursor(gfx::NativeWindow native_window) override {
+@@ -197,16 +204,18 @@ class ScreenMac : public Screen {
    int GetNumDisplays() const override { return GetAllDisplays().size(); }
  
    const std::vector<Display>& GetAllDisplays() const override {
@@ -147,7 +147,7 @@ index 4e0a2cb6991cafa96c1e2077f38ef315544890fc..9f0d860316d2aabc6f344e47a1c5b4d5
      if (!window)
        return GetPrimaryDisplay();
  
-@@ -279,31 +288,30 @@ void RemoveObserver(DisplayObserver* observer) override {
+@@ -279,31 +288,30 @@ class ScreenMac : public Screen {
    static void DisplayReconfigurationCallBack(CGDirectDisplayID display,
                                               CGDisplayChangeSummaryFlags flags,
                                               void* userInfo) {
@@ -189,7 +189,7 @@ index 4e0a2cb6991cafa96c1e2077f38ef315544890fc..9f0d860316d2aabc6f344e47a1c5b4d5
      if (displays_require_update_) {
        displays_ = BuildDisplaysFromQuartz();
        displays_require_update_ = false;
-@@ -311,7 +319,7 @@ void EnsureDisplaysValid() const {
+@@ -311,7 +319,7 @@ class ScreenMac : public Screen {
    }
  
    void ConfigureTimerFired() {
@@ -198,7 +198,7 @@ index 4e0a2cb6991cafa96c1e2077f38ef315544890fc..9f0d860316d2aabc6f344e47a1c5b4d5
      change_notifier_.NotifyDisplaysChanged(old_displays_, displays_);
      old_displays_ = displays_;
    }
-@@ -325,7 +333,7 @@ void ConfigureTimerFired() {
+@@ -325,7 +333,7 @@ class ScreenMac : public Screen {
      // It would be ridiculous to have this many displays connected, but
      // CGDirectDisplayID is just an integer, so supporting up to this many
      // doesn't hurt.
@@ -207,7 +207,7 @@ index 4e0a2cb6991cafa96c1e2077f38ef315544890fc..9f0d860316d2aabc6f344e47a1c5b4d5
      CGDisplayCount online_display_count = 0;
      if (CGGetOnlineDisplayList(base::size(online_displays), online_displays,
                                 &online_display_count) != kCGErrorSuccess) {
-@@ -361,21 +369,32 @@ void ConfigureTimerFired() {
+@@ -361,21 +369,32 @@ class ScreenMac : public Screen {
                              : displays;
    }
  

--- a/patches/chromium/make_autocorrect_off_and_spellcheck_false_disable_touch_bar_typing.patch
+++ b/patches/chromium/make_autocorrect_off_and_spellcheck_false_disable_touch_bar_typing.patch
@@ -18,7 +18,7 @@ diff --git a/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm b/co
 index 9113fb00d144d6cee789f608f8b3761b93ca7ae8..1e92b2b515056235de6277a43be207f79c94dedf 100644
 --- a/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
 +++ b/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
-@@ -2220,7 +2220,9 @@ - (void)invalidateTouchBar {
+@@ -2220,7 +2220,9 @@ extern NSString* NSTextInputReplacementRangeAttributeName;
  }
  
  - (NSTouchBar*)makeTouchBar {

--- a/patches/chromium/mas-cfisobjc.patch
+++ b/patches/chromium/mas-cfisobjc.patch
@@ -9,7 +9,7 @@ diff --git a/base/mac/foundation_util.mm b/base/mac/foundation_util.mm
 index 8b20ebc678c39b722bd5b03930ce89847e8cc73a..dca8c939e757003aafc1528ec7bbb739bf971fa6 100644
 --- a/base/mac/foundation_util.mm
 +++ b/base/mac/foundation_util.mm
-@@ -26,7 +26,6 @@
+@@ -26,7 +26,6 @@ CFTypeID SecKeyGetTypeID();
  #if !defined(OS_IOS)
  CFTypeID SecACLGetTypeID();
  CFTypeID SecTrustedApplicationGetTypeID();
@@ -17,7 +17,7 @@ index 8b20ebc678c39b722bd5b03930ce89847e8cc73a..dca8c939e757003aafc1528ec7bbb739
  #endif
  }  // extern "C"
  
-@@ -315,8 +314,7 @@ void SetBaseBundleID(const char* new_base_bundle_id) {
+@@ -315,8 +314,7 @@ NSFont* CFToNSCast(CTFontRef cf_val) {
        const_cast<NSFont*>(reinterpret_cast<const NSFont*>(cf_val));
    DCHECK(!cf_val ||
           CTFontGetTypeID() == CFGetTypeID(cf_val) ||
@@ -27,7 +27,7 @@ index 8b20ebc678c39b722bd5b03930ce89847e8cc73a..dca8c939e757003aafc1528ec7bbb739
    return ns_val;
  }
  
-@@ -384,9 +382,6 @@ CTFontRef NSToCFCast(NSFont* ns_val) {
+@@ -384,9 +382,6 @@ CFCast<CTFontRef>(const CFTypeRef& cf_val) {
      return (CTFontRef)(cf_val);
    }
  

--- a/patches/chromium/mas_blink_no_private_api.patch
+++ b/patches/chromium/mas_blink_no_private_api.patch
@@ -18,7 +18,7 @@ index 94afefcee81b87c05bf9b1199d90d3d4b5ea84a6..2ec7f04c71824b47de1ddbf1f0e8625d
  extern "C" {
  
  // Kill ring calls. Would be better to use NSKillRing.h, but that's not
-@@ -39,38 +40,53 @@
+@@ -39,38 +40,53 @@ NSString* _NSYankFromKillRing();
  void _NSNewKillRingSequence();
  void _NSSetKillRingToYankedState();
  }
@@ -92,7 +92,7 @@ index e94235acb17335fbc78c606ff26036871117bd09..7c4bd19215c67f649636ae69b9a21b5c
  
  namespace blink {
  
-@@ -72,10 +74,12 @@ void _NSDrawCarbonThemeListBox(NSRect frame,
+@@ -72,10 +74,12 @@ bool ThemePainterMac::PaintTextField(const Node* node,
    // behavior change while remaining a fragile solution.
    // https://bugs.chromium.org/p/chromium/issues/detail?id=658085#c3
    if (!use_ns_text_field_cell) {
@@ -105,7 +105,7 @@ index e94235acb17335fbc78c606ff26036871117bd09..7c4bd19215c67f649636ae69b9a21b5c
      return false;
    }
  
-@@ -161,10 +165,12 @@ void _NSDrawCarbonThemeListBox(NSRect frame,
+@@ -161,10 +165,12 @@ bool ThemePainterMac::PaintTextArea(const Node* node,
                                      const PaintInfo& paint_info,
                                      const IntRect& r) {
    LocalCurrentGraphicsContext local_context(paint_info.context, r);

--- a/patches/chromium/mas_disable_custom_window_frame.patch
+++ b/patches/chromium/mas_disable_custom_window_frame.patch
@@ -18,7 +18,7 @@ index 1ffb647e85e00ff60d84234e47f5d7d385f65245..439cc6df5e0cc1ec3732d6f2a2e00d54
  @interface NSWindow (PrivateBrowserNativeWidgetAPI)
  + (Class)frameViewClassForStyleMask:(NSUInteger)windowStyle;
  @end
-@@ -69,10 +70,13 @@ - (NSRect)_draggableFrame NS_DEPRECATED_MAC(10_10, 10_11) {
+@@ -69,10 +70,13 @@
  
  @end
  
@@ -32,7 +32,7 @@ index 1ffb647e85e00ff60d84234e47f5d7d385f65245..439cc6df5e0cc1ec3732d6f2a2e00d54
  + (Class)frameViewClassForStyleMask:(NSUInteger)windowStyle {
    // - NSThemeFrame and its subclasses will be nil if it's missing at runtime.
    if ([BrowserWindowFrame class])
-@@ -87,6 +91,8 @@ - (BOOL)_usesCustomDrawing {
+@@ -87,6 +91,8 @@
    return NO;
  }
  
@@ -54,7 +54,7 @@ index 8416c7c6e052dafb2aad61c0bd3224c36e945d23..cd356beda023ab2409b16d58ca38c70b
  @interface NSWindow (PrivateAPI)
  + (Class)frameViewClassForStyleMask:(NSUInteger)windowStyle;
  @end
-@@ -18,8 +20,12 @@ - (CGFloat)_titlebarHeight {
+@@ -18,8 +20,12 @@
  }
  @end
  
@@ -67,7 +67,7 @@ index 8416c7c6e052dafb2aad61c0bd3224c36e945d23..cd356beda023ab2409b16d58ca38c70b
  + (Class)frameViewClassForStyleMask:(NSUInteger)windowStyle {
    if ([NativeWidgetMacFramelessNSWindowFrame class]) {
      return [NativeWidgetMacFramelessNSWindowFrame class];
-@@ -27,4 +33,6 @@ + (Class)frameViewClassForStyleMask:(NSUInteger)windowStyle {
+@@ -27,4 +33,6 @@
    return [super frameViewClassForStyleMask:windowStyle];
  }
  
@@ -108,7 +108,7 @@ index bf4cd6d246358c568cbe192c48748099a3c1de20..6955d39751832815ddec1fec32d791fc
  - (BOOL)hasKeyAppearance;
  - (long long)_resizeDirectionForMouseLocation:(CGPoint)location;
  
-@@ -56,6 +58,8 @@ - (void)cr_mouseDownOnFrameView:(NSEvent*)event {
+@@ -56,6 +58,8 @@
  }
  @end
  
@@ -117,7 +117,7 @@ index bf4cd6d246358c568cbe192c48748099a3c1de20..6955d39751832815ddec1fec32d791fc
  @implementation NativeWidgetMacNSWindowTitledFrame
  - (void)mouseDown:(NSEvent*)event {
    if (self.window.isMovable)
-@@ -77,6 +81,8 @@ - (BOOL)usesCustomDrawing {
+@@ -77,6 +81,8 @@
  }
  @end
  
@@ -126,7 +126,7 @@ index bf4cd6d246358c568cbe192c48748099a3c1de20..6955d39751832815ddec1fec32d791fc
  @implementation NativeWidgetMacNSWindow {
   @private
    base::scoped_nsobject<CommandDispatcher> commandDispatcher_;
-@@ -154,6 +160,8 @@ - (BOOL)hasViewsMenuActive {
+@@ -154,6 +160,8 @@
  
  // NSWindow overrides.
  
@@ -135,7 +135,7 @@ index bf4cd6d246358c568cbe192c48748099a3c1de20..6955d39751832815ddec1fec32d791fc
  + (Class)frameViewClassForStyleMask:(NSWindowStyleMask)windowStyle {
    if (windowStyle & NSWindowStyleMaskTitled) {
      if (Class customFrame = [NativeWidgetMacNSWindowTitledFrame class])
-@@ -165,6 +173,8 @@ + (Class)frameViewClassForStyleMask:(NSWindowStyleMask)windowStyle {
+@@ -165,6 +173,8 @@
    return [super frameViewClassForStyleMask:windowStyle];
  }
  

--- a/patches/chromium/mas_disable_remote_accessibility.patch
+++ b/patches/chromium/mas_disable_remote_accessibility.patch
@@ -10,7 +10,7 @@ diff --git a/components/remote_cocoa/app_shim/application_bridge.mm b/components
 index 628196e20d2b3b30231cb03af8288244a4196146..28dbc7f300dc72779ca3e3cb6fbb3d9a0b14666b 100644
 --- a/components/remote_cocoa/app_shim/application_bridge.mm
 +++ b/components/remote_cocoa/app_shim/application_bridge.mm
-@@ -44,6 +44,7 @@
+@@ -44,6 +44,7 @@ class NativeWidgetBridgeOwner : public NativeWidgetNSWindowHostHelper {
  
    // NativeWidgetNSWindowHostHelper:
    id GetNativeViewAccessible() override {
@@ -18,7 +18,7 @@ index 628196e20d2b3b30231cb03af8288244a4196146..28dbc7f300dc72779ca3e3cb6fbb3d9a
      if (!remote_accessibility_element_) {
        int64_t browser_pid = 0;
        std::vector<uint8_t> element_token;
-@@ -54,6 +55,9 @@ id GetNativeViewAccessible() override {
+@@ -54,6 +55,9 @@ class NativeWidgetBridgeOwner : public NativeWidgetNSWindowHostHelper {
            ui::RemoteAccessibility::GetRemoteElementFromToken(element_token);
      }
      return remote_accessibility_element_.get();
@@ -28,7 +28,7 @@ index 628196e20d2b3b30231cb03af8288244a4196146..28dbc7f300dc72779ca3e3cb6fbb3d9a
    }
    void DispatchKeyEvent(ui::KeyEvent* event) override {
      bool event_handled = false;
-@@ -91,8 +95,10 @@ void GetWordAt(const gfx::Point& location_in_content,
+@@ -91,8 +95,10 @@ class NativeWidgetBridgeOwner : public NativeWidgetNSWindowHostHelper {
    mojom::TextInputHostAssociatedPtr text_input_host_ptr_;
  
    std::unique_ptr<NativeWidgetNSWindowBridge> bridge_;
@@ -43,7 +43,7 @@ diff --git a/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm 
 index 6fc744210179b06384d9eba08da02a626dab4930..3db03e957c0325417747a952f2dffb45b3c81916 100644
 --- a/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
 +++ b/components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
-@@ -554,10 +554,12 @@ NSUInteger CountBridgedWindows(NSArray* child_windows) {
+@@ -554,10 +554,12 @@ void NativeWidgetNSWindowBridge::CreateContentView(uint64_t ns_view_id,
    // this should be treated as an error and caught early.
    CHECK(bridged_view_);
  
@@ -60,7 +60,7 @@ diff --git a/content/app_shim_remote_cocoa/ns_view_bridge_factory_impl.mm b/cont
 index 938854358e5b683d5d77c5aa825963daa67e5b2f..c79ee1552668b8522eb88b86dbe4a31bf267bdfe 100644
 --- a/content/app_shim_remote_cocoa/ns_view_bridge_factory_impl.mm
 +++ b/content/app_shim_remote_cocoa/ns_view_bridge_factory_impl.mm
-@@ -61,8 +61,10 @@ id GetFocusedBrowserAccessibilityElement() override {
+@@ -61,8 +61,10 @@ class RenderWidgetHostNSViewBridgeOwner
      return nil;
    }
    void SetAccessibilityWindow(NSWindow* window) override {
@@ -71,7 +71,7 @@ index 938854358e5b683d5d77c5aa825963daa67e5b2f..c79ee1552668b8522eb88b86dbe4a31b
    }
  
    void ForwardKeyboardEvent(const content::NativeWebKeyboardEvent& key_event,
-@@ -121,8 +123,10 @@ void SmartMagnify(const blink::WebGestureEvent& web_event) override {
+@@ -121,8 +123,10 @@ class RenderWidgetHostNSViewBridgeOwner
  
    mojom::RenderWidgetHostNSViewHostAssociatedPtr host_;
    std::unique_ptr<RenderWidgetHostNSViewBridge> bridge_;
@@ -113,7 +113,7 @@ diff --git a/content/browser/renderer_host/render_widget_host_view_mac.mm b/cont
 index 9f36053c15a9895677c791e1578d16bc867c4265..6a9f9c466a45312c190b30e53146b9b303b9f32a 100644
 --- a/content/browser/renderer_host/render_widget_host_view_mac.mm
 +++ b/content/browser/renderer_host/render_widget_host_view_mac.mm
-@@ -245,8 +245,10 @@
+@@ -245,8 +245,10 @@ RenderWidgetHostViewMac::~RenderWidgetHostViewMac() {
  void RenderWidgetHostViewMac::MigrateNSViewBridge(
      remote_cocoa::mojom::Application* remote_cocoa_application,
      uint64_t parent_ns_view_id) {
@@ -124,7 +124,7 @@ index 9f36053c15a9895677c791e1578d16bc867c4265..6a9f9c466a45312c190b30e53146b9b3
  
    // Disconnect from the previous bridge (this will have the effect of
    // destroying the associated bridge), and close the binding (to allow it
-@@ -1383,8 +1385,10 @@ void CombineTextNodesAndMakeCallback(SpeechCallback callback,
+@@ -1383,8 +1385,10 @@ RenderWidgetHostViewMac::AccessibilityGetNativeViewAccessible() {
  
  gfx::NativeViewAccessible
  RenderWidgetHostViewMac::AccessibilityGetNativeViewAccessibleForWindow() {
@@ -135,7 +135,7 @@ index 9f36053c15a9895677c791e1578d16bc867c4265..6a9f9c466a45312c190b30e53146b9b3
    return [GetInProcessNSView() window];
  }
  
-@@ -1424,9 +1428,11 @@ void CombineTextNodesAndMakeCallback(SpeechCallback callback,
+@@ -1424,9 +1428,11 @@ id RenderWidgetHostViewMac::GetFocusedBrowserAccessibilityElement() {
  }
  
  void RenderWidgetHostViewMac::SetAccessibilityWindow(NSWindow* window) {
@@ -147,7 +147,7 @@ index 9f36053c15a9895677c791e1578d16bc867c4265..6a9f9c466a45312c190b30e53146b9b3
  }
  
  bool RenderWidgetHostViewMac::SyncIsWidgetForMainFrame(
-@@ -1907,12 +1913,14 @@ void CombineTextNodesAndMakeCallback(SpeechCallback callback,
+@@ -1907,12 +1913,14 @@ void RenderWidgetHostViewMac::StopSpeaking() {
  
  void RenderWidgetHostViewMac::SetRemoteAccessibilityWindowToken(
      const std::vector<uint8_t>& window_token) {
@@ -201,7 +201,7 @@ index 2a58aebabb23443a2c11364af4988c573f3909ba..3424b6011e80e9c995519b6a8d652abd
 +
  #endif  // UI_BASE_COCOA_REMOTE_ACCESSIBILITY_API_H_
 diff --git a/ui/views/cocoa/native_widget_mac_ns_window_host.h b/ui/views/cocoa/native_widget_mac_ns_window_host.h
-index 528ec883d22679a92c1d82da783588f8e33e4d99..c8b3f1752526c85fd9793e95b29424120c7c5158 100644
+index 5058eb6048a6120dab6f1ce30ff56a6fee7be7b7..b73c6993b46cc926f92e3598ec7bb1379ec8300d 100644
 --- a/ui/views/cocoa/native_widget_mac_ns_window_host.h
 +++ b/ui/views/cocoa/native_widget_mac_ns_window_host.h
 @@ -28,7 +28,9 @@
@@ -229,10 +229,10 @@ index 528ec883d22679a92c1d82da783588f8e33e4d99..c8b3f1752526c85fd9793e95b2942412
    // Used to force the NSApplication's focused accessibility element to be the
    // views::Views accessibility tree when the NSView for this is focused.
 diff --git a/ui/views/cocoa/native_widget_mac_ns_window_host.mm b/ui/views/cocoa/native_widget_mac_ns_window_host.mm
-index 6aa9e71245f131b176a2c6d4416786d5bcac621e..b24a364c7689d8ca3df680b9b57bd9d040885985 100644
+index 89eb028e840b4e997e3e4706fcc6c9bb070c2491..b85cf12286d6add7c063b8552cda25b579983d96 100644
 --- a/ui/views/cocoa/native_widget_mac_ns_window_host.mm
 +++ b/ui/views/cocoa/native_widget_mac_ns_window_host.mm
-@@ -348,14 +348,22 @@ void UpdateCALayerParams(gfx::CALayerParams* ca_layer_params) {
+@@ -351,14 +351,22 @@ gfx::NativeViewAccessible
  NativeWidgetMacNSWindowHost::GetNativeViewAccessibleForNSView() const {
    if (in_process_ns_window_bridge_)
      return in_process_ns_window_bridge_->ns_view();
@@ -255,7 +255,7 @@ index 6aa9e71245f131b176a2c6d4416786d5bcac621e..b24a364c7689d8ca3df680b9b57bd9d0
  }
  
  remote_cocoa::mojom::NativeWidgetNSWindow*
-@@ -1191,6 +1199,7 @@ void UpdateCALayerParams(gfx::CALayerParams* ca_layer_params) {
+@@ -1194,6 +1202,7 @@ void NativeWidgetMacNSWindowHost::OnFocusWindowToolbar() {
  void NativeWidgetMacNSWindowHost::SetRemoteAccessibilityTokens(
      const std::vector<uint8_t>& window_token,
      const std::vector<uint8_t>& view_token) {
@@ -263,7 +263,7 @@ index 6aa9e71245f131b176a2c6d4416786d5bcac621e..b24a364c7689d8ca3df680b9b57bd9d0
    remote_window_accessible_ =
        ui::RemoteAccessibility::GetRemoteElementFromToken(window_token);
    remote_view_accessible_ =
-@@ -1198,14 +1207,17 @@ void UpdateCALayerParams(gfx::CALayerParams* ca_layer_params) {
+@@ -1201,14 +1210,17 @@ void NativeWidgetMacNSWindowHost::SetRemoteAccessibilityTokens(
    [remote_view_accessible_ setWindowUIElement:remote_window_accessible_.get()];
    [remote_view_accessible_
        setTopLevelUIElement:remote_window_accessible_.get()];

--- a/patches/chromium/mas_disable_remote_layer.patch
+++ b/patches/chromium/mas_disable_remote_layer.patch
@@ -6,7 +6,7 @@ Subject: mas_disable_remote_layer.patch
 Disable remote layer APIs (CAContext and CALayerHost) for MAS build.
 
 diff --git a/gpu/ipc/service/image_transport_surface_overlay_mac.h b/gpu/ipc/service/image_transport_surface_overlay_mac.h
-index f343b7e0e04a..d0ecefd4333c 100644
+index f343b7e0e04ab6b36c5eb3d544af28684ca2ef37..d0ecefd4333ccb92349d9c99e458b11d5c7bbe31 100644
 --- a/gpu/ipc/service/image_transport_surface_overlay_mac.h
 +++ b/gpu/ipc/service/image_transport_surface_overlay_mac.h
 @@ -20,7 +20,9 @@
@@ -30,10 +30,10 @@ index f343b7e0e04a..d0ecefd4333c 100644
  
    gfx::Size pixel_size_;
 diff --git a/gpu/ipc/service/image_transport_surface_overlay_mac.mm b/gpu/ipc/service/image_transport_surface_overlay_mac.mm
-index 10b345d3727c..b52f03be6351 100644
+index 10b345d3727c95f243e6fed4692af99094c16565..b52f03be6351e9648238147b87433c81d7a4078f 100644
 --- a/gpu/ipc/service/image_transport_surface_overlay_mac.mm
 +++ b/gpu/ipc/service/image_transport_surface_overlay_mac.mm
-@@ -63,6 +63,7 @@
+@@ -63,6 +63,7 @@ ImageTransportSurfaceOverlayMacBase<
  template <typename BaseClass>
  bool ImageTransportSurfaceOverlayMacBase<BaseClass>::Initialize(
      gl::GLSurfaceFormat format) {
@@ -41,7 +41,7 @@ index 10b345d3727c..b52f03be6351 100644
    // Create the CAContext to send this to the GPU process, and the layer for
    // the context.
    if (use_remote_layer_api_) {
-@@ -71,6 +72,7 @@
+@@ -71,6 +72,7 @@ bool ImageTransportSurfaceOverlayMacBase<BaseClass>::Initialize(
          [CAContext contextWithCGSConnection:connection_id options:@{}] retain]);
      [ca_context_ setLayer:ca_layer_tree_coordinator_->GetCALayerForDisplay()];
    }
@@ -49,7 +49,7 @@ index 10b345d3727c..b52f03be6351 100644
    return true;
  }
  
-@@ -136,7 +138,9 @@
+@@ -136,7 +138,9 @@ ImageTransportSurfaceOverlayMacBase<BaseClass>::SwapBuffersInternal(
                           "GLImpl", static_cast<int>(gl::GetGLImplementation()),
                           "width", pixel_size_.width());
      if (use_remote_layer_api_) {
@@ -60,10 +60,10 @@ index 10b345d3727c..b52f03be6351 100644
        IOSurfaceRef io_surface =
            ca_layer_tree_coordinator_->GetIOSurfaceForDisplay();
 diff --git a/ui/accelerated_widget_mac/display_ca_layer_tree.mm b/ui/accelerated_widget_mac/display_ca_layer_tree.mm
-index 60abe639bd9c..c38eed5fbdef 100644
+index 60abe639bd9c9cf6885f811c741a45eeb683ec58..c38eed5fbdefc96a3d60e4ab70d3b007264ccb3c 100644
 --- a/ui/accelerated_widget_mac/display_ca_layer_tree.mm
 +++ b/ui/accelerated_widget_mac/display_ca_layer_tree.mm
-@@ -98,6 +98,7 @@ - (void)setContentsChanged;
+@@ -98,6 +98,7 @@ void DisplayCALayerTree::UpdateCALayerTree(
  }
  
  void DisplayCALayerTree::GotCALayerFrame(uint32_t ca_context_id) {
@@ -71,7 +71,7 @@ index 60abe639bd9c..c38eed5fbdef 100644
    // Early-out if the remote layer has not changed.
    if ([remote_layer_ contextId] == ca_context_id)
      return;
-@@ -122,6 +123,9 @@ - (void)setContentsChanged;
+@@ -122,6 +123,9 @@ void DisplayCALayerTree::GotCALayerFrame(uint32_t ca_context_id) {
      [io_surface_layer_ removeFromSuperlayer];
      io_surface_layer_.reset();
    }
@@ -82,7 +82,7 @@ index 60abe639bd9c..c38eed5fbdef 100644
  
  void DisplayCALayerTree::GotIOSurfaceFrame(
 diff --git a/ui/base/cocoa/remote_layer_api.h b/ui/base/cocoa/remote_layer_api.h
-index 2057fe69d1bb..2aba330fc488 100644
+index 2057fe69d1bb4a2eb0b1dabc5473a30d676847fe..2aba330fc488660ef874caae26a06e6847cdaf93 100644
 --- a/ui/base/cocoa/remote_layer_api.h
 +++ b/ui/base/cocoa/remote_layer_api.h
 @@ -13,6 +13,7 @@
@@ -103,7 +103,7 @@ index 2057fe69d1bb..2aba330fc488 100644
  
  // This function will check if all of the interfaces listed above are supported
 diff --git a/ui/base/cocoa/remote_layer_api.mm b/ui/base/cocoa/remote_layer_api.mm
-index bbaf9f466f49..8c846ce9523a 100644
+index bbaf9f466f4999acb5bfccf3b9565fd8f556ca2f..8c846ce9523a4b2f6fbdbdbeae4f94b45ac3c115 100644
 --- a/ui/base/cocoa/remote_layer_api.mm
 +++ b/ui/base/cocoa/remote_layer_api.mm
 @@ -12,6 +12,7 @@
@@ -125,7 +125,7 @@ index bbaf9f466f49..8c846ce9523a 100644
  
  }  // namespace
 diff --git a/ui/views/cocoa/native_widget_mac_ns_window_host.h b/ui/views/cocoa/native_widget_mac_ns_window_host.h
-index 528ec883d226..5058eb6048a6 100644
+index 528ec883d22679a92c1d82da783588f8e33e4d99..5058eb6048a6120dab6f1ce30ff56a6fee7be7b7 100644
 --- a/ui/views/cocoa/native_widget_mac_ns_window_host.h
 +++ b/ui/views/cocoa/native_widget_mac_ns_window_host.h
 @@ -446,11 +446,13 @@ class VIEWS_EXPORT NativeWidgetMacNSWindowHost
@@ -143,10 +143,10 @@ index 528ec883d226..5058eb6048a6 100644
    // The geometry of the window and its contents view, in screen coordinates.
    gfx::Rect window_bounds_in_screen_;
 diff --git a/ui/views/cocoa/native_widget_mac_ns_window_host.mm b/ui/views/cocoa/native_widget_mac_ns_window_host.mm
-index 6aa9e71245f1..89eb028e840b 100644
+index 6aa9e71245f131b176a2c6d4416786d5bcac621e..89eb028e840b4e997e3e4706fcc6c9bb070c2491 100644
 --- a/ui/views/cocoa/native_widget_mac_ns_window_host.mm
 +++ b/ui/views/cocoa/native_widget_mac_ns_window_host.mm
-@@ -213,6 +213,7 @@ bool PositionWindowInScreenCoordinates(Widget* widget,
+@@ -213,6 +213,7 @@ uint64_t g_last_bridged_native_widget_id = 0;
  
  }  // namespace
  
@@ -154,7 +154,7 @@ index 6aa9e71245f1..89eb028e840b 100644
  // A gfx::CALayerParams may pass the content to be drawn across processes via
  // either an IOSurface (sent as mach port) or a CAContextID (which is an
  // integer). For historical reasons, software compositing uses IOSurfaces.
-@@ -267,6 +268,8 @@ void UpdateCALayerParams(gfx::CALayerParams* ca_layer_params) {
+@@ -267,6 +268,8 @@ class NativeWidgetMacNSWindowHost::IOSurfaceToRemoteLayerInterceptor {
    base::scoped_nsobject<CALayer> io_surface_layer_;
  };
  
@@ -163,7 +163,7 @@ index 6aa9e71245f1..89eb028e840b 100644
  // static
  NativeWidgetMacNSWindowHost* NativeWidgetMacNSWindowHost::GetFromNativeWindow(
      gfx::NativeWindow native_window) {
-@@ -1472,6 +1475,7 @@ void UpdateCALayerParams(gfx::CALayerParams* ca_layer_params) {
+@@ -1472,6 +1475,7 @@ void NativeWidgetMacNSWindowHost::AcceleratedWidgetCALayerParamsUpdated() {
    const gfx::CALayerParams* ca_layer_params =
        compositor_->widget()->GetCALayerParams();
    if (ca_layer_params) {
@@ -171,7 +171,7 @@ index 6aa9e71245f1..89eb028e840b 100644
      // Replace IOSurface mach ports with CAContextIDs only when using the
      // out-of-process bridge (to reduce risk, because this workaround is being
      // merged to late-life-cycle release branches) and when an IOSurface
-@@ -1488,8 +1492,11 @@ void UpdateCALayerParams(gfx::CALayerParams* ca_layer_params) {
+@@ -1488,8 +1492,11 @@ void NativeWidgetMacNSWindowHost::AcceleratedWidgetCALayerParamsUpdated() {
            &updated_ca_layer_params);
        remote_ns_window_ptr_->SetCALayerParams(updated_ca_layer_params);
      } else {

--- a/patches/chromium/mas_disable_spi_file_type_mappings.patch
+++ b/patches/chromium/mas_disable_spi_file_type_mappings.patch
@@ -18,7 +18,7 @@ index a510c87ea7d92763a20db61f1dd946f363fff7a3..b5f8ed97440200c3fccadfccce28c7bc
  // SPI declaration; see the commentary in GetPlatformExtensionsForMimeType.
  // iOS must not use any private API, per Apple guideline.
  
-@@ -26,7 +26,7 @@ @interface NSURLFileTypeMappings : NSObject
+@@ -26,7 +26,7 @@
  + (NSURLFileTypeMappings*)sharedMappings;
  - (NSArray*)extensionsForMIMEType:(NSString*)mimeType;
  @end
@@ -27,7 +27,7 @@ index a510c87ea7d92763a20db61f1dd946f363fff7a3..b5f8ed97440200c3fccadfccce28c7bc
  
  namespace net {
  
-@@ -75,7 +75,7 @@ - (NSArray*)extensionsForMIMEType:(NSString*)mimeType;
+@@ -75,7 +75,7 @@ bool PlatformMimeUtil::GetPlatformPreferredExtensionForMimeType(
  void PlatformMimeUtil::GetPlatformExtensionsForMimeType(
      const std::string& mime_type,
      std::unordered_set<base::FilePath::StringType>* extensions) const {
@@ -36,7 +36,7 @@ index a510c87ea7d92763a20db61f1dd946f363fff7a3..b5f8ed97440200c3fccadfccce28c7bc
    NSArray* extensions_list = nil;
  #else
    // There is no API for this that uses UTIs. The WebKitSystemInterface call
-@@ -90,7 +90,7 @@ - (NSArray*)extensionsForMIMEType:(NSString*)mimeType;
+@@ -90,7 +90,7 @@ void PlatformMimeUtil::GetPlatformExtensionsForMimeType(
    NSArray* extensions_list =
        [[NSURLFileTypeMappings sharedMappings]
            extensionsForMIMEType:base::SysUTF8ToNSString(mime_type)];

--- a/patches/chromium/mas_no_private_api.patch
+++ b/patches/chromium/mas_no_private_api.patch
@@ -41,7 +41,7 @@ diff --git a/content/browser/accessibility/browser_accessibility_cocoa.mm b/cont
 index 0a6c3c488c71106f23779481ccec92c0aa8b6bbf..ac2343f648ba3db19ffcb1fc1503e5d68cdb5135 100644
 --- a/content/browser/accessibility/browser_accessibility_cocoa.mm
 +++ b/content/browser/accessibility/browser_accessibility_cocoa.mm
-@@ -225,6 +225,7 @@
+@@ -225,6 +225,7 @@ NSDictionary* attributeToMethodNameMap = nil;
  // VoiceOver uses -1 to mean "no limit" for AXResultsLimit.
  const int kAXResultsLimitNoLimit = -1;
  
@@ -49,7 +49,7 @@ index 0a6c3c488c71106f23779481ccec92c0aa8b6bbf..ac2343f648ba3db19ffcb1fc1503e5d6
  extern "C" {
  
  // The following are private accessibility APIs required for cursor navigation
-@@ -432,6 +433,7 @@ void AddMisspelledTextAttributes(const AXPlatformRange& ax_range,
+@@ -432,6 +433,7 @@ NSAttributedString* GetAttributedTextForTextMarkerRange(id marker_range) {
    AddMisspelledTextAttributes(ax_range, attributed_text);
    return attributed_text;
  }
@@ -57,7 +57,7 @@ index 0a6c3c488c71106f23779481ccec92c0aa8b6bbf..ac2343f648ba3db19ffcb1fc1503e5d6
  
  // Returns an autoreleased copy of the AXNodeData's attribute.
  NSString* NSStringForStringAttribute(BrowserAccessibility* browserAccessibility,
-@@ -699,7 +701,9 @@ + (void)initialize {
+@@ -699,7 +701,9 @@ NSString* const NSAccessibilityRequiredAttributeChrome = @"AXRequired";
        {NSAccessibilityEditableAncestorAttribute, @"editableAncestor"},
        {NSAccessibilityElementBusyAttribute, @"elementBusy"},
        {NSAccessibilityEnabledAttribute, @"enabled"},
@@ -67,7 +67,7 @@ index 0a6c3c488c71106f23779481ccec92c0aa8b6bbf..ac2343f648ba3db19ffcb1fc1503e5d6
        {NSAccessibilityExpandedAttribute, @"expanded"},
        {NSAccessibilityFocusableAncestorAttribute, @"focusableAncestor"},
        {NSAccessibilityFocusedAttribute, @"focused"},
-@@ -734,13 +738,17 @@ + (void)initialize {
+@@ -734,13 +738,17 @@ NSString* const NSAccessibilityRequiredAttributeChrome = @"AXRequired";
        {NSAccessibilityRowsAttribute, @"rows"},
        // TODO(aboxhall): expose
        // NSAccessibilityServesAsTitleForUIElementsAttribute
@@ -85,7 +85,7 @@ index 0a6c3c488c71106f23779481ccec92c0aa8b6bbf..ac2343f648ba3db19ffcb1fc1503e5d6
        {NSAccessibilitySizeAttribute, @"size"},
        {NSAccessibilitySortDirectionAttribute, @"sortDirection"},
        {NSAccessibilitySubroleAttribute, @"subrole"},
-@@ -1238,6 +1246,7 @@ - (NSNumber*)enabled {
+@@ -1238,6 +1246,7 @@ NSString* const NSAccessibilityRequiredAttributeChrome = @"AXRequired";
                                    ax::mojom::Restriction::kDisabled];
  }
  
@@ -93,7 +93,7 @@ index 0a6c3c488c71106f23779481ccec92c0aa8b6bbf..ac2343f648ba3db19ffcb1fc1503e5d6
  // Returns a text marker that points to the last character in the document that
  // can be selected with VoiceOver.
  - (id)endTextMarker {
-@@ -1248,6 +1257,7 @@ - (id)endTextMarker {
+@@ -1248,6 +1257,7 @@ NSString* const NSAccessibilityRequiredAttributeChrome = @"AXRequired";
    BrowserAccessibilityPositionInstance position = root->CreatePositionAt(0);
    return CreateTextMarker(position->CreatePositionAtEndOfAnchor());
  }
@@ -101,7 +101,7 @@ index 0a6c3c488c71106f23779481ccec92c0aa8b6bbf..ac2343f648ba3db19ffcb1fc1503e5d6
  
  - (NSNumber*)expanded {
    if (![self instanceActive])
-@@ -2119,6 +2129,7 @@ - (NSValue*)selectedTextRange {
+@@ -2119,6 +2129,7 @@ NSString* const NSAccessibilityRequiredAttributeChrome = @"AXRequired";
    return [NSValue valueWithRange:NSMakeRange(selStart, selLength)];
  }
  
@@ -109,7 +109,7 @@ index 0a6c3c488c71106f23779481ccec92c0aa8b6bbf..ac2343f648ba3db19ffcb1fc1503e5d6
  - (id)selectedTextMarkerRange {
    if (![self instanceActive])
      return nil;
-@@ -2154,6 +2165,7 @@ - (id)selectedTextMarkerRange {
+@@ -2154,6 +2165,7 @@ NSString* const NSAccessibilityRequiredAttributeChrome = @"AXRequired";
        CreateAXPlatformRange(*anchorObject, anchorOffset, anchorAffinity,
                              *focusObject, focusOffset, focusAffinity));
  }
@@ -117,7 +117,7 @@ index 0a6c3c488c71106f23779481ccec92c0aa8b6bbf..ac2343f648ba3db19ffcb1fc1503e5d6
  
  - (NSValue*)size {
    if (![self instanceActive])
-@@ -2186,6 +2198,7 @@ - (NSString*)sortDirection {
+@@ -2186,6 +2198,7 @@ NSString* const NSAccessibilityRequiredAttributeChrome = @"AXRequired";
    return nil;
  }
  
@@ -125,7 +125,7 @@ index 0a6c3c488c71106f23779481ccec92c0aa8b6bbf..ac2343f648ba3db19ffcb1fc1503e5d6
  // Returns a text marker that points to the first character in the document that
  // can be selected with VoiceOver.
  - (id)startTextMarker {
-@@ -2196,6 +2209,7 @@ - (id)startTextMarker {
+@@ -2196,6 +2209,7 @@ NSString* const NSAccessibilityRequiredAttributeChrome = @"AXRequired";
    BrowserAccessibilityPositionInstance position = root->CreatePositionAt(0);
    return CreateTextMarker(position->CreatePositionAtStartOfAnchor());
  }
@@ -133,7 +133,7 @@ index 0a6c3c488c71106f23779481ccec92c0aa8b6bbf..ac2343f648ba3db19ffcb1fc1503e5d6
  
  // Returns a subrole based upon the role.
  - (NSString*)subrole {
-@@ -2487,11 +2501,13 @@ - (NSAttributedString*)attributedValueForRange:(NSRange)range {
+@@ -2487,11 +2501,13 @@ NSString* const NSAccessibilityRequiredAttributeChrome = @"AXRequired";
    NSMutableAttributedString* attributedValue =
        [[[NSMutableAttributedString alloc] initWithString:value] autorelease];
  
@@ -147,7 +147,7 @@ index 0a6c3c488c71106f23779481ccec92c0aa8b6bbf..ac2343f648ba3db19ffcb1fc1503e5d6
  
    return [attributedValue attributedSubstringFromRange:range];
  }
-@@ -2574,9 +2590,8 @@ - (id)accessibilityAttributeValue:(NSString*)attribute
+@@ -2574,9 +2590,8 @@ NSString* const NSAccessibilityRequiredAttributeChrome = @"AXRequired";
        return ToBrowserAccessibilityCocoa(cell);
    }
  
@@ -159,7 +159,7 @@ index 0a6c3c488c71106f23779481ccec92c0aa8b6bbf..ac2343f648ba3db19ffcb1fc1503e5d6
      BrowserAccessibilityPositionInstance position =
          CreatePositionFromTextMarker(parameter);
      if (!position->IsNullPosition())
-@@ -2866,6 +2881,7 @@ - (id)accessibilityAttributeValue:(NSString*)attribute
+@@ -2866,6 +2881,7 @@ NSString* const NSAccessibilityRequiredAttributeChrome = @"AXRequired";
  
      return CreateTextMarker(root->CreatePositionAt(index));
    }
@@ -167,7 +167,7 @@ index 0a6c3c488c71106f23779481ccec92c0aa8b6bbf..ac2343f648ba3db19ffcb1fc1503e5d6
  
    if ([attribute isEqualToString:
                       NSAccessibilityBoundsForRangeParameterizedAttribute]) {
-@@ -2899,6 +2915,7 @@ - (id)accessibilityAttributeValue:(NSString*)attribute
+@@ -2899,6 +2915,7 @@ NSString* const NSAccessibilityRequiredAttributeChrome = @"AXRequired";
      return nil;
    }
  
@@ -175,7 +175,7 @@ index 0a6c3c488c71106f23779481ccec92c0aa8b6bbf..ac2343f648ba3db19ffcb1fc1503e5d6
    if ([attribute
            isEqualToString:
                NSAccessibilityLineTextMarkerRangeForTextMarkerParameterizedAttribute]) {
-@@ -2979,6 +2996,7 @@ AXPlatformRange range(position->CreatePreviousLineStartPosition(
+@@ -2979,6 +2996,7 @@ NSString* const NSAccessibilityRequiredAttributeChrome = @"AXRequired";
  
      return @(child->GetIndexInParent());
    }
@@ -187,7 +187,7 @@ diff --git a/content/browser/accessibility/browser_accessibility_manager_mac.mm 
 index 851da832bd30e05974317601712f309b2d542ab6..dd6d4c50468ec5f3364213e43b9336f13b153a19 100644
 --- a/content/browser/accessibility/browser_accessibility_manager_mac.mm
 +++ b/content/browser/accessibility/browser_accessibility_manager_mac.mm
-@@ -493,6 +493,7 @@ void PostAnnouncementNotification(NSString* announcement) {
+@@ -493,6 +493,7 @@ NSDictionary* BrowserAccessibilityManagerMac::
        [user_info setObject:native_focus_object
                      forKey:NSAccessibilityTextChangeElement];
  
@@ -195,7 +195,7 @@ index 851da832bd30e05974317601712f309b2d542ab6..dd6d4c50468ec5f3364213e43b9336f1
        id selected_text = [native_focus_object selectedTextMarkerRange];
        if (selected_text) {
          NSString* const NSAccessibilitySelectedTextMarkerRangeAttribute =
-@@ -500,6 +501,7 @@ void PostAnnouncementNotification(NSString* announcement) {
+@@ -500,6 +501,7 @@ NSDictionary* BrowserAccessibilityManagerMac::
          [user_info setObject:selected_text
                        forKey:NSAccessibilitySelectedTextMarkerRangeAttribute];
        }
@@ -219,7 +219,7 @@ index e59ac93d0e1554a2df5d8c74db2beba25d090228..6657c48664bdec4964b382f80309d1bf
  
  namespace content {
  
-@@ -22,6 +24,7 @@
+@@ -22,6 +24,7 @@ namespace {
  // verifies there are no existing open connections), and then indicates that
  // Chrome should continue execution without access to launchservicesd.
  void DisableSystemServices() {
@@ -247,7 +247,7 @@ index 8e4a469b6f0675dc7b82543d5758f0c2ec226809..2fcfb6edb5f57bd25756257b77361d25
  extern "C" {
  // Undocumented IOBluetooth Preference API [1]. Used by `blueutil` [2] and
  // `Karabiner` [3] to programmatically control the Bluetooth state. Calling the
-@@ -49,6 +50,7 @@
+@@ -49,6 +50,7 @@ extern "C" {
  // [4] https://support.apple.com/kb/PH25091
  void IOBluetoothPreferenceSetControllerPowerState(int state);
  }
@@ -255,7 +255,7 @@ index 8e4a469b6f0675dc7b82543d5758f0c2ec226809..2fcfb6edb5f57bd25756257b77361d25
  
  namespace {
  
-@@ -121,8 +123,10 @@ CBCentralManagerState GetCBManagerState(CBCentralManager* manager) {
+@@ -121,8 +123,10 @@ BluetoothAdapterMac::BluetoothAdapterMac()
        controller_state_function_(
            base::BindRepeating(&BluetoothAdapterMac::GetHostControllerState,
                                base::Unretained(this))),
@@ -266,7 +266,7 @@ index 8e4a469b6f0675dc7b82543d5758f0c2ec226809..2fcfb6edb5f57bd25756257b77361d25
        should_update_name_(true),
        classic_discovery_manager_(
            BluetoothDiscoveryManagerMac::CreateClassic(this)),
-@@ -303,8 +307,12 @@ CBCentralManagerState GetCBManagerState(CBCentralManager* manager) {
+@@ -303,8 +307,12 @@ void BluetoothAdapterMac::DeviceConnected(IOBluetoothDevice* device) {
  }
  
  bool BluetoothAdapterMac::SetPoweredImpl(bool powered) {

--- a/patches/chromium/port_aria_tree_fix_for_macos_voiceover.patch
+++ b/patches/chromium/port_aria_tree_fix_for_macos_voiceover.patch
@@ -25,7 +25,7 @@ diff --git a/content/browser/accessibility/browser_accessibility_cocoa.mm b/cont
 index ac2343f648ba3db19ffcb1fc1503e5d68cdb5135..eda671d3a04263fe4c5895c1bcb1359edc11f65b 100644
 --- a/content/browser/accessibility/browser_accessibility_cocoa.mm
 +++ b/content/browser/accessibility/browser_accessibility_cocoa.mm
-@@ -2012,7 +2012,9 @@ - (NSArray*)rows {
+@@ -2012,7 +2012,9 @@ NSString* const NSAccessibilityRequiredAttributeChrome = @"AXRequired";
      return nil;
    NSMutableArray* ret = [[[NSMutableArray alloc] init] autorelease];
  
@@ -36,7 +36,7 @@ index ac2343f648ba3db19ffcb1fc1503e5d68cdb5135..eda671d3a04263fe4c5895c1bcb1359e
      for (BrowserAccessibilityCocoa* child in [self children]) {
        if ([[child role] isEqualToString:NSAccessibilityRowRole])
          [ret addObject:child];
-@@ -2465,6 +2467,19 @@ - (id)window {
+@@ -2465,6 +2467,19 @@ NSString* const NSAccessibilityRequiredAttributeChrome = @"AXRequired";
    return manager->GetWindow();
  }
  

--- a/patches/chromium/protect_automatic_pull_handlers_with_mutex.patch
+++ b/patches/chromium/protect_automatic_pull_handlers_with_mutex.patch
@@ -1,7 +1,7 @@
-From b5950ad76471d6aa446af46aee645fb5e32c435d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Hongchan Choi <hongchan@chromium.org>
 Date: Fri, 13 Mar 2020 02:52:15 +0000
-Subject: [PATCH] Protect automatic pull handlers with Mutex
+Subject: Protect automatic pull handlers with Mutex
 
 In some cases, |rendering_automatic_pull_handlers_| in
 DeferredTaskHandler can be touched from both the main thread and the
@@ -17,13 +17,9 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2101712
 Commit-Queue: Hongchan Choi <hongchan@chromium.org>
 Reviewed-by: Raymond Toy <rtoy@chromium.org>
 Cr-Commit-Position: refs/heads/master@{#750000}
----
- .../modules/webaudio/deferred_task_handler.cc | 26 ++++++++++++++-----
- .../modules/webaudio/deferred_task_handler.h  |  5 ++++
- 2 files changed, 25 insertions(+), 6 deletions(-)
 
 diff --git a/third_party/blink/renderer/modules/webaudio/deferred_task_handler.cc b/third_party/blink/renderer/modules/webaudio/deferred_task_handler.cc
-index d02a7f69fe191..00bfc7b8d624b 100644
+index 9fd38f0dde71b5c773a861992f0e989ba6a9d5e0..6ecedccc14ed15b81e916f0e1ff8f635489dcecc 100644
 --- a/third_party/blink/renderer/modules/webaudio/deferred_task_handler.cc
 +++ b/third_party/blink/renderer/modules/webaudio/deferred_task_handler.cc
 @@ -132,6 +132,7 @@ void DeferredTaskHandler::HandleDirtyAudioNodeOutputs() {
@@ -85,14 +81,14 @@ index d02a7f69fe191..00bfc7b8d624b 100644
    deletable_orphan_handlers_.clear();
    automatic_pull_handlers_.clear();
 -  rendering_automatic_pull_handlers_.clear();
-   finished_source_handlers_.clear();
    active_source_handlers_.clear();
  }
+ 
 diff --git a/third_party/blink/renderer/modules/webaudio/deferred_task_handler.h b/third_party/blink/renderer/modules/webaudio/deferred_task_handler.h
-index 3cf47ca77a8b1..49cbf6977ddfc 100644
+index 0ede5f5b5dabeeef9decc94c94d91ddc7351c722..af384d0941da47bbe544be3c0ce5739ca4c384e1 100644
 --- a/third_party/blink/renderer/modules/webaudio/deferred_task_handler.h
 +++ b/third_party/blink/renderer/modules/webaudio/deferred_task_handler.h
-@@ -265,6 +265,11 @@ class MODULES_EXPORT DeferredTaskHandler final
+@@ -263,6 +263,11 @@ class MODULES_EXPORT DeferredTaskHandler final
  
    // Graph locking.
    RecursiveMutex context_graph_mutex_;

--- a/patches/chromium/render_widget_host_view_mac.patch
+++ b/patches/chromium/render_widget_host_view_mac.patch
@@ -20,7 +20,7 @@ index e692286b9c15cbbde03f7dff3f98f54c3f0e9365..9113fb00d144d6cee789f608f8b3761b
  // These are not documented, so use only after checking -respondsToSelector:.
  @interface NSApplication (UndocumentedSpeechMethods)
  - (void)speakString:(NSString*)string;
-@@ -571,6 +576,9 @@ - (BOOL)acceptsMouseEventsWhenInactive {
+@@ -571,6 +576,9 @@ void ExtractUnderlines(NSAttributedString* string,
  }
  
  - (BOOL)acceptsFirstMouse:(NSEvent*)theEvent {
@@ -30,7 +30,7 @@ index e692286b9c15cbbde03f7dff3f98f54c3f0e9365..9113fb00d144d6cee789f608f8b3761b
    return [self acceptsMouseEventsWhenInactive];
  }
  
-@@ -990,6 +998,10 @@ - (void)keyEvent:(NSEvent*)theEvent wasKeyEquivalent:(BOOL)equiv {
+@@ -990,6 +998,10 @@ void ExtractUnderlines(NSAttributedString* string,
                                eventType == NSKeyDown &&
                                !(modifierFlags & NSCommandKeyMask);
  
@@ -41,7 +41,7 @@ index e692286b9c15cbbde03f7dff3f98f54c3f0e9365..9113fb00d144d6cee789f608f8b3761b
    // We only handle key down events and just simply forward other events.
    if (eventType != NSKeyDown) {
      hostHelper_->ForwardKeyboardEvent(event, latency_info);
-@@ -1769,9 +1781,11 @@ - (NSAccessibilityRole)accessibilityRole {
+@@ -1769,9 +1781,11 @@ void ExtractUnderlines(NSAttributedString* string,
  // Since this implementation doesn't have to wait any IPC calls, this doesn't
  // make any key-typing jank. --hbono 7/23/09
  //
@@ -53,7 +53,7 @@ index e692286b9c15cbbde03f7dff3f98f54c3f0e9365..9113fb00d144d6cee789f608f8b3761b
  
  - (NSArray*)validAttributesForMarkedText {
    // This code is just copied from WebKit except renaming variables.
-@@ -1780,7 +1794,10 @@ - (NSArray*)validAttributesForMarkedText {
+@@ -1780,7 +1794,10 @@ extern NSString* NSTextInputReplacementRangeAttributeName;
          initWithObjects:NSUnderlineStyleAttributeName,
                          NSUnderlineColorAttributeName,
                          NSMarkedClauseSegmentAttributeName,

--- a/patches/chromium/webview_cross_drag.patch
+++ b/patches/chromium/webview_cross_drag.patch
@@ -20,7 +20,7 @@ diff --git a/content/browser/web_contents/web_drag_dest_mac.mm b/content/browser
 index c4638ac6e86d6a816848cdbbdfa3e70d45086d90..18bd2fb8171568745549d490ee93887418890157 100644
 --- a/content/browser/web_contents/web_drag_dest_mac.mm
 +++ b/content/browser/web_contents/web_drag_dest_mac.mm
-@@ -336,6 +336,7 @@ - (void)setDragStartTrackersForProcess:(int)processID {
+@@ -336,6 +336,7 @@ content::GlobalRoutingID GetRenderViewHostID(content::RenderViewHost* rvh) {
  }
  
  - (bool)isValidDragTarget:(content::RenderWidgetHostImpl*)targetRWH {


### PR DESCRIPTION
Protect automatic pull handlers with Mutex

In some cases, |rendering_automatic_pull_handlers_| in
DeferredTaskHandler can be touched from both the main thread and the
audio rendering thread. This CL adds a lock when it is updated,
processed, and cleared.

crash on the repro case after 30 min.

Test: Locally confirmed that the ASAN build with this patch does not
Bug: 1061018
Change-Id: I5f4440edcdc26e4a3afbfe8fad88492bdb49c323
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2101712
Commit-Queue: Hongchan Choi <hongchan@chromium.org>
Reviewed-by: Raymond Toy <rtoy@chromium.org>
Cr-Commit-Position: refs/heads/master@{#750000}

Notes: Security: backport fix for CVE-2020-6451: Use after free in WebAudio