### PR TITLE
fix: Add default Bluetooth permission strings

### DIFF
--- a/shell/browser/resources/mac/Info.plist
+++ b/shell/browser/resources/mac/Info.plist
@@ -40,5 +40,9 @@
     <string>This app needs access to the microphone</string>
     <key>NSCameraUsageDescription</key>
     <string>This app needs access to the camera</string>
+    <key>NSBluetoothAlwaysUsageDescription</key>
+    <string>This app needs access to Bluetooth</string>
+    <key>NSBluetoothPeripheralUsageDescription</key>
+    <string>This app needs access to Bluetooth</string>
   </dict>
 </plist>


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

We've received several reports of our app crashing when loading pages that require Bluetooth on Big Sur. As described in the [corresponding Chrome issue](https://bugs.chromium.org/p/chromium/issues/detail?id=1126246):

> For apps compiled against the macOS 11.0 SDK, TCC will crash
> if the NSBluetoothAlwaysUsageDescription string isn't available
> and Bluetooth APIs are called.

This PR makes the same change as Chrome to Electron's info.plist (following #19871).

I'm not sure if it's actually necessary to include `NSBluetoothPeripheralUsageDescription`; Apple's [documentation](https://developer.apple.com/documentation/bundleresources/information_property_list/nsbluetoothperipheralusagedescription) describes it as being used only on old versions of iOS. However, since Chrome includes it, I figured it's safer to include it here too.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added default Bluetooth permission strings to info.plist.