### PR TITLE
chore: fix package.json reference to atom directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "generate-version-json": "node script/generate-version-json.js",
     "lint": "node ./script/lint.js && npm run lint:clang-format && npm run lint:docs",
     "lint:js": "node ./script/lint.js --js",
-    "lint:clang-format": "python script/run-clang-format.py -r -c atom/ chromium_src/ || (echo \"\\nCode not formatted correctly.\" && exit 1)",
+    "lint:clang-format": "python script/run-clang-format.py -r -c chromium_src/ shell/ || (echo \"\\nCode not formatted correctly.\" && exit 1)",
     "lint:cpp": "node ./script/lint.js --cc",
     "lint:objc": "node ./script/lint.js --objc",
     "lint:py": "node ./script/lint.js --py",


### PR DESCRIPTION
#### Description of Change

Fix a leftover bug from the migration from `atom/` to `shell/` -- one of the package.json scripts still referred to the atom directory.

#### Checklist

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none