### PR TITLE
test: bind to 127.0.0.1 in contextBridge spec

### DIFF
--- a/spec-main/api-context-bridge-spec.ts
+++ b/spec-main/api-context-bridge-spec.ts
@@ -22,7 +22,7 @@ describe('contextBridge', () => {
       res.setHeader('Content-Type', 'text/html');
       res.end('');
     });
-    await new Promise(resolve => server.listen(0, resolve));
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
   });
 
   after(async () => {


### PR DESCRIPTION
#### Description of Change
This prevents a firewall dialog from popping up on macOS.

#### Release Notes

Notes: none