### PR TITLE
fix: duplicate suspend/resume events

### DIFF
--- a/shell/browser/api/electron_api_power_monitor_mac.mm
+++ b/shell/browser/api/electron_api_power_monitor_mac.mm
@@ -24,29 +24,27 @@
   if ((self = [super init])) {
     NSDistributedNotificationCenter* distCenter =
         [NSDistributedNotificationCenter defaultCenter];
+    // A notification that the screen was locked.
     [distCenter addObserver:self
                    selector:@selector(onScreenLocked:)
                        name:@"com.apple.screenIsLocked"
                      object:nil];
+    // A notification that the screen was unlocked by the user.
     [distCenter addObserver:self
                    selector:@selector(onScreenUnlocked:)
                        name:@"com.apple.screenIsUnlocked"
                      object:nil];
-
     // A notification that the workspace posts before the machine goes to sleep.
-    [[[NSWorkspace sharedWorkspace] notificationCenter]
-        addObserver:self
-           selector:@selector(isSuspending:)
-               name:NSWorkspaceWillSleepNotification
-             object:nil];
-
+    [distCenter addObserver:self
+                   selector:@selector(isSuspending:)
+                       name:NSWorkspaceWillSleepNotification
+                     object:nil];
     // A notification that the workspace posts when the machine wakes from
     // sleep.
-    [[[NSWorkspace sharedWorkspace] notificationCenter]
-        addObserver:self
-           selector:@selector(isResuming:)
-               name:NSWorkspaceDidWakeNotification
-             object:nil];
+    [distCenter addObserver:self
+                   selector:@selector(isResuming:)
+                       name:NSWorkspaceDidWakeNotification
+                     object:nil];
   }
   return self;
 }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/24803.

Switches to use `NSDistributedNotificationCenter`, as using `[[[NSWorkspace sharedWorkspace] notificationCenter]` cause the events to be emitted twice.

Before:

<img width="355" alt="Screen Shot 2020-08-03 at 11 58 04 AM" src="https://user-images.githubusercontent.com/2036040/89217314-d1c37800-d580-11ea-8590-d29a5785162a.png">

After:

<img width="286" alt="Screen Shot 2020-08-03 at 11 57 47 AM" src="https://user-images.githubusercontent.com/2036040/89217318-d425d200-d580-11ea-9514-848a6fc0c25e.png">

Tested with https://gist.github.com/e498427e185c11ac5d81e3bd0fb6dc72

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed an issue where suspend/resume were emitted twice on macOS.
