### PR TITLE
fix: crash when navigating from a page with webview that has inherited zoom level

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1413,6 +1413,11 @@ bool WebContents::OnMessageReceived(const IPC::Message& message) {
 // we need to make sure the api::WebContents is also deleted.
 // For #4, the WebContents will be destroyed by embedder.
 void WebContents::WebContentsDestroyed() {
+  // Give chance for guest delegate to cleanup its observers
+  // since the native class is only destroyed in the next tick.
+  if (guest_delegate_)
+    guest_delegate_->WillDestroy();
+
   // Cleanup relationships with other parts.
   RemoveFromWeakMap();
 

--- a/shell/browser/web_view_guest_delegate.cc
+++ b/shell/browser/web_view_guest_delegate.cc
@@ -57,6 +57,10 @@ void WebViewGuestDelegate::AttachToIframe(
   api_web_contents_->Emit("did-attach");
 }
 
+void WebViewGuestDelegate::WillDestroy() {
+  ResetZoomController();
+}
+
 void WebViewGuestDelegate::DidDetach() {
   ResetZoomController();
 }

--- a/shell/browser/web_view_guest_delegate.h
+++ b/shell/browser/web_view_guest_delegate.h
@@ -24,6 +24,7 @@ class WebViewGuestDelegate : public content::BrowserPluginGuestDelegate,
   // Attach to the iframe.
   void AttachToIframe(content::WebContents* embedder_web_contents,
                       int embedder_frame_id);
+  void WillDestroy();
 
  protected:
   // content::BrowserPluginGuestDelegate:

--- a/spec-main/webview-spec.ts
+++ b/spec-main/webview-spec.ts
@@ -315,6 +315,23 @@ describe('<webview> tag', function () {
       const [, zoomLevel] = await emittedOnce(ipcMain, 'webview-origin-zoom-level');
       expect(zoomLevel).to.equal(2.0);
     });
+
+    it('does not crash when navigating with zoom level inherited from parent', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          webviewTag: true,
+          nodeIntegration: true,
+          zoomFactor: 1.2,
+          session: webviewSession
+        }
+      });
+      const attachPromise = emittedOnce(w.webContents, 'did-attach-webview');
+      w.loadFile(path.join(fixtures, 'pages', 'webview-did-attach-event.html'));
+      const [, webview] = await attachPromise;
+      expect(webview.getZoomFactor()).to.equal(1.2);
+      await w.loadURL(`${zoomScheme}://host1`);
+    });
   });
 
   describe('nativeWindowOpen option', () => {

--- a/spec-main/webview-spec.ts
+++ b/spec-main/webview-spec.ts
@@ -327,7 +327,7 @@ describe('<webview> tag', function () {
         }
       });
       const attachPromise = emittedOnce(w.webContents, 'did-attach-webview');
-      w.loadFile(path.join(fixtures, 'pages', 'webview-did-attach-event.html'));
+      w.loadFile(path.join(fixtures, 'pages', 'webview-zoom-inherited.html'));
       const [, webview] = await attachPromise;
       expect(webview.getZoomFactor()).to.equal(1.2);
       await w.loadURL(`${zoomScheme}://host1`);

--- a/spec-main/webview-spec.ts
+++ b/spec-main/webview-spec.ts
@@ -327,8 +327,10 @@ describe('<webview> tag', function () {
         }
       });
       const attachPromise = emittedOnce(w.webContents, 'did-attach-webview');
+      const readyPromise = emittedOnce(ipcMain, 'dom-ready');
       w.loadFile(path.join(fixtures, 'pages', 'webview-zoom-inherited.html'));
       const [, webview] = await attachPromise;
+      await readyPromise;
       expect(webview.getZoomFactor()).to.equal(1.2);
       await w.loadURL(`${zoomScheme}://host1`);
     });

--- a/spec/fixtures/pages/webview-zoom-inherited.html
+++ b/spec/fixtures/pages/webview-zoom-inherited.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<webview src="./a.html" id="view" partition="webview-temp"/>
+</body>
+</html>

--- a/spec/fixtures/pages/webview-zoom-inherited.html
+++ b/spec/fixtures/pages/webview-zoom-inherited.html
@@ -2,4 +2,11 @@
 <body>
 <webview src="./a.html" id="view" partition="webview-temp"/>
 </body>
+<script>
+  const {ipcRenderer} = require('electron')
+  const view = document.getElementById('view')
+  view.addEventListener('dom-ready', () => {
+    ipcRenderer.send('dom-ready')
+  })
+</script>
 </html>


### PR DESCRIPTION
#### Description of Change

Repro https://gist.github.com/deepak1556/4e98046880c9ff4fecc03813708a2264

Refs https://github.com/microsoft/vscode/issues/102195

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: fix crash when navigating from a page with webview that has inherited zoom level
