### PR TITLE
fix: allow extensions to access local files

### DIFF
--- a/shell/browser/extensions/electron_extension_loader.cc
+++ b/shell/browser/extensions/electron_extension_loader.cc
@@ -37,7 +37,8 @@ std::pair<scoped_refptr<const Extension>, std::string> LoadUnpacked(
     return std::make_pair(nullptr, err);
   }
 
-  int load_flags = Extension::FOLLOW_SYMLINKS_ANYWHERE;
+  int load_flags =
+      Extension::FOLLOW_SYMLINKS_ANYWHERE | Extension::ALLOW_FILE_ACCESS;
   std::string load_error;
   scoped_refptr<Extension> extension = file_util::LoadExtension(
       extension_dir, Manifest::COMMAND_LINE, load_flags, &load_error);


### PR DESCRIPTION
#### Description of Change

Allows file access for _all extensions_ (except probably the pdf viewer which is created separately).

This is how it was pre-9, until 9.0.0 broke react devtools on local `file://` urls (#24011). 

I'm not sure if this is a good solution.
An alternative would be to add an explicit opt-in to `loadExtension()`, but that would require API changes.

I would actually prefer an explicit opt-in over this, but I didn't heard a feedback on https://github.com/electron/electron/issues/24011#issuecomment-674316115, and this is a far easier change, so I started with this first. Hence a draft until there is a resolution on which approach should be followed.

Fixes: #24011.

Confirmed that react-devtools now works over `file://` with this patch.

cc @nornagon @samuelmaddock @RangerMauve

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.
- ~`npm test` passes~ can't test locally, tests are hardcoded to expect CI env, see https://github.com/electron/electron/pull/25151#issuecomment-681536581
- ~tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)~

#### Release Notes

Notes: Fixed extensions access to `file://` protocol to unbreak react-devtools.