### PR TITLE
fix: do not allow child windows to specify their own preload script

### DIFF
--- a/lib/common/parse-features-string.ts
+++ b/lib/common/parse-features-string.ts
@@ -75,7 +75,7 @@ export function parseWebViewWebPreferences (preferences: string) {
   return parseCommaSeparatedKeyValue(preferences, false).parsed;
 }
 
-const allowedWebPreferences = ['zoomFactor', 'nodeIntegration', 'enableRemoteModule', 'preload', 'javascript', 'contextIsolation', 'webviewTag'] as const;
+const allowedWebPreferences = ['zoomFactor', 'nodeIntegration', 'enableRemoteModule', 'javascript', 'contextIsolation', 'webviewTag'] as const;
 type AllowedWebPreference = (typeof allowedWebPreferences)[number];
 
 /**


### PR DESCRIPTION
This is a potential path for escalation.  There is no reason for a renderer to be able to choose it's own preload script.

Notes: no-notes