### PR TITLE
fix: call node::Stop on exit

### DIFF
--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -233,7 +233,7 @@ int NodeMain(int argc, char* argv[]) {
 
     node::ResetStdio();
 
-    env->set_can_call_into_js(false);
+    node::Stop(env);
     env->stop_sub_worker_contexts();
     env->RunCleanup();
 

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -552,6 +552,7 @@ void ElectronBrowserMainParts::PostMainMessageLoopRun() {
   // invoke Node/V8 APIs inside them.
   node_debugger_->Stop();
   node_env_->env()->set_trace_sync_io(false);
+  node::Stop(node_env_->env());
   node_env_.reset();
   js_env_->OnMessageLoopDestroying();
 


### PR DESCRIPTION
Backport of #25430.

Notes: Fixed an issue that could cause a normally-exiting process to fail with an "illegal access" message and exit code 7.
