### PR TITLE
revert: disable rosetta as Electron does not run under rosetta

### DIFF
--- a/shell/app/resources/mac/loginhelper-Info.plist
+++ b/shell/app/resources/mac/loginhelper-Info.plist
@@ -12,7 +12,5 @@
 	<string>APPL</string>
 	<key>LSBackgroundOnly</key>
 	<true/>
-	<key>LSRequiresNativeExecution</key>
-	<true/>
 </dict>
 </plist>

--- a/shell/browser/resources/mac/Info.plist
+++ b/shell/browser/resources/mac/Info.plist
@@ -40,7 +40,5 @@
     <string>This app needs access to the microphone</string>
     <key>NSCameraUsageDescription</key>
     <string>This app needs access to the camera</string>
-    <key>LSRequiresNativeExecution</key>
-    <true/>
   </dict>
 </plist>

--- a/shell/common/resources/mac/Info.plist
+++ b/shell/common/resources/mac/Info.plist
@@ -14,7 +14,5 @@
 	<true/>
 	<key>CFBundleVersion</key>
 	<string>${ELECTRON_VERSION}</string>
-	<key>LSRequiresNativeExecution</key>
-	<true/>
 </dict>
 </plist>

--- a/shell/renderer/resources/mac/Info.plist
+++ b/shell/renderer/resources/mac/Info.plist
@@ -12,7 +12,5 @@
   <true/>
   <key>NSSupportsAutomaticGraphicsSwitching</key>
   <true/>
-  <key>LSRequiresNativeExecution</key>
-  <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Reverts electron/electron#24670

Notes: re-enable Rosetta on Apple Silicon devices