### PR TITLE
fix: close window when leave fs crash

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -308,11 +308,11 @@ void BrowserWindow::OnWindowResize() {
 }
 
 void BrowserWindow::OnWindowLeaveFullScreen() {
-  TopLevelWindow::OnWindowLeaveFullScreen();
 #if defined(OS_MACOSX)
   if (web_contents()->IsFullscreenForCurrentTab())
     web_contents()->ExitFullscreen(true);
 #endif
+  TopLevelWindow::OnWindowLeaveFullScreen();
 }
 
 void BrowserWindow::Focus() {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -3883,6 +3883,22 @@ describe('BrowserWindow module', () => {
     });
 
     ifdescribe(process.platform === 'darwin')('fullscreen state', () => {
+      it('should not cause a crash if called when exiting fullscreen', (done) => {
+        const w = new BrowserWindow();
+        w.once('enter-full-screen', async () => {
+          expect(w.isFullScreen()).to.be.true('isFullScreen');
+          await tick();
+          w.setFullScreen(false);
+        });
+
+        w.once('leave-full-screen', () => {
+          expect(w.isFullScreen()).to.be.false('isFullScreen');
+          w.close();
+          done();
+        });
+        w.setFullScreen(true);
+      });
+
       it('can be changed with setFullScreen method', (done) => {
         const w = new BrowserWindow();
         w.once('enter-full-screen', async () => {


### PR DESCRIPTION
Backport of #25468

See that PR for details.


Notes: Fixed a crash when closing window in an event listener after exiting fullscreen on macOS.
