### PR TITLE
fix: getLoginItemSettings() on windows

### DIFF
--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -171,13 +171,12 @@ base::string16 GetAppForProtocolUsingRegistry(const GURL& url) {
 }
 
 bool FormatCommandLineString(base::string16* exe,
-                             const std::vector<base::string16>& launch_args,
-                             bool formatArgs) {
+                             const std::vector<base::string16>& launch_args {
   if (exe->empty() && !GetProcessExecPath(exe)) {
     return false;
   }
 
-  if (formatArgs && !launch_args.empty()) {
+  if (!launch_args.empty()) {
     *exe = base::StringPrintf(L"%ls %ls", exe->c_str(),
                               base::JoinString(launch_args, L" ").c_str());
   }
@@ -623,7 +622,7 @@ void Browser::SetLoginItemSettings(LoginItemSettings settings) {
 
   if (settings.open_at_login) {
     base::string16 exe = settings.path;
-    if (FormatCommandLineString(&exe, settings.args, true)) {
+    if (FormatCommandLineString(&exe, settings.args)) {
       key.WriteValue(key_name, exe.c_str());
 
       if (settings.enabled) {
@@ -662,7 +661,7 @@ Browser::LoginItemSettings Browser::GetLoginItemSettings(
   // keep old openAtLogin behaviour
   if (!FAILED(key.ReadValue(GetAppUserModelID(), &keyVal))) {
     base::string16 exe = options.path;
-    if (FormatCommandLineString(&exe, options.args, true)) {
+    if (FormatCommandLineString(&exe, options.args)) {
       settings.open_at_login = keyVal == exe;
     }
   }

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -171,7 +171,7 @@ base::string16 GetAppForProtocolUsingRegistry(const GURL& url) {
 }
 
 bool FormatCommandLineString(base::string16* exe,
-                             const std::vector<base::string16>& launch_args {
+                             const std::vector<base::string16>& launch_args) {
   if (exe->empty() && !GetProcessExecPath(exe)) {
     return false;
   }

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -604,6 +604,16 @@ describe('app module', () => {
       '--processStart', `"${path.basename(process.execPath)}"`,
       '--process-start-args', '"--hidden"'
     ];
+    const regAddArgs = [
+      'ADD',
+      'HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\Run',
+      '/v',
+      'additionalEntry',
+      '/t',
+      'REG_BINARY',
+      '/f',
+      '/d'
+    ];
 
     before(function () {
       if (process.platform === 'linux' || process.mas) this.skip();
@@ -612,11 +622,13 @@ describe('app module', () => {
     beforeEach(() => {
       app.setLoginItemSettings({ openAtLogin: false });
       app.setLoginItemSettings({ openAtLogin: false, path: updateExe, args: processStartArgs });
+      app.setLoginItemSettings({ name: 'additionalEntry', openAtLogin: false });
     });
 
     afterEach(() => {
       app.setLoginItemSettings({ openAtLogin: false });
       app.setLoginItemSettings({ openAtLogin: false, path: updateExe, args: processStartArgs });
+      app.setLoginItemSettings({ name: 'additionalEntry', openAtLogin: false });
     });
 
     ifit(process.platform !== 'win32')('sets and returns the app as a login item', function () {
@@ -631,7 +643,7 @@ describe('app module', () => {
     });
 
     ifit(process.platform === 'win32')('sets and returns the app as a login item (windows)', function () {
-      app.setLoginItemSettings({ openAtLogin: true });
+      app.setLoginItemSettings({ openAtLogin: true, enabled: true });
       expect(app.getLoginItemSettings()).to.deep.equal({
         openAtLogin: true,
         openAsHidden: false,
@@ -645,6 +657,24 @@ describe('app module', () => {
           args: [],
           scope: 'user',
           enabled: true
+        }]
+      });
+
+      app.setLoginItemSettings({ openAtLogin: false });
+      app.setLoginItemSettings({ openAtLogin: true, enabled: false });
+      expect(app.getLoginItemSettings()).to.deep.equal({
+        openAtLogin: true,
+        openAsHidden: false,
+        wasOpenedAtLogin: false,
+        wasOpenedAsHidden: false,
+        restoreState: false,
+        executableWillLaunchAtLogin: false,
+        launchItems: [{
+          name: 'electron.app.Electron',
+          path: process.execPath,
+          args: [],
+          scope: 'user',
+          enabled: false
         }]
       });
     });
@@ -775,6 +805,117 @@ describe('app module', () => {
           enabled: true
         }]
       });
+    });
+
+    ifit(process.platform === 'win32')('finds launch items independent of args', function () {
+      app.setLoginItemSettings({ openAtLogin: true, args: ['arg1'] });
+      app.setLoginItemSettings({ openAtLogin: true, name: 'additionalEntry', enabled: false, args: ['arg2'] });
+      expect(app.getLoginItemSettings()).to.deep.equal({
+        openAtLogin: false,
+        openAsHidden: false,
+        wasOpenedAtLogin: false,
+        wasOpenedAsHidden: false,
+        restoreState: false,
+        executableWillLaunchAtLogin: true,
+        launchItems: [{
+          name: 'additionalEntry',
+          path: process.execPath,
+          args: ['arg2'],
+          scope: 'user',
+          enabled: false
+        }, {
+          name: 'electron.app.Electron',
+          path: process.execPath,
+          args: ['arg1'],
+          scope: 'user',
+          enabled: true
+        }]
+      });
+    });
+
+    ifit(process.platform === 'win32')('finds launch items independent of path quotation or casing', function () {
+      const expectation = {
+        openAtLogin: false,
+        openAsHidden: false,
+        wasOpenedAtLogin: false,
+        wasOpenedAsHidden: false,
+        restoreState: false,
+        executableWillLaunchAtLogin: true,
+        launchItems: [{
+          name: 'additionalEntry',
+          path: 'C:\\electron\\myapp.exe',
+          args: ['arg1'],
+          scope: 'user',
+          enabled: true
+        }]
+      };
+
+      app.setLoginItemSettings({ openAtLogin: true, name: 'additionalEntry', enabled: true, path: 'C:\\electron\\myapp.exe', args: ['arg1'] });
+      expect(app.getLoginItemSettings({ path: '"C:\\electron\\MYAPP.exe"' })).to.deep.equal(expectation);
+
+      app.setLoginItemSettings({ openAtLogin: false, name: 'additionalEntry' });
+      app.setLoginItemSettings({ openAtLogin: true, name: 'additionalEntry', enabled: true, path: '"C:\\electron\\MYAPP.exe"', args: ['arg1'] });
+      expect(app.getLoginItemSettings({ path: 'C:\\electron\\myapp.exe' })).to.deep.equal({
+        ...expectation,
+        launchItems: [
+          {
+            name: 'additionalEntry',
+            path: 'C:\\electron\\MYAPP.exe',
+            args: ['arg1'],
+            scope: 'user',
+            enabled: true
+          }
+        ]
+      });
+    });
+
+    ifit(process.platform === 'win32')('detects disabled by TaskManager', async function () {
+      app.setLoginItemSettings({ openAtLogin: true, name: 'additionalEntry', enabled: true, args: ['arg1'] });
+      const appProcess = cp.spawn('reg', [...regAddArgs, '030000000000000000000000']);
+      await emittedOnce(appProcess, 'exit');
+      expect(app.getLoginItemSettings()).to.deep.equal({
+        openAtLogin: false,
+        openAsHidden: false,
+        wasOpenedAtLogin: false,
+        wasOpenedAsHidden: false,
+        restoreState: false,
+        executableWillLaunchAtLogin: false,
+        launchItems: [{
+          name: 'additionalEntry',
+          path: process.execPath,
+          args: ['arg1'],
+          scope: 'user',
+          enabled: false
+        }]
+      });
+    });
+
+    ifit(process.platform === 'win32')('detects enabled by TaskManager', async function () {
+      const expectation = {
+        openAtLogin: false,
+        openAsHidden: false,
+        wasOpenedAtLogin: false,
+        wasOpenedAsHidden: false,
+        restoreState: false,
+        executableWillLaunchAtLogin: true,
+        launchItems: [{
+          name: 'additionalEntry',
+          path: process.execPath,
+          args: ['arg1'],
+          scope: 'user',
+          enabled: true
+        }]
+      };
+
+      app.setLoginItemSettings({ openAtLogin: true, name: 'additionalEntry', enabled: false, args: ['arg1'] });
+      let appProcess = cp.spawn('reg', [...regAddArgs, '020000000000000000000000']);
+      await emittedOnce(appProcess, 'exit');
+      expect(app.getLoginItemSettings()).to.deep.equal(expectation);
+
+      app.setLoginItemSettings({ openAtLogin: true, name: 'additionalEntry', enabled: false, args: ['arg1'] });
+      appProcess = cp.spawn('reg', [...regAddArgs, '000000000000000000000000']);
+      await emittedOnce(appProcess, 'exit');
+      expect(app.getLoginItemSettings()).to.deep.equal(expectation);
     });
   });
 


### PR DESCRIPTION
#### Description of Change
Pull request #24494 introduced better support for launch on login settings on Windows. Unfortunately, 2 bugs made it into the PR. First, the `getLoginItemSettings()` is supposed to report all launch items that would start the executable independent of the arguments. This is fixed now.  In addition to that, the API can also detect executable path independent of quotation. Second, the TaskManager used a certain binary in the StartupApporved registry key to enable/disable a launch item. There was a little twister in the logic code. Fixed now as well. I added relevant tests that would have exposed these bugs. /cc @MarshallOfSound  

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [X] `npm test` passes
- [X] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [X] relevant documentation is changed or added
- [X] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes:
* Fixed detection of launch on login items
* Fixed detection of enabled state set by TaskManager