### PR TITLE
ci: ignore failures on Ninja summary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -890,6 +890,8 @@ step-ninja-summary: &step-ninja-summary
   run:
     name: Print ninja summary
     command: |
+      set +e
+      set +o pipefail
       python depot_tools/post_build_ninja_summary.py -C src/out/Default
 
 step-ninja-report: &step-ninja-report


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Occasionally CircleCI builds fail while printing the ninja summary of the build.  Since this report is informational only, this PR changes that step so that any failures are ignored.

Here's an example of a failed build: https://app.circleci.com/pipelines/github/electron/electron/33723/workflows/138db88d-eacb-4421-8ea9-3b1a6c5cef81/jobs/741116
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
