### PR TITLE
fix: check for destroyed webcontents in converter

### DIFF
--- a/shell/common/gin_converters/content_converter.cc
+++ b/shell/common/gin_converters/content_converter.cc
@@ -237,6 +237,12 @@ v8::Local<v8::Value> Converter<content::WebContents*>::ToV8(
 bool Converter<content::WebContents*>::FromV8(v8::Isolate* isolate,
                                               v8::Local<v8::Value> val,
                                               content::WebContents** out) {
+  if (!val->IsObject())
+    return false;
+  // gin's unwrapping converter doesn't expect the pointer inside to ever be
+  // nullptr, so we check here first before attempting to unwrap.
+  if (gin_helper::Destroyable::IsDestroyed(val.As<v8::Object>()))
+    return false;
   electron::api::WebContents* web_contents = nullptr;
   if (!gin::ConvertFromV8(isolate, val, &web_contents) || !web_contents)
     return false;

--- a/spec-main/fixtures/crash-cases/webview-attach-destroyed/index.js
+++ b/spec-main/fixtures/crash-cases/webview-attach-destroyed/index.js
@@ -1,0 +1,9 @@
+const { app, BrowserWindow } = require('electron');
+
+app.whenReady().then(() => {
+  const w = new BrowserWindow({ show: false, webPreferences: { webviewTag: true } });
+  w.loadURL('data:text/html,<webview src="data:text/html,hi"></webview>');
+  app.on('web-contents-created', () => {
+    w.close();
+  });
+});


### PR DESCRIPTION
Backport of #25431

Notes: Fixed a crash that could happen when a window was closed while a webview was in the process of being attached.