### PR TITLE
build: in release notes script, do not assume electron dirname

### DIFF
--- a/script/release/notes/notes.js
+++ b/script/release/notes/notes.js
@@ -11,7 +11,7 @@ const octokit = new Octokit({
   auth: process.env.ELECTRON_GITHUB_TOKEN
 });
 
-const { SRC_DIR } = require('../../lib/utils');
+const { ELECTRON_DIR } = require('../../lib/utils');
 
 const MAX_FAIL_COUNT = 3;
 const CHECK_INTERVAL = 5000;
@@ -387,13 +387,12 @@ const getNotes = async (fromRef, toRef, newVersion) => {
   }
 
   const pool = new Pool();
-  const electronDir = path.resolve(SRC_DIR, 'electron');
-  const toBranch = await getBranchNameOfRef(toRef, electronDir);
+  const toBranch = await getBranchNameOfRef(toRef, ELECTRON_DIR);
 
   console.log(`Generating release notes between ${fromRef} and ${toRef} for version ${newVersion} in branch ${toBranch}`);
 
   // get the electron/electron commits
-  const electron = { owner: 'electron', repo: 'electron', dir: electronDir };
+  const electron = { owner: 'electron', repo: 'electron', dir: ELECTRON_DIR };
   await addRepoToPool(pool, electron, fromRef, toRef);
 
   // remove any old commits


### PR DESCRIPTION
#### Description of Change

Followup to a7ed3e62b88121b6b03da2b7116743f069a2eb9b, this may fix the directory name issue.

CC @codebytere @MarshallOfSound 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: none