### PR TITLE
fix: Allow windows behind macOS elements if frame = false

### DIFF
--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -91,8 +91,20 @@ bool ScopedDisableResize::disable_resize_ = false;
 
   NSRect result = [super constrainFrameRect:frameRect toScreen:screen];
   // Enable the window to be larger than screen.
-  if ([self enableLargerThanScreen])
-    result.size = frameRect.size;
+  if ([self enableLargerThanScreen]) {
+    // If we have a frame, ensure that we only position the window
+    // somewhere where the user can move or resize it (and not
+    // behind the menu bar, for instance)
+    //
+    // If there's no frame, put the window wherever the developer
+    // wanted it to go
+    if (shell_->has_frame()) {
+      result.size = frameRect.size;
+    } else {
+      result = frameRect;
+    }
+  }
+
   return result;
 }
 

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1673,6 +1673,13 @@ describe('BrowserWindow module', () => {
       const after = w.getPosition();
       expect(after[1]).to.be.at.least(0);
     });
+    it('can move the window behind menu bar if it has no frame', () => {
+      const w = new BrowserWindow({ show: true, enableLargerThanScreen: true, frame: false });
+      w.setPosition(-10, -10);
+      const after = w.getPosition();
+      expect(after[0]).to.be.equal(-10);
+      expect(after[1]).to.be.equal(-10);
+    });
     it('without it, cannot move the window out of screen', () => {
       const w = new BrowserWindow({ show: true, enableLargerThanScreen: false });
       w.setPosition(-10, -10);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/24000.

In #22770, we ensured that windows cannot be moved behind the menu bar or be too close to the dock. That was a good idea - we wanted to make sure that windows can always be moved by the user.

However, some apps (Slack) are using frameless windows to purposefully draw content onto the screen. In Slack's case, that's a red border, only six pixels tall, that goes around the screen. With the fix mentioned above, we couldn't get the window as close to the screen's boundary as we wanted to. That turned the PR above into a breaking change without workarounds available.

With this proposed fix, I'm allowing frame-less windows to be positioned exactly where the developer wants them to be, even if that's behind the dock or the menu bar. I'm hoping that it's a good compromise between "helping the developer" and ensuring that previously covered use cases remain possible.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fix: Allow windows behind macOS elements if "frame" is false.
