### PR TITLE
chore: only do semantic check on PR titles

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,2 @@
+# Always validate the PR title, and ignore the commits
+titleOnly: true


### PR DESCRIPTION
It is not necessary requiring commit messages to be semantic, since we always do "squash and merge" so as long as the PR title is semantic the final commit message will be too.

This would make it easier to merge PRs from beginners since lots of them do not understand why the "
Semantic Pull Requests" check keeps failing. 

Notes: none