### PR TITLE
fix: hiddenInset missing maximize button

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1764,12 +1764,12 @@ void NativeWindowMac::AddContentViewLayers(bool minimizable, bool closable) {
       [[window_ standardWindowButton:NSWindowZoomButton] setHidden:YES];
       [[window_ standardWindowButton:NSWindowMiniaturizeButton] setHidden:YES];
       [[window_ standardWindowButton:NSWindowCloseButton] setHidden:YES];
-    }
 
-    // Some third-party macOS utilities check the zoom button's enabled state to
-    // determine whether to show custom UI on hover, so we disable it here to
-    // prevent them from doing so in a frameless app window.
-    SetMaximizable(false);
+      // Some third-party macOS utilities check the zoom button's enabled state
+      // to determine whether to show custom UI on hover, so we disable it here
+      // to prevent them from doing so in a frameless app window.
+      SetMaximizable(false);
+    }
   }
 }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/27283.
Refs https://github.com/electron/electron/pull/26901.

Previous we early-exited subsequent logic [here](https://github.com/electron/electron/pull/26901/files#diff-148ef9a1a6f049d9fef8c6272a4871d89315f8fc6cd80dc2d41a28b21b29184cL1714-L1715) for non-normal `titleBarStyle`s, but this change made it such that `SetMaximizable(false);` would be called for `hidden` and `hiddenInset` which would cause those styles to lose their zoom buttons. Fix this by moving that line into other associated logic exclusive to `normal` and `customButtonsOnHover` styles.

cc @jkleinsc @zcbenz  

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the zoom button was missing for windows with `titleBarStyle: hiddenInset` on macOS.
