### PR TITLE
fix: unclickable regions in some draggable BrowserViews

### DIFF
--- a/shell/browser/native_browser_view_views.cc
+++ b/shell/browser/native_browser_view_views.cc
@@ -40,7 +40,6 @@ void NativeBrowserViewViews::UpdateDraggableRegions(
   auto snapped_regions = mojo::Clone(regions);
   for (auto& snapped_region : snapped_regions) {
     snapped_region->bounds.Offset(offset);
-    snapped_region->draggable = true;
   }
 
   draggable_region_ = DraggableRegionsToSkRegion(snapped_regions);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/27131.
Closes https://github.com/electron/electron/issues/27149.

Fixes an issue where some BrowserViews might exhibit unclickable button behavior when loading some websites. What was happening was that #26738 made the mistaken assumption that snapped areas should be draggable, which meant that when users set `-webkit-app-region: no-drag` the areas would become draggable (and thus not clickable).

Tested with https://gist.github.com/f1426205af6799b5d208d1cd54136457 and confirmed not to regress initial fix made in https://github.com/electron/electron/pull/26738 with https://gist.github.com/7278c8c62ec976110afb47ef2d861a7a.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where some draggable regions were not clickable when loaded into BrowserViews on Windows.
