### PR TITLE
chore: use consistent parameter names

### DIFF
--- a/shell/browser/api/electron_api_notification.h
+++ b/shell/browser/api/electron_api_notification.h
@@ -90,7 +90,7 @@ class Notification : public gin::Wrappable<Notification>,
   void SetSound(const base::string16& sound);
   void SetActions(const std::vector<electron::NotificationAction>& actions);
   void SetCloseButtonText(const base::string16& text);
-  void SetToastXml(const base::string16& text);
+  void SetToastXml(const base::string16& new_toast_xml);
 
  private:
   base::string16 title_;

--- a/shell/browser/api/electron_api_url_loader.h
+++ b/shell/browser/api/electron_api_url_loader.h
@@ -63,7 +63,7 @@ class SimpleURLLoaderWrapper
   const char* GetTypeName() override;
 
  private:
-  SimpleURLLoaderWrapper(std::unique_ptr<network::ResourceRequest> loader,
+  SimpleURLLoaderWrapper(std::unique_ptr<network::ResourceRequest> request,
                          network::mojom::URLLoaderFactory* url_loader_factory,
                          int options);
 

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -25,8 +25,8 @@ class View : public gin_helper::Wrappable<View> {
                              v8::Local<v8::FunctionTemplate> prototype);
 
 #if BUILDFLAG(ENABLE_VIEWS_API)
-  void AddChildView(gin::Handle<View> view);
-  void AddChildViewAt(gin::Handle<View> view, size_t index);
+  void AddChildView(gin::Handle<View> child);
+  void AddChildViewAt(gin::Handle<View> child, size_t index);
 #endif
 
   views::View* view() const { return view_; }

--- a/shell/browser/api/message_port.h
+++ b/shell/browser/api/message_port.h
@@ -32,7 +32,7 @@ class MessagePort : public gin::Wrappable<MessagePort>, mojo::MessageReceiver {
   void Start();
   void Close();
 
-  void Entangle(blink::MessagePortDescriptor handle);
+  void Entangle(blink::MessagePortDescriptor port);
   void Entangle(blink::MessagePortChannel channel);
 
   blink::MessagePortChannel Disentangle();

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -99,7 +99,7 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
       content::BrowserContext* browser_context,
       const GURL& url,
       bool has_navigation_started,
-      bool has_request_started,
+      bool has_response_started,
       content::SiteInstance** affinity_site_instance) const override;
   void RegisterPendingSiteInstance(
       content::RenderFrameHost* render_frame_host,
@@ -288,13 +288,13 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
                                   content::RenderFrameHost* speculative_rfh,
                                   content::BrowserContext* browser_context,
                                   const GURL& dest_url,
-                                  bool has_request_started) const;
+                                  bool has_response_started) const;
   bool NavigationWasRedirectedCrossSite(
       content::BrowserContext* browser_context,
       content::SiteInstance* current_instance,
       content::SiteInstance* speculative_instance,
       const GURL& dest_url,
-      bool has_request_started) const;
+      bool has_response_started) const;
   void AddProcessPreferences(int process_id, ProcessPreferences prefs);
   void RemoveProcessPreferences(int process_id);
   bool IsProcessObserved(int process_id) const;

--- a/shell/browser/electron_download_manager_delegate.h
+++ b/shell/browser/electron_download_manager_delegate.h
@@ -41,7 +41,7 @@ class ElectronDownloadManagerDelegate
   // Get the save path set on the associated api::DownloadItem object
   void GetItemSavePath(download::DownloadItem* item, base::FilePath* path);
   void GetItemSaveDialogOptions(download::DownloadItem* item,
-                                file_dialog::DialogSettings* settings);
+                                file_dialog::DialogSettings* options);
 
   void OnDownloadPathGenerated(uint32_t download_id,
                                content::DownloadTargetCallback callback,

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -350,7 +350,7 @@ bool NativeWindow::AddTabbedWindow(NativeWindow* window) {
   return true;  // for non-Mac platforms
 }
 
-void NativeWindow::SetVibrancy(const std::string& filename) {}
+void NativeWindow::SetVibrancy(const std::string& type) {}
 
 void NativeWindow::SetTouchBar(
     std::vector<gin_helper::PersistentDictionary> items) {}

--- a/shell/browser/net/proxying_websocket.h
+++ b/shell/browser/net/proxying_websocket.h
@@ -122,7 +122,7 @@ class ProxyingWebSocket : public network::mojom::WebSocketHandshakeClient,
 
   void PauseIncomingMethodCallProcessing();
   void ResumeIncomingMethodCallProcessing();
-  void OnError(int result);
+  void OnError(int error_code);
   // This is used for detecting errors on mojo connection with the network
   // service.
   void OnMojoConnectionErrorWithCustomReason(uint32_t custom_reason,

--- a/shell/browser/notifications/win/windows_toast_notification.h
+++ b/shell/browser/notifications/win/windows_toast_notification.h
@@ -66,7 +66,7 @@ class WindowsToastNotification : public Notification {
       const std::wstring& icon_path,
       const std::wstring& timeout_type,
       const bool silent,
-      ABI::Windows::Data::Xml::Dom::IXmlDocument** toastXml);
+      ABI::Windows::Data::Xml::Dom::IXmlDocument** toast_xml);
   HRESULT SetXmlAudioSilent(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc);
   HRESULT SetXmlScenarioReminder(
       ABI::Windows::Data::Xml::Dom::IXmlDocument* doc);
@@ -77,10 +77,11 @@ class WindowsToastNotification : public Notification {
                      const std::wstring& body);
   HRESULT SetXmlImage(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
                       const std::wstring& icon_path);
-  HRESULT GetTextNodeList(ScopedHString* tag,
-                          ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
-                          ABI::Windows::Data::Xml::Dom::IXmlNodeList** nodeList,
-                          uint32_t reqLength);
+  HRESULT GetTextNodeList(
+      ScopedHString* tag,
+      ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
+      ABI::Windows::Data::Xml::Dom::IXmlNodeList** node_list,
+      uint32_t req_length);
   HRESULT AppendTextToXml(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
                           ABI::Windows::Data::Xml::Dom::IXmlNode* node,
                           const std::wstring& text);

--- a/shell/common/color_util.h
+++ b/shell/common/color_util.h
@@ -12,7 +12,7 @@
 namespace electron {
 
 // Parse hex color like "#FFF" or "#EFEFEF"
-SkColor ParseHexColor(const std::string& name);
+SkColor ParseHexColor(const std::string& color_string);
 
 // Convert color to RGB hex value like "#ABCDEF"
 std::string ToRGBHex(SkColor color);

--- a/shell/renderer/api/electron_api_context_bridge.h
+++ b/shell/renderer/api/electron_api_context_bridge.h
@@ -21,7 +21,7 @@ void ProxyFunctionWrapper(const v8::FunctionCallbackInfo<v8::Value>& info);
 v8::MaybeLocal<v8::Object> CreateProxyForAPI(
     const v8::Local<v8::Object>& api_object,
     const v8::Local<v8::Context>& source_context,
-    const v8::Local<v8::Context>& target_context,
+    const v8::Local<v8::Context>& destination_context,
     context_bridge::ObjectCache* object_cache,
     bool support_dynamic_properties,
     int recursion_depth);

--- a/shell/renderer/extensions/electron_extensions_dispatcher_delegate.h
+++ b/shell/renderer/extensions/electron_extensions_dispatcher_delegate.h
@@ -28,7 +28,7 @@ class ElectronExtensionsDispatcherDelegate
       extensions::ResourceBundleSourceMap* source_map) override;
   void RequireWebViewModules(extensions::ScriptContext* context) override;
   void OnActiveExtensionsUpdated(
-      const std::set<std::string>& extensions_ids) override;
+      const std::set<std::string>& extension_ids) override;
   void InitializeBindingsSystem(
       extensions::Dispatcher* dispatcher,
       extensions::NativeExtensionBindingsSystem* bindings_system) override;


### PR DESCRIPTION
#### Description of Change
Results of a `clang-tidy` check: keep parameter names consistent between declaration and definition. There were more flagged, but these were the easy ones where it was only a change in the header (with one exception).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
