### PR TITLE
fix: assign session to remote webContents

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -385,6 +385,9 @@ WebContents::WebContents(v8::Isolate* isolate,
     : content::WebContentsObserver(web_contents),
       type_(Type::REMOTE),
       weak_factory_(this) {
+  auto session = Session::CreateFrom(isolate, GetBrowserContext());
+  session_.Reset(isolate, session.ToV8());
+
   web_contents->SetUserAgentOverride(blink::UserAgentOverride::UserAgentOnly(
                                          GetBrowserContext()->GetUserAgent()),
                                      false);

--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -264,6 +264,16 @@ ifdescribe(process.electronBinding('features').isExtensionsEnabled())('chrome ex
     });
   });
 
+  it('has session in background page', async () => {
+    const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
+    await customSession.loadExtension(path.join(fixtures, 'extensions', 'persistent-background-page'));
+    const w = new BrowserWindow({ show: false, webPreferences: { session: customSession } });
+    const promise = emittedOnce(app, 'web-contents-created');
+    await w.loadURL(`about:blank`);
+    const [, bgPageContents] = await promise;
+    expect(bgPageContents.session).to.not.equal(undefined);
+  });
+
   describe('devtools extensions', () => {
     let showPanelTimeoutId: any = null;
     afterEach(() => {

--- a/spec-main/fixtures/extensions/persistent-background-page/background.js
+++ b/spec-main/fixtures/extensions/persistent-background-page/background.js
@@ -1,0 +1,1 @@
+/* eslint-disable no-undef */

--- a/spec-main/fixtures/extensions/persistent-background-page/manifest.json
+++ b/spec-main/fixtures/extensions/persistent-background-page/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "persistent-background-page",
+  "version": "1.0",
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": true
+  },
+  "manifest_version": 2
+}


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/23989.

Notes: Fixed no `session` in webContents of type remote.