### PR TITLE
docs: Type names changed from Wrapper to Primitive #14023

### DIFF
--- a/docs/api/accelerator.md
+++ b/docs/api/accelerator.md
@@ -2,7 +2,7 @@
 
 > Define keyboard shortcuts.
 
-Accelerators are Strings that can contain multiple modifiers and a single key code,
+Accelerators are strings that can contain multiple modifiers and a single key code,
 combined by the `+` character, and are used to define keyboard shortcuts
 throughout your application.
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -101,7 +101,7 @@ to a shutdown/restart of the system or a user logout.
 Returns:
 
 * `event` Event
-* `path` String
+* `path` string
 
 Emitted when the user wants to open a file with the application. The `open-file`
 event is usually emitted when the application is already open and the OS wants
@@ -120,7 +120,7 @@ filepath.
 Returns:
 
 * `event` Event
-* `url` String
+* `url` string
 
 Emitted when the user wants to open a URL with the application. Your application's
 `Info.plist` file must define the URL scheme within the `CFBundleURLTypes` key, and
@@ -133,7 +133,7 @@ You should call `event.preventDefault()` if you want to handle this event.
 Returns:
 
 * `event` Event
-* `hasVisibleWindows` Boolean
+* `hasVisibleWindows` boolean
 
 Emitted when the application is activated. Various actions can trigger
 this event, such as launching the application for the first time, attempting
@@ -155,7 +155,7 @@ when Dock icon is clicked or application is re-launched.
 Returns:
 
 * `event` Event
-* `type` String - A string identifying the activity. Maps to
+* `type` string - A string identifying the activity. Maps to
   [`NSUserActivity.activityType`][activity-type].
 * `userInfo` unknown - Contains app-specific state stored by the activity on
   another device.
@@ -174,7 +174,7 @@ Supported activity types are specified in the app's `Info.plist` under the
 Returns:
 
 * `event` Event
-* `type` String - A string identifying the activity. Maps to
+* `type` string - A string identifying the activity. Maps to
   [`NSUserActivity.activityType`][activity-type].
 
 Emitted during [Handoff][handoff] before an activity from a different device wants
@@ -186,9 +186,9 @@ this event.
 Returns:
 
 * `event` Event
-* `type` String - A string identifying the activity. Maps to
+* `type` string - A string identifying the activity. Maps to
   [`NSUserActivity.activityType`][activity-type].
-* `error` String - A string with the error's localized description.
+* `error` string - A string with the error's localized description.
 
 Emitted during [Handoff][handoff] when an activity from a different device
 fails to be resumed.
@@ -198,7 +198,7 @@ fails to be resumed.
 Returns:
 
 * `event` Event
-* `type` String - A string identifying the activity. Maps to
+* `type` string - A string identifying the activity. Maps to
   [`NSUserActivity.activityType`][activity-type].
 * `userInfo` unknown - Contains app-specific state stored by the activity.
 
@@ -210,7 +210,7 @@ resumed on another one.
 Returns:
 
 * `event` Event
-* `type` String - A string identifying the activity. Maps to
+* `type` string - A string identifying the activity. Maps to
   [`NSUserActivity.activityType`][activity-type].
 * `userInfo` unknown - Contains app-specific state stored by the activity.
 
@@ -268,11 +268,11 @@ Returns:
 
 * `event` Event
 * `webContents` [WebContents](web-contents.md)
-* `url` String
-* `error` String - The error code
+* `url` string
+* `error` string - The error code
 * `certificate` [Certificate](structures/certificate.md)
 * `callback` Function
-  * `isTrusted` Boolean - Whether to consider the certificate as trusted
+  * `isTrusted` boolean - Whether to consider the certificate as trusted
 
 Emitted when failed to verify the `certificate` for `url`, to trust the
 certificate you should prevent the default behavior with
@@ -328,14 +328,14 @@ Returns:
 * `authenticationResponseDetails` Object
   * `url` URL
 * `authInfo` Object
-  * `isProxy` Boolean
-  * `scheme` String
-  * `host` String
+  * `isProxy` boolean
+  * `scheme` string
+  * `host` string
   * `port` Integer
-  * `realm` String
+  * `realm` string
 * `callback` Function
-  * `username` String (optional)
-  * `password` String (optional)
+  * `username` string (optional)
+  * `password` string (optional)
 
 Emitted when `webContents` wants to do basic auth.
 
@@ -365,7 +365,7 @@ Emitted whenever there is a GPU info update.
 Returns:
 
 * `event` Event
-* `killed` Boolean
+* `killed` boolean
 
 Emitted when the GPU process crashes or is killed.
 
@@ -380,7 +380,7 @@ Returns:
 
 * `event` Event
 * `webContents` [WebContents](web-contents.md)
-* `killed` Boolean
+* `killed` boolean
 
 Emitted when the renderer process of `webContents` crashes or is killed.
 
@@ -396,7 +396,7 @@ Returns:
 * `event` Event
 * `webContents` [WebContents](web-contents.md)
 * `details` Object
-  * `reason` String - The reason the render process is gone.  Possible values:
+  * `reason` string - The reason the render process is gone.  Possible values:
     * `clean-exit` - Process exited with an exit code of zero
     * `abnormal-exit` - Process exited with a non-zero exit code
     * `killed` - Process was sent a SIGTERM or otherwise killed externally
@@ -414,7 +414,7 @@ Returns:
 
 * `event` Event
 * `details` Object
-  * `type` String - Process type. One of the following values:
+  * `type` string - Process type. One of the following values:
     * `Utility`
     * `Zygote`
     * `Sandbox helper`
@@ -422,7 +422,7 @@ Returns:
     * `Pepper Plugin`
     * `Pepper Plugin Broker`
     * `Unknown`
-  * `reason` String - The reason the child process is gone. Possible values:
+  * `reason` string - The reason the child process is gone. Possible values:
     * `clean-exit` - Process exited with an exit code of zero
     * `abnormal-exit` - Process exited with a non-zero exit code
     * `killed` - Process was sent a SIGTERM or otherwise killed externally
@@ -430,9 +430,9 @@ Returns:
     * `oom` - Process ran out of memory
     * `launch-failed` - Process never successfully launched
     * `integrity-failure` - Windows code integrity checks failed
-  * `exitCode` Number - The exit code for the process
+  * `exitCode` number - The exit code for the process
       (e.g. status from waitpid if on posix, from GetExitCodeProcess on Windows).
-  * `name` String (optional) - The name of the process. i.e. for plugins it might be Flash.
+  * `name` string (optional) - The name of the process. i.e. for plugins it might be Flash.
     Examples for utility: `Audio Service`, `Content Decryption Module Service`, `Network Service`, `Video Capture`, etc.
 
 Emitted when the child process unexpectedly disappears. This is normally
@@ -443,7 +443,7 @@ because it was crashed or killed. It does not include renderer processes.
 Returns:
 
 * `event` Event
-* `accessibilitySupportEnabled` Boolean - `true` when Chrome's accessibility
+* `accessibilitySupportEnabled` boolean - `true` when Chrome's accessibility
   support is enabled, `false` otherwise.
 
 Emitted when Chrome's accessibility support changes. This event fires when
@@ -472,8 +472,8 @@ app.on('session-created', (session) => {
 Returns:
 
 * `event` Event
-* `argv` String[] - An array of the second instance's command line arguments
-* `workingDirectory` String - The second instance's working directory
+* `argv` string[] - An array of the second instance's command line arguments
+* `workingDirectory` string - The second instance's working directory
 
 This event will be emitted inside the primary instance of your application
 when a second instance has been executed and calls `app.requestSingleInstanceLock()`.
@@ -507,7 +507,7 @@ Returns:
 
 * `event` Event
 * `webContents` [WebContents](web-contents.md)
-* `moduleName` String
+* `moduleName` string
 
 Emitted when `remote.require()` is called in the renderer process of `webContents`.
 Calling `event.preventDefault()` will prevent the module from being returned.
@@ -519,7 +519,7 @@ Returns:
 
 * `event` Event
 * `webContents` [WebContents](web-contents.md)
-* `globalName` String
+* `globalName` string
 
 Emitted when `remote.getGlobal()` is called in the renderer process of `webContents`.
 Calling `event.preventDefault()` will prevent the global from being returned.
@@ -531,7 +531,7 @@ Returns:
 
 * `event` Event
 * `webContents` [WebContents](web-contents.md)
-* `moduleName` String
+* `moduleName` string
 
 Emitted when `remote.getBuiltin()` is called in the renderer process of `webContents`.
 Calling `event.preventDefault()` will prevent the module from being returned.
@@ -588,8 +588,8 @@ and `will-quit` events will not be emitted.
 ### `app.relaunch([options])`
 
 * `options` Object (optional)
-  * `args` String[] (optional)
-  * `execPath` String (optional)
+  * `args` string[] (optional)
+  * `execPath` string (optional)
 
 Relaunches the app when current instance exits.
 
@@ -616,7 +616,7 @@ app.exit(0)
 
 ### `app.isReady()`
 
-Returns `Boolean` - `true` if Electron has finished initializing, `false` otherwise.
+Returns `boolean` - `true` if Electron has finished initializing, `false` otherwise.
 See also `app.whenReady()`.
 
 ### `app.whenReady()`
@@ -628,7 +628,7 @@ and subscribing to the `ready` event if the app is not ready yet.
 ### `app.focus([options])`
 
 * `options` Object (optional)
-  * `steal` Boolean _macOS_ - Make the receiver the active app even if another app is
+  * `steal` boolean _macOS_ - Make the receiver the active app even if another app is
   currently active.
 
 On Linux, focuses on the first visible window. On macOS, makes the application
@@ -647,7 +647,7 @@ them.
 
 ### `app.setAppLogsPath([path])`
 
-* `path` String (optional) - A custom path for your logs. Must be absolute.
+* `path` string (optional) - A custom path for your logs. Must be absolute.
 
 Sets or creates a directory your app's logs which can then be manipulated with `app.getPath()` or `app.setPath(pathName, newPath)`.
 
@@ -655,11 +655,11 @@ Calling `app.setAppLogsPath()` without a `path` parameter will result in this di
 
 ### `app.getAppPath()`
 
-Returns `String` - The current application directory.
+Returns `string` - The current application directory.
 
 ### `app.getPath(name)`
 
-* `name` String - You can request the following paths by the name:
+* `name` string - You can request the following paths by the name:
   * `home` User's home directory.
   * `appData` Per-user application data directory, which by default points to:
     * `%APPDATA%` on Windows
@@ -682,16 +682,16 @@ Returns `String` - The current application directory.
   * `pepperFlashSystemPlugin` Full path to the system version of the Pepper Flash plugin.
   * `crashDumps` Directory where crash dumps are stored.
 
-Returns `String` - A path to a special directory or file associated with `name`. On
+Returns `string` - A path to a special directory or file associated with `name`. On
 failure, an `Error` is thrown.
 
 If `app.getPath('logs')` is called without called `app.setAppLogsPath()` being called first, a default log directory will be created equivalent to calling `app.setAppLogsPath()` without a `path` parameter.
 
 ### `app.getFileIcon(path[, options])`
 
-* `path` String
+* `path` string
 * `options` Object (optional)
-  * `size` String
+  * `size` string
     * `small` - 16x16
     * `normal` - 32x32
     * `large` - 48x48 on _Linux_, 32x32 on _Windows_, unsupported on _macOS_.
@@ -709,8 +709,8 @@ On _Linux_ and _macOS_, icons depend on the application associated with file mim
 
 ### `app.setPath(name, path)`
 
-* `name` String
-* `path` String
+* `name` string
+* `path` string
 
 Overrides the `path` to a special directory or file associated with `name`.
 If the path specifies a directory that does not exist, an `Error` is thrown.
@@ -724,13 +724,13 @@ directory. If you want to change this location, you have to override the
 
 ### `app.getVersion()`
 
-Returns `String` - The version of the loaded application. If no version is found in the
+Returns `string` - The version of the loaded application. If no version is found in the
 application's `package.json` file, the version of the current bundle or
 executable is returned.
 
 ### `app.getName()`
 
-Returns `String` - The current application's name, which is the name in the application's
+Returns `string` - The current application's name, which is the name in the application's
 `package.json` file.
 
 Usually the `name` field of `package.json` is a short lowercase name, according
@@ -740,7 +740,7 @@ preferred over `name` by Electron.
 
 ### `app.setName(name)`
 
-* `name` String
+* `name` string
 
 Overrides the current application's name.
 
@@ -748,7 +748,7 @@ Overrides the current application's name.
 
 ### `app.getLocale()`
 
-Returns `String` - The current application locale. Possible return values are documented [here](locales.md).
+Returns `string` - The current application locale. Possible return values are documented [here](locales.md).
 
 To set the locale, you'll want to use a command line switch at app startup, which may be found [here](https://github.com/electron/electron/blob/master/docs/api/command-line-switches.md).
 
@@ -759,13 +759,13 @@ To set the locale, you'll want to use a command line switch at app startup, whic
 
 ### `app.getLocaleCountryCode()`
 
-Returns `String` - User operating system's locale two-letter [ISO 3166](https://www.iso.org/iso-3166-country-codes.html) country code. The value is taken from native OS APIs.
+Returns `string` - User operating system's locale two-letter [ISO 3166](https://www.iso.org/iso-3166-country-codes.html) country code. The value is taken from native OS APIs.
 
 **Note:** When unable to detect locale country code, it returns empty string.
 
 ### `app.addRecentDocument(path)` _macOS_ _Windows_
 
-* `path` String
+* `path` string
 
 Adds `path` to the recent documents list.
 
@@ -778,15 +778,15 @@ Clears the recent documents list.
 
 ### `app.setAsDefaultProtocolClient(protocol[, path, args])`
 
-* `protocol` String - The name of your protocol, without `://`. For example,
+* `protocol` string - The name of your protocol, without `://`. For example,
   if you want your app to handle `electron://` links, call this method with
   `electron` as the parameter.
-* `path` String (optional) _Windows_ - The path to the Electron executable.
+* `path` string (optional) _Windows_ - The path to the Electron executable.
   Defaults to `process.execPath`
-* `args` String[] (optional) _Windows_ - Arguments passed to the executable.
+* `args` string[] (optional) _Windows_ - Arguments passed to the executable.
   Defaults to an empty array
 
-Returns `Boolean` - Whether the call succeeded.
+Returns `boolean` - Whether the call succeeded.
 
 Sets the current executable as the default handler for a protocol (aka URI
 scheme). It allows you to integrate your app deeper into the operating system.
@@ -809,22 +809,22 @@ The API uses the Windows Registry and `LSSetDefaultHandlerForURLScheme` internal
 
 ### `app.removeAsDefaultProtocolClient(protocol[, path, args])` _macOS_ _Windows_
 
-* `protocol` String - The name of your protocol, without `://`.
-* `path` String (optional) _Windows_ - Defaults to `process.execPath`
-* `args` String[] (optional) _Windows_ - Defaults to an empty array
+* `protocol` string - The name of your protocol, without `://`.
+* `path` string (optional) _Windows_ - Defaults to `process.execPath`
+* `args` string[] (optional) _Windows_ - Defaults to an empty array
 
-Returns `Boolean` - Whether the call succeeded.
+Returns `boolean` - Whether the call succeeded.
 
 This method checks if the current executable as the default handler for a
 protocol (aka URI scheme). If so, it will remove the app as the default handler.
 
 ### `app.isDefaultProtocolClient(protocol[, path, args])`
 
-* `protocol` String - The name of your protocol, without `://`.
-* `path` String (optional) _Windows_ - Defaults to `process.execPath`
-* `args` String[] (optional) _Windows_ - Defaults to an empty array
+* `protocol` string - The name of your protocol, without `://`.
+* `path` string (optional) _Windows_ - Defaults to `process.execPath`
+* `args` string[] (optional) _Windows_ - Defaults to an empty array
 
-Returns `Boolean` - Whether the current executable is the default handler for a
+Returns `boolean` - Whether the current executable is the default handler for a
 protocol (aka URI scheme).
 
 **Note:** On macOS, you can use this method to check if the app has been
@@ -837,11 +837,11 @@ The API uses the Windows Registry and `LSCopyDefaultHandlerForURLScheme` interna
 
 ### `app.getApplicationNameForProtocol(url)`
 
-* `url` String - a URL with the protocol name to check. Unlike the other
+* `url` string - a URL with the protocol name to check. Unlike the other
   methods in this family, this accepts an entire URL, including `://` at a
   minimum (e.g. `https://`).
 
-Returns `String` - Name of the application handling the protocol, or an empty
+Returns `string` - Name of the application handling the protocol, or an empty
   string if there is no handler. For instance, if Electron is the default
   handler of the URL, this could be `Electron` on Windows and Mac. However,
   don't rely on the precise format which is not guaranteed to remain unchanged.
@@ -852,14 +852,14 @@ This method returns the application name of the default handler for the protocol
 
 ### `app.getApplicationInfoForProtocol(url)` _macOS_ _Windows_
 
-* `url` String - a URL with the protocol name to check. Unlike the other
+* `url` string - a URL with the protocol name to check. Unlike the other
   methods in this family, this accepts an entire URL, including `://` at a
   minimum (e.g. `https://`).
 
 Returns `Promise<Object>` - Resolve with an object containing the following:
   * `icon` NativeImage - the display icon of the app handling the protocol.
-  * `path` String  - installation path of the app handling the protocol.
-  * `name` String - display name of the app handling the protocol.
+  * `path` string  - installation path of the app handling the protocol.
+  * `name` string - display name of the app handling the protocol.
 
 This method returns a promise that contains the application name, icon and path of the default handler for the protocol
 (aka URI scheme) of a URL.
@@ -872,7 +872,7 @@ Adds `tasks` to the [Tasks][tasks] category of the Jump List on Windows.
 
 `tasks` is an array of [`Task`](structures/task.md) objects.
 
-Returns `Boolean` - Whether the call succeeded.
+Returns `boolean` - Whether the call succeeded.
 
 **Note:** If you'd like to customize the Jump List even more use
 `app.setJumpList(categories)` instead.
@@ -985,7 +985,7 @@ app.setJumpList([
 
 ### `app.requestSingleInstanceLock()`
 
-Returns `Boolean`
+Returns `boolean`
 
 The return value of this method indicates whether or not this instance of your
 application successfully obtained the lock.  If it failed to obtain the lock,
@@ -1032,7 +1032,7 @@ if (!gotTheLock) {
 
 ### `app.hasSingleInstanceLock()`
 
-Returns `Boolean`
+Returns `boolean`
 
 This method returns whether or not this instance of your app is currently
 holding the single instance lock.  You can request the lock with
@@ -1046,10 +1046,10 @@ allow multiple instances of the application to once again run side by side.
 
 ### `app.setUserActivity(type, userInfo[, webpageURL])` _macOS_
 
-* `type` String - Uniquely identifies the activity. Maps to
+* `type` string - Uniquely identifies the activity. Maps to
   [`NSUserActivity.activityType`][activity-type].
 * `userInfo` any - App-specific state to store for use by another device.
-* `webpageURL` String (optional) - The webpage to load in a browser if no suitable app is
+* `webpageURL` string (optional) - The webpage to load in a browser if no suitable app is
   installed on the resuming device. The scheme must be `http` or `https`.
 
 Creates an `NSUserActivity` and sets it as the current activity. The activity
@@ -1057,7 +1057,7 @@ is eligible for [Handoff][handoff] to another device afterward.
 
 ### `app.getCurrentActivityType()` _macOS_
 
-Returns `String` - The type of the currently running activity.
+Returns `string` - The type of the currently running activity.
 
 ### `app.invalidateCurrentActivity()` _macOS_
 
@@ -1069,7 +1069,7 @@ Marks the current [Handoff][handoff] user activity as inactive without invalidat
 
 ### `app.updateCurrentActivity(type, userInfo)` _macOS_
 
-* `type` String - Uniquely identifies the activity. Maps to
+* `type` string - Uniquely identifies the activity. Maps to
   [`NSUserActivity.activityType`][activity-type].
 * `userInfo` any - App-specific state to store for use by another device.
 
@@ -1078,13 +1078,13 @@ Updates the current activity if its type matches `type`, merging the entries fro
 
 ### `app.setAppUserModelId(id)` _Windows_
 
-* `id` String
+* `id` string
 
 Changes the [Application User Model ID][app-user-model-id] to `id`.
 
 ### `app.setActivationPolicy(policy)` _macOS_
 
-* `policy` String - Can be 'regular', 'accessory', or 'prohibited'.
+* `policy` string - Can be 'regular', 'accessory', or 'prohibited'.
 
 Sets the activation policy for a given app.
 
@@ -1096,8 +1096,8 @@ Activation policy types:
 ### `app.importCertificate(options, callback)` _Linux_
 
 * `options` Object
-  * `certificate` String - Path for the pkcs12 file.
-  * `password` String - Passphrase for the certificate.
+  * `certificate` string - Path for the pkcs12 file.
+  * `password` string - Passphrase for the certificate.
 * `callback` Function
   * `result` Integer - Result of import.
 
@@ -1131,7 +1131,7 @@ Returns [`GPUFeatureStatus`](structures/gpu-feature-status.md) - The Graphics Fe
 
 ### `app.getGPUInfo(infoType)`
 
-* `infoType` String - Can be `basic` or `complete`.
+* `infoType` string - Can be `basic` or `complete`.
 
 Returns `Promise<unknown>`
 
@@ -1173,7 +1173,7 @@ Using `basic` should be preferred if only basic information like `vendorId` or `
 
 * `count` Integer
 
-Returns `Boolean` - Whether the call succeeded.
+Returns `boolean` - Whether the call succeeded.
 
 Sets the counter badge for current app. Setting the count to `0` will hide the
 badge.
@@ -1189,14 +1189,14 @@ Returns `Integer` - The current value displayed in the counter badge.
 
 ### `app.isUnityRunning()` _Linux_
 
-Returns `Boolean` - Whether the current desktop environment is Unity launcher.
+Returns `boolean` - Whether the current desktop environment is Unity launcher.
 
 ### `app.getLoginItemSettings([options])` _macOS_ _Windows_
 
 * `options` Object (optional)
-  * `path` String (optional) _Windows_ - The executable path to compare against.
+  * `path` string (optional) _Windows_ - The executable path to compare against.
     Defaults to `process.execPath`.
-  * `args` String[] (optional) _Windows_ - The command-line arguments to compare
+  * `args` string[] (optional) _Windows_ - The command-line arguments to compare
     against. Defaults to an empty array.
 
 If you provided `path` and `args` options to `app.setLoginItemSettings`, then you
@@ -1204,43 +1204,43 @@ need to pass the same arguments here for `openAtLogin` to be set correctly.
 
 Returns `Object`:
 
-* `openAtLogin` Boolean - `true` if the app is set to open at login.
-* `openAsHidden` Boolean _macOS_ - `true` if the app is set to open as hidden at login.
+* `openAtLogin` boolean - `true` if the app is set to open at login.
+* `openAsHidden` boolean _macOS_ - `true` if the app is set to open as hidden at login.
   This setting is not available on [MAS builds][mas-builds].
-* `wasOpenedAtLogin` Boolean _macOS_ - `true` if the app was opened at login
+* `wasOpenedAtLogin` boolean _macOS_ - `true` if the app was opened at login
   automatically. This setting is not available on [MAS builds][mas-builds].
-* `wasOpenedAsHidden` Boolean _macOS_ - `true` if the app was opened as a hidden login
+* `wasOpenedAsHidden` boolean _macOS_ - `true` if the app was opened as a hidden login
   item. This indicates that the app should not open any windows at startup.
   This setting is not available on [MAS builds][mas-builds].
-* `restoreState` Boolean _macOS_ - `true` if the app was opened as a login item that
+* `restoreState` boolean _macOS_ - `true` if the app was opened as a login item that
   should restore the state from the previous session. This indicates that the
   app should restore the windows that were open the last time the app was
   closed. This setting is not available on [MAS builds][mas-builds].
-* `executableWillLaunchAtLogin` Boolean _Windows_ - `true` if app is set to open at login and its run key is not deactivated. This differs from `openAtLogin` as it ignores the `args` option, this property will be true if the given executable would be launched at login with **any** arguments.
+* `executableWillLaunchAtLogin` boolean _Windows_ - `true` if app is set to open at login and its run key is not deactivated. This differs from `openAtLogin` as it ignores the `args` option, this property will be true if the given executable would be launched at login with **any** arguments.
 * `launchItems` Object[] _Windows_
-  * `name` String _Windows_ - name value of a registry entry.
-  * `path` String _Windows_ - The executable to an app that corresponds to a registry entry.
-  * `args` String[] _Windows_ - the command-line arguments to pass to the executable.
-  * `scope` String _Windows_ - one of `user` or `machine`. Indicates whether the registry entry is under `HKEY_CURRENT USER` or `HKEY_LOCAL_MACHINE`.
-  * `enabled` Boolean _Windows_ - `true` if the app registry key is startup approved and therefore shows as `enabled` in Task Manager and Windows settings.
+  * `name` string _Windows_ - name value of a registry entry.
+  * `path` string _Windows_ - The executable to an app that corresponds to a registry entry.
+  * `args` string[] _Windows_ - the command-line arguments to pass to the executable.
+  * `scope` string _Windows_ - one of `user` or `machine`. Indicates whether the registry entry is under `HKEY_CURRENT USER` or `HKEY_LOCAL_MACHINE`.
+  * `enabled` boolean _Windows_ - `true` if the app registry key is startup approved and therefore shows as `enabled` in Task Manager and Windows settings.
 
 ### `app.setLoginItemSettings(settings)` _macOS_ _Windows_
 
 * `settings` Object
-  * `openAtLogin` Boolean (optional) - `true` to open the app at login, `false` to remove
+  * `openAtLogin` boolean (optional) - `true` to open the app at login, `false` to remove
     the app as a login item. Defaults to `false`.
-  * `openAsHidden` Boolean (optional) _macOS_ - `true` to open the app as hidden. Defaults to
+  * `openAsHidden` boolean (optional) _macOS_ - `true` to open the app as hidden. Defaults to
     `false`. The user can edit this setting from the System Preferences so
     `app.getLoginItemSettings().wasOpenedAsHidden` should be checked when the app
     is opened to know the current value. This setting is not available on [MAS builds][mas-builds].
-  * `path` String (optional) _Windows_ - The executable to launch at login.
+  * `path` string (optional) _Windows_ - The executable to launch at login.
     Defaults to `process.execPath`.
-  * `args` String[] (optional) _Windows_ - The command-line arguments to pass to
+  * `args` string[] (optional) _Windows_ - The command-line arguments to pass to
     the executable. Defaults to an empty array. Take care to wrap paths in
     quotes.
-  * `enabled` Boolean (optional) _Windows_ - `true` will change the startup approved registry key and `enable / disable` the App in Task Manager and Windows Settings.
+  * `enabled` boolean (optional) _Windows_ - `true` will change the startup approved registry key and `enable / disable` the App in Task Manager and Windows Settings.
     Defaults to `true`.
-  * `name` String (optional) _Windows_ - value name to write into registry. Defaults to the app's AppUserModelId().
+  * `name` string (optional) _Windows_ - value name to write into registry. Defaults to the app's AppUserModelId().
 Set the app's login item settings.
 
 To work with Electron's `autoUpdater` on Windows, which uses [Squirrel][Squirrel-Windows],
@@ -1264,7 +1264,7 @@ app.setLoginItemSettings({
 
 ### `app.isAccessibilitySupportEnabled()` _macOS_ _Windows_
 
-Returns `Boolean` - `true` if Chrome's accessibility support is enabled,
+Returns `boolean` - `true` if Chrome's accessibility support is enabled,
 `false` otherwise. This API will return `true` if the use of assistive
 technologies, such as screen readers, has been detected. See
 https://www.chromium.org/developers/design-documents/accessibility for more
@@ -1272,7 +1272,7 @@ details.
 
 ### `app.setAccessibilitySupportEnabled(enabled)` _macOS_ _Windows_
 
-* `enabled` Boolean - Enable or disable [accessibility tree](https://developers.google.com/web/fundamentals/accessibility/semantics-builtin/the-accessibility-tree) rendering
+* `enabled` boolean - Enable or disable [accessibility tree](https://developers.google.com/web/fundamentals/accessibility/semantics-builtin/the-accessibility-tree) rendering
 
 Manually enables Chrome's accessibility support, allowing to expose accessibility switch to users in application settings. See [Chromium's accessibility docs](https://www.chromium.org/developers/design-documents/accessibility) for more
 details. Disabled by default.
@@ -1288,14 +1288,14 @@ Show the app's about panel options. These options can be overridden with `app.se
 ### `app.setAboutPanelOptions(options)`
 
 * `options` Object
-  * `applicationName` String (optional) - The app's name.
-  * `applicationVersion` String (optional) - The app's version.
-  * `copyright` String (optional) - Copyright information.
-  * `version` String (optional) _macOS_ - The app's build version number.
-  * `credits` String (optional) _macOS_ _Windows_ - Credit information.
-  * `authors` String[] (optional) _Linux_ - List of app authors.
-  * `website` String (optional) _Linux_ - The app's website.
-  * `iconPath` String (optional) _Linux_ _Windows_ - Path to the app's icon in a JPEG or PNG file format. On Linux, will be shown as 64x64 pixels while retaining aspect ratio.
+  * `applicationName` string (optional) - The app's name.
+  * `applicationVersion` string (optional) - The app's version.
+  * `copyright` string (optional) - Copyright information.
+  * `version` string (optional) _macOS_ - The app's build version number.
+  * `credits` string (optional) _macOS_ _Windows_ - Credit information.
+  * `authors` string[] (optional) _Linux_ - List of app authors.
+  * `website` string (optional) _Linux_ - The app's website.
+  * `iconPath` string (optional) _Linux_ _Windows_ - Path to the app's icon in a JPEG or PNG file format. On Linux, will be shown as 64x64 pixels while retaining aspect ratio.
 
 Set the about panel options. This will override the values defined in the app's `.plist` file on macOS. See the [Apple docs][about-panel-options] for more details. On Linux, values must be set in order to be shown; there are no defaults.
 
@@ -1303,7 +1303,7 @@ If you do not set `credits` but still wish to surface them in your app, AppKit w
 
 ### `app.isEmojiPanelSupported()`
 
-Returns `Boolean` - whether or not the current OS version allows for native emoji pickers.
+Returns `boolean` - whether or not the current OS version allows for native emoji pickers.
 
 ### `app.showEmojiPanel()` _macOS_ _Windows_
 
@@ -1311,7 +1311,7 @@ Show the platform's native emoji picker.
 
 ### `app.startAccessingSecurityScopedResource(bookmarkData)` _mas_
 
-* `bookmarkData` String - The base64 encoded security scoped bookmark data returned by the `dialog.showOpenDialog` or `dialog.showSaveDialog` methods.
+* `bookmarkData` string - The base64 encoded security scoped bookmark data returned by the `dialog.showOpenDialog` or `dialog.showSaveDialog` methods.
 
 Returns `Function` - This function **must** be called once you have finished accessing the security scoped file. If you do not remember to stop accessing the bookmark, [kernel resources will be leaked](https://developer.apple.com/reference/foundation/nsurl/1417051-startaccessingsecurityscopedreso?language=objc) and your app will lose its ability to reach outside the sandbox completely, until your app is restarted.
 
@@ -1334,16 +1334,16 @@ This method can only be called before app is ready.
 
 ### `app.isInApplicationsFolder()` _macOS_
 
-Returns `Boolean` - Whether the application is currently running from the
+Returns `boolean` - Whether the application is currently running from the
 systems Application folder. Use in combination with `app.moveToApplicationsFolder()`
 
 ### `app.moveToApplicationsFolder([options])` _macOS_
 
 * `options` Object (optional)
-  * `conflictHandler` Function<Boolean> (optional) - A handler for potential conflict in move failure.
-    * `conflictType` String - The type of move conflict encountered by the handler; can be `exists` or `existsAndRunning`, where `exists` means that an app of the same name is present in the Applications directory and `existsAndRunning` means both that it exists and that it's presently running.
+  * `conflictHandler` Function<boolean> (optional) - A handler for potential conflict in move failure.
+    * `conflictType` string - The type of move conflict encountered by the handler; can be `exists` or `existsAndRunning`, where `exists` means that an app of the same name is present in the Applications directory and `existsAndRunning` means both that it exists and that it's presently running.
 
-Returns `Boolean` - Whether the move was successful. Please note that if
+Returns `boolean` - Whether the move was successful. Please note that if
 the move is successful, your application will quit and relaunch.
 
 No confirmation dialog will be presented by default. If you wish to allow
@@ -1379,13 +1379,13 @@ Would mean that if an app already exists in the user directory, if the user choo
 
 ### `app.isSecureKeyboardEntryEnabled()` _macOS_
 
-Returns `Boolean` - whether `Secure Keyboard Entry` is enabled.
+Returns `boolean` - whether `Secure Keyboard Entry` is enabled.
 
 By default this API will return `false`.
 
 ### `app.setSecureKeyboardEntryEnabled(enabled)` _macOS_
 
-* `enabled` Boolean - Enable or disable `Secure Keyboard Entry`
+* `enabled` boolean - Enable or disable `Secure Keyboard Entry`
 
 Set the `Secure Keyboard Entry` is enabled in your application.
 
@@ -1400,7 +1400,7 @@ details.
 
 ### `app.accessibilitySupportEnabled` _macOS_ _Windows_
 
-A `Boolean` property that's `true` if Chrome's accessibility support is enabled, `false` otherwise. This property will be `true` if the use of assistive technologies, such as screen readers, has been detected. Setting this property to `true` manually enables Chrome's accessibility support, allowing developers to expose accessibility switch to users in application settings.
+A `boolean` property that's `true` if Chrome's accessibility support is enabled, `false` otherwise. This property will be `true` if the use of assistive technologies, such as screen readers, has been detected. Setting this property to `true` manually enables Chrome's accessibility support, allowing developers to expose accessibility switch to users in application settings.
 
 See [Chromium's accessibility docs](https://www.chromium.org/developers/design-documents/accessibility) for more details. Disabled by default.
 
@@ -1437,7 +1437,7 @@ dock on macOS.
 
 ### `app.isPackaged` _Readonly_
 
-A `Boolean` property that returns  `true` if the app is packaged, `false` otherwise. For many apps, this property can be used to distinguish development and production environments.
+A `boolean` property that returns  `true` if the app is packaged, `false` otherwise. For many apps, this property can be used to distinguish development and production environments.
 
 [dock-menu]:https://developer.apple.com/macos/human-interface-guidelines/menus/dock-menus/
 [tasks]:https://msdn.microsoft.com/en-us/library/windows/desktop/dd378460(v=vs.85).aspx#tasks
@@ -1456,7 +1456,7 @@ A `Boolean` property that returns  `true` if the app is packaged, `false` otherw
 
 ### `app.name`
 
-A `String` property that indicates the current application's name, which is the name in the application's `package.json` file.
+A `string` property that indicates the current application's name, which is the name in the application's `package.json` file.
 
 Usually the `name` field of `package.json` is a short lowercase name, according
 to the npm modules spec. You should usually also specify a `productName`
@@ -1465,7 +1465,7 @@ preferred over `name` by Electron.
 
 ### `app.userAgentFallback`
 
-A `String` which is the user agent string Electron will use as a global fallback.
+A `string` which is the user agent string Electron will use as a global fallback.
 
 This is the user agent that will be used when no user agent is set at the
 `webContents` or `session` level.  It is useful for ensuring that your entire
@@ -1474,7 +1474,7 @@ in your app's initialization to ensure that your overridden value is used.
 
 ### `app.allowRendererProcessReuse`
 
-A `Boolean` which when `true` disables the overrides that Electron has in place
+A `boolean` which when `true` disables the overrides that Electron has in place
 to ensure renderer processes are restarted on every navigation.  The current
 default value for this property is `true`.
 

--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -77,10 +77,10 @@ Emitted when there is no available update.
 Returns:
 
 * `event` Event
-* `releaseNotes` String
-* `releaseName` String
+* `releaseNotes` string
+* `releaseName` string
 * `releaseDate` Date
-* `updateURL` String
+* `updateURL` string
 
 Emitted when an update has been downloaded.
 
@@ -102,16 +102,16 @@ The `autoUpdater` object has the following methods:
 ### `autoUpdater.setFeedURL(options)`
 
 * `options` Object
-  * `url` String
-  * `headers` Record<String, String> (optional) _macOS_ - HTTP request headers.
-  * `serverType` String (optional) _macOS_ - Can be `json` or `default`, see the [Squirrel.Mac][squirrel-mac]
+  * `url` string
+  * `headers` Record<string, string> (optional) _macOS_ - HTTP request headers.
+  * `serverType` string (optional) _macOS_ - Can be `json` or `default`, see the [Squirrel.Mac][squirrel-mac]
     README for more information.
 
 Sets the `url` and initialize the auto updater.
 
 ### `autoUpdater.getFeedURL()`
 
-Returns `String` - The current update feed URL.
+Returns `string` - The current update feed URL.
 
 ### `autoUpdater.checkForUpdates()`
 

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -43,13 +43,13 @@ Objects created with `new BrowserView` have the following instance methods:
 #### `view.setAutoResize(options)` _Experimental_
 
 * `options` Object
-  * `width` Boolean (optional) - If `true`, the view's width will grow and shrink together
+  * `width` boolean (optional) - If `true`, the view's width will grow and shrink together
     with the window. `false` by default.
-  * `height` Boolean (optional) - If `true`, the view's height will grow and shrink
+  * `height` boolean (optional) - If `true`, the view's height will grow and shrink
     together with the window. `false` by default.
-  * `horizontal` Boolean (optional) - If `true`, the view's x position and width will grow
+  * `horizontal` boolean (optional) - If `true`, the view's x position and width will grow
     and shrink proportionally with the window. `false` by default.
-  * `vertical` Boolean (optional) - If `true`, the view's y position and height will grow
+  * `vertical` boolean (optional) - If `true`, the view's y position and height will grow
     and shrink proportionally with the window. `false` by default.
 
 #### `view.setBounds(bounds)` _Experimental_
@@ -66,5 +66,5 @@ The `bounds` of this BrowserView instance as `Object`.
 
 #### `view.setBackgroundColor(color)` _Experimental_
 
-* `color` String - Color in `#aarrggbb` or `#argb` form. The alpha channel is
+* `color` string - Color in `#aarrggbb` or `#argb` form. The alpha channel is
   optional.

--- a/docs/api/browser-window-proxy.md
+++ b/docs/api/browser-window-proxy.md
@@ -21,7 +21,7 @@ Forcefully closes the child window without calling its unload event.
 
 #### `win.eval(code)`
 
-* `code` String
+* `code` string
 
 Evaluates the code in the child window.
 
@@ -36,7 +36,7 @@ Invokes the print dialog on the child window.
 #### `win.postMessage(message, targetOrigin)`
 
 * `message` any
-* `targetOrigin` String
+* `targetOrigin` string
 
 Sends a message to the child window with the specified origin or `*` for no
 origin preference.
@@ -50,4 +50,4 @@ The `BrowserWindowProxy` object has the following instance properties:
 
 #### `win.closed`
 
-A `Boolean` that is set to true after the child window gets closed.
+A `boolean` that is set to true after the child window gets closed.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -141,79 +141,79 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     Default is to center the window.
   * `y` Integer (optional) - (**required** if x is used) Window's top offset from screen.
     Default is to center the window.
-  * `useContentSize` Boolean (optional) - The `width` and `height` would be used as web
+  * `useContentSize` boolean (optional) - The `width` and `height` would be used as web
     page's size, which means the actual window's size will include window
     frame's size and be slightly larger. Default is `false`.
-  * `center` Boolean (optional) - Show window in the center of the screen.
+  * `center` boolean (optional) - Show window in the center of the screen.
   * `minWidth` Integer (optional) - Window's minimum width. Default is `0`.
   * `minHeight` Integer (optional) - Window's minimum height. Default is `0`.
   * `maxWidth` Integer (optional) - Window's maximum width. Default is no limit.
   * `maxHeight` Integer (optional) - Window's maximum height. Default is no limit.
-  * `resizable` Boolean (optional) - Whether window is resizable. Default is `true`.
-  * `movable` Boolean (optional) - Whether window is movable. This is not implemented
+  * `resizable` boolean (optional) - Whether window is resizable. Default is `true`.
+  * `movable` boolean (optional) - Whether window is movable. This is not implemented
     on Linux. Default is `true`.
-  * `minimizable` Boolean (optional) - Whether window is minimizable. This is not
+  * `minimizable` boolean (optional) - Whether window is minimizable. This is not
     implemented on Linux. Default is `true`.
-  * `maximizable` Boolean (optional) - Whether window is maximizable. This is not
+  * `maximizable` boolean (optional) - Whether window is maximizable. This is not
     implemented on Linux. Default is `true`.
-  * `closable` Boolean (optional) - Whether window is closable. This is not implemented
+  * `closable` boolean (optional) - Whether window is closable. This is not implemented
     on Linux. Default is `true`.
-  * `focusable` Boolean (optional) - Whether the window can be focused. Default is
+  * `focusable` boolean (optional) - Whether the window can be focused. Default is
     `true`. On Windows setting `focusable: false` also implies setting
     `skipTaskbar: true`. On Linux setting `focusable: false` makes the window
     stop interacting with wm, so the window will always stay on top in all
     workspaces.
-  * `alwaysOnTop` Boolean (optional) - Whether the window should always stay on top of
+  * `alwaysOnTop` boolean (optional) - Whether the window should always stay on top of
     other windows. Default is `false`.
-  * `fullscreen` Boolean (optional) - Whether the window should show in fullscreen. When
+  * `fullscreen` boolean (optional) - Whether the window should show in fullscreen. When
     explicitly set to `false` the fullscreen button will be hidden or disabled
     on macOS. Default is `false`.
-  * `fullscreenable` Boolean (optional) - Whether the window can be put into fullscreen
+  * `fullscreenable` boolean (optional) - Whether the window can be put into fullscreen
     mode. On macOS, also whether the maximize/zoom button should toggle full
     screen mode or maximize window. Default is `true`.
-  * `simpleFullscreen` Boolean (optional) - Use pre-Lion fullscreen on macOS. Default is `false`.
-  * `skipTaskbar` Boolean (optional) - Whether to show the window in taskbar. Default is
+  * `simpleFullscreen` boolean (optional) - Use pre-Lion fullscreen on macOS. Default is `false`.
+  * `skipTaskbar` boolean (optional) - Whether to show the window in taskbar. Default is
     `false`.
-  * `kiosk` Boolean (optional) - Whether the window is in kiosk mode. Default is `false`.
-  * `title` String (optional) - Default window title. Default is `"Electron"`. If the HTML tag `<title>` is defined in the HTML file loaded by `loadURL()`, this property will be ignored.
-  * `icon` ([NativeImage](native-image.md) | String) (optional) - The window icon. On Windows it is
+  * `kiosk` boolean (optional) - Whether the window is in kiosk mode. Default is `false`.
+  * `title` string (optional) - Default window title. Default is `"Electron"`. If the HTML tag `<title>` is defined in the HTML file loaded by `loadURL()`, this property will be ignored.
+  * `icon` ([NativeImage](native-image.md) | string) (optional) - The window icon. On Windows it is
     recommended to use `ICO` icons to get best visual effects, you can also
     leave it undefined so the executable's icon will be used.
-  * `show` Boolean (optional) - Whether window should be shown when created. Default is
+  * `show` boolean (optional) - Whether window should be shown when created. Default is
     `true`.
-  * `paintWhenInitiallyHidden` Boolean (optional) - Whether the renderer should be active when `show` is `false` and it has just been created.  In order for `document.visibilityState` to work correctly on first load with `show: false` you should set this to `false`.  Setting this to `false` will cause the `ready-to-show` event to not fire.  Default is `true`.
-  * `frame` Boolean (optional) - Specify `false` to create a
+  * `paintWhenInitiallyHidden` boolean (optional) - Whether the renderer should be active when `show` is `false` and it has just been created.  In order for `document.visibilityState` to work correctly on first load with `show: false` you should set this to `false`.  Setting this to `false` will cause the `ready-to-show` event to not fire.  Default is `true`.
+  * `frame` boolean (optional) - Specify `false` to create a
     [Frameless Window](frameless-window.md). Default is `true`.
   * `parent` BrowserWindow (optional) - Specify parent window. Default is `null`.
-  * `modal` Boolean (optional) - Whether this is a modal window. This only works when the
+  * `modal` boolean (optional) - Whether this is a modal window. This only works when the
     window is a child window. Default is `false`.
-  * `acceptFirstMouse` Boolean (optional) - Whether the web view accepts a single
+  * `acceptFirstMouse` boolean (optional) - Whether the web view accepts a single
     mouse-down event that simultaneously activates the window. Default is
     `false`.
-  * `disableAutoHideCursor` Boolean (optional) - Whether to hide cursor when typing.
+  * `disableAutoHideCursor` boolean (optional) - Whether to hide cursor when typing.
     Default is `false`.
-  * `autoHideMenuBar` Boolean (optional) - Auto hide the menu bar unless the `Alt`
+  * `autoHideMenuBar` boolean (optional) - Auto hide the menu bar unless the `Alt`
     key is pressed. Default is `false`.
-  * `enableLargerThanScreen` Boolean (optional) - Enable the window to be resized larger
+  * `enableLargerThanScreen` boolean (optional) - Enable the window to be resized larger
     than screen. Only relevant for macOS, as other OSes allow
     larger-than-screen windows by default. Default is `false`.
-  * `backgroundColor` String (optional) - Window's background color as a hexadecimal value,
+  * `backgroundColor` string (optional) - Window's background color as a hexadecimal value,
     like `#66CD00` or `#FFF` or `#80FFFFFF` (alpha in #AARRGGBB format is supported if
     `transparent` is set to `true`). Default is `#FFF` (white).
-  * `hasShadow` Boolean (optional) - Whether window should have a shadow. Default is `true`.
-  * `opacity` Number (optional) - Set the initial opacity of the window, between 0.0 (fully
+  * `hasShadow` boolean (optional) - Whether window should have a shadow. Default is `true`.
+  * `opacity` number (optional) - Set the initial opacity of the window, between 0.0 (fully
     transparent) and 1.0 (fully opaque). This is only implemented on Windows and macOS.
-  * `darkTheme` Boolean (optional) - Forces using dark theme for the window, only works on
+  * `darkTheme` boolean (optional) - Forces using dark theme for the window, only works on
     some GTK+3 desktop environments. Default is `false`.
-  * `transparent` Boolean (optional) - Makes the window [transparent](frameless-window.md#transparent-window).
+  * `transparent` boolean (optional) - Makes the window [transparent](frameless-window.md#transparent-window).
     Default is `false`. On Windows, does not work unless the window is frameless.
-  * `type` String (optional) - The type of window, default is normal window. See more about
+  * `type` string (optional) - The type of window, default is normal window. See more about
     this below.
-  * `visualEffectState` String (optional) - Specify how the material appearance should reflect window activity state on macOS. Must be used with the `vibrancy` property. Possible values are:
+  * `visualEffectState` string (optional) - Specify how the material appearance should reflect window activity state on macOS. Must be used with the `vibrancy` property. Possible values are:
     * `followWindow` - The backdrop should automatically appear active when the window is active, and inactive when it is not. This is the default.
     * `active` - The backdrop should always appear active.
     * `inactive` - The backdrop should always appear inactive.
-  * `titleBarStyle` String (optional) - The style of window title bar.
+  * `titleBarStyle` string (optional) - The style of window title bar.
     Default is `default`. Possible values are:
     * `default` - Results in the standard gray opaque Mac title
       bar.
@@ -222,120 +222,120 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       the top left.
     * `hiddenInset` - Results in a hidden title bar with an alternative look
       where the traffic light buttons are slightly more inset from the window edge.
-    * `customButtonsOnHover` Boolean (optional) - Draw custom close,
+    * `customButtonsOnHover` boolean (optional) - Draw custom close,
       and minimize buttons on macOS frameless windows. These buttons will not display
       unless hovered over in the top left of the window. These custom buttons prevent
       issues with mouse events that occur with the standard window toolbar buttons.
       **Note:** This option is currently experimental.
   * `trafficLightPosition` [Point](structures/point.md) (optional) - Set a custom position for the traffic light buttons. Can only be used with `titleBarStyle` set to `hidden`
-  * `fullscreenWindowTitle` Boolean (optional) - Shows the title in the
+  * `fullscreenWindowTitle` boolean (optional) - Shows the title in the
     title bar in full screen mode on macOS for all `titleBarStyle` options.
     Default is `false`.
-  * `thickFrame` Boolean (optional) - Use `WS_THICKFRAME` style for frameless windows on
+  * `thickFrame` boolean (optional) - Use `WS_THICKFRAME` style for frameless windows on
     Windows, which adds standard window frame. Setting it to `false` will remove
     window shadow and window animations. Default is `true`.
-  * `vibrancy` String (optional) - Add a type of vibrancy effect to the window, only on
+  * `vibrancy` string (optional) - Add a type of vibrancy effect to the window, only on
     macOS. Can be `appearance-based`, `light`, `dark`, `titlebar`, `selection`,
     `menu`, `popover`, `sidebar`, `medium-light`, `ultra-dark`, `header`, `sheet`, `window`, `hud`, `fullscreen-ui`, `tooltip`, `content`, `under-window`, or `under-page`.  Please note that using `frame: false` in combination with a vibrancy value requires that you use a non-default `titleBarStyle` as well. Also note that `appearance-based`, `light`, `dark`, `medium-light`, and `ultra-dark` have been deprecated and will be removed in an upcoming version of macOS.
-  * `zoomToPageWidth` Boolean (optional) - Controls the behavior on macOS when
+  * `zoomToPageWidth` boolean (optional) - Controls the behavior on macOS when
     option-clicking the green stoplight button on the toolbar or by clicking the
     Window > Zoom menu item. If `true`, the window will grow to the preferred
     width of the web page when zoomed, `false` will cause it to zoom to the
     width of the screen. This will also affect the behavior when calling
     `maximize()` directly. Default is `false`.
-  * `tabbingIdentifier` String (optional) - Tab group name, allows opening the
+  * `tabbingIdentifier` string (optional) - Tab group name, allows opening the
     window as a native tab on macOS 10.12+. Windows with the same tabbing
     identifier will be grouped together. This also adds a native new tab button
     to your window's tab bar and allows your `app` and window to receive the
     `new-window-for-tab` event.
   * `webPreferences` Object (optional) - Settings of web page's features.
-    * `devTools` Boolean (optional) - Whether to enable DevTools. If it is set to `false`, can not use `BrowserWindow.webContents.openDevTools()` to open DevTools. Default is `true`.
-    * `nodeIntegration` Boolean (optional) - Whether node integration is enabled.
+    * `devTools` boolean (optional) - Whether to enable DevTools. If it is set to `false`, can not use `BrowserWindow.webContents.openDevTools()` to open DevTools. Default is `true`.
+    * `nodeIntegration` boolean (optional) - Whether node integration is enabled.
       Default is `false`.
-    * `nodeIntegrationInWorker` Boolean (optional) - Whether node integration is
+    * `nodeIntegrationInWorker` boolean (optional) - Whether node integration is
       enabled in web workers. Default is `false`. More about this can be found
       in [Multithreading](../tutorial/multithreading.md).
-    * `nodeIntegrationInSubFrames` Boolean (optional) - Experimental option for
+    * `nodeIntegrationInSubFrames` boolean (optional) - Experimental option for
       enabling Node.js support in sub-frames such as iframes and child windows. All your preloads will load for
       every iframe, you can use `process.isMainFrame` to determine if you are
       in the main frame or not.
-    * `preload` String (optional) - Specifies a script that will be loaded before other
+    * `preload` string (optional) - Specifies a script that will be loaded before other
       scripts run in the page. This script will always have access to node APIs
       no matter whether node integration is turned on or off. The value should
       be the absolute file path to the script.
       When node integration is turned off, the preload script can reintroduce
       Node global symbols back to the global scope. See example
       [here](process.md#event-loaded).
-    * `sandbox` Boolean (optional) - If set, this will sandbox the renderer
+    * `sandbox` boolean (optional) - If set, this will sandbox the renderer
       associated with the window, making it compatible with the Chromium
       OS-level sandbox and disabling the Node.js engine. This is not the same as
       the `nodeIntegration` option and the APIs available to the preload script
       are more limited. Read more about the option [here](sandbox-option.md).
-    * `enableRemoteModule` Boolean (optional) - Whether to enable the [`remote`](remote.md) module.
+    * `enableRemoteModule` boolean (optional) - Whether to enable the [`remote`](remote.md) module.
       Default is `false`.
     * `session` [Session](session.md#class-session) (optional) - Sets the session used by the
       page. Instead of passing the Session object directly, you can also choose to
       use the `partition` option instead, which accepts a partition string. When
       both `session` and `partition` are provided, `session` will be preferred.
       Default is the default session.
-    * `partition` String (optional) - Sets the session used by the page according to the
+    * `partition` string (optional) - Sets the session used by the page according to the
       session's partition string. If `partition` starts with `persist:`, the page
       will use a persistent session available to all pages in the app with the
       same `partition`. If there is no `persist:` prefix, the page will use an
       in-memory session. By assigning the same `partition`, multiple pages can share
       the same session. Default is the default session.
-    * `affinity` String (optional) - When specified, web pages with the same
+    * `affinity` string (optional) - When specified, web pages with the same
       `affinity` will run in the same renderer process. Note that due to reusing
       the renderer process, certain `webPreferences` options will also be shared
       between the web pages even when you specified different values for them,
       including but not limited to `preload`, `sandbox` and `nodeIntegration`.
       So it is suggested to use exact same `webPreferences` for web pages with
       the same `affinity`. _Deprecated_
-    * `zoomFactor` Number (optional) - The default zoom factor of the page, `3.0` represents
+    * `zoomFactor` number (optional) - The default zoom factor of the page, `3.0` represents
       `300%`. Default is `1.0`.
-    * `javascript` Boolean (optional) - Enables JavaScript support. Default is `true`.
-    * `webSecurity` Boolean (optional) - When `false`, it will disable the
+    * `javascript` boolean (optional) - Enables JavaScript support. Default is `true`.
+    * `webSecurity` boolean (optional) - When `false`, it will disable the
       same-origin policy (usually using testing websites by people), and set
       `allowRunningInsecureContent` to `true` if this options has not been set
       by user. Default is `true`.
-    * `allowRunningInsecureContent` Boolean (optional) - Allow an https page to run
+    * `allowRunningInsecureContent` boolean (optional) - Allow an https page to run
       JavaScript, CSS or plugins from http URLs. Default is `false`.
-    * `images` Boolean (optional) - Enables image support. Default is `true`.
-    * `textAreasAreResizable` Boolean (optional) - Make TextArea elements resizable. Default
+    * `images` boolean (optional) - Enables image support. Default is `true`.
+    * `textAreasAreResizable` boolean (optional) - Make TextArea elements resizable. Default
       is `true`.
-    * `webgl` Boolean (optional) - Enables WebGL support. Default is `true`.
-    * `plugins` Boolean (optional) - Whether plugins should be enabled. Default is `false`.
-    * `experimentalFeatures` Boolean (optional) - Enables Chromium's experimental features.
+    * `webgl` boolean (optional) - Enables WebGL support. Default is `true`.
+    * `plugins` boolean (optional) - Whether plugins should be enabled. Default is `false`.
+    * `experimentalFeatures` boolean (optional) - Enables Chromium's experimental features.
       Default is `false`.
-    * `scrollBounce` Boolean (optional) - Enables scroll bounce (rubber banding) effect on
+    * `scrollBounce` boolean (optional) - Enables scroll bounce (rubber banding) effect on
       macOS. Default is `false`.
-    * `enableBlinkFeatures` String (optional) - A list of feature strings separated by `,`, like
+    * `enableBlinkFeatures` string (optional) - A list of feature strings separated by `,`, like
       `CSSVariables,KeyboardEventKey` to enable. The full list of supported feature
       strings can be found in the [RuntimeEnabledFeatures.json5][runtime-enabled-features]
       file.
-    * `disableBlinkFeatures` String (optional) - A list of feature strings separated by `,`,
+    * `disableBlinkFeatures` string (optional) - A list of feature strings separated by `,`,
       like `CSSVariables,KeyboardEventKey` to disable. The full list of supported
       feature strings can be found in the
       [RuntimeEnabledFeatures.json5][runtime-enabled-features] file.
     * `defaultFontFamily` Object (optional) - Sets the default font for the font-family.
-      * `standard` String (optional) - Defaults to `Times New Roman`.
-      * `serif` String (optional) - Defaults to `Times New Roman`.
-      * `sansSerif` String (optional) - Defaults to `Arial`.
-      * `monospace` String (optional) - Defaults to `Courier New`.
-      * `cursive` String (optional) - Defaults to `Script`.
-      * `fantasy` String (optional) - Defaults to `Impact`.
+      * `standard` string (optional) - Defaults to `Times New Roman`.
+      * `serif` string (optional) - Defaults to `Times New Roman`.
+      * `sansSerif` string (optional) - Defaults to `Arial`.
+      * `monospace` string (optional) - Defaults to `Courier New`.
+      * `cursive` string (optional) - Defaults to `Script`.
+      * `fantasy` string (optional) - Defaults to `Impact`.
     * `defaultFontSize` Integer (optional) - Defaults to `16`.
     * `defaultMonospaceFontSize` Integer (optional) - Defaults to `13`.
     * `minimumFontSize` Integer (optional) - Defaults to `0`.
-    * `defaultEncoding` String (optional) - Defaults to `ISO-8859-1`.
-    * `backgroundThrottling` Boolean (optional) - Whether to throttle animations and timers
+    * `defaultEncoding` string (optional) - Defaults to `ISO-8859-1`.
+    * `backgroundThrottling` boolean (optional) - Whether to throttle animations and timers
       when the page becomes background. This also affects the
       [Page Visibility API](#page-visibility). Defaults to `true`.
-    * `offscreen` Boolean (optional) - Whether to enable offscreen rendering for the browser
+    * `offscreen` boolean (optional) - Whether to enable offscreen rendering for the browser
       window. Defaults to `false`. See the
       [offscreen rendering tutorial](../tutorial/offscreen-rendering.md) for
       more details.
-    * `contextIsolation` Boolean (optional) - Whether to run Electron APIs and
+    * `contextIsolation` boolean (optional) - Whether to run Electron APIs and
       the specified `preload` script in a separate JavaScript context. Defaults
       to `false`. The context that the `preload` script runs in will still
       have full access to the `document` and `window` globals but it will use
@@ -349,14 +349,14 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       You can access this context in the dev tools by selecting the
       'Electron Isolated Context' entry in the combo box at the top of the
       Console tab.
-    * `worldSafeExecuteJavaScript` Boolean (optional) - If true, values returned from `webFrame.executeJavaScript` will be sanitized to ensure JS values
+    * `worldSafeExecuteJavaScript` boolean (optional) - If true, values returned from `webFrame.executeJavaScript` will be sanitized to ensure JS values
       can't unsafely cross between worlds when using `contextIsolation`.  The default
       is `false`. In Electron 12, the default will be changed to `true`. _Deprecated_
-    * `nativeWindowOpen` Boolean (optional) - Whether to use native
+    * `nativeWindowOpen` boolean (optional) - Whether to use native
       `window.open()`. Defaults to `false`. Child windows will always have node
       integration disabled unless `nodeIntegrationInSubFrames` is true. **Note:** This option is currently
       experimental.
-    * `webviewTag` Boolean (optional) - Whether to enable the [`<webview>` tag](webview-tag.md).
+    * `webviewTag` boolean (optional) - Whether to enable the [`<webview>` tag](webview-tag.md).
       Defaults to `false`. **Note:** The
       `preload` script configured for the `<webview>` will have node integration
       enabled when it is executed so you should ensure remote/untrusted content
@@ -364,34 +364,34 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       script. You can use the `will-attach-webview` event on [webContents](web-contents.md)
       to strip away the `preload` script and to validate or alter the
       `<webview>`'s initial settings.
-    * `additionalArguments` String[] (optional) - A list of strings that will be appended
+    * `additionalArguments` string[] (optional) - A list of strings that will be appended
       to `process.argv` in the renderer process of this app.  Useful for passing small
       bits of data down to renderer process preload scripts.
-    * `safeDialogs` Boolean (optional) - Whether to enable browser style
+    * `safeDialogs` boolean (optional) - Whether to enable browser style
       consecutive dialog protection. Default is `false`.
-    * `safeDialogsMessage` String (optional) - The message to display when
+    * `safeDialogsMessage` string (optional) - The message to display when
       consecutive dialog protection is triggered. If not defined the default
       message would be used, note that currently the default message is in
       English and not localized.
-    * `disableDialogs` Boolean (optional) - Whether to disable dialogs
+    * `disableDialogs` boolean (optional) - Whether to disable dialogs
       completely. Overrides `safeDialogs`. Default is `false`.
-    * `navigateOnDragDrop` Boolean (optional) - Whether dragging and dropping a
+    * `navigateOnDragDrop` boolean (optional) - Whether dragging and dropping a
       file or link onto the page causes a navigation. Default is `false`.
-    * `autoplayPolicy` String (optional) - Autoplay policy to apply to
+    * `autoplayPolicy` string (optional) - Autoplay policy to apply to
       content in the window, can be `no-user-gesture-required`,
       `user-gesture-required`, `document-user-activation-required`. Defaults to
       `no-user-gesture-required`.
-    * `disableHtmlFullscreenWindowResize` Boolean (optional) - Whether to
+    * `disableHtmlFullscreenWindowResize` boolean (optional) - Whether to
       prevent the window from resizing when entering HTML Fullscreen. Default
       is `false`.
-    * `accessibleTitle` String (optional) - An alternative title string provided only
+    * `accessibleTitle` string (optional) - An alternative title string provided only
       to accessibility tools such as screen readers. This string is not directly
       visible to users.
-    * `spellcheck` Boolean (optional) - Whether to enable the builtin spellchecker.
+    * `spellcheck` boolean (optional) - Whether to enable the builtin spellchecker.
       Default is `true`.
-    * `enableWebSQL` Boolean (optional) - Whether to enable the [WebSQL api](https://www.w3.org/TR/webdatabase/).
+    * `enableWebSQL` boolean (optional) - Whether to enable the [WebSQL api](https://www.w3.org/TR/webdatabase/).
       Default is `true`.
-    * `v8CacheOptions` String (optional) - Enforces the v8 code caching policy
+    * `v8CacheOptions` string (optional) - Enforces the v8 code caching policy
       used by blink. Accepted values are
       * `none` - Disables code caching
       * `code` - Heuristic based code caching
@@ -430,8 +430,8 @@ labeled as such.
 Returns:
 
 * `event` Event
-* `title` String
-* `explicitSet` Boolean
+* `title` string
+* `explicitSet` boolean
 
 Emitted when the document changed its title, calling `event.preventDefault()`
 will prevent the native window's title from changing.
@@ -580,7 +580,7 @@ Emitted when the window leaves a full-screen state triggered by HTML API.
 Returns:
 
 * `event` Event
-* `isAlwaysOnTop` Boolean
+* `isAlwaysOnTop` boolean
 
 Emitted when the window is set or unset to show always on top of other windows.
 
@@ -589,7 +589,7 @@ Emitted when the window is set or unset to show always on top of other windows.
 Returns:
 
 * `event` Event
-* `command` String
+* `command` string
 
 Emitted when an [App Command](https://msdn.microsoft.com/en-us/library/windows/desktop/ms646275(v=vs.85).aspx)
 is invoked. These are typically related to keyboard media keys or browser
@@ -632,7 +632,7 @@ Emitted when scroll wheel event phase filed upon reaching the edge of element.
 Returns:
 
 * `event` Event
-* `direction` String
+* `direction` string
 
 Emitted on 3-finger swipe. Possible directions are `up`, `right`, `down`, `left`.
 
@@ -700,7 +700,7 @@ Returns `BrowserWindow | null` - The window with the given `id`.
 
 #### `BrowserWindow.addExtension(path)` _Deprecated_
 
-* `path` String
+* `path` string
 
 Adds Chrome extension located at `path`, and returns extension's name.
 
@@ -714,7 +714,7 @@ is emitted.
 
 #### `BrowserWindow.removeExtension(name)` _Deprecated_
 
-* `name` String
+* `name` string
 
 Remove a Chrome extension by name.
 
@@ -726,7 +726,7 @@ is emitted.
 
 #### `BrowserWindow.getExtensions()` _Deprecated_
 
-Returns `Record<String, ExtensionInfo>` - The keys are the extension names and each value is
+Returns `Record<string, ExtensionInfo>` - The keys are the extension names and each value is
 an Object containing `name` and `version` properties.
 
 **Note:** This API cannot be called before the `ready` event of the `app` module
@@ -737,7 +737,7 @@ is emitted.
 
 #### `BrowserWindow.addDevToolsExtension(path)` _Deprecated_
 
-* `path` String
+* `path` string
 
 Adds DevTools extension located at `path`, and returns extension's name.
 
@@ -756,7 +756,7 @@ is emitted.
 
 #### `BrowserWindow.removeDevToolsExtension(name)` _Deprecated_
 
-* `name` String
+* `name` string
 
 Remove a DevTools extension by name.
 
@@ -811,92 +811,92 @@ A `Integer` property representing the unique ID of the window. Each ID is unique
 
 #### `win.autoHideMenuBar`
 
-A `Boolean` property that determines whether the window menu bar should hide itself automatically. Once set, the menu bar will only show when users press the single `Alt` key.
+A `boolean` property that determines whether the window menu bar should hide itself automatically. Once set, the menu bar will only show when users press the single `Alt` key.
 
 If the menu bar is already visible, setting this property to `true` won't
 hide it immediately.
 
 #### `win.simpleFullScreen`
 
-A `Boolean` property that determines whether the window is in simple (pre-Lion) fullscreen mode.
+A `boolean` property that determines whether the window is in simple (pre-Lion) fullscreen mode.
 
 #### `win.fullScreen`
 
-A `Boolean` property that determines whether the window is in fullscreen mode.
+A `boolean` property that determines whether the window is in fullscreen mode.
 
 #### `win.visibleOnAllWorkspaces`
 
-A `Boolean` property that determines whether the window is visible on all workspaces.
+A `boolean` property that determines whether the window is visible on all workspaces.
 
 **Note:** Always returns false on Windows.
 
 #### `win.shadow`
 
-A `Boolean` property that determines whether the window has a shadow.
+A `boolean` property that determines whether the window has a shadow.
 
 #### `win.menuBarVisible` _Windows_ _Linux_
 
-A `Boolean` property that determines whether the menu bar should be visible.
+A `boolean` property that determines whether the menu bar should be visible.
 
 **Note:** If the menu bar is auto-hide, users can still bring up the menu bar by pressing the single `Alt` key.
 
 ####  `win.kiosk`
 
-A `Boolean` property that determines whether the window is in kiosk mode.
+A `boolean` property that determines whether the window is in kiosk mode.
 
 #### `win.documentEdited` _macOS_
 
-A `Boolean` property that specifies whether the window’s document has been edited.
+A `boolean` property that specifies whether the window’s document has been edited.
 
 The icon in title bar will become gray when set to `true`.
 
 #### `win.representedFilename` _macOS_
 
-A `String` property that determines the pathname of the file the window represents,
+A `string` property that determines the pathname of the file the window represents,
 and the icon of the file will show in window's title bar.
 
 #### `win.title`
 
-A `String` property that determines the title of the native window.
+A `string` property that determines the title of the native window.
 
 **Note:** The title of the web page can be different from the title of the native window.
 
 #### `win.minimizable`
 
-A `Boolean` property that determines whether the window can be manually minimized by user.
+A `boolean` property that determines whether the window can be manually minimized by user.
 
 On Linux the setter is a no-op, although the getter returns `true`.
 
 #### `win.maximizable`
 
-A `Boolean` property that determines whether the window can be manually maximized by user.
+A `boolean` property that determines whether the window can be manually maximized by user.
 
 On Linux the setter is a no-op, although the getter returns `true`.
 
 #### `win.fullScreenable`
 
-A `Boolean` property that determines whether the maximize/zoom window button toggles fullscreen mode or
+A `boolean` property that determines whether the maximize/zoom window button toggles fullscreen mode or
 maximizes the window.
 
 #### `win.resizable`
 
-A `Boolean` property that determines whether the window can be manually resized by user.
+A `boolean` property that determines whether the window can be manually resized by user.
 
 #### `win.closable`
 
-A `Boolean` property that determines whether the window can be manually closed by user.
+A `boolean` property that determines whether the window can be manually closed by user.
 
 On Linux the setter is a no-op, although the getter returns `true`.
 
 #### `win.movable`
 
-A `Boolean` property that determines Whether the window can be moved by user.
+A `boolean` property that determines Whether the window can be moved by user.
 
 On Linux the setter is a no-op, although the getter returns `true`.
 
 #### `win.excludedFromShownWindowsMenu` _macOS_
 
-A `Boolean` property that determines whether the window is excluded from the application’s Windows menu. `false` by default.
+A `boolean` property that determines whether the window is excluded from the application’s Windows menu. `false` by default.
 
 ```js
 const win = new BrowserWindow({ height: 600, width: 600 })
@@ -915,7 +915,7 @@ Menu.setApplicationMenu(menu)
 
 #### `win.accessibleTitle`
 
-A `String` property that defines an alternative title provided only to
+A `string` property that defines an alternative title provided only to
 accessibility tools such as screen readers. This string is not directly
 visible to users.
 
@@ -948,11 +948,11 @@ Removes focus from the window.
 
 #### `win.isFocused()`
 
-Returns `Boolean` - Whether the window is focused.
+Returns `boolean` - Whether the window is focused.
 
 #### `win.isDestroyed()`
 
-Returns `Boolean` - Whether the window is destroyed.
+Returns `boolean` - Whether the window is destroyed.
 
 #### `win.show()`
 
@@ -968,11 +968,11 @@ Hides the window.
 
 #### `win.isVisible()`
 
-Returns `Boolean` - Whether the window is visible to the user.
+Returns `boolean` - Whether the window is visible to the user.
 
 #### `win.isModal()`
 
-Returns `Boolean` - Whether current window is a modal window.
+Returns `boolean` - Whether current window is a modal window.
 
 #### `win.maximize()`
 
@@ -985,7 +985,7 @@ Unmaximizes the window.
 
 #### `win.isMaximized()`
 
-Returns `Boolean` - Whether the window is maximized.
+Returns `boolean` - Whether the window is maximized.
 
 #### `win.minimize()`
 
@@ -998,21 +998,21 @@ Restores the window from minimized state to its previous state.
 
 #### `win.isMinimized()`
 
-Returns `Boolean` - Whether the window is minimized.
+Returns `boolean` - Whether the window is minimized.
 
 #### `win.setFullScreen(flag)`
 
-* `flag` Boolean
+* `flag` boolean
 
 Sets whether the window should be in fullscreen mode.
 
 #### `win.isFullScreen()`
 
-Returns `Boolean` - Whether the window is in fullscreen mode.
+Returns `boolean` - Whether the window is in fullscreen mode.
 
 #### `win.setSimpleFullScreen(flag)` _macOS_
 
-* `flag` Boolean
+* `flag` boolean
 
 Enters or leaves simple fullscreen mode.
 
@@ -1020,11 +1020,11 @@ Simple fullscreen mode emulates the native fullscreen behavior found in versions
 
 #### `win.isSimpleFullScreen()` _macOS_
 
-Returns `Boolean` - Whether the window is in simple (pre-Lion) fullscreen mode.
+Returns `boolean` - Whether the window is in simple (pre-Lion) fullscreen mode.
 
 #### `win.isNormal()`
 
-Returns `Boolean` - Whether the window is in normal state (not maximized, not minimized, not in fullscreen mode).
+Returns `boolean` - Whether the window is in normal state (not maximized, not minimized, not in fullscreen mode).
 
 #### `win.setAspectRatio(aspectRatio[, extraSize])` _macOS_ _Linux_
 
@@ -1049,7 +1049,7 @@ height areas you have within the overall content view.
 
 #### `win.setBackgroundColor(backgroundColor)`
 
-* `backgroundColor` String - Window's background color as a hexadecimal value,
+* `backgroundColor` string - Window's background color as a hexadecimal value,
   like `#66CD00` or `#FFF` or `#80FFFFFF` (alpha is supported if `transparent`
   is `true`). Default is `#FFF` (white).
 
@@ -1058,10 +1058,10 @@ Sets the background color of the window. See [Setting
 
 #### `win.previewFile(path[, displayName])` _macOS_
 
-* `path` String - The absolute path to the file to preview with QuickLook. This
+* `path` string - The absolute path to the file to preview with QuickLook. This
   is important as Quick Look uses the file name and file extension on the path
   to determine the content type of the file to open.
-* `displayName` String (optional) - The name of the file to display on the
+* `displayName` string (optional) - The name of the file to display on the
   Quick Look modal view. This is purely visual and does not affect the content
   type of the file. Defaults to `path`.
 
@@ -1074,7 +1074,7 @@ Closes the currently open [Quick Look][quick-look] panel.
 #### `win.setBounds(bounds[, animate])`
 
 * `bounds` Partial<[Rectangle](structures/rectangle.md)>
-* `animate` Boolean (optional) _macOS_
+* `animate` boolean (optional) _macOS_
 
 Resizes and moves the window to the supplied bounds. Any properties that are not supplied will default to their current values.
 
@@ -1098,13 +1098,13 @@ Returns [`Rectangle`](structures/rectangle.md) - The `bounds` of the window as `
 
 #### `win.getBackgroundColor()`
 
-Returns `String` - Gets the background color of the window. See [Setting
+Returns `string` - Gets the background color of the window. See [Setting
 `backgroundColor`](#setting-backgroundcolor).
 
 #### `win.setContentBounds(bounds[, animate])`
 
 * `bounds` [Rectangle](structures/rectangle.md)
-* `animate` Boolean (optional) _macOS_
+* `animate` boolean (optional) _macOS_
 
 Resizes and moves the window's client area (e.g. the web page) to
 the supplied bounds.
@@ -1121,19 +1121,19 @@ Returns [`Rectangle`](structures/rectangle.md) - Contains the window bounds of t
 
 #### `win.setEnabled(enable)`
 
-* `enable` Boolean
+* `enable` boolean
 
 Disable or enable the window.
 
 #### `win.isEnabled()`
 
-Returns `Boolean` - whether the window is enabled.
+Returns `boolean` - whether the window is enabled.
 
 #### `win.setSize(width, height[, animate])`
 
 * `width` Integer
 * `height` Integer
-* `animate` Boolean (optional) _macOS_
+* `animate` boolean (optional) _macOS_
 
 Resizes the window to `width` and `height`. If `width` or `height` are below any set minimum size constraints the window will snap to its minimum size.
 
@@ -1145,7 +1145,7 @@ Returns `Integer[]` - Contains the window's width and height.
 
 * `width` Integer
 * `height` Integer
-* `animate` Boolean (optional) _macOS_
+* `animate` boolean (optional) _macOS_
 
 Resizes the window's client area (e.g. the web page) to `width` and `height`.
 
@@ -1177,76 +1177,76 @@ Returns `Integer[]` - Contains the window's maximum width and height.
 
 #### `win.setResizable(resizable)`
 
-* `resizable` Boolean
+* `resizable` boolean
 
 Sets whether the window can be manually resized by the user.
 
 #### `win.isResizable()`
 
-Returns `Boolean` - Whether the window can be manually resized by the user.
+Returns `boolean` - Whether the window can be manually resized by the user.
 
 #### `win.setMovable(movable)` _macOS_ _Windows_
 
-* `movable` Boolean
+* `movable` boolean
 
 Sets whether the window can be moved by user. On Linux does nothing.
 
 #### `win.isMovable()` _macOS_ _Windows_
 
-Returns `Boolean` - Whether the window can be moved by user.
+Returns `boolean` - Whether the window can be moved by user.
 
 On Linux always returns `true`.
 
 #### `win.setMinimizable(minimizable)` _macOS_ _Windows_
 
-* `minimizable` Boolean
+* `minimizable` boolean
 
 Sets whether the window can be manually minimized by user. On Linux does nothing.
 
 #### `win.isMinimizable()` _macOS_ _Windows_
 
-Returns `Boolean` - Whether the window can be manually minimized by the user.
+Returns `boolean` - Whether the window can be manually minimized by the user.
 
 On Linux always returns `true`.
 
 #### `win.setMaximizable(maximizable)` _macOS_ _Windows_
 
-* `maximizable` Boolean
+* `maximizable` boolean
 
 Sets whether the window can be manually maximized by user. On Linux does nothing.
 
 #### `win.isMaximizable()` _macOS_ _Windows_
 
-Returns `Boolean` - Whether the window can be manually maximized by user.
+Returns `boolean` - Whether the window can be manually maximized by user.
 
 On Linux always returns `true`.
 
 #### `win.setFullScreenable(fullscreenable)`
 
-* `fullscreenable` Boolean
+* `fullscreenable` boolean
 
 Sets whether the maximize/zoom window button toggles fullscreen mode or maximizes the window.
 
 #### `win.isFullScreenable()`
 
-Returns `Boolean` - Whether the maximize/zoom window button toggles fullscreen mode or maximizes the window.
+Returns `boolean` - Whether the maximize/zoom window button toggles fullscreen mode or maximizes the window.
 
 #### `win.setClosable(closable)` _macOS_ _Windows_
 
-* `closable` Boolean
+* `closable` boolean
 
 Sets whether the window can be manually closed by user. On Linux does nothing.
 
 #### `win.isClosable()` _macOS_ _Windows_
 
-Returns `Boolean` - Whether the window can be manually closed by user.
+Returns `boolean` - Whether the window can be manually closed by user.
 
 On Linux always returns `true`.
 
 #### `win.setAlwaysOnTop(flag[, level][, relativeLevel])`
 
-* `flag` Boolean
-* `level` String (optional) _macOS_ _Windows_ - Values include `normal`,
+* `flag` boolean
+* `level` string (optional) _macOS_ _Windows_ - Values include `normal`,
   `floating`, `torn-off-menu`, `modal-panel`, `main-menu`, `status`,
   `pop-up-menu`, `screen-saver`, and ~~`dock`~~ (Deprecated). The default is
   `floating` when `flag` is true. The `level` is reset to `normal` when the
@@ -1264,11 +1264,11 @@ can not be focused on.
 
 #### `win.isAlwaysOnTop()`
 
-Returns `Boolean` - Whether the window is always on top of other windows.
+Returns `boolean` - Whether the window is always on top of other windows.
 
 #### `win.moveAbove(mediaSourceId)`
 
-* `mediaSourceId` String - Window id in the format of DesktopCapturerSource's id. For example "window:1869:0".
+* `mediaSourceId` string - Window id in the format of DesktopCapturerSource's id. For example "window:1869:0".
 
 Moves window above the source window in the sense of z-order. If the
 `mediaSourceId` is not of type window or if the window does not exist then
@@ -1286,7 +1286,7 @@ Moves window to the center of the screen.
 
 * `x` Integer
 * `y` Integer
-* `animate` Boolean (optional) _macOS_
+* `animate` boolean (optional) _macOS_
 
 Moves window to `x` and `y`.
 
@@ -1296,13 +1296,13 @@ Returns `Integer[]` - Contains the window's current position.
 
 #### `win.setTitle(title)`
 
-* `title` String
+* `title` string
 
 Changes the title of native window to `title`.
 
 #### `win.getTitle()`
 
-Returns `String` - The title of the native window.
+Returns `string` - The title of the native window.
 
 **Note:** The title of the web page can be different from the title of the native
 window.
@@ -1326,29 +1326,29 @@ win.setSheetOffset(toolbarRect.height)
 
 #### `win.flashFrame(flag)`
 
-* `flag` Boolean
+* `flag` boolean
 
 Starts or stops flashing the window to attract user's attention.
 
 #### `win.setSkipTaskbar(skip)`
 
-* `skip` Boolean
+* `skip` boolean
 
 Makes the window not show in the taskbar.
 
 #### `win.setKiosk(flag)`
 
-* `flag` Boolean
+* `flag` boolean
 
 Enters or leaves kiosk mode.
 
 #### `win.isKiosk()`
 
-Returns `Boolean` - Whether the window is in kiosk mode.
+Returns `boolean` - Whether the window is in kiosk mode.
 
 #### `win.isTabletMode()` _Windows_
 
-Returns `Boolean` - Whether the window is in Windows 10 tablet mode.
+Returns `boolean` - Whether the window is in Windows 10 tablet mode.
 
 Since Windows 10 users can [use their PC as tablet](https://support.microsoft.com/en-us/help/17210/windows-10-use-your-pc-like-a-tablet),
 under this mode apps can choose to optimize their UI for tablets, such as
@@ -1359,7 +1359,7 @@ can be be used to listen to changes to tablet mode.
 
 #### `win.getMediaSourceId()`
 
-Returns `String` - Window id in the format of DesktopCapturerSource's id. For example "window:1234:0".
+Returns `string` - Window id in the format of DesktopCapturerSource's id. For example "window:1234:0".
 
 More precisely the format is `window:id:other_id` where `id` is `HWND` on
 Windows, `CGWindowID` (`uint64_t`) on macOS and `Window` (`unsigned long`) on
@@ -1385,7 +1385,7 @@ the message is received in the WndProc.
 
 * `message` Integer
 
-Returns `Boolean` - `true` or `false` depending on whether the message is hooked.
+Returns `boolean` - `true` or `false` depending on whether the message is hooked.
 
 #### `win.unhookWindowMessage(message)` _Windows_
 
@@ -1399,25 +1399,25 @@ Unhooks all of the window messages.
 
 #### `win.setRepresentedFilename(filename)` _macOS_
 
-* `filename` String
+* `filename` string
 
 Sets the pathname of the file the window represents, and the icon of the file
 will show in window's title bar.
 
 #### `win.getRepresentedFilename()` _macOS_
 
-Returns `String` - The pathname of the file the window represents.
+Returns `string` - The pathname of the file the window represents.
 
 #### `win.setDocumentEdited(edited)` _macOS_
 
-* `edited` Boolean
+* `edited` boolean
 
 Specifies whether the window’s document has been edited, and the icon in title
 bar will become gray when set to `true`.
 
 #### `win.isDocumentEdited()` _macOS_
 
-Returns `Boolean` - Whether the window's document has been edited.
+Returns `boolean` - Whether the window's document has been edited.
 
 #### `win.focusOnWebView()`
 
@@ -1433,13 +1433,13 @@ Captures a snapshot of the page within `rect`. Omitting `rect` will capture the 
 
 #### `win.loadURL(url[, options])`
 
-* `url` String
+* `url` string
 * `options` Object (optional)
-  * `httpReferrer` (String | [Referrer](structures/referrer.md)) (optional) - An HTTP Referrer URL.
-  * `userAgent` String (optional) - A user agent originating the request.
-  * `extraHeaders` String (optional) - Extra headers separated by "\n"
+  * `httpReferrer` (string | [Referrer](structures/referrer.md)) (optional) - An HTTP Referrer URL.
+  * `userAgent` string (optional) - A user agent originating the request.
+  * `extraHeaders` string (optional) - Extra headers separated by "\n"
   * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadBlob[]](structures/upload-blob.md)) (optional)
-  * `baseURLForDataURL` String (optional) - Base URL (with trailing path separator) for files to be loaded by the data URL. This is needed only if the specified `url` is a data URL and needs to load other files.
+  * `baseURLForDataURL` string (optional) - Base URL (with trailing path separator) for files to be loaded by the data URL. This is needed only if the specified `url` is a data URL and needs to load other files.
 
 Returns `Promise<void>` - the promise will resolve when the page has finished loading
 (see [`did-finish-load`](web-contents.md#event-did-finish-load)), and rejects
@@ -1479,11 +1479,11 @@ win.loadURL('http://localhost:8000/post', {
 
 #### `win.loadFile(filePath[, options])`
 
-* `filePath` String
+* `filePath` string
 * `options` Object (optional)
-  * `query` Record<String, String> (optional) - Passed to `url.format()`.
-  * `search` String (optional) - Passed to `url.format()`.
-  * `hash` String (optional) - Passed to `url.format()`.
+  * `query` Record<string, string> (optional) - Passed to `url.format()`.
+  * `search` string (optional) - Passed to `url.format()`.
+  * `hash` string (optional) - Passed to `url.format()`.
 
 Returns `Promise<void>` - the promise will resolve when the page has finished loading
 (see [`did-finish-load`](web-contents.md#event-did-finish-load)), and rejects
@@ -1511,7 +1511,7 @@ Remove the window's menu bar.
 
 * `progress` Double
 * `options` Object (optional)
-  * `mode` String _Windows_ - Mode for the progress bar. Can be `none`, `normal`, `indeterminate`, `error` or `paused`.
+  * `mode` string _Windows_ - Mode for the progress bar. Can be `none`, `normal`, `indeterminate`, `error` or `paused`.
 
 Sets progress value in progress bar. Valid range is [0, 1.0].
 
@@ -1531,7 +1531,7 @@ mode set (but with a value within the valid range), `normal` will be assumed.
 * `overlay` [NativeImage](native-image.md) | null - the icon to display on the bottom
 right corner of the taskbar icon. If this parameter is `null`, the overlay is
 cleared
-* `description` String - a description that will be provided to Accessibility
+* `description` string - a description that will be provided to Accessibility
 screen readers
 
 Sets a 16 x 16 pixel overlay onto the current taskbar icon, usually used to
@@ -1539,24 +1539,24 @@ convey some sort of application status or to passively notify the user.
 
 #### `win.setHasShadow(hasShadow)`
 
-* `hasShadow` Boolean
+* `hasShadow` boolean
 
 Sets whether the window should have a shadow.
 
 #### `win.hasShadow()`
 
-Returns `Boolean` - Whether the window has a shadow.
+Returns `boolean` - Whether the window has a shadow.
 
 #### `win.setOpacity(opacity)` _Windows_ _macOS_
 
-* `opacity` Number - between 0.0 (fully transparent) and 1.0 (fully opaque)
+* `opacity` number - between 0.0 (fully transparent) and 1.0 (fully opaque)
 
 Sets the opacity of the window. On Linux, does nothing. Out of bound number
 values are clamped to the [0, 1] range.
 
 #### `win.getOpacity()`
 
-Returns `Number` - between 0.0 (fully transparent) and 1.0 (fully opaque). On
+Returns `number` - between 0.0 (fully transparent) and 1.0 (fully opaque). On
 Linux, always returns 1.
 
 #### `win.setShape(rects)` _Windows_ _Linux_ _Experimental_
@@ -1574,10 +1574,10 @@ whatever is behind the window.
 
 * `buttons` [ThumbarButton[]](structures/thumbar-button.md)
 
-Returns `Boolean` - Whether the buttons were added successfully
+Returns `boolean` - Whether the buttons were added successfully
 
 Add a thumbnail toolbar with a specified set of buttons to the thumbnail image
-of a window in a taskbar button layout. Returns a `Boolean` object indicates
+of a window in a taskbar button layout. Returns a `boolean` object indicates
 whether the thumbnail has been added successfully.
 
 The number of buttons in thumbnail toolbar should be no greater than 7 due to
@@ -1591,11 +1591,11 @@ The `buttons` is an array of `Button` objects:
   * `icon` [NativeImage](native-image.md) - The icon showing in thumbnail
     toolbar.
   * `click` Function
-  * `tooltip` String (optional) - The text of the button's tooltip.
-  * `flags` String[] (optional) - Control specific states and behaviors of the
+  * `tooltip` string (optional) - The text of the button's tooltip.
+  * `flags` string[] (optional) - Control specific states and behaviors of the
     button. By default, it is `['enabled']`.
 
-The `flags` is an array that can include following `String`s:
+The `flags` is an array that can include following `string`s:
 
 * `enabled` - The button is active and available to the user.
 * `disabled` - The button is disabled. It is present, but has a visual state
@@ -1619,7 +1619,7 @@ the entire window by specifying an empty region:
 
 #### `win.setThumbnailToolTip(toolTip)` _Windows_
 
-* `toolTip` String
+* `toolTip` string
 
 Sets the toolTip that is displayed when hovering over the window thumbnail
 in the taskbar.
@@ -1627,13 +1627,13 @@ in the taskbar.
 #### `win.setAppDetails(options)` _Windows_
 
 * `options` Object
-  * `appId` String (optional) - Window's [App User Model ID](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391569(v=vs.85).aspx).
+  * `appId` string (optional) - Window's [App User Model ID](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391569(v=vs.85).aspx).
     It has to be set, otherwise the other options will have no effect.
-  * `appIconPath` String (optional) - Window's [Relaunch Icon](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391573(v=vs.85).aspx).
+  * `appIconPath` string (optional) - Window's [Relaunch Icon](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391573(v=vs.85).aspx).
   * `appIconIndex` Integer (optional) - Index of the icon in `appIconPath`.
     Ignored when `appIconPath` is not set. Default is `0`.
-  * `relaunchCommand` String (optional) - Window's [Relaunch Command](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391571(v=vs.85).aspx).
-  * `relaunchDisplayName` String (optional) - Window's [Relaunch Display Name](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391572(v=vs.85).aspx).
+  * `relaunchCommand` string (optional) - Window's [Relaunch Command](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391571(v=vs.85).aspx).
+  * `relaunchDisplayName` string (optional) - Window's [Relaunch Display Name](https://msdn.microsoft.com/en-us/library/windows/desktop/dd391572(v=vs.85).aspx).
 
 Sets the properties for the window's taskbar button.
 
@@ -1646,13 +1646,13 @@ Same as `webContents.showDefinitionForSelection()`.
 
 #### `win.setIcon(icon)` _Windows_ _Linux_
 
-* `icon` [NativeImage](native-image.md) | String
+* `icon` [NativeImage](native-image.md) | string
 
 Changes window icon.
 
 #### `win.setWindowButtonVisibility(visible)` _macOS_
 
-* `visible` Boolean
+* `visible` boolean
 
 Sets whether the window traffic light buttons should be visible.
 
@@ -1660,7 +1660,7 @@ This cannot be called when `titleBarStyle` is set to `customButtonsOnHover`.
 
 #### `win.setAutoHideMenuBar(hide)`
 
-* `hide` Boolean
+* `hide` boolean
 
 Sets whether the window menu bar should hide itself automatically. Once set the
 menu bar will only show when users press the single `Alt` key.
@@ -1669,23 +1669,23 @@ If the menu bar is already visible, calling `setAutoHideMenuBar(true)` won't hid
 
 #### `win.isMenuBarAutoHide()`
 
-Returns `Boolean` - Whether menu bar automatically hides itself.
+Returns `boolean` - Whether menu bar automatically hides itself.
 
 #### `win.setMenuBarVisibility(visible)` _Windows_ _Linux_
 
-* `visible` Boolean
+* `visible` boolean
 
 Sets whether the menu bar should be visible. If the menu bar is auto-hide, users can still bring up the menu bar by pressing the single `Alt` key.
 
 #### `win.isMenuBarVisible()`
 
-Returns `Boolean` - Whether the menu bar is visible.
+Returns `boolean` - Whether the menu bar is visible.
 
 #### `win.setVisibleOnAllWorkspaces(visible[, options])`
 
-* `visible` Boolean
+* `visible` boolean
 * `options` Object (optional)
-  * `visibleOnFullScreen` Boolean (optional) _macOS_ - Sets whether
+  * `visibleOnFullScreen` boolean (optional) _macOS_ - Sets whether
     the window should be visible above fullscreen windows
 
 Sets whether the window should be visible on all workspaces.
@@ -1694,15 +1694,15 @@ Sets whether the window should be visible on all workspaces.
 
 #### `win.isVisibleOnAllWorkspaces()`
 
-Returns `Boolean` - Whether the window is visible on all workspaces.
+Returns `boolean` - Whether the window is visible on all workspaces.
 
 **Note:** This API always returns false on Windows.
 
 #### `win.setIgnoreMouseEvents(ignore[, options])`
 
-* `ignore` Boolean
+* `ignore` boolean
 * `options` Object (optional)
-  * `forward` Boolean (optional) _macOS_ _Windows_ - If true, forwards mouse move
+  * `forward` boolean (optional) _macOS_ _Windows_ - If true, forwards mouse move
     messages to Chromium, enabling mouse related events such as `mouseleave`.
     Only used when `ignore` is true. If `ignore` is false, forwarding is always
     disabled regardless of this value.
@@ -1715,7 +1715,7 @@ events.
 
 #### `win.setContentProtection(enable)` _macOS_ _Windows_
 
-* `enable` Boolean
+* `enable` boolean
 
 Prevents the window contents from being captured by other apps.
 
@@ -1724,7 +1724,7 @@ On Windows it calls SetWindowDisplayAffinity with `WDA_MONITOR`.
 
 #### `win.setFocusable(focusable)` _macOS_ _Windows_
 
-* `focusable` Boolean
+* `focusable` boolean
 
 Changes whether the window can be focused.
 
@@ -1747,7 +1747,7 @@ Returns `BrowserWindow[]` - All child windows.
 
 #### `win.setAutoHideCursor(autoHide)` _macOS_
 
-* `autoHide` Boolean
+* `autoHide` boolean
 
 Controls whether to hide cursor when typing.
 
@@ -1784,7 +1784,7 @@ Adds a window as a tab on this window, after the tab for the window instance.
 
 #### `win.setVibrancy(type)` _macOS_
 
-* `type` String | null - Can be `appearance-based`, `light`, `dark`, `titlebar`,
+* `type` string | null - Can be `appearance-based`, `light`, `dark`, `titlebar`,
   `selection`, `menu`, `popover`, `sidebar`, `medium-light`, `ultra-dark`, `header`, `sheet`, `window`, `hud`, `fullscreen-ui`, `tooltip`, `content`, `under-window`, or `under-page`. See
   the [macOS documentation][vibrancy-docs] for more details.
 

--- a/docs/api/client-request.md
+++ b/docs/api/client-request.md
@@ -9,20 +9,20 @@ interface and is therefore an [EventEmitter][event-emitter].
 
 ### `new ClientRequest(options)`
 
-* `options` (Object | String) - If `options` is a String, it is interpreted as
+* `options` (Object | string) - If `options` is a string, it is interpreted as
 the request URL. If it is an object, it is expected to fully specify an HTTP request via the
 following properties:
-  * `method` String (optional) - The HTTP request method. Defaults to the GET
+  * `method` string (optional) - The HTTP request method. Defaults to the GET
     method.
-  * `url` String (optional) - The request URL. Must be provided in the absolute
+  * `url` string (optional) - The request URL. Must be provided in the absolute
     form with the protocol scheme specified as http or https.
   * `session` Session (optional) - The [`Session`](session.md) instance with
     which the request is associated.
-  * `partition` String (optional) - The name of the [`partition`](session.md)
+  * `partition` string (optional) - The name of the [`partition`](session.md)
     with which the request is associated. Defaults to the empty string. The
     `session` option supersedes `partition`. Thus if a `session` is explicitly
     specified, `partition` is ignored.
-  * `credentials` String (optional) - Can be `include` or `omit`. Whether to
+  * `credentials` string (optional) - Can be `include` or `omit`. Whether to
     send [credentials](https://fetch.spec.whatwg.org/#credentials) with this
     request. If set to `include`, credentials from the session associated with
     the request will be used. If set to `omit`, credentials will not be sent
@@ -32,17 +32,17 @@ following properties:
     option of the same name. If this option is not specified, authentication
     data from the session will be sent, and cookies will not be sent (unless
     `useSessionCookies` is set).
-  * `useSessionCookies` Boolean (optional) - Whether to send cookies with this
+  * `useSessionCookies` boolean (optional) - Whether to send cookies with this
     request from the provided session. If `credentials` is specified, this
     option has no effect. Default is `false`.
-  * `protocol` String (optional) - Can be `http:` or `https:`. The protocol
+  * `protocol` string (optional) - Can be `http:` or `https:`. The protocol
     scheme in the form 'scheme:'. Defaults to 'http:'.
-  * `host` String (optional) - The server host provided as a concatenation of
+  * `host` string (optional) - The server host provided as a concatenation of
     the hostname and the port number 'hostname:port'.
-  * `hostname` String (optional) - The server host name.
+  * `hostname` string (optional) - The server host name.
   * `port` Integer (optional) - The server's listening port number.
-  * `path` String (optional) - The path part of the request URL.
-  * `redirect` String (optional) - Can be `follow`, `error` or `manual`. The
+  * `path` string (optional) - The path part of the request URL.
+  * `redirect` string (optional) - Can be `follow`, `error` or `manual`. The
     redirect mode for this request. When mode is `error`, any redirection will
     be aborted. When mode is `manual` the redirection will be cancelled unless
     [`request.followRedirect`](#requestfollowredirect) is invoked synchronously
@@ -77,21 +77,21 @@ Returns:
 Returns:
 
 * `authInfo` Object
-  * `isProxy` Boolean
-  * `scheme` String
-  * `host` String
+  * `isProxy` boolean
+  * `scheme` string
+  * `host` string
   * `port` Integer
-  * `realm` String
+  * `realm` string
 * `callback` Function
-  * `username` String (optional)
-  * `password` String (optional)
+  * `username` string (optional)
+  * `password` string (optional)
 
 Emitted when an authenticating proxy is asking for user credentials.
 
 The `callback` function is expected to be called back with user credentials:
 
-* `username` String
-* `password` String
+* `username` string
+* `password` string
 
 ```JavaScript
 request.on('login', (authInfo, callback) => {
@@ -145,9 +145,9 @@ event indicates that no more events will be emitted on either the `request` or
 Returns:
 
 * `statusCode` Integer
-* `method` String
-* `redirectUrl` String
-* `responseHeaders` Record<String, String[]>
+* `method` string
+* `redirectUrl` string
+* `responseHeaders` Record<string, string[]>
 
 Emitted when the server returns a redirect response (e.g. 301 Moved
 Permanently). Calling [`request.followRedirect`](#requestfollowredirect) will
@@ -159,7 +159,7 @@ continue with the redirection.  If this event is handled,
 
 #### `request.chunkedEncoding`
 
-A `Boolean` specifying whether the request will use HTTP chunked transfer encoding
+A `boolean` specifying whether the request will use HTTP chunked transfer encoding
 or not. Defaults to false. The property is readable and writable, however it can
 be set only before the first write operation as the HTTP headers are not yet put
 on the wire. Trying to set the `chunkedEncoding` property after the first write
@@ -173,12 +173,12 @@ internally buffered inside Electron process memory.
 
 #### `request.setHeader(name, value)`
 
-* `name` String - An extra HTTP header name.
-* `value` String - An extra HTTP header value.
+* `name` string - An extra HTTP header name.
+* `value` string - An extra HTTP header value.
 
 Adds an extra HTTP header. The header name will be issued as-is without
 lowercasing. It can be called only before first write. Calling this method after
-the first write will throw an error. If the passed value is not a `String`, its
+the first write will throw an error. If the passed value is not a `string`, its
 `toString()` method will be called to obtain the final value.
 
 Certain headers are restricted from being set by apps. These headers are
@@ -197,22 +197,22 @@ Additionally, setting the `Connection` header to the value `upgrade` is also dis
 
 #### `request.getHeader(name)`
 
-* `name` String - Specify an extra header name.
+* `name` string - Specify an extra header name.
 
-Returns `String` - The value of a previously set extra header name.
+Returns `string` - The value of a previously set extra header name.
 
 #### `request.removeHeader(name)`
 
-* `name` String - Specify an extra header name.
+* `name` string - Specify an extra header name.
 
 Removes a previously set extra header name. This method can be called only
 before first write. Trying to call it after the first write will throw an error.
 
 #### `request.write(chunk[, encoding][, callback])`
 
-* `chunk` (String | Buffer) - A chunk of the request body's data. If it is a
+* `chunk` (string | Buffer) - A chunk of the request body's data. If it is a
 string, it is converted into a Buffer using the specified encoding.
-* `encoding` String (optional) - Used to convert string chunks into Buffer
+* `encoding` string (optional) - Used to convert string chunks into Buffer
 objects. Defaults to 'utf-8'.
 * `callback` Function (optional) - Called after the write operation ends.
 
@@ -228,8 +228,8 @@ it is not allowed to add or remove a custom header.
 
 #### `request.end([chunk][, encoding][, callback])`
 
-* `chunk` (String | Buffer) (optional)
-* `encoding` String (optional)
+* `chunk` (string | Buffer) (optional)
+* `encoding` string (optional)
 * `callback` Function (optional)
 
 Sends the last chunk of the request data. Subsequent write or end operations
@@ -251,9 +251,9 @@ event.
 
 Returns `Object`:
 
-* `active` Boolean - Whether the request is currently active. If this is false
+* `active` boolean - Whether the request is currently active. If this is false
 no other properties will be set
-* `started` Boolean - Whether the upload has started. If this is false both
+* `started` boolean - Whether the upload has started. If this is false both
 `current` and `total` will be set to 0.
 * `current` Integer - The number of bytes that have been uploaded so far
 * `total` Integer - The number of bytes that will be uploaded this request

--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -10,7 +10,7 @@ you need to pass `selection` to each method:
 ```javascript
 const { clipboard } = require('electron')
 
-clipboard.writeText('Example String', 'selection')
+clipboard.writeText('Example string', 'selection')
 console.log(clipboard.readText('selection'))
 ```
 
@@ -22,9 +22,9 @@ The `clipboard` module has the following methods:
 
 ### `clipboard.readText([type])`
 
-* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+* `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
-Returns `String` - The content in the clipboard as plain text.
+Returns `string` - The content in the clipboard as plain text.
 
 ```js
 const { clipboard } = require('electron')
@@ -38,8 +38,8 @@ console.log(text)
 
 ### `clipboard.writeText(text[, type])`
 
-* `text` String
-* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+* `text` string
+* `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Writes the `text` into the clipboard as plain text.
 
@@ -52,9 +52,9 @@ clipboard.writeText(text)
 
 ### `clipboard.readHTML([type])`
 
-* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+* `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
-Returns `String` - The content in the clipboard as markup.
+Returns `string` - The content in the clipboard as markup.
 
 ```js
 const { clipboard } = require('electron')
@@ -68,8 +68,8 @@ console.log(html)
 
 ### `clipboard.writeHTML(markup[, type])`
 
-* `markup` String
-* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+* `markup` string
+* `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Writes `markup` to the clipboard.
 
@@ -81,22 +81,22 @@ clipboard.writeHTML('<b>Hi</b')
 
 ### `clipboard.readImage([type])`
 
-* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+* `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Returns [`NativeImage`](native-image.md) - The image content in the clipboard.
 
 ### `clipboard.writeImage(image[, type])`
 
 * `image` [NativeImage](native-image.md)
-* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+* `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Writes `image` to the clipboard.
 
 ### `clipboard.readRTF([type])`
 
-* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+* `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
-Returns `String` - The content in the clipboard as RTF.
+Returns `string` - The content in the clipboard as RTF.
 
 ```js
 const { clipboard } = require('electron')
@@ -110,8 +110,8 @@ console.log(rtf)
 
 ### `clipboard.writeRTF(text[, type])`
 
-* `text` String
-* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+* `text` string
+* `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Writes the `text` into the clipboard in RTF.
 
@@ -126,8 +126,8 @@ clipboard.writeRTF(rtf)
 
 Returns `Object`:
 
-* `title` String
-* `url` String
+* `title` string
+* `url` string
 
 Returns an Object containing `title` and `url` keys representing the bookmark in
 the clipboard. The `title` and `url` values will be empty strings when the
@@ -135,9 +135,9 @@ bookmark is unavailable.
 
 ### `clipboard.writeBookmark(title, url[, type])` _macOS_ _Windows_
 
-* `title` String
-* `url` String
-* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+* `title` string
+* `url` string
+* `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Writes the `title` and `url` into the clipboard as a bookmark.
 
@@ -156,28 +156,28 @@ clipboard.writeBookmark({
 
 ### `clipboard.readFindText()` _macOS_
 
-Returns `String` - The text on the find pasteboard, which is the pasteboard that holds information about the current state of the active application’s find panel.
+Returns `string` - The text on the find pasteboard, which is the pasteboard that holds information about the current state of the active application’s find panel.
 
 This method uses synchronous IPC when called from the renderer process.
 The cached value is reread from the find pasteboard whenever the application is activated.
 
 ### `clipboard.writeFindText(text)` _macOS_
 
-* `text` String
+* `text` string
 
 Writes the `text` into the find pasteboard (the pasteboard that holds information about the current state of the active application’s find panel) as plain text. This method uses synchronous IPC when called from the renderer process.
 
 ### `clipboard.clear([type])`
 
-* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+* `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Clears the clipboard content.
 
 ### `clipboard.availableFormats([type])`
 
-* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+* `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
-Returns `String[]` - An array of supported formats for the clipboard `type`.
+Returns `string[]` - An array of supported formats for the clipboard `type`.
 
 ```js
 const { clipboard } = require('electron')
@@ -189,10 +189,10 @@ console.log(formats)
 
 ### `clipboard.has(format[, type])` _Experimental_
 
-* `format` String
-* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+* `format` string
+* `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
-Returns `Boolean` - Whether the clipboard supports the specified `format`.
+Returns `boolean` - Whether the clipboard supports the specified `format`.
 
 ```js
 const { clipboard } = require('electron')
@@ -204,13 +204,13 @@ console.log(hasFormat)
 
 ### `clipboard.read(format)` _Experimental_
 
-* `format` String
+* `format` string
 
-Returns `String` - Reads `format` type from the clipboard.
+Returns `string` - Reads `format` type from the clipboard.
 
 ### `clipboard.readBuffer(format)` _Experimental_
 
-* `format` String
+* `format` string
 
 Returns `Buffer` - Reads `format` type from the clipboard.
 
@@ -228,9 +228,9 @@ console.log(buffer.equals(out))
 
 ### `clipboard.writeBuffer(format, buffer[, type])` _Experimental_
 
-* `format` String
+* `format` string
 * `buffer` Buffer
-* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+* `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Writes the `buffer` into the clipboard as `format`.
 
@@ -244,12 +244,12 @@ clipboard.writeBuffer('public.utf8-plain-text', buffer)
 ### `clipboard.write(data[, type])`
 
 * `data` Object
-  * `text` String (optional)
-  * `html` String (optional)
+  * `text` string (optional)
+  * `html` string (optional)
   * `image` [NativeImage](native-image.md) (optional)
-  * `rtf` String (optional)
-  * `bookmark` String (optional) - The title of the URL at `text`.
-* `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
+  * `rtf` string (optional)
+  * `bookmark` string (optional) - The title of the URL at `text`.
+* `type` string (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.
 
 Writes `data` to the clipboard.
 

--- a/docs/api/command-line.md
+++ b/docs/api/command-line.md
@@ -19,8 +19,8 @@ document.
 
 #### `commandLine.appendSwitch(switch[, value])`
 
-* `switch` String - A command-line switch, without the leading `--`
-* `value` String (optional) - A value for the given switch
+* `switch` string - A command-line switch, without the leading `--`
+* `value` string (optional) - A value for the given switch
 
 Append a switch (with optional `value`) to Chromium's command line.
 
@@ -29,7 +29,7 @@ control Chromium's behavior.
 
 #### `commandLine.appendArgument(value)`
 
-* `value` String - The argument to append to the command line
+* `value` string - The argument to append to the command line
 
 Append an argument to Chromium's command line. The argument will be quoted
 correctly. Switches will precede arguments regardless of appending order.
@@ -41,14 +41,14 @@ control Chromium's behavior.
 
 #### `commandLine.hasSwitch(switch)`
 
-* `switch` String - A command-line switch
+* `switch` string - A command-line switch
 
-Returns `Boolean` - Whether the command-line switch is present.
+Returns `boolean` - Whether the command-line switch is present.
 
 #### `commandLine.getSwitchValue(switch)`
 
-* `switch` String - A command-line switch
+* `switch` string - A command-line switch
 
-Returns `String` - The command-line switch value.
+Returns `string` - The command-line switch value.
 
 **Note:** When the switch is not present or has no value, it returns empty string.

--- a/docs/api/content-tracing.md
+++ b/docs/api/content-tracing.md
@@ -32,7 +32,7 @@ The `contentTracing` module has the following methods:
 
 ### `contentTracing.getCategories()`
 
-Returns `Promise<String[]>` - resolves with an array of category groups once all child processes have acknowledged the `getCategories` request
+Returns `Promise<string[]>` - resolves with an array of category groups once all child processes have acknowledged the `getCategories` request
 
 Get a set of category groups. The category groups can change as new code paths
 are reached. See also the [list of built-in tracing
@@ -57,9 +57,9 @@ only one trace operation can be in progress at a time.
 
 ### `contentTracing.stopRecording([resultFilePath])`
 
-* `resultFilePath` String (optional)
+* `resultFilePath` string (optional)
 
-Returns `Promise<String>` - resolves with a path to a file that contains the traced data once all child processes have acknowledged the `stopRecording` request
+Returns `Promise<string>` - resolves with a path to a file that contains the traced data once all child processes have acknowledged the `stopRecording` request
 
 Stop recording on all processes.
 
@@ -77,8 +77,8 @@ will be returned in the promise.
 
 Returns `Promise<Object>` - Resolves with an object containing the `value` and `percentage` of trace buffer maximum usage
 
-* `value` Number
-* `percentage` Number
+* `value` number
+* `percentage` number
 
 Get the maximum usage across processes of trace buffer as a percentage of the
 full state.

--- a/docs/api/context-bridge.md
+++ b/docs/api/context-bridge.md
@@ -43,15 +43,15 @@ The `contextBridge` module has the following methods:
 
 ### `contextBridge.exposeInMainWorld(apiKey, api)` _Experimental_
 
-* `apiKey` String - The key to inject the API onto `window` with.  The API will be accessible on `window[apiKey]`.
-* `api` Record<String, any> - Your API object, more information on what this API can be and how it works is available below.
+* `apiKey` string - The key to inject the API onto `window` with.  The API will be accessible on `window[apiKey]`.
+* `api` Record<string, any> - Your API object, more information on what this API can be and how it works is available below.
 
 ## Usage
 
 ### API Objects
 
 The `api` object provided to [`exposeInMainWorld`](#contextbridgeexposeinmainworldapikey-api-experimental) must be an object
-whose keys are strings and values are a `Function`, `String`, `Number`, `Array`, `Boolean`, or another nested object that meets the same conditions.
+whose keys are strings and values are a `Function`, `string`, `number`, `Array`, `boolean`, or another nested object that meets the same conditions.
 
 `Function` values are proxied to the other context and all other values are **copied** and **frozen**. Any data / primitives sent in
 the API object become immutable and updates on either side of the bridge do not result in an update on the other side.
@@ -97,9 +97,9 @@ has been included below for completeness:
 
 | Type | Complexity | Parameter Support | Return Value Support | Limitations |
 | ---- | ---------- | ----------------- | -------------------- | ----------- |
-| `String` | Simple | ✅ | ✅ | N/A |
-| `Number` | Simple | ✅ | ✅ | N/A |
-| `Boolean` | Simple | ✅ | ✅ | N/A |
+| `string` | Simple | ✅ | ✅ | N/A |
+| `number` | Simple | ✅ | ✅ | N/A |
+| `boolean` | Simple | ✅ | ✅ | N/A |
 | `Object` | Complex | ✅ | ✅ | Keys must be supported using only "Simple" types in this table.  Values must be supported in this table.  Prototype modifications are dropped.  Sending custom classes will copy values but not the prototype. |
 | `Array` | Complex | ✅ | ✅ | Same limitations as the `Object` type |
 | `Error` | Complex | ✅ | ✅ | Errors that are thrown are also copied, this can result in the message and stack trace of the error changing slightly due to being thrown in a different context |

--- a/docs/api/cookies.md
+++ b/docs/api/cookies.md
@@ -47,7 +47,7 @@ The following events are available on instances of `Cookies`:
 
 * `event` Event
 * `cookie` [Cookie](structures/cookie.md) - The cookie that was changed.
-* `cause` String - The cause of the change with one of the following values:
+* `cause` string - The cause of the change with one of the following values:
   * `explicit` - The cookie was changed directly by a consumer's action.
   * `overwrite` - The cookie was automatically removed due to an insert
     operation that overwrote it.
@@ -55,7 +55,7 @@ The following events are available on instances of `Cookies`:
   * `evicted` - The cookie was automatically evicted during garbage collection.
   * `expired-overwrite` - The cookie was overwritten with an already-expired
     expiration date.
-* `removed` Boolean - `true` if the cookie was removed, `false` otherwise.
+* `removed` boolean - `true` if the cookie was removed, `false` otherwise.
 
 Emitted when a cookie is changed because it was added, edited, removed, or
 expired.
@@ -67,14 +67,14 @@ The following methods are available on instances of `Cookies`:
 #### `cookies.get(filter)`
 
 * `filter` Object
-  * `url` String (optional) - Retrieves cookies which are associated with
+  * `url` string (optional) - Retrieves cookies which are associated with
     `url`. Empty implies retrieving cookies of all URLs.
-  * `name` String (optional) - Filters cookies by name.
-  * `domain` String (optional) - Retrieves cookies whose domains match or are
+  * `name` string (optional) - Filters cookies by name.
+  * `domain` string (optional) - Retrieves cookies whose domains match or are
     subdomains of `domains`.
-  * `path` String (optional) - Retrieves cookies whose path matches `path`.
-  * `secure` Boolean (optional) - Filters cookies by their Secure property.
-  * `session` Boolean (optional) - Filters out session or persistent cookies.
+  * `path` string (optional) - Retrieves cookies whose path matches `path`.
+  * `secure` boolean (optional) - Filters cookies by their Secure property.
+  * `session` boolean (optional) - Filters out session or persistent cookies.
 
 Returns `Promise<Cookie[]>` - A promise which resolves an array of cookie objects.
 
@@ -84,19 +84,19 @@ the response.
 #### `cookies.set(details)`
 
 * `details` Object
-  * `url` String - The URL to associate the cookie with. The promise will be rejected if the URL is invalid.
-  * `name` String (optional) - The name of the cookie. Empty by default if omitted.
-  * `value` String (optional) - The value of the cookie. Empty by default if omitted.
-  * `domain` String (optional) - The domain of the cookie; this will be normalized with a preceding dot so that it's also valid for subdomains. Empty by default if omitted.
-  * `path` String (optional) - The path of the cookie. Empty by default if omitted.
-  * `secure` Boolean (optional) - Whether the cookie should be marked as Secure. Defaults to
+  * `url` string - The URL to associate the cookie with. The promise will be rejected if the URL is invalid.
+  * `name` string (optional) - The name of the cookie. Empty by default if omitted.
+  * `value` string (optional) - The value of the cookie. Empty by default if omitted.
+  * `domain` string (optional) - The domain of the cookie; this will be normalized with a preceding dot so that it's also valid for subdomains. Empty by default if omitted.
+  * `path` string (optional) - The path of the cookie. Empty by default if omitted.
+  * `secure` boolean (optional) - Whether the cookie should be marked as Secure. Defaults to
     false.
-  * `httpOnly` Boolean (optional) - Whether the cookie should be marked as HTTP only.
+  * `httpOnly` boolean (optional) - Whether the cookie should be marked as HTTP only.
     Defaults to false.
   * `expirationDate` Double (optional) - The expiration date of the cookie as the number of
     seconds since the UNIX epoch. If omitted then the cookie becomes a session
     cookie and will not be retained between sessions.
-  * `sameSite` String (optional) - The [Same Site](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies) policy to apply to this cookie.  Can be `unspecified`, `no_restriction`, `lax` or `strict`.  Default is `no_restriction`.
+  * `sameSite` string (optional) - The [Same Site](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies) policy to apply to this cookie.  Can be `unspecified`, `no_restriction`, `lax` or `strict`.  Default is `no_restriction`.
 
 Returns `Promise<void>` - A promise which resolves when the cookie has been set
 
@@ -104,8 +104,8 @@ Sets a cookie with `details`.
 
 #### `cookies.remove(url, name)`
 
-* `url` String - The URL associated with the cookie.
-* `name` String - The name of cookie to remove.
+* `url` string - The URL associated with the cookie.
+* `name` string - The name of cookie to remove.
 
 Returns `Promise<void>` - A promise which resolves when the cookie has been removed
 

--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -77,28 +77,28 @@ The `crashReporter` module has the following methods:
 ### `crashReporter.start(options)`
 
 * `options` Object
-  * `submitURL` String - URL that crash reports will be sent to as POST.
-  * `productName` String (optional) - Defaults to `app.name`.
-  * `companyName` String (optional) _Deprecated_ - Deprecated alias for
+  * `submitURL` string - URL that crash reports will be sent to as POST.
+  * `productName` string (optional) - Defaults to `app.name`.
+  * `companyName` string (optional) _Deprecated_ - Deprecated alias for
     `{ globalExtra: { _companyName: ... } }`.
-  * `uploadToServer` Boolean (optional) - Whether crash reports should be sent
+  * `uploadToServer` boolean (optional) - Whether crash reports should be sent
     to the server. If false, crash reports will be collected and stored in the
     crashes directory, but not uploaded. Default is `true`.
-  * `ignoreSystemCrashHandler` Boolean (optional) - If true, crashes generated
+  * `ignoreSystemCrashHandler` boolean (optional) - If true, crashes generated
     in the main process will not be forwarded to the system crash handler.
     Default is `false`.
-  * `rateLimit` Boolean (optional) _macOS_ _Windows_ - If true, limit the
+  * `rateLimit` boolean (optional) _macOS_ _Windows_ - If true, limit the
     number of crashes uploaded to 1/hour. Default is `false`.
-  * `compress` Boolean (optional) - If true, crash reports will be compressed
+  * `compress` boolean (optional) - If true, crash reports will be compressed
     and uploaded with `Content-Encoding: gzip`. Default is `true`.
-  * `extra` Record<String, String> (optional) - Extra string key/value
+  * `extra` Record<string, string> (optional) - Extra string key/value
     annotations that will be sent along with crash reports that are generated
     in the main process. Only string values are supported. Crashes generated in
     child processes will not contain these extra
     parameters to crash reports generated from child processes, call
     [`addExtraParameter`](#crashreporteraddextraparameterkey-value) from the
     child process.
-  * `globalExtra` Record<String, String> (optional) - Extra string key/value
+  * `globalExtra` Record<string, string> (optional) - Extra string key/value
     annotations that will be sent along with any crash reports generated in any
     process. These annotations cannot be changed once the crash reporter has
     been started. If a key is present in both the global extra parameters and
@@ -150,14 +150,14 @@ ID.
 
 ### `crashReporter.getUploadToServer()`
 
-Returns `Boolean` - Whether reports should be submitted to the server. Set through
+Returns `boolean` - Whether reports should be submitted to the server. Set through
 the `start` method or `setUploadToServer`.
 
 **Note:** Calling this method from the renderer process is deprecated.
 
 ### `crashReporter.setUploadToServer(uploadToServer)`
 
-* `uploadToServer` Boolean - Whether reports should be submitted to the server.
+* `uploadToServer` boolean - Whether reports should be submitted to the server.
 
 This would normally be controlled by user preferences. This has no effect if
 called before `start` is called.
@@ -166,14 +166,14 @@ called before `start` is called.
 
 ### `crashReporter.getCrashesDirectory()` _Deprecated_
 
-Returns `String` - The directory where crashes are temporarily stored before being uploaded.
+Returns `string` - The directory where crashes are temporarily stored before being uploaded.
 
 **Note:** This method is deprecated, use `app.getPath('crashDumps')` instead.
 
 ### `crashReporter.addExtraParameter(key, value)`
 
-* `key` String - Parameter key, must be no longer than 39 bytes.
-* `value` String - Parameter value, must be no longer than 127 bytes.
+* `key` string - Parameter key, must be no longer than 39 bytes.
+* `value` string - Parameter value, must be no longer than 127 bytes.
 
 Set an extra parameter to be sent with the crash report. The values specified
 here will be sent in addition to any values set via the `extra` option when
@@ -199,29 +199,29 @@ your crash reporting backend you should stitch together keys in this format.
 
 ### `crashReporter.removeExtraParameter(key)`
 
-* `key` String - Parameter key, must be no longer than 39 bytes.
+* `key` string - Parameter key, must be no longer than 39 bytes.
 
 Remove an extra parameter from the current set of parameters. Future crashes
 will not include this parameter.
 
 ### `crashReporter.getParameters()`
 
-Returns `Record<String, String>` - The current 'extra' parameters of the crash reporter.
+Returns `Record<string, string>` - The current 'extra' parameters of the crash reporter.
 
 ## Crash Report Payload
 
 The crash reporter will send the following data to the `submitURL` as
 a `multipart/form-data` `POST`:
 
-* `ver` String - The version of Electron.
-* `platform` String - e.g. 'win32'.
-* `process_type` String - e.g. 'renderer'.
-* `guid` String - e.g. '5e1286fc-da97-479e-918b-6bfb0c3d1c72'.
-* `_version` String - The version in `package.json`.
-* `_productName` String - The product name in the `crashReporter` `options`
+* `ver` string - The version of Electron.
+* `platform` string - e.g. 'win32'.
+* `process_type` string - e.g. 'renderer'.
+* `guid` string - e.g. '5e1286fc-da97-479e-918b-6bfb0c3d1c72'.
+* `_version` string - The version in `package.json`.
+* `_productName` string - The product name in the `crashReporter` `options`
   object.
-* `prod` String - Name of the underlying product. In this case Electron.
-* `_companyName` String - The company name in the `crashReporter` `options`
+* `prod` string - Name of the underlying product. In this case Electron.
+* `_companyName` string - The company name in the `crashReporter` `options`
   object.
 * `upload_file_minidump` File - The crash report in the format of `minidump`.
 * All level one properties of the `extra` object in the `crashReporter`

--- a/docs/api/debugger.md
+++ b/docs/api/debugger.md
@@ -39,7 +39,7 @@ win.webContents.debugger.sendCommand('Network.enable')
 Returns:
 
 * `event` Event
-* `reason` String - Reason for detaching debugger.
+* `reason` string - Reason for detaching debugger.
 
 Emitted when the debugging session is terminated. This happens either when
 `webContents` is closed or devtools is invoked for the attached `webContents`.
@@ -49,10 +49,10 @@ Emitted when the debugging session is terminated. This happens either when
 Returns:
 
 * `event` Event
-* `method` String - Method name.
+* `method` string - Method name.
 * `params` any - Event parameters defined by the 'parameters'
    attribute in the remote debugging protocol.
-* `sessionId` String - Unique identifier of attached debugging session,
+* `sessionId` string - Unique identifier of attached debugging session,
    will match the value sent from `debugger.sendCommand`.
 
 Emitted whenever the debugging target issues an instrumentation event.
@@ -64,13 +64,13 @@ Emitted whenever the debugging target issues an instrumentation event.
 
 #### `debugger.attach([protocolVersion])`
 
-* `protocolVersion` String (optional) - Requested debugging protocol version.
+* `protocolVersion` string (optional) - Requested debugging protocol version.
 
 Attaches the debugger to the `webContents`.
 
 #### `debugger.isAttached()`
 
-Returns `Boolean` - Whether a debugger is attached to the `webContents`.
+Returns `boolean` - Whether a debugger is attached to the `webContents`.
 
 #### `debugger.detach()`
 
@@ -78,10 +78,10 @@ Detaches the debugger from the `webContents`.
 
 #### `debugger.sendCommand(method[, commandParams, sessionId])`
 
-* `method` String - Method name, should be one of the methods defined by the
+* `method` string - Method name, should be one of the methods defined by the
    [remote debugging protocol][rdp].
 * `commandParams` any (optional) - JSON object with request parameters.
-* `sessionId` String (optional) - send command to the target with associated
+* `sessionId` string (optional) - send command to the target with associated
    debugging session id. The initial value can be obtained by sending
    [Target.attachToTarget][attachToTarget] message.
 

--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -79,13 +79,13 @@ The `desktopCapturer` module has the following methods:
 ### `desktopCapturer.getSources(options)`
 
 * `options` Object
-  * `types` String[] - An array of Strings that lists the types of desktop sources
+  * `types` string[] - An array of strings that lists the types of desktop sources
     to be captured, available types are `screen` and `window`.
   * `thumbnailSize` [Size](structures/size.md) (optional) - The size that the media source thumbnail
     should be scaled to. Default is `150` x `150`. Set width or height to 0 when you do not need
     the thumbnails. This will save the processing time required for capturing the content of each
     window and screen.
-  * `fetchWindowIcons` Boolean (optional) - Set to true to enable fetching window icons. The default
+  * `fetchWindowIcons` boolean (optional) - Set to true to enable fetching window icons. The default
     value is false. When false the appIcon property of the sources return null. Same if a source has
     the type screen.
 

--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -19,12 +19,12 @@ The `dialog` module has the following methods:
 
 * `browserWindow` [BrowserWindow](browser-window.md) (optional)
 * `options` Object
-  * `title` String (optional)
-  * `defaultPath` String (optional)
-  * `buttonLabel` String (optional) - Custom label for the confirmation button, when
+  * `title` string (optional)
+  * `defaultPath` string (optional)
+  * `buttonLabel` string (optional) - Custom label for the confirmation button, when
     left empty the default label will be used.
   * `filters` [FileFilter[]](structures/file-filter.md) (optional)
-  * `properties` String[] (optional) - Contains which features the dialog should
+  * `properties` string[] (optional) - Contains which features the dialog should
     use. The following values are supported:
     * `openFile` - Allow files to be selected.
     * `openDirectory` - Allow directories to be selected.
@@ -41,11 +41,11 @@ The `dialog` module has the following methods:
     * `treatPackageAsDirectory` _macOS_ - Treat packages, such as `.app` folders,
       as a directory instead of a file.
     * `dontAddToRecent` _Windows_ - Do not add the item being opened to the recent documents list.
-  * `message` String (optional) _macOS_ - Message to display above input
+  * `message` string (optional) _macOS_ - Message to display above input
     boxes.
-  * `securityScopedBookmarks` Boolean (optional) _macOS_ _mas_ - Create [security scoped bookmarks](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) when packaged for the Mac App Store.
+  * `securityScopedBookmarks` boolean (optional) _macOS_ _mas_ - Create [security scoped bookmarks](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) when packaged for the Mac App Store.
 
-Returns `String[] | undefined`, the file paths chosen by the user; if the dialog is cancelled it returns `undefined`.
+Returns `string[] | undefined`, the file paths chosen by the user; if the dialog is cancelled it returns `undefined`.
 
 The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal.
 
@@ -82,12 +82,12 @@ dialog.showOpenDialogSync(mainWindow, {
 
 * `browserWindow` [BrowserWindow](browser-window.md) (optional)
 * `options` Object
-  * `title` String (optional)
-  * `defaultPath` String (optional)
-  * `buttonLabel` String (optional) - Custom label for the confirmation button, when
+  * `title` string (optional)
+  * `defaultPath` string (optional)
+  * `buttonLabel` string (optional) - Custom label for the confirmation button, when
     left empty the default label will be used.
   * `filters` [FileFilter[]](structures/file-filter.md) (optional)
-  * `properties` String[] (optional) - Contains which features the dialog should
+  * `properties` string[] (optional) - Contains which features the dialog should
     use. The following values are supported:
     * `openFile` - Allow files to be selected.
     * `openDirectory` - Allow directories to be selected.
@@ -104,15 +104,15 @@ dialog.showOpenDialogSync(mainWindow, {
     * `treatPackageAsDirectory` _macOS_ - Treat packages, such as `.app` folders,
       as a directory instead of a file.
     * `dontAddToRecent` _Windows_ - Do not add the item being opened to the recent documents list.
-  * `message` String (optional) _macOS_ - Message to display above input
+  * `message` string (optional) _macOS_ - Message to display above input
     boxes.
-  * `securityScopedBookmarks` Boolean (optional) _macOS_ _mas_ - Create [security scoped bookmarks](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) when packaged for the Mac App Store.
+  * `securityScopedBookmarks` boolean (optional) _macOS_ _mas_ - Create [security scoped bookmarks](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) when packaged for the Mac App Store.
 
 Returns `Promise<Object>` - Resolve with an object containing the following:
 
-* `canceled` Boolean - whether or not the dialog was canceled.
-* `filePaths` String[] - An array of file paths chosen by the user. If the dialog is cancelled this will be an empty array.
-* `bookmarks` String[] (optional) _macOS_ _mas_ - An array matching the `filePaths` array of base64 encoded strings which contains security scoped bookmark data. `securityScopedBookmarks` must be enabled for this to be populated. (For return values, see [table here](#bookmarks-array).)
+* `canceled` boolean - whether or not the dialog was canceled.
+* `filePaths` string[] - An array of file paths chosen by the user. If the dialog is cancelled this will be an empty array.
+* `bookmarks` string[] (optional) _macOS_ _mas_ - An array matching the `filePaths` array of base64 encoded strings which contains security scoped bookmark data. `securityScopedBookmarks` must be enabled for this to be populated. (For return values, see [table here](#bookmarks-array).)
 
 The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal.
 
@@ -154,27 +154,27 @@ dialog.showOpenDialog(mainWindow, {
 
 * `browserWindow` [BrowserWindow](browser-window.md) (optional)
 * `options` Object
-  * `title` String (optional)
-  * `defaultPath` String (optional) - Absolute directory path, absolute file
+  * `title` string (optional)
+  * `defaultPath` string (optional) - Absolute directory path, absolute file
     path, or file name to use by default.
-  * `buttonLabel` String (optional) - Custom label for the confirmation button, when
+  * `buttonLabel` string (optional) - Custom label for the confirmation button, when
     left empty the default label will be used.
   * `filters` [FileFilter[]](structures/file-filter.md) (optional)
-  * `message` String (optional) _macOS_ - Message to display above text fields.
-  * `nameFieldLabel` String (optional) _macOS_ - Custom label for the text
+  * `message` string (optional) _macOS_ - Message to display above text fields.
+  * `nameFieldLabel` string (optional) _macOS_ - Custom label for the text
     displayed in front of the filename text field.
-  * `showsTagField` Boolean (optional) _macOS_ - Show the tags input box,
+  * `showsTagField` boolean (optional) _macOS_ - Show the tags input box,
     defaults to `true`.
-  * `properties` String[] (optional)
+  * `properties` string[] (optional)
     * `showHiddenFiles` - Show hidden files in dialog.
     * `createDirectory` _macOS_ - Allow creating new directories from dialog.
     * `treatPackageAsDirectory` _macOS_ - Treat packages, such as `.app` folders,
       as a directory instead of a file.
     * `showOverwriteConfirmation` _Linux_ - Sets whether the user will be presented a confirmation dialog if the user types a file name that already exists.
     * `dontAddToRecent` _Windows_ - Do not add the item being saved to the recent documents list.
-  * `securityScopedBookmarks` Boolean (optional) _macOS_ _mas_ - Create a [security scoped bookmark](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) when packaged for the Mac App Store. If this option is enabled and the file doesn't already exist a blank file will be created at the chosen path.
+  * `securityScopedBookmarks` boolean (optional) _macOS_ _mas_ - Create a [security scoped bookmark](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) when packaged for the Mac App Store. If this option is enabled and the file doesn't already exist a blank file will be created at the chosen path.
 
-Returns `String | undefined`, the path of the file chosen by the user; if the dialog is cancelled it returns `undefined`.
+Returns `string | undefined`, the path of the file chosen by the user; if the dialog is cancelled it returns `undefined`.
 
 The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal.
 
@@ -185,29 +185,29 @@ The `filters` specifies an array of file types that can be displayed, see
 
 * `browserWindow` [BrowserWindow](browser-window.md) (optional)
 * `options` Object
-  * `title` String (optional)
-  * `defaultPath` String (optional) - Absolute directory path, absolute file
+  * `title` string (optional)
+  * `defaultPath` string (optional) - Absolute directory path, absolute file
     path, or file name to use by default.
-  * `buttonLabel` String (optional) - Custom label for the confirmation button, when
+  * `buttonLabel` string (optional) - Custom label for the confirmation button, when
     left empty the default label will be used.
   * `filters` [FileFilter[]](structures/file-filter.md) (optional)
-  * `message` String (optional) _macOS_ - Message to display above text fields.
-  * `nameFieldLabel` String (optional) _macOS_ - Custom label for the text
+  * `message` string (optional) _macOS_ - Message to display above text fields.
+  * `nameFieldLabel` string (optional) _macOS_ - Custom label for the text
     displayed in front of the filename text field.
-  * `showsTagField` Boolean (optional) _macOS_ - Show the tags input box, defaults to `true`.
-  * `properties` String[] (optional)
+  * `showsTagField` boolean (optional) _macOS_ - Show the tags input box, defaults to `true`.
+  * `properties` string[] (optional)
     * `showHiddenFiles` - Show hidden files in dialog.
     * `createDirectory` _macOS_ - Allow creating new directories from dialog.
     * `treatPackageAsDirectory` _macOS_ - Treat packages, such as `.app` folders,
       as a directory instead of a file.
     * `showOverwriteConfirmation` _Linux_ - Sets whether the user will be presented a confirmation dialog if the user types a file name that already exists.
     * `dontAddToRecent` _Windows_ - Do not add the item being saved to the recent documents list.
-  * `securityScopedBookmarks` Boolean (optional) _macOS_ _mas_ - Create a [security scoped bookmark](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) when packaged for the Mac App Store. If this option is enabled and the file doesn't already exist a blank file will be created at the chosen path.
+  * `securityScopedBookmarks` boolean (optional) _macOS_ _mas_ - Create a [security scoped bookmark](https://developer.apple.com/library/content/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html#//apple_ref/doc/uid/TP40011183-CH3-SW16) when packaged for the Mac App Store. If this option is enabled and the file doesn't already exist a blank file will be created at the chosen path.
 
 Returns `Promise<Object>` - Resolve with an object containing the following:
-  * `canceled` Boolean - whether or not the dialog was canceled.
-  * `filePath` String (optional) - If the dialog is canceled, this will be `undefined`.
-  * `bookmark` String (optional) _macOS_ _mas_ - Base64 encoded string which contains the security scoped bookmark data for the saved file. `securityScopedBookmarks` must be enabled for this to be present. (For return values, see [table here](#bookmarks-array).)
+  * `canceled` boolean - whether or not the dialog was canceled.
+  * `filePath` string (optional) - If the dialog is canceled, this will be `undefined`.
+  * `bookmark` string (optional) _macOS_ _mas_ - Base64 encoded string which contains the security scoped bookmark data for the saved file. `securityScopedBookmarks` must be enabled for this to be present. (For return values, see [table here](#bookmarks-array).)
 
 The `browserWindow` argument allows the dialog to attach itself to a parent window, making it modal.
 
@@ -221,32 +221,32 @@ expanding and collapsing the dialog.
 
 * `browserWindow` [BrowserWindow](browser-window.md) (optional)
 * `options` Object
-  * `type` String (optional) - Can be `"none"`, `"info"`, `"error"`, `"question"` or
+  * `type` string (optional) - Can be `"none"`, `"info"`, `"error"`, `"question"` or
   `"warning"`. On Windows, `"question"` displays the same icon as `"info"`, unless
   you set an icon using the `"icon"` option. On macOS, both `"warning"` and
   `"error"` display the same warning icon.
-  * `buttons` String[] (optional) - Array of texts for buttons. On Windows, an empty array
+  * `buttons` string[] (optional) - Array of texts for buttons. On Windows, an empty array
     will result in one button labeled "OK".
   * `defaultId` Integer (optional) - Index of the button in the buttons array which will
     be selected by default when the message box opens.
-  * `title` String (optional) - Title of the message box, some platforms will not show it.
-  * `message` String - Content of the message box.
-  * `detail` String (optional) - Extra information of the message.
-  * `checkboxLabel` String (optional) - If provided, the message box will
+  * `title` string (optional) - Title of the message box, some platforms will not show it.
+  * `message` string - Content of the message box.
+  * `detail` string (optional) - Extra information of the message.
+  * `checkboxLabel` string (optional) - If provided, the message box will
     include a checkbox with the given label.
-  * `checkboxChecked` Boolean (optional) - Initial checked state of the
+  * `checkboxChecked` boolean (optional) - Initial checked state of the
     checkbox. `false` by default.
-  * `icon` ([NativeImage](native-image.md) | String) (optional)
+  * `icon` ([NativeImage](native-image.md) | string) (optional)
   * `cancelId` Integer (optional) - The index of the button to be used to cancel the dialog, via
     the `Esc` key. By default this is assigned to the first button with "cancel" or "no" as the
     label. If no such labeled buttons exist and this option is not set, `0` will be used as the
     return value.
-  * `noLink` Boolean (optional) - On Windows Electron will try to figure out which one of
+  * `noLink` boolean (optional) - On Windows Electron will try to figure out which one of
     the `buttons` are common buttons (like "Cancel" or "Yes"), and show the
     others as command links in the dialog. This can make the dialog appear in
     the style of modern Windows apps. If you don't like this behavior, you can
     set `noLink` to `true`.
-  * `normalizeAccessKeys` Boolean (optional) - Normalize the keyboard access keys
+  * `normalizeAccessKeys` boolean (optional) - Normalize the keyboard access keys
     across platforms. Default is `false`. Enabling this assumes `&` is used in
     the button labels for the placement of the keyboard shortcut access key
     and labels will be converted so they work correctly on each platform, `&`
@@ -267,32 +267,32 @@ If `browserWindow` is not shown dialog will not be attached to it. In such case 
 
 * `browserWindow` [BrowserWindow](browser-window.md) (optional)
 * `options` Object
-  * `type` String (optional) - Can be `"none"`, `"info"`, `"error"`, `"question"` or
+  * `type` string (optional) - Can be `"none"`, `"info"`, `"error"`, `"question"` or
   `"warning"`. On Windows, `"question"` displays the same icon as `"info"`, unless
   you set an icon using the `"icon"` option. On macOS, both `"warning"` and
   `"error"` display the same warning icon.
-  * `buttons` String[] (optional) - Array of texts for buttons. On Windows, an empty array
+  * `buttons` string[] (optional) - Array of texts for buttons. On Windows, an empty array
     will result in one button labeled "OK".
   * `defaultId` Integer (optional) - Index of the button in the buttons array which will
     be selected by default when the message box opens.
-  * `title` String (optional) - Title of the message box, some platforms will not show it.
-  * `message` String - Content of the message box.
-  * `detail` String (optional) - Extra information of the message.
-  * `checkboxLabel` String (optional) - If provided, the message box will
+  * `title` string (optional) - Title of the message box, some platforms will not show it.
+  * `message` string - Content of the message box.
+  * `detail` string (optional) - Extra information of the message.
+  * `checkboxLabel` string (optional) - If provided, the message box will
     include a checkbox with the given label.
-  * `checkboxChecked` Boolean (optional) - Initial checked state of the
+  * `checkboxChecked` boolean (optional) - Initial checked state of the
     checkbox. `false` by default.
   * `icon` [NativeImage](native-image.md) (optional)
   * `cancelId` Integer (optional) - The index of the button to be used to cancel the dialog, via
     the `Esc` key. By default this is assigned to the first button with "cancel" or "no" as the
     label. If no such labeled buttons exist and this option is not set, `0` will be used as the
     return value.
-  * `noLink` Boolean (optional) - On Windows Electron will try to figure out which one of
+  * `noLink` boolean (optional) - On Windows Electron will try to figure out which one of
     the `buttons` are common buttons (like "Cancel" or "Yes"), and show the
     others as command links in the dialog. This can make the dialog appear in
     the style of modern Windows apps. If you don't like this behavior, you can
     set `noLink` to `true`.
-  * `normalizeAccessKeys` Boolean (optional) - Normalize the keyboard access keys
+  * `normalizeAccessKeys` boolean (optional) - Normalize the keyboard access keys
     across platforms. Default is `false`. Enabling this assumes `&` is used in
     the button labels for the placement of the keyboard shortcut access key
     and labels will be converted so they work correctly on each platform, `&`
@@ -302,8 +302,8 @@ If `browserWindow` is not shown dialog will not be attached to it. In such case 
     via `Alt-W` on Windows and Linux.
 
 Returns `Promise<Object>` - resolves with a promise containing the following properties:
-  * `response` Number - The index of the clicked button.
-  * `checkboxChecked` Boolean - The checked state of the checkbox if
+  * `response` number - The index of the clicked button.
+  * `checkboxChecked` boolean - The checked state of the checkbox if
   `checkboxLabel` was set. Otherwise `false`.
 
 Shows a message box.
@@ -312,8 +312,8 @@ The `browserWindow` argument allows the dialog to attach itself to a parent wind
 
 ### `dialog.showErrorBox(title, content)`
 
-* `title` String - The title to display in the error box.
-* `content` String - The text content to display in the error box.
+* `title` string - The title to display in the error box.
+* `content` string - The text content to display in the error box.
 
 Displays a modal dialog that shows an error message.
 
@@ -327,7 +327,7 @@ and no GUI dialog will appear.
 * `browserWindow` [BrowserWindow](browser-window.md) (optional)
 * `options` Object
   * `certificate` [Certificate](structures/certificate.md) - The certificate to trust/import.
-  * `message` String - The message to display to the user.
+  * `message` string - The message to display to the user.
 
 Returns `Promise<void>` - resolves when the certificate trust dialog is shown.
 

--- a/docs/api/dock.md
+++ b/docs/api/dock.md
@@ -15,7 +15,7 @@ app.dock.bounce()
 
 #### `dock.bounce([type])` _macOS_
 
-* `type` String (optional) - Can be `critical` or `informational`. The default is
+* `type` string (optional) - Can be `critical` or `informational`. The default is
  `informational`
 
 Returns `Integer` - an ID representing the request.
@@ -37,19 +37,19 @@ Cancel the bounce of `id`.
 
 #### `dock.downloadFinished(filePath)` _macOS_
 
-* `filePath` String
+* `filePath` string
 
 Bounces the Downloads stack if the filePath is inside the Downloads folder.
 
 #### `dock.setBadge(text)` _macOS_
 
-* `text` String
+* `text` string
 
 Sets the string to be displayed in the dock’s badging area.
 
 #### `dock.getBadge()` _macOS_
 
-Returns `String` - The badge string of the dock.
+Returns `string` - The badge string of the dock.
 
 #### `dock.hide()` _macOS_
 
@@ -61,7 +61,7 @@ Returns `Promise<void>` - Resolves when the dock icon is shown.
 
 #### `dock.isVisible()` _macOS_
 
-Returns `Boolean` - Whether the dock icon is visible.
+Returns `boolean` - Whether the dock icon is visible.
 
 #### `dock.setMenu(menu)` _macOS_
 
@@ -75,6 +75,6 @@ Returns `Menu | null` - The application's [dock menu][dock-menu].
 
 #### `dock.setIcon(image)` _macOS_
 
-* `image` ([NativeImage](native-image.md) | String)
+* `image` ([NativeImage](native-image.md) | string)
 
 Sets the `image` associated with this dock icon.

--- a/docs/api/download-item.md
+++ b/docs/api/download-item.md
@@ -44,7 +44,7 @@ win.webContents.session.on('will-download', (event, item, webContents) => {
 Returns:
 
 * `event` Event
-* `state` String - Can be `progressing` or `interrupted`.
+* `state` string - Can be `progressing` or `interrupted`.
 
 Emitted when the download has been updated and is not done.
 
@@ -58,7 +58,7 @@ The `state` can be one of following:
 Returns:
 
 * `event` Event
-* `state` String - Can be `completed`, `cancelled` or `interrupted`.
+* `state` string - Can be `completed`, `cancelled` or `interrupted`.
 
 Emitted when the download is in a terminal state. This includes a completed
 download, a cancelled download (via `downloadItem.cancel()`), and interrupted
@@ -76,7 +76,7 @@ The `downloadItem` object has the following methods:
 
 #### `downloadItem.setSavePath(path)`
 
-* `path` String - Set the save file path of the download item.
+* `path` string - Set the save file path of the download item.
 
 The API is only available in session's `will-download` callback function.
 If `path` doesn't exist, Electron will try to make the directory recursively.
@@ -85,7 +85,7 @@ routine to determine the save path; this usually prompts a save dialog.
 
 #### `downloadItem.getSavePath()`
 
-Returns `String` - The save path of the download item. This will be either the path
+Returns `string` - The save path of the download item. This will be either the path
 set via `downloadItem.setSavePath(path)` or the path selected from the shown
 save dialog.
 
@@ -108,7 +108,7 @@ Pauses the download.
 
 #### `downloadItem.isPaused()`
 
-Returns `Boolean` - Whether the download is paused.
+Returns `boolean` - Whether the download is paused.
 
 #### `downloadItem.resume()`
 
@@ -118,7 +118,7 @@ Resumes the download that has been paused.
 
 #### `downloadItem.canResume()`
 
-Returns `Boolean` - Whether the download can resume.
+Returns `boolean` - Whether the download can resume.
 
 #### `downloadItem.cancel()`
 
@@ -126,19 +126,19 @@ Cancels the download operation.
 
 #### `downloadItem.getURL()`
 
-Returns `String` - The origin URL where the item is downloaded from.
+Returns `string` - The origin URL where the item is downloaded from.
 
 #### `downloadItem.getMimeType()`
 
-Returns `String` - The files mime type.
+Returns `string` - The files mime type.
 
 #### `downloadItem.hasUserGesture()`
 
-Returns `Boolean` - Whether the download has user gesture.
+Returns `boolean` - Whether the download has user gesture.
 
 #### `downloadItem.getFilename()`
 
-Returns `String` - The file name of the download item.
+Returns `string` - The file name of the download item.
 
 **Note:** The file name is not always the same as the actual one saved in local
 disk. If user changes the file name in a prompted download saving dialog, the
@@ -156,27 +156,27 @@ Returns `Integer` - The received bytes of the download item.
 
 #### `downloadItem.getContentDisposition()`
 
-Returns `String` - The Content-Disposition field from the response
+Returns `string` - The Content-Disposition field from the response
 header.
 
 #### `downloadItem.getState()`
 
-Returns `String` - The current state. Can be `progressing`, `completed`, `cancelled` or `interrupted`.
+Returns `string` - The current state. Can be `progressing`, `completed`, `cancelled` or `interrupted`.
 
 **Note:** The following methods are useful specifically to resume a
 `cancelled` item when session is restarted.
 
 #### `downloadItem.getURLChain()`
 
-Returns `String[]` - The complete URL chain of the item including any redirects.
+Returns `string[]` - The complete URL chain of the item including any redirects.
 
 #### `downloadItem.getLastModifiedTime()`
 
-Returns `String` - Last-Modified header value.
+Returns `string` - Last-Modified header value.
 
 #### `downloadItem.getETag()`
 
-Returns `String` - ETag header value.
+Returns `string` - ETag header value.
 
 #### `downloadItem.getStartTime()`
 
@@ -187,7 +187,7 @@ started.
 
 #### `downloadItem.savePath`
 
-A `String` property that determines the save file path of the download item.
+A `string` property that determines the save file path of the download item.
 
 The property is only available in session's `will-download` callback function.
 If user doesn't set the save path via the property, Electron will use the original

--- a/docs/api/download-item.md
+++ b/docs/api/download-item.md
@@ -180,7 +180,7 @@ Returns `string` - ETag header value.
 
 #### `downloadItem.getStartTime()`
 
-Returns `Double` - Number of seconds since the UNIX epoch when the download was
+Returns `Double` - number of seconds since the UNIX epoch when the download was
 started.
 
 ### Instance Properties

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -47,7 +47,7 @@ The `globalShortcut` module has the following methods:
 * `accelerator` [Accelerator](accelerator.md)
 * `callback` Function
 
-Returns `Boolean` - Whether or not the shortcut was registered successfully.
+Returns `boolean` - Whether or not the shortcut was registered successfully.
 
 Registers a global shortcut of `accelerator`. The `callback` is called when
 the registered shortcut is pressed by the user.
@@ -87,7 +87,7 @@ the app has been authorized as a [trusted accessibility client](https://develope
 
 * `accelerator` [Accelerator](accelerator.md)
 
-Returns `Boolean` - Whether this application has registered `accelerator`.
+Returns `boolean` - Whether this application has registered `accelerator`.
 
 When the accelerator is already taken by other applications, this call will
 still return `false`. This behavior is intended by operating systems, since they

--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -66,7 +66,7 @@ the app has been authorized as a [trusted accessibility client](https://develope
 
 ### `globalShortcut.registerAll(accelerators, callback)`
 
-* `accelerators` String[] - an array of [Accelerator](accelerator.md)s.
+* `accelerators` string[] - an array of [Accelerator](accelerator.md)s.
 * `callback` Function
 
 Registers a global shortcut of all `accelerator` items in `accelerators`. The `callback` is called when any of the registered shortcuts are pressed by the user.

--- a/docs/api/in-app-purchase.md
+++ b/docs/api/in-app-purchase.md
@@ -23,16 +23,16 @@ The `inAppPurchase` module has the following methods:
 
 ### `inAppPurchase.purchaseProduct(productID[, quantity])`
 
-* `productID` String - The identifiers of the product to purchase. (The identifier of `com.example.app.product1` is `product1`).
+* `productID` string - The identifiers of the product to purchase. (The identifier of `com.example.app.product1` is `product1`).
 * `quantity` Integer (optional) - The number of items the user wants to purchase.
 
-Returns `Promise<Boolean>` - Returns `true` if the product is valid and added to the payment queue.
+Returns `Promise<boolean>` - Returns `true` if the product is valid and added to the payment queue.
 
 You should listen for the `transactions-updated` event as soon as possible and certainly before you call `purchaseProduct`.
 
 ### `inAppPurchase.getProducts(productIDs)`
 
-* `productIDs` String[] - The identifiers of the products to get.
+* `productIDs` string[] - The identifiers of the products to get.
 
 Returns `Promise<Product[]>` - Resolves with an array of [`Product`](structures/product.md) objects.
 
@@ -40,7 +40,7 @@ Retrieves the product descriptions.
 
 ### `inAppPurchase.canMakePayments()`
 
-Returns `Boolean` - whether a user can make a payment.
+Returns `boolean` - whether a user can make a payment.
 
 ### `inAppPurchase.restoreCompletedTransactions()`
 
@@ -50,7 +50,7 @@ Restores finished transactions. This method can be called either to install purc
 
 ### `inAppPurchase.getReceiptURL()`
 
-Returns `String` - the path to the receipt.
+Returns `string` - the path to the receipt.
 
 ### `inAppPurchase.finishAllTransactions()`
 
@@ -58,6 +58,6 @@ Completes all pending transactions.
 
 ### `inAppPurchase.finishTransactionByDate(date)`
 
-* `date` String - The ISO formatted date of the transaction to finish.
+* `date` string - The ISO formatted date of the transaction to finish.
 
 Completes the pending transactions corresponding to the date.

--- a/docs/api/incoming-message.md
+++ b/docs/api/incoming-message.md
@@ -47,7 +47,7 @@ An `Integer` indicating the HTTP response status code.
 
 #### `response.statusMessage`
 
-A `String` representing the HTTP status message.
+A `string` representing the HTTP status message.
 
 #### `response.headers`
 
@@ -65,7 +65,7 @@ formatted as follows:
 
 #### `response.httpVersion`
 
-A `String` indicating the HTTP protocol version number. Typical values are '1.0'
+A `string` indicating the HTTP protocol version number. Typical values are '1.0'
 or '1.1'. Additionally `httpVersionMajor` and `httpVersionMinor` are two
 Integer-valued readable properties that return respectively the HTTP major and
 minor version numbers.

--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -55,7 +55,7 @@ The `ipcMain` module has the following method to listen for events:
 
 ### `ipcMain.on(channel, listener)`
 
-* `channel` String
+* `channel` string
 * `listener` Function
   * `event` IpcMainEvent
   * `...args` any[]
@@ -65,7 +65,7 @@ Listens to `channel`, when a new message arrives `listener` would be called with
 
 ### `ipcMain.once(channel, listener)`
 
-* `channel` String
+* `channel` string
 * `listener` Function
   * `event` IpcMainEvent
   * `...args` any[]
@@ -75,7 +75,7 @@ only the next time a message is sent to `channel`, after which it is removed.
 
 ### `ipcMain.removeListener(channel, listener)`
 
-* `channel` String
+* `channel` string
 * `listener` Function
   * `...args` any[]
 
@@ -84,13 +84,13 @@ Removes the specified `listener` from the listener array for the specified
 
 ### `ipcMain.removeAllListeners([channel])`
 
-* `channel` String (optional)
+* `channel` string (optional)
 
 Removes listeners of the specified `channel`.
 
 ### `ipcMain.handle(channel, listener)`
 
-* `channel` String
+* `channel` string
 * `listener` Function<Promise<void> | any>
   * `event` IpcMainInvokeEvent
   * `...args` any[]
@@ -122,7 +122,7 @@ WebContents is the source of the invoke request.
 
 ### `ipcMain.handleOnce(channel, listener)`
 
-* `channel` String
+* `channel` string
 * `listener` Function<Promise<void> | any>
   * `event` IpcMainInvokeEvent
   * `...args` any[]
@@ -132,7 +132,7 @@ Handles a single `invoke`able IPC message, then removes the listener. See
 
 ### `ipcMain.removeHandler(channel)`
 
-* `channel` String
+* `channel` string
 
 Removes any handler for `channel`, if present.
 

--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -166,7 +166,7 @@ documentation](https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel).
 
 ### `ipcRenderer.sendTo(webContentsId, channel, ...args)`
 
-* `webContentsId` Number
+* `webContentsId` number
 * `channel` string
 * `...args` any[]
 

--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -17,7 +17,7 @@ The `ipcRenderer` module has the following method to listen for events and send 
 
 ### `ipcRenderer.on(channel, listener)`
 
-* `channel` String
+* `channel` string
 * `listener` Function
   * `event` IpcRendererEvent
   * `...args` any[]
@@ -27,7 +27,7 @@ Listens to `channel`, when a new message arrives `listener` would be called with
 
 ### `ipcRenderer.once(channel, listener)`
 
-* `channel` String
+* `channel` string
 * `listener` Function
   * `event` IpcRendererEvent
   * `...args` any[]
@@ -37,7 +37,7 @@ only the next time a message is sent to `channel`, after which it is removed.
 
 ### `ipcRenderer.removeListener(channel, listener)`
 
-* `channel` String
+* `channel` string
 * `listener` Function
   * `...args` any[]
 
@@ -46,13 +46,13 @@ Removes the specified `listener` from the listener array for the specified
 
 ### `ipcRenderer.removeAllListeners(channel)`
 
-* `channel` String
+* `channel` string
 
 Removes all listeners, or those of the specified `channel`.
 
 ### `ipcRenderer.send(channel, ...args)`
 
-* `channel` String
+* `channel` string
 * `...args` any[]
 
 Send an asynchronous message to the main process via `channel`, along with
@@ -74,7 +74,7 @@ If you want to receive a single response from the main process, like the result 
 
 ### `ipcRenderer.invoke(channel, ...args)`
 
-* `channel` String
+* `channel` string
 * `...args` any[]
 
 Returns `Promise<any>` - Resolves with the response from the main process.
@@ -112,7 +112,7 @@ If you do not need a response to the message, consider using [`ipcRenderer.send`
 
 ### `ipcRenderer.sendSync(channel, ...args)`
 
-* `channel` String
+* `channel` string
 * `...args` any[]
 
 Returns `any` - The value sent back by the [`ipcMain`](ipc-main.md) handler.
@@ -137,7 +137,7 @@ and replies by setting `event.returnValue`.
 
 ### `ipcRenderer.postMessage(channel, message, [transfer])`
 
-* `channel` String
+* `channel` string
 * `message` any
 * `transfer` MessagePort[] (optional)
 
@@ -167,14 +167,14 @@ documentation](https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel).
 ### `ipcRenderer.sendTo(webContentsId, channel, ...args)`
 
 * `webContentsId` Number
-* `channel` String
+* `channel` string
 * `...args` any[]
 
 Sends a message to a window with `webContentsId` via `channel`.
 
 ### `ipcRenderer.sendToHost(channel, ...args)`
 
-* `channel` String
+* `channel` string
 * `...args` any[]
 
 Like `ipcRenderer.send` but the event will be sent to the `<webview>` element in

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -14,39 +14,39 @@ See [`Menu`](menu.md) for examples.
     * `menuItem` MenuItem
     * `browserWindow` [BrowserWindow](browser-window.md) | undefined - This will not be defined if no window is open.
     * `event` [KeyboardEvent](structures/keyboard-event.md)
-  * `role` String (optional) - Can be `undo`, `redo`, `cut`, `copy`, `paste`, `pasteAndMatchStyle`, `delete`, `selectAll`, `reload`, `forceReload`, `toggleDevTools`, `resetZoom`, `zoomIn`, `zoomOut`, `togglefullscreen`, `window`, `minimize`, `close`, `help`, `about`, `services`, `hide`, `hideOthers`, `unhide`, `quit`, `startSpeaking`, `stopSpeaking`, `zoom`, `front`, `appMenu`, `fileMenu`, `editMenu`, `viewMenu`, `recentDocuments`, `toggleTabBar`, `selectNextTab`, `selectPreviousTab`, `mergeAllWindows`, `clearRecentDocuments`, `moveTabToNewWindow` or `windowMenu` - Define the action of the menu item, when specified the
+  * `role` string (optional) - Can be `undo`, `redo`, `cut`, `copy`, `paste`, `pasteAndMatchStyle`, `delete`, `selectAll`, `reload`, `forceReload`, `toggleDevTools`, `resetZoom`, `zoomIn`, `zoomOut`, `togglefullscreen`, `window`, `minimize`, `close`, `help`, `about`, `services`, `hide`, `hideOthers`, `unhide`, `quit`, `startSpeaking`, `stopSpeaking`, `zoom`, `front`, `appMenu`, `fileMenu`, `editMenu`, `viewMenu`, `recentDocuments`, `toggleTabBar`, `selectNextTab`, `selectPreviousTab`, `mergeAllWindows`, `clearRecentDocuments`, `moveTabToNewWindow` or `windowMenu` - Define the action of the menu item, when specified the
     `click` property will be ignored. See [roles](#roles).
-  * `type` String (optional) - Can be `normal`, `separator`, `submenu`, `checkbox` or
+  * `type` string (optional) - Can be `normal`, `separator`, `submenu`, `checkbox` or
     `radio`.
-  * `label` String (optional)
-  * `sublabel` String (optional)
-  * `toolTip` String (optional) _macOS_ - Hover text for this menu item.
+  * `label` string (optional)
+  * `sublabel` string (optional)
+  * `toolTip` string (optional) _macOS_ - Hover text for this menu item.
   * `accelerator` [Accelerator](accelerator.md) (optional)
-  * `icon` ([NativeImage](native-image.md) | String) (optional)
-  * `enabled` Boolean (optional) - If false, the menu item will be greyed out and
+  * `icon` ([NativeImage](native-image.md) | string) (optional)
+  * `enabled` boolean (optional) - If false, the menu item will be greyed out and
     unclickable.
-  * `acceleratorWorksWhenHidden` Boolean (optional) _macOS_ - default is `true`, and when `false` will prevent the accelerator from triggering the item if the item is not visible`.
-  * `visible` Boolean (optional) - If false, the menu item will be entirely hidden.
-  * `checked` Boolean (optional) - Should only be specified for `checkbox` or `radio` type
+  * `acceleratorWorksWhenHidden` boolean (optional) _macOS_ - default is `true`, and when `false` will prevent the accelerator from triggering the item if the item is not visible`.
+  * `visible` boolean (optional) - If false, the menu item will be entirely hidden.
+  * `checked` boolean (optional) - Should only be specified for `checkbox` or `radio` type
     menu items.
-  * `registerAccelerator` Boolean (optional) _Linux_ _Windows_ - If false, the accelerator won't be registered
+  * `registerAccelerator` boolean (optional) _Linux_ _Windows_ - If false, the accelerator won't be registered
     with the system, but it will still be displayed. Defaults to true.
   * `submenu` (MenuItemConstructorOptions[] | [Menu](menu.md)) (optional) - Should be specified
     for `submenu` type menu items. If `submenu` is specified, the `type: 'submenu'` can be omitted.
     If the value is not a [`Menu`](menu.md) then it will be automatically converted to one using
     `Menu.buildFromTemplate`.
-  * `id` String (optional) - Unique within a single menu. If defined then it can be used
+  * `id` string (optional) - Unique within a single menu. If defined then it can be used
     as a reference to this item by the position attribute.
-  * `before` String[] (optional) - Inserts this item before the item with the specified label. If
+  * `before` string[] (optional) - Inserts this item before the item with the specified label. If
     the referenced item doesn't exist the item will be inserted at the end of  the menu. Also implies
     that the menu item in question should be placed in the same “group” as the item.
-  * `after` String[] (optional) - Inserts this item after the item with the specified label. If the
+  * `after` string[] (optional) - Inserts this item after the item with the specified label. If the
     referenced item doesn't exist the item will be inserted at the end of
     the menu.
-  * `beforeGroupContaining` String[] (optional) - Provides a means for a single context menu to declare
+  * `beforeGroupContaining` string[] (optional) - Provides a means for a single context menu to declare
     the placement of their containing group before the containing group of the item
     with the specified label.
-  * `afterGroupContaining` String[] (optional) - Provides a means for a single context menu to declare
+  * `afterGroupContaining` string[] (optional) - Provides a means for a single context menu to declare
     the placement of their containing group after the containing group of the item
     with the specified label.
 
@@ -125,12 +125,12 @@ The following properties are available on instances of `MenuItem`:
 
 #### `menuItem.id`
 
-A `String` indicating the item's unique id, this property can be
+A `string` indicating the item's unique id, this property can be
 dynamically changed.
 
 #### `menuItem.label`
 
-A `String` indicating the item's visible label.
+A `string` indicating the item's visible label.
 
 #### `menuItem.click`
 
@@ -147,11 +147,11 @@ item's submenu, if present.
 
 #### `menuItem.type`
 
-A `String` indicating the type of the item. Can be `normal`, `separator`, `submenu`, `checkbox` or `radio`.
+A `string` indicating the type of the item. Can be `normal`, `separator`, `submenu`, `checkbox` or `radio`.
 
 #### `menuItem.role`
 
-A `String` (optional) indicating the item's role, if set. Can be `undo`, `redo`, `cut`, `copy`, `paste`, `pasteAndMatchStyle`, `delete`, `selectAll`, `reload`, `forceReload`, `toggleDevTools`, `resetZoom`, `zoomIn`, `zoomOut`, `togglefullscreen`, `window`, `minimize`, `close`, `help`, `about`, `services`, `hide`, `hideOthers`, `unhide`, `quit`, `startSpeaking`, `stopSpeaking`, `zoom`, `front`, `appMenu`, `fileMenu`, `editMenu`, `viewMenu`, `recentDocuments`, `toggleTabBar`, `selectNextTab`, `selectPreviousTab`, `mergeAllWindows`, `clearRecentDocuments`, `moveTabToNewWindow` or `windowMenu`
+A `string` (optional) indicating the item's role, if set. Can be `undo`, `redo`, `cut`, `copy`, `paste`, `pasteAndMatchStyle`, `delete`, `selectAll`, `reload`, `forceReload`, `toggleDevTools`, `resetZoom`, `zoomIn`, `zoomOut`, `togglefullscreen`, `window`, `minimize`, `close`, `help`, `about`, `services`, `hide`, `hideOthers`, `unhide`, `quit`, `startSpeaking`, `stopSpeaking`, `zoom`, `front`, `appMenu`, `fileMenu`, `editMenu`, `viewMenu`, `recentDocuments`, `toggleTabBar`, `selectNextTab`, `selectPreviousTab`, `mergeAllWindows`, `clearRecentDocuments`, `moveTabToNewWindow` or `windowMenu`
 
 #### `menuItem.accelerator`
 
@@ -159,30 +159,30 @@ A `Accelerator` (optional) indicating the item's accelerator, if set.
 
 #### `menuItem.icon`
 
-A `NativeImage | String` (optional) indicating the
+A `NativeImage | string` (optional) indicating the
 item's icon, if set.
 
 #### `menuItem.sublabel`
 
-A `String` indicating the item's sublabel.
+A `string` indicating the item's sublabel.
 
 #### `menuItem.toolTip` _macOS_
 
-A `String` indicating the item's hover text.
+A `string` indicating the item's hover text.
 
 #### `menuItem.enabled`
 
-A `Boolean` indicating whether the item is enabled, this property can be
+A `boolean` indicating whether the item is enabled, this property can be
 dynamically changed.
 
 #### `menuItem.visible`
 
-A `Boolean` indicating whether the item is visible, this property can be
+A `boolean` indicating whether the item is visible, this property can be
 dynamically changed.
 
 #### `menuItem.checked`
 
-A `Boolean` indicating whether the item is checked, this property can be
+A `boolean` indicating whether the item is checked, this property can be
 dynamically changed.
 
 A `checkbox` menu item will toggle the `checked` property on and off when
@@ -195,14 +195,14 @@ You can add a `click` function for additional behavior.
 
 #### `menuItem.registerAccelerator`
 
-A `Boolean` indicating if the accelerator should be registered with the
+A `boolean` indicating if the accelerator should be registered with the
 system or just displayed.
 
 This property can be dynamically changed.
 
 #### `menuItem.commandId`
 
-A `Number` indicating an item's sequential unique id.
+A `number` indicating an item's sequential unique id.
 
 #### `menuItem.menu`
 

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -41,7 +41,7 @@ be dynamically modified.
 
 #### `Menu.sendActionToFirstResponder(action)` _macOS_
 
-* `action` String
+* `action` string
 
 Sends the `action` to the first responder of application. This is used for
 emulating default macOS menu behaviors. Usually you would use the
@@ -69,11 +69,11 @@ The `menu` object has the following instance methods:
 
 * `options` Object (optional)
   * `window` [BrowserWindow](browser-window.md) (optional) - Default is the focused window.
-  * `x` Number (optional) - Default is the current mouse cursor position.
+  * `x` number (optional) - Default is the current mouse cursor position.
     Must be declared if `y` is declared.
-  * `y` Number (optional) - Default is the current mouse cursor position.
+  * `y` number (optional) - Default is the current mouse cursor position.
     Must be declared if `x` is declared.
-  * `positioningItem` Number (optional) _macOS_ - The index of the menu item to
+  * `positioningItem` number (optional) _macOS_ - The index of the menu item to
     be positioned under the mouse cursor at the specified coordinates. Default
     is -1.
   * `callback` Function (optional) - Called when menu is closed.
@@ -94,7 +94,7 @@ Appends the `menuItem` to the menu.
 
 #### `menu.getMenuItemById(id)`
 
-* `id` String
+* `id` string
 
 Returns `MenuItem | null` the item with the specified `id`
 

--- a/docs/api/native-image.md
+++ b/docs/api/native-image.md
@@ -8,7 +8,7 @@ In Electron, for the APIs that take images, you can pass either file paths or
 `NativeImage` instances. An empty image will be used when `null` is passed.
 
 For example, when creating a tray or setting a window's icon, you can pass an
-image file path as a `String`:
+image file path as a `string`:
 
 ```javascript
 const { BrowserWindow, Tray } = require('electron')
@@ -121,14 +121,14 @@ Creates an empty `NativeImage` instance.
 
 ### `nativeImage.createThumbnailFromPath(path, maxSize)` _macOS_ _Windows_
 
-* `path` String - path to a file that we intend to construct a thumbnail out of.
+* `path` string - path to a file that we intend to construct a thumbnail out of.
 * `maxSize` [Size](structures/size.md) - the maximum width and height (positive numbers) the thumbnail returned can be. The Windows implementation will ignore `maxSize.height` and scale the height according to `maxSize.width`.
 
 Returns `Promise<NativeImage>` - fulfilled with the file's thumbnail preview image, which is a [NativeImage](native-image.md).
 
 ### `nativeImage.createFromPath(path)`
 
-* `path` String
+* `path` string
 
 Returns `NativeImage`
 
@@ -170,7 +170,7 @@ Creates a new `NativeImage` instance from `buffer`. Tries to decode as PNG or JP
 
 ### `nativeImage.createFromDataURL(dataURL)`
 
-* `dataURL` String
+* `dataURL` string
 
 Returns `NativeImage`
 
@@ -178,8 +178,8 @@ Creates a new `NativeImage` instance from `dataURL`.
 
 ### `nativeImage.createFromNamedImage(imageName[, hslShift])` _macOS_
 
-* `imageName` String
-* `hslShift` Number[] (optional)
+* `imageName` string
+* `hslShift` number[] (optional)
 
 Returns `NativeImage`
 
@@ -247,7 +247,7 @@ data.
 * `options` Object (optional)
   * `scaleFactor` Double (optional) - Defaults to 1.0.
 
-Returns `String` - The data URL of the image.
+Returns `string` - The data URL of the image.
 
 #### `image.getBitmap([options])`
 
@@ -271,7 +271,7 @@ image instead of a copy, so you _must_ ensure that the associated
 
 #### `image.isEmpty()`
 
-Returns `Boolean` - Whether the image is empty.
+Returns `boolean` - Whether the image is empty.
 
 #### `image.getSize([scaleFactor])`
 
@@ -283,13 +283,13 @@ If `scaleFactor` is passed, this will return the size corresponding to the image
 
 #### `image.setTemplateImage(option)`
 
-* `option` Boolean
+* `option` boolean
 
 Marks the image as a template image.
 
 #### `image.isTemplateImage()`
 
-Returns `Boolean` - Whether the image is a template image.
+Returns `boolean` - Whether the image is a template image.
 
 #### `image.crop(rect)`
 
@@ -302,7 +302,7 @@ Returns `NativeImage` - The cropped image.
 * `options` Object
   * `width` Integer (optional) - Defaults to the image's width.
   * `height` Integer (optional) - Defaults to the image's height.
-  * `quality` String (optional) - The desired quality of the resize image.
+  * `quality` string (optional) - The desired quality of the resize image.
     Possible values are `good`, `better`, or `best`. The default is `best`.
     These values express a desired quality/speed tradeoff. They are translated
     into an algorithm-specific method that depends on the capabilities
@@ -335,7 +335,7 @@ Returns `Float[]` - An array of all scale factors corresponding to representatio
   * `height` Integer (optional) - Defaults to 0. Required if a bitmap buffer
     is specified as `buffer`.
   * `buffer` Buffer (optional) - The buffer containing the raw image data.
-  * `dataURL` String (optional) - The data URL containing either a base 64
+  * `dataURL` string (optional) - The data URL containing either a base 64
     encoded PNG or JPEG image.
 
 Add an image representation for a specific scale factor. This can be used
@@ -348,6 +348,6 @@ can be called on empty images.
 
 #### `nativeImage.isMacTemplateImage` _macOS_
 
-A `Boolean` property that determines whether the image is considered a [template image](https://developer.apple.com/documentation/appkit/nsimage/1520017-template).
+A `boolean` property that determines whether the image is considered a [template image](https://developer.apple.com/documentation/appkit/nsimage/1520017-template).
 
 Please note that this property only has an effect on macOS.

--- a/docs/api/native-theme.md
+++ b/docs/api/native-theme.md
@@ -21,13 +21,13 @@ The `nativeTheme` module has the following properties:
 
 ### `nativeTheme.shouldUseDarkColors` _Readonly_
 
-A `Boolean` for if the OS / Chromium currently has a dark mode enabled or is
+A `boolean` for if the OS / Chromium currently has a dark mode enabled or is
 being instructed to show a dark-style UI.  If you want to modify this value you
 should use `themeSource` below.
 
 ### `nativeTheme.themeSource`
 
-A `String` property that can be `system`, `light` or `dark`.  It is used to override and supersede
+A `string` property that can be `system`, `light` or `dark`.  It is used to override and supersede
 the value that Chromium has chosen to use internally.
 
 Setting this property to `system` will remove the override and
@@ -57,10 +57,10 @@ Your application should then always use `shouldUseDarkColors` to determine what 
 
 ### `nativeTheme.shouldUseHighContrastColors` _macOS_ _Windows_ _Readonly_
 
-A `Boolean` for if the OS / Chromium currently has high-contrast mode enabled
+A `boolean` for if the OS / Chromium currently has high-contrast mode enabled
 or is being instructed to show a high-contrast UI.
 
 ### `nativeTheme.shouldUseInvertedColorScheme` _macOS_ _Windows_ _Readonly_
 
-A `Boolean` for if the OS / Chromium currently has an inverted color scheme
+A `boolean` for if the OS / Chromium currently has an inverted color scheme
 or is being instructed to use an inverted color scheme.

--- a/docs/api/net-log.md
+++ b/docs/api/net-log.md
@@ -24,14 +24,14 @@ of the `app` module gets emitted.
 
 ### `netLog.startLogging(path[, options])`
 
-* `path` String - File path to record network logs.
+* `path` string - File path to record network logs.
 * `options` Object (optional)
-  * `captureMode` String (optional) - What kinds of data should be captured. By
+  * `captureMode` string (optional) - What kinds of data should be captured. By
     default, only metadata about requests will be captured. Setting this to
     `includeSensitive` will include cookies and authentication data. Setting
     it to `everything` will include all bytes transferred on sockets. Can be
     `default`, `includeSensitive` or `everything`.
-  * `maxFileSize` Number (optional) - When the log grows beyond this size,
+  * `maxFileSize` number (optional) - When the log grows beyond this size,
     logging will automatically stop. Defaults to unlimited.
 
 Returns `Promise<void>` - resolves when the net log has begun recording.
@@ -48,4 +48,4 @@ Stops recording network events. If not called, net logging will automatically en
 
 ### `netLog.currentlyLogging` _Readonly_
 
-A `Boolean` property that indicates whether network logs are currently being recorded.
+A `boolean` property that indicates whether network logs are currently being recorded.

--- a/docs/api/net.md
+++ b/docs/api/net.md
@@ -54,7 +54,7 @@ The `net` module has the following methods:
 
 ### `net.request(options)`
 
-* `options` (ClientRequestConstructorOptions | String) - The `ClientRequest` constructor options.
+* `options` (ClientRequestConstructorOptions | string) - The `ClientRequest` constructor options.
 
 Returns [`ClientRequest`](./client-request.md)
 

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -24,24 +24,24 @@ The `Notification` class has the following static methods:
 
 #### `Notification.isSupported()`
 
-Returns `Boolean` - Whether or not desktop notifications are supported on the current system
+Returns `boolean` - Whether or not desktop notifications are supported on the current system
 
 ### `new Notification([options])`
 
 * `options` Object (optional)
-  * `title` String (optional) - A title for the notification, which will be shown at the top of the notification window when it is shown.
-  * `subtitle` String (optional) _macOS_ - A subtitle for the notification, which will be displayed below the title.
-  * `body` String (optional) - The body text of the notification, which will be displayed below the title or subtitle.
-  * `silent` Boolean (optional) - Whether or not to emit an OS notification noise when showing the notification.
-  * `icon` (String | [NativeImage](native-image.md)) (optional) - An icon to use in the notification.
-  * `hasReply` Boolean (optional) _macOS_ - Whether or not to add an inline reply option to the notification.
-  * `timeoutType` String (optional) _Linux_ _Windows_ - The timeout duration of the notification. Can be 'default' or 'never'.
-  * `replyPlaceholder` String (optional) _macOS_ - The placeholder to write in the inline reply input field.
-  * `sound` String (optional) _macOS_ - The name of the sound file to play when the notification is shown.
-  * `urgency` String (optional) _Linux_ - The urgency level of the notification. Can be 'normal', 'critical', or 'low'.
+  * `title` string (optional) - A title for the notification, which will be shown at the top of the notification window when it is shown.
+  * `subtitle` string (optional) _macOS_ - A subtitle for the notification, which will be displayed below the title.
+  * `body` string (optional) - The body text of the notification, which will be displayed below the title or subtitle.
+  * `silent` boolean (optional) - Whether or not to emit an OS notification noise when showing the notification.
+  * `icon` (string | [NativeImage](native-image.md)) (optional) - An icon to use in the notification.
+  * `hasReply` boolean (optional) _macOS_ - Whether or not to add an inline reply option to the notification.
+  * `timeoutType` string (optional) _Linux_ _Windows_ - The timeout duration of the notification. Can be 'default' or 'never'.
+  * `replyPlaceholder` string (optional) _macOS_ - The placeholder to write in the inline reply input field.
+  * `sound` string (optional) _macOS_ - The name of the sound file to play when the notification is shown.
+  * `urgency` string (optional) _Linux_ - The urgency level of the notification. Can be 'normal', 'critical', or 'low'.
   * `actions` [NotificationAction[]](structures/notification-action.md) (optional) _macOS_ - Actions to add to the notification. Please read the available actions and limitations in the `NotificationAction` documentation.
-  * `closeButtonText` String (optional) _macOS_ - A custom title for the close button of an alert. An empty string will cause the default localized text to be used.
-  * `toastXml` String (optional) _Windows_ - A custom description of the Notification on Windows superseding all properties above. Provides full customization of design and behavior of the notification.
+  * `closeButtonText` string (optional) _macOS_ - A custom title for the close button of an alert. An empty string will cause the default localized text to be used.
+  * `toastXml` string (optional) _Windows_ - A custom description of the Notification on Windows superseding all properties above. Provides full customization of design and behavior of the notification.
 
 ### Instance Events
 
@@ -84,7 +84,7 @@ is closed.
 Returns:
 
 * `event` Event
-* `reply` String - The string the user entered into the inline reply field.
+* `reply` string - The string the user entered into the inline reply field.
 
 Emitted when the user clicks the "Reply" button on a notification with `hasReply: true`.
 
@@ -93,14 +93,14 @@ Emitted when the user clicks the "Reply" button on a notification with `hasReply
 Returns:
 
 * `event` Event
-* `index` Number - The index of the action that was activated.
+* `index` number - The index of the action that was activated.
 
 #### Event: 'failed' _Windows_
 
 Returns:
 
 * `event` Event
-* `error` String - The error encountered during execution of the `show()` method.
+* `error` string - The error encountered during execution of the `show()` method.
 
 Emitted when an error is encountered while creating and showing the native notification.
 
@@ -126,45 +126,45 @@ Dismisses the notification.
 
 #### `notification.title`
 
-A `String` property representing the title of the notification.
+A `string` property representing the title of the notification.
 
 #### `notification.subtitle`
 
-A `String` property representing the subtitle of the notification.
+A `string` property representing the subtitle of the notification.
 
 #### `notification.body`
 
-A `String` property representing the body of the notification.
+A `string` property representing the body of the notification.
 
 #### `notification.replyPlaceholder`
 
-A `String` property representing the reply placeholder of the notification.
+A `string` property representing the reply placeholder of the notification.
 
 #### `notification.sound`
 
-A `String` property representing the sound of the notification.
+A `string` property representing the sound of the notification.
 
 #### `notification.closeButtonText`
 
-A `String` property representing the close button text of the notification.
+A `string` property representing the close button text of the notification.
 
 #### `notification.silent`
 
-A `Boolean` property representing whether the notification is silent.
+A `boolean` property representing whether the notification is silent.
 
 #### `notification.hasReply`
 
-A `Boolean` property representing whether the notification has a reply action.
+A `boolean` property representing whether the notification has a reply action.
 
 #### `notification.urgency` _Linux_
 
-A `String` property representing the urgency level of the notification. Can be 'normal', 'critical', or 'low'.
+A `string` property representing the urgency level of the notification. Can be 'normal', 'critical', or 'low'.
 
 Default is 'low' - see [NotifyUrgency](https://developer.gnome.org/notification-spec/#urgency-levels) for more information.
 
 #### `notification.timeoutType` _Linux_ _Windows_
 
-A `String` property representing the type of timeout duration for the notification. Can be 'default' or 'never'.
+A `string` property representing the type of timeout duration for the notification. Can be 'default' or 'never'.
 
 If `timeoutType` is set to 'never', the notification never expires. It stays open until closed by the calling API or the user.
 
@@ -174,7 +174,7 @@ A [`NotificationAction[]`](structures/notification-action.md) property represent
 
 #### `notification.toastXml` _Windows_
 
-A `String` property representing the custom Toast XML of the notification.
+A `string` property representing the custom Toast XML of the notification.
 
 ### Playing Sounds
 

--- a/docs/api/power-monitor.md
+++ b/docs/api/power-monitor.md
@@ -55,7 +55,7 @@ The `powerMonitor` module has the following methods:
 
 * `idleThreshold` Integer
 
-Returns `String` - The system's current state. Can be `active`, `idle`, `locked` or `unknown`.
+Returns `string` - The system's current state. Can be `active`, `idle`, `locked` or `unknown`.
 
 Calculate the system idle state. `idleThreshold` is the amount of time (in seconds)
 before considered idle.  `locked` is available on supported systems only.

--- a/docs/api/power-save-blocker.md
+++ b/docs/api/power-save-blocker.md
@@ -21,7 +21,7 @@ The `powerSaveBlocker` module has the following methods:
 
 ### `powerSaveBlocker.start(type)`
 
-* `type` String - Power save blocker type.
+* `type` string - Power save blocker type.
   * `prevent-app-suspension` - Prevent the application from being suspended.
     Keeps system active but allows screen to be turned off. Example use cases:
     downloading a file or playing audio.
@@ -53,4 +53,4 @@ Stops the specified power save blocker.
 
 * `id` Integer - The power save blocker id returned by `powerSaveBlocker.start`.
 
-Returns `Boolean` - Whether the corresponding `powerSaveBlocker` has started.
+Returns `boolean` - Whether the corresponding `powerSaveBlocker` has started.

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -58,60 +58,60 @@ process.once('loaded', () => {
 
 ### `process.defaultApp` _Readonly_
 
-A `Boolean`. When app is started by being passed as parameter to the default app, this
+A `boolean`. When app is started by being passed as parameter to the default app, this
 property is `true` in the main process, otherwise it is `undefined`.
 
 ### `process.isMainFrame` _Readonly_
 
-A `Boolean`, `true` when the current renderer context is the "main" renderer
+A `boolean`, `true` when the current renderer context is the "main" renderer
 frame. If you want the ID of the current frame you should use `webFrame.routingId`.
 
 ### `process.mas` _Readonly_
 
-A `Boolean`. For Mac App Store build, this property is `true`, for other builds it is
+A `boolean`. For Mac App Store build, this property is `true`, for other builds it is
 `undefined`.
 
 ### `process.noAsar`
 
-A `Boolean` that controls ASAR support inside your application. Setting this to `true`
+A `boolean` that controls ASAR support inside your application. Setting this to `true`
 will disable the support for `asar` archives in Node's built-in modules.
 
 ### `process.noDeprecation`
 
-A `Boolean` that controls whether or not deprecation warnings are printed to `stderr`.
+A `boolean` that controls whether or not deprecation warnings are printed to `stderr`.
 Setting this to `true` will silence deprecation warnings. This property is used
 instead of the `--no-deprecation` command line flag.
 
 ### `process.resourcesPath` _Readonly_
 
-A `String` representing the path to the resources directory.
+A `string` representing the path to the resources directory.
 
 ### `process.sandboxed` _Readonly_
 
-A `Boolean`. When the renderer process is sandboxed, this property is `true`,
+A `boolean`. When the renderer process is sandboxed, this property is `true`,
 otherwise it is `undefined`.
 
 ### `process.throwDeprecation`
 
-A `Boolean` that controls whether or not deprecation warnings will be thrown as
+A `boolean` that controls whether or not deprecation warnings will be thrown as
 exceptions. Setting this to `true` will throw errors for deprecations. This
 property is used instead of the `--throw-deprecation` command line flag.
 
 ### `process.traceDeprecation`
 
-A `Boolean` that controls whether or not deprecations printed to `stderr` include
+A `boolean` that controls whether or not deprecations printed to `stderr` include
  their stack trace. Setting this to `true` will print stack traces for deprecations.
  This property is instead of the `--trace-deprecation` command line flag.
 
 ### `process.traceProcessWarnings`
-A `Boolean` that controls whether or not process warnings printed to `stderr` include
+A `boolean` that controls whether or not process warnings printed to `stderr` include
  their stack trace. Setting this to `true` will print stack traces for process warnings
  (including deprecations). This property is instead of the `--trace-warnings` command
  line flag.
 
 ### `process.type` _Readonly_
 
-A `String` representing the current process's type, can be:
+A `string` representing the current process's type, can be:
 
 * `browser` - The main process
 * `renderer` - A renderer process
@@ -119,15 +119,15 @@ A `String` representing the current process's type, can be:
 
 ### `process.versions.chrome` _Readonly_
 
-A `String` representing Chrome's version string.
+A `string` representing Chrome's version string.
 
 ### `process.versions.electron` _Readonly_
 
-A `String` representing Electron's version string.
+A `string` representing Electron's version string.
 
 ### `process.windowsStore` _Readonly_
 
-A `Boolean`. If the app is running as a Windows Store app (appx), this property is `true`,
+A `boolean`. If the app is running as a Windows Store app (appx), this property is `true`,
 for otherwise it is `undefined`.
 
 ## Methods
@@ -140,7 +140,7 @@ Causes the main thread of the current process crash.
 
 ### `process.getCreationTime()`
 
-Returns `Number | null` - The number of milliseconds since epoch, or `null` if the information is unavailable
+Returns `number | null` - The number of milliseconds since epoch, or `null` if the information is unavailable
 
 Indicates the creation time of the application.
 The time is represented as number of milliseconds since epoch. It returns null if it is unable to get the process creation time.
@@ -165,7 +165,7 @@ Returns `Object`:
 * `heapSizeLimit` Integer
 * `mallocedMemory` Integer
 * `peakMallocedMemory` Integer
-* `doesZapGarbage` Boolean
+* `doesZapGarbage` boolean
 
 Returns an object with V8 heap statistics. Note that all statistics are reported in Kilobytes.
 
@@ -213,7 +213,7 @@ that all statistics are reported in Kilobytes.
 
 ### `process.getSystemVersion()`
 
-Returns `String` - The version of the host operating system.
+Returns `string` - The version of the host operating system.
 
 Example:
 
@@ -229,9 +229,9 @@ console.log(version)
 
 ### `process.takeHeapSnapshot(filePath)`
 
-* `filePath` String - Path to the output file.
+* `filePath` string - Path to the output file.
 
-Returns `Boolean` - Indicates whether the snapshot has been created successfully.
+Returns `boolean` - Indicates whether the snapshot has been created successfully.
 
 Takes a V8 heap snapshot and saves it to `filePath`.
 

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -110,13 +110,13 @@ expect streaming responses.
 
 ### `protocol.registerFileProtocol(scheme, handler)`
 
-* `scheme` String
+* `scheme` string
 * `handler` Function
   * `request` [ProtocolRequest](structures/protocol-request.md)
   * `callback` Function
-    * `response` (String | [ProtocolResponse](structures/protocol-response.md))
+    * `response` (string | [ProtocolResponse](structures/protocol-response.md))
 
-Returns `Boolean` - Whether the protocol was successfully registered
+Returns `boolean` - Whether the protocol was successfully registered
 
 Registers a protocol of `scheme` that will send a file as the response. The
 `handler` will be called with `request` and `callback` where `request` is
@@ -131,13 +131,13 @@ from protocols that follow the "generic URI syntax" like `file:`.
 
 ### `protocol.registerBufferProtocol(scheme, handler)`
 
-* `scheme` String
+* `scheme` string
 * `handler` Function
   * `request` [ProtocolRequest](structures/protocol-request.md)
   * `callback` Function
     * `response` (Buffer | [ProtocolResponse](structures/protocol-response.md))
 
-Returns `Boolean` - Whether the protocol was successfully registered
+Returns `boolean` - Whether the protocol was successfully registered
 
 Registers a protocol of `scheme` that will send a `Buffer` as a response.
 
@@ -155,29 +155,29 @@ protocol.registerBufferProtocol('atom', (request, callback) => {
 
 ### `protocol.registerStringProtocol(scheme, handler)`
 
-* `scheme` String
+* `scheme` string
 * `handler` Function
   * `request` [ProtocolRequest](structures/protocol-request.md)
   * `callback` Function
-    * `response` (String | [ProtocolResponse](structures/protocol-response.md))
+    * `response` (string | [ProtocolResponse](structures/protocol-response.md))
 
-Returns `Boolean` - Whether the protocol was successfully registered
+Returns `boolean` - Whether the protocol was successfully registered
 
-Registers a protocol of `scheme` that will send a `String` as a response.
+Registers a protocol of `scheme` that will send a `string` as a response.
 
 The usage is the same with `registerFileProtocol`, except that the `callback`
-should be called with either a `String` or an object that has the `data`
+should be called with either a `string` or an object that has the `data`
 property.
 
 ### `protocol.registerHttpProtocol(scheme, handler)`
 
-* `scheme` String
+* `scheme` string
 * `handler` Function
   * `request` [ProtocolRequest](structures/protocol-request.md)
   * `callback` Function
     * `response` ProtocolResponse
 
-Returns `Boolean` - Whether the protocol was successfully registered
+Returns `boolean` - Whether the protocol was successfully registered
 
 Registers a protocol of `scheme` that will send an HTTP request as a response.
 
@@ -186,13 +186,13 @@ should be called with an object that has the `url` property.
 
 ### `protocol.registerStreamProtocol(scheme, handler)`
 
-* `scheme` String
+* `scheme` string
 * `handler` Function
   * `request` [ProtocolRequest](structures/protocol-request.md)
   * `callback` Function
     * `response` (ReadableStream | [ProtocolResponse](structures/protocol-response.md))
 
-Returns `Boolean` - Whether the protocol was successfully registered
+Returns `boolean` - Whether the protocol was successfully registered
 
 Registers a protocol of `scheme` that will send a stream as a response.
 
@@ -235,95 +235,95 @@ protocol.registerStreamProtocol('atom', (request, callback) => {
 
 ### `protocol.unregisterProtocol(scheme)`
 
-* `scheme` String
+* `scheme` string
 
-Returns `Boolean` - Whether the protocol was successfully unregistered
+Returns `boolean` - Whether the protocol was successfully unregistered
 
 Unregisters the custom protocol of `scheme`.
 
 ### `protocol.isProtocolRegistered(scheme)`
 
-* `scheme` String
+* `scheme` string
 
-Returns `Boolean` - Whether `scheme` is already registered.
+Returns `boolean` - Whether `scheme` is already registered.
 
 ### `protocol.interceptFileProtocol(scheme, handler)`
 
-* `scheme` String
+* `scheme` string
 * `handler` Function
   * `request` [ProtocolRequest](structures/protocol-request.md)
   * `callback` Function
-    * `response` (String | [ProtocolResponse](structures/protocol-response.md))
+    * `response` (string | [ProtocolResponse](structures/protocol-response.md))
 
-Returns `Boolean` - Whether the protocol was successfully intercepted
+Returns `boolean` - Whether the protocol was successfully intercepted
 
 Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
 which sends a file as a response.
 
 ### `protocol.interceptStringProtocol(scheme, handler)`
 
-* `scheme` String
+* `scheme` string
 * `handler` Function
   * `request` [ProtocolRequest](structures/protocol-request.md)
   * `callback` Function
-    * `response` (String | [ProtocolResponse](structures/protocol-response.md))
+    * `response` (string | [ProtocolResponse](structures/protocol-response.md))
 
-Returns `Boolean` - Whether the protocol was successfully intercepted
+Returns `boolean` - Whether the protocol was successfully intercepted
 
 Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
-which sends a `String` as a response.
+which sends a `string` as a response.
 
 ### `protocol.interceptBufferProtocol(scheme, handler)`
 
-* `scheme` String
+* `scheme` string
 * `handler` Function
   * `request` [ProtocolRequest](structures/protocol-request.md)
   * `callback` Function
     * `response` (Buffer | [ProtocolResponse](structures/protocol-response.md))
 
-Returns `Boolean` - Whether the protocol was successfully intercepted
+Returns `boolean` - Whether the protocol was successfully intercepted
 
 Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
 which sends a `Buffer` as a response.
 
 ### `protocol.interceptHttpProtocol(scheme, handler)`
 
-* `scheme` String
+* `scheme` string
 * `handler` Function
   * `request` [ProtocolRequest](structures/protocol-request.md)
   * `callback` Function
     * `response` [ProtocolResponse](structures/protocol-response.md)
 
-Returns `Boolean` - Whether the protocol was successfully intercepted
+Returns `boolean` - Whether the protocol was successfully intercepted
 
 Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
 which sends a new HTTP request as a response.
 
 ### `protocol.interceptStreamProtocol(scheme, handler)`
 
-* `scheme` String
+* `scheme` string
 * `handler` Function
   * `request` [ProtocolRequest](structures/protocol-request.md)
   * `callback` Function
     * `response` (ReadableStream | [ProtocolResponse](structures/protocol-response.md))
 
-Returns `Boolean` - Whether the protocol was successfully intercepted
+Returns `boolean` - Whether the protocol was successfully intercepted
 
 Same as `protocol.registerStreamProtocol`, except that it replaces an existing
 protocol handler.
 
 ### `protocol.uninterceptProtocol(scheme)`
 
-* `scheme` String
+* `scheme` string
 
-Returns `Boolean` - Whether the protocol was successfully unintercepted
+Returns `boolean` - Whether the protocol was successfully unintercepted
 
 Remove the interceptor installed for `scheme` and restore its original handler.
 
 ### `protocol.isProtocolIntercepted(scheme)`
 
-* `scheme` String
+* `scheme` string
 
-Returns `Boolean` - Whether `scheme` is already intercepted.
+Returns `boolean` - Whether `scheme` is already intercepted.
 
 [file-system-api]: https://developer.mozilla.org/en-US/docs/Web/API/LocalFileSystem

--- a/docs/api/remote.md
+++ b/docs/api/remote.md
@@ -166,7 +166,7 @@ Returns [`WebContents`](web-contents.md) - The web contents of this web page.
 
 ### `remote.getGlobal(name)`
 
-* `name` String
+* `name` string
 
 Returns `any` - The global variable of `name` (e.g. `global[name]`) in the main
 process.

--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -76,7 +76,7 @@ Returns:
 
 * `event` Event
 * `display` [Display](structures/display.md)
-* `changedMetrics` String[]
+* `changedMetrics` string[]
 
 Emitted when one or more metrics change in a `display`. The `changedMetrics` is
 an array of strings that describe the changes. Possible changes are `bounds`,

--- a/docs/api/service-workers.md
+++ b/docs/api/service-workers.md
@@ -41,7 +41,7 @@ Returns:
   * `source` string - The type of source for this message.  Can be `javascript`, `xml`, `network`, `console-api`, `storage`, `app-cache`, `rendering`, `security`, `deprecation`, `worker`, `violation`, `intervention`, `recommendation` or `other`.
   * `level` number - The log level, from 0 to 3. In order it matches `verbose`, `info`, `warning` and `error`.
   * `sourceUrl` string - The URL the message came from
-  * `lineNumber` number - The line number of the source that triggered this console message
+  * `linenumber` number - The line number of the source that triggered this console message
 
 Emitted when a service worker logs something to the console.
 

--- a/docs/api/service-workers.md
+++ b/docs/api/service-workers.md
@@ -36,12 +36,12 @@ Returns:
 
 * `event` Event
 * `messageDetails` Object - Information about the console message
-  * `message` String - The actual console message
-  * `versionId` Number - The version ID of the service worker that sent the log message
-  * `source` String - The type of source for this message.  Can be `javascript`, `xml`, `network`, `console-api`, `storage`, `app-cache`, `rendering`, `security`, `deprecation`, `worker`, `violation`, `intervention`, `recommendation` or `other`.
-  * `level` Number - The log level, from 0 to 3. In order it matches `verbose`, `info`, `warning` and `error`.
-  * `sourceUrl` String - The URL the message came from
-  * `lineNumber` Number - The line number of the source that triggered this console message
+  * `message` string - The actual console message
+  * `versionId` number - The version ID of the service worker that sent the log message
+  * `source` string - The type of source for this message.  Can be `javascript`, `xml`, `network`, `console-api`, `storage`, `app-cache`, `rendering`, `security`, `deprecation`, `worker`, `violation`, `intervention`, `recommendation` or `other`.
+  * `level` number - The log level, from 0 to 3. In order it matches `verbose`, `info`, `warning` and `error`.
+  * `sourceUrl` string - The URL the message came from
+  * `lineNumber` number - The line number of the source that triggered this console message
 
 Emitted when a service worker logs something to the console.
 
@@ -51,11 +51,11 @@ The following methods are available on instances of `ServiceWorkers`:
 
 #### `serviceWorkers.getAllRunning()`
 
-Returns `Record<Number, ServiceWorkerInfo>` - A [ServiceWorkerInfo](structures/service-worker-info.md) object where the keys are the service worker version ID and the values are the information about that service worker.
+Returns `Record<number, ServiceWorkerInfo>` - A [ServiceWorkerInfo](structures/service-worker-info.md) object where the keys are the service worker version ID and the values are the information about that service worker.
 
 #### `serviceWorkers.getFromVersionID(versionId)`
 
-* `versionId` Number
+* `versionId` number
 
 Returns [`ServiceWorkerInfo`](structures/service-worker-info.md) - Information about this service worker
 

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -25,9 +25,9 @@ The `session` module has the following methods:
 
 ### `session.fromPartition(partition[, options])`
 
-* `partition` String
+* `partition` string
 * `options` Object (optional)
-  * `cache` Boolean - Whether to enable cache.
+  * `cache` boolean - Whether to enable cache.
 
 Returns `Session` - A session instance from `partition` string. When there is an existing
 `Session` with the same `partition`, it will be returned; otherwise a new
@@ -130,9 +130,9 @@ initialized to support the start of the extension's background page.
 Returns:
 
 * `event` Event
-* `preconnectUrl` String - The URL being requested for preconnection by the
+* `preconnectUrl` string - The URL being requested for preconnection by the
   renderer.
-* `allowCredentials` Boolean - True if the renderer is requesting that the
+* `allowCredentials` boolean - True if the renderer is requesting that the
   connection include credentials (see the
   [spec](https://w3c.github.io/resource-hints/#preconnect) for more details.)
 
@@ -144,7 +144,7 @@ a [resource hint](https://w3c.github.io/resource-hints/).
 Returns:
 
 * `event` Event
-* `languageCode` String - The language code of the dictionary file
+* `languageCode` string - The language code of the dictionary file
 
 Emitted when a hunspell dictionary file has been successfully initialized. This
 occurs after the file has been downloaded.
@@ -154,7 +154,7 @@ occurs after the file has been downloaded.
 Returns:
 
 * `event` Event
-* `languageCode` String - The language code of the dictionary file
+* `languageCode` string - The language code of the dictionary file
 
 Emitted when a hunspell dictionary file starts downloading
 
@@ -163,7 +163,7 @@ Emitted when a hunspell dictionary file starts downloading
 Returns:
 
 * `event` Event
-* `languageCode` String - The language code of the dictionary file
+* `languageCode` string - The language code of the dictionary file
 
 Emitted when a hunspell dictionary file has been successfully downloaded
 
@@ -172,7 +172,7 @@ Emitted when a hunspell dictionary file has been successfully downloaded
 Returns:
 
 * `event` Event
-* `languageCode` String - The language code of the dictionary file
+* `languageCode` string - The language code of the dictionary file
 
 Emitted when a hunspell dictionary file download fails.  For details
 on the failure you should collect a netlog and inspect the download
@@ -186,7 +186,7 @@ Returns:
 * `portList` [SerialPort[]](structures/serial-port.md)
 * `webContents` [WebContents](web-contents.md)
 * `callback` Function
-  * `portId` String
+  * `portId` string
 
 Emitted when a serial port needs to be selected when a call to
 `navigator.serial.requestPort` is made. `callback` should be called with
@@ -265,13 +265,13 @@ Clears the session’s HTTP cache.
 #### `ses.clearStorageData([options])`
 
 * `options` Object (optional)
-  * `origin` String (optional) - Should follow `window.location.origin`’s representation
+  * `origin` string (optional) - Should follow `window.location.origin`’s representation
     `scheme://host:port`.
-  * `storages` String[] (optional) - The types of storages to clear, can contain:
+  * `storages` string[] (optional) - The types of storages to clear, can contain:
     `appcache`, `cookies`, `filesystem`, `indexdb`, `localstorage`,
     `shadercache`, `websql`, `serviceworkers`, `cachestorage`. If not
     specified, clear all storage types.
-  * `quotas` String[] (optional) - The types of quotas to clear, can contain:
+  * `quotas` string[] (optional) - The types of quotas to clear, can contain:
     `temporary`, `persistent`, `syncable`. If not specified, clear all quotas.
 
 Returns `Promise<void>` - resolves when the storage data has been cleared.
@@ -283,9 +283,9 @@ Writes any unwritten DOMStorage data to disk.
 #### `ses.setProxy(config)`
 
 * `config` Object
-  * `pacScript` String (optional) - The URL associated with the PAC file.
-  * `proxyRules` String (optional) - Rules indicating which proxies to use.
-  * `proxyBypassRules` String (optional) - Rules indicating which URLs should
+  * `pacScript` string (optional) - The URL associated with the PAC file.
+  * `proxyRules` string (optional) - Rules indicating which proxies to use.
+  * `proxyBypassRules` string (optional) - Rules indicating which URLs should
     bypass the proxy settings.
 
 Returns `Promise<void>` - Resolves when the proxy setting process is complete.
@@ -361,11 +361,11 @@ The `proxyBypassRules` is a comma separated list of rules described below:
 
 * `url` URL
 
-Returns `Promise<String>` - Resolves with the proxy information for `url`.
+Returns `Promise<string>` - Resolves with the proxy information for `url`.
 
 #### `ses.setDownloadPath(path)`
 
-* `path` String - The download location.
+* `path` string - The download location.
 
 Sets download saving directory. By default, the download directory will be the
 `Downloads` under the respective app folder.
@@ -373,7 +373,7 @@ Sets download saving directory. By default, the download directory will be the
 #### `ses.enableNetworkEmulation(options)`
 
 * `options` Object
-  * `offline` Boolean (optional) - Whether to emulate network outage. Defaults
+  * `offline` boolean (optional) - Whether to emulate network outage. Defaults
     to false.
   * `latency` Double (optional) - RTT in ms. Defaults to 0 which will disable
     latency throttling.
@@ -399,8 +399,8 @@ window.webContents.session.enableNetworkEmulation({ offline: true })
 #### `ses.preconnect(options)`
 
 * `options` Object
-  * `url` String - URL for preconnect. Only the origin is relevant for opening the socket.
-  * `numSockets` Number (optional) - number of sockets to preconnect. Must be between 1 and 6. Defaults to 1.
+  * `url` string - URL for preconnect. Only the origin is relevant for opening the socket.
+  * `numSockets` number (optional) - number of sockets to preconnect. Must be between 1 and 6. Defaults to 1.
 
 Preconnects the given number of sockets to an origin.
 
@@ -413,10 +413,10 @@ the original network configuration.
 
 * `proc` Function | null
   * `request` Object
-    * `hostname` String
+    * `hostname` string
     * `certificate` [Certificate](structures/certificate.md)
     * `validatedCertificate` [Certificate](structures/certificate.md)
-    * `verificationResult` String - Verification result from chromium.
+    * `verificationResult` string - Verification result from chromium.
     * `errorCode` Integer - Error code.
   * `callback` Function
     * `verificationResult` Integer - Value can be one of certificate error codes
@@ -452,7 +452,7 @@ win.webContents.session.setCertificateVerifyProc((request, callback) => {
 
 * `handler` Function | null
   * `webContents` [WebContents](web-contents.md) - WebContents requesting the permission.  Please note that if the request comes from a subframe you should use `requestingUrl` to check the request origin.
-  * `permission` String - The type of requested permission.
+  * `permission` string - The type of requested permission.
     * `media` -  Request access to media devices such as camera, microphone and speakers.
     * `mediaKeySystem` - Request access to DRM protected content.
     * `geolocation` - Request access to user's current location.
@@ -463,13 +463,13 @@ win.webContents.session.setCertificateVerifyProc((request, callback) => {
     * `fullscreen` - Request for the app to enter fullscreen mode.
     * `openExternal` - Request to open links in external applications.
   * `callback` Function
-    * `permissionGranted` Boolean - Allow or deny the permission.
+    * `permissionGranted` boolean - Allow or deny the permission.
   * `details` Object - Some properties are only available on certain permission types.
-    * `externalURL` String (optional) - The url of the `openExternal` request.
-    * `mediaTypes` String[] (optional) - The types of media access being requested, elements can be `video`
+    * `externalURL` string (optional) - The url of the `openExternal` request.
+    * `mediaTypes` string[] (optional) - The types of media access being requested, elements can be `video`
       or `audio`
-    * `requestingUrl` String - The last URL the requesting frame loaded
-    * `isMainFrame` Boolean - Whether the frame making the request is the main frame
+    * `requestingUrl` string - The last URL the requesting frame loaded
+    * `isMainFrame` boolean - Whether the frame making the request is the main frame
 
 Sets the handler which can be used to respond to permission requests for the `session`.
 Calling `callback(true)` will allow the permission and `callback(false)` will reject it.
@@ -488,16 +488,16 @@ session.fromPartition('some-partition').setPermissionRequestHandler((webContents
 
 #### `ses.setPermissionCheckHandler(handler)`
 
-* `handler` Function<Boolean> | null
+* `handler` Function<boolean> | null
   * `webContents` [WebContents](web-contents.md) - WebContents checking the permission.  Please note that if the request comes from a subframe you should use `requestingUrl` to check the request origin.
-  * `permission` String - Type of permission check.  Valid values are `midiSysex`, `notifications`, `geolocation`, `media`,`mediaKeySystem`,`midi`, `pointerLock`, `fullscreen`, `openExternal`, or `serial`.
-  * `requestingOrigin` String - The origin URL of the permission check
+  * `permission` string - Type of permission check.  Valid values are `midiSysex`, `notifications`, `geolocation`, `media`,`mediaKeySystem`,`midi`, `pointerLock`, `fullscreen`, `openExternal`, or `serial`.
+  * `requestingOrigin` string - The origin URL of the permission check
   * `details` Object - Some properties are only available on certain permission types.
-    * `securityOrigin` String - The security origin of the `media` check.
-    * `mediaType` String - The type of media access being requested, can be `video`,
+    * `securityOrigin` string - The security origin of the `media` check.
+    * `mediaType` string - The type of media access being requested, can be `video`,
       `audio` or `unknown`
-    * `requestingUrl` String - The last URL the requesting frame loaded
-    * `isMainFrame` Boolean - Whether the frame making the request is the main frame
+    * `requestingUrl` string - The last URL the requesting frame loaded
+    * `isMainFrame` boolean - Whether the frame making the request is the main frame
 
 Sets the handler which can be used to respond to permission checks for the `session`.
 Returning `true` will allow the permission and `false` will reject it.
@@ -522,7 +522,7 @@ Clears the host resolver cache.
 
 #### `ses.allowNTLMCredentialsForDomains(domains)`
 
-* `domains` String - A comma-separated list of servers for which
+* `domains` string - A comma-separated list of servers for which
   integrated authentication is enabled.
 
 Dynamically sets whether to always send credentials for HTTP NTLM or Negotiate
@@ -540,8 +540,8 @@ session.defaultSession.allowNTLMCredentialsForDomains('*')
 
 #### `ses.setUserAgent(userAgent[, acceptLanguages])`
 
-* `userAgent` String
-* `acceptLanguages` String (optional)
+* `userAgent` string
+* `acceptLanguages` string (optional)
 
 Overrides the `userAgent` and `acceptLanguages` for this session.
 
@@ -553,22 +553,22 @@ This doesn't affect existing `WebContents`, and each `WebContents` can use
 
 #### `ses.isPersistent()`
 
-Returns `Boolean` - Whether or not this session is a persistent one. The default
+Returns `boolean` - Whether or not this session is a persistent one. The default
 `webContents` session of a `BrowserWindow` is persistent. When creating a session
 from a partition, session prefixed with `persist:` will be persistent, while others
 will be temporary.
 
 #### `ses.getUserAgent()`
 
-Returns `String` - The user agent for this session.
+Returns `string` - The user agent for this session.
 
 #### `ses.setSSLConfig(config)`
 
 * `config` Object
-  * `minVersion` String - Can be `tls1`, `tls1.1`, `tls1.2` or `tls1.3`. The
+  * `minVersion` string - Can be `tls1`, `tls1.1`, `tls1.2` or `tls1.3`. The
     minimum SSL version to allow when connecting to remote servers. Defaults to
     `tls1`.
-  * `maxVersion` String - Can be `tls1.2` or `tls1.3`. The maximum SSL version
+  * `maxVersion` string - Can be `tls1.2` or `tls1.3`. The maximum SSL version
     to allow when connecting to remote servers. Defaults to `tls1.3`.
 
 Sets the SSL configuration for the session. All subsequent network requests
@@ -578,13 +578,13 @@ reused for new connections.
 
 #### `ses.getBlobData(identifier)`
 
-* `identifier` String - Valid UUID.
+* `identifier` string - Valid UUID.
 
 Returns `Promise<Buffer>` - resolves with blob data.
 
 #### `ses.downloadURL(url)`
 
-* `url` String
+* `url` string
 
 Initiates a download of the resource at `url`.
 The API will generate a [DownloadItem](download-item.md) that can be accessed
@@ -596,13 +596,13 @@ unlike [`webContents.downloadURL`](web-contents.md#contentsdownloadurlurl).
 #### `ses.createInterruptedDownload(options)`
 
 * `options` Object
-  * `path` String - Absolute path of the download.
-  * `urlChain` String[] - Complete URL chain for the download.
-  * `mimeType` String (optional)
+  * `path` string - Absolute path of the download.
+  * `urlChain` string[] - Complete URL chain for the download.
+  * `mimeType` string (optional)
   * `offset` Integer - Start range for the download.
   * `length` Integer - Total length of the download.
-  * `lastModified` String (optional) - Last-Modified header value.
-  * `eTag` String (optional) - ETag header value.
+  * `lastModified` string (optional) - Last-Modified header value.
+  * `eTag` string (optional) - ETag header value.
   * `startTime` Double (optional) - Time when download was started in
     number of seconds since UNIX epoch.
 
@@ -618,19 +618,19 @@ Returns `Promise<void>` - resolves when the session’s HTTP authentication cach
 
 #### `ses.setPreloads(preloads)`
 
-* `preloads` String[] - An array of absolute path to preload scripts
+* `preloads` string[] - An array of absolute path to preload scripts
 
 Adds scripts that will be executed on ALL web contents that are associated with
 this session just before normal `preload` scripts run.
 
 #### `ses.getPreloads()`
 
-Returns `String[]` an array of paths to preload scripts that have been
+Returns `string[]` an array of paths to preload scripts that have been
 registered.
 
 #### `ses.setSpellCheckerLanguages(languages)`
 
-* `languages` String[] - An array of language codes to enable the spellchecker for.
+* `languages` string[] - An array of language codes to enable the spellchecker for.
 
 The built in spellchecker does not automatically detect what language a user is typing in.  In order for the
 spell checker to correctly check their words you must call this API with an array of language codes.  You can
@@ -640,7 +640,7 @@ get the list of supported language codes with the `ses.availableSpellCheckerLang
 
 #### `ses.getSpellCheckerLanguages()`
 
-Returns `String[]` - An array of language codes the spellchecker is enabled for.  If this list is empty the spellchecker
+Returns `string[]` - An array of language codes the spellchecker is enabled for.  If this list is empty the spellchecker
 will fallback to using `en-US`.  By default on launch if this setting is an empty list Electron will try to populate this
 setting with the current OS locale.  This setting is persisted across restarts.
 
@@ -648,7 +648,7 @@ setting with the current OS locale.  This setting is persisted across restarts.
 
 #### `ses.setSpellCheckerDictionaryDownloadURL(url)`
 
-* `url` String - A base URL for Electron to download hunspell dictionaries from.
+* `url` string - A base URL for Electron to download hunspell dictionaries from.
 
 By default Electron will download hunspell dictionaries from the Chromium CDN.  If you want to override this
 behavior you can use this API to point the dictionary downloader at your own hosted version of the hunspell
@@ -664,30 +664,30 @@ note the trailing slash.  The URL to the dictionaries is formed as `${url}${file
 
 #### `ses.listWordsInSpellCheckerDictionary()`
 
-Returns `Promise<String[]>` - An array of all words in app's custom dictionary.
+Returns `Promise<string[]>` - An array of all words in app's custom dictionary.
 Resolves when the full dictionary is loaded from disk.
 
 #### `ses.addWordToSpellCheckerDictionary(word)`
 
-* `word` String - The word you want to add to the dictionary
+* `word` string - The word you want to add to the dictionary
 
-Returns `Boolean` - Whether the word was successfully written to the custom dictionary. This API
+Returns `boolean` - Whether the word was successfully written to the custom dictionary. This API
 will not work on non-persistent (in-memory) sessions.
 
 **Note:** On macOS and Windows 10 this word will be written to the OS custom dictionary as well
 
 #### `ses.removeWordFromSpellCheckerDictionary(word)`
 
-* `word` String - The word you want to remove from the dictionary
+* `word` string - The word you want to remove from the dictionary
 
-Returns `Boolean` - Whether the word was successfully removed from the custom dictionary. This API
+Returns `boolean` - Whether the word was successfully removed from the custom dictionary. This API
 will not work on non-persistent (in-memory) sessions.
 
 **Note:** On macOS and Windows 10 this word will be removed from the OS custom dictionary as well
 
 #### `ses.loadExtension(path)`
 
-* `path` String - Path to a directory containing an unpacked Chrome extension
+* `path` string - Path to a directory containing an unpacked Chrome extension
 
 Returns `Promise<Extension>` - resolves when the extension is loaded.
 
@@ -726,7 +726,7 @@ supported and will throw an error.
 
 #### `ses.removeExtension(extensionId)`
 
-* `extensionId` String - ID of extension to remove
+* `extensionId` string - ID of extension to remove
 
 Unloads an extension.
 
@@ -735,7 +735,7 @@ is emitted.
 
 #### `ses.getExtension(extensionId)`
 
-* `extensionId` String - ID of extension to query
+* `extensionId` string - ID of extension to query
 
 Returns `Extension` | `null` - The loaded extension with the given ID.
 
@@ -755,7 +755,7 @@ The following properties are available on instances of `Session`:
 
 #### `ses.availableSpellCheckerLanguages` _Readonly_
 
-A `String[]` array which consists of all the known available spell checker languages.  Providing a language
+A `string[]` array which consists of all the known available spell checker languages.  Providing a language
 code to the `setSpellCheckerLanaguages` API that isn't in this array will result in an error.
 
 #### `ses.cookies` _Readonly_

--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -22,24 +22,24 @@ The `shell` module has the following methods:
 
 ### `shell.showItemInFolder(fullPath)`
 
-* `fullPath` String
+* `fullPath` string
 
 Show the given file in a file manager. If possible, select the file.
 
 ### `shell.openPath(path)`
 
-* `path` String
+* `path` string
 
-Returns `Promise<String>` - Resolves with a string containing the error message corresponding to the failure if a failure occurred, otherwise "".
+Returns `Promise<string>` - Resolves with a string containing the error message corresponding to the failure if a failure occurred, otherwise "".
 
 Open the given file in the desktop's default manner.
 
 ### `shell.openExternal(url[, options])`
 
-* `url` String - Max 2081 characters on windows.
+* `url` string - Max 2081 characters on windows.
 * `options` Object (optional)
-  * `activate` Boolean (optional) _macOS_ - `true` to bring the opened application to the foreground. The default is `true`.
-  * `workingDirectory` String (optional) _Windows_ - The working directory.
+  * `activate` boolean (optional) _macOS_ - `true` to bring the opened application to the foreground. The default is `true`.
+  * `workingDirectory` string (optional) _Windows_ - The working directory.
 
 Returns `Promise<void>`
 
@@ -47,10 +47,10 @@ Open the given external protocol URL in the desktop's default manner. (For examp
 
 ### `shell.moveItemToTrash(fullPath[, deleteOnFail])` _Deprecated_
 
-* `fullPath` String
-* `deleteOnFail` Boolean (optional) - Whether or not to unilaterally remove the item if the Trash is disabled or unsupported on the volume. _macOS_
+* `fullPath` string
+* `deleteOnFail` boolean (optional) - Whether or not to unilaterally remove the item if the Trash is disabled or unsupported on the volume. _macOS_
 
-Returns `Boolean` - Whether the item was successfully moved to the trash or otherwise deleted.
+Returns `boolean` - Whether the item was successfully moved to the trash or otherwise deleted.
 
 > NOTE: This method is deprecated. Use `shell.trashItem` instead.
 
@@ -58,7 +58,7 @@ Move the given file to trash and returns a boolean status for the operation.
 
 ### `shell.trashItem(path)`
 
-* `path` String - path to the item to be moved to the trash.
+* `path` string - path to the item to be moved to the trash.
 
 Returns `Promise<void>` - Resolves when the operation has been completed.
 Rejects if there was an error while deleting the requested item.
@@ -72,21 +72,21 @@ Play the beep sound.
 
 ### `shell.writeShortcutLink(shortcutPath[, operation], options)` _Windows_
 
-* `shortcutPath` String
-* `operation` String (optional) - Default is `create`, can be one of following:
+* `shortcutPath` string
+* `operation` string (optional) - Default is `create`, can be one of following:
   * `create` - Creates a new shortcut, overwriting if necessary.
   * `update` - Updates specified properties only on an existing shortcut.
   * `replace` - Overwrites an existing shortcut, fails if the shortcut doesn't
     exist.
 * `options` [ShortcutDetails](structures/shortcut-details.md)
 
-Returns `Boolean` - Whether the shortcut was created successfully.
+Returns `boolean` - Whether the shortcut was created successfully.
 
 Creates or updates a shortcut link at `shortcutPath`.
 
 ### `shell.readShortcutLink(shortcutPath)` _Windows_
 
-* `shortcutPath` String
+* `shortcutPath` string
 
 Returns [`ShortcutDetails`](structures/shortcut-details.md)
 

--- a/docs/api/structures/bluetooth-device.md
+++ b/docs/api/structures/bluetooth-device.md
@@ -1,4 +1,4 @@
 # BluetoothDevice Object
 
-* `deviceName` String
-* `deviceId` String
+* `deviceName` string
+* `deviceId` string

--- a/docs/api/structures/certificate-principal.md
+++ b/docs/api/structures/certificate-principal.md
@@ -1,8 +1,8 @@
 # CertificatePrincipal Object
 
-* `commonName` String - Common Name.
-* `organizations` String[] - Organization names.
-* `organizationUnits` String[] - Organization Unit names.
-* `locality` String - Locality.
-* `state` String - State or province.
-* `country` String - Country or region.
+* `commonName` string - Common Name.
+* `organizations` string[] - Organization names.
+* `organizationUnits` string[] - Organization Unit names.
+* `locality` string - Locality.
+* `state` string - State or province.
+* `country` string - Country or region.

--- a/docs/api/structures/certificate.md
+++ b/docs/api/structures/certificate.md
@@ -1,12 +1,12 @@
 # Certificate Object
 
-* `data` String - PEM encoded data
+* `data` string - PEM encoded data
 * `issuer` [CertificatePrincipal](certificate-principal.md) - Issuer principal
-* `issuerName` String - Issuer's Common Name
+* `issuerName` string - Issuer's Common Name
 * `issuerCert` Certificate - Issuer certificate (if not self-signed)
 * `subject` [CertificatePrincipal](certificate-principal.md) - Subject principal
-* `subjectName` String - Subject's Common Name
-* `serialNumber` String - Hex value represented string
-* `validStart` Number - Start date of the certificate being valid in seconds
-* `validExpiry` Number - End date of the certificate being valid in seconds
-* `fingerprint` String - Fingerprint of the certificate
+* `subjectName` string - Subject's Common Name
+* `serialNumber` string - Hex value represented string
+* `validStart` number - Start date of the certificate being valid in seconds
+* `validExpiry` number - End date of the certificate being valid in seconds
+* `fingerprint` string - Fingerprint of the certificate

--- a/docs/api/structures/cookie.md
+++ b/docs/api/structures/cookie.md
@@ -1,15 +1,15 @@
 # Cookie Object
 
-* `name` String - The name of the cookie.
-* `value` String - The value of the cookie.
-* `domain` String (optional) - The domain of the cookie; this will be normalized with a preceding dot so that it's also valid for subdomains.
-* `hostOnly` Boolean (optional) - Whether the cookie is a host-only cookie; this will only be `true` if no domain was passed.
-* `path` String (optional) - The path of the cookie.
-* `secure` Boolean (optional) - Whether the cookie is marked as secure.
-* `httpOnly` Boolean (optional) - Whether the cookie is marked as HTTP only.
-* `session` Boolean (optional) - Whether the cookie is a session cookie or a persistent
+* `name` string - The name of the cookie.
+* `value` string - The value of the cookie.
+* `domain` string (optional) - The domain of the cookie; this will be normalized with a preceding dot so that it's also valid for subdomains.
+* `hostOnly` boolean (optional) - Whether the cookie is a host-only cookie; this will only be `true` if no domain was passed.
+* `path` string (optional) - The path of the cookie.
+* `secure` boolean (optional) - Whether the cookie is marked as secure.
+* `httpOnly` boolean (optional) - Whether the cookie is marked as HTTP only.
+* `session` boolean (optional) - Whether the cookie is a session cookie or a persistent
   cookie with an expiration date.
 * `expirationDate` Double (optional) - The expiration date of the cookie as
   the number of seconds since the UNIX epoch. Not provided for session
   cookies.
-* `sameSite` String - The [Same Site](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies) policy applied to this cookie.  Can be `unspecified`, `no_restriction`, `lax` or `strict`.
+* `sameSite` string - The [Same Site](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies) policy applied to this cookie.  Can be `unspecified`, `no_restriction`, `lax` or `strict`.

--- a/docs/api/structures/crash-report.md
+++ b/docs/api/structures/crash-report.md
@@ -1,4 +1,4 @@
 # CrashReport Object
 
 * `date` Date
-* `id` String
+* `id` string

--- a/docs/api/structures/custom-scheme.md
+++ b/docs/api/structures/custom-scheme.md
@@ -1,11 +1,11 @@
 # CustomScheme Object
 
-* `scheme` String - Custom schemes to be registered with options.
+* `scheme` string - Custom schemes to be registered with options.
 * `privileges` Object (optional)
-  * `standard` Boolean (optional) - Default false.
-  * `secure` Boolean (optional) - Default false.
-  * `bypassCSP` Boolean (optional) - Default false.
-  * `allowServiceWorkers` Boolean (optional) - Default false.
-  * `supportFetchAPI` Boolean (optional) - Default false.
-  * `corsEnabled` Boolean (optional) - Default false.
-  * `stream` Boolean (optional) - Default false.
+  * `standard` boolean (optional) - Default false.
+  * `secure` boolean (optional) - Default false.
+  * `bypassCSP` boolean (optional) - Default false.
+  * `allowServiceWorkers` boolean (optional) - Default false.
+  * `supportFetchAPI` boolean (optional) - Default false.
+  * `corsEnabled` boolean (optional) - Default false.
+  * `stream` boolean (optional) - Default false.

--- a/docs/api/structures/desktop-capturer-source.md
+++ b/docs/api/structures/desktop-capturer-source.md
@@ -1,10 +1,10 @@
 # DesktopCapturerSource Object
 
-* `id` String - The identifier of a window or screen that can be used as a
+* `id` string - The identifier of a window or screen that can be used as a
   `chromeMediaSourceId` constraint when calling
   [`navigator.webkitGetUserMedia`]. The format of the identifier will be
   `window:XX` or `screen:XX`, where `XX` is a random generated number.
-* `name` String - A screen source will be named either `Entire Screen` or
+* `name` string - A screen source will be named either `Entire Screen` or
   `Screen <index>`, while the name of a window source will match the window
   title.
 * `thumbnail` [NativeImage](../native-image.md) - A thumbnail image. **Note:**
@@ -12,7 +12,7 @@
   `thumbnailSize` specified in the `options` passed to
   `desktopCapturer.getSources`. The actual size depends on the scale of the
   screen or window.
-* `display_id` String - A unique identifier that will correspond to the `id` of
+* `display_id` string - A unique identifier that will correspond to the `id` of
   the matching [Display](display.md) returned by the [Screen API](../screen.md).
   On some platforms, this is equivalent to the `XX` portion of the `id` field
   above and on others it will differ. It will be an empty string if not

--- a/docs/api/structures/display.md
+++ b/docs/api/structures/display.md
@@ -1,20 +1,20 @@
 # Display Object
 
-* `id` Number - Unique identifier associated with the display.
-* `rotation` Number - Can be 0, 90, 180, 270, represents screen rotation in
+* `id` number - Unique identifier associated with the display.
+* `rotation` number - Can be 0, 90, 180, 270, represents screen rotation in
   clock-wise degrees.
-* `scaleFactor` Number - Output device's pixel scale factor.
-* `touchSupport` String - Can be `available`, `unavailable`, `unknown`.
-* `monochrome` Boolean - Whether or not the display is a monochrome display.
-* `accelerometerSupport` String - Can be `available`, `unavailable`, `unknown`.
-* `colorSpace` String -  represent a color space (three-dimensional object which contains all realizable color combinations) for the purpose of color conversions
-* `colorDepth` Number - The number of bits per pixel.
-* `depthPerComponent` Number - The number of bits per color component.
+* `scaleFactor` number - Output device's pixel scale factor.
+* `touchSupport` string - Can be `available`, `unavailable`, `unknown`.
+* `monochrome` boolean - Whether or not the display is a monochrome display.
+* `accelerometerSupport` string - Can be `available`, `unavailable`, `unknown`.
+* `colorSpace` string -  represent a color space (three-dimensional object which contains all realizable color combinations) for the purpose of color conversions
+* `colorDepth` number - The number of bits per pixel.
+* `depthPerComponent` number - The number of bits per color component.
 * `bounds` [Rectangle](rectangle.md)
 * `size` [Size](size.md)
 * `workArea` [Rectangle](rectangle.md)
 * `workAreaSize` [Size](size.md)
-* `internal` Boolean - `true` for an internal display and `false` for an external display
+* `internal` boolean - `true` for an internal display and `false` for an external display
 
 The `Display` object represents a physical display connected to the system. A
 fake `Display` may exist on a headless system, or a `Display` may correspond to

--- a/docs/api/structures/extension-info.md
+++ b/docs/api/structures/extension-info.md
@@ -1,4 +1,4 @@
 # ExtensionInfo Object
 
-* `name` String
-* `version` String
+* `name` string
+* `version` string

--- a/docs/api/structures/extension.md
+++ b/docs/api/structures/extension.md
@@ -1,8 +1,8 @@
 # Extension Object
 
-* `id` String
+* `id` string
 * `manifest` any - Copy of the [extension's manifest data](https://developer.chrome.com/extensions/manifest).
-* `name` String
-* `path` String - The extension's file path.
-* `version` String
-* `url` String - The extension's `chrome-extension://` URL.
+* `name` string
+* `path` string - The extension's file path.
+* `version` string
+* `url` string - The extension's `chrome-extension://` URL.

--- a/docs/api/structures/file-filter.md
+++ b/docs/api/structures/file-filter.md
@@ -1,4 +1,4 @@
 # FileFilter Object
 
-* `name` String
-* `extensions` String[]
+* `name` string
+* `extensions` string[]

--- a/docs/api/structures/file-path-with-headers.md
+++ b/docs/api/structures/file-path-with-headers.md
@@ -1,4 +1,4 @@
 # FilePathWithHeaders Object
 
-* `path` String - The path to the file to send.
+* `path` string - The path to the file to send.
 * `headers` Record<string, string> (optional) - Additional headers to be sent.

--- a/docs/api/structures/gpu-feature-status.md
+++ b/docs/api/structures/gpu-feature-status.md
@@ -1,18 +1,18 @@
 # GPUFeatureStatus Object
 
-* `2d_canvas` String - Canvas.
-* `flash_3d` String - Flash.
-* `flash_stage3d` String - Flash Stage3D.
-* `flash_stage3d_baseline` String - Flash Stage3D Baseline profile.
-* `gpu_compositing` String - Compositing.
-* `multiple_raster_threads` String - Multiple Raster Threads.
-* `native_gpu_memory_buffers` String - Native GpuMemoryBuffers.
-* `rasterization` String - Rasterization.
-* `video_decode` String - Video Decode.
-* `video_encode` String - Video Encode.
-* `vpx_decode` String - VPx Video Decode.
-* `webgl` String - WebGL.
-* `webgl2` String - WebGL2.
+* `2d_canvas` string - Canvas.
+* `flash_3d` string - Flash.
+* `flash_stage3d` string - Flash Stage3D.
+* `flash_stage3d_baseline` string - Flash Stage3D Baseline profile.
+* `gpu_compositing` string - Compositing.
+* `multiple_raster_threads` string - Multiple Raster Threads.
+* `native_gpu_memory_buffers` string - Native GpuMemoryBuffers.
+* `rasterization` string - Rasterization.
+* `video_decode` string - Video Decode.
+* `video_encode` string - Video Encode.
+* `vpx_decode` string - VPx Video Decode.
+* `webgl` string - WebGL.
+* `webgl2` string - WebGL2.
 
 Possible values:
 

--- a/docs/api/structures/input-event.md
+++ b/docs/api/structures/input-event.md
@@ -1,6 +1,6 @@
 # InputEvent Object
 
-* `modifiers` String[] (optional) - An array of modifiers of the event, can
+* `modifiers` string[] (optional) - An array of modifiers of the event, can
   be `shift`, `control`, `ctrl`, `alt`, `meta`, `command`, `cmd`, `isKeypad`,
   `isAutoRepeat`, `leftButtonDown`, `middleButtonDown`, `rightButtonDown`,
   `capsLock`, `numLock`, `left`, `right`.

--- a/docs/api/structures/ipc-main-event.md
+++ b/docs/api/structures/ipc-main-event.md
@@ -5,5 +5,5 @@
 * `sender` WebContents - Returns the `webContents` that sent the message
 * `ports` MessagePortMain[] - A list of MessagePorts that were transferred with this message
 * `reply` Function - A function that will send an IPC message to the renderer frame that sent the original message that you are currently handling.  You should use this method to "reply" to the sent message in order to guarantee the reply will go to the correct process and frame.
-  * `channel` String
+  * `channel` string
   * `...args` any[]

--- a/docs/api/structures/jump-list-category.md
+++ b/docs/api/structures/jump-list-category.md
@@ -1,6 +1,6 @@
 # JumpListCategory Object
 
-* `type` String (optional) - One of the following:
+* `type` string (optional) - One of the following:
   * `tasks` - Items in this category will be placed into the standard `Tasks`
     category. There can be only one such category, and it will always be
     displayed at the bottom of the Jump List.
@@ -10,7 +10,7 @@
     of the category and its items are set by Windows. Items may be added to
     this category indirectly using `app.addRecentDocument(path)`.
   * `custom` - Displays tasks or file links, `name` must be set by the app.
-* `name` String (optional) - Must be set if `type` is `custom`, otherwise it should be
+* `name` string (optional) - Must be set if `type` is `custom`, otherwise it should be
   omitted.
 * `items` JumpListItem[] (optional) - Array of [`JumpListItem`](jump-list-item.md) objects if `type` is `tasks` or
   `custom`, otherwise it should be omitted.

--- a/docs/api/structures/jump-list-item.md
+++ b/docs/api/structures/jump-list-item.md
@@ -1,29 +1,29 @@
 # JumpListItem Object
 
-* `type` String (optional) - One of the following:
+* `type` string (optional) - One of the following:
   * `task` - A task will launch an app with specific arguments.
   * `separator` - Can be used to separate items in the standard `Tasks`
     category.
   * `file` - A file link will open a file using the app that created the
     Jump List, for this to work the app must be registered as a handler for
     the file type (though it doesn't have to be the default handler).
-* `path` String (optional) - Path of the file to open, should only be set if `type` is
+* `path` string (optional) - Path of the file to open, should only be set if `type` is
   `file`.
-* `program` String (optional) - Path of the program to execute, usually you should
+* `program` string (optional) - Path of the program to execute, usually you should
   specify `process.execPath` which opens the current program. Should only be
   set if `type` is `task`.
-* `args` String (optional) - The command line arguments when `program` is executed. Should
+* `args` string (optional) - The command line arguments when `program` is executed. Should
   only be set if `type` is `task`.
-* `title` String (optional) - The text to be displayed for the item in the Jump List.
+* `title` string (optional) - The text to be displayed for the item in the Jump List.
   Should only be set if `type` is `task`.
-* `description` String (optional) - Description of the task (displayed in a tooltip).
+* `description` string (optional) - Description of the task (displayed in a tooltip).
   Should only be set if `type` is `task`.
-* `iconPath` String (optional) - The absolute path to an icon to be displayed in a
+* `iconPath` string (optional) - The absolute path to an icon to be displayed in a
   Jump List, which can be an arbitrary resource file that contains an icon
   (e.g. `.ico`, `.exe`, `.dll`). You can usually specify `process.execPath` to
   show the program icon.
-* `iconIndex` Number (optional) - The index of the icon in the resource file. If a
+* `iconIndex` number (optional) - The index of the icon in the resource file. If a
   resource file contains multiple icons this value can be used to specify the
   zero-based index of the icon that should be displayed for this task. If a
   resource file contains only one icon, this property should be set to zero.
-* `workingDirectory` String (optional) - The working directory. Default is empty.
+* `workingDirectory` string (optional) - The working directory. Default is empty.

--- a/docs/api/structures/keyboard-input-event.md
+++ b/docs/api/structures/keyboard-input-event.md
@@ -1,6 +1,6 @@
 # KeyboardInputEvent Object extends `InputEvent`
 
-* `type` String - The type of the event, can be `keyDown`, `keyUp` or `char`.
-* `keyCode` String - The character that will be sent
+* `type` string - The type of the event, can be `keyDown`, `keyUp` or `char`.
+* `keyCode` string - The character that will be sent
   as the keyboard event. Should only use the valid key codes in
   [Accelerator](../accelerator.md).

--- a/docs/api/structures/mime-typed-buffer.md
+++ b/docs/api/structures/mime-typed-buffer.md
@@ -1,5 +1,5 @@
 # MimeTypedBuffer Object
 
-* `mimeType` String (optional) - MIME type of the buffer.
-* `charset` String (optional) - Charset of the buffer.
+* `mimeType` string (optional) - MIME type of the buffer.
+* `charset` string (optional) - Charset of the buffer.
 * `data` Buffer - The actual Buffer content.

--- a/docs/api/structures/mouse-input-event.md
+++ b/docs/api/structures/mouse-input-event.md
@@ -1,10 +1,10 @@
 # MouseInputEvent Object extends `InputEvent`
 
-* `type` String - The type of the event, can be `mouseDown`,
+* `type` string - The type of the event, can be `mouseDown`,
     `mouseUp`, `mouseEnter`, `mouseLeave`, `contextMenu`, `mouseWheel` or `mouseMove`.
 * `x` Integer
 * `y` Integer
-* `button` String (optional) - The button pressed, can be `left`, `middle`, `right`.
+* `button` string (optional) - The button pressed, can be `left`, `middle`, `right`.
 * `globalX` Integer (optional)
 * `globalY` Integer (optional)
 * `movementX` Integer (optional)

--- a/docs/api/structures/mouse-wheel-input-event.md
+++ b/docs/api/structures/mouse-wheel-input-event.md
@@ -1,11 +1,11 @@
 # MouseWheelInputEvent Object extends `MouseInputEvent`
 
-* `type` String - The type of the event, can be `mouseWheel`.
+* `type` string - The type of the event, can be `mouseWheel`.
 * `deltaX` Integer (optional)
 * `deltaY` Integer (optional)
 * `wheelTicksX` Integer (optional)
 * `wheelTicksY` Integer (optional)
 * `accelerationRatioX` Integer (optional)
 * `accelerationRatioY` Integer (optional)
-* `hasPreciseScrollingDeltas` Boolean (optional)
-* `canScroll` Boolean (optional)
+* `hasPreciseScrollingDeltas` boolean (optional)
+* `canScroll` boolean (optional)

--- a/docs/api/structures/notification-action.md
+++ b/docs/api/structures/notification-action.md
@@ -1,7 +1,7 @@
 # NotificationAction Object
 
-* `type` String - The type of action, can be `button`.
-* `text` String (optional) - The label for the given action.
+* `type` string - The type of action, can be `button`.
+* `text` string (optional) - The label for the given action.
 
 ## Platform / Action Support
 

--- a/docs/api/structures/post-body.md
+++ b/docs/api/structures/post-body.md
@@ -2,10 +2,10 @@
 
 * `data` Array<[PostData](./post-data.md)> - The post data to be sent to the
   new window.
-* `contentType` String - The `content-type` header used for the data. One of
+* `contentType` string - The `content-type` header used for the data. One of
   `application/x-www-form-urlencoded` or `multipart/form-data`. Corresponds to
   the `enctype` attribute of the submitted HTML form.
-* `boundary` String (optional) - The boundary used to separate multiple parts of
+* `boundary` string (optional) - The boundary used to separate multiple parts of
   the message. Only valid when `contentType` is `multipart/form-data`.
 
 Note that keys starting with `--` are not currently supported. For example, this will errantly submit as `multipart/form-data` when `nativeWindowOpen` is set to `false` in webPreferences:

--- a/docs/api/structures/post-data.md
+++ b/docs/api/structures/post-data.md
@@ -1,16 +1,16 @@
 # PostData Object
 
-* `type` String - One of the following:
+* `type` string - One of the following:
   * `rawData` - The data is available as a `Buffer`, in the `rawData` field.
   * `file` - The object represents a file. The `filePath`, `offset`, `length`
     and `modificationTime` fields will be used to describe the file.
   * `blob` - The object represents a `Blob`. The `blobUUID` field will be used
     to describe the `Blob`.
-* `bytes` String (optional) - The raw bytes of the post data in a `Buffer`.
+* `bytes` string (optional) - The raw bytes of the post data in a `Buffer`.
   Required for the `rawData` type.
-* `filePath` String (optional) - The path of the file being uploaded. Required
+* `filePath` string (optional) - The path of the file being uploaded. Required
   for the `file` type.
-* `blobUUID` String (optional) - The `UUID` of the `Blob` being uploaded.
+* `blobUUID` string (optional) - The `UUID` of the `Blob` being uploaded.
   Required for the `blob` type.
 * `offset` Integer (optional) - The offset from the beginning of the file being
   uploaded, in bytes. Only valid for `file` types.

--- a/docs/api/structures/printer-info.md
+++ b/docs/api/structures/printer-info.md
@@ -1,10 +1,10 @@
 # PrinterInfo Object
 
-* `name` String - the name of the printer as understood by the OS.
-* `displayName` String - the name of the printer as shown in Print Preview.
-* `description` String - a longer description of the printer's type.
-* `status` Number - the current status of the printer.
-* `isDefault` Boolean - whether or not a given printer is set as the default printer on the OS.
+* `name` string - the name of the printer as understood by the OS.
+* `displayName` string - the name of the printer as shown in Print Preview.
+* `description` string - a longer description of the printer's type.
+* `status` number - the current status of the printer.
+* `isDefault` boolean - whether or not a given printer is set as the default printer on the OS.
 * `options` Object - an object containing a variable number of platform-specific printer information.
 
 The number represented by `status` means different things on different platforms: on Windows its potential values can be found [here](https://docs.microsoft.com/en-us/windows/win32/printdocs/printer-info-2), and on Linux and macOS they can be found [here](https://www.cups.org/doc/cupspm.html).

--- a/docs/api/structures/process-metric.md
+++ b/docs/api/structures/process-metric.md
@@ -1,7 +1,7 @@
 # ProcessMetric Object
 
 * `pid` Integer - Process id of the process.
-* `type` String - Process type. One of the following values:
+* `type` string - Process type. One of the following values:
   * `Browser`
   * `Tab`
   * `Utility`
@@ -11,16 +11,16 @@
   * `Pepper Plugin`
   * `Pepper Plugin Broker`
   * `Unknown`
-* `name` String (optional) - The name of the process. i.e. for plugins it might be Flash.
+* `name` string (optional) - The name of the process. i.e. for plugins it might be Flash.
     Examples for utility: `Audio Service`, `Content Decryption Module Service`, `Network Service`, `Video Capture`, etc.
 * `cpu` [CPUUsage](cpu-usage.md) - CPU usage of the process.
-* `creationTime` Number - Creation time for this process.
+* `creationTime` number - Creation time for this process.
     The time is represented as number of milliseconds since epoch.
     Since the `pid` can be reused after a process dies,
     it is useful to use both the `pid` and the `creationTime` to uniquely identify a process.
 * `memory` [MemoryInfo](memory-info.md) - Memory information for the process.
-* `sandboxed` Boolean (optional) _macOS_ _Windows_ - Whether the process is sandboxed on OS level.
-* `integrityLevel` String (optional) _Windows_ - One of the following values:
+* `sandboxed` boolean (optional) _macOS_ _Windows_ - Whether the process is sandboxed on OS level.
+* `integrityLevel` string (optional) _Windows_ - One of the following values:
   * `untrusted`
   * `low`
   * `medium`

--- a/docs/api/structures/product.md
+++ b/docs/api/structures/product.md
@@ -1,11 +1,11 @@
 # Product Object
 
-* `productIdentifier` String - The string that identifies the product to the Apple App Store.
-* `localizedDescription` String - A description of the product.
-* `localizedTitle` String - The name of the product.
-* `contentVersion` String - A string that identifies the version of the content.
-* `contentLengths` Number[] - The total size of the content, in bytes.
-* `price` Number - The cost of the product in the local currency.
-* `formattedPrice` String - The locale formatted price of the product.
-* `currencyCode` String - 3 character code presenting a product's currency based on the ISO 4217 standard.
-* `isDownloadable` Boolean - A Boolean value that indicates whether the App Store has downloadable content for this product. `true` if at least one file has been associated with the product.
+* `productIdentifier` string - The string that identifies the product to the Apple App Store.
+* `localizedDescription` string - A description of the product.
+* `localizedTitle` string - The name of the product.
+* `contentVersion` string - A string that identifies the version of the content.
+* `contentLengths` number[] - The total size of the content, in bytes.
+* `price` number - The cost of the product in the local currency.
+* `formattedPrice` string - The locale formatted price of the product.
+* `currencyCode` string - 3 character code presenting a product's currency based on the ISO 4217 standard.
+* `isDownloadable` boolean - A Boolean value that indicates whether the App Store has downloadable content for this product. `true` if at least one file has been associated with the product.

--- a/docs/api/structures/protocol-response-upload-data.md
+++ b/docs/api/structures/protocol-response-upload-data.md
@@ -1,4 +1,4 @@
 # ProtocolResponseUploadData Object
 
-* `contentType` String - MIME type of the content.
-* `data` String | Buffer - Content to be sent.
+* `contentType` string - MIME type of the content.
+* `data` string | Buffer - Content to be sent.

--- a/docs/api/structures/protocol-response.md
+++ b/docs/api/structures/protocol-response.md
@@ -3,27 +3,27 @@
 * `error` Integer (optional) - When assigned, the `request` will fail with the
   `error` number . For the available error numbers you can use, please see the
   [net error list][net-error].
-* `statusCode` Number (optional) - The HTTP response code, default is 200.
-* `charset` String (optional) - The charset of response body, default is
+* `statusCode` number (optional) - The HTTP response code, default is 200.
+* `charset` string (optional) - The charset of response body, default is
   `"utf-8"`.
-* `mimeType` String (optional) - The MIME type of response body, default is
+* `mimeType` string (optional) - The MIME type of response body, default is
   `"text/html"`. Setting `mimeType` would implicitly set the `content-type`
   header in response, but if `content-type` is already set in `headers`, the
   `mimeType` would be ignored.
 * `headers` Record<string, string | string[]> (optional) - An object containing the response headers. The
-  keys must be String, and values must be either String or Array of String.
-* `data` (Buffer | String | ReadableStream) (optional) - The response body. When
+  keys must be string, and values must be either string or Array of string.
+* `data` (Buffer | string | ReadableStream) (optional) - The response body. When
   returning stream as response, this is a Node.js readable stream representing
   the response body. When returning `Buffer` as response, this is a `Buffer`.
-  When returning `String` as response, this is a `String`. This is ignored for
+  When returning `string` as response, this is a `string`. This is ignored for
   other types of responses.
-* `path` String (optional) - Path to the file which would be sent as response
+* `path` string (optional) - Path to the file which would be sent as response
   body. This is only used for file responses.
-* `url` String (optional) - Download the `url` and pipe the result as response
+* `url` string (optional) - Download the `url` and pipe the result as response
   body. This is only used for URL responses.
-* `referrer` String (optional) - The `referrer` URL. This is only used for file
+* `referrer` string (optional) - The `referrer` URL. This is only used for file
   and URL responses.
-* `method` String (optional) - The HTTP `method`. This is only used for file
+* `method` string (optional) - The HTTP `method`. This is only used for file
   and URL responses.
 * `session` Session (optional) - The session used for requesting URL, by default
   the HTTP request will reuse the current session. Setting `session` to `null`

--- a/docs/api/structures/referrer.md
+++ b/docs/api/structures/referrer.md
@@ -1,7 +1,7 @@
 # Referrer Object
 
-* `url` String - HTTP Referrer URL.
-* `policy` String - Can be `default`, `unsafe-url`,
+* `url` string - HTTP Referrer URL.
+* `policy` string - Can be `default`, `unsafe-url`,
   `no-referrer-when-downgrade`, `no-referrer`, `origin`,
   `strict-origin-when-cross-origin`, `same-origin` or `strict-origin`.
   See the [Referrer-Policy spec][1] for more details on the

--- a/docs/api/structures/scrubber-item.md
+++ b/docs/api/structures/scrubber-item.md
@@ -1,4 +1,4 @@
 # ScrubberItem Object
 
-* `label` String (optional) - The text to appear in this item.
+* `label` string (optional) - The text to appear in this item.
 * `icon` NativeImage (optional) - The image to appear in this item.

--- a/docs/api/structures/segmented-control-segment.md
+++ b/docs/api/structures/segmented-control-segment.md
@@ -1,5 +1,5 @@
 # SegmentedControlSegment Object
 
-* `label` String (optional) - The text to appear in this segment.
+* `label` string (optional) - The text to appear in this segment.
 * `icon` NativeImage (optional) - The image to appear in this segment.
-* `enabled` Boolean (optional) - Whether this segment is selectable. Default: true.
+* `enabled` boolean (optional) - Whether this segment is selectable. Default: true.

--- a/docs/api/structures/serial-port.md
+++ b/docs/api/structures/serial-port.md
@@ -1,8 +1,8 @@
 # SerialPort Object
 
-* `portId` String - Unique identifier for the port
-* `portName` String - Name of the port
-* `displayName` String - Addtional information for the port
-* `persistentId` String - This platform-specific identifier, if present, can be used to identify the device across restarts of the application and operating system.
-* `vendorId` String - Optional USB vendor ID
-* `productId` String - Optional USB product ID
+* `portId` string - Unique identifier for the port
+* `portName` string - Name of the port
+* `displayName` string - Addtional information for the port
+* `persistentId` string - This platform-specific identifier, if present, can be used to identify the device across restarts of the application and operating system.
+* `vendorId` string - Optional USB vendor ID
+* `productId` string - Optional USB product ID

--- a/docs/api/structures/service-worker-info.md
+++ b/docs/api/structures/service-worker-info.md
@@ -1,5 +1,5 @@
 # ServiceWorkerInfo Object
 
-* `scriptUrl` String - The full URL to the script that this service worker runs
-* `scope` String - The base URL that this service worker is active for.
-* `renderProcessId` Number - The virtual ID of the process that this service worker is running in.  This is not an OS level PID.  This aligns with the ID set used for `webContents.getProcessId()`.
+* `scriptUrl` string - The full URL to the script that this service worker runs
+* `scope` string - The base URL that this service worker is active for.
+* `renderProcessId` number - The virtual ID of the process that this service worker is running in.  This is not an OS level PID.  This aligns with the ID set used for `webContents.getProcessId()`.

--- a/docs/api/structures/shared-worker-info.md
+++ b/docs/api/structures/shared-worker-info.md
@@ -1,4 +1,4 @@
 # SharedWorkerInfo Object
 
-* `id` String - The unique id of the shared worker.
-* `url` String - The url of the shared worker.
+* `id` string - The unique id of the shared worker.
+* `url` string - The url of the shared worker.

--- a/docs/api/structures/shortcut-details.md
+++ b/docs/api/structures/shortcut-details.md
@@ -1,17 +1,17 @@
 # ShortcutDetails Object
 
-* `target` String - The target to launch from this shortcut.
-* `cwd` String (optional) - The working directory. Default is empty.
-* `args` String (optional) - The arguments to be applied to `target` when
+* `target` string - The target to launch from this shortcut.
+* `cwd` string (optional) - The working directory. Default is empty.
+* `args` string (optional) - The arguments to be applied to `target` when
 launching from this shortcut. Default is empty.
-* `description` String (optional) - The description of the shortcut. Default
+* `description` string (optional) - The description of the shortcut. Default
 is empty.
-* `icon` String (optional) - The path to the icon, can be a DLL or EXE. `icon`
+* `icon` string (optional) - The path to the icon, can be a DLL or EXE. `icon`
 and `iconIndex` have to be set together. Default is empty, which uses the
 target's icon.
-* `iconIndex` Number (optional) - The resource ID of icon when `icon` is a
+* `iconIndex` number (optional) - The resource ID of icon when `icon` is a
 DLL or EXE. Default is 0.
-* `appUserModelId` String (optional) - The Application User Model ID. Default
+* `appUserModelId` string (optional) - The Application User Model ID. Default
 is empty.
-* `toastActivatorClsid` String (optional) - The Application Toast Activator CLSID. Needed
+* `toastActivatorClsid` string (optional) - The Application Toast Activator CLSID. Needed
 for participating in Action Center.

--- a/docs/api/structures/task.md
+++ b/docs/api/structures/task.md
@@ -1,15 +1,15 @@
 # Task Object
 
-* `program` String - Path of the program to execute, usually you should
+* `program` string - Path of the program to execute, usually you should
   specify `process.execPath` which opens the current program.
-* `arguments` String - The command line arguments when `program` is
+* `arguments` string - The command line arguments when `program` is
   executed.
-* `title` String - The string to be displayed in a JumpList.
-* `description` String - Description of this task.
-* `iconPath` String - The absolute path to an icon to be displayed in a
+* `title` string - The string to be displayed in a JumpList.
+* `description` string - Description of this task.
+* `iconPath` string - The absolute path to an icon to be displayed in a
   JumpList, which can be an arbitrary resource file that contains an icon. You
   can usually specify `process.execPath` to show the icon of the program.
-* `iconIndex` Number - The icon index in the icon file. If an icon file
+* `iconIndex` number - The icon index in the icon file. If an icon file
   consists of two or more icons, set this value to identify the icon. If an
   icon file consists of one icon, this value is 0.
-* `workingDirectory` String (optional) - The working directory. Default is empty.
+* `workingDirectory` string (optional) - The working directory. Default is empty.

--- a/docs/api/structures/thumbar-button.md
+++ b/docs/api/structures/thumbar-button.md
@@ -3,11 +3,11 @@
 * `icon` [NativeImage](../native-image.md) - The icon showing in thumbnail
   toolbar.
 * `click` Function
-* `tooltip` String (optional) - The text of the button's tooltip.
-* `flags` String[] (optional) - Control specific states and behaviors of the
+* `tooltip` string (optional) - The text of the button's tooltip.
+* `flags` string[] (optional) - Control specific states and behaviors of the
   button. By default, it is `['enabled']`.
 
-The `flags` is an array that can include following `String`s:
+The `flags` is an array that can include following `string`s:
 
 * `enabled` - The button is active and available to the user.
 * `disabled` - The button is disabled. It is present, but has a visual state

--- a/docs/api/structures/trace-categories-and-options.md
+++ b/docs/api/structures/trace-categories-and-options.md
@@ -1,11 +1,11 @@
 # TraceCategoriesAndOptions Object
 
-* `categoryFilter` String - A filter to control what category groups
+* `categoryFilter` string - A filter to control what category groups
   should be traced. A filter can have an optional '-' prefix to exclude
   category groups that contain a matching category. Having both included
   and excluded category patterns in the same list is not supported. Examples:
   `test_MyTest*`, `test_MyTest*,test_OtherStuff`, `-excluded_category1,-excluded_category2`.
-* `traceOptions` String - Controls what kind of tracing is enabled,
+* `traceOptions` string - Controls what kind of tracing is enabled,
   it is a comma-delimited sequence of the following strings:
   `record-until-full`, `record-continuously`, `trace-to-console`, `enable-sampling`, `enable-systrace`,
   e.g. `'record-until-full,enable-sampling'`.

--- a/docs/api/structures/trace-config.md
+++ b/docs/api/structures/trace-config.md
@@ -1,6 +1,6 @@
 # TraceConfig Object
 
-* `recording_mode` String (optional) - Can be `record-until-full`, `record-continuously`, `record-as-much-as-possible` or `trace-to-console`. Defaults to `record-until-full`.
+* `recording_mode` string (optional) - Can be `record-until-full`, `record-continuously`, `record-as-much-as-possible` or `trace-to-console`. Defaults to `record-until-full`.
 * `trace_buffer_size_in_kb` number (optional) - maximum size of the trace
   recording buffer in kilobytes. Defaults to 100MB.
 * `trace_buffer_size_in_events` number (optional) - maximum size of the trace
@@ -9,17 +9,17 @@
   according to a specific list of events that have been manually vetted to not
   include any PII. See [the implementation in
   Chromium][trace_event_args_whitelist.cc] for specifics.
-* `included_categories` String[] (optional) - a list of tracing categories to
+* `included_categories` string[] (optional) - a list of tracing categories to
   include. Can include glob-like patterns using `*` at the end of the category
   name. See [tracing categories][] for the list of categories.
-* `excluded_categories` String[] (optional) - a list of tracing categories to
+* `excluded_categories` string[] (optional) - a list of tracing categories to
   exclude. Can include glob-like patterns using `*` at the end of the category
   name. See [tracing categories][] for the list of categories.
 * `included_process_ids` number[] (optional) - a list of process IDs to
   include in the trace. If not specified, trace all processes.
-* `histogram_names` String[] (optional) - a list of [histogram][] names to report
+* `histogram_names` string[] (optional) - a list of [histogram][] names to report
   with the trace.
-* `memory_dump_config` Record<String, any> (optional) - if the
+* `memory_dump_config` Record<string, any> (optional) - if the
   `disabled-by-default-memory-infra` category is enabled, this contains
   optional additional configuration for data collection. See the [Chromium
   memory-infra docs][memory-infra docs] for more information.

--- a/docs/api/structures/transaction.md
+++ b/docs/api/structures/transaction.md
@@ -1,11 +1,11 @@
 # Transaction Object
 
-* `transactionIdentifier` String - A string that uniquely identifies a successful payment transaction.
-* `transactionDate` String - The date the transaction was added to the App Store’s payment queue.
-* `originalTransactionIdentifier` String - The identifier of the restored transaction by the App Store.
-* `transactionState` String - The transaction state, can be `purchasing`, `purchased`, `failed`, `restored` or `deferred`.
+* `transactionIdentifier` string - A string that uniquely identifies a successful payment transaction.
+* `transactionDate` string - The date the transaction was added to the App Store’s payment queue.
+* `originalTransactionIdentifier` string - The identifier of the restored transaction by the App Store.
+* `transactionState` string - The transaction state, can be `purchasing`, `purchased`, `failed`, `restored` or `deferred`.
 * `errorCode` Integer - The error code if an error occurred while processing the transaction.
-* `errorMessage` String - The error message if an error occurred while processing the transaction.
+* `errorMessage` string - The error message if an error occurred while processing the transaction.
 * `payment` Object
-  * `productIdentifier` String - The identifier of the purchased product.
+  * `productIdentifier` string - The identifier of the purchased product.
   * `quantity` Integer  - The quantity purchased.

--- a/docs/api/structures/upload-blob.md
+++ b/docs/api/structures/upload-blob.md
@@ -1,4 +1,4 @@
 # UploadBlob Object
 
-* `type` String - `blob`.
-* `blobUUID` String - UUID of blob data to upload.
+* `type` string - `blob`.
+* `blobUUID` string - UUID of blob data to upload.

--- a/docs/api/structures/upload-data.md
+++ b/docs/api/structures/upload-data.md
@@ -1,6 +1,6 @@
 # UploadData Object
 
 * `bytes` Buffer - Content being sent.
-* `file` String (optional) - Path of file being uploaded.
-* `blobUUID` String (optional) - UUID of blob data. Use [ses.getBlobData](../session.md#sesgetblobdataidentifier) method
+* `file` string (optional) - Path of file being uploaded.
+* `blobUUID` string (optional) - UUID of blob data. Use [ses.getBlobData](../session.md#sesgetblobdataidentifier) method
   to retrieve the data.

--- a/docs/api/structures/upload-file.md
+++ b/docs/api/structures/upload-file.md
@@ -1,7 +1,7 @@
 # UploadFile Object
 
-* `type` String - `file`.
-* `filePath` String - Path of file to be uploaded.
+* `type` string - `file`.
+* `filePath` string - Path of file to be uploaded.
 * `offset` Integer - Defaults to `0`.
 * `length` Integer - Number of bytes to read from `offset`.
   Defaults to `0`.

--- a/docs/api/structures/upload-raw-data.md
+++ b/docs/api/structures/upload-raw-data.md
@@ -1,4 +1,4 @@
 # UploadRawData Object
 
-* `type` String - `rawData`.
+* `type` string - `rawData`.
 * `bytes` Buffer - Data to be uploaded.

--- a/docs/api/structures/web-source.md
+++ b/docs/api/structures/web-source.md
@@ -1,5 +1,5 @@
 # WebSource Object
 
-* `code` String
-* `url` String (optional)
+* `code` string
+* `url` string (optional)
 * `startLine` Integer (optional) - Default is 1.

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -18,7 +18,7 @@ The `systemPreferences` object emits the following events:
 Returns:
 
 * `event` Event
-* `newColor` String - The new RGBA color the user assigned to be their system
+* `newColor` string - The new RGBA color the user assigned to be their system
   accent color.
 
 ### Event: 'color-changed' _Windows_
@@ -32,7 +32,7 @@ Returns:
 Returns:
 
 * `event` Event
-* `invertedColorScheme` Boolean - `true` if an inverted color scheme (a high contrast color scheme with light text and dark backgrounds) is being used, `false` otherwise.
+* `invertedColorScheme` boolean - `true` if an inverted color scheme (a high contrast color scheme with light text and dark backgrounds) is being used, `false` otherwise.
 
 **Deprecated:** Should use the new [`updated`](native-theme.md#event-updated) event on the `nativeTheme` module.
 
@@ -41,7 +41,7 @@ Returns:
 Returns:
 
 * `event` Event
-* `highContrastColorScheme` Boolean - `true` if a high contrast theme is being used, `false` otherwise.
+* `highContrastColorScheme` boolean - `true` if a high contrast theme is being used, `false` otherwise.
 
 **Deprecated:** Should use the new [`updated`](native-theme.md#event-updated) event on the `nativeTheme` module.
 
@@ -49,7 +49,7 @@ Returns:
 
 ### `systemPreferences.isDarkMode()` _macOS_ _Windows_ _Deprecated_
 
-Returns `Boolean` - Whether the system is in Dark Mode.
+Returns `boolean` - Whether the system is in Dark Mode.
 
 **Note:** On macOS 10.15 Catalina in order for this API to return the correct value when in the "automatic" dark mode setting you must either have `NSRequiresAquaSystemAppearance=false` in your `Info.plist` or be on Electron `>=7.0.0`.  See the [dark mode guide](../tutorial/mojave-dark-mode-guide.md) for more information.
 
@@ -57,48 +57,48 @@ Returns `Boolean` - Whether the system is in Dark Mode.
 
 ### `systemPreferences.isSwipeTrackingFromScrollEventsEnabled()` _macOS_
 
-Returns `Boolean` - Whether the Swipe between pages setting is on.
+Returns `boolean` - Whether the Swipe between pages setting is on.
 
 ### `systemPreferences.postNotification(event, userInfo[, deliverImmediately])` _macOS_
 
-* `event` String
-* `userInfo` Record<String, any>
-* `deliverImmediately` Boolean (optional) - `true` to post notifications immediately even when the subscribing app is inactive.
+* `event` string
+* `userInfo` Record<string, any>
+* `deliverImmediately` boolean (optional) - `true` to post notifications immediately even when the subscribing app is inactive.
 
 Posts `event` as native notifications of macOS. The `userInfo` is an Object
 that contains the user information dictionary sent along with the notification.
 
 ### `systemPreferences.postLocalNotification(event, userInfo)` _macOS_
 
-* `event` String
-* `userInfo` Record<String, any>
+* `event` string
+* `userInfo` Record<string, any>
 
 Posts `event` as native notifications of macOS. The `userInfo` is an Object
 that contains the user information dictionary sent along with the notification.
 
 ### `systemPreferences.postWorkspaceNotification(event, userInfo)` _macOS_
 
-* `event` String
-* `userInfo` Record<String, any>
+* `event` string
+* `userInfo` Record<string, any>
 
 Posts `event` as native notifications of macOS. The `userInfo` is an Object
 that contains the user information dictionary sent along with the notification.
 
 ### `systemPreferences.subscribeNotification(event, callback)` _macOS_
 
-* `event` String
+* `event` string
 * `callback` Function
-  * `event` String
-  * `userInfo` Record<String, unknown>
-  * `object` String
+  * `event` string
+  * `userInfo` Record<string, unknown>
+  * `object` string
 
-Returns `Number` - The ID of this subscription
+Returns `number` - The ID of this subscription
 
 Subscribes to native notifications of macOS, `callback` will be called with
 `callback(event, userInfo)` when the corresponding `event` happens. The
 `userInfo` is an Object that contains the user information dictionary sent
 along with the notification. The `object` is the sender of the notification,
-and only supports `NSString` values for now.
+and only supports `NSstring` values for now.
 
 The `id` of the subscriber is returned, which can be used to unsubscribe the
 `event`.
@@ -113,24 +113,24 @@ example values of `event` are:
 
 ### `systemPreferences.subscribeLocalNotification(event, callback)` _macOS_
 
-* `event` String
+* `event` string
 * `callback` Function
-  * `event` String
-  * `userInfo` Record<String, unknown>
-  * `object` String
+  * `event` string
+  * `userInfo` Record<string, unknown>
+  * `object` string
 
-Returns `Number` - The ID of this subscription
+Returns `number` - The ID of this subscription
 
 Same as `subscribeNotification`, but uses `NSNotificationCenter` for local defaults.
 This is necessary for events such as `NSUserDefaultsDidChangeNotification`.
 
 ### `systemPreferences.subscribeWorkspaceNotification(event, callback)` _macOS_
 
-* `event` String
+* `event` string
 * `callback` Function
-  * `event` String
-  * `userInfo` Record<String, unknown>
-  * `object` String
+  * `event` string
+  * `userInfo` Record<string, unknown>
+  * `object` string
 
 Same as `subscribeNotification`, but uses `NSWorkspace.sharedWorkspace.notificationCenter`.
 This is necessary for events such as `NSWorkspaceDidActivateApplicationNotification`.
@@ -155,14 +155,14 @@ Same as `unsubscribeNotification`, but removes the subscriber from `NSWorkspace.
 
 ### `systemPreferences.registerDefaults(defaults)` _macOS_
 
-* `defaults` Record<String, String | Boolean | Number> - a dictionary of (`key: value`) user defaults
+* `defaults` Record<string, string | boolean | number> - a dictionary of (`key: value`) user defaults
 
 Add the specified defaults to your application's `NSUserDefaults`.
 
 ### `systemPreferences.getUserDefault(key, type)` _macOS_
 
-* `key` String
-* `type` String - Can be `string`, `boolean`, `integer`, `float`, `double`,
+* `key` string
+* `type` string - Can be `string`, `boolean`, `integer`, `float`, `double`,
   `url`, `array` or `dictionary`.
 
 Returns `any` - The value of `key` in `NSUserDefaults`.
@@ -179,9 +179,9 @@ Some popular `key` and `type`s are:
 
 ### `systemPreferences.setUserDefault(key, type, value)` _macOS_
 
-* `key` String
-* `type` String - Can be `string`, `boolean`, `integer`, `float`, `double`, `url`, `array` or `dictionary`.
-* `value` String
+* `key` string
+* `type` string - Can be `string`, `boolean`, `integer`, `float`, `double`, `url`, `array` or `dictionary`.
+* `value` string
 
 Set the value of `key` in `NSUserDefaults`.
 
@@ -194,14 +194,14 @@ Some popular `key` and `type`s are:
 
 ### `systemPreferences.removeUserDefault(key)` _macOS_
 
-* `key` String
+* `key` string
 
 Removes the `key` in `NSUserDefaults`. This can be used to restore the default
 or global value of a `key` previously set with `setUserDefault`.
 
 ### `systemPreferences.isAeroGlassEnabled()` _Windows_
 
-Returns `Boolean` - `true` if [DWM composition][dwm-composition] (Aero Glass) is
+Returns `boolean` - `true` if [DWM composition][dwm-composition] (Aero Glass) is
 enabled, and `false` otherwise.
 
 An example of using it to determine if you should create a transparent window or
@@ -233,7 +233,7 @@ if (browserOptions.transparent) {
 
 ### `systemPreferences.getAccentColor()` _Windows_ _macOS_
 
-Returns `String` - The users current system wide accent color preference in RGBA
+Returns `string` - The users current system wide accent color preference in RGBA
 hexadecimal form.
 
 ```js
@@ -248,7 +248,7 @@ This API is only available on macOS 10.14 Mojave or newer.
 
 ### `systemPreferences.getColor(color)` _Windows_ _macOS_
 
-* `color` String - One of the following values:
+* `color` string - One of the following values:
   * On **Windows**:
     * `3d-dark-shadow` - Dark shadow for three-dimensional display elements.
     * `3d-face` - Face color for three-dimensional display elements and for dialog
@@ -325,7 +325,7 @@ This API is only available on macOS 10.14 Mojave or newer.
     * `window-background` - The background of a window.
     * `window-frame-text` - The text in the window's titlebar area.
 
-Returns `String` - The system color setting in RGB hexadecimal form (`#ABCDEF`).
+Returns `string` - The system color setting in RGB hexadecimal form (`#ABCDEF`).
 See the [Windows docs][windows-colors] and the [macOS docs][macos-colors] for more details.
 
 The following colors are only available on macOS 10.14: `find-highlight`, `selected-content-background`, `separator`, `unemphasized-selected-content-background`, `unemphasized-selected-text-background`, and `unemphasized-selected-text`.
@@ -335,7 +335,7 @@ The following colors are only available on macOS 10.14: `find-highlight`, `selec
 
 ### `systemPreferences.getSystemColor(color)` _macOS_
 
-* `color` String - One of the following values:
+* `color` string - One of the following values:
   * `blue`
   * `brown`
   * `gray`
@@ -346,32 +346,32 @@ The following colors are only available on macOS 10.14: `find-highlight`, `selec
   * `red`
   * `yellow`
 
-Returns `String` - The standard system color formatted as `#RRGGBBAA`.
+Returns `string` - The standard system color formatted as `#RRGGBBAA`.
 
 Returns one of several standard system colors that automatically adapt to vibrancy and changes in accessibility settings like 'Increase contrast' and 'Reduce transparency'. See [Apple Documentation](https://developer.apple.com/design/human-interface-guidelines/macos/visual-design/color#system-colors) for  more details.
 
 ### `systemPreferences.isInvertedColorScheme()` _Windows_ _Deprecated_
 
-Returns `Boolean` - `true` if an inverted color scheme (a high contrast color scheme with light text and dark backgrounds) is active, `false` otherwise.
+Returns `boolean` - `true` if an inverted color scheme (a high contrast color scheme with light text and dark backgrounds) is active, `false` otherwise.
 
 **Deprecated:** Should use the new [`nativeTheme.shouldUseInvertedColorScheme`](native-theme.md#nativethemeshoulduseinvertedcolorscheme-macos-windows-readonly) API.
 
 ### `systemPreferences.isHighContrastColorScheme()` _macOS_ _Windows_ _Deprecated_
 
-Returns `Boolean` - `true` if a high contrast theme is active, `false` otherwise.
+Returns `boolean` - `true` if a high contrast theme is active, `false` otherwise.
 
 **Deprecated:** Should use the new [`nativeTheme.shouldUseHighContrastColors`](native-theme.md#nativethemeshouldusehighcontrastcolors-macos-windows-readonly) API.
 
 ### `systemPreferences.getEffectiveAppearance()` _macOS_
 
-Returns `String` - Can be `dark`, `light` or `unknown`.
+Returns `string` - Can be `dark`, `light` or `unknown`.
 
 Gets the macOS appearance setting that is currently applied to your application,
 maps to [NSApplication.effectiveAppearance](https://developer.apple.com/documentation/appkit/nsapplication/2967171-effectiveappearance?language=objc)
 
 ### `systemPreferences.getAppLevelAppearance()` _macOS_ _Deprecated_
 
-Returns `String` | `null` - Can be `dark`, `light` or `unknown`.
+Returns `string` | `null` - Can be `dark`, `light` or `unknown`.
 
 Gets the macOS appearance setting that you have declared you want for
 your application, maps to [NSApplication.appearance](https://developer.apple.com/documentation/appkit/nsapplication/2967170-appearance?language=objc).
@@ -379,20 +379,20 @@ You can use the `setAppLevelAppearance` API to set this value.
 
 ### `systemPreferences.setAppLevelAppearance(appearance)` _macOS_ _Deprecated_
 
-* `appearance` String | null - Can be `dark` or `light`
+* `appearance` string | null - Can be `dark` or `light`
 
 Sets the appearance setting for your application, this should override the
 system default and override the value of `getEffectiveAppearance`.
 
 ### `systemPreferences.canPromptTouchID()` _macOS_
 
-Returns `Boolean` - whether or not this device has the ability to use Touch ID.
+Returns `boolean` - whether or not this device has the ability to use Touch ID.
 
 **NOTE:** This API will return `false` on macOS systems older than Sierra 10.12.2.
 
 ### `systemPreferences.promptTouchID(reason)` _macOS_
 
-* `reason` String - The reason you are asking for Touch ID authentication
+* `reason` string - The reason you are asking for Touch ID authentication
 
 Returns `Promise<void>` - resolves if the user has successfully authenticated with Touch ID.
 
@@ -412,15 +412,15 @@ This API itself will not protect your user data; rather, it is a mechanism to al
 
 ### `systemPreferences.isTrustedAccessibilityClient(prompt)` _macOS_
 
-* `prompt` Boolean - whether or not the user will be informed via prompt if the current process is untrusted.
+* `prompt` boolean - whether or not the user will be informed via prompt if the current process is untrusted.
 
-Returns `Boolean` - `true` if the current process is a trusted accessibility client and `false` if it is not.
+Returns `boolean` - `true` if the current process is a trusted accessibility client and `false` if it is not.
 
 ### `systemPreferences.getMediaAccessStatus(mediaType)` _Windows_ _macOS_
 
-* `mediaType` String - Can be `microphone`, `camera` or `screen`.
+* `mediaType` string - Can be `microphone`, `camera` or `screen`.
 
-Returns `String` - Can be `not-determined`, `granted`, `denied`, `restricted` or `unknown`.
+Returns `string` - Can be `not-determined`, `granted`, `denied`, `restricted` or `unknown`.
 
 This user consent was not required on macOS 10.13 High Sierra or lower so this method will always return `granted`.
 macOS 10.14 Mojave or higher requires consent for `microphone` and `camera` access.
@@ -431,9 +431,9 @@ It will always return `granted` for `screen` and for all media types on older ve
 
 ### `systemPreferences.askForMediaAccess(mediaType)` _macOS_
 
-* `mediaType` String - the type of media being requested; can be `microphone`, `camera`.
+* `mediaType` string - the type of media being requested; can be `microphone`, `camera`.
 
-Returns `Promise<Boolean>` - A promise that resolves with `true` if consent was granted and `false` if it was denied. If an invalid `mediaType` is passed, the promise will be rejected. If an access request was denied and later is changed through the System Preferences pane, a restart of the app will be required for the new permissions to take effect. If access has already been requested and denied, it _must_ be changed through the preference pane; an alert will not pop up and the promise will resolve with the existing access status.
+Returns `Promise<boolean>` - A promise that resolves with `true` if consent was granted and `false` if it was denied. If an invalid `mediaType` is passed, the promise will be rejected. If an access request was denied and later is changed through the System Preferences pane, a restart of the app will be required for the new permissions to take effect. If access has already been requested and denied, it _must_ be changed through the preference pane; an alert will not pop up and the promise will resolve with the existing access status.
 
 **Important:** In order to properly leverage this API, you [must set](https://developer.apple.com/documentation/avfoundation/cameras_and_media_capture/requesting_authorization_for_media_capture_on_macos?language=objc) the `NSMicrophoneUsageDescription` and `NSCameraUsageDescription` strings in your app's `Info.plist` file. The values for these keys will be used to populate the permission dialogs so that the user will be properly informed as to the purpose of the permission request. See [Electron Application Distribution](https://electronjs.org/docs/tutorial/application-distribution#macos) for more information about how to set these in the context of Electron.
 
@@ -443,9 +443,9 @@ This user consent was not required until macOS 10.14 Mojave, so this method will
 
 Returns `Object`:
 
-* `shouldRenderRichAnimation` Boolean - Returns true if rich animations should be rendered. Looks at session type (e.g. remote desktop) and accessibility settings to give guidance for heavy animations.
-* `scrollAnimationsEnabledBySystem` Boolean - Determines on a per-platform basis whether scroll animations (e.g. produced by home/end key) should be enabled.
-* `prefersReducedMotion` Boolean - Determines whether the user desires reduced motion based on platform APIs.
+* `shouldRenderRichAnimation` boolean - Returns true if rich animations should be rendered. Looks at session type (e.g. remote desktop) and accessibility settings to give guidance for heavy animations.
+* `scrollAnimationsEnabledBySystem` boolean - Determines on a per-platform basis whether scroll animations (e.g. produced by home/end key) should be enabled.
+* `prefersReducedMotion` boolean - Determines whether the user desires reduced motion based on platform APIs.
 
 Returns an object with system animation settings.
 
@@ -453,7 +453,7 @@ Returns an object with system animation settings.
 
 ### `systemPreferences.appLevelAppearance` _macOS_
 
-A `String` property that can be `dark`, `light` or `unknown`. It determines the macOS appearance setting for
+A `string` property that can be `dark`, `light` or `unknown`. It determines the macOS appearance setting for
 your application. This maps to values in: [NSApplication.appearance](https://developer.apple.com/documentation/appkit/nsapplication/2967170-appearance?language=objc). Setting this will override the
 system default as well as the value of `getEffectiveAppearance`.
 
@@ -463,7 +463,7 @@ This property is only available on macOS 10.14 Mojave or newer.
 
 ### `systemPreferences.effectiveAppearance` _macOS_ _Readonly_
 
-A `String` property that can be `dark`, `light` or `unknown`.
+A `string` property that can be `dark`, `light` or `unknown`.
 
 Returns the macOS appearance setting that is currently applied to your application,
 maps to [NSApplication.effectiveAppearance](https://developer.apple.com/documentation/appkit/nsapplication/2967171-effectiveappearance?language=objc)

--- a/docs/api/touch-bar-button.md
+++ b/docs/api/touch-bar-button.md
@@ -7,14 +7,14 @@ Process: [Main](../tutorial/application-architecture.md#main-and-renderer-proces
 ### `new TouchBarButton(options)`
 
 * `options` Object
-  * `label` String (optional) - Button text.
-  * `accessibilityLabel` String (optional) - A short description of the button for use by screenreaders like VoiceOver.
-  * `backgroundColor` String (optional) - Button background color in hex format,
+  * `label` string (optional) - Button text.
+  * `accessibilityLabel` string (optional) - A short description of the button for use by screenreaders like VoiceOver.
+  * `backgroundColor` string (optional) - Button background color in hex format,
     i.e `#ABCDEF`.
-  * `icon` [NativeImage](native-image.md) | String (optional) - Button icon.
-  * `iconPosition` String (optional) - Can be `left`, `right` or `overlay`. Defaults to `overlay`.
+  * `icon` [NativeImage](native-image.md) | string (optional) - Button icon.
+  * `iconPosition` string (optional) - Can be `left`, `right` or `overlay`. Defaults to `overlay`.
   * `click` Function (optional) - Function to call when the button is clicked.
-  * `enabled` Boolean (optional) - Whether the button is in an enabled state.  Default is `true`.
+  * `enabled` string (optional) - Whether the button is in an enabled state.  Default is `true`.
 
 When defining `accessibilityLabel`, ensure you have considered macOS [best practices](https://developer.apple.com/documentation/appkit/nsaccessibilitybutton/1524910-accessibilitylabel?language=objc).
 
@@ -24,16 +24,16 @@ The following properties are available on instances of `TouchBarButton`:
 
 #### `touchBarButton.accessibilityLabel`
 
-A `String` representing the description of the button to be read by a screen reader. Will only be read by screen readers if no label is set.
+A `string` representing the description of the button to be read by a screen reader. Will only be read by screen readers if no label is set.
 
 #### `touchBarButton.label`
 
-A `String` representing the button's current text. Changing this value immediately updates the button
+A `string` representing the button's current text. Changing this value immediately updates the button
 in the touch bar.
 
 #### `touchBarButton.backgroundColor`
 
-A `String` hex code representing the button's current background color. Changing this value immediately updates
+A `string` hex code representing the button's current background color. Changing this value immediately updates
 the button in the touch bar.
 
 #### `touchBarButton.icon`
@@ -43,8 +43,8 @@ in the touch bar.
 
 #### `touchBarButton.iconPosition`
 
-A `String` - Can be `left`, `right` or `overlay`.  Defaults to `overlay`.
+A `string` - Can be `left`, `right` or `overlay`.  Defaults to `overlay`.
 
 #### `touchBarButton.enabled`
 
-A `Boolean` representing whether the button is in an enabled state.
+A `string` representing whether the button is in an enabled state.

--- a/docs/api/touch-bar-color-picker.md
+++ b/docs/api/touch-bar-color-picker.md
@@ -7,12 +7,12 @@ Process: [Main](../tutorial/application-architecture.md#main-and-renderer-proces
 ### `new TouchBarColorPicker(options)`
 
 * `options` Object
-  * `availableColors` String[] (optional) - Array of hex color strings to
+  * `availableColors` string[] (optional) - Array of hex color strings to
     appear as possible colors to select.
-  * `selectedColor` String (optional) - The selected hex color in the picker,
+  * `selectedColor` string (optional) - The selected hex color in the picker,
     i.e `#ABCDEF`.
   * `change` Function (optional) - Function to call when a color is selected.
-    * `color` String - The color that the user selected from the picker.
+    * `color` string - The color that the user selected from the picker.
 
 ### Instance Properties
 
@@ -20,10 +20,10 @@ The following properties are available on instances of `TouchBarColorPicker`:
 
 #### `touchBarColorPicker.availableColors`
 
-A `String[]` array representing the color picker's available colors to select. Changing this value immediately
+A `string[]` array representing the color picker's available colors to select. Changing this value immediately
 updates the color picker in the touch bar.
 
 #### `touchBarColorPicker.selectedColor`
 
-A `String` hex code representing the color picker's currently selected color. Changing this value immediately
+A `string` hex code representing the color picker's currently selected color. Changing this value immediately
 updates the color picker in the touch bar.

--- a/docs/api/touch-bar-label.md
+++ b/docs/api/touch-bar-label.md
@@ -7,9 +7,9 @@ Process: [Main](../tutorial/application-architecture.md#main-and-renderer-proces
 ### `new TouchBarLabel(options)`
 
 * `options` Object
-  * `label` String (optional) - Text to display.
-  * `accessibilityLabel` String (optional) - A short description of the button for use by screenreaders like VoiceOver.
-  * `textColor` String (optional) - Hex color of text, i.e `#ABCDEF`.
+  * `label` string (optional) - Text to display.
+  * `accessibilityLabel` string (optional) - A short description of the button for use by screenreaders like VoiceOver.
+  * `textColor` string (optional) - Hex color of text, i.e `#ABCDEF`.
 
 When defining `accessibilityLabel`, ensure you have considered macOS [best practices](https://developer.apple.com/documentation/appkit/nsaccessibilitybutton/1524910-accessibilitylabel?language=objc).
 
@@ -19,14 +19,14 @@ The following properties are available on instances of `TouchBarLabel`:
 
 #### `touchBarLabel.label`
 
-A `String` representing the label's current text. Changing this value immediately updates the label in
+A `string` representing the label's current text. Changing this value immediately updates the label in
 the touch bar.
 
 #### `touchBarLabel.accessibilityLabel`
 
-A `String` representing the description of the label to be read by a screen reader.
+A `string` representing the description of the label to be read by a screen reader.
 
 #### `touchBarLabel.textColor`
 
-A `String` hex code representing the label's current text color. Changing this value immediately updates the
+A `string` hex code representing the label's current text color. Changing this value immediately updates the
 label in the touch bar.

--- a/docs/api/touch-bar-popover.md
+++ b/docs/api/touch-bar-popover.md
@@ -7,7 +7,7 @@ Process: [Main](../tutorial/application-architecture.md#main-and-renderer-proces
 ### `new TouchBarPopover(options)`
 
 * `options` Object
-  * `label` String (optional) - Popover button text.
+  * `label` string (optional) - Popover button text.
   * `icon` [NativeImage](native-image.md) (optional) - Popover button icon.
   * `items` [TouchBar](touch-bar.md) - Items to display in the popover.
   * `showCloseButton` Boolean (optional) - `true` to display a close button
@@ -19,7 +19,7 @@ The following properties are available on instances of `TouchBarPopover`:
 
 #### `touchBarPopover.label`
 
-A `String` representing the popover's current button text. Changing this value immediately updates the
+A `string` representing the popover's current button text. Changing this value immediately updates the
 popover in the touch bar.
 
 #### `touchBarPopover.icon`

--- a/docs/api/touch-bar-popover.md
+++ b/docs/api/touch-bar-popover.md
@@ -10,7 +10,7 @@ Process: [Main](../tutorial/application-architecture.md#main-and-renderer-proces
   * `label` string (optional) - Popover button text.
   * `icon` [NativeImage](native-image.md) (optional) - Popover button icon.
   * `items` [TouchBar](touch-bar.md) - Items to display in the popover.
-  * `showCloseButton` Boolean (optional) - `true` to display a close button
+  * `showCloseButton` boolean (optional) - `true` to display a close button
     on the left of the popover, `false` to not show it. Default is `true`.
 
 ### Instance Properties

--- a/docs/api/touch-bar-scrubber.md
+++ b/docs/api/touch-bar-scrubber.md
@@ -12,11 +12,11 @@ Process: [Main](../tutorial/application-architecture.md#main-and-renderer-proces
     * `selectedIndex` Integer - The index of the item the user selected.
   * `highlight` Function (optional) - Called when the user taps any item.
     * `highlightedIndex` Integer - The index of the item the user touched.
-  * `selectedStyle` String (optional) - Selected item style. Can be `background`, `outline` or `none`. Defaults to `none`.
-  * `overlayStyle` String (optional) - Selected overlay item style. Can be `background`, `outline` or `none`. Defaults to `none`.
-  * `showArrowButtons` Boolean (optional) - Defaults to `false`.
-  * `mode` String (optional) - Can be `fixed` or `free`. The default is `free`.
-  * `continuous` Boolean (optional) - Defaults to `true`.
+  * `selectedStyle` string (optional) - Selected item style. Can be `background`, `outline` or `none`. Defaults to `none`.
+  * `overlayStyle` string (optional) - Selected overlay item style. Can be `background`, `outline` or `none`. Defaults to `none`.
+  * `showArrowButtons` boolean (optional) - Defaults to `false`.
+  * `mode` string (optional) - Can be `fixed` or `free`. The default is `free`.
+  * `continuous` boolean (optional) - Defaults to `true`.
 
 ### Instance Properties
 
@@ -29,7 +29,7 @@ updates the control in the touch bar. Updating deep properties inside this array
 
 #### `touchBarScrubber.selectedStyle`
 
-A `String` representing the style that selected items in the scrubber should have. Updating this value immediately
+A `string` representing the style that selected items in the scrubber should have. Updating this value immediately
 updates the control in the touch bar. Possible values:
 
 * `background` - Maps to `[NSScrubberSelectionStyle roundedBackgroundStyle]`.
@@ -38,7 +38,7 @@ updates the control in the touch bar. Possible values:
 
 #### `touchBarScrubber.overlayStyle`
 
-A `String` representing the style that selected items in the scrubber should have. This style is overlayed on top
+A `string` representing the style that selected items in the scrubber should have. This style is overlayed on top
 of the scrubber item instead of being placed behind it. Updating this value immediately updates the control in the
 touch bar. Possible values:
 
@@ -48,12 +48,12 @@ touch bar. Possible values:
 
 #### `touchBarScrubber.showArrowButtons`
 
-A `Boolean` representing whether to show the left / right selection arrows in this scrubber. Updating this value
+A `boolean` representing whether to show the left / right selection arrows in this scrubber. Updating this value
 immediately updates the control in the touch bar.
 
 #### `touchBarScrubber.mode`
 
-A `String` representing the mode of this scrubber. Updating this value immediately
+A `string` representing the mode of this scrubber. Updating this value immediately
 updates the control in the touch bar. Possible values:
 
 * `fixed` - Maps to `NSScrubberModeFixed`.
@@ -61,5 +61,5 @@ updates the control in the touch bar. Possible values:
 
 #### `touchBarScrubber.continuous`
 
-A `Boolean` representing whether this scrubber is continuous or not. Updating this value immediately
+A `boolean` representing whether this scrubber is continuous or not. Updating this value immediately
 updates the control in the touch bar.

--- a/docs/api/touch-bar-segmented-control.md
+++ b/docs/api/touch-bar-segmented-control.md
@@ -7,7 +7,7 @@ Process: [Main](../tutorial/application-architecture.md#main-and-renderer-proces
 ### `new TouchBarSegmentedControl(options)`
 
 * `options` Object
-  * `segmentStyle` String (optional) - Style of the segments:
+  * `segmentStyle` string (optional) - Style of the segments:
     * `automatic` - Default. The appearance of the segmented control is
       automatically determined based on the type of window in which the control
       is displayed and the position within the window. Maps to `NSSegmentStyleAutomatic`.
@@ -21,7 +21,7 @@ Process: [Main](../tutorial/application-architecture.md#main-and-renderer-proces
     * `small-square` - The control is displayed using the small square style. Maps to `NSSegmentStyleSmallSquare`.
     * `separated` - The segments in the control are displayed very close to each
       other but not touching. Maps to `NSSegmentStyleSeparated`.
-  * `mode` String (optional) - The selection mode of the control:
+  * `mode` string (optional) - The selection mode of the control:
     * `single` - Default. One item selected at a time, selecting one deselects the previously selected item. Maps to `NSSegmentSwitchTrackingSelectOne`.
     * `multiple` - Multiple items can be selected at a time. Maps to `NSSegmentSwitchTrackingSelectAny`.
     * `buttons` - Make the segments act as buttons, each segment can be pressed and released but never marked as active. Maps to `NSSegmentSwitchTrackingMomentary`.
@@ -29,7 +29,7 @@ Process: [Main](../tutorial/application-architecture.md#main-and-renderer-proces
   * `selectedIndex` Integer (optional) - The index of the currently selected segment, will update automatically with user interaction. When the mode is `multiple` it will be the last selected item.
   * `change` Function (optional) - Called when the user selects a new segment.
     * `selectedIndex` Integer - The index of the segment the user selected.
-    * `isSelected` Boolean - Whether as a result of user selection the segment is selected or not.
+    * `isSelected` boolean - Whether as a result of user selection the segment is selected or not.
 
 ### Instance Properties
 
@@ -37,7 +37,7 @@ The following properties are available on instances of `TouchBarSegmentedControl
 
 #### `touchBarSegmentedControl.segmentStyle`
 
-A `String` representing the controls current segment style. Updating this value immediately updates the control
+A `string` representing the controls current segment style. Updating this value immediately updates the control
 in the touch bar.
 
 #### `touchBarSegmentedControl.segments`
@@ -52,4 +52,4 @@ in the touch bar. User interaction with the touch bar will update this value aut
 
 #### `touchBarSegmentedControl.mode`
 
-A `String` representing the current selection mode of the control.  Can be `single`, `multiple` or `buttons`.
+A `string` representing the current selection mode of the control.  Can be `single`, `multiple` or `buttons`.

--- a/docs/api/touch-bar-slider.md
+++ b/docs/api/touch-bar-slider.md
@@ -7,12 +7,12 @@ Process: [Main](../tutorial/application-architecture.md#main-and-renderer-proces
 ### `new TouchBarSlider(options)`
 
 * `options` Object
-  * `label` String (optional) - Label text.
+  * `label` string (optional) - Label text.
   * `value` Integer (optional) - Selected value.
   * `minValue` Integer (optional) - Minimum value.
   * `maxValue` Integer (optional) - Maximum value.
   * `change` Function (optional) - Function to call when the slider is changed.
-    * `newValue` Number - The value that the user selected on the Slider.
+    * `newValue` number - The value that the user selected on the Slider.
 
 ### Instance Properties
 
@@ -20,20 +20,20 @@ The following properties are available on instances of `TouchBarSlider`:
 
 #### `touchBarSlider.label`
 
-A `String` representing the slider's current text. Changing this value immediately updates the slider
+A `string` representing the slider's current text. Changing this value immediately updates the slider
 in the touch bar.
 
 #### `touchBarSlider.value`
 
-A `Number` representing the slider's current value. Changing this value immediately updates the slider
+A `number` representing the slider's current value. Changing this value immediately updates the slider
 in the touch bar.
 
 #### `touchBarSlider.minValue`
 
-A `Number` representing the slider's current minimum value. Changing this value immediately updates the
+A `number` representing the slider's current minimum value. Changing this value immediately updates the
 slider in the touch bar.
 
 #### `touchBarSlider.maxValue`
 
-A `Number` representing the slider's current maximum value. Changing this value immediately updates the
+A `number` representing the slider's current maximum value. Changing this value immediately updates the
 slider in the touch bar.

--- a/docs/api/touch-bar-spacer.md
+++ b/docs/api/touch-bar-spacer.md
@@ -7,7 +7,7 @@ Process: [Main](../tutorial/application-architecture.md#main-and-renderer-proces
 ### `new TouchBarSpacer(options)`
 
 * `options` Object
-  * `size` String (optional) - Size of spacer, possible values are:
+  * `size` string (optional) - Size of spacer, possible values are:
     * `small` - Small space between items. Maps to `NSTouchBarItemIdentifierFixedSpaceSmall`. This is the default.
     * `large` - Large space between items. Maps to `NSTouchBarItemIdentifierFixedSpaceLarge`.
     * `flexible` - Take up all available space. Maps to `NSTouchBarItemIdentifierFlexibleSpace`.
@@ -18,4 +18,4 @@ The following properties are available on instances of `TouchBarSpacer`:
 
 #### `touchBarSpacer.size`
 
-A `String` representing the size of the spacer.  Can be `small`, `large` or `flexible`.
+A `string` representing the size of the spacer.  Can be `small`, `large` or `flexible`.

--- a/docs/api/tray.md
+++ b/docs/api/tray.md
@@ -60,8 +60,8 @@ rely on the `click` event and always attach a context menu to the tray icon.
 
 ### `new Tray(image, [guid])`
 
-* `image` ([NativeImage](native-image.md) | String)
-* `guid` String (optional) _Windows_ - Assigns a GUID to the tray icon. If the executable is signed and the signature contains an organization in the subject line then the GUID is permanently associated with that signature. OS level settings like the position of the tray icon in the system tray will persist even if the path to the executable changes. If the executable is not code-signed then the GUID is permanently associated with the path to the executable. Changing the path to the executable will break the creation of the tray icon and a new GUID must be used. However, it is highly recommended to use the GUID parameter only in conjunction with code-signed executable. If an App defines multiple tray icons then each icon must use a separate GUID.
+* `image` ([NativeImage](native-image.md) | string)
+* `guid` string (optional) _Windows_ - Assigns a GUID to the tray icon. If the executable is signed and the signature contains an organization in the subject line then the GUID is permanently associated with that signature. OS level settings like the position of the tray icon in the system tray will persist even if the path to the executable changes. If the executable is not code-signed then the GUID is permanently associated with the path to the executable. Changing the path to the executable will break the creation of the tray icon and a new GUID must be used. However, it is highly recommended to use the GUID parameter only in conjunction with code-signed executable. If an App defines multiple tray icons then each icon must use a separate GUID.
 
 Creates a new tray icon associated with the `image`.
 
@@ -119,7 +119,7 @@ Emitted when any dragged items are dropped on the tray icon.
 Returns:
 
 * `event` Event
-* `files` String[] - The paths of the dropped files.
+* `files` string[] - The paths of the dropped files.
 
 Emitted when dragged files are dropped in the tray icon.
 
@@ -128,7 +128,7 @@ Emitted when dragged files are dropped in the tray icon.
 Returns:
 
 * `event` Event
-* `text` String - the dropped text string.
+* `text` string - the dropped text string.
 
 Emitted when dragged text is dropped in the tray icon.
 
@@ -201,37 +201,37 @@ Destroys the tray icon immediately.
 
 #### `tray.setImage(image)`
 
-* `image` ([NativeImage](native-image.md) | String)
+* `image` ([NativeImage](native-image.md) | string)
 
 Sets the `image` associated with this tray icon.
 
 #### `tray.setPressedImage(image)` _macOS_
 
-* `image` ([NativeImage](native-image.md) | String)
+* `image` ([NativeImage](native-image.md) | string)
 
 Sets the `image` associated with this tray icon when pressed on macOS.
 
 #### `tray.setToolTip(toolTip)`
 
-* `toolTip` String
+* `toolTip` string
 
 Sets the hover text for this tray icon.
 
 #### `tray.setTitle(title[, options])` _macOS_
 
-* `title` String
+* `title` string
 * `options` Object (optional)
-  * `fontType` String (optional) - The font family variant to display, can be `monospaced` or `monospacedDigit`. `monospaced` is available in macOS 10.15+ and `monospacedDigit` is available in macOS 10.11+.  When left blank, the title uses the default system font.
+  * `fontType` string (optional) - The font family variant to display, can be `monospaced` or `monospacedDigit`. `monospaced` is available in macOS 10.15+ and `monospacedDigit` is available in macOS 10.11+.  When left blank, the title uses the default system font.
 
 Sets the title displayed next to the tray icon in the status bar (Support ANSI colors).
 
 #### `tray.getTitle()` _macOS_
 
-Returns `String` - the title displayed next to the tray icon in the status bar
+Returns `string` - the title displayed next to the tray icon in the status bar
 
 #### `tray.setIgnoreDoubleClickEvents(ignore)` _macOS_
 
-* `ignore` Boolean
+* `ignore` boolean
 
 Sets the option to ignore double click events. Ignoring these events allows you
 to detect every individual click of the tray icon.
@@ -240,18 +240,18 @@ This value is set to false by default.
 
 #### `tray.getIgnoreDoubleClickEvents()` _macOS_
 
-Returns `Boolean` - Whether double click events will be ignored.
+Returns `boolean` - Whether double click events will be ignored.
 
 #### `tray.displayBalloon(options)` _Windows_
 
 * `options` Object
-  * `icon` ([NativeImage](native-image.md) | String) (optional) - Icon to use when `iconType` is `custom`.
-  * `iconType` String (optional) - Can be `none`, `info`, `warning`, `error` or `custom`. Default is `custom`.
-  * `title` String
-  * `content` String
-  * `largeIcon` Boolean (optional) - The large version of the icon should be used. Default is `true`. Maps to [`NIIF_LARGE_ICON`][NIIF_LARGE_ICON].
-  * `noSound` Boolean (optional) - Do not play the associated sound. Default is `false`. Maps to [`NIIF_NOSOUND`][NIIF_NOSOUND].
-  * `respectQuietTime` Boolean (optional) - Do not display the balloon notification if the current user is in "quiet time". Default is `false`. Maps to [`NIIF_RESPECT_QUIET_TIME`][NIIF_RESPECT_QUIET_TIME].
+  * `icon` ([NativeImage](native-image.md) | string) (optional) - Icon to use when `iconType` is `custom`.
+  * `iconType` string (optional) - Can be `none`, `info`, `warning`, `error` or `custom`. Default is `custom`.
+  * `title` string
+  * `content` string
+  * `largeIcon` boolean (optional) - The large version of the icon should be used. Default is `true`. Maps to [`NIIF_LARGE_ICON`][NIIF_LARGE_ICON].
+  * `noSound` boolean (optional) - Do not play the associated sound. Default is `false`. Maps to [`NIIF_NOSOUND`][NIIF_NOSOUND].
+  * `respectQuietTime` boolean (optional) - Do not display the balloon notification if the current user is in "quiet time". Default is `false`. Maps to [`NIIF_RESPECT_QUIET_TIME`][NIIF_RESPECT_QUIET_TIME].
 
 Displays a tray balloon.
 
@@ -298,6 +298,6 @@ The `bounds` of this tray icon as `Object`.
 
 #### `tray.isDestroyed()`
 
-Returns `Boolean` - Whether the tray icon is destroyed.
+Returns `boolean` - Whether the tray icon is destroyed.
 
 [event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -515,7 +515,7 @@ Returns:
 * `result` Object
   * `requestId` Integer
   * `activeMatchOrdinal` Integer - Position of the active match.
-  * `matches` Integer - Number of Matches.
+  * `matches` Integer - number of Matches.
   * `selectionArea` Rectangle - Coordinates of first match region.
   * `finalUpdate` boolean
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -63,9 +63,9 @@ Returns:
 
 * `event` Event
 * `errorCode` Integer
-* `errorDescription` String
-* `validatedURL` String
-* `isMainFrame` Boolean
+* `errorDescription` string
+* `validatedURL` string
+* `isMainFrame` boolean
 * `frameProcessId` Integer
 * `frameRoutingId` Integer
 
@@ -78,9 +78,9 @@ Returns:
 
 * `event` Event
 * `errorCode` Integer
-* `errorDescription` String
-* `validatedURL` String
-* `isMainFrame` Boolean
+* `errorDescription` string
+* `validatedURL` string
+* `isMainFrame` boolean
 * `frameProcessId` Integer
 * `frameRoutingId` Integer
 
@@ -92,7 +92,7 @@ This event is like `did-fail-load` but emitted when the load was cancelled
 Returns:
 
 * `event` Event
-* `isMainFrame` Boolean
+* `isMainFrame` boolean
 * `frameProcessId` Integer
 * `frameRoutingId` Integer
 
@@ -119,8 +119,8 @@ Emitted when the document in the given frame is loaded.
 Returns:
 
 * `event` Event
-* `title` String
-* `explicitSet` Boolean
+* `title` string
+* `explicitSet` boolean
 
 Fired when page title is set during navigation. `explicitSet` is false when
 title is synthesized from file url.
@@ -130,7 +130,7 @@ title is synthesized from file url.
 Returns:
 
 * `event` Event
-* `favicons` String[] - Array of URLs.
+* `favicons` string[] - Array of URLs.
 
 Emitted when page receives favicon urls.
 
@@ -139,13 +139,13 @@ Emitted when page receives favicon urls.
 Returns:
 
 * `event` NewWindowWebContentsEvent
-* `url` String
-* `frameName` String
-* `disposition` String - Can be `default`, `foreground-tab`, `background-tab`,
+* `url` string
+* `frameName` string
+* `disposition` string - Can be `default`, `foreground-tab`, `background-tab`,
   `new-window`, `save-to-disk` and `other`.
 * `options` BrowserWindowConstructorOptions - The options which will be used for creating the new
   [`BrowserWindow`](browser-window.md).
-* `additionalFeatures` String[] - The non-standard features (features not handled
+* `additionalFeatures` string[] - The non-standard features (features not handled
   by Chromium or Electron) given to `window.open()`.
 * `referrer` [Referrer](structures/referrer.md) - The referrer that will be
   passed to the new window. May or may not result in the `Referer` header being
@@ -194,7 +194,7 @@ myBrowserWindow.webContents.on('new-window', (event, url, frameName, disposition
 Returns:
 
 * `event` Event
-* `url` String
+* `url` string
 
 Emitted when a user or the page wants to start navigation. It can happen when
 the `window.location` object is changed or a user clicks a link in the page.
@@ -213,9 +213,9 @@ Calling `event.preventDefault()` will prevent the navigation.
 Returns:
 
 * `event` Event
-* `url` String
-* `isInPlace` Boolean
-* `isMainFrame` Boolean
+* `url` string
+* `isInPlace` boolean
+* `isMainFrame` boolean
 * `frameProcessId` Integer
 * `frameRoutingId` Integer
 
@@ -227,9 +227,9 @@ Emitted when any frame (including main) starts navigating. `isInplace` will be
 Returns:
 
 * `event` Event
-* `url` String
-* `isInPlace` Boolean
-* `isMainFrame` Boolean
+* `url` string
+* `isInPlace` boolean
+* `isMainFrame` boolean
 * `frameProcessId` Integer
 * `frameRoutingId` Integer
 
@@ -247,9 +247,9 @@ redirect).
 Returns:
 
 * `event` Event
-* `url` String
-* `isInPlace` Boolean
-* `isMainFrame` Boolean
+* `url` string
+* `isInPlace` boolean
+* `isMainFrame` boolean
 * `frameProcessId` Integer
 * `frameRoutingId` Integer
 
@@ -264,9 +264,9 @@ checkout out the `will-redirect` event above.
 Returns:
 
 * `event` Event
-* `url` String
+* `url` string
 * `httpResponseCode` Integer - -1 for non HTTP navigations
-* `httpStatusText` String - empty for non HTTP navigations
+* `httpStatusText` string - empty for non HTTP navigations
 
 Emitted when a main frame navigation is done.
 
@@ -279,10 +279,10 @@ this purpose.
 Returns:
 
 * `event` Event
-* `url` String
+* `url` string
 * `httpResponseCode` Integer - -1 for non HTTP navigations
-* `httpStatusText` String - empty for non HTTP navigations,
-* `isMainFrame` Boolean
+* `httpStatusText` string - empty for non HTTP navigations,
+* `isMainFrame` boolean
 * `frameProcessId` Integer
 * `frameRoutingId` Integer
 
@@ -297,8 +297,8 @@ this purpose.
 Returns:
 
 * `event` Event
-* `url` String
-* `isMainFrame` Boolean
+* `url` string
+* `isMainFrame` boolean
 * `frameProcessId` Integer
 * `frameRoutingId` Integer
 
@@ -343,7 +343,7 @@ win.webContents.on('will-prevent-unload', (event) => {
 Returns:
 
 * `event` Event
-* `killed` Boolean
+* `killed` boolean
 
 Emitted when the renderer process crashes or is killed.
 
@@ -358,7 +358,7 @@ Returns:
 
 * `event` Event
 * `details` Object
-  * `reason` String - The reason the render process is gone.  Possible values:
+  * `reason` string - The reason the render process is gone.  Possible values:
     * `clean-exit` - Process exited with an exit code of zero
     * `abnormal-exit` - Process exited with a non-zero exit code
     * `killed` - Process was sent a SIGTERM or otherwise killed externally
@@ -383,8 +383,8 @@ Emitted when the unresponsive web page becomes responsive again.
 Returns:
 
 * `event` Event
-* `name` String
-* `version` String
+* `name` string
+* `version` string
 
 Emitted when a plugin process has crashed.
 
@@ -398,15 +398,15 @@ Returns:
 
 * `event` Event
 * `input` Object - Input properties.
-  * `type` String - Either `keyUp` or `keyDown`.
-  * `key` String - Equivalent to [KeyboardEvent.key][keyboardevent].
-  * `code` String - Equivalent to [KeyboardEvent.code][keyboardevent].
-  * `isAutoRepeat` Boolean - Equivalent to [KeyboardEvent.repeat][keyboardevent].
-  * `isComposing` Boolean - Equivalent to [KeyboardEvent.isComposing][keyboardevent].
-  * `shift` Boolean - Equivalent to [KeyboardEvent.shiftKey][keyboardevent].
-  * `control` Boolean - Equivalent to [KeyboardEvent.controlKey][keyboardevent].
-  * `alt` Boolean - Equivalent to [KeyboardEvent.altKey][keyboardevent].
-  * `meta` Boolean - Equivalent to [KeyboardEvent.metaKey][keyboardevent].
+  * `type` string - Either `keyUp` or `keyDown`.
+  * `key` string - Equivalent to [KeyboardEvent.key][keyboardevent].
+  * `code` string - Equivalent to [KeyboardEvent.code][keyboardevent].
+  * `isAutoRepeat` boolean - Equivalent to [KeyboardEvent.repeat][keyboardevent].
+  * `isComposing` boolean - Equivalent to [KeyboardEvent.isComposing][keyboardevent].
+  * `shift` boolean - Equivalent to [KeyboardEvent.shiftKey][keyboardevent].
+  * `control` boolean - Equivalent to [KeyboardEvent.controlKey][keyboardevent].
+  * `alt` boolean - Equivalent to [KeyboardEvent.altKey][keyboardevent].
+  * `meta` boolean - Equivalent to [KeyboardEvent.metaKey][keyboardevent].
 
 Emitted before dispatching the `keydown` and `keyup` events in the page.
 Calling `event.preventDefault` will prevent the page `keydown`/`keyup` events
@@ -439,7 +439,7 @@ Emitted when the window leaves a full-screen state triggered by HTML API.
 
 Returns:
 * `event` Event
-* `zoomDirection` String - Can be `in` or `out`.
+* `zoomDirection` string - Can be `in` or `out`.
 
 Emitted when the user is requesting to change the zoom level using the mouse wheel.
 
@@ -460,11 +460,11 @@ Emitted when DevTools is focused / opened.
 Returns:
 
 * `event` Event
-* `url` String
-* `error` String - The error code.
+* `url` string
+* `error` string - The error code.
 * `certificate` [Certificate](structures/certificate.md)
 * `callback` Function
-  * `isTrusted` Boolean - Indicates whether the certificate can be considered trusted.
+  * `isTrusted` boolean - Indicates whether the certificate can be considered trusted.
 
 Emitted when failed to verify the `certificate` for `url`.
 
@@ -494,14 +494,14 @@ Returns:
 * `authenticationResponseDetails` Object
   * `url` URL
 * `authInfo` Object
-  * `isProxy` Boolean
-  * `scheme` String
-  * `host` String
+  * `isProxy` boolean
+  * `scheme` string
+  * `host` string
   * `port` Integer
-  * `realm` String
+  * `realm` string
 * `callback` Function
-  * `username` String (optional)
-  * `password` String (optional)
+  * `username` string (optional)
+  * `password` string (optional)
 
 Emitted when `webContents` wants to do basic auth.
 
@@ -517,7 +517,7 @@ Returns:
   * `activeMatchOrdinal` Integer - Position of the active match.
   * `matches` Integer - Number of Matches.
   * `selectionArea` Rectangle - Coordinates of first match region.
-  * `finalUpdate` Boolean
+  * `finalUpdate` boolean
 
 Emitted when a result is available for
 [`webContents.findInPage`] request.
@@ -535,7 +535,7 @@ Emitted when media is paused or done playing.
 Returns:
 
 * `event` Event
-* `color` (String | null) - Theme color is in format of '#rrggbb'. It is `null` when no theme color is set.
+* `color` (string | null) - Theme color is in format of '#rrggbb'. It is `null` when no theme color is set.
 
 Emitted when a page's theme color changes. This is usually due to encountering
 a meta tag:
@@ -549,7 +549,7 @@ a meta tag:
 Returns:
 
 * `event` Event
-* `url` String
+* `url` string
 
 Emitted when mouse moves over a link or the keyboard moves the focus to a link.
 
@@ -558,7 +558,7 @@ Emitted when mouse moves over a link or the keyboard moves the focus to a link.
 Returns:
 
 * `event` Event
-* `type` String
+* `type` string
 * `image` [NativeImage](native-image.md) (optional)
 * `scale` Float (optional) - scaling factor for the custom cursor.
 * `size` [Size](structures/size.md) (optional) - the size of the `image`.
@@ -585,57 +585,57 @@ Returns:
 * `params` Object
   * `x` Integer - x coordinate.
   * `y` Integer - y coordinate.
-  * `linkURL` String - URL of the link that encloses the node the context menu
+  * `linkURL` string - URL of the link that encloses the node the context menu
     was invoked on.
-  * `linkText` String - Text associated with the link. May be an empty
+  * `linkText` string - Text associated with the link. May be an empty
     string if the contents of the link are an image.
-  * `pageURL` String - URL of the top level page that the context menu was
+  * `pageURL` string - URL of the top level page that the context menu was
     invoked on.
-  * `frameURL` String - URL of the subframe that the context menu was invoked
+  * `frameURL` string - URL of the subframe that the context menu was invoked
     on.
-  * `srcURL` String - Source URL for the element that the context menu
+  * `srcURL` string - Source URL for the element that the context menu
     was invoked on. Elements with source URLs are images, audio and video.
-  * `mediaType` String - Type of the node the context menu was invoked on. Can
+  * `mediaType` string - Type of the node the context menu was invoked on. Can
     be `none`, `image`, `audio`, `video`, `canvas`, `file` or `plugin`.
-  * `hasImageContents` Boolean - Whether the context menu was invoked on an image
+  * `hasImageContents` boolean - Whether the context menu was invoked on an image
     which has non-empty contents.
-  * `isEditable` Boolean - Whether the context is editable.
-  * `selectionText` String - Text of the selection that the context menu was
+  * `isEditable` boolean - Whether the context is editable.
+  * `selectionText` string - Text of the selection that the context menu was
     invoked on.
-  * `titleText` String - Title or alt text of the selection that the context
+  * `titleText` string - Title or alt text of the selection that the context
     was invoked on.
-  * `misspelledWord` String - The misspelled word under the cursor, if any.
-  * `dictionarySuggestions` String[] - An array of suggested words to show the
+  * `misspelledWord` string - The misspelled word under the cursor, if any.
+  * `dictionarySuggestions` string[] - An array of suggested words to show the
     user to replace the `misspelledWord`.  Only available if there is a misspelled
     word and spellchecker is enabled.
-  * `frameCharset` String - The character encoding of the frame on which the
+  * `frameCharset` string - The character encoding of the frame on which the
     menu was invoked.
-  * `inputFieldType` String - If the context menu was invoked on an input
+  * `inputFieldType` string - If the context menu was invoked on an input
     field, the type of that field. Possible values are `none`, `plainText`,
     `password`, `other`.
-  * `menuSourceType` String - Input source that invoked the context menu.
+  * `menuSourceType` string - Input source that invoked the context menu.
     Can be `none`, `mouse`, `keyboard`, `touch` or `touchMenu`.
   * `mediaFlags` Object - The flags for the media element the context menu was
     invoked on.
-    * `inError` Boolean - Whether the media element has crashed.
-    * `isPaused` Boolean - Whether the media element is paused.
-    * `isMuted` Boolean - Whether the media element is muted.
-    * `hasAudio` Boolean - Whether the media element has audio.
-    * `isLooping` Boolean - Whether the media element is looping.
-    * `isControlsVisible` Boolean - Whether the media element's controls are
+    * `inError` boolean - Whether the media element has crashed.
+    * `isPaused` boolean - Whether the media element is paused.
+    * `isMuted` boolean - Whether the media element is muted.
+    * `hasAudio` boolean - Whether the media element has audio.
+    * `isLooping` boolean - Whether the media element is looping.
+    * `isControlsVisible` boolean - Whether the media element's controls are
       visible.
-    * `canToggleControls` Boolean - Whether the media element's controls are
+    * `canToggleControls` boolean - Whether the media element's controls are
       toggleable.
-    * `canRotate` Boolean - Whether the media element can be rotated.
+    * `canRotate` boolean - Whether the media element can be rotated.
   * `editFlags` Object - These flags indicate whether the renderer believes it
     is able to perform the corresponding action.
-    * `canUndo` Boolean - Whether the renderer believes it can undo.
-    * `canRedo` Boolean - Whether the renderer believes it can redo.
-    * `canCut` Boolean - Whether the renderer believes it can cut.
-    * `canCopy` Boolean - Whether the renderer believes it can copy
-    * `canPaste` Boolean - Whether the renderer believes it can paste.
-    * `canDelete` Boolean - Whether the renderer believes it can delete.
-    * `canSelectAll` Boolean - Whether the renderer believes it can select all.
+    * `canUndo` boolean - Whether the renderer believes it can undo.
+    * `canRedo` boolean - Whether the renderer believes it can redo.
+    * `canCut` boolean - Whether the renderer believes it can cut.
+    * `canCopy` boolean - Whether the renderer believes it can copy
+    * `canPaste` boolean - Whether the renderer believes it can paste.
+    * `canDelete` boolean - Whether the renderer believes it can delete.
+    * `canSelectAll` boolean - Whether the renderer believes it can select all.
 
 Emitted when there is a new context menu that needs to be handled.
 
@@ -646,7 +646,7 @@ Returns:
 * `event` Event
 * `devices` [BluetoothDevice[]](structures/bluetooth-device.md)
 * `callback` Function
-  * `deviceId` String
+  * `deviceId` string
 
 Emitted when bluetooth device needs to be selected on call to
 `navigator.bluetooth.requestDevice`. To use `navigator.bluetooth` api
@@ -739,9 +739,9 @@ Returns:
 
 * `event` Event
 * `level` Integer - The log level, from 0 to 3. In order it matches `verbose`, `info`, `warning` and `error`.
-* `message` String - The actual console message
+* `message` string - The actual console message
 * `line` Integer - The line number of the source that triggered this console message
-* `sourceId` String
+* `sourceId` string
 
 Emitted when the associated window logs a console message.
 
@@ -750,7 +750,7 @@ Emitted when the associated window logs a console message.
 Returns:
 
 * `event` Event
-* `preloadPath` String
+* `preloadPath` string
 * `error` Error
 
 Emitted when the preload script `preloadPath` throws an unhandled exception `error`.
@@ -760,7 +760,7 @@ Emitted when the preload script `preloadPath` throws an unhandled exception `err
 Returns:
 
 * `event` Event
-* `channel` String
+* `channel` string
 * `...args` any[]
 
 Emitted when the renderer process sends an asynchronous message via `ipcRenderer.send()`.
@@ -770,7 +770,7 @@ Emitted when the renderer process sends an asynchronous message via `ipcRenderer
 Returns:
 
 * `event` Event
-* `channel` String
+* `channel` string
 * `...args` any[]
 
 Emitted when the renderer process sends a synchronous message via `ipcRenderer.sendSync()`.
@@ -789,7 +789,7 @@ Calling `event.preventDefault()` will make it return empty sources.
 Returns:
 
 * `event` IpcMainEvent
-* `moduleName` String
+* `moduleName` string
 
 Emitted when `remote.require()` is called in the renderer process.
 Calling `event.preventDefault()` will prevent the module from being returned.
@@ -800,7 +800,7 @@ Custom value can be returned by setting `event.returnValue`.
 Returns:
 
 * `event` IpcMainEvent
-* `globalName` String
+* `globalName` string
 
 Emitted when `remote.getGlobal()` is called in the renderer process.
 Calling `event.preventDefault()` will prevent the global from being returned.
@@ -811,7 +811,7 @@ Custom value can be returned by setting `event.returnValue`.
 Returns:
 
 * `event` IpcMainEvent
-* `moduleName` String
+* `moduleName` string
 
 Emitted when `remote.getBuiltin()` is called in the renderer process.
 Calling `event.preventDefault()` will prevent the module from being returned.
@@ -841,13 +841,13 @@ Custom value can be returned by setting `event.returnValue`.
 
 #### `contents.loadURL(url[, options])`
 
-* `url` String
+* `url` string
 * `options` Object (optional)
-  * `httpReferrer` (String | [Referrer](structures/referrer.md)) (optional) - An HTTP Referrer url.
-  * `userAgent` String (optional) - A user agent originating the request.
-  * `extraHeaders` String (optional) - Extra headers separated by "\n".
+  * `httpReferrer` (string | [Referrer](structures/referrer.md)) (optional) - An HTTP Referrer url.
+  * `userAgent` string (optional) - A user agent originating the request.
+  * `extraHeaders` string (optional) - Extra headers separated by "\n".
   * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadBlob[]](structures/upload-blob.md)) (optional)
-  * `baseURLForDataURL` String (optional) - Base url (with trailing path separator) for files to be loaded by the data url. This is needed only if the specified `url` is a data url and needs to load other files.
+  * `baseURLForDataURL` string (optional) - Base url (with trailing path separator) for files to be loaded by the data url. This is needed only if the specified `url` is a data url and needs to load other files.
 
 Returns `Promise<void>` - the promise will resolve when the page has finished loading
 (see [`did-finish-load`](web-contents.md#event-did-finish-load)), and rejects
@@ -866,11 +866,11 @@ webContents.loadURL('https://github.com', options)
 
 #### `contents.loadFile(filePath[, options])`
 
-* `filePath` String
+* `filePath` string
 * `options` Object (optional)
-  * `query` Record<String, String> (optional) - Passed to `url.format()`.
-  * `search` String (optional) - Passed to `url.format()`.
-  * `hash` String (optional) - Passed to `url.format()`.
+  * `query` Record<string, string> (optional) - Passed to `url.format()`.
+  * `search` string (optional) - Passed to `url.format()`.
+  * `hash` string (optional) - Passed to `url.format()`.
 
 Returns `Promise<void>` - the promise will resolve when the page has finished loading
 (see [`did-finish-load`](web-contents.md#event-did-finish-load)), and rejects
@@ -896,14 +896,14 @@ win.loadFile('src/index.html')
 
 #### `contents.downloadURL(url)`
 
-* `url` String
+* `url` string
 
 Initiates a download of the resource at `url` without navigating. The
 `will-download` event of `session` will be triggered.
 
 #### `contents.getURL()`
 
-Returns `String` - The URL of the current web page.
+Returns `string` - The URL of the current web page.
 
 ```javascript
 const { BrowserWindow } = require('electron')
@@ -916,11 +916,11 @@ win.loadURL('http://github.com').then(() => {
 
 #### `contents.getTitle()`
 
-Returns `String` - The title of the current web page.
+Returns `string` - The title of the current web page.
 
 #### `contents.isDestroyed()`
 
-Returns `Boolean` - Whether the web page is destroyed.
+Returns `boolean` - Whether the web page is destroyed.
 
 #### `contents.focus()`
 
@@ -928,20 +928,20 @@ Focuses the web page.
 
 #### `contents.isFocused()`
 
-Returns `Boolean` - Whether the web page is focused.
+Returns `boolean` - Whether the web page is focused.
 
 #### `contents.isLoading()`
 
-Returns `Boolean` - Whether web page is still loading resources.
+Returns `boolean` - Whether web page is still loading resources.
 
 #### `contents.isLoadingMainFrame()`
 
-Returns `Boolean` - Whether the main frame (and not just iframes or frames within it) is
+Returns `boolean` - Whether the main frame (and not just iframes or frames within it) is
 still loading.
 
 #### `contents.isWaitingForResponse()`
 
-Returns `Boolean` - Whether the web page is waiting for a first-response from the main
+Returns `boolean` - Whether the web page is waiting for a first-response from the main
 resource of the page.
 
 #### `contents.stop()`
@@ -958,17 +958,17 @@ Reloads current page and ignores cache.
 
 #### `contents.canGoBack()`
 
-Returns `Boolean` - Whether the browser can go back to previous web page.
+Returns `boolean` - Whether the browser can go back to previous web page.
 
 #### `contents.canGoForward()`
 
-Returns `Boolean` - Whether the browser can go forward to next web page.
+Returns `boolean` - Whether the browser can go forward to next web page.
 
 #### `contents.canGoToOffset(offset)`
 
 * `offset` Integer
 
-Returns `Boolean` - Whether the web page can go to `offset`.
+Returns `boolean` - Whether the web page can go to `offset`.
 
 #### `contents.clearHistory()`
 
@@ -996,7 +996,7 @@ Navigates to the specified offset from the "current entry".
 
 #### `contents.isCrashed()`
 
-Returns `Boolean` - Whether the renderer process has crashed.
+Returns `boolean` - Whether the renderer process has crashed.
 
 #### `contents.forcefullyCrashRenderer()`
 
@@ -1028,21 +1028,21 @@ contents.on('unresponsive', async () => {
 
 #### `contents.setUserAgent(userAgent)`
 
-* `userAgent` String
+* `userAgent` string
 
 Overrides the user agent for this web page.
 
 #### `contents.getUserAgent()`
 
-Returns `String` - The user agent for this web page.
+Returns `string` - The user agent for this web page.
 
 #### `contents.insertCSS(css[, options])`
 
-* `css` String
+* `css` string
 * `options` Object (optional)
-  * `cssOrigin` String (optional) - Can be either 'user' or 'author'; Specifying 'user' enables you to prevent websites from overriding the CSS you insert. Default is 'author'.
+  * `cssOrigin` string (optional) - Can be either 'user' or 'author'; Specifying 'user' enables you to prevent websites from overriding the CSS you insert. Default is 'author'.
 
-Returns `Promise<String>` - A promise that resolves with a key for the inserted CSS that can later be used to remove the CSS via `contents.removeInsertedCSS(key)`.
+Returns `Promise<string>` - A promise that resolves with a key for the inserted CSS that can later be used to remove the CSS via `contents.removeInsertedCSS(key)`.
 
 Injects CSS into the current web page and returns a unique key for the inserted
 stylesheet.
@@ -1055,7 +1055,7 @@ contents.on('did-finish-load', () => {
 
 #### `contents.removeInsertedCSS(key)`
 
-* `key` String
+* `key` string
 
 Returns `Promise<void>` - Resolves if the removal was successful.
 
@@ -1071,8 +1071,8 @@ contents.on('did-finish-load', async () => {
 
 #### `contents.executeJavaScript(code[, userGesture])`
 
-* `code` String
-* `userGesture` Boolean (optional) - Default is `false`.
+* `code` string
+* `userGesture` boolean (optional) - Default is `false`.
 
 Returns `Promise<any>` - A promise that resolves with the result of the executed code
 or is rejected if the result of the code is a rejected promise.
@@ -1096,7 +1096,7 @@ contents.executeJavaScript('fetch("https://jsonplaceholder.typicode.com/users/1"
 
 * `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electron's `contextIsolation` feature.  You can provide any integer here.
 * `scripts` [WebSource[]](structures/web-source.md)
-* `userGesture` Boolean (optional) - Default is `false`.
+* `userGesture` boolean (optional) - Default is `false`.
 
 Returns `Promise<any>` - A promise that resolves with the result of the executed code
 or is rejected if the result of the code is a rejected promise.
@@ -1105,23 +1105,23 @@ Works like `executeJavaScript` but evaluates `scripts` in an isolated context.
 
 #### `contents.setIgnoreMenuShortcuts(ignore)`
 
-* `ignore` Boolean
+* `ignore` boolean
 
 Ignore application menu shortcuts while this web contents is focused.
 
 #### `contents.setAudioMuted(muted)`
 
-* `muted` Boolean
+* `muted` boolean
 
 Mute the audio on the current web page.
 
 #### `contents.isAudioMuted()`
 
-Returns `Boolean` - Whether this page has been muted.
+Returns `boolean` - Whether this page has been muted.
 
 #### `contents.isCurrentlyAudible()`
 
-Returns `Boolean` - Whether audio is currently playing.
+Returns `boolean` - Whether audio is currently playing.
 
 #### `contents.setZoomFactor(factor)`
 
@@ -1134,11 +1134,11 @@ The factor must be greater than 0.0.
 
 #### `contents.getZoomFactor()`
 
-Returns `Number` - the current zoom factor.
+Returns `number` - the current zoom factor.
 
 #### `contents.setZoomLevel(level)`
 
-* `level` Number - Zoom level.
+* `level` number - Zoom level.
 
 Changes the zoom level to the specified level. The original size is 0 and each
 increment above or below represents zooming 20% larger or smaller to default
@@ -1151,12 +1151,12 @@ limits of 300% and 50% of original size, respectively. The formula for this is
 
 #### `contents.getZoomLevel()`
 
-Returns `Number` - the current zoom level.
+Returns `number` - the current zoom level.
 
 #### `contents.setVisualZoomLevelLimits(minimumLevel, maximumLevel)`
 
-* `minimumLevel` Number
-* `maximumLevel` Number
+* `minimumLevel` number
+* `maximumLevel` number
 
 Returns `Promise<void>`
 
@@ -1213,19 +1213,19 @@ Executes the editing command `unselect` in web page.
 
 #### `contents.replace(text)`
 
-* `text` String
+* `text` string
 
 Executes the editing command `replace` in web page.
 
 #### `contents.replaceMisspelling(text)`
 
-* `text` String
+* `text` string
 
 Executes the editing command `replaceMisspelling` in web page.
 
 #### `contents.insertText(text)`
 
-* `text` String
+* `text` string
 
 Returns `Promise<void>`
 
@@ -1233,12 +1233,12 @@ Inserts `text` to the focused element.
 
 #### `contents.findInPage(text[, options])`
 
-* `text` String - Content to be searched, must not be empty.
+* `text` string - Content to be searched, must not be empty.
 * `options` Object (optional)
-  * `forward` Boolean (optional) - Whether to search forward or backward, defaults to `true`.
-  * `findNext` Boolean (optional) - Whether the operation is first request or a follow up,
+  * `forward` boolean (optional) - Whether to search forward or backward, defaults to `true`.
+  * `findNext` boolean (optional) - Whether the operation is first request or a follow up,
     defaults to `false`.
-  * `matchCase` Boolean (optional) - Whether search should be case-sensitive,
+  * `matchCase` boolean (optional) - Whether search should be case-sensitive,
     defaults to `false`.
 
 Returns `Integer` - The request id used for the request.
@@ -1248,7 +1248,7 @@ can be obtained by subscribing to [`found-in-page`](web-contents.md#event-found-
 
 #### `contents.stopFindInPage(action)`
 
-* `action` String - Specifies the action to take place when ending
+* `action` string - Specifies the action to take place when ending
   [`webContents.findInPage`] request.
   * `clearSelection` - Clear the selection.
   * `keepSelection` - Translate the selection into a normal selection.
@@ -1276,13 +1276,13 @@ Captures a snapshot of the page within `rect`. Omitting `rect` will capture the 
 
 #### `contents.isBeingCaptured()`
 
-Returns `Boolean` - Whether this page is being captured. It returns true when the capturer count
+Returns `boolean` - Whether this page is being captured. It returns true when the capturer count
 is large then 0.
 
 #### `contents.incrementCapturerCount([size, stayHidden])`
 
 * `size` [Size](structures/size.md) (optional) - The preferred size for the capturer.
-* `stayHidden` Boolean (optional) -  Keep the page hidden instead of visible.
+* `stayHidden` boolean (optional) -  Keep the page hidden instead of visible.
 
 Increase the capturer count by one. The page is considered visible when its browser window is
 hidden and the capturer count is non-zero. If you would like the page to stay hidden, you should ensure that `stayHidden` is set to true.
@@ -1291,7 +1291,7 @@ This also affects the Page Visibility API.
 
 #### `contents.decrementCapturerCount([stayHidden])`
 
-* `stayHidden` Boolean (optional) -  Keep the page in hidden state instead of visible.
+* `stayHidden` boolean (optional) -  Keep the page in hidden state instead of visible.
 
 Decrease the capturer count by one. The page will be set to hidden or occluded state when its
 browser window is hidden or occluded and the capturer count reaches zero. If you want to
@@ -1306,36 +1306,36 @@ Returns [`PrinterInfo[]`](structures/printer-info.md)
 #### `contents.print([options], [callback])`
 
 * `options` Object (optional)
-  * `silent` Boolean (optional) - Don't ask user for print settings. Default is `false`.
-  * `printBackground` Boolean (optional) - Prints the background color and image of
+  * `silent` boolean (optional) - Don't ask user for print settings. Default is `false`.
+  * `printBackground` boolean (optional) - Prints the background color and image of
     the web page. Default is `false`.
-  * `deviceName` String (optional) - Set the printer device name to use. Must be the system-defined name and not the 'friendly' name, e.g 'Brother_QL_820NWB' and not 'Brother QL-820NWB'.
-  * `color` Boolean (optional) - Set whether the printed web page will be in color or grayscale. Default is `true`.
+  * `deviceName` string (optional) - Set the printer device name to use. Must be the system-defined name and not the 'friendly' name, e.g 'Brother_QL_820NWB' and not 'Brother QL-820NWB'.
+  * `color` boolean (optional) - Set whether the printed web page will be in color or grayscale. Default is `true`.
   * `margins` Object (optional)
-    * `marginType` String (optional) - Can be `default`, `none`, `printableArea`, or `custom`. If `custom` is chosen, you will also need to specify `top`, `bottom`, `left`, and `right`.
-    * `top` Number (optional) - The top margin of the printed web page, in pixels.
-    * `bottom` Number (optional) - The bottom margin of the printed web page, in pixels.
-    * `left` Number (optional) - The left margin of the printed web page, in pixels.
-    * `right` Number (optional) - The right margin of the printed web page, in pixels.
-  * `landscape` Boolean (optional) - Whether the web page should be printed in landscape mode. Default is `false`.
-  * `scaleFactor` Number (optional) - The scale factor of the web page.
-  * `pagesPerSheet` Number (optional) - The number of pages to print per page sheet.
-  * `collate` Boolean (optional) - Whether the web page should be collated.
-  * `copies` Number (optional) - The number of copies of the web page to print.
+    * `marginType` string (optional) - Can be `default`, `none`, `printableArea`, or `custom`. If `custom` is chosen, you will also need to specify `top`, `bottom`, `left`, and `right`.
+    * `top` number (optional) - The top margin of the printed web page, in pixels.
+    * `bottom` number (optional) - The bottom margin of the printed web page, in pixels.
+    * `left` number (optional) - The left margin of the printed web page, in pixels.
+    * `right` number (optional) - The right margin of the printed web page, in pixels.
+  * `landscape` boolean (optional) - Whether the web page should be printed in landscape mode. Default is `false`.
+  * `scaleFactor` number (optional) - The scale factor of the web page.
+  * `pagesPerSheet` number (optional) - The number of pages to print per page sheet.
+  * `collate` boolean (optional) - Whether the web page should be collated.
+  * `copies` number (optional) - The number of copies of the web page to print.
   * `pageRanges` Object[]  (optional) - The page range to print. On macOS, only one range is honored.
-    * `from` Number - Index of the first page to print (0-based).
-    * `to` Number - Index of the last page to print (inclusive) (0-based).
-  * `duplexMode` String (optional) - Set the duplex mode of the printed web page. Can be `simplex`, `shortEdge`, or `longEdge`.
+    * `from` number - Index of the first page to print (0-based).
+    * `to` number - Index of the last page to print (inclusive) (0-based).
+  * `duplexMode` string (optional) - Set the duplex mode of the printed web page. Can be `simplex`, `shortEdge`, or `longEdge`.
   * `dpi` Record<string, number> (optional)
-    * `horizontal` Number (optional) - The horizontal dpi.
-    * `vertical` Number (optional) - The vertical dpi.
-  * `header` String (optional) - String to be printed as page header.
-  * `footer` String (optional) - String to be printed as page footer.
-  * `pageSize` String | Size (optional) - Specify page size of the printed document. Can be `A3`,
+    * `horizontal` number (optional) - The horizontal dpi.
+    * `vertical` number (optional) - The vertical dpi.
+  * `header` string (optional) - string to be printed as page header.
+  * `footer` string (optional) - string to be printed as page footer.
+  * `pageSize` string | Size (optional) - Specify page size of the printed document. Can be `A3`,
   `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height`.
 * `callback` Function (optional)
-  * `success` Boolean - Indicates success of the print call.
-  * `failureReason` String - Error description called back if the print fails.
+  * `success` boolean - Indicates success of the print call.
+  * `failureReason` string - Error description called back if the print fails.
 
 When a custom `pageSize` is passed, Chromium attempts to validate platform specific minimum values for `width_microns` and `height_microns`. Width and height must both be minimum 353 microns but may be higher on some operating systems.
 
@@ -1364,19 +1364,19 @@ win.webContents.print(options, (success, errorType) => {
 
 * `options` Object
   * `headerFooter` Record<string, string> (optional) - the header and footer for the PDF.
-    * `title` String - The title for the PDF header.
-    * `url` String - the url for the PDF footer.
-  * `landscape` Boolean (optional) - `true` for landscape, `false` for portrait.
+    * `title` string - The title for the PDF header.
+    * `url` string - the url for the PDF footer.
+  * `landscape` boolean (optional) - `true` for landscape, `false` for portrait.
   * `marginsType` Integer (optional) - Specifies the type of margins to use. Uses 0 for
     default margin, 1 for no margin, and 2 for minimum margin.
-  * `scaleFactor` Number (optional) - The scale factor of the web page. Can range from 0 to 100.
+  * `scaleFactor` number (optional) - The scale factor of the web page. Can range from 0 to 100.
   * `pageRanges` Record<string, number> (optional) - The page range to print.
-    * `from` Number - Index of the first page to print (0-based).
-    * `to` Number - Index of the last page to print (inclusive) (0-based).
-  * `pageSize` String | Size (optional) - Specify page size of the generated PDF. Can be `A3`,
+    * `from` number - Index of the first page to print (0-based).
+    * `to` number - Index of the last page to print (inclusive) (0-based).
+  * `pageSize` string | Size (optional) - Specify page size of the generated PDF. Can be `A3`,
   `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height` and `width` in microns.
-  * `printBackground` Boolean (optional) - Whether to print CSS backgrounds.
-  * `printSelectionOnly` Boolean (optional) - Whether to print selection only.
+  * `printBackground` boolean (optional) - Whether to print CSS backgrounds.
+  * `printSelectionOnly` boolean (optional) - Whether to print selection only.
 
 Returns `Promise<Buffer>` - Resolves with the generated PDF data.
 
@@ -1427,7 +1427,7 @@ win.webContents.on('did-finish-load', () => {
 
 #### `contents.addWorkSpace(path)`
 
-* `path` String
+* `path` string
 
 Adds the specified path to DevTools workspace. Must be used after DevTools
 creation:
@@ -1442,7 +1442,7 @@ win.webContents.on('devtools-opened', () => {
 
 #### `contents.removeWorkSpace(path)`
 
-* `path` String
+* `path` string
 
 Removes the specified path from DevTools workspace.
 
@@ -1528,10 +1528,10 @@ app.whenReady().then(() => {
 #### `contents.openDevTools([options])`
 
 * `options` Object (optional)
-  * `mode` String - Opens the devtools with specified dock state, can be
+  * `mode` string - Opens the devtools with specified dock state, can be
     `right`, `bottom`, `undocked`, `detach`. Defaults to last used dock state.
     In `undocked` mode it's possible to dock back. In `detach` mode it's not.
-  * `activate` Boolean (optional) - Whether to bring the opened devtools window
+  * `activate` boolean (optional) - Whether to bring the opened devtools window
     to the foreground. The default is `true`.
 
 Opens the devtools.
@@ -1545,11 +1545,11 @@ Closes the devtools.
 
 #### `contents.isDevToolsOpened()`
 
-Returns `Boolean` - Whether the devtools is opened.
+Returns `boolean` - Whether the devtools is opened.
 
 #### `contents.isDevToolsFocused()`
 
-Returns `Boolean` - Whether the devtools view is focused .
+Returns `boolean` - Whether the devtools view is focused .
 
 #### `contents.toggleDevTools()`
 
@@ -1568,7 +1568,7 @@ Opens the developer tools for the shared worker context.
 
 #### `contents.inspectSharedWorkerById(workerId)`
 
-* `workerId` String
+* `workerId` string
 
 Inspects the shared worker based on its ID.
 
@@ -1582,7 +1582,7 @@ Opens the developer tools for the service worker context.
 
 #### `contents.send(channel, ...args)`
 
-* `channel` String
+* `channel` string
 * `...args` any[]
 
 Send an asynchronous message to the renderer process via `channel`, along with
@@ -1630,7 +1630,7 @@ app.whenReady().then(() => {
 #### `contents.sendToFrame(frameId, channel, ...args)`
 
 * `frameId` Integer
-* `channel` String
+* `channel` string
 * `...args` any[]
 
 Send an asynchronous message to a specific frame in a renderer process via
@@ -1665,7 +1665,7 @@ ipcMain.on('ping', (event) => {
 
 #### `contents.postMessage(channel, message, [transfer])`
 
-* `channel` String
+* `channel` string
 * `message` any
 * `transfer` MessagePortMain[] (optional)
 
@@ -1692,7 +1692,7 @@ ipcRenderer.on('port', (e, msg) => {
 #### `contents.enableDeviceEmulation(parameters)`
 
 * `parameters` Object
-  * `screenPosition` String - Specify the screen type to emulate
+  * `screenPosition` string - Specify the screen type to emulate
       (default: `desktop`):
     * `desktop` - Desktop screen type.
     * `mobile` - Mobile screen type.
@@ -1721,7 +1721,7 @@ Sends an input `event` to the page.
 
 #### `contents.beginFrameSubscription([onlyDirty ,]callback)`
 
-* `onlyDirty` Boolean (optional) - Defaults to `false`.
+* `onlyDirty` boolean (optional) - Defaults to `false`.
 * `callback` Function
   * `image` [NativeImage](native-image.md)
   * `dirtyRect` [Rectangle](structures/rectangle.md)
@@ -1745,8 +1745,8 @@ End subscribing for frame presentation events.
 #### `contents.startDrag(item)`
 
 * `item` Object
-  * `file` String[] | String - The path(s) to the file(s) being dragged.
-  * `icon` [NativeImage](native-image.md) | String - The image must be
+  * `file` string[] | string - The path(s) to the file(s) being dragged.
+  * `icon` [NativeImage](native-image.md) | string - The image must be
     non-empty on macOS.
 
 Sets the `item` as dragging item for current drag-drop operation, `file` is the
@@ -1755,8 +1755,8 @@ the cursor when dragging.
 
 #### `contents.savePage(fullPath, saveType)`
 
-* `fullPath` String - The full file path.
-* `saveType` String - Specify the save type.
+* `fullPath` string - The full file path.
+* `saveType` string - Specify the save type.
   * `HTMLOnly` - Save only the HTML of the page.
   * `HTMLComplete` - Save complete-html page.
   * `MHTML` - Save complete-html page as MHTML.
@@ -1784,7 +1784,7 @@ Shows pop-up dictionary that searches the selected word on the page.
 
 #### `contents.isOffscreen()`
 
-Returns `Boolean` - Indicates whether *offscreen rendering* is enabled.
+Returns `boolean` - Indicates whether *offscreen rendering* is enabled.
 
 #### `contents.startPainting()`
 
@@ -1796,7 +1796,7 @@ If *offscreen rendering* is enabled and painting, stop painting.
 
 #### `contents.isPainting()`
 
-Returns `Boolean` - If *offscreen rendering* is enabled returns whether it is currently painting.
+Returns `boolean` - If *offscreen rendering* is enabled returns whether it is currently painting.
 
 #### `contents.setFrameRate(fps)`
 
@@ -1818,11 +1818,11 @@ one through the `'paint'` event.
 
 #### `contents.getWebRTCIPHandlingPolicy()`
 
-Returns `String` - Returns the WebRTC IP Handling Policy.
+Returns `string` - Returns the WebRTC IP Handling Policy.
 
 #### `contents.setWebRTCIPHandlingPolicy(policy)`
 
-* `policy` String - Specify the WebRTC IP Handling Policy.
+* `policy` string - Specify the WebRTC IP Handling Policy.
   * `default` - Exposes user's public and local IPs. This is the default
   behavior. When this policy is used, WebRTC has the right to enumerate all
   interfaces and bind them to discover public interfaces.
@@ -1854,7 +1854,7 @@ be compared to the `frameProcessId` passed by frame specific navigation events
 
 #### `contents.takeHeapSnapshot(filePath)`
 
-* `filePath` String - Path to the output file.
+* `filePath` string - Path to the output file.
 
 Returns `Promise<void>` - Indicates whether the snapshot has been created successfully.
 
@@ -1862,39 +1862,39 @@ Takes a V8 heap snapshot and saves it to `filePath`.
 
 #### `contents.getBackgroundThrottling()`
 
-Returns `Boolean` - whether or not this WebContents will throttle animations and timers
+Returns `boolean` - whether or not this WebContents will throttle animations and timers
 when the page becomes backgrounded. This also affects the Page Visibility API.
 
 #### `contents.setBackgroundThrottling(allowed)`
 
-* `allowed` Boolean
+* `allowed` boolean
 
 Controls whether or not this WebContents will throttle animations and timers
 when the page becomes backgrounded. This also affects the Page Visibility API.
 
 #### `contents.getType()`
 
-Returns `String` - the type of the webContent. Can be `backgroundPage`, `window`, `browserView`, `remote`, `webview` or `offscreen`.
+Returns `string` - the type of the webContent. Can be `backgroundPage`, `window`, `browserView`, `remote`, `webview` or `offscreen`.
 
 ### Instance Properties
 
 #### `contents.audioMuted`
 
-A `Boolean` property that determines whether this page is muted.
+A `boolean` property that determines whether this page is muted.
 
 #### `contents.userAgent`
 
-A `String` property that determines the user agent for this web page.
+A `string` property that determines the user agent for this web page.
 
 #### `contents.zoomLevel`
 
-A `Number` property that determines the zoom level for this web contents.
+A `number` property that determines the zoom level for this web contents.
 
 The original size is 0 and each increment above or below represents zooming 20% larger or smaller to default limits of 300% and 50% of original size, respectively. The formula for this is `scale := 1.2 ^ level`.
 
 #### `contents.zoomFactor`
 
-A `Number` property that determines the zoom factor for this web contents.
+A `number` property that determines the zoom factor for this web contents.
 
 The zoom factor is the zoom percent divided by 100, so 300% = 3.0.
 
@@ -1935,5 +1935,5 @@ A [`Debugger`](debugger.md) instance for this webContents.
 
 #### `contents.backgroundThrottling`
 
-A `Boolean` property that determines whether or not this WebContents will throttle animations and timers
+A `boolean` property that determines whether or not this WebContents will throttle animations and timers
 when the page becomes backgrounded. This also affects the Page Visibility API.

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -31,11 +31,11 @@ The factor must be greater than 0.0.
 
 ### `webFrame.getZoomFactor()`
 
-Returns `Number` - The current zoom factor.
+Returns `number` - The current zoom factor.
 
 ### `webFrame.setZoomLevel(level)`
 
-* `level` Number - Zoom level.
+* `level` number - Zoom level.
 
 Changes the zoom level to the specified level. The original size is 0 and each
 increment above or below represents zooming 20% larger or smaller to default
@@ -47,12 +47,12 @@ limits of 300% and 50% of original size, respectively.
 
 ### `webFrame.getZoomLevel()`
 
-Returns `Number` - The current zoom level.
+Returns `number` - The current zoom level.
 
 ### `webFrame.setVisualZoomLevelLimits(minimumLevel, maximumLevel)`
 
-* `minimumLevel` Number
-* `maximumLevel` Number
+* `minimumLevel` number
+* `maximumLevel` number
 
 Sets the maximum and minimum pinch-to-zoom level.
 
@@ -64,12 +64,12 @@ Sets the maximum and minimum pinch-to-zoom level.
 
 ### `webFrame.setSpellCheckProvider(language, provider)`
 
-* `language` String
+* `language` string
 * `provider` Object
   * `spellCheck` Function
-    * `words` String[]
+    * `words` string[]
     * `callback` Function
-      * `misspeltWords` String[]
+      * `misspeltWords` string[]
 
 Sets a provider for spell checking in input fields and text areas.
 
@@ -107,9 +107,9 @@ webFrame.setSpellCheckProvider('en-US', {
 
 ### `webFrame.insertCSS(css)`
 
-* `css` String - CSS source code.
+* `css` string - CSS source code.
 
-Returns `String` - A key for the inserted CSS that can later be used to remove
+Returns `string` - A key for the inserted CSS that can later be used to remove
 the CSS via `webFrame.removeInsertedCSS(key)`.
 
 Injects CSS into the current web page and returns a unique key for the inserted
@@ -117,21 +117,21 @@ stylesheet.
 
 ### `webFrame.removeInsertedCSS(key)`
 
-* `key` String
+* `key` string
 
 Removes the inserted CSS from the current web page. The stylesheet is identified
 by its key, which is returned from `webFrame.insertCSS(css)`.
 
 ### `webFrame.insertText(text)`
 
-* `text` String
+* `text` string
 
 Inserts `text` to the focused element.
 
 ### `webFrame.executeJavaScript(code[, userGesture, callback])`
 
-* `code` String
-* `userGesture` Boolean (optional) - Default is `false`.
+* `code` string
+* `userGesture` boolean (optional) - Default is `false`.
 * `callback` Function (optional) - Called after script has been executed. Unless
   the frame is suspended (e.g. showing a modal alert), execution will be
   synchronous and the callback will be invoked before the method returns. For
@@ -156,7 +156,7 @@ this limitation.
             world used by Electron's `contextIsolation` feature. Accepts values
             in the range 1..536870911.
 * `scripts` [WebSource[]](structures/web-source.md)
-* `userGesture` Boolean (optional) - Default is `false`.
+* `userGesture` boolean (optional) - Default is `false`.
 * `callback` Function (optional) - Called after script has been executed. Unless
   the frame is suspended (e.g. showing a modal alert), execution will be
   synchronous and the callback will be invoked before the method returns.  For
@@ -177,9 +177,9 @@ dispatch errors of isolated worlds to foreign worlds.
 ### `webFrame.setIsolatedWorldInfo(worldId, info)`
 * `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electrons `contextIsolation` feature. Chrome extensions reserve the range of IDs in `[1 << 20, 1 << 29)`. You can provide any integer here.
 * `info` Object
-  * `securityOrigin` String (optional) - Security origin for the isolated world.
-  * `csp` String (optional) - Content Security Policy for the isolated world.
-  * `name` String (optional) - Name for isolated world. Useful in devtools.
+  * `securityOrigin` string (optional) - Security origin for the isolated world.
+  * `csp` string (optional) - Content Security Policy for the isolated world.
+  * `name` string (optional) - Name for isolated world. Useful in devtools.
 
 Set the security origin, content security policy and name of the isolated world.
 Note: If the `csp` is specified, then the `securityOrigin` also has to be specified.
@@ -234,7 +234,7 @@ and intend to stay there).
 
 ### `webFrame.getFrameForSelector(selector)`
 
-* `selector` String - CSS selector for a frame element.
+* `selector` string - CSS selector for a frame element.
 
 Returns `WebFrame` - The frame element in `webFrame's` document selected by
 `selector`, `null` would be returned if `selector` does not select a frame or
@@ -242,7 +242,7 @@ if the frame is not in the current renderer process.
 
 ### `webFrame.findFrameByName(name)`
 
-* `name` String
+* `name` string
 
 Returns `WebFrame` - A child of `webFrame` with the supplied `name`, `null`
 would be returned if there's no such frame or if the frame is not in the current

--- a/docs/api/web-request.md
+++ b/docs/api/web-request.md
@@ -43,22 +43,22 @@ The following methods are available on instances of `WebRequest`:
 #### `webRequest.onBeforeRequest([filter, ]listener)`
 
 * `filter` Object (optional)
-  * `urls` String[] - Array of URL patterns that will be used to filter out the
+  * `urls` string[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
 * `listener` Function | null
   * `details` Object
     * `id` Integer
-    * `url` String
-    * `method` String
+    * `url` string
+    * `method` string
     * `webContentsId` Integer (optional)
-    * `resourceType` String
-    * `referrer` String
+    * `resourceType` string
+    * `referrer` string
     * `timestamp` Double
     * `uploadData` [UploadData[]](structures/upload-data.md)
   * `callback` Function
     * `response` Object
-      * `cancel` Boolean (optional)
-      * `redirectURL` String (optional) - The original request is prevented from
+      * `cancel` boolean (optional)
+      * `redirectURL` string (optional) - The original request is prevented from
         being sent or completed and is instead redirected to the given URL.
 
 The `listener` will be called with `listener(details, callback)` when a request
@@ -86,21 +86,21 @@ Some examples of valid `urls`:
 #### `webRequest.onBeforeSendHeaders([filter, ]listener)`
 
 * `filter` Object (optional)
-  * `urls` String[] - Array of URL patterns that will be used to filter out the
+  * `urls` string[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
 * `listener` Function | null
   * `details` Object
     * `id` Integer
-    * `url` String
-    * `method` String
+    * `url` string
+    * `method` string
     * `webContentsId` Integer (optional)
-    * `resourceType` String
-    * `referrer` String
+    * `resourceType` string
+    * `referrer` string
     * `timestamp` Double
     * `requestHeaders` Record<string, string>
   * `callback` Function
     * `beforeSendResponse` Object
-      * `cancel` Boolean (optional)
+      * `cancel` boolean (optional)
       * `requestHeaders` Record<string, string | string[]> (optional) - When provided, request will be made
   with these headers.
 
@@ -113,16 +113,16 @@ The `callback` has to be called with a `response` object.
 #### `webRequest.onSendHeaders([filter, ]listener)`
 
 * `filter` Object (optional)
-  * `urls` String[] - Array of URL patterns that will be used to filter out the
+  * `urls` string[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
 * `listener` Function | null
   * `details` Object
     * `id` Integer
-    * `url` String
-    * `method` String
+    * `url` string
+    * `method` string
     * `webContentsId` Integer (optional)
-    * `resourceType` String
-    * `referrer` String
+    * `resourceType` string
+    * `referrer` string
     * `timestamp` Double
     * `requestHeaders` Record<string, string>
 
@@ -133,27 +133,27 @@ response are visible by the time this listener is fired.
 #### `webRequest.onHeadersReceived([filter, ]listener)`
 
 * `filter` Object (optional)
-  * `urls` String[] - Array of URL patterns that will be used to filter out the
+  * `urls` string[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
 * `listener` Function | null
   * `details` Object
     * `id` Integer
-    * `url` String
-    * `method` String
+    * `url` string
+    * `method` string
     * `webContentsId` Integer (optional)
-    * `resourceType` String
-    * `referrer` String
+    * `resourceType` string
+    * `referrer` string
     * `timestamp` Double
-    * `statusLine` String
+    * `statusLine` string
     * `statusCode` Integer
     * `requestHeaders` Record<string, string>
     * `responseHeaders` Record<string, string[]> (optional)
   * `callback` Function
     * `headersReceivedResponse` Object
-      * `cancel` Boolean (optional)
+      * `cancel` boolean (optional)
       * `responseHeaders` Record<string, string | string[]> (optional) - When provided, the server is assumed
         to have responded with these headers.
-      * `statusLine` String (optional) - Should be provided when overriding
+      * `statusLine` string (optional) - Should be provided when overriding
         `responseHeaders` to change header status otherwise original response
         header's status will be used.
 
@@ -165,22 +165,22 @@ The `callback` has to be called with a `response` object.
 #### `webRequest.onResponseStarted([filter, ]listener)`
 
 * `filter` Object (optional)
-  * `urls` String[] - Array of URL patterns that will be used to filter out the
+  * `urls` string[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
 * `listener` Function | null
   * `details` Object
     * `id` Integer
-    * `url` String
-    * `method` String
+    * `url` string
+    * `method` string
     * `webContentsId` Integer (optional)
-    * `resourceType` String
-    * `referrer` String
+    * `resourceType` string
+    * `referrer` string
     * `timestamp` Double
     * `responseHeaders` Record<string, string[]> (optional)
-    * `fromCache` Boolean - Indicates whether the response was fetched from disk
+    * `fromCache` boolean - Indicates whether the response was fetched from disk
       cache.
     * `statusCode` Integer
-    * `statusLine` String
+    * `statusLine` string
 
 The `listener` will be called with `listener(details)` when first byte of the
 response body is received. For HTTP requests, this means that the status line
@@ -189,23 +189,23 @@ and response headers are available.
 #### `webRequest.onBeforeRedirect([filter, ]listener)`
 
 * `filter` Object (optional)
-  * `urls` String[] - Array of URL patterns that will be used to filter out the
+  * `urls` string[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
 * `listener` Function | null
   * `details` Object
     * `id` Integer
-    * `url` String
-    * `method` String
+    * `url` string
+    * `method` string
     * `webContentsId` Integer (optional)
-    * `resourceType` String
-    * `referrer` String
+    * `resourceType` string
+    * `referrer` string
     * `timestamp` Double
-    * `redirectURL` String
+    * `redirectURL` string
     * `statusCode` Integer
-    * `statusLine` String
-    * `ip` String (optional) - The server IP address that the request was
+    * `statusLine` string
+    * `ip` string (optional) - The server IP address that the request was
       actually sent to.
-    * `fromCache` Boolean
+    * `fromCache` boolean
     * `responseHeaders` Record<string, string[]> (optional)
 
 The `listener` will be called with `listener(details)` when a server initiated
@@ -214,22 +214,22 @@ redirect is about to occur.
 #### `webRequest.onCompleted([filter, ]listener)`
 
 * `filter` Object (optional)
-  * `urls` String[] - Array of URL patterns that will be used to filter out the
+  * `urls` string[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
 * `listener` Function | null
   * `details` Object
     * `id` Integer
-    * `url` String
-    * `method` String
+    * `url` string
+    * `method` string
     * `webContentsId` Integer (optional)
-    * `resourceType` String
-    * `referrer` String
+    * `resourceType` string
+    * `referrer` string
     * `timestamp` Double
     * `responseHeaders` Record<string, string[]> (optional)
-    * `fromCache` Boolean
+    * `fromCache` boolean
     * `statusCode` Integer
-    * `statusLine` String
-    * `error` String
+    * `statusLine` string
+    * `error` string
 
 The `listener` will be called with `listener(details)` when a request is
 completed.
@@ -237,18 +237,18 @@ completed.
 #### `webRequest.onErrorOccurred([filter, ]listener)`
 
 * `filter` Object (optional)
-  * `urls` String[] - Array of URL patterns that will be used to filter out the
+  * `urls` string[] - Array of URL patterns that will be used to filter out the
         requests that do not match the URL patterns.
 * `listener` Function | null
   * `details` Object
     * `id` Integer
-    * `url` String
-    * `method` String
+    * `url` string
+    * `method` string
     * `webContentsId` Integer (optional)
-    * `resourceType` String
-    * `referrer` String
+    * `resourceType` string
+    * `referrer` string
     * `timestamp` Double
-    * `fromCache` Boolean
-    * `error` String - The error description.
+    * `fromCache` boolean
+    * `error` string - The error description.
 
 The `listener` will be called with `listener(details)` when an error occurs.

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -100,7 +100,7 @@ The `webview` tag has the following attributes:
 <webview src="https://www.github.com/"></webview>
 ```
 
-A `String` representing the visible URL. Writing to this attribute initiates top-level
+A `string` representing the visible URL. Writing to this attribute initiates top-level
 navigation.
 
 Assigning `src` its own value will reload the current page.
@@ -114,7 +114,7 @@ The `src` attribute can also accept data URLs, such as
 <webview src="http://www.google.com/" nodeintegration></webview>
 ```
 
-A `Boolean`. When this attribute is present the guest page in `webview` will have node
+A `boolean`. When this attribute is present the guest page in `webview` will have node
 integration and can use node APIs like `require` and `process` to access low
 level system resources. Node integration is disabled by default in the guest
 page.
@@ -125,7 +125,7 @@ page.
 <webview src="http://www.google.com/" nodeintegrationinsubframes></webview>
 ```
 
-A `Boolean` for the experimental option for enabling NodeJS support in sub-frames such as iframes
+A `boolean` for the experimental option for enabling NodeJS support in sub-frames such as iframes
 inside the `webview`. All your preloads will load for every iframe, you can
 use `process.isMainFrame` to determine if you are in the main frame or not.
 This option is disabled by default in the guest page.
@@ -136,7 +136,7 @@ This option is disabled by default in the guest page.
 <webview src="http://www.google.com/" enableremotemodule="false"></webview>
 ```
 
-A `Boolean`. When this attribute is `false` the guest page in `webview` will not have access
+A `boolean`. When this attribute is `false` the guest page in `webview` will not have access
 to the [`remote`](remote.md) module. The remote module is unavailable by default.
 
 ### `plugins`
@@ -145,7 +145,7 @@ to the [`remote`](remote.md) module. The remote module is unavailable by default
 <webview src="https://www.github.com/" plugins></webview>
 ```
 
-A `Boolean`. When this attribute is present the guest page in `webview` will be able to use
+A `boolean`. When this attribute is present the guest page in `webview` will be able to use
 browser plugins. Plugins are disabled by default.
 
 ### `preload`
@@ -154,7 +154,7 @@ browser plugins. Plugins are disabled by default.
 <webview src="https://www.github.com/" preload="./test.js"></webview>
 ```
 
-A `String` that specifies a script that will be loaded before other scripts run in the guest
+A `string` that specifies a script that will be loaded before other scripts run in the guest
 page. The protocol of script's URL must be either `file:` or `asar:`, because it
 will be loaded by `require` in guest page under the hood.
 
@@ -171,7 +171,7 @@ the `webPreferences` specified to the `will-attach-webview` event.
 <webview src="https://www.github.com/" httpreferrer="http://cheng.guru"></webview>
 ```
 
-A `String` that sets the referrer URL for the guest page.
+A `string` that sets the referrer URL for the guest page.
 
 ### `useragent`
 
@@ -179,7 +179,7 @@ A `String` that sets the referrer URL for the guest page.
 <webview src="https://www.github.com/" useragent="Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko"></webview>
 ```
 
-A `String` that sets the user agent for the guest page before the page is navigated to. Once the
+A `string` that sets the user agent for the guest page before the page is navigated to. Once the
 page is loaded, use the `setUserAgent` method to change the user agent.
 
 ### `disablewebsecurity`
@@ -188,7 +188,7 @@ page is loaded, use the `setUserAgent` method to change the user agent.
 <webview src="https://www.github.com/" disablewebsecurity></webview>
 ```
 
-A `Boolean`. When this attribute is present the guest page will have web security disabled.
+A `boolean`. When this attribute is present the guest page will have web security disabled.
 Web security is enabled by default.
 
 ### `partition`
@@ -198,7 +198,7 @@ Web security is enabled by default.
 <webview src="https://electronjs.org" partition="electron"></webview>
 ```
 
-A `String` that sets the session used by the page. If `partition` starts with `persist:`, the
+A `string` that sets the session used by the page. If `partition` starts with `persist:`, the
 page will use a persistent session available to all pages in the app with the
 same `partition`. if there is no `persist:` prefix, the page will use an
 in-memory session. By assigning the same `partition`, multiple pages can share
@@ -215,7 +215,7 @@ value will fail with a DOM exception.
 <webview src="https://www.github.com/" allowpopups></webview>
 ```
 
-A `Boolean`. When this attribute is present the guest page will be allowed to open new
+A `boolean`. When this attribute is present the guest page will be allowed to open new
 windows. Popups are disabled by default.
 
 ### `webpreferences`
@@ -224,7 +224,7 @@ windows. Popups are disabled by default.
 <webview src="https://github.com" webpreferences="allowRunningInsecureContent, javascript=no"></webview>
 ```
 
-A `String` which is a comma separated list of strings which specifies the web preferences to be set on the webview.
+A `string` which is a comma separated list of strings which specifies the web preferences to be set on the webview.
 The full list of supported preference strings can be found in [BrowserWindow](browser-window.md#new-browserwindowoptions).
 
 The string follows the same format as the features string in `window.open`.
@@ -238,7 +238,7 @@ Special values `yes` and `1` are interpreted as `true`, while `no` and `0` are i
 <webview src="https://www.github.com/" enableblinkfeatures="PreciseMemoryInfo, CSSVariables"></webview>
 ```
 
-A `String` which is a list of strings which specifies the blink features to be enabled separated by `,`.
+A `string` which is a list of strings which specifies the blink features to be enabled separated by `,`.
 The full list of supported feature strings can be found in the
 [RuntimeEnabledFeatures.json5][runtime-enabled-features] file.
 
@@ -248,7 +248,7 @@ The full list of supported feature strings can be found in the
 <webview src="https://www.github.com/" disableblinkfeatures="PreciseMemoryInfo, CSSVariables"></webview>
 ```
 
-A `String` which is a list of strings which specifies the blink features to be disabled separated by `,`.
+A `string` which is a list of strings which specifies the blink features to be disabled separated by `,`.
 The full list of supported feature strings can be found in the
 [RuntimeEnabledFeatures.json5][runtime-enabled-features] file.
 
@@ -271,11 +271,11 @@ webview.addEventListener('dom-ready', () => {
 
 * `url` URL
 * `options` Object (optional)
-  * `httpReferrer` (String | [Referrer](structures/referrer.md)) (optional) - An HTTP Referrer url.
-  * `userAgent` String (optional) - A user agent originating the request.
-  * `extraHeaders` String (optional) - Extra headers separated by "\n"
+  * `httpReferrer` (string | [Referrer](structures/referrer.md)) (optional) - An HTTP Referrer url.
+  * `userAgent` string (optional) - A user agent originating the request.
+  * `extraHeaders` string (optional) - Extra headers separated by "\n"
   * `postData` ([UploadRawData[]](structures/upload-raw-data.md) | [UploadFile[]](structures/upload-file.md) | [UploadBlob[]](structures/upload-blob.md)) (optional)
-  * `baseURLForDataURL` String (optional) - Base url (with trailing path separator) for files to be loaded by the data url. This is needed only if the specified `url` is a data url and needs to load other files.
+  * `baseURLForDataURL` string (optional) - Base url (with trailing path separator) for files to be loaded by the data url. This is needed only if the specified `url` is a data url and needs to load other files.
 
 Returns `Promise<void>` - The promise will resolve when the page has finished loading
 (see [`did-finish-load`](webview-tag.md#event-did-finish-load)), and rejects
@@ -287,30 +287,30 @@ e.g. the `http://` or `file://`.
 
 ### `<webview>.downloadURL(url)`
 
-* `url` String
+* `url` string
 
 Initiates a download of the resource at `url` without navigating.
 
 ### `<webview>.getURL()`
 
-Returns `String` - The URL of guest page.
+Returns `string` - The URL of guest page.
 
 ### `<webview>.getTitle()`
 
-Returns `String` - The title of guest page.
+Returns `string` - The title of guest page.
 
 ### `<webview>.isLoading()`
 
-Returns `Boolean` - Whether guest page is still loading resources.
+Returns `boolean` - Whether guest page is still loading resources.
 
 ### `<webview>.isLoadingMainFrame()`
 
-Returns `Boolean` - Whether the main frame (and not just iframes or frames within it) is
+Returns `boolean` - Whether the main frame (and not just iframes or frames within it) is
 still loading.
 
 ### `<webview>.isWaitingForResponse()`
 
-Returns `Boolean` - Whether the guest page is waiting for a first-response for the
+Returns `boolean` - Whether the guest page is waiting for a first-response for the
 main resource of the page.
 
 ### `<webview>.stop()`
@@ -327,17 +327,17 @@ Reloads the guest page and ignores cache.
 
 ### `<webview>.canGoBack()`
 
-Returns `Boolean` - Whether the guest page can go back.
+Returns `boolean` - Whether the guest page can go back.
 
 ### `<webview>.canGoForward()`
 
-Returns `Boolean` - Whether the guest page can go forward.
+Returns `boolean` - Whether the guest page can go forward.
 
 ### `<webview>.canGoToOffset(offset)`
 
 * `offset` Integer
 
-Returns `Boolean` - Whether the guest page can go to `offset`.
+Returns `boolean` - Whether the guest page can go to `offset`.
 
 ### `<webview>.clearHistory()`
 
@@ -365,23 +365,23 @@ Navigates to the specified offset from the "current entry".
 
 ### `<webview>.isCrashed()`
 
-Returns `Boolean` - Whether the renderer process has crashed.
+Returns `boolean` - Whether the renderer process has crashed.
 
 ### `<webview>.setUserAgent(userAgent)`
 
-* `userAgent` String
+* `userAgent` string
 
 Overrides the user agent for the guest page.
 
 ### `<webview>.getUserAgent()`
 
-Returns `String` - The user agent for guest page.
+Returns `string` - The user agent for guest page.
 
 ### `<webview>.insertCSS(css)`
 
-* `css` String
+* `css` string
 
-Returns `Promise<String>` - A promise that resolves with a key for the inserted
+Returns `Promise<string>` - A promise that resolves with a key for the inserted
 CSS that can later be used to remove the CSS via
 `<webview>.removeInsertedCSS(key)`.
 
@@ -390,7 +390,7 @@ stylesheet.
 
 ### `<webview>.removeInsertedCSS(key)`
 
-* `key` String
+* `key` string
 
 Returns `Promise<void>` - Resolves if the removal was successful.
 
@@ -399,8 +399,8 @@ by its key, which is returned from `<webview>.insertCSS(css)`.
 
 ### `<webview>.executeJavaScript(code[, userGesture])`
 
-* `code` String
-* `userGesture` Boolean (optional) - Default `false`.
+* `code` string
+* `userGesture` boolean (optional) - Default `false`.
 
 Returns `Promise<any>` - A promise that resolves with the result of the executed code
 or is rejected if the result of the code is a rejected promise.
@@ -419,11 +419,11 @@ Closes the DevTools window of guest page.
 
 ### `<webview>.isDevToolsOpened()`
 
-Returns `Boolean` - Whether guest page has a DevTools window attached.
+Returns `boolean` - Whether guest page has a DevTools window attached.
 
 ### `<webview>.isDevToolsFocused()`
 
-Returns `Boolean` - Whether DevTools window of guest page is focused.
+Returns `boolean` - Whether DevTools window of guest page is focused.
 
 ### `<webview>.inspectElement(x, y)`
 
@@ -442,17 +442,17 @@ Opens the DevTools for the service worker context present in the guest page.
 
 ### `<webview>.setAudioMuted(muted)`
 
-* `muted` Boolean
+* `muted` boolean
 
 Set guest page muted.
 
 ### `<webview>.isAudioMuted()`
 
-Returns `Boolean` - Whether guest page has been muted.
+Returns `boolean` - Whether guest page has been muted.
 
 ### `<webview>.isCurrentlyAudible()`
 
-Returns `Boolean` - Whether audio is currently playing.
+Returns `boolean` - Whether audio is currently playing.
 
 ### `<webview>.undo()`
 
@@ -492,19 +492,19 @@ Executes editing command `unselect` in page.
 
 ### `<webview>.replace(text)`
 
-* `text` String
+* `text` string
 
 Executes editing command `replace` in page.
 
 ### `<webview>.replaceMisspelling(text)`
 
-* `text` String
+* `text` string
 
 Executes editing command `replaceMisspelling` in page.
 
 ### `<webview>.insertText(text)`
 
-* `text` String
+* `text` string
 
 Returns `Promise<void>`
 
@@ -512,12 +512,12 @@ Inserts `text` to the focused element.
 
 ### `<webview>.findInPage(text[, options])`
 
-* `text` String - Content to be searched, must not be empty.
+* `text` string - Content to be searched, must not be empty.
 * `options` Object (optional)
-  * `forward` Boolean (optional) - Whether to search forward or backward, defaults to `true`.
-  * `findNext` Boolean (optional) - Whether the operation is first request or a follow up,
+  * `forward` boolean (optional) - Whether to search forward or backward, defaults to `true`.
+  * `findNext` boolean (optional) - Whether the operation is first request or a follow up,
     defaults to `false`.
-  * `matchCase` Boolean (optional) - Whether search should be case-sensitive,
+  * `matchCase` boolean (optional) - Whether search should be case-sensitive,
     defaults to `false`.
 
 Returns `Integer` - The request id used for the request.
@@ -527,7 +527,7 @@ can be obtained by subscribing to [`found-in-page`](webview-tag.md#event-found-i
 
 ### `<webview>.stopFindInPage(action)`
 
-* `action` String - Specifies the action to take place when ending
+* `action` string - Specifies the action to take place when ending
   [`<webview>.findInPage`](#webviewfindinpagetext-options) request.
   * `clearSelection` - Clear the selection.
   * `keepSelection` - Translate the selection into a normal selection.
@@ -538,32 +538,32 @@ Stops any `findInPage` request for the `webview` with the provided `action`.
 ### `<webview>.print([options])`
 
 * `options` Object (optional)
-  * `silent` Boolean (optional) - Don't ask user for print settings. Default is `false`.
-  * `printBackground` Boolean (optional) - Prints the background color and image of
+  * `silent` boolean (optional) - Don't ask user for print settings. Default is `false`.
+  * `printBackground` boolean (optional) - Prints the background color and image of
     the web page. Default is `false`.
-  * `deviceName` String (optional) - Set the printer device name to use. Must be the system-defined name and not the 'friendly' name, e.g 'Brother_QL_820NWB' and not 'Brother QL-820NWB'.
-  * `color` Boolean (optional) - Set whether the printed web page will be in color or grayscale. Default is `true`.
+  * `deviceName` string (optional) - Set the printer device name to use. Must be the system-defined name and not the 'friendly' name, e.g 'Brother_QL_820NWB' and not 'Brother QL-820NWB'.
+  * `color` boolean (optional) - Set whether the printed web page will be in color or grayscale. Default is `true`.
   * `margins` Object (optional)
-    * `marginType` String (optional) - Can be `default`, `none`, `printableArea`, or `custom`. If `custom` is chosen, you will also need to specify `top`, `bottom`, `left`, and `right`.
-    * `top` Number (optional) - The top margin of the printed web page, in pixels.
-    * `bottom` Number (optional) - The bottom margin of the printed web page, in pixels.
-    * `left` Number (optional) - The left margin of the printed web page, in pixels.
-    * `right` Number (optional) - The right margin of the printed web page, in pixels.
-  * `landscape` Boolean (optional) - Whether the web page should be printed in landscape mode. Default is `false`.
-  * `scaleFactor` Number (optional) - The scale factor of the web page.
-  * `pagesPerSheet` Number (optional) - The number of pages to print per page sheet.
-  * `collate` Boolean (optional) - Whether the web page should be collated.
-  * `copies` Number (optional) - The number of copies of the web page to print.
+    * `marginType` string (optional) - Can be `default`, `none`, `printableArea`, or `custom`. If `custom` is chosen, you will also need to specify `top`, `bottom`, `left`, and `right`.
+    * `top` number (optional) - The top margin of the printed web page, in pixels.
+    * `bottom` number (optional) - The bottom margin of the printed web page, in pixels.
+    * `left` number (optional) - The left margin of the printed web page, in pixels.
+    * `right` number (optional) - The right margin of the printed web page, in pixels.
+  * `landscape` boolean (optional) - Whether the web page should be printed in landscape mode. Default is `false`.
+  * `scaleFactor` number (optional) - The scale factor of the web page.
+  * `pagesPerSheet` number (optional) - The number of pages to print per page sheet.
+  * `collate` boolean (optional) - Whether the web page should be collated.
+  * `copies` number (optional) - The number of copies of the web page to print.
   * `pageRanges` Object[] (optional) - The page range to print.
-    * `from` Number - Index of the first page to print (0-based).
-    * `to` Number - Index of the last page to print (inclusive) (0-based).
-  * `duplexMode` String (optional) - Set the duplex mode of the printed web page. Can be `simplex`, `shortEdge`, or `longEdge`.
+    * `from` number - Index of the first page to print (0-based).
+    * `to` number - Index of the last page to print (inclusive) (0-based).
+  * `duplexMode` string (optional) - Set the duplex mode of the printed web page. Can be `simplex`, `shortEdge`, or `longEdge`.
   * `dpi` Record<string, number> (optional)
-    * `horizontal` Number (optional) - The horizontal dpi.
-    * `vertical` Number (optional) - The vertical dpi.
-  * `header` String (optional) - String to be printed as page header.
-  * `footer` String (optional) - String to be printed as page footer.
-  * `pageSize` String | Size (optional) - Specify page size of the printed document. Can be `A3`,
+    * `horizontal` number (optional) - The horizontal dpi.
+    * `vertical` number (optional) - The vertical dpi.
+  * `header` string (optional) - string to be printed as page header.
+  * `footer` string (optional) - string to be printed as page footer.
+  * `pageSize` string | Size (optional) - Specify page size of the printed document. Can be `A3`,
   `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height`.
 
 Returns `Promise<void>`
@@ -574,20 +574,20 @@ Prints `webview`'s web page. Same as `webContents.print([options])`.
 
 * `options` Object
   * `headerFooter` Record<string, string> (optional) - the header and footer for the PDF.
-    * `title` String - The title for the PDF header.
-    * `url` String - the url for the PDF footer.
-  * `landscape` Boolean (optional) - `true` for landscape, `false` for portrait.
+    * `title` string - The title for the PDF header.
+    * `url` string - the url for the PDF footer.
+  * `landscape` boolean (optional) - `true` for landscape, `false` for portrait.
   * `marginsType` Integer (optional) - Specifies the type of margins to use. Uses 0 for
     default margin, 1 for no margin, and 2 for minimum margin.
     and `width` in microns.
-  * `scaleFactor` Number (optional) - The scale factor of the web page. Can range from 0 to 100.
+  * `scaleFactor` number (optional) - The scale factor of the web page. Can range from 0 to 100.
   * `pageRanges` Record<string, number> (optional) - The page range to print. On macOS, only the first range is honored.
-    * `from` Number - Index of the first page to print (0-based).
-    * `to` Number - Index of the last page to print (inclusive) (0-based).
-  * `pageSize` String | Size (optional) - Specify page size of the generated PDF. Can be `A3`,
+    * `from` number - Index of the first page to print (0-based).
+    * `to` number - Index of the last page to print (inclusive) (0-based).
+  * `pageSize` string | Size (optional) - Specify page size of the generated PDF. Can be `A3`,
   `A4`, `A5`, `Legal`, `Letter`, `Tabloid` or an Object containing `height`
-  * `printBackground` Boolean (optional) - Whether to print CSS backgrounds.
-  * `printSelectionOnly` Boolean (optional) - Whether to print selection only.
+  * `printBackground` boolean (optional) - Whether to print CSS backgrounds.
+  * `printSelectionOnly` boolean (optional) - Whether to print selection only.
 
 Returns `Promise<Uint8Array>` - Resolves with the generated PDF data.
 
@@ -603,7 +603,7 @@ Captures a snapshot of the page within `rect`. Omitting `rect` will capture the 
 
 ### `<webview>.send(channel, ...args)`
 
-* `channel` String
+* `channel` string
 * `...args` any[]
 
 Returns `Promise<void>`
@@ -628,14 +628,14 @@ for detailed description of `event` object.
 
 ### `<webview>.setZoomFactor(factor)`
 
-* `factor` Number - Zoom factor.
+* `factor` number - Zoom factor.
 
 Changes the zoom factor to the specified factor. Zoom factor is
 zoom percent divided by 100, so 300% = 3.0.
 
 ### `<webview>.setZoomLevel(level)`
 
-* `level` Number - Zoom level.
+* `level` number - Zoom level.
 
 Changes the zoom level to the specified level. The original size is 0 and each
 increment above or below represents zooming 20% larger or smaller to default
@@ -648,16 +648,16 @@ limits of 300% and 50% of original size, respectively. The formula for this is
 
 ### `<webview>.getZoomFactor()`
 
-Returns `Number` - the current zoom factor.
+Returns `number` - the current zoom factor.
 
 ### `<webview>.getZoomLevel()`
 
-Returns `Number` - the current zoom level.
+Returns `number` - the current zoom level.
 
 ### `<webview>.setVisualZoomLevelLimits(minimumLevel, maximumLevel)`
 
-* `minimumLevel` Number
-* `maximumLevel` Number
+* `minimumLevel` number
+* `maximumLevel` number
 
 Returns `Promise<void>`
 
@@ -669,7 +669,7 @@ Shows pop-up dictionary that searches the selected word on the page.
 
 ### `<webview>.getWebContentsId()`
 
-Returns `Number` - The WebContents ID of this `webview`.
+Returns `number` - The WebContents ID of this `webview`.
 
 ## DOM Events
 
@@ -679,8 +679,8 @@ The following DOM events are available to the `webview` tag:
 
 Returns:
 
-* `url` String
-* `isMainFrame` Boolean
+* `url` string
+* `isMainFrame` boolean
 
 Fired when a load has committed. This includes navigation within the current
 document as well as subframe document-level loads, but does not include
@@ -696,9 +696,9 @@ spinning, and the `onload` event is dispatched.
 Returns:
 
 * `errorCode` Integer
-* `errorDescription` String
-* `validatedURL` String
-* `isMainFrame` Boolean
+* `errorDescription` string
+* `validatedURL` string
+* `isMainFrame` boolean
 
 This event is like `did-finish-load`, but fired when the load failed or was
 cancelled, e.g. `window.stop()` is invoked.
@@ -707,7 +707,7 @@ cancelled, e.g. `window.stop()` is invoked.
 
 Returns:
 
-* `isMainFrame` Boolean
+* `isMainFrame` boolean
 
 Fired when a frame has done navigation.
 
@@ -727,8 +727,8 @@ Fired when document in the given frame is loaded.
 
 Returns:
 
-* `title` String
-* `explicitSet` Boolean
+* `title` string
+* `explicitSet` boolean
 
 Fired when page title is set during navigation. `explicitSet` is false when
 title is synthesized from file url.
@@ -737,7 +737,7 @@ title is synthesized from file url.
 
 Returns:
 
-* `favicons` String[] - Array of URLs.
+* `favicons` string[] - Array of URLs.
 
 Fired when page receives favicon urls.
 
@@ -754,9 +754,9 @@ Fired when page leaves fullscreen triggered by HTML API.
 Returns:
 
 * `level` Integer - The log level, from 0 to 3. In order it matches `verbose`, `info`, `warning` and `error`.
-* `message` String - The actual console message
+* `message` string - The actual console message
 * `line` Integer - The line number of the source that triggered this console message
-* `sourceId` String
+* `sourceId` string
 
 Fired when the guest window logs a console message.
 
@@ -779,7 +779,7 @@ Returns:
   * `activeMatchOrdinal` Integer - Position of the active match.
   * `matches` Integer - Number of Matches.
   * `selectionArea` Rectangle - Coordinates of first match region.
-  * `finalUpdate` Boolean
+  * `finalUpdate` boolean
 
 Fired when a result is available for
 [`webview.findInPage`](#webviewfindinpagetext-options) request.
@@ -798,9 +798,9 @@ console.log(requestId)
 
 Returns:
 
-* `url` String
-* `frameName` String
-* `disposition` String - Can be `default`, `foreground-tab`, `background-tab`,
+* `url` string
+* `frameName` string
+* `disposition` string - Can be `default`, `foreground-tab`, `background-tab`,
   `new-window`, `save-to-disk` and `other`.
 * `options` BrowserWindowConstructorOptions - The options which should be used for creating the new
   [`BrowserWindow`](browser-window.md).
@@ -825,7 +825,7 @@ webview.addEventListener('new-window', async (e) => {
 
 Returns:
 
-* `url` String
+* `url` string
 
 Emitted when a user or the page wants to start navigation. It can happen when
 the `window.location` object is changed or a user clicks a link in the page.
@@ -843,7 +843,7 @@ Calling `event.preventDefault()` does __NOT__ have any effect.
 
 Returns:
 
-* `url` String
+* `url` string
 
 Emitted when a navigation is done.
 
@@ -855,8 +855,8 @@ this purpose.
 
 Returns:
 
-* `isMainFrame` Boolean
-* `url` String
+* `isMainFrame` boolean
+* `url` string
 
 Emitted when an in-page navigation happened.
 
@@ -882,7 +882,7 @@ webview.addEventListener('close', () => {
 
 Returns:
 
-* `channel` String
+* `channel` string
 * `args` any[]
 
 Fired when the guest page has sent an asynchronous message to embedder page.
@@ -916,8 +916,8 @@ Fired when the renderer process is crashed.
 
 Returns:
 
-* `name` String
-* `version` String
+* `name` string
+* `version` string
 
 Fired when a plugin process is crashed.
 
@@ -937,7 +937,7 @@ Emitted when media is paused or done playing.
 
 Returns:
 
-* `themeColor` String
+* `themeColor` string
 
 Emitted when a page's theme color changes. This is usually due to encountering a meta tag:
 
@@ -949,7 +949,7 @@ Emitted when a page's theme color changes. This is usually due to encountering a
 
 Returns:
 
-* `url` String
+* `url` string
 
 Emitted when mouse moves over a link or the keyboard moves the focus to a link.
 

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -777,7 +777,7 @@ Returns:
 * `result` Object
   * `requestId` Integer
   * `activeMatchOrdinal` Integer - Position of the active match.
-  * `matches` Integer - Number of Matches.
+  * `matches` Integer - number of Matches.
   * `selectionArea` Rectangle - Coordinates of first match region.
   * `finalUpdate` boolean
 

--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -16,9 +16,9 @@ string.
 
 ### `window.open(url[, frameName][, features])`
 
-* `url` String
-* `frameName` String (optional)
-* `features` String (optional)
+* `url` string
+* `frameName` string (optional)
+* `features` string (optional)
 
 Returns [`BrowserWindowProxy`](browser-window-proxy.md) - Creates a new window
 and returns an instance of `BrowserWindowProxy` class.
@@ -45,8 +45,8 @@ window.open('https://github.com', '_blank', 'nodeIntegration=no')
 
 ### `window.opener.postMessage(message, targetOrigin)`
 
-* `message` String
-* `targetOrigin` String
+* `message` string
+* `targetOrigin` string
 
 Sends a message to the parent window with the specified origin or `*` for no
 origin preference.


### PR DESCRIPTION
Reference issue - #14023 
### Description of Change
Changed all the types from wrappers to primitive types in all the files of the docs.
For example: 
(before) type : "String"
(after) type : "string"

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
