### PR TITLE
docs: clarify a11y docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,7 @@ an issue:
 * [Accessibility](tutorial/accessibility.md)
   * [Spectron](tutorial/accessibility.md#spectron)
   * [Devtron](tutorial/accessibility.md#devtron)
-  * [Enabling Accessibility](tutorial/accessibility.md#enabling-accessibility)
+  * [Manually Enabling Accessibility Features](tutorial/accessibility.md#manually-enabling-accessibility-features)
 * [Testing and Debugging](tutorial/application-debugging.md)
   * [Debugging the Main Process](tutorial/debugging-main-process.md)
   * [Debugging the Main Process with Visual Studio Code](tutorial/debugging-main-process-vscode.md)

--- a/docs/tutorial/accessibility.md
+++ b/docs/tutorial/accessibility.md
@@ -46,9 +46,6 @@ accessibility documentation with a pull request.
 
 ## Enabling Accessibility
 
-Electron applications keep accessibility disabled by default for performance
-reasons but there are multiple ways to enable it.
-
 ### Inside Application
 
 By using [`app.setAccessibilitySupportEnabled(enabled)`][setAccessibilitySupportEnabled],

--- a/docs/tutorial/accessibility.md
+++ b/docs/tutorial/accessibility.md
@@ -1,6 +1,6 @@
 # Accessibility
 
-Making accessible applications is important and we're happy to introduce new
+Making accessible applications is important and we're happy to provide
 functionality to [Devtron][devtron] and [Spectron][spectron] that gives
 developers the opportunity to make their apps better for everyone.
 
@@ -11,7 +11,7 @@ websites because they're both ultimately HTML. With Electron apps, however,
 you can't use the online resources for accessibility audits because your app
 doesn't have a URL to point the auditor to.
 
-These new features bring those auditing tools to your Electron app. You can
+These features bring those auditing tools to your Electron app. You can
 choose to add audits to your tests with Spectron or use them within DevTools
 with Devtron. Read on for a summary of the tools.
 
@@ -32,7 +32,7 @@ You can read more about this feature in [Spectron's documentation][spectron-a11y
 
 ## Devtron
 
-In Devtron, there is a new accessibility tab which will allow you to audit a
+In Devtron, there is an accessibility tab which will allow you to audit a
 page in your app, sort and filter the results.
 
 ![devtron screenshot][devtron-screenshot]
@@ -44,23 +44,29 @@ audit rules this library uses on that [repository's wiki][a11y-devtools-wiki].
 If you know of other great accessibility tools for Electron, add them to the
 accessibility documentation with a pull request.
 
-## Enabling Accessibility
+## Manually enabling accessibility features
 
-### Inside Application
+Electron applications will automatically enable accessibility features in the
+presence of assistive technology (e.g. [JAWS](https://www.freedomscientific.com/products/software/jaws/)
+on Windows or [VoiceOver](https://help.apple.com/voiceover/mac/10.15/) on macOS).
+See Chrome's [accessibility documentation][a11y-docs] for more details.
 
-By using [`app.setAccessibilitySupportEnabled(enabled)`][setAccessibilitySupportEnabled],
-you can expose accessibility switch to users in the application preferences.
-User's system assistive utilities have priority over this setting and will
-override it.
+You can also manually toggle these features either within your Electron application
+or by setting flags in third-party native software.
 
-### Assistive Technology
+### Using Electron's API
 
-Electron application will enable accessibility automatically when it detects
-assistive technology (Windows) or VoiceOver (macOS). See Chrome's
-[accessibility documentation][a11y-docs] for more details.
+By using the [`app.setAccessibilitySupportEnabled(enabled)`][setAccessibilitySupportEnabled]
+API, you can manually expose Chrome's accessibility tree to users in the application preferences.
+Note that the user's system assistive utilities have priority over this setting and
+will override it.
 
-On macOS, third-party assistive technology can switch accessibility inside
-Electron applications by setting the attribute `AXManualAccessibility`
+### Within third-party software
+
+#### macOS
+
+On macOS, third-party assistive technology can toggle accessibility features inside
+Electron applications by setting the `AXManualAccessibility` attribute
 programmatically:
 
 ```objc


### PR DESCRIPTION
#### Description of Change

Clarifies our accessibility docs. This doc definitely needs a rewrite down the line, but this is a temporary stopgap to remove some misleading statements.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: none
