### PR TITLE
test: extract RemoteControlApp to spec-helpers

### DIFF
--- a/spec-main/index.js
+++ b/spec-main/index.js
@@ -109,4 +109,8 @@ app.whenReady().then(async () => {
   chai.use(require('dirty-chai'));
 
   const runner = mocha.run(cb);
+  const { runCleanupFunctions } = require('./spec-helpers');
+  runner.on('test end', () => {
+    runCleanupFunctions();
+  });
 });

--- a/spec-main/spec-helpers.ts
+++ b/spec-main/spec-helpers.ts
@@ -2,3 +2,19 @@ export const ifit = (condition: boolean) => (condition ? it : it.skip);
 export const ifdescribe = (condition: boolean) => (condition ? describe : describe.skip);
 
 export const delay = (time: number) => new Promise(resolve => setTimeout(resolve, time));
+
+type CleanupFunction = (() => void) | (() => Promise<void>)
+const cleanupFunctions: CleanupFunction[] = [];
+export async function runCleanupFunctions () {
+  for (const cleanup of cleanupFunctions) {
+    const r = cleanup();
+    if (r instanceof Promise) { await r; }
+  }
+  cleanupFunctions.length = 0;
+}
+
+afterEach(runCleanupFunctions);
+
+export function defer (f: CleanupFunction) {
+  cleanupFunctions.push(f);
+}

--- a/spec-main/spec-helpers.ts
+++ b/spec-main/spec-helpers.ts
@@ -31,7 +31,7 @@ class RemoteControlApp {
     this.port = port;
   }
 
-  remoteEval (js: string): Promise<any> {
+  remoteEval = (js: string): Promise<any> => {
     return new Promise((resolve, reject) => {
       const req = http.request({
         host: '127.0.0.1',
@@ -53,7 +53,8 @@ class RemoteControlApp {
       req.end();
     });
   }
-  remotely (script: Function, ...args: any[]): Promise<any> {
+
+  remotely = (script: Function, ...args: any[]): Promise<any> => {
     return this.remoteEval(`(${script})(...${JSON.stringify(args)})`);
   }
 }

--- a/spec-main/spec-helpers.ts
+++ b/spec-main/spec-helpers.ts
@@ -1,3 +1,8 @@
+import * as childProcess from 'child_process';
+import * as path from 'path';
+import * as http from 'http';
+import * as v8 from 'v8';
+
 export const ifit = (condition: boolean) => (condition ? it : it.skip);
 export const ifdescribe = (condition: boolean) => (condition ? describe : describe.skip);
 
@@ -15,4 +20,58 @@ export async function runCleanupFunctions () {
 
 export function defer (f: CleanupFunction) {
   cleanupFunctions.push(f);
+}
+
+class RemoteControlApp {
+  process: childProcess.ChildProcess;
+  port: number;
+
+  constructor (proc: childProcess.ChildProcess, port: number) {
+    this.process = proc;
+    this.port = port;
+  }
+
+  remoteEval (js: string): Promise<any> {
+    return new Promise((resolve, reject) => {
+      const req = http.request({
+        host: '127.0.0.1',
+        port: this.port,
+        method: 'POST'
+      }, res => {
+        const chunks = [] as Buffer[];
+        res.on('data', chunk => { chunks.push(chunk); });
+        res.on('end', () => {
+          const ret = v8.deserialize(Buffer.concat(chunks));
+          if (Object.prototype.hasOwnProperty.call(ret, 'error')) {
+            reject(new Error(`remote error: ${ret.error}\n\nTriggered at:`));
+          } else {
+            resolve(ret.result);
+          }
+        });
+      });
+      req.write(js);
+      req.end();
+    });
+  }
+  remotely (script: Function, ...args: any[]): Promise<any> {
+    return this.remoteEval(`(${script})(...${JSON.stringify(args)})`);
+  }
+}
+
+export async function startRemoteControlApp () {
+  const appPath = path.join(__dirname, 'fixtures', 'apps', 'remote-control');
+  const appProcess = childProcess.spawn(process.execPath, [appPath]);
+  appProcess.stderr.on('data', d => {
+    process.stderr.write(d);
+  });
+  const port = await new Promise<number>(resolve => {
+    appProcess.stdout.on('data', d => {
+      const m = /Listening: (\d+)/.exec(d.toString());
+      if (m && m[1] != null) {
+        resolve(Number(m[1]));
+      }
+    });
+  });
+  defer(() => { appProcess.kill('SIGINT'); });
+  return new RemoteControlApp(appProcess, port);
 }

--- a/spec-main/spec-helpers.ts
+++ b/spec-main/spec-helpers.ts
@@ -13,8 +13,6 @@ export async function runCleanupFunctions () {
   cleanupFunctions.length = 0;
 }
 
-afterEach(runCleanupFunctions);
-
 export function defer (f: CleanupFunction) {
   cleanupFunctions.push(f);
 }


### PR DESCRIPTION
#### Description of Change

RemoteControlApp can in many circumstances replace a custom fixture apps when you need to test code which needs to run in a separate instance of Electron. Call `await startRemoteControlApp()` to boot up an app. That function returns an instance of `RemoteControlApp`, which has a method called `remoteEval` that lets you execute code in the child app and receive response data from the child. This behaves similarly to `webContents.executeJavaScript()`, except instead of running JS in a renderer process, it runs JS in the main process of a child app. The app will automatically be closed after the test is complete, thanks to `defer()`.

There’s also a convenience method, `remotely`, which takes a function instead of a string, and handles stringifying the function and serializing arguments.

Example usage:

```ts
import { startRemoteControlApp } from './spec-helpers';
it('crashes when calling process.crash()', async () => {
  const child = await startRemoteControlApp();

  // The serialization to/from the child uses Structured Clone.
  const dateFromChild = await child.remotely(() => new Date);
  expect(dateFromChild).to.be.an.instanceOf(Date);

  // Passing arguments using |remotely|. Note that the function is stringified
  // before being sent to the child process, so if it refers to variables in the
  // scope, they will be undefined when the function is executed in the child.
  const added = await child.remotely((a, b) => a + b, 1, 2);
  expect(added).to.equal(3);

  child.remotely(() => { process.crash(); });
  const code = await new Promise(resolve => {
    child.process.on('exit', (code) => resolve(code));
  });
  expect(code).to.equal(139);
});
```

Depends on https://github.com/electron/electron/pull/24019

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: none
