### PR TITLE
fix: notify URLLoaderClient about redirect inside intercepted protocol (backport to 7-2-X)

### DIFF
--- a/shell/browser/net/atom_url_loader_factory.cc
+++ b/shell/browser/net/atom_url_loader_factory.cc
@@ -230,7 +230,19 @@ void AtomURLLoaderFactory::StartLoading(
   std::string location;
   if (head.headers->IsRedirect(&location)) {
     network::ResourceRequest new_request = request;
-    new_request.url = GURL(location);
+    GURL new_location = GURL(location);
+
+    new_request.url = new_location;
+    new_request.site_for_cookies = new_location;
+
+    net::RedirectInfo redirect_info;
+    redirect_info.status_code = head.headers->response_code();
+    redirect_info.new_method = request.method;
+    redirect_info.new_url = new_location;
+    redirect_info.new_site_for_cookies = new_location;
+
+    client->OnReceiveRedirect(redirect_info, head);
+
     // When the redirection comes from an intercepted scheme (which has
     // |proxy_factory| passed), we askes the proxy factory to create a loader
     // for new URL, otherwise we call |StartLoadingHttp|, which creates


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Backport of Fix for - https://github.com/electron/electron/issues/23741 to 7.2.X. (it was not straigt-froward, as logic needed to be modified, and target files have been renamed) 
Change makes chromium aware of redirect inside an intercepted protocol

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [X] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed intercepted protocols not raising Redirect information back to Chromium