### PR TITLE
fix: printing with too-high priority

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2215,7 +2215,7 @@ void WebContents::Print(gin::Arguments* args) {
   }
 
   base::ThreadPool::PostTaskAndReplyWithResult(
-      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_BLOCKING},
+      FROM_HERE, {base::MayBlock(), base::TaskPriority::BEST_EFFORT},
       base::BindOnce(&GetDefaultPrinterAsync),
       base::BindOnce(&WebContents::OnGetDefaultPrinter,
                      weak_factory_.GetWeakPtr(), std::move(settings),


### PR DESCRIPTION
#### Description of Change

Fixes a DCHECK that occurs if printing is called too close to a page load. We set the task priority to `USER_BLOCKING`, so it would take precedence over the page load and trigger the following DCHECK:

<details>
<Summary>Stacktrace</Summary>

```
[12754:1013/200654.797687:FATAL:document_loader.cc(633)] Check failed: !frame_->GetPage()->Paused(). 
8:06:55 PM0   Electron Framework                  0x0000000118018cc9 base::debug::CollectStackTrace(void**, unsigned long) + 9
8:06:55 PM1   Electron Framework                  0x0000000117f13663 base::debug::StackTrace::StackTrace() + 19
8:06:55 PM2   Electron Framework                  0x0000000117f31b85 logging::LogMessage::~LogMessage() + 261
8:06:55 PM3   Electron Framework                  0x0000000117f3281e logging::LogMessage::~LogMessage() + 14
8:06:55 PM4   Electron Framework                  0x000000011beca8fc blink::DocumentLoader::BodyDataReceived(base::span<char const, 18446744073709551615ul>) + 364
8:06:55 PM5   Electron Framework                  0x000000011d76e4b1 content::NavigationBodyLoader::ReadFromDataPipe() + 897
8:06:55 PM6   Electron Framework                  0x000000011d76d48c content::NavigationBodyLoader::OnReadable(unsigned int) + 172
8:06:55 PM7   Electron Framework                  0x000000011d76d27b content::NavigationBodyLoader::OnStartLoadingResponseBody(mojo::ScopedHandleBase<mojo::DataPipeConsumerHandle>) + 491
8:06:55 PM8   Electron Framework                  0x000000011d76def3 content::NavigationBodyLoader::BindURLLoaderAndStartLoadingResponseBodyIfPossible() + 99
8:06:55 PM9   Electron Framework                  0x000000011d76dac7 content::NavigationBodyLoader::StartLoadingBody(blink::WebNavigationBodyLoader::Client*, bool) + 327
8:06:55 PM10  Electron Framework                  0x000000011bece10e blink::DocumentLoader::StartLoadingResponse() + 526
8:06:55 PM11  Electron Framework                  0x000000011bed047b blink::DocumentLoader::CommitNavigation() + 2651
8:06:55 PM12  Electron Framework                  0x000000011bee694a blink::FrameLoader::CommitDocumentLoader(blink::DocumentLoader*, base::Optional<blink::Document::UnloadEventTiming> const&, blink::HistoryItem*, blink::CommitReason) + 394
8:06:55 PM13  Electron Framework                  0x000000011bee9997 blink::FrameLoader::CommitNavigation(std::__1::unique_ptr<blink::WebNavigationParams, std::__1::default_delete<blink::WebNavigationParams> >, std::__1::unique_ptr<blink::WebDocumentLoader::ExtraData, std::__1::default_delete<blink::WebDocumentLoader::ExtraData> >, blink::CommitReason) + 2871
8:06:55 PM14  Electron Framework                  0x000000011b74f714 blink::WebLocalFrameImpl::CommitNavigation(std::__1::unique_ptr<blink::WebNavigationParams, std::__1::default_delete<blink::WebNavigationParams> >, std::__1::unique_ptr<blink::WebDocumentLoader::ExtraData, std::__1::default_delete<blink::WebDocumentLoader::ExtraData> >) + 228
8:06:55 PM15  Electron Framework                  0x000000011d7b796f content::RenderFrameImpl::CommitNavigationWithParams(mojo::StructPtr<content::mojom::CommonNavigationParams>, mojo::StructPtr<content::mojom::CommitNavigationParams>, std::__1::unique_ptr<blink::PendingURLLoaderFactoryBundle, std::__1::default_delete<blink::PendingURLLoaderFactoryBundle> >, base::Optional<std::__1::vector<mojo::StructPtr<blink::mojom::TransferrableURLLoader>, std::__1::allocator<mojo::StructPtr<blink::mojom::TransferrableURLLoader> > > >, mojo::StructPtr<blink::mojom::ControllerServiceWorkerInfo>, mojo::StructPtr<blink::mojom::ServiceWorkerContainerInfoForClient>, mojo::PendingRemote<network::mojom::URLLoaderFactory>, std::__1::unique_ptr<content::DocumentState, std::__1::default_delete<content::DocumentState> >, std::__1::unique_ptr<blink::WebNavigationParams, std::__1::default_delete<blink::WebNavigationParams> >) + 2863
8:06:55 PM16  Electron Framework                  0x000000011d7d79cf void base::internal::FunctorTraits<void (content::RenderFrameImpl::*)(mojo::StructPtr<content::mojom::CommonNavigationParams>, mojo::StructPtr<content::mojom::CommitNavigationParams>, std::__1::unique_ptr<blink::PendingURLLoaderFactoryBundle, std::__1::default_delete<blink::PendingURLLoaderFactoryBundle> >, base::Optional<std::__1::vector<mojo::StructPtr<blink::mojom::TransferrableURLLoader>, std::__1::allocator<mojo::StructPtr<blink::mojom::TransferrableURLLoader> > > >, mojo::StructPtr<blink::mojom::ControllerServiceWorkerInfo>, mojo::StructPtr<blink::mojom::ServiceWorkerContainerInfoForClient>, mojo::PendingRemote<network::mojom::URLLoaderFactory>, std::__1::unique_ptr<content::DocumentState, std::__1::default_delete<content::DocumentState> >, std::__1::unique_ptr<blink::WebNavigationParams, std::__1::default_delete<blink::WebNavigationParams> >), void>::Invoke<void (content::RenderFrameImpl::*)(mojo::StructPtr<content::mojom::CommonNavigationParams>, mojo::StructPtr<content::mojom::CommitNavigationParams>, std::__1::unique_ptr<blink::PendingURLLoaderFactoryBundle, std::__1::default_delete<blink::PendingURLLoaderFactoryBundle> >, base::Optional<std::__1::vector<mojo::StructPtr<blink::mojom::TransferrableURLLoader>, std::__1::allocator<mojo::StructPtr<blink::mojom::TransferrableURLLoader> > > >, mojo::StructPtr<blink::mojom::ControllerServiceWorkerInfo>, mojo::StructPtr<blink::mojom::ServiceWorkerContainerInfoForClient>, mojo::PendingRemote<network::mojom::URLLoaderFactory>, std::__1::unique_ptr<content::DocumentState, std::__1::default_delete<content::DocumentState> >, std::__1::unique_ptr<blink::WebNavigationParams, std::__1::default_delete<blink::WebNavigationParams> >), base::WeakPtr<content::RenderFrameImpl>, mojo::StructPtr<content::mojom::CommonNavigationParams>, mojo::StructPtr<content::mojom::CommitNavigationParams>, std::__1::unique_ptr<blink::PendingURLLoaderFactoryBundle, std::__1::default_delete<blink::PendingURLLoaderFactoryBundle> >, base::Optional<std::__1::vector<mojo::StructPtr<blink::mojom::TransferrableURLLoader>, std::__1::allocator<mojo::StructPtr<blink::mojom::TransferrableURLLoader> > > >, mojo::StructPtr<blink::mojom::ControllerServiceWorkerInfo>, mojo::StructPtr<blink::mojom::ServiceWorkerContainerInfoForClient>, mojo::PendingRemote<network::mojom::URLLoaderFactory>, std::__1::unique_ptr<content::DocumentState, std::__1::default_delete<content::DocumentState> >, std::__1::unique_ptr<blink::WebNavigationParams, std::__1::default_delete<blink::WebNavigationParams> > >(void (content::RenderFrameImpl::*)(mojo::StructPtr<content::mojom::CommonNavigationParams>, mojo::StructPtr<content::mojom::CommitNavigationParams>, std::__1::unique_ptr<blink::PendingURLLoaderFactoryBundle, std::__1::default_delete<blink::PendingURLLoaderFactoryBundle> >, base::Optional<std::__1::vector<mojo::StructPtr<blink::mojom::TransferrableURLLoader>, std::__1::allocator<mojo::StructPtr<blink::mojom::TransferrableURLLoader> > > >, mojo::StructPtr<blink::mojom::ControllerServiceWorkerInfo>, mojo::StructPtr<blink::mojom::ServiceWorkerContainerInfoForClient>, mojo::PendingRemote<network::mojom::URLLoaderFactory>, std::__1::unique_ptr<content::DocumentState, std::__1::default_delete<content::DocumentState> >, std::__1::unique_ptr<blink::WebNavigationParams, std::__1::default_delete<blink::WebNavigationParams> >), base::WeakPtr<content::RenderFrameImpl>&&, mojo::StructPtr<content::mojom::CommonNavigationParams>&&, mojo::StructPtr<content::mojom::CommitNavigationParams>&&, std::__1::unique_ptr<blink::PendingURLLoaderFactoryBundle, std::__1::default_delete<blink::PendingURLLoaderFactoryBundle> >&&, base::Optional<std::__1::vector<mojo::StructPtr<blink::mojom::TransferrableURLLoader>, std::__1::allocator<mojo::StructPtr<blink::mojom::TransferrableURLLoader> > > >&&, mojo::StructPtr<blink::mojom::ControllerServiceWorkerInfo>&&, mojo::StructPtr<blink::mojom::ServiceWorkerContainerInfoForClient>&&, mojo::PendingRemote<network::mojom::URLLoaderFactory>&&, std::__1::unique_ptr<content::DocumentState, std::__1::default_delete<content::DocumentState> >&&, std::__1::unique_ptr<blink::WebNavigationParams, std::__1::default_delete<blink::WebNavigationParams> >&&) + 399
8:06:55 PM17  Electron Framework                  0x000000011d7d781f base::internal::Invoker<base::internal::BindState<void (content::RenderFrameImpl::*)(mojo::StructPtr<content::mojom::CommonNavigationParams>, mojo::StructPtr<content::mojom::CommitNavigationParams>, std::__1::unique_ptr<blink::PendingURLLoaderFactoryBundle, std::__1::default_delete<blink::PendingURLLoaderFactoryBundle> >, base::Optional<std::__1::vector<mojo::StructPtr<blink::mojom::TransferrableURLLoa
8:06:55 PMRenderer process crashed - see https://www.electronjs.org/docs/tutorial/application-debugging for potential debugging information.
8:06:55 PM[12752:1013/200655.244091:WARNING:ca_layer_tree_coordinator.mm(54)] Blank frame: No overlays or CALayers
8:06:56 PM
```

</details>

This is fixed by downgrading task priority to `BEST_EFFORT`. 

Tested with https://gist.github.com/b14da80f25082859922f60bc302a4445.

cc @deepak1556 @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes potential renderer crashes when loading a webpage too near to a call to `webContents.print()`.
