### PR TITLE
chore: remove redundant access modifier

### DIFF
--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -632,7 +632,6 @@ class WebContents : public gin::Wrappable<WebContents>,
   void DevToolsClosed() override;
   void DevToolsResized() override;
 
- private:
   ElectronBrowserContext* GetBrowserContext() const;
 
   // Binds the given request for the ElectronBrowser API. When the


### PR DESCRIPTION
The access is already 'private' at this point in the file.

Notes: none
