### PR TITLE
fix: use default NSVisualEffectState enum case

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1450,7 +1450,7 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
 
     [effect_view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
     [effect_view setBlendingMode:NSVisualEffectBlendingModeBehindWindow];
-    [effect_view setState:NSVisualEffectStateActive];
+    [effect_view setState:NSVisualEffectStateFollowsWindowActiveState];
     [[window_ contentView] addSubview:effect_view
                            positioned:NSWindowBelow
                            relativeTo:nil];


### PR DESCRIPTION
Backport of #24471

See that PR for details.


Notes: Fixed an issue where macOS window vibrancy active state did not always match the active state of the window.
