### PR TITLE
docs: add links for alternate ways to handle update servers that have auth

### DIFF
--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -132,6 +132,10 @@ autoUpdater.on('error', message => {
 })
 ```
 
+## Handing Updates Manually
+
+Because the requests made by Auto Update aren't under your direct control, you may find situations that are difficult to handle (such as if the update server is behind authentication). The `url` field does support files, which means that with some effort, you can sidestep the server-communication aspect of the process. [Here's an example of how this could work](https://github.com/electron/electron/issues/5020#issuecomment-477636990).
+
 [now]: https://zeit.co/now
 [hazel]: https://github.com/zeit/hazel
 [nuts]: https://github.com/GitbookIO/nuts


### PR DESCRIPTION
In some situations, we can't use auto update to communicate with our update server directly, and proxies can be tricky to get working. I spent a loooong time exploring a lot of options before coming across the comment I linked, so It thought it could be beneficial to people like me of the future. cc @MarshallOfSound 

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [-] `npm test` passes
- [-] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [-] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none