### PR TITLE
fix: close window when leave fs crash

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -336,11 +336,11 @@ void BrowserWindow::OnWindowResize() {
 }
 
 void BrowserWindow::OnWindowLeaveFullScreen() {
-  TopLevelWindow::OnWindowLeaveFullScreen();
 #if defined(OS_MACOSX)
   if (web_contents()->IsFullscreenForCurrentTab())
     web_contents()->ExitFullscreen(true);
 #endif
+  TopLevelWindow::OnWindowLeaveFullScreen();
 }
 
 void BrowserWindow::Focus() {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -3938,6 +3938,22 @@ describe('BrowserWindow module', () => {
     });
 
     ifdescribe(process.platform === 'darwin')('fullscreen state', () => {
+      it('should not cause a crash if called when exiting fullscreen', async () => {
+        const w = new BrowserWindow();
+
+        const enterFullScreen = emittedOnce(w, 'enter-full-screen');
+        w.setFullScreen(true);
+        await enterFullScreen;
+
+        await delay();
+
+        const leaveFullScreen = emittedOnce(w, 'leave-full-screen');
+        w.setFullScreen(false);
+        await leaveFullScreen;
+
+        w.close();
+      });
+
       it('can be changed with setFullScreen method', async () => {
         const w = new BrowserWindow();
         const enterFullScreen = emittedOnce(w, 'enter-full-screen');


### PR DESCRIPTION
Backport of #25468

See that PR for details.


Notes: Fixed a crash when closing window in an event listener after exiting fullscreen on macOS.
