### PR TITLE
feat: add support for spelling panel on macOS

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -657,6 +657,14 @@ source_set("electron_lib") {
       "shell/browser/electron_pdf_web_contents_helper_client.h",
     ]
   }
+  if (enable_builtin_spellchecker && has_spellcheck_panel) {
+    sources += [
+      "shell/browser/ui/cocoa/electron_render_widget_host_view_mac_delegate.h",
+      "shell/browser/ui/cocoa/electron_render_widget_host_view_mac_delegate.mm",
+      "shell/browser/ui/cocoa/electron_web_contents_view_delegate.h",
+      "shell/browser/ui/cocoa/electron_web_contents_view_delegate.mm",
+    ]
+  }
 
   sources += get_target_outputs(":electron_fuses")
 

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -97,6 +97,7 @@ The `role` property can have following values:
 The following additional roles are available on _macOS_:
 
 * `showSpellingPanel` - Open the "Spelling and Grammar" panel.
+* `checkSpelling` - Check document's spelling now.
 * `appMenu` - Whole default "App" menu (About, Services, etc.)
 * `hide` - Map to the `hide` action.
 * `hideOthers` - Map to the `hideOtherApplications` action.

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -96,6 +96,7 @@ The `role` property can have following values:
 
 The following additional roles are available on _macOS_:
 
+* `showSpellingPanel` - Open the "Spelling and Grammar" panel.
 * `appMenu` - Whole default "App" menu (About, Services, etc.)
 * `hide` - Map to the `hide` action.
 * `hideOthers` - Map to the `hideOtherApplications` action.

--- a/filenames.gni
+++ b/filenames.gni
@@ -628,6 +628,8 @@ filenames = {
     "shell/renderer/api/electron_api_spell_check_client.cc",
     "shell/renderer/api/electron_api_spell_check_client.h",
     "shell/renderer/api/electron_api_web_frame.cc",
+    "shell/renderer/binder_registry_holder.cc",
+    "shell/renderer/binder_registry_holder.h",
     "shell/renderer/browser_exposed_renderer_interfaces.cc",
     "shell/renderer/browser_exposed_renderer_interfaces.h",
     "shell/renderer/content_settings_observer.cc",

--- a/lib/browser/api/menu-item-roles.ts
+++ b/lib/browser/api/menu-item-roles.ts
@@ -6,7 +6,8 @@ const isLinux = process.platform === 'linux';
 
 type RoleId = 'about' | 'close' | 'copy' | 'cut' | 'delete' | 'forcereload' | 'front' | 'help' | 'hide' | 'hideothers' | 'minimize' |
   'paste' | 'pasteandmatchstyle' | 'quit' | 'redo' | 'reload' | 'resetzoom' | 'selectall' | 'services' | 'recentdocuments' | 'clearrecentdocuments' | 'startspeaking' | 'stopspeaking' |
-  'toggledevtools' | 'togglefullscreen' | 'undo' | 'unhide' | 'window' | 'zoom' | 'zoomin' | 'zoomout' | 'togglespellchecker' |
+  'toggledevtools' | 'togglefullscreen' | 'undo' | 'unhide' | 'window' | 'zoom' | 'zoomin' | 'zoomout' |
+  'togglespellchecker' | 'showspellingpanel' |
   'appmenu' | 'filemenu' | 'editmenu' | 'viewmenu' | 'windowmenu' | 'sharemenu'
 interface Role {
   label: string;
@@ -194,6 +195,10 @@ export const roleList: Record<RoleId, Role> = {
       const ses = wc ? wc.session : session.defaultSession;
       ses.spellCheckerEnabled = !ses.spellCheckerEnabled;
     }
+  },
+  showspellingpanel: {
+    label: 'Show Spelling and Grammar',
+    nonNativeMacOSRole: true
   },
   // App submenu should be used for Mac only
   appmenu: {

--- a/lib/browser/api/menu-item-roles.ts
+++ b/lib/browser/api/menu-item-roles.ts
@@ -7,7 +7,7 @@ const isLinux = process.platform === 'linux';
 type RoleId = 'about' | 'close' | 'copy' | 'cut' | 'delete' | 'forcereload' | 'front' | 'help' | 'hide' | 'hideothers' | 'minimize' |
   'paste' | 'pasteandmatchstyle' | 'quit' | 'redo' | 'reload' | 'resetzoom' | 'selectall' | 'services' | 'recentdocuments' | 'clearrecentdocuments' | 'startspeaking' | 'stopspeaking' |
   'toggledevtools' | 'togglefullscreen' | 'undo' | 'unhide' | 'window' | 'zoom' | 'zoomin' | 'zoomout' |
-  'togglespellchecker' | 'showspellingpanel' |
+  'togglespellchecker' | 'showspellingpanel' | 'checkspelling' |
   'appmenu' | 'filemenu' | 'editmenu' | 'viewmenu' | 'windowmenu' | 'sharemenu'
 interface Role {
   label: string;
@@ -197,8 +197,10 @@ export const roleList: Record<RoleId, Role> = {
     }
   },
   showspellingpanel: {
-    label: 'Show Spelling and Grammar',
-    nonNativeMacOSRole: true
+    label: 'Show Spelling and Grammar'
+  },
+  checkspelling: {
+    label: 'Check Document Now'
   },
   // App submenu should be used for Mac only
   appmenu: {

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -29,6 +29,7 @@
 #include "chrome/common/chrome_version.h"
 #include "components/net_log/chrome_net_log.h"
 #include "components/network_hints/common/network_hints.mojom.h"
+#include "components/spellcheck/spellcheck_buildflags.h"
 #include "content/public/browser/browser_main_runner.h"
 #include "content/public/browser/browser_ppapi_host.h"
 #include "content/public/browser/browser_task_traits.h"
@@ -122,6 +123,9 @@
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
 #include "chrome/browser/spellchecker/spell_check_host_chrome_impl.h"  // nogncheck
 #include "components/spellcheck/common/spellcheck.mojom.h"  // nogncheck
+#if BUILDFLAG(HAS_SPELLCHECK_PANEL)
+#include "chrome/browser/spellchecker/spell_check_panel_host_impl.h"  // nogncheck
+#endif
 #endif
 
 #if BUILDFLAG(OVERRIDE_LOCATION_PROVIDER)
@@ -1620,6 +1624,14 @@ void ElectronBrowserClient::BindHostReceiverForRenderer(
                                      std::move(host_receiver));
     return;
   }
+#if BUILDFLAG(HAS_SPELLCHECK_PANEL)
+  if (auto host_receiver =
+          receiver.As<spellcheck::mojom::SpellCheckPanelHost>()) {
+    SpellCheckPanelHostImpl::Create(render_process_host->GetID(),
+                                    std::move(host_receiver));
+    return;
+  }
+#endif  // BUILDFLAG(HAS_SPELLCHECK_PANEL)
 #endif
 }
 

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -125,6 +125,7 @@
 #include "components/spellcheck/common/spellcheck.mojom.h"  // nogncheck
 #if BUILDFLAG(HAS_SPELLCHECK_PANEL)
 #include "chrome/browser/spellchecker/spell_check_panel_host_impl.h"  // nogncheck
+#include "shell/browser/ui/cocoa/electron_web_contents_view_delegate.h"
 #endif
 #endif
 
@@ -1718,6 +1719,14 @@ void ElectronBrowserClient::GetAdditionalMappedFilesForChildProcess(
   if (crash_signal_fd >= 0) {
     mappings->Share(kCrashDumpSignal, crash_signal_fd);
   }
+}
+#endif
+
+#if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER) && BUILDFLAG(HAS_SPELLCHECK_PANEL)
+content::WebContentsViewDelegate*
+ElectronBrowserClient::GetWebContentsViewDelegate(
+    content::WebContents* web_contents) {
+  return new ElectronWebContentsViewDelegate();
 }
 #endif
 

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -13,6 +13,7 @@
 
 #include "base/files/file_path.h"
 #include "base/synchronization/lock.h"
+#include "components/spellcheck/spellcheck_buildflags.h"
 #include "content/public/browser/content_browser_client.h"
 #include "content/public/browser/render_process_host_observer.h"
 #include "content/public/browser/web_contents.h"
@@ -77,6 +78,10 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
       const base::CommandLine& command_line,
       int child_process_id,
       content::PosixFileDescriptorInfo* mappings) override;
+#endif
+#if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER) && BUILDFLAG(HAS_SPELLCHECK_PANEL)
+  content::WebContentsViewDelegate* GetWebContentsViewDelegate(
+      content::WebContents* web_contents) override;
 #endif
 
   std::string GetUserAgent() override;

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -17,6 +17,7 @@
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/utf_string_conversions.h"
 #include "chrome/browser/icon_manager.h"
+#include "components/spellcheck/spellcheck_buildflags.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/child_process_security_policy.h"
 #include "content/public/browser/device_service.h"
@@ -115,6 +116,7 @@
 
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
 #include "chrome/browser/spellchecker/spellcheck_factory.h"  // nogncheck
+#include "components/spellcheck/browser/spellcheck_platform.h"
 #endif
 
 namespace electron {
@@ -518,6 +520,13 @@ void ElectronBrowserMainParts::PostMainMessageLoopStart() {
 void ElectronBrowserMainParts::PostMainMessageLoopRun() {
 #if defined(OS_MAC)
   FreeAppDelegate();
+#endif
+
+#if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER) && BUILDFLAG(HAS_SPELLCHECK_PANEL)
+  // We have to close the spelling panel on shutdown, otherwise macOS would
+  // automatically show the spelling panel on next start, which most apps do
+  // not do.
+  spellcheck_platform::ShowSpellingPanel(false);
 #endif
 
   // Shutdown the DownloadManager before destroying Node to prevent

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -67,6 +67,7 @@ Role kRolesMap[] = {
     {@selector(moveTabToNewWindow:), "movetabtonewwindow"},
     {@selector(clearRecentDocuments:), "clearrecentdocuments"},
     {@selector(showGuessPanel:), "showspellingpanel"},
+    {@selector(checkSpelling:), "checkspelling"},
 };
 
 // Called when adding a submenu to the menu and checks if the submenu, via its

--- a/shell/browser/ui/cocoa/electron_menu_controller.mm
+++ b/shell/browser/ui/cocoa/electron_menu_controller.mm
@@ -66,6 +66,7 @@ Role kRolesMap[] = {
     {@selector(mergeAllWindows:), "mergeallwindows"},
     {@selector(moveTabToNewWindow:), "movetabtonewwindow"},
     {@selector(clearRecentDocuments:), "clearrecentdocuments"},
+    {@selector(showGuessPanel:), "showspellingpanel"},
 };
 
 // Called when adding a submenu to the menu and checks if the submenu, via its

--- a/shell/browser/ui/cocoa/electron_render_widget_host_view_mac_delegate.h
+++ b/shell/browser/ui/cocoa/electron_render_widget_host_view_mac_delegate.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2020 Microsoft, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_BROWSER_UI_COCOA_ELECTRON_RENDER_WIDGET_HOST_VIEW_MAC_DELEGATE_H_
+#define SHELL_BROWSER_UI_COCOA_ELECTRON_RENDER_WIDGET_HOST_VIEW_MAC_DELEGATE_H_
+
+#import <Cocoa/Cocoa.h>
+
+#import "content/public/browser/render_widget_host_view_mac_delegate.h"
+
+namespace content {
+class RenderWidgetHost;
+}
+
+@interface ElectronRenderWidgetHostViewMacDelegate
+    : NSObject <RenderWidgetHostViewMacDelegate> {
+ @private
+  content::RenderWidgetHost* _renderWidgetHost;  // weak
+}
+
+- (id)initWithRenderWidgetHost:(content::RenderWidgetHost*)renderWidgetHost;
+@end
+
+#endif  // SHELL_BROWSER_UI_COCOA_ELECTRON_RENDER_WIDGET_HOST_VIEW_MAC_DELEGATE_H_

--- a/shell/browser/ui/cocoa/electron_render_widget_host_view_mac_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_render_widget_host_view_mac_delegate.mm
@@ -26,6 +26,20 @@
   return self;
 }
 
+- (BOOL)validateUserInterfaceItem:(id<NSValidatedUserInterfaceItem>)item
+                      isValidItem:(BOOL*)valid {
+  SEL action = [item action];
+  if (action == @selector(checkSpelling:)) {
+    *valid = content::RenderViewHost::From(_renderWidgetHost) != nullptr;
+    return YES;
+  }
+  if (action == @selector(showGuessPanel:)) {
+    *valid = YES;
+    return YES;
+  }
+  return NO;
+}
+
 // Spellchecking methods
 // The implementations are copied from
 // chrome/browser/renderer_host/chrome_render_widget_host_view_mac_delegate.mm

--- a/shell/browser/ui/cocoa/electron_render_widget_host_view_mac_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_render_widget_host_view_mac_delegate.mm
@@ -1,0 +1,125 @@
+// Copyright (c) 2020 Microsoft, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/ui/cocoa/electron_render_widget_host_view_mac_delegate.h"
+
+#include "base/strings/sys_string_conversions.h"
+#include "components/spellcheck/browser/spellcheck_platform.h"
+#include "components/spellcheck/common/spellcheck_panel.mojom.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/render_process_host.h"
+#include "content/public/browser/render_view_host.h"
+#include "content/public/browser/render_widget_host.h"
+#include "content/public/browser/render_widget_host_view.h"
+#include "content/public/browser/web_contents.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "services/service_manager/public/cpp/interface_provider.h"
+
+@implementation ElectronRenderWidgetHostViewMacDelegate
+
+- (id)initWithRenderWidgetHost:(content::RenderWidgetHost*)renderWidgetHost {
+  self = [super init];
+  if (self) {
+    _renderWidgetHost = renderWidgetHost;
+  }
+  return self;
+}
+
+// Spellchecking methods
+// The implementations are copied from
+// chrome/browser/renderer_host/chrome_render_widget_host_view_mac_delegate.mm
+
+// This message is sent whenever the user specifies that a word should be
+// changed from the spellChecker.
+- (void)changeSpelling:(id)sender {
+  // Grab the currently selected word from the spell panel, as this is the word
+  // that we want to replace the selected word in the text with.
+  NSString* newWord = [[sender selectedCell] stringValue];
+  if (newWord != nil) {
+    content::WebContents* webContents =
+        content::WebContents::FromRenderViewHost(
+            content::RenderViewHost::From(_renderWidgetHost));
+    webContents->ReplaceMisspelling(base::SysNSStringToUTF16(newWord));
+  }
+}
+
+// This message is sent by NSSpellChecker whenever the next word should be
+// advanced to, either after a correction or clicking the "Find Next" button.
+// This isn't documented anywhere useful, like in NSSpellProtocol.h with the
+// other spelling panel methods. This is probably because Apple assumes that the
+// the spelling panel will be used with an NSText, which will automatically
+// catch this and advance to the next word for you. Thanks Apple.
+// This is also called from the Edit -> Spelling -> Check Spelling menu item.
+- (void)checkSpelling:(id)sender {
+  content::WebContents* webContents = content::WebContents::FromRenderViewHost(
+      content::RenderViewHost::From(_renderWidgetHost));
+  if (webContents && webContents->GetFocusedFrame()) {
+    mojo::Remote<spellcheck::mojom::SpellCheckPanel>
+        focused_spell_check_panel_client;
+    webContents->GetFocusedFrame()->GetRemoteInterfaces()->GetInterface(
+        focused_spell_check_panel_client.BindNewPipeAndPassReceiver());
+    focused_spell_check_panel_client->AdvanceToNextMisspelling();
+  }
+}
+
+// This message is sent by the spelling panel whenever a word is ignored.
+- (void)ignoreSpelling:(id)sender {
+  // Ideally, we would ask the current RenderView for its tag, but that would
+  // mean making a blocking IPC call from the browser. Instead,
+  // spellcheck_platform::CheckSpelling remembers the last tag and
+  // spellcheck_platform::IgnoreWord assumes that is the correct tag.
+  NSString* wordToIgnore = [sender stringValue];
+  if (wordToIgnore != nil)
+    spellcheck_platform::IgnoreWord(nullptr,
+                                    base::SysNSStringToUTF16(wordToIgnore));
+}
+
+- (void)showGuessPanel:(id)sender {
+  const bool visible = spellcheck_platform::SpellingPanelVisible();
+
+  content::WebContents* webContents = content::WebContents::FromRenderViewHost(
+      content::RenderViewHost::From(_renderWidgetHost));
+  DCHECK(webContents && webContents->GetFocusedFrame());
+
+  mojo::Remote<spellcheck::mojom::SpellCheckPanel>
+      focused_spell_check_panel_client;
+  webContents->GetFocusedFrame()->GetRemoteInterfaces()->GetInterface(
+      focused_spell_check_panel_client.BindNewPipeAndPassReceiver());
+  focused_spell_check_panel_client->ToggleSpellPanel(visible);
+}
+
+// END Spellchecking methods
+
+// RenderWidgetHostViewMacDelegate events
+
+- (void)beginGestureWithEvent:(NSEvent*)event {
+}
+
+- (void)endGestureWithEvent:(NSEvent*)event {
+}
+
+- (void)touchesMovedWithEvent:(NSEvent*)event {
+}
+
+- (void)touchesBeganWithEvent:(NSEvent*)event {
+}
+
+- (void)touchesCancelledWithEvent:(NSEvent*)event {
+}
+
+- (void)touchesEndedWithEvent:(NSEvent*)event {
+}
+
+- (void)rendererHandledWheelEvent:(const blink::WebMouseWheelEvent&)event
+                         consumed:(BOOL)consumed {
+}
+
+- (void)rendererHandledGestureScrollEvent:(const blink::WebGestureEvent&)event
+                                 consumed:(BOOL)consumed {
+}
+
+- (void)rendererHandledOverscrollEvent:(const ui::DidOverscrollParams&)params {
+}
+
+@end

--- a/shell/browser/ui/cocoa/electron_web_contents_view_delegate.h
+++ b/shell/browser/ui/cocoa/electron_web_contents_view_delegate.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2020 Microsoft, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_BROWSER_UI_COCOA_ELECTRON_WEB_CONTENTS_VIEW_DELEGATE_H_
+#define SHELL_BROWSER_UI_COCOA_ELECTRON_WEB_CONTENTS_VIEW_DELEGATE_H_
+
+#include "base/macros.h"
+#include "content/public/browser/web_contents_view_delegate.h"
+
+#if defined(__OBJC__)
+#include "content/public/browser/render_widget_host_view_mac_delegate.h"
+#endif  // defined(__OBJC__)
+
+namespace electron {
+
+class ElectronWebContentsViewDelegate
+    : public content::WebContentsViewDelegate {
+ public:
+  ElectronWebContentsViewDelegate();
+  ~ElectronWebContentsViewDelegate() override;
+
+  // WebContentsViewDelegate:
+#if defined(__OBJC__)
+  NSObject<RenderWidgetHostViewMacDelegate>* CreateRenderWidgetHostViewDelegate(
+      content::RenderWidgetHost* render_widget_host,
+      bool is_popup) override;
+#else
+  void* CreateRenderWidgetHostViewDelegate(
+      content::RenderWidgetHost* render_widget_host,
+      bool is_popup) override;
+#endif  // defined(__OBJC__)
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(ElectronWebContentsViewDelegate);
+};
+
+}  // namespace electron
+
+#endif  // SHELL_BROWSER_UI_COCOA_ELECTRON_WEB_CONTENTS_VIEW_DELEGATE_H_

--- a/shell/browser/ui/cocoa/electron_web_contents_view_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_web_contents_view_delegate.mm
@@ -1,0 +1,23 @@
+// Copyright (c) 2020 Microsoft, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/ui/cocoa/electron_web_contents_view_delegate.h"
+
+#include "shell/browser/ui/cocoa/electron_render_widget_host_view_mac_delegate.h"
+
+namespace electron {
+
+ElectronWebContentsViewDelegate::ElectronWebContentsViewDelegate() {}
+
+ElectronWebContentsViewDelegate::~ElectronWebContentsViewDelegate() {}
+
+NSObject<RenderWidgetHostViewMacDelegate>*
+ElectronWebContentsViewDelegate::CreateRenderWidgetHostViewDelegate(
+    content::RenderWidgetHost* render_widget_host,
+    bool is_popup) {
+  return [[ElectronRenderWidgetHostViewMacDelegate alloc]
+      initWithRenderWidgetHost:render_widget_host];
+}
+
+}  // namespace electron

--- a/shell/renderer/binder_registry_holder.cc
+++ b/shell/renderer/binder_registry_holder.cc
@@ -1,0 +1,24 @@
+// Copyright (c) 2020 Microsoft, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/renderer/binder_registry_holder.h"
+
+namespace electron {
+
+BinderRegistryHolder::BinderRegistryHolder(content::RenderFrame* render_frame)
+    : content::RenderFrameObserver(render_frame) {}
+
+BinderRegistryHolder::~BinderRegistryHolder() {}
+
+void BinderRegistryHolder::OnInterfaceRequestForFrame(
+    const std::string& interface_name,
+    mojo::ScopedMessagePipeHandle* interface_pipe) {
+  registry_.TryBindInterface(interface_name, interface_pipe);
+}
+
+void BinderRegistryHolder::OnDestruct() {
+  delete this;
+}
+
+}  // namespace electron

--- a/shell/renderer/binder_registry_holder.h
+++ b/shell/renderer/binder_registry_holder.h
@@ -2,6 +2,11 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#ifndef SHELL_RENDERER_BINDER_REGISTRY_HOLDER_H_
+#define SHELL_RENDERER_BINDER_REGISTRY_HOLDER_H_
+
+#include <string>
+
 #include "content/public/renderer/render_frame_observer.h"
 #include "services/service_manager/public/cpp/binder_registry.h"
 
@@ -27,3 +32,5 @@ class BinderRegistryHolder : public content::RenderFrameObserver {
 };
 
 }  // namespace electron
+
+#endif  // SHELL_RENDERER_BINDER_REGISTRY_HOLDER_H_

--- a/shell/renderer/binder_registry_holder.h
+++ b/shell/renderer/binder_registry_holder.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2020 Microsoft, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "content/public/renderer/render_frame_observer.h"
+#include "services/service_manager/public/cpp/binder_registry.h"
+
+namespace electron {
+
+class BinderRegistryHolder : public content::RenderFrameObserver {
+ public:
+  explicit BinderRegistryHolder(content::RenderFrame* render_frame);
+  ~BinderRegistryHolder() override;
+
+  service_manager::BinderRegistry* registry() { return &registry_; }
+
+ private:
+  // RenderFrameObserver implementation.
+  void OnInterfaceRequestForFrame(
+      const std::string& interface_name,
+      mojo::ScopedMessagePipeHandle* interface_pipe) override;
+  void OnDestruct() override;
+
+  service_manager::BinderRegistry registry_;
+
+  DISALLOW_COPY_AND_ASSIGN(BinderRegistryHolder);
+};
+
+}  // namespace electron

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -13,6 +13,7 @@
 #include "base/strings/string_split.h"
 #include "base/strings/stringprintf.h"
 #include "components/network_hints/renderer/web_prescient_networking_impl.h"
+#include "components/spellcheck/spellcheck_buildflags.h"
 #include "content/common/buildflags.h"
 #include "content/public/common/content_constants.h"
 #include "content/public/common/content_switches.h"
@@ -26,6 +27,7 @@
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/options_switches.h"
 #include "shell/common/world_ids.h"
+#include "shell/renderer/binder_registry_holder.h"
 #include "shell/renderer/browser_exposed_renderer_interfaces.h"
 #include "shell/renderer/content_settings_observer.h"
 #include "shell/renderer/electron_api_service_impl.h"
@@ -52,6 +54,9 @@
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
 #include "components/spellcheck/renderer/spellcheck.h"
 #include "components/spellcheck/renderer/spellcheck_provider.h"
+#if BUILDFLAG(HAS_SPELLCHECK_PANEL)
+#include "components/spellcheck/renderer/spellcheck_panel.h"
+#endif  // BUILDFLAG(HAS_SPELLCHECK_PANEL)
 #endif
 
 #if BUILDFLAG(ENABLE_PDF_VIEWER)
@@ -291,8 +296,13 @@ void RendererClientBase::RenderFrameCreated(
 #endif
 
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
-  if (render_frame->GetBlinkPreferences().enable_spellcheck)
+  if (render_frame->GetBlinkPreferences().enable_spellcheck) {
     new SpellCheckProvider(render_frame, spellcheck_.get(), this);
+#if BUILDFLAG(HAS_SPELLCHECK_PANEL)
+    auto* holder = new BinderRegistryHolder(render_frame);
+    new SpellCheckPanel(render_frame, holder->registry(), this);
+#endif  // BUILDFLAG(HAS_SPELLCHECK_PANEL)
+  }
 #endif
 }
 


### PR DESCRIPTION
#### Description of Change

Close #3211.

This PR adds 2 menu item roles `showSpellingPanel ` and `checkSpelling`, which map to the "Show Spelling and Grammar" and "Check Document Now" menu items on macOS.

<img width="442" alt="Screen Shot 2020-11-05 at 9 17 31" src="https://user-images.githubusercontent.com/639601/98181927-d31d8b80-1f47-11eb-94ec-5cfc53937e1c.png">

There are also lots of code added to make the spelling panel work.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Add `showSpellingPanel ` and `checkSpelling` menu item roles.