### PR TITLE
chore: use ESLint API for linting

### DIFF
--- a/script/lint.js
+++ b/script/lint.js
@@ -309,7 +309,7 @@ async function main () {
     const filenames = await findFiles(opts, linter);
     if (filenames.length) {
       if (opts.verbose) { console.log(`linting ${filenames.length} ${linter.key} ${filenames.length === 1 ? 'file' : 'files'}`); }
-      await inter.run(opts, filenames);
+      await linter.run(opts, filenames);
     }
   }
 }

--- a/script/lint.js
+++ b/script/lint.js
@@ -2,6 +2,7 @@
 
 const { GitProcess } = require('dugite');
 const childProcess = require('child_process');
+const { ESLint } = require('eslint');
 const fs = require('fs');
 const klaw = require('klaw');
 const minimist = require('minimist');


### PR DESCRIPTION
#### Description of Change

This is a better fix for #26014, and has some other benefits.

Count successes instead of expecting error output. Seems that the most common reason the linters get broken is that they aren't actually running what is expected, something silently fails, and silence is considered success. Invert that logic, and start with a fail state, so if nothing runs, it's a failure by default.

When in verbose mode, output names of files linted even if they ran clean. This again makes it easier to tell if a linter is running as intended, or silently failing.

#### Checklist

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none