### PR TITLE
fix: ensure ready-to-show event is fired

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -615,6 +615,13 @@ WebContents.prototype._init = function () {
     app.emit('login', event, this, ...args);
   });
 
+  this.on('ready-to-show' as any, (event) => {
+    const owner = this.getOwnerBrowserWindow();
+    if (owner && !owner.isDestroyed()) {
+      owner.emit('ready-to-show');
+    }
+  });
+
   const event = process._linkedBinding('electron_browser_event').createEmpty();
   app.emit('web-contents-created', event, this);
 

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -618,7 +618,7 @@ WebContents.prototype._init = function () {
   this.on('ready-to-show' as any, () => {
     const owner = this.getOwnerBrowserWindow();
     if (owner && !owner.isDestroyed()) {
-      process.nextTick( () => {
+      process.nextTick(() => {
         owner.emit('ready-to-show');
       });
     }

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -615,10 +615,12 @@ WebContents.prototype._init = function () {
     app.emit('login', event, this, ...args);
   });
 
-  this.on('ready-to-show' as any, (event) => {
+  this.on('ready-to-show' as any, () => {
     const owner = this.getOwnerBrowserWindow();
     if (owner && !owner.isDestroyed()) {
-      owner.emit('ready-to-show');
+      process.nextTick( () => {
+        owner.emit('ready-to-show');
+      });
     }
   });
 

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -157,30 +157,10 @@ void BrowserWindow::DidFirstVisuallyNonEmptyPaint() {
   base::ThreadTaskRunnerHandle::Get()->PostTask(
       FROM_HERE, base::BindOnce(
                      [](base::WeakPtr<BrowserWindow> self) {
-                       if (self && !self->did_ready_to_show_fired_) {
-                         self->did_ready_to_show_fired_ = true;
+                       if (self)
                          self->Emit("ready-to-show");
-                       }
                      },
                      GetWeakPtr()));
-}
-
-void BrowserWindow::DidFinishLoad(content::RenderFrameHost* render_frame_host,
-                                  const GURL& validated_url) {
-  // The DidFirstVisuallyNonEmptyPaint event is not very stable that, sometimes
-  // on some machines it might not be fired, and the actual behavior depends on
-  // the version of Chromium.
-  // To work around this bug, we ensure the ready-to-show event is emitted if it
-  // has not been emitted in did-finish-load event.
-  // Note that we use did-finish-load event instead of dom-ready event because
-  // the latter may actually be emitted before the ready-to-show event.
-  // See also https://github.com/electron/electron/issues/7779.
-  if (window()->IsVisible() || did_ready_to_show_fired_)
-    return;
-  if (render_frame_host->GetParent())  // child frame
-    return;
-  did_ready_to_show_fired_ = true;
-  Emit("ready-to-show");
 }
 
 void BrowserWindow::BeforeUnloadDialogCancelled() {

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -152,15 +152,6 @@ void BrowserWindow::DidFirstVisuallyNonEmptyPaint() {
   auto* const view = web_contents()->GetRenderWidgetHostView();
   view->Show();
   view->SetSize(window()->GetContentSize());
-
-  // Emit the ReadyToShow event in next tick in case of pending drawing work.
-  base::ThreadTaskRunnerHandle::Get()->PostTask(
-      FROM_HERE, base::BindOnce(
-                     [](base::WeakPtr<BrowserWindow> self) {
-                       if (self)
-                         self->Emit("ready-to-show");
-                     },
-                     GetWeakPtr()));
 }
 
 void BrowserWindow::BeforeUnloadDialogCancelled() {

--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -49,8 +49,6 @@ class BrowserWindow : public BaseWindow,
                              content::RenderViewHost* new_host) override;
   void RenderViewCreated(content::RenderViewHost* render_view_host) override;
   void DidFirstVisuallyNonEmptyPaint() override;
-  void DidFinishLoad(content::RenderFrameHost* render_frame_host,
-                     const GURL& validated_url) override;
   void BeforeUnloadDialogCancelled() override;
   void OnRendererUnresponsive(content::RenderProcessHost*) override;
   void OnRendererResponsive(
@@ -120,8 +118,6 @@ class BrowserWindow : public BaseWindow,
   // Closure that would be called when window is unresponsive when closing,
   // it should be cancelled when we can prove that the window is responsive.
   base::CancelableClosure window_unresponsive_closure_;
-
-  bool did_ready_to_show_fired_ = false;
 
 #if defined(OS_MAC)
   std::vector<mojom::DraggableRegionPtr> draggable_regions_;

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -26,6 +26,7 @@
 #include "content/browser/renderer_host/render_frame_host_manager.h"  // nogncheck
 #include "content/browser/renderer_host/render_widget_host_impl.h"  // nogncheck
 #include "content/browser/renderer_host/render_widget_host_view_base.h"  // nogncheck
+#include "content/browser/web_contents/web_contents_impl.h"  // nogncheck
 #include "content/common/widget_messages.h"
 #include "content/public/browser/child_process_security_policy.h"
 #include "content/public/browser/context_menu_params.h"
@@ -1238,6 +1239,12 @@ void WebContents::Invoke(bool internal,
   // webContents.emit('-ipc-invoke', new Event(), internal, channel, arguments);
   EmitWithSender("-ipc-invoke", receivers_.current_context(),
                  std::move(callback), internal, channel, std::move(arguments));
+}
+
+void WebContents::OnFirstNonEmptyLayout() {
+  if (receivers_.current_context() == web_contents()->GetMainFrame()) {
+    Emit("ready-to-show");
+  }
 }
 
 void WebContents::ReceivePostMessage(const std::string& channel,

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -26,7 +26,6 @@
 #include "content/browser/renderer_host/render_frame_host_manager.h"  // nogncheck
 #include "content/browser/renderer_host/render_widget_host_impl.h"  // nogncheck
 #include "content/browser/renderer_host/render_widget_host_view_base.h"  // nogncheck
-#include "content/browser/web_contents/web_contents_impl.h"  // nogncheck
 #include "content/common/widget_messages.h"
 #include "content/public/browser/child_process_security_policy.h"
 #include "content/public/browser/context_menu_params.h"

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -631,6 +631,7 @@ class WebContents : public gin::Wrappable<WebContents>,
               const std::string& channel,
               blink::CloneableMessage arguments,
               InvokeCallback callback) override;
+  void OnFirstNonEmptyLayout() override;
   void ReceivePostMessage(const std::string& channel,
                           blink::TransferableMessage message) override;
   void MessageSync(bool internal,

--- a/shell/common/api/api.mojom
+++ b/shell/common/api/api.mojom
@@ -49,6 +49,10 @@ interface ElectronBrowser {
       string channel,
       blink.mojom.CloneableMessage arguments) => (blink.mojom.CloneableMessage result);
 
+  // Informs underlying WebContents that first non-empty layout was performed
+  // by compositor.
+  OnFirstNonEmptyLayout();
+
   ReceivePostMessage(string channel, blink.mojom.TransferableMessage message);
 
   // Emits an event on |channel| from the ipcMain JavaScript object in the main

--- a/shell/renderer/electron_render_frame_observer.cc
+++ b/shell/renderer/electron_render_frame_observer.cc
@@ -128,6 +128,16 @@ void ElectronRenderFrameObserver::OnDestruct() {
   delete this;
 }
 
+void ElectronRenderFrameObserver::DidMeaningfulLayout(
+    blink::WebMeaningfulLayout layout_type) {
+  if (layout_type == blink::WebMeaningfulLayout::kVisuallyNonEmpty) {
+    mojo::Remote<mojom::ElectronBrowser> browser_remote;
+    render_frame_->GetRemoteInterfaces()->GetInterface(
+        browser_remote.BindNewPipeAndPassReceiver());
+    browser_remote->OnFirstNonEmptyLayout();
+  }
+}
+
 void ElectronRenderFrameObserver::CreateIsolatedWorldContext() {
   auto* frame = render_frame_->GetWebFrame();
   blink::WebIsolatedWorldInfo info;

--- a/shell/renderer/electron_render_frame_observer.h
+++ b/shell/renderer/electron_render_frame_observer.h
@@ -33,6 +33,7 @@ class ElectronRenderFrameObserver : public content::RenderFrameObserver {
   void WillReleaseScriptContext(v8::Local<v8::Context> context,
                                 int world_id) override;
   void OnDestruct() override;
+  void DidMeaningfulLayout(blink::WebMeaningfulLayout layout_type) override;
 
  private:
   bool ShouldNotifyClient(int world_id);


### PR DESCRIPTION
#### Description of Change

When this chromium change landed:
https://chromium-review.googlesource.com/c/chromium/src/+/2215143
event `ready-to-show` is not always emitted. This pull request removes following workaround for the problem:
https://github.com/electron/electron/pull/25448
and fixes the problem the way which ensures that event is emitted exactly at the same moment it would be emitted before problematic chromium change landed. Previous fix was not ideal as with it event `ready-to-show` is emitted only after `did-finish-load` was received what significantly delays moment the window is displayed (also: it may happen that `did-finish-load` is never emitted for certain pages). 


#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix ready-to-show event not emitted on some machines.