### PR TITLE
fix: crash on exit in Event destructor

### DIFF
--- a/shell/browser/api/event.cc
+++ b/shell/browser/api/event.cc
@@ -21,11 +21,15 @@ Event::Event() {}
 Event::~Event() {
   if (callback_) {
     v8::Isolate* isolate = electron::JavascriptEnvironment::GetIsolate();
-    v8::HandleScope scope(isolate);
-    auto message = gin::DataObjectBuilder(isolate)
-                       .Set("error", "reply was never sent")
-                       .Build();
-    SendReply(isolate, message);
+    // If there's no current context, it means we're shutting down, so we don't
+    // need to send an event.
+    if (!isolate->GetCurrentContext().IsEmpty()) {
+      v8::HandleScope scope(isolate);
+      auto message = gin::DataObjectBuilder(isolate)
+                         .Set("error", "reply was never sent")
+                         .Build();
+      SendReply(isolate, message);
+    }
   }
 }
 
@@ -62,7 +66,7 @@ gin::ObjectTemplateBuilder Event::GetObjectTemplateBuilder(
 }
 
 const char* Event::GetTypeName() {
-  return "WebRequest";
+  return "Event";
 }
 
 // static


### PR DESCRIPTION
#### Description of Change
e.g. in CI: https://ci.appveyor.com/project/electron-bot/electron-ia32-testing/builds/36345418

Haven't repro'd locally, so this fix is speculative.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)

#### Release Notes

Notes: none
