### PR TITLE
docs: fix role typos in startSpeaking/stopSpeaking

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -195,8 +195,8 @@ const template = [
         {
           label: 'Speech',
           submenu: [
-            { role: 'startspeaking' },
-            { role: 'stopspeaking' }
+            { role: 'startSpeaking' },
+            { role: 'stopSpeaking' }
           ]
         }
       ] : [


### PR DESCRIPTION
#### Description of Change
Fix typos in docs for `startSpeaking` and `stopSpeaking` roles

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] relevant documentation is changed or added
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: none