### PR TITLE
build: use https for sysroot download

### DIFF
--- a/patches/chromium/sysroot.patch
+++ b/patches/chromium/sysroot.patch
@@ -7,7 +7,7 @@ Make chrome's install-sysroot scripts point to our custom sysroot builds,
 which include extra deps that Electron needs (e.g. libnotify)
 
 diff --git a/build/linux/sysroot_scripts/install-sysroot.py b/build/linux/sysroot_scripts/install-sysroot.py
-index f8b7906cc557fb196e19dd6684a29c174b56c789..9fe9fe15f6bbaa38bb74930c4d069000f680987b 100755
+index f8b7906cc557fb196e19dd6684a29c174b56c789..351b3a658b6b6d1dbe2370e825058b8b6dcbf9df 100755
 --- a/build/linux/sysroot_scripts/install-sysroot.py
 +++ b/build/linux/sysroot_scripts/install-sysroot.py
 @@ -37,9 +37,11 @@ except ImportError:
@@ -19,7 +19,7 @@ index f8b7906cc557fb196e19dd6684a29c174b56c789..9fe9fe15f6bbaa38bb74930c4d069000
  
 -URL_PREFIX = 'https://commondatastorage.googleapis.com'
 -URL_PATH = 'chrome-linux-sysroot/toolchain'
-+URL_PREFIX = 'http://s3.amazonaws.com'
++URL_PREFIX = 'https://s3.amazonaws.com'
 +URL_PATH = 'electronjs-sysroots/toolchain'
  
  VALID_ARCHS = ('arm', 'arm64', 'i386', 'amd64', 'mips', 'mips64el')


### PR DESCRIPTION
This isn't actually that bad as the `install-sysroot` script does SHA validation of the sysroot tarball.  But hey, we should use https anyway lol

Notes: no-notes
