### PR TITLE
docs: rename launch-failure -> launch-failed to match C++ code

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -382,7 +382,7 @@ Returns:
     * `killed` - Process was sent a SIGTERM or otherwise killed externally
     * `crashed` - Process crashed
     * `oom` - Process ran out of memory
-    * `launch-failure` - Process never successfully launched
+    * `launch-failed` - Process never successfully launched
     * `integrity-failure` - Windows code integrity checks failed
 
 Emitted when the renderer process unexpectedly dissapears.  This is normally

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -351,7 +351,7 @@ Returns:
     * `killed` - Process was sent a SIGTERM or otherwise killed externally
     * `crashed` - Process crashed
     * `oom` - Process ran out of memory
-    * `launch-failure` - Process never successfully launched
+    * `launch-failed` - Process never successfully launched
     * `integrity-failure` - Windows code integrity checks failed
 
 Emitted when the renderer process unexpectedly dissapears.  This is normally


### PR DESCRIPTION
Backport of #25726

See that PR for details.


Notes: none