### PR TITLE
docs: rename duplicated interface

### DIFF
--- a/docs/api/structures/new-window-event.md
+++ b/docs/api/structures/new-window-event.md
@@ -1,4 +1,0 @@
-# NewWindowEvent Object extends `Event`
-
-* `newGuest` BrowserWindow (optional)
-

--- a/docs/api/structures/new-window-web-contents-event.md
+++ b/docs/api/structures/new-window-web-contents-event.md
@@ -1,0 +1,4 @@
+# NewWindowWebContentsEvent Object extends `Event`
+
+* `newGuest` BrowserWindow (optional)
+

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -138,7 +138,7 @@ Emitted when page receives favicon urls.
 
 Returns:
 
-* `event` NewWindowEvent
+* `event` NewWindowWebContentsEvent
 * `url` String
 * `frameName` String
 * `disposition` String - Can be `default`, `foreground-tab`, `background-tab`,

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -100,7 +100,7 @@ auto_filenames = {
     "docs/api/structures/mime-typed-buffer.md",
     "docs/api/structures/mouse-input-event.md",
     "docs/api/structures/mouse-wheel-input-event.md",
-    "docs/api/structures/new-window-event.md",
+    "docs/api/structures/new-window-web-contents-event.md",
     "docs/api/structures/notification-action.md",
     "docs/api/structures/point.md",
     "docs/api/structures/post-body.md",


### PR DESCRIPTION
A recent PR landed that conflicted with a different type name.  This renames the newly added type.

Notes: no-notes