### PR TITLE
feat: add name to app.getAppMetrics() output

### DIFF
--- a/docs/api/structures/process-metric.md
+++ b/docs/api/structures/process-metric.md
@@ -11,6 +11,8 @@
   * `Pepper Plugin`
   * `Pepper Plugin Broker`
   * `Unknown`
+* `name` String (optional) - The name of the process. i.e. for plugins it might be Flash.
+    Examples for utility: `Audio Service`, `Content Decryption Module Service`, `Network Service`, `Video Capture`, etc.
 * `cpu` [CPUUsage](cpu-usage.md) - CPU usage of the process.
 * `creationTime` Number - Creation time for this process.
     The time is represented as number of milliseconds since epoch.

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -158,7 +158,9 @@ class App : public ElectronBrowserClient::Delegate,
 
  private:
   void SetAppPath(const base::FilePath& app_path);
-  void ChildProcessLaunched(int process_type, base::ProcessHandle handle);
+  void ChildProcessLaunched(int process_type,
+                            base::ProcessHandle handle,
+                            const std::string& name = std::string());
   void ChildProcessDisconnected(base::ProcessId pid);
 
   void SetAppLogsPath(gin_helper::ErrorThrower thrower,

--- a/shell/browser/api/process_metric.cc
+++ b/shell/browser/api/process_metric.cc
@@ -52,9 +52,11 @@ namespace electron {
 
 ProcessMetric::ProcessMetric(int type,
                              base::ProcessHandle handle,
-                             std::unique_ptr<base::ProcessMetrics> metrics) {
+                             std::unique_ptr<base::ProcessMetrics> metrics,
+                             const std::string& name) {
   this->type = type;
   this->metrics = std::move(metrics);
+  this->name = name;
 
 #if defined(OS_WIN)
   HANDLE duplicate_handle = INVALID_HANDLE_VALUE;

--- a/shell/browser/api/process_metric.h
+++ b/shell/browser/api/process_metric.h
@@ -6,6 +6,7 @@
 #define SHELL_BROWSER_API_PROCESS_METRIC_H_
 
 #include <memory>
+#include <string>
 
 #include "base/process/process.h"
 #include "base/process/process_handle.h"
@@ -37,10 +38,12 @@ struct ProcessMetric {
   int type;
   base::Process process;
   std::unique_ptr<base::ProcessMetrics> metrics;
+  std::string name;
 
   ProcessMetric(int type,
                 base::ProcessHandle handle,
-                std::unique_ptr<base::ProcessMetrics> metrics);
+                std::unique_ptr<base::ProcessMetrics> metrics,
+                const std::string& name = std::string());
   ~ProcessMetric();
 
 #if !defined(OS_LINUX)

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -1087,6 +1087,10 @@ describe('app module', () => {
         expect(entry.memory).to.have.property('workingSetSize').that.is.greaterThan(0);
         expect(entry.memory).to.have.property('peakWorkingSetSize').that.is.greaterThan(0);
 
+        if (entry.type === 'Utility') {
+          expect(entry).to.have.property('name').that.is.a('string');
+        }
+
         if (process.platform === 'win32') {
           expect(entry.memory).to.have.property('privateBytes').that.is.greaterThan(0);
         }


### PR DESCRIPTION
#### Description of Change
Add `name` to `app.getAppMetrics()` output.

Examples:
- `Audio Service`
- `Content Decryption Module Service`
- `Network Service`
- `Video Capture`

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes
Notes: Added `name` to `app.getAppMetrics()` output.