### PR TITLE
feat: support suspend/resume on macOS

### DIFF
--- a/docs/api/power-monitor.md
+++ b/docs/api/power-monitor.md
@@ -8,11 +8,11 @@ Process: [Main](../glossary.md#main-process)
 
 The `powerMonitor` module emits the following events:
 
-### Event: 'suspend' _Linux_ _Windows_
+### Event: 'suspend'
 
 Emitted when the system is suspending.
 
-### Event: 'resume' _Linux_ _Windows_
+### Event: 'resume'
 
 Emitted when system is resuming.
 

--- a/shell/browser/api/electron_api_power_monitor_mac.mm
+++ b/shell/browser/api/electron_api_power_monitor_mac.mm
@@ -32,6 +32,21 @@
                    selector:@selector(onScreenUnlocked:)
                        name:@"com.apple.screenIsUnlocked"
                      object:nil];
+
+    // A notification that the workspace posts before the machine goes to sleep.
+    [[[NSWorkspace sharedWorkspace] notificationCenter]
+        addObserver:self
+           selector:@selector(isSuspending:)
+               name:NSWorkspaceWillSleepNotification
+             object:nil];
+
+    // A notification that the workspace posts when the machine wakes from
+    // sleep.
+    [[[NSWorkspace sharedWorkspace] notificationCenter]
+        addObserver:self
+           selector:@selector(isResuming:)
+               name:NSWorkspaceDidWakeNotification
+             object:nil];
   }
   return self;
 }
@@ -45,14 +60,26 @@
   self->emitters.push_back(monitor_);
 }
 
+- (void)isSuspending:(NSNotification*)notify {
+  for (auto* emitter : self->emitters) {
+    emitter->Emit("suspend");
+  }
+}
+
+- (void)isResuming:(NSNotification*)notify {
+  for (auto* emitter : self->emitters) {
+    emitter->Emit("resume");
+  }
+}
+
 - (void)onScreenLocked:(NSNotification*)notification {
-  for (auto*& emitter : self->emitters) {
+  for (auto* emitter : self->emitters) {
     emitter->Emit("lock-screen");
   }
 }
 
 - (void)onScreenUnlocked:(NSNotification*)notification {
-  for (auto*& emitter : self->emitters) {
+  for (auto* emitter : self->emitters) {
     emitter->Emit("unlock-screen");
   }
 }


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/24244 and https://github.com/electron/electron/pull/24251.

This adds suspend/resume support to macOS.

cc @deepak1556 @MarshallOfSound @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Added support for suspend and resume events to macOS.
