### PR TITLE
perf: use type-utils for desktopCapturer.getSources() result serialization

### DIFF
--- a/lib/browser/desktop-capturer.ts
+++ b/lib/browser/desktop-capturer.ts
@@ -34,15 +34,9 @@ export const getSources = (event: Electron.IpcMainEvent, options: ElectronIntern
       reject(error);
     };
 
-    capturer._onfinished = (sources: Electron.DesktopCapturerSource[], fetchWindowIcons: boolean) => {
+    capturer._onfinished = (sources: Electron.DesktopCapturerSource[]) => {
       stopRunning();
-      resolve(sources.map(source => ({
-        id: source.id,
-        name: source.name,
-        thumbnail: source.thumbnail.toDataURL(),
-        display_id: source.display_id,
-        appIcon: (fetchWindowIcons && source.appIcon) ? source.appIcon.toDataURL() : null
-      })));
+      resolve(sources);
     };
 
     capturer.startHandling(options.captureWindow, options.captureScreen, options.thumbnailSize, options.fetchWindowIcons);

--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -62,7 +62,7 @@ ipcMainUtils.handleSync('ELECTRON_BROWSER_CLIPBOARD_SYNC', function (event, meth
 if (BUILDFLAG(ENABLE_DESKTOP_CAPTURER)) {
   const desktopCapturer = require('@electron/internal/browser/desktop-capturer');
 
-  ipcMainInternal.handle('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', function (event, options, stack) {
+  ipcMainInternal.handle('ELECTRON_BROWSER_DESKTOP_CAPTURER_GET_SOURCES', async function (event, options, stack) {
     logStack(event.sender, 'desktopCapturer.getSources()', stack);
     const customEvent = emitCustomEvent(event.sender, 'desktop-capturer-get-sources');
 
@@ -71,7 +71,7 @@ if (BUILDFLAG(ENABLE_DESKTOP_CAPTURER)) {
       return [];
     }
 
-    return desktopCapturer.getSources(event, options);
+    return typeUtils.serialize(await desktopCapturer.getSources(event, options));
   });
 }
 

--- a/lib/renderer/api/desktop-capturer.ts
+++ b/lib/renderer/api/desktop-capturer.ts
@@ -1,5 +1,5 @@
-import { nativeImage } from 'electron';
 import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
+import { deserialize } from '@electron/internal/common/type-utils';
 
 const { hasSwitch } = process.electronBinding('command_line');
 
@@ -35,11 +35,5 @@ export async function getSources (options: Electron.SourcesOptions) {
     fetchWindowIcons
   } as ElectronInternal.GetSourcesOptions, getCurrentStack());
 
-  return sources.map(source => ({
-    id: source.id,
-    name: source.name,
-    thumbnail: nativeImage.createFromDataURL(source.thumbnail),
-    display_id: source.display_id,
-    appIcon: source.appIcon ? nativeImage.createFromDataURL(source.appIcon) : null
-  }));
+  return deserialize(sources);
 }

--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -49,6 +49,8 @@ struct Converter<electron::api::DesktopCapturer::Source> {
           "appIcon",
           electron::api::NativeImage::Create(
               isolate, gfx::Image(GetWindowIcon(source.media_list_source.id))));
+    } else {
+      dict.Set("appIcon", nullptr);
     }
     return ConvertToV8(isolate, dict);
   }
@@ -191,8 +193,7 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
     v8::Isolate* isolate = v8::Isolate::GetCurrent();
     v8::Locker locker(isolate);
     v8::HandleScope scope(isolate);
-    gin_helper::CallMethod(this, "_onfinished", captured_sources_,
-                           fetch_window_icons_);
+    gin_helper::CallMethod(this, "_onfinished", captured_sources_);
   }
 }
 

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -123,9 +123,9 @@ declare namespace ElectronInternal {
   interface GetSourcesResult {
     id: string;
     name: string;
-    thumbnail: string;
+    thumbnail: Electron.NativeImage;
     display_id: string;
-    appIcon: string | null;
+    appIcon: Electron.NativeImage | null;
   }
 
   interface KeyWeakMap<K, V> {


### PR DESCRIPTION
#### Description of Change
Avoids compressing to / decompressing from PNG (`nativeImage.toDataURL()` / `nativeImage.createFromDataURL()`) when sending `NativeImage` instances over IPC.

On my machine it saves around 10-20% of time when calling `desktopCapturer.getSources()`, depending on the `thumbnailSize`.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes