### PR TITLE
fix: crash on nativeImage on Windows on ARM

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1154,6 +1154,10 @@ if (is_mac) {
         "/DELAYLOAD:api-ms-win-core-winrt-string-l1-1-0.dll",
       ]
 
+      if (target_cpu == "arm64") {
+        ldflags += [ "/guard:cf,nolongjmp" ]
+      }
+
       # This is to support renaming of electron.exe. node-gyp has hard-coded
       # executable names which it will recognise as node. This module definition
       # file claims that the electron executable is in fact named "node.exe",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1155,7 +1155,7 @@ if (is_mac) {
       ]
 
       if (target_cpu == "arm64") {
-        ldflags -= [ "/guard:cf" ]
+        configs -= [ "//build/config/win:cfi_linker" ]
         ldflags += [ "/guard:cf,nolongjmp" ]
       }
 

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1155,6 +1155,7 @@ if (is_mac) {
       ]
 
       if (target_cpu == "arm64") {
+        ldflags -= [ "/guard:cf" ]
         ldflags += [ "/guard:cf,nolongjmp" ]
       }
 

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -173,13 +173,7 @@ describe('nativeImage module', () => {
       const imageB = nativeImage.createFromBitmap(imageA.toBitmap(), imageA.getSize());
       expect(imageB.getSize()).to.deep.equal({ width: 538, height: 190 });
 
-      let imageC;
-      // TODO fix nativeImage.createFromBuffer from bitmaps on WOA.  See https://github.com/electron/electron/issues/25069
-      if (process.platform === 'win32' && process.arch === 'arm64') {
-        imageC = nativeImage.createFromBuffer(imageA.toPNG(), { ...imageA.getSize(), scaleFactor: 2.0 });
-      } else {
-        imageC = nativeImage.createFromBuffer(imageA.toBitmap(), { ...imageA.getSize(), scaleFactor: 2.0 });
-      }
+      const imageC = nativeImage.createFromBuffer(imageA.toBitmap(), { ...imageA.getSize(), scaleFactor: 2.0 });
       expect(imageC.getSize()).to.deep.equal({ width: 269, height: 95 });
     });
 
@@ -192,8 +186,7 @@ describe('nativeImage module', () => {
     });
   });
 
-  // TODO fix nativeImage.createFromBuffer on WOA.  See https://github.com/electron/electron/issues/25069
-  ifdescribe(!(process.platform === 'win32' && process.arch === 'arm64'))('createFromBuffer(buffer, options)', () => {
+  describe('createFromBuffer(buffer, options)', () => {
     it('returns an empty image when the buffer is empty', () => {
       expect(nativeImage.createFromBuffer(Buffer.from([])).isEmpty()).to.be.true();
     });
@@ -347,8 +340,7 @@ describe('nativeImage module', () => {
   });
 
   describe('createFromPath(path)', () => {
-    // TODO fix nativeImage.createFromPath on WOA.  See https://github.com/electron/electron/issues/25069
-    ifit(!(process.platform === 'win32' && process.arch === 'arm64'))('returns an empty image for invalid paths', () => {
+    it('returns an empty image for invalid paths', () => {
       expect(nativeImage.createFromPath('').isEmpty()).to.be.true();
       expect(nativeImage.createFromPath('does-not-exist.png').isEmpty()).to.be.true();
       expect(nativeImage.createFromPath('does-not-exist.ico').isEmpty()).to.be.true();
@@ -520,8 +512,7 @@ describe('nativeImage module', () => {
   });
 
   describe('addRepresentation()', () => {
-    // TODO fix nativeImage.createFromBuffer on WOA.  See https://github.com/electron/electron/issues/25069
-    ifit(!(process.platform === 'win32' && process.arch === 'arm64'))('does not add representation when the buffer is too small', () => {
+    it('does not add representation when the buffer is too small', () => {
       const image = nativeImage.createEmpty();
 
       image.addRepresentation({


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
This PR fixes the crashes on WOA when using nativeImage.  This issue was caused by this change:
https://source.chromium.org/chromium/chromium/src/+/master:build/config/win/BUILD.gn;l=100;bpv=1;bpt=0, so this PR reverts that change on WOA until the upstream issues  https://bugs.chromium.org/p/chromium/issues/detail?id=1126549 and https://bugs.llvm.org/show_bug.cgi?id=47463 are resolved.

Fixes #25069 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->Fixed crashes using nativeImage on Windows on ARM.
