### PR TITLE
fix: default to simplex for printing DuplexMode

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2025,7 +2025,8 @@ void WebContents::Print(gin_helper::Arguments* args) {
   }
 
   // Duplex type user wants to use.
-  printing::mojom::DuplexMode duplex_mode;
+  printing::mojom::DuplexMode duplex_mode =
+      printing::mojom::DuplexMode::kSimplex;
   options.Get("duplexMode", &duplex_mode);
   settings.SetIntKey(printing::kSettingDuplexMode,
                      static_cast<int>(duplex_mode));


### PR DESCRIPTION
#### Description of Change

Linux requires that `duplex_mode` have a default, which is `kSimplex`. We need to set that before attempting to convert so that it doesn't fall down into this [`NOTREACHED()`](https://source.chromium.org/chromium/chromium/src/+/master:ui/gtk/printing/print_dialog_gtk.cc;l=276?q=print_dialog_gtk.cc&ss=chromium&originalUrl=https:%2F%2Fcs.chromium.org%2Fsearch%2F) DCHECK failure.

cc @jkleinsc @MarshallOfSound @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed potentially invalid duplex mode settings on Linux.
