### PR TITLE
fix: notifications successfully never timeout with included flag

### DIFF
--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -260,8 +260,9 @@ bool WindowsToastNotification::SetXmlScenarioReminder(IXmlDocument* doc) {
     return false;
 
   ComPtr<IXmlNode> scenario_attribute_pnode;
-  return (FAILED(toast_attributes.Get()->SetNamedItem(
-      scenario_attribute_node.Get(), &scenario_attribute_pnode))) return false;
+  if (FAILED(toast_attributes.Get()->SetNamedItem(scenario_attribute_node.Get(),
+                                                  &scenario_attribute_pnode)))
+    return false;
 
   // Create "actions" wrapper
   ComPtr<IXmlElement> actions_wrapper_element;


### PR DESCRIPTION
#### Description of Change
Backport of #25820

@codebytere

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where Windows notifications with timeoutType of 'never' did not work properly.
