### PR TITLE
fix: do not render inactive titlebar as active on Windows

### DIFF
--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -24,6 +24,14 @@ bool ElectronDesktopWindowTreeHostWin::PreHandleMSG(UINT message,
   return native_window_view_->PreHandleMSG(message, w_param, l_param, result);
 }
 
+bool ElectronDesktopWindowTreeHostWin::ShouldPaintAsActive() const {
+  // Tell Chromium to use system default behavior when rendering inactive
+  // titlebar, otherwise it would render inactive titlebar as active under
+  // some cases.
+  // See also https://github.com/electron/electron/issues/24647.
+  return false;
+}
+
 bool ElectronDesktopWindowTreeHostWin::HasNativeFrame() const {
   // Since we never use chromium's titlebar implementation, we can just say
   // that we use a native titlebar. This will disable the repaint locking when

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
@@ -25,6 +25,7 @@ class ElectronDesktopWindowTreeHostWin
                     WPARAM w_param,
                     LPARAM l_param,
                     LRESULT* result) override;
+  bool ShouldPaintAsActive() const override;
   bool HasNativeFrame() const override;
   bool GetClientAreaInsets(gfx::Insets* insets,
                            HMONITOR monitor) const override;


### PR DESCRIPTION
#### Description of Change

Chromium renders titlebar as active as long as there is any views window active, even when current window is not active, which is different from most other win32 apps. We prevent this behavior by overriding the `WM_NCACTIVATE` message to default behavior.

Close https://github.com/electron/electron/issues/24647.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fix inactive windows having active titlebar on Windows