### PR TITLE
fix: fetch fresh frame_host reference on use to avoid holding destroyed references

### DIFF
--- a/shell/browser/network_hints_handler_impl.cc
+++ b/shell/browser/network_hints_handler_impl.cc
@@ -20,7 +20,7 @@ NetworkHintsHandlerImpl::NetworkHintsHandlerImpl(
     content::RenderFrameHost* frame_host)
     : network_hints::SimpleNetworkHintsHandlerImpl(
           frame_host->GetProcess()->GetID()),
-      render_frame_host_(frame_host) {}
+      browser_context_(frame_host->GetProcess()->GetBrowserContext()) {}
 
 NetworkHintsHandlerImpl::~NetworkHintsHandlerImpl() = default;
 
@@ -28,11 +28,12 @@ void NetworkHintsHandlerImpl::Preconnect(const GURL& url,
                                          bool allow_credentials) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 
-  content::BrowserContext* browser_context =
-      render_frame_host_->GetProcess()->GetBrowserContext();
+  if (!browser_context_) {
+    return;
+  }
   auto* session = electron::api::Session::FromWrappedClass(
       v8::Isolate::GetCurrent(),
-      static_cast<electron::ElectronBrowserContext*>(browser_context));
+      static_cast<electron::ElectronBrowserContext*>(browser_context_));
   if (session) {
     session->Emit("preconnect", url, allow_credentials);
   }

--- a/shell/browser/network_hints_handler_impl.h
+++ b/shell/browser/network_hints_handler_impl.h
@@ -9,7 +9,8 @@
 
 namespace content {
 class RenderFrameHost;
-}
+class BrowserContext;
+}  // namespace content
 
 class NetworkHintsHandlerImpl
     : public network_hints::SimpleNetworkHintsHandlerImpl {
@@ -27,7 +28,7 @@ class NetworkHintsHandlerImpl
  private:
   explicit NetworkHintsHandlerImpl(content::RenderFrameHost*);
 
-  content::RenderFrameHost* render_frame_host_ = nullptr;
+  content::BrowserContext* browser_context_ = nullptr;
 };
 
 #endif  // SHELL_BROWSER_NETWORK_HINTS_HANDLER_IMPL_H_


### PR DESCRIPTION
#### Description of Change

Backports https://github.com/electron/electron/pull/23271

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash which could occur during page navigations
