### PR TITLE
fix: support new PDF viewer update

### DIFF
--- a/shell/browser/extensions/api/resources_private/resources_private_api.cc
+++ b/shell/browser/extensions/api/resources_private/resources_private_api.cc
@@ -63,6 +63,11 @@ void AddStringsForPdf(base::DictionaryValue* dict) {
 
 void AddAdditionalDataForPdf(base::DictionaryValue* dict) {
 #if BUILDFLAG(ENABLE_PDF)
+  dict->SetStringKey(
+      "pdfViewerUpdateEnabledAttribute",
+      base::FeatureList::IsEnabled(chrome_pdf::features::kPDFViewerUpdate)
+          ? "pdf-viewer-update-enabled"
+          : "");
   dict->SetKey("pdfFormSaveEnabled",
                base::Value(base::FeatureList::IsEnabled(
                    chrome_pdf::features::kSaveEditedPDFForm)));


### PR DESCRIPTION
#### Description of Change

Adds missing support for new PDF viewer UI.

Enable-able with `app.commandLine.appendSwitch('enable-features', 'PDFViewerUpdate')`.

Default:
<img width="912" alt="Screen Shot 2020-10-16 at 6 27 44 PM" src="https://user-images.githubusercontent.com/2036040/96325529-66b10b80-0fdd-11eb-99a1-00d45f4036a1.png">

With feature enabled:

<img width="912" alt="Screen Shot 2020-10-16 at 6 27 32 PM" src="https://user-images.githubusercontent.com/2036040/96325539-7deff900-0fdd-11eb-92b6-94725875d106.png">

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Enabled support for new Chromium experimental PDF viewer UI.
