### PR TITLE
fix: add check in IsMaximized for non-WS_THICKFRAME windows

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -632,8 +632,6 @@ void NativeWindowViews::SetBounds(const gfx::Rect& bounds, bool animate) {
   }
 #endif
 
-  LOG(INFO) << " NativeWindowViews::SetBounds - bounds: " << bounds.ToString()
-            << " " << __LINE__;
   widget()->SetBounds(bounds);
 }
 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -530,6 +530,20 @@ void NativeWindowViews::Unmaximize() {
 }
 
 bool NativeWindowViews::IsMaximized() {
+  // For window without WS_THICKFRAME style, we can not call IsMaximized().
+  // This path will be used for transparent windows as well.
+
+#if defined(OS_WIN)
+  gfx::Rect current_bounds = GetBounds();
+  if (!(::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE) & WS_THICKFRAME)) {
+    // Compare the size of the window with the size of the display
+    auto display =
+        display::Screen::GetScreen()->GetDisplayNearestPoint(GetPosition());
+    return ((display.work_area().width() == current_bounds.width()) &&
+            (display.work_area().height() == current_bounds.height()))
+  }
+#endif
+
   return widget()->IsMaximized();
 }
 
@@ -618,6 +632,8 @@ void NativeWindowViews::SetBounds(const gfx::Rect& bounds, bool animate) {
   }
 #endif
 
+  LOG(INFO) << " NativeWindowViews::SetBounds - bounds: " << bounds.ToString()
+            << " " << __LINE__;
   widget()->SetBounds(bounds);
 }
 

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -149,9 +149,7 @@ std::set<NativeWindowViews*> NativeWindowViews::forwarding_windows_;
 HHOOK NativeWindowViews::mouse_hook_ = NULL;
 
 void NativeWindowViews::Maximize() {
-  // Only use Maximize() when:
-  // 1. window has WS_THICKFRAME style;
-  // 2. and window is not frameless when there is autohide taskbar.
+  // Only use Maximize() when window has WS_THICKFRAME style
   if (::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE) & WS_THICKFRAME) {
     if (IsVisible())
       widget()->Maximize();
@@ -161,6 +159,8 @@ void NativeWindowViews::Maximize() {
     return;
   } else {
     restore_bounds_ = GetBounds();
+    LOG(INFO) << "NativeWindowViews::Maximize - restore_bounds_: "
+              << restore_bounds_.ToString() << " " << __LINE__;
     auto display =
         display::Screen::GetScreen()->GetDisplayNearestPoint(GetPosition());
     SetBounds(display.work_area(), false);

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -159,8 +159,6 @@ void NativeWindowViews::Maximize() {
     return;
   } else {
     restore_bounds_ = GetBounds();
-    LOG(INFO) << "NativeWindowViews::Maximize - restore_bounds_: "
-              << restore_bounds_.ToString() << " " << __LINE__;
     auto display =
         display::Screen::GetScreen()->GetDisplayNearestPoint(GetPosition());
     SetBounds(display.work_area(), false);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/25348

This PR allows for windows without the WS_THICKFRAME style to be properly checked when determining if they are maximized. Transparent windows fall under this category. Since windows without the WS_THICKFRAME style cannot be put in a maximized state, we simulate it by increasing the window to the size of the display. Previously, when a window without the WS_THICKFRAME style was "maximized" in this way, the IsMaximized check did not account for this workaround. Now IsMaximized checks for both cases involving WS_THICKFRAME. 
(An additional criteria commented for maximization was also removed, since the implementation was removed at some point before this PR). 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: None
