### PR TITLE
feat: add osProcessId / name properties to webFrameMain

### DIFF
--- a/docs/api/web-frame-main.md
+++ b/docs/api/web-frame-main.md
@@ -122,9 +122,17 @@ content. The identifier is fixed at the creation of the frame and stays
 constant for the lifetime of the frame. When the frame is removed, the id is
 not used again.
 
+#### `frame.name` _Readonly_
+
+A `String` representing the frame name.
+
+#### `frame.osProcessId` _Readonly_
+
+An `Integer` representing the operating system `pid` of the process which owns this frame.
+
 #### `frame.processId` _Readonly_
 
-An `Integer` representing the id of the process which owns this frame.
+An `Integer` representing the Chromium internal `pid` of the process which owns this frame.
 
 #### `frame.routingId` _Readonly_
 

--- a/docs/api/web-frame-main.md
+++ b/docs/api/web-frame-main.md
@@ -133,6 +133,7 @@ An `Integer` representing the operating system `pid` of the process which owns t
 #### `frame.processId` _Readonly_
 
 An `Integer` representing the Chromium internal `pid` of the process which owns this frame.
+This is not the same as the OS process ID; to read that use `frame.osProcessId`.
 
 #### `frame.routingId` _Readonly_
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1591,18 +1591,6 @@ base::ProcessId WebContents::GetOSProcessID() const {
   return base::GetProcId(process_handle);
 }
 
-base::ProcessId WebContents::GetOSProcessIdForFrame(
-    const std::string& name,
-    const std::string& document_url) const {
-  for (auto* frame : web_contents()->GetAllFrames()) {
-    if (frame->GetFrameName() == name &&
-        frame->GetLastCommittedURL().spec() == document_url) {
-      return base::GetProcId(frame->GetProcess()->GetProcess().Handle());
-    }
-  }
-  return base::kNullProcessId;
-}
-
 WebContents::Type WebContents::GetType() const {
   return type_;
 }
@@ -2942,8 +2930,6 @@ v8::Local<v8::ObjectTemplate> WebContents::FillObjectTemplate(
                  &WebContents::SetBackgroundThrottling)
       .SetMethod("getProcessId", &WebContents::GetProcessID)
       .SetMethod("getOSProcessId", &WebContents::GetOSProcessID)
-      .SetMethod("_getOSProcessIdForFrame",
-                 &WebContents::GetOSProcessIdForFrame)
       .SetMethod("equal", &WebContents::Equal)
       .SetMethod("_loadURL", &WebContents::LoadURL)
       .SetMethod("downloadURL", &WebContents::DownloadURL)

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -209,8 +209,6 @@ class WebContents : public gin::Wrappable<WebContents>,
   void SetBackgroundThrottling(bool allowed);
   int GetProcessID() const;
   base::ProcessId GetOSProcessID() const;
-  base::ProcessId GetOSProcessIdForFrame(const std::string& name,
-                                         const std::string& document_url) const;
   Type GetType() const;
   bool Equal(const WebContents* web_contents) const;
   void LoadURL(const GURL& url, const gin_helper::Dictionary& options);

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -120,6 +120,20 @@ int WebFrameMain::FrameTreeNodeID(v8::Isolate* isolate) const {
   return render_frame_->GetFrameTreeNodeId();
 }
 
+std::string WebFrameMain::Name(v8::Isolate* isolate) const {
+  if (!CheckRenderFrame())
+    return std::string();
+  return render_frame_->GetFrameName();
+}
+
+base::ProcessId WebFrameMain::OSProcessID(v8::Isolate* isolate) const {
+  if (!CheckRenderFrame())
+    return -1;
+  base::ProcessHandle process_handle =
+      render_frame_->GetProcess()->GetProcess().Handle();
+  return base::GetProcId(process_handle);
+}
+
 int WebFrameMain::ProcessID(v8::Isolate* isolate) const {
   if (!CheckRenderFrame())
     return -1;
@@ -210,6 +224,8 @@ gin::ObjectTemplateBuilder WebFrameMain::GetObjectTemplateBuilder(
       .SetMethod("executeJavaScript", &WebFrameMain::ExecuteJavaScript)
       .SetMethod("reload", &WebFrameMain::Reload)
       .SetProperty("frameTreeNodeId", &WebFrameMain::FrameTreeNodeID)
+      .SetProperty("name", &WebFrameMain::Name)
+      .SetProperty("osProcessId", &WebFrameMain::OSProcessID)
       .SetProperty("processId", &WebFrameMain::ProcessID)
       .SetProperty("routingId", &WebFrameMain::RoutingID)
       .SetProperty("url", &WebFrameMain::URL)

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "base/process/process.h"
 #include "gin/handle.h"
 #include "gin/wrappable.h"
 
@@ -68,6 +69,8 @@ class WebFrameMain : public gin::Wrappable<WebFrameMain> {
   bool Reload(v8::Isolate* isolate);
 
   int FrameTreeNodeID(v8::Isolate* isolate) const;
+  std::string Name(v8::Isolate* isolate) const;
+  base::ProcessId OSProcessID(v8::Isolate* isolate) const;
   int ProcessID(v8::Isolate* isolate) const;
   int RoutingID(v8::Isolate* isolate) const;
   GURL URL(v8::Isolate* isolate) const;

--- a/spec-main/api-subframe-spec.ts
+++ b/spec-main/api-subframe-spec.ts
@@ -216,7 +216,7 @@ ifdescribe(process.platform !== 'linux')('cross-site frame sandboxing', () => {
         await w.loadURL(serverUrl);
 
         const pidMain = w.webContents.getOSProcessId();
-        const pidFrame = (w.webContents as any)._getOSProcessIdForFrame('frame', crossSiteUrl);
+        const pidFrame = w.webContents.mainFrame.frames.find(f => f.name === 'frame')!.osProcessId;
 
         const metrics = app.getAppMetrics();
         const isProcessSandboxed = function (pid: number) {

--- a/spec-main/api-web-frame-main-spec.ts
+++ b/spec-main/api-web-frame-main-spec.ts
@@ -127,6 +127,8 @@ describe('webFrameMain module', () => {
       await w.loadFile(path.join(subframesPath, 'frame.html'));
       const webFrame = w.webContents.mainFrame;
       expect(webFrame).to.haveOwnProperty('frameTreeNodeId');
+      expect(webFrame).to.haveOwnProperty('name');
+      expect(webFrame).to.haveOwnProperty('osProcessId');
       expect(webFrame).to.haveOwnProperty('processId');
       expect(webFrame).to.haveOwnProperty('routingId');
     });


### PR DESCRIPTION
#### Description of Change
This allows removing the private `w.webContents._getOSProcessIdForFrame` API, which was only used in a test.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `osProcessId` / `name` properties to `webFrameMain`.