### PR TITLE
chore: improve docs relative link linting

### DIFF
--- a/script/check-relative-doc-links.py
+++ b/script/check-relative-doc-links.py
@@ -95,14 +95,27 @@ def getBrokenLinks(filepath):
 
 
 def checkSections(sections, lines):
-  sectionHeader = sections[1].replace('-', '')
+  invalidCharsRegex = '[^A-Za-z0-9_ \-]'
+  sectionHeader = sections[1]
   regexSectionTitle = re.compile('# (?P<header>.*)')
   for line in lines:
     matchHeader = regexSectionTitle.search(line)
     if matchHeader:
-     matchHeader = filter(str.isalnum, str(matchHeader.group('header')))
-     if matchHeader.lower() == sectionHeader:
-      return True
+      # This does the following to slugify a header name:
+      #  * Replace whitespace with dashes
+      #  * Strip anything that's not alphanumeric or a dash
+      #  * Anything quoted with backticks (`) is an exception and will
+      #    not have underscores stripped
+      matchHeader = str(matchHeader.group('header')).replace(' ', '-')
+      matchHeader = ''.join(
+        map(
+          lambda match: re.sub(invalidCharsRegex, '', match[0])
+          + re.sub(invalidCharsRegex + '|_', '', match[1]),
+          re.findall('(`[^`]+`)|([^`]+)', matchHeader),
+        )
+      )
+      if matchHeader.lower() == sectionHeader:
+        return True
   return False
 
 


### PR DESCRIPTION
#### Description of Change

There's a wrinkle to the way anchors are generated for the website documentation it seems. While underscores are valid characters for a URL fragment, they're normally stripped *except* for when they're inside backticks.

An example from the documentation: <https://www.electronjs.org/docs/api/environment-variables#electron_force_window_menu_bar-linux>

That's a bit of a pain to try to represent with regex, the best I could do was multiple passes, first to separate out any backticked and not backticked sections, then another pass to allow underscores in one and not the other. I tried to keep it concise.

There was also weird indentation on that section (a single space) so it shows a couple lines changed which are only whitespace.

EDIT: Actually, now that I've done all that, I'm wondering if I got it inverted. Is it that `_Something_` has underscores stripped while they're normally not stripped? Or even the specific keywords like `_Linux_`, `_Deprecated_`, etc?

Maybe @MarshallOfSound knows more about the root behavior here. I'd imagine the "single source of truth" on this one is wherever the headers are turned into HTML IDs, but that could be down a rabbit hole of libraries.

#### Checklist

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none