### PR TITLE
doc: Can not set the BrowserWindow's webContents

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -171,22 +171,18 @@ instance, failing to do so may result in unexpected behavior. For example:
 myBrowserWindow.webContents.on('new-window', (event, url, frameName, disposition, options, additionalFeatures, referrer, postBody) => {
   event.preventDefault()
   const win = new BrowserWindow({
-    webContents: options.webContents, // use existing webContents if provided
     show: false
   })
   win.once('ready-to-show', () => win.show())
-  if (!options.webContents) {
-    const loadOptions = {
-      httpReferrer: referrer
-    }
-    if (postBody != null) {
-      const { data, contentType, boundary } = postBody
-      loadOptions.postData = postBody.data
-      loadOptions.extraHeaders = `content-type: ${contentType}; boundary=${boundary}`
-    }
-
-    win.loadURL(url, loadOptions) // existing webContents will be navigated automatically
+  const loadOptions = {
+    httpReferrer: referrer
   }
+  if (postBody != null) {
+    const { data, contentType, boundary } = postBody
+    loadOptions.postData = postBody.data
+    loadOptions.extraHeaders = `content-type: ${contentType}; boundary=${boundary}`
+  }
+  win.loadURL(url, loadOptions) // existing webContents will be navigated automatically
   event.newGuest = win
 })
 ```


### PR DESCRIPTION
#### Description of Change
One can not set the BrowserWindow's webContents when create a new BrowserWindow instance , so remove some lines of the example code.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
