### PR TITLE
fix: showing certificate dialog with no window

### DIFF
--- a/lib/browser/api/dialog.js
+++ b/lib/browser/api/dialog.js
@@ -249,7 +249,11 @@ module.exports = {
   },
 
   showCertificateTrustDialog: function (window, options) {
-    if (window && window.constructor !== BrowserWindow) options = window;
+    if (window && window.constructor !== BrowserWindow) {
+      options = window;
+      window = null;
+    }
+
     if (options == null || typeof options !== 'object') {
       throw new TypeError('options must be an object');
     }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/24066.

Fixes an issue in `dialog.showCertificateTrustDialog` where `window` was not explicitly set to null when no optional window was passed. This caused a converter error as the `NativeWindow` converter doesn't know how to handle `undefined`. It's not possible to add a regression test for this case, unfortunately, as the cert trust dialog blocks the main process.

cc @MarshallOfSound @ckerr @jkleinsc 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed an error when calling `dialog.showCertificateTrustDialog` with no `BrowserWindow`.
