### PR TITLE
revert: "fix: reply notifs sometimes destroyed too early"

### DIFF
--- a/shell/browser/notifications/mac/notification_center_delegate.mm
+++ b/shell/browser/notifications/mac/notification_center_delegate.mm
@@ -43,10 +43,7 @@
     // https://developer.apple.com/documentation/foundation/nsusernotificationactivationtype?language=objc
     if (notif.activationType ==
         NSUserNotificationActivationTypeContentsClicked) {
-      // If a notification with a reply button is clicked and the user has not
-      // yet replied, we do not want to destroy the notification.
-      bool should_destroy = ![notif hasReplyButton];
-      notification->NotificationClicked(should_destroy);
+      notification->NotificationClicked();
     } else if (notif.activationType ==
                NSUserNotificationActivationTypeActionButtonClicked) {
       notification->NotificationActivated();

--- a/shell/browser/notifications/notification.cc
+++ b/shell/browser/notifications/notification.cc
@@ -21,12 +21,10 @@ Notification::~Notification() {
     delegate()->NotificationDestroyed();
 }
 
-void Notification::NotificationClicked(bool should_destroy) {
+void Notification::NotificationClicked() {
   if (delegate())
     delegate()->NotificationClick();
-
-  if (should_destroy)
-    Destroy();
+  Destroy();
 }
 
 void Notification::NotificationDismissed() {

--- a/shell/browser/notifications/notification.h
+++ b/shell/browser/notifications/notification.h
@@ -54,7 +54,7 @@ class Notification {
   virtual void Dismiss() = 0;
 
   // Should be called by derived classes.
-  void NotificationClicked(bool should_destroy = true);
+  void NotificationClicked();
   void NotificationDismissed();
   void NotificationFailed();
 

--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -476,7 +476,7 @@ IFACEMETHODIMP ToastEventHandler::Invoke(
     IInspectable* args) {
   base::PostTask(
       FROM_HERE, {content::BrowserThread::UI},
-      base::BindOnce(&Notification::NotificationClicked, notification_, true));
+      base::BindOnce(&Notification::NotificationClicked, notification_));
   if (IsDebuggingNotifications())
     LOG(INFO) << "Notification clicked";
 


### PR DESCRIPTION
Reverts electron/electron#25086

Notes: Fixed issue where clicking notifications would no longer dismiss them as expected