### PR TITLE
fix: delay emitting powerMonitor events on windows

### DIFF
--- a/shell/browser/api/electron_api_power_monitor.h
+++ b/shell/browser/api/electron_api_power_monitor.h
@@ -78,8 +78,6 @@ class PowerMonitor : public gin::Wrappable<PowerMonitor>,
   PowerObserverLinux power_observer_linux_{this};
 #endif
 
-  v8::Global<v8::Value> pinned_;
-
   DISALLOW_COPY_AND_ASSIGN(PowerMonitor);
 };
 

--- a/shell/browser/api/electron_api_power_monitor_win.cc
+++ b/shell/browser/api/electron_api_power_monitor_win.cc
@@ -7,6 +7,7 @@
 #include <windows.h>
 #include <wtsapi32.h>
 
+#include "base/task/thread_pool.h"
 #include "base/win/windows_types.h"
 #include "base/win/wrapped_window_proc.h"
 #include "ui/base/win/shell.h"

--- a/shell/browser/api/electron_api_power_monitor_win.cc
+++ b/shell/browser/api/electron_api_power_monitor_win.cc
@@ -85,22 +85,22 @@ LRESULT CALLBACK PowerMonitor::WndProc(HWND hwnd,
         // Unretained is OK because this object is eternally pinned.
         base::ThreadPool::PostTask(
             FROM_HERE, {content::BrowserThread::UI},
-            base::BindOnce(&Emit, base::Unretained(this), "lock-screen"));
+            base::BindOnce(&Emit<>, base::Unretained(this), "lock-screen"));
       } else if (wparam == WTS_SESSION_UNLOCK) {
         base::ThreadPool::PostTask(
             FROM_HERE, {content::BrowserThread::UI},
-            base::BindOnce(&Emit, base::Unretained(this), "unlock-screen"));
+            base::BindOnce(&Emit<>, base::Unretained(this), "unlock-screen"));
       }
     }
   } else if (message == WM_POWERBROADCAST) {
     if (wparam == PBT_APMRESUMEAUTOMATIC) {
       base::ThreadPool::PostTask(
           FROM_HERE, {content::BrowserThread::UI},
-          base::BindOnce(&Emit, base::Unretained(this), "resume"));
+          base::BindOnce(&Emit<>, base::Unretained(this), "resume"));
     } else if (wparam == PBT_APMSUSPEND) {
       base::ThreadPool::PostTask(
           FROM_HERE, {content::BrowserThread::UI},
-          base::BindOnce(&Emit, base::Unretained(this), "suspend"));
+          base::BindOnce(&Emit<>, base::Unretained(this), "suspend"));
     }
   }
   return ::DefWindowProc(hwnd, message, wparam, lparam);

--- a/shell/browser/api/electron_api_power_monitor_win.cc
+++ b/shell/browser/api/electron_api_power_monitor_win.cc
@@ -83,26 +83,26 @@ LRESULT CALLBACK PowerMonitor::WndProc(HWND hwnd,
     if (should_treat_as_current_session) {
       if (wparam == WTS_SESSION_LOCK) {
         // Unretained is OK because this object is eternally pinned.
-        base::ThreadPool::PostTask(
-            FROM_HERE, {content::BrowserThread::UI},
+        content::GetUIThreadTaskRunner({})->PostTask(
+            FROM_HERE,
             base::BindOnce([](PowerMonitor* pm) { pm->Emit("lock-screen"); },
                            base::Unretained(this)));
       } else if (wparam == WTS_SESSION_UNLOCK) {
-        base::ThreadPool::PostTask(
-            FROM_HERE, {content::BrowserThread::UI},
+        content::GetUIThreadTaskRunner({})->PostTask(
+            FROM_HERE,
             base::BindOnce([](PowerMonitor* pm) { pm->Emit("unlock-screen"); },
                            base::Unretained(this)));
       }
     }
   } else if (message == WM_POWERBROADCAST) {
     if (wparam == PBT_APMRESUMEAUTOMATIC) {
-      base::ThreadPool::PostTask(
-          FROM_HERE, {content::BrowserThread::UI},
+      content::GetUIThreadTaskRunner({})->PostTask(
+          FROM_HERE,
           base::BindOnce([](PowerMonitor* pm) { pm->Emit("resume"); },
                          base::Unretained(this)));
     } else if (wparam == PBT_APMSUSPEND) {
-      base::ThreadPool::PostTask(
-          FROM_HERE, {content::BrowserThread::UI},
+      content::GetUIThreadTaskRunner({})->PostTask(
+          FROM_HERE,
           base::BindOnce([](PowerMonitor* pm) { pm->Emit("suspend"); },
                          base::Unretained(this)));
     }

--- a/shell/browser/api/electron_api_power_monitor_win.cc
+++ b/shell/browser/api/electron_api_power_monitor_win.cc
@@ -85,22 +85,26 @@ LRESULT CALLBACK PowerMonitor::WndProc(HWND hwnd,
         // Unretained is OK because this object is eternally pinned.
         base::ThreadPool::PostTask(
             FROM_HERE, {content::BrowserThread::UI},
-            base::BindOnce(&Emit<>, base::Unretained(this), "lock-screen"));
+            base::BindOnce([](PowerMonitor* pm) { pm->Emit("lock-screen"); },
+                           base::Unretained(this)));
       } else if (wparam == WTS_SESSION_UNLOCK) {
         base::ThreadPool::PostTask(
             FROM_HERE, {content::BrowserThread::UI},
-            base::BindOnce(&Emit<>, base::Unretained(this), "unlock-screen"));
+            base::BindOnce([](PowerMonitor* pm) { pm->Emit("unlock-screen"); },
+                           base::Unretained(this)));
       }
     }
   } else if (message == WM_POWERBROADCAST) {
     if (wparam == PBT_APMRESUMEAUTOMATIC) {
       base::ThreadPool::PostTask(
           FROM_HERE, {content::BrowserThread::UI},
-          base::BindOnce(&Emit<>, base::Unretained(this), "resume"));
+          base::BindOnce([](PowerMonitor* pm) { pm->Emit("resume"); },
+                         base::Unretained(this)));
     } else if (wparam == PBT_APMSUSPEND) {
       base::ThreadPool::PostTask(
           FROM_HERE, {content::BrowserThread::UI},
-          base::BindOnce(&Emit<>, base::Unretained(this), "suspend"));
+          base::BindOnce([](PowerMonitor* pm) { pm->Emit("suspend"); },
+                         base::Unretained(this)));
     }
   }
   return ::DefWindowProc(hwnd, message, wparam, lparam);

--- a/shell/browser/api/electron_api_power_monitor_win.cc
+++ b/shell/browser/api/electron_api_power_monitor_win.cc
@@ -81,16 +81,25 @@ LRESULT CALLBACK PowerMonitor::WndProc(HWND hwnd,
     }
     if (should_treat_as_current_session) {
       if (wparam == WTS_SESSION_LOCK) {
-        Emit("lock-screen");
+        // Unretained is OK because this object is eternally pinned.
+        base::ThreadPool::PostTask(
+            FROM_HERE, {content::BrowserThread::UI},
+            base::BindOnce(&Emit, base::Unretained(this), "lock-screen"));
       } else if (wparam == WTS_SESSION_UNLOCK) {
-        Emit("unlock-screen");
+        base::ThreadPool::PostTask(
+            FROM_HERE, {content::BrowserThread::UI},
+            base::BindOnce(&Emit, base::Unretained(this), "unlock-screen"));
       }
     }
   } else if (message == WM_POWERBROADCAST) {
     if (wparam == PBT_APMRESUMEAUTOMATIC) {
-      Emit("resume");
+      base::ThreadPool::PostTask(
+          FROM_HERE, {content::BrowserThread::UI},
+          base::BindOnce(&Emit, base::Unretained(this), "resume"));
     } else if (wparam == PBT_APMSUSPEND) {
-      Emit("suspend");
+      base::ThreadPool::PostTask(
+          FROM_HERE, {content::BrowserThread::UI},
+          base::BindOnce(&Emit, base::Unretained(this), "suspend"));
     }
   }
   return ::DefWindowProc(hwnd, message, wparam, lparam);

--- a/shell/browser/api/electron_api_power_monitor_win.cc
+++ b/shell/browser/api/electron_api_power_monitor_win.cc
@@ -7,9 +7,9 @@
 #include <windows.h>
 #include <wtsapi32.h>
 
-#include "base/task/thread_pool.h"
 #include "base/win/windows_types.h"
 #include "base/win/wrapped_window_proc.h"
+#include "content/public/browser/browser_task_traits.h"
 #include "ui/base/win/shell.h"
 #include "ui/gfx/win/hwnd_util.h"
 


### PR DESCRIPTION
#### Description of Change
This delays emitting certain powerMonitor events on Windows to avoid entering V8 during a WndProc callback, which can cause crashes.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a rare crash on Windows that could occur when emitting certain powerMonitor events.