### PR TITLE
docs: update menu example to avoid remote

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -141,13 +141,7 @@ can have a submenu.
 
 ## Examples
 
-The `Menu` class is only available in the main process, but you can also use it
-in the render process via the [`remote`](remote.md) module.
-
-### Main process
-
-An example of creating the application menu in the main process with the
-simple template API:
+An example of creating the application menu with the simple template API:
 
 ```javascript
 const { app, Menu } = require('electron')
@@ -257,26 +251,60 @@ Menu.setApplicationMenu(menu)
 
 ### Render process
 
-Below is an example of creating a menu dynamically in a web page
-(render process) by using the [`remote`](remote.md) module, and showing it when
-the user right clicks the page:
+To create menus initiated by the renderer process, send the required
+information to the main process using IPC and have the main process display the
+menu on behalf of the renderer.
+
+Below is an example of creating a menu with dynamic information in a web page,
+and showing it when the user right clicks the page:
 
 ```html
 <!-- index.html -->
 <script>
-const { remote } = require('electron')
-const { Menu, MenuItem } = remote
-
-const menu = new Menu()
-menu.append(new MenuItem({ label: 'MenuItem1', click() { console.log('item 1 clicked') } }))
-menu.append(new MenuItem({ type: 'separator' }))
-menu.append(new MenuItem({ label: 'MenuItem2', type: 'checkbox', checked: true }))
+const { ipcRenderer } = require('electron')
 
 window.addEventListener('contextmenu', (e) => {
   e.preventDefault()
-  menu.popup({ window: remote.getCurrentWindow() })
-}, false)
+  const template = [
+    { label: 'Menu Item 1', id: 'menu-item-1' },
+    { type: 'separator' },
+    { label: 'Menu Item 2', type: 'checkbox', checked: true, id: 'menu-item-2' },
+  ]
+  ipcRenderer.invoke('show-menu', template).then((clickedId) => {
+    if (clickedId === 'menu-item-1') {
+      console.log('item 1 clicked')
+    }
+  })
+})
 </script>
+```
+
+```js
+// main.js
+const { BrowserWindow, ipcMain, Menu } = require('electron')
+
+ipcMain.handle('show-menu', (event, template) => {
+  const menu = Menu.buildFromTemplate(template)
+  menu.popup(BrowserWindow.fromWebContents(event.sender))
+  return new Promise((resolve, reject) => {
+    function handleClicks (menu) {
+      for (const item of menu.items) {
+        if (item.id) {
+          item.click = () => resolve(item.id)
+        }
+        if (item.submenu) {
+          handleClicks(item.submenu)
+        }
+      }
+    }
+    handleClicks(menu)
+    menu.on('menu-will-close', () => {
+      // This event is emitted before the 'click' callback above is called, so
+      // wait until the next tick before signaling that the menu was dismissed.
+      setTimeout(() => resolve(null))
+    })
+  })
+})
 ```
 
 ## Notes on macOS Application Menu

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -260,9 +260,9 @@ Below is an example of showing a menu when the user right clicks the page:
 ```js
 // renderer
 window.addEventListener('contextmenu', (e) => {
-   e.preventDefault()
-   ipcRenderer.send('show-context-menu')
- })
+  e.preventDefault()
+  ipcRenderer.send('show-context-menu')
+})
 
 ipcRenderer.on('context-menu-command', (e, command) => {
   // ...
@@ -271,10 +271,12 @@ ipcRenderer.on('context-menu-command', (e, command) => {
 // main
 ipcMain.on('show-context-menu', (event) => {
   const template = [
-    { label: 'Menu Item 1',
-      click: () => { event.sender.send('context-menu-command', 'menu-item-1') } },
+    {
+      label: 'Menu Item 1',
+      click: () => { event.sender.send('context-menu-command', 'menu-item-1') }
+    },
     { type: 'separator' },
-    { label: 'Menu Item 2', type: 'checkbox', checked: true },
+    { label: 'Menu Item 2', type: 'checkbox', checked: true }
   ]
   const menu = Menu.buildFromTemplate(template)
   menu.popup(BrowserWindow.fromWebContents(event.sender))


### PR DESCRIPTION
#### Description of Change
Replaced with an example using `ipcRenderer.invoke()`.

I'm not thrilled with this example, but the `Menu` API as it is leaves little choice. This would be much easier with an API like `Menu.on('item-clicked')` and `Menu.on('did-close-menu')`.

Ref https://github.com/electron/electron/issues/21408#issuecomment-674519033

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none