### PR TITLE
fix(extensions): add more properties to port.sender.tab

### DIFF
--- a/shell/browser/extensions/electron_messaging_delegate.cc
+++ b/shell/browser/extensions/electron_messaging_delegate.cc
@@ -20,10 +20,9 @@
 #include "extensions/browser/pref_names.h"
 #include "extensions/common/api/messaging/port_id.h"
 #include "extensions/common/extension.h"
+#include "shell/browser/api/electron_api_web_contents.h"
 #include "ui/gfx/native_widget_types.h"
 #include "url/gurl.h"
-
-#include "shell/browser/api/electron_api_web_contents.h"
 
 namespace extensions {
 
@@ -48,6 +47,13 @@ ElectronMessagingDelegate::MaybeGetTabInfo(content::WebContents* web_contents) {
       auto tab = std::make_unique<base::DictionaryValue>();
       tab->SetWithoutPathExpansion(
           "id", std::make_unique<base::Value>(api_contents->ID()));
+      tab->SetWithoutPathExpansion(
+          "url", std::make_unique<base::Value>(api_contents->GetURL().spec()));
+      tab->SetWithoutPathExpansion(
+          "title", std::make_unique<base::Value>(api_contents->GetTitle()));
+      tab->SetWithoutPathExpansion(
+          "audible",
+          std::make_unique<base::Value>(api_contents->IsCurrentlyAudible()));
       return tab;
     }
   }


### PR DESCRIPTION
Backport of #22592 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
