### PR TITLE
fix: allow browser process to save v8 code cache

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1005,6 +1005,22 @@ bool ElectronBrowserClient::ArePersistentMediaDeviceIDsAllowed(
   return true;
 }
 
+content::GeneratedCodeCacheSettings
+ElectronBrowserClient::GetGeneratedCodeCacheSettings(
+    content::BrowserContext* context) {
+  // We always set the browser process to save the generated code cache, but
+  // the storage partition will ensure that cache is not saved for in memory
+  // sessions.
+  // https://source.chromium.org/chromium/chromium/src/+/master:content/browser/storage_partition_impl.cc;l=1315
+  //
+  // Setting size to 0 will automatically pick up size based on available disk
+  // space.
+  //
+  // We use the user data path set for each browser context to save the cache.
+  // It will be under <user-data-dir>/Code Cache/
+  return content::GeneratedCodeCacheSettings(true, 0, context->GetPath());
+}
+
 void ElectronBrowserClient::SiteInstanceDeleting(
     content::SiteInstance* site_instance) {
   // We are storing weak_ptr, is it fundamental to maintain the map up-to-date

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -266,6 +266,8 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
       const GURL& scope,
       const GURL& site_for_cookies,
       const base::Optional<url::Origin>& top_frame_origin) override;
+  content::GeneratedCodeCacheSettings GetGeneratedCodeCacheSettings(
+      content::BrowserContext* context) override;
 
   // content::RenderProcessHostObserver:
   void RenderProcessHostDestroyed(content::RenderProcessHost* host) override;


### PR DESCRIPTION
#### Description of Change

Follow-up to https://github.com/electron/electron/pull/23842

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Persist v8 code cache to disk under user data directory
