### PR TITLE
feat: make win.setAspectRatio() work on Windows

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -965,7 +965,7 @@ Returns `Boolean` - Whether the window is in simple (pre-Lion) fullscreen mode.
 
 Returns `Boolean` - Whether the window is in normal state (not maximized, not minimized, not in fullscreen mode).
 
-#### `win.setAspectRatio(aspectRatio[, extraSize])` _macOS_ _Linux_
+#### `win.setAspectRatio(aspectRatio[, extraSize])`
 
 * `aspectRatio` Float - The aspect ratio to maintain for some portion of the
 content view.
@@ -985,6 +985,9 @@ the player itself we would call this function with arguments of 16/9 and
 { width: 40, height: 50 }. The second argument doesn't care where the extra width and height
 are within the content view--only that they exist. Sum any extra width and
 height areas you have within the overall content view.
+
+The aspect ratio is not respected when window is resized programmingly with
+APIs like `win.setSize`.
 
 #### `win.setBackgroundColor(backgroundColor)`
 

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -15,6 +15,7 @@ webview_cross_drag.patch
 gin_enable_disable_v8_platform.patch
 blink-worker-enable-csp-in-file-scheme.patch
 disable-redraw-lock.patch
+enable_reset_aspect_ratio.patch
 v8_context_snapshot_generator.patch
 boringssl_build_gn.patch
 pepper_plugin_support.patch

--- a/patches/chromium/enable_reset_aspect_ratio.patch
+++ b/patches/chromium/enable_reset_aspect_ratio.patch
@@ -19,10 +19,10 @@ index a409755330351e7e1684c31f7c7cc6882a2dc7af..3349f38e1df8ff7e5c70f1c177b11914
                                     aspect_ratio.height());
  }
 diff --git a/ui/views/win/hwnd_message_handler.cc b/ui/views/win/hwnd_message_handler.cc
-index 34b58eb81f42e70a17250b99dfaa58891dc076c1..10c584016c427b1969bf707f79e74fa9f7e3e882 100644
+index dc2cdf7467912d36261583c91c8f46fbe041c5e0..a23108d0a38af3388b35bd5a0ae3cc3d5e565d93 100644
 --- a/ui/views/win/hwnd_message_handler.cc
 +++ b/ui/views/win/hwnd_message_handler.cc
-@@ -924,8 +924,11 @@ void HWNDMessageHandler::SetFullscreen(bool fullscreen) {
+@@ -919,8 +919,11 @@ void HWNDMessageHandler::SetFullscreen(bool fullscreen) {
  }
  
  void HWNDMessageHandler::SetAspectRatio(float aspect_ratio) {

--- a/patches/chromium/enable_reset_aspect_ratio.patch
+++ b/patches/chromium/enable_reset_aspect_ratio.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Thu, 4 Oct 2018 14:57:02 -0700
+Subject: feat: enable setting aspect ratio to 0
+
+Make SetAspectRatio accept 0 as valid input, which would reset to null.
+
+diff --git a/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc b/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc
+index a409755330351e7e1684c31f7c7cc6882a2dc7af..3349f38e1df8ff7e5c70f1c177b11914e4fa3e30 100644
+--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc
++++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_win.cc
+@@ -484,7 +484,7 @@ void DesktopWindowTreeHostWin::SetOpacity(float opacity) {
+ }
+ 
+ void DesktopWindowTreeHostWin::SetAspectRatio(const gfx::SizeF& aspect_ratio) {
+-  DCHECK(!aspect_ratio.IsEmpty());
++  DCHECK_NE(aspect_ratio.height(), 0);
+   message_handler_->SetAspectRatio(aspect_ratio.width() /
+                                    aspect_ratio.height());
+ }
+diff --git a/ui/views/win/hwnd_message_handler.cc b/ui/views/win/hwnd_message_handler.cc
+index 34b58eb81f42e70a17250b99dfaa58891dc076c1..10c584016c427b1969bf707f79e74fa9f7e3e882 100644
+--- a/ui/views/win/hwnd_message_handler.cc
++++ b/ui/views/win/hwnd_message_handler.cc
+@@ -924,8 +924,11 @@ void HWNDMessageHandler::SetFullscreen(bool fullscreen) {
+ }
+ 
+ void HWNDMessageHandler::SetAspectRatio(float aspect_ratio) {
+-  // If the aspect ratio is not in the valid range, do nothing.
+-  DCHECK_GT(aspect_ratio, 0.0f);
++  // If the aspect ratio is 0, reset it to null.
++  if (aspect_ratio == 0.0f) {
++    aspect_ratio_.reset();
++    return;
++  }
+ 
+   aspect_ratio_ = aspect_ratio;
+ 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -755,13 +755,11 @@ bool NativeWindowViews::IsResizable() {
 void NativeWindowViews::SetAspectRatio(double aspect_ratio,
                                        const gfx::Size& extra_size) {
   NativeWindow::SetAspectRatio(aspect_ratio, extra_size);
-#if defined(OS_LINUX)
   gfx::SizeF aspect(aspect_ratio, 1.0);
   // Scale up because SetAspectRatio() truncates aspect value to int
   aspect.Scale(100);
 
   widget()->SetAspectRatio(aspect);
-#endif
 }
 
 void NativeWindowViews::SetMovable(bool movable) {

--- a/shell/browser/ui/views/frameless_view.cc
+++ b/shell/browser/ui/views/frameless_view.cc
@@ -114,7 +114,10 @@ gfx::Size FramelessView::GetMinimumSize() const {
 }
 
 gfx::Size FramelessView::GetMaximumSize() const {
-  return window_->GetContentMaximumSize();
+  gfx::Size size = window_->GetContentMaximumSize();
+  // Electron public APIs returns (0, 0) when maximum size is not set, but it
+  // would break internal window APIs like HWNDMessageHandler::SetAspectRatio.
+  return size.IsEmpty() ? gfx::Size(INT_MAX, INT_MAX) : size;
 }
 
 const char* FramelessView::GetClassName() const {

--- a/shell/browser/ui/views/native_frame_view.cc
+++ b/shell/browser/ui/views/native_frame_view.cc
@@ -18,7 +18,10 @@ gfx::Size NativeFrameView::GetMinimumSize() const {
 }
 
 gfx::Size NativeFrameView::GetMaximumSize() const {
-  return window_->GetMaximumSize();
+  gfx::Size size = window_->GetMaximumSize();
+  // Electron public APIs returns (0, 0) when maximum size is not set, but it
+  // would break internal window APIs like HWNDMessageHandler::SetAspectRatio.
+  return size.IsEmpty() ? gfx::Size(INT_MAX, INT_MAX) : size;
 }
 
 const char* NativeFrameView::GetClassName() const {


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/8036.

This PR makes `win.setAspectRatio` work on Windows. It didn't work previously because the Windows implementation requires a non-zero maximum size, while we provided (0, 0) when maximum size is not set.

There is also a patch added to allow setting aspect ratio to 0 on Windows.

I'm unable to write a test for this because the aspect ratio is not respected when window is resized programmingly with APIs like `win.setSize`, it is also why we did not have a test for it at the first place.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Make `win.setAspectRatio()` work on Windows.