### PR TITLE
ci: use call instead of cmd /C

### DIFF
--- a/script/setup-win-for-dev.bat
+++ b/script/setup-win-for-dev.bat
@@ -71,11 +71,11 @@ SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 
 REM Install nodejs python git and yarn needed dependencies
 choco install -y nodejs python2 git yarn windows-sdk-10-version-1903-windbg
-cmd /c C:\ProgramData\chocolatey\bin\RefreshEnv.cmd
+call C:\ProgramData\chocolatey\bin\RefreshEnv.cmd
 SET PATH=C:\Python27\;C:\Python27\Scripts;%PATH%
 
 pip install pywin32
-cmd /c C:\ProgramData\chocolatey\bin\RefreshEnv.cmd
+call C:\ProgramData\chocolatey\bin\RefreshEnv.cmd
 pip2 install pywin32
 
 REM Setup Depot Tools


### PR DESCRIPTION


#### Description of Change

Since we want to import the environment change from RefreshEnv.cmd
we also want to share the same execution context of the
caller.

Cc: @nornagon @ikkisoft @jkleinsc 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: no-notes
