### PR TITLE
feat: add session.setCorsOriginAccessList API

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -662,6 +662,29 @@ event. The [DownloadItem](download-item.md) will not have any `WebContents` asso
 the initial state will be `interrupted`. The download will start only when the
 `resume` API is called on the [DownloadItem](download-item.md).
 
+#### `ses.setCorsOriginAccessList(origin, allowPatterns, blockPatterns)`
+
+* `origin` String - The Origin URL for which to set the CORS policy.
+* `allowPatterns` String[] - An array of URL patterns to allow.
+* `blockPatterns` String[] - An array of URL patterns to block.
+
+Returns `Promise<void>` - Resolves when the operation is complete.
+
+Adds additional URL patterns to the allow and block list of the CORS policy.
+This is often used to securely permit pages from your custom protocol to access resources that would otherwise be blocked by CORS, such as `file:///` URLs, without having to use `webSecurity: false`.
+This can also be used to block access to certain resources.
+
+```javascript
+const { app, session } = require('electron')
+
+app.whenReady().then(async () => {
+  await session.defaultSession.setCorsOriginAccessList(
+    'custom://abc/hello.html',
+    ['https://*.github.com/*', '*://electron.github.io', 'file'], /* allow list */
+    ['http://*/*'] /* block list */)
+})
+```
+
 #### `ses.clearAuthCache()`
 
 Returns `Promise<void>` - resolves when the session’s HTTP authentication cache has been cleared.

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -292,7 +292,9 @@ Do not disable `webSecurity` in production applications.
 
 Disabling `webSecurity` will disable the same-origin policy and set
 `allowRunningInsecureContent` property to `true`. In other words, it allows
-the execution of insecure code from different domains.
+the execution of insecure code from different domains. It also allows any
+website from any URL to access files on the local computer using
+the `file:///` protocol.
 
 ### How?
 
@@ -316,6 +318,24 @@ const mainWindow = new BrowserWindow()
 
 <!-- Good -->
 <webview src="page.html"></webview>
+```
+
+### Allow custom protocol to access `file:///` resources
+
+Instead of disabling `webSecurity`, consider using the
+[`session.setCorsOriginAccessList`][set-cors-origin-access-list] API
+to allow cross-origin resource access for your custom protocol.
+
+```javascript
+const { app, session } = require('electron')
+
+app.whenReady().then(async () => {
+  await session.defaultSession.setCorsOriginAccessList(
+    'my-custom-protocol://abc/index.html',
+    ['file'], /* allow list */
+    [] /* block list */
+  )
+})
 ```
 
 ## 6) Define a Content Security Policy
@@ -694,3 +714,4 @@ which potential security issues are not as widely known.
 [open-external]: ../api/shell.md#shellopenexternalurl-options
 [sandbox]: ../api/sandbox-option.md
 [responsible-disclosure]: https://en.wikipedia.org/wiki/Responsible_disclosure
+[set-cors-origin-access-list]: ../api/session.md#sessetcorsoriginaccesslistorigin-allowpatterns-blockpatterns

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -5,6 +5,7 @@
 #ifndef SHELL_BROWSER_API_ELECTRON_API_SESSION_H_
 #define SHELL_BROWSER_API_ELECTRON_API_SESSION_H_
 
+#include <set>
 #include <string>
 #include <vector>
 
@@ -124,6 +125,10 @@ class Session : public gin::Wrappable<Session>,
   v8::Local<v8::Value> NetLog(v8::Isolate* isolate);
   void Preconnect(const gin_helper::Dictionary& options, gin::Arguments* args);
   v8::Local<v8::Promise> CloseAllConnections();
+  v8::Local<v8::Promise> SetCorsOriginAccessList(
+      const GURL& url,
+      const std::set<URLPattern>& allow_pattern_set,
+      const std::set<URLPattern>& block_pattern_set);
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
   base::Value GetSpellCheckerLanguages();
   void SetSpellCheckerLanguages(gin_helper::ErrorThrower thrower,

--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -30,19 +30,6 @@
 namespace gin {
 
 template <>
-struct Converter<URLPattern> {
-  static bool FromV8(v8::Isolate* isolate,
-                     v8::Local<v8::Value> val,
-                     URLPattern* out) {
-    std::string pattern;
-    if (!ConvertFromV8(isolate, val, &pattern))
-      return false;
-    *out = URLPattern(URLPattern::SCHEME_ALL);
-    return out->Parse(pattern) == URLPattern::ParseResult::kSuccess;
-  }
-};
-
-template <>
 struct Converter<extensions::WebRequestResourceType> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    extensions::WebRequestResourceType type) {

--- a/shell/browser/net/network_context_service.cc
+++ b/shell/browser/net/network_context_service.cc
@@ -87,6 +87,11 @@ void NetworkContextService::ConfigureNetworkContextParams(
   network_context_params->enable_ftp_url_support = true;
 #endif  // !BUILDFLAG(DISABLE_FTP_SUPPORT)
 
+  network_context_params->cors_origin_access_list =
+      browser_context_->GetSharedCorsOriginAccessList()
+          ->GetOriginAccessList()
+          .CreateCorsOriginAccessPatternsList();
+
   proxy_config_monitor_.AddToNetworkContextParams(network_context_params);
 
   BrowserProcessImpl::ApplyProxyModeFromCommandLine(

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -12,6 +12,7 @@
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "base/values.h"
+#include "extensions/common/url_pattern.h"
 #include "gin/converter.h"
 #include "gin/dictionary.h"
 #include "net/cert/x509_certificate.h"
@@ -398,6 +399,17 @@ v8::Local<v8::Value> Converter<net::RedirectInfo>::ToV8(
            val.is_signed_exchange_fallback_redirect);
 
   return ConvertToV8(isolate, dict);
+}
+
+// static
+bool Converter<URLPattern>::FromV8(v8::Isolate* isolate,
+                                   v8::Local<v8::Value> val,
+                                   URLPattern* out) {
+  std::string pattern;
+  if (!ConvertFromV8(isolate, val, &pattern))
+    return false;
+  *out = URLPattern(URLPattern::SCHEME_ALL);
+  return out->Parse(pattern) == URLPattern::ParseResult::kSuccess;
 }
 
 }  // namespace gin

--- a/shell/common/gin_converters/net_converter.h
+++ b/shell/common/gin_converters/net_converter.h
@@ -13,6 +13,8 @@
 #include "services/network/public/mojom/fetch_api.mojom.h"
 #include "shell/browser/net/cert_verifier_client.h"
 
+class URLPattern;
+
 namespace base {
 class DictionaryValue;
 class ListValue;
@@ -112,6 +114,13 @@ template <>
 struct Converter<net::RedirectInfo> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    const net::RedirectInfo& val);
+};
+
+template <>
+struct Converter<URLPattern> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     URLPattern* out);
 };
 
 template <typename K, typename V>


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Summary: A new "local" scheme privilege is added, which grants access to file:// resources without needing to disable webSecurity.

Rationale:

- It is common for electron apps to define a custom protocol to serve app resources [(as seen from first example here)](https://www.electronjs.org/docs/api/protocol).
- Apps that registers their custom protocol as `secure` cannot access files from the `file:///` protocol.
- This rejection comes from deep within chromium and no Electron API seem to be able to override that, except `webSecurity: false`. Things I've tried:
  - `registerFileProtocol('file'...)`
  - `interceptFileProtocol('file'...)`
  - `session.defaultSession.webRequest.onBeforeRequest`
- `webSecurity: false` is not a recommended practice for security purposes by https://www.electronjs.org/docs/tutorial/security

This PR adds a `local` privilege to scheme registration, which adds the scheme to `blink::SchemeRegistry::RegisterURLSchemeAsLocal`. 
Doing so marks the protocol as local, thus allowing it to access local resources via the pathway:
[`SecurityOrigin::CanDisplay()`](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/platform/weborigin/security_origin.cc;l=417;drc=8d3351f2b93dc4fef60b794c47ec22ebf54f3e8b;bpv=1;bpt=1)
[`SecurityOrigin::can_load_local_resources_`](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/platform/weborigin/security_origin.cc;l=144;drc=8d3351f2b93dc4fef60b794c47ec22ebf54f3e8b)
[`SecurityOrigin::IsLocal()`](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/platform/weborigin/security_origin.cc;l=471;drc=8d3351f2b93dc4fef60b794c47ec22ebf54f3e8b)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Added "local" scheme privilege, which grants access to file:// without the need to disable webSecurity.

<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
