### PR TITLE
fix: bounds-check the IPC result before accessing.

### DIFF
--- a/lib/renderer/api/ipc-renderer.js
+++ b/lib/renderer/api/ipc-renderer.js
@@ -14,7 +14,7 @@ if (!ipcRenderer.send) {
 
   ipcRenderer.sendSync = function (channel, ...args) {
     const result = ipc.sendSync(internal, channel, args);
-    if (!Array.isArray(result)) {
+    if (!Array.isArray(result) || result.length !== 1) {
       throw new Error(`Unexpected return value from ipcRenderer.sendSync: ${result}`);
     }
     return result[0];

--- a/lib/renderer/api/ipc-renderer.js
+++ b/lib/renderer/api/ipc-renderer.js
@@ -13,7 +13,11 @@ if (!ipcRenderer.send) {
   };
 
   ipcRenderer.sendSync = function (channel, ...args) {
-    return ipc.sendSync(internal, channel, args)[0];
+    const result = ipc.sendSync(internal, channel, args);
+    if (!Array.isArray(result)) {
+      throw new Error(`Unexpected return value from ipcRenderer.sendSync: ${result}`);
+    }
+    return result[0];
   };
 
   ipcRenderer.sendToHost = function (channel, ...args) {

--- a/shell/renderer/api/atom_api_renderer_ipc.cc
+++ b/shell/renderer/api/atom_api_renderer_ipc.cc
@@ -102,6 +102,10 @@ class IPCRenderer : public mate::Wrappable<IPCRenderer> {
 
     electron_browser_ptr_->MessageSync(internal, channel, std::move(arguments),
                                        &result);
+
+    if (!result.is_list() || result.GetList().empty())
+      return base::Value{};
+
     return std::move(result.GetList().at(0));
   }
 


### PR DESCRIPTION
#### Description of Change

Closes #23849.

In  `atom_api_renderer_ipc.cc`'s `SendSync()` method, we access the response's list elements before checking the length of the list. This PR addresses that by bounds-checking and returning an empty base::Value if the list is empty.

Note, this only addresses the immediate crash happening on IPC SendSync failure. As described [in-ticket](https://github.com/electron/electron/issues/23849#issuecomment-636308118), the root cause is in Electron 7's IPC, which was refactored in 8 / 9 and the long-term solution is to upgrade to a newer version of Electron.

CC @miniak @alexeykuzmin @MarshallOfSound 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [ ] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed crash when handling synchronous IPC errors.