### PR TITLE
fix: macOS modal focus behavior

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -284,27 +284,27 @@ void BrowserWindow::OnWindowClosed() {
 
 void BrowserWindow::OnWindowBlur() {
   web_contents()->StoreFocus();
-#if defined(OS_MACOSX)
-  auto* rwhv = web_contents()->GetRenderWidgetHostView();
-  if (rwhv)
-    rwhv->SetActive(false);
-#endif
 
   TopLevelWindow::OnWindowBlur();
 }
 
 void BrowserWindow::OnWindowFocus() {
   web_contents()->RestoreFocus();
-#if defined(OS_MACOSX)
-  auto* rwhv = web_contents()->GetRenderWidgetHostView();
-  if (rwhv)
-    rwhv->SetActive(true);
-#else
+
+#if !defined(OS_MACOSX)
   if (!api_web_contents_->IsDevToolsOpened())
     web_contents()->Focus();
 #endif
 
   TopLevelWindow::OnWindowFocus();
+}
+
+void BrowserWindow::OnWindowIsKeyChanged(bool is_key) {
+#if defined(OS_MACOSX)
+  auto* rwhv = web_contents()->GetRenderWidgetHostView();
+  if (rwhv)
+    rwhv->SetActive(is_key);
+#endif
 }
 
 void BrowserWindow::OnWindowResize() {

--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -66,6 +66,7 @@ class BrowserWindow : public TopLevelWindow,
   // NativeWindowObserver:
   void RequestPreferredWidth(int* width) override;
   void OnCloseButtonClicked(bool* prevent_default) override;
+  void OnWindowIsKeyChanged(bool is_key) override;
 
   // TopLevelWindow:
   void OnWindowClosed() override;

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -439,6 +439,11 @@ void NativeWindow::NotifyWindowFocus() {
     observer.OnWindowFocus();
 }
 
+void NativeWindow::NotifyWindowIsKeyChanged(bool is_key) {
+  for (NativeWindowObserver& observer : observers_)
+    observer.OnWindowIsKeyChanged(is_key);
+}
+
 void NativeWindow::NotifyWindowShow() {
   for (NativeWindowObserver& observer : observers_)
     observer.OnWindowShow();

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -257,6 +257,7 @@ class NativeWindow : public base::SupportsUserData,
   void NotifyWindowBlur();
   void NotifyWindowFocus();
   void NotifyWindowShow();
+  void NotifyWindowIsKeyChanged(bool is_key);
   void NotifyWindowHide();
   void NotifyWindowMaximize();
   void NotifyWindowUnmaximize();

--- a/shell/browser/native_window_observer.h
+++ b/shell/browser/native_window_observer.h
@@ -57,6 +57,9 @@ class NativeWindowObserver : public base::CheckedObserver {
   // Called when window gains focus.
   virtual void OnWindowFocus() {}
 
+  // Called when window gained or lost key window status.
+  virtual void OnWindowIsKeyChanged(bool is_key) {}
+
   // Called when window is shown.
   virtual void OnWindowShow() {}
 

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -97,6 +97,21 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
   shell_->NotifyWindowBlur();
 }
 
+- (void)windowDidBecomeKey:(NSNotification*)notification {
+  shell_->NotifyWindowIsKeyChanged(true);
+}
+
+- (void)windowDidResignKey:(NSNotification*)notification {
+  // If our app is still active and we're still the key window, ignore this
+  // message, since it just means that a menu extra (on the "system status bar")
+  // was activated; we'll get another |-windowDidResignKey| if we ever really
+  // lose key window status.
+  if ([NSApp isActive] && ([NSApp keyWindow] == [notification object]))
+    return;
+
+  shell_->NotifyWindowIsKeyChanged(false);
+}
+
 - (NSSize)windowWillResize:(NSWindow*)sender toSize:(NSSize)frameSize {
   NSSize newSize = frameSize;
   double aspectRatio = shell_->GetAspectRatio();


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/18502.

Refs https://github.com/electron/electron/pull/19128#issuecomment-509439237.

Splits out `SetActive` behavior from `OnWindowFocus/OnWindowBlur` into a new method `OnWindowIsKeyChanged`.

Tested with https://gist.github.com/86396ae26e6462de78dbb9abf38402fd and confirmed not to regress https://github.com/electron/electron/issues/19124.

Before:
<img width="173" alt="Screen Shot 2020-06-24 at 10 21 10 AM" src="https://user-images.githubusercontent.com/2036040/85602667-72c72680-b604-11ea-9fc2-48e787fafa34.png">

After:
<img width="159" alt="Screen Shot 2020-06-24 at 10 19 45 AM" src="https://user-images.githubusercontent.com/2036040/85602563-5aefa280-b604-11ea-8e5d-bb05bde278f6.png">

cc @zcbenz @MarshallOfSound @deepak1556 @erickzhao 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed bug on macOS where the main window could be targeted for a focus event when it was disabled behind a modal.
