### PR TITLE
fix: handle BrowserView reparenting

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -1081,10 +1081,12 @@ void BaseWindow::ResetBrowserViews() {
         !browser_view.IsEmpty()) {
       // There's a chance that the BrowserView may have been reparented - only
       // reset if the owner window is *this* window.
-      auto* owner_window = browser_view->web_contents()->owner_window();
-      if (browser_view->web_contents() && owner_window == window_.get()) {
-        browser_view->web_contents()->SetOwnerWindow(nullptr);
-        owner_window->RemoveBrowserView(browser_view->view());
+      if (browser_view->web_contents()) {
+        auto* owner_window = browser_view->web_contents()->owner_window();
+        if (owner_window == window_.get()) {
+          browser_view->web_contents()->SetOwnerWindow(nullptr);
+          owner_window->RemoveBrowserView(browser_view->view());
+        }
       }
     }
 

--- a/spec-main/api-browser-view-spec.ts
+++ b/spec-main/api-browser-view-spec.ts
@@ -149,6 +149,27 @@ describe('BrowserView module', () => {
         w.addBrowserView(view1);
       }).to.not.throw();
     });
+
+    it('can handle BrowserView reparenting', async () => {
+      view = new BrowserView();
+
+      w.addBrowserView(view);
+      view.webContents.loadURL('about:blank');
+      await emittedOnce(view.webContents, 'did-finish-load');
+
+      const w2 = new BrowserWindow({ show: false });
+      w2.addBrowserView(view);
+
+      w.close();
+
+      view.webContents.loadURL(`file://${fixtures}/pages/blank.html`);
+      await emittedOnce(view.webContents, 'did-finish-load');
+
+      // Clean up - the afterEach hook assumes the webContents on w is still alive.
+      w = new BrowserWindow({ show: false });
+      w2.close();
+      w2.destroy();
+    });
   });
 
   describe('BrowserWindow.removeBrowserView()', () => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/26975.

Fixes an issue where a `BrowserView` couldn't be reparented properly (moved from one `BrowserWindow` to another) because it wasn't properly detached from the first `BrowserWindow`.

A `BrowserWindow` has a one-to-many relationship with `BrowserViews`, but a `BrowserView` can only have a single owner window. As such, if a `BrowserView` is added to a `BrowserWindow` which has an owner window which is  both not null and _not_ the current window in question, then it needs to be properly detached from the previous owner window.

Tested with https://gist.github.com/a786242649a5d2e462c3328c905f0c9f.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue where BrowserViews couldn't be effectively reparented.
