### PR TITLE
fix: missing handlescopes in event emission

### DIFF
--- a/shell/browser/api/electron_api_tray.cc
+++ b/shell/browser/api/electron_api_tray.cc
@@ -93,14 +93,20 @@ gin::Handle<Tray> Tray::New(gin_helper::ErrorThrower thrower,
 void Tray::OnClicked(const gfx::Rect& bounds,
                      const gfx::Point& location,
                      int modifiers) {
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope scope(isolate);
   EmitCustomEvent("click", CreateEventFromFlags(modifiers), bounds, location);
 }
 
 void Tray::OnDoubleClicked(const gfx::Rect& bounds, int modifiers) {
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope scope(isolate);
   EmitCustomEvent("double-click", CreateEventFromFlags(modifiers), bounds);
 }
 
 void Tray::OnRightClicked(const gfx::Rect& bounds, int modifiers) {
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope scope(isolate);
   EmitCustomEvent("right-click", CreateEventFromFlags(modifiers), bounds);
 }
 
@@ -129,22 +135,32 @@ void Tray::OnDropText(const std::string& text) {
 }
 
 void Tray::OnMouseEntered(const gfx::Point& location, int modifiers) {
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope scope(isolate);
   EmitCustomEvent("mouse-enter", CreateEventFromFlags(modifiers), location);
 }
 
 void Tray::OnMouseExited(const gfx::Point& location, int modifiers) {
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope scope(isolate);
   EmitCustomEvent("mouse-leave", CreateEventFromFlags(modifiers), location);
 }
 
 void Tray::OnMouseMoved(const gfx::Point& location, int modifiers) {
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope scope(isolate);
   EmitCustomEvent("mouse-move", CreateEventFromFlags(modifiers), location);
 }
 
 void Tray::OnMouseUp(const gfx::Point& location, int modifiers) {
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope scope(isolate);
   EmitCustomEvent("mouse-up", CreateEventFromFlags(modifiers), location);
 }
 
 void Tray::OnMouseDown(const gfx::Point& location, int modifiers) {
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope scope(isolate);
   EmitCustomEvent("mouse-down", CreateEventFromFlags(modifiers), location);
 }
 

--- a/shell/browser/api/electron_api_tray.h
+++ b/shell/browser/api/electron_api_tray.h
@@ -12,6 +12,7 @@
 #include "gin/handle.h"
 #include "gin/wrappable.h"
 #include "shell/browser/event_emitter_mixin.h"
+#include "shell/browser/javascript_environment.h"
 #include "shell/browser/ui/tray_icon.h"
 #include "shell/browser/ui/tray_icon_observer.h"
 #include "shell/common/gin_converters/guid_converter.h"

--- a/shell/browser/api/ui_event.cc
+++ b/shell/browser/api/ui_event.cc
@@ -18,6 +18,7 @@ constexpr int mouse_button_flags =
 
 v8::Local<v8::Object> CreateEventFromFlags(int flags) {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
   const int is_mouse_click = static_cast<bool>(flags & mouse_button_flags);
   return gin::DataObjectBuilder(isolate)
       .Set("shiftKey", static_cast<bool>(flags & ui::EF_SHIFT_DOWN))

--- a/shell/browser/api/ui_event.cc
+++ b/shell/browser/api/ui_event.cc
@@ -18,7 +18,6 @@ constexpr int mouse_button_flags =
 
 v8::Local<v8::Object> CreateEventFromFlags(int flags) {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
-  v8::HandleScope handle_scope(isolate);
   const int is_mouse_click = static_cast<bool>(flags & mouse_button_flags);
   return gin::DataObjectBuilder(isolate)
       .Set("shiftKey", static_cast<bool>(flags & ui::EF_SHIFT_DOWN))

--- a/shell/browser/event_emitter_mixin.h
+++ b/shell/browser/event_emitter_mixin.h
@@ -39,6 +39,7 @@ class EventEmitterMixin {
                        v8::Local<v8::Object> custom_event,
                        Args&&... args) {
     v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::HandleScope scope(isolate);
     v8::Local<v8::Object> wrapper;
     if (!static_cast<T*>(this)->GetWrapper(isolate).ToLocal(&wrapper))
       return false;

--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -20,6 +20,10 @@
 #include "shell/common/node_includes.h"
 #include "tracing/trace_event.h"
 
+namespace {
+v8::Isolate* g_isolate;
+}
+
 namespace electron {
 
 JavascriptEnvironment::JavascriptEnvironment(uv_loop_t* event_loop)
@@ -46,6 +50,7 @@ JavascriptEnvironment::~JavascriptEnvironment() {
     context_.Get(isolate_)->Exit();
   }
   isolate_->Exit();
+  g_isolate = nullptr;
 }
 
 v8::Isolate* JavascriptEnvironment::Initialize(uv_loop_t* event_loop) {
@@ -73,8 +78,15 @@ v8::Isolate* JavascriptEnvironment::Initialize(uv_loop_t* event_loop) {
 
   v8::Isolate* isolate = v8::Isolate::Allocate();
   platform_->RegisterIsolate(isolate, event_loop);
+  g_isolate = isolate;
 
   return isolate;
+}
+
+// static
+v8::Isolate* JavascriptEnvironment::GetIsolate() {
+  CHECK(g_isolate);
+  return g_isolate;
 }
 
 void JavascriptEnvironment::OnMessageLoopCreated() {

--- a/shell/browser/javascript_environment.h
+++ b/shell/browser/javascript_environment.h
@@ -34,6 +34,8 @@ class JavascriptEnvironment {
     return v8::Local<v8::Context>::New(isolate_, context_);
   }
 
+  static v8::Isolate* GetIsolate();
+
  private:
   v8::Isolate* Initialize(uv_loop_t* event_loop);
   // Leaked on exit.


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/23139.

Fixes crashes in `CreateEventFromFlags` and `EmitCustomEvent` owing to missing `HandleScopes`.

cc @deepak1556 @zcbenz @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed some event listener crashes in Tray.
