### PR TITLE
fix: draggable region edge calculation on resize

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -13,6 +13,7 @@
 #include "content/public/browser/render_process_host.h"
 #include "content/public/browser/render_view_host.h"
 #include "shell/browser/browser.h"
+#include "shell/browser/native_browser_view.h"
 #include "shell/browser/unresponsive_suppressor.h"
 #include "shell/browser/web_contents_preferences.h"
 #include "shell/browser/window_list.h"
@@ -301,8 +302,15 @@ void BrowserWindow::OnWindowIsKeyChanged(bool is_key) {
 
 void BrowserWindow::OnWindowResize() {
 #if defined(OS_MACOSX)
-  if (!draggable_regions_.empty())
+  if (!draggable_regions_.empty()) {
     UpdateDraggableRegions(draggable_regions_);
+  } else {
+    // Ensure draggable bounds are recalculated for BrowserViews if any exist.
+    auto browser_views = window_->browser_views();
+    for (NativeBrowserView* view : browser_views) {
+      view->UpdateDraggableRegions(draggable_regions_);
+    }
+  }
 #endif
   TopLevelWindow::OnWindowResize();
 }

--- a/shell/browser/api/electron_api_browser_window_mac.mm
+++ b/shell/browser/api/electron_api_browser_window_mac.mm
@@ -82,8 +82,8 @@ void BrowserWindow::UpdateDraggableRegions(
     if ([subview isKindOfClass:[ControlRegionView class]])
       [subview removeFromSuperview];
 
-  // Draggable regions is implemented by having the whole web view draggable
-  // (mouseDownCanMoveWindow) and overlaying regions that are not draggable.
+  // Draggable regions are implemented by having the whole web view draggable
+  // and overlaying regions that are not draggable.
   if (&draggable_regions_ != &regions) {
     draggable_regions_.clear();
     for (const auto& r : regions)

--- a/shell/browser/native_browser_view_mac.h
+++ b/shell/browser/native_browser_view_mac.h
@@ -28,6 +28,8 @@ class NativeBrowserViewMac : public NativeBrowserView {
       const std::vector<mojom::DraggableRegionPtr>& regions) override;
 
  private:
+  std::vector<mojom::DraggableRegionPtr> draggable_regions_;
+
   DISALLOW_COPY_AND_ASSIGN(NativeBrowserViewMac);
 };
 

--- a/shell/browser/native_browser_view_mac.mm
+++ b/shell/browser/native_browser_view_mac.mm
@@ -206,6 +206,9 @@ void NativeBrowserViewMac::SetBounds(const gfx::Rect& bounds) {
   view.frame =
       NSMakeRect(bounds.x(), superview_height - bounds.y() - bounds.height(),
                  bounds.width(), bounds.height());
+
+  // Ensure draggable regions are properly updated to reflect new bounds.
+  UpdateDraggableRegions(draggable_regions_);
 }
 
 gfx::Rect NativeBrowserViewMac::GetBounds() {
@@ -245,8 +248,22 @@ void NativeBrowserViewMac::UpdateDraggableRegions(
 
   NSInteger webViewWidth = NSWidth([web_view bounds]);
   NSInteger webViewHeight = NSHeight([web_view bounds]);
-  auto drag_exclude_rects = CalculateNonDraggableRegions(
-      DraggableRegionsToSkRegion(regions), webViewWidth, webViewHeight);
+
+  std::vector<gfx::Rect> drag_exclude_rects;
+  if (regions.empty()) {
+    drag_exclude_rects.push_back(gfx::Rect(0, 0, webViewWidth, webViewHeight));
+  } else {
+    drag_exclude_rects = CalculateNonDraggableRegions(
+        DraggableRegionsToSkRegion(regions), webViewWidth, webViewHeight);
+  }
+
+  // Draggable regions are implemented by having the whole web view draggable
+  // and overlaying regions that are not draggable.
+  if (&draggable_regions_ != &regions) {
+    draggable_regions_.clear();
+    for (const auto& r : regions)
+      draggable_regions_.push_back(r.Clone());
+  }
 
   // Remove all DragRegionViews that were added last time. Note that we need
   // to copy the `subviews` array to avoid mutation during iteration.


### PR DESCRIPTION
Backport of #26233

See that PR for details.


Notes: Fixes an issue where draggable regions were not properly updated on BrowserViews when a containing `BrowserWindow` was resized.
