### PR TITLE
docs: correct typo in native file drag and drop

### DIFF
--- a/docs/tutorial/native-file-drag-drop.md
+++ b/docs/tutorial/native-file-drag-drop.md
@@ -52,7 +52,7 @@ ipcMain.on('ondragstart', (event, filePath) => {
 ```
 
 After launching the Electron application, try dragging and dropping
-the item from the BroswerWindow onto your desktop. In this guide,
+the item from the BrowserWindow onto your desktop. In this guide,
 the item is a Markdown file located in the root of the project:
 
 ![Drag and drop](../images/drag-and-drop.gif)


### PR DESCRIPTION
#### Description of Change

Corrects minor typo in the documentation of Native file drag and drop.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: `docs: correct typo in native file drag and drop`<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->

I am a bit intimidated by the amount of guidelines for such a big project; I'm happy to update if I missed something!
