### PR TITLE
docs: errors in isolated world are not dispatched to foreign worlds

### DIFF
--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -162,9 +162,13 @@ this limitation.
   * `error` Error
 
 Returns `Promise<any>` - A promise that resolves with the result of the executed
-code or is rejected if execution throws or results in a rejected promise.
+code or is rejected if execution could not start.
 
 Works like `executeJavaScript` but evaluates `scripts` in an isolated context.
+
+Note that when the execution of script fails, the returned promise will not
+reject and the `result` would be `undefined`. This is because Chromium does not
+dispatch errors of isolated worlds to foreign worlds.
 
 ### `webFrame.setIsolatedWorldInfo(worldId, info)`
 * `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature. Chrome extensions reserve the range of IDs in `[1 << 20, 1 << 29)`. You can provide any integer here.


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/22490.

Chromium does not dispatch errors of isolated worlds to foreign worlds, so the promise returned by `webFrame.executeJavaScriptInIsolatedWorld` will not reject when execution fails.

https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/frame/pausable_script_executor.cc;l=62-72

```
    // Note: An error event in an isolated world will never be dispatched to
    // a foreign world.
```

It is possible to make the errors pass through worlds by patching Chromium, but it is risky and has few benefits, so I think we should just document the behavior.

#### Release Notes

Notes: none