### PR TITLE
test: fix visibility flake on mac

### DIFF
--- a/spec-main/visibility-state-spec.ts
+++ b/spec-main/visibility-state-spec.ts
@@ -69,7 +69,7 @@ ifdescribe(process.platform !== 'linux')('document.visibilityState', () => {
     // TODO(MarshallOfSound): Figure out if we can work around this 1 tick issue for users
     if (process.platform === 'darwin') {
       // Wait for a tick, the window being "shown" takes 1 tick on macOS
-      await delay(0);
+      await delay(10000);
     }
     w.hide();
     load();


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
This fixes the "document.visibilityState should be hidden when the window is initially shown but hidden before the page is loaded - should be hidden when the window is initially shown but hidden before the page is loaded" which is very flaky on mac, eg: https://app.circleci.com/pipelines/github/electron/electron/32242/workflows/db09c645-46e2-46d4-99b9-45f2389bbda0/jobs/710158

I modified the tests to run the visibility suite 100 times with this change and it successfully ran without flaking:
https://app.circleci.com/pipelines/github/electron/electron/32232/workflows/5516c841-9f62-48a3-a553-2d6ab29170b8

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
