### PR TITLE
fix: Close protocol response streams when aborted

### DIFF
--- a/shell/browser/net/node_stream_loader.cc
+++ b/shell/browser/net/node_stream_loader.cc
@@ -42,6 +42,12 @@ NodeStreamLoader::~NodeStreamLoader() {
     node::MakeCallback(isolate_, emitter_.Get(isolate_), "removeListener",
                        node::arraysize(args), args, {0, 0});
   }
+
+  // Destroy the stream if not already ended
+  if (!ended_) {
+    node::MakeCallback(isolate_, emitter_.Get(isolate_), "destroy", 0, nullptr,
+                       {0, 0});
+  }
 }
 
 void NodeStreamLoader::Start(network::ResourceResponseHead head) {

--- a/spec-main/api-protocol-spec.ts
+++ b/spec-main/api-protocol-spec.ts
@@ -442,6 +442,30 @@ describe('protocol module', () => {
       ajax(protocolName + '://fake-host')
       await hasEndedPromise
     })
+
+    it('destroys response streams when aborted before completion', async () => {
+      const events = new EventEmitter()
+      registerStreamProtocol(protocolName, (request, callback) => {
+        const responseStream = new stream.PassThrough()
+        responseStream.push('data\r\n')
+        responseStream.on('close', () => {
+          events.emit('close')
+        })
+        callback({
+          statusCode: 200,
+          headers: { 'Content-Type': 'text/plain' },
+          data: responseStream
+        })
+        events.emit('respond')
+      })
+
+      const hasRespondedPromise = emittedOnce(events, 'respond')
+      const hasClosedPromise = emittedOnce(events, 'close')
+      ajax(protocolName + '://fake-host')
+      await hasRespondedPromise
+      await contents.loadFile(path.join(__dirname, 'fixtures', 'pages', 'jquery.html'))
+      await hasClosedPromise
+    })
   })
 
   describe('protocol.isProtocolHandled', () => {

--- a/spec-main/fixtures/pages/jquery.html
+++ b/spec-main/fixtures/pages/jquery.html
@@ -1,0 +1,21 @@
+<html>
+<head>
+  <script src="../../../spec/static/jquery-2.0.3.min.js"></script>
+</head>
+<body>
+<script>
+  window.ajax = (url, options) => {
+    return new Promise((resolve, reject) => {
+      options.url = url
+      options.success = (data, status, request) => {
+        resolve({data, status: request.status, headers: request.getAllResponseHeaders()})
+      }
+      options.error = (xhr, errorType, error) => {
+        reject(error ? error : new Error(`${xhr.status}`))
+      }
+      $.ajax(options)
+    })
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
Backport of #24014

See that PR for details.

Notes: Protocol response streams are now destroyed if the request is aborted.