### PR TITLE
docs:  notification documentation fix

### DIFF
--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -26,10 +26,10 @@ The `Notification` class has the following static methods:
 
 Returns `Boolean` - Whether or not desktop notifications are supported on the current system
 
-### `new Notification([options])`
+### `new Notification(title, [options])`
 
+* `title` String (optional) - A title for the notification, which will be shown at the top of the notification window when it is shown.
 * `options` Object (optional)
-  * `title` String (optional) - A title for the notification, which will be shown at the top of the notification window when it is shown.
   * `subtitle` String (optional) _macOS_ - A subtitle for the notification, which will be displayed below the title.
   * `body` String (optional) - The body text of the notification, which will be displayed below the title or subtitle.
   * `silent` Boolean (optional) - Whether or not to emit an OS notification noise when showing the notification.

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -28,7 +28,7 @@ Returns `Boolean` - Whether or not desktop notifications are supported on the cu
 
 ### `new Notification(title, [options])`
 
-* `title` String (optional) - A title for the notification, which will be shown at the top of the notification window when it is shown.
+* `title` String - A title for the notification, which will be shown at the top of the notification window when it is shown.
 * `options` Object (optional)
   * `subtitle` String (optional) _macOS_ - A subtitle for the notification, which will be displayed below the title.
   * `body` String (optional) - The body text of the notification, which will be displayed below the title or subtitle.


### PR DESCRIPTION
#### Description of Change
The new Notification parameters were saying that the title parameter is optional ans is supposed to be in the optional object containing every other parameter when in truth, the observed behavior is that the title is a mandatory first argument.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] relevant documentation is changed or added
