### PR TITLE
docs: badgeCount needs notifications permission on macOS

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1305,6 +1305,9 @@ On macOS, setting this with any nonzero integer shows on the dock icon. On Linux
 **Note:** Unity launcher requires the existence of a `.desktop` file to work,
 for more information please read [Desktop Environment Integration][unity-requirement].
 
+**Note:** On macOS, you need to ensure that your application has the permission
+to display notifications for this property to take effect.
+
 ### `app.commandLine` _Readonly_
 
 A [`CommandLine`](./command-line.md) object that allows you to read and manipulate the


### PR DESCRIPTION
#### Description of Change

In order for `badgeCount` to properly update the dock icon on macOS, the application needs to have the permissions to display notifications.

Cross-refs #22715.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes