### PR TITLE
fix: resolve RegisterSuspendResumeNotification dynamically

### DIFF
--- a/shell/browser/api/electron_api_power_monitor_win.cc
+++ b/shell/browser/api/electron_api_power_monitor_win.cc
@@ -8,7 +8,6 @@
 #include <wtsapi32.h>
 
 #include "base/win/windows_types.h"
-#include "base/win/windows_version.h"
 #include "base/win/wrapped_window_proc.h"
 #include "ui/base/win/shell.h"
 #include "ui/gfx/win/hwnd_util.h"
@@ -44,7 +43,12 @@ void PowerMonitor::InitPlatformSpecificMonitors() {
 
   // For Windows 8 and later, a new "connected standy" mode has been added and
   // we must explicitly register for its notifications.
-  if (base::win::GetVersion() >= base::win::Version::WIN8) {
+  auto RegisterSuspendResumeNotification =
+      reinterpret_cast<decltype(&::RegisterSuspendResumeNotification)>(
+          GetProcAddress(GetModuleHandle(L"user32.dll"),
+                         "RegisterSuspendResumeNotification"));
+
+  if (RegisterSuspendResumeNotification) {
     RegisterSuspendResumeNotification(static_cast<HANDLE>(window_),
                                       DEVICE_NOTIFY_WINDOW_HANDLE);
   }


### PR DESCRIPTION
#### Description of Change
Fix Electron not working on Windows 7 after https://github.com/electron/electron/pull/25076
<img width="475" alt="Screen Shot 2020-08-27 at 4 49 39 PM" src="https://user-images.githubusercontent.com/1281234/91458098-6a4dcf00-e885-11ea-8e2c-074bc18da683.png">

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes
Notes: Fixed Electron not working on Windows 7 after https://github.com/electron/electron/pull/25076