### PR TITLE
chore: cherry-pick 6aa1e71fbd09 from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -7,3 +7,4 @@ workaround_an_undefined_symbol_error.patch
 do_not_export_private_v8_symbols_on_windows.patch
 revert_cleanup_switch_offset_of_to_offsetof_where_possible.patch
 fix_build_deprecated_attirbute_for_older_msvc_versions.patch
+cherry-pick-6aa1e71fbd09.patch

--- a/patches/v8/cherry-pick-6aa1e71fbd09.patch
+++ b/patches/v8/cherry-pick-6aa1e71fbd09.patch
@@ -1,7 +1,10 @@
-From 6aa1e71fbd09f8cf21800eb78ecebad9e96b9d59 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andreas Haas <ahaas@chromium.org>
 Date: Tue, 25 Aug 2020 11:46:46 +0200
-Subject: [PATCH] Merged: [wasm][streaming] Avoid aborting the stream after it finished
+Subject: Merged: [wasm][streaming] Avoid aborting the stream after it finished
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 With WebAssembly streaming compilation it is possible that FinishStream
 indirectly calls AbortStream. This had the effect that while
@@ -34,13 +37,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2465830
 Cr-Commit-Position: refs/branch-heads/8.6@{#22}
 Cr-Branched-From: a64aed2333abf49e494d2a5ce24bbd14fff19f60-refs/heads/8.6.395@{#1}
 Cr-Branched-From: a626bc036236c9bf92ac7b87dc40c9e538b087e3-refs/heads/master@{#69472}
----
 
 diff --git a/src/wasm/streaming-decoder.cc b/src/wasm/streaming-decoder.cc
-index aa93626..c9f984a 100644
+index eb2978070074981f20b0e2f27401bce39e0029d9..88f40b9a00df75231b9938a4691c1330d047b070 100644
 --- a/src/wasm/streaming-decoder.cc
 +++ b/src/wasm/streaming-decoder.cc
-@@ -214,6 +214,7 @@
+@@ -214,6 +214,7 @@ class V8_EXPORT_PRIVATE AsyncStreamingDecoder : public StreamingDecoder {
    bool code_section_processed_ = false;
    uint32_t module_offset_ = 0;
    size_t total_size_ = 0;
@@ -48,7 +50,7 @@ index aa93626..c9f984a 100644
  
    // We need wire bytes in an array for deserializing cached modules.
    std::vector<uint8_t> wire_bytes_for_deserializing_;
-@@ -258,6 +259,8 @@
+@@ -258,6 +259,8 @@ size_t AsyncStreamingDecoder::DecodingState::ReadBytes(
  
  void AsyncStreamingDecoder::Finish() {
    TRACE_STREAMING("Finish\n");
@@ -57,7 +59,7 @@ index aa93626..c9f984a 100644
    if (!ok()) return;
  
    if (deserializing()) {
-@@ -298,6 +301,8 @@
+@@ -298,6 +301,8 @@ void AsyncStreamingDecoder::Finish() {
  
  void AsyncStreamingDecoder::Abort() {
    TRACE_STREAMING("Abort\n");

--- a/patches/v8/cherry-pick-6aa1e71fbd09.patch
+++ b/patches/v8/cherry-pick-6aa1e71fbd09.patch
@@ -1,0 +1,68 @@
+From 6aa1e71fbd09f8cf21800eb78ecebad9e96b9d59 Mon Sep 17 00:00:00 2001
+From: Andreas Haas <ahaas@chromium.org>
+Date: Tue, 25 Aug 2020 11:46:46 +0200
+Subject: [PATCH] Merged: [wasm][streaming] Avoid aborting the stream after it finished
+
+With WebAssembly streaming compilation it is possible that FinishStream
+indirectly calls AbortStream. This had the effect that while
+FinishStream fulfilled the promise, AbortStream disposed the promise
+by removing the compile job from the wasm engine and thereby deallocated
+AsyncCompileJob and all the state that belongs to it. Without that
+state, FinishStream could not finish fulfilling the promise correctly.
+
+With this CL the streaming decoder remembers that the stream has
+already been finished. When the stream has been finished, all calls to
+Abort get ignored.
+
+The regression test for this issue requires the Chrome embedding, see
+https://crrev.com/c/2368359
+
+R=​clemensb@chromium.org
+NOTRY=true
+NOPRESUBMIT=true
+NOTREECHECKS=true
+
+(cherry picked from commit 32dd54709cd2ecdfc553aff3f7ab5377ff7c91a2)
+
+Bug: chromium:1117258
+Change-Id: Ifc28a1ee38c228b051c4d7d85b305fe2a721fa1f
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2367858
+Commit-Queue: Andreas Haas <ahaas@chromium.org>
+Reviewed-by: Clemens Backes <clemensb@chromium.org>
+Cr-Original-Commit-Position: refs/heads/master@{#69549}
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2465830
+Cr-Commit-Position: refs/branch-heads/8.6@{#22}
+Cr-Branched-From: a64aed2333abf49e494d2a5ce24bbd14fff19f60-refs/heads/8.6.395@{#1}
+Cr-Branched-From: a626bc036236c9bf92ac7b87dc40c9e538b087e3-refs/heads/master@{#69472}
+---
+
+diff --git a/src/wasm/streaming-decoder.cc b/src/wasm/streaming-decoder.cc
+index aa93626..c9f984a 100644
+--- a/src/wasm/streaming-decoder.cc
++++ b/src/wasm/streaming-decoder.cc
+@@ -214,6 +214,7 @@
+   bool code_section_processed_ = false;
+   uint32_t module_offset_ = 0;
+   size_t total_size_ = 0;
++  bool stream_finished_ = false;
+ 
+   // We need wire bytes in an array for deserializing cached modules.
+   std::vector<uint8_t> wire_bytes_for_deserializing_;
+@@ -258,6 +259,8 @@
+ 
+ void AsyncStreamingDecoder::Finish() {
+   TRACE_STREAMING("Finish\n");
++  DCHECK(!stream_finished_);
++  stream_finished_ = true;
+   if (!ok()) return;
+ 
+   if (deserializing()) {
+@@ -298,6 +301,8 @@
+ 
+ void AsyncStreamingDecoder::Abort() {
+   TRACE_STREAMING("Abort\n");
++  if (stream_finished_) return;
++  stream_finished_ = true;
+   if (!ok()) return;  // Failed already.
+   processor_->OnAbort();
+   Fail();


### PR DESCRIPTION
Merged: [wasm][streaming] Avoid aborting the stream after it finished

With WebAssembly streaming compilation it is possible that FinishStream
indirectly calls AbortStream. This had the effect that while
FinishStream fulfilled the promise, AbortStream disposed the promise
by removing the compile job from the wasm engine and thereby deallocated
AsyncCompileJob and all the state that belongs to it. Without that
state, FinishStream could not finish fulfilling the promise correctly.

With this CL the streaming decoder remembers that the stream has
already been finished. When the stream has been finished, all calls to
Abort get ignored.

The regression test for this issue requires the Chrome embedding, see
https://crrev.com/c/2368359

R=​clemensb@chromium.org
NOTRY=true
NOPRESUBMIT=true
NOTREECHECKS=true

(cherry picked from commit 32dd54709cd2ecdfc553aff3f7ab5377ff7c91a2)

Bug: chromium:1117258
Change-Id: Ifc28a1ee38c228b051c4d7d85b305fe2a721fa1f
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2367858
Commit-Queue: Andreas Haas <ahaas@chromium.org>
Reviewed-by: Clemens Backes <clemensb@chromium.org>
Cr-Original-Commit-Position: refs/heads/master@{#69549}
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2465830
Cr-Commit-Position: refs/branch-heads/8.6@{#22}
Cr-Branched-From: a64aed2333abf49e494d2a5ce24bbd14fff19f60-refs/heads/8.6.395@{#1}
Cr-Branched-From: a626bc036236c9bf92ac7b87dc40c9e538b087e3-refs/heads/master@{#69472}

Notes: Security: backported fix for chromium:1117258.
