### PR TITLE
fix: add a "set" trap to the "screen" module proxy

### DIFF
--- a/spec-main/api-screen-spec.ts
+++ b/spec-main/api-screen-spec.ts
@@ -2,6 +2,18 @@ import { expect } from 'chai';
 import { screen } from 'electron/main';
 
 describe('screen module', () => {
+  describe('methods reassignment', () => {
+    it('works for a selected method', () => {
+      const originalFunction = screen.getPrimaryDisplay;
+      try {
+        (screen as any).getPrimaryDisplay = () => null;
+        expect(screen.getPrimaryDisplay()).to.be.null();
+      } finally {
+        screen.getPrimaryDisplay = originalFunction;
+      }
+    });
+  });
+
   describe('screen.getCursorScreenPoint()', () => {
     it('returns a point object', () => {
       const point = screen.getCursorScreenPoint();


### PR DESCRIPTION
Backport of #26818

See that PR for details.


Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> Fixed "screen" methods to be reassignable again.
