### PR TITLE
docs: tidy up links

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1105,7 +1105,7 @@ Activation policy types:
 
 Imports the certificate in pkcs12 format into the platform certificate store.
 `callback` is called with the `result` of import operation, a value of `0`
-indicates success while any other value indicates failure according to Chromium [net_error_list](https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h).
+indicates success while any other value indicates failure according to Chromium [net_error_list](https://source.chromium.org/chromium/chromium/src/+/master:net/base/net_error_list.h).
 
 ### `app.disableHardwareAcceleration()`
 

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -88,7 +88,7 @@ win.show()
 * On Linux, users have to put `--enable-transparent-visuals --disable-gpu` in
   the command line to disable GPU and allow ARGB to make transparent window,
   this is caused by an upstream bug that [alpha channel doesn't work on some
-  NVidia drivers](https://code.google.com/p/chromium/issues/detail?id=369209) on
+  NVidia drivers](https://bugs.chromium.org/p/chromium/issues/detail?id=369209) on
   Linux.
 * On Mac, the native window shadow will not be shown on a transparent window.
 

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -454,7 +454,7 @@ the original network configuration.
     * `errorCode` Integer - Error code.
   * `callback` Function
     * `verificationResult` Integer - Value can be one of certificate error codes
-    from [here](https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h).
+    from [here](https://source.chromium.org/chromium/chromium/src/+/master:net/base/net_error_list.h).
     Apart from the certificate error codes, the following special codes can be used.
       * `0` - Indicates success and disables Certificate Transparency verification.
       * `-2` - Indicates failure.

--- a/docs/api/structures/protocol-response.md
+++ b/docs/api/structures/protocol-response.md
@@ -31,4 +31,4 @@
 * `uploadData` ProtocolResponseUploadData (optional) - The data used as upload data. This is only
   used for URL responses when `method` is `"POST"`.
 
-[net-error]: https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h
+[net-error]: https://source.chromium.org/chromium/chromium/src/+/master:net/base/net_error_list.h

--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -26,7 +26,7 @@ Security` → `System` → `Advanced system settings` and add a system variable
 your locally installed version of Visual Studio (by default, `depot_tools` will
 try to download a Google-internal version that only Googlers have access to).
 
-[depot-tools]: http://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html#_setting_up
+[depot-tools]: https://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html#_setting_up
 
 ### Setting up the git cache
 

--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -16,7 +16,7 @@ Follow the guidelines below for building Electron on Windows.
   * [Python for Windows (pywin32) Extensions](https://pypi.org/project/pywin32/#files)
   is also needed in order to run the build process.
 * [Node.js](https://nodejs.org/download/)
-* [Git](http://git-scm.com)
+* [Git](https://git-scm.com)
 * Debugging Tools for Windows of Windows SDK 10.0.15063.468 if you plan on
 creating a full distribution since `symstore.exe` is used for creating a symbol
 store from `.pdb` files.

--- a/docs/development/chromium-development.md
+++ b/docs/development/chromium-development.md
@@ -8,6 +8,6 @@
 - [Code Search](https://cs.chromium.org/)
 - [Source Code](https://cs.chromium.org/chromium/src/)
 - [Development Calendar and Release Info](https://www.chromium.org/developers/calendar)
-- [Discussion Groups](http://www.chromium.org/developers/discussion-groups)
+- [Discussion Groups](https://www.chromium.org/developers/discussion-groups)
 
 See also [V8 Development](v8-development.md)

--- a/docs/development/clang-format.md
+++ b/docs/development/clang-format.md
@@ -1,6 +1,6 @@
 # Using clang-format on C++ Code
 
-[`clang-format`](http://clang.llvm.org/docs/ClangFormat.html) is a tool to
+[`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) is a tool to
 automatically format C/C++/Objective-C code, so that developers don't need to
 worry about style issues during code reviews.
 
@@ -31,5 +31,5 @@ You can also integrate `clang-format` directly into your favorite editors.
 For further guidance on setting up editor integration, see these pages:
 
   * [Atom](https://atom.io/packages/clang-format)
-  * [Vim & Emacs](http://clang.llvm.org/docs/ClangFormat.html#vim-integration)
+  * [Vim & Emacs](https://clang.llvm.org/docs/ClangFormat.html#vim-integration)
   * [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format)

--- a/docs/development/coding-style.md
+++ b/docs/development/coding-style.md
@@ -47,7 +47,7 @@ formatted correctly.
 
 ## JavaScript
 
-* Write [standard](https://npm.im/standard) JavaScript style.
+* Write [standard](https://www.npmjs.com/package/standard) JavaScript style.
 * File names should be concatenated with `-` instead of `_`, e.g.
   `file-name.js` rather than `file_name.js`, because in
   [github/atom](https://github.com/github/atom) module names are usually in

--- a/docs/development/debugging-instructions-macos.md
+++ b/docs/development/debugging-instructions-macos.md
@@ -129,4 +129,4 @@ will explain more complex debugging scenarios.
 
 [lldb-command-structure]: https://developer.apple.com/library/mac/documentation/IDEs/Conceptual/gdb_to_lldb_transition_guide/document/lldb-basics.html#//apple_ref/doc/uid/TP40012917-CH2-SW2
 [lldb-standalone]: https://developer.apple.com/library/mac/documentation/IDEs/Conceptual/gdb_to_lldb_transition_guide/document/lldb-terminal-workflow-tutorial.html
-[lldb-tutorial]: http://lldb.llvm.org/tutorial.html
+[lldb-tutorial]: https://lldb.llvm.org/tutorial.html

--- a/docs/development/electron-vs-nwjs.md
+++ b/docs/development/electron-vs-nwjs.md
@@ -19,7 +19,7 @@ application.
 
 Electron works more like the Node.js runtime. Electron's APIs are lower level so
 you can use it for browser testing in place of
-[PhantomJS](http://phantomjs.org/).
+[PhantomJS](https://phantomjs.org/).
 
 ## 2) Node Integration
 

--- a/docs/development/v8-development.md
+++ b/docs/development/v8-development.md
@@ -2,10 +2,10 @@
 
 > A collection of resources for learning and using V8
 
-* [V8 Tracing](https://github.com/v8/v8/wiki/Tracing-V8)
-* [V8 Profiler](https://github.com/v8/v8/wiki/V8-Profiler) - Profiler combinations which are useful for profiling: `--prof`, `--trace-ic`, `--trace-opt`, `--trace-deopt`, `--print-bytecode`, `--print-opt-code`
+* [V8 Tracing](https://v8.dev/docs/trace)
+* [V8 Profiler](https://v8.dev/docs/profile) - Profiler combinations which are useful for profiling: `--prof`, `--trace-ic`, `--trace-opt`, `--trace-deopt`, `--print-bytecode`, `--print-opt-code`
 * [V8 Interpreter Design](https://docs.google.com/document/d/11T2CRex9hXxoJwbYqVQ32yIPMh0uouUZLdyrtmMoL44/edit?ts=56f27d9d#heading=h.6jz9dj3bnr8t)
-* [Optimizing compiler](https://github.com/v8/v8/wiki/TurboFan)
-* [V8 GDB Debugging](https://github.com/v8/v8/wiki/GDB-JIT-Interface)
+* [Optimizing compiler](https://v8.dev/docs/turbofan)
+* [V8 GDB Debugging](https://v8.dev/docs/gdb-jit)
 
 See also [Chromium Development](chromium-development.md)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -133,7 +133,7 @@ is only available in renderer processes.
 
 ## The font looks blurry, what is this and what can I do?
 
-If [sub-pixel anti-aliasing](http://alienryderflex.com/sub_pixel/) is deactivated, then fonts on LCD screens can look blurry. Example:
+If [sub-pixel anti-aliasing](https://alienryderflex.com/sub_pixel/) is deactivated, then fonts on LCD screens can look blurry. Example:
 
 ![subpixel rendering example]
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -159,7 +159,7 @@ building it.
 V8's version numbers always correspond to those of Google Chrome. Chrome 59
 includes V8 5.9, Chrome 58 includes V8 5.8, etc.
 
-- [developers.google.com/v8](https://developers.google.com/v8)
+- [v8.dev](https://v8.dev/)
 - [nodejs.org/api/v8.html](https://nodejs.org/api/v8.html)
 - [docs/development/v8-development.md](development/v8-development.md)
 

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -48,7 +48,7 @@ For API references, there are exceptions to this rule.
 * Lines should be wrapped at 80 columns.
 * No nesting lists more than 2 levels (due to the markdown renderer).
 * All `js` and `javascript` code blocks are linted with
-[standard-markdown](http://npm.im/standard-markdown).
+[standard-markdown](https://www.npmjs.com/package/standard-markdown).
 
 ## Picking words
 

--- a/docs/tutorial/automated-testing-with-a-custom-driver.md
+++ b/docs/tutorial/automated-testing-with-a-custom-driver.md
@@ -1,6 +1,6 @@
 # Automated Testing with a Custom Driver
 
-To write automated tests for your Electron app, you will need a way to "drive" your application. [Spectron](https://electronjs.org/spectron) is a commonly-used solution which lets you emulate user actions via [WebDriver](http://webdriver.io/). However, it's also possible to write your own custom driver using node's builtin IPC-over-STDIO. The benefit of a custom driver is that it tends to require less overhead than Spectron, and lets you expose custom methods to your test suite.
+To write automated tests for your Electron app, you will need a way to "drive" your application. [Spectron](https://electronjs.org/spectron) is a commonly-used solution which lets you emulate user actions via [WebDriver](https://webdriver.io/). However, it's also possible to write your own custom driver using node's builtin IPC-over-STDIO. The benefit of a custom driver is that it tends to require less overhead than Spectron, and lets you expose custom methods to your test suite.
 
 To create a custom driver, we'll use Node.js' [child_process](https://nodejs.org/api/child_process.html) API. The test suite will spawn the Electron process, then establish a simple messaging protocol:
 

--- a/docs/tutorial/electron-versioning.md
+++ b/docs/tutorial/electron-versioning.md
@@ -16,7 +16,7 @@ npm install --save-dev electron@latest
 
 ## Version 1.x
 
-Electron versions *< 2.0* did not conform to the [semver](http://semver.org) spec: major versions corresponded to end-user API changes, minor versions corresponded to Chromium major releases, and patch versions corresponded to new features and bug fixes. While convenient for developers merging features, it creates problems for developers of client-facing applications. The QA testing cycles of major apps like Slack, Stride, Teams, Skype, VS Code, Atom, and Desktop can be lengthy and stability is a highly desired outcome. There is a high risk in adopting new features while trying to absorb bug fixes.
+Electron versions *< 2.0* did not conform to the [semver](https://semver.org) spec: major versions corresponded to end-user API changes, minor versions corresponded to Chromium major releases, and patch versions corresponded to new features and bug fixes. While convenient for developers merging features, it creates problems for developers of client-facing applications. The QA testing cycles of major apps like Slack, Stride, Teams, Skype, VS Code, Atom, and Desktop can be lengthy and stability is a highly desired outcome. There is a high risk in adopting new features while trying to absorb bug fixes.
 
 Here is an example of the 1.x strategy:
 

--- a/docs/tutorial/mac-app-store-submission-guide.md
+++ b/docs/tutorial/mac-app-store-submission-guide.md
@@ -242,14 +242,14 @@ Electron uses following cryptographic algorithms:
 * ECDH - ANS X9.63–2001
 * HKDF - [NIST SP 800-56C](https://csrc.nist.gov/publications/nistpubs/800-56C/SP-800-56C.pdf)
 * PBKDF2 - [RFC 2898](https://tools.ietf.org/html/rfc2898)
-* RSA - [RFC 3447](http://www.ietf.org/rfc/rfc3447)
+* RSA - [RFC 3447](https://www.ietf.org/rfc/rfc3447)
 * SHA - [FIPS 180-4](https://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf)
 * Blowfish - https://www.schneier.com/cryptography/blowfish/
 * CAST - [RFC 2144](https://tools.ietf.org/html/rfc2144), [RFC 2612](https://tools.ietf.org/html/rfc2612)
 * DES - [FIPS 46-3](https://csrc.nist.gov/publications/fips/fips46-3/fips46-3.pdf)
 * DH - [RFC 2631](https://tools.ietf.org/html/rfc2631)
 * DSA - [ANSI X9.30](https://webstore.ansi.org/RecordDetail.aspx?sku=ANSI+X9.30-1%3A1997)
-* EC - [SEC 1](http://www.secg.org/sec1-v2.pdf)
+* EC - [SEC 1](https://www.secg.org/sec1-v2.pdf)
 * IDEA - "On the Design and Security of Block Ciphers" book by X. Lai
 * MD2 - [RFC 1319](https://tools.ietf.org/html/rfc1319)
 * MD4 - [RFC 6150](https://tools.ietf.org/html/rfc6150)
@@ -257,7 +257,7 @@ Electron uses following cryptographic algorithms:
 * MDC2 - [ISO/IEC 10118-2](https://wiki.openssl.org/index.php/Manual:Mdc2(3))
 * RC2 - [RFC 2268](https://tools.ietf.org/html/rfc2268)
 * RC4 - [RFC 4345](https://tools.ietf.org/html/rfc4345)
-* RC5 - http://people.csail.mit.edu/rivest/Rivest-rc5rev.pdf
+* RC5 - https://people.csail.mit.edu/rivest/Rivest-rc5rev.pdf
 * RIPEMD - [ISO/IEC 10118-3](https://webstore.ansi.org/RecordDetail.aspx?sku=ISO%2FIEC%2010118-3:2004)
 
 [developer-program]: https://developer.apple.com/support/compare-memberships/

--- a/docs/tutorial/using-selenium-and-webdriver.md
+++ b/docs/tutorial/using-selenium-and-webdriver.md
@@ -11,7 +11,7 @@ From [ChromeDriver - WebDriver for Chrome][chrome-driver]:
 ## Setting up Spectron
 
 [Spectron][spectron] is the officially supported ChromeDriver testing framework
-for Electron. It is built on top of [WebdriverIO](http://webdriver.io/) and
+for Electron. It is built on top of [WebdriverIO](https://webdriver.io/) and
 has helpers to access Electron APIs in your tests and bundles ChromeDriver.
 
 ```sh
@@ -51,7 +51,7 @@ verifyWindowIsVisibleWithTitle(myApp)
 
 ## Setting up with WebDriverJs
 
-[WebDriverJs](https://code.google.com/p/selenium/wiki/WebDriverJs) provides
+[WebDriverJs](https://www.selenium.dev/selenium/docs/api/javascript/index.html) provides
 a Node package for testing with web driver, we will use it as an example.
 
 ### 1. Start ChromeDriver
@@ -108,7 +108,7 @@ driver.quit()
 
 ## Setting up with WebdriverIO
 
-[WebdriverIO](http://webdriver.io/) provides a Node package for testing with web
+[WebdriverIO](https://webdriver.io/) provides a Node package for testing with web
 driver.
 
 ### 1. Start ChromeDriver


### PR DESCRIPTION
#### Description of Change
Tidying up some links in the docs. Couple different things rolled into one PR:

* Change links to code.google.com since it's no longer active
* Fix a couple broken links
* http:// => https:// when supported - least chance of breaking going forward and HTTPS all the things
* Changed some links that auto-redirected or had a "no longer at this URL" landing page to be the current URL

#### Checklist

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none
