### PR TITLE
fix: make setWindowButtonVisibility work for customButtonsOnHover

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1595,8 +1595,6 @@ Changes window icon.
 
 Sets whether the window traffic light buttons should be visible.
 
-This cannot be called when `titleBarStyle` is set to `customButtonsOnHover`.
-
 #### `win.setAutoHideMenuBar(hide)`
 
 * `hide` Boolean

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -841,6 +841,14 @@ void BaseWindow::SetVibrancy(v8::Isolate* isolate, v8::Local<v8::Value> value) {
 }
 
 #if defined(OS_MAC)
+void BaseWindow::SetWindowButtonVisibility(bool visible) {
+  window_->SetWindowButtonVisibility(visible);
+}
+
+bool BaseWindow::GetWindowButtonVisibility() const {
+  return window_->GetWindowButtonVisibility();
+}
+
 void BaseWindow::SetTrafficLightPosition(const gfx::Point& position) {
   // For backward compatibility we treat (0, 0) as reseting to default.
   if (position.IsOrigin())
@@ -892,13 +900,6 @@ void BaseWindow::AddTabbedWindow(NativeWindow* window,
                                  gin_helper::Arguments* args) {
   if (!window_->AddTabbedWindow(window))
     args->ThrowError("AddTabbedWindow cannot be called by a window on itself.");
-}
-
-void BaseWindow::SetWindowButtonVisibility(bool visible,
-                                           gin_helper::Arguments* args) {
-  if (!window_->SetWindowButtonVisibility(visible)) {
-    args->ThrowError("Not supported for this window");
-  }
 }
 
 void BaseWindow::SetAutoHideMenuBar(bool auto_hide) {
@@ -1230,6 +1231,8 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("addTabbedWindow", &BaseWindow::AddTabbedWindow)
       .SetMethod("setWindowButtonVisibility",
                  &BaseWindow::SetWindowButtonVisibility)
+      .SetMethod("_getWindowButtonVisibility",
+                 &BaseWindow::GetWindowButtonVisibility)
       .SetProperty("excludedFromShownWindowsMenu",
                    &BaseWindow::IsExcludedFromShownWindowsMenu,
                    &BaseWindow::SetExcludedFromShownWindowsMenu)

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -188,6 +188,8 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   virtual void SetVibrancy(v8::Isolate* isolate, v8::Local<v8::Value> value);
 
 #if defined(OS_MAC)
+  void SetWindowButtonVisibility(bool visible);
+  bool GetWindowButtonVisibility() const;
   void SetTrafficLightPosition(const gfx::Point& position);
   gfx::Point GetTrafficLightPosition() const;
 #endif
@@ -201,7 +203,6 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void MoveTabToNewWindow();
   void ToggleTabBar();
   void AddTabbedWindow(NativeWindow* window, gin_helper::Arguments* args);
-  void SetWindowButtonVisibility(bool visible, gin_helper::Arguments* args);
   void SetAutoHideMenuBar(bool auto_hide);
   bool IsMenuBarAutoHide();
   void SetMenuBarVisibility(bool visible);

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -372,10 +372,6 @@ bool NativeWindow::IsMenuBarVisible() {
   return true;
 }
 
-bool NativeWindow::SetWindowButtonVisibility(bool visible) {
-  return false;
-}
-
 double NativeWindow::GetAspectRatio() {
   return aspect_ratio_;
 }

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -199,6 +199,8 @@ class NativeWindow : public base::SupportsUserData,
 
   // Traffic Light API
 #if defined(OS_MAC)
+  virtual void SetWindowButtonVisibility(bool visible) = 0;
+  virtual bool GetWindowButtonVisibility() const = 0;
   virtual void SetTrafficLightPosition(base::Optional<gfx::Point> position) = 0;
   virtual base::Optional<gfx::Point> GetTrafficLightPosition() const = 0;
   virtual void RedrawTrafficLights() = 0;
@@ -216,9 +218,6 @@ class NativeWindow : public base::SupportsUserData,
   virtual void MoveTabToNewWindow();
   virtual void ToggleTabBar();
   virtual bool AddTabbedWindow(NativeWindow* window);
-
-  // Returns false if unsupported.
-  virtual bool SetWindowButtonVisibility(bool visible);
 
   // Toggle the menu bar.
   virtual void SetAutoHideMenuBar(bool auto_hide);

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -117,6 +117,8 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
   bool IsVisibleOnAllWorkspaces() override;
   void SetAutoHideCursor(bool auto_hide) override;
   void SetVibrancy(const std::string& type) override;
+  void SetWindowButtonVisibility(bool visible) override;
+  bool GetWindowButtonVisibility() const override;
   void SetTrafficLightPosition(base::Optional<gfx::Point> position) override;
   base::Optional<gfx::Point> GetTrafficLightPosition() const override;
   void RedrawTrafficLights() override;
@@ -130,7 +132,6 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
   void MoveTabToNewWindow() override;
   void ToggleTabBar() override;
   bool AddTabbedWindow(NativeWindow* window) override;
-  bool SetWindowButtonVisibility(bool visible) override;
   void SetAspectRatio(double aspect_ratio,
                       const gfx::Size& extra_size) override;
   void PreviewFile(const std::string& path,
@@ -187,6 +188,7 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
   // Add custom layers to the content view.
   void AddContentViewLayers(bool minimizable, bool closable);
 
+  void InternalSetWindowButtonVisibility(bool visible);
   void InternalSetParentWindow(NativeWindow* parent, bool attach);
   void SetForwardMouseMessages(bool forward);
 

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1509,15 +1509,40 @@ describe('BrowserWindow module', () => {
       }).to.not.throw();
     });
 
-    it('throws with custom title bar buttons', () => {
-      expect(() => {
-        const w = new BrowserWindow({
-          show: false,
-          titleBarStyle: 'customButtonsOnHover',
-          frame: false
-        });
-        w.setWindowButtonVisibility(true);
-      }).to.throw('Not supported for this window');
+    it('changes window button visibility for normal window', () => {
+      const w = new BrowserWindow({ show: false });
+      expect(w._getWindowButtonVisibility()).to.equal(true);
+      w.setWindowButtonVisibility(false);
+      expect(w._getWindowButtonVisibility()).to.equal(false);
+      w.setWindowButtonVisibility(true);
+      expect(w._getWindowButtonVisibility()).to.equal(true);
+    });
+
+    it('changes window button visibility for frameless window', () => {
+      const w = new BrowserWindow({ show: false, frame: false });
+      expect(w._getWindowButtonVisibility()).to.equal(false);
+      w.setWindowButtonVisibility(true);
+      expect(w._getWindowButtonVisibility()).to.equal(true);
+      w.setWindowButtonVisibility(false);
+      expect(w._getWindowButtonVisibility()).to.equal(false);
+    });
+
+    it('changes window button visibility for hiddenInset window', () => {
+      const w = new BrowserWindow({ show: false, frame: false, titleBarStyle: 'hiddenInset' });
+      expect(w._getWindowButtonVisibility()).to.equal(true);
+      w.setWindowButtonVisibility(false);
+      expect(w._getWindowButtonVisibility()).to.equal(false);
+      w.setWindowButtonVisibility(true);
+      expect(w._getWindowButtonVisibility()).to.equal(true);
+    });
+
+    it('changes window button visibility for customButtonsOnHover window', () => {
+      const w = new BrowserWindow({ show: false, frame: false, titleBarStyle: 'customButtonsOnHover' });
+      expect(w._getWindowButtonVisibility()).to.equal(true);
+      w.setWindowButtonVisibility(false);
+      expect(w._getWindowButtonVisibility()).to.equal(false);
+      w.setWindowButtonVisibility(true);
+      expect(w._getWindowButtonVisibility()).to.equal(true);
     });
   });
 

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -31,6 +31,7 @@ declare namespace Electron {
     _setTouchBarItems: (items: TouchBarItemType[]) => void;
     _setEscapeTouchBarItem: (item: TouchBarItemType | {}) => void;
     _refreshTouchBarItem: (itemID: string) => void;
+    _getWindowButtonVisibility: () => boolean;
     frameName: string;
     on(event: '-touch-bar-interaction', listener: (event: Event, itemID: string, details: any) => void): this;
     removeListener(event: '-touch-bar-interaction', listener: (event: Event, itemID: string, details: any) => void): this;


### PR DESCRIPTION
#### Description of Change

I have been cleaning up `titleBarStyle`'s implementations and this is part of the refactoring. No one requested for this but it would be a good thing to fix an edge case in our APIs.

I have also added some tests for the `setWindowButtonVisibility` API.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Make `BrowserWindow.setWindowButtonVisibility` work for window with `customButtonsOnHover` titlebar style.