### PR TITLE
fix: throw instead of crash when using ipcRenderer after context released (#23917)

### DIFF
--- a/shell/renderer/api/electron_api_renderer_ipc.cc
+++ b/shell/renderer/api/electron_api_renderer_ipc.cc
@@ -16,6 +16,7 @@
 #include "shell/common/api/api.mojom.h"
 #include "shell/common/gin_converters/blink_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
+#include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/node_bindings.h"
 #include "shell/common/node_includes.h"
@@ -25,6 +26,9 @@ using blink::WebLocalFrame;
 using content::RenderFrame;
 
 namespace {
+
+const char kIPCMethodCalledAfterContextReleasedError[] =
+    "IPC method called after context was released";
 
 RenderFrame* GetCurrentRenderFrame() {
   WebLocalFrame* frame = WebLocalFrame::FrameForCurrentContext();
@@ -79,9 +83,14 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
 
  private:
   void SendMessage(v8::Isolate* isolate,
+                   gin_helper::ErrorThrower thrower,
                    bool internal,
                    const std::string& channel,
                    v8::Local<v8::Value> arguments) {
+    if (!electron_browser_ptr_) {
+      thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
+      return;
+    }
     blink::CloneableMessage message;
     if (!gin::ConvertFromV8(isolate, arguments, &message)) {
       return;
@@ -90,9 +99,14 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
   }
 
   v8::Local<v8::Promise> Invoke(v8::Isolate* isolate,
+                                gin_helper::ErrorThrower thrower,
                                 bool internal,
                                 const std::string& channel,
                                 v8::Local<v8::Value> arguments) {
+    if (!electron_browser_ptr_) {
+      thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
+      return v8::Local<v8::Promise>();
+    }
     blink::CloneableMessage message;
     if (!gin::ConvertFromV8(isolate, arguments, &message)) {
       return v8::Local<v8::Promise>();
@@ -111,11 +125,16 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
   }
 
   void SendTo(v8::Isolate* isolate,
+              gin_helper::ErrorThrower thrower,
               bool internal,
               bool send_to_all,
               int32_t web_contents_id,
               const std::string& channel,
               v8::Local<v8::Value> arguments) {
+    if (!electron_browser_ptr_) {
+      thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
+      return;
+    }
     blink::CloneableMessage message;
     if (!gin::ConvertFromV8(isolate, arguments, &message)) {
       return;
@@ -125,8 +144,13 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
   }
 
   void SendToHost(v8::Isolate* isolate,
+                  gin_helper::ErrorThrower thrower,
                   const std::string& channel,
                   v8::Local<v8::Value> arguments) {
+    if (!electron_browser_ptr_) {
+      thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
+      return;
+    }
     blink::CloneableMessage message;
     if (!gin::ConvertFromV8(isolate, arguments, &message)) {
       return;
@@ -135,9 +159,14 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
   }
 
   blink::CloneableMessage SendSync(v8::Isolate* isolate,
+                                   gin_helper::ErrorThrower thrower,
                                    bool internal,
                                    const std::string& channel,
                                    v8::Local<v8::Value> arguments) {
+    if (!electron_browser_ptr_) {
+      thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
+      return blink::CloneableMessage();
+    }
     blink::CloneableMessage message;
     if (!gin::ConvertFromV8(isolate, arguments, &message)) {
       return blink::CloneableMessage();

--- a/shell/renderer/api/electron_api_renderer_ipc.cc
+++ b/shell/renderer/api/electron_api_renderer_ipc.cc
@@ -83,12 +83,12 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
 
  private:
   void SendMessage(v8::Isolate* isolate,
-                   gin_helper::ErrorThrower thrower,
                    bool internal,
                    const std::string& channel,
                    v8::Local<v8::Value> arguments) {
     if (!electron_browser_ptr_) {
-      thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
+      gin_helper::ErrorThrower(isolate).ThrowError(
+          kIPCMethodCalledAfterContextReleasedError);
       return;
     }
     blink::CloneableMessage message;
@@ -99,12 +99,12 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
   }
 
   v8::Local<v8::Promise> Invoke(v8::Isolate* isolate,
-                                gin_helper::ErrorThrower thrower,
                                 bool internal,
                                 const std::string& channel,
                                 v8::Local<v8::Value> arguments) {
     if (!electron_browser_ptr_) {
-      thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
+      gin_helper::ErrorThrower(isolate).ThrowError(
+          kIPCMethodCalledAfterContextReleasedError);
       return v8::Local<v8::Promise>();
     }
     blink::CloneableMessage message;
@@ -125,14 +125,14 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
   }
 
   void SendTo(v8::Isolate* isolate,
-              gin_helper::ErrorThrower thrower,
               bool internal,
               bool send_to_all,
               int32_t web_contents_id,
               const std::string& channel,
               v8::Local<v8::Value> arguments) {
     if (!electron_browser_ptr_) {
-      thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
+      gin_helper::ErrorThrower(isolate).ThrowError(
+          kIPCMethodCalledAfterContextReleasedError);
       return;
     }
     blink::CloneableMessage message;
@@ -144,11 +144,11 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
   }
 
   void SendToHost(v8::Isolate* isolate,
-                  gin_helper::ErrorThrower thrower,
                   const std::string& channel,
                   v8::Local<v8::Value> arguments) {
     if (!electron_browser_ptr_) {
-      thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
+      gin_helper::ErrorThrower(isolate).ThrowError(
+          kIPCMethodCalledAfterContextReleasedError);
       return;
     }
     blink::CloneableMessage message;
@@ -159,12 +159,12 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
   }
 
   blink::CloneableMessage SendSync(v8::Isolate* isolate,
-                                   gin_helper::ErrorThrower thrower,
                                    bool internal,
                                    const std::string& channel,
                                    v8::Local<v8::Value> arguments) {
     if (!electron_browser_ptr_) {
-      thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
+      gin_helper::ErrorThrower(isolate).ThrowError(
+          kIPCMethodCalledAfterContextReleasedError);
       return blink::CloneableMessage();
     }
     blink::CloneableMessage message;

--- a/spec-main/api-ipc-renderer-spec.ts
+++ b/spec-main/api-ipc-renderer-spec.ts
@@ -190,14 +190,13 @@ describe('ipcRenderer module', () => {
         const childIpc = child.require('electron').ipcRenderer;
         child.close();
         return new Promise(resolve => {
-          setTimeout(() => {
+          setInterval(() => {
             try {
               childIpc.send('hello');
             } catch (e) {
               resolve(e);
             }
-            resolve(false);
-          }, 100);
+          }, 16);
         });
       }})()`);
       expect(error).to.have.property('message', 'IPC method called after context was released');


### PR DESCRIPTION
Backport of #23917

Notes: Fixed a crash that could occur when using the `ipcRenderer` module after blink had released the context. Instead, a JS exception will be thrown.
