### PR TITLE
fix: build with printing disabled

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -338,7 +338,6 @@ source_set("electron_lib") {
     "//base/allocator:buildflags",
     "//chrome/app:command_ids",
     "//chrome/app/resources:platform_locale_settings",
-    "//chrome/services/printing/public/mojom",
     "//components/certificate_transparency",
     "//components/language/core/browser",
     "//components/net_log",
@@ -632,7 +631,10 @@ source_set("electron_lib") {
       "shell/renderer/printing/print_render_frame_helper_delegate.cc",
       "shell/renderer/printing/print_render_frame_helper_delegate.h",
     ]
-    deps += [ "//components/printing/common:mojo_interfaces" ]
+    deps += [
+      "//chrome/services/printing/public/mojom",
+      "//components/printing/common:mojo_interfaces",
+    ]
   }
 
   if (enable_electron_extensions) {


### PR DESCRIPTION
#### Description of Change

```
Undefined symbols for architecture x86_64:
  "SkPDF::AttributeList::appendName(char const*, char const*, char const*)", referenced from:
      (anonymous namespace)::RecursiveBuildStructureTree(ui::AXNode const*, SkPDF::StructureElementNode*) in metafile_utils.o
  "SkPDF::AttributeList::appendNodeIdArray(char const*, char const*, std::__1::vector<int, std::__1::allocator<int> > const&)", referenced from:
      (anonymous namespace)::RecursiveBuildStructureTree(ui::AXNode const*, SkPDF::StructureElementNode*) in metafile_utils.o
  "SkPDF::AttributeList::appendInt(char const*, char const*, int)", referenced from:
      (anonymous namespace)::RecursiveBuildStructureTree(ui::AXNode const*, SkPDF::StructureElementNode*) in metafile_utils.o
ld: symbol(s) not found for architecture x86_64
```

#### Release Notes

Notes: no-notes
