### PR TITLE
feat: allow passing URL filter to intercept protocol functions

### DIFF
--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -247,12 +247,12 @@ Unregisters the custom protocol of `scheme`.
 
 Returns `Boolean` - Whether `scheme` is already registered.
 
-### `protocol.interceptFileProtocol(scheme[, filter], handler)`
+### `protocol.interceptFileProtocol(scheme[, options], handler)`
 
 * `scheme` String
-* `filter` Object (optional)
-  * `urls` String[] - Array of URL patterns that will be used to filter out the
-        requests that do not match the URL patterns.
+* `options` Object (optional)
+  * `urls` String[] (optional) - Array of URL patterns that will be used to
+        filter out the requests that do not match the URL patterns.
 * `handler` Function
   * `request` [ProtocolRequest](structures/protocol-request.md)
   * `callback` Function
@@ -263,12 +263,12 @@ Returns `Boolean` - Whether the protocol was successfully intercepted
 Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
 which sends a file as a response.
 
-### `protocol.interceptStringProtocol(scheme[, filter], handler)`
+### `protocol.interceptStringProtocol(scheme[, options], handler)`
 
 * `scheme` String
-* `filter` Object (optional)
-  * `urls` String[] - Array of URL patterns that will be used to filter out the
-        requests that do not match the URL patterns.
+* `options` Object (optional)
+  * `urls` String[] (optional) - Array of URL patterns that will be used to
+        filter out the requests that do not match the URL patterns.
 * `handler` Function
   * `request` [ProtocolRequest](structures/protocol-request.md)
   * `callback` Function
@@ -279,12 +279,12 @@ Returns `Boolean` - Whether the protocol was successfully intercepted
 Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
 which sends a `String` as a response.
 
-### `protocol.interceptBufferProtocol(scheme[, filter], handler)`
+### `protocol.interceptBufferProtocol(scheme[, options], handler)`
 
 * `scheme` String
-* `filter` Object (optional)
-  * `urls` String[] - Array of URL patterns that will be used to filter out the
-        requests that do not match the URL patterns.
+* `options` Object (optional)
+  * `urls` String[] (optional) - Array of URL patterns that will be used to
+        filter out the requests that do not match the URL patterns.
 * `handler` Function
   * `request` [ProtocolRequest](structures/protocol-request.md)
   * `callback` Function
@@ -295,12 +295,12 @@ Returns `Boolean` - Whether the protocol was successfully intercepted
 Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
 which sends a `Buffer` as a response.
 
-### `protocol.interceptHttpProtocol(scheme[, filter], handler)`
+### `protocol.interceptHttpProtocol(scheme[, options], handler)`
 
 * `scheme` String
-* `filter` Object (optional)
-  * `urls` String[] - Array of URL patterns that will be used to filter out the
-        requests that do not match the URL patterns.
+* `options` Object (optional)
+  * `urls` String[] (optional) - Array of URL patterns that will be used to
+        filter out the requests that do not match the URL patterns.
 * `handler` Function
   * `request` [ProtocolRequest](structures/protocol-request.md)
   * `callback` Function
@@ -311,12 +311,12 @@ Returns `Boolean` - Whether the protocol was successfully intercepted
 Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
 which sends a new HTTP request as a response.
 
-### `protocol.interceptStreamProtocol(scheme[, filter], handler)`
+### `protocol.interceptStreamProtocol(scheme[, options], handler)`
 
 * `scheme` String
-* `filter` Object (optional)
-  * `urls` String[] - Array of URL patterns that will be used to filter out the
-        requests that do not match the URL patterns.
+* `options` Object (optional)
+  * `urls` String[] (optional) - Array of URL patterns that will be used to
+        filter out the requests that do not match the URL patterns.
 * `handler` Function
   * `request` [ProtocolRequest](structures/protocol-request.md)
   * `callback` Function

--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -247,9 +247,12 @@ Unregisters the custom protocol of `scheme`.
 
 Returns `Boolean` - Whether `scheme` is already registered.
 
-### `protocol.interceptFileProtocol(scheme, handler)`
+### `protocol.interceptFileProtocol(scheme[, filter], handler)`
 
 * `scheme` String
+* `filter` Object (optional)
+  * `urls` String[] - Array of URL patterns that will be used to filter out the
+        requests that do not match the URL patterns.
 * `handler` Function
   * `request` [ProtocolRequest](structures/protocol-request.md)
   * `callback` Function
@@ -260,9 +263,12 @@ Returns `Boolean` - Whether the protocol was successfully intercepted
 Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
 which sends a file as a response.
 
-### `protocol.interceptStringProtocol(scheme, handler)`
+### `protocol.interceptStringProtocol(scheme[, filter], handler)`
 
 * `scheme` String
+* `filter` Object (optional)
+  * `urls` String[] - Array of URL patterns that will be used to filter out the
+        requests that do not match the URL patterns.
 * `handler` Function
   * `request` [ProtocolRequest](structures/protocol-request.md)
   * `callback` Function
@@ -273,9 +279,12 @@ Returns `Boolean` - Whether the protocol was successfully intercepted
 Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
 which sends a `String` as a response.
 
-### `protocol.interceptBufferProtocol(scheme, handler)`
+### `protocol.interceptBufferProtocol(scheme[, filter], handler)`
 
 * `scheme` String
+* `filter` Object (optional)
+  * `urls` String[] - Array of URL patterns that will be used to filter out the
+        requests that do not match the URL patterns.
 * `handler` Function
   * `request` [ProtocolRequest](structures/protocol-request.md)
   * `callback` Function
@@ -286,9 +295,12 @@ Returns `Boolean` - Whether the protocol was successfully intercepted
 Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
 which sends a `Buffer` as a response.
 
-### `protocol.interceptHttpProtocol(scheme, handler)`
+### `protocol.interceptHttpProtocol(scheme[, filter], handler)`
 
 * `scheme` String
+* `filter` Object (optional)
+  * `urls` String[] - Array of URL patterns that will be used to filter out the
+        requests that do not match the URL patterns.
 * `handler` Function
   * `request` [ProtocolRequest](structures/protocol-request.md)
   * `callback` Function
@@ -299,9 +311,12 @@ Returns `Boolean` - Whether the protocol was successfully intercepted
 Intercepts `scheme` protocol and uses `handler` as the protocol's new handler
 which sends a new HTTP request as a response.
 
-### `protocol.interceptStreamProtocol(scheme, handler)`
+### `protocol.interceptStreamProtocol(scheme[, filter], handler)`
 
 * `scheme` String
+* `filter` Object (optional)
+  * `urls` String[] - Array of URL patterns that will be used to filter out the
+        requests that do not match the URL patterns.
 * `handler` Function
   * `request` [ProtocolRequest](structures/protocol-request.md)
   * `callback` Function

--- a/filenames.gni
+++ b/filenames.gni
@@ -472,6 +472,8 @@ filenames = {
     "shell/browser/ui/webui/accessibility_ui.h",
     "shell/browser/unresponsive_suppressor.cc",
     "shell/browser/unresponsive_suppressor.h",
+    "shell/browser/url_util.cc",
+    "shell/browser/url_util.h",
     "shell/browser/web_contents_permission_helper.cc",
     "shell/browser/web_contents_permission_helper.h",
     "shell/browser/web_contents_preferences.cc",

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -5,6 +5,7 @@
 #include "shell/browser/api/electron_api_protocol.h"
 
 #include <memory>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -201,8 +202,10 @@ bool Protocol::IsProtocolRegistered(const std::string& scheme) {
 
 ProtocolError Protocol::InterceptProtocol(ProtocolType type,
                                           const std::string& scheme,
-                                          const ProtocolHandler& handler) {
-  bool added = protocol_registry_->InterceptProtocol(type, scheme, handler);
+                                          const ProtocolHandler& handler,
+                                          std::set<URLPattern> url_patterns) {
+  bool added = protocol_registry_->InterceptProtocol(type, scheme, handler,
+                                                     url_patterns);
   return added ? ProtocolError::kOK : ProtocolError::kIntercepted;
 }
 

--- a/shell/browser/api/electron_api_protocol.h
+++ b/shell/browser/api/electron_api_protocol.h
@@ -91,14 +91,13 @@ class Protocol : public gin::Wrappable<Protocol> {
       args->ThrowTypeError("First argument must be the scheme");
       return false;
     }
-    gin::Dictionary dict(args->isolate());
-    auto has_filter = args->Length() == 3;
-    if (has_filter) {
+    gin::Dictionary options(args->isolate());
+    auto has_options = args->Length() == 3;
+    if (has_options) {
       v8::Local<v8::Value> arg;
-      // next argument should be an options object object
       if (!args->GetNext(&arg) || arg->IsFunction() ||
-          !gin::ConvertFromV8(args->isolate(), arg, &dict)) {
-        args->ThrowTypeError("Second argument must be option object");
+          !gin::ConvertFromV8(args->isolate(), arg, &options)) {
+        args->ThrowTypeError("Second argument must be an options object");
         return false;
       }
     }
@@ -109,7 +108,7 @@ class Protocol : public gin::Wrappable<Protocol> {
     }
     std::set<std::string> filter_patterns;
     std::set<URLPattern> url_patterns;
-    if (has_filter && dict.Get("urls", &filter_patterns)) {
+    if (has_options && options.Get("urls", &filter_patterns)) {
       std::string parse_error;
       url_patterns = ParseURLPatterns(filter_patterns, &parse_error);
       if (!parse_error.empty()) {

--- a/shell/browser/net/electron_url_loader_factory.h
+++ b/shell/browser/net/electron_url_loader_factory.h
@@ -6,10 +6,12 @@
 #define SHELL_BROWSER_NET_ELECTRON_URL_LOADER_FACTORY_H_
 
 #include <map>
+#include <set>
 #include <string>
 #include <utility>
 
 #include "content/public/browser/non_network_url_loader_factory_base.h"
+#include "extensions/common/url_pattern.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/receiver_set.h"
@@ -36,8 +38,9 @@ using ProtocolHandler =
     base::Callback<void(const network::ResourceRequest&, StartLoadingCallback)>;
 
 // scheme => (type, handler).
-using HandlersMap =
-    std::map<std::string, std::pair<ProtocolType, ProtocolHandler>>;
+using HandlersMap = std::map<
+    std::string,
+    std::pair<ProtocolType, std::pair<ProtocolHandler, std::set<URLPattern>>>>;
 
 // Implementation of URLLoaderFactory.
 class ElectronURLLoaderFactory

--- a/shell/browser/protocol_registry.h
+++ b/shell/browser/protocol_registry.h
@@ -5,9 +5,11 @@
 #ifndef SHELL_BROWSER_PROTOCOL_REGISTRY_H_
 #define SHELL_BROWSER_PROTOCOL_REGISTRY_H_
 
+#include <set>
 #include <string>
 
 #include "content/public/browser/content_browser_client.h"
+#include "extensions/common/url_pattern.h"
 #include "shell/browser/net/electron_url_loader_factory.h"
 
 namespace content {
@@ -39,7 +41,8 @@ class ProtocolRegistry {
 
   bool InterceptProtocol(ProtocolType type,
                          const std::string& scheme,
-                         const ProtocolHandler& handler);
+                         const ProtocolHandler& handler,
+                         std::set<URLPattern> url_patterns);
   bool UninterceptProtocol(const std::string& scheme);
   bool IsProtocolIntercepted(const std::string& scheme);
 

--- a/shell/browser/url_util.cc
+++ b/shell/browser/url_util.cc
@@ -1,0 +1,46 @@
+// Copyright (c) 2020 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include <set>
+#include <string>
+#include <utility>
+
+#include "shell/browser/url_util.h"
+
+namespace electron {
+
+bool MatchesFilterCondition(const GURL url,
+                            const std::set<URLPattern>& patterns) {
+  if (patterns.empty())
+    return true;
+
+  for (const auto& pattern : patterns) {
+    if (pattern.MatchesURL(url))
+      return true;
+  }
+  return false;
+}
+
+std::set<URLPattern> ParseURLPatterns(
+    const std::set<std::string>& filter_patterns,
+    std::string* error) {
+  std::set<URLPattern> rv;
+
+  for (const std::string& filter_pattern : filter_patterns) {
+    URLPattern pattern(URLPattern::SCHEME_ALL);
+    const URLPattern::ParseResult result =
+        pattern.Parse(std::move(filter_pattern));
+    if (result == URLPattern::ParseResult::kSuccess) {
+      rv.insert(pattern);
+    } else {
+      const char* error_type = URLPattern::GetParseResultString(result);
+      *error = "Invalid url pattern " + filter_pattern + ": " + error_type;
+      break;
+    }
+  }
+
+  return rv;
+}
+
+}  // namespace electron

--- a/shell/browser/url_util.h
+++ b/shell/browser/url_util.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2020 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_BROWSER_URL_UTIL_H_
+#define SHELL_BROWSER_URL_UTIL_H_
+
+#include <set>
+#include <string>
+
+#include "extensions/common/url_pattern.h"
+#include "url/gurl.h"
+
+namespace electron {
+
+bool MatchesFilterCondition(const GURL original_request,
+                            const std::set<URLPattern>& patterns);
+std::set<URLPattern> ParseURLPatterns(
+    const std::set<std::string>& filter_patterns,
+    std::string* error);
+
+}  // namespace electron
+
+#endif  // SHELL_BROWSER_URL_UTIL_H_

--- a/spec-main/api-protocol-spec.ts
+++ b/spec-main/api-protocol-spec.ts
@@ -492,42 +492,37 @@ describe('protocol module', () => {
       protocol.uninterceptProtocol('https');
     });
 
+    type InterceptStringProtocolParams = Parameters<typeof protocol.interceptStringProtocol>;
+    type InterceptStringProtocolHandler = InterceptStringProtocolParams[1];
+    const handler: InterceptStringProtocolHandler  = (request, callback) => {
+      try {
+        callback(text);
+        callback('');
+      } catch (error) {
+        // Ignore error
+      }
+    };
+
     it('intercepts if URL matches any of the URL patterns', async () => {
-      interceptStringProtocol('https', { urls: ['https://fake-host/*'] }, (request, callback) => {
-        try {
-          callback(text);
-          callback('');
-        } catch (error) {
-          // Ignore error
-        }
-      });
+      interceptStringProtocol('https', { urls: ['https://fake-host/*'] }, handler);
       const r = await ajax('https://fake-host/some-path');
       expect(r.data).to.be.equal(text);
     });
 
-    it('intercepts any URL if empty filter is passed', async () => {
-      interceptStringProtocol('https', { urls: [] }, (request, callback) => {
-        try {
-          callback(text);
-          callback('');
-        } catch (error) {
-          // Ignore error
-        }
-      });
+    it('intercepts any URL if empty filter array is passed', async () => {
+      interceptStringProtocol('https', { urls: [] }, handler);
+      const r = await ajax('https://fake-host/some-path');
+      expect(r.data).to.be.equal(text);
+    });
+
+    it('intercepts any URL if empty options is passed', async () => {
+      interceptStringProtocol('https', { }, handler);
       const r = await ajax('https://fake-host/some-path');
       expect(r.data).to.be.equal(text);
     });
 
     it('does not intercept if URL does not matches any of the URL patterns', async () => {
-      interceptStringProtocol('https', { urls: ['https://another-fake-host/*'] }, (request, callback) => {
-        try {
-          callback(text);
-          callback('');
-        } catch (error) {
-          // Ignore error
-        }
-      });
-
+      interceptStringProtocol('https', { urls: ['https://another-fake-host/*'] }, handler);
       await expect(ajax('https://fake-host/some-path')).to.be.eventually.rejectedWith(Error, '404');
     });
 


### PR DESCRIPTION
#### Description of Change
The goal is to allow passing an array of URL patterns to all intercept*Protocol functions, similarly to how it is done in the `webRequest` module. This should make the intercept API more useful, since right now one cannot intercept https without handling all requests.

Note that unlike webRequest, the protocol API allows intercepting requests at a lower level, before web security is aware. So the only way an app can intercept an https URL without breaking web security is by using the protocol API.

The first commit is a refactor which moves webRequest code that parses/matches URL patterns into a separate module. The second modifies protocol API to allow an optional second parameter to intercept functions. If no argument is passed, then all URLs will be intercepted (which is how it works now).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Modified protocol API to allow passing URL filters to intercept functions.
