### PR TITLE
docs: document optional scaleFactor param to nativeImage fns

### DIFF
--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -266,9 +266,13 @@ image instead of a copy, so you _must_ ensure that the associated
 
 Returns `Boolean` - Whether the image is empty.
 
-#### `image.getSize()`
+#### `image.getSize([scaleFactor])`
 
-Returns [`Size`](structures/size.md)
+* `scaleFactor` Double (optional) - Defaults to 1.0.
+
+Returns [`Size`](structures/size.md).
+
+If `scaleFactor` is passed, this will return the aspect ratio corresponding to the image representation most closely matching the passed value.
 
 #### `image.setTemplateImage(option)`
 
@@ -303,9 +307,17 @@ Returns `NativeImage` - The resized image.
 If only the `height` or the `width` are specified then the current aspect ratio
 will be preserved in the resized image.
 
-#### `image.getAspectRatio()`
+#### `image.getAspectRatio([scaleFactor])`
+
+* `scaleFactor` Double (optional) - Defaults to 1.0.
 
 Returns `Float` - The image's aspect ratio.
+
+If `scaleFactor` is passed, this will return the aspect ratio corresponding to the image representation most closely matching the passed value.
+
+#### `image.getScaleFactors()`
+
+Returns `Float[]` - An array of all scale factors corresponding to representations for a given nativeImage.
 
 #### `image.addRepresentation(options)`
 

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -272,7 +272,7 @@ Returns `Boolean` - Whether the image is empty.
 
 Returns [`Size`](structures/size.md).
 
-If `scaleFactor` is passed, this will return the aspect ratio corresponding to the image representation most closely matching the passed value.
+If `scaleFactor` is passed, this will return the size corresponding to the image representation most closely matching the passed value.
 
 #### `image.setTemplateImage(option)`
 


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/23543.

Documents new optional `scaleFactor` parameter on `nativeImage.getSize()` and  `nativeImage.getAspectRatio()` as well as new convenience function `nativeImage.getScaleFactors()`. Previously, those functions would return the size and aspect ratio for the default image representation.

cc @nornagon @MarshallOfSound 
 
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none