### PR TITLE
build: lint the npm folder

### DIFF
--- a/npm/cli.js
+++ b/npm/cli.js
@@ -1,25 +1,25 @@
 #!/usr/bin/env node
 
-var electron = require('./')
+const electron = require('./');
 
-var proc = require('child_process')
+const proc = require('child_process');
 
-var child = proc.spawn(electron, process.argv.slice(2), { stdio: 'inherit', windowsHide: false })
+const child = proc.spawn(electron, process.argv.slice(2), { stdio: 'inherit', windowsHide: false });
 child.on('close', function (code, signal) {
   if (code === null) {
-    console.error(electron, 'exited with signal', signal)
-    process.exit(1)
+    console.error(electron, 'exited with signal', signal);
+    process.exit(1);
   }
-  process.exit(code)
-})
+  process.exit(code);
+});
 
 const handleTerminationSignal = function (signal) {
   process.on(signal, function signalHandler () {
     if (!child.killed) {
-      child.kill(signal)
+      child.kill(signal);
     }
-  })
-}
+  });
+};
 
-handleTerminationSignal('SIGINT')
-handleTerminationSignal('SIGTERM')
+handleTerminationSignal('SIGINT');
+handleTerminationSignal('SIGTERM');

--- a/npm/index.js
+++ b/npm/index.js
@@ -1,18 +1,18 @@
-var fs = require('fs')
-var path = require('path')
+const fs = require('fs');
+const path = require('path');
 
-var pathFile = path.join(__dirname, 'path.txt')
+const pathFile = path.join(__dirname, 'path.txt');
 
 function getElectronPath () {
   if (fs.existsSync(pathFile)) {
-    var executablePath = fs.readFileSync(pathFile, 'utf-8')
+    const executablePath = fs.readFileSync(pathFile, 'utf-8');
     if (process.env.ELECTRON_OVERRIDE_DIST_PATH) {
-      return path.join(process.env.ELECTRON_OVERRIDE_DIST_PATH, executablePath)
+      return path.join(process.env.ELECTRON_OVERRIDE_DIST_PATH, executablePath);
     }
-    return path.join(__dirname, 'dist', executablePath)
+    return path.join(__dirname, 'dist', executablePath);
   } else {
-    throw new Error('Electron failed to install correctly, please delete node_modules/electron and try installing again')
+    throw new Error('Electron failed to install correctly, please delete node_modules/electron and try installing again');
   }
 }
 
-module.exports = getElectronPath()
+module.exports = getElectronPath();

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,21 +1,21 @@
 #!/usr/bin/env node
 
-const {version} = require('./package')
+const { version } = require('./package');
 
-const fs = require('fs')
-const os = require('os')
-const path = require('path')
-const extract = require('extract-zip')
-const { downloadArtifact } = require('@electron/get')
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const extract = require('extract-zip');
+const { downloadArtifact } = require('@electron/get');
 
 if (process.env.ELECTRON_SKIP_BINARY_DOWNLOAD) {
-  process.exit(0)
+  process.exit(0);
 }
 
-const platformPath = getPlatformPath()
+const platformPath = getPlatformPath();
 
 if (isInstalled()) {
-  process.exit(0)
+  process.exit(0);
 }
 
 // downloads if not cached
@@ -27,57 +27,57 @@ downloadArtifact({
   platform: process.env.npm_config_platform || process.platform,
   arch: process.env.npm_config_arch || process.arch
 }).then(extractFile).catch(err => {
-  console.error(err.stack)
-  process.exit(1)
-})
+  console.error(err.stack);
+  process.exit(1);
+});
 
 function isInstalled () {
   try {
     if (fs.readFileSync(path.join(__dirname, 'dist', 'version'), 'utf-8').replace(/^v/, '') !== version) {
-      return false
+      return false;
     }
 
     if (fs.readFileSync(path.join(__dirname, 'path.txt'), 'utf-8') !== platformPath) {
-      return false
+      return false;
     }
   } catch (ignored) {
-    return false
+    return false;
   }
-  
-  const electronPath = process.env.ELECTRON_OVERRIDE_DIST_PATH || path.join(__dirname, 'dist', platformPath)
-  
-  return fs.existsSync(electronPath)
+
+  const electronPath = process.env.ELECTRON_OVERRIDE_DIST_PATH || path.join(__dirname, 'dist', platformPath);
+
+  return fs.existsSync(electronPath);
 }
 
 // unzips and makes path.txt point at the correct executable
 function extractFile (zipPath) {
   return new Promise((resolve, reject) => {
     extract(zipPath, { dir: path.join(__dirname, 'dist') }, err => {
-      if (err) return reject(err)
+      if (err) return reject(err);
 
       fs.writeFile(path.join(__dirname, 'path.txt'), platformPath, err => {
-        if (err) return reject(err)
+        if (err) return reject(err);
 
-        resolve()
-      })
-    })
-  })
+        resolve();
+      });
+    });
+  });
 }
 
 function getPlatformPath () {
-  const platform = process.env.npm_config_platform || os.platform()
+  const platform = process.env.npm_config_platform || os.platform();
 
   switch (platform) {
     case 'mas':
     case 'darwin':
-      return 'Electron.app/Contents/MacOS/Electron'
+      return 'Electron.app/Contents/MacOS/Electron';
     case 'freebsd':
     case 'openbsd':
     case 'linux':
-      return 'electron'
+      return 'electron';
     case 'win32':
-      return 'electron.exe'
+      return 'electron.exe';
     default:
-      throw new Error('Electron builds are not available on platform: ' + platform)
+      throw new Error('Electron builds are not available on platform: ' + platform);
   }
 }

--- a/script/lint.js
+++ b/script/lint.js
@@ -93,7 +93,7 @@ const LINTERS = [{
   }
 }, {
   key: 'javascript',
-  roots: ['lib', 'spec', 'spec-main', 'script', 'default_app', 'build'],
+  roots: ['build', 'default_app', 'lib', 'npm', 'script', 'spec', 'spec-main'],
   ignoreRoots: ['spec/node_modules', 'spec-main/node_modules'],
   test: filename => filename.endsWith('.js') || filename.endsWith('.ts'),
   run: (opts, filenames) => {


### PR DESCRIPTION
#### Description of Change
The `npm` folder wasn't being linted, added it to linting and fixed up the violations (was just `const` and semicolons). Alphabetized the list of folders to lint because when in doubt, alphabetize.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
