### PR TITLE
style: use build/include_directory for NOLINT

### DIFF
--- a/shell/app/electron_content_client.cc
+++ b/shell/app/electron_content_client.cc
@@ -25,7 +25,7 @@
 #include "ui/base/resource/resource_bundle.h"
 #include "url/url_constants.h"
 // In SHARED_INTERMEDIATE_DIR.
-#include "widevine_cdm_version.h"  // NOLINT(build/include)
+#include "widevine_cdm_version.h"  // NOLINT(build/include_directory)
 
 #if defined(WIDEVINE_CDM_AVAILABLE)
 #include "base/native_library.h"

--- a/shell/app/uv_task_runner.h
+++ b/shell/app/uv_task_runner.h
@@ -10,7 +10,7 @@
 #include "base/callback.h"
 #include "base/location.h"
 #include "base/single_thread_task_runner.h"
-#include "uv.h"  // NOLINT(build/include)
+#include "uv.h"  // NOLINT(build/include_directory)
 
 namespace electron {
 

--- a/shell/browser/javascript_environment.h
+++ b/shell/browser/javascript_environment.h
@@ -9,7 +9,7 @@
 
 #include "base/macros.h"
 #include "gin/public/isolate_holder.h"
-#include "uv.h"  // NOLINT(build/include)
+#include "uv.h"  // NOLINT(build/include_directory)
 
 namespace node {
 class Environment;

--- a/shell/common/api/electron_bindings.h
+++ b/shell/common/api/electron_bindings.h
@@ -14,7 +14,7 @@
 #include "base/process/process_metrics.h"
 #include "base/strings/string16.h"
 #include "shell/common/gin_helper/promise.h"
-#include "uv.h"  // NOLINT(build/include)
+#include "uv.h"  // NOLINT(build/include_directory)
 
 namespace gin_helper {
 class Arguments;

--- a/shell/common/electron_command_line.cc
+++ b/shell/common/electron_command_line.cc
@@ -5,7 +5,7 @@
 #include "shell/common/electron_command_line.h"
 
 #include "base/command_line.h"
-#include "uv.h"  // NOLINT(build/include)
+#include "uv.h"  // NOLINT(build/include_directory)
 
 namespace electron {
 

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -9,7 +9,7 @@
 #include "base/macros.h"
 #include "base/memory/weak_ptr.h"
 #include "base/single_thread_task_runner.h"
-#include "uv.h"  // NOLINT(build/include)
+#include "uv.h"  // NOLINT(build/include_directory)
 #include "v8/include/v8.h"
 
 namespace base {

--- a/shell/renderer/renderer_client_base.h
+++ b/shell/renderer/renderer_client_base.h
@@ -13,7 +13,7 @@
 #include "electron/buildflags/buildflags.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 // In SHARED_INTERMEDIATE_DIR.
-#include "widevine_cdm_version.h"  // NOLINT(build/include)
+#include "widevine_cdm_version.h"  // NOLINT(build/include_directory)
 
 #if defined(WIDEVINE_CDM_AVAILABLE)
 #include "chrome/renderer/media/chrome_key_systems_provider.h"  // nogncheck


### PR DESCRIPTION
#### Description of Change

build/include linter was splitted to build/include_directory at depot_tools upstream.
Fixing PR `lint` check failure. (seen here: https://github.com/electron/electron/runs/614050973 https://github.com/electron/electron/pull/23247)

https://crrev.com/c/2159690
https://crbug.com/1073191

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none