### PR TITLE
fix: use Node's microtasks policy in node_main.cc

### DIFF
--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -78,6 +78,7 @@ int NodeMain(int argc, char* argv[]) {
 
     // Initialize gin::IsolateHolder.
     JavascriptEnvironment gin_env(loop);
+    gin_env.isolate()->SetMicrotasksPolicy(v8::MicrotasksPolicy::kExplicit);
 
     node::IsolateData* isolate_data =
         node::CreateIsolateData(gin_env.isolate(), loop, gin_env.platform());

--- a/spec/fixtures/module/node-promise-timer.js
+++ b/spec/fixtures/module/node-promise-timer.js
@@ -1,0 +1,23 @@
+const waitMs = (msec) => new Promise((resolve) => setTimeout(resolve, msec));
+
+const intervalMsec = 100;
+const numIterations = 2;
+let curIteration = 0;
+let promise;
+
+for (let i = 0; i < numIterations; i++) {
+  promise = (promise || waitMs(intervalMsec)).then(() => {
+    ++curIteration;
+    return waitMs(intervalMsec);
+  });
+}
+
+// https://github.com/electron/electron/issues/21515 was about electron
+// exiting before promises finished. This test sets the pending exitCode
+// to failure, then resets it to success only if all promises finish.
+process.exitCode = 1;
+promise.then(() => {
+  if (curIteration === numIterations) {
+    process.exitCode = 0;
+  }
+});

--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -690,4 +690,17 @@ describe('node feature', () => {
     const result = ChildProcess.spawnSync(remote.process.execPath, [path.resolve(fixtures, 'api', 'electron-main-module', 'app.asar')]);
     expect(result.status).to.equal(0);
   });
+
+  it('handles Promise timeouts correctly', (done) => {
+    const scriptPath = path.join(fixtures, 'module', 'node-promise-timer.js');
+    const child = ChildProcess.spawn(process.execPath, [scriptPath], {
+      env: { ELECTRON_RUN_AS_NODE: 'true' }
+    });
+    emittedOnce(child, 'exit').then(([code, signal]) => {
+      expect(code).to.equal(0);
+      expect(signal).to.equal(null);
+      child.kill();
+      done();
+    });
+  });
 });


### PR DESCRIPTION
#### Description of Change

Backport of #23153. This is basically the same as the 8-x-y backport; it just didn't trop cleanly to 7-2-x due to spec shear.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed Promise timeout issue when running Electron as Node.