### PR TITLE
fix: use Node's microtasks policy in node_main.cc

### DIFF
--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -146,6 +146,10 @@ int NodeMain(int argc, char* argv[]) {
     JavascriptEnvironment gin_env(loop);
 
     v8::Isolate* isolate = gin_env.isolate();
+    // TODO(ckerr) and/or TODO(codebytere) use node::SetIsolateMiscHandlers()
+    node::IsolateSettings is;
+    isolate->SetMicrotasksPolicy(is.policy);
+
     v8::Isolate::Scope isolate_scope(isolate);
     v8::Locker locker(isolate);
     node::Environment* env = nullptr;

--- a/spec-main/node-spec.ts
+++ b/spec-main/node-spec.ts
@@ -307,4 +307,17 @@ describe('node feature', () => {
     const result = childProcess.spawnSync(process.execPath, [path.resolve(fixtures, 'api', 'electron-main-module', 'app.asar')]);
     expect(result.status).to.equal(0);
   });
+
+  it('handles Promise timeouts correctly', (done) => {
+    const scriptPath = path.join(fixtures, 'module', 'node-promise-timer.js');
+    const child = childProcess.spawn(process.execPath, [scriptPath], {
+      env: { ELECTRON_RUN_AS_NODE: 'true' }
+    });
+    emittedOnce(child, 'exit').then(([code, signal]) => {
+      expect(code).to.equal(0);
+      expect(signal).to.equal(null);
+      child.kill();
+      done();
+    });
+  });
 });

--- a/spec/fixtures/module/node-promise-timer.js
+++ b/spec/fixtures/module/node-promise-timer.js
@@ -1,0 +1,23 @@
+const waitMs = (msec) => new Promise((resolve) => setTimeout(resolve, msec));
+
+const intervalMsec = 100;
+const numIterations = 2;
+let curIteration = 0;
+let promise;
+
+for (let i = 0; i < numIterations; i++) {
+  promise = (promise || waitMs(intervalMsec)).then(() => {
+    ++curIteration;
+    return waitMs(intervalMsec);
+  });
+}
+
+// https://github.com/electron/electron/issues/21515 was about electron
+// exiting before promises finished. This test sets the pending exitCode
+// to failure, then resets it to success only if all promises finish.
+process.exitCode = 1;
+promise.then(() => {
+  if (curIteration === numIterations) {
+    process.exitCode = 0;
+  }
+});


### PR DESCRIPTION
Fixes #21515. See that ticket for a looong writeup.

#### Description of Change

Node [uses](https://github.com/nodejs/node/blob/666c67e078bddc32f25409f4a929c1e9b5f47373/src/api/environment.cc#L191) a `kExplicit` microtasks policy; previously we were using the V8 default value of `kAuto`. This PR ensures we use the same policy as Node by extracting it from `node::IsolateSettings`.

CC @codebytere,@nornagon

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed Promise timeout issue when running Electron as Node.