### PR TITLE
fix: output Unix-style paths for git diffs on Win

### DIFF
--- a/script/run-clang-format.py
+++ b/script/run-clang-format.py
@@ -15,6 +15,7 @@ import fnmatch
 import io
 import multiprocessing
 import os
+import posixpath
 import signal
 import subprocess
 import sys
@@ -134,6 +135,8 @@ def run_clang_format_diff(args, file_name):
             proc.returncode, file_name), errs)
     if args.fix:
         return None, errs
+    if sys.platform == 'win32':
+        file_name = file_name.replace(os.sep, posixpath.sep)
     return make_diff(file_name, original, outs), errs
 
 


### PR DESCRIPTION
#### Description of Change
The output of the linting script recommends using `git apply` to apply changes, but on Windows this fails because the paths in the patch aren't compatible with `git apply`. This PR ensures the paths look as expected when running on Windows.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
