### PR TITLE
build: fix build with enable_pdf_viewer=false

### DIFF
--- a/electron_paks.gni
+++ b/electron_paks.gni
@@ -55,7 +55,6 @@ template("electron_extra_paks") {
     output = "${invoker.output_dir}/resources.pak"
     sources = [
       "$root_gen_dir/chrome/dev_ui_browser_resources.pak",
-      "$root_gen_dir/chrome/print_preview_pdf_resources.pak",
       "$root_gen_dir/components/components_resources.pak",
       "$root_gen_dir/content/browser/resources/media/media_internals_resources.pak",
       "$root_gen_dir/content/browser/tracing/tracing_resources.pak",
@@ -71,7 +70,6 @@ template("electron_extra_paks") {
     ]
     deps = [
       "//chrome/browser:dev_ui_browser_resources",
-      "//chrome/browser/resources:print_preview_pdf_resources",
       "//components/resources",
       "//content:content_resources",
       "//content:dev_ui_content_resources",
@@ -96,6 +94,10 @@ template("electron_extra_paks") {
     sources +=
         [ "$root_gen_dir/content/browser/devtools/devtools_resources.pak" ]
     deps += [ "//content/browser/devtools:devtools_resources" ]
+    if (enable_pdf_viewer) {
+      sources += [ "$root_gen_dir/chrome/print_preview_pdf_resources.pak" ]
+      deps += [ "//chrome/browser/resources:print_preview_pdf_resources" ]
+    }
     if (enable_print_preview) {
       sources += [ "$root_gen_dir/chrome/print_preview_resources.pak" ]
       deps += [ "//chrome/browser/resources:print_preview_resources" ]

--- a/shell/browser/extensions/electron_extensions_api_client.cc
+++ b/shell/browser/extensions/electron_extensions_api_client.cc
@@ -7,13 +7,14 @@
 #include <memory>
 #include <string>
 
+#include "electron/buildflags/buildflags.h"
 #include "extensions/browser/guest_view/mime_handler_view/mime_handler_view_guest_delegate.h"
 #include "printing/buildflags/buildflags.h"
 #include "shell/browser/extensions/api/management/electron_management_api_delegate.h"
 #include "shell/browser/extensions/electron_extension_web_contents_observer.h"
 #include "shell/browser/extensions/electron_messaging_delegate.h"
 
-#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+#if BUILDFLAG(ENABLE_PDF_VIEWER)
 #include "components/pdf/browser/pdf_web_contents_helper.h"
 #include "shell/browser/electron_pdf_web_contents_helper_client.h"
 #endif
@@ -54,7 +55,7 @@ void ElectronExtensionsAPIClient::AttachWebContentsHelpers(
   extensions::ElectronExtensionWebContentsObserver::CreateForWebContents(
       web_contents);
 
-#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+#if BUILDFLAG(ENABLE_PDF_VIEWER)
   pdf::PDFWebContentsHelper::CreateForWebContentsWithClient(
       web_contents, std::make_unique<ElectronPDFWebContentsHelperClient>());
 #endif


### PR DESCRIPTION
#### Description of Change
Fix build with `enable_pdf_viewer=false`.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: none