### PR TITLE
fix: add handle scope in SelectClientCertificate

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -755,7 +755,7 @@ base::OnceClosure App::SelectClientCertificate(
 
   auto shared_identities =
       std::make_shared<net::ClientCertIdentityList>(std::move(identities));
-
+  v8::HandleScope handle_scope(isolate());
   bool prevent_default =
       Emit("select-client-certificate",
            WebContents::FromOrCreate(isolate(), web_contents),


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/24868.

See that PR for details.

Notes: Fix crash when using client certificate.