### PR TITLE
fix: CSP with unsafe-eval detection with Trusted Types

### DIFF
--- a/lib/renderer/security-warnings.ts
+++ b/lib/renderer/security-warnings.ts
@@ -81,7 +81,7 @@ const isUnsafeEvalEnabled: () => Promise<boolean> = function () {
   // Call _executeJavaScript to bypass the world-safe deprecation warning
   return (webFrame as any)._executeJavaScript(`(${(() => {
     try {
-      new Function(''); // eslint-disable-line no-new,no-new-func
+      eval(window.trustedTypes.emptyScript); // eslint-disable-line no-eval
     } catch {
       return false;
     }

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -272,6 +272,7 @@ declare interface Window {
     }
   };
   ResizeObserver: ResizeObserver;
+  trustedTypes: TrustedTypePolicyFactory;
 }
 
 /**
@@ -322,4 +323,42 @@ interface ResizeObserverEntry {
    * Element's content rect when ResizeObserverCallback is invoked.
    */
   readonly contentRect: DOMRectReadOnly;
+}
+
+// https://w3c.github.io/webappsec-trusted-types/dist/spec/#trusted-types
+
+type TrustedHTML = string;
+type TrustedScript = string;
+type TrustedScriptURL = string;
+type TrustedType = TrustedHTML | TrustedScript | TrustedScriptURL;
+type StringContext = 'TrustedHTML' | 'TrustedScript' | 'TrustedScriptURL';
+
+// https://w3c.github.io/webappsec-trusted-types/dist/spec/#typedef-trustedtypepolicy
+
+interface TrustedTypePolicy {
+  createHTML(input: string, ...arguments: any[]): TrustedHTML;
+  createScript(input: string, ...arguments: any[]): TrustedScript;
+  createScriptURL(input: string, ...arguments: any[]): TrustedScriptURL;
+}
+
+// https://w3c.github.io/webappsec-trusted-types/dist/spec/#typedef-trustedtypepolicyoptions
+
+interface TrustedTypePolicyOptions {
+  createHTML?: (input: string, ...arguments: any[]) => TrustedHTML;
+  createScript?: (input: string, ...arguments: any[]) => TrustedScript;
+  createScriptURL?: (input: string, ...arguments: any[]) => TrustedScriptURL;
+}
+
+// https://w3c.github.io/webappsec-trusted-types/dist/spec/#typedef-trustedtypepolicyfactory
+
+interface TrustedTypePolicyFactory {
+  createPolicy(policyName: string, policyOptions: TrustedTypePolicyOptions): TrustedTypePolicy
+  isHTML(value: any): boolean;
+  isScript(value: any): boolean;
+  isScriptURL(value: any): boolean;
+  readonly emptyHTML: TrustedHTML;
+  readonly emptyScript: TrustedScript;
+  getAttributeType(tagName: string, attribute: string, elementNs?: string, attrNs?: string): StringContext | null;
+  getPropertyType(tagName: string, property: string, elementNs?: string): StringContext | null;
+  readonly defaultPolicy: TrustedTypePolicy | null;
 }


### PR DESCRIPTION
#### Description of Change
Fixes #27211
Need to use `eval('')` instead of `new Function('')` due to a bug in [Trusted Types for function constructor](https://github.com/w3c/webappsec-trusted-types/wiki/Trusted-Types-for-function-constructor).

Before:
<img width="912" alt="Screen Shot 2021-01-22 at 6 05 07 AM" src="https://user-images.githubusercontent.com/1281234/105449699-2ebf0180-5c79-11eb-9ce0-cbe4c5ca6726.png">
After:
<img width="912" alt="Screen Shot 2021-01-22 at 6 05 23 AM" src="https://user-images.githubusercontent.com/1281234/105449706-32528880-5c79-11eb-9dc6-863d5dd44837.png">

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed CSP with `unsafe-eval` detection with Trusted Types.