### PR TITLE
fix: use try/catch for base class converter error

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -98,10 +98,15 @@ BaseWindow::BaseWindow(v8::Isolate* isolate,
   window_->AddObserver(this);
 
 #if defined(TOOLKIT_VIEWS)
+  v8::TryCatch try_catch(isolate);
+
   // Sets the window icon.
   gin::Handle<NativeImage> icon;
   if (options.Get(options::kIcon, &icon) && !icon.IsEmpty())
     SetIcon(icon);
+
+  if (try_catch.HasCaught())
+    LOG(ERROR) << "Failed to convert NativeImage";
 #endif
 }
 

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -98,15 +98,14 @@ BaseWindow::BaseWindow(v8::Isolate* isolate,
   window_->AddObserver(this);
 
 #if defined(TOOLKIT_VIEWS)
-  v8::TryCatch try_catch(isolate);
-
-  // Sets the window icon.
-  gin::Handle<NativeImage> icon;
-  if (options.Get(options::kIcon, &icon) && !icon.IsEmpty())
-    SetIcon(icon);
-
-  if (try_catch.HasCaught())
-    LOG(ERROR) << "Failed to convert NativeImage";
+  {
+    v8::TryCatch try_catch(isolate);
+    gin::Handle<NativeImage> icon;
+    if (options.Get(options::kIcon, &icon) && !icon.IsEmpty())
+      SetIcon(icon);
+    if (try_catch.HasCaught())
+      LOG(ERROR) << "Failed to convert NativeImage";
+  }
 #endif
 }
 


### PR DESCRIPTION
#### Description of Change

Even though this worked previously, we shouldn't be throwing errors in converters because they call into JS and therefore can destroy `this` and cause crashes later. This will be followed up with a refactor to remove the exception from the converter and refactor callsites, but for now this PR mitigates the crash.

cc @nornagon @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: none
