### PR TITLE
chore: cherry-pick fix from chromium issue 1091404

### DIFF
--- a/patches/config.json
+++ b/patches/config.json
@@ -17,5 +17,7 @@
 
   "src/electron/patches/webrtc": "src/third_party/webrtc",
 
-  "src/electron/patches/usrsctp": "src/third_party/usrsctp/usrsctplib"
+  "src/electron/patches/usrsctp": "src/third_party/usrsctp/usrsctplib",
+
+  "src/electron/patches/pdfium": "src/third_party/pdfium"
 }

--- a/patches/pdfium/.patches
+++ b/patches/pdfium/.patches
@@ -1,0 +1,1 @@
+backport_1091404.patch

--- a/patches/pdfium/backport_1091404.patch
+++ b/patches/pdfium/backport_1091404.patch
@@ -1,0 +1,79 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Wed, 23 Oct 2019 12:54:32 -0700
+Subject: fix: make PDFium JS host object have immutable prototypes
+
+[1091404] [High] [CVE-2020-6513]: Google Chrome PDFium Javascript Active Document Memory Corruption Vulnerability - TALOS-2020-1092
+Backport https://pdfium.googlesource.com/pdfium.git/+/bee2261eab794536f236013fa8c9d01728ed326b.
+
+diff --git a/fxjs/cfxjs_engine.cpp b/fxjs/cfxjs_engine.cpp
+index c4d46a29f694c2346de6a9bcde619a5281bd5136..485f7c91a794b951f40956d2c425eb3f65005a5a 100644
+--- a/fxjs/cfxjs_engine.cpp
++++ b/fxjs/cfxjs_engine.cpp
+@@ -144,6 +144,7 @@ class CFXJS_ObjDefinition {
+     v8::HandleScope handle_scope(isolate);
+     v8::Local<v8::FunctionTemplate> fun = v8::FunctionTemplate::New(isolate);
+     fun->InstanceTemplate()->SetInternalFieldCount(2);
++    fun->InstanceTemplate()->SetImmutableProto();
+     fun->SetCallHandler(CallHandler, v8::Number::New(isolate, eObjType));
+     if (eObjType == FXJSOBJTYPE_GLOBAL) {
+       fun->InstanceTemplate()->Set(
+diff --git a/testing/resources/javascript/immutable_proto.in b/testing/resources/javascript/immutable_proto.in
+new file mode 100644
+index 0000000000000000000000000000000000000000..61885c53758167cae5af47f8736014dcb0933aaf
+--- /dev/null
++++ b/testing/resources/javascript/immutable_proto.in
+@@ -0,0 +1,43 @@
++{{header}}
++{{object 1 0}} <<
++  /Type /Catalog
++  /Pages 2 0 R
++  /OpenAction 10 0 R
++>>
++endobj
++{{object 2 0}} <<
++  /Type /Pages
++  /Count 1
++  /Kids [
++    3 0 R
++  ]
++>>
++endobj
++{{object 3 0}} <<
++  /Type /Page
++  /Parent 2 0 R
++  /MediaBox [0 0 612 792]
++>>
++endobj
++% OpenAction action
++{{object 10 0}} <<
++  /Type /Action
++  /S /JavaScript
++  /JS 11 0 R
++>>
++endobj
++{{object 11 0}} <<
++  {{streamlen}}
++>>
++stream
++{{include expect.js}}
++expect("this.__proto__", "[object Object]");
++expect("app.__proto__", "[object Object]");
++expectError("this.__proto__ = {}");
++expectError("app.__proto__ = this");
++endstream
++endobj
++{{xref}}
++{{trailer}}
++{{startxref}}
++%%EOF
+diff --git a/testing/resources/javascript/immutable_proto_expected.txt b/testing/resources/javascript/immutable_proto_expected.txt
+new file mode 100644
+index 0000000000000000000000000000000000000000..7e7c6701e39592ec130ae52fc98f8af903b3152b
+--- /dev/null
++++ b/testing/resources/javascript/immutable_proto_expected.txt
+@@ -0,0 +1,4 @@
++Alert: PASS: this.__proto__ = [object Object]
++Alert: PASS: app.__proto__ = [object Object]
++Alert: PASS: this.__proto__ = {} threw TypeError: Immutable prototype object '[object global]' cannot have their prototype set
++Alert: PASS: app.__proto__ = this threw TypeError: Immutable prototype object '[object Object]' cannot have their prototype set


### PR DESCRIPTION
[1091404] [High] [CVE-2020-6513]: Google Chrome PDFium Javascript Active Document Memory Corruption Vulnerability - TALOS-2020-1092
Backport https://pdfium.googlesource.com/pdfium.git/+/bee2261eab794536f236013fa8c9d01728ed326b.

Notes: none