### PR TITLE
chore: don't self-include inspectable_web_contents.h

### DIFF
--- a/shell/browser/ui/inspectable_web_contents.h
+++ b/shell/browser/ui/inspectable_web_contents.h
@@ -23,7 +23,6 @@
 #include "content/public/browser/web_contents_delegate.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "electron/buildflags/buildflags.h"
-#include "shell/browser/ui/inspectable_web_contents.h"
 #include "ui/gfx/geometry/rect.h"
 
 class PrefService;


### PR DESCRIPTION
behavioral no-op. was fine because of header guards.

Notes: none