### PR TITLE
build: strip local/dbg symbols, from Linux binaries

### DIFF
--- a/script/strip-binaries.py
+++ b/script/strip-binaries.py
@@ -22,7 +22,7 @@ def strip_binary(binary_path, target_cpu):
     strip = 'mips64el-redhat-linux-strip'
   else:
     strip = 'strip'
-  execute([strip, '--preserve-dates', binary_path])
+  execute([strip, '--discard-all', '--strip-debug', '--preserve-dates', binary_path])
 
 def main():
   args = parse_args()


### PR DESCRIPTION
#### Description of Change

Non full stripping seems to be the cause of limited
non-determinism. Employ similar default as macOS when
stripping away symbols.

--discard-all       Remove all local symbols (saving only global symbols).
--strip-debug     Remove the debugging symbol table entries (those created by the -g option to cc(1) and other compilers).

Cc: @nornagon @ikkisoft @jkleinsc 
 
#### Checklist

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: no-notes
