### PR TITLE
docs: update breaking changes for Electron 11

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -103,7 +103,22 @@ shell.trashItem(path).then(/* ... */)
 
 ## Planned Breaking API Changes (11.0)
 
-There are no breaking changes planned for 11.0.
+### Removed: `BrowserView.{fromId, fromWebContents, getAllViews}` and `id` property of `BrowserView`
+The experimental APIs `BrowserView.{fromId, fromWebContents, getAllViews}`
+have now been removed. Additionally, the `id` property of `BrowserView`
+has also been removed.
+
+For more detailed information, see [#23578](https://github.com/electron/electron/pull/23578).
+
+### Removed: `desktopCapturer.getMediaSourceIdForWebContents()`
+
+The `desktopCapturer` API method `getMediaSourceIdForWebContents` has been
+removed. The method required a WebContents id, but required fetching the id
+through the main process. Any renderer process that could send an IPC message
+could get a token for a video stream in any other renderer, opening up
+a potential security vulnerability.
+
+For more detailed information, see [#25414](https://github.com/electron/electron/pull/25414).
 
 ## Planned Breaking API Changes (10.0)
 

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -103,22 +103,12 @@ shell.trashItem(path).then(/* ... */)
 
 ## Planned Breaking API Changes (11.0)
 
-### Removed: `BrowserView.{fromId, fromWebContents, getAllViews}` and `id` property of `BrowserView`
-The experimental APIs `BrowserView.{fromId, fromWebContents, getAllViews}`
+### Removed: `BrowserView.{destroy, fromId, fromWebContents, getAllViews}` and `id` property of `BrowserView`
+The experimental APIs `BrowserView.{destroy, fromId, fromWebContents, getAllViews}`
 have now been removed. Additionally, the `id` property of `BrowserView`
 has also been removed.
 
 For more detailed information, see [#23578](https://github.com/electron/electron/pull/23578).
-
-### Removed: `desktopCapturer.getMediaSourceIdForWebContents()`
-
-The `desktopCapturer` API method `getMediaSourceIdForWebContents` has been
-removed. The method required a WebContents id, but required fetching the id
-through the main process. Any renderer process that could send an IPC message
-could get a token for a video stream in any other renderer, opening up
-a potential security vulnerability.
-
-For more detailed information, see [#25414](https://github.com/electron/electron/pull/25414).
 
 ## Planned Breaking API Changes (10.0)
 


### PR DESCRIPTION
#### Description of Change

This PR updates our Planned Breaking Changes document to include two new breaking changes introduced in Electron 11, including links to the relevant PRs.

~Note: I added a brief description for why the `desktopCapturer.getMediaSourceIdForWebContents()` API method was removed, but that may be an unnecessary amount of detail. If we want to keep the description down to a simple "This API has been removed", very happy to change it.~ Removed this method entirely 🙂 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
