### PR TITLE
fix: memory leak in desktopCapturer.getSources

### DIFF
--- a/lib/browser/desktop-capturer.ts
+++ b/lib/browser/desktop-capturer.ts
@@ -48,6 +48,9 @@ export const getSourcesImpl = (event: Electron.IpcMainEvent | null, args: Electr
       }
       // Remove from currentlyRunning once we resolve or reject
       currentlyRunning = currentlyRunning.filter(running => running.options !== options);
+      if (event) {
+        event.sender.removeListener('destroyed', stopRunning);
+      }
     };
 
     capturer._onerror = (error: string) => {
@@ -66,7 +69,7 @@ export const getSourcesImpl = (event: Electron.IpcMainEvent | null, args: Electr
     // reference to emit and the capturer itself so that it never dispatches
     // back to the renderer
     if (event) {
-      event.sender.once('destroyed', () => stopRunning());
+      event.sender.once('destroyed', stopRunning);
     }
   });
 


### PR DESCRIPTION
#### Description of Change
Fixes #21555.

The event listener was never being removed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a memory leak in desktopCapturer.getSources.
