### PR TITLE
test: make sure tests fail properly instead of timing out

### DIFF
--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -209,21 +209,17 @@ describe('app module', () => {
   });
 
   describe('app.requestSingleInstanceLock', () => {
-    it('prevents the second launch of app', function (done) {
+    it('prevents the second launch of app', async function () {
       this.timeout(120000);
       const appPath = path.join(fixturesPath, 'api', 'singleton');
       const first = cp.spawn(process.execPath, [appPath]);
-      first.once('exit', code => {
-        expect(code).to.equal(0);
-      });
+      await emittedOnce(first.stdout, 'data');
       // Start second app when received output.
-      first.stdout.once('data', () => {
-        const second = cp.spawn(process.execPath, [appPath]);
-        second.once('exit', code => {
-          expect(code).to.equal(1);
-          done();
-        });
-      });
+      const second = cp.spawn(process.execPath, [appPath]);
+      const [code2] = await emittedOnce(second, 'exit');
+      expect(code2).to.equal(1);
+      const [code1] = await emittedOnce(first, 'exit');
+      expect(code1).to.equal(0);
     });
 
     it('passes arguments to the second-instance event', async () => {
@@ -986,34 +982,28 @@ describe('app module', () => {
       }
     });
 
-    it('does not launch for argument following a URL', done => {
+    it('does not launch for argument following a URL', async () => {
       const appPath = path.join(fixturesPath, 'api', 'quit-app');
       // App should exit with non 123 code.
       const first = cp.spawn(process.execPath, [appPath, 'electron-test:?', 'abc']);
-      first.once('exit', code => {
-        expect(code).to.not.equal(123);
-        done();
-      });
+      const [code] = await emittedOnce(first, 'exit');
+      expect(code).to.not.equal(123);
     });
 
-    it('launches successfully for argument following a file path', done => {
+    it('launches successfully for argument following a file path', async () => {
       const appPath = path.join(fixturesPath, 'api', 'quit-app');
       // App should exit with code 123.
       const first = cp.spawn(process.execPath, [appPath, 'e:\\abc', 'abc']);
-      first.once('exit', code => {
-        expect(code).to.equal(123);
-        done();
-      });
+      const [code] = await emittedOnce(first, 'exit');
+      expect(code).to.equal(123);
     });
 
-    it('launches successfully for multiple URIs following --', done => {
+    it('launches successfully for multiple URIs following --', async () => {
       const appPath = path.join(fixturesPath, 'api', 'quit-app');
       // App should exit with code 123.
       const first = cp.spawn(process.execPath, [appPath, '--', 'http://electronjs.org', 'electron-test://testdata']);
-      first.once('exit', code => {
-        expect(code).to.equal(123);
-        done();
-      });
+      const [code] = await emittedOnce(first, 'exit');
+      expect(code).to.equal(123);
     });
   });
 

--- a/spec-main/api-browser-view-spec.ts
+++ b/spec-main/api-browser-view-spec.ts
@@ -233,17 +233,16 @@ describe('BrowserView module', () => {
   });
 
   describe('window.open()', () => {
-    it('works in BrowserView', (done) => {
+    it('works in BrowserView', async () => {
       view = new BrowserView();
       w.setBrowserView(view);
-      view.webContents.once('new-window', (e, url, frameName, disposition, options, additionalFeatures) => {
-        e.preventDefault();
-        expect(url).to.equal('http://host/');
-        expect(frameName).to.equal('host');
-        expect(additionalFeatures[0]).to.equal('this-is-not-a-standard-feature');
-        done();
-      });
+      const newWindow = emittedOnce(view.webContents, 'new-window');
+      view.webContents.once('new-window', event => event.preventDefault());
       view.webContents.loadFile(path.join(fixtures, 'pages', 'window-open.html'));
+      const [, url, frameName,,, additionalFeatures] = await newWindow;
+      expect(url).to.equal('http://host/');
+      expect(frameName).to.equal('host');
+      expect(additionalFeatures[0]).to.equal('this-is-not-a-standard-feature');
     });
   });
 });

--- a/spec-main/api-debugger-spec.ts
+++ b/spec-main/api-debugger-spec.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { AddressInfo } from 'net';
 import { BrowserWindow } from 'electron/main';
 import { closeAllWindows } from './window-helpers';
-import { emittedOnce } from './events-helpers';
+import { emittedOnce, emittedUntil } from './events-helpers';
 
 describe('debugger module', () => {
   const fixtures = path.resolve(__dirname, '..', 'spec', 'fixtures');
@@ -21,18 +21,11 @@ describe('debugger module', () => {
   afterEach(closeAllWindows);
 
   describe('debugger.attach', () => {
-    it('succeeds when devtools is already open', done => {
-      w.webContents.on('did-finish-load', () => {
-        w.webContents.openDevTools();
-        try {
-          w.webContents.debugger.attach();
-        } catch (err) {
-          done(`unexpected error : ${err}`);
-        }
-        expect(w.webContents.debugger.isAttached()).to.be.true();
-        done();
-      });
-      w.webContents.loadURL('about:blank');
+    it('succeeds when devtools is already open', async () => {
+      await w.webContents.loadURL('about:blank');
+      w.webContents.openDevTools();
+      w.webContents.debugger.attach();
+      expect(w.webContents.debugger.isAttached()).to.be.true();
     });
 
     it('fails when protocol version is not supported', done => {
@@ -44,49 +37,33 @@ describe('debugger module', () => {
       }
     });
 
-    it('attaches when no protocol version is specified', done => {
-      try {
-        w.webContents.debugger.attach();
-      } catch (err) {
-        done(`unexpected error : ${err}`);
-      }
+    it('attaches when no protocol version is specified', async () => {
+      w.webContents.debugger.attach();
       expect(w.webContents.debugger.isAttached()).to.be.true();
-      done();
     });
   });
 
   describe('debugger.detach', () => {
-    it('fires detach event', (done) => {
-      w.webContents.debugger.on('detach', (e, reason) => {
-        expect(reason).to.equal('target closed');
-        expect(w.webContents.debugger.isAttached()).to.be.false();
-        done();
-      });
-
-      try {
-        w.webContents.debugger.attach();
-      } catch (err) {
-        done(`unexpected error : ${err}`);
-      }
+    it('fires detach event', async () => {
+      const detach = emittedOnce(w.webContents.debugger, 'detach');
+      w.webContents.debugger.attach();
       w.webContents.debugger.detach();
+      const [, reason] = await detach;
+      expect(reason).to.equal('target closed');
+      expect(w.webContents.debugger.isAttached()).to.be.false();
     });
 
-    it('doesn\'t disconnect an active devtools session', done => {
+    it('doesn\'t disconnect an active devtools session', async () => {
       w.webContents.loadURL('about:blank');
-      try {
-        w.webContents.debugger.attach();
-      } catch (err) {
-        return done(`unexpected error : ${err}`);
-      }
+      const detach = emittedOnce(w.webContents.debugger, 'detach');
+      w.webContents.debugger.attach();
       w.webContents.openDevTools();
       w.webContents.once('devtools-opened', () => {
         w.webContents.debugger.detach();
       });
-      w.webContents.debugger.on('detach', () => {
-        expect(w.webContents.debugger.isAttached()).to.be.false();
-        expect((w as any).devToolsWebContents.isDestroyed()).to.be.false();
-        done();
-      });
+      await detach;
+      expect(w.webContents.debugger.isAttached()).to.be.false();
+      expect((w as any).devToolsWebContents.isDestroyed()).to.be.false();
     });
   });
 
@@ -130,33 +107,20 @@ describe('debugger module', () => {
       w.webContents.debugger.detach();
     });
 
-    it('fires message event', done => {
+    it('fires message event', async () => {
       const url = process.platform !== 'win32'
         ? `file://${path.join(fixtures, 'pages', 'a.html')}`
         : `file:///${path.join(fixtures, 'pages', 'a.html').replace(/\\/g, '/')}`;
       w.webContents.loadURL(url);
-
-      try {
-        w.webContents.debugger.attach();
-      } catch (err) {
-        done(`unexpected error : ${err}`);
-      }
-
-      w.webContents.debugger.on('message', (e, method, params) => {
-        if (method === 'Console.messageAdded') {
-          try {
-            expect(params.message.level).to.equal('log');
-            expect(params.message.url).to.equal(url);
-            expect(params.message.text).to.equal('a');
-            done();
-          } catch (e) {
-            done(e);
-          } finally {
-            w.webContents.debugger.detach();
-          }
-        }
-      });
+      w.webContents.debugger.attach();
+      const message = emittedUntil(w.webContents.debugger, 'message',
+        (event: Electron.Event, method: string) => method === 'Console.messageAdded');
       w.webContents.debugger.sendCommand('Console.enable');
+      const [,, params] = await message;
+      w.webContents.debugger.detach();
+      expect((params as any).message.level).to.equal('log');
+      expect((params as any).message.url).to.equal(url);
+      expect((params as any).message.text).to.equal('a');
     });
 
     it('returns error message when command fails', async () => {

--- a/spec-main/api-menu-item-spec.ts
+++ b/spec-main/api-menu-item-spec.ts
@@ -43,9 +43,13 @@ describe('MenuItems', () => {
       const menu = Menu.buildFromTemplate([{
         label: 'text',
         click: (item) => {
-          expect(item.constructor.name).to.equal('MenuItem');
-          expect(item.label).to.equal('text');
-          done();
+          try {
+            expect(item.constructor.name).to.equal('MenuItem');
+            expect(item.label).to.equal('text');
+            done();
+          } catch (e) {
+            done(e);
+          }
         }
       }]);
       menu._executeCommand({}, menu.items[0].commandId);

--- a/spec-main/api-protocol-spec.ts
+++ b/spec-main/api-protocol-spec.ts
@@ -305,8 +305,12 @@ describe('protocol module', () => {
 
     it('can access request headers', (done) => {
       protocol.registerHttpProtocol(protocolName, (request) => {
-        expect(request).to.have.property('headers');
-        done();
+        try {
+          expect(request).to.have.property('headers');
+          done();
+        } catch (e) {
+          done(e);
+        }
       });
       ajax(protocolName + '://fake-host');
     });
@@ -597,8 +601,12 @@ describe('protocol module', () => {
 
     it('can access request headers', (done) => {
       protocol.interceptHttpProtocol('http', (request) => {
-        expect(request).to.have.property('headers');
-        done();
+        try {
+          expect(request).to.have.property('headers');
+          done();
+        } catch (e) {
+          done(e);
+        }
       });
       ajax('http://fake-host');
     });

--- a/spec-main/api-remote-spec.ts
+++ b/spec-main/api-remote-spec.ts
@@ -344,7 +344,7 @@ ifdescribe(features.isRemoteModuleEnabled())('remote module', () => {
   });
 
   describe('remote objects registry', () => {
-    it('does not dereference until the render view is deleted (regression)', (done) => {
+    it('does not dereference until the render view is deleted (regression)', async () => {
       const w = new BrowserWindow({
         show: false,
         webPreferences: {
@@ -353,12 +353,10 @@ ifdescribe(features.isRemoteModuleEnabled())('remote module', () => {
         }
       });
 
-      ipcMain.once('error-message', (event, message) => {
-        expect(message).to.match(/^Cannot call method 'getURL' on missing remote object/);
-        done();
-      });
-
+      const message = emittedOnce(ipcMain, 'error-message');
       w.loadFile(path.join(fixtures, 'api', 'render-view-deleted.html'));
+      const [, msg] = await message;
+      expect(msg).to.match(/^Cannot call method 'getURL' on missing remote object/);
     });
   });
 

--- a/spec-main/api-session-spec.ts
+++ b/spec-main/api-session-spec.ts
@@ -423,15 +423,23 @@ describe('session module', () => {
                        </html>`;
 
       protocol.registerStringProtocol(scheme, (request, callback) => {
-        if (request.method === 'GET') {
-          callback({ data: content, mimeType: 'text/html' });
-        } else if (request.method === 'POST') {
-          const uuid = request.uploadData![1].blobUUID;
-          expect(uuid).to.be.a('string');
-          session.defaultSession.getBlobData(uuid!).then(result => {
-            expect(result.toString()).to.equal(postData);
-            done();
-          });
+        try {
+          if (request.method === 'GET') {
+            callback({ data: content, mimeType: 'text/html' });
+          } else if (request.method === 'POST') {
+            const uuid = request.uploadData![1].blobUUID;
+            expect(uuid).to.be.a('string');
+            session.defaultSession.getBlobData(uuid!).then(result => {
+              try {
+                expect(result.toString()).to.equal(postData);
+                done();
+              } catch (e) {
+                done(e);
+              }
+            });
+          }
+        } catch (e) {
+          done(e);
         }
       });
       const w = new BrowserWindow({ show: false });
@@ -618,8 +626,12 @@ describe('session module', () => {
       session.defaultSession.once('will-download', function (e, item) {
         item.savePath = downloadFilePath;
         item.on('done', function (e, state) {
-          assertDownload(state, item);
-          done();
+          try {
+            assertDownload(state, item);
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
       session.defaultSession.downloadURL(`${url}:${port}`);
@@ -631,8 +643,12 @@ describe('session module', () => {
       w.webContents.session.once('will-download', function (e, item) {
         item.savePath = downloadFilePath;
         item.on('done', function (e, state) {
-          assertDownload(state, item);
-          done();
+          try {
+            assertDownload(state, item);
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
       w.webContents.downloadURL(`${url}:${port}`);
@@ -649,8 +665,12 @@ describe('session module', () => {
       w.webContents.session.once('will-download', function (e, item) {
         item.savePath = downloadFilePath;
         item.on('done', function (e, state) {
-          assertDownload(state, item, true);
-          done();
+          try {
+            assertDownload(state, item, true);
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
       w.webContents.downloadURL(`${protocolName}://item`);
@@ -687,13 +707,17 @@ describe('session module', () => {
       w.webContents.session.once('will-download', function (e, item) {
         item.savePath = downloadFilePath;
         item.on('done', function (e, state) {
-          expect(state).to.equal('cancelled');
-          expect(item.getFilename()).to.equal('mock.pdf');
-          expect(item.getMimeType()).to.equal('application/pdf');
-          expect(item.getReceivedBytes()).to.equal(0);
-          expect(item.getTotalBytes()).to.equal(mockPDF.length);
-          expect(item.getContentDisposition()).to.equal(contentDisposition);
-          done();
+          try {
+            expect(state).to.equal('cancelled');
+            expect(item.getFilename()).to.equal('mock.pdf');
+            expect(item.getMimeType()).to.equal('application/pdf');
+            expect(item.getReceivedBytes()).to.equal(0);
+            expect(item.getTotalBytes()).to.equal(mockPDF.length);
+            expect(item.getContentDisposition()).to.equal(contentDisposition);
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
         item.cancel();
       });
@@ -712,8 +736,12 @@ describe('session module', () => {
       w.webContents.session.once('will-download', function (e, item) {
         item.savePath = downloadFilePath;
         item.on('done', function () {
-          expect(item.getFilename()).to.equal('download.pdf');
-          done();
+          try {
+            expect(item.getFilename()).to.equal('download.pdf');
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
         item.cancel();
       });
@@ -744,8 +772,12 @@ describe('session module', () => {
         item.setSavePath(filePath);
         item.setSaveDialogOptions(options);
         item.on('done', function () {
-          expect(item.getSaveDialogOptions()).to.deep.equal(options);
-          done();
+          try {
+            expect(item.getSaveDialogOptions()).to.deep.equal(options);
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
         item.cancel();
       });
@@ -761,8 +793,12 @@ describe('session module', () => {
             item.resume();
           }
           item.on('done', function (e, state) {
-            expect(state).to.equal('interrupted');
-            done();
+            try {
+              expect(state).to.equal('interrupted');
+              done();
+            } catch (e) {
+              done(e);
+            }
           });
         });
         w.webContents.downloadURL(`file://${path.join(__dirname, 'does-not-exist.txt')}`);

--- a/spec-main/modules-spec.ts
+++ b/spec-main/modules-spec.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import { BrowserWindow } from 'electron/main';
 import { ifdescribe, ifit } from './spec-helpers';
 import { closeAllWindows } from './window-helpers';
+import { emittedOnce } from './events-helpers';
 import * as childProcess from 'child_process';
 
 const Module = require('module');
@@ -23,12 +24,10 @@ describe('modules support', () => {
         await expect(w.webContents.executeJavaScript('{ require(\'echo\'); null }')).to.be.fulfilled();
       });
 
-      ifit(features.isRunAsNodeEnabled())('can be required in node binary', function (done) {
+      ifit(features.isRunAsNodeEnabled())('can be required in node binary', async function () {
         const child = childProcess.fork(path.join(fixtures, 'module', 'echo.js'));
-        child.on('message', (msg) => {
-          expect(msg).to.equal('ok');
-          done();
-        });
+        const [msg] = await emittedOnce(child, 'message');
+        expect(msg).to.equal('ok');
       });
 
       ifit(process.platform === 'win32')('can be required if electron.exe is renamed', () => {

--- a/spec/api-web-frame-spec.js
+++ b/spec/api-web-frame-spec.js
@@ -39,70 +39,51 @@ describe('webFrame module', function () {
       childFrameElement.remove();
     });
 
-    it('executeJavaScript() yields results via a promise and a sync callback', done => {
+    it('executeJavaScript() yields results via a promise and a sync callback', async () => {
       let callbackResult, callbackError;
 
-      childFrame
+      const executeJavaScript = childFrame
         .executeJavaScript('1 + 1', (result, error) => {
           callbackResult = result;
           callbackError = error;
-        })
-        .then(
-          promiseResult => {
-            expect(promiseResult).to.equal(2);
-            done();
-          },
-          promiseError => {
-            done(promiseError);
-          }
-        );
+        });
 
       expect(callbackResult).to.equal(2);
       expect(callbackError).to.be.undefined();
+
+      const promiseResult = await executeJavaScript;
+      expect(promiseResult).to.equal(2);
     });
 
-    it('executeJavaScriptInIsolatedWorld() yields results via a promise and a sync callback', done => {
+    it('executeJavaScriptInIsolatedWorld() yields results via a promise and a sync callback', async () => {
       let callbackResult, callbackError;
 
-      childFrame
+      const executeJavaScriptInIsolatedWorld = childFrame
         .executeJavaScriptInIsolatedWorld(999, [{ code: '1 + 1' }], (result, error) => {
           callbackResult = result;
           callbackError = error;
-        })
-        .then(
-          promiseResult => {
-            expect(promiseResult).to.equal(2);
-            done();
-          },
-          promiseError => {
-            done(promiseError);
-          }
-        );
+        });
 
       expect(callbackResult).to.equal(2);
       expect(callbackError).to.be.undefined();
+
+      const promiseResult = await executeJavaScriptInIsolatedWorld;
+      expect(promiseResult).to.equal(2);
     });
 
-    it('executeJavaScript() yields errors via a promise and a sync callback', done => {
+    it('executeJavaScript() yields errors via a promise and a sync callback', async () => {
       let callbackResult, callbackError;
 
-      childFrame
+      const executeJavaScript = childFrame
         .executeJavaScript('thisShouldProduceAnError()', (result, error) => {
           callbackResult = result;
           callbackError = error;
-        })
-        .then(
-          promiseResult => {
-            done(new Error('error is expected'));
-          },
-          promiseError => {
-            expect(promiseError).to.be.an('error');
-            done();
-          }
-        );
+        });
 
       expect(callbackResult).to.be.undefined();
       expect(callbackError).to.be.an('error');
+
+      await expect(executeJavaScript).to.eventually.be.rejected('error is expected');
     });
 
     // executeJavaScriptInIsolatedWorld is failing to detect exec errors and is neither
@@ -113,23 +94,16 @@ describe('webFrame module', function () {
     // it('executeJavaScriptInIsolatedWorld() yields errors via a promise and a sync callback', done => {
     //   let callbackResult, callbackError
     //
-    //   childFrame
+    //   const executeJavaScriptInIsolatedWorld = childFrame
     //     .executeJavaScriptInIsolatedWorld(999, [{ code: 'thisShouldProduceAnError()' }], (result, error) => {
     //       callbackResult = result
     //       callbackError = error
-    //     })
-    //     .then(
-    //       promiseResult => {
-    //         done(new Error('error is expected'))
-    //       },
-    //       promiseError => {
-    //         expect(promiseError).to.be.an('error')
-    //         done()
-    //       }
-    //     )
+    //     });
     //
     //   expect(callbackResult).to.be.undefined()
     //   expect(callbackError).to.be.an('error')
+    //
+    //   expect(executeJavaScriptInIsolatedWorld).to.eventually.be.rejected('error is expected');
     // })
 
     it('executeJavaScript(InIsolatedWorld) can be used without a callback', async () => {

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -4,6 +4,8 @@ const fs = require('fs');
 const path = require('path');
 const temp = require('temp').track();
 const util = require('util');
+const { emittedOnce } = require('./events-helpers');
+const { ifit } = require('./spec-helpers');
 const nativeImage = require('electron').nativeImage;
 
 const features = process._linkedBinding('electron_common_features');
@@ -99,53 +101,77 @@ describe('asar package', function () {
       it('reads a normal file', function (done) {
         const p = path.join(asarDir, 'a.asar', 'file1');
         fs.readFile(p, function (err, content) {
-          expect(err).to.be.null();
-          expect(String(content).trim()).to.equal('file1');
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(String(content).trim()).to.equal('file1');
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
       it('reads from a empty file', function (done) {
         const p = path.join(asarDir, 'empty.asar', 'file1');
         fs.readFile(p, function (err, content) {
-          expect(err).to.be.null();
-          expect(String(content)).to.equal('');
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(String(content)).to.equal('');
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
       it('reads from a empty file with encoding', function (done) {
         const p = path.join(asarDir, 'empty.asar', 'file1');
         fs.readFile(p, 'utf8', function (err, content) {
-          expect(err).to.be.null();
-          expect(content).to.equal('');
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(content).to.equal('');
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
       it('reads a linked file', function (done) {
         const p = path.join(asarDir, 'a.asar', 'link1');
         fs.readFile(p, function (err, content) {
-          expect(err).to.be.null();
-          expect(String(content).trim()).to.equal('file1');
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(String(content).trim()).to.equal('file1');
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
       it('reads a file from linked directory', function (done) {
         const p = path.join(asarDir, 'a.asar', 'link2', 'link2', 'file1');
         fs.readFile(p, function (err, content) {
-          expect(err).to.be.null();
-          expect(String(content).trim()).to.equal('file1');
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(String(content).trim()).to.equal('file1');
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
       it('throws ENOENT error when can not find file', function (done) {
         const p = path.join(asarDir, 'a.asar', 'not-exist');
         fs.readFile(p, function (err) {
-          expect(err.code).to.equal('ENOENT');
-          done();
+          try {
+            expect(err.code).to.equal('ENOENT');
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
     });
@@ -192,9 +218,13 @@ describe('asar package', function () {
         const p = path.join(asarDir, 'a.asar', 'file1');
         const dest = temp.path();
         fs.copyFile(p, dest, function (err) {
-          expect(err).to.be.null();
-          expect(fs.readFileSync(p).equals(fs.readFileSync(dest))).to.be.true();
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(fs.readFileSync(p).equals(fs.readFileSync(dest))).to.be.true();
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
@@ -202,9 +232,13 @@ describe('asar package', function () {
         const p = path.join(asarDir, 'unpack.asar', 'a.txt');
         const dest = temp.path();
         fs.copyFile(p, dest, function (err) {
-          expect(err).to.be.null();
-          expect(fs.readFileSync(p).equals(fs.readFileSync(dest))).to.be.true();
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(fs.readFileSync(p).equals(fs.readFileSync(dest))).to.be.true();
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
     });
@@ -339,80 +373,108 @@ describe('asar package', function () {
       it('returns information of root', function (done) {
         const p = path.join(asarDir, 'a.asar');
         fs.lstat(p, function (err, stats) {
-          expect(err).to.be.null();
-          expect(stats.isFile()).to.be.false();
-          expect(stats.isDirectory()).to.be.true();
-          expect(stats.isSymbolicLink()).to.be.false();
-          expect(stats.size).to.equal(0);
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(stats.isFile()).to.be.false();
+            expect(stats.isDirectory()).to.be.true();
+            expect(stats.isSymbolicLink()).to.be.false();
+            expect(stats.size).to.equal(0);
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
       it('returns information of root with stats as bigint', function (done) {
         const p = path.join(asarDir, 'a.asar');
         fs.lstat(p, { bigint: false }, function (err, stats) {
-          expect(err).to.be.null();
-          expect(stats.isFile()).to.be.false();
-          expect(stats.isDirectory()).to.be.true();
-          expect(stats.isSymbolicLink()).to.be.false();
-          expect(stats.size).to.equal(0);
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(stats.isFile()).to.be.false();
+            expect(stats.isDirectory()).to.be.true();
+            expect(stats.isSymbolicLink()).to.be.false();
+            expect(stats.size).to.equal(0);
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
       it('returns information of a normal file', function (done) {
         const p = path.join(asarDir, 'a.asar', 'link2', 'file1');
         fs.lstat(p, function (err, stats) {
-          expect(err).to.be.null();
-          expect(stats.isFile()).to.be.true();
-          expect(stats.isDirectory()).to.be.false();
-          expect(stats.isSymbolicLink()).to.be.false();
-          expect(stats.size).to.equal(6);
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(stats.isFile()).to.be.true();
+            expect(stats.isDirectory()).to.be.false();
+            expect(stats.isSymbolicLink()).to.be.false();
+            expect(stats.size).to.equal(6);
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
       it('returns information of a normal directory', function (done) {
         const p = path.join(asarDir, 'a.asar', 'dir1');
         fs.lstat(p, function (err, stats) {
-          expect(err).to.be.null();
-          expect(stats.isFile()).to.be.false();
-          expect(stats.isDirectory()).to.be.true();
-          expect(stats.isSymbolicLink()).to.be.false();
-          expect(stats.size).to.equal(0);
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(stats.isFile()).to.be.false();
+            expect(stats.isDirectory()).to.be.true();
+            expect(stats.isSymbolicLink()).to.be.false();
+            expect(stats.size).to.equal(0);
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
       it('returns information of a linked file', function (done) {
         const p = path.join(asarDir, 'a.asar', 'link2', 'link1');
         fs.lstat(p, function (err, stats) {
-          expect(err).to.be.null();
-          expect(stats.isFile()).to.be.false();
-          expect(stats.isDirectory()).to.be.false();
-          expect(stats.isSymbolicLink()).to.be.true();
-          expect(stats.size).to.equal(0);
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(stats.isFile()).to.be.false();
+            expect(stats.isDirectory()).to.be.false();
+            expect(stats.isSymbolicLink()).to.be.true();
+            expect(stats.size).to.equal(0);
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
       it('returns information of a linked directory', function (done) {
         const p = path.join(asarDir, 'a.asar', 'link2', 'link2');
         fs.lstat(p, function (err, stats) {
-          expect(err).to.be.null();
-          expect(stats.isFile()).to.be.false();
-          expect(stats.isDirectory()).to.be.false();
-          expect(stats.isSymbolicLink()).to.be.true();
-          expect(stats.size).to.equal(0);
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(stats.isFile()).to.be.false();
+            expect(stats.isDirectory()).to.be.false();
+            expect(stats.isSymbolicLink()).to.be.true();
+            expect(stats.size).to.equal(0);
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
       it('throws ENOENT error when can not find file', function (done) {
         const p = path.join(asarDir, 'a.asar', 'file4');
         fs.lstat(p, function (err) {
-          expect(err.code).to.equal('ENOENT');
-          done();
+          try {
+            expect(err.code).to.equal('ENOENT');
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
     });
@@ -592,9 +654,13 @@ describe('asar package', function () {
         const parent = fs.realpathSync(asarDir);
         const p = 'a.asar';
         fs.realpath(path.join(parent, p), (err, r) => {
-          expect(err).to.be.null();
-          expect(r).to.equal(path.join(parent, p));
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(r).to.equal(path.join(parent, p));
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
@@ -602,9 +668,13 @@ describe('asar package', function () {
         const parent = fs.realpathSync(asarDir);
         const p = path.join('a.asar', 'file1');
         fs.realpath(path.join(parent, p), (err, r) => {
-          expect(err).to.be.null();
-          expect(r).to.equal(path.join(parent, p));
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(r).to.equal(path.join(parent, p));
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
@@ -612,9 +682,13 @@ describe('asar package', function () {
         const parent = fs.realpathSync(asarDir);
         const p = path.join('a.asar', 'dir1');
         fs.realpath(path.join(parent, p), (err, r) => {
-          expect(err).to.be.null();
-          expect(r).to.equal(path.join(parent, p));
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(r).to.equal(path.join(parent, p));
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
@@ -622,9 +696,13 @@ describe('asar package', function () {
         const parent = fs.realpathSync(asarDir);
         const p = path.join('a.asar', 'link2', 'link1');
         fs.realpath(path.join(parent, p), (err, r) => {
-          expect(err).to.be.null();
-          expect(r).to.equal(path.join(parent, 'a.asar', 'file1'));
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(r).to.equal(path.join(parent, 'a.asar', 'file1'));
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
@@ -632,9 +710,13 @@ describe('asar package', function () {
         const parent = fs.realpathSync(asarDir);
         const p = path.join('a.asar', 'link2', 'link2');
         fs.realpath(path.join(parent, p), (err, r) => {
-          expect(err).to.be.null();
-          expect(r).to.equal(path.join(parent, 'a.asar', 'dir1'));
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(r).to.equal(path.join(parent, 'a.asar', 'dir1'));
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
@@ -642,9 +724,13 @@ describe('asar package', function () {
         const parent = fs.realpathSync(asarDir);
         const p = path.join('unpack.asar', 'a.txt');
         fs.realpath(path.join(parent, p), (err, r) => {
-          expect(err).to.be.null();
-          expect(r).to.equal(path.join(parent, p));
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(r).to.equal(path.join(parent, p));
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
@@ -652,8 +738,12 @@ describe('asar package', function () {
         const parent = fs.realpathSync(asarDir);
         const p = path.join('a.asar', 'not-exist');
         fs.realpath(path.join(parent, p), err => {
-          expect(err.code).to.equal('ENOENT');
-          done();
+          try {
+            expect(err.code).to.equal('ENOENT');
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
     });
@@ -713,9 +803,13 @@ describe('asar package', function () {
         const parent = fs.realpathSync.native(asarDir);
         const p = 'a.asar';
         fs.realpath.native(path.join(parent, p), (err, r) => {
-          expect(err).to.be.null();
-          expect(r).to.equal(path.join(parent, p));
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(r).to.equal(path.join(parent, p));
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
@@ -723,9 +817,13 @@ describe('asar package', function () {
         const parent = fs.realpathSync.native(asarDir);
         const p = path.join('a.asar', 'file1');
         fs.realpath.native(path.join(parent, p), (err, r) => {
-          expect(err).to.be.null();
-          expect(r).to.equal(path.join(parent, p));
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(r).to.equal(path.join(parent, p));
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
@@ -733,9 +831,13 @@ describe('asar package', function () {
         const parent = fs.realpathSync.native(asarDir);
         const p = path.join('a.asar', 'dir1');
         fs.realpath.native(path.join(parent, p), (err, r) => {
-          expect(err).to.be.null();
-          expect(r).to.equal(path.join(parent, p));
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(r).to.equal(path.join(parent, p));
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
@@ -743,9 +845,13 @@ describe('asar package', function () {
         const parent = fs.realpathSync.native(asarDir);
         const p = path.join('a.asar', 'link2', 'link1');
         fs.realpath.native(path.join(parent, p), (err, r) => {
-          expect(err).to.be.null();
-          expect(r).to.equal(path.join(parent, 'a.asar', 'file1'));
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(r).to.equal(path.join(parent, 'a.asar', 'file1'));
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
@@ -753,9 +859,13 @@ describe('asar package', function () {
         const parent = fs.realpathSync.native(asarDir);
         const p = path.join('a.asar', 'link2', 'link2');
         fs.realpath.native(path.join(parent, p), (err, r) => {
-          expect(err).to.be.null();
-          expect(r).to.equal(path.join(parent, 'a.asar', 'dir1'));
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(r).to.equal(path.join(parent, 'a.asar', 'dir1'));
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
@@ -763,9 +873,13 @@ describe('asar package', function () {
         const parent = fs.realpathSync.native(asarDir);
         const p = path.join('unpack.asar', 'a.txt');
         fs.realpath.native(path.join(parent, p), (err, r) => {
-          expect(err).to.be.null();
-          expect(r).to.equal(path.join(parent, p));
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(r).to.equal(path.join(parent, p));
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
@@ -773,8 +887,12 @@ describe('asar package', function () {
         const parent = fs.realpathSync.native(asarDir);
         const p = path.join('a.asar', 'not-exist');
         fs.realpath.native(path.join(parent, p), err => {
-          expect(err.code).to.equal('ENOENT');
-          done();
+          try {
+            expect(err.code).to.equal('ENOENT');
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
     });
@@ -820,9 +938,13 @@ describe('asar package', function () {
       it('reads dirs from root', function (done) {
         const p = path.join(asarDir, 'a.asar');
         fs.readdir(p, function (err, dirs) {
-          expect(err).to.be.null();
-          expect(dirs).to.deep.equal(['dir1', 'dir2', 'dir3', 'file1', 'file2', 'file3', 'link1', 'link2', 'ping.js']);
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(dirs).to.deep.equal(['dir1', 'dir2', 'dir3', 'file1', 'file2', 'file3', 'link1', 'link2', 'ping.js']);
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
@@ -830,40 +952,56 @@ describe('asar package', function () {
         const p = path.join(asarDir, 'a.asar');
 
         fs.readdir(p, { withFileTypes: true }, (err, dirs) => {
-          expect(err).to.be.null();
-          for (const dir of dirs) {
-            expect(dir instanceof fs.Dirent).to.be.true();
-          }
+          try {
+            expect(err).to.be.null();
+            for (const dir of dirs) {
+              expect(dir instanceof fs.Dirent).to.be.true();
+            }
 
-          const names = dirs.map(a => a.name);
-          expect(names).to.deep.equal(['dir1', 'dir2', 'dir3', 'file1', 'file2', 'file3', 'link1', 'link2', 'ping.js']);
-          done();
+            const names = dirs.map(a => a.name);
+            expect(names).to.deep.equal(['dir1', 'dir2', 'dir3', 'file1', 'file2', 'file3', 'link1', 'link2', 'ping.js']);
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
       it('reads dirs from a normal dir', function (done) {
         const p = path.join(asarDir, 'a.asar', 'dir1');
         fs.readdir(p, function (err, dirs) {
-          expect(err).to.be.null();
-          expect(dirs).to.deep.equal(['file1', 'file2', 'file3', 'link1', 'link2']);
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(dirs).to.deep.equal(['file1', 'file2', 'file3', 'link1', 'link2']);
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
       it('reads dirs from a linked dir', function (done) {
         const p = path.join(asarDir, 'a.asar', 'link2', 'link2');
         fs.readdir(p, function (err, dirs) {
-          expect(err).to.be.null();
-          expect(dirs).to.deep.equal(['file1', 'file2', 'file3', 'link1', 'link2']);
-          done();
+          try {
+            expect(err).to.be.null();
+            expect(dirs).to.deep.equal(['file1', 'file2', 'file3', 'link1', 'link2']);
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
       it('throws ENOENT error when can not find file', function (done) {
         const p = path.join(asarDir, 'a.asar', 'not-exist');
         fs.readdir(p, function (err) {
-          expect(err.code).to.equal('ENOENT');
-          done();
+          try {
+            expect(err.code).to.equal('ENOENT');
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
     });
@@ -942,8 +1080,12 @@ describe('asar package', function () {
       it('throws ENOENT error when can not find file', function (done) {
         const p = path.join(asarDir, 'a.asar', 'not-exist');
         fs.open(p, 'r', function (err) {
-          expect(err.code).to.equal('ENOENT');
-          done();
+          try {
+            expect(err.code).to.equal('ENOENT');
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
     });
@@ -968,8 +1110,12 @@ describe('asar package', function () {
       it('throws error when calling inside asar archive', function (done) {
         const p = path.join(asarDir, 'a.asar', 'not-exist');
         fs.mkdir(p, function (err) {
-          expect(err.code).to.equal('ENOTDIR');
-          done();
+          try {
+            expect(err.code).to.equal('ENOTDIR');
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
     });
@@ -995,8 +1141,12 @@ describe('asar package', function () {
         const p = path.join(asarDir, 'a.asar', 'file1');
         // eslint-disable-next-line
         fs.exists(p, function (exists) {
-          expect(exists).to.be.true();
-          done();
+          try {
+            expect(exists).to.be.true();
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
@@ -1004,8 +1154,12 @@ describe('asar package', function () {
         const p = path.join(asarDir, 'a.asar', 'not-exist');
         // eslint-disable-next-line
         fs.exists(p, function (exists) {
-          expect(exists).to.be.false();
-          done();
+          try {
+            expect(exists).to.be.false();
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
@@ -1013,8 +1167,12 @@ describe('asar package', function () {
         const p = path.join(asarDir, 'a.asar', 'file1');
         // eslint-disable-next-line
         util.promisify(fs.exists)(p).then(exists => {
-          expect(exists).to.be.true();
-          done();
+          try {
+            expect(exists).to.be.true();
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
@@ -1022,8 +1180,12 @@ describe('asar package', function () {
         const p = path.join(asarDir, 'a.asar', 'not-exist');
         // eslint-disable-next-line
         util.promisify(fs.exists)(p).then(exists => {
-          expect(exists).to.be.false();
-          done();
+          try {
+            expect(exists).to.be.false();
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
     });
@@ -1044,32 +1206,48 @@ describe('asar package', function () {
       it('accesses a normal file', function (done) {
         const p = path.join(asarDir, 'a.asar', 'file1');
         fs.access(p, function (err) {
-          expect(err).to.be.undefined();
-          done();
+          try {
+            expect(err).to.be.undefined();
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
       it('throws an error when called with write mode', function (done) {
         const p = path.join(asarDir, 'a.asar', 'file1');
         fs.access(p, fs.constants.R_OK | fs.constants.W_OK, function (err) {
-          expect(err.code).to.equal('EACCES');
-          done();
+          try {
+            expect(err.code).to.equal('EACCES');
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
       it('throws an error when called on non-existent file', function (done) {
         const p = path.join(asarDir, 'a.asar', 'not-exist');
         fs.access(p, function (err) {
-          expect(err.code).to.equal('ENOENT');
-          done();
+          try {
+            expect(err.code).to.equal('ENOENT');
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
       it('allows write mode for unpacked files', function (done) {
         const p = path.join(asarDir, 'unpack.asar', 'a.txt');
         fs.access(p, fs.constants.R_OK | fs.constants.W_OK, function (err) {
-          expect(err).to.be.null();
-          done();
+          try {
+            expect(err).to.be.null();
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
     });
@@ -1136,8 +1314,12 @@ describe('asar package', function () {
       it('opens a normal js file', function (done) {
         const child = ChildProcess.fork(path.join(asarDir, 'a.asar', 'ping.js'));
         child.on('message', function (msg) {
-          expect(msg).to.equal('message');
-          done();
+          try {
+            expect(msg).to.equal('message');
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
         child.send('message');
       });
@@ -1146,8 +1328,12 @@ describe('asar package', function () {
         const file = path.join(asarDir, 'a.asar', 'file1');
         const child = ChildProcess.fork(path.join(fixtures, 'module', 'asar.js'));
         child.on('message', function (content) {
-          expect(content).to.equal(fs.readFileSync(file).toString());
-          done();
+          try {
+            expect(content).to.equal(fs.readFileSync(file).toString());
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
         child.send(file);
       });
@@ -1158,9 +1344,13 @@ describe('asar package', function () {
 
       it('should not try to extract the command if there is a reference to a file inside an .asar', function (done) {
         ChildProcess.exec('echo ' + echo + ' foo bar', function (error, stdout) {
-          expect(error).to.be.null();
-          expect(stdout.toString().replace(/\r/g, '')).to.equal(echo + ' foo bar\n');
-          done();
+          try {
+            expect(error).to.be.null();
+            expect(stdout.toString().replace(/\r/g, '')).to.equal(echo + ' foo bar\n');
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
@@ -1175,9 +1365,13 @@ describe('asar package', function () {
       const echo = path.join(asarDir, 'echo.asar', 'echo');
 
       it('should not try to extract the command if there is a reference to a file inside an .asar', function (done) {
-        const stdout = ChildProcess.execSync('echo ' + echo + ' foo bar');
-        expect(stdout.toString().replace(/\r/g, '')).to.equal(echo + ' foo bar\n');
-        done();
+        try {
+          const stdout = ChildProcess.execSync('echo ' + echo + ' foo bar');
+          expect(stdout.toString().replace(/\r/g, '')).to.equal(echo + ' foo bar\n');
+          done();
+        } catch (e) {
+          done(e);
+        }
       });
     });
 
@@ -1194,21 +1388,28 @@ describe('asar package', function () {
 
       it('executes binaries', function (done) {
         execFile(echo, ['test'], function (error, stdout) {
-          expect(error).to.be.null();
-          expect(stdout).to.equal('test\n');
-          done();
+          try {
+            expect(error).to.be.null();
+            expect(stdout).to.equal('test\n');
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
       it('executes binaries without callback', function (done) {
         const process = execFile(echo, ['test']);
         process.on('close', function (code) {
-          expect(code).to.equal(0);
-          done();
+          try {
+            expect(code).to.equal(0);
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
         process.on('error', function () {
-          expect.fail();
-          done();
+          done('error');
         });
       });
 
@@ -1351,9 +1552,13 @@ describe('asar package', function () {
           }
         });
         forked.on('message', function (stats) {
-          expect(stats.isFile).to.be.true();
-          expect(stats.size).to.equal(778);
-          done();
+          try {
+            expect(stats.isFile).to.be.true();
+            expect(stats.size).to.equal(778);
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
@@ -1370,10 +1575,14 @@ describe('asar package', function () {
           output += data;
         });
         spawned.stdout.on('close', function () {
-          const stats = JSON.parse(output);
-          expect(stats.isFile).to.be.true();
-          expect(stats.size).to.equal(778);
-          done();
+          try {
+            const stats = JSON.parse(output);
+            expect(stats.isFile).to.be.true();
+            expect(stats.size).to.equal(778);
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
     });
@@ -1383,32 +1592,48 @@ describe('asar package', function () {
     it('can request a file in package', function (done) {
       const p = path.resolve(asarDir, 'a.asar', 'file1');
       $.get('file://' + p, function (data) {
-        expect(data.trim()).to.equal('file1');
-        done();
+        try {
+          expect(data.trim()).to.equal('file1');
+          done();
+        } catch (e) {
+          done(e);
+        }
       });
     });
 
     it('can request a file in package with unpacked files', function (done) {
       const p = path.resolve(asarDir, 'unpack.asar', 'a.txt');
       $.get('file://' + p, function (data) {
-        expect(data.trim()).to.equal('a');
-        done();
+        try {
+          expect(data.trim()).to.equal('a');
+          done();
+        } catch (e) {
+          done(e);
+        }
       });
     });
 
     it('can request a linked file in package', function (done) {
       const p = path.resolve(asarDir, 'a.asar', 'link2', 'link1');
       $.get('file://' + p, function (data) {
-        expect(data.trim()).to.equal('file1');
-        done();
+        try {
+          expect(data.trim()).to.equal('file1');
+          done();
+        } catch (e) {
+          done(e);
+        }
       });
     });
 
     it('can request a file in filesystem', function (done) {
       const p = path.resolve(asarDir, 'file');
       $.get('file://' + p, function (data) {
-        expect(data.trim()).to.equal('file');
-        done();
+        try {
+          expect(data.trim()).to.equal('file');
+          done();
+        } catch (e) {
+          done(e);
+        }
       });
     });
 
@@ -1417,8 +1642,12 @@ describe('asar package', function () {
       $.ajax({
         url: 'file://' + p,
         error: function (err) {
-          expect(err.status).to.equal(404);
-          done();
+          try {
+            expect(err.status).to.equal(404);
+            done();
+          } catch (e) {
+            done(e);
+          }
         }
       });
     });
@@ -1433,18 +1662,12 @@ describe('asar package', function () {
       expect(stats.isFile()).to.be.true();
     });
 
-    it('is available in forked scripts', function (done) {
-      if (!features.isRunAsNodeEnabled()) {
-        this.skip();
-        done();
-      }
-
+    ifit(features.isRunAsNodeEnabled())('is available in forked scripts', async function () {
       const child = ChildProcess.fork(path.join(fixtures, 'module', 'original-fs.js'));
-      child.on('message', function (msg) {
-        expect(msg).to.equal('object');
-        done();
-      });
+      const message = emittedOnce(child, 'message');
       child.send('message');
+      const [msg] = await message;
+      expect(msg).to.equal('object');
     });
 
     it('can be used with streams', () => {

--- a/spec/spec-helpers.js
+++ b/spec/spec-helpers.js
@@ -1,2 +1,4 @@
 exports.ifit = (condition) => (condition ? it : it.skip);
 exports.ifdescribe = (condition) => (condition ? describe : describe.skip);
+
+exports.delay = (time = 0) => new Promise(resolve => setTimeout(resolve, time));

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -4,7 +4,7 @@ const http = require('http');
 const url = require('url');
 const { ipcRenderer } = require('electron');
 const { emittedOnce, waitForEvent } = require('./events-helpers');
-const { ifdescribe, ifit } = require('./spec-helpers');
+const { ifdescribe, ifit, delay } = require('./spec-helpers');
 
 const features = process._linkedBinding('electron_common_features');
 const nativeModulesEnabled = process.env.ELECTRON_SKIP_NATIVE_MODULE_TESTS;
@@ -284,10 +284,15 @@ describe('<webview> tag', function () {
     it('sets the referrer url', (done) => {
       const referrer = 'http://github.com/';
       const server = http.createServer((req, res) => {
-        res.end();
-        server.close();
-        expect(req.headers.referer).to.equal(referrer);
-        done();
+        try {
+          expect(req.headers.referer).to.equal(referrer);
+          done();
+        } catch (e) {
+          done(e);
+        } finally {
+          res.end();
+          server.close();
+        }
       }).listen(0, '127.0.0.1', () => {
         const port = server.address().port;
         loadWebView(webview, {
@@ -737,24 +742,28 @@ describe('<webview> tag', function () {
       };
 
       const loadListener = () => {
-        if (loadCount === 1) {
-          webview.src = `file://${fixtures}/pages/base-page.html`;
-        } else if (loadCount === 2) {
-          expect(webview.canGoBack()).to.be.true();
-          expect(webview.canGoForward()).to.be.false();
+        try {
+          if (loadCount === 1) {
+            webview.src = `file://${fixtures}/pages/base-page.html`;
+          } else if (loadCount === 2) {
+            expect(webview.canGoBack()).to.be.true();
+            expect(webview.canGoForward()).to.be.false();
 
-          webview.goBack();
-        } else if (loadCount === 3) {
-          webview.goForward();
-        } else if (loadCount === 4) {
-          expect(webview.canGoBack()).to.be.true();
-          expect(webview.canGoForward()).to.be.false();
+            webview.goBack();
+          } else if (loadCount === 3) {
+            webview.goForward();
+          } else if (loadCount === 4) {
+            expect(webview.canGoBack()).to.be.true();
+            expect(webview.canGoForward()).to.be.false();
 
-          webview.removeEventListener('did-finish-load', loadListener);
-          done();
+            webview.removeEventListener('did-finish-load', loadListener);
+            done();
+          }
+
+          loadCount += 1;
+        } catch (e) {
+          done(e);
         }
-
-        loadCount += 1;
       };
 
       webview.addEventListener('ipc-message', listener);
@@ -803,8 +812,12 @@ describe('<webview> tag', function () {
       server.listen(0, '127.0.0.1', () => {
         const port = server.address().port;
         webview.addEventListener('ipc-message', (e) => {
-          expect(e.channel).to.equal(message);
-          done();
+          try {
+            expect(e.channel).to.equal(message);
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
         loadWebView(webview, {
           nodeintegration: 'on',
@@ -1042,15 +1055,14 @@ describe('<webview> tag', function () {
   });
 
   describe('will-attach-webview event', () => {
-    it('does not emit when src is not changed', (done) => {
+    it('does not emit when src is not changed', async () => {
+      console.log('loadWebView(webview)');
       loadWebView(webview);
-      setTimeout(() => {
-        const expectedErrorMessage =
-            'The WebView must be attached to the DOM ' +
-            'and the dom-ready event emitted before this method can be called.';
-        expect(() => { webview.stop(); }).to.throw(expectedErrorMessage);
-        done();
-      });
+      await delay();
+      const expectedErrorMessage =
+          'The WebView must be attached to the DOM ' +
+          'and the dom-ready event emitted before this method can be called.';
+      expect(() => { webview.stop(); }).to.throw(expectedErrorMessage);
     });
 
     it('supports changing the web preferences', async () => {


### PR DESCRIPTION
#### Description of Change
Makes the tests fail properly instead of timing out:
- either wrap `expect()` in `try` / `catch`
- or re-implement test with `async` / `await`

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes
Notes: no-notes