### PR TITLE
docs: update versioning doc for new major-x-y format

### DIFF
--- a/docs/tutorial/electron-versioning.md
+++ b/docs/tutorial/electron-versioning.md
@@ -57,7 +57,7 @@ Stabilization branches are branches that run parallel to master, taking in only 
 
 ![](../images/versioning-sketch-1.png)
 
-Stabilization branches are always either **major** or **minor** version lines, and named against the following template `$MAJOR-$MINOR-x` e.g. `2-0-x`.
+Since Electron 8, stabilization branches are always **major** version lines, and named against the following template `$MAJOR-x-y` e.g. `8-x-y`.  Prior to that we used **minor** version lines and named them as `$MAJOR-$MINOR-x` e.g. `2-0-x`
 
 We allow for multiple stabilization branches to exist simultaneously, and intend to support at least two in parallel at all times, backporting security fixes as necessary.
 ![](../images/versioning-sketch-2.png)


### PR DESCRIPTION
It was pointed out that this is out of date

Notes: no-notes