### PR TITLE
fix: correctly support the --inspect-brk-node flag

### DIFF
--- a/shell/browser/node_debugger.cc
+++ b/shell/browser/node_debugger.cc
@@ -34,7 +34,11 @@ void NodeDebugger::Start() {
                        std::make_shared<node::ExclusiveAccess<node::HostPort>>(
                            debug_options.host_port),
                        true /* is_main */))
-    DCHECK(env_->inspector_agent()->IsListening());
+    DCHECK(inspector->IsListening());
+
+  if (inspector->options().break_node_first_line) {
+    inspector->PauseOnNextJavascriptStatement("Break at bootstrap");
+  }
 }
 
 void NodeDebugger::Stop() {


### PR DESCRIPTION
Very useful for profiling Electron's boot process.

Notes: none