### PR TITLE
fix: use default NSVisualEffectState enum case

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1451,7 +1451,7 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
 
     [effect_view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
     [effect_view setBlendingMode:NSVisualEffectBlendingModeBehindWindow];
-    [effect_view setState:NSVisualEffectStateActive];
+    [effect_view setState:NSVisualEffectStateFollowsWindowActiveState];
 
     // Make frameless Vibrant windows have rounded corners.
     if (!has_frame() && !is_modal()) {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/16417.

In [Apple documentation](https://developer.apple.com/documentation/appkit/nsvisualeffectstate/nsvisualeffectstatefollowswindowactivestate?language=objc) `NSVisualEffectState` is an enum with three options detailing how the material appearance should reflect window activity state. We were previously using `NSVisualEffectStateActive`, meaning that the backdrop would always appear active. This breaks from the default as specified in the first link, which is `NSVisualEffectStateFollowsWindowActiveState` and means that the backdrop should automatically appear active when the window is active, and inactive when it is not. This thus changes our effect state to the more expected default.

cc @miniak @zcbenz @jkleinsc 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed an issue where macOS window vibrancy active state did not always match the active state of the window.
