### PR TITLE
fix: calculate frame when setting window placement

### DIFF
--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -273,8 +273,8 @@ class NativeWindowViews : public NativeWindow,
   // Set to true if the window is always on top and behind the task bar.
   bool behind_task_bar_ = false;
 
-  // Whether to block Chromium from handling window messages.
-  bool block_chromium_message_handler_ = false;
+  // Whether we want to set window placement without side effect.
+  bool is_setting_window_placement_ = false;
 #endif
 
   // Handles unhandled keyboard messages coming back from the renderer process.

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -971,6 +971,26 @@ describe('BrowserWindow module', () => {
           w.show()
           w.minimize()
         })
+        it('does not change size for a frameless window with min size', async () => {
+          w.destroy()
+          w = new BrowserWindow({
+            show: false,
+            frame: false,
+            width: 300,
+            height: 300,
+            minWidth: 300,
+            minHeight: 300
+          })
+          const bounds = w.getBounds()
+          w.once('minimize', () => {
+            w.restore()
+          })
+          const restore = emittedOnce(w, 'restore')
+          w.show()
+          w.minimize()
+          await restore
+          expectBoundsEqual(w.getNormalBounds(), bounds)
+        })
       })
       ifdescribe(process.platform === 'win32')(`Fullscreen state`, () => {
         it(`checks normal bounds when fullscreen'ed`, (done) => {


### PR DESCRIPTION
Backport of #25014

See that PR for details.

Notes: Fix frameless window's size being changed when restored from minimized state.