### PR TITLE
fix: block custom window.open when nativeWindowOpen is true

### DIFF
--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -219,6 +219,12 @@ const canAccessWindow = function (sender, target) {
 
 // Routed window.open messages with raw options
 ipcMainInternal.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', (event, url, frameName, features) => {
+  // This should only be allowed for senders that have nativeWindowOpen: false
+  const webPreferences = event.sender.getLastWebPreferences();
+  if (webPreferences.nativeWindowOpen || webPreferences.sandbox) {
+    event.returnValue = null;
+    throw new Error('GUEST_WINDOW_MANAGER_WINDOW_OPEN denied: expected native window.open');
+  }
   if (url == null || url === '') url = 'about:blank';
   if (frameName == null) frameName = '';
   if (features == null) features = '';

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -654,6 +654,34 @@ describe('chromium features', () => {
       const [, window] = await emittedOnce(app, 'browser-window-created');
       expect(window.getTitle()).to.equal('__proto__');
     });
+
+    it('denies custom open when nativeWindowOpen: true', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          contextIsolation: false,
+          nodeIntegration: true,
+          nativeWindowOpen: true
+        }
+      });
+      w.loadURL('about:blank');
+
+      const previousListeners = process.listeners('uncaughtException');
+      process.removeAllListeners('uncaughtException');
+      try {
+        const uncaughtException = new Promise<Error>(resolve => {
+          process.once('uncaughtException', resolve);
+        });
+        expect(await w.webContents.executeJavaScript(`(${function () {
+          const ipc = process.electronBinding('ipc').ipc;
+          return ipc.sendSync(true, 'ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', ['', '', ''])[0];
+        }})()`)).to.be.null();
+        const exception = await uncaughtException;
+        expect(exception.message).to.match(/denied: expected native window\.open/);
+      } finally {
+        previousListeners.forEach(l => process.on('uncaughtException', l));
+      }
+    });
   });
 
   describe('window.opener', () => {


### PR DESCRIPTION
#### Description of Change
This prevents windows that have `nativeWindowOpen: true` (or `sandbox: true` which implies it) from being able to use the `ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN` ipc event, which handles non-native window.open calls.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
