### PR TITLE
fix: Add .paks for media-internals and webrtc-internals pages

### DIFF
--- a/electron_paks.gni
+++ b/electron_paks.gni
@@ -55,7 +55,9 @@ template("electron_extra_paks") {
     output = "${invoker.output_dir}/resources.pak"
     sources = [
       "$root_gen_dir/components/components_resources.pak",
+      "$root_gen_dir/content/browser/resources/media/media_internals_resources.pak",
       "$root_gen_dir/content/browser/tracing/tracing_resources.pak",
+      "$root_gen_dir/content/browser/webrtc/resources/webrtc_internals_resources.pak",
       "$root_gen_dir/content/content_resources.pak",
       "$root_gen_dir/content/dev_ui_content_resources.pak",
       "$root_gen_dir/mojo/public/js/mojo_bindings_resources.pak",
@@ -68,7 +70,9 @@ template("electron_extra_paks") {
       "//components/resources",
       "//content:content_resources",
       "//content:dev_ui_content_resources",
+      "//content/browser/resources/media:media_internals_resources",
       "//content/browser/tracing:resources",
+      "//content/browser/webrtc/resources",
       "//electron:resources",
       "//mojo/public/js:resources",
       "//net:net_resources",

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -1122,7 +1122,7 @@ describe('chromium features', () => {
           new Promise((resolve, reject) => {
             try {
               let req = window.indexedDB.open('${dbName}');
-              req.onsuccess = (event) => { 
+              req.onsuccess = (event) => {
                 let db = req.result;
                 resolve(db.name);
               }
@@ -1264,6 +1264,28 @@ describe('chromium features', () => {
         // Initial page + pushed state.
         expect((w.webContents as any).length()).to.equal(2);
       });
+    });
+  });
+
+  describe('chrome://media-internals', () => {
+    it('loads the page successfully', async () => {
+      const w = new BrowserWindow({ show: false });
+      w.loadURL('chrome://media-internals');
+      const pageExists = await w.webContents.executeJavaScript(
+        "window.hasOwnProperty('chrome') && window.chrome.hasOwnProperty('send')"
+      );
+      expect(pageExists).to.be.true();
+    });
+  });
+
+  describe('chrome://webrtc-internals', () => {
+    it('loads the page successfully', async () => {
+      const w = new BrowserWindow({ show: false });
+      w.loadURL('chrome://webrtc-internals');
+      const pageExists = await w.webContents.executeJavaScript(
+        "window.hasOwnProperty('chrome') && window.chrome.hasOwnProperty('send')"
+      );
+      expect(pageExists).to.be.true();
     });
   });
 });


### PR DESCRIPTION
#### Description of Change

Since `electron@8.0.0` the `chrome://media-internals` and `chrome://webrtc-internals` were inaccessible, because their resource packages (.pak files) were not included properly into electron's build configuration.

Related issue: #22120

#### Checklist

- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed `chrome://media-internals` and `chrome://webrtc-internals` pages not loading.