### PR TITLE
feat: enable network isolation for all requests

### DIFF
--- a/shell/browser/net/network_context_service.cc
+++ b/shell/browser/net/network_context_service.cc
@@ -6,10 +6,12 @@
 
 #include <utility>
 
+#include "base/feature_list.h"
 #include "chrome/common/chrome_constants.h"
 #include "content/public/browser/network_service_instance.h"
 #include "net/net_buildflags.h"
 #include "services/network/network_service.h"
+#include "services/network/public/cpp/features.h"
 #include "shell/browser/browser_process_impl.h"
 #include "shell/browser/electron_browser_client.h"
 #include "shell/browser/net/system_network_context_manager.h"
@@ -79,6 +81,14 @@ void NetworkContextService::ConfigureNetworkContextParams(
 #if !BUILDFLAG(DISABLE_FTP_SUPPORT)
   network_context_params->enable_ftp_url_support = true;
 #endif  // !BUILDFLAG(DISABLE_FTP_SUPPORT)
+
+  network_context_params->split_auth_cache_by_network_isolation_key =
+      base::FeatureList::IsEnabled(
+          network::features::kSplitAuthCacheByNetworkIsolationKey);
+
+  // All consumers of the main NetworkContext must provide NetworkIsolationKeys
+  // / IsolationInfos, so storage can be isolated on a per-site basis.
+  network_context_params->require_network_isolation_key = true;
 
   proxy_config_monitor_.AddToNetworkContextParams(network_context_params);
 


### PR DESCRIPTION
#### Description of Change

PR to see what breaks when the flag is enabled.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [ ] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: none