### PR TITLE
fix: save normal window bounds when maximizing

### DIFF
--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -315,14 +315,8 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
   // Here we handle the WM_SIZE event in order to figure out what is the current
   // window state and notify the user accordingly.
   switch (w_param) {
-    case SIZE_MAXIMIZED: {
-      last_window_state_ = ui::SHOW_STATE_MAXIMIZED;
-      NotifyWindowMaximize();
-      break;
-    }
-    case SIZE_MINIMIZED:
-      last_window_state_ = ui::SHOW_STATE_MINIMIZED;
-
+    case SIZE_MAXIMIZED:
+    case SIZE_MINIMIZED: {
       WINDOWPLACEMENT wp;
       wp.length = sizeof(WINDOWPLACEMENT);
 
@@ -330,8 +324,15 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
         last_normal_placement_bounds_ = gfx::Rect(wp.rcNormalPosition);
       }
 
-      NotifyWindowMinimize();
+      if (w_param == SIZE_MAXIMIZED) {
+        last_window_state_ = ui::SHOW_STATE_MAXIMIZED;
+        NotifyWindowMaximize();
+      } else if (w_param == SIZE_MINIMIZED) {
+        last_window_state_ = ui::SHOW_STATE_MINIMIZED;
+        NotifyWindowMinimize();
+      }
       break;
+    }
     case SIZE_RESTORED:
       switch (last_window_state_) {
         case ui::SHOW_STATE_MAXIMIZED:

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -324,10 +324,14 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
         last_normal_placement_bounds_ = gfx::Rect(wp.rcNormalPosition);
       }
 
-      if (w_param == SIZE_MAXIMIZED) {
+      // Note that SIZE_MAXIMIZED and SIZE_MINIMIZED might be emitted for
+      // multiple times for one resize because of the SetWindowPlacement call.
+      if (w_param == SIZE_MAXIMIZED &&
+          last_window_state_ != ui::SHOW_STATE_MAXIMIZED) {
         last_window_state_ = ui::SHOW_STATE_MAXIMIZED;
         NotifyWindowMaximize();
-      } else if (w_param == SIZE_MINIMIZED) {
+      } else if (w_param == SIZE_MINIMIZED &&
+                 last_window_state_ != ui::SHOW_STATE_MINIMIZED) {
         last_window_state_ = ui::SHOW_STATE_MINIMIZED;
         NotifyWindowMinimize();
       }

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -983,6 +983,26 @@ describe('BrowserWindow module', () => {
           await unmaximize;
           expectBoundsEqual(w.getNormalBounds(), bounds);
         });
+        it('does not change size for a frameless window with min size', async () => {
+          w.destroy();
+          w = new BrowserWindow({
+            show: false,
+            frame: false,
+            width: 300,
+            height: 300,
+            minWidth: 300,
+            minHeight: 300
+          });
+          const bounds = w.getBounds();
+          w.once('maximize', () => {
+            w.unmaximize();
+          });
+          const unmaximize = emittedOnce(w, 'unmaximize');
+          w.show();
+          w.maximize();
+          await unmaximize;
+          expectBoundsEqual(w.getNormalBounds(), bounds);
+        });
       });
 
       ifdescribe(process.platform !== 'linux')('Minimized state', () => {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -2975,6 +2975,15 @@ describe('BrowserWindow module', () => {
       await maximize;
     });
 
+    it('emits only one event when frameless window is maximized', () => {
+      const w = new BrowserWindow({ show: false, frame: false });
+      let emitted = 0;
+      w.on('maximize', () => emitted++);
+      w.show();
+      w.maximize();
+      expect(emitted).to.equal(1);
+    });
+
     it('emits an event when window is unmaximized', async () => {
       const w = new BrowserWindow({ show: false });
       const unmaximize = emittedOnce(w, 'unmaximize');


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/22440.
Close https://github.com/electron/electron/issues/24780.

The normal bounds of window should be saved when maximizing, otherwise the window size would be slightly changed after unmaximizing. We are already doing the same thing when minimizing.

This PR also includes a fix to prevent maximize/minimize events to be emitted multiples due to our SetWindowPlacement hack.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fix window size being changed after unmaximizing.