### PR TITLE
chore: cleanup typings/internal-electron.d.ts

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -121,7 +121,7 @@ const defaultPrintingSetting = {
 
 // JavaScript implementations of WebContents.
 const binding = process._linkedBinding('electron_browser_web_contents');
-const { WebContents } = binding as { WebContents: { prototype: Electron.WebContentsInternal } };
+const { WebContents } = binding as { WebContents: { prototype: Electron.WebContents } };
 
 WebContents.prototype.send = function (channel, ...args) {
   if (typeof channel !== 'string') {
@@ -200,7 +200,7 @@ for (const method of webFrameMethods) {
   };
 }
 
-const waitTillCanExecuteJavaScript = async (webContents: Electron.WebContentsInternal) => {
+const waitTillCanExecuteJavaScript = async (webContents: Electron.WebContents) => {
   if (webContents.getURL() && !webContents.isLoadingMainFrame()) return;
 
   return new Promise((resolve) => {
@@ -491,7 +491,7 @@ WebContents.prototype._init = function () {
   this.setMaxListeners(0);
 
   // Dispatch IPC messages to the ipc module.
-  this.on('-ipc-message' as any, function (this: Electron.WebContentsInternal, event: any, internal: boolean, channel: string, args: any[]) {
+  this.on('-ipc-message' as any, function (this: Electron.WebContents, event: any, internal: boolean, channel: string, args: any[]) {
     if (internal) {
       addReplyInternalToEvent(event);
       ipcMainInternal.emit(channel, event, ...args);
@@ -516,7 +516,7 @@ WebContents.prototype._init = function () {
     }
   });
 
-  this.on('-ipc-message-sync' as any, function (this: Electron.WebContentsInternal, event: any, internal: boolean, channel: string, args: any[]) {
+  this.on('-ipc-message-sync' as any, function (this: Electron.WebContents, event: any, internal: boolean, channel: string, args: any[]) {
     addReturnValueToEvent(event);
     if (internal) {
       addReplyInternalToEvent(event);
@@ -559,7 +559,7 @@ WebContents.prototype._init = function () {
   });
 
   // The devtools requests the webContents to reload.
-  this.on('devtools-reload-page', function (this: Electron.WebContentsInternal) {
+  this.on('devtools-reload-page', function (this: Electron.WebContents) {
     this.reload();
   });
 
@@ -582,7 +582,7 @@ WebContents.prototype._init = function () {
 
     // Create a new browser window for the native implementation of
     // "window.open", used in sandbox and nativeWindowOpen mode.
-    this.on('-add-new-contents' as any, (event: any, webContents: Electron.WebContentsInternal, disposition: string,
+    this.on('-add-new-contents' as any, (event: any, webContents: Electron.WebContents, disposition: string,
       userGesture: boolean, left: number, top: number, width: number, height: number, url: string, frameName: string,
       referrer: string, rawFeatures: string, postData: string) => {
       if ((disposition !== 'foreground-tab' && disposition !== 'new-window' &&

--- a/lib/browser/ipc-main-internal-utils.ts
+++ b/lib/browser/ipc-main-internal-utils.ts
@@ -14,13 +14,11 @@ export const handleSync = function <T extends IPCHandler> (channel: string, hand
 
 let nextId = 0;
 
-export function invokeInWebContents<T> (sender: Electron.WebContentsInternal, sendToAll: boolean, command: string, ...args: any[]) {
+export function invokeInWebContents<T> (sender: Electron.WebContents, sendToAll: boolean, command: string, ...args: any[]) {
   return new Promise<T>((resolve, reject) => {
     const requestId = ++nextId;
     const channel = `${command}_RESPONSE_${requestId}`;
-    ipcMainInternal.on(channel, function handler (
-      event, error: Electron.SerializedError, result: any
-    ) {
+    ipcMainInternal.on(channel, function handler (event, error: Error, result: any) {
       if (event.sender !== sender) {
         console.error(`Reply to ${command} sent by unexpected WebContents (${event.sender.id})`);
         return;

--- a/lib/renderer/ipc-renderer-internal.ts
+++ b/lib/renderer/ipc-renderer-internal.ts
@@ -4,7 +4,7 @@ const { ipc } = process._linkedBinding('electron_renderer_ipc');
 
 const internal = true;
 
-const ipcRendererInternal = new EventEmitter() as any as Electron.IpcRendererInternal;
+const ipcRendererInternal = new EventEmitter() as any as ElectronInternal.IpcRendererInternal;
 ipcRendererInternal.send = function (channel, ...args) {
   return ipc.send(internal, channel, args);
 };

--- a/lib/renderer/web-view/guest-view-internal.ts
+++ b/lib/renderer/web-view/guest-view-internal.ts
@@ -99,7 +99,7 @@ export function createGuest (params: Record<string, any>): Promise<number> {
 export function attachGuest (
   elementInstanceId: number, guestInstanceId: number, params: Record<string, any>, contentWindow: Window
 ) {
-  const embedderFrameId = (webFrame as ElectronInternal.WebFrameInternal).getWebFrameId(contentWindow);
+  const embedderFrameId = webFrame.getWebFrameId(contentWindow);
   if (embedderFrameId < 0) { // this error should not happen.
     throw new Error('Invalid embedder frame');
   }

--- a/lib/renderer/web-view/web-view-element.ts
+++ b/lib/renderer/web-view/web-view-element.ts
@@ -85,8 +85,7 @@ const registerWebViewElement = (v8Util: NodeJS.V8UtilBinding, webViewImpl: typeo
   webViewImpl.setupMethods(WebViewElement);
 
   // The customElements.define has to be called in a special scope.
-  const webFrame = webViewImpl.webFrame as ElectronInternal.WebFrameInternal;
-  webFrame.allowGuestViewElementDefinition(window, () => {
+  webViewImpl.webFrame.allowGuestViewElementDefinition(window, () => {
     window.customElements.define('webview', WebViewElement);
     (window as any).WebView = WebViewElement;
 

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -57,57 +57,6 @@ declare namespace Electron {
     _getPreloadPaths(): string[];
     equal(other: WebContents): boolean;
     _initiallyShown: boolean;
-  }
-
-  interface WebPreferences {
-    guestInstanceId?: number;
-    openerId?: number;
-  }
-
-  interface SerializedError {
-    message: string;
-    stack?: string,
-    name: string,
-    from: Electron.ProcessType,
-    cause: SerializedError,
-    __ELECTRON_SERIALIZED_ERROR__: true
-  }
-
-  interface ErrorWithCause extends Error {
-    from?: string;
-    cause?: ErrorWithCause;
-  }
-
-  interface InjectionBase {
-    url: string;
-    code: string
-  }
-
-  interface ContentScript {
-    js: Array<InjectionBase>;
-    css: Array<InjectionBase>;
-    runAt: string;
-    matches: {
-      some: (input: (pattern: string) => boolean | RegExpMatchArray | null) => boolean;
-    }
-    /**
-     * Whether to match all frames, or only the top one.
-     * https://developer.chrome.com/extensions/content_scripts#frames
-     */
-    allFrames: boolean
-  }
-
-  type ContentScriptEntry = {
-    extensionId: string;
-    contentScripts: ContentScript[];
-  }
-
-  interface IpcRendererInternal extends Electron.IpcRenderer {
-    invoke<T>(channel: string, ...args: any[]): Promise<T>;
-    sendToAll(webContentsId: number, channel: string, ...args: any[]): void
-  }
-
-  interface WebContentsInternal extends Electron.WebContents {
     _send(internal: boolean, sendToAll: boolean, channel: string, args: any): boolean;
     _sendToFrame(internal: boolean, sendToAll: boolean, frameId: number, channel: string, args: any): boolean;
     _sendToFrameInternal(frameId: number, channel: string, args: any): boolean;
@@ -121,6 +70,16 @@ declare namespace Electron {
     canGoToIndex(index: number): boolean;
     getActiveIndex(): number;
     length(): number;
+  }
+
+  interface WebFrame {
+    getWebFrameId(window: Window): number;
+    allowGuestViewElementDefinition(window: Window, context: any): void;
+  }
+
+  interface WebPreferences {
+    guestInstanceId?: number;
+    openerId?: number;
   }
 
   interface Menu {
@@ -169,7 +128,7 @@ declare namespace Electron {
   }
 
   class View {}
-  
+
   // Experimental views API
   class BaseWindow {
     constructor(args: {show: boolean})
@@ -244,11 +203,9 @@ declare namespace ElectronInternal {
     appIcon: Electron.NativeImage | null;
   }
 
-  interface KeyWeakMap<K, V> {
-    set(key: K, value: V): void;
-    get(key: K): V | undefined;
-    has(key: K): boolean;
-    remove(key: K): void;
+  interface IpcRendererInternal extends Electron.IpcRenderer {
+    invoke<T>(channel: string, ...args: any[]): Promise<T>;
+    sendToAll(webContentsId: number, channel: string, ...args: any[]): void
   }
 
   // Internal IPC has _replyInternal and NO reply method
@@ -268,11 +225,6 @@ declare namespace ElectronInternal {
     name: string;
     private?: boolean;
     loader: ModuleLoader;
-  }
-
-  interface WebFrameInternal extends Electron.WebFrame {
-    getWebFrameId(window: Window): number;
-    allowGuestViewElementDefinition(window: Window, context: any): void;
   }
 
   interface WebFrameResizeEvent extends Electron.Event {


### PR DESCRIPTION
#### Description of Change
Unused stuff removed + merged `Electron.WebContentsInternal` into `Electron.WebContents`.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes