### PR TITLE
fix: setSimpleFullScreen shows traffic lights in frameless window

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1139,7 +1139,8 @@ void NativeWindowMac::SetSimpleFullScreen(bool simple_fullscreen) {
     }
 
     // Restore window controls visibility state
-    const bool window_button_hidden = !window_button_visibility_.value_or(true);
+    const bool window_button_hidden =
+        !window_button_visibility_.value_or(true) || !has_frame();
     [[window standardWindowButton:NSWindowZoomButton]
         setHidden:window_button_hidden];
     [[window standardWindowButton:NSWindowMiniaturizeButton]


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/25613.

Whether or not window controls are hidden is also predicated on framelessness. This fixes that.

cc @zcbenz @jkleinsc 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where frameless windows showed window controls after being in simple fullscreen mode on macOS.
