### PR TITLE
feat: add text zoom factor method on webcontents and webframe

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1079,6 +1079,15 @@ The factor must be greater than 0.0.
 
 Returns `Number` - the current zoom factor.
 
+#### `contents.setTextZoomFactor(factor)`
+
+* `factor` Double - Text Zoom factor; default is 1.0.
+
+Changes the text zoom factor to the specified factor. Text Zoom factor is only
+text zoom percent divided by 100, so 300% = 3.0.
+
+The factor must be greater than 0.0.
+
 **[Deprecated](modernization/property-updates.md)**
 
 #### `contents.setZoomLevel(level)`

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -33,6 +33,20 @@ The factor must be greater than 0.0.
 
 Returns `Number` - The current zoom factor.
 
+### `webFrame.setTextZoomFactor(factor)`
+
+* `factor` Double - Text Zoom factor; default is 1.0.
+
+Changes the text zoom factor to the specified factor.Text Zoom factor is
+only text zoom percent divided by 100, so 300% = 3.0.
+
+The factor must be greater than 0.0.
+
+
+### `webFrame.getTextZoomFactor()`
+
+Returns `Number` - The current text zoom factor.
+
 ### `webFrame.setZoomLevel(level)`
 
 * `level` Number - Zoom level.

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -176,7 +176,8 @@ const webFrameMethods = [
   'insertText',
   'removeInsertedCSS',
   'setLayoutZoomLevelLimits',
-  'setVisualZoomLevelLimits'
+  'setVisualZoomLevelLimits',
+  'setTextZoomFactor'
 ];
 
 for (const method of webFrameMethods) {

--- a/shell/renderer/api/atom_api_web_frame.cc
+++ b/shell/renderer/api/atom_api_web_frame.cc
@@ -262,8 +262,25 @@ void SetZoomFactor(mate::Arguments* args,
   SetZoomLevel(window, blink::WebView::ZoomFactorToZoomLevel(factor));
 }
 
+void SetTextZoomFactor(mate::Arguments* args,
+                       v8::Local<v8::Value> window,
+                       double factor) {
+  if (factor < std::numeric_limits<double>::epsilon()) {
+    args->ThrowError("'textZoomFactor' must be a double greater than 0.0");
+    return;
+  }
+
+  blink::WebFrame* web_frame = GetRenderFrame(window)->GetWebFrame();
+  web_frame->View()->SetTextZoomFactor(factor);
+}
+
 double GetZoomFactor(v8::Local<v8::Value> window) {
   return blink::WebView::ZoomLevelToZoomFactor(GetZoomLevel(window));
+}
+
+double GetTextZoomFactor(v8::Local<v8::Value> window) {
+  blink::WebFrame* web_frame = GetRenderFrame(window)->GetWebFrame();
+  return web_frame->View()->TextZoomFactor();
 }
 
 void SetVisualZoomLevelLimits(v8::Local<v8::Value> window,
@@ -584,6 +601,8 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("setZoomLevel", &SetZoomLevel);
   dict.SetMethod("getZoomLevel", &GetZoomLevel);
   dict.SetMethod("setZoomFactor", &SetZoomFactor);
+  dict.SetMethod("setTextZoomFactor", &SetTextZoomFactor);
+  dict.SetMethod("getTextZoomFactor", &GetTextZoomFactor);
   dict.SetMethod("getZoomFactor", &GetZoomFactor);
   dict.SetMethod("setVisualZoomLevelLimits", &SetVisualZoomLevelLimits);
   dict.SetMethod("setLayoutZoomLevelLimits", &SetLayoutZoomLevelLimits);

--- a/spec/api-web-contents-spec.js
+++ b/spec/api-web-contents-spec.js
@@ -577,6 +577,28 @@ describe('webContents module', () => {
     });
   });
 
+  describe('text zoom api', () => {
+    it('set text zoom factor in webcontents', (done) => {
+      const preload = path.join(fixtures, 'module', 'preload-contents-zoomtext.js');
+      w.destroy();
+      w = new BrowserWindow({
+        show: true,
+        webPreferences: {
+          preload
+        }
+      });
+      ipcMain.on('textZoomFactor', (event, textZoomFactor) => {
+        expect(textZoomFactor).to.eq(2);
+        done();
+      });
+      ipcMain.on('ready', event => {
+        w.webContents.setTextZoomFactor(2);
+        event.reply('getTextZoomFactor');
+      });
+      w.loadURL('about:blank');
+    });
+  });
+
   describe('zoom api', () => {
     const zoomScheme = remote.getGlobal('zoomScheme');
     const hostZoomMap = {

--- a/spec/fixtures/module/preload-contents-zoomtext.js
+++ b/spec/fixtures/module/preload-contents-zoomtext.js
@@ -1,0 +1,7 @@
+const { webFrame, ipcRenderer } = require('electron');
+
+ipcRenderer.send('ready');
+
+ipcRenderer.on('getTextZoomFactor', (event) => {
+  event.sender.send('textZoomFactor', webFrame.getTextZoomFactor());
+});

--- a/spec/fixtures/module/preload-textzoom.js
+++ b/spec/fixtures/module/preload-textzoom.js
@@ -1,0 +1,7 @@
+const { webFrame, ipcRenderer } = require('electron');
+const url = require('url');
+const { textZoom } = url.parse(window.location.href, true).query;
+
+webFrame.setTextZoomFactor(parseFloat(textZoom));
+
+ipcRenderer.send('initalTextZoomFactor', webFrame.getTextZoomFactor());

--- a/spec/fixtures/pages/webview-text-zoom-factor.html
+++ b/spec/fixtures/pages/webview-text-zoom-factor.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<webview nodeintegration src="about:blank?textZoom=2" preload="../module/preload-textzoom.js"/>
+</body>
+</html>

--- a/spec/ts-smoke/electron/renderer.ts
+++ b/spec/ts-smoke/electron/renderer.ts
@@ -53,6 +53,9 @@ remote.getCurrentWindow().capturePage().then(buf => {
 webFrame.setZoomFactor(2)
 console.log(webFrame.getZoomFactor())
 
+webFrame.setTextZoomFactor(2)
+console.log(webFrame.getTextZoomFactor())
+
 webFrame.setZoomLevel(200)
 console.log(webFrame.getZoomLevel())
 

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1515,6 +1515,22 @@ describe('<webview> tag', function () {
     generateSpecs('with sandbox', true);
   });
 
+  describe('text zoom behavior', () => {
+    it('enable text zoom in webview', async () => {
+      const w = await openTheWindow({
+        show: true,
+        webPreferences: {
+          webviewTag: true
+        }
+      });
+      const initalTextZoomEventPromise = emittedOnce(ipcMain, 'initalTextZoomFactor');
+      w.loadFile(path.join(fixtures, 'pages', 'webview-text-zoom-factor.html'));
+
+      const [, initalTextZoom] = await initalTextZoomEventPromise;
+      expect(initalTextZoom).to.equal(2);
+    });
+  });
+
   describe('zoom behavior', () => {
     const zoomScheme = remote.getGlobal('zoomScheme');
     const webviewSession = session.fromPartition('webview-temp');


### PR DESCRIPTION
#### Description of Change

I need to set the zoom ratio of the webframe globally to complete a font scaling requirement, similar to https://developer.android.com/reference/android/webkit/WebSettings#setTextZoom(int)

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: add text zoom api on webframe and webcontents
