### PR TITLE
docs: note remote deprecation in docs/api/remote

### DIFF
--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -4,6 +4,16 @@
 
 Process: [Renderer](../glossary.md#renderer-process)
 
+> ⚠️ WARNING ⚠️
+> The `remote` module is [deprecated](https://github.com/electron/electron/issues/21408).
+> Instead of `remote`, use [`ipcRenderer`](ipc-renderer.md) and
+> [`ipcMain`](ipc-main.md).
+>
+> Read more about why the `remote` module is deprecated [here](https://medium.com/@nornagon/electrons-remote-module-considered-harmful-70d69500f31).
+>
+> If you still want to use `remote` despite the performance and security
+> concerns, see [@electron/remote](https://github.com/electron/remote).
+
 The `remote` module provides a simple way to do inter-process communication
 (IPC) between the renderer process (web page) and the main process.
 


### PR DESCRIPTION
#### Description of Change
Adds a note to the top of the `remote` documentation about the impending deprecation.

#### Release Notes

Notes: none