### PR TITLE
fix: expose electron/common and electron/renderer modules in sandboxed preloads

### DIFF
--- a/lib/sandboxed_renderer/init.ts
+++ b/lib/sandboxed_renderer/init.ts
@@ -45,6 +45,8 @@ const electron = require('electron');
 
 const loadedModules = new Map([
   ['electron', electron],
+  ['electron/common', electron],
+  ['electron/renderer', electron],
   ['events', events],
   ['timers', require('timers')],
   ['url', require('url')]


### PR DESCRIPTION
These were introduced recently on master in `reset-search-paths` which doesn't run in sandboxed renderers, this updates our `preloadRequire` method to support them.

Notes: none