### PR TITLE
chore: cherry-pick 146bd99e762b from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -15,3 +15,4 @@ cherry-pick-7e5c7b5964.patch
 cherry-pick-6a4cd97d6691.patch
 cherry-pick-6aa1e71fbd09.patch
 perf_make_getpositioninfoslow_faster.patch
+cherry-pick-146bd99e762b.patch

--- a/patches/v8/cherry-pick-146bd99e762b.patch
+++ b/patches/v8/cherry-pick-146bd99e762b.patch
@@ -1,7 +1,7 @@
-From 146bd99e762bd93f6c5520bb94f02b8ab0aa8d42 Mon Sep 17 00:00:00 2001
-From: ishell@chromium.org <ishell@chromium.org>
-Date: Tue, 03 Nov 2020 12:42:43 +0100
-Subject: [PATCH] Merged: Squashed multiple commits.
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "ishell@chromium.org" <ishell@chromium.org>
+Date: Tue, 3 Nov 2020 12:42:43 +0100
+Subject: Merged: Squashed multiple commits.
 
 Merged: [map] Try to in-place transition during map update
 Revision: 8e3ae62d294818733a0322d8e8abd53d4e410f19
@@ -21,13 +21,12 @@ Reviewed-by: Toon Verwaest <verwaest@chromium.org>
 Cr-Commit-Position: refs/branch-heads/8.7@{#31}
 Cr-Branched-From: 0d81cd72688512abcbe1601015baee390c484a6a-refs/heads/8.7.220@{#1}
 Cr-Branched-From: 942c2ef85caef00fcf02517d049f05e9a3d4b440-refs/heads/master@{#70196}
----
 
 diff --git a/src/objects/map-updater.cc b/src/objects/map-updater.cc
-index e51bcfc..b4b1587 100644
+index 8c9b94014f8efaa4463cc883877ed52d24963d4c..5a016614a1782913e2297a4a396fc4402ea41cee 100644
 --- a/src/objects/map-updater.cc
 +++ b/src/objects/map-updater.cc
-@@ -232,10 +232,7 @@
+@@ -232,10 +232,7 @@ MapUpdater::State MapUpdater::TryReconfigureToDataFieldInplace() {
          handle(old_descriptors_->GetFieldType(modified_descriptor_), isolate_),
          MaybeHandle<Object>(), new_field_type_, MaybeHandle<Object>());
    }
@@ -39,7 +38,7 @@ index e51bcfc..b4b1587 100644
                    new_representation_, new_field_type_);
    // Check that the descriptor array was updated.
    DCHECK(old_descriptors_->GetDetails(modified_descriptor_)
-@@ -401,7 +398,13 @@
+@@ -401,7 +398,13 @@ MapUpdater::State MapUpdater::FindTargetMap() {
      }
      Representation tmp_representation = tmp_details.representation();
      if (!old_details.representation().fits_into(tmp_representation)) {
@@ -55,10 +54,10 @@ index e51bcfc..b4b1587 100644
  
      if (tmp_details.location() == kField) {
 diff --git a/src/objects/map.cc b/src/objects/map.cc
-index dd941b3..d1370ae 100644
+index 2dc288628c8ea69d425e3b86e63e151157b9f925..1799cff1a2284c9b0d7cdaec99d0c310c733042c 100644
 --- a/src/objects/map.cc
 +++ b/src/objects/map.cc
-@@ -610,6 +610,7 @@
+@@ -609,6 +609,7 @@ void Map::DeprecateTransitionTree(Isolate* isolate) {
      transitions.GetTarget(i).DeprecateTransitionTree(isolate);
    }
    DCHECK(!constructor_or_backpointer().IsFunctionTemplateInfo());
@@ -67,10 +66,10 @@ index dd941b3..d1370ae 100644
    if (FLAG_trace_maps) {
      LOG(isolate, MapEvent("Deprecate", handle(*this, isolate), Handle<Map>()));
 diff --git a/test/cctest/test-field-type-tracking.cc b/test/cctest/test-field-type-tracking.cc
-index a9fa589..2f59d7b 100644
+index 840478a5203847f331f792eae7125a60396f896a..7abbcbde350a08bbb7d364c15184bc896607848b 100644
 --- a/test/cctest/test-field-type-tracking.cc
 +++ b/test/cctest/test-field-type-tracking.cc
-@@ -1038,7 +1038,8 @@
+@@ -1019,7 +1019,8 @@ namespace {
  // where "p2A" and "p2B" differ only in the attributes.
  //
  void TestReconfigureDataFieldAttribute_GeneralizeField(
@@ -80,7 +79,7 @@ index a9fa589..2f59d7b 100644
    Isolate* isolate = CcTest::i_isolate();
  
    Expectations expectations(isolate);
-@@ -1107,24 +1108,29 @@
+@@ -1079,22 +1080,26 @@ void TestReconfigureDataFieldAttribute_GeneralizeField(
    CHECK_NE(*map2, *new_map);
    CHECK(expectations2.Check(*map2));
  
@@ -90,16 +89,11 @@ index a9fa589..2f59d7b 100644
                                expected.type);
    }
 -  CHECK(map->is_deprecated());
--  CHECK(!code_field_type->marked_for_deoptimization());
--  CHECK(!code_field_repr->marked_for_deoptimization());
--  CHECK(!code_field_const->marked_for_deoptimization());
+-  CHECK(!code->marked_for_deoptimization());
 -  CHECK_NE(*map, *new_map);
 +  if (expected_deprecation) {
-+    // |map| should be deprecated and |new_map| should match new expectations.
 +    CHECK(map->is_deprecated());
-+    CHECK(!code_field_type->marked_for_deoptimization());
-+    CHECK(!code_field_repr->marked_for_deoptimization());
-+    CHECK(!code_field_const->marked_for_deoptimization());
++    CHECK(!code->marked_for_deoptimization());
 +    CHECK_NE(*map, *new_map);
  
 -  CHECK(!new_map->is_deprecated());
@@ -122,7 +116,7 @@ index a9fa589..2f59d7b 100644
  }
  
  // This test ensures that trivial field generalization (from HeapObject to
-@@ -1240,22 +1246,22 @@
+@@ -1200,22 +1205,22 @@ TEST(ReconfigureDataFieldAttribute_GeneralizeSmiFieldToDouble) {
    TestReconfigureDataFieldAttribute_GeneralizeField(
        {PropertyConstness::kConst, Representation::Smi(), any_type},
        {PropertyConstness::kConst, Representation::Double(), any_type},
@@ -149,7 +143,7 @@ index a9fa589..2f59d7b 100644
  }
  
  TEST(ReconfigureDataFieldAttribute_GeneralizeSmiFieldToTagged) {
-@@ -1270,22 +1276,26 @@
+@@ -1230,22 +1235,26 @@ TEST(ReconfigureDataFieldAttribute_GeneralizeSmiFieldToTagged) {
    TestReconfigureDataFieldAttribute_GeneralizeField(
        {PropertyConstness::kConst, Representation::Smi(), any_type},
        {PropertyConstness::kConst, Representation::HeapObject(), value_type},
@@ -180,7 +174,7 @@ index a9fa589..2f59d7b 100644
  }
  
  TEST(ReconfigureDataFieldAttribute_GeneralizeDoubleFieldToTagged) {
-@@ -1300,22 +1310,26 @@
+@@ -1260,22 +1269,26 @@ TEST(ReconfigureDataFieldAttribute_GeneralizeDoubleFieldToTagged) {
    TestReconfigureDataFieldAttribute_GeneralizeField(
        {PropertyConstness::kConst, Representation::Double(), any_type},
        {PropertyConstness::kConst, Representation::HeapObject(), value_type},
@@ -211,7 +205,7 @@ index a9fa589..2f59d7b 100644
  }
  
  TEST(ReconfigureDataFieldAttribute_GeneralizeHeapObjFieldToHeapObj) {
-@@ -1401,7 +1415,8 @@
+@@ -1361,7 +1374,8 @@ TEST(ReconfigureDataFieldAttribute_GeneralizeHeapObjectFieldToTagged) {
    TestReconfigureDataFieldAttribute_GeneralizeField(
        {PropertyConstness::kMutable, Representation::HeapObject(), value_type},
        {PropertyConstness::kMutable, Representation::Smi(), any_type},
@@ -220,10 +214,10 @@ index a9fa589..2f59d7b 100644
 +      !FLAG_modify_field_representation_inplace);
  }
  
- // Checks that given |map| is deprecated and that it updates to given |new_map|
+ 
 diff --git a/test/mjsunit/regress/regress-1143772.js b/test/mjsunit/regress/regress-1143772.js
 new file mode 100644
-index 0000000..40bc494
+index 0000000000000000000000000000000000000000..40bc494d458afec816fd72e3fbb36b20a7942649
 --- /dev/null
 +++ b/test/mjsunit/regress/regress-1143772.js
 @@ -0,0 +1,71 @@

--- a/patches/v8/cherry-pick-146bd99e762b.patch
+++ b/patches/v8/cherry-pick-146bd99e762b.patch
@@ -1,0 +1,300 @@
+From 146bd99e762bd93f6c5520bb94f02b8ab0aa8d42 Mon Sep 17 00:00:00 2001
+From: ishell@chromium.org <ishell@chromium.org>
+Date: Tue, 03 Nov 2020 12:42:43 +0100
+Subject: [PATCH] Merged: Squashed multiple commits.
+
+Merged: [map] Try to in-place transition during map update
+Revision: 8e3ae62d294818733a0322d8e8abd53d4e410f19
+
+Merged: [map] Skip loading the field owner before GeneralizeField
+Revision: a928f5fcc2a67c2c8d621ece48f76deb0d36637b
+
+BUG=chromium:1143772
+NOTRY=true
+NOPRESUBMIT=true
+NOTREECHECKS=true
+R=verwaest@chromium.org
+
+Change-Id: I78628cb697b21caa2098cc5948e226af5fcd020c
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2516474
+Reviewed-by: Toon Verwaest <verwaest@chromium.org>
+Cr-Commit-Position: refs/branch-heads/8.7@{#31}
+Cr-Branched-From: 0d81cd72688512abcbe1601015baee390c484a6a-refs/heads/8.7.220@{#1}
+Cr-Branched-From: 942c2ef85caef00fcf02517d049f05e9a3d4b440-refs/heads/master@{#70196}
+---
+
+diff --git a/src/objects/map-updater.cc b/src/objects/map-updater.cc
+index e51bcfc..b4b1587 100644
+--- a/src/objects/map-updater.cc
++++ b/src/objects/map-updater.cc
+@@ -232,10 +232,7 @@
+         handle(old_descriptors_->GetFieldType(modified_descriptor_), isolate_),
+         MaybeHandle<Object>(), new_field_type_, MaybeHandle<Object>());
+   }
+-  Handle<Map> field_owner(
+-      old_map_->FindFieldOwner(isolate_, modified_descriptor_), isolate_);
+-
+-  GeneralizeField(field_owner, modified_descriptor_, new_constness_,
++  GeneralizeField(old_map_, modified_descriptor_, new_constness_,
+                   new_representation_, new_field_type_);
+   // Check that the descriptor array was updated.
+   DCHECK(old_descriptors_->GetDetails(modified_descriptor_)
+@@ -401,7 +398,13 @@
+     }
+     Representation tmp_representation = tmp_details.representation();
+     if (!old_details.representation().fits_into(tmp_representation)) {
+-      break;
++      // Try updating the field in-place to a generalized type.
++      Representation generalized =
++          tmp_representation.generalize(old_details.representation());
++      if (!tmp_representation.CanBeInPlaceChangedTo(generalized)) {
++        break;
++      }
++      tmp_representation = generalized;
+     }
+ 
+     if (tmp_details.location() == kField) {
+diff --git a/src/objects/map.cc b/src/objects/map.cc
+index dd941b3..d1370ae 100644
+--- a/src/objects/map.cc
++++ b/src/objects/map.cc
+@@ -610,6 +610,7 @@
+     transitions.GetTarget(i).DeprecateTransitionTree(isolate);
+   }
+   DCHECK(!constructor_or_backpointer().IsFunctionTemplateInfo());
++  DCHECK(CanBeDeprecated());
+   set_is_deprecated(true);
+   if (FLAG_trace_maps) {
+     LOG(isolate, MapEvent("Deprecate", handle(*this, isolate), Handle<Map>()));
+diff --git a/test/cctest/test-field-type-tracking.cc b/test/cctest/test-field-type-tracking.cc
+index a9fa589..2f59d7b 100644
+--- a/test/cctest/test-field-type-tracking.cc
++++ b/test/cctest/test-field-type-tracking.cc
+@@ -1038,7 +1038,8 @@
+ // where "p2A" and "p2B" differ only in the attributes.
+ //
+ void TestReconfigureDataFieldAttribute_GeneralizeField(
+-    const CRFTData& from, const CRFTData& to, const CRFTData& expected) {
++    const CRFTData& from, const CRFTData& to, const CRFTData& expected,
++    bool expected_deprecation) {
+   Isolate* isolate = CcTest::i_isolate();
+ 
+   Expectations expectations(isolate);
+@@ -1107,24 +1108,29 @@
+   CHECK_NE(*map2, *new_map);
+   CHECK(expectations2.Check(*map2));
+ 
+-  // |map| should be deprecated and |new_map| should match new expectations.
+   for (int i = kSplitProp; i < kPropCount; i++) {
+     expectations.SetDataField(i, expected.constness, expected.representation,
+                               expected.type);
+   }
+-  CHECK(map->is_deprecated());
+-  CHECK(!code_field_type->marked_for_deoptimization());
+-  CHECK(!code_field_repr->marked_for_deoptimization());
+-  CHECK(!code_field_const->marked_for_deoptimization());
+-  CHECK_NE(*map, *new_map);
++  if (expected_deprecation) {
++    // |map| should be deprecated and |new_map| should match new expectations.
++    CHECK(map->is_deprecated());
++    CHECK(!code_field_type->marked_for_deoptimization());
++    CHECK(!code_field_repr->marked_for_deoptimization());
++    CHECK(!code_field_const->marked_for_deoptimization());
++    CHECK_NE(*map, *new_map);
+ 
+-  CHECK(!new_map->is_deprecated());
+-  CHECK(expectations.Check(*new_map));
++    CHECK(!new_map->is_deprecated());
++    CHECK(expectations.Check(*new_map));
+ 
+-  // Update deprecated |map|, it should become |new_map|.
+-  Handle<Map> updated_map = Map::Update(isolate, map);
+-  CHECK_EQ(*new_map, *updated_map);
+-  CheckMigrationTarget(isolate, *map, *updated_map);
++    // Update deprecated |map|, it should become |new_map|.
++    Handle<Map> updated_map = Map::Update(isolate, map);
++    CHECK_EQ(*new_map, *updated_map);
++    CheckMigrationTarget(isolate, *map, *updated_map);
++  } else {
++    CHECK(!map->is_deprecated());
++    CHECK(expectations.Check(*map));
++  }
+ }
+ 
+ // This test ensures that trivial field generalization (from HeapObject to
+@@ -1240,22 +1246,22 @@
+   TestReconfigureDataFieldAttribute_GeneralizeField(
+       {PropertyConstness::kConst, Representation::Smi(), any_type},
+       {PropertyConstness::kConst, Representation::Double(), any_type},
+-      {PropertyConstness::kConst, Representation::Double(), any_type});
++      {PropertyConstness::kConst, Representation::Double(), any_type}, true);
+ 
+   TestReconfigureDataFieldAttribute_GeneralizeField(
+       {PropertyConstness::kConst, Representation::Smi(), any_type},
+       {PropertyConstness::kMutable, Representation::Double(), any_type},
+-      {PropertyConstness::kMutable, Representation::Double(), any_type});
++      {PropertyConstness::kMutable, Representation::Double(), any_type}, true);
+ 
+   TestReconfigureDataFieldAttribute_GeneralizeField(
+       {PropertyConstness::kMutable, Representation::Smi(), any_type},
+       {PropertyConstness::kConst, Representation::Double(), any_type},
+-      {PropertyConstness::kMutable, Representation::Double(), any_type});
++      {PropertyConstness::kMutable, Representation::Double(), any_type}, true);
+ 
+   TestReconfigureDataFieldAttribute_GeneralizeField(
+       {PropertyConstness::kMutable, Representation::Smi(), any_type},
+       {PropertyConstness::kMutable, Representation::Double(), any_type},
+-      {PropertyConstness::kMutable, Representation::Double(), any_type});
++      {PropertyConstness::kMutable, Representation::Double(), any_type}, true);
+ }
+ 
+ TEST(ReconfigureDataFieldAttribute_GeneralizeSmiFieldToTagged) {
+@@ -1270,22 +1276,26 @@
+   TestReconfigureDataFieldAttribute_GeneralizeField(
+       {PropertyConstness::kConst, Representation::Smi(), any_type},
+       {PropertyConstness::kConst, Representation::HeapObject(), value_type},
+-      {PropertyConstness::kConst, Representation::Tagged(), any_type});
++      {PropertyConstness::kConst, Representation::Tagged(), any_type},
++      !FLAG_modify_field_representation_inplace);
+ 
+   TestReconfigureDataFieldAttribute_GeneralizeField(
+       {PropertyConstness::kConst, Representation::Smi(), any_type},
+       {PropertyConstness::kMutable, Representation::HeapObject(), value_type},
+-      {PropertyConstness::kMutable, Representation::Tagged(), any_type});
++      {PropertyConstness::kMutable, Representation::Tagged(), any_type},
++      !FLAG_modify_field_representation_inplace);
+ 
+   TestReconfigureDataFieldAttribute_GeneralizeField(
+       {PropertyConstness::kMutable, Representation::Smi(), any_type},
+       {PropertyConstness::kConst, Representation::HeapObject(), value_type},
+-      {PropertyConstness::kMutable, Representation::Tagged(), any_type});
++      {PropertyConstness::kMutable, Representation::Tagged(), any_type},
++      !FLAG_modify_field_representation_inplace);
+ 
+   TestReconfigureDataFieldAttribute_GeneralizeField(
+       {PropertyConstness::kMutable, Representation::Smi(), any_type},
+       {PropertyConstness::kMutable, Representation::HeapObject(), value_type},
+-      {PropertyConstness::kMutable, Representation::Tagged(), any_type});
++      {PropertyConstness::kMutable, Representation::Tagged(), any_type},
++      !FLAG_modify_field_representation_inplace);
+ }
+ 
+ TEST(ReconfigureDataFieldAttribute_GeneralizeDoubleFieldToTagged) {
+@@ -1300,22 +1310,26 @@
+   TestReconfigureDataFieldAttribute_GeneralizeField(
+       {PropertyConstness::kConst, Representation::Double(), any_type},
+       {PropertyConstness::kConst, Representation::HeapObject(), value_type},
+-      {PropertyConstness::kConst, Representation::Tagged(), any_type});
++      {PropertyConstness::kConst, Representation::Tagged(), any_type},
++      FLAG_unbox_double_fields || !FLAG_modify_field_representation_inplace);
+ 
+   TestReconfigureDataFieldAttribute_GeneralizeField(
+       {PropertyConstness::kConst, Representation::Double(), any_type},
+       {PropertyConstness::kMutable, Representation::HeapObject(), value_type},
+-      {PropertyConstness::kMutable, Representation::Tagged(), any_type});
++      {PropertyConstness::kMutable, Representation::Tagged(), any_type},
++      FLAG_unbox_double_fields || !FLAG_modify_field_representation_inplace);
+ 
+   TestReconfigureDataFieldAttribute_GeneralizeField(
+       {PropertyConstness::kMutable, Representation::Double(), any_type},
+       {PropertyConstness::kConst, Representation::HeapObject(), value_type},
+-      {PropertyConstness::kMutable, Representation::Tagged(), any_type});
++      {PropertyConstness::kMutable, Representation::Tagged(), any_type},
++      FLAG_unbox_double_fields || !FLAG_modify_field_representation_inplace);
+ 
+   TestReconfigureDataFieldAttribute_GeneralizeField(
+       {PropertyConstness::kMutable, Representation::Double(), any_type},
+       {PropertyConstness::kMutable, Representation::HeapObject(), value_type},
+-      {PropertyConstness::kMutable, Representation::Tagged(), any_type});
++      {PropertyConstness::kMutable, Representation::Tagged(), any_type},
++      FLAG_unbox_double_fields || !FLAG_modify_field_representation_inplace);
+ }
+ 
+ TEST(ReconfigureDataFieldAttribute_GeneralizeHeapObjFieldToHeapObj) {
+@@ -1401,7 +1415,8 @@
+   TestReconfigureDataFieldAttribute_GeneralizeField(
+       {PropertyConstness::kMutable, Representation::HeapObject(), value_type},
+       {PropertyConstness::kMutable, Representation::Smi(), any_type},
+-      {PropertyConstness::kMutable, Representation::Tagged(), any_type});
++      {PropertyConstness::kMutable, Representation::Tagged(), any_type},
++      !FLAG_modify_field_representation_inplace);
+ }
+ 
+ // Checks that given |map| is deprecated and that it updates to given |new_map|
+diff --git a/test/mjsunit/regress/regress-1143772.js b/test/mjsunit/regress/regress-1143772.js
+new file mode 100644
+index 0000000..40bc494
+--- /dev/null
++++ b/test/mjsunit/regress/regress-1143772.js
+@@ -0,0 +1,71 @@
++// Copyright 2020 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++//
++// Flags: --allow-natives-syntax
++
++(function() {
++    // Only run this test if doubles are transitioned in-place to tagged.
++    let x = {};
++    x.a = 0.1;
++    let y = {};
++    y.a = {};
++    if (!%HaveSameMap(x, y)) return;
++
++    // m1: {}
++    let m1 = {};
++
++    // m2: {a:d}
++    let m2 = {};
++    assertTrue(%HaveSameMap(m2, m1));
++    m2.a = 13.37;
++
++    // m3: {a:d, b:s}
++    let m3 = {};
++    m3.a = 13.37;
++    assertTrue(%HaveSameMap(m3, m2));
++    m3.b = 1;
++
++    // m4: {a:d, b:s, c:h}
++    let m4 = {};
++    m4.a = 13.37;
++    m4.b = 1;
++    assertTrue(%HaveSameMap(m4, m3));
++    m4.c = {};
++
++    // m4_2 == m4
++    let m4_2 = {};
++    m4_2.a = 13.37;
++    m4_2.b = 1;
++    m4_2.c = {};
++    assertTrue(%HaveSameMap(m4_2, m4));
++
++    // m5: {a:d, b:d}
++    let m5 = {};
++    m5.a = 13.37;
++    assertTrue(%HaveSameMap(m5, m2));
++    m5.b = 13.37;
++    assertFalse(%HaveSameMap(m5, m3));
++
++    // At this point, Map3 and Map4 are both deprecated. Map2 transitions to
++    // Map5. Map5 is the migration target for Map3.
++    assertFalse(%HaveSameMap(m5, m3));
++
++    // m6: {a:d, b:d, c:d}
++    let m6 = {};
++    m6.a = 13.37;
++    assertTrue(%HaveSameMap(m6, m2));
++    m6.b = 13.37;
++    assertTrue(%HaveSameMap(m6, m5));
++    m6.c = 13.37
++
++    // Make m7: {a:d, b:d, c:t}
++    let m7 = m4_2;
++    assertTrue(%HaveSameMap(m7, m4));
++    // Map4 is deprecated, so this property access triggers a Map migration.
++    // With in-place map updates and no double unboxing, this should end up
++    // migrating to Map6, and updating it in-place.
++    m7.c;
++    assertFalse(%HaveSameMap(m7, m4));
++    assertTrue(%HaveSameMap(m6, m7));
++})();


### PR DESCRIPTION
Merged: Squashed multiple commits.

Merged: [map] Try to in-place transition during map update
Revision: 8e3ae62d294818733a0322d8e8abd53d4e410f19

Merged: [map] Skip loading the field owner before GeneralizeField
Revision: a928f5fcc2a67c2c8d621ece48f76deb0d36637b

BUG=chromium:1143772
NOTRY=true
NOPRESUBMIT=true
NOTREECHECKS=true
R=verwaest@chromium.org

Change-Id: I78628cb697b21caa2098cc5948e226af5fcd020c
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2516474
Reviewed-by: Toon Verwaest <verwaest@chromium.org>
Cr-Commit-Position: refs/branch-heads/8.7@{#31}
Cr-Branched-From: 0d81cd72688512abcbe1601015baee390c484a6a-refs/heads/8.7.220@{#1}
Cr-Branched-From: 942c2ef85caef00fcf02517d049f05e9a3d4b440-refs/heads/master@{#70196}


Notes: Security: backported fix for 1143772.