### PR TITLE
fix: do not use CONTEXT_MENU flag for tray menu (reland)

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -110,3 +110,4 @@ fix_handling_non_client_pointer_events_from_pen_on_windows_10.patch
 a11y_iterate_all_descendants_for_getselectioncount.patch
 allow_ime_to_insert_zero-length_composition_string.patch
 cherry-pick-eac3d9283d11.patch
+remove_menu_window_task_item.patch

--- a/patches/chromium/remove_menu_window_task_item.patch
+++ b/patches/chromium/remove_menu_window_task_item.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Thu, 4 Oct 2018 14:57:02 -0700
+Subject: fix: remove menu window from taskbar
+
+Refs https://chromium-review.googlesource.com/c/chromium/src/+/2245941
+
+diff --git a/ui/views/widget/widget_hwnd_utils.cc b/ui/views/widget/widget_hwnd_utils.cc
+index 40e66a212e3ea158b61f11d804a3c1644023b2d7..89f5b62f95dfec59bacf79f33895438039fac1c5 100644
+--- a/ui/views/widget/widget_hwnd_utils.cc
++++ b/ui/views/widget/widget_hwnd_utils.cc
+@@ -118,6 +118,8 @@ void CalculateWindowStylesFromInitParams(
+         else
+           *style |= WS_BORDER;
+       }
++      if (!params.force_show_in_taskbar)
++        *ex_style |= WS_EX_TOOLWINDOW;
+       break;
+     case Widget::InitParams::TYPE_TOOLTIP:
+       *style |= WS_POPUP;

--- a/shell/browser/ui/win/notify_icon.cc
+++ b/shell/browser/ui/win/notify_icon.cc
@@ -17,7 +17,6 @@
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/image/image.h"
 #include "ui/views/controls/menu/menu_runner.h"
-#include "ui/views/widget/widget.h"
 
 namespace {
 
@@ -44,11 +43,7 @@ UINT ConvertIconType(electron::TrayIcon::IconType type) {
 namespace electron {
 
 NotifyIcon::NotifyIcon(NotifyIconHost* host, UINT id, HWND window, UINT message)
-    : host_(host),
-      icon_id_(id),
-      window_(window),
-      message_id_(message),
-      weak_factory_(this) {
+    : host_(host), icon_id_(id), window_(window), message_id_(message) {
   NOTIFYICONDATA icon_data;
   InitIconData(&icon_data);
   icon_data.uFlags |= NIF_MESSAGE;
@@ -207,26 +202,10 @@ void NotifyIcon::PopUpContextMenu(const gfx::Point& pos,
   if (pos.IsOrigin())
     rect.set_origin(display::Screen::GetScreen()->GetCursorScreenPoint());
 
-  // Create a widget for the menu, otherwise we get no keyboard events, which
-  // is required for accessibility.
-  widget_.reset(new views::Widget());
-  views::Widget::InitParams params(views::Widget::InitParams::TYPE_POPUP);
-  params.ownership =
-      views::Widget::InitParams::Ownership::WIDGET_OWNS_NATIVE_WIDGET;
-  params.bounds = gfx::Rect(0, 0, 0, 0);
-  params.force_software_compositing = true;
-  params.z_order = ui::ZOrderLevel::kFloatingUIElement;
-
-  widget_->Init(std::move(params));
-
-  widget_->Show();
-  widget_->Activate();
-  menu_runner_.reset(new views::MenuRunner(
-      menu_model != nullptr ? menu_model : menu_model_,
-      views::MenuRunner::CONTEXT_MENU | views::MenuRunner::HAS_MNEMONICS,
-      base::BindRepeating(&NotifyIcon::OnContextMenuClosed,
-                          weak_factory_.GetWeakPtr())));
-  menu_runner_->RunMenuAt(widget_.get(), NULL, rect,
+  menu_runner_.reset(
+      new views::MenuRunner(menu_model != nullptr ? menu_model : menu_model_,
+                            views::MenuRunner::HAS_MNEMONICS));
+  menu_runner_->RunMenuAt(nullptr, nullptr, rect,
                           views::MenuAnchorPosition::kTopLeft,
                           ui::MENU_SOURCE_MOUSE);
 }
@@ -252,10 +231,6 @@ void NotifyIcon::InitIconData(NOTIFYICONDATA* icon_data) {
   icon_data->cbSize = sizeof(NOTIFYICONDATA);
   icon_data->hWnd = window_;
   icon_data->uID = icon_id_;
-}
-
-void NotifyIcon::OnContextMenuClosed() {
-  widget_->Close();
 }
 
 }  // namespace electron

--- a/shell/browser/ui/win/notify_icon.h
+++ b/shell/browser/ui/win/notify_icon.h
@@ -14,7 +14,6 @@
 
 #include "base/compiler_specific.h"
 #include "base/macros.h"
-#include "base/memory/weak_ptr.h"
 #include "base/win/scoped_gdi_object.h"
 #include "shell/browser/ui/tray_icon.h"
 
@@ -24,8 +23,7 @@ class Point;
 
 namespace views {
 class MenuRunner;
-class Widget;
-}  // namespace views
+}
 
 namespace electron {
 
@@ -68,7 +66,6 @@ class NotifyIcon : public TrayIcon {
 
  private:
   void InitIconData(NOTIFYICONDATA* icon_data);
-  void OnContextMenuClosed();
 
   // The tray that owns us.  Weak.
   NotifyIconHost* host_;
@@ -90,12 +87,6 @@ class NotifyIcon : public TrayIcon {
 
   // Context menu associated with this icon (if any).
   std::unique_ptr<views::MenuRunner> menu_runner_;
-
-  // Temporary widget for the context menu, needed for keyboard event capture.
-  std::unique_ptr<views::Widget> widget_;
-
-  // WeakPtrFactory for CloseClosure safety.
-  base::WeakPtrFactory<NotifyIcon> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(NotifyIcon);
 };


### PR DESCRIPTION
Backport of #24097

See that PR for details.

Notes: Fix tray menu showing in taskbar on Windows.