### PR TITLE
test: skip "handles Promise timeouts correctly" when ELECTRON_RUN_AS_NODE is disabled

### DIFF
--- a/spec-main/node-spec.ts
+++ b/spec-main/node-spec.ts
@@ -308,7 +308,7 @@ describe('node feature', () => {
     expect(result.status).to.equal(0);
   });
 
-  it('handles Promise timeouts correctly', (done) => {
+  ifit(features.isRunAsNodeEnabled())('handles Promise timeouts correctly', (done) => {
     const scriptPath = path.join(fixtures, 'module', 'node-promise-timer.js');
     const child = childProcess.spawn(process.execPath, [scriptPath], {
       env: { ELECTRON_RUN_AS_NODE: 'true' }


### PR DESCRIPTION
#### Description of Change
This test fails when `ELECTRON_RUN_AS_NODE` is disabled, let's skip it in this case.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: none