### PR TITLE
fix: prevent Menu.buildFromTemplate with empty array

### DIFF
--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -16,7 +16,7 @@ const MenuItem = function (options) {
   }
   this.submenu = this.submenu || roles.getDefaultSubmenu(this.role);
   if (this.submenu != null && this.submenu.constructor !== Menu) {
-    this.submenu = Menu.buildFromTemplate(this.submenu);
+    this.submenu = Menu.buildFromTemplate(this.submenu, true);
   }
   if (this.type == null && this.submenu != null) {
     this.type = 'submenu';

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -173,13 +173,17 @@ Menu.setApplicationMenu = function (menu) {
   }
 };
 
-Menu.buildFromTemplate = function (template) {
-  if (!Array.isArray(template) || template.length === 0) {
+Menu.buildFromTemplate = function (template, isSubmenu = false) {
+  if (!Array.isArray(template)) {
+    throw new TypeError('Invalid template for Menu: Menu template must be an array');
+  } else if (!isSubmenu && template.length === 0) {
     throw new TypeError('Invalid template for Menu: Menu template must be an non-empty array');
   }
+
   if (!areValidTemplateItems(template)) {
     throw new TypeError('Invalid template for MenuItem: must have at least one of label, role or type');
   }
+
   const filtered = removeExtraSeparators(template);
   const sorted = sortTemplate(filtered);
 

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -174,8 +174,8 @@ Menu.setApplicationMenu = function (menu) {
 };
 
 Menu.buildFromTemplate = function (template) {
-  if (!Array.isArray(template)) {
-    throw new TypeError('Invalid template for Menu: Menu template must be an array');
+  if (!Array.isArray(template) || template.length === 0) {
+    throw new TypeError('Invalid template for Menu: Menu template must be an non-empty array');
   }
   if (!areValidTemplateItems(template)) {
     throw new TypeError('Invalid template for MenuItem: must have at least one of label, role or type');

--- a/spec-main/api-menu-spec.ts
+++ b/spec-main/api-menu-spec.ts
@@ -86,10 +86,23 @@ describe('Menu module', function () {
         Menu.buildFromTemplate([{ visible: true }]);
       }).to.throw(/Invalid template for MenuItem: must have at least one of label, role or type/);
     });
+
     it('does throw exception for undefined', () => {
       expect(() => {
         Menu.buildFromTemplate([undefined as any]);
       }).to.throw(/Invalid template for MenuItem: must have at least one of label, role or type/);
+    });
+
+    it('throws when an empty array is passed as a template', () => {
+      expect(() => {
+        Menu.buildFromTemplate([]);
+      }).to.throw(/Invalid template for Menu: Menu template must be an non-empty array/);
+    });
+
+    it('throws when an non-array is passed as a template', () => {
+      expect(() => {
+        Menu.buildFromTemplate('hello' as any);
+      }).to.throw(/Invalid template for Menu: Menu template must be an non-empty array/);
     });
 
     describe('Menu sorting and building', () => {

--- a/spec-main/api-menu-spec.ts
+++ b/spec-main/api-menu-spec.ts
@@ -102,7 +102,7 @@ describe('Menu module', function () {
     it('throws when an non-array is passed as a template', () => {
       expect(() => {
         Menu.buildFromTemplate('hello' as any);
-      }).to.throw(/Invalid template for Menu: Menu template must be an non-empty array/);
+      }).to.throw(/Invalid template for Menu: Menu template must be an array/);
     });
 
     describe('Menu sorting and building', () => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/23282.

Prevent issues with menu creation and subsequent pane focus from menu bar by preventing menus from being created from an empty array. I can't conceive a valid use case for this, since if one wants to remove a menu they should be be passing `null` to `win.setMenu()` or calling `win.removeMenu()`. This issue is also specific to top-level menus, and not submenus, so the new check and exception is scoped to top-level menus.

cc @zcbenz @jkleinsc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a potential crash when menu is created from an empty template.
