### PR TITLE
fix: service worker crash with Node.js

### DIFF
--- a/patches/chromium/dcheck.patch
+++ b/patches/chromium/dcheck.patch
@@ -45,6 +45,22 @@ index 954d5401b71bb090c1c533783398298f28eeefbd..dd9051afe099cb1ef3aebb825cf05c34
    // The browser requested to clear the session history when it initiated the
    // navigation. Now we know that the renderer has updated its state accordingly
    // and it is safe to also clear the browser side history.
+diff --git a/third_party/blink/renderer/core/workers/worker_global_scope.cc b/third_party/blink/renderer/core/workers/worker_global_scope.cc
+index d56e4c2a3ad775144a1c913bd592eebfdfc1a0c7..07d3d47cfd2ca997a9e911b030778ba1a315d6cf 100644
+--- a/third_party/blink/renderer/core/workers/worker_global_scope.cc
++++ b/third_party/blink/renderer/core/workers/worker_global_scope.cc
+@@ -152,7 +152,10 @@ WorkerGlobalScope::~WorkerGlobalScope() {
+ }
+ 
+ NOINLINE const KURL& WorkerGlobalScope::Url() const {
+-  CHECK(url_.IsValid());
++  // Whenever JS is called into during context creation, this CHECK
++  // is triggered, which happens when Node integration is added to workers.
++  // This can be removed when we upgrade to Node.js v14.
++  // CHECK(url_.IsValid());
+   return url_;
+ }
+ 
 diff --git a/ui/base/clipboard/clipboard_win.cc b/ui/base/clipboard/clipboard_win.cc
 index b422119ff36713399358b27aff8b18423f79d954..5c223f360ca641a3e29f23e6d409d7f97414a985 100644
 --- a/ui/base/clipboard/clipboard_win.cc

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -441,6 +441,30 @@ describe('chromium features', () => {
       w.webContents.on('crashed', () => done(new Error('WebContents crashed.')));
       w.loadFile(path.join(fixturesPath, 'pages', 'service-worker', 'index.html'));
     });
+
+    it('should not crash when nodeIntegration is enabled', (done) => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true,
+          nodeIntegrationInWorker: true
+        }
+      });
+
+      w.webContents.on('ipc-message', (event, channel, message) => {
+        if (channel === 'reload') {
+          w.webContents.reload();
+        } else if (channel === 'error') {
+          done(`unexpected error : ${message}`);
+        } else if (channel === 'response') {
+          expect(message).to.equal('Hello from serviceWorker!');
+          done();
+        }
+      });
+
+      w.webContents.on('crashed', () => done(new Error('WebContents crashed.')));
+      w.loadFile(path.join(fixturesPath, 'pages', 'service-worker', 'index.html'));
+    });
   });
 
   describe('navigator.geolocation', () => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/24715.

This crash occurs because any calls into JS in `WebWorkerObserver::ContextCreated` trigger a CHECK [here](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/workers/worker_global_scope.cc;l=155?q=%22WorkerGlobalScope::url%22&ss=chromium&originalUrl=https:%2F%2Fcs.chromium.org%2F).

I initially tried:

- Preventing gin from emitting if the execution context is a service worker, but it turns out that in Node.js v12 `LoadEnvironment` also calls into JS so this solution wouldn't be tenable until we roll in the updates to the embedder API added in [this commit](https://github.com/nodejs/node/pull/30467/commits/7336b7fc1ba97d2b7d1028252631748cf12a2fed) in Node.js v14
- Setting the URL so that it's not null - `InitializeURL` is a [protected member](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/workers/worker_global_scope.h;l=237;bpv=1;bpt=1?originalUrl=https:%2F%2Fcs.chromium.org%2F) of `WorkerGlobalScope` though so this would also require a patch.

For now i think thus that the best path is just to disable the CHECK as there exists a path for its removal in Node.js v14 via something like:

```
blink::ExecutionContext* execution_context = blink::ToExecutionContext(worker_context);
bool should_emit = !execution_context->IsServiceWorkerGlobalScope();

// Load everything.
node_bindings_->LoadEnvironment(env, should_emit);
```

cc @nornagon @deepak1556 @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed a crash in service workers when `nodeIntegrationInWorker`s was enabled.
