### PR TITLE
build: remove dead symlink from MAS build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -831,7 +831,7 @@ step-restore-out-cache: &step-restore-out-cache
     paths:
       - ./src/out/Default
     keys:
-      - v7-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
+      - v8-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
     name: Restoring out cache
 
 step-set-git-cache-path: &step-set-git-cache-path
@@ -855,7 +855,7 @@ step-save-out-cache: &step-save-out-cache
   save_cache:
     paths:
       - ./src/out/Default
-    key: v7-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
+    key: v8-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
     name: Persisting out cache
 
 step-run-electron-only-hooks: &step-run-electron-only-hooks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,6 +418,7 @@ step-electron-build: &step-electron-build
       fi
       cd src
       ninja -C out/Default electron -j $NUMBER_OF_NINJA_PROCESSES
+      node electron/script/check-symlinks.js
 
 step-native-unittests-build: &step-native-unittests-build
   run:

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -325,7 +325,6 @@ source_set("electron_lib") {
     "//chrome/app/resources:platform_locale_settings",
     "//chrome/services/printing/public/mojom",
     "//components/certificate_transparency",
-    "//components/crash/core/app",
     "//components/language/core/browser",
     "//components/net_log",
     "//components/network_hints/browser",
@@ -432,6 +431,9 @@ source_set("electron_lib") {
       "*\bviews/*",
     ]
   }
+  if (!is_mas_build) {
+    deps += [ "//components/crash/core/app" ]
+  }
 
   set_sources_assignment_filter(
       sources_assignment_filter + extra_source_filters)
@@ -457,9 +459,12 @@ source_set("electron_lib") {
     deps += [
       "//components/remote_cocoa/app_shim",
       "//content/common:mac_helpers",
-      "//third_party/crashpad/crashpad/client",
       "//ui/accelerated_widget_mac",
     ]
+
+    if (!is_mas_build) {
+      deps += [ "//third_party/crashpad/crashpad/client" ]
+    }
 
     libs = [
       "AVFoundation.framework",
@@ -763,8 +768,10 @@ if (is_mac) {
     framework_contents = [
       "Resources",
       "Libraries",
-      "Helpers",
     ]
+    if (!is_mas_build) {
+      framework_contents += [ "Helpers" ]
+    }
     public_deps = [
       ":electron_framework_libraries",
       ":electron_lib",
@@ -995,12 +1002,15 @@ if (is_mac) {
 
     group("electron_symbols") {
       deps = [
-        ":crashpad_handler_syms",
         ":electron_app_syms",
         ":electron_framework_syms",
         ":swiftshader_egl_syms",
         ":swiftshader_gles_syms",
       ]
+
+      if (!is_mas_build) {
+        deps += [ ":crashpad_handler_syms" ]
+      }
 
       foreach(helper_params, content_mac_helpers) {
         _helper_target = helper_params[0]

--- a/script/check-symlinks.js
+++ b/script/check-symlinks.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+
+const utils = require('./lib/utils');
+
+if (process.platform !== 'darwin') {
+  console.log('Not checking symlinks on non-darwin platform');
+  process.exit(0);
+}
+
+const appPath = path.resolve(__dirname, '..', '..', 'out', utils.getOutDir(), 'Electron.app');
+const visited = new Set();
+const traverse = (p) => {
+  if (visited.has(p)) return;
+
+  visited.add(p);
+  if (!fs.statSync(p).isDirectory()) return;
+
+  for (const child of fs.readdirSync(p)) {
+    const childPath = path.resolve(p, child);
+    let realPath;
+    try {
+      realPath = fs.realpathSync(childPath);
+    } catch (err) {
+      if (err.path) {
+        console.error('Detected an invalid symlink');
+        console.error('Source:', childPath);
+        let link = fs.readlinkSync(childPath);
+        if (!link.startsWith('.')) {
+          link = `../${link}`;
+        }
+        console.error('Target:', path.resolve(childPath, link));
+        process.exit(1);
+      } else {
+        throw err;
+      }
+    }
+    traverse(realPath);
+  }
+};
+
+traverse(appPath);

--- a/script/zip_manifests/dist_zip.mac_mas.x64.manifest
+++ b/script/zip_manifests/dist_zip.mac_mas.x64.manifest
@@ -3,7 +3,6 @@ Electron.app/Contents/
 Electron.app/Contents/Frameworks/
 Electron.app/Contents/Frameworks/Electron Framework.framework/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Electron Framework
-Electron.app/Contents/Frameworks/Electron Framework.framework/Helpers
 Electron.app/Contents/Frameworks/Electron Framework.framework/Libraries
 Electron.app/Contents/Frameworks/Electron Framework.framework/Resources
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/

--- a/shell/app/electron_crash_reporter_client.h
+++ b/shell/app/electron_crash_reporter_client.h
@@ -12,7 +12,7 @@
 #include "base/macros.h"
 #include "base/no_destructor.h"
 #include "build/build_config.h"
-#include "components/crash/core/app/crash_reporter_client.h"
+#include "components/crash/core/app/crash_reporter_client.h"  // nogncheck
 
 class ElectronCrashReporterClient : public crash_reporter::CrashReporterClient {
  public:

--- a/shell/app/electron_main_delegate.cc
+++ b/shell/app/electron_main_delegate.cc
@@ -22,7 +22,6 @@
 #include "base/strings/string_split.h"
 #include "chrome/common/chrome_paths.h"
 #include "components/content_settings/core/common/content_settings_pattern.h"
-#include "components/crash/core/app/crashpad.h"
 #include "components/crash/core/common/crash_key.h"
 #include "components/crash/core/common/crash_keys.h"
 #include "content/public/common/content_switches.h"
@@ -62,6 +61,10 @@
 #include "components/crash/core/app/breakpad_linux.h"
 #include "v8/include/v8-wasm-trap-handler-posix.h"
 #include "v8/include/v8.h"
+#endif
+
+#if !defined(MAS_BUILD)
+#include "components/crash/core/app/crashpad.h"
 #endif
 
 namespace electron {

--- a/shell/app/electron_main_delegate.cc
+++ b/shell/app/electron_main_delegate.cc
@@ -64,7 +64,7 @@
 #endif
 
 #if !defined(MAS_BUILD)
-#include "components/crash/core/app/crashpad.h"
+#include "components/crash/core/app/crashpad.h"  // nogncheck
 #endif
 
 namespace electron {

--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -18,7 +18,6 @@
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/thread_pool/thread_pool_instance.h"
 #include "base/threading/thread_task_runner_handle.h"
-#include "components/crash/core/app/crashpad.h"
 #include "content/public/common/content_switches.h"
 #include "electron/electron_version.h"
 #include "gin/array_buffer.h"
@@ -41,6 +40,10 @@
 
 #if defined(OS_WIN)
 #include "chrome/child/v8_crashpad_support_win.h"
+#endif
+
+#if !defined(MAS_BUILD)
+#include "components/crash/core/app/crashpad.h"
 #endif
 
 namespace {

--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -43,7 +43,7 @@
 #endif
 
 #if !defined(MAS_BUILD)
-#include "components/crash/core/app/crashpad.h"
+#include "components/crash/core/app/crashpad.h"  // nogncheck
 #endif
 
 namespace {

--- a/shell/browser/api/electron_api_crash_reporter.cc
+++ b/shell/browser/api/electron_api_crash_reporter.cc
@@ -16,25 +16,28 @@
 #include "base/path_service.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/threading/thread_restrictions.h"
-#include "chrome/browser/crash_upload_list/crash_upload_list_crashpad.h"
 #include "chrome/common/chrome_paths.h"
-#include "components/crash/core/app/crashpad.h"
-#include "components/crash/core/common/crash_key.h"
 #include "components/upload_list/crash_upload_list.h"
 #include "components/upload_list/text_log_upload_list.h"
 #include "content/public/common/content_switches.h"
 #include "gin/arguments.h"
 #include "gin/data_object_builder.h"
 #include "services/service_manager/embedder/switches.h"
-#include "shell/app/electron_crash_reporter_client.h"
-#include "shell/common/crash_keys.h"
 #include "shell/common/electron_paths.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_converters/file_path_converter.h"
 #include "shell/common/gin_converters/time_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_includes.h"
+
+#if !defined(MAS_BUILD)
+#include "chrome/browser/crash_upload_list/crash_upload_list_crashpad.h"
+#include "components/crash/core/app/crashpad.h"
+#include "components/crash/core/common/crash_key.h"
+#include "shell/app/electron_crash_reporter_client.h"
+#include "shell/common/crash_keys.h"
 #include "third_party/crashpad/crashpad/client/crashpad_info.h"
+#endif
 
 #if defined(OS_LINUX)
 #include "components/crash/core/app/breakpad_linux.h"
@@ -61,6 +64,14 @@ namespace electron {
 namespace api {
 
 namespace crash_reporter {
+
+#if defined(MAS_BUILD)
+namespace {
+
+void NoOp() {}
+
+}  // namespace
+#endif
 
 bool IsCrashReporterEnabled() {
   return g_crash_reporter_initialized;
@@ -203,8 +214,13 @@ void Initialize(v8::Local<v8::Object> exports,
                 void* priv) {
   gin_helper::Dictionary dict(context->GetIsolate(), exports);
   dict.SetMethod("start", &electron::api::crash_reporter::Start);
+#if defined(MAS_BUILD)
+  dict.SetMethod("addExtraParameter", &electron::api::crash_reporter::NoOp);
+  dict.SetMethod("removeExtraParameter", &electron::api::crash_reporter::NoOp);
+#else
   dict.SetMethod("addExtraParameter", &electron::crash_keys::SetCrashKey);
   dict.SetMethod("removeExtraParameter", &electron::crash_keys::ClearCrashKey);
+#endif
   dict.SetMethod("getParameters", &GetParameters);
   dict.SetMethod("getUploadedReports", &GetUploadedReports);
   dict.SetMethod("setUploadToServer", &SetUploadToServer);

--- a/shell/browser/api/electron_api_crash_reporter.cc
+++ b/shell/browser/api/electron_api_crash_reporter.cc
@@ -32,11 +32,11 @@
 
 #if !defined(MAS_BUILD)
 #include "chrome/browser/crash_upload_list/crash_upload_list_crashpad.h"
-#include "components/crash/core/app/crashpad.h"
+#include "components/crash/core/app/crashpad.h"  // nogncheck
 #include "components/crash/core/common/crash_key.h"
 #include "shell/app/electron_crash_reporter_client.h"
 #include "shell/common/crash_keys.h"
-#include "third_party/crashpad/crashpad/client/crashpad_info.h"
+#include "third_party/crashpad/crashpad/client/crashpad_info.h"  // nogncheck
 #endif
 
 #if defined(OS_LINUX)

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -173,8 +173,8 @@
 #include "base/debug/leak_annotations.h"
 #include "components/crash/content/browser/crash_handler_host_linux.h"
 #include "components/crash/core/app/breakpad_linux.h"
-#include "components/crash/core/app/crash_switches.h"
-#include "components/crash/core/app/crashpad.h"
+#include "components/crash/core/app/crash_switches.h"  // nogncheck
+#include "components/crash/core/app/crashpad.h"        // nogncheck
 #endif
 
 using content::BrowserThread;

--- a/shell/common/crash_keys.cc
+++ b/shell/common/crash_keys.cc
@@ -16,7 +16,7 @@
 #include "content/public/common/content_switches.h"
 #include "shell/common/electron_constants.h"
 #include "shell/common/options_switches.h"
-#include "third_party/crashpad/crashpad/client/annotation.h"
+#include "third_party/crashpad/crashpad/client/annotation.h"  // nogncheck
 
 namespace electron {
 


### PR DESCRIPTION
Fixes #23828

This fixes the stray symbolic link and adds a script to ensure it doesn't happen again

Notes: Fixed mac app store rejection notice for invalid symbolic link in bundle.