### PR TITLE
fix: set default menu in will-finish-launching event

### DIFF
--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -207,10 +207,9 @@ const { setDefaultApplicationMenu } = require('@electron/internal/browser/defaul
 
 // Create default menu.
 //
-// Note that the task must be added before loading any app, so we can make sure
-// the call is maded before any user window is created, otherwise the default
-// menu may show even when user explicitly hides the menu.
-app.whenReady().then(setDefaultApplicationMenu);
+// The |will-finish-launching| event is emitted before |ready| event, so default
+// menu is set before any user window is created.
+app.once('will-finish-launching', setDefaultApplicationMenu);
 
 if (packagePath) {
   // Finally load app's main.js and transfer control to C++.

--- a/spec-main/fixtures/api/test-menu-visibility/main.js
+++ b/spec-main/fixtures/api/test-menu-visibility/main.js
@@ -1,7 +1,10 @@
 const { app, BrowserWindow } = require('electron');
 
 let win;
-app.whenReady().then(function () {
+// This test uses "app.once('ready')" while the |test-menu-null| test uses
+// "app.whenReady()", the 2 APIs have slight difference on timing to cover
+// more cases.
+app.once('ready', function () {
   win = new BrowserWindow({});
   win.setMenuBarVisibility(false);
 


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/23026, which was regressed due to `setDefaultApplicationMenu` being changed to use `whenReady`. When user uses `ready` event directly, their callback would be called before `setDefaultApplicationMenu()` and the default menu would override their menu settings.

It is hard to ensure the `setDefaultApplicationMenu` is called before user's `ready` callbacks, especially when promises are involved. However we can use the `will-finish-launching` event which is guaranteed to be called before the `ready` event, and we have explicitly documented that users should only create window after the `ready` event.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix `win.setMenuBarVisibility(false)` not hiding menu bar.