### PR TITLE
fix: Cannot read property 'setDockSide' of undefined

### DIFF
--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -576,7 +576,7 @@ void InspectableWebContents::LoadCompleted() {
       base::RemoveChars(current_dock_state, "\"", &dock_state_);
     }
     base::string16 javascript = base::UTF8ToUTF16(
-        "Components.dockController.setDockSide(\"" + dock_state_ + "\");");
+        "UI.DockController.instance().setDockSide(\"" + dock_state_ + "\");");
     GetDevToolsWebContents()->GetMainFrame()->ExecuteJavaScript(
         javascript, base::NullCallback());
   }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/26300.

Refs:
 * https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/2391226
 * https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/2354551

cc @nornagon @ckerr @jkleinsc 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an Uncaught TypeError when opening DevTools.