### PR TITLE
fix: message box missing an "OK" button in GTK

### DIFF
--- a/shell/browser/ui/message_box_gtk.cc
+++ b/shell/browser/ui/message_box_gtk.cc
@@ -87,9 +87,13 @@ class GtkMessageBox : public NativeWindowObserver {
 
     // Add buttons.
     GtkDialog* dialog = GTK_DIALOG(dialog_);
-    for (size_t i = 0; i < settings.buttons.size(); ++i) {
-      gtk_dialog_add_button(dialog, TranslateToStock(i, settings.buttons[i]),
-                            i);
+    if (settings.buttons.size() == 0) {
+      gtk_dialog_add_button(dialog, TranslateToStock(0, "OK"), 0);
+    } else {
+      for (size_t i = 0; i < settings.buttons.size(); ++i) {
+        gtk_dialog_add_button(dialog, TranslateToStock(i, settings.buttons[i]),
+                              i);
+      }
     }
     gtk_dialog_set_default_response(dialog, settings.default_id);
 
@@ -220,7 +224,7 @@ void ShowErrorBox(const base::string16& title, const base::string16& content) {
   if (Browser::Get()->is_ready()) {
     electron::MessageBoxSettings settings;
     settings.type = electron::MessageBoxType::kError;
-    settings.buttons = {"OK"};
+    settings.buttons = {};
     settings.title = "Error";
     settings.message = base::UTF16ToUTF8(title);
     settings.detail = base::UTF16ToUTF8(content);


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

##### The current behavior

<img width="649" alt="截屏2020-12-07 下午5 47 50" src="https://user-images.githubusercontent.com/16272760/101335805-a0ebaa80-38b4-11eb-8f9c-26cffeaaed14.png">


##### The new behavior

<img width="649" alt="截屏2020-12-07 下午5 47 08" src="https://user-images.githubusercontent.com/16272760/101335811-a2b56e00-38b4-11eb-9065-513feeccc866.png">


Tests: https://github.com/stevenjoezhang/electron-quick-start
Issue resolved: https://github.com/electron/electron/issues/26482
See also https://github.com/electron/electron/pull/2145
Ref https://developer.gnome.org/gtk3/stable/GtkMessageDialog.html#gtk-message-dialog-new

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue that a message box in GTK contains no buttons.