### PR TITLE
test: skip remote module related tests when enable_remote_module = false

### DIFF
--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1936,7 +1936,7 @@ describe('BrowserWindow module', () => {
       });
     });
 
-    describe('"enableRemoteModule" option', () => {
+    ifdescribe(features.isRemoteModuleEnabled())('"enableRemoteModule" option', () => {
       const generateSpecs = (description: string, sandbox: boolean) => {
         describe(description, () => {
           const preload = path.join(__dirname, 'fixtures', 'module', 'preload-remote.js');
@@ -2294,7 +2294,7 @@ describe('BrowserWindow module', () => {
       });
 
       // see #9387
-      it('properly manages remote object references after page reload', (done) => {
+      ifit(features.isRemoteModuleEnabled())('properly manages remote object references after page reload', (done) => {
         const w = new BrowserWindow({
           show: false,
           webPreferences: {
@@ -2327,7 +2327,7 @@ describe('BrowserWindow module', () => {
         });
       });
 
-      it('properly manages remote object references after page reload in child window', (done) => {
+      ifit(features.isRemoteModuleEnabled())('properly manages remote object references after page reload in child window', (done) => {
         const w = new BrowserWindow({
           show: false,
           webPreferences: {

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -831,11 +831,10 @@ describe('webContents module', () => {
       const protocol = session.defaultSession.protocol;
       protocol.registerStringProtocol(scheme, (request, callback) => {
         const response = `<script>
-                            const {ipcRenderer, remote} = require('electron')
+                            const {ipcRenderer} = require('electron')
                             ipcRenderer.send('set-zoom', window.location.hostname)
                             ipcRenderer.on(window.location.hostname + '-zoom-set', () => {
-                              const { zoomLevel } = remote.getCurrentWebContents()
-                              ipcRenderer.send(window.location.hostname + '-zoom-level', zoomLevel)
+                              ipcRenderer.send(window.location.hostname + '-zoom-level')
                             })
                           </script>`;
         callback({ data: response, mimeType: 'text/html' });
@@ -921,14 +920,15 @@ describe('webContents module', () => {
     });
 
     it('can persist zoom level across navigation', (done) => {
-      const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, enableRemoteModule: true } });
+      const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true } });
       let finalNavigation = false;
       ipcMain.on('set-zoom', (e, host) => {
         const zoomLevel = hostZoomMap[host];
         if (!finalNavigation) w.webContents.zoomLevel = zoomLevel;
         e.sender.send(`${host}-zoom-set`);
       });
-      ipcMain.on('host1-zoom-level', (e, zoomLevel) => {
+      ipcMain.on('host1-zoom-level', (e) => {
+        const zoomLevel = e.sender.getZoomLevel();
         const expectedZoomLevel = hostZoomMap.host1;
         expect(zoomLevel).to.equal(expectedZoomLevel);
         if (finalNavigation) {
@@ -937,7 +937,8 @@ describe('webContents module', () => {
           w.loadURL(`${scheme}://host2`);
         }
       });
-      ipcMain.once('host2-zoom-level', (e, zoomLevel) => {
+      ipcMain.once('host2-zoom-level', (e) => {
+        const zoomLevel = e.sender.getZoomLevel();
         const expectedZoomLevel = hostZoomMap.host2;
         expect(zoomLevel).to.equal(expectedZoomLevel);
         finalNavigation = true;
@@ -947,7 +948,7 @@ describe('webContents module', () => {
     });
 
     it('can propagate zoom level across same session', (done) => {
-      const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, enableRemoteModule: true } });
+      const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true } });
       const w2 = new BrowserWindow({ show: false });
       w2.webContents.on('did-finish-load', () => {
         const zoomLevel1 = w.webContents.zoomLevel;
@@ -1047,7 +1048,8 @@ describe('webContents module', () => {
         w2.close();
         done();
       });
-      ipcMain.once('temporary-zoom-set', (e, zoomLevel) => {
+      ipcMain.once('temporary-zoom-set', (e) => {
+        const zoomLevel = e.sender.getZoomLevel();
         w2.loadFile(path.join(fixturesPath, 'pages', 'c.html'));
         finalZoomLevel = zoomLevel;
       });

--- a/spec-main/fixtures/module/delete-buffer.js
+++ b/spec-main/fixtures/module/delete-buffer.js
@@ -6,6 +6,8 @@ delete window.Buffer;
 delete global.Buffer;
 
 // Test that remote.js doesn't use Buffer global
-remote.require(path.join(__dirname, 'print_name.js')).echo(Buffer.from('bar'));
+if (remote) {
+  remote.require(path.join(__dirname, 'print_name.js')).echo(Buffer.from('bar'));
+}
 
 window.test = Buffer.from('buffer');

--- a/spec-main/webview-spec.ts
+++ b/spec-main/webview-spec.ts
@@ -2,7 +2,10 @@ import * as path from 'path';
 import { BrowserWindow, session, ipcMain, app, WebContents } from 'electron/main';
 import { closeAllWindows } from './window-helpers';
 import { emittedOnce } from './events-helpers';
+import { ifdescribe } from './spec-helpers';
 import { expect } from 'chai';
+
+const features = process.electronBinding('features');
 
 async function loadWebView (w: WebContents, attributes: Record<string, string>, openDevTools: boolean = false): Promise<void> {
   await w.executeJavaScript(`
@@ -570,7 +573,7 @@ describe('<webview> tag', function () {
     });
   });
 
-  describe('enableremotemodule attribute', () => {
+  ifdescribe(features.isRemoteModuleEnabled())('enableremotemodule attribute', () => {
     let w: BrowserWindow;
     beforeEach(async () => {
       w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, webviewTag: true } });


### PR DESCRIPTION
#### Description of Change
Cleaning up left-over `remote` module usage in the tests and skipping `remote` module related tests completely.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes