### PR TITLE
chore: add V8 crash information to crashReporter

### DIFF
--- a/shell/common/api/electron_api_v8_util.cc
+++ b/shell/common/api/electron_api_v8_util.cc
@@ -103,16 +103,6 @@ void RequestGarbageCollectionForTesting(v8::Isolate* isolate) {
       v8::Isolate::GarbageCollectionType::kFullGarbageCollection);
 }
 
-// This causes a fatal error by creating a circular extension dependency.
-void TriggerFatalErrorForTesting(v8::Isolate* isolate) {
-  static const char* aDeps[] = {"B"};
-  v8::RegisterExtension(std::make_unique<v8::Extension>("A", "", 1, aDeps));
-  static const char* bDeps[] = {"A"};
-  v8::RegisterExtension(std::make_unique<v8::Extension>("B", "", 1, bDeps));
-  v8::ExtensionConfiguration config(1, bDeps);
-  v8::Context::New(isolate, &config);
-}
-
 bool IsSameOrigin(const GURL& l, const GURL& r) {
   return url::Origin::Create(l).IsSameOriginWith(url::Origin::Create(r));
 }
@@ -138,6 +128,16 @@ std::vector<v8::Local<v8::Value>> GetWeaklyTrackedValues(v8::Isolate* isolate) {
   }
   return locals;
 }
+
+// This causes a fatal error by creating a circular extension dependency.
+void TriggerFatalErrorForTesting(v8::Isolate* isolate) {
+  static const char* aDeps[] = {"B"};
+  v8::RegisterExtension(std::make_unique<v8::Extension>("A", "", 1, aDeps));
+  static const char* bDeps[] = {"A"};
+  v8::RegisterExtension(std::make_unique<v8::Extension>("B", "", 1, bDeps));
+  v8::ExtensionConfiguration config(1, bDeps);
+  v8::Context::New(isolate, &config);
+}
 #endif
 
 void Initialize(v8::Local<v8::Object> exports,
@@ -153,8 +153,8 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("requestGarbageCollectionForTesting",
                  &RequestGarbageCollectionForTesting);
   dict.SetMethod("isSameOrigin", &IsSameOrigin);
-  dict.SetMethod("triggerFatalErrorForTesting", &TriggerFatalErrorForTesting);
 #ifdef DCHECK_IS_ON
+  dict.SetMethod("triggerFatalErrorForTesting", &TriggerFatalErrorForTesting);
   dict.SetMethod("getWeaklyTrackedValues", &GetWeaklyTrackedValues);
   dict.SetMethod("clearWeaklyTrackedValues", &ClearWeaklyTrackedValues);
   dict.SetMethod("weaklyTrackValue", &WeaklyTrackValue);

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -137,13 +137,16 @@ bool IsPackagedApp() {
 #endif
 }
 
-void FatalErrorCallback(const char* location, const char* message) {
+void V8FatalErrorCallback(const char* location, const char* message) {
   LOG(ERROR) << "Fatal error in V8: " << location << " " << message;
 
+#if !defined(MAS_BUILD)
   electron::crash_keys::SetCrashKey("electron.v8-fatal.message", message);
   electron::crash_keys::SetCrashKey("electron.v8-fatal.location", location);
+#endif
 
-  electron::ElectronBindings::Crash();
+  volatile int* zero = nullptr;
+  *zero = 0;
 }
 
 // Initialize Node.js cli options to pass to Node.js
@@ -413,7 +416,7 @@ node::Environment* NodeBindings::CreateEnvironment(
 
   // Use a custom fatal error callback to allow us to add
   // crash message and location to CrashReports.
-  is.fatal_error_callback = FatalErrorCallback;
+  is.fatal_error_callback = V8FatalErrorCallback;
 
   if (browser_env_ == BrowserEnvironment::BROWSER) {
     // Node.js requires that microtask checkpoints be explicitly invoked.

--- a/spec-main/api-crash-reporter-spec.ts
+++ b/spec-main/api-crash-reporter-spec.ts
@@ -28,6 +28,8 @@ type CrashInfo = {
   globalParam: 'globalValue' | undefined
   addedThenRemoved: 'to-be-removed' | undefined
   longParam: string | undefined
+  'electron.v8-fatal.location': string | undefined
+  'electron.v8-fatal.message': string | undefined
 }
 
 function checkCrash (expectedProcessType: string, fields: CrashInfo) {
@@ -191,6 +193,32 @@ ifdescribe(!isLinuxOnArm && !process.mas && !process.env.DISABLE_CRASH_REPORTER_
         expect(crash.mainProcessSpecific).to.be.undefined();
         expect(crash.rendererSpecific).to.equal('rs');
         expect(crash.addedThenRemoved).to.be.undefined();
+      });
+
+      it('contains v8 crash keys when a v8 crash occurs', async () => {
+        const { remotely } = await startRemoteControlApp();
+        const { port, waitForCrash } = await startServer();
+
+        await remotely((port: number) => {
+          require('electron').crashReporter.start({
+            submitURL: `http://127.0.0.1:${port}`,
+            ignoreSystemCrashHandler: true
+          });
+        }, [port]);
+
+        remotely(() => {
+          const { BrowserWindow } = require('electron');
+          const bw = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true } });
+          bw.loadURL('about:blank');
+          bw.webContents.executeJavaScript('process._linkedBinding(\'electron_common_v8_util\').triggerFatalErrorForTesting()');
+        });
+
+        const crash = await waitForCrash();
+        expect(crash.prod).to.equal('Electron');
+        expect(crash._productName).to.equal('remote-control');
+        expect(crash.process_type).to.equal('renderer');
+        expect(crash['electron.v8-fatal.location']).to.equal('v8::Context::New()');
+        expect(crash['electron.v8-fatal.message']).to.equal('Circular extension dependency');
       });
     });
   });

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -44,6 +44,7 @@ declare namespace NodeJS {
     clearWeaklyTrackedValues(): void;
     getWeaklyTrackedValues(): any[];
     addRemoteObjectRef(contextId: string, id: number): void;
+    triggerFatalErrorForTesting(): void;
   }
 
   type AsarFileInfo = {


### PR DESCRIPTION
#### Description of Change

This PR restores our use of a custom V8 fatal error handler with the purpose of improving crash reports for crashes originating in V8. When a v8 crash occurs, the message and location will be added as extra parameters to the crash report for more effective debugging.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Added V8 crash message and location information to crashReport parameters. 
