### PR TITLE
feat: add V8CacheOptions webpreference

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -387,7 +387,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       Default is `true`.
     * `enableWebSQL` Boolean (optional) - Whether to enable the [WebSQL api](https://www.w3.org/TR/webdatabase/).
       Default is `true`.
-    * `V8CacheOptions` String (optional) - Enforces the v8 code caching policy
+    * `v8CacheOptions` String (optional) - Enforces the v8 code caching policy
       used by blink. Accepted values are
       * `none` - Disables code caching
       * `code` - Heuristic based code caching

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -387,6 +387,13 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       Default is `true`.
     * `enableWebSQL` Boolean (optional) - Whether to enable the [WebSQL api](https://www.w3.org/TR/webdatabase/).
       Default is `true`.
+    * `V8CacheOptions` String (optional) - Enforces the v8 code caching policy
+      used by blink. Accepted values are
+      * `none` - Disables code caching
+      * `code` - Heuristic based code caching
+      * `bypassHeatCheck` - Bypass code caching heuristics but with lazy compilation
+      * `bypassHeatCheckAndEagerCompile` - Same as above except compilation is eager.
+      Default policy is `code`.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -488,7 +488,7 @@ void WebContentsPreferences::OverrideWebkitPrefs(
     prefs->default_encoding = encoding;
 
   std::string v8_cache_options;
-  if (GetAsString(&preference_, "V8CacheOptions", &v8_cache_options)) {
+  if (GetAsString(&preference_, "v8CacheOptions", &v8_cache_options)) {
     if (v8_cache_options == "none") {
       prefs->v8_cache_options = blink::mojom::V8CacheOptions::kNone;
     } else if (v8_cache_options == "code") {

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -26,6 +26,7 @@
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/options_switches.h"
+#include "third_party/blink/public/mojom/v8_cache_options.mojom.h"
 
 #if defined(OS_WIN)
 #include "ui/gfx/switches.h"
@@ -485,6 +486,23 @@ void WebContentsPreferences::OverrideWebkitPrefs(
   std::string encoding;
   if (GetAsString(&preference_, "defaultEncoding", &encoding))
     prefs->default_encoding = encoding;
+
+  std::string v8_cache_options;
+  if (GetAsString(&preference_, "V8CacheOptions", &v8_cache_options)) {
+    if (v8_cache_options == "none") {
+      prefs->v8_cache_options = blink::mojom::V8CacheOptions::kNone;
+    } else if (v8_cache_options == "code") {
+      prefs->v8_cache_options = blink::mojom::V8CacheOptions::kCode;
+    } else if (v8_cache_options == "bypassHeatCheck") {
+      prefs->v8_cache_options =
+          blink::mojom::V8CacheOptions::kCodeWithoutHeatCheck;
+    } else if (v8_cache_options == "bypassHeatCheckAndEagerCompile") {
+      prefs->v8_cache_options =
+          blink::mojom::V8CacheOptions::kFullCodeWithoutHeatCheck;
+    } else {
+      prefs->v8_cache_options = blink::mojom::V8CacheOptions::kDefault;
+    }
+  }
 }
 
 WEB_CONTENTS_USER_DATA_KEY_IMPL(WebContentsPreferences)


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/microsoft/vscode/issues/98682#issuecomment-635159734 for context

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: V8CacheOptions is a new webpreference option to enforce code caching policy
