### PR TITLE
fix: nativeImage.crop().toBitmap() returning garbage

### DIFF
--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -468,6 +468,12 @@ describe('nativeImage module', () => {
       expect(cropB.getSize()).to.deep.equal({ width: 25, height: 64 });
       expect(cropA.toPNG().equals(cropB.toPNG())).to.be.false();
     });
+
+    it('toBitmap() returns a buffer of the right size', () => {
+      const image = nativeImage.createFromPath(path.join(__dirname, 'fixtures', 'assets', 'logo.png'));
+      const crop = image.crop({ width: 25, height: 64, x: 0, y: 0 });
+      expect(crop.toBitmap().length).to.equal(25 * 64 * 4);
+    });
   });
 
   describe('getAspectRatio()', () => {


### PR DESCRIPTION
#### Description of Change
Fixes #9351. That PR hypothesized that createFromBuffer was parsing the bitmap as a PNG, which is not the case. What was actually happening was that `.crop()` was returning an image which shared the underlying data, but updated the bounds. This meant that when `.toBitmap()` was called, it was retrieving a reference to the pre-cropped pixel data, which included pixels off to the right of the image (because that is how the pixels are stored in memory).

```
memory:
0x0000: rgbargba rgbargba rgbargba rgbargba
0x0020: rgbargba rgbargba rgbargba rgbargba
0x0040: rgbargba rgbargba rgbargba rgbargba
0x0060: rgbargba rgbargba rgbargba rgbargba
[...]
```

The cropped image's pixel data, as it is shared, points to the same start position (0x0000 in the above example), but stores the information that only the first N pixels of each row should be read. For example, a crop starting at 0,0 of size 4x3 of the above image would look like:

```
0x0000:[rgbargba rgbargba]rgbargba rgbargba
0x0020:[rgbargba rgbargba]rgbargba rgbargba
0x0040:[rgbargba rgbargba]rgbargba rgbargba
0x0060: rgbargba rgbargba rgbargba rgbargba
[...]
```


`bitmap.pixelRef()` returns the pointer to the start, and `computeByteSize()` returns the total amount of bytes needed to encompass _all_ the data (including the bits that were cropped out to the left and right of the cropped image), but it does not specify which subset of each row to copy, which is why the returned buffer length was longer than expected.

The new code uses Skia's own functions for copying pixel data around instead of operating on raw memory, resolving the issue.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed NativeImage.crop().toBitmap() returning incorrect data.
