### PR TITLE
build: use buffering when applying patches

### DIFF
--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -62,6 +62,7 @@ def am(repo, patch_data, threeway=False, directory=None, exclude=None,
   command = ['git'] + root_args + ['am'] + args
   proc = subprocess.Popen(
       command,
+      bufsize=-1,
       stdin=subprocess.PIPE)
   proc.communicate(patch_data.encode('utf-8'))
   if proc.returncode != 0:


### PR DESCRIPTION
#### Description of Change
On my local machine this shaves 10-25 seconds from applying patches. Seems like a free (minor) improvement. The `-1` means "fully buffered".
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
