### PR TITLE
fix: optimized asar paths checks

### DIFF
--- a/lib/asar/fs-wrapper.ts
+++ b/lib/asar/fs-wrapper.ts
@@ -50,7 +50,7 @@ const splitPath = (archivePathOrBuffer: string | Buffer) => {
     archivePath = archivePathOrBuffer.toString();
   }
   if (typeof archivePath !== 'string') return { isAsar: <const>false };
-  if(!asarRe.test(archivePath)) return { isAsar: <const>false };
+  if (!asarRe.test(archivePath)) return { isAsar: <const>false };
 
   return asar.splitPath(path.normalize(archivePath));
 };

--- a/lib/asar/fs-wrapper.ts
+++ b/lib/asar/fs-wrapper.ts
@@ -37,6 +37,8 @@ const getOrCreateArchive = (archivePath: string) => {
   return newArchive;
 };
 
+const asarRe = /\.asar/i;
+
 // Separate asar package's path from full path.
 const splitPath = (archivePathOrBuffer: string | Buffer) => {
   // Shortcut for disabled asar.
@@ -48,6 +50,7 @@ const splitPath = (archivePathOrBuffer: string | Buffer) => {
     archivePath = archivePathOrBuffer.toString();
   }
   if (typeof archivePath !== 'string') return { isAsar: <const>false };
+  if(!asarRe.test(archivePath)) return { isAsar: <const>false };
 
   return asar.splitPath(path.normalize(archivePath));
 };


### PR DESCRIPTION
#### Description of Change

Checking if a path might be inside an asar archive or not is too slow in the current implementation, in the screenshot below I had my app read 50k files from disk, that took about 4.5 seconds and almost 1 entire second was spent just checking if those paths could have been in an asar archive or not.

None of those paths were in fact in asar archives. I think it's pretty common to load many files from outside asar archives for some apps, so this check should be fast.

It might be interesting to note also that depending on how the reading is implement and the OS is configured trying to read a file from disk may result in multiple different attempts to read that file from disk, as when dealing with a large number of files an EMFILE error is likely to be thrown, so the current slow check may actually be performed multiple times for each request.

![image](https://user-images.githubusercontent.com/1812093/96373937-84aa7780-1167-11eb-97b2-e80535707a6e.png)

The suggested quick check for paths that are not inside asar archives runs the following snippet, which does probably an order of magnitude more checks, in an order of magnitude less time, ~60ms in my machine.

```ts
const asarPaths = [];
const noAsarPaths = [];
for ( let i = 0, l = 1000000; i < l; i++ ) {
  asarPaths.push ( '/foo/bar/something.asar/baz.txt' );
  noAsarPaths.push ( '/foo/bar/baz.txt' );
}
const re = /\.asar/i;
console.time ( 'check' );
for ( let i = 0, l = 1000000; i < l; i++ ) {
  re.test ( asarPaths[i] );
  re.test ( noAsarPaths[i] );
}
console.timeEnd ( 'check' );
```

#### Checklist

- [x] PR description included and stakeholders cc'd (I'm not sure who those stakeholders might be, so I'm going to ping @MarshallOfSound here)
- [x] ~~`npm test` passes~~ I didn't actually run the tests because the change in really minimal and I checked things manually, hopefully somebody else who don't need to rebuild Electron from scratch in their machine could run the tests locally if needed.
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none