### PR TITLE
fix: do not mutate ipc instances across contexts

### DIFF
--- a/lib/renderer/api/ipc-renderer.ts
+++ b/lib/renderer/api/ipc-renderer.ts
@@ -5,32 +5,35 @@ const v8Util = process.electronBinding('v8_util');
 const ipcRenderer = v8Util.getHiddenValue<Electron.IpcRenderer>(global, 'ipc');
 const internal = false;
 
-ipcRenderer.send = function (channel, ...args) {
-  return ipc.send(internal, channel, args);
-};
+// TODO(MarshallOfSound): Remove if statement when isolated_bundle and content_script_bundle are gone
+if (!ipcRenderer.send) {
+  ipcRenderer.send = function (channel, ...args) {
+    return ipc.send(internal, channel, args);
+  };
 
-ipcRenderer.sendSync = function (channel, ...args) {
-  return ipc.sendSync(internal, channel, args)[0];
-};
+  ipcRenderer.sendSync = function (channel, ...args) {
+    return ipc.sendSync(internal, channel, args)[0];
+  };
 
-ipcRenderer.sendToHost = function (channel, ...args) {
-  return ipc.sendToHost(channel, args);
-};
+  ipcRenderer.sendToHost = function (channel, ...args) {
+    return ipc.sendToHost(channel, args);
+  };
 
-ipcRenderer.sendTo = function (webContentsId, channel, ...args) {
-  return ipc.sendTo(internal, false, webContentsId, channel, args);
-};
+  ipcRenderer.sendTo = function (webContentsId, channel, ...args) {
+    return ipc.sendTo(internal, false, webContentsId, channel, args);
+  };
 
-ipcRenderer.invoke = async function (channel, ...args) {
-  const { error, result } = await ipc.invoke(internal, channel, args);
-  if (error) {
-    throw new Error(`Error invoking remote method '${channel}': ${error}`);
-  }
-  return result;
-};
+  ipcRenderer.invoke = async function (channel, ...args) {
+    const { error, result } = await ipc.invoke(internal, channel, args);
+    if (error) {
+      throw new Error(`Error invoking remote method '${channel}': ${error}`);
+    }
+    return result;
+  };
 
-ipcRenderer.postMessage = function (channel: string, message: any, transferables: any) {
-  return ipc.postMessage(channel, message, transferables);
-};
+  ipcRenderer.postMessage = function (channel: string, message: any, transferables: any) {
+    return ipc.postMessage(channel, message, transferables);
+  };
+}
 
 export default ipcRenderer;

--- a/lib/renderer/ipc-renderer-internal.ts
+++ b/lib/renderer/ipc-renderer-internal.ts
@@ -5,26 +5,29 @@ const v8Util = process.electronBinding('v8_util');
 export const ipcRendererInternal = v8Util.getHiddenValue<Electron.IpcRendererInternal>(global, 'ipc-internal');
 const internal = true;
 
-ipcRendererInternal.send = function (channel, ...args) {
-  return ipc.send(internal, channel, args);
-};
+// TODO(MarshallOfSound): Remove if statement when isolated_bundle and content_script_bundle are gone
+if (!ipcRendererInternal.send) {
+  ipcRendererInternal.send = function (channel, ...args) {
+    return ipc.send(internal, channel, args);
+  };
 
-ipcRendererInternal.sendSync = function (channel, ...args) {
-  return ipc.sendSync(internal, channel, args)[0];
-};
+  ipcRendererInternal.sendSync = function (channel, ...args) {
+    return ipc.sendSync(internal, channel, args)[0];
+  };
 
-ipcRendererInternal.sendTo = function (webContentsId, channel, ...args) {
-  return ipc.sendTo(internal, false, webContentsId, channel, args);
-};
+  ipcRendererInternal.sendTo = function (webContentsId, channel, ...args) {
+    return ipc.sendTo(internal, false, webContentsId, channel, args);
+  };
 
-ipcRendererInternal.sendToAll = function (webContentsId, channel, ...args) {
-  return ipc.sendTo(internal, true, webContentsId, channel, args);
-};
+  ipcRendererInternal.sendToAll = function (webContentsId, channel, ...args) {
+    return ipc.sendTo(internal, true, webContentsId, channel, args);
+  };
 
-ipcRendererInternal.invoke = async function<T> (channel: string, ...args: any[]) {
-  const { error, result } = await ipc.invoke<T>(internal, channel, args);
-  if (error) {
-    throw new Error(`Error invoking remote method '${channel}': ${error}`);
-  }
-  return result;
-};
+  ipcRendererInternal.invoke = async function<T> (channel: string, ...args: any[]) {
+    const { error, result } = await ipc.invoke<T>(internal, channel, args);
+    if (error) {
+      throw new Error(`Error invoking remote method '${channel}': ${error}`);
+    }
+    return result;
+  };
+}


### PR DESCRIPTION
IPC is shared across contexts sometimes, this stops us mutating IPC instances that have already been initialized in another context.  This can be removed once `content_script` and `isolated_init` have been completely removed

Notes: no-notes