### PR TITLE
fix: only notify mouse-up on mouse-up

### DIFF
--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -131,10 +131,6 @@
 }
 
 - (void)handleClickNotifications:(NSEvent*)event {
-  trayIcon_->NotifyMouseUp(
-      gfx::ScreenPointFromNSPoint([event locationInWindow]),
-      ui::EventFlagsFromModifiers([event modifierFlags]));
-
   // If we are ignoring double click events, we should ignore the `clickCount`
   // value and immediately emit a click event.
   BOOL shouldBeHandledAsASingleClick =
@@ -171,6 +167,10 @@
 
 - (void)mouseUp:(NSEvent*)event {
   [[statusItem_ button] highlight:NO];
+
+  trayIcon_->NotifyMouseUp(
+      gfx::ScreenPointFromNSPoint([event locationInWindow]),
+      ui::EventFlagsFromModifiers([event modifierFlags]));
 
   [self handleClickNotifications:event];
 }


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/24200.

Moved the `mouse-up` handler into `handleClickEvents` which it shouldn't have been. This does not need to go to 8 or 10, only 9, since it's been handled in the backports already (https://github.com/electron/electron/pull/24235).

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: none.
