### PR TITLE
docs: Add warning about process.windowsStore

### DIFF
--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -128,7 +128,7 @@ A `String` representing Electron's version string.
 ### `process.windowsStore` _Readonly_
 
 A `Boolean`. If the app is running as a Windows Store app (appx), this property is `true`,
-for otherwise it is `undefined`.
+for otherwise it is `undefined`. **NOTE**: This does not work on recent versions of Electron, don't rely on it yet. See [#18161](https://github.com/electron/electron/issues/18161).
 
 ## Methods
 


### PR DESCRIPTION
## Description of Change

I think it's good to warn people about using this variable, because it does not work, and now every developer who uses it in their app will get an unpleasant surprise when their app gets complaints from a user in the Windows Store.

See https://github.com/electron/electron/issues/18161

#### Checklist

- [ ] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

none