### PR TITLE
fix: include clipboard / clipboardSanitized in permission request enum

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -349,7 +349,7 @@ win.webContents.session.setCertificateVerifyProc((request, callback) => {
 * `handler` Function | null
   * `webContents` [WebContents](web-contents.md) - WebContents requesting the permission.  Please note that if the request comes from a subframe you should use `requestingUrl` to check the request origin.
   * `permission` String - Enum of 'media', 'geolocation', 'notifications', 'midiSysex',
-    'pointerLock', 'fullscreen', 'openExternal'.
+    'pointerLock', 'fullscreen', 'openExternal', 'mediaKeySystem', 'clipboard', 'clipboardSanitized'.
   * `callback` Function
     * `permissionGranted` Boolean - Allow or deny the permission.
   * `details` Object - Some properties are only available on certain permission types.

--- a/shell/common/gin_converters/content_converter.cc
+++ b/shell/common/gin_converters/content_converter.cc
@@ -188,6 +188,10 @@ v8::Local<v8::Value> Converter<content::PermissionType>::ToV8(
       return StringToV8(isolate, "mediaKeySystem");
     case content::PermissionType::MIDI:
       return StringToV8(isolate, "midi");
+    case content::PermissionType::CLIPBOARD_READ_WRITE:
+      return StringToV8(isolate, "clipboard");
+    case content::PermissionType::CLIPBOARD_SANITIZED_WRITE:
+      return StringToV8(isolate, "clipboardSanitized");
     default:
       break;
   }


### PR DESCRIPTION
Fixes #23328

Notes: clipboard permission requests are now correctly identified in the permission request handler