### PR TITLE
ci: force homebrew cache to update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,13 +322,13 @@ step-restore-brew-cache: &step-restore-brew-cache
     paths:
       - /usr/local/Homebrew
     keys:
-      - v1-brew-cache-{{ arch }}
+      - v2-brew-cache-{{ arch }}
 
 step-save-brew-cache: &step-save-brew-cache
   save_cache:
     paths:
       - /usr/local/Homebrew
-    key: v1-brew-cache-{{ arch }}
+    key: v2-brew-cache-{{ arch }}
     name: Persisting brew cache
 
 step-get-more-space-on-mac: &step-get-more-space-on-mac


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
We are seeing CircleCI macos builds fail with an error installing gnu-tar via homebrew, eg: https://app.circleci.com/pipelines/github/electron/electron/30441/workflows/e0caaa0b-6cfe-46fb-97ad-81311777c571/jobs/670922.

This PR updates our homebrew cache key used on CircleCI which seems to resolve the issue.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
