### PR TITLE
test: retry the "v8 samples" test for a few times

### DIFF
--- a/spec-main/api-content-tracing-spec.ts
+++ b/spec-main/api-content-tracing-spec.ts
@@ -122,7 +122,10 @@ ifdescribe(!(process.platform !== 'win32' && ['arm', 'arm64'].includes(process.a
   });
 
   describe('captured events', () => {
-    it('include V8 samples from the main process', async () => {
+    it('include V8 samples from the main process', async function () {
+      // This test is flaky on macOS CI.
+      this.retries(3);
+
       await contentTracing.startRecording({
         categoryFilter: 'disabled-by-default-v8.cpu_profiler',
         traceOptions: 'record-until-full'


### PR DESCRIPTION
#### Description of Change

The "include V8 samples from the main process" test has been flaky on macOS CI, for example some recent runs:
https://app.circleci.com/pipelines/github/electron/electron/29836/workflows/287feb4c-5dd8-476f-a96b-d5c132fc51f9/jobs/658074
https://app.circleci.com/pipelines/github/electron/electron/29824/workflows/e69824d3-727a-490b-83b1-a766e64ce18f/jobs/657685
https://app.circleci.com/pipelines/github/electron/electron/29802/workflows/177d7a61-3cc8-40e4-8a59-b8bf7465f4e3/jobs/657224

I don't have a good idea of how to make it more reliable, but making it retry for a few times should be fine since we only need to know that the v8 samples can be captured.

#### Release Notes

Notes: none