### PR TITLE
chore: remove deprecated shell.moveItemToTrash()

### DIFF
--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -45,17 +45,6 @@ Returns `Promise<void>`
 
 Open the given external protocol URL in the desktop's default manner. (For example, mailto: URLs in the user's default mail agent).
 
-### `shell.moveItemToTrash(fullPath[, deleteOnFail])` _Deprecated_
-
-* `fullPath` String
-* `deleteOnFail` Boolean (optional) - Whether or not to unilaterally remove the item if the Trash is disabled or unsupported on the volume. _macOS_
-
-Returns `Boolean` - Whether the item was successfully moved to the trash or otherwise deleted.
-
-> NOTE: This method is deprecated. Use `shell.trashItem` instead.
-
-Move the given file to trash and returns a boolean status for the operation.
-
 ### `shell.trashItem(path)`
 
 * `path` String - path to the item to be moved to the trash.

--- a/lib/common/api/shell.ts
+++ b/lib/common/api/shell.ts
@@ -1,7 +1,3 @@
-import { deprecate } from 'electron/main';
-
 const shell = process._linkedBinding('electron_common_shell');
-
-shell.moveItemToTrash = deprecate.renameFunction(shell.moveItemToTrash, 'shell.trashItem');
 
 export default shell;

--- a/shell/common/api/electron_api_shell.cc
+++ b/shell/common/api/electron_api_shell.cc
@@ -85,16 +85,6 @@ v8::Local<v8::Promise> OpenPath(v8::Isolate* isolate,
   return handle;
 }
 
-bool MoveItemToTrash(gin::Arguments* args) {
-  base::FilePath full_path;
-  args->GetNext(&full_path);
-
-  bool delete_on_fail = false;
-  args->GetNext(&delete_on_fail);
-
-  return platform_util::MoveItemToTrash(full_path, delete_on_fail);
-}
-
 v8::Local<v8::Promise> TrashItem(v8::Isolate* isolate,
                                  const base::FilePath& path) {
   gin_helper::Promise<void> promise(isolate);
@@ -181,7 +171,6 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("showItemInFolder", &platform_util::ShowItemInFolder);
   dict.SetMethod("openPath", &OpenPath);
   dict.SetMethod("openExternal", &OpenExternal);
-  dict.SetMethod("moveItemToTrash", &MoveItemToTrash);
   dict.SetMethod("trashItem", &TrashItem);
   dict.SetMethod("beep", &platform_util::Beep);
 #if defined(OS_WIN)

--- a/shell/common/platform_util.h
+++ b/shell/common/platform_util.h
@@ -40,9 +40,6 @@ void OpenExternal(const GURL& url,
                   const OpenExternalOptions& options,
                   OpenCallback callback);
 
-// Move a file to trash. (Deprecated.)
-bool MoveItemToTrash(const base::FilePath& full_path, bool delete_on_fail);
-
 // Move a file to trash, asynchronously.
 void TrashItem(const base::FilePath& full_path,
                base::OnceCallback<void(bool, const std::string&)> callback);

--- a/shell/common/platform_util_mac.mm
+++ b/shell/common/platform_util_mac.mm
@@ -153,11 +153,6 @@ bool MoveItemToTrashWithError(const base::FilePath& full_path,
   return did_trash;
 }
 
-bool MoveItemToTrash(const base::FilePath& path, bool delete_on_fail) {
-  std::string error;  // ignored
-  return MoveItemToTrashWithError(path, delete_on_fail, &error);
-}
-
 namespace internal {
 
 bool PlatformTrashItem(const base::FilePath& full_path, std::string* error) {

--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -422,12 +422,6 @@ bool MoveItemToTrashWithError(const base::FilePath& path,
   return true;
 }
 
-bool MoveItemToTrash(const base::FilePath& path, bool delete_on_fail) {
-  std::string error;  // ignored
-  base::win::ScopedCOMInitializer com_initializer;
-  return MoveItemToTrashWithError(path, delete_on_fail, &error);
-}
-
 namespace internal {
 
 bool PlatformTrashItem(const base::FilePath& full_path, std::string* error) {

--- a/spec-main/api-shell-spec.ts
+++ b/spec-main/api-shell-spec.ts
@@ -7,8 +7,6 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import { AddressInfo } from 'net';
 import { expect } from 'chai';
-import { ifit } from './spec-helpers';
-import { execSync } from 'child_process';
 
 describe('shell module', () => {
   describe('shell.openExternal()', () => {
@@ -60,56 +58,6 @@ describe('shell module', () => {
         shell.openExternal(url),
         requestReceived
       ]);
-    });
-  });
-
-  describe('shell.moveItemToTrash()', () => {
-    it('moves an item to the trash', async () => {
-      const dir = await fs.mkdtemp(path.resolve(app.getPath('temp'), 'electron-shell-spec-'));
-      const filename = path.join(dir, 'temp-to-be-deleted');
-      await fs.writeFile(filename, 'dummy-contents');
-      const result = shell.moveItemToTrash(filename);
-      expect(result).to.be.true();
-      expect(fs.existsSync(filename)).to.be.false();
-    });
-
-    it('returns false when called with a nonexistent path', () => {
-      const filename = path.join(app.getPath('temp'), 'does-not-exist');
-      const result = shell.moveItemToTrash(filename);
-      expect(result).to.be.false();
-    });
-
-    ifit(process.platform === 'darwin')('returns false when file has immutable flag', async () => {
-      const dir = await fs.mkdtemp(path.resolve(app.getPath('temp'), 'electron-shell-spec-'));
-      const tempPath = path.join(dir, 'locked-file');
-      await fs.writeFile(tempPath, 'delete me if you can');
-
-      // https://ss64.com/osx/chflags.html
-      execSync(`chflags uchg ${tempPath}`);
-      expect(shell.moveItemToTrash(tempPath)).to.be.false();
-      expect(await fs.pathExists(tempPath)).to.be.true();
-
-      execSync(`chflags nouchg ${tempPath}`);
-      expect(shell.moveItemToTrash(tempPath)).to.be.true();
-      expect(await fs.pathExists(tempPath)).to.be.false();
-    });
-
-    ifit(process.platform === 'win32')('returns false when path is in use', async () => {
-      const tempPath = await fs.mkdtemp(path.resolve(app.getPath('temp'), 'electron-shell-spec-'));
-      const cwd = process.cwd();
-      try {
-        // A process working directory is automatically locked on Windows.
-        // This is a workaround to avoid pulling in fs-extras flock method.
-        process.chdir(tempPath);
-
-        expect(shell.moveItemToTrash(tempPath)).to.be.false();
-        expect(await fs.pathExists(tempPath)).to.be.true();
-      } finally {
-        process.chdir(cwd);
-      }
-
-      expect(shell.moveItemToTrash(tempPath)).to.be.true();
-      expect(await fs.pathExists(tempPath)).to.be.false();
     });
   });
 

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -1051,7 +1051,7 @@ app.whenReady().then(() => {
 // https://github.com/electron/electron/blob/master/docs/api/shell.md
 
 shell.showItemInFolder('/home/user/Desktop/test.txt')
-shell.moveItemToTrash('/home/user/Desktop/test.txt')
+shell.trashItem('/home/user/Desktop/test.txt').then(() => {})
 
 shell.openPath('/home/user/Desktop/test.txt').then(err => {
   if (err) console.log(err)


### PR DESCRIPTION
#### Description of Change
[This is already documented as removed in Electron 13](https://github.com/electron/electron/blob/master/docs/breaking-changes.md#removed-shellmoveitemtotrash)

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Removed deprecated `shell.moveItemToTrash()`.
