### PR TITLE
fix: draggable region edge calculation on resize

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -14,6 +14,7 @@
 #include "content/public/browser/render_view_host.h"
 #include "shell/browser/api/electron_api_web_contents_view.h"
 #include "shell/browser/browser.h"
+#include "shell/browser/native_browser_view.h"
 #include "shell/browser/unresponsive_suppressor.h"
 #include "shell/browser/web_contents_preferences.h"
 #include "shell/browser/window_list.h"
@@ -304,9 +305,15 @@ void BrowserWindow::OnWindowIsKeyChanged(bool is_key) {
 
 void BrowserWindow::OnWindowResize() {
 #if defined(OS_MAC)
-  // Always update draggable regions here to ensure draggable bounds
-  // are recalculated for BrowserViews if any exist.
-  UpdateDraggableRegions(draggable_regions_);
+  if (!draggable_regions_.empty()) {
+    UpdateDraggableRegions(draggable_regions_);
+  } else {
+    // Ensure draggable bounds are recalculated for BrowserViews if any exist.
+    auto browser_views = window_->browser_views();
+    for (NativeBrowserView* view : browser_views) {
+      view->UpdateDraggableRegions(draggable_regions_);
+    }
+  }
 #endif
   BaseWindow::OnWindowResize();
 }

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -304,8 +304,9 @@ void BrowserWindow::OnWindowIsKeyChanged(bool is_key) {
 
 void BrowserWindow::OnWindowResize() {
 #if defined(OS_MAC)
-  if (!draggable_regions_.empty())
-    UpdateDraggableRegions(draggable_regions_);
+  // Always update draggable regions here to ensure draggable bounds
+  // are recalculated for BrowserViews if any exist.
+  UpdateDraggableRegions(draggable_regions_);
 #endif
   BaseWindow::OnWindowResize();
 }

--- a/shell/browser/api/electron_api_browser_window_mac.mm
+++ b/shell/browser/api/electron_api_browser_window_mac.mm
@@ -82,8 +82,8 @@ void BrowserWindow::UpdateDraggableRegions(
     if ([subview isKindOfClass:[ControlRegionView class]])
       [subview removeFromSuperview];
 
-  // Draggable regions is implemented by having the whole web view draggable
-  // (mouseDownCanMoveWindow) and overlaying regions that are not draggable.
+  // Draggable regions are implemented by having the whole web view draggable
+  // and overlaying regions that are not draggable.
   if (&draggable_regions_ != &regions) {
     draggable_regions_.clear();
     for (const auto& r : regions)

--- a/shell/browser/native_browser_view_mac.h
+++ b/shell/browser/native_browser_view_mac.h
@@ -28,6 +28,8 @@ class NativeBrowserViewMac : public NativeBrowserView {
       const std::vector<mojom::DraggableRegionPtr>& regions) override;
 
  private:
+  std::vector<mojom::DraggableRegionPtr> draggable_regions_;
+
   DISALLOW_COPY_AND_ASSIGN(NativeBrowserViewMac);
 };
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/26116.
Closes https://github.com/electron/electron/issues/22780.

Fixes an issue where draggable regions were not properly updated on BrowserViews when a containing `BrowserWindow` was resized. This was occurring because we were only updating draggable regions when the regions were non-empty, which was a logical error since the width and height will always need to be recalculated for a `BrowserView` contained within a frameless `BrowserWindow` on resize. Beyond that, it's the case that `BrowserView` bounds will not be set during the first call to `UpdateDraggableRegions` so we need to ensure the draggable regions are updated when the bounds _do_ get set. 

Tested with 
- https://gist.github.com/2c072f42d7abaf27e73961b1dde87811
- https://gist.github.com/codebytere/aab0eb3835ed4550e2498ef63c0a0be2

cc @deepak1556 @MarshallOfSound @zcbenz (and @ccorcos!)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue where draggable regions were not properly updated on BrowserViews when a containing `BrowserWindow` was resized.
