### PR TITLE
chore: add DCHECK to ensure extension_system() is not used for in-memory sessions

### DIFF
--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -139,9 +139,10 @@ class ElectronBrowserContext
   }
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-  // Guard usages of extension_system() with !IsOffTheRecord()
-  // There is no extension system for in-memory sessions
   extensions::ElectronExtensionSystem* extension_system() {
+    // Guard usages of extension_system() with !IsOffTheRecord()
+    // There is no extension system for in-memory sessions
+    DCHECK(!IsOffTheRecord());
     return extension_system_;
   }
 #endif


### PR DESCRIPTION
Just safety checks so we crash if this is mis-used

Notes: no-notes