### PR TITLE
fix: renderer crash on setImmediate

### DIFF
--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -170,6 +170,20 @@ bool AllowWasmCodeGenerationCallback(v8::Local<v8::Context> context,
                                                v8::String::Empty(isolate));
 }
 
+void ErrorMessageListener(v8::Local<v8::Message> message,
+                          v8::Local<v8::Value> data) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  node::Environment* env = node::Environment::GetCurrent(isolate);
+
+  // TODO(codebytere): properly emit the after() hooks now
+  // that the exception has been handled.
+  // See node/lib/internal/process/execution.js#L176-L180
+
+  // Ensure that the async id stack is properly cleared so the async
+  // hook stack does not becomes corrupted.
+  env->async_hooks()->clear_async_id_stack();
+}
+
 // Initialize Node.js cli options to pass to Node.js
 // See https://nodejs.org/api/cli.html#cli_options
 void SetNodeCliFlags() {
@@ -469,6 +483,12 @@ node::Environment* NodeBindings::CreateEnvironment(
     // We do not want to use Node.js' message listener as it interferes with
     // Blink's.
     is.flags &= ~node::IsolateSettingsFlags::MESSAGE_LISTENER_WITH_ERROR_LEVEL;
+
+    // Isolate message listeners are additive (you can add multiple), so instead
+    // we add an extra one here to ensure that the async hook stack is properly
+    // cleared when errors are thrown.
+    context->GetIsolate()->AddMessageListenerWithErrorLevel(
+        ErrorMessageListener, v8::Isolate::kMessageError);
 
     // We do not want to use the promise rejection callback that Node.js uses,
     // because it does not send PromiseRejectionEvents to the global script

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -180,8 +180,11 @@ void ErrorMessageListener(v8::Local<v8::Message> message,
   // See node/lib/internal/process/execution.js#L176-L180
 
   // Ensure that the async id stack is properly cleared so the async
-  // hook stack does not becomes corrupted.
-  env->async_hooks()->clear_async_id_stack();
+  // hook stack does not become corrupted.
+
+  if (env) {
+    env->async_hooks()->clear_async_id_stack();
+  }
 }
 
 // Initialize Node.js cli options to pass to Node.js

--- a/spec-main/fixtures/crash-cases/setimmediate-renderer-crash/index.js
+++ b/spec-main/fixtures/crash-cases/setimmediate-renderer-crash/index.js
@@ -1,0 +1,22 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+app.whenReady().then(() => {
+  const win = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      preload: path.resolve(__dirname, 'preload.js')
+    }
+  });
+
+  win.loadURL('data:text/html,<body>');
+
+  win.webContents.on('render-process-gone', () => {
+    process.exit(1);
+  });
+
+  win.webContents.on('did-finish-load', () => {
+    setTimeout(() => app.quit());
+  });
+});

--- a/spec-main/fixtures/crash-cases/setimmediate-renderer-crash/index.js
+++ b/spec-main/fixtures/crash-cases/setimmediate-renderer-crash/index.js
@@ -10,7 +10,7 @@ app.whenReady().then(() => {
     }
   });
 
-  win.loadURL('data:text/html,<body>');
+  win.loadURL('about:blank');
 
   win.webContents.on('render-process-gone', () => {
     process.exit(1);

--- a/spec-main/fixtures/crash-cases/setimmediate-renderer-crash/preload.js
+++ b/spec-main/fixtures/crash-cases/setimmediate-renderer-crash/preload.js
@@ -1,0 +1,3 @@
+setImmediate(() => {
+  throw new Error('oh no');
+});


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/26055.

Fixes an issue whereby a corrupted `async_hooks` stack would crash the renderer when throwing some errors in the renderer process. This happened because Node.js resets the async hook stack when exceptions are thrown inside their uncaught exception handler, and in the renderer process we were using Blink's which did not do this. This is fixed by adding our own uncaught message listener to the renderer isolate - this resets the async hook stack to mitigate the crash and better align with Node.js' behavior. Isolate message listeners are additive (you can add multiple) so this does not interfere with Blink's own handling.

cc @ckerr @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue whereby a corrupted `async_hooks` stack would crash the renderer when throwing some errors in the renderer process.
