### PR TITLE
fix: default to simplex for printing DuplexMode

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2020,7 +2020,7 @@ void WebContents::Print(gin_helper::Arguments* args) {
   }
 
   // Duplex type user wants to use.
-  printing::DuplexMode duplex_mode;
+  printing::DuplexMode duplex_mode = printing::SIMPLEX;
   options.Get("duplexMode", &duplex_mode);
   settings.SetIntKey(printing::kSettingDuplexMode, duplex_mode);
 


### PR DESCRIPTION
Backport of #24489

See that PR for details.


Notes: Fixed potentially invalid duplex mode settings on Linux.
