### PR TITLE
feat: correctly identify permissions when using setPermissionRequestHandler

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -462,6 +462,7 @@ win.webContents.session.setCertificateVerifyProc((request, callback) => {
 * `handler` Function | null
   * `webContents` [WebContents](web-contents.md) - WebContents requesting the permission.  Please note that if the request comes from a subframe you should use `requestingUrl` to check the request origin.
   * `permission` String - The type of requested permission.
+    * `clipboard-read` - Request access to read from the clipboard.
     * `media` -  Request access to media devices such as camera, microphone and speakers.
     * `mediaKeySystem` - Request access to DRM protected content.
     * `geolocation` - Request access to user's current location.

--- a/shell/common/gin_converters/content_converter.cc
+++ b/shell/common/gin_converters/content_converter.cc
@@ -178,6 +178,10 @@ v8::Local<v8::Value> Converter<content::PermissionType>::ToV8(
   // Not all permissions are currently used by Electron but this will future
   // proof these conversions.
   switch (val) {
+    case content::PermissionType::ACCESSIBILITY_EVENTS:
+      return StringToV8(isolate, "accessibilityEvents");
+    case content::PermissionType::AR:
+      return StringToV8(isolate, "ar");
     case content::PermissionType::BACKGROUND_FETCH:
       return StringToV8(isolate, "background-fetch");
     case content::PermissionType::BACKGROUND_SYNC:
@@ -186,6 +190,8 @@ v8::Local<v8::Value> Converter<content::PermissionType>::ToV8(
       return StringToV8(isolate, "clipboard-read");
     case content::PermissionType::CLIPBOARD_SANITIZED_WRITE:
       return StringToV8(isolate, "clipboard-sanitized-write");
+    case content::PermissionType::FLASH:
+      return StringToV8(isolate, "flash");
     case content::PermissionType::CAMERA_PAN_TILT_ZOOM:
     case content::PermissionType::FONT_ACCESS:
       return StringToV8(isolate, "font-access");
@@ -216,11 +222,15 @@ v8::Local<v8::Value> Converter<content::PermissionType>::ToV8(
       return StringToV8(isolate, "screen-wake-lock");
     case content::PermissionType::SENSORS:
       return StringToV8(isolate, "sensors");
+    case content::PermissionType::STORAGE_ACCESS_GRANT:
+      return StringToV8(isolate, "storage-access");
+    case content::PermissionType::VR:
+      return StringToV8(isolate, "vr");
     case content::PermissionType::WAKE_LOCK_SYSTEM:
       return StringToV8(isolate, "system-wake-lock");
     case content::PermissionType::WINDOW_PLACEMENT:
       return StringToV8(isolate, "window-placement");
-    default:
+    case content::PermissionType::NUM:
       break;
   }
 

--- a/shell/common/gin_converters/content_converter.cc
+++ b/shell/common/gin_converters/content_converter.cc
@@ -175,6 +175,8 @@ v8::Local<v8::Value> Converter<content::PermissionType>::ToV8(
     const content::PermissionType& val) {
   using PermissionType = electron::WebContentsPermissionHelper::PermissionType;
   switch (val) {
+    case content::PermissionType::CLIPBOARD_READ_WRITE:
+      return StringToV8(isolate, "clipboard-read");
     case content::PermissionType::MIDI_SYSEX:
       return StringToV8(isolate, "midiSysex");
     case content::PermissionType::NOTIFICATIONS:

--- a/shell/common/gin_converters/content_converter.cc
+++ b/shell/common/gin_converters/content_converter.cc
@@ -179,7 +179,7 @@ v8::Local<v8::Value> Converter<content::PermissionType>::ToV8(
   // proof these conversions.
   switch (val) {
     case content::PermissionType::ACCESSIBILITY_EVENTS:
-      return StringToV8(isolate, "accessibilityEvents");
+      return StringToV8(isolate, "accessibility-events");
     case content::PermissionType::AR:
       return StringToV8(isolate, "ar");
     case content::PermissionType::BACKGROUND_FETCH:

--- a/shell/common/gin_converters/content_converter.cc
+++ b/shell/common/gin_converters/content_converter.cc
@@ -174,13 +174,39 @@ v8::Local<v8::Value> Converter<content::PermissionType>::ToV8(
     v8::Isolate* isolate,
     const content::PermissionType& val) {
   using PermissionType = electron::WebContentsPermissionHelper::PermissionType;
+  // Based on mappings from content/browser/devtools/protocol/browser_handler.cc
+  // Not all permissions are currently used by Electron but this will future
+  // proof these conversions.
   switch (val) {
+    case content::PermissionType::BACKGROUND_FETCH:
+      return StringToV8(isolate, "background-fetch");
+    case content::PermissionType::BACKGROUND_SYNC:
+      return StringToV8(isolate, "background-sync");
     case content::PermissionType::CLIPBOARD_READ_WRITE:
       return StringToV8(isolate, "clipboard-read");
+    case content::PermissionType::CLIPBOARD_SANITIZED_WRITE:
+      return StringToV8(isolate, "clipboard-sanitized-write");
+    case content::PermissionType::CAMERA_PAN_TILT_ZOOM:
+    case content::PermissionType::VIDEO_CAPTURE:
+      return StringToV8(isolate, "camera");
+    case content::PermissionType::FONT_ACCESS:
+      return StringToV8(isolate, "font-access");
+    case content::PermissionType::IDLE_DETECTION:
+      return StringToV8(isolate, "idle-detection");
+    case content::PermissionType::AUDIO_CAPTURE:
+      return StringToV8(isolate, "microphone");
     case content::PermissionType::MIDI_SYSEX:
       return StringToV8(isolate, "midiSysex");
+    case content::PermissionType::NFC:
+      return StringToV8(isolate, "nfc");
     case content::PermissionType::NOTIFICATIONS:
       return StringToV8(isolate, "notifications");
+    case content::PermissionType::PAYMENT_HANDLER:
+      return StringToV8(isolate, "payment-handler");
+    case content::PermissionType::PERIODIC_BACKGROUND_SYNC:
+      return StringToV8(isolate, "periodic-background-sync");
+    case content::PermissionType::DURABLE_STORAGE:
+      return StringToV8(isolate, "persistent-storage");
     case content::PermissionType::GEOLOCATION:
       return StringToV8(isolate, "geolocation");
     case content::PermissionType::AUDIO_CAPTURE:
@@ -190,6 +216,14 @@ v8::Local<v8::Value> Converter<content::PermissionType>::ToV8(
       return StringToV8(isolate, "mediaKeySystem");
     case content::PermissionType::MIDI:
       return StringToV8(isolate, "midi");
+    case content::PermissionType::WAKE_LOCK_SCREEN:
+      return StringToV8(isolate, "screen-wake-lock");
+    case content::PermissionType::SENSORS:
+      return StringToV8(isolate, "sensors");
+    case content::PermissionType::WAKE_LOCK_SYSTEM:
+      return StringToV8(isolate, "system-wake-lock");
+    case content::PermissionType::WINDOW_PLACEMENT:
+      return StringToV8(isolate, "window-placement");
     default:
       break;
   }

--- a/shell/common/gin_converters/content_converter.cc
+++ b/shell/common/gin_converters/content_converter.cc
@@ -187,14 +187,10 @@ v8::Local<v8::Value> Converter<content::PermissionType>::ToV8(
     case content::PermissionType::CLIPBOARD_SANITIZED_WRITE:
       return StringToV8(isolate, "clipboard-sanitized-write");
     case content::PermissionType::CAMERA_PAN_TILT_ZOOM:
-    case content::PermissionType::VIDEO_CAPTURE:
-      return StringToV8(isolate, "camera");
     case content::PermissionType::FONT_ACCESS:
       return StringToV8(isolate, "font-access");
     case content::PermissionType::IDLE_DETECTION:
       return StringToV8(isolate, "idle-detection");
-    case content::PermissionType::AUDIO_CAPTURE:
-      return StringToV8(isolate, "microphone");
     case content::PermissionType::MIDI_SYSEX:
       return StringToV8(isolate, "midiSysex");
     case content::PermissionType::NFC:

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -1529,7 +1529,7 @@ describe('navigator.clipboard', () => {
 
   it('returns clipboard contents when a PermissionRequestHandler is not defined', async () => {
     const clipboard = await readClipboard();
-    expect(clipboard).to.equal('[object ClipboardItem]');
+    expect(clipboard).to.not.equal('Read permission denied.');
   });
 
   it('returns an error when permission denied', async () => {
@@ -1553,6 +1553,6 @@ describe('navigator.clipboard', () => {
       }
     });
     const clipboard = await readClipboard();
-    expect(clipboard).to.equal('[object ClipboardItem]');
+    expect(clipboard).to.not.equal('Read permission denied.');
   });
 });

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -1503,3 +1503,56 @@ describe('navigator.serial', () => {
     expect(port).to.equal('[object SerialPort]');
   });
 });
+
+describe('navigator.clipboard', () => {
+  let w: BrowserWindow;
+  before(async () => {
+    w = new BrowserWindow({
+      show: false,
+      webPreferences: {
+        enableBlinkFeatures: 'Serial'
+      }
+    });
+    await w.loadFile(path.join(fixturesPath, 'pages', 'blank.html'));
+  });
+
+  const readClipboard: any = () => {
+    return w.webContents.executeJavaScript(`
+      navigator.clipboard.read().then(clipboard => clipboard.toString()).catch(err => err.message);
+    `, true);
+  };
+
+  after(closeAllWindows);
+  afterEach(() => {
+    session.defaultSession.setPermissionRequestHandler(null);
+  });
+
+  it('returns clipboard contents when a PermissionRequestHandler is not defined', async () => {
+    const clipboard = await readClipboard();
+    expect(clipboard).to.equal('[object ClipboardItem]');
+  });
+
+  it('returns an error when permission denied', async () => {
+    session.defaultSession.setPermissionRequestHandler((wc, permission, callback) => {
+      if (permission === 'clipboard-read') {
+        callback(false);
+      } else {
+        callback(true);
+      }
+    });
+    const clipboard = await readClipboard();
+    expect(clipboard).to.equal('Read permission denied.');
+  });
+
+  it('returns clipboard contents when permission is granted', async () => {
+    session.defaultSession.setPermissionRequestHandler((wc, permission, callback) => {
+      if (permission === 'clipboard-read') {
+        callback(true);
+      } else {
+        callback(false);
+      }
+    });
+    const clipboard = await readClipboard();
+    expect(clipboard).to.equal('[object ClipboardItem]');
+  });
+});


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

When using `setPermissionRequestHandler` if  `navigator.clipboard.read()`, the permission would be described as `unknown`.  This PR fixes that permission to be `clipboard-read` which complies with https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/read.

Additionally, I've mapped all of the permissions from https://source.chromium.org/chromium/chromium/src/+/master:content/browser/devtools/protocol/browser_handler.cc;l=141 so that in the future other permission types are not seen as `unknown`.

Resolves #26089
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->updated setPermissionRequestHandler to correctly recognize permissions being requested.
