### PR TITLE
docs: document process.crashReporter apis in node children

### DIFF
--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -39,6 +39,37 @@ is an implementation detail driven by Chromium, and it may change in future. In
 particular, crashpad is newer and will likely eventually replace breakpad on
 all platforms.
 
+### Note about Node child processes on Linux
+
+If you are using the Node.js `child_process` module and want to report crashes
+from those processes on Linux, there is an extra step you will need to take to
+properly initialize the crash reporter in the child process. This is not
+necessary on Mac or Windows, as those platforms use Crashpad, which
+automatically monitors child processes.
+
+Since `require('electron')` is not available in Node child processes, the
+following APIs are available on the `process` object in Node child processes.
+Note that, on Linux, each Node child process has its own separate instance of
+the breakpad crash reporter. This is dissimilar to renderer child processes,
+which have a "stub" breakpad reporter which returns information to the main
+process for reporting.
+
+#### `process.crashReporter.start(options)`
+
+See [`crashReporter.start()`](#crashreporterstartoptions).
+
+#### `process.crashReporter.getParameters()`
+
+See [`crashReporter.getParameters()`](#crashreportergetparameters).
+
+#### `process.crashReporter.addExtraParameter(key, value)`
+
+See [`crashReporter.addExtraParameter(key, value)`](#crashreporteraddextraparameterkey-value).
+
+#### `process.crashReporter.removeExtraParameter(key)`
+
+See [`crashReporter.removeExtraParameter(key)`](#crashreporterremoveextraparameterkey).
+
 ## Methods
 
 The `crashReporter` module has the following methods:


### PR DESCRIPTION
#### Description of Change
This documents the long-available, never-documented `process.crashReporter`
APIs for getting breakpad working in node child processes.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none
