### PR TITLE
chore: cherry-pick 826a4af58b3d from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -94,3 +94,4 @@ feat_enable_offscreen_rendering_with_viz_compositor.patch
 when_suspending_context_don_t_clear_handlers.patch
 use_keepselfalive_on_audiocontext_to_keep_it_alive_until_rendering.patch
 never_let_a_non-zero-size_pixel_snap_to_zero_size.patch
+cherry-pick-826a4af58b3d.patch

--- a/patches/chromium/cherry-pick-826a4af58b3d.patch
+++ b/patches/chromium/cherry-pick-826a4af58b3d.patch
@@ -1,7 +1,7 @@
-From 826a4af58b3d26e49a47ce4df2ac6d06af1c2dc2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mustafa Emre Acer <meacer@chromium.org>
 Date: Fri, 10 Apr 2020 00:43:45 +0000
-Subject: [PATCH] Don't decode invalid punycode in URL formatter
+Subject: Don't decode invalid punycode in URL formatter
 
 TBR=meacer@chromium.org
 
@@ -17,26 +17,22 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2144830
 Reviewed-by: Mustafa Emre Acer <meacer@chromium.org>
 Cr-Commit-Position: refs/branch-heads/4103@{#62}
 Cr-Branched-From: 8ad47e8d21f6866e4a37f47d83a860d41debf514-refs/heads/master@{#756066}
----
- .../url_formatter/spoof_checks/idn_spoof_checker_unittest.cc  | 2 ++
- components/url_formatter/url_formatter.cc                     | 4 +++-
- 2 files changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/components/url_formatter/spoof_checks/idn_spoof_checker_unittest.cc b/components/url_formatter/spoof_checks/idn_spoof_checker_unittest.cc
-index 44f2963d58f9b..f9821773c9681 100644
+index f695e5c403cbcb020b2ef8016fb513ba1b8d97d1..ffd06415c9afd54c008d86f817cb0e704de87601 100644
 --- a/components/url_formatter/spoof_checks/idn_spoof_checker_unittest.cc
 +++ b/components/url_formatter/spoof_checks/idn_spoof_checker_unittest.cc
-@@ -70,6 +70,8 @@ const IDNTestCase kIdnCases[] = {
-     {"www.google.com.", L"www.google.com.", kSafe},
-     {".", L".", kSafe},
-     {"", L"", kSafe},
+@@ -55,6 +55,8 @@ const IDNTestCase kIdnCases[] = {
+     {"www.google.com.", L"www.google.com.", true},
+     {".", L".", true},
+     {"", L"", true},
 +    // Invalid IDN
-+    {"xn--example-.com", L"xn--example-.com", kInvalid},
++    {"xn--example-.com", L"xn--example-.com", false},
      // IDN
      // Hanzi (Traditional Chinese)
-     {"xn--1lq90ic7f1rc.cn", L"\x5317\x4eac\x5927\x5b78.cn", kSafe},
+     {"xn--1lq90ic7f1rc.cn", L"\x5317\x4eac\x5927\x5b78.cn", true},
 diff --git a/components/url_formatter/url_formatter.cc b/components/url_formatter/url_formatter.cc
-index 58cadb980bb87..d7cc2ea441c91 100644
+index 58cadb980bb877c933e37457b1ab0883357ece47..d7cc2ea441c916fb77a520f8fe440cff042b6aab 100644
 --- a/components/url_formatter/url_formatter.cc
 +++ b/components/url_formatter/url_formatter.cc
 @@ -408,9 +408,11 @@ bool IDNToUnicodeOneComponent(const base::char16* comp,

--- a/patches/chromium/cherry-pick-826a4af58b3d.patch
+++ b/patches/chromium/cherry-pick-826a4af58b3d.patch
@@ -1,0 +1,54 @@
+From 826a4af58b3d26e49a47ce4df2ac6d06af1c2dc2 Mon Sep 17 00:00:00 2001
+From: Mustafa Emre Acer <meacer@chromium.org>
+Date: Fri, 10 Apr 2020 00:43:45 +0000
+Subject: [PATCH] Don't decode invalid punycode in URL formatter
+
+TBR=meacer@chromium.org
+
+(cherry picked from commit 50c6e900fc4170a14154cbfea57ade2aa50990b5)
+
+Bug: 1063566
+Change-Id: I631ba68718cf69c5972555d7826b089e27fa5150
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2137872
+Reviewed-by: Peter Kasting <pkasting@chromium.org>
+Commit-Queue: Peter Kasting <pkasting@chromium.org>
+Cr-Original-Commit-Position: refs/heads/master@{#756819}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2144830
+Reviewed-by: Mustafa Emre Acer <meacer@chromium.org>
+Cr-Commit-Position: refs/branch-heads/4103@{#62}
+Cr-Branched-From: 8ad47e8d21f6866e4a37f47d83a860d41debf514-refs/heads/master@{#756066}
+---
+ .../url_formatter/spoof_checks/idn_spoof_checker_unittest.cc  | 2 ++
+ components/url_formatter/url_formatter.cc                     | 4 +++-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/components/url_formatter/spoof_checks/idn_spoof_checker_unittest.cc b/components/url_formatter/spoof_checks/idn_spoof_checker_unittest.cc
+index 44f2963d58f9b..f9821773c9681 100644
+--- a/components/url_formatter/spoof_checks/idn_spoof_checker_unittest.cc
++++ b/components/url_formatter/spoof_checks/idn_spoof_checker_unittest.cc
+@@ -70,6 +70,8 @@ const IDNTestCase kIdnCases[] = {
+     {"www.google.com.", L"www.google.com.", kSafe},
+     {".", L".", kSafe},
+     {"", L"", kSafe},
++    // Invalid IDN
++    {"xn--example-.com", L"xn--example-.com", kInvalid},
+     // IDN
+     // Hanzi (Traditional Chinese)
+     {"xn--1lq90ic7f1rc.cn", L"\x5317\x4eac\x5927\x5b78.cn", kSafe},
+diff --git a/components/url_formatter/url_formatter.cc b/components/url_formatter/url_formatter.cc
+index 58cadb980bb87..d7cc2ea441c91 100644
+--- a/components/url_formatter/url_formatter.cc
++++ b/components/url_formatter/url_formatter.cc
+@@ -408,9 +408,11 @@ bool IDNToUnicodeOneComponent(const base::char16* comp,
+     return false;
+ 
+   // Early return if the input cannot be an IDN component.
++  // Valid punycode must not end with a dash.
+   static const base::char16 kIdnPrefix[] = {'x', 'n', '-', '-'};
+   if (comp_len <= base::size(kIdnPrefix) ||
+-      memcmp(comp, kIdnPrefix, sizeof(kIdnPrefix)) != 0) {
++      memcmp(comp, kIdnPrefix, sizeof(kIdnPrefix)) != 0 ||
++      comp[comp_len - 1] == '-') {
+     out->append(comp, comp_len);
+     return false;
+   }


### PR DESCRIPTION
Don't decode invalid punycode in URL formatter

TBR=meacer@chromium.org

(cherry picked from commit 50c6e900fc4170a14154cbfea57ade2aa50990b5)

Bug: 1063566
Change-Id: I631ba68718cf69c5972555d7826b089e27fa5150
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2137872
Reviewed-by: Peter Kasting <pkasting@chromium.org>
Commit-Queue: Peter Kasting <pkasting@chromium.org>
Cr-Original-Commit-Position: refs/heads/master@{#756819}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2144830
Reviewed-by: Mustafa Emre Acer <meacer@chromium.org>
Cr-Commit-Position: refs/branch-heads/4103@{#62}
Cr-Branched-From: 8ad47e8d21f6866e4a37f47d83a860d41debf514-refs/heads/master@{#756066}

Notes: Security: backported fix for CVE-2020-6460: Insufficient data validation in URL formatting.