### PR TITLE
fix: run Node.js at-exit callbacks in renderer proc

### DIFF
--- a/shell/renderer/atom_renderer_client.cc
+++ b/shell/renderer/atom_renderer_client.cc
@@ -174,8 +174,11 @@ void AtomRendererClient::WillReleaseScriptContext(
   // avoid memory leaks
   auto* command_line = base::CommandLine::ForCurrentProcess();
   if (command_line->HasSwitch(switches::kNodeIntegrationInSubFrames) ||
-      command_line->HasSwitch(switches::kDisableElectronSiteInstanceOverrides))
+      command_line->HasSwitch(
+          switches::kDisableElectronSiteInstanceOverrides)) {
+    node::RunAtExit(env);
     node::FreeEnvironment(env);
+  }
 
   // ElectronBindings is tracking node environments.
   electron_bindings_->EnvironmentDestroyed(env);


### PR DESCRIPTION
Backport of #23419

See that PR for details.


Notes: Ensured that exit callbacks are run for Node.js in the renderer process.
