### PR TITLE
refactor: convert more C++ enums to C++11 enum classes

### DIFF
--- a/shell/browser/api/electron_api_system_preferences.h
+++ b/shell/browser/api/electron_api_system_preferences.h
@@ -26,7 +26,7 @@ namespace electron {
 namespace api {
 
 #if defined(OS_MAC)
-enum NotificationCenterKind {
+enum class NotificationCenterKind {
   kNSDistributedNotificationCenter = 0,
   kNSNotificationCenter,
   kNSWorkspaceNotificationCenter,

--- a/shell/browser/api/electron_api_system_preferences_mac.mm
+++ b/shell/browser/api/electron_api_system_preferences_mac.mm
@@ -140,12 +140,13 @@ void SystemPreferences::PostNotification(const std::string& name,
 int SystemPreferences::SubscribeNotification(
     const std::string& name,
     const NotificationCallback& callback) {
-  return DoSubscribeNotification(name, callback,
-                                 kNSDistributedNotificationCenter);
+  return DoSubscribeNotification(
+      name, callback, NotificationCenterKind::kNSDistributedNotificationCenter);
 }
 
 void SystemPreferences::UnsubscribeNotification(int request_id) {
-  DoUnsubscribeNotification(request_id, kNSDistributedNotificationCenter);
+  DoUnsubscribeNotification(
+      request_id, NotificationCenterKind::kNSDistributedNotificationCenter);
 }
 
 void SystemPreferences::PostLocalNotification(const std::string& name,
@@ -159,11 +160,13 @@ void SystemPreferences::PostLocalNotification(const std::string& name,
 int SystemPreferences::SubscribeLocalNotification(
     const std::string& name,
     const NotificationCallback& callback) {
-  return DoSubscribeNotification(name, callback, kNSNotificationCenter);
+  return DoSubscribeNotification(name, callback,
+                                 NotificationCenterKind::kNSNotificationCenter);
 }
 
 void SystemPreferences::UnsubscribeLocalNotification(int request_id) {
-  DoUnsubscribeNotification(request_id, kNSNotificationCenter);
+  DoUnsubscribeNotification(request_id,
+                            NotificationCenterKind::kNSNotificationCenter);
 }
 
 void SystemPreferences::PostWorkspaceNotification(
@@ -179,12 +182,13 @@ void SystemPreferences::PostWorkspaceNotification(
 int SystemPreferences::SubscribeWorkspaceNotification(
     const std::string& name,
     const NotificationCallback& callback) {
-  return DoSubscribeNotification(name, callback,
-                                 kNSWorkspaceNotificationCenter);
+  return DoSubscribeNotification(
+      name, callback, NotificationCenterKind::kNSWorkspaceNotificationCenter);
 }
 
 void SystemPreferences::UnsubscribeWorkspaceNotification(int request_id) {
-  DoUnsubscribeNotification(request_id, kNSWorkspaceNotificationCenter);
+  DoUnsubscribeNotification(
+      request_id, NotificationCenterKind::kNSWorkspaceNotificationCenter);
 }
 
 int SystemPreferences::DoSubscribeNotification(
@@ -195,13 +199,13 @@ int SystemPreferences::DoSubscribeNotification(
   __block NotificationCallback copied_callback = callback;
   NSNotificationCenter* center;
   switch (kind) {
-    case kNSDistributedNotificationCenter:
+    case NotificationCenterKind::kNSDistributedNotificationCenter:
       center = [NSDistributedNotificationCenter defaultCenter];
       break;
-    case kNSNotificationCenter:
+    case NotificationCenterKind::kNSNotificationCenter:
       center = [NSNotificationCenter defaultCenter];
       break;
-    case kNSWorkspaceNotificationCenter:
+    case NotificationCenterKind::kNSWorkspaceNotificationCenter:
       center = [[NSWorkspace sharedWorkspace] notificationCenter];
       break;
     default:
@@ -239,13 +243,13 @@ void SystemPreferences::DoUnsubscribeNotification(int request_id,
     id observer = iter->second;
     NSNotificationCenter* center;
     switch (kind) {
-      case kNSDistributedNotificationCenter:
+      case NotificationCenterKind::kNSDistributedNotificationCenter:
         center = [NSDistributedNotificationCenter defaultCenter];
         break;
-      case kNSNotificationCenter:
+      case NotificationCenterKind::kNSNotificationCenter:
         center = [NSNotificationCenter defaultCenter];
         break;
-      case kNSWorkspaceNotificationCenter:
+      case NotificationCenterKind::kNSWorkspaceNotificationCenter:
         center = [[NSWorkspace sharedWorkspace] notificationCenter];
         break;
       default:

--- a/shell/browser/api/electron_api_web_request.h
+++ b/shell/browser/api/electron_api_web_request.h
@@ -86,14 +86,14 @@ class WebRequest : public gin::Wrappable<WebRequest>, public WebRequestAPI {
   WebRequest(v8::Isolate* isolate, content::BrowserContext* browser_context);
   ~WebRequest() override;
 
-  enum SimpleEvent {
+  enum class SimpleEvent {
     kOnSendHeaders,
     kOnBeforeRedirect,
     kOnResponseStarted,
     kOnCompleted,
     kOnErrorOccurred,
   };
-  enum ResponseEvent {
+  enum class ResponseEvent {
     kOnBeforeRequest,
     kOnBeforeSendHeaders,
     kOnHeadersReceived,


### PR DESCRIPTION
#### Description of Change
Follow-up to #18087

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes