### PR TITLE
chore: update patches for master conflicts

### DIFF
--- a/patches/chromium/disable_color_correct_rendering.patch
+++ b/patches/chromium/disable_color_correct_rendering.patch
@@ -20,10 +20,10 @@ to deal with color spaces. That is being tracked at
 https://crbug.com/634542 and https://crbug.com/711107.
 
 diff --git a/cc/trees/layer_tree_host_impl.cc b/cc/trees/layer_tree_host_impl.cc
-index 461198cc1c11bbd15e6bdc846ba563f4f62916af..454dc37ab4b46cd449ae10c6a5dc9014f57e74e8 100644
+index f2beaa8238c66b942620e053f4abae32441f2851..82aa964e34a966e3e2300c2b951d6431d294d111 100644
 --- a/cc/trees/layer_tree_host_impl.cc
 +++ b/cc/trees/layer_tree_host_impl.cc
-@@ -1830,6 +1830,10 @@ void LayerTreeHostImpl::SetIsLikelyToRequireADraw(
+@@ -1859,6 +1859,10 @@ void LayerTreeHostImpl::SetIsLikelyToRequireADraw(
  
  gfx::ColorSpace LayerTreeHostImpl::GetRasterColorSpace(
      gfx::ContentColorUsage content_color_usage) const {


### PR DESCRIPTION
Fixes master CI as we had a race between two patch PRs landing that resulted in an invalid patch set on master.  In the future our automation should handle this.

https://electronhq.slack.com/archives/C9SBTCH8R/p1591087281053100

Notes: none