### PR TITLE
test: use emittedUntil in PDF Viewer tests

### DIFF
--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { BrowserWindow, WebContents, session, ipcMain, app, protocol, webContents } from 'electron/main';
-import { emittedOnce } from './events-helpers';
+import { emittedOnce, emittedUntil } from './events-helpers';
 import { closeAllWindows } from './window-helpers';
 import * as https from 'https';
 import * as http from 'http';
@@ -1283,15 +1283,17 @@ describe('chromium features', () => {
     it('opens when loading a pdf resource as top level navigation', async () => {
       const w = new BrowserWindow({ show: false });
       w.loadURL(pdfSource);
-      const [, contents] = await emittedOnce(app, 'web-contents-created');
-      expect(contents.getURL()).to.equal('chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai/index.html');
+      await emittedUntil(app, 'web-contents-created', (event: Electron.Event, contents: WebContents) => {
+        return contents.getURL() === 'chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai/index.html';
+      });
     });
 
     it('opens when loading a pdf resource in a iframe', async () => {
       const w = new BrowserWindow({ show: false });
       w.loadFile(path.join(__dirname, 'fixtures', 'pages', 'pdf-in-iframe.html'));
-      const [, contents] = await emittedOnce(app, 'web-contents-created');
-      expect(contents.getURL()).to.equal('chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai/index.html');
+      await emittedUntil(app, 'web-contents-created', (event: Electron.Event, contents: WebContents) => {
+        return contents.getURL() === 'chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai/index.html';
+      });
     });
   });
 


### PR DESCRIPTION
#### Description of Change
We are getting this error when running Electron tests on our internal builds:
```
not ok 1620 chrome extensions emits extension lifecycle events
  AssertionError: expected 'mhjfbmdgcfjbbpaeojofohoefgiehjai' to equal 'eljodghdfipnjkfegmopjgggbaniogag'
      at Context.<anonymous> (electron/spec-main/extensions-spec.ts:135:34)
```
Handle the case when multiple extensions are loaded.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)

#### Release Notes
Notes: no-notes
