### PR TITLE
chore: remove unused code from our js scripts

### DIFF
--- a/script/doc-only-change.js
+++ b/script/doc-only-change.js
@@ -3,8 +3,6 @@ const { Octokit } = require('@octokit/rest');
 const octokit = new Octokit();
 const path = require('path');
 
-const SOURCE_ROOT = path.normalize(path.dirname(__dirname));
-
 async function checkIfDocOnlyChange () {
   if (args.prNumber || args.prBranch || args.prURL) {
     try {

--- a/script/node-spec-runner.js
+++ b/script/node-spec-runner.js
@@ -10,12 +10,10 @@ const args = require('minimist')(process.argv.slice(2), {
 const BASE = path.resolve(__dirname, '../..');
 const DISABLED_TESTS = require('./node-disabled-tests.json');
 const NODE_DIR = path.resolve(BASE, 'third_party', 'electron_node');
-const NPX_CMD = process.platform === 'win32' ? 'npx.cmd' : 'npx';
 const JUNIT_DIR = args.jUnitDir ? path.resolve(args.jUnitDir) : null;
 const TAP_FILE_NAME = 'test.tap';
 
 const utils = require('./lib/utils');
-const { YARN_VERSION } = require('./yarn');
 
 if (!process.mainModule) {
   throw new Error('Must call the node spec runner directly');

--- a/script/release/ci-release-build.js
+++ b/script/release/ci-release-build.js
@@ -91,7 +91,6 @@ async function circleCIcall (targetBranch, job, options) {
   try {
     const circleResponse = await circleCIRequest(CIRCLECI_PIPELINE_URL, 'POST', buildRequest);
     console.log(`CircleCI release build pipeline ${circleResponse.id} for ${job} triggered.`);
-    const pipelineInfoUrl = `https://circleci.com/api/v2/pipeline/${circleResponse.id}`;
     const workflowId = await getCircleCIWorkflowId(circleResponse.id);
     if (workflowId === -1) {
       return;

--- a/script/release/release-artifact-cleanup.js
+++ b/script/release/release-artifact-cleanup.js
@@ -5,7 +5,6 @@ const args = require('minimist')(process.argv.slice(2), {
   string: ['tag', 'releaseID'],
   default: { releaseID: '' }
 });
-const path = require('path');
 const { execSync } = require('child_process');
 const { GitProcess } = require('dugite');
 const { getCurrentBranch, ELECTRON_DIR } = require('../lib/utils.js');

--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -30,7 +30,6 @@ const utils = require('./lib/utils');
 const { YARN_VERSION } = require('./yarn');
 
 const BASE = path.resolve(__dirname, '../..');
-const NPM_CMD = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 const NPX_CMD = process.platform === 'win32' ? 'npx.cmd' : 'npx';
 
 const runners = new Map([

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -2,7 +2,7 @@
 process.throwDeprecation = false;
 
 const electron = require('electron');
-const { app, BrowserWindow, crashReporter, dialog, ipcMain, protocol, webContents, session } = electron;
+const { app, BrowserWindow, dialog, ipcMain, protocol, webContents, session } = electron;
 
 try {
   require('fs').rmdirSync(app.getPath('userData'), { recursive: true });


### PR DESCRIPTION
#### Description of Change

Similar to yesterday's Python PR @ #25406, this is a simple cleanup patch that removes some unused import/requires and vars in our javscript scripts.

h/t again to lgtm for collating these.

No particular stakeholders; review from anyone is welcomed.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none