### PR TITLE
fix: wasm codegen in script.runInNewContext

### DIFF
--- a/script/node-disabled-tests.json
+++ b/script/node-disabled-tests.json
@@ -166,7 +166,6 @@
   "parallel/test-v8-flags",
   "parallel/test-v8-coverage",
   "parallel/test-vm-basic",
-  "parallel/test-vm-codegen",
   "parallel/test-vm-parse-abort-on-uncaught-exception",
   "parallel/test-vm-syntax-error-message",
   "parallel/test-warn-sigprof",

--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -29,6 +29,17 @@
 #include "shell/common/crash_reporter/crash_reporter_win.h"
 #endif
 
+namespace {
+
+bool AllowWasmCodeGenerationCallback(v8::Local<v8::Context> context,
+                                     v8::Local<v8::String>) {
+  v8::Local<v8::Value> wasm_code_gen = context->GetEmbedderData(
+      node::ContextEmbedderIndex::kAllowWasmCodeGeneration);
+  return wasm_code_gen->IsUndefined() || wasm_code_gen->IsTrue();
+}
+
+}  // namespace
+
 namespace electron {
 
 #if !defined(OS_LINUX)
@@ -93,6 +104,10 @@ int NodeMain(int argc, char* argv[]) {
     node::BootstrapEnvironment(env);
 
     gin_helper::Dictionary process(gin_env.isolate(), env->process_object());
+
+    gin_env.isolate()->SetAllowWasmCodeGenerationCallback(
+        AllowWasmCodeGenerationCallback);
+
 #if defined(OS_WIN)
     process.SetMethod("log", &ElectronBindings::Log);
 #endif


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/23129.

See that PR for more details.

Notes: Fixes broken use of `contextCodeGeneration` parameter to Node.js' `script.runInNewContext()`.