### PR TITLE
fix: isolate callbacks in node_bindings

### DIFF
--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -164,7 +164,7 @@ int NodeMain(int argc, char* argv[]) {
                                     exec_argc, exec_argv);
       CHECK_NE(nullptr, env);
 
-      // TODO(codebytere): we shouldn't have to call this - upstream?
+      // This needs to be called before the inspector is initialized.
       env->InitializeDiagnostics();
 
       // This is needed in order to enable v8 host weakref hooks.

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -219,6 +219,23 @@ void SetNodeOptions(base::Environment* env) {
   }
 }
 
+void HostCleanupFinalizationGroupCallback(
+    v8::Local<v8::Context> context,
+    v8::Local<v8::FinalizationGroup> group) {
+  node::Environment* env = node::Environment::GetCurrent(context);
+  if (env == nullptr) {
+    return;
+  }
+  env->RegisterFinalizationGroupForCleanup(group);
+}
+
+bool AllowWasmCodeGenerationCallback(v8::Local<v8::Context> context,
+                                     v8::Local<v8::String>) {
+  v8::Local<v8::Value> wasm_code_gen = context->GetEmbedderData(
+      node::ContextEmbedderIndex::kAllowWasmCodeGeneration);
+  return wasm_code_gen->IsUndefined() || wasm_code_gen->IsTrue();
+}
+
 }  // namespace
 
 namespace electron {
@@ -394,14 +411,32 @@ node::Environment* NodeBindings::CreateEnvironment(
   }
 
   if (browser_env_ == BrowserEnvironment::BROWSER) {
-    // SetAutorunMicrotasks is no longer called in node::CreateEnvironment
-    // so instead call it here to match expected node behavior
+    // This policy ensures microtask checkpoints are explicitly invoked.
     context->GetIsolate()->SetMicrotasksPolicy(v8::MicrotasksPolicy::kExplicit);
   } else {
-    // Node uses the deprecated SetAutorunMicrotasks(false) mode, we should
-    // switch to use the scoped policy to match blink's behavior.
+    // Match Blink's behavior by allowing microtasks invocation to be controlled
+    // by MicrotasksScope objects.
     context->GetIsolate()->SetMicrotasksPolicy(v8::MicrotasksPolicy::kScoped);
   }
+
+  // This needs to be called before the inspector is initialized.
+  env->InitializeDiagnostics();
+
+  // Ensure that WeakRefs work properly by specifying the callback to be called
+  // when FinalizationRegistries are ready to be cleaned up and require
+  // FinalizationGroup::Cleanup() to be called in a future task.
+  context->GetIsolate()->SetHostCleanupFinalizationGroupCallback(
+      HostCleanupFinalizationGroupCallback);
+
+  // Set the callback to invoke to check if wasm code generation should be
+  // allowed.
+  context->GetIsolate()->SetAllowWasmCodeGenerationCallback(
+      AllowWasmCodeGenerationCallback);
+
+  // Generate more detailed source positions to code objects. This results in
+  // better results when mapping profiling samples to script source.
+  v8::CpuProfiler::UseDetailedSourcePositionsForProfiling(
+      context->GetIsolate());
 
   gin_helper::Dictionary process(context->GetIsolate(), env->process_object());
   process.SetReadOnly("type", process_type);

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -411,7 +411,8 @@ node::Environment* NodeBindings::CreateEnvironment(
   }
 
   if (browser_env_ == BrowserEnvironment::BROWSER) {
-    // This policy ensures microtask checkpoints are explicitly invoked.
+    // This policy requires that microtask checkpoints be explicitly invoked.
+    // Node.js requires this.
     context->GetIsolate()->SetMicrotasksPolicy(v8::MicrotasksPolicy::kExplicit);
   } else {
     // Match Blink's behavior by allowing microtasks invocation to be controlled


### PR DESCRIPTION
#### Description of Change

While some aspects of embedding are necessarily different between emulated Node.js and Node.js as it's embedded in the main and renderer processes of Electron, there's been some skew recently in our embedding processes resultant of the fact that we only test some of Node's functionality in emulated mode and therefore miss potential holes in non-emulated mode.

In the future, we should seek to test these more effectively, but for now we should at least close that gap by ensuring that isolate setup is better executed in non-emulated mode. There remains some work to be done here around `async_hooks` (see https://github.com/electron/electron/pull/23213) but that will require a little more investigation to determine what of `SetupIsolateForNode` can be safely executed in a non-emulated environment without causing collateral damage.

cc @nornagon @ckerr @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed some Wasm and diagnostics issues in main and renderer process execution of Node.js
