### PR TITLE
feat: crashReporter: expose rateLimit and compress options

### DIFF
--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -48,6 +48,11 @@ The `crashReporter` module has the following methods:
   * `productName` String (optional) - Defaults to `app.name`.
   * `uploadToServer` Boolean (optional) - Whether crash reports should be sent to the server. Default is `true`.
   * `ignoreSystemCrashHandler` Boolean (optional) - Default is `false`.
+  * `rateLimit` Boolean (optional) _macOS_ _Windows_ - If true, limit the
+    number of crashes uploaded to 1/hour. Default is `false`.
+  * `compress` Boolean (optional) _macOS_ _Windows_ - If true, crash reports
+    will be compressed and uploaded with `Content-Encoding: gzip`. Not all
+    collection servers support compressed payloads. Default is `false`.
   * `extra` Record<String, String> (optional) - An object you can define that will be sent along with the
     report. Only string properties are sent correctly. Nested objects are not
     supported. When using Windows, the property names and values must be fewer than 64 characters.

--- a/lib/common/crash-reporter.js
+++ b/lib/common/crash-reporter.js
@@ -21,7 +21,9 @@ class CrashReporter {
       extra = {},
       ignoreSystemCrashHandler = false,
       submitURL,
-      uploadToServer = true
+      uploadToServer = true,
+      rateLimit = false,
+      compress = false
     } = options;
 
     if (companyName == null) throw new Error('companyName is a required option to crashReporter.start');
@@ -39,7 +41,7 @@ class CrashReporter {
     if (extra._companyName == null) extra._companyName = companyName;
     if (extra._version == null) extra._version = ret.appVersion;
 
-    binding.start(ret.productName, companyName, submitURL, ret.crashesDirectory, uploadToServer, ignoreSystemCrashHandler, extra);
+    binding.start(ret.productName, companyName, submitURL, ret.crashesDirectory, uploadToServer, ignoreSystemCrashHandler, rateLimit, compress, extra);
   }
 
   getLastCrashReport () {

--- a/shell/common/crash_reporter/crash_reporter.cc
+++ b/shell/common/crash_reporter/crash_reporter.cc
@@ -143,12 +143,20 @@ void CrashReporter::StartInstance(const gin_helper::Dictionary& options) {
   options.Get("crashesDirectory", &crashes_dir);
   StringMap extra_parameters;
   options.Get("extra", &extra_parameters);
+  bool rate_limit = false;
+  options.Get("rateLimit", &rate_limit);
+  bool compress = false;
+  options.Get("compress", &compress);
 
   extra_parameters["_productName"] = product_name;
   extra_parameters["_companyName"] = company_name;
 
-  reporter->Start(product_name, company_name, submit_url, crashes_dir, true,
-                  false, extra_parameters);
+  bool upload_to_server = true;
+  bool skip_system_crash_handler = false;
+
+  reporter->Start(product_name, company_name, submit_url, crashes_dir,
+                  upload_to_server, skip_system_crash_handler, rate_limit,
+                  compress, extra_parameters);
 }
 
 }  // namespace crash_reporter

--- a/shell/common/crash_reporter/crash_reporter.cc
+++ b/shell/common/crash_reporter/crash_reporter.cc
@@ -52,12 +52,14 @@ void CrashReporter::Start(const std::string& product_name,
                           const base::FilePath& crashes_dir,
                           bool upload_to_server,
                           bool skip_system_crash_handler,
+                          bool rate_limit,
+                          bool compress,
                           const StringMap& extra_parameters) {
   is_initialized_ = true;
   SetUploadParameters(extra_parameters);
 
   Init(product_name, company_name, submit_url, crashes_dir, upload_to_server,
-       skip_system_crash_handler);
+       skip_system_crash_handler, rate_limit, compress);
 }
 
 void CrashReporter::SetUploadParameters(const StringMap& parameters) {

--- a/shell/common/crash_reporter/crash_reporter.cc
+++ b/shell/common/crash_reporter/crash_reporter.cc
@@ -107,7 +107,9 @@ void CrashReporter::Init(const std::string& product_name,
                          const std::string& submit_url,
                          const base::FilePath& crashes_dir,
                          bool auto_submit,
-                         bool skip_system_crash_handler) {}
+                         bool skip_system_crash_handler,
+                         bool rate_limit,
+                         bool compress) {}
 
 void CrashReporter::SetUploadParameters() {}
 

--- a/shell/common/crash_reporter/crash_reporter.h
+++ b/shell/common/crash_reporter/crash_reporter.h
@@ -63,7 +63,8 @@ class CrashReporter {
                     const std::string& submit_url,
                     const base::FilePath& crashes_dir,
                     bool upload_to_server,
-                    bool skip_system_crash_handler);
+                    bool skip_system_crash_handler bool rate_limit,
+                    bool compress);
   virtual void SetUploadParameters();
 
   StringMap upload_parameters_;

--- a/shell/common/crash_reporter/crash_reporter.h
+++ b/shell/common/crash_reporter/crash_reporter.h
@@ -63,7 +63,8 @@ class CrashReporter {
                     const std::string& submit_url,
                     const base::FilePath& crashes_dir,
                     bool upload_to_server,
-                    bool skip_system_crash_handler bool rate_limit,
+                    bool skip_system_crash_handler,
+                    bool rate_limit,
                     bool compress);
   virtual void SetUploadParameters();
 

--- a/shell/common/crash_reporter/crash_reporter.h
+++ b/shell/common/crash_reporter/crash_reporter.h
@@ -40,6 +40,8 @@ class CrashReporter {
              const base::FilePath& crashes_dir,
              bool upload_to_server,
              bool skip_system_crash_handler,
+             bool rate_limit,
+             bool compress,
              const StringMap& extra_parameters);
 
   virtual std::vector<CrashReporter::UploadReportResult> GetUploadedReports(

--- a/shell/common/crash_reporter/crash_reporter_linux.cc
+++ b/shell/common/crash_reporter/crash_reporter_linux.cc
@@ -61,7 +61,9 @@ void CrashReporterLinux::Init(const std::string& product_name,
                               const std::string& submit_url,
                               const base::FilePath& crashes_dir,
                               bool upload_to_server,
-                              bool skip_system_crash_handler) {
+                              bool skip_system_crash_handler,
+                              bool rate_limit,
+                              bool compress) {
   EnableCrashDumping(crashes_dir);
 
   upload_url_ = submit_url;

--- a/shell/common/crash_reporter/crash_reporter_linux.h
+++ b/shell/common/crash_reporter/crash_reporter_linux.h
@@ -33,7 +33,9 @@ class CrashReporterLinux : public CrashReporter {
             const std::string& submit_url,
             const base::FilePath& crashes_dir,
             bool upload_to_server,
-            bool skip_system_crash_handler) override;
+            bool skip_system_crash_handler,
+            bool rate_limit,
+            bool compress) override;
   void SetUploadToServer(bool upload_to_server) override;
   void SetUploadParameters() override;
   bool GetUploadToServer() override;

--- a/shell/common/crash_reporter/crash_reporter_mac.h
+++ b/shell/common/crash_reporter/crash_reporter_mac.h
@@ -26,7 +26,9 @@ class CrashReporterMac : public CrashReporterCrashpad {
             const std::string& submit_url,
             const base::FilePath& crashes_dir,
             bool upload_to_server,
-            bool skip_system_crash_handler) override;
+            bool skip_system_crash_handler,
+            bool rate_limit,
+            bool compress) override;
   void SetUploadParameters() override;
 
  private:

--- a/shell/common/crash_reporter/crash_reporter_mac.mm
+++ b/shell/common/crash_reporter/crash_reporter_mac.mm
@@ -27,7 +27,9 @@ void CrashReporterMac::Init(const std::string& product_name,
                             const std::string& submit_url,
                             const base::FilePath& crashes_dir,
                             bool upload_to_server,
-                            bool skip_system_crash_handler) {
+                            bool skip_system_crash_handler,
+                            bool rate_limit,
+                            bool compress) {
   // check whether crashpad has been initialized.
   // Only need to initialize once.
   if (simple_string_dictionary_)
@@ -39,10 +41,11 @@ void CrashReporterMac::Init(const std::string& product_name,
       base::FilePath handler_path =
           framework_bundle_path.Append("Resources").Append("crashpad_handler");
 
-      std::vector<std::string> args = {
-          "--no-rate-limit",
-          "--no-upload-gzip",  // not all servers accept gzip
-      };
+      std::vector<std::string> args;
+      if (!rate_limit)
+        args.emplace_back("--no-rate-limit");
+      if (!compress)
+        args.emplace_back("--no-upload-gzip");
 
       crashpad::CrashpadClient crashpad_client;
       crashpad_client.StartHandler(handler_path, crashes_dir, crashes_dir,

--- a/shell/common/crash_reporter/crash_reporter_win.cc
+++ b/shell/common/crash_reporter/crash_reporter_win.cc
@@ -62,7 +62,9 @@ void CrashReporterWin::Init(const std::string& product_name,
                             const std::string& submit_url,
                             const base::FilePath& crashes_dir,
                             bool upload_to_server,
-                            bool skip_system_crash_handler) {
+                            bool skip_system_crash_handler,
+                            bool rate_limit,
+                            bool compress) {
   // check whether crashpad has been initialized.
   // Only need to initialize once.
   if (simple_string_dictionary_)
@@ -71,10 +73,11 @@ void CrashReporterWin::Init(const std::string& product_name,
     base::FilePath handler_path;
     base::PathService::Get(base::FILE_EXE, &handler_path);
 
-    std::vector<std::string> args = {
-        "--no-rate-limit",
-        "--no-upload-gzip",  // not all servers accept gzip
-    };
+    std::vector<std::string> args;
+    if (!rate_limit)
+      args.emplace_back("--no-rate-limit");
+    if (!compress)
+      args.emplace_back("--no-upload-gzip");
     args.push_back(base::StringPrintf("--type=%s", kCrashpadProcess));
     args.push_back(
         base::StringPrintf("--%s=%s", kCrashesDirectoryKey,

--- a/shell/common/crash_reporter/crash_reporter_win.h
+++ b/shell/common/crash_reporter/crash_reporter_win.h
@@ -30,7 +30,9 @@ class CrashReporterWin : public CrashReporterCrashpad {
             const std::string& submit_url,
             const base::FilePath& crashes_dir,
             bool upload_to_server,
-            bool skip_system_crash_handler) override;
+            bool skip_system_crash_handler,
+            bool rate_limit,
+            bool compress) override;
   void SetUploadParameters() override;
 
   crashpad::CrashpadClient& GetCrashpadClient();


### PR DESCRIPTION
#### Description of Change
This allows users to control these options in crashpad. Breakpad doesn't expose similarly simple primitives for controlling upload behavior, unfortunately, so for now this is limited to macOS and Windows.

At some point in the future, finer-grained rate-limiting controls may become available (see https://bugs.chromium.org/p/crashpad/issues/detail?id=23), at which time we should consider expanding this API. I think it's reasonable to expose a simple boolean for now though, as most possible future expansions to the API could be supported in a backwards-compatible way. For instance, if the crashpad API is expanded to allow user code to determine whether a given crash report should be uploaded, replacing this simple "1/hour" option, then in addition to exposing the new capability, we could interpret `rateLimit: true` by passing in callback logic that implements something close to the old 1/hour behavior.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `rateLimit` and `compress` options to `crashReporter`.