### PR TITLE
fix: incorrect case in content::PermissionType mapping

### DIFF
--- a/shell/common/gin_converters/content_converter.cc
+++ b/shell/common/gin_converters/content_converter.cc
@@ -190,7 +190,6 @@ v8::Local<v8::Value> Converter<content::PermissionType>::ToV8(
       return StringToV8(isolate, "clipboard-read");
     case content::PermissionType::CLIPBOARD_SANITIZED_WRITE:
       return StringToV8(isolate, "clipboard-sanitized-write");
-    case content::PermissionType::CAMERA_PAN_TILT_ZOOM:
     case content::PermissionType::FONT_ACCESS:
       return StringToV8(isolate, "font-access");
     case content::PermissionType::IDLE_DETECTION:
@@ -209,6 +208,7 @@ v8::Local<v8::Value> Converter<content::PermissionType>::ToV8(
       return StringToV8(isolate, "persistent-storage");
     case content::PermissionType::GEOLOCATION:
       return StringToV8(isolate, "geolocation");
+    case content::PermissionType::CAMERA_PAN_TILT_ZOOM:
     case content::PermissionType::AUDIO_CAPTURE:
     case content::PermissionType::VIDEO_CAPTURE:
       return StringToV8(isolate, "media");


### PR DESCRIPTION
Backport of #27006.

See that PR for details.

Notes: Apps requesting the CAMERA_PAN_TILT_ZOOM permission will have the permission request handler called with a permission string of "media" instead of "font-access".