### PR TITLE
fix: only bezel frameless windows

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1454,25 +1454,27 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
     [effect_view setState:NSVisualEffectStateActive];
 
     // Make frameless Vibrant windows have rounded corners.
-    CGFloat radius = 5.0f;  // default corner radius
-    CGFloat dimension = 2 * radius + 1;
-    NSSize size = NSMakeSize(dimension, dimension);
-    NSImage* maskImage = [NSImage imageWithSize:size
-                                        flipped:NO
-                                 drawingHandler:^BOOL(NSRect rect) {
-                                   NSBezierPath* bezierPath = [NSBezierPath
-                                       bezierPathWithRoundedRect:rect
-                                                         xRadius:radius
-                                                         yRadius:radius];
-                                   [[NSColor blackColor] set];
-                                   [bezierPath fill];
-                                   return YES;
-                                 }];
-    [maskImage setCapInsets:NSEdgeInsetsMake(radius, radius, radius, radius)];
-    [maskImage setResizingMode:NSImageResizingModeStretch];
+    if (!has_frame()) {
+      CGFloat radius = 5.0f;  // default corner radius
+      CGFloat dimension = 2 * radius + 1;
+      NSSize size = NSMakeSize(dimension, dimension);
+      NSImage* maskImage = [NSImage imageWithSize:size
+                                          flipped:NO
+                                   drawingHandler:^BOOL(NSRect rect) {
+                                     NSBezierPath* bezierPath = [NSBezierPath
+                                         bezierPathWithRoundedRect:rect
+                                                           xRadius:radius
+                                                           yRadius:radius];
+                                     [[NSColor blackColor] set];
+                                     [bezierPath fill];
+                                     return YES;
+                                   }];
+      [maskImage setCapInsets:NSEdgeInsetsMake(radius, radius, radius, radius)];
+      [maskImage setResizingMode:NSImageResizingModeStretch];
 
-    [effect_view setMaskImage:maskImage];
-    [window_ setCornerMask:maskImage];
+      [effect_view setMaskImage:maskImage];
+      [window_ setCornerMask:maskImage];
+    }
 
     [[window_ contentView] addSubview:effect_view
                            positioned:NSWindowBelow


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/23767.

Previously we set bezeled corners on all windows when setting vibrancy regardless of their framelessness, and we should only be doing this when the window is specified to be frameless.

Before:
<img width="312" alt="Screen Shot 2020-05-26 at 12 34 51 PM" src="https://user-images.githubusercontent.com/2036040/82942761-51afdf00-9f4d-11ea-9ca1-1e60d8113582.png">

After:
<img width="312" alt="Screen Shot 2020-05-26 at 12 34 44 PM" src="https://user-images.githubusercontent.com/2036040/82942767-55436600-9f4d-11ea-9e1d-8f48287b82e4.png">

cc @ckerr @jkleinsc @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a bezeling issue on vibrant non-frameless BrowserWindows.
