### PR TITLE
fix: broken --trace-sync-io flag in Node.js

### DIFF
--- a/script/node-disabled-tests.json
+++ b/script/node-disabled-tests.json
@@ -123,7 +123,6 @@
   "parallel/test-signal-handler",
   "parallel/test-source-map",
   "parallel/test-stdout-close-catch",
-  "parallel/test-sync-io-option",
   "parallel/test-tls-cert-chains-concat",
   "parallel/test-tls-cert-chains-in-ca",
   "parallel/test-tls-cli-max-version-1.2",

--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -201,6 +201,8 @@ int NodeMain(int argc, char* argv[]) {
 
     node::LoadEnvironment(env);
 
+    env->set_trace_sync_io(env->options()->trace_sync_io);
+
     {
       v8::SealHandleScope seal(isolate);
       bool more;
@@ -224,6 +226,9 @@ int NodeMain(int argc, char* argv[]) {
     }
 
     node_debugger.Stop();
+
+    env->set_trace_sync_io(false);
+
     exit_code = node::EmitExit(env);
 
     node::ResetStdio();

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -331,6 +331,8 @@ void ElectronBrowserMainParts::PostEarlyInitialization() {
   node_debugger_ = std::make_unique<NodeDebugger>(env);
   node_debugger_->Start();
 
+  env->set_trace_sync_io(env->options()->trace_sync_io);
+
   // Add Electron extended APIs.
   electron_bindings_->BindTo(js_env_->isolate(), env->process_object());
 
@@ -549,6 +551,7 @@ void ElectronBrowserMainParts::PostMainMessageLoopRun() {
   // Destroy node platform after all destructors_ are executed, as they may
   // invoke Node/V8 APIs inside them.
   node_debugger_->Stop();
+  node_env_->env()->set_trace_sync_io(false);
   node_env_.reset();
   js_env_->OnMessageLoopDestroying();
 


### PR DESCRIPTION
Backport of #24529

See that PR for details.


Notes: Fixed broken `--trace-sync-io` flag in Node.js.
