### PR TITLE
refactor: stop using isolate() in WebContents

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -721,10 +721,12 @@ void WebContents::AddNewContents(
   auto* tracker = ChildWebContentsTracker::FromWebContents(new_contents.get());
   DCHECK(tracker);
 
-  v8::Locker locker(isolate());
-  v8::HandleScope handle_scope(isolate());
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+
+  v8::Locker locker(isolate);
+  v8::HandleScope handle_scope(isolate);
   auto api_web_contents =
-      CreateAndTake(isolate(), std::move(new_contents), Type::BROWSER_WINDOW);
+      CreateAndTake(isolate, std::move(new_contents), Type::BROWSER_WINDOW);
   if (Emit("-add-new-contents", api_web_contents, disposition, user_gesture,
            initial_rect.x(), initial_rect.y(), initial_rect.width(),
            initial_rect.height(), tracker->url, tracker->frame_name,
@@ -896,9 +898,10 @@ void WebContents::FindReply(content::WebContents* web_contents,
   if (!final_update)
     return;
 
-  v8::Locker locker(isolate());
-  v8::HandleScope handle_scope(isolate());
-  gin_helper::Dictionary result = gin::Dictionary::CreateEmpty(isolate());
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::Locker locker(isolate);
+  v8::HandleScope handle_scope(isolate);
+  gin_helper::Dictionary result = gin::Dictionary::CreateEmpty(isolate);
   result.Set("requestId", request_id);
   result.Set("matches", number_of_matches);
   result.Set("selectionArea", selection_rect);
@@ -1003,9 +1006,9 @@ void WebContents::RenderViewDeleted(content::RenderViewHost* render_view_host) {
 
 void WebContents::RenderProcessGone(base::TerminationStatus status) {
   Emit("crashed", status == base::TERMINATION_STATUS_PROCESS_WAS_KILLED);
-  v8::HandleScope handle_scope(isolate());
-  gin_helper::Dictionary details =
-      gin_helper::Dictionary::CreateEmpty(isolate());
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope handle_scope(isolate);
+  gin_helper::Dictionary details = gin_helper::Dictionary::CreateEmpty(isolate);
   details.Set("reason", status);
   Emit("render-process-gone", details);
 }
@@ -1153,11 +1156,12 @@ void WebContents::Invoke(bool internal,
 
 void WebContents::ReceivePostMessage(const std::string& channel,
                                      blink::TransferableMessage message) {
-  v8::HandleScope handle_scope(isolate());
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope handle_scope(isolate);
   auto wrapped_ports =
-      MessagePort::EntanglePorts(isolate(), std::move(message.ports));
+      MessagePort::EntanglePorts(isolate, std::move(message.ports));
   v8::Local<v8::Value> message_value =
-      electron::DeserializeV8Value(isolate(), message);
+      electron::DeserializeV8Value(isolate, message);
   EmitWithSender("-ipc-ports", receivers_.current_context(), InvokeCallback(),
                  false, channel, message_value, std::move(wrapped_ports));
 }
@@ -1165,8 +1169,9 @@ void WebContents::ReceivePostMessage(const std::string& channel,
 void WebContents::PostMessage(const std::string& channel,
                               v8::Local<v8::Value> message_value,
                               base::Optional<v8::Local<v8::Value>> transfer) {
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   blink::TransferableMessage transferable_message;
-  if (!electron::SerializeV8Value(isolate(), message_value,
+  if (!electron::SerializeV8Value(isolate, message_value,
                                   &transferable_message)) {
     // SerializeV8Value sets an exception.
     return;
@@ -1174,16 +1179,16 @@ void WebContents::PostMessage(const std::string& channel,
 
   std::vector<gin::Handle<MessagePort>> wrapped_ports;
   if (transfer) {
-    if (!gin::ConvertFromV8(isolate(), *transfer, &wrapped_ports)) {
-      isolate()->ThrowException(v8::Exception::Error(
-          gin::StringToV8(isolate(), "Invalid value for transfer")));
+    if (!gin::ConvertFromV8(isolate, *transfer, &wrapped_ports)) {
+      isolate->ThrowException(v8::Exception::Error(
+          gin::StringToV8(isolate, "Invalid value for transfer")));
       return;
     }
   }
 
   bool threw_exception = false;
   transferable_message.ports =
-      MessagePort::DisentanglePorts(isolate(), wrapped_ports, &threw_exception);
+      MessagePort::DisentanglePorts(isolate, wrapped_ports, &threw_exception);
   if (threw_exception)
     return;
 
@@ -1211,8 +1216,9 @@ void WebContents::MessageTo(bool internal,
                             const std::string& channel,
                             blink::CloneableMessage arguments) {
   TRACE_EVENT1("electron", "WebContents::MessageTo", "channel", channel);
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   auto* web_contents = gin_helper::TrackableObject<WebContents>::FromWeakMapID(
-      isolate(), web_contents_id);
+      isolate, web_contents_id);
 
   if (web_contents) {
     web_contents->SendIPCMessageWithSender(internal, send_to_all, channel,
@@ -1352,11 +1358,12 @@ void WebContents::DevToolsFocused() {
 }
 
 void WebContents::DevToolsOpened() {
-  v8::Locker locker(isolate());
-  v8::HandleScope handle_scope(isolate());
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::Locker locker(isolate);
+  v8::HandleScope handle_scope(isolate);
   auto handle =
-      FromOrCreate(isolate(), managed_web_contents()->GetDevToolsWebContents());
-  devtools_web_contents_.Reset(isolate(), handle.ToV8());
+      FromOrCreate(isolate, managed_web_contents()->GetDevToolsWebContents());
+  devtools_web_contents_.Reset(isolate, handle.ToV8());
 
   // Set inspected tabID.
   base::Value tab_id(ID());
@@ -1373,8 +1380,9 @@ void WebContents::DevToolsOpened() {
 }
 
 void WebContents::DevToolsClosed() {
-  v8::Locker locker(isolate());
-  v8::HandleScope handle_scope(isolate());
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::Locker locker(isolate);
+  v8::HandleScope handle_scope(isolate);
   devtools_web_contents_.Reset();
 
   Emit("devtools-closed");
@@ -1656,7 +1664,8 @@ std::string WebContents::GetUserAgent() {
 v8::Local<v8::Promise> WebContents::SavePage(
     const base::FilePath& full_file_path,
     const content::SavePageType& save_type) {
-  gin_helper::Promise<void> promise(isolate());
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  gin_helper::Promise<void> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
   auto* handler = new SavePageHandler(web_contents(), std::move(promise));
@@ -2074,7 +2083,8 @@ std::vector<printing::PrinterBasicInfo> WebContents::GetPrinterList() {
 }
 
 v8::Local<v8::Promise> WebContents::PrintToPDF(base::DictionaryValue settings) {
-  gin_helper::Promise<v8::Local<v8::Value>> promise(isolate());
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  gin_helper::Promise<v8::Local<v8::Value>> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
   PrintPreviewMessageHandler::FromWebContents(web_contents())
       ->PrintToPDF(std::move(settings), std::move(promise));
@@ -2216,10 +2226,11 @@ bool WebContents::SendIPCMessage(bool internal,
                                  bool send_to_all,
                                  const std::string& channel,
                                  v8::Local<v8::Value> args) {
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   blink::CloneableMessage message;
-  if (!gin::ConvertFromV8(isolate(), args, &message)) {
-    isolate()->ThrowException(v8::Exception::Error(
-        gin::StringToV8(isolate(), "Failed to serialize arguments")));
+  if (!gin::ConvertFromV8(isolate, args, &message)) {
+    isolate->ThrowException(v8::Exception::Error(
+        gin::StringToV8(isolate, "Failed to serialize arguments")));
     return false;
   }
   return SendIPCMessageWithSender(internal, send_to_all, channel,
@@ -2256,10 +2267,11 @@ bool WebContents::SendIPCMessageToFrame(bool internal,
                                         int32_t frame_id,
                                         const std::string& channel,
                                         v8::Local<v8::Value> args) {
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   blink::CloneableMessage message;
-  if (!gin::ConvertFromV8(isolate(), args, &message)) {
-    isolate()->ThrowException(v8::Exception::Error(
-        gin::StringToV8(isolate(), "Failed to serialize arguments")));
+  if (!gin::ConvertFromV8(isolate, args, &message)) {
+    isolate->ThrowException(v8::Exception::Error(
+        gin::StringToV8(isolate, "Failed to serialize arguments")));
     return false;
   }
   auto frames = web_contents()->GetAllFrames();
@@ -2384,7 +2396,7 @@ void WebContents::StartDrag(const gin_helper::Dictionary& item,
 
 v8::Local<v8::Promise> WebContents::CapturePage(gin_helper::Arguments* args) {
   gfx::Rect rect;
-  gin_helper::Promise<gfx::Image> promise(isolate());
+  gin_helper::Promise<gfx::Image> promise(args->isolate());
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
   // get rect arguments if they exist
@@ -2595,11 +2607,12 @@ v8::Local<v8::Value> WebContents::GetLastWebPreferences(
   return gin::ConvertToV8(isolate, *web_preferences->last_preference());
 }
 
-v8::Local<v8::Value> WebContents::GetOwnerBrowserWindow() const {
+v8::Local<v8::Value> WebContents::GetOwnerBrowserWindow(
+    v8::Isolate* isolate) const {
   if (owner_window())
-    return BrowserWindow::From(isolate(), owner_window());
+    return BrowserWindow::From(isolate, owner_window());
   else
-    return v8::Null(isolate());
+    return v8::Null(isolate);
 }
 
 int32_t WebContents::ID() const {
@@ -2640,12 +2653,12 @@ void WebContents::SetDevToolsWebContents(const WebContents* devtools) {
     managed_web_contents()->SetDevToolsWebContents(devtools->web_contents());
 }
 
-v8::Local<v8::Value> WebContents::GetNativeView() const {
+v8::Local<v8::Value> WebContents::GetNativeView(v8::Isolate* isolate) const {
   gfx::NativeView ptr = web_contents()->GetNativeView();
-  auto buffer = node::Buffer::Copy(isolate(), reinterpret_cast<char*>(&ptr),
+  auto buffer = node::Buffer::Copy(isolate, reinterpret_cast<char*>(&ptr),
                                    sizeof(gfx::NativeView));
   if (buffer.IsEmpty())
-    return v8::Null(isolate());
+    return v8::Null(isolate);
   else
     return buffer.ToLocalChecked();
 }
@@ -2681,8 +2694,9 @@ void WebContents::NotifyUserActivation() {
 }
 
 v8::Local<v8::Promise> WebContents::TakeHeapSnapshot(
+    v8::Isolate* isolate,
     const base::FilePath& file_path) {
-  gin_helper::Promise<void> promise(isolate());
+  gin_helper::Promise<void> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
   base::ThreadRestrictions::ScopedAllowIO allow_io;

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -232,7 +232,7 @@ class WebContents : public gin_helper::TrackableObject<WebContents>,
   bool IsCurrentlyAudible();
   void SetEmbedder(const WebContents* embedder);
   void SetDevToolsWebContents(const WebContents* devtools);
-  v8::Local<v8::Value> GetNativeView() const;
+  v8::Local<v8::Value> GetNativeView(v8::Isolate* isolate) const;
   void IncrementCapturerCount(gin_helper::Arguments* args);
   void DecrementCapturerCount(gin_helper::Arguments* args);
   bool IsBeingCaptured();
@@ -359,7 +359,7 @@ class WebContents : public gin_helper::TrackableObject<WebContents>,
   v8::Local<v8::Value> GetLastWebPreferences(v8::Isolate* isolate) const;
 
   // Returns the owner window.
-  v8::Local<v8::Value> GetOwnerBrowserWindow() const;
+  v8::Local<v8::Value> GetOwnerBrowserWindow(v8::Isolate* isolate) const;
 
   // Grants the child process the capability to access URLs with the origin of
   // the specified URL.
@@ -368,7 +368,8 @@ class WebContents : public gin_helper::TrackableObject<WebContents>,
   // Notifies the web page that there is user interaction.
   void NotifyUserActivation();
 
-  v8::Local<v8::Promise> TakeHeapSnapshot(const base::FilePath& file_path);
+  v8::Local<v8::Promise> TakeHeapSnapshot(v8::Isolate* isolate,
+                                          const base::FilePath& file_path);
 
   // Properties.
   int32_t ID() const;


### PR DESCRIPTION
#### Description of Change
This refactors api::WebContents to not use the isolate() member function from TrackableObject, in preparation for switching WebContents away from gin_helper.

#### Release Notes

Notes: none