### PR TITLE
fix: emit 'shutdown' outside -[NSApplication terminate:]

### DIFF
--- a/shell/browser/mac/electron_application.h
+++ b/shell/browser/mac/electron_application.h
@@ -17,6 +17,7 @@
   base::scoped_nsobject<NSUserActivity> currentActivity_;
   NSCondition* handoffLock_;
   BOOL updateReceived_;
+  BOOL userStoppedShutdown_;
   base::Callback<bool()> shouldShutdown_;
 }
 
@@ -24,6 +25,9 @@
 
 - (void)setShutdownHandler:(base::Callback<bool()>)handler;
 - (void)registerURLHandler;
+
+// Called when macOS itself is shutting down.
+- (void)willPowerOff:(NSNotification*)notify;
 
 // CrAppProtocol:
 - (BOOL)isHandlingSendEvent;

--- a/shell/browser/mac/electron_application.mm
+++ b/shell/browser/mac/electron_application.mm
@@ -41,9 +41,14 @@ inline void dispatch_sync_main(dispatch_block_t block) {
   return (AtomApplication*)[super sharedApplication];
 }
 
+- (void)willPowerOff:(NSNotification*)notify {
+  userStoppedShutdown_ = shouldShutdown_ && !shouldShutdown_.Run();
+}
+
 - (void)terminate:(id)sender {
-  if (shouldShutdown_ && !shouldShutdown_.Run())
-    return;  // User will call Quit later.
+  // User will call Quit later.
+  if (userStoppedShutdown_)
+    return;
 
   // We simply try to close the browser, which in turn will try to close the
   // windows. Termination can proceed if all windows are closed or window close

--- a/shell/browser/mac/electron_application_delegate.mm
+++ b/shell/browser/mac/electron_application_delegate.mm
@@ -48,11 +48,21 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
                                                  useDefaultAccelerator:NO]);
 }
 
+- (void)willPowerOff:(NSNotification*)notify {
+  [[AtomApplication sharedApplication] willPowerOff:notify];
+}
+
 - (void)applicationWillFinishLaunching:(NSNotification*)notify {
   // Don't add the "Enter Full Screen" menu item automatically.
   [[NSUserDefaults standardUserDefaults]
       setBool:NO
        forKey:@"NSFullScreenMenuItemEverywhere"];
+
+  [[[NSWorkspace sharedWorkspace] notificationCenter]
+      addObserver:self
+         selector:@selector(willPowerOff:)
+             name:NSWorkspaceWillPowerOffNotification
+           object:nil];
 
   electron::Browser::Get()->WillFinishLaunching();
 }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/24105.

When macOS shuts down, Cocoa will send an `NSWorkspaceWillPowerOffNotification` followed by `-[NSApplication terminate:]`. The original PR that added this on macOS hooked into the latter  instead of the former, thereby creating the side effect that it would also be called when the app _itself_ terminated. 

For more effective dx, this PR registers for `NSWorkspaceWillPowerOffNotification` and then emits `'shutdown'` when the notification is sent instead.

cc @zcbenz @deepak1556 @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed an issue where `shutdown` would be emitted both on app _and_ system shutdown on macOS.
