### PR TITLE
build: make electron renderer init scripts profilable

### DIFF
--- a/build/webpack/run-compiler.js
+++ b/build/webpack/run-compiler.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path')
 const webpack = require('webpack')
 
@@ -9,6 +10,9 @@ config.output = {
   filename: path.basename(outPath)
 }
 
+const { wrapInitWithProfilingTimeout } = config;
+delete config.wrapInitWithProfilingTimeout;
+
 webpack(config, (err, stats) => {
   if (err) {
     console.error(err)
@@ -17,6 +21,18 @@ webpack(config, (err, stats) => {
     console.error(stats.toString('normal'))
     process.exit(1)
   } else {
+    if (wrapInitWithProfilingTimeout) {
+      const contents = fs.readFileSync(outPath, 'utf8');
+      const newContents = `function ___electron_webpack_init__() {
+${contents}
+};
+if ((globalThis.process || binding.process).argv.includes("--profile-electron-init")) {
+  setTimeout(___electron_webpack_init__, 0);
+} else {
+  ___electron_webpack_init__();
+}`;
+      fs.writeFileSync(outPath, newContents);
+    }
     process.exit(0)
   }
 })

--- a/build/webpack/webpack.config.base.js
+++ b/build/webpack/webpack.config.base.js
@@ -73,7 +73,8 @@ module.exports = ({
   alwaysHasNode,
   loadElectronFromAlternateTarget,
   targetDeletesNodeGlobals,
-  target
+  target,
+  wrapInitWithProfilingTimeout
 }) => {
   let entry = path.resolve(electronRoot, 'lib', target, 'init.ts')
   if (!fs.existsSync(entry)) {
@@ -88,6 +89,7 @@ module.exports = ({
     output: {
       filename: `${target}.bundle.js`
     },
+    wrapInitWithProfilingTimeout,
     resolve: {
       alias: {
         ...alias,

--- a/build/webpack/webpack.config.renderer.js
+++ b/build/webpack/webpack.config.renderer.js
@@ -1,5 +1,6 @@
 module.exports = require('./webpack.config.base')({
   target: 'renderer',
   alwaysHasNode: true,
-  targetDeletesNodeGlobals: true
+  targetDeletesNodeGlobals: true,
+  wrapInitWithProfilingTimeout: true
 })

--- a/build/webpack/webpack.config.sandboxed_renderer.js
+++ b/build/webpack/webpack.config.sandboxed_renderer.js
@@ -1,4 +1,5 @@
 module.exports = require('./webpack.config.base')({
   target: 'sandboxed_renderer',
-  alwaysHasNode: false
+  alwaysHasNode: false,
+  wrapInitWithProfilingTimeout: true,
 })

--- a/build/webpack/webpack.gni
+++ b/build/webpack/webpack.gni
@@ -16,6 +16,7 @@ template("webpack_build") {
     inputs = [
                invoker.config_file,
                "//electron/build/webpack/webpack.config.base.js",
+               "//electron/build/webpack/run-compiler.js",
                "//electron/tsconfig.json",
                "//electron/yarn.lock",
                "//electron/typings/internal-ambient.d.ts",

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -766,6 +766,11 @@ void ElectronBrowserClient::AppendExtraCommandLineSwitches(
       command_line->AppendSwitchPath(switches::kAppPath, app_path);
     }
 
+    std::unique_ptr<base::Environment> env(base::Environment::Create());
+    if (env->HasVar("ELECTRON_PROFILE_INIT_SCRIPTS")) {
+      command_line->AppendSwitch("profile-electron-init");
+    }
+
     content::WebContents* web_contents =
         GetWebContentsFromProcessID(process_id);
     if (web_contents) {


### PR DESCRIPTION
The devtools profiler is not attached at the point we run out init scripts (or our apps preload scripts), we do not really want to change when we run these init scripts but for when a dev is doing performance work it makes sense to give them an option to make the devtools profiler actually work on both our init scripts and their preload script.  This PR adds that logic behind an environment variable `ELECTRON_PROFILE_INIT_SCRIPTS` that maintainers can use to profile these init scripts.

Notes: none