### PR TITLE
fix: internalModuleReadJSON for unpacked JSON

### DIFF
--- a/lib/asar/fs-wrapper.ts
+++ b/lib/asar/fs-wrapper.ts
@@ -689,7 +689,8 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     if (info.size === 0) return ['', false];
     if (info.unpacked) {
       const realPath = archive.copyFileOut(filePath);
-      return fs.readFileSync(realPath, { encoding: 'utf8' });
+      const str = fs.readFileSync(realPath, { encoding: 'utf8' });
+      return [str, str.length > 0];
     }
 
     logASARAccess(asarPath, filePath, info.offset);

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -1444,7 +1444,8 @@ describe('asar package', function () {
 
       it('reads a normal file with unpacked files', function () {
         const p = path.join(asarDir, 'unpack.asar', 'a.txt');
-        expect(internalModuleReadJSON(p).toString().trim()).to.equal('a');
+        const [s, c] = internalModuleReadJSON(p);
+        expect([s.toString().trim(), c]).to.eql(['a', true]);
       });
     });
 


### PR DESCRIPTION
#### Description of Change

For some reasons, one `return` statement wasn't updated to the new output type consisting of an array in the next PR: https://github.com/electron/electron/pull/24707/files#diff-0c073d40320d69e1a416d4610fa7720f374be5f0d28ff9a0d8ad9c34b358e192R685

This broke import of modules which `package.json` is unpacked.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed import of unpacked node modules.
