### PR TITLE
fix: make protocol wrapper remote-friendly again

### DIFF
--- a/lib/browser/api/protocol.ts
+++ b/lib/browser/api/protocol.ts
@@ -17,8 +17,12 @@ Object.setPrototypeOf(protocol, new Proxy({}, {
 
   ownKeys () {
     if (!app.isReady()) return [];
+    return Reflect.ownKeys(session.defaultSession!.protocol);
+  },
 
-    return Object.getOwnPropertyNames(Object.getPrototypeOf(session.defaultSession!.protocol));
+  has: (target, property: string) => {
+    if (!app.isReady()) return false;
+    return Reflect.has(session.defaultSession!.protocol, property);
   },
 
   getOwnPropertyDescriptor () {

--- a/spec-main/api-remote-spec.ts
+++ b/spec-main/api-remote-spec.ts
@@ -7,7 +7,7 @@ import { ipcMain, BrowserWindow } from 'electron/main';
 import { emittedOnce } from './events-helpers';
 import { NativeImage } from 'electron/common';
 import { serialize, deserialize } from '../lib/common/type-utils';
-import { nativeImage } from 'electron';
+import { protocol, nativeImage } from 'electron';
 
 const features = process._linkedBinding('electron_common_features');
 
@@ -640,6 +640,16 @@ ifdescribe(features.isRemoteModuleEnabled())('remote module', () => {
 
       const { functionWithToStringProperty } = require('electron').remote.require(path.join(fixtures, 'to-string-non-function.js'));
       expect(functionWithToStringProperty.toString).to.equal('hello');
+    });
+
+    const protocolKeys = Object.getOwnPropertyNames(protocol);
+    remotely.it(protocolKeys)('remote.protocol returns all keys', (protocolKeys: [string]) => {
+      const protocol = require('electron').remote.protocol;
+      const remoteKeys = Object.getOwnPropertyNames(protocol);
+      expect(remoteKeys).to.deep.equal(protocolKeys);
+      for (const key of remoteKeys) {
+        expect(typeof (protocol as any)[key]).to.equal('function');
+      }
     });
   });
 


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/26900.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed `protocol` methods not being accessible via `remote.protocol`.