### PR TITLE
fix: prevent crash if BrowserView webContents was destroyed

### DIFF
--- a/shell/browser/api/electron_api_top_level_window.cc
+++ b/shell/browser/api/electron_api_top_level_window.cc
@@ -752,7 +752,8 @@ void TopLevelWindow::AddBrowserView(v8::Local<v8::Value> value) {
     auto get_that_view = browser_views_.find(browser_view->weak_map_id());
     if (get_that_view == browser_views_.end()) {
       window_->AddBrowserView(browser_view->view());
-      browser_view->web_contents()->SetOwnerWindow(window_.get());
+      if (browser_view->web_contents())
+        browser_view->web_contents()->SetOwnerWindow(window_.get());
       browser_views_[browser_view->weak_map_id()].Reset(isolate(), value);
     }
   }
@@ -765,8 +766,8 @@ void TopLevelWindow::RemoveBrowserView(v8::Local<v8::Value> value) {
     auto get_that_view = browser_views_.find(browser_view->weak_map_id());
     if (get_that_view != browser_views_.end()) {
       window_->RemoveBrowserView(browser_view->view());
-      browser_view->web_contents()->SetOwnerWindow(nullptr);
-
+      if (browser_view->web_contents())
+        browser_view->web_contents()->SetOwnerWindow(nullptr);
       (*get_that_view).second.Reset(isolate(), value);
       browser_views_.erase(get_that_view);
     }
@@ -1060,7 +1061,8 @@ void TopLevelWindow::ResetBrowserViews() {
                            &browser_view) &&
         !browser_view.IsEmpty()) {
       window_->RemoveBrowserView(browser_view->view());
-      browser_view->web_contents()->SetOwnerWindow(nullptr);
+      if (browser_view->web_contents())
+        browser_view->web_contents()->SetOwnerWindow(nullptr);
     }
 
     item.second.Reset();

--- a/shell/browser/api/electron_api_top_level_window.cc
+++ b/shell/browser/api/electron_api_top_level_window.cc
@@ -751,9 +751,10 @@ void TopLevelWindow::AddBrowserView(v8::Local<v8::Value> value) {
       gin::ConvertFromV8(isolate(), value, &browser_view)) {
     auto get_that_view = browser_views_.find(browser_view->weak_map_id());
     if (get_that_view == browser_views_.end()) {
-      window_->AddBrowserView(browser_view->view());
-      if (browser_view->web_contents())
+      if (browser_view->web_contents()) {
+        window_->AddBrowserView(browser_view->view());
         browser_view->web_contents()->SetOwnerWindow(window_.get());
+      }
       browser_views_[browser_view->weak_map_id()].Reset(isolate(), value);
     }
   }
@@ -765,9 +766,10 @@ void TopLevelWindow::RemoveBrowserView(v8::Local<v8::Value> value) {
       gin::ConvertFromV8(isolate(), value, &browser_view)) {
     auto get_that_view = browser_views_.find(browser_view->weak_map_id());
     if (get_that_view != browser_views_.end()) {
-      window_->RemoveBrowserView(browser_view->view());
-      if (browser_view->web_contents())
+      if (browser_view->web_contents()) {
+        window_->RemoveBrowserView(browser_view->view());
         browser_view->web_contents()->SetOwnerWindow(nullptr);
+      }
       (*get_that_view).second.Reset(isolate(), value);
       browser_views_.erase(get_that_view);
     }
@@ -1060,9 +1062,10 @@ void TopLevelWindow::ResetBrowserViews() {
                            v8::Local<v8::Value>::New(isolate(), item.second),
                            &browser_view) &&
         !browser_view.IsEmpty()) {
-      window_->RemoveBrowserView(browser_view->view());
-      if (browser_view->web_contents())
+      if (browser_view->web_contents()) {
         browser_view->web_contents()->SetOwnerWindow(nullptr);
+        window_->RemoveBrowserView(browser_view->view());
+      }
     }
 
     item.second.Reset();

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -634,7 +634,8 @@ WebContents::~WebContents() {
     } else {
       // Destroy WebContents asynchronously unless app is shutting down,
       // because destroy() might be called inside WebContents's event handler.
-      DestroyWebContents(!IsGuest() /* async */);
+      bool is_browser_view = type_ == Type::BROWSER_VIEW;
+      DestroyWebContents(!(IsGuest() || is_browser_view) /* async */);
       // The WebContentsDestroyed will not be called automatically because we
       // destroy the webContents in the next tick. So we have to manually
       // call it here to make sure "destroyed" event is emitted.

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1252,12 +1252,15 @@ void NativeWindowMac::AddBrowserView(NativeBrowserView* view) {
   }
 
   add_browser_view(view);
-  auto* native_view =
-      view->GetInspectableWebContentsView()->GetNativeView().GetNativeNSView();
-  [[window_ contentView] addSubview:native_view
-                         positioned:NSWindowAbove
-                         relativeTo:nil];
-  native_view.hidden = NO;
+  if (view->GetInspectableWebContentsView()) {
+    auto* native_view = view->GetInspectableWebContentsView()
+                            ->GetNativeView()
+                            .GetNativeNSView();
+    [[window_ contentView] addSubview:native_view
+                           positioned:NSWindowAbove
+                           relativeTo:nil];
+    native_view.hidden = NO;
+  }
 
   [CATransaction commit];
 }
@@ -1271,8 +1274,9 @@ void NativeWindowMac::RemoveBrowserView(NativeBrowserView* view) {
     return;
   }
 
-  [view->GetInspectableWebContentsView()->GetNativeView().GetNativeNSView()
-      removeFromSuperview];
+  if (view->GetInspectableWebContentsView())
+    [view->GetInspectableWebContentsView()->GetNativeView().GetNativeNSView()
+        removeFromSuperview];
   remove_browser_view(view);
 
   [CATransaction commit];

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1069,9 +1069,9 @@ void NativeWindowViews::AddBrowserView(NativeBrowserView* view) {
   }
 
   add_browser_view(view);
-
-  content_view()->AddChildView(
-      view->GetInspectableWebContentsView()->GetView());
+  if (view->GetInspectableWebContentsView())
+    content_view()->AddChildView(
+        view->GetInspectableWebContentsView()->GetView());
 }
 
 void NativeWindowViews::RemoveBrowserView(NativeBrowserView* view) {
@@ -1082,8 +1082,9 @@ void NativeWindowViews::RemoveBrowserView(NativeBrowserView* view) {
     return;
   }
 
-  content_view()->RemoveChildView(
-      view->GetInspectableWebContentsView()->GetView());
+  if (view->GetInspectableWebContentsView())
+    content_view()->RemoveChildView(
+        view->GetInspectableWebContentsView()->GetView());
   remove_browser_view(view);
 }
 

--- a/spec-main/api-browser-view-spec.ts
+++ b/spec-main/api-browser-view-spec.ts
@@ -140,20 +140,31 @@ describe('BrowserView module', () => {
       view1.destroy();
       view2.destroy();
     });
+
     it('does not throw if called multiple times with same view', () => {
       view = new BrowserView();
       w.addBrowserView(view);
       w.addBrowserView(view);
       w.addBrowserView(view);
     });
+
+    it('does not crash if the BrowserView webContents are destroyed prior to window removal', () => {
+      expect(() => {
+        const view1 = new BrowserView();
+        (view1.webContents as any).destroy();
+        w.addBrowserView(view1);
+      }).to.not.throw();
+    });
   });
 
   describe('BrowserWindow.removeBrowserView()', () => {
     it('does not throw if called multiple times with same view', () => {
-      view = new BrowserView();
-      w.addBrowserView(view);
-      w.removeBrowserView(view);
-      w.removeBrowserView(view);
+      expect(() => {
+        view = new BrowserView();
+        w.addBrowserView(view);
+        w.removeBrowserView(view);
+        w.removeBrowserView(view);
+      }).to.not.throw();
     });
   });
 


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/25112.

See that PR for more details.

Notes: none