### PR TITLE
docs: added charset to MimeTypedBuffer

### DIFF
--- a/docs/api/structures/mime-typed-buffer.md
+++ b/docs/api/structures/mime-typed-buffer.md
@@ -1,4 +1,5 @@
 # MimeTypedBuffer Object
 
-* `mimeType` String - The mimeType of the Buffer that you are sending.
+* `mimeType` String (optional) - MIME type of the buffer.
+* `charset` String (optional) - Charset of the buffer.
 * `data` Buffer - The actual Buffer content.


### PR DESCRIPTION
#### Description of Change

I think this should be aligned with `StringProtocolResponse`. At least the `charset` was missing from the docs.

https://www.electronjs.org/docs/api/protocol#protocolregisterbufferprotocolscheme-handler-completion

>  should be called with either a Buffer object or an object that has the data, mimeType, and charset properties.

Notes: none