### PR TITLE
build: save mksnapshot args in Windows mksnapshot.zip

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -152,7 +152,11 @@ build_script:
   - ninja -C out/ffmpeg electron:electron_ffmpeg_zip
   - ninja -C out/Default electron:electron_dist_zip
   - ninja -C out/Default shell_browser_ui_unittests
+  - gn desc out/Default v8:run_mksnapshot_default args > out/Default/mksnapshot_args
   - ninja -C out/Default electron:electron_mksnapshot_zip
+  - cd out\Default
+  - 7z a mksnapshot.zip mksnapshot_args gen\v8\embedded.S
+  - cd ..\..
   - ninja -C out/Default electron:hunspell_dictionaries_zip
   - ninja -C out/Default electron:electron_chromedriver_zip
   - ninja -C out/Default third_party/electron_node:headers
@@ -203,8 +207,7 @@ test_script:
   - if "%RUN_TESTS%"=="true" ( echo Running test suite & node script/yarn test -- --enable-logging)
   - cd ..
   - if "%RUN_TESTS%"=="true" ( echo Verifying non proprietary ffmpeg & python electron\script\verify-ffmpeg.py --build-dir out\Default --source-root %cd% --ffmpeg-path out\ffmpeg )
-  - echo "About to verify mksnapshot"  
-  - if "%RUN_TESTS%"=="true" ( gn desc out\Default v8:run_mksnapshot_default args > out\Default\mksnapshot_args )
+  - echo "About to verify mksnapshot"
   - if "%RUN_TESTS%"=="true" ( echo Verifying mksnapshot & python electron\script\verify-mksnapshot.py --build-dir out\Default --source-root %cd% )
   - echo "Done verifying mksnapshot"
   - if "%RUN_TESTS%"=="true" ( echo Verifying chromedriver & python electron\script\verify-chromedriver.py --build-dir out\Default --source-root %cd% )


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
#21991 added `mksnapshot_args` to the mksnapshot zips for Linux and macOS but did not do so for Windows.  https://github.com/electron/mksnapshot/pull/27 updated the mksnapshot node module to use this args file to make sure mksnapshot is properly executed, so we need this file in the Windows zips as well.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
