### PR TITLE
docs: note no planned breaking changes for v11

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -32,6 +32,8 @@ See [#23265](https://github.com/electron/electron/pull/23265) for more details.
 
 ## Planned Breaking API Changes (11.0)
 
+There are no breaking changes planned for 11.0.
+
 ## Planned Breaking API Changes (10.0)
 
 ### Deprecated: `companyName` argument to `crashReporter.start()`


### PR DESCRIPTION
v11 is planned to be a "quiet release". There may end up being breaking changes if our hand is forced by an upstream dependency, but for now there are no such changes planned. This adds a note to that effect so that the section isn't empty.

Notes: none