### PR TITLE
fix: increase max crash key value length

### DIFF
--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -156,9 +156,15 @@ parameters in a renderer process will not result in those parameters being sent
 with crashes that occur in other renderer processes or in the main process.
 
 **Note:** Parameters have limits on the length of the keys and values. Key
-names must be no longer than 39 bytes, and values must be no longer than 127
+names must be no longer than 39 bytes, and values must be no longer than 20320
 bytes. Keys with names longer than the maximum will be silently ignored. Key
 values longer than the maximum length will be truncated.
+
+**Note:** On linux values that are longer than 127 bytes will be chunked into
+multiple keys, each 127 bytes in length.  E.g. `addExtraParameter('foo', 'a'.repeat(130))`
+will result in two chunked keys `foo__1` and `foo__2`, the first will contain
+the first 127 bytes and the second will contain the remaining 3 bytes.  On
+your crash reporting backend you should stitch together keys in this format.
 
 ### `crashReporter.removeExtraParameter(key)`
 

--- a/shell/common/crash_keys.cc
+++ b/shell/common/crash_keys.cc
@@ -24,8 +24,19 @@ namespace crash_keys {
 
 namespace {
 
-using ExtraCrashKeys = std::deque<
-    crash_reporter::CrashKeyString<crashpad::Annotation::kValueMaxSize - 1>>;
+#if defined(OS_LINUX)
+// Breakpad has a flawed system of calculating the number of chunks
+// we add 127 bytes to force an extra chunk
+constexpr size_t kMaxCrashKeyValueSize = 20479;
+#else
+constexpr size_t kMaxCrashKeyValueSize = 20320;
+#endif
+
+static_assert(kMaxCrashKeyValueSize < crashpad::Annotation::kValueMaxSize,
+              "max crash key value length above what crashpad supports");
+
+using ExtraCrashKeys =
+    std::deque<crash_reporter::CrashKeyString<kMaxCrashKeyValueSize>>;
 ExtraCrashKeys& GetExtraCrashKeys() {
   static base::NoDestructor<ExtraCrashKeys> extra_keys;
   return *extra_keys;

--- a/shell/common/crash_keys.cc
+++ b/shell/common/crash_keys.cc
@@ -24,7 +24,7 @@ namespace crash_keys {
 
 namespace {
 
-using ExtraCrashKeys = std::deque<crash_reporter::CrashKeyString<127>>;
+using ExtraCrashKeys = std::deque<crash_reporter::CrashKeyString<crashpad::Annotation::kValueMaxSize>>;
 ExtraCrashKeys& GetExtraCrashKeys() {
   static base::NoDestructor<ExtraCrashKeys> extra_keys;
   return *extra_keys;

--- a/shell/common/crash_keys.cc
+++ b/shell/common/crash_keys.cc
@@ -24,7 +24,8 @@ namespace crash_keys {
 
 namespace {
 
-using ExtraCrashKeys = std::deque<crash_reporter::CrashKeyString<crashpad::Annotation::kValueMaxSize>>;
+using ExtraCrashKeys = std::deque<
+    crash_reporter::CrashKeyString<crashpad::Annotation::kValueMaxSize - 1>>;
 ExtraCrashKeys& GetExtraCrashKeys() {
   static base::NoDestructor<ExtraCrashKeys> extra_keys;
   return *extra_keys;

--- a/spec-main/api-crash-reporter-spec.ts
+++ b/spec-main/api-crash-reporter-spec.ts
@@ -196,19 +196,19 @@ ifdescribe(!isLinuxOnArm && !process.mas && !process.env.DISABLE_CRASH_REPORTER_
   });
 
   ifdescribe(!isLinuxOnArm)('extra parameter limits', () => {
-    it('should truncate extra values longer than 127 characters', async () => {
+    it('should truncate extra values longer than 5 * 4096 characters', async () => {
       const { port, waitForCrash } = await startServer();
       const { remotely } = await startRemoteControlApp();
       remotely((port: number) => {
         require('electron').crashReporter.start({
           submitURL: `http://127.0.0.1:${port}`,
           ignoreSystemCrashHandler: true,
-          extra: { longParam: 'a'.repeat(130) }
+          extra: { longParam: 'a'.repeat(7 * 4096) }
         });
         setTimeout(() => process.crash());
       }, port);
       const crash = await waitForCrash();
-      expect(crash).to.have.property('longParam', 'a'.repeat(127));
+      expect(crash).to.have.property('longParam', 'a'.repeat(5 * 4096 - 1));
     });
 
     it('should omit extra keys with names longer than the maximum', async () => {

--- a/spec-main/api-crash-reporter-spec.ts
+++ b/spec-main/api-crash-reporter-spec.ts
@@ -199,15 +199,12 @@ ifdescribe(!isLinuxOnArm && !process.mas && !process.env.DISABLE_CRASH_REPORTER_
     function stitchLongCrashParam (crash: any, paramKey: string) {
       if (crash[paramKey]) return crash[paramKey];
       let chunk = 1;
-      if (crash[`${paramKey}__${chunk}`]) {
-        let stitched = '';
-        while (crash[`${paramKey}__${chunk}`]) {
-          stitched += crash[`${paramKey}__${chunk}`];
-          chunk++;
-        }
-        return stitched;
+      let stitched = '';
+      while (crash[`${paramKey}__${chunk}`]) {
+        stitched += crash[`${paramKey}__${chunk}`];
+        chunk++;
       }
-      return null;
+      return stitched;
     }
 
     it('should truncate extra values longer than 5 * 4096 characters', async () => {


### PR DESCRIPTION
#### Description of Change
This allows storing more complex data in the crash values, and will enable Sentry's reporter to switch away from their custom uploader.

This will waste memory for smaller crash keys, but most apps use only a small number of crash keys, so the excess won't be significant. In future, we can optimize this further by either separating crash keys into various classes by length, or expanding the API to allow the user to specify the maximum length of the key, or some other system.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Increased maximum length for crash keys from 127B to 20KB.