### PR TITLE
feat: add frame and webContents to webRequest details

### DIFF
--- a/docs/api/web-request.md
+++ b/docs/api/web-request.md
@@ -51,6 +51,8 @@ The following methods are available on instances of `WebRequest`:
     * `url` String
     * `method` String
     * `webContentsId` Integer (optional)
+    * `webContents` WebContents (optional)
+    * `frame` WebFrameMain (optional)
     * `resourceType` String
     * `referrer` String
     * `timestamp` Double
@@ -94,6 +96,8 @@ Some examples of valid `urls`:
     * `url` String
     * `method` String
     * `webContentsId` Integer (optional)
+    * `webContents` WebContents (optional)
+    * `frame` WebFrameMain (optional)
     * `resourceType` String
     * `referrer` String
     * `timestamp` Double
@@ -121,6 +125,8 @@ The `callback` has to be called with a `response` object.
     * `url` String
     * `method` String
     * `webContentsId` Integer (optional)
+    * `webContents` WebContents (optional)
+    * `frame` WebFrameMain (optional)
     * `resourceType` String
     * `referrer` String
     * `timestamp` Double
@@ -141,6 +147,8 @@ response are visible by the time this listener is fired.
     * `url` String
     * `method` String
     * `webContentsId` Integer (optional)
+    * `webContents` WebContents (optional)
+    * `frame` WebFrameMain (optional)
     * `resourceType` String
     * `referrer` String
     * `timestamp` Double
@@ -173,6 +181,8 @@ The `callback` has to be called with a `response` object.
     * `url` String
     * `method` String
     * `webContentsId` Integer (optional)
+    * `webContents` WebContents (optional)
+    * `frame` WebFrameMain (optional)
     * `resourceType` String
     * `referrer` String
     * `timestamp` Double
@@ -197,6 +207,8 @@ and response headers are available.
     * `url` String
     * `method` String
     * `webContentsId` Integer (optional)
+    * `webContents` WebContents (optional)
+    * `frame` WebFrameMain (optional)
     * `resourceType` String
     * `referrer` String
     * `timestamp` Double
@@ -222,6 +234,8 @@ redirect is about to occur.
     * `url` String
     * `method` String
     * `webContentsId` Integer (optional)
+    * `webContents` WebContents (optional)
+    * `frame` WebFrameMain (optional)
     * `resourceType` String
     * `referrer` String
     * `timestamp` Double
@@ -245,6 +259,8 @@ completed.
     * `url` String
     * `method` String
     * `webContentsId` Integer (optional)
+    * `webContents` WebContents (optional)
+    * `frame` WebFrameMain (optional)
     * `resourceType` String
     * `referrer` String
     * `timestamp` Double

--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -21,6 +21,7 @@
 #include "shell/browser/electron_browser_context.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/common/gin_converters/callback_converter.h"
+#include "shell/common/gin_converters/frame_converter.h"
 #include "shell/common/gin_converters/gurl_converter.h"
 #include "shell/common/gin_converters/net_converter.h"
 #include "shell/common/gin_converters/std_converter.h"
@@ -160,8 +161,7 @@ void ToDictionary(gin::Dictionary* details, extensions::WebRequestInfo* info) {
   auto* render_frame_host =
       content::RenderFrameHost::FromID(info->render_process_id, info->frame_id);
   if (render_frame_host) {
-    details->Set("frame",
-                 WebFrameMain::From(details->isolate(), render_frame_host));
+    details->Set("frame", render_frame_host);
     auto* web_contents =
         content::WebContents::FromRenderFrameHost(render_frame_host);
     auto* api_web_contents = WebContents::From(web_contents);

--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -17,6 +17,7 @@
 #include "net/http/http_content_disposition.h"
 #include "shell/browser/api/electron_api_session.h"
 #include "shell/browser/api/electron_api_web_contents.h"
+#include "shell/browser/api/electron_api_web_frame_main.h"
 #include "shell/browser/electron_browser_context.h"
 #include "shell/browser/javascript_environment.h"
 #include "shell/common/gin_converters/callback_converter.h"
@@ -156,12 +157,19 @@ void ToDictionary(gin::Dictionary* details, extensions::WebRequestInfo* info) {
                  HttpResponseHeadersToV8(info->response_headers.get()));
   }
 
-  auto* web_contents = content::WebContents::FromRenderFrameHost(
-      content::RenderFrameHost::FromID(info->render_process_id,
-                                       info->frame_id));
-  auto* api_web_contents = WebContents::From(web_contents);
-  if (api_web_contents)
-    details->Set("webContentsId", api_web_contents->ID());
+  auto* render_frame_host =
+      content::RenderFrameHost::FromID(info->render_process_id, info->frame_id);
+  if (render_frame_host) {
+    details->Set("frame",
+                 WebFrameMain::From(details->isolate(), render_frame_host));
+    auto* web_contents =
+        content::WebContents::FromRenderFrameHost(render_frame_host);
+    auto* api_web_contents = WebContents::From(web_contents);
+    if (api_web_contents) {
+      details->Set("webContents", api_web_contents);
+      details->Set("webContentsId", api_web_contents->ID());
+    }
+  }
 }
 
 void ToDictionary(gin::Dictionary* details,

--- a/spec-main/api-web-request-spec.ts
+++ b/spec-main/api-web-request-spec.ts
@@ -90,6 +90,9 @@ describe('webRequest module', () => {
         expect(details.id).to.be.a('number');
         expect(details.timestamp).to.be.a('number');
         expect(details.webContentsId).to.be.a('number');
+        expect(details.webContents).to.be.an('object');
+        expect(details.webContents!.id).to.equal(details.webContentsId);
+        expect(details.frame).to.be.an('object');
         expect(details.url).to.be.a('string').that.is.equal(defaultURL);
         expect(details.method).to.be.a('string').that.is.equal('GET');
         expect(details.resourceType).to.be.a('string').that.is.equal('xhr');


### PR DESCRIPTION
#### Description of Change
This adds a `frame` property to the `details` object passed to `webRequest`
handlers, so that the main process can discriminate based on the origin frame.

It also adds a `webContents` property for more convenient access to the
containing `WebContents`--this was already indirectly available as
`webContentsId`, but there's no reason not to expose the object directly.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `frame` and `webContents` properties to the details object in webRequest handlers.
