### PR TITLE
docs: Update ipcMain.handle() docs in ipc-main.md for error-handling details

### DIFF
--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -120,9 +120,9 @@ The `event` that is passed as the first argument to the handler is the same as
 that passed to a regular event listener. It includes information about which
 WebContents is the source of the invoke request.
 
-Errors thrown through `handle` in the main process are not transparent as they 
-are serialized and only the `message` property from the original error is 
-provided to the renderer process. Please refer to 
+Errors thrown through `handle` in the main process are not transparent as they
+are serialized and only the `message` property from the original error is
+provided to the renderer process. Please refer to
 [#24427](https://github.com/electron/electron/issues/24427) for details.
 
 ### `ipcMain.handleOnce(channel, listener)`

--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -125,41 +125,6 @@ are serialized and only the `message` property from the original error is
 provided to the renderer process. Please refer to 
 [#24427](https://github.com/electron/electron/issues/24427) for details.
 
-If needed, an unsafe workaround uses a wrapper for `handle` to throw 
-custom errors. 
-```js
-// Main process
-const encodeError = (e) => {
-  return {name: e.name, message: e.message, extra: {...e}}
-}
-
-const handleWithCustomErrors = (channel, handler) => {
-  ipcMain.handle(channel, async (...args) => {
-    try {
-      return {result: await Promise.resolve(handler(...args))}
-    } catch (e) {
-      return {error: encodeError(e)}
-    }
-  })
-}
-
-// Renderer process
-const decodeError = ({name, message, extra}) => {
-  const e = new Error(message)
-  e.name = name
-  Object.assign(e, extra)
-  return e
-}
-
-const invokeWithCustomErrors = async (...args) => {
-  const {error, result} = await ipcRenderer.invoke(...args)
-  if (error) {
-    throw decodeError(error)
-  }
-  return result
-}
-```
-
 ### `ipcMain.handleOnce(channel, listener)`
 
 * `channel` String

--- a/docs/api/ipc-main.md
+++ b/docs/api/ipc-main.md
@@ -121,9 +121,12 @@ that passed to a regular event listener. It includes information about which
 WebContents is the source of the invoke request.
 
 Errors thrown through `handle` in the main process are not transparent as they 
-are serialized and only the error message from the is provided to the renderer 
-process. If needed, an unsafe workaround uses a wrapper for `handle` to throw 
-custom errors.
+are serialized and only the `message` property from the original error is 
+provided to the renderer process. Please refer to 
+[#24427](https://github.com/electron/electron/issues/24427) for details.
+
+If needed, an unsafe workaround uses a wrapper for `handle` to throw 
+custom errors. 
 ```js
 // Main process
 const encodeError = (e) => {
@@ -156,8 +159,6 @@ const invokeWithCustomErrors = async (...args) => {
   return result
 }
 ```
-Please refer to [#24427](https://github.com/electron/electron/issues/24427)
-for details.
 
 ### `ipcMain.handleOnce(channel, listener)`
 


### PR DESCRIPTION
#### Description of Change
Include information in ipcMain documentation about ipcMain.handle() error handling and workaround provided by @nornagon included in issue #24427.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none