### PR TITLE
chore: fix DCHECK on print job cancellation

### DIFF
--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -90,7 +90,7 @@ index 977ad787270844b218a87fbe04fea616619e84ba..592fe4459cdae22d23a933a31c452c44
  }
  
 diff --git a/chrome/browser/printing/print_view_manager_base.cc b/chrome/browser/printing/print_view_manager_base.cc
-index 2917e93c3f22b3bcbe683c2b944c7af25e66f950..2cdfd7cec04c979aa8ca77273f9816495cdf147a 100644
+index 2917e93c3f22b3bcbe683c2b944c7af25e66f950..33f48f473efd04e165ec7b9a8738b8d7c18a6adc 100644
 --- a/chrome/browser/printing/print_view_manager_base.cc
 +++ b/chrome/browser/printing/print_view_manager_base.cc
 @@ -27,10 +27,7 @@
@@ -249,6 +249,9 @@ index 2917e93c3f22b3bcbe683c2b944c7af25e66f950..2cdfd7cec04c979aa8ca77273f981649
    printing_rfh_ = nullptr;
  
 +  if (!callback_.is_null()) {
++    registrar_.Remove(this, chrome::NOTIFICATION_PRINT_JOB_EVENT,
++                  content::NotificationService::AllSources());
++
 +    std::string cb_str = "";
 +    if (!printing_succeeded_)
 +      cb_str = printing_cancelled_ ? "cancelled" : "failed";
@@ -263,9 +266,6 @@ index 2917e93c3f22b3bcbe683c2b944c7af25e66f950..2cdfd7cec04c979aa8ca77273f981649
  
 -  registrar_.Remove(this, chrome::NOTIFICATION_PRINT_JOB_EVENT,
 -                    content::Source<PrintJob>(print_job_.get()));
-+  if (!callback_.is_null())
-+    registrar_.Remove(this, chrome::NOTIFICATION_PRINT_JOB_EVENT,
-+                      content::NotificationService::AllSources());
    // Don't close the worker thread.
    print_job_ = nullptr;
  }


### PR DESCRIPTION
#### Description of Change

Fixes the following DCHECK:

```
[25652:0818/224532.220407:FATAL:notification_registrar.cc(52)] Check failed: !IsRegistered(observer, type, source). Duplicate registration.
```

encountered as a result of `callback_.is_null()` being checked after `std::move` was called and so the notification observer not properly being removed.

cc @deepak1556  @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: none
