### PR TITLE
chore: cherry-pick d866af575997 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -166,3 +166,4 @@ only_zero_out_cross-origin_audio_that_doesn_t_get_played_out.patch
 fix_setparentacessibile_crash_win.patch
 backport_1142331.patch
 backport_1151865.patch
+cherry-pick-d866af575997.patch

--- a/patches/chromium/cherry-pick-d866af575997.patch
+++ b/patches/chromium/cherry-pick-d866af575997.patch
@@ -1,0 +1,40 @@
+From d866af575997f2b9c0476be5c58c09b7b7885c4e Mon Sep 17 00:00:00 2001
+From: Raymond Toy <rtoy@chromium.org>
+Date: Mon, 07 Dec 2020 17:55:30 +0000
+Subject: [PATCH] Clear handlers when the base context goes away.
+
+Previously, in BaseAudioContext::Clear() we called
+GetDeferredTaskHandler().ClearHandlersToBeDeleted().  But this was
+also called in DeferredTaskHandler::ContextWillBeDestroyed(), which is
+called in BaseAudioContext::~BaseAudioContext().
+
+There's no need to call this twice while handling the audio context
+going away.
+
+Manually verified that the tests from issue 1125635 and 1153658 work,
+and the deadlock in issue 1136571 is gone.
+
+Bug: 1150065, 1153658
+Change-Id: Iee15c31dc637bf82d66bfd79d5238b1f80813153
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2575418
+Commit-Queue: Raymond Toy <rtoy@chromium.org>
+Reviewed-by: Hongchan Choi <hongchan@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#834265}
+---
+
+diff --git a/third_party/blink/renderer/modules/webaudio/base_audio_context.cc b/third_party/blink/renderer/modules/webaudio/base_audio_context.cc
+index db8b7c5c..7d20049 100644
+--- a/third_party/blink/renderer/modules/webaudio/base_audio_context.cc
++++ b/third_party/blink/renderer/modules/webaudio/base_audio_context.cc
+@@ -141,9 +141,8 @@
+ }
+ 
+ void BaseAudioContext::Clear() {
+-  // The audio rendering thread is dead.  Nobody will schedule AudioHandler
+-  // deletion.  Let's do it ourselves.
+-  GetDeferredTaskHandler().ClearHandlersToBeDeleted();
++  // Make a note that we've cleared out the context so that there's no pending
++  // activity.
+   is_cleared_ = true;
+ }
+ 

--- a/patches/chromium/cherry-pick-d866af575997.patch
+++ b/patches/chromium/cherry-pick-d866af575997.patch
@@ -1,7 +1,7 @@
-From d866af575997f2b9c0476be5c58c09b7b7885c4e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Raymond Toy <rtoy@chromium.org>
-Date: Mon, 07 Dec 2020 17:55:30 +0000
-Subject: [PATCH] Clear handlers when the base context goes away.
+Date: Mon, 7 Dec 2020 17:55:30 +0000
+Subject: Clear handlers when the base context goes away.
 
 Previously, in BaseAudioContext::Clear() we called
 GetDeferredTaskHandler().ClearHandlersToBeDeleted().  But this was
@@ -20,16 +20,15 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2575418
 Commit-Queue: Raymond Toy <rtoy@chromium.org>
 Reviewed-by: Hongchan Choi <hongchan@chromium.org>
 Cr-Commit-Position: refs/heads/master@{#834265}
----
 
 diff --git a/third_party/blink/renderer/modules/webaudio/base_audio_context.cc b/third_party/blink/renderer/modules/webaudio/base_audio_context.cc
-index db8b7c5c..7d20049 100644
+index 8d008c2143088426fe617ecbf47a93d09eea0c6b..733031f80e1d0ae4c104c6969cacf7b81ab01196 100644
 --- a/third_party/blink/renderer/modules/webaudio/base_audio_context.cc
 +++ b/third_party/blink/renderer/modules/webaudio/base_audio_context.cc
-@@ -141,9 +141,8 @@
- }
+@@ -141,9 +141,8 @@ void BaseAudioContext::Initialize() {
  
  void BaseAudioContext::Clear() {
+   destination_node_.Clear();
 -  // The audio rendering thread is dead.  Nobody will schedule AudioHandler
 -  // deletion.  Let's do it ourselves.
 -  GetDeferredTaskHandler().ClearHandlersToBeDeleted();


### PR DESCRIPTION
Clear handlers when the base context goes away.

Previously, in BaseAudioContext::Clear() we called
GetDeferredTaskHandler().ClearHandlersToBeDeleted().  But this was
also called in DeferredTaskHandler::ContextWillBeDestroyed(), which is
called in BaseAudioContext::~BaseAudioContext().

There's no need to call this twice while handling the audio context
going away.

Manually verified that the tests from issue 1125635 and 1153658 work,
and the deadlock in issue 1136571 is gone.

Bug: 1150065, 1153658
Change-Id: Iee15c31dc637bf82d66bfd79d5238b1f80813153
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2575418
Commit-Queue: Raymond Toy <rtoy@chromium.org>
Reviewed-by: Hongchan Choi <hongchan@chromium.org>
Cr-Commit-Position: refs/heads/master@{#834265}


Notes: Security: backported fix for 1150065, 1153658.