### PR TITLE
fix: Upload all *.dll.pdb to symbol server

### DIFF
--- a/script/release/uploaders/upload-symbols.py
+++ b/script/release/uploaders/upload-symbols.py
@@ -29,6 +29,8 @@ PDB_LIST = [
   os.path.join(RELEASE_DIR, '{0}.exe.pdb'.format(PROJECT_NAME))
 ]
 
+PDB_LIST += glob.glob(os.path.join(RELEASE_DIR, '*.dll.pdb'))
+
 NPX_CMD = "npx"
 if sys.platform == "win32":
     NPX_CMD += ".cmd"


### PR DESCRIPTION
Fixes #26961.

Notes: Add Electron DLLs like libGLESv2.dll to symbol server