### PR TITLE
chore: update to latest TypeScript, which has built-in WeakRef declarations

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -187,7 +187,7 @@ for (const method of webFrameMethods) {
 const waitTillCanExecuteJavaScript = async (webContents: Electron.WebContents) => {
   if (webContents.getURL() && !webContents.isLoadingMainFrame()) return;
 
-  return new Promise((resolve) => {
+  return new Promise<void>((resolve) => {
     webContents.once('did-stop-loading', () => {
       resolve();
     });

--- a/lib/browser/devtools.ts
+++ b/lib/browser/devtools.ts
@@ -62,7 +62,7 @@ const assertChromeDevTools = function (contents: Electron.WebContents, api: stri
 };
 
 ipcMainInternal.handle(IPC_MESSAGES.INSPECTOR_CONTEXT_MENU, function (event, items: ContextMenuItem[], isEditMenu: boolean) {
-  return new Promise(resolve => {
+  return new Promise<number | void>(resolve => {
     assertChromeDevTools(event.sender, 'window.InspectorFrontendHost.showContextMenuAtPoint()');
 
     const template = isEditMenu ? getEditMenuItems() : convertToMenuTemplate(items, resolve);

--- a/lib/renderer/api/remote.ts
+++ b/lib/renderer/api/remote.ts
@@ -15,7 +15,7 @@ const { hasSwitch } = process._linkedBinding('electron_common_command_line');
 
 const callbacksRegistry = new CallbacksRegistry();
 const remoteObjectCache = new Map();
-const finalizationRegistry = new (window as any).FinalizationRegistry((id: number) => {
+const finalizationRegistry = new FinalizationRegistry((id: number) => {
   const ref = remoteObjectCache.get(id);
   if (ref !== undefined && ref.deref() === undefined) {
     remoteObjectCache.delete(id);
@@ -34,7 +34,7 @@ function getCachedRemoteObject (id: number) {
   }
 }
 function setCachedRemoteObject (id: number, value: any) {
-  const wr = new (window as any).WeakRef(value);
+  const wr = new WeakRef(value);
   remoteObjectCache.set(id, wr);
   finalizationRegistry.register(value, id);
   return value;

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "timers-browserify": "1.4.2",
     "ts-loader": "^8.0.2",
     "ts-node": "6.2.0",
-    "typescript": "^4.0.2",
+    "typescript": "^4.1.3",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12",
     "wrapper-webpack-plugin": "^2.1.0"

--- a/script/gen-filenames.ts
+++ b/script/gen-filenames.ts
@@ -60,7 +60,7 @@ const main = async () => {
       output += chunk.toString();
     });
     child.stderr.on('data', chunk => console.error(chunk.toString()));
-    await new Promise((resolve, reject) => child.on('exit', (code) => {
+    await new Promise<void>((resolve, reject) => child.on('exit', (code) => {
       if (code !== 0) {
         console.error(output);
         return reject(new Error(`Failed to list webpack dependencies for entry: ${webpackTarget.name}`));

--- a/spec-main/api-autoupdater-darwin-spec.ts
+++ b/spec-main/api-autoupdater-darwin-spec.ts
@@ -184,7 +184,7 @@ describeFn('autoUpdater behavior', function () {
 
     afterEach(async () => {
       if (httpServer) {
-        await new Promise(resolve => {
+        await new Promise<void>(resolve => {
           httpServer.close(() => {
             httpServer = null as any;
             server = null as any;
@@ -288,7 +288,7 @@ describeFn('autoUpdater behavior', function () {
             pub_date: (new Date()).toString()
           });
         });
-        const relaunchPromise = new Promise((resolve) => {
+        const relaunchPromise = new Promise<void>((resolve) => {
           server.get('/update-check/updated/:version', (req, res) => {
             res.status(204).send();
             resolve();
@@ -338,7 +338,7 @@ describeFn('autoUpdater behavior', function () {
             ]
           });
         });
-        const relaunchPromise = new Promise((resolve) => {
+        const relaunchPromise = new Promise<void>((resolve) => {
           server.get('/update-check/updated/:version', (req, res) => {
             res.status(204).send();
             resolve();

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -72,7 +72,7 @@ describe('BrowserWindow module', () => {
       const w = new BrowserWindow({ show: false });
       // Keep a weak reference to the window.
       // eslint-disable-next-line no-undef
-      const wr = new (globalThis as any).WeakRef(w);
+      const wr = new WeakRef(w);
       await delay();
       // Do garbage collection, since |w| is not referenced in this closure
       // it would be gone after next call if there is no other reference.
@@ -1445,7 +1445,7 @@ describe('BrowserWindow module', () => {
       });
       server.on('connection', () => { connections++; });
 
-      await new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve()));
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', () => resolve()));
       url = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
     });
     afterEach(async () => {

--- a/spec-main/api-context-bridge-spec.ts
+++ b/spec-main/api-context-bridge-spec.ts
@@ -22,7 +22,7 @@ describe('contextBridge', () => {
       res.setHeader('Content-Type', 'text/html');
       res.end('');
     });
-    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
   });
 
   after(async () => {

--- a/spec-main/api-crash-reporter-spec.ts
+++ b/spec-main/api-crash-reporter-spec.ts
@@ -89,7 +89,7 @@ const startServer = async () => {
     req.pipe(busboy);
   });
 
-  await new Promise(resolve => {
+  await new Promise<void>(resolve => {
     server.listen(0, '127.0.0.1', () => { resolve(); });
   });
 

--- a/spec-main/api-ipc-spec.ts
+++ b/spec-main/api-ipc-spec.ts
@@ -33,7 +33,7 @@ describe('ipc module', () => {
         expect(arg).to.equal(123);
         return 3;
       });
-      const done = new Promise(resolve => ipcMain.once('result', (e, arg) => {
+      const done = new Promise<void>(resolve => ipcMain.once('result', (e, arg) => {
         expect(arg).to.deep.equal({ result: 3 });
         resolve();
       }));
@@ -47,7 +47,7 @@ describe('ipc module', () => {
         await new Promise(setImmediate);
         return 3;
       });
-      const done = new Promise(resolve => ipcMain.once('result', (e, arg) => {
+      const done = new Promise<void>(resolve => ipcMain.once('result', (e, arg) => {
         expect(arg).to.deep.equal({ result: 3 });
         resolve();
       }));
@@ -59,7 +59,7 @@ describe('ipc module', () => {
       ipcMain.handleOnce('test', () => {
         throw new Error('some error');
       });
-      const done = new Promise(resolve => ipcMain.once('result', (e, arg) => {
+      const done = new Promise<void>(resolve => ipcMain.once('result', (e, arg) => {
         expect(arg.error).to.match(/some error/);
         resolve();
       }));
@@ -72,7 +72,7 @@ describe('ipc module', () => {
         await new Promise(setImmediate);
         throw new Error('some error');
       });
-      const done = new Promise(resolve => ipcMain.once('result', (e, arg) => {
+      const done = new Promise<void>(resolve => ipcMain.once('result', (e, arg) => {
         expect(arg.error).to.match(/some error/);
         resolve();
       }));
@@ -81,7 +81,7 @@ describe('ipc module', () => {
     });
 
     it('throws an error if no handler is registered', async () => {
-      const done = new Promise(resolve => ipcMain.once('result', (e, arg) => {
+      const done = new Promise<void>(resolve => ipcMain.once('result', (e, arg) => {
         expect(arg.error).to.match(/No handler registered/);
         resolve();
       }));
@@ -92,7 +92,7 @@ describe('ipc module', () => {
     it('throws an error when invoking a handler that was removed', async () => {
       ipcMain.handle('test', () => {});
       ipcMain.removeHandler('test');
-      const done = new Promise(resolve => ipcMain.once('result', (e, arg) => {
+      const done = new Promise<void>(resolve => ipcMain.once('result', (e, arg) => {
         expect(arg.error).to.match(/No handler registered/);
         resolve();
       }));
@@ -136,7 +136,7 @@ describe('ipc module', () => {
       const received: number[] = [];
       ipcMain.on('test-async', (e, i) => { received.push(i); });
       ipcMain.on('test-sync', (e, i) => { received.push(i); e.returnValue = null; });
-      const done = new Promise(resolve => ipcMain.once('done', () => { resolve(); }));
+      const done = new Promise<void>(resolve => ipcMain.once('done', () => { resolve(); }));
       function rendererStressTest () {
         const { ipcRenderer } = require('electron');
         for (let i = 0; i < 1000; i++) {
@@ -167,7 +167,7 @@ describe('ipc module', () => {
       ipcMain.handle('test-invoke', (e, i) => { received.push(i); });
       ipcMain.on('test-async', (e, i) => { received.push(i); });
       ipcMain.on('test-sync', (e, i) => { received.push(i); e.returnValue = null; });
-      const done = new Promise(resolve => ipcMain.once('done', () => { resolve(); }));
+      const done = new Promise<void>(resolve => ipcMain.once('done', () => { resolve(); }));
       function rendererStressTest () {
         const { ipcRenderer } = require('electron');
         for (let i = 0; i < 1000; i++) {

--- a/spec-main/api-menu-spec.ts
+++ b/spec-main/api-menu-spec.ts
@@ -868,7 +868,7 @@ describe('Menu module', function () {
 
       // Keep a weak reference to the menu.
       // eslint-disable-next-line no-undef
-      const wr = new (globalThis as any).WeakRef(menu);
+      const wr = new WeakRef(menu);
 
       await delay();
 
@@ -881,7 +881,7 @@ describe('Menu module', function () {
 
       // Try to receive menu from weak reference.
       if (wr.deref()) {
-        wr.deref().closePopup();
+        wr.deref()!.closePopup();
       } else {
         throw new Error('Menu is garbage-collected while popuping');
       }
@@ -910,7 +910,7 @@ describe('Menu module', function () {
       const appProcess = cp.spawn(process.execPath, [appPath]);
 
       let output = '';
-      await new Promise((resolve) => {
+      await new Promise<void>((resolve) => {
         appProcess.stdout.on('data', data => {
           output += data;
           if (data.indexOf('Window has') > -1) {

--- a/spec-main/api-net-log-spec.ts
+++ b/spec-main/api-net-log-spec.ts
@@ -89,7 +89,7 @@ describe('netLog module', () => {
   it('should include cookies when requested', async () => {
     await testNetLog().startLogging(dumpFileDynamic, { captureMode: 'includeSensitive' });
     const unique = require('uuid').v4();
-    await new Promise((resolve) => {
+    await new Promise<void>((resolve) => {
       const req = net.request(serverUrl);
       req.setHeader('Cookie', `foo=${unique}`);
       req.on('response', (response) => {
@@ -107,7 +107,7 @@ describe('netLog module', () => {
   it('should include socket bytes when requested', async () => {
     await testNetLog().startLogging(dumpFileDynamic, { captureMode: 'everything' });
     const unique = require('uuid').v4();
-    await new Promise((resolve) => {
+    await new Promise<void>((resolve) => {
       const req = net.request({ method: 'POST', url: serverUrl });
       req.on('response', (response) => {
         response.on('data', () => {}); // https://github.com/electron/electron/issues/19214

--- a/spec-main/api-protocol-spec.ts
+++ b/spec-main/api-protocol-spec.ts
@@ -262,7 +262,7 @@ describe('protocol module', () => {
         res.end(text);
         server.close();
       });
-      await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
 
       const port = (server.address() as AddressInfo).port;
       const url = 'http://127.0.0.1:' + port;
@@ -292,7 +292,7 @@ describe('protocol module', () => {
         }
       });
       after(() => server.close());
-      await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
 
       const port = (server.address() as AddressInfo).port;
       const url = `${protocolName}://fake-host`;
@@ -778,7 +778,7 @@ describe('protocol module', () => {
         server.close();
         requestReceived.resolve();
       });
-      await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
       const port = (server.address() as AddressInfo).port;
       const content = `<script>fetch("http://127.0.0.1:${port}")</script>`;
       registerStringProtocol(standardScheme, (request, callback) => callback({ data: content, mimeType: 'text/html' }));

--- a/spec-main/api-service-workers-spec.ts
+++ b/spec-main/api-service-workers-spec.ts
@@ -31,7 +31,7 @@ describe('session.serviceWorkers', () => {
       }
       res.end(fs.readFileSync(path.resolve(__dirname, 'fixtures', 'api', 'service-workers', file)));
     });
-    await new Promise(resolve => {
+    await new Promise<void>(resolve => {
       server.listen(0, '127.0.0.1', () => {
         baseUrl = `http://localhost:${(server.address() as AddressInfo).port}/${uuid}`;
         resolve();

--- a/spec-main/api-session-spec.ts
+++ b/spec-main/api-session-spec.ts
@@ -51,7 +51,7 @@ describe('session module', () => {
         res.end('finished');
         server.close();
       });
-      await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
       const { port } = server.address() as AddressInfo;
       const w = new BrowserWindow({ show: false });
       await w.loadURL(`${url}:${port}`);
@@ -274,7 +274,7 @@ describe('session module', () => {
         res.end(mockFile);
         downloadServer.close();
       });
-      await new Promise(resolve => downloadServer.listen(0, '127.0.0.1', resolve));
+      await new Promise<void>(resolve => downloadServer.listen(0, '127.0.0.1', resolve));
 
       const port = (downloadServer.address() as AddressInfo).port;
       const url = `http://127.0.0.1:${port}/`;
@@ -290,7 +290,7 @@ describe('session module', () => {
       expect(itemUrl).to.equal(url);
       expect(itemFilename).to.equal('mockFile.txt');
       // Delay till the next tick.
-      await new Promise(resolve => setImmediate(() => resolve()));
+      await new Promise<void>(resolve => setImmediate(() => resolve()));
       expect(() => item.getURL()).to.throw('DownloadItem used after being destroyed');
     });
   });
@@ -390,7 +390,7 @@ describe('session module', () => {
         });
         res.end(pac);
       });
-      await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
       {
         const config = { pacScript: `http://127.0.0.1:${(server.address() as AddressInfo).port}` };
         await customSession.setProxy(config);
@@ -464,7 +464,7 @@ describe('session module', () => {
         });
         res.end(pac);
       });
-      await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
       const config = { mode: 'pac_script' as any, pacScript: `http://127.0.0.1:${(server.address() as AddressInfo).port}` };
       await customSession.setProxy(config);
       {
@@ -618,7 +618,7 @@ describe('session module', () => {
       setTimeout(() => {
         ses2.setCertificateVerifyProc((opts, callback) => callback(0));
       });
-      await expect(new Promise((resolve, reject) => {
+      await expect(new Promise<void>((resolve, reject) => {
         req.on('error', (err) => {
           reject(err);
         });
@@ -642,7 +642,7 @@ describe('session module', () => {
           res.end('authenticated');
         }
       });
-      await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
       const port = (server.address() as AddressInfo).port;
       const fetch = (url: string) => new Promise((resolve, reject) => {
         const request = net.request({ url, session: ses });
@@ -694,7 +694,7 @@ describe('session module', () => {
         });
         res.end(mockPDF);
       });
-      await new Promise(resolve => downloadServer.listen(0, '127.0.0.1', resolve));
+      await new Promise<void>(resolve => downloadServer.listen(0, '127.0.0.1', resolve));
       address = downloadServer.address() as AddressInfo;
     });
     after(async () => {
@@ -940,7 +940,7 @@ describe('session module', () => {
           .on('error', (error: any) => { throw error; }).pipe(res);
       });
       try {
-        await new Promise(resolve => rangeServer.listen(0, '127.0.0.1', resolve));
+        await new Promise<void>(resolve => rangeServer.listen(0, '127.0.0.1', resolve));
         const port = (rangeServer.address() as AddressInfo).port;
         const w = new BrowserWindow({ show: false });
         const downloadCancelled: Promise<Electron.DownloadItem> = new Promise((resolve) => {
@@ -1072,7 +1072,7 @@ describe('session module', () => {
         res.end();
         server.close();
       });
-      await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
       await w.loadURL(`http://127.0.0.1:${(server.address() as AddressInfo).port}`);
       expect(headers!['user-agent']).to.equal(userAgent);
       expect(headers!['accept-language']).to.equal('en-US,fr;q=0.9,de;q=0.8');
@@ -1106,7 +1106,7 @@ describe('session module', () => {
       }, (req, res) => {
         res.end('hi');
       });
-      await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
       defer(() => server.close());
       const { port } = server.address() as AddressInfo;
 

--- a/spec-main/api-shell-spec.ts
+++ b/spec-main/api-shell-spec.ts
@@ -32,7 +32,7 @@ describe('shell module', () => {
 
     it('opens an external link', async () => {
       let url = 'http://127.0.0.1';
-      let requestReceived;
+      let requestReceived: Promise<any>;
       if (process.platform === 'linux') {
         process.env.BROWSER = '/bin/true';
         process.env.DE = 'generic';
@@ -49,12 +49,12 @@ describe('shell module', () => {
         const server = http.createServer((req, res) => {
           res.end();
         });
-        await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
-        requestReceived = new Promise(resolve => server.on('connection', () => resolve()));
+        await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+        requestReceived = new Promise<void>(resolve => server.on('connection', () => resolve()));
         url = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
       }
 
-      await Promise.all([
+      await Promise.all<void>([
         shell.openExternal(url),
         requestReceived
       ]);

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -327,7 +327,7 @@ describe('webContents module', () => {
 
     it('rejects if the load is aborted', async () => {
       const s = http.createServer(() => { /* never complete the request */ });
-      await new Promise(resolve => s.listen(0, '127.0.0.1', resolve));
+      await new Promise<void>(resolve => s.listen(0, '127.0.0.1', resolve));
       const { port } = s.address() as AddressInfo;
       const p = expect(w.loadURL(`http://127.0.0.1:${port}`)).to.eventually.be.rejectedWith(Error, /ERR_ABORTED/);
       // load a different file before the first load completes, causing the
@@ -345,9 +345,9 @@ describe('webContents module', () => {
         resp = res;
         // don't end the response yet
       });
-      await new Promise(resolve => s.listen(0, '127.0.0.1', resolve));
+      await new Promise<void>(resolve => s.listen(0, '127.0.0.1', resolve));
       const { port } = s.address() as AddressInfo;
-      const p = new Promise(resolve => {
+      const p = new Promise<void>(resolve => {
         w.webContents.on('did-fail-load', (event, errorCode, errorDescription, validatedURL, isMainFrame) => {
           if (!isMainFrame) {
             resolve();
@@ -369,9 +369,9 @@ describe('webContents module', () => {
         resp = res;
         // don't end the response yet
       });
-      await new Promise(resolve => s.listen(0, '127.0.0.1', resolve));
+      await new Promise<void>(resolve => s.listen(0, '127.0.0.1', resolve));
       const { port } = s.address() as AddressInfo;
-      const p = new Promise(resolve => {
+      const p = new Promise<void>(resolve => {
         w.webContents.on('did-frame-finish-load', (event, isMainFrame) => {
           if (!isMainFrame) {
             resolve();
@@ -1210,7 +1210,7 @@ describe('webContents module', () => {
       const renderViewDeletedHandler = () => {
         currentRenderViewDeletedEmitted = true;
       };
-      const childWindowCreated = new Promise((resolve) => {
+      const childWindowCreated = new Promise<void>((resolve) => {
         app.once('browser-window-created', (event, window) => {
           childWindow = window;
           window.webContents.on('current-render-view-deleted' as any, renderViewDeletedHandler);

--- a/spec-main/api-web-request-spec.ts
+++ b/spec-main/api-web-request-spec.ts
@@ -452,7 +452,7 @@ describe('webRequest module', () => {
       });
 
       // Start server.
-      await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
       const port = String((server.address() as AddressInfo).port);
 
       // Use a separate session for testing.

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -59,7 +59,7 @@ describe('reporting api', () => {
       // "deprecation" report.
       res.end('<script>webkitRequestAnimationFrame(() => {})</script>');
     });
-    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
     const bw = new BrowserWindow({
       show: false
     });
@@ -220,7 +220,7 @@ describe('web security', () => {
       res.setHeader('Content-Type', 'text/html');
       res.end('<body>');
     });
-    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
     serverUrl = `http://localhost:${(server.address() as any).port}`;
   });
   after(() => {
@@ -574,7 +574,7 @@ describe('chromium features', () => {
           res.end(`body:${body}`);
         });
       });
-      await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
       serverUrl = `http://localhost:${(server.address() as any).port}`;
     });
     after(async () => {

--- a/spec-main/crash-spec.ts
+++ b/spec-main/crash-spec.ts
@@ -17,7 +17,7 @@ const runFixtureAndEnsureCleanExit = (args: string[]) => {
   child.stderr.on('data', (chunk: Buffer) => {
     out += chunk.toString();
   });
-  return new Promise((resolve) => {
+  return new Promise<void>((resolve) => {
     child.on('exit', (code, signal) => {
       if (code !== 0 || signal !== null) {
         console.error(out);

--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -36,7 +36,7 @@ describe('chrome extensions', () => {
       });
     });
 
-    await new Promise(resolve => server.listen(0, '127.0.0.1', () => {
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', () => {
       port = String((server.address() as AddressInfo).port);
       url = `http://127.0.0.1:${port}`;
       resolve();
@@ -287,7 +287,7 @@ describe('chrome extensions', () => {
     });
 
     it('does not take precedence over Electron webRequest - http', async () => {
-      return new Promise((resolve) => {
+      return new Promise<void>((resolve) => {
         (async () => {
           customSession.webRequest.onBeforeRequest((details, callback) => {
             resolve();
@@ -302,7 +302,7 @@ describe('chrome extensions', () => {
     });
 
     it('does not take precedence over Electron webRequest - WebSocket', () => {
-      return new Promise((resolve) => {
+      return new Promise<void>((resolve) => {
         (async () => {
           customSession.webRequest.onBeforeSendHeaders(() => {
             resolve();

--- a/spec-main/modules-spec.ts
+++ b/spec-main/modules-spec.ts
@@ -58,7 +58,7 @@ describe('modules support', () => {
 
       ifit(features.isRunAsNodeEnabled())('can be required in node binary', async function () {
         const child = childProcess.fork(path.join(fixtures, 'module', 'uv-dlopen.js'));
-        await new Promise(resolve => child.once('exit', (exitCode) => {
+        await new Promise<void>(resolve => child.once('exit', (exitCode) => {
           expect(exitCode).to.equal(0);
           resolve();
         }));

--- a/spec-main/visibility-state-spec.ts
+++ b/spec-main/visibility-state-spec.ts
@@ -114,7 +114,7 @@ ifdescribe(process.platform !== 'linux')('document.visibilityState', () => {
 
     const makeOtherWindow = (opts: { x: number; y: number; width: number; height: number; }) => {
       child = cp.spawn(process.execPath, [path.resolve(__dirname, 'fixtures', 'chromium', 'other-window.js'), `${opts.x}`, `${opts.y}`, `${opts.width}`, `${opts.height}`]);
-      return new Promise(resolve => {
+      return new Promise<void>(resolve => {
         child.stdout!.on('data', (chunk) => {
           if (chunk.toString().includes('__ready__')) resolve();
         });

--- a/spec-main/webview-spec.ts
+++ b/spec-main/webview-spec.ts
@@ -255,7 +255,7 @@ describe('<webview> tag', function () {
           zoomFactor: 1.2
         }
       });
-      const promise = new Promise((resolve) => {
+      const promise = new Promise<void>((resolve) => {
         ipcMain.on('webview-zoom-level', (event, zoomLevel, zoomFactor, newHost, final) => {
           if (!newHost) {
             expect(zoomFactor).to.equal(1.44);
@@ -285,7 +285,7 @@ describe('<webview> tag', function () {
           zoomFactor: 1.2
         }
       });
-      const promise = new Promise((resolve) => {
+      const promise = new Promise<void>((resolve) => {
         ipcMain.on('webview-zoom-in-page', (event, zoomLevel, zoomFactor, final) => {
           expect(zoomFactor).to.equal(1.44);
           expect(zoomLevel).to.equal(2.0);
@@ -500,7 +500,7 @@ describe('<webview> tag', function () {
     const partition = 'permissionTest';
 
     function setUpRequestHandler (webContentsId: number, requestedPermission: string) {
-      return new Promise((resolve, reject) => {
+      return new Promise<void>((resolve, reject) => {
         session.fromPartition(partition).setPermissionRequestHandler(function (webContents, permission, callback) {
           if (webContents.id === webContentsId) {
             // requestMIDIAccess with sysex requests both midi and midiSysex so

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "es2020",
     "lib": [
       "es2019",
+      "esnext.weakref",
       "dom",
       "dom.iterable"
     ],

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -232,7 +232,6 @@ declare namespace NodeJS {
     _firstFileName?: string;
 
     helperExecPath: string;
-    isRemoteModuleEnabled: boolean;
   }
 }
 
@@ -324,61 +323,3 @@ interface ResizeObserverEntry {
    */
   readonly contentRect: DOMRectReadOnly;
 }
-
-// https://github.com/microsoft/TypeScript/pull/38232
-
-interface WeakRef<T extends object> {
-  readonly [Symbol.toStringTag]: 'WeakRef';
-
-  /**
-   * Returns the WeakRef instance's target object, or undefined if the target object has been
-   * reclaimed.
-   */
-  deref(): T | undefined;
-}
-
-interface WeakRefConstructor {
-  readonly prototype: WeakRef<any>;
-
-  /**
-   * Creates a WeakRef instance for the given target object.
-   * @param target The target object for the WeakRef instance.
-   */
-  new<T extends object>(target?: T): WeakRef<T>;
-}
-
-declare var WeakRef: WeakRefConstructor;
-
-interface FinalizationRegistry {
-  readonly [Symbol.toStringTag]: 'FinalizationRegistry';
-
-  /**
-   * Registers an object with the registry.
-   * @param target The target object to register.
-   * @param heldValue The value to pass to the finalizer for this object. This cannot be the
-   * target object.
-   * @param unregisterToken The token to pass to the unregister method to unregister the target
-   * object. If provided (and not undefined), this must be an object. If not provided, the target
-   * cannot be unregistered.
-   */
-  register(target: object, heldValue: any, unregisterToken?: object): void;
-
-  /**
-   * Unregisters an object from the registry.
-   * @param unregisterToken The token that was used as the unregisterToken argument when calling
-   * register to register the target object.
-   */
-  unregister(unregisterToken: object): void;
-}
-
-interface FinalizationRegistryConstructor {
-  readonly prototype: FinalizationRegistry;
-
-  /**
-   * Creates a finalization registry with an associated cleanup callback
-   * @param cleanupCallback The callback to call after an object in the registry has been reclaimed.
-   */
-  new(cleanupCallback: (heldValue: any) => void): FinalizationRegistry;
-}
-
-declare var FinalizationRegistry: FinalizationRegistryConstructor;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7997,10 +7997,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
-  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
+typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
#### Description of Change
Allows removing copied `WeakRef` / `FinalizationRegistry` declarations.
Addresses [resolve’s Parameters Are No Longer Optional in Promises](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#resolves-parameters-are-no-longer-optional-in-promises)

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes