### PR TITLE
chore: cherry-pick 44d052c and 0919d75 from v8.

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -16,3 +16,5 @@ cherry-pick-146bd99e762b.patch
 cherry-pick-633f67caa6d0.patch
 cherry-pick-290fe9c6e245.patch
 cherry-pick-63166010061d.patch
+merged_deoptimizer_stricter_checks_during_deoptimization.patch
+merged_compiler_mark_jsstoreinarrayliteral_as_needing_a_frame.patch

--- a/patches/v8/merged_compiler_mark_jsstoreinarrayliteral_as_needing_a_frame.patch
+++ b/patches/v8/merged_compiler_mark_jsstoreinarrayliteral_as_needing_a_frame.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Georg Neis <neis@chromium.org>
+Date: Fri, 8 Jan 2021 10:24:06 +0100
+Subject: Merged: [compiler] Mark JSStoreInArrayLiteral as needing a frame
+ state
+
+Revision: b837e0338963611c08344cbb6f655a0abd9238c1
+
+BUG=chromium:1161357
+NOTRY=true
+NOPRESUBMIT=true
+NOTREECHECKS=true
+R=mythria@chromium.org
+
+Change-Id: Ic95dfd20d45d895934dee1592ebf427544eec73b
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2616223
+Reviewed-by: Mythri Alle <mythria@chromium.org>
+Commit-Queue: Georg Neis <neis@chromium.org>
+Cr-Commit-Position: refs/branch-heads/8.8@{#24}
+Cr-Branched-From: 2dbcdc105b963ee2501c82139eef7e0603977ff0-refs/heads/8.8.278@{#1}
+Cr-Branched-From: 366d30c99049b3f1c673f8a93deb9f879d0fa9f0-refs/heads/master@{#71094}
+
+diff --git a/src/compiler/operator-properties.cc b/src/compiler/operator-properties.cc
+index bf0f724a99378dfe42b6f56649979d893942871c..2d80d3df66b35c26b05c2709817434b2655cd017 100644
+--- a/src/compiler/operator-properties.cc
++++ b/src/compiler/operator-properties.cc
+@@ -200,6 +200,7 @@ bool OperatorProperties::HasFrameStateInput(const Operator* op) {
+     case IrOpcode::kJSStoreNamedOwn:
+     case IrOpcode::kJSStoreDataPropertyInLiteral:
+     case IrOpcode::kJSDeleteProperty:
++    case IrOpcode::kJSStoreInArrayLiteral:
+ 
+     // Conversions
+     case IrOpcode::kJSToLength:

--- a/patches/v8/merged_deoptimizer_stricter_checks_during_deoptimization.patch
+++ b/patches/v8/merged_deoptimizer_stricter_checks_during_deoptimization.patch
@@ -1,0 +1,69 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Georg Neis <neis@chromium.org>
+Date: Fri, 8 Jan 2021 09:33:18 +0100
+Subject: Merged: [deoptimizer] Stricter checks during deoptimization
+
+Revision: 506e893b812e03dbebe34b11d8aa9d4eb6869d89
+
+BUG=chromium:1161357
+NOTRY=true
+NOPRESUBMIT=true
+NOTREECHECKS=true
+R=mythria@chromium.org
+
+Change-Id: I97b69ae11d85bc0acd4a0c7bd28e1b692433de80
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2616219
+Reviewed-by: Mythri Alle <mythria@chromium.org>
+Commit-Queue: Georg Neis <neis@chromium.org>
+Cr-Commit-Position: refs/branch-heads/8.8@{#23}
+Cr-Branched-From: 2dbcdc105b963ee2501c82139eef7e0603977ff0-refs/heads/8.8.278@{#1}
+Cr-Branched-From: 366d30c99049b3f1c673f8a93deb9f879d0fa9f0-refs/heads/master@{#71094}
+
+diff --git a/src/deoptimizer/deoptimizer.cc b/src/deoptimizer/deoptimizer.cc
+index 066be8211626d2da85684b24b7ff22602f1dde20..804b77c065723de1d27ace6bbbe5456ef42fbad0 100644
+--- a/src/deoptimizer/deoptimizer.cc
++++ b/src/deoptimizer/deoptimizer.cc
+@@ -250,6 +250,7 @@ class ActivationsFinder : public ThreadVisitor {
+           SafepointEntry safepoint = code.GetSafepointEntry(it.frame()->pc());
+           int trampoline_pc = safepoint.trampoline_pc();
+           DCHECK_IMPLIES(code == topmost_, safe_to_deopt_);
++          CHECK_GE(trampoline_pc, 0);
+           // Replace the current pc on the stack with the trampoline.
+           // TODO(v8:10026): avoid replacing a signed pointer.
+           Address* pc_addr = it.frame()->pc_address();
+diff --git a/test/mjsunit/mjsunit.status b/test/mjsunit/mjsunit.status
+index 47b7bee75b6243740acab30520ed544ead6d54e5..cc91da82e6a21ba693400a239fa084c431e545c1 100644
+--- a/test/mjsunit/mjsunit.status
++++ b/test/mjsunit/mjsunit.status
+@@ -73,6 +73,10 @@
+   # Enable once multi-byte prefixed opcodes are correctly handled
+   'regress/wasm/regress-1065599': [SKIP],
+ 
++  # crbug.com/1161357
++  # TODO(solanes): Remove this entry once the underlying issue is fixed.
++  'regress/regress-1161357': [PASS, FAIL],
++
+   ##############################################################################
+   # Tests where variants make no sense.
+   'd8/enable-tracing': [PASS, NO_VARIANTS],
+diff --git a/test/mjsunit/regress/regress-1161357.js b/test/mjsunit/regress/regress-1161357.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..b6f03b92ac970f1f24c8e6aa03b27e849d2ae7bc
+--- /dev/null
++++ b/test/mjsunit/regress/regress-1161357.js
+@@ -0,0 +1,15 @@
++// Copyright 2020 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++for (let i = 0; i < 3; i++) {
++  for (let j = 0; j < 32767; j++) {
++    Number;
++  }
++  for (let j = 0; j < 2335; j++) {
++    Number;
++  }
++  var arr = [, ...(new Int16Array(0xffff)), 4294967296];
++  arr.concat(Number, arr)
++}
++eval(``);


### PR DESCRIPTION
[deoptimizer] Stricter checks during deoptimization

Revision: 506e893b812e03dbebe34b11d8aa9d4eb6869d89

BUG=chromium:1161357
NOTRY=true
NOPRESUBMIT=true
NOTREECHECKS=true
R=mythria@chromium.org

Change-Id: I97b69ae11d85bc0acd4a0c7bd28e1b692433de80
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2616219
Reviewed-by: Mythri Alle <mythria@chromium.org>
Commit-Queue: Georg Neis <neis@chromium.org>
Cr-Commit-Position: refs/branch-heads/8.8@{#23}
Cr-Branched-From: 2dbcdc105b963ee2501c82139eef7e0603977ff0-refs/heads/8.8.278@{#1}
Cr-Branched-From: 366d30c99049b3f1c673f8a93deb9f879d0fa9f0-refs/heads/master@{#71094}

[compiler] Mark JSStoreInArrayLiteral as needing a frame state

Revision: b837e0338963611c08344cbb6f655a0abd9238c1

BUG=chromium:1161357
NOTRY=true
NOPRESUBMIT=true
NOTREECHECKS=true
R=mythria@chromium.org

Change-Id: Ic95dfd20d45d895934dee1592ebf427544eec73b
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2616223
Reviewed-by: Mythri Alle <mythria@chromium.org>
Commit-Queue: Georg Neis <neis@chromium.org>
Cr-Commit-Position: refs/branch-heads/8.8@{#24}
Cr-Branched-From: 2dbcdc105b963ee2501c82139eef7e0603977ff0-refs/heads/8.8.278@{#1}
Cr-Branched-From: 366d30c99049b3f1c673f8a93deb9f879d0fa9f0-refs/heads/master@{#71094}

#### Release Notes

Notes: backported the fix to CVE-2021-21118 from V8.
