### PR TITLE
fix: Update Squirrel.mac to fix permissions bug.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -20,7 +20,7 @@ vars = {
   'nan_version':
     '2c4ee8a32a299eada3cd6e468bbd0a473bfea96d',
   'squirrel.mac_version':
-    'a3a5b3f03b824441c014893b18f99a103b2603e9',
+    'cdc0729c8bf8576bfef18629186e1e9ecf1b0d9f',
 
   'pyyaml_version': '3.12',
   'requests_version': 'e4d59bedfd3c7f4f254f4f5d036587bcd8152458',

--- a/patches/squirrel.mac/build_add_gn_config.patch
+++ b/patches/squirrel.mac/build_add_gn_config.patch
@@ -305,7 +305,7 @@ index e42332ab13fb01000c73cf0b3b757d1f7141da6f..f8754dbd6a1490d2b50f1014e2daa5c1
  
  NSString * const SQRLCodeSignatureErrorDomain = @"SQRLCodeSignatureErrorDomain";
 diff --git a/Squirrel/SQRLDirectoryManager.m b/Squirrel/SQRLDirectoryManager.m
-index 34f321077f0bf59de98a41dea2cea95eff72486d..200891ca73ac67754219204340881ef85aff4845 100644
+index fb130fa5dca4570e0822c8cfdab6831bb57ab5ad..d439906827e0f9fb5550bb6c9840a4e75352f3d7 100644
 --- a/Squirrel/SQRLDirectoryManager.m
 +++ b/Squirrel/SQRLDirectoryManager.m
 @@ -8,7 +8,7 @@


### PR DESCRIPTION
#### Description of Change

This PR updates Squirrel.mac so that we get this fix: https://github.com/Squirrel/Squirrel.Mac/pull/255

> Squirrel.mac has an issue wherein if ShipIt_stderr.log or ShipIt_stdout.log aren't writable, ShipIt will fail to launch. If the entire ShipIt directory isn't writable, we detect that and prompt the user for credentials, but if the directory is writable and the log files contained are not, we just die silently.

> This PR changes the logic used the generate the log file URLs so that we always generate writable log file URLs. Before returning the log file URL, we test to see if it's writable. If not, we append a number to the URL and test that URL. We repeat this process until we find a writable log file URL, or we reach 100 and give up.

> I also included a little code cleanup to reduce duplication, so that this new logic doesn't get copied all over the place.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
