### PR TITLE
build: fix installing of code-signing identity on macOS

### DIFF
--- a/script/codesign/codesign.cnf
+++ b/script/codesign/codesign.cnf
@@ -1,7 +1,7 @@
 [req]
 default_bits = 4096
 encrypt_key = no
-default_md = 512
+default_md = sha512
 distinguished_name = req_distinguished_name
 prompt = no
 


### PR DESCRIPTION
#### Description of Change
Make it work with a bit different OpenSSL version.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes
