### PR TITLE
fix: re-enable the spellchecker when new language list set

### DIFF
--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -847,6 +847,9 @@ void Session::SetSpellCheckerLanguages(
   }
   browser_context_->prefs()->Set(spellcheck::prefs::kSpellCheckDictionaries,
                                  language_codes);
+  // Enable spellcheck if > 0 languages, disable if no languages set
+  browser_context_->prefs()->SetBoolean(spellcheck::prefs::kSpellCheckEnable,
+                                        !languages.empty());
 }
 
 void SetSpellCheckerDictionaryDownloadURL(gin_helper::ErrorThrower thrower,

--- a/spec-main/spec-helpers.ts
+++ b/spec-main/spec-helpers.ts
@@ -2,9 +2,19 @@ import * as childProcess from 'child_process';
 import * as path from 'path';
 import * as http from 'http';
 import * as v8 from 'v8';
+import { SuiteFunction, TestFunction } from 'mocha';
 
-export const ifit = (condition: boolean) => (condition ? it : it.skip);
-export const ifdescribe = (condition: boolean) => (condition ? describe : describe.skip);
+const addOnly = <T>(fn: Function): T => {
+  const wrapped = (...args: any[]) => {
+    return fn(...args);
+  };
+  (wrapped as any).only = wrapped;
+  (wrapped as any).skip = wrapped;
+  return wrapped as any;
+};
+
+export const ifit = (condition: boolean) => (condition ? it : addOnly<TestFunction>(it.skip));
+export const ifdescribe = (condition: boolean) => (condition ? describe : addOnly<SuiteFunction>(describe.skip));
 
 export const delay = (time: number = 0) => new Promise(resolve => setTimeout(resolve, time));
 

--- a/spec-main/spellchecker-spec.ts
+++ b/spec-main/spellchecker-spec.ts
@@ -13,8 +13,12 @@ ifdescribe(features.isBuiltinSpellCheckerEnabled())('spellchecker', () => {
 
   beforeEach(async () => {
     w = new BrowserWindow({
-      show: false
+      show: false,
+      webPreferences: {
+        partition: `unique-spell-${Date.now()}`
+      }
     });
+    w.webContents.session.setSpellCheckerLanguages(['en-US']);
     await w.loadFile(path.resolve(__dirname, './fixtures/chromium/spellchecker.html'));
   });
 
@@ -46,6 +50,26 @@ ifdescribe(features.isBuiltinSpellCheckerEnabled())('spellchecker', () => {
   });
 
   ifit(shouldRun)('should detect incorrectly spelled words as incorrect', async () => {
+    await w.webContents.executeJavaScript('document.body.querySelector("textarea").value = "Beautifulllll asd asd"');
+    await w.webContents.executeJavaScript('document.body.querySelector("textarea").focus()');
+    const contextMenuPromise = emittedOnce(w.webContents, 'context-menu');
+    // Wait for spellchecker to load
+    await delay(500);
+    w.webContents.sendInputEvent({
+      type: 'mouseDown',
+      button: 'right',
+      x: 43,
+      y: 42
+    });
+    const contextMenuParams: Electron.ContextMenuParams = (await contextMenuPromise)[1];
+    expect(contextMenuParams.misspelledWord).to.eq('Beautifulllll');
+    expect(contextMenuParams.dictionarySuggestions).to.have.length.of.at.least(1);
+  });
+
+  ifit(shouldRun)('should detect incorrectly spelled words as incorrect after disabling all languages and re-enabling', async () => {
+    w.webContents.session.setSpellCheckerLanguages([]);
+    await delay(500);
+    w.webContents.session.setSpellCheckerLanguages(['en-US']);
     await w.webContents.executeJavaScript('document.body.querySelector("textarea").value = "Beautifulllll asd asd"');
     await w.webContents.executeJavaScript('document.body.querySelector("textarea").focus()');
     const contextMenuPromise = emittedOnce(w.webContents, 'context-menu');


### PR DESCRIPTION
Backport of #26119

See that PR for details.

Notes: Fixed issue where setting the spellchecker languages to an empty array would permanently disable the spellchecker till the end of time