### PR TITLE
feat: add force option to app.focus()

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -564,10 +564,16 @@ Returns `Promise<void>` - fulfilled when Electron is initialized.
 May be used as a convenient alternative to checking `app.isReady()`
 and subscribing to the `ready` event if the app is not ready yet.
 
-### `app.focus()`
+### `app.focus([options])`
+
+* `options` Object (optional)
+  * `steal` Boolean _macOS_ - Make the receiver the active app even if another app is
+  currently active.
 
 On Linux, focuses on the first visible window. On macOS, makes the application
 the active app. On Windows, focuses on the application's first window.
+
+You should seek to use the `steal` option as sparingly as possible.
 
 ### `app.hide()` _macOS_
 

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -54,7 +54,7 @@ class Browser : public WindowListObserver {
   void Shutdown();
 
   // Focus the application.
-  void Focus();
+  void Focus(gin_helper::Arguments* args);
 
   // Returns the version of the executable (or bundle).
   std::string GetVersion() const;

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -54,7 +54,7 @@ class Browser : public WindowListObserver {
   void Shutdown();
 
   // Focus the application.
-  void Focus(gin_helper::Arguments* args);
+  void Focus(mate::Arguments* args);
 
   // Returns the version of the executable (or bundle).
   std::string GetVersion() const;

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -84,7 +84,7 @@ bool SetDefaultWebClient(const std::string& protocol) {
   return ran_ok && exit_code == EXIT_SUCCESS;
 }
 
-void Browser::Focus() {
+void Browser::Focus(gin_helper::Arguments* args) {
   // Focus on the first visible window.
   for (auto* const window : WindowList::GetWindows()) {
     if (window->IsVisible()) {

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -84,7 +84,7 @@ bool SetDefaultWebClient(const std::string& protocol) {
   return ran_ok && exit_code == EXIT_SUCCESS;
 }
 
-void Browser::Focus(gin_helper::Arguments* args) {
+void Browser::Focus(mate::Arguments* args) {
   // Focus on the first visible window.
   for (auto* const window : WindowList::GetWindows()) {
     if (window->IsVisible()) {

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -35,7 +35,7 @@ void Browser::SetShutdownHandler(base::Callback<bool()> handler) {
 }
 
 void Browser::Focus(mate::Arguments* args) {
-  gin_helper::Dictionary opts;
+  mate::Dictionary opts;
   bool steal_focus = false;
 
   if (args->GetNext(&opts)) {

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -13,6 +13,7 @@
 #include "base/mac/scoped_cftyperef.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/sys_string_conversions.h"
+#include "native_mate/dictionary.h"
 #include "net/base/mac/url_conversions.h"
 #include "shell/browser/mac/dict_util.h"
 #include "shell/browser/mac/electron_application.h"

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -34,7 +34,7 @@ void Browser::SetShutdownHandler(base::Callback<bool()> handler) {
   [[AtomApplication sharedApplication] setShutdownHandler:std::move(handler)];
 }
 
-void Browser::Focus(gin_helper::Arguments* args) {
+void Browser::Focus(mate::Arguments* args) {
   gin_helper::Dictionary opts;
   bool steal_focus = false;
 

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -20,6 +20,9 @@
 #include "shell/browser/native_window.h"
 #include "shell/browser/window_list.h"
 #include "shell/common/application_info.h"
+#include "shell/common/gin_helper/arguments.h"
+#include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/platform_util.h"
 #include "shell/common/promise_util.h"
 #include "ui/gfx/image/image.h"
@@ -31,8 +34,20 @@ void Browser::SetShutdownHandler(base::Callback<bool()> handler) {
   [[AtomApplication sharedApplication] setShutdownHandler:std::move(handler)];
 }
 
-void Browser::Focus() {
-  [[AtomApplication sharedApplication] activateIgnoringOtherApps:NO];
+void Browser::Focus(gin_helper::Arguments* args) {
+  gin_helper::Dictionary opts;
+  bool steal_focus = false;
+
+  if (args->GetNext(&opts)) {
+    gin_helper::ErrorThrower thrower(args->isolate());
+    if (!opts.Get("steal", &steal_focus)) {
+      thrower.ThrowError(
+          "Expected options object to contain a 'steal' boolean property");
+      return;
+    }
+  }
+
+  [[AtomApplication sharedApplication] activateIgnoringOtherApps:steal_focus];
 }
 
 void Browser::Hide() {

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -163,7 +163,7 @@ Browser::UserTask::UserTask() = default;
 Browser::UserTask::UserTask(const UserTask&) = default;
 Browser::UserTask::~UserTask() = default;
 
-void Browser::Focus() {
+void Browser::Focus(gin_helper::Arguments* args) {
   // On Windows we just focus on the first window found for this process.
   DWORD pid = GetCurrentProcessId();
   EnumWindows(&WindowsEnumerationHandler, reinterpret_cast<LPARAM>(&pid));

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -163,7 +163,7 @@ Browser::UserTask::UserTask() = default;
 Browser::UserTask::UserTask(const UserTask&) = default;
 Browser::UserTask::~UserTask() = default;
 
-void Browser::Focus(gin_helper::Arguments* args) {
+void Browser::Focus(mate::Arguments* args) {
   // On Windows we just focus on the first window found for this process.
   DWORD pid = GetCurrentProcessId();
   EnumWindows(&WindowsEnumerationHandler, reinterpret_cast<LPARAM>(&pid));


### PR DESCRIPTION
#### Description of Change

Backport #22612 to `8-x-y`. semver minor change.

CC @electron/wg-releases 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Add a new `force` parameter to `app.focus()` on macOS to allow apps to forcefully take focus.