### PR TITLE
docs: remove app feedback program doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -92,7 +92,6 @@ These individual tutorials expand on topics discussed in the guide above.
 * Electron Releases & Developer Feedback
   * [Versioning Policy](tutorial/electron-versioning.md)
   * [Release Timelines](tutorial/electron-timelines.md)
-  * [App Feedback Program](tutorial/app-feedback-program.md)
 * [Packaging App Source Code with asar](tutorial/application-packaging.md)
   * [Generating asar Archives](tutorial/application-packaging.md#generating-asar-archives)
   * [Using asar Archives](tutorial/application-packaging.md#using-asar-archives)

--- a/docs/tutorial/app-feedback-program.md
+++ b/docs/tutorial/app-feedback-program.md
@@ -1,3 +1,0 @@
-# Electron App Feedback Program
-
-Electron is working on building a streamlined release process and having faster releases. To help with that, we have the App Feedback Program for large-scale Electron apps to test our beta releases and report app-specific issues to the Electron team. We use this program to help us prioritize work and get applications upgraded to the next stable release as soon as possible. There are a few requirements we expect from participants, such as attending short, online weekly check-ins. Please visit the [blog post](https://electronjs.org/blog/app-feedback-program) for details and sign-up.


### PR DESCRIPTION
#### Description of Change

As we're sunsetting the original iteration of the App Feedback Program, this document is getting removed.

_Note: It might be helpful to add an additional PR to the existing blog post over at electronjs.org to reflect this fact as well, in case anyone stumbles upon that._

cc @sofianguy 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none
