### PR TITLE
docs: coordinate system of Display.bounds and Display.workArea

### DIFF
--- a/docs/api/structures/display.md
+++ b/docs/api/structures/display.md
@@ -11,9 +11,9 @@
 * `colorDepth` Number - The number of bits per pixel.
 * `depthPerComponent` Number - The number of bits per color component.
 * `displayFrequency` Number - The display refresh rate.
-* `bounds` [Rectangle](rectangle.md)
+* `bounds` [Rectangle](rectangle.md) - the bounds of the display in DIP points.
 * `size` [Size](size.md)
-* `workArea` [Rectangle](rectangle.md)
+* `workArea` [Rectangle](rectangle.md) - the work area of the display in DIP points.
 * `workAreaSize` [Size](size.md)
 * `internal` Boolean - `true` for an internal display and `false` for an external display
 


### PR DESCRIPTION
#### Description of Change
These properties are in DIP points (rather than screen points). We can use `screen.dipToScreen*` to convert to screen points.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added

Notes: none.