### PR TITLE
test: skip 'can successfully delete the Buffer global' when remote module is disabled

### DIFF
--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1913,7 +1913,7 @@ describe('BrowserWindow module', () => {
         const [, test] = await emittedOnce(ipcMain, 'answer');
         expect(test).to.eql('preload');
       });
-      it('can successfully delete the Buffer global', async () => {
+      ifit(features.isRemoteModuleEnabled())('can successfully delete the Buffer global', async () => {
         const preload = path.join(__dirname, 'fixtures', 'module', 'delete-buffer.js');
         const w = new BrowserWindow({
           show: false,

--- a/spec-main/fixtures/module/delete-buffer.js
+++ b/spec-main/fixtures/module/delete-buffer.js
@@ -6,8 +6,6 @@ delete window.Buffer;
 delete global.Buffer;
 
 // Test that remote.js doesn't use Buffer global
-if (remote) {
-  remote.require(path.join(__dirname, 'print_name.js')).echo(Buffer.from('bar'));
-}
+remote.require(path.join(__dirname, 'print_name.js')).echo(Buffer.from('bar'));
 
 window.test = Buffer.from('buffer');


### PR DESCRIPTION
#### Description of Change
This test was not testing anything when the `remote` module was disabled. Follow-up to #23557

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes