### PR TITLE
fix: persist maximizable state when toggling fullscreen

### DIFF
--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -207,11 +207,17 @@ bool ScopedDisableResize::disable_resize_ = false;
 
   // If we're in simple fullscreen mode and trying to exit it
   // we need to ensure we exit it properly to prevent a crash
-  // with NSWindowStyleMaskTitled mode
-  if (is_simple_fs || always_simple_fs)
+  // with NSWindowStyleMaskTitled mode.
+  if (is_simple_fs || always_simple_fs) {
     shell_->SetSimpleFullScreen(!is_simple_fs);
-  else
+  } else {
+    bool maximizable = shell_->IsMaximizable();
     [super toggleFullScreen:sender];
+
+    // Exiting fullscreen causes Cocoa to redraw the NSWindow, which resets
+    // the enabled state for NSWindowZoomButton. We need to persist it.
+    shell_->SetMaximizable(maximizable);
+  }
 }
 
 - (void)performMiniaturize:(id)sender {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/22963.

Exiting fullscreen on macOS via `Toggle Fullscreen` causes Cocoa to redraw the NSWindow, which resets the enabled state for NSWindowZoomButton. If `maximizable` was false, the zoom button would suddenly become enabled when a user hit `Toggle Fullscreen` fullscreen twice, leading to state drift. This fixes that.

Tested with https://gist.github.com/88dfab886b69cd83cafb28e85d1dcdd4.

cc @nornagon @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue with `maximizable` state persistence of BrowserWindows on macOS.
