### PR TITLE
chore: TS-ify Guest View Manager

### DIFF
--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -227,7 +227,7 @@ auto_filenames = {
     "lib/browser/default-menu.ts",
     "lib/browser/desktop-capturer.ts",
     "lib/browser/devtools.ts",
-    "lib/browser/guest-view-manager.js",
+    "lib/browser/guest-view-manager.ts",
     "lib/browser/guest-window-manager.js",
     "lib/browser/init.ts",
     "lib/browser/ipc-main-impl.ts",

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -1,6 +1,6 @@
 /// <reference path="../electron.d.ts" />
 
- /**
+/**
  * This file augments the Electron TS namespace with the internal APIs
  * that are not documented but are used by Electron internally
  */
@@ -57,11 +57,17 @@ declare namespace Electron {
     _getPreloadPaths(): string[];
     equal(other: WebContents): boolean;
     _initiallyShown: boolean;
+    equal(other: WebContents): string;
+    create(opts: Electron.WebPreferences): Electron.WebContents;
+    attachParams: Record<string, any>;
+    viewInstanceId: string;
   }
 
   interface WebPreferences {
     guestInstanceId?: number;
     openerId?: number;
+    preloadURL?: string;
+    disablePopups?: boolean;
   }
 
   interface SerializedError {
@@ -161,7 +167,6 @@ declare namespace Electron {
     acceleratorWorksWhenHidden?: boolean;
   }
 
-
   const deprecate: ElectronInternal.DeprecationUtil;
 
   namespace Main {
@@ -169,7 +174,7 @@ declare namespace Electron {
   }
 
   class View {}
-  
+
   // Experimental views API
   class BaseWindow {
     constructor(args: {show: boolean})


### PR DESCRIPTION
#### Description of Change
Converts guest-view-manager.js to TypeScript

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [X] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [X] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

Failing tests from `npm test` are due to async timeouts.

Notes: none