### PR TITLE
fix: deinit platform before resetting node env

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -507,8 +507,8 @@ void ElectronBrowserMainParts::PostMainMessageLoopRun() {
   // Destroy node platform after all destructors_ are executed, as they may
   // invoke Node/V8 APIs inside them.
   node_debugger_->Stop();
-  node_env_.reset();
   js_env_->OnMessageLoopDestroying();
+  node_env_.reset();
 
   fake_browser_process_->PostMainMessageLoopRun();
 }


### PR DESCRIPTION
#### Description of Change
This is a speculative fix for [this](https://app.circleci.com/pipelines/github/electron/electron/23190/workflows/c8155267-8f60-4d8a-8f06-e4806ce96674/jobs/522529) crash-on-exit:

```
Electron(1087,0x1165b35c0) malloc: *** error for object 0x115824000: pointer being freed was not allocated
Electron(1087,0x1165b35c0) malloc: *** set a breakpoint in malloc_error_break to debug
Received signal 6
0   Electron Framework                  0x000000011ba36069 base::debug::CollectStackTrace(void**, unsigned long) + 9
1   Electron Framework                  0x000000011b900c93 base::debug::StackTrace::StackTrace() + 19
2   Electron Framework                  0x000000011ba35f11 base::debug::(anonymous namespace)::StackDumpSignalHandler(int, __siginfo*, void*) + 2385
3   libsystem_platform.dylib            0x00007fff730cab5d _sigtramp + 29
4   ???                                 0x0000000000000210 0x0 + 528
5   libsystem_c.dylib                   0x00007fff72f8a6a6 abort + 127
6   libsystem_malloc.dylib              0x00007fff73098aef malloc_vreport + 545
7   libsystem_malloc.dylib              0x00007fff730988b0 malloc_report + 151
8   Electron Framework                  0x000000012173ae5e node::Buffer::(anonymous namespace)::CallbackInfo::WeakCallback(v8::WeakCallbackInfo<node::Buffer::(anonymous namespace)::CallbackInfo> const&) + 30
9   Electron Framework                  0x0000000118a86b2f unsigned long v8::internal::GlobalHandles::InvokeFirstPassWeakCallbacks<v8::internal::GlobalHandles::Node>(std::__1::vector<std::__1::pair<v8::internal::GlobalHandles::Node*, v8::internal::GlobalHandles::PendingPhantomCallback>, std::__1::allocator<std::__1::pair<v8::internal::GlobalHandles::Node*, v8::internal::GlobalHandles::PendingPhantomCallback> > >*) + 223
10  Electron Framework                  0x0000000118a86a33 v8::internal::GlobalHandles::InvokeFirstPassWeakCallbacks() + 19
11  Electron Framework                  0x0000000118afa866 v8::internal::Heap::PerformGarbageCollection(v8::internal::GarbageCollector, v8::GCCallbackFlags) + 1910
12  Electron Framework                  0x0000000118af80bb v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) + 1083
13  Electron Framework                  0x0000000118b04953 v8::internal::Heap::FinalizeIncrementalMarkingIfComplete(v8::internal::GarbageCollectionReason) + 227
14  Electron Framework                  0x0000000118b1f390 v8::internal::IncrementalMarkingJob::Task::RunInternal() + 432
15  Electron Framework                  0x00000001217ce317 node::PerIsolatePlatformData::RunForegroundTask(std::__1::unique_ptr<v8::Task, std::__1::default_delete<v8::Task> >) + 263
16  Electron Framework                  0x00000001217cd062 node::PerIsolatePlatformData::FlushForegroundTasksInternal() + 962
17  Electron Framework                  0x00000001217ce5a0 node::NodePlatform::DrainTasks(v8::Isolate*) + 128
18  Electron Framework                  0x0000000116714c54 electron::JavascriptEnvironment::OnMessageLoopDestroying() + 132
19  Electron Framework                  0x0000000116708152 electron::ElectronBrowserMainParts::PostMainMessageLoopRun() + 178
20  Electron Framework                  0x000000011a2e7fe2 content::BrowserMainLoop::ShutdownThreadsAndCleanUp() + 354
21  Electron Framework                  0x000000011a2ea572 content::BrowserMainRunnerImpl::Shutdown() + 258
22  Electron Framework                  0x000000011a2e4877 content::BrowserMain(content::MainFunctionParams const&) + 279
23  Electron Framework                  0x000000011a0a3d08 content::ContentMainRunnerImpl::RunServiceManager(content::MainFunctionParams&, bool) + 1080
24  Electron Framework                  0x000000011a0a38a3 content::ContentMainRunnerImpl::Run(bool) + 531
25  Electron Framework                  0x000000011e098ccc service_manager::Main(service_manager::MainParams const&) + 3180
26  Electron Framework                  0x00000001182bae98 content::ContentMain(content::ContentMainParams const&) + 120
27  Electron Framework                  0x00000001165de9c6 ElectronMain + 134
28  Electron                            0x000000010dc1f1f1 main + 289
29  libdyld.dylib                       0x00007fff72ee53d5 start + 1
```

Possibly introduced by #23039.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed crash-on-exit that could happen during node platform deinitialization.