### PR TITLE
build: move to ACR for docker image storage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ parameters:
 # Build machines configs.
 docker-image: &docker-image
   docker:
-    - image: electronjs/build:d09fd95029bd8c1c73069888231b29688ef385ed
+    - image: electron.azurecr.io/build:4cec2c5ab66765caa724e37bae2bffb9b29722a5
 
 machine-linux-medium: &machine-linux-medium
   <<: *docker-image

--- a/vsts-arm32v7.yml
+++ b/vsts-arm32v7.yml
@@ -1,7 +1,7 @@
 resources:
   containers:
   - container: arm32v7-test-container
-    image: electronjs/build:arm32v7-697b894f36d127155e020f4e8ad4b2e5f6a09613
+    image: electron.azurecr.io/build:arm32v7-4cec2c5ab66765caa724e37bae2bffb9b29722a5
     options: --shm-size 128m
 
 jobs:

--- a/vsts-arm64v8.yml
+++ b/vsts-arm64v8.yml
@@ -1,7 +1,7 @@
 resources:
   containers:
   - container: arm64v8-test-container
-    image: electronjs/build:arm64v8-697b894f36d127155e020f4e8ad4b2e5f6a09613
+    image: electron.azurecr.io/build:arm64v8-4cec2c5ab66765caa724e37bae2bffb9b29722a5
     options: --shm-size 128m
 
 jobs:


### PR DESCRIPTION
Due to upcoming rate limits being imposed by dockerhub we're moving to ACR for our build image storage

Notes: no-notes