### PR TITLE
fix: NOTREACHED in content::ChildProcessHost::GetChildPath when enable_plugins=false

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -701,10 +701,15 @@ void ElectronBrowserClient::AppendExtraCommandLineSwitches(
         content::ChildProcessHost::CHILD_RENDERER);
     auto gpu_child_path = content::ChildProcessHost::GetChildPath(
         content::ChildProcessHost::CHILD_GPU);
+#if BUILDFLAG(ENABLE_PLUGINS)
     auto plugin_child_path = content::ChildProcessHost::GetChildPath(
         content::ChildProcessHost::CHILD_PLUGIN);
-    if (program != renderer_child_path && program != gpu_child_path &&
-        program != plugin_child_path) {
+#endif
+    if (program != renderer_child_path && program != gpu_child_path
+#if BUILDFLAG(ENABLE_PLUGINS)
+        && program != plugin_child_path
+#endif
+    ) {
       child_path = content::ChildProcessHost::GetChildPath(
           content::ChildProcessHost::CHILD_NORMAL);
       CHECK_EQ(program, child_path)

--- a/shell/browser/extensions/electron_component_extension_resource_manager.cc
+++ b/shell/browser/extensions/electron_component_extension_resource_manager.cc
@@ -17,7 +17,7 @@
 #include "electron/buildflags/buildflags.h"
 
 #if BUILDFLAG(ENABLE_PDF_VIEWER)
-#include "chrome/browser/pdf/pdf_extension_util.h"
+#include "chrome/browser/pdf/pdf_extension_util.h"  // nogncheck
 #include "extensions/common/constants.h"
 #endif
 

--- a/shell/browser/extensions/electron_extension_system.cc
+++ b/shell/browser/extensions/electron_extension_system.cc
@@ -38,7 +38,7 @@
 #include "shell/browser/extensions/electron_extension_loader.h"
 
 #if BUILDFLAG(ENABLE_PDF_VIEWER)
-#include "chrome/browser/pdf/pdf_extension_util.h"
+#include "chrome/browser/pdf/pdf_extension_util.h"  // nogncheck
 #endif
 
 using content::BrowserContext;

--- a/shell/browser/extensions/electron_extensions_api_client.cc
+++ b/shell/browser/extensions/electron_extensions_api_client.cc
@@ -15,7 +15,7 @@
 #include "shell/browser/extensions/electron_messaging_delegate.h"
 
 #if BUILDFLAG(ENABLE_PDF_VIEWER)
-#include "components/pdf/browser/pdf_web_contents_helper.h"
+#include "components/pdf/browser/pdf_web_contents_helper.h"  // nogncheck
 #include "shell/browser/electron_pdf_web_contents_helper_client.h"
 #endif
 

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -54,7 +54,7 @@
 #endif
 
 #if BUILDFLAG(ENABLE_PDF_VIEWER)
-#include "chrome/renderer/pepper/chrome_pdf_print_client.h"
+#include "chrome/renderer/pepper/chrome_pdf_print_client.h"  // nogncheck
 #include "shell/common/electron_constants.h"
 #endif  // BUILDFLAG(ENABLE_PDF_VIEWER)
 


### PR DESCRIPTION
#### Description of Change
Calling `content::ChildProcessHost::GetChildPath(content::ChildProcessHost::CHILD_PLUGIN)` fails when `enable_plugins=false`.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes