### PR TITLE
refactor: improve the REPL

### DIFF
--- a/default_app/main.ts
+++ b/default_app/main.ts
@@ -149,10 +149,10 @@ function startRepl () {
   // Prevent quitting.
   app.on('window-all-closed', () => {});
 
-  const colors = { GREEN: '32', MAGENTA: '35' };
+  const GREEN = '32';
   const colorize = (color: string, s: string) => `\x1b[${color}m${s}\x1b[0m`;
-  const electronVersion = colorize(colors.MAGENTA, `v${process.versions.electron}`);
-  const nodeVersion = colorize(colors.GREEN, `v${process.versions.node}`);
+  const electronVersion = colorize(GREEN, `v${process.versions.electron}`);
+  const nodeVersion = colorize(GREEN, `v${process.versions.node}`);
 
   console.info(`
     Welcome to the Electron.js REPL \\[._.]/

--- a/default_app/main.ts
+++ b/default_app/main.ts
@@ -1,8 +1,9 @@
-import { app, dialog } from 'electron';
+import * as electron from 'electron';
 
 import * as fs from 'fs';
 import * as path from 'path';
 import * as url from 'url';
+const { app, dialog } = electron;
 
 type DefaultAppOptions = {
   file: null | string;
@@ -145,13 +146,57 @@ function startRepl () {
     process.exit(1);
   }
 
-  // prevent quitting
+  // Prevent quitting.
   app.on('window-all-closed', () => {});
 
-  const repl = require('repl');
-  repl.start('> ').on('exit', () => {
+  const colors = { GREEN: '32', MAGENTA: '35' };
+  const colorize = (color: string, s: string) => `\x1b[${color}m${s}\x1b[0m`;
+  const electronVersion = colorize(colors.MAGENTA, `v${process.versions.electron}`);
+  const nodeVersion = colorize(colors.GREEN, `v${process.versions.node}`);
+
+  console.info(`
+    Welcome to the Electron.js REPL \\[._.]/
+
+    You can access all Electron.js modules here as well as Node.js modules.
+    Using: Node.js ${nodeVersion} and Electron.js ${electronVersion}
+  `);
+
+  const { REPLServer } = require('repl');
+  const repl = new REPLServer({
+    prompt: '> '
+  }).on('exit', () => {
     process.exit(0);
   });
+
+  // Copied from node/lib/repl.js. For better DX, we don't want to
+  // show e.g 'contentTracing' at a higher priority than 'const', so
+  // we only trigger custom tab-completion when no common words are
+  // potentially matches.
+  const commonWords = [
+    'async', 'await', 'break', 'case', 'catch', 'const', 'continue',
+    'debugger', 'default', 'delete', 'do', 'else', 'export', 'false',
+    'finally', 'for', 'function', 'if', 'import', 'in', 'instanceof', 'let',
+    'new', 'null', 'return', 'switch', 'this', 'throw', 'true', 'try',
+    'typeof', 'var', 'void', 'while', 'with', 'yield'
+  ];
+
+  const electronBuiltins = [...Object.keys(electron), 'original-fs', 'electron'];
+
+  const defaultComplete = repl.completer;
+  repl.completer = (line: string, callback: Function) => {
+    const lastSpace = line.lastIndexOf(' ');
+    const currentSymbol = line.substring(lastSpace + 1, repl.cursor);
+
+    const filterFn = (c: string) => c.startsWith(currentSymbol);
+    const ignores = commonWords.filter(filterFn);
+    const hits = electronBuiltins.filter(filterFn);
+
+    if (!ignores.length && hits.length) {
+      callback(null, [hits, currentSymbol]);
+    } else {
+      defaultComplete.apply(repl, [line, callback]);
+    }
+  };
 }
 
 // Start the specified app if there is one specified in command line, otherwise


### PR DESCRIPTION
#### Description of Change

This PR improves the Electron REPL experience. It adds a welcome message to the REPL to let users know what versions of Node.js and Electron they're running, as well as overriding the completer function in the REPL to preload and add tab autocompletion for Electron's own modules.

<img width="581" alt="Screen Shot 2020-06-18 at 10 27 15 PM" src="https://user-images.githubusercontent.com/2036040/85099793-38e4c300-b1b3-11ea-987d-a07622f0e282.png">

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Improved the default REPL experience when running Electron with the `--interactive` flag.