### PR TITLE
ci: use longer mocha timeout on WOA testing

### DIFF
--- a/azure-pipelines-woa.yml
+++ b/azure-pipelines-woa.yml
@@ -71,6 +71,7 @@ steps:
     ELECTRON_TEST_RESULTS_DIR: junit
     MOCHA_MULTI_REPORTERS: 'mocha-junit-reporter, tap'
     MOCHA_REPORTER: mocha-multi-reporters
+    MOCHA_TIMEOUT: 120000
 
 - task: PublishTestResults@2
   displayName: 'Publish Test Results'

--- a/spec-main/index.js
+++ b/spec-main/index.js
@@ -62,7 +62,8 @@ app.whenReady().then(() => {
   if (!process.env.MOCHA_REPORTER) {
     mocha.ui('bdd').reporter('tap');
   }
-  mocha.timeout(30000);
+  const mochaTimeout = process.env.MOCHA_TIMEOUT || 30000;
+  mocha.timeout(mochaTimeout);
 
   if (argv.grep) mocha.grep(argv.grep);
   if (argv.invert) mocha.invert();

--- a/spec/static/index.html
+++ b/spec/static/index.html
@@ -41,7 +41,9 @@
   if (!process.env.MOCHA_REPORTER) {
     mocha.ui('bdd').reporter('tap')
   }
-  mocha.timeout(30000)
+
+  const mochaTimeout = process.env.MOCHA_TIMEOUT || 30000
+  mocha.timeout(mochaTimeout)
 
   const query = Mocha.utils.parseQuery(window.location.search || '')
   if (query.grep) mocha.grep(query.grep)


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
On WOA we are seeing random timeout failures on certain tests.  Since WOA machines are smaller resourced machines these timeouts may simply be a side effect of slower machines.  This PR changes our WOA testing to use a longer timeout.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
