### PR TITLE
chore: cherry-pick fix from chromium issue 1065731

### DIFF
--- a/patches/config.json
+++ b/patches/config.json
@@ -11,5 +11,7 @@
 
   "src/electron/patches/webrtc": "src/third_party/webrtc",
 
-  "src/electron/patches/skia": "src/third_party/skia"
+  "src/electron/patches/skia": "src/third_party/skia",
+
+  "src/electron/patches/ffmpeg": "src/third_party/ffmpeg"
 }

--- a/patches/ffmpeg/.patches
+++ b/patches/ffmpeg/.patches
@@ -1,0 +1,1 @@
+backport_1065731.patch

--- a/patches/ffmpeg/backport_1065731.patch
+++ b/patches/ffmpeg/backport_1065731.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Thu, 4 Oct 2018 14:57:02 -0700
+Subject: fix: check return value from avio_read()
+
+[1065731] [Medium]: audio_decoder_fuzzer: Use-of-uninitialized-value in amr_read_header
+Backport https://chromium.googlesource.com/chromium/third_party/ffmpeg.git/+/5b967f56b6d85f62446836fc8ef64d0dcfcbda17
+
+diff --git a/libavformat/amr.c b/libavformat/amr.c
+index eccbbde5b0218e36fd27920850908d88539b9242..b8a5debb167737578f40e3cddc28dbd95871f2b5 100644
+--- a/libavformat/amr.c
++++ b/libavformat/amr.c
+@@ -89,13 +89,15 @@ static int amr_read_header(AVFormatContext *s)
+     AVStream *st;
+     uint8_t header[9];
+ 
+-    avio_read(pb, header, 6);
++    if (avio_read(pb, header, 6) != 6)
++        return AVERROR_INVALIDDATA;
+ 
+     st = avformat_new_stream(s, NULL);
+     if (!st)
+         return AVERROR(ENOMEM);
+     if (memcmp(header, AMR_header, 6)) {
+-        avio_read(pb, header + 6, 3);
++        if (avio_read(pb, header + 6, 3) != 3)
++            return AVERROR_INVALIDDATA;
+         if (memcmp(header, AMRWB_header, 9)) {
+             return -1;
+         }


### PR DESCRIPTION
[[1065731](https://crbug.com/1065731)] [**Medium**]: audio_decoder_fuzzer: Use-of-uninitialized-value in amr_read_header
Backport https://chromium.googlesource.com/chromium/third_party/ffmpeg.git/+/5b967f56b6d85f62446836fc8ef64d0dcfcbda17

Notes: fix: use-of-uninitialized-value in amr_read_header. (Chromium security issue 1065731)