### PR TITLE
fix: improve redirect behavior in protocol module

### DIFF
--- a/spec-main/api-protocol-spec.ts
+++ b/spec-main/api-protocol-spec.ts
@@ -671,6 +671,26 @@ describe('protocol module', () => {
       const r = await ajax('http://fake-host');
       expect(r.data).to.equal('redirect');
     });
+
+    it('should discard post data after redirection', async () => {
+      interceptStreamProtocol('http', (request, callback) => {
+        if (request.url.indexOf('http://fake-host') === 0) {
+          setTimeout(() => {
+            callback({
+              statusCode: 302,
+              headers: {
+                Location: 'http://fake-redirect'
+              }
+            });
+          }, 300);
+        } else {
+          expect(request.url.indexOf('http://fake-redirect')).to.equal(0);
+          callback(getStream(3, request.method));
+        }
+      });
+      const r = await ajax('http://fake-host', { type: 'POST', data: postData });
+      expect(r.data).to.equal('GET');
+    });
   });
 
   describe('protocol.uninterceptProtocol', () => {


### PR DESCRIPTION
#### Description of Change

Refs code in [`content/common/service_worker/service_worker_loader_helpers.cc`](https://source.chromium.org/chromium/chromium/src/+/5da0ed1e65305ab2c6d9de2bb4ce62f159520ba8:content/common/service_worker/service_worker_loader_helpers.cc;l=127-151).

Close #25894. It may fix it, but no reproduce case has been provided, so I can't definitively say that this fixes it.

I tried to add test coverage, but the test times out for some reason. I can see that it reaches the expected `callback(text)` after redirecting, but the promise from `executeJavaScript` never resolves. I've tried both `ajax` and `fetch` to no avail. The test was manually tested using that intercept code and acted as expected - `POST`s receiving a 302 or 303 redirects will be request the new location using `GET` rather than the current behavior of staying on `POST`. The test mentions matching Chromium's behavior because by-the-spec 302 is supposed to act like 307, but in Chromium (and I think every browser) it acts like 303 for backwards compatibility.

So the test failure seems to be a testing-only failure. Maybe someone else can spot an issue I'm not seeing.

cc @zcbenz

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed behavior of 302/303/307 redirect responses in the protocol module.
