### PR TITLE
fix: session argument of app 'session-created' event

### DIFF
--- a/lib/browser/api/app.ts
+++ b/lib/browser/api/app.ts
@@ -135,6 +135,10 @@ for (const name of events) {
   });
 }
 
+app.on('-session-created' as any, (event, session) => {
+  app.emit('session-created', session);
+});
+
 // Deprecate allowRendererProcessReuse but only if they set it to false, no need to log if
 // they are setting it to true
 deprecate.removeProperty(app, 'allowRendererProcessReuse', [false]);

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -950,8 +950,7 @@ gin::Handle<Session> Session::CreateFrom(
   ElectronBrowserMainParts::Get()->RegisterDestructionCallback(
       base::BindOnce([](Session* session) { delete session; }, handle.get()));
 
-  App::Get()->EmitCustomEvent("session-created",
-                              handle.ToV8().As<v8::Object>());
+  App::Get()->Emit("-session-created", handle.ToV8().As<v8::Object>());
 
   return handle;
 }


### PR DESCRIPTION
#### Description of Change
Fixes #25457

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed `session` argument of `app` `'session-created'` event.