### PR TITLE
test: skip 'handles Promise timeouts correctly' when ELECTRON_RUN_AS_NODE is disabled 

### DIFF
--- a/spec/node-spec.js
+++ b/spec/node-spec.js
@@ -9,6 +9,7 @@ const { ipcRenderer, remote } = require('electron');
 const features = process.electronBinding('features');
 
 const { emittedOnce } = require('./events-helpers');
+const { ifit } = require('./spec-helpers');
 
 const isCI = remote.getGlobal('isCi');
 chai.use(dirtyChai);
@@ -691,7 +692,7 @@ describe('node feature', () => {
     expect(result.status).to.equal(0);
   });
 
-  it('handles Promise timeouts correctly', (done) => {
+  ifit(features.isRunAsNodeEnabled())('handles Promise timeouts correctly', (done) => {
     const scriptPath = path.join(fixtures, 'module', 'node-promise-timer.js');
     const child = ChildProcess.spawn(process.execPath, [scriptPath], {
       env: { ELECTRON_RUN_AS_NODE: 'true' }

--- a/spec/spec-helpers.js
+++ b/spec/spec-helpers.js
@@ -1,0 +1,2 @@
+exports.ifit = (condition) => (condition ? it : it.skip);
+exports.ifdescribe = (condition) => (condition ? describe : describe.skip);


### PR DESCRIPTION
Backport of #23415

See that PR for details.


Notes: none