### PR TITLE
fix: make webContents.id work even after destroy

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -503,6 +503,13 @@ WebContents.prototype._init = function () {
   this.goToOffset = navigationController.goToOffset.bind(navigationController);
   this.getActiveIndex = navigationController.getActiveIndex.bind(navigationController);
   this.length = navigationController.length.bind(navigationController);
+  // Read off the ID at construction time, so that it's accessible even after
+  // the underlying C++ WebContents is destroyed.
+  const id = this.id;
+  Object.defineProperty(this, 'id', {
+    value: id,
+    writable: false
+  });
 
   this._windowOpenHandler = null;
 


### PR DESCRIPTION
#### Description of Change
Fixes #26567.

This makes `WebContents.id` work even after the underlying `WebContents` C++
object is destroyed, allowing `remote` to clean up its object registry safely.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash that could occur on app quit when using the remote module.
