### PR TITLE
fix: fixed possible problem with visibility state on mac

### DIFF
--- a/patches/chromium/disable_hidden.patch
+++ b/patches/chromium/disable_hidden.patch
@@ -46,3 +46,16 @@ index 12e1923fd2943af92aaf6f691d28212bdd2a73dd..3b66abb180df5f3da7c4fa8de7727962
      host()->WasHidden();
      aura::WindowTreeHost* host = window_->GetHost();
      if (delegated_frame_host_) {
+diff --git a/content/browser/renderer_host/render_widget_host_view_mac.mm b/content/browser/renderer_host/render_widget_host_view_mac.mm
+index 9fe6d55cc0db..8ae2e0ab6457 100644
+--- a/content/browser/renderer_host/render_widget_host_view_mac.mm
++++ b/content/browser/renderer_host/render_widget_host_view_mac.mm
+@@ -437,7 +437,7 @@ void RenderWidgetHostViewMac::Hide() {
+ }
+ 
+ void RenderWidgetHostViewMac::WasUnOccluded() {
+-  if (!host()->is_hidden())
++  if (!host()->is_hidden() || host()->disable_hidden_)
+     return;
+ 
+   browser_compositor_->SetRenderWidgetHostIsHidden(false);


### PR DESCRIPTION
I don't know if it's possible to create Electron's app to present
the problem but in our project we added possibility to turn on/off
the frame on the window and after adding new container to the window
it becomes blank because of the wrong visibility state of the window.

Notes: fixed possible problem with visibility state on mac
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
