### PR TITLE
chore: a few style fixes for internal-ambient.d.ts

### DIFF
--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -227,7 +227,7 @@ declare namespace NodeJS {
   }
 }
 
-declare module NodeJS  {
+declare module NodeJS {
   interface Global {
     require: NodeRequire;
     module: NodeModule;
@@ -319,7 +319,7 @@ interface ResizeObserverEntry {
 // https://github.com/microsoft/TypeScript/pull/38232
 
 interface WeakRef<T extends object> {
-  readonly [Symbol.toStringTag]: "WeakRef";
+  readonly [Symbol.toStringTag]: 'WeakRef';
 
   /**
    * Returns the WeakRef instance's target object, or undefined if the target object has been
@@ -341,7 +341,7 @@ interface WeakRefConstructor {
 declare var WeakRef: WeakRefConstructor;
 
 interface FinalizationRegistry {
-  readonly [Symbol.toStringTag]: "FinalizationRegistry";
+  readonly [Symbol.toStringTag]: 'FinalizationRegistry';
 
   /**
    * Registers an object with the registry.


### PR DESCRIPTION
#### Description of Change

Just whitespace and consistent quote style.

Could probably add `eslint` coverage of the typings files. The only other violations were usage of `var`, which could probably just be swapped to `const`, but I deferred on that change in case there was something I was overlooking there.

#### Checklist

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none