### PR TITLE
feat: add webContents.forcefullyCrashRenderer() to forcefully terminate a renderer process

### DIFF
--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -266,6 +266,15 @@ static_library("chrome") {
       ]
     }
   }
+
+  sources += [ "//chrome/browser/hang_monitor/hang_crash_dump.h" ]
+  if (is_mac) {
+    sources += [ "//chrome/browser/hang_monitor/hang_crash_dump_mac.cc" ]
+  } else if (is_win) {
+    sources += [ "//chrome/browser/hang_monitor/hang_crash_dump_win.cc" ]
+  } else {
+    sources += [ "//chrome/browser/hang_monitor/hang_crash_dump.cc" ]
+  }
 }
 
 source_set("plugins") {

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -998,6 +998,34 @@ Navigates to the specified offset from the "current entry".
 
 Returns `Boolean` - Whether the renderer process has crashed.
 
+#### `contents.crashProcess()`
+
+Forcefully terminates the renderer process that is currently hosting this
+`webContents`. This will cause the `render-process-gone` event to be emitted
+with the `reason=killed`. Please note that some webContents share renderer
+processes and therefore calling this method may also crash the host process
+for other webContents as well.
+
+Calling `reload()` immediately after calling this
+method will force the reload to occur in a new process. This should be used
+when this process is unstable or unusable, for instance in order to recover
+from the `unresponsive` event.
+
+```js
+contents.on('unresponsive', async () => {
+  const { response } = await dialog.showMessageBox({
+    message: 'App X has become unresponsive',
+    title: 'Do you want to try forcefully reloading the app?',
+    buttons: ['OK', 'Cancel'],
+    cancelId: 1
+  })
+  if (response === 0) {
+    contents.crashProcess()
+    contents.reload()
+  }
+})
+```
+
 #### `contents.setUserAgent(userAgent)`
 
 * `userAgent` String

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -998,11 +998,11 @@ Navigates to the specified offset from the "current entry".
 
 Returns `Boolean` - Whether the renderer process has crashed.
 
-#### `contents.crashProcess()`
+#### `contents.forcefullyCrashRenderer()`
 
 Forcefully terminates the renderer process that is currently hosting this
 `webContents`. This will cause the `render-process-gone` event to be emitted
-with the `reason=killed`. Please note that some webContents share renderer
+with the `reason=killed || reason=crashed`. Please note that some webContents share renderer
 processes and therefore calling this method may also crash the host process
 for other webContents as well.
 
@@ -1020,7 +1020,7 @@ contents.on('unresponsive', async () => {
     cancelId: 1
   })
   if (response === 0) {
-    contents.crashProcess()
+    contents.forcefullyCrashRenderer()
     contents.reload()
   }
 })

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1764,7 +1764,7 @@ bool WebContents::IsCrashed() const {
   return web_contents()->IsCrashed();
 }
 
-void WebContents::CrashProcess() {
+void WebContents::ForcefullyCrashRenderer() {
   content::RenderWidgetHostView* view =
       web_contents()->GetRenderWidgetHostView();
   if (!view)
@@ -2946,7 +2946,8 @@ v8::Local<v8::ObjectTemplate> WebContents::FillObjectTemplate(
       .SetMethod("_goForward", &WebContents::GoForward)
       .SetMethod("_goToOffset", &WebContents::GoToOffset)
       .SetMethod("isCrashed", &WebContents::IsCrashed)
-      .SetMethod("crashProcess", &WebContents::CrashProcess)
+      .SetMethod("forcefullyCrashRenderer",
+                 &WebContents::ForcefullyCrashRenderer)
       .SetMethod("setUserAgent", &WebContents::SetUserAgent)
       .SetMethod("getUserAgent", &WebContents::GetUserAgent)
       .SetMethod("savePage", &WebContents::SavePage)

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -21,6 +21,7 @@
 #include "base/threading/thread_task_runner_handle.h"
 #include "base/values.h"
 #include "chrome/browser/browser_process.h"
+#include "chrome/browser/hang_monitor/hang_crash_dump.h"
 #include "chrome/browser/ssl/security_state_tab_helper.h"
 #include "content/browser/renderer_host/frame_tree_node.h"  // nogncheck
 #include "content/browser/renderer_host/render_frame_host_manager.h"  // nogncheck
@@ -1763,6 +1764,30 @@ bool WebContents::IsCrashed() const {
   return web_contents()->IsCrashed();
 }
 
+void WebContents::CrashProcess() {
+  content::RenderWidgetHostView* view =
+      web_contents()->GetRenderWidgetHostView();
+  if (!view)
+    return;
+
+  content::RenderWidgetHost* rwh = view->GetRenderWidgetHost();
+  if (!rwh)
+    return;
+
+  content::RenderProcessHost* rph = rwh->GetProcess();
+  if (rph) {
+#if defined(OS_LINUX) || defined(OS_CHROMEOS)
+    // A generic |CrashDumpHungChildProcess()| is not implemented for Linux.
+    // Instead we send an explicit IPC to crash on the renderer's IO thread.
+    rph->ForceCrash();
+#else
+    // Try to generate a crash report for the hung process.
+    CrashDumpHungChildProcess(rph->GetProcess().Handle());
+    rph->Shutdown(content::RESULT_CODE_HUNG);
+#endif
+  }
+}
+
 void WebContents::SetUserAgent(const std::string& user_agent) {
   web_contents()->SetUserAgentOverride(
       blink::UserAgentOverride::UserAgentOnly(user_agent), false);
@@ -2921,6 +2946,7 @@ v8::Local<v8::ObjectTemplate> WebContents::FillObjectTemplate(
       .SetMethod("_goForward", &WebContents::GoForward)
       .SetMethod("_goToOffset", &WebContents::GoToOffset)
       .SetMethod("isCrashed", &WebContents::IsCrashed)
+      .SetMethod("crashProcess", &WebContents::CrashProcess)
       .SetMethod("setUserAgent", &WebContents::SetUserAgent)
       .SetMethod("getUserAgent", &WebContents::GetUserAgent)
       .SetMethod("savePage", &WebContents::SavePage)

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -228,6 +228,7 @@ class WebContents : public gin::Wrappable<WebContents>,
   const std::string GetWebRTCIPHandlingPolicy() const;
   void SetWebRTCIPHandlingPolicy(const std::string& webrtc_ip_handling_policy);
   bool IsCrashed() const;
+  void CrashProcess();
   void SetUserAgent(const std::string& user_agent);
   std::string GetUserAgent();
   void InsertCSS(const std::string& css);

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -228,7 +228,7 @@ class WebContents : public gin::Wrappable<WebContents>,
   const std::string GetWebRTCIPHandlingPolicy() const;
   void SetWebRTCIPHandlingPolicy(const std::string& webrtc_ip_handling_policy);
   bool IsCrashed() const;
-  void CrashProcess();
+  void ForcefullyCrashRenderer();
   void SetUserAgent(const std::string& user_agent);
   std::string GetUserAgent();
   void InsertCSS(const std::string& css);

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -1245,34 +1245,53 @@ describe('webContents module', () => {
     });
   });
 
-  describe('crash behavior', () => {
-    let w: BrowserWindow;
-    beforeEach(async () => {
-      w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true } });
-      await w.loadURL('data:text/html,<h1>Hello, World!</h1>');
-    });
-    afterEach(closeAllWindows);
+  const crashPrefs = [
+    {
+      nodeIntegration: true
+    },
+    {
+      sandbox: true
+    }
+  ];
 
-    it('isCrashed() is false by default', () => {
-      expect(w.webContents.isCrashed()).to.equal(false);
-    });
+  const nicePrefs = (o: any) => {
+    let s = '';
+    for (const key of Object.keys(o)) {
+      s += `${key}=${o[key]}, `;
+    }
+    return `(${s.slice(0, s.length - 2)})`;
+  };
 
-    it('crashProcess() crashes the process with reason=killed', async () => {
-      expect(w.webContents.isCrashed()).to.equal(false);
-      const crashEvent = emittedOnce(w.webContents, 'render-process-gone');
-      w.webContents.crashProcess();
-      const [, details] = await crashEvent;
-      expect(details.reason).to.equal('killed');
-      expect(w.webContents.isCrashed()).to.equal(true);
-    });
+  for (const prefs of crashPrefs) {
+    describe(`crash  with webPreferences ${nicePrefs(prefs)}`, () => {
+      let w: BrowserWindow;
+      beforeEach(async () => {
+        w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true } });
+        await w.loadURL('about:blank');
+      });
+      afterEach(closeAllWindows);
 
-    it('a crashed process is recoverable with reload()', async () => {
-      expect(w.webContents.isCrashed()).to.equal(false);
-      w.webContents.crashProcess();
-      w.webContents.reload();
-      expect(w.webContents.isCrashed()).to.equal(false);
+      it('isCrashed() is false by default', () => {
+        expect(w.webContents.isCrashed()).to.equal(false);
+      });
+
+      it('forcefullyCrashRenderer() crashes the process with reason=killed||crashed', async () => {
+        expect(w.webContents.isCrashed()).to.equal(false);
+        const crashEvent = emittedOnce(w.webContents, 'render-process-gone');
+        w.webContents.forcefullyCrashRenderer();
+        const [, details] = await crashEvent;
+        expect(details.reason === 'killed' || details.reason === 'crashed').to.equal(true, 'reason should be killed || crashed');
+        expect(w.webContents.isCrashed()).to.equal(true);
+      });
+
+      it('a crashed process is recoverable with reload()', async () => {
+        expect(w.webContents.isCrashed()).to.equal(false);
+        w.webContents.forcefullyCrashRenderer();
+        w.webContents.reload();
+        expect(w.webContents.isCrashed()).to.equal(false);
+      });
     });
-  });
+  }
 
   // Destroying webContents in its event listener is going to crash when
   // Electron is built in Debug mode.


### PR DESCRIPTION
Currently the only way to recover a hung renderer is to close the window or manually call `kill ${webContents.getProcessId()}` neither of which is ideal.  This adds a simple new method that aligns with what Chrome does to make killing a webConents in a hung state super easy.

Notes: Added `webContents.forcefullyCrashRenderer()` to forcefully terminate a renderer process to assist with recovering a hung renderer.