### PR TITLE
Using SetExcludedWindow in setContentProtection

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1686,9 +1686,10 @@ All mouse events happened in this window will be passed to the window below
 this window, but if this window has focus, it will still receive keyboard
 events.
 
-#### `win.setContentProtection(enable)` _macOS_ _Windows_
+#### `win.setContentProtection(enable, sourceId)` _macOS_ _Windows_
 
 * `enable` Boolean
+* `sourceId` String - Window id in the format of DesktopCapturerSource's id. For example "window:1869:0".
 
 Prevents the window contents from being captured by other apps.
 

--- a/shell/browser/api/electron_api_top_level_window.cc
+++ b/shell/browser/api/electron_api_top_level_window.cc
@@ -674,8 +674,8 @@ void TopLevelWindow::SetIgnoreMouseEvents(bool ignore,
   return window_->SetIgnoreMouseEvents(ignore, forward);
 }
 
-void TopLevelWindow::SetContentProtection(bool enable) {
-  return window_->SetContentProtection(enable);
+void TopLevelWindow::SetContentProtection(bool enable, const std::string& sourceId) {
+  return window_->SetContentProtection(enable, sourceId);
 }
 
 void TopLevelWindow::SetFocusable(bool focusable) {

--- a/shell/browser/api/electron_api_top_level_window.h
+++ b/shell/browser/api/electron_api_top_level_window.h
@@ -166,7 +166,7 @@ class TopLevelWindow : public gin_helper::TrackableObject<TopLevelWindow>,
   void SetDocumentEdited(bool edited);
   bool IsDocumentEdited();
   void SetIgnoreMouseEvents(bool ignore, gin_helper::Arguments* args);
-  void SetContentProtection(bool enable);
+  void SetContentProtection(bool enable, const std::string& sourceId);
   void SetFocusable(bool focusable);
   void SetMenu(v8::Isolate* isolate, v8::Local<v8::Value> menu);
   void RemoveMenu();

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -159,7 +159,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetDocumentEdited(bool edited);
   virtual bool IsDocumentEdited();
   virtual void SetIgnoreMouseEvents(bool ignore, bool forward) = 0;
-  virtual void SetContentProtection(bool enable) = 0;
+  virtual void SetContentProtection(bool enable, const std::string& sourceId) = 0;
   virtual void SetFocusable(bool focusable);
   virtual void SetMenu(ElectronMenuModel* menu);
   virtual void SetParentWindow(NativeWindow* parent);

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -104,7 +104,7 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
   void SetDocumentEdited(bool edited) override;
   bool IsDocumentEdited() override;
   void SetIgnoreMouseEvents(bool ignore, bool forward) override;
-  void SetContentProtection(bool enable) override;
+  void SetContentProtection(bool enable, const std::string& sourceId) override;
   void SetFocusable(bool focusable) override;
   void AddBrowserView(NativeBrowserView* browser_view) override;
   void RemoveBrowserView(NativeBrowserView* browser_view) override;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1230,7 +1230,14 @@ void NativeWindowMac::SetIgnoreMouseEvents(bool ignore, bool forward) {
   }
 }
 
-void NativeWindowMac::SetContentProtection(bool enable) {
+void NativeWindowMac::SetContentProtection(bool enable, const std::string& sourceId) {
+  const content::DesktopMediaID id = content::DesktopMediaID::Parse(sourceId);
+  if (id.type != content::DesktopMediaID::TYPE_WINDOW)
+    return false;
+
+  // Check if the window source is valid.
+  const CGWindowID window_id = id.id;
+  webrtc::DesktopCapturer::SetExcludedWindow(window_id);
   [window_
       setSharingType:enable ? NSWindowSharingNone : NSWindowSharingReadOnly];
 }

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -964,7 +964,7 @@ void NativeWindowViews::SetIgnoreMouseEvents(bool ignore, bool forward) {
 #endif
 }
 
-void NativeWindowViews::SetContentProtection(bool enable) {
+void NativeWindowViews::SetContentProtection(bool enable, const std::string& sourceId) {
 #if defined(OS_WIN)
   DWORD affinity = enable ? WDA_MONITOR : WDA_NONE;
   ::SetWindowDisplayAffinity(GetAcceleratedWidget(), affinity);

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -107,7 +107,7 @@ class NativeWindowViews : public NativeWindow,
   void SetOpacity(const double opacity) override;
   double GetOpacity() override;
   void SetIgnoreMouseEvents(bool ignore, bool forward) override;
-  void SetContentProtection(bool enable) override;
+  void SetContentProtection(bool enable, const std::string& sourceId) override;
   void SetFocusable(bool focusable) override;
   void SetMenu(ElectronMenuModel* menu_model) override;
   void AddBrowserView(NativeBrowserView* browser_view) override;


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->

The new webrtc capturer doesn't respect NSWindowSharingNone
https://bugs.chromium.org/p/webrtc/issues/detail?id=8652#c45

Trying to use webrtc::DesktopCapturer::SetExcludedWindow instead as suggested.