### PR TITLE
chore: remove ancient Browser::Focus implementation on Windows

### DIFF
--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -64,6 +64,18 @@ Browser* Browser::Get() {
   return ElectronBrowserMainParts::Get()->browser();
 }
 
+#if defined(OS_WIN) || defined(OS_LINUX)
+void Browser::Focus(gin::Arguments* args) {
+  // Focus on the first visible window.
+  for (auto* const window : WindowList::GetWindows()) {
+    if (window->IsVisible()) {
+      window->Focus(true);
+      break;
+    }
+  }
+}
+#endif
+
 void Browser::Quit() {
   if (is_quiting_)
     return;

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -84,16 +84,6 @@ bool SetDefaultWebClient(const std::string& protocol) {
   return ran_ok && exit_code == EXIT_SUCCESS;
 }
 
-void Browser::Focus(gin::Arguments* args) {
-  // Focus on the first visible window.
-  for (auto* const window : WindowList::GetWindows()) {
-    if (window->IsVisible()) {
-      window->Focus(true);
-      break;
-    }
-  }
-}
-
 void Browser::AddRecentDocument(const base::FilePath& path) {}
 
 void Browser::ClearRecentDocuments() {}

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -43,19 +43,6 @@ namespace electron {
 
 namespace {
 
-BOOL CALLBACK WindowsEnumerationHandler(HWND hwnd, LPARAM param) {
-  DWORD target_process_id = *reinterpret_cast<DWORD*>(param);
-  DWORD process_id = 0;
-
-  GetWindowThreadProcessId(hwnd, &process_id);
-  if (process_id == target_process_id) {
-    SetFocus(hwnd);
-    return FALSE;
-  }
-
-  return TRUE;
-}
-
 bool GetProcessExecPath(base::string16* exe) {
   base::FilePath path;
   if (!base::PathService::Get(base::FILE_EXE, &path)) {
@@ -291,12 +278,6 @@ std::unique_ptr<FileVersionInfo> FetchFileVersionInfo() {
 Browser::UserTask::UserTask() = default;
 Browser::UserTask::UserTask(const UserTask&) = default;
 Browser::UserTask::~UserTask() = default;
-
-void Browser::Focus(gin::Arguments* args) {
-  // On Windows we just focus on the first window found for this process.
-  DWORD pid = GetCurrentProcessId();
-  EnumWindows(&WindowsEnumerationHandler, reinterpret_cast<LPARAM>(&pid));
-}
 
 void GetFileIcon(const base::FilePath& path,
                  v8::Isolate* isolate,


### PR DESCRIPTION
#### Description of Change

Reuse the general `Browser::Focus` implementation on Windows, and remove the ancient low-level code.

#### Release Notes

Notes: none