### PR TITLE
build: fix filenames autogen with new BUILDFLAG syntax

### DIFF
--- a/build/webpack/webpack.config.base.js
+++ b/build/webpack/webpack.config.base.js
@@ -21,7 +21,7 @@ class AccessDependenciesPlugin {
 }
 
 const defines = {
-  BUILDFLAG: ''
+  BUILDFLAG: onlyPrintingGraph ? '(a => a)' : ''
 }
 
 const buildFlagsPrefix = '--buildflags='
@@ -95,7 +95,7 @@ module.exports = ({
     },
     module: {
       rules: [{
-        test: (moduleName) => ignoredModules.includes(moduleName),
+        test: (moduleName) => !onlyPrintingGraph && ignoredModules.includes(moduleName),
         loader: 'null-loader',
       }, {
         test: /\.ts$/,


### PR DESCRIPTION
Issues caused by https://github.com/electron/electron/commit/90833d372f174a872fbcd1a5933426ff74fd36e2

Notes: none