### PR TITLE
fix: expose v8util.createIDWeakMap() regardless of enable_remote_module

### DIFF
--- a/build/webpack/webpack.config.base.js
+++ b/build/webpack/webpack.config.base.js
@@ -21,7 +21,7 @@ class AccessDependenciesPlugin {
 }
 
 const defines = {
-  BUILDFLAG: ' '
+  BUILDFLAG: ''
 }
 
 const buildFlagsPrefix = '--buildflags='

--- a/shell/common/api/electron_api_v8_util.cc
+++ b/shell/common/api/electron_api_v8_util.cc
@@ -7,6 +7,7 @@
 
 #include "base/hash/hash.h"
 #include "electron/buildflags/buildflags.h"
+#include "shell/common/api/electron_api_key_weak_map.h"
 #include "shell/common/gin_converters/content_converter.h"
 #include "shell/common/gin_converters/gurl_converter.h"
 #include "shell/common/gin_converters/std_converter.h"
@@ -16,7 +17,6 @@
 #include "v8/include/v8-profiler.h"
 
 #if BUILDFLAG(ENABLE_REMOTE_MODULE)
-#include "shell/common/api/electron_api_key_weak_map.h"
 #include "shell/common/api/remote/remote_callback_freer.h"
 #include "shell/common/api/remote/remote_object_freer.h"
 #endif
@@ -127,12 +127,12 @@ void Initialize(v8::Local<v8::Object> exports,
                  &electron::RemoteCallbackFreer::BindTo);
   dict.SetMethod("setRemoteObjectFreer", &electron::RemoteObjectFreer::BindTo);
   dict.SetMethod("addRemoteObjectRef", &electron::RemoteObjectFreer::AddRef);
-  dict.SetMethod("createIDWeakMap",
-                 &electron::api::KeyWeakMap<int32_t>::Create);
   dict.SetMethod(
       "createDoubleIDWeakMap",
       &electron::api::KeyWeakMap<std::pair<std::string, int32_t>>::Create);
 #endif
+  dict.SetMethod("createIDWeakMap",
+                 &electron::api::KeyWeakMap<int32_t>::Create);
   dict.SetMethod("requestGarbageCollectionForTesting",
                  &RequestGarbageCollectionForTesting);
   dict.SetMethod("isSameOrigin", &IsSameOrigin);


### PR DESCRIPTION
#### Description of Change
Fix regression from #23499.
`v8util.createIDWeakMap()` is used outside of the `remote` module since #23499.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes