### PR TITLE
chore: cherry-pick ffed0925f2 from WebRTC.

### DIFF
--- a/patches/config.json
+++ b/patches/config.json
@@ -5,5 +5,7 @@
 
   "src/electron/patches/v8":  "src/v8",
 
-  "src/electron/patches/node": "src/third_party/electron_node"
+  "src/electron/patches/node": "src/third_party/electron_node",
+
+  "src/electron/patches/usrsctp": "src/third_party/usrsctp/usrsctplib"
 }

--- a/patches/usrsctp/.patches
+++ b/patches/usrsctp/.patches
@@ -1,0 +1,1 @@
+fix_a_use-after-free_bug_for_the_userland_stack.patch

--- a/patches/usrsctp/fix_a_use-after-free_bug_for_the_userland_stack.patch
+++ b/patches/usrsctp/fix_a_use-after-free_bug_for_the_userland_stack.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pedro Pontes <pepontes@microsoft.com>
+Date: Fri, 9 Oct 2020 18:03:51 +0200
+Subject: Fix a use-after-free bug for the userland stack.
+
+Backports https://github.com/sctplab/usrsctp/commit/ffed0925f27d404173c1e3e750d818f432d2c019?branch=ffed0925f27d404173c1e3e750d818f432d2c019
+
+diff --git a/usrsctplib/netinet/sctp_indata.c b/usrsctplib/netinet/sctp_indata.c
+index 8b332355a5bfe5c25fa4fcc4afe4a740957a9075..38e1a9196f514bd480e5f4e5e34609ba0d910762 100755
+--- a/usrsctplib/netinet/sctp_indata.c
++++ b/usrsctplib/netinet/sctp_indata.c
+@@ -1694,6 +1694,7 @@ sctp_process_a_data_chunk(struct sctp_tcb *stcb, struct sctp_association *asoc,
+ 			  int *break_flag, int last_chunk, uint8_t chk_type)
+ {
+ 	struct sctp_tmit_chunk *chk = NULL; /* make gcc happy */
++	struct sctp_stream_in *strm;
+ 	uint32_t tsn, fsn, gap, mid;
+ 	struct mbuf *dmbuf;
+ 	int the_len;
+@@ -2329,12 +2330,13 @@ finish_express_del:
+ 			/* All can be removed */
+ 			TAILQ_FOREACH_SAFE(control, &asoc->pending_reply_queue, next, ncontrol) {
+ 				TAILQ_REMOVE(&asoc->pending_reply_queue, control, next);
++				strm = &asoc->strmin[control->sinfo_stream];
+ 				sctp_queue_data_to_stream(stcb, asoc, control, abort_flag, &need_reasm_check);
+ 				if (*abort_flag) {
+ 					return (0);
+ 				}
+ 				if (need_reasm_check) {
+-					(void)sctp_deliver_reasm_check(stcb, asoc, &asoc->strmin[control->sinfo_stream], SCTP_READ_LOCK_NOT_HELD);
++					(void)sctp_deliver_reasm_check(stcb, asoc, strm, SCTP_READ_LOCK_NOT_HELD);
+ 					need_reasm_check = 0;
+ 				}
+ 			}
+@@ -2349,12 +2351,13 @@ finish_express_del:
+ 				 * control->sinfo_tsn > liste->tsn
+ 				 */
+ 				TAILQ_REMOVE(&asoc->pending_reply_queue, control, next);
++				strm = &asoc->strmin[control->sinfo_stream];
+ 				sctp_queue_data_to_stream(stcb, asoc, control, abort_flag, &need_reasm_check);
+ 				if (*abort_flag) {
+ 					return (0);
+ 				}
+ 				if (need_reasm_check) {
+-					(void)sctp_deliver_reasm_check(stcb, asoc, &asoc->strmin[control->sinfo_stream], SCTP_READ_LOCK_NOT_HELD);
++					(void)sctp_deliver_reasm_check(stcb, asoc, strm, SCTP_READ_LOCK_NOT_HELD);
+ 					need_reasm_check = 0;
+ 				}
+ 			}


### PR DESCRIPTION
Cherry pick fix for usrsctp UAF bug to M86.

The commit being cherry picked is:
https://github.com/sctplab/usrsctp/commit/ffed0925f27d404173c1e3e750d818f432d2c019

TBR=hta@chromium.org

Bug: chromium:1124659
Change-Id: I229c8a01fd051b1dfe499a609f72484ce7611af3
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2424803
Reviewed-by: Krishna Govind <govind@chromium.org>
Reviewed-by: Prudhvi Kumar Bommana <pbommana@google.com>
Commit-Queue: Krishna Govind <govind@chromium.org>
Commit-Queue: Taylor <deadbeef@chromium.org> Cr-Commit-Position: refs/branch-heads/4240@{#941}
Cr-Branched-From: f297677702651916bbf65e59c0d4bbd4ce57d1ee-refs/heads/master@{#800218}

#### Release Notes

Notes: Backported the fix to CVE-2020-15969: Use after free in WebRTC.
