### PR TITLE
fix: hover text only working when VO enabled

### DIFF
--- a/shell/browser/mac/electron_application.mm
+++ b/shell/browser/mac/electron_application.mm
@@ -177,20 +177,11 @@ inline void dispatch_sync_main(dispatch_block_t block) {
   electron::Browser::Get()->OpenURL(base::SysNSStringToUTF8(url));
 }
 
-- (bool)voiceOverEnabled {
-  NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
-  [defaults addSuiteNamed:@"com.apple.universalaccess"];
-  [defaults synchronize];
-
-  return [defaults boolForKey:@"voiceOverOnOffKey"];
-}
-
 - (void)accessibilitySetValue:(id)value forAttribute:(NSString*)attribute {
   // Undocumented attribute that VoiceOver happens to set while running.
   // Chromium uses this too, even though it's not exactly right.
   if ([attribute isEqualToString:@"AXEnhancedUserInterface"]) {
-    bool enableAccessibility = ([self voiceOverEnabled] && [value boolValue]);
-    [self updateAccessibilityEnabled:enableAccessibility];
+    [self updateAccessibilityEnabled:[value boolValue]];
   } else if ([attribute isEqualToString:@"AXManualAccessibility"]) {
     [self updateAccessibilityEnabled:[value boolValue]];
   }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/25695.

Previously some screenreader-associated accessibility tooling was being enabled exclusively when VoiceOver was turned on, which broke Hover Text among some other things. This is because we only called `ax_state->OnScreenReaderDetected();` if VoiceOver was enabled, and is fixed by removing that condition. The previous condition seems to have been added as a result of https://github.com/atom/atom/issues/3288, but some local testing seems to ensure that text to speech still works after this removal.

cc @ckerr @jkleinsc @zcbenz  

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where Hover Text on macOS Catalina did not work without VoiceOver also being enabled.
