### PR TITLE
refactor: remove x11 logic from filenames.gni

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -507,15 +507,13 @@ source_set("electron_lib") {
       "//ui/wm",
     ]
     if (use_x11) {
+      sources += filenames.lib_sources_linux_x11
       deps += [
         "//ui/gfx/x",
         "//ui/gtk/x",
       ]
     }
     configs += [ ":gio_unix" ]
-    if (use_x11) {
-      deps += [ "//ui/gfx/x" ]
-    }
     defines += [
       # Disable warnings for g_settings_list_schemas.
       "GLIB_DISABLE_DEPRECATION_WARNINGS",

--- a/filenames.gni
+++ b/filenames.gni
@@ -1,5 +1,3 @@
-import("//build/config/ui.gni")
-
 filenames = {
   default_app_ts_sources = [
     "default_app/default_app.ts",
@@ -43,6 +41,19 @@ filenames = {
     "shell/common/node_bindings_linux.cc",
     "shell/common/node_bindings_linux.h",
     "shell/common/platform_util_linux.cc",
+  ]
+
+  lib_sources_linux_x11 = [
+    "chromium_src/chrome/browser/ui/views/frame/global_menu_bar_registrar_x11.cc",
+    "chromium_src/chrome/browser/ui/views/frame/global_menu_bar_registrar_x11.h",
+    "shell/browser/ui/views/global_menu_bar_x11.cc",
+    "shell/browser/ui/views/global_menu_bar_x11.h",
+    "shell/browser/ui/x/event_disabler.cc",
+    "shell/browser/ui/x/event_disabler.h",
+    "shell/browser/ui/x/window_state_watcher.cc",
+    "shell/browser/ui/x/window_state_watcher.h",
+    "shell/browser/ui/x/x_window_utils.cc",
+    "shell/browser/ui/x/x_window_utils.h",
   ]
 
   lib_sources_posix = [
@@ -633,21 +644,6 @@ filenames = {
     "shell/utility/electron_content_utility_client.cc",
     "shell/utility/electron_content_utility_client.h",
   ]
-
-  if (use_x11) {
-    lib_sources_linux += [
-      "chromium_src/chrome/browser/ui/views/frame/global_menu_bar_registrar_x11.cc",
-      "chromium_src/chrome/browser/ui/views/frame/global_menu_bar_registrar_x11.h",
-      "shell/browser/ui/views/global_menu_bar_x11.cc",
-      "shell/browser/ui/views/global_menu_bar_x11.h",
-      "shell/browser/ui/x/event_disabler.cc",
-      "shell/browser/ui/x/event_disabler.h",
-      "shell/browser/ui/x/window_state_watcher.cc",
-      "shell/browser/ui/x/window_state_watcher.h",
-      "shell/browser/ui/x/x_window_utils.cc",
-      "shell/browser/ui/x/x_window_utils.h",
-    ]
-  }
 
   lib_sources_nss = [
     "chromium_src/chrome/browser/certificate_manager_model.cc",


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Remove X11 related logic from `filenames.gni` in order to keep this file data-only as [suggested](https://github.com/electron/electron/pull/26022/files#r510341547) by @nornagon.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd (@nornagon)
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none
