### PR TITLE
test: disable parallel/test-worker-sharedarraybuffer-from-worker-thread

### DIFF
--- a/script/node-disabled-tests.json
+++ b/script/node-disabled-tests.json
@@ -160,6 +160,7 @@
   "parallel/test-worker-message-port",
   "parallel/test-worker-message-port-transfer-duplicate",
   "parallel/test-worker-message-port-transfer-target",
+  "parallel/test-worker-sharedarraybuffer-from-worker-thread",
   "parallel/test-worker-stdio",
   "parallel/test-zlib-unused-weak",
   "pseudo-tty/test-set-raw-mode-reset-process-exit",


### PR DESCRIPTION
#### Description of Change

This test is responsible for most recent `linux-testing-node` CI failures.

I have checked our patches on Node and V8, and I'm confident that this failure is not caused by our patches.

#### Release Notes

Notes: none