### PR TITLE
refactor: move TerminationStatus converter

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -522,6 +522,7 @@ filenames = {
     "shell/common/electron_paths.h",
     "shell/common/gin_converters/accelerator_converter.cc",
     "shell/common/gin_converters/accelerator_converter.h",
+    "shell/common/gin_converters/base_converter.h",
     "shell/common/gin_converters/blink_converter.cc",
     "shell/common/gin_converters/blink_converter.h",
     "shell/common/gin_converters/callback_converter.h",

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -45,6 +45,7 @@
 #include "shell/common/application_info.h"
 #include "shell/common/electron_command_line.h"
 #include "shell/common/electron_paths.h"
+#include "shell/common/gin_converters/base_converter.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_converters/file_path_converter.h"
 #include "shell/common/gin_converters/gurl_converter.h"

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -101,6 +101,7 @@
 #include "shell/common/api/electron_api_native_image.h"
 #include "shell/common/color_util.h"
 #include "shell/common/electron_constants.h"
+#include "shell/common/gin_converters/base_converter.h"
 #include "shell/common/gin_converters/blink_converter.h"
 #include "shell/common/gin_converters/callback_converter.h"
 #include "shell/common/gin_converters/content_converter.h"

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -74,42 +74,8 @@ class ResourceRequestBody;
 }
 
 namespace gin {
-
 class Arguments;
-
-template <>
-struct Converter<base::TerminationStatus> {
-  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   const base::TerminationStatus& status) {
-    switch (status) {
-      case base::TERMINATION_STATUS_NORMAL_TERMINATION:
-        return gin::ConvertToV8(isolate, "clean-exit");
-      case base::TERMINATION_STATUS_ABNORMAL_TERMINATION:
-        return gin::ConvertToV8(isolate, "abnormal-exit");
-      case base::TERMINATION_STATUS_PROCESS_WAS_KILLED:
-        return gin::ConvertToV8(isolate, "killed");
-      case base::TERMINATION_STATUS_PROCESS_CRASHED:
-        return gin::ConvertToV8(isolate, "crashed");
-      case base::TERMINATION_STATUS_STILL_RUNNING:
-        return gin::ConvertToV8(isolate, "still-running");
-      case base::TERMINATION_STATUS_LAUNCH_FAILED:
-        return gin::ConvertToV8(isolate, "launch-failed");
-      case base::TERMINATION_STATUS_OOM:
-        return gin::ConvertToV8(isolate, "oom");
-#if defined(OS_WIN)
-      case base::TERMINATION_STATUS_INTEGRITY_FAILURE:
-        return gin::ConvertToV8(isolate, "integrity-failure");
-#endif
-      case base::TERMINATION_STATUS_MAX_ENUM:
-        NOTREACHED();
-        return gin::ConvertToV8(isolate, "");
-    }
-    NOTREACHED();
-    return gin::ConvertToV8(isolate, "");
-  }
-};
-
-}  // namespace gin
+}
 
 namespace electron {
 

--- a/shell/common/gin_converters/base_converter.h
+++ b/shell/common/gin_converters/base_converter.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2014 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_COMMON_GIN_CONVERTERS_BASE_CONVERTER_H_
+#define SHELL_COMMON_GIN_CONVERTERS_BASE_CONVERTER_H_
+
+#include "base/process/kill.h"
+#include "gin/converter.h"
+
+namespace gin {
+
+template <>
+struct Converter<base::TerminationStatus> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const base::TerminationStatus& status) {
+    switch (status) {
+      case base::TERMINATION_STATUS_NORMAL_TERMINATION:
+        return gin::ConvertToV8(isolate, "clean-exit");
+      case base::TERMINATION_STATUS_ABNORMAL_TERMINATION:
+        return gin::ConvertToV8(isolate, "abnormal-exit");
+      case base::TERMINATION_STATUS_PROCESS_WAS_KILLED:
+        return gin::ConvertToV8(isolate, "killed");
+      case base::TERMINATION_STATUS_PROCESS_CRASHED:
+        return gin::ConvertToV8(isolate, "crashed");
+      case base::TERMINATION_STATUS_STILL_RUNNING:
+        return gin::ConvertToV8(isolate, "still-running");
+      case base::TERMINATION_STATUS_LAUNCH_FAILED:
+        return gin::ConvertToV8(isolate, "launch-failed");
+      case base::TERMINATION_STATUS_OOM:
+        return gin::ConvertToV8(isolate, "oom");
+#if defined(OS_WIN)
+      case base::TERMINATION_STATUS_INTEGRITY_FAILURE:
+        return gin::ConvertToV8(isolate, "integrity-failure");
+#endif
+      case base::TERMINATION_STATUS_MAX_ENUM:
+        NOTREACHED();
+        return gin::ConvertToV8(isolate, "");
+    }
+    NOTREACHED();
+    return gin::ConvertToV8(isolate, "");
+  }
+};
+
+}  // namespace gin
+
+#endif  // SHELL_COMMON_GIN_CONVERTERS_BASE_CONVERTER_H_

--- a/shell/common/gin_converters/base_converter.h
+++ b/shell/common/gin_converters/base_converter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 GitHub, Inc.
+// Copyright (c) 2020 GitHub, Inc.
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 


### PR DESCRIPTION
#### Description of Change
This converter isn't needed in the electron_api_web_contents.h header.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none
