### PR TITLE
chore: cherry-pick 3ca3d70c7af5 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -125,3 +125,4 @@ merge_m86_ensure_that_buffers_used_by_imagedecoder_haven_t_been.patch
 cherry-pick-2d18de63acf1.patch
 only_zero_out_cross-origin_audio_that_doesn_t_get_played_out.patch
 fix_setparentacessibile_crash_win.patch
+cherry-pick-3ca3d70c7af5.patch

--- a/patches/chromium/cherry-pick-3ca3d70c7af5.patch
+++ b/patches/chromium/cherry-pick-3ca3d70c7af5.patch
@@ -1,7 +1,8 @@
-From 3ca3d70c7af50aa7024a351f70b289b8ccdc4a5f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Yuri Wiitala <miu@chromium.org>
 Date: Thu, 10 Dec 2020 18:07:39 +0000
-Subject: [PATCH] Minor UI logic changes to prevent a UAF bug when starting tab capture.
+Subject: Minor UI logic changes to prevent a UAF bug when starting tab
+ capture.
 
 See discussion in crbug 1155426 for details. Changes:
 
@@ -17,16 +18,15 @@ Reviewed-by: Guido Urdaneta <guidou@chromium.org>
 Reviewed-by: Marina Ciocea <marinaciocea@chromium.org>
 Commit-Queue: Yuri Wiitala <miu@chromium.org>
 Cr-Commit-Position: refs/heads/master@{#835736}
----
 
 diff --git a/chrome/browser/media/webrtc/media_stream_capture_indicator.cc b/chrome/browser/media/webrtc/media_stream_capture_indicator.cc
-index 7858dd5..0296c44 100644
+index ce93d308a3d1099d9edbeea88ce8d05e60158117..99203ebb36edc21697518d172d67831deed8ba04 100644
 --- a/chrome/browser/media/webrtc/media_stream_capture_indicator.cc
 +++ b/chrome/browser/media/webrtc/media_stream_capture_indicator.cc
-@@ -208,7 +208,12 @@
-       const std::string& label,
-       std::vector<content::DesktopMediaID> screen_capture_ids,
-       StateChangeCallback state_change_callback) override {
+@@ -186,7 +186,12 @@ class MediaStreamCaptureIndicator::UIDelegate : public content::MediaStreamUI {
+   gfx::NativeViewId OnStarted(
+       base::OnceClosure stop_callback,
+       content::MediaStreamUI::SourceCallback source_callback) override {
 -    DCHECK(!started_);
 +    if (started_) {
 +      // Ignore possibly-compromised renderers that might call
@@ -38,10 +38,10 @@ index 7858dd5..0296c44 100644
  
      if (device_usage_) {
 diff --git a/chrome/browser/ui/views/tab_sharing/tab_sharing_ui_views.cc b/chrome/browser/ui/views/tab_sharing/tab_sharing_ui_views.cc
-index 8c73fc2..1ad0717 100644
+index 1582ccedd3fac5368e7adf94ec222e5d85b18aab..35e4f3e93c41f52fb50599da4050c0f3c25dd0d4 100644
 --- a/chrome/browser/ui/views/tab_sharing/tab_sharing_ui_views.cc
 +++ b/chrome/browser/ui/views/tab_sharing/tab_sharing_ui_views.cc
-@@ -135,8 +135,10 @@
+@@ -134,8 +134,10 @@ TabSharingUIViews::TabSharingUIViews(const content::DesktopMediaID& media_id,
  }
  
  TabSharingUIViews::~TabSharingUIViews() {

--- a/patches/chromium/cherry-pick-3ca3d70c7af5.patch
+++ b/patches/chromium/cherry-pick-3ca3d70c7af5.patch
@@ -1,0 +1,56 @@
+From 3ca3d70c7af50aa7024a351f70b289b8ccdc4a5f Mon Sep 17 00:00:00 2001
+From: Yuri Wiitala <miu@chromium.org>
+Date: Thu, 10 Dec 2020 18:07:39 +0000
+Subject: [PATCH] Minor UI logic changes to prevent a UAF bug when starting tab capture.
+
+See discussion in crbug 1155426 for details. Changes:
+
+MediaStreamCaptureIndicator::UIDelegate: Ignore multiple calls to
+OnStarted().
+
+TabSharingUIViews: Unconditionally execute clean-up tasks in destructor.
+
+Bug: 1155426
+Change-Id: I392fba38118ce51744ba36b4dec19ebfe39f1fbe
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2581028
+Reviewed-by: Guido Urdaneta <guidou@chromium.org>
+Reviewed-by: Marina Ciocea <marinaciocea@chromium.org>
+Commit-Queue: Yuri Wiitala <miu@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#835736}
+---
+
+diff --git a/chrome/browser/media/webrtc/media_stream_capture_indicator.cc b/chrome/browser/media/webrtc/media_stream_capture_indicator.cc
+index 7858dd5..0296c44 100644
+--- a/chrome/browser/media/webrtc/media_stream_capture_indicator.cc
++++ b/chrome/browser/media/webrtc/media_stream_capture_indicator.cc
+@@ -208,7 +208,12 @@
+       const std::string& label,
+       std::vector<content::DesktopMediaID> screen_capture_ids,
+       StateChangeCallback state_change_callback) override {
+-    DCHECK(!started_);
++    if (started_) {
++      // Ignore possibly-compromised renderers that might call
++      // MediaStreamDispatcherHost::OnStreamStarted() more than once.
++      // See: https://crbug.com/1155426
++      return 0;
++    }
+     started_ = true;
+ 
+     if (device_usage_) {
+diff --git a/chrome/browser/ui/views/tab_sharing/tab_sharing_ui_views.cc b/chrome/browser/ui/views/tab_sharing/tab_sharing_ui_views.cc
+index 8c73fc2..1ad0717 100644
+--- a/chrome/browser/ui/views/tab_sharing/tab_sharing_ui_views.cc
++++ b/chrome/browser/ui/views/tab_sharing/tab_sharing_ui_views.cc
+@@ -135,8 +135,10 @@
+ }
+ 
+ TabSharingUIViews::~TabSharingUIViews() {
+-  if (!infobars_.empty())
+-    StopSharing();
++  // Unconditionally call StopSharing(), to ensure all clean-up has been
++  // performed if tasks race (e.g., OnStarted() is called after
++  // OnInfoBarRemoved()). See: https://crbug.com/1155426
++  StopSharing();
+ }
+ 
+ gfx::NativeViewId TabSharingUIViews::OnStarted(


### PR DESCRIPTION
Minor UI logic changes to prevent a UAF bug when starting tab capture.

See discussion in crbug 1155426 for details. Changes:

MediaStreamCaptureIndicator::UIDelegate: Ignore multiple calls to
OnStarted().

TabSharingUIViews: Unconditionally execute clean-up tasks in destructor.

Bug: 1155426
Change-Id: I392fba38118ce51744ba36b4dec19ebfe39f1fbe
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2581028
Reviewed-by: Guido Urdaneta <guidou@chromium.org>
Reviewed-by: Marina Ciocea <marinaciocea@chromium.org>
Commit-Queue: Yuri Wiitala <miu@chromium.org>
Cr-Commit-Position: refs/heads/master@{#835736}


Notes: Security: backported fix for 1155426.