### PR TITLE
chore: use no-op ShouldAbortOnUncaughtException cb

### DIFF
--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -429,6 +429,12 @@ node::Environment* NodeBindings::CreateEnvironment(
   // crash message and location to CrashReports.
   is.fatal_error_callback = V8FatalErrorCallback;
 
+  // We don't want to abort either in the renderer or browser processes.
+  // We already listen for uncaught exceptions and handle them there.
+  is.should_abort_on_uncaught_exception_callback = [](v8::Isolate*) {
+    return false;
+  };
+
   if (browser_env_ == BrowserEnvironment::BROWSER) {
     // Node.js requires that microtask checkpoints be explicitly invoked.
     is.policy = v8::MicrotasksPolicy::kExplicit;


### PR DESCRIPTION
#### Description of Change

Previously we were letting Node.js use its default callback for deciding whether uncaught exceptions should abort the process. However, in the renderer process we definitely do not want to crash the process. We in fact already intercept uncaught exceptions in both the [renderer](https://github.com/electron/electron/blob/8baa9deccdbd2473c99811eaf2291c3d00fce0ff/lib/renderer/init.ts#L153) and [browser](https://github.com/electron/electron/blob/77038b7bda7c6633523541fc452bba1bc487e277/lib/browser/init.ts#L45) process to prevent quitting, and so should always return false in this isolate callback.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
