### PR TITLE
chore: cherry-pick 8f24f935c903 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -110,3 +110,4 @@ cherry-pick-30261f9de11e.patch
 cherry-pick-88f263f401b4.patch
 cherry-pick-229fdaf8fc05.patch
 cherry-pick-1ed869ad4bb3.patch
+cherry-pick-8f24f935c903.patch

--- a/patches/chromium/cherry-pick-8f24f935c903.patch
+++ b/patches/chromium/cherry-pick-8f24f935c903.patch
@@ -1,7 +1,7 @@
-From 8f24f935c90374af613965a48525e8c3a7928c95 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Adrian Taylor <adetaylor@chromium.org>
-Date: Thu, 05 Nov 2020 08:50:39 +0000
-Subject: [PATCH] Prevent overflow of drag image on Windows.
+Date: Thu, 5 Nov 2020 08:50:39 +0000
+Subject: Prevent overflow of drag image on Windows.
 
 (cherry picked from commit 236b1a349111fc945c741f85e1b1e2e04d9c42ff)
 
@@ -24,13 +24,12 @@ Commit-Queue: Victor-Gabriel Savu <vsavu@google.com>
 Cr-Commit-Position: refs/branch-heads/4240_112@{#18}
 Cr-Branched-From: 427c00d3874b6abcf4c4c2719768835fc3ef26d6-refs/branch-heads/4240@{#1291}
 Cr-Branched-From: f297677702651916bbf65e59c0d4bbd4ce57d1ee-refs/heads/master@{#800218}
----
 
 diff --git a/ui/base/dragdrop/os_exchange_data_provider_win.cc b/ui/base/dragdrop/os_exchange_data_provider_win.cc
-index f5ec26a..9eb9c8d 100644
+index b51a0161fdf028ac2a4f079b813d6622602f980c..41f163a3424e89a9370faebb77ac0058da9b01f6 100644
 --- a/ui/base/dragdrop/os_exchange_data_provider_win.cc
 +++ b/ui/base/dragdrop/os_exchange_data_provider_win.cc
-@@ -707,7 +707,7 @@
+@@ -714,7 +714,7 @@ void OSExchangeDataProviderWin::SetDragImage(
    int width = unpremul_bitmap.width();
    int height = unpremul_bitmap.height();
    size_t rowbytes = unpremul_bitmap.rowBytes();

--- a/patches/chromium/cherry-pick-8f24f935c903.patch
+++ b/patches/chromium/cherry-pick-8f24f935c903.patch
@@ -1,0 +1,41 @@
+From 8f24f935c90374af613965a48525e8c3a7928c95 Mon Sep 17 00:00:00 2001
+From: Adrian Taylor <adetaylor@chromium.org>
+Date: Thu, 05 Nov 2020 08:50:39 +0000
+Subject: [PATCH] Prevent overflow of drag image on Windows.
+
+(cherry picked from commit 236b1a349111fc945c741f85e1b1e2e04d9c42ff)
+
+(cherry picked from commit 5f61af8f3af5efd0d915a51da6df822678d959b9)
+
+Bug: 1144489
+Change-Id: I130adffc1c69073295537aaff3ce7054260064fc
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2513345
+Reviewed-by: Krishna Govind <govind@chromium.org>
+Cr-Original-Original-Commit-Position: refs/branch-heads/4310@{#4}
+Cr-Original-Original-Branched-From: 3e31ebb7467fdc4295f123385825b8c95ef13332-refs/heads/master@{#822916}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2513349
+Reviewed-by: Adrian Taylor <adetaylor@chromium.org>
+Commit-Queue: Krishna Govind <govind@chromium.org>
+Cr-Original-Commit-Position: refs/branch-heads/4240@{#1373}
+Cr-Original-Branched-From: f297677702651916bbf65e59c0d4bbd4ce57d1ee-refs/heads/master@{#800218}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2517728
+Reviewed-by: Achuith Bhandarkar <achuith@chromium.org>
+Commit-Queue: Victor-Gabriel Savu <vsavu@google.com>
+Cr-Commit-Position: refs/branch-heads/4240_112@{#18}
+Cr-Branched-From: 427c00d3874b6abcf4c4c2719768835fc3ef26d6-refs/branch-heads/4240@{#1291}
+Cr-Branched-From: f297677702651916bbf65e59c0d4bbd4ce57d1ee-refs/heads/master@{#800218}
+---
+
+diff --git a/ui/base/dragdrop/os_exchange_data_provider_win.cc b/ui/base/dragdrop/os_exchange_data_provider_win.cc
+index f5ec26a..9eb9c8d 100644
+--- a/ui/base/dragdrop/os_exchange_data_provider_win.cc
++++ b/ui/base/dragdrop/os_exchange_data_provider_win.cc
+@@ -707,7 +707,7 @@
+   int width = unpremul_bitmap.width();
+   int height = unpremul_bitmap.height();
+   size_t rowbytes = unpremul_bitmap.rowBytes();
+-  DCHECK_EQ(rowbytes, static_cast<size_t>(width) * 4u);
++  CHECK_EQ(rowbytes, static_cast<size_t>(width) * 4u);
+ 
+   void* bits;
+   HBITMAP hbitmap;


### PR DESCRIPTION
Prevent overflow of drag image on Windows.

(cherry picked from commit 236b1a349111fc945c741f85e1b1e2e04d9c42ff)

(cherry picked from commit 5f61af8f3af5efd0d915a51da6df822678d959b9)

Bug: 1144489
Change-Id: I130adffc1c69073295537aaff3ce7054260064fc
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2513345
Reviewed-by: Krishna Govind <govind@chromium.org>
Cr-Original-Original-Commit-Position: refs/branch-heads/4310@{#4}
Cr-Original-Original-Branched-From: 3e31ebb7467fdc4295f123385825b8c95ef13332-refs/heads/master@{#822916}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2513349
Reviewed-by: Adrian Taylor <adetaylor@chromium.org>
Commit-Queue: Krishna Govind <govind@chromium.org>
Cr-Original-Commit-Position: refs/branch-heads/4240@{#1373}
Cr-Original-Branched-From: f297677702651916bbf65e59c0d4bbd4ce57d1ee-refs/heads/master@{#800218}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2517728
Reviewed-by: Achuith Bhandarkar <achuith@chromium.org>
Commit-Queue: Victor-Gabriel Savu <vsavu@google.com>
Cr-Commit-Position: refs/branch-heads/4240_112@{#18}
Cr-Branched-From: 427c00d3874b6abcf4c4c2719768835fc3ef26d6-refs/branch-heads/4240@{#1291}
Cr-Branched-From: f297677702651916bbf65e59c0d4bbd4ce57d1ee-refs/heads/master@{#800218}


Notes: Security: backported fix for 1144489.