### PR TITLE
fix: revert 6ecf729 to fix Linux titlebar dark mode (master)

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -207,7 +207,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `opacity` Number (optional) - Set the initial opacity of the window, between 0.0 (fully
     transparent) and 1.0 (fully opaque). This is only implemented on Windows and macOS.
   * `darkTheme` Boolean (optional) - Forces using dark theme for the window, only works on
-    some GTK desktop environments. Default is [`nativeTheme.shouldUseDarkColors`](native-theme.md).
+    some GTK+3 desktop environments. Default is `false`.
   * `transparent` Boolean (optional) - Makes the window [transparent](frameless-window.md#transparent-window).
     Default is `false`. On Windows, does not work unless the window is frameless.
   * `type` String (optional) - The type of window, default is normal window. See more about

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -914,6 +914,10 @@ void BaseWindow::CloseFilePreview() {
   window_->CloseFilePreview();
 }
 
+void BaseWindow::SetGTKDarkThemeEnabled(bool use_dark_theme) {
+  window_->SetGTKDarkThemeEnabled(use_dark_theme);
+}
+
 v8::Local<v8::Value> BaseWindow::GetContentView() const {
   if (content_view_.IsEmpty())
     return v8::Null(isolate());

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -206,6 +206,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void SetAspectRatio(double aspect_ratio, gin_helper::Arguments* args);
   void PreviewFile(const std::string& path, gin_helper::Arguments* args);
   void CloseFilePreview();
+  void SetGTKDarkThemeEnabled(bool use_dark_theme);
 
   // Public getters of NativeWindow.
   v8::Local<v8::Value> GetContentView() const;

--- a/shell/browser/api/electron_api_native_theme.cc
+++ b/shell/browser/api/electron_api_native_theme.cc
@@ -10,8 +10,6 @@
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "gin/handle.h"
-#include "shell/browser/native_window_views.h"
-#include "shell/browser/window_list.h"
 #include "shell/common/gin_converters/std_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/object_template_builder.h"
@@ -53,13 +51,8 @@ void NativeTheme::SetThemeSource(ui::NativeTheme::ThemeSource override) {
   // Update the macOS appearance setting for this new override value
   UpdateMacOSAppearanceForOverrideValue(override);
 #endif
-#if defined(USE_X11)
-  const bool dark_enabled = ShouldUseDarkColors();
-  for (auto* window : WindowList::GetWindows()) {
-    static_cast<NativeWindowViews*>(window)->SetGTKDarkThemeEnabled(
-        dark_enabled);
-  }
-#endif
+  // TODO(MarshallOfSound): Update all existing browsers windows to use GTK dark
+  // theme
 }
 
 ui::NativeTheme::ThemeSource NativeTheme::GetThemeSource() const {

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -234,6 +234,8 @@ class NativeWindow : public base::SupportsUserData,
                            const std::string& display_name);
   virtual void CloseFilePreview();
 
+  virtual void SetGTKDarkThemeEnabled(bool use_dark_theme) = 0;
+
   // Converts between content bounds and window bounds.
   virtual gfx::Rect ContentBoundsToWindowBounds(
       const gfx::Rect& bounds) const = 0;

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -138,6 +138,7 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
       std::vector<gin_helper::PersistentDictionary> items) override;
   void RefreshTouchBarItem(const std::string& item_id) override;
   void SetEscapeTouchBarItem(gin_helper::PersistentDictionary item) override;
+  void SetGTKDarkThemeEnabled(bool use_dark_theme) override {}
 
   gfx::Rect ContentBoundsToWindowBounds(const gfx::Rect& bounds) const override;
   gfx::Rect WindowBoundsToContentBounds(const gfx::Rect& bounds) const override;

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -34,7 +34,6 @@
 #include "ui/base/hit_test.h"
 #include "ui/gfx/image/image.h"
 #include "ui/gfx/native_widget_types.h"
-#include "ui/native_theme/native_theme.h"
 #include "ui/views/background.h"
 #include "ui/views/controls/webview/unhandled_keyboard_event_handler.h"
 #include "ui/views/controls/webview/webview.h"
@@ -215,10 +214,10 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
   window_state_watcher_ = std::make_unique<WindowStateWatcher>(this);
 
   // Set _GTK_THEME_VARIANT to dark if we have "dark-theme" option set.
-  bool use_dark_theme =
-      ui::NativeTheme::GetInstanceForNativeUi()->ShouldUseDarkColors();
-  options.Get(options::kDarkTheme, &use_dark_theme);
-  SetGTKDarkThemeEnabled(use_dark_theme);
+  bool use_dark_theme = false;
+  if (options.Get(options::kDarkTheme, &use_dark_theme) && use_dark_theme) {
+    SetGTKDarkThemeEnabled(use_dark_theme);
+  }
 
   // Before the window is mapped the SetWMSpecState can not work, so we have
   // to manually set the _NET_WM_STATE.
@@ -326,6 +325,20 @@ NativeWindowViews::~NativeWindowViews() {
   aura::Window* window = GetNativeWindow();
   if (window)
     window->RemovePreTargetHandler(this);
+#endif
+}
+
+void NativeWindowViews::SetGTKDarkThemeEnabled(bool use_dark_theme) {
+#if defined(USE_X11)
+  if (use_dark_theme) {
+    ui::SetStringProperty(static_cast<x11::Window>(GetAcceleratedWidget()),
+                          gfx::GetAtom("_GTK_THEME_VARIANT"),
+                          gfx::GetAtom("UTF8_STRING"), "dark");
+  } else {
+    ui::SetStringProperty(static_cast<x11::Window>(GetAcceleratedWidget()),
+                          gfx::GetAtom("_GTK_THEME_VARIANT"),
+                          gfx::GetAtom("UTF8_STRING"), "light");
+  }
 #endif
 }
 
@@ -1288,20 +1301,6 @@ void NativeWindowViews::SetIcon(const gfx::ImageSkia& icon) {
   auto* tree_host = views::DesktopWindowTreeHostLinux::GetHostForWidget(
       GetAcceleratedWidget());
   tree_host->SetWindowIcons(icon, {});
-}
-#endif
-
-#if defined(USE_X11)
-void NativeWindowViews::SetGTKDarkThemeEnabled(bool use_dark_theme) {
-  if (use_dark_theme) {
-    ui::SetStringProperty(static_cast<x11::Window>(GetAcceleratedWidget()),
-                          gfx::GetAtom("_GTK_THEME_VARIANT"),
-                          gfx::GetAtom("UTF8_STRING"), "dark");
-  } else {
-    ui::SetStringProperty(static_cast<x11::Window>(GetAcceleratedWidget()),
-                          gfx::GetAtom("_GTK_THEME_VARIANT"),
-                          gfx::GetAtom("UTF8_STRING"), "light");
-  }
 }
 #endif
 

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -128,6 +128,8 @@ class NativeWindowViews : public NativeWindow,
 
   bool IsVisibleOnAllWorkspaces() override;
 
+  void SetGTKDarkThemeEnabled(bool use_dark_theme) override;
+
   content::DesktopMediaID GetDesktopMediaID() const override;
   gfx::AcceleratedWidget GetAcceleratedWidget() const override;
   NativeWindowHandle GetNativeWindowHandle() const override;
@@ -154,10 +156,6 @@ class NativeWindowViews : public NativeWindow,
   void SetIcon(HICON small_icon, HICON app_icon);
 #elif defined(USE_X11)
   void SetIcon(const gfx::ImageSkia& icon);
-#endif
-
-#if defined(USE_X11)
-  void SetGTKDarkThemeEnabled(bool use_dark_theme);
 #endif
 
   SkRegion* draggable_region() const { return draggable_region_.get(); }


### PR DESCRIPTION
#### Description of Change

Fixes #24741.

This was discussed earlier this evening in the @electron/wg-releases meeting. As Sam suggested, reverting 6ecf729 from #20138 fixes the issue.

Manually reverted due to code shear.

CC @MarshallOfSound @jkleinsc 

NB: A little nuance is necessary on the checklist item "THIS IS NOT A BREAKING CHANGE": this PR returns the default value of `darkTheme` on Linux to the same value in stable releases e.g. 9-x-y, but differs from the default value in the 10.0.0 betas. This PR has a sibling to revert in 10-x-y before the 10.0.0 release.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed a 10.0.0-beta.1 issue that broke dark mode window titlebars on Linux.