### PR TITLE
fix: uv loop polling when render process reuse enabled

### DIFF
--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -108,11 +108,11 @@ void ElectronRendererClient::DidCreateScriptContext(
 
   injected_frames_.insert(render_frame);
 
-  // If this is the first environment we are creating, prepare the node
-  // bindings.
   if (!node_integration_initialized_) {
     node_integration_initialized_ = true;
     node_bindings_->Initialize();
+    node_bindings_->PrepareMessageLoop();
+  } else if (reuse_renderer_processes_enabled) {
     node_bindings_->PrepareMessageLoop();
   }
 
@@ -129,7 +129,7 @@ void ElectronRendererClient::DidCreateScriptContext(
 
   // If we have disabled the site instance overrides we should prevent loading
   // any non-context aware native module
-  if (command_line->HasSwitch(switches::kDisableElectronSiteInstanceOverrides))
+  if (reuse_renderer_processes_enabled)
     env->ForceOnlyContextAwareNativeModules();
   env->WarnNonContextAwareNativeModules();
 

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -4262,6 +4262,30 @@ describe('BrowserWindow module', () => {
     });
   });
 
+  describe('reloading with allowRendererProcessReuse enabled', () => {
+    it('does not cause Node.js module API hangs after reload', (done) => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      });
+
+      let count = 0;
+      ipcMain.on('async-node-api-done', () => {
+        if (count === 3) {
+          ipcMain.removeAllListeners('async-node-api-done');
+          done();
+        } else {
+          count++;
+          w.reload();
+        }
+      });
+
+      w.loadFile(path.join(fixtures, 'pages', 'send-after-node.html'));
+    });
+  });
+
   describe('window.webContents.focus()', () => {
     afterEach(closeAllWindows);
     it('focuses window', async () => {


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/25869.

See that PR for more details.

Notes: Fixed an issue where some Node.js module API calls hung in the renderer process after reloads when render process reuse was enabled.