### PR TITLE
fix: isTrustedSender() in test-app

### DIFF
--- a/default_app/default_app.ts
+++ b/default_app/default_app.ts
@@ -1,5 +1,6 @@
 import { app, dialog, BrowserWindow, shell, ipcMain } from 'electron';
 import * as path from 'path';
+import * as url from 'url';
 
 let mainWindow: BrowserWindow | null = null;
 
@@ -29,12 +30,11 @@ function isTrustedSender (webContents: Electron.WebContents) {
     return false;
   }
 
-  const parsedUrl = new URL(webContents.getURL());
-  const urlPath = process.platform === 'win32'
-    // Strip the prefixed "/" that occurs on windows
-    ? path.resolve(parsedUrl.pathname.substr(1))
-    : parsedUrl.pathname;
-  return parsedUrl.protocol === 'file:' && urlPath === indexPath;
+  try {
+    return url.fileURLToPath(webContents.getURL()) === indexPath;
+  } catch {
+    return false;
+  }
 }
 
 ipcMain.handle('bootstrap', (event) => {


### PR DESCRIPTION
#### Description of Change
Handles spaces and special characters in Electron path properly.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes
Notes: Fixed "null path-to-app" in test-app when Electron's path contains spaces or special characters.