### PR TITLE
feat: allow setting the Origin header and Sec-Fetch-* headers in net.request()

### DIFF
--- a/docs/api/client-request.md
+++ b/docs/api/client-request.md
@@ -47,6 +47,7 @@ following properties:
     be aborted. When mode is `manual` the redirection will be cancelled unless
     [`request.followRedirect`](#requestfollowredirect) is invoked synchronously
     during the [`redirect`](#event-redirect) event.  Defaults to `follow`.
+  * `origin` String (optional) - The origin URL of the request.
 
 `options` properties such as `protocol`, `host`, `hostname`, `port` and `path`
 strictly follow the Node.js model as described in the

--- a/lib/browser/api/net.ts
+++ b/lib/browser/api/net.ts
@@ -256,7 +256,8 @@ function parseOptions (optionsIn: ClientRequestConstructorOptions | string): Nod
     headers: {},
     body: null as any,
     useSessionCookies: options.useSessionCookies,
-    credentials: options.credentials
+    credentials: options.credentials,
+    origin: options.origin
   };
   const headers: Record<string, string | string[]> = options.headers || {};
   for (const [name, value] of Object.entries(headers)) {
@@ -414,6 +415,7 @@ export class ClientRequest extends Writable implements Electron.ClientRequest {
       return ret;
     };
     this._urlLoaderOptions.referrer = this.getHeader('referer') || '';
+    this._urlLoaderOptions.origin = this._urlLoaderOptions.origin || this.getHeader('origin') || '';
     const opts = { ...this._urlLoaderOptions, extraHeaders: stringifyValues(this._urlLoaderOptions.headers) };
     this._urlLoader = createURLLoader(opts);
     this._urlLoader.on('response-started', (event, finalUrl, responseHead) => {

--- a/lib/browser/api/net.ts
+++ b/lib/browser/api/net.ts
@@ -416,6 +416,7 @@ export class ClientRequest extends Writable implements Electron.ClientRequest {
     };
     this._urlLoaderOptions.referrer = this.getHeader('referer') || '';
     this._urlLoaderOptions.origin = this._urlLoaderOptions.origin || this.getHeader('origin') || '';
+    this._urlLoaderOptions.hasUserActivation = this.getHeader('sec-fetch-user') === '?1';
     const opts = { ...this._urlLoaderOptions, extraHeaders: stringifyValues(this._urlLoaderOptions.headers) };
     this._urlLoader = createURLLoader(opts);
     this._urlLoader.on('response-started', (event, finalUrl, responseHead) => {

--- a/lib/browser/api/net.ts
+++ b/lib/browser/api/net.ts
@@ -417,6 +417,7 @@ export class ClientRequest extends Writable implements Electron.ClientRequest {
     this._urlLoaderOptions.referrer = this.getHeader('referer') || '';
     this._urlLoaderOptions.origin = this._urlLoaderOptions.origin || this.getHeader('origin') || '';
     this._urlLoaderOptions.hasUserActivation = this.getHeader('sec-fetch-user') === '?1';
+    this._urlLoaderOptions.mode = this.getHeader('sec-fetch-mode') || '';
     const opts = { ...this._urlLoaderOptions, extraHeaders: stringifyValues(this._urlLoaderOptions.headers) };
     this._urlLoader = createURLLoader(opts);
     this._urlLoader.on('response-started', (event, finalUrl, responseHead) => {

--- a/lib/browser/api/net.ts
+++ b/lib/browser/api/net.ts
@@ -418,6 +418,7 @@ export class ClientRequest extends Writable implements Electron.ClientRequest {
     this._urlLoaderOptions.origin = this._urlLoaderOptions.origin || this.getHeader('origin') || '';
     this._urlLoaderOptions.hasUserActivation = this.getHeader('sec-fetch-user') === '?1';
     this._urlLoaderOptions.mode = this.getHeader('sec-fetch-mode') || '';
+    this._urlLoaderOptions.destination = this.getHeader('sec-fetch-dest') || '';
     const opts = { ...this._urlLoaderOptions, extraHeaders: stringifyValues(this._urlLoaderOptions.headers) };
     this._urlLoader = createURLLoader(opts);
     this._urlLoader.on('response-started', (event, finalUrl, responseHead) => {

--- a/shell/browser/api/electron_api_url_loader.cc
+++ b/shell/browser/api/electron_api_url_loader.cc
@@ -381,6 +381,11 @@ gin::Handle<SimpleURLLoaderWrapper> SimpleURLLoaderWrapper::Create(
   if (!origin.empty()) {
     request->request_initiator = url::Origin::Create(GURL(origin));
   }
+  bool has_user_activation;
+  if (opts.Get("hasUserActivation", &has_user_activation)) {
+    request->trusted_params = network::ResourceRequest::TrustedParams();
+    request->trusted_params->has_user_activation = has_user_activation;
+  }
 
   bool credentials_specified =
       opts.Get("credentials", &request->credentials_mode);

--- a/shell/browser/api/electron_api_url_loader.cc
+++ b/shell/browser/api/electron_api_url_loader.cc
@@ -400,6 +400,51 @@ gin::Handle<SimpleURLLoaderWrapper> SimpleURLLoaderWrapper::Create(
     }
   }
 
+  std::string destination;
+  if (opts.Get("destination", &destination) && !destination.empty()) {
+    if (destination == "empty") {
+      request->destination = network::mojom::RequestDestination::kEmpty;
+    } else if (destination == "audio") {
+      request->destination = network::mojom::RequestDestination::kAudio;
+    } else if (destination == "audioworklet") {
+      request->destination = network::mojom::RequestDestination::kAudioWorklet;
+    } else if (destination == "document") {
+      request->destination = network::mojom::RequestDestination::kDocument;
+    } else if (destination == "embed") {
+      request->destination = network::mojom::RequestDestination::kEmbed;
+    } else if (destination == "font") {
+      request->destination = network::mojom::RequestDestination::kFont;
+    } else if (destination == "frame") {
+      request->destination = network::mojom::RequestDestination::kFrame;
+    } else if (destination == "iframe") {
+      request->destination = network::mojom::RequestDestination::kIframe;
+    } else if (destination == "image") {
+      request->destination = network::mojom::RequestDestination::kImage;
+    } else if (destination == "manifest") {
+      request->destination = network::mojom::RequestDestination::kManifest;
+    } else if (destination == "object") {
+      request->destination = network::mojom::RequestDestination::kObject;
+    } else if (destination == "paintworklet") {
+      request->destination = network::mojom::RequestDestination::kPaintWorklet;
+    } else if (destination == "report") {
+      request->destination = network::mojom::RequestDestination::kReport;
+    } else if (destination == "script") {
+      request->destination = network::mojom::RequestDestination::kScript;
+    } else if (destination == "serviceworker") {
+      request->destination = network::mojom::RequestDestination::kServiceWorker;
+    } else if (destination == "style") {
+      request->destination = network::mojom::RequestDestination::kStyle;
+    } else if (destination == "track") {
+      request->destination = network::mojom::RequestDestination::kTrack;
+    } else if (destination == "video") {
+      request->destination = network::mojom::RequestDestination::kVideo;
+    } else if (destination == "worker") {
+      request->destination = network::mojom::RequestDestination::kWorker;
+    } else if (destination == "xslt") {
+      request->destination = network::mojom::RequestDestination::kXslt;
+    }
+  }
+
   bool credentials_specified =
       opts.Get("credentials", &request->credentials_mode);
   std::vector<std::pair<std::string, std::string>> extra_headers;

--- a/shell/browser/api/electron_api_url_loader.cc
+++ b/shell/browser/api/electron_api_url_loader.cc
@@ -376,6 +376,12 @@ gin::Handle<SimpleURLLoaderWrapper> SimpleURLLoaderWrapper::Create(
   opts.Get("method", &request->method);
   opts.Get("url", &request->url);
   opts.Get("referrer", &request->referrer);
+  std::string origin;
+  opts.Get("origin", &origin);
+  if (!origin.empty()) {
+    request->request_initiator = url::Origin::Create(GURL(origin));
+  }
+
   bool credentials_specified =
       opts.Get("credentials", &request->credentials_mode);
   std::vector<std::pair<std::string, std::string>> extra_headers;

--- a/shell/browser/api/electron_api_url_loader.cc
+++ b/shell/browser/api/electron_api_url_loader.cc
@@ -387,6 +387,19 @@ gin::Handle<SimpleURLLoaderWrapper> SimpleURLLoaderWrapper::Create(
     request->trusted_params->has_user_activation = has_user_activation;
   }
 
+  std::string mode;
+  if (opts.Get("mode", &mode) && !mode.empty()) {
+    if (mode == "navigate") {
+      request->mode = network::mojom::RequestMode::kNavigate;
+    } else if (mode == "cors") {
+      request->mode = network::mojom::RequestMode::kCors;
+    } else if (mode == "no-cors") {
+      request->mode = network::mojom::RequestMode::kNoCors;
+    } else if (mode == "same-origin") {
+      request->mode = network::mojom::RequestMode::kSameOrigin;
+    }
+  }
+
   bool credentials_specified =
       opts.Get("credentials", &request->credentials_mode);
   std::vector<std::pair<std::string, std::string>> extra_headers;

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -866,6 +866,36 @@ describe('net module', () => {
       await collectStreamBody(await getResponse(urlRequest));
     });
 
+    it('should set sec-fetch-mode to no-cors by default', async () => {
+      const serverUrl = await respondOnce.toSingleURL((request, response) => {
+        expect(request.headers['sec-fetch-mode']).to.equal('no-cors');
+        response.statusCode = 200;
+        response.statusMessage = 'OK';
+        response.end();
+      });
+      const urlRequest = net.request({
+        url: serverUrl
+      });
+      await collectStreamBody(await getResponse(urlRequest));
+    });
+
+    ['navigate', 'cors', 'no-cors', 'same-origin'].forEach((mode) => {
+      it(`should set sec-fetch-mode to ${mode} if requested`, async () => {
+        const serverUrl = await respondOnce.toSingleURL((request, response) => {
+          expect(request.headers['sec-fetch-mode']).to.equal(mode);
+          response.statusCode = 200;
+          response.statusMessage = 'OK';
+          response.end();
+        });
+        const urlRequest = net.request({
+          url: serverUrl,
+          origin: serverUrl
+        });
+        urlRequest.setHeader('sec-fetch-mode', mode);
+        await collectStreamBody(await getResponse(urlRequest));
+      });
+    });
+
     it('should be able to abort an HTTP request before first write', async () => {
       const serverUrl = await respondOnce.toSingleURL((request, response) => {
         response.end();

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -797,6 +797,48 @@ describe('net module', () => {
       it('should not store cookies');
     });
 
+    it('should set sec-fetch-site to same-origin for request from same origin', async () => {
+      const serverUrl = await respondOnce.toSingleURL((request, response) => {
+        expect(request.headers['sec-fetch-site']).to.equal('same-origin');
+        response.statusCode = 200;
+        response.statusMessage = 'OK';
+        response.end();
+      });
+      const urlRequest = net.request({
+        url: serverUrl,
+        origin: serverUrl
+      });
+      await collectStreamBody(await getResponse(urlRequest));
+    });
+
+    it('should set sec-fetch-site to same-origin for request with the same origin header', async () => {
+      const serverUrl = await respondOnce.toSingleURL((request, response) => {
+        expect(request.headers['sec-fetch-site']).to.equal('same-origin');
+        response.statusCode = 200;
+        response.statusMessage = 'OK';
+        response.end();
+      });
+      const urlRequest = net.request({
+        url: serverUrl
+      });
+      urlRequest.setHeader('Origin', serverUrl);
+      await collectStreamBody(await getResponse(urlRequest));
+    });
+
+    it('should set sec-fetch-site to cross-site for request from other origin', async () => {
+      const serverUrl = await respondOnce.toSingleURL((request, response) => {
+        expect(request.headers['sec-fetch-site']).to.equal('cross-site');
+        response.statusCode = 200;
+        response.statusMessage = 'OK';
+        response.end();
+      });
+      const urlRequest = net.request({
+        url: serverUrl,
+        origin: 'https://not-exists.com'
+      });
+      await collectStreamBody(await getResponse(urlRequest));
+    });
+
     it('should be able to abort an HTTP request before first write', async () => {
       const serverUrl = await respondOnce.toSingleURL((request, response) => {
         response.end();

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -475,6 +475,26 @@ describe('net module', () => {
       await collectStreamBody(response);
     });
 
+    it('should not change the case of header name', async () => {
+      const customHeaderName = 'X-Header-Name';
+      const customHeaderValue = 'value';
+      const serverUrl = await respondOnce.toSingleURL((request, response) => {
+        expect(request.headers[customHeaderName.toLowerCase()]).to.equal(customHeaderValue.toString());
+        expect(request.rawHeaders.includes(customHeaderName)).to.equal(true);
+        response.statusCode = 200;
+        response.statusMessage = 'OK';
+        response.end();
+      });
+
+      const urlRequest = net.request(serverUrl);
+      urlRequest.setHeader(customHeaderName, customHeaderValue);
+      expect(urlRequest.getHeader(customHeaderName)).to.equal(customHeaderValue);
+      urlRequest.write('');
+      const response = await getResponse(urlRequest);
+      expect(response.statusCode).to.equal(200);
+      await collectStreamBody(response);
+    });
+
     it('should not be able to set a custom HTTP request header after first write', async () => {
       const customHeaderName = 'Some-Custom-Header-Name';
       const customHeaderValue = 'Some-Customer-Header-Value';

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -839,6 +839,33 @@ describe('net module', () => {
       await collectStreamBody(await getResponse(urlRequest));
     });
 
+    it('should not send sec-fetch-user header by default', async () => {
+      const serverUrl = await respondOnce.toSingleURL((request, response) => {
+        expect(request.headers).not.to.have.property('sec-fetch-user');
+        response.statusCode = 200;
+        response.statusMessage = 'OK';
+        response.end();
+      });
+      const urlRequest = net.request({
+        url: serverUrl
+      });
+      await collectStreamBody(await getResponse(urlRequest));
+    });
+
+    it('should set sec-fetch-user to ?1 if requested', async () => {
+      const serverUrl = await respondOnce.toSingleURL((request, response) => {
+        expect(request.headers['sec-fetch-user']).to.equal('?1');
+        response.statusCode = 200;
+        response.statusMessage = 'OK';
+        response.end();
+      });
+      const urlRequest = net.request({
+        url: serverUrl
+      });
+      urlRequest.setHeader('sec-fetch-user', '?1');
+      await collectStreamBody(await getResponse(urlRequest));
+    });
+
     it('should be able to abort an HTTP request before first write', async () => {
       const serverUrl = await respondOnce.toSingleURL((request, response) => {
         response.end();

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -896,6 +896,41 @@ describe('net module', () => {
       });
     });
 
+    it('should set sec-fetch-dest to empty by default', async () => {
+      const serverUrl = await respondOnce.toSingleURL((request, response) => {
+        expect(request.headers['sec-fetch-dest']).to.equal('empty');
+        response.statusCode = 200;
+        response.statusMessage = 'OK';
+        response.end();
+      });
+      const urlRequest = net.request({
+        url: serverUrl
+      });
+      await collectStreamBody(await getResponse(urlRequest));
+    });
+
+    [
+      'empty', 'audio', 'audioworklet', 'document', 'embed', 'font',
+      'frame', 'iframe', 'image', 'manifest', 'object', 'paintworklet',
+      'report', 'script', 'serviceworker', 'style', 'track', 'video',
+      'worker', 'xslt'
+    ].forEach((dest) => {
+      it(`should set sec-fetch-dest to ${dest} if requested`, async () => {
+        const serverUrl = await respondOnce.toSingleURL((request, response) => {
+          expect(request.headers['sec-fetch-dest']).to.equal(dest);
+          response.statusCode = 200;
+          response.statusMessage = 'OK';
+          response.end();
+        });
+        const urlRequest = net.request({
+          url: serverUrl,
+          origin: serverUrl
+        });
+        urlRequest.setHeader('sec-fetch-dest', dest);
+        await collectStreamBody(await getResponse(urlRequest));
+      });
+    });
+
     it('should be able to abort an HTTP request before first write', async () => {
       const serverUrl = await respondOnce.toSingleURL((request, response) => {
         response.end();

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -120,6 +120,7 @@ declare namespace NodeJS {
     partition?: string;
     referrer?: string;
     origin?: string;
+    hasUserActivation?: boolean;
   };
   type ResponseHead = {
     statusCode: number;

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -122,6 +122,7 @@ declare namespace NodeJS {
     origin?: string;
     hasUserActivation?: boolean;
     mode?: string;
+    destination?: string;
   };
   type ResponseHead = {
     statusCode: number;

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -119,6 +119,7 @@ declare namespace NodeJS {
     session?: Electron.Session;
     partition?: string;
     referrer?: string;
+    origin?: string;
   };
   type ResponseHead = {
     statusCode: number;

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -121,6 +121,7 @@ declare namespace NodeJS {
     referrer?: string;
     origin?: string;
     hasUserActivation?: boolean;
+    mode?: string;
   };
   type ResponseHead = {
     statusCode: number;


### PR DESCRIPTION
#### Description of Change
This pull request is based on #26134. It's possible to reproduce a request send by Chrome Browser with #26134 and this pull request. 

Is ok to backport this PR to stable branches, such as 10-x-y?

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Allowed setting the 'Origin' header and Sec-Fetch-* headers in net.request().