### PR TITLE
docs: renames Comodo to Sectigo

### DIFF
--- a/docs/tutorial/code-signing.md
+++ b/docs/tutorial/code-signing.md
@@ -189,7 +189,7 @@ You can get a code signing certificate from a lot of resellers. Prices vary, so
 it may be worth your time to shop around. Popular resellers include:
 
 * [digicert](https://www.digicert.com/code-signing/microsoft-authenticode.htm)
-* [Comodo](https://www.comodo.com/landing/ssl-certificate/authenticode-signature/)
+* [Sectigo](https://sectigo.com/ssl-certificates-tls/code-signing)
 * [GoDaddy](https://au.godaddy.com/web-security/code-signing-certificate)
 * Amongst others, please shop around to find one that suits your needs, Google
   is your friend 😄


### PR DESCRIPTION
The certificate authority mentioned "Comodo" has recently been renamed "Sectigo". This updates the name of the certificate authority, and the link to get the code signing certificates for Sectigo/Comodo.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [X] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [X] relevant documentation is changed or added
- [X] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none.