### PR TITLE
test: deflake WOA tests

### DIFF
--- a/azure-pipelines-woa.yml
+++ b/azure-pipelines-woa.yml
@@ -71,7 +71,6 @@ steps:
     ELECTRON_TEST_RESULTS_DIR: junit
     MOCHA_MULTI_REPORTERS: 'mocha-junit-reporter, tap'
     MOCHA_REPORTER: mocha-multi-reporters
-    MOCHA_TIMEOUT: 120000
 
 - task: PublishTestResults@2
   displayName: 'Publish Test Results'

--- a/spec-main/api-menu-spec.ts
+++ b/spec-main/api-menu-spec.ts
@@ -10,7 +10,6 @@ import { closeWindow } from './window-helpers';
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 
 describe('Menu module', function () {
-  this.timeout(5000);
   describe('Menu.buildFromTemplate', () => {
     it('should be able to attach extra fields', () => {
       const menu = Menu.buildFromTemplate([
@@ -885,9 +884,14 @@ describe('Menu module', function () {
       const appProcess = cp.spawn(process.execPath, [appPath]);
 
       let output = '';
-      appProcess.stdout.on('data', data => { output += data; });
-
-      await emittedOnce(appProcess, 'exit');
+      await new Promise((resolve) => {
+        appProcess.stdout.on('data', data => {
+          output += data;
+          if (data.indexOf('Window has') > -1) {
+            resolve();
+          }
+        });
+      });
       expect(output).to.include('Window has no menu');
     });
 

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -1233,7 +1233,10 @@ describe('chromium features', () => {
       w.loadURL(pdfSource);
       const [, contents] = await emittedOnce(app, 'web-contents-created');
       expect(contents.getURL()).to.equal('chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai/index.html');
-      await emittedOnce(contents, 'did-finish-load');
+      await new Promise((resolve) => {
+        contents.on('did-finish-load', resolve);
+        contents.on('did-frame-finish-load', resolve);
+      });
     });
 
     it('opens when loading a pdf resource in a iframe', async () => {
@@ -1241,7 +1244,10 @@ describe('chromium features', () => {
       w.loadFile(path.join(__dirname, 'fixtures', 'pages', 'pdf-in-iframe.html'));
       const [, contents] = await emittedOnce(app, 'web-contents-created');
       expect(contents.getURL()).to.equal('chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai/index.html');
-      await emittedOnce(contents, 'did-finish-load');
+      await new Promise((resolve) => {
+        contents.on('did-finish-load', resolve);
+        contents.on('did-frame-finish-load', resolve);
+      });
     });
   });
 

--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -294,11 +294,12 @@ describe('chrome extensions', () => {
     it('loads a devtools extension', async () => {
       const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
       customSession.loadExtension(path.join(fixtures, 'extensions', 'devtools-extension'));
+      const winningMessage = emittedOnce(ipcMain, 'winning');
       const w = new BrowserWindow({ show: true, webPreferences: { session: customSession, nodeIntegration: true } });
       await w.loadURL(url);
       w.webContents.openDevTools();
       showLastDevToolsPanel(w);
-      await emittedOnce(ipcMain, 'winning');
+      await winningMessage;
     });
   });
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
This PR deflakes 3 tests that have been flaky on WOA as well as other platforms.
1. `chromium features PDF Viewer opens when loading a pdf resource as top level navigation`
2. `Menu.setApplicationMenu does not override null menu on startup`
3. `devtools extensions loads a devtools extension`.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
