### PR TITLE
fix: NSImageName string conversion

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2363,7 +2363,7 @@ void WebContents::StartDrag(const gin_helper::Dictionary& item,
   }
 
   gin::Handle<NativeImage> icon;
-  if (!item.Get("icon", &icon)) {
+  if (!item.Get("icon", &icon) || icon->image().IsEmpty()) {
     args->ThrowError("Must specify non-empty 'icon' option");
     return;
   }

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -490,9 +490,8 @@ gin::Handle<NativeImage> NativeImage::CreateFromDataURL(v8::Isolate* isolate,
 }
 
 #if !defined(OS_MACOSX)
-gin::Handle<NativeImage> NativeImage::CreateFromNamedImage(
-    gin::Arguments* args,
-    const std::string& name) {
+gin::Handle<NativeImage> NativeImage::CreateFromNamedImage(gin::Arguments* args,
+                                                           std::string name) {
   return CreateEmpty(args->isolate());
 }
 #endif

--- a/shell/common/api/electron_api_native_image.h
+++ b/shell/common/api/electron_api_native_image.h
@@ -62,7 +62,7 @@ class NativeImage : public gin_helper::Wrappable<NativeImage> {
   static gin::Handle<NativeImage> CreateFromDataURL(v8::Isolate* isolate,
                                                     const GURL& url);
   static gin::Handle<NativeImage> CreateFromNamedImage(gin::Arguments* args,
-                                                       const std::string& name);
+                                                       std::string name);
 
   static void BuildPrototype(v8::Isolate* isolate,
                              v8::Local<v8::FunctionTemplate> prototype);

--- a/shell/common/api/electron_api_native_image_mac.mm
+++ b/shell/common/api/electron_api_native_image_mac.mm
@@ -33,12 +33,24 @@ double safeShift(double in, double def) {
   return def;
 }
 
-gin::Handle<NativeImage> NativeImage::CreateFromNamedImage(
-    gin::Arguments* args,
-    const std::string& name) {
+gin::Handle<NativeImage> NativeImage::CreateFromNamedImage(gin::Arguments* args,
+                                                           std::string name) {
   @autoreleasepool {
     std::vector<double> hsl_shift;
+
+    // The string representations of NSImageNames don't match the strings
+    // themselves; they instead follow the following pattern:
+    //  * NSImageNameActionTemplate -> "NSActionTemplate"
+    //  * NSImageNameMultipleDocuments -> "NSMultipleDocuments"
+    // To account for this, we strip out "ImageName" from the passed string.
+    std::string to_remove("ImageName");
+    size_t pos = name.find(to_remove);
+    if (pos != std::string::npos) {
+      name.erase(pos, to_remove.length());
+    }
+
     NSImage* image = [NSImage imageNamed:base::SysUTF8ToNSString(name)];
+
     if (!image.valid) {
       return CreateEmpty(args->isolate());
     }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/23428.

Ah, Apple. Previously, we assumed that `NSImageName`s constant names matched their underlying strings. After some digging, I determined that the string representations of `NSImageName`s do _not_ in fact match the strings
themselves and instead follow the following pattern:

 * NSImageNameActionTemplate -> "NSActionTemplate"
 * NSImageNameMultipleDocuments -> "NSMultipleDocuments"

To account for this, we can strip out "ImageName" from the passed string so that it matches the system string.

Tested with https://gist.github.com/fb71b7a822216ad886263f5a48856502.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `startDrag` could crash if some specific strings were passed into `nativeImage.createFromImage` to create the `icon`.
