### PR TITLE
chore: cherry-pick 44bb4d7abee6 from angle

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -1,0 +1,1 @@
+d3d11_fix_bug_with_static_vertex_attributes.patch

--- a/patches/angle/d3d11_fix_bug_with_static_vertex_attributes.patch
+++ b/patches/angle/d3d11_fix_bug_with_static_vertex_attributes.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jamie Madill <jmadill@chromium.org>
+Date: Wed, 22 Jul 2020 13:58:50 -0400
+Subject: D3D11: Fix bug with static vertex attributes.
+
+In some specific cases after binding a zero size buffer we could end
+up trying to use a buffer storage that was no longer valid. Fix this
+by ensuring we don't flush dirty bits when we have an early exit due
+to a zero size buffer.
+
+Also adds a regression test.
+
+Bug: chromium:1107433
+Change-Id: I9db560e8dd3699abed2bb7fe6d91060148ba1817
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/2314216
+Commit-Queue: Jamie Madill <jmadill@chromium.org>
+Reviewed-by: Geoff Lang <geofflang@chromium.org>
+
+diff --git a/src/libANGLE/renderer/d3d/d3d11/VertexArray11.cpp b/src/libANGLE/renderer/d3d/d3d11/VertexArray11.cpp
+index 5f834b5c8dbc63d3bcc374eca15a17ee442d77e3..b0e27c9f0c6c316fe347a44776a6926b093a81c4 100644
+--- a/src/libANGLE/renderer/d3d/d3d11/VertexArray11.cpp
++++ b/src/libANGLE/renderer/d3d/d3d11/VertexArray11.cpp
+@@ -250,8 +250,6 @@ angle::Result VertexArray11::updateDirtyAttribs(const gl::Context *context,
+ 
+     for (size_t dirtyAttribIndex : activeDirtyAttribs)
+     {
+-        mAttribsToTranslate.reset(dirtyAttribIndex);
+-
+         auto *translatedAttrib   = &mTranslatedAttribs[dirtyAttribIndex];
+         const auto &currentValue = glState.getVertexAttribCurrentValue(dirtyAttribIndex);
+ 
+@@ -279,6 +277,9 @@ angle::Result VertexArray11::updateDirtyAttribs(const gl::Context *context,
+                 UNREACHABLE();
+                 break;
+         }
++
++        // Make sure we reset the dirty bit after the switch because STATIC can early exit.
++        mAttribsToTranslate.reset(dirtyAttribIndex);
+     }
+ 
+     return angle::Result::Continue;

--- a/patches/config.json
+++ b/patches/config.json
@@ -13,5 +13,7 @@
 
   "src/electron/patches/skia": "src/third_party/skia",
 
+  "src/electron/patches/angle": "src/third_party/angle",
+
   "src/electron/patches/ffmpeg": "src/third_party/ffmpeg"
 }


### PR DESCRIPTION
D3D11: Fix bug with static vertex attributes.

In some specific cases after binding a zero size buffer we could end
up trying to use a buffer storage that was no longer valid. Fix this
by ensuring we don't flush dirty bits when we have an early exit due
to a zero size buffer.

Also adds a regression test.

Bug: chromium:1107433
Change-Id: I9db560e8dd3699abed2bb7fe6d91060148ba1817
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/2314216
Commit-Queue: Jamie Madill <jmadill@chromium.org>
Reviewed-by: Geoff Lang <geofflang@chromium.org>

Notes: Security: backported fix for 1107433.