### PR TITLE
feat: add mas_build crash key

### DIFF
--- a/shell/common/crash_keys.cc
+++ b/shell/common/crash_keys.cc
@@ -144,17 +144,16 @@ void SetPlatformCrashKey() {
   platform_key.Set("win32");
 #elif defined(OS_MACOSX)
   platform_key.Set("darwin");
-#elif defined(OS_LINUX)
-  platform_key.Set("linux");
-#else
-#error Unknown platform.
-#endif
-
   static crash_reporter::CrashKeyString<1> mas_key("mas_build");
 #if defined(MAS_BUILD)
   mas_key.Set("1");
 #else
   mas_key.Set("0");
+#endif
+#elif defined(OS_LINUX)
+  platform_key.Set("linux");
+#else
+#error Unknown platform.
 #endif
 }
 

--- a/shell/common/crash_keys.cc
+++ b/shell/common/crash_keys.cc
@@ -147,7 +147,14 @@ void SetPlatformCrashKey() {
 #elif defined(OS_LINUX)
   platform_key.Set("linux");
 #else
-  platform_key.Set("unknown");
+#error Unknown platform.
+#endif
+
+  static crash_reporter::CrashKeyString<1> mas_key("mas_build");
+#if defined(MAS_BUILD)
+  mas_key.Set("1");
+#else
+  mas_key.Set("0");
 #endif
 }
 


### PR DESCRIPTION
#### Description of Change
This adds a new crash key, `mas_build`, that will be present in mac crashes. Its value is `1` if the crash is from a MAS build, or `0` otherwise.

It's useful to be able to distinguish between MAS and non-MAS builds when debugging crashes, both because the symbolication is different (since the addresses of functions are different) and because the runtime environment is different.

I considered changing the value of the `platform` key from `darwin` to `darwin-mas` on MAS builds, but decided against it because (1) the `platform` key is redundant with a key that `//components/crash` adds, and might eventually be removed, (2) having both `platform` and `plat` exist but take different values is surprising, and (3) this approach is less likely to break anyone depending on particular crash keys existing and having certain expected values.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Added a new default crash key on macOS builds, `mas_build`, for distinguishing between crashes from MAS vs. non-MAS builds.