### PR TITLE
fix: Save As PDF from PDF Preview

### DIFF
--- a/shell/browser/extensions/electron_extensions_api_client.cc
+++ b/shell/browser/extensions/electron_extensions_api_client.cc
@@ -17,7 +17,6 @@
 #if BUILDFLAG(ENABLE_PRINTING)
 #include "chrome/browser/printing/print_view_manager_basic.h"
 #include "components/printing/browser/print_manager_utils.h"
-#include "printing/buildflags/buildflags.h"
 #include "shell/browser/printing/print_preview_message_handler.h"
 #endif
 

--- a/shell/browser/extensions/electron_extensions_api_client.cc
+++ b/shell/browser/extensions/electron_extensions_api_client.cc
@@ -14,6 +14,13 @@
 #include "shell/browser/extensions/electron_extension_web_contents_observer.h"
 #include "shell/browser/extensions/electron_messaging_delegate.h"
 
+#if BUILDFLAG(ENABLE_PRINTING)
+#include "chrome/browser/printing/print_view_manager_basic.h"
+#include "components/printing/browser/print_manager_utils.h"
+#include "printing/buildflags/buildflags.h"
+#include "shell/browser/printing/print_preview_message_handler.h"
+#endif
+
 #if BUILDFLAG(ENABLE_PDF_VIEWER)
 #include "components/pdf/browser/pdf_web_contents_helper.h"  // nogncheck
 #include "shell/browser/electron_pdf_web_contents_helper_client.h"
@@ -52,13 +59,18 @@ MessagingDelegate* ElectronExtensionsAPIClient::GetMessagingDelegate() {
 
 void ElectronExtensionsAPIClient::AttachWebContentsHelpers(
     content::WebContents* web_contents) const {
-  extensions::ElectronExtensionWebContentsObserver::CreateForWebContents(
-      web_contents);
+#if BUILDFLAG(ENABLE_PRINTING)
+  electron::PrintPreviewMessageHandler::CreateForWebContents(web_contents);
+  printing::PrintViewManagerBasic::CreateForWebContents(web_contents);
+#endif
 
 #if BUILDFLAG(ENABLE_PDF_VIEWER)
   pdf::PDFWebContentsHelper::CreateForWebContentsWithClient(
       web_contents, std::make_unique<ElectronPDFWebContentsHelperClient>());
 #endif
+
+  extensions::ElectronExtensionWebContentsObserver::CreateForWebContents(
+      web_contents);
 }
 
 ManagementAPIDelegate*

--- a/shell/renderer/printing/print_render_frame_helper_delegate.cc
+++ b/shell/renderer/printing/print_render_frame_helper_delegate.cc
@@ -4,17 +4,13 @@
 
 #include "shell/renderer/printing/print_render_frame_helper_delegate.h"
 
-#include "chrome/common/chrome_switches.h"
-#include "chrome/common/url_constants.h"
 #include "content/public/renderer/render_frame.h"
 #include "extensions/buildflags/buildflags.h"
 #include "third_party/blink/public/web/web_element.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 
 #if BUILDFLAG(ENABLE_EXTENSIONS)
-#include "chrome/common/extensions/extension_constants.h"
 #include "extensions/common/constants.h"
-#include "extensions/renderer/guest_view/mime_handler_view/post_message_support.h"
 #endif  // BUILDFLAG(ENABLE_EXTENSIONS)
 
 namespace electron {
@@ -28,11 +24,10 @@ blink::WebElement PrintRenderFrameHelperDelegate::GetPdfElement(
     blink::WebLocalFrame* frame) {
 #if BUILDFLAG(ENABLE_EXTENSIONS)
   GURL url = frame->GetDocument().Url();
-  bool inside_print_preview = url.GetOrigin() == chrome::kChromeUIPrintURL;
   bool inside_pdf_extension =
       url.SchemeIs(extensions::kExtensionScheme) &&
       url.host_piece() == extension_misc::kPdfExtensionId;
-  if (inside_print_preview || inside_pdf_extension) {
+  if (inside_pdf_extension) {
     // <object> with id="plugin" is created in
     // chrome/browser/resources/pdf/pdf_viewer_base.js.
     auto viewer_element = frame->GetDocument().GetElementById("viewer");

--- a/shell/renderer/printing/print_render_frame_helper_delegate.cc
+++ b/shell/renderer/printing/print_render_frame_helper_delegate.cc
@@ -4,9 +4,18 @@
 
 #include "shell/renderer/printing/print_render_frame_helper_delegate.h"
 
+#include "chrome/common/chrome_switches.h"
+#include "chrome/common/url_constants.h"
 #include "content/public/renderer/render_frame.h"
+#include "extensions/buildflags/buildflags.h"
 #include "third_party/blink/public/web/web_element.h"
 #include "third_party/blink/public/web/web_local_frame.h"
+
+#if BUILDFLAG(ENABLE_EXTENSIONS)
+#include "chrome/common/extensions/extension_constants.h"
+#include "extensions/common/constants.h"
+#include "extensions/renderer/guest_view/mime_handler_view/post_message_support.h"
+#endif  // BUILDFLAG(ENABLE_EXTENSIONS)
 
 namespace electron {
 
@@ -17,6 +26,26 @@ PrintRenderFrameHelperDelegate::~PrintRenderFrameHelperDelegate() = default;
 // Return the PDF object element if |frame| is the out of process PDF extension.
 blink::WebElement PrintRenderFrameHelperDelegate::GetPdfElement(
     blink::WebLocalFrame* frame) {
+#if BUILDFLAG(ENABLE_EXTENSIONS)
+  GURL url = frame->GetDocument().Url();
+  bool inside_print_preview = url.GetOrigin() == chrome::kChromeUIPrintURL;
+  bool inside_pdf_extension =
+      url.SchemeIs(extensions::kExtensionScheme) &&
+      url.host_piece() == extension_misc::kPdfExtensionId;
+  if (inside_print_preview || inside_pdf_extension) {
+    // <object> with id="plugin" is created in
+    // chrome/browser/resources/pdf/pdf_viewer_base.js.
+    auto viewer_element = frame->GetDocument().GetElementById("viewer");
+    if (!viewer_element.IsNull() && !viewer_element.ShadowRoot().IsNull()) {
+      auto plugin_element =
+          viewer_element.ShadowRoot().QuerySelector("#plugin");
+      if (!plugin_element.IsNull()) {
+        return plugin_element;
+      }
+    }
+    NOTREACHED();
+  }
+#endif  // BUILDFLAG(ENABLE_EXTENSIONS)
   return blink::WebElement();
 }
 

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -54,7 +54,6 @@
 #endif
 
 #if BUILDFLAG(ENABLE_PDF_VIEWER)
-#include "chrome/renderer/pepper/chrome_pdf_print_client.h"  // nogncheck
 #include "shell/common/electron_constants.h"
 #endif  // BUILDFLAG(ENABLE_PDF_VIEWER)
 
@@ -171,9 +170,9 @@ void RendererClientBase::RenderThreadStarted() {
   thread->AddObserver(extensions_renderer_client_->GetDispatcher());
 #endif
 
-#if BUILDFLAG(ENABLE_PDF_VIEWER)
-  // Enables printing from Chrome PDF viewer.
-  pdf::PepperPDFHost::SetPrintClient(new ChromePDFPrintClient());
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+  pdf_print_client_.reset(new ChromePDFPrintClient());
+  pdf::PepperPDFHost::SetPrintClient(pdf_print_client_.get());
 #endif
 
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -170,7 +170,8 @@ void RendererClientBase::RenderThreadStarted() {
   thread->AddObserver(extensions_renderer_client_->GetDispatcher());
 #endif
 
-#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+#if BUILDFLAG(ENABLE_PDF_VIEWER)
+  // Enables printing from Chrome PDF viewer.
   pdf_print_client_.reset(new ChromePDFPrintClient());
   pdf::PepperPDFHost::SetPrintClient(pdf_print_client_.get());
 #endif

--- a/shell/renderer/renderer_client_base.h
+++ b/shell/renderer/renderer_client_base.h
@@ -11,6 +11,7 @@
 
 #include "content/public/renderer/content_renderer_client.h"
 #include "electron/buildflags/buildflags.h"
+#include "printing/buildflags/buildflags.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 // In SHARED_INTERMEDIATE_DIR.
 #include "widevine_cdm_version.h"  // NOLINT(build/include_directory)
@@ -18,6 +19,10 @@
 #if defined(WIDEVINE_CDM_AVAILABLE)
 #include "chrome/renderer/media/chrome_key_systems_provider.h"  // nogncheck
 #endif
+
+#if BUILDFLAG(ENABLE_PDF_VIEWER)
+#include "chrome/renderer/pepper/chrome_pdf_print_client.h"  // nogncheck
+#endif  // BUILDFLAG(ENABLE_PDF_VIEWER)
 
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
 #include "services/service_manager/public/cpp/binder_registry.h"
@@ -138,6 +143,9 @@ class RendererClientBase : public content::ContentRendererClient
 
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
   std::unique_ptr<SpellCheck> spellcheck_;
+#endif
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+  std::unique_ptr<ChromePDFPrintClient> pdf_print_client_;
 #endif
 };
 

--- a/shell/renderer/renderer_client_base.h
+++ b/shell/renderer/renderer_client_base.h
@@ -144,7 +144,7 @@ class RendererClientBase : public content::ContentRendererClient
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
   std::unique_ptr<SpellCheck> spellcheck_;
 #endif
-#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+#if BUILDFLAG(ENABLE_PDF_VIEWER)
   std::unique_ptr<ChromePDFPrintClient> pdf_print_client_;
 #endif
 };


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/24458.

Adds missing WebContents helpers to `ElectronExtensionsAPIClient` so that the relevant IPC events can be listened to. Also ensures that we can get the correct pdf element to print in `GetPdfElement`.

cc @deepak1556 @nornagon @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `Save as PDF` from PDF Viewer Print dialog failed and sometimes crashed.
