### PR TITLE
fix: wrap OnWindowMessage w/ handlescope

### DIFF
--- a/shell/browser/api/electron_api_top_level_window.cc
+++ b/shell/browser/api/electron_api_top_level_window.cc
@@ -14,6 +14,7 @@
 #include "shell/browser/api/electron_api_menu.h"
 #include "shell/browser/api/electron_api_view.h"
 #include "shell/browser/api/electron_api_web_contents.h"
+#include "shell/browser/javascript_environment.h"
 #include "shell/common/color_util.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_converters/file_path_converter.h"
@@ -290,9 +291,12 @@ void TopLevelWindow::OnWindowMessage(UINT message,
                                      WPARAM w_param,
                                      LPARAM l_param) {
   if (IsWindowMessageHooked(message)) {
+    v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+    v8::Locker locker(isolate);
+    v8::HandleScope scope(isolate);
     messages_callback_map_[message].Run(
-        ToBuffer(isolate(), static_cast<void*>(&w_param), sizeof(WPARAM)),
-        ToBuffer(isolate(), static_cast<void*>(&l_param), sizeof(LPARAM)));
+        ToBuffer(isolate, static_cast<void*>(&w_param), sizeof(WPARAM)),
+        ToBuffer(isolate, static_cast<void*>(&l_param), sizeof(LPARAM)));
   }
 }
 #endif

--- a/shell/browser/api/electron_api_top_level_window.cc
+++ b/shell/browser/api/electron_api_top_level_window.cc
@@ -291,12 +291,11 @@ void TopLevelWindow::OnWindowMessage(UINT message,
                                      WPARAM w_param,
                                      LPARAM l_param) {
   if (IsWindowMessageHooked(message)) {
-    v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
-    v8::Locker locker(isolate);
-    v8::HandleScope scope(isolate);
+    v8::Locker locker(isolate());
+    v8::HandleScope scope(isolate());
     messages_callback_map_[message].Run(
-        ToBuffer(isolate, static_cast<void*>(&w_param), sizeof(WPARAM)),
-        ToBuffer(isolate, static_cast<void*>(&l_param), sizeof(LPARAM)));
+        ToBuffer(isolate(), static_cast<void*>(&w_param), sizeof(WPARAM)),
+        ToBuffer(isolate(), static_cast<void*>(&l_param), sizeof(LPARAM)));
   }
 }
 #endif


### PR DESCRIPTION
Backport of #24716.

Notes: Fixed a crash that could happen when using `hookWindowMessage` on Windows.