### PR TITLE
refactor: make passing empty template no-op in setMenu

### DIFF
--- a/lib/browser/api/menu-item.js
+++ b/lib/browser/api/menu-item.js
@@ -16,7 +16,7 @@ const MenuItem = function (options) {
   }
   this.submenu = this.submenu || roles.getDefaultSubmenu(this.role);
   if (this.submenu != null && this.submenu.constructor !== Menu) {
-    this.submenu = Menu.buildFromTemplate(this.submenu, true);
+    this.submenu = Menu.buildFromTemplate(this.submenu);
   }
   if (this.type == null && this.submenu != null) {
     this.type = 'submenu';

--- a/lib/browser/api/menu.js
+++ b/lib/browser/api/menu.js
@@ -173,11 +173,9 @@ Menu.setApplicationMenu = function (menu) {
   }
 };
 
-Menu.buildFromTemplate = function (template, isSubmenu = false) {
+Menu.buildFromTemplate = function (template) {
   if (!Array.isArray(template)) {
     throw new TypeError('Invalid template for Menu: Menu template must be an array');
-  } else if (!isSubmenu && template.length === 0) {
-    throw new TypeError('Invalid template for Menu: Menu template must be an non-empty array');
   }
 
   if (!areValidTemplateItems(template)) {

--- a/shell/browser/api/electron_api_top_level_window.cc
+++ b/shell/browser/api/electron_api_top_level_window.cc
@@ -689,10 +689,16 @@ void TopLevelWindow::SetMenu(v8::Isolate* isolate, v8::Local<v8::Value> value) {
   if (value->IsObject() && value->ToObject(context).ToLocal(&object) &&
       gin::ConvertFromV8(isolate, value, &menu) && !menu.IsEmpty()) {
     menu_.Reset(isolate, menu.ToV8());
-    window_->SetMenu(menu->model());
+
+    // We only want to update the menu if the menu has a non-zero item count,
+    // or we risk crashes.
+    if (menu->model()->GetItemCount() == 0) {
+      RemoveMenu();
+    } else {
+      window_->SetMenu(menu->model());
+    }
   } else if (value->IsNull()) {
-    menu_.Reset();
-    window_->SetMenu(nullptr);
+    RemoveMenu();
   } else {
     isolate->ThrowException(
         v8::Exception::TypeError(gin::StringToV8(isolate, "Invalid Menu")));

--- a/spec-main/api-menu-spec.ts
+++ b/spec-main/api-menu-spec.ts
@@ -93,12 +93,6 @@ describe('Menu module', function () {
       }).to.throw(/Invalid template for MenuItem: must have at least one of label, role or type/);
     });
 
-    it('throws when an empty array is passed as a template', () => {
-      expect(() => {
-        Menu.buildFromTemplate([]);
-      }).to.throw(/Invalid template for Menu: Menu template must be an non-empty array/);
-    });
-
     it('throws when an non-array is passed as a template', () => {
       expect(() => {
         Menu.buildFromTemplate('hello' as any);


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/23308#issuecomment-621982786.

The first PR was a breaking change that this avoids, for use cases like `Menu.buildFromTemplate([]).popup()` which would previously have no-op'd and would now throw exceptions. This now simply ensures that calls to `win.setMenu(Menu.buildFromTemplate([]))` are functionally equivalent to `win.setMenu(null)`.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
