### PR TITLE
fix: missing HandleScope in OnDownloadPathGenerated

### DIFF
--- a/shell/browser/electron_download_manager_delegate.cc
+++ b/shell/browser/electron_download_manager_delegate.cc
@@ -117,6 +117,7 @@ void ElectronDownloadManagerDelegate::OnDownloadPathGenerated(
     settings.force_detached = offscreen;
 
     v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::HandleScope scope(isolate);
     gin_helper::Promise<gin_helper::Dictionary> dialog_promise(isolate);
     auto dialog_callback = base::BindOnce(
         &ElectronDownloadManagerDelegate::OnDownloadSaveDialogDone,


### PR DESCRIPTION
#### Description of Change

Fixes a missing handlescope in `ElectronDownloadManagerDelegate::OnDownloadPathGenerated`.

Caused the following:

<details>

```sh
Received signal 11 SEGV_MAPERR 000000000000

0   Electron Framework                  0x0000000114dfe489 base::debug::CollectStackTrace(void**, unsigned long) + 9

1   Electron Framework                  0x0000000114cc89e3 base::debug::StackTrace::StackTrace() + 19

2   Electron Framework                  0x0000000114dfe331 base::debug::(anonymous namespace)::StackDumpSignalHandler(int, __siginfo*, void*) + 2385

3   libsystem_platform.dylib            0x00007fff68b0a5fd _sigtramp + 29

4   libsystem_c.dylib                   0x00007fff689afee7 _vsnprintf + 417

5   Electron Framework                  0x0000000111c2df34 v8::Utils::ReportApiFailure(char const*, char const*) + 116

6   Electron Framework                  0x0000000111ecb702 v8::internal::HandleScope::Extend(v8::internal::Isolate*) + 66

7   Electron Framework                  0x0000000111c29617 v8::internal::HandleScope::CreateHandle(v8::internal::Isolate*, unsigned long) + 103

8   Electron Framework                  0x0000000111c45bfa v8::Isolate::GetCurrentContext() + 282

9   Electron Framework                  0x000000010fc36058 gin_helper::PromiseBase::PromiseBase(v8::Isolate*) + 24

10  Electron Framework                  0x000000010fb6fa82 electron::ElectronDownloadManagerDelegate::OnDownloadPathGenerated(unsigned int, base::OnceCallback<void (base::FilePath const&, download::DownloadItem::TargetDisposition, download::DownloadDangerType, download::DownloadItem::MixedContentStatus, base::FilePath const&, download::DownloadInterruptReason)>, base::FilePath const&) + 898

11  Electron Framework                  0x000000010fb7167e void base::internal::FunctorTraits<void (electron::ElectronDownloadManagerDelegate::*)(unsigned int, base::OnceCallback<void (base::FilePath const&, download::DownloadItem::TargetDisposition, download::DownloadDangerType, download::DownloadItem::MixedContentStatus, base::FilePath const&, download::DownloadInterruptReason)>, base::FilePath const&), void>::Invoke<void (electron::ElectronDownloadManagerDelegate::*)(unsigned int, base::OnceCallback<void (base::FilePath const&, download::DownloadItem::TargetDisposition, download::DownloadDangerType, download::DownloadItem::MixedContentStatus, base::FilePath const&, download::DownloadInterruptReason)>, base::FilePath const&), base::WeakPtr<electron::ElectronDownloadManagerDelegate>, unsigned int, base::OnceCallback<void (base::FilePath const&, download::DownloadItem::TargetDisposition, download::DownloadDangerType, download::DownloadItem::MixedContentStatus, base::FilePath const&, download::DownloadInterruptReason)>, base::FilePath const&>(void (electron::ElectronDownloadManagerDelegate::*)(unsigned int, base::OnceCallback<void (base::FilePath const&, download::DownloadItem::TargetDisposition, download::DownloadDangerType, download::DownloadItem::MixedContentStatus, base::FilePath const&, download::DownloadInterruptReason)>, base::FilePath const&), base::WeakPtr<electron::ElectronDownloadManagerDelegate>&&, unsigned int&&, base::OnceCallback<void (base::FilePath const&, download::DownloadItem::TargetDisposition, download::DownloadDangerType, download::DownloadItem::MixedContentStatus, base::FilePath const&, download::DownloadInterruptReason)>&&, base::FilePath const&) + 190

12  Electron Framework                  0x000000010fb718ee void base::internal::ReplyAdapter<base::FilePath, base::FilePath const&>(base::OnceCallback<void (base::FilePath const&)>, std::__1::unique_ptr<base::FilePath, std::__1::default_delete<base::FilePath> >*) + 190

13  Electron Framework                  0x000000010fb71b47 base::internal::Invoker<base::internal::BindState<void (*)(base::OnceCallback<void (base::FilePath const&)>, std::__1::unique_ptr<base::FilePath, std::__1::default_delete<base::FilePath> >*), base::OnceCallback<void (base::FilePath const&)>, base::internal::OwnedWrapper<std::__1::unique_ptr<base::FilePath, std::__1::default_delete<base::FilePath> >, std::__1::default_delete<std::__1::unique_ptr<base::FilePath, std::__1::default_delete<base::FilePath> > > > >, void ()>::RunOnce(base::internal::BindStateBase*) + 39

14  Electron Framework                  0x0000000114db12dd base::(anonymous namespace)::PostTaskAndReplyRelay::RunReply(base::(anonymous namespace)::PostTaskAndReplyRelay) + 253

15  Electron Framework                  0x0000000114db1379 base::internal::Invoker<base::internal::BindState<void (*)(base::(anonymous namespace)::PostTaskAndReplyRelay), base::(anonymous namespace)::PostTaskAndReplyRelay>, void ()>::RunOnce(base::internal::BindStateBase*) + 73

16  Electron Framework                  0x0000000114d60554 base::TaskAnnotator::RunTask(char const*, base::PendingTask*) + 404

17  Electron Framework                  0x0000000114d816a5 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::sequence_manager::LazyNow*, bool*) + 485

18  Electron Framework                  0x0000000114d81392 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoSomeWork() + 162

19  Electron Framework                  0x0000000114e206ff base::MessagePumpCFRunLoopBase::RunWork() + 63

20  Electron Framework                  0x0000000114e1446a base::mac::CallWithEHFrame(void () block_pointer) + 10

21  Electron Framework                  0x0000000114e1fecf base::MessagePumpCFRunLoopBase::RunWorkSource(void*) + 63

22  CoreFoundation                      0x00007fff2e9c9f12 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 17

23  CoreFoundation                      0x00007fff2e9c9eb1 __CFRunLoopDoSource0 + 103

24  CoreFoundation                      0x00007fff2e9c9ccb __CFRunLoopDoSources0 + 209

25  CoreFoundation                      0x00007fff2e9c89fa __CFRunLoopRun + 927

26  CoreFoundation                      0x00007fff2e9c7ffe CFRunLoopRunSpecific + 462

27  HIToolbox                           0x00007fff2d5fbabd RunCurrentEventLoopInMode + 292

28  HIToolbox                           0x00007fff2d5fb7d5 ReceiveNextEventCommon + 584

29  HIToolbox                           0x00007fff2d5fb579 _BlockUntilNextEventMatchingListInModeWithFilter + 64

30  AppKit                              0x00007fff2bc46c99 _DPSNextEvent + 883

31  AppKit                              0x00007fff2bc454e0 -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1352

32  AppKit                              0x00007fff2bc371ee -[NSApplication run] + 658

33  Electron Framework                  0x0000000114e2189c base::MessagePumpNSApplication::DoRun(base::MessagePump::Delegate*) + 348

34  Electron Framework                  0x0000000114e1f822 base::MessagePumpCFRunLoopBase::Run(base::MessagePump::Delegate*) + 130

35  Electron Framework                  0x0000000114d82072 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool, base::TimeDelta) + 242

36  Electron Framework                  0x0000000114d33b45 base::RunLoop::Run() + 821

37  Electron Framework                  0x00000001136e80b1 content::BrowserMainLoop::RunMainMessageLoopParts() + 225

38  Electron Framework                  0x00000001136ea7f6 content::BrowserMainRunnerImpl::Run() + 102

39  Electron Framework                  0x00000001136e4d1b content::BrowserMain(content::MainFunctionParams const&) + 267

40  Electron Framework                  0x000000011349d151 content::ContentMainRunnerImpl::RunServiceManager(content::MainFunctionParams&, bool) + 1121

41  Electron Framework                  0x000000011349ccc3 content::ContentMainRunnerImpl::Run(bool) + 531

42  Electron Framework                  0x00000001174533ac service_manager::Main(service_manager::MainParams const&) + 3180

43  Electron Framework                  0x0000000111706ae8 content::ContentMain(content::ContentMainParams const&) + 120

44  Electron Framework                  0x000000010fa45006 ElectronMain + 134

45  Electron                            0x00000001078221f1 main + 289

46  libdyld.dylib                       0x00007fff68911cc9 start + 1

47  ???                                 0x0000000000000004 0x0 + 4

[end of stack trace]

Electron exited.
```

</details>

cc @nornagon @zcbenz @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none