### PR TITLE
fix: Don't ignore the referer header in net.request

### DIFF
--- a/lib/browser/api/net.js
+++ b/lib/browser/api/net.js
@@ -371,6 +371,7 @@ class ClientRequest extends Writable {
       }
       return ret;
     };
+    this._urlLoaderOptions.referrer = this._urlLoaderOptions.extraHeaders.referer || '';
     const opts = { ...this._urlLoaderOptions, extraHeaders: stringifyValues(this._urlLoaderOptions.extraHeaders) };
     this._urlLoader = new URLLoader(opts);
     this._urlLoader.on('response-started', (event, finalUrl, responseHead) => {

--- a/shell/browser/api/electron_api_url_loader.cc
+++ b/shell/browser/api/electron_api_url_loader.cc
@@ -347,6 +347,7 @@ mate::WrappableBase* SimpleURLLoaderWrapper::New(gin::Arguments* args) {
   request->attach_same_site_cookies = true;
   opts.Get("method", &request->method);
   opts.Get("url", &request->url);
+  opts.Get("referrer", &request->referrer);
   std::map<std::string, std::string> extra_headers;
   if (opts.Get("extraHeaders", &extra_headers)) {
     for (const auto& it : extra_headers) {

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -1251,6 +1251,38 @@ describe('net module', () => {
         setTimeout(resolve, 50);
       });
     });
+
+    it('should remove the referer header when no referrer url specified', async () => {
+      const serverUrl = await respondOnce.toSingleURL((request, response) => {
+        expect(request.headers.referer).to.equal(undefined);
+        response.statusCode = 200;
+        response.statusMessage = 'OK';
+        response.end();
+      });
+      const urlRequest = net.request(serverUrl);
+      urlRequest.end();
+
+      const response = await getResponse(urlRequest);
+      expect(response.statusCode).to.equal(200);
+      await collectStreamBody(response);
+    });
+
+    it('should set the referer header when a referrer url specified', async () => {
+      const referrerURL = 'https://www.electronjs.org/';
+      const serverUrl = await respondOnce.toSingleURL((request, response) => {
+        expect(request.headers.referer).to.equal(referrerURL);
+        response.statusCode = 200;
+        response.statusMessage = 'OK';
+        response.end();
+      });
+      const urlRequest = net.request(serverUrl);
+      urlRequest.setHeader('referer', referrerURL);
+      urlRequest.end();
+
+      const response = await getResponse(urlRequest);
+      expect(response.statusCode).to.equal(200);
+      await collectStreamBody(response);
+    });
   });
 
   describe('IncomingMessage API', () => {


### PR DESCRIPTION
Backport of #23386 

Fixes #23102  

See that PR for details.

Notes: Don't ignore the referrer header in net.request