### PR TITLE
build: fix Node.js filename generation

### DIFF
--- a/patches/node/build_add_gn_build_files.patch
+++ b/patches/node/build_add_gn_build_files.patch
@@ -1615,10 +1615,10 @@ index 0000000000000000000000000000000000000000..01f62d4ae6e3b9d539444e3dff069f00
 +  main(sys.argv[1:])
 diff --git a/tools/generate_gn_filenames_json.py b/tools/generate_gn_filenames_json.py
 new file mode 100755
-index 0000000000000000000000000000000000000000..9be5ffae55057c4072599d17384735984851de5a
+index 0000000000000000000000000000000000000000..e5fd79da5323e7039730fd8cca66caae8c84e903
 --- /dev/null
 +++ b/tools/generate_gn_filenames_json.py
-@@ -0,0 +1,63 @@
+@@ -0,0 +1,70 @@
 +#!/usr/bin/env python
 +import json
 +import os
@@ -1653,21 +1653,28 @@ index 0000000000000000000000000000000000000000..9be5ffae55057c4072599d1738473598
 +  node_gyp_path = os.path.join(node_root_dir, 'node.gyp')
 +  out = {}
 +  node_gyp = LoadPythonDictionary(node_gyp_path)
-+  out['library_files'] = node_gyp['variables']['library_files']
 +  node_lib_target = next(
 +      t for t in node_gyp['targets']
 +      if t['target_name'] == '<(node_lib_target_name)')
-+  node_source_blacklist = {
++  node_source_blocklist = {
 +      '<@(library_files)',
 +      'common.gypi',
 +      '<(SHARED_INTERMEDIATE_DIR)/node_javascript.cc',
 +  }
-+  out['node_sources'] = [
++
++  def filter_v8_files(files):
++    if any(f.startswith('deps/v8/') for f in files):
++      files = [f.replace('deps/v8/', '//v8/', 1) for f in files]
++    return files
++
++  out['library_files'] = filter_v8_files(node_gyp['variables']['library_files'])
++
++  blocklisted_sources = [
 +      f for f in node_lib_target['sources']
-+      if f not in node_source_blacklist]
++      if f not in node_source_blocklist]
++  out['node_sources'] = filter_v8_files(blocklisted_sources)
 +
 +  out['headers'] = []
-+
 +  def add_headers(files, dest_dir):
 +    if 'src/node.h' in files:
 +      files = [f for f in files if f.endswith('.h') and f != 'src/node_version.h']


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/v8/v8/commit/56bf834a2b122616d00c6cc85243e4d80a1ca241.

V8 started using relative paths in DEPS, which meant that our GN filename generation script would not correctly recognize some JS files in V8 and repoint them to the V8 in the Chromium src tree. This fixes that error, which previously would look like:

```diff --git a/filenames.json b/filenames.json
index d3315d9150ac674e06948d72ae02179a9151d74c..6b0f9b7167b1964dd598a3a52c575641dd4937c1 100644
--- a/filenames.json
+++ b/filenames.json
@@ -310,17 +310,17 @@
     "lib/internal/streams/state.js",
     "lib/internal/streams/pipeline.js",
     "lib/internal/streams/end-of-stream.js",
-    "//v8/tools/splaytree.js",
-    "//v8/tools/codemap.js",
-    "//v8/tools/consarray.js",
-    "//v8/tools/csvparser.js",
-    "//v8/tools/profile.js",
-    "//v8/tools/profile_view.js",
-    "//v8/tools/logreader.js",
-    "//v8/tools/arguments.js",
-    "//v8/tools/tickprocessor.js",
-    "//v8/tools/SourceMap.js",
-    "//v8/tools/tickprocessor-driver.js",
+    "deps/v8/tools/splaytree.js",
+    "deps/v8/tools/codemap.js",
+    "deps/v8/tools/consarray.js",
+    "deps/v8/tools/csvparser.js",
+    "deps/v8/tools/profile.js",
+    "deps/v8/tools/profile_view.js",
+    "deps/v8/tools/logreader.js",
+    "deps/v8/tools/arguments.js",
+    "deps/v8/tools/tickprocessor.js",
+    "deps/v8/tools/SourceMap.js",
+    "deps/v8/tools/tickprocessor-driver.js",
     "deps/node-inspect/lib/_inspect.js",
     "deps/node-inspect/lib/internal/inspect_client.js",
     "deps/node-inspect/lib/internal/inspect_repl.js",
@@ -521,6 +521,6 @@
     "src/udp_wrap.h",
     "src/util.h",
     "src/util-inl.h",
-    "//v8/include/v8.h"
+    "deps/v8/include/v8.h"
   ]
 }
```

cc @nornagon @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
