### PR TITLE
fix: destroy GetSize callback at last

### DIFF
--- a/shell/browser/api/electron_api_url_loader.cc
+++ b/shell/browser/api/electron_api_url_loader.cc
@@ -203,10 +203,10 @@ class JSChunkedDataPipeGetter : public gin::Wrappable<JSChunkedDataPipeGetter>,
   }
 
   void Finished() {
-    size_callback_.Reset();
     body_func_.Reset();
-    receiver_.reset();
     data_producer_.reset();
+    receiver_.reset();
+    size_callback_.Reset();
   }
 
   GetSizeCallback size_callback_;


### PR DESCRIPTION
#### Description of Change

Encountered this crash in CI:

```
[452:0602/222020.682124:FATAL:chunked_data_pipe_getter.mojom.cc(169)] Check failed: !connected. ChunkedDataPipeGetter::GetSizeCallback was destroyed without first either being run or its corresponding binding being closed. It is an error to drop response callbacks which still correspond to an open interface pipe.
#0 0x559fef314219 base::debug::CollectStackTrace() 
#1 0x559fef24a0b3 base::debug::StackTrace::StackTrace()
#2 0x559fef25eb6f logging::LogMessage::~LogMessage()
#3 0x559fef25f3ee logging::LogMessage::~LogMessage()
#4 0x559fec00eb7e network::mojom::ChunkedDataPipeGetter_GetSize_ProxyToResponder::OnIsConnectedComplete()
#5 0x559fef5e94b1 mojo::(anonymous namespace)::ResponderThunk::IsConnectedAsync()
#6 0x559fec00eaa0 std::__1::unique_ptr<>::reset()
#7 0x559fec00ea19 base::internal::BindState<>::Destroy()
#8 0x559febb2f2af electron::api::(anonymous namespace)::JSChunkedDataPipeGetter::OnWriteChunkComplete()
#9 0x559febb2f4bc base::internal::Invoker<>::RunOnce() 
#10 0x559fef607ccc mojo::DataPipeProducer::OnWriteComplete()
```

According to the message, destroying the GetSize callback after destroying the pipe should be able to fix it.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: none