### PR TITLE
fix: broken PDF viewer

### DIFF
--- a/electron_paks.gni
+++ b/electron_paks.gni
@@ -91,8 +91,10 @@ template("electron_extra_paks") {
     }
 
     # New paks should be added here by default.
-    sources +=
-        [ "$root_gen_dir/content/browser/devtools/devtools_resources.pak" ]
+    sources += [
+      "$root_gen_dir/content/browser/devtools/devtools_resources.pak",
+      "$root_gen_dir/ui/resources/webui_generated_resources.pak",
+    ]
     deps += [ "//content/browser/devtools:devtools_resources" ]
     if (enable_print_preview) {
       sources += [ "$root_gen_dir/chrome/print_preview_resources.pak" ]


### PR DESCRIPTION
#### Description of Change

Fixes broken PDF viewer introduced in https://github.com/electron/electron/pull/25995. 

Refs https://chromium-review.googlesource.com/c/chromium/src/+/2489921.

Verifiable by adding

```js
mainWindow.loadURL('http://www.africau.edu/images/default/sample.pdf')
```

to any fiddle.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes PDFs not loading in the PDF viewer.
