### PR TITLE
docs: update the URL for catapult's trace viewer.

### DIFF
--- a/docs/api/content-tracing.md
+++ b/docs/api/content-tracing.md
@@ -83,4 +83,4 @@ Returns `Promise<Object>` - Resolves with an object containing the `value` and `
 Get the maximum usage across processes of trace buffer as a percentage of the
 full state.
 
-[trace viewer]: https://github.com/catapult-project/catapult/blob/master/tracing
+[trace viewer]: https://chromium.googlesource.com/catapult/+/HEAD/tracing/README.md


### PR DESCRIPTION
#### Description of Change

Teeny PR to fix the trace-viewer URL that we link to in docs: The old URL points to a now-archived repo; the updated URL points to catapult's landing page for trace-viewer.

CC @electron/wg-releases 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: none