### PR TITLE
build: drop use of --typeRoots for default_app

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -184,7 +184,6 @@ target_gen_default_app_js = "$target_gen_dir/js/default_app"
 
 typescript_build("default_app_js") {
   deps = [ ":build_electron_definitions" ]
-  type_root = rebase_path("$target_gen_dir/tsc/electron/typings")
 
   sources = filenames.default_app_ts_sources
 

--- a/build/tsc.gni
+++ b/build/tsc.gni
@@ -26,19 +26,12 @@ template("typescript_build") {
       "//electron/typings/internal-electron.d.ts",
     ]
 
-    type_roots = "node_modules/@types,typings"
-    if (defined(invoker.type_root)) {
-      type_roots += "," + invoker.type_root
-    }
-
     base_out_path = invoker.output_gen_dir + "/electron/"
     args = [
       "-p",
       rebase_path(invoker.tsconfig),
       "--outDir",
       rebase_path("$base_out_path" + invoker.output_dir_name),
-      "--typeRoots",
-      type_roots,
     ]
 
     outputs = []


### PR DESCRIPTION
#### Description of Change
Full disclaimer, I don't know much about GN and the *.gni files.

I bumped into this randomly while debugging a build issue (problem in my source tree).

I believe it's a correct change because:
* `node_modules/@types` is default behavior so it will still be used
* `typings` should be covered by the `include` in `tsconfig.default_app.json`
* `$target_gen_dir/tsc/electron/typings` doesn't exist - I believe this should be `$target_gen_dir/tsc/typings` if it were to have any effect, since I don't see `$target_gen_dir/tsc/electron/typings` existing.


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
