### PR TITLE
fix: add .paks for media-internals and webrtc-internals pages

### DIFF
--- a/electron_paks.gni
+++ b/electron_paks.gni
@@ -54,7 +54,9 @@ template("electron_extra_paks") {
     output = "${invoker.output_dir}/resources.pak"
     sources = [
       "$root_gen_dir/components/components_resources.pak",
+      "$root_gen_dir/content/browser/resources/media/media_internals_resources.pak",
       "$root_gen_dir/content/browser/tracing/tracing_resources.pak",
+      "$root_gen_dir/content/browser/webrtc/resources/webrtc_internals_resources.pak",
       "$root_gen_dir/content/content_resources.pak",
       "$root_gen_dir/mojo/public/js/mojo_bindings_resources.pak",
       "$root_gen_dir/net/net_resources.pak",
@@ -65,7 +67,9 @@ template("electron_extra_paks") {
     deps = [
       "//components/resources",
       "//content:resources",
+      "//content/browser/resources/media:media_internals_resources",
       "//content/browser/tracing:resources",
+      "//content/browser/webrtc/resources",
       "//electron:resources",
       "//mojo/public/js:resources",
       "//net:net_resources",

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -1081,7 +1081,7 @@ describe('chromium features', () => {
           new Promise((resolve, reject) => {
             try {
               let req = window.indexedDB.open('${dbName}');
-              req.onsuccess = (event) => { 
+              req.onsuccess = (event) => {
                 let db = req.result;
                 resolve(db.name);
               }
@@ -1313,8 +1313,29 @@ describe('chromium features', () => {
       })
     })
   })
-})
 
+  describe('chrome://media-internals', () => {
+    it('loads the page successfully', async () => {
+      const w = new BrowserWindow({ show: false })
+      w.loadURL('chrome://media-internals')
+      const pageExists = await w.webContents.executeJavaScript(
+        "window.hasOwnProperty('chrome') && window.chrome.hasOwnProperty('send')"
+      )
+      expect(pageExists).to.be.true()
+    })
+  })
+
+  describe('chrome://webrtc-internals', () => {
+    it('loads the page successfully', async () => {
+      const w = new BrowserWindow({ show: false })
+      w.loadURL('chrome://webrtc-internals')
+      const pageExists = await w.webContents.executeJavaScript(
+        "window.hasOwnProperty('chrome') && window.chrome.hasOwnProperty('send')"
+      )
+      expect(pageExists).to.be.true()
+    })
+  })
+})
 
 describe('font fallback', () => {
   async function getRenderedFonts (html: string) {


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/24010.

Notes: Fixed `chrome://media-internals` and `chrome://webrtc-internals` pages not loading.