### PR TITLE
build: only check patch diffs in testing builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,7 @@ env-release-build: &env-release-build
   STRIP_BINARIES: true
   GENERATE_SYMBOLS: true
   CHECK_DIST_MANIFEST: '1'
+  IS_RELEASE: true
 
 env-headless-testing: &env-headless-testing
   DISPLAY: ':99.0'
@@ -256,23 +257,25 @@ step-gclient-sync: &step-gclient-sync
           "$CIRCLE_REPOSITORY_URL"
 
         ELECTRON_USE_THREE_WAY_MERGE_FOR_PATCHES=1 gclient sync --with_branch_heads --with_tags
-        # Re-export all the patches to check if there were changes.
-        python src/electron/script/export_all_patches.py src/electron/patches/config.json
-        cd src/electron
-        git update-index --refresh || true
-        if ! git diff-index --quiet HEAD --; then
-          # There are changes to the patches. Make a git commit with the updated patches
-          git add patches
-          GIT_COMMITTER_NAME="Electron Bot" GIT_COMMITTER_EMAIL="anonymous@electronjs.org" git commit -m "update patches" --author="Electron Bot <anonymous@electronjs.org>"
-          # Export it
-          mkdir -p ../../patches
-          git format-patch -1 --stdout --keep-subject --no-stat --full-index > ../../patches/update-patches.patch
-          echo
-          echo "======================================================================"
-          echo "There were changes to the patches when applying."
-          echo "Check the CI artifacts for a patch you can apply to fix it."
-          echo "======================================================================"
-          exit 1
+        if [ "$IS_RELEASE" != "true" ]; then
+          # Re-export all the patches to check if there were changes.
+          python src/electron/script/export_all_patches.py src/electron/patches/config.json
+          cd src/electron
+          git update-index --refresh || true
+          if ! git diff-index --quiet HEAD --; then
+            # There are changes to the patches. Make a git commit with the updated patches
+            git add patches
+            GIT_COMMITTER_NAME="Electron Bot" GIT_COMMITTER_EMAIL="anonymous@electronjs.org" git commit -m "update patches" --author="Electron Bot <anonymous@electronjs.org>"
+            # Export it
+            mkdir -p ../../patches
+            git format-patch -1 --stdout --keep-subject --no-stat --full-index > ../../patches/update-patches.patch
+            echo
+            echo "======================================================================"
+            echo "There were changes to the patches when applying."
+            echo "Check the CI artifacts for a patch you can apply to fix it."
+            echo "======================================================================"
+            exit 1
+          fi
         fi
       fi
 

--- a/patches/chromium/rename_the_v8_context_snapshot_on_arm64_macos_builds.patch
+++ b/patches/chromium/rename_the_v8_context_snapshot_on_arm64_macos_builds.patch
@@ -14,10 +14,10 @@ Bug: 1142017
 Change-Id: I8449b72ba3a36e7ce69b9d9ec7768bd80ecc3e3a
 
 diff --git a/android_webview/BUILD.gn b/android_webview/BUILD.gn
-index 49ba7977cc0d5710918b3452ab57078ba31c9949..a362123cad17d061690e7cb5a26413fdb51ac96b 100644
+index 3c15429a9db345644192648a55696d9c94f82fcc..8eab9949c34cb71f44f9a332af9f489ed3f6f178 100644
 --- a/android_webview/BUILD.gn
 +++ b/android_webview/BUILD.gn
-@@ -803,7 +803,7 @@ if (android_64bit_target_cpu) {
+@@ -802,7 +802,7 @@ if (android_64bit_target_cpu) {
             "32-bit targets shouldn't have secondary abi")
      arch_suffix = "32"
      if (use_v8_context_snapshot) {
@@ -27,10 +27,10 @@ index 49ba7977cc0d5710918b3452ab57078ba31c9949..a362123cad17d061690e7cb5a26413fd
      } else {
        renaming_sources = [ "$_secondary_abi_out_dir/snapshot_blob.bin" ]
 diff --git a/chrome/BUILD.gn b/chrome/BUILD.gn
-index f7a1a0a98e1fd719a978dca14a743f4c12a360fc..d95d8602356c4488f2e8dfd9acbacf56fe6da4c7 100644
+index ed0dc4afc3dad05575272c931d6b82b632f61115..bda4b844a1c9fb1ac1bdb8dbd7ef380f0147382f 100644
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -768,7 +768,7 @@ if (is_win) {
+@@ -774,7 +774,7 @@ if (is_win) {
      if (v8_use_external_startup_data) {
        public_deps += [ "//v8" ]
        if (use_v8_context_snapshot) {
@@ -53,7 +53,7 @@ index 7c7af8c0d9487abcd82ecd9d2d5b1ab4b737148b..df39ea145cc6b05775db7fbfb680fce8
        } else {
          inputs += [ "$root_out_dir/snapshot_blob.bin" ]
 diff --git a/content/browser/BUILD.gn b/content/browser/BUILD.gn
-index ea3dbb364ece871c9ac9e21c0cd17aecb1b0480f..e38fe0bab6d66fbbed23c0ed3ccfa84eff9257f9 100644
+index fed29f648218c47c07dd6b23c0787d13016ee3c0..daf8d17a9d3035b857f83aa1935ed0a0c1987bc7 100644
 --- a/content/browser/BUILD.gn
 +++ b/content/browser/BUILD.gn
 @@ -36,6 +36,7 @@ source_set("browser") {
@@ -78,10 +78,10 @@ index d557c41a38e17c61e1b91d3daa47ea17e13a6a9e..43c93e3f50290d2aef230083a4bcebf3
    return {{kV8SnapshotDataDescriptor,
             base::FilePath(FILE_PATH_LITERAL("snapshot_blob.bin"))}};
 diff --git a/content/shell/BUILD.gn b/content/shell/BUILD.gn
-index 4e5161f3b5d71ef511fba0183dbdad0b2c6b58c9..09d4a1e0a80d193ab05bf6c61278e7cc7f6d7beb 100644
+index 831caaf67c31f4fdb1df47d434803ffe44d7db85..51a0b31eb616ee39d672ead2aafe470bdebaa6bd 100644
 --- a/content/shell/BUILD.gn
 +++ b/content/shell/BUILD.gn
-@@ -560,7 +560,7 @@ if (is_mac) {
+@@ -562,7 +562,7 @@ if (is_mac) {
      if (v8_use_external_startup_data) {
        public_deps += [ "//v8" ]
        if (use_v8_context_snapshot) {


### PR DESCRIPTION
We should only be testing whether or not the patch diffs have changed in testing builds - diffs during the release process should not fail the release process itself.

cc @jkleinsc @MarshallOfSound 

Notes: none