### PR TITLE
fix: allow ClientRequest responses to be throttled

### DIFF
--- a/lib/browser/api/net.ts
+++ b/lib/browser/api/net.ts
@@ -102,7 +102,8 @@ class IncomingMessage extends Readable {
     throw new Error('HTTP trailers are not supported');
   }
 
-  _storeInternalData (chunk: Buffer | null) {
+  _storeInternalData (chunk: Buffer | null, resume /* TODO*/) {
+    // TODO: save |resume| function somewhere? on this._resume?
     this._data.push(chunk);
     this._pushInternalData();
   }
@@ -112,6 +113,7 @@ class IncomingMessage extends Readable {
       const chunk = this._data.shift();
       this._shouldPush = this.push(chunk);
     }
+    // TODO: call |this._resume| here if _shouldPush is true?
   }
 
   _read () {
@@ -402,7 +404,9 @@ export class ClientRequest extends Writable implements Electron.ClientRequest {
       const response = this._response = new IncomingMessage(responseHead);
       this.emit('response', response);
     });
-    this._urlLoader.on('data', (event, data) => {
+    this._urlLoader.on('data', (event, data, resume) => {
+      // TODO: we need to call |resume| in order to get the next chunk from the
+      // network. 
       this._response!._storeInternalData(Buffer.from(data));
     });
     this._urlLoader.on('complete', () => {

--- a/lib/browser/api/net.ts
+++ b/lib/browser/api/net.ts
@@ -412,9 +412,7 @@ export class ClientRequest extends Writable implements Electron.ClientRequest {
       const response = this._response = new IncomingMessage(responseHead);
       this.emit('response', response);
     });
-    // @ts-ignore
-    this._urlLoader.on('data', (event, data, resume: () => void) => {
-      // TODO: we need to call |resume| to get the next chunk from the network.
+    this._urlLoader.on('data', (event, data, resume) => {
       this._response!._storeInternalData(Buffer.from(data), resume);
     });
     this._urlLoader.on('complete', () => {

--- a/shell/browser/api/electron_api_url_loader.cc
+++ b/shell/browser/api/electron_api_url_loader.cc
@@ -427,8 +427,7 @@ void SimpleURLLoaderWrapper::OnDataReceived(base::StringPiece string_piece,
   auto array_buffer = v8::ArrayBuffer::New(isolate, string_piece.size());
   auto backing_store = array_buffer->GetBackingStore();
   memcpy(backing_store->Data(), string_piece.data(), string_piece.size());
-  Emit("data", array_buffer);
-  std::move(resume).Run();
+  Emit("data", array_buffer, base::AdaptCallbackForRepeating(std::move(resume)));
 }
 
 void SimpleURLLoaderWrapper::OnComplete(bool success) {

--- a/shell/browser/api/electron_api_url_loader.cc
+++ b/shell/browser/api/electron_api_url_loader.cc
@@ -427,7 +427,8 @@ void SimpleURLLoaderWrapper::OnDataReceived(base::StringPiece string_piece,
   auto array_buffer = v8::ArrayBuffer::New(isolate, string_piece.size());
   auto backing_store = array_buffer->GetBackingStore();
   memcpy(backing_store->Data(), string_piece.data(), string_piece.size());
-  Emit("data", array_buffer, base::AdaptCallbackForRepeating(std::move(resume)));
+  Emit("data", array_buffer,
+       base::AdaptCallbackForRepeating(std::move(resume)));
 }
 
 void SimpleURLLoaderWrapper::OnComplete(bool success) {

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -1412,8 +1412,8 @@ describe('net module', () => {
       const urlRequest = net.request(serverUrl);
       urlRequest.on('response', () => {});
       urlRequest.end();
-      await delay(1000);
-      expect(numChunksSent).to.be.at.most(10);
+      await delay(2000);
+      expect(numChunksSent).to.be.at.most(20);
     });
   });
 

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -4,7 +4,7 @@ import * as http from 'http';
 import * as url from 'url';
 import { AddressInfo, Socket } from 'net';
 import { emittedOnce } from './events-helpers';
-import { defer } from './spec-helpers';
+import { defer, delay } from './spec-helpers';
 
 const kOneKiloByte = 1024;
 const kOneMegaByte = kOneKiloByte * kOneKiloByte;
@@ -1392,6 +1392,28 @@ describe('net module', () => {
       netRequest.end();
       await collectStreamBody(nodeResponse);
       expect(nodeRequestProcessed).to.equal(true);
+    });
+
+    it('should correctly throttle an incoming stream', async () => {
+      let numChunksSent = 0;
+      const serverUrl = await respondOnce.toSingleURL((request, response) => {
+        const data = randomString(kOneMegaByte);
+        const write = () => {
+          let ok = true;
+          do {
+            numChunksSent++;
+            if (numChunksSent > 30) return;
+            ok = response.write(data);
+          } while (ok);
+          response.once('drain', write);
+        };
+        write();
+      });
+      const urlRequest = net.request(serverUrl);
+      urlRequest.on('response', () => {});
+      urlRequest.end();
+      await delay(200);
+      expect(numChunksSent).to.be.at.most(2);
     });
   });
 

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -1412,8 +1412,8 @@ describe('net module', () => {
       const urlRequest = net.request(serverUrl);
       urlRequest.on('response', () => {});
       urlRequest.end();
-      await delay(200);
-      expect(numChunksSent).to.be.at.most(2);
+      await delay(1000);
+      expect(numChunksSent).to.be.at.most(10);
     });
   });
 

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -118,7 +118,7 @@ declare namespace NodeJS {
 
   interface URLLoader extends EventEmitter {
     cancel(): void;
-    on(eventName: 'data', listener: (event: any, data: ArrayBuffer) => void): this;
+    on(eventName: 'data', listener: (event: any, data: ArrayBuffer, resume: () => void) => void): this;
     on(eventName: 'response-started', listener: (event: any, finalUrl: string, responseHead: ResponseHead) => void): this;
     on(eventName: 'complete', listener: (event: any) => void): this;
     on(eventName: 'error', listener: (event: any, netErrorString: string) => void): this;


### PR DESCRIPTION
#### Description of Change

Closes #25130.

Previously, when making a client request, the IncomingMessage class was implementing the Readable stream property correctly. However, its buffer will get filled without stopping by the SimpleURLLoaderWrapper. 

This PR passes up a callback from the SimpleURLLoaderWrapper layer to the IncomingMessage class. This callback allows the IncomingMessage class to properly stop the readable stream when it is full and needs the request to pause, and then resume the stream when appropriate.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where net.request would continue downloading data even when the consuming stream was throttled.
