### PR TITLE
chore: remove unused imports in our python scripts

### DIFF
--- a/build/profile_toolchain.py
+++ b/build/profile_toolchain.py
@@ -11,7 +11,6 @@ import find_depot_tools
 from vs_toolchain import \
     SetEnvironmentAndGetRuntimeDllDirs, \
     SetEnvironmentAndGetSDKDir, \
-    GetVisualStudioVersion, \
     NormalizePath
 
 sys.path.append("%s/win_toolchain" % find_depot_tools.add_depot_tools_to_path())

--- a/build/run-in-dir.py
+++ b/build/run-in-dir.py
@@ -1,6 +1,5 @@
 import sys
 import os
-import subprocess
 
 def main(argv):
   cwd = argv[1]

--- a/script/apply_all_patches.py
+++ b/script/apply_all_patches.py
@@ -3,7 +3,6 @@
 import argparse
 import json
 import os
-import sys
 
 from lib import git
 from lib.patches import patch_from_dir

--- a/script/dbus_mock.py
+++ b/script/dbus_mock.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import atexit
 import os
 import subprocess
 import sys

--- a/script/export_all_patches.py
+++ b/script/export_all_patches.py
@@ -2,8 +2,6 @@
 
 import argparse
 import json
-import os
-import sys
 
 from lib import git
 

--- a/script/git-export-patches
+++ b/script/git-export-patches
@@ -1,9 +1,6 @@
 #!/usr/bin/env python2
 
 import argparse
-import os
-import re
-import subprocess
 import sys
 
 from lib import git

--- a/script/git-import-patches
+++ b/script/git-import-patches
@@ -1,7 +1,6 @@
 #!/usr/bin/env python2
 
 import argparse
-import os
 import sys
 
 from lib import git

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-import errno
 import os
-import platform
 import sys
 
 # URL to the mips64el sysroot image.

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -3,12 +3,9 @@
 from __future__ import print_function
 import atexit
 import contextlib
-import datetime
 import errno
 import json
 import os
-import platform
-import re
 import shutil
 import ssl
 import stat
@@ -23,8 +20,7 @@ except ImportError:
   from urllib2 import urlopen
 import zipfile
 
-from lib.config import is_verbose_mode, PLATFORM
-from lib.env_util import get_vs_env
+from lib.config import is_verbose_mode
 
 ELECTRON_DIR = os.path.abspath(
   os.path.dirname(os.path.dirname(os.path.dirname(__file__)))

--- a/script/release/uploaders/upload-symbols.py
+++ b/script/release/uploaders/upload-symbols.py
@@ -14,8 +14,8 @@ def is_fs_case_sensitive():
 sys.path.append(
   os.path.abspath(os.path.dirname(os.path.abspath(__file__)) + "/../.."))
 
-from lib.config import PLATFORM, s3_config, enable_verbose_mode
-from lib.util import get_electron_branding, execute, rm_rf, safe_mkdir, s3put, \
+from lib.config import PLATFORM, s3_config
+from lib.util import get_electron_branding, execute, s3put, \
                      get_out_dir, ELECTRON_DIR
 
 RELEASE_DIR = get_out_dir()

--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -3,7 +3,6 @@
 from __future__ import print_function
 import argparse
 import datetime
-import errno
 import hashlib
 import json
 import mmap
@@ -12,18 +11,16 @@ import shutil
 import subprocess
 from struct import Struct
 import sys
-import tempfile
 
 sys.path.append(
   os.path.abspath(os.path.dirname(os.path.abspath(__file__)) + "/../.."))
 
-from io import StringIO
 from zipfile import ZipFile
 from lib.config import PLATFORM, get_target_arch,  get_env_var, s3_config, \
                        get_zip_name
 from lib.util import get_electron_branding, execute, get_electron_version, \
-                     scoped_cwd, s3put, get_electron_exec, \
-                     get_out_dir, SRC_DIR, ELECTRON_DIR
+                     s3put, get_electron_exec, get_out_dir, \
+                     SRC_DIR, ELECTRON_DIR
 
 
 ELECTRON_REPO = 'electron/electron'

--- a/script/verify-chromedriver.py
+++ b/script/verify-chromedriver.py
@@ -5,10 +5,8 @@ from __future__ import print_function
 import argparse
 import os
 import re
-import shlex
 import subprocess
 import sys
-import time
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 

--- a/script/verify-mksnapshot.py
+++ b/script/verify-mksnapshot.py
@@ -7,7 +7,6 @@ import shutil
 import subprocess
 import sys
 
-from lib.config import get_target_arch
 from lib.util import get_electron_branding, rm_rf, scoped_cwd
 
 PROJECT_NAME = get_electron_branding()['project_name']


### PR DESCRIPTION
#### Description of Change

Simple cleanup patch that removes some 'unused import' warnings in our python scripts.

Seen at [lgtm](https://lgtm.com/projects/g/electron/electron/?mode=list&id=py%2Funused-import) and confirmed with manual inspection.

No particular stakeholders; review from anyone is welcomed

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none