### PR TITLE
docs: update webContents.send link in ipcMain docs

### DIFF
--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -148,4 +148,4 @@ found in the [`ipc-main-invoke-event`](structures/ipc-main-invoke-event.md)
 structure docs.
 
 [event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter
-[web-contents-send]: web-contents.md#contentssendchannel-arg1-arg2-
+[web-contents-send]: web-contents.md#contentssendchannel-args


### PR DESCRIPTION
#### Description of Change
Update the link to https://www.electronjs.org/docs/api/web-contents#contentssendchannel-args.

I guess the parameters changed at some point and we didn't update this link.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: none
