### PR TITLE
build: python3 compatibility for run-clang-format.py

### DIFF
--- a/script/run-clang-format.py
+++ b/script/run-clang-format.py
@@ -119,13 +119,14 @@ def run_clang_format_diff(args, file_name):
         raise DiffError(str(exc))
     proc_stdout = proc.stdout
     proc_stderr = proc.stderr
-    if sys.version_info[0] < 3:
-        # make the pipes compatible with Python 3,
-        # reading lines should output unicode
-        encoding = 'utf-8'
-        proc_stdout = codecs.getreader(encoding)(proc_stdout)
-        proc_stderr = codecs.getreader(encoding)(proc_stderr)
-    # hopefully the stderr pipe won't get full and block the process
+    if sys.version_info[0] == 3:
+        proc_stdout = proc_stdout.detach()
+        proc_stderr = proc_stderr.detach()
+    # make the pipes compatible with Python 3,
+    # reading lines should output unicode
+    encoding = 'utf-8'
+    proc_stdout = codecs.getreader(encoding)(proc_stdout)
+    proc_stderr = codecs.getreader(encoding)(proc_stderr)
     outs = list(proc_stdout.readlines())
     errs = list(proc_stderr.readlines())
     proc.wait()
@@ -330,8 +331,8 @@ def main():
                 if not args.quiet:
                     print_diff(outs, use_color=colored_stdout)
                     for line in outs:
-                        patch_file.write(line)
-                    patch_file.write('\n')
+                        patch_file.write(line.encode('utf-8'))
+                    patch_file.write('\n'.encode('utf-8'))
                 if retcode == ExitStatus.SUCCESS:
                     retcode = ExitStatus.DIFF
 


### PR DESCRIPTION
#### Description of Change

The linting script wasn't working with Python3 due to some Unicode compatibility issues in `run-clang-format.py`. This fixes those issues. Change tested under Python 2.7 and 3.8.

cc @codebytere @zcbenz 
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
