### PR TITLE
fix: add missing isComposing KeyboardEvent property

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -366,6 +366,7 @@ Returns:
   * `key` String - Equivalent to [KeyboardEvent.key][keyboardevent].
   * `code` String - Equivalent to [KeyboardEvent.code][keyboardevent].
   * `isAutoRepeat` Boolean - Equivalent to [KeyboardEvent.repeat][keyboardevent].
+  * `isComposing` Boolean - Equivalent to [KeyboardEvent.isComposing][keyboardevent].
   * `shift` Boolean - Equivalent to [KeyboardEvent.shiftKey][keyboardevent].
   * `control` Boolean - Equivalent to [KeyboardEvent.controlKey][keyboardevent].
   * `alt` Boolean - Equivalent to [KeyboardEvent.altKey][keyboardevent].

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -64,6 +64,7 @@ auto_filenames = {
     "docs/api/touch-bar.md",
     "docs/api/tray.md",
     "docs/api/web-contents.md",
+    "docs/api/web-contents.md.orig",
     "docs/api/web-frame.md",
     "docs/api/web-request.md",
     "docs/api/webview-tag.md",

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -64,7 +64,6 @@ auto_filenames = {
     "docs/api/touch-bar.md",
     "docs/api/tray.md",
     "docs/api/web-contents.md",
-    "docs/api/web-contents.md.orig",
     "docs/api/web-frame.md",
     "docs/api/web-request.md",
     "docs/api/webview-tag.md",

--- a/shell/common/native_mate_converters/blink_converter.cc
+++ b/shell/common/native_mate_converters/blink_converter.cc
@@ -245,6 +245,7 @@ v8::Local<v8::Value> Converter<content::NativeWebKeyboardEvent>::ToV8(
 
   using Modifiers = blink::WebInputEvent::Modifiers;
   dict.Set("isAutoRepeat", (in.GetModifiers() & Modifiers::kIsAutoRepeat) != 0);
+  dict.Set("isComposing", (in.GetModifiers() & Modifiers::kIsComposing) != 0);
   dict.Set("shift", (in.GetModifiers() & Modifiers::kShiftKey) != 0);
   dict.Set("control", (in.GetModifiers() & Modifiers::kControlKey) != 0);
   dict.Set("alt", (in.GetModifiers() & Modifiers::kAltKey) != 0);


### PR DESCRIPTION
#### Description of Change

Manually backport #23971 to 8-x-y. See that PR for details.

CC @electron/wg-releases @codebytere 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Add missing support for isComposing KeyboardEvent property.