### PR TITLE
refactor: remove extra args from crashreporter init

### DIFF
--- a/lib/common/crash-reporter.js
+++ b/lib/common/crash-reporter.js
@@ -41,7 +41,7 @@ class CrashReporter {
     if (extra._companyName == null) extra._companyName = companyName;
     if (extra._version == null) extra._version = ret.appVersion;
 
-    binding.start(ret.productName, companyName, submitURL, ret.crashesDirectory, uploadToServer, ignoreSystemCrashHandler, rateLimit, compress, extra);
+    binding.start(submitURL, ret.crashesDirectory, uploadToServer, ignoreSystemCrashHandler, rateLimit, compress, extra);
   }
 
   getLastCrashReport () {

--- a/shell/common/crash_reporter/crash_reporter.cc
+++ b/shell/common/crash_reporter/crash_reporter.cc
@@ -46,9 +46,7 @@ bool CrashReporter::IsInitialized() {
   return is_initialized_;
 }
 
-void CrashReporter::Start(const std::string& product_name,
-                          const std::string& company_name,
-                          const std::string& submit_url,
+void CrashReporter::Start(const std::string& submit_url,
                           const base::FilePath& crashes_dir,
                           bool upload_to_server,
                           bool skip_system_crash_handler,
@@ -58,8 +56,8 @@ void CrashReporter::Start(const std::string& product_name,
   is_initialized_ = true;
   SetUploadParameters(extra_parameters);
 
-  Init(product_name, company_name, submit_url, crashes_dir, upload_to_server,
-       skip_system_crash_handler, rate_limit, compress);
+  Init(submit_url, crashes_dir, upload_to_server, skip_system_crash_handler,
+       rate_limit, compress);
 }
 
 void CrashReporter::SetUploadParameters(const StringMap& parameters) {
@@ -71,12 +69,6 @@ void CrashReporter::SetUploadParameters(const StringMap& parameters) {
 
   // Setting platform dependent parameters.
   SetUploadParameters();
-}
-
-void CrashReporter::SetUploadToServer(const bool upload_to_server) {}
-
-bool CrashReporter::GetUploadToServer() {
-  return true;
 }
 
 std::vector<CrashReporter::UploadReportResult>
@@ -101,22 +93,6 @@ CrashReporter::GetUploadedReports(const base::FilePath& crashes_dir) {
   }
   return result;
 }
-
-void CrashReporter::Init(const std::string& product_name,
-                         const std::string& company_name,
-                         const std::string& submit_url,
-                         const base::FilePath& crashes_dir,
-                         bool auto_submit,
-                         bool skip_system_crash_handler,
-                         bool rate_limit,
-                         bool compress) {}
-
-void CrashReporter::SetUploadParameters() {}
-
-void CrashReporter::AddExtraParameter(const std::string& key,
-                                      const std::string& value) {}
-
-void CrashReporter::RemoveExtraParameter(const std::string& key) {}
 
 std::map<std::string, std::string> CrashReporter::GetParameters() const {
   return upload_parameters_;
@@ -156,9 +132,9 @@ void CrashReporter::StartInstance(const gin_helper::Dictionary& options) {
   bool upload_to_server = true;
   bool skip_system_crash_handler = false;
 
-  reporter->Start(product_name, company_name, submit_url, crashes_dir,
-                  upload_to_server, skip_system_crash_handler, rate_limit,
-                  compress, extra_parameters);
+  reporter->Start(submit_url, crashes_dir, upload_to_server,
+                  skip_system_crash_handler, rate_limit, compress,
+                  extra_parameters);
 }
 
 }  // namespace crash_reporter

--- a/shell/common/crash_reporter/crash_reporter.cc
+++ b/shell/common/crash_reporter/crash_reporter.cc
@@ -99,9 +99,28 @@ std::map<std::string, std::string> CrashReporter::GetParameters() const {
 }
 
 #if defined(OS_MACOSX) && defined(MAS_BUILD)
+class DummyCrashReporter : public CrashReporter {
+ public:
+  ~DummyCrashReporter() override {}
+
+  void SetUploadToServer(bool upload_to_server) override {}
+  bool GetUploadToServer() override {}
+  void AddExtraParameter(const std::string& key,
+                         const std::string& value) override {}
+  void RemoveExtraParameter(const std::string& key) override {}
+
+  void Init(const std::string& submit_url,
+            const base::FilePath& crashes_dir,
+            bool upload_to_server,
+            bool skip_system_crash_handler,
+            bool rate_limit,
+            bool compress) override {}
+  void SetUploadParameters() override {}
+};
+
 // static
 CrashReporter* CrashReporter::GetInstance() {
-  static CrashReporter crash_reporter;
+  static DummyCrashReporter crash_reporter;
   return &crash_reporter;
 }
 #endif

--- a/shell/common/crash_reporter/crash_reporter.cc
+++ b/shell/common/crash_reporter/crash_reporter.cc
@@ -104,7 +104,7 @@ class DummyCrashReporter : public CrashReporter {
   ~DummyCrashReporter() override {}
 
   void SetUploadToServer(bool upload_to_server) override {}
-  bool GetUploadToServer() override {}
+  bool GetUploadToServer() override { return false; }
   void AddExtraParameter(const std::string& key,
                          const std::string& value) override {}
   void RemoveExtraParameter(const std::string& key) override {}

--- a/shell/common/crash_reporter/crash_reporter.h
+++ b/shell/common/crash_reporter/crash_reporter.h
@@ -34,9 +34,7 @@ class CrashReporter {
   static void StartInstance(const gin_helper::Dictionary& options);
 
   bool IsInitialized();
-  void Start(const std::string& product_name,
-             const std::string& company_name,
-             const std::string& submit_url,
+  void Start(const std::string& submit_url,
              const base::FilePath& crashes_dir,
              bool upload_to_server,
              bool skip_system_crash_handler,
@@ -47,25 +45,23 @@ class CrashReporter {
   virtual std::vector<CrashReporter::UploadReportResult> GetUploadedReports(
       const base::FilePath& crashes_dir);
 
-  virtual void SetUploadToServer(bool upload_to_server);
-  virtual bool GetUploadToServer();
+  virtual void SetUploadToServer(bool upload_to_server) = 0;
+  virtual bool GetUploadToServer() = 0;
   virtual void AddExtraParameter(const std::string& key,
-                                 const std::string& value);
-  virtual void RemoveExtraParameter(const std::string& key);
+                                 const std::string& value) = 0;
+  virtual void RemoveExtraParameter(const std::string& key) = 0;
   virtual std::map<std::string, std::string> GetParameters() const;
 
  protected:
   CrashReporter();
   virtual ~CrashReporter();
 
-  virtual void Init(const std::string& product_name,
-                    const std::string& company_name,
-                    const std::string& submit_url,
+  virtual void Init(const std::string& submit_url,
                     const base::FilePath& crashes_dir,
                     bool upload_to_server,
                     bool skip_system_crash_handler,
                     bool rate_limit,
-                    bool compress);
+                    bool compress) = 0;
   virtual void SetUploadParameters();
 
   StringMap upload_parameters_;

--- a/shell/common/crash_reporter/crash_reporter.h
+++ b/shell/common/crash_reporter/crash_reporter.h
@@ -62,7 +62,7 @@ class CrashReporter {
                     bool skip_system_crash_handler,
                     bool rate_limit,
                     bool compress) = 0;
-  virtual void SetUploadParameters();
+  virtual void SetUploadParameters() = 0;
 
   StringMap upload_parameters_;
   std::string process_type_;

--- a/shell/common/crash_reporter/crash_reporter_linux.cc
+++ b/shell/common/crash_reporter/crash_reporter_linux.cc
@@ -88,8 +88,7 @@ bool CrashReporterLinux::GetUploadToServer() {
 void CrashReporterLinux::AddExtraParameter(const std::string& key,
                                            const std::string& value) {}
 
-void CrashReporterLinux::RemoveExtraParameter(const std::string& key) override {
-}
+void CrashReporterLinux::RemoveExtraParameter(const std::string& key) {}
 
 void CrashReporterLinux::EnableCrashDumping(const base::FilePath& crashes_dir) {
   {

--- a/shell/common/crash_reporter/crash_reporter_linux.cc
+++ b/shell/common/crash_reporter/crash_reporter_linux.cc
@@ -85,6 +85,12 @@ bool CrashReporterLinux::GetUploadToServer() {
   return upload_to_server_;
 }
 
+void CrashReporterLinux::AddExtraParameter(const std::string& key,
+                                           const std::string& value) {}
+
+void CrashReporterLinux::RemoveExtraParameter(const std::string& key) override {
+}
+
 void CrashReporterLinux::EnableCrashDumping(const base::FilePath& crashes_dir) {
   {
     base::ThreadRestrictions::ScopedAllowIO allow_io;

--- a/shell/common/crash_reporter/crash_reporter_linux.cc
+++ b/shell/common/crash_reporter/crash_reporter_linux.cc
@@ -56,9 +56,7 @@ CrashReporterLinux::CrashReporterLinux() : pid_(getpid()) {
 
 CrashReporterLinux::~CrashReporterLinux() = default;
 
-void CrashReporterLinux::Init(const std::string& product_name,
-                              const std::string& company_name,
-                              const std::string& submit_url,
+void CrashReporterLinux::Init(const std::string& submit_url,
                               const base::FilePath& crashes_dir,
                               bool upload_to_server,
                               bool skip_system_crash_handler,

--- a/shell/common/crash_reporter/crash_reporter_linux.h
+++ b/shell/common/crash_reporter/crash_reporter_linux.h
@@ -37,6 +37,9 @@ class CrashReporterLinux : public CrashReporter {
   void SetUploadToServer(bool upload_to_server) override;
   void SetUploadParameters() override;
   bool GetUploadToServer() override;
+  void AddExtraParameter(const std::string& key,
+                         const std::string& value) override;
+  void RemoveExtraParameter(const std::string& key) override;
 
  private:
   friend struct base::DefaultSingletonTraits<CrashReporterLinux>;

--- a/shell/common/crash_reporter/crash_reporter_linux.h
+++ b/shell/common/crash_reporter/crash_reporter_linux.h
@@ -28,9 +28,7 @@ class CrashReporterLinux : public CrashReporter {
  public:
   static CrashReporterLinux* GetInstance();
 
-  void Init(const std::string& product_name,
-            const std::string& company_name,
-            const std::string& submit_url,
+  void Init(const std::string& submit_url,
             const base::FilePath& crashes_dir,
             bool upload_to_server,
             bool skip_system_crash_handler,

--- a/shell/common/crash_reporter/crash_reporter_mac.h
+++ b/shell/common/crash_reporter/crash_reporter_mac.h
@@ -21,9 +21,7 @@ class CrashReporterMac : public CrashReporterCrashpad {
  public:
   static CrashReporterMac* GetInstance();
 
-  void Init(const std::string& product_name,
-            const std::string& company_name,
-            const std::string& submit_url,
+  void Init(const std::string& submit_url,
             const base::FilePath& crashes_dir,
             bool upload_to_server,
             bool skip_system_crash_handler,

--- a/shell/common/crash_reporter/crash_reporter_mac.mm
+++ b/shell/common/crash_reporter/crash_reporter_mac.mm
@@ -22,9 +22,7 @@ CrashReporterMac::CrashReporterMac() {}
 
 CrashReporterMac::~CrashReporterMac() {}
 
-void CrashReporterMac::Init(const std::string& product_name,
-                            const std::string& company_name,
-                            const std::string& submit_url,
+void CrashReporterMac::Init(const std::string& submit_url,
                             const base::FilePath& crashes_dir,
                             bool upload_to_server,
                             bool skip_system_crash_handler,

--- a/shell/common/crash_reporter/crash_reporter_win.cc
+++ b/shell/common/crash_reporter/crash_reporter_win.cc
@@ -57,9 +57,7 @@ void CrashReporterWin::SetUnhandledExceptionFilter() {
 }
 #endif
 
-void CrashReporterWin::Init(const std::string& product_name,
-                            const std::string& company_name,
-                            const std::string& submit_url,
+void CrashReporterWin::Init(const std::string& submit_url,
                             const base::FilePath& crashes_dir,
                             bool upload_to_server,
                             bool skip_system_crash_handler,

--- a/shell/common/crash_reporter/crash_reporter_win.h
+++ b/shell/common/crash_reporter/crash_reporter_win.h
@@ -25,9 +25,7 @@ class CrashReporterWin : public CrashReporterCrashpad {
   static void SetUnhandledExceptionFilter();
 #endif
 
-  void Init(const std::string& product_name,
-            const std::string& company_name,
-            const std::string& submit_url,
+  void Init(const std::string& submit_url,
             const base::FilePath& crashes_dir,
             bool upload_to_server,
             bool skip_system_crash_handler,


### PR DESCRIPTION
#### Description of Change
These args were unused. Their effects are applied in JS.

Also clean up the parent class by making some methods pure-virtual.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none