### PR TITLE
fix: decompress devtools discovery html

### DIFF
--- a/shell/browser/ui/devtools_manager_delegate.cc
+++ b/shell/browser/ui/devtools_manager_delegate.cc
@@ -129,9 +129,8 @@ DevToolsManagerDelegate::CreateNewTarget(const GURL& url) {
 }
 
 std::string DevToolsManagerDelegate::GetDiscoveryPageHTML() {
-  return ui::ResourceBundle::GetSharedInstance()
-      .GetRawDataResource(IDR_CONTENT_SHELL_DEVTOOLS_DISCOVERY_PAGE)
-      .as_string();
+  return ui::ResourceBundle::GetSharedInstance().LoadDataResourceString(
+      IDR_CONTENT_SHELL_DEVTOOLS_DISCOVERY_PAGE);
 }
 
 bool DevToolsManagerDelegate::HasBundledFrontendResources() {


### PR DESCRIPTION
#### Description of Change
Beginning with
https://chromium.googlesource.com/chromium/src/+/6b83ee683f6c545be29ee807c6d0b6ac1508a549,
rolled into Electron with #23219, grit compresses html/js/css/svg by default.
We were serving the raw resource for the devtools discovery page (shown when
using `--remote-debugging-port=9092`), which was serving a raw gzipped page. We
now use a more appropriate accessor which decompresses if needed.

Fixes #25570.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed the remote-debugging-port discovery page showing garbled text.
