### PR TITLE
fix: nativeImage remote serialization

### DIFF
--- a/lib/browser/rpc-server.js
+++ b/lib/browser/rpc-server.js
@@ -8,6 +8,7 @@ const v8Util = process.electronBinding('v8_util');
 const eventBinding = process.electronBinding('event');
 const clipboard = process.electronBinding('clipboard');
 const features = process.electronBinding('features');
+const { NativeImage } = process.electronBinding('native_image');
 
 const { getContentScripts } = require('@electron/internal/browser/chrome-extension');
 const { crashReporterInit } = require('@electron/internal/browser/crash-reporter-init');
@@ -17,7 +18,7 @@ const objectsRegistry = require('@electron/internal/browser/objects-registry');
 const guestViewManager = require('@electron/internal/browser/guest-view-manager');
 const bufferUtils = require('@electron/internal/common/buffer-utils');
 const errorUtils = require('@electron/internal/common/error-utils');
-const typeUtils = require('@electron/internal/common/type-utils');
+const { deserialize, serialize } = require('@electron/internal/common/type-utils');
 const { isPromise } = require('@electron/internal/common/is-promise');
 
 const hasProp = {}.hasOwnProperty;
@@ -77,6 +78,8 @@ const valueToMeta = function (sender, contextId, value, optimizeSimpleObject = f
       meta.type = 'buffer';
     } else if (Array.isArray(value)) {
       meta.type = 'array';
+    } else if (value instanceof NativeImage) {
+      meta.type = 'nativeimage';
     } else if (value instanceof Error) {
       meta.type = 'error';
     } else if (value instanceof Date) {
@@ -95,6 +98,8 @@ const valueToMeta = function (sender, contextId, value, optimizeSimpleObject = f
   // Fill the meta object according to value's type.
   if (meta.type === 'array') {
     meta.members = value.map((el) => valueToMeta(sender, contextId, el, optimizeSimpleObject));
+  } else if (meta.type === 'nativeimage') {
+    meta.value = serialize(value);
   } else if (meta.type === 'object' || meta.type === 'function') {
     meta.name = value.constructor ? value.constructor.name : '';
 
@@ -181,6 +186,8 @@ const removeRemoteListenersAndLogWarning = (sender, callIntoRenderer) => {
 const unwrapArgs = function (sender, frameId, contextId, args) {
   const metaToValue = function (meta) {
     switch (meta.type) {
+      case 'nativeimage':
+        return deserialize(meta.value);
       case 'value':
         return meta.value;
       case 'remote-object':
@@ -496,7 +503,7 @@ ipcMainUtils.handle('ELECTRON_BROWSER_CLIPBOARD', function (event, method, ...ar
     throw new Error(`Invalid method: ${method}`);
   }
 
-  return typeUtils.serialize(electron.clipboard[method](...typeUtils.deserialize(args)));
+  return serialize(electron.clipboard[method](...deserialize(args)));
 });
 
 if (features.isDesktopCapturerEnabled()) {

--- a/lib/common/type-utils.ts
+++ b/lib/common/type-utils.ts
@@ -6,13 +6,54 @@ const objectMap = function (source: Object, mapper: (value: any) => any) {
   return Object.fromEntries(targetEntries);
 };
 
+function serializeNativeImage (image: any) {
+  const representations = [];
+  const scaleFactors = image.getScaleFactors();
+
+  // Use Buffer when there's only one representation for better perf.
+  // This avoids compressing to/from PNG where it's not necessary to
+  // ensure uniqueness of dataURLs (since there's only one).
+  if (scaleFactors.length === 1) {
+    const scaleFactor = scaleFactors[0];
+    const size = image.getSize(scaleFactor);
+    const buffer = image.toBitmap({ scaleFactor });
+    representations.push({ scaleFactor, size, buffer });
+  } else {
+    // Construct from dataURLs to ensure that they are not lost in creation.
+    for (const scaleFactor of scaleFactors) {
+      const size = image.getSize(scaleFactor);
+      const dataURL = image.toDataURL({ scaleFactor });
+      representations.push({ scaleFactor, size, dataURL });
+    }
+  }
+  return { __ELECTRON_SERIALIZED_NativeImage__: true, representations };
+}
+
+function deserializeNativeImage (value: any) {
+  const image = nativeImage.createEmpty();
+
+  // Use Buffer when there's only one representation for better perf.
+  // This avoids compressing to/from PNG where it's not necessary to
+  // ensure uniqueness of dataURLs (since there's only one).
+  if (value.representations.length === 1) {
+    const { buffer, size, scaleFactor } = value.representations[0];
+    const { width, height } = size;
+    image.addRepresentation({ buffer, scaleFactor, width, height });
+  } else {
+    // Construct from dataURLs to ensure that they are not lost in creation.
+    for (const rep of value.representations) {
+      const { dataURL, size, scaleFactor } = rep;
+      const { width, height } = size;
+      image.addRepresentation({ dataURL, scaleFactor, width, height });
+    }
+  }
+
+  return image;
+}
+
 export function serialize (value: any): any {
   if (value instanceof NativeImage) {
-    return {
-      buffer: value.toBitmap(),
-      size: value.getSize(),
-      __ELECTRON_SERIALIZED_NativeImage__: true
-    };
+    return serializeNativeImage(value);
   } else if (Array.isArray(value)) {
     return value.map(serialize);
   } else if (value instanceof Buffer) {
@@ -26,7 +67,7 @@ export function serialize (value: any): any {
 
 export function deserialize (value: any): any {
   if (value && value.__ELECTRON_SERIALIZED_NativeImage__) {
-    return nativeImage.createFromBitmap(value.buffer, value.size);
+    return deserializeNativeImage(value);
   } else if (Array.isArray(value)) {
     return value.map(deserialize);
   } else if (value instanceof Buffer) {

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -1,10 +1,12 @@
 'use strict';
 
 const v8Util = process.electronBinding('v8_util');
+const { NativeImage } = process.electronBinding('native_image');
 
 const { CallbacksRegistry } = require('@electron/internal/renderer/callbacks-registry');
 const bufferUtils = require('@electron/internal/common/buffer-utils');
 const errorUtils = require('@electron/internal/common/error-utils');
+const { deserialize, serialize } = require('@electron/internal/common/type-utils');
 const { isPromise } = require('@electron/internal/common/is-promise');
 const { ipcRendererInternal } = require('@electron/internal/renderer/ipc-renderer-internal');
 
@@ -34,7 +36,9 @@ function wrapArgs (args, visited = new Set()) {
       };
     }
 
-    if (Array.isArray(value)) {
+    if (value instanceof NativeImage) {
+      return { type: 'nativeimage', value: serialize(value) };
+    } else if (Array.isArray(value)) {
       visited.add(value);
       const meta = {
         type: 'array',
@@ -214,6 +218,7 @@ function metaToValue (meta) {
   const types = {
     value: () => meta.value,
     array: () => meta.members.map((member) => metaToValue(member)),
+    nativeimage: () => deserialize(meta.value),
     buffer: () => bufferUtils.metaToBuffer(meta.value),
     promise: () => Promise.resolve({ then: metaToValue(meta.then) }),
     error: () => metaToPlainObject(meta),

--- a/native_mate/native_mate/function_template.h
+++ b/native_mate/native_mate/function_template.h
@@ -9,6 +9,7 @@
 
 #include "base/callback.h"
 #include "base/logging.h"
+#include "base/optional.h"
 #include "native_mate/arguments.h"
 #include "native_mate/wrappable_base.h"
 #include "v8/include/v8.h"
@@ -102,6 +103,18 @@ bool GetNextArgument(Arguments* args,
   } else {
     return args->GetNext(result);
   }
+}
+
+// Support base::Optional as an argument.
+template <typename T>
+bool GetNextArgument(Arguments* args,
+                     int create_flags,
+                     bool is_first,
+                     base::Optional<T>* result) {
+  T converted;
+  if (args->GetNext(&converted))
+    result->emplace(std::move(converted));
+  return true;
 }
 
 // For advanced use cases, we allow callers to request the unparsed Arguments

--- a/shell/common/api/atom_api_native_image.h
+++ b/shell/common/api/atom_api_native_image.h
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 #include "base/values.h"
 #include "native_mate/dictionary.h"
@@ -84,16 +85,17 @@ class NativeImage : public mate::Wrappable<NativeImage> {
   v8::Local<v8::Value> ToPNG(mate::Arguments* args);
   v8::Local<v8::Value> ToJPEG(v8::Isolate* isolate, int quality);
   v8::Local<v8::Value> ToBitmap(mate::Arguments* args);
+  std::vector<float> GetScaleFactors();
   v8::Local<v8::Value> GetBitmap(mate::Arguments* args);
   v8::Local<v8::Value> GetNativeHandle(v8::Isolate* isolate,
                                        mate::Arguments* args);
-  mate::Handle<NativeImage> Resize(v8::Isolate* isolate,
+  mate::Handle<NativeImage> Resize(mate::Arguments* args,
                                    const base::DictionaryValue& options);
   mate::Handle<NativeImage> Crop(v8::Isolate* isolate, const gfx::Rect& rect);
   std::string ToDataURL(mate::Arguments* args);
   bool IsEmpty();
-  gfx::Size GetSize();
-  float GetAspectRatio();
+  gfx::Size GetSize(const base::Optional<float> scale_factor);
+  float GetAspectRatio(const base::Optional<float> scale_factor);
   void AddRepresentation(const mate::Dictionary& options);
 
   // Mark the image as template image.

--- a/spec-main/api-remote-spec.ts
+++ b/spec-main/api-remote-spec.ts
@@ -2,7 +2,8 @@ import * as path from 'path'
 import { expect } from 'chai'
 import { closeWindow } from './window-helpers'
 
-import { ipcMain, BrowserWindow } from 'electron'
+import { ipcMain, BrowserWindow, nativeImage } from 'electron'
+import { serialize, deserialize } from '../lib/common/type-utils';
 
 describe('remote module', () => {
   const fixtures = path.join(__dirname, 'fixtures')
@@ -32,6 +33,119 @@ describe('remote module', () => {
     }
     return result
   }
+
+  describe('typeUtils serialization/deserialization', () => {
+    it('serializes and deserializes an empty NativeImage', () => {
+      const image = nativeImage.createEmpty();
+      const serializedImage = serialize(image);
+      const empty = deserialize(serializedImage);
+
+      expect(empty.isEmpty()).to.be.true();
+      expect(empty.getAspectRatio()).to.equal(1);
+      expect(empty.toDataURL()).to.equal('data:image/png;base64,');
+      expect(empty.toDataURL({ scaleFactor: 2.0 })).to.equal('data:image/png;base64,');
+      expect(empty.getSize()).to.deep.equal({ width: 0, height: 0 });
+      expect(empty.getBitmap()).to.be.empty();
+      expect(empty.getBitmap({ scaleFactor: 2.0 })).to.be.empty();
+      expect(empty.toBitmap()).to.be.empty();
+      expect(empty.toBitmap({ scaleFactor: 2.0 })).to.be.empty();
+      expect(empty.toJPEG(100)).to.be.empty();
+      expect(empty.toPNG()).to.be.empty();
+      expect(empty.toPNG({ scaleFactor: 2.0 })).to.be.empty();
+    });
+
+    it('serializes and deserializes a non-empty NativeImage', () => {
+      const dataURL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAFklEQVQYlWP8//8/AwMDEwMDAwMDAwAkBgMBBMzldwAAAABJRU5ErkJggg==';
+      const image = nativeImage.createFromDataURL(dataURL);
+      const serializedImage = serialize(image);
+      const nonEmpty = deserialize(serializedImage);
+
+      expect(nonEmpty.isEmpty()).to.be.false();
+      expect(nonEmpty.getAspectRatio()).to.equal(1);
+      expect(nonEmpty.toDataURL()).to.not.be.empty();
+      expect(nonEmpty.toDataURL({ scaleFactor: 1.0 })).to.equal(dataURL);
+      expect(nonEmpty.getSize()).to.deep.equal({ width: 2, height: 2 });
+      expect(nonEmpty.getBitmap()).to.not.be.empty();
+      expect(nonEmpty.toPNG()).to.not.be.empty();
+    });
+
+    it('serializes and deserializes a non-empty NativeImage with multiple representations', () => {
+      const image = nativeImage.createEmpty();
+
+      const dataURL1 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQYlWNgAAIAAAUAAdafFs0AAAAASUVORK5CYII=';
+      image.addRepresentation({ scaleFactor: 1.0, dataURL: dataURL1 });
+
+      const dataURL2 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAFklEQVQYlWP8//8/AwMDEwMDAwMDAwAkBgMBBMzldwAAAABJRU5ErkJggg==';
+      image.addRepresentation({ scaleFactor: 2.0, dataURL: dataURL2 });
+
+      const serializedImage = serialize(image);
+      const nonEmpty = deserialize(serializedImage);
+
+      expect(nonEmpty.isEmpty()).to.be.false();
+      expect(nonEmpty.getAspectRatio()).to.equal(1);
+      expect(nonEmpty.getSize()).to.deep.equal({ width: 1, height: 1 });
+      expect(nonEmpty.getBitmap()).to.not.be.empty();
+      expect(nonEmpty.getBitmap({ scaleFactor: 1.0 })).to.not.be.empty();
+      expect(nonEmpty.getBitmap({ scaleFactor: 2.0 })).to.not.be.empty();
+      expect(nonEmpty.toBitmap()).to.not.be.empty();
+      expect(nonEmpty.toBitmap({ scaleFactor: 1.0 })).to.not.be.empty();
+      expect(nonEmpty.toBitmap({ scaleFactor: 2.0 })).to.not.be.empty();
+      expect(nonEmpty.toPNG()).to.not.be.empty();
+      expect(nonEmpty.toPNG({ scaleFactor: 1.0 })).to.not.be.empty();
+      expect(nonEmpty.toPNG({ scaleFactor: 2.0 })).to.not.be.empty();
+      expect(nonEmpty.toDataURL()).to.not.be.empty();
+      expect(nonEmpty.toDataURL({ scaleFactor: 1.0 })).to.equal(dataURL1);
+      expect(nonEmpty.toDataURL({ scaleFactor: 2.0 })).to.equal(dataURL2);
+    });
+
+    it('serializes and deserializes an Array', () => {
+      const array = [1, 2, 3, 4, 5];
+      const serialized = serialize(array);
+      const deserialized = deserialize(serialized);
+
+      expect(deserialized).to.deep.equal(array);
+    });
+
+    it('serializes and deserializes a Buffer', () => {
+      const buffer = Buffer.from('hello world!', 'utf-8');
+      const serialized = serialize(buffer);
+      const deserialized = deserialize(serialized);
+
+      expect(deserialized).to.deep.equal(buffer);
+    });
+
+    it('serializes and deserializes a Boolean', () => {
+      const bool = true;
+      const serialized = serialize(bool);
+      const deserialized = deserialize(serialized);
+
+      expect(deserialized).to.equal(bool);
+    });
+
+    it('serializes and deserializes a Number', () => {
+      const number = 42;
+      const serialized = serialize(number);
+      const deserialized = deserialize(serialized);
+
+      expect(deserialized).to.equal(number);
+    });
+
+    it('serializes and deserializes a String', () => {
+      const str = 'hello world';
+      const serialized = serialize(str);
+      const deserialized = deserialize(serialized);
+
+      expect(deserialized).to.equal(str);
+    });
+
+    it('serializes and deserializes a simple Object', () => {
+      const obj = { hello: 'world', 'answer-to-everything': 42 };
+      const serialized = serialize(obj);
+      const deserialized = deserialize(serialized);
+
+      expect(deserialized).to.deep.equal(obj);
+    });
+  });
 
   describe('remote.getGlobal filtering', () => {
     it('can return custom values', async () => {

--- a/spec-main/package.json
+++ b/spec-main/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "version": "0.1.0",
   "devDependencies": {
+    "@types/dirty-chai": "^2.0.0",
     "@types/ws": "^7.2.0",
     "ws": "^7.2.1"
   }

--- a/spec-main/yarn.lock
+++ b/spec-main/yarn.lock
@@ -2,6 +2,26 @@
 # yarn lockfile v1
 
 
+"@types/chai-as-promised@*":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.2.tgz#2f564420e81eaf8650169e5a3a6b93e096e5068b"
+  integrity sha512-PO2gcfR3Oxa+u0QvECLe1xKXOqYTzCmWf0FhLhjREoW3fPAVamjihL7v1MOVLJLsnAMdLcjkfrs01yvDMwVK4Q==
+  dependencies:
+    "@types/chai" "*"
+
+"@types/chai@*":
+  version "4.2.11"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.11.tgz#d3614d6c5f500142358e6ed24e1bf16657536c50"
+  integrity sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==
+
+"@types/dirty-chai@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/dirty-chai/-/dirty-chai-2.0.2.tgz#eeac4802329a41ed7815ac0c1a6360335bf77d0c"
+  integrity sha512-BruwIN/UQEU0ePghxEX+OyjngpOfOUKJQh3cmfeq2h2Su/g001iljVi3+Y2y2EFp3IPgjf4sMrRU33Hxv1FUqw==
+  dependencies:
+    "@types/chai" "*"
+    "@types/chai-as-promised" "*"
+
 "@types/node@*":
   version "13.7.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.0.tgz#b417deda18cf8400f278733499ad5547ed1abec4"


### PR DESCRIPTION
#### Description of Change

Manually backport #23543 to 7-3-x.
Manually backport #23666 to 7-3-x.
Manually backport #23693 to 7-3-x.
Manually backport #23759 to 7-3-x.

See those PRs for more details.

This PR is mostly a backport of #23797 with the following changes for compatibility to 7-3-x:
 * add dirty-chai devdep to spec-main
 * remove serialization tests for RegExp, Date, and Error because 7-3-x predates the [SCA refactor](https://github.com/electron/electron/pull/20214)

CC @codebytere @electron/wg-releases 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Ensured proper nativeImage serialization between renderer and browser processes via remote.
