### PR TITLE
chore: log hint on renderer crash

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -461,6 +461,11 @@ const addReturnValueToEvent = (event: any) => {
   });
 };
 
+const loggingEnabled = () => {
+  return Object.prototype.hasOwnProperty.call(process.env, 'ELECTRON_ENABLE_LOGGING') ||
+    process.argv.some(arg => arg.toLowerCase().startsWith('--enable-logging'));
+};
+
 // Add JavaScript wrappers for WebContents class.
 WebContents.prototype._init = function () {
   // The navigation controller.
@@ -545,8 +550,8 @@ WebContents.prototype._init = function () {
     app.emit('renderer-process-crashed', event, this, ...args);
 
     // Log out a hint to help users better debug renderer crashes.
-    if (!process.env.ELECTRON_ENABLE_LOGGING) {
-      console.info('Renderer process crashed - setting ELECTRON_ENABLE_LOGGING may provide more information.');
+    if (loggingEnabled()) {
+      console.info('Renderer process crashed - see https://www.electronjs.org/docs/tutorial/application-debugging for potential debugging information.');
     }
   });
 

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -543,6 +543,11 @@ WebContents.prototype._init = function () {
 
   this.on('crashed', (event, ...args) => {
     app.emit('renderer-process-crashed', event, this, ...args);
+
+    // Log out a hint to help users better debug renderer crashes.
+    if (!process.env.ELECTRON_ENABLE_LOGGING) {
+      console.info('Renderer process crashed - setting ELECTRON_ENABLE_LOGGING may provide more information.');
+    }
   });
 
   this.on('render-process-gone', (event, ...args) => {


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/25141#issuecomment-686719615.

It's clear that we can and should provide more helpful tips when debugging certain types of crashes in Electron, but this seems like a small and helpful step we can take towards helping users debug renderer crashes. This will now log a small hint to console when the renderer crashes, telling them that they can set the logging env var to potentially see more information.

cc @ckerr @jkleinsc @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added a small console hint to console to help debug renderer crashes.
