### PR TITLE
fix: add Wayland support

### DIFF
--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -93,9 +93,18 @@ static_library("chrome") {
 
   if (is_linux) {
     sources += [ "//chrome/browser/icon_loader_auralinux.cc" ]
+    if (use_x11) {
+      sources += [
+        "//chrome/browser/extensions/global_shortcut_listener_x11.cc",
+        "//chrome/browser/extensions/global_shortcut_listener_x11.h",
+      ]
+    } else if (use_ozone) {
+      sources += [
+        "//chrome/browser/extensions/global_shortcut_listener_ozone.cc",
+        "//chrome/browser/extensions/global_shortcut_listener_ozone.h",
+      ]
+    }
     sources += [
-      "//chrome/browser/extensions/global_shortcut_listener_x11.cc",
-      "//chrome/browser/extensions/global_shortcut_listener_x11.h",
       "//chrome/browser/ui/views/status_icons/concat_menu_model.cc",
       "//chrome/browser/ui/views/status_icons/concat_menu_model.h",
       "//chrome/browser/ui/views/status_icons/status_icon_linux_dbus.cc",

--- a/filenames.gni
+++ b/filenames.gni
@@ -1,3 +1,5 @@
+import("//build/config/ui.gni")
+
 filenames = {
   default_app_ts_sources = [
     "default_app/default_app.ts",
@@ -22,20 +24,10 @@ filenames = {
   ]
 
   lib_sources_linux = [
-    "chromium_src/chrome/browser/ui/views/frame/global_menu_bar_registrar_x11.cc",
-    "chromium_src/chrome/browser/ui/views/frame/global_menu_bar_registrar_x11.h",
     "shell/browser/ui/file_dialog_gtk.cc",
     "shell/browser/ui/message_box_gtk.cc",
     "shell/browser/ui/tray_icon_gtk.cc",
     "shell/browser/ui/tray_icon_gtk.h",
-    "shell/browser/ui/views/global_menu_bar_x11.cc",
-    "shell/browser/ui/views/global_menu_bar_x11.h",
-    "shell/browser/ui/x/event_disabler.cc",
-    "shell/browser/ui/x/event_disabler.h",
-    "shell/browser/ui/x/window_state_watcher.cc",
-    "shell/browser/ui/x/window_state_watcher.h",
-    "shell/browser/ui/x/x_window_utils.cc",
-    "shell/browser/ui/x/x_window_utils.h",
     "shell/browser/browser_linux.cc",
     "shell/browser/lib/power_observer_linux.cc",
     "shell/browser/lib/power_observer_linux.h",
@@ -641,6 +633,21 @@ filenames = {
     "shell/utility/electron_content_utility_client.cc",
     "shell/utility/electron_content_utility_client.h",
   ]
+
+  if (use_x11) {
+    lib_sources_linux += [
+      "chromium_src/chrome/browser/ui/views/frame/global_menu_bar_registrar_x11.cc",
+      "chromium_src/chrome/browser/ui/views/frame/global_menu_bar_registrar_x11.h",
+      "shell/browser/ui/views/global_menu_bar_x11.cc",
+      "shell/browser/ui/views/global_menu_bar_x11.h",
+      "shell/browser/ui/x/event_disabler.cc",
+      "shell/browser/ui/x/event_disabler.h",
+      "shell/browser/ui/x/window_state_watcher.cc",
+      "shell/browser/ui/x/window_state_watcher.h",
+      "shell/browser/ui/x/x_window_utils.cc",
+      "shell/browser/ui/x/x_window_utils.h",
+    ]
+  }
 
   lib_sources_nss = [
     "chromium_src/chrome/browser/certificate_manager_model.cc",

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -999,7 +999,7 @@ void BaseWindow::SetIcon(gin::Handle<NativeImage> icon) {
   static_cast<NativeWindowViews*>(window_.get())
       ->SetIcon(icon->GetHICON(GetSystemMetrics(SM_CXSMICON)),
                 icon->GetHICON(GetSystemMetrics(SM_CXICON)));
-#elif defined(USE_X11)
+#elif defined(OS_LINUX)
   static_cast<NativeWindowViews*>(window_.get())
       ->SetIcon(icon->image().AsImageSkia());
 #endif

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -29,7 +29,7 @@ class WMState;
 }
 #endif
 
-#if defined(OS_LINUX)
+#if defined(USE_X11)
 namespace ui {
 class GtkUiDelegate;
 }
@@ -133,6 +133,9 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
 
 #if defined(USE_X11)
   std::unique_ptr<ui::GtkUiDelegate> gtk_ui_delegate_;
+#endif
+
+#if defined(OS_LINUX)
   // Used to notify the native theme of changes to dark mode.
   std::unique_ptr<DarkThemeObserver> dark_theme_observer_;
 #endif

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -109,7 +109,7 @@ void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
   } else {
     SetSizeConstraints(size_constraints);
   }
-#if defined(OS_WIN) || defined(USE_X11)
+#if defined(OS_WIN) || defined(OS_LINUX)
   bool resizable;
   if (options.Get(options::kResizable, &resizable)) {
     SetResizable(resizable);

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -43,13 +43,17 @@
 #include "ui/wm/core/shadow_types.h"
 #include "ui/wm/core/window_util.h"
 
-#if defined(USE_X11)
+#if defined(OS_LINUX)
 #include "base/strings/string_util.h"
 #include "shell/browser/browser.h"
 #include "shell/browser/linux/unity_service.h"
 #include "shell/browser/ui/views/frameless_view.h"
-#include "shell/browser/ui/views/global_menu_bar_x11.h"
 #include "shell/browser/ui/views/native_frame_view.h"
+#include "ui/views/widget/desktop_aura/desktop_window_tree_host_linux.h"
+#include "ui/views/window/native_frame_view.h"
+
+#if defined(USE_X11)
+#include "shell/browser/ui/views/global_menu_bar_x11.h"
 #include "shell/browser/ui/x/event_disabler.h"
 #include "shell/browser/ui/x/window_state_watcher.h"
 #include "shell/browser/ui/x/x_window_utils.h"
@@ -57,8 +61,12 @@
 #include "ui/gfx/x/shape.h"
 #include "ui/gfx/x/x11_atom_cache.h"
 #include "ui/gfx/x/x11_types.h"
-#include "ui/views/widget/desktop_aura/desktop_window_tree_host_linux.h"
-#include "ui/views/window/native_frame_view.h"
+#endif
+
+#if defined(USE_OZONE) || defined(USE_X11)
+#include "ui/base/ui_base_features.h"
+#endif
+
 #elif defined(OS_WIN)
 #include "base/win/win_util.h"
 #include "shell/browser/ui/views/win_frame_view.h"
@@ -211,45 +219,56 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
   options.Get(options::kType, &window_type);
 
 #if defined(USE_X11)
-  // Start monitoring window states.
-  window_state_watcher_ = std::make_unique<WindowStateWatcher>(this);
+  if (!features::IsUsingOzonePlatform()) {
+    // Start monitoring window states.
+    window_state_watcher_ = std::make_unique<WindowStateWatcher>(this);
 
-  // Set _GTK_THEME_VARIANT to dark if we have "dark-theme" option set.
-  bool use_dark_theme = false;
-  if (options.Get(options::kDarkTheme, &use_dark_theme) && use_dark_theme) {
-    SetGTKDarkThemeEnabled(use_dark_theme);
+    // Set _GTK_THEME_VARIANT to dark if we have "dark-theme" option set.
+    bool use_dark_theme = false;
+    if (options.Get(options::kDarkTheme, &use_dark_theme) && use_dark_theme) {
+      SetGTKDarkThemeEnabled(use_dark_theme);
+    }
   }
+#endif
 
-  // Before the window is mapped the SetWMSpecState can not work, so we have
-  // to manually set the _NET_WM_STATE.
-  std::vector<x11::Atom> state_atom_list;
-  bool skip_taskbar = false;
-  if (options.Get(options::kSkipTaskbar, &skip_taskbar) && skip_taskbar) {
-    state_atom_list.push_back(gfx::GetAtom("_NET_WM_STATE_SKIP_TASKBAR"));
-  }
-
-  // Before the window is mapped, there is no SHOW_FULLSCREEN_STATE.
-  if (fullscreen) {
-    state_atom_list.push_back(gfx::GetAtom("_NET_WM_STATE_FULLSCREEN"));
-  }
-
-  if (parent) {
+#if defined(OS_LINUX)
+  if (parent)
     SetParentWindow(parent);
-    // Force using dialog type for child window.
-    window_type = "dialog";
-    // Modal window needs the _NET_WM_STATE_MODAL hint.
-    if (is_modal())
-      state_atom_list.push_back(gfx::GetAtom("_NET_WM_STATE_MODAL"));
+#endif
+
+#if defined(USE_X11)
+  if (!features::IsUsingOzonePlatform()) {
+    // Before the window is mapped the SetWMSpecState can not work, so we have
+    // to manually set the _NET_WM_STATE.
+    std::vector<x11::Atom> state_atom_list;
+    bool skip_taskbar = false;
+    if (options.Get(options::kSkipTaskbar, &skip_taskbar) && skip_taskbar) {
+      state_atom_list.push_back(gfx::GetAtom("_NET_WM_STATE_SKIP_TASKBAR"));
+    }
+
+    // Before the window is mapped, there is no SHOW_FULLSCREEN_STATE.
+    if (fullscreen) {
+      state_atom_list.push_back(gfx::GetAtom("_NET_WM_STATE_FULLSCREEN"));
+    }
+
+    if (parent) {
+      // Force using dialog type for child window.
+      window_type = "dialog";
+
+      // Modal window needs the _NET_WM_STATE_MODAL hint.
+      if (is_modal())
+        state_atom_list.push_back(gfx::GetAtom("_NET_WM_STATE_MODAL"));
+    }
+
+    if (!state_atom_list.empty())
+      ui::SetAtomArrayProperty(static_cast<x11::Window>(GetAcceleratedWidget()),
+                               "_NET_WM_STATE", "ATOM", state_atom_list);
+
+    // Set the _NET_WM_WINDOW_TYPE.
+    if (!window_type.empty())
+      SetWindowType(static_cast<x11::Window>(GetAcceleratedWidget()),
+                    window_type);
   }
-
-  if (!state_atom_list.empty())
-    ui::SetAtomArrayProperty(static_cast<x11::Window>(GetAcceleratedWidget()),
-                             "_NET_WM_STATE", "ATOM", state_atom_list);
-
-  // Set the _NET_WM_WINDOW_TYPE.
-  if (!window_type.empty())
-    SetWindowType(static_cast<x11::Window>(GetAcceleratedWidget()),
-                  window_type);
 #endif
 
 #if defined(OS_WIN)
@@ -331,14 +350,11 @@ NativeWindowViews::~NativeWindowViews() {
 
 void NativeWindowViews::SetGTKDarkThemeEnabled(bool use_dark_theme) {
 #if defined(USE_X11)
-  if (use_dark_theme) {
+  if (!features::IsUsingOzonePlatform()) {
+    const std::string color = use_dark_theme ? "dark" : "light";
     ui::SetStringProperty(static_cast<x11::Window>(GetAcceleratedWidget()),
                           gfx::GetAtom("_GTK_THEME_VARIANT"),
-                          gfx::GetAtom("UTF8_STRING"), "dark");
-  } else {
-    ui::SetStringProperty(static_cast<x11::Window>(GetAcceleratedWidget()),
-                          gfx::GetAtom("_GTK_THEME_VARIANT"),
-                          gfx::GetAtom("UTF8_STRING"), "light");
+                          gfx::GetAtom("UTF8_STRING"), color);
   }
 #endif
 }
@@ -395,7 +411,7 @@ void NativeWindowViews::Show() {
   NotifyWindowShow();
 
 #if defined(USE_X11)
-  if (global_menu_bar_)
+  if (!features::IsUsingOzonePlatform() && global_menu_bar_)
     global_menu_bar_->OnWindowMapped();
 #endif
 }
@@ -406,7 +422,7 @@ void NativeWindowViews::ShowInactive() {
   NotifyWindowShow();
 
 #if defined(USE_X11)
-  if (global_menu_bar_)
+  if (!features::IsUsingOzonePlatform() && global_menu_bar_)
     global_menu_bar_->OnWindowMapped();
 #endif
 }
@@ -420,7 +436,7 @@ void NativeWindowViews::Hide() {
   NotifyWindowHide();
 
 #if defined(USE_X11)
-  if (global_menu_bar_)
+  if (!features::IsUsingOzonePlatform() && global_menu_bar_)
     global_menu_bar_->OnWindowUnmapped();
 #endif
 }
@@ -432,8 +448,14 @@ bool NativeWindowViews::IsVisible() {
 bool NativeWindowViews::IsEnabled() {
 #if defined(OS_WIN)
   return ::IsWindowEnabled(GetAcceleratedWidget());
-#elif defined(USE_X11)
-  return !event_disabler_.get();
+#elif defined(OS_LINUX)
+#if defined(USE_X11)
+  if (!features::IsUsingOzonePlatform()) {
+    return !event_disabler_.get();
+  }
+#endif
+  NOTIMPLEMENTED();
+  return true;
 #endif
 }
 
@@ -470,15 +492,17 @@ void NativeWindowViews::SetEnabledInternal(bool enable) {
 #if defined(OS_WIN)
   ::EnableWindow(GetAcceleratedWidget(), enable);
 #elif defined(USE_X11)
-  views::DesktopWindowTreeHostPlatform* tree_host =
-      views::DesktopWindowTreeHostLinux::GetHostForWidget(
-          GetAcceleratedWidget());
-  if (enable) {
-    tree_host->RemoveEventRewriter(event_disabler_.get());
-    event_disabler_.reset();
-  } else {
-    event_disabler_ = std::make_unique<EventDisabler>();
-    tree_host->AddEventRewriter(event_disabler_.get());
+  if (!features::IsUsingOzonePlatform()) {
+    views::DesktopWindowTreeHostPlatform* tree_host =
+        views::DesktopWindowTreeHostLinux::GetHostForWidget(
+            GetAcceleratedWidget());
+    if (enable) {
+      tree_host->RemoveEventRewriter(event_disabler_.get());
+      event_disabler_.reset();
+    } else {
+      event_disabler_ = std::make_unique<EventDisabler>();
+      tree_host->AddEventRewriter(event_disabler_.get());
+    }
   }
 #endif
 }
@@ -584,7 +608,7 @@ bool NativeWindowViews::IsFullscreen() const {
 }
 
 void NativeWindowViews::SetBounds(const gfx::Rect& bounds, bool animate) {
-#if defined(OS_WIN) || defined(USE_X11)
+#if defined(OS_WIN) || defined(OS_LINUX)
   // On Linux and Windows the minimum and maximum size should be updated with
   // window size when window is not resizable.
   if (!resizable_) {
@@ -675,11 +699,13 @@ bool NativeWindowViews::MoveAbove(const std::string& sourceId) {
                  0, 0, 0,
                  SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
 #elif defined(USE_X11)
-  if (!IsWindowValid(static_cast<x11::Window>(id.id)))
-    return false;
+  if (!features::IsUsingOzonePlatform()) {
+    if (!IsWindowValid(static_cast<x11::Window>(id.id)))
+      return false;
 
-  electron::MoveWindowAbove(static_cast<x11::Window>(GetAcceleratedWidget()),
-                            static_cast<x11::Window>(id.id));
+    electron::MoveWindowAbove(static_cast<x11::Window>(GetAcceleratedWidget()),
+                              static_cast<x11::Window>(id.id));
+  }
 #endif
 
   return true;
@@ -695,8 +721,10 @@ void NativeWindowViews::MoveTop() {
                  size.width(), size.height(),
                  SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
 #elif defined(USE_X11)
-  electron::MoveWindowToForeground(
-      static_cast<x11::Window>(GetAcceleratedWidget()));
+  if (!features::IsUsingOzonePlatform()) {
+    electron::MoveWindowToForeground(
+        static_cast<x11::Window>(GetAcceleratedWidget()));
+  }
 #endif
 }
 
@@ -881,8 +909,10 @@ void NativeWindowViews::SetSkipTaskbar(bool skip) {
     taskbar_host_.RestoreThumbarButtons(GetAcceleratedWidget());
   }
 #elif defined(USE_X11)
-  SetWMSpecState(static_cast<x11::Window>(GetAcceleratedWidget()), skip,
-                 gfx::GetAtom("_NET_WM_STATE_SKIP_TASKBAR"));
+  if (!features::IsUsingOzonePlatform()) {
+    SetWMSpecState(static_cast<x11::Window>(GetAcceleratedWidget()), skip,
+                   gfx::GetAtom("_NET_WM_STATE_SKIP_TASKBAR"));
+  }
 #endif
 }
 
@@ -980,23 +1010,27 @@ void NativeWindowViews::SetIgnoreMouseEvents(bool ignore, bool forward) {
     SetForwardMouseMessages(forward);
   }
 #elif defined(USE_X11)
-  auto* connection = x11::Connection::Get();
-  if (ignore) {
-    x11::Rectangle r{0, 0, 1, 1};
-    connection->shape().Rectangles({
-        .operation = x11::Shape::So::Set,
-        .destination_kind = x11::Shape::Sk::Input,
-        .ordering = x11::ClipOrdering::YXBanded,
-        .destination_window = static_cast<x11::Window>(GetAcceleratedWidget()),
-        .rectangles = {r},
-    });
-  } else {
-    connection->shape().Mask({
-        .operation = x11::Shape::So::Set,
-        .destination_kind = x11::Shape::Sk::Input,
-        .destination_window = static_cast<x11::Window>(GetAcceleratedWidget()),
-        .source_bitmap = x11::Pixmap::None,
-    });
+  if (!features::IsUsingOzonePlatform()) {
+    auto* connection = x11::Connection::Get();
+    if (ignore) {
+      x11::Rectangle r{0, 0, 1, 1};
+      connection->shape().Rectangles({
+          .operation = x11::Shape::So::Set,
+          .destination_kind = x11::Shape::Sk::Input,
+          .ordering = x11::ClipOrdering::YXBanded,
+          .destination_window =
+              static_cast<x11::Window>(GetAcceleratedWidget()),
+          .rectangles = {r},
+      });
+    } else {
+      connection->shape().Mask({
+          .operation = x11::Shape::So::Set,
+          .destination_kind = x11::Shape::Sk::Input,
+          .destination_window =
+              static_cast<x11::Window>(GetAcceleratedWidget()),
+          .source_bitmap = x11::Pixmap::None,
+      });
+    }
   }
 #endif
 }
@@ -1024,21 +1058,23 @@ void NativeWindowViews::SetFocusable(bool focusable) {
 
 void NativeWindowViews::SetMenu(ElectronMenuModel* menu_model) {
 #if defined(USE_X11)
-  // Remove global menu bar.
-  if (global_menu_bar_ && menu_model == nullptr) {
-    global_menu_bar_.reset();
-    root_view_->UnregisterAcceleratorsWithFocusManager();
-    return;
-  }
-
-  // Use global application menu bar when possible.
-  if (ShouldUseGlobalMenuBar()) {
-    if (!global_menu_bar_)
-      global_menu_bar_ = std::make_unique<GlobalMenuBarX11>(this);
-    if (global_menu_bar_->IsServerStarted()) {
-      root_view_->RegisterAcceleratorsWithFocusManager(menu_model);
-      global_menu_bar_->SetMenu(menu_model);
+  if (!features::IsUsingOzonePlatform()) {
+    // Remove global menu bar.
+    if (global_menu_bar_ && menu_model == nullptr) {
+      global_menu_bar_.reset();
+      root_view_->UnregisterAcceleratorsWithFocusManager();
       return;
+    }
+
+    // Use global application menu bar when possible.
+    if (ShouldUseGlobalMenuBar()) {
+      if (!global_menu_bar_)
+        global_menu_bar_ = std::make_unique<GlobalMenuBarX11>(this);
+      if (global_menu_bar_->IsServerStarted()) {
+        root_view_->RegisterAcceleratorsWithFocusManager(menu_model);
+        global_menu_bar_->SetMenu(menu_model);
+        return;
+      }
     }
   }
 #endif
@@ -1104,11 +1140,13 @@ void NativeWindowViews::SetParentWindow(NativeWindow* parent) {
   NativeWindow::SetParentWindow(parent);
 
 #if defined(USE_X11)
-  ui::SetProperty(static_cast<x11::Window>(GetAcceleratedWidget()),
-                  x11::Atom::WM_TRANSIENT_FOR, x11::Atom::WINDOW,
-                  parent
-                      ? static_cast<x11::Window>(parent->GetAcceleratedWidget())
-                      : ui::GetX11RootWindow());
+  if (!features::IsUsingOzonePlatform()) {
+    ui::SetProperty(
+        static_cast<x11::Window>(GetAcceleratedWidget()),
+        x11::Atom::WM_TRANSIENT_FOR, x11::Atom::WINDOW,
+        parent ? static_cast<x11::Window>(parent->GetAcceleratedWidget())
+               : ui::GetX11RootWindow());
+  }
 #elif defined(OS_WIN)
   // To set parentship between windows into Windows is better to play with the
   //  owner instead of the parent, as Windows natively seems to do if a parent
@@ -1183,14 +1221,16 @@ void NativeWindowViews::SetVisibleOnAllWorkspaces(bool visible,
 
 bool NativeWindowViews::IsVisibleOnAllWorkspaces() {
 #if defined(USE_X11)
-  // Use the presence/absence of _NET_WM_STATE_STICKY in _NET_WM_STATE to
-  // determine whether the current window is visible on all workspaces.
-  x11::Atom sticky_atom = gfx::GetAtom("_NET_WM_STATE_STICKY");
-  std::vector<x11::Atom> wm_states;
-  ui::GetAtomArrayProperty(static_cast<x11::Window>(GetAcceleratedWidget()),
-                           "_NET_WM_STATE", &wm_states);
-  return std::find(wm_states.begin(), wm_states.end(), sticky_atom) !=
-         wm_states.end();
+  if (!features::IsUsingOzonePlatform()) {
+    // Use the presence/absence of _NET_WM_STATE_STICKY in _NET_WM_STATE to
+    // determine whether the current window is visible on all workspaces.
+    x11::Atom sticky_atom = gfx::GetAtom("_NET_WM_STATE_STICKY");
+    std::vector<x11::Atom> wm_states;
+    ui::GetAtomArrayProperty(static_cast<x11::Window>(GetAcceleratedWidget()),
+                             "_NET_WM_STATE", &wm_states);
+    return std::find(wm_states.begin(), wm_states.end(), sticky_atom) !=
+           wm_states.end();
+  }
 #endif
   return false;
 }

--- a/shell/browser/ui/file_dialog_gtk.cc
+++ b/shell/browser/ui/file_dialog_gtk.cc
@@ -15,8 +15,15 @@
 #include "shell/browser/unresponsive_suppressor.h"
 #include "shell/common/gin_converters/file_path_converter.h"
 #include "ui/base/glib/glib_signal.h"
-#include "ui/events/platform/x11/x11_event_source.h"
 #include "ui/gtk/gtk_util.h"
+
+#if defined(USE_X11)
+#include "ui/events/platform/x11/x11_event_source.h"
+#endif
+
+#if defined(USE_OZONE) || defined(USE_X11)
+#include "ui/base/ui_base_features.h"
+#endif
 
 namespace file_dialog {
 
@@ -135,11 +142,15 @@ class FileChooserDialog {
                      this);
     gtk_widget_show_all(dialog_);
 
-    // We need to call gtk_window_present after making the widgets visible to
-    // make sure window gets correctly raised and gets focus.
-    x11::Time time = ui::X11EventSource::GetInstance()->GetTimestamp();
-    gtk_window_present_with_time(GTK_WINDOW(dialog_),
-                                 static_cast<uint32_t>(time));
+#if defined(USE_X11)
+    if (!features::IsUsingOzonePlatform()) {
+      // We need to call gtk_window_present after making the widgets visible to
+      // make sure window gets correctly raised and gets focus.
+      x11::Time time = ui::X11EventSource::GetInstance()->GetTimestamp();
+      gtk_window_present_with_time(GTK_WINDOW(dialog_),
+                                   static_cast<uint32_t>(time));
+    }
+#endif
   }
 
   void RunSaveAsynchronous(

--- a/shell/browser/ui/gtk/menu_util.cc
+++ b/shell/browser/ui/gtk/menu_util.cc
@@ -22,6 +22,10 @@
 #include "ui/events/event_constants.h"
 #include "ui/events/keycodes/keyboard_code_conversion_x.h"
 
+#if defined(USE_OZONE) || defined(USE_X11)
+#include "ui/base/ui_base_features.h"
+#endif
+
 namespace electron {
 
 namespace gtkui {
@@ -222,12 +226,14 @@ void BuildSubmenuFromModel(ui::MenuModel* model,
     }
 
 #if defined(USE_X11)
-    ui::Accelerator accelerator;
-    if (model->GetAcceleratorAt(i, &accelerator)) {
-      gtk_widget_add_accelerator(menu_item, "activate", nullptr,
-                                 GetGdkKeyCodeForAccelerator(accelerator),
-                                 GetGdkModifierForAccelerator(accelerator),
-                                 GTK_ACCEL_VISIBLE);
+    if (!features::IsUsingOzonePlatform()) {
+      ui::Accelerator accelerator;
+      if (model->GetAcceleratorAt(i, &accelerator)) {
+        gtk_widget_add_accelerator(menu_item, "activate", nullptr,
+                                   GetGdkKeyCodeForAccelerator(accelerator),
+                                   GetGdkModifierForAccelerator(accelerator),
+                                   GTK_ACCEL_VISIBLE);
+      }
     }
 #endif
 

--- a/shell/browser/ui/message_box_gtk.cc
+++ b/shell/browser/ui/message_box_gtk.cc
@@ -13,9 +13,16 @@
 #include "shell/browser/native_window_views.h"
 #include "shell/browser/unresponsive_suppressor.h"
 #include "ui/base/glib/glib_signal.h"
-#include "ui/events/platform/x11/x11_event_source.h"
 #include "ui/gfx/image/image_skia.h"
 #include "ui/gtk/gtk_util.h"
+
+#if defined(USE_X11)
+#include "ui/events/platform/x11/x11_event_source.h"
+#endif
+
+#if defined(USE_OZONE) || defined(USE_X11)
+#include "ui/base/ui_base_features.h"
+#endif
 
 #define ANSI_FOREGROUND_RED "\x1b[31m"
 #define ANSI_FOREGROUND_BLACK "\x1b[30m"
@@ -133,11 +140,16 @@ class GtkMessageBox : public NativeWindowObserver {
 
   void Show() {
     gtk_widget_show(dialog_);
-    // We need to call gtk_window_present after making the widgets visible to
-    // make sure window gets correctly raised and gets focus.
-    x11::Time time = ui::X11EventSource::GetInstance()->GetTimestamp();
-    gtk_window_present_with_time(GTK_WINDOW(dialog_),
-                                 static_cast<uint32_t>(time));
+
+#if defined(USE_X11)
+    if (!features::IsUsingOzonePlatform()) {
+      // We need to call gtk_window_present after making the widgets visible to
+      // make sure window gets correctly raised and gets focus.
+      x11::Time time = ui::X11EventSource::GetInstance()->GetTimestamp();
+      gtk_window_present_with_time(GTK_WINDOW(dialog_),
+                                   static_cast<uint32_t>(time));
+    }
+#endif
   }
 
   int RunSynchronous() {

--- a/shell/browser/ui/views/menu_bar.cc
+++ b/shell/browser/ui/views/menu_bar.cc
@@ -17,7 +17,7 @@
 #include "ui/views/layout/box_layout.h"
 #include "ui/views/widget/widget.h"
 
-#if defined(USE_X11)
+#if defined(OS_LINUX)
 #include "ui/gtk/gtk_util.h"
 #endif
 
@@ -282,7 +282,7 @@ void MenuBar::ButtonPressed(views::Button* source, const ui::Event& event) {
 void MenuBar::RefreshColorCache() {
   const ui::NativeTheme* theme = GetNativeTheme();
   if (theme) {
-#if defined(USE_X11)
+#if defined(OS_LINUX)
     background_color_ = gtk::GetBgColor("GtkMenuBar#menubar");
     enabled_color_ =
         gtk::GetFgColor("GtkMenuBar#menubar GtkMenuItem#menuitem GtkLabel");
@@ -319,7 +319,7 @@ void MenuBar::UpdateViewColors() {
   // set child colors
   if (menu_model_ == nullptr)
     return;
-#if defined(USE_X11)
+#if defined(OS_LINUX)
   const auto& textColor = has_focus_ ? enabled_color_ : disabled_color_;
   for (auto* child : GetChildrenInZOrder()) {
     auto* button = static_cast<SubmenuButton*>(child);

--- a/shell/browser/ui/views/menu_bar.h
+++ b/shell/browser/ui/views/menu_bar.h
@@ -90,7 +90,7 @@ class MenuBar : public views::AccessiblePaneView,
 
   void RefreshColorCache();
   SkColor background_color_;
-#if defined(USE_X11)
+#if defined(OS_LINUX)
   SkColor enabled_color_;
   SkColor disabled_color_;
 #endif


### PR DESCRIPTION
#### Description of Change

Add initial support for running Electron on Wayland (#10915).

Since version 87, Wayland support is enabled in the default Chromium *build* and can be enabled at *runtime* with a feature flag: `--enable-features=UseOzonePlatform --ozone-platform=wayland` ([chromium#1085700](https://bugs.chromium.org/p/chromium/issues/detail?id=1085700)).

This pull-request attempts to do the same for Electron. This means that the non-Ozone X11 is still the default but Ozone/Wayland and Ozone/X11 can now be chosen *at runtime* using this feature flag:

```
electron --enable-features=UseOzonePlatform --ozone-platform=wayland
```

```
electron --enable-features=UseOzonePlatform --ozone-platform=x11
```

**The Wayland support is very experimental and various features which were working in X11 may either be broken or not implemented for Wayland.** 

Therefore, this pull-request should be seen more like *the minimal amount of changes required to show an Electron window in Wayland* rather than the complete set of changes required to bring full Wayland support to Electron.

##### Build configuration

I'm not familiar with Electron's CI build system but there's a chance it might require some changes to accommodate Wayland support on Linux. If it turns out that's the case I might need some help from someone familiar with these systems.

FWIW, this is the [build tools](https://github.com/electron/build-tools) config that I've used locally to build and test this:

<details>
 <summary>GN gen args</summary>
 
```json
{
  "goma": "cache-only",
  "root": "/home/vially/projects/electron",
  "gen": {
    "args": [
      "import(\"//electron/build/args/testing.gn\")",
      "import(\"/home/vially/.electron_build_tools/third_party/goma.gn\")",
      "blink_symbol_level=0",
      "icu_use_data_file=false",
      "is_component_ffmpeg=false",
      "link_pulseaudio=true",
      "treat_warnings_as_errors=false",
      "use_gnome_keyring=false",
      "use_sysroot=false",
      "use_ozone=true",
      "ozone_auto_platforms=false",
      "ozone_platform_wayland=true",
      "ozone_platform_x11=true",
      "use_system_libwayland=true",
      "use_glib=true",
      "rtc_use_pipewire=true"
    ],
    "out": "Testing"
  },
  "env": {
    "CHROMIUM_BUILDTOOLS_PATH": "/home/vially/projects/electron/src/buildtools",
    "GIT_CACHE_PATH": "/home/vially/.git_cache"
  },
  "remotes": {
    "electron": {
      "origin": "git@github.com:electron/electron.git",
      "hedgepigdaniel": "git@github.com:hedgepigdaniel/electron.git",
      "fork": "git@github.com:vially/electron.git"
    },
    "node": {
      "origin": "git@github.com:electron/node.git"
    }
  }
}
```
</details>


#### Acknowledgements

Thank you @hedgepigdaniel for providing the [set of patches](https://github.com/hedgepigdaniel/electron/commits/arch-10) that this pull-request was based on. Also a big thank you to @msisov, @nickdiego, @tonikitoo and many others from the @Igalia team for adding Wayland support to Chromium.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd (@ckerr @zcbenz)
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none