### PR TITLE
chore: support --remote-debugging-pipe command line flag

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -439,10 +439,14 @@ void ElectronBrowserMainParts::PreMainMessageLoopRun() {
   content::WebUIControllerFactory::RegisterFactory(
       ElectronWebUIControllerFactory::GetInstance());
 
-  // --remote-debugging-port
   auto* command_line = base::CommandLine::ForCurrentProcess();
-  if (command_line->HasSwitch(switches::kRemoteDebuggingPort))
+  if (command_line->HasSwitch(switches::kRemoteDebuggingPipe)) {
+    // --remote-debugging-pipe
+    content::DevToolsAgentHost::StartRemoteDebuggingPipeHandler();
+  } else if (command_line->HasSwitch(switches::kRemoteDebuggingPort)) {
+    // --remote-debugging-port
     DevToolsManagerDelegate::StartHttpHandler();
+  }
 
 #if !defined(OS_MACOSX)
   // The corresponding call in macOS is in ElectronApplicationDelegate.
@@ -511,6 +515,7 @@ void ElectronBrowserMainParts::PostMainMessageLoopRun() {
   node_env_.reset();
 
   fake_browser_process_->PostMainMessageLoopRun();
+  content::DevToolsAgentHost::StopRemoteDebuggingPipeHandler();
 }
 
 #if !defined(OS_MACOSX)

--- a/spec-main/pipe-transport.ts
+++ b/spec-main/pipe-transport.ts
@@ -1,0 +1,37 @@
+// A small pipe transport for talking to Electron over CDP.
+export class PipeTransport {
+  private _pipeWrite: NodeJS.WritableStream | null;
+  private _pendingMessage = '';
+
+  onmessage?: (message: string) => void;
+
+  constructor (pipeWrite: NodeJS.WritableStream, pipeRead: NodeJS.ReadableStream) {
+    this._pipeWrite = pipeWrite;
+    pipeRead.on('data', buffer => this._dispatch(buffer));
+  }
+
+  send (message: Object) {
+    this._pipeWrite!.write(JSON.stringify(message));
+    this._pipeWrite!.write('\0');
+  }
+
+  _dispatch (buffer: Buffer) {
+    let end = buffer.indexOf('\0');
+    if (end === -1) {
+      this._pendingMessage += buffer.toString();
+      return;
+    }
+    const message = this._pendingMessage + buffer.toString(undefined, 0, end);
+    if (this.onmessage) { this.onmessage.call(null, JSON.parse(message)); }
+
+    let start = end + 1;
+    end = buffer.indexOf('\0', start);
+    while (end !== -1) {
+      const message = buffer.toString(undefined, start, end);
+      if (this.onmessage) { this.onmessage.call(null, JSON.parse(message)); }
+      start = end + 1;
+      end = buffer.indexOf('\0', start);
+    }
+    this._pendingMessage = buffer.toString(undefined, start);
+  }
+}


### PR DESCRIPTION
#### Description of Change

This change introduces a new `--remote-debugging-pipe` command line flag.

When passed, Electron exposes Chrome remote debugging protocol over the process Pipes 3 & 4, similarly to how Chrome itself does.

This option is handy for the debugging and testing scenarios where binding a port for the remote debugging web socket is problematic or insecure.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are added
- [x] PR title follows semantic
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
