### PR TITLE
build: fix missing dependency resulting in a random build failure

### DIFF
--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -367,6 +367,7 @@ source_set("chrome_spellchecker") {
   sources = []
   deps = []
   libs = []
+  public_deps = []
 
   if (enable_builtin_spellchecker) {
     sources += [
@@ -406,15 +407,13 @@ source_set("chrome_spellchecker") {
       "//components/spellcheck:buildflags",
       "//components/sync",
     ]
+
+    public_deps += [ "//chrome/common:constants" ]
   }
 
-  public_deps = [
+  public_deps += [
     "//components/spellcheck/browser",
     "//components/spellcheck/common",
     "//components/spellcheck/renderer",
   ]
-
-  if (enable_builtin_spellchecker) {
-    public_deps += [ "//chrome/common:constants" ]
-  }
 }

--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -415,6 +415,6 @@ source_set("chrome_spellchecker") {
   ]
 
   if (enable_builtin_spellchecker) {
-    public_deps += [ "//chrome/common" ]
+    public_deps += [ "//chrome/common:constants" ]
   }
 }

--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -384,7 +384,6 @@ source_set("chrome_spellchecker") {
       "//chrome/browser/spellchecker/spellcheck_language_policy_handler.h",
       "//chrome/browser/spellchecker/spellcheck_service.cc",
       "//chrome/browser/spellchecker/spellcheck_service.h",
-      "//chrome/common/pref_names.h",
     ]
 
     if (has_spellcheck_panel) {
@@ -414,4 +413,8 @@ source_set("chrome_spellchecker") {
     "//components/spellcheck/common",
     "//components/spellcheck/renderer",
   ]
+
+  if (enable_builtin_spellchecker) {
+    public_deps += [ "//chrome/common" ]
+  }
 }


### PR DESCRIPTION
#### Description of Change
* build: pref_names.h #includes files generated by separate GN targets,
  any sources that include that file have to live in a target that depends
  on the target it comes from

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none
