### PR TITLE
fix: Close protocol response streams when aborted

### DIFF
--- a/shell/browser/net/node_stream_loader.cc
+++ b/shell/browser/net/node_stream_loader.cc
@@ -42,6 +42,12 @@ NodeStreamLoader::~NodeStreamLoader() {
     node::MakeCallback(isolate_, emitter_.Get(isolate_), "removeListener",
                        node::arraysize(args), args, {0, 0});
   }
+
+  // Destroy the stream if not already ended
+  if (!ended_) {
+    node::MakeCallback(isolate_, emitter_.Get(isolate_), "destroy", 0, nullptr,
+                       {0, 0});
+  }
 }
 
 void NodeStreamLoader::Start(network::mojom::URLResponseHeadPtr head) {


### PR DESCRIPTION
#### Description of Change

We noticed that streams were not being closed if the response is aborted prematurely (eg due to a page navigation) which has the potential to create memory leaks. This PR ensures that the stream is destroyed in that scenario.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Protocol response streams are now destroyed if the request is aborted.