### PR TITLE
feat: allow disabling touchBar text input emoji picker

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -192,6 +192,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     `false`.
   * `disableAutoHideCursor` Boolean (optional) - Whether to hide cursor when typing.
     Default is `false`.
+  * `disableTouchBarEmojiPicker`  Boolean (optional) - Whether to automatically add an emoji picker to the touchBar
+    when inside a text input. Default is `false`.
   * `autoHideMenuBar` Boolean (optional) - Auto hide the menu bar unless the `Alt`
     key is pressed. Default is `false`.
   * `enableLargerThanScreen` Boolean (optional) - Enable the window to be resized larger
@@ -1739,6 +1741,12 @@ Returns `BrowserWindow[]` - All child windows.
 * `autoHide` Boolean
 
 Controls whether to hide cursor when typing.
+
+#### `win.setDisableTouchbarEmojiPicker(disable)` _macOS_
+
+* `disable` Boolean
+
+Controls whether or not an emoji picker should be placed in the TouchBar when inside a text input.
 
 #### `win.selectPreviousTab()` _macOS_
 

--- a/patches/chromium/render_widget_host_view_mac.patch
+++ b/patches/chromium/render_widget_host_view_mac.patch
@@ -10,22 +10,23 @@ kinds of utility windows. Similarly for `disableAutoHideCursor`.
 Additionally, disables usage of some private APIs in MAS builds.
 
 diff --git a/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm b/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
-index eae6d8c330a523e85c7997e59091be0ce42031dc..3f23af8dca0d8a1fa149877cde1a553360610eba 100644
+index eae6d8c330a523e85c7997e59091be0ce42031dc..5cc4fe9cba065941a75594ac00fb7aff62c7d963 100644
 --- a/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
 +++ b/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
-@@ -154,6 +154,11 @@ void ExtractUnderlines(NSAttributedString* string,
+@@ -154,6 +154,12 @@ void ExtractUnderlines(NSAttributedString* string,
  
  }  // namespace
  
 +@interface NSWindow (AtomCustomMethods)
 +- (BOOL)acceptsFirstMouse;
 +- (BOOL)disableAutoHideCursor;
++- (BOOL)disableTouchbarEmojiPicker;
 +@end
 +
  // These are not documented, so use only after checking -respondsToSelector:.
  @interface NSApplication (UndocumentedSpeechMethods)
  - (void)speakString:(NSString*)string;
-@@ -573,6 +578,9 @@ - (BOOL)acceptsMouseEventsWhenInactive {
+@@ -573,6 +579,9 @@ - (BOOL)acceptsMouseEventsWhenInactive {
  }
  
  - (BOOL)acceptsFirstMouse:(NSEvent*)theEvent {
@@ -35,7 +36,7 @@ index eae6d8c330a523e85c7997e59091be0ce42031dc..3f23af8dca0d8a1fa149877cde1a5533
    return [self acceptsMouseEventsWhenInactive];
  }
  
-@@ -996,6 +1004,10 @@ - (void)keyEvent:(NSEvent*)theEvent wasKeyEquivalent:(BOOL)equiv {
+@@ -996,6 +1005,10 @@ - (void)keyEvent:(NSEvent*)theEvent wasKeyEquivalent:(BOOL)equiv {
                                eventType == NSKeyDown &&
                                !(modifierFlags & NSCommandKeyMask);
  
@@ -46,7 +47,7 @@ index eae6d8c330a523e85c7997e59091be0ce42031dc..3f23af8dca0d8a1fa149877cde1a5533
    // We only handle key down events and just simply forward other events.
    if (eventType != NSKeyDown) {
      _hostHelper->ForwardKeyboardEvent(event, latency_info);
-@@ -1772,9 +1784,11 @@ - (NSAccessibilityRole)accessibilityRole {
+@@ -1772,9 +1785,11 @@ - (NSAccessibilityRole)accessibilityRole {
  // Since this implementation doesn't have to wait any IPC calls, this doesn't
  // make any key-typing jank. --hbono 7/23/09
  //
@@ -58,7 +59,7 @@ index eae6d8c330a523e85c7997e59091be0ce42031dc..3f23af8dca0d8a1fa149877cde1a5533
  
  - (NSArray*)validAttributesForMarkedText {
    // This code is just copied from WebKit except renaming variables.
-@@ -1783,7 +1797,10 @@ - (NSArray*)validAttributesForMarkedText {
+@@ -1783,7 +1798,10 @@ - (NSArray*)validAttributesForMarkedText {
          initWithObjects:NSUnderlineStyleAttributeName,
                          NSUnderlineColorAttributeName,
                          NSMarkedClauseSegmentAttributeName,
@@ -70,3 +71,14 @@ index eae6d8c330a523e85c7997e59091be0ce42031dc..3f23af8dca0d8a1fa149877cde1a5533
    }
    return _validAttributesForMarkedText.get();
  }
+@@ -2225,6 +2243,10 @@ - (NSTouchBar*)makeTouchBar {
+         _textInputType == ui::TEXT_INPUT_TYPE_SEARCH ||
+         _textInputType == ui::TEXT_INPUT_TYPE_TEXT_AREA ||
+         _textInputType == ui::TEXT_INPUT_TYPE_CONTENT_EDITABLE;
++    
++    if ([[self window] respondsToSelector:@selector(disableTouchbarEmojiPicker)] &&
++      [[self window] disableTouchbarEmojiPicker])
++      includeEmojiPicker = false;
+     if (includeEmojiPicker) {
+       touchBar.defaultItemIdentifiers = @[
+         NSTouchBarItemIdentifierCharacterPicker,

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -821,6 +821,10 @@ void BaseWindow::SetAutoHideCursor(bool auto_hide) {
   window_->SetAutoHideCursor(auto_hide);
 }
 
+void BaseWindow::SetDisableTouchbarEmojiPicker(bool disable) {
+  window_->SetDisableTouchbarEmojiPicker(disable);
+}
+
 void BaseWindow::SetVibrancy(v8::Isolate* isolate, v8::Local<v8::Value> value) {
   std::string type = gin::V8ToString(isolate, value);
   window_->SetVibrancy(type);
@@ -1190,6 +1194,8 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
                  &BaseWindow::IsVisibleOnAllWorkspaces)
 #if defined(OS_MAC)
       .SetMethod("setAutoHideCursor", &BaseWindow::SetAutoHideCursor)
+      .SetMethod("setDisableTouchbarEmojiPicker",
+                 &BaseWindow::SetDisableTouchbarEmojiPicker)
 #endif
       .SetMethod("setVibrancy", &BaseWindow::SetVibrancy)
 #if defined(OS_MAC)

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -182,6 +182,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void SetVisibleOnAllWorkspaces(bool visible, gin_helper::Arguments* args);
   bool IsVisibleOnAllWorkspaces();
   void SetAutoHideCursor(bool auto_hide);
+  void SetDisableTouchbarEmojiPicker(bool disable);
   virtual void SetVibrancy(v8::Isolate* isolate, v8::Local<v8::Value> value);
 
 #if defined(OS_MAC)

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -332,6 +332,8 @@ void NativeWindow::SetParentWindow(NativeWindow* parent) {
 
 void NativeWindow::SetAutoHideCursor(bool auto_hide) {}
 
+void NativeWindow::SetDisableTouchbarEmojiPicker(bool disable) {}
+
 void NativeWindow::SelectPreviousTab() {}
 
 void NativeWindow::SelectNextTab() {}

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -192,6 +192,8 @@ class NativeWindow : public base::SupportsUserData,
 
   virtual void SetAutoHideCursor(bool auto_hide);
 
+  virtual void SetDisableTouchbarEmojiPicker(bool disable);
+
   // Vibrancy API
   virtual void SetVibrancy(const std::string& type);
 

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -124,6 +124,8 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
 
   void SetAutoHideCursor(bool auto_hide) override;
 
+  void SetDisableTouchbarEmojiPicker(bool disable) override;
+
   void SelectPreviousTab() override;
   void SelectNextTab() override;
   void MergeAllWindows() override;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -498,6 +498,13 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   options.Get(options::kDisableAutoHideCursor, &disableAutoHideCursor);
   [window_ setDisableAutoHideCursor:disableAutoHideCursor];
 
+  // Disable the emoji picker that Chrome automatically places in the touchbar
+  // when inside a text/text area/search/contenteditable.
+  bool disableTouchbarEmojiPicker = false;
+  options.Get(options::kDisableTouchbarEmojiPicker,
+              &disableTouchbarEmojiPicker);
+  [window_ setDisableTouchbarEmojiPicker:disableTouchbarEmojiPicker];
+
   // Use an NSEvent monitor to listen for the wheel event.
   BOOL __block began = NO;
   wheel_event_monitor_ = [NSEvent
@@ -1405,6 +1412,10 @@ bool NativeWindowMac::IsVisibleOnAllWorkspaces() {
 
 void NativeWindowMac::SetAutoHideCursor(bool auto_hide) {
   [window_ setDisableAutoHideCursor:!auto_hide];
+}
+
+void NativeWindowMac::SetDisableTouchbarEmojiPicker(bool disable) {
+  [window_ setDisableTouchbarEmojiPicker:disable];
 }
 
 void NativeWindowMac::SelectPreviousTab() {

--- a/shell/browser/ui/cocoa/electron_ns_window.h
+++ b/shell/browser/ui/cocoa/electron_ns_window.h
@@ -34,6 +34,7 @@ class ScopedDisableResize {
 @property BOOL acceptsFirstMouse;
 @property BOOL enableLargerThanScreen;
 @property BOOL disableAutoHideCursor;
+@property BOOL disableTouchbarEmojiPicker;
 @property BOOL disableKeyOrMainWindow;
 @property(nonatomic, retain) NSView* vibrantView;
 @property(nonatomic, retain) NSImage* cornerMask;

--- a/shell/browser/ui/cocoa/electron_ns_window.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window.mm
@@ -26,6 +26,7 @@ bool ScopedDisableResize::disable_resize_ = false;
 @synthesize acceptsFirstMouse;
 @synthesize enableLargerThanScreen;
 @synthesize disableAutoHideCursor;
+@synthesize disableTouchbarEmojiPicker;
 @synthesize disableKeyOrMainWindow;
 @synthesize vibrantView;
 @synthesize cornerMask;

--- a/shell/common/options_switches.cc
+++ b/shell/common/options_switches.cc
@@ -78,6 +78,9 @@ const char kType[] = "type";
 // Disable auto-hiding cursor.
 const char kDisableAutoHideCursor[] = "disableAutoHideCursor";
 
+// Disable TouchBar emoji picker for text fields.
+const char kDisableTouchbarEmojiPicker[] = "disableTouchbarEmojiPicker";
+
 // Use the macOS' standard window instead of the textured window.
 const char kStandardWindow[] = "standardWindow";
 

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -47,6 +47,7 @@ extern const char kDarkTheme[];
 extern const char kTransparent[];
 extern const char kType[];
 extern const char kDisableAutoHideCursor[];
+extern const char kDisableTouchbarEmojiPicker[];
 extern const char kStandardWindow[];
 extern const char kBackgroundColor[];
 extern const char kHasShadow[];


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/25465.

In https://chromium-review.googlesource.com/c/chromium/src/+/1953663, Chromium made it such that an emoji picker was included on the touch bar for most web text fields. This was added in a non-removable fashion and as @bpasero notes in https://github.com/electron/electron/issues/25465 takes up valuable space. As such, we should make it such that the emoji picker is an opt-out feature that can be removed by developers looking to maximize touchbar space.

Tested with https://gist.github.com/0c443233a57982129eb02a8dbe72272c.

cc @zcbenz @deepak1556 @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Allowed for opt-out of the emoji picker placed in the touchBar on macOS in most web fields.
