### PR TITLE
fix: correctly handle nexttick scheduling in stream reads

### DIFF
--- a/shell/browser/net/node_stream_loader.h
+++ b/shell/browser/net/node_stream_loader.h
@@ -87,6 +87,11 @@ class NodeStreamLoader : public network::mojom::URLLoader {
   // flag.
   bool readable_ = false;
 
+  // It's possible for reads to be queued using nextTick() during read()
+  // which will cause 'readable' to emit during ReadMore, so we track if
+  // that occurred in a flag.
+  bool has_read_waiting_ = false;
+
   // Store the V8 callbacks to unsubscribe them later.
   std::map<std::string, v8::Global<v8::Value>> handlers_;
 

--- a/spec-main/api-protocol-spec.ts
+++ b/spec-main/api-protocol-spec.ts
@@ -7,6 +7,7 @@ import * as http from 'http';
 import * as fs from 'fs';
 import * as qs from 'querystring';
 import * as stream from 'stream';
+import { EventEmitter } from 'events';
 import { closeWindow } from './window-helpers';
 import { emittedOnce } from './events-helpers';
 
@@ -408,6 +409,36 @@ describe('protocol module', () => {
       });
       const r = await ajax(protocolName + '://fake-host');
       expect(r.data).to.have.lengthOf(1024 * 1024 * 2);
+    });
+
+    it('can handle next-tick scheduling during read calls', async () => {
+      const events = new EventEmitter();
+      function createStream () {
+        const buffers = [
+          Buffer.alloc(65536),
+          Buffer.alloc(65537),
+          Buffer.alloc(39156)
+        ];
+        const e = new stream.Readable({ highWaterMark: 0 });
+        e.push(buffers.shift());
+        e._read = function () {
+          process.nextTick(() => this.push(buffers.shift() || null));
+        };
+        e.on('end', function () {
+          events.emit('end');
+        });
+        return e;
+      }
+      registerStreamProtocol(protocolName, (request, callback) => {
+        callback({
+          statusCode: 200,
+          headers: { 'Content-Type': 'text/plain' },
+          data: createStream()
+        });
+      });
+      const hasEndedPromise = emittedOnce(events, 'end');
+      ajax(protocolName + '://fake-host');
+      await hasEndedPromise;
     });
   });
 


### PR DESCRIPTION
#### Description of Change

We discovered some cases where protocol streaming responses would stall before completing. We isolated the issue to the case where a stream's read handler scheduled a `push()` using `nextTick()`, which (according to @mafintosh, who I trust to know about this sort of thing) will get scheduled to run prior to control being returned to C++. This means the call into js' `read()` will return nothing, but the `'readable'` event will get missed.

We were able to fix this by flagging when that occurs and automatically retrying the read.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [ ] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fix an issue which would cause streaming protocol responses to stall in some cases
