### PR TITLE
perf: remove GC timer that fired once per minute.

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -405,11 +405,6 @@ void ElectronBrowserMainParts::PreMainMessageLoopRun() {
   ui::TouchFactory::SetTouchDeviceListFromCommandLine();
 #endif
 
-  // Start idle gc.
-  gc_timer_.Start(FROM_HERE, base::TimeDelta::FromMinutes(1),
-                  base::BindRepeating(&v8::Isolate::LowMemoryNotification,
-                                      base::Unretained(js_env_->isolate())));
-
   content::WebUIControllerFactory::RegisterFactory(
       ElectronWebUIControllerFactory::GetInstance());
 

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -158,8 +158,6 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   std::unique_ptr<ElectronExtensionsBrowserClient> extensions_browser_client_;
 #endif
 
-  base::RepeatingTimer gc_timer_;
-
   // List of callbacks should be executed before destroying JS env.
   std::list<base::OnceClosure> destructors_;
 


### PR DESCRIPTION
#### Description of Change

Fixes #25954

ElectronBrowserMainParts has a periodic timer that is used to trigger GC once a minute even on an idle system. While one wakeup per minute isn't bad, it's also been in there since 2014 and doesn't seem to be necessary.

This heartbeat doesn't seem to be necessary, at least for a simple system. I see no difference in memory use with or without this timer when running the default app for an hour.

Any review welcomed. CC'ing @nornagon as he commented on #25954

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none.