### PR TITLE
docs: fix explanation of darwin auto-quit prevention

### DIFF
--- a/docs/tutorial/first-app.md
+++ b/docs/tutorial/first-app.md
@@ -141,10 +141,10 @@ function createWindow () {
 // Some APIs can only be used after this event occurs.
 app.whenReady().then(createWindow)
 
-// Quit when all windows are closed.
+// Quit when all windows are closed, except on macOS. There, it's common
+// for applications and their menu bar to stay active until the user quits
+// explicitly with Cmd + Q.
 app.on('window-all-closed', () => {
-  // On macOS it is common for applications and their menu bar
-  // to stay active until the user quits explicitly with Cmd + Q
   if (process.platform !== 'darwin') {
     app.quit()
   }


### PR DESCRIPTION
#### Description of Change
I fixed the comment above the auto-quit prevention for macOS.
Before it suggested the code quits the app, now it says the code prevents the app from quitting.

#### Release Notes

Notes: none