### PR TITLE
chore: cherry-pick 2882e1afd982 from angle

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -1,3 +1,4 @@
 update_the_active_texture_cache_before_changing_the_texture_binding.patch
 fix_stale_validation_cache_on_buffer_deletion.patch
 d3d11_fix_bug_with_static_vertex_attributes.patch
+cherry-pick-2882e1afd982.patch

--- a/patches/angle/cherry-pick-2882e1afd982.patch
+++ b/patches/angle/cherry-pick-2882e1afd982.patch
@@ -1,22 +1,19 @@
-From 2882e1afd98253db2d6e5bb892dd3bfd3c69cb6a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jamie Madill <jmadill@chromium.org>
 Date: Tue, 20 Oct 2020 09:45:23 -0400
-Subject: [PATCH] Fix missing validation cache update on VAO binding.
-
-
+Subject: Fix missing validation cache update on VAO binding.
 
 Bug: chromium:1139398
 Change-Id: I85a0d7a72bc2c97b07ebc5f86effd8e36aefd544
 Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/2485581
 Reviewed-by: Geoff Lang <geofflang@chromium.org>
 Commit-Queue: Jamie Madill <jmadill@chromium.org>
----
 
 diff --git a/src/libANGLE/Context.cpp b/src/libANGLE/Context.cpp
-index b7e431f..ec2a1d4 100644
+index f73391da2bd3461ab5c53b30e9fed7376773a051..1ce952124cc02c3d4fbeec0b18095b6d92740369 100644
 --- a/src/libANGLE/Context.cpp
 +++ b/src/libANGLE/Context.cpp
-@@ -8705,6 +8705,7 @@
+@@ -8675,6 +8675,7 @@ void StateCache::onVertexArrayBindingChange(Context *context)
      updateActiveAttribsMask(context);
      updateVertexElementLimits(context);
      updateBasicDrawStatesError();
@@ -25,44 +22,14 @@ index b7e431f..ec2a1d4 100644
  
  void StateCache::onProgramExecutableChange(Context *context)
 diff --git a/src/libANGLE/Context.h b/src/libANGLE/Context.h
-index 74a0e98..bfc8980 100644
+index 9c2abcae729775701cc5b37f1599b849db5978d3..ba0884c4e6bf327e8f2cdd0faf780c897a95c119 100644
 --- a/src/libANGLE/Context.h
 +++ b/src/libANGLE/Context.h
-@@ -204,6 +204,7 @@
+@@ -202,6 +202,7 @@ class StateCache final : angle::NonCopyable
      // 2. onVertexArrayBufferStateChange.
      // 3. onBufferBindingChange.
      // 4. onVertexArrayStateChange.
 +    // 5. onVertexArrayBindingStateChange.
-     intptr_t getBasicDrawElementsError(const Context *context) const
+     intptr_t getBasicDrawElementsError(Context *context) const
      {
          if (mCachedBasicDrawElementsError != kInvalidPointer)
-diff --git a/src/tests/gl_tests/StateChangeTest.cpp b/src/tests/gl_tests/StateChangeTest.cpp
-index e7568dc..7c86993 100644
---- a/src/tests/gl_tests/StateChangeTest.cpp
-+++ b/src/tests/gl_tests/StateChangeTest.cpp
-@@ -5800,6 +5800,25 @@
-     ASSERT_GL_NO_ERROR();
- }
- 
-+// Tests DrawElements with an empty buffer using a VAO.
-+TEST_P(WebGL2ValidationStateChangeTest, DrawElementsEmptyVertexArray)
-+{
-+    ANGLE_GL_PROGRAM(program, essl1_shaders::vs::Simple(), essl1_shaders::fs::Red());
-+
-+    glUseProgram(program);
-+
-+    // Draw with empty buffer. Out of range but valid.
-+    GLBuffer buffer;
-+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, buffer);
-+    glDrawElements(GL_TRIANGLES, 0, GL_UNSIGNED_SHORT, reinterpret_cast<const GLvoid *>(0x1000));
-+
-+    // Switch VAO. No buffer bound, should be an error.
-+    GLVertexArray vao;
-+    glBindVertexArray(vao);
-+    glDrawElements(GL_LINE_STRIP, 0x1000, GL_UNSIGNED_SHORT,
-+                   reinterpret_cast<const GLvoid *>(0x1000));
-+    EXPECT_GL_ERROR(GL_INVALID_OPERATION);
-+}
- }  // anonymous namespace
- 
- ANGLE_INSTANTIATE_TEST_ES2(StateChangeTest);

--- a/patches/angle/cherry-pick-2882e1afd982.patch
+++ b/patches/angle/cherry-pick-2882e1afd982.patch
@@ -1,0 +1,68 @@
+From 2882e1afd98253db2d6e5bb892dd3bfd3c69cb6a Mon Sep 17 00:00:00 2001
+From: Jamie Madill <jmadill@chromium.org>
+Date: Tue, 20 Oct 2020 09:45:23 -0400
+Subject: [PATCH] Fix missing validation cache update on VAO binding.
+
+
+
+Bug: chromium:1139398
+Change-Id: I85a0d7a72bc2c97b07ebc5f86effd8e36aefd544
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/2485581
+Reviewed-by: Geoff Lang <geofflang@chromium.org>
+Commit-Queue: Jamie Madill <jmadill@chromium.org>
+---
+
+diff --git a/src/libANGLE/Context.cpp b/src/libANGLE/Context.cpp
+index b7e431f..ec2a1d4 100644
+--- a/src/libANGLE/Context.cpp
++++ b/src/libANGLE/Context.cpp
+@@ -8705,6 +8705,7 @@
+     updateActiveAttribsMask(context);
+     updateVertexElementLimits(context);
+     updateBasicDrawStatesError();
++    updateBasicDrawElementsError();
+ }
+ 
+ void StateCache::onProgramExecutableChange(Context *context)
+diff --git a/src/libANGLE/Context.h b/src/libANGLE/Context.h
+index 74a0e98..bfc8980 100644
+--- a/src/libANGLE/Context.h
++++ b/src/libANGLE/Context.h
+@@ -204,6 +204,7 @@
+     // 2. onVertexArrayBufferStateChange.
+     // 3. onBufferBindingChange.
+     // 4. onVertexArrayStateChange.
++    // 5. onVertexArrayBindingStateChange.
+     intptr_t getBasicDrawElementsError(const Context *context) const
+     {
+         if (mCachedBasicDrawElementsError != kInvalidPointer)
+diff --git a/src/tests/gl_tests/StateChangeTest.cpp b/src/tests/gl_tests/StateChangeTest.cpp
+index e7568dc..7c86993 100644
+--- a/src/tests/gl_tests/StateChangeTest.cpp
++++ b/src/tests/gl_tests/StateChangeTest.cpp
+@@ -5800,6 +5800,25 @@
+     ASSERT_GL_NO_ERROR();
+ }
+ 
++// Tests DrawElements with an empty buffer using a VAO.
++TEST_P(WebGL2ValidationStateChangeTest, DrawElementsEmptyVertexArray)
++{
++    ANGLE_GL_PROGRAM(program, essl1_shaders::vs::Simple(), essl1_shaders::fs::Red());
++
++    glUseProgram(program);
++
++    // Draw with empty buffer. Out of range but valid.
++    GLBuffer buffer;
++    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, buffer);
++    glDrawElements(GL_TRIANGLES, 0, GL_UNSIGNED_SHORT, reinterpret_cast<const GLvoid *>(0x1000));
++
++    // Switch VAO. No buffer bound, should be an error.
++    GLVertexArray vao;
++    glBindVertexArray(vao);
++    glDrawElements(GL_LINE_STRIP, 0x1000, GL_UNSIGNED_SHORT,
++                   reinterpret_cast<const GLvoid *>(0x1000));
++    EXPECT_GL_ERROR(GL_INVALID_OPERATION);
++}
+ }  // anonymous namespace
+ 
+ ANGLE_INSTANTIATE_TEST_ES2(StateChangeTest);


### PR DESCRIPTION
Fix missing validation cache update on VAO binding.



Bug: chromium:1139398
Change-Id: I85a0d7a72bc2c97b07ebc5f86effd8e36aefd544
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/2485581
Reviewed-by: Geoff Lang <geofflang@chromium.org>
Commit-Queue: Jamie Madill <jmadill@chromium.org>


Notes: Security: backported fix for chromium:1139398.