### PR TITLE
fix: read GTK dark theme setting on Linux

### DIFF
--- a/shell/browser/atom_browser_main_parts.cc
+++ b/shell/browser/atom_browser_main_parts.cc
@@ -70,6 +70,7 @@
 #include "ui/base/x/x11_util.h"
 #include "ui/base/x/x11_util_internal.h"
 #include "ui/events/devices/x11/touch_factory_x11.h"
+#include "ui/gfx/color_utils.h"
 #include "ui/views/linux_ui/linux_ui.h"
 #endif
 
@@ -204,9 +205,37 @@ int X11EmptyErrorHandler(Display* d, XErrorEvent* error) {
 int X11EmptyIOErrorHandler(Display* d) {
   return 0;
 }
+
+// GTK does not provide a way to check if current theme is dark, so we compare
+// the text and background luminosity to get a result.
+// This trick comes from FireFox.
+void UpdateDarkThemeSetting() {
+  float bg =
+      color_utils::GetRelativeLuminance(libgtkui::GetBgColor("GtkLabel"));
+  float fg =
+      color_utils::GetRelativeLuminance(libgtkui::GetFgColor("GtkLabel"));
+  bool is_dark = fg > bg;
+  // Pass it to NativeUi theme, which is used by the nativeTheme module and most
+  // places in Electron.
+  ui::NativeTheme::GetInstanceForNativeUi()->set_use_dark_colors(is_dark);
+  // Pass it to Web Theme, to make "prefers-color-scheme" media query work.
+  ui::NativeTheme::GetInstanceForWeb()->set_use_dark_colors(is_dark);
+}
 #endif
 
 }  // namespace
+
+#if defined(USE_X11)
+class DarkThemeObserver : public ui::NativeThemeObserver {
+ public:
+  DarkThemeObserver() = default;
+
+  // ui::NativeThemeObserver:
+  void OnNativeThemeUpdated(ui::NativeTheme* observed_theme) override {
+    UpdateDarkThemeSetting();
+  }
+};
+#endif
 
 // static
 AtomBrowserMainParts* AtomBrowserMainParts::self_ = nullptr;
@@ -267,7 +296,6 @@ void AtomBrowserMainParts::RegisterDestructionCallback(
 int AtomBrowserMainParts::PreEarlyInitialization() {
   field_trial_list_ = std::make_unique<base::FieldTrialList>(nullptr);
 #if defined(USE_X11)
-  views::LinuxUI::SetInstance(BuildGtkUi());
   OverrideLinuxAppDataPath();
 
   // Installs the X11 error handlers for the browser process used during
@@ -405,8 +433,20 @@ void AtomBrowserMainParts::PostDestroyThreads() {
 void AtomBrowserMainParts::ToolkitInitialized() {
   ui::MaterialDesignController::Initialize();
 
-#if defined(USE_AURA) && defined(USE_X11)
-  views::LinuxUI::instance()->Initialize();
+#if defined(USE_X11)
+  views::LinuxUI* linux_ui = BuildGtkUi();
+  views::LinuxUI::SetInstance(linux_ui);
+  linux_ui->Initialize();
+
+  // Chromium does not respect GTK dark theme setting, but they may change
+  // in future and this code might be no longer needed. Check the Chromium
+  // issue to keep updated:
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=998903
+  UpdateDarkThemeSetting();
+  // Update the naitve theme when GTK theme changes. The GetNativeTheme
+  // here returns a NativeThemeGtk, which monitors GTK settings.
+  dark_theme_observer_.reset(new DarkThemeObserver);
+  linux_ui->GetNativeTheme(nullptr)->AddObserver(dark_theme_observer_.get());
 #endif
 
 #if defined(USE_AURA)

--- a/shell/browser/atom_browser_main_parts.h
+++ b/shell/browser/atom_browser_main_parts.h
@@ -52,6 +52,10 @@ class ViewsDelegate;
 class ViewsDelegateMac;
 #endif
 
+#if defined(USE_X11)
+class DarkThemeObserver;
+#endif
+
 class AtomBrowserMainParts : public content::BrowserMainParts {
  public:
   explicit AtomBrowserMainParts(const content::MainFunctionParams& params);
@@ -118,6 +122,10 @@ class AtomBrowserMainParts : public content::BrowserMainParts {
 
 #if defined(USE_AURA)
   std::unique_ptr<wm::WMState> wm_state_;
+#endif
+
+#if defined(USE_X11)
+  std::unique_ptr<DarkThemeObserver> dark_theme_observer_;
 #endif
 
   std::unique_ptr<views::LayoutProvider> layout_provider_;


### PR DESCRIPTION
Backport of #23678

Notes: Fix GTK dark theme setting not respected in Electron on Linux.