### PR TITLE
fix: do not reset process_id in URLLoaderFactoryParams

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1090,10 +1090,9 @@ void ElectronBrowserClient::OverrideURLLoaderFactoryParams(
     content::RenderProcessHost* process,
     const url::Origin& origin,
     network::mojom::URLLoaderFactoryParams* factory_params) {
-  const auto& iter = process_preferences_.find(process->GetID());
-  if (iter != process_preferences_.end() && !iter->second.web_security) {
-    // bypass CORB
-    factory_params->process_id = iter->first;
+  // Bypass CORB when web security is disabled.
+  auto it = process_preferences_.find(factory_params->process_id);
+  if (it != process_preferences_.end() && !it->second.web_security) {
     factory_params->is_corb_enabled = false;
   }
 }

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -277,6 +277,14 @@ describe('web security', () => {
       <script src="${serverUrl}"></script>`)
     await p
   })
+
+  it('does not crash when multiple WebContent are created with web security disabled', () => {
+    const options = { webPreferences: { webSecurity: false } }
+    const w1 = new BrowserWindow(options)
+    w1.loadURL(serverUrl)
+    const w2 = new BrowserWindow(options)
+    w2.loadURL(serverUrl)
+  })
 })
 
 describe('command line switches', () => {


### PR DESCRIPTION
Backport of #25139

See that PR for details.

Notes: Fix network permission error when there are multiple WebContents sharing same session are created with web security disabled.