### PR TITLE
fix: only focus a webContents if the window was not initially hidden

### DIFF
--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -30,9 +30,11 @@ BrowserWindow.prototype._init = function () {
   // Though this hack is only needed on macOS when the app is launched from
   // Finder, we still do it on all platforms in case of other bugs we don't
   // know.
-  this.webContents.once('load-url', function () {
-    this.focus();
-  });
+  if (this.webContents._initiallyShown) {
+    this.webContents.once('load-url', function () {
+      this.focus();
+    });
+  }
 
   // Redirect focus/blur event to app instance too.
   this.on('blur', (event) => {

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -453,8 +453,8 @@ WebContents::WebContents(v8::Isolate* isolate,
   // BrowserViews are not attached to a window initially so they should start
   // off as hidden. This is also important for compositor recycling. See:
   // https://github.com/electron/electron/pull/21372
-  bool initially_shown = type_ != Type::BROWSER_VIEW;
-  options.Get(options::kShow, &initially_shown);
+  initially_shown_ = type_ != Type::BROWSER_VIEW;
+  options.Get(options::kShow, &initially_shown_);
 
   // Obtain the session.
   std::string partition;
@@ -510,7 +510,7 @@ WebContents::WebContents(v8::Isolate* isolate,
 #endif
   } else {
     content::WebContents::CreateParams params(session->browser_context());
-    params.initially_hidden = !initially_shown;
+    params.initially_hidden = !initially_shown_;
     web_contents = content::WebContents::Create(params);
   }
 
@@ -2678,6 +2678,10 @@ v8::Local<v8::Value> WebContents::Debugger(v8::Isolate* isolate) {
   return v8::Local<v8::Value>::New(isolate, debugger_);
 }
 
+bool WebContents::WasInitiallyShown() {
+  return initially_shown_;
+}
+
 void WebContents::GrantOriginAccess(const GURL& url) {
   content::ChildProcessSecurityPolicy::GetInstance()->GrantCommitOrigin(
       web_contents()->GetMainFrame()->GetProcess()->GetID(),
@@ -2852,7 +2856,8 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetProperty("session", &WebContents::Session)
       .SetProperty("hostWebContents", &WebContents::HostWebContents)
       .SetProperty("devToolsWebContents", &WebContents::DevToolsWebContents)
-      .SetProperty("debugger", &WebContents::Debugger);
+      .SetProperty("debugger", &WebContents::Debugger)
+      .SetProperty("_initiallyShown", &WebContents::WasInitiallyShown);
 }
 
 ElectronBrowserContext* WebContents::GetBrowserContext() const {

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -376,6 +376,7 @@ class WebContents : public gin_helper::TrackableObject<WebContents>,
   content::WebContents* HostWebContents() const;
   v8::Local<v8::Value> DevToolsWebContents(v8::Isolate* isolate);
   v8::Local<v8::Value> Debugger(v8::Isolate* isolate);
+  bool WasInitiallyShown();
 
   WebContentsZoomController* GetZoomController() { return zoom_controller_; }
 
@@ -649,6 +650,8 @@ class WebContents : public gin_helper::TrackableObject<WebContents>,
 
   // Observers of this WebContents.
   base::ObserverList<ExtendedWebContentsObserver> observers_;
+
+  bool initially_shown_ = true;
 
   // The ID of the process of the currently committed RenderViewHost.
   // -1 means no speculative RVH has been committed yet.

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -32,6 +32,7 @@ declare namespace Electron {
   interface WebContents {
     _getURL(): string;
     getOwnerBrowserWindow(): Electron.BrowserWindow;
+    _initiallyShown: boolean;
   }
 
   interface SerializedError {


### PR DESCRIPTION
Backport of #25292

See that PR for details.


Notes: Fixed an issue where `document.hasFocus` and `document.activeElement` would be inconsistent upon showing a window that was initially created with `show: false`