### PR TITLE
fix: fs.readdir/readdirSync should support withFileTypes

### DIFF
--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -572,7 +572,7 @@
     };
 
     const { readdir } = fs;
-    fs.readdir = function (pathArgument, options, callback) {
+    fs.readdir = function (pathArgument, options = {}, callback) {
       const { isAsar, asarPath, filePath } = splitPath(pathArgument);
       if (typeof options === 'function') {
         callback = options;
@@ -594,13 +594,29 @@
         return;
       }
 
+      if (options.withFileTypes) {
+        const dirents = [];
+        for (const file of files) {
+          const stats = archive.stat(file);
+          if (stats.isFile) {
+            dirents.push(new fs.Dirent(file, fs.constants.UV_DIRENT_FILE));
+          } else if (stats.isDirectory) {
+            dirents.push(new fs.Dirent(file, fs.constants.UV_DIRENT_DIR));
+          } else if (stats.isLink) {
+            dirents.push(new fs.Dirent(file, fs.constants.UV_DIRENT_LINK));
+          }
+        }
+        nextTick(callback, [null, dirents]);
+        return;
+      }
+
       nextTick(callback, [null, files]);
     };
 
     fs.promises.readdir = util.promisify(fs.readdir);
 
     const { readdirSync } = fs;
-    fs.readdirSync = function (pathArgument, options) {
+    fs.readdirSync = function (pathArgument, options = {}) {
       const { isAsar, asarPath, filePath } = splitPath(pathArgument);
       if (!isAsar) return readdirSync.apply(this, arguments);
 
@@ -612,6 +628,21 @@
       const files = archive.readdir(filePath);
       if (!files) {
         throw createError(AsarError.NOT_FOUND, { asarPath, filePath });
+      }
+
+      if (options.withFileTypes) {
+        const dirents = [];
+        for (const file of files) {
+          const stats = archive.stat(file);
+          if (stats.isFile) {
+            dirents.push(new fs.Dirent(file, fs.constants.UV_DIRENT_FILE));
+          } else if (stats.isDirectory) {
+            dirents.push(new fs.Dirent(file, fs.constants.UV_DIRENT_DIR));
+          } else if (stats.isLink) {
+            dirents.push(new fs.Dirent(file, fs.constants.UV_DIRENT_LINK));
+          }
+        }
+        return dirents;
       }
 
       return files;

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -792,6 +792,16 @@ describe('asar package', function () {
         expect(dirs).to.deep.equal(['file1', 'file2', 'file3', 'link1', 'link2']);
       });
 
+      it('supports withFileTypes', function () {
+        const p = path.join(asarDir, 'a.asar');
+        const dirs = fs.readdirSync(p, { withFileTypes: true });
+        for (const dir of dirs) {
+          expect(dir instanceof fs.Dirent).to.be.true();
+        }
+        const names = dirs.map(a => a.name);
+        expect(names).to.deep.equal(['dir1', 'dir2', 'dir3', 'file1', 'file2', 'file3', 'link1', 'link2', 'ping.js']);
+      });
+
       it('reads dirs from a linked dir', function () {
         const p = path.join(asarDir, 'a.asar', 'link2', 'link2');
         const dirs = fs.readdirSync(p);
@@ -816,6 +826,21 @@ describe('asar package', function () {
         });
       });
 
+      it('supports withFileTypes', function (done) {
+        const p = path.join(asarDir, 'a.asar');
+
+        fs.readdir(p, { withFileTypes: true }, (err, dirs) => {
+          expect(err).to.be.null();
+          for (const dir of dirs) {
+            expect(dir instanceof fs.Dirent).to.be.true();
+          }
+
+          const names = dirs.map(a => a.name);
+          expect(names).to.deep.equal(['dir1', 'dir2', 'dir3', 'file1', 'file2', 'file3', 'link1', 'link2', 'ping.js']);
+          done();
+        });
+      });
+
       it('reads dirs from a normal dir', function (done) {
         const p = path.join(asarDir, 'a.asar', 'dir1');
         fs.readdir(p, function (err, dirs) {
@@ -824,6 +849,7 @@ describe('asar package', function () {
           done();
         });
       });
+
       it('reads dirs from a linked dir', function (done) {
         const p = path.join(asarDir, 'a.asar', 'link2', 'link2');
         fs.readdir(p, function (err, dirs) {
@@ -847,6 +873,16 @@ describe('asar package', function () {
         const p = path.join(asarDir, 'a.asar');
         const dirs = await fs.promises.readdir(p);
         expect(dirs).to.deep.equal(['dir1', 'dir2', 'dir3', 'file1', 'file2', 'file3', 'link1', 'link2', 'ping.js']);
+      });
+
+      it('supports withFileTypes', async function () {
+        const p = path.join(asarDir, 'a.asar');
+        const dirs = await fs.promises.readdir(p, { withFileTypes: true });
+        for (const dir of dirs) {
+          expect(dir instanceof fs.Dirent).to.be.true();
+        }
+        const names = dirs.map(a => a.name);
+        expect(names).to.deep.equal(['dir1', 'dir2', 'dir3', 'file1', 'file2', 'file3', 'link1', 'link2', 'ping.js']);
       });
 
       it('reads dirs from a normal dir', async function () {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/19074.

Fixes an inconsistency between the Node.js implementations of `fs.readdir` and `fs.readdirSync` where we did not support `withFileTypes` under asar. When `{ withFileTypes: true }` is passed as an option to either of the above methods, the methods should return `fs.Dirent[]`.

This fixes the issue by using existing data we already have through `archive.stat` to appropriately return `fs.Dirent[]` when this option is passed.

cc @zcbenz @jkleinsc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixes an issue where `withFileTypes` was not supported as an option to `fs.readdir` or `fs.readdirSync` under asar.
