### PR TITLE
refactor: wire will-navigate up to a navigation throttle instead of OpenURL

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -769,12 +769,7 @@ content::WebContents* WebContents::OpenURLFromTab(
          params.post_data);
     return nullptr;
   }
-  if (!weak_this)
-    return nullptr;
 
-  // Give user a chance to cancel navigation.
-  if (Emit("will-navigate", params.url))
-    return nullptr;
   if (!weak_this)
     return nullptr;
 

--- a/shell/browser/electron_navigation_throttle.cc
+++ b/shell/browser/electron_navigation_throttle.cc
@@ -21,6 +21,30 @@ const char* ElectronNavigationThrottle::GetNameForLogging() {
 }
 
 content::NavigationThrottle::ThrottleCheckResult
+ElectronNavigationThrottle::WillStartRequest() {
+  auto* handle = navigation_handle();
+  auto* contents = handle->GetWebContents();
+  if (!contents) {
+    NOTREACHED();
+    return PROCEED;
+  }
+
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope scope(isolate);
+  api::WebContents* api_contents = api::WebContents::From(contents);
+  if (!api_contents) {
+    // No need to emit any event if the WebContents is not available in JS.
+    return PROCEED;
+  }
+
+  if (handle->IsRendererInitiated() && handle->IsInMainFrame() &&
+      api_contents->EmitNavigationEvent("will-navigate", handle)) {
+    return CANCEL;
+  }
+  return PROCEED;
+}
+
+content::NavigationThrottle::ThrottleCheckResult
 ElectronNavigationThrottle::WillRedirectRequest() {
   auto* handle = navigation_handle();
   auto* contents = handle->GetWebContents();

--- a/shell/browser/electron_navigation_throttle.h
+++ b/shell/browser/electron_navigation_throttle.h
@@ -14,6 +14,8 @@ class ElectronNavigationThrottle : public content::NavigationThrottle {
   explicit ElectronNavigationThrottle(content::NavigationHandle* handle);
   ~ElectronNavigationThrottle() override;
 
+  ElectronNavigationThrottle::ThrottleCheckResult WillStartRequest() override;
+
   ElectronNavigationThrottle::ThrottleCheckResult WillRedirectRequest()
       override;
 


### PR DESCRIPTION
Was talking to some Chromium folks and apparently this is the more _correct_ way of doing this.  This also aligns our impl of `will-redirect` and `will-navigate` so that's good too.

Notes: no-notes