### PR TITLE
chore: use auto to avoid repeating type

### DIFF
--- a/shell/browser/api/electron_api_debugger.cc
+++ b/shell/browser/api/electron_api_debugger.cc
@@ -54,8 +54,7 @@ void Debugger::DispatchProtocolMessage(DevToolsAgentHost* agent_host,
                                        base::JSON_REPLACE_INVALID_CHARACTERS);
   if (!parsed_message || !parsed_message->is_dict())
     return;
-  base::DictionaryValue* dict =
-      static_cast<base::DictionaryValue*>(parsed_message.get());
+  auto* dict = static_cast<base::DictionaryValue*>(parsed_message.get());
   int id;
   if (!dict->GetInteger("id", &id)) {
     std::string method;

--- a/shell/browser/api/electron_api_download_item.cc
+++ b/shell/browser/api/electron_api_download_item.cc
@@ -77,7 +77,7 @@ gin::WrapperInfo DownloadItem::kWrapperInfo = {gin::kEmbedderNativeGin};
 DownloadItem* DownloadItem::FromDownloadItem(
     download::DownloadItem* download_item) {
   // ^- say that 7 times fast in a row
-  UserDataLink* data = static_cast<UserDataLink*>(
+  auto* data = static_cast<UserDataLink*>(
       download_item->GetUserData(kElectronApiDownloadItemKey));
   return data ? data->download_item.get() : nullptr;
 }

--- a/shell/browser/api/electron_api_power_monitor_win.cc
+++ b/shell/browser/api/electron_api_power_monitor_win.cc
@@ -58,7 +58,7 @@ LRESULT CALLBACK PowerMonitor::WndProcStatic(HWND hwnd,
                                              UINT message,
                                              WPARAM wparam,
                                              LPARAM lparam) {
-  PowerMonitor* msg_wnd =
+  auto* msg_wnd =
       reinterpret_cast<PowerMonitor*>(GetWindowLongPtr(hwnd, GWLP_USERDATA));
   if (msg_wnd)
     return msg_wnd->WndProc(hwnd, message, wparam, lparam);

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -1039,7 +1039,7 @@ bool Session::RemoveWordFromSpellCheckerDictionary(const std::string& word) {
 
 // static
 Session* Session::FromBrowserContext(content::BrowserContext* context) {
-  UserDataLink* data =
+  auto* data =
       static_cast<UserDataLink*>(context->GetUserData(kElectronApiSessionKey));
   return data ? data->session : nullptr;
 }

--- a/shell/browser/api/electron_api_system_preferences_win.cc
+++ b/shell/browser/api/electron_api_system_preferences_win.cc
@@ -218,7 +218,7 @@ LRESULT CALLBACK SystemPreferences::WndProcStatic(HWND hwnd,
                                                   UINT message,
                                                   WPARAM wparam,
                                                   LPARAM lparam) {
-  SystemPreferences* msg_wnd = reinterpret_cast<SystemPreferences*>(
+  auto* msg_wnd = reinterpret_cast<SystemPreferences*>(
       GetWindowLongPtr(hwnd, GWLP_USERDATA));
   if (msg_wnd)
     return msg_wnd->WndProc(hwnd, message, wparam, lparam);

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3096,7 +3096,7 @@ gin::Handle<WebContents> WebContents::CreateAndTake(
 WebContents* WebContents::From(content::WebContents* web_contents) {
   if (!web_contents)
     return nullptr;
-  UserDataLink* data = static_cast<UserDataLink*>(
+  auto* data = static_cast<UserDataLink*>(
       web_contents->GetUserData(kElectronApiWebContentsKey));
   return data ? data->web_contents.get() : nullptr;
 }

--- a/shell/browser/api/process_metric.cc
+++ b/shell/browser/api/process_metric.cc
@@ -105,7 +105,7 @@ ProcessIntegrityLevel ProcessMetric::GetIntegrityLevel() const {
   }
 
   auto token_label_bytes = std::make_unique<char[]>(token_info_length);
-  TOKEN_MANDATORY_LABEL* token_label =
+  auto* token_label =
       reinterpret_cast<TOKEN_MANDATORY_LABEL*>(token_label_bytes.get());
   if (!::GetTokenInformation(token, TokenIntegrityLevel, token_label,
                              token_info_length, &token_info_length)) {

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -922,7 +922,7 @@ ElectronBrowserClient::CreateWindowForPictureInPicture(
 #if defined(OS_WIN)
   base::string16 app_user_model_id = Browser::Get()->GetAppUserModelID();
   if (!app_user_model_id.empty()) {
-    OverlayWindowViews* overlay_window_view =
+    auto* overlay_window_view =
         static_cast<OverlayWindowViews*>(overlay_window.get());
     ui::win::SetAppIdForWindow(app_user_model_id,
                                overlay_window_view->GetNativeWindow()

--- a/shell/browser/electron_download_manager_delegate.cc
+++ b/shell/browser/electron_download_manager_delegate.cc
@@ -153,9 +153,8 @@ void ElectronDownloadManagerDelegate::OnDownloadSaveDialogDone(
   if (!canceled) {
     if (result.Get("filePath", &path)) {
       // Remember the last selected download directory.
-      ElectronBrowserContext* browser_context =
-          static_cast<ElectronBrowserContext*>(
-              download_manager_->GetBrowserContext());
+      auto* browser_context = static_cast<ElectronBrowserContext*>(
+          download_manager_->GetBrowserContext());
       browser_context->prefs()->SetFilePath(prefs::kDownloadDefaultDirectory,
                                             path.DirName());
 
@@ -211,9 +210,8 @@ bool ElectronDownloadManagerDelegate::DetermineDownloadTarget(
     return true;
   }
 
-  ElectronBrowserContext* browser_context =
-      static_cast<ElectronBrowserContext*>(
-          download_manager_->GetBrowserContext());
+  auto* browser_context = static_cast<ElectronBrowserContext*>(
+      download_manager_->GetBrowserContext());
   base::FilePath default_download_path =
       browser_context->prefs()->GetFilePath(prefs::kDownloadDefaultDirectory);
 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1384,8 +1384,7 @@ void NativeWindowViews::OnWidgetBoundsChanged(views::Widget* changed_widget,
     int width_delta = new_bounds.width() - widget_size_.width();
     int height_delta = new_bounds.height() - widget_size_.height();
     for (NativeBrowserView* item : browser_views()) {
-      NativeBrowserViewViews* native_view =
-          static_cast<NativeBrowserViewViews*>(item);
+      auto* native_view = static_cast<NativeBrowserViewViews*>(item);
       native_view->SetAutoResizeProportions(widget_size_);
       native_view->AutoResize(new_bounds, width_delta, height_delta);
     }
@@ -1453,7 +1452,7 @@ bool NativeWindowViews::ShouldDescendIntoChildForEventHandling(
 
   // And the events on border for dragging resizable frameless window.
   if (!has_frame() && CanResize()) {
-    FramelessView* frame =
+    auto* frame =
         static_cast<FramelessView*>(widget()->non_client_view()->frame_view());
     return frame->ResizingBorderHitTest(location) == HTNOWHERE;
   }

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -397,7 +397,7 @@ LRESULT CALLBACK NativeWindowViews::SubclassProc(HWND hwnd,
                                                  LPARAM l_param,
                                                  UINT_PTR subclass_id,
                                                  DWORD_PTR ref_data) {
-  NativeWindowViews* window = reinterpret_cast<NativeWindowViews*>(ref_data);
+  auto* window = reinterpret_cast<NativeWindowViews*>(ref_data);
   switch (msg) {
     case WM_MOUSELEAVE: {
       // When input is forwarded to underlying windows, this message is posted.

--- a/shell/browser/notifications/platform_notification_service.cc
+++ b/shell/browser/notifications/platform_notification_service.cc
@@ -96,8 +96,7 @@ void PlatformNotificationService::DisplayNotification(
   // See: https://notifications.spec.whatwg.org/#showing-a-notification
   presenter->CloseNotificationWithId(notification_id);
 
-  NotificationDelegateImpl* delegate =
-      new NotificationDelegateImpl(notification_id);
+  auto* delegate = new NotificationDelegateImpl(notification_id);
 
   auto notification = presenter->CreateNotification(delegate, notification_id);
   if (notification) {

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -382,8 +382,7 @@ void OffScreenRenderWidgetHostView::TakeFallbackContentFrom(
     content::RenderWidgetHostView* view) {
   DCHECK(!static_cast<content::RenderWidgetHostViewBase*>(view)
               ->IsRenderWidgetHostViewChildFrame());
-  OffScreenRenderWidgetHostView* view_osr =
-      static_cast<OffScreenRenderWidgetHostView*>(view);
+  auto* view_osr = static_cast<OffScreenRenderWidgetHostView*>(view);
   SetBackgroundColor(view_osr->background_color_);
   if (GetDelegatedFrameHost() && view_osr->GetDelegatedFrameHost()) {
     GetDelegatedFrameHost()->TakeFallbackContentFrom(

--- a/shell/browser/osr/osr_web_contents_view.cc
+++ b/shell/browser/osr/osr_web_contents_view.cc
@@ -126,15 +126,13 @@ OffScreenWebContentsView::CreateViewForWidget(
 content::RenderWidgetHostViewBase*
 OffScreenWebContentsView::CreateViewForChildWidget(
     content::RenderWidgetHost* render_widget_host) {
-  content::WebContentsImpl* web_contents_impl =
+  auto* web_contents_impl =
       static_cast<content::WebContentsImpl*>(web_contents_);
 
-  OffScreenRenderWidgetHostView* view =
-      static_cast<OffScreenRenderWidgetHostView*>(
-          web_contents_impl->GetOuterWebContents()
-              ? web_contents_impl->GetOuterWebContents()
-                    ->GetRenderWidgetHostView()
-              : web_contents_impl->GetRenderWidgetHostView());
+  auto* view = static_cast<OffScreenRenderWidgetHostView*>(
+      web_contents_impl->GetOuterWebContents()
+          ? web_contents_impl->GetOuterWebContents()->GetRenderWidgetHostView()
+          : web_contents_impl->GetRenderWidgetHostView());
 
   return new OffScreenRenderWidgetHostView(transparent_, painting_,
                                            view->GetFrameRate(), callback_,

--- a/shell/browser/serial/serial_chooser_context.cc
+++ b/shell/browser/serial/serial_chooser_context.cc
@@ -44,7 +44,7 @@ base::UnguessableToken DecodeToken(base::StringPiece input) {
     return base::UnguessableToken();
   }
 
-  const uint64_t* data = reinterpret_cast<const uint64_t*>(buffer.data());
+  const auto* data = reinterpret_cast<const uint64_t*>(buffer.data());
   return base::UnguessableToken::Deserialize(data[0], data[1]);
 }
 

--- a/shell/browser/ui/views/autofill_popup_view.cc
+++ b/shell/browser/ui/views/autofill_popup_view.cc
@@ -73,7 +73,7 @@ void AutofillPopupView::Show() {
     // The widget is destroyed by the corresponding NativeWidget, so we use
     // a weak pointer to hold the reference and don't have to worry about
     // deletion.
-    views::Widget* widget = new views::Widget;
+    auto* widget = new views::Widget;
     views::Widget::InitParams params(views::Widget::InitParams::TYPE_POPUP);
     params.delegate = this;
     params.parent = parent_widget_->GetNativeView();

--- a/shell/browser/ui/views/inspectable_web_contents_view_views.cc
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.cc
@@ -89,7 +89,7 @@ InspectableWebContentsViewViews::InspectableWebContentsViewViews(
       title_(base::ASCIIToUTF16("Developer Tools")) {
   if (!inspectable_web_contents_->IsGuest() &&
       inspectable_web_contents_->GetWebContents()->GetNativeView()) {
-    views::WebView* contents_web_view = new views::WebView(nullptr);
+    auto* contents_web_view = new views::WebView(nullptr);
     contents_web_view->SetWebContents(
         inspectable_web_contents_->GetWebContents());
     contents_web_view_ = contents_web_view;

--- a/shell/browser/ui/views/menu_bar.cc
+++ b/shell/browser/ui/views/menu_bar.cc
@@ -272,7 +272,7 @@ void MenuBar::ButtonPressed(views::Button* source, const ui::Event& event) {
   }
 
   // Deleted in MenuDelegate::OnMenuClosed
-  MenuDelegate* menu_delegate = new MenuDelegate(this);
+  auto* menu_delegate = new MenuDelegate(this);
   menu_delegate->RunMenu(
       menu_model_->GetSubmenuModelAt(id), source,
       event.IsKeyEvent() ? ui::MENU_SOURCE_KEYBOARD : ui::MENU_SOURCE_MOUSE);

--- a/shell/browser/ui/views/menu_delegate.cc
+++ b/shell/browser/ui/views/menu_delegate.cc
@@ -39,7 +39,7 @@ void MenuDelegate::RunMenu(ElectronMenuModel* model,
   id_ = button->tag();
   adapter_ = std::make_unique<MenuModelAdapter>(model);
 
-  views::MenuItemView* item = new views::MenuItemView(this);
+  auto* item = new views::MenuItemView(this);
   static_cast<MenuModelAdapter*>(adapter_.get())->BuildMenu(item);
 
   menu_runner_ = std::make_unique<views::MenuRunner>(

--- a/shell/browser/ui/win/notify_icon_host.cc
+++ b/shell/browser/ui/win/notify_icon_host.cc
@@ -89,7 +89,7 @@ NotifyIcon* NotifyIconHost::CreateNotifyIcon(base::Optional<UUID> guid) {
   if (guid.has_value()) {
     for (NotifyIcons::const_iterator i(notify_icons_.begin());
          i != notify_icons_.end(); ++i) {
-      NotifyIcon* current_win_icon = static_cast<NotifyIcon*>(*i);
+      auto* current_win_icon = static_cast<NotifyIcon*>(*i);
       if (current_win_icon->guid() == guid.value()) {
         LOG(WARNING)
             << "Guid already in use. Existing tray entry will be replaced.";
@@ -97,7 +97,7 @@ NotifyIcon* NotifyIconHost::CreateNotifyIcon(base::Optional<UUID> guid) {
     }
   }
 
-  NotifyIcon* notify_icon =
+  auto* notify_icon =
       new NotifyIcon(this, NextIconId(), window_, kNotifyIconMessage,
                      guid.has_value() ? guid.value() : GUID_DEFAULT);
 
@@ -121,7 +121,7 @@ LRESULT CALLBACK NotifyIconHost::WndProcStatic(HWND hwnd,
                                                UINT message,
                                                WPARAM wparam,
                                                LPARAM lparam) {
-  NotifyIconHost* msg_wnd =
+  auto* msg_wnd =
       reinterpret_cast<NotifyIconHost*>(GetWindowLongPtr(hwnd, GWLP_USERDATA));
   if (msg_wnd)
     return msg_wnd->WndProc(hwnd, message, wparam, lparam);
@@ -137,7 +137,7 @@ LRESULT CALLBACK NotifyIconHost::WndProc(HWND hwnd,
     // We need to reset all of our icons because the taskbar went away.
     for (NotifyIcons::const_iterator i(notify_icons_.begin());
          i != notify_icons_.end(); ++i) {
-      NotifyIcon* win_icon = static_cast<NotifyIcon*>(*i);
+      auto* win_icon = static_cast<NotifyIcon*>(*i);
       win_icon->ResetIcon();
     }
     return TRUE;
@@ -147,7 +147,7 @@ LRESULT CALLBACK NotifyIconHost::WndProc(HWND hwnd,
     // Find the selected status icon.
     for (NotifyIcons::const_iterator i(notify_icons_.begin());
          i != notify_icons_.end(); ++i) {
-      NotifyIcon* current_win_icon = static_cast<NotifyIcon*>(*i);
+      auto* current_win_icon = static_cast<NotifyIcon*>(*i);
       if (current_win_icon->icon_id() == wparam) {
         win_icon = current_win_icon;
         break;

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -108,7 +108,7 @@ void ElectronBindings::ActivateUVLoop(v8::Isolate* isolate) {
 
 // static
 void ElectronBindings::OnCallNextTick(uv_async_t* handle) {
-  ElectronBindings* self = static_cast<ElectronBindings*>(handle->data);
+  auto* self = static_cast<ElectronBindings*>(handle->data);
   for (std::list<node::Environment*>::const_iterator it =
            self->pending_next_ticks_.begin();
        it != self->pending_next_ticks_.end(); ++it) {

--- a/shell/common/gin_helper/callback.cc
+++ b/shell/common/gin_helper/callback.cc
@@ -55,7 +55,7 @@ void CallTranslater(v8::Local<v8::External> external,
     }
   }
 
-  TranslaterHolder* holder = static_cast<TranslaterHolder*>(external->Value());
+  auto* holder = static_cast<TranslaterHolder*>(external->Value());
   holder->translater.Run(args);
 
   // Free immediately for one-time callback.

--- a/shell/common/gin_helper/wrappable.cc
+++ b/shell/common/gin_helper/wrappable.cc
@@ -64,8 +64,7 @@ void WrappableBase::InitWith(v8::Isolate* isolate,
 // static
 void WrappableBase::FirstWeakCallback(
     const v8::WeakCallbackInfo<WrappableBase>& data) {
-  WrappableBase* wrappable =
-      static_cast<WrappableBase*>(data.GetInternalField(0));
+  auto* wrappable = static_cast<WrappableBase*>(data.GetInternalField(0));
   if (wrappable) {
     wrappable->wrapper_.Reset();
     data.SetSecondPassCallback(SecondWeakCallback);
@@ -75,8 +74,7 @@ void WrappableBase::FirstWeakCallback(
 // static
 void WrappableBase::SecondWeakCallback(
     const v8::WeakCallbackInfo<WrappableBase>& data) {
-  WrappableBase* wrappable =
-      static_cast<WrappableBase*>(data.GetInternalField(0));
+  auto* wrappable = static_cast<WrappableBase*>(data.GetInternalField(0));
   if (wrappable)
     delete wrappable;
 }

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -560,7 +560,7 @@ void NodeBindings::WakeupEmbedThread() {
 
 // static
 void NodeBindings::EmbedThreadRunner(void* arg) {
-  NodeBindings* self = static_cast<NodeBindings*>(arg);
+  auto* self = static_cast<NodeBindings*>(arg);
 
   while (true) {
     // Wait for the main loop to deal with events.

--- a/shell/common/skia_util.cc
+++ b/shell/common/skia_util.cc
@@ -128,7 +128,7 @@ bool AddImageSkiaRepFromPath(gfx::ImageSkia* image,
       return false;
   }
 
-  const unsigned char* data =
+  const auto* data =
       reinterpret_cast<const unsigned char*>(file_contents.data());
   size_t size = file_contents.size();
 


### PR DESCRIPTION
#### Description of Change
Another `clang-tidy` suggestion. Use `auto` when the type is already specified elsewhere in the statement.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
