### PR TITLE
fix: client area inset calculation when maximized for framless windows

### DIFF
--- a/shell/browser/ui/views/win_frame_view.cc
+++ b/shell/browser/ui/views/win_frame_view.cc
@@ -4,7 +4,12 @@
 
 #include "shell/browser/ui/views/win_frame_view.h"
 
+#include <algorithm>
+
+#include "base/win/windows_version.h"
 #include "shell/browser/native_window_views.h"
+#include "ui/base/win/hwnd_metrics.h"
+#include "ui/display/win/screen_win.h"
 #include "ui/views/widget/widget.h"
 #include "ui/views/win/hwnd_util.h"
 
@@ -16,11 +21,72 @@ WinFrameView::WinFrameView() {}
 
 WinFrameView::~WinFrameView() {}
 
+gfx::Insets WinFrameView::GetGlassInsets() const {
+  int frame_height =
+      display::win::ScreenWin::GetSystemMetricsInDIP(SM_CYSIZEFRAME) +
+      display::win::ScreenWin::GetSystemMetricsInDIP(SM_CXPADDEDBORDER);
+
+  int frame_size =
+      base::win::GetVersion() < base::win::Version::WIN10
+          ? display::win::ScreenWin::GetSystemMetricsInDIP(SM_CXSIZEFRAME)
+          : 0;
+
+  return gfx::Insets(frame_height, frame_size, frame_size, frame_size);
+}
+
+gfx::Insets WinFrameView::GetClientAreaInsets(HMONITOR monitor) const {
+  gfx::Insets insets;
+  if (base::win::GetVersion() < base::win::Version::WIN10) {
+    // This tells Windows that most of the window is a client area, meaning
+    // Chrome will draw it. Windows still fills in the glass bits because of the
+    // DwmExtendFrameIntoClientArea call in |UpdateDWMFrame|.
+    // Without this 1 pixel offset on the right and bottom:
+    //   * windows paint in a more standard way, and
+    //   * we get weird black bars at the top when maximized in multiple monitor
+    //     configurations.
+    int border_thickness = 1;
+    insets.Set(0, 0, border_thickness, border_thickness);
+  } else {
+    const int frame_thickness = ui::GetFrameThickness(monitor);
+    insets.Set(0, frame_thickness, frame_thickness, frame_thickness);
+  }
+  return insets;
+}
+
 gfx::Rect WinFrameView::GetWindowBoundsForClientBounds(
     const gfx::Rect& client_bounds) const {
-  return views::GetWindowBoundsForClientBounds(
-      static_cast<views::View*>(const_cast<WinFrameView*>(this)),
-      client_bounds);
+  if (window_->IsMaximized() && !window_->has_frame()) {
+    gfx::Insets insets = GetGlassInsets();
+    insets += GetClientAreaInsets(
+        MonitorFromWindow(HWNDForView(this), MONITOR_DEFAULTTONEAREST));
+    return gfx::Rect(client_bounds.x() - insets.left(),
+                     client_bounds.y() - insets.top(),
+                     client_bounds.width() + insets.left() + insets.right(),
+                     client_bounds.height() + insets.top() + insets.bottom());
+  } else {
+    return views::GetWindowBoundsForClientBounds(
+        static_cast<views::View*>(const_cast<WinFrameView*>(this)),
+        client_bounds);
+  }
+}
+
+gfx::Rect WinFrameView::GetBoundsForClientView() const {
+  if (window_->IsMaximized() && !window_->has_frame()) {
+    gfx::Insets insets = GetGlassInsets();
+    return gfx::Rect(insets.left(), insets.top(),
+                     std::max(0, width() - insets.left() - insets.right()),
+                     std::max(0, height() - insets.top() - insets.bottom()));
+  } else {
+    return bounds();
+  }
+}
+
+gfx::Size WinFrameView::CalculatePreferredSize() const {
+  gfx::Size pref = frame_->client_view()->GetPreferredSize();
+  gfx::Rect bounds(0, 0, pref.width(), pref.height());
+  return frame_->non_client_view()
+      ->GetWindowBoundsForClientBounds(bounds)
+      .size();
 }
 
 int WinFrameView::NonClientHitTest(const gfx::Point& point) {

--- a/shell/browser/ui/views/win_frame_view.cc
+++ b/shell/browser/ui/views/win_frame_view.cc
@@ -59,10 +59,9 @@ gfx::Rect WinFrameView::GetWindowBoundsForClientBounds(
     gfx::Insets insets = GetGlassInsets();
     insets += GetClientAreaInsets(
         MonitorFromWindow(HWNDForView(this), MONITOR_DEFAULTTONEAREST));
-    return gfx::Rect(client_bounds.x() - insets.left(),
-                     client_bounds.y() - insets.top(),
-                     client_bounds.width() + insets.left() + insets.right(),
-                     client_bounds.height() + insets.top() + insets.bottom());
+    gfx::Rect result(client_bounds);
+    result.Inset(-insets);
+    return result;
   } else {
     return views::GetWindowBoundsForClientBounds(
         static_cast<views::View*>(const_cast<WinFrameView*>(this)),
@@ -73,9 +72,9 @@ gfx::Rect WinFrameView::GetWindowBoundsForClientBounds(
 gfx::Rect WinFrameView::GetBoundsForClientView() const {
   if (window_->IsMaximized() && !window_->has_frame()) {
     gfx::Insets insets = GetGlassInsets();
-    return gfx::Rect(insets.left(), insets.top(),
-                     std::max(0, width() - insets.left() - insets.right()),
-                     std::max(0, height() - insets.top() - insets.bottom()));
+    gfx::Rect result(width(), height());
+    result.Inset(insets);
+    return result;
   } else {
     return bounds();
   }
@@ -83,7 +82,7 @@ gfx::Rect WinFrameView::GetBoundsForClientView() const {
 
 gfx::Size WinFrameView::CalculatePreferredSize() const {
   gfx::Size pref = frame_->client_view()->GetPreferredSize();
-  gfx::Rect bounds(0, 0, pref.width(), pref.height());
+  gfx::Rect bounds(pref);
   return frame_->non_client_view()
       ->GetWindowBoundsForClientBounds(bounds)
       .size();

--- a/shell/browser/ui/views/win_frame_view.cc
+++ b/shell/browser/ui/views/win_frame_view.cc
@@ -20,7 +20,7 @@ gfx::Insets GetGlassInsets() {
       display::win::ScreenWin::GetSystemMetricsInDIP(SM_CXPADDEDBORDER);
 
   int frame_size =
-      base::win::GetVersion() < base::win::Version::WIN10
+      base::win::GetVersion() < base::win::Version::WIN8
           ? display::win::ScreenWin::GetSystemMetricsInDIP(SM_CXSIZEFRAME)
           : 0;
 

--- a/shell/browser/ui/views/win_frame_view.h
+++ b/shell/browser/ui/views/win_frame_view.h
@@ -15,10 +15,15 @@ class WinFrameView : public FramelessView {
   WinFrameView();
   ~WinFrameView() override;
 
+  gfx::Insets GetGlassInsets() const;
+  gfx::Insets GetClientAreaInsets(HMONITOR monitor) const;
+
   // views::NonClientFrameView:
+  gfx::Rect GetBoundsForClientView() const override;
   gfx::Rect GetWindowBoundsForClientBounds(
       const gfx::Rect& client_bounds) const override;
   int NonClientHitTest(const gfx::Point& point) override;
+  gfx::Size CalculatePreferredSize() const override;
 
   // views::View:
   const char* GetClassName() const override;

--- a/shell/browser/ui/views/win_frame_view.h
+++ b/shell/browser/ui/views/win_frame_view.h
@@ -15,26 +15,16 @@ class WinFrameView : public FramelessView {
   WinFrameView();
   ~WinFrameView() override;
 
-  // Get frame metrics in pixels.
-  gfx::Insets GetGlassInsetsInPixels() const;
-
-  // Get frame metrics in DIP.
-  gfx::Insets GetGlassInsets() const;
-  gfx::Insets GetClientAreaInsets() const;
-
   // views::NonClientFrameView:
   gfx::Rect GetBoundsForClientView() const override;
   gfx::Rect GetWindowBoundsForClientBounds(
       const gfx::Rect& client_bounds) const override;
   int NonClientHitTest(const gfx::Point& point) override;
-  gfx::Size CalculatePreferredSize() const override;
 
   // views::View:
   const char* GetClassName() const override;
 
  private:
-  HMONITOR GetMonitor() const;
-
   DISALLOW_COPY_AND_ASSIGN(WinFrameView);
 };
 

--- a/shell/browser/ui/views/win_frame_view.h
+++ b/shell/browser/ui/views/win_frame_view.h
@@ -15,8 +15,12 @@ class WinFrameView : public FramelessView {
   WinFrameView();
   ~WinFrameView() override;
 
+  // Get frame metrics in pixels.
+  gfx::Insets GetGlassInsetsInPixels() const;
+
+  // Get frame metrics in DIP.
   gfx::Insets GetGlassInsets() const;
-  gfx::Insets GetClientAreaInsets(HMONITOR monitor) const;
+  gfx::Insets GetClientAreaInsets() const;
 
   // views::NonClientFrameView:
   gfx::Rect GetBoundsForClientView() const override;
@@ -29,6 +33,8 @@ class WinFrameView : public FramelessView {
   const char* GetClassName() const override;
 
  private:
+  HMONITOR GetMonitor() const;
+
   DISALLOW_COPY_AND_ASSIGN(WinFrameView);
 };
 

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -53,7 +53,7 @@ bool ElectronDesktopWindowTreeHostWin::GetDwmFrameInsetsInPixels(
                            monitor, SM_CYSIZEFRAME) +
                        display::win::ScreenWin::GetSystemMetricsForMonitor(
                            monitor, SM_CXPADDEDBORDER);
-    int frame_size = base::win::GetVersion() < base::win::Version::WIN10
+    int frame_size = base::win::GetVersion() < base::win::Version::WIN8
                          ? display::win::ScreenWin::GetSystemMetricsForMonitor(
                                monitor, SM_CXSIZEFRAME)
                          : 0;
@@ -67,7 +67,7 @@ bool ElectronDesktopWindowTreeHostWin::GetClientAreaInsets(
     gfx::Insets* insets,
     HMONITOR monitor) const {
   if (IsMaximized() && !native_window_view_->has_frame()) {
-    if (base::win::GetVersion() < base::win::Version::WIN10) {
+    if (base::win::GetVersion() < base::win::Version::WIN8) {
       // This tells Windows that most of the window is a client area, meaning
       // Chrome will draw it. Windows still fills in the glass bits because of
       // the // DwmExtendFrameIntoClientArea call in |UpdateDWMFrame|.

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/ui/win/electron_desktop_window_tree_host_win.h"
 
+#include "base/win/windows_version.h"
 #include "shell/browser/ui/views/win_frame_view.h"
 #include "ui/base/win/hwnd_metrics.h"
 #include "ui/base/win/shell.h"
@@ -46,9 +47,17 @@ bool ElectronDesktopWindowTreeHostWin::HasNativeFrame() const {
 bool ElectronDesktopWindowTreeHostWin::GetDwmFrameInsetsInPixels(
     gfx::Insets* insets) const {
   if (IsMaximized() && !native_window_view_->has_frame()) {
-    WinFrameView* frame = static_cast<WinFrameView*>(
-        native_window_view_->widget()->non_client_view()->frame_view());
-    *insets = frame->GetGlassInsetsInPixels();
+    HMONITOR monitor = ::MonitorFromWindow(
+        native_window_view_->GetAcceleratedWidget(), MONITOR_DEFAULTTONEAREST);
+    int frame_height = display::win::ScreenWin::GetSystemMetricsForMonitor(
+                           monitor, SM_CYSIZEFRAME) +
+                       display::win::ScreenWin::GetSystemMetricsForMonitor(
+                           monitor, SM_CXPADDEDBORDER);
+    int frame_size = base::win::GetVersion() < base::win::Version::WIN10
+                         ? display::win::ScreenWin::GetSystemMetricsForMonitor(
+                               monitor, SM_CXSIZEFRAME)
+                         : 0;
+    insets->Set(frame_height, frame_size, frame_size, frame_size);
     return true;
   }
   return false;
@@ -58,9 +67,23 @@ bool ElectronDesktopWindowTreeHostWin::GetClientAreaInsets(
     gfx::Insets* insets,
     HMONITOR monitor) const {
   if (IsMaximized() && !native_window_view_->has_frame()) {
-    WinFrameView* frame = static_cast<WinFrameView*>(
-        native_window_view_->widget()->non_client_view()->frame_view());
-    *insets = frame->GetClientAreaInsets();
+    if (base::win::GetVersion() < base::win::Version::WIN10) {
+      // This tells Windows that most of the window is a client area, meaning
+      // Chrome will draw it. Windows still fills in the glass bits because of
+      // the // DwmExtendFrameIntoClientArea call in |UpdateDWMFrame|.
+      // Without this 1 pixel offset on the right and bottom:
+      //   * windows paint in a more standard way, and
+      //   * we get weird black bars at the top when maximized in multiple
+      //     monitor configurations.
+      int border_thickness = 1;
+      insets->Set(0, 0, border_thickness, border_thickness);
+    } else {
+      const int frame_thickness = ui::GetFrameThickness(monitor);
+      // Reduce the Windows non-client border size because we extend the border
+      // into our client area in UpdateDWMFrame(). The top inset must be 0 or
+      // else Windows will draw a full native titlebar outside the client area.
+      insets->Set(0, frame_thickness, frame_thickness, frame_thickness);
+    }
     return true;
   }
   return false;

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -7,7 +7,8 @@
 #include "shell/browser/ui/views/win_frame_view.h"
 #include "ui/base/win/hwnd_metrics.h"
 #include "ui/base/win/shell.h"
-#include "ui/display/win/dpi.h"
+#include "ui/display/win/screen_win.h"
+#include "ui/views/win/hwnd_util.h"
 
 namespace electron {
 
@@ -50,7 +51,8 @@ bool ElectronDesktopWindowTreeHostWin::GetDwmFrameInsetsInPixels(
     *insets = frame->GetGlassInsets();
     // The DWM API's expect values in pixels. We need to convert from DIP to
     // pixels here.
-    *insets = insets->Scale(display::win::GetDPIScale());
+    *insets = insets->Scale(
+        display::win::ScreenWin::GetScaleFactorForHWND(HWNDForView(frame)));
     return true;
   }
   return false;

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -48,11 +48,7 @@ bool ElectronDesktopWindowTreeHostWin::GetDwmFrameInsetsInPixels(
   if (IsMaximized() && !native_window_view_->has_frame()) {
     WinFrameView* frame = static_cast<WinFrameView*>(
         native_window_view_->widget()->non_client_view()->frame_view());
-    *insets = frame->GetGlassInsets();
-    // The DWM API's expect values in pixels. We need to convert from DIP to
-    // pixels here.
-    *insets = insets->Scale(
-        display::win::ScreenWin::GetScaleFactorForHWND(HWNDForView(frame)));
+    *insets = frame->GetGlassInsetsInPixels();
     return true;
   }
   return false;
@@ -64,7 +60,7 @@ bool ElectronDesktopWindowTreeHostWin::GetClientAreaInsets(
   if (IsMaximized() && !native_window_view_->has_frame()) {
     WinFrameView* frame = static_cast<WinFrameView*>(
         native_window_view_->widget()->non_client_view()->frame_view());
-    *insets = frame->GetClientAreaInsets(monitor);
+    *insets = frame->GetClientAreaInsets();
     return true;
   }
   return false;

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
@@ -27,6 +27,7 @@ class ElectronDesktopWindowTreeHostWin
                     LRESULT* result) override;
   bool ShouldPaintAsActive() const override;
   bool HasNativeFrame() const override;
+  bool GetDwmFrameInsetsInPixels(gfx::Insets* insets) const override;
   bool GetClientAreaInsets(gfx::Insets* insets,
                            HMONITOR monitor) const override;
 


### PR DESCRIPTION
#### Description of Change

Fixes the following regressions introduced by https://github.com/electron/electron/pull/21164

Refs

https://github.com/microsoft/vscode/issues/86260
https://github.com/microsoft/vscode/issues/85310
https://github.com/microsoft/vscode/issues/85592
https://github.com/microsoft/vscode/issues/85655

Also fixes a side effect of this bug that caused increased usage of GPU under certain conditions which was identified by teams app.

Gist: https://gist.github.com/deepak1556/6e672eea191d3e5f50e429d312a56446

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes:  Fixes the following issues for frameless when maximized on Windows
* fix unreachable task bar when auto hidden with position top
* fix 1px extending to secondary monitor
* fix 1px overflowing into taskbar at certain resolutions
* fix white line on top of window under 4k resolutions