### PR TITLE
fix: ensure ready-to-show event is fired

### DIFF
--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -49,6 +49,8 @@ class BrowserWindow : public TopLevelWindow,
                              content::RenderViewHost* new_host) override;
   void RenderViewCreated(content::RenderViewHost* render_view_host) override;
   void DidFirstVisuallyNonEmptyPaint() override;
+  void DidFinishLoad(content::RenderFrameHost* render_frame_host,
+                     const GURL& validated_url) override;
   void BeforeUnloadDialogCancelled() override;
   void OnRendererUnresponsive(content::RenderProcessHost*) override;
   void OnRendererResponsive(
@@ -118,6 +120,8 @@ class BrowserWindow : public TopLevelWindow,
   // Closure that would be called when window is unresponsive when closing,
   // it should be cancelled when we can prove that the window is responsive.
   base::CancelableClosure window_unresponsive_closure_;
+
+  bool did_ready_to_show_fired_ = false;
 
 #if defined(OS_MACOSX)
   std::vector<mojom::DraggableRegionPtr> draggable_regions_;

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1280,7 +1280,7 @@ describe('BrowserWindow module', () => {
 
     it('preserves transparency', async () => {
       const w = new BrowserWindow({ show: false, transparent: true });
-      w.loadURL('about:blank');
+      w.loadFile(path.join(fixtures, 'pages', 'theme-color.html'));
       await emittedOnce(w, 'ready-to-show');
       w.show();
 


### PR DESCRIPTION
Backport of #25448

See that PR for details.

Notes: Fix `ready-to-show` event not emitted on some machines.