### PR TITLE
feat: [crashReporter] enable compression by default

### DIFF
--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -59,7 +59,7 @@ The `crashReporter` module has the following methods:
   * `rateLimit` Boolean (optional) _macOS_ _Windows_ - If true, limit the
     number of crashes uploaded to 1/hour. Default is `false`.
   * `compress` Boolean (optional) - If true, crash reports will be compressed
-    and uploaded with `Content-Encoding: gzip`. Default is `false`.
+    and uploaded with `Content-Encoding: gzip`. Default is `true`.
   * `extra` Record<String, String> (optional) - Extra string key/value
     annotations that will be sent along with crash reports that are generated
     in the main process. Only string values are supported. Crashes generated in

--- a/lib/browser/api/crash-reporter.ts
+++ b/lib/browser/api/crash-reporter.ts
@@ -13,7 +13,7 @@ class CrashReporter {
       submitURL,
       uploadToServer = true,
       rateLimit = false,
-      compress = false
+      compress = true
     } = options || {};
 
     if (submitURL == null) throw new Error('submitURL is a required option to crashReporter.start');

--- a/spec-main/api-crash-reporter-spec.ts
+++ b/spec-main/api-crash-reporter-spec.ts
@@ -232,6 +232,7 @@ ifdescribe(!isLinuxOnArm && !process.mas && !process.env.DISABLE_CRASH_REPORTER_
         await remotely((port: number) => {
           require('electron').crashReporter.start({
             submitURL: `http://127.0.0.1:${port}`,
+            compress: false,
             ignoreSystemCrashHandler: true
           });
         }, [port]);
@@ -271,6 +272,7 @@ ifdescribe(!isLinuxOnArm && !process.mas && !process.env.DISABLE_CRASH_REPORTER_
       remotely((port: number) => {
         require('electron').crashReporter.start({
           submitURL: `http://127.0.0.1:${port}`,
+          compress: false,
           ignoreSystemCrashHandler: true,
           extra: { longParam: 'a'.repeat(100000) }
         });
@@ -287,6 +289,7 @@ ifdescribe(!isLinuxOnArm && !process.mas && !process.env.DISABLE_CRASH_REPORTER_
       remotely((port: number, kKeyLengthMax: number) => {
         require('electron').crashReporter.start({
           submitURL: `http://127.0.0.1:${port}`,
+          compress: false,
           ignoreSystemCrashHandler: true,
           extra: {
             ['a'.repeat(kKeyLengthMax + 10)]: 'value',
@@ -399,6 +402,7 @@ ifdescribe(!isLinuxOnArm && !process.mas && !process.env.DISABLE_CRASH_REPORTER_
       await remotely((port: number) => {
         require('electron').crashReporter.start({
           submitURL: `http://127.0.0.1:${port}`,
+          compress: false,
           ignoreSystemCrashHandler: true
         });
       }, [port]);

--- a/spec-main/fixtures/apps/crash/main.js
+++ b/spec-main/fixtures/apps/crash/main.js
@@ -12,6 +12,7 @@ const addGlobalParam = app.commandLine.getSwitchValue('add-global-param')?.split
 crashReporter.start({
   productName: 'Zombies',
   companyName: 'Umbrella Corporation',
+  compress: false,
   uploadToServer,
   submitURL: url,
   ignoreSystemCrashHandler: true,

--- a/spec-main/fixtures/apps/crash/node-crash.js
+++ b/spec-main/fixtures/apps/crash/node-crash.js
@@ -2,6 +2,7 @@ if (process.platform === 'linux') {
   process.crashReporter.start({
     submitURL: process.argv[2],
     productName: 'Zombies',
+    compress: false,
     globalExtra: {
       _version: process.argv[3]
     }


### PR DESCRIPTION
#### Description of Change
This is already written up in the planned breaking changes for 12.0.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Changed the default of `crashReporter.start({ compress })` from `false` to `true`.