### PR TITLE
feat: add process.uptime() to sandboxed renderers

### DIFF
--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -22,6 +22,7 @@ In sandboxed renderers the `process` object contains only a subset of the APIs:
 * `getSystemVersion()`
 * `getCPUUsage()`
 * `getIOCounters()`
+* `uptime()`
 * `argv`
 * `execPath`
 * `env`

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -90,6 +90,11 @@ v8::Local<v8::Value> CreatePreloadScript(v8::Isolate* isolate,
                                        preloadSrc);
 }
 
+double Uptime() {
+  return (base::Time::Now() - base::Process::Current().CreationTime())
+      .InSecondsF();
+}
+
 void InvokeHiddenCallback(v8::Handle<v8::Context> context,
                           const std::string& hidden_key,
                           const std::string& callback_name) {
@@ -137,6 +142,7 @@ void ElectronSandboxedRendererClient::InitializeBindings(
 
   ElectronBindings::BindProcess(isolate, &process, metrics_.get());
 
+  process.SetMethod("uptime", Uptime);
   process.Set("argv", base::CommandLine::ForCurrentProcess()->argv());
   process.SetReadOnly("pid", base::GetCurrentProcId());
   process.SetReadOnly("sandboxed", true);

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -2533,6 +2533,7 @@ describe('BrowserWindow module', () => {
         expect(test.systemVersion).to.be.a('string');
         expect(test.cpuUsage).to.be.an('object');
         expect(test.ioCounters).to.be.an('object');
+        expect(test.uptime).to.be.a('number');
         expect(test.arch).to.equal(process.arch);
         expect(test.platform).to.equal(process.platform);
         expect(test.env).to.deep.equal(process.env);

--- a/spec-main/fixtures/module/preload-sandbox.js
+++ b/spec-main/fixtures/module/preload-sandbox.js
@@ -33,6 +33,7 @@
         systemVersion: invoke(() => process.getSystemVersion()),
         cpuUsage: invoke(() => process.getCPUUsage()),
         ioCounters: invoke(() => process.getIOCounters()),
+        uptime: invoke(() => process.uptime()),
         env: process.env,
         execPath: process.execPath,
         pid: process.pid,


### PR DESCRIPTION
#### Description of Change
Add [`process.uptime()`](https://nodejs.org/api/process.html#process_process_uptime) to sandboxed renderers.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `process.uptime()` to sandboxed renderers.