### PR TITLE
fix: correct null pointer checks in autoresizing browser views

### DIFF
--- a/shell/browser/native_browser_view_views.cc
+++ b/shell/browser/native_browser_view_views.cc
@@ -27,7 +27,7 @@ void NativeBrowserViewViews::SetAutoResizeProportions(
   if ((auto_resize_flags_ & AutoResizeFlags::kAutoResizeHorizontal) &&
       !auto_horizontal_proportion_set_) {
     auto* iwc_view = GetInspectableWebContentsView();
-    if (iwc_view)
+    if (!iwc_view)
       return;
     auto* view = iwc_view->GetView();
     auto view_bounds = view->bounds();
@@ -41,7 +41,7 @@ void NativeBrowserViewViews::SetAutoResizeProportions(
   if ((auto_resize_flags_ & AutoResizeFlags::kAutoResizeVertical) &&
       !auto_vertical_proportion_set_) {
     auto* iwc_view = GetInspectableWebContentsView();
-    if (iwc_view)
+    if (!iwc_view)
       return;
     auto* view = iwc_view->GetView();
     auto view_bounds = view->bounds();
@@ -58,8 +58,9 @@ void NativeBrowserViewViews::AutoResize(const gfx::Rect& new_window,
                                         int width_delta,
                                         int height_delta) {
   auto* iwc_view = GetInspectableWebContentsView();
-  if (iwc_view)
+  if (!iwc_view)
     return;
+   
   auto* view = iwc_view->GetView();
   const auto flags = GetAutoResizeFlags();
   if (!(flags & kAutoResizeWidth)) {

--- a/shell/browser/native_browser_view_views.cc
+++ b/shell/browser/native_browser_view_views.cc
@@ -60,7 +60,6 @@ void NativeBrowserViewViews::AutoResize(const gfx::Rect& new_window,
   auto* iwc_view = GetInspectableWebContentsView();
   if (!iwc_view)
     return;
-   
   auto* view = iwc_view->GetView();
   const auto flags = GetAutoResizeFlags();
   if (!(flags & kAutoResizeWidth)) {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/25728

This PR is restoring the ability for browser views to auto-resize. Previously when a window was resized, the browser view would remain the same size. Now the browser view resizes automatically with the window. 

cc @codebytere 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Browser views will properly resize within windows.
