### PR TITLE
docs: update link to `did-fail-load` events

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -70,7 +70,7 @@ Returns:
 * `frameRoutingId` Integer
 
 This event is like `did-finish-load` but emitted when the load failed.
-The full list of error codes and their meaning is available [here](https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h).
+The full list of error codes and their meaning is available [here](https://chromium.googlesource.com/chromium/src/+/master/net/base/net_error_list.h).
 
 #### Event: 'did-fail-provisional-load'
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -70,7 +70,7 @@ Returns:
 * `frameRoutingId` Integer
 
 This event is like `did-finish-load` but emitted when the load failed.
-The full list of error codes and their meaning is available [here](https://chromium.googlesource.com/chromium/src/+/master/net/base/net_error_list.h).
+The full list of error codes and their meaning is available [here](https://source.chromium.org/chromium/chromium/src/+/master:net/base/net_error_list.h).
 
 #### Event: 'did-fail-provisional-load'
 


### PR DESCRIPTION
#### Description of Change

The old link at https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h seems to redirect to https://source.chromium.org/chromium now.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
