### PR TITLE
test: refactor how spec files are collected

### DIFF
--- a/spec-main/index.js
+++ b/spec-main/index.js
@@ -37,7 +37,7 @@ protocol.registerSchemesAsPrivileged([
   { scheme: 'bar', privileges: { standard: true } }
 ]);
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
   require('ts-node/register');
 
   const argv = require('yargs')
@@ -68,53 +68,45 @@ app.whenReady().then(() => {
   if (argv.grep) mocha.grep(argv.grep);
   if (argv.invert) mocha.invert();
 
-  // Read all test files.
-  const walker = require('walkdir').walk(__dirname, {
-    no_recurse: true
-  });
-
-  // This allows you to run specific modules only:
-  // npm run test -match=menu
-  const moduleMatch = process.env.npm_config_match
-    ? new RegExp(process.env.npm_config_match, 'g')
-    : null;
-
-  const testFiles = [];
-  walker.on('file', (file) => {
-    if (/-spec\.[tj]s$/.test(file) &&
-        (!moduleMatch || moduleMatch.test(file))) {
-      testFiles.push(file);
+  const filter = (file) => {
+    if (!/-spec\.[tj]s$/.test(file)) {
+      return false;
     }
+
+    // This allows you to run specific modules only:
+    // npm run test -match=menu
+    const moduleMatch = process.env.npm_config_match
+      ? new RegExp(process.env.npm_config_match, 'g')
+      : null;
+    if (moduleMatch && !moduleMatch.test(file)) {
+      return false;
+    }
+
+    const baseElectronDir = path.resolve(__dirname, '..');
+    if (argv.files && !argv.files.includes(path.relative(baseElectronDir, file))) {
+      return false;
+    }
+
+    return true;
+  };
+
+  const getFiles = require('../spec/static/get-files');
+  const testFiles = await getFiles(__dirname, { filter });
+  testFiles.sort().forEach((file) => {
+    mocha.addFile(file);
   });
 
-  const baseElectronDir = path.resolve(__dirname, '..');
-
-  walker.on('end', () => {
-    testFiles.sort();
-    testFiles.forEach((file) => {
-      if (!argv.files || argv.files.includes(path.relative(baseElectronDir, file))) {
-        mocha.addFile(file);
-      }
+  const cb = () => {
+    // Ensure the callback is called after runner is defined
+    process.nextTick(() => {
+      process.exit(runner.failures);
     });
-    const cb = () => {
-      // Ensure the callback is called after runner is defined
-      process.nextTick(() => {
-        process.exit(runner.failures);
-      });
-    };
+  };
 
-    // Set up chai in the correct order
-    const chai = require('chai');
-    chai.use(require('chai-as-promised'));
-    chai.use(require('dirty-chai'));
+  // Set up chai in the correct order
+  const chai = require('chai');
+  chai.use(require('chai-as-promised'));
+  chai.use(require('dirty-chai'));
 
-    const runner = mocha.run(cb);
-  });
+  const runner = mocha.run(cb);
 });
-
-function partition (xs, f) {
-  const trues = [];
-  const falses = [];
-  xs.forEach(x => (f(x) ? trues : falses).push(x));
-  return [trues, falses];
-}

--- a/spec/static/get-files.js
+++ b/spec/static/get-files.js
@@ -1,0 +1,15 @@
+async function getFiles (directoryPath, { filter = null } = {}) {
+  const files = [];
+  const walker = require('walkdir').walk(directoryPath, {
+    no_recurse: true
+  });
+  walker.on('file', (file) => {
+    if (!filter || filter(file)) {
+      files.push(file);
+    }
+  });
+  await new Promise((resolve) => walker.on('end', resolve));
+  return files;
+}
+
+module.exports = getFiles;

--- a/spec/static/index.html
+++ b/spec/static/index.html
@@ -1,7 +1,7 @@
 <body>
 <script src="jquery-2.0.3.min.js"></script>
 <script type="text/javascript" charset="utf-8">
-(function() {
+(async function() {
   // Deprecated APIs are still supported and should be tested.
   process.throwDeprecation = false
 
@@ -49,47 +49,45 @@
   if (query.grep) mocha.grep(query.grep)
   if (query.invert) mocha.invert()
 
-  const files = query.files ? query.files.split(',') : undefined
-
-  // Read all test files.
-  const walker = require('walkdir').walk(path.dirname(__dirname), {
-    no_recurse: true
-  })
-
-  // This allows you to run specific modules only:
-  // npm run test -match=menu
-  const moduleMatch = process.env.npm_config_match
-    ? new RegExp(process.env.npm_config_match, 'g')
-    : null
-
-  const testFiles = []
-  walker.on('file', (file) => {
-    if (/-spec\.js$/.test(file) && (!moduleMatch || moduleMatch.test(file))) {
-      testFiles.push(file)
+  const filter = (file) => {
+    if (!/-spec\.js$/.test(file)) {
+      return false
     }
+
+    // This allows you to run specific modules only:
+    // npm run test -match=menu
+    const moduleMatch = process.env.npm_config_match
+      ? new RegExp(process.env.npm_config_match, 'g')
+      : null
+    if (moduleMatch && !moduleMatch.test(file)) {
+      return false
+    }
+
+    const files = query.files ? query.files.split(',') : undefined
+    const baseElectronDir = path.resolve(__dirname, '..', '..')
+    if (files && !files.includes(path.relative(baseElectronDir, file))) {
+      return false
+    }
+
+    return true
+  }
+
+  const getFiles = require('./get-files')
+  const testFiles = await getFiles(path.dirname(__dirname), { filter })
+  testFiles.sort().forEach((file) => {
+    mocha.addFile(file)
   })
 
-  const baseElectronDir = path.resolve(__dirname, '..', '..')
+  // Set up chai in the correct order
+  const chai = require('chai')
+  chai.use(require('chai-as-promised'))
+  chai.use(require('dirty-chai'))
 
-  walker.on('end', () => {
-    testFiles.sort()
-    testFiles.forEach((file) => {
-      if (!files || files.includes(path.relative(baseElectronDir, file))) {
-        mocha.addFile(file)
-      }
-    })
-
-    // Set up chai in the correct order
-    const chai = require('chai')
-    chai.use(require('chai-as-promised'))
-    chai.use(require('dirty-chai'))
-
-    const runner = mocha.run(() => {
-      // Ensure the callback is called after runner is defined
-      setTimeout(() => {
-        ipcRenderer.send('process.exit', runner.failures)
-      }, 0)
-    })
+  const runner = mocha.run(() => {
+    // Ensure the callback is called after runner is defined
+    setTimeout(() => {
+      ipcRenderer.send('process.exit', runner.failures)
+    }, 0)
   })
 })()
 </script>


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Just a refactoring.
Move all logic of how spec files are matched into a single function (twice). We now match files by a file name (`/-spec\.[tj]s$/`) pattern, and optionally select some by a file name (`npm_config_match`) or a full file path (`argv.files`).


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
