### PR TITLE
fix: allow IME insert zero length composition string

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -124,3 +124,4 @@ cherry-pick-86c02c5dcd37.patch
 fix_hunspell_crash.patch
 introduce_a_mutex_for_the_rendering_loop_in_baseaudiocontext.patch
 fix_default_to_ntlm_v2_in_network_service.patch
+fix_allow_ime_to_insert_zero-length_composition_string.patch

--- a/patches/chromium/fix_allow_ime_to_insert_zero-length_composition_string.patch
+++ b/patches/chromium/fix_allow_ime_to_insert_zero-length_composition_string.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Peng Lyu <penn.lv@gmail.com>
+Date: Tue, 9 Jun 2020 21:49:37 -0700
+Subject: Fix: allow IME to insert zero-length composition string
+
+Backport: https://chromium.googlesource.com/chromium/src.git/+/c20afc96e36f572d10c65d97f4313ba50a58280f%5E%21/#F0
+
+diff --git a/ui/base/ime/win/tsf_text_store.cc b/ui/base/ime/win/tsf_text_store.cc
+index 069a7caf54f4bd9027d8c473eec9315e6f14d8ff..73188e73bd5fd0f162a9b23b045b8927d6536ad4 100644
+--- a/ui/base/ime/win/tsf_text_store.cc
++++ b/ui/base/ime/win/tsf_text_store.cc
+@@ -610,9 +610,7 @@ STDMETHODIMP TSFTextStore::RequestLock(DWORD lock_flags, HRESULT* result) {
+   // 3. User commits current composition text.
+   if (((new_composition_start > last_composition_start &&
+         text_input_client_->HasCompositionText()) ||
+-       (wparam_keydown_fired_ == 0 && !has_composition_range_ &&
+-        !text_input_client_->HasCompositionText()) ||
+-       (wparam_keydown_fired_ != 0 && !has_composition_range_)) &&
++      !has_composition_range_) &&
+       text_input_client_) {
+     CommitTextAndEndCompositionIfAny(last_composition_start,
+                                      new_composition_start);
+@@ -1295,8 +1293,11 @@ void TSFTextStore::CommitTextAndEndCompositionIfAny(size_t old_size,
+             : new_committed_string_size);
+     // TODO(crbug.com/978678): Unify the behavior of
+     //     |TextInputClient::InsertText(text)| for the empty text.
+-    if (!new_committed_string.empty())
++    if (!new_committed_string.empty()) {
+       text_input_client_->InsertText(new_committed_string);
++    } else {
++      text_input_client_->ClearCompositionText();
++    }
+     // Notify accessibility about this committed composition
+     text_input_client_->SetActiveCompositionForAccessibility(
+         replace_text_range_, new_committed_string,


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Bug:
* Multiple IMEs no longer terminate after pressing shift https://bugs.chromium.org/p/chromium/issues/detail?id=1091069#c9
* Issue in VS Code https://github.com/microsoft/vscode/issues/98968

Expected behavior:
* IME quits composition mode after pressing shift

cc @deepak1556 


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix issue with some IMEs on windows (for ex: Zhuyin) don't terminate after pressing shift