### PR TITLE
fix: Don't ignore the referer header in net.request

### DIFF
--- a/lib/browser/api/net.ts
+++ b/lib/browser/api/net.ts
@@ -386,6 +386,7 @@ class ClientRequest extends Writable implements Electron.ClientRequest {
       }
       return ret;
     };
+    this._urlLoaderOptions.referrer = this._urlLoaderOptions.extraHeaders.referer || '';
     const opts = { ...this._urlLoaderOptions, extraHeaders: stringifyValues(this._urlLoaderOptions.extraHeaders) };
     this._urlLoader = createURLLoader(opts);
     this._urlLoader.on('response-started', (event, finalUrl, responseHead) => {

--- a/shell/browser/api/electron_api_url_loader.cc
+++ b/shell/browser/api/electron_api_url_loader.cc
@@ -352,6 +352,7 @@ gin::Handle<SimpleURLLoaderWrapper> SimpleURLLoaderWrapper::Create(
   request->force_ignore_site_for_cookies = true;
   opts.Get("method", &request->method);
   opts.Get("url", &request->url);
+  opts.Get("referrer", &request->referrer);
   std::map<std::string, std::string> extra_headers;
   if (opts.Get("extraHeaders", &extra_headers)) {
     for (const auto& it : extra_headers) {

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -1253,6 +1253,38 @@ describe('net module', () => {
         setTimeout(resolve, 50);
       });
     });
+
+    it('should remove the referer header when no referrer url specified', async () => {
+      const serverUrl = await respondOnce.toSingleURL((request, response) => {
+        expect(request.headers.referer).to.equal(undefined);
+        response.statusCode = 200;
+        response.statusMessage = 'OK';
+        response.end();
+      });
+      const urlRequest = net.request(serverUrl);
+      urlRequest.end();
+
+      const response = await getResponse(urlRequest);
+      expect(response.statusCode).to.equal(200);
+      await collectStreamBody(response);
+    });
+
+    it('should set the referer header when a referrer url specified', async () => {
+      const referrerURL = 'https://www.electronjs.org/';
+      const serverUrl = await respondOnce.toSingleURL((request, response) => {
+        expect(request.headers.referer).to.equal(referrerURL);
+        response.statusCode = 200;
+        response.statusMessage = 'OK';
+        response.end();
+      });
+      const urlRequest = net.request(serverUrl);
+      urlRequest.setHeader('referer', referrerURL);
+      urlRequest.end();
+
+      const response = await getResponse(urlRequest);
+      expect(response.statusCode).to.equal(200);
+      await collectStreamBody(response);
+    });
   });
 
   describe('IncomingMessage API', () => {

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -58,6 +58,7 @@ declare namespace NodeJS {
     body: Uint8Array | BodyFunc;
     session?: Electron.Session;
     partition?: string;
+    referrer?: string;
   }
   type ResponseHead = {
     statusCode: number;


### PR DESCRIPTION
#### Description of Change
Don't ignore the referrer header for a request, fixes #22411 #23102.

@zcbenz @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Don't ignore the referrer header in net.request

