### PR TITLE
fix: nullptr check when closing windows

### DIFF
--- a/shell/browser/window_list.cc
+++ b/shell/browser/window_list.cc
@@ -84,16 +84,19 @@ void WindowList::CloseAllWindows() {
 #if defined(OS_MACOSX)
   std::reverse(windows.begin(), windows.end());
 #endif
-  for (auto* const& window : windows)
-    if (!window->IsClosed())
+  for (auto* const& window : windows) {
+    if (window && !window->IsClosed())
       window->Close();
+  }
 }
 
 // static
 void WindowList::DestroyAllWindows() {
   WindowVector windows = GetInstance()->windows_;
-  for (auto* const& window : windows)
-    window->CloseImmediately();  // e.g. Destroy()
+  for (auto* const& window : windows) {
+    if (window)
+      window->CloseImmediately();
+  }
 }
 
 WindowList::WindowList() = default;

--- a/shell/browser/window_list.cc
+++ b/shell/browser/window_list.cc
@@ -10,6 +10,18 @@
 #include "shell/browser/native_window.h"
 #include "shell/browser/window_list_observer.h"
 
+namespace {
+template <typename T>
+std::vector<base::WeakPtr<T>> ConvertToWeakPtrVector(std::vector<T*> raw_ptrs) {
+  std::vector<base::WeakPtr<T>> converted_to_weak;
+  for (auto* raw_ptr : raw_ptrs) {
+    base::WeakPtr<T> weak = raw_ptr->GetWeakPtr();
+    converted_to_weak.push_back(weak);
+  }
+  return converted_to_weak;
+}
+}  // namespace
+
 namespace electron {
 
 // static
@@ -93,7 +105,10 @@ void WindowList::CloseAllWindows() {
 // static
 void WindowList::DestroyAllWindows() {
   WindowVector windows = GetInstance()->windows_;
-  for (auto* const& window : windows) {
+  std::vector<base::WeakPtr<NativeWindow>> weak_windows =
+      ConvertToWeakPtrVector(windows);
+
+  for (const auto& window : weak_windows) {
     if (window)
       window->CloseImmediately();
   }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/14161.

We weren't performing a nullptr check, so we would experience an `EXC_BAD_ACCESS` crash
if an object in the WindowVector is destroyed during cleanup. This fixes that by adding said nullptr check.

cc @zcbenz @deepak1556 @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an occasional crash when closing all BrowserWindows.
