### PR TITLE
fix: app.importCertificate crash on Linux

### DIFF
--- a/chromium_src/chrome/browser/certificate_manager_model.cc
+++ b/chromium_src/chrome/browser/certificate_manager_model.cc
@@ -36,6 +36,7 @@ net::NSSCertDatabase* GetNSSCertDatabaseForResourceContext(
     // Linux has only a single persistent slot compared to ChromeOS's separate
     // public and private slot.
     // Redirect any slot usage to this persistent slot on Linux.
+    crypto::EnsureNSSInit();
     g_nss_cert_database = new net::NSSCertDatabase(
         crypto::ScopedPK11Slot(PK11_GetInternalKeySlot()) /* public slot */,
         crypto::ScopedPK11Slot(PK11_GetInternalKeySlot()) /* private slot */);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/25506.

Refs https://chromium-review.googlesource.com/c/chromium/src/+/1857045.

When we rolled Chromium in [this commit](https://github.com/electron/electron/commit/b6246dcf122e584c672566877cb60d33dbc4705e) we adapted for updates in the above CL but missed the critical line `crypto::EnsureNSSInit()` which ensures that `PK11_GetInternalKeySlot()` return non-nullptr values.

<details>
<summary>Stacktrace</summary>:

<img width="662" alt="Screen Shot 2020-09-17 at 5 38 35 PM" src="https://user-images.githubusercontent.com/2036040/93538954-ac11e880-f90c-11ea-8c0b-a3688677907a.png">
</details>

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash in `app.importCertificate()` on Linux.
