### PR TITLE
fix: generate symbols for the correct crashpad handler binary

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -989,10 +989,10 @@ if (is_mac) {
     }
 
     extract_symbols("crashpad_handler_syms") {
-      binary = "$root_out_dir/crashpad_handler"
+      binary = "$root_out_dir/chrome_crashpad_handler"
       symbol_dir = "$root_out_dir/breakpad_symbols"
-      dsym_file = "$root_out_dir/crashpad_handler.dSYM/Contents/Resources/DWARF/crashpad_handler"
-      deps = [ "//third_party/crashpad/crashpad/handler:crashpad_handler" ]
+      dsym_file = "$root_out_dir/chrome_crashpad_handler.dSYM/Contents/Resources/DWARF/chrome_crashpad_handler"
+      deps = [ "//components/crash/core/app:chrome_crashpad_handler" ]
     }
 
     group("electron_symbols") {


### PR DESCRIPTION
#### Description of Change
The path of the crashpad handler changed in #23461 but wasn't updated for the correct symbols. This fixes that.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed missing debug symbols for crashpad handler on macOS.