### PR TITLE
chore: put NativeWindowMac's methods in order

### DIFF
--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -236,7 +236,7 @@ class NativeWindow : public base::SupportsUserData,
                            const std::string& display_name);
   virtual void CloseFilePreview();
 
-  virtual void SetGTKDarkThemeEnabled(bool use_dark_theme) = 0;
+  virtual void SetGTKDarkThemeEnabled(bool use_dark_theme) {}
 
   // Converts between content bounds and window bounds.
   virtual gfx::Rect ContentBoundsToWindowBounds(

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -32,11 +32,6 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
   NativeWindowMac(const gin_helper::Dictionary& options, NativeWindow* parent);
   ~NativeWindowMac() override;
 
-  // Cleanup observers when window is getting closed. Note that the destructor
-  // can be called much later after window gets closed, so we should not do
-  // cleanup in destructor.
-  void Cleanup();
-
   // NativeWindow:
   void SetContentView(views::View* view) override;
   void Close() override;
@@ -68,11 +63,6 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
   void MoveTop() override;
   bool IsResizable() override;
   void SetMovable(bool movable) override;
-  void SetAspectRatio(double aspect_ratio,
-                      const gfx::Size& extra_size) override;
-  void PreviewFile(const std::string& path,
-                   const std::string& display_name) override;
-  void CloseFilePreview() override;
   bool IsMovable() override;
   void SetMinimizable(bool minimizable) override;
   bool IsMinimizable() override;
@@ -122,31 +112,37 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
   void SetProgressBar(double progress, const ProgressState state) override;
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description) override;
-
   void SetVisibleOnAllWorkspaces(bool visible,
                                  bool visibleOnFullScreen) override;
   bool IsVisibleOnAllWorkspaces() override;
-
   void SetAutoHideCursor(bool auto_hide) override;
-
+  void SetVibrancy(const std::string& type) override;
+  void SetTrafficLightPosition(base::Optional<gfx::Point> position) override;
+  base::Optional<gfx::Point> GetTrafficLightPosition() const override;
+  void RedrawTrafficLights() override;
+  void SetTouchBar(
+      std::vector<gin_helper::PersistentDictionary> items) override;
+  void RefreshTouchBarItem(const std::string& item_id) override;
+  void SetEscapeTouchBarItem(gin_helper::PersistentDictionary item) override;
   void SelectPreviousTab() override;
   void SelectNextTab() override;
   void MergeAllWindows() override;
   void MoveTabToNewWindow() override;
   void ToggleTabBar() override;
   bool AddTabbedWindow(NativeWindow* window) override;
-
   bool SetWindowButtonVisibility(bool visible) override;
-
-  void SetVibrancy(const std::string& type) override;
-  void SetTouchBar(
-      std::vector<gin_helper::PersistentDictionary> items) override;
-  void RefreshTouchBarItem(const std::string& item_id) override;
-  void SetEscapeTouchBarItem(gin_helper::PersistentDictionary item) override;
-  void SetGTKDarkThemeEnabled(bool use_dark_theme) override {}
-
+  void SetAspectRatio(double aspect_ratio,
+                      const gfx::Size& extra_size) override;
+  void PreviewFile(const std::string& path,
+                   const std::string& display_name) override;
+  void CloseFilePreview() override;
   gfx::Rect ContentBoundsToWindowBounds(const gfx::Rect& bounds) const override;
   gfx::Rect WindowBoundsToContentBounds(const gfx::Rect& bounds) const override;
+
+  // Cleanup observers when window is getting closed. Note that the destructor
+  // can be called much later after window gets closed, so we should not do
+  // cleanup in destructor.
+  void Cleanup();
 
   // Use a custom content view instead of Chromium's BridgedContentView.
   void OverrideNSWindowContentView();
@@ -156,12 +152,7 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
   void SetCollectionBehavior(bool on, NSUInteger flag);
   void SetWindowLevel(int level);
 
-  // Custom traffic light positioning
-  void RedrawTrafficLights() override;
   void SetExitingFullScreen(bool flag);
-  void SetTrafficLightPosition(base::Optional<gfx::Point> position) override;
-  base::Optional<gfx::Point> GetTrafficLightPosition() const override;
-  void OnNativeThemeUpdated(ui::NativeTheme* observed_theme) override;
 
   enum class VisualEffectState {
     kFollowWindow,
@@ -188,6 +179,9 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
   // views::WidgetDelegate:
   bool CanResize() const override;
   views::View* GetContentsView() override;
+
+  // ui::NativeThemeObserver:
+  void OnNativeThemeUpdated(ui::NativeTheme* observed_theme) override;
 
  private:
   // Add custom layers to the content view.


### PR DESCRIPTION
#### Description of Change

The `NativeWindowMac` class has become a bit hard to work on, because its overrides do not match the base class's order, and its method definitions do not match the declarations' order. So I'm putting them in order in this PR.

This will make certain backports harder, but I think it worths the efforts otherwise the class will only become more messy, and I already find it very difficult to add new methods to this class.

There is no actual change to the code except for simple moves.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes