### PR TITLE
fix: prevent crash when keyboard event immediately precedes calling BrowserWindow.close()

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1417,6 +1417,10 @@ void NativeWindowViews::OnWidgetDestroying(views::Widget* widget) {
 #endif
 }
 
+void NativeWindowViews::OnWidgetDestroyed(views::Widget* changed_widget) {
+  widget_destroyed_ = true;
+}
+
 void NativeWindowViews::DeleteDelegate() {
   if (is_modal() && this->parent()) {
     auto* parent = this->parent();
@@ -1513,6 +1517,9 @@ void NativeWindowViews::OnWidgetMove() {
 void NativeWindowViews::HandleKeyboardEvent(
     content::WebContents*,
     const content::NativeWebKeyboardEvent& event) {
+  if (widget_destroyed_)
+    return;
+
 #if defined(OS_LINUX)
   if (event.windows_key_code == ui::VKEY_BROWSER_BACK)
     NotifyWindowExecuteAppCommand(kBrowserBackward);

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -174,6 +174,7 @@ class NativeWindowViews : public NativeWindow,
   void OnWidgetBoundsChanged(views::Widget* widget,
                              const gfx::Rect& bounds) override;
   void OnWidgetDestroying(views::Widget* widget) override;
+  void OnWidgetDestroyed(views::Widget* widget) override;
 
   // views::WidgetDelegate:
   void DeleteDelegate() override;
@@ -313,6 +314,7 @@ class NativeWindowViews : public NativeWindow,
   std::string title_;
   gfx::Size widget_size_;
   double opacity_ = 1.0;
+  bool widget_destroyed_ = false;
 
   DISALLOW_COPY_AND_ASSIGN(NativeWindowViews);
 };

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -110,6 +110,14 @@ describe('BrowserWindow module', () => {
       await emittedOnce(w.webContents, 'before-unload-fired');
     });
 
+    it('should not crash when keyboard event is sent before closing', async () => {
+      await w.loadURL('data:text/html,pls no crash');
+      const closed = emittedOnce(w, 'closed');
+      w.webContents.sendInputEvent({ type: 'keyDown', keyCode: 'Escape' });
+      w.close();
+      await closed;
+    });
+
     describe('when invoked synchronously inside navigation observer', () => {
       let server: http.Server = null as unknown as http.Server;
       let url: string = null as unknown as string;


### PR DESCRIPTION
#### Description of Change

Versions affected:
- 10.2.0
- 11.2.0
- 12.0.0-beta.14

Activating a key to close a window will cause a silent crash. Handling the keyboard event will lead to a nullptr dereferenced in Chromium code if the window widget has already been destroyed.

I've only been able to reproduce this on Windows. I've tested macOS as well.

Callstack when the segfault occurs:
![devenv_2021-01-12_18-49-59OBpJ](https://user-images.githubusercontent.com/1656324/104506044-d0c45700-55b2-11eb-9d4a-66b49b45aa5c.png)

Crash occurs in [ui/views/focus/focus_manager.cc](https://source.chromium.org/chromium/chromium/src/+/master:ui/views/focus/focus_manager.cc;l=614-615;drc=7ccffaf0933ccc647c744bf66971bcf5f33a676a)
```c++
bool FocusManager::RedirectAcceleratorToBubbleAnchorWidget(
    const ui::Accelerator& accelerator) {
  views::BubbleDialogDelegate* widget_delegate =
      widget_->widget_delegate()->AsBubbleDialogDelegate();
```

Here's a fiddle gist to reproduce the crash on Windows:
https://gist.github.com/samuelmaddock/26cea69b6001773453c89a6edd55903f

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed crash when a keyboard event immediately precedes calling `browserWindow.close()` on Windows.
