### PR TITLE
build: don't generate patches mtime cache if it already exists

### DIFF
--- a/script/patches-mtime-cache.py
+++ b/script/patches-mtime-cache.py
@@ -105,10 +105,7 @@ def main():
         "generate", help="generate the mtime cache"
     )
     generate_subparser.add_argument(
-        "--cache-file",
-        type=argparse.FileType("w"),
-        required=True,
-        help="mtime cache file",
+        "--cache-file", required=True, help="mtime cache file"
     )
 
     set_subparser = subparsers.add_parser(
@@ -133,8 +130,18 @@ def main():
 
     if args.operation == "generate":
         try:
-            mtime_cache = generate_cache(json.load(args.patches_config))
-            json.dump(mtime_cache, args.cache_file, indent=2)
+            # Cache file may exist from a previously aborted sync. Reuse it.
+            with open(args.cache_file, mode="r") as f:
+                json.load(f)  # Make sure it's not an empty file
+                print("Using existing mtime cache for patches")
+                return 0
+        except:
+            pass
+
+        try:
+            with open(args.cache_file, mode="w") as f:
+                mtime_cache = generate_cache(json.load(args.patches_config))
+                json.dump(mtime_cache, f, indent=2)
         except Exception:
             print(
                 "ERROR: failed to generate mtime cache for patches",


### PR DESCRIPTION
#### Description of Change

There's a window where an unsuccessful sync (canceled, hits an error, cosmic radiation, etc) will have put files back to a clean state, but not finished, patched, and applied the mtime cache. Currently running sync again will re-generate the mtime cache, rendering it useless for its intended purpose, and upon successful sync you'll be back to a long re-build.

This PR closes the window and will re-use an mtime cache if it's still there. It is deleted after being applied, so it should only exist if a sync was unsuccessful.

I don't think there's any concerns here, the file hash should prevent anything funky from happening.

cc @nornagon 

#### Checklist

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none