### PR TITLE
refactor: don't send ipcRenderer.sendSync() returnValue as an array

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -457,7 +457,7 @@ const addReplyInternalToEvent = (event: any) => {
 
 const addReturnValueToEvent = (event: any) => {
   Object.defineProperty(event, 'returnValue', {
-    set: (value) => event.sendReply([value]),
+    set: (value) => event.sendReply(value),
     get: () => {}
   });
 };

--- a/lib/renderer/api/ipc-renderer.ts
+++ b/lib/renderer/api/ipc-renderer.ts
@@ -10,7 +10,7 @@ ipcRenderer.send = function (channel, ...args) {
 };
 
 ipcRenderer.sendSync = function (channel, ...args) {
-  return ipc.sendSync(internal, channel, args)[0];
+  return ipc.sendSync(internal, channel, args);
 };
 
 ipcRenderer.sendToHost = function (channel, ...args) {

--- a/lib/renderer/ipc-renderer-internal.ts
+++ b/lib/renderer/ipc-renderer-internal.ts
@@ -10,7 +10,7 @@ ipcRendererInternal.send = function (channel, ...args) {
 };
 
 ipcRendererInternal.sendSync = function (channel, ...args) {
-  return ipc.sendSync(internal, channel, args)[0];
+  return ipc.sendSync(internal, channel, args);
 };
 
 ipcRendererInternal.sendTo = function (webContentsId, channel, ...args) {

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -790,7 +790,7 @@ describe('chromium features', () => {
         });
         expect(await w.webContents.executeJavaScript(`(${function () {
           const { ipc } = process._linkedBinding('electron_renderer_ipc');
-          return ipc.sendSync(true, 'GUEST_WINDOW_MANAGER_WINDOW_OPEN', ['', '', ''])[0];
+          return ipc.sendSync(true, 'GUEST_WINDOW_MANAGER_WINDOW_OPEN', ['', '', '']);
         }})()`)).to.be.null();
         const exception = await uncaughtException;
         expect(exception.message).to.match(/denied: expected native window\.open/);


### PR DESCRIPTION
#### Description of Change
This is not necessary since the switch to [Structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes
Notes: no-notes
