### PR TITLE
fix: throw instead of crash when using ipcRenderer after context released

### DIFF
--- a/shell/renderer/api/electron_api_renderer_ipc.cc
+++ b/shell/renderer/api/electron_api_renderer_ipc.cc
@@ -83,12 +83,12 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
 
  private:
   void SendMessage(v8::Isolate* isolate,
-                   gin_helper::ErrorThrower thrower,
                    bool internal,
                    const std::string& channel,
                    v8::Local<v8::Value> arguments) {
     if (!electron_browser_ptr_) {
-      thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
+      gin_helper::ErrorThrower(isolate).ThrowError(
+          kIPCMethodCalledAfterContextReleasedError);
       return;
     }
     blink::CloneableMessage message;
@@ -99,12 +99,12 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
   }
 
   v8::Local<v8::Promise> Invoke(v8::Isolate* isolate,
-                                gin_helper::ErrorThrower thrower,
                                 bool internal,
                                 const std::string& channel,
                                 v8::Local<v8::Value> arguments) {
     if (!electron_browser_ptr_) {
-      thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
+      gin_helper::ErrorThrower(isolate).ThrowError(
+          kIPCMethodCalledAfterContextReleasedError);
       return v8::Local<v8::Promise>();
     }
     blink::CloneableMessage message;
@@ -125,14 +125,14 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
   }
 
   void SendTo(v8::Isolate* isolate,
-              gin_helper::ErrorThrower thrower,
               bool internal,
               bool send_to_all,
               int32_t web_contents_id,
               const std::string& channel,
               v8::Local<v8::Value> arguments) {
     if (!electron_browser_ptr_) {
-      thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
+      gin_helper::ErrorThrower(isolate).ThrowError(
+          kIPCMethodCalledAfterContextReleasedError);
       return;
     }
     blink::CloneableMessage message;
@@ -144,11 +144,11 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
   }
 
   void SendToHost(v8::Isolate* isolate,
-                  gin_helper::ErrorThrower thrower,
                   const std::string& channel,
                   v8::Local<v8::Value> arguments) {
     if (!electron_browser_ptr_) {
-      thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
+      gin_helper::ErrorThrower(isolate).ThrowError(
+          kIPCMethodCalledAfterContextReleasedError);
       return;
     }
     blink::CloneableMessage message;
@@ -159,12 +159,12 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
   }
 
   blink::CloneableMessage SendSync(v8::Isolate* isolate,
-                                   gin_helper::ErrorThrower thrower,
                                    bool internal,
                                    const std::string& channel,
                                    v8::Local<v8::Value> arguments) {
     if (!electron_browser_ptr_) {
-      thrower.ThrowError(kIPCMethodCalledAfterContextReleasedError);
+      gin_helper::ErrorThrower(isolate).ThrowError(
+          kIPCMethodCalledAfterContextReleasedError);
       return blink::CloneableMessage();
     }
     blink::CloneableMessage message;

--- a/spec-main/api-ipc-renderer-spec.ts
+++ b/spec-main/api-ipc-renderer-spec.ts
@@ -9,7 +9,7 @@ describe('ipcRenderer module', () => {
 
   let w: BrowserWindow
   before(async () => {
-    w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true } })
+    w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, nativeWindowOpen: true } })
     await w.loadURL('about:blank')
   })
   after(async () => {
@@ -192,4 +192,25 @@ describe('ipcRenderer module', () => {
       expect(result).to.deep.equal([])
     })
   })
-})
+
+  describe('after context is released', () => {
+    it('throws an exception', async () => {
+      const error = await w.webContents.executeJavaScript(`(${() => {
+        const child = window.open('', 'child', 'show=no,nodeIntegration=yes')! as any;
+        const childIpc = child.require('electron').ipcRenderer;
+        child.close();
+        return new Promise(resolve => {
+          setTimeout(() => {
+            try {
+              childIpc.send('hello');
+            } catch (e) {
+              resolve(e);
+            }
+            resolve(false);
+          }, 100);
+        });
+      }})()`);
+      expect(error).to.have.property('message', 'IPC method called after context was released');
+    });
+  });
+});

--- a/spec-main/api-ipc-renderer-spec.ts
+++ b/spec-main/api-ipc-renderer-spec.ts
@@ -9,7 +9,7 @@ describe('ipcRenderer module', () => {
 
   let w: BrowserWindow
   before(async () => {
-    w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, nativeWindowOpen: true } })
+    w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, nativeWindowOpen: true, nodeIntegrationInSubFrames: true } })
     await w.loadURL('about:blank')
   })
   after(async () => {


### PR DESCRIPTION
Backport of #23917

Notes: Fixed a crash that could occur when using the `ipcRenderer` module after blink had released the context. Instead, a JS exception will be thrown.
