### PR TITLE
refactor: more efficient key string matching

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -582,6 +582,7 @@ filenames = {
     "shell/common/process_util.h",
     "shell/common/skia_util.cc",
     "shell/common/skia_util.h",
+    "shell/common/string_lookup.h",
     "shell/common/v8_value_converter.cc",
     "shell/common/v8_value_converter.h",
     "shell/common/v8_value_serializer.cc",

--- a/shell/browser/api/electron_api_system_preferences_win.cc
+++ b/shell/browser/api/electron_api_system_preferences_win.cc
@@ -13,6 +13,7 @@
 #include "base/win/windows_types.h"
 #include "base/win/wrapped_window_proc.h"
 #include "shell/common/color_util.h"
+#include "shell/common/string_lookup.h"
 #include "ui/base/win/shell.h"
 #include "ui/gfx/color_utils.h"
 #include "ui/gfx/win/hwnd_util.h"
@@ -97,73 +98,44 @@ std::string SystemPreferences::GetAccentColor() {
 
 std::string SystemPreferences::GetColor(gin_helper::ErrorThrower thrower,
                                         const std::string& color) {
-  int id;
-  if (color == "3d-dark-shadow") {
-    id = COLOR_3DDKSHADOW;
-  } else if (color == "3d-face") {
-    id = COLOR_3DFACE;
-  } else if (color == "3d-highlight") {
-    id = COLOR_3DHIGHLIGHT;
-  } else if (color == "3d-light") {
-    id = COLOR_3DLIGHT;
-  } else if (color == "3d-shadow") {
-    id = COLOR_3DSHADOW;
-  } else if (color == "active-border") {
-    id = COLOR_ACTIVEBORDER;
-  } else if (color == "active-caption") {
-    id = COLOR_ACTIVECAPTION;
-  } else if (color == "active-caption-gradient") {
-    id = COLOR_GRADIENTACTIVECAPTION;
-  } else if (color == "app-workspace") {
-    id = COLOR_APPWORKSPACE;
-  } else if (color == "button-text") {
-    id = COLOR_BTNTEXT;
-  } else if (color == "caption-text") {
-    id = COLOR_CAPTIONTEXT;
-  } else if (color == "desktop") {
-    id = COLOR_DESKTOP;
-  } else if (color == "disabled-text") {
-    id = COLOR_GRAYTEXT;
-  } else if (color == "highlight") {
-    id = COLOR_HIGHLIGHT;
-  } else if (color == "highlight-text") {
-    id = COLOR_HIGHLIGHTTEXT;
-  } else if (color == "hotlight") {
-    id = COLOR_HOTLIGHT;
-  } else if (color == "inactive-border") {
-    id = COLOR_INACTIVEBORDER;
-  } else if (color == "inactive-caption") {
-    id = COLOR_INACTIVECAPTION;
-  } else if (color == "inactive-caption-gradient") {
-    id = COLOR_GRADIENTINACTIVECAPTION;
-  } else if (color == "inactive-caption-text") {
-    id = COLOR_INACTIVECAPTIONTEXT;
-  } else if (color == "info-background") {
-    id = COLOR_INFOBK;
-  } else if (color == "info-text") {
-    id = COLOR_INFOTEXT;
-  } else if (color == "menu") {
-    id = COLOR_MENU;
-  } else if (color == "menu-highlight") {
-    id = COLOR_MENUHILIGHT;
-  } else if (color == "menubar") {
-    id = COLOR_MENUBAR;
-  } else if (color == "menu-text") {
-    id = COLOR_MENUTEXT;
-  } else if (color == "scrollbar") {
-    id = COLOR_SCROLLBAR;
-  } else if (color == "window") {
-    id = COLOR_WINDOW;
-  } else if (color == "window-frame") {
-    id = COLOR_WINDOWFRAME;
-  } else if (color == "window-text") {
-    id = COLOR_WINDOWTEXT;
-  } else {
+  static constexpr StringLookup<int, 30> ids{
+      {{{"3d-dark-shadow", COLOR_3DDKSHADOW},
+        {"3d-face", COLOR_3DFACE},
+        {"3d-highlight", COLOR_3DHIGHLIGHT},
+        {"3d-light", COLOR_3DLIGHT},
+        {"3d-shadow", COLOR_3DSHADOW},
+        {"active-border", COLOR_ACTIVEBORDER},
+        {"active-caption", COLOR_ACTIVECAPTION},
+        {"active-caption-gradient", COLOR_GRADIENTACTIVECAPTION},
+        {"app-workspace", COLOR_APPWORKSPACE},
+        {"button-text", COLOR_BTNTEXT},
+        {"caption-text", COLOR_CAPTIONTEXT},
+        {"desktop", COLOR_DESKTOP},
+        {"disabled-text", COLOR_GRAYTEXT},
+        {"highlight", COLOR_HIGHLIGHT},
+        {"highlight-text", COLOR_HIGHLIGHTTEXT},
+        {"hotlight", COLOR_HOTLIGHT},
+        {"inactive-border", COLOR_INACTIVEBORDER},
+        {"inactive-caption", COLOR_INACTIVECAPTION},
+        {"inactive-caption-gradient", COLOR_GRADIENTINACTIVECAPTION},
+        {"inactive-caption-text", COLOR_INACTIVECAPTIONTEXT},
+        {"info-background", COLOR_INFOBK},
+        {"info-text", COLOR_INFOTEXT},
+        {"menu", COLOR_MENU},
+        {"menu-highlight", COLOR_MENUHILIGHT},
+        {"menu-text", COLOR_MENUTEXT},
+        {"menubar", COLOR_MENUBAR},
+        {"scrollbar", COLOR_SCROLLBAR},
+        {"window", COLOR_WINDOW},
+        {"window-frame", COLOR_WINDOWFRAME},
+        {"window-text", COLOR_WINDOWTEXT}}}};
+  static_assert(ids.IsSorted(), "please sort ids");
+  const auto id = ids.lookup(color);
+  if (!id) {
     thrower.ThrowError("Unknown color: " + color);
     return "";
   }
-
-  return ToRGBHex(color_utils::GetSysSkColor(id));
+  return ToRGBHex(color_utils::GetSysSkColor(*id));
 }
 
 std::string SystemPreferences::GetMediaAccessStatus(

--- a/shell/browser/ui/win/taskbar_host.cc
+++ b/shell/browser/ui/win/taskbar_host.cc
@@ -11,6 +11,7 @@
 #include "base/strings/utf_string_conversions.h"
 #include "base/win/scoped_gdi_object.h"
 #include "shell/browser/native_window.h"
+#include "shell/common/string_lookup.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "ui/display/win/screen_win.h"
 #include "ui/gfx/icon_util.h"
@@ -29,20 +30,21 @@ const int kButtonIdBase = 40001;
 
 bool GetThumbarButtonFlags(const std::vector<std::string>& flags,
                            THUMBBUTTONFLAGS* out) {
+  static constexpr StringLookup<THUMBBUTTONFLAGS, 5> flagmap{
+      {{{"disabled", THBF_DISABLED},
+        {"dismissonclick", THBF_DISMISSONCLICK},
+        {"hidden", THBF_HIDDEN},
+        {"nobackground", THBF_NOBACKGROUND},
+        {"noninteractive", THBF_NONINTERACTIVE}}}};
+  static_assert(flagmap.IsSorted(), "please sort flagmap");
+
   THUMBBUTTONFLAGS result = THBF_ENABLED;  // THBF_ENABLED == 0
-  for (const auto& flag : flags) {
-    if (flag == "disabled")
-      result |= THBF_DISABLED;
-    else if (flag == "dismissonclick")
-      result |= THBF_DISMISSONCLICK;
-    else if (flag == "nobackground")
-      result |= THBF_NOBACKGROUND;
-    else if (flag == "hidden")
-      result |= THBF_HIDDEN;
-    else if (flag == "noninteractive")
-      result |= THBF_NONINTERACTIVE;
-    else
+  for (const auto& name : flags) {
+    const auto flag = flagmap.lookup(name);
+    if (!flag) {
       return false;
+    }
+    result |= *flag;
   }
   *out = result;
   return true;

--- a/shell/common/string_lookup.h
+++ b/shell/common/string_lookup.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2020 Microsoft, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include <algorithm>
+#include <array>
+#include <string>
+
+#include "base/optional.h"
+#include "base/strings/string_piece.h"
+
+namespace electron {
+
+/**
+ * Efficient constexpr mapping of string/value pairs known at compile time.
+ * Example code:
+ *
+ * // declaration
+ * static constexpr StringLookup<int, 6> candidates {{{
+ *   { "ford", 15 },
+ *   { "jarrah", 16 },
+ *   { "kwon", 42 }
+ *   { "locke", 4 },
+ *   { "reyes", 8 },
+ *   { "shephard", 23 },
+ * }}};
+ * static_assert(candidates.IsSorted(), "please sort candidates");
+ *
+ * // usage
+ * base::Optional<int> number = candidates.lookup("kwon");
+ */
+template <typename Value, size_t Size>
+struct StringLookup {
+  std::array<std::pair<base::StringPiece, Value>, Size> data;
+
+  base::Optional<Value> lookup(base::StringPiece key) const {
+    const auto compare = [](auto const& a, auto const& b) {
+      return a.first < b;
+    };
+    const auto* it =
+        std::lower_bound(std::cbegin(data), std::cend(data), key, compare);
+    return it != std::cend(data) && key == it->first ? it->second
+                                                     : base::Optional<Value>{};
+  }
+
+  constexpr bool IsSorted() const {
+    for (std::size_t i = 0; i < data.size() - 1; ++i) {
+      if (data[i].first > data[i + 1].first) {
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
+}  // namespace electron

--- a/shell/common/string_lookup.h
+++ b/shell/common/string_lookup.h
@@ -2,9 +2,13 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#ifndef SHELL_COMMON_STRING_LOOKUP_H_
+#define SHELL_COMMON_STRING_LOOKUP_H_
+
 #include <algorithm>
 #include <array>
 #include <string>
+#include <utility>
 
 #include "base/optional.h"
 #include "base/strings/string_piece.h"
@@ -54,3 +58,5 @@ struct StringLookup {
 };
 
 }  // namespace electron
+
+#endif  // SHELL_COMMON_STRING_LOOKUP_H_


### PR DESCRIPTION
#### Description of Change

This was a lunchtime experiment with constexpr that worked out well enough to PR it. My goal was to make more structured / efficient / readable string matching to replace long `if (str == "foo") ... else (foo == "bar") ...` chains. This adds a StringPiece-to-Value map that's all built at compile-time.

Advantages:
* The map is built at compile time and has negligible overhead -- in fact using this shrunk `keyboard_util.o` by about 25%
* makes code more readable by forcing a structured key/value mapping
* lookups are binary instead of linear

Disadvantages:
* Takes a few lines of setup. The code is cheap but the conceptual overhead is not worth it for short lists.
* In general we don't do _that_ many string lookups.

I like the struct, but I'm undecided on whether this is overkill and would like another opinion. Reviewers welcomed.

CC @nornagon

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none