### PR TITLE
fix: crash when invoking app.quit()

### DIFF
--- a/shell/browser/api/electron_api_browser_view.cc
+++ b/shell/browser/api/electron_api_browser_view.cc
@@ -92,10 +92,8 @@ BrowserView::BrowserView(gin::Arguments* args,
 
 BrowserView::~BrowserView() {
   if (api_web_contents_) {  // destroy() is called
-    // Destroy WebContents asynchronously unless app is shutting down,
-    // because destroy() might be called inside WebContents's event handler.
     api_web_contents_->RemoveObserver(this);
-    api_web_contents_->DestroyWebContents(!Browser::Get()->is_shutting_down());
+    api_web_contents_->DestroyWebContents(true /* async */);
   }
 }
 

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -446,10 +446,9 @@ void BrowserWindow::Cleanup() {
   if (host)
     host->GetWidget()->RemoveInputEventObserver(this);
 
-  // Destroy WebContents asynchronously unless app is shutting down,
-  // because destroy() might be called inside WebContents's event handler.
-  api_web_contents_->DestroyWebContents(!Browser::Get()->is_shutting_down());
   Observe(nullptr);
+
+  api_web_contents_->DestroyWebContents(true /* async */);
 }
 
 void BrowserWindow::OnWindowShow() {

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -65,11 +65,11 @@ Browser* Browser::Get() {
 }
 
 void Browser::Quit() {
-  if (is_quiting_)
+  if (is_quitting_)
     return;
 
-  is_quiting_ = HandleBeforeQuit();
-  if (!is_quiting_)
+  is_quitting_ = HandleBeforeQuit();
+  if (!is_quitting_)
     return;
 
   if (electron::WindowList::IsEmpty())
@@ -87,7 +87,7 @@ void Browser::Exit(gin::Arguments* args) {
     exit(code);
   } else {
     // Prepare to quit when all windows have been closed.
-    is_quiting_ = true;
+    is_quitting_ = true;
 
     // Remember this caller so that we don't emit unrelated events.
     is_exiting_ = true;
@@ -104,11 +104,11 @@ void Browser::Exit(gin::Arguments* args) {
 }
 
 void Browser::Shutdown() {
-  if (is_shutdown_)
+  if (is_shutting_down_)
     return;
 
-  is_shutdown_ = true;
-  is_quiting_ = true;
+  is_shutting_down_ = true;
+  is_quitting_ = true;
 
   for (BrowserObserver& observer : observers_)
     observer.OnQuit();
@@ -214,14 +214,14 @@ void Browser::PreCreateThreads() {
 }
 
 void Browser::SetMainMessageLoopQuitClosure(base::OnceClosure quit_closure) {
-  if (is_shutdown_)
+  if (is_shutting_down_)
     RunQuitClosure(std::move(quit_closure));
   else
     quit_main_message_loop_ = std::move(quit_closure);
 }
 
 void Browser::NotifyAndShutdown() {
-  if (is_shutdown_)
+  if (is_shutting_down_)
     return;
 
   bool prevent_default = false;
@@ -229,7 +229,7 @@ void Browser::NotifyAndShutdown() {
     observer.OnWillQuit(&prevent_default);
 
   if (prevent_default) {
-    is_quiting_ = false;
+    is_quitting_ = false;
     return;
   }
 
@@ -245,16 +245,16 @@ bool Browser::HandleBeforeQuit() {
 }
 
 void Browser::OnWindowCloseCancelled(NativeWindow* window) {
-  if (is_quiting_)
+  if (is_quitting_)
     // Once a beforeunload handler has prevented the closing, we think the quit
     // is cancelled too.
-    is_quiting_ = false;
+    is_quitting_ = false;
 }
 
 void Browser::OnWindowAllClosed() {
   if (is_exiting_) {
     Shutdown();
-  } else if (is_quiting_) {
+  } else if (is_quitting_) {
     NotifyAndShutdown();
   } else {
     for (BrowserObserver& observer : observers_)

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -306,8 +306,7 @@ class Browser : public WindowListObserver {
   void SetSecureKeyboardEntryEnabled(bool enabled);
 #endif
 
-  bool is_shutting_down() const { return is_shutdown_; }
-  bool is_quiting() const { return is_quiting_; }
+  bool is_shutting_down() const { return is_shutting_down_; }
   bool is_ready() const { return is_ready_; }
   v8::Local<v8::Value> WhenReady(v8::Isolate* isolate);
 
@@ -324,7 +323,7 @@ class Browser : public WindowListObserver {
   // Send the before-quit message and start closing windows.
   bool HandleBeforeQuit();
 
-  bool is_quiting_ = false;
+  bool is_quitting_ = false;
 
  private:
   // WindowListObserver implementations:
@@ -344,7 +343,7 @@ class Browser : public WindowListObserver {
   bool is_ready_ = false;
 
   // The browser is being shutdown.
-  bool is_shutdown_ = false;
+  bool is_shutting_down_ = false;
 
   // Null until/unless the default main message loop is running.
   base::OnceClosure quit_main_message_loop_;

--- a/spec-main/fixtures/crash-cases/quit-inside-navigation-event/index.js
+++ b/spec-main/fixtures/crash-cases/quit-inside-navigation-event/index.js
@@ -1,0 +1,9 @@
+const { app, BrowserWindow } = require('electron');
+
+app.whenReady().then(() => {
+  const mainWindow = new BrowserWindow();
+  mainWindow.loadURL('about:blank');
+  mainWindow.webContents.on('did-finish-load', () => {
+    app.quit();
+  });
+});


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/26423.

Fixes a crash seen when calling `app.quit()` inside navigation events like `did-finish-load`, `did-fail-load`, etc. This was happening because we were quitting synchronously in the same tick before all observers had finished notifying, as confirmed by the fact that calling `setTimeout(() => { app.quit() })` also solved the problem. We fix this by making `api_web_contents_->DestroyWebContents` asynchronous in all cases _including_ shutdown.

Tested with https://gist.github.com/ckerr/d6c4cb50635d1d2dca939ce51df84b92

cc @MarshallOfSound @nornagon @jkleinsc 

<details>
<Summary>Stacktrace</Summary>

```
55429:1110/134149.999064:FATAL:web_contents_impl.cc(879)] Check failed: !observers_.is_notifying_observers(). 
0   Electron Framework                  0x00000001143d3769 base::debug::CollectStackTrace(void**, unsigned long) + 9
1   Electron Framework                  0x00000001142c7c63 base::debug::StackTrace::StackTrace() + 19
2   Electron Framework                  0x00000001142e8115 logging::LogMessage::~LogMessage() + 261
3   Electron Framework                  0x00000001142e8fde logging::LogMessage::~LogMessage() + 14
4   Electron Framework                  0x00000001133c0360 content::WebContentsImpl::~WebContentsImpl() + 352
5   Electron Framework                  0x00000001133c278e content::WebContentsImpl::~WebContentsImpl() + 14
6   Electron Framework                  0x000000010eb55396 electron::InspectableWebContents::~InspectableWebContents() + 262
7   Electron Framework                  0x000000010eb5560e electron::InspectableWebContents::~InspectableWebContents() + 14
8   Electron Framework                  0x000000010ea27651 electron::api::BrowserWindow::Cleanup() + 193
9   Electron Framework                  0x000000010ea285cb electron::api::BrowserWindow::OnWindowClosed() + 27
10  Electron Framework                  0x000000010eb18363 electron::NativeWindow::NotifyWindowClosed() + 323
11  Electron Framework                  0x000000010ebfe7ad -[ElectronNSWindowDelegate windowWillClose:] + 45
```
</details>

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes a crash seen when calling `app.quit()` inside some navigation events.
