### PR TITLE
chore: cherry-pick da9b5ec032ad from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -125,3 +125,4 @@ merge_m86_ensure_that_buffers_used_by_imagedecoder_haven_t_been.patch
 cherry-pick-2d18de63acf1.patch
 only_zero_out_cross-origin_audio_that_doesn_t_get_played_out.patch
 fix_setparentacessibile_crash_win.patch
+cherry-pick-da9b5ec032ad.patch

--- a/patches/chromium/cherry-pick-da9b5ec032ad.patch
+++ b/patches/chromium/cherry-pick-da9b5ec032ad.patch
@@ -1,7 +1,7 @@
-From da9b5ec032ad503c5c0c147b6b2ce20ee86270e7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniele Castagna <dcastagna@chromium.org>
 Date: Mon, 14 Dec 2020 23:03:31 +0000
-Subject: [PATCH] viz: Destroy |gpu_memory_buffer_factory_| on IOThread
+Subject: viz: Destroy |gpu_memory_buffer_factory_| on IOThread
 
 |gpu_memory_buffer_factory_| weak pointers are checked on the
 IOThread.
@@ -18,13 +18,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2563077
 Commit-Queue: Daniele Castagna <dcastagna@chromium.org>
 Reviewed-by: Andres Calderon Jaramillo <andrescj@chromium.org>
 Cr-Commit-Position: refs/heads/master@{#836827}
----
 
 diff --git a/components/viz/service/gl/gpu_service_impl.cc b/components/viz/service/gl/gpu_service_impl.cc
-index 0a19757..03834a7 100644
+index 98cdbff9bf021f9665abdb339a25753b2e7b4807..6ab1e86035089b748eb636cc5e654702ee19fd9e 100644
 --- a/components/viz/service/gl/gpu_service_impl.cc
 +++ b/components/viz/service/gl/gpu_service_impl.cc
-@@ -430,16 +430,18 @@
+@@ -428,16 +428,18 @@ GpuServiceImpl::~GpuServiceImpl() {
    GetLogMessageManager()->ShutdownLogging();
  
    // Destroy the receiver on the IO thread.
@@ -53,7 +52,7 @@ index 0a19757..03834a7 100644
  
    if (watchdog_thread_)
      watchdog_thread_->OnGpuProcessTearDown();
-@@ -447,6 +449,26 @@
+@@ -445,6 +447,26 @@ GpuServiceImpl::~GpuServiceImpl() {
    media_gpu_channel_manager_.reset();
    gpu_channel_manager_.reset();
  

--- a/patches/chromium/cherry-pick-da9b5ec032ad.patch
+++ b/patches/chromium/cherry-pick-da9b5ec032ad.patch
@@ -1,0 +1,82 @@
+From da9b5ec032ad503c5c0c147b6b2ce20ee86270e7 Mon Sep 17 00:00:00 2001
+From: Daniele Castagna <dcastagna@chromium.org>
+Date: Mon, 14 Dec 2020 23:03:31 +0000
+Subject: [PATCH] viz: Destroy |gpu_memory_buffer_factory_| on IOThread
+
+|gpu_memory_buffer_factory_| weak pointers are checked on the
+IOThread.
+Weak pointers should be invalidated on the same thread that
+checks them.
+
+This CL moves the destruction of |gpu_memory_buffer_factory_|
+on the IOThread to avoid possible use after free issues.
+
+Bug: 1152645
+
+Change-Id: I0d42814f0e435a3746728515da1f32d08a1252cf
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2563077
+Commit-Queue: Daniele Castagna <dcastagna@chromium.org>
+Reviewed-by: Andres Calderon Jaramillo <andrescj@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#836827}
+---
+
+diff --git a/components/viz/service/gl/gpu_service_impl.cc b/components/viz/service/gl/gpu_service_impl.cc
+index 0a19757..03834a7 100644
+--- a/components/viz/service/gl/gpu_service_impl.cc
++++ b/components/viz/service/gl/gpu_service_impl.cc
+@@ -430,16 +430,18 @@
+   GetLogMessageManager()->ShutdownLogging();
+ 
+   // Destroy the receiver on the IO thread.
+-  base::WaitableEvent wait;
+-  auto destroy_receiver_task = base::BindOnce(
+-      [](mojo::Receiver<mojom::GpuService>* receiver,
+-         base::WaitableEvent* wait) {
+-        receiver->reset();
+-        wait->Signal();
+-      },
+-      &receiver_, &wait);
+-  if (io_runner_->PostTask(FROM_HERE, std::move(destroy_receiver_task)))
+-    wait.Wait();
++  {
++    base::WaitableEvent wait;
++    auto destroy_receiver_task = base::BindOnce(
++        [](mojo::Receiver<mojom::GpuService>* receiver,
++           base::WaitableEvent* wait) {
++          receiver->reset();
++          wait->Signal();
++        },
++        &receiver_, base::Unretained(&wait));
++    if (io_runner_->PostTask(FROM_HERE, std::move(destroy_receiver_task)))
++      wait.Wait();
++  }
+ 
+   if (watchdog_thread_)
+     watchdog_thread_->OnGpuProcessTearDown();
+@@ -447,6 +449,26 @@
+   media_gpu_channel_manager_.reset();
+   gpu_channel_manager_.reset();
+ 
++  // Destroy |gpu_memory_buffer_factory_| on the IO thread since its weakptrs
++  // are checked there.
++  {
++    base::WaitableEvent wait;
++    auto destroy_gmb_factory = base::BindOnce(
++        [](std::unique_ptr<gpu::GpuMemoryBufferFactory> gmb_factory,
++           base::WaitableEvent* wait) {
++          gmb_factory.reset();
++          wait->Signal();
++        },
++        std::move(gpu_memory_buffer_factory_), base::Unretained(&wait));
++
++    if (io_runner_->PostTask(FROM_HERE, std::move(destroy_gmb_factory))) {
++      // |gpu_memory_buffer_factory_| holds a raw pointer to
++      // |vulkan_context_provider_|. Waiting here enforces the correct order
++      // of destruction.
++      wait.Wait();
++    }
++  }
++
+   // Scheduler must be destroyed before sync point manager is destroyed.
+   scheduler_.reset();
+   owned_sync_point_manager_.reset();


### PR DESCRIPTION
viz: Destroy |gpu_memory_buffer_factory_| on IOThread

|gpu_memory_buffer_factory_| weak pointers are checked on the
IOThread.
Weak pointers should be invalidated on the same thread that
checks them.

This CL moves the destruction of |gpu_memory_buffer_factory_|
on the IOThread to avoid possible use after free issues.

Bug: 1152645

Change-Id: I0d42814f0e435a3746728515da1f32d08a1252cf
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2563077
Commit-Queue: Daniele Castagna <dcastagna@chromium.org>
Reviewed-by: Andres Calderon Jaramillo <andrescj@chromium.org>
Cr-Commit-Position: refs/heads/master@{#836827}


Notes: Security: backported fix for 1152645.