### PR TITLE
build: type check the script folder during lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1037,6 +1037,11 @@ steps-lint: &steps-lint
           cd src/electron
           node script/yarn install --frozen-lockfile
           node script/yarn lint
+    - run:
+        name: Run Script Typechecker
+        command: |
+          cd src/electron
+          node script/yarn tsc -p tsconfig.script.json
 
 steps-checkout-and-save-cache: &steps-checkout-and-save-cache
   steps:

--- a/tsconfig.script.json
+++ b/tsconfig.script.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": [
+    "script"
+  ]
+}


### PR DESCRIPTION
Follow up to #24891

Ensures our TS scripts are actually type safe as not all scripts are exercised on CI

Notes: no-notes