### PR TITLE
fix: broken --trace-sync-io flag in Node.js

### DIFF
--- a/script/node-disabled-tests.json
+++ b/script/node-disabled-tests.json
@@ -6,7 +6,6 @@
   "parallel/test-async-hooks-top-level-clearimmediate",
   "parallel/test-inspector-async-hook-after-done",
   "parallel/test-inspector-workers-flat-list",
-  "parallel/test-sync-io-option",
   "parallel/test-heapdump-async-hooks-init-promise",
   "parallel/test-http2-reset-flood",
   "parallel/test-bootstrap-modules",

--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -130,6 +130,8 @@ int NodeMain(int argc, char* argv[]) {
 
     node::LoadEnvironment(env);
 
+    env->set_trace_sync_io(env->options()->trace_sync_io);
+
     bool more;
     do {
       more = uv_run(env->event_loop(), UV_RUN_ONCE);
@@ -146,6 +148,9 @@ int NodeMain(int argc, char* argv[]) {
     } while (more == true);
 
     node_debugger.Stop();
+
+    env->set_trace_sync_io(false);
+
     exit_code = node::EmitExit(env);
     env->set_can_call_into_js(false);
     node::RunAtExit(env);

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -336,6 +336,8 @@ void ElectronBrowserMainParts::PostEarlyInitialization() {
   node_debugger_ = std::make_unique<NodeDebugger>(env);
   node_debugger_->Start();
 
+  env->set_trace_sync_io(env->options()->trace_sync_io);
+
   // Add Electron extended APIs.
   electron_bindings_->BindTo(js_env_->isolate(), env->process_object());
 
@@ -550,6 +552,7 @@ void ElectronBrowserMainParts::PostMainMessageLoopRun() {
   // Destroy node platform after all destructors_ are executed, as they may
   // invoke Node/V8 APIs inside them.
   node_debugger_->Stop();
+  node_env_->env()->set_trace_sync_io(false);
   node_env_.reset();
   js_env_->OnMessageLoopDestroying();
 


### PR DESCRIPTION
Backport of #24529

See that PR for details.


Notes: Fixed broken `--trace-sync-io` flag in Node.js.
