### PR TITLE
fix: window.open not accepting size values with "px" at the end

### DIFF
--- a/lib/common/parse-features-string.ts
+++ b/lib/common/parse-features-string.ts
@@ -38,7 +38,7 @@ const keysOfTypeNumber = ['top', 'left', ...Object.keys(keysOfTypeNumberCompileT
 type CoercedValue = string | number | boolean;
 function coerce (key: string, value: string): CoercedValue {
   if (keysOfTypeNumber.includes(key)) {
-    return Number(value);
+    return parseInt(value);
   }
 
   switch (value) {

--- a/lib/common/parse-features-string.ts
+++ b/lib/common/parse-features-string.ts
@@ -38,7 +38,7 @@ const keysOfTypeNumber = ['top', 'left', ...Object.keys(keysOfTypeNumberCompileT
 type CoercedValue = string | number | boolean;
 function coerce (key: string, value: string): CoercedValue {
   if (keysOfTypeNumber.includes(key)) {
-    return parseInt(value);
+    return parseInt(value, 10);
   }
 
   switch (value) {


### PR DESCRIPTION
#### Description of Change
Close #26077 , correctly parses "px" at end of size string
#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
notes: Fix `window.open` not accepting size values with "px" at the end.