### PR TITLE
fix: submenu should be autoreleased

### DIFF
--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -297,7 +297,7 @@ static base::scoped_nsobject<NSMenu> recentDocumentsMenuSwap_;
 
     [item setTarget:nil];
     [item setAction:nil];
-    NSMenu* submenu = [[NSMenu alloc] initWithTitle:label];
+    NSMenu* submenu = [[[NSMenu alloc] initWithTitle:label] autorelease];
     [item setSubmenu:submenu];
     [NSApp setServicesMenu:submenu];
   } else if (type == electron::ElectronMenuModel::TYPE_SUBMENU &&


### PR DESCRIPTION
#### Description of Change

The `submenu` is a strong property so it must be autoreleased before being assigned.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix memory leak when creating "Services" menu.