### PR TITLE
fix: webframe crashes for removed render frame

### DIFF
--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -16,6 +16,7 @@
 #include "native_mate/dictionary.h"
 #include "services/service_manager/public/cpp/interface_provider.h"
 #include "shell/common/api/api.mojom.h"
+#include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/native_mate_converters/blink_converter.h"
 #include "shell/common/native_mate_converters/string16_converter.h"
 #include "shell/common/node_includes.h"
@@ -232,17 +233,34 @@ void SetName(v8::Local<v8::Value> window, const std::string& name) {
       blink::WebString::FromUTF8(name));
 }
 
-void SetZoomLevel(v8::Local<v8::Value> window, double level) {
+void SetZoomLevel(gin_helper::ErrorThrower thrower,
+                  v8::Local<v8::Value> window,
+                  double level) {
   content::RenderFrame* render_frame = GetRenderFrame(window);
+  if (!render_frame) {
+    thrower.ThrowError(
+        "Render frame was torn down before webFrame.setZoomLevel could be "
+        "executed");
+    return;
+  }
+
   mojom::ElectronBrowserPtr browser_ptr;
   render_frame->GetRemoteInterfaces()->GetInterface(
       mojo::MakeRequest(&browser_ptr));
   browser_ptr->SetTemporaryZoomLevel(level);
 }
 
-double GetZoomLevel(v8::Local<v8::Value> window) {
+double GetZoomLevel(gin_helper::ErrorThrower thrower,
+                    v8::Local<v8::Value> window) {
   double result = 0.0;
   content::RenderFrame* render_frame = GetRenderFrame(window);
+  if (!render_frame) {
+    thrower.ThrowError(
+        "Render frame was torn down before webFrame.getZoomLevel could be "
+        "executed");
+    return result;
+  }
+
   mojom::ElectronBrowserPtr browser_ptr;
   render_frame->GetRemoteInterfaces()->GetInterface(
       mojo::MakeRequest(&browser_ptr));
@@ -258,31 +276,51 @@ void SetZoomFactor(gin_helper::ErrorThrower thrower,
     return;
   }
 
-  SetZoomLevel(window, blink::PageZoomFactorToZoomLevel(factor));
+  SetZoomLevel(thrower, window, blink::PageZoomFactorToZoomLevel(factor));
 }
 
-double GetZoomFactor(v8::Local<v8::Value> window) {
-  return blink::PageZoomLevelToZoomFactor(GetZoomLevel(window));
+double GetZoomFactor(gin_helper::ErrorThrower thrower,
+                     v8::Local<v8::Value> window) {
+  double zoom_level = GetZoomLevel(thrower, window);
+  return blink::PageZoomLevelToZoomFactor(zoom_level);
 }
 
-void SetVisualZoomLevelLimits(v8::Local<v8::Value> window,
+void SetVisualZoomLevelLimits(gin_helper::ErrorThrower thrower,
+                              v8::Local<v8::Value> window,
                               double min_level,
                               double max_level) {
-  blink::WebFrame* web_frame = GetRenderFrame(window)->GetWebFrame();
+  auto* render_frame = GetRenderFrame(window);
+  if (!render_frame) {
+    thrower.ThrowError(
+        "Render frame was torn down before webFrame.setVisualZoomLevelLimits "
+        "could be executed");
+    return;
+  }
+
+  blink::WebFrame* web_frame = render_frame->GetWebFrame();
   web_frame->View()->SetDefaultPageScaleLimits(min_level, max_level);
   web_frame->View()->SetIgnoreViewportTagScaleLimits(true);
 }
 
-void AllowGuestViewElementDefinition(v8::Isolate* isolate,
+void AllowGuestViewElementDefinition(gin_helper::ErrorThrower thrower,
                                      v8::Local<v8::Value> window,
                                      v8::Local<v8::Object> context,
                                      v8::Local<v8::Function> register_cb) {
-  v8::HandleScope handle_scope(isolate);
+  v8::HandleScope handle_scope(thrower.isolate());
   v8::Context::Scope context_scope(context->CreationContext());
   blink::WebCustomElement::EmbedderNamesAllowedScope embedder_names_scope;
-  GetRenderFrame(context)->GetWebFrame()->RequestExecuteV8Function(
-      context->CreationContext(), register_cb, v8::Null(isolate), 0, nullptr,
-      nullptr);
+
+  auto* render_frame = GetRenderFrame(window);
+  if (!render_frame) {
+    thrower.ThrowError(
+        "Render frame was torn down before "
+        "webFrame.allowGuestViewElementDefinition could be executed");
+    return;
+  }
+
+  render_frame->GetWebFrame()->RequestExecuteV8Function(
+      context->CreationContext(), register_cb, v8::Null(thrower.isolate()), 0,
+      nullptr, nullptr);
 }
 
 int GetWebFrameId(v8::Local<v8::Value> window,
@@ -318,6 +356,13 @@ void SetSpellCheckProvider(mate::Arguments* args,
 
   // Remove the old client.
   content::RenderFrame* render_frame = GetRenderFrame(window);
+  if (!render_frame) {
+    args->ThrowError(
+        "Render frame was torn down before webFrame.setSpellCheckProvider "
+        "could be executed");
+    return;
+  }
+
   auto* existing = SpellCheckerHolder::FromRenderFrame(render_frame);
   if (existing)
     existing->UnsetAndDestroy();
@@ -332,8 +377,18 @@ void SetSpellCheckProvider(mate::Arguments* args,
   new SpellCheckerHolder(render_frame, std::move(spell_check_client));
 }
 
-void InsertText(v8::Local<v8::Value> window, const std::string& text) {
-  blink::WebFrame* web_frame = GetRenderFrame(window)->GetWebFrame();
+void InsertText(gin_helper::ErrorThrower thrower,
+                v8::Local<v8::Value> window,
+                const std::string& text) {
+  auto* render_frame = GetRenderFrame(window);
+  if (!render_frame) {
+    thrower.ThrowError(
+        "Render frame was torn down before webFrame.insertText could be "
+        "executed");
+    return;
+  }
+
+  blink::WebFrame* web_frame = render_frame->GetWebFrame();
   if (web_frame->IsWebLocalFrame()) {
     web_frame->ToWebLocalFrame()
         ->FrameWidget()
@@ -354,7 +409,15 @@ base::string16 InsertCSS(v8::Local<v8::Value> window,
   if (args->GetNext(&options))
     options.Get("cssOrigin", &css_origin);
 
-  blink::WebFrame* web_frame = GetRenderFrame(window)->GetWebFrame();
+  auto* render_frame = GetRenderFrame(window);
+  if (!render_frame) {
+    args->ThrowError(
+        "Render frame was torn down before webFrame.insertCSS could be "
+        "executed");
+    return base::string16();
+  }
+
+  blink::WebFrame* web_frame = render_frame->GetWebFrame();
   if (web_frame->IsWebLocalFrame()) {
     return web_frame->ToWebLocalFrame()
         ->GetDocument()
@@ -364,8 +427,18 @@ base::string16 InsertCSS(v8::Local<v8::Value> window,
   return base::string16();
 }
 
-void RemoveInsertedCSS(v8::Local<v8::Value> window, const base::string16& key) {
-  blink::WebFrame* web_frame = GetRenderFrame(window)->GetWebFrame();
+void RemoveInsertedCSS(gin_helper::ErrorThrower thrower,
+                       v8::Local<v8::Value> window,
+                       const base::string16& key) {
+  auto* render_frame = GetRenderFrame(window);
+  if (!render_frame) {
+    thrower.ThrowError(
+        "Render frame was torn down before webFrame.removeInsertedCSS could be "
+        "executed");
+    return;
+  }
+
+  blink::WebFrame* web_frame = render_frame->GetWebFrame();
   if (web_frame->IsWebLocalFrame()) {
     web_frame->ToWebLocalFrame()->GetDocument().RemoveInsertedStyleSheet(
         blink::WebString::FromUTF16(key));
@@ -379,10 +452,18 @@ v8::Local<v8::Promise> ExecuteJavaScript(mate::Arguments* args,
   util::Promise<v8::Local<v8::Value>> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
+  auto* render_frame = GetRenderFrame(window);
+  if (!render_frame) {
+    promise.RejectWithErrorMessage(
+        "Render frame was torn down before webFrame.executeJavaScript could be "
+        "executed");
+    return handle;
+  }
+
   bool has_user_gesture = false;
   args->GetNext(&has_user_gesture);
 
-  GetRenderFrame(window)->GetWebFrame()->RequestExecuteScriptAndReturnValue(
+  render_frame->GetWebFrame()->RequestExecuteScriptAndReturnValue(
       blink::WebScriptSource(blink::WebString::FromUTF16(code)),
       has_user_gesture, new ScriptExecutionCallback(std::move(promise)));
 
@@ -397,6 +478,14 @@ v8::Local<v8::Promise> ExecuteJavaScriptInIsolatedWorld(
   v8::Isolate* isolate = args->isolate();
   util::Promise<v8::Local<v8::Value>> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
+
+  auto* render_frame = GetRenderFrame(window);
+  if (!render_frame) {
+    promise.RejectWithErrorMessage(
+        "Render frame was torn down before webFrame.executeJavaScript could be "
+        "executed");
+    return handle;
+  }
 
   std::vector<blink::WebScriptSource> sources;
 
@@ -427,7 +516,7 @@ v8::Local<v8::Promise> ExecuteJavaScriptInIsolatedWorld(
   // Debugging tip: if you see a crash stack trace beginning from this call,
   // then it is very likely that some exception happened when executing the
   // "content_script/init.js" script.
-  GetRenderFrame(window)->GetWebFrame()->RequestExecuteScriptInIsolatedWorld(
+  render_frame->GetWebFrame()->RequestExecuteScriptInIsolatedWorld(
       world_id, &sources.front(), sources.size(), has_user_gesture,
       scriptExecutionType, new ScriptExecutionCallback(std::move(promise)));
 
@@ -438,6 +527,14 @@ void SetIsolatedWorldInfo(v8::Local<v8::Value> window,
                           int world_id,
                           const mate::Dictionary& options,
                           mate::Arguments* args) {
+  auto* render_frame = GetRenderFrame(window);
+  if (!render_frame) {
+    args->ThrowError(
+        "Render frame was torn down before webFrame.setIsolatedWorldInfo could "
+        "be executed");
+    return;
+  }
+
   std::string origin_url, security_policy, name;
   options.Get("securityOrigin", &origin_url);
   options.Get("csp", &security_policy);
@@ -454,7 +551,7 @@ void SetIsolatedWorldInfo(v8::Local<v8::Value> window,
       blink::WebString::FromUTF8(origin_url));
   info.content_security_policy = blink::WebString::FromUTF8(security_policy);
   info.human_readable_name = blink::WebString::FromUTF8(name);
-  GetRenderFrame(window)->GetWebFrame()->SetIsolatedWorldInfo(world_id, info);
+  render_frame->GetWebFrame()->SetIsolatedWorldInfo(world_id, info);
 }
 
 blink::WebCacheResourceTypeStats GetResourceUsage(v8::Isolate* isolate) {
@@ -483,7 +580,11 @@ v8::Local<v8::Value> FindFrameByRoutingId(v8::Isolate* isolate,
 
 v8::Local<v8::Value> GetOpener(v8::Isolate* isolate,
                                v8::Local<v8::Value> window) {
-  blink::WebFrame* frame = GetRenderFrame(window)->GetWebFrame()->Opener();
+  auto* render_frame = GetRenderFrame(window);
+  if (!render_frame)
+    return v8::Null(isolate);
+
+  blink::WebFrame* frame = render_frame->GetWebFrame()->Opener();
   if (frame && frame->IsWebLocalFrame())
     return frame->ToWebLocalFrame()->MainWorldScriptContext()->Global();
   else
@@ -501,7 +602,11 @@ v8::Local<v8::Value> GetFrameParent(v8::Isolate* isolate,
 }
 
 v8::Local<v8::Value> GetTop(v8::Isolate* isolate, v8::Local<v8::Value> window) {
-  blink::WebFrame* frame = GetRenderFrame(window)->GetWebFrame()->Top();
+  auto* render_frame = GetRenderFrame(window);
+  if (!render_frame)
+    return v8::Null(isolate);
+
+  blink::WebFrame* frame = render_frame->GetWebFrame()->Top();
   if (frame && frame->IsWebLocalFrame())
     return frame->ToWebLocalFrame()->MainWorldScriptContext()->Global();
   else
@@ -510,7 +615,11 @@ v8::Local<v8::Value> GetTop(v8::Isolate* isolate, v8::Local<v8::Value> window) {
 
 v8::Local<v8::Value> GetFirstChild(v8::Isolate* isolate,
                                    v8::Local<v8::Value> window) {
-  blink::WebFrame* frame = GetRenderFrame(window)->GetWebFrame()->FirstChild();
+  auto* render_frame = GetRenderFrame(window);
+  if (!render_frame)
+    return v8::Null(isolate);
+
+  blink::WebFrame* frame = render_frame->GetWebFrame()->FirstChild();
   if (frame && frame->IsWebLocalFrame())
     return frame->ToWebLocalFrame()->MainWorldScriptContext()->Global();
   else
@@ -519,7 +628,11 @@ v8::Local<v8::Value> GetFirstChild(v8::Isolate* isolate,
 
 v8::Local<v8::Value> GetNextSibling(v8::Isolate* isolate,
                                     v8::Local<v8::Value> window) {
-  blink::WebFrame* frame = GetRenderFrame(window)->GetWebFrame()->NextSibling();
+  auto* render_frame = GetRenderFrame(window);
+  if (!render_frame)
+    return v8::Null(isolate);
+
+  blink::WebFrame* frame = render_frame->GetWebFrame()->NextSibling();
   if (frame && frame->IsWebLocalFrame())
     return frame->ToWebLocalFrame()->MainWorldScriptContext()->Global();
   else
@@ -545,17 +658,29 @@ v8::Local<v8::Value> GetFrameForSelector(v8::Isolate* isolate,
 v8::Local<v8::Value> FindFrameByName(v8::Isolate* isolate,
                                      v8::Local<v8::Value> window,
                                      const std::string& name) {
-  blink::WebFrame* frame =
-      GetRenderFrame(window)->GetWebFrame()->FindFrameByName(
-          blink::WebString::FromUTF8(name));
+  auto* render_frame = GetRenderFrame(window);
+  if (!render_frame)
+    return v8::Null(isolate);
+
+  blink::WebFrame* frame = render_frame->GetWebFrame()->FindFrameByName(
+      blink::WebString::FromUTF8(name));
   if (frame && frame->IsWebLocalFrame())
     return frame->ToWebLocalFrame()->MainWorldScriptContext()->Global();
   else
     return v8::Null(isolate);
 }
 
-int GetRoutingId(v8::Local<v8::Value> window) {
-  return GetRenderFrame(window)->GetRoutingID();
+int GetRoutingId(gin_helper::ErrorThrower thrower,
+                 v8::Local<v8::Value> window) {
+  auto* render_frame = GetRenderFrame(window);
+  if (!render_frame) {
+    thrower.ThrowError(
+        "Render frame was torn down before webFrame.getRoutingId could be "
+        "executed");
+    return 0;
+  }
+
+  return render_frame->GetRoutingID();
 }
 
 }  // namespace api


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/22925.

See that PR for more details.

Notes: Fixed occasional WebFrame crashes caused by removed iframes.