### PR TITLE
docs: update autoUpdater tutorial API

### DIFF
--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -80,9 +80,9 @@ Next, construct the URL of the update server and tell
 
 ```javascript
 const server = 'https://your-deployment-url.com'
-const feed = `${server}/update/${process.platform}/${app.getVersion()}`
+const url = `${server}/update/${process.platform}/${app.getVersion()}`
 
-autoUpdater.setFeedURL(feed)
+autoUpdater.setFeedURL({ url })
 ```
 
 As the final step, check for updates. The example below will check every minute:


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electronjs.org/issues/3780

Updates this tutorial to use the newer `autoUpdater.setFeedURL(options)` API. This API was changed in #11925, but our tutorial still reflected the deprecated `autoUpdater.setFeedURL(url, header)` API.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
