### PR TITLE
chore: cherry-pick daad98ce from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -150,3 +150,4 @@ cherry-pick-88f263f401b4.patch
 cherry-pick-229fdaf8fc05.patch
 cherry-pick-1ed869ad4bb3.patch
 crashpad-initialize-logging.patch
+make_macos_os_version_numbers_consistent.patch

--- a/patches/chromium/make_macos_os_version_numbers_consistent.patch
+++ b/patches/chromium/make_macos_os_version_numbers_consistent.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Avi Drissman <avi@chromium.org>
+Date: Sat, 25 Jul 2020 17:38:19 +0000
+Subject: Make macOS OS version numbers consistent
+
+The "IsOS/IsAtLeastOS/IsAtMostOS" functions are driven from the Darwin
+version number, which is always accurate. Adjust the
+SysInfo::OperatingSystemVersionNumbers() function to return accurate
+version numbers (or the best we can deduce) so that all version
+numbers returned by helper functions are accurate and consistent.
+
+Bug: 1101439
+Bug: 1108832
+Change-Id: I2ca92478d76bf572cc55875cba443f4978482d10
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2315490
+Reviewed-by: Mark Mentovai <mark@chromium.org>
+Commit-Queue: Avi Drissman <avi@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#791491}
+
+diff --git a/base/system/sys_info_mac.mm b/base/system/sys_info_mac.mm
+index 265d7678060fd003b4f28b2b50f8a80be5253c88..3becbd628e19084de6fd87de4adcdec2c5af67b4 100644
+--- a/base/system/sys_info_mac.mm
++++ b/base/system/sys_info_mac.mm
+@@ -62,6 +62,19 @@ void SysInfo::OperatingSystemVersionNumbers(int32_t* major_version,
+   *major_version = version.majorVersion;
+   *minor_version = version.minorVersion;
+   *bugfix_version = version.patchVersion;
++
++  // TODO(https://crbug.com/1108832): If an app is built against a pre-macOS
++  // 11.0 SDK, macOS will lie as to what version it is, saying that it is macOS
++  // "10.16" rather than "11.0". The problem is that the "IsOS/IsAtLeastOS/
++  // IsAtMostOS" functions are driven from the Darwin version number, which
++  // isn't lied about, and therefore the values returned by this function and
++  // those functions are inconsistent. Therefore, unlie about these values.
++
++  if (*major_version == 10 && *minor_version >= 16) {
++    *major_version = *minor_version - 5;
++    *minor_version = *bugfix_version;
++    *bugfix_version = 0;
++  }
+ }
+ 
+ // static

--- a/spec/api-process-spec.js
+++ b/spec/api-process-spec.js
@@ -70,6 +70,9 @@ describe('process module', () => {
   describe('process.getSystemVersion()', () => {
     it('returns a string', () => {
       expect(process.getSystemVersion()).to.be.a('string');
+      if (process.platform === 'darwin') {
+        expect(process.getSystemVersion()).to.not.equal('10.16'); // #26419
+      }
     });
   });
 


### PR DESCRIPTION
#### Description of Change

Fixes #26419

The "IsOS/IsAtLeastOS/IsAtMostOS" functions are driven from the Darwin
version number, which is always accurate. Adjust the
SysInfo::OperatingSystemVersionNumbers() function to return accurate
version numbers (or the best we can deduce) so that all version
numbers returned by helper functions are accurate and consistent.

Change-Id: I2ca92478d76bf572cc55875cba443f4978482d10
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2315490

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed value of `getSystemVersion()` on Big Sur