### PR TITLE
feat: add disabledCipherSuites option to setSSLConfig

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -578,6 +578,7 @@ Returns `String` - The user agent for this session.
     parsable cipher suites in this form will not return an error.
     Ex: To disable TLS_RSA_WITH_RC4_128_MD5, specify 0x0004, while to
     disable TLS_ECDH_ECDSA_WITH_RC4_128_SHA, specify 0xC002.
+    Note that TLSv1.3 ciphers cannot be disabled using this mechanism.
 
 Sets the SSL configuration for the session. All subsequent network requests
 will use the new configuration. Existing network connections (such as WebSocket

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -565,11 +565,19 @@ Returns `String` - The user agent for this session.
 #### `ses.setSSLConfig(config)`
 
 * `config` Object
-  * `minVersion` String - Can be `tls1`, `tls1.1`, `tls1.2` or `tls1.3`. The
+  * `minVersion` String (optional) - Can be `tls1`, `tls1.1`, `tls1.2` or `tls1.3`. The
     minimum SSL version to allow when connecting to remote servers. Defaults to
     `tls1`.
-  * `maxVersion` String - Can be `tls1.2` or `tls1.3`. The maximum SSL version
+  * `maxVersion` String (optional) - Can be `tls1.2` or `tls1.3`. The maximum SSL version
     to allow when connecting to remote servers. Defaults to `tls1.3`.
+  * `disabledCipherSuites` Integer[] (optional) - List of cipher suites which
+    should be explicitly prevented from being used in addition to those
+    disabled by the net built-in policy.
+    Supported literal forms: 0xAABB, where AA is `cipher_suite[0]` and BB is
+    `cipher_suite[1]`, as defined in RFC 2246, Section 7.4.1.2. Unrecognized but
+    parsable cipher suites in this form will not return an error.
+    Ex: To disable TLS_RSA_WITH_RC4_128_MD5, specify 0x0004, while to
+    disable TLS_ECDH_ECDSA_WITH_RC4_128_SHA, specify 0xC002.
 
 Sets the SSL configuration for the session. All subsequent network requests
 will use the new configuration. Existing network connections (such as WebSocket

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -224,8 +224,14 @@ struct Converter<network::mojom::SSLConfigPtr> {
         return false;
     }
 
-    // TODO(nornagon): also support client_cert_pooling_policy and
-    // disabled_cipher_suites. Maybe other SSLConfig properties too?
+    if (options.Has("disabledCipherSuites") &&
+        !options.Get("disabledCipherSuites", &(*out)->disabled_cipher_suites)) {
+      return false;
+    }
+    std::sort((*out)->disabled_cipher_suites.begin(),
+              (*out)->disabled_cipher_suites.end());
+
+    // TODO(nornagon): also support other SSLConfig properties?
     return true;
   }
 };

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -203,6 +203,19 @@ bool SSLProtocolVersionFromString(const std::string& version_str,
 }
 
 template <>
+struct Converter<uint16_t> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     uint16_t* out) {
+    auto maybe = val->IntegerValue(isolate->GetCurrentContext());
+    if (maybe.IsNothing())
+      return false;
+    *out = maybe.FromJust();
+    return true;
+  }
+};
+
+template <>
 struct Converter<network::mojom::SSLConfigPtr> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,


### PR DESCRIPTION
#### Description of Change
This adds a new option, `disabledCipherSuites`, to the `ses.setSSLConfig`
method. It configures the underlying SSLConfig parameter by the same name.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added a `disabledCipherSuites` option to `Session.setSSLConfig`.
