### PR TITLE
[wip] feat: add hooks for profiling startup performance

### DIFF
--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -149,6 +149,23 @@ The time is represented as number of milliseconds since epoch. It returns null i
 
 Returns [`CPUUsage`](structures/cpu-usage.md)
 
+### `process.getProfilingMarks()`
+
+Returns an object of name/timestamp pairs that can be used in profiling an application's performance.
+
+FIXME: add more information
+
+Returns `Object`:
+
+* `main` Date
+* `basicStartupComplete` Date
+* `nodeLoadEnvironment` Date
+* `initBegin` Date
+* `initEnd` Date
+* `didCreateScriptContext` Date | null
+* `renderFrameCreated` Date | null
+* `renderThreadStarted` Date | null
+
 ### `process.getIOCounters()` _Windows_ _Linux_
 
 Returns [`IOCounters`](structures/io-counters.md)

--- a/filenames.gni
+++ b/filenames.gni
@@ -570,6 +570,8 @@ filenames = {
     "shell/common/platform_util_win.cc",
     "shell/common/process_util.cc",
     "shell/common/process_util.h",
+    "shell/common/profiling.cc",
+    "shell/common/profiling.h",
     "shell/common/skia_util.cc",
     "shell/common/skia_util.h",
     "shell/common/v8_value_converter.cc",

--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -17,6 +17,9 @@ require('../common/reset-search-paths');
 // Import common settings.
 require('@electron/internal/common/init');
 
+const v8Util = process.electronBinding('v8_util');
+v8Util.markInitBegin();
+
 process.electronBinding('event_emitter').setEventEmitterPrototype(EventEmitter.prototype);
 
 if (process.platform === 'win32') {
@@ -206,6 +209,8 @@ const { setDefaultApplicationMenu } = require('@electron/internal/browser/defaul
 // The |will-finish-launching| event is emitted before |ready| event, so default
 // menu is set before any user window is created.
 app.once('will-finish-launching', setDefaultApplicationMenu);
+
+v8Util.markInitEnd();
 
 if (packagePath) {
   // Finally load app's main.js and transfer control to C++.

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -38,6 +38,7 @@ require('@electron/internal/common/init');
 
 // The global variable will be used by ipc for event dispatching
 const v8Util = process.electronBinding('v8_util');
+v8Util.markInitBegin();
 
 const ipcEmitter = new EventEmitter();
 const ipcInternalEmitter = new EventEmitter();
@@ -187,6 +188,8 @@ if (nodeIntegration) {
     });
   }
 }
+
+v8Util.markInitEnd();
 
 // Load the preload scripts.
 for (const preloadScript of preloadScripts) {

--- a/lib/sandboxed_renderer/init.js
+++ b/lib/sandboxed_renderer/init.js
@@ -8,6 +8,7 @@ const { EventEmitter } = events;
 process.electronBinding = require('@electron/internal/common/electron-binding-setup').electronBindingSetup(binding.get, 'renderer');
 
 const v8Util = process.electronBinding('v8_util');
+v8Util.markInitBegin();
 // Expose Buffer shim as a hidden value. This is used by C++ code to
 // deserialize Buffer instances sent from browser process.
 v8Util.setHiddenValue(global, 'Buffer', Buffer);
@@ -169,6 +170,8 @@ function runPreloadScript (preloadSrc) {
 
   preloadFn(preloadRequire, preloadProcess, Buffer, global, setImmediate, clearImmediate, {});
 }
+
+v8Util.markInitEnd();
 
 for (const { preloadPath, preloadSrc, preloadError } of preloadScripts) {
   try {

--- a/shell/app/electron_library_main.mm
+++ b/shell/app/electron_library_main.mm
@@ -13,8 +13,10 @@
 #include "shell/app/node_main.h"
 #include "shell/common/electron_command_line.h"
 #include "shell/common/mac/main_application_bundle.h"
+#include "shell/common/profiling.h"
 
 int ElectronMain(int argc, char* argv[]) {
+  electron::profiling::Mark("main");
   electron::ElectronMainDelegate delegate;
   content::ContentMainParams params(&delegate);
   params.argc = argc;

--- a/shell/app/electron_main.cc
+++ b/shell/app/electron_main.cc
@@ -44,6 +44,7 @@
 #include "shell/app/node_main.h"
 #include "shell/common/electron_command_line.h"
 #include "shell/common/electron_constants.h"
+#include "shell/common/profiling.h"
 
 #if defined(HELPER_EXECUTABLE) && !defined(MAS_BUILD)
 #include "sandbox/mac/seatbelt_exec.h"  // nogncheck
@@ -99,6 +100,8 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
 
   if (!arguments.argv)
     return -1;
+
+  electron::profiling::Mark("main");
 
 #ifdef _DEBUG
   // Don't display assert dialog boxes in CI test runs
@@ -171,6 +174,7 @@ int main(int argc, char* argv[]) {
   }
 #endif
 
+  electron::profiling::Mark("main");
   electron::ElectronMainDelegate delegate;
   content::ContentMainParams params(&delegate);
   params.argc = argc;

--- a/shell/app/electron_main_delegate.cc
+++ b/shell/app/electron_main_delegate.cc
@@ -33,6 +33,7 @@
 #include "shell/browser/feature_list.h"
 #include "shell/browser/relauncher.h"
 #include "shell/common/options_switches.h"
+#include "shell/common/profiling.h"
 #include "shell/renderer/electron_renderer_client.h"
 #include "shell/renderer/electron_sandboxed_renderer_client.h"
 #include "shell/utility/electron_content_utility_client.h"
@@ -130,6 +131,7 @@ const size_t ElectronMainDelegate::kNonWildcardDomainNonPortSchemesSize =
     base::size(kNonWildcardDomainNonPortSchemes);
 
 bool ElectronMainDelegate::BasicStartupComplete(int* exit_code) {
+  profiling::Mark("basic_startup_complete");
   auto* command_line = base::CommandLine::ForCurrentProcess();
 
   logging::LoggingSettings settings;

--- a/shell/common/api/electron_api_v8_util.cc
+++ b/shell/common/api/electron_api_v8_util.cc
@@ -11,6 +11,7 @@
 #include "shell/common/gin_converters/gurl_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_includes.h"
+#include "shell/common/profiling.h"
 #include "url/origin.h"
 #include "v8/include/v8-profiler.h"
 
@@ -102,6 +103,14 @@ void TakeHeapSnapshot(v8::Isolate* isolate) {
   isolate->GetHeapProfiler()->TakeHeapSnapshot();
 }
 
+void MarkInitBegin() {
+  electron::profiling::Mark("init_begin");
+}
+
+void MarkInitEnd() {
+  electron::profiling::Mark("init_end");
+}
+
 void RequestGarbageCollectionForTesting(v8::Isolate* isolate) {
   isolate->RequestGarbageCollectionForTesting(
       v8::Isolate::GarbageCollectionType::kFullGarbageCollection);
@@ -135,6 +144,8 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("requestGarbageCollectionForTesting",
                  &RequestGarbageCollectionForTesting);
   dict.SetMethod("isSameOrigin", &IsSameOrigin);
+  dict.SetMethod("markInitBegin", &MarkInitBegin);
+  dict.SetMethod("markInitEnd", &MarkInitEnd);
 }
 
 }  // namespace

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -28,6 +28,7 @@
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/heap_snapshot.h"
 #include "shell/common/node_includes.h"
+#include "shell/common/profiling.h"
 #include "third_party/blink/renderer/platform/heap/process_heap.h"  // nogncheck
 
 namespace electron {
@@ -72,6 +73,7 @@ void ElectronBindings::BindProcess(v8::Isolate* isolate,
   process->SetMethod("getCPUUsage",
                      base::BindRepeating(&ElectronBindings::GetCPUUsage,
                                          base::Unretained(metrics)));
+  process->SetMethod("getProfilingMarks", &GetProfilingMarks);
 
 #if defined(MAS_BUILD)
   process->SetReadOnly("mas", true);

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -31,6 +31,7 @@
 #include "shell/common/gin_helper/locker.h"
 #include "shell/common/mac/main_application_bundle.h"
 #include "shell/common/node_includes.h"
+#include "shell/common/profiling.h"
 
 #define ELECTRON_BUILTIN_MODULES(V)      \
   V(electron_browser_app)                \
@@ -451,6 +452,7 @@ node::Environment* NodeBindings::CreateEnvironment(
 }
 
 void NodeBindings::LoadEnvironment(node::Environment* env) {
+  profiling::Mark("node_load_environment");
   node::LoadEnvironment(env);
   gin_helper::EmitEvent(env->isolate(), env->process_object(), "loaded");
 }

--- a/shell/common/profiling.cc
+++ b/shell/common/profiling.cc
@@ -1,0 +1,47 @@
+// Copyright (c) 2019 Microsoft Corporation.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include <vector>
+
+#include "electron/shell/common/gin_helper/dictionary.h"
+#include "electron/shell/common/profiling.h"
+
+namespace gin {
+
+template <>
+struct Converter<base::Time> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const base::Time& val) {
+    v8::MaybeLocal<v8::Value> date =
+        v8::Date::New(isolate->GetCurrentContext(), val.ToJsTime());
+    if (date.IsEmpty())
+      return v8::Null(isolate);
+    return date.ToLocalChecked();
+  }
+};
+
+}  // namespace gin
+
+namespace electron {
+
+namespace profiling {
+
+std::vector<std::pair<std::string, base::Time>> marks;
+
+void Mark(base::StringPiece key) {
+  marks.emplace_back(key.as_string(), base::Time::Now());
+}
+
+}  // namespace profiling
+
+v8::Local<v8::Value> GetProfilingMarks(v8::Isolate* isolate) {
+  gin_helper::Dictionary dict = gin::Dictionary::CreateEmpty(isolate);
+  dict.SetHidden("simple", true);
+  for (const auto& it : profiling::marks) {
+    dict.Set(it.first, it.second);
+  }
+  return gin::ConvertToV8(isolate, dict);
+}
+
+}  // namespace electron

--- a/shell/common/profiling.h
+++ b/shell/common/profiling.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2019 Microsoft Corporation.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SRC_ELECTRON_SHELL_COMMON_PROFILING_H_
+#define SRC_ELECTRON_SHELL_COMMON_PROFILING_H_
+
+#include "base/strings/string_piece.h"
+#include "v8/include/v8.h"
+
+namespace electron {
+
+namespace profiling {
+
+void Mark(base::StringPiece key);
+
+}  // namespace profiling
+
+v8::Local<v8::Value> GetProfilingMarks(v8::Isolate* isolate);
+
+}  // namespace electron
+
+#endif  // SRC_ELECTRON_SHELL_COMMON_PROFILING_H_

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -24,6 +24,7 @@
 #include "shell/common/color_util.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/options_switches.h"
+#include "shell/common/profiling.h"
 #include "shell/common/world_ids.h"
 #include "shell/renderer/browser_exposed_renderer_interfaces.h"
 #include "shell/renderer/content_settings_observer.h"
@@ -124,6 +125,7 @@ void RendererClientBase::DidCreateScriptContext(
     v8::Handle<v8::Context> context,
     content::RenderFrame* render_frame) {
   // global.setHidden("contextId", `${processHostId}-${++next_context_id_}`)
+  profiling::Mark("did_create_script_context");
   auto context_id = base::StringPrintf(
       "%s-%" PRId64, renderer_client_id_.c_str(), ++next_context_id_);
   gin_helper::Dictionary global(context->GetIsolate(), context->Global());
@@ -142,6 +144,7 @@ void RendererClientBase::AddRenderBindings(
     v8::Local<v8::Object> binding_object) {}
 
 void RendererClientBase::RenderThreadStarted() {
+  profiling::Mark("render_thread_started");
   auto* command_line = base::CommandLine::ForCurrentProcess();
 
 #if BUILDFLAG(USE_EXTERNAL_POPUP_MENU)
@@ -243,6 +246,7 @@ void RendererClientBase::ExposeInterfacesToBrowser(mojo::BinderMap* binders) {
 
 void RendererClientBase::RenderFrameCreated(
     content::RenderFrame* render_frame) {
+  profiling::Mark("render_frame_created");
 #if defined(TOOLKIT_VIEWS)
   new AutofillAgent(render_frame,
                     render_frame->GetAssociatedInterfaceRegistry());

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -34,6 +34,8 @@ declare namespace NodeJS {
     createIDWeakMap<V>(): ElectronInternal.KeyWeakMap<number, V>;
     createDoubleIDWeakMap<V>(): ElectronInternal.KeyWeakMap<[string, number], V>;
     setRemoteCallbackFreer(fn: Function, frameId: number, contextId: String, id: number, sender: any): void
+    markInitBegin(): void;
+    markInitEnd(): void;
   }
 
   interface Process {


### PR DESCRIPTION
#### Description of Change

This is a draft of some code that's been used by an internal app for awhile. Since it could be useful to other users too, this is a draft of an API that could be both generally usable and also extensible.

The documentation and tests are incomplete since this PR is still in the feedback-gathering phase...

Feedback welcomed @miniak @alexeykuzmin 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added startup profiling API.