### PR TITLE
fix: crash when application launched from UNUserNotificationCenter notification

### DIFF
--- a/shell/browser/mac/electron_application_delegate.mm
+++ b/shell/browser/mac/electron_application_delegate.mm
@@ -69,9 +69,9 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
 
 - (void)applicationDidFinishLaunching:(NSNotification*)notify {
   NSUserNotification* user_notification =
-      [notify userInfo][(id) @"NSApplicationLaunchUserNotificationKey"];
+      [notify userInfo][NSApplicationLaunchUserNotificationKey];
 
-  if (user_notification.userInfo) {
+  if ([user_notification isKindOfClass:[NSUserNotification class]]) {
     electron::Browser::Get()->DidFinishLaunching(
         electron::NSDictionaryToDictionaryValue(user_notification.userInfo));
   } else {


### PR DESCRIPTION
#### Description of Change
We have a custom node module, which is using the new `UNUserNotificationCenter` APIs to show notifications. When the application is launched from such notification, the `NSApplicationLaunchUserNotificationKey` points to a `UNNotificationResponse` instance instead of `NSNotification`. This leads to an unrecognized selector exception. Check for `NSNotification` before accessing the `userInfo` property.

We can also use the `NSApplicationLaunchUserNotificationKey` directly, as it was introduced in macOS 10.8
Checking `userInfo` for `nil` is not necessary, as it's done by `NSDictionaryToDictionaryValue`.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed crash when application launched from `UNUserNotificationCenter` notification (via a native node module).