### PR TITLE
refactor: inline and rename findInPage request id

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2649,7 +2649,7 @@ uint32_t WebContents::FindInPage(gin::Arguments* args) {
     return 0;
   }
 
-  uint32_t request_id = GetNextRequestId();
+  uint32_t request_id = ++find_in_page_request_id_;
   gin_helper::Dictionary dict;
   auto options = blink::mojom::FindOptions::New();
   if (args->GetNext(&dict)) {

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -642,8 +642,6 @@ class WebContents : public gin::Wrappable<WebContents>,
       content::RenderFrameHost* render_frame_host);
   void OnElectronBrowserConnectionError();
 
-  uint32_t GetNextRequestId() { return ++request_id_; }
-
 #if BUILDFLAG(ENABLE_OSR)
   OffScreenWebContentsView* GetOffScreenWebContentsView() const;
   OffScreenRenderWidgetHostView* GetOffScreenRenderWidgetHostView() const;
@@ -779,7 +777,7 @@ class WebContents : public gin::Wrappable<WebContents>,
   int32_t id_;
 
   // Request id used for findInPage request.
-  uint32_t request_id_ = 0;
+  uint32_t find_in_page_request_id_ = 0;
 
   // Whether background throttling is disabled.
   bool background_throttling_ = true;


### PR DESCRIPTION
"request" is quite generic, and since the method is only called once and is
very simple, I inlined it.

Notes: none
