### PR TITLE
fix: crash in renderer process with non-context-aware modules

### DIFF
--- a/patches/node/chore_prevent_warn_non_context-aware_native_modules_being_loaded.patch
+++ b/patches/node/chore_prevent_warn_non_context-aware_native_modules_being_loaded.patch
@@ -79,7 +79,7 @@ index f89365a1aa7ffacbb423e01a68f484992751f76f..38d17f4e18aa38fde2c2f59a9816c8fb
    // This stores whether the --abort-on-uncaught-exception flag was passed
    // to Node.
 diff --git a/src/node_binding.cc b/src/node_binding.cc
-index ca5a01f925a2ae69ba4295d82316e546f45c60cd..928afa04f4312db23ef4de8c32e0705784ccee7f 100644
+index ca5a01f925a2ae69ba4295d82316e546f45c60cd..f85ab2332a1c0267bd50d5f979d90e55c84a2990 100644
 --- a/src/node_binding.cc
 +++ b/src/node_binding.cc
 @@ -3,6 +3,7 @@
@@ -90,18 +90,18 @@ index ca5a01f925a2ae69ba4295d82316e546f45c60cd..928afa04f4312db23ef4de8c32e07057
  #include "util.h"
  
  #if HAVE_OPENSSL
-@@ -463,8 +464,19 @@ void DLOpen(const FunctionCallbackInfo<Value>& args) {
+@@ -463,8 +464,20 @@ void DLOpen(const FunctionCallbackInfo<Value>& args) {
        if (mp->nm_context_register_func == nullptr) {
          if (env->force_context_aware()) {
            dlib->Close();
 -          THROW_ERR_NON_CONTEXT_AWARE_DISABLED(env);
--          return false;
 +          char errmsg[1024];
 +          snprintf(errmsg,
 +                   sizeof(errmsg),
 +                   "Loading non-context-aware native module in renderer: '%s', but app.allowRendererProcessReuse is true. See https://github.com/electron/electron/issues/18397.",
 +                   *filename);
 +          env->ThrowError(errmsg);
+           return false;
 +        } else if (env->warn_context_aware()) {
 +          char errmsg[1024];
 +          snprintf(errmsg,


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/27252. 

We need to return `false` when a user attempts to load a non-context-aware native module in the renderer process with `app.allowRendererProcessReuse` enabled. This became an issue in Electron v12 and on because the default of `app.allowRendererProcessReuse` switched to `true`.

Verified by adding `require('node-pty').spawn('/bin/sh')` to an arbitrary renderer process and observing the correct error:

```
"Uncaught Error: Loading non-context-aware native module in renderer: '/private/var/folders/w4/6ckkx75165l174lkz07vgx_m0000gn/T/tmp-64859-HboWDaDRZg4c/node_modules/node-pty/build/Release/pty.node',
```

in console.

cc @deepak1556 @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash in renderer process when loading non-context-aware modules with `app.allowRendererProcessReuse` enabled.