### PR TITLE
build: remove dead symlink from MAS build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -831,7 +831,7 @@ step-restore-out-cache: &step-restore-out-cache
     paths:
       - ./src/out/Default
     keys:
-      - v7-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
+      - v8-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
     name: Restoring out cache
 
 step-set-git-cache-path: &step-set-git-cache-path
@@ -855,7 +855,7 @@ step-save-out-cache: &step-save-out-cache
   save_cache:
     paths:
       - ./src/out/Default
-    key: v7-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
+    key: v8-out-cache-{{ checksum "src/electron/.depshash" }}-{{ checksum "src/electron/.depshash-target" }}
     name: Persisting out cache
 
 step-run-electron-only-hooks: &step-run-electron-only-hooks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,6 +418,7 @@ step-electron-build: &step-electron-build
       fi
       cd src
       ninja -C out/Default electron -j $NUMBER_OF_NINJA_PROCESSES
+      node electron/script/check-symlinks.js
 
 step-native-unittests-build: &step-native-unittests-build
   run:

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -326,7 +326,6 @@ source_set("electron_lib") {
     "//chrome/app/resources:platform_locale_settings",
     "//chrome/services/printing/public/mojom",
     "//components/certificate_transparency",
-    "//components/crash/core/app",
     "//components/language/core/browser",
     "//components/net_log",
     "//components/network_hints/browser",
@@ -434,6 +433,9 @@ source_set("electron_lib") {
       "*\bviews/*",
     ]
   }
+  if (!is_mas_build) {
+    deps += [ "//components/crash/core/app" ]
+  }
 
   set_sources_assignment_filter(
       sources_assignment_filter + extra_source_filters)
@@ -459,9 +461,12 @@ source_set("electron_lib") {
     deps += [
       "//components/remote_cocoa/app_shim",
       "//content/common:mac_helpers",
-      "//third_party/crashpad/crashpad/client",
       "//ui/accelerated_widget_mac",
     ]
+
+    if (!is_mas_build) {
+      deps += [ "//third_party/crashpad/crashpad/client" ]
+    }
 
     libs = [
       "AVFoundation.framework",
@@ -773,8 +778,10 @@ if (is_mac) {
     framework_contents = [
       "Resources",
       "Libraries",
-      "Helpers",
     ]
+    if (!is_mas_build) {
+      framework_contents += [ "Helpers" ]
+    }
     public_deps = [
       ":electron_framework_libraries",
       ":electron_lib",
@@ -1005,12 +1012,15 @@ if (is_mac) {
 
     group("electron_symbols") {
       deps = [
-        ":crashpad_handler_syms",
         ":electron_app_syms",
         ":electron_framework_syms",
         ":swiftshader_egl_syms",
         ":swiftshader_gles_syms",
       ]
+
+      if (!is_mas_build) {
+        deps += [ ":crashpad_handler_syms" ]
+      }
 
       foreach(helper_params, content_mac_helpers) {
         _helper_target = helper_params[0]

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -488,6 +488,12 @@ source_set("electron_lib") {
       sources += [ "shell/browser/api/electron_api_app_mas.mm" ]
       sources -= [ "shell/browser/auto_updater_mac.mm" ]
       defines += [ "MAS_BUILD" ]
+      sources -= [
+        "shell/app/electron_crash_reporter_client.cc",
+        "shell/app/electron_crash_reporter_client.h",
+        "shell/common/crash_keys.cc",
+        "shell/common/crash_keys.h",
+      ]
     } else {
       libs += [
         "Squirrel.framework",

--- a/script/check-symlinks.js
+++ b/script/check-symlinks.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+
+const utils = require('./lib/utils');
+
+if (process.platform !== 'darwin') {
+  console.log('Not checking symlinks on non-darwin platform');
+  process.exit(0);
+}
+
+const appPath = path.resolve(__dirname, '..', '..', 'out', utils.getOutDir(), 'Electron.app');
+const visited = new Set();
+const traverse = (p) => {
+  if (visited.has(p)) return;
+
+  visited.add(p);
+  if (!fs.statSync(p).isDirectory()) return;
+
+  for (const child of fs.readdirSync(p)) {
+    const childPath = path.resolve(p, child);
+    let realPath;
+    try {
+      realPath = fs.realpathSync(childPath);
+    } catch (err) {
+      if (err.path) {
+        console.error('Detected an invalid symlink');
+        console.error('Source:', childPath);
+        let link = fs.readlinkSync(childPath);
+        if (!link.startsWith('.')) {
+          link = `../${link}`;
+        }
+        console.error('Target:', path.resolve(childPath, link));
+        process.exit(1);
+      } else {
+        throw err;
+      }
+    }
+    traverse(realPath);
+  }
+};
+
+traverse(appPath);

--- a/script/zip_manifests/dist_zip.mac_mas.x64.manifest
+++ b/script/zip_manifests/dist_zip.mac_mas.x64.manifest
@@ -3,7 +3,6 @@ Electron.app/Contents/
 Electron.app/Contents/Frameworks/
 Electron.app/Contents/Frameworks/Electron Framework.framework/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Electron Framework
-Electron.app/Contents/Frameworks/Electron Framework.framework/Helpers
 Electron.app/Contents/Frameworks/Electron Framework.framework/Libraries
 Electron.app/Contents/Frameworks/Electron Framework.framework/Resources
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/

--- a/shell/app/electron_main_delegate.cc
+++ b/shell/app/electron_main_delegate.cc
@@ -22,7 +22,6 @@
 #include "base/strings/string_split.h"
 #include "chrome/common/chrome_paths.h"
 #include "components/content_settings/core/common/content_settings_pattern.h"
-#include "components/crash/core/app/crashpad.h"
 #include "components/crash/core/common/crash_key.h"
 #include "components/crash/core/common/crash_keys.h"
 #include "content/public/common/content_switches.h"
@@ -62,6 +61,10 @@
 #include "components/crash/core/app/breakpad_linux.h"
 #include "v8/include/v8-wasm-trap-handler-posix.h"
 #include "v8/include/v8.h"
+#endif
+
+#if !defined(MAS_BUILD)
+#include "components/crash/core/app/crashpad.h"
 #endif
 
 namespace electron {

--- a/shell/app/electron_main_delegate.cc
+++ b/shell/app/electron_main_delegate.cc
@@ -22,8 +22,6 @@
 #include "base/strings/string_split.h"
 #include "chrome/common/chrome_paths.h"
 #include "components/content_settings/core/common/content_settings_pattern.h"
-#include "components/crash/core/common/crash_key.h"
-#include "components/crash/core/common/crash_keys.h"
 #include "content/public/common/content_switches.h"
 #include "electron/buildflags/buildflags.h"
 #include "extensions/common/constants.h"
@@ -32,13 +30,10 @@
 #include "services/service_manager/sandbox/switches.h"
 #include "services/tracing/public/cpp/stack_sampling/tracing_sampler_profiler.h"
 #include "shell/app/electron_content_client.h"
-#include "shell/app/electron_crash_reporter_client.h"
-#include "shell/browser/api/electron_api_crash_reporter.h"
 #include "shell/browser/electron_browser_client.h"
 #include "shell/browser/electron_gpu_client.h"
 #include "shell/browser/feature_list.h"
 #include "shell/browser/relauncher.h"
-#include "shell/common/crash_keys.h"
 #include "shell/common/electron_paths.h"
 #include "shell/common/options_switches.h"
 #include "shell/renderer/electron_renderer_client.h"
@@ -64,7 +59,12 @@
 #endif
 
 #if !defined(MAS_BUILD)
-#include "components/crash/core/app/crashpad.h"
+#include "components/crash/core/app/crashpad.h"  // nogncheck
+#include "components/crash/core/common/crash_key.h"
+#include "components/crash/core/common/crash_keys.h"
+#include "shell/app/electron_crash_reporter_client.h"
+#include "shell/browser/api/electron_api_crash_reporter.h"
+#include "shell/common/crash_keys.h"
 #endif
 
 namespace electron {

--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -23,13 +23,10 @@
 #include "gin/array_buffer.h"
 #include "gin/public/isolate_holder.h"
 #include "gin/v8_initializer.h"
-#include "shell/app/electron_crash_reporter_client.h"
 #include "shell/app/uv_task_runner.h"
-#include "shell/browser/api/electron_api_crash_reporter.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/browser/node_debugger.h"
 #include "shell/common/api/electron_bindings.h"
-#include "shell/common/crash_keys.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_bindings.h"
 #include "shell/common/node_includes.h"
@@ -43,7 +40,10 @@
 #endif
 
 #if !defined(MAS_BUILD)
-#include "components/crash/core/app/crashpad.h"
+#include "components/crash/core/app/crashpad.h"  // nogncheck
+#include "shell/app/electron_crash_reporter_client.h"
+#include "shell/browser/api/electron_api_crash_reporter.h"
+#include "shell/common/crash_keys.h"
 #endif
 
 namespace {
@@ -86,6 +86,11 @@ void SetNodeCliFlags() {
   // console so we don't need to handle that ourselves
   ProcessGlobalArgs(&args, nullptr, &errors, node::kDisallowedInEnvironment);
 }
+
+#if defined(MAS_BUILD)
+void SetCrashKeyStub(const std::string& key, const std::string& value) {}
+void ClearCrashKeyStub(const std::string& key) {}
+#endif
 
 }  // namespace
 
@@ -220,10 +225,14 @@ int NodeMain(int argc, char* argv[]) {
 #endif
 
       reporter.SetMethod("getParameters", &GetParameters);
-      reporter.SetMethod("addExtraParameter",
-                         &electron::crash_keys::SetCrashKey);
-      reporter.SetMethod("removeExtraParameter",
-                         &electron::crash_keys::ClearCrashKey);
+#if defined(MAS_BUILD)
+      dict.SetMethod("addExtraParameter", &SetCrashKeyStub);
+      dict.SetMethod("removeExtraParameter", &ClearCrashKeyStub);
+#else
+      dict.SetMethod("addExtraParameter", &electron::crash_keys::SetCrashKey);
+      dict.SetMethod("removeExtraParameter",
+                     &electron::crash_keys::ClearCrashKey);
+#endif
 
       process.Set("crashReporter", reporter);
 

--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -18,7 +18,6 @@
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/thread_pool/thread_pool_instance.h"
 #include "base/threading/thread_task_runner_handle.h"
-#include "components/crash/core/app/crashpad.h"
 #include "content/public/common/content_switches.h"
 #include "electron/electron_version.h"
 #include "gin/array_buffer.h"
@@ -41,6 +40,10 @@
 
 #if defined(OS_WIN)
 #include "chrome/child/v8_crashpad_support_win.h"
+#endif
+
+#if !defined(MAS_BUILD)
+#include "components/crash/core/app/crashpad.h"
 #endif
 
 namespace {

--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -226,11 +226,11 @@ int NodeMain(int argc, char* argv[]) {
 
       reporter.SetMethod("getParameters", &GetParameters);
 #if defined(MAS_BUILD)
-      dict.SetMethod("addExtraParameter", &SetCrashKeyStub);
-      dict.SetMethod("removeExtraParameter", &ClearCrashKeyStub);
+      reporter.SetMethod("addExtraParameter", &SetCrashKeyStub);
+      reporter.SetMethod("removeExtraParameter", &ClearCrashKeyStub);
 #else
-      dict.SetMethod("addExtraParameter", &electron::crash_keys::SetCrashKey);
-      dict.SetMethod("removeExtraParameter",
+      reporter.SetMethod("addExtraParameter", &electron::crash_keys::SetCrashKey);
+      reporter.SetMethod("removeExtraParameter",
                      &electron::crash_keys::ClearCrashKey);
 #endif
 

--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -229,9 +229,10 @@ int NodeMain(int argc, char* argv[]) {
       reporter.SetMethod("addExtraParameter", &SetCrashKeyStub);
       reporter.SetMethod("removeExtraParameter", &ClearCrashKeyStub);
 #else
-      reporter.SetMethod("addExtraParameter", &electron::crash_keys::SetCrashKey);
+      reporter.SetMethod("addExtraParameter",
+                         &electron::crash_keys::SetCrashKey);
       reporter.SetMethod("removeExtraParameter",
-                     &electron::crash_keys::ClearCrashKey);
+                         &electron::crash_keys::ClearCrashKey);
 #endif
 
       process.Set("crashReporter", reporter);

--- a/shell/browser/api/electron_api_crash_reporter.cc
+++ b/shell/browser/api/electron_api_crash_reporter.cc
@@ -16,25 +16,28 @@
 #include "base/path_service.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/threading/thread_restrictions.h"
-#include "chrome/browser/crash_upload_list/crash_upload_list_crashpad.h"
 #include "chrome/common/chrome_paths.h"
-#include "components/crash/core/app/crashpad.h"
-#include "components/crash/core/common/crash_key.h"
 #include "components/upload_list/crash_upload_list.h"
 #include "components/upload_list/text_log_upload_list.h"
 #include "content/public/common/content_switches.h"
 #include "gin/arguments.h"
 #include "gin/data_object_builder.h"
 #include "services/service_manager/embedder/switches.h"
-#include "shell/app/electron_crash_reporter_client.h"
-#include "shell/common/crash_keys.h"
 #include "shell/common/electron_paths.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_converters/file_path_converter.h"
 #include "shell/common/gin_converters/time_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_includes.h"
+
+#if !defined(MAS_BUILD)
+#include "chrome/browser/crash_upload_list/crash_upload_list_crashpad.h"
+#include "components/crash/core/app/crashpad.h"
+#include "components/crash/core/common/crash_key.h"
+#include "shell/app/electron_crash_reporter_client.h"
+#include "shell/common/crash_keys.h"
 #include "third_party/crashpad/crashpad/client/crashpad_info.h"
+#endif
 
 #if defined(OS_LINUX)
 #include "components/crash/core/app/breakpad_linux.h"
@@ -61,6 +64,14 @@ namespace electron {
 namespace api {
 
 namespace crash_reporter {
+
+#if defined(MAS_BUILD)
+namespace {
+
+void NoOp() {}
+
+}  // namespace
+#endif
 
 bool IsCrashReporterEnabled() {
   return g_crash_reporter_initialized;
@@ -203,8 +214,13 @@ void Initialize(v8::Local<v8::Object> exports,
                 void* priv) {
   gin_helper::Dictionary dict(context->GetIsolate(), exports);
   dict.SetMethod("start", &electron::api::crash_reporter::Start);
+#if defined(MAS_BUILD)
+  dict.SetMethod("addExtraParameter", &electron::api::crash_reporter::NoOp);
+  dict.SetMethod("removeExtraParameter", &electron::api::crash_reporter::NoOp);
+#else
   dict.SetMethod("addExtraParameter", &electron::crash_keys::SetCrashKey);
   dict.SetMethod("removeExtraParameter", &electron::crash_keys::ClearCrashKey);
+#endif
   dict.SetMethod("getParameters", &GetParameters);
   dict.SetMethod("getUploadedReports", &GetUploadedReports);
   dict.SetMethod("setUploadToServer", &SetUploadToServer);

--- a/shell/browser/api/electron_api_crash_reporter.cc
+++ b/shell/browser/api/electron_api_crash_reporter.cc
@@ -32,11 +32,11 @@
 
 #if !defined(MAS_BUILD)
 #include "chrome/browser/crash_upload_list/crash_upload_list_crashpad.h"
-#include "components/crash/core/app/crashpad.h"
+#include "components/crash/core/app/crashpad.h"  // nogncheck
 #include "components/crash/core/common/crash_key.h"
 #include "shell/app/electron_crash_reporter_client.h"
 #include "shell/common/crash_keys.h"
-#include "third_party/crashpad/crashpad/client/crashpad_info.h"
+#include "third_party/crashpad/crashpad/client/crashpad_info.h"  // nogncheck
 #endif
 
 #if defined(OS_LINUX)

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -169,12 +169,12 @@
 #include "content/public/common/child_process_host.h"
 #endif
 
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) && !defined(MAS_BUILD)
 #include "base/debug/leak_annotations.h"
 #include "components/crash/content/browser/crash_handler_host_linux.h"
-#include "components/crash/core/app/breakpad_linux.h"
-#include "components/crash/core/app/crash_switches.h"
-#include "components/crash/core/app/crashpad.h"
+#include "components/crash/core/app/breakpad_linux.h"  // nogncheck
+#include "components/crash/core/app/crash_switches.h"  // nogncheck
+#include "components/crash/core/app/crashpad.h"        // nogncheck
 #endif
 
 using content::BrowserThread;

--- a/shell/renderer/api/electron_api_crash_reporter_renderer.cc
+++ b/shell/renderer/api/electron_api_crash_reporter_renderer.cc
@@ -3,9 +3,12 @@
 // found in the LICENSE file.
 
 #include "base/bind.h"
-#include "shell/common/crash_keys.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_includes.h"
+
+#if !defined(MAS_BUILD)
+#include "shell/common/crash_keys.h"
+#endif
 
 namespace {
 


### PR DESCRIPTION
Fixes #23828

This fixes the stray symbolic link and adds a script to ensure it doesn't happen again

Notes: Fixed mac app store rejection notice for invalid symbolic link in bundle.