### PR TITLE
build: fix building with enable_remote_module = false

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -581,8 +581,6 @@ source_set("electron_lib") {
 
   if (enable_remote_module) {
     sources += [
-      "shell/common/api/remote/object_life_monitor.cc",
-      "shell/common/api/remote/object_life_monitor.h",
       "shell/common/api/remote/remote_callback_freer.cc",
       "shell/common/api/remote/remote_callback_freer.h",
       "shell/common/api/remote/remote_object_freer.cc",

--- a/filenames.gni
+++ b/filenames.gni
@@ -454,6 +454,8 @@ filenames = {
     "shell/common/api/electron_bindings.cc",
     "shell/common/api/electron_bindings.h",
     "shell/common/api/features.cc",
+    "shell/common/api/object_life_monitor.cc",
+    "shell/common/api/object_life_monitor.h",
     "shell/common/application_info.cc",
     "shell/common/application_info.h",
     "shell/common/application_info_linux.cc",

--- a/shell/common/api/electron_api_v8_util.cc
+++ b/shell/common/api/electron_api_v8_util.cc
@@ -127,12 +127,12 @@ void Initialize(v8::Local<v8::Object> exports,
                  &electron::RemoteCallbackFreer::BindTo);
   dict.SetMethod("setRemoteObjectFreer", &electron::RemoteObjectFreer::BindTo);
   dict.SetMethod("addRemoteObjectRef", &electron::RemoteObjectFreer::AddRef);
+  dict.SetMethod("createIDWeakMap",
+                 &electron::api::KeyWeakMap<int32_t>::Create);
   dict.SetMethod(
       "createDoubleIDWeakMap",
       &electron::api::KeyWeakMap<std::pair<std::string, int32_t>>::Create);
 #endif
-  dict.SetMethod("createIDWeakMap",
-                 &electron::api::KeyWeakMap<int32_t>::Create);
   dict.SetMethod("requestGarbageCollectionForTesting",
                  &RequestGarbageCollectionForTesting);
   dict.SetMethod("isSameOrigin", &IsSameOrigin);

--- a/shell/common/api/object_life_monitor.cc
+++ b/shell/common/api/object_life_monitor.cc
@@ -3,7 +3,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "shell/common/api/remote/object_life_monitor.h"
+#include "shell/common/api/object_life_monitor.h"
 
 #include "base/bind.h"
 #include "base/message_loop/message_loop.h"

--- a/shell/common/api/object_life_monitor.h
+++ b/shell/common/api/object_life_monitor.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#ifndef SHELL_COMMON_API_REMOTE_OBJECT_LIFE_MONITOR_H_
-#define SHELL_COMMON_API_REMOTE_OBJECT_LIFE_MONITOR_H_
+#ifndef SHELL_COMMON_API_OBJECT_LIFE_MONITOR_H_
+#define SHELL_COMMON_API_OBJECT_LIFE_MONITOR_H_
 
 #include "base/macros.h"
 #include "base/memory/weak_ptr.h"
@@ -31,4 +31,4 @@ class ObjectLifeMonitor {
 
 }  // namespace electron
 
-#endif  // SHELL_COMMON_API_REMOTE_OBJECT_LIFE_MONITOR_H_
+#endif  // SHELL_COMMON_API_OBJECT_LIFE_MONITOR_H_

--- a/shell/common/api/remote/remote_callback_freer.h
+++ b/shell/common/api/remote/remote_callback_freer.h
@@ -8,7 +8,7 @@
 #include <string>
 
 #include "content/public/browser/web_contents_observer.h"
-#include "shell/common/api/remote/object_life_monitor.h"
+#include "shell/common/api/object_life_monitor.h"
 
 namespace electron {
 

--- a/shell/common/api/remote/remote_object_freer.h
+++ b/shell/common/api/remote/remote_object_freer.h
@@ -8,7 +8,7 @@
 #include <map>
 #include <string>
 
-#include "shell/common/api/remote/object_life_monitor.h"
+#include "shell/common/api/object_life_monitor.h"
 
 namespace electron {
 

--- a/shell/renderer/api/context_bridge/object_cache.cc
+++ b/shell/renderer/api/context_bridge/object_cache.cc
@@ -6,7 +6,7 @@
 
 #include <utility>
 
-#include "shell/common/api/remote/object_life_monitor.h"
+#include "shell/common/api/object_life_monitor.h"
 
 namespace electron {
 

--- a/shell/renderer/api/context_bridge/render_frame_function_store.cc
+++ b/shell/renderer/api/context_bridge/render_frame_function_store.cc
@@ -6,7 +6,7 @@
 
 #include <utility>
 
-#include "shell/common/api/remote/object_life_monitor.h"
+#include "shell/common/api/object_life_monitor.h"
 
 namespace electron {
 

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -15,7 +15,7 @@
 #include "base/strings/string_number_conversions.h"
 #include "content/public/renderer/render_frame.h"
 #include "content/public/renderer/render_frame_observer.h"
-#include "shell/common/api/remote/object_life_monitor.h"
+#include "shell/common/api/object_life_monitor.h"
 #include "shell/common/gin_converters/blink_converter.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_helper/dictionary.h"


### PR DESCRIPTION
#### Description of Change
Fix building with `enable_remote_module = false`.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes