### PR TITLE
build: python3 compat and fix line endings on Win

### DIFF
--- a/script/check-trailing-whitespace.py
+++ b/script/check-trailing-whitespace.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import argparse
+import io
 import os
 import sys
 
@@ -38,12 +39,11 @@ def main():
 
 def hasTrailingWhiteSpace(filepath, fix):
   try:
-    f = open(filepath, 'r')
-    lines = f.read().splitlines()
+    with io.open(filepath, 'r', encoding='utf-8') as f:
+      lines = f.read().splitlines()
   except KeyboardInterrupt:
     print('Keyboard interruption while parsing. Please try again.')
-  finally:
-    f.close()
+    return
 
   fixed_lines = []
   for num, line in enumerate(lines):
@@ -53,7 +53,7 @@ def hasTrailingWhiteSpace(filepath, fix):
           num + 1, filepath))
       return True
   if fix:
-    with open(filepath, 'w') as f:
+    with io.open(filepath, 'w', newline='\n', encoding='utf-8') as f:
       print(fixed_lines)
       f.writelines(fixed_lines)
 


### PR DESCRIPTION
#### Description of Change
The `check-trailing-whitespace.py` script wasn't Python3 compatible and was also swapping the line endings for all files when run on Windows.

This includes a typo fix from #25766, so best to merge that PR first for no conflict here.

cc @zcbenz 
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
