### PR TITLE
fix: make process.windowsStore work reliably

### DIFF
--- a/shell/common/application_info_win.cc
+++ b/shell/common/application_info_win.cc
@@ -93,8 +93,8 @@ bool IsRunningInDesktopBridgeImpl() {
       }
     }
 
-    UINT32 length;
-    wchar_t packageFamilyName[PACKAGE_FAMILY_NAME_MAX_LENGTH + 1];
+    UINT32 length = PACKAGE_FAMILY_NAME_MAX_LENGTH;
+    wchar_t packageFamilyName[PACKAGE_FAMILY_NAME_MAX_LENGTH];
     HANDLE proc = GetCurrentProcess();
     LONG result =
         (*get_package_family_namePtr)(proc, &length, packageFamilyName);


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/18161.

The `length` was not initialized when passed to `GetPackageFamilyName`, resulting in `process.windowsStore` being random undefined in difference versions.

#### Release Notes

Notes: Fix `process.windowsStore` returning undefined in AppX packages.