### PR TITLE
fix: BrowserWindow.fromBrowserView in multiple-BrowserView windows

### DIFF
--- a/lib/browser/api/browser-window.ts
+++ b/lib/browser/api/browser-window.ts
@@ -96,11 +96,7 @@ BrowserWindow.fromWebContents = (webContents: WebContents) => {
 };
 
 BrowserWindow.fromBrowserView = (browserView: BrowserView) => {
-  for (const window of BrowserWindow.getAllWindows()) {
-    if (window.getBrowserView() === browserView) return window;
-  }
-
-  return null;
+  return BrowserWindow.fromWebContents(browserView.webContents);
 };
 
 BrowserWindow.prototype.setTouchBar = function (touchBar) {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1634,7 +1634,7 @@ describe('BrowserWindow module', () => {
   describe('BrowserWindow.fromBrowserView(browserView)', () => {
     afterEach(closeAllWindows);
 
-    it('returns the window with the browserView', () => {
+    it('returns the window with the BrowserView', () => {
       const w = new BrowserWindow({ show: false });
       const bv = new BrowserView();
       w.setBrowserView(bv);
@@ -1643,6 +1643,22 @@ describe('BrowserWindow module', () => {
         (bv.webContents as any).destroy();
       });
       expect(BrowserWindow.fromBrowserView(bv)!.id).to.equal(w.id);
+    });
+
+    it('returns the window when there are multiple BrowserViews', () => {
+      const w = new BrowserWindow({ show: false });
+      const bv1 = new BrowserView();
+      w.addBrowserView(bv1);
+      const bv2 = new BrowserView();
+      w.addBrowserView(bv2);
+      defer(() => {
+        w.removeBrowserView(bv1);
+        w.removeBrowserView(bv2);
+        (bv1.webContents as any).destroy();
+        (bv2.webContents as any).destroy();
+      });
+      expect(BrowserWindow.fromBrowserView(bv1)!.id).to.equal(w.id);
+      expect(BrowserWindow.fromBrowserView(bv2)!.id).to.equal(w.id);
     });
 
     it('returns undefined if not attached', () => {


### PR DESCRIPTION
#### Description of Change
Fixes #26488.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed BrowserWindow.fromBrowserView throwing an error when there were multiple BrowserViews in a window.