### PR TITLE
fix: setCertVerifyProc canceling unrelated requests

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -483,6 +483,8 @@ win.webContents.session.setCertificateVerifyProc((request, callback) => {
 })
 ```
 
+> **NOTE:** The result of this procedure is cached by the network service.
+
 #### `ses.setPermissionRequestHandler(handler)`
 
 * `handler` Function | null

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -619,9 +619,6 @@ void Session::SetCertVerifyProc(v8::Local<v8::Value> val,
   content::BrowserContext::GetDefaultStoragePartition(browser_context_)
       ->GetNetworkContext()
       ->SetCertVerifierClient(std::move(cert_verifier_client_remote));
-
-  // This causes the cert verifier cache to be cleared.
-  content::GetNetworkService()->OnCertDBChanged();
 }
 
 void Session::SetPermissionRequestHandler(v8::Local<v8::Value> val,


### PR DESCRIPTION
#### Description of Change
This changes the behavior of ses.setCertificateVerifyProc so that it no longer
resets connections and clears the certificate verifier cache.

The original reason for clearing the cache was that our tests were written in
such a way that caching the result of the computation would interfere with the
functionality under test. Unfortunately, the only way we have to clear the
cache also has the side effect of canceling all open TLS requests in all
sessions. In lieu of a way to have this method affect only the session in which
it's called, I think that a better behavior is to not reset the cache. The
expected use for `setCertificateVerifyProc` is to call it once at the beginning
of a session's lifetime, so I believe that the impact of this behavior change
on real apps will be minimal.

Fixes #25338.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed `ses.setCertificateVerifyProc` canceling requests in unrelated sessions.
