### PR TITLE
docs: spelling

### DIFF
--- a/docs/tutorial/updates.md
+++ b/docs/tutorial/updates.md
@@ -132,7 +132,7 @@ autoUpdater.on('error', message => {
 })
 ```
 
-## Handing Updates Manually
+## Handling Updates Manually
 
 Because the requests made by Auto Update aren't under your direct control, you may find situations that are difficult to handle (such as if the update server is behind authentication). The `url` field does support files, which means that with some effort, you can sidestep the server-communication aspect of the process. [Here's an example of how this could work](https://github.com/electron/electron/issues/5020#issuecomment-477636990).
 


### PR DESCRIPTION
#### Description of Change
Caught a spelling issue and thought I'd fix it. Thanks for the great docs!

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
