### PR TITLE
fix: fail protocol request when OnWrite fails

### DIFF
--- a/shell/browser/net/electron_url_loader_factory.cc
+++ b/shell/browser/net/electron_url_loader_factory.cc
@@ -153,15 +153,13 @@ struct WriteData {
 };
 
 void OnWrite(std::unique_ptr<WriteData> write_data, MojoResult result) {
-  if (result != MOJO_RESULT_OK) {
-    network::URLLoaderCompletionStatus status(net::ERR_FAILED);
-    return;
+  network::URLLoaderCompletionStatus status(net::ERR_FAILED);
+  if (result == MOJO_RESULT_OK) {
+    status = network::URLLoaderCompletionStatus(net::OK);
+    status.encoded_data_length = write_data->data.size();
+    status.encoded_body_length = write_data->data.size();
+    status.decoded_body_length = write_data->data.size();
   }
-
-  network::URLLoaderCompletionStatus status(net::OK);
-  status.encoded_data_length = write_data->data.size();
-  status.encoded_body_length = write_data->data.size();
-  status.decoded_body_length = write_data->data.size();
   write_data->client->OnComplete(status);
 }
 


### PR DESCRIPTION
#### Description of Change

Wasn't sending a failed response for a protocol request in an error case, could have left the request without a response. I don't know of a way to easily test this, wasn't able to trigger it, seems like a corner-case.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fixed error handling on write failure in the protocol module