### PR TITLE
fix: update squirrel.mac to handle bug in Big Sur

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -20,7 +20,7 @@ vars = {
   'nan_version':
     '2c4ee8a32a299eada3cd6e468bbd0a473bfea96d',
   'squirrel.mac_version':
-    '44468f858ce0d25c27bd5e674abfa104e0119738',
+    'a3a5b3f03b824441c014893b18f99a103b2603e9',
 
   'boto_version': 'f7574aa6cc2c819430c1f05e9a1a1a666ef8169b',
   'pyyaml_version': '3.12',

--- a/patches/squirrel.mac/build_add_gn_config.patch
+++ b/patches/squirrel.mac/build_add_gn_config.patch
@@ -464,7 +464,7 @@ index f84127f642516078249925953e97621909265deb..478509cdd528db4fcfa340c6f93fa58a
  NSString * const SQRLZipArchiverErrorDomain = @"SQRLZipArchiverErrorDomain";
  NSString * const SQRLZipArchiverExitCodeErrorKey = @"SQRLZipArchiverExitCodeErrorKey";
 diff --git a/Squirrel/ShipIt-main.m b/Squirrel/ShipIt-main.m
-index 9db530f3642585154057143d590bb393b86dc063..b6047ea61a71b7f8c7b4d33e47adc23e2baadcee 100644
+index 433ad21eb28bb74389ae4900eec2b9d0e03fdd8e..db246534e176f9c3ea2dd8b1c8659378fdc2435d 100644
 --- a/Squirrel/ShipIt-main.m
 +++ b/Squirrel/ShipIt-main.m
 @@ -8,10 +8,10 @@

--- a/spec-main/api-autoupdater-darwin-spec.ts
+++ b/spec-main/api-autoupdater-darwin-spec.ts
@@ -307,7 +307,7 @@ describeFn('autoUpdater behavior', function () {
 
         await relaunchPromise;
         expect(requests).to.have.lengthOf(3);
-        expect(requests[2]).to.have.property('url', '/update-check/updated/2.0.0');
+        expect(requests[2].url).to.equal('/update-check/updated/2.0.0');
         expect(requests[2].header('user-agent')).to.include('Electron/');
       });
     });


### PR DESCRIPTION
Fixes #25626

This is not the greatest workaround but at least it works.

Notes: Fixed issue where `quitAndInstall()` would not restart the app upon update completion on macOS Big Sur