### PR TITLE
fix: do not use CONTEXT_MENU flag for tray menu

### DIFF
--- a/shell/browser/ui/win/notify_icon.cc
+++ b/shell/browser/ui/win/notify_icon.cc
@@ -18,7 +18,6 @@
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/image/image.h"
 #include "ui/views/controls/menu/menu_runner.h"
-#include "ui/views/widget/widget.h"
 
 namespace {
 
@@ -49,11 +48,7 @@ NotifyIcon::NotifyIcon(NotifyIconHost* host,
                        HWND window,
                        UINT message,
                        GUID guid)
-    : host_(host),
-      icon_id_(id),
-      window_(window),
-      message_id_(message),
-      weak_factory_(this) {
+    : host_(host), icon_id_(id), window_(window), message_id_(message) {
   guid_ = guid;
   is_using_guid_ = guid != GUID_DEFAULT;
   NOTIFYICONDATA icon_data;
@@ -213,26 +208,10 @@ void NotifyIcon::PopUpContextMenu(const gfx::Point& pos,
   if (pos.IsOrigin())
     rect.set_origin(display::Screen::GetScreen()->GetCursorScreenPoint());
 
-  // Create a widget for the menu, otherwise we get no keyboard events, which
-  // is required for accessibility.
-  widget_.reset(new views::Widget());
-  views::Widget::InitParams params(views::Widget::InitParams::TYPE_POPUP);
-  params.ownership =
-      views::Widget::InitParams::Ownership::WIDGET_OWNS_NATIVE_WIDGET;
-  params.bounds = gfx::Rect(0, 0, 0, 0);
-  params.force_software_compositing = true;
-  params.z_order = ui::ZOrderLevel::kFloatingUIElement;
-
-  widget_->Init(std::move(params));
-
-  widget_->Show();
-  widget_->Activate();
-  menu_runner_.reset(new views::MenuRunner(
-      menu_model != nullptr ? menu_model : menu_model_,
-      views::MenuRunner::CONTEXT_MENU | views::MenuRunner::HAS_MNEMONICS,
-      base::BindRepeating(&NotifyIcon::OnContextMenuClosed,
-                          weak_factory_.GetWeakPtr())));
-  menu_runner_->RunMenuAt(widget_.get(), NULL, rect,
+  menu_runner_.reset(
+      new views::MenuRunner(menu_model != nullptr ? menu_model : menu_model_,
+                            views::MenuRunner::HAS_MNEMONICS));
+  menu_runner_->RunMenuAt(nullptr, nullptr, rect,
                           views::MenuAnchorPosition::kTopLeft,
                           ui::MENU_SOURCE_MOUSE);
 }
@@ -271,10 +250,6 @@ void NotifyIcon::InitIconData(NOTIFYICONDATA* icon_data) {
     icon_data->uFlags = NIF_GUID;
     icon_data->guidItem = guid_;
   }
-}
-
-void NotifyIcon::OnContextMenuClosed() {
-  widget_->Close();
 }
 
 }  // namespace electron

--- a/shell/browser/ui/win/notify_icon.h
+++ b/shell/browser/ui/win/notify_icon.h
@@ -14,7 +14,6 @@
 
 #include "base/compiler_specific.h"
 #include "base/macros.h"
-#include "base/memory/weak_ptr.h"
 #include "base/win/scoped_gdi_object.h"
 #include "shell/browser/ui/tray_icon.h"
 #include "shell/browser/ui/win/notify_icon_host.h"
@@ -25,8 +24,7 @@ class Point;
 
 namespace views {
 class MenuRunner;
-class Widget;
-}  // namespace views
+}
 
 namespace electron {
 
@@ -75,7 +73,6 @@ class NotifyIcon : public TrayIcon {
 
  private:
   void InitIconData(NOTIFYICONDATA* icon_data);
-  void OnContextMenuClosed();
 
   // The tray that owns us.  Weak.
   NotifyIconHost* host_;
@@ -103,12 +100,6 @@ class NotifyIcon : public TrayIcon {
 
   // Context menu associated with this icon (if any).
   std::unique_ptr<views::MenuRunner> menu_runner_;
-
-  // Temporary widget for the context menu, needed for keyboard event capture.
-  std::unique_ptr<views::Widget> widget_;
-
-  // WeakPtrFactory for CloseClosure safety.
-  base::WeakPtrFactory<NotifyIcon> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(NotifyIcon);
 };


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/11587.

Tray menu does not popup on a window, so it should not use `CONTEXT_MENU` flag otherwise some things would not work. The workaround used in https://github.com/electron/electron/pull/15302 stopped working after some Chromium upgrades.

This PR makes our tray menu code aligned with Chromium `status_icon_win.cc`.

#### Release Notes

Notes: Fix tray menu on Windows not keyboard navigable.