### PR TITLE
fix: segfault in SerialChooserController

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1314,6 +1314,17 @@ steps-tests: &steps-tests
           cd src
           (cd electron && node script/yarn test --runners=main --trace-uncaught --enable-logging --files $(circleci tests glob spec-main/*-spec.ts | circleci tests split))
           (cd electron && node script/yarn test --runners=remote --trace-uncaught --enable-logging --files $(circleci tests glob spec/*-spec.js | circleci tests split))
+          cd electron
+          for i in {1..100}
+          do
+            echo "TESTING SERIAL #:$i"
+            node script/yarn test --runners=main --trace-uncaught --enable-logging --files spec-main/chromium-spec.ts -g "navigator.serial"
+            if [[ "$?" -ne 0 ]]; then
+              echo "FOUND FAILURE after $i tries"
+              break
+            fi
+          done
+          echo "Done testing with $i tries"
     - run:
         name: Check test results existence
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1314,17 +1314,6 @@ steps-tests: &steps-tests
           cd src
           (cd electron && node script/yarn test --runners=main --trace-uncaught --enable-logging --files $(circleci tests glob spec-main/*-spec.ts | circleci tests split))
           (cd electron && node script/yarn test --runners=remote --trace-uncaught --enable-logging --files $(circleci tests glob spec/*-spec.js | circleci tests split))
-          cd electron
-          for i in {1..100}
-          do
-            echo "TESTING SERIAL #:$i"
-            node script/yarn test --runners=main --trace-uncaught --enable-logging --files spec-main/chromium-spec.ts -g "navigator.serial"
-            if [[ "$?" -ne 0 ]]; then
-              echo "FOUND FAILURE after $i tries"
-              break
-            fi
-          done
-          echo "Done testing with $i tries"
     - run:
         name: Check test results existence
         command: |

--- a/shell/browser/serial/serial_chooser_controller.cc
+++ b/shell/browser/serial/serial_chooser_controller.cc
@@ -69,11 +69,13 @@ SerialChooserController::SerialChooserController(
   DCHECK(chooser_context_);
   chooser_context_->GetPortManager()->GetDevices(base::BindOnce(
       &SerialChooserController::OnGetDevices, weak_factory_.GetWeakPtr()));
-  observer_.Add(chooser_context_.get());
 }
 
 SerialChooserController::~SerialChooserController() {
   RunCallback(/*port=*/nullptr);
+  if (chooser_context_) {
+    chooser_context_->RemovePortObserver(this);
+  }
 }
 
 api::Session* SerialChooserController::GetSession() {
@@ -104,10 +106,6 @@ void SerialChooserController::OnPortRemoved(
     }
     ports_.erase(it);
   }
-}
-
-void SerialChooserController::OnPortManagerConnectionError() {
-  observer_.RemoveAll();
 }
 
 void SerialChooserController::OnDeviceChosen(const std::string& port_id) {

--- a/shell/browser/serial/serial_chooser_controller.h
+++ b/shell/browser/serial/serial_chooser_controller.h
@@ -10,7 +10,6 @@
 
 #include "base/macros.h"
 #include "base/memory/weak_ptr.h"
-#include "base/scoped_observer.h"
 #include "base/strings/string16.h"
 #include "content/public/browser/serial_chooser.h"
 #include "content/public/browser/web_contents.h"
@@ -44,7 +43,7 @@ class SerialChooserController final : public SerialChooserContext::PortObserver,
   // SerialChooserContext::PortObserver:
   void OnPortAdded(const device::mojom::SerialPortInfo& port) override;
   void OnPortRemoved(const device::mojom::SerialPortInfo& port) override;
-  void OnPortManagerConnectionError() override;
+  void OnPortManagerConnectionError() override {}
 
  private:
   api::Session* GetSession();
@@ -59,11 +58,6 @@ class SerialChooserController final : public SerialChooserContext::PortObserver,
   url::Origin embedding_origin_;
 
   base::WeakPtr<SerialChooserContext> chooser_context_;
-  ScopedObserver<SerialChooserContext,
-                 SerialChooserContext::PortObserver,
-                 &SerialChooserContext::AddPortObserver,
-                 &SerialChooserContext::RemovePortObserver>
-      observer_{this};
 
   std::vector<device::mojom::SerialPortInfoPtr> ports_;
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
This fixes #25781.   The segfault was caused by the fact that the ScopedObserver on the SerialChooserController was trying to call RemovePortObserver on a SerialChooserContext that had already been destroyed. 

Since this segfault was happening sporadically, I modified testing to run through the serial tests 100 times until it errored out.
Here's a test run of it segfaulting before the fix was applied:
https://app.circleci.com/pipelines/github/electron/electron/30787/workflows/9b8b67bb-e324-47b4-a9f4-c1a29dec83b9/jobs/678333

And here is a test run after the fix where it successfully ran serial port tests 100 times without segfault:
https://app.circleci.com/pipelines/github/electron/electron/31155/workflows/1fae9ecb-008e-4e2d-8ad9-cade5c72ac2a

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->Fixed crash while exiting Electron after using the Web Serial API.
