### PR TITLE
fix: add check in IsMaximized for non-WS_THICKFRAME windows

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -530,6 +530,20 @@ void NativeWindowViews::Unmaximize() {
 }
 
 bool NativeWindowViews::IsMaximized() {
+  // For window without WS_THICKFRAME style, we can not call IsMaximized().
+  // This path will be used for transparent windows as well.
+
+#if defined(OS_WIN)
+  if (!(::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE) & WS_THICKFRAME)) {
+    // Compare the size of the window with the size of the display
+    auto display = display::Screen::GetScreen()->GetDisplayNearestWindow(
+        GetNativeWindow());
+    // Maximized if the window is the same dimensions and placement as the
+    // display
+    return GetBounds() == display.work_area();
+  }
+#endif
+
   return widget()->IsMaximized();
 }
 

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -149,9 +149,7 @@ std::set<NativeWindowViews*> NativeWindowViews::forwarding_windows_;
 HHOOK NativeWindowViews::mouse_hook_ = NULL;
 
 void NativeWindowViews::Maximize() {
-  // Only use Maximize() when:
-  // 1. window has WS_THICKFRAME style;
-  // 2. and window is not frameless when there is autohide taskbar.
+  // Only use Maximize() when window has WS_THICKFRAME style
   if (::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE) & WS_THICKFRAME) {
     if (IsVisible())
       widget()->Maximize();
@@ -161,8 +159,8 @@ void NativeWindowViews::Maximize() {
     return;
   } else {
     restore_bounds_ = GetBounds();
-    auto display =
-        display::Screen::GetScreen()->GetDisplayNearestPoint(GetPosition());
+    auto display = display::Screen::GetScreen()->GetDisplayNearestWindow(
+        GetNativeWindow());
     SetBounds(display.work_area(), false);
   }
 }

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1059,6 +1059,25 @@ describe('BrowserWindow module', () => {
           await unmaximize;
           expectBoundsEqual(w.getNormalBounds(), bounds);
         });
+        it('can check transparent window maximization', async () => {
+          w.destroy();
+          w = new BrowserWindow({
+            show: false,
+            width: 300,
+            height: 300,
+            transparent: true
+          });
+
+          const maximize = emittedOnce(w, 'resize');
+          w.show();
+          w.maximize();
+          await maximize;
+          expect(w.isMaximized()).to.equal(true);
+          const unmaximize = emittedOnce(w, 'resize');
+          w.unmaximize();
+          await unmaximize;
+          expect(w.isMaximized()).to.equal(false);
+        });
       });
 
       ifdescribe(process.platform !== 'linux')('Minimized state', () => {


### PR DESCRIPTION
#### Description of Change

Backport of #26586

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where IsMaximized would incorrectly return false for some windows on Windows.