### PR TITLE
Add context to ipcRenderer docs

### DIFF
--- a/docs/tutorial/context-isolation.md
+++ b/docs/tutorial/context-isolation.md
@@ -68,3 +68,6 @@ contextBridge.exposeInMainWorld('myAPI', {
 })
 ```
 
+The reason arbitary IPC messages are insecure is because electron uses `ipcRenderer` internally for communication. You only
+want to expose the IPC messages important for your app, not the electron internals.
+


### PR DESCRIPTION
It was not clear to me why exposing `invoke()` was bad but exposes a function that does `invoke('api', commandName)` was good.

My app has many IPC commands and writing explicit messages that whitelist each one is tedious and boilerplatey. It took me a while to understand that electron also uses `ipcRenderer` internally and that it's that which needs protection for security reasons.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
- [ ] This is **NOT A BREAKING CHANGE**. Breaking changes may not be merged to master until 11-x-y is branched.

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
