### PR TITLE
docs: fix Chrome Tracing tool link markdown

### DIFF
--- a/docs/tutorial/performance.md
+++ b/docs/tutorial/performance.md
@@ -42,7 +42,7 @@ improve performance.
 
 To learn more about how to profile your app's code, familiarize yourself with
 the Chrome Developer Tools. For advanced analysis looking at multiple processes
-at once, consider the [Chrome Tracing] tool.
+at once, consider the [Chrome Tracing](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool) tool.
 
 ### Recommended Reading
 


### PR DESCRIPTION
#### Description of Change
Docs fix link markdown for Chrome Tracing tool

#### Checklist

- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: None