### PR TITLE
chore: duplicate symbols for mojom interfaces in component build

### DIFF
--- a/shell/common/api/BUILD.gn
+++ b/shell/common/api/BUILD.gn
@@ -9,6 +9,11 @@ mojom("mojo") {
     "//third_party/blink/public/mojom:mojom_core",
     "//ui/gfx/geometry/mojom",
   ]
+  
+  # Needed for component build or we'll get duplicate symbols for many mojom
+  # interfaces aready included in blink_common.dll
+  overridden_deps = [ "//third_party/blink/public/mojom:mojom_core" ]
+  component_deps = [ "//third_party/blink/public/common" ]
 
   enabled_features = []
   if (enable_remote_module) {

--- a/shell/common/api/BUILD.gn
+++ b/shell/common/api/BUILD.gn
@@ -9,7 +9,7 @@ mojom("mojo") {
     "//third_party/blink/public/mojom:mojom_core",
     "//ui/gfx/geometry/mojom",
   ]
-  
+
   # Needed for component build or we'll get duplicate symbols for many mojom
   # interfaces aready included in blink_common.dll
   overridden_deps = [ "//third_party/blink/public/mojom:mojom_core" ]


### PR DESCRIPTION
#### Description of Change

When enabling the component build it fails (at least on windows where I tested) due the fact that many mojom interfaces are included both by linking against `blink_common.dll` and by having `//third_party/blink/public/mojom:mojom_core` (source_set) as a dependency of `shell/common/api:mojo`. 
This change mirrors what happens in `//content/public/common/BUILD.gn`, which overrides the dependency on the source set with one on the blink_common dll, thus fixing the duplicate problem.
The override happens only if the component build is enabled so it shouldn't cause any issues for the builds already working.

#### Note
Note that this change does not make it so that you can build with is_component_build=true right after cloning, for that to happen there are a few more problems that I encountered and that need to be fixed as well, nonetheless the one in this PR was by far the hardest to track down and only requires a small change to a single file be fixed.

Other steps for the component build to succeed:
- Add the cflag `"-Wno-macro-redefined"` to `//third-party/zlib:zlib_warnings` (for some reason ZEXTERN is defined the same way both in `//third-party/zlib/chromeconf.h` and `third-party/zlib/zconf.h` and both headers are included in the build.
- Build electron-node as a static library even in component build. (Building it as a shared_library in component build adds some missing imports)

Notes: none