### PR TITLE
feat: add text zoom factor method on webcontents and webframe

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1084,6 +1084,15 @@ The factor must be greater than 0.0.
 
 Returns `Number` - the current zoom factor.
 
+#### `contents.setTextZoomFactor(factor)`
+
+* `factor` Double - Text Zoom factor; default is 1.0.
+
+Changes the text zoom factor to the specified factor. Text Zoom factor is only
+text zoom percent divided by 100, so 300% = 3.0.
+
+The factor must be greater than 0.0.
+
 #### `contents.setZoomLevel(level)`
 
 * `level` Number - Zoom level.

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -33,6 +33,22 @@ The factor must be greater than 0.0.
 
 Returns `Number` - The current zoom factor.
 
+
+### `webFrame.setTextZoomFactor(factor)`
+
+* `factor` Double - Text Zoom factor; default is 1.0.
+
+Changes the text zoom factor to the specified factor.Text Zoom factor is
+only text zoom percent divided by 100, so 300% = 3.0.
+
+The factor must be greater than 0.0.
+
+
+### `webFrame.getTextZoomFactor()`
+
+Returns `Number` - The current text zoom factor.
+
+
 ### `webFrame.setZoomLevel(level)`
 
 * `level` Number - Zoom level.

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -185,7 +185,8 @@ const webFrameMethods = [
   'insertCSS',
   'insertText',
   'removeInsertedCSS',
-  'setVisualZoomLevelLimits'
+  'setVisualZoomLevelLimits',
+  'setTextZoomFactor'
 ];
 
 for (const method of webFrameMethods) {

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -305,10 +305,27 @@ void SetZoomFactor(gin_helper::ErrorThrower thrower,
   SetZoomLevel(thrower, window, blink::PageZoomFactorToZoomLevel(factor));
 }
 
+void SetTextZoomFactor(mate::Arguments* args,
+                       v8::Local<v8::Value> window,
+                       double factor) {
+  if (factor < std::numeric_limits<double>::epsilon()) {
+    args->ThrowError("'textZoomFactor' must be a double greater than 0.0");
+    return;
+  }
+
+  blink::WebFrame* web_frame = GetRenderFrame(window)->GetWebFrame();
+  web_frame->View()->SetTextZoomFactor(factor);
+}
+
 double GetZoomFactor(gin_helper::ErrorThrower thrower,
                      v8::Local<v8::Value> window) {
   double zoom_level = GetZoomLevel(thrower, window);
   return blink::PageZoomLevelToZoomFactor(zoom_level);
+}
+
+double GetTextZoomFactor(v8::Local<v8::Value> window) {
+  blink::WebFrame* web_frame = GetRenderFrame(window)->GetWebFrame();
+  return web_frame->View()->TextZoomFactor();
 }
 
 void SetVisualZoomLevelLimits(gin_helper::ErrorThrower thrower,
@@ -746,6 +763,8 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("getZoomLevel", &GetZoomLevel);
   dict.SetMethod("setZoomFactor", &SetZoomFactor);
   dict.SetMethod("getZoomFactor", &GetZoomFactor);
+  dict.SetMethod("setTextZoomFactor", &SetTextZoomFactor);
+  dict.SetMethod("getTextZoomFactor", &GetTextZoomFactor);
   dict.SetMethod("setVisualZoomLevelLimits", &SetVisualZoomLevelLimits);
   dict.SetMethod("allowGuestViewElementDefinition",
                  &AllowGuestViewElementDefinition);

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -818,6 +818,26 @@ describe('webContents module', () => {
       expect(w.webContents.audioMuted).to.be.false();
     });
   });
+  describe('text zoom api', () => {
+    it('set text zoom factor in webcontents', (done) => {
+      const preload = path.join(fixturesPath, 'module', 'preload-contents-zoomtext.js');
+      const w = new BrowserWindow({
+        show: true,
+        webPreferences: {
+          preload
+        }
+      });
+      ipcMain.on('textZoomFactor', (event, textZoomFactor) => {
+        expect(textZoomFactor).to.eq(2);
+        done();
+      });
+      ipcMain.on('ready', (event) => {
+        w.webContents.setTextZoomFactor(2);
+        event.reply('getTextZoomFactor');
+      });
+      w.loadURL('about:blank');
+    });
+  });
 
   describe('zoom api', () => {
     const scheme = (global as any).standardScheme;

--- a/spec-main/webview-spec.ts
+++ b/spec-main/webview-spec.ts
@@ -196,6 +196,22 @@ describe('<webview> tag', function () {
     expect(tabId).to.equal(childWebContentsId);
   });
 
+  describe('text zoom behavior', () => {
+    it('enable text zoom in webview', async () => {
+      const w = new BrowserWindow({
+        show: true,
+        webPreferences: {
+          webviewTag: true
+        }
+      });
+      const initalTextZoomEventPromise = emittedOnce(ipcMain, 'initalTextZoomFactor');
+      w.loadFile(path.join(fixtures, 'pages', 'webview-text-zoom-factor.html'));
+
+      const [, initalTextZoom] = await initalTextZoomEventPromise;
+      expect(initalTextZoom).to.equal(2);
+    });
+  });
+
   describe('zoom behavior', () => {
     const zoomScheme = standardScheme;
     const webviewSession = session.fromPartition('webview-temp');

--- a/spec/fixtures/module/preload-contents-zoomtext.js
+++ b/spec/fixtures/module/preload-contents-zoomtext.js
@@ -1,0 +1,7 @@
+const { webFrame, ipcRenderer } = require('electron');
+
+ipcRenderer.send('ready');
+
+ipcRenderer.on('getTextZoomFactor', (event) => {
+  event.sender.send('textZoomFactor', webFrame.getTextZoomFactor());
+});

--- a/spec/fixtures/module/preload-textzoom.js
+++ b/spec/fixtures/module/preload-textzoom.js
@@ -1,0 +1,7 @@
+const { webFrame, ipcRenderer } = require('electron');
+const url = require('url');
+const { textZoom } = url.parse(window.location.href, true).query;
+
+webFrame.setTextZoomFactor(parseFloat(textZoom));
+
+ipcRenderer.send('initalTextZoomFactor', webFrame.getTextZoomFactor());

--- a/spec/fixtures/pages/webview-text-zoom-factor.html
+++ b/spec/fixtures/pages/webview-text-zoom-factor.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<webview nodeintegration src="about:blank?textZoom=2" preload="../module/preload-textzoom.js"/>
+</body>
+</html>

--- a/spec/ts-smoke/electron/renderer.ts
+++ b/spec/ts-smoke/electron/renderer.ts
@@ -53,6 +53,9 @@ remote.getCurrentWindow().capturePage().then(buf => {
 webFrame.setZoomFactor(2)
 console.log(webFrame.getZoomFactor())
 
+webFrame.setTextZoomFactor(2)
+console.log(webFrame.getTextZoomFactor())
+
 webFrame.setZoomLevel(200)
 console.log(webFrame.getZoomLevel())
 


### PR DESCRIPTION
#### Description of Change
rebase [this pr](https://github.com/electron/electron/pull/23267)  to master

set the zoom ratio of the webframe globally to complete a font scaling

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: add text zoom api on webframe and webcontents