### PR TITLE
chore: tidy up usage of PendingRemote

### DIFF
--- a/shell/browser/net/proxying_url_loader_factory.cc
+++ b/shell/browser/net/proxying_url_loader_factory.cc
@@ -802,8 +802,8 @@ void ProxyingURLLoaderFactory::CreateLoaderAndStart(
   // Check if user has intercepted this scheme.
   auto it = intercepted_handlers_.find(request.url.scheme());
   if (it != intercepted_handlers_.end()) {
-    mojo::Remote<network::mojom::URLLoaderFactory> loader_remote;
-    this->Clone(loader_remote.BindNewPipeAndPassReceiver());
+    mojo::PendingRemote<network::mojom::URLLoaderFactory> loader_remote;
+    this->Clone(loader_remote.InitWithNewPipeAndPassReceiver());
 
     // <scheme, <type, handler>>
     it->second.second.Run(
@@ -811,7 +811,7 @@ void ProxyingURLLoaderFactory::CreateLoaderAndStart(
         base::BindOnce(&ElectronURLLoaderFactory::StartLoading,
                        std::move(loader), routing_id, request_id, options,
                        request, std::move(client), traffic_annotation,
-                       loader_remote.Unbind(), it->second.first));
+                       std::move(loader_remote), it->second.first));
     return;
   }
 


### PR DESCRIPTION
#### Description of Change
Tidies up some of the usage of `mojo::PendingRemote` from #25393.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
