### PR TITLE
fix: block custom window.open when nativeWindowOpen is true (#23188)

### DIFF
--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -188,6 +188,14 @@ const canAccessWindow = function (sender, target) {
 
 // Routed window.open messages with raw options
 ipcMainInternal.on('ELECTRON_GUEST_WINDOW_MANAGER_WINDOW_OPEN', (event, url, frameName, features) => {
+  // This should only be allowed for senders that have nativeWindowOpen: false
+  {
+    const webPreferences = event.sender.getLastWebPreferences();
+    if (webPreferences.nativeWindowOpen || webPreferences.sandbox) {
+      event.returnValue = null;
+      throw new Error('GUEST_WINDOW_MANAGER_WINDOW_OPEN denied: expected native window.open');
+    }
+  }
   if (url == null || url === '') url = 'about:blank';
   if (frameName == null) frameName = '';
   if (features == null) features = '';


### PR DESCRIPTION
Backport of #23188.

Notes: Fixed an issue where windows without `nativeWindowOpen: true` could invoke the non-native-open path.