### PR TITLE
feat: add Windows fallbackToUser option to OpenExternalOptions

### DIFF
--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -40,6 +40,7 @@ Open the given file in the desktop's default manner.
 * `options` Object (optional)
   * `activate` Boolean (optional) _macOS_ - `true` to bring the opened application to the foreground. The default is `true`.
   * `workingDirectory` String (optional) _Windows_ - The working directory.
+  * `fallbackToUser` Boolean (optional) _Windows_ - `true` to open an Open With dialog if the file to be opened does not have a program associated with it. The default is `false`.
 
 Returns `Promise<void>`
 

--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -40,7 +40,7 @@ Open the given file in the desktop's default manner.
 * `options` Object (optional)
   * `activate` Boolean (optional) _macOS_ - `true` to bring the opened application to the foreground. The default is `true`.
   * `workingDirectory` String (optional) _Windows_ - The working directory.
-  * `fallbackToUser` Boolean (optional) _Windows_ - `true` to open an Open With dialog if the file to be opened does not have a program associated with it. The default is `false`.
+  * `fallbackToUser` Boolean (optional) _Windows_ - `true` to show an `Open With` dialog if the file to be opened does not have a program associated with it. The default is `false`.
 
 Returns `Promise<void>`
 

--- a/shell/common/api/electron_api_shell.cc
+++ b/shell/common/api/electron_api_shell.cc
@@ -63,6 +63,7 @@ v8::Local<v8::Promise> OpenExternal(const GURL& url, gin::Arguments* args) {
     if (args->GetNext(&obj)) {
       obj.Get("activate", &options.activate);
       obj.Get("workingDirectory", &options.working_dir);
+      obj.Get("fallbackToUser", &options.fallback_to_user);
     }
   }
 

--- a/shell/common/platform_util.h
+++ b/shell/common/platform_util.h
@@ -31,6 +31,7 @@ void OpenPath(const base::FilePath& full_path, OpenCallback callback);
 
 struct OpenExternalOptions {
   bool activate = true;
+  bool fallbackToUser = false;
   base::FilePath working_dir;
 };
 

--- a/shell/common/platform_util.h
+++ b/shell/common/platform_util.h
@@ -31,7 +31,7 @@ void OpenPath(const base::FilePath& full_path, OpenCallback callback);
 
 struct OpenExternalOptions {
   bool activate = true;
-  bool fallbackToUser = false;
+  bool fallback_to_user = false;
   base::FilePath working_dir;
 };
 

--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -244,17 +244,17 @@ std::string OpenExternalOnWorkerThread(
   base::string16 escaped_url = L"\"" + base::UTF8ToUTF16(url.spec()) + L"\"";
   base::string16 working_dir = options.working_dir.value();
 
-  ULONG openCallRes = reinterpret_cast<ULONG>(ShellExecuteW(
+  LONGLONG open_call_res = reinterpret_cast<LONGLONG>(ShellExecuteW(
       nullptr, L"open", escaped_url.c_str(), nullptr,
       working_dir.empty() ? nullptr : working_dir.c_str(), SW_SHOWNORMAL));
-  if (options.fallbackToUser && openCallRes == SE_ERR_NOASSOC) {
+  if (options.fallback_to_user && open_call_res == SE_ERR_NOASSOC) {
     const OPENASINFO info = {escaped_url.c_str(), nullptr,
                              OAIF_ALLOW_REGISTRATION | OAIF_REGISTER_EXT |
                                  OAIF_EXEC | OAIF_FILE_IS_URI};
     if (SHOpenWithDialog(NULL, &info) != S_OK) {
       return "Failed to open";
     }
-  } else if (openCallRes <= 32) {
+  } else if (open_call_res <= 32) {
     return "Failed to open";
   }
   return "";

--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -248,7 +248,13 @@ std::string OpenExternalOnWorkerThread(
           ShellExecuteW(nullptr, L"open", escaped_url.c_str(), nullptr,
                         working_dir.empty() ? nullptr : working_dir.c_str(),
                         SW_SHOWNORMAL)) <= 32) {
-    return "Failed to open";
+    if (!options.fallbackToUser ||
+        reinterpret_cast<ULONG_PTR>(
+            ShellExecuteW(nullptr, L"openas", escaped_url.c_str(), nullptr,
+                          working_dir.empty() ? nullptr : working_dir.c_str(),
+                          SW_SHOWNORMAL)) <= 32) {
+      return "Failed to open";
+    }
   }
   return "";
 }

--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -244,17 +244,16 @@ std::string OpenExternalOnWorkerThread(
   base::string16 escaped_url = L"\"" + base::UTF8ToUTF16(url.spec()) + L"\"";
   base::string16 working_dir = options.working_dir.value();
 
-  if (reinterpret_cast<ULONG_PTR>(
-          ShellExecuteW(nullptr, L"open", escaped_url.c_str(), nullptr,
-                        working_dir.empty() ? nullptr : working_dir.c_str(),
-                        SW_SHOWNORMAL)) <= 32) {
-    if (!options.fallbackToUser ||
-        reinterpret_cast<ULONG_PTR>(
-            ShellExecuteW(nullptr, L"openas", escaped_url.c_str(), nullptr,
-                          working_dir.empty() ? nullptr : working_dir.c_str(),
-                          SW_SHOWNORMAL)) <= 32) {
-      return "Failed to open";
-    }
+  ULONG_PTR res = reinterpret_cast<ULONG_PTR>(ShellExecuteW(
+      nullptr, L"open", escaped_url.c_str(), nullptr,
+      working_dir.empty() ? nullptr : working_dir.c_str(), SW_SHOWNORMAL));
+  if (options.fallbackToUser && res == SE_ERR_NOASSOC) {
+    res = reinterpret_cast<ULONG_PTR>(ShellExecuteW(
+        nullptr, L"openas", escaped_url.c_str(), nullptr,
+        working_dir.empty() ? nullptr : working_dir.c_str(), SW_SHOWNORMAL));
+  }
+  if (res <= 32) {
+    return "Failed to open";
   }
   return "";
 }

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -1056,7 +1056,8 @@ shell.openPath('/home/user/Desktop/test.txt').then(err => {
 })
 
 shell.openExternal('https://github.com', {
-  activate: false
+  activate: false,
+  fallbackToUser: true
 }).then(() => {})
 
 shell.beep()

--- a/spec/ts-smoke/electron/main.ts
+++ b/spec/ts-smoke/electron/main.ts
@@ -1056,8 +1056,7 @@ shell.openPath('/home/user/Desktop/test.txt').then(err => {
 })
 
 shell.openExternal('https://github.com', {
-  activate: false,
-  fallbackToUser: true
+  activate: false
 }).then(() => {})
 
 shell.beep()


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
On Windows, if a file does not have a program associated with it, the open call fails with error SE_ERR_NOASSOC. this PR adds the option to make an openas call instead in that case, which opens an `Open With` dialog.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [X] tests are changed (https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [X] relevant documentation is changed or added
- [X] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `fallbackToUser` option to OpenExternalOptions for Windows. <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
