### PR TITLE
fix: moveAbove not working on Windows

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -654,8 +654,8 @@ bool NativeWindowViews::MoveAbove(const std::string& sourceId) {
   if (!::IsWindow(otherWindow))
     return false;
 
-  ::SetWindowPos(GetAcceleratedWidget(), GetWindow(otherWindow, GW_HWNDPREV),
-                 0, 0, 0, 0,
+  ::SetWindowPos(GetAcceleratedWidget(), GetWindow(otherWindow, GW_HWNDPREV), 0,
+                 0, 0, 0,
                  SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
 #elif defined(USE_X11)
   if (!IsWindowValid(id.id))

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -654,10 +654,8 @@ bool NativeWindowViews::MoveAbove(const std::string& sourceId) {
   if (!::IsWindow(otherWindow))
     return false;
 
-  gfx::Point pos = GetPosition();
-  gfx::Size size = GetSize();
-  ::SetWindowPos(GetAcceleratedWidget(), otherWindow, pos.x(), pos.y(),
-                 size.width(), size.height(),
+  ::SetWindowPos(GetAcceleratedWidget(), GetWindow(otherWindow, GW_HWNDPREV),
+                 0, 0, 0, 0,
                  SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
 #elif defined(USE_X11)
   if (!IsWindowValid(id.id))


### PR DESCRIPTION
#### Description of Change

The current logic for `BrowserWindow`'s `moveAbove` is broken on Windows systems. It'll always set the window behind the referenced one, working like a *moveBehind*.

The documentation for [setWindowPos](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowpos) second argument `hWndInsertAfter` is a bit confusing...

> A handle to the window to precede the positioned window in the Z order. This parameter must be a window handle or one of the following values.

Since Windows refers to the Z order from low to high it means that the window provided as reference will always _precede_ the electron window, which is the opposite of what we want in this function, since the electron window is displayed behind the referenced window.

The change is simply to ask `SetWindowPos` to position our window *behind* the window that's *above* the reference window, effectively making our window sit just above the reference one.

Demo repo can be found at https://github.com/drslump/electron-quick-start/tree/moveAbove-windows-bug.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fixed BrowserWindow.moveAbove on Windows
