### PR TITLE
fix: webContents interaction with draggable BrowserViews

### DIFF
--- a/patches/chromium/render_widget_host_view_mac.patch
+++ b/patches/chromium/render_widget_host_view_mac.patch
@@ -10,10 +10,10 @@ kinds of utility windows. Similarly for `disableAutoHideCursor`.
 Additionally, disables usage of some private APIs in MAS builds.
 
 diff --git a/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm b/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
-index eae6d8c330a523e85c7997e59091be0ce42031dc..3f23af8dca0d8a1fa149877cde1a553360610eba 100644
+index eae6d8c330a523e85c7997e59091be0ce42031dc..d90f13139cfc9291c76824a6529e2931176d1079 100644
 --- a/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
 +++ b/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
-@@ -154,6 +154,11 @@ void ExtractUnderlines(NSAttributedString* string,
+@@ -154,6 +154,15 @@ void ExtractUnderlines(NSAttributedString* string,
  
  }  // namespace
  
@@ -22,10 +22,14 @@ index eae6d8c330a523e85c7997e59091be0ce42031dc..3f23af8dca0d8a1fa149877cde1a5533
 +- (BOOL)disableAutoHideCursor;
 +@end
 +
++@interface NSView (ElectronCustomMethods)
++- (BOOL)shouldIgnoreMouseEvent;
++@end
++
  // These are not documented, so use only after checking -respondsToSelector:.
  @interface NSApplication (UndocumentedSpeechMethods)
  - (void)speakString:(NSString*)string;
-@@ -573,6 +578,9 @@ - (BOOL)acceptsMouseEventsWhenInactive {
+@@ -573,6 +582,9 @@ - (BOOL)acceptsMouseEventsWhenInactive {
  }
  
  - (BOOL)acceptsFirstMouse:(NSEvent*)theEvent {
@@ -35,7 +39,18 @@ index eae6d8c330a523e85c7997e59091be0ce42031dc..3f23af8dca0d8a1fa149877cde1a5533
    return [self acceptsMouseEventsWhenInactive];
  }
  
-@@ -996,6 +1004,10 @@ - (void)keyEvent:(NSEvent*)theEvent wasKeyEquivalent:(BOOL)equiv {
+@@ -648,6 +660,10 @@ - (BOOL)shouldIgnoreMouseEvent:(NSEvent*)theEvent {
+   // its parent view.
+   BOOL hitSelf = NO;
+   while (view) {
++    if ([view respondsToSelector:@selector(shouldIgnoreMouseEvent)] && ![view shouldIgnoreMouseEvent]) {
++      return NO;
++    }
++
+     if (view == self)
+       hitSelf = YES;
+     if ([view isKindOfClass:[self class]] && ![view isEqual:self] &&
+@@ -996,6 +1012,10 @@ - (void)keyEvent:(NSEvent*)theEvent wasKeyEquivalent:(BOOL)equiv {
                                eventType == NSKeyDown &&
                                !(modifierFlags & NSCommandKeyMask);
  
@@ -46,7 +61,7 @@ index eae6d8c330a523e85c7997e59091be0ce42031dc..3f23af8dca0d8a1fa149877cde1a5533
    // We only handle key down events and just simply forward other events.
    if (eventType != NSKeyDown) {
      _hostHelper->ForwardKeyboardEvent(event, latency_info);
-@@ -1772,9 +1784,11 @@ - (NSAccessibilityRole)accessibilityRole {
+@@ -1772,9 +1792,11 @@ - (NSAccessibilityRole)accessibilityRole {
  // Since this implementation doesn't have to wait any IPC calls, this doesn't
  // make any key-typing jank. --hbono 7/23/09
  //
@@ -58,7 +73,7 @@ index eae6d8c330a523e85c7997e59091be0ce42031dc..3f23af8dca0d8a1fa149877cde1a5533
  
  - (NSArray*)validAttributesForMarkedText {
    // This code is just copied from WebKit except renaming variables.
-@@ -1783,7 +1797,10 @@ - (NSArray*)validAttributesForMarkedText {
+@@ -1783,7 +1805,10 @@ - (NSArray*)validAttributesForMarkedText {
          initWithObjects:NSUnderlineStyleAttributeName,
                          NSUnderlineColorAttributeName,
                          NSMarkedClauseSegmentAttributeName,

--- a/shell/browser/native_browser_view_mac.mm
+++ b/shell/browser/native_browser_view_mac.mm
@@ -34,10 +34,16 @@ const NSAutoresizingMaskOptions kDefaultAutoResizingMask =
   return NO;
 }
 
-- (NSView*)hitTest:(NSPoint)aPoint {
-  // Pass-through events that don't hit one of the exclusion zones
+- (BOOL)shouldIgnoreMouseEvent {
+  NSEventType type = [[NSApp currentEvent] type];
+  return type != NSEventTypeLeftMouseDragged &&
+         type != NSEventTypeLeftMouseDown;
+}
+
+- (NSView*)hitTest:(NSPoint)point {
+  // Pass-through events that hit one of the exclusion zones
   for (NSView* exclusion_zones in [self subviews]) {
-    if ([exclusion_zones hitTest:aPoint])
+    if ([exclusion_zones hitTest:point])
       return nil;
   }
 
@@ -45,6 +51,8 @@ const NSAutoresizingMaskOptions kDefaultAutoResizingMask =
 }
 
 - (void)mouseDown:(NSEvent*)event {
+  [super mouseDown:event];
+
   if ([self.window respondsToSelector:@selector(performWindowDragWithEvent)]) {
     // According to Google, using performWindowDragWithEvent:
     // does not generate a NSWindowWillMoveNotification. Hence post one.
@@ -65,7 +73,7 @@ const NSAutoresizingMaskOptions kDefaultAutoResizingMask =
   self.initialLocation = [event locationInWindow];
 }
 
-- (void)mouseDragged:(NSEvent*)theEvent {
+- (void)mouseDragged:(NSEvent*)event {
   if ([self.window respondsToSelector:@selector(performWindowDragWithEvent)]) {
     return;
   }
@@ -125,15 +133,13 @@ const NSAutoresizingMaskOptions kDefaultAutoResizingMask =
   [self.window setFrameOrigin:newOrigin];
 }
 
-// Debugging tips:
-// Uncomment the following four lines to color DragRegionView bright red
-// #ifdef DEBUG_DRAG_REGIONS
-// - (void)drawRect:(NSRect)aRect
-// {
-//     [[NSColor redColor] set];
-//     NSRectFill([self bounds]);
-// }
-// #endif
+// For debugging purposes only.
+- (void)drawRect:(NSRect)aRect {
+  if (getenv("ELECTRON_DEBUG_DRAG_REGIONS")) {
+    [[[NSColor greenColor] colorWithAlphaComponent:0.5] set];
+    NSRectFill([self bounds]);
+  }
+}
 
 @end
 
@@ -146,15 +152,13 @@ const NSAutoresizingMaskOptions kDefaultAutoResizingMask =
   return NO;
 }
 
-// Debugging tips:
-// Uncomment the following four lines to color ExcludeDragRegionView bright red
-// #ifdef DEBUG_DRAG_REGIONS
-// - (void)drawRect:(NSRect)aRect
-// {
-//     [[NSColor greenColor] set];
-//     NSRectFill([self bounds]);
-// }
-// #endif
+// For debugging purposes only.
+- (void)drawRect:(NSRect)aRect {
+  if (getenv("ELECTRON_DEBUG_DRAG_REGIONS")) {
+    [[[NSColor redColor] colorWithAlphaComponent:0.5] set];
+    NSRectFill([self bounds]);
+  }
+}
 
 @end
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/26355.

Fixed an issue where some buttons were un-clickable in some BrowserViews with draggable regions enabled.

This was happening because the way we construct draggable regions in `BrowserViews` is different than what we do in `BrowserWindows` - we implement them in the former by creating a new draggable `NSView` and overlaying regions that are not draggable. To accomplish this, we need to `hitTest` the view, so we can perform the correct actions when a user mouses down and tries to drag. Chromium explicitly chooses to ignore  mouse events in `RenderWidgetHostViewCocoa` when another view has returned itself in the `hitTest`, which is the case here and the root of the bug.

To fix the issue resultant of the above, we explicitly need to tell Chromium that it should _not_ use its own mouse ignore logic if a `NSEventTypeLeftMouseDragged` or `NSEventTypeLeftMouseDown` event - it should first check to see if we've told it not to do that and then proceed accordingly.

Tested with https://gist.github.com/060ad478da5b628726da4b4ea94a16a6.

cc @MarshallOfSound @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where some buttons were un-clickable in some BrowserViews with draggable regions enabled. 
