### PR TITLE
feat: allow monospaced font styles to be specified for macOS tray titles

### DIFF
--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -221,7 +221,7 @@ Sets the hover text for this tray icon.
 
 * `title` String
 * `options` Object (optional)
-  * `fontType` String (optional) - The font family variant to display, one of `monospaced` (available in macOS 10.15+) or `monospacedDigit` (available in macOS 10.11+). When left blank, the title uses the default system font.
+  * `fontType` String (optional) - The font family variant to display, can be `monospaced` or `monospacedDigit`. `monospaced` is available in macOS 10.15+ and `monospacedDigit` is available in macOS 10.11+.  When left blank, the title uses the default system font.
 
 Sets the title displayed next to the tray icon in the status bar (Support ANSI colors).
 

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -217,10 +217,11 @@ Sets the `image` associated with this tray icon when pressed on macOS.
 
 Sets the hover text for this tray icon.
 
-#### `tray.setTitle(title, [fontType])` _macOS_
+#### `tray.setTitle(title[, options])` _macOS_
 
 * `title` String
-* `fontType` String (optional) - The font family variant to display, one of `monospaced` (available in macOS 10.15+) or `monospacedDigit` (available in macOS 10.11+). When left blank, the title uses the default system font.
+* `options` Object (optional)
+  * `fontType` String (optional) - The font family variant to display, one of `monospaced` (available in macOS 10.15+) or `monospacedDigit` (available in macOS 10.11+). When left blank, the title uses the default system font.
 
 Sets the title displayed next to the tray icon in the status bar (Support ANSI colors).
 

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -217,9 +217,10 @@ Sets the `image` associated with this tray icon when pressed on macOS.
 
 Sets the hover text for this tray icon.
 
-#### `tray.setTitle(title)` _macOS_
+#### `tray.setTitle(title, [fontType])` _macOS_
 
 * `title` String
+* `fontType` String (optional) - The font family variant to display, one of `monospaced` (available in macOS 10.15+) or `monospacedDigit` (available in macOS 10.11+). When left blank, the title uses the default system font.
 
 Sets the title displayed next to the tray icon in the status bar (Support ANSI colors).
 

--- a/shell/browser/api/electron_api_tray.cc
+++ b/shell/browser/api/electron_api_tray.cc
@@ -212,8 +212,7 @@ void Tray::SetToolTip(const std::string& tool_tip) {
   tray_icon_->SetToolTip(tool_tip);
 }
 
-void Tray::SetTitle(gin_helper::ErrorThrower thrower,
-                    const std::string& title,
+void Tray::SetTitle(const std::string& title,
                     const base::Optional<gin_helper::Dictionary>& options,
                     gin::Arguments* args) {
   if (!CheckAlive())
@@ -225,17 +224,17 @@ void Tray::SetTitle(gin_helper::ErrorThrower thrower,
       // Validate the font type if it's passed in
       if (title_options.font_type != "monospaced" &&
           title_options.font_type != "monospacedDigit") {
-        thrower.ThrowError(
+        args->ThrowTypeError(
             "fontType must be one of 'monospaced' or 'monospacedDigit'");
         return;
       }
     } else if (options->Has("fontType")) {
-      thrower.ThrowError(
+      args->ThrowTypeError(
           "fontType must be one of 'monospaced' or 'monospacedDigit'");
       return;
     }
   } else if (args->Length() >= 2) {
-    thrower.ThrowError("setTitle options must be an object");
+    args->ThrowTypeError("setTitle options must be an object");
     return;
   }
 

--- a/shell/browser/api/electron_api_tray.cc
+++ b/shell/browser/api/electron_api_tray.cc
@@ -227,13 +227,16 @@ void Tray::SetTitle(gin_helper::ErrorThrower thrower,
           title_options.font_type != "monospacedDigit") {
         thrower.ThrowError(
             "fontType must be one of 'monospaced' or 'monospacedDigit'");
+        return;
       }
     } else if (options->Has("fontType")) {
       thrower.ThrowError(
           "fontType must be one of 'monospaced' or 'monospacedDigit'");
+      return;
     }
   } else if (args->Length() >= 2) {
     thrower.ThrowError("setTitle options must be an object");
+    return;
   }
 
   tray_icon_->SetTitle(title, title_options);

--- a/shell/browser/api/electron_api_tray.cc
+++ b/shell/browser/api/electron_api_tray.cc
@@ -212,11 +212,19 @@ void Tray::SetToolTip(const std::string& tool_tip) {
   tray_icon_->SetToolTip(tool_tip);
 }
 
-void Tray::SetTitle(const std::string& title) {
+void Tray::SetTitle(const std::string& title, gin::Arguments* args) {
   if (!CheckAlive())
     return;
 #if defined(OS_MAC)
-  tray_icon_->SetTitle(title);
+  std::string font_type;
+  v8::Local<v8::Value> font_arg;
+  if (args->GetNext(&font_arg)) {
+    if (!gin::ConvertFromV8(args->isolate(), font_arg, &font_type)) {
+      args->ThrowError();
+      return;
+    }
+  }
+  tray_icon_->SetTitle(title, font_type);
 #endif
 }
 

--- a/shell/browser/api/electron_api_tray.h
+++ b/shell/browser/api/electron_api_tray.h
@@ -86,8 +86,7 @@ class Tray : public gin::Wrappable<Tray>,
   void SetImage(gin::Handle<NativeImage> image);
   void SetPressedImage(gin::Handle<NativeImage> image);
   void SetToolTip(const std::string& tool_tip);
-  void SetTitle(gin_helper::ErrorThrower thrower,
-                const std::string& title,
+  void SetTitle(const std::string& title,
                 const base::Optional<gin_helper::Dictionary>& options,
                 gin::Arguments* args);
   std::string GetTitle();

--- a/shell/browser/api/electron_api_tray.h
+++ b/shell/browser/api/electron_api_tray.h
@@ -86,7 +86,7 @@ class Tray : public gin::Wrappable<Tray>,
   void SetImage(gin::Handle<NativeImage> image);
   void SetPressedImage(gin::Handle<NativeImage> image);
   void SetToolTip(const std::string& tool_tip);
-  void SetTitle(const std::string& title);
+  void SetTitle(const std::string& title, gin::Arguments* args);
   std::string GetTitle();
   void SetIgnoreDoubleClickEvents(bool ignore);
   bool GetIgnoreDoubleClickEvents();

--- a/shell/browser/api/electron_api_tray.h
+++ b/shell/browser/api/electron_api_tray.h
@@ -86,7 +86,10 @@ class Tray : public gin::Wrappable<Tray>,
   void SetImage(gin::Handle<NativeImage> image);
   void SetPressedImage(gin::Handle<NativeImage> image);
   void SetToolTip(const std::string& tool_tip);
-  void SetTitle(const std::string& title, gin::Arguments* args);
+  void SetTitle(gin_helper::ErrorThrower thrower,
+                const std::string& title,
+                const base::Optional<gin_helper::Dictionary>& options,
+                gin::Arguments* args);
   std::string GetTitle();
   void SetIgnoreDoubleClickEvents(bool ignore);
   bool GetIgnoreDoubleClickEvents();

--- a/shell/browser/ui/tray_icon.h
+++ b/shell/browser/ui/tray_icon.h
@@ -45,9 +45,13 @@ class TrayIcon {
   virtual void SetIgnoreDoubleClickEvents(bool ignore) = 0;
   virtual bool GetIgnoreDoubleClickEvents() = 0;
 
+  struct TitleOptions {
+    std::string font_type;
+  };
+
   // Set/Get title displayed next to status icon in the status bar.
   virtual void SetTitle(const std::string& title,
-                        const std::string& font_type) = 0;
+                        const TitleOptions& options) = 0;
   virtual std::string GetTitle() = 0;
 #endif
 

--- a/shell/browser/ui/tray_icon.h
+++ b/shell/browser/ui/tray_icon.h
@@ -46,7 +46,8 @@ class TrayIcon {
   virtual bool GetIgnoreDoubleClickEvents() = 0;
 
   // Set/Get title displayed next to status icon in the status bar.
-  virtual void SetTitle(const std::string& title) = 0;
+  virtual void SetTitle(const std::string& title,
+                        const std::string& font_type) = 0;
   virtual std::string GetTitle() = 0;
 #endif
 

--- a/shell/browser/ui/tray_icon_cocoa.h
+++ b/shell/browser/ui/tray_icon_cocoa.h
@@ -25,7 +25,8 @@ class TrayIconCocoa : public TrayIcon {
   void SetImage(const gfx::Image& image) override;
   void SetPressedImage(const gfx::Image& image) override;
   void SetToolTip(const std::string& tool_tip) override;
-  void SetTitle(const std::string& title) override;
+  void SetTitle(const std::string& title,
+                const std::string& font_type) override;
   std::string GetTitle() override;
   void SetIgnoreDoubleClickEvents(bool ignore) override;
   bool GetIgnoreDoubleClickEvents() override;

--- a/shell/browser/ui/tray_icon_cocoa.h
+++ b/shell/browser/ui/tray_icon_cocoa.h
@@ -25,8 +25,7 @@ class TrayIconCocoa : public TrayIcon {
   void SetImage(const gfx::Image& image) override;
   void SetPressedImage(const gfx::Image& image) override;
   void SetToolTip(const std::string& tool_tip) override;
-  void SetTitle(const std::string& title,
-                const std::string& font_type) override;
+  void SetTitle(const std::string& title, const TitleOptions& options) override;
   std::string GetTitle() override;
   void SetIgnoreDoubleClickEvents(bool ignore) override;
   bool GetIgnoreDoubleClickEvents() override;

--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -336,9 +336,9 @@ void TrayIconCocoa::SetToolTip(const std::string& tool_tip) {
 }
 
 void TrayIconCocoa::SetTitle(const std::string& title,
-                             const std::string& font_type) {
+                             const TitleOptions& options) {
   [status_item_view_ setTitle:base::SysUTF8ToNSString(title)
-                    font_type:base::SysUTF8ToNSString(font_type)];
+                    font_type:base::SysUTF8ToNSString(options.font_type)];
 }
 
 std::string TrayIconCocoa::GetTitle() {

--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -103,13 +103,42 @@
   return ignoreDoubleClickEvents_;
 }
 
-- (void)setTitle:(NSString*)title {
+- (void)setTitle:(NSString*)title font_type:(NSString*)font_type {
+  NSMutableAttributedString* attributed_title =
+      [[NSMutableAttributedString alloc] initWithString:title];
+
   if ([title containsANSICodes]) {
-    [[statusItem_ button]
-        setAttributedTitle:[title attributedStringParsingANSICodes]];
-  } else {
-    [[statusItem_ button] setTitle:title];
+    attributed_title = [title attributedStringParsingANSICodes];
   }
+
+  // Change font type, if specified
+  CGFloat existing_size = [[[statusItem_ button] font] pointSize];
+  if ([font_type isEqualToString:@"monospaced"]) {
+    if (@available(macOS 10.15, *)) {
+      NSDictionary* attributes = @{
+        NSFontAttributeName :
+            [NSFont monospacedSystemFontOfSize:existing_size
+                                        weight:NSFontWeightRegular]
+      };
+      [attributed_title
+          setAttributes:attributes
+                  range:NSMakeRange(0, [attributed_title length])];
+    }
+  } else if ([font_type isEqualToString:@"monospacedDigit"]) {
+    if (@available(macOS 10.11, *)) {
+      NSDictionary* attributes = @{
+        NSFontAttributeName :
+            [NSFont monospacedDigitSystemFontOfSize:existing_size
+                                             weight:NSFontWeightRegular]
+      };
+      [attributed_title
+          setAttributes:attributes
+                  range:NSMakeRange(0, [attributed_title length])];
+    }
+  }
+
+  // Set title
+  [[statusItem_ button] setAttributedTitle:attributed_title];
 
   // Fix icon margins.
   if (title.length > 0) {
@@ -306,8 +335,10 @@ void TrayIconCocoa::SetToolTip(const std::string& tool_tip) {
   [status_item_view_ setToolTip:base::SysUTF8ToNSString(tool_tip)];
 }
 
-void TrayIconCocoa::SetTitle(const std::string& title) {
-  [status_item_view_ setTitle:base::SysUTF8ToNSString(title)];
+void TrayIconCocoa::SetTitle(const std::string& title,
+                             const std::string& font_type) {
+  [status_item_view_ setTitle:base::SysUTF8ToNSString(title)
+                    font_type:base::SysUTF8ToNSString(font_type)];
 }
 
 std::string TrayIconCocoa::GetTitle() {

--- a/spec-main/api-tray-spec.ts
+++ b/spec-main/api-tray-spec.ts
@@ -187,7 +187,7 @@ describe('tray module', () => {
 
     it('throws on invalid font types', () => {
       expect(() => {
-        tray.setTitle('Hello World!', { fontType: 'blep' });
+        tray.setTitle('Hello World!', { fontType: 'blep' as any });
       }).to.throw(/fontType must be one of 'monospaced' or 'monospacedDigit'/);
     });
   });

--- a/spec-main/api-tray-spec.ts
+++ b/spec-main/api-tray-spec.ts
@@ -159,5 +159,18 @@ describe('tray module', () => {
 
       expect(newTitle).to.equal(title);
     });
+
+    it('can be called with a font type', () => {
+      expect(() => {
+        tray.setTitle('Hello World!', 'monospaced');
+        tray.setTitle('Hello World!', 'monospacedDigit');
+      }).to.not.throw();
+    });
+
+    it('throws on non-string font types', () => {
+      expect(() => {
+        tray.setTitle('Hello World!', 5.4 as any);
+      }).to.throw(/index 1/);
+    });
   });
 });

--- a/spec-main/api-tray-spec.ts
+++ b/spec-main/api-tray-spec.ts
@@ -160,17 +160,35 @@ describe('tray module', () => {
       expect(newTitle).to.equal(title);
     });
 
-    it('can be called with a font type', () => {
+    it('can have an options object passed in', () => {
       expect(() => {
-        tray.setTitle('Hello World!', 'monospaced');
-        tray.setTitle('Hello World!', 'monospacedDigit');
+        tray.setTitle('Hello World!', {});
       }).to.not.throw();
     });
 
-    it('throws on non-string font types', () => {
+    it('throws when the options parameter is not an object', () => {
       expect(() => {
-        tray.setTitle('Hello World!', 5.4 as any);
-      }).to.throw(/index 1/);
+        tray.setTitle('Hello World!', 'test' as any);
+      }).to.throw(/setTitle options must be an object/);
+    });
+
+    it('can have a font type option set', () => {
+      expect(() => {
+        tray.setTitle('Hello World!', { fontType: 'monospaced' });
+        tray.setTitle('Hello World!', { fontType: 'monospacedDigit' });
+      }).to.not.throw();
+    });
+
+    it('throws when the font type is specified but is not a string', () => {
+      expect(() => {
+        tray.setTitle('Hello World!', { fontType: 5.4 as any });
+      }).to.throw(/fontType must be one of 'monospaced' or 'monospacedDigit'/);
+    });
+
+    it('throws on invalid font types', () => {
+      expect(() => {
+        tray.setTitle('Hello World!', { fontType: 'blep' });
+      }).to.throw(/fontType must be one of 'monospaced' or 'monospacedDigit'/);
     });
   });
 });


### PR DESCRIPTION
#### Description of Change

Implements #22363 — add a parameter to `tray.setTitle` on macOS allowing the font type to optionally be specified as one of `monospaced` or `monospacedDigit`. The font attributes are set on the attributed string passed to the NSStatusItem.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: added optional parameter to specify monospaced font types for macOS tray titles
