### PR TITLE
fix: intermittent 100% CPU usage on macOS

### DIFF
--- a/patches/node/.patches
+++ b/patches/node/.patches
@@ -40,3 +40,4 @@ fix_comment_out_incompatible_crypto_modules.patch
 test_account_for_non-node_basename.patch
 lib_src_switch_buffer_kmaxlength_to_size_t.patch
 update_tests_after_increasing_typed_array_size.patch
+darwin_work_around_clock_jumping_back_in_time.patch

--- a/patches/node/darwin_work_around_clock_jumping_back_in_time.patch
+++ b/patches/node/darwin_work_around_clock_jumping_back_in_time.patch
@@ -1,0 +1,64 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ben Noordhuis <info@bnoordhuis.nl>
+Date: Wed, 1 Jul 2020 10:32:57 +0200
+Subject: darwin: work around clock jumping back in time
+
+It was reported that mach_absolute_time() can jump backward in time when
+the machine is suspended. Use mach_continuous_time() when available to
+work around that (macOS 10.12 and up.)
+
+Fixes: https://github.com/libuv/libuv/issues/2891
+PR-URL: https://github.com/libuv/libuv/pull/2894
+Reviewed-By: Phil Willoughby <philwill@fb.com>
+Reviewed-By: Santiago Gimeno <santiago.gimeno@gmail.com>
+
+diff --git a/deps/uv/src/unix/darwin.c b/deps/uv/src/unix/darwin.c
+index 654aba26b1f9249e3e76b48ae1ad674d9fd12718..4f53ad1fc7f1907281013ca5dc4b251c692d3a7b 100644
+--- a/deps/uv/src/unix/darwin.c
++++ b/deps/uv/src/unix/darwin.c
+@@ -25,6 +25,7 @@
+ #include <stdint.h>
+ #include <errno.h>
+ 
++#include <dlfcn.h>
+ #include <mach/mach.h>
+ #include <mach/mach_time.h>
+ #include <mach-o/dyld.h> /* _NSGetExecutablePath */
+@@ -32,6 +33,10 @@
+ #include <sys/sysctl.h>
+ #include <unistd.h>  /* sysconf */
+ 
++static uv_once_t once = UV_ONCE_INIT;
++static uint64_t (*time_func)(void);
++static mach_timebase_info_data_t timebase;
++
+ 
+ int uv__platform_loop_init(uv_loop_t* loop) {
+   loop->cf_state = NULL;
+@@ -48,15 +53,19 @@ void uv__platform_loop_delete(uv_loop_t* loop) {
+ }
+ 
+ 
+-uint64_t uv__hrtime(uv_clocktype_t type) {
+-  static mach_timebase_info_data_t info;
+-
+-  if ((ACCESS_ONCE(uint32_t, info.numer) == 0 ||
+-       ACCESS_ONCE(uint32_t, info.denom) == 0) &&
+-      mach_timebase_info(&info) != KERN_SUCCESS)
++static void uv__hrtime_init_once(void) {
++  if (KERN_SUCCESS != mach_timebase_info(&timebase))
+     abort();
+ 
+-  return mach_absolute_time() * info.numer / info.denom;
++  time_func = (uint64_t (*)(void)) dlsym(RTLD_DEFAULT, "mach_continuous_time");
++  if (time_func == NULL)
++    time_func = mach_absolute_time;
++}
++
++
++uint64_t uv__hrtime(uv_clocktype_t type) {
++  uv_once(&once, uv__hrtime_init_once);
++  return time_func() * timebase.numer / timebase.denom;
+ }
+ 
+ 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/24385.

Fixes an issue caused by https://github.com/libuv/libuv/issues/2891:

> The problem is that CLOCK_UPTIME_RAW experiences an epoch reset (ie it goes backwards) sometimes when the machine has been asleep. In my testing it seems that a sleep of over 1 hour with under 50% battery remaining triggers this effect reasonably reliably - I guess that this combination makes the machine enter a very-low-power state that resets whatever counter is used.

cc @WillerZ @zcbenz @nornagon @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixes an intermittent high-CPU usage problem caused a system clock issue during sleep.
