### PR TITLE
feat: hide electron links in default help menu when packaged

### DIFF
--- a/lib/browser/default-menu.ts
+++ b/lib/browser/default-menu.ts
@@ -1,4 +1,4 @@
-import { Menu } from 'electron/main';
+import { app, Menu } from 'electron/main';
 import { shell } from 'electron/common';
 
 const v8Util = process._linkedBinding('electron_common_v8_util');
@@ -10,7 +10,7 @@ export const setDefaultApplicationMenu = () => {
 
   const helpMenu: Electron.MenuItemConstructorOptions = {
     role: 'help',
-    submenu: [
+    submenu: app.isPackaged() ? [] : [
       {
         label: 'Learn More',
         click: async () => {

--- a/lib/browser/default-menu.ts
+++ b/lib/browser/default-menu.ts
@@ -10,7 +10,7 @@ export const setDefaultApplicationMenu = () => {
 
   const helpMenu: Electron.MenuItemConstructorOptions = {
     role: 'help',
-    submenu: app.isPackaged() ? [] : [
+    submenu: app.isPackaged ? [] : [
       {
         label: 'Learn More',
         click: async () => {


### PR DESCRIPTION
#### Description of Change
When an app is packaged, it shouldn't point to the Electron website or issue tracker.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Removed links to the Electron website from the default 'Help' menu in packaged apps.
