### PR TITLE
fix: leave behind the unmodified XDG_CURRENT_DESKTOP variable

### DIFF
--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -147,3 +147,14 @@ the one downloaded by `npm install`. Usage:
 ```sh
 export ELECTRON_OVERRIDE_DIST_PATH=/Users/username/projects/electron/out/Testing
 ```
+
+## Set By Electron
+
+Electron sets some variables in your environment at runtime.
+
+### `ORIGINAL_XDG_CURRENT_DESKTOP`
+
+This variable is set to the value of `XDG_CURRENT_DESKTOP` that your application
+originally launched with.  Electron sometimes modifies the value of `XDG_CURRENT_DESKTOP`
+to affect other logic within Chromium so if you want access to the _original_ value
+you should look up this environment variable instead.

--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -186,6 +186,7 @@ function currentPlatformSupportsAppIndicator () {
 }
 
 // Workaround for electron/electron#5050 and electron/electron#9046
+process.env.ORIGINAL_XDG_CURRENT_DESKTOP = process.env.XDG_CURRENT_DESKTOP;
 if (currentPlatformSupportsAppIndicator()) {
   process.env.XDG_CURRENT_DESKTOP = 'Unity';
 }


### PR DESCRIPTION
By mutating this variable apps can't actually check the original value for things like platform/OS/UA detection.

Notes: no-notes