### PR TITLE
fix: prevent Menu.buildFromTemplate with empty array

### DIFF
--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -16,7 +16,7 @@ const MenuItem = function (options) {
   }
   this.submenu = this.submenu || roles.getDefaultSubmenu(this.role);
   if (this.submenu != null && this.submenu.constructor !== Menu) {
-    this.submenu = Menu.buildFromTemplate(this.submenu);
+    this.submenu = Menu.buildFromTemplate(this.submenu, true);
   }
   if (this.type == null && this.submenu != null) {
     this.type = 'submenu';

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -165,13 +165,17 @@ Menu.setApplicationMenu = function (menu) {
   }
 };
 
-Menu.buildFromTemplate = function (template) {
+Menu.buildFromTemplate = function (template, isSubmenu = false) {
   if (!Array.isArray(template)) {
     throw new TypeError('Invalid template for Menu: Menu template must be an array');
+  } else if (!isSubmenu && template.length === 0) {
+    throw new TypeError('Invalid template for Menu: Menu template must be an non-empty array');
   }
+
   if (!areValidTemplateItems(template)) {
     throw new TypeError('Invalid template for MenuItem: must have at least one of label, role or type');
   }
+
   const filtered = removeExtraSeparators(template);
   const sorted = sortTemplate(filtered);
 

--- a/spec-main/api-menu-spec.ts
+++ b/spec-main/api-menu-spec.ts
@@ -83,14 +83,27 @@ describe('Menu module', function () {
 
     it('does throw exception for object without role, label, or type attribute', () => {
       expect(() => {
-        Menu.buildFromTemplate([{ 'visible': true }])
-      }).to.throw(/Invalid template for MenuItem: must have at least one of label, role or type/)
-    })
+        Menu.buildFromTemplate([{ visible: true }]);
+      }).to.throw(/Invalid template for MenuItem: must have at least one of label, role or type/);
+    });
+
     it('does throw exception for undefined', () => {
       expect(() => {
         Menu.buildFromTemplate([undefined as any])
       }).to.throw(/Invalid template for MenuItem: must have at least one of label, role or type/)
     })
+
+    it('throws when an empty array is passed as a template', () => {
+      expect(() => {
+        Menu.buildFromTemplate([]);
+      }).to.throw(/Invalid template for Menu: Menu template must be an non-empty array/);
+    });
+
+    it('throws when an non-array is passed as a template', () => {
+      expect(() => {
+        Menu.buildFromTemplate('hello' as any);
+      }).to.throw(/Invalid template for Menu: Menu template must be an array/);
+    });
 
     describe('Menu sorting and building', () => {
       describe('sorts groups', () => {


### PR DESCRIPTION
Backport of #23308

See that PR for details.


Notes: Fixed a potential crash when menu is created from an empty template.
