### PR TITLE
fix: multiple fixes to redirects in intercepted requests

### DIFF
--- a/shell/browser/net/electron_url_loader_factory.cc
+++ b/shell/browser/net/electron_url_loader_factory.cc
@@ -259,7 +259,8 @@ void ElectronURLLoaderFactory::StartLoading(
   // API in WebRequestProxyingURLLoaderFactory.
   std::string location;
   if (head->headers->IsRedirect(&location)) {
-    auto new_method = ComputeMethodForRedirect(request.method, head->headers->response_code());
+    auto new_method = ComputeMethodForRedirect(request.method,
+                                               head->headers->response_code());
     auto new_location = request.url.Resolve(location);
     auto new_site_for_cookies = net::SiteForCookies::FromUrl(new_location);
 

--- a/shell/browser/net/electron_url_loader_factory.cc
+++ b/shell/browser/net/electron_url_loader_factory.cc
@@ -194,6 +194,24 @@ void ElectronURLLoaderFactory::Clone(
   receivers_.Add(this, std::move(receiver));
 }
 
+std::string ComputeMethodForRedirect(const std::string& method,
+                                     int http_status_code) {
+  // For 303 redirects, all request methods except HEAD are converted to GET,
+  // as per the latest httpbis draft.  The draft also allows POST requests to
+  // be converted to GETs when following 301/302 redirects, for historical
+  // reasons. Most major browsers do this and so shall we.  Both RFC 2616 and
+  // the httpbis draft say to prompt the user to confirm the generation of new
+  // requests, other than GET and HEAD requests, but IE omits these prompts and
+  // so shall we.
+  // See: https://tools.ietf.org/html/rfc7231#section-6.4
+  if ((http_status_code == 303 && method != "HEAD") ||
+      ((http_status_code == 301 || http_status_code == 302) &&
+       method == "POST")) {
+    return "GET";
+  }
+  return method;
+}
+
 // static
 void ElectronURLLoaderFactory::StartLoading(
     mojo::PendingReceiver<network::mojom::URLLoader> loader,
@@ -241,16 +259,18 @@ void ElectronURLLoaderFactory::StartLoading(
   // API in WebRequestProxyingURLLoaderFactory.
   std::string location;
   if (head->headers->IsRedirect(&location)) {
-    GURL new_location = GURL(location);
-    net::SiteForCookies new_site_for_cookies =
-        net::SiteForCookies::FromUrl(new_location);
+    auto new_method = ComputeMethodForRedirect(request.method, head->headers->response_code());
+    auto new_location = request.url.Resolve(location);
+    auto new_site_for_cookies = net::SiteForCookies::FromUrl(new_location);
+
     network::ResourceRequest new_request = request;
     new_request.url = new_location;
     new_request.site_for_cookies = new_site_for_cookies;
+    new_request.method = new_method;
 
     net::RedirectInfo redirect_info;
     redirect_info.status_code = head->headers->response_code();
-    redirect_info.new_method = request.method;
+    redirect_info.new_method = new_method;
     redirect_info.new_url = new_location;
     redirect_info.new_site_for_cookies = new_site_for_cookies;
     mojo::Remote<network::mojom::URLLoaderClient> client_remote(
@@ -258,7 +278,7 @@ void ElectronURLLoaderFactory::StartLoading(
 
     client_remote->OnReceiveRedirect(redirect_info, std::move(head));
 
-    // Unound client, so it an be passed to sub-methods
+    // Unound client, so it can be passed to sub-methods
     client = client_remote.Unbind();
     // When the redirection comes from an intercepted scheme (which has
     // |proxy_factory| passed), we askes the proxy factory to create a loader

--- a/shell/browser/net/electron_url_loader_factory.cc
+++ b/shell/browser/net/electron_url_loader_factory.cc
@@ -123,11 +123,16 @@ network::mojom::URLResponseHeadPtr ToResponseHead(
       } else {
         continue;
       }
-      // Some apps are passing content-type via headers, which is not accepted
-      // in NetworkService.
-      if (base::ToLowerASCII(iter.first) == "content-type") {
+
+      auto header_name_lowercase = base::ToLowerASCII(iter.first);
+
+      if (header_name_lowercase == "content-type") {
+        // Some apps are passing content-type via headers, which is not accepted
+        // in NetworkService.
         head->headers->GetMimeTypeAndCharset(&head->mime_type, &head->charset);
         has_content_type = true;
+      } else if (header_name_lowercase == "content-length") {
+        head->content_length = std::stol(iter.second.GetString());
       }
     }
   }

--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -820,6 +820,8 @@ void ProxyingURLLoaderFactory::CreateLoaderAndStart(
   // Check if user has intercepted this scheme.
   auto it = intercepted_handlers_.find(request.url.scheme());
   if (it != intercepted_handlers_.end()) {
+    intercepted_requests_.emplace(request_id);
+
     // <scheme, <type, handler>>
     it->second.second.Run(
         request, base::BindOnce(&ElectronURLLoaderFactory::StartLoading,
@@ -915,7 +917,7 @@ void ProxyingURLLoaderFactory::RemoveRequest(int32_t network_service_request_id,
 void ProxyingURLLoaderFactory::MaybeDeleteThis() {
   // Even if all URLLoaderFactory pipes connected to this object have been
   // closed it has to stay alive until all active requests have completed.
-  if (target_factory_.is_bound() || !requests_.empty())
+  if (target_factory_.is_bound() || !requests_.empty() || !intercepted_requests_.empty())
     return;
 
   delete this;

--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -917,7 +917,8 @@ void ProxyingURLLoaderFactory::RemoveRequest(int32_t network_service_request_id,
 void ProxyingURLLoaderFactory::MaybeDeleteThis() {
   // Even if all URLLoaderFactory pipes connected to this object have been
   // closed it has to stay alive until all active requests have completed.
-  if (target_factory_.is_bound() || !requests_.empty() || !intercepted_requests_.empty())
+  if (target_factory_.is_bound() || !requests_.empty() ||
+      !intercepted_requests_.empty())
     return;
 
   delete this;

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -238,6 +238,7 @@ class ProxyingURLLoaderFactory
   content::BrowserContext* const browser_context_;
   const int render_process_id_;
   uint64_t* request_id_generator_;  // managed by ElectronBrowserClient
+  std::set<int32_t> intercepted_requests_;
   std::unique_ptr<extensions::ExtensionNavigationUIData> navigation_ui_data_;
   base::Optional<int64_t> navigation_id_;
   mojo::ReceiverSet<network::mojom::URLLoaderFactory> proxy_receivers_;


### PR DESCRIPTION
#### Description of Change
Minor fixes to handling intercepted requests:

- 'content-length' wasn't passed down the stream
- for redirects,  methods were not converted to 'GET' and caused too many redirects
- intermittent access violation during redirects

#### Checklist
- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic
- [x] [PR release notes]

#### Release Notes

Notes: Fixed following issues for intercepted requests:
- Fixed issue where on redirects methods were not converted to 'GET' and caused too many redirects
- Fixed 'content-length' not being passed down the stream 
- Fixed intermittent access violation that could occur during handling redirects


