### PR TITLE
chore: cherry-pick c1a7439efcc7 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -133,3 +133,4 @@ indexeddb_reset_async_tasks_in_webidbgetdbnamescallbacksimpl.patch
 reland_fix_uaf_in_selecttype.patch
 cherry-pick-f6cb89728f04.patch
 backport_1081874.patch
+backport_1122684.patch

--- a/patches/chromium/backport_1122684.patch
+++ b/patches/chromium/backport_1122684.patch
@@ -1,0 +1,149 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Thu, 4 Oct 2018 14:57:02 -0700
+Subject: fix: elide headers in QuicHttp3Logger
+
+[1122684] [High] [CVE-2020-15959]: Insufficient policy enforcement in networking.
+Backport https://chromium.googlesource.com/chromium/src/+/c1a7439efcc7626c34d3e38503c974e4c215c489.
+
+diff --git a/net/quic/quic_http3_logger.cc b/net/quic/quic_http3_logger.cc
+index 8240046a419ed41fa340c106f45d6e9468ec7bf9..4cebe54bce4df8daaffe1a31f07ffe431a96bff6 100644
+--- a/net/quic/quic_http3_logger.cc
++++ b/net/quic/quic_http3_logger.cc
+@@ -9,10 +9,13 @@
+ #include <vector>
+ 
+ #include "base/metrics/histogram_macros.h"
++#include "base/strings/strcat.h"
+ #include "base/strings/string_number_conversions.h"
++#include "net/http/http_log_util.h"
+ #include "net/log/net_log_capture_mode.h"
+ #include "net/log/net_log_event_type.h"
+ #include "net/log/net_log_values.h"
++#include "net/spdy/spdy_log_util.h"
+ 
+ namespace net {
+ 
+@@ -64,20 +67,19 @@ base::Value NetLogThreeIntParams(base::StringPiece name1,
+   return dict;
+ }
+ 
+-base::Value NetLogHeadersToDict(const quic::QuicHeaderList& headers) {
+-  base::Value dict(base::Value::Type::DICTIONARY);
+-  for (auto header : headers) {
+-    dict.SetStringKey(header.first, header.second);
+-  }
+-  return dict;
+-}
+-
+-base::Value NetLogHeadersToDict(const spdy::SpdyHeaderBlock& headers) {
+-  base::Value dict(base::Value::Type::DICTIONARY);
+-  for (auto header : headers) {
+-    dict.SetStringKey(header.first, header.second);
++base::ListValue ElideQuicHeaderListForNetLog(
++    const quic::QuicHeaderList& headers,
++    NetLogCaptureMode capture_mode) {
++  base::ListValue headers_list;
++  for (const auto& header : headers) {
++    base::StringPiece key = header.first;
++    base::StringPiece value = header.second;
++    headers_list.Append(NetLogStringValue(
++        base::StrCat({key, ": ",
++                      ElideHeaderValueForNetLog(capture_mode, key.as_string(),
++                                                value.as_string())})));
+   }
+-  return dict;
++  return headers_list;
+ }
+ 
+ }  // namespace
+@@ -235,11 +237,13 @@ void QuicHttp3Logger::OnHeadersDecoded(quic::QuicStreamId stream_id,
+     return;
+   }
+   net_log_.AddEvent(
+-      NetLogEventType::HTTP3_HEADERS_DECODED, [stream_id, &headers] {
++      NetLogEventType::HTTP3_HEADERS_DECODED,
++      [stream_id, &headers](NetLogCaptureMode capture_mode) {
+         base::Value dict(base::Value::Type::DICTIONARY);
+         dict.SetKey("stream_id",
+                     NetLogNumberValue(static_cast<uint64_t>(stream_id)));
+-        dict.SetKey("headers", NetLogHeadersToDict(headers));
++        dict.SetKey("headers",
++                    ElideQuicHeaderListForNetLog(headers, capture_mode));
+         return dict;
+       });
+ }
+@@ -266,16 +270,18 @@ void QuicHttp3Logger::OnPushPromiseDecoded(quic::QuicStreamId stream_id,
+   if (!net_log_.IsCapturing()) {
+     return;
+   }
+-  net_log_.AddEvent(NetLogEventType::HTTP3_PUSH_PROMISE_DECODED, [stream_id,
+-                                                                  push_id,
+-                                                                  &headers] {
+-    base::Value dict(base::Value::Type::DICTIONARY);
+-    dict.SetKey("stream_id",
+-                NetLogNumberValue(static_cast<uint64_t>(stream_id)));
+-    dict.SetKey("push_id", NetLogNumberValue(static_cast<uint64_t>(push_id)));
+-    dict.SetKey("headers", NetLogHeadersToDict(headers));
+-    return dict;
+-  });
++  net_log_.AddEvent(
++      NetLogEventType::HTTP3_PUSH_PROMISE_DECODED,
++      [stream_id, push_id, &headers](NetLogCaptureMode capture_mode) {
++        base::Value dict(base::Value::Type::DICTIONARY);
++        dict.SetKey("stream_id",
++                    NetLogNumberValue(static_cast<uint64_t>(stream_id)));
++        dict.SetKey("push_id",
++                    NetLogNumberValue(static_cast<uint64_t>(push_id)));
++        dict.SetKey("headers",
++                    ElideQuicHeaderListForNetLog(headers, capture_mode));
++        return dict;
++      });
+ }
+ 
+ void QuicHttp3Logger::OnUnknownFrameReceived(
+@@ -344,11 +350,13 @@ void QuicHttp3Logger::OnHeadersFrameSent(
+     return;
+   }
+   net_log_.AddEvent(
+-      NetLogEventType::HTTP3_HEADERS_SENT, [stream_id, &header_block] {
++      NetLogEventType::HTTP3_HEADERS_SENT,
++      [stream_id, &header_block](NetLogCaptureMode capture_mode) {
+         base::Value dict(base::Value::Type::DICTIONARY);
+         dict.SetKey("stream_id",
+                     NetLogNumberValue(static_cast<uint64_t>(stream_id)));
+-        dict.SetKey("headers", NetLogHeadersToDict(header_block));
++        dict.SetKey("headers",
++                    ElideSpdyHeaderBlockForNetLog(header_block, capture_mode));
+         return dict;
+       });
+ }
+@@ -360,16 +368,18 @@ void QuicHttp3Logger::OnPushPromiseFrameSent(
+   if (!net_log_.IsCapturing()) {
+     return;
+   }
+-  net_log_.AddEvent(NetLogEventType::HTTP3_PUSH_PROMISE_SENT, [stream_id,
+-                                                               push_id,
+-                                                               &header_block] {
+-    base::Value dict(base::Value::Type::DICTIONARY);
+-    dict.SetKey("stream_id",
+-                NetLogNumberValue(static_cast<uint64_t>(stream_id)));
+-    dict.SetKey("push_id", NetLogNumberValue(static_cast<uint64_t>(push_id)));
+-    dict.SetKey("headers", NetLogHeadersToDict(header_block));
+-    return dict;
+-  });
++  net_log_.AddEvent(
++      NetLogEventType::HTTP3_PUSH_PROMISE_SENT,
++      [stream_id, push_id, &header_block](NetLogCaptureMode capture_mode) {
++        base::Value dict(base::Value::Type::DICTIONARY);
++        dict.SetKey("stream_id",
++                    NetLogNumberValue(static_cast<uint64_t>(stream_id)));
++        dict.SetKey("push_id",
++                    NetLogNumberValue(static_cast<uint64_t>(push_id)));
++        dict.SetKey("headers",
++                    ElideSpdyHeaderBlockForNetLog(header_block, capture_mode));
++        return dict;
++      });
+ }
+ 
+ }  // namespace net


### PR DESCRIPTION
[1122684] [High] [CVE-2020-15959]: Insufficient policy enforcement in networking.
Backport https://chromium.googlesource.com/chromium/src/+/c1a7439efcc7626c34d3e38503c974e4c215c489.

Notes: Security: backported fix for 1122684.
