### PR TITLE
fix: wasm codegen in script.runInNewContext

### DIFF
--- a/script/node-disabled-tests.json
+++ b/script/node-disabled-tests.json
@@ -185,7 +185,6 @@
   "parallel/test-v8-coverage",
   "parallel/test-v8-flags",
   "parallel/test-vm-basic",
-  "parallel/test-vm-codegen",
   "parallel/test-vm-module-basic",
   "parallel/test-vm-parse-abort-on-uncaught-exception",
   "parallel/test-vm-sigint",

--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -85,6 +85,13 @@ void HostCleanupFinalizationGroupCallback(
   env->RegisterFinalizationGroupForCleanup(group);
 }
 
+bool AllowWasmCodeGenerationCallback(v8::Local<v8::Context> context,
+                                     v8::Local<v8::String>) {
+  v8::Local<v8::Value> wasm_code_gen = context->GetEmbedderData(
+      node::ContextEmbedderIndex::kAllowWasmCodeGeneration);
+  return wasm_code_gen->IsUndefined() || wasm_code_gen->IsTrue();
+}
+
 }  // namespace
 
 namespace electron {
@@ -160,6 +167,9 @@ int NodeMain(int argc, char* argv[]) {
       // TODO(codebytere): we shouldn't have to call this - upstream?
       isolate->SetHostCleanupFinalizationGroupCallback(
           HostCleanupFinalizationGroupCallback);
+
+      isolate->SetAllowWasmCodeGenerationCallback(
+          AllowWasmCodeGenerationCallback);
 
       gin_helper::Dictionary process(isolate, env->process_object());
 #if defined(OS_WIN)


### PR DESCRIPTION
#### Description of Change

Fixes broken use of `contextCodeGeneration` parameter to Node.js'  [`script.runInNewContext`](https://github.com/nodejs/node/blob/c78d3f22560fb6d7080713c3a77b3759b088dfd0/doc/api/vm.md#L221-L226). Verified with broken Node.js smoke test which now works.

cc @nornagon @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes broken use of `contextCodeGeneration` parameter to Node.js'  `script.runInNewContext()`.
