### PR TITLE
refactor: use platform-specific TaskRunner to print

### DIFF
--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -684,6 +684,8 @@ class WebContents : public gin::Wrappable<WebContents>,
 
   bool initially_shown_ = true;
 
+  scoped_refptr<base::TaskRunner> print_task_runner_;
+
   service_manager::BinderRegistryWithArgs<content::RenderFrameHost*> registry_;
   mojo::ReceiverSet<mojom::ElectronBrowser, content::RenderFrameHost*>
       receivers_;


### PR DESCRIPTION
Backport of #27225.

See that PR for details.

Notes: none