### PR TITLE
build: convert some scripts to TS

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
       "node script/lint.js --js --fix --only --"
     ],
     "*.{js,ts,d.ts}": [
-      "node script/gen-filenames.js"
+      "ts-node script/gen-filenames.ts"
     ],
     "*.{cc,mm,c,h}": [
       "python script/run-clang-format.py -r -c --fix"
@@ -124,13 +124,13 @@
       "node script/lint.js --py --fix --only --"
     ],
     "docs/api/**/*.md": [
-      "node script/gen-filenames.js",
+      "ts-node script/gen-filenames.ts",
       "python script/check-trailing-whitespace.py --fix",
       "git add filenames.auto.gni"
     ],
     "{*.patch,.patches}": [
       "node script/lint.js --patches --only --",
-      "node script/check-patch-diff.js"
+      "ts-node script/check-patch-diff.ts"
     ],
     "DEPS": [
       "node script/gen-hunspell-filenames.js"

--- a/script/check-patch-diff.ts
+++ b/script/check-patch-diff.ts
@@ -1,6 +1,5 @@
-const { spawnSync } = require('child_process');
-const path = require('path');
-const { inspect } = require('util');
+import { spawnSync } from 'child_process';
+import * as path from 'path';
 
 const srcPath = path.resolve(__dirname, '..', '..', '..');
 const patchExportFnPath = path.resolve(__dirname, 'export_all_patches.py');

--- a/script/codesign/gen-trust.ts
+++ b/script/codesign/gen-trust.ts
@@ -1,6 +1,6 @@
-const cp = require('child_process');
-const fs = require('fs');
-const path = require('path');
+import * as cp from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
 
 const certificatePath = process.argv[2];
 const outPath = process.argv[3];

--- a/script/codesign/generate-identity.sh
+++ b/script/codesign/generate-identity.sh
@@ -40,7 +40,7 @@ DevToolsSecurity -enable
 # security import "$dir"/public.key -k $KEY_CHAIN
 
 # Generate Trust Settings
-node "$(dirname $0)"/gen-trust.js "$dir"/certificate.cer "$dir"/trust.xml
+npx ts-node node "$(dirname $0)"/gen-trust.ts "$dir"/certificate.cer "$dir"/trust.xml
 
 # Import Trust Settings
 sudo security trust-settings-import -d "$dir/trust.xml"


### PR DESCRIPTION
Extending our type-safety into the "script" folder.  In a future PR we'll add a "tsc" check to the lint step on CI so that we know that all scripts pass a type check.

Notes: no-notes