### PR TITLE
fix: clipboard.readBuffer returning empty value

### DIFF
--- a/shell/common/api/electron_api_clipboard.cc
+++ b/shell/common/api/electron_api_clipboard.cc
@@ -71,9 +71,8 @@ void Clipboard::WriteBuffer(const std::string& format,
   base::span<const uint8_t> payload_span(
       reinterpret_cast<const uint8_t*>(node::Buffer::Data(buffer)),
       node::Buffer::Length(buffer));
-  writer.WriteData(
-      base::UTF8ToUTF16(ui::ClipboardFormatType::GetType(format).Serialize()),
-      mojo_base::BigBuffer(payload_span));
+  writer.WriteData(base::UTF8ToUTF16(format),
+                   mojo_base::BigBuffer(payload_span));
 }
 
 void Clipboard::Write(const gin_helper::Dictionary& data,

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -112,37 +112,17 @@ describe('clipboard module', () => {
     });
   });
 
-  describe('clipboard.writeBuffer(format, buffer)', () => {
+  describe('clipboard.readBuffer(format)', () => {
     it('writes a Buffer for the specified format', function () {
-      if (process.platform !== 'darwin') {
-        // FIXME(alexeykuzmin): Skip the test.
-        // this.skip()
-        return;
-      }
-
       const buffer = Buffer.from('writeBuffer', 'utf8');
       clipboard.writeBuffer('public.utf8-plain-text', buffer);
-      expect(clipboard.readText()).to.equal('writeBuffer');
+      expect(buffer.equals(clipboard.readBuffer('public.utf8-plain-text'))).to.equal(true);
     });
 
     it('throws an error when a non-Buffer is specified', () => {
       expect(() => {
         clipboard.writeBuffer('public.utf8-plain-text', 'hello');
       }).to.throw(/buffer must be a node Buffer/);
-    });
-  });
-
-  describe('clipboard.readBuffer(format)', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip();
-      }
-    });
-
-    it('returns a Buffer of the content for the specified format', () => {
-      const buffer = Buffer.from('this is binary', 'utf8');
-      clipboard.writeText(buffer.toString());
-      expect(buffer.equals(clipboard.readBuffer('public.utf8-plain-text'))).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/24253

The implementation regressed with https://chromium-review.googlesource.com/c/chromium/src/+/1729965 where the upstream api now expects the raw format type.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: fix clipboard.readBuffer returning incorrect value
