### PR TITLE
fix: make pasteandmatchstyle accelerator os specific

### DIFF
--- a/lib/browser/api/menu-item-roles.js
+++ b/lib/browser/api/menu-item-roles.js
@@ -71,7 +71,7 @@ const roles = {
   },
   pasteandmatchstyle: {
     label: 'Paste and Match Style',
-    accelerator: 'Shift+CommandOrControl+V',
+    accelerator: isMac ? 'Cmd+Option+Shift+V' : 'Shift+CommandOrControl+V',
     webContentsMethod: 'pasteAndMatchStyle',
     registerAccelerator: false
   },


### PR DESCRIPTION
#### Description of Change
Make pasteandmatchstyle accelerator OS specific: ‘Cmd+Option+Shift+V’ for macOS  and ‘Shift+CommandOrControl+V’ for the other platforms. Previous behavior: ‘Shift+CommandOrControl+V’ used for all platforms (Mac, Windows, Linux).
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes
Notes:  Fixed "Paste and Match Style" shortcut on macOS to match OS's "Option-Shift-Command-V"