### PR TITLE
refactor: replace USE_X11 with OS_LINUX for sharing code with Ozone

### DIFF
--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -15,7 +15,7 @@
 #include "shell/browser/window_list.h"
 #include "shell/common/application_info.h"
 
-#if defined(USE_X11)
+#if defined(OS_LINUX)
 #include "shell/browser/linux/unity_service.h"
 #include "ui/gtk/gtk_util.h"
 #endif

--- a/shell/browser/common_web_contents_delegate.h
+++ b/shell/browser/common_web_contents_delegate.h
@@ -130,7 +130,7 @@ class CommonWebContentsDelegate : public content::WebContentsDelegate,
 #if defined(TOOLKIT_VIEWS) && !defined(OS_MAC)
   gfx::ImageSkia GetDevToolsWindowIcon() override;
 #endif
-#if defined(USE_X11)
+#if defined(OS_LINUX)
   void GetDevToolsWindowWMClass(std::string* name,
                                 std::string* class_name) override;
 #endif

--- a/shell/browser/common_web_contents_delegate_views.cc
+++ b/shell/browser/common_web_contents_delegate_views.cc
@@ -11,7 +11,7 @@
 #include "shell/browser/web_contents_preferences.h"
 #include "ui/events/keycodes/keyboard_codes.h"
 
-#if defined(USE_X11)
+#if defined(OS_LINUX)
 #include "shell/browser/browser.h"
 #endif
 
@@ -49,7 +49,7 @@ gfx::ImageSkia CommonWebContentsDelegate::GetDevToolsWindowIcon() {
       ->GetWindowAppIcon();
 }
 
-#if defined(USE_X11)
+#if defined(OS_LINUX)
 void CommonWebContentsDelegate::GetDevToolsWindowWMClass(
     std::string* name,
     std::string* class_name) {

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -229,7 +229,7 @@ void UpdateDarkThemeSetting() {
 
 }  // namespace
 
-#if defined(USE_X11)
+#if defined(OS_LINUX)
 class DarkThemeObserver : public ui::NativeThemeObserver {
  public:
   DarkThemeObserver() = default;
@@ -350,7 +350,7 @@ int ElectronBrowserMainParts::PreCreateThreads() {
 #if defined(USE_AURA)
   display::Screen* screen = views::CreateDesktopScreen();
   display::Screen::SetScreenInstance(screen);
-#if defined(USE_X11)
+#if defined(OS_LINUX)
   views::LinuxUI::instance()->UpdateDeviceScaleFactor();
 #endif
 #endif

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -29,7 +29,7 @@ class WMState;
 }
 #endif
 
-#if defined(USE_X11)
+#if defined(OS_LINUX)
 namespace ui {
 class GtkUiDelegate;
 }
@@ -59,7 +59,7 @@ class ViewsDelegate;
 class ViewsDelegateMac;
 #endif
 
-#if defined(USE_X11)
+#if defined(OS_LINUX)
 class DarkThemeObserver;
 #endif
 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -192,7 +192,7 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
     params.parent = parent->GetNativeWindow();
 
   params.native_widget = new ElectronDesktopNativeWidgetAura(this);
-#elif defined(USE_X11)
+#elif defined(OS_LINUX)
   std::string name = Browser::Get()->GetName();
   // Set WM_WINDOW_ROLE.
   params.wm_role_name = "browser-window";
@@ -482,7 +482,7 @@ void NativeWindowViews::SetEnabledInternal(bool enable) {
 #endif
 }
 
-#if defined(USE_X11)
+#if defined(OS_LINUX)
 void NativeWindowViews::Maximize() {
   if (IsVisible())
     widget()->Maximize();
@@ -798,7 +798,7 @@ bool NativeWindowViews::IsClosable() {
     return false;
   }
   return !(info.fState & MFS_DISABLED);
-#elif defined(USE_X11)
+#elif defined(OS_LINUX)
   return true;
 #endif
 }
@@ -1138,7 +1138,7 @@ void NativeWindowViews::SetProgressBar(double progress,
                                        NativeWindow::ProgressState state) {
 #if defined(OS_WIN)
   taskbar_host_.SetProgressBar(GetAcceleratedWidget(), progress, state);
-#elif defined(USE_X11)
+#elif defined(OS_LINUX)
   if (unity::IsRunning()) {
     unity::SetProgressFraction(progress);
   }
@@ -1194,7 +1194,7 @@ content::DesktopMediaID NativeWindowViews::GetDesktopMediaID() const {
 #if defined(OS_WIN)
   window_handle =
       reinterpret_cast<content::DesktopMediaID::Id>(accelerated_widget);
-#elif defined(USE_X11)
+#elif defined(OS_LINUX)
   window_handle = static_cast<uint32_t>(accelerated_widget);
 #endif
   aura::WindowTreeHost* const host =
@@ -1297,7 +1297,7 @@ void NativeWindowViews::SetIcon(HICON window_icon, HICON app_icon) {
   SendMessage(hwnd, WM_SETICON, ICON_BIG,
               reinterpret_cast<LPARAM>(app_icon_.get()));
 }
-#elif defined(USE_X11)
+#elif defined(OS_LINUX)
 void NativeWindowViews::SetIcon(const gfx::ImageSkia& icon) {
   auto* tree_host = views::DesktopWindowTreeHostLinux::GetHostForWidget(
       GetAcceleratedWidget());
@@ -1382,7 +1382,7 @@ bool NativeWindowViews::CanMaximize() const {
 bool NativeWindowViews::CanMinimize() const {
 #if defined(OS_WIN)
   return minimizable_;
-#elif defined(USE_X11)
+#elif defined(OS_LINUX)
   return true;
 #endif
 }

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -154,7 +154,7 @@ class NativeWindowViews : public NativeWindow,
                     LPARAM l_param,
                     LRESULT* result);
   void SetIcon(HICON small_icon, HICON app_icon);
-#elif defined(USE_X11)
+#elif defined(OS_LINUX)
   void SetIcon(const gfx::ImageSkia& icon);
 #endif
 

--- a/shell/browser/ui/inspectable_web_contents_view_delegate.h
+++ b/shell/browser/ui/inspectable_web_contents_view_delegate.h
@@ -23,7 +23,7 @@ class InspectableWebContentsViewDelegate {
   // Returns the icon of devtools window.
   virtual gfx::ImageSkia GetDevToolsWindowIcon();
 
-#if defined(USE_X11)
+#if defined(OS_LINUX)
   // Called when creating devtools window.
   virtual void GetDevToolsWindowWMClass(std::string* name,
                                         std::string* class_name) {}

--- a/shell/browser/ui/views/inspectable_web_contents_view_views.cc
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.cc
@@ -186,7 +186,7 @@ void InspectableWebContentsViewViews::SetIsDocked(bool docked, bool activate) {
     params.delegate = devtools_window_delegate_;
     params.bounds = inspectable_web_contents()->GetDevToolsBounds();
 
-#if defined(USE_X11)
+#if defined(OS_LINUX)
     params.wm_role_name = "devtools";
     if (GetDelegate())
       GetDelegate()->GetDevToolsWindowWMClass(&params.wm_class_name,


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

This pull-request is a *small first step* in trying to bring support for Wayland to Electron. I'm planning to follow up on this with more pull-requests in an effort to upstream [these Wayland patches](https://github.com/electron/electron/compare/10-x-y...hedgepigdaniel:arch-10?expand=1).

However, those patches will need some adjustments in order to make them compatible with the upcoming Chromium changes ([chromium#1085700](https://bugs.chromium.org/p/chromium/issues/detail?id=1085700)) which will soon be merged into Electron (#25488). In particular, it should be taken into consideration that the `USE_X11` and `USE_OZONE` build flags are no longer mutually exclusive.

Also, `USE_X11` is [going away](https://github.com/electron/electron/issues/10915#issuecomment-558515636) so it might be desirable as a long term goal to remove it from Electron too and replace it with the Ozone equivalents.

With that in mind, this pull-request replaces a few instances of `#if defined(USE_X11)` with `#if defined(OS_LINUX)` where it was identified that the guarded code could be shared with Ozone.

The more meaningful changes will come in the upcoming pull-requests but I'll be waiting for [these chromium changes](https://chromium-review.googlesource.com/c/chromium/src/+/2382834) to be pulled into Electron first (#24984, #25488).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd (@zcbenz @hedgepigdaniel)
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none
