### PR TITLE
fix: handle asynchronous URL loading in bw proxy

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -882,10 +882,10 @@ Returns `String` - The URL of the current web page.
 ```javascript
 const { BrowserWindow } = require('electron')
 let win = new BrowserWindow({ width: 800, height: 600 })
-win.loadURL('http://github.com')
-
-let currentURL = win.webContents.getURL()
-console.log(currentURL)
+win.loadURL('http://github.com').then(() => {
+  const currentURL = win.webContents.getURL()
+  console.log(currentURL)
+})
 ```
 
 #### `contents.getTitle()`

--- a/lib/renderer/window-setup.ts
+++ b/lib/renderer/window-setup.ts
@@ -126,7 +126,11 @@ class LocationProxy {
   }
 
   private getGuestURL (): URL | null {
-    const urlString = this._invokeWebContentsMethodSync('getURL') as string;
+    const maybeURL = this._invokeWebContentsMethodSync('getURL') as string;
+
+    // When there's no previous frame the url will be blank, so accountfor that here
+    // to prevent url parsing errors on an empty string.
+    const urlString = maybeURL !== '' ? maybeURL : 'about:blank';
     try {
       return new URL(urlString);
     } catch (e) {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -3994,7 +3994,7 @@ describe('BrowserWindow module', () => {
         window.postMessage({openedLocation}, '*')
       `)
       const [, data] = await p
-      expect(data.pageContext.openedLocation).to.equal('')
+      expect(data.pageContext.openedLocation).to.equal('about:blank')
     })
   })
 


### PR DESCRIPTION
Backport of #23776

See that PR for details.


Notes: Fixed an issue where `window.location` properties would throw an error for windows opened with `window.open`.
