### PR TITLE
feat: add support for webContents option in BrowserView

### DIFF
--- a/script/gen-filenames.ts
+++ b/script/gen-filenames.ts
@@ -101,7 +101,7 @@ ${target.dependencies.map(dep => `    "${dep}",`).join('\n')}
 `);
 };
 
-if (process.mainModule === module) {
+if ((process as any).mainModule === module) {
   main().catch((err) => {
     console.error(err);
     process.exit(1);

--- a/shell/browser/api/electron_api_browser_view.cc
+++ b/shell/browser/api/electron_api_browser_view.cc
@@ -78,8 +78,17 @@ BrowserView::BrowserView(gin::Arguments* args,
       gin::Dictionary::CreateEmpty(isolate);
   options.Get(options::kWebPreferences, &web_preferences);
   web_preferences.Set("type", "browserView");
-  gin::Handle<class WebContents> web_contents =
-      WebContents::Create(isolate, web_preferences);
+
+  v8::Local<v8::Value> value;
+
+  // Copy the webContents option to webPreferences. This is only used internally
+  // to implement nativeWindowOpen option.
+  if (options.Get("webContents", &value)) {
+    web_preferences.SetHidden("webContents", value);
+  }
+
+  auto web_contents =
+      WebContents::CreateFromWebPreferences(args->isolate(), web_preferences);
 
   web_contents_.Reset(isolate, web_contents.ToV8());
   api_web_contents_ = web_contents.get();

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3115,6 +3115,33 @@ gin::Handle<WebContents> WebContents::FromOrCreate(
 }
 
 // static
+gin::Handle<WebContents> WebContents::CreateFromWebPreferences(
+    v8::Isolate* isolate,
+    const gin_helper::Dictionary& web_preferences) {
+  // Check if webPreferences has |webContents| option.
+  gin::Handle<WebContents> web_contents;
+  if (web_preferences.GetHidden("webContents", &web_contents) &&
+      !web_contents.IsEmpty()) {
+    // Set webPreferences from options if using an existing webContents.
+    // These preferences will be used when the webContent launches new
+    // render processes.
+    auto* existing_preferences =
+        WebContentsPreferences::From(web_contents->web_contents());
+    base::DictionaryValue web_preferences_dict;
+    if (gin::ConvertFromV8(isolate, web_preferences.GetHandle(),
+                           &web_preferences_dict)) {
+      existing_preferences->Clear();
+      existing_preferences->Merge(web_preferences_dict);
+    }
+  } else {
+    // Create one if not.
+    web_contents = WebContents::New(isolate, web_preferences);
+  }
+
+  return web_contents;
+}
+
+// static
 WebContents* WebContents::FromID(int32_t id) {
   return GetAllWebContents().Lookup(id);
 }

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -166,6 +166,10 @@ class WebContents : public gin::Wrappable<WebContents>,
       v8::Isolate* isolate,
       content::WebContents* web_contents);
 
+  static gin::Handle<WebContents> CreateFromWebPreferences(
+      v8::Isolate* isolate,
+      const gin_helper::Dictionary& web_preferences);
+
   // gin::Wrappable
   static gin::WrapperInfo kWrapperInfo;
   static v8::Local<v8::ObjectTemplate> FillObjectTemplate(

--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -96,25 +96,9 @@ v8::Local<v8::Function> WebContentsView::GetConstructor(v8::Isolate* isolate) {
 gin_helper::WrappableBase* WebContentsView::New(
     gin_helper::Arguments* args,
     const gin_helper::Dictionary& web_preferences) {
-  // Check if BrowserWindow has passend |webContents| option to us.
-  gin::Handle<WebContents> web_contents;
-  if (web_preferences.GetHidden("webContents", &web_contents) &&
-      !web_contents.IsEmpty()) {
-    // Set webPreferences from options if using an existing webContents.
-    // These preferences will be used when the webContent launches new
-    // render processes.
-    auto* existing_preferences =
-        WebContentsPreferences::From(web_contents->web_contents());
-    base::DictionaryValue web_preferences_dict;
-    if (gin::ConvertFromV8(args->isolate(), web_preferences.GetHandle(),
-                           &web_preferences_dict)) {
-      existing_preferences->Clear();
-      existing_preferences->Merge(web_preferences_dict);
-    }
-  } else {
-    // Create one if not.
-    web_contents = WebContents::Create(args->isolate(), web_preferences);
-  }
+  auto web_contents =
+      WebContents::CreateFromWebPreferences(args->isolate(), web_preferences);
+
   // Constructor call.
   auto* view = new WebContentsView(args->isolate(), web_contents);
   view->InitWithArgs(args);

--- a/spec-main/api-browser-view-spec.ts
+++ b/spec-main/api-browser-view-spec.ts
@@ -39,6 +39,15 @@ describe('BrowserView module', () => {
     expect(webContents.getAllWebContents()).to.have.length(0);
   });
 
+  it('can be created with an existing webContents', async () => {
+    const wc = (webContents as any).create({ sandbox: true });
+    await wc.loadURL('about:blank');
+
+    view = new BrowserView({ webContents: wc } as any);
+
+    expect(view.webContents.getURL()).to.equal('about:blank');
+  });
+
   describe('BrowserView.setBackgroundColor()', () => {
     it('does not throw for valid args', () => {
       view = new BrowserView();


### PR DESCRIPTION
#### Description of Change

Backport of #26802

I had to mark `process` as any, since the `mainModule` property has been deprecated and the pre-commit hook wouldn't let me commit changes.

#### Release Notes

Notes: none
