### PR TITLE
fix: use system installed objcopy to copy debug symbols

### DIFF
--- a/script/add-debug-link.py
+++ b/script/add-debug-link.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 from lib.config import LINUX_BINARIES, PLATFORM
-from lib.util import execute, get_objcopy_path, get_out_dir
+from lib.util import execute, get_out_dir
 
 def add_debug_link_into_binaries(directory, target_cpu, debug_dir):
   for binary in LINUX_BINARIES:
@@ -14,18 +14,15 @@ def add_debug_link_into_binaries(directory, target_cpu, debug_dir):
       add_debug_link_into_binary(binary_path, target_cpu, debug_dir)
 
 def add_debug_link_into_binary(binary_path, target_cpu, debug_dir):
-  try:
-    objcopy = get_objcopy_path(target_cpu)
-  except:
-    if PLATFORM == 'linux' and (target_cpu == 'x86' or target_cpu == 'arm' or
-       target_cpu == 'arm64'):
-      # Skip because no objcopy binary on the given target.
-      return
-    raise
+  if PLATFORM == 'linux' and (target_cpu == 'x86' or target_cpu == 'arm' or
+    target_cpu == 'arm64'):
+    # Skip because no objcopy binary on the given target.
+    return
+
   debug_name = get_debug_name(binary_path)
   # Make sure the path to the binary is not relative because of cwd param.
   real_binary_path = os.path.realpath(binary_path)
-  cmd = [objcopy, '--add-gnu-debuglink=' + debug_name, real_binary_path]
+  cmd = ['objcopy', '--add-gnu-debuglink=' + debug_name, real_binary_path]
   execute(cmd, cwd=debug_dir)
 
 def get_debug_name(binary_path):

--- a/script/copy-debug-symbols.py
+++ b/script/copy-debug-symbols.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 from lib.config import LINUX_BINARIES, PLATFORM
-from lib.util import execute, get_objcopy_path, get_out_dir, safe_mkdir
+from lib.util import execute, get_out_dir, safe_mkdir
 
 # It has to be done before stripping the binaries.
 def copy_debug_from_binaries(directory, out_dir, target_cpu, compress):
@@ -15,16 +15,12 @@ def copy_debug_from_binaries(directory, out_dir, target_cpu, compress):
       copy_debug_from_binary(binary_path, out_dir, target_cpu, compress)
 
 def copy_debug_from_binary(binary_path, out_dir, target_cpu, compress):
-  try:
-    objcopy = get_objcopy_path(target_cpu)
-  except:
-    if PLATFORM == 'linux' and (target_cpu == 'x86' or target_cpu == 'arm' or
-       target_cpu == 'arm64'):
-      # Skip because no objcopy binary on the given target.
-      return
-    raise
+  if PLATFORM == 'linux' and (target_cpu == 'x86' or target_cpu == 'arm' or
+     target_cpu == 'arm64'):
+    # Skip because no objcopy binary on the given target.
+    return    
   debug_name = get_debug_name(binary_path)
-  cmd = [objcopy, '--only-keep-debug']
+  cmd = ['objcopy', '--only-keep-debug']
   if compress:
     cmd.extend(['--compress-debug-sections'])
   cmd.extend([binary_path, os.path.join(out_dir, debug_name)])

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -268,14 +268,3 @@ def get_buildtools_executable(name):
   if sys.platform == 'win32':
     path += '.exe'
   return path
-
-def get_objcopy_path(target_cpu):
-  if PLATFORM != 'linux':
-    raise Exception(
-      "get_objcopy_path: unexpected platform '{0}'".format(PLATFORM))
-
-  if target_cpu != 'x64':
-      raise Exception(
-      "get_objcopy_path: unexpected target cpu '{0}'".format(target_cpu))
-  return os.path.join(SRC_DIR, 'third_party', 'binutils', 'Linux_x64',
-                        'Release', 'bin', 'objcopy')


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
https://chromium-review.googlesource.com/c/chromium/src/+/2181970 removed third_party/binutils which we were relying on for objcopy to copy debug symbols.  This PR changes our scripts to use the system installed `objcopy` instead.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->no-notes
