### PR TITLE
fix: uv loop polling when render process reuse enabled

### DIFF
--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -108,11 +108,11 @@ void ElectronRendererClient::DidCreateScriptContext(
 
   injected_frames_.insert(render_frame);
 
-  // If this is the first environment we are creating, prepare the node
-  // bindings.
   if (!node_integration_initialized_) {
     node_integration_initialized_ = true;
     node_bindings_->Initialize();
+    node_bindings_->PrepareMessageLoop();
+  } else if (reuse_renderer_processes_enabled) {
     node_bindings_->PrepareMessageLoop();
   }
 
@@ -129,7 +129,7 @@ void ElectronRendererClient::DidCreateScriptContext(
 
   // If we have disabled the site instance overrides we should prevent loading
   // any non-context aware native module
-  if (command_line->HasSwitch(switches::kDisableElectronSiteInstanceOverrides))
+  if (reuse_renderer_processes_enabled)
     env->set_force_context_aware(true);
   env->set_warn_context_aware(true);
 

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -4286,6 +4286,30 @@ describe('BrowserWindow module', () => {
     });
   });
 
+  describe('reloading with allowRendererProcessReuse enabled', () => {
+    it('does not cause Node.js module API hangs after reload', (done) => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      });
+
+      let count = 0;
+      ipcMain.on('async-node-api-done', () => {
+        if (count === 3) {
+          ipcMain.removeAllListeners('async-node-api-done');
+          done();
+        } else {
+          count++;
+          w.reload();
+        }
+      });
+
+      w.loadFile(path.join(fixtures, 'pages', 'send-after-node.html'));
+    });
+  });
+
   describe('window.webContents.focus()', () => {
     afterEach(closeAllWindows);
     it('focuses window', async () => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/22119.
Closes https://github.com/electron/electron/issues/25314.
Closes https://github.com/electron/electron/issues/23910.
Closes https://github.com/electron/electron/issues/25405.
Closes https://github.com/electron/electron/issues/25496.

Fixes an issue where some Node.js module API calls hung in the renderer process on reload when renderer process reuse was in effect. This was happening because when render process reuse was enabled, Chromium reused the same process, but the main thread was still bound to the old iocp (on windows, and respective interface for other platforms) because libuv didn't destroy it. The queue then went on to operate on this old iocp - when we reloaded, a new iocp was created but not bound to the main thread and so we would not properly be informed of events on it. This is fixed by preparing the message loop on _every_ reload when reuse is enabled with `node_bindings_->PrepareMessageLoop()`.

cc @zcbenz @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where some Node.js module API calls hung in the renderer process after reloads when render process reuse was enabled.
