### PR TITLE
fix: save normal window bounds when maximizing

### DIFF
--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -315,14 +315,8 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
   // Here we handle the WM_SIZE event in order to figure out what is the current
   // window state and notify the user accordingly.
   switch (w_param) {
-    case SIZE_MAXIMIZED: {
-      last_window_state_ = ui::SHOW_STATE_MAXIMIZED;
-      NotifyWindowMaximize();
-      break;
-    }
-    case SIZE_MINIMIZED:
-      last_window_state_ = ui::SHOW_STATE_MINIMIZED;
-
+    case SIZE_MAXIMIZED:
+    case SIZE_MINIMIZED: {
       WINDOWPLACEMENT wp;
       wp.length = sizeof(WINDOWPLACEMENT);
 
@@ -330,8 +324,19 @@ void NativeWindowViews::HandleSizeEvent(WPARAM w_param, LPARAM l_param) {
         last_normal_placement_bounds_ = gfx::Rect(wp.rcNormalPosition);
       }
 
-      NotifyWindowMinimize();
+      // Note that SIZE_MAXIMIZED and SIZE_MINIMIZED might be emitted for
+      // multiple times for one resize because of the SetWindowPlacement call.
+      if (w_param == SIZE_MAXIMIZED &&
+          last_window_state_ != ui::SHOW_STATE_MAXIMIZED) {
+        last_window_state_ = ui::SHOW_STATE_MAXIMIZED;
+        NotifyWindowMaximize();
+      } else if (w_param == SIZE_MINIMIZED &&
+                 last_window_state_ != ui::SHOW_STATE_MINIMIZED) {
+        last_window_state_ = ui::SHOW_STATE_MINIMIZED;
+        NotifyWindowMinimize();
+      }
       break;
+    }
     case SIZE_RESTORED:
       switch (last_window_state_) {
         case ui::SHOW_STATE_MAXIMIZED:

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1007,6 +1007,26 @@ describe('BrowserWindow module', () => {
           w.show();
           w.maximize();
         });
+        it('does not change size for a frameless window with min size', async () => {
+          w.destroy();
+          w = new BrowserWindow({
+            show: false,
+            frame: false,
+            width: 300,
+            height: 300,
+            minWidth: 300,
+            minHeight: 300
+          });
+          const bounds = w.getBounds();
+          w.once('maximize', () => {
+            w.unmaximize();
+          });
+          const unmaximize = emittedOnce(w, 'unmaximize');
+          w.show();
+          w.maximize();
+          await unmaximize;
+          expectBoundsEqual(w.getNormalBounds(), bounds);
+        });
       });
 
       ifdescribe(process.platform !== 'linux')('Minimized state', () => {
@@ -2941,6 +2961,15 @@ describe('BrowserWindow module', () => {
       w.once('maximize', () => { done(); });
       w.show();
       w.maximize();
+    });
+
+    it('emits only one event when frameless window is maximized', () => {
+      const w = new BrowserWindow({ show: false, frame: false });
+      let emitted = 0;
+      w.on('maximize', () => emitted++);
+      w.show();
+      w.maximize();
+      expect(emitted).to.equal(1);
     });
 
     it('emits an event when window is unmaximized', (done) => {


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/25051.

See that PR for more details.

Notes: Fix window size being changed after unmaximizing.