### PR TITLE
fix: release NSAlert properly

### DIFF
--- a/shell/browser/ui/message_box_mac.mm
+++ b/shell/browser/ui/message_box_mac.mm
@@ -12,6 +12,7 @@
 
 #include "base/callback.h"
 #include "base/mac/mac_util.h"
+#include "base/mac/scoped_nsobject.h"
 #include "base/strings/sys_string_conversions.h"
 #include "shell/browser/native_window.h"
 #include "skia/ext/skia_utils_mac.h"
@@ -94,14 +95,14 @@ NSAlert* CreateNSAlert(const MessageBoxSettings& settings) {
 }  // namespace
 
 int ShowMessageBoxSync(const MessageBoxSettings& settings) {
-  NSAlert* alert = CreateNSAlert(settings);
+  base::scoped_nsobject<NSAlert> alert(CreateNSAlert(settings));
 
   // Use runModal for synchronous alert without parent, since we don't have a
   // window to wait for. Also use it when window is provided but it is not
   // shown as it would be impossible to dismiss the alert if it is connected
   // to invisible window (see #22671).
   if (!settings.parent_window || !settings.parent_window->IsVisible())
-    return [[alert autorelease] runModal];
+    return [alert runModal];
 
   __block int ret_code = -1;
 
@@ -140,6 +141,7 @@ void ShowMessageBox(const MessageBoxSettings& settings,
                   completionHandler:^(NSModalResponse response) {
                     std::move(callback_).Run(
                         response, alert.suppressionButton.state == NSOnState);
+                    [alert release];
                   }];
   }
 }


### PR DESCRIPTION
#### Description of Change

Fix a few cases that leak NSAlert objects.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix memory leak on macOS when using `dialog.showMessageBox` API.