### PR TITLE
chore: make WebContentsView take webPreferences as parameter

### DIFF
--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const electron = require('electron');
-const { WebContentsView, TopLevelWindow, deprecate } = electron;
+const { TopLevelWindow, deprecate } = electron;
 const { BrowserWindow } = process.electronBinding('window');
 
 Object.setPrototypeOf(BrowserWindow.prototype, TopLevelWindow.prototype);
@@ -12,9 +12,6 @@ BrowserWindow.prototype._init = function () {
 
   // Avoid recursive require.
   const { app } = electron;
-
-  // Create WebContentsView.
-  this.setContentView(new WebContentsView(this.webContents));
 
   const nativeSetBounds = this.setBounds;
   this.setBounds = (bounds, ...opts) => {

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -32,8 +32,6 @@ namespace api {
 BrowserWindow::BrowserWindow(gin::Arguments* args,
                              const gin_helper::Dictionary& options)
     : TopLevelWindow(args->isolate(), options), weak_factory_(this) {
-  gin::Handle<class WebContents> web_contents;
-
   // Use options.webPreferences in WebContents.
   v8::Isolate* isolate = args->isolate();
   gin_helper::Dictionary web_preferences =
@@ -60,22 +58,9 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
     web_preferences.Set(options::kShow, show);
   }
 
-  if (options.Get("webContents", &web_contents) && !web_contents.IsEmpty()) {
-    // Set webPreferences from options if using an existing webContents.
-    // These preferences will be used when the webContent launches new
-    // render processes.
-    auto* existing_preferences =
-        WebContentsPreferences::From(web_contents->web_contents());
-    base::DictionaryValue web_preferences_dict;
-    if (gin::ConvertFromV8(isolate, web_preferences.GetHandle(),
-                           &web_preferences_dict)) {
-      existing_preferences->Clear();
-      existing_preferences->Merge(web_preferences_dict);
-    }
-  } else {
-    // Creates the WebContents used by BrowserWindow.
-    web_contents = WebContents::Create(isolate, web_preferences);
-  }
+  // Creates the WebContents used by BrowserWindow.
+  gin::Handle<class WebContents> web_contents =
+      WebContents::Create(isolate, web_preferences);
 
   web_contents_.Reset(isolate, web_contents.ToV8());
   api_web_contents_ = web_contents->GetWeakPtr();

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -59,16 +59,15 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
     web_preferences.Set(options::kShow, show);
   }
 
-  // Creates the WebContents used by BrowserWindow.
-  gin::Handle<class WebContents> web_contents =
-      WebContents::Create(isolate, web_preferences);
-  web_contents_.Reset(isolate, web_contents.ToV8());
-
   // Creates the WebContentsView.
   gin::Handle<WebContentsView> web_contents_view =
-      WebContentsView::Create(isolate, web_contents);
+      WebContentsView::Create(isolate, web_preferences.GetHandle());
   DCHECK(web_contents_view.get());
 
+  // Save a reference of the WebContents.
+  gin::Handle<WebContents> web_contents =
+      web_contents_view->GetWebContents(isolate);
+  web_contents_.Reset(isolate, web_contents.ToV8());
   api_web_contents_ = web_contents->GetWeakPtr();
   api_web_contents_->AddObserver(this);
   Observe(api_web_contents_->web_contents());

--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -5,7 +5,6 @@
 #include "shell/browser/api/electron_api_web_contents_view.h"
 
 #include "base/no_destructor.h"
-#include "content/public/browser/web_contents_user_data.h"
 #include "shell/browser/api/electron_api_web_contents.h"
 #include "shell/browser/browser.h"
 #include "shell/browser/ui/inspectable_web_contents_view.h"
@@ -17,29 +16,6 @@
 #if defined(OS_MACOSX)
 #include "shell/browser/ui/cocoa/delayed_native_view_host.h"
 #endif
-
-namespace {
-
-// Used to indicate whether a WebContents already has a view.
-class WebContentsViewRelay
-    : public content::WebContentsUserData<WebContentsViewRelay> {
- public:
-  ~WebContentsViewRelay() override = default;
-
- private:
-  explicit WebContentsViewRelay(content::WebContents* contents) {}
-  friend class content::WebContentsUserData<WebContentsViewRelay>;
-
-  electron::api::WebContentsView* view_ = nullptr;
-
-  WEB_CONTENTS_USER_DATA_KEY_DECL();
-
-  DISALLOW_COPY_AND_ASSIGN(WebContentsViewRelay);
-};
-
-WEB_CONTENTS_USER_DATA_KEY_IMPL(WebContentsViewRelay)
-
-}  // namespace
 
 namespace electron {
 
@@ -80,7 +56,6 @@ WebContentsView::WebContentsView(v8::Isolate* isolate,
   // managed by InspectableWebContents.
   set_delete_view(false);
 #endif
-  WebContentsViewRelay::CreateForWebContents(web_contents->web_contents());
   Observe(web_contents->web_contents());
 }
 

--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -10,6 +10,7 @@
 #include "shell/browser/ui/inspectable_web_contents_view.h"
 #include "shell/common/gin_helper/constructor.h"
 #include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
 
 #if defined(OS_MACOSX)
@@ -78,6 +79,12 @@ WebContentsView::~WebContentsView() {
   }
 }
 
+v8::Local<v8::Value> WebContentsView::GetWebContents(v8::Isolate* isolate) {
+  if (web_contents_.IsEmpty())
+    return v8::Null(isolate);
+  return v8::Local<v8::Value>::New(isolate, web_contents_);
+}
+
 void WebContentsView::WebContentsDestroyed() {
   api_web_contents_ = nullptr;
   web_contents_.Reset();
@@ -109,7 +116,11 @@ gin_helper::WrappableBase* WebContentsView::New(
 // static
 void WebContentsView::BuildPrototype(
     v8::Isolate* isolate,
-    v8::Local<v8::FunctionTemplate> prototype) {}
+    v8::Local<v8::FunctionTemplate> prototype) {
+  prototype->SetClassName(gin::StringToV8(isolate, "WebContentsView"));
+  gin_helper::ObjectTemplateBuilder(isolate, prototype->PrototypeTemplate())
+      .SetProperty("webContents", &WebContentsView::GetWebContents);
+}
 
 }  // namespace api
 

--- a/shell/browser/api/electron_api_web_contents_view.h
+++ b/shell/browser/api/electron_api_web_contents_view.h
@@ -18,9 +18,15 @@ class WebContents;
 
 class WebContentsView : public View, public content::WebContentsObserver {
  public:
-  static gin_helper::WrappableBase* New(gin_helper::Arguments* args,
-                                        gin::Handle<WebContents> web_contents);
+  // Create a new instance of WebContentsView.
+  static gin::Handle<WebContentsView> Create(
+      v8::Isolate* isolate,
+      gin::Handle<WebContents> web_contents);
 
+  // Return the cached constructor function.
+  static v8::Local<v8::Function> GetConstructor(v8::Isolate* isolate);
+
+  // gin_helper::Wrappable
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype);
 
@@ -38,6 +44,9 @@ class WebContentsView : public View, public content::WebContentsObserver {
   void WebContentsDestroyed() override;
 
  private:
+  static gin_helper::WrappableBase* New(gin_helper::Arguments* args,
+                                        gin::Handle<WebContents> web_contents);
+
   // Keep a reference to v8 wrapper.
   v8::Global<v8::Value> web_contents_;
   api::WebContents* api_web_contents_;

--- a/shell/browser/api/electron_api_web_contents_view.h
+++ b/shell/browser/api/electron_api_web_contents_view.h
@@ -8,6 +8,10 @@
 #include "content/public/browser/web_contents_observer.h"
 #include "shell/browser/api/electron_api_view.h"
 
+namespace gin_helper {
+class Dictionary;
+}
+
 namespace electron {
 
 class InspectableWebContents;
@@ -21,7 +25,7 @@ class WebContentsView : public View, public content::WebContentsObserver {
   // Create a new instance of WebContentsView.
   static gin::Handle<WebContentsView> Create(
       v8::Isolate* isolate,
-      gin::Handle<WebContents> web_contents);
+      v8::Local<v8::Value> web_preferences);
 
   // Return the cached constructor function.
   static v8::Local<v8::Function> GetConstructor(v8::Isolate* isolate);
@@ -31,21 +35,20 @@ class WebContentsView : public View, public content::WebContentsObserver {
                              v8::Local<v8::FunctionTemplate> prototype);
 
   // Public APIs.
-  v8::Local<v8::Value> GetWebContents(v8::Isolate* isolate);
+  gin::Handle<WebContents> GetWebContents(v8::Isolate* isolate);
 
  protected:
   // Takes an existing WebContents.
-  WebContentsView(v8::Isolate* isolate,
-                  gin::Handle<WebContents> web_contents,
-                  InspectableWebContents* iwc);
+  WebContentsView(v8::Isolate* isolate, gin::Handle<WebContents> web_contents);
   ~WebContentsView() override;
 
   // content::WebContentsObserver:
   void WebContentsDestroyed() override;
 
  private:
-  static gin_helper::WrappableBase* New(gin_helper::Arguments* args,
-                                        gin::Handle<WebContents> web_contents);
+  static gin_helper::WrappableBase* New(
+      gin_helper::Arguments* args,
+      const gin_helper::Dictionary& web_preferences);
 
   // Keep a reference to v8 wrapper.
   v8::Global<v8::Value> web_contents_;

--- a/shell/browser/api/electron_api_web_contents_view.h
+++ b/shell/browser/api/electron_api_web_contents_view.h
@@ -24,7 +24,11 @@ class WebContentsView : public View, public content::WebContentsObserver {
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype);
 
+  // Public APIs.
+  v8::Local<v8::Value> GetWebContents(v8::Isolate* isolate);
+
  protected:
+  // Takes an existing WebContents.
   WebContentsView(v8::Isolate* isolate,
                   gin::Handle<WebContents> web_contents,
                   InspectableWebContents* iwc);

--- a/shell/browser/api/electron_api_web_contents_view.h
+++ b/shell/browser/api/electron_api_web_contents_view.h
@@ -26,14 +26,9 @@ class WebContentsView : public View, public content::WebContentsObserver {
   static gin::Handle<WebContentsView> Create(
       v8::Isolate* isolate,
       const gin_helper::Dictionary& web_preferences);
-  static gin::Handle<WebContentsView> CreateWithWebContents(
-      v8::Isolate* isolate,
-      gin::Handle<WebContents> web_contents);
 
   // Return the cached constructor function.
-  static v8::Local<v8::Function> GetConstructorForNew(v8::Isolate* isolate);
-  static v8::Local<v8::Function> GetConstructorForNewWithWebContents(
-      v8::Isolate* isolate);
+  static v8::Local<v8::Function> GetConstructor(v8::Isolate* isolate);
 
   // gin_helper::Wrappable
   static void BuildPrototype(v8::Isolate* isolate,
@@ -54,9 +49,6 @@ class WebContentsView : public View, public content::WebContentsObserver {
   static gin_helper::WrappableBase* New(
       gin_helper::Arguments* args,
       const gin_helper::Dictionary& web_preferences);
-  static gin_helper::WrappableBase* NewWithWebContents(
-      gin_helper::Arguments* args,
-      gin::Handle<WebContents> web_contents);
 
   // Keep a reference to v8 wrapper.
   v8::Global<v8::Value> web_contents_;

--- a/shell/browser/api/electron_api_web_contents_view.h
+++ b/shell/browser/api/electron_api_web_contents_view.h
@@ -25,10 +25,15 @@ class WebContentsView : public View, public content::WebContentsObserver {
   // Create a new instance of WebContentsView.
   static gin::Handle<WebContentsView> Create(
       v8::Isolate* isolate,
-      v8::Local<v8::Value> web_preferences);
+      const gin_helper::Dictionary& web_preferences);
+  static gin::Handle<WebContentsView> CreateWithWebContents(
+      v8::Isolate* isolate,
+      gin::Handle<WebContents> web_contents);
 
   // Return the cached constructor function.
-  static v8::Local<v8::Function> GetConstructor(v8::Isolate* isolate);
+  static v8::Local<v8::Function> GetConstructorForNew(v8::Isolate* isolate);
+  static v8::Local<v8::Function> GetConstructorForNewWithWebContents(
+      v8::Isolate* isolate);
 
   // gin_helper::Wrappable
   static void BuildPrototype(v8::Isolate* isolate,
@@ -49,6 +54,9 @@ class WebContentsView : public View, public content::WebContentsObserver {
   static gin_helper::WrappableBase* New(
       gin_helper::Arguments* args,
       const gin_helper::Dictionary& web_preferences);
+  static gin_helper::WrappableBase* NewWithWebContents(
+      gin_helper::Arguments* args,
+      gin::Handle<WebContents> web_contents);
 
   // Keep a reference to v8 wrapper.
   v8::Global<v8::Value> web_contents_;

--- a/spec-main/ambient.d.ts
+++ b/spec-main/ambient.d.ts
@@ -27,7 +27,7 @@ declare namespace Electron {
   }
   class View {}
   class WebContentsView {
-    constructor(webContents: WebContents)
+    constructor(options: BrowserWindowConstructorOptions)
   }
 
   namespace Main {

--- a/spec-main/api-web-contents-view-spec.ts
+++ b/spec-main/api-web-contents-view-spec.ts
@@ -4,25 +4,15 @@ import * as path from 'path';
 import { emittedOnce } from './events-helpers';
 import { closeWindow } from './window-helpers';
 
-import { webContents, TopLevelWindow, WebContentsView } from 'electron/main';
+import { TopLevelWindow, WebContentsView } from 'electron/main';
 
 describe('WebContentsView', () => {
   let w: TopLevelWindow;
   afterEach(() => closeWindow(w as any).then(() => { w = null as unknown as TopLevelWindow; }));
 
   it('can be used as content view', () => {
-    const web = (webContents as any).create({});
     w = new TopLevelWindow({ show: false });
-    w.setContentView(new WebContentsView(web));
-  });
-
-  it('prevents adding same WebContents', () => {
-    const web = (webContents as any).create({});
-    w = new TopLevelWindow({ show: false });
-    w.setContentView(new WebContentsView(web));
-    expect(() => {
-      w.setContentView(new WebContentsView(web));
-    }).to.throw('The WebContents has already been added to a View');
+    w.setContentView(new WebContentsView({}));
   });
 
   describe('new WebContentsView()', () => {
@@ -50,9 +40,8 @@ describe('WebContentsView', () => {
   }
 
   it('doesn\'t crash when GCed during allocation', (done) => {
-    const web = (webContents as any).create({});
     // eslint-disable-next-line no-new
-    new WebContentsView(web);
+    new WebContentsView({});
     setTimeout(() => {
       // NB. the crash we're testing for is the lack of a current `v8::Context`
       // when emitting an event in WebContents's destructor. V8 is inconsistent

--- a/spec-main/fixtures/api/leak-exit-webcontentsview.js
+++ b/spec-main/fixtures/api/leak-exit-webcontentsview.js
@@ -1,7 +1,6 @@
-const { WebContentsView, app, webContents } = require('electron');
+const { WebContentsView, app } = require('electron');
 app.whenReady().then(function () {
-  const web = webContents.create({});
-  new WebContentsView(web)  // eslint-disable-line
+  new WebContentsView({})  // eslint-disable-line
 
   app.quit();
 });


### PR DESCRIPTION
#### Description of Change

This PR changes the public JS constructor of `WebContentsView` to take `web_preferences` as parameter and create `WebContents` inside it. This is required for making the APIs public (https://github.com/electron/governance/pull/254). I'll write documentations in another PR.

#### Release Notes

Notes: none