### PR TITLE
docs: add restricted header info to ClientRequest docs

### DIFF
--- a/docs/api/client-request.md
+++ b/docs/api/client-request.md
@@ -171,7 +171,7 @@ lowercasing. It can be called only before first write. Calling this method after
 the first write will throw an error. If the passed value is not a `String`, its
 `toString()` method will be called to obtain the final value.
 
-Certain headers are restricted from being set by app consumers. These headers are
+Certain headers are restricted from being set by apps. These headers are
 listed below. More information on restricted headers can be found in
 [Chromium's header utils](https://source.chromium.org/chromium/chromium/src/+/master:services/network/public/cpp/header_util.cc;drc=1562cab3f1eda927938f8f4a5a91991fefde66d3;bpv=1;bpt=1;l=22).
 
@@ -182,6 +182,8 @@ listed below. More information on restricted headers can be found in
 * `Cookie2`
 * `Keep-Alive`
 * `Transfer-Encoding`
+
+Additionally, setting the `Connection` header to the value `upgrade` is also disallowed.
 
 #### `request.getHeader(name)`
 

--- a/docs/api/client-request.md
+++ b/docs/api/client-request.md
@@ -171,6 +171,18 @@ lowercasing. It can be called only before first write. Calling this method after
 the first write will throw an error. If the passed value is not a `String`, its
 `toString()` method will be called to obtain the final value.
 
+Certain headers are restricted from being set by app consumers. These headers are
+listed below. More information on restricted headers can be found in
+[Chromium's header utils](https://source.chromium.org/chromium/chromium/src/+/master:services/network/public/cpp/header_util.cc;drc=1562cab3f1eda927938f8f4a5a91991fefde66d3;bpv=1;bpt=1;l=22).
+
+* `Content-Length`
+* `Host`
+* `Trailer` or `Te`
+* `Upgrade`
+* `Cookie2`
+* `Keep-Alive`
+* `Transfer-Encoding`
+
 #### `request.getHeader(name)`
 
 * `name` String - Specify an extra header name.


### PR DESCRIPTION
#### Description of Change

Addresses #21148. (cc @nornagon)

Beginning in Electron 7, trying to set a `Host` header when creating a request with `net` throws a net::ERR_INVALID_ARGUMENT error. This is due to a Chromium change introduced in 7, where certain header types are now restricted from being [set by a consumer](https://source.chromium.org/chromium/chromium/src/+/master:services/network/public/cpp/header_util.cc;drc=1562cab3f1eda927938f8f4a5a91991fefde66d3;bpv=1;bpt=1;l=22).

It doesn't seem like we'll be able to resolve this without patching Chrome directly, but this PR updates our docs to give developers a warning about what headers are restricted/will throw an error if set, and where they can find more information.

_Note: I didn't add any release notes since this is a small doc change for something that has been present since 7.0.0, but happy to add a note if it would be helpful!_

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: none
