### PR TITLE
fix: bind fake mojo service for badging

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -97,6 +97,7 @@
 #include "shell/common/options_switches.h"
 #include "shell/common/platform_util.h"
 #include "third_party/blink/public/common/loader/url_loader_throttle.h"
+#include "third_party/blink/public/mojom/badging/badging.mojom.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "ui/native_theme/native_theme.h"
 #include "v8/include/v8.h"
@@ -1573,6 +1574,12 @@ void ElectronBrowserClient::BindHostReceiverForRenderer(
 #endif
 }
 
+void BindBadgeManagerFrameReceiver(
+    content::RenderFrameHost* frame,
+    mojo::PendingReceiver<blink::mojom::BadgeService> receiver) {
+  LOG(WARNING) << "The Chromium Badging API is not available in Electron";
+}
+
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
 void BindMimeHandlerService(
     content::RenderFrameHost* frame_host,
@@ -1609,6 +1616,8 @@ void ElectronBrowserClient::RegisterBrowserInterfaceBindersForFrame(
     mojo::BinderMapWithContext<content::RenderFrameHost*>* map) {
   map->Add<network_hints::mojom::NetworkHintsHandler>(
       base::BindRepeating(&BindNetworkHintsHandler));
+  map->Add<blink::mojom::BadgeService>(
+      base::BindRepeating(&BindBadgeManagerFrameReceiver));
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   map->Add<extensions::mime_handler::MimeHandlerService>(
       base::BindRepeating(&BindMimeHandlerService));

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -17,6 +17,14 @@ const features = process._linkedBinding('electron_common_features');
 describe('chromium feature', () => {
   const fixtures = path.resolve(__dirname, 'fixtures');
 
+  describe('Badging API', () => {
+    it('does not crash', () => {
+      expect(() => {
+        navigator.setAppBadge(42);
+      }).to.not.throw();
+    });
+  });
+
   describe('heap snapshot', () => {
     it('does not crash', function () {
       process._linkedBinding('electron_common_v8_util').takeHeapSnapshot();


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/25141.

Bind a fake mojo service for the [Badging API](https://web.dev/badging-api/). When users add e.g. `navigator.setAppBadge(42)` to the renderer, they will now see

```
The Chromium Badging API is not available in Electron
```

logged as a warning.

cc @nornagon @MarshallOfSound @deepak1556 


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash in the renderer process when invoking the Badging API.
