### PR TITLE
fix: use-after-free in ElectronBrowserContext during shutdown

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -535,7 +535,11 @@ void ElectronBrowserMainParts::PostMainMessageLoopRun() {
   node::Stop(node_env_->env());
   node_env_.reset();
 
+  auto default_context_key = ElectronBrowserContext::PartitionKey("", false);
+  std::unique_ptr<ElectronBrowserContext> default_context = std::move(
+      ElectronBrowserContext::browser_context_map()[default_context_key]);
   ElectronBrowserContext::browser_context_map().clear();
+  default_context.reset();
 
   fake_browser_process_->PostMainMessageLoopRun();
   content::DevToolsAgentHost::StopRemoteDebuggingPipeHandler();


### PR DESCRIPTION
#### Description of Change
This fixes a use-after-free bug which could happen when using OTR sessions (i.e. partitions whose name does not begin with `persist:`). Detected by [asan](https://github.com/electron/electron/pull/23570).

The bug here is that OTR sessions use the default session as their "parent" session:
https://github.com/electron/electron/blob/0be6c92aa91475bdff38c67afedc0ea0a976c8e5/shell/browser/extensions/electron_extensions_browser_client.cc#L112-L120

The child session expects the parent session to still be alive during destruction. This PR ensures that.

Probably unrelatedly to this PR, there is some weird disagreement about what the "parent" session is here: https://github.com/electron/electron/blob/0be6c92aa91475bdff38c67afedc0ea0a976c8e5/shell/browser/extensions/electron_extension_system_factory.cc#L41-L45

Fixes #26540.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a use-after-free bug during shutdown when using off-the-record sessions.