### PR TITLE
chore: remove unused deprecate.fnToProperty()

### DIFF
--- a/lib/common/api/deprecate.ts
+++ b/lib/common/api/deprecate.ts
@@ -76,23 +76,6 @@ const deprecate: ElectronInternal.DeprecationUtil = {
     });
   },
 
-  // deprecate a getter/setter function pair in favor of a property
-  fnToProperty: (prototype: any, prop: string, getter: string, setter?: string) => {
-    const withWarnOnce = function (obj: any, key: any, oldName: string, newName: string) {
-      const warn = warnOnce(oldName, newName);
-      const method = obj[key];
-      return function (this: any, ...args: any) {
-        warn();
-        return method.apply(this, args);
-      };
-    };
-
-    prototype[getter.substr(1)] = withWarnOnce(prototype, getter, `${getter.substr(1)} function`, `${prop} property`);
-    if (setter) {
-      prototype[setter.substr(1)] = withWarnOnce(prototype, setter, `${setter.substr(1)} function`, `${prop} property`);
-    }
-  },
-
   // remove a property with no replacement
   removeProperty: (o, removedName, onlyForValues) => {
     // if the property's already been removed, warn about it

--- a/spec-main/api-deprecate-spec.ts
+++ b/spec-main/api-deprecate-spec.ts
@@ -169,30 +169,6 @@ describe('deprecate', () => {
     }).to.throw(/this is deprecated/);
   });
 
-  it('warns when a function is deprecated in favor of a property', () => {
-    const warnings: string[] = [];
-    deprecate.setHandler(warning => warnings.push(warning));
-
-    const newProp = 'newProp';
-    const mod: any = {
-      _oldGetterFn () { return 'getter'; },
-      _oldSetterFn () { return 'setter'; }
-    };
-
-    deprecate.fnToProperty(mod, 'newProp', '_oldGetterFn', '_oldSetterFn');
-
-    mod.oldGetterFn();
-    mod.oldSetterFn();
-
-    expect(warnings).to.have.lengthOf(2);
-
-    expect(warnings[0]).to.include('oldGetterFn');
-    expect(warnings[0]).to.include(newProp);
-
-    expect(warnings[1]).to.include('oldSetterFn');
-    expect(warnings[1]).to.include(newProp);
-  });
-
   describe('moveAPI', () => {
     beforeEach(() => {
       deprecate.setHandler(null);

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -102,7 +102,6 @@ declare namespace ElectronInternal {
     removeFunction(fn: Function, removedName: string): Function;
     renameFunction(fn: Function, newName: string | Function): Function;
     event(emitter: NodeJS.EventEmitter, oldName: string, newName: string): void;
-    fnToProperty(module: any, prop: string, getter: string, setter?: string): void;
     removeProperty<T, K extends (keyof T & string)>(object: T, propertyName: K, onlyForValues?: any[]): T;
     renameProperty<T, K extends (keyof T & string)>(object: T, oldName: string, newName: K): T;
     moveAPI(fn: Function, oldUsage: string, newUsage: string): Function;


### PR DESCRIPTION
#### Description of Change
Remove unused `deprecate.fnToProperty()`.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes
Notes: no-notes