### PR TITLE
chore: fix DCHECK on print job cancellation

### DIFF
--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -244,11 +244,13 @@ index 8a743d0dd74b087059ff812019ae568a22c5fa01..551dbc7b0bfdbf4ca549278bb3dfc4e3
    printing_succeeded_ = false;
    return true;
  }
-@@ -632,14 +654,22 @@ void PrintViewManagerBase::ReleasePrintJob() {
+@@ -632,6 +632,15 @@ void PrintViewManagerBase::ReleasePrintJob() {
    content::RenderFrameHost* rfh = printing_rfh_;
    printing_rfh_ = nullptr;
  
 +  if (!callback_.is_null()) {
++    registrar_.Remove(this, chrome::NOTIFICATION_PRINT_JOB_EVENT,
++                      content::NotificationService::AllSources());
 +    std::string cb_str = "";
 +    if (!printing_succeeded_)
 +      cb_str = printing_cancelled_ ? "cancelled" : "failed";
@@ -258,17 +260,6 @@ index 8a743d0dd74b087059ff812019ae568a22c5fa01..551dbc7b0bfdbf4ca549278bb3dfc4e3
    if (!print_job_)
      return;
  
-   if (rfh)
-     GetPrintRenderFrame(rfh)->PrintingDone(printing_succeeded_);
- 
--  registrar_.Remove(this, chrome::NOTIFICATION_PRINT_JOB_EVENT,
--                    content::Source<PrintJob>(print_job_.get()));
-+  if (!callback_.is_null())
-+    registrar_.Remove(this, chrome::NOTIFICATION_PRINT_JOB_EVENT,
-+                      content::NotificationService::AllSources());
-   // Don't close the worker thread.
-   print_job_ = nullptr;
- }
 @@ -675,7 +705,7 @@ bool PrintViewManagerBase::RunInnerMessageLoop() {
  }
  

--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -90,7 +90,7 @@ index 52efa2037a31f84a261502107bfebc69ae5a419e..4834e92ae99f12043e5ce476370f6434
  }
  
 diff --git a/chrome/browser/printing/print_view_manager_base.cc b/chrome/browser/printing/print_view_manager_base.cc
-index 8a743d0dd74b087059ff812019ae568a22c5fa01..551dbc7b0bfdbf4ca549278bb3dfc4e3abb5cf0f 100644
+index 8a743d0dd74b087059ff812019ae568a22c5fa01..617b246ab41a42990e191c6ab548679a240416bd 100644
 --- a/chrome/browser/printing/print_view_manager_base.cc
 +++ b/chrome/browser/printing/print_view_manager_base.cc
 @@ -27,10 +27,7 @@
@@ -244,7 +244,7 @@ index 8a743d0dd74b087059ff812019ae568a22c5fa01..551dbc7b0bfdbf4ca549278bb3dfc4e3
    printing_succeeded_ = false;
    return true;
  }
-@@ -632,6 +632,15 @@ void PrintViewManagerBase::ReleasePrintJob() {
+@@ -632,6 +654,15 @@ void PrintViewManagerBase::ReleasePrintJob() {
    content::RenderFrameHost* rfh = printing_rfh_;
    printing_rfh_ = nullptr;
  
@@ -260,7 +260,7 @@ index 8a743d0dd74b087059ff812019ae568a22c5fa01..551dbc7b0bfdbf4ca549278bb3dfc4e3
    if (!print_job_)
      return;
  
-@@ -675,7 +705,7 @@ bool PrintViewManagerBase::RunInnerMessageLoop() {
+@@ -675,7 +706,7 @@ bool PrintViewManagerBase::RunInnerMessageLoop() {
  }
  
  bool PrintViewManagerBase::OpportunisticallyCreatePrintJob(int cookie) {


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/25031.

See that PR for more details.

Notes: Fixed a potential crash on print job cancellation.