### PR TITLE
test: load page with some content when testing extension

### DIFF
--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -40,7 +40,8 @@ describe('chrome extensions', () => {
     const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
     await customSession.loadExtension(path.join(fixtures, 'extensions', 'red-bg'));
     const w = new BrowserWindow({ show: false, webPreferences: { session: customSession } });
-    await w.loadURL(url);
+    w.loadURL(url);
+    await emittedOnce(w.webContents, 'dom-ready');
     const bg = await w.webContents.executeJavaScript('document.documentElement.style.backgroundColor');
     expect(bg).to.equal('red');
   });
@@ -94,7 +95,8 @@ describe('chrome extensions', () => {
     const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
     await customSession.loadExtension(path.join(fixtures, 'extensions', 'red-bg'));
     const w = new BrowserWindow({ show: false }); // not in the session
-    await w.loadURL(url);
+    w.loadURL(url);
+    await emittedOnce(w.webContents, 'dom-ready');
     const bg = await w.webContents.executeJavaScript('document.documentElement.style.backgroundColor');
     expect(bg).to.equal('');
   });
@@ -117,7 +119,8 @@ describe('chrome extensions', () => {
       const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
       extension = await customSession.loadExtension(path.join(fixtures, 'extensions', 'chrome-i18n'));
       w = new BrowserWindow({ show: false, webPreferences: { session: customSession, nodeIntegration: true } });
-      await w.loadURL(url);
+      w.loadURL(url);
+      await emittedOnce(w.webContents, 'dom-ready');
     });
     it('getAcceptLanguages()', async () => {
       const result = await exec('getAcceptLanguages');
@@ -137,7 +140,8 @@ describe('chrome extensions', () => {
       await customSession.loadExtension(path.join(fixtures, 'extensions', 'chrome-runtime'));
       const w = new BrowserWindow({ show: false, webPreferences: { session: customSession } });
       try {
-        await w.loadURL(url);
+        w.loadURL(url);
+        await emittedOnce(w.webContents, 'dom-ready');
         content = JSON.parse(await w.webContents.executeJavaScript('document.documentElement.textContent'));
         expect(content).to.be.an('object');
       } finally {
@@ -486,7 +490,8 @@ describe('chrome extensions', () => {
     it('loads a ui page of an extension', async () => {
       const { id } = await session.defaultSession.loadExtension(path.join(fixtures, 'extensions', 'ui-page'));
       const w = new BrowserWindow({ show: false });
-      await w.loadURL(`chrome-extension://${id}/bare-page.html`);
+      w.loadURL(`chrome-extension://${id}/bare-page.html`);
+      await emittedOnce(w.webContents, 'dom-ready');
       const textContent = await w.webContents.executeJavaScript('document.body.textContent');
       expect(textContent).to.equal('ui page loaded ok\n');
     });
@@ -494,7 +499,8 @@ describe('chrome extensions', () => {
     it('can load resources', async () => {
       const { id } = await session.defaultSession.loadExtension(path.join(fixtures, 'extensions', 'ui-page'));
       const w = new BrowserWindow({ show: false });
-      await w.loadURL(`chrome-extension://${id}/page-script-load.html`);
+      w.loadURL(`chrome-extension://${id}/page-script-load.html`);
+      await emittedOnce(w.webContents, 'dom-ready');
       const textContent = await w.webContents.executeJavaScript('document.body.textContent');
       expect(textContent).to.equal('script loaded ok\n');
     });

--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -10,11 +10,13 @@ import { emittedOnce, emittedNTimes } from './events-helpers';
 const fixtures = path.join(__dirname, 'fixtures');
 
 describe('chrome extensions', () => {
+  const emptyPage = '<script>console.log("loaded")</script>';
+
   // NB. extensions are only allowed on http://, https:// and ftp:// (!) urls by default.
   let server: http.Server;
   let url: string;
   before(async () => {
-    server = http.createServer((req, res) => res.end());
+    server = http.createServer((req, res) => res.end(emptyPage));
     await new Promise(resolve => server.listen(0, '127.0.0.1', () => {
       url = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
       resolve();
@@ -132,7 +134,7 @@ describe('chrome extensions', () => {
     let content: any;
     before(async () => {
       const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
-      customSession.loadExtension(path.join(fixtures, 'extensions', 'chrome-runtime'));
+      await customSession.loadExtension(path.join(fixtures, 'extensions', 'chrome-runtime'));
       const w = new BrowserWindow({ show: false, webPreferences: { session: customSession } });
       try {
         await w.loadURL(url);

--- a/spec-main/fixtures/extensions/chrome-runtime/manifest.json
+++ b/spec-main/fixtures/extensions/chrome-runtime/manifest.json
@@ -5,7 +5,7 @@
     {
       "matches": ["<all_urls>"],
       "js": ["main.js"],
-      "run_at": "document_start"
+      "run_at": "document_end"
     }
   ],
   "manifest_version": 2


### PR DESCRIPTION
#### Description of Change

When loading a completely blank page, the `did-finish-load` event may emit immediately instead of waiting for the script in extensions to run. Adding some content in the page can probably reduce the flakiness of extension tests, and it would help debugging if the test is still flaky. 

There is also a slight change to the extension so its code can overwrite page's content.

#### Release Notes

Notes: none