### PR TITLE
docs: fix incorrect dialog.showMessageBox() docs

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -306,7 +306,7 @@ Returns `Promise<Object>` - resolves with a promise containing the following pro
   * `checkboxChecked` Boolean - The checked state of the checkbox if
   `checkboxLabel` was set. Otherwise `false`.
 
-Shows a message box, it will block the process until the message box is closed.
+Shows a message box.
 
 The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal.
 


### PR DESCRIPTION
#### Description of Change
dialog.showMessageBoxSync() is blocking the process, whereas dialog.showMessageBox() is not.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
