### PR TITLE
fix: ensure object is not used after move

### DIFF
--- a/shell/browser/net/electron_url_loader_factory.cc
+++ b/shell/browser/net/electron_url_loader_factory.cc
@@ -549,9 +549,10 @@ void ElectronURLLoaderFactory::SendContents(
   write_data->data = std::move(data);
   write_data->producer =
       std::make_unique<mojo::DataPipeProducer>(std::move(producer));
+  auto* producer_ptr = write_data->producer.get();
 
   base::StringPiece string_piece(write_data->data);
-  write_data->producer->Write(
+  producer_ptr->Write(
       std::make_unique<mojo::StringDataSource>(
           string_piece, mojo::StringDataSource::AsyncWritingMode::
                             STRING_STAYS_VALID_UNTIL_COMPLETION),


### PR DESCRIPTION
#### Description of Change
From `clang-tidy`:

```
electron/shell/browser/net/electron_url_loader_factory.cc:554:3: warning: 'write_data' used after it was moved [bugprone-use-after-move]
  write_data->producer->Write(
  ^
electron/shell/browser/net/electron_url_loader_factory.cc:558:7: note: move occurred here
      base::BindOnce(OnWrite, std::move(write_data)));
      ^
electron/shell/browser/net/electron_url_loader_factory.cc:554:3: note: the use and move are unsequenced, i.e. there is no guarantee about the order in which they are evaluated
  write_data->producer->Write(
  ^
```

I think the change is a bit clunky, but it does fix the potential order of evaluation issue. Suggestions for more elegant alternatives welcome.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
