### PR TITLE
fix: recognize ?Cancel/?No as default cancel buttons

### DIFF
--- a/lib/browser/api/dialog.ts
+++ b/lib/browser/api/dialog.ts
@@ -186,7 +186,6 @@ const messageBox = (sync: boolean, window: BrowserWindow | null, options?: Messa
   const messageBoxType = messageBoxTypes.indexOf(type);
   if (messageBoxType === -1) throw new TypeError('Invalid message box type');
   if (!Array.isArray(buttons)) throw new TypeError('Buttons must be an array');
-  if (options.normalizeAccessKeys) buttons = buttons.map(normalizeAccessKey);
   if (typeof title !== 'string') throw new TypeError('Title must be a string');
   if (typeof noLink !== 'boolean') throw new TypeError('noLink must be a boolean');
   if (typeof message !== 'string') throw new TypeError('Message must be a string');
@@ -203,13 +202,16 @@ const messageBox = (sync: boolean, window: BrowserWindow | null, options?: Messa
     // If the defaultId is set to 0, ensure the cancel button is a different index (1)
     cancelId = (defaultId === 0 && buttons.length > 1) ? 1 : 0;
     for (let i = 0; i < buttons.length; i++) {
-      const text = buttons[i].toLowerCase();
+      var text = buttons[i].toLowerCase();
+      if (options.normalizeAccessKeys) text = text.replace('?', '');
       if (text === 'cancel' || text === 'no') {
         cancelId = i;
         break;
       }
     }
   }
+
+  if (options.normalizeAccessKeys) buttons = buttons.map(normalizeAccessKey);
 
   const settings = {
     window,

--- a/lib/browser/api/dialog.ts
+++ b/lib/browser/api/dialog.ts
@@ -202,7 +202,7 @@ const messageBox = (sync: boolean, window: BrowserWindow | null, options?: Messa
     // If the defaultId is set to 0, ensure the cancel button is a different index (1)
     cancelId = (defaultId === 0 && buttons.length > 1) ? 1 : 0;
     for (let i = 0; i < buttons.length; i++) {
-      var text = buttons[i].toLowerCase();
+      let text = buttons[i].toLowerCase();
       if (options.normalizeAccessKeys) text = text.replace('?', '');
       if (text === 'cancel' || text === 'no') {
         cancelId = i;


### PR DESCRIPTION
#### Description of Change
This allows e.g. `?Cancel` to be recognized automatically as the cancel button.

#### Checklist

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none