### PR TITLE
test: support for adding extra module paths

### DIFF
--- a/spec-main/index.js
+++ b/spec-main/index.js
@@ -4,6 +4,13 @@ const v8 = require('v8');
 
 Module.globalPaths.push(path.resolve(__dirname, '../spec/node_modules'));
 
+// Extra module paths which can be used to load Mocha reporters
+if (process.env.ELECTRON_TEST_EXTRA_MODULE_PATHS) {
+  for (const modulePath of process.env.ELECTRON_TEST_EXTRA_MODULE_PATHS.split(':')) {
+    Module.globalPaths.push(modulePath);
+  }
+}
+
 // We want to terminate on errors, not throw up a dialog
 process.on('uncaughtException', (err) => {
   console.error('Unhandled exception in main spec runner:', err);

--- a/spec/static/index.html
+++ b/spec/static/index.html
@@ -5,9 +5,17 @@
   // Deprecated APIs are still supported and should be tested.
   process.throwDeprecation = false
 
+  const Module = require('module');
   const path = require('path')
   const electron = require('electron')
   const { ipcRenderer } = electron
+
+  // Extra module paths which can be used to load Mocha reporters
+  if (process.env.ELECTRON_TEST_EXTRA_MODULE_PATHS) {
+    for (const modulePath of process.env.ELECTRON_TEST_EXTRA_MODULE_PATHS.split(':')) {
+      Module.globalPaths.push(modulePath);
+    }
+  }
 
   // Set up chai-as-promised here first to avoid conflicts
   // It must be loaded first or really strange things happen inside


### PR DESCRIPTION
#### Description of Change

I'd like to be able to use a different `MOCHA_REPORTER`, which is almost fully supported, but currently that reporter must be in `spec/node_modules` or `spec-main/node_modules`. This PR adds ~`MOCHA_MODULE_PATHS`~ `ELECTRON_EXTRA_MODULE_PATHS` for adding to the module paths so that reporters can be loaded from outside the tree. This seemed like the most concise and small way to get the desired functionality.

Could also be used to remove `mocha-appveyor-reporter` as a dependency and use this functionality to load it on AppVeyor.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none