### PR TITLE
fix: use acceptLanguages argument in session.setUserAgent()

### DIFF
--- a/shell/browser/api/atom_api_session.cc
+++ b/shell/browser/api/atom_api_session.cc
@@ -39,6 +39,7 @@
 #include "net/http/http_auth_handler_factory.h"
 #include "net/http/http_auth_preferences.h"
 #include "net/http/http_cache.h"
+#include "net/http/http_util.h"
 #include "services/network/network_service.h"
 #include "services/network/public/cpp/features.h"
 #include "shell/browser/api/atom_api_cookies.h"
@@ -497,9 +498,16 @@ void Session::AllowNTLMCredentialsForDomains(const std::string& domains) {
 void Session::SetUserAgent(const std::string& user_agent,
                            mate::Arguments* args) {
   browser_context_->SetUserAgent(user_agent);
-  content::BrowserContext::GetDefaultStoragePartition(browser_context_.get())
-      ->GetNetworkContext()
-      ->SetUserAgent(user_agent);
+  auto* network_context = content::BrowserContext::GetDefaultStoragePartition(
+                              browser_context_.get())
+                              ->GetNetworkContext();
+  network_context->SetUserAgent(user_agent);
+
+  std::string accept_lang;
+  if (args->GetNext(&accept_lang)) {
+    network_context->SetAcceptLanguage(
+        net::HttpUtil::GenerateAcceptLanguageHeader(accept_lang));
+  }
 }
 
 std::string Session::GetUserAgent() {

--- a/spec-main/api-session-spec.js
+++ b/spec-main/api-session-spec.js
@@ -906,7 +906,7 @@ describe('session module', () => {
     it('sets the User-Agent header for web requests made from renderers', async () => {
       const userAgent = 'test-agent'
       const ses = session.fromPartition(''+Math.random())
-      ses.setUserAgent(userAgent)
+      ses.setUserAgent(userAgent, 'en-US,fr,de');
       const w = new BrowserWindow({ show: false, webPreferences: { session: ses } })
       let headers = null
       const server = http.createServer((req, res) => {
@@ -917,6 +917,7 @@ describe('session module', () => {
       await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
       await w.loadURL(`http://127.0.0.1:${server.address().port}`)
       expect(headers['user-agent']).to.equal(userAgent)
+      expect(headers['accept-language']).to.equal('en-US,fr;q=0.9,de;q=0.8');
     })
   })
 })


### PR DESCRIPTION
Backport of #23944

See that PR for details.


Notes: Fixed the `acceptLanguages` argument being ignored in `session.setUserAgent()`.