### PR TITLE
fix: handle electron script errors better

### DIFF
--- a/build/webpack/webpack.config.base.js
+++ b/build/webpack/webpack.config.base.js
@@ -69,7 +69,8 @@ module.exports = ({
   loadElectronFromAlternateTarget,
   targetDeletesNodeGlobals,
   target,
-  wrapInitWithProfilingTimeout
+  wrapInitWithProfilingTimeout,
+  wrapInitWithTryCatch
 }) => {
   let entry = path.resolve(electronRoot, 'lib', target, 'init.ts');
   if (!fs.existsSync(entry)) {
@@ -87,6 +88,7 @@ module.exports = ({
       filename: `${target}.bundle.js`
     },
     wrapInitWithProfilingTimeout,
+    wrapInitWithTryCatch,
     resolve: {
       alias: {
         '@electron/internal': path.resolve(electronRoot, 'lib'),

--- a/build/webpack/webpack.config.isolated_renderer.js
+++ b/build/webpack/webpack.config.isolated_renderer.js
@@ -1,4 +1,5 @@
 module.exports = require('./webpack.config.base')({
   target: 'isolated_renderer',
-  alwaysHasNode: false
+  alwaysHasNode: false,
+  wrapInitWithTryCatch: true
 });

--- a/build/webpack/webpack.config.renderer.js
+++ b/build/webpack/webpack.config.renderer.js
@@ -2,5 +2,6 @@ module.exports = require('./webpack.config.base')({
   target: 'renderer',
   alwaysHasNode: true,
   targetDeletesNodeGlobals: true,
-  wrapInitWithProfilingTimeout: true
+  wrapInitWithProfilingTimeout: true,
+  wrapInitWithTryCatch: true
 });

--- a/build/webpack/webpack.config.sandboxed_renderer.js
+++ b/build/webpack/webpack.config.sandboxed_renderer.js
@@ -1,5 +1,6 @@
 module.exports = require('./webpack.config.base')({
   target: 'sandboxed_renderer',
   alwaysHasNode: false,
-  wrapInitWithProfilingTimeout: true
+  wrapInitWithProfilingTimeout: true,
+  wrapInitWithTryCatch: true
 });

--- a/build/webpack/webpack.config.worker.js
+++ b/build/webpack/webpack.config.worker.js
@@ -2,5 +2,6 @@ module.exports = require('./webpack.config.base')({
   target: 'worker',
   loadElectronFromAlternateTarget: 'renderer',
   alwaysHasNode: true,
-  targetDeletesNodeGlobals: true
+  targetDeletesNodeGlobals: true,
+  wrapInitWithTryCatch: true
 });

--- a/shell/common/node_util.cc
+++ b/shell/common/node_util.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "shell/common/node_util.h"
+#include "base/logging.h"
 #include "shell/common/node_includes.h"
 #include "third_party/electron_node/src/node_native_module_env.h"
 
@@ -17,6 +18,7 @@ v8::MaybeLocal<v8::Value> CompileAndCall(
     std::vector<v8::Local<v8::Value>>* arguments,
     node::Environment* optional_env) {
   v8::Isolate* isolate = context->GetIsolate();
+  v8::TryCatch try_catch(isolate);
   v8::MaybeLocal<v8::Function> compiled =
       node::native_module::NativeModuleEnv::LookupAndCompile(
           context, id, parameters, optional_env);
@@ -24,8 +26,14 @@ v8::MaybeLocal<v8::Value> CompileAndCall(
     return v8::MaybeLocal<v8::Value>();
   }
   v8::Local<v8::Function> fn = compiled.ToLocalChecked().As<v8::Function>();
-  return fn->Call(context, v8::Null(isolate), arguments->size(),
-                  arguments->data());
+  v8::MaybeLocal<v8::Value> ret = fn->Call(
+      context, v8::Null(isolate), arguments->size(), arguments->data());
+  // This will only be caught when something has gone terrible wrong as all
+  // electron scripts are wrapped in a try {} catch {} in run-compiler.js
+  if (try_catch.HasCaught()) {
+    LOG(ERROR) << "Failed to CompileAndCall electron script: " << id;
+  }
+  return ret;
 }
 
 }  // namespace util


### PR DESCRIPTION
There are some super rare occurrences where Electron JS can throw errors (we're not perfect either 😉 ).  This updates it so these errors don't impact things like renderer process creation negatively by catching, logging and absorbing them.

Notes: no-notes