### PR TITLE
fix: systemPreferences.effectiveAppearance returning systemPreferences.getAppLevelAppearance()

### DIFF
--- a/lib/browser/api/system-preferences.ts
+++ b/lib/browser/api/system-preferences.ts
@@ -16,7 +16,7 @@ if ('getAppLevelAppearance' in systemPreferences) {
 }
 
 if ('getEffectiveAppearance' in systemPreferences) {
-  const nativeEAGetter = systemPreferences.getAppLevelAppearance;
+  const nativeEAGetter = systemPreferences.getEffectiveAppearance;
   Object.defineProperty(SystemPreferences.prototype, 'effectiveAppearance', {
     get: () => nativeEAGetter.call(systemPreferences)
   });


### PR DESCRIPTION
Backport of #26852

See that PR for details.

Notes: Fix `systemPreferences.effectiveAppearance` returning `systemPreferences.getAppLevelAppearance()`.