### PR TITLE
feat: add macOS fast user switching evt

### DIFF
--- a/docs/api/power-monitor.md
+++ b/docs/api/power-monitor.md
@@ -39,6 +39,14 @@ Emitted when the system is about to lock the screen.
 
 Emitted as soon as the systems screen is unlocked.
 
+### Event: 'user-did-become-active' _macOS_
+
+Emitted when a login session is activated. See [documentation](https://developer.apple.com/documentation/appkit/nsworkspacesessiondidbecomeactivenotification?language=objc) for more information.
+
+### Event: 'user-did-resign-active' _macOS_
+
+Emitted when a login session is deactivated. See [documentation](https://developer.apple.com/documentation/appkit/nsworkspacesessiondidresignactivenotification?language=objc) for more information.
+
 ## Methods
 
 The `powerMonitor` module has the following methods:

--- a/shell/browser/api/electron_api_power_monitor_mac.mm
+++ b/shell/browser/api/electron_api_power_monitor_mac.mm
@@ -45,6 +45,18 @@
                    selector:@selector(isResuming:)
                        name:NSWorkspaceDidWakeNotification
                      object:nil];
+    // A notification that the workspace posts when the user session becomes
+    // active.
+    [distCenter addObserver:self
+                   selector:@selector(onUserDidBecomeActive:)
+                       name:NSWorkspaceSessionDidBecomeActiveNotification
+                     object:nil];
+    // A notification that the workspace posts when the user session becomes
+    // inactive.
+    [distCenter addObserver:self
+                   selector:@selector(onUserDidResignActive:)
+                       name:NSWorkspaceSessionDidResignActiveNotification
+                     object:nil];
   }
   return self;
 }
@@ -79,6 +91,18 @@
 - (void)onScreenUnlocked:(NSNotification*)notification {
   for (auto* emitter : self->emitters) {
     emitter->Emit("unlock-screen");
+  }
+}
+
+- (void)onUserDidBecomeActive:(NSNotification*)notification {
+  for (auto* emitter : self->emitters) {
+    emitter->Emit("user-did-become-active");
+  }
+}
+
+- (void)onUserDidResignActive:(NSNotification*)notification {
+  for (auto* emitter : self->emitters) {
+    emitter->Emit("user-did-resign-active");
   }
 }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/25039.

Adds fast user switching detection, which occurs when one logs out and then back in again as another user. This is distinct from `suspend`/`resume` - since no suspension occurs neither event is fired in this case.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Adds fast user switching event to powerMonitor on macOS. 
