### PR TITLE
test: remove usage of the remote module from tests

### DIFF
--- a/spec-main/fixtures/api/close-beforeunload-undefined.html
+++ b/spec-main/fixtures/api/close-beforeunload-undefined.html
@@ -3,7 +3,7 @@
 <script type="text/javascript" charset="utf-8">
   window.onbeforeunload = function() {
     setTimeout(function() {
-      require('electron').remote.getCurrentWindow().emit('onbeforeunload');
+      require('electron').ipcRenderer.sendSync('onbeforeunload');
     }, 0);
   }
   window.onload = () => window.close();


### PR DESCRIPTION
#### Description of Change
There is a leftover usage of the remote module in tests
https://github.com/electron/electron/blob/fc468cce3bdaa1ca3db2cd189dd9b06e12784cc7/spec-main/fixtures/api/close-beforeunload-undefined.html#L6

It was replaced in other places with
https://github.com/electron/electron/blob/fc468cce3bdaa1ca3db2cd189dd9b06e12784cc7/spec-main/fixtures/api/close-beforeunload-false.html#L9

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes