### PR TITLE
feat: allow path override with --ignore-scripts

### DIFF
--- a/npm/index.js
+++ b/npm/index.js
@@ -4,11 +4,14 @@ const path = require('path');
 const pathFile = path.join(__dirname, 'path.txt');
 
 function getElectronPath () {
+  let executablePath;
   if (fs.existsSync(pathFile)) {
-    const executablePath = fs.readFileSync(pathFile, 'utf-8');
-    if (process.env.ELECTRON_OVERRIDE_DIST_PATH) {
-      return path.join(process.env.ELECTRON_OVERRIDE_DIST_PATH, executablePath);
-    }
+    executablePath = fs.readFileSync(pathFile, 'utf-8');
+  }
+  if (process.env.ELECTRON_OVERRIDE_DIST_PATH) {
+    return path.join(process.env.ELECTRON_OVERRIDE_DIST_PATH, executablePath || 'electron');
+  }
+  if (executablePath) {
     return path.join(__dirname, 'dist', executablePath);
   } else {
     throw new Error('Electron failed to install correctly, please delete node_modules/electron and try installing again');


### PR DESCRIPTION
If you --ignore-scripts when installing electron currently, it'll fail to write the path.txt file and thus fail to use the override dist path. Open to other solutions - just hoping to be able to use a prebuilt electron binary with the default package without having to muck around with it installing an unused version.

#### Description of Change

Default to `electron` if the `ELECTRON_OVERRIDE_DIST_PATH` environment variable is present.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none