### PR TITLE
chore: cherry-pick fix from chromium issue 1113227

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -118,3 +118,4 @@ backport_1016278.patch
 backport_1042986.patch
 a11y_axplatformnodebase_getindexinparent_returns_base_optional.patch
 worker_feat_add_hook_to_notify_script_ready.patch
+reconnect_p2p_socket_dispatcher_if_network_service_dies.patch

--- a/patches/chromium/reconnect_p2p_socket_dispatcher_if_network_service_dies.patch
+++ b/patches/chromium/reconnect_p2p_socket_dispatcher_if_network_service_dies.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Taylor Brandstetter <deadbeef@chromium.org>
+Date: Wed, 12 Aug 2020 05:24:50 +0000
+Subject: Reconnect P2P socket dispatcher if network service dies.
+
+Bug: chromium:1113227
+Change-Id: Ifc8e856fde4cf4eee25149f0a1e86a3cad71ea83
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2344747
+Commit-Queue: Taylor <deadbeef@chromium.org>
+Reviewed-by: Guido Urdaneta <guidou@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#797125}
+
+diff --git a/third_party/blink/renderer/platform/p2p/socket_dispatcher.cc b/third_party/blink/renderer/platform/p2p/socket_dispatcher.cc
+index 6c3adda46f77bc15d7d1998871b0daeb34780a77..29884a255f24556f4dc8b41b22304938a4f0d775 100644
+--- a/third_party/blink/renderer/platform/p2p/socket_dispatcher.cc
++++ b/third_party/blink/renderer/platform/p2p/socket_dispatcher.cc
+@@ -110,6 +110,18 @@ void P2PSocketDispatcher::RequestNetworkEventsIfNecessary() {
+ void P2PSocketDispatcher::OnConnectionError() {
+   base::AutoLock lock(p2p_socket_manager_lock_);
+   p2p_socket_manager_.reset();
++  // Attempt to reconnect in case the network service crashed in his being
++  // restarted.
++  PostCrossThreadTask(
++      *main_task_runner_.get(), FROM_HERE,
++      CrossThreadBindOnce(&P2PSocketDispatcher::ReconnectP2PSocketManager,
++                          scoped_refptr<P2PSocketDispatcher>(this)));
++}
++
++void P2PSocketDispatcher::ReconnectP2PSocketManager() {
++  network_notification_client_receiver_.reset();
++  GetP2PSocketManager()->StartNetworkNotifications(
++      network_notification_client_receiver_.BindNewPipeAndPassRemote());
+ }
+ 
+ }  // namespace blink
+diff --git a/third_party/blink/renderer/platform/p2p/socket_dispatcher.h b/third_party/blink/renderer/platform/p2p/socket_dispatcher.h
+index de9b6690e0b27d3c4a263e8f908c0a95a675a089..c250d2af99d5291f34a7e3bfdb63fcbb70a5bd73 100644
+--- a/third_party/blink/renderer/platform/p2p/socket_dispatcher.h
++++ b/third_party/blink/renderer/platform/p2p/socket_dispatcher.h
+@@ -83,6 +83,7 @@ class PLATFORM_EXPORT P2PSocketDispatcher
+   void RequestNetworkEventsIfNecessary();
+ 
+   void OnConnectionError();
++  void ReconnectP2PSocketManager();
+ 
+   scoped_refptr<base::SingleThreadTaskRunner> main_task_runner_;
+ 


### PR DESCRIPTION
#### Description of Change
Currently, when the underlying network connection breaks from changing network IP address, the underlying chromium network connection does not update with the new IP address for RTC. This causes all RTC connections to fail after this scenario happens. The only way to work around this issue is to completely close the tab or restart the electron application. 

The Chromium team created a fix for this in the master branch and the git hash https://chromium.googlesource.com/chromium/src/+/72ac0aae53384a914ea11e4f71dfcb81cf53830b. This PR is to cherry pick this fix on top of the version of chromium used by Electron 9-x-y and then create a patch file.

The original conversation on the bug board can be followed at https://bugs.chromium.org/p/chromium/issues/detail?id=1113227.

Backport https://chromium.googlesource.com/chromium/src/+/72ac0aae53384a914ea11e4f71dfcb81cf53830b

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Resolve network issues that prevented RTC calls from being connected due to network IP address changes and ICE. (Chromium issue 1113227)
