### PR TITLE
build: fix failing arm64 builds on macOS

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -104,3 +104,4 @@ skip_atk_toolchain_check.patch
 fix_missing_weakptr_check_in_preconnectmanager.patch
 revert_swiftshader_roll_in_deps.patch
 worker_feat_add_hook_to_notify_script_ready.patch
+mac_work_around_xcode_12b3_sdk_bug.patch

--- a/patches/chromium/mac_work_around_xcode_12b3_sdk_bug.patch
+++ b/patches/chromium/mac_work_around_xcode_12b3_sdk_bug.patch
@@ -1,0 +1,56 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mark Mentovai <mark@chromium.org>
+Date: Thu, 23 Jul 2020 02:02:37 +0000
+Subject: mac: Work around Xcode 12b3 SDK bug
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The macOS 11.0 20A5323l SDK in Xcode 12b3 12A8169g totally hides the
+kCGColorSpaceITUR_2020_PQ_EOTF declaration in an #if whenever the SDK
+version is ≥ 10.16, which of course it always is. Chrome does use that
+constant, so work around the SDK bug by providing our a local
+declaration when that SDK version is in use.
+
+Bug: 1108561
+Change-Id: I6ed31d30705bc754616e413c38fb250a7934484d
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2315078
+Reviewed-by: Avi Drissman <avi@chromium.org>
+Commit-Queue: Avi Drissman <avi@chromium.org>
+Commit-Queue: Mark Mentovai <mark@chromium.org>
+Auto-Submit: Mark Mentovai <mark@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#791119}
+
+diff --git a/ui/gfx/mac/io_surface.cc b/ui/gfx/mac/io_surface.cc
+index 93a9652b71d86441e15b87aafd7a6b1a13f45830..5e06d0b7804e90cd044c64188ed113c9593dd8be 100644
+--- a/ui/gfx/mac/io_surface.cc
++++ b/ui/gfx/mac/io_surface.cc
+@@ -4,6 +4,8 @@
+ 
+ #include "ui/gfx/mac/io_surface.h"
+ 
++#include <Availability.h>
++#include <CoreGraphics/CoreGraphics.h>
+ #include <stddef.h>
+ #include <stdint.h>
+ 
+@@ -18,6 +20,19 @@
+ #include "ui/gfx/icc_profile.h"
+ #include "ui/gfx/switches.h"
+ 
++#if defined(__MAC_11_0) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_16
++// https://crbug.com/1108561: This is supposed to be deprecated (but available)
++// through 10.15.4, but the macOS 11.0 20A5323l SDK from Xcode 12b3 12A8169g
++// doesn’t declare it at all when the SDK version is 10.16 or later, which of
++// course it always is. It’s a bug in the SDK. Work around it with the
++// declaration that’s hidden.
++//
++// TODO(https://crbug.com/1108627): remove this workaround if and when the SDK
++// bug is fixed.
++CG_EXTERN const CFStringRef kCGColorSpaceITUR_2020_PQ_EOTF
++CG_AVAILABLE_BUT_DEPRECATED(10.14.6, 10.15.4, 12.6, 13.4);
++#endif
++
+ namespace gfx {
+ 
+ namespace {


### PR DESCRIPTION
#### Description of Change

Backports https://chromium-review.googlesource.com/c/chromium/src/+/2315078.

Fixes arm64 failures as seen [here](https://app.circleci.com/pipelines/github/electron/electron/27821/workflows/e5050650-98f3-4afa-b5de-0a21d88c84ac/jobs/617930).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: none
