### PR TITLE
docs: Fixed click handler function arguments of MenuItem

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -10,10 +10,10 @@ See [`Menu`](menu.md) for examples.
 
 * `options` Object
   * `click` Function (optional) - Will be called with
-    `click(menuItem, browserWindow, event)` when the menu item is clicked.
-    * `menuItem` MenuItem
-    * `browserWindow` [BrowserWindow](browser-window.md) | undefined - This will not be defined if no window is open.
+    `click(event, focusedWindow, focusedWebContents)` when the menu item is clicked.
     * `event` [KeyboardEvent](structures/keyboard-event.md)
+    * `focusedWindow` [BrowserWindow](browser-window.md)  | undefined - This will not be defined if no window is open.
+    * `focusedWebContents` [WebContents](web-contents.md)
   * `role` String (optional) - Can be `undo`, `redo`, `cut`, `copy`, `paste`, `pasteAndMatchStyle`, `delete`, `selectAll`, `reload`, `forceReload`, `toggleDevTools`, `resetZoom`, `zoomIn`, `zoomOut`, `togglefullscreen`, `window`, `minimize`, `close`, `help`, `about`, `services`, `hide`, `hideOthers`, `unhide`, `quit`, `startSpeaking`, `stopSpeaking`, `zoom`, `front`, `appMenu`, `fileMenu`, `editMenu`, `viewMenu`, `recentDocuments`, `toggleTabBar`, `selectNextTab`, `selectPreviousTab`, `mergeAllWindows`, `clearRecentDocuments`, `moveTabToNewWindow` or `windowMenu` - Define the action of the menu item, when specified the
     `click` property will be ignored. See [roles](#roles).
   * `type` String (optional) - Can be `normal`, `separator`, `submenu`, `checkbox` or


### PR DESCRIPTION
As can be seen on line no. 50 of [`menu-item.js`](https://github.com/electron/electron/blob/v9.2.0/lib/browser/api/menu-item.js), the arguments of click handler function were documented incorrectly. Fixed it.

#### Description of Change
Changed incorrect MenuItem's click handler arguments `click(menuItem, browserWindow, event)` to correct version `click(event, focusedWindow, focusedWebContents)`

#### Checklist


- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed click handler function schema of MenuItem 
