### PR TITLE
chore: force source code and markdown files to use LF line ending

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,13 @@
 # files to be checked out with LF endings even if core.autocrlf is true.
 *.patch text eol=lf
 patches/**/.patches merge=union
+
+# Source code and markdown files should always use LF as line ending.
+*.cc text eol=lf
+*.mm text eol=lf
+*.h text eol=lf
+*.js text eol=lf
+*.ts text eol=lf
+*.py text eol=lf
+*.ps1 text eol=lf
+*.md text eol=lf


### PR DESCRIPTION
#### Description of Change

Make sure source code and markdown files always have the correct line endings even when the contributor does not have a proper `core.autocrlf` setting.

#### Checklist

- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: none