### PR TITLE
build: use correct v8_context_snapshot_generator in mksnapshot zip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -670,8 +670,10 @@ step-mksnapshot-build: &step-mksnapshot-build
       if [ "`uname`" != "Darwin" ]; then
         if [ "$TARGET_ARCH" == "arm" ]; then
           electron/script/strip-binaries.py --file $PWD/out/Default/clang_x86_v8_arm/mksnapshot
+          electron/script/strip-binaries.py --file $PWD/out/Default/clang_x86_v8_arm/v8_context_snapshot_generator
         elif [ "$TARGET_ARCH" == "arm64" ]; then
           electron/script/strip-binaries.py --file $PWD/out/Default/clang_x64_v8_arm64/mksnapshot
+          electron/script/strip-binaries.py --file $PWD/out/Default/clang_x64_v8_arm64/v8_context_snapshot_generator
         else
           electron/script/strip-binaries.py --file $PWD/out/Default/mksnapshot
           electron/script/strip-binaries.py --file $PWD/out/Default/v8_context_snapshot_generator

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1271,7 +1271,7 @@ dist_zip("electron_chromedriver_zip") {
 
 mksnapshot_deps = [
   ":licenses",
-  "//tools/v8_context_snapshot:v8_context_snapshot_generator",
+  "//tools/v8_context_snapshot:v8_context_snapshot_generator($v8_snapshot_toolchain)",
   "//v8:mksnapshot($v8_snapshot_toolchain)",
 ]
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
While getting mksnapshot ready for the 9-x-y release, I realized that our packaging of mksnapshot for arm/arm64 is incorrect.  The mksnapshot zip contains two executables:
`mksnapshot` and `v8_context_snapshot_generator`.  Before this fix the mksnapshot zip for arm and arm64 contained an x64 mksnapshot binary and a arm/arm64 `v8_context_snapshot_generator` binary.  Since you cannot run mksnapshot on arm/arm64 it doesn't make sense to include the arm/arm64 `v8_context_snapshot_generator` binary but we should instead include the x64 `v8_context_snapshot_generator` binary so that you can generate arm/arm64 snapshots on an x64 machine.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->Fixes v8_context_snapshot_generator included in arm/arm64 mksnapshot zip files.
