### PR TITLE
fix: reply notifs sometimes destroyed too early

### DIFF
--- a/shell/browser/notifications/mac/notification_center_delegate.mm
+++ b/shell/browser/notifications/mac/notification_center_delegate.mm
@@ -43,7 +43,10 @@
     // https://developer.apple.com/documentation/foundation/nsusernotificationactivationtype?language=objc
     if (notif.activationType ==
         NSUserNotificationActivationTypeContentsClicked) {
-      notification->NotificationClicked();
+      // If a notification with a reply button is clicked and the user has not
+      // yet replied, we do not want to destroy the notification.
+      bool should_destroy = ![notif hasReplyButton];
+      notification->NotificationClicked(should_destroy);
     } else if (notif.activationType ==
                NSUserNotificationActivationTypeActionButtonClicked) {
       notification->NotificationActivated();

--- a/shell/browser/notifications/notification.cc
+++ b/shell/browser/notifications/notification.cc
@@ -21,10 +21,12 @@ Notification::~Notification() {
     delegate()->NotificationDestroyed();
 }
 
-void Notification::NotificationClicked() {
+void Notification::NotificationClicked(bool should_destroy) {
   if (delegate())
     delegate()->NotificationClick();
-  Destroy();
+
+  if (should_destroy)
+    Destroy();
 }
 
 void Notification::NotificationDismissed() {

--- a/shell/browser/notifications/notification.h
+++ b/shell/browser/notifications/notification.h
@@ -54,7 +54,7 @@ class Notification {
   virtual void Dismiss() = 0;
 
   // Should be called by derived classes.
-  void NotificationClicked();
+  void NotificationClicked(bool should_destroy = true);
   void NotificationDismissed();
   void NotificationFailed();
 

--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -476,7 +476,7 @@ IFACEMETHODIMP ToastEventHandler::Invoke(
     IInspectable* args) {
   base::PostTask(
       FROM_HERE, {content::BrowserThread::UI},
-      base::BindOnce(&Notification::NotificationClicked, notification_));
+      base::BindOnce(&Notification::NotificationClicked, notification_, true));
   if (IsDebuggingNotifications())
     LOG(INFO) << "Notification clicked";
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/25062.

Fixes an issue where notifications with a reply button could potentially be destroyed too early when a user clicked on the notification body before replying, which meant that when they did finally reply the reply callback would never be called. This happened because we were destroying the notification on _any_ activation type, and it's possible for reply-type notifications to be activated more than once. This fixes that by ensuring that reply-type notifications are only destroyed when the activation type is `NSUserNotificationActivationTypeReplied`.

Tested with https://gist.github.com/60a2cff9d13903bf538ebfc3c8134f0f.

cc @MarshallOfSound @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed an issue where notifications with a reply button could potentially be destroyed too early when a user clicked on the notification body before replying.
