### PR TITLE
feat: add support for preventing the system context menu

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -667,6 +667,20 @@ Emitted when the window has closed a sheet.
 
 Emitted when the native new tab button is clicked.
 
+#### Event: 'system-context-menu' _Windows_
+
+Returns:
+
+* `event` Event
+* `point` [Point](structures/point.md) - The screen coordinates the context menu was triggered at
+
+Emitted when the system context menu is triggered on the window, this is
+normally only triggered when the user right clicks on the non-client area
+of your window.  This is the window titlebar or any area you have declared
+as `-webkit-app-region: drag` in a frameless window.
+
+Calling `event.preventDefault()` will prevent the menu from being displayed.
+
 ### Static Methods
 
 The `BrowserWindow` class has the following static methods:

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -294,6 +294,12 @@ void BaseWindow::OnNewWindowForTab() {
   Emit("new-window-for-tab");
 }
 
+void BaseWindow::OnSystemContextMenu(int x, int y, bool* prevent_default) {
+  if (Emit("system-context-menu", gfx::Point(x, y))) {
+    *prevent_default = true;
+  }
+}
+
 #if defined(OS_WIN)
 void BaseWindow::OnWindowMessage(UINT message, WPARAM w_param, LPARAM l_param) {
   if (IsWindowMessageHooked(message)) {

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -82,6 +82,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void OnTouchBarItemResult(const std::string& item_id,
                             const base::DictionaryValue& details) override;
   void OnNewWindowForTab() override;
+  void OnSystemContextMenu(int x, int y, bool* prevent_default) override;
 #if defined(OS_WIN)
   void OnWindowMessage(UINT message, WPARAM w_param, LPARAM l_param) override;
 #endif

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -579,6 +579,13 @@ void NativeWindow::NotifyNewWindowForTab() {
     observer.OnNewWindowForTab();
 }
 
+void NativeWindow::NotifyWindowSystemContextMenu(int x,
+                                                 int y,
+                                                 bool* prevent_default) {
+  for (NativeWindowObserver& observer : observers_)
+    observer.OnSystemContextMenu(x, y, prevent_default);
+}
+
 #if defined(OS_WIN)
 void NativeWindow::NotifyWindowMessage(UINT message,
                                        WPARAM w_param,

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -288,6 +288,7 @@ class NativeWindow : public base::SupportsUserData,
   void NotifyTouchBarItemInteraction(const std::string& item_id,
                                      const base::DictionaryValue& details);
   void NotifyNewWindowForTab();
+  void NotifyWindowSystemContextMenu(int x, int y, bool* prevent_default);
 
 #if defined(OS_WIN)
   void NotifyWindowMessage(UINT message, WPARAM w_param, LPARAM l_param);

--- a/shell/browser/native_window_observer.h
+++ b/shell/browser/native_window_observer.h
@@ -92,6 +92,7 @@ class NativeWindowObserver : public base::CheckedObserver {
   virtual void OnTouchBarItemResult(const std::string& item_id,
                                     const base::DictionaryValue& details) {}
   virtual void OnNewWindowForTab() {}
+  virtual void OnSystemContextMenu(int x, int y, bool* prevent_default) {}
 
 // Called when window message received
 #if defined(OS_WIN)

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -306,6 +306,12 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
       }
       return false;
     }
+    case WM_CONTEXTMENU: {
+      bool prevent_default = false;
+      NotifyWindowSystemContextMenu(GET_X_LPARAM(l_param),
+                                    GET_Y_LPARAM(l_param), &prevent_default);
+      return prevent_default;
+    }
     default:
       return false;
   }


### PR DESCRIPTION
Docs explain this well enough hopefully, basically there is a menu that appears when you right click on the non-client area of your app.  This event lets you prevent that menu appearing and passes the coordinates so you can in theory replace it with your own menu if you wanted.

Pretty standard event wiring, nothing new here.

Notes: Added new `system-context-menu` event to allow preventing and overriding the system context menu