### PR TITLE
chore: wrap add/remove view in extra check

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -744,9 +744,10 @@ void BaseWindow::AddBrowserView(v8::Local<v8::Value> value) {
       gin::ConvertFromV8(isolate(), value, &browser_view)) {
     auto get_that_view = browser_views_.find(browser_view->ID());
     if (get_that_view == browser_views_.end()) {
-      window_->AddBrowserView(browser_view->view());
-      if (browser_view->web_contents())
+      if (browser_view->web_contents()) {
+        window_->AddBrowserView(browser_view->view());
         browser_view->web_contents()->SetOwnerWindow(window_.get());
+      }
       browser_views_[browser_view->ID()].Reset(isolate(), value);
     }
   }
@@ -758,9 +759,10 @@ void BaseWindow::RemoveBrowserView(v8::Local<v8::Value> value) {
       gin::ConvertFromV8(isolate(), value, &browser_view)) {
     auto get_that_view = browser_views_.find(browser_view->ID());
     if (get_that_view != browser_views_.end()) {
-      window_->RemoveBrowserView(browser_view->view());
-      if (browser_view->web_contents())
+      if (browser_view->web_contents()) {
+        window_->RemoveBrowserView(browser_view->view());
         browser_view->web_contents()->SetOwnerWindow(nullptr);
+      }
       (*get_that_view).second.Reset(isolate(), value);
       browser_views_.erase(get_that_view);
     }
@@ -1055,9 +1057,10 @@ void BaseWindow::ResetBrowserViews() {
                            v8::Local<v8::Value>::New(isolate(), item.second),
                            &browser_view) &&
         !browser_view.IsEmpty()) {
-      window_->RemoveBrowserView(browser_view->view());
-      if (browser_view->web_contents())
+      if (browser_view->web_contents()) {
         browser_view->web_contents()->SetOwnerWindow(nullptr);
+        window_->RemoveBrowserView(browser_view->view());
+      }
     }
 
     item.second.Reset();


### PR DESCRIPTION
#### Description of Change

Refs a flaky crash seen [here](https://ci.appveyor.com/project/electron-bot/electron-ljo26/builds/34854895#L39127)

Move `BaseWindow` invocations of  `window_->[Add|Remove}BrowserView(browser_view->view());` into checks for `browser_view->web_contents()` not having been destroyed.

cc @jkleinsc 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [x] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: none
