### PR TITLE
chore: remove ScopedAllowBlockingForTesting

### DIFF
--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -108,8 +108,6 @@ ElectronBrowserContext::ElectronBrowserContext(const std::string& partition,
       in_memory_(in_memory),
       ssl_config_(network::mojom::SSLConfig::New()),
       weak_factory_(this) {
-  // TODO(nornagon): remove once https://crbug.com/1048822 is fixed.
-  base::ScopedAllowBlockingForTesting allow_blocking;
   user_agent_ = ElectronBrowserClient::Get()->GetUserAgent();
 
   // Read options.


### PR DESCRIPTION
#### Description of Change

Working on something tangential and noticed that upstream https://bugs.chromium.org/p/chromium/issues/detail?id=1048822 has been fixed by [this CL](https://chromium-review.googlesource.com/c/chromium/src/+/2324169) and this can thus be removed.

cc @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none