### PR TITLE
fix: make shell.moveItemToTrash return false on Windows when move is unsuccessful

### DIFF
--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -12,6 +12,7 @@
 #include "base/nix/xdg_util.h"
 #include "base/process/kill.h"
 #include "base/process/launch.h"
+#include "base/threading/thread_restrictions.h"
 #include "ui/gtk/gtk_util.h"
 #include "url/gurl.h"
 
@@ -51,6 +52,8 @@ bool XDGUtil(const std::vector<std::string>& argv,
     return false;
 
   if (wait_for_exit) {
+    base::ScopedAllowBaseSyncPrimitivesForTesting
+        allow_sync;  // required by WaitForExit
     int exit_code = -1;
     bool success = process.WaitForExit(&exit_code);
     if (!callback.is_null())

--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -387,10 +387,14 @@ bool MoveItemToTrash(const base::FilePath& path, bool delete_on_fail) {
   if (!delete_sink)
     return false;
 
+  BOOL pfAnyOperationsAborted;
+
   // Processes the queued command DeleteItem. This will trigger
   // the DeleteFileProgressSink to check for Recycle Bin.
   return SUCCEEDED(pfo->DeleteItem(delete_item.Get(), delete_sink.Get())) &&
-         SUCCEEDED(pfo->PerformOperations());
+         SUCCEEDED(pfo->PerformOperations()) &&
+         SUCCEEDED(pfo->GetAnyOperationsAborted(&pfAnyOperationsAborted)) &&
+         !pfAnyOperationsAborted;
 }
 
 bool GetFolderPath(int key, base::FilePath* result) {

--- a/spec-main/api-shell-spec.ts
+++ b/spec-main/api-shell-spec.ts
@@ -1,9 +1,12 @@
-import { BrowserWindow } from 'electron/main';
+import { BrowserWindow, app } from 'electron/main';
 import { shell } from 'electron/common';
 import { closeAllWindows } from './window-helpers';
 import { emittedOnce } from './events-helpers';
 import * as http from 'http';
+import * as fs from 'fs-extra';
+import * as path from 'path';
 import { AddressInfo } from 'net';
+import { expect } from 'chai';
 
 describe('shell module', () => {
   describe('shell.openExternal()', () => {
@@ -55,6 +58,23 @@ describe('shell module', () => {
         shell.openExternal(url),
         requestReceived
       ]);
+    });
+  });
+
+  describe('shell.moveItemToTrash()', () => {
+    it('moves an item to the trash', async () => {
+      const dir = await fs.mkdtemp(path.resolve(app.getPath('temp'), 'electron-shell-spec-'));
+      const filename = path.join(dir, 'temp-to-be-deleted');
+      await fs.writeFile(filename, 'dummy-contents');
+      const result = shell.moveItemToTrash(filename);
+      expect(result).to.be.true();
+      expect(fs.existsSync(filename)).to.be.false();
+    });
+
+    it('returns false when called with a nonexistent path', () => {
+      const filename = path.join(app.getPath('temp'), 'does-not-exist');
+      const result = shell.moveItemToTrash(filename);
+      expect(result).to.be.false();
     });
   });
 });


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Backport of #25113 
Backport of #25124

#### Release Notes

Notes: Fixed shell.moveItemToTrash on Windows so that it returns false when move was unsuccessful.