### PR TITLE
fix: incorrect case in content::PermissionType mapping

### DIFF
--- a/shell/common/gin_converters/content_converter.cc
+++ b/shell/common/gin_converters/content_converter.cc
@@ -190,7 +190,6 @@ v8::Local<v8::Value> Converter<content::PermissionType>::ToV8(
       return StringToV8(isolate, "clipboard-read");
     case content::PermissionType::CLIPBOARD_SANITIZED_WRITE:
       return StringToV8(isolate, "clipboard-sanitized-write");
-    case content::PermissionType::CAMERA_PAN_TILT_ZOOM:
     case content::PermissionType::FONT_ACCESS:
       return StringToV8(isolate, "font-access");
     case content::PermissionType::IDLE_DETECTION:
@@ -209,6 +208,7 @@ v8::Local<v8::Value> Converter<content::PermissionType>::ToV8(
       return StringToV8(isolate, "persistent-storage");
     case content::PermissionType::GEOLOCATION:
       return StringToV8(isolate, "geolocation");
+    case content::PermissionType::CAMERA_PAN_TILT_ZOOM:
     case content::PermissionType::AUDIO_CAPTURE:
     case content::PermissionType::VIDEO_CAPTURE:
       return StringToV8(isolate, "media");


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
When mapping content::PermissionType enum values from C++ to javascript, the content::PermissionType::CAMERA_PAN_TILT_ZOOM case statement fell through to the next case, which was FONT_ACCESS. This meant that if the CAMERA_PAN_TILT_ZOOM permission were requested, the JS permission request handler would get called with the string 'font-access' as the permission.

This change changes that mapping so that CAMERA_PAN_TILT_ZOOM corresponds to the string 'media'. Having CAMERA_PAN_TILT_ZOOM be the same string as VIDEO_CAPTURE matches https://source.chromium.org/chromium/chromium/src/+/master:content/browser/devtools/protocol/browser_handler.cc;l=150?q=CAMERA_PAN_TILT_ZOOM%20-f:%5Eout%20lang:cc&start=11.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes

#### Release Notes

Notes: Apps requesting the CAMERA_PAN_TILT_ZOOM permission will have the permission request handler called with a permission string of "media" instead of "font-access".