### PR TITLE
chore: fix patch warnings in 11-x-y

### DIFF
--- a/patches/chromium/disable_color_correct_rendering.patch
+++ b/patches/chromium/disable_color_correct_rendering.patch
@@ -81,7 +81,7 @@ index 5575c90cf05ec43bc787711f1d44b8dd58ead99c..a544d836159522751c1262370d8c1562
        !command_line->HasSwitch(switches::kUIDisablePartialSwap);
  #if defined(OS_APPLE)
 diff --git a/components/viz/service/display/gl_renderer.cc b/components/viz/service/display/gl_renderer.cc
-index e5179c0e4971bc593860b1e5b606fec651e6756b..fc7c09d19c60d498885d3e4f1a4a4ac995060e3d 100644
+index e5179c0e4971bc593860b1e5b606fec651e6756b..1f3343600c6203c84586f6e4dcdc5976d9cf44f3 100644
 --- a/components/viz/service/display/gl_renderer.cc
 +++ b/components/viz/service/display/gl_renderer.cc
 @@ -86,6 +86,9 @@
@@ -121,7 +121,7 @@ index e5179c0e4971bc593860b1e5b606fec651e6756b..fc7c09d19c60d498885d3e4f1a4a4ac9
                                         tint_gl_composited_content_,
                                         ShouldApplyRoundedCorner(quad)),
 -                CurrentRenderPassColorSpace(), CurrentRenderPassColorSpace());
-+                PATCH_CS(CurrentRenderPassColorSpace()), 
++                PATCH_CS(CurrentRenderPassColorSpace()),
 +                PATCH_CS(CurrentRenderPassColorSpace()));
  
    gfx::ColorSpace quad_color_space = gfx::ColorSpace::CreateSRGB();

--- a/patches/chromium/fix_disable_usage_of_setapplicationisdaemon_and.patch
+++ b/patches/chromium/fix_disable_usage_of_setapplicationisdaemon_and.patch
@@ -7,7 +7,7 @@ Disable usage of SetApplicationIsDaemon and
 _LSSetApplicationLaunchServicesServerConnectionStatus in MAS builds
 
 diff --git a/sandbox/mac/system_services.cc b/sandbox/mac/system_services.cc
-index 9f5261425162791668c2d15b7ffba091f831d652..590cfca18a648ab90c5f27e723dcb19f8a021ba3 100644
+index 9f5261425162791668c2d15b7ffba091f831d652..dbeb65bad93120dca0d102f733ed8b3981a503eb 100644
 --- a/sandbox/mac/system_services.cc
 +++ b/sandbox/mac/system_services.cc
 @@ -9,6 +9,7 @@
@@ -39,11 +39,11 @@ index 9f5261425162791668c2d15b7ffba091f831d652..590cfca18a648ab90c5f27e723dcb19f
  }
  
  void DisableCoreServicesCheckFix() {
-+#if !defined(MAS_BUILD)
++  #if !defined(MAS_BUILD)
    if (__builtin_available(macOS 10.15, *)) {
      _CSCheckFixDisable();
    }
-+  #endif  
++  #endif
  }
  
  }  // namespace sandbox

--- a/patches/chromium/fix_patch_out_profile_refs_in_accessibility_ui.patch
+++ b/patches/chromium/fix_patch_out_profile_refs_in_accessibility_ui.patch
@@ -7,7 +7,7 @@ This tweaks Chrome's Accessibility support at chrome://accessibility
 to make it usable from Electron by removing Profile references.
 
 diff --git a/chrome/browser/accessibility/accessibility_ui.cc b/chrome/browser/accessibility/accessibility_ui.cc
-index 63dcc09dc00d58eb141a1833db8abe9e8c43f05d..8d6546111e1e3b52b02b19d2f49265c3d8f55cbc 100644
+index 63dcc09dc00d58eb141a1833db8abe9e8c43f05d..c2025573bae6d53543ee9dd620e011735f7b7e6a 100644
 --- a/chrome/browser/accessibility/accessibility_ui.cc
 +++ b/chrome/browser/accessibility/accessibility_ui.cc
 @@ -19,7 +19,9 @@
@@ -101,7 +101,7 @@ index 63dcc09dc00d58eb141a1833db8abe9e8c43f05d..8d6546111e1e3b52b02b19d2f49265c3
 +#if 0
    PrefService* pref = Profile::FromWebUI(web_ui())->GetPrefs();
    bool internal = pref->GetBoolean(prefs::kShowInternalAccessibilityTree);
-+#endif  
++#endif
    std::string accessibility_contents =
 -      web_contents->DumpAccessibilityTree(internal, property_filters);
 +      web_contents->DumpAccessibilityTree(true, property_filters);

--- a/patches/chromium/fix_properly_honor_printing_page_ranges.patch
+++ b/patches/chromium/fix_properly_honor_printing_page_ranges.patch
@@ -23,7 +23,7 @@ index 909aaf6ce803fed32eb1c64c0abcf272731762da..ba431655fe5894c7d9b04464ea36307a
    // Returns true if duplex mode is set.
    bool SetDuplexModeInPrintSettings(mojom::DuplexMode mode);
 diff --git a/printing/printing_context_mac.mm b/printing/printing_context_mac.mm
-index 51c8ff31497fd03842ac9e7da4eab8a5919ec898..53e11ca26e82f2eac18a3465cabde2605b061319 100644
+index 51c8ff31497fd03842ac9e7da4eab8a5919ec898..e48cb9427b8d288f61249e387239c1a2ff59d305 100644
 --- a/printing/printing_context_mac.mm
 +++ b/printing/printing_context_mac.mm
 @@ -188,7 +188,8 @@ PMPaper MatchPaper(CFArrayRef paper_list,
@@ -43,7 +43,7 @@ index 51c8ff31497fd03842ac9e7da4eab8a5919ec898..53e11ca26e82f2eac18a3465cabde260
 +bool PrintingContextMac::SetPrintRangeInPrintSettings(const PageRanges& ranges) {
 +  // Default is already NSPrintAllPages - we can safely bail.
 +  if (ranges.empty())
-+    return true; 
++    return true;
 +
 +  auto* print_settings =
 +      static_cast<PMPrintSettings>([print_info_.get() PMPrintSettings]);

--- a/patches/chromium/gpu_notify_when_dxdiag_request_fails.patch
+++ b/patches/chromium/gpu_notify_when_dxdiag_request_fails.patch
@@ -12,14 +12,14 @@ rendering and there is no signal from browser process on this event
 to identify it.
 
 diff --git a/content/browser/gpu/gpu_data_manager_impl.cc b/content/browser/gpu/gpu_data_manager_impl.cc
-index 1f36d0320040b318c8f8611253ddffb2749e3dc3..15bcff79b7d416366b1d1dc187c966466a2eacb7 100644
+index 1f36d0320040b318c8f8611253ddffb2749e3dc3..eca3b23f0cd294d9a3a5f724f9208a920d40cfbd 100644
 --- a/content/browser/gpu/gpu_data_manager_impl.cc
 +++ b/content/browser/gpu/gpu_data_manager_impl.cc
 @@ -229,6 +229,11 @@ void GpuDataManagerImpl::TerminateInfoCollectionGpuProcess() {
    base::AutoLock auto_lock(lock_);
    private_->TerminateInfoCollectionGpuProcess();
  }
-+  
++
 +bool GpuDataManagerImpl::DxdiagDx12VulkanRequested() const {
 +  base::AutoLock auto_lock(lock_);
 +  return private_->DxdiagDx12VulkanRequested();

--- a/patches/chromium/mas_no_private_api.patch
+++ b/patches/chromium/mas_no_private_api.patch
@@ -421,7 +421,7 @@ index 894ac47e596c1c96a7e0659be80ed8a5629d0304..eca797a24df79b8502b9698e6ed8830a
  
  }  // namespace
 diff --git a/content/renderer/theme_helper_mac.mm b/content/renderer/theme_helper_mac.mm
-index 1db129740992672a4e8be8100da18b6813f1a4f8..5b1e456020ac859c826dbef2826cacf3bb60108b 100644
+index 1db129740992672a4e8be8100da18b6813f1a4f8..dc18d623869e815d4d1ef64ad8bceb6948f5cc9e 100644
 --- a/content/renderer/theme_helper_mac.mm
 +++ b/content/renderer/theme_helper_mac.mm
 @@ -7,11 +7,11 @@
@@ -447,7 +447,7 @@ index 1db129740992672a4e8be8100da18b6813f1a4f8..5b1e456020ac859c826dbef2826cacf3
 +#else
 +    NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
 +    NSString *default_key = @"CGFontRenderingGetFontSmoothingDisabled";
-+    // Check that key exists since boolForKey defaults to NO when the 
++    // Check that key exists since boolForKey defaults to NO when the
 +    // key is missing and this key in fact defaults to YES;
 +    if ([defaults objectForKey:default_key] == nil)
 +      return false;

--- a/patches/node/allow_preventing_preparestacktracecallback.patch
+++ b/patches/node/allow_preventing_preparestacktracecallback.patch
@@ -29,7 +29,7 @@ index e42416b4807fcc9d35a93399b916968b45ed0c7a..adf033f2e1855ad1c9738f9746677566
  
  void SetIsolateMiscHandlers(v8::Isolate* isolate, const IsolateSettings& s) {
 diff --git a/src/node.h b/src/node.h
-index 4c4e55e338d7b42c36818a45f6b41170c495adde..ad2727fbab366df0dcc60d7562951c953f952ae3 100644
+index 0bf092cae8741459aa8ef883d18f5810b255abe3..0917daec298229a942c1790becfbefd19d01fb8d 100644
 --- a/src/node.h
 +++ b/src/node.h
 @@ -305,7 +305,8 @@ class NODE_EXTERN MultiIsolatePlatform : public v8::Platform {

--- a/patches/node/fix_allow_preventing_setpromiserejectcallback.patch
+++ b/patches/node/fix_allow_preventing_setpromiserejectcallback.patch
@@ -28,7 +28,7 @@ index 2bfba8a011c2b902932e6b1714bbb55b945cd96d..28851b8a8f8bdd6dec0f54c62f79fd75
    if (s.flags & DETAILED_SOURCE_POSITIONS_FOR_PROFILING)
      v8::CpuProfiler::UseDetailedSourcePositionsForProfiling(isolate);
 diff --git a/src/node.h b/src/node.h
-index b9b11b4331bd3ae4a87f65758ee09af25222e19a..60ecc3bd3499c23b297bc11e7f052aede20520c2 100644
+index b9b11b4331bd3ae4a87f65758ee09af25222e19a..1e4e805fda7a8dc8d8a2f4f37180dc85ac67128e 100644
 --- a/src/node.h
 +++ b/src/node.h
 @@ -304,12 +304,14 @@ class NODE_EXTERN MultiIsolatePlatform : public v8::Platform {
@@ -43,7 +43,7 @@ index b9b11b4331bd3ae4a87f65758ee09af25222e19a..60ecc3bd3499c23b297bc11e7f052aed
  struct IsolateSettings {
    uint64_t flags = MESSAGE_LISTENER_WITH_ERROR_LEVEL |
 -      DETAILED_SOURCE_POSITIONS_FOR_PROFILING;
-+      DETAILED_SOURCE_POSITIONS_FOR_PROFILING | 
++      DETAILED_SOURCE_POSITIONS_FOR_PROFILING |
 +      SHOULD_SET_PROMISE_REJECTION_CALLBACK;
    v8::MicrotasksPolicy policy = v8::MicrotasksPolicy::kExplicit;
  

--- a/patches/node/n-api_src_provide_asynchronous_cleanup_hooks.patch
+++ b/patches/node/n-api_src_provide_asynchronous_cleanup_hooks.patch
@@ -110,7 +110,7 @@ index 037bdda6f41c825dd112b0cc9fca0ebde47c6163..3b16c0350d8a8494202144407664af41
    Environment* env = Environment::GetCurrent(isolate);
    if (env == nullptr) return -1;
 diff --git a/src/node.h b/src/node.h
-index 60ecc3bd3499c23b297bc11e7f052aede20520c2..4c4e55e338d7b42c36818a45f6b41170c495adde 100644
+index 1e4e805fda7a8dc8d8a2f4f37180dc85ac67128e..0bf092cae8741459aa8ef883d18f5810b255abe3 100644
 --- a/src/node.h
 +++ b/src/node.h
 @@ -739,6 +739,20 @@ NODE_EXTERN void RemoveEnvironmentCleanupHook(v8::Isolate* isolate,


### PR DESCRIPTION
#### Description of Change

Fixes the patch warnings that had accumulated in the 11-x-y branch e.g. trailing whitespaces. No functional changes.

No single stakeholder; random reviewers welcomed

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none