### PR TITLE
fix: improve perf of multi-scale nativeImage serialization

### DIFF
--- a/lib/common/type-utils.ts
+++ b/lib/common/type-utils.ts
@@ -38,21 +38,10 @@ function serializeNativeImage (image: any) {
   const representations = [];
   const scaleFactors = image.getScaleFactors();
 
-  // Use Buffer when there's only one representation for better perf.
-  // This avoids compressing to/from PNG where it's not necessary to
-  // ensure uniqueness of dataURLs (since there's only one).
-  if (scaleFactors.length === 1) {
-    const scaleFactor = scaleFactors[0];
+  for (const scaleFactor of scaleFactors) {
     const size = image.getSize(scaleFactor);
     const buffer = image.toBitmap({ scaleFactor });
     representations.push({ scaleFactor, size, buffer });
-  } else {
-    // Construct from dataURLs to ensure that they are not lost in creation.
-    for (const scaleFactor of scaleFactors) {
-      const size = image.getSize(scaleFactor);
-      const dataURL = image.toDataURL({ scaleFactor });
-      representations.push({ scaleFactor, size, dataURL });
-    }
   }
   return { __ELECTRON_SERIALIZED_NativeImage__: true, representations };
 }
@@ -60,20 +49,10 @@ function serializeNativeImage (image: any) {
 function deserializeNativeImage (value: any) {
   const image = nativeImage.createEmpty();
 
-  // Use Buffer when there's only one representation for better perf.
-  // This avoids compressing to/from PNG where it's not necessary to
-  // ensure uniqueness of dataURLs (since there's only one).
-  if (value.representations.length === 1) {
-    const { buffer, size, scaleFactor } = value.representations[0];
+  for (const rep of value.representations) {
+    const { buffer, size, scaleFactor } = rep;
     const { width, height } = size;
     image.addRepresentation({ buffer, scaleFactor, width, height });
-  } else {
-    // Construct from dataURLs to ensure that they are not lost in creation.
-    for (const rep of value.representations) {
-      const { dataURL, size, scaleFactor } = rep;
-      const { width, height } = size;
-      image.addRepresentation({ dataURL, scaleFactor, width, height });
-    }
   }
 
   return image;

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -255,7 +255,7 @@ gfx::Size NativeImage::GetSize(const base::Optional<float> scale_factor) {
   float sf = scale_factor.value_or(1.0f);
   gfx::ImageSkiaRep image_rep = image_.AsImageSkia().GetRepresentation(sf);
 
-  return gfx::Size(image_rep.GetWidth(), image_rep.GetHeight());
+  return gfx::Size(image_rep.pixel_width(), image_rep.pixel_height());
 }
 
 std::vector<float> NativeImage::GetScaleFactors() {

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -260,7 +260,11 @@ gfx::Size NativeImage::GetSize(const base::Optional<float> scale_factor) {
 
 std::vector<float> NativeImage::GetScaleFactors() {
   gfx::ImageSkia image_skia = image_.AsImageSkia();
-  return image_skia.GetSupportedScales();
+  std::vector<float> scale_factors;
+  for (const auto& rep : image_skia.image_reps()) {
+    scale_factors.push_back(rep.scale());
+  }
+  return scale_factors;
 }
 
 float NativeImage::GetAspectRatio(const base::Optional<float> scale_factor) {

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -383,18 +383,20 @@ gin::Handle<NativeImage> NativeImage::Create(v8::Isolate* isolate,
 gin::Handle<NativeImage> NativeImage::CreateFromPNG(v8::Isolate* isolate,
                                                     const char* buffer,
                                                     size_t length) {
-  gfx::Image image = gfx::Image::CreateFrom1xPNGBytes(
-      reinterpret_cast<const unsigned char*>(buffer), length);
-  return Create(isolate, image);
+  gfx::ImageSkia image_skia;
+  electron::util::AddImageSkiaRepFromPNG(
+      &image_skia, reinterpret_cast<const unsigned char*>(buffer), length, 1.0);
+  return Create(isolate, gfx::Image(image_skia));
 }
 
 // static
 gin::Handle<NativeImage> NativeImage::CreateFromJPEG(v8::Isolate* isolate,
                                                      const char* buffer,
                                                      size_t length) {
-  gfx::Image image = gfx::ImageFrom1xJPEGEncodedData(
-      reinterpret_cast<const unsigned char*>(buffer), length);
-  return Create(isolate, image);
+  gfx::ImageSkia image_skia;
+  electron::util::AddImageSkiaRepFromJPEG(
+      &image_skia, reinterpret_cast<const unsigned char*>(buffer), length, 1.0);
+  return Create(isolate, gfx::Image(image_skia));
 }
 
 // static

--- a/spec-main/api-remote-spec.ts
+++ b/spec-main/api-remote-spec.ts
@@ -107,7 +107,7 @@ describe('typeUtils serialization/deserialization', () => {
     expect(nonEmpty.isEmpty()).to.be.false();
     expect(nonEmpty.getAspectRatio()).to.equal(1);
     expect(nonEmpty.toDataURL()).to.not.be.empty();
-    expect(nonEmpty.toDataURL({ scaleFactor: 1.0 })).to.equal(dataURL);
+    expect(nonEmpty.toBitmap({ scaleFactor: 1.0 })).to.deep.equal(image.toBitmap({ scaleFactor: 1.0 }));
     expect(nonEmpty.getSize()).to.deep.equal({ width: 2, height: 2 });
     expect(nonEmpty.getBitmap()).to.not.be.empty();
     expect(nonEmpty.toPNG()).to.not.be.empty();
@@ -132,14 +132,12 @@ describe('typeUtils serialization/deserialization', () => {
     expect(nonEmpty.getBitmap({ scaleFactor: 1.0 })).to.not.be.empty();
     expect(nonEmpty.getBitmap({ scaleFactor: 2.0 })).to.not.be.empty();
     expect(nonEmpty.toBitmap()).to.not.be.empty();
-    expect(nonEmpty.toBitmap({ scaleFactor: 1.0 })).to.not.be.empty();
-    expect(nonEmpty.toBitmap({ scaleFactor: 2.0 })).to.not.be.empty();
+    expect(nonEmpty.toBitmap({ scaleFactor: 1.0 })).to.deep.equal(image.toBitmap({ scaleFactor: 1.0 }));
+    expect(nonEmpty.toBitmap({ scaleFactor: 2.0 })).to.deep.equal(image.toBitmap({ scaleFactor: 2.0 }));
     expect(nonEmpty.toPNG()).to.not.be.empty();
     expect(nonEmpty.toPNG({ scaleFactor: 1.0 })).to.not.be.empty();
     expect(nonEmpty.toPNG({ scaleFactor: 2.0 })).to.not.be.empty();
     expect(nonEmpty.toDataURL()).to.not.be.empty();
-    expect(nonEmpty.toDataURL({ scaleFactor: 1.0 })).to.equal(dataURL1);
-    expect(nonEmpty.toDataURL({ scaleFactor: 2.0 })).to.equal(dataURL2);
   });
 
   it('serializes and deserializes an Array', () => {

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -174,7 +174,7 @@ describe('nativeImage module', () => {
       expect(imageB.getSize()).to.deep.equal({ width: 538, height: 190 });
 
       const imageC = nativeImage.createFromBuffer(imageA.toBitmap(), { ...imageA.getSize(), scaleFactor: 2.0 });
-      expect(imageC.getSize()).to.deep.equal({ width: 269, height: 95 });
+      expect(imageC.getSize()).to.deep.equal({ width: 538, height: 190 });
     });
 
     it('throws on invalid arguments', () => {
@@ -227,7 +227,7 @@ describe('nativeImage module', () => {
 
       const imageI = nativeImage.createFromBuffer(imageA.toBitmap(),
         { width: 538, height: 190, scaleFactor: 2.0 });
-      expect(imageI.getSize()).to.deep.equal({ width: 269, height: 95 });
+      expect(imageI.getSize()).to.deep.equal({ width: 538, height: 190 });
     });
 
     it('throws on invalid arguments', () => {
@@ -279,7 +279,7 @@ describe('nativeImage module', () => {
         scaleFactor: 2.0
       });
       expect(imageOne.getSize()).to.deep.equal(
-        { width: imageData.width / 2, height: imageData.height / 2 });
+        { width: imageData.width, height: imageData.height });
 
       const imageTwo = nativeImage.createFromDataURL(imageOne.toDataURL());
       expect(imageTwo.getSize()).to.deep.equal(
@@ -314,7 +314,7 @@ describe('nativeImage module', () => {
         scaleFactor: 2.0
       });
       expect(imageB.getSize()).to.deep.equal(
-        { width: imageData.width / 2, height: imageData.height / 2 });
+        { width: imageData.width, height: imageData.height });
 
       const imageC = nativeImage.createFromBuffer(imageB.toPNG());
       expect(imageC.getSize()).to.deep.equal(
@@ -335,7 +335,7 @@ describe('nativeImage module', () => {
       const imageFromBufferTwo = nativeImage.createFromBuffer(
         image.toPNG({ scaleFactor: 2.0 }), { scaleFactor: 2.0 });
       expect(imageFromBufferTwo.getSize()).to.deep.equal(
-        { width: imageData.width / 2, height: imageData.height / 2 });
+        { width: imageData.width, height: imageData.height });
     });
   });
 

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -533,11 +533,14 @@ describe('nativeImage module', () => {
         buffer: nativeImage.createFromPath(imageDataOne.path).toPNG()
       });
 
+      expect(image.getScaleFactors()).to.deep.equal([1]);
+
       const imageDataTwo = getImage({ width: 2, height: 2 });
       image.addRepresentation({
         scaleFactor: 2.0,
         buffer: nativeImage.createFromPath(imageDataTwo.path).toPNG()
       });
+      expect(image.getScaleFactors()).to.deep.equal([1, 2]);
 
       const imageDataThree = getImage({ width: 3, height: 3 });
       image.addRepresentation({
@@ -545,10 +548,15 @@ describe('nativeImage module', () => {
         buffer: nativeImage.createFromPath(imageDataThree.path).toPNG()
       });
 
+      expect(image.getScaleFactors()).to.deep.equal([1, 2, 3]);
+
       image.addRepresentation({
         scaleFactor: 4.0,
         buffer: 'invalid'
       });
+
+      // this one failed, so it shouldn't show up in the scale factors
+      expect(image.getScaleFactors()).to.deep.equal([1, 2, 3]);
 
       expect(image.isEmpty()).to.be.false();
       expect(image.getSize()).to.deep.equal({ width: 1, height: 1 });


### PR DESCRIPTION
#### Description of Change
Closes #25545.

#23693 added new code for handling serialization of multi-scale nativeImages. This optimizes that by using the bitmap encoding for all scales, instead of converting to PNG data URLs when there is more than one scale factor.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a performance regression when sending `nativeImage` structures over `remote`.