### PR TITLE
fix: ensure guest-embedder map is updated when webview is removed

### DIFF
--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -254,6 +254,9 @@ const attachGuest = function (event, embedderFrameId, elementInstanceId, guestIn
 // Remove an guest-embedder relationship.
 const detachGuest = function (embedder, guestInstanceId) {
   const guestInstance = guestInstances[guestInstanceId];
+
+  if (!guestInstance) return;
+
   if (embedder !== guestInstance.embedder) {
     return;
   }
@@ -334,6 +337,10 @@ handleMessage('ELECTRON_GUEST_VIEW_MANAGER_ATTACH_GUEST', function (event, embed
   } catch (error) {
     console.error(`Guest attach failed: ${error}`);
   }
+});
+
+handleMessage('ELECTRON_GUEST_VIEW_MANAGER_DETACH_GUEST', function (event, guestInstanceId) {
+  return detachGuest(event.sender, guestInstanceId);
 });
 
 // this message is sent by the actual <webview>

--- a/lib/renderer/web-view/guest-view-internal.ts
+++ b/lib/renderer/web-view/guest-view-internal.ts
@@ -110,9 +110,14 @@ export function attachGuest (
   invoke('ELECTRON_GUEST_VIEW_MANAGER_ATTACH_GUEST', embedderFrameId, elementInstanceId, guestInstanceId, params);
 }
 
+export function detachGuest (guestInstanceId: number) {
+  return invokeSync('ELECTRON_GUEST_VIEW_MANAGER_DETACH_GUEST', guestInstanceId);
+}
+
 export const guestViewInternalModule = {
   deregisterEvents,
   createGuest,
   createGuestSync,
-  attachGuest
+  attachGuest,
+  detachGuest
 };

--- a/lib/renderer/web-view/web-view-element.ts
+++ b/lib/renderer/web-view/web-view-element.ts
@@ -66,6 +66,9 @@ const defineWebViewElement = (v8Util: NodeJS.V8UtilBinding, webViewImpl: typeof 
         return;
       }
       guestViewInternal.deregisterEvents(internal.viewInstanceId);
+      if (internal.guestInstanceId) {
+        guestViewInternal.detachGuest(internal.guestInstanceId);
+      }
       internal.elementAttached = false;
       this.internalInstanceId = 0;
       internal.reset();


### PR DESCRIPTION
#### Description of Change

Backports https://github.com/electron/electron/pull/23342

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix crash with webview during some window management events like resize, scroll etc.
