### PR TITLE
fix: do not leak IPC or context bridge promises

### DIFF
--- a/shell/renderer/api/electron_api_ipc_renderer.cc
+++ b/shell/renderer/api/electron_api_ipc_renderer.cc
@@ -7,6 +7,7 @@
 #include "base/task/post_task.h"
 #include "base/values.h"
 #include "content/public/renderer/render_frame.h"
+#include "content/public/renderer/render_frame_observer.h"
 #include "gin/dictionary.h"
 #include "gin/handle.h"
 #include "gin/object_template_builder.h"
@@ -36,7 +37,8 @@ RenderFrame* GetCurrentRenderFrame() {
   return RenderFrame::FromWebFrame(frame);
 }
 
-class IPCRenderer : public gin::Wrappable<IPCRenderer> {
+class IPCRenderer : public gin::Wrappable<IPCRenderer>,
+                    public content::RenderFrameObserver {
  public:
   static gin::WrapperInfo kWrapperInfo;
 
@@ -44,19 +46,32 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer> {
     return gin::CreateHandle(isolate, new IPCRenderer(isolate));
   }
 
-  explicit IPCRenderer(v8::Isolate* isolate) {
+  explicit IPCRenderer(v8::Isolate* isolate)
+      : content::RenderFrameObserver(GetCurrentRenderFrame()) {
     RenderFrame* render_frame = GetCurrentRenderFrame();
     DCHECK(render_frame);
+    weak_context_ =
+        v8::Global<v8::Context>(isolate, isolate->GetCurrentContext());
+    weak_context_.SetWeak();
 
     render_frame->GetRemoteInterfaces()->GetInterface(
         mojo::MakeRequest(&electron_browser_ptr_));
+  }
+
+  void OnDestruct() override { electron_browser_ptr_.reset(); }
+
+  void WillReleaseScriptContext(v8::Local<v8::Context> context,
+                                int32_t world_id) override {
+    if (weak_context_.IsEmpty() ||
+        weak_context_.Get(context->GetIsolate()) == context)
+      electron_browser_ptr_.reset();
   }
 
   // gin::Wrappable:
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(
       v8::Isolate* isolate) override {
     return gin::Wrappable<IPCRenderer>::GetObjectTemplateBuilder(isolate)
-        .SetMethod("send", &IPCRenderer::Send)
+        .SetMethod("send", &IPCRenderer::SendMessage)
         .SetMethod("sendSync", &IPCRenderer::SendSync)
         .SetMethod("sendTo", &IPCRenderer::SendTo)
         .SetMethod("sendToHost", &IPCRenderer::SendToHost)
@@ -67,10 +82,10 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer> {
   const char* GetTypeName() override { return "IPCRenderer"; }
 
  private:
-  void Send(v8::Isolate* isolate,
-            bool internal,
-            const std::string& channel,
-            v8::Local<v8::Value> arguments) {
+  void SendMessage(v8::Isolate* isolate,
+                   bool internal,
+                   const std::string& channel,
+                   v8::Local<v8::Value> arguments) {
     blink::CloneableMessage message;
     if (!electron::SerializeV8Value(isolate, arguments, &message)) {
       return;
@@ -175,6 +190,7 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer> {
     return electron::DeserializeV8Value(isolate, result);
   }
 
+  v8::Global<v8::Context> weak_context_;
   electron::mojom::ElectronBrowserPtr electron_browser_ptr_;
 };
 


### PR DESCRIPTION
This fixes three main memory leaks to do with our promise helper mostly:

* `IPCRenderer` would hold pending promises for `invoke` calls even after the render frame was removed, those promises had a strong ref to the `Context` so the context was never freed
* `contextBridge` proxy promise had a similar issue with heap allocating the promise, if it was never resolved or rejected it would never be released, thus never releasing the strong ref to `Context`
* And a final leak again in the proxy promise impl where we passed strong global of source and destination context into the then and catch functions, if the promise was left pending the globals would not be freed. These have been converted to weak refs.

Notes: Fixed memory leaks in sandbox mode when using `contextBridge` with promises or `ipcRenderer.invoke`