### PR TITLE
chore: handle Browser.close over CDP

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -364,6 +364,7 @@ source_set("electron_lib") {
     "//third_party/blink/public:blink",
     "//third_party/boringssl",
     "//third_party/electron_node:node_lib",
+    "//third_party/inspector_protocol:crdtp",
     "//third_party/leveldatabase",
     "//third_party/libyuv",
     "//third_party/webrtc_overrides:webrtc_component",


### PR DESCRIPTION
#### Description of Change

This change makes Electron handle [`Browser.close`](https://chromedevtools.github.io/devtools-protocol/tot/Browser/#method-close) CDP command for automation. Automation driver can start Electron process, but it needs a graceful way of shutting it down to prevent core dump pollution. Chrome and Headless have similar logic implemented in [BrowserHandler::Close](https://cs.chromium.org/search/?q=BrowserHandler::Close&sq=package:chromium&type=cs).

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are added
- [x] PR title follows semantic

#### Release Notes

Notes: none
