### PR TITLE
docs: remove GitHub references

### DIFF
--- a/docs/development/debug-instructions-windows.md
+++ b/docs/development/debug-instructions-windows.md
@@ -3,7 +3,7 @@
 If you experience crashes or issues in Electron that you believe are not caused
 by your JavaScript application, but instead by Electron itself, debugging can
 be a little bit tricky, especially for developers not used to native/C++
-debugging. However, using Visual Studio, GitHub's hosted Electron Symbol Server,
+debugging. However, using Visual Studio, Electron's hosted Symbol Server,
 and the Electron source code, you can enable step-through debugging
 with breakpoints inside Electron's source code.
 
@@ -22,7 +22,7 @@ with breakpoints inside Electron's source code.
 
 * **Visual Studio with C++ Tools**: The free community editions of Visual
   Studio 2013 and Visual Studio 2015 both work. Once installed,
-  [configure Visual Studio to use GitHub's Electron Symbol server](setting-up-symbol-server.md).
+  [configure Visual Studio to use Electron's Symbol server](setting-up-symbol-server.md).
   It will enable Visual Studio to gain a better understanding of what happens
   inside Electron, making it easier to present variables in a human-readable
   format.

--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -7,7 +7,7 @@ Electron's [autoUpdater](../api/auto-updater.md) module.
 
 ## Using `update.electronjs.org`
 
-GitHub's Electron team maintains [update.electronjs.org], a free and open-source
+The Electron team maintains [update.electronjs.org], a free and open-source
 webservice that Electron apps can use to self-update. The service is designed
 for Electron apps that meet the following criteria:
 


### PR DESCRIPTION
#### Description of Change

Removes lines in our documentation specifically mentioning the Electron team as GitHub's. I did a keyword search for each document within the `/docs` folder with `GitHub` (case-sensitive) in its body.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none