### PR TITLE
fix: pdf viewer template strings

### DIFF
--- a/electron_paks.gni
+++ b/electron_paks.gni
@@ -54,6 +54,7 @@ template("electron_extra_paks") {
                            ])
     output = "${invoker.output_dir}/resources.pak"
     sources = [
+      "$root_gen_dir/chrome/print_preview_pdf_resources.pak",
       "$root_gen_dir/components/components_resources.pak",
       "$root_gen_dir/content/browser/resources/media/media_internals_resources.pak",
       "$root_gen_dir/content/browser/tracing/tracing_resources.pak",
@@ -68,6 +69,7 @@ template("electron_extra_paks") {
       "$target_gen_dir/electron_resources.pak",
     ]
     deps = [
+      "//chrome/browser/resources:print_preview_pdf_resources",
       "//components/resources",
       "//content:content_resources",
       "//content:dev_ui_content_resources",

--- a/shell/browser/extensions/electron_component_extension_resource_manager.cc
+++ b/shell/browser/extensions/electron_component_extension_resource_manager.cc
@@ -5,6 +5,7 @@
 #include "shell/browser/extensions/electron_component_extension_resource_manager.h"
 
 #include <string>
+#include <utility>
 
 #include "base/logging.h"
 #include "base/path_service.h"

--- a/shell/browser/extensions/electron_component_extension_resource_manager.cc
+++ b/shell/browser/extensions/electron_component_extension_resource_manager.cc
@@ -13,13 +13,31 @@
 #include "build/build_config.h"
 #include "chrome/common/chrome_paths.h"
 #include "chrome/grit/component_extension_resources_map.h"
+#include "electron/buildflags/buildflags.h"
 
+#if BUILDFLAG(ENABLE_PDF_VIEWER)
+#include "chrome/browser/pdf/pdf_extension_util.h"
+#include "extensions/common/constants.h"
+#endif
 namespace extensions {
 
 ElectronComponentExtensionResourceManager::
     ElectronComponentExtensionResourceManager() {
   AddComponentResourceEntries(kComponentExtensionResources,
                               kComponentExtensionResourcesSize);
+#if BUILDFLAG(ENABLE_PDF_VIEWER)
+  // Register strings for the PDF viewer, so that $i18n{} replacements work.
+  base::Value pdf_strings(base::Value::Type::DICTIONARY);
+  pdf_extension_util::AddStrings(
+      pdf_extension_util::PdfViewerContext::kPdfViewer, &pdf_strings);
+  pdf_extension_util::AddAdditionalData(&pdf_strings);
+
+  ui::TemplateReplacements pdf_viewer_replacements;
+  ui::TemplateReplacementsFromDictionaryValue(
+      base::Value::AsDictionaryValue(pdf_strings), &pdf_viewer_replacements);
+  extension_template_replacements_[extension_misc::kPdfExtensionId] =
+      std::move(pdf_viewer_replacements);
+#endif
 }
 
 ElectronComponentExtensionResourceManager::


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/24913.

See that PR for more details.

Notes: Fixed broken toolbar hover text in the PDF viewer.