### PR TITLE
fix: global shortcut media keys working with accessibility

### DIFF
--- a/patches/chromium/fix_use_the_new_mediaplaypause_key_listener_for_internal_chrome.patch
+++ b/patches/chromium/fix_use_the_new_mediaplaypause_key_listener_for_internal_chrome.patch
@@ -8,6 +8,54 @@ The new kGlobalRequiresAccessibility Scope type should be upstreamed
 and then we can use that and minimize this patch to just the change in
 global_shortcut_listener_mac.mm
 
+diff --git a/chrome/browser/extensions/global_shortcut_listener.cc b/chrome/browser/extensions/global_shortcut_listener.cc
+index bc009606d01469125052e68a9cdc82aaa697c764..ff18043cb07d748a49adea9874517fb29e3e7f9f 100644
+--- a/chrome/browser/extensions/global_shortcut_listener.cc
++++ b/chrome/browser/extensions/global_shortcut_listener.cc
+@@ -7,6 +7,7 @@
+ #include "base/check.h"
+ #include "base/notreached.h"
+ #include "content/public/browser/browser_thread.h"
++#include "content/public/browser/media_keys_listener_manager.h"
+ #include "ui/base/accelerators/accelerator.h"
+ 
+ using content::BrowserThread;
+@@ -66,6 +67,22 @@ void GlobalShortcutListener::UnregisterAccelerator(
+     StopListening();
+ }
+ 
++// static
++void GlobalShortcutListener::SetShouldUseInternalMediaKeyHandling(bool should_use) {
++  if (content::MediaKeysListenerManager::
++            IsMediaKeysListenerManagerEnabled()) {
++    content::MediaKeysListenerManager* media_keys_listener_manager =
++        content::MediaKeysListenerManager::GetInstance();
++    DCHECK(media_keys_listener_manager);
++
++    if (should_use) {
++      media_keys_listener_manager->EnableInternalMediaKeyHandling();
++    } else {
++      media_keys_listener_manager->DisableInternalMediaKeyHandling();
++    }
++  }
++}
++
+ void GlobalShortcutListener::UnregisterAccelerators(Observer* observer) {
+   CHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
+   if (IsShortcutHandlingSuspended())
+diff --git a/chrome/browser/extensions/global_shortcut_listener.h b/chrome/browser/extensions/global_shortcut_listener.h
+index 9aec54a3263d24491d24013a80b719dfc834ecd4..001a6cb2a5eb701351fa924109b43fab6f30748d 100644
+--- a/chrome/browser/extensions/global_shortcut_listener.h
++++ b/chrome/browser/extensions/global_shortcut_listener.h
+@@ -31,6 +31,8 @@ class GlobalShortcutListener {
+ 
+   static GlobalShortcutListener* GetInstance();
+ 
++  static void SetShouldUseInternalMediaKeyHandling(bool should_use);
++
+   // Register an observer for when a certain |accelerator| is struck. Returns
+   // true if register successfully, or false if 1) the specificied |accelerator|
+   // has been registered by another caller or other native applications, or
 diff --git a/chrome/browser/extensions/global_shortcut_listener_mac.mm b/chrome/browser/extensions/global_shortcut_listener_mac.mm
 index befe726af9c10b1563a7fc0bb77cc55f65943d5c..bac51f33f35f96fe4ecc764cf5ca887176642f74 100644
 --- a/chrome/browser/extensions/global_shortcut_listener_mac.mm
@@ -21,6 +69,26 @@ index befe726af9c10b1563a7fc0bb77cc55f65943d5c..bac51f33f35f96fe4ecc764cf5ca8871
      DCHECK(media_keys_listener_);
    }
  }
+diff --git a/content/browser/media/media_keys_listener_manager_impl.cc b/content/browser/media/media_keys_listener_manager_impl.cc
+index 22fd524ae2996108fefdc3bb55a0f2b366310aa9..047fdce0bb57f1d78963200f907df147e174b978 100644
+--- a/content/browser/media/media_keys_listener_manager_impl.cc
++++ b/content/browser/media/media_keys_listener_manager_impl.cc
+@@ -177,8 +177,14 @@ void MediaKeysListenerManagerImpl::EnsureMediaKeysListener() {
+ 
+   EnsureAuxiliaryServices();
+ 
+-  media_keys_listener_ = ui::MediaKeysListener::Create(
++  if (!media_key_handling_enabled_) {
++    media_keys_listener_ = ui::MediaKeysListener::Create(
++      this, ui::MediaKeysListener::Scope::kGlobalRequiresAccessibility);
++  } else {
++    media_keys_listener_ = ui::MediaKeysListener::Create(
+       this, ui::MediaKeysListener::Scope::kGlobal);
++  }
++
+   DCHECK(media_keys_listener_);
+ 
+   media_keys_listener_->SetIsMediaPlaying(is_media_playing_);
 diff --git a/ui/base/accelerators/media_keys_listener.h b/ui/base/accelerators/media_keys_listener.h
 index 6787fa39da18ec26c215e4cbe0b3f69093323f8c..ec10c46cde437a935edfdf79e5ba9622c6ba1d67 100644
 --- a/ui/base/accelerators/media_keys_listener.h

--- a/patches/chromium/fix_use_the_new_mediaplaypause_key_listener_for_internal_chrome.patch
+++ b/patches/chromium/fix_use_the_new_mediaplaypause_key_listener_for_internal_chrome.patch
@@ -70,7 +70,7 @@ index befe726af9c10b1563a7fc0bb77cc55f65943d5c..bac51f33f35f96fe4ecc764cf5ca8871
    }
  }
 diff --git a/content/browser/media/media_keys_listener_manager_impl.cc b/content/browser/media/media_keys_listener_manager_impl.cc
-index 22fd524ae2996108fefdc3bb55a0f2b366310aa9..047fdce0bb57f1d78963200f907df147e174b978 100644
+index 28dc8c8451940b18e74384aad10d4d9e886b31a3..f9e1854ed72cc5a9f2431df066eb72f5242569f1 100644
 --- a/content/browser/media/media_keys_listener_manager_impl.cc
 +++ b/content/browser/media/media_keys_listener_manager_impl.cc
 @@ -177,8 +177,14 @@ void MediaKeysListenerManagerImpl::EnsureMediaKeysListener() {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/24052.

Initially, I tried to fix this in https://github.com/electron/electron/pull/21442, by patching out Chromium's usage of `RemoteCommandCenterDelegate` entirely, as it uses `MPRemoteCommandCenter` in a change added in [this CL](https://chromium-review.googlesource.com/c/chromium/src/+/1480702). `MPRemoteCommandCenter` makes it such that `globalShortcuts` in Electron will not work as intended, because by design an app does not receive remote control events until it begins playing audio. However, as of macOS Catalina, the alternate implementation requires accessibility access to have been granted, which means that it created a situation where simply trying to watch a YouTube video and hitting play/pause would trigger Electron to request a user for Accessibility permissions. For many large apps this is extremely undesirable behavior. 

This second-pass solution splits the difference. What we want is for unilateral override _only_ when registering `globalShortcuts`, which means disabling internal media key handling specifically in that use case. Chromium's media key listener manager already kept track of `media_key_handling_enabled` as a member, so I added a new static method to `GlobalShortcutListenerMac` that allows us to enable and disable it when registering and unregistering shortcuts. Then, we can ensure it's off when registering global shortcuts, and on otherwise (preserving previous behavior).

Tested with https://gist.github.com/codebytere/a7e33c6f03a84dbcc2878859237422dd.

cc @MarshallOfSound @ckerr @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed media keys working unilaterally when registered with `globalShortcut`
