### PR TITLE
chore: make BridgeErrorTarget, NotificationCenterKind enum class

### DIFF
--- a/shell/browser/api/electron_api_system_preferences.h
+++ b/shell/browser/api/electron_api_system_preferences.h
@@ -26,7 +26,7 @@ namespace electron {
 namespace api {
 
 #if defined(OS_MAC)
-enum NotificationCenterKind {
+enum class NotificationCenterKind {
   kNSDistributedNotificationCenter = 0,
   kNSNotificationCenter,
   kNSWorkspaceNotificationCenter,

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -128,7 +128,7 @@ v8::MaybeLocal<v8::Value> GetPrivate(v8::Local<v8::Context> context,
 }
 
 // Where the context bridge should create the exception it is about to throw
-enum BridgeErrorTarget {
+enum class BridgeErrorTarget {
   // The source / calling context.  This is default and correct 99% of the time,
   // the caller / context asking for the conversion will receive the error and
   // therefore the error should be made in that context


### PR DESCRIPTION
#### Description of Change

Inspired by https://github.com/electron/electron/pull/26050 -- I wondered "hmm does any other code need that" and found a couple of instances. Using 'enum class' gives better type safety.

CC @miniak 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none