### PR TITLE
fix: readdir/readdirSync (w/ withFileTypes) failing on a deep directory within asar archive

### DIFF
--- a/lib/asar/fs-wrapper.ts
+++ b/lib/asar/fs-wrapper.ts
@@ -615,9 +615,10 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     if (options.withFileTypes) {
       const dirents = [];
       for (const file of files) {
-        const stats = archive.stat(file);
+        const childPath = path.join(filePath, file);
+        const stats = archive.stat(childPath);
         if (!stats) {
-          const error = createError(AsarError.NOT_FOUND, { asarPath, filePath: file });
+          const error = createError(AsarError.NOT_FOUND, { asarPath, filePath: childPath });
           nextTick(callback!, [error]);
           return;
         }
@@ -657,9 +658,10 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
     if (options && (options as any).withFileTypes) {
       const dirents = [];
       for (const file of files) {
-        const stats = archive.stat(file);
+        const childPath = path.join(filePath, file);
+        const stats = archive.stat(childPath);
         if (!stats) {
-          throw createError(AsarError.NOT_FOUND, { asarPath, filePath: file });
+          throw createError(AsarError.NOT_FOUND, { asarPath, filePath: childPath });
         }
         if (stats.isFile) {
           dirents.push(new fs.Dirent(file, fs.constants.UV_DIRENT_FILE));

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -920,6 +920,16 @@ describe('asar package', function () {
         expect(names).to.deep.equal(['dir1', 'dir2', 'dir3', 'file1', 'file2', 'file3', 'link1', 'link2', 'ping.js']);
       });
 
+      it('supports withFileTypes for a deep directory', function () {
+        const p = path.join(asarDir, 'a.asar', 'dir3');
+        const dirs = fs.readdirSync(p, { withFileTypes: true });
+        for (const dir of dirs) {
+          expect(dir instanceof fs.Dirent).to.be.true();
+        }
+        const names = dirs.map(a => a.name);
+        expect(names).to.deep.equal(['file1', 'file2', 'file3']);
+      });
+
       it('reads dirs from a linked dir', function () {
         const p = path.join(asarDir, 'a.asar', 'link2', 'link2');
         const dirs = fs.readdirSync(p);


### PR DESCRIPTION
#### Description of Change
when using `readdir`/`readdirSync` (w/ withFileTypes) on a deep directory within the archive, the code fails to get the stats of child paths.

#### Checklist

- [x] PR description included and stakeholders cc'd <-- @nornagon @MarshallOfSound (apologies if you are not the correct address)
- [ ] `npm test` passes <-- had difficulty building electron on my machine
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed `readdir`/`readdirSync` (w/ `withFileTypes`) failing on a deep directory within archive.