### PR TITLE
fix: Don't sort the headers of ClientRequest

### DIFF
--- a/shell/browser/api/electron_api_url_loader.cc
+++ b/shell/browser/api/electron_api_url_loader.cc
@@ -378,7 +378,7 @@ gin::Handle<SimpleURLLoaderWrapper> SimpleURLLoaderWrapper::Create(
   opts.Get("referrer", &request->referrer);
   bool credentials_specified =
       opts.Get("credentials", &request->credentials_mode);
-  std::map<std::string, std::string> extra_headers;
+  std::vector<std::pair<std::string, std::string>> extra_headers;
   if (opts.Get("extraHeaders", &extra_headers)) {
     for (const auto& it : extra_headers) {
       if (!net::HttpUtil::IsValidHeaderName(it.first) ||

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -537,6 +537,27 @@ describe('net module', () => {
       await collectStreamBody(response);
     });
 
+    it('should keep the order of headers', async () => {
+      const customHeaderNameA = 'X-Header-100';
+      const customHeaderNameB = 'X-Header-200';
+      const serverUrl = await respondOnce.toSingleURL((request, response) => {
+        const headerNames = Array.from(Object.keys(request.headers));
+        const headerAIndex = headerNames.indexOf(customHeaderNameA.toLowerCase());
+        const headerBIndex = headerNames.indexOf(customHeaderNameB.toLowerCase());
+        expect(headerBIndex).to.be.below(headerAIndex);
+        response.statusCode = 200;
+        response.statusMessage = 'OK';
+        response.end();
+      });
+
+      const urlRequest = net.request(serverUrl);
+      urlRequest.setHeader(customHeaderNameB, 'b');
+      urlRequest.setHeader(customHeaderNameA, 'a');
+      const response = await getResponse(urlRequest);
+      expect(response.statusCode).to.equal(200);
+      await collectStreamBody(response);
+    });
+
     it('should be able to set cookie header line', async () => {
       const cookieHeaderName = 'Cookie';
       const cookieHeaderValue = 'test=12345';


### PR DESCRIPTION
#### Description of Change
This pull request make net.request to keep the order of headers for the request.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix: Don't sort the headers of ClientRequest
