### PR TITLE
docs: add debugging vars to env var doc

### DIFF
--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -122,7 +122,7 @@ Prints Chrome's internal logging to the console.
 
 ### `ELECTRON_DEBUG_DRAG_REGIONS`
 
-Adds coloration to draggable regions on `BrowserViews` on macOS - draggable regions will be colored
+Adds coloration to draggable regions on [`BrowserView`](./browser-view.md)s on macOS - draggable regions will be colored
 green and non-draggable regions will be colored green to aid debugging.
 
 ### `ELECTRON_DEBUG_NOTIFICATIONS`

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -120,6 +120,15 @@ debugging purposes.
 
 Prints Chrome's internal logging to the console.
 
+### `ELECTRON_DEBUG_DRAG_REGIONS`
+
+Adds coloration to draggable regions on `BrowserViews` on macOS - draggable regions will be colored
+green and non-draggable regions will be colored green to aid debugging.
+
+### `ELECTRON_DEBUG_NOTIFICATIONS`
+
+Adds extra debugging logs to Notification lifecycles on macOS to aid in debugging.
+
 ### `ELECTRON_LOG_ASAR_READS`
 
 When Electron reads from an ASAR file, log the read offset and file path to

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -123,11 +123,20 @@ Prints Chrome's internal logging to the console.
 ### `ELECTRON_DEBUG_DRAG_REGIONS`
 
 Adds coloration to draggable regions on [`BrowserView`](./browser-view.md)s on macOS - draggable regions will be colored
-green and non-draggable regions will be colored green to aid debugging.
+green and non-draggable regions will be colored red to aid debugging.
 
 ### `ELECTRON_DEBUG_NOTIFICATIONS`
 
-Adds extra debugging logs to Notification lifecycles on macOS to aid in debugging.
+Adds extra logs to [`Notification`](./notification.md) lifecycles on macOS to aid in debugging. Extra logging will be displayed when new Notifications are created or activated. They will also be displayed when common actions are taken: a notification is shown, dismissed, its button is clicked, or it is replied to.
+
+Sample output:
+
+```sh
+Notification created (com.github.Electron:notification:EAF7B87C-A113-43D7-8E76-F88EC9D73D44)
+Notification displayed (com.github.Electron:notification:EAF7B87C-A113-43D7-8E76-F88EC9D73D44)
+Notification activated (com.github.Electron:notification:EAF7B87C-A113-43D7-8E76-F88EC9D73D44)
+Notification replied to (com.github.Electron:notification:EAF7B87C-A113-43D7-8E76-F88EC9D73D44)
+```
 
 ### `ELECTRON_LOG_ASAR_READS`
 


### PR DESCRIPTION
#### Description of Change

Adds information about two environment variables that can be enabled for more effective debugging.

cc @MarshallOfSound @zcbenz @jkleinsc 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none.
