### PR TITLE
docs: add a white background to body in quick-start.md

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -106,7 +106,7 @@ The `index.html` page looks as follows:
     <title>Hello World!</title>
     <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline';" />
 </head>
-<body>
+<body style="background: white;">
     <h1>Hello World!</h1>
     We are using node <script>document.write(process.versions.node)</script>,
     Chrome <script>document.write(process.versions.chrome)</script>,


### PR DESCRIPTION
#### Description of Change

I've added `style="background: white;"` to the `body` tag in the quick start guide so that the resulting app would have a white background, like developers usually expect, or at least to be able to see the "Hello World" text, like in the result image in the quick start guide itself.

This is the current result after following the quick start guide on a Windows with dark-theme on:
![image](https://user-images.githubusercontent.com/26556598/99196584-03f68f80-2796-11eb-87eb-47516bd2b1ec.png)
and this is after the background addition:
![image](https://user-images.githubusercontent.com/26556598/99196601-1a045000-2796-11eb-89a1-6291dd7ccb42.png)

Maybe the better change is to change electron itself to have white as a default like in Chrome, but I'm not sure.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added

#### Release Notes

Notes: none
