### PR TITLE
chore: cleanup some typos in comments

### DIFF
--- a/lib/browser/guest-view-manager.ts
+++ b/lib/browser/guest-view-manager.ts
@@ -247,7 +247,7 @@ const watchEmbedder = function (embedder: Electron.WebContents) {
   }
   watchedEmbedders.add(embedder);
 
-  // Forward embedder window visiblity change events to guest
+  // Forward embedder window visibility change events to guest
   const onVisibilityChange = function (visibilityState: VisibilityState) {
     for (const guestInstanceId of Object.keys(guestInstances)) {
       const guestInstance = guestInstances[guestInstanceId];

--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -121,7 +121,7 @@ if (packageJson.desktopName != null) {
   app.setDesktopName(`${app.name}.desktop`);
 }
 
-// Set v8 flags, delibrately lazy load so that apps that do not use this
+// Set v8 flags, deliberately lazy load so that apps that do not use this
 // feature do not pay the price
 if (packageJson.v8Flags != null) {
   require('v8').setFlagsFromString(packageJson.v8Flags);

--- a/lib/browser/navigation-controller.ts
+++ b/lib/browser/navigation-controller.ts
@@ -20,10 +20,10 @@ ipcMainInternal.on('ELECTRON_NAVIGATION_CONTROLLER_LENGTH', function (event) {
 });
 
 // JavaScript implementation of Chromium's NavigationController.
-// Instead of relying on Chromium for history control, we compeletely do history
+// Instead of relying on Chromium for history control, we completely do history
 // control on user land, and only rely on WebContents.loadURL for navigation.
 // This helps us avoid Chromium's various optimizations so we can ensure renderer
-// process is restarted everytime.
+// process is restarted every time.
 export class NavigationController extends EventEmitter {
   currentIndex: number = -1;
   inPageIndex: number = -1;

--- a/lib/renderer/api/remote.ts
+++ b/lib/renderer/api/remote.ts
@@ -134,7 +134,7 @@ function wrapArgs (args: any[], visited = new Set()): any {
 
 // Populate object's members from descriptors.
 // The |ref| will be kept referenced by |members|.
-// This matches |getObjectMemebers| in rpc-server.
+// This matches |getObjectMembers| in rpc-server.
 function setObjectMembers (ref: any, object: any, metaId: number, members: ObjectMember[]) {
   if (!Array.isArray(members)) return;
 

--- a/lib/renderer/web-view/web-view-attributes.ts
+++ b/lib/renderer/web-view/web-view-attributes.ts
@@ -122,7 +122,7 @@ class SrcAttribute extends WebViewAttribute {
     super.setValueIgnoreMutation(value);
 
     // takeRecords() is needed to clear queued up src mutations. Without it, it
-    // is possible for this change to get picked up asyncronously by src's
+    // is possible for this change to get picked up asynchronously by src's
     // mutation observer |observer|, and then get handled even though we do not
     // want to handle this mutation.
     this.observer.takeRecords();

--- a/lib/renderer/window-setup.ts
+++ b/lib/renderer/window-setup.ts
@@ -79,7 +79,7 @@ class LocationProxy {
         const guestURL = this.getGuestURL();
         if (guestURL) {
           // TypeScript doesn't want us to assign to read-only variables.
-          // It's right, that's bad, but we're doing it anway.
+          // It's right, that's bad, but we're doing it anyway.
           (guestURL as any)[propertyKey] = newVal;
 
           return this._invokeWebContentsMethod('loadURL', guestURL.toString());
@@ -127,7 +127,7 @@ class LocationProxy {
   private getGuestURL (): URL | null {
     const maybeURL = this._invokeWebContentsMethodSync('getURL') as string;
 
-    // When there's no previous frame the url will be blank, so accountfor that here
+    // When there's no previous frame the url will be blank, so account for that here
     // to prevent url parsing errors on an empty string.
     const urlString = maybeURL !== '' ? maybeURL : 'about:blank';
     try {

--- a/shell/app/electron_main_delegate.cc
+++ b/shell/app/electron_main_delegate.cc
@@ -222,8 +222,8 @@ bool ElectronMainDelegate::BasicStartupComplete(int* exit_code) {
   // Logging with pid and timestamp.
   logging::SetLogItems(true, false, true, false);
 
-  // Enable convient stack printing. This is enabled by default in non-official
-  // builds.
+  // Enable convenient stack printing. This is enabled by default in
+  // non-official builds.
   if (env->HasVar("ELECTRON_ENABLE_STACK_DUMPING"))
     base::debug::EnableInProcessStackDumping();
 

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -248,7 +248,7 @@ void BrowserWindow::OnCloseButtonClicked(bool* prevent_default) {
 
   // Assume the window is not responding if it doesn't cancel the close and is
   // not closed in 5s, in this way we can quickly show the unresponsive
-  // dialog when the window is busy executing some script withouth waiting for
+  // dialog when the window is busy executing some script without waiting for
   // the unresponsive timeout.
   if (window_unresponsive_closure_.IsCancelled())
     ScheduleUnresponsiveEvent(5000);

--- a/shell/browser/api/electron_api_menu.h
+++ b/shell/browser/api/electron_api_menu.h
@@ -126,7 +126,7 @@ struct Converter<electron::ElectronMenuModel*> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      electron::ElectronMenuModel** out) {
-    // null would be tranfered to NULL.
+    // null would be transferred to NULL.
     if (val->IsNull()) {
       *out = nullptr;
       return true;

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1100,7 +1100,7 @@ void WebContents::PluginCrashed(const base::FilePath& plugin_path,
   auto* plugin_service = content::PluginService::GetInstance();
   plugin_service->GetPluginInfoByPath(plugin_path, &info);
   Emit("plugin-crashed", info.name, info.version);
-#endif  // BUILDFLAG(ENABLE_PLUIGNS)
+#endif  // BUILDFLAG(ENABLE_PLUGINS)
 }
 
 void WebContents::MediaStartedPlaying(const MediaPlayerInfo& video_type,

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -195,7 +195,7 @@ class Browser : public WindowListObserver {
   void UserActivityWasContinued(const std::string& type,
                                 base::DictionaryValue user_info);
 
-  // Gives an oportunity to update the Handoff payload.
+  // Gives an opportunity to update the Handoff payload.
   bool UpdateUserActivityState(const std::string& type,
                                base::DictionaryValue user_info);
 

--- a/shell/browser/common_web_contents_delegate.h
+++ b/shell/browser/common_web_contents_delegate.h
@@ -39,7 +39,7 @@ class CommonWebContentsDelegate : public content::WebContentsDelegate,
   CommonWebContentsDelegate();
   ~CommonWebContentsDelegate() override;
 
-  // Creates a InspectableWebContents object and takes onwership of
+  // Creates a InspectableWebContents object and takes ownership of
   // |web_contents|.
   void InitWithWebContents(content::WebContents* web_contents,
                            ElectronBrowserContext* browser_context,

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -403,7 +403,7 @@ bool ElectronBrowserClient::ShouldForceNewSiteInstance(
     const GURL& url,
     bool has_response_started) const {
   if (url.SchemeIs(url::kJavaScriptScheme))
-    // "javacript:" scheme should always use same SiteInstance
+    // "javascript:" scheme should always use same SiteInstance
     return false;
   if (url.SchemeIs(extensions::kExtensionScheme))
     return false;

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -357,7 +357,7 @@ void ElectronBrowserMainParts::ToolkitInitialized() {
   // issue to keep updated:
   // https://bugs.chromium.org/p/chromium/issues/detail?id=998903
   UpdateDarkThemeSetting();
-  // Update the naitve theme when GTK theme changes. The GetNativeTheme
+  // Update the native theme when GTK theme changes. The GetNativeTheme
   // here returns a NativeThemeGtk, which monitors GTK settings.
   dark_theme_observer_.reset(new DarkThemeObserver);
   linux_ui->GetNativeTheme(nullptr)->AddObserver(dark_theme_observer_.get());

--- a/shell/browser/media/media_capture_devices_dispatcher.h
+++ b/shell/browser/media/media_capture_devices_dispatcher.h
@@ -47,7 +47,7 @@ class MediaCaptureDevicesDispatcher : public content::MediaObserver {
 
   // Unittests that do not require actual device enumeration should call this
   // API on the singleton. It is safe to call this multiple times on the
-  // signleton.
+  // singleton.
   void DisableDeviceEnumerationForTesting();
 
   // Overridden from content::MediaObserver:

--- a/shell/browser/microtasks_runner.cc
+++ b/shell/browser/microtasks_runner.cc
@@ -21,7 +21,7 @@ void MicrotasksRunner::DidProcessTask(const base::PendingTask& pending_task) {
   v8::Isolate::Scope scope(isolate_);
   // In the browser process we follow Node.js microtask policy of kExplicit
   // and let the MicrotaskRunner which is a task observer for chromium UI thread
-  // scheduler run the micotask checkpoint. This worked fine because Node.js
+  // scheduler run the microtask checkpoint. This worked fine because Node.js
   // also runs microtasks through its task queue, but after
   // https://github.com/electron/electron/issues/20013 Node.js now performs its
   // own microtask checkpoint and it may happen is some situations that there is

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -156,7 +156,7 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
   if (enable_larger_than_screen())
     // We need to set a default maximum window size here otherwise Windows
     // will not allow us to resize the window larger than scree.
-    // Setting directly to INT_MAX somehow doesn't work, so we just devide
+    // Setting directly to INT_MAX somehow doesn't work, so we just divide
     // by 10, which should still be large enough.
     SetContentSizeConstraints(extensions::SizeConstraints(
         gfx::Size(), gfx::Size(INT_MAX / 10, INT_MAX / 10)));

--- a/shell/browser/net/electron_url_loader_factory.cc
+++ b/shell/browser/net/electron_url_loader_factory.cc
@@ -279,10 +279,10 @@ void ElectronURLLoaderFactory::StartLoading(
 
     client_remote->OnReceiveRedirect(redirect_info, std::move(head));
 
-    // Unound client, so it an be passed to sub-methods
+    // Unbound client, so it an be passed to sub-methods
     client = client_remote.Unbind();
     // When the redirection comes from an intercepted scheme (which has
-    // |proxy_factory| passed), we askes the proxy factory to create a loader
+    // |proxy_factory| passed), we ask the proxy factory to create a loader
     // for new URL, otherwise we call |StartLoadingHttp|, which creates
     // loader with default factory.
     //

--- a/shell/browser/net/node_stream_loader.cc
+++ b/shell/browser/net/node_stream_loader.cc
@@ -128,7 +128,7 @@ void NodeStreamLoader::ReadMore() {
   // Hold the buffer until the write is done.
   buffer_.Reset(isolate_, buffer);
 
-  // Write buffer to mojo pipe asyncronously.
+  // Write buffer to mojo pipe asynchronously.
   is_reading_ = false;
   is_writing_ = true;
   producer_->Write(std::make_unique<mojo::StringDataSource>(

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -227,9 +227,9 @@ class ProxyingURLLoaderFactory
 
   // This is passed from api::Protocol.
   //
-  // The Protocol instance lives through the lifetime of BrowserContenxt,
-  // which is guarenteed to cover the lifetime of URLLoaderFactory, so the
-  // reference is guarenteed to be valid.
+  // The Protocol instance lives through the lifetime of BrowserContext,
+  // which is guaranteed to cover the lifetime of URLLoaderFactory, so the
+  // reference is guaranteed to be valid.
   //
   // In this way we can avoid using code from api namespace in this file.
   const HandlersMap& intercepted_handlers_;

--- a/shell/browser/net/proxying_websocket.cc
+++ b/shell/browser/net/proxying_websocket.cc
@@ -438,7 +438,7 @@ void ProxyingWebSocket::OnError(int error_code) {
 void ProxyingWebSocket::OnMojoConnectionErrorWithCustomReason(
     uint32_t custom_reason,
     const std::string& description) {
-  // Here we want to nofiy the custom reason to the client, which is why
+  // Here we want to notify the custom reason to the client, which is why
   // we reset |forwarding_handshake_client_| manually.
   forwarding_handshake_client_.ResetWithReason(custom_reason, description);
   OnError(net::ERR_FAILED);

--- a/shell/browser/net/proxying_websocket.h
+++ b/shell/browser/net/proxying_websocket.h
@@ -39,7 +39,7 @@ class ProxyingWebSocket : public network::mojom::WebSocketHandshakeClient,
 
   // AuthRequiredResponse indicates how an OnAuthRequired call is handled.
   enum class AuthRequiredResponse {
-    // No credenitals were provided.
+    // No credentials were provided.
     AUTH_REQUIRED_RESPONSE_NO_ACTION,
     // AuthCredentials is filled in with a username and password, which should
     // be used in a response to the provided auth challenge.

--- a/shell/browser/ui/devtools_manager_delegate.cc
+++ b/shell/browser/ui/devtools_manager_delegate.cc
@@ -115,7 +115,7 @@ void DevToolsManagerDelegate::HandleCommand(
     // protocol UberDispatcher and generating proper protocol handlers.
     // Since we only have one method and it is supposed to close Electron,
     // we don't need to add this complexity. Should we decide to support
-    // metohds like Browser.setWindowBounds, we'll need to do it though.
+    // methods like Browser.setWindowBounds, we'll need to do it though.
     base::PostTask(FROM_HERE, {content::BrowserThread::UI},
                    base::BindOnce([]() { Browser::Get()->Quit(); }));
     return;

--- a/shell/browser/ui/message_box_win.cc
+++ b/shell/browser/ui/message_box_win.cc
@@ -136,7 +136,7 @@ DialogResult ShowTaskDialogUTF16(NativeWindow* parent,
     }
   }
 
-  // If "detail" is empty then don't make message hilighted.
+  // If "detail" is empty then don't make message highlighted.
   if (detail.empty()) {
     config.pszContent = message.c_str();
   } else {

--- a/shell/browser/ui/views/menu_delegate.cc
+++ b/shell/browser/ui/views/menu_delegate.cc
@@ -129,7 +129,7 @@ views::MenuItemView* MenuDelegate::GetSiblingMenu(
     bool switch_in_progress = !!button_to_open_;
     // Always update target to open.
     button_to_open_ = button;
-    // Switching menu asyncnously to avoid crash.
+    // Switching menu asynchronously to avoid crash.
     if (!switch_in_progress) {
       base::PostTask(FROM_HERE, {content::BrowserThread::UI},
                      base::BindOnce(&views::MenuRunner::Cancel,

--- a/shell/browser/ui/win/taskbar_host.cc
+++ b/shell/browser/ui/win/taskbar_host.cc
@@ -67,7 +67,7 @@ bool TaskbarHost::SetThumbarButtons(HWND window,
   callback_map_.clear();
 
   // The number of buttons in thumbar can not be changed once it is created,
-  // so we have to claim kMaxButtonsCount buttons initialy in case users add
+  // so we have to claim kMaxButtonsCount buttons initially in case users add
   // more buttons later.
   base::win::ScopedHICON icons[kMaxButtonsCount] = {};
   THUMBBUTTON thumb_buttons[kMaxButtonsCount] = {};

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -145,7 +145,7 @@ WebContentsPreferences::WebContentsPreferences(
   SetDefaultBoolIfUndefined(options::kEnableWebSQL, true);
   bool webSecurity = true;
   SetDefaultBoolIfUndefined(options::kWebSecurity, webSecurity);
-  // If webSecurity was explicity set to false, let's inherit that into
+  // If webSecurity was explicitly set to false, let's inherit that into
   // insecureContent
   if (web_preferences.Get(options::kWebSecurity, &webSecurity) &&
       !webSecurity) {

--- a/shell/browser/web_contents_zoom_controller.cc
+++ b/shell/browser/web_contents_zoom_controller.cc
@@ -263,7 +263,7 @@ void WebContentsZoomController::SetZoomFactorOnNavigationIfNeeded(
 
   // When kZoomFactor is available, it takes precedence over
   // pref store values but if the host has zoom factor set explicitly
-  // then it takes precendence.
+  // then it takes precedence.
   // pref store < kZoomFactor < setZoomLevel
   std::string host = net::GetHostOrSpecFromURL(url);
   std::string scheme = url.scheme();

--- a/shell/common/gin_converters/native_window_converter.h
+++ b/shell/common/gin_converters/native_window_converter.h
@@ -15,7 +15,7 @@ struct Converter<electron::NativeWindow*> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      electron::NativeWindow** out) {
-    // null would be tranfered to NULL.
+    // null would be transferred to NULL.
     if (val->IsNull()) {
       *out = NULL;
       return true;

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -273,8 +273,8 @@ v8::Local<v8::Value> Converter<network::ResourceRequestBody>::ToV8(
       case network::mojom::DataElementType::kDataPipe: {
         upload_data.Set("type", "blob");
         // TODO(zcbenz): After the NetworkService refactor, the old blobUUID API
-        // becomes unecessarily complex, we should deprecate the getBlobData API
-        // and return the DataPipeHolder wrapper directly.
+        // becomes unnecessarily complex, we should deprecate the getBlobData
+        // API and return the DataPipeHolder wrapper directly.
         auto holder = electron::api::DataPipeHolder::Create(isolate, element);
         upload_data.Set("blobUUID", holder->id());
         // The lifetime of data pipe is bound to the uploadData object.

--- a/shell/renderer/renderer_client_base.h
+++ b/shell/renderer/renderer_client_base.h
@@ -133,7 +133,7 @@ class RendererClientBase : public content::ContentRendererClient
 #endif
   bool isolated_world_;
   std::string renderer_client_id_;
-  // An increasing ID used for indentifying an V8 context in this process.
+  // An increasing ID used for identifying an V8 context in this process.
   int64_t next_context_id_ = 0;
 
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)


### PR DESCRIPTION
#### Description of Change
Cleaning up typos (or "creative spellings" as I like to call them) in comments throughout the project. Started from catching a couple while reading code and expanded it to looking for more since `cspell` makes it easy.

Only changes are to comments, so no risk of anything breaking.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
