### PR TITLE
fix: use a weakptr for the context bridge function store

### DIFF
--- a/shell/renderer/api/electron_api_context_bridge.h
+++ b/shell/renderer/api/electron_api_context_bridge.h
@@ -21,7 +21,7 @@ class RenderFrameFunctionStore;
 }
 
 v8::Local<v8::Value> ProxyFunctionWrapper(
-    context_bridge::RenderFrameFunctionStore* store,
+    base::WeakPtr<context_bridge::RenderFrameFunctionStore> store,
     size_t func_id,
     bool support_dynamic_properties,
     gin_helper::Arguments* args);


### PR DESCRIPTION
Love a good WeakPtr...

Crash flow is quite complicated but traced to:

* Expose function via ctxBridge from context A to context B
* Somehow pass the function from context B to context C (through a child window for instance via window.opener)
* Context C stores a reference to the function
* Release context A and B (by reloading the window)
* Call function in context C

**Before:** Crash
**After:** Error thrown about calling a function from a released context

Notes: Fixed crash when calling functions passed over the contextBridge into a third context after the primary context has been released.