### PR TITLE
refactor: remove renderer-side refcount in remote

### DIFF
--- a/lib/browser/remote/objects-registry.ts
+++ b/lib/browser/remote/objects-registry.ts
@@ -51,14 +51,6 @@ class ObjectsRegistry {
   // Dereference an object according to its ID.
   // Note that an object may be double-freed (cleared when page is reloaded, and
   // then garbage collected in old page).
-  // rendererSideRefCount is the ref count that the renderer process reported
-  // at time of GC if this is different to the number of references we sent to
-  // the given owner then a GC occurred between a ref being sent and the value
-  // being pulled out of the weak map.
-  // In this case we decrement out ref count and do not delete the stored
-  // object
-  // For more details on why we do renderer side ref counting see
-  // https://github.com/electron/electron/pull/17464
   remove (webContents: WebContents, contextId: string, id: number) {
     const ownerKey = getOwnerKey(webContents, contextId);
     const owner = this.owners[ownerKey];

--- a/lib/browser/remote/objects-registry.ts
+++ b/lib/browser/remote/objects-registry.ts
@@ -59,11 +59,11 @@ class ObjectsRegistry {
   // object
   // For more details on why we do renderer side ref counting see
   // https://github.com/electron/electron/pull/17464
-  remove (webContents: WebContents, contextId: string, id: number, rendererSideRefCount: number) {
+  remove (webContents: WebContents, contextId: string, id: number) {
     const ownerKey = getOwnerKey(webContents, contextId);
     const owner = this.owners[ownerKey];
     if (owner && owner.has(id)) {
-      const newRefCount = owner.get(id)! - rendererSideRefCount;
+      const newRefCount = owner.get(id)! - 1;
 
       // Only completely remove if the number of references GCed in the
       // renderer is the same as the number of references we sent them

--- a/lib/browser/remote/server.ts
+++ b/lib/browser/remote/server.ts
@@ -557,8 +557,8 @@ handleRemoteCommand('ELECTRON_BROWSER_MEMBER_GET', function (event, contextId, i
   return valueToMeta(event.sender, contextId, obj[name]);
 });
 
-handleRemoteCommand('ELECTRON_BROWSER_DEREFERENCE', function (event, contextId, id, rendererSideRefCount) {
-  objectsRegistry.remove(event.sender, contextId, id, rendererSideRefCount);
+handleRemoteCommand('ELECTRON_BROWSER_DEREFERENCE', function (event, contextId, id) {
+  objectsRegistry.remove(event.sender, contextId, id);
 });
 
 handleRemoteCommand('ELECTRON_BROWSER_CONTEXT_RELEASE', (event, contextId) => {

--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -231,7 +231,6 @@ function metaToValue (meta) {
   } else {
     let ret;
     if (remoteObjectCache.has(meta.id)) {
-      v8Util.addRemoteObjectRef(contextId, meta.id);
       return remoteObjectCache.get(meta.id);
     }
 
@@ -261,7 +260,6 @@ function metaToValue (meta) {
     // Track delegate obj's lifetime & tell browser to clean up when object is GCed.
     v8Util.setRemoteObjectFreer(ret, contextId, meta.id);
     v8Util.setHiddenValue(ret, 'electronId', meta.id);
-    v8Util.addRemoteObjectRef(contextId, meta.id);
     remoteObjectCache.set(meta.id, ret);
     return ret;
   }

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1225,12 +1225,10 @@ void WebContents::MessageHost(const std::string& channel,
 
 #if BUILDFLAG(ENABLE_REMOTE_MODULE)
 void WebContents::DereferenceRemoteJSObject(const std::string& context_id,
-                                            int object_id,
-                                            int ref_count) {
+                                            int object_id) {
   base::ListValue args;
   args.Append(context_id);
   args.Append(object_id);
-  args.Append(ref_count);
   EmitWithSender("-ipc-message", bindings_.dispatch_context(), InvokeCallback(),
                  /* internal */ true, "ELECTRON_BROWSER_DEREFERENCE",
                  std::move(args));

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -599,8 +599,7 @@ class WebContents : public gin_helper::TrackableObject<WebContents>,
                    blink::CloneableMessage arguments) override;
 #if BUILDFLAG(ENABLE_REMOTE_MODULE)
   void DereferenceRemoteJSObject(const std::string& context_id,
-                                 int object_id,
-                                 int ref_count) override;
+                                 int object_id) override;
 #endif
   void UpdateDraggableRegions(
       std::vector<mojom::DraggableRegionPtr> regions) override;

--- a/shell/common/api/api.mojom
+++ b/shell/common/api/api.mojom
@@ -84,8 +84,7 @@ interface ElectronBrowser {
   [EnableIf=enable_remote_module]
   DereferenceRemoteJSObject(
     string context_id,
-    int32 object_id,
-    int32 ref_count);
+    int32 object_id);
 
   UpdateDraggableRegions(
     array<DraggableRegion> regions);

--- a/shell/common/api/electron_api_v8_util.cc
+++ b/shell/common/api/electron_api_v8_util.cc
@@ -149,7 +149,6 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("setRemoteCallbackFreer",
                  &electron::RemoteCallbackFreer::BindTo);
   dict.SetMethod("setRemoteObjectFreer", &electron::RemoteObjectFreer::BindTo);
-  dict.SetMethod("addRemoteObjectRef", &electron::RemoteObjectFreer::AddRef);
   dict.SetMethod(
       "createDoubleIDWeakMap",
       &electron::api::KeyWeakMap<std::pair<std::string, int32_t>>::Create);

--- a/shell/common/api/remote/remote_object_freer.h
+++ b/shell/common/api/remote/remote_object_freer.h
@@ -18,7 +18,6 @@ class RemoteObjectFreer : public ObjectLifeMonitor {
                      v8::Local<v8::Object> target,
                      const std::string& context_id,
                      int object_id);
-  static void AddRef(const std::string& context_id, int object_id);
 
  protected:
   RemoteObjectFreer(v8::Isolate* isolate,
@@ -28,9 +27,6 @@ class RemoteObjectFreer : public ObjectLifeMonitor {
   ~RemoteObjectFreer() override;
 
   void RunDestructor() override;
-
-  // { context_id => { object_id => ref_count }}
-  static std::map<std::string, std::map<int, int>> ref_mapper_;
 
  private:
   std::string context_id_;


### PR DESCRIPTION
#### Description of Change
The refcount on the renderer side is always 1.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: none