### PR TITLE
feat: support exclude from capture on Windows

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1702,7 +1702,9 @@ events.
 Prevents the window contents from being captured by other apps.
 
 On macOS it sets the NSWindow's sharingType to NSWindowSharingNone.
-On Windows it calls SetWindowDisplayAffinity with `WDA_MONITOR`.
+On Windows it calls SetWindowDisplayAffinity with `WDA_EXCLUDEFROMCAPTURE`.
+For Windows 10 version 2004 and up the window will be removed from capture entirely,
+older Windows versions behave as if `WDA_MONITOR` is applied capturing a black window.
 
 #### `win.setFocusable(focusable)` _macOS_ _Windows_
 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -971,7 +971,7 @@ void NativeWindowViews::SetIgnoreMouseEvents(bool ignore, bool forward) {
 
 void NativeWindowViews::SetContentProtection(bool enable) {
 #if defined(OS_WIN)
-  DWORD affinity = enable ? WDA_MONITOR : WDA_NONE;
+  DWORD affinity = enable ? WDA_EXCLUDEFROMCAPTURE : WDA_NONE;
   ::SetWindowDisplayAffinity(GetAcceleratedWidget(), affinity);
 #endif
 }


### PR DESCRIPTION
#### Description of Change

This change will allow full window exclusion similar to Mac's current behavior for Windows 10 versions 2004 and later.
Older Windows versions will still show a black window as before, but `WDA_EXCLUDEFROMCAPTURE` simply falls back to `WDA_MONITOR`.

https://github.com/microsoft/Windows.UI.Composition-Win32-Samples/issues/64#issuecomment-697074762

Windows api docs here: https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowdisplayaffinity

https://blogs.windows.com/windowsdeveloper/2019/09/16/new-ways-to-do-screen-capture/


#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Windows 10 versions 2004 and later support `WDA_EXCLUDEFROMCAPTURE` and will now exclude a window entirely from screen capture when `setContentProtection`  is enabled. Older Windows versions will continue to show a black window as before.