### PR TITLE
chore: cherry-pick fix from chromium issue 1080481

### DIFF
--- a/patches/config.json
+++ b/patches/config.json
@@ -19,5 +19,7 @@
 
   "src/electron/patches/usrsctp": "src/third_party/usrsctp/usrsctplib",
 
-  "src/electron/patches/pdfium": "src/third_party/pdfium"
+  "src/electron/patches/pdfium": "src/third_party/pdfium",
+
+  "src/electron/patches/skia": "src/third_party/skia"
 }

--- a/patches/skia/.patches
+++ b/patches/skia/.patches
@@ -1,0 +1,1 @@
+backport_1080481.patch

--- a/patches/skia/backport_1080481.patch
+++ b/patches/skia/backport_1080481.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Thu, 4 Oct 2018 14:57:02 -0700
+Subject: fix: drop SkTextBlobs with > 2M glyphs
+
+[1080481] [Medium] [CVE-2020-6523]: Security: Skia: Integer Overflow in GrTextBlob::Make
+Backport https://skia.googlesource.com/skia.git/+/8d2ebfffaf6ece9a7e9839dca2d7907f241c3460
+
+diff --git a/src/core/SkCanvas.cpp b/src/core/SkCanvas.cpp
+index 519558d2a50e456a3b836c89ed842b8626976c9a..a046678540961097bcf2e81fbd8cc36634e7fb06 100644
+--- a/src/core/SkCanvas.cpp
++++ b/src/core/SkCanvas.cpp
+@@ -2683,6 +2683,19 @@ void SkCanvas::drawTextBlob(const SkTextBlob* blob, SkScalar x, SkScalar y,
+     TRACE_EVENT0("skia", TRACE_FUNC);
+     RETURN_ON_NULL(blob);
+     RETURN_ON_FALSE(blob->bounds().makeOffset(x, y).isFinite());
++
++    // Overflow if more than 2^21 glyphs stopping a buffer overflow latter in the stack.
++    // See chromium:1080481
++    // TODO: can consider unrolling a few at a time if this limit becomes a problem.
++    int totalGlyphCount = 0;
++    constexpr int kMaxGlyphCount = 1 << 21;
++    SkTextBlob::Iter i(*blob);
++    SkTextBlob::Iter::Run r;
++    while (i.next(&r)) {
++        int glyphsLeft = kMaxGlyphCount - totalGlyphCount;
++        RETURN_ON_FALSE(r.fGlyphCount <= glyphsLeft);
++        totalGlyphCount += r.fGlyphCount;
++    }
+     this->onDrawTextBlob(blob, x, y, paint);
+ }
+ 


### PR DESCRIPTION
[[1080481](https://crbug.com/1080481)] [**Medium**] [CVE-2020-6523]: Security: Skia: Integer Overflow in GrTextBlob::Make
Backport https://skia.googlesource.com/skia.git/+/8d2ebfffaf6ece9a7e9839dca2d7907f241c3460

Notes: fix: integer overflow in GrTextBlob::Make. (Chromium security issue 1080481)