### PR TITLE
feat: Electron Fuses, package time feature toggles

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -303,6 +303,19 @@ templated_file("electron_version_header") {
   args_files = get_target_outputs(":electron_version_args")
 }
 
+action("electron_fuses") {
+  script = "build/fuses/build.py"
+
+  inputs = [ "build/fuses/fuses.json" ]
+
+  outputs = [
+    "$target_gen_dir/fuses.h",
+    "$target_gen_dir/fuses.cc",
+  ]
+
+  args = rebase_path(outputs)
+}
+
 source_set("electron_lib") {
   configs += [ "//v8:external_startup_data" ]
   configs += [ "//third_party/electron_node:node_internals" ]
@@ -313,6 +326,7 @@ source_set("electron_lib") {
   ]
 
   deps = [
+    ":electron_fuses",
     ":electron_js2c",
     ":electron_version_header",
     ":manifests",
@@ -673,6 +687,8 @@ source_set("electron_lib") {
       "shell/browser/electron_pdf_web_contents_helper_client.h",
     ]
   }
+
+  sources += get_target_outputs(":electron_fuses")
 }
 
 electron_paks("packed_resources") {

--- a/build/fuses/build.py
+++ b/build/fuses/build.py
@@ -70,9 +70,9 @@ for fuse in fuses:
   index += 1
   initial_config += fuse_defaults[fuse]
   name = ''.join(word.title() for word in fuse.split('_'))
-  getters_h += "bool Is{name}Enabled();\n".replace("{name}", name)
+  getters_h += "FUSE_EXPORT bool Is{name}Enabled();\n".replace("{name}", name)
   getters_cc += """
-FUSE_EXPORT bool Is{name}Enabled() {
+bool Is{name}Enabled() {
   return kFuseWire[{index}] == '1';
 }
 """.replace("{name}", name).replace("{index}", str(index))

--- a/build/fuses/build.py
+++ b/build/fuses/build.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import sys
+
+dir_path = os.path.dirname(os.path.realpath(__file__))
+
+SENTINEL = "dL7pKGdnNz796PbbjQWNKmHXBZaB9tsX"
+
+TEMPLATE_H = """
+#ifndef ELECTRON_FUSES_H_
+#define ELECTRON_FUSES_H_
+
+namespace electron {
+
+namespace fuses {
+
+extern const volatile char kFuseWire[];
+
+{getters}
+
+}  // namespace fuses
+
+}  // namespace electron
+
+#endif  // ELECTRON_FUSES_H_
+"""
+
+TEMPLATE_CC = """
+#include "electron/fuses.h"
+
+#include <iostream>
+
+namespace electron {
+
+namespace fuses {
+
+const volatile char kFuseWire[] = "{sentinel}{fuse_version}{initial_config}";
+
+{getters}
+
+}
+
+}
+"""
+
+with open(os.path.join(dir_path, "fuses.json"), 'r') as f:
+  fuse_defaults = json.load(f)
+
+fuse_version = fuse_defaults['_version']
+del fuse_defaults['_version']
+del fuse_defaults['_comment']
+
+if fuse_version >= pow(2, 8):
+  raise Exception("Fuse version can not exceed one byte in size")
+
+fuses = fuse_defaults.keys()
+
+initial_config = ""
+getters_h = ""
+getters_cc = ""
+index = len(SENTINEL)
+for fuse in fuses:
+  index += 1
+  initial_config += "1" if fuse_defaults[fuse] else "0"
+  name = ''.join(word.title() for word in fuse.split('_'))
+  getters_h += "bool Is{name}Enabled();\n".replace("{name}", name)
+  getters_cc += """
+__attribute__((__visibility__("default"))) bool Is{name}Enabled() {
+  return kFuseWire[{index}] == '1';
+}
+""".replace("{name}", name).replace("{index}", str(index))
+
+header = TEMPLATE_H.replace("{getters}", getters_h.strip())
+impl = TEMPLATE_CC.replace("{sentinel}", SENTINEL).replace("{fuse_version}", chr(fuse_version)).replace("{initial_config}", initial_config).replace("{getters}", getters_cc.strip())
+
+with open(sys.argv[1], 'w') as f:
+  f.write(header)
+
+with open(sys.argv[2], 'w') as f:
+  f.write(impl)

--- a/build/fuses/fuses.json
+++ b/build/fuses/fuses.json
@@ -1,5 +1,6 @@
 {
-  "_comment": "Modifying this file in any way (removing, adding or changing values) should result in the _version prop being incremented",
+  "_comment": "Modifying the fuse schema in any way should result in the _version prop being incremented.  NEVER REMOVE A FUSE, instead mark it as removed with '-1'",
+  "_schema": "0 == off, 1 == on, -1 == removed fuse",
   "_version": 1,
-  "run_as_node": true
+  "run_as_node": "1"
 }

--- a/build/fuses/fuses.json
+++ b/build/fuses/fuses.json
@@ -1,6 +1,6 @@
 {
-  "_comment": "Modifying the fuse schema in any way should result in the _version prop being incremented.  NEVER REMOVE A FUSE, instead mark it as removed with '-1'",
-  "_schema": "0 == off, 1 == on, -1 == removed fuse",
+  "_comment": "Modifying the fuse schema in any way should result in the _version prop being incremented.  NEVER REMOVE A FUSE, instead mark it as removed with 'r'",
+  "_schema": "0 == off, 1 == on, r == removed fuse",
   "_version": 1,
   "run_as_node": "1"
 }

--- a/build/fuses/fuses.json
+++ b/build/fuses/fuses.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "Modifying this file in any way (removing, adding or changing values) should result in the _version prop being incremented",
+  "_version": 1,
+  "run_as_node": true
+}

--- a/build/fuses/fuses.json
+++ b/build/fuses/fuses.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Modifying the fuse schema in any way should result in the _version prop being incremented.  NEVER REMOVE A FUSE, instead mark it as removed with 'r'",
+  "_comment": "Modifying the fuse schema in any breaking way should result in the _version prop being incremented.  NEVER remove a fuse or change its meaning, instead mark it as removed with 'r'",
   "_schema": "0 == off, 1 == on, r == removed fuse",
   "_version": 1,
   "run_as_node": "1"

--- a/docs/tutorial/fuses.md
+++ b/docs/tutorial/fuses.md
@@ -1,0 +1,52 @@
+# Electron Fuses
+
+> Package time feature toggles
+
+## What are fuses?
+
+For a subset of Electron functionality it makes sense to disable certain features for an entire application.  For example, 99% of apps don't make use of `ELECTRON_RUN_AS_NODE`, these applications want to be able to ship a binary that is incapable of using that feature.  We also don't want Electron consumers building Electron from source as that is both a massive technical challenge and has a high cost of both time and money.
+
+Fuses are the solution to this problem, at a high level they are "magic bits" in the Electron binary that can be flipped when packaging your Electron app to enable / disable certain features / restrictions.  Because they are flipped at package time before you code sign your app the OS becomes responsible for ensuring those bits aren't flipped back via OS level code signing validation (Gatekeeper / App Locker).
+
+## How do I flip the fuses?
+
+### The easy way
+
+We've made a handy module `@electron/fuses` to make flipping these fuses easy.  Check out the README of that module for more details on usage and potential error cases.
+
+```js
+require('@electron/fuses').flipFuses(
+  // Path to electron
+  require('electron'),
+  // Fuses to flip
+  {
+    runAsNode: false
+  }
+)
+```
+
+### The hard way
+
+#### Quick Glossary
+
+* **Fuse Wire**: A sequence of bytes in the Electron binary used to control the fuses
+* **Sentinel**: A static known sequence of bytes you can use to locate the fuse wire
+* **Fuse Schema**: The format / allowed values for the fuse wire
+
+Manually flipping fuses requires editing the correct Electron binary and modifying the fuse wire to be the sequence of bytes that represent the state of the fuses you want.
+
+Somewhere in the Electron binary there will be a sequence of bytes that look like this:
+
+```text
+| ...binary | sentinel_bytes | fuse_version | fuse_wire_length | fuse_wire | ...binary |
+```
+
+* `sentinel_bytes` is always this exact string `dL7pKGdnNz796PbbjQWNKmHXBZaB9tsX`
+* `fuse_version` is a single byte whose integer value represents the version of the fuse schema
+* `fuse_wire_length` is a single byte whose integer value represents the number of fuses in the following fuse wire
+* `fuse_wire` is a sequence of N bytes, each byte represents a single fuse and its state.
+  * "0" indicates the fuse is disabled
+  * "1" indicates the fuse is enabled
+  * "r" indicates the fuse is removed and is now a noop
+
+To flip a fuse you find its position in the fuse wire and change it to "0" or "1" depending on the state you'd like.

--- a/docs/tutorial/fuses.md
+++ b/docs/tutorial/fuses.md
@@ -50,3 +50,5 @@ Somewhere in the Electron binary there will be a sequence of bytes that look lik
   * "r" (0x72) indicates the fuse has been removed and changing the byte to either 1 or 0 will have no effect.
 
 To flip a fuse you find its position in the fuse wire and change it to "0" or "1" depending on the state you'd like.
+
+You can view the current schema [here](https://github.com/electron/electron/blob/master/build/fuses/fuses.json).

--- a/docs/tutorial/fuses.md
+++ b/docs/tutorial/fuses.md
@@ -33,7 +33,7 @@ require('@electron/fuses').flipFuses(
 * **Sentinel**: A static known sequence of bytes you can use to locate the fuse wire
 * **Fuse Schema**: The format / allowed values for the fuse wire
 
-Manually flipping fuses requires editing the correct Electron binary and modifying the fuse wire to be the sequence of bytes that represent the state of the fuses you want.
+Manually flipping fuses requires editing the Electron binary and modifying the fuse wire to be the sequence of bytes that represent the state of the fuses you want.
 
 Somewhere in the Electron binary there will be a sequence of bytes that look like this:
 
@@ -42,11 +42,11 @@ Somewhere in the Electron binary there will be a sequence of bytes that look lik
 ```
 
 * `sentinel_bytes` is always this exact string `dL7pKGdnNz796PbbjQWNKmHXBZaB9tsX`
-* `fuse_version` is a single byte whose integer value represents the version of the fuse schema
-* `fuse_wire_length` is a single byte whose integer value represents the number of fuses in the following fuse wire
+* `fuse_version` is a single byte whose unsigned integer value represents the version of the fuse schema
+* `fuse_wire_length` is a single byte whose unsigned integer value represents the number of fuses in the following fuse wire
 * `fuse_wire` is a sequence of N bytes, each byte represents a single fuse and its state.
-  * "0" indicates the fuse is disabled
-  * "1" indicates the fuse is enabled
-  * "r" indicates the fuse is removed and is now a noop
+  * "0" (0x30) indicates the fuse is disabled
+  * "1" (0x31) indicates the fuse is enabled
+  * "r" (0x72) indicates the fuse has been removed and changing the byte to either 1 or 0 will have no effect.
 
 To flip a fuse you find its position in the fuse wire and change it to "0" or "1" depending on the state you'd like.

--- a/shell/app/electron_library_main.mm
+++ b/shell/app/electron_library_main.mm
@@ -26,8 +26,10 @@ int ElectronMain(int argc, char* argv[]) {
 
 #if BUILDFLAG(ENABLE_RUN_AS_NODE)
 int ElectronInitializeICUandStartNode(int argc, char* argv[]) {
-  if (!electron::fuses::IsRunAsNodeEnabled())
+  if (!electron::fuses::IsRunAsNodeEnabled()) {
+    CHECK(false);
     return 1;
+  }
 
   base::AtExitManager atexit_manager;
   base::mac::ScopedNSAutoreleasePool pool;

--- a/shell/app/electron_library_main.mm
+++ b/shell/app/electron_library_main.mm
@@ -9,6 +9,7 @@
 #include "base/mac/bundle_locations.h"
 #include "base/mac/scoped_nsautorelease_pool.h"
 #include "content/public/app/content_main.h"
+#include "electron/fuses.h"
 #include "shell/app/electron_main_delegate.h"
 #include "shell/app/node_main.h"
 #include "shell/common/electron_command_line.h"
@@ -25,6 +26,9 @@ int ElectronMain(int argc, char* argv[]) {
 
 #if BUILDFLAG(ENABLE_RUN_AS_NODE)
 int ElectronInitializeICUandStartNode(int argc, char* argv[]) {
+  if (!electron::fuses::IsRunAsNodeEnabled())
+    return 1;
+
   base::AtExitManager atexit_manager;
   base::mac::ScopedNSAutoreleasePool pool;
   base::mac::SetOverrideFrameworkBundlePath(

--- a/shell/app/electron_library_main.mm
+++ b/shell/app/electron_library_main.mm
@@ -27,7 +27,7 @@ int ElectronMain(int argc, char* argv[]) {
 #if BUILDFLAG(ENABLE_RUN_AS_NODE)
 int ElectronInitializeICUandStartNode(int argc, char* argv[]) {
   if (!electron::fuses::IsRunAsNodeEnabled()) {
-    CHECK(false);
+    CHECK(false) << "run_as_node fuse is disabled";
     return 1;
   }
 

--- a/shell/app/electron_main.cc
+++ b/shell/app/electron_main.cc
@@ -47,6 +47,7 @@
 #include "base/at_exit.h"
 #include "base/i18n/icu_util.h"
 #include "electron/buildflags/buildflags.h"
+#include "electron/fuses.h"
 #include "shell/app/node_main.h"
 #include "shell/common/electron_command_line.h"
 #include "shell/common/electron_constants.h"
@@ -128,7 +129,8 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
 #endif
 
 #if BUILDFLAG(ENABLE_RUN_AS_NODE)
-  bool run_as_node = IsEnvSet(electron::kRunAsNode);
+  bool run_as_node =
+      electron::fuses::IsRunAsNodeEnabled() && IsEnvSet(electron::kRunAsNode);
 #else
   bool run_as_node = false;
 #endif
@@ -141,7 +143,7 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
   std::transform(arguments.argv, arguments.argv + arguments.argc, argv.begin(),
                  [](auto& a) { return _strdup(base::WideToUTF8(a).c_str()); });
 #if BUILDFLAG(ENABLE_RUN_AS_NODE)
-  if (run_as_node) {
+  if (electron::fuses::IsRunAsNodeEnabled() && run_as_node) {
     base::AtExitManager atexit_manager;
     base::i18n::InitializeICU();
     auto ret = electron::NodeMain(argv.size(), argv.data());
@@ -216,7 +218,7 @@ int main(int argc, char* argv[]) {
   FixStdioStreams();
 
 #if BUILDFLAG(ENABLE_RUN_AS_NODE)
-  if (IsEnvSet(electron::kRunAsNode)) {
+  if (electron::fuses::IsRunAsNodeEnabled() && IsEnvSet(electron::kRunAsNode)) {
     base::i18n::InitializeICU();
     base::AtExitManager atexit_manager;
     return electron::NodeMain(argc, argv);
@@ -237,7 +239,7 @@ int main(int argc, char* argv[]) {
   FixStdioStreams();
 
 #if BUILDFLAG(ENABLE_RUN_AS_NODE)
-  if (IsEnvSet(electron::kRunAsNode)) {
+  if (electron::fuses::IsRunAsNodeEnabled() && IsEnvSet(electron::kRunAsNode)) {
     return ElectronInitializeICUandStartNode(argc, argv);
   }
 #endif

--- a/shell/common/api/features.cc
+++ b/shell/common/api/features.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "electron/buildflags/buildflags.h"
+#include "electron/fuses.h"
 #include "printing/buildflags/buildflags.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_includes.h"
@@ -30,7 +31,7 @@ bool IsPDFViewerEnabled() {
 }
 
 bool IsRunAsNodeEnabled() {
-  return BUILDFLAG(ENABLE_RUN_AS_NODE);
+  return electron::fuses::IsRunAsNodeEnabled() && BUILDFLAG(ENABLE_RUN_AS_NODE);
 }
 
 bool IsFakeLocationProviderEnabled() {

--- a/shell/common/crash_keys.cc
+++ b/shell/common/crash_keys.cc
@@ -14,6 +14,7 @@
 #include "base/strings/string_split.h"
 #include "components/crash/core/common/crash_key.h"
 #include "content/public/common/content_switches.h"
+#include "electron/fuses.h"
 #include "shell/common/electron_constants.h"
 #include "shell/common/options_switches.h"
 #include "third_party/crashpad/crashpad/client/annotation.h"
@@ -100,6 +101,9 @@ void GetCrashKeys(std::map<std::string, std::string>* keys) {
 namespace {
 bool IsRunningAsNode() {
 #if BUILDFLAG(ENABLE_RUN_AS_NODE)
+  if (!electron::fuses::IsRunAsNodeEnabled())
+    return false;
+
   return base::Environment::Create()->HasVar(electron::kRunAsNode);
 #else
   return false;


### PR DESCRIPTION
#### Problem Statement

Certain features or Electron are undesirable for specific deployments / environments and although they can be disabled / not-utilized at the app level certain security models take account for user-level code execution.  E.g. Being able to run electron apps with `ELECTRON_RUN_AS_NODE` and just get a node binary is not-ideal.  We want a way to toggle certain features in a way that both doesn't require app developers to build Electron in-house and ensures that OS level app integrity / code-signing protection (gatekeeper / app-locker) correctly prevent modification of these toggles.

#### Solution: Electron Fuses

Utilizing a known address / section of the app binary we can create a series of "fuses" (toggles) that can be overwritten after Electron has been built into a `.app` / `.exe`.  These can be overwritten by writing raw data to the correct address in the binary.  In order to locate this known address we use a fixed sentinel string that is guaranteed to directly prefix the fuses.

The format of this string is `{sentinel}{fuse_version}{...fuses}`.

This allows packaging tools to find the sentinel, and then know that the next byte is the fuse version and each sequential byte is a fuse.  The `fuse_version` should be used to determine what each fuse is and how many there are.  A handy tool `@electron/fuses` will be built to abstract away most of this complexity for developers.

#### Example use cases

This PR implements one use case (disabling `ELECTRON_RUN_AS_NODE`), other potential use cases which could be implemented in the future using this system.

* Disabling bad flags (`--disable-sandbox`, `--remote-debugging-port`, etc.)
* Disabling the node debugger
* Disable the `app`, `app.asar`, `default_app.asar` load path search and enforce only one of those is ever searched
* Enforce certain webPrefs (E.g. all webContents must have `sandbox`, `contextIsolation`, etc.)
* Other wild stuff that depends on other crazy ideas

#### Implementation Details

Adding a new fuse is as easy as adding a new key to the `fuses.json` file, the fuse implementation is automatically generated as part of the build step so if you add a new `foo_thing_enabled` fuse a new method `electron::fuses::IsFooThingEnabled()` will automatically exist.

#### To Do

* [x] Documentation
* [ ] Build `@electron/fuses` for controlling the fuses at the packaging phase
* [ ] Tests

Notes: Implemented [Electron Fuses](https://example.com) for customizing certain Electron features at package time.