### PR TITLE
feat: Expose renderer spellcheck API

### DIFF
--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -257,6 +257,20 @@ renderer process.
 
 Returns `WebFrame` - that has the supplied `routingId`, `null` if not found.
 
+### `webFrame.isWordMisspelled(word)`
+
+* `word` String - The word to be spellchecked.
+
+Returns `Boolean` - True if the word is misspelled according to the built in
+spellchecker, false otherwise. If no dictionary is loaded, always return false.
+
+### `webFrame.getWordSuggestions(word)`
+
+* `word` String - The misspelled word.
+
+Returns `String[]` - A list of suggested words for a given word. If the word
+is spelled correctly, the result will be empty.
+
 ## Properties
 
 ### `webFrame.top` _Readonly_

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -10,6 +10,8 @@
 
 #include "base/command_line.h"
 #include "base/memory/memory_pressure_listener.h"
+#include "base/strings/utf_string_conversions.h"
+#include "components/spellcheck/renderer/spellcheck.h"
 #include "content/public/renderer/render_frame.h"
 #include "content/public/renderer/render_frame_observer.h"
 #include "content/public/renderer/render_frame_visitor.h"
@@ -24,6 +26,7 @@
 #include "shell/common/node_includes.h"
 #include "shell/common/options_switches.h"
 #include "shell/renderer/api/electron_api_spell_check_client.h"
+#include "shell/renderer/electron_renderer_client.h"
 #include "third_party/blink/public/common/page/page_zoom.h"
 #include "third_party/blink/public/common/web_cache/web_cache_resource_type_stats.h"
 #include "third_party/blink/public/platform/web_cache.h"
@@ -99,6 +102,24 @@ content::RenderFrame* GetRenderFrame(v8::Local<v8::Value> value) {
   if (!frame)
     return nullptr;
   return content::RenderFrame::FromWebFrame(frame);
+}
+
+bool SpellCheckWord(v8::Isolate* isolate,
+                    v8::Local<v8::Value> window,
+                    const std::string& word,
+                    std::vector<base::string16>* optional_suggestions) {
+  size_t start;
+  size_t length;
+
+  ElectronRendererClient* client = ElectronRendererClient::Get();
+  auto* render_frame = GetRenderFrame(window);
+  if (!render_frame)
+    return true;
+
+  base::string16 w = base::UTF8ToUTF16(word);
+  int id = render_frame->GetRoutingID();
+  return client->GetSpellCheck()->SpellCheckWord(
+      w.c_str(), 0, word.size(), id, &start, &length, optional_suggestions);
 }
 
 class RenderFrameStatus final : public content::RenderFrameObserver {
@@ -671,6 +692,20 @@ blink::WebCacheResourceTypeStats GetResourceUsage(v8::Isolate* isolate) {
   return stats;
 }
 
+bool IsWordMisspelled(v8::Isolate* isolate,
+                      v8::Local<v8::Value> window,
+                      const std::string& word) {
+  return !SpellCheckWord(isolate, window, word, nullptr);
+}
+
+std::vector<base::string16> GetWordSuggestions(v8::Isolate* isolate,
+                                               v8::Local<v8::Value> window,
+                                               const std::string& word) {
+  std::vector<base::string16> suggestions;
+  SpellCheckWord(isolate, window, word, &suggestions);
+  return suggestions;
+}
+
 void ClearCache(v8::Isolate* isolate) {
   isolate->IdleNotificationDeadline(0.5);
   blink::WebCache::Clear();
@@ -826,6 +861,10 @@ void Initialize(v8::Local<v8::Object> exports,
                  &ExecuteJavaScriptInIsolatedWorld);
   dict.SetMethod("setIsolatedWorldInfo", &SetIsolatedWorldInfo);
   dict.SetMethod("getResourceUsage", &GetResourceUsage);
+#if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
+  dict.SetMethod("isWordMisspelled", &IsWordMisspelled);
+  dict.SetMethod("getWordSuggestions", &GetWordSuggestions);
+#endif
   dict.SetMethod("clearCache", &ClearCache);
   dict.SetMethod("_findFrameByRoutingId", &FindFrameByRoutingId);
   dict.SetMethod("_getFrameForSelector", &GetFrameForSelector);

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -34,13 +34,25 @@ bool IsDevToolsExtension(content::RenderFrame* render_frame) {
 
 }  // namespace
 
+// static
+ElectronRendererClient* ElectronRendererClient::self_ = nullptr;
+
 ElectronRendererClient::ElectronRendererClient()
     : node_bindings_(
           NodeBindings::Create(NodeBindings::BrowserEnvironment::RENDERER)),
-      electron_bindings_(new ElectronBindings(node_bindings_->uv_loop())) {}
+      electron_bindings_(new ElectronBindings(node_bindings_->uv_loop())) {
+  DCHECK(!self_) << "Cannot have two ElectronRendererClient";
+  self_ = this;
+}
 
 ElectronRendererClient::~ElectronRendererClient() {
   asar::ClearArchives();
+}
+
+// static
+ElectronRendererClient* ElectronRendererClient::Get() {
+  DCHECK(self_);
+  return self_;
 }
 
 void ElectronRendererClient::RenderFrameCreated(

--- a/shell/renderer/electron_renderer_client.h
+++ b/shell/renderer/electron_renderer_client.h
@@ -26,6 +26,8 @@ class ElectronRendererClient : public RendererClientBase {
   ElectronRendererClient();
   ~ElectronRendererClient() override;
 
+  static ElectronRendererClient* Get();
+
   // electron::RendererClientBase:
   void DidCreateScriptContext(v8::Handle<v8::Context> context,
                               content::RenderFrame* render_frame) override;
@@ -69,6 +71,8 @@ class ElectronRendererClient : public RendererClientBase {
   // its script context. Doing so in a web page without scripts would trigger
   // assertion, so we have to keep a book of injected web frames.
   std::set<content::RenderFrame*> injected_frames_;
+
+  static ElectronRendererClient* self_;
 
   DISALLOW_COPY_AND_ASSIGN(ElectronRendererClient);
 };


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Exposes renderer side browser spellcheck API to the javascript environment.
Resolves https://github.com/electron/electron/issues/22829

Rationale: Electron-based apps that uses CodeMirror (a hugely popular editor) are unable to benefit from the built-in spellchecker since CodeMirror does not use a ContentEditable (everything is faked). CodeMirror exposes a way to highlight errors, but given that we are currently unable to ask for a spellcheck from javascript, all Electron+CodeMirror apps use a js-based spellcheck library like https://github.com/cfinke/Typo.js which is considerably slower than the built-in native spellchecker.

This PR adds the following API:

- `isWordMisspelled(word: string): boolean`
- `getWordSuggestions(word: string): string[]`

**Current WIP adds the methods to the global `process` object which is just so I can test that it works.**
I've tested this and it works. Now to figure out where to put the API.

Ideally I would like this to be a module on `require('electron')`, similar to [IPCRenderer](https://github.com/electron/electron/blob/master/shell/renderer/api/electron_api_ipc_renderer.cc).
In practice, I have not found a way to pass the `WeakPtr<Spellcheck>` to [the renderer API stack](https://github.com/electron/electron/blob/master/lib/renderer/api/module-list.ts). I was also unable to find a reference back to `ElectronRendererClient`/`RenderClientBase` from an API module.
If someone with experience can give me some tips on how to achieve it that would be great!

Also currently missing tests and documentation.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Added spellcheck API to renderer.