### PR TITLE
feat: add displayFrequency to Display object

### DIFF
--- a/docs/api/structures/display.md
+++ b/docs/api/structures/display.md
@@ -10,6 +10,7 @@
 * `colorSpace` String -  represent a color space (three-dimensional object which contains all realizable color combinations) for the purpose of color conversions
 * `colorDepth` Number - The number of bits per pixel.
 * `depthPerComponent` Number - The number of bits per color component.
+* `displayFrequency` Number - The display refresh rate.
 * `bounds` [Rectangle](rectangle.md)
 * `size` [Size](size.md)
 * `workArea` [Rectangle](rectangle.md)

--- a/shell/common/gin_converters/gfx_converter.cc
+++ b/shell/common/gin_converters/gfx_converter.cc
@@ -151,6 +151,7 @@ v8::Local<v8::Value> Converter<display::Display>::ToV8(
   dict.Set("colorSpace", val.color_spaces().GetRasterColorSpace().ToString());
   dict.Set("depthPerComponent", val.depth_per_component());
   dict.Set("size", val.size());
+  dict.Set("displayFrequency", val.display_frequency());
   dict.Set("workAreaSize", val.work_area_size());
   dict.Set("scaleFactor", val.device_scale_factor());
   dict.Set("rotation", val.RotationAsDegree());

--- a/spec-main/api-screen-spec.ts
+++ b/spec-main/api-screen-spec.ts
@@ -30,6 +30,7 @@ describe('screen module', () => {
       expect(display).to.have.property('depthPerComponent').that.is.a('number');
       expect(display).to.have.property('colorDepth').that.is.a('number');
       expect(display).to.have.property('colorSpace').that.is.a('string');
+      expect(display).to.have.property('displayFrequency').that.is.a('number');
     });
 
     it('has a size object property', function () {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/26460.

Refs https://chromium-review.googlesource.com/c/chromium/src/+/1621328.

Adds `displayFrequency` to the `Display` object to allow getting information about the refresh rate.

cc @jkleinsc @MarshallOfSound @zcbenz 

 
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `displayFrequency` to the `Display` object to allow getting information about the refresh rate on Windows.
