### PR TITLE
test: disable backgrounding occluded windows

### DIFF
--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -26,6 +26,10 @@ for (const flag of unknownFlags) {
   }
 }
 
+const extraTestArgs = [
+  '--disable-backgrounding-occluded-windows'
+];
+
 const utils = require('./lib/utils');
 const { YARN_VERSION } = require('./yarn');
 
@@ -125,7 +129,7 @@ async function runElectronTests () {
 
 async function runRemoteBasedElectronTests () {
   let exe = path.resolve(BASE, utils.getElectronExec());
-  const runnerArgs = ['electron/spec', ...unknownArgs.slice(2)];
+  const runnerArgs = ['electron/spec', ...unknownArgs.slice(2)].concat(extraTestArgs);
   if (process.platform === 'linux') {
     runnerArgs.unshift(path.resolve(__dirname, 'dbus_mock.py'), exe);
     exe = 'python';
@@ -196,7 +200,7 @@ async function runNativeElectronTests () {
 
 async function runMainProcessElectronTests () {
   let exe = path.resolve(BASE, utils.getElectronExec());
-  const runnerArgs = ['electron/spec-main', ...unknownArgs.slice(2)];
+  const runnerArgs = ['electron/spec-main', ...unknownArgs.slice(2)].concat(extraTestArgs);
   if (process.platform === 'linux') {
     runnerArgs.unshift(path.resolve(__dirname, 'dbus_mock.py'), exe);
     exe = 'python';


### PR DESCRIPTION
#### Description of Change
This flag is designed for deflaking visibility tests in Chrome. I was able to produce flakes on my local machine by cmd+tabbing while the test was running, but with this flag I'm no longer able to reproduce them.

#### Release Notes

Notes: none
