### PR TITLE
feat: add webPreferences.enablePreferredSizeMode

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -398,6 +398,10 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       * `bypassHeatCheck` - Bypass code caching heuristics but with lazy compilation
       * `bypassHeatCheckAndEagerCompile` - Same as above except compilation is eager.
       Default policy is `code`.
+    * `preferredSizeMode` Boolean (optional) - Whether to enable preferred size
+      mode. Enabling this will cause the `preferred-size-changed` event to be
+      emitted on the `WebContents` when the minimum size of the document's
+      layout changes.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -399,9 +399,10 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       * `bypassHeatCheckAndEagerCompile` - Same as above except compilation is eager.
       Default policy is `code`.
     * `preferredSizeMode` Boolean (optional) - Whether to enable preferred size
-      mode. Enabling this will cause the `preferred-size-changed` event to be
-      emitted on the `WebContents` when the minimum size of the document's
-      layout changes.
+      mode. The preferred size is the minimum size to contain the layout of the
+      document—without requiring scrolling. Enabling this will cause the
+      `preferred-size-changed` event to be emitted on the `WebContents` when
+      the preferred size changes. Default is `false`.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -398,11 +398,11 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       * `bypassHeatCheck` - Bypass code caching heuristics but with lazy compilation
       * `bypassHeatCheckAndEagerCompile` - Same as above except compilation is eager.
       Default policy is `code`.
-    * `preferredSizeMode` Boolean (optional) - Whether to enable preferred size
-      mode. The preferred size is the minimum size needed to contain the layout
-      of the document—without requiring scrolling. Enabling this will cause the
-      `preferred-size-changed` event to be emitted on the `WebContents` when
-      the preferred size changes. Default is `false`.
+    * `enablePreferredSizeMode` Boolean (optional) - Whether to enable
+      preferred size mode. The preferred size is the minimum size needed to
+      contain the layout of the document—without requiring scrolling. Enabling
+      this will cause the `preferred-size-changed` event to be emitted on the
+      `WebContents` when the preferred size changes. Default is `false`.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -399,8 +399,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       * `bypassHeatCheckAndEagerCompile` - Same as above except compilation is eager.
       Default policy is `code`.
     * `preferredSizeMode` Boolean (optional) - Whether to enable preferred size
-      mode. The preferred size is the minimum size to contain the layout of the
-      document—without requiring scrolling. Enabling this will cause the
+      mode. The preferred size is the minimum size needed to contain the layout
+      of the document—without requiring scrolling. Enabling this will cause the
       `preferred-size-changed` event to be emitted on the `WebContents` when
       the preferred size changes. Default is `false`.
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -842,8 +842,8 @@ Custom value can be returned by setting `event.returnValue`.
 Returns:
 
 * `event` Event
-* `preferredSize` [Size](structures/size.md) - The minimum size to contain the layout of
-  the document—without requiring scrolling.
+* `preferredSize` [Size](structures/size.md) - The minimum size needed to
+  contain the layout of the document—without requiring scrolling.
 
 Emitted when the `WebContents` preferred size has changed.
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -837,6 +837,19 @@ Emitted when `remote.getCurrentWebContents()` is called in the renderer process.
 Calling `event.preventDefault()` will prevent the object from being returned.
 Custom value can be returned by setting `event.returnValue`.
 
+#### Event: 'preferred-size-changed'
+
+Returns:
+
+* `event` Event
+* `size` [Size](structures/size.md) - The minimum size to contain the layout of
+  the top-level frame's document.
+
+Emitted when the `WebContents` preferred size has changed.
+
+This event will only be emitted when `preferredSizeMode` is enabled in
+`webPreferences`.
+
 ### Instance Methods
 
 #### `contents.loadURL(url[, options])`

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -847,8 +847,8 @@ Returns:
 
 Emitted when the `WebContents` preferred size has changed.
 
-This event will only be emitted when `preferredSizeMode` is enabled in
-`webPreferences`.
+This event will only be emitted when `enablePreferredSizeMode` is set to `true`
+in `webPreferences`.
 
 ### Instance Methods
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -842,8 +842,8 @@ Custom value can be returned by setting `event.returnValue`.
 Returns:
 
 * `event` Event
-* `size` [Size](structures/size.md) - The minimum size to contain the layout of
-  the top-level frame's document.
+* `preferredSize` [Size](structures/size.md) - The minimum size to contain the layout of
+  the document—without requiring scrolling.
 
 Emitted when the `WebContents` preferred size has changed.
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1173,6 +1173,11 @@ void WebContents::DidStartLoading() {
 
 void WebContents::DidStopLoading() {
   Emit("did-stop-loading");
+
+  auto* web_preferences = WebContentsPreferences::From(web_contents());
+  if (web_preferences &&
+      web_preferences->IsEnabled(options::kPreferredSizeMode))
+    web_contents()->GetRenderViewHost()->EnablePreferredSizeMode();
 }
 
 bool WebContents::EmitNavigationEvent(
@@ -2901,6 +2906,11 @@ v8::Local<v8::Promise> WebContents::TakeHeapSnapshot(
           },
           base::Owned(std::move(electron_renderer)), std::move(promise)));
   return handle;
+}
+
+void WebContents::UpdatePreferredSize(content::WebContents* web_contents,
+                                      const gfx::Size& pref_size) {
+  Emit("preferred-size-changed", pref_size);
 }
 
 // static

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1176,7 +1176,7 @@ void WebContents::DidStopLoading() {
 
   auto* web_preferences = WebContentsPreferences::From(web_contents());
   if (web_preferences &&
-      web_preferences->IsEnabled(options::kPreferredSizeMode))
+      web_preferences->IsEnabled(options::kEnablePreferredSizeMode))
     web_contents()->GetRenderViewHost()->EnablePreferredSizeMode();
 }
 

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -551,6 +551,8 @@ class WebContents : public gin::Wrappable<WebContents>,
   content::JavaScriptDialogManager* GetJavaScriptDialogManager(
       content::WebContents* source) override;
   void OnAudioStateChanged(bool audible) override;
+  void UpdatePreferredSize(content::WebContents* web_contents,
+                           const gfx::Size& pref_size) override;
 
   // content::WebContentsObserver:
   void BeforeUnloadFired(bool proceed,

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -143,6 +143,7 @@ WebContentsPreferences::WebContentsPreferences(
   SetDefaultBoolIfUndefined(options::kTextAreasAreResizable, true);
   SetDefaultBoolIfUndefined(options::kWebGL, true);
   SetDefaultBoolIfUndefined(options::kEnableWebSQL, true);
+  SetDefaultBoolIfUndefined(options::kPreferredSizeMode, false);
   bool webSecurity = true;
   SetDefaultBoolIfUndefined(options::kWebSecurity, webSecurity);
   // If webSecurity was explicity set to false, let's inherit that into

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -143,7 +143,7 @@ WebContentsPreferences::WebContentsPreferences(
   SetDefaultBoolIfUndefined(options::kTextAreasAreResizable, true);
   SetDefaultBoolIfUndefined(options::kWebGL, true);
   SetDefaultBoolIfUndefined(options::kEnableWebSQL, true);
-  SetDefaultBoolIfUndefined(options::kPreferredSizeMode, false);
+  SetDefaultBoolIfUndefined(options::kEnablePreferredSizeMode, false);
   bool webSecurity = true;
   SetDefaultBoolIfUndefined(options::kWebSecurity, webSecurity);
   // If webSecurity was explicity set to false, let's inherit that into

--- a/shell/common/options_switches.cc
+++ b/shell/common/options_switches.cc
@@ -191,8 +191,7 @@ const char kEnableRemoteModule[] = "enableRemoteModule";
 
 const char kEnableWebSQL[] = "enableWebSQL";
 
-// Enables preferred size mode.
-const char kPreferredSizeMode[] = "preferredSizeMode";
+const char kEnablePreferredSizeMode[] = "enablePreferredSizeMode";
 
 }  // namespace options
 

--- a/shell/common/options_switches.cc
+++ b/shell/common/options_switches.cc
@@ -191,6 +191,9 @@ const char kEnableRemoteModule[] = "enableRemoteModule";
 
 const char kEnableWebSQL[] = "enableWebSQL";
 
+// Enables preferred size mode.
+const char kPreferredSizeMode[] = "preferredSizeMode";
+
 }  // namespace options
 
 namespace switches {

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -87,6 +87,7 @@ extern const char kTextAreasAreResizable[];
 extern const char kWebGL[];
 extern const char kNavigateOnDragDrop[];
 extern const char kEnableWebSQL[];
+extern const char kPreferredSizeMode[];
 
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
 extern const char kSpellcheck[];

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -87,7 +87,7 @@ extern const char kTextAreasAreResizable[];
 extern const char kWebGL[];
 extern const char kNavigateOnDragDrop[];
 extern const char kEnableWebSQL[];
-extern const char kPreferredSizeMode[];
+extern const char kEnablePreferredSizeMode[];
 
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
 extern const char kSpellcheck[];


### PR DESCRIPTION
#### Description of Change

For Chrome extension popups and options windows, the size of their frame corresponds to the minimum size of their document's layout. To enable this, `RenderViewHost::EnablePreferredSizeMode` exists to notify the RenderView to send back updates with its size. This gives an interesting result where the document can dictate its frame's size.

In practice, it looks like this:
![2020-10-10_14-45-18](https://user-images.githubusercontent.com/1656324/95662742-3eba3780-0b07-11eb-998e-289dc817ca47.gif)

Example code:
```js
const view = new BrowserView({
  webPreferences: {
    preferredSizeMode: true,
  },
})
view.webContents.on('preferred-size-changed', (event, size) => {
  view.setBounds({ x: 0, y: 0, width: size.width, height: size.height })
})
```

I could see this being useful for specialized modal popups as well.

cc @electron/wg-api -- Question for you: is it worth adding tests for just adding bindings to existing Chromium functionality?

relates to #19447

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `webPreferences.preferredSizeMode` to allow sizing views according to their document's minimum size.
