### PR TITLE
fix: passing content-length down the stream for intercepted requests

### DIFF
--- a/shell/browser/net/electron_url_loader_factory.cc
+++ b/shell/browser/net/electron_url_loader_factory.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "base/guid.h"
+#include "base/strings/string_number_conversions.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/storage_partition.h"
 #include "mojo/public/cpp/bindings/binding.h"
@@ -123,7 +124,6 @@ network::mojom::URLResponseHeadPtr ToResponseHead(
       } else {
         continue;
       }
-
       auto header_name_lowercase = base::ToLowerASCII(iter.first);
 
       if (header_name_lowercase == "content-type") {
@@ -131,8 +131,9 @@ network::mojom::URLResponseHeadPtr ToResponseHead(
         // in NetworkService.
         head->headers->GetMimeTypeAndCharset(&head->mime_type, &head->charset);
         has_content_type = true;
-      } else if (header_name_lowercase == "content-length") {
-        head->content_length = std::stol(iter.second.GetString());
+      } else if (header_name_lowercase == "content-length" &&
+                 iter.second.is_string()) {
+        base::StringToInt64(iter.second.GetString(), &head->content_length);
       }
     }
   }

--- a/shell/browser/net/electron_url_loader_factory.cc
+++ b/shell/browser/net/electron_url_loader_factory.cc
@@ -123,11 +123,16 @@ network::mojom::URLResponseHeadPtr ToResponseHead(
       } else {
         continue;
       }
-      // Some apps are passing content-type via headers, which is not accepted
-      // in NetworkService.
-      if (base::ToLowerASCII(iter.first) == "content-type") {
+
+      auto header_name_lowercase = base::ToLowerASCII(iter.first);
+
+      if (header_name_lowercase == "content-type") {
+        // Some apps are passing content-type via headers, which is not accepted
+        // in NetworkService.
         head->headers->GetMimeTypeAndCharset(&head->mime_type, &head->charset);
         has_content_type = true;
+      } else if (header_name_lowercase == "content-length") {
+        head->content_length = std::stol(iter.second.GetString());
       }
     }
   }

--- a/spec-main/api-protocol-spec.ts
+++ b/spec-main/api-protocol-spec.ts
@@ -919,11 +919,11 @@ describe('protocol module', () => {
       await protocol.unregisterProtocol('stream');
     });
 
-    it('successfully plays videos with stream: false on streaming protocols', async () => {
+    it('successfully plays videos when content is bufferred (stream: false)', async () => {
       await streamsResponses(standardScheme, 'play');
     });
 
-    it('successfully plays videos with stream: true on streaming protocols', async () => {
+    it('successfully plays videos when streaming content (stream: true)', async () => {
       await streamsResponses('stream', 'play');
     });
 

--- a/spec-main/api-protocol-spec.ts
+++ b/spec-main/api-protocol-spec.ts
@@ -919,8 +919,8 @@ describe('protocol module', () => {
       await protocol.unregisterProtocol('stream');
     });
 
-    it('does not successfully play videos with stream: false on streaming protocols', async () => {
-      await streamsResponses(standardScheme, 'error');
+    it('successfully plays videos with stream: false on streaming protocols', async () => {
+      await streamsResponses(standardScheme, 'play');
     });
 
     it('successfully plays videos with stream: true on streaming protocols', async () => {

--- a/spec-main/api-protocol-spec.ts
+++ b/spec-main/api-protocol-spec.ts
@@ -919,7 +919,7 @@ describe('protocol module', () => {
       await protocol.unregisterProtocol('stream');
     });
 
-    it('successfully plays videos when content is bufferred (stream: false)', async () => {
+    it('successfully plays videos when content is buffered (stream: false)', async () => {
       await streamsResponses(standardScheme, 'play');
     });
 


### PR DESCRIPTION
#### Description of Change
Passing 'content-length' down the stream for intercepted request.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added]
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines]
- [x] [PR release notes]

#### Release Notes
Notes: Fixed an issue that file length is not available in 'will-download' event when file is downloaded thourgh intercepted request
Fixed an issue that videos are not played for custom protocols and buffered content.