### PR TITLE
fix: uv_walk crash on web worker close

### DIFF
--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -96,25 +96,25 @@ ELECTRON_DESKTOP_CAPTURER_MODULE(V)
 namespace {
 
 void stop_and_close_uv_loop(uv_loop_t* loop) {
-  // Close any active handles
   uv_stop(loop);
-  uv_walk(
-      loop,
-      [](uv_handle_t* handle, void*) {
-        if (!uv_is_closing(handle)) {
-          uv_close(handle, nullptr);
-        }
-      },
-      nullptr);
+  int error = uv_loop_close(loop);
 
-  // Run the loop to let it finish all the closing handles
-  // NB: after uv_stop(), uv_run(UV_RUN_DEFAULT) returns 0 when that's done
-  for (;;)
-    if (!uv_run(loop, UV_RUN_DEFAULT))
-      break;
+  while (error) {
+    uv_run(loop, UV_RUN_DEFAULT);
+    uv_stop(loop);
+    uv_walk(
+        loop,
+        [](uv_handle_t* handle, void*) {
+          if (!uv_is_closing(handle)) {
+            uv_close(handle, nullptr);
+          }
+        },
+        nullptr);
+    uv_run(loop, UV_RUN_DEFAULT);
+    error = uv_loop_close(loop);
+  }
 
-  DCHECK(!uv_loop_alive(loop));
-  uv_loop_close(loop);
+  DCHECK(error == 0);
 }
 
 bool g_is_initialized = false;
@@ -274,6 +274,7 @@ NodeBindings::~NodeBindings() {
   // Quit the embed thread.
   embed_closed_ = true;
   uv_sem_post(&embed_sem_);
+
   WakeupEmbedThread();
 
   // Wait for everything to be done.
@@ -284,7 +285,7 @@ NodeBindings::~NodeBindings() {
   uv_close(reinterpret_cast<uv_handle_t*>(&dummy_uv_handle_), nullptr);
 
   // Clean up worker loop
-  if (uv_loop_ == &worker_loop_)
+  if (in_worker_loop())
     stop_and_close_uv_loop(uv_loop_);
 }
 
@@ -501,7 +502,8 @@ void NodeBindings::WakeupMainThread() {
 }
 
 void NodeBindings::WakeupEmbedThread() {
-  uv_async_send(&dummy_uv_handle_);
+  if (!in_worker_loop())
+    uv_async_send(&dummy_uv_handle_);
 }
 
 // static

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -114,7 +114,7 @@ void stop_and_close_uv_loop(uv_loop_t* loop) {
     error = uv_loop_close(loop);
   }
 
-  DCHECK(error == 0);
+  DCHECK_EQ(error, 0);
 }
 
 bool g_is_initialized = false;

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -58,6 +58,8 @@ class NodeBindings {
 
   uv_loop_t* uv_loop() const { return uv_loop_; }
 
+  bool in_worker_loop() const { return uv_loop_ == &worker_loop_; }
+
  protected:
   explicit NodeBindings(BrowserEnvironment browser_env);
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/22069.

Not calling this final `async_send` in the context of a worker loop fixes this issue for reasons i'm still fully sussing out. What happens at present is that when it is called, it somehow corrupts the libuv loop on what i currently believe is a threading issue. The root cause of this is the `delete this` call in `web_worker_observer` but I believe this is the most direct fix.

Tested with https://github.com/trusktr/electron-web-worker-example.

When you hit reload a handful of times without this fix it reliably crashes the renderer, and after this fix no crashes are seen. 

cc @ckerr @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed a termination crash on Web Workers with Node.js integration enabled.
