### PR TITLE
refactor: check ELECTRON_ENABLE_LOGGING via native implementation

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -452,6 +452,7 @@ filenames = {
     "shell/common/api/electron_api_clipboard.h",
     "shell/common/api/electron_api_clipboard_mac.mm",
     "shell/common/api/electron_api_command_line.cc",
+    "shell/common/api/electron_api_environment.cc",
     "shell/common/api/electron_api_key_weak_map.h",
     "shell/common/api/electron_api_native_image.cc",
     "shell/common/api/electron_api_native_image.h",

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -461,8 +461,11 @@ const addReturnValueToEvent = (event: any) => {
   });
 };
 
+const commandLine = process._linkedBinding('electron_common_command_line');
+const environment = process._linkedBinding('electron_common_environment');
+
 const loggingEnabled = () => {
-  return process.env.ELECTRON_ENABLE_LOGGING || app.commandLine.hasSwitch('enable-logging');
+  return environment.hasVar('ELECTRON_ENABLE_LOGGING') || commandLine.hasSwitch('enable-logging');
 };
 
 // Add JavaScript wrappers for WebContents class.

--- a/shell/common/api/electron_api_environment.cc
+++ b/shell/common/api/electron_api_environment.cc
@@ -1,0 +1,45 @@
+// Copyright (c) 2020 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "base/environment.h"
+#include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/node_includes.h"
+
+namespace {
+
+v8::Local<v8::Value> GetVar(v8::Isolate* isolate, const std::string& name) {
+  std::string value;
+  if (base::Environment::Create()->GetVar(name, &value)) {
+    return gin::StringToV8(isolate, value);
+  } else {
+    return v8::Null(isolate);
+  }
+}
+
+bool HasVar(const std::string& name) {
+  return base::Environment::Create()->HasVar(name);
+}
+
+bool SetVar(const std::string& name, const std::string& value) {
+  return base::Environment::Create()->SetVar(name, value);
+}
+
+bool UnSetVar(const std::string& name) {
+  return base::Environment::Create()->UnSetVar(name);
+}
+
+void Initialize(v8::Local<v8::Object> exports,
+                v8::Local<v8::Value> unused,
+                v8::Local<v8::Context> context,
+                void* priv) {
+  gin_helper::Dictionary dict(context->GetIsolate(), exports);
+  dict.SetMethod("getVar", &GetVar);
+  dict.SetMethod("hasVar", &HasVar);
+  dict.SetMethod("setVar", &SetVar);
+  dict.SetMethod("unSetVar", &UnSetVar);
+}
+
+}  // namespace
+
+NODE_LINKED_MODULE_CONTEXT_AWARE(electron_common_environment, Initialize)

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -67,6 +67,7 @@
   V(electron_common_asar)                \
   V(electron_common_clipboard)           \
   V(electron_common_command_line)        \
+  V(electron_common_environment)         \
   V(electron_common_features)            \
   V(electron_common_native_image)        \
   V(electron_common_native_theme)        \

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -47,6 +47,13 @@ declare namespace NodeJS {
     triggerFatalErrorForTesting(): void;
   }
 
+  interface EnvironmentBinding {
+    getVar(name: string): string | null;
+    hasVar(name: string): boolean;
+    setVar(name: string, value: string): boolean;
+    unSetVar(name: string): boolean;
+  }
+
   type AsarFileInfo = {
     size: number;
     unpacked: boolean;
@@ -136,6 +143,7 @@ declare namespace NodeJS {
     _linkedBinding(name: 'electron_common_features'): FeaturesBinding;
     _linkedBinding(name: 'electron_browser_app'): { app: Electron.App, App: Function };
     _linkedBinding(name: 'electron_common_command_line'): Electron.CommandLine;
+    _linkedBinding(name: 'electron_common_environment'): EnvironmentBinding;
     _linkedBinding(name: 'electron_browser_desktop_capturer'): {
       createDesktopCapturer(): ElectronInternal.DesktopCapturer;
     };


### PR DESCRIPTION
#### Description of Change
Expose `electron_common_environment` binding wrapping Chromium's `base::Environment`.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes