### PR TITLE
fix: export libuv symbols

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1144,7 +1144,12 @@ if (is_mac) {
       ]
     }
     if (is_linux) {
-      ldflags = [ "-pie" ]
+      ldflags = [
+        "-pie",
+        "-Wl,--whole-archive",
+        "obj/third_party/electron_node/deps/uv/libuv.a",
+        "-Wl,--no-whole-archive",
+      ]
 
       if (!is_component_build && is_component_ffmpeg) {
         configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -813,6 +813,9 @@ if (is_mac) {
       "-Wl,-install_name,@rpath/$output_name.framework/$output_name",
       "-rpath",
       "@loader_path/Libraries",
+
+      # Required for exporting all symbols of libuv.
+      "-Wl,-force_load,obj/third_party/electron_node/deps/uv/libuv.a",
     ]
     if (is_component_build) {
       ldflags += [
@@ -1144,24 +1147,18 @@ if (is_mac) {
       ]
     }
     if (is_linux) {
-      ldflags = [ "-pie" ]
+      ldflags = [
+        "-pie",
 
-      if (!is_component_build && is_component_ffmpeg) {
-        configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
-      }
-    }
-
-    if (is_linux || is_mac) {
-      ldflags += [
+        # Required for exporting all symbols of libuv.
         "-Wl,--whole-archive",
         "obj/third_party/electron_node/deps/uv/libuv.a",
         "-Wl,--no-whole-archive",
       ]
-    }
 
-    if (is_mac) {
-      ldflags +=
-          [ "-Wl,-force_load,obj/third_party/electron_node/deps/uv/libuv.a" ]
+      if (!is_component_build && is_component_ffmpeg) {
+        configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
+      }
     }
   }
 

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1155,6 +1155,11 @@ if (is_mac) {
         configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
       }
     }
+
+    if (is_mac) {
+      ldflags =
+          [ "-Wl,-force_load,obj/third_party/electron_node/deps/uv/libuv.a" ]
+    }
   }
 
   if (is_official_build) {

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1144,20 +1144,23 @@ if (is_mac) {
       ]
     }
     if (is_linux) {
-      ldflags = [
-        "-pie",
-        "-Wl,--whole-archive",
-        "obj/third_party/electron_node/deps/uv/libuv.a",
-        "-Wl,--no-whole-archive",
-      ]
+      ldflags = [ "-pie" ]
 
       if (!is_component_build && is_component_ffmpeg) {
         configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
       }
     }
 
+    if (is_linux || is_mac) {
+      ldflags += [
+        "-Wl,--whole-archive",
+        "obj/third_party/electron_node/deps/uv/libuv.a",
+        "-Wl,--no-whole-archive",
+      ]
+    }
+
     if (is_mac) {
-      ldflags =
+      ldflags +=
           [ "-Wl,-force_load,obj/third_party/electron_node/deps/uv/libuv.a" ]
     }
   }

--- a/spec-main/fixtures/module/uv-dlopen.js
+++ b/spec-main/fixtures/module/uv-dlopen.js
@@ -1,0 +1,1 @@
+require('uv-dlopen');

--- a/spec-main/fixtures/native-addon/uv-dlopen/binding.gyp
+++ b/spec-main/fixtures/native-addon/uv-dlopen/binding.gyp
@@ -3,8 +3,6 @@
     {
       "target_name": "test_module",
       "sources": [ "main.cpp" ],
-      "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],
-      "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ]
     },
     {
       "target_name": "libfoo",

--- a/spec-main/fixtures/native-addon/uv-dlopen/binding.gyp
+++ b/spec-main/fixtures/native-addon/uv-dlopen/binding.gyp
@@ -1,0 +1,15 @@
+{
+  "targets": [
+    {
+      "target_name": "test_module",
+      "sources": [ "main.cpp" ],
+      "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],
+      "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ]
+    },
+    {
+      "target_name": "libfoo",
+      "type": "shared_library",
+      "sources": [ "foo.cpp" ]
+    }
+  ]
+}

--- a/spec-main/fixtures/native-addon/uv-dlopen/foo.cpp
+++ b/spec-main/fixtures/native-addon/uv-dlopen/foo.cpp
@@ -1,0 +1,2 @@
+extern "C"
+void foo() { }

--- a/spec-main/fixtures/native-addon/uv-dlopen/index.js
+++ b/spec-main/fixtures/native-addon/uv-dlopen/index.js
@@ -3,8 +3,9 @@ const testLoadLibrary = require('./build/Release/test_module');
 const lib = (() => {
   switch (process.platform) {
     case 'linux':
-    case 'darwin':
       return `${__dirname}/build/Release/foo.so`;
+    case 'darwin':
+      return `${__dirname}/build/Release/foo.dylib`;
     case 'win32':
       return `${__dirname}/build/Release/libfoo.dll`;
     default:

--- a/spec-main/fixtures/native-addon/uv-dlopen/index.js
+++ b/spec-main/fixtures/native-addon/uv-dlopen/index.js
@@ -3,10 +3,10 @@ const testLoadLibrary = require('./build/Release/test_module');
 const lib = (() => {
   switch (process.platform) {
     case 'linux':
+    case 'darwin':
       return `${__dirname}/build/Release/foo.so`;
     case 'win32':
       return `${__dirname}/build/Release/libfoo.dll`;
-    // TODO: add library path for mac
     default:
       throw new Error('unsupported os');
   }

--- a/spec-main/fixtures/native-addon/uv-dlopen/index.js
+++ b/spec-main/fixtures/native-addon/uv-dlopen/index.js
@@ -1,0 +1,15 @@
+const testLoadLibrary = require('./build/Release/test_module');
+
+const lib = (() => {
+  switch (process.platform) {
+    case 'linux':
+      return `${__dirname}/build/Release/foo.so`;
+    case 'win32':
+      return `${__dirname}/build/Release/libfoo.dll`;
+    // TODO: add library path for mac
+    default:
+      throw new Error('unsupported os');
+  }
+})();
+
+testLoadLibrary(lib);

--- a/spec-main/fixtures/native-addon/uv-dlopen/main.cpp
+++ b/spec-main/fixtures/native-addon/uv-dlopen/main.cpp
@@ -1,0 +1,24 @@
+#include <napi.h>
+#include <uv.h>
+
+namespace test_module {
+
+Napi::Value TestLoadLibrary(const Napi::CallbackInfo& info) {
+  auto lib_path = info[0].ToString().Utf8Value();
+  uv_lib_t lib;
+  auto result = uv_dlopen(lib_path.c_str(), &lib);
+  if (result == 0) {
+    return Napi::Value::From(info.Env(), true);
+  } else {
+    Napi::Error::New(info.Env(), uv_dlerror(&lib)).ThrowAsJavaScriptException();
+    return Napi::Value();
+  }
+}
+
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+  return Napi::Function::New(env, TestLoadLibrary);
+}
+
+NODE_API_MODULE(TestLoadLibrary, Init);
+
+}  // namespace test_module

--- a/spec-main/fixtures/native-addon/uv-dlopen/package.json
+++ b/spec-main/fixtures/native-addon/uv-dlopen/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "uv-dlopen",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "node-addon-api": "^3.0.0"
+  }
+}

--- a/spec-main/fixtures/native-addon/uv-dlopen/package.json
+++ b/spec-main/fixtures/native-addon/uv-dlopen/package.json
@@ -1,9 +1,5 @@
 {
   "name": "uv-dlopen",
   "version": "0.0.1",
-  "description": "",
-  "main": "index.js",
-  "dependencies": {
-    "node-addon-api": "^3.0.0"
-  }
+  "main": "index.js"
 }

--- a/spec-main/modules-spec.ts
+++ b/spec-main/modules-spec.ts
@@ -44,7 +44,12 @@ describe('modules support', () => {
       });
     });
 
-    ifdescribe(nativeModulesEnabled)('module that use uv_dlopen', () => {
+    const enablePlatforms: NodeJS.Platform[] = [
+      'linux',
+      'darwin',
+      'win32'
+    ];
+    ifdescribe(nativeModulesEnabled && enablePlatforms.includes(process.platform))('module that use uv_dlopen', () => {
       it('can be required in renderer', async () => {
         const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true } });
         w.loadURL('about:blank');

--- a/spec-main/modules-spec.ts
+++ b/spec-main/modules-spec.ts
@@ -44,6 +44,22 @@ describe('modules support', () => {
       });
     });
 
+    ifdescribe(nativeModulesEnabled)('module that use uv_dlopen', () => {
+      it('can be required in renderer', async () => {
+        const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true } });
+        w.loadURL('about:blank');
+        await expect(w.webContents.executeJavaScript('{ require(\'uv-dlopen\'); null }')).to.be.fulfilled();
+      });
+
+      ifit(features.isRunAsNodeEnabled())('can be required in node binary', async function () {
+        const child = childProcess.fork(path.join(fixtures, 'module', 'uv-dlopen.js'));
+        await new Promise(resolve => child.once('exit', (exitCode) => {
+          expect(exitCode).to.equal(0);
+          resolve();
+        }));
+      });
+    });
+
     describe('q', () => {
       describe('Q.when', () => {
         it('emits the fullfil callback', (done) => {

--- a/spec-main/package.json
+++ b/spec-main/package.json
@@ -10,6 +10,7 @@
     "echo": "file:fixtures/native-addon/echo",
     "q": "^1.5.1",
     "sinon": "^9.0.1",
+    "uv-dlopen": "file:fixtures/native-addon/uv-dlopen",
     "ws": "^7.2.1"
   },
   "dependencies": {

--- a/spec-main/package.json
+++ b/spec-main/package.json
@@ -10,7 +10,7 @@
     "echo": "file:fixtures/native-addon/echo",
     "q": "^1.5.1",
     "sinon": "^9.0.1",
-    "uv-dlopen": "file:fixtures/native-addon/uv-dlopen",
+    "uv-dlopen": "./fixtures/native-addon/uv-dlopen/",
     "ws": "^7.2.1"
   },
   "dependencies": {

--- a/spec-main/yarn.lock
+++ b/spec-main/yarn.lock
@@ -193,11 +193,6 @@ nise@^4.0.1:
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
 
-node-addon-api@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.0.0.tgz#812446a1001a54f71663bed188314bba07e09247"
-  integrity sha512-sSHCgWfJ+Lui/u+0msF3oyCgvdkhxDbkCS6Q8uiJquzOimkJBvX6hl5aSSA7DR1XbMpdM8r7phjcF63sF4rkKg==
-
 node-ensure@^0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/node-ensure/-/node-ensure-0.0.0.tgz#ecae764150de99861ec5c810fd5d096b183932a7"
@@ -273,10 +268,8 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-"uv-dlopen@file:fixtures/native-addon/uv-dlopen":
+uv-dlopen@./fixtures/native-addon/uv-dlopen/:
   version "0.0.1"
-  dependencies:
-    node-addon-api "^3.0.0"
 
 worker-loader@^2.0.0:
   version "2.0.0"

--- a/spec-main/yarn.lock
+++ b/spec-main/yarn.lock
@@ -193,6 +193,11 @@ nise@^4.0.1:
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
 
+node-addon-api@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.0.0.tgz#812446a1001a54f71663bed188314bba07e09247"
+  integrity sha512-sSHCgWfJ+Lui/u+0msF3oyCgvdkhxDbkCS6Q8uiJquzOimkJBvX6hl5aSSA7DR1XbMpdM8r7phjcF63sF4rkKg==
+
 node-ensure@^0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/node-ensure/-/node-ensure-0.0.0.tgz#ecae764150de99861ec5c810fd5d096b183932a7"
@@ -267,6 +272,11 @@ uri-js@^4.2.2:
   integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
   dependencies:
     punycode "^2.1.0"
+
+"uv-dlopen@file:fixtures/native-addon/uv-dlopen":
+  version "0.0.1"
+  dependencies:
+    node-addon-api "^3.0.0"
 
 worker-loader@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Forces libuv symbols to be exported, this fixes #24428.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed undefined symbol error when loading native modules that uses `uv_dlopen` <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
