### PR TITLE
chore: remove IPC hiddens

### DIFF
--- a/lib/renderer/api/ipc-renderer.ts
+++ b/lib/renderer/api/ipc-renderer.ts
@@ -1,39 +1,36 @@
-const { ipc } = process.electronBinding('ipc');
-const v8Util = process.electronBinding('v8_util');
+import { EventEmitter } from 'events';
 
-// Created by init.js.
-const ipcRenderer = v8Util.getHiddenValue<Electron.IpcRenderer>(global, 'ipc');
+const { ipc } = process.electronBinding('ipc');
+
 const internal = false;
 
-// TODO(MarshallOfSound): Remove if statement when isolated_bundle and content_script_bundle are gone
-if (!ipcRenderer.send) {
-  ipcRenderer.send = function (channel, ...args) {
-    return ipc.send(internal, channel, args);
-  };
+const ipcRenderer = new EventEmitter() as Electron.IpcRenderer;
+ipcRenderer.send = function (channel, ...args) {
+  return ipc.send(internal, channel, args);
+};
 
-  ipcRenderer.sendSync = function (channel, ...args) {
-    return ipc.sendSync(internal, channel, args)[0];
-  };
+ipcRenderer.sendSync = function (channel, ...args) {
+  return ipc.sendSync(internal, channel, args)[0];
+};
 
-  ipcRenderer.sendToHost = function (channel, ...args) {
-    return ipc.sendToHost(channel, args);
-  };
+ipcRenderer.sendToHost = function (channel, ...args) {
+  return ipc.sendToHost(channel, args);
+};
 
-  ipcRenderer.sendTo = function (webContentsId, channel, ...args) {
-    return ipc.sendTo(internal, false, webContentsId, channel, args);
-  };
+ipcRenderer.sendTo = function (webContentsId, channel, ...args) {
+  return ipc.sendTo(internal, false, webContentsId, channel, args);
+};
 
-  ipcRenderer.invoke = async function (channel, ...args) {
-    const { error, result } = await ipc.invoke(internal, channel, args);
-    if (error) {
-      throw new Error(`Error invoking remote method '${channel}': ${error}`);
-    }
-    return result;
-  };
+ipcRenderer.invoke = async function (channel, ...args) {
+  const { error, result } = await ipc.invoke(internal, channel, args);
+  if (error) {
+    throw new Error(`Error invoking remote method '${channel}': ${error}`);
+  }
+  return result;
+};
 
-  ipcRenderer.postMessage = function (channel: string, message: any, transferables: any) {
-    return ipc.postMessage(channel, message, transferables);
-  };
-}
+ipcRenderer.postMessage = function (channel: string, message: any, transferables: any) {
+  return ipc.postMessage(channel, message, transferables);
+};
 
 export default ipcRenderer;

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from 'events';
 import * as path from 'path';
 
 const Module = require('module');
@@ -39,20 +38,17 @@ require('@electron/internal/common/init');
 // The global variable will be used by ipc for event dispatching
 const v8Util = process.electronBinding('v8_util');
 
-const ipcEmitter = new EventEmitter();
-const ipcInternalEmitter = new EventEmitter();
-v8Util.setHiddenValue(global, 'ipc', ipcEmitter);
-v8Util.setHiddenValue(global, 'ipc-internal', ipcInternalEmitter);
+const { ipcRendererInternal } = require('@electron/internal/renderer/ipc-renderer-internal');
+const ipcRenderer = require('@electron/internal/renderer/api/ipc-renderer').default;
 
 v8Util.setHiddenValue(global, 'ipcNative', {
   onMessage (internal: boolean, channel: string, ports: any[], args: any[], senderId: number) {
-    const sender = internal ? ipcInternalEmitter : ipcEmitter;
+    const sender = internal ? ipcRendererInternal : ipcRenderer;
     sender.emit(channel, { sender, senderId, ports }, ...args);
   }
 });
 
 // Use electron module after everything is ready.
-const { ipcRendererInternal } = require('@electron/internal/renderer/ipc-renderer-internal');
 const { webFrameInit } = require('@electron/internal/renderer/web-frame-init');
 webFrameInit();
 

--- a/lib/renderer/ipc-renderer-internal.ts
+++ b/lib/renderer/ipc-renderer-internal.ts
@@ -1,33 +1,32 @@
-const { ipc } = process.electronBinding('ipc');
-const v8Util = process.electronBinding('v8_util');
+import { EventEmitter } from 'events';
 
-// Created by init.js.
-export const ipcRendererInternal = v8Util.getHiddenValue<Electron.IpcRendererInternal>(global, 'ipc-internal');
+const { ipc } = process.electronBinding('ipc');
+
 const internal = true;
 
-// TODO(MarshallOfSound): Remove if statement when isolated_bundle and content_script_bundle are gone
-if (!ipcRendererInternal.send) {
-  ipcRendererInternal.send = function (channel, ...args) {
-    return ipc.send(internal, channel, args);
-  };
+const ipcRendererInternal = new EventEmitter() as any as Electron.IpcRendererInternal;
+ipcRendererInternal.send = function (channel, ...args) {
+  return ipc.send(internal, channel, args);
+};
 
-  ipcRendererInternal.sendSync = function (channel, ...args) {
-    return ipc.sendSync(internal, channel, args)[0];
-  };
+ipcRendererInternal.sendSync = function (channel, ...args) {
+  return ipc.sendSync(internal, channel, args)[0];
+};
 
-  ipcRendererInternal.sendTo = function (webContentsId, channel, ...args) {
-    return ipc.sendTo(internal, false, webContentsId, channel, args);
-  };
+ipcRendererInternal.sendTo = function (webContentsId, channel, ...args) {
+  return ipc.sendTo(internal, false, webContentsId, channel, args);
+};
 
-  ipcRendererInternal.sendToAll = function (webContentsId, channel, ...args) {
-    return ipc.sendTo(internal, true, webContentsId, channel, args);
-  };
+ipcRendererInternal.sendToAll = function (webContentsId, channel, ...args) {
+  return ipc.sendTo(internal, true, webContentsId, channel, args);
+};
 
-  ipcRendererInternal.invoke = async function<T> (channel: string, ...args: any[]) {
-    const { error, result } = await ipc.invoke<T>(internal, channel, args);
-    if (error) {
-      throw new Error(`Error invoking remote method '${channel}': ${error}`);
-    }
-    return result;
-  };
-}
+ipcRendererInternal.invoke = async function<T> (channel: string, ...args: any[]) {
+  const { error, result } = await ipc.invoke<T>(internal, channel, args);
+  if (error) {
+    throw new Error(`Error invoking remote method '${channel}': ${error}`);
+  }
+  return result;
+};
+
+export { ipcRendererInternal };

--- a/lib/sandboxed_renderer/init.ts
+++ b/lib/sandboxed_renderer/init.ts
@@ -11,12 +11,6 @@ const v8Util = process.electronBinding('v8_util');
 // Expose Buffer shim as a hidden value. This is used by C++ code to
 // deserialize Buffer instances sent from browser process.
 v8Util.setHiddenValue(global, 'Buffer', Buffer);
-// The `lib/renderer/api/ipc-renderer.ts` module looks for the ipc object in the
-// "ipc" hidden value
-v8Util.setHiddenValue(global, 'ipc', new EventEmitter());
-// The `lib/renderer/ipc-renderer-internal.ts` module looks for the ipc object in the
-// "ipc-internal" hidden value
-v8Util.setHiddenValue(global, 'ipc-internal', new EventEmitter());
 // The process object created by webpack is not an event emitter, fix it so
 // the API is more compatible with non-sandboxed renderers.
 for (const prop of Object.keys(EventEmitter.prototype) as (keyof typeof process)[]) {


### PR DESCRIPTION
We no longer use these (and when we did it was wrong and we did bad things with them 😆 ) so this cleans up the globals so we don't accidentally start using them again

Notes: none