### PR TITLE
docs: add snapcraft + electron-packager example

### DIFF
--- a/docs/tutorial/snapcraft.md
+++ b/docs/tutorial/snapcraft.md
@@ -142,7 +142,7 @@ If you want to apply this example to an existing project:
 ```sh
 $ snapcraft
 
-<output snipped>                                                                                                                                                                                                         
+<output snipped>
 Snapped electron-packager-hello-world_0.1_amd64.snap
 ```
 

--- a/docs/tutorial/snapcraft.md
+++ b/docs/tutorial/snapcraft.md
@@ -132,7 +132,7 @@ parts:
     - libnspr4
 ```
 
-If you want to apply this example to an existing project, replace `source: https://github.com/electron/electron-quick-start.git` with `source: .`, and replace all instances of 'electron-quick-start` with your project's name.
+If you want to apply this example to an existing project, replace `source: https://github.com/electron/electron-quick-start.git` with `source: .`, and replace all instances of `electron-quick-start` with your project's name.
 
 ### Step 2: Build the snap
 

--- a/docs/tutorial/snapcraft.md
+++ b/docs/tutorial/snapcraft.md
@@ -132,7 +132,10 @@ parts:
     - libnspr4
 ```
 
-If you want to apply this example to an existing project, replace `source: https://github.com/electron/electron-quick-start.git` with `source: .`, and replace all instances of `electron-quick-start` with your project's name.
+If you want to apply this example to an existing project:
+
+- Replace `source: https://github.com/electron/electron-quick-start.git` with `source: .`.
+- Replace all instances of `electron-quick-start` with your project's name.
 
 ### Step 2: Build the snap
 

--- a/docs/tutorial/snapcraft.md
+++ b/docs/tutorial/snapcraft.md
@@ -92,7 +92,7 @@ snap(options)
 
 Create your project directory and add add the following to `snap/snapcraft.yaml`:
 
-```
+```yaml
 name: electron-packager-hello-world
 version: '0.1'
 summary: Hello World Electron app
@@ -136,7 +136,7 @@ If you want to apply this example to an existing project, replace `source: https
 
 ### Step 2: Build the snap
 
-```
+```sh
 $ snapcraft
 
 <output snipped>                                                                                                                                                                                                         
@@ -145,13 +145,13 @@ Snapped electron-packager-hello-world_0.1_amd64.snap
 
 ### Step 3: Install the snap
 
-```
+```sh
 sudo snap install electron-packager-hello-world_0.1_amd64.snap --dangerous
 ```
 
 ### Step 4: Run the snap
 
-```
+```sh
 electron-packager-hello-world
 ```
 

--- a/docs/tutorial/snapcraft.md
+++ b/docs/tutorial/snapcraft.md
@@ -86,6 +86,75 @@ snap(options)
   .then(snapPath => console.log(`Created snap at ${snapPath}!`))
 ```
 
+## Using `snapcraft` with `electron-packager`
+
+### Step 1: Create Sample Snapcraft Project
+
+Create your project directory and add add the following to `snap/snapcraft.yaml`:
+
+```
+name: electron-packager-hello-world
+version: '0.1'
+summary: Hello World Electron app
+description: |
+  Simple Hello World Electron app as an example
+base: core18
+confinement: strict
+grade: stable
+
+apps:
+  electron-packager-hello-world:
+    command: electron-quick-start/electron-quick-start --no-sandbox
+    extensions: [gnome-3-34]
+    plugs:
+    - browser-support
+    - network
+    - network-bind
+    environment:
+      # Correct the TMPDIR path for Chromium Framework/Electron to ensure
+      # libappindicator has readable resources.
+      TMPDIR: $XDG_RUNTIME_DIR
+
+parts:
+  electron-quick-start:
+    plugin: nil
+    source: https://github.com/electron/electron-quick-start.git
+    override-build: |
+        npm install electron electron-packager
+        npx electron-packager . --overwrite --platform=linux --output=release-build --prune=true
+        cp -rv ./electron-quick-start-linux-* $SNAPCRAFT_PART_INSTALL/electron-quick-start
+    build-snaps:
+    - node/14/stable
+    build-packages:
+    - unzip
+    stage-packages:
+    - libnss3
+    - libnspr4
+```
+
+If you want to apply this example to an existing project, replace `source: https://github.com/electron/electron-quick-start.git` with `source: .`, and replace all instances of 'electron-quick-start` with your project's name.
+
+### Step 2: Build the snap
+
+```
+$ snapcraft
+
+<output snipped>                                                                                                                                                                                                         
+Snapped electron-packager-hello-world_0.1_amd64.snap
+```
+
+### Step 3: Install the snap
+
+```
+sudo snap install electron-packager-hello-world_0.1_amd64.snap --dangerous
+```
+
+### Step 4: Run the snap
+
+```
+electron-packager-hello-world
+```
+
 ## Using an Existing Debian Package
 
 Snapcraft is capable of taking an existing `.deb` file and turning it into


### PR DESCRIPTION
Add example to snap electron app (electron-quick-start)
using snapcraft & electron-packager.

Include notes on how to apply this to an existing project.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none