### PR TITLE
test: do not run spellchecker tests if the feature is disabled (9-x-y)

### DIFF
--- a/buildflags/buildflags.gni
+++ b/buildflags/buildflags.gni
@@ -35,5 +35,5 @@ declare_args() {
   enable_electron_extensions = true
 
   # Enable Spellchecker support
-  enable_builtin_spellchecker = true
+  enable_builtin_spellchecker = false  # FIXME
 }

--- a/buildflags/buildflags.gni
+++ b/buildflags/buildflags.gni
@@ -35,5 +35,5 @@ declare_args() {
   enable_electron_extensions = true
 
   # Enable Spellchecker support
-  enable_builtin_spellchecker = false  # FIXME
+  enable_builtin_spellchecker = true
 }

--- a/shell/common/api/features.cc
+++ b/shell/common/api/features.cc
@@ -9,6 +9,10 @@
 
 namespace {
 
+bool IsBuiltinSpellCheckerEnabled() {
+  return BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER);
+}
+
 bool IsDesktopCapturerEnabled() {
   return BUILDFLAG(ENABLE_DESKTOP_CAPTURER);
 }
@@ -66,6 +70,7 @@ void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Context> context,
                 void* priv) {
   gin_helper::Dictionary dict(context->GetIsolate(), exports);
+  dict.SetMethod("isBuiltinSpellCheckerEnabled", &IsBuiltinSpellCheckerEnabled);
   dict.SetMethod("isDesktopCapturerEnabled", &IsDesktopCapturerEnabled);
   dict.SetMethod("isOffscreenRenderingEnabled", &IsOffscreenRenderingEnabled);
   dict.SetMethod("isRemoteModuleEnabled", &IsRemoteModuleEnabled);

--- a/spec-main/spellchecker-spec.ts
+++ b/spec-main/spellchecker-spec.ts
@@ -1,9 +1,11 @@
-import { BrowserWindow, Session, session } from 'electron';
-
 import { expect } from 'chai';
+import { BrowserWindow, Session, session } from 'electron';
+import { ifdescribe } from './spec-helpers';
 import { closeWindow } from './window-helpers';
 
-describe('spellchecker', () => {
+const features = process.electronBinding('features');
+
+ifdescribe(features.isBuiltinSpellCheckerEnabled())('spellchecker', () => {
   let w: BrowserWindow;
 
   beforeEach(async () => {

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -9,6 +9,7 @@ declare const ENABLE_VIEW_API: boolean;
 
 declare namespace NodeJS {
   interface FeaturesBinding {
+    isBuiltinSpellCheckerEnabled(): boolean;
     isDesktopCapturerEnabled(): boolean;
     isOffscreenRenderingEnabled(): boolean;
     isRemoteModuleEnabled(): boolean;


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
The spellchecker tests should check if the feature is enabled first.

Builds with `enable_builtin_spellchecker = false`:
- [linux](https://app.circleci.com/pipelines/github/electron/electron/24922/workflows/4fb892fc-2b05-4be1-ba83-2cbc6c5d8a58)
- [macOS](https://app.circleci.com/pipelines/github/electron/electron/24922/workflows/c585cad3-2f94-4921-a607-b90637b9f222)
- [Windows x64](https://ci.appveyor.com/project/electron-bot/electron-ljo26/builds/33052151)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
