### PR TITLE
chore: convert guest-window-manager.js to TypeScript

### DIFF
--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -228,7 +228,7 @@ auto_filenames = {
     "lib/browser/desktop-capturer.ts",
     "lib/browser/devtools.ts",
     "lib/browser/guest-view-manager.js",
-    "lib/browser/guest-window-manager.js",
+    "lib/browser/guest-window-manager.ts",
     "lib/browser/init.ts",
     "lib/browser/ipc-main-impl.ts",
     "lib/browser/ipc-main-internal-utils.ts",

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -566,7 +566,7 @@ WebContents.prototype._init = function () {
   if (this.getType() !== 'remote') {
     // Make new windows requested by links behave like "window.open".
     this.on('-new-window' as any, (event: any, url: string, frameName: string, disposition: string,
-      rawFeatures: string, referrer: string, postData: string) => {
+      rawFeatures: string, referrer: string, postData: Electron.UploadRawData[]) => {
       const { options, webPreferences, additionalFeatures } = parseFeatures(rawFeatures);
       const mergedOptions = {
         show: true,
@@ -584,7 +584,7 @@ WebContents.prototype._init = function () {
     // "window.open", used in sandbox and nativeWindowOpen mode.
     this.on('-add-new-contents' as any, (event: any, webContents: Electron.WebContents, disposition: string,
       userGesture: boolean, left: number, top: number, width: number, height: number, url: string, frameName: string,
-      referrer: string, rawFeatures: string, postData: string) => {
+      referrer: string, rawFeatures: string, postData: Electron.UploadRawData[]) => {
       if ((disposition !== 'foreground-tab' && disposition !== 'new-window' &&
            disposition !== 'background-tab')) {
         event.preventDefault();

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -45,6 +45,7 @@ declare namespace NodeJS {
     getWeaklyTrackedValues(): any[];
     addRemoteObjectRef(contextId: string, id: number): void;
     triggerFatalErrorForTesting(): void;
+    isSameOrigin(left: string, right: string): boolean;
   }
 
   type AsarFileInfo = {

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -26,6 +26,7 @@ declare namespace Electron {
     _setTouchBarItems: (items: TouchBarItemType[]) => void;
     _setEscapeTouchBarItem: (item: TouchBarItemType | {}) => void;
     _refreshTouchBarItem: (itemID: string) => void;
+    frameName: string;
     on(event: '-touch-bar-interaction', listener: (event: Event, itemID: string, details: any) => void): this;
     removeListener(event: '-touch-bar-interaction', listener: (event: Event, itemID: string, details: any) => void): this;
   }
@@ -57,6 +58,7 @@ declare namespace Electron {
     _getPreloadPaths(): string[];
     equal(other: WebContents): boolean;
     _initiallyShown: boolean;
+    browserWindowOptions: BrowserWindowConstructorOptions;
     _send(internal: boolean, sendToAll: boolean, channel: string, args: any): boolean;
     _sendToFrame(internal: boolean, sendToAll: boolean, frameId: number, channel: string, args: any): boolean;
     _sendToFrameInternal(frameId: number, channel: string, args: any): boolean;
@@ -80,6 +82,7 @@ declare namespace Electron {
   interface WebPreferences {
     guestInstanceId?: number;
     openerId?: number;
+    disablePopups?: boolean
   }
 
   interface Menu {


### PR DESCRIPTION
#### Description of Change
Convert `guest-window-manager.js` to TypeScript.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes