### PR TITLE
docs: remove reference to remote from faq

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -159,5 +159,6 @@ Notice that just setting the background in the CSS does not have the desired eff
 [local-storage]: https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage
 [session-storage]: https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage
 [indexed-db]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
+[message-port]: https://developer.mozilla.org/en-US/docs/Web/API/MessagePort
 [browser-window]: api/browser-window.md
 [subpixel rendering example]: images/subpixel-rendering-screenshot.gif

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -43,26 +43,14 @@ use HTML5 APIs which are already available in browsers. Good candidates are
 [Storage API][storage], [`localStorage`][local-storage],
 [`sessionStorage`][session-storage], and [IndexedDB][indexed-db].
 
-Or you can use the IPC system, which is specific to Electron, to store objects
-in the main process as a global variable, and then to access them from the
-renderers through the `remote` property of `electron` module:
-
-```javascript
-// In the main process.
-global.sharedObject = {
-  someProperty: 'default value'
-}
-```
-
-```javascript
-// In page 1.
-require('electron').remote.getGlobal('sharedObject').someProperty = 'new value'
-```
-
-```javascript
-// In page 2.
-console.log(require('electron').remote.getGlobal('sharedObject').someProperty)
-```
+Alternatively, you can use the IPC primitives that are provided by Electron. To
+share data between the main and renderer processes, you can use the
+[`ipcMain`](api/ipc-main.md) and [`ipcRenderer`](api/ipc-renderer.md) modules.
+To communicate directly between web pages, you can send a
+[`MessagePort`][message-port] from one to the other, possibly via the main process
+using [`ipcRenderer.postMessage()`](api/ipc-renderer.md#ipcrendererpostmessagechannel-message-transfer).
+Subsequent communication over message ports is direct and does not detour through
+the main process.
 
 ## My app's tray disappeared after a few minutes.
 


### PR DESCRIPTION
#### Description of Change
Replaced with references to ipcMain/ipcRenderer and MessagePort.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: none