### PR TITLE
test: skip protocol.registerSchemesAsPrivileged stream test when media not supported

### DIFF
--- a/spec-main/api-protocol-spec.ts
+++ b/spec-main/api-protocol-spec.ts
@@ -908,8 +908,12 @@ describe('protocol module', () => {
       await fs.promises.unlink(videoPath);
     });
 
-    beforeEach(async () => {
+    beforeEach(async function () {
       w = new BrowserWindow({ show: false });
+      await w.loadURL('about:blank');
+      if (!await w.webContents.executeJavaScript('document.createElement(\'video\').canPlayType(\'video/webm; codecs="vp8.0"\')')) {
+        this.skip();
+      }
     });
 
     afterEach(async () => {


### PR DESCRIPTION
#### Description of Change
This test fails when using a custom ffmpeg build without the appropriate codecs.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)

#### Release Notes
Notes: no-notes