### PR TITLE
fix: MakeAbsoluteFilePath is a blocking call

### DIFF
--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -62,6 +62,7 @@ base::FilePath NormalizePath(const base::FilePath& path) {
     return path;
   }
 
+  base::ThreadRestrictions::ScopedAllowIO allow_blocking;
   base::FilePath absolute_path = MakeAbsoluteFilePath(path);
   // MakeAbsoluteFilePath returns an empty path on failures so use original path
   if (absolute_path.empty()) {


### PR DESCRIPTION
#### Description of Change

Passing relative paths as images would cause DCHECK assertions due to `MakeAbsoluteFilePath` being a blocking call.

I have marked the scope to allow blocking to avoid the assertions, but we should probably figure out a way to avoid this at all.

```
[6812:0529/113826.538:FATAL:thread_restrictions.cc(78)] Check failed: !g_blocking_disallowed.Get().Get(). Function marked as blocking was called from a scope that disallows blocking! If this task is running inside the ThreadPool, it needs to have MayBlock() in its TaskTraits. Otherwise, consider making this blocking work asynchronous or, as a last resort, you may use ScopedAllowBlocking (see its documentation for best practices).

Backtrace:
        base::debug::CollectStackTrace [0x00007FF767144F92+18] (o:\base\debug\stack_trace_win.cc:284)
        base::debug::StackTrace::StackTrace [0x00007FF76709B932+18] (o:\base\debug\stack_trace.cc:203)
        logging::LogMessage::~LogMessage [0x00007FF7670AF4A7+215] (o:\base\logging.cc:605)
        logging::LogMessage::~LogMessage [0x00007FF7670B0110+16] (o:\base\logging.cc:598)
        base::internal::AssertBlockingAllowed [0x00007FF767115D93+163] (o:\base\threading\thread_restrictions.cc:85)
        base::ScopedBlockingCall::ScopedBlockingCall [0x00007FF76711164B+155] (o:\base\threading\scoped_blocking_call.cc:40)
        electron::api::NativeImage::CreateFromPath [0x00007FF763D37248+168] (o:\electron\shell\common\api\electron_api_native_image.cc:400)
        gin::Converter<electron::api::NativeImage *,void>::FromV8 [0x00007FF763D38860+138] (o:\electron\shell\common\api\electron_api_native_image.cc:560)
        gin::ConvertFromV8<gin::Handle<electron::api::NativeImage> > [0x00007FF763C6E375+110] (o:\gin\converter.h:284)
```

#### Release Notes

Notes: none