### PR TITLE
fix: Allow VoiceOver to navigate "back into" web contents

### DIFF
--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -130,7 +130,7 @@ bool ScopedDisableResize::disable_resize_ = false;
   // the window title instead of using Cmd+C to get the selected text.
   NSPredicate* predicate = [NSPredicate
       predicateWithFormat:@"(self isKindOfClass: %@) OR (self.className == %@)",
-                          [NSButtonCell class], @"ElectronAdaptedContentView"];
+                          [NSButtonCell class], @"BrowserAccessibilityCocoa"];
 
   NSArray* children = [super accessibilityAttributeValue:attribute];
   NSMutableArray* mutableChildren = [[children mutableCopy] autorelease];

--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -121,16 +121,16 @@ bool ScopedDisableResize::disable_resize_ = false;
   if (![attribute isEqualToString:@"AXChildren"])
     return [super accessibilityAttributeValue:attribute];
 
-  // Filter out objects that aren't the title bar buttons. This has the effect
-  // of removing the window title, which VoiceOver already sees.
+  // We want to remove the window title (also known as
+  // NSAccessibilityReparentingCellProxy), which VoiceOver already sees.
   // * when VoiceOver is disabled, this causes Cmd+C to be used for TTS but
   //   still leaves the buttons available in the accessibility tree.
   // * when VoiceOver is enabled, the full accessibility tree is used.
   // Without removing the title and with VO disabled, the TTS would always read
   // the window title instead of using Cmd+C to get the selected text.
-  NSPredicate* predicate = [NSPredicate
-      predicateWithFormat:@"(self isKindOfClass: %@) OR (self.className == %@)",
-                          [NSButtonCell class], @"BrowserAccessibilityCocoa"];
+  NSPredicate* predicate =
+      [NSPredicate predicateWithFormat:@"(self.className != %@)",
+                                       @"NSAccessibilityReparentingCellProxy"];
 
   NSArray* children = [super accessibilityAttributeValue:attribute];
   NSMutableArray* mutableChildren = [[children mutableCopy] autorelease];

--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -130,19 +130,11 @@ bool ScopedDisableResize::disable_resize_ = false;
   // the window title instead of using Cmd+C to get the selected text.
   NSPredicate* predicate = [NSPredicate
       predicateWithFormat:@"(self isKindOfClass: %@) OR (self.className == %@)",
-                          [NSButtonCell class], @"RenderWidgetHostViewCocoa"];
+                          [NSButtonCell class], @"ElectronAdaptedContentView"];
 
   NSArray* children = [super accessibilityAttributeValue:attribute];
   NSMutableArray* mutableChildren = [[children mutableCopy] autorelease];
   [mutableChildren filterUsingPredicate:predicate];
-
-  // We need to add the web contents: Without us doing so, VoiceOver
-  // users will be able to navigate up the a11y tree, but not back down.
-  // The content view contains the "web contents", which VoiceOver
-  // immediately understands.
-  NSView* contentView =
-      [shell_->GetNativeWindow().GetNativeNSWindow() contentView];
-  [mutableChildren addObject:contentView];
 
   return mutableChildren;
 }


### PR DESCRIPTION
#### Description of Change

After some consultation with our friends at Apple, I've figured out why exactly VoiceOver has such trouble getting "back into" web contents when it was first navigated out. As it turns out, by default, there is no `RenderWidgetHostViewCocoa` in the AXChildren array, so our custom filter ensuring that it's included doesn't do anything. Instead, the web contents are part of a class named `BrowserAccessibilityCocoa`.

[Note: I've previously tried to fix this by manually adding the `contentView`, which worked in some cases, but not all]

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixes an issue where VoiceOver was unable to navigate from the top-level window back into the web contents