### PR TITLE
fix: properly emit after hooks after exception

### DIFF
--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -176,14 +176,18 @@ void ErrorMessageListener(v8::Local<v8::Message> message,
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   node::Environment* env = node::Environment::GetCurrent(isolate);
 
-  // TODO(codebytere): properly emit the after() hooks now
-  // that the exception has been handled.
-  // See node/lib/internal/process/execution.js#L176-L180
-
-  // Ensure that the async id stack is properly cleared so the async
-  // hook stack does not become corrupted.
-
   if (env) {
+    // Emit the after() hooks now that the exception has been handled.
+    // Analogous to node/lib/internal/process/execution.js#L176-L180
+    if (env->async_hooks()->fields()[node::AsyncHooks::kAfter]) {
+      while (env->async_hooks()->fields()[node::AsyncHooks::kStackLength]) {
+        node::AsyncWrap::EmitAfter(env, env->execution_async_id());
+        env->async_hooks()->pop_async_context(env->execution_async_id());
+      }
+    }
+
+    // Ensure that the async id stack is properly cleared so the async
+    // hook stack does not become corrupted.
     env->async_hooks()->clear_async_id_stack();
   }
 }


### PR DESCRIPTION
#### Description of Change

Addresses an outstanding TODO of mine. We should be properly emitting the after() `async_hooks` when an exception has been handled in the renderer process. This is done in Node.js [here](https://github.com/nodejs/node/blob/ddff2b2b22c5b7691c100ad4eea07ca926bcea05/lib/internal/process/execution.js#L182-L187).

cc @zcbenz @nornagon @jkleinsc 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where some `async_hooks` were not properly emitted after an error in the renderer process.