### PR TITLE
fix: disable use of the vm module in the renderer

### DIFF
--- a/lib/common/reset-search-paths.ts
+++ b/lib/common/reset-search-paths.ts
@@ -5,6 +5,18 @@ const Module = require('module');
 // Clear Node's global search paths.
 Module.globalPaths.length = 0;
 
+// We do not want to allow use of the VM module in the renderer process as
+// it conflicts with Blink's V8::Context internal logic.
+if (process.type === 'renderer') {
+  const _load = Module._load;
+  Module._load = function (request: string) {
+    if (request === 'vm') {
+      console.warn('The vm module of Node.js is deprecated in the renderer process and will be removed.');
+    }
+    return _load.apply(this, arguments);
+  };
+}
+
 // Prevent Node from adding paths outside this app to search paths.
 const resourcesPathWithTrailingSlash = process.resourcesPath + path.sep;
 const originalNodeModulePaths = Module._nodeModulePaths;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/25888.
Refs https://github.com/electron/electron/pull/25910#issuecomment-713197726.

Deprecate the use of the `vm` module in the Renderer process - as @nornagon noted, Blink assumes in many places that all Contexts come with a ScriptState, and thus using Node.js' `vm` module in the renderer process is asking for trouble. This adds a deprecation warning for future removal.

cc @nornagon @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Deprecated the use of the `vm` module in the renderer process.
