### PR TITLE
build: show more info about exported patches

### DIFF
--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -276,7 +276,7 @@ def export_patches(repo, out_dir, patch_range=None, dry_run=False):
   if patch_range is None:
     patch_range, num_patches = guess_base_commit(repo)
     sys.stderr.write(
-        "Exporting {} patches since {}\n".format(num_patches, patch_range)
+        "Exporting {} patches in {} since {}\n".format(num_patches, repo, patch_range[0:7])
     )
   patch_data = format_patch(repo, patch_range)
   patches = split_patches(patch_data)


### PR DESCRIPTION
Before:
```sh
electron on git:roller/chromium/master ❯ e patches all                  10:05AM
Exporting 11 patches since ef6c61213b14d3cf31e97bbd314e1dda24794a0d
Exporting 1 patches since 78d3966b3c331292ea29ec38661b25df0a245948
Exporting 1 patches since 3b39cefc6195f782b655e2c73ac2a73313c28879
Exporting 32 patches since a2f9a70900a7cde073b1426d71fd211bbd25c342
Exporting 2 patches since cdc0729c8bf8576bfef18629186e1e9ecf1b0d9f
Exporting 1 patches since 74ab5baccc6f7202c8ac69a8d1e152c29dc1ea76
Exporting 108 patches since 232a0643cdd7b98a844b43c6c5e3fa33a2c60f78
Exporting 2 patches since ca058c06474c4492f0fbd517679793234dde6165
Exporting 1 patches since 2c4ee8a32a299eada3cd6e468bbd0a473bfea96d
```

After:
```sh
electron on git:roller/chromium/master ❯ e patches all                  10:07AM
Exporting 11 patches in src/v8 since ef6c612
Exporting 1 patches in src/third_party/squirrel.mac/vendor/Mantle since 78d3966
Exporting 1 patches in src/third_party/depot_tools since 3b39cef
Exporting 32 patches in src/third_party/electron_node since a2f9a70
Exporting 2 patches in src/third_party/squirrel.mac since cdc0729
Exporting 1 patches in src/third_party/squirrel.mac/vendor/ReactiveObjC since 74ab5ba
Exporting 108 patches in src since 232a064
Exporting 2 patches in src/third_party/boringssl/src since ca058c0
Exporting 1 patches in src/third_party/nan since 2c4ee8a
```

Notes: none
