### PR TITLE
chore: update symbol server URL

### DIFF
--- a/docs/development/setting-up-symbol-server.md
+++ b/docs/development/setting-up-symbol-server.md
@@ -15,7 +15,7 @@ calls, and other compiler optimizations. The only workaround is to build an
 unoptimized local build.
 
 The official symbol server URL for Electron is
-https://electron-symbols.githubapp.com.
+https://symbols.electronjs.org.
 You cannot visit this URL directly, you must add it to the symbol path of your
 debugging tool. In the examples below, a local cache directory is used to avoid
 repeatedly fetching the PDB from the server. Replace `c:\code\symbols` with an
@@ -30,7 +30,7 @@ directory on your computer, if you'd prefer a different location for downloaded
 symbols):
 
 ```powershell
-SRV*c:\code\symbols\*https://electron-symbols.githubapp.com
+SRV*c:\code\symbols\*https://symbols.electronjs.org
 ```
 
 Set this string as `_NT_SYMBOL_PATH` in the environment, using the Windbg menus,
@@ -38,7 +38,7 @@ or by typing the `.sympath` command. If you would like to get symbols from
 Microsoft's symbol server as well, you should list that first:
 
 ```powershell
-SRV*c:\code\symbols\*https://msdl.microsoft.com/download/symbols;SRV*c:\code\symbols\*https://electron-symbols.githubapp.com
+SRV*c:\code\symbols\*https://msdl.microsoft.com/download/symbols;SRV*c:\code\symbols\*https://symbols.electronjs.org
 ```
 
 ## Using the symbol server in Visual Studio


### PR DESCRIPTION
Update docs to point at the symbol server URL we own.  This is just a CNAME / alias to the same deployment

Notes: no-notes