### PR TITLE
build: fix for "enable_desktop_capturer = false"

### DIFF
--- a/build/webpack/webpack.config.base.js
+++ b/build/webpack/webpack.config.base.js
@@ -34,8 +34,7 @@ if (buildFlagArg) {
   for (const line of flagFile.split(/(\r\n|\r|\n)/g)) {
     const flagMatch = line.match(/#define BUILDFLAG_INTERNAL_(.+?)\(\) \(([01])\)/)
     if (flagMatch) {
-      const flagName = flagMatch[1];
-      const flagValue = flagMatch[2];
+      const [, flagName, flagValue] = flagMatch;
       defines[flagName] = JSON.stringify(Boolean(parseInt(flagValue, 10)));
     }
   }
@@ -64,11 +63,6 @@ if (defines['ENABLE_VIEWS_API'] === 'false') {
   )
 }
 
-const alias = {}
-for (const ignoredModule of ignoredModules) {
-  alias[ignoredModule] = path.resolve(electronRoot, 'lib/common/dummy.ts')
-}
-
 module.exports = ({
   alwaysHasNode,
   loadElectronFromAlternateTarget,
@@ -90,22 +84,27 @@ module.exports = ({
     },
     resolve: {
       alias: {
-        ...alias,
         '@electron/internal': path.resolve(electronRoot, 'lib'),
         'electron': path.resolve(electronRoot, 'lib', loadElectronFromAlternateTarget || target, 'api', 'exports', 'electron.ts'),
-        // Force timers to resolve to our dependency that doens't use window.postMessage
+        // Force timers to resolve to our dependency that doesn't use window.postMessage
         'timers': path.resolve(electronRoot, 'node_modules', 'timers-browserify', 'main.js')
       },
       extensions: ['.ts', '.js']
     },
     module: {
       rules: [{
+        test: (moduleName) => ignoredModules.includes(moduleName),
+        loader: 'null-loader',
+      }, {
         test: /\.ts$/,
         loader: 'ts-loader',
         options: {
           configFile: path.resolve(electronRoot, 'tsconfig.electron.json'),
           transpileOnly: onlyPrintingGraph,
-          ignoreDiagnostics: [6059]
+          ignoreDiagnostics: [
+            // File '{0}' is not under 'rootDir' '{1}'.
+            6059,
+          ]
         }
       }]
     },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "lint-staged": "^8.1.0",
     "minimist": "^1.2.0",
     "nugget": "^2.0.1",
+    "null-loader": "^4.0.0",
     "pre-flight": "^1.1.0",
     "remark-cli": "^4.0.0",
     "remark-preset-lint-markdown-style-guide": "^2.1.1",

--- a/spec-main/api-desktop-capturer-spec.ts
+++ b/spec-main/api-desktop-capturer-spec.ts
@@ -7,12 +7,20 @@ import { closeAllWindows } from './window-helpers';
 
 const features = process.electronBinding('features');
 
-ifdescribe(features.isDesktopCapturerEnabled() && !process.arch.includes('arm') && process.platform !== 'win32')('desktopCapturer', () => {
+ifdescribe(!process.arch.includes('arm') && process.platform !== 'win32')('desktopCapturer', () => {
+  if (!features.isDesktopCapturerEnabled()) {
+    // This condition can't go the `ifdescribe` call because its inner code
+    // it still executed, and if the feature is disabled some function calls here fail.
+    return;
+  }
+
   let w: BrowserWindow;
+
   before(async () => {
     w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true } });
     await w.loadURL('about:blank');
   });
+
   after(closeAllWindows);
 
   const getSources: typeof desktopCapturer.getSources = (options: SourcesOptions) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -254,6 +254,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
+"@types/json-schema@^7.0.4":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
+  integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
+
 "@types/linkify-it@*":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-2.1.0.tgz#ea3dd64c4805597311790b61e872cbd1ed2cd806"
@@ -664,6 +669,16 @@ ajv@^6.10.2, ajv@^6.9.1:
   integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
   dependencies:
     fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.12.2:
+  version "6.12.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
+  integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==
+  dependencies:
+    fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
@@ -2100,6 +2115,11 @@ emojis-list@^2.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
   integrity sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
 
+emojis-list@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
+  integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
+
 encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
@@ -2659,6 +2679,11 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
+fast-deep-equal@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
+  integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
 
 fast-glob@^2.0.2:
   version "2.2.7"
@@ -4049,6 +4074,13 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
+json5@^2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
+  integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
+  dependencies:
+    minimist "^1.2.5"
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -4258,6 +4290,15 @@ loader-utils@1.2.3, loader-utils@^1.0.2, loader-utils@^1.2.3:
     big.js "^5.2.2"
     emojis-list "^2.0.0"
     json5 "^1.0.1"
+
+loader-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.0.tgz#e4cace5b816d425a166b5f097e10cd12b36064b0"
+  integrity sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^2.1.2"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -4673,6 +4714,11 @@ minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0, minimist@~1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
 minipass@^2.2.1, minipass@^2.3.5:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
@@ -4961,6 +5007,14 @@ nugget@^2.0.1:
     request "^2.45.0"
     single-line-log "^1.1.2"
     throttleit "0.0.2"
+
+null-loader@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.0.tgz#8e491b253cd87341d82c0e84b66980d806dfbd04"
+  integrity sha512-vSoBF6M08/RHwc6r0gvB/xBJBtmbvvEkf6+IiadUCoNYchjxE8lwzCGFg0Qp2D25xPiJxUBh2iNWzlzGMILp7Q==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^2.6.5"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -6706,6 +6760,15 @@ schema-utils@^1.0.0:
     ajv "^6.1.0"
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
+
+schema-utils@^2.6.5:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.0.tgz#17151f76d8eae67fbbf77960c33c676ad9f4efc7"
+  integrity sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==
+  dependencies:
+    "@types/json-schema" "^7.0.4"
+    ajv "^6.12.2"
+    ajv-keywords "^3.4.1"
 
 semver-compare@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Some builds flags are not properly respected. Let's fix it.

Here are builds with `enable_desktop_capturer`, `enable_remote_module`, and `enable_views_api ` set to `false` before the change:
- [linux x64](https://app.circleci.com/pipelines/github/electron/electron/25221/workflows/0eec8742-7f9f-4563-8aaa-dd380cbc032b)
- [mac x64](https://app.circleci.com/pipelines/github/electron/electron/25221/workflows/5cc0a27f-fff0-428c-8d84-902bcdbd8e39)
- _sorry, no Windows build, they're relatively slow_

> [tsl] ERROR in /home/builduser/project/src/electron/lib/browser/api/desktop-capturer.ts(1,32)
      TS2306: File '/home/builduser/project/src/electron/lib/common/dummy.ts' is not a module.

and after the change:
- [linux x64](https://app.circleci.com/pipelines/github/electron/electron/25227/workflows/c3f7e871-9b9a-4f40-89ef-36f6fa669cbc)
- [mac x64](https://app.circleci.com/pipelines/github/electron/electron/25227/workflows/59b8cfdd-2dca-4bb8-bd44-809c845b2885)
- [windows x64](https://ci.appveyor.com/project/electron-bot/electron-ljo26/builds/33227334)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
