### PR TITLE
fix: assign session to remote webContents

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -393,6 +393,9 @@ WebContents::WebContents(v8::Isolate* isolate,
     : content::WebContentsObserver(web_contents),
       type_(Type::REMOTE),
       weak_factory_(this) {
+  auto session = Session::CreateFrom(isolate, GetBrowserContext());
+  session_.Reset(isolate, session.ToV8());
+
   web_contents->SetUserAgentOverride(blink::UserAgentOverride::UserAgentOnly(
                                          GetBrowserContext()->GetUserAgent()),
                                      false);

--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -269,7 +269,7 @@ describe('chrome extensions', () => {
     });
   });
 
-  it('has webPreferences and session in background page', async () => {
+  it('has session in background page', async () => {
     const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
     await customSession.loadExtension(path.join(fixtures, 'extensions', 'persistent-background-page'));
     const w = new BrowserWindow({ show: false, webPreferences: { session: customSession } });

--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { session, BrowserWindow, ipcMain, WebContents, Extension } from 'electron/main';
+import { app, session, BrowserWindow, ipcMain, WebContents, Extension } from 'electron/main';
 import { closeAllWindows, closeWindow } from './window-helpers';
 import * as http from 'http';
 import { AddressInfo } from 'net';
@@ -267,6 +267,16 @@ describe('chrome extensions', () => {
       const receivedMessage = await w.webContents.executeJavaScript('window.completionPromise');
       expect(receivedMessage).to.deep.equal({ some: 'message' });
     });
+  });
+
+  it('has webPreferences and session in background page', async () => {
+    const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
+    await customSession.loadExtension(path.join(fixtures, 'extensions', 'persistent-background-page'));
+    const w = new BrowserWindow({ show: false, webPreferences: { session: customSession } });
+    const promise = emittedOnce(app, 'web-contents-created');
+    await w.loadURL(`about:blank`);
+    const [, bgPageContents] = await promise;
+    expect(bgPageContents.session).to.not.equal(undefined);
   });
 
   describe('devtools extensions', () => {

--- a/spec-main/fixtures/extensions/persistent-background-page/background.js
+++ b/spec-main/fixtures/extensions/persistent-background-page/background.js
@@ -1,0 +1,1 @@
+/* eslint-disable no-undef */

--- a/spec-main/fixtures/extensions/persistent-background-page/manifest.json
+++ b/spec-main/fixtures/extensions/persistent-background-page/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "persistent-background-page",
+  "version": "1.0",
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": true
+  },
+  "manifest_version": 2
+}


### PR DESCRIPTION
#### Description of Change
This PR ensures that remote webContents (such as devtools and extension background pages) get initialized with `session_` set.

Could this be backported to 9-x-y and 10-x-y, please?

Closes #23615
Ref #19447

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed no `session` in webContents of type remote.
