### PR TITLE
chore: cherry-pick da9b5ec032ad from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -166,3 +166,4 @@ only_zero_out_cross-origin_audio_that_doesn_t_get_played_out.patch
 fix_setparentacessibile_crash_win.patch
 backport_1142331.patch
 backport_1151865.patch
+cherry-pick-da9b5ec032ad.patch

--- a/patches/chromium/cherry-pick-da9b5ec032ad.patch
+++ b/patches/chromium/cherry-pick-da9b5ec032ad.patch
@@ -1,7 +1,7 @@
-From da9b5ec032ad503c5c0c147b6b2ce20ee86270e7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniele Castagna <dcastagna@chromium.org>
 Date: Mon, 14 Dec 2020 23:03:31 +0000
-Subject: [PATCH] viz: Destroy |gpu_memory_buffer_factory_| on IOThread
+Subject: viz: Destroy |gpu_memory_buffer_factory_| on IOThread
 
 |gpu_memory_buffer_factory_| weak pointers are checked on the
 IOThread.
@@ -18,13 +18,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2563077
 Commit-Queue: Daniele Castagna <dcastagna@chromium.org>
 Reviewed-by: Andres Calderon Jaramillo <andrescj@chromium.org>
 Cr-Commit-Position: refs/heads/master@{#836827}
----
 
 diff --git a/components/viz/service/gl/gpu_service_impl.cc b/components/viz/service/gl/gpu_service_impl.cc
-index 0a19757..03834a7 100644
+index a1a9ea18efad22dedf420c1dd0e9569868125148..6d955aa1ddd8d60df4d93f0ae22b48f2ae2aa299 100644
 --- a/components/viz/service/gl/gpu_service_impl.cc
 +++ b/components/viz/service/gl/gpu_service_impl.cc
-@@ -430,16 +430,18 @@
+@@ -362,16 +362,18 @@ GpuServiceImpl::~GpuServiceImpl() {
    GetLogMessageManager()->ShutdownLogging();
  
    // Destroy the receiver on the IO thread.
@@ -53,7 +52,7 @@ index 0a19757..03834a7 100644
  
    if (watchdog_thread_)
      watchdog_thread_->OnGpuProcessTearDown();
-@@ -447,6 +449,26 @@
+@@ -379,6 +381,26 @@ GpuServiceImpl::~GpuServiceImpl() {
    media_gpu_channel_manager_.reset();
    gpu_channel_manager_.reset();
  

--- a/patches/chromium/cherry-pick-da9b5ec032ad.patch
+++ b/patches/chromium/cherry-pick-da9b5ec032ad.patch
@@ -1,0 +1,82 @@
+From da9b5ec032ad503c5c0c147b6b2ce20ee86270e7 Mon Sep 17 00:00:00 2001
+From: Daniele Castagna <dcastagna@chromium.org>
+Date: Mon, 14 Dec 2020 23:03:31 +0000
+Subject: [PATCH] viz: Destroy |gpu_memory_buffer_factory_| on IOThread
+
+|gpu_memory_buffer_factory_| weak pointers are checked on the
+IOThread.
+Weak pointers should be invalidated on the same thread that
+checks them.
+
+This CL moves the destruction of |gpu_memory_buffer_factory_|
+on the IOThread to avoid possible use after free issues.
+
+Bug: 1152645
+
+Change-Id: I0d42814f0e435a3746728515da1f32d08a1252cf
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2563077
+Commit-Queue: Daniele Castagna <dcastagna@chromium.org>
+Reviewed-by: Andres Calderon Jaramillo <andrescj@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#836827}
+---
+
+diff --git a/components/viz/service/gl/gpu_service_impl.cc b/components/viz/service/gl/gpu_service_impl.cc
+index 0a19757..03834a7 100644
+--- a/components/viz/service/gl/gpu_service_impl.cc
++++ b/components/viz/service/gl/gpu_service_impl.cc
+@@ -430,16 +430,18 @@
+   GetLogMessageManager()->ShutdownLogging();
+ 
+   // Destroy the receiver on the IO thread.
+-  base::WaitableEvent wait;
+-  auto destroy_receiver_task = base::BindOnce(
+-      [](mojo::Receiver<mojom::GpuService>* receiver,
+-         base::WaitableEvent* wait) {
+-        receiver->reset();
+-        wait->Signal();
+-      },
+-      &receiver_, &wait);
+-  if (io_runner_->PostTask(FROM_HERE, std::move(destroy_receiver_task)))
+-    wait.Wait();
++  {
++    base::WaitableEvent wait;
++    auto destroy_receiver_task = base::BindOnce(
++        [](mojo::Receiver<mojom::GpuService>* receiver,
++           base::WaitableEvent* wait) {
++          receiver->reset();
++          wait->Signal();
++        },
++        &receiver_, base::Unretained(&wait));
++    if (io_runner_->PostTask(FROM_HERE, std::move(destroy_receiver_task)))
++      wait.Wait();
++  }
+ 
+   if (watchdog_thread_)
+     watchdog_thread_->OnGpuProcessTearDown();
+@@ -447,6 +449,26 @@
+   media_gpu_channel_manager_.reset();
+   gpu_channel_manager_.reset();
+ 
++  // Destroy |gpu_memory_buffer_factory_| on the IO thread since its weakptrs
++  // are checked there.
++  {
++    base::WaitableEvent wait;
++    auto destroy_gmb_factory = base::BindOnce(
++        [](std::unique_ptr<gpu::GpuMemoryBufferFactory> gmb_factory,
++           base::WaitableEvent* wait) {
++          gmb_factory.reset();
++          wait->Signal();
++        },
++        std::move(gpu_memory_buffer_factory_), base::Unretained(&wait));
++
++    if (io_runner_->PostTask(FROM_HERE, std::move(destroy_gmb_factory))) {
++      // |gpu_memory_buffer_factory_| holds a raw pointer to
++      // |vulkan_context_provider_|. Waiting here enforces the correct order
++      // of destruction.
++      wait.Wait();
++    }
++  }
++
+   // Scheduler must be destroyed before sync point manager is destroyed.
+   scheduler_.reset();
+   owned_sync_point_manager_.reset();


### PR DESCRIPTION
viz: Destroy |gpu_memory_buffer_factory_| on IOThread

|gpu_memory_buffer_factory_| weak pointers are checked on the
IOThread.
Weak pointers should be invalidated on the same thread that
checks them.

This CL moves the destruction of |gpu_memory_buffer_factory_|
on the IOThread to avoid possible use after free issues.

Bug: 1152645

Change-Id: I0d42814f0e435a3746728515da1f32d08a1252cf
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2563077
Commit-Queue: Daniele Castagna <dcastagna@chromium.org>
Reviewed-by: Andres Calderon Jaramillo <andrescj@chromium.org>
Cr-Commit-Position: refs/heads/master@{#836827}


Notes: Security: backported fix for 1152645.