### PR TITLE
feat: add app render-process-gone event

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -369,6 +369,30 @@ Returns:
 
 Emitted when the renderer process of `webContents` crashes or is killed.
 
+**Deprecated:** This event is superceded by the `render-process-gone` event
+which contains more information about why the render process dissapeared. It
+isn't always because it crashed.  The `killed` boolean can be replaced by
+checking `reason === 'killed'` when you switch to that event.
+
+#### Event: 'render-process-gone'
+
+Returns:
+
+* `event` Event
+* `webContents` [WebContents](web-contents.md)
+* `details` Object
+  * `reason` String - The reason the render process is gone.  Possible values:
+    * `clean-exit` - Process exited with an exit code of zero
+    * `abnormal-exit` - Process exited with a non-zero exit code
+    * `killed` - Process was sent a SIGTERM or otherwise killed externally
+    * `crashed` - Process crashed
+    * `oom` - Process ran out of memory
+    * `launch-failure` - Process never successfully launched
+    * `integrity-failure` - Windows code integrity checks failed
+
+Emitted when the renderer process unexpectedly dissapears.  This is normally
+because it was crashed or killed.
+
 ### Event: 'accessibility-support-changed' _macOS_ _Windows_
 
 Returns:

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -501,6 +501,10 @@ WebContents.prototype._init = function () {
     app.emit('renderer-process-crashed', event, this, ...args);
   });
 
+  this.on('render-process-gone', (event, ...args) => {
+    app.emit('render-process-gone', event, this, ...args);
+  });
+
   // The devtools requests the webContents to reload.
   this.on('devtools-reload-page', function () {
     this.reload();

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -432,6 +432,25 @@ describe('app module', () => {
       expect(webContents).to.equal(w.webContents);
     });
 
+    it('should emit render-process-gone event when renderer crashes', async function () {
+      // FIXME: re-enable this test on win32.
+      if (process.platform === 'win32') { return this.skip(); }
+      w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      });
+      await w.loadURL('about:blank');
+
+      const promise = emittedOnce(app, 'render-process-gone');
+      w.webContents.executeJavaScript('process.crash()');
+
+      const [, webContents, details] = await promise;
+      expect(webContents).to.equal(w.webContents);
+      expect(details.reason).to.be.oneOf(['crashed', 'abnormal-exit']);
+    });
+
     ifdescribe(features.isDesktopCapturerEnabled())('desktopCapturer module filtering', () => {
       it('should emit desktop-capturer-get-sources event when desktopCapturer.getSources() is invoked', async () => {
         w = new BrowserWindow({


### PR DESCRIPTION
#### Description of Change
Follow up to #23096.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added new `render-process-gone` event on `app` to replace the `renderer-process-crashed` event.