### PR TITLE
fix: systemPreferences.effectiveAppearance returning systemPreferences.getAppLevelAppearance()

### DIFF
--- a/lib/browser/api/system-preferences.ts
+++ b/lib/browser/api/system-preferences.ts
@@ -11,7 +11,7 @@ if ('getAppLevelAppearance' in systemPreferences) {
 }
 
 if ('getEffectiveAppearance' in systemPreferences) {
-  const nativeEAGetter = systemPreferences.getAppLevelAppearance;
+  const nativeEAGetter = systemPreferences.getEffectiveAppearance;
   Object.defineProperty(systemPreferences, 'effectiveAppearance', {
     get: () => nativeEAGetter.call(systemPreferences)
   });


### PR DESCRIPTION
#### Description of Change
This seems like a copy-paste error. It should return `systemPreferences.getEffectiveAppearance()`.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fix `systemPreferences.effectiveAppearance` returning `systemPreferences.getAppLevelAppearance()`.