### PR TITLE
docs: update verb tenses for structured clone notes

### DIFF
--- a/docs/api/ipc-renderer.md
+++ b/docs/api/ipc-renderer.md
@@ -62,10 +62,9 @@ included. Sending Functions, Promises, Symbols, WeakMaps, or WeakSets will
 throw an exception.
 
 > **NOTE:** Sending non-standard JavaScript types such as DOM objects or
-> special Electron objects is deprecated, and will begin throwing an exception
-> starting with Electron 9.
-
-> **NOTE:** Since the main process does not have support for DOM objects such as
+> special Electron objects will throw an exception.
+>
+> Since the main process does not have support for DOM objects such as
 > `ImageBitmap`, `File`, `DOMMatrix` and so on, such objects cannot be sent over
 > Electron's IPC to the main process, as the main process would have no way to decode
 > them. Attempting to send such objects over IPC will result in an error.
@@ -90,11 +89,10 @@ Algorithm][SCA], just like [`window.postMessage`][], so prototype chains will no
 included. Sending Functions, Promises, Symbols, WeakMaps, or WeakSets will
 throw an exception.
 
-> **NOTE**: Sending non-standard JavaScript types such as DOM objects or
-> special Electron objects is deprecated, and will begin throwing an exception
-> starting with Electron 9.
-
-> **NOTE:** Since the main process does not have support for DOM objects such as
+> **NOTE:** Sending non-standard JavaScript types such as DOM objects or
+> special Electron objects will throw an exception.
+>
+> Since the main process does not have support for DOM objects such as
 > `ImageBitmap`, `File`, `DOMMatrix` and so on, such objects cannot be sent over
 > Electron's IPC to the main process, as the main process would have no way to decode
 > them. Attempting to send such objects over IPC will result in an error.
@@ -134,11 +132,10 @@ Algorithm][SCA], just like [`window.postMessage`][], so prototype chains will no
 included. Sending Functions, Promises, Symbols, WeakMaps, or WeakSets will
 throw an exception.
 
-> **NOTE**: Sending non-standard JavaScript types such as DOM objects or
-> special Electron objects is deprecated, and will begin throwing an exception
-> starting with Electron 9.
-
-> **NOTE:** Since the main process does not have support for DOM objects such as
+> **NOTE:** Sending non-standard JavaScript types such as DOM objects or
+> special Electron objects will throw an exception.
+>
+> Since the main process does not have support for DOM objects such as
 > `ImageBitmap`, `File`, `DOMMatrix` and so on, such objects cannot be sent over
 > Electron's IPC to the main process, as the main process would have no way to decode
 > them. Attempting to send such objects over IPC will result in an error.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1673,8 +1673,7 @@ included. Sending Functions, Promises, Symbols, WeakMaps, or WeakSets will
 throw an exception.
 
 > **NOTE**: Sending non-standard JavaScript types such as DOM objects or
-> special Electron objects is deprecated, and will begin throwing an exception
-> starting with Electron 9.
+> special Electron objects will throw an exception.
 
 The renderer process can handle the message by listening to `channel` with the
 [`ipcRenderer`](ipc-renderer.md) module.
@@ -1722,9 +1721,8 @@ Send an asynchronous message to a specific frame in a renderer process via
 chains will not be included. Sending Functions, Promises, Symbols, WeakMaps, or
 WeakSets will throw an exception.
 
-> **NOTE**: Sending non-standard JavaScript types such as DOM objects or
-> special Electron objects is deprecated, and will begin throwing an exception
-> starting with Electron 9.
+> **NOTE:** Sending non-standard JavaScript types such as DOM objects or
+> special Electron objects will throw an exception.
 
 The renderer process can handle the message by listening to `channel` with the
 [`ipcRenderer`](ipc-renderer.md) module.


### PR DESCRIPTION
#### Description of Change

As per feedback on Appzi, this removes the copy that specifies the version number where passing DOM objects over IPC is deprecated, since the feature was removed back in Electron 9.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
