### PR TITLE
chore: remove unused _replyInternal method

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -461,16 +461,6 @@ const addReplyToEvent = (event: any) => {
   };
 };
 
-const addReplyInternalToEvent = (event: any) => {
-  Object.defineProperty(event, '_replyInternal', {
-    configurable: false,
-    enumerable: false,
-    value: (...args: any[]) => {
-      event.sender._sendToFrameInternal(event.frameId, ...args);
-    }
-  });
-};
-
 const addReturnValueToEvent = (event: any) => {
   Object.defineProperty(event, 'returnValue', {
     set: (value) => event.sendReply(value),
@@ -515,7 +505,6 @@ WebContents.prototype._init = function () {
   // Dispatch IPC messages to the ipc module.
   this.on('-ipc-message' as any, function (this: Electron.WebContents, event: any, internal: boolean, channel: string, args: any[]) {
     if (internal) {
-      addReplyInternalToEvent(event);
       ipcMainInternal.emit(channel, event, ...args);
     } else {
       addReplyToEvent(event);
@@ -541,7 +530,6 @@ WebContents.prototype._init = function () {
   this.on('-ipc-message-sync' as any, function (this: Electron.WebContents, event: any, internal: boolean, channel: string, args: any[]) {
     addReturnValueToEvent(event);
     if (internal) {
-      addReplyInternalToEvent(event);
       ipcMainInternal.emit(channel, event, ...args);
     } else {
       addReplyToEvent(event);

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -237,7 +237,6 @@ declare namespace ElectronInternal {
 
   // Internal IPC has _replyInternal and NO reply method
   interface IpcMainInternalEvent extends Omit<Electron.IpcMainEvent, 'reply'> {
-    _replyInternal(...args: any[]): void;
   }
 
   interface IpcMainInternal extends NodeJS.EventEmitter {


### PR DESCRIPTION
#### Description of Change
This method is not called.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
