### PR TITLE
fix: webContents interaction with draggable browserviews

### DIFF
--- a/patches/chromium/render_widget_host_view_mac.patch
+++ b/patches/chromium/render_widget_host_view_mac.patch
@@ -10,10 +10,10 @@ kinds of utility windows. Similarly for `disableAutoHideCursor`.
 Additionally, disables usage of some private APIs in MAS builds.
 
 diff --git a/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm b/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
-index c7fb942367100b7a371d8941c73fc608a1a39435..ab0e620e824e0a0df93b12d2ff42cc1937812fd3 100644
+index c7fb942367100b7a371d8941c73fc608a1a39435..18b561acce8d3a8abe233162cff34d436fb8f970 100644
 --- a/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
 +++ b/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
-@@ -154,6 +154,11 @@ void ExtractUnderlines(NSAttributedString* string,
+@@ -154,6 +154,15 @@ void ExtractUnderlines(NSAttributedString* string,
  
  }  // namespace
  
@@ -22,10 +22,14 @@ index c7fb942367100b7a371d8941c73fc608a1a39435..ab0e620e824e0a0df93b12d2ff42cc19
 +- (BOOL)disableAutoHideCursor;
 +@end
 +
++@interface NSView (ElectronCustomMethods)
++- (BOOL)shouldIgnoreMouseEvent;
++@end
++
  // These are not documented, so use only after checking -respondsToSelector:.
  @interface NSApplication (UndocumentedSpeechMethods)
  - (void)speakString:(NSString*)string;
-@@ -573,6 +578,9 @@ void ExtractUnderlines(NSAttributedString* string,
+@@ -573,6 +582,9 @@ void ExtractUnderlines(NSAttributedString* string,
  }
  
  - (BOOL)acceptsFirstMouse:(NSEvent*)theEvent {
@@ -35,7 +39,16 @@ index c7fb942367100b7a371d8941c73fc608a1a39435..ab0e620e824e0a0df93b12d2ff42cc19
    return [self acceptsMouseEventsWhenInactive];
  }
  
-@@ -983,6 +991,10 @@ void ExtractUnderlines(NSAttributedString* string,
+@@ -648,6 +660,8 @@ void ExtractUnderlines(NSAttributedString* string,
+   // its parent view.
+   BOOL hitSelf = NO;
+   while (view) {
++    if ([view respondsToSelector:@selector(shouldIgnoreMouseEvent)] && ![view shouldIgnoreMouseEvent])
++      return NO;
+     if (view == self)
+       hitSelf = YES;
+     if ([view isKindOfClass:[self class]] && ![view isEqual:self] &&
+@@ -983,6 +997,10 @@ void ExtractUnderlines(NSAttributedString* string,
                                eventType == NSKeyDown &&
                                !(modifierFlags & NSCommandKeyMask);
  
@@ -46,7 +59,7 @@ index c7fb942367100b7a371d8941c73fc608a1a39435..ab0e620e824e0a0df93b12d2ff42cc19
    // We only handle key down events and just simply forward other events.
    if (eventType != NSKeyDown) {
      _hostHelper->ForwardKeyboardEvent(event, latency_info);
-@@ -1759,9 +1771,11 @@ void ExtractUnderlines(NSAttributedString* string,
+@@ -1759,9 +1777,11 @@ void ExtractUnderlines(NSAttributedString* string,
  // Since this implementation doesn't have to wait any IPC calls, this doesn't
  // make any key-typing jank. --hbono 7/23/09
  //
@@ -58,7 +71,7 @@ index c7fb942367100b7a371d8941c73fc608a1a39435..ab0e620e824e0a0df93b12d2ff42cc19
  
  - (NSArray*)validAttributesForMarkedText {
    // This code is just copied from WebKit except renaming variables.
-@@ -1770,7 +1784,10 @@ extern NSString* NSTextInputReplacementRangeAttributeName;
+@@ -1770,7 +1790,10 @@ extern NSString* NSTextInputReplacementRangeAttributeName;
          initWithObjects:NSUnderlineStyleAttributeName,
                          NSUnderlineColorAttributeName,
                          NSMarkedClauseSegmentAttributeName,

--- a/shell/browser/native_browser_view_mac.mm
+++ b/shell/browser/native_browser_view_mac.mm
@@ -34,10 +34,16 @@ const NSAutoresizingMaskOptions kDefaultAutoResizingMask =
   return NO;
 }
 
-- (NSView*)hitTest:(NSPoint)aPoint {
-  // Pass-through events that don't hit one of the exclusion zones
+- (BOOL)shouldIgnoreMouseEvent {
+  NSEventType type = [[NSApp currentEvent] type];
+  return type != NSEventTypeLeftMouseDragged &&
+         type != NSEventTypeLeftMouseDown;
+}
+
+- (NSView*)hitTest:(NSPoint)point {
+  // Pass-through events that hit one of the exclusion zones
   for (NSView* exclusion_zones in [self subviews]) {
-    if ([exclusion_zones hitTest:aPoint])
+    if ([exclusion_zones hitTest:point])
       return nil;
   }
 
@@ -45,6 +51,8 @@ const NSAutoresizingMaskOptions kDefaultAutoResizingMask =
 }
 
 - (void)mouseDown:(NSEvent*)event {
+  [super mouseDown:event];
+
   if ([self.window respondsToSelector:@selector(performWindowDragWithEvent)]) {
     // According to Google, using performWindowDragWithEvent:
     // does not generate a NSWindowWillMoveNotification. Hence post one.
@@ -65,7 +73,7 @@ const NSAutoresizingMaskOptions kDefaultAutoResizingMask =
   self.initialLocation = [event locationInWindow];
 }
 
-- (void)mouseDragged:(NSEvent*)theEvent {
+- (void)mouseDragged:(NSEvent*)event {
   if ([self.window respondsToSelector:@selector(performWindowDragWithEvent)]) {
     return;
   }
@@ -125,15 +133,13 @@ const NSAutoresizingMaskOptions kDefaultAutoResizingMask =
   [self.window setFrameOrigin:newOrigin];
 }
 
-// Debugging tips:
-// Uncomment the following four lines to color DragRegionView bright red
-// #ifdef DEBUG_DRAG_REGIONS
-// - (void)drawRect:(NSRect)aRect
-// {
-//     [[NSColor redColor] set];
-//     NSRectFill([self bounds]);
-// }
-// #endif
+// For debugging purposes only.
+- (void)drawRect:(NSRect)aRect {
+  if (getenv("ELECTRON_DEBUG_DRAG_REGIONS")) {
+    [[[NSColor greenColor] colorWithAlphaComponent:0.5] set];
+    NSRectFill([self bounds]);
+  }
+}
 
 @end
 
@@ -146,15 +152,13 @@ const NSAutoresizingMaskOptions kDefaultAutoResizingMask =
   return NO;
 }
 
-// Debugging tips:
-// Uncomment the following four lines to color ExcludeDragRegionView bright red
-// #ifdef DEBUG_DRAG_REGIONS
-// - (void)drawRect:(NSRect)aRect
-// {
-//     [[NSColor greenColor] set];
-//     NSRectFill([self bounds]);
-// }
-// #endif
+// For debugging purposes only.
+- (void)drawRect:(NSRect)aRect {
+  if (getenv("ELECTRON_DEBUG_DRAG_REGIONS")) {
+    [[[NSColor redColor] colorWithAlphaComponent:0.5] set];
+    NSRectFill([self bounds]);
+  }
+}
 
 @end
 


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/26496.

See that PR for details.

Notes: Fixed an issue where some buttons were un-clickable in some BrowserViews with draggable regions enabled. 