### PR TITLE
fix(extensions): define platform info to prevent renderer crash

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -642,6 +642,7 @@ source_set("electron_lib") {
       "shell/common/extensions/api",
       "shell/common/extensions/api:extensions_features",
       "//chrome/browser/resources:component_extension_resources",
+      "//components/update_client:update_client",
       "//components/zoom",
       "//extensions/browser",
       "//extensions/browser:core_api_provider",

--- a/docs/api/extensions.md
+++ b/docs/api/extensions.md
@@ -74,6 +74,7 @@ The following methods of `chrome.runtime` are supported:
 
 - `chrome.runtime.getBackgroundPage`
 - `chrome.runtime.getManifest`
+- `chrome.runtime.getPlatformInfo`
 - `chrome.runtime.getURL`
 - `chrome.runtime.connect`
 - `chrome.runtime.sendMessage`

--- a/shell/browser/extensions/api/runtime/electron_runtime_api_delegate.cc
+++ b/shell/browser/extensions/api/runtime/electron_runtime_api_delegate.cc
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "build/build_config.h"
+#include "components/update_client/update_query_params.h"
 #include "extensions/common/api/runtime.h"
 #include "shell/browser/extensions/electron_extension_system.h"
 
@@ -42,10 +43,57 @@ bool ElectronRuntimeAPIDelegate::CheckForUpdates(
 void ElectronRuntimeAPIDelegate::OpenURL(const GURL& uninstall_url) {}
 
 bool ElectronRuntimeAPIDelegate::GetPlatformInfo(PlatformInfo* info) {
-  // TODO(nornagon): put useful information here.
-#if defined(OS_LINUX)
-  info->os = api::runtime::PLATFORM_OS_LINUX;
-#endif
+  const char* os = update_client::UpdateQueryParams::GetOS();
+  if (strcmp(os, "mac") == 0) {
+    info->os = extensions::api::runtime::PLATFORM_OS_MAC;
+  } else if (strcmp(os, "win") == 0) {
+    info->os = extensions::api::runtime::PLATFORM_OS_WIN;
+  } else if (strcmp(os, "linux") == 0) {
+    info->os = extensions::api::runtime::PLATFORM_OS_LINUX;
+  } else if (strcmp(os, "openbsd") == 0) {
+    info->os = extensions::api::runtime::PLATFORM_OS_OPENBSD;
+  } else {
+    NOTREACHED();
+    return false;
+  }
+
+  const char* arch = update_client::UpdateQueryParams::GetArch();
+  if (strcmp(arch, "arm") == 0) {
+    info->arch = extensions::api::runtime::PLATFORM_ARCH_ARM;
+  } else if (strcmp(arch, "arm64") == 0) {
+    info->arch = extensions::api::runtime::PLATFORM_ARCH_ARM64;
+  } else if (strcmp(arch, "x86") == 0) {
+    info->arch = extensions::api::runtime::PLATFORM_ARCH_X86_32;
+  } else if (strcmp(arch, "x64") == 0) {
+    info->arch = extensions::api::runtime::PLATFORM_ARCH_X86_64;
+  } else if (strcmp(arch, "mipsel") == 0) {
+    info->arch = extensions::api::runtime::PLATFORM_ARCH_MIPS;
+  } else if (strcmp(arch, "mips64el") == 0) {
+    info->arch = extensions::api::runtime::PLATFORM_ARCH_MIPS64;
+  } else {
+    NOTREACHED();
+    return false;
+  }
+
+  const char* nacl_arch = update_client::UpdateQueryParams::GetNaclArch();
+  if (strcmp(nacl_arch, "arm") == 0) {
+    info->nacl_arch = extensions::api::runtime::PLATFORM_NACL_ARCH_ARM;
+  } else if (strcmp(nacl_arch, "arm64") == 0) {
+    // Use ARM for ARM64 NaCl, as ARM64 NaCl is not available.
+    info->nacl_arch = extensions::api::runtime::PLATFORM_NACL_ARCH_ARM;
+  } else if (strcmp(nacl_arch, "x86-32") == 0) {
+    info->nacl_arch = extensions::api::runtime::PLATFORM_NACL_ARCH_X86_32;
+  } else if (strcmp(nacl_arch, "x86-64") == 0) {
+    info->nacl_arch = extensions::api::runtime::PLATFORM_NACL_ARCH_X86_64;
+  } else if (strcmp(nacl_arch, "mips32") == 0) {
+    info->nacl_arch = extensions::api::runtime::PLATFORM_NACL_ARCH_MIPS;
+  } else if (strcmp(nacl_arch, "mips64") == 0) {
+    info->nacl_arch = extensions::api::runtime::PLATFORM_NACL_ARCH_MIPS64;
+  } else {
+    NOTREACHED();
+    return false;
+  }
+
   return true;
 }  // namespace extensions
 

--- a/shell/browser/extensions/api/runtime/electron_runtime_api_delegate.cc
+++ b/shell/browser/extensions/api/runtime/electron_runtime_api_delegate.cc
@@ -66,10 +66,6 @@ bool ElectronRuntimeAPIDelegate::GetPlatformInfo(PlatformInfo* info) {
     info->arch = extensions::api::runtime::PLATFORM_ARCH_X86_32;
   } else if (strcmp(arch, "x64") == 0) {
     info->arch = extensions::api::runtime::PLATFORM_ARCH_X86_64;
-  } else if (strcmp(arch, "mipsel") == 0) {
-    info->arch = extensions::api::runtime::PLATFORM_ARCH_MIPS;
-  } else if (strcmp(arch, "mips64el") == 0) {
-    info->arch = extensions::api::runtime::PLATFORM_ARCH_MIPS64;
   } else {
     NOTREACHED();
     return false;
@@ -85,10 +81,6 @@ bool ElectronRuntimeAPIDelegate::GetPlatformInfo(PlatformInfo* info) {
     info->nacl_arch = extensions::api::runtime::PLATFORM_NACL_ARCH_X86_32;
   } else if (strcmp(nacl_arch, "x86-64") == 0) {
     info->nacl_arch = extensions::api::runtime::PLATFORM_NACL_ARCH_X86_64;
-  } else if (strcmp(nacl_arch, "mips32") == 0) {
-    info->nacl_arch = extensions::api::runtime::PLATFORM_NACL_ARCH_MIPS;
-  } else if (strcmp(nacl_arch, "mips64") == 0) {
-    info->nacl_arch = extensions::api::runtime::PLATFORM_NACL_ARCH_MIPS64;
   } else {
     NOTREACHED();
     return false;

--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -40,9 +40,8 @@ describe('chrome extensions', () => {
   it('does not crash when using chrome.management', async () => {
     const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
     const w = new BrowserWindow({ show: false, webPreferences: { session: customSession, sandbox: true } });
-    w.loadURL('about:blank');
+    await w.loadURL('about:blank');
 
-    await emittedOnce(w.webContents, 'dom-ready');
     await customSession.loadExtension(path.join(fixtures, 'extensions', 'persistent-background-page'));
     const args: any = await emittedOnce(app, 'web-contents-created');
     const wc: Electron.WebContents = args[1];
@@ -60,9 +59,8 @@ describe('chrome extensions', () => {
   it('can open WebSQLDatabase in a background page', async () => {
     const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
     const w = new BrowserWindow({ show: false, webPreferences: { session: customSession, sandbox: true } });
-    w.loadURL('about:blank');
+    await w.loadURL('about:blank');
 
-    await emittedOnce(w.webContents, 'dom-ready');
     await customSession.loadExtension(path.join(fixtures, 'extensions', 'persistent-background-page'));
     const args: any = await emittedOnce(app, 'web-contents-created');
     const wc: Electron.WebContents = args[1];
@@ -77,8 +75,7 @@ describe('chrome extensions', () => {
     const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
     const w = new BrowserWindow({ show: false, webPreferences: { session: customSession, sandbox: true } });
     const extension = await customSession.loadExtension(path.join(fixtures, 'extensions', 'ui-page'));
-    w.loadURL(`${extension.url}bare-page.html`);
-    await emittedOnce(w.webContents, 'dom-ready');
+    await w.loadURL(`${extension.url}bare-page.html`);
     await expect(fetch(w.webContents, `${url}/cors`)).to.not.be.rejectedWith(TypeError);
   });
 
@@ -90,8 +87,7 @@ describe('chrome extensions', () => {
     const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
     await customSession.loadExtension(path.join(fixtures, 'extensions', 'red-bg'));
     const w = new BrowserWindow({ show: false, webPreferences: { session: customSession } });
-    w.loadURL(url);
-    await emittedOnce(w.webContents, 'dom-ready');
+    await w.loadURL(url);
     const bg = await w.webContents.executeJavaScript('document.documentElement.style.backgroundColor');
     expect(bg).to.equal('red');
   });
@@ -145,8 +141,7 @@ describe('chrome extensions', () => {
     const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
     await customSession.loadExtension(path.join(fixtures, 'extensions', 'red-bg'));
     const w = new BrowserWindow({ show: false }); // not in the session
-    w.loadURL(url);
-    await emittedOnce(w.webContents, 'dom-ready');
+    await w.loadURL(url);
     const bg = await w.webContents.executeJavaScript('document.documentElement.style.backgroundColor');
     expect(bg).to.equal('');
   });
@@ -169,8 +164,7 @@ describe('chrome extensions', () => {
       const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
       extension = await customSession.loadExtension(path.join(fixtures, 'extensions', 'chrome-i18n'));
       w = new BrowserWindow({ show: false, webPreferences: { session: customSession, nodeIntegration: true } });
-      w.loadURL(url);
-      await emittedOnce(w.webContents, 'dom-ready');
+      await w.loadURL(url);
     });
     it('getAcceptLanguages()', async () => {
       const result = await exec('getAcceptLanguages');
@@ -195,8 +189,7 @@ describe('chrome extensions', () => {
       const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
       await customSession.loadExtension(path.join(fixtures, 'extensions', 'chrome-runtime'));
       w = new BrowserWindow({ show: false, webPreferences: { session: customSession, nodeIntegration: true } });
-      w.loadURL(url);
-      await emittedOnce(w.webContents, 'dom-ready');
+      await w.loadURL(url);
     });
     it('getManifest()', async () => {
       const result = await exec('getManifest');
@@ -560,8 +553,7 @@ describe('chrome extensions', () => {
     it('loads a ui page of an extension', async () => {
       const { id } = await session.defaultSession.loadExtension(path.join(fixtures, 'extensions', 'ui-page'));
       const w = new BrowserWindow({ show: false });
-      w.loadURL(`chrome-extension://${id}/bare-page.html`);
-      await emittedOnce(w.webContents, 'dom-ready');
+      await w.loadURL(`chrome-extension://${id}/bare-page.html`);
       const textContent = await w.webContents.executeJavaScript('document.body.textContent');
       expect(textContent).to.equal('ui page loaded ok\n');
     });
@@ -569,8 +561,7 @@ describe('chrome extensions', () => {
     it('can load resources', async () => {
       const { id } = await session.defaultSession.loadExtension(path.join(fixtures, 'extensions', 'ui-page'));
       const w = new BrowserWindow({ show: false });
-      w.loadURL(`chrome-extension://${id}/page-script-load.html`);
-      await emittedOnce(w.webContents, 'dom-ready');
+      await w.loadURL(`chrome-extension://${id}/page-script-load.html`);
       const textContent = await w.webContents.executeJavaScript('document.body.textContent');
       expect(textContent).to.equal('script loaded ok\n');
     });

--- a/spec-main/fixtures/extensions/chrome-runtime/background.js
+++ b/spec-main/fixtures/extensions/chrome-runtime/background.js
@@ -1,0 +1,12 @@
+/* global chrome */
+
+chrome.runtime.onMessage.addListener((message, sender, reply) => {
+  switch (message) {
+    case 'getPlatformInfo':
+      chrome.runtime.getPlatformInfo(reply);
+      break;
+  }
+
+  // Respond asynchronously
+  return true;
+});

--- a/spec-main/fixtures/extensions/chrome-runtime/main.js
+++ b/spec-main/fixtures/extensions/chrome-runtime/main.js
@@ -1,6 +1,39 @@
 /* eslint-disable */
-document.documentElement.textContent = JSON.stringify({
-  manifest: chrome.runtime.getManifest(),
-  id: chrome.runtime.id,
-  url: chrome.runtime.getURL('main.js')
+
+function evalInMainWorld(fn) {
+  const script = document.createElement('script')
+  script.textContent = `((${fn})())`
+  document.documentElement.appendChild(script)
+}
+
+async function exec(name) {
+  let result
+  switch (name) {
+    case 'getManifest':
+      result = chrome.runtime.getManifest()
+      break
+    case 'id':
+      result = chrome.runtime.id
+      break
+    case 'getURL':
+      result = chrome.runtime.getURL('main.js')
+      break
+    case 'getPlatformInfo': {
+      result = await new Promise(resolve => {
+        chrome.runtime.sendMessage(name, resolve)
+      })
+      break
+    }
+  }
+
+  const funcStr = `() => { require('electron').ipcRenderer.send('success', ${JSON.stringify(result)}) }`
+  evalInMainWorld(funcStr)
+}
+
+window.addEventListener('message', event => {
+  exec(event.data.name)
+})
+
+evalInMainWorld(() => {
+  window.exec = name => window.postMessage({ name })
 })

--- a/spec-main/fixtures/extensions/chrome-runtime/manifest.json
+++ b/spec-main/fixtures/extensions/chrome-runtime/manifest.json
@@ -8,5 +8,9 @@
       "run_at": "document_end"
     }
   ],
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": false
+  },
   "manifest_version": 2
 }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Fully implements `chrome.runtime.getPlatformInfo` such that the calling renderer won't crash/hang.

The implementation is copied from [chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate.cc](https://source.chromium.org/chromium/chromium/src/+/master:chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate.cc;l=285;drc=89ce2d1e6202423c9c0f0c83cec1f198cf55eded).

Ref #19447

cc @nornagon @sentialx 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed `chrome.runtime.getPlatformInfo` crashing the background process upon being invoked.
