### PR TITLE
feat(extensions): expose ExtensionRegistryObserver events in Session

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -102,12 +102,9 @@ Emitted after an extension is loaded. This occurs whenever an extension is
 added to the "enabled" set of extensions. This includes:
 - Extensions being loaded from `Session.loadExtension`.
 - Extensions being reloaded:
+   * from a crash.
+   * from a disabled state (if the extension is disabled then enabled).
    * if the extension requested it ([`chrome.runtime.reload()`](https://developer.chrome.com/extensions/runtime#method-reload)).
-
-<!--
-Refer to //extensions/browser/extension_registry_observer.h for further
-explaination.
--->
 
 #### Event: 'extension-unloaded'
 
@@ -116,7 +113,9 @@ Returns:
 * `event` Event
 * `extension` [Extension](structures/extension.md)
 
-Emitted after an extension is unloaded.
+Emitted after an extension is unloaded. The extension no longer exists in
+the group of enabled extensions, but it can still be a member of another
+group, like disabled, blocklisted, or terminated.
 
 #### Event: 'extension-ready'
 

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -91,6 +91,43 @@ session.defaultSession.on('will-download', (event, item, webContents) => {
 })
 ```
 
+#### Event: 'extension-loaded'
+
+Returns:
+
+* `event` Event
+* `extension` [Extension](structures/extension.md)
+
+Emitted after an extension is loaded. This occurs whenever an extension is
+added to the "enabled" set of extensions. This includes:
+- Extensions being loaded from `Session.loadExtension`.
+- Extensions being reloaded:
+   * if the extension requested it ([`chrome.runtime.reload()`](https://developer.chrome.com/extensions/runtime#method-reload)).
+
+<!--
+Refer to //extensions/browser/extension_registry_observer.h for further
+explaination.
+-->
+
+#### Event: 'extension-unloaded'
+
+Returns:
+
+* `event` Event
+* `extension` [Extension](structures/extension.md)
+
+Emitted after an extension is unloaded.
+
+#### Event: 'extension-ready'
+
+Returns:
+
+* `event` Event
+* `extension` [Extension](structures/extension.md)
+
+Emitted after an extension is loaded and all necessary browser state is
+initialized to support the start of the extension's background page.
+
 #### Event: 'preconnect'
 
 Returns:

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -103,7 +103,6 @@ added to the "enabled" set of extensions. This includes:
 - Extensions being loaded from `Session.loadExtension`.
 - Extensions being reloaded:
    * from a crash.
-   * from a disabled state (if the extension is disabled then enabled).
    * if the extension requested it ([`chrome.runtime.reload()`](https://developer.chrome.com/extensions/runtime#method-reload)).
 
 #### Event: 'extension-unloaded'
@@ -113,9 +112,8 @@ Returns:
 * `event` Event
 * `extension` [Extension](structures/extension.md)
 
-Emitted after an extension is unloaded. The extension no longer exists in
-the group of enabled extensions, but it can still be a member of another
-group, like disabled, blocklisted, or terminated.
+Emitted after an extension is unloaded. This occurs when
+`Session.removeExtension` is called.
 
 #### Event: 'extension-ready'
 

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -26,7 +26,6 @@
 #endif
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-#include "base/scoped_observer.h"
 #include "extensions/browser/extension_registry.h"
 #include "extensions/browser/extension_registry_observer.h"
 #endif
@@ -176,12 +175,6 @@ class Session : public gin::Wrappable<Session>,
   base::UnguessableToken network_emulation_token_;
 
   ElectronBrowserContext* browser_context_;
-
-#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-  ScopedObserver<extensions::ExtensionRegistry,
-                 extensions::ExtensionRegistryObserver>
-      registry_observer_{this};
-#endif
 
   DISALLOW_COPY_AND_ASSIGN(Session);
 };

--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -127,6 +127,23 @@ describe('chrome extensions', () => {
     }
   });
 
+  it('emits extension lifecycle events', async () => {
+    const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
+
+    const loadedPromise = emittedOnce(customSession, 'extension-loaded');
+    const extension = await customSession.loadExtension(path.join(fixtures, 'extensions', 'red-bg'));
+    const [, loadedExtension] = await loadedPromise;
+    const [, readyExtension] = await emittedOnce(customSession, 'extension-ready');
+
+    expect(loadedExtension.id).to.equal(extension.id);
+    expect(readyExtension.id).to.equal(extension.id);
+
+    const unloadedPromise = emittedOnce(customSession, 'extension-unloaded');
+    await customSession.removeExtension(extension.id);
+    const [, unloadedExtension] = await unloadedPromise;
+    expect(unloadedExtension.id).to.equal(extension.id);
+  });
+
   it('lists loaded extensions in getAllExtensions', async () => {
     const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
     const e = await customSession.loadExtension(path.join(fixtures, 'extensions', 'red-bg'));


### PR DESCRIPTION
#### Description of Change
Extensions can be loaded or unloaded for various reasons. In some cases, this can occur by no means of the Electron programmer, such as in the case of [`chrome.runtime.reload()`](https://developer.chrome.com/extensions/runtime#method-reload).

In order to be able to manage state about extensions outside of Electron's APIs, events related to loading and unloaded extensions are needed. The only alternative would be to monkey-patch the `Session` prototype.

The use case I have is to manage state in my own implementation of [`chrome.browserAction`](https://developer.chrome.com/extensions/browserAction). I need to know when an extension is added or removed to set or delete saved state.

Ref #19447

cc @nornagon @sentialx 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Add `extension-loaded`, `extension-unloaded`, and `extension-ready` events to `Session`.
