### PR TITLE
docs: gclient sync --ignore_locks was removed

### DIFF
--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -254,10 +254,6 @@ New-ItemProperty -Path "HKLM:\System\CurrentControlSet\Services\Lanmanworkstatio
 
 ## Troubleshooting
 
-### Stale locks in the git cache
-If `gclient sync` is interrupted while using the git cache, it will leave
-the cache locked. To remove the lock, pass the `--ignore_locks` argument to `gclient sync`.
-
 ### I'm being asked for a username/password for chromium-internal.googlesource.com
 If you see a prompt for `Username for 'https://chrome-internal.googlesource.com':` when running `gclient sync` on Windows, it's probably because the `DEPOT_TOOLS_WIN_TOOLCHAIN` environment variable is not set to 0. Open `Control Panel` → `System and Security` → `System` → `Advanced system settings` and add a system variable
 `DEPOT_TOOLS_WIN_TOOLCHAIN` with value `0`.  This tells `depot_tools` to use


### PR DESCRIPTION
#### Description of Change

It seems that `gclient sync` has removed `--ignore_locks`, when you use it you get the following output (but execution continues): `Warning: ignore_locks is no longer used. Please remove its usage.`

It looks like this change [landed in May 2020](https://chromium.googlesource.com/chromium/tools/depot_tools.git/+/14a83aec5603e47208a4a41c8c085a1991d33d47). There does not appear to be an equivalent flag, I believe that change was meant to alleviate the issue and remove the need for the flag. Since `gclient` auto-updates, I assume pretty much anyone using the docs will be using a version with that change, so seems reasonable to drop this section from the docs.

cc @codebytere 
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
