### PR TITLE
refactor: WebContents::From returns pointer

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -712,9 +712,9 @@ bool App::CanCreateWindow(
   content::WebContents* web_contents =
       content::WebContents::FromRenderFrameHost(opener);
   if (web_contents) {
-    auto api_web_contents = WebContents::From(isolate(), web_contents);
+    WebContents* api_web_contents = WebContents::From(web_contents);
     // No need to emit any event if the WebContents is not available in JS.
-    if (!api_web_contents.IsEmpty()) {
+    if (api_web_contents) {
       api_web_contents->OnCreateWindow(target_url, referrer, frame_name,
                                        disposition, raw_features, body);
     }

--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -215,8 +215,7 @@ std::string DesktopCapturer::GetMediaSourceIdForWebContents(
     int32_t request_web_contents_id,
     int32_t web_contents_id) {
   std::string id;
-  auto* web_contents = gin_helper::TrackableObject<WebContents>::FromWeakMapID(
-      isolate, web_contents_id);
+  auto* web_contents = WebContents::FromID(web_contents_id);
 
   if (!web_contents) {
     thrower.ThrowError("Failed to find WebContents with id " +
@@ -232,9 +231,7 @@ std::string DesktopCapturer::GetMediaSourceIdForWebContents(
       content::WebContentsMediaCaptureId(main_frame->GetProcess()->GetID(),
                                          main_frame->GetRoutingID()));
 
-  auto* request_web_contents =
-      gin_helper::TrackableObject<WebContents>::FromWeakMapID(
-          isolate, request_web_contents_id);
+  auto* request_web_contents = WebContents::FromID(request_web_contents_id);
   if (request_web_contents) {
     // comment copied from
     // chrome/browser/extensions/api/desktop_capture/desktop_capture_base.cc

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -944,7 +944,7 @@ std::unique_ptr<content::BluetoothChooser> WebContents::RunBluetoothChooser(
 content::JavaScriptDialogManager* WebContents::GetJavaScriptDialogManager(
     content::WebContents* source) {
   if (!dialog_manager_)
-    dialog_manager_ = std::make_unique<ElectronJavaScriptDialogManager>(this);
+    dialog_manager_ = std::make_unique<ElectronJavaScriptDialogManager>();
 
   return dialog_manager_.get();
 }
@@ -2864,24 +2864,25 @@ gin::Handle<WebContents> WebContents::CreateAndTake(
 }
 
 // static
-gin::Handle<WebContents> WebContents::From(v8::Isolate* isolate,
-                                           content::WebContents* web_contents) {
+WebContents* WebContents::From(content::WebContents* web_contents) {
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   auto* existing = TrackableObject::FromWrappedClass(isolate, web_contents);
-  if (existing)
-    return gin::CreateHandle(isolate, static_cast<WebContents*>(existing));
-  else
-    return gin::Handle<WebContents>();
+  return static_cast<WebContents*>(existing);
 }
 
 // static
 gin::Handle<WebContents> WebContents::FromOrCreate(
     v8::Isolate* isolate,
     content::WebContents* web_contents) {
-  auto existing = From(isolate, web_contents);
-  if (!existing.IsEmpty())
-    return existing;
-  else
-    return gin::CreateHandle(isolate, new WebContents(isolate, web_contents));
+  WebContents* api_web_contents = From(web_contents);
+  if (!api_web_contents)
+    api_web_contents = new WebContents(isolate, web_contents);
+  return gin::CreateHandle(isolate, api_web_contents);
+}
+
+// static
+WebContents* WebContents::FromID(int32_t id) {
+  return FromWeakMapID(JavascriptEnvironment::GetIsolate(), id);
 }
 
 }  // namespace api

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -154,9 +154,10 @@ class WebContents : public gin_helper::TrackableObject<WebContents>,
       std::unique_ptr<content::WebContents> web_contents,
       Type type);
 
-  // Get the V8 wrapper of |web_content|, return empty handle if not wrapped.
-  static gin::Handle<WebContents> From(v8::Isolate* isolate,
-                                       content::WebContents* web_content);
+  // Get the api::WebContents associated with |web_contents|. Returns nullptr
+  // if there is no associated wrapper.
+  static WebContents* From(content::WebContents* web_contents);
+  static WebContents* FromID(int32_t id);
 
   // Get the V8 wrapper of the |web_contents|, or create one if not existed.
   //

--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -31,7 +31,7 @@ WebContentsView::WebContentsView(v8::Isolate* isolate,
 #else
     : View(web_contents->managed_web_contents()->GetView()->GetView()),
 #endif
-      web_contents_(isolate, web_contents->GetWrapper()),
+      web_contents_(isolate, web_contents.ToV8()),
       api_web_contents_(web_contents.get()) {
 #if !defined(OS_MACOSX)
   // On macOS the View is a newly-created |DelayedNativeViewHost| and it is our

--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -143,10 +143,9 @@ void ToDictionary(gin::Dictionary* details, extensions::WebRequestInfo* info) {
   auto* web_contents = content::WebContents::FromRenderFrameHost(
       content::RenderFrameHost::FromID(info->render_process_id,
                                        info->frame_id));
-  int32_t id = api::WebContents::GetIDFromWrappedClass(web_contents);
-  // id must be greater than zero.
-  if (id > 0)
-    details->Set("webContentsId", id);
+  auto* api_web_contents = WebContents::From(web_contents);
+  if (api_web_contents)
+    details->Set("webContentsId", api_web_contents->ID());
 }
 
 void ToDictionary(gin::Dictionary* details,

--- a/shell/browser/electron_autofill_driver.cc
+++ b/shell/browser/electron_autofill_driver.cc
@@ -31,10 +31,8 @@ void AutofillDriver::ShowAutofillPopup(
     const std::vector<base::string16>& labels) {
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope scope(isolate);
-  auto* web_contents =
-      api::WebContents::From(isolate, content::WebContents::FromRenderFrameHost(
-                                          render_frame_host_))
-          .get();
+  auto* web_contents = api::WebContents::From(
+      content::WebContents::FromRenderFrameHost(render_frame_host_));
   if (!web_contents || !web_contents->owner_window())
     return;
 

--- a/shell/browser/electron_javascript_dialog_manager.cc
+++ b/shell/browser/electron_javascript_dialog_manager.cc
@@ -27,9 +27,7 @@ constexpr int kUserWantsNoMoreDialogs = -1;
 
 }  // namespace
 
-ElectronJavaScriptDialogManager::ElectronJavaScriptDialogManager(
-    api::WebContents* api_web_contents)
-    : api_web_contents_(api_web_contents) {}
+ElectronJavaScriptDialogManager::ElectronJavaScriptDialogManager() {}
 ElectronJavaScriptDialogManager::~ElectronJavaScriptDialogManager() = default;
 
 void ElectronJavaScriptDialogManager::RunJavaScriptDialog(
@@ -115,9 +113,11 @@ void ElectronJavaScriptDialogManager::RunBeforeUnloadDialog(
     content::RenderFrameHost* rfh,
     bool is_reload,
     DialogClosedCallback callback) {
-  bool default_prevented = api_web_contents_->Emit("will-prevent-unload");
-  std::move(callback).Run(default_prevented, base::string16());
-  return;
+  auto* api_web_contents = api::WebContents::From(web_contents);
+  if (api_web_contents) {
+    bool default_prevented = api_web_contents->Emit("will-prevent-unload");
+    std::move(callback).Run(default_prevented, base::string16());
+  }
 }
 
 void ElectronJavaScriptDialogManager::CancelDialogs(

--- a/shell/browser/electron_javascript_dialog_manager.h
+++ b/shell/browser/electron_javascript_dialog_manager.h
@@ -19,7 +19,7 @@ class WebContents;
 class ElectronJavaScriptDialogManager
     : public content::JavaScriptDialogManager {
  public:
-  explicit ElectronJavaScriptDialogManager();
+  ElectronJavaScriptDialogManager();
   ~ElectronJavaScriptDialogManager() override;
 
   // content::JavaScriptDialogManager implementations.

--- a/shell/browser/electron_javascript_dialog_manager.h
+++ b/shell/browser/electron_javascript_dialog_manager.h
@@ -19,7 +19,7 @@ class WebContents;
 class ElectronJavaScriptDialogManager
     : public content::JavaScriptDialogManager {
  public:
-  explicit ElectronJavaScriptDialogManager(api::WebContents* api_web_contents);
+  explicit ElectronJavaScriptDialogManager();
   ~ElectronJavaScriptDialogManager() override;
 
   // content::JavaScriptDialogManager implementations.
@@ -43,7 +43,6 @@ class ElectronJavaScriptDialogManager
                             int code,
                             bool checkbox_checked);
 
-  api::WebContents* api_web_contents_;
   std::map<std::string, int> origin_counts_;
 };
 

--- a/shell/browser/electron_navigation_throttle.cc
+++ b/shell/browser/electron_navigation_throttle.cc
@@ -31,8 +31,8 @@ ElectronNavigationThrottle::WillRedirectRequest() {
 
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope scope(isolate);
-  auto api_contents = electron::api::WebContents::From(isolate, contents);
-  if (api_contents.IsEmpty()) {
+  api::WebContents* api_contents = api::WebContents::From(contents);
+  if (!api_contents) {
     // No need to emit any event if the WebContents is not available in JS.
     return PROCEED;
   }

--- a/shell/browser/extensions/api/streams_private/streams_private_api.cc
+++ b/shell/browser/extensions/api/streams_private/streams_private_api.cc
@@ -58,8 +58,7 @@ void StreamsPrivateAPI::SendExecuteMimeTypeHandlerEvent(
       extensions::Extension::GetBaseURLFromExtensionId(extension_id).spec() +
       handler->handler_url());
   int tab_id = -1;
-  auto* api_contents = electron::api::WebContents::FromWrappedClass(
-      v8::Isolate::GetCurrent(), web_contents);
+  auto* api_contents = electron::api::WebContents::From(web_contents);
   if (api_contents)
     tab_id = api_contents->ID();
   std::unique_ptr<extensions::StreamContainer> stream_container(

--- a/shell/browser/extensions/api/tabs/tabs_api.cc
+++ b/shell/browser/extensions/api/tabs/tabs_api.cc
@@ -92,8 +92,7 @@ bool ExecuteCodeInTabFunction::CanExecuteScriptOnPage(std::string* error) {
   // If |tab_id| is specified, look for the tab. Otherwise default to selected
   // tab in the current window.
   CHECK_GE(execute_tab_id_, 0);
-  auto* contents = electron::api::WebContents::FromWeakMapID(
-      v8::Isolate::GetCurrent(), execute_tab_id_);
+  auto* contents = electron::api::WebContents::FromID(execute_tab_id_);
   if (!contents) {
     return false;
   }
@@ -146,8 +145,7 @@ bool ExecuteCodeInTabFunction::CanExecuteScriptOnPage(std::string* error) {
 
 ScriptExecutor* ExecuteCodeInTabFunction::GetScriptExecutor(
     std::string* error) {
-  auto* contents = electron::api::WebContents::FromWeakMapID(
-      v8::Isolate::GetCurrent(), execute_tab_id_);
+  auto* contents = electron::api::WebContents::FromID(execute_tab_id_);
   if (!contents)
     return nullptr;
   return contents->script_executor();
@@ -170,8 +168,7 @@ ExtensionFunction::ResponseAction TabsGetFunction::Run() {
   EXTENSION_FUNCTION_VALIDATE(params.get());
   int tab_id = params->tab_id;
 
-  auto* contents = electron::api::WebContents::FromWeakMapID(
-      v8::Isolate::GetCurrent(), tab_id);
+  auto* contents = electron::api::WebContents::FromID(tab_id);
   if (!contents)
     return RespondNow(Error("No such tab"));
 
@@ -193,8 +190,7 @@ ExtensionFunction::ResponseAction TabsSetZoomFunction::Run() {
   EXTENSION_FUNCTION_VALIDATE(params);
 
   int tab_id = params->tab_id ? *params->tab_id : -1;
-  auto* contents = electron::api::WebContents::FromWeakMapID(
-      v8::Isolate::GetCurrent(), tab_id);
+  auto* contents = electron::api::WebContents::FromID(tab_id);
   if (!contents)
     return RespondNow(Error("No such tab"));
 
@@ -222,8 +218,7 @@ ExtensionFunction::ResponseAction TabsGetZoomFunction::Run() {
   EXTENSION_FUNCTION_VALIDATE(params);
 
   int tab_id = params->tab_id ? *params->tab_id : -1;
-  auto* contents = electron::api::WebContents::FromWeakMapID(
-      v8::Isolate::GetCurrent(), tab_id);
+  auto* contents = electron::api::WebContents::FromID(tab_id);
   if (!contents)
     return RespondNow(Error("No such tab"));
 
@@ -239,8 +234,7 @@ ExtensionFunction::ResponseAction TabsGetZoomSettingsFunction::Run() {
   EXTENSION_FUNCTION_VALIDATE(params);
 
   int tab_id = params->tab_id ? *params->tab_id : -1;
-  auto* contents = electron::api::WebContents::FromWeakMapID(
-      v8::Isolate::GetCurrent(), tab_id);
+  auto* contents = electron::api::WebContents::FromID(tab_id);
   if (!contents)
     return RespondNow(Error("No such tab"));
 
@@ -265,8 +259,7 @@ ExtensionFunction::ResponseAction TabsSetZoomSettingsFunction::Run() {
   EXTENSION_FUNCTION_VALIDATE(params);
 
   int tab_id = params->tab_id ? *params->tab_id : -1;
-  auto* contents = electron::api::WebContents::FromWeakMapID(
-      v8::Isolate::GetCurrent(), tab_id);
+  auto* contents = electron::api::WebContents::FromID(tab_id);
   if (!contents)
     return RespondNow(Error("No such tab"));
 

--- a/shell/browser/extensions/electron_messaging_delegate.cc
+++ b/shell/browser/extensions/electron_messaging_delegate.cc
@@ -41,8 +41,7 @@ ElectronMessagingDelegate::IsNativeMessagingHostAllowed(
 std::unique_ptr<base::DictionaryValue>
 ElectronMessagingDelegate::MaybeGetTabInfo(content::WebContents* web_contents) {
   if (web_contents) {
-    auto* api_contents = electron::api::WebContents::FromWrappedClass(
-        v8::Isolate::GetCurrent(), web_contents);
+    auto* api_contents = electron::api::WebContents::From(web_contents);
     if (api_contents) {
       auto tab = std::make_unique<base::DictionaryValue>();
       tab->SetWithoutPathExpansion(
@@ -63,8 +62,7 @@ ElectronMessagingDelegate::MaybeGetTabInfo(content::WebContents* web_contents) {
 content::WebContents* ElectronMessagingDelegate::GetWebContentsByTabId(
     content::BrowserContext* browser_context,
     int tab_id) {
-  auto* contents = electron::api::WebContents::FromWeakMapID(
-      v8::Isolate::GetCurrent(), tab_id);
+  auto* contents = electron::api::WebContents::FromID(tab_id);
   if (!contents) {
     return nullptr;
   }

--- a/shell/browser/login_handler.cc
+++ b/shell/browser/login_handler.cc
@@ -54,8 +54,8 @@ void LoginHandler::EmitEvent(
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope scope(isolate);
 
-  auto api_web_contents = api::WebContents::From(isolate, web_contents());
-  if (api_web_contents.IsEmpty()) {
+  api::WebContents* api_web_contents = api::WebContents::From(web_contents());
+  if (!api_web_contents) {
     std::move(auth_required_callback_).Run(base::nullopt);
     return;
   }


### PR DESCRIPTION
#### Description of Change
This introduces an abstraction for fetching an api::WebContents by ID or from the related content::WebContents, instead of having callers directly use the TrackableObject API. This is in preparation for refactoring api::WebContents away from TrackableObject.

#### Release Notes

Notes: none