### PR TITLE
fix: make screen wrapper remote-friendly again

### DIFF
--- a/lib/browser/api/screen.ts
+++ b/lib/browser/api/screen.ts
@@ -16,5 +16,23 @@ export default new Proxy({}, {
       return v.bind(_screen);
     }
     return v;
+  },
+  ownKeys: () => {
+    if (_screen === undefined) {
+      _screen = createScreen();
+    }
+    return Reflect.ownKeys(_screen);
+  },
+  has: (target, prop: string) => {
+    if (_screen === undefined) {
+      _screen = createScreen();
+    }
+    return prop in _screen;
+  },
+  getOwnPropertyDescriptor: (target, prop: string) => {
+    if (_screen === undefined) {
+      _screen = createScreen();
+    }
+    return Reflect.getOwnPropertyDescriptor(_screen, prop);
   }
 });


### PR DESCRIPTION
#### Description of Change

This restores accessibility of `screen` methods via `remote.screen`.

Fixes #26610.

Cc @nornagon.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed `screen` methods not being accessible via `remote.screen`.
