### PR TITLE
fix: re-enable the spellchecker when new language list set

### DIFF
--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -957,6 +957,9 @@ void Session::SetSpellCheckerLanguages(
   }
   browser_context_->prefs()->Set(spellcheck::prefs::kSpellCheckDictionaries,
                                  language_codes);
+  // Enable spellcheck if > 0 languages, disable if no languages set
+  browser_context_->prefs()->SetBoolean(spellcheck::prefs::kSpellCheckEnable,
+                                        !languages.empty());
 }
 
 void SetSpellCheckerDictionaryDownloadURL(gin_helper::ErrorThrower thrower,

--- a/spec-main/spec-helpers.ts
+++ b/spec-main/spec-helpers.ts
@@ -2,9 +2,19 @@ import * as childProcess from 'child_process';
 import * as path from 'path';
 import * as http from 'http';
 import * as v8 from 'v8';
+import { SuiteFunction, TestFunction } from 'mocha';
 
-export const ifit = (condition: boolean) => (condition ? it : it.skip);
-export const ifdescribe = (condition: boolean) => (condition ? describe : describe.skip);
+const addOnly = <T>(fn: Function): T => {
+  const wrapped = (...args: any[]) => {
+    return fn(...args);
+  }
+  (wrapped as any).only = wrapped;
+  (wrapped as any).skip = wrapped;
+  return wrapped as any;
+};
+
+export const ifit = (condition: boolean) => (condition ? it : addOnly<TestFunction>(it.skip));
+export const ifdescribe = (condition: boolean) => (condition ? describe : addOnly<SuiteFunction>(describe.skip))
 
 export const delay = (time: number = 0) => new Promise(resolve => setTimeout(resolve, time));
 

--- a/spec-main/spec-helpers.ts
+++ b/spec-main/spec-helpers.ts
@@ -7,14 +7,14 @@ import { SuiteFunction, TestFunction } from 'mocha';
 const addOnly = <T>(fn: Function): T => {
   const wrapped = (...args: any[]) => {
     return fn(...args);
-  }
+  };
   (wrapped as any).only = wrapped;
   (wrapped as any).skip = wrapped;
   return wrapped as any;
 };
 
 export const ifit = (condition: boolean) => (condition ? it : addOnly<TestFunction>(it.skip));
-export const ifdescribe = (condition: boolean) => (condition ? describe : addOnly<SuiteFunction>(describe.skip))
+export const ifdescribe = (condition: boolean) => (condition ? describe : addOnly<SuiteFunction>(describe.skip));
 
 export const delay = (time: number = 0) => new Promise(resolve => setTimeout(resolve, time));
 


### PR DESCRIPTION
Chromium recently added prefs logic to disable the spellchecker if the list of languages is empty, but the logic to re-enable if the languages are provided again lives in another part of Chromium.  This change makes it so our API re-enables the spellchecker correctly when required.

Refs: https://chromium-review.googlesource.com/c/chromium/src/+/2390300

Notes: Fixed issue where setting the spellchecker languages to an empty array would permanently disable the spellchecker till the end of time