### PR TITLE
test: disable flaky arm tests

### DIFF
--- a/spec-main/api-service-workers-spec.ts
+++ b/spec-main/api-service-workers-spec.ts
@@ -7,6 +7,7 @@ import { v4 } from 'uuid';
 import { AddressInfo } from 'net';
 import { closeWindow } from './window-helpers';
 import { emittedOnce, emittedNTimes } from './events-helpers';
+import { ifdescribe } from './spec-helpers';
 
 const partition = 'service-workers-spec';
 const uuid = v4();
@@ -65,7 +66,8 @@ describe('session.serviceWorkers', () => {
     });
   });
 
-  describe('getFromVersionID()', () => {
+  // TODO (jkleinsc) - reenable this test once https://github.com/electron/electron/issues/26043 is resolved
+  ifdescribe(!process.arch.includes('arm'))('getFromVersionID()', () => {
     it('should report the correct script url and scope', async () => {
       const eventInfo = await emittedOnce(ses.serviceWorkers, 'console-message', () => w.loadURL(`${baseUrl}/index.html`));
       const details: Electron.MessageDetails = eventInfo[1];

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -1375,7 +1375,8 @@ describe('webContents module', () => {
     }
   });
 
-  describe('did-change-theme-color event', () => {
+  // TODO (jkleinsc) - reenable this test on WOA once https://github.com/electron/electron/issues/26045 is resolved
+  ifdescribe(process.platform !== 'win32' || process.arch !== 'arm64')('did-change-theme-color event', () => {
     afterEach(closeAllWindows);
     it('is triggered with correct theme color', (done) => {
       const w = new BrowserWindow({ show: true });

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -986,7 +986,8 @@ describe('<webview> tag', function () {
     });
   });
 
-  describe('did-change-theme-color event', () => {
+  // TODO (jkleinsc) - reenable this test on WOA once https://github.com/electron/electron/issues/26045 is resolved
+  ifdescribe(process.platform !== 'win32' || process.arch !== 'arm64')('did-change-theme-color event', () => {
     it('emits when theme color changes', async () => {
       loadWebView(webview, {
         src: `file://${fixtures}/pages/theme-color.html`


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Looking at analytics from Azure DevOps there are a couple of tests that are consistently flaky on arm (both Linux and Windows variants).  This PR disables those flakes so that we can get our ARM CI to the point where it can be relied on for PR validation instead of maintainers ignoring it.  

I have logged issues here: #26045 and here #26043 to track the flaky tests.

FWIW flake frequency can be see here:
[Linux armv7 (32 bit arm)](https://github.visualstudio.com/electron/_test/analytics?definitionId=41&contextType=build)
[Linux armv8 (64 bit arm)](https://github.visualstudio.com/electron/_test/analytics?definitionId=40&contextType=build)
[Windows on ARM](https://github.visualstudio.com/electron/_test/analytics?definitionId=48&contextType=build)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
