### PR TITLE
chore: shrink boringssl patch

### DIFF
--- a/patches/node/fix_use_crypto_impls_for_compat.patch
+++ b/patches/node/fix_use_crypto_impls_for_compat.patch
@@ -3,12 +3,12 @@ From: Shelley Vohr <shelley.vohr@gmail.com>
 Date: Wed, 12 Feb 2020 15:08:04 -0800
 Subject: fix: use crypto impls for compat
 
-BoringSSL does not export DSA_get0_q, ECDSA_SIG_get0_r, or ECDSA_SIG_get0_s. This
-patch works around that problem by using the implementations of those functions as
-found in the OpenSSL repo. I plan to upstream a version of this.
+BoringSSL does not export DSA_get0_q. This patch works around that problem
+by using the implementations of those functions as found in the OpenSSL repo.
+I plan to try and upstream a version of this.
 
 diff --git a/src/node_crypto.cc b/src/node_crypto.cc
-index 5e00468aac8b9f9c5ef7ea2f1e3b62991bfde255..c22989e1dae04b05cda1163e1583213ef990ecab 100644
+index 5e00468aac8b9f9c5ef7ea2f1e3b62991bfde255..81a75049e51ee9e24f69361fca27ee858597c8e7 100644
 --- a/src/node_crypto.cc
 +++ b/src/node_crypto.cc
 @@ -4481,7 +4481,7 @@ static unsigned int GetBytesOfRS(const ManagedEVPPKey& pkey) {
@@ -20,14 +20,3 @@ index 5e00468aac8b9f9c5ef7ea2f1e3b62991bfde255..c22989e1dae04b05cda1163e1583213e
    } else if (base_id == EVP_PKEY_EC) {
      EC_KEY* ec_key = EVP_PKEY_get0_EC_KEY(pkey.get());
      const EC_GROUP* ec_group = EC_KEY_get0_group(ec_key);
-@@ -4510,8 +4510,8 @@ static AllocatedBuffer ConvertSignatureToP1363(Environment* env,
-   AllocatedBuffer buf = env->AllocateManaged(2 * n);
-   unsigned char* data = reinterpret_cast<unsigned char*>(buf.data());
- 
--  const BIGNUM* r = ECDSA_SIG_get0_r(asn1_sig.get());
--  const BIGNUM* s = ECDSA_SIG_get0_s(asn1_sig.get());
-+  const BIGNUM* r = asn1_sig.get()->r;
-+  const BIGNUM* s = asn1_sig.get()->s;
-   CHECK_EQ(n, static_cast<unsigned int>(BN_bn2binpad(r, data, n)));
-   CHECK_EQ(n, static_cast<unsigned int>(BN_bn2binpad(s, data + n, n)));
- 


### PR DESCRIPTION
#### Description of Change

Shrink BoringSSL patch as a result of upstreaming in [this CL](https://boringssl-review.googlesource.com/c/boringssl/+/40044).

cc @deepak1556 @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
