### PR TITLE
feat: enable nativeWindowOpen by default

### DIFF
--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -126,7 +126,7 @@ WebContentsPreferences::WebContentsPreferences(
   SetDefaultBoolIfUndefined(options::kDisableHtmlFullscreenWindowResize, false);
   SetDefaultBoolIfUndefined(options::kWebviewTag, false);
   SetDefaultBoolIfUndefined(options::kSandbox, false);
-  SetDefaultBoolIfUndefined(options::kNativeWindowOpen, false);
+  SetDefaultBoolIfUndefined(options::kNativeWindowOpen, true);
   if (IsUndefined(options::kContextIsolation)) {
     node::Environment* env = node::Environment::GetCurrent(isolate);
     EmitWarning(env,


### PR DESCRIPTION
#### Description of Change
Using the native implementation of window.open avoids many headaches and workarounds that have built up over the years. We should make this the default, and deprecate and eventually remove the non-native version.

Apps that require custom window.open behavior similar to the non-native window.open shim can implement similar behavior using IPC if required. But I'm not aware of any situations which require it.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: nativeWindowOpen is now enabled by default.
