### PR TITLE
feat: Add did-become-active event on mac

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -140,6 +140,16 @@ this event, such as launching the application for the first time, attempting
 to re-launch the application when it's already running, or clicking on the
 application's dock or taskbar icon.
 
+### Event: 'did-become-active' _macOS_
+
+Returns:
+
+* `event` Event
+
+Emitted when mac application become active. Difference from `activate` event is
+that `did-become-active` is emitted every time the app becomes active, not only
+when Dock icon is clicked or application is re-launched.
+
 ### Event: 'continue-activity' _macOS_
 
 Returns:

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -684,6 +684,10 @@ void App::OnUpdateUserActivityState(bool* prevent_default,
 void App::OnNewWindowForTab() {
   Emit("new-window-for-tab");
 }
+
+void App::OnDidBecomeActive() {
+  Emit("did-become-active");
+}
 #endif
 
 bool App::CanCreateWindow(

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -106,6 +106,7 @@ class App : public ElectronBrowserClient::Delegate,
       const std::string& type,
       const base::DictionaryValue& user_info) override;
   void OnNewWindowForTab() override;
+  void OnDidBecomeActive() override;
 #endif
 
   // content::ContentBrowserClient:

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -262,6 +262,11 @@ void Browser::NewWindowForTab() {
   for (BrowserObserver& observer : observers_)
     observer.OnNewWindowForTab();
 }
+
+void Browser::DidBecomeActive() {
+  for (BrowserObserver& observer : observers_)
+    observer.OnDidBecomeActive();
+}
 #endif
 
 }  // namespace electron

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -240,6 +240,9 @@ class Browser : public WindowListObserver {
 #if defined(OS_MACOSX)
   // Tell the application to create a new window for a tab.
   void NewWindowForTab();
+
+  // Tell the application that application did become active
+  void DidBecomeActive();
 #endif  // defined(OS_MACOSX)
 
   // Tell the application that application is activated with visible/invisible

--- a/shell/browser/browser_observer.h
+++ b/shell/browser/browser_observer.h
@@ -82,6 +82,9 @@ class BrowserObserver : public base::CheckedObserver {
       const base::DictionaryValue& user_info) {}
   // User clicked the native macOS new tab button. (macOS only)
   virtual void OnNewWindowForTab() {}
+
+  // Browser did become active.
+  virtual void OnDidBecomeActive() {}
 #endif
 
  protected:

--- a/shell/browser/mac/electron_application_delegate.mm
+++ b/shell/browser/mac/electron_application_delegate.mm
@@ -89,6 +89,10 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
 #endif
 }
 
+- (void)applicationDidBecomeActive:(NSNotification*)notification {
+  electron::Browser::Get()->DidBecomeActive();
+}
+
 - (NSMenu*)applicationDockMenu:(NSApplication*)sender {
   if (menu_controller_)
     return [menu_controller_ menu];


### PR DESCRIPTION
#### Description of Change
Add new mac specific event `did-become-active`. 

It is just straightforward implementation of [applicationDidBecomeActive:](https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428577-applicationdidbecomeactive?language=objc) notification. 

Difference between `did-become-active` and existing `activate` event is that `did-become-active` is fired anyway the application is activated while `activate` is limited to app being activated by clicking the Dock icon or re-launching the app from Finder.

Patching the behavior of `activate` turned out to be BC desciribed in https://github.com/electron/electron/pull/23727#issuecomment-635119103 and was reverted. Using separate event is safer and should not break anything.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
(https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added did-become-active event on Mac for observing any application activation.
