### PR TITLE
docs: add hardened runtime entitlement info

### DIFF
--- a/docs/tutorial/code-signing.md
+++ b/docs/tutorial/code-signing.md
@@ -100,6 +100,25 @@ To see all of this in action, check out Electron Fiddle's source code,
 [especially its `electron-forge` configuration
 file](https://github.com/electron/fiddle/blob/master/forge.config.js).
 
+If you plan to access the microphone or camera within your app using Electron's APIs, you'll also
+need to add the following entitlements:
+
+```xml
+<key>com.apple.security.device.audio-input</key>
+<true/>
+<key>com.apple.security.device.camera</key>
+<true/>
+```
+
+If these are not present in your app's entitlements when you invoke, for example:
+
+```js
+const { systemPreferences } = require('electron')
+
+const microphone = systemPreferences.askForMediaAccess('microphone')
+```
+
+Your app may crash. See the Resource Access section in [Hardened Runtime](https://developer.apple.com/documentation/security/hardened_runtime) for more information and entitlements you may need.
 
 ## `electron-builder`
 


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/fiddle/pull/426.

Adds information needed about entitlements and system resources access to prevent potential crashes.

cc @MarshallOfSound @felixrieseberg 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: none
