### PR TITLE
fix: <webview> not working with Trusted Types

### DIFF
--- a/lib/renderer/web-view/web-view-impl.ts
+++ b/lib/renderer/web-view/web-view-impl.ts
@@ -44,7 +44,9 @@ export class WebViewImpl {
     // Create internal iframe element.
     this.internalElement = this.createInternalElement();
     const shadowRoot = this.webviewNode.attachShadow({ mode: 'open' });
-    shadowRoot.innerHTML = '<!DOCTYPE html><style type="text/css">:host { display: flex; }</style>';
+    const style = shadowRoot.ownerDocument.createElement('style');
+    style.textContent = ':host { display: flex; }';
+    shadowRoot.appendChild(style);
     this.setupWebViewAttributes();
     this.viewInstanceId = getNextId();
     shadowRoot.appendChild(this.internalElement);

--- a/spec-main/webview-spec.ts
+++ b/spec-main/webview-spec.ts
@@ -63,7 +63,6 @@ describe('<webview> tag', function () {
       show: false,
       webPreferences: {
         webviewTag: true,
-        nodeIntegration: true,
         sandbox: true
       }
     });
@@ -76,7 +75,6 @@ describe('<webview> tag', function () {
       show: false,
       webPreferences: {
         webviewTag: true,
-        nodeIntegration: true,
         contextIsolation: true
       }
     });
@@ -89,12 +87,22 @@ describe('<webview> tag', function () {
       show: false,
       webPreferences: {
         webviewTag: true,
-        nodeIntegration: true,
         contextIsolation: true,
         sandbox: true
       }
     });
     w.loadFile(path.join(fixtures, 'pages', 'webview-isolated.html'));
+    await emittedOnce(ipcMain, 'pong');
+  });
+
+  it('works with Trusted Types', async () => {
+    const w = new BrowserWindow({
+      show: false,
+      webPreferences: {
+        webviewTag: true
+      }
+    });
+    w.loadFile(path.join(fixtures, 'pages', 'webview-trusted-types.html'));
     await emittedOnce(ipcMain, 'pong');
   });
 

--- a/spec/fixtures/pages/webview-trusted-types.html
+++ b/spec/fixtures/pages/webview-trusted-types.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'; trusted-types *">
+</head>
+<body>
+<webview preload="../module/isolated-ping.js" src="about:blank"/>
+</body>
+</html>


### PR DESCRIPTION
#### Description of Change
Fixes #27211

Before:
<img width="912" alt="Screen Shot 2021-01-22 at 6 21 26 AM" src="https://user-images.githubusercontent.com/1281234/105450169-359a4400-5c7a-11eb-878e-d28082bb2c1b.png">
After:
<img width="912" alt="Screen Shot 2021-01-22 at 6 24 50 AM" src="https://user-images.githubusercontent.com/1281234/105450350-9164cd00-5c7a-11eb-91a1-c36c1923c76f.png">

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed `<webview>` not working with Trusted Types.
