### PR TITLE
fix: make draggable regions work when devtools is opened on macOS

### DIFF
--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -63,6 +63,9 @@ class BrowserWindow : public BaseWindow,
   void OnActivateContents() override;
   void OnPageTitleUpdated(const base::string16& title,
                           bool explicit_set) override;
+#if defined(OS_MAC)
+  void OnDevToolsResized() override;
+#endif
 
   // NativeWindowObserver:
   void RequestPreferredWidth(int* width) override;

--- a/shell/browser/api/electron_api_browser_window_mac.mm
+++ b/shell/browser/api/electron_api_browser_window_mac.mm
@@ -12,26 +12,8 @@
 #include "base/mac/scoped_nsobject.h"
 #include "shell/browser/native_browser_view.h"
 #include "shell/browser/native_window_mac.h"
+#include "shell/browser/ui/cocoa/electron_inspectable_web_contents_view.h"
 #include "shell/browser/ui/inspectable_web_contents_view.h"
-
-@interface NSView (WebContentsView)
-- (void)setMouseDownCanMoveWindow:(BOOL)can_move;
-@end
-
-@interface ControlRegionView : NSView
-@end
-
-@implementation ControlRegionView
-
-- (BOOL)mouseDownCanMoveWindow {
-  return NO;
-}
-
-- (NSView*)hitTest:(NSPoint)aPoint {
-  return nil;
-}
-
-@end
 
 namespace electron {
 

--- a/shell/browser/api/electron_api_browser_window_mac.mm
+++ b/shell/browser/api/electron_api_browser_window_mac.mm
@@ -36,6 +36,10 @@ void BrowserWindow::OverrideNSWindowContentView(InspectableWebContents* iwc) {
   [contentView viewDidMoveToWindow];
 }
 
+void BrowserWindow::OnDevToolsResized() {
+  UpdateDraggableRegions(draggable_regions_);
+}
+
 void BrowserWindow::UpdateDraggableRegions(
     const std::vector<mojom::DraggableRegionPtr>& regions) {
   if (window_->has_frame())

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1481,6 +1481,11 @@ void WebContents::DevToolsClosed() {
   Emit("devtools-closed");
 }
 
+void WebContents::DevToolsResized() {
+  for (ExtendedWebContentsObserver& observer : observers_)
+    observer.OnDevToolsResized();
+}
+
 bool WebContents::OnMessageReceived(const IPC::Message& message) {
   bool handled = true;
   IPC_BEGIN_MESSAGE_MAP(WebContents, message)

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -590,6 +590,7 @@ class WebContents : public gin::Wrappable<WebContents>,
   void DevToolsFocused() override;
   void DevToolsOpened() override;
   void DevToolsClosed() override;
+  void DevToolsResized() override;
 
  private:
   ElectronBrowserContext* GetBrowserContext() const;

--- a/shell/browser/extended_web_contents_observer.h
+++ b/shell/browser/extended_web_contents_observer.h
@@ -25,6 +25,7 @@ class ExtendedWebContentsObserver : public base::CheckedObserver {
   virtual void OnActivateContents() {}
   virtual void OnPageTitleUpdated(const base::string16& title,
                                   bool explicit_set) {}
+  virtual void OnDevToolsResized() {}
 
  protected:
   ~ExtendedWebContentsObserver() override {}

--- a/shell/browser/ui/cocoa/electron_inspectable_web_contents_view.h
+++ b/shell/browser/ui/cocoa/electron_inspectable_web_contents_view.h
@@ -17,12 +17,20 @@ class InspectableWebContentsViewMac;
 
 using electron::InspectableWebContentsViewMac;
 
+@interface NSView (WebContentsView)
+- (void)setMouseDownCanMoveWindow:(BOOL)can_move;
+@end
+
+@interface ControlRegionView : NSView
+@end
+
 @interface ElectronInspectableWebContentsView : BaseView <NSWindowDelegate> {
  @private
   electron::InspectableWebContentsViewMac* inspectableWebContentsView_;
 
   base::scoped_nsobject<NSView> fake_view_;
   base::scoped_nsobject<NSWindow> devtools_window_;
+  base::scoped_nsobject<ControlRegionView> devtools_mask_;
   BOOL devtools_visible_;
   BOOL devtools_docked_;
   BOOL devtools_is_first_responder_;

--- a/shell/browser/ui/cocoa/electron_inspectable_web_contents_view.mm
+++ b/shell/browser/ui/cocoa/electron_inspectable_web_contents_view.mm
@@ -86,6 +86,14 @@
     inspectableWebContentsView_->GetDelegate()->DevToolsFocused();
 }
 
+- (void)notifyDevToolsResized {
+  // When devtools is opened, resizing devtools would not trigger
+  // UpdateDraggableRegions for WebContents, so we have to notify the window
+  // to do an update of draggable regions.
+  if (inspectableWebContentsView_->GetDelegate())
+    inspectableWebContentsView_->GetDelegate()->DevToolsResized();
+}
+
 - (void)setDevToolsVisible:(BOOL)visible activate:(BOOL)activate {
   if (visible == devtools_visible_)
     return;
@@ -117,6 +125,7 @@
       [devToolsView removeFromSuperview];
       [devtools_mask_ removeFromSuperview];
       [self adjustSubviews];
+      [self notifyDevToolsResized];
     }
   } else {
     if (visible) {
@@ -233,6 +242,8 @@
     devtools_frame.size.height = sb.size.height;
   }
   [devtools_mask_ setFrame:devtools_frame];
+
+  [self notifyDevToolsResized];
 }
 
 - (void)setTitle:(NSString*)title {

--- a/shell/browser/ui/inspectable_web_contents_view_delegate.h
+++ b/shell/browser/ui/inspectable_web_contents_view_delegate.h
@@ -19,6 +19,7 @@ class InspectableWebContentsViewDelegate {
   virtual void DevToolsFocused() {}
   virtual void DevToolsOpened() {}
   virtual void DevToolsClosed() {}
+  virtual void DevToolsResized() {}
 
   // Returns the icon of devtools window.
   virtual gfx::ImageSkia GetDevToolsWindowIcon();


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/3647.

On macOS the draggable regions would stop working when devtools is opened, because the docked devtools is implemented by placing the devtools view under the main WebContents, and the devtools view itself is not draggable.

This PR makes the devtools view itself draggable to make the draggable regions work, and then put a view above the devtools area to exclude it from dragging.

The UI structure looks like this:

<img width="633" alt="Screen Shot 2020-11-06 at 17 08 34" src="https://user-images.githubusercontent.com/639601/98341787-c6d22500-2052-11eb-8f49-1ef8ce0e211a.png">

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix draggable regions stops working when devtools is opened on macOS