### PR TITLE
docs: fixed minor typos

### DIFF
--- a/docs/tutorial/mojave-dark-mode-guide.md
+++ b/docs/tutorial/mojave-dark-mode-guide.md
@@ -13,11 +13,11 @@ to automate the `Info.plist` changes during app build time.
 
 ## Automatically updating the native interfaces
 
-"Native Interfaces" include the file picker, window border, dialogs, context menus and more; basically,
+"Native Interfaces" include the file picker, window border, dialogs, context menus, and more; basically,
 anything where the UI comes from macOS and not your app. As of Electron 7.0.0, the default behavior
-is to opt in to this automatic theming from the OS. If you wish to opt out and are using Electron
+is to opt into this automatic theming from the OS. If you wish to opt-out and are using Electron
 &gt; 8.0.0, you must set the `NSRequiresAquaSystemAppearance` key in the `Info.plist` file to `true`.
-Please note that Electron 8.0.0 and above will not let your opt out of this theming, due to the use
+Please note that Electron 8.0.0 and above will not let your opt-out of this theming, due to the use
 of the macOS 10.14 SDK.
 
 ## Automatically updating your own interfaces


### PR DESCRIPTION
I was going through the entire documentation and decided to fix this to the best of my knowledge.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: none
