### PR TITLE
fix: uaf in WebContents::DidStopLoading

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1447,12 +1447,12 @@ void WebContents::DidStartLoading() {
 }
 
 void WebContents::DidStopLoading() {
-  Emit("did-stop-loading");
-
   auto* web_preferences = WebContentsPreferences::From(web_contents());
   if (web_preferences &&
       web_preferences->IsEnabled(options::kEnablePreferredSizeMode))
     web_contents()->GetRenderViewHost()->EnablePreferredSizeMode();
+
+  Emit("did-stop-loading");
 }
 
 bool WebContents::EmitNavigationEvent(


### PR DESCRIPTION
#### Description of Change
Fixes #26475.

Introduced in 10a209ecba.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a use-after-free error that could occur when destroying a WebContents during the `did-stop-loading` event.
