### PR TITLE
test: skip media-started-playing media-paused events test when media not supported

### DIFF
--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -934,6 +934,12 @@ describe('<webview> tag', function () {
   });
 
   describe('media-started-playing media-paused events', () => {
+    beforeEach(function () {
+      if (!document.createElement('audio').canPlayType('audio/wav')) {
+        this.skip();
+      }
+    });
+
     it('emits when audio starts and stops playing', async () => {
       await loadWebView(webview, { src: `file://${fixtures}/pages/base-page.html` });
 


### PR DESCRIPTION
#### Description of Change
This test fails when using a custom ffmpeg build without the appropriate codecs.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)

#### Release Notes
Notes: no-notes