### PR TITLE
fix: handle security warnings promise when JS is disabled

### DIFF
--- a/lib/renderer/security-warnings.ts
+++ b/lib/renderer/security-warnings.ts
@@ -180,7 +180,7 @@ const warnAboutInsecureCSP = function () {
 
     console.warn('%cElectron Security Warning (Insecure Content-Security-Policy)',
       'font-weight: bold;', warning);
-  });
+  }).catch(() => {});
 };
 
 /**


### PR DESCRIPTION
Fixes #26829

Notes: Fixes uncaught promise rejection when creating `webContents` with javascript disabled