### PR TITLE
fix: multiple extension filters on macOS

### DIFF
--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -92,7 +92,16 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
   for (const Filter& filter : filters) {
     NSMutableSet* file_type_set = [NSMutableSet set];
     [filter_names addObject:@(filter.first.c_str())];
-    for (const std::string& ext : filter.second) {
+    for (std::string ext : filter.second) {
+      // macOS is incapable of understanding multiple file extensions,
+      // so we need to tokenize the extension that's been passed in.
+      // We want to err on the side of allowing files, so we pass
+      // along only the final extension ('tar.gz' => 'gz').
+      auto pos = ext.rfind('.');
+      if (pos != std::string::npos) {
+        ext.erase(0, pos + 1);
+      }
+
       [file_type_set addObject:@(ext.c_str())];
     }
     [file_types_list addObject:[file_type_set allObjects]];


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/23316.

Fixes an issue whereby `macOS` would fail to allow file extensions containing periods.`macOS`, it turns out, is incapable of understanding multiple file extensions, so if something like `tar.gz` is passed in it will not match files correctly because it natively will throw out anything it doesn't recognize as a valid system extension. We fix this by tokenizing the extension and only passing the final component of the extension (as delimited by `.`) to `macOS`.

Tested with https://gist.github.com/7ce9ea238a838bdfb30337ac43daa8a6.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue whereby `macOS` would fail to allow file extensions containing periods.
