### PR TITLE
docs: coordinate system of badly named method getCursorScreenPoint

### DIFF
--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -92,8 +92,6 @@ Returns [`Point`](structures/point.md)
 
 The current absolute position of the mouse pointer.
 Despite the name of this method, the return value is a DIP point, not a screen point!
-To get the screen point (for example, to pass to [robotjs](https://github.com/octalmage/robotjs) for mouse control),
-use `dipToScreenPoint` on the return value.
 
 ### `screen.getPrimaryDisplay()`
 

--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -91,7 +91,8 @@ The `screen` module has the following methods:
 Returns [`Point`](structures/point.md)
 
 The current absolute position of the mouse pointer.
-Despite the name of this method, the return value is a DIP point, not a screen point!
+
+**Note:** The return value is a DIP point, not a screen physical point.
 
 ### `screen.getPrimaryDisplay()`
 

--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -91,6 +91,9 @@ The `screen` module has the following methods:
 Returns [`Point`](structures/point.md)
 
 The current absolute position of the mouse pointer.
+Despite the name of this method, the return value is a DIP point, not a screen point!
+To get the screen point (for example, to pass to [robotjs](https://github.com/octalmage/robotjs) for mouse control),
+use `dipToScreenPoint` on the return value.
 
 ### `screen.getPrimaryDisplay()`
 


### PR DESCRIPTION
[Electron inherits this confusing name from Chromium](https://github.com/chromium/chromium/blob/99314be8152e688bafbbf9a615536bdbb289ea87/ui/display/win/screen_win.cc#L677-L681). We can also see there that the return value is a DIPPoint, due to `ScreenToDIPPoint` call:

    gfx::Point ScreenWin::GetCursorScreenPoint() {
      POINT pt;
      ::GetCursorPos(&pt);
      return gfx::ToFlooredPoint(ScreenToDIPPoint(gfx::PointF(gfx::Point(pt))));
    }

I lost over a day due to debugging this. I don't think we can change the method name due to backwards compatibility, but we can at least make amends in the documentation.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none