### PR TITLE
refactor: use platform-specific TaskRunner to print

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -440,6 +440,29 @@ base::string16 GetDefaultPrinterAsync() {
   }
   return base::UTF8ToUTF16(printer_name);
 }
+
+// Copied from
+// chrome/browser/ui/webui/print_preview/local_printer_handler_default.cc:L36-L54
+scoped_refptr<base::TaskRunner> CreatePrinterHandlerTaskRunner() {
+  // USER_VISIBLE because the result is displayed in the print preview dialog.
+#if !defined(OS_WIN)
+  static constexpr base::TaskTraits kTraits = {
+      base::MayBlock(), base::TaskPriority::USER_VISIBLE};
+#endif
+
+#if defined(USE_CUPS)
+  // CUPS is thread safe.
+  return base::ThreadPool::CreateTaskRunner(kTraits);
+#elif defined(OS_WIN)
+  // Windows drivers are likely not thread-safe and need to be accessed on the
+  // UI thread.
+  return content::GetUIThreadTaskRunner(
+      {base::MayBlock(), base::TaskPriority::USER_VISIBLE});
+#else
+  // Be conservative on unsupported platforms.
+  return base::ThreadPool::CreateSingleThreadTaskRunner(kTraits);
+#endif
+}
 #endif
 
 struct UserDataLink : public base::SupportsUserData::Data {
@@ -590,6 +613,7 @@ WebContents::WebContents(v8::Isolate* isolate,
       devtools_file_system_indexer_(new DevToolsFileSystemIndexer),
       file_task_runner_(
           base::ThreadPool::CreateSequencedTaskRunner({base::MayBlock()})),
+      print_task_runner_(CreatePrinterHandlerTaskRunner()),
       weak_factory_(this) {
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   // WebContents created by extension host will have valid ViewType set.
@@ -623,6 +647,7 @@ WebContents::WebContents(v8::Isolate* isolate,
       devtools_file_system_indexer_(new DevToolsFileSystemIndexer),
       file_task_runner_(
           base::ThreadPool::CreateSequencedTaskRunner({base::MayBlock()})),
+      print_task_runner_(CreatePrinterHandlerTaskRunner()),
       weak_factory_(this) {
   DCHECK(type != Type::kRemote)
       << "Can't take ownership of a remote WebContents";
@@ -638,6 +663,7 @@ WebContents::WebContents(v8::Isolate* isolate,
       devtools_file_system_indexer_(new DevToolsFileSystemIndexer),
       file_task_runner_(
           base::ThreadPool::CreateSequencedTaskRunner({base::MayBlock()})),
+      print_task_runner_(CreatePrinterHandlerTaskRunner()),
       weak_factory_(this) {
   // Read options.
   options.Get("backgroundThrottling", &background_throttling_);
@@ -2514,9 +2540,8 @@ void WebContents::Print(gin::Arguments* args) {
     settings.SetIntKey(printing::kSettingDpiVertical, dpi);
   }
 
-  base::ThreadPool::PostTaskAndReplyWithResult(
-      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_BLOCKING},
-      base::BindOnce(&GetDefaultPrinterAsync),
+  print_task_runner_->PostTaskAndReplyWithResult(
+      FROM_HERE, base::BindOnce(&GetDefaultPrinterAsync),
       base::BindOnce(&WebContents::OnGetDefaultPrinter,
                      weak_factory_.GetWeakPtr(), std::move(settings),
                      std::move(callback), device_name, silent));

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -366,9 +366,6 @@ struct Converter<scoped_refptr<content::DevToolsAgentHost>> {
 
 namespace electron {
 
-class PrintingScopedAllowBlocking : public base::ScopedAllowBlockingForTesting {
-};
-
 namespace api {
 
 namespace {
@@ -427,7 +424,7 @@ base::string16 GetDefaultPrinterAsync() {
 #if defined(OS_WIN)
   // Blocking is needed here because Windows printer drivers are oftentimes
   // not thread-safe and have to be accessed on the UI thread.
-  PrintingScopedAllowBlocking allow_blocking;
+  base::ThreadRestrictions::ScopedAllowIO allow_io;
 #endif
 
   scoped_refptr<printing::PrintBackend> print_backend =
@@ -2546,9 +2543,8 @@ void WebContents::Print(gin::Arguments* args) {
     settings.SetIntKey(printing::kSettingDpiVertical, dpi);
   }
 
-  base::PostTaskAndReplyWithResult(
-      print_task_runner_.get(), FROM_HERE,
-      base::BindOnce(&GetDefaultPrinterAsync),
+  print_task_runner_->PostTaskAndReplyWithResult(
+      FROM_HERE, base::BindOnce(&GetDefaultPrinterAsync),
       base::BindOnce(&WebContents::OnGetDefaultPrinter,
                      weak_factory_.GetWeakPtr(), std::move(settings),
                      std::move(callback), device_name, silent));

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -366,6 +366,9 @@ struct Converter<scoped_refptr<content::DevToolsAgentHost>> {
 
 namespace electron {
 
+class PrintingScopedAllowBlocking : public base::ScopedAllowBlockingForTesting {
+};
+
 namespace api {
 
 namespace {
@@ -421,8 +424,11 @@ bool IsDeviceNameValid(const base::string16& device_name) {
 }
 
 base::string16 GetDefaultPrinterAsync() {
-  base::ScopedBlockingCall scoped_blocking_call(FROM_HERE,
-                                                base::BlockingType::MAY_BLOCK);
+#if defined(OS_WIN)
+  // Blocking is needed here because Windows printer drivers are oftentimes
+  // not thread-safe and have to be accessed on the UI thread.
+  PrintingScopedAllowBlocking allow_blocking;
+#endif
 
   scoped_refptr<printing::PrintBackend> print_backend =
       printing::PrintBackend::CreateInstance(
@@ -2540,8 +2546,9 @@ void WebContents::Print(gin::Arguments* args) {
     settings.SetIntKey(printing::kSettingDpiVertical, dpi);
   }
 
-  print_task_runner_->PostTaskAndReplyWithResult(
-      FROM_HERE, base::BindOnce(&GetDefaultPrinterAsync),
+  base::PostTaskAndReplyWithResult(
+      print_task_runner_.get(), FROM_HERE,
+      base::BindOnce(&GetDefaultPrinterAsync),
       base::BindOnce(&WebContents::OnGetDefaultPrinter,
                      weak_factory_.GetWeakPtr(), std::move(settings),
                      std::move(callback), device_name, silent));

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -783,6 +783,7 @@ class WebContents : public gin::Wrappable<WebContents>,
   DevToolsIndexingJobsMap devtools_indexing_jobs_;
 
   scoped_refptr<base::SequencedTaskRunner> file_task_runner_;
+  scoped_refptr<base::TaskRunner> print_task_runner_;
 
   // Stores the frame thats currently in fullscreen, nullptr if there is none.
   content::RenderFrameHost* fullscreen_frame_ = nullptr;


### PR DESCRIPTION
#### Description of Change

We should be using the upstream TaskRunner logic that Chromium does, as seen [here](https://source.chromium.org/chromium/chromium/src/+/master:chrome/browser/ui/webui/print_preview/local_printer_handler_default.cc;l=36-57;bpv=1;bpt=1). This fixes that. 

cc @deepak1556 @zcbenz @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none