### PR TITLE
fix: don't try to init mmap on missing asar

### DIFF
--- a/shell/common/asar/archive.cc
+++ b/shell/common/asar/archive.cc
@@ -119,7 +119,7 @@ bool FillFileInfoWithNode(Archive::FileInfo* info,
 
 Archive::Archive(const base::FilePath& path) : path_(path) {
   base::ThreadRestrictions::ScopedAllowIO allow_io;
-  if (!file_.Initialize(path_)) {
+  if (base::PathExists(path_) && !file_.Initialize(path_)) {
     LOG(ERROR) << "Failed to open ASAR archive at '" << path_.value() << "'";
   }
 }


### PR DESCRIPTION
#### Description of Change

Fixes the following errors:
```
[58920:0807/085420.005973:ERROR:memory_mapped_file.cc(61)] Couldn't open /Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/Resources/app.asar
[58920:0807/085420.005994:ERROR:archive.cc(123)] Failed to open ASAR archive at '/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/Resources/app.asar'
[58920:0807/085420.006249:ERROR:memory_mapped_file.cc(61)] Couldn't open /Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/Resources/app.asar
[58920:0807/085420.006257:ERROR:archive.cc(123)] Failed to open ASAR archive at '/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/Resources/app.asar'
[58920:0807/085420.006501:ERROR:memory_mapped_file.cc(61)] Couldn't open /Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/Resources/app.asar
[58920:0807/085420.006508:ERROR:archive.cc(123)] Failed to open ASAR archive at '/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/Resources/app.asar'
[58920:0807/085420.006749:ERROR:memory_mapped_file.cc(61)] Couldn't open /Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/Resources/app.asar
[58920:0807/085420.006756:ERROR:archive.cc(123)] Failed to open ASAR archive at '/Users/codebytere/Developer/electron-gn/src/out/Testing/Electron.app/Contents/Resources/app.asar'
```

Seen in console owing to our trying to initialize a MemoryMappedFile with a nonexistent path.

cc @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed an issue where errors were seen for nonexistent asar files.
