### PR TITLE
chore: tweak branch detection in release notes.

### DIFF
--- a/script/release/notes/notes.js
+++ b/script/release/notes/notes.js
@@ -381,6 +381,7 @@ async function getBranchNameOfRef (ref, dir) {
   return (await runGit(dir, ['branch', '--all', '--contains', ref, '--sort', 'version:refname']))
     .split(/\r?\n/) // split into lines
     .shift() // we sorted by refname and want the first result
+    .match(/(?:\s?\*\s){0,1}(.*)/)[1] // if present, remove leading '* ' in case we're currently in that branch
     .match(/(?:.*\/)?(.*)/)[1] // 'remote/origins/10-x-y' -> '10-x-y'
     .trim();
 }
@@ -398,7 +399,7 @@ const getNotes = async (fromRef, toRef, newVersion) => {
   const pool = new Pool();
   const toBranch = await getBranchNameOfRef(toRef, ELECTRON_DIR);
 
-  console.log(`Generating release notes between ${fromRef} and ${toRef} for version ${newVersion} in branch ${toBranch}`);
+  console.log(`Generating release notes between '${fromRef}' and '${toRef}' for version '${newVersion}' in branch '${toBranch}'`);
 
   // get the electron/electron commits
   const electron = { owner: 'electron', repo: 'electron', dir: ELECTRON_DIR };


### PR DESCRIPTION
#### Description of Change

Fix a wart in branch detection that caused the [11.0.0-beta.12 release notes](https://github.com/electron/electron/releases/tag/v11.0.0-beta.12) to say the changes were "also in 11."

CC @codebytere 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none