### PR TITLE
fix: make shell.moveItemToTrash return false on Windows when move is unsuccessful

### DIFF
--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -387,10 +387,14 @@ bool MoveItemToTrash(const base::FilePath& path, bool delete_on_fail) {
   if (!delete_sink)
     return false;
 
+  BOOL pfAnyOperationsAborted;
+
   // Processes the queued command DeleteItem. This will trigger
   // the DeleteFileProgressSink to check for Recycle Bin.
   return SUCCEEDED(pfo->DeleteItem(delete_item.Get(), delete_sink.Get())) &&
-         SUCCEEDED(pfo->PerformOperations());
+         SUCCEEDED(pfo->PerformOperations()) &&
+         SUCCEEDED(pfo->GetAnyOperationsAborted(&pfAnyOperationsAborted)) &&
+         !pfAnyOperationsAborted;
 }
 
 bool GetFolderPath(int key, base::FilePath* result) {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Backport of #25124

#### Release Notes

Notes: Fixed shell.moveItemToTrash on Windows so that it returns false when move was unsuccessful.