### PR TITLE
fix: save dialog extensions should be deterministic

### DIFF
--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -90,7 +90,8 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
 
   // Create array to keep file types and their name.
   for (const Filter& filter : filters) {
-    NSMutableSet* file_type_set = [NSMutableSet set];
+    NSMutableOrderedSet* file_type_set =
+        [NSMutableOrderedSet orderedSetWithCapacity:filters.size()];
     [filter_names addObject:@(filter.first.c_str())];
     for (std::string ext : filter.second) {
       // macOS is incapable of understanding multiple file extensions,
@@ -104,7 +105,7 @@ void SetAllowedFileTypes(NSSavePanel* dialog, const Filters& filters) {
 
       [file_type_set addObject:@(ext.c_str())];
     }
-    [file_types_list addObject:[file_type_set allObjects]];
+    [file_types_list addObject:[file_type_set array]];
   }
 
   // Passing empty array to setAllowedFileTypes will cause exception.


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/25152.

The extensions were being added to an `NSMutableSet` previously, which caused nondeterministic ordering for the first one to appear in the UI when the dialog appeared. This fixes that by leveraging `NSOrderedMutableSet` to maintain ordering.

cc @jkleinsc @zcbenz @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: Fixed an issue where filters set in dialogs on macOS would have nondeterministic ordering.