### PR TITLE
chore: remove unused sendToAll + related APIs

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -131,10 +131,7 @@ WebContents.prototype.send = function (channel, ...args) {
     throw new Error('Missing required channel argument');
   }
 
-  const internal = false;
-  const sendToAll = false;
-
-  return this._send(internal, sendToAll, channel, args);
+  return this._send(false /* internal */, channel, args);
 };
 
 WebContents.prototype.postMessage = function (...args) {
@@ -149,20 +146,7 @@ WebContents.prototype._sendInternal = function (channel, ...args) {
     throw new Error('Missing required channel argument');
   }
 
-  const internal = true;
-  const sendToAll = false;
-
-  return this._send(internal, sendToAll, channel, args);
-};
-WebContents.prototype._sendInternalToAll = function (channel, ...args) {
-  if (typeof channel !== 'string') {
-    throw new Error('Missing required channel argument');
-  }
-
-  const internal = true;
-  const sendToAll = true;
-
-  return this._send(internal, sendToAll, channel, args);
+  return this._send(true /* internal */, channel, args);
 };
 WebContents.prototype.sendToFrame = function (frameId, channel, ...args) {
   if (typeof channel !== 'string') {
@@ -171,10 +155,7 @@ WebContents.prototype.sendToFrame = function (frameId, channel, ...args) {
     throw new Error('Missing required frameId argument');
   }
 
-  const internal = false;
-  const sendToAll = false;
-
-  return this._sendToFrame(internal, sendToAll, frameId, channel, args);
+  return this._sendToFrame(false /* internal */, frameId, channel, args);
 };
 WebContents.prototype._sendToFrameInternal = function (frameId, channel, ...args) {
   if (typeof channel !== 'string') {
@@ -183,10 +164,7 @@ WebContents.prototype._sendToFrameInternal = function (frameId, channel, ...args
     throw new Error('Missing required frameId argument');
   }
 
-  const internal = true;
-  const sendToAll = false;
-
-  return this._sendToFrame(internal, sendToAll, frameId, channel, args);
+  return this._sendToFrame(true /* internal */, frameId, channel, args);
 };
 
 // Following methods are mapped to webFrame.
@@ -199,7 +177,7 @@ const webFrameMethods = [
 
 for (const method of webFrameMethods) {
   WebContents.prototype[method] = function (...args: any[]): Promise<any> {
-    return ipcMainUtils.invokeInWebContents(this, false, IPC_MESSAGES.RENDERER_WEB_FRAME_METHOD, method, ...args);
+    return ipcMainUtils.invokeInWebContents(this, IPC_MESSAGES.RENDERER_WEB_FRAME_METHOD, method, ...args);
   };
 }
 
@@ -217,11 +195,11 @@ const waitTillCanExecuteJavaScript = async (webContents: Electron.WebContents) =
 // WebContents has been loaded.
 WebContents.prototype.executeJavaScript = async function (code, hasUserGesture) {
   await waitTillCanExecuteJavaScript(this);
-  return ipcMainUtils.invokeInWebContents(this, false, IPC_MESSAGES.RENDERER_WEB_FRAME_METHOD, 'executeJavaScript', String(code), !!hasUserGesture);
+  return ipcMainUtils.invokeInWebContents(this, IPC_MESSAGES.RENDERER_WEB_FRAME_METHOD, 'executeJavaScript', String(code), !!hasUserGesture);
 };
 WebContents.prototype.executeJavaScriptInIsolatedWorld = async function (worldId, code, hasUserGesture) {
   await waitTillCanExecuteJavaScript(this);
-  return ipcMainUtils.invokeInWebContents(this, false, IPC_MESSAGES.RENDERER_WEB_FRAME_METHOD, 'executeJavaScriptInIsolatedWorld', worldId, code, !!hasUserGesture);
+  return ipcMainUtils.invokeInWebContents(this, IPC_MESSAGES.RENDERER_WEB_FRAME_METHOD, 'executeJavaScriptInIsolatedWorld', worldId, code, !!hasUserGesture);
 };
 
 // Translate the options of printToPDF.

--- a/lib/browser/ipc-main-internal-utils.ts
+++ b/lib/browser/ipc-main-internal-utils.ts
@@ -14,7 +14,7 @@ export const handleSync = function <T extends IPCHandler> (channel: string, hand
 
 let nextId = 0;
 
-export function invokeInWebContents<T> (sender: Electron.WebContents, sendToAll: boolean, command: string, ...args: any[]) {
+export function invokeInWebContents<T> (sender: Electron.WebContents, command: string, ...args: any[]) {
   return new Promise<T>((resolve, reject) => {
     const requestId = ++nextId;
     const channel = `${command}_RESPONSE_${requestId}`;
@@ -33,10 +33,6 @@ export function invokeInWebContents<T> (sender: Electron.WebContents, sendToAll:
       }
     });
 
-    if (sendToAll) {
-      sender._sendInternalToAll(command, requestId, ...args);
-    } else {
-      sender._sendInternal(command, requestId, ...args);
-    }
+    sender._sendInternal(command, requestId, ...args);
   });
 }

--- a/lib/renderer/api/ipc-renderer.ts
+++ b/lib/renderer/api/ipc-renderer.ts
@@ -18,7 +18,7 @@ ipcRenderer.sendToHost = function (channel, ...args) {
 };
 
 ipcRenderer.sendTo = function (webContentsId, channel, ...args) {
-  return ipc.sendTo(internal, false, webContentsId, channel, args);
+  return ipc.sendTo(internal, webContentsId, channel, args);
 };
 
 ipcRenderer.invoke = async function (channel, ...args) {

--- a/lib/renderer/ipc-renderer-internal.ts
+++ b/lib/renderer/ipc-renderer-internal.ts
@@ -14,11 +14,7 @@ ipcRendererInternal.sendSync = function (channel, ...args) {
 };
 
 ipcRendererInternal.sendTo = function (webContentsId, channel, ...args) {
-  return ipc.sendTo(internal, false, webContentsId, channel, args);
-};
-
-ipcRendererInternal.sendToAll = function (webContentsId, channel, ...args) {
-  return ipc.sendTo(internal, true, webContentsId, channel, args);
+  return ipc.sendTo(internal, webContentsId, channel, args);
 };
 
 ipcRendererInternal.invoke = async function<T> (channel: string, ...args: any[]) {

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2703,7 +2703,7 @@ bool WebContents::SendIPCMessageWithSender(bool internal,
   auto* frame_host = web_contents()->GetMainFrame();
   mojo::AssociatedRemote<mojom::ElectronRenderer> electron_renderer;
   frame_host->GetRemoteAssociatedInterfaces()->GetInterface(&electron_renderer);
-  electron_renderer->Message(internal, channel, args.ShallowClone(), sender_id);
+  electron_renderer->Message(internal, channel, std::move(args), sender_id);
   return true;
 }
 

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -249,18 +249,15 @@ class WebContents : public gin::Wrappable<WebContents>,
 
   // Send messages to browser.
   bool SendIPCMessage(bool internal,
-                      bool send_to_all,
                       const std::string& channel,
                       v8::Local<v8::Value> args);
 
   bool SendIPCMessageWithSender(bool internal,
-                                bool send_to_all,
                                 const std::string& channel,
                                 blink::CloneableMessage args,
                                 int32_t sender_id = 0);
 
   bool SendIPCMessageToFrame(bool internal,
-                             bool send_to_all,
                              int32_t frame_id,
                              const std::string& channel,
                              v8::Local<v8::Value> args);
@@ -619,7 +616,6 @@ class WebContents : public gin::Wrappable<WebContents>,
                    blink::CloneableMessage arguments,
                    MessageSyncCallback callback) override;
   void MessageTo(bool internal,
-                 bool send_to_all,
                  int32_t web_contents_id,
                  const std::string& channel,
                  blink::CloneableMessage arguments) override;

--- a/shell/common/api/api.mojom
+++ b/shell/common/api/api.mojom
@@ -8,7 +8,6 @@ import "third_party/blink/public/mojom/messaging/transferable_message.mojom";
 interface ElectronRenderer {
   Message(
       bool internal,
-      bool send_to_all,
       string channel,
       blink.mojom.CloneableMessage arguments,
       int32 sender_id);
@@ -67,7 +66,6 @@ interface ElectronBrowser {
   // WebContents's main frame, specified by |web_contents_id|.
   MessageTo(
     bool internal,
-    bool send_to_all,
     int32 web_contents_id,
     string channel,
     blink.mojom.CloneableMessage arguments);

--- a/shell/renderer/api/electron_api_ipc_renderer.cc
+++ b/shell/renderer/api/electron_api_ipc_renderer.cc
@@ -172,7 +172,6 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
   void SendTo(v8::Isolate* isolate,
               gin_helper::ErrorThrower thrower,
               bool internal,
-              bool send_to_all,
               int32_t web_contents_id,
               const std::string& channel,
               v8::Local<v8::Value> arguments) {
@@ -184,8 +183,8 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
     if (!electron::SerializeV8Value(isolate, arguments, &message)) {
       return;
     }
-    electron_browser_remote_->MessageTo(internal, send_to_all, web_contents_id,
-                                        channel, std::move(message));
+    electron_browser_remote_->MessageTo(internal, web_contents_id, channel,
+                                        std::move(message));
   }
 
   void SendToHost(v8::Isolate* isolate,

--- a/shell/renderer/electron_api_service_impl.cc
+++ b/shell/renderer/electron_api_service_impl.cc
@@ -132,7 +132,6 @@ void ElectronApiServiceImpl::OnConnectionError() {
 }
 
 void ElectronApiServiceImpl::Message(bool internal,
-                                     bool send_to_all,
                                      const std::string& channel,
                                      blink::CloneableMessage arguments,
                                      int32_t sender_id) {
@@ -168,18 +167,6 @@ void ElectronApiServiceImpl::Message(bool internal,
   v8::Local<v8::Value> args = gin::ConvertToV8(isolate, arguments);
 
   EmitIPCEvent(context, internal, channel, {}, args, sender_id);
-
-  // Also send the message to all sub-frames.
-  // TODO(MarshallOfSound): Completely move this logic to the main process
-  if (send_to_all) {
-    for (blink::WebFrame* child = frame->FirstChild(); child;
-         child = child->NextSibling())
-      if (child->IsWebLocalFrame()) {
-        v8::Local<v8::Context> child_context =
-            renderer_client_->GetContext(child->ToWebLocalFrame(), isolate);
-        EmitIPCEvent(child_context, internal, channel, {}, args, sender_id);
-      }
-  }
 }
 
 void ElectronApiServiceImpl::ReceivePostMessage(

--- a/shell/renderer/electron_api_service_impl.h
+++ b/shell/renderer/electron_api_service_impl.h
@@ -29,7 +29,6 @@ class ElectronApiServiceImpl : public mojom::ElectronRenderer,
       mojo::PendingAssociatedReceiver<mojom::ElectronRenderer> receiver);
 
   void Message(bool internal,
-               bool send_to_all,
                const std::string& channel,
                blink::CloneableMessage arguments,
                int32_t sender_id) override;

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -32,7 +32,7 @@ declare namespace NodeJS {
     send(internal: boolean, channel: string, args: any[]): void;
     sendSync(internal: boolean, channel: string, args: any[]): any;
     sendToHost(channel: string, args: any[]): void;
-    sendTo(internal: boolean, sendToAll: boolean, webContentsId: number, channel: string, args: any[]): void;
+    sendTo(internal: boolean, webContentsId: number, channel: string, args: any[]): void;
     invoke<T>(internal: boolean, channel: string, args: any[]): Promise<{ error: string, result: T }>;
     postMessage(channel: string, message: any, transferables: MessagePort[]): void;
   }

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -67,12 +67,11 @@ declare namespace Electron {
     _windowOpenHandler: ((opts: {url: string, frameName: string, features: string}) => any) | null;
     _callWindowOpenHandler(event: any, url: string, frameName: string, rawFeatures: string): Electron.BrowserWindowConstructorOptions | null;
     _setNextChildWebPreferences(prefs: Partial<Electron.BrowserWindowConstructorOptions['webPreferences']> & Pick<Electron.BrowserWindowConstructorOptions, 'backgroundColor'>): void;
-    _send(internal: boolean, sendToAll: boolean, channel: string, args: any): boolean;
-    _sendToFrame(internal: boolean, sendToAll: boolean, frameId: number, channel: string, args: any): boolean;
+    _send(internal: boolean, channel: string, args: any): boolean;
+    _sendToFrame(internal: boolean, frameId: number, channel: string, args: any): boolean;
     _sendToFrameInternal(frameId: number, channel: string, ...args: any[]): boolean;
     _postMessage(channel: string, message: any, transfer?: any[]): void;
     _sendInternal(channel: string, ...args: any[]): void;
-    _sendInternalToAll(channel: string, ...args: any[]): void;
     _printToPDF(options: any): Promise<Buffer>;
     _print(options: any, callback?: (success: boolean, failureReason: string) => void): void;
     _getPrinters(): Electron.PrinterInfo[];
@@ -232,7 +231,6 @@ declare namespace ElectronInternal {
 
   interface IpcRendererInternal extends Electron.IpcRenderer {
     invoke<T>(channel: string, ...args: any[]): Promise<T>;
-    sendToAll(webContentsId: number, channel: string, ...args: any[]): void;
     onMessageFromMain(channel: string, listener: (event: Electron.IpcRendererEvent, ...args: any[]) => void): this;
     onceMessageFromMain(channel: string, listener: (event: Electron.IpcRendererEvent, ...args: any[]) => void): this;
   }


### PR DESCRIPTION
#### Description of Change
No longer needed after the native Chrome extensions support has landed.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes