### PR TITLE
refactor: improve MoveItemToTrash error description

### DIFF
--- a/shell/common/platform_util_mac.mm
+++ b/shell/common/platform_util_mac.mm
@@ -137,13 +137,15 @@ bool MoveItemToTrash(const base::FilePath& full_path, bool delete_on_fail) {
     // Handle this by deleting the item as a fallback.
     if (!did_trash && [err code] == NSFeatureUnsupportedError) {
       did_trash = [[NSFileManager defaultManager] removeItemAtURL:url
-                                                            error:nil];
+                                                            error:&err];
     }
   }
 
-  if (!did_trash)
+  if (!did_trash) {
     LOG(WARNING) << "NSWorkspace failed to move file " << full_path.value()
-                 << " to trash";
+                 << " to trash: "
+                 << base::SysNSStringToUTF8([err localizedDescription]);
+  }
 
   return did_trash;
 }


### PR DESCRIPTION
#### Description of Change

Very mild refactor to `MoveItemToTrash` on macOS - when failure occurred we would LOG that a failure occurred but not make the failure's underlying cause available to the user, which would help them better diagnose that failure. This improves that experience by ensuring that the localized error description is included in the log.

cc @ckerr @jkleinsc 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Improved error logging on `moveItemToTrash` failures on macOS.
