### PR TITLE
fix: screen EventEmitter methods with remote

### DIFF
--- a/lib/browser/api/screen.ts
+++ b/lib/browser/api/screen.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from 'events';
+
 const { createScreen } = process._linkedBinding('electron_common_screen');
 
 let _screen: Electron.Screen;
@@ -36,5 +38,11 @@ export default new Proxy({}, {
   getOwnPropertyDescriptor: (target, property: string) => {
     createScreenIfNeeded();
     return Reflect.getOwnPropertyDescriptor(_screen, property);
+  },
+  getPrototypeOf: () => {
+    // This is necessary as a result of weirdness with EventEmitterMixin
+    // and FunctionTemplate - we need to explicitly ensure it's returned
+    // in the prototype.
+    return EventEmitter.prototype;
   }
 });


### PR DESCRIPTION
#### Description of Change

Follow-up to https://github.com/electron/electron/pull/26620.
Closes https://github.com/electron/electron/issues/26713.

Fixes an issue whereby `remote.screen` EventEmitter methods are undefined in the renderer. This is fixed by implementing `getPrototypeOf` as a Proxy trap.

cc @nornagon @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue whereby `remote.screen` `EventEmitter` methods are undefined in the renderer. 
