### PR TITLE
fix: register for connected standby changes

### DIFF
--- a/shell/browser/api/electron_api_power_monitor_win.cc
+++ b/shell/browser/api/electron_api_power_monitor_win.cc
@@ -8,6 +8,7 @@
 #include <wtsapi32.h>
 
 #include "base/win/windows_types.h"
+#include "base/win/windows_version.h"
 #include "base/win/wrapped_window_proc.h"
 #include "ui/base/win/shell.h"
 #include "ui/gfx/win/hwnd_util.h"
@@ -40,6 +41,13 @@ void PowerMonitor::InitPlatformSpecificMonitors() {
 
   // Tel windows we want to be notified with session events
   WTSRegisterSessionNotification(window_, NOTIFY_FOR_THIS_SESSION);
+
+  // For Windows 8 and later, a new "connected standy" mode has been added and
+  // we must explicitly register for its notifications.
+  if (base::win::GetVersion() >= base::win::Version::WIN8) {
+    RegisterSuspendResumeNotification(static_cast<HANDLE>(window_),
+                                      DEVICE_NOTIFY_WINDOW_HANDLE);
+  }
 }
 
 LRESULT CALLBACK PowerMonitor::WndProcStatic(HWND hwnd,


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/24499.

For Windows 8 and later,  a new "connected standby" mode has been added and we must explicitly register for its notifications to get the `suspend/resume` events.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fix `powerMonitor` not emitting `suspend`/`resume` events on some Windows machines.