### PR TITLE
fix: Ensure electron delay loads the same modules as chromium

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1139,7 +1139,7 @@ if (is_mac) {
       ]
 
       ldflags = []
-      
+
       libs = [
         "comctl32.lib",
         "uiautomationcore.lib",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1138,13 +1138,13 @@ if (is_mac) {
         "//components/crash/core/app:run_as_crashpad_handler",
       ]
 
+      ldflags = []
+      
       libs = [
         "comctl32.lib",
         "uiautomationcore.lib",
         "wtsapi32.lib",
       ]
-
-      ldflags = []
 
       configs += [
         "//build/config/win:windowed",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1144,14 +1144,11 @@ if (is_mac) {
         "wtsapi32.lib",
       ]
 
-      configs += [ "//build/config/win:windowed" ]
+      ldflags = []
 
-      ldflags = [
-        # Windows 7 doesn't have these DLLs.
-        # TODO: are there other DLLs we need to list here to be win7
-        # compatible?
-        "/DELAYLOAD:api-ms-win-core-winrt-l1-1-0.dll",
-        "/DELAYLOAD:api-ms-win-core-winrt-string-l1-1-0.dll",
+      configs += [
+        "//build/config/win:windowed",
+        "//build/config/win:delayloads",
       ]
 
       if (target_cpu == "arm64") {


### PR DESCRIPTION
This change adds the same module delay load list that chromium uses for electron.  Some modules were already getting delay loaded from other build files in chromium but not the main list via //build/config/win:delayloads.  We do not include the list of delay loads in delayloads_not_for_child_dll as those have issues being loaded in sandboxes processes.  This will reduce the overall reference set impact of the electron processes.
notes: Added missing module delay loads on windows to reduce per process reference set impact