### PR TITLE
feat: add visible-on-all-workspaces-changed event

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -580,6 +580,15 @@ Returns:
 
 Emitted when the window is set or unset to show always on top of other windows.
 
+#### Event: 'visible-on-all-workspaces-changed'
+
+Returns:
+
+* `event` Event
+* `isVisibleOnAllWorkspaces` Boolean
+
+Emitted when a window is set or unset to be visible on all workspaces.
+
 #### Event: 'app-command' _Windows_ _Linux_
 
 Returns:

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -280,6 +280,10 @@ void BaseWindow::OnWindowAlwaysOnTopChanged() {
   Emit("always-on-top-changed", IsAlwaysOnTop());
 }
 
+void BaseWindow::OnWindowVisibleOnAllWorkspacesChanged() {
+  Emit("visible-on-all-workspaces-changed", IsVisibleOnAllWorkspaces());
+}
+
 void BaseWindow::OnExecuteAppCommand(const std::string& command_name) {
   Emit("app-command", command_name);
 }

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -78,6 +78,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void OnWindowEnterHtmlFullScreen() override;
   void OnWindowLeaveHtmlFullScreen() override;
   void OnWindowAlwaysOnTopChanged() override;
+  void OnWindowVisibleOnAllWorkspacesChanged() override;
   void OnExecuteAppCommand(const std::string& command_name) override;
   void OnTouchBarItemResult(const std::string& item_id,
                             const base::DictionaryValue& details) override;

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -556,6 +556,11 @@ void NativeWindow::NotifyWindowAlwaysOnTopChanged() {
     observer.OnWindowAlwaysOnTopChanged();
 }
 
+void NativeWindow::NotifyWindowVisibleOnAllWorkspacesChanged() {
+  for (NativeWindowObserver& observer : observers_)
+    observer.OnWindowVisibleOnAllWorkspacesChanged();
+}
+
 void NativeWindow::NotifyWindowExecuteAppCommand(const std::string& command) {
   for (NativeWindowObserver& observer : observers_)
     observer.OnExecuteAppCommand(command);

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -280,6 +280,7 @@ class NativeWindow : public base::SupportsUserData,
   void NotifyWindowEnterHtmlFullScreen();
   void NotifyWindowLeaveHtmlFullScreen();
   void NotifyWindowAlwaysOnTopChanged();
+  void NotifyWindowVisibleOnAllWorkspacesChanged();
   void NotifyWindowExecuteAppCommand(const std::string& command);
   void NotifyTouchBarItemInteraction(const std::string& item_id,
                                      const base::DictionaryValue& details);

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1353,6 +1353,8 @@ void NativeWindowMac::SetOverlayIcon(const gfx::Image& overlay,
 
 void NativeWindowMac::SetVisibleOnAllWorkspaces(bool visible) {
   SetCollectionBehavior(visible, NSWindowCollectionBehaviorCanJoinAllSpaces);
+
+  NativeWindow::NotifyWindowVisibleOnAllWorkspacesChanged();
 }
 
 bool NativeWindowMac::IsVisibleOnAllWorkspaces() {

--- a/shell/browser/native_window_observer.h
+++ b/shell/browser/native_window_observer.h
@@ -89,6 +89,7 @@ class NativeWindowObserver : public base::CheckedObserver {
   virtual void OnWindowEnterHtmlFullScreen() {}
   virtual void OnWindowLeaveHtmlFullScreen() {}
   virtual void OnWindowAlwaysOnTopChanged() {}
+  virtual void OnWindowVisibleOnAllWorkspacesChanged() {}
   virtual void OnTouchBarItemResult(const std::string& item_id,
                                     const base::DictionaryValue& details) {}
   virtual void OnNewWindowForTab() {}

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1145,6 +1145,8 @@ bool NativeWindowViews::IsMenuBarVisible() {
 
 void NativeWindowViews::SetVisibleOnAllWorkspaces(bool visible) {
   widget()->SetVisibleOnAllWorkspaces(visible);
+
+  NativeWindow::NotifyWindowVisibleOnAllWorkspacesChanged();
 }
 
 bool NativeWindowViews::IsVisibleOnAllWorkspaces() {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -3550,6 +3550,15 @@ describe('BrowserWindow module', () => {
           expect(w.isVisibleOnAllWorkspaces()).to.be.true();
         });
       });
+
+      ifit(process.platform !== 'win32')('emits an event when the visibleOnAllWorkspaces state changes', async () => {
+        const w = new BrowserWindow({ show: false });
+        const visibleOnAllWorkspacesEvent = emittedOnce(w, 'visible-on-all-workspaces-changed');
+        expect(w.visibleOnAllWorkspaces).to.be.false();
+        w.visibleOnAllWorkspaces = true;
+        const [, visibleOnAllWorkspaces] = await visibleOnAllWorkspacesEvent;
+        expect(visibleOnAllWorkspaces).to.be.true();
+      });
     });
 
     ifdescribe(process.platform === 'darwin')('documentEdited state', () => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/24451.

At present, there is not a way to detect when the "visibleOnAllWorkspaces" property changes from outside the app, which are possible by e.g. toggling from the macOS dock. A developer could attempt to poll for changes, but that's somewhat unwieldy when we could instead add an event to more effectively notify developers of changes to this window property.

cc @zcbenz @miniak @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Added a` visible-on-all-workspaces-changed` event to poll for changes to window workspace visibility.
