### PR TITLE
feat: add clipboard.writeFilePaths/readFilePaths APIs

### DIFF
--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -167,6 +167,16 @@ The cached value is reread from the find pasteboard whenever the application is 
 
 Writes the `text` into the find pasteboard (the pasteboard that holds information about the current state of the active application’s find panel) as plain text. This method uses synchronous IPC when called from the renderer process.
 
+### `clipboard.readFilePaths()`
+
+Returns `String[]` - An Array of file paths in clipboard.
+
+### `clipboard.writeFilePaths(paths)`
+
+* `paths` String[] - An Array of file paths.
+
+Writes file paths into clipboard.
+
 ### `clipboard.clear([type])`
 
 * `type` String (optional) - Can be `selection` or `clipboard`; default is 'clipboard'. `selection` is only available on Linux.

--- a/filenames.gni
+++ b/filenames.gni
@@ -106,6 +106,7 @@ filenames = {
     "shell/browser/ui/win/taskbar_host.h",
     "shell/browser/win/scoped_hstring.cc",
     "shell/browser/win/scoped_hstring.h",
+    "shell/common/api/electron_api_clipboard_win.cc",
     "shell/common/api/electron_api_native_image_win.cc",
     "shell/common/application_info_win.cc",
     "shell/common/language_util_win.cc",

--- a/filenames.gni
+++ b/filenames.gni
@@ -36,6 +36,7 @@ filenames = {
     "shell/browser/ui/message_box_gtk.cc",
     "shell/browser/ui/tray_icon_gtk.cc",
     "shell/browser/ui/tray_icon_gtk.h",
+    "shell/common/api/electron_api_clipboard_gtk.cc",
     "shell/common/application_info_linux.cc",
     "shell/common/language_util_linux.cc",
     "shell/common/node_bindings_linux.cc",

--- a/shell/common/api/electron_api_clipboard.cc
+++ b/shell/common/api/electron_api_clipboard.cc
@@ -5,6 +5,7 @@
 #include "shell/common/api/electron_api_clipboard.h"
 
 #include "base/strings/utf_string_conversions.h"
+#include "shell/common/gin_converters/file_path_converter.h"
 #include "shell/common/gin_converters/image_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/node_includes.h"
@@ -245,6 +246,8 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("writeImage", &electron::api::Clipboard::WriteImage);
   dict.SetMethod("readFindText", &electron::api::Clipboard::ReadFindText);
   dict.SetMethod("writeFindText", &electron::api::Clipboard::WriteFindText);
+  dict.SetMethod("readFilePaths", &electron::api::Clipboard::ReadFilePaths);
+  dict.SetMethod("writeFilePaths", &electron::api::Clipboard::WriteFilePaths);
   dict.SetMethod("readBuffer", &electron::api::Clipboard::ReadBuffer);
   dict.SetMethod("writeBuffer", &electron::api::Clipboard::WriteBuffer);
   dict.SetMethod("clear", &electron::api::Clipboard::Clear);

--- a/shell/common/api/electron_api_clipboard.h
+++ b/shell/common/api/electron_api_clipboard.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "base/files/file_path.h"
 #include "ui/base/clipboard/clipboard.h"
 #include "ui/gfx/image/image.h"
 #include "v8/include/v8.h"
@@ -55,6 +56,9 @@ class Clipboard {
 
   static base::string16 ReadFindText();
   static void WriteFindText(const base::string16& text);
+
+  static std::vector<base::FilePath> ReadFilePaths();
+  static void WriteFilePaths(const std::vector<base::FilePath>& paths);
 
   static v8::Local<v8::Value> ReadBuffer(const std::string& format_string,
                                          gin_helper::Arguments* args);

--- a/shell/common/api/electron_api_clipboard_gtk.cc
+++ b/shell/common/api/electron_api_clipboard_gtk.cc
@@ -1,0 +1,73 @@
+// Copyright (c) 2020 Microsoft, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/common/api/electron_api_clipboard.h"
+
+#include <gtk/gtk.h>
+
+namespace electron {
+
+namespace api {
+
+namespace {
+
+void ClipboardGet(GtkClipboard* clipboard,
+                  GtkSelectionData* selection,
+                  guint info,
+                  gchar** uris) {
+  DCHECK_EQ(info, 0u);
+  gtk_selection_data_set_uris(selection, uris);
+}
+
+void ClipboardClear(GtkClipboard* clipboard, gchar** uris) {
+  g_strfreev(uris);
+}
+
+}  // namespace
+
+std::vector<base::FilePath> Clipboard::ReadFilePaths() {
+  std::vector<base::FilePath> result;
+  GtkClipboard* clipboard = gtk_clipboard_get(GDK_SELECTION_CLIPBOARD);
+  gchar** uris = gtk_clipboard_wait_for_uris(clipboard);
+  if (!uris)
+    return result;
+  for (int i = 0; uris[i]; i++) {
+    if (gchar* path = g_filename_from_uri(uris[i], nullptr, nullptr)) {
+      result.emplace_back(path);
+      g_free(path);
+    }
+  }
+  g_strfreev(uris);
+  return result;
+}
+
+void Clipboard::WriteFilePaths(const std::vector<base::FilePath>& paths) {
+  // Convert vector to gchar* array, will be destroyed by ClipboardClear.
+  gchar** uris = g_new(gchar*, paths.size() + 1);
+  if (!uris)
+    return;
+  size_t i;
+  for (i = 0; i < paths.size(); ++i) {
+    uris[i] = g_filename_to_uri(paths[i].value().c_str(), nullptr, nullptr);
+  }
+  uris[i] = nullptr;
+
+  GtkTargetList* targets = gtk_target_list_new(nullptr, 0);
+  gtk_target_list_add_uri_targets(targets, 0);
+  int number = 0;
+  GtkTargetEntry* table = gtk_target_table_new_from_list(targets, &number);
+  DCHECK_EQ(number, 1);
+
+  GtkClipboard* clipboard = gtk_clipboard_get(GDK_SELECTION_CLIPBOARD);
+  gtk_clipboard_set_with_data(clipboard, table, number,
+                              (GtkClipboardGetFunc)ClipboardGet,
+                              (GtkClipboardClearFunc)ClipboardClear, uris);
+
+  gtk_target_list_unref(targets);
+  gtk_target_table_free(table, number);
+}
+
+}  // namespace api
+
+}  // namespace electron

--- a/shell/common/api/electron_api_clipboard_mac.mm
+++ b/shell/common/api/electron_api_clipboard_mac.mm
@@ -2,8 +2,12 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "base/strings/sys_string_conversions.h"
 #include "shell/common/api/electron_api_clipboard.h"
+
+#include <vector>
+
+#include "base/mac/foundation_util.h"
+#include "base/strings/sys_string_conversions.h"
 #include "ui/base/cocoa/find_pasteboard.h"
 
 namespace electron {
@@ -17,6 +21,27 @@ void Clipboard::WriteFindText(const base::string16& text) {
 
 base::string16 Clipboard::ReadFindText() {
   return GetFindPboardText();
+}
+
+std::vector<base::FilePath> Clipboard::ReadFilePaths() {
+  std::vector<base::FilePath> result;
+  NSArray* paths = [[NSPasteboard generalPasteboard]
+      propertyListForType:NSFilenamesPboardType];
+  if (paths) {
+    result.reserve([paths count]);
+    for (NSString* path in paths)
+      result.push_back(base::mac::NSStringToFilePath(path));
+  }
+  return result;
+}
+
+void Clipboard::WriteFilePaths(const std::vector<base::FilePath>& paths) {
+  NSMutableArray* filePaths = [NSMutableArray array];
+  for (const auto& path : paths)
+    [filePaths addObject:base::SysUTF8ToNSString(path.value())];
+  NSPasteboard* pasteboard = [NSPasteboard generalPasteboard];
+  [pasteboard declareTypes:@[ NSFilenamesPboardType ] owner:nil];
+  [pasteboard setPropertyList:filePaths forType:NSFilenamesPboardType];
 }
 
 }  // namespace api

--- a/shell/common/api/electron_api_clipboard_win.cc
+++ b/shell/common/api/electron_api_clipboard_win.cc
@@ -1,0 +1,83 @@
+// Copyright (c) 2020 Microsoft, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/common/api/electron_api_clipboard.h"
+
+#include <shellapi.h>
+#include <shlobj.h>
+
+#include "base/win/scoped_hglobal.h"
+
+namespace electron {
+
+namespace api {
+
+std::vector<base::FilePath> Clipboard::ReadFilePaths() {
+  std::vector<base::FilePath> result;
+  ::OpenClipboard(NULL);
+  base::win::ScopedHGlobal<HDROP> hdrop(::GetClipboardData(CF_HDROP));
+  if (hdrop.get()) {
+    const int kMaxFilenameLen = 4096;
+    const unsigned num_files = ::DragQueryFileW(hdrop.get(), 0xffffffff, 0, 0);
+    result.reserve(num_files);
+    for (unsigned int i = 0; i < num_files; ++i) {
+      wchar_t filename[kMaxFilenameLen];
+      if (!::DragQueryFileW(hdrop.get(), i, filename, kMaxFilenameLen))
+        continue;
+      result.push_back(base::FilePath(filename));
+    }
+  }
+  ::CloseClipboard();
+  return result;
+}
+
+void Clipboard::WriteFilePaths(const std::vector<base::FilePath>& paths) {
+  // CF_HDROP clipboard format consists of DROPFILES structure, a series of file
+  // names including the terminating null character and the additional null
+  // character at the tail to terminate the array.
+  // For example,
+  //| DROPFILES | FILENAME 1 | NULL | ... | FILENAME n | NULL | NULL |
+  // For more details, please refer to
+  // https://docs.microsoft.com/ko-kr/windows/desktop/shell/clipboard#cf_hdrop
+  size_t total_bytes = sizeof(DROPFILES);
+  for (const auto& filename : paths) {
+    // Allocate memory of the filename's length including the null
+    // character.
+    total_bytes += (filename.value().length() + 1) * sizeof(wchar_t);
+  }
+  // |data| needs to be terminated by an additional null character.
+  total_bytes += sizeof(wchar_t);
+
+  // GHND combines GMEM_MOVEABLE and GMEM_ZEROINIT, and GMEM_ZEROINIT
+  // initializes memory contents to zero.
+  HANDLE hdata = ::GlobalAlloc(GHND, total_bytes);
+  if (!hdata)
+    return;
+
+  {
+    base::win::ScopedHGlobal<DROPFILES*> locked_mem(hdata);
+    DROPFILES* drop_files = locked_mem.get();
+    drop_files->pFiles = sizeof(DROPFILES);
+    drop_files->fWide = TRUE;
+
+    wchar_t* data = reinterpret_cast<wchar_t*>(
+        reinterpret_cast<BYTE*>(drop_files) + sizeof(DROPFILES));
+
+    size_t next_filename_offset = 0;
+    for (const auto& filename : paths) {
+      wcscpy(data + next_filename_offset, filename.value().c_str());
+      // Skip the terminating null character of the filename.
+      next_filename_offset += filename.value().length() + 1;
+    }
+  }
+
+  ::OpenClipboard(NULL);
+  if (!::SetClipboardData(CF_HDROP, hdata))
+    ::GlobalFree(hdata);  // only free data when failed to set clipboard
+  ::CloseClipboard();
+}
+
+}  // namespace api
+
+}  // namespace electron

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -71,6 +71,19 @@ describe('clipboard module', () => {
     });
   });
 
+  describe('clipboard.readFilePaths', () => {
+    it('returns file paths correctly', () => {
+      const paths = [process.execPath, __dirname, __filename];
+      clipboard.writeFilePaths(paths);
+      expect(clipboard.readFilePaths()).to.deep.equal(paths);
+    });
+
+    it('returns empty array when there is no file paths', () => {
+      clipboard.writeText(__filename);
+      expect(clipboard.readFilePaths()).to.deep.equal([]);
+    });
+  });
+
   describe('clipboard.write()', () => {
     it('returns data correctly', () => {
       const text = 'test';


### PR DESCRIPTION
#### Description of Change

Add `clipboard.writeFilePaths/readFilePaths` APIs that can be used to get/set file pointers in clipboard, close https://github.com/electron/electron/issues/9035.

Note that Chromium does not provide public APIs for writing file paths so we have to implement the API separately for each platform.

Also for the same reason we are unable to add `filePaths` to the `clipboard.write` API, otherwise a patch to Chromium would be required. But usually users would not need to write `filePaths` and other types of data into clipboard at the same time, and even if eventually we want to implement that, there will be no change to the `clipboard.writeFilePaths/readFilePaths` APIs.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Add `clipboard.writeFilePaths/readFilePaths` APIs.