### PR TITLE
feat: add ability to close connections for a session

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -295,6 +295,9 @@ Sets the proxy settings.
 When `pacScript` and `proxyRules` are provided together, the `proxyRules`
 option is ignored and `pacScript` configuration is applied.
 
+You may need `ses.closeAllConnections` to close currently in flight connections to prevent
+pooled sockets using previous proxy from being reused by future requests.
+
 The `proxyRules` has to follow the rules below:
 
 ```sh
@@ -403,6 +406,12 @@ window.webContents.session.enableNetworkEmulation({ offline: true })
   * `numSockets` Number (optional) - number of sockets to preconnect. Must be between 1 and 6. Defaults to 1.
 
 Preconnects the given number of sockets to an origin.
+
+#### `ses.closeAllConnections()`
+
+Returns `Promise<void>` - Resolves when all connections are closed.
+
+**Note:** It will terminate / fail all requests currently in flight.
 
 #### `ses.disableNetworkEmulation()`
 

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -122,6 +122,7 @@ class Session : public gin::Wrappable<Session>,
   v8::Local<v8::Value> WebRequest(v8::Isolate* isolate);
   v8::Local<v8::Value> NetLog(v8::Isolate* isolate);
   void Preconnect(const gin_helper::Dictionary& options, gin::Arguments* args);
+  v8::Local<v8::Promise> CloseAllConnections();
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
   base::Value GetSpellCheckerLanguages();
   void SetSpellCheckerLanguages(gin_helper::ErrorThrower thrower,


### PR DESCRIPTION
#### Description of Change
These methods are needed for closing idle and active connections after
switching to another proxy for a session, otherwise these connections may
be reused for future requests which is unexpected for most of users.

this pull request was a part of #24937

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: New api for closing connections for a session

@deepak1556 