### PR TITLE
fix: increase stack size on windows

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1154,6 +1154,19 @@ if (is_mac) {
         ldflags += [ "/guard:cf,nolongjmp" ]
       }
 
+      if (current_cpu == "x86") {
+        # Set the initial stack size to 0.5MiB, instead of the 1.5MiB needed by
+        # Chrome's main thread. This saves significant memory on threads (like
+        # those in the Windows thread pool, and others) whose stack size we can
+        # only control through this setting. Because Chrome's main thread needs
+        # a minimum 1.5 MiB stack, the main thread (in 32-bit builds only) uses
+        # fibers to switch to a 1.5 MiB stack before running any other code.
+        ldflags += [ "/STACK:0x80000" ]
+      } else {
+        # Increase the initial stack size. The default is 1MB, this is 8MB.
+        ldflags += [ "/STACK:0x800000" ]
+      }
+
       # This is to support renaming of electron.exe. node-gyp has hard-coded
       # executable names which it will recognise as node. This module definition
       # file claims that the electron executable is in fact named "node.exe",


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/microsoft/vscode/issues/112172

Upstream issue https://bugs.chromium.org/p/chromium/issues/detail?id=1164201

Fix is based on https://bugs.chromium.org/p/chromium/issues/detail?id=1164201#c6

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Increase stack size on windows x64 to 8MB
