### PR TITLE
fix: renderer crash on setImmediate

### DIFF
--- a/spec-main/fixtures/crash-cases/setimmediate-renderer-crash/index.js
+++ b/spec-main/fixtures/crash-cases/setimmediate-renderer-crash/index.js
@@ -1,0 +1,22 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+app.whenReady().then(() => {
+  const win = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      preload: path.resolve(__dirname, 'preload.js')
+    }
+  });
+
+  win.loadURL('about:blank');
+
+  win.webContents.on('render-process-gone', () => {
+    process.exit(1);
+  });
+
+  win.webContents.on('did-finish-load', () => {
+    setTimeout(() => app.quit());
+  });
+});

--- a/spec-main/fixtures/crash-cases/setimmediate-renderer-crash/preload.js
+++ b/spec-main/fixtures/crash-cases/setimmediate-renderer-crash/preload.js
@@ -1,0 +1,3 @@
+setImmediate(() => {
+  throw new Error('oh no');
+});


### PR DESCRIPTION
Backport of #26365.

See that PR for details.

Notes: Fixes an issue whereby a corrupted `async_hooks` stack would crash the renderer when throwing some errors in the renderer process.