### PR TITLE
fix: crash when navigating from a page with webview that has inherited zoom level

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1352,6 +1352,11 @@ bool WebContents::OnMessageReceived(const IPC::Message& message) {
 // we need to make sure the api::WebContents is also deleted.
 // For #4, the WebContents will be destroyed by embedder.
 void WebContents::WebContentsDestroyed() {
+  // Give chance for guest delegate to cleanup its observers
+  // since the native class is only destroyed in the next tick.
+  if (guest_delegate_)
+    guest_delegate_->WillDestroy();
+
   // Cleanup relationships with other parts.
   RemoveFromWeakMap();
 

--- a/shell/browser/web_view_guest_delegate.cc
+++ b/shell/browser/web_view_guest_delegate.cc
@@ -58,6 +58,10 @@ void WebViewGuestDelegate::AttachToIframe(
   api_web_contents_->Emit("did-attach");
 }
 
+void WebViewGuestDelegate::WillDestroy() {
+  ResetZoomController();
+}
+
 void WebViewGuestDelegate::DidDetach() {
   ResetZoomController();
 }

--- a/shell/browser/web_view_guest_delegate.h
+++ b/shell/browser/web_view_guest_delegate.h
@@ -24,6 +24,7 @@ class WebViewGuestDelegate : public content::BrowserPluginGuestDelegate,
   // Attach to the iframe.
   void AttachToIframe(content::WebContents* embedder_web_contents,
                       int embedder_frame_id);
+  void WillDestroy();
 
  protected:
   // content::BrowserPluginGuestDelegate:

--- a/spec-main/webview-spec.ts
+++ b/spec-main/webview-spec.ts
@@ -273,6 +273,25 @@ describe('<webview> tag', function () {
       const [, zoomLevel] = await emittedOnce(ipcMain, 'webview-origin-zoom-level')
       expect(zoomLevel).to.equal(2.0)
     })
+
+    it('does not crash when navigating with zoom level inherited from parent', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          webviewTag: true,
+          nodeIntegration: true,
+          zoomFactor: 1.2,
+          session: webviewSession
+        }
+      })
+      const attachPromise = emittedOnce(w.webContents, 'did-attach-webview')
+      const readyPromise = emittedOnce(ipcMain, 'dom-ready')
+      w.loadFile(path.join(fixtures, 'pages', 'webview-zoom-inherited.html'))
+      const [, webview] = await attachPromise
+      await readyPromise
+      expect(webview.getZoomFactor()).to.equal(1.2)
+      await w.loadURL(`${zoomScheme}://host1`)
+    })
   })
 
   describe('nativeWindowOpen option', () => {

--- a/spec/fixtures/pages/webview-zoom-inherited.html
+++ b/spec/fixtures/pages/webview-zoom-inherited.html
@@ -1,0 +1,12 @@
+<html>
+<body>
+<webview src="./a.html" id="view" partition="webview-temp"/>
+</body>
+<script>
+  const {ipcRenderer} = require('electron')
+  const view = document.getElementById('view')
+  view.addEventListener('dom-ready', () => {
+    ipcRenderer.send('dom-ready')
+  })
+</script>
+</html>


### PR DESCRIPTION
#### Description of Change

Backports https://github.com/electron/electron/pull/24757

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: fix crash when navigating from a page with webview that has inherited zoom level
