### PR TITLE
fix: set presentationModeEnabled value for PDF viewer

### DIFF
--- a/shell/browser/extensions/api/resources_private/resources_private_api.cc
+++ b/shell/browser/extensions/api/resources_private/resources_private_api.cc
@@ -63,14 +63,17 @@ void AddStringsForPdf(base::DictionaryValue* dict) {
 
 void AddAdditionalDataForPdf(base::DictionaryValue* dict) {
 #if BUILDFLAG(ENABLE_PDF)
+  dict->SetKey("pdfFormSaveEnabled",
+               base::Value(base::FeatureList::IsEnabled(
+                   chrome_pdf::features::kSaveEditedPDFForm)));
   dict->SetStringKey(
       "pdfViewerUpdateEnabledAttribute",
       base::FeatureList::IsEnabled(chrome_pdf::features::kPDFViewerUpdate)
           ? "pdf-viewer-update-enabled"
           : "");
-  dict->SetKey("pdfFormSaveEnabled",
+  dict->SetKey("presentationModeEnabled",
                base::Value(base::FeatureList::IsEnabled(
-                   chrome_pdf::features::kSaveEditedPDFForm)));
+                   chrome_pdf::features::kPdfViewerPresentationMode)));
   dict->SetKey("pdfAnnotationsEnabled", base::Value(false));
   dict->SetKey("printingEnabled", base::Value(true));
 #endif  // BUILDFLAG(ENABLE_PDF)


### PR DESCRIPTION
#### Description of Change

Fixes the following error seen when loading PDFs:

```
[74831:0107/104235.588122:INFO:CONSOLE(222)] "Unexpected condition on chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai/index.html: Could not find value for presentationModeEnabled", source: chrome://resources/js/load_time_data.m.js (222)
[74831:0107/104235.588212:INFO:CONSOLE(222)] "Unexpected condition on chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai/index.html: [undefined] (presentationModeEnabled) is not a boolean", source: chrome://resources/js/load_time_data.m.js (222)
```

cc @MarshallOfSound @jkleinsc 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix missing presentation mode option in PDF viewer.
