### PR TITLE
fix: suppress worldSafe warning emitted from security checks

### DIFF
--- a/lib/renderer/security-warnings.ts
+++ b/lib/renderer/security-warnings.ts
@@ -76,8 +76,9 @@ const isLocalhost = function () {
  *
  * @returns {boolean} Is a CSP with `unsafe-eval` set?
  */
-const isUnsafeEvalEnabled = function () {
-  return webFrame.executeJavaScript(`(${(() => {
+const isUnsafeEvalEnabled: () => Promise<boolean> = function () {
+  // Call _executeJavaScript to bypass the world-safe deprecation warning
+  return (webFrame as any)._executeJavaScript(`(${(() => {
     try {
       new Function(''); // eslint-disable-line no-new,no-new-func
     } catch {


### PR DESCRIPTION
#### Description of Change
The "hello world" Electron app was emitting a warning about executeJavaScript being called without world-safe turned on, even though the client code wasn't calling executeJavaScript. It turns out the culprit was in the security warnings code. For now, suppress the warning by calling `_executeJavaScript` directly.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Suppressed a spurious warning about executeJavaScript being called without worldSafeExecuteJavaScript being enabled in apps that do not call executeJavaScript.
