### PR TITLE
refactor: remove unnecessary copied helper

### DIFF
--- a/shell/common/gin_converters/blink_converter.cc
+++ b/shell/common/gin_converters/blink_converter.cc
@@ -25,6 +25,7 @@
 #include "third_party/blink/public/common/widget/device_emulation_params.h"
 #include "third_party/blink/public/platform/web_size.h"
 #include "ui/base/clipboard/clipboard.h"
+#include "ui/events/blink/blink_event_util.h"
 #include "ui/events/keycodes/dom/keycode_converter.h"
 #include "ui/events/keycodes/keyboard_code_conversion.h"
 
@@ -197,7 +198,7 @@ bool Converter<blink::WebKeyboardEvent>::FromV8(v8::Isolate* isolate,
 
   ui::DomKey domKey;
   ui::KeyboardCode dummy_code;
-  int flags = electron::WebEventModifiersToEventFlags(out->GetModifiers());
+  int flags = ui::WebEventModifiersToEventFlags(out->GetModifiers());
   if (ui::DomCodeToUsLayoutDomKey(domCode, flags, &domKey, &dummy_code))
     out->dom_key = static_cast<int>(domKey);
 

--- a/shell/common/keyboard_util.cc
+++ b/shell/common/keyboard_util.cc
@@ -326,33 +326,4 @@ ui::KeyboardCode KeyboardCodeFromStr(const std::string& str, bool* shifted) {
     return KeyboardCodeFromKeyIdentifier(str, shifted);
 }
 
-int WebEventModifiersToEventFlags(int modifiers) {
-  int flags = 0;
-
-  if (modifiers & blink::WebInputEvent::Modifiers::kShiftKey)
-    flags |= ui::EF_SHIFT_DOWN;
-  if (modifiers & blink::WebInputEvent::Modifiers::kControlKey)
-    flags |= ui::EF_CONTROL_DOWN;
-  if (modifiers & blink::WebInputEvent::Modifiers::kAltKey)
-    flags |= ui::EF_ALT_DOWN;
-  if (modifiers & blink::WebInputEvent::Modifiers::kMetaKey)
-    flags |= ui::EF_COMMAND_DOWN;
-  if (modifiers & blink::WebInputEvent::Modifiers::kCapsLockOn)
-    flags |= ui::EF_CAPS_LOCK_ON;
-  if (modifiers & blink::WebInputEvent::Modifiers::kNumLockOn)
-    flags |= ui::EF_NUM_LOCK_ON;
-  if (modifiers & blink::WebInputEvent::Modifiers::kScrollLockOn)
-    flags |= ui::EF_SCROLL_LOCK_ON;
-  if (modifiers & blink::WebInputEvent::Modifiers::kLeftButtonDown)
-    flags |= ui::EF_LEFT_MOUSE_BUTTON;
-  if (modifiers & blink::WebInputEvent::Modifiers::kMiddleButtonDown)
-    flags |= ui::EF_MIDDLE_MOUSE_BUTTON;
-  if (modifiers & blink::WebInputEvent::Modifiers::kRightButtonDown)
-    flags |= ui::EF_RIGHT_MOUSE_BUTTON;
-  if (modifiers & blink::WebInputEvent::Modifiers::kIsAutoRepeat)
-    flags |= ui::EF_IS_REPEAT;
-
-  return flags;
-}
-
 }  // namespace electron

--- a/shell/common/keyboard_util.h
+++ b/shell/common/keyboard_util.h
@@ -20,9 +20,6 @@ ui::KeyboardCode KeyboardCodeFromCharCode(base::char16 c, bool* shifted);
 // pressed.
 ui::KeyboardCode KeyboardCodeFromStr(const std::string& str, bool* shifted);
 
-// Ported from ui/events/blink/blink_event_util.h
-int WebEventModifiersToEventFlags(int modifiers);
-
 }  // namespace electron
 
 #endif  // SHELL_COMMON_KEYBOARD_UTIL_H_


### PR DESCRIPTION
#### Description of Change

Removes unnecessarily copied code from a helper in Chromium we can call directly. At the time this was added to Electron we could not directly call it, and now we can and should.

cc @jkleinsc @ckerr @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
