### PR TITLE
docs: trim trailing whitespace

### DIFF
--- a/docs/tutorial/boilerplates-and-clis.md
+++ b/docs/tutorial/boilerplates-and-clis.md
@@ -32,7 +32,7 @@ into a cohesive package so that anyone can jump right in to Electron
 development.
 
 Forge comes with [a ready-to-use template](https://electronforge.io/templates) using Webpack as a bundler. It includes an example typescript configuration and provides two configuration files to enable easy customization. It uses the same core modules used by the
-greater Electron community (like [`electron-packager`](https://github.com/electron/electron-packager)) – 
+greater Electron community (like [`electron-packager`](https://github.com/electron/electron-packager)) –
 changes made by Electron maintainers (like Slack) benefit Forge's users, too.
 
 You can find more information and documentation on [electronforge.io](https://electronforge.io/).


### PR DESCRIPTION
#### Description of Change
This trailing whitespace was going undetected by the `check-trailing-whitespace.py` script, but the changes in #25767 (to read the files as UTF8) caused it to be detected. I believe that's because the dash is actually an en dash (U+2013), so the previous processing wasn't recognizing the end of the line.

Open question on whether the docs should have Unicode in them, or if that en dash should be converted to a hyphen, it doesn't appear the coding style doc makes any statement on this. This PR leaves it as is.

cc @zcbenz @nornagon 
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
