### PR TITLE
fix: volume key globalShortcut registration

### DIFF
--- a/patches/chromium/command-ismediakey.patch
+++ b/patches/chromium/command-ismediakey.patch
@@ -3,17 +3,8 @@ From: Jeremy Apthorp <jeremya@chromium.org>
 Date: Wed, 10 Oct 2018 15:07:34 -0700
 Subject: command-ismediakey.patch
 
-Override MediaKeysListener::IsMediaKeycode to also listen for Volume Up, Volume Down,
-and Mute. We also need to patch out Chromium's usage of RemoteCommandCenterDelegate, as
-it uses MPRemoteCommandCenter. MPRemoteCommandCenter makes it such that GlobalShortcuts
-in Electron will not work as intended, because by design an app does not receive remote
-control events until it begins playing audio. This means that a media shortcut would not kick
-into effect until you, for example, began playing a YouTube video which sort of defeats the
-purpose of GlobalShortcuts.
-
-At the moment there is no upstream possibility for this; but perhaps Chromium may
-consider some kind of switch, enabled by default, which would conditionally choose to avoid usage of
-RemoteCommandCenterDelegate on macOS.
+Override MediaKeysListener::IsMediaKeycode and associated functions to also listen for
+Volume Up, Volume Down, and Mute.
 
 diff --git a/chrome/browser/extensions/global_shortcut_listener_win.cc b/chrome/browser/extensions/global_shortcut_listener_win.cc
 index c5125495b4d178ffb18be4d2d9670f7556412cbd..cddb321abb938c667a4a2089f87eab999510e9b1 100644
@@ -101,3 +92,19 @@ index 85378bb565de617b1bd611d28c8714361747a357..36de4c0b0353be2418dacd388e92d7c3
      return event;
    }
  
+diff --git a/ui/base/accelerators/system_media_controls_media_keys_listener.cc b/ui/base/accelerators/system_media_controls_media_keys_listener.cc
+index 9d6084ceaccfd071549e63e3015f55ef292312ec..3f6af8b1b49bf0f226e9336c222884b07bf69e55 100644
+--- a/ui/base/accelerators/system_media_controls_media_keys_listener.cc
++++ b/ui/base/accelerators/system_media_controls_media_keys_listener.cc
+@@ -65,6 +65,11 @@ bool SystemMediaControlsMediaKeysListener::StartWatchingMediaKey(
+     case VKEY_MEDIA_STOP:
+       service_->SetIsStopEnabled(true);
+       break;
++    case VKEY_VOLUME_DOWN:
++    case VKEY_VOLUME_UP:
++    case VKEY_VOLUME_MUTE:
++      // Do nothing.
++      break;
+     default:
+       NOTREACHED();
+   }

--- a/shell/browser/api/electron_api_global_shortcut.cc
+++ b/shell/browser/api/electron_api_global_shortcut.cc
@@ -28,7 +28,9 @@ bool RegisteringMediaKeyForUntrustedClient(const ui::Accelerator& accelerator) {
   if (base::mac::IsAtLeastOS10_14()) {
     constexpr ui::KeyboardCode mediaKeys[] = {
         ui::VKEY_MEDIA_PLAY_PAUSE, ui::VKEY_MEDIA_NEXT_TRACK,
-        ui::VKEY_MEDIA_PREV_TRACK, ui::VKEY_MEDIA_STOP};
+        ui::VKEY_MEDIA_PREV_TRACK, ui::VKEY_MEDIA_STOP,
+        ui::VKEY_VOLUME_UP,        ui::VKEY_VOLUME_DOWN,
+        ui::VKEY_VOLUME_MUTE};
 
     if (std::find(std::begin(mediaKeys), std::end(mediaKeys),
                   accelerator.key_code()) != std::end(mediaKeys)) {
@@ -59,7 +61,7 @@ GlobalShortcut::~GlobalShortcut() {
 void GlobalShortcut::OnKeyPressed(const ui::Accelerator& accelerator) {
   if (accelerator_callback_map_.find(accelerator) ==
       accelerator_callback_map_.end()) {
-    // This should never occur, because if it does, GlobalGlobalShortcutListener
+    // This should never occur, because if it does, GlobalShortcutListener
     // notifies us with wrong accelerator.
     NOTREACHED();
     return;

--- a/spec-main/api-global-shortcut-spec.ts
+++ b/spec-main/api-global-shortcut-spec.ts
@@ -43,4 +43,21 @@ describe('globalShortcut module', () => {
     expect(globalShortcut.isRegistered(accelerators[0])).to.be.false('first unregistered')
     expect(globalShortcut.isRegistered(accelerators[1])).to.be.false('second unregistered')
   })
+
+  it('does not crash when registering media keys as global shortcuts', () => {
+    const accelerators = [
+      'VolumeUp',
+      'VolumeDown',
+      'VolumeMute',
+      'MediaNextTrack',
+      'MediaPreviousTrack',
+      'MediaStop', 'MediaPlayPause'
+    ];
+
+    expect(() => {
+      globalShortcut.registerAll(accelerators, () => {});
+    }).to.not.throw();
+
+    globalShortcut.unregisterAll();
+  });
 })


### PR DESCRIPTION
Backport of #23782

See that PR for details.


Notes: Fixed an issue with volume-related `globalShortcut` registration.
