### PR TITLE
fix: pdf viewer template strings

### DIFF
--- a/electron_paks.gni
+++ b/electron_paks.gni
@@ -55,6 +55,7 @@ template("electron_extra_paks") {
     output = "${invoker.output_dir}/resources.pak"
     sources = [
       "$root_gen_dir/chrome/dev_ui_browser_resources.pak",
+      "$root_gen_dir/chrome/print_preview_pdf_resources.pak",
       "$root_gen_dir/components/components_resources.pak",
       "$root_gen_dir/content/browser/resources/media/media_internals_resources.pak",
       "$root_gen_dir/content/browser/tracing/tracing_resources.pak",
@@ -69,6 +70,7 @@ template("electron_extra_paks") {
     ]
     deps = [
       "//chrome/browser:dev_ui_browser_resources",
+      "//chrome/browser/resources:print_preview_pdf_resources",
       "//components/resources",
       "//content:content_resources",
       "//content:dev_ui_content_resources",

--- a/shell/browser/common_web_contents_delegate.cc
+++ b/shell/browser/common_web_contents_delegate.cc
@@ -209,7 +209,7 @@ void CommonWebContentsDelegate::InitWithWebContents(
       web_contents, std::make_unique<ElectronPDFWebContentsHelperClient>());
 #endif
 
-  // Determien whether the WebContents is offscreen.
+  // Determine whether the WebContents is offscreen.
   auto* web_preferences = WebContentsPreferences::From(web_contents);
   offscreen_ =
       web_preferences && web_preferences->IsEnabled(options::kOffscreen);

--- a/shell/browser/extensions/electron_component_extension_resource_manager.cc
+++ b/shell/browser/extensions/electron_component_extension_resource_manager.cc
@@ -5,6 +5,7 @@
 #include "shell/browser/extensions/electron_component_extension_resource_manager.h"
 
 #include <string>
+#include <utility>
 
 #include "base/logging.h"
 #include "base/path_service.h"
@@ -13,6 +14,12 @@
 #include "build/build_config.h"
 #include "chrome/common/chrome_paths.h"
 #include "chrome/grit/component_extension_resources_map.h"
+#include "electron/buildflags/buildflags.h"
+
+#if BUILDFLAG(ENABLE_PDF_VIEWER)
+#include "chrome/browser/pdf/pdf_extension_util.h"
+#include "extensions/common/constants.h"
+#endif
 
 namespace extensions {
 
@@ -20,6 +27,19 @@ ElectronComponentExtensionResourceManager::
     ElectronComponentExtensionResourceManager() {
   AddComponentResourceEntries(kComponentExtensionResources,
                               kComponentExtensionResourcesSize);
+#if BUILDFLAG(ENABLE_PDF_VIEWER)
+  // Register strings for the PDF viewer, so that $i18n{} replacements work.
+  base::Value pdf_strings(base::Value::Type::DICTIONARY);
+  pdf_extension_util::AddStrings(
+      pdf_extension_util::PdfViewerContext::kPdfViewer, &pdf_strings);
+  pdf_extension_util::AddAdditionalData(&pdf_strings);
+
+  ui::TemplateReplacements pdf_viewer_replacements;
+  ui::TemplateReplacementsFromDictionaryValue(
+      base::Value::AsDictionaryValue(pdf_strings), &pdf_viewer_replacements);
+  extension_template_replacements_[extension_misc::kPdfExtensionId] =
+      std::move(pdf_viewer_replacements);
+#endif
 }
 
 ElectronComponentExtensionResourceManager::


### PR DESCRIPTION
#### Description of Change

Fixes broken i18n string templating in the PDF viewer extension.

Before:

![before](https://user-images.githubusercontent.com/2036040/89750877-a6f68980-da82-11ea-81a7-f652ea4c84ea.png)

After:
![after](https://user-images.githubusercontent.com/2036040/89750883-acec6a80-da82-11ea-8751-bc4777f68264.png)

Sorry for the potato quality of these comparisons, its lowkey impossible to take a screenshot of something that requires hovering 😅 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed broken toolbar text in the PDF viewer.
