### PR TITLE
fix: remove same-tag notifications before showing new ones

### DIFF
--- a/shell/browser/notifications/mac/cocoa_notification.mm
+++ b/shell/browser/notifications/mac/cocoa_notification.mm
@@ -111,8 +111,6 @@ void CocoaNotification::Dismiss() {
 
   NotificationDismissed();
 
-  this->LogAction("dismissed");
-
   notification_.reset(nil);
 }
 
@@ -163,8 +161,9 @@ void CocoaNotification::NotificationDismissed() {
 }
 
 void CocoaNotification::LogAction(const char* action) {
-  if (getenv("ELECTRON_DEBUG_NOTIFICATIONS")) {
+  if (getenv("ELECTRON_DEBUG_NOTIFICATIONS") && notification_) {
     NSString* identifier = [notification_ valueForKey:@"identifier"];
+    DCHECK(identifier);
     LOG(INFO) << "Notification " << action << " (" << [identifier UTF8String]
               << ")";
   }

--- a/shell/browser/notifications/notification_presenter.cc
+++ b/shell/browser/notifications/notification_presenter.cc
@@ -37,8 +37,11 @@ void NotificationPresenter::CloseNotificationWithId(
                          [&notification_id](const Notification* n) {
                            return n->notification_id() == notification_id;
                          });
-  if (it != notifications_.end())
-    (*it)->Dismiss();
+  if (it != notifications_.end()) {
+    Notification* notification = (*it);
+    notification->Dismiss();
+    notifications_.erase(notification);
+  }
 }
 
 }  // namespace electron

--- a/shell/browser/notifications/platform_notification_service.cc
+++ b/shell/browser/notifications/platform_notification_service.cc
@@ -86,8 +86,19 @@ void PlatformNotificationService::DisplayNotification(
   auto* presenter = browser_client_->GetNotificationPresenter();
   if (!presenter)
     return;
+
+  // If a new notification is created with the same tag as an
+  // existing one, replace the old notification with the new one.
+  // The notification_id is generated from the tag, so the only way a
+  // notification will be closed as a result of this call is if one with
+  // the same tag is already extant.
+  //
+  // See: https://notifications.spec.whatwg.org/#showing-a-notification
+  presenter->CloseNotificationWithId(notification_id);
+
   NotificationDelegateImpl* delegate =
       new NotificationDelegateImpl(notification_id);
+
   auto notification = presenter->CreateNotification(delegate, notification_id);
   if (notification) {
     browser_client_->WebNotificationAllowed(


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/24290.

Fixes an issue where notifications where not being closed properly when more than one notification was created in the renderer process with the same tag.

Per spec: https://notifications.spec.whatwg.org/#showing-a-notification

<img width="1128" alt="Screen Shot 2020-07-01 at 9 15 14 PM" src="https://user-images.githubusercontent.com/2036040/86315791-fa51fe00-bbdf-11ea-8fc5-cc371f32b259.png">

Tested with https://gist.github.com/fd16a663434667d2096cd31ec7f2662f.

cc @MarshallOfSound @zcbenz  

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed an issue where some old notifications were not properly removed from the Notification Center on macOS.
