### PR TITLE
feat: add APIs to enable/disable spell checker

### DIFF
--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -88,6 +88,7 @@ The `role` property can have following values:
 * `resetZoom` - Reset the focused page's zoom level to the original size.
 * `zoomIn` - Zoom in the focused page by 10%.
 * `zoomOut` - Zoom out the focused page by 10%.
+* `toggleSpellChecker` - Enable/disable builtin spell checker.
 * `fileMenu` - Whole default "File" menu (Close / Quit)
 * `editMenu` - Whole default "Edit" menu (Undo, Copy, etc.).
 * `viewMenu` - Whole default "View" menu (Reload, Toggle Developer Tools, etc.)

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -672,6 +672,16 @@ this session just before normal `preload` scripts run.
 Returns `String[]` an array of paths to preload scripts that have been
 registered.
 
+#### `ses.setSpellCheckerEnabled(enable)`
+
+* `enable` Boolean
+
+Sets whether to enable the builtin spell checker.
+
+#### `ses.isSpellCheckerEnabled()`
+
+Returns `Boolean` - Whether the builtin spell checker is enabled.
+
 #### `ses.setSpellCheckerLanguages(languages)`
 
 * `languages` String[] - An array of language codes to enable the spellchecker for.
@@ -801,6 +811,10 @@ The following properties are available on instances of `Session`:
 
 A `String[]` array which consists of all the known available spell checker languages.  Providing a language
 code to the `setSpellCheckerLanguages` API that isn't in this array will result in an error.
+
+#### `ses.spellCheckerEnabled`
+
+A `Boolean` indicating whether builtin spell checker is enabled.
 
 #### `ses.cookies` _Readonly_
 

--- a/lib/browser/api/menu-item.ts
+++ b/lib/browser/api/menu-item.ts
@@ -22,7 +22,7 @@ const MenuItem = function (this: any, options: any) {
     throw new Error('Invalid submenu');
   }
 
-  this.overrideReadOnlyProperty('type', 'normal');
+  this.overrideReadOnlyProperty('type', roles.getDefaultType(this.role));
   this.overrideReadOnlyProperty('role');
   this.overrideReadOnlyProperty('accelerator');
   this.overrideReadOnlyProperty('icon');
@@ -46,7 +46,8 @@ const MenuItem = function (this: any, options: any) {
   const click = options.click;
   this.click = (event: Event, focusedWindow: BrowserWindow, focusedWebContents: WebContents) => {
     // Manually flip the checked flags when clicked.
-    if (this.type === 'checkbox' || this.type === 'radio') {
+    if (!roles.shouldOverrideCheckStatus(this.role) &&
+        (this.type === 'checkbox' || this.type === 'radio')) {
       this.checked = !this.checked;
     }
 
@@ -64,6 +65,11 @@ MenuItem.types = ['normal', 'separator', 'submenu', 'checkbox', 'radio'];
 
 MenuItem.prototype.getDefaultRoleAccelerator = function () {
   return roles.getDefaultAccelerator(this.role);
+};
+
+MenuItem.prototype.getCheckStatus = function () {
+  if (!roles.shouldOverrideCheckStatus(this.role)) return this.checked;
+  return roles.getCheckStatus(this.role);
 };
 
 MenuItem.prototype.overrideProperty = function (name: string, defaultValue: any = null) {

--- a/lib/browser/api/menu.ts
+++ b/lib/browser/api/menu.ts
@@ -17,7 +17,9 @@ Menu.prototype._init = function () {
 };
 
 Menu.prototype._isCommandIdChecked = function (id) {
-  return this.commandsMap[id] ? this.commandsMap[id].checked : false;
+  const item = this.commandsMap[id];
+  if (!item) return false;
+  return item.getCheckStatus();
 };
 
 Menu.prototype._isCommandIdEnabled = function (id) {

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -1078,6 +1078,17 @@ bool Session::RemoveWordFromSpellCheckerDictionary(const std::string& word) {
 #endif
   return service->GetCustomDictionary()->RemoveWord(word);
 }
+
+void Session::SetSpellCheckerEnabled(bool b) {
+  browser_context_->prefs()->SetBoolean(spellcheck::prefs::kSpellCheckEnable,
+                                        b);
+}
+
+bool Session::IsSpellCheckerEnabled() const {
+  return browser_context_->prefs()->GetBoolean(
+      spellcheck::prefs::kSpellCheckEnable);
+}
+
 #endif  // BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
 
 // static
@@ -1180,6 +1191,10 @@ gin::ObjectTemplateBuilder Session::GetObjectTemplateBuilder(
                  &Session::AddWordToSpellCheckerDictionary)
       .SetMethod("removeWordFromSpellCheckerDictionary",
                  &Session::RemoveWordFromSpellCheckerDictionary)
+      .SetMethod("setSpellCheckerEnabled", &Session::SetSpellCheckerEnabled)
+      .SetMethod("isSpellCheckerEnabled", &Session::IsSpellCheckerEnabled)
+      .SetProperty("spellCheckerEnabled", &Session::IsSpellCheckerEnabled,
+                   &Session::SetSpellCheckerEnabled)
 #endif
       .SetMethod("preconnect", &Session::Preconnect)
       .SetMethod("closeAllConnections", &Session::CloseAllConnections)

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -131,6 +131,8 @@ class Session : public gin::Wrappable<Session>,
   v8::Local<v8::Promise> ListWordsInSpellCheckerDictionary();
   bool AddWordToSpellCheckerDictionary(const std::string& word);
   bool RemoveWordFromSpellCheckerDictionary(const std::string& word);
+  void SetSpellCheckerEnabled(bool b);
+  bool IsSpellCheckerEnabled() const;
 #endif
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)

--- a/spec-main/spellchecker-spec.ts
+++ b/spec-main/spellchecker-spec.ts
@@ -101,6 +101,29 @@ ifdescribe(features.isBuiltinSpellCheckerEnabled())('spellchecker', () => {
     expect(await callWebFrameFn('getWordSuggestions("testt")')).to.not.be.empty();
   });
 
+  describe('spellCheckerEnabled', () => {
+    it('is enabled by default', async () => {
+      expect(w.webContents.session.spellCheckerEnabled).to.be.true();
+    });
+
+    ifit(shouldRun)('can be dynamically changed', async () => {
+      await w.webContents.executeJavaScript('document.body.querySelector("textarea").value = "Beautifulllll asd asd"');
+      await w.webContents.executeJavaScript('document.body.querySelector("textarea").focus()');
+      // Wait for spellchecker to load
+      await delay(500);
+
+      const callWebFrameFn = (expr: string) => w.webContents.executeJavaScript('require("electron").webFrame.' + expr);
+
+      w.webContents.session.spellCheckerEnabled = false;
+      expect(w.webContents.session.spellCheckerEnabled).to.be.false();
+      expect(await callWebFrameFn('isWordMisspelled("testt")')).to.equal(false);
+
+      w.webContents.session.spellCheckerEnabled = true;
+      expect(w.webContents.session.spellCheckerEnabled).to.be.true();
+      expect(await callWebFrameFn('isWordMisspelled("testt")')).to.equal(true);
+    });
+  });
+
   describe('custom dictionary word list API', () => {
     let ses: Session;
 

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -136,6 +136,7 @@ declare namespace Electron {
     overrideReadOnlyProperty(property: string, value: any): void;
     groupId: number;
     getDefaultRoleAccelerator(): Accelerator | undefined;
+    getCheckStatus(): boolean;
     acceleratorWorksWhenHidden?: boolean;
   }
 


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/3211.

This PR adds a `ses.spellCheckerEnabled` property which can be used to enable/disable the builtin spell checker, and a `toggleSpellChecker` menu item role that maps to the "Check Spelling While Typing" menu item.

<img width="326" alt="Screen Shot 2020-11-05 at 9 30 38" src="https://user-images.githubusercontent.com/639601/98182624-96529400-1f49-11eb-9f89-50a6f7cd9a58.png">

To completely solve #3211 we also need some APIs for the spell panel, which are added in https://github.com/electron/electron/pull/26332.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Add APIs to enable/disable spell checker.