### PR TITLE
fix: roll back to 80.0.3987.163

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -11,7 +11,7 @@ gclient_gn_args = [
 
 vars = {
   'chromium_version':
-    '80.0.3987.165',
+    '80.0.3987.163',
   'node_version':
     'v12.13.0',
   'nan_version':

--- a/patches/chromium/use_keepselfalive_on_audiocontext_to_keep_it_alive_until_rendering.patch
+++ b/patches/chromium/use_keepselfalive_on_audiocontext_to_keep_it_alive_until_rendering.patch
@@ -118,10 +118,10 @@ index 6e3455921f5a1b81fe8a43d44beecfbd9aa93dc1..d3e521f1291a2f90963199cadba02ae3
  
  }  // namespace blink
 diff --git a/third_party/blink/renderer/modules/webaudio/base_audio_context.h b/third_party/blink/renderer/modules/webaudio/base_audio_context.h
-index d6e4fe5e25ffbaa5273a7aa6d4042cc474ba1c06..af0a27d0cb49faa34de540df5c25ae4f1d6f8734 100644
+index a99b2dddad44416d8761335f1111c441be79c486..051890e2742344d3ed2c8b6ae3b0c384eef252a0 100644
 --- a/third_party/blink/renderer/modules/webaudio/base_audio_context.h
 +++ b/third_party/blink/renderer/modules/webaudio/base_audio_context.h
-@@ -282,7 +282,7 @@ class MODULES_EXPORT BaseAudioContext
+@@ -285,7 +285,7 @@ class MODULES_EXPORT BaseAudioContext
  
    DEFINE_ATTRIBUTE_EVENT_LISTENER(statechange, kStatechange)
  


### PR DESCRIPTION
#### Description of Change
This is actually more of a roll "forward", since 163 includes several changes that 165 didn't:

```
* 052d3b44972e (tag: 80.0.3987.165, refs/patches/upstream-head) Incrementing VERSION to 80.0.3987.165 [chrome-release-bot]
* 599754e17c97 logs: Implement size limit for user logs [Joon Ahn]
* b032a48e4ee3 Setting version to 80.0.3987.164 [chrome-release-bot]
* 9fb54ff5ece0 Publish DEPS for 80.0.3987.158 [chrome-release-bot]
| * 3770caa190b6 (tag: 80.0.3987.163) Publish DEPS for 80.0.3987.163 [chrome-release-bot]
| * e7fbe071abe9 Incrementing VERSION to 80.0.3987.163 [chrome-release-bot]
| * fc11c43603c0 Revert "Crash when a process node is destroyed while still hosting worker nodes" [Patrick Monette]
| * 3d2784d7fa18 M80 merge: Fix themes for extensions lite for supervised users [James Cook]
| * f2c5dd613815 Incrementing VERSION to 80.0.3987.162 [chrome-release-bot]
| * 4e5a9529c020 Revert "3987: pin v8 to 9c25291e705136181ede345dabcf05fb054812af." [Srinivas Sista]
| * d84d2c896ef4 3987: [iOS]Updated "shard size" to "swarming tasks" for EG tests. [John Budorick]
| * 5714fda506da Incrementing VERSION to 80.0.3987.161 [chrome-release-bot]
| * 34364febb5c0 Android: Update Play Core [Peter Wen]
| * 1a49b1135d32 Incrementing VERSION to 80.0.3987.160 [chrome-release-bot]
| * 39588f9f46ea [Merge to M80] Worker: Stop passing creator's origin for starting a dedicated worker [Hiroki Nakagawa]
| * 84c7116cd2eb Incrementing VERSION to 80.0.3987.159 [chrome-release-bot]
| * f1c37ded70b8 M80 merge: Enable supervised users to install extensions from policy allowlist [James Cook]
| * d1d9a6eb4be6 Pepper: support GpuMemoryBuffer-based frame in MediaStream Video [Shik Chen]
| * b251e5d04acc Clear context from orphan handlers when BaseAudioContext is going away [Raymond Toy]
| * fadaf051bb01 [PM] Fix invariant tracking [Patrick Monette]
| * cb6da3a7587f Crash when a process node is destroyed while still hosting worker nodes [Patrick Monette]
| * 4c737aabcb3a Protect AutofillPopupControllerImpl from being destroyed in Show(). [Vasilii Sukhanov]
| * 684baa766f80 Protect automatic pull handlers with Mutex [Hongchan Choi]
|/
* af496874d27c Incrementing VERSION to 80.0.3987.158 [chrome-release-bot]
```

It seems 165 was a ChromeOS-only release which we shouldn't have picked up.

Fixes #25492

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Updated to Chrome 80.0.3987.163.