### PR TITLE
fix: add port / user information in standard schemes

### DIFF
--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -96,7 +96,7 @@ non-standard schemes can not recognize relative URLs:
 
 Registering a scheme as standard will allow access to files through the
 [FileSystem API][file-system-api]. Otherwise the renderer will throw a security
-error for the scheme.
+error for the scheme. It will also allow the scheme to contain a port and user information.
 
 By default web storage apis (localStorage, sessionStorage, webSQL, indexedDB,
 cookies) are disabled for non standard schemes. So in general if you want to

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -103,7 +103,7 @@ void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
     if (custom_scheme.options.standard) {
       auto* policy = content::ChildProcessSecurityPolicy::GetInstance();
       url::AddStandardScheme(custom_scheme.scheme.c_str(),
-                             url::SCHEME_WITH_HOST);
+                             url::SCHEME_WITH_HOST_PORT_AND_USER_INFORMATION);
       g_standard_schemes.push_back(custom_scheme.scheme);
       policy->RegisterWebSafeScheme(custom_scheme.scheme);
     }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Fixes #24725 by registering standard schemes as having host and username fields.

This issue was breaking support for `gemini://` URLs

What's the best way to add a test for this use case?

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Custom protocol schemes can now have ports and user information
<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
