### PR TITLE
refactor: use owner window for BrowserWindow.fromWebContents

### DIFF
--- a/lib/browser/api/browser-window.ts
+++ b/lib/browser/api/browser-window.ts
@@ -92,11 +92,7 @@ BrowserWindow.getFocusedWindow = () => {
 };
 
 BrowserWindow.fromWebContents = (webContents: WebContents) => {
-  for (const window of BrowserWindow.getAllWindows()) {
-    if (window.webContents && window.webContents.equal(webContents)) return window;
-  }
-
-  return null;
+  return webContents.getOwnerBrowserWindow();
 };
 
 BrowserWindow.fromBrowserView = (browserView: BrowserView) => {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1584,6 +1584,10 @@ describe('BrowserWindow module', () => {
       const w = new BrowserWindow({ show: false });
       const bv = new BrowserView();
       w.setBrowserView(bv);
+      defer(() => {
+        w.removeBrowserView(bv);
+        (bv.webContents as any).destroy();
+      });
       await bv.webContents.loadURL('about:blank');
       expect(BrowserWindow.fromWebContents(bv.webContents)!.id).to.equal(w.id);
     });

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1579,6 +1579,26 @@ describe('BrowserWindow module', () => {
         contents.destroy();
       }
     });
+
+    it('returns the correct window for a BrowserView webcontents', async () => {
+      const w = new BrowserWindow({ show: false });
+      const bv = new BrowserView();
+      w.setBrowserView(bv);
+      await bv.webContents.loadURL('about:blank');
+      expect(BrowserWindow.fromWebContents(bv.webContents)!.id).to.equal(w.id);
+    });
+
+    it('returns the correct window for a WebView webcontents', async () => {
+      const w = new BrowserWindow({ show: false, webPreferences: { webviewTag: true } });
+      w.loadURL('data:text/html,<webview src="data:text/html,hi"></webview>');
+      // NOTE(nornagon): Waiting for 'did-attach-webview' is a workaround for
+      // https://github.com/electron/electron/issues/25413, and is not integral
+      // to the test.
+      const p = emittedOnce(w.webContents, 'did-attach-webview');
+      const [, webviewContents] = await emittedOnce(app, 'web-contents-created');
+      expect(BrowserWindow.fromWebContents(webviewContents)!.id).to.equal(w.id);
+      await p;
+    });
   });
 
   describe('BrowserWindow.openDevTools()', () => {


### PR DESCRIPTION
#### Description of Change
I _think_ this is strictly more accurate than the previous implementation, in
that it should work for BrowserView (and maybe webview too?).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: BrowserWindow.fromWebContents() now returns an accurate result for WebContents in a BrowserView or webview.
