### PR TITLE
chore: cherry-pick 6763a713f957 from undefined

### DIFF
--- a/patches/undefined/.patches
+++ b/patches/undefined/.patches
@@ -1,0 +1,1 @@
+cherry-pick-6763a713f957.patch

--- a/patches/undefined/cherry-pick-6763a713f957.patch
+++ b/patches/undefined/cherry-pick-6763a713f957.patch
@@ -1,0 +1,32 @@
+From 6763a713f957008a8f53a33299aadb829b54f1ff Mon Sep 17 00:00:00 2001
+From: Brian Osman <brianosman@google.com>
+Date: Thu, 03 Sep 2020 15:19:14 -0400
+Subject: [PATCH] Limit morphology radius to 100 pixels
+
+This limit is arbitrary, but hopefully prevents pathological (or
+malicious) SVG content from consuming huge amounts of CPU/GPU time,
+without impacting any legitimate uses of feMorphology. (Typical usage
+has a much smaller radius).
+
+Bug: chromium:1123035
+Change-Id: I4405bc595128e9a6287eb5efa1be14621baa3a00
+Reviewed-on: https://skia-review.googlesource.com/c/skia/+/315219
+Reviewed-by: Mike Reed <reed@google.com>
+Commit-Queue: Brian Osman <brianosman@google.com>
+---
+
+diff --git a/src/effects/imagefilters/SkMorphologyImageFilter.cpp b/src/effects/imagefilters/SkMorphologyImageFilter.cpp
+index e1cb998..9496474 100644
+--- a/src/effects/imagefilters/SkMorphologyImageFilter.cpp
++++ b/src/effects/imagefilters/SkMorphologyImageFilter.cpp
+@@ -637,7 +637,9 @@
+     int height = SkScalarRoundToInt(radius.height());
+ 
+     // Width (or height) must fit in a signed 32-bit int to avoid UBSAN issues (crbug.com/1018190)
+-    constexpr int kMaxRadius = (std::numeric_limits<int>::max() - 1) / 2;
++    // Further, we limit the radius to something much smaller, to avoid extremely slow draw calls:
++    // (crbug.com/1123035):
++    constexpr int kMaxRadius = 100; // (std::numeric_limits<int>::max() - 1) / 2;
+ 
+     if (width < 0 || height < 0 || width > kMaxRadius || height > kMaxRadius) {
+         return nullptr;


### PR DESCRIPTION
Limit morphology radius to 100 pixels

This limit is arbitrary, but hopefully prevents pathological (or
malicious) SVG content from consuming huge amounts of CPU/GPU time,
without impacting any legitimate uses of feMorphology. (Typical usage
has a much smaller radius).

Bug: chromium:1123035
Change-Id: I4405bc595128e9a6287eb5efa1be14621baa3a00
Reviewed-on: https://skia-review.googlesource.com/c/skia/+/315219
Reviewed-by: Mike Reed <reed@google.com>
Commit-Queue: Brian Osman <brianosman@google.com>


Notes: Security: backported fix for chromium:1123035.