### PR TITLE
docs: remove confusing notes on Node

### DIFF
--- a/docs/tutorial/first-app.md
+++ b/docs/tutorial/first-app.md
@@ -44,23 +44,10 @@ run the main process. An example of your `package.json` might look like this:
 ```
 
 __Note__: If the `main` field is not present in `package.json`, Electron will
-attempt to load an `index.js` (as Node.js does). If this was actually
-a simple Node application, you would add a `start` script that instructs `node`
-to execute the current package:
+attempt to load an `index.js` (as Node.js does).
 
-```json
-{
-  "name": "your-app",
-  "version": "0.1.0",
-  "main": "main.js",
-  "scripts": {
-    "start": "node ."
-  }
-}
-```
-
-Turning this Node application into an Electron application is quite simple - we
-merely replace the `node` runtime with the `electron` runtime.
+By default `npm start` would run the main script with node, in order to make
+it run with Electron, you can add a `scripts` field:
 
 ```json
 {

--- a/docs/tutorial/first-app.md
+++ b/docs/tutorial/first-app.md
@@ -46,8 +46,8 @@ run the main process. An example of your `package.json` might look like this:
 __Note__: If the `main` field is not present in `package.json`, Electron will
 attempt to load an `index.js` (as Node.js does).
 
-By default `npm start` would run the main script with node, in order to make
-it run with Electron, you can add a `scripts` field:
+By default, `npm start` would run the main script with Node.js. in order to make
+it run with Electron, you can add a `start` script:
 
 ```json
 {


### PR DESCRIPTION
#### Description of Change

In the first app tutorial, there is a note on how to run the project with Node, while the tutorial is about Electron. So many new users copied the code in their projects and complained it did not work, which was because they copied the code to run with Node, instead of the code to run with Electron.

We should just remove this part, it is very confusing even with careful read.

See https://github.com/electron/electron-quick-start/issues/363.

#### Release Notes

Notes: none