### PR TITLE
refactor(extensions): break load warnings into newlines

### DIFF
--- a/shell/browser/extensions/electron_extension_loader.cc
+++ b/shell/browser/extensions/electron_extension_loader.cc
@@ -52,9 +52,9 @@ std::pair<scoped_refptr<const Extension>, std::string> LoadUnpacked(
   // Log warnings.
   if (extension->install_warnings().size()) {
     warnings += "Warnings loading extension at " +
-                base::UTF16ToUTF8(extension_dir.LossyDisplayName()) + ": ";
+                base::UTF16ToUTF8(extension_dir.LossyDisplayName()) + ":\n";
     for (const auto& warning : extension->install_warnings()) {
-      warnings += warning.message + " ";
+      warnings += "  " + warning.message + "\n";
     }
   }
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Makes the extension loader warnings more readable. Previously they were all joined together on a single line.

```
(node:21392) ExtensionLoadWarning: Warnings loading extension at D:\work\electron-extensions\extensions\cjpalhdlnbpafiamejdnhcphjbkeiagm\1.24.4_0:
  Unrecognized manifest key 'author'.
  Unrecognized manifest key 'browser_action'.
  Unrecognized manifest key 'commands'.
  Unrecognized manifest key 'minimum_chrome_version'.
  Unrecognized manifest key 'short_name'.
  Unrecognized manifest key 'storage'.
  Unrecognized manifest key 'update_url'.
  Permission 'contextMenus' is unknown or URL pattern is malformed.
  Permission 'privacy' is unknown or URL pattern is malformed.
  Permission 'tabs' is unknown or URL pattern is malformed.
  Permission 'webNavigation' is unknown or URL pattern is malformed.
  Cannot load extension with file or directory name _metadata. Filenames starting with "_" are reserved for use by the system.

(node:21392) ExtensionLoadWarning: Warnings loading extension at D:\work\electron-extensions\extensions\fakegmdomhmegokfomgmkbopjibonfcp:
  Unrecognized manifest key 'browser_action'.
  Unrecognized manifest key 'optional_permissions'.
  Unrecognized manifest key 'short_name'.
  Unrecognized manifest key 'update_url'.
  Permission 'tabs' is unknown or URL pattern is malformed.
  Permission 'webNavigation' is unknown or URL pattern is malformed.
  Permission 'contextMenus' is unknown or URL pattern is malformed.
  Permission 'contentSettings' is unknown or URL pattern is malformed.
  Cannot load extension with file or directory name _metadata. Filenames starting with "_" are reserved for use by the system.
```

cc @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none
