### PR TITLE
fix: undo and redo broken in webviews

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -92,3 +92,4 @@ fix_account_for_print_preview_disabled_when_printing_to_pdf.patch
 web_contents.patch
 ui_gtk_public_header.patch
 layoutng_make_hittestresult_localpoint_for_inline_element.patch
+fix-ensure-edit-cmds-to-sent-focused-WebContents.patch

--- a/patches/chromium/fix-ensure-edit-cmds-to-sent-focused-WebContents.patch
+++ b/patches/chromium/fix-ensure-edit-cmds-to-sent-focused-WebContents.patch
@@ -1,26 +1,15 @@
-From 92c229a7129cb7cd2b4bd71a8cf03f69d774e11a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shelley Vohr <shelley.vohr@gmail.com>
 Date: Thu, 30 Apr 2020 13:39:46 -0500
-Subject: [PATCH] fix: ensure edit cmds to sent focused WebContents
+Subject: fix: ensure edit cmds to sent focused WebContents
 
 Fixes an issue whereby some edit commands were not being
 sent to the focused WebContents. This fixes the issue by
 adding the malfunctioning commands to RenderFrameHostDelegate
 and then calling them that way.
----
- .../frame_host/interstitial_page_impl.cc      | 24 +++++++++++++++++++
- .../frame_host/interstitial_page_impl.h       |  3 +++
- .../render_widget_host_delegate.h             |  3 +++
- .../render_widget_host_unittest.cc            |  3 +++
- .../render_widget_host_view_mac.mm            | 18 +++++++-------
- ...st_view_mac_editcommand_helper_unittest.mm |  3 +++
- .../text_input_client_mac_unittest.mm         |  3 +++
- .../test/mock_render_widget_host_delegate.cc  |  6 +++++
- .../test/mock_render_widget_host_delegate.h   |  3 +++
- 9 files changed, 57 insertions(+), 9 deletions(-)
 
 diff --git a/content/browser/frame_host/interstitial_page_impl.cc b/content/browser/frame_host/interstitial_page_impl.cc
-index 72f9b6d58234..7fecac21ea36 100644
+index 72f9b6d582345736d1b0b05f52925e8e036cf131..7fecac21ea36670a20bc2b317cfe11eb5e0b2524 100644
 --- a/content/browser/frame_host/interstitial_page_impl.cc
 +++ b/content/browser/frame_host/interstitial_page_impl.cc
 @@ -451,6 +451,22 @@ void InterstitialPageImpl::ExecuteEditCommand(
@@ -62,7 +51,7 @@ index 72f9b6d58234..7fecac21ea36 100644
    auto* input_handler = GetFocusedFrameInputHandler();
    if (!input_handler)
 diff --git a/content/browser/frame_host/interstitial_page_impl.h b/content/browser/frame_host/interstitial_page_impl.h
-index e645cd751280..095ae4dffb1f 100644
+index e645cd75128085e15c1213df206847dd02fb5a83..095ae4dffb1f576a8ceefd2a4ab9f8f93473e460 100644
 --- a/content/browser/frame_host/interstitial_page_impl.h
 +++ b/content/browser/frame_host/interstitial_page_impl.h
 @@ -119,9 +119,12 @@ class CONTENT_EXPORT InterstitialPageImpl : public InterstitialPage,
@@ -79,7 +68,7 @@ index e645cd751280..095ae4dffb1f 100644
    RenderFrameHostDelegate* CreateNewWindow(
        RenderFrameHost* opener,
 diff --git a/content/browser/renderer_host/render_widget_host_delegate.h b/content/browser/renderer_host/render_widget_host_delegate.h
-index 234baaefaa36..ef04420a733e 100644
+index 234baaefaa36a2a64f7c365462c44807b0a1eabb..ef04420a733ef3d2bdc7d50af1d149db337494a4 100644
 --- a/content/browser/renderer_host/render_widget_host_delegate.h
 +++ b/content/browser/renderer_host/render_widget_host_delegate.h
 @@ -148,9 +148,12 @@ class CONTENT_EXPORT RenderWidgetHostDelegate {
@@ -96,7 +85,7 @@ index 234baaefaa36..ef04420a733e 100644
  
    // Requests the renderer to move the selection extent to a new position.
 diff --git a/content/browser/renderer_host/render_widget_host_unittest.cc b/content/browser/renderer_host/render_widget_host_unittest.cc
-index 5697455918f9..f5a7fdaa2187 100644
+index 5697455918f9aa2f4225eba1a5566950e34ec410..f5a7fdaa218742249cde04c73bcab43de0d83eed 100644
 --- a/content/browser/renderer_host/render_widget_host_unittest.cc
 +++ b/content/browser/renderer_host/render_widget_host_unittest.cc
 @@ -426,9 +426,12 @@ class MockRenderWidgetHostDelegate : public RenderWidgetHostDelegate {
@@ -113,7 +102,7 @@ index 5697455918f9..f5a7fdaa2187 100644
  
   private:
 diff --git a/content/browser/renderer_host/render_widget_host_view_mac.mm b/content/browser/renderer_host/render_widget_host_view_mac.mm
-index 472869202ff8..17e3fe40522e 100644
+index 472869202ff8a62d854c9ca39ca9f14e2f91e8cf..17e3fe40522e088057eaf01a290b658a0b6d1d01 100644
 --- a/content/browser/renderer_host/render_widget_host_view_mac.mm
 +++ b/content/browser/renderer_host/render_widget_host_view_mac.mm
 @@ -1799,15 +1799,15 @@ void RenderWidgetHostViewMac::ExecuteEditCommand(const std::string& command) {
@@ -152,7 +141,7 @@ index 472869202ff8..17e3fe40522e 100644
  
  void RenderWidgetHostViewMac::SelectAll() {
 diff --git a/content/browser/renderer_host/render_widget_host_view_mac_editcommand_helper_unittest.mm b/content/browser/renderer_host/render_widget_host_view_mac_editcommand_helper_unittest.mm
-index 760e47e9edd7..2b0f1135e584 100644
+index 760e47e9edd7b92b7bc6074f6da9c76048be8f28..2b0f1135e584852048081629eb6297e4e1fcc574 100644
 --- a/content/browser/renderer_host/render_widget_host_view_mac_editcommand_helper_unittest.mm
 +++ b/content/browser/renderer_host/render_widget_host_view_mac_editcommand_helper_unittest.mm
 @@ -91,9 +91,12 @@ class RenderWidgetHostDelegateEditCommandCounter
@@ -169,7 +158,7 @@ index 760e47e9edd7..2b0f1135e584 100644
  };
  
 diff --git a/content/browser/renderer_host/text_input_client_mac_unittest.mm b/content/browser/renderer_host/text_input_client_mac_unittest.mm
-index 158e0507af74..e7b8109cdc78 100644
+index 158e0507af7433e16c47227e7519b12e14554f1b..e7b8109cdc78e76d737bd0c067f8d33e0c171117 100644
 --- a/content/browser/renderer_host/text_input_client_mac_unittest.mm
 +++ b/content/browser/renderer_host/text_input_client_mac_unittest.mm
 @@ -40,9 +40,12 @@ class MockRenderWidgetHostDelegate : public RenderWidgetHostDelegate {
@@ -186,7 +175,7 @@ index 158e0507af74..e7b8109cdc78 100644
  };
  
 diff --git a/content/test/mock_render_widget_host_delegate.cc b/content/test/mock_render_widget_host_delegate.cc
-index 8e7922a2e83b..4aa08a55c036 100644
+index 8e7922a2e83b1272e93fbd7c8c5323ad7ed9c3a7..4aa08a55c036569e39d4d02254b347d8470462af 100644
 --- a/content/test/mock_render_widget_host_delegate.cc
 +++ b/content/test/mock_render_widget_host_delegate.cc
 @@ -31,12 +31,18 @@ void MockRenderWidgetHostDelegate::ExecuteEditCommand(
@@ -209,7 +198,7 @@ index 8e7922a2e83b..4aa08a55c036 100644
  
  void MockRenderWidgetHostDelegate::CreateInputEventRouter() {
 diff --git a/content/test/mock_render_widget_host_delegate.h b/content/test/mock_render_widget_host_delegate.h
-index 5cdc010273f0..16273c2ec761 100644
+index 5cdc010273f0bd03419c14046ee6cb8603a29dbf..16273c2ec761668249277a0be77aa429bcba1aef 100644
 --- a/content/test/mock_render_widget_host_delegate.h
 +++ b/content/test/mock_render_widget_host_delegate.h
 @@ -42,9 +42,12 @@ class MockRenderWidgetHostDelegate : public RenderWidgetHostDelegate {
@@ -225,6 +214,3 @@ index 5cdc010273f0..16273c2ec761 100644
    void SelectAll() override;
    RenderWidgetHostInputEventRouter* GetInputEventRouter() override;
    RenderWidgetHostImpl* GetFocusedRenderWidgetHost(
--- 
-2.26.2
-

--- a/patches/chromium/fix-ensure-edit-cmds-to-sent-focused-WebContents.patch
+++ b/patches/chromium/fix-ensure-edit-cmds-to-sent-focused-WebContents.patch
@@ -1,0 +1,230 @@
+From 92c229a7129cb7cd2b4bd71a8cf03f69d774e11a Mon Sep 17 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Thu, 30 Apr 2020 13:39:46 -0500
+Subject: [PATCH] fix: ensure edit cmds to sent focused WebContents
+
+Fixes an issue whereby some edit commands were not being
+sent to the focused WebContents. This fixes the issue by
+adding the malfunctioning commands to RenderFrameHostDelegate
+and then calling them that way.
+---
+ .../frame_host/interstitial_page_impl.cc      | 24 +++++++++++++++++++
+ .../frame_host/interstitial_page_impl.h       |  3 +++
+ .../render_widget_host_delegate.h             |  3 +++
+ .../render_widget_host_unittest.cc            |  3 +++
+ .../render_widget_host_view_mac.mm            | 18 +++++++-------
+ ...st_view_mac_editcommand_helper_unittest.mm |  3 +++
+ .../text_input_client_mac_unittest.mm         |  3 +++
+ .../test/mock_render_widget_host_delegate.cc  |  6 +++++
+ .../test/mock_render_widget_host_delegate.h   |  3 +++
+ 9 files changed, 57 insertions(+), 9 deletions(-)
+
+diff --git a/content/browser/frame_host/interstitial_page_impl.cc b/content/browser/frame_host/interstitial_page_impl.cc
+index 72f9b6d58234..7fecac21ea36 100644
+--- a/content/browser/frame_host/interstitial_page_impl.cc
++++ b/content/browser/frame_host/interstitial_page_impl.cc
+@@ -451,6 +451,22 @@ void InterstitialPageImpl::ExecuteEditCommand(
+   input_handler->ExecuteEditCommand(command, value);
+ }
+ 
++void InterstitialPageImpl::Undo() {
++  auto* input_handler = GetFocusedFrameInputHandler();
++  if (!input_handler)
++    return;
++  input_handler->Undo();
++  RecordAction(base::UserMetricsAction("Undo"));
++}
++
++void InterstitialPageImpl::Redo() {
++  auto* input_handler = GetFocusedFrameInputHandler();
++  if (!input_handler)
++    return;
++  input_handler->Redo();
++  RecordAction(base::UserMetricsAction("Redo"));
++}
++
+ void InterstitialPageImpl::Copy() {
+   auto* input_handler = GetFocusedFrameInputHandler();
+   if (!input_handler)
+@@ -467,6 +483,14 @@ void InterstitialPageImpl::Paste() {
+   RecordAction(base::UserMetricsAction("Paste"));
+ }
+ 
++void InterstitialPageImpl::PasteAndMatchStyle() {
++  auto* input_handler = GetFocusedFrameInputHandler();
++  if (!input_handler)
++    return;
++  input_handler->PasteAndMatchStyle();
++  RecordAction(base::UserMetricsAction("PasteAndMatchStyle"));
++}
++
+ void InterstitialPageImpl::SelectAll() {
+   auto* input_handler = GetFocusedFrameInputHandler();
+   if (!input_handler)
+diff --git a/content/browser/frame_host/interstitial_page_impl.h b/content/browser/frame_host/interstitial_page_impl.h
+index e645cd751280..095ae4dffb1f 100644
+--- a/content/browser/frame_host/interstitial_page_impl.h
++++ b/content/browser/frame_host/interstitial_page_impl.h
+@@ -119,9 +119,12 @@ class CONTENT_EXPORT InterstitialPageImpl : public InterstitialPage,
+   ui::AXMode GetAccessibilityMode() override;
+   void ExecuteEditCommand(const std::string& command,
+                           const base::Optional<base::string16>& value) override;
++  void Undo() override;
++  void Redo() override;
+   void Cut() override;
+   void Copy() override;
+   void Paste() override;
++  void PasteAndMatchStyle() override;
+   void SelectAll() override;
+   RenderFrameHostDelegate* CreateNewWindow(
+       RenderFrameHost* opener,
+diff --git a/content/browser/renderer_host/render_widget_host_delegate.h b/content/browser/renderer_host/render_widget_host_delegate.h
+index 234baaefaa36..ef04420a733e 100644
+--- a/content/browser/renderer_host/render_widget_host_delegate.h
++++ b/content/browser/renderer_host/render_widget_host_delegate.h
+@@ -148,9 +148,12 @@ class CONTENT_EXPORT RenderWidgetHostDelegate {
+   virtual void ExecuteEditCommand(
+       const std::string& command,
+       const base::Optional<base::string16>& value) = 0;
++  virtual void Undo() = 0;
++  virtual void Redo() = 0;
+   virtual void Cut() = 0;
+   virtual void Copy() = 0;
+   virtual void Paste() = 0;
++  virtual void PasteAndMatchStyle() = 0;
+   virtual void SelectAll() = 0;
+ 
+   // Requests the renderer to move the selection extent to a new position.
+diff --git a/content/browser/renderer_host/render_widget_host_unittest.cc b/content/browser/renderer_host/render_widget_host_unittest.cc
+index 5697455918f9..f5a7fdaa2187 100644
+--- a/content/browser/renderer_host/render_widget_host_unittest.cc
++++ b/content/browser/renderer_host/render_widget_host_unittest.cc
+@@ -426,9 +426,12 @@ class MockRenderWidgetHostDelegate : public RenderWidgetHostDelegate {
+       const std::string& command,
+       const base::Optional<base::string16>& value) override {}
+ 
++  void Undo() override {}
++  void Redo() override {}
+   void Cut() override {}
+   void Copy() override {}
+   void Paste() override {}
++  void PasteAndMatchStyle() override {}
+   void SelectAll() override {}
+ 
+  private:
+diff --git a/content/browser/renderer_host/render_widget_host_view_mac.mm b/content/browser/renderer_host/render_widget_host_view_mac.mm
+index 472869202ff8..17e3fe40522e 100644
+--- a/content/browser/renderer_host/render_widget_host_view_mac.mm
++++ b/content/browser/renderer_host/render_widget_host_view_mac.mm
+@@ -1799,15 +1799,15 @@ void RenderWidgetHostViewMac::ExecuteEditCommand(const std::string& command) {
+ }
+ 
+ void RenderWidgetHostViewMac::Undo() {
+-  WebContents* web_contents = GetWebContents();
+-  if (web_contents)
+-    web_contents->Undo();
++  if (auto* delegate = GetFocusedRenderWidgetHostDelegate()) {
++    delegate->Undo();
++  }
+ }
+ 
+ void RenderWidgetHostViewMac::Redo() {
+-  WebContents* web_contents = GetWebContents();
+-  if (web_contents)
+-    web_contents->Redo();
++  if (auto* delegate = GetFocusedRenderWidgetHostDelegate()) {
++    delegate->Redo();
++  }
+ }
+ 
+ void RenderWidgetHostViewMac::Cut() {
+@@ -1835,9 +1835,9 @@ void RenderWidgetHostViewMac::Paste() {
+ }
+ 
+ void RenderWidgetHostViewMac::PasteAndMatchStyle() {
+-  WebContents* web_contents = GetWebContents();
+-  if (web_contents)
+-    web_contents->PasteAndMatchStyle();
++  if (auto* delegate = GetFocusedRenderWidgetHostDelegate()) {
++    delegate->PasteAndMatchStyle();
++  }
+ }
+ 
+ void RenderWidgetHostViewMac::SelectAll() {
+diff --git a/content/browser/renderer_host/render_widget_host_view_mac_editcommand_helper_unittest.mm b/content/browser/renderer_host/render_widget_host_view_mac_editcommand_helper_unittest.mm
+index 760e47e9edd7..2b0f1135e584 100644
+--- a/content/browser/renderer_host/render_widget_host_view_mac_editcommand_helper_unittest.mm
++++ b/content/browser/renderer_host/render_widget_host_view_mac_editcommand_helper_unittest.mm
+@@ -91,9 +91,12 @@ class RenderWidgetHostDelegateEditCommandCounter
+       const base::Optional<base::string16>& value) override {
+     edit_command_message_count_++;
+   }
++  void Undo() override {}
++  void Redo() override {}
+   void Cut() override {}
+   void Copy() override {}
+   void Paste() override {}
++  void PasteAndMatchStyle() override {}
+   void SelectAll() override {}
+ };
+ 
+diff --git a/content/browser/renderer_host/text_input_client_mac_unittest.mm b/content/browser/renderer_host/text_input_client_mac_unittest.mm
+index 158e0507af74..e7b8109cdc78 100644
+--- a/content/browser/renderer_host/text_input_client_mac_unittest.mm
++++ b/content/browser/renderer_host/text_input_client_mac_unittest.mm
+@@ -40,9 +40,12 @@ class MockRenderWidgetHostDelegate : public RenderWidgetHostDelegate {
+   void ExecuteEditCommand(
+       const std::string& command,
+       const base::Optional<base::string16>& value) override {}
++  void Undo() override {}
++  void Redo() override {}
+   void Cut() override {}
+   void Copy() override {}
+   void Paste() override {}
++  void PasteAndMatchStyle() override {}
+   void SelectAll() override {}
+ };
+ 
+diff --git a/content/test/mock_render_widget_host_delegate.cc b/content/test/mock_render_widget_host_delegate.cc
+index 8e7922a2e83b..4aa08a55c036 100644
+--- a/content/test/mock_render_widget_host_delegate.cc
++++ b/content/test/mock_render_widget_host_delegate.cc
+@@ -31,12 +31,18 @@ void MockRenderWidgetHostDelegate::ExecuteEditCommand(
+     const std::string& command,
+     const base::Optional<base::string16>& value) {}
+ 
++void MockRenderWidgetHostDelegate::Undo() {}
++
++void MockRenderWidgetHostDelegate::Redo() {}
++
+ void MockRenderWidgetHostDelegate::Cut() {}
+ 
+ void MockRenderWidgetHostDelegate::Copy() {}
+ 
+ void MockRenderWidgetHostDelegate::Paste() {}
+ 
++void MockRenderWidgetHostDelegate::PasteAndMatchStyle() {}
++
+ void MockRenderWidgetHostDelegate::SelectAll() {}
+ 
+ void MockRenderWidgetHostDelegate::CreateInputEventRouter() {
+diff --git a/content/test/mock_render_widget_host_delegate.h b/content/test/mock_render_widget_host_delegate.h
+index 5cdc010273f0..16273c2ec761 100644
+--- a/content/test/mock_render_widget_host_delegate.h
++++ b/content/test/mock_render_widget_host_delegate.h
+@@ -42,9 +42,12 @@ class MockRenderWidgetHostDelegate : public RenderWidgetHostDelegate {
+       const NativeWebKeyboardEvent& event) override;
+   void ExecuteEditCommand(const std::string& command,
+                           const base::Optional<base::string16>& value) override;
++  void Undo() override;
++  void Redo() override;
+   void Cut() override;
+   void Copy() override;
+   void Paste() override;
++  void PasteAndMatchStyle() override;
+   void SelectAll() override;
+   RenderWidgetHostInputEventRouter* GetInputEventRouter() override;
+   RenderWidgetHostImpl* GetFocusedRenderWidgetHost(
+-- 
+2.26.2
+


### PR DESCRIPTION
#### Description of Change

Backport upstream fix https://chromium-review.googlesource.com/c/chromium/src/+/2135187 to 9-x-y [as suggested](https://github.com/electron/electron/pull/23341#issuecomment-621566167). 

Supercedes https://github.com/electron/electron/pull/23352, which has been closed.

Fixes #22744 for 9-x-y.

CC @codebytere @deepak1556 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where undo and redo shortcuts did not work in webviews.

