### PR TITLE
build: fix crashpad+asan

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -757,6 +757,12 @@ if (is_mac) {
     outputs = [ "{{bundle_resources_dir}}/{{source_file_part}}" ]
 
     public_deps = [ "//third_party/crashpad/crashpad/handler:crashpad_handler" ]
+
+    if (is_asan) {
+      # crashpad_handler requires the ASan runtime at its @executable_path.
+      sources += [ "$root_out_dir/libclang_rt.asan_osx_dynamic.dylib" ]
+      public_deps += [ "//build/config/sanitizers:copy_asan_runtime" ]
+    }
   }
 
   mac_framework_bundle("electron_framework") {


### PR DESCRIPTION
#### Description of Change
This fixes an issue where the crashpad reporter wouldn't start when building with asan, due to not being able to find the asan dylib, e.g.

```
dyld: Library not loaded: @executable_path/libclang_rt.asan_osx_dynamic.dylib
  Referenced from: /Users/nornagon/work/electron-gn/src/out/Testing/Electron.app/Contents/Frameworks/Electron Framework.framework/Resources/crashpad_handler
  Reason: image not found
```

This would manifest when running an app as a log message when starting the crashpad handler:

```
[85013:0420/143027.954855:ERROR:file_io.cc(89)] ReadExactly: expected 8, observed 0
```

This snippet is copied from [`//chrome/BUILD.gn:675`](https://chromium.googlesource.com/chromium/src/+/3bdd2420941cba3c4754923d842e44c9b30a1960/chrome/BUILD.gn#675).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none