### PR TITLE
fix: default offset when no BrowserView drag regions

### DIFF
--- a/shell/browser/native_browser_view_mac.mm
+++ b/shell/browser/native_browser_view_mac.mm
@@ -294,11 +294,14 @@ void NativeBrowserViewMac::UpdateDraggableRegions(
     draggable_regions_ = mojo::Clone(regions);
 
   std::vector<gfx::Rect> drag_exclude_rects;
-  if (regions.empty()) {
-    drag_exclude_rects.emplace_back(0, 0, webViewWidth, webViewHeight);
+  if (draggable_regions_.empty()) {
+    const auto bounds = GetBounds();
+    drag_exclude_rects.emplace_back(bounds.x(), bounds.y(), webViewWidth,
+                                    webViewHeight);
   } else {
     drag_exclude_rects = CalculateNonDraggableRegions(
-        DraggableRegionsToSkRegion(regions), webViewWidth, webViewHeight);
+        DraggableRegionsToSkRegion(draggable_regions_), webViewWidth,
+        webViewHeight);
   }
 
   UpdateDraggableRegions(drag_exclude_rects);

--- a/shell/browser/ui/drag_util.cc
+++ b/shell/browser/ui/drag_util.cc
@@ -32,8 +32,8 @@ std::unique_ptr<SkRegion> DraggableRegionsToSkRegion(
   auto sk_region = std::make_unique<SkRegion>();
   for (const auto& region : regions) {
     sk_region->op(
-        {region->bounds.x(), region->bounds.y(), region->bounds.right(),
-         region->bounds.bottom()},
+        SkIRect::MakeLTRB(region->bounds.x(), region->bounds.y(),
+                          region->bounds.right(), region->bounds.bottom()),
         region->draggable ? SkRegion::kUnion_Op : SkRegion::kDifference_Op);
   }
   return sk_region;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/27112.

Fixes an issue where non-draggable regions on `BrowserView`s would have an incorrectly assumed `(x,y)` origin of `(0,0)` which is an assumption that can be made for `BrowserWindow`s but _not_ for `BrowserView`s. In the latter case, we should calculate and pass the origin point of the BrowserView and pass it instead.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue where non-draggable regions on BrowserViews could have incorrectly calculated bounds.
