### PR TITLE
fix: mitigate use of private macOS font API

### DIFF
--- a/patches/chromium/mas_no_private_api.patch
+++ b/patches/chromium/mas_no_private_api.patch
@@ -420,6 +420,44 @@ index 28ca1646af0b0cce40d27baec71cbe65adc334fa..bae65c1f485bc02eb9ef2ebf7018af4a
  }
  
  }  // namespace
+diff --git a/content/renderer/theme_helper_mac.mm b/content/renderer/theme_helper_mac.mm
+index 1db129740992672a4e8be8100da18b6813f1a4f8..5b1e456020ac859c826dbef2826cacf3bb60108b 100644
+--- a/content/renderer/theme_helper_mac.mm
++++ b/content/renderer/theme_helper_mac.mm
+@@ -7,11 +7,11 @@
+ #include <Cocoa/Cocoa.h>
+ 
+ #include "base/strings/sys_string_conversions.h"
+-
++#if !defined(MAS_BUILD)
+ extern "C" {
+ bool CGFontRenderingGetFontSmoothingDisabled(void) API_AVAILABLE(macos(10.14));
+ }
+-
++#endif
+ namespace content {
+ 
+ void SystemColorsDidChange(int aqua_color_variant,
+@@ -59,8 +59,19 @@ void SystemColorsDidChange(int aqua_color_variant,
+ bool IsSubpixelAntialiasingAvailable() {
+   if (__builtin_available(macOS 10.14, *)) {
+     // See https://trac.webkit.org/changeset/239306/webkit for more info.
++#if !defined(MAS_BUILD)
+     return !CGFontRenderingGetFontSmoothingDisabled();
++#else
++    NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
++    NSString *default_key = @"CGFontRenderingGetFontSmoothingDisabled";
++    // Check that key exists since boolForKey defaults to NO when the 
++    // key is missing and this key in fact defaults to YES;
++    if ([defaults objectForKey:default_key] == nil)
++      return false;
++    return ![defaults boolForKey:default_key];
++#endif
+   }
++
+   return true;
+ }
+ 
 diff --git a/device/bluetooth/bluetooth_adapter_mac.mm b/device/bluetooth/bluetooth_adapter_mac.mm
 index 933483c36d94336c8e9cc56a53bc86aee01e12d0..a48b4af66fb4edcf74caef5bec68c53be5469fe8 100644
 --- a/device/bluetooth/bluetooth_adapter_mac.mm


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/25115.

Fixes an issue where apps could be rejected in MAS becuase of the presence of a new private API: `CGFontRenderingGetFontSmoothingDisabled()`. The feature was added to ensure that macOS LCD text behavior was respected, but as it causes rejections we should disable the feature on MAS builds.

cc @MarshallOfSound @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed an issue where some apps might be rejected from the Mac App Store owing to a private font-related API added in Chromium.
