### PR TITLE
feat: add ContextBridgeMutability feature

### DIFF
--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/feature_list.h"
 #include "base/no_destructor.h"
 #include "base/strings/string_number_conversions.h"
 #include "content/public/renderer/render_frame.h"
@@ -24,6 +25,12 @@
 #include "shell/common/world_ids.h"
 #include "third_party/blink/public/web/web_element.h"
 #include "third_party/blink/public/web/web_local_frame.h"
+
+namespace features {
+
+const base::Feature kContextBridgeMutability{"ContextBridgeMutability",
+                                             base::FEATURE_DISABLED_BY_DEFAULT};
+}
 
 namespace electron {
 
@@ -552,6 +559,12 @@ void ExposeAPIInMainWorld(v8::Isolate* isolate,
     if (maybe_proxy.IsEmpty())
       return;
     auto proxy = maybe_proxy.ToLocalChecked();
+
+    if (base::FeatureList::IsEnabled(features::kContextBridgeMutability)) {
+      global.Set(key, proxy);
+      return;
+    }
+
     if (proxy->IsObject() && !proxy->IsTypedArray() &&
         !DeepFreeze(v8::Local<v8::Object>::Cast(proxy), main_context))
       return;

--- a/spec-main/fixtures/api/context-bridge/context-bridge-mutability/index.html
+++ b/spec-main/fixtures/api/context-bridge/context-bridge-mutability/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<body>
+    <script>
+        try {
+            window.str = 'some-modified-text';
+            window.obj.prop = 'obj-modified-prop';
+            window.arr.splice(2, 0, 5);
+        } catch (e) { }
+        console.log(window.str);
+        console.log(window.obj.prop);
+        console.log(window.arr);
+    </script>
+</body>
+
+</html>

--- a/spec-main/fixtures/api/context-bridge/context-bridge-mutability/main.js
+++ b/spec-main/fixtures/api/context-bridge/context-bridge-mutability/main.js
@@ -1,0 +1,20 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+let win;
+app.whenReady().then(function () {
+  win = new BrowserWindow({
+    webPreferences: {
+      contextIsolation: true,
+      preload: path.join(__dirname, 'preload.js')
+    }
+  });
+
+  win.loadFile('index.html');
+
+  win.webContents.on('console-message', (event, level, message) => {
+    console.log(message);
+  });
+
+  win.webContents.on('did-finish-load', () => app.quit());
+});

--- a/spec-main/fixtures/api/context-bridge/context-bridge-mutability/package.json
+++ b/spec-main/fixtures/api/context-bridge/context-bridge-mutability/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "context-bridge-mutability",
+    "main": "main.js"
+}

--- a/spec-main/fixtures/api/context-bridge/context-bridge-mutability/preload.js
+++ b/spec-main/fixtures/api/context-bridge/context-bridge-mutability/preload.js
@@ -1,0 +1,5 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('str', 'some-text');
+contextBridge.exposeInMainWorld('obj', { prop: 'obj-prop' });
+contextBridge.exposeInMainWorld('arr', [1, 2, 3, 4]);


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

This PR adds a new `base::Feature` - `ContextBridgeMutability`. When the feature is enabled values that are exposed via context bridge are not freezed and are not made readonly.

**ContextBridgeMutability off**
![image](https://user-images.githubusercontent.com/22342377/104910402-8f082780-5989-11eb-98cf-bcc41d0c68ac.png)

**ContextBridgeMutability on**
![image](https://user-images.githubusercontent.com/22342377/104910528-b828b800-5989-11eb-9321-ce14335f45df.png)

As discussed with @MarshallOfSound no need to document it.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Adding `ContextBridgeMutability` feature that skips context bridge `DeepFreeze` and `SetReadOnlyNonConfigurable` when exposing a value.
