### PR TITLE
fix(extensions): enable WebSQL in background pages

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -764,6 +764,16 @@ void ElectronBrowserClient::AppendExtraCommandLineSwitches(
       command_line->AppendSwitch("profile-electron-init");
     }
 
+    // Extension background pages don't have WebContentsPreferences, but they
+    // support WebSQL by default.
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
+    content::RenderProcessHost* process =
+        content::RenderProcessHost::FromID(process_id);
+    if (extensions::ProcessMap::Get(process->GetBrowserContext())
+            ->Contains(process_id))
+      command_line->AppendSwitch(switches::kEnableWebSQL);
+#endif
+
     content::WebContents* web_contents =
         GetWebContentsFromProcessID(process_id);
     if (web_contents) {

--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -32,6 +32,31 @@ describe('chrome extensions', () => {
     });
   });
 
+  it('can open WebSQLDatabase in a background page', async () => {
+    const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
+    const w = new BrowserWindow({ show: false, webPreferences: { session: customSession, sandbox: true } });
+    w.loadURL('about:blank');
+
+    await emittedOnce(w.webContents, 'dom-ready');
+    await customSession.loadExtension(path.join(fixtures, 'extensions', 'persistent-background-page'));
+    const args: any = await emittedOnce(app, 'web-contents-created');
+    const wc: Electron.WebContents = args[1];
+    await expect(wc.executeJavaScript('(()=>{try{openDatabase("t", "1.0", "test", 2e5);return true;}catch(e){throw e}})()')).to.not.be.rejected();
+  });
+
+  function fetch (contents: WebContents, url: string) {
+    return contents.executeJavaScript(`fetch(${JSON.stringify(url)})`);
+  }
+
+  it('bypasses CORS in requests made from extensions', async () => {
+    const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
+    const w = new BrowserWindow({ show: false, webPreferences: { session: customSession, sandbox: true } });
+    const extension = await customSession.loadExtension(path.join(fixtures, 'extensions', 'ui-page'));
+    w.loadURL(`${extension.url}bare-page.html`);
+    await emittedOnce(w.webContents, 'dom-ready');
+    await expect(fetch(w.webContents, `${url}/cors`)).to.not.be.rejectedWith(TypeError);
+  });
+
   it('loads an extension', async () => {
     // NB. we have to use a persist: session (i.e. non-OTR) because the
     // extension registry is redirected to the main session. so installing an
@@ -274,7 +299,7 @@ describe('chrome extensions', () => {
     await customSession.loadExtension(path.join(fixtures, 'extensions', 'persistent-background-page'));
     const w = new BrowserWindow({ show: false, webPreferences: { session: customSession } });
     const promise = emittedOnce(app, 'web-contents-created');
-    await w.loadURL(`about:blank`);
+    await w.loadURL('about:blank');
     const [, bgPageContents] = await promise;
     expect(bgPageContents.session).to.not.equal(undefined);
   });

--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -44,19 +44,6 @@ describe('chrome extensions', () => {
     await expect(wc.executeJavaScript('(()=>{try{openDatabase("t", "1.0", "test", 2e5);return true;}catch(e){throw e}})()')).to.not.be.rejected();
   });
 
-  function fetch (contents: WebContents, url: string) {
-    return contents.executeJavaScript(`fetch(${JSON.stringify(url)})`);
-  }
-
-  it('bypasses CORS in requests made from extensions', async () => {
-    const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
-    const w = new BrowserWindow({ show: false, webPreferences: { session: customSession, sandbox: true } });
-    const extension = await customSession.loadExtension(path.join(fixtures, 'extensions', 'ui-page'));
-    w.loadURL(`${extension.url}bare-page.html`);
-    await emittedOnce(w.webContents, 'dom-ready');
-    await expect(fetch(w.webContents, `${url}/cors`)).to.not.be.rejectedWith(TypeError);
-  });
-
   it('loads an extension', async () => {
     // NB. we have to use a persist: session (i.e. non-OTR) because the
     // extension registry is redirected to the main session. so installing an


### PR DESCRIPTION
Backport of #24798

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed not working `WebSQLDatabase` in extension background pages.