### PR TITLE
fix: only focus a webContents if the window was not initially hidden

### DIFF
--- a/lib/browser/api/browser-window.ts
+++ b/lib/browser/api/browser-window.ts
@@ -28,9 +28,11 @@ Object.setPrototypeOf(BrowserWindow.prototype, BaseWindow.prototype);
   // Though this hack is only needed on macOS when the app is launched from
   // Finder, we still do it on all platforms in case of other bugs we don't
   // know.
-  this.webContents.once('load-url' as any, function (this: WebContents) {
-    this.focus();
-  });
+  if (this.webContents._initiallyShown) {
+    this.webContents.once('load-url' as any, function (this: WebContents) {
+      this.focus();
+    });
+  }
 
   // Redirect focus/blur event to app instance too.
   this.on('blur', (event: Event) => {

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -474,8 +474,8 @@ WebContents::WebContents(v8::Isolate* isolate,
   // BrowserViews are not attached to a window initially so they should start
   // off as hidden. This is also important for compositor recycling. See:
   // https://github.com/electron/electron/pull/21372
-  bool initially_shown = type_ != Type::BROWSER_VIEW;
-  options.Get(options::kShow, &initially_shown);
+  initially_shown_ = type_ != Type::BROWSER_VIEW;
+  options.Get(options::kShow, &initially_shown_);
 
   // Obtain the session.
   std::string partition;
@@ -531,7 +531,7 @@ WebContents::WebContents(v8::Isolate* isolate,
 #endif
   } else {
     content::WebContents::CreateParams params(session->browser_context());
-    params.initially_hidden = !initially_shown;
+    params.initially_hidden = !initially_shown_;
     web_contents = content::WebContents::Create(params);
   }
 
@@ -2732,6 +2732,10 @@ v8::Local<v8::Value> WebContents::Debugger(v8::Isolate* isolate) {
   return v8::Local<v8::Value>::New(isolate, debugger_);
 }
 
+bool WebContents::WasInitiallyShown() {
+  return initially_shown_;
+}
+
 void WebContents::GrantOriginAccess(const GURL& url) {
   content::ChildProcessSecurityPolicy::GetInstance()->GrantCommitOrigin(
       web_contents()->GetMainFrame()->GetProcess()->GetID(),
@@ -2925,6 +2929,7 @@ v8::Local<v8::ObjectTemplate> WebContents::FillObjectTemplate(
       .SetProperty("hostWebContents", &WebContents::HostWebContents)
       .SetProperty("devToolsWebContents", &WebContents::DevToolsWebContents)
       .SetProperty("debugger", &WebContents::Debugger)
+      .SetProperty("_initiallyShown", &WebContents::WasInitiallyShown)
       .Build();
 }
 

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -393,6 +393,7 @@ class WebContents : public gin::Wrappable<WebContents>,
   content::WebContents* HostWebContents() const;
   v8::Local<v8::Value> DevToolsWebContents(v8::Isolate* isolate);
   v8::Local<v8::Value> Debugger(v8::Isolate* isolate);
+  bool WasInitiallyShown();
 
   WebContentsZoomController* GetZoomController() { return zoom_controller_; }
 
@@ -682,6 +683,8 @@ class WebContents : public gin::Wrappable<WebContents>,
 
   // Observers of this WebContents.
   base::ObserverList<ExtendedWebContentsObserver> observers_;
+
+  bool initially_shown_ = true;
 
   // The ID of the process of the currently committed RenderViewHost.
   // -1 means no speculative RVH has been committed yet.

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -56,6 +56,7 @@ declare namespace Electron {
     getLastWebPreferences(): Electron.WebPreferences;
     _getPreloadPaths(): string[];
     equal(other: WebContents): boolean;
+    _initiallyShown: boolean;
   }
 
   interface WebPreferences {


### PR DESCRIPTION
Fixes #25287

Notes: Fixed an issue where `document.hasFocus` and `document.activeElement` would be inconsistent upon showing a window that was initially created with `show: false`