### PR TITLE
docs: pepper flash plugin info appears at chrome://version now

### DIFF
--- a/docs/tutorial/using-pepper-flash-plugin.md
+++ b/docs/tutorial/using-pepper-flash-plugin.md
@@ -7,7 +7,7 @@ and then enable it in your application.
 ## Prepare a Copy of Flash Plugin
 
 On macOS and Linux, the details of the Pepper Flash plugin can be found by
-navigating to `chrome://flash` in the Chrome browser. Its location and version
+navigating to `chrome://version` in the Chrome browser. Its location and version
 are useful for Electron's Pepper Flash support. You can also copy it to another
 location.
 


### PR DESCRIPTION
#### Description of Change

`chrome://flash` doesn't seem to exist anymore, but similar information appears at `chrome://version`.

#### Checklist


#### Release Notes

Notes: none
