### PR TITLE
feat: add app.runningUnderRosettaTranslation to detect running under rosetta

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1490,7 +1490,7 @@ on the direction Electron is going with renderer process restarts and usage of
 native modules in the renderer process please check out this
 [Tracking Issue](https://github.com/electron/electron/issues/18397).
 
-### `app.isRunningUnderRosettaTranslation` _macOS_ _Readonly_
+### `app.runningUnderRosettaTranslation` _macOS_ _Readonly_
 
 A `Boolean` which when `true` indicates that the app is currently running
 under the [Rosetta Translator Environment](https://en.wikipedia.org/wiki/Rosetta_(software)).

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1489,3 +1489,12 @@ which native modules you can use in the renderer process.  For more information
 on the direction Electron is going with renderer process restarts and usage of
 native modules in the renderer process please check out this
 [Tracking Issue](https://github.com/electron/electron/issues/18397).
+
+### `app.isRunningUnderRosettaTranslation` _macOS_ _Readonly_
+
+A `Boolean` which when `true` indicates that the app is currently running
+under the [Rosetta Translator Environment](https://en.wikipedia.org/wiki/Rosetta_(software)).
+
+You can use this property to prompt users to download the arm64 version of
+your application when they are running the x64 version under Rosetta
+incorrectly.

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1666,7 +1666,7 @@ gin::ObjectTemplateBuilder App::GetObjectTemplateBuilder(v8::Isolate* isolate) {
 #endif
 #if defined(OS_MAC)
       .SetProperty("dock", &App::GetDockAPI)
-      .SetProperty("isRunningUnderRosettaTranslation",
+      .SetProperty("runningUnderRosettaTranslation",
                    &App::IsRunningUnderRosettaTranslation)
 #endif
       .SetProperty("userAgentFallback", &App::GetUserAgentFallback,
@@ -1674,7 +1674,7 @@ gin::ObjectTemplateBuilder App::GetObjectTemplateBuilder(v8::Isolate* isolate) {
       .SetMethod("enableSandbox", &App::EnableSandbox)
       .SetProperty("allowRendererProcessReuse",
                    &App::CanBrowserClientUseCustomSiteInstance,
-                   &App::SetBrowserClientCanUseCustomSiteInstance)
+                   &App::SetBrowserClientCanUseCustomSiteInstance);
 }
 
 const char* App::GetTypeName() {

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1666,13 +1666,15 @@ gin::ObjectTemplateBuilder App::GetObjectTemplateBuilder(v8::Isolate* isolate) {
 #endif
 #if defined(OS_MAC)
       .SetProperty("dock", &App::GetDockAPI)
+      .SetProperty("isRunningUnderRosettaTranslation",
+                   &App::IsRunningUnderRosettaTranslation)
 #endif
       .SetProperty("userAgentFallback", &App::GetUserAgentFallback,
                    &App::SetUserAgentFallback)
       .SetMethod("enableSandbox", &App::EnableSandbox)
       .SetProperty("allowRendererProcessReuse",
                    &App::CanBrowserClientUseCustomSiteInstance,
-                   &App::SetBrowserClientCanUseCustomSiteInstance);
+                   &App::SetBrowserClientCanUseCustomSiteInstance)
 }
 
 const char* App::GetTypeName() {

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -221,7 +221,7 @@ class App : public ElectronBrowserClient::Delegate,
   bool MoveToApplicationsFolder(gin_helper::ErrorThrower, gin::Arguments* args);
   bool IsInApplicationsFolder();
   v8::Local<v8::Value> GetDockAPI(v8::Isolate* isolate);
-  bool IsRunningUnderRosettaTranslation();
+  bool IsRunningUnderRosettaTranslation() const;
   v8::Global<v8::Value> dock_;
 #endif
 

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -221,6 +221,7 @@ class App : public ElectronBrowserClient::Delegate,
   bool MoveToApplicationsFolder(gin_helper::ErrorThrower, gin::Arguments* args);
   bool IsInApplicationsFolder();
   v8::Local<v8::Value> GetDockAPI(v8::Isolate* isolate);
+  bool IsRunningUnderRosettaTranslation();
   v8::Global<v8::Value> dock_;
 #endif
 

--- a/shell/browser/api/electron_api_app_mac.mm
+++ b/shell/browser/api/electron_api_app_mac.mm
@@ -64,7 +64,7 @@ bool App::IsRunningUnderRosettaTranslation() {
   if (sysctlbyname("sysctl.proc_translated", &ret, &size, NULL, 0) == -1) {
     return false;
   }
-  return ret == = 1;
+  return ret == 1;
 }
 
 }  // namespace api

--- a/shell/browser/api/electron_api_app_mac.mm
+++ b/shell/browser/api/electron_api_app_mac.mm
@@ -58,13 +58,14 @@ void App::SetActivationPolicy(gin_helper::ErrorThrower thrower,
   [NSApp setActivationPolicy:activation_policy];
 }
 
-bool App::IsRunningUnderRosettaTranslation() {
-  int ret = 0;
-  size_t size = sizeof(ret);
-  if (sysctlbyname("sysctl.proc_translated", &ret, &size, NULL, 0) == -1) {
+bool App::IsRunningUnderRosettaTranslation() const {
+  int proc_translated = 0;
+  size_t size = sizeof(proc_translated);
+  if (sysctlbyname("sysctl.proc_translated", &proc_translated, &size, NULL,
+                   0) == -1) {
     return false;
   }
-  return ret == 1;
+  return proc_translated == 1;
 }
 
 }  // namespace api

--- a/shell/browser/api/electron_api_app_mac.mm
+++ b/shell/browser/api/electron_api_app_mac.mm
@@ -58,6 +58,15 @@ void App::SetActivationPolicy(gin_helper::ErrorThrower thrower,
   [NSApp setActivationPolicy:activation_policy];
 }
 
+bool App::IsRunningUnderRosettaTranslation() {
+  int ret = 0;
+  size_t size = sizeof(ret);
+  if (sysctlbyname("sysctl.proc_translated", &ret, &size, NULL, 0) == -1) {
+    return false;
+  }
+  return ret == = 1;
+}
+
 }  // namespace api
 
 }  // namespace electron

--- a/shell/browser/api/electron_api_app_mac.mm
+++ b/shell/browser/api/electron_api_app_mac.mm
@@ -9,6 +9,7 @@
 #include "shell/common/electron_paths.h"
 
 #import <Cocoa/Cocoa.h>
+#import <sys/sysctl.h>
 
 namespace electron {
 


### PR DESCRIPTION
As in title and notes, simple API, code is straight from apples docs.

Docs reference for rosetta detection: https://developer.apple.com/documentation/apple_silicon/about_the_rosetta_translation_environment?language=objc#3616845

Notes: Added new `app.runningUnderRosettaTranslation` property to detect when running under rosetta on Apple silicon