### PR TITLE
fix: heap-use-after-free in tray.popUpContextMenu

### DIFF
--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -173,8 +173,16 @@
                             useDefaultAccelerator:NO]);
     // Hacky way to mimic design of ordinary tray menu.
     [statusItem_ setMenu:[menuController menu]];
+    // -performClick: is a blocking call, which will run the task loop inside
+    // itself. This can potentially include running JS, which can result in
+    // this object being released. We take a temporary reference here to make
+    // sure we stay alive long enough to successfully return from this
+    // function.
+    // TODO(nornagon/codebytere): Avoid nesting task loops here.
+    [self retain];
     [[statusItem_ button] performClick:self];
     [statusItem_ setMenu:[menuController_ menu]];
+    [self release];
     return;
   }
 

--- a/spec-main/api-tray-spec.ts
+++ b/spec-main/api-tray-spec.ts
@@ -51,6 +51,13 @@ describe('tray module', () => {
       })
       tray.popUpContextMenu()
     })
+
+    it('can be called with a menu', () => {
+      const menu = Menu.buildFromTemplate([{ label: 'Test' }])
+      expect(() => {
+        tray.popUpContextMenu(menu)
+      }).to.not.throw()
+    })
   })
 
   describe('tray.getBounds()', () => {


### PR DESCRIPTION
Backport of #22842. See that change for details

Notes: Fixed a use-after-free error that could happen if a Tray was destroyed while showing a custom context menu.