### PR TITLE
fix: calculate frame when setting window placement

### DIFF
--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -278,8 +278,8 @@ class NativeWindowViews : public NativeWindow,
   // Set to true if the window is always on top and behind the task bar.
   bool behind_task_bar_ = false;
 
-  // Whether to block Chromium from handling window messages.
-  bool block_chromium_message_handler_ = false;
+  // Whether we want to set window placement without side effect.
+  bool is_setting_window_placement_ = false;
 #endif
 
   // Handles unhandled keyboard messages coming back from the renderer process.

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1005,6 +1005,26 @@ describe('BrowserWindow module', () => {
           await restore;
           expectBoundsEqual(w.getNormalBounds(), bounds);
         });
+        it('does not change size for a frameless window with min size', async () => {
+          w.destroy();
+          w = new BrowserWindow({
+            show: false,
+            frame: false,
+            width: 300,
+            height: 300,
+            minWidth: 300,
+            minHeight: 300
+          });
+          const bounds = w.getBounds();
+          w.once('minimize', () => {
+            w.restore();
+          });
+          const restore = emittedOnce(w, 'restore');
+          w.show();
+          w.minimize();
+          await restore;
+          expectBoundsEqual(w.getNormalBounds(), bounds);
+        });
       });
 
       ifdescribe(process.platform === 'win32')('Fullscreen state', () => {


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/22393.

When calling `SetWindowPlacement`, we should let Chromium handle the `WM_NCCALCSIZE` message otherwise the window size would be wrong for frameless window.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fix frameless window's size being changed when restored from minimized state.