### PR TITLE
fix: sync devtools frontend mime types with upstream

### DIFF
--- a/shell/browser/ui/devtools_ui.cc
+++ b/shell/browser/ui/devtools_ui.cc
@@ -22,7 +22,12 @@ namespace electron {
 namespace {
 
 std::string PathWithoutParams(const std::string& path) {
-  return GURL(std::string("devtools://devtools/") + path).path().substr(1);
+  return GURL(base::StrCat({content::kChromeDevToolsScheme,
+                            url::kStandardSchemeSeparator,
+                            chrome::kChromeUIDevToolsHost}))
+      .Resolve(path)
+      .path()
+      .substr(1);
 }
 
 std::string GetMimeTypeForPath(const std::string& path) {
@@ -33,11 +38,19 @@ std::string GetMimeTypeForPath(const std::string& path) {
                             base::CompareCase::INSENSITIVE_ASCII)) {
     return "text/css";
   } else if (base::EndsWith(filename, ".js",
+                            base::CompareCase::INSENSITIVE_ASCII) ||
+             base::EndsWith(filename, ".mjs",
                             base::CompareCase::INSENSITIVE_ASCII)) {
     return "application/javascript";
   } else if (base::EndsWith(filename, ".png",
                             base::CompareCase::INSENSITIVE_ASCII)) {
     return "image/png";
+  } else if (base::EndsWith(filename, ".map",
+                            base::CompareCase::INSENSITIVE_ASCII)) {
+    return "application/json";
+  } else if (base::EndsWith(filename, ".ts",
+                            base::CompareCase::INSENSITIVE_ASCII)) {
+    return "application/x-typescript";
   } else if (base::EndsWith(filename, ".gif",
                             base::CompareCase::INSENSITIVE_ASCII)) {
     return "image/gif";

--- a/shell/browser/ui/devtools_ui.cc
+++ b/shell/browser/ui/devtools_ui.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "base/memory/ref_counted_memory.h"
+#include "base/strings/strcat.h"
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
 #include "chrome/common/webui_url_constants.h"


### PR DESCRIPTION
#### Description of Change
Fixes #25778.

This updates the function to match
https://source.chromium.org/chromium/chromium/src/+/master:chrome/browser/ui/webui/devtools_ui_data_source.cc;l=52;drc=2de0b2cfe26853bda417346c8a6e6538a06780d8.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed the pretty-print JavaScript feature in DevTools not functioning correctly.
