### PR TITLE
chore: cherry-pick 814a27f8522b from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -135,3 +135,4 @@ cherry-pick-52dceba66599.patch
 cherry-pick-abc6ab85e704.patch
 avoid_use-after-free.patch
 cherry-pick-3b5f65c0aeca.patch
+cherry-pick-814a27f8522b.patch

--- a/patches/chromium/cherry-pick-814a27f8522b.patch
+++ b/patches/chromium/cherry-pick-814a27f8522b.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrey Kosyakov <caseq@chromium.org>
+Date: Fri, 28 Aug 2020 18:55:17 +0000
+Subject: Delegate TargetHandler::Session permission checks to the root client
+
+Bug: 1114636
+Change-Id: Iba3865206d7e80b363ec69180ac05e20b56aade2
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2380855
+Reviewed-by: Dmitry Gozman <dgozman@chromium.org>
+Reviewed-by: Devlin <rdevlin.cronin@chromium.org>
+Commit-Queue: Andrey Kosyakov <caseq@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#802736}
+(cherry picked from commit 814a27f8522b6ccddcce1a8f6a3b8fb37128ecf9)
+
+diff --git a/content/browser/devtools/protocol/target_handler.cc b/content/browser/devtools/protocol/target_handler.cc
+index 7a30ab12a1a9fff313e8ea14f5c3bf7a327e6cc1..84606285982a8ab0f85b787a3dc3a82344c4f369 100644
+--- a/content/browser/devtools/protocol/target_handler.cc
++++ b/content/browser/devtools/protocol/target_handler.cc
+@@ -382,6 +382,26 @@ class TargetHandler::Session : public DevToolsAgentHostClient {
+     Detach(true);
+   }
+ 
++  bool MayAttachToURL(const GURL& url, bool is_webui) override {
++    return GetRootClient()->MayAttachToURL(url, is_webui);
++  }
++
++  bool MayAttachToBrowser() override {
++    return GetRootClient()->MayAttachToBrowser();
++  }
++
++  bool MayReadLocalFiles() override {
++    return GetRootClient()->MayReadLocalFiles();
++  }
++
++  bool MayWriteLocalFiles() override {
++    return GetRootClient()->MayWriteLocalFiles();
++  }
++
++  content::DevToolsAgentHostClient* GetRootClient() {
++    return handler_->root_session_->GetClient();
++  }
++
+   TargetHandler* handler_;
+   scoped_refptr<DevToolsAgentHost> agent_host_;
+   std::string id_;


### PR DESCRIPTION
Delegate TargetHandler::Session permission checks to the root client

Bug: 1114636
Change-Id: Iba3865206d7e80b363ec69180ac05e20b56aade2
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2380855
Reviewed-by: Dmitry Gozman <dgozman@chromium.org>
Reviewed-by: Devlin <rdevlin.cronin@chromium.org>
Commit-Queue: Andrey Kosyakov <caseq@chromium.org>
Cr-Commit-Position: refs/heads/master@{#802736}

Notes: Security: backported fix for 1114636.