### PR TITLE
docs: fix supported platforms of powerMonitor

### DIFF
--- a/docs/api/power-monitor.md
+++ b/docs/api/power-monitor.md
@@ -8,19 +8,19 @@ Process: [Main](../glossary.md#main-process)
 
 The `powerMonitor` module emits the following events:
 
-### Event: 'suspend'
+### Event: 'suspend' _macOS_ _Windows_
 
 Emitted when the system is suspending.
 
-### Event: 'resume'
+### Event: 'resume' _macOS_ _Windows_
 
 Emitted when system is resuming.
 
-### Event: 'on-ac' _Windows_
+### Event: 'on-ac' _macOS_ _Windows_
 
 Emitted when the system changes to AC power.
 
-### Event: 'on-battery' _Windows_
+### Event: 'on-battery' _macOS_  _Windows_
 
 Emitted when system changes to battery power.
 


### PR DESCRIPTION
#### Description of Change

The `resume/suspend/on-ac/on-battery` events are only implemented on macOS and Windows, currently we don't have a Linux implementation.

#### Release Notes

Notes: none