### PR TITLE
fix: use acceptLanguages argument in session.setUserAgent()

### DIFF
--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -40,6 +40,7 @@
 #include "net/http/http_auth_handler_factory.h"
 #include "net/http/http_auth_preferences.h"
 #include "net/http/http_cache.h"
+#include "net/http/http_util.h"
 #include "services/network/network_service.h"
 #include "services/network/public/cpp/features.h"
 #include "shell/browser/api/electron_api_app.h"
@@ -591,9 +592,16 @@ void Session::AllowNTLMCredentialsForDomains(const std::string& domains) {
 void Session::SetUserAgent(const std::string& user_agent,
                            gin::Arguments* args) {
   browser_context_->SetUserAgent(user_agent);
-  content::BrowserContext::GetDefaultStoragePartition(browser_context_.get())
-      ->GetNetworkContext()
-      ->SetUserAgent(user_agent);
+  auto* network_context = content::BrowserContext::GetDefaultStoragePartition(
+                              browser_context_.get())
+                              ->GetNetworkContext();
+  network_context->SetUserAgent(user_agent);
+
+  std::string accept_lang;
+  if (args->GetNext(&accept_lang)) {
+    network_context->SetAcceptLanguage(
+        net::HttpUtil::GenerateAcceptLanguageHeader(accept_lang));
+  }
 }
 
 std::string Session::GetUserAgent() {

--- a/spec-main/api-session-spec.ts
+++ b/spec-main/api-session-spec.ts
@@ -924,7 +924,7 @@ describe('session module', () => {
     it('sets the User-Agent header for web requests made from renderers', async () => {
       const userAgent = 'test-agent';
       const ses = session.fromPartition('' + Math.random());
-      ses.setUserAgent(userAgent);
+      ses.setUserAgent(userAgent, 'en-US,fr,de');
       const w = new BrowserWindow({ show: false, webPreferences: { session: ses } });
       let headers: http.IncomingHttpHeaders | null = null;
       const server = http.createServer((req, res) => {
@@ -935,6 +935,7 @@ describe('session module', () => {
       await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
       await w.loadURL(`http://127.0.0.1:${(server.address() as AddressInfo).port}`);
       expect(headers!['user-agent']).to.equal(userAgent);
+      expect(headers!['accept-language']).to.equal('en-US,fr;q=0.9,de;q=0.8');
     });
   });
 


### PR DESCRIPTION
#### Description of Change
The `acceptLanguages` argument was lost when re-implementing [`session.setUserAgent()`](https://github.com/electron/electron/blob/master/docs/api/session.md#sessetuseragentuseragent-acceptlanguages) in #20014. It's still documented.

Fixes https://github.com/electron/electron/issues/23211

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed the `acceptLanguages` argument being ignored in `session.setUserAgent()`.