### PR TITLE
chore: minify internal JS code

### DIFF
--- a/build/webpack/webpack.config.base.js
+++ b/build/webpack/webpack.config.base.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 const webpack = require('webpack')
+const TerserPlugin = require('terser-webpack-plugin');
 
 const electronRoot = path.resolve(__dirname, '../..')
 
@@ -77,7 +78,7 @@ module.exports = ({
 
   return ({
     mode: 'development',
-    devtool: 'inline-source-map',
+    devtool: false,
     entry,
     target: alwaysHasNode ? 'node' : 'web',
     output: {
@@ -116,6 +117,17 @@ module.exports = ({
       // We provide our own "timers" import above, any usage of setImmediate inside
       // one of our renderer bundles should import it from the 'timers' package
       setImmediate: false,
+    },
+    optimization: {
+      minimize: true,
+      minimizer: [
+        new TerserPlugin({
+          terserOptions: {
+            keep_classnames: true,
+            keep_fnames: true,
+          },
+        }),
+      ],
     },
     plugins: [
       new AccessDependenciesPlugin(),


### PR DESCRIPTION
This improves boot performance by 40-50ms on my `testing` build.  The raw size of the JS + the overwhelmingly large sourcemap results in the JS script compiler doing far too much work.  If we make it easier for it, unsurprisingly, it gets faster.

There is a trade off here that JS exceptions internal to Electron may be harder to read, but that's reasonable IMO and it's definitely not that hard to read minified JS.  This also removes the sourcemap because it's stupidly big and doesn't work properly anyway.

Notes: no-notes