### PR TITLE
build: use python 2 shebang for git scripts

### DIFF
--- a/script/git-export-patches
+++ b/script/git-export-patches
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 import os

--- a/script/git-import-patches
+++ b/script/git-import-patches
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 import os


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Change shebang for the `git-import-patches`/`git-export-patches` scripts to use `python2`.

Ideally these scripts should be ported to Python 3 but until that happens these changes are meant to provide a temporary solution that makes them compatible with operating systems where the `python` binary points to Python 3.

##### Linux

Since these scripts are not compatible with Python 3 yet, trying to run them on a Linux distribution where `/usr/bin/python` points to Python 3 results in an error similar to:

```
Traceback (most recent call last):
  File "/path/to/electron/src/electron/script/git-export-patches", line 26, in <module>
    main(sys.argv[1:])
  File "/path/to/electron/src/electron/script/git-export-patches", line 22, in main
    git.export_patches('.', args.output, patch_range=args.patch_range)
  File "/path/to/electron/src/electron/script/lib/git.py", line 265, in export_patches
    patch_range, num_patches = guess_base_commit(repo)
  File "/path/to/electron/src/electron/script/lib/git.py", line 174, in guess_base_commit
    num_commits = get_commit_count(repo, upstream_head + '..')
TypeError: can't concat str to bytes
```

The easiest way to reproduce this is by running an [e patches](https://github.com/electron/build-tools#e-patches-patch-dir) command on a Linux distribution where `/usr/bin/python` points to Python 3 (e.g.: Fedora/Arch Linux/etc).

The other Linux distributions where `/usr/bin/python` points to Python 2 (e.g.: Ubuntu/Debian) also provide a `/usr/bin/python2` binary, so this change should not affect them.

##### macOS

I'm not sure how this affects macOS and I don't have access to an Apple device to test this. Does macOS provide a `python2` binary? This [stackoverflow answer](https://apple.stackexchange.com/a/376081) seems to suggest it does, so hopefully these changes will work fine on macOS too.

##### Windows

I suppose Windows does not use the shebang in any way so I don't think these changes should affect it. I may be wrong though so it would be great if someone more knowledgeable could confirm this.



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd (/cc @MarshallOfSound)
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release notes

Notes: none