### PR TITLE
fix: pass require.resolve paths option to wrapped method

### DIFF
--- a/lib/common/reset-search-paths.ts
+++ b/lib/common/reset-search-paths.ts
@@ -43,10 +43,10 @@ if (process.type === 'renderer') {
 }
 
 const originalResolveFilename = Module._resolveFilename;
-Module._resolveFilename = function (request: string, parent: NodeModule, isMain: boolean) {
+Module._resolveFilename = function (request: string, parent: NodeModule, isMain: boolean, options?: { paths: Array<string>}) {
   if (request === 'electron' || request.startsWith('electron/')) {
     return 'electron';
   } else {
-    return originalResolveFilename(request, parent, isMain);
+    return originalResolveFilename(request, parent, isMain, options);
   }
 };


### PR DESCRIPTION
#### Description of Change
`reset-search-paths` wraps the built-in node `Module._resolveFilename` method. However the wrapper does not pass through the `options` argument. This means that `require.resolve` ignores the `options` object, which is used to pass paths for scoped resolution. This PR passes the options object to the wrapped method.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed bug that meant require.resolve paths option was ignored