### PR TITLE
doc: fix incorrect formatting in browser docs.

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1123,7 +1123,7 @@ Disable or enable the window.
 
 #### `win.isEnabled()`
 
-Returns Boolean - whether the window is enabled.
+Returns `Boolean` - whether the window is enabled.
 
 #### `win.setSize(width, height[, animate])`
 


### PR DESCRIPTION
#### Description of Change
Fix incorrect formatting in browser documentation.

Missing backticks caused the docs parser to think that the return type
of the `isEnabled` function was null, where it was supposed to be a
boolean type.

The side effect of this was that the generated typescript typings were
incorrect for this function.

Fixes #24409


#### Checklist

- [ x] PR description included and stakeholders cc'd
- [ x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [ x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Generated typing for win.isEnabled now is set to a boolean.
