### PR TITLE
refactor: use public node::CallbackScope where possible

### DIFF
--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -89,7 +89,6 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
 
   Browser* browser() { return browser_.get(); }
   BrowserProcessImpl* browser_process() { return fake_browser_process_.get(); }
-  NodeEnvironment* node_env() { return node_env_.get(); }
 
  protected:
   // content::BrowserMainParts:

--- a/shell/browser/microtasks_runner.cc
+++ b/shell/browser/microtasks_runner.cc
@@ -29,11 +29,9 @@ void MicrotasksRunner::DidProcessTask(const base::PendingTask& pending_task) {
   // up Node.js dealying its callbacks. To fix this, now we always lets Node.js
   // handle the checkpoint in the browser process.
   {
-    auto* node_env = electron::ElectronBrowserMainParts::Get()->node_env();
     v8::HandleScope scope(isolate_);
-    node::InternalCallbackScope microtasks_scope(
-        node_env->env(), v8::Object::New(isolate_), {0, 0},
-        node::InternalCallbackScope::kNoFlags);
+    node::CallbackScope microtasks_scope(isolate_, v8::Object::New(isolate_),
+                                         {0, 0});
   }
 }
 

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -113,7 +113,7 @@ void ElectronBindings::OnCallNextTick(uv_async_t* handle) {
     gin_helper::Locker locker(env->isolate());
     v8::Context::Scope context_scope(env->context());
     v8::HandleScope handle_scope(env->isolate());
-    node::CallbackScope scope(env->isolate() v8::Object::New(env->isolate()),
+    node::CallbackScope scope(env->isolate(), v8::Object::New(env->isolate()),
                               {0, 0});
   }
 

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -113,9 +113,8 @@ void ElectronBindings::OnCallNextTick(uv_async_t* handle) {
     gin_helper::Locker locker(env->isolate());
     v8::Context::Scope context_scope(env->context());
     v8::HandleScope handle_scope(env->isolate());
-    node::InternalCallbackScope scope(env, v8::Object::New(env->isolate()),
-                                      {0, 0},
-                                      node::InternalCallbackScope::kNoFlags);
+    node::CallbackScope scope(env->isolate() v8::Object::New(env->isolate()),
+                              {0, 0});
   }
 
   self->pending_next_ticks_.clear();


### PR DESCRIPTION
#### Description of Change

We should be using the publicly exposed `CallbackScope` where possible, since `InternalCallbackScope` is not public and ideally we should be working to get rid of our patch exposing it. We can't fully get rid of it yet, since our integration with `async_hooks` is broken and we need to specifically skip them when we're adding a callback scope to load the `Environment` in `ELECTRON_RUN_AS_NODE`, but i'll be doing that as a follow up.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
