### PR TITLE
fix: weakly reference MenuModel from MenuController

### DIFF
--- a/shell/browser/ui/cocoa/electron_menu_controller.h
+++ b/shell/browser/ui/cocoa/electron_menu_controller.h
@@ -10,6 +10,7 @@
 
 #include "base/callback.h"
 #include "base/mac/scoped_nsobject.h"
+#include "base/memory/weak_ptr.h"
 #include "base/strings/string16.h"
 
 namespace electron {
@@ -24,14 +25,12 @@ class ElectronMenuModel;
 // as it only maintains weak references.
 @interface ElectronMenuController : NSObject <NSMenuDelegate> {
  @protected
-  electron::ElectronMenuModel* model_;  // weak
+  base::WeakPtr<electron::ElectronMenuModel> model_;
   base::scoped_nsobject<NSMenu> menu_;
   BOOL isMenuOpen_;
   BOOL useDefaultAccelerator_;
   base::OnceClosure closeCallback;
 }
-
-@property(nonatomic, assign) electron::ElectronMenuModel* model;
 
 // Builds a NSMenu from the pre-built model (must not be nil). Changes made
 // to the contents of the model after calling this will not be noticed.
@@ -45,6 +44,9 @@ class ElectronMenuModel;
 
 // Programmatically close the constructed menu.
 - (void)cancel;
+
+- (electron::ElectronMenuModel*)model;
+- (void)setModel:(electron::ElectronMenuModel*)model;
 
 // Access to the constructed menu if the complex initializer was used. If the
 // default initializer was used, then this will create the menu on first call.

--- a/shell/browser/ui/electron_menu_model.h
+++ b/shell/browser/ui/electron_menu_model.h
@@ -7,6 +7,7 @@
 
 #include <map>
 
+#include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 #include "base/observer_list_types.h"
 #include "ui/base/models/simple_menu_model.h"
@@ -69,6 +70,10 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
   void MenuWillClose() override;
   void MenuWillShow() override;
 
+  base::WeakPtr<ElectronMenuModel> GetWeakPtr() {
+    return weak_factory_.GetWeakPtr();
+  }
+
   using SimpleMenuModel::GetSubmenuModelAt;
   ElectronMenuModel* GetSubmenuModelAt(int index);
 
@@ -79,6 +84,8 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
   std::map<int, base::string16> roles_;      // command id -> role
   std::map<int, base::string16> sublabels_;  // command id -> sublabel
   base::ObserverList<Observer> observers_;
+
+  base::WeakPtrFactory<ElectronMenuModel> weak_factory_{this};
 
   DISALLOW_COPY_AND_ASSIGN(ElectronMenuModel);
 };


### PR DESCRIPTION
#### Description of Change

Refs:
- https://bugs.chromium.org/p/chromium/issues/detail?id=998835
- https://chromium-review.googlesource.com/c/chromium/src/+/1804538

Fixes a crash i've seen intermittently in [Sentry](https://sentry.io/organizations/electronjs/issues/1688038590/?referrer=slack) on Catalina machines running Fiddle.

From the OG CL:

> Before this CL, MenuController's contract required that the provided MenuModel outlived a MenuController instance. As of 10.15, it's impossible to fulfill that contract: AppKit seems to like keeping MenuController instances (via [NSMenuItem target]) alive until the next autorelease pool drain, and there's no way for the C++ code that creates & manages a MenuModel to know when that will happen. 

This PR makes it such that `ElectronMenuController` holds a `base::WeakPtr` to its `ElectronMenuModel`, rather than a raw ptr, and handles the `ElectronMenuModel` being destroyed before the `ElectronMenuController`.

cc @MarshallOfSound @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an occasional menu crash on macOS Catalina when menu is closing.