### PR TITLE
chore: cherry-pick fix from chromium issue 1052492

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -117,3 +117,4 @@ avoid_using_x11_shm_for_remote_connections.patch
 backport_1065122.patch
 backport_1074317.patch
 backport_1090543.patch
+backport_1052492.patch

--- a/patches/chromium/backport_1052492.patch
+++ b/patches/chromium/backport_1052492.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Thu, 4 Oct 2018 14:57:02 -0700
+Subject: fix: adding a new MSAN check to validate if the skImage is
+ initialized
+
+[1052492] [Medium]: Use-of-uninitialized-value in blink::ImageDataBuffer::ImageDataBuffer
+Backport https://chromium.googlesource.com/chromium/src/+/bad271a777cf623ddcd6908e9de6ec5bbcd51f6a
+
+diff --git a/third_party/blink/renderer/platform/graphics/image_data_buffer.cc b/third_party/blink/renderer/platform/graphics/image_data_buffer.cc
+index fe622fba3ae9a6f9a6b1915309fefea5c38a8cf7..9abb2b2747e0f44dd909179140bf05ee5985802e 100644
+--- a/third_party/blink/renderer/platform/graphics/image_data_buffer.cc
++++ b/third_party/blink/renderer/platform/graphics/image_data_buffer.cc
+@@ -54,6 +54,13 @@ ImageDataBuffer::ImageDataBuffer(scoped_refptr<StaticBitmapImage> image) {
+   retained_image_ = image->PaintImageForCurrentFrame().GetSkImage();
+   if (!retained_image_)
+     return;
++#if defined(MEMORY_SANITIZER)
++  // Test if retained_image has an initialized pixmap.
++  SkPixmap pixmap;
++  if (retained_image_->peekPixels(&pixmap))
++    MSAN_CHECK_MEM_IS_INITIALIZED(pixmap.addr(), pixmap.computeByteSize());
++#endif
++
+   if (retained_image_->isTextureBacked() ||
+       retained_image_->isLazyGenerated() ||
+       retained_image_->alphaType() != kUnpremul_SkAlphaType) {


### PR DESCRIPTION
[[1052492](https://crbug.com/1052492)] [**Medium**]: Use-of-uninitialized-value in blink::ImageDataBuffer::ImageDataBuffer
Backport https://chromium.googlesource.com/chromium/src/+/bad271a777cf623ddcd6908e9de6ec5bbcd51f6a

Notes: fix: use-of-uninitialized-value in blink::ImageDataBuffer::ImageDataBuffer. (Chromium security issue 1052492)