### PR TITLE
feat: support fullScreen BrowserWindow property

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -807,6 +807,10 @@ hide it immediately.
 
 A `Boolean` property that determines whether the window is in simple (pre-Lion) fullscreen mode.
 
+#### `win.fullScreen`
+
+A `Boolean` property that determines whether the window is in fullscreen mode.
+
 #### `win.visibleOnAllWorkspaces`
 
 A `Boolean` property that determines whether the window is visible on all workspaces.

--- a/lib/browser/api/top-level-window.js
+++ b/lib/browser/api/top-level-window.js
@@ -29,6 +29,11 @@ Object.defineProperty(TopLevelWindow.prototype, 'visibleOnAllWorkspaces', {
   set: function (visible) { this.setVisibleOnAllWorkspaces(visible); }
 });
 
+Object.defineProperty(TopLevelWindow.prototype, 'fullScreen', {
+  get: function () { return this.isFullScreen(); },
+  set: function (full) { this.setFullScreen(full); }
+});
+
 Object.defineProperty(TopLevelWindow.prototype, 'simpleFullScreen', {
   get: function () { return this.isSimpleFullScreen(); },
   set: function (simple) { this.setSimpleFullScreen(simple); }

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1010,27 +1010,78 @@ describe('BrowserWindow module', () => {
       });
 
       ifdescribe(process.platform === 'win32')(`Fullscreen state`, () => {
-        it(`checks normal bounds when fullscreen'ed`, (done) => {
-          const bounds = w.getBounds();
-          w.once('enter-full-screen', () => {
-            expectBoundsEqual(w.getNormalBounds(), bounds);
-            done();
+        it('with properties', () => {
+          it('can be set with the fullscreen constructor option', () => {
+            w = new BrowserWindow({ fullscreen: true });
+            expect(w.fullScreen).to.be.true();
           });
-          w.show();
-          w.setFullScreen(true);
+
+          it('can be changed', () => {
+            w.fullScreen = false;
+            expect(w.fullScreen).to.be.false();
+            w.fullScreen = true;
+            expect(w.fullScreen).to.be.true();
+          });
+
+          it(`checks normal bounds when fullscreen'ed`, (done) => {
+            const bounds = w.getBounds();
+            w.once('enter-full-screen', () => {
+              expectBoundsEqual(w.getNormalBounds(), bounds);
+              done();
+            });
+            w.show();
+            w.fullScreen = true;
+          });
+
+          it(`checks normal bounds when unfullscreen'ed`, (done) => {
+            const bounds = w.getBounds();
+            w.once('enter-full-screen', () => {
+              w.fullScreen = false;
+            });
+            w.once('leave-full-screen', () => {
+              expectBoundsEqual(w.getNormalBounds(), bounds);
+              done();
+            });
+            w.show();
+            w.fullScreen = true;
+          });
         });
 
-        it(`checks normal bounds when unfullscreen'ed`, (done) => {
-          const bounds = w.getBounds();
-          w.once('enter-full-screen', () => {
+        it('with functions', () => {
+          it('can be set with the fullscreen constructor option', () => {
+            w = new BrowserWindow({ fullscreen: true });
+            expect(w.isFullScreen()).to.be.true();
+          });
+
+          it('can be changed', () => {
             w.setFullScreen(false);
+            expect(w.isFullScreen()).to.be.false();
+            w.setFullScreen(true);
+            expect(w.isFullScreen()).to.be.true();
           });
-          w.once('leave-full-screen', () => {
-            expectBoundsEqual(w.getNormalBounds(), bounds);
-            done();
+
+          it(`checks normal bounds when fullscreen'ed`, (done) => {
+            const bounds = w.getBounds();
+            w.once('enter-full-screen', () => {
+              expectBoundsEqual(w.getNormalBounds(), bounds);
+              done();
+            });
+            w.show();
+            w.setFullScreen(true);
           });
-          w.show();
-          w.setFullScreen(true);
+
+          it(`checks normal bounds when unfullscreen'ed`, (done) => {
+            const bounds = w.getBounds();
+            w.once('enter-full-screen', () => {
+              w.setFullScreen(false);
+            });
+            w.once('leave-full-screen', () => {
+              expectBoundsEqual(w.getNormalBounds(), bounds);
+              done();
+            });
+            w.show();
+            w.setFullScreen(true);
+          });
         });
       });
     });


### PR DESCRIPTION
#### Description of Change

Longstanding follow-up to discussion from a few weeks back; add `fullScreen` property support for `BrowserWindow`s alongside `isFullScreen` and `setFullScreen`.

cc @zcbenz @electron/wg-api 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes:  Added `fullScreen` property support for `BrowserWindow`s.
