### PR TITLE
fix: reject contentTracing.stopRecording on failure

### DIFF
--- a/shell/browser/api/electron_api_content_tracing.cc
+++ b/shell/browser/api/electron_api_content_tracing.cc
@@ -71,7 +71,10 @@ void StopTracing(gin_helper::Promise<base::FilePath> promise,
         *file_path, base::AdaptCallbackForRepeating(base::BindOnce(
                         &gin_helper::Promise<base::FilePath>::ResolvePromise,
                         std::move(promise), *file_path)));
-    TracingController::GetInstance()->StopTracing(endpoint);
+    if (!TracingController::GetInstance()->StopTracing(endpoint)) {
+      promise.RejectWithErrorMessage(
+          "Failed to stop tracing (was a trace in progress?)");
+    }
   } else {
     promise.RejectWithErrorMessage(
         "Failed to create temporary file for trace data");

--- a/shell/browser/api/electron_api_content_tracing.cc
+++ b/shell/browser/api/electron_api_content_tracing.cc
@@ -66,18 +66,26 @@ base::Optional<base::FilePath> CreateTemporaryFileOnIO() {
 
 void StopTracing(gin_helper::Promise<base::FilePath> promise,
                  base::Optional<base::FilePath> file_path) {
+  auto resolve_or_reject = base::AdaptCallbackForRepeating(base::BindOnce(
+      [](gin_helper::Promise<base::FilePath> promise,
+         const base::FilePath& path, base::Optional<std::string> error) {
+        if (error) {
+          promise.RejectWithErrorMessage(error.value());
+        } else {
+          promise.Resolve(path);
+        }
+      },
+      std::move(promise), *file_path));
   if (file_path) {
     auto endpoint = TracingController::CreateFileEndpoint(
-        *file_path, base::AdaptCallbackForRepeating(base::BindOnce(
-                        &gin_helper::Promise<base::FilePath>::ResolvePromise,
-                        std::move(promise), *file_path)));
+        *file_path, base::BindRepeating(resolve_or_reject, base::nullopt));
     if (!TracingController::GetInstance()->StopTracing(endpoint)) {
-      promise.RejectWithErrorMessage(
-          "Failed to stop tracing (was a trace in progress?)");
+      resolve_or_reject.Run(base::make_optional(
+          "Failed to stop tracing (was a trace in progress?)"));
     }
   } else {
-    promise.RejectWithErrorMessage(
-        "Failed to create temporary file for trace data");
+    resolve_or_reject.Run(
+        base::make_optional("Failed to create temporary file for trace data"));
   }
 }
 

--- a/spec-main/api-content-tracing-spec.ts
+++ b/spec-main/api-content-tracing-spec.ts
@@ -119,6 +119,10 @@ ifdescribe(!(process.platform !== 'win32' && ['arm', 'arm64'].includes(process.a
       const resultFilePath = await record(/* options */ {}, /* outputFilePath */ undefined);
       expect(resultFilePath).to.be.a('string').that.is.not.empty('result path');
     });
+
+    it('rejects if no trace is happening', async () => {
+      await expect(contentTracing.stopRecording()).to.be.rejected();
+    });
   });
 
   describe('captured events', () => {


### PR DESCRIPTION
#### Description of Change
Fixes #26607. I'm not sure this catches _all_ situations in which the
FileEndpoint's callback isn't called, but it catches a major one!

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed `contentTracing.stopRecording()` not rejecting when there is no trace in progress.
