### PR TITLE
docs: add missing contextBridge API to README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -143,6 +143,7 @@ These individual tutorials expand on topics discussed in the guide above.
 
 ### Modules for the Renderer Process (Web Page):
 
+* [contextBridge](api/context-bridge.md)
 * [desktopCapturer](api/desktop-capturer.md)
 * [ipcRenderer](api/ipc-renderer.md)
 * [remote](api/remote.md)


### PR DESCRIPTION
#### Description of Change

The docs README is manually generated, and doesn't include the `contextBridge` API. 🙃 

This PR fixes the problem!

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes