### PR TITLE
fix: actually clear pending requests in DevToolsAgentHost

### DIFF
--- a/shell/browser/api/electron_api_debugger.cc
+++ b/shell/browser/api/electron_api_debugger.cc
@@ -185,6 +185,7 @@ v8::Local<v8::Promise> Debugger::SendCommand(gin::Arguments* args) {
 void Debugger::ClearPendingRequests() {
   for (auto& it : pending_requests_)
     it.second.RejectWithErrorMessage("target closed while handling command");
+  pending_requests_.clear();
 }
 
 // static


### PR DESCRIPTION
#### Description of Change

Refs https://source.chromium.org/chromium/chromium/src/+/master:chrome/browser/extensions/api/debugger/debugger_api.cc;l=322-326;drc=7f6312f028d758cd23cd0d6d8df5ffaf4a5d23a7;bpv=0;bpt=1

cc @deepak1556 @zcbenz @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
