### PR TITLE
feat: add support for will-navigate and will-fail-load custom error pages

### DIFF
--- a/docs/api/structures/cancellable-navigation-event.md
+++ b/docs/api/structures/cancellable-navigation-event.md
@@ -1,0 +1,6 @@
+# CancellableNavigationEvent Object extends `Event`
+
+* `returnValue` Object | null - Set this to cancel the navigation event and optionally return a custom error code or error page
+  * `errorCode` Number - Can be any error code from the [Net Error List](https://source.chromium.org/chromium/chromium/src/+/master:net/base/net_error_list.h).  If you provide `errorPage` then this code can not be `-3`. We recommend using `-2` which is `net::Aborted`.
+  * `errorPage` String (optional) - Custom HTML error page to display when the navigation is cancelled.
+

--- a/docs/api/structures/cancellable-navigation-event.md
+++ b/docs/api/structures/cancellable-navigation-event.md
@@ -1,6 +1,6 @@
 # CancellableNavigationEvent Object extends `Event`
 
-* `returnValue` Object | null - Set this to cancel the navigation event and optionally return a custom error code or error page
+* `returnValue` Object - Set this to cancel the navigation event and optionally return a custom error code or error page
   * `errorCode` Number - Can be any error code from the [Net Error List](https://source.chromium.org/chromium/chromium/src/+/master:net/base/net_error_list.h).  If you provide `errorPage` then this code can not be `-3`. We recommend using `-2` which is `net::Aborted`.
   * `errorPage` String (optional) - Custom HTML error page to display when the navigation is cancelled.
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -73,8 +73,8 @@ Returns:
 This event will be emitted after `did-start-loading` and always before the
 `did-fail-load` event for the same navigation.
 
-Settings `event.returnValue` to an HTML string will result in a custom error page being
-displayed using that HTML.
+Settings `event.returnValue` to the appropriate object will result in a custom error page being
+displayed using custom HTML.
 
 #### Event: 'did-fail-load'
 
@@ -262,8 +262,8 @@ this purpose.
 
 Calling `event.preventDefault()` will prevent the navigation.
 
-Settings `event.returnValue` to an HTML string will result in a custom error page being
-displayed using that HTML and the navigation being cancelled.
+Settings `event.returnValue` to the appropriate object will result in a custom error page being
+displayed using custom HTML and the navigation being cancelled.
 
 #### Event: 'did-start-navigation'
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -61,7 +61,7 @@ spinning, and the `onload` event was dispatched.
 
 Returns:
 
-* `event` Event
+* `event` [CancellableNavigationEvent](structures/cancellable-navigation-event.md)
 * `url` String
 * `isInPlace` Boolean
 * `isMainFrame` Boolean
@@ -247,7 +247,7 @@ See [`window.open()`](window-open.md) for more details and how to use this in co
 
 Returns:
 
-* `event` Event
+* `event` [CancellableNavigationEvent](structures/cancellable-navigation-event.md)
 * `url` String
 
 Emitted when a user or the page wants to start navigation. It can happen when

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -57,6 +57,25 @@ Process: [Main](../glossary.md#main-process)
 Emitted when the navigation is done, i.e. the spinner of the tab has stopped
 spinning, and the `onload` event was dispatched.
 
+#### Event: 'will-fail-load'
+
+Returns:
+
+* `event` Event
+* `url` String
+* `isInPlace` Boolean
+* `isMainFrame` Boolean
+* `frameProcessId` Integer
+* `frameRoutingId` Integer
+* `errorCode` Integer
+* `errorDescription` String
+
+This event will be emitted after `did-start-loading` and always before the
+`did-fail-load` event for the same navigation.
+
+Settings `event.returnValue` to an HTML string will result in a custom error page being
+displayed using that HTML.
+
 #### Event: 'did-fail-load'
 
 Returns:
@@ -242,6 +261,9 @@ or updating the `window.location.hash`. Use `did-navigate-in-page` event for
 this purpose.
 
 Calling `event.preventDefault()` will prevent the navigation.
+
+Settings `event.returnValue` to an HTML string will result in a custom error page being
+displayed using that HTML and the navigation being cancelled.
 
 #### Event: 'did-start-navigation'
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -57,7 +57,7 @@ Process: [Main](../glossary.md#main-process)
 Emitted when the navigation is done, i.e. the spinner of the tab has stopped
 spinning, and the `onload` event was dispatched.
 
-#### Event: 'will-fail-load'
+#### Event: 'will-fail-load' _Experimental_
 
 Returns:
 
@@ -243,7 +243,7 @@ Not emitted if the creation of the window is canceled from
 
 See [`window.open()`](window-open.md) for more details and how to use this in conjunction with `webContents.setWindowOpenHandler`.
 
-#### Event: 'will-navigate'
+#### Event: 'will-navigate' _Experimental_
 
 Returns:
 

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -819,7 +819,7 @@ which potential security issues are not as widely known.
 [webview-tag]: ../api/webview-tag.md
 [web-contents]: ../api/web-contents.md
 [window-open-handler]: ../api/web-contents.md#contentssetwindowopenhandler-handler
-[will-navigate]: ../api/web-contents.md#event-will-navigate
+[will-navigate]: ../api/web-contents.md#event-will-navigateexperimental
 [open-external]: ../api/shell.md#shellopenexternalurl-options
 [sandbox]: ../api/sandbox-option.md
 [responsible-disclosure]: https://en.wikipedia.org/wiki/Responsible_disclosure

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -73,6 +73,7 @@ auto_filenames = {
     "docs/api/webview-tag.md",
     "docs/api/window-open.md",
     "docs/api/structures/bluetooth-device.md",
+    "docs/api/structures/cancellable-navigation-event.md",
     "docs/api/structures/certificate-principal.md",
     "docs/api/structures/certificate.md",
     "docs/api/structures/cookie.md",

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1470,7 +1470,8 @@ void WebContents::DidStopLoading() {
 
 bool WebContents::EmitNavigationEvent(
     const std::string& event,
-    content::NavigationHandle* navigation_handle) {
+    content::NavigationHandle* navigation_handle,
+    gin_helper::Event::ValueCallback callback) {
   bool is_main_frame = navigation_handle->IsInMainFrame();
   int frame_tree_node_id = navigation_handle->GetFrameTreeNodeId();
   content::FrameTreeNode* frame_tree_node =
@@ -1490,8 +1491,18 @@ bool WebContents::EmitNavigationEvent(
   }
   bool is_same_document = navigation_handle->IsSameDocument();
   auto url = navigation_handle->GetURL();
-  return Emit(event, url, is_same_document, is_main_frame, frame_process_id,
-              frame_routing_id);
+  int code = navigation_handle->GetNetErrorCode();
+  auto description = net::ErrorToShortString(code);
+  return EmitWithSender(event, nullptr, std::move(callback), url,
+                        is_same_document, is_main_frame, frame_process_id,
+                        frame_routing_id, code, description);
+}
+
+bool WebContents::EmitNavigationEvent(
+    const std::string& event,
+    content::NavigationHandle* navigation_handle) {
+  return EmitNavigationEvent(event, navigation_handle,
+                             gin_helper::Event::ValueCallback());
 }
 
 void WebContents::BindElectronBrowser(
@@ -1513,8 +1524,9 @@ void WebContents::Message(bool internal,
   TRACE_EVENT1("electron", "WebContents::Message", "channel", channel);
   // webContents.emit('-ipc-message', new Event(), internal, channel,
   // arguments);
-  EmitWithSender("-ipc-message", receivers_.current_context(), InvokeCallback(),
-                 internal, channel, std::move(arguments));
+  EmitWithSender("-ipc-message", receivers_.current_context(),
+                 gin_helper::Event::ValueCallback(), internal, channel,
+                 std::move(arguments));
 }
 
 void WebContents::Invoke(bool internal,
@@ -1524,7 +1536,9 @@ void WebContents::Invoke(bool internal,
   TRACE_EVENT1("electron", "WebContents::Invoke", "channel", channel);
   // webContents.emit('-ipc-invoke', new Event(), internal, channel, arguments);
   EmitWithSender("-ipc-invoke", receivers_.current_context(),
-                 std::move(callback), internal, channel, std::move(arguments));
+                 gin_helper::Event::AdaptInvokeCallbackToValueCallback(
+                     std::move(callback)),
+                 internal, channel, std::move(arguments));
 }
 
 void WebContents::OnFirstNonEmptyLayout() {
@@ -1541,8 +1555,9 @@ void WebContents::ReceivePostMessage(const std::string& channel,
       MessagePort::EntanglePorts(isolate, std::move(message.ports));
   v8::Local<v8::Value> message_value =
       electron::DeserializeV8Value(isolate, message);
-  EmitWithSender("-ipc-ports", receivers_.current_context(), InvokeCallback(),
-                 false, channel, message_value, std::move(wrapped_ports));
+  EmitWithSender("-ipc-ports", receivers_.current_context(),
+                 gin_helper::Event::ValueCallback(), false, channel,
+                 message_value, std::move(wrapped_ports));
 }
 
 void WebContents::PostMessage(const std::string& channel,
@@ -1586,7 +1601,9 @@ void WebContents::MessageSync(bool internal,
   // webContents.emit('-ipc-message-sync', new Event(sender, message), internal,
   // channel, arguments);
   EmitWithSender("-ipc-message-sync", receivers_.current_context(),
-                 std::move(callback), internal, channel, std::move(arguments));
+                 gin_helper::Event::AdaptInvokeCallbackToValueCallback(
+                     std::move(callback)),
+                 internal, channel, std::move(arguments));
 }
 
 void WebContents::MessageTo(bool internal,
@@ -1608,7 +1625,8 @@ void WebContents::MessageHost(const std::string& channel,
   TRACE_EVENT1("electron", "WebContents::MessageHost", "channel", channel);
   // webContents.emit('ipc-message-host', new Event(), channel, args);
   EmitWithSender("ipc-message-host", receivers_.current_context(),
-                 InvokeCallback(), channel, std::move(arguments));
+                 gin_helper::Event::ValueCallback(), channel,
+                 std::move(arguments));
 }
 
 void WebContents::UpdateDraggableRegions(

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -30,6 +30,7 @@
 #include "mojo/public/cpp/bindings/receiver_set.h"
 #include "printing/buildflags/buildflags.h"
 #include "services/service_manager/public/cpp/binder_registry.h"
+#include "shell/browser/api/event.h"
 #include "shell/browser/api/frame_subscriber.h"
 #include "shell/browser/api/save_page_handler.h"
 #include "shell/browser/event_emitter_mixin.h"
@@ -408,11 +409,15 @@ class WebContents : public gin::Wrappable<WebContents>,
   bool EmitNavigationEvent(const std::string& event,
                            content::NavigationHandle* navigation_handle);
 
+  bool EmitNavigationEvent(const std::string& event,
+                           content::NavigationHandle* navigation_handle,
+                           gin_helper::Event::ValueCallback callback);
+
   // this.emit(name, new Event(sender, message), args...);
   template <typename... Args>
   bool EmitWithSender(base::StringPiece name,
                       content::RenderFrameHost* sender,
-                      electron::mojom::ElectronBrowser::InvokeCallback callback,
+                      gin_helper::Event::ValueCallback callback,
                       Args&&... args) {
     DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
     v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();

--- a/shell/browser/api/event.h
+++ b/shell/browser/api/event.h
@@ -18,16 +18,20 @@ namespace gin_helper {
 class Event : public gin::Wrappable<Event> {
  public:
   using InvokeCallback = electron::mojom::ElectronBrowser::InvokeCallback;
+  using ValueCallback = base::OnceCallback<bool(v8::Local<v8::Value>)>;
 
   static gin::WrapperInfo kWrapperInfo;
 
   static gin::Handle<Event> Create(v8::Isolate* isolate);
 
-  // Pass the callback to be invoked.
-  void SetCallback(InvokeCallback callback);
+  static ValueCallback AdaptInvokeCallbackToValueCallback(
+      InvokeCallback callback);
 
   // event.PreventDefault().
   void PreventDefault(v8::Isolate* isolate);
+
+  // Pass the callback to be invoked.
+  void SetCallback(ValueCallback callback);
 
   // event.sendReply(value), used for replying to synchronous messages and
   // `invoke` calls.
@@ -44,7 +48,7 @@ class Event : public gin::Wrappable<Event> {
 
  private:
   // Replyer for the synchronous messages.
-  InvokeCallback callback_;
+  ValueCallback callback_;
 
   DISALLOW_COPY_AND_ASSIGN(Event);
 };

--- a/shell/browser/electron_navigation_throttle.cc
+++ b/shell/browser/electron_navigation_throttle.cc
@@ -4,11 +4,31 @@
 
 #include "shell/browser/electron_navigation_throttle.h"
 
+#include <memory>
+#include <string>
+
 #include "content/public/browser/navigation_handle.h"
 #include "shell/browser/api/electron_api_web_contents.h"
 #include "shell/browser/javascript_environment.h"
 
 namespace electron {
+
+namespace {
+
+bool HandleEventReturnValue(std::shared_ptr<bool> is_delay_called,
+                            std::shared_ptr<std::string> error_html,
+                            v8::Local<v8::Value> val) {
+  if (*is_delay_called)
+    return true;
+
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  std::string provided_html;
+  if (gin::ConvertFromV8(isolate, val, &provided_html))
+    *error_html = provided_html;
+  return true;
+}
+
+}  // namespace
 
 ElectronNavigationThrottle::ElectronNavigationThrottle(
     content::NavigationHandle* navigation_handle)
@@ -21,7 +41,9 @@ const char* ElectronNavigationThrottle::GetNameForLogging() {
 }
 
 content::NavigationThrottle::ThrottleCheckResult
-ElectronNavigationThrottle::WillStartRequest() {
+ElectronNavigationThrottle::DelegateEventToWebContents(
+    const std::string& event_name,
+    net::Error error_code) {
   auto* handle = navigation_handle();
   auto* contents = handle->GetWebContents();
   if (!contents) {
@@ -37,10 +59,35 @@ ElectronNavigationThrottle::WillStartRequest() {
     return PROCEED;
   }
 
-  if (handle->IsRendererInitiated() && handle->IsInMainFrame() &&
-      api_contents->EmitNavigationEvent("will-navigate", handle)) {
+  std::shared_ptr<bool> is_delay_called(new bool(false));
+  std::shared_ptr<std::string> error_html(new std::string);
+  if (api_contents->EmitNavigationEvent(
+          event_name, handle,
+          base::BindOnce(&HandleEventReturnValue, is_delay_called,
+                         error_html))) {
+    *is_delay_called = true;
+
+    if (!error_html->empty()) {
+      return content::NavigationThrottle::ThrottleCheckResult(
+          CANCEL, error_code, *error_html);
+    }
     return CANCEL;
   }
+  *is_delay_called = true;
+  return PROCEED;
+}
+
+content::NavigationThrottle::ThrottleCheckResult
+ElectronNavigationThrottle::WillFailRequest() {
+  return DelegateEventToWebContents("-will-fail-load",
+                                    navigation_handle()->GetNetErrorCode());
+}
+
+content::NavigationThrottle::ThrottleCheckResult
+ElectronNavigationThrottle::WillStartRequest() {
+  auto* handle = navigation_handle();
+  if (handle->IsRendererInitiated() && handle->IsInMainFrame())
+    return DelegateEventToWebContents("-will-navigate", net::ERR_FAILED);
   return PROCEED;
 }
 

--- a/shell/browser/electron_navigation_throttle.cc
+++ b/shell/browser/electron_navigation_throttle.cc
@@ -86,7 +86,7 @@ content::NavigationThrottle::ThrottleCheckResult
 ElectronNavigationThrottle::WillStartRequest() {
   auto* handle = navigation_handle();
   if (handle->IsRendererInitiated() && handle->IsInMainFrame())
-    return DelegateEventToWebContents("-will-navigate", net::ERR_FAILED);
+    return DelegateEventToWebContents("-will-navigate", net::ERR_ABORTED);
   return PROCEED;
 }
 

--- a/shell/browser/electron_navigation_throttle.h
+++ b/shell/browser/electron_navigation_throttle.h
@@ -7,6 +7,8 @@
 
 #include "content/public/browser/navigation_throttle.h"
 
+#include <string>
+
 namespace electron {
 
 class ElectronNavigationThrottle : public content::NavigationThrottle {
@@ -16,12 +18,18 @@ class ElectronNavigationThrottle : public content::NavigationThrottle {
 
   ElectronNavigationThrottle::ThrottleCheckResult WillStartRequest() override;
 
+  ElectronNavigationThrottle::ThrottleCheckResult WillFailRequest() override;
+
   ElectronNavigationThrottle::ThrottleCheckResult WillRedirectRequest()
       override;
 
   const char* GetNameForLogging() override;
 
  private:
+  content::NavigationThrottle::ThrottleCheckResult DelegateEventToWebContents(
+      const std::string& event_name,
+      net::Error error_code);
+
   DISALLOW_COPY_AND_ASSIGN(ElectronNavigationThrottle);
 };
 

--- a/shell/browser/electron_navigation_throttle.h
+++ b/shell/browser/electron_navigation_throttle.h
@@ -5,9 +5,9 @@
 #ifndef SHELL_BROWSER_ELECTRON_NAVIGATION_THROTTLE_H_
 #define SHELL_BROWSER_ELECTRON_NAVIGATION_THROTTLE_H_
 
-#include "content/public/browser/navigation_throttle.h"
-
 #include <string>
+
+#include "content/public/browser/navigation_throttle.h"
 
 namespace electron {
 

--- a/shell/common/gin_helper/event_emitter.cc
+++ b/shell/common/gin_helper/event_emitter.cc
@@ -49,13 +49,12 @@ v8::Local<v8::Object> CreateEvent(v8::Isolate* isolate,
   return event;
 }
 
-v8::Local<v8::Object> CreateNativeEvent(
-    v8::Isolate* isolate,
-    v8::Local<v8::Object> sender,
-    content::RenderFrameHost* frame,
-    electron::mojom::ElectronBrowser::MessageSyncCallback callback) {
+v8::Local<v8::Object> CreateNativeEvent(v8::Isolate* isolate,
+                                        v8::Local<v8::Object> sender,
+                                        content::RenderFrameHost* frame,
+                                        Event::ValueCallback callback) {
   v8::Local<v8::Object> event;
-  if (frame && callback) {
+  if (callback) {
     gin::Handle<Event> native_event = Event::Create(isolate);
     native_event->SetCallback(std::move(callback));
     event = v8::Local<v8::Object>::Cast(native_event.ToV8());

--- a/shell/common/gin_helper/event_emitter.h
+++ b/shell/common/gin_helper/event_emitter.h
@@ -29,7 +29,7 @@ v8::Local<v8::Object> CreateNativeEvent(
     v8::Isolate* isolate,
     v8::Local<v8::Object> sender,
     content::RenderFrameHost* frame,
-    electron::mojom::ElectronBrowser::MessageSyncCallback callback);
+    base::OnceCallback<bool(v8::Local<v8::Value>)> callback);
 
 }  // namespace internal
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -325,6 +325,8 @@
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/klaw/-/klaw-3.0.1.tgz#29f90021c0234976aa4eb97efced9cb6db9fa8b3"
   integrity sha512-acnF3n9mYOr1aFJKFyvfNX0am9EtPUsYPq22QUCGdJE+MVt6UyAN1jwo+PmOPqXD4K7ZS9MtxDEp/un0lxFccA==
+  dependencies:
+    "@types/node" "*"
 
 "@types/linkify-it@*":
   version "2.1.0"


### PR DESCRIPTION
### Use Cases

Closes https://github.com/electron/electron/issues/30369.

Sometimes users navigation failures occur, mostly due to network issues (proxy, DNS failure, etc.) currently those failures send users to a blank page that is very hard to customize or show any meaningful information on.

This new event and new capability to provide custom HTML error pages allows app devs to provide actually _useful_ error pages in the same style as their app for a much nicer "app" experience vs the "white screen of doom" that people associate with web apps failing to load.

### Example Usage

```js
mainWindow.webContents.on('will-fail-request', (e, url, isInPlace, isMainFrame, frameProcessId, frameRoutingId, errorCode, errorDescription) => {
  e.returnValue = {
    errorCode: -2,
    errorPage: `
<html>
<body>
  <h1>Oh no, something went wrong</h1>
  <p>URL: ${url}</p>
  <p>Error: ${errorCode} - ${errorDescription}</p>
</body>
</html>`
  };
});
```


### Screenshot
![Screen Shot 2020-08-25 at 1 53 53 PM](https://user-images.githubusercontent.com/6634592/91227550-8dd51600-e6db-11ea-88a0-445f5221e7b0.png)


Notes:
* Added new `will-fail-load` event that is emitted when a navigation is about to fail for a known reason
* Added capability to `will-fail-load`, `will-navigate` and `will-redirect` events to provide a custom error page as raw HTML.  This allows end users to display custom UI when preventing navigations, when network failures occur or other issues cause navigation failures