### PR TITLE
refactor: move GetPrinterList off WebContents

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -283,6 +283,7 @@ filenames = {
     "shell/browser/api/electron_api_power_monitor.h",
     "shell/browser/api/electron_api_power_save_blocker.cc",
     "shell/browser/api/electron_api_power_save_blocker.h",
+    "shell/browser/api/electron_api_printing.cc",
     "shell/browser/api/electron_api_protocol.cc",
     "shell/browser/api/electron_api_protocol.h",
     "shell/browser/api/electron_api_screen.cc",

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -123,6 +123,7 @@ const defaultPrintingSetting = {
 
 // JavaScript implementations of WebContents.
 const binding = process._linkedBinding('electron_browser_web_contents');
+const printing = process._linkedBinding('electron_browser_printing');
 const { WebContents } = binding as { WebContents: { prototype: Electron.WebContents } };
 
 WebContents.prototype.send = function (channel, ...args) {
@@ -416,8 +417,10 @@ WebContents.prototype.print = function (options = {}, callback) {
 };
 
 WebContents.prototype.getPrinters = function () {
-  if (this._getPrinters) {
-    return this._getPrinters();
+  // TODO(nornagon): this API has nothing to do with WebContents and should be
+  // moved.
+  if (printing.getPrinterList) {
+    return printing.getPrinterList();
   } else {
     console.error('Error: Printing feature is disabled.');
     return [];

--- a/shell/browser/api/electron_api_printing.cc
+++ b/shell/browser/api/electron_api_printing.cc
@@ -1,0 +1,77 @@
+// Copyright (c) 2020 Slack Technologies, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "base/threading/thread_restrictions.h"
+#include "chrome/browser/browser_process.h"
+#include "gin/converter.h"
+#include "printing/buildflags/buildflags.h"
+#include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/node_includes.h"
+
+#if BUILDFLAG(ENABLE_PRINTING)
+#include "printing/backend/print_backend.h"
+#endif
+
+namespace gin {
+
+#if BUILDFLAG(ENABLE_PRINTING)
+template <>
+struct Converter<printing::PrinterBasicInfo> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const printing::PrinterBasicInfo& val) {
+    gin_helper::Dictionary dict = gin::Dictionary::CreateEmpty(isolate);
+    dict.Set("name", val.printer_name);
+    dict.Set("displayName", val.display_name);
+    dict.Set("description", val.printer_description);
+    dict.Set("status", val.printer_status);
+    dict.Set("isDefault", val.is_default ? true : false);
+    dict.Set("options", val.options);
+    return dict.GetHandle();
+  }
+};
+#endif
+
+}  // namespace gin
+
+namespace electron {
+
+namespace api {
+
+#if BUILDFLAG(ENABLE_PRINTING)
+printing::PrinterList GetPrinterList() {
+  printing::PrinterList printers;
+  auto print_backend = printing::PrintBackend::CreateInstance(
+      g_browser_process->GetApplicationLocale());
+  {
+    // TODO(deepak1556): Deprecate this api in favor of an
+    // async version and post a non blocing task call.
+    base::ThreadRestrictions::ScopedAllowIO allow_io;
+    print_backend->EnumeratePrinters(&printers);
+  }
+  return printers;
+}
+#endif
+
+}  // namespace api
+
+}  // namespace electron
+
+namespace {
+
+using namespace electron::api;
+
+void Initialize(v8::Local<v8::Object> exports,
+                v8::Local<v8::Value> unused,
+                v8::Local<v8::Context> context,
+                void* priv) {
+  v8::Isolate* isolate = context->GetIsolate();
+  gin_helper::Dictionary dict(isolate, exports);
+#if BUILDFLAG(ENABLE_PRINTING)
+  dict.SetMethod("getPrinterList", base::BindRepeating(&GetPrinterList));
+#endif
+}
+
+}  // namespace
+
+NODE_LINKED_MODULE_CONTEXT_AWARE(electron_browser_printing, Initialize)

--- a/shell/browser/api/electron_api_printing.cc
+++ b/shell/browser/api/electron_api_printing.cc
@@ -59,7 +59,7 @@ printing::PrinterList GetPrinterList() {
 
 namespace {
 
-using namespace electron::api;
+using electron::api::GetPrinterList;
 
 void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Value> unused,

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -163,6 +163,10 @@
 #include "printing/backend/print_backend.h"  // nogncheck
 #include "printing/mojom/print.mojom.h"
 #include "shell/browser/printing/print_preview_message_handler.h"
+
+#if defined(OS_WIN)
+#include "printing/backend/win_helper.h"
+#endif
 #endif
 
 #if BUILDFLAG(ENABLE_COLOR_CHOOSER)

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -45,12 +45,7 @@
 #if BUILDFLAG(ENABLE_PRINTING)
 #include "chrome/browser/printing/print_view_manager_basic.h"
 #include "components/printing/common/print_messages.h"
-#include "printing/backend/print_backend.h"  // nogncheck
 #include "shell/browser/printing/print_preview_message_handler.h"
-
-#if defined(OS_WIN)
-#include "printing/backend/win_helper.h"
-#endif
 #endif
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
@@ -257,7 +252,6 @@ class WebContents : public gin::Wrappable<WebContents>,
                            bool silent,
                            base::string16 default_printer);
   void Print(gin::Arguments* args);
-  printing::PrinterList GetPrinterList();
   // Print current page as PDF.
   v8::Local<v8::Promise> PrintToPDF(base::DictionaryValue settings);
 #endif

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -56,6 +56,7 @@
   V(electron_browser_power_monitor)      \
   V(electron_browser_power_save_blocker) \
   V(electron_browser_protocol)           \
+  V(electron_browser_printing)           \
   V(electron_browser_session)            \
   V(electron_browser_system_preferences) \
   V(electron_browser_base_window)        \


### PR DESCRIPTION
#### Description of Change
This method doesn't need anything related to WebContents, so move it to a
separate module. Ultimately I think the API should be moved as well, but this
PR leaves the API unchanged.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)

#### Release Notes

Notes: none
