### PR TITLE
chore: include alt text for images in markdown

### DIFF
--- a/docs/tutorial/electron-versioning.md
+++ b/docs/tutorial/electron-versioning.md
@@ -114,7 +114,7 @@ An example lifecycle in pictures:
 
 A few examples of how various semver ranges will pick up new releases:
 
-![Semvars and Releases](../images/versioning-sketch-7.png)
+![Semvers and Releases](../images/versioning-sketch-7.png)
 
 # Missing Features: Alphas
 

--- a/docs/tutorial/electron-versioning.md
+++ b/docs/tutorial/electron-versioning.md
@@ -20,7 +20,7 @@ Electron versions *< 2.0* did not conform to the [semver](https://semver.org) sp
 
 Here is an example of the 1.x strategy:
 
-![](../images/versioning-sketch-0.png)
+![1.x Versioning](../images/versioning-sketch-0.png)
 
 An app developed with `1.8.1` cannot take the `1.8.3` bug fix without either absorbing the `1.8.2` feature, or by backporting the fix and maintaining a new release line.
 
@@ -54,12 +54,12 @@ Note that most Chromium updates will be considered breaking. Fixes that can be b
 
 Stabilization branches are branches that run parallel to master, taking in only cherry-picked commits that are related to security or stability. These branches are never merged back to master.
 
-![](../images/versioning-sketch-1.png)
+![Stabilization Branches](../images/versioning-sketch-1.png)
 
 Since Electron 8, stabilization branches are always **major** version lines, and named against the following template `$MAJOR-x-y` e.g. `8-x-y`.  Prior to that we used **minor** version lines and named them as `$MAJOR-$MINOR-x` e.g. `2-0-x`
 
 We allow for multiple stabilization branches to exist simultaneously, and intend to support at least two in parallel at all times, backporting security fixes as necessary.
-![](../images/versioning-sketch-2.png)
+![Multiple Stability Branches](../images/versioning-sketch-2.png)
 
 Older lines will not be supported by GitHub, but other groups can take ownership and backport stability and security fixes on their own. We discourage this, but recognize that it makes life easier for many app developers.
 
@@ -104,17 +104,17 @@ For each major and minor bump, you should expect to see something like the follo
 An example lifecycle in pictures:
 
 * A new release branch is created that includes the latest set of features. It is published as `2.0.0-beta.1`.
-![](../images/versioning-sketch-3.png)
+![New Release Branch](../images/versioning-sketch-3.png)
 * A bug fix comes into master that can be backported to the release branch. The patch is applied, and a new beta is published as `2.0.0-beta.2`.
-![](../images/versioning-sketch-4.png)
+![Bugfix Backport to Beta](../images/versioning-sketch-4.png)
 * The beta is considered _generally stable_ and it is published again as a non-beta under `2.0.0`.
-![](../images/versioning-sketch-5.png)
+![Beta to Stable](../images/versioning-sketch-5.png)
 * Later, a zero-day exploit is revealed and a fix is applied to master. We backport the fix to the `2-0-x` line and release `2.0.1`.
-![](../images/versioning-sketch-6.png)
+![Security Backports](../images/versioning-sketch-6.png)
 
 A few examples of how various semver ranges will pick up new releases:
 
-![](../images/versioning-sketch-7.png)
+![Semvars and Releases](../images/versioning-sketch-7.png)
 
 # Missing Features: Alphas
 


### PR DESCRIPTION
#### Description of Change

Good practice to include alt text for images. Not having them gets you dinged in Lighthouse accessibility audits.

#### Checklist

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none