### PR TITLE
chore: remove unused sendToAll on renderer side

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -171,10 +171,7 @@ WebContents.prototype.sendToFrame = function (frameId, channel, ...args) {
     throw new Error('Missing required frameId argument');
   }
 
-  const internal = false;
-  const sendToAll = false;
-
-  return this._sendToFrame(internal, sendToAll, frameId, channel, args);
+  return this._sendToFrame(false /* internal */, frameId, channel, args);
 };
 WebContents.prototype._sendToFrameInternal = function (frameId, channel, ...args) {
   if (typeof channel !== 'string') {
@@ -183,10 +180,7 @@ WebContents.prototype._sendToFrameInternal = function (frameId, channel, ...args
     throw new Error('Missing required frameId argument');
   }
 
-  const internal = true;
-  const sendToAll = false;
-
-  return this._sendToFrame(internal, sendToAll, frameId, channel, args);
+  return this._sendToFrame(true /* internal */, frameId, channel, args);
 };
 
 // Following methods are mapped to webFrame.

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2718,14 +2718,13 @@ bool WebContents::SendIPCMessageWithSender(bool internal,
     mojo::AssociatedRemote<mojom::ElectronRenderer> electron_renderer;
     frame_host->GetRemoteAssociatedInterfaces()->GetInterface(
         &electron_renderer);
-    electron_renderer->Message(internal, false, channel, args.ShallowClone(),
+    electron_renderer->Message(internal, channel, args.ShallowClone(),
                                sender_id);
   }
   return true;
 }
 
 bool WebContents::SendIPCMessageToFrame(bool internal,
-                                        bool send_to_all,
                                         int32_t frame_id,
                                         const std::string& channel,
                                         v8::Local<v8::Value> args) {
@@ -2747,7 +2746,7 @@ bool WebContents::SendIPCMessageToFrame(bool internal,
 
   mojo::AssociatedRemote<mojom::ElectronRenderer> electron_renderer;
   (*iter)->GetRemoteAssociatedInterfaces()->GetInterface(&electron_renderer);
-  electron_renderer->Message(internal, send_to_all, channel, std::move(message),
+  electron_renderer->Message(internal, channel, std::move(message),
                              0 /* sender_id */);
   return true;
 }

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -260,7 +260,6 @@ class WebContents : public gin::Wrappable<WebContents>,
                                 int32_t sender_id = 0);
 
   bool SendIPCMessageToFrame(bool internal,
-                             bool send_to_all,
                              int32_t frame_id,
                              const std::string& channel,
                              v8::Local<v8::Value> args);

--- a/shell/common/api/api.mojom
+++ b/shell/common/api/api.mojom
@@ -8,7 +8,6 @@ import "third_party/blink/public/mojom/messaging/transferable_message.mojom";
 interface ElectronRenderer {
   Message(
       bool internal,
-      bool send_to_all,
       string channel,
       blink.mojom.CloneableMessage arguments,
       int32 sender_id);

--- a/shell/renderer/electron_api_service_impl.cc
+++ b/shell/renderer/electron_api_service_impl.cc
@@ -132,7 +132,6 @@ void ElectronApiServiceImpl::OnConnectionError() {
 }
 
 void ElectronApiServiceImpl::Message(bool internal,
-                                     bool send_to_all,
                                      const std::string& channel,
                                      blink::CloneableMessage arguments,
                                      int32_t sender_id) {
@@ -168,18 +167,6 @@ void ElectronApiServiceImpl::Message(bool internal,
   v8::Local<v8::Value> args = gin::ConvertToV8(isolate, arguments);
 
   EmitIPCEvent(context, internal, channel, {}, args, sender_id);
-
-  // Also send the message to all sub-frames.
-  // TODO(MarshallOfSound): Completely move this logic to the main process
-  if (send_to_all) {
-    for (blink::WebFrame* child = frame->FirstChild(); child;
-         child = child->NextSibling())
-      if (child->IsWebLocalFrame()) {
-        v8::Local<v8::Context> child_context =
-            renderer_client_->GetContext(child->ToWebLocalFrame(), isolate);
-        EmitIPCEvent(child_context, internal, channel, {}, args, sender_id);
-      }
-  }
 }
 
 void ElectronApiServiceImpl::ReceivePostMessage(

--- a/shell/renderer/electron_api_service_impl.h
+++ b/shell/renderer/electron_api_service_impl.h
@@ -29,7 +29,6 @@ class ElectronApiServiceImpl : public mojom::ElectronRenderer,
       mojo::PendingAssociatedReceiver<mojom::ElectronRenderer> receiver);
 
   void Message(bool internal,
-               bool send_to_all,
                const std::string& channel,
                blink::CloneableMessage arguments,
                int32_t sender_id) override;

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -68,7 +68,7 @@ declare namespace Electron {
     _callWindowOpenHandler(event: any, url: string, frameName: string, rawFeatures: string): Electron.BrowserWindowConstructorOptions | null;
     _setNextChildWebPreferences(prefs: Partial<Electron.BrowserWindowConstructorOptions['webPreferences']> & Pick<Electron.BrowserWindowConstructorOptions, 'backgroundColor'>): void;
     _send(internal: boolean, sendToAll: boolean, channel: string, args: any): boolean;
-    _sendToFrame(internal: boolean, sendToAll: boolean, frameId: number, channel: string, args: any): boolean;
+    _sendToFrame(internal: boolean, frameId: number, channel: string, args: any): boolean;
     _sendToFrameInternal(frameId: number, channel: string, ...args: any[]): boolean;
     _postMessage(channel: string, message: any, transfer?: any[]): void;
     _sendInternal(channel: string, ...args: any[]): void;


### PR DESCRIPTION
#### Description of Change
The combination of `sendToFrame` and `sendToAll` does not make sense

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes