### PR TITLE
docs: update information on Linux support

### DIFF
--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -105,15 +105,13 @@ Running apps packaged with previous versions is possible using the ia32 binary.
 
 ### Linux
 
-The prebuilt `ia32` (`i686`) and `x64` (`amd64`) binaries of Electron are built on
-Ubuntu 12.04, the `armv7l` binary is built against ARM v7 with hard-float ABI and
-NEON for Debian Wheezy.
+The prebuilt binaries of Electron are built on Ubuntu 18.04.
 
 Whether the prebuilt binary can run on a distribution depends on whether the
 distribution includes the libraries that Electron is linked to on the building
-platform, so only Ubuntu 12.04 is guaranteed to work, but following platforms
+platform, so only Ubuntu 18.04 is guaranteed to work, but following platforms
 are also verified to be able to run the prebuilt binaries of Electron:
 
-* Ubuntu 12.04 and newer
-* Fedora 21
-* Debian 8
+* Ubuntu 14.04 and newer
+* Fedora 24 and newer
+* Debian 8 and newer

--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -109,10 +109,6 @@ The prebuilt `ia32` (`i686`) and `x64` (`amd64`) binaries of Electron are built 
 Ubuntu 12.04, the `armv7l` binary is built against ARM v7 with hard-float ABI and
 NEON for Debian Wheezy.
 
-[Until the release of Electron 2.0][arm-breaking-change], Electron will also
-continue to release the `armv7l` binary with a simple `arm` suffix. Both binaries
-are identical.
-
 Whether the prebuilt binary can run on a distribution depends on whether the
 distribution includes the libraries that Electron is linked to on the building
 platform, so only Ubuntu 12.04 is guaranteed to work, but following platforms
@@ -121,5 +117,3 @@ are also verified to be able to run the prebuilt binaries of Electron:
 * Ubuntu 12.04 and newer
 * Fedora 21
 * Debian 8
-
-[arm-breaking-change]: ../breaking-changes.md#duplicate-arm-assets


### PR DESCRIPTION
#### Description of Change

Attempted to update information in this doc.

* Removes a section of the doc that was relevant for Electron 1 and below.
* Seems like we're building on Ubuntu 18.04 based on [electron/build-images](https://github.com/electron/build-images). Is this accurate for all Linux binaries? @jkleinsc @MarshallOfSound 
* Tried to update minimum version numbers for Linux distros informed by [Chrome's minimum version requirements](https://support.google.com/chrome/a/answer/7100626?hl=en#gbwa:~:text=64%2Dbit%20Ubuntu%2014.04%2B%2C%20Debian%208%2B%2C%20openSUSE%2013.3%2B%2C%20or%20Fedora%20Linux%2024%2B).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
