### PR TITLE
perf: pass primitives directly through the context bridge, avoids copying

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,8 @@
     "ENABLE_DESKTOP_CAPTURER": "readonly",
     "ENABLE_ELECTRON_EXTENSIONS": "readonly",
     "ENABLE_REMOTE_MODULE": "readonly",
-    "ENABLE_VIEW_API": "readonly"
+    "ENABLE_VIEW_API": "readonly",
+    "BigInt": "readonly"
   },
   "overrides": [
     {

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -147,6 +147,17 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContext(
       return v8::MaybeLocal<v8::Value>();
     }
   }
+
+  // Certain primitives always use the current contexts prototype and we can
+  // pass these through directly which is significantly more performant than
+  // copying them. This list of primitives is based on the classification of
+  // "primitive value" as defined in the ECMA262 spec
+  // https://tc39.es/ecma262/#sec-primitive-value
+  if (value->IsString() || value->IsNumber() || value->IsNullOrUndefined() ||
+      value->IsBoolean() || value->IsSymbol() || value->IsBigInt()) {
+    return v8::MaybeLocal<v8::Value>(value);
+  }
+
   // Check Cache
   auto cached_value = object_cache->GetCachedProxiedObject(value);
   if (!cached_value.IsEmpty()) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2020",
     "lib": [
       "es2019",
       "dom",


### PR DESCRIPTION
Backport of #24531

See that PR for details.


Notes: Improved the performance of sending JS primitives over the context bridge