### PR TITLE
fix: asynchronous URL loading in BW Proxy

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -907,10 +907,10 @@ Returns `String` - The URL of the current web page.
 ```javascript
 const { BrowserWindow } = require('electron')
 let win = new BrowserWindow({ width: 800, height: 600 })
-win.loadURL('http://github.com')
-
-let currentURL = win.webContents.getURL()
-console.log(currentURL)
+win.loadURL('http://github.com').then(() => {
+  const currentURL = win.webContents.getURL()
+  console.log(currentURL)
+})
 ```
 
 #### `contents.getTitle()`

--- a/lib/renderer/window-setup.ts
+++ b/lib/renderer/window-setup.ts
@@ -125,7 +125,11 @@ class LocationProxy {
   }
 
   private getGuestURL (): URL | null {
-    const urlString = this._invokeWebContentsMethodSync('getURL') as string;
+    const maybeURL = this._invokeWebContentsMethodSync('getURL') as string;
+
+    // When there's no previous frame the url will be blank, so accountfor that here
+    // to prevent url parsing errors on an empty string.
+    const urlString = maybeURL !== '' ? maybeURL : 'about:blank';
     try {
       return new URL(urlString);
     } catch (e) {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -4128,7 +4128,7 @@ describe('BrowserWindow module', () => {
         window.postMessage({openedLocation}, '*')
       `);
       const [, data] = await p;
-      expect(data.pageContext.openedLocation).to.equal('');
+      expect(data.pageContext.openedLocation).to.equal('about:blank');
     });
   });
 


### PR DESCRIPTION
#### Description of Change

Fixes an issue where this error:

```
window-setup.ts:132 LocationProxy: failed to parse string  TypeError: Failed to construct 'URL': Invalid URL
    at LocationProxy.getGuestURL (window-setup.ts:130)
    at LocationProxy.get [as href] (window-setup.ts:74)
    at Object.get href [as href] (window-setup.ts:94)
    at Object.<anonymous> (/private/var/folders/w4/6ckkx75165l174lkz07vgx_m0000gn/T/tmp-68137Olpd1KcWdwQ5/renderer.js:2)
    at Object.<anonymous> (/private/var/folders/w4/6ckkx75165l174lkz07vgx_m0000gn/T/tmp-68137Olpd1KcWdwQ5/renderer.js:4)
    at Module._compile (internal/modules/cjs/loader.js:967)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1004)
    at Module.load (internal/modules/cjs/loader.js:815)
    at Module._load (internal/modules/cjs/loader.js:727)
    at Module._load (electron/js2c/asar.js:738)
```

was appearing repeatedly in console because we were not properly waiting for `win.loadURL()` to complete in guest webcontents.

Tested with https://gist.github.com/d61bdf43af7962cc11420f666fe06820.

This fix can also be verified with [this existing test](https://github.com/electron/electron/blob/33d6a99d40eac66efc34a7c9e2f766112f637177/spec-main/api-browser-window-spec.ts#L4158-L4176) because it will no longer throw the above error as seen in CI logs.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `window.location` properties would throw an error for windows opened with `window.open`.
