### PR TITLE
fix: avoid creating client_id file for empty DIR_CRASH_DUMPS

### DIFF
--- a/shell/browser/api/electron_api_crash_reporter.cc
+++ b/shell/browser/api/electron_api_crash_reporter.cc
@@ -86,18 +86,22 @@ const std::map<std::string, std::string>& GetGlobalCrashKeys() {
   return GetGlobalCrashKeysMutable();
 }
 
-base::FilePath GetClientIdPath() {
-  base::FilePath path;
-  base::PathService::Get(electron::DIR_CRASH_DUMPS, &path);
-  return path.Append("client_id");
+bool GetClientIdPath(base::FilePath* path) {
+  if (base::PathService::Get(electron::DIR_CRASH_DUMPS, path)) {
+    *path = path->Append("client_id");
+    return true;
+  }
+  return false;
 }
 
 std::string ReadClientId() {
   base::ThreadRestrictions::ScopedAllowIO allow_io;
   std::string client_id;
   // "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".length == 36
-  if (!base::ReadFileToStringWithMaxSize(GetClientIdPath(), &client_id, 36) ||
-      client_id.size() != 36)
+  base::FilePath client_id_path;
+  if (GetClientIdPath(&client_id_path) &&
+      (!base::ReadFileToStringWithMaxSize(client_id_path, &client_id, 36) ||
+       client_id.size() != 36))
     return std::string();
   return client_id;
 }
@@ -105,7 +109,9 @@ std::string ReadClientId() {
 void WriteClientId(const std::string& client_id) {
   DCHECK_EQ(client_id.size(), 36u);
   base::ThreadRestrictions::ScopedAllowIO allow_io;
-  base::WriteFile(GetClientIdPath(), client_id);
+  base::FilePath client_id_path;
+  if (GetClientIdPath(&client_id_path))
+    base::WriteFile(client_id_path, client_id);
 }
 
 std::string GetClientId() {


### PR DESCRIPTION
#### Description of Change

Node child process don't set `DIR_CRASH_DUMPS` unless the undocumented `BREAKPAD_DUMP_LOCATION ` is specified, in these situations client_id file will be generated under the working directory. 

Refs https://github.com/microsoft/vscode/issues/105743

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix client_id file being generated in the working directory for node child process