### PR TITLE
chore: remove extra setTitlebarAppearsTransparent

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -471,11 +471,6 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
     }
   }
 
-  // Hide the title bar background
-  if (title_bar_style_ != TitleBarStyle::kNormal) {
-    [window_ setTitlebarAppearsTransparent:YES];
-  }
-
   // Hide the title bar.
   if (title_bar_style_ == TitleBarStyle::kHiddenInset) {
     base::scoped_nsobject<NSToolbar> toolbar(


### PR DESCRIPTION
#### Description of Change

`setTitlebarAppearsTransparent` has already been called above for frameless window, and `title_bar_style_ != TitleBarStyle::kNormal` forces the window to be a frameless window.

#### Release Notes

Notes: none