### PR TITLE
fix: exclude crashpad_handler binary on linux

### DIFF
--- a/build/zip.py
+++ b/build/zip.py
@@ -31,7 +31,7 @@ PATHS_TO_SKIP = [
   # app bundle.
   # On Linux, we don't use crashpad, but this binary is still built for some
   # reason. Exclude it from the zip.
-  'crashpad_handler',
+  './crashpad_handler',
 ]
 
 def skip_path(dep, dist_zip, target_cpu):

--- a/build/zip.py
+++ b/build/zip.py
@@ -25,6 +25,13 @@ PATHS_TO_SKIP = [
   # //chrome/browser/resources/ssl/ssl_error_assistant, but we don't need to
   # ship it.
   'pyproto',
+
+  # On Windows, this binary doesn't exist (the crashpad handler is built-in).
+  # On MacOS, the binary is called 'chrome_crashpad_handler' and is inside the
+  # app bundle.
+  # On Linux, we don't use crashpad, but this binary is still built for some
+  # reason. Exclude it from the zip.
+  'crashpad_handler',
 ]
 
 def skip_path(dep, dist_zip, target_cpu):

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -29,7 +29,6 @@ PLATFORM = {
 LINUX_BINARIES = [
   'electron',
   'chrome-sandbox',
-  'crashpad_handler',
   'libffmpeg.so',
   'libGLESv2.so',
   'libEGL.so',

--- a/script/zip_manifests/dist_zip.linux.arm.manifest
+++ b/script/zip_manifests/dist_zip.linux.arm.manifest
@@ -69,6 +69,5 @@ snapshot_blob.bin
 swiftshader/libEGL.so
 swiftshader/libGLESv2.so
 vk_swiftshader_icd.json
-crashpad_handler
 v8_context_snapshot.bin
 version

--- a/script/zip_manifests/dist_zip.linux.arm64.manifest
+++ b/script/zip_manifests/dist_zip.linux.arm64.manifest
@@ -69,6 +69,5 @@ snapshot_blob.bin
 swiftshader/libEGL.so
 swiftshader/libGLESv2.so
 vk_swiftshader_icd.json
-crashpad_handler
 v8_context_snapshot.bin
 version

--- a/script/zip_manifests/dist_zip.linux.x64.manifest
+++ b/script/zip_manifests/dist_zip.linux.x64.manifest
@@ -69,6 +69,5 @@ snapshot_blob.bin
 swiftshader/libEGL.so
 swiftshader/libGLESv2.so
 vk_swiftshader_icd.json
-crashpad_handler
 v8_context_snapshot.bin
 version

--- a/script/zip_manifests/dist_zip.linux.x86.manifest
+++ b/script/zip_manifests/dist_zip.linux.x86.manifest
@@ -69,6 +69,5 @@ snapshot_blob.bin
 swiftshader/libEGL.so
 swiftshader/libGLESv2.so
 vk_swiftshader_icd.json
-crashpad_handler
 v8_context_snapshot.bin
 version


### PR DESCRIPTION
#### Description of Change
This binary was being built & included on Linux despite the fact that we do not use crashpad on Linux.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Removed extraneous crashpad_handler binary from the Linux distribution files.