### PR TITLE
docs: remove references to 'remote' from app-arch tutorial

### DIFF
--- a/docs/tutorial/application-architecture.md
+++ b/docs/tutorial/application-architecture.md
@@ -38,11 +38,11 @@ process of the web page must communicate with the main process to request that
 the main process perform those operations.
 
 > #### Aside: Communication Between Processes
-> In Electron, we have several ways to communicate between the main process
-and renderer processes, such as [`ipcRenderer`](../api/ipc-renderer.md) and
-[`ipcMain`](../api/ipc-main.md) modules for sending messages, and the
-[remote](../api/remote.md) module for RPC style communication. There is also
-an FAQ entry on [how to share data between web pages][share-data].
+> In Electron, communicating between the main process and renderer processes,
+> is done through the [`ipcRenderer`](../api/ipc-renderer.md) and
+> [`ipcMain`](../api/ipc-main.md) modules. There is also an FAQ entry on [how
+> to share data between web pages][share-data].
+
 
 ## Using Electron APIs
 
@@ -71,19 +71,25 @@ const win = new BrowserWindow()
 ```
 
 Since communication between the processes is possible, a renderer process
-can call upon the main process to perform tasks. Electron comes with a
-module called `remote` that exposes APIs usually only available on the
-main process. In order to create a `BrowserWindow` from a renderer process,
-we'd use the remote as a middle-man:
+can call upon the main process to perform tasks through IPC.
 
 ```javascript
-// This will work in a renderer process, but be `undefined` in the
-// main process:
-const { remote } = require('electron')
-const { BrowserWindow } = remote
+// In the main process:
+const { ipcMain } = require('electron')
 
-const win = new BrowserWindow()
+ipcMain.handle('perform-action', (event, ...args) => {
+  // ... do something on behalf of the renderer ...
+})
+
+// In the renderer process:
+const { ipcRenderer } = require('electron')
+
+ipcRenderer.invoke('perform-action', ...args)
 ```
+
+Note that code in the renderer may not be trustworthy, so it's important
+to carefully validate in the main process requests that come from renderers,
+especially if they host third-party content.
 
 ## Using Node.js APIs
 


### PR DESCRIPTION
#### Description of Change
Thanks to @bentorkington for pointing this out.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: none