### PR TITLE
fix: add deps on the new devtools highlighter

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -360,6 +360,7 @@ source_set("electron_lib") {
     "//services/viz/privileged/mojom/compositing",
     "//skia",
     "//third_party/blink/public:blink",
+    "//third_party/blink/public:blink_devtools_inspector_resources",
     "//third_party/boringssl",
     "//third_party/electron_node:node_lib",
     "//third_party/inspector_protocol:crdtp",

--- a/electron_paks.gni
+++ b/electron_paks.gni
@@ -64,6 +64,7 @@ template("electron_extra_paks") {
       "$root_gen_dir/mojo/public/js/mojo_bindings_resources.pak",
       "$root_gen_dir/net/net_resources.pak",
       "$root_gen_dir/third_party/blink/public/resources/blink_resources.pak",
+      "$root_gen_dir/third_party/blink/public/resources/inspector_overlay_resources.pak",
       "$root_gen_dir/ui/resources/webui_resources.pak",
       "$target_gen_dir/electron_resources.pak",
     ]
@@ -78,6 +79,7 @@ template("electron_extra_paks") {
       "//electron:resources",
       "//mojo/public/js:resources",
       "//net:net_resources",
+      "//third_party/blink/public:devtools_inspector_resources",
       "//third_party/blink/public:resources",
       "//ui/resources",
     ]


### PR DESCRIPTION
Fixes #24523

Refs: https://chromium-review.googlesource.com/c/chromium/src/+/2225720

Notes: The element highlighter in devtools works again