### PR TITLE
fix: wrap EmitWarning with HandleScope

### DIFF
--- a/shell/common/process_util.cc
+++ b/shell/common/process_util.cc
@@ -12,6 +12,7 @@ namespace electron {
 void EmitWarning(node::Environment* env,
                  const std::string& warning_msg,
                  const std::string& warning_type) {
+  v8::HandleScope scope(env->isolate());
   gin::Dictionary process(env->isolate(), env->process_object());
 
   base::RepeatingCallback<void(base::StringPiece, base::StringPiece,


### PR DESCRIPTION
It needed one:

```
5   Electron Framework                  0x0000000119f8ac74 v8::Utils::ReportApiFailure(char const*, char const*) + 116
6   Electron Framework                  0x000000011a230192 v8::internal::HandleScope::Extend(v8::internal::Isolate*) + 66
7   Electron Framework                  0x0000000119f85c17 v8::internal::HandleScope::CreateHandle(v8::internal::Isolate*, unsigned long) + 103
8   Electron Framework                  0x0000000119fa293a v8::Isolate::GetCurrentContext() + 282
9   Electron Framework                  0x0000000117fa0fc7 bool gin::Dictionary::Get<base::RepeatingCallback<void (base::BasicStringPiece<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, base::BasicStringPiece<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, base::BasicStringPiece<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >)> >(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, base::RepeatingCallback<void (base::BasicStringPiece<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, base::BasicStringPiece<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, base::BasicStringPiece<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >)>*) + 39
10  Electron Framework                  0x0000000117fa0ee6 electron::EmitWarning(node::Environment*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) + 198
11  Electron Framework                  0x0000000117e3939a _ZN4base8internal7InvokerINS0_9BindStateIZN8electron3api7Session13LoadExtensionERKNS_8FilePathEE3$_2JN10gin_helper7PromiseIPKN10extensions9ExtensionEEEEEEFvSF_RKNSt3__112basic_stringIcNSI_11char_traitsIcEENSI_9allocatorIcEEEEEE7RunOnceEPNS0_13BindStateBaseESF_SQ_ + 378
12  Electron Framework                  0x0000000117fde735 extensions::ElectronExtensionLoader::FinishExtensionLoad(base::OnceCallback<void (extensions::Extension const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)>, std::__1::pair<scoped_refptr<extensions::Extension const>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >) + 197
[...]
```

#### Release Notes

Notes: Fixed a crash that could happen when a warning was emitted when loading an extension.