### PR TITLE
chore: enable Trusted Types in default app

### DIFF
--- a/default_app/index.html
+++ b/default_app/index.html
@@ -2,6 +2,7 @@
 
 <head>
   <title>Electron</title>
+  <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'; trusted-types electron-default-app" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'sha256-6PH54BfkNq/EMMhUY7nhHf3c+AxloOwfy7hWyT01CM8='; style-src 'self'; img-src 'self'; connect-src 'self'" />
   <link href="./styles.css" type="text/css" rel="stylesheet" />
   <link href="./octicon/build.css" type="text/css" rel="stylesheet" />

--- a/default_app/preload.ts
+++ b/default_app/preload.ts
@@ -1,10 +1,15 @@
 import { ipcRenderer, contextBridge } from 'electron';
 
+const policy = window.trustedTypes.createPolicy('electron-default-app', {
+  // we trust the SVG contents
+  createHTML: input => input
+});
+
 async function getOcticonSvg (name: string) {
   try {
     const response = await fetch(`octicon/${name}.svg`);
     const div = document.createElement('div');
-    div.innerHTML = await response.text();
+    div.innerHTML = policy.createHTML(await response.text());
     return div;
   } catch {
     return null;


### PR DESCRIPTION
#### Description of Change
Inspired by #27211

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes
