### PR TITLE
feat: app.getPath('recent')

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -608,6 +608,7 @@ Returns `String` - The current application directory.
   * `music` Directory for a user's music.
   * `pictures` Directory for a user's pictures.
   * `videos` Directory for a user's videos.
+  * `recent` Directory for the user's recent files (Windows only).
   * `logs` Directory for your app's log folder.
   * `pepperFlashSystemPlugin` Full path to the system version of the Pepper Flash plugin.
   * `crashDumps` Directory where crash dumps are stored.

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -917,9 +917,10 @@ base::FilePath App::GetPath(gin_helper::ErrorThrower thrower,
 
 #if defined(OS_WIN)
     // If we get the "recent" path before setting it, set it
-    if (!succeed && name == "recent") {
-      SetRecentPath(thrower, base::Optional<base::FilePath>());
-      succeed = base::PathService::Get(key, &path);
+    if (!succeed && name == "recent" &&
+        platform_util::GetFolderPath(DIR_RECENT, &path)) {
+      base::ThreadRestrictions::ScopedAllowIO allow_io;
+      succeed = base::PathService::Override(DIR_RECENT, path);
     }
 #endif
   }

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -54,6 +54,7 @@
 #include "shell/common/gin_helper/object_template_builder.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/options_switches.h"
+#include "shell/common/platform_util.h"
 #include "ui/gfx/image/image.h"
 
 #if defined(OS_WIN)
@@ -425,6 +426,10 @@ int GetPathConstant(const std::string& name) {
     return chrome::DIR_USER_PICTURES;
   else if (name == "videos")
     return chrome::DIR_USER_VIDEOS;
+#if defined(OS_WIN)
+  else if (name == "recent")
+    return electron::DIR_RECENT;
+#endif
   else if (name == "pepperFlashSystemPlugin")
     return chrome::FILE_PEPPER_FLASH_SYSTEM_PLUGIN;
   else
@@ -871,6 +876,30 @@ void App::SetAppLogsPath(gin_helper::ErrorThrower thrower,
 }
 #endif
 
+#if defined(OS_WIN)
+void App::SetRecentPath(gin_helper::ErrorThrower thrower,
+                        base::Optional<base::FilePath> custom_path) {
+  if (custom_path.has_value()) {
+    if (!custom_path->IsAbsolute()) {
+      thrower.ThrowError("Path must be absolute");
+      return;
+    }
+    {
+      base::ThreadRestrictions::ScopedAllowIO allow_io;
+      base::PathService::Override(DIR_RECENT, custom_path.value());
+    }
+  } else {
+    base::FilePath path;
+    if (platform_util::GetFolderPath(DIR_RECENT, &path)) {
+      {
+        base::ThreadRestrictions::ScopedAllowIO allow_io;
+        base::PathService::Override(DIR_RECENT, path);
+      }
+    }
+  }
+}
+#endif
+
 base::FilePath App::GetPath(gin_helper::ErrorThrower thrower,
                             const std::string& name) {
   bool succeed = false;
@@ -885,6 +914,14 @@ base::FilePath App::GetPath(gin_helper::ErrorThrower thrower,
       SetAppLogsPath(thrower, base::Optional<base::FilePath>());
       succeed = base::PathService::Get(key, &path);
     }
+
+#if defined(OS_WIN)
+    // If we get the "recent" path before setting it, set it
+    if (!succeed && name == "recent") {
+      SetRecentPath(thrower, base::Optional<base::FilePath>());
+      succeed = base::PathService::Get(key, &path);
+    }
+#endif
   }
 
   if (!succeed)

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -876,30 +876,6 @@ void App::SetAppLogsPath(gin_helper::ErrorThrower thrower,
 }
 #endif
 
-#if defined(OS_WIN)
-void App::SetRecentPath(gin_helper::ErrorThrower thrower,
-                        base::Optional<base::FilePath> custom_path) {
-  if (custom_path.has_value()) {
-    if (!custom_path->IsAbsolute()) {
-      thrower.ThrowError("Path must be absolute");
-      return;
-    }
-    {
-      base::ThreadRestrictions::ScopedAllowIO allow_io;
-      base::PathService::Override(DIR_RECENT, custom_path.value());
-    }
-  } else {
-    base::FilePath path;
-    if (platform_util::GetFolderPath(DIR_RECENT, &path)) {
-      {
-        base::ThreadRestrictions::ScopedAllowIO allow_io;
-        base::PathService::Override(DIR_RECENT, path);
-      }
-    }
-  }
-}
-#endif
-
 base::FilePath App::GetPath(gin_helper::ErrorThrower thrower,
                             const std::string& name) {
   bool succeed = false;

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -160,8 +160,10 @@ class App : public ElectronBrowserClient::Delegate,
 
   void SetAppLogsPath(gin_helper::ErrorThrower thrower,
                       base::Optional<base::FilePath> custom_path);
+#if defined(OS_WIN)
   void SetRecentPath(gin_helper::ErrorThrower thrower,
                      base::Optional<base::FilePath> custom_path);
+#endif
 
   // Get/Set the pre-defined path in PathService.
   base::FilePath GetPath(gin_helper::ErrorThrower thrower,

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -160,6 +160,8 @@ class App : public ElectronBrowserClient::Delegate,
 
   void SetAppLogsPath(gin_helper::ErrorThrower thrower,
                       base::Optional<base::FilePath> custom_path);
+  void SetRecentPath(gin_helper::ErrorThrower thrower,
+                     base::Optional<base::FilePath> custom_path);
 
   // Get/Set the pre-defined path in PathService.
   base::FilePath GetPath(gin_helper::ErrorThrower thrower,

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -160,10 +160,6 @@ class App : public ElectronBrowserClient::Delegate,
 
   void SetAppLogsPath(gin_helper::ErrorThrower thrower,
                       base::Optional<base::FilePath> custom_path);
-#if defined(OS_WIN)
-  void SetRecentPath(gin_helper::ErrorThrower thrower,
-                     base::Optional<base::FilePath> custom_path);
-#endif
 
   // Get/Set the pre-defined path in PathService.
   base::FilePath GetPath(gin_helper::ErrorThrower thrower,

--- a/shell/common/electron_paths.h
+++ b/shell/common/electron_paths.h
@@ -26,6 +26,10 @@ enum {
   DIR_USER_CACHE,              // Directory where user cache can be written.
   DIR_APP_LOGS,                // Directory where app logs live
 
+#if defined(OS_WIN)
+  DIR_RECENT,  // Directory where recent files live
+#endif
+
 #if defined(OS_LINUX)
   DIR_APP_DATA,  // Application Data directory under the user profile.
 #endif

--- a/shell/common/platform_util.h
+++ b/shell/common/platform_util.h
@@ -45,6 +45,11 @@ bool MoveItemToTrash(const base::FilePath& full_path, bool delete_on_fail);
 
 void Beep();
 
+#if defined(OS_WIN)
+// SHGetFolderPath calls not covered by Chromium
+bool GetFolderPath(int key, base::FilePath* result);
+#endif
+
 #if defined(OS_MACOSX)
 bool GetLoginItemEnabled();
 bool SetLoginItemEnabled(bool enabled);

--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -32,6 +32,7 @@
 #include "base/win/windows_version.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
+#include "shell/browser/electron_paths.h"
 #include "ui/base/win/shell.h"
 #include "url/gurl.h"
 
@@ -390,6 +391,25 @@ bool MoveItemToTrash(const base::FilePath& path, bool delete_on_fail) {
   // the DeleteFileProgressSink to check for Recycle Bin.
   return SUCCEEDED(pfo->DeleteItem(delete_item.Get(), delete_sink.Get())) &&
          SUCCEEDED(pfo->PerformOperations());
+}
+
+bool GetFolderPath(int key, base::FilePath* result) {
+  wchar_t system_buffer[MAX_PATH];
+  system_buffer[0] = 0;
+
+  base::FilePath cur;
+  switch (key) {
+    case electron::DIR_RECENT:
+      if (FAILED(SHGetFolderPath(NULL, CSIDL_RECENT, NULL, SHGFP_TYPE_CURRENT,
+                                 system_buffer))) {
+        return false;
+      }
+      cur = base::FilePath(system_buffer);
+      break;
+  }
+
+  *result = cur;
+  return true;
 }
 
 void Beep() {

--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -32,7 +32,7 @@
 #include "base/win/windows_version.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
-#include "shell/browser/electron_paths.h"
+#include "shell/common/electron_paths.h"
 #include "ui/base/win/shell.h"
 #include "url/gurl.h"
 

--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -395,20 +395,17 @@ bool MoveItemToTrash(const base::FilePath& path, bool delete_on_fail) {
 
 bool GetFolderPath(int key, base::FilePath* result) {
   wchar_t system_buffer[MAX_PATH];
-  system_buffer[0] = 0;
 
-  base::FilePath cur;
   switch (key) {
     case electron::DIR_RECENT:
       if (FAILED(SHGetFolderPath(NULL, CSIDL_RECENT, NULL, SHGFP_TYPE_CURRENT,
                                  system_buffer))) {
         return false;
       }
-      cur = base::FilePath(system_buffer);
+      *result = base::FilePath(system_buffer);
       break;
   }
 
-  *result = cur;
   return true;
 }
 

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -737,6 +737,22 @@ describe('app module', () => {
       app.setPath('music', __dirname);
       expect(app.getPath('music')).to.equal(__dirname);
     });
+
+    if (process.platform === 'win32') {
+      it('gets the folder for recent files', () => {
+        const recent = app.getPath('recent');
+
+        // We expect that one of our test machines have overriden this
+        // to be something crazy, it'll always include the word "Recent"
+        // unless people have been registry-hacking like crazy
+        expect(recent).to.include('Recent');
+      });
+
+      it('can override the recent files path', () => {
+        app.setPath('recent', 'C:\\fake-path');
+        expect(app.getPath('recent')).to.equal('C:\\fake-path');
+      });
+    }
   });
 
   describe('setPath(name, path)', () => {


### PR DESCRIPTION
#### Description of Change

This PR introduces `app.getPath('recent')`, which returns `FOLDERID_recent`, more commonly known as `CSIDL_RECENT`. It's the folder where Windows keeps all its recent files. If you're building an app, `SHGetFolderPath` is your only way to get this path - there is no environment variable, little PowerShell script, or other simple solution to get it. C++ or FFI is the only way.

#### Why?
Given that we're already offering developers a handy way to get `Desktop`, `Pictures`, `Videos`, or `Music` locations, it makes sense that developers expect that they can get other special folders with `getPath()`. You probably guessed it, but this PR fills an actual need in our app. 

If we don't add it, we're asking devs to write a full native Node module to get this path, which feels insanely cumbersome. 

This PR adds lines, but I don't expect any forced maintenance burden - this code hasn't changed on in Windows since we've first had Windows.

#### Why not?

On the other hand, I'd understand if we don't want to keep adding folders. Windows has [many of them](https://docs.microsoft.com/en-us/previous-versions/bb762584(v=vs.85)), and this does feel like a decent chunk of code in our core files for a single method.

#### Alternatives

@nornagon and I briefly discussed using a [PathServiceProvider](https://source.chromium.org/chromium/chromium/src/+/master:base/path_service.h;l=23?q=pathservice&ss=chromium&originalUrl=https:%2F%2Fcs.chromium.org%2F), but requirements on _when_ we'd need to register that thing made us believe that this solution is less involved.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added the ability to get the "Recent" folder on Windows with `app.getPath('recent')`
