### PR TITLE
build: improve patch filename remembering

### DIFF
--- a/script/lib/patches.py
+++ b/script/lib/patches.py
@@ -8,11 +8,13 @@ def read_patch(patch_dir, patch_filename):
   """Read a patch from |patch_dir/filename| and amend the commit message with
   metadata about the patch file it came from."""
   ret = []
+  added_filename_line = False
   patch_path = os.path.join(patch_dir, patch_filename)
   with codecs.open(patch_path, encoding='utf-8') as f:
     for l in f.readlines():
-      if l.startswith('diff -'):
+      if not added_filename_line and (l.startswith('diff -') or l.startswith('---')):
         ret.append('Patch-Filename: {}\n'.format(patch_filename))
+        added_filename_line = True
       ret.append(l)
   return ''.join(ret)
 


### PR DESCRIPTION
#### Description of Change
This improves the quality of the system that handles remembering what filenames patches have. Previously, it would forget the filename of a patch if a stat block was included, e.g.

```
From 069f545fb7e14ad7149cdeea9865eeb76972fa48 Mon Sep 17 00:00:00 2001
From: Jeremy Apthorp <nornagon@nornagon.net>
Date: Thu, 9 Apr 2020 16:58:34 -0700
Subject: [PATCH] build: improve patch filename remembering

---
 script/lib/patches.py | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)

diff --git a/script/lib/patches.py b/script/lib/patches.py
index c3035b88e..2365303de 100644
--- a/script/lib/patches.py
+++ b/script/lib/patches.py
@@ -8,11 +8,13 @@ def read_patch(patch_dir, patch_filename):
[...]
```

because it would add the `Patch-Filename` information after the `---` separator, resulting in the information not being included in the commit message.

This additionally fixes an issue where the `Patch-Filename` header was being injected into the patch before every `diff --git` line, instead of only the first.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none