### PR TITLE
fix: broken --trace-sync-io flag in Node.js

### DIFF
--- a/script/node-disabled-tests.json
+++ b/script/node-disabled-tests.json
@@ -81,7 +81,6 @@
   "parallel/test-signal-handler",
   "parallel/test-source-map",
   "parallel/test-stdout-close-catch",
-  "parallel/test-sync-io-option",
   "parallel/test-tls-cert-chains-concat",
   "parallel/test-tls-cert-chains-in-ca",
   "parallel/test-tls-cli-max-version-1.2",

--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -256,6 +256,8 @@ int NodeMain(int argc, char* argv[]) {
       node::LoadEnvironment(env);
     }
 
+    env->set_trace_sync_io(env->options()->trace_sync_io);
+
     {
       v8::SealHandleScope seal(isolate);
       bool more;
@@ -279,6 +281,9 @@ int NodeMain(int argc, char* argv[]) {
     }
 
     node_debugger.Stop();
+
+    env->set_trace_sync_io(false);
+
     exit_code = node::EmitExit(env);
 
     node::ResetStdio();

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -325,6 +325,8 @@ void ElectronBrowserMainParts::PostEarlyInitialization() {
   node_debugger_ = std::make_unique<NodeDebugger>(env);
   node_debugger_->Start();
 
+  env->set_trace_sync_io(env->options()->trace_sync_io);
+
   // Add Electron extended APIs.
   electron_bindings_->BindTo(js_env_->isolate(), env->process_object());
 
@@ -547,6 +549,7 @@ void ElectronBrowserMainParts::PostMainMessageLoopRun() {
   // Destroy node platform after all destructors_ are executed, as they may
   // invoke Node/V8 APIs inside them.
   node_debugger_->Stop();
+  node_env_->env()->set_trace_sync_io(false);
   js_env_->OnMessageLoopDestroying();
   node_env_.reset();
 


### PR DESCRIPTION
#### Description of Change

Fixes broken `--trace-sync-io` flag in Node.js resultant of us not properly setting it in our embedded logic.

cc @nornagon @MarshallOfSound @jkleinsc 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed broken `--trace-sync-io` flag in Node.js.
