### PR TITLE
fix: Revert "fix: do not use CONTEXT_MENU flag for tray menu"

### DIFF
--- a/shell/browser/ui/win/notify_icon.cc
+++ b/shell/browser/ui/win/notify_icon.cc
@@ -17,11 +17,16 @@
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/image/image.h"
 #include "ui/views/controls/menu/menu_runner.h"
+#include "ui/views/widget/widget.h"
 
 namespace electron {
 
 NotifyIcon::NotifyIcon(NotifyIconHost* host, UINT id, HWND window, UINT message)
-    : host_(host), icon_id_(id), window_(window), message_id_(message) {
+    : host_(host),
+      icon_id_(id),
+      window_(window),
+      message_id_(message),
+      weak_factory_(this) {
   NOTIFYICONDATA icon_data;
   InitIconData(&icon_data);
   icon_data.uFlags |= NIF_MESSAGE;
@@ -155,10 +160,26 @@ void NotifyIcon::PopUpContextMenu(const gfx::Point& pos,
   if (pos.IsOrigin())
     rect.set_origin(display::Screen::GetScreen()->GetCursorScreenPoint());
 
-  menu_runner_.reset(
-      new views::MenuRunner(menu_model != nullptr ? menu_model : menu_model_,
-                            views::MenuRunner::HAS_MNEMONICS));
-  menu_runner_->RunMenuAt(nullptr, nullptr, rect,
+  // Create a widget for the menu, otherwise we get no keyboard events, which
+  // is required for accessibility.
+  widget_.reset(new views::Widget());
+  views::Widget::InitParams params(views::Widget::InitParams::TYPE_POPUP);
+  params.ownership =
+      views::Widget::InitParams::Ownership::WIDGET_OWNS_NATIVE_WIDGET;
+  params.bounds = gfx::Rect(0, 0, 0, 0);
+  params.force_software_compositing = true;
+  params.z_order = ui::ZOrderLevel::kFloatingUIElement;
+
+  widget_->Init(std::move(params));
+
+  widget_->Show();
+  widget_->Activate();
+  menu_runner_.reset(new views::MenuRunner(
+      menu_model != nullptr ? menu_model : menu_model_,
+      views::MenuRunner::CONTEXT_MENU | views::MenuRunner::HAS_MNEMONICS,
+      base::BindRepeating(&NotifyIcon::OnContextMenuClosed,
+                          weak_factory_.GetWeakPtr())));
+  menu_runner_->RunMenuAt(widget_.get(), NULL, rect,
                           views::MenuAnchorPosition::kTopLeft,
                           ui::MENU_SOURCE_MOUSE);
 }
@@ -184,6 +205,10 @@ void NotifyIcon::InitIconData(NOTIFYICONDATA* icon_data) {
   icon_data->cbSize = sizeof(NOTIFYICONDATA);
   icon_data->hWnd = window_;
   icon_data->uID = icon_id_;
+}
+
+void NotifyIcon::OnContextMenuClosed() {
+  widget_->Close();
 }
 
 }  // namespace electron

--- a/shell/browser/ui/win/notify_icon.h
+++ b/shell/browser/ui/win/notify_icon.h
@@ -14,6 +14,7 @@
 
 #include "base/compiler_specific.h"
 #include "base/macros.h"
+#include "base/memory/weak_ptr.h"
 #include "base/win/scoped_gdi_object.h"
 #include "shell/browser/ui/tray_icon.h"
 
@@ -23,7 +24,8 @@ class Point;
 
 namespace views {
 class MenuRunner;
-}
+class Widget;
+}  // namespace views
 
 namespace electron {
 
@@ -66,6 +68,7 @@ class NotifyIcon : public TrayIcon {
 
  private:
   void InitIconData(NOTIFYICONDATA* icon_data);
+  void OnContextMenuClosed();
 
   // The tray that owns us.  Weak.
   NotifyIconHost* host_;
@@ -87,6 +90,12 @@ class NotifyIcon : public TrayIcon {
 
   // Context menu associated with this icon (if any).
   std::unique_ptr<views::MenuRunner> menu_runner_;
+
+  // Temporary widget for the context menu, needed for keyboard event capture.
+  std::unique_ptr<views::Widget> widget_;
+
+  // WeakPtrFactory for CloseClosure safety.
+  base::WeakPtrFactory<NotifyIcon> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(NotifyIcon);
 };


### PR DESCRIPTION
Reverts electron/electron#23897

As per #24049

Notes: no-notes