### PR TITLE
build: fix missing dependency resulting in a random build failure

### DIFF
--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -83,7 +83,8 @@ static_library("chrome") {
     "//components/proxy_config",
     "//components/security_state/content",
     "//content/public/browser",
-    "//electron:packed_resources",
+    "//services/strings",
+    "//chrome/browser:dev_ui_browser_resources",
   ]
 
   deps = [

--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -83,6 +83,7 @@ static_library("chrome") {
     "//components/proxy_config",
     "//components/security_state/content",
     "//content/public/browser",
+    "//electron:packed_resources",
   ]
 
   deps = [

--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -76,6 +76,7 @@ static_library("chrome") {
   }
 
   public_deps = [
+    "//chrome/browser:dev_ui_browser_resources",
     "//chrome/common",
     "//chrome/common:version_header",
     "//components/keyed_service/content",
@@ -84,7 +85,6 @@ static_library("chrome") {
     "//components/security_state/content",
     "//content/public/browser",
     "//services/strings",
-    "//chrome/browser:dev_ui_browser_resources",
   ]
 
   deps = [


### PR DESCRIPTION
#### Description of Change

* build: Some files from the //electron/chromium_src:chrome #include generated resources, since the target doesn't depend on them, we get random build failures, compare:
`[18/10847] CXX obj/electron/chromium_src/chrome/chrome_mojo_proxy_resolver_factory.obj
FAILED: obj/electron/chromium_src/chrome/chrome_mojo_proxy_resolver_factory.obj
e:\clones\of-master\src\electron\external_binaries\sccache ..\..\third_party\llvm-build\Release+Asserts\bin\clang-cl.exe /nologo ...
../../chrome/browser/net/chrome_mojo_proxy_resolver_factory.cc(25,10): fatal error: 'services/strings/grit/services_strings.h' file not found
#include "services/strings/grit/services_strings.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
[22/10847] CXX obj/electron/chromium_src/chrome/accessibility_ui.obj
FAILED: obj/electron/chromium_src/chrome/accessibility_ui.obj
e:\clones\of-master\src\electron\external_binaries\sccache ..\..\third_party\llvm-build\Release+Asserts\bin\clang-cl.exe /nologo ...
../../chrome/browser/accessibility/accessibility_ui.cc(28,10): fatal error: 'chrome/grit/dev_ui_browser_resources.h' file not found
#include "chrome/grit/dev_ui_browser_resources.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
[43/10847] CXX obj/electron/chromium_src/chrome/preconnect_manager.obj
ninja: build stopped: subcommand failed.`

#### Checklist

- [ ] PR description included and stakeholders cc'd

#### Release Notes

Notes: None
