### PR TITLE
[wip] feat(extensions): add enable/disable extension methods to Session

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -615,6 +615,18 @@ Unloads an extension.
 **Note:** This API cannot be called before the `ready` event of the `app` module
 is emitted.
 
+#### `ses.enableExtension(extensionId)`
+
+* `extensionId` String - ID of extension to enable
+
+Enables an extension. If the extension is already enabled, does nothing.
+
+#### `ses.disableExtension(extensionId)`
+
+* `extensionId` String - ID of extension to disable
+
+Disables an extension. If the extension is already disabled, does nothing.
+
 #### `ses.getExtension(extensionId)`
 
 * `extensionId` String - ID of extension to query

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -727,6 +727,18 @@ void Session::RemoveExtension(const std::string& extension_id) {
   extension_system->RemoveExtension(extension_id);
 }
 
+void Session::EnableExtension(const std::string& extension_id) {
+  auto* extension_system = static_cast<extensions::ElectronExtensionSystem*>(
+      extensions::ExtensionSystem::Get(browser_context()));
+  extension_system->EnableExtension(extension_id);
+}
+
+void Session::DisableExtension(const std::string& extension_id) {
+  auto* extension_system = static_cast<extensions::ElectronExtensionSystem*>(
+      extensions::ExtensionSystem::Get(browser_context()));
+  extension_system->DisableExtension(extension_id);
+}
+
 v8::Local<v8::Value> Session::GetExtension(const std::string& extension_id) {
   auto* registry = extensions::ExtensionRegistry::Get(browser_context());
   const extensions::Extension* extension =
@@ -1009,6 +1021,8 @@ gin::ObjectTemplateBuilder Session::GetObjectTemplateBuilder(
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
       .SetMethod("loadExtension", &Session::LoadExtension)
       .SetMethod("removeExtension", &Session::RemoveExtension)
+      .SetMethod("enableExtension", &Session::EnableExtension)
+      .SetMethod("disableExtension", &Session::DisableExtension)
       .SetMethod("getExtension", &Session::GetExtension)
       .SetMethod("getAllExtensions", &Session::GetAllExtensions)
 #endif

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -124,6 +124,8 @@ class Session : public gin::Wrappable<Session>,
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   v8::Local<v8::Promise> LoadExtension(const base::FilePath& extension_path);
   void RemoveExtension(const std::string& extension_id);
+  void EnableExtension(const std::string& extension_id);
+  void DisableExtension(const std::string& extension_id);
   v8::Local<v8::Value> GetExtension(const std::string& extension_id);
   v8::Local<v8::Value> GetAllExtensions();
 #endif

--- a/shell/browser/extensions/electron_extension_loader.cc
+++ b/shell/browser/extensions/electron_extension_loader.cc
@@ -103,6 +103,16 @@ void ElectronExtensionLoader::UnloadExtension(
   extension_registrar_.RemoveExtension(extension_id, reason);
 }
 
+void ElectronExtensionLoader::EnableExtension(const std::string& extension_id) {
+  extension_registrar_.EnableExtension(extension_id);
+}
+
+void ElectronExtensionLoader::DisableExtension(
+    const std::string& extension_id) {
+  extension_registrar_.DisableExtension(
+      extension_id, extensions::disable_reason::DISABLE_USER_ACTION);
+}
+
 void ElectronExtensionLoader::FinishExtensionLoad(
     base::OnceCallback<void(const Extension*, const std::string&)> cb,
     std::pair<scoped_refptr<const Extension>, std::string> result) {
@@ -168,8 +178,7 @@ bool ElectronExtensionLoader::CanEnableExtension(const Extension* extension) {
 }
 
 bool ElectronExtensionLoader::CanDisableExtension(const Extension* extension) {
-  // Extensions cannot be disabled by the user.
-  return false;
+  return true;
 }
 
 bool ElectronExtensionLoader::ShouldBlockExtension(const Extension* extension) {

--- a/shell/browser/extensions/electron_extension_loader.h
+++ b/shell/browser/extensions/electron_extension_loader.h
@@ -50,6 +50,12 @@ class ElectronExtensionLoader : public ExtensionRegistrar::Delegate {
   void UnloadExtension(const ExtensionId& extension_id,
                        extensions::UnloadedExtensionReason reason);
 
+  // Enables the extension. If the extension is already enabled, does nothing.
+  void EnableExtension(const std::string& extension_id);
+
+  // Disables the extension. If the extension is already disabled, does nothing.
+  void DisableExtension(const std::string& extension_id);
+
   ExtensionRegistrar* registrar() { return &extension_registrar_; }
 
  private:

--- a/shell/browser/extensions/electron_extension_system.cc
+++ b/shell/browser/extensions/electron_extension_system.cc
@@ -74,6 +74,15 @@ void ElectronExtensionSystem::RemoveExtension(const ExtensionId& extension_id) {
       extension_id, extensions::UnloadedExtensionReason::UNINSTALL);
 }
 
+void ElectronExtensionSystem::EnableExtension(const std::string& extension_id) {
+  extension_loader_->EnableExtension(extension_id);
+}
+
+void ElectronExtensionSystem::DisableExtension(
+    const std::string& extension_id) {
+  extension_loader_->DisableExtension(extension_id);
+}
+
 void ElectronExtensionSystem::Shutdown() {
   extension_loader_.reset();
 }

--- a/shell/browser/extensions/electron_extension_system.h
+++ b/shell/browser/extensions/electron_extension_system.h
@@ -51,6 +51,9 @@ class ElectronExtensionSystem : public ExtensionSystem {
 
   void RemoveExtension(const ExtensionId& extension_id);
 
+  void EnableExtension(const ExtensionId& extension_id);
+  void DisableExtension(const ExtensionId& extension_id);
+
   // KeyedService implementation:
   void Shutdown() override;
 

--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -156,6 +156,22 @@ describe('chrome extensions', () => {
     await expect(customSession.loadExtension(path.join(fixtures, 'extensions', 'red-bg'))).to.eventually.be.rejectedWith('Extensions cannot be loaded in a temporary session');
   });
 
+  it('toggles an extension', async () => {
+    const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
+    const extension = await customSession.loadExtension(path.join(fixtures, 'extensions', 'red-bg'));
+    const w = new BrowserWindow({ show: false, webPreferences: { session: customSession } });
+
+    (customSession as any).disableExtension(extension.id);
+    await w.loadURL(url);
+    let bg = await w.webContents.executeJavaScript('document.documentElement.style.backgroundColor');
+    expect(bg).to.not.equal('red');
+
+    (customSession as any).enableExtension(extension.id);
+    await w.reload();
+    bg = await w.webContents.executeJavaScript('document.documentElement.style.backgroundColor');
+    expect(bg).to.equal('red');
+  });
+
   describe('chrome.i18n', () => {
     let w: BrowserWindow;
     let extension: Extension;


### PR DESCRIPTION
#### Description of Change

Allows the user to toggle an extension at runtime.

This is useful in cases where an extension should be loaded, but the user can decide whether or not it should run (ie. Chrome's extension toggle preferences).

TODO:
- [ ] Figure out whether to add `Session.isExtensionEnabled(boolean)` or modify `Session.getAllExtensions()` to include enabled state.
- [x] ~~Check if this can help solve #24977 (I did notice that the PDF extension shows up in an `extension-ready` event added in #25385).~~ PDF extension gets disabled, but it simply fails to load the plugin ([screenshot](https://user-images.githubusercontent.com/1656324/92865580-7f217b00-f3cc-11ea-817e-8f3bb0057c8c.png)).
- [ ] Verify that the modified `ExtensionPrefs` values are only in-memory.

Ref #19447

cc @sentialx - Let me know if you have any input on the direction here for these APIs.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `Session.enableExtension(extensionId)` and `Session.disableExtension(extensionId)`.
