### PR TITLE
feat: support suspend/resume on Windows

### DIFF
--- a/docs/api/power-monitor.md
+++ b/docs/api/power-monitor.md
@@ -8,11 +8,11 @@ Process: [Main](../glossary.md#main-process)
 
 The `powerMonitor` module emits the following events:
 
-### Event: 'suspend'
+### Event: 'suspend' _Linux_ _Windows_
 
 Emitted when the system is suspending.
 
-### Event: 'resume'
+### Event: 'resume' _Linux_ _Windows_
 
 Emitted when system is resuming.
 

--- a/shell/browser/api/electron_api_power_monitor_win.cc
+++ b/shell/browser/api/electron_api_power_monitor_win.cc
@@ -73,6 +73,12 @@ LRESULT CALLBACK PowerMonitor::WndProc(HWND hwnd,
         Emit("unlock-screen");
       }
     }
+  } else if (message == WM_POWERBROADCAST) {
+    if (wparam == PBT_APMRESUMEAUTOMATIC) {
+      Emit("resume");
+    } else if (wparam == PBT_APMSUSPEND) {
+      Emit("suspend");
+    }
   }
   return ::DefWindowProc(hwnd, message, wparam, lparam);
 }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/24244.

Add support for `suspend` and `resume` on Windows.

cc @zcbenz @MarshallOfSound @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Added support for suspend and resume events to Windows.
