### PR TITLE
build: fix nightly release copy

### DIFF
--- a/script/release/prepare-release.js
+++ b/script/release/prepare-release.js
@@ -89,13 +89,13 @@ async function createRelease (branchToTarget, isBeta) {
     if (newVersion.indexOf('nightly') > 0) {
       releaseBody = 'Note: This is a nightly release.  Please file new issues ' +
         'for any bugs you find in it.\n \n This release is published to npm ' +
-        'under the nightly tag and can be installed via npm install electron@nightly, ' +
-        `or npm i electron-nightly@${newVersion.substr(1)}.\n \n ${releaseNotes.text}`;
+        'under the nightly tag and can be installed via `npm install electron@nightly`, ' +
+        `or \`npm install electron-nightly@${newVersion.substr(1)}\`.\n \n ${releaseNotes.text}`;
     } else {
       releaseBody = 'Note: This is a beta release.  Please file new issues ' +
         'for any bugs you find in it.\n \n This release is published to npm ' +
-        'under the beta tag and can be installed via npm install electron@beta, ' +
-        `or npm i electron@${newVersion.substr(1)}.\n \n ${releaseNotes.text}`;
+        'under the beta tag and can be installed via `npm install electron@beta`, ' +
+        `or \`npm install electron@${newVersion.substr(1)}\`.\n \n ${releaseNotes.text}`;
     }
     releaseIsPrelease = true;
   } else {


### PR DESCRIPTION
#### Description of Change

Fixes a small nit i noticed when looking at some nightlies: there should be backticks and we should be using `i` or `install` consistently.

cc @MarshallOfSound @jkleinsc 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none.