### PR TITLE
chore: remove deprecated systemPreferences methods

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -89,6 +89,35 @@ BrowserWindow.getDevToolsExtensions()
 session.defaultSession.getAllExtensions()
 ```
 
+### Removed: methods in `systemPreferences`
+
+The following `systemPreferences` methods have been deprecated:
+* `systemPreferences.isDarkMode()`
+* `systemPreferences.isInvertedColorScheme()`
+* `systemPreferences.isHighContrastColorScheme()`
+
+Use the following `nativeTheme` properties instead:
+* `nativeTheme.shouldUseDarkColors`
+* `nativeTheme.shouldUseInvertedColorScheme`
+* `nativeTheme.shouldUseHighContrastColors`
+
+```js
+// Removed in Electron 13
+systemPreferences.isDarkMode()
+// Replace with
+nativeTheme.shouldUseDarkColors
+
+// Removed in Electron 13
+systemPreferences.isInvertedColorScheme()
+// Replace with
+nativeTheme.shouldUseInvertedColorScheme
+
+// Removed in Electron 13
+systemPreferences.isHighContrastColorScheme()
+// Replace with
+nativeTheme.shouldUseHighContrastColors
+```
+
 ## Planned Breaking API Changes (12.0)
 
 ### Removed: Pepper Flash support

--- a/lib/browser/api/system-preferences.ts
+++ b/lib/browser/api/system-preferences.ts
@@ -1,4 +1,3 @@
-import { deprecate } from 'electron/main';
 const { systemPreferences } = process._linkedBinding('electron_browser_system_preferences');
 
 if ('getAppLevelAppearance' in systemPreferences) {
@@ -16,21 +15,5 @@ if ('getEffectiveAppearance' in systemPreferences) {
     get: () => nativeEAGetter.call(systemPreferences)
   });
 }
-
-systemPreferences.isDarkMode = deprecate.moveAPI(
-  systemPreferences.isDarkMode,
-  'systemPreferences.isDarkMode()',
-  'nativeTheme.shouldUseDarkColors'
-);
-systemPreferences.isInvertedColorScheme = deprecate.moveAPI(
-  systemPreferences.isInvertedColorScheme,
-  'systemPreferences.isInvertedColorScheme()',
-  'nativeTheme.shouldUseInvertedColorScheme'
-);
-systemPreferences.isHighContrastColorScheme = deprecate.moveAPI(
-  systemPreferences.isHighContrastColorScheme,
-  'systemPreferences.isHighContrastColorScheme()',
-  'nativeTheme.shouldUseHighContrastColors'
-);
 
 export default systemPreferences;

--- a/shell/browser/api/electron_api_system_preferences.cc
+++ b/shell/browser/api/electron_api_system_preferences.cc
@@ -31,12 +31,6 @@ SystemPreferences::~SystemPreferences() {
 #endif
 }
 
-#if !defined(OS_MAC)
-bool SystemPreferences::IsDarkMode() {
-  return ui::NativeTheme::GetInstanceForNativeUi()->ShouldUseDarkColors();
-}
-#endif
-
 bool SystemPreferences::IsInvertedColorScheme() {
   return ui::NativeTheme::GetInstanceForNativeUi()
              ->GetPlatformHighContrastColorScheme() ==
@@ -115,11 +109,6 @@ gin::ObjectTemplateBuilder SystemPreferences::GetObjectTemplateBuilder(
                  &SystemPreferences::IsTrustedAccessibilityClient)
       .SetMethod("askForMediaAccess", &SystemPreferences::AskForMediaAccess)
 #endif
-      .SetMethod("isInvertedColorScheme",
-                 &SystemPreferences::IsInvertedColorScheme)
-      .SetMethod("isHighContrastColorScheme",
-                 &SystemPreferences::IsHighContrastColorScheme)
-      .SetMethod("isDarkMode", &SystemPreferences::IsDarkMode)
       .SetMethod("getAnimationSettings",
                  &SystemPreferences::GetAnimationSettings);
 }

--- a/shell/browser/api/electron_api_system_preferences.h
+++ b/shell/browser/api/electron_api_system_preferences.h
@@ -117,7 +117,6 @@ class SystemPreferences
   v8::Local<v8::Value> GetAppLevelAppearance(v8::Isolate* isolate);
   void SetAppLevelAppearance(gin::Arguments* args);
 #endif
-  bool IsDarkMode();
   bool IsInvertedColorScheme();
   bool IsHighContrastColorScheme();
   v8::Local<v8::Value> GetAnimationSettings(v8::Isolate* isolate);

--- a/shell/browser/api/electron_api_system_preferences_mac.mm
+++ b/shell/browser/api/electron_api_system_preferences_mac.mm
@@ -628,15 +628,6 @@ void SystemPreferences::RemoveUserDefault(const std::string& name) {
   [defaults removeObjectForKey:base::SysUTF8ToNSString(name)];
 }
 
-bool SystemPreferences::IsDarkMode() {
-  if (@available(macOS 10.14, *)) {
-    return ui::NativeTheme::GetInstanceForNativeUi()->ShouldUseDarkColors();
-  }
-  NSString* mode = [[NSUserDefaults standardUserDefaults]
-      stringForKey:@"AppleInterfaceStyle"];
-  return [mode isEqualToString:@"Dark"];
-}
-
 bool SystemPreferences::IsSwipeTrackingFromScrollEventsEnabled() {
   return [NSEvent isSwipeTrackingFromScrollEventsEnabled];
 }

--- a/spec-main/api-system-preferences-spec.ts
+++ b/spec-main/api-system-preferences-spec.ts
@@ -244,18 +244,6 @@ describe('systemPreferences module', () => {
     });
   });
 
-  describe('systemPreferences.isInvertedColorScheme()', () => {
-    it('returns a boolean', () => {
-      expect(systemPreferences.isInvertedColorScheme()).to.be.a('boolean');
-    });
-  });
-
-  describe('systemPreferences.isHighContrastColorScheme()', () => {
-    it('returns a boolean', () => {
-      expect(systemPreferences.isHighContrastColorScheme()).to.be.a('boolean');
-    });
-  });
-
   ifdescribe(process.platform === 'darwin')('systemPreferences.canPromptTouchID()', () => {
     it('returns a boolean', () => {
       expect(systemPreferences.canPromptTouchID()).to.be.a('boolean');


### PR DESCRIPTION
#### Description of Change
Deprecated documentation added in #26848.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Remove deprecated `systemPreferences` methods.