### PR TITLE
chore: rename atom things to electron things in our docs / scripts

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -139,32 +139,7 @@ When using Electron's built-in module you might encounter an error like this:
 Uncaught TypeError: Cannot read property 'setZoomLevel' of undefined
 ```
 
-This is because you have the [npm `electron` module][electron-module] installed
-either locally or globally, which overrides Electron's built-in module.
-
-To verify whether you are using the correct built-in module, you can print the
-path of the `electron` module:
-
-```javascript
-console.log(require.resolve('electron'))
-```
-
-and then check if it is in the following form:
-
-```sh
-"/path/to/Electron.app/Contents/Resources/atom.asar/renderer/api/lib/exports/electron.js"
-```
-
-If it is something like `node_modules/electron/index.js`, then you have to
-either remove the npm `electron` module, or rename it.
-
-```sh
-npm uninstall electron
-npm uninstall -g electron
-```
-
-However if you are using the built-in module but still getting this error, it
-is very likely you are using the module in the wrong process. For example
+It is very likely you are using the module in the wrong process. For example
 `electron.app` can only be used in the main process, while `electron.webFrame`
 is only available in renderer processes.
 

--- a/docs/tutorial/application-distribution.md
+++ b/docs/tutorial/application-distribution.md
@@ -74,7 +74,7 @@ before distributing it to users.
 ### Windows
 
 You can rename `electron.exe` to any name you like, and edit its icon and other
-information with tools like [rcedit](https://github.com/atom/rcedit).
+information with tools like [rcedit](https://github.com/electron/rcedit).
 
 ### macOS
 

--- a/docs/tutorial/windows-store-guide.md
+++ b/docs/tutorial/windows-store-guide.md
@@ -64,8 +64,7 @@ The output should look roughly like this:
 │   ├── [...]
 ├── node.dll
 ├── resources
-│   ├── app
-│   └── atom.asar
+│   └── app.asar
 ├── v8_context_snapshot.bin
 ├── squirrel.exe
 └── ui_resources_200_percent.pak

--- a/lib/browser/remote/objects-registry.ts
+++ b/lib/browser/remote/objects-registry.ts
@@ -91,14 +91,14 @@ class ObjectsRegistry {
 
   // Private: Saves the object into storage and assigns an ID for it.
   saveToStorage (object: any) {
-    let id: number = v8Util.getHiddenValue(object, 'atomId');
+    let id: number = v8Util.getHiddenValue(object, 'electronId');
     if (!id) {
       id = ++this.nextId;
       this.storage[id] = {
         count: 0,
         object: object
       };
-      v8Util.setHiddenValue(object, 'atomId', id);
+      v8Util.setHiddenValue(object, 'electronId', id);
     }
     return id;
   }
@@ -111,7 +111,7 @@ class ObjectsRegistry {
     }
     pointer.count -= 1;
     if (pointer.count === 0) {
-      v8Util.deleteHiddenValue(pointer.object, 'atomId');
+      v8Util.deleteHiddenValue(pointer.object, 'electronId');
       delete this.storage[id];
     }
   }

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -61,10 +61,10 @@ function wrapArgs (args, visited = new Set()) {
             value.then(onFulfilled, onRejected);
           })
         };
-      } else if (v8Util.getHiddenValue(value, 'atomId')) {
+      } else if (v8Util.getHiddenValue(value, 'electronId')) {
         return {
           type: 'remote-object',
-          id: v8Util.getHiddenValue(value, 'atomId')
+          id: v8Util.getHiddenValue(value, 'electronId')
         };
       }
 
@@ -256,7 +256,7 @@ function metaToValue (meta) {
 
     // Track delegate obj's lifetime & tell browser to clean up when object is GCed.
     v8Util.setRemoteObjectFreer(ret, contextId, meta.id);
-    v8Util.setHiddenValue(ret, 'atomId', meta.id);
+    v8Util.setHiddenValue(ret, 'electronId', meta.id);
     v8Util.addRemoteObjectRef(contextId, meta.id);
     remoteObjectCache.set(meta.id, ret);
     return ret;

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -60,7 +60,7 @@ v8Util.setHiddenValue(global, 'ipcNative', {
   }
 });
 
-// AtomSandboxedRendererClient will look for the "lifecycle" hidden object when
+// ElectronSandboxedRendererClient will look for the "lifecycle" hidden object when
 v8Util.setHiddenValue(global, 'lifecycle', {
   onLoaded () {
     process.emit('loaded');

--- a/script/lint.js
+++ b/script/lint.js
@@ -11,17 +11,8 @@ const SOURCE_ROOT = path.normalize(path.dirname(__dirname));
 const DEPOT_TOOLS = path.resolve(SOURCE_ROOT, '..', 'third_party', 'depot_tools');
 
 const BLACKLIST = new Set([
-  ['shell', 'browser', 'mac', 'atom_application.h'],
-  ['shell', 'browser', 'mac', 'atom_application_delegate.h'],
   ['shell', 'browser', 'resources', 'win', 'resource.h'],
   ['shell', 'browser', 'notifications', 'mac', 'notification_center_delegate.h'],
-  ['shell', 'browser', 'ui', 'cocoa', 'atom_bundle_mover.h'],
-  ['shell', 'browser', 'ui', 'cocoa', 'atom_menu_controller.h'],
-  ['shell', 'browser', 'ui', 'cocoa', 'atom_ns_window.h'],
-  ['shell', 'browser', 'ui', 'cocoa', 'atom_ns_window_delegate.h'],
-  ['shell', 'browser', 'ui', 'cocoa', 'atom_preview_item.h'],
-  ['shell', 'browser', 'ui', 'cocoa', 'atom_touch_bar.h'],
-  ['shell', 'browser', 'ui', 'cocoa', 'atom_inspectable_web_contents_view.h'],
   ['shell', 'browser', 'ui', 'cocoa', 'event_dispatching_window.h'],
   ['shell', 'browser', 'ui', 'cocoa', 'NSColor+Hex.h'],
   ['shell', 'browser', 'ui', 'cocoa', 'NSString+ANSI.h'],

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -234,7 +234,7 @@ class ProxyingURLLoaderFactory
 
   content::BrowserContext* const browser_context_;
   const int render_process_id_;
-  uint64_t* request_id_generator_;  // managed by AtomBrowserClient
+  uint64_t* request_id_generator_;  // managed by ElectronBrowserClient
   std::unique_ptr<extensions::ExtensionNavigationUIData> navigation_ui_data_;
   base::Optional<int64_t> navigation_id_;
   mojo::ReceiverSet<network::mojom::URLLoaderFactory> proxy_receivers_;

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -30,7 +30,7 @@ import {
 import * as path from 'path'
 
 // Quick start
-// https://github.com/atom/electron/blob/master/docs/tutorial/quick-start.md
+// https://github.com/electron/electron/blob/master/docs/tutorial/quick-start.md
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the javascript object is GCed.
@@ -172,7 +172,7 @@ app.whenReady().then(() => {
 app.getLocale()
 
 // Desktop environment integration
-// https://github.com/atom/electron/blob/master/docs/tutorial/desktop-environment-integration.md
+// https://github.com/electron/electron/blob/master/docs/tutorial/desktop-environment-integration.md
 
 app.addRecentDocument('/Users/USERNAME/Desktop/work.type')
 app.clearRecentDocuments()
@@ -318,7 +318,7 @@ app.setAboutPanelOptions({
 })
 
 // Online/Offline Event Detection
-// https://github.com/atom/electron/blob/master/docs/tutorial/online-offline-events.md
+// https://github.com/electron/electron/blob/master/docs/tutorial/online-offline-events.md
 
 let onlineStatusWindow: Electron.BrowserWindow
 
@@ -333,7 +333,7 @@ ipcMain.on('online-status-changed', (event: any, status: any) => {
 })
 
 // Synopsis
-// https://github.com/atom/electron/blob/master/docs/api/synopsis.md
+// https://github.com/electron/electron/blob/master/docs/api/synopsis.md
 
 app.whenReady().then(() => {
   window = new BrowserWindow({
@@ -345,7 +345,7 @@ app.whenReady().then(() => {
 })
 
 // Supported command line switches
-// https://github.com/atom/electron/blob/master/docs/api/command-line-switches.md
+// https://github.com/electron/electron/blob/master/docs/api/command-line-switches.md
 
 app.commandLine.appendSwitch('remote-debugging-port', '8315')
 app.commandLine.appendSwitch('host-rules', 'MAP * 127.0.0.1')
@@ -385,7 +385,7 @@ if (browserOptions.transparent) {
 }
 
 // app
-// https://github.com/atom/electron/blob/master/docs/api/app.md
+// https://github.com/electron/electron/blob/master/docs/api/app.md
 
 app.on('certificate-error', function (event, webContents, url, error, certificate, callback) {
   if (url === 'https://github.com') {
@@ -416,7 +416,7 @@ app.relaunch({ args: process.argv.slice(1).concat(['--relaunch']) })
 app.exit(0)
 
 // auto-updater
-// https://github.com/atom/electron/blob/master/docs/api/auto-updater.md
+// https://github.com/electron/electron/blob/master/docs/api/auto-updater.md
 
 autoUpdater.setFeedURL({
   url: 'http://mycompany.com/myapp/latest?version=' + app.getVersion(),
@@ -437,7 +437,7 @@ autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName, releaseDa
 })
 
 // BrowserWindow
-// https://github.com/atom/electron/blob/master/docs/api/browser-window.md
+// https://github.com/electron/electron/blob/master/docs/api/browser-window.md
 
 let win3 = new BrowserWindow({ width: 800, height: 600, show: false })
 win3.on('closed', () => {
@@ -465,7 +465,7 @@ window.setIcon('/path/to/icon')
 const installed = BrowserWindow.getDevToolsExtensions().hasOwnProperty('devtron')
 
 // content-tracing
-// https://github.com/atom/electron/blob/master/docs/api/content-tracing.md
+// https://github.com/electron/electron/blob/master/docs/api/content-tracing.md
 
 const options = {
   categoryFilter: '*',
@@ -482,7 +482,7 @@ contentTracing.startRecording(options).then(() => {
 })
 
 // dialog
-// https://github.com/atom/electron/blob/master/docs/api/dialog.md
+// https://github.com/electron/electron/blob/master/docs/api/dialog.md
 
 // variant without browserWindow
 dialog.showOpenDialogSync({
@@ -503,7 +503,7 @@ dialog.showOpenDialog(win3, {
 })
 
 // global-shortcut
-// https://github.com/atom/electron/blob/master/docs/api/global-shortcut.md
+// https://github.com/electron/electron/blob/master/docs/api/global-shortcut.md
 
 // Register a 'ctrl+x' shortcut listener.
 const ret = globalShortcut.register('ctrl+x', () => {
@@ -521,7 +521,7 @@ globalShortcut.unregister('ctrl+x')
 globalShortcut.unregisterAll()
 
 // ipcMain
-// https://github.com/atom/electron/blob/master/docs/api/ipc-main-process.md
+// https://github.com/electron/electron/blob/master/docs/api/ipc-main-process.md
 
 ipcMain.on('asynchronous-message', (event, arg: any) => {
   console.log(arg) // prints "ping"
@@ -547,7 +547,7 @@ const winWindows = new BrowserWindow({
 })
 
 // menu-item
-// https://github.com/atom/electron/blob/master/docs/api/menu-item.md
+// https://github.com/electron/electron/blob/master/docs/api/menu-item.md
 
 const menuItem = new MenuItem({})
 
@@ -557,7 +557,7 @@ menuItem.click = (passedMenuItem: Electron.MenuItem, browserWindow: Electron.Bro
 }
 
 // menu
-// https://github.com/atom/electron/blob/master/docs/api/menu.md
+// https://github.com/electron/electron/blob/master/docs/api/menu.md
 
 let menu = new Menu()
 menu.append(new MenuItem({ label: 'MenuItem1', click: () => { console.log('item 1 clicked') } }))
@@ -850,7 +850,7 @@ app.whenReady().then(() => {
 })
 
 // power-monitor
-// https://github.com/atom/electron/blob/master/docs/api/power-monitor.md
+// https://github.com/electron/electron/blob/master/docs/api/power-monitor.md
 
 app.whenReady().then(() => {
   powerMonitor.on('suspend', () => {
@@ -868,7 +868,7 @@ app.whenReady().then(() => {
 })
 
 // power-save-blocker
-// https://github.com/atom/electron/blob/master/docs/api/power-save-blocker.md
+// https://github.com/electron/electron/blob/master/docs/api/power-save-blocker.md
 
 const id = powerSaveBlocker.start('prevent-display-sleep')
 console.log(powerSaveBlocker.isStarted(id))
@@ -876,7 +876,7 @@ console.log(powerSaveBlocker.isStarted(id))
 powerSaveBlocker.stop(id)
 
 // protocol
-// https://github.com/atom/electron/blob/master/docs/api/protocol.md
+// https://github.com/electron/electron/blob/master/docs/api/protocol.md
 
 app.whenReady().then(() => {
   protocol.registerSchemesAsPrivileged([{ scheme: 'https', privileges: { standard: true, allowServiceWorkers: true } }])
@@ -907,7 +907,7 @@ app.whenReady().then(() => {
 })
 
 // tray
-// https://github.com/atom/electron/blob/master/docs/api/tray.md
+// https://github.com/electron/electron/blob/master/docs/api/tray.md
 
 let appIcon: Electron.Tray = null
 app.whenReady().then(() => {
@@ -950,7 +950,7 @@ app.whenReady().then(() => {
 })
 
 // clipboard
-// https://github.com/atom/electron/blob/master/docs/api/clipboard.md
+// https://github.com/electron/electron/blob/master/docs/api/clipboard.md
 
 {
   let str: string
@@ -973,7 +973,7 @@ app.whenReady().then(() => {
 }
 
 // crash-reporter
-// https://github.com/atom/electron/blob/master/docs/api/crash-reporter.md
+// https://github.com/electron/electron/blob/master/docs/api/crash-reporter.md
 
 crashReporter.start({
   productName: 'YourName',
@@ -989,7 +989,7 @@ console.log(crashReporter.getLastCrashReport())
 console.log(crashReporter.getUploadedReports())
 
 // nativeImage
-// https://github.com/atom/electron/blob/master/docs/api/native-image.md
+// https://github.com/electron/electron/blob/master/docs/api/native-image.md
 
 const appIcon2 = new Tray('/Users/somebody/images/icon.png')
 const window2 = new BrowserWindow({ icon: '/Users/somebody/images/window.png' })
@@ -1014,7 +1014,7 @@ process.hang()
 process.setFdLimit(8192)
 
 // screen
-// https://github.com/atom/electron/blob/master/docs/api/screen.md
+// https://github.com/electron/electron/blob/master/docs/api/screen.md
 
 app.whenReady().then(() => {
   const size = screen.getPrimaryDisplay().workAreaSize
@@ -1052,7 +1052,7 @@ app.whenReady().then(() => {
 })
 
 // shell
-// https://github.com/atom/electron/blob/master/docs/api/shell.md
+// https://github.com/electron/electron/blob/master/docs/api/shell.md
 
 shell.showItemInFolder('/home/user/Desktop/test.txt')
 shell.moveItemToTrash('/home/user/Desktop/test.txt')
@@ -1070,7 +1070,7 @@ shell.beep()
 shell.writeShortcutLink('/home/user/Desktop/shortcut.lnk', 'update', shell.readShortcutLink('/home/user/Desktop/shortcut.lnk'))
 
 // cookies
-// https://github.com/atom/electron/blob/master/docs/api/cookies.md
+// https://github.com/electron/electron/blob/master/docs/api/cookies.md
 {
   const { session } = require('electron')
 
@@ -1102,7 +1102,7 @@ shell.writeShortcutLink('/home/user/Desktop/shortcut.lnk', 'update', shell.readS
 }
 
 // session
-// https://github.com/atom/electron/blob/master/docs/api/session.md
+// https://github.com/electron/electron/blob/master/docs/api/session.md
 
 session.defaultSession.on('will-download', (event, item, webContents) => {
   event.preventDefault()

--- a/spec/ts-smoke/electron/renderer.ts
+++ b/spec/ts-smoke/electron/renderer.ts
@@ -12,7 +12,7 @@ import {
 import * as fs from 'fs'
 
 // In renderer process (web page).
-// https://github.com/atom/electron/blob/master/docs/api/ipc-renderer.md
+// https://github.com/electron/electron/blob/master/docs/api/ipc-renderer.md
 console.log(ipcRenderer.sendSync('synchronous-message', 'ping')) // prints "pong"
 
 ipcRenderer.on('asynchronous-reply', (event, arg: any) => {
@@ -23,7 +23,7 @@ ipcRenderer.on('asynchronous-reply', (event, arg: any) => {
 ipcRenderer.send('asynchronous-message', 'ping')
 
 // remote
-// https://github.com/atom/electron/blob/master/docs/api/remote.md
+// https://github.com/electron/electron/blob/master/docs/api/remote.md
 
 const BrowserWindow = remote.BrowserWindow
 const win = new BrowserWindow({ width: 800, height: 600 })
@@ -48,7 +48,7 @@ remote.getCurrentWindow().capturePage().then(buf => {
 })
 
 // web-frame
-// https://github.com/atom/electron/blob/master/docs/api/web-frame.md
+// https://github.com/electron/electron/blob/master/docs/api/web-frame.md
 
 webFrame.setZoomFactor(2)
 console.log(webFrame.getZoomFactor())
@@ -79,7 +79,7 @@ console.log(webFrame.getResourceUsage())
 webFrame.clearCache()
 
 // clipboard
-// https://github.com/atom/electron/blob/master/docs/api/clipboard.md
+// https://github.com/electron/electron/blob/master/docs/api/clipboard.md
 
 clipboard.writeText('Example String')
 clipboard.writeText('Example String', 'selection')
@@ -95,7 +95,7 @@ clipboard.write({
 })
 
 // crash-reporter
-// https://github.com/atom/electron/blob/master/docs/api/crash-reporter.md
+// https://github.com/electron/electron/blob/master/docs/api/crash-reporter.md
 
 crashReporter.start({
   productName: 'YourName',
@@ -105,7 +105,7 @@ crashReporter.start({
 })
 
 // desktopCapturer
-// https://github.com/atom/electron/blob/master/docs/api/desktop-capturer.md
+// https://github.com/electron/electron/blob/master/docs/api/desktop-capturer.md
 
 const desktopCapturer = require('electron').desktopCapturer
 
@@ -139,7 +139,7 @@ function getUserMediaError (error: Error) {
 }
 
 // File object
-// https://github.com/atom/electron/blob/master/docs/api/file-object.md
+// https://github.com/electron/electron/blob/master/docs/api/file-object.md
 
 /*
 <div id="holder">
@@ -165,7 +165,7 @@ holder.ondrop = function (e) {
 }
 
 // nativeImage
-// https://github.com/atom/electron/blob/master/docs/api/native-image.md
+// https://github.com/electron/electron/blob/master/docs/api/native-image.md
 
 const Tray = remote.Tray
 const appIcon2 = new Tray('/Users/somebody/images/icon.png')
@@ -185,7 +185,7 @@ process.once('loaded', function () {
 })
 
 // screen
-// https://github.com/atom/electron/blob/master/docs/api/screen.md
+// https://github.com/electron/electron/blob/master/docs/api/screen.md
 
 const app = remote.app
 
@@ -215,12 +215,12 @@ app.whenReady().then(() => {
 })
 
 // shell
-// https://github.com/atom/electron/blob/master/docs/api/shell.md
+// https://github.com/electron/electron/blob/master/docs/api/shell.md
 
 shell.openExternal('https://github.com').then(() => {})
 
 // <webview>
-// https://github.com/atom/electron/blob/master/docs/api/web-view-tag.md
+// https://github.com/electron/electron/blob/master/docs/api/web-view-tag.md
 
 const webview = document.createElement('webview')
 webview.loadURL('https://github.com')


### PR DESCRIPTION
Finishing up the removal of `atom` from our source.  Some of the documentation was outdated / wrong so I fixed that too.

Notes: none