### PR TITLE
chore: cherry-pick b977dff8 from freetype

### DIFF
--- a/patches/config.json
+++ b/patches/config.json
@@ -19,5 +19,7 @@
 
   "src/electron/patches/skia": "src/third_party/skia",
 
-  "src/electron/patches/ffmpeg": "src/third_party/ffmpeg"
+  "src/electron/patches/ffmpeg": "src/third_party/ffmpeg",
+
+  "src/electron/patches/freetype": "src/third_party/freetype/src"
 }

--- a/patches/freetype/.patches
+++ b/patches/freetype/.patches
@@ -1,0 +1,1 @@
+test_early_to_prevent_overflow.patch

--- a/patches/freetype/test_early_to_prevent_overflow.patch
+++ b/patches/freetype/test_early_to_prevent_overflow.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrey Belenko <anbelen@microsoft.com>
+Date: Tue, 20 Oct 2020 21:24:11 +0200
+Subject: Test early to prevent overflow.
+
+Bug: chromium:1139963
+
+diff --git a/src/sfnt/pngshim.c b/src/sfnt/pngshim.c
+index 5f80ac2df1fe9e4e9b17383e6eb6c85a5368787e..72bac72a9afb970e7ddf022102384404a22429ba 100644
+--- a/src/sfnt/pngshim.c
++++ b/src/sfnt/pngshim.c
+@@ -328,6 +328,13 @@
+ 
+     if ( populate_map_and_metrics )
+     {
++      /* reject too large bitmaps similarly to the rasterizer */
++      if ( imgWidth > 0x7FFF || imgHeight > 0x7FFF )
++      {
++        error = FT_THROW( Array_Too_Large );
++        goto DestroyExit;
++      }
++
+       metrics->width  = (FT_UShort)imgWidth;
+       metrics->height = (FT_UShort)imgHeight;
+ 
+@@ -336,13 +343,6 @@
+       map->pixel_mode = FT_PIXEL_MODE_BGRA;
+       map->pitch      = (int)( map->width * 4 );
+       map->num_grays  = 256;
+-
+-      /* reject too large bitmaps similarly to the rasterizer */
+-      if ( map->rows > 0x7FFF || map->width > 0x7FFF )
+-      {
+-        error = FT_THROW( Array_Too_Large );
+-        goto DestroyExit;
+-      }
+     }
+ 
+     /* convert palette/gray image to rgb */


### PR DESCRIPTION
Check for overflow.

BUG=chromium:1139963

[Upstream fix](https://chromium.googlesource.com/chromium/src/third_party/freetype2.git/+/b977dff8c99b19d92f10f20c02acfe8101ce4d6f%5E%21/#F0)

Notes: backported fix for CVE-2020-15999