### PR TITLE
fix: make sure hunspell dict file is not destroyed in UI thread

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -95,3 +95,4 @@ breakpad_treat_node_processes_as_browser_processes.patch
 upload_list_add_loadsync_method.patch
 breakpad_allow_getting_string_values_for_crash_keys.patch
 crash_allow_disabling_compression_on_linux.patch
+fix_hunspell_crash.patch

--- a/patches/chromium/fix_hunspell_crash.patch
+++ b/patches/chromium/fix_hunspell_crash.patch
@@ -1,0 +1,147 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Thu, 4 Oct 2018 14:57:02 -0700
+Subject: Make sure hunspell file is not destroyed in UI thread
+
+Submitted to Chromium at:
+https://chromium-review.googlesource.com/c/chromium/src/+/2206199/1
+
+diff --git a/chrome/browser/spellchecker/spellcheck_hunspell_dictionary.cc b/chrome/browser/spellchecker/spellcheck_hunspell_dictionary.cc
+index 653ef44ff095015ef25cc59bf42f9fbd9d907160..d6f9bf8e0d2cf2e52698d4d132361a5d7118d00c 100644
+--- a/chrome/browser/spellchecker/spellcheck_hunspell_dictionary.cc
++++ b/chrome/browser/spellchecker/spellcheck_hunspell_dictionary.cc
+@@ -93,21 +93,28 @@ bool SaveDictionaryData(std::unique_ptr<std::string> data,
+ 
+ }  // namespace
+ 
+-SpellcheckHunspellDictionary::DictionaryFile::DictionaryFile() {
+-}
++SpellcheckHunspellDictionary::DictionaryFile::DictionaryFile(
++    base::TaskRunner* task_runner) : task_runner_(task_runner) {}
+ 
+ SpellcheckHunspellDictionary::DictionaryFile::~DictionaryFile() {
++  if (file.IsValid()) {
++    task_runner_->PostTask(FROM_HERE,
++                           base::BindOnce(&CloseDictionary, std::move(file)));
++  }
+ }
+ 
+ SpellcheckHunspellDictionary::DictionaryFile::DictionaryFile(
+     DictionaryFile&& other)
+-    : path(other.path), file(std::move(other.file)) {}
++    : path(other.path),
++      file(std::move(other.file)),
++      task_runner_(std::move(other.task_runner_)) {}
+ 
+ SpellcheckHunspellDictionary::DictionaryFile&
+ SpellcheckHunspellDictionary::DictionaryFile::operator=(
+     DictionaryFile&& other) {
+   path = other.path;
+   file = std::move(other.file);
++  task_runner_ = std::move(other.task_runner_);
+   return *this;
+ }
+ 
+@@ -121,15 +128,10 @@ SpellcheckHunspellDictionary::SpellcheckHunspellDictionary(
+       use_browser_spellchecker_(false),
+       browser_context_(browser_context),
+       spellcheck_service_(spellcheck_service),
+-      download_status_(DOWNLOAD_NONE) {}
++      download_status_(DOWNLOAD_NONE),
++      dictionary_file_(task_runner_.get()) {}
+ 
+ SpellcheckHunspellDictionary::~SpellcheckHunspellDictionary() {
+-  if (dictionary_file_.file.IsValid()) {
+-    task_runner_->PostTask(
+-        FROM_HERE,
+-        base::BindOnce(&CloseDictionary, std::move(dictionary_file_.file)));
+-  }
+-
+ #if BUILDFLAG(USE_BROWSER_SPELLCHECKER)
+   // Disable the language from platform spellchecker.
+   if (spellcheck::UseBrowserSpellChecker())
+@@ -324,7 +326,8 @@ void SpellcheckHunspellDictionary::DownloadDictionary(GURL url) {
+ #if !defined(OS_ANDROID)
+ // static
+ SpellcheckHunspellDictionary::DictionaryFile
+-SpellcheckHunspellDictionary::OpenDictionaryFile(const base::FilePath& path) {
++SpellcheckHunspellDictionary::OpenDictionaryFile(base::TaskRunner* task_runner,
++                                                 const base::FilePath& path) {
+   base::ScopedBlockingCall scoped_blocking_call(FROM_HERE,
+                                                 base::BlockingType::MAY_BLOCK);
+ 
+@@ -335,7 +338,7 @@ SpellcheckHunspellDictionary::OpenDictionaryFile(const base::FilePath& path) {
+   // For systemwide installations on Windows, the default directory may not
+   // have permissions for download. In that case, the alternate directory for
+   // download is chrome::DIR_USER_DATA.
+-  DictionaryFile dictionary;
++  DictionaryFile dictionary(task_runner);
+ 
+ #if defined(OS_WIN)
+   // Check if the dictionary exists in the fallback location. If so, use it
+@@ -377,7 +380,7 @@ SpellcheckHunspellDictionary::OpenDictionaryFile(const base::FilePath& path) {
+ // static
+ SpellcheckHunspellDictionary::DictionaryFile
+ SpellcheckHunspellDictionary::InitializeDictionaryLocation(
+-    const std::string& language) {
++    base::TaskRunner* task_runner, const std::string& language) {
+   base::ScopedBlockingCall scoped_blocking_call(FROM_HERE,
+                                                 base::BlockingType::MAY_BLOCK);
+ 
+@@ -392,7 +395,7 @@ SpellcheckHunspellDictionary::InitializeDictionaryLocation(
+   base::FilePath dict_path =
+       spellcheck::GetVersionedFileName(language, dict_dir);
+ 
+-  return OpenDictionaryFile(dict_path);
++  return OpenDictionaryFile(task_runner, dict_path);
+ }
+ 
+ void SpellcheckHunspellDictionary::InitializeDictionaryLocationComplete(
+@@ -481,7 +484,8 @@ void SpellcheckHunspellDictionary::PlatformSupportsLanguageComplete(
+ #if !defined(OS_ANDROID) && BUILDFLAG(USE_RENDERER_SPELLCHECKER)
+     base::PostTaskAndReplyWithResult(
+         task_runner_.get(), FROM_HERE,
+-        base::BindOnce(&InitializeDictionaryLocation, language_),
++        base::BindOnce(&InitializeDictionaryLocation,
++                       base::RetainedRef(task_runner_.get()), language_),
+         base::BindOnce(
+             &SpellcheckHunspellDictionary::InitializeDictionaryLocationComplete,
+             weak_ptr_factory_.GetWeakPtr()));
+diff --git a/chrome/browser/spellchecker/spellcheck_hunspell_dictionary.h b/chrome/browser/spellchecker/spellcheck_hunspell_dictionary.h
+index 4662bdc08b54304a7f8b2995f60fea9dc5617fff..7679f526c05980889adb2f6a8a0c20dd7f5415c3 100644
+--- a/chrome/browser/spellchecker/spellcheck_hunspell_dictionary.h
++++ b/chrome/browser/spellchecker/spellcheck_hunspell_dictionary.h
+@@ -99,7 +99,7 @@ class SpellcheckHunspellDictionary
+   // blocking sequence.
+   struct DictionaryFile {
+    public:
+-    DictionaryFile();
++    explicit DictionaryFile(base::TaskRunner* task_runner);
+     ~DictionaryFile();
+ 
+     DictionaryFile(DictionaryFile&& other);
+@@ -112,6 +112,9 @@ class SpellcheckHunspellDictionary
+     base::File file;
+ 
+    private:
++    // Task runner where the file is created.
++    scoped_refptr<base::TaskRunner> task_runner_;
++
+     DISALLOW_COPY_AND_ASSIGN(DictionaryFile);
+   };
+ 
+@@ -126,11 +129,12 @@ class SpellcheckHunspellDictionary
+ #if !defined(OS_ANDROID)
+   // Figures out the location for the dictionary, verifies its contents, and
+   // opens it.
+-  static DictionaryFile OpenDictionaryFile(const base::FilePath& path);
++  static DictionaryFile OpenDictionaryFile(base::TaskRunner* task_runner,
++                                           const base::FilePath& path);
+ 
+   // Gets the default location for the dictionary file.
+   static DictionaryFile InitializeDictionaryLocation(
+-      const std::string& language);
++      base::TaskRunner* task_runner, const std::string& language);
+ 
+   // The reply point for PostTaskAndReplyWithResult, called after the dictionary
+   // file has been initialized.


### PR DESCRIPTION
#### Description of Change

This should be able to fix this crash on Windows CI:

```
[904:0518/140618.257:FATAL:thread_restrictions.cc(78)] Check failed: !g_blocking_disallowed.Get().Get(). Function marked as blocking was called from a scope that disallows blocking! If this task is running inside the ThreadPool, it needs to have MayBlock() in its TaskTraits. Otherwise, consider making this blocking work asynchronous or, as a last resort, you may use ScopedAllowBlocking (see its documentation for best practices).
g_blocking_disallowed currently set to true by
Backtrace:
        base::ThreadRestrictions::ScopedAllowIO::~ScopedAllowIO [0x00007FF77B095FB9+105] (o:\base\threading\thread_restrictions.cc:297)
        net::ProxyConfigServiceWin::~ProxyConfigServiceWin [0x00007FF77D777DEC+140] (o:\net\proxy_resolution\win\proxy_config_service_win.cc:52)
        net::ProxyConfigServiceWin::~ProxyConfigServiceWin [0x00007FF77D7788D0+16] (o:\net\proxy_resolution\win\proxy_config_service_win.cc:46)
        ProxyConfigServiceImpl::~ProxyConfigServiceImpl [0x00007FF77B83D050+16] (o:\components\proxy_config\pref_proxy_config_tracker_impl.cc:66)
        ProxyConfigMonitor::~ProxyConfigMonitor [0x00007FF77B95E654+332] (o:\chrome\browser\net\proxy_config_monitor.cc:83)
        electron::NetworkContextService::~NetworkContextService [0x00007FF777D1942E+30] (o:\electron\shell\browser\net\network_context_service.cc:20)
```

This crash is actually not related to `ProxyConfigServiceWin`, the actual crash is bellow, and it is trigged by `~ProxyConfigServiceWin` when testing `session.setProxy`:

```
Backtrace:
        base::debug::CollectStackTrace [0x00007FF6805435C2+18] (o:\base\debug\stack_trace_win.cc:284)
        base::debug::StackTrace::StackTrace [0x00007FF68049BCC2+18] (o:\base\debug\stack_trace.cc:203)
        logging::LogMessage::~LogMessage [0x00007FF6804AF447+215] (o:\base\logging.cc:605)
        logging::LogMessage::~LogMessage [0x00007FF6804B0190+16] (o:\base\logging.cc:598)
        base::internal::AssertBlockingAllowed [0x00007FF680514B33+163] (o:\base\threading\thread_restrictions.cc:85)
        base::ScopedBlockingCall::ScopedBlockingCall [0x00007FF6805103EB+155] (o:\base\threading\scoped_blocking_call.cc:40)
        base::File::Close [0x00007FF680549E4B+139] (o:\base\files\file_win.cc:42)
        SpellcheckHunspellDictionary::DictionaryFile::~DictionaryFile [0x00007FF680071DDE+194] (o:\chrome\browser\spellchecker\spellcheck_hunspell_dictionary.cc:102)
        base::OnceCallback<void (SpellcheckHunspellDictionary::DictionaryFile)>::Run [0x00007FF6800749BF+75] (o:\base\callback.h:100)
        base::internal::ReplyAdapter<SpellcheckHunspellDictionary::DictionaryFile,SpellcheckHunspellDictionary::DictionaryFile> [0x00007FF6800747AA+138] (o:\base\post_task_and_reply_with_result_internal.h:31)
        base::internal::Invoker<base::internal::BindState<void (*)(base::OnceCallback<base::Optional<base::FilePath> ()>, std::__1::unique_ptr<base::Optional<base::FilePath>,std::__1::default_delete<base::Optional<base::FilePath>>> *),base::OnceCallback<base::Opt [0x00007FF67D0D0885+53] (o:\base\bind_internal.h:666)
        base::`anonymous namespace'::PostTaskAndReplyRelay::RunReply [0x00007FF680F42E69+217] (o:\base\threading\post_task_and_reply_impl.cc:114)
        base::internal::Invoker<base::internal::BindState<void (*)(base::(anonymous namespace)::PostTaskAndReplyRelay),base::(anonymous namespace)::PostTaskAndReplyRelay>,void ()>::RunOnce [0x00007FF680F42F14+84] (o:\base\bind_internal.h:666)
        base::TaskAnnotator::RunTask [0x00007FF6804F665F+431] (o:\base\task\common\task_annotator.cc:142)
        base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl [0x00007FF680F4897F+447] (o:\base\task\sequence_manager\thread_controller_with_message_pump_impl.cc:322)
        base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork [0x00007FF680F4866F+191] (o:\base\task\sequence_manager\thread_controller_with_message_pump_impl.cc:248)
        base::MessagePumpForUI::DoRunLoop [0x00007FF68054CA5A+314] (o:\base\message_loop\message_pump_win.cc:219)
        base::MessagePumpWin::Run [0x00007FF68054C02C+156] (o:\base\message_loop\message_pump_win.cc:76)
        base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run [0x00007FF680F491D1+257] (o:\base\task\sequence_manager\thread_controller_with_message_pump_impl.cc:429)
        base::RunLoop::Run [0x00007FF6804DAD1E+942] (o:\base\run_loop.cc:126)
        content::BrowserMainLoop::MainMessageLoopRun [0x00007FF67F8E2BD6+148] (o:\content\browser\browser_main_loop.cc:1497)
        content::BrowserMainLoop::RunMainMessageLoopParts [0x00007FF67F8E2A63+65] (o:\content\browser\browser_main_loop.cc:1059)
        content::BrowserMainRunnerImpl::Run [0x00007FF67F8E4DAF+143] (o:\content\browser\browser_main_runner_impl.cc:151)
        content::BrowserMain [0x00007FF67F8DFBD3+275] (o:\content\browser\browser_main.cc:47)
        content::RunBrowserProcessMain [0x00007FF67F7ACC3D+89] (o:\content\app\content_main_runner_impl.cc:502)
        content::ContentMainRunnerImpl::RunServiceManager [0x00007FF67F7ADA22+922] (o:\content\app\content_main_runner_impl.cc:944)
        content::ContentMainRunnerImpl::Run [0x00007FF67F7AD65A+426] (o:\content\app\content_main_runner_impl.cc:848)
        service_manager::Main [0x00007FF680BC35E5+2381] (o:\services\service_manager\embedder\main.cc:454)
        content::ContentMain [0x00007FF67E0C02B4+100] (o:\content\app\content_main.cc:19)
        wWinMain [0x00007FF67D0A1476+858] (o:\electron\shell\app\electron_main.cc:210)
        __scrt_common_main_seh [0x00007FF6844894A2+262] (d:\agent\_work\3\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
        BaseThreadInitThunk [0x00007FFD764C13D2+34]
        RtlUserThreadStart [0x00007FFD789554F4+52]
```

Details of the crash can be found at https://chromium-review.googlesource.com/c/chromium/src/+/2206199/1.

#### Release Notes

Notes: none