### PR TITLE
chore: cleanup unused WebContents::DereferenceRemoteJSObject()

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1226,18 +1226,6 @@ void WebContents::MessageHost(const std::string& channel,
                  InvokeCallback(), channel, std::move(arguments));
 }
 
-#if BUILDFLAG(ENABLE_REMOTE_MODULE)
-void WebContents::DereferenceRemoteJSObject(const std::string& context_id,
-                                            int object_id) {
-  base::ListValue args;
-  args.Append(context_id);
-  args.Append(object_id);
-  EmitWithSender("-ipc-message", bindings_.dispatch_context(), InvokeCallback(),
-                 /* internal */ true, "ELECTRON_BROWSER_DEREFERENCE",
-                 std::move(args));
-}
-#endif
-
 void WebContents::UpdateDraggableRegions(
     std::vector<mojom::DraggableRegionPtr> regions) {
   for (ExtendedWebContentsObserver& observer : observers_)

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -597,10 +597,6 @@ class WebContents : public gin_helper::TrackableObject<WebContents>,
                  blink::CloneableMessage arguments) override;
   void MessageHost(const std::string& channel,
                    blink::CloneableMessage arguments) override;
-#if BUILDFLAG(ENABLE_REMOTE_MODULE)
-  void DereferenceRemoteJSObject(const std::string& context_id,
-                                 int object_id) override;
-#endif
   void UpdateDraggableRegions(
       std::vector<mojom::DraggableRegionPtr> regions) override;
   void SetTemporaryZoomLevel(double level) override;

--- a/shell/common/api/api.mojom
+++ b/shell/common/api/api.mojom
@@ -72,13 +72,6 @@ interface ElectronBrowser {
     string channel,
     blink.mojom.CloneableMessage arguments);
 
-  // This is an API specific to the "remote" module, and will ultimately be
-  // replaced by generic IPC once WeakRef is generally available.
-  [EnableIf=enable_remote_module]
-  DereferenceRemoteJSObject(
-    string context_id,
-    int32 object_id);
-
   UpdateDraggableRegions(
     array<DraggableRegion> regions);
 


### PR DESCRIPTION
#### Description of Change
Follow-up to #24115

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes
Notes: no-notes