### PR TITLE
ci: make sure msedge isn't running at end of woa test

### DIFF
--- a/azure-pipelines-woa.yml
+++ b/azure-pipelines-woa.yml
@@ -88,5 +88,6 @@ steps:
 - powershell: |
     Get-Process | Where Name –Like "electron*" | Stop-Process
     Get-Process | Where Name –Like "MicrosoftEdge*" | Stop-Process
+    Get-Process | Where Name –Like "msedge*" | Stop-Process
   displayName: 'Kill processes left running from last test run'
   condition: always()


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
This PR updates our WOA CI to stop execution of Edge if it is running at the end of our tests.  We already had a step to do so, but it was looking for the original Edge, not the new chromium based one.  This will resolve WOA test failures like:
https://github.visualstudio.com/electron/_build/results?buildId=66991&view=results
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
