### PR TITLE
fix: read GTK dark theme setting on Linux

### DIFF
--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -59,6 +59,10 @@ class ViewsDelegate;
 class ViewsDelegateMac;
 #endif
 
+#if defined(USE_X11)
+class DarkThemeObserver;
+#endif
+
 class ElectronBrowserMainParts : public content::BrowserMainParts {
  public:
   explicit ElectronBrowserMainParts(const content::MainFunctionParams& params);
@@ -129,6 +133,8 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
 
 #if defined(USE_X11)
   std::unique_ptr<ui::GtkUiDelegate> gtk_ui_delegate_;
+  // Used to notify the native theme of changes to dark mode.
+  std::unique_ptr<DarkThemeObserver> dark_theme_observer_;
 #endif
 
   std::unique_ptr<views::LayoutProvider> layout_provider_;


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/21427.

Chromium does not respect the dark theme settings from GTK, according to [a Chromium issue](https://bugs.chromium.org/p/chromium/issues/detail?id=998903) it is intended and because of Chromium having its own settings of themes (custom theme, WebUI theme, forced dark theme).

This PR makes sure the default dark theme setting of Electron is synced with GTK.

I don't have a test for this though, since it involves desktop environment settings of the host machine. (We don't test dark theme for macOS neither.)

#### Release Notes

Notes: Fix GTK dark theme setting not respected in Electron on Linux.