### PR TITLE
fix: print from PDF viewer not working

### DIFF
--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -247,6 +247,8 @@ static_library("chrome") {
       "//chrome/renderer/extensions/extension_hooks_delegate.h",
       "//chrome/renderer/extensions/tabs_hooks_delegate.cc",
       "//chrome/renderer/extensions/tabs_hooks_delegate.h",
+      "//chrome/renderer/pepper/chrome_pdf_print_client.cc",
+      "//chrome/renderer/pepper/chrome_pdf_print_client.h",
     ]
   }
 }

--- a/shell/browser/extensions/api/resources_private/resources_private_api.cc
+++ b/shell/browser/extensions/api/resources_private/resources_private_api.cc
@@ -69,10 +69,7 @@ void AddAdditionalDataForPdf(base::DictionaryValue* dict) {
   dict->SetKey("pdfAnnotationsEnabled",
                base::Value(base::FeatureList::IsEnabled(
                    chrome_pdf::features::kPDFAnnotations)));
-
-  // TODO(nornagon): enable printing once it works.
-  bool enable_printing = false;
-  dict->SetKey("printingEnabled", base::Value(enable_printing));
+  dict->SetKey("printingEnabled", base::Value(true));
 #endif  // BUILDFLAG(ENABLE_PDF)
 }
 

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -68,6 +68,7 @@
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 #include "base/strings/utf_string_conversions.h"
+#include "chrome/renderer/pepper/chrome_pdf_print_client.h"
 #include "content/public/common/webplugininfo.h"
 #include "extensions/common/constants.h"
 #include "extensions/common/extensions_client.h"
@@ -160,6 +161,9 @@ void RendererClientBase::RenderThreadStarted() {
 
   extensions_renderer_client_.reset(new ElectronExtensionsRendererClient);
   extensions::ExtensionsRendererClient::Set(extensions_renderer_client_.get());
+
+  // Enables printing from Chrome PDF viewer.
+  pdf::PepperPDFHost::SetPrintClient(new ChromePDFPrintClient());
 
   thread->AddObserver(extensions_renderer_client_->GetDispatcher());
 #endif


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/22760.

See that PR for details.

Notes: Fixed the print button functionality in the PDF viewer extension.