### PR TITLE
docs: added additional instructions to RUN the application

### DIFF
--- a/docs/tutorial/first-app.md
+++ b/docs/tutorial/first-app.md
@@ -188,6 +188,15 @@ Once you've created your initial `main.js`, `index.html`, and `package.json`
 files, you can try your app by running `npm start` from your application's
 directory.
 
+**Note**: If you are building this project without downloading the example
+repository, your `start` script in `package.json` should look like this
+
+```json
+  "scripts": {
+    "start": "electron ."
+  }
+```
+
 ## Trying this Example
 
 Clone and run the code in this tutorial by using the


### PR DESCRIPTION
In the existing documentation only "npm start" is given as the
instruction to run the project, however the definition of the 'start'
script is not mentioned anywhere.

When I tried running the sample project initially, i was under the
impression that 'start' would be the usual 'node index.js'. It was
only after i tried running the program, i realized there was something
wrong. And after referring the 'package.json' of the example I
understood how the command to run the program is actually
'electron .'

Hence I feel it is important for the users to know the exact contents
of the 'start' script and I have accordingly updated the documentation.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none