### PR TITLE
Remove redundant release note items

### DIFF
--- a/script/release/notes/notes.js
+++ b/script/release/notes/notes.js
@@ -49,7 +49,6 @@ class Commit {
   hash: string;
   issueNumber? number;
   note? string;
-  originalSubject? string;
   prKey? GHKey;
   revertHash? string;
   subject? string;
@@ -160,10 +159,6 @@ const parseCommitMessage = (commitMessage, owner, repo, commit = {}) => {
     subject = subject.slice(0, pos).trim();
   }
 
-  if (!commit.originalSubject) {
-    commit.originalSubject = subject;
-  }
-
   if (body) {
     commit.body = body;
 
@@ -243,7 +238,7 @@ const getLocalCommitHashes = async (dir, ref) => {
 
 /*
  * possible properties:
- * breakingChange, hash, issueNumber, originalSubject,
+ * breakingChange, hash, issueNumber,
  * pr { owner, repo, number, branch }, revertHash, subject, type
  */
 const getLocalCommitDetails = async (module, point1, point2) => {

--- a/script/release/notes/notes.js
+++ b/script/release/notes/notes.js
@@ -511,8 +511,6 @@ const getNotes = async (fromRef, toRef, newVersion) => {
   return notes;
 };
 
-// FIXME: Chromium commit messages don't have this info anymore...
-// Might be better to find another way to add Chromium/Node/V8 version into relnotes
 const removeSupercededChromiumUpdates = (commits) => {
   const chromiumRegex = /^Updated Chromium to \d+\.\d+\.\d+\.\d+/;
   const updates = commits.filter(commit => (commit.note || commit.subject).match(chromiumRegex));

--- a/script/release/notes/notes.js
+++ b/script/release/notes/notes.js
@@ -263,14 +263,14 @@ const getLocalCommitHashes = async (dir, ref) => {
 
 /*
  * possible properties:
- * breakingChange, email, hash, issueNumber, originalSubject, parentHashes,
+ * breakingChange, hash, issueNumber, originalSubject,
  * pr { owner, repo, number, branch }, revertHash, subject, type
  */
 const getLocalCommitDetails = async (module, point1, point2) => {
   const { owner, repo, dir } = module;
 
   const fieldSep = '||';
-  const format = ['%H', '%P', '%aE', '%B'].join(fieldSep);
+  const format = ['%H', '%B'].join(fieldSep);
   const args = ['log', '-z', '--cherry-pick', '--right-only', '--first-parent', `--format=${format}`, `${point1}..${point2}`];
   const commits = (await runGit(dir, args)).split('\0').map(field => field.trim());
   const details = [];
@@ -278,14 +278,8 @@ const getLocalCommitDetails = async (module, point1, point2) => {
     if (!commit) {
       continue;
     }
-    const [hash, parentHashes, email, commitMessage] = commit.split(fieldSep, 4).map(field => field.trim());
-    details.push(parseCommitMessage(commitMessage, owner, repo, {
-      email,
-      hash,
-      owner,
-      repo,
-      parentHashes: parentHashes.split()
-    }));
+    const [hash, commitMessage] = commit.split(fieldSep, 2).map(field => field.trim());
+    details.push(parseCommitMessage(commitMessage, owner, repo, { hash, owner, repo }));
   }
   return details;
 };


### PR DESCRIPTION
#### Description of Change

In X.0.0 releases, skip PRs that have already been backported and released to older branches.

Supercedes https://github.com/electron/electron/pull/23325. This is the same code change but this commit history is cleaner because I footgunned that branch :smiley: 

CC @jkleinsc for re-review

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none