### PR TITLE
feat: record v8 cpu samples in the main process

### DIFF
--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -12,6 +12,7 @@
 #include "base/task/current_thread.h"
 #include "base/task/thread_pool/initialization_util.h"
 #include "base/threading/thread_task_runner_handle.h"
+#include "base/trace_event/trace_event.h"
 #include "content/public/common/content_switches.h"
 #include "gin/array_buffer.h"
 #include "gin/v8_initializer.h"
@@ -23,6 +24,43 @@
 namespace {
 v8::Isolate* g_isolate;
 }
+
+namespace gin {
+
+class ConvertableToTraceFormatWrapper final
+    : public base::trace_event::ConvertableToTraceFormat {
+ public:
+  explicit ConvertableToTraceFormatWrapper(
+      std::unique_ptr<v8::ConvertableToTraceFormat> inner)
+      : inner_(std::move(inner)) {}
+  ~ConvertableToTraceFormatWrapper() override = default;
+  void AppendAsTraceFormat(std::string* out) const final {
+    inner_->AppendAsTraceFormat(out);
+  }
+
+ private:
+  std::unique_ptr<v8::ConvertableToTraceFormat> inner_;
+
+  DISALLOW_COPY_AND_ASSIGN(ConvertableToTraceFormatWrapper);
+};
+
+}  // namespace gin
+
+// Allow std::unique_ptr<v8::ConvertableToTraceFormat> to be a valid
+// initialization value for trace macros.
+template <>
+struct base::trace_event::TraceValue::Helper<
+    std::unique_ptr<v8::ConvertableToTraceFormat>> {
+  static constexpr unsigned char kType = TRACE_VALUE_TYPE_CONVERTABLE;
+  static inline void SetValue(
+      TraceValue* v,
+      std::unique_ptr<v8::ConvertableToTraceFormat> value) {
+    // NOTE: |as_convertable| is an owning pointer, so using new here
+    // is acceptable.
+    v->as_convertable =
+        new gin::ConvertableToTraceFormatWrapper(std::move(value));
+  }
+};
 
 namespace electron {
 
@@ -52,6 +90,144 @@ JavascriptEnvironment::~JavascriptEnvironment() {
   g_isolate = nullptr;
 }
 
+class EnabledStateObserverImpl final
+    : public base::trace_event::TraceLog::EnabledStateObserver {
+ public:
+  EnabledStateObserverImpl() {
+    base::trace_event::TraceLog::GetInstance()->AddEnabledStateObserver(this);
+  }
+
+  ~EnabledStateObserverImpl() override {
+    base::trace_event::TraceLog::GetInstance()->RemoveEnabledStateObserver(
+        this);
+  }
+
+  void OnTraceLogEnabled() final {
+    base::AutoLock lock(mutex_);
+    for (auto* o : observers_) {
+      o->OnTraceEnabled();
+    }
+  }
+
+  void OnTraceLogDisabled() final {
+    base::AutoLock lock(mutex_);
+    for (auto* o : observers_) {
+      o->OnTraceDisabled();
+    }
+  }
+
+  void AddObserver(v8::TracingController::TraceStateObserver* observer) {
+    {
+      base::AutoLock lock(mutex_);
+      DCHECK(!observers_.count(observer));
+      observers_.insert(observer);
+    }
+
+    // Fire the observer if recording is already in progress.
+    if (base::trace_event::TraceLog::GetInstance()->IsEnabled())
+      observer->OnTraceEnabled();
+  }
+
+  void RemoveObserver(v8::TracingController::TraceStateObserver* observer) {
+    base::AutoLock lock(mutex_);
+    DCHECK(observers_.count(observer) == 1);
+    observers_.erase(observer);
+  }
+
+ private:
+  base::Lock mutex_;
+  std::unordered_set<v8::TracingController::TraceStateObserver*> observers_;
+
+  DISALLOW_COPY_AND_ASSIGN(EnabledStateObserverImpl);
+};
+
+base::LazyInstance<EnabledStateObserverImpl>::Leaky g_trace_state_dispatcher =
+    LAZY_INSTANCE_INITIALIZER;
+
+class TracingControllerImpl : public node::tracing::TracingController {
+ public:
+  TracingControllerImpl() = default;
+  ~TracingControllerImpl() override = default;
+
+  // TracingController implementation.
+  const uint8_t* GetCategoryGroupEnabled(const char* name) override {
+    return TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(name);
+  }
+  uint64_t AddTraceEvent(
+      char phase,
+      const uint8_t* category_enabled_flag,
+      const char* name,
+      const char* scope,
+      uint64_t id,
+      uint64_t bind_id,
+      int32_t num_args,
+      const char** arg_names,
+      const uint8_t* arg_types,
+      const uint64_t* arg_values,
+      std::unique_ptr<v8::ConvertableToTraceFormat>* arg_convertables,
+      unsigned int flags) override {
+    base::trace_event::TraceArguments args(
+        num_args, arg_names, arg_types,
+        reinterpret_cast<const unsigned long long*>(arg_values),
+        arg_convertables);
+    DCHECK_LE(num_args, 2);
+    base::trace_event::TraceEventHandle handle =
+        TRACE_EVENT_API_ADD_TRACE_EVENT_WITH_BIND_ID(
+            phase, category_enabled_flag, name, scope, id, bind_id, &args,
+            flags);
+    uint64_t result;
+    memcpy(&result, &handle, sizeof(result));
+    return result;
+  }
+  uint64_t AddTraceEventWithTimestamp(
+      char phase,
+      const uint8_t* category_enabled_flag,
+      const char* name,
+      const char* scope,
+      uint64_t id,
+      uint64_t bind_id,
+      int32_t num_args,
+      const char** arg_names,
+      const uint8_t* arg_types,
+      const uint64_t* arg_values,
+      std::unique_ptr<v8::ConvertableToTraceFormat>* arg_convertables,
+      unsigned int flags,
+      int64_t timestampMicroseconds) override {
+    base::trace_event::TraceArguments args(
+        num_args, arg_names, arg_types,
+        reinterpret_cast<const unsigned long long*>(arg_values),
+        arg_convertables);
+    DCHECK_LE(num_args, 2);
+    base::TimeTicks timestamp =
+        base::TimeTicks() +
+        base::TimeDelta::FromMicroseconds(timestampMicroseconds);
+    base::trace_event::TraceEventHandle handle =
+        TRACE_EVENT_API_ADD_TRACE_EVENT_WITH_THREAD_ID_AND_TIMESTAMP(
+            phase, category_enabled_flag, name, scope, id, bind_id,
+            TRACE_EVENT_API_CURRENT_THREAD_ID, timestamp, &args, flags);
+    uint64_t result;
+    memcpy(&result, &handle, sizeof(result));
+    return result;
+  }
+  void UpdateTraceEventDuration(const uint8_t* category_enabled_flag,
+                                const char* name,
+                                uint64_t handle) override {
+    base::trace_event::TraceEventHandle traceEventHandle;
+    memcpy(&traceEventHandle, &handle, sizeof(handle));
+    TRACE_EVENT_API_UPDATE_TRACE_EVENT_DURATION(category_enabled_flag, name,
+                                                traceEventHandle);
+  }
+  void AddTraceStateObserver(TraceStateObserver* observer) override {
+    g_trace_state_dispatcher.Get().AddObserver(observer);
+  }
+  void RemoveTraceStateObserver(TraceStateObserver* observer) override {
+    g_trace_state_dispatcher.Get().RemoveObserver(observer);
+  }
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(TracingControllerImpl);
+};
+
 v8::Isolate* JavascriptEnvironment::Initialize(uv_loop_t* event_loop) {
   auto* cmd = base::CommandLine::ForCurrentProcess();
 
@@ -63,7 +239,7 @@ v8::Isolate* JavascriptEnvironment::Initialize(uv_loop_t* event_loop) {
   // The V8Platform of gin relies on Chromium's task schedule, which has not
   // been started at this point, so we have to rely on Node's V8Platform.
   auto* tracing_agent = node::CreateAgent();
-  auto* tracing_controller = tracing_agent->GetTracingController();
+  auto* tracing_controller = new TracingControllerImpl();
   node::tracing::TraceEventHelper::SetAgent(tracing_agent);
   platform_ = node::CreatePlatform(
       base::RecommendedMaxNumberOfThreadsInThreadGroup(3, 8, 0.1, 0),


### PR DESCRIPTION
#### Description of Change
This connects V8's cpu sampler to the "tracing enabled" signal that's emitted when content tracing is enabled. This is derived from the [gin::V8Platform](https://source.chromium.org/chromium/chromium/src/+/master:gin/v8_platform.cc;l=65;drc=9caa721efb4ef1e0fb855cc7116512964fe6b928) implementation of same. We don't get this in the main process from gin because we don't use gin's V8 platform in the main process. (We do in the renderer process, which is why v8 sampling works fine there currently).

NB. this can tickle what I think is a bug in V8 related to allocating from the heap during a "heap-allocation-disallowed" zone. Marked WIP until I've resolved the issue.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: When the `disabled-by-default-v8.cpu_profiler` tracing category is enabled, cpu samples will now be collected from the main process as well as the renderer.