### PR TITLE
fix: draggable regions calculation in BrowserWindow/BrowserView

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -309,10 +309,9 @@ void BrowserWindow::OnWindowResize() {
   if (!draggable_regions_.empty()) {
     UpdateDraggableRegions(draggable_regions_);
   } else {
-    // Ensure draggable bounds are recalculated for BrowserViews if any exist.
     auto browser_views = window_->browser_views();
     for (NativeBrowserView* view : browser_views) {
-      view->UpdateDraggableRegions(draggable_regions_);
+      view->UpdateDraggableRegions(view->draggable_regions());
     }
   }
 #endif

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -309,9 +309,8 @@ void BrowserWindow::OnWindowResize() {
   if (!draggable_regions_.empty()) {
     UpdateDraggableRegions(draggable_regions_);
   } else {
-    auto browser_views = window_->browser_views();
-    for (NativeBrowserView* view : browser_views) {
-      view->UpdateDraggableRegions(view->draggable_regions());
+    for (NativeBrowserView* view : window_->browser_views()) {
+      view->UpdateDraggableRegions(view->GetDraggableRegions());
     }
   }
 #endif

--- a/shell/browser/api/electron_api_browser_window_mac.mm
+++ b/shell/browser/api/electron_api_browser_window_mac.mm
@@ -77,17 +77,17 @@ void BrowserWindow::UpdateDraggableRegions(
       draggable_regions_.push_back(r.Clone());
   }
 
-  auto browser_views = window_->browser_views();
-  for (NativeBrowserView* view : browser_views) {
-    view->UpdateDraggableRegions(draggable_regions_);
-  }
-
   std::vector<gfx::Rect> drag_exclude_rects;
   if (regions.empty()) {
     drag_exclude_rects.push_back(gfx::Rect(0, 0, webViewWidth, webViewHeight));
   } else {
     drag_exclude_rects = CalculateNonDraggableRegions(
         DraggableRegionsToSkRegion(regions), webViewWidth, webViewHeight);
+  }
+
+  auto browser_views = window_->browser_views();
+  for (NativeBrowserView* view : browser_views) {
+    view->UpdateDraggableRegions(drag_exclude_rects);
   }
 
   // Create and add a ControlRegionView for each region that needs to be

--- a/shell/browser/api/electron_api_browser_window_mac.mm
+++ b/shell/browser/api/electron_api_browser_window_mac.mm
@@ -71,22 +71,18 @@ void BrowserWindow::UpdateDraggableRegions(
 
   // Draggable regions are implemented by having the whole web view draggable
   // and overlaying regions that are not draggable.
-  if (&draggable_regions_ != &regions) {
-    draggable_regions_.clear();
-    for (const auto& r : regions)
-      draggable_regions_.push_back(r.Clone());
-  }
+  if (&draggable_regions_ != &regions)
+    draggable_regions_ = mojo::Clone(regions);
 
   std::vector<gfx::Rect> drag_exclude_rects;
   if (regions.empty()) {
-    drag_exclude_rects.push_back(gfx::Rect(0, 0, webViewWidth, webViewHeight));
+    drag_exclude_rects.emplace_back(0, 0, webViewWidth, webViewHeight);
   } else {
     drag_exclude_rects = CalculateNonDraggableRegions(
         DraggableRegionsToSkRegion(regions), webViewWidth, webViewHeight);
   }
 
-  auto browser_views = window_->browser_views();
-  for (NativeBrowserView* view : browser_views) {
+  for (NativeBrowserView* view : window_->browser_views()) {
     view->UpdateDraggableRegions(drag_exclude_rects);
   }
 

--- a/shell/browser/native_browser_view.h
+++ b/shell/browser/native_browser_view.h
@@ -5,6 +5,7 @@
 #ifndef SHELL_BROWSER_NATIVE_BROWSER_VIEW_H_
 #define SHELL_BROWSER_NATIVE_BROWSER_VIEW_H_
 
+#include <utility>
 #include <vector>
 
 #include "base/macros.h"
@@ -40,12 +41,19 @@ class NativeBrowserView : public content::WebContentsObserver {
     return inspectable_web_contents_;
   }
 
+  std::vector<mojom::DraggableRegionPtr> draggable_regions() {
+    return std::move(draggable_regions_);
+  }
+
   InspectableWebContentsView* GetInspectableWebContentsView();
 
   virtual void SetAutoResizeFlags(uint8_t flags) = 0;
   virtual void SetBounds(const gfx::Rect& bounds) = 0;
   virtual gfx::Rect GetBounds() = 0;
   virtual void SetBackgroundColor(SkColor color) = 0;
+
+  virtual void UpdateDraggableRegions(
+      const std::vector<gfx::Rect>& drag_exclude_rects) {}
 
   // Called when the window needs to update its draggable region.
   virtual void UpdateDraggableRegions(
@@ -57,6 +65,7 @@ class NativeBrowserView : public content::WebContentsObserver {
   void WebContentsDestroyed() override;
 
   InspectableWebContents* inspectable_web_contents_;
+  std::vector<mojom::DraggableRegionPtr> draggable_regions_;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(NativeBrowserView);

--- a/shell/browser/native_browser_view.h
+++ b/shell/browser/native_browser_view.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_NATIVE_BROWSER_VIEW_H_
 #define SHELL_BROWSER_NATIVE_BROWSER_VIEW_H_
 
-#include <utility>
 #include <vector>
 
 #include "base/macros.h"
@@ -41,8 +40,8 @@ class NativeBrowserView : public content::WebContentsObserver {
     return inspectable_web_contents_;
   }
 
-  std::vector<mojom::DraggableRegionPtr> draggable_regions() {
-    return std::move(draggable_regions_);
+  const std::vector<mojom::DraggableRegionPtr>& GetDraggableRegions() const {
+    return draggable_regions_;
   }
 
   InspectableWebContentsView* GetInspectableWebContentsView();

--- a/shell/browser/native_browser_view_mac.h
+++ b/shell/browser/native_browser_view_mac.h
@@ -27,8 +27,8 @@ class NativeBrowserViewMac : public NativeBrowserView {
   void UpdateDraggableRegions(
       const std::vector<mojom::DraggableRegionPtr>& regions) override;
 
- private:
-  std::vector<mojom::DraggableRegionPtr> draggable_regions_;
+  void UpdateDraggableRegions(
+      const std::vector<gfx::Rect>& drag_exclude_rects) override;
 
   DISALLOW_COPY_AND_ASSIGN(NativeBrowserViewMac);
 };

--- a/shell/browser/native_browser_view_mac.mm
+++ b/shell/browser/native_browser_view_mac.mm
@@ -290,15 +290,12 @@ void NativeBrowserViewMac::UpdateDraggableRegions(
 
   // Draggable regions are implemented by having the whole web view draggable
   // and overlaying regions that are not draggable.
-  if (&draggable_regions_ != &regions) {
-    draggable_regions_.clear();
-    for (const auto& r : regions)
-      draggable_regions_.push_back(r.Clone());
-  }
+  if (&draggable_regions_ != &regions)
+    draggable_regions_ = mojo::Clone(regions);
 
   std::vector<gfx::Rect> drag_exclude_rects;
   if (regions.empty()) {
-    drag_exclude_rects.push_back(gfx::Rect(0, 0, webViewWidth, webViewHeight));
+    drag_exclude_rects.emplace_back(0, 0, webViewWidth, webViewHeight);
   } else {
     drag_exclude_rects = CalculateNonDraggableRegions(
         DraggableRegionsToSkRegion(regions), webViewWidth, webViewHeight);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/26588.

Fixes a regression introduced in https://github.com/electron/electron/pull/26145. As a part of that PR, I reworked the parameters to `UpdateDraggableRegions` in `NativeBrowserView` such that they took  `const std::vector<mojom::DraggableRegionPtr>& regions` instead of `const std::vector<gfx::Rect>& drag_exclude_rects`. This was necessary in order to enable draggable regions worked on BrowserViews standalone, but introduced a new issue.

This was that `drag_exclude_rects` were then calculated from the passed regions, they would be calculated with the `webViewWidth` and `webViewHeight` _relative to the containing WebContents_. This caused https://github.com/electron/electron/issues/26588. To fix this, we need to ensure that the excluded rects are calculated relative to the `BrowserWindow`'s `WebContents` when it is the `BrowserWindow` which contains the draggable regions. This is done by adding a new `UpdateDraggableRegions` function overload and refactoring accordingly.

We also need to ensure that when the containing `BrowserWindow` is resized, and there are no draggable regions set on said  `BrowserWindow`, that the `BrowserViews` resize themselves accordingly. This is done by exposing an accessor to `draggable_regions` of a given `NativeBrowserView` and triggering a recalculation.

Tested with https://gist.github.com/ckerr/9261213d7edaadc590f8400c79ab9118 to ensure the bug was fixed, as well as https://gist.github.com/codebytere/2c072f42d7abaf27e73961b1dde87811 to ensure that this fix does not regress previous fixes.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where draggable regions in BrowserWindow causes BrowserView to become draggable in non-correspondent places.
