### PR TITLE
docs: end listener must be placed before data listener

### DIFF
--- a/docs/api/incoming-message.md
+++ b/docs/api/incoming-message.md
@@ -20,7 +20,7 @@ applicative code.
 
 #### Event: 'end'
 
-Indicates that response body has ended.
+Indicates that response body has ended. Must be placed before 'data' event.
 
 #### Event: 'aborted'
 


### PR DESCRIPTION
Description for the bug: on('end', ...) must be placed before on('data', ...) - otherwise, 'end' event will be never called.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none