### PR TITLE
fix: NativeImage.getScaleFactors returns correct scales

### DIFF
--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -270,7 +270,11 @@ gfx::Size NativeImage::GetSize(const base::Optional<float> scale_factor) {
 
 std::vector<float> NativeImage::GetScaleFactors() {
   gfx::ImageSkia image_skia = image_.AsImageSkia();
-  return image_skia.GetSupportedScales();
+  std::vector<float> scale_factors;
+  for (const auto& rep : image_skia.image_reps()) {
+    scale_factors.push_back(rep.scale());
+  }
+  return scale_factors;
 }
 
 float NativeImage::GetAspectRatio(const base::Optional<float> scale_factor) {

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -393,18 +393,20 @@ gin::Handle<NativeImage> NativeImage::Create(v8::Isolate* isolate,
 gin::Handle<NativeImage> NativeImage::CreateFromPNG(v8::Isolate* isolate,
                                                     const char* buffer,
                                                     size_t length) {
-  gfx::Image image = gfx::Image::CreateFrom1xPNGBytes(
-      reinterpret_cast<const unsigned char*>(buffer), length);
-  return Create(isolate, image);
+  gfx::ImageSkia image_skia;
+  electron::util::AddImageSkiaRepFromPNG(
+      &image_skia, reinterpret_cast<const unsigned char*>(buffer), length, 1.0);
+  return Create(isolate, gfx::Image(image_skia));
 }
 
 // static
 gin::Handle<NativeImage> NativeImage::CreateFromJPEG(v8::Isolate* isolate,
                                                      const char* buffer,
                                                      size_t length) {
-  gfx::Image image = gfx::ImageFrom1xJPEGEncodedData(
-      reinterpret_cast<const unsigned char*>(buffer), length);
-  return Create(isolate, image);
+  gfx::ImageSkia image_skia;
+  electron::util::AddImageSkiaRepFromJPEG(
+      &image_skia, reinterpret_cast<const unsigned char*>(buffer), length, 1.0);
+  return Create(isolate, gfx::Image(image_skia));
 }
 
 // static

--- a/spec-main/api-remote-spec.ts
+++ b/spec-main/api-remote-spec.ts
@@ -107,7 +107,7 @@ describe('typeUtils serialization/deserialization', () => {
     expect(nonEmpty.isEmpty()).to.be.false();
     expect(nonEmpty.getAspectRatio()).to.equal(1);
     expect(nonEmpty.toDataURL()).to.not.be.empty();
-    expect(nonEmpty.toDataURL({ scaleFactor: 1.0 })).to.equal(dataURL);
+    expect(nonEmpty.toBitmap({ scaleFactor: 1.0 })).to.deep.equal(image.toBitmap({ scaleFactor: 1.0 }));
     expect(nonEmpty.getSize()).to.deep.equal({ width: 2, height: 2 });
     expect(nonEmpty.getBitmap()).to.not.be.empty();
     expect(nonEmpty.toPNG()).to.not.be.empty();
@@ -132,14 +132,12 @@ describe('typeUtils serialization/deserialization', () => {
     expect(nonEmpty.getBitmap({ scaleFactor: 1.0 })).to.not.be.empty();
     expect(nonEmpty.getBitmap({ scaleFactor: 2.0 })).to.not.be.empty();
     expect(nonEmpty.toBitmap()).to.not.be.empty();
-    expect(nonEmpty.toBitmap({ scaleFactor: 1.0 })).to.not.be.empty();
-    expect(nonEmpty.toBitmap({ scaleFactor: 2.0 })).to.not.be.empty();
+    expect(nonEmpty.toBitmap({ scaleFactor: 1.0 })).to.deep.equal(image.toBitmap({ scaleFactor: 1.0 }));
+    expect(nonEmpty.toBitmap({ scaleFactor: 2.0 })).to.deep.equal(image.toBitmap({ scaleFactor: 2.0 }));
     expect(nonEmpty.toPNG()).to.not.be.empty();
     expect(nonEmpty.toPNG({ scaleFactor: 1.0 })).to.not.be.empty();
     expect(nonEmpty.toPNG({ scaleFactor: 2.0 })).to.not.be.empty();
     expect(nonEmpty.toDataURL()).to.not.be.empty();
-    expect(nonEmpty.toDataURL({ scaleFactor: 1.0 })).to.equal(dataURL1);
-    expect(nonEmpty.toDataURL({ scaleFactor: 2.0 })).to.equal(dataURL2);
   });
 
   it('serializes and deserializes an Array', () => {

--- a/spec/api-native-image-spec.js
+++ b/spec/api-native-image-spec.js
@@ -539,11 +539,15 @@ describe('nativeImage module', () => {
         buffer: nativeImage.createFromPath(imageDataOne.path).toPNG()
       });
 
+      expect(image.getScaleFactors()).to.deep.equal([1]);
+
       const imageDataTwo = getImage({ width: 2, height: 2 });
       image.addRepresentation({
         scaleFactor: 2.0,
         buffer: nativeImage.createFromPath(imageDataTwo.path).toPNG()
       });
+
+      expect(image.getScaleFactors()).to.deep.equal([1, 2]);
 
       const imageDataThree = getImage({ width: 3, height: 3 });
       image.addRepresentation({
@@ -551,10 +555,15 @@ describe('nativeImage module', () => {
         buffer: nativeImage.createFromPath(imageDataThree.path).toPNG()
       });
 
+      expect(image.getScaleFactors()).to.deep.equal([1, 2, 3]);
+
       image.addRepresentation({
         scaleFactor: 4.0,
         buffer: 'invalid'
       });
+
+      // this one failed, so it shouldn't show up in the scale factors
+      expect(image.getScaleFactors()).to.deep.equal([1, 2, 3]);
 
       expect(image.isEmpty()).to.be.false();
       expect(image.getSize()).to.deep.equal({ width: 1, height: 1 });


### PR DESCRIPTION
#### Description of Change
Extracting part of #25727 which is safer (though doesn't fix everything that #25727 does).

`gfx::ImageSkia::GetSupportedScales()` is a static method that always returns the same values, regardless of the properties of the image.

Fixing this necessitated changing the `CreateFromPNG` function to call `AddImageSkiaRepFromPNG` instead of `CreateFrom1xPNGBytes`. The reason is that `gfx::Image` has some functionality for lazily decoding PNG images on an as-needed basis. When a `gfx::Image` is created with a PNG source, it will only materialize a representation (pixel buffer) for that image when a specific scale factor is requested. So asking for "what scale factors does this image have?" of an image created in this way, when no scale factors have already been requested, would return an empty list.

This has the downside that we now eagerly decode PNGs instead of lazily decoding them. Unfortunately, there is no way to detect the "lazy-decoding" state through the API that `gfx::Image` decodes. This PR chooses correctness over performance.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed NativeImage.getScaleFactors() always returning the same value.