### PR TITLE
chore: tidy up markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ _If an issue has been closed and you still feel it's relevant, feel free to ping
 ### Languages
 
 We accept issues in *any* language.
-When an issue is posted in a language besides English, it is acceptable and encouraged to post an English-translated copy as a reply. 
+When an issue is posted in a language besides English, it is acceptable and encouraged to post an English-translated copy as a reply.
 Anyone may post the translated reply.
 In most cases, a quick pass through translation software is sufficient.
 Having the original text _as well as_ the translation can help mitigate translation errors.
@@ -66,5 +66,5 @@ See [Coding Style](https://electronjs.org/docs/development/coding-style) for inf
 
 ## Further Reading
 
-For more in-depth guides on developing Electron, see 
+For more in-depth guides on developing Electron, see
 [/docs/development](/docs/development/README.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Electron Logo](https://electronjs.org/images/electron-logo.svg)](https://electronjs.org)
 
-
 [![CircleCI Build Status](https://circleci.com/gh/electron/electron/tree/master.svg?style=shield)](https://circleci.com/gh/electron/electron/tree/master)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/4lggi9dpjc1qob7k/branch/master?svg=true)](https://ci.appveyor.com/project/electron-bot/electron-ljo26/branch/master)
 [![devDependency Status](https://david-dm.org/electron/electron/dev-status.svg)](https://david-dm.org/electron/electron?type=dev)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,4 +13,5 @@ Report security bugs in third-party modules to the person or team maintaining th
 For context on Electron's security notification process, please see the [Notifications](https://github.com/electron/governance/blob/master/wg-security/membership-and-notifications.md#notifications) section of the Security WG's [Membership and Notifications](https://github.com/electron/governance/blob/master/wg-security/membership-and-notifications.md) Governance document.
 
 ## Learning More About Security
+
 To learn more about securing an Electron application, please see the [security tutorial](docs/tutorial/security.md).

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1463,7 +1463,7 @@ By default, an empty `options` will be regarded as:
 }
 ```
 
-Use `page-break-before: always; ` CSS style to force to print to a new page.
+Use `page-break-before: always;` CSS style to force to print to a new page.
 
 An example of `webContents.printToPDF`:
 

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -104,6 +104,7 @@ shell.trashItem(path).then(/* ... */)
 ## Planned Breaking API Changes (11.0)
 
 ### Removed: `BrowserView.{destroy, fromId, fromWebContents, getAllViews}` and `id` property of `BrowserView`
+
 The experimental APIs `BrowserView.{destroy, fromId, fromWebContents, getAllViews}`
 have now been removed. Additionally, the `id` property of `BrowserView`
 has also been removed.
@@ -190,6 +191,7 @@ We [recommend moving away from the remote
 module](https://medium.com/@nornagon/electrons-remote-module-considered-harmful-70d69500f31).
 
 ### `protocol.unregisterProtocol`
+
 ### `protocol.uninterceptProtocol`
 
 The APIs are now synchronous and the optional callback is no longer needed.
@@ -202,14 +204,23 @@ protocol.unregisterProtocol(scheme)
 ```
 
 ### `protocol.registerFileProtocol`
+
 ### `protocol.registerBufferProtocol`
+
 ### `protocol.registerStringProtocol`
+
 ### `protocol.registerHttpProtocol`
+
 ### `protocol.registerStreamProtocol`
+
 ### `protocol.interceptFileProtocol`
+
 ### `protocol.interceptStringProtocol`
+
 ### `protocol.interceptBufferProtocol`
+
 ### `protocol.interceptHttpProtocol`
+
 ### `protocol.interceptStreamProtocol`
 
 The APIs are now synchronous and the optional callback is no longer needed.

--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -189,7 +189,6 @@ Not all combinations of source and target CPU/OS are supported by Chromium.
 | Windows x64 | Windows x86   | Automatically tested |
 | Linux x64   | Linux x86     | Automatically tested |
 
-
 If you test other combinations and find them to work, please update this document :)
 
 See the GN reference for allowable values of [`target_os`][target_os values]

--- a/docs/tutorial/debugging-vscode.md
+++ b/docs/tutorial/debugging-vscode.md
@@ -35,7 +35,6 @@ $ code electron-quick-start
 }
 ```
 
-
 #### 3. Debugging
 
 Set some breakpoints in `main.js`, and start debugging in the [Debug View](https://code.visualstudio.com/docs/editor/debugging). You should be able to hit the breakpoints.
@@ -84,16 +83,16 @@ $ code electron-quick-start
   ]
 }
 ```
+
 **Configuration Notes**
 
-- `cppvsdbg` requires the [built-in C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) be enabled.
-- `${workspaceFolder}` is the full path to Chromium's `src` directory.
-- `your-executable-location` will be one of the following depending on a few items:
-  -  `Testing`: If you are using the default settings of [Electron's Build-Tools](https://github.com/electron/build-tools) or the default instructions when [building from source](https://www.electronjs.org/docs/development/build-instructions-gn#building).
-  -  `Release`: If you built a Release build rather than a Testing build.
-  -  `your-directory-name`: If you modified this during your build process from the default, this will be whatever you specified.
-- The `args` array string `"your-electron-project-path"` should be the absolute path to either the directory or `main.js` file of the Electron project you are using for testing. In this example, it should be your path to `electron-quick-start`.
-
+* `cppvsdbg` requires the [built-in C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) be enabled.
+* `${workspaceFolder}` is the full path to Chromium's `src` directory.
+* `your-executable-location` will be one of the following depending on a few items:
+  * `Testing`: If you are using the default settings of [Electron's Build-Tools](https://github.com/electron/build-tools) or the default instructions when [building from source](https://www.electronjs.org/docs/development/build-instructions-gn#building).
+  * `Release`: If you built a Release build rather than a Testing build.
+  * `your-directory-name`: If you modified this during your build process from the default, this will be whatever you specified.
+* The `args` array string `"your-electron-project-path"` should be the absolute path to either the directory or `main.js` file of the Electron project you are using for testing. In this example, it should be your path to `electron-quick-start`.
 
 #### 3. Debugging
 


### PR DESCRIPTION
#### Description of Change

General tidying up. Getting close to having a clean run of `markdownlint` with a few rules turned off, these changes move it a little bit closer.

#### Checklist

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none