### PR TITLE
feat: support dialog accessory view option on macOS

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -240,6 +240,10 @@ expanding and collapsing the dialog.
   * `title` String (optional) - Title of the message box, some platforms will not show it.
   * `message` String - Content of the message box.
   * `detail` String (optional) - Extra information of the message.
+  * `richText` Object (optional) _macOS_ - Text to display in a rich text area.
+    * `text` String - the text to display in the rich text view.
+    * `width` Number (optional) - the width of the rich text view (will default to minimum width for `text`)
+    * `height` Number (optional) - the width of the rich text view (will default to minimum height for `text`)
   * `checkboxLabel` String (optional) - If provided, the message box will
     include a checkbox with the given label.
   * `checkboxChecked` Boolean (optional) - Initial checked state of the
@@ -286,6 +290,10 @@ If `browserWindow` is not shown dialog will not be attached to it. In such case 
   * `title` String (optional) - Title of the message box, some platforms will not show it.
   * `message` String - Content of the message box.
   * `detail` String (optional) - Extra information of the message.
+  * `richText` Object (optional) _macOS_ - Text to display in a rich text area. If you want to specify width or height you must specify both.
+    * `text` String - the text to display in the rich text view.
+    * `width` Number (optional) - the width of the rich text view. Will default to 300px for `text`, and must be declared if `height` is declared.
+    * `height` Number (optional) - the width of the rich text view. Will default to minimum height for `text`, and must be declared if `width` is declared.
   * `checkboxLabel` String (optional) - If provided, the message box will
     include a checkbox with the given label.
   * `checkboxChecked` Boolean (optional) - Initial checked state of the

--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -159,6 +159,7 @@ const messageBox = (sync, window, options) => {
     buttons = [],
     cancelId,
     checkboxLabel = '',
+    richText = {},
     checkboxChecked,
     defaultId = -1,
     detail = '',
@@ -184,6 +185,20 @@ const messageBox = (sync, window, options) => {
     throw new Error('checkboxChecked requires that checkboxLabel also be passed');
   }
 
+  if (typeof richText !== 'object') {
+    throw new TypeError('richText must be an object');
+  } else if (Object.keys(richText).length > 0) {
+    const { width, height, text } = richText;
+    if (typeof text !== 'string') {
+      throw new TypeError('richText.text must be a string');
+    }
+    if (width || height) {
+      if (![width, height].every(v => typeof v === 'number')) {
+        throw new TypeError('richText width and height must be numbers');
+      }
+    }
+  }
+
   // Choose a default button to get selected when dialog is cancelled.
   if (cancelId == null) {
     // If the defaultId is set to 0, ensure the cancel button is a different index (1)
@@ -207,6 +222,7 @@ const messageBox = (sync, window, options) => {
     title,
     message,
     detail,
+    richText,
     checkboxLabel,
     checkboxChecked,
     icon

--- a/shell/browser/ui/message_box.h
+++ b/shell/browser/ui/message_box.h
@@ -41,6 +41,14 @@ struct MessageBoxSettings {
   bool checkbox_checked = false;
   gfx::ImageSkia icon;
 
+  std::string rich_text;
+  // We choose 300 here as a reasonable default to prevent wildly
+  // tall NSAlerts. If we don't do this they look very scary.
+  int width = 300;
+  int height = 15;
+  int x;
+  int y;
+
   MessageBoxSettings();
   MessageBoxSettings(const MessageBoxSettings&);
   ~MessageBoxSettings();

--- a/shell/common/gin_converters/message_box_converter.cc
+++ b/shell/common/gin_converters/message_box_converter.cc
@@ -31,6 +31,16 @@ bool Converter<electron::MessageBoxSettings>::FromV8(
   dict.Get("noLink", &out->no_link);
   dict.Get("checkboxChecked", &out->checkbox_checked);
   dict.Get("icon", &out->icon);
+
+  gin::Dictionary rich_text_dict = gin::Dictionary::CreateEmpty(isolate);
+  if (dict.Get("richText", &rich_text_dict)) {
+    rich_text_dict.Get("text", &out->rich_text);
+    rich_text_dict.Get("width", &out->width);
+    rich_text_dict.Get("height", &out->height);
+    rich_text_dict.Get("x", &out->x);
+    rich_text_dict.Get("y", &out->y);
+  }
+
   return true;
 }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/12437.

Add support for a richer detail area in message boxes on macOS, which will allow for improved error and messaging experiences.

Tested with: https://gist.github.com/f4e52dc49cbbc95f2ca588cce9af7eff

New view:
<img width="535" alt="Screen Shot 2020-05-21 at 12 09 28 AM" src="https://user-images.githubusercontent.com/2036040/82533619-83154e80-9af8-11ea-8807-e6a8fb6e924b.png">

cc @MarshallOfSound @zcbenz @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added support for a rich dialog view on macOS.
