### PR TITLE
chore: Revert "fix: trigger activate event when app is activated via app switcher"

### DIFF
--- a/shell/browser/mac/atom_application_delegate.mm
+++ b/shell/browser/mac/atom_application_delegate.mm
@@ -40,10 +40,7 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
 @end
 #endif  // BUILDFLAG(USE_ALLOCATOR_SHIM)
 
-@implementation AtomApplicationDelegate {
- @private
-  bool isFirstActivation_;
-}
+@implementation AtomApplicationDelegate
 
 - (void)setApplicationDockMenu:(electron::AtomMenuModel*)model {
   menu_controller_.reset([[AtomMenuController alloc] initWithModel:model
@@ -80,8 +77,6 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
         @selector(_coreAttributesFromRange:whichAttributes:completionHandler:));
   }
 #endif
-
-  isFirstActivation_ = true;
 }
 
 - (NSMenu*)applicationDockMenu:(NSApplication*)sender {
@@ -96,35 +91,11 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
   return electron::Browser::Get()->OpenFile(filename_str) ? YES : NO;
 }
 
-- (void)applicationDidBecomeActive:(NSNotification*)notify {
-  // Originally `applicationShouldHandleReopen:hasVisibleWindows:` was used to
-  // emit Activate event. But the message is sent only when application is
-  // activated via Dock or Finder ignoring the App Switcher (cmd+tab).
-  //
-  // Using `applicationDidBecomeActive' is more reliable but to maintain
-  // compatibility with previous implementation we ignore activation
-  // immediately after the application launch, and compute the
-  // hasVisibleWindows on our own.
-  //
-  // Details in https://github.com/electron/electron/pull/23727.
-
-  if (isFirstActivation_) {
-    isFirstActivation_ = false;
-    return;
-  }
-
-  NSApplication* app = notify.object;
-  bool hasVisibleWindows = false;
-
-  for (NSWindow* win in app.windows) {
-    if (win.isVisible || win.miniaturized) {
-      hasVisibleWindows = true;
-      break;
-    }
-  }
-
+- (BOOL)applicationShouldHandleReopen:(NSApplication*)theApplication
+                    hasVisibleWindows:(BOOL)flag {
   electron::Browser* browser = electron::Browser::Get();
-  browser->Activate(hasVisibleWindows);
+  browser->Activate(static_cast<bool>(flag));
+  return flag;
 }
 
 - (BOOL)application:(NSApplication*)sender


### PR DESCRIPTION
Reverts electron/electron#23727 since it is causing a breaking change. See https://github.com/electron/electron/pull/23727#issuecomment-635119103 for more.

Notes: none