### PR TITLE
fix: do not reset process_id in URLLoaderFactoryParams

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1506,15 +1506,10 @@ void ElectronBrowserClient::OverrideURLLoaderFactoryParams(
     const url::Origin& origin,
     bool is_for_isolated_world,
     network::mojom::URLLoaderFactoryParams* factory_params) {
-  for (const auto& iter : process_preferences_) {
-    if (iter.second.browser_context != browser_context)
-      continue;
-
-    if (!iter.second.web_security) {
-      // bypass CORB
-      factory_params->process_id = iter.first;
-      factory_params->is_corb_enabled = false;
-    }
+  // Bypass CORB when web security is disabled.
+  auto it = process_preferences_.find(factory_params->process_id);
+  if (it != process_preferences_.end() && !it->second.web_security) {
+    factory_params->is_corb_enabled = false;
   }
 
   extensions::URLLoaderFactoryManager::OverrideURLLoaderFactoryParams(

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -245,6 +245,14 @@ describe('web security', () => {
       <script src="${serverUrl}"></script>`);
     await p;
   });
+
+  it('does not crash when multiple WebContent are created with web security disabled', () => {
+    const options = { webPreferences: { webSecurity: false } };
+    const w1 = new BrowserWindow(options);
+    w1.loadURL(serverUrl);
+    const w2 = new BrowserWindow(options);
+    w2.loadURL(serverUrl);
+  });
 });
 
 describe('command line switches', () => {


### PR DESCRIPTION
#### Description of Change

Fix #24991.

In `OverrideURLLoaderFactoryParams` when disabling CORB, the `process_id` parameter was also changed.

This would cause a DCHECK assertion under certain cases (see https://github.com/electron/electron/issues/24991#issuecomment-680413218), and under Release build while the DHCECK assertion would be disabled, it would cause weird permission errors due to wrong process id being set (see https://github.com/electron/electron/issues/24991#issuecomment-677724346).

This behavior was introduced by https://github.com/electron/electron/pull/19488/commits/6d3e6abf9f43dab8773dd27c82333554ed55fca4 from https://github.com/electron/electron/pull/19488, according to its description, the purpose was to disable CORB when web security is disabled. The original change did need to set the `process_id` because it was constructing a new Param struct, but after later Chromium upgrades there was no longer need to set `process_id` because the method was changed to override the parameters instead of creating a new one.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fix network permission error when there are multiple WebContents sharing same session are created with web security disabled.