### PR TITLE
refactor: remove path from nativeImage converter

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -101,8 +101,7 @@ BaseWindow::BaseWindow(v8::Isolate* isolate,
 #if defined(TOOLKIT_VIEWS)
   v8::Local<v8::Value> icon;
   if (options.Get(options::kIcon, &icon)) {
-    gin_helper::ErrorThrower thrower(isolate);
-    SetIcon(thrower, icon);
+    SetIcon(gin_helper::ErrorThrower(isolate), icon);
   }
 #endif
 }
@@ -1008,12 +1007,13 @@ void BaseWindow::SetIcon(gin_helper::ErrorThrower thrower,
     native_image = electron::api::NativeImage::CreateFromPath(thrower.isolate(),
                                                               icon_path);
     if (native_image->image().IsEmpty()) {
-      thrower.ThrowError("Failed to convert path to nativeImage");
+      thrower.ThrowError("Failed to load image from path '" +
+                         icon_path.value() + "'");
       return;
     }
   } else {
     if (!gin::ConvertFromV8(thrower.isolate(), icon, &native_image)) {
-      thrower.ThrowError("Failed to convert nativeImage");
+      thrower.ThrowTypeError("Argument must be a file path or a NativeImage");
       return;
     }
   }

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -99,13 +99,10 @@ BaseWindow::BaseWindow(v8::Isolate* isolate,
   window_->AddObserver(this);
 
 #if defined(TOOLKIT_VIEWS)
-  {
-    v8::TryCatch try_catch(isolate);
-    gin::Handle<NativeImage> icon;
-    if (options.Get(options::kIcon, &icon) && !icon.IsEmpty())
-      SetIcon(icon);
-    if (try_catch.HasCaught())
-      LOG(ERROR) << "Failed to convert NativeImage";
+  v8::Local<v8::Value> icon;
+  if (options.Get(options::kIcon, &icon)) {
+    gin_helper::ErrorThrower thrower(isolate);
+    SetIcon(thrower, icon);
   }
 #endif
 }
@@ -1003,14 +1000,31 @@ bool BaseWindow::SetThumbarButtons(gin_helper::Arguments* args) {
 }
 
 #if defined(TOOLKIT_VIEWS)
-void BaseWindow::SetIcon(gin::Handle<NativeImage> icon) {
+void BaseWindow::SetIcon(gin_helper::ErrorThrower thrower,
+                         v8::Local<v8::Value> icon) {
+  gin::Handle<NativeImage> native_image;
+  base::FilePath icon_path;
+  if (gin::ConvertFromV8(thrower.isolate(), icon, &icon_path)) {
+    native_image = electron::api::NativeImage::CreateFromPath(thrower.isolate(),
+                                                              icon_path);
+    if (native_image->image().IsEmpty()) {
+      thrower.ThrowError("Failed to convert path to nativeImage");
+      return;
+    }
+  } else {
+    if (!gin::ConvertFromV8(thrower.isolate(), icon, &native_image)) {
+      thrower.ThrowError("Failed to convert nativeImage");
+      return;
+    }
+  }
+
 #if defined(OS_WIN)
   static_cast<NativeWindowViews*>(window_.get())
-      ->SetIcon(icon->GetHICON(GetSystemMetrics(SM_CXSMICON)),
-                icon->GetHICON(GetSystemMetrics(SM_CXICON)));
+      ->SetIcon(native_image->GetHICON(GetSystemMetrics(SM_CXSMICON)),
+                native_image->GetHICON(GetSystemMetrics(SM_CXICON)));
 #elif defined(OS_LINUX)
   static_cast<NativeWindowViews*>(window_.get())
-      ->SetIcon(icon->image().AsImageSkia());
+      ->SetIcon(native_image->image().AsImageSkia());
 #endif
 }
 #endif

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -101,7 +101,7 @@ BaseWindow::BaseWindow(v8::Isolate* isolate,
 #if defined(TOOLKIT_VIEWS)
   v8::Local<v8::Value> icon;
   if (options.Get(options::kIcon, &icon)) {
-    SetIcon(gin_helper::ErrorThrower(isolate), icon);
+    SetIcon(isolate, icon);
   }
 #endif
 }
@@ -999,24 +999,10 @@ bool BaseWindow::SetThumbarButtons(gin_helper::Arguments* args) {
 }
 
 #if defined(TOOLKIT_VIEWS)
-void BaseWindow::SetIcon(gin_helper::ErrorThrower thrower,
-                         v8::Local<v8::Value> icon) {
+void BaseWindow::SetIcon(v8::Isolate* isolate, v8::Local<v8::Value> icon) {
   gin::Handle<NativeImage> native_image;
-  base::FilePath icon_path;
-  if (gin::ConvertFromV8(thrower.isolate(), icon, &icon_path)) {
-    native_image = electron::api::NativeImage::CreateFromPath(thrower.isolate(),
-                                                              icon_path);
-    if (native_image->image().IsEmpty()) {
-      thrower.ThrowError("Failed to load image from path '" +
-                         icon_path.value() + "'");
-      return;
-    }
-  } else {
-    if (!gin::ConvertFromV8(thrower.isolate(), icon, &native_image)) {
-      thrower.ThrowTypeError("Argument must be a file path or a NativeImage");
-      return;
-    }
-  }
+  if (!NativeImage::TryConvertNativeImage(isolate, icon, &native_image))
+    return;
 
 #if defined(OS_WIN)
   static_cast<NativeWindowViews*>(window_.get())

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -1000,7 +1000,7 @@ bool BaseWindow::SetThumbarButtons(gin_helper::Arguments* args) {
 
 #if defined(TOOLKIT_VIEWS)
 void BaseWindow::SetIcon(v8::Isolate* isolate, v8::Local<v8::Value> icon) {
-  gin::Handle<NativeImage> native_image;
+  NativeImage* native_image = nullptr;
   if (!NativeImage::TryConvertNativeImage(isolate, icon, &native_image))
     return;
 

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -222,7 +222,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   // Extra APIs added in JS.
   bool SetThumbarButtons(gin_helper::Arguments* args);
 #if defined(TOOLKIT_VIEWS)
-  void SetIcon(gin_helper::ErrorThrower thrower, v8::Local<v8::Value> icon);
+  void SetIcon(v8::Isolate* isolate, v8::Local<v8::Value> icon);
 #endif
 #if defined(OS_WIN)
   typedef base::RepeatingCallback<void(v8::Local<v8::Value>,

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -17,6 +17,7 @@
 #include "shell/browser/native_window.h"
 #include "shell/browser/native_window_observer.h"
 #include "shell/common/api/electron_api_native_image.h"
+#include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/trackable_object.h"
 
 namespace electron {
@@ -221,7 +222,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   // Extra APIs added in JS.
   bool SetThumbarButtons(gin_helper::Arguments* args);
 #if defined(TOOLKIT_VIEWS)
-  void SetIcon(gin::Handle<NativeImage> icon);
+  void SetIcon(gin_helper::ErrorThrower thrower, v8::Local<v8::Value> icon);
 #endif
 #if defined(OS_WIN)
   typedef base::RepeatingCallback<void(v8::Local<v8::Value>,

--- a/shell/browser/api/electron_api_tray.cc
+++ b/shell/browser/api/electron_api_tray.cc
@@ -62,11 +62,11 @@ namespace api {
 
 gin::WrapperInfo Tray::kWrapperInfo = {gin::kEmbedderNativeGin};
 
-Tray::Tray(v8::Local<v8::Value> image,
-           base::Optional<UUID> guid,
-           gin::Arguments* args)
+Tray::Tray(v8::Isolate* isolate,
+           v8::Local<v8::Value> image,
+           base::Optional<UUID> guid)
     : tray_icon_(TrayIcon::Create(guid)) {
-  SetImage(args->isolate(), image);
+  SetImage(isolate, image);
   tray_icon_->AddObserver(this);
 }
 

--- a/shell/browser/api/electron_api_tray.cc
+++ b/shell/browser/api/electron_api_tray.cc
@@ -192,7 +192,7 @@ void Tray::SetImage(v8::Isolate* isolate, v8::Local<v8::Value> image) {
   if (!CheckAlive())
     return;
 
-  gin::Handle<NativeImage> native_image;
+  NativeImage* native_image = nullptr;
   if (!NativeImage::TryConvertNativeImage(isolate, image, &native_image))
     return;
 
@@ -207,7 +207,7 @@ void Tray::SetPressedImage(v8::Isolate* isolate, v8::Local<v8::Value> image) {
   if (!CheckAlive())
     return;
 
-  gin::Handle<NativeImage> native_image;
+  NativeImage* native_image = nullptr;
   if (!NativeImage::TryConvertNativeImage(isolate, image, &native_image))
     return;
 
@@ -296,7 +296,7 @@ void Tray::DisplayBalloon(gin_helper::ErrorThrower thrower,
   }
 
   v8::Local<v8::Value> icon_value;
-  gin::Handle<NativeImage> icon;
+  NativeImage* icon = nullptr;
   if (options.Get("icon", &icon_value) &&
       !NativeImage::TryConvertNativeImage(thrower.isolate(), icon_value,
                                           &icon)) {
@@ -308,7 +308,7 @@ void Tray::DisplayBalloon(gin_helper::ErrorThrower thrower,
   options.Get("noSound", &balloon_options.no_sound);
   options.Get("respectQuietTime", &balloon_options.respect_quiet_time);
 
-  if (!icon.IsEmpty()) {
+  if (icon) {
 #if defined(OS_WIN)
     balloon_options.icon = icon->GetHICON(
         GetSystemMetrics(balloon_options.large_icon ? SM_CXICON : SM_CXSMICON));

--- a/shell/browser/api/electron_api_tray.h
+++ b/shell/browser/api/electron_api_tray.h
@@ -54,9 +54,9 @@ class Tray : public gin::Wrappable<Tray>,
   static gin::WrapperInfo kWrapperInfo;
 
  private:
-  Tray(v8::Local<v8::Value> image,
-       base::Optional<UUID> guid,
-       gin::Arguments* args);
+  Tray(v8::Isolate* isolate,
+       v8::Local<v8::Value> image,
+       base::Optional<UUID> guid);
   ~Tray() override;
 
   // TrayIconObserver:

--- a/shell/browser/api/electron_api_tray.h
+++ b/shell/browser/api/electron_api_tray.h
@@ -43,7 +43,7 @@ class Tray : public gin::Wrappable<Tray>,
  public:
   // gin_helper::Constructible
   static gin::Handle<Tray> New(gin_helper::ErrorThrower thrower,
-                               gin::Handle<NativeImage> image,
+                               v8::Local<v8::Value> image,
                                base::Optional<UUID> guid,
                                gin::Arguments* args);
   static v8::Local<v8::ObjectTemplate> FillObjectTemplate(
@@ -54,7 +54,7 @@ class Tray : public gin::Wrappable<Tray>,
   static gin::WrapperInfo kWrapperInfo;
 
  private:
-  Tray(gin::Handle<NativeImage> image,
+  Tray(v8::Local<v8::Value> image,
        base::Optional<UUID> guid,
        gin::Arguments* args);
   ~Tray() override;
@@ -83,8 +83,8 @@ class Tray : public gin::Wrappable<Tray>,
   // JS API:
   void Destroy();
   bool IsDestroyed();
-  void SetImage(gin::Handle<NativeImage> image);
-  void SetPressedImage(gin::Handle<NativeImage> image);
+  void SetImage(v8::Isolate* isolate, v8::Local<v8::Value> image);
+  void SetPressedImage(v8::Isolate* isolate, v8::Local<v8::Value> image);
   void SetToolTip(const std::string& tool_tip);
   void SetTitle(const std::string& title,
                 const base::Optional<gin_helper::Dictionary>& options,

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2826,7 +2826,7 @@ void WebContents::StartDrag(const gin_helper::Dictionary& item,
     return;
   }
 
-  gin::Handle<NativeImage> icon;
+  NativeImage* icon = nullptr;
   if (!NativeImage::TryConvertNativeImage(args->isolate(), icon_value, &icon) ||
       icon->image().IsEmpty()) {
     return;

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2813,7 +2813,6 @@ void WebContents::EndFrameSubscription() {
 
 void WebContents::StartDrag(const gin_helper::Dictionary& item,
                             gin::Arguments* args) {
-  gin_helper::ErrorThrower thrower(args->isolate());
   base::FilePath file;
   std::vector<base::FilePath> files;
   if (!item.Get("files", &files) && item.Get("file", &file)) {
@@ -2832,7 +2831,8 @@ void WebContents::StartDrag(const gin_helper::Dictionary& item,
     base::CurrentThread::ScopedNestableTaskAllower allow;
     DragFileItems(files, icon->image(), web_contents()->GetNativeView());
   } else {
-    thrower.ThrowError("Must specify either 'file' or 'files' option");
+    gin_helper::ErrorThrower(args->isolate())
+        .ThrowError("Must specify either 'file' or 'files' option");
   }
 }
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2820,20 +2820,11 @@ void WebContents::StartDrag(const gin_helper::Dictionary& item,
     files.push_back(file);
   }
 
+  v8::Local<v8::Value> icon_value;
   gin::Handle<NativeImage> icon;
-  base::FilePath icon_path;
-  if (item.Get("icon", &icon_path)) {
-    icon = electron::api::NativeImage::CreateFromPath(thrower.isolate(),
-                                                      icon_path);
-    if (icon->image().IsEmpty()) {
-      thrower.ThrowError("Must specify non-empty 'icon' option");
-      return;
-    }
-  } else {
-    if (!item.Get("icon", &icon) || icon->image().IsEmpty()) {
-      thrower.ThrowError("Must specify non-empty 'icon' option");
-      return;
-    }
+  if (item.Get("icon", &icon_value) &&
+      !NativeImage::TryConvertNativeImage(args->isolate(), icon_value, &icon)) {
+    return;
   }
 
   // Start dragging.

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2813,6 +2813,7 @@ void WebContents::EndFrameSubscription() {
 
 void WebContents::StartDrag(const gin_helper::Dictionary& item,
                             gin::Arguments* args) {
+  gin_helper::ErrorThrower thrower(args->isolate());
   base::FilePath file;
   std::vector<base::FilePath> files;
   if (!item.Get("files", &files) && item.Get("file", &file)) {
@@ -2820,10 +2821,19 @@ void WebContents::StartDrag(const gin_helper::Dictionary& item,
   }
 
   gin::Handle<NativeImage> icon;
-  if (!item.Get("icon", &icon) || icon->image().IsEmpty()) {
-    gin_helper::ErrorThrower(args->isolate())
-        .ThrowError("Must specify non-empty 'icon' option");
-    return;
+  base::FilePath icon_path;
+  if (item.Get("icon", &icon_path)) {
+    icon = electron::api::NativeImage::CreateFromPath(thrower.isolate(),
+                                                      icon_path);
+    if (icon->image().IsEmpty()) {
+      thrower.ThrowError("Must specify non-empty 'icon' option");
+      return;
+    }
+  } else {
+    if (!item.Get("icon", &icon) || icon->image().IsEmpty()) {
+      thrower.ThrowError("Must specify non-empty 'icon' option");
+      return;
+    }
   }
 
   // Start dragging.
@@ -2831,8 +2841,7 @@ void WebContents::StartDrag(const gin_helper::Dictionary& item,
     base::CurrentThread::ScopedNestableTaskAllower allow;
     DragFileItems(files, icon->image(), web_contents()->GetNativeView());
   } else {
-    gin_helper::ErrorThrower(args->isolate())
-        .ThrowError("Must specify either 'file' or 'files' option");
+    thrower.ThrowError("Must specify either 'file' or 'files' option");
   }
 }
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2820,9 +2820,15 @@ void WebContents::StartDrag(const gin_helper::Dictionary& item,
   }
 
   v8::Local<v8::Value> icon_value;
+  if (!item.Get("icon", &icon_value)) {
+    gin_helper::ErrorThrower(args->isolate())
+        .ThrowError("'icon' parameter is required");
+    return;
+  }
+
   gin::Handle<NativeImage> icon;
-  if (item.Get("icon", &icon_value) &&
-      !NativeImage::TryConvertNativeImage(args->isolate(), icon_value, &icon)) {
+  if (!NativeImage::TryConvertNativeImage(args->isolate(), icon_value, &icon) ||
+      icon->image().IsEmpty()) {
     return;
   }
 

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -223,7 +223,7 @@ class Browser : public WindowListObserver {
   void DockSetMenu(ElectronMenuModel* model);
 
   // Set docks' icon.
-  void DockSetIcon(const gfx::Image& image);
+  void DockSetIcon(v8::Isolate* isolate, v8::Local<v8::Value> icon);
 
 #endif  // defined(OS_MAC)
 

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -460,9 +460,9 @@ void Browser::DockSetIcon(v8::Isolate* isolate, v8::Local<v8::Value> icon) {
 
   if (!icon->IsNull()) {
     api::NativeImage* native_image = nullptr;
-    if (api::NativeImage::TryConvertNativeImage(isolate, icon, &native_image)) {
-      image = native_image->image();
-    }
+    if (!api::NativeImage::TryConvertNativeImage(isolate, icon, &native_image))
+      return;
+    image = native_image->image();
   }
 
   [[AtomApplication sharedApplication]

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -456,12 +456,17 @@ void Browser::DockSetMenu(ElectronMenuModel* model) {
 }
 
 void Browser::DockSetIcon(v8::Isolate* isolate, v8::Local<v8::Value> icon) {
-  api::NativeImage* native_image = nullptr;
-  if (!api::NativeImage::TryConvertNativeImage(isolate, icon, &native_image))
-    return;
+  gfx::Image image;
+
+  if (!icon->IsNull()) {
+    api::NativeImage* native_image = nullptr;
+    if (api::NativeImage::TryConvertNativeImage(isolate, icon, &native_image)) {
+      image = native_image->image();
+    }
+  }
 
   [[AtomApplication sharedApplication]
-      setApplicationIconImage:native_image->image().AsNSImage()];
+      setApplicationIconImage:image.AsNSImage()];
 }
 
 void Browser::ShowAboutPanel() {

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -20,6 +20,7 @@
 #include "shell/browser/mac/electron_application_delegate.h"
 #include "shell/browser/native_window.h"
 #include "shell/browser/window_list.h"
+#include "shell/common/api/electron_api_native_image.h"
 #include "shell/common/application_info.h"
 #include "shell/common/gin_converters/image_converter.h"
 #include "shell/common/gin_helper/arguments.h"
@@ -454,9 +455,13 @@ void Browser::DockSetMenu(ElectronMenuModel* model) {
   [delegate setApplicationDockMenu:model];
 }
 
-void Browser::DockSetIcon(const gfx::Image& image) {
+void Browser::DockSetIcon(v8::Isolate* isolate, v8::Local<v8::Value> icon) {
+  gin::Handle<api::NativeImage> native_image;
+  if (!api::NativeImage::TryConvertNativeImage(isolate, icon, &native_image))
+    return;
+
   [[AtomApplication sharedApplication]
-      setApplicationIconImage:image.AsNSImage()];
+      setApplicationIconImage:native_image->image().AsNSImage()];
 }
 
 void Browser::ShowAboutPanel() {

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -456,7 +456,7 @@ void Browser::DockSetMenu(ElectronMenuModel* model) {
 }
 
 void Browser::DockSetIcon(v8::Isolate* isolate, v8::Local<v8::Value> icon) {
-  gin::Handle<api::NativeImage> native_image;
+  api::NativeImage* native_image = nullptr;
   if (!api::NativeImage::TryConvertNativeImage(isolate, icon, &native_image))
     return;
 

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -587,24 +587,6 @@ bool Converter<electron::api::NativeImage*>::FromV8(
     v8::Isolate* isolate,
     v8::Local<v8::Value> val,
     electron::api::NativeImage** out) {
-  // Try converting from file path.
-  base::FilePath path;
-  if (ConvertFromV8(isolate, val, &path)) {
-    *out = electron::api::NativeImage::CreateFromPath(isolate, path).get();
-    if ((*out)->image().IsEmpty()) {
-#if defined(OS_WIN)
-      const auto img_path = base::UTF16ToUTF8(path.value());
-#else
-      const auto img_path = path.value();
-#endif
-      isolate->ThrowException(v8::Exception::Error(
-          StringToV8(isolate, "Image could not be created from " + img_path)));
-      return false;
-    }
-
-    return true;
-  }
-
   // reinterpret_cast is safe here because NativeImage is the only subclass of
   // gin::Wrappable<NativeImage>.
   *out = static_cast<electron::api::NativeImage*>(

--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -17,6 +17,7 @@
 #include "gin/arguments.h"
 #include "gin/object_template_builder.h"
 #include "gin/per_isolate_data.h"
+#include "gin/wrappable.h"
 #include "net/base/data_url.h"
 #include "shell/common/asar/asar_util.h"
 #include "shell/common/gin_converters/file_path_converter.h"
@@ -135,14 +136,12 @@ NativeImage::~NativeImage() {
 }
 
 // static
-bool NativeImage::TryConvertNativeImage(
-    v8::Isolate* isolate,
-    v8::Local<v8::Value> image,
-    gin::Handle<NativeImage>* native_image) {
+bool NativeImage::TryConvertNativeImage(v8::Isolate* isolate,
+                                        v8::Local<v8::Value> image,
+                                        NativeImage** native_image) {
   base::FilePath icon_path;
   if (gin::ConvertFromV8(isolate, image, &icon_path)) {
-    *native_image =
-        electron::api::NativeImage::CreateFromPath(isolate, icon_path);
+    *native_image = NativeImage::CreateFromPath(isolate, icon_path).get();
     if ((*native_image)->image().IsEmpty()) {
 #if defined(OS_WIN)
       const auto img_path = base::UTF16ToUTF8(icon_path.value());
@@ -599,32 +598,6 @@ gin::WrapperInfo NativeImage::kWrapperInfo = {gin::kEmbedderNativeGin};
 }  // namespace api
 
 }  // namespace electron
-
-namespace gin {
-
-v8::Local<v8::Value> Converter<electron::api::NativeImage*>::ToV8(
-    v8::Isolate* isolate,
-    electron::api::NativeImage* val) {
-  v8::Local<v8::Object> ret;
-  if (val && val->GetWrapper(isolate).ToLocal(&ret))
-    return ret;
-  else
-    return v8::Null(isolate);
-}
-
-bool Converter<electron::api::NativeImage*>::FromV8(
-    v8::Isolate* isolate,
-    v8::Local<v8::Value> val,
-    electron::api::NativeImage** out) {
-  // reinterpret_cast is safe here because NativeImage is the only subclass of
-  // gin::Wrappable<NativeImage>.
-  *out = static_cast<electron::api::NativeImage*>(
-      static_cast<gin::WrappableBase*>(gin::internal::FromV8Impl(
-          isolate, val, &electron::api::NativeImage::kWrapperInfo)));
-  return *out != nullptr;
-}
-
-}  // namespace gin
 
 namespace {
 

--- a/shell/common/api/electron_api_native_image.h
+++ b/shell/common/api/electron_api_native_image.h
@@ -77,6 +77,10 @@ class NativeImage : public gin::Wrappable<NativeImage> {
 
   static v8::Local<v8::FunctionTemplate> GetConstructor(v8::Isolate* isolate);
 
+  static bool TryConvertNativeImage(v8::Isolate* isolate,
+                                    v8::Local<v8::Value> image,
+                                    gin::Handle<NativeImage>* native_image);
+
   // gin::Wrappable
   static gin::WrapperInfo kWrapperInfo;
   gin::ObjectTemplateBuilder GetObjectTemplateBuilder(

--- a/shell/common/api/electron_api_native_image.h
+++ b/shell/common/api/electron_api_native_image.h
@@ -79,7 +79,7 @@ class NativeImage : public gin::Wrappable<NativeImage> {
 
   static bool TryConvertNativeImage(v8::Isolate* isolate,
                                     v8::Local<v8::Value> image,
-                                    gin::Handle<NativeImage>* native_image);
+                                    NativeImage** native_image);
 
   // gin::Wrappable
   static gin::WrapperInfo kWrapperInfo;
@@ -136,19 +136,5 @@ class NativeImage : public gin::Wrappable<NativeImage> {
 }  // namespace api
 
 }  // namespace electron
-
-namespace gin {
-
-// A custom converter that allows converting path to NativeImage.
-template <>
-struct Converter<electron::api::NativeImage*> {
-  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
-                                   electron::api::NativeImage* val);
-  static bool FromV8(v8::Isolate* isolate,
-                     v8::Local<v8::Value> val,
-                     electron::api::NativeImage** out);
-};
-
-}  // namespace gin
 
 #endif  // SHELL_COMMON_API_ELECTRON_API_NATIVE_IMAGE_H_

--- a/shell/common/gin_converters/image_converter.cc
+++ b/shell/common/gin_converters/image_converter.cc
@@ -27,9 +27,19 @@ bool Converter<gfx::Image>::FromV8(v8::Isolate* isolate,
   if (val->IsNull())
     return true;
 
+  // First see if the user has passed a path.
   gin::Handle<electron::api::NativeImage> native_image;
-  if (!gin::ConvertFromV8(isolate, val, &native_image))
-    return false;
+  base::FilePath icon_path;
+  if (gin::ConvertFromV8(isolate, val, &icon_path)) {
+    native_image =
+        electron::api::NativeImage::CreateFromPath(isolate, icon_path);
+    if (native_image->image().IsEmpty())
+      return false;
+  } else {
+    // Try a normal nativeImage if that fails.
+    if (!gin::ConvertFromV8(isolate, val, &native_image))
+      return false;
+  }
 
   *out = native_image->image();
   return true;

--- a/shell/common/gin_converters/image_converter.cc
+++ b/shell/common/gin_converters/image_converter.cc
@@ -28,11 +28,11 @@ bool Converter<gfx::Image>::FromV8(v8::Isolate* isolate,
     return true;
 
   // First see if the user has passed a path.
-  gin::Handle<electron::api::NativeImage> native_image;
+  electron::api::NativeImage* native_image = nullptr;
   base::FilePath icon_path;
   if (gin::ConvertFromV8(isolate, val, &icon_path)) {
     native_image =
-        electron::api::NativeImage::CreateFromPath(isolate, icon_path);
+        electron::api::NativeImage::CreateFromPath(isolate, icon_path).get();
     if (native_image->image().IsEmpty())
       return false;
   } else {

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -1541,6 +1541,15 @@ describe('app module', () => {
       });
     });
 
+    describe('dock.setIcon', () => {
+      it('throws a descriptive error for a bad icon path', () => {
+        const badPath = path.resolve('I', 'Do', 'Not', 'Exist');
+        expect(() => {
+          app.dock.setIcon(badPath);
+        }).to.throw(/Failed to load image from path (.+)/);
+      });
+    });
+
     describe('dock.bounce', () => {
       it('should return -1 for unknown bounce type', () => {
         expect(app.dock.bounce('bad type' as any)).to.equal(-1);

--- a/spec-main/api-tray-spec.ts
+++ b/spec-main/api-tray-spec.ts
@@ -19,7 +19,7 @@ describe('tray module', () => {
       const badPath = path.resolve('I', 'Do', 'Not', 'Exist');
       expect(() => {
         tray = new Tray(badPath);
-      }).to.throw(/Failed to convert path to nativeImage/);
+      }).to.throw(/Failed to load image from path (.+)/);
     });
 
     ifit(process.platform === 'win32')('throws a descriptive error if an invalid guid is given', () => {
@@ -136,7 +136,7 @@ describe('tray module', () => {
       const badPath = path.resolve('I', 'Do', 'Not', 'Exist');
       expect(() => {
         tray.setImage(badPath);
-      }).to.throw(/Failed to convert path to nativeImage/);
+      }).to.throw(/Failed to load image from path (.+)/);
     });
 
     it('accepts empty image', () => {
@@ -149,7 +149,7 @@ describe('tray module', () => {
       const badPath = path.resolve('I', 'Do', 'Not', 'Exist');
       expect(() => {
         tray.setPressedImage(badPath);
-      }).to.throw(/Failed to convert path to nativeImage/);
+      }).to.throw(/Failed to load image from path (.+)/);
     });
 
     it('accepts empty image', () => {
@@ -166,7 +166,7 @@ describe('tray module', () => {
           content: 'wow content',
           icon: badPath
         });
-      }).to.throw(/Failed to convert path to nativeImage/);
+      }).to.throw(/Failed to load image from path (.+)/);
     });
 
     it('accepts an empty image', () => {

--- a/spec-main/api-tray-spec.ts
+++ b/spec-main/api-tray-spec.ts
@@ -19,10 +19,10 @@ describe('tray module', () => {
       const badPath = path.resolve('I', 'Do', 'Not', 'Exist');
       expect(() => {
         tray = new Tray(badPath);
-      }).to.throw(/Error processing argument at index 0/);
+      }).to.throw(/Failed to convert path to nativeImage/);
     });
 
-    ifit(process.platform === 'win32')('throws a descriptive error if an invlaid guid is given', () => {
+    ifit(process.platform === 'win32')('throws a descriptive error if an invalid guid is given', () => {
       expect(() => {
         tray = new Tray(nativeImage.createEmpty(), 'I am not a guid');
       }).to.throw('Invalid GUID format');
@@ -132,14 +132,49 @@ describe('tray module', () => {
   });
 
   describe('tray.setImage(image)', () => {
+    it('throws a descriptive error for a missing file', () => {
+      const badPath = path.resolve('I', 'Do', 'Not', 'Exist');
+      expect(() => {
+        tray.setImage(badPath);
+      }).to.throw(/Failed to convert path to nativeImage/);
+    });
+
     it('accepts empty image', () => {
       tray.setImage(nativeImage.createEmpty());
     });
   });
 
   describe('tray.setPressedImage(image)', () => {
+    it('throws a descriptive error for a missing file', () => {
+      const badPath = path.resolve('I', 'Do', 'Not', 'Exist');
+      expect(() => {
+        tray.setPressedImage(badPath);
+      }).to.throw(/Failed to convert path to nativeImage/);
+    });
+
     it('accepts empty image', () => {
       tray.setPressedImage(nativeImage.createEmpty());
+    });
+  });
+
+  ifdescribe(process.platform === 'win32')('tray.displayBalloon(image)', () => {
+    it('throws a descriptive error for a missing file', () => {
+      const badPath = path.resolve('I', 'Do', 'Not', 'Exist');
+      expect(() => {
+        tray.displayBalloon({
+          title: 'title',
+          content: 'wow content',
+          icon: badPath
+        });
+      }).to.throw(/Failed to convert path to nativeImage/);
+    });
+
+    it('accepts an empty image', () => {
+      tray.displayBalloon({
+        title: 'title',
+        content: 'wow content',
+        icon: nativeImage.createEmpty()
+      });
     });
   });
 

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -764,11 +764,11 @@ describe('webContents module', () => {
 
       expect(() => {
         w.webContents.startDrag({ file: __filename } as any);
-      }).to.throw('Must specify non-empty \'icon\' option');
+      }).to.throw('\'icon\' parameter is required');
 
       expect(() => {
         w.webContents.startDrag({ file: __filename, icon: path.join(mainFixturesPath, 'blank.png') });
-      }).to.throw('Must specify non-empty \'icon\' option');
+      }).to.throw(/Failed to load image from path (.+)/);
     });
   });
 


### PR DESCRIPTION
#### Description of Change

This refactor pulls the `base::FilePath` converter option out of the `NativeImage` converter.  Our converter contract is that converters return false when they fail -  they shouldn't touch the exception state.

Placed which previously leveraged the `NativeImage` converter to allow either a path or an image object are now changed to take `v8::Local<v8::Value>`s in their arguments instead of `gin::Handle<NativeImage>`, and detect the type passed and invoke the appropriate method for acquiring the image depending on whether the user passed a bespoke `NativeImage` or a string.

This also allows for better error handling by allowing the callers to decide whether to throw errors into JavaScript.

cc @nornagon @jkleinsc @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
