### PR TITLE
docs: can use depot_tools Python for Windows build

### DIFF
--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -13,13 +13,6 @@ Follow the guidelines below for building Electron on Windows.
   set a few environment variables to point the toolchains to your installation path.
     * `vs2019_install = DRIVE:\path\to\Microsoft Visual Studio\2019\Community`, replacing `2019` and `Community` with your installed versions and replacing `DRIVE:` with the drive that Visual Studio is on. Often, this will be `C:`.
     * `WINDOWSSDKDIR = DRIVE:\path\to\Windows Kits\10`, replacing `DRIVE:` with the drive that Windows Kits is on. Often, this will be `C:`.
-* [Python 2.7.10 or higher](http://www.python.org/download/releases/2.7/)
-  * Contrary to the `depot_tools` setup instructions linked below, you will need
-  to use your locally installed Python with at least version 2.7.10 (with
-  support for TLS 1.2). To do so, make sure that in **PATH**, your locally
-  installed Python comes before the `depot_tools` folder. Right now
-  `depot_tools` still comes with Python 2.7.6, which will cause the `gclient`
-  command to fail (see https://crbug.com/868864).
   * [Python for Windows (pywin32) Extensions](https://pypi.org/project/pywin32/#files)
   is also needed in order to run the build process.
 * [Node.js](https://nodejs.org/download/)


### PR DESCRIPTION
#### Description of Change
Currently `depot_tools` [will bootstrap Python 2.7.17 on Windows](https://chromium.googlesource.com/chromium/tools/depot_tools.git/+/24289f2e94f31c4c57866483a4082d625c5a06a9/bootstrap/manifest.txt#21) so the note about using your locally installed Python is no longer needed.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
