### PR TITLE
docs: correct meaning of DesktopCapturerSource.id 

### DIFF
--- a/docs/api/structures/desktop-capturer-source.md
+++ b/docs/api/structures/desktop-capturer-source.md
@@ -3,7 +3,10 @@
 * `id` String - The identifier of a window or screen that can be used as a
   `chromeMediaSourceId` constraint when calling
   [`navigator.webkitGetUserMedia`]. The format of the identifier will be
-  `window:XX` or `screen:XX`, where `XX` is a random generated number.
+  `window:XX:YY` or `screen:ZZ:0`. XX is the windowID/handle. YY is 1 for
+  the current process, and 0 for all others. And ZZ is a sequential number
+  to indicate the screen (this does NOT correspond to the listing 
+  'screen 1', 'screen 2', ..., 'screen n' in the source's name. 
 * `name` String - A screen source will be named either `Entire Screen` or
   `Screen <index>`, while the name of a window source will match the window
   title.

--- a/docs/api/structures/desktop-capturer-source.md
+++ b/docs/api/structures/desktop-capturer-source.md
@@ -4,9 +4,9 @@
   `chromeMediaSourceId` constraint when calling
   [`navigator.webkitGetUserMedia`]. The format of the identifier will be
   `window:XX:YY` or `screen:ZZ:0`. XX is the windowID/handle. YY is 1 for
-  the current process, and 0 for all others. And ZZ is a sequential number
-  to indicate the screen (this does NOT correspond to the listing 
-  'screen 1', 'screen 2', ..., 'screen n' in the source's name. 
+  the current process, and 0 for all others. ZZ is a sequential number
+  that represents the screen, and it does not equal to the index in the
+  source's name.
 * `name` String - A screen source will be named either `Entire Screen` or
   `Screen <index>`, while the name of a window source will match the window
   title.


### PR DESCRIPTION
Corrected the meaning of the id string to match observed behavior (verified on Windows 10 and Ubuntu)

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] relevant documentation is changed or added


#### Release Notes
Corrected the meaning of the id string to match observed behavior (verified on Windows 10 and Ubuntu)

Notes: none