### PR TITLE
docs: add discord link to docs community page

### DIFF
--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -9,8 +9,12 @@ If you're looking for programming help,
 for answers to questions,
 or to join in discussion with other developers who use Electron,
 you can interact with the community in these locations:
-- [`electron`](https://discuss.atom.io/c/electron) category on the Atom
-forums
+- [`Electron's Discord`](https://discord.com/invite/electron) has channels for:
+  - Getting help
+  - Ecosystem apps like [Electron Forge](https://github.com/electron-userland/electron-forge) and [Electron Fiddle](https://github.com/electron/fiddle)
+  - Sharing ideas with other Electron app developers
+  - And more!
+- [`electron`](https://discuss.atom.io/c/electron) category on the Atom forums
 - `#atom-shell` channel on Freenode
 - `#electron` channel on [Atom's Slack](https://discuss.atom.io/t/join-us-on-slack/16638?source_topic_id=25406)
 - [`electron-ru`](https://telegram.me/electron_ru) *(Russian)*


### PR DESCRIPTION
#### Description of Change

Similar to @erickzhao's https://github.com/electron/electron/pull/25751. 

I know we've rejected at least one other Discord-link-adding PR as redundant (https://github.com/electron/electron/pull/25759); however, I think this one is warranted because we've been linking to `docs/tutorial/support.md` as the clearinghouse for community / help links for a long time now, e.g. in the ["not an issue" issue triage response](https://github.com/electron/governance/blob/master/playbooks/responses/not-an-issue.md).

CC @electron/wg-outreach 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none