### PR TITLE
fix: call node::Stop on exit

### DIFF
--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -290,6 +290,7 @@ int NodeMain(int argc, char* argv[]) {
 
     node::RunAtExit(env);
     node::FreeEnvironment(env);
+    node::Stop(env);
     node::FreeIsolateData(isolate_data);
 
     gin_env.platform()->DrainTasks(isolate);

--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -284,13 +284,12 @@ int NodeMain(int argc, char* argv[]) {
 
     node::ResetStdio();
 
-    env->set_can_call_into_js(false);
+    node::Stop(env);
     env->stop_sub_worker_contexts();
     env->RunCleanup();
 
     node::RunAtExit(env);
     node::FreeEnvironment(env);
-    node::Stop(env);
     node::FreeIsolateData(isolate_data);
 
     gin_env.platform()->DrainTasks(isolate);

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -551,6 +551,7 @@ void ElectronBrowserMainParts::PostMainMessageLoopRun() {
   node_debugger_->Stop();
   node_env_->env()->set_trace_sync_io(false);
   js_env_->OnMessageLoopDestroying();
+  node::Stop(node_env_->env());
   node_env_.reset();
 
   ElectronBrowserContext::browser_context_map().clear();


### PR DESCRIPTION
#### Description of Change
I believe this fixes #25267, the "illegal access" message we sometimes see at exit.

I don't have a test or a full root cause analysis for this yet, but what appears to be happening is this:

1. When we call `node::FreeEnvironment` from `ElectronBrowserMainParts::PostMainMessageLoopRun`, it calls `node::CleanupHandles`.
2. `node::CleanupHandles` disallows JS execution, using [`Isolate::DisallowJavascriptExecutionScope`](https://github.com/nodejs/node/blob/b1831fed3a289d883944d23d2130368d90a48be2/src/env.cc#L595).
3. `node::CleanupHandles` [triggers a uv loop run](https://github.com/nodejs/node/blob/b1831fed3a289d883944d23d2130368d90a48be2/src/env.cc#L613), which triggers [`ElectronBindings::OnCallNextTick`](https://github.com/electron/electron/blob/ce865914594af79f0311a361a9d3c9a55d875f45/shell/common/api/electron_bindings.cc#L114).
4. `ElectronBindings::OnCallNextTick` [runs the microtask queue](https://github.com/electron/electron/blob/ce865914594af79f0311a361a9d3c9a55d875f45/shell/common/api/electron_bindings.cc#L123), which sometimes includes an entry into JS. (Not always, though. This is the bit I'm confused about: what are the conditions in which there's a pending JS microtask here?)
5. Attempting to execute JS while JS execution is disallowed [throws an "illegal access" exception](https://source.chromium.org/chromium/chromium/src/+/master:v8/src/execution/execution.cc;l=312;drc=2e96276c762073eb1e4de8a95bb944bd764f75fb).

This change causes `env->can_call_into_js()` to return false after `node::Stop()` is called, which means `InternalCallbackScope::Close()` [won't run any JS](https://github.com/nodejs/node/blob/a038199265519fa4db88a639b0e438675d23c4d1/src/api/callback.cc#L85), which avoids this error.

The remaining questions in my mind are:
1. Why were we not calling `node::Stop()` before? Was it simply an oversight, or was it an intentional choice?
2. Under what circumstances does `CleanupHandles` end up invoking JS? What is putting a JS task in the microtask queue during exit?
3. How can we write a test for this?

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue that could cause a normally-exiting process to fail with an "illegal access" message and exit code 7.
