### PR TITLE
fix: send guid with linux crashes

### DIFF
--- a/shell/browser/api/electron_api_crash_reporter.h
+++ b/shell/browser/api/electron_api_crash_reporter.h
@@ -19,6 +19,7 @@ bool IsCrashReporterEnabled();
 
 #if defined(OS_LINUX)
 const std::map<std::string, std::string>& GetGlobalCrashKeys();
+std::string GetClientId();
 #endif
 
 // JS bindings API; exposed publicly because it's also called from node_main.cc

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -722,8 +722,10 @@ void ElectronBrowserClient::AppendExtraCommandLineSwitches(
   bool enable_crash_reporter = false;
   enable_crash_reporter = breakpad::IsCrashReporterEnabled();
   if (enable_crash_reporter) {
-    command_line->AppendSwitch(::switches::kEnableCrashReporter);
-    std::string switch_value;
+    std::string switch_value =
+        api::crash_reporter::GetClientId() + ",no_channel";
+    command_line->AppendSwitchASCII(::switches::kEnableCrashReporter,
+                                    switch_value);
     for (const auto& pair : api::crash_reporter::GetGlobalCrashKeys()) {
       if (!switch_value.empty())
         switch_value += ",";


### PR DESCRIPTION
#### Description of Change
Fixes #24053.

This saves the crash reporter ID in a file in the crash dumps directory, which roughly matches how Crashpad works.

Chrome stores this as a browser preference, and also has some complicated logic around when they regenerate the token, as it's used for a lot of other metrics-related things. I don't believe it's important for Electron to replicate that logic, especially given that Chrome's Crashpad reporter doesn't seem to do so.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed missing `guid` parameter in Linux crash reports.