### PR TITLE
chore: cherry-pick fix from chromium issue 1081722

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -130,3 +130,4 @@ backport_1063177.patch
 backport_1065122.patch
 backport_1074317.patch
 backport_1090543.patch
+backport_1081722.patch

--- a/patches/chromium/backport_1081722.patch
+++ b/patches/chromium/backport_1081722.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Thu, 4 Oct 2018 14:57:02 -0700
+Subject: fix: replace memcopy with memmove for overlapping copies
+
+[1081722] [Medium] [CVE-2020-6524]: Security: memcpy-param-overlap in AudioBuffer::copyFromChannel
+Backport https://chromium.googlesource.com/chromium/src/+/2be9b1c27fb97e8a82e068794fc0fba555182c03
+
+diff --git a/third_party/blink/renderer/modules/webaudio/audio_buffer.cc b/third_party/blink/renderer/modules/webaudio/audio_buffer.cc
+index c2934d9b1dc0c8f0206293e19dcf1dd22c48fe96..361d1e2559f7861813fc2af2a9f194112a42f9f0 100644
+--- a/third_party/blink/renderer/modules/webaudio/audio_buffer.cc
++++ b/third_party/blink/renderer/modules/webaudio/audio_buffer.cc
+@@ -270,7 +270,7 @@ void AudioBuffer::copyFromChannel(NotShared<DOMFloat32Array> destination,
+   DCHECK_LE(count, channel_data->length());
+   DCHECK_LE(buffer_offset + count, channel_data->length());
+ 
+-  memcpy(dst, src + buffer_offset, count * sizeof(*src));
++  memmove(dst, src + buffer_offset, count * sizeof(*src));
+ }
+ 
+ void AudioBuffer::copyToChannel(NotShared<DOMFloat32Array> source,
+@@ -313,7 +313,7 @@ void AudioBuffer::copyToChannel(NotShared<DOMFloat32Array> source,
+   DCHECK_LE(buffer_offset + count, channel_data->length());
+   DCHECK_LE(count, source.View()->length());
+ 
+-  memcpy(dst + buffer_offset, src, count * sizeof(*dst));
++  memmove(dst + buffer_offset, src, count * sizeof(*dst));
+ }
+ 
+ void AudioBuffer::Zero() {


### PR DESCRIPTION
[[1081722](https://crbug.com/1081722)] [**Medium**] [CVE-2020-6524]: Security: memcpy-param-overlap in AudioBuffer::copyFromChannel
Backport https://chromium.googlesource.com/chromium/src/+/2be9b1c27fb97e8a82e068794fc0fba555182c03

Notes: fix: memcpy-param-overlap in AudioBuffer::copyFromChannel. (Chromium security issue 1081722)