### PR TITLE
test: attempt to track down "illegal access" error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1162,11 +1162,10 @@ steps-tests: &steps-tests
           ELECTRON_TEST_RESULTS_DIR: junit
           MOCHA_MULTI_REPORTERS: mocha-junit-reporter, tap
           ELECTRON_DISABLE_SECURITY_WARNINGS: 1
-          NODE_OPTIONS: --trace-uncaught
         command: |
           cd src
-          (cd electron && node script/yarn test --runners=main --enable-logging --files $(circleci tests glob spec-main/*-spec.ts | circleci tests split))
-          (cd electron && node script/yarn test --runners=remote --enable-logging --files $(circleci tests glob spec/*-spec.js | circleci tests split))
+          (cd electron && node script/yarn test --runners=main --trace-uncaught --enable-logging --files $(circleci tests glob spec-main/*-spec.ts | circleci tests split))
+          (cd electron && node script/yarn test --runners=remote --trace-uncaught --enable-logging --files $(circleci tests glob spec/*-spec.js | circleci tests split))
     - run:
         name: Check test results existence
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1162,6 +1162,7 @@ steps-tests: &steps-tests
           ELECTRON_TEST_RESULTS_DIR: junit
           MOCHA_MULTI_REPORTERS: mocha-junit-reporter, tap
           ELECTRON_DISABLE_SECURITY_WARNINGS: 1
+          NODE_OPTIONS: --trace-uncaught
         command: |
           cd src
           (cd electron && node script/yarn test --runners=main --enable-logging --files $(circleci tests glob spec-main/*-spec.ts | circleci tests split))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -200,6 +200,7 @@ test_script:
         echo "Skipping tests for $env:GN_CONFIG build"
       }
   - cd electron
+  - set "NODE_OPTIONS=--trace-uncaught"
   - if "%RUN_TESTS%"=="true" ( echo Running test suite & node script/yarn test -- --enable-logging)
   - cd ..
   - if "%RUN_TESTS%"=="true" ( echo Verifying non proprietary ffmpeg & python electron\script\verify-ffmpeg.py --build-dir out\Default --source-root %cd% --ffmpeg-path out\ffmpeg )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -200,8 +200,7 @@ test_script:
         echo "Skipping tests for $env:GN_CONFIG build"
       }
   - cd electron
-  - set "NODE_OPTIONS=--trace-uncaught"
-  - if "%RUN_TESTS%"=="true" ( echo Running test suite & node script/yarn test -- --enable-logging)
+  - if "%RUN_TESTS%"=="true" ( echo Running test suite & node script/yarn test -- --trace-uncaught --enable-logging)
   - cd ..
   - if "%RUN_TESTS%"=="true" ( echo Verifying non proprietary ffmpeg & python electron\script\verify-ffmpeg.py --build-dir out\Default --source-root %cd% --ffmpeg-path out\ffmpeg )
   - echo "About to verify mksnapshot"  


### PR DESCRIPTION
We've been seeing this occasionally in CI and I'm not sure what causes it. This is an attempt to track down the cause.

e.g. https://ci.appveyor.com/project/electron-bot/electron-ljo26/builds/32959911

Notes: none