### PR TITLE
build: s3put not replacing enough \\

### DIFF
--- a/script/lib/s3put.js
+++ b/script/lib/s3put.js
@@ -13,7 +13,7 @@ if (prefix && !prefix.endsWith(path.sep)) prefix = path.resolve(prefix) + path.s
 function filenameToKey (file) {
   file = path.resolve(file);
   if (file.startsWith(prefix)) file = file.substr(prefix.length - 1);
-  return key_prefix + file.replace(path.sep, '/');
+  return key_prefix + (path.sep === '\\' ? file.replace(/\\/g, '/') : file);
 }
 
 let anErrorOccurred = false;


### PR DESCRIPTION
#### Description of Change
`replace('...')` only replaces the first instance :sigh:

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none
