### PR TITLE
chore: cherry-pick 5ffbb7ed173a from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -116,3 +116,4 @@ cherry-pick-bbb64b5c6916.patch
 ignore_renderframehostimpl_detach_for_speculative_rfhs.patch
 cherry-pick-eec5025668f8.patch
 cherry-pick-bbc6ab5bb49c.patch
+cherry-pick-5ffbb7ed173a.patch

--- a/patches/chromium/cherry-pick-5ffbb7ed173a.patch
+++ b/patches/chromium/cherry-pick-5ffbb7ed173a.patch
@@ -1,7 +1,7 @@
-From 5ffbb7ed173a4033519132874db5161a410a506c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Darwin Huang <huangdarwin@chromium.org>
 Date: Fri, 13 Nov 2020 10:07:05 +0000
-Subject: [PATCH] Pepper: Ensure weak pointer is still valid before use (M86).
+Subject: Pepper: Ensure weak pointer is still valid before use (M86).
 
 TBR=bbudge@chromium.org
 (cherry picked from commit f24c213293752250db05e11c5e4b77adce002d38)
@@ -16,13 +16,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2536757
 Reviewed-by: Darwin Huang <huangdarwin@chromium.org>
 Cr-Commit-Position: refs/branch-heads/4240@{#1448}
 Cr-Branched-From: f297677702651916bbf65e59c0d4bbd4ce57d1ee-refs/heads/master@{#800218}
----
 
 diff --git a/content/browser/renderer_host/pepper/pepper_file_io_host.cc b/content/browser/renderer_host/pepper/pepper_file_io_host.cc
-index 412a0143..9e534bc 100644
+index 28fba2fc56ddb7f42f3390db99999998ba912867..74bb7c539f8f05971b020e1d370098f5825e0ac2 100644
 --- a/content/browser/renderer_host/pepper/pepper_file_io_host.cc
 +++ b/content/browser/renderer_host/pepper/pepper_file_io_host.cc
-@@ -248,7 +248,12 @@
+@@ -248,7 +248,12 @@ void PepperFileIOHost::GotUIThreadStuffForInternalFileSystems(
      return;
    }
  

--- a/patches/chromium/cherry-pick-5ffbb7ed173a.patch
+++ b/patches/chromium/cherry-pick-5ffbb7ed173a.patch
@@ -1,0 +1,38 @@
+From 5ffbb7ed173a4033519132874db5161a410a506c Mon Sep 17 00:00:00 2001
+From: Darwin Huang <huangdarwin@chromium.org>
+Date: Fri, 13 Nov 2020 10:07:05 +0000
+Subject: [PATCH] Pepper: Ensure weak pointer is still valid before use (M86).
+
+TBR=bbudge@chromium.org
+(cherry picked from commit f24c213293752250db05e11c5e4b77adce002d38)
+
+Bug: 1146675
+Change-Id: I382dcb5c0b09a26e3c397ebef46947f626e2aef9
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2527065
+Reviewed-by: Bill Budge <bbudge@chromium.org>
+Commit-Queue: Darwin Huang <huangdarwin@chromium.org>
+Cr-Original-Commit-Position: refs/heads/master@{#825558}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2536757
+Reviewed-by: Darwin Huang <huangdarwin@chromium.org>
+Cr-Commit-Position: refs/branch-heads/4240@{#1448}
+Cr-Branched-From: f297677702651916bbf65e59c0d4bbd4ce57d1ee-refs/heads/master@{#800218}
+---
+
+diff --git a/content/browser/renderer_host/pepper/pepper_file_io_host.cc b/content/browser/renderer_host/pepper/pepper_file_io_host.cc
+index 412a0143..9e534bc 100644
+--- a/content/browser/renderer_host/pepper/pepper_file_io_host.cc
++++ b/content/browser/renderer_host/pepper/pepper_file_io_host.cc
+@@ -248,7 +248,12 @@
+     return;
+   }
+ 
+-  DCHECK(file_system_host_.get());
++  if (!file_system_host_.get()) {
++    reply_context.params.set_result(PP_ERROR_FAILED);
++    SendOpenErrorReply(reply_context);
++    return;
++  }
++
+   DCHECK(file_system_host_->GetFileSystemOperationRunner());
+ 
+   file_system_host_->GetFileSystemOperationRunner()->OpenFile(


### PR DESCRIPTION
Pepper: Ensure weak pointer is still valid before use (M86).

TBR=bbudge@chromium.org
(cherry picked from commit f24c213293752250db05e11c5e4b77adce002d38)

Bug: 1146675
Change-Id: I382dcb5c0b09a26e3c397ebef46947f626e2aef9
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2527065
Reviewed-by: Bill Budge <bbudge@chromium.org>
Commit-Queue: Darwin Huang <huangdarwin@chromium.org>
Cr-Original-Commit-Position: refs/heads/master@{#825558}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2536757
Reviewed-by: Darwin Huang <huangdarwin@chromium.org>
Cr-Commit-Position: refs/branch-heads/4240@{#1448}
Cr-Branched-From: f297677702651916bbf65e59c0d4bbd4ce57d1ee-refs/heads/master@{#800218}


Notes: Security: backported the fix to CVE-2020-16014: Use after free in PPAPI.