### PR TITLE
refactor: replace base::Bind() with base::BindOnce() / base::BindRepeating()

### DIFF
--- a/shell/browser/api/electron_api_screen.cc
+++ b/shell/browser/api/electron_api_screen.cc
@@ -109,22 +109,22 @@ static gfx::Rect DIPToScreenRect(electron::NativeWindow* window,
 
 void Screen::OnDisplayAdded(const display::Display& new_display) {
   base::ThreadTaskRunnerHandle::Get()->PostNonNestableTask(
-      FROM_HERE, base::Bind(&DelayEmit, base::Unretained(this), "display-added",
-                            new_display));
+      FROM_HERE, base::BindOnce(&DelayEmit, base::Unretained(this),
+                                "display-added", new_display));
 }
 
 void Screen::OnDisplayRemoved(const display::Display& old_display) {
   base::ThreadTaskRunnerHandle::Get()->PostNonNestableTask(
-      FROM_HERE, base::Bind(&DelayEmit, base::Unretained(this),
-                            "display-removed", old_display));
+      FROM_HERE, base::BindOnce(&DelayEmit, base::Unretained(this),
+                                "display-removed", old_display));
 }
 
 void Screen::OnDisplayMetricsChanged(const display::Display& display,
                                      uint32_t changed_metrics) {
   base::ThreadTaskRunnerHandle::Get()->PostNonNestableTask(
-      FROM_HERE, base::Bind(&DelayEmitWithMetrics, base::Unretained(this),
-                            "display-metrics-changed", display,
-                            MetricsToArray(changed_metrics)));
+      FROM_HERE, base::BindOnce(&DelayEmitWithMetrics, base::Unretained(this),
+                                "display-metrics-changed", display,
+                                MetricsToArray(changed_metrics)));
 }
 
 // static

--- a/shell/browser/api/message_port.cc
+++ b/shell/browser/api/message_port.cc
@@ -132,7 +132,7 @@ void MessagePort::Entangle(blink::MessagePortDescriptor port) {
   connector_->PauseIncomingMethodCallProcessing();
   connector_->set_incoming_receiver(this);
   connector_->set_connection_error_handler(
-      base::Bind(&MessagePort::Close, weak_factory_.GetWeakPtr()));
+      base::BindOnce(&MessagePort::Close, weak_factory_.GetWeakPtr()));
   if (HasPendingActivity())
     Pin();
 }

--- a/shell/browser/extensions/electron_extension_system.cc
+++ b/shell/browser/extensions/electron_extension_system.cc
@@ -173,11 +173,11 @@ AppSorting* ElectronExtensionSystem::app_sorting() {
 void ElectronExtensionSystem::RegisterExtensionWithRequestContexts(
     const Extension* extension,
     base::OnceClosure callback) {
-  base::PostTaskAndReply(
-      FROM_HERE, {BrowserThread::IO},
-      base::Bind(&InfoMap::AddExtension, info_map(),
-                 base::RetainedRef(extension), base::Time::Now(), false, false),
-      std::move(callback));
+  base::PostTaskAndReply(FROM_HERE, {BrowserThread::IO},
+                         base::BindOnce(&InfoMap::AddExtension, info_map(),
+                                        base::RetainedRef(extension),
+                                        base::Time::Now(), false, false),
+                         std::move(callback));
 }
 
 void ElectronExtensionSystem::UnregisterExtensionWithRequestContexts(

--- a/shell/browser/net/url_pipe_loader.cc
+++ b/shell/browser/net/url_pipe_loader.cc
@@ -40,7 +40,7 @@ void URLPipeLoader::Start(
     const net::NetworkTrafficAnnotationTag& annotation,
     base::DictionaryValue upload_data) {
   loader_ = network::SimpleURLLoader::Create(std::move(request), annotation);
-  loader_->SetOnResponseStartedCallback(base::Bind(
+  loader_->SetOnResponseStartedCallback(base::BindOnce(
       &URLPipeLoader::OnResponseStarted, weak_factory_.GetWeakPtr()));
 
   // TODO(zcbenz): The old protocol API only supports string as upload data,

--- a/shell/browser/ui/gtk/app_indicator_icon.cc
+++ b/shell/browser/ui/gtk/app_indicator_icon.cc
@@ -365,8 +365,9 @@ void AppIndicatorIcon::UpdateClickActionReplacementMenuItem() {
   DCHECK(!tool_tip_.empty());
   menu_->UpdateClickActionReplacementMenuItem(
       tool_tip_.c_str(),
-      base::Bind(&AppIndicatorIcon::OnClickActionReplacementMenuItemActivated,
-                 base::Unretained(this)));
+      base::BindRepeating(
+          &AppIndicatorIcon::OnClickActionReplacementMenuItemActivated,
+          base::Unretained(this)));
 }
 
 void AppIndicatorIcon::OnClickActionReplacementMenuItemActivated() {

--- a/shell/common/api/electron_api_clipboard.cc
+++ b/shell/common/api/electron_api_clipboard.cc
@@ -185,7 +185,7 @@ gfx::Image Clipboard::ReadImage(gin_helper::Arguments* args) {
   clipboard->ReadImage(
       GetClipboardBuffer(args),
       /* data_dst = */ nullptr,
-      base::Bind(
+      base::BindOnce(
           [](base::Optional<gfx::Image>* image, const SkBitmap& result) {
             image->emplace(gfx::Image::CreateFrom1xBitmap(result));
           },

--- a/shell/common/gin_converters/callback_converter.h
+++ b/shell/common/gin_converters/callback_converter.h
@@ -19,7 +19,7 @@ struct Converter<base::RepeatingCallback<Sig>> {
     // We don't use CreateFunctionTemplate here because it creates a new
     // FunctionTemplate everytime, which is cached by V8 and causes leaks.
     auto translater =
-        base::Bind(&gin_helper::NativeFunctionInvoker<Sig>::Go, val);
+        base::BindRepeating(&gin_helper::NativeFunctionInvoker<Sig>::Go, val);
     // To avoid memory leak, we ensure that the callback can only be called
     // for once.
     return gin_helper::CreateFunctionFromTranslater(isolate, translater, true);

--- a/shell/common/gin_helper/callback.h
+++ b/shell/common/gin_helper/callback.h
@@ -142,7 +142,8 @@ template <typename Sig>
 v8::Local<v8::Value> CallbackToV8Leaked(
     v8::Isolate* isolate,
     const base::RepeatingCallback<Sig>& val) {
-  Translater translater = base::Bind(&NativeFunctionInvoker<Sig>::Go, val);
+  Translater translater =
+      base::BindRepeating(&NativeFunctionInvoker<Sig>::Go, val);
   return CreateFunctionFromTranslater(isolate, translater, false);
 }
 

--- a/shell/common/gin_helper/wrappable.h
+++ b/shell/common/gin_helper/wrappable.h
@@ -26,7 +26,7 @@ class Wrappable : public WrappableBase {
   static void SetConstructor(v8::Isolate* isolate,
                              const base::Callback<Sig>& constructor) {
     v8::Local<v8::FunctionTemplate> templ = gin_helper::CreateFunctionTemplate(
-        isolate, base::Bind(&internal::InvokeNew<Sig>, constructor));
+        isolate, base::BindRepeating(&internal::InvokeNew<Sig>, constructor));
     templ->InstanceTemplate()->SetInternalFieldCount(1);
     T::BuildPrototype(isolate, templ);
     gin::PerIsolateData::From(isolate)->SetFunctionTemplate(&kWrapperInfo,

--- a/shell/renderer/electron_autofill_agent.cc
+++ b/shell/renderer/electron_autofill_agent.cc
@@ -53,8 +53,8 @@ AutofillAgent::AutofillAgent(content::RenderFrame* frame,
                              blink::AssociatedInterfaceRegistry* registry)
     : content::RenderFrameObserver(frame), weak_ptr_factory_(this) {
   render_frame()->GetWebFrame()->SetAutofillClient(this);
-  registry->AddInterface(
-      base::Bind(&AutofillAgent::BindReceiver, base::Unretained(this)));
+  registry->AddInterface(base::BindRepeating(&AutofillAgent::BindReceiver,
+                                             base::Unretained(this)));
 }
 
 AutofillAgent::~AutofillAgent() = default;


### PR DESCRIPTION
#### Description of Change
Replace deprecated `base::Bind()` with explicit `base::BindOnce()` / `base::BindRepeating()`.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes
