### PR TITLE
build: fix invocation of cpplint on Windows

### DIFF
--- a/script/lint.js
+++ b/script/lint.js
@@ -23,6 +23,8 @@ const IGNORELIST = new Set([
   ['spec', 'ts-smoke', 'runner.js']
 ].map(tokens => path.join(SOURCE_ROOT, ...tokens)));
 
+const IS_WINDOWS = process.platform === 'win32';
+
 function spawnAndCheckExitCode (cmd, args, opts) {
   opts = Object.assign({ stdio: 'inherit' }, opts);
   const status = childProcess.spawnSync(cmd, args, opts).status;
@@ -30,7 +32,7 @@ function spawnAndCheckExitCode (cmd, args, opts) {
 }
 
 function cpplint (args) {
-  const result = childProcess.spawnSync('cpplint.py', args, { encoding: 'utf8' });
+  const result = childProcess.spawnSync(IS_WINDOWS ? 'cpplint.bat' : 'cpplint.py', args, { encoding: 'utf8', shell: true });
   // cpplint.py writes EVERYTHING to stderr, including status messages
   if (result.stderr) {
     for (const line of result.stderr.split(/[\r\n]+/)) {
@@ -39,8 +41,9 @@ function cpplint (args) {
       }
     }
   }
-  if (result.status) {
-    process.exit(result.status);
+  if (result.status !== 0) {
+    if (result.error) console.error(result.error);
+    process.exit(result.status || 1);
   }
 }
 


### PR DESCRIPTION
#### Description of Change
First of a few PRs that are going to be needed to fix up the linters on Windows, see #26009.

Reason these have been silently failing is because `childProcess.spawnSync` will return a status of `null` if it fails due to a signal, or an error such as ENONET. Good thing to keep in mind for error handling.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
