### PR TITLE
docs: improve relative link linting and fix broken

### DIFF
--- a/docs/api/command-line-switches.md
+++ b/docs/api/command-line-switches.md
@@ -232,7 +232,7 @@ Specify ways of the inspector web socket url exposure.
 By default inspector websocket url is available in stderr and under /json/list endpoint on http://host:port/json/list.
 
 [app]: app.md
-[append-switch]: app.md#appcommandlineappendswitchswitch-value
+[append-switch]: command-line.md#commandlineappendswitchswitch-value
 [ready]: app.md#event-ready
 [play-silent-audio]: https://github.com/atom/atom/pull/9485/files
 [debugging-main-process]: ../tutorial/debugging-main-process.md

--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -95,7 +95,7 @@ Returns `Promise<DesktopCapturerSource[]>` - Resolves with an array of [`Desktop
 which can detected by [`systemPreferences.getMediaAccessStatus`].
 
 [`navigator.mediaDevices.getUserMedia`]: https://developer.mozilla.org/en/docs/Web/API/MediaDevices/getUserMedia
-[`systemPreferences.getMediaAccessStatus`]: system-preferences.md#systempreferencesgetmediaaccessstatusmediatype-macos
+[`systemPreferences.getMediaAccessStatus`]: system-preferences.md#systempreferencesgetmediaaccessstatusmediatype-windows-macos
 
 ## Caveats
 

--- a/docs/api/structures/ipc-renderer-event.md
+++ b/docs/api/structures/ipc-renderer-event.md
@@ -4,4 +4,4 @@
 * `senderId` Integer - The `webContents.id` that sent the message, you can call `event.sender.sendTo(event.senderId, ...)` to reply to the message, see [ipcRenderer.sendTo][ipc-renderer-sendto] for more information. This only applies to messages sent from a different renderer. Messages sent directly from the main process set `event.senderId` to `0`.
 * `ports` MessagePort[] - A list of MessagePorts that were transferred with this message
 
-[ipc-renderer-sendto]: #ipcrenderersendtowindowid-channel--arg1-arg2-
+[ipc-renderer-sendto]: ../ipc-renderer.md#ipcrenderersendtowebcontentsid-channel-args

--- a/docs/tutorial/progress-bar.md
+++ b/docs/tutorial/progress-bar.md
@@ -32,4 +32,4 @@ win.setProgressBar(0.5)
 ```
 
 [taskbar-progress-image]: https://cloud.githubusercontent.com/assets/639601/5081682/16691fda-6f0e-11e4-9676-49b6418f1264.png
-[setprogressbar]: ../api/browser-window.md#winsetprogressbarprogress
+[setprogressbar]: ../api/browser-window.md#winsetprogressbarprogress-options

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -814,6 +814,6 @@ which potential security issues are not as widely known.
 [web-contents]: ../api/web-contents.md
 [new-window]: ../api/web-contents.md#event-new-window
 [will-navigate]: ../api/web-contents.md#event-will-navigate
-[open-external]: ../api/shell.md#shellopenexternalurl-options-callback
+[open-external]: ../api/shell.md#shellopenexternalurl-options
 [sandbox]: ../api/sandbox-option.md
 [responsible-disclosure]: https://en.wikipedia.org/wiki/Responsible_disclosure

--- a/script/check-relative-doc-links.py
+++ b/script/check-relative-doc-links.py
@@ -48,14 +48,20 @@ def getBrokenLinks(filepath):
   finally:
     f.close()
 
-  regexLink = re.compile('\[(.*?)\]\((?P<links>(.*?))\)')
+  linkRegexLink = re.compile('\[(.*?)\]\((?P<link>(.*?))\)')
+  referenceLinkRegex = re.compile('^\s{0,3}\[.*?\]:\s*(?P<link>[^<\s]+|<[^<>\r\n]+>)')
   links = []
   for line in lines:
-    matchLinks = regexLink.search(line)
+    matchLinks = linkRegexLink.search(line)
+    matchReferenceLinks = referenceLinkRegex.search(line)
     if matchLinks:
-      relativeLink = matchLinks.group('links')
+      relativeLink = matchLinks.group('link')
       if not str(relativeLink).startswith('http'):
         links.append(relativeLink)
+    if matchReferenceLinks:
+      referenceLink = matchReferenceLinks.group('link').strip('<>')
+      if not str(referenceLink).startswith('http'):
+        links.append(referenceLink)
 
   for link in links:
     sections = link.split('#')


### PR DESCRIPTION
#### Description of Change
The linter for broken relative links wasn't looking for reference links, so I improved it to do so, and fixed the handful of broken links it found. The regex was a bit of a pain, the [specification for a Markdown reference link](https://github.github.com/gfm/#reference-link) is a bit tricky to fully express with a regex. I think I have full coverage for any uses in the docs, but no guarantees if there's extra line endings in there.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
