### PR TITLE
test: multiple processes may crash in crashReporter test

### DIFF
--- a/spec-main/api-crash-reporter-spec.ts
+++ b/spec-main/api-crash-reporter-spec.ts
@@ -556,7 +556,7 @@ ifdescribe(!isLinuxOnArm && !process.mas && !process.env.DISABLE_CRASH_REPORTER_
           const newFileAppeared = waitForNewFileInDir(reportsDir);
           crash(crashingProcess, remotely);
           const newFiles = await newFileAppeared;
-          expect(newFiles).to.have.length(1);
+          expect(newFiles.length).to.be.greaterThan(0);
           expect(newFiles[0]).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.dmp$/);
         });
 
@@ -575,7 +575,7 @@ ifdescribe(!isLinuxOnArm && !process.mas && !process.env.DISABLE_CRASH_REPORTER_
           const newFileAppeared = waitForNewFileInDir(reportsDir);
           crash(crashingProcess, remotely);
           const newFiles = await newFileAppeared;
-          expect(newFiles).to.have.length(1, `Files that appeared: ${JSON.stringify(newFiles)}`);
+          expect(newFiles.length).to.be.greaterThan(0);
           expect(newFiles[0]).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.dmp$/);
         });
       });


### PR DESCRIPTION
#### Description of Change

When making a renderer process crash intentionally, some other utility process may also crash due to process handle being invalidated, which results in multiple crash reports being sent.

This causes CI flakes like this:

```
Received signal 11 SEGV_MAPERR 000000000000
0   Electron Framework                  0x00000001127abb99 base::debug::CollectStackTrace(void**, unsigned long) + 9
1   Electron Framework                  0x00000001126870e3 base::debug::StackTrace::StackTrace() + 19
2   Electron Framework                  0x00000001127aba61 base::debug::(anonymous namespace)::StackDumpSignalHandler(int, __siginfo*, void*) + 2385
3   libsystem_platform.dylib            0x00007fff7a3f3b5d _sigtramp + 29
4   Electron Framework                  0x000000010f931d09 v8::internal::Heap_PageFlagsAreConsistent(v8::internal::HeapObject) + 9
5   Electron Framework                  0x000000010d472c36 gin_helper::Dispatcher<void ()>::DispatchToCallback(v8::FunctionCallbackInfo<v8::Value> const&) + 262
6   Electron Framework                  0x000000010f72a918 v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo) + 888
7   Electron Framework                  0x000000010f728d6b v8::internal::MaybeHandle<v8::internal::Object> v8::internal::(anonymous namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::FunctionTemplateInfo>, v8::internal::Handle<v8::internal::Object>, v8::internal::BuiltinArguments) + 1243
8   Electron Framework                  0x000000010f727148 v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments, v8::internal::Isolate*) + 472
9   Electron Framework                  0x000000010f726cc7 v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) + 119
10  Electron Framework                  0x00000001108b9eff Builtins_CEntry_Return1_DontSaveFPRegs_ArgvOnStack_BuiltinExit + 63
11  Electron Framework                  0x000000011069a7f5 Builtins_InterpreterEntryTrampoline + 213
[end of stack trace]
[1391:0521/015325.322022:FATAL:invitation.cc(312)] Check failed: handle_.is_valid(). 
0   Electron Framework                  0x0000000110cbfb99 base::debug::CollectStackTrace(void**, unsigned long) + 9
1   Electron Framework                  0x0000000110b9b0e3 base::debug::StackTrace::StackTrace() + 19
2   Electron Framework                  0x0000000110bb7a85 logging::LogMessage::~LogMessage() + 261
3   Electron Framework                  0x0000000110bb877e logging::LogMessage::~LogMessage() + 14
4   Electron Framework                  0x00000001114bd2dd mojo::IncomingInvitation::ExtractMessagePipe(base::BasicStringPiece<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >) + 173
5   Electron Framework                  0x00000001114bd3ab mojo::IncomingInvitation::ExtractMessagePipe(unsigned long long) + 27
6   Electron Framework                  0x00000001132b36c2 content::ChildThreadImpl::Init(content::ChildThreadImpl::Options const&) + 1330
7   Electron Framework                  0x00000001132b276f content::ChildThreadImpl::ChildThreadImpl(base::RepeatingCallback<void ()>, content::ChildThreadImpl::Options const&) + 1231
8   Electron Framework                  0x00000001102cfd28 content::UtilityThreadImpl::UtilityThreadImpl(base::RepeatingCallback<void ()>) + 152
9   Electron Framework                  0x00000001102cf607 content::UtilityMain(content::MainFunctionParams const&) + 919
10  Electron Framework                  0x000000010f422fb1 content::ContentMainRunnerImpl::Run(bool) + 449
11  Electron Framework                  0x00000001132a89b9 service_manager::Main(service_manager::MainParams const&) + 3321
12  Electron Framework                  0x000000010d61f898 content::ContentMain(content::ContentMainParams const&) + 120
13  Electron Framework                  0x000000010b9687c6 ElectronMain + 134
14  Electron Helper                     0x0000000101f3a22e main + 430
15  libdyld.dylib                       0x00007fff7a20e3d5 start + 1
16  ???                                 0x0000000000000009 0x0 + 9

not ok 364 crashReporter module crash dumps directory when main crashes respects an overridden crash dump directory
  AssertionError: Files that appeared: ["8310c35a-6be6-4725-b583-6ca89013095c.dmp","d3a3bfd4-a404-4937-912f-241777c62328.dmp"]: expected [ Array(2) ] to have a length of 1 but got 2
      at Context.<anonymous> (electron/spec-main/api-crash-reporter-spec.ts:578:36)
```

#### Release Notes

Notes: none