### PR TITLE
fix: add a "set" trap to the "screen" module proxy

### DIFF
--- a/lib/browser/api/screen.ts
+++ b/lib/browser/api/screen.ts
@@ -2,37 +2,39 @@ const { createScreen } = process._linkedBinding('electron_common_screen');
 
 let _screen: Electron.Screen;
 
+const createScreenIfNeeded = () => {
+  if (_screen === undefined) {
+    _screen = createScreen();
+  }
+};
+
 // We can't call createScreen until after app.on('ready'), but this module
 // exposes an instance created by createScreen. In order to avoid
 // side-effecting and calling createScreen upon import of this module, instead
 // we export a proxy which lazily calls createScreen on first access.
 export default new Proxy({}, {
-  get: (target, prop: keyof Electron.Screen) => {
-    if (_screen === undefined) {
-      _screen = createScreen();
+  get: (target, property: keyof Electron.Screen) => {
+    createScreenIfNeeded();
+    const value = _screen[property];
+    if (typeof value === 'function') {
+      return value.bind(_screen);
     }
-    const v = _screen[prop];
-    if (typeof v === 'function') {
-      return v.bind(_screen);
-    }
-    return v;
+    return value;
+  },
+  set: (target, property: string, value: unknown) => {
+    createScreenIfNeeded();
+    return Reflect.set(_screen, property, value);
   },
   ownKeys: () => {
-    if (_screen === undefined) {
-      _screen = createScreen();
-    }
+    createScreenIfNeeded();
     return Reflect.ownKeys(_screen);
   },
-  has: (target, prop: string) => {
-    if (_screen === undefined) {
-      _screen = createScreen();
-    }
-    return prop in _screen;
+  has: (target, property: string) => {
+    createScreenIfNeeded();
+    return property in _screen;
   },
-  getOwnPropertyDescriptor: (target, prop: string) => {
-    if (_screen === undefined) {
-      _screen = createScreen();
-    }
-    return Reflect.getOwnPropertyDescriptor(_screen, prop);
+  getOwnPropertyDescriptor: (target, property: string) => {
+    createScreenIfNeeded();
+    return Reflect.getOwnPropertyDescriptor(_screen, property);
   }
 });

--- a/spec-main/api-screen-spec.ts
+++ b/spec-main/api-screen-spec.ts
@@ -1,7 +1,19 @@
 import { expect } from 'chai';
 import { screen } from 'electron/main';
+import * as sinon from 'sinon';
 
 describe('screen module', () => {
+  describe('methods reassignment', () => {
+    after(() => {
+      sinon.restore();
+    });
+
+    it('works for a selected method', () => {
+      sinon.stub((screen as any), 'getPrimaryDisplay').returns(null);
+      expect(screen.getPrimaryDisplay()).to.be.null();
+    });
+  });
+
   describe('screen.getCursorScreenPoint()', () => {
     it('returns a point object', () => {
       const point = screen.getCursorScreenPoint();

--- a/spec-main/api-screen-spec.ts
+++ b/spec-main/api-screen-spec.ts
@@ -1,16 +1,16 @@
 import { expect } from 'chai';
 import { screen } from 'electron/main';
-import * as sinon from 'sinon';
 
 describe('screen module', () => {
   describe('methods reassignment', () => {
-    after(() => {
-      sinon.restore();
-    });
-
     it('works for a selected method', () => {
-      sinon.stub((screen as any), 'getPrimaryDisplay').returns(null);
-      expect(screen.getPrimaryDisplay()).to.be.null();
+      const originalFunction = screen.getPrimaryDisplay;
+      try {
+        (screen as any).getPrimaryDisplay = () => null;
+        expect(screen.getPrimaryDisplay()).to.be.null();
+      } finally {
+        screen.getPrimaryDisplay = originalFunction;
+      }
     });
   });
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Let's make it possible to stub `screen` methods for testing.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> Fixed "screen" methods to be reassignable again.
