### PR TITLE
docs: clarify default value of enableRemoteModule

### DIFF
--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -702,7 +702,11 @@ succeeding.
 
 ```js
 // Bad if the renderer can run untrusted content
-const mainWindow = new BrowserWindow({})
+const mainWindow = new BrowserWindow({
+  webPreferences: {
+    enableRemoteModule: true
+  }
+})
 ```
 
 ```js
@@ -716,11 +720,16 @@ const mainWindow = new BrowserWindow({
 
 ```html
 <!-- Bad if the renderer can run untrusted content  -->
-<webview src="page.html"></webview>
+<webview enableremotemodule="true" src="page.html"></webview>
 
 <!-- Good -->
 <webview enableremotemodule="false" src="page.html"></webview>
 ```
+
+> **Note:** The default value of `enableRemoteModule` is `false` starting
+> from Electron 10. For prior versions, you need to explicitly disable
+> the `remote` module by the means above.
+
 
 ## 16) Filter the `remote` module
 


### PR DESCRIPTION
#### Description of Change

Since `enableRemoteModule` is false by default as of Electron 10, the security doc should no longer imply that it's enabled by default.

cc @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
