### PR TITLE
test: improve app 'session-created' event spec

### DIFF
--- a/spec-main/api-session-spec.ts
+++ b/spec-main/api-session-spec.ts
@@ -979,10 +979,10 @@ describe('session module', () => {
 
   describe('session-created event', () => {
     it('is emitted when a session is created', async () => {
-      const eventEmitted = new Promise<Session>(resolve => app.once('session-created', resolve));
-      session.fromPartition('' + Math.random());
-      const s = await eventEmitted;
-      expect(s.constructor.name).to.equal('Session');
+      const sessionCreated = emittedOnce(app, 'session-created');
+      const session1 = session.fromPartition('' + Math.random());
+      const [session2] = await sessionCreated;
+      expect(session1).to.equal(session2);
     });
   });
 });


### PR DESCRIPTION
#### Description of Change
Makes the test fail without #25798
```
not ok 1 session module session-created event is emitted when a session is created
  TypeError: Illegal invocation: Function must be called on an object of type Session
      at formatProperty (node_modules/chai/lib/chai/utils/inspect.js:294:31)
      at /Users/miburda/Development/github/electron-gn/src/electron/node_modules/chai/lib/chai/utils/inspect.js:190:14
      at Array.map (<anonymous>)
      at formatValue (node_modules/chai/lib/chai/utils/inspect.js:189:19)
      at inspect (node_modules/chai/lib/chai/utils/inspect.js:32:10)
      at objDisplay (node_modules/chai/lib/chai/utils/objDisplay.js:28:13)
      at /Users/miburda/Development/github/electron-gn/src/electron/node_modules/chai/lib/chai/utils/getMessage.js:47:48
      at String.replace (<anonymous>)
      at Object.getMessage (node_modules/chai/lib/chai/utils/getMessage.js:47:6)
      at Proxy.Assertion.assert (node_modules/chai/lib/chai/assertion.js:139:18)
```

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes