### PR TITLE
fix: pdf preview download button not working

### DIFF
--- a/shell/browser/extensions/electron_extensions_api_client.cc
+++ b/shell/browser/extensions/electron_extensions_api_client.cc
@@ -8,8 +8,14 @@
 #include <string>
 
 #include "extensions/browser/guest_view/mime_handler_view/mime_handler_view_guest_delegate.h"
+#include "printing/buildflags/buildflags.h"
 #include "shell/browser/extensions/electron_extension_web_contents_observer.h"
 #include "shell/browser/extensions/electron_messaging_delegate.h"
+
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+#include "components/pdf/browser/pdf_web_contents_helper.h"
+#include "shell/browser/electron_pdf_web_contents_helper_client.h"
+#endif
 
 namespace extensions {
 
@@ -46,6 +52,11 @@ void ElectronExtensionsAPIClient::AttachWebContentsHelpers(
     content::WebContents* web_contents) const {
   extensions::ElectronExtensionWebContentsObserver::CreateForWebContents(
       web_contents);
+
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+  pdf::PDFWebContentsHelper::CreateForWebContentsWithClient(
+      web_contents, std::make_unique<ElectronPDFWebContentsHelperClient>());
+#endif
 }
 
 std::unique_ptr<MimeHandlerViewGuestDelegate>


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/22178.

Before: Nothing.

After:

<img width="533" alt="Screen Shot 2020-08-11 at 10 44 18 PM" src="https://user-images.githubusercontent.com/2036040/89979317-4dc65b80-dc24-11ea-96a2-d0bd0a5ff9b8.png">

Unfortunately this can't be hooked up to `will-download` infrastructure in its current form - it runs through fairly separate logic and adding the ability to intercept and prevent default a la the existing event implementation would require some patching that at this juncture i don't think is in our best interest.

cc @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed an issue where the Save button did not function in PDF previews.
