### PR TITLE
fix: do not use crashpad APIs in the MAS build

### DIFF
--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -286,13 +286,15 @@ static_library("chrome") {
     }
   }
 
-  sources += [ "//chrome/browser/hang_monitor/hang_crash_dump.h" ]
-  if (is_mac) {
-    sources += [ "//chrome/browser/hang_monitor/hang_crash_dump_mac.cc" ]
-  } else if (is_win) {
-    sources += [ "//chrome/browser/hang_monitor/hang_crash_dump_win.cc" ]
-  } else {
-    sources += [ "//chrome/browser/hang_monitor/hang_crash_dump.cc" ]
+  if (!is_mas_build) {
+    sources += [ "//chrome/browser/hang_monitor/hang_crash_dump.h" ]
+    if (is_mac) {
+      sources += [ "//chrome/browser/hang_monitor/hang_crash_dump_mac.cc" ]
+    } else if (is_win) {
+      sources += [ "//chrome/browser/hang_monitor/hang_crash_dump_win.cc" ]
+    } else {
+      sources += [ "//chrome/browser/hang_monitor/hang_crash_dump.cc" ]
+    }
   }
 }
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -27,7 +27,6 @@
 #include "base/threading/thread_task_runner_handle.h"
 #include "base/values.h"
 #include "chrome/browser/browser_process.h"
-#include "chrome/browser/hang_monitor/hang_crash_dump.h"
 #include "chrome/browser/ssl/security_state_tab_helper.h"
 #include "chrome/common/pref_names.h"
 #include "components/prefs/pref_service.h"
@@ -177,6 +176,10 @@
 #if BUILDFLAG(ENABLE_PDF_VIEWER)
 #include "components/pdf/browser/pdf_web_contents_helper.h"  // nogncheck
 #include "shell/browser/electron_pdf_web_contents_helper_client.h"
+#endif
+
+#ifndef MAS_BUILD
+#include "chrome/browser/hang_monitor/hang_crash_dump.h"  // nogncheck
 #endif
 
 namespace gin {
@@ -2113,7 +2116,9 @@ void WebContents::ForcefullyCrashRenderer() {
     rph->ForceCrash();
 #else
     // Try to generate a crash report for the hung process.
+#ifndef MAS_BUILD
     CrashDumpHungChildProcess(rph->GetProcess().Handle());
+#endif
     rph->Shutdown(content::RESULT_CODE_HUNG);
 #endif
   }


### PR DESCRIPTION
Fixes #26480

Notes: Removed private API usage that was blocking Mac App Store releases