### PR TITLE
refactor: move IPC handlers from navigation-controller to rpc-server

### DIFF
--- a/lib/browser/navigation-controller.ts
+++ b/lib/browser/navigation-controller.ts
@@ -1,24 +1,5 @@
-import { ipcMainInternal } from '@electron/internal/browser/ipc-main-internal';
 import type { WebContents, LoadURLOptions } from 'electron/main';
 import { EventEmitter } from 'events';
-import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
-
-// The history operation in renderer is redirected to browser.
-ipcMainInternal.on(IPC_MESSAGES.NAVIGATION_CONTROLLER_GO_BACK, function (event) {
-  event.sender.goBack();
-});
-
-ipcMainInternal.on(IPC_MESSAGES.NAVIGATION_CONTROLLER_GO_FORWARD, function (event) {
-  event.sender.goForward();
-});
-
-ipcMainInternal.on(IPC_MESSAGES.NAVIGATION_CONTROLLER_GO_TO_OFFSET, function (event, offset) {
-  event.sender.goToOffset(offset);
-});
-
-ipcMainInternal.on(IPC_MESSAGES.NAVIGATION_CONTROLLER_LENGTH, function (event) {
-  event.returnValue = event.sender.length();
-});
 
 // JavaScript implementation of Chromium's NavigationController.
 // Instead of relying on Chromium for history control, we completely do history

--- a/lib/browser/rpc-server.ts
+++ b/lib/browser/rpc-server.ts
@@ -100,6 +100,22 @@ ipcMainUtils.handleSync(IPC_MESSAGES.BROWSER_SANDBOX_LOAD, async function (event
   };
 });
 
+ipcMainInternal.on(IPC_MESSAGES.NAVIGATION_CONTROLLER_GO_BACK, function (event) {
+  event.sender.goBack();
+});
+
+ipcMainInternal.on(IPC_MESSAGES.NAVIGATION_CONTROLLER_GO_FORWARD, function (event) {
+  event.sender.goForward();
+});
+
+ipcMainInternal.on(IPC_MESSAGES.NAVIGATION_CONTROLLER_GO_TO_OFFSET, function (event, offset) {
+  event.sender.goToOffset(offset);
+});
+
+ipcMainInternal.on(IPC_MESSAGES.NAVIGATION_CONTROLLER_LENGTH, function (event) {
+  event.returnValue = event.sender.length();
+});
+
 ipcMainInternal.on(IPC_MESSAGES.BROWSER_PRELOAD_ERROR, function (event, preloadPath: string, error: Error) {
   event.sender.emit('preload-error', event, preloadPath, error);
 });


### PR DESCRIPTION
#### Description of Change
Only keep the `NavigationController` class in `lib/browser/navigation-controller.ts`.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes