### PR TITLE
fix: frameless vibrant modals shouldn't bezel

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1454,7 +1454,7 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
     [effect_view setState:NSVisualEffectStateActive];
 
     // Make frameless Vibrant windows have rounded corners.
-    if (!has_frame()) {
+    if (!has_frame() && !is_modal()) {
       CGFloat radius = 5.0f;  // default corner radius
       CGFloat dimension = 2 * radius + 1;
       NSSize size = NSMakeSize(dimension, dimension);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/24216.

Frameless vibrant windows should only bezel if they're _not_ modals.

Before:
<img width="912" alt="Screen Shot 2020-06-22 at 10 40 39 PM" src="https://user-images.githubusercontent.com/2036040/85365083-76aa5a00-b4d9-11ea-8c04-e0f5fd40cc49.png">

After:
<img width="912" alt="Screen Shot 2020-06-22 at 10 40 53 PM" src="https://user-images.githubusercontent.com/2036040/85365095-7b6f0e00-b4d9-11ea-8fff-106b8ae51b59.png">

cc @MarshallOfSound @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed an issue where frameless modal windows with a vibrancy setting had bezeled corners.
