### PR TITLE
feat: add missing 'context-menu' values

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -687,7 +687,6 @@ Returns:
     * `canPaste` Boolean - Whether the renderer believes it can paste.
     * `canDelete` Boolean - Whether the renderer believes it can delete.
     * `canSelectAll` Boolean - Whether the renderer believes it can select all.
-    * `canTranslate` Boolean - Whether the renderer believes it can perform translation.
     * `canEditRichly` Boolean - Whether the renderer believes it can edit text richly.
 
 Emitted when there is a new context menu that needs to be handled.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -673,6 +673,7 @@ Returns:
     * `canToggleControls` Boolean - Whether the media element's controls are
       toggleable.
     * `canPrint` Boolean - Whether the media element can be printed.
+    * `canSave` Boolean - Whether or not the media element can be downloaded.
     * `canShowPictureInPicture` Boolean - Whether the media element can show picture-in-picture.
     * `isShowingPictureInPicture` Boolean - Whether the media element is currently showing picture-in-picture.
     * `canRotate` Boolean - Whether the media element can be rotated.
@@ -682,7 +683,7 @@ Returns:
     * `canUndo` Boolean - Whether the renderer believes it can undo.
     * `canRedo` Boolean - Whether the renderer believes it can redo.
     * `canCut` Boolean - Whether the renderer believes it can cut.
-    * `canCopy` Boolean - Whether the renderer believes it can copy
+    * `canCopy` Boolean - Whether the renderer believes it can copy.
     * `canPaste` Boolean - Whether the renderer believes it can paste.
     * `canDelete` Boolean - Whether the renderer believes it can delete.
     * `canSelectAll` Boolean - Whether the renderer believes it can select all.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -640,8 +640,15 @@ Returns:
   * `isEditable` Boolean - Whether the context is editable.
   * `selectionText` String - Text of the selection that the context menu was
     invoked on.
-  * `titleText` String - Title or alt text of the selection that the context
-    was invoked on.
+  * `titleText` String - Title text of the selection that the context menu was
+    invoked on.
+  * `altText` String - Alt text of the selection that the context menu was
+    invoked on.
+  * `suggestedFilename` String - Suggested filename to be used when saving file through 'Save
+    Link As' option of context menu.
+  * `selectionRect` [Rectangle](structures/rectangle.md) - Rect representing the coordinates in the document space of the selection.
+  * `selectionStartOffset` Number - Start position of the selection text.
+  * `referrerPolicy` [Referrer](structures/referrer.md) - The referrer policy of the frame on which the menu is invoked.
   * `misspelledWord` String - The misspelled word under the cursor, if any.
   * `dictionarySuggestions` String[] - An array of suggested words to show the
     user to replace the `misspelledWord`.  Only available if there is a misspelled
@@ -651,8 +658,9 @@ Returns:
   * `inputFieldType` String - If the context menu was invoked on an input
     field, the type of that field. Possible values are `none`, `plainText`,
     `password`, `other`.
+  * `spellcheckEnabled` Boolean - If the context is editable, whether or not spellchecking is enabled.
   * `menuSourceType` String - Input source that invoked the context menu.
-    Can be `none`, `mouse`, `keyboard`, `touch` or `touchMenu`.
+    Can be `none`, `mouse`, `keyboard`, `touch`, `touchMenu`, `longPress`, `longTap`, `touchHandle`, `stylus`, `adjustSelection`, or `adjustSelectionReset`.
   * `mediaFlags` Object - The flags for the media element the context menu was
     invoked on.
     * `inError` Boolean - Whether the media element has crashed.
@@ -664,7 +672,11 @@ Returns:
       visible.
     * `canToggleControls` Boolean - Whether the media element's controls are
       toggleable.
+    * `canPrint` Boolean - Whether the media element can be printed.
+    * `canShowPictureInPicture` Boolean - Whether the media element can show picture-in-picture.
+    * `isShowingPictureInPicture` Boolean - Whether the media element is currently showing picture-in-picture.
     * `canRotate` Boolean - Whether the media element can be rotated.
+    * `canLoop` Boolean - Whether the media element can be looped.
   * `editFlags` Object - These flags indicate whether the renderer believes it
     is able to perform the corresponding action.
     * `canUndo` Boolean - Whether the renderer believes it can undo.
@@ -674,6 +686,8 @@ Returns:
     * `canPaste` Boolean - Whether the renderer believes it can paste.
     * `canDelete` Boolean - Whether the renderer believes it can delete.
     * `canSelectAll` Boolean - Whether the renderer believes it can select all.
+    * `canTranslate` Boolean - Whether the renderer believes it can perform translation.
+    * `canEditRichly` Boolean - Whether the renderer believes it can edit text richly.
 
 Emitted when there is a new context menu that needs to be handled.
 

--- a/shell/common/gin_converters/blink_converter.cc
+++ b/shell/common/gin_converters/blink_converter.cc
@@ -385,8 +385,6 @@ v8::Local<v8::Value> EditFlagsToV8(v8::Isolate* isolate, int editFlags) {
            !!(editFlags & blink::ContextMenuDataEditFlags::kCanDelete));
   dict.Set("canSelectAll",
            !!(editFlags & blink::ContextMenuDataEditFlags::kCanSelectAll));
-  dict.Set("canTranslate",
-           !!(editFlags & blink::ContextMenuDataEditFlags::kCanTranslate));
   dict.Set("canEditRichly",
            !!(editFlags & blink::ContextMenuDataEditFlags::kCanEditRichly));
 

--- a/shell/common/gin_converters/blink_converter.cc
+++ b/shell/common/gin_converters/blink_converter.cc
@@ -385,6 +385,10 @@ v8::Local<v8::Value> EditFlagsToV8(v8::Isolate* isolate, int editFlags) {
            !!(editFlags & blink::ContextMenuDataEditFlags::kCanDelete));
   dict.Set("canSelectAll",
            !!(editFlags & blink::ContextMenuDataEditFlags::kCanSelectAll));
+  dict.Set("canTranslate",
+           !!(editFlags & blink::ContextMenuDataEditFlags::kCanTranslate));
+  dict.Set("canEditRichly",
+           !!(editFlags & blink::ContextMenuDataEditFlags::kCanEditRichly));
 
   return ConvertToV8(isolate, dict);
 }
@@ -396,16 +400,26 @@ v8::Local<v8::Value> MediaFlagsToV8(v8::Isolate* isolate, int mediaFlags) {
   dict.Set("isPaused",
            !!(mediaFlags & blink::WebContextMenuData::kMediaPaused));
   dict.Set("isMuted", !!(mediaFlags & blink::WebContextMenuData::kMediaMuted));
+  dict.Set("canSave",
+           !!(mediaFlags & blink::WebContextMenuData::kMediaCanSave));
   dict.Set("hasAudio",
            !!(mediaFlags & blink::WebContextMenuData::kMediaHasAudio));
-  dict.Set("isLooping",
-           (mediaFlags & blink::WebContextMenuData::kMediaLoop) != 0);
+  dict.Set("isLooping", !!(mediaFlags & blink::WebContextMenuData::kMediaLoop));
   dict.Set("isControlsVisible",
-           (mediaFlags & blink::WebContextMenuData::kMediaControls) != 0);
+           !!(mediaFlags & blink::WebContextMenuData::kMediaControls));
   dict.Set("canToggleControls",
            !!(mediaFlags & blink::WebContextMenuData::kMediaCanToggleControls));
+  dict.Set("canPrint",
+           !!(mediaFlags & blink::WebContextMenuData::kMediaCanPrint));
   dict.Set("canRotate",
            !!(mediaFlags & blink::WebContextMenuData::kMediaCanRotate));
+  dict.Set(
+      "canShowPictureInPicture",
+      !!(mediaFlags & blink::WebContextMenuData::kMediaCanPictureInPicture));
+  dict.Set("isShowingPictureInPicture",
+           !!(mediaFlags & blink::WebContextMenuData::kMediaPictureInPicture));
+  dict.Set("canLoop",
+           !!(mediaFlags & blink::WebContextMenuData::kMediaCanLoop));
   return ConvertToV8(isolate, dict);
 }
 

--- a/shell/common/gin_converters/content_converter.cc
+++ b/shell/common/gin_converters/content_converter.cc
@@ -15,6 +15,7 @@
 #include "shell/browser/web_contents_permission_helper.h"
 #include "shell/common/gin_converters/blink_converter.h"
 #include "shell/common/gin_converters/callback_converter.h"
+#include "shell/common/gin_converters/gfx_converter.h"
 #include "shell/common/gin_converters/gurl_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "ui/events/keycodes/dom/keycode_converter.h"
@@ -90,6 +91,18 @@ struct Converter<ui::MenuSourceType> {
         return StringToV8(isolate, "touch");
       case ui::MENU_SOURCE_TOUCH_EDIT_MENU:
         return StringToV8(isolate, "touchMenu");
+      case ui::MENU_SOURCE_LONG_PRESS:
+        return StringToV8(isolate, "longPress");
+      case ui::MENU_SOURCE_LONG_TAP:
+        return StringToV8(isolate, "longTap");
+      case ui::MENU_SOURCE_TOUCH_HANDLE:
+        return StringToV8(isolate, "touchHandle");
+      case ui::MENU_SOURCE_STYLUS:
+        return StringToV8(isolate, "stylus");
+      case ui::MENU_SOURCE_ADJUST_SELECTION:
+        return StringToV8(isolate, "adjustSelection");
+      case ui::MENU_SOURCE_ADJUST_SELECTION_RESET:
+        return StringToV8(isolate, "adjustSelectionReset");
       default:
         return StringToV8(isolate, "none");
     }
@@ -138,11 +151,18 @@ v8::Local<v8::Value> Converter<ContextMenuParamsWithWebContents>::ToV8(
   dict.Set("editFlags", EditFlagsToV8(isolate, params.edit_flags));
   dict.Set("selectionText", params.selection_text);
   dict.Set("titleText", params.title_text);
+  dict.Set("altText", params.alt_text);
+  dict.Set("suggestedFilename", params.suggested_filename);
   dict.Set("misspelledWord", params.misspelled_word);
+  dict.Set("selectionRect", params.selection_rect);
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
   dict.Set("dictionarySuggestions", params.dictionary_suggestions);
+  dict.Set("spellcheckEnabled", params.spellcheck_enabled);
+#else
+  dict.Set("spellcheckEnabled", false);
 #endif
   dict.Set("frameCharset", params.frame_charset);
+  dict.Set("referrerPolicy", params.referrer_policy);
   dict.Set("inputFieldType", params.input_field_type);
   dict.Set("menuSourceType", params.source_type);
 


### PR DESCRIPTION
#### Description of Change

This PR fills in a nontrivial amount of data missing from the object emitted by the 'context-menu' event. It'd been a significant amount of time since this was last updated, so a number of fields have been added to the object which may be useful to users handling the event and which we should therefore expose.

cc @zcbenz @jkleinsc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added missing fields to the parameters emitted as part of the `context-menu` event.