### PR TITLE
chore: don't duplicate devtools constants

### DIFF
--- a/shell/browser/electron_web_ui_controller_factory.cc
+++ b/shell/browser/electron_web_ui_controller_factory.cc
@@ -6,17 +6,12 @@
 
 #include <string>
 
+#include "chrome/common/webui_url_constants.h"
 #include "content/public/browser/web_contents.h"
 #include "electron/buildflags/buildflags.h"
 #include "shell/browser/ui/devtools_ui.h"
 
 namespace electron {
-
-namespace {
-
-const char kChromeUIDevToolsBundledHost[] = "devtools";
-
-}  // namespace
 
 // static
 ElectronWebUIControllerFactory* ElectronWebUIControllerFactory::GetInstance() {
@@ -30,7 +25,7 @@ ElectronWebUIControllerFactory::~ElectronWebUIControllerFactory() = default;
 content::WebUI::TypeID ElectronWebUIControllerFactory::GetWebUIType(
     content::BrowserContext* browser_context,
     const GURL& url) {
-  if (url.host() == kChromeUIDevToolsBundledHost) {
+  if (url.host() == chrome::kChromeUIDevToolsHost) {
     return const_cast<ElectronWebUIControllerFactory*>(this);
   }
 
@@ -53,7 +48,7 @@ std::unique_ptr<content::WebUIController>
 ElectronWebUIControllerFactory::CreateWebUIControllerForURL(
     content::WebUI* web_ui,
     const GURL& url) {
-  if (url.host() == kChromeUIDevToolsBundledHost) {
+  if (url.host() == chrome::kChromeUIDevToolsHost) {
     auto* browser_context = web_ui->GetWebContents()->GetBrowserContext();
     return std::make_unique<DevToolsUI>(browser_context, web_ui);
   }

--- a/shell/browser/ui/devtools_ui.cc
+++ b/shell/browser/ui/devtools_ui.cc
@@ -11,6 +11,7 @@
 #include "base/memory/ref_counted_memory.h"
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
+#include "chrome/common/webui_url_constants.h"
 #include "content/public/browser/devtools_frontend_host.h"
 #include "content/public/browser/url_data_source.h"
 #include "content/public/browser/web_contents.h"
@@ -19,9 +20,6 @@
 namespace electron {
 
 namespace {
-
-const char kChromeUIDevToolsHost[] = "devtools";
-const char kChromeUIDevToolsBundledPath[] = "bundled";
 
 std::string PathWithoutParams(const std::string& path) {
   return GURL(std::string("devtools://devtools/") + path).path().substr(1);
@@ -59,14 +57,14 @@ class BundledDataSource : public content::URLDataSource {
   ~BundledDataSource() override = default;
 
   // content::URLDataSource implementation.
-  std::string GetSource() override { return kChromeUIDevToolsHost; }
+  std::string GetSource() override { return chrome::kChromeUIDevToolsHost; }
 
   void StartDataRequest(const GURL& url,
                         const content::WebContents::Getter& wc_getter,
                         GotDataCallback callback) override {
     const std::string path = content::URLDataSource::URLToRequestPath(url);
     // Serve request from local bundle.
-    std::string bundled_path_prefix(kChromeUIDevToolsBundledPath);
+    std::string bundled_path_prefix(chrome::kChromeUIDevToolsBundledPath);
     bundled_path_prefix += "/";
     if (base::StartsWith(path, bundled_path_prefix,
                          base::CompareCase::INSENSITIVE_ASCII)) {


### PR DESCRIPTION
#### Description of Change

We had duplicate devtools constants everywhere and already have access to those selfsame constants in `chrome/common/webui_url_constants.h`.

cc @MarshallOfSound @deepak1556 @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: none
