### PR TITLE
feat: add serviceName to 'child-process-gone' / app.getAppMetrics()

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -432,6 +432,7 @@ Returns:
     * `integrity-failure` - Windows code integrity checks failed
   * `exitCode` Number - The exit code for the process
       (e.g. status from waitpid if on posix, from GetExitCodeProcess on Windows).
+  * `serviceName` String (optional) - The non-localized name of the process.
   * `name` String (optional) - The name of the process.
     Examples for utility: `Audio Service`, `Content Decryption Module Service`, `Network Service`, `Video Capture`, etc.
 

--- a/docs/api/structures/process-metric.md
+++ b/docs/api/structures/process-metric.md
@@ -11,7 +11,8 @@
   * `Pepper Plugin`
   * `Pepper Plugin Broker`
   * `Unknown`
-* `name` String (optional) - The name of the process. i.e. for plugins it might be Flash.
+* `serviceName` String (optional) - The non-localized name of the process.
+* `name` String (optional) - The name of the process.
     Examples for utility: `Audio Service`, `Content Decryption Module Service`, `Network Service`, `Video Capture`, etc.
 * `cpu` [CPUUsage](cpu-usage.md) - CPU usage of the process.
 * `creationTime` Number - Creation time for this process.

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -168,6 +168,7 @@ class App : public ElectronBrowserClient::Delegate,
   void SetAppPath(const base::FilePath& app_path);
   void ChildProcessLaunched(int process_type,
                             base::ProcessHandle handle,
+                            const std::string& service_name = std::string(),
                             const std::string& name = std::string());
   void ChildProcessDisconnected(base::ProcessId pid);
 

--- a/shell/browser/api/process_metric.cc
+++ b/shell/browser/api/process_metric.cc
@@ -53,9 +53,11 @@ namespace electron {
 ProcessMetric::ProcessMetric(int type,
                              base::ProcessHandle handle,
                              std::unique_ptr<base::ProcessMetrics> metrics,
+                             const std::string& service_name,
                              const std::string& name) {
   this->type = type;
   this->metrics = std::move(metrics);
+  this->service_name = service_name;
   this->name = name;
 
 #if defined(OS_WIN)

--- a/shell/browser/api/process_metric.h
+++ b/shell/browser/api/process_metric.h
@@ -38,11 +38,13 @@ struct ProcessMetric {
   int type;
   base::Process process;
   std::unique_ptr<base::ProcessMetrics> metrics;
+  std::string service_name;
   std::string name;
 
   ProcessMetric(int type,
                 base::ProcessHandle handle,
                 std::unique_ptr<base::ProcessMetrics> metrics,
+                const std::string& service_name = std::string(),
                 const std::string& name = std::string());
   ~ProcessMetric();
 

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -1176,6 +1176,10 @@ describe('app module', () => {
         expect(entry.memory).to.have.property('workingSetSize').that.is.greaterThan(0);
         expect(entry.memory).to.have.property('peakWorkingSetSize').that.is.greaterThan(0);
 
+        if (entry.type === 'Utility' || entry.type === 'GPU') {
+          expect(entry.serviceName).to.be.a('string').that.does.not.equal('');
+        }
+
         if (entry.type === 'Utility') {
           expect(entry).to.have.property('name').that.is.a('string');
         }


### PR DESCRIPTION
#### Description of Change
It turns out that the `name` added in #24359 is localized. Add non-localized `serviceName`.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added non-localized `serviceName` to `'child-process-gone'` / `app.getAppMetrics()`.
