### PR TITLE
build: bump extract-zip version to v1.4

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@electron/get": "^1.0.1",
     "@types/node": "^14.6.2",
-    "extract-zip": "^1.0.3"
+    "extract-zip": "^1.4.1"
   },
   "engines": {
     "node": ">= 8.6"


### PR DESCRIPTION
#### Description of Change
Bumps extract-zip to v1.4.1.
Tried with v1.7 which is the last one to support node8, but it did not pass the tests.
V1.4 uses less dependencies than v1.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: none