### PR TITLE
docs: fix relative link

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -155,7 +155,7 @@ Returns:
   be set. If no post data is to be sent, the value will be `null`. Only defined
   when the window is being created by a form that set `target=_blank`.
 
-Deprecated in favor of [`webContents.setWindowOpenHandler`](web-contents.md#contentssetwindowopenhandler-handler).
+Deprecated in favor of [`webContents.setWindowOpenHandler`](web-contents.md#contentssetwindowopenhandlerhandler).
 
 Emitted when the page requests to open a new window for a `url`. It could be
 requested by `window.open` or an external link like `<a target='_blank'>`.
@@ -203,7 +203,7 @@ Returns:
       BrowserWindow. They are merged in increasing precedence: options inherited
       from the parent, parsed options from the `features` string from
       `window.open()`, and options given by
-      [`webContents.setWindowOpenHandler`](web-contents.md#contentssetwindowopenhandler-handler).
+      [`webContents.setWindowOpenHandler`](web-contents.md#contentssetwindowopenhandlerhandler).
       Unrecognized options are not filtered out.
     * `additionalFeatures` String[] - The non-standard features (features not
       handled Chromium or Electron) _Deprecated_
@@ -220,7 +220,7 @@ Returns:
 
 Emitted _after_ successful creation of a window via `window.open` in the renderer.
 Not emitted if the creation of the window is canceled from
-[`webContents.setWindowOpenHandler`](web-contents.md#contentssetwindowopenhandler-handler).
+[`webContents.setWindowOpenHandler`](web-contents.md#contentssetwindowopenhandlerhandler).
 
 See [`window.open()`](window-open.md) for more details and how to use this in conjunction with `webContents.setWindowOpenHandler`.
 

--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -26,7 +26,7 @@ BrowserWindow constructor options are set by, in increasing precedence
 order: options inherited from the parent, parsed options
 from the `features` string from `window.open()`, security-related webPreferences
 inherited from the parent, and options given by
-[`webContents.setWindowOpenHandler`](web-contents.md#contentssetwindowopenhandler-handler).
+[`webContents.setWindowOpenHandler`](web-contents.md#contentssetwindowopenhandlerhandler).
 Note that `webContents.setWindowOpenHandler` has final say and full privilege
 because it is invoked in the main process.
 

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -818,7 +818,7 @@ which potential security issues are not as widely known.
 [browser-view]: ../api/browser-view.md
 [webview-tag]: ../api/webview-tag.md
 [web-contents]: ../api/web-contents.md
-[window-open-handler]: ../api/web-contents.md#contentssetwindowopenhandler-handler
+[window-open-handler]: ../api/web-contents.md#contentssetwindowopenhandlerhandler
 [will-navigate]: ../api/web-contents.md#event-will-navigate
 [open-external]: ../api/shell.md#shellopenexternalurl-options
 [sandbox]: ../api/sandbox-option.md


### PR DESCRIPTION
#### Description of Change

Looks like this snuck in before #26359 landed, and since #26359 was older than this change, the lint check was green but out-of-date, letting it be merged, but then causing lint to go red on master.

#### Checklist

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none