### PR TITLE
fix: trigger about panel for about role on win

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -69,6 +69,7 @@ a `type`.
 The `role` property can have following values:
 
 * `undo`
+* `about` - Trigger a native about panel (custom message box on Window, which does not provide its own).
 * `redo`
 * `cut`
 * `copy`
@@ -94,7 +95,6 @@ The `role` property can have following values:
 The following additional roles are available on _macOS_:
 
 * `appMenu` - Whole default "App" menu (About, Services, etc.)
-* `about` - Map to the `orderFrontStandardAboutPanel` action.
 * `hide` - Map to the `hide` action.
 * `hideOthers` - Map to the `hideOtherApplications` action.
 * `unhide` - Map to the `unhideAllApplications` action.

--- a/lib/browser/api/menu-item-roles.js
+++ b/lib/browser/api/menu-item-roles.js
@@ -10,7 +10,8 @@ const roles = {
   about: {
     get label () {
       return isLinux ? 'About' : `About ${app.name}`;
-    }
+    },
+    ...(isWindows && { appMethod: 'showAboutPanel' })
   },
   close: {
     label: isMac ? 'Close Window' : 'Close',


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/23681.

Triggers `app.showAboutPanel` on windows when a menuItem with the `about` role is added, since Windows does not provide a default system about menu.

cc @zcbenz @MarshallOfSound @jkleinsc @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the 'about' role had on effect on Windows menus.
