### PR TITLE
fix: clean up implementations of titleBarStyle

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -228,6 +228,9 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       experimental.
   * `trafficLightPosition` [Point](structures/point.md) (optional) - Set a
     custom position for the traffic light buttons in frameless windows.
+  * `fullscreenWindowTitle` Boolean (optional) _Deprecated_ - Shows the title in
+    the title bar in full screen mode on macOS for `hiddenInset` titleBarStyle.
+    Default is `false`.
   * `thickFrame` Boolean (optional) - Use `WS_THICKFRAME` style for frameless windows on
     Windows, which adds standard window frame. Setting it to `false` will remove
     window shadow and window animations. Default is `true`.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -222,14 +222,12 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       the top left.
     * `hiddenInset` - Results in a hidden title bar with an alternative look
       where the traffic light buttons are slightly more inset from the window edge.
-    * `customButtonsOnHover` Boolean (optional) - Draw custom close,
-      and minimize buttons on macOS frameless windows. These buttons will not display
-      unless hovered over in the top left of the window. These custom buttons prevent
-      issues with mouse events that occur with the standard window toolbar buttons.
-      **Note:** This option is currently experimental.
+    * `customButtonsOnHover` - Results in a hidden title bar and a full size
+      content window, the traffic light buttons will display when being hovered
+      over in the top left of the window.  **Note:** This option is currently
+      experimental.
   * `trafficLightPosition` [Point](structures/point.md) (optional) - Set a
-    custom position for the traffic light buttons. Can only be used with
-    `titleBarStyle` set to `hidden` or `customButtonsOnHover`.
+    custom position for the traffic light buttons in frameless windows.
   * `thickFrame` Boolean (optional) - Use `WS_THICKFRAME` style for frameless windows on
     Windows, which adds standard window frame. Setting it to `false` will remove
     window shadow and window animations. Default is `true`.
@@ -1737,13 +1735,12 @@ deprecated and will be removed in an upcoming version of macOS.
 
 * `position` [Point](structures/point.md)
 
-Set a custom position for the traffic light buttons. Can only be used with
-`titleBarStyle` set to `hidden` or `customButtonsOnHover`.
+Set a custom position for the traffic light buttons in frameless window.
 
 #### `win.getTrafficLightPosition()` _macOS_
 
-Returns `Point` - The current position for the traffic light buttons. Can only
-be used with `titleBarStyle` set to `hidden` or `customButtonsOnHover`.
+Returns `Point` - The custom position for the traffic light buttons in
+frameless window.
 
 #### `win.setTouchBar(touchBar)` _macOS_
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -230,9 +230,6 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `trafficLightPosition` [Point](structures/point.md) (optional) - Set a
     custom position for the traffic light buttons. Can only be used with
     `titleBarStyle` set to `hidden` or `customButtonsOnHover`.
-  * `fullscreenWindowTitle` Boolean (optional) - Shows the title in the
-    title bar in full screen mode on macOS for all `titleBarStyle` options.
-    Default is `false`.
   * `thickFrame` Boolean (optional) - Use `WS_THICKFRAME` style for frameless windows on
     Windows, which adds standard window frame. Setting it to `false` will remove
     window shadow and window animations. Default is `true`.

--- a/filenames.gni
+++ b/filenames.gni
@@ -180,6 +180,8 @@ filenames = {
     "shell/browser/ui/cocoa/root_view_mac.mm",
     "shell/browser/ui/cocoa/views_delegate_mac.h",
     "shell/browser/ui/cocoa/views_delegate_mac.mm",
+    "shell/browser/ui/cocoa/window_buttons_view.h",
+    "shell/browser/ui/cocoa/window_buttons_view.mm",
     "shell/browser/ui/drag_util_mac.mm",
     "shell/browser/ui/file_dialog_mac.mm",
     "shell/browser/ui/inspectable_web_contents_view_mac.h",

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -280,8 +280,8 @@ class NativeWindow : public base::SupportsUserData,
   void NotifyWindowRotateGesture(float rotation);
   void NotifyWindowSheetBegin();
   void NotifyWindowSheetEnd();
-  void NotifyWindowEnterFullScreen();
-  void NotifyWindowLeaveFullScreen();
+  virtual void NotifyWindowEnterFullScreen();
+  virtual void NotifyWindowLeaveFullScreen();
   void NotifyWindowEnterHtmlFullScreen();
   void NotifyWindowLeaveHtmlFullScreen();
   void NotifyWindowAlwaysOnTopChanged();

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -216,7 +216,6 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
   bool is_kiosk_ = false;
   bool was_fullscreen_ = false;
   bool zoom_to_page_width_ = false;
-  bool fullscreen_window_title_ = true;
   bool resizable_ = true;
   bool exiting_fullscreen_ = false;
   base::Optional<gfx::Point> traffic_light_position_;

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -142,8 +142,8 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
   void NotifyWindowEnterFullScreen() override;
   void NotifyWindowLeaveFullScreen() override;
 
-  void NoitfyWindowWillEnterFullScreen();
-  void NoitfyWindowWillLeaveFullScreen();
+  void NotifyWindowWillEnterFullScreen();
+  void NotifyWindowWillLeaveFullScreen();
 
   // Cleanup observers when window is getting closed. Note that the destructor
   // can be called much later after window gets closed, so we should not do

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -21,7 +21,7 @@
 @class ElectronNSWindowDelegate;
 @class ElectronPreviewItem;
 @class ElectronTouchBar;
-@class CustomWindowButtonView;
+@class WindowButtonsView;
 
 namespace electron {
 
@@ -139,6 +139,11 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
   void CloseFilePreview() override;
   gfx::Rect ContentBoundsToWindowBounds(const gfx::Rect& bounds) const override;
   gfx::Rect WindowBoundsToContentBounds(const gfx::Rect& bounds) const override;
+  void NotifyWindowEnterFullScreen() override;
+  void NotifyWindowLeaveFullScreen() override;
+
+  void NoitfyWindowWillEnterFullScreen();
+  void NoitfyWindowWillLeaveFullScreen();
 
   // Cleanup observers when window is getting closed. Note that the destructor
   // can be called much later after window gets closed, so we should not do
@@ -152,8 +157,6 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
   void SetStyleMask(bool on, NSUInteger flag);
   void SetCollectionBehavior(bool on, NSUInteger flag);
   void SetWindowLevel(int level);
-
-  void SetExitingFullScreen(bool flag);
 
   enum class VisualEffectState {
     kFollowWindow,
@@ -172,7 +175,6 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
   ElectronPreviewItem* preview_item() const { return preview_item_.get(); }
   ElectronTouchBar* touch_bar() const { return touch_bar_.get(); }
   bool zoom_to_page_width() const { return zoom_to_page_width_; }
-  bool fullscreen_window_title() const { return fullscreen_window_title_; }
   bool always_simple_fullscreen() const { return always_simple_fullscreen_; }
   bool exiting_fullscreen() const { return exiting_fullscreen_; }
 
@@ -189,6 +191,7 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
   void AddContentViewLayers(bool minimizable, bool closable);
 
   void InternalSetWindowButtonVisibility(bool visible);
+  void InternalSetStandardButtonsVisibility(bool visible);
   void InternalSetParentWindow(NativeWindow* parent, bool attach);
   void SetForwardMouseMessages(bool forward);
 
@@ -197,7 +200,7 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
   base::scoped_nsobject<ElectronNSWindowDelegate> window_delegate_;
   base::scoped_nsobject<ElectronPreviewItem> preview_item_;
   base::scoped_nsobject<ElectronTouchBar> touch_bar_;
-  base::scoped_nsobject<CustomWindowButtonView> buttons_view_;
+  base::scoped_nsobject<WindowButtonsView> buttons_view_;
 
   // Event monitor for scroll wheel event.
   id wheel_event_monitor_;
@@ -213,7 +216,7 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
   bool is_kiosk_ = false;
   bool was_fullscreen_ = false;
   bool zoom_to_page_width_ = false;
-  bool fullscreen_window_title_ = false;
+  bool fullscreen_window_title_ = true;
   bool resizable_ = true;
   bool exiting_fullscreen_ = false;
   base::Optional<gfx::Point> traffic_light_position_;

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -188,7 +188,7 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
 
  private:
   // Add custom layers to the content view.
-  void AddContentViewLayers(bool minimizable, bool closable);
+  void AddContentViewLayers();
 
   void InternalSetWindowButtonVisibility(bool visible);
   void InternalSetStandardButtonsVisibility(bool visible);

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -275,6 +275,13 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   options.GetOptional(options::kTrafficLightPosition, &traffic_light_position_);
   options.Get(options::kVisualEffectState, &visual_effect_state_);
 
+  if (options.Has(options::kFullscreenWindowTitle)) {
+    EmitWarning(node::Environment::GetCurrent(v8::Isolate::GetCurrent()),
+                "\"fullscreenWindowTitle\" option has been deprecated and is "
+                "no-op now.",
+                "electron");
+  }
+
   bool minimizable = true;
   options.Get(options::kMinimizable, &minimizable);
 

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -29,6 +29,7 @@
 #include "shell/browser/ui/cocoa/electron_preview_item.h"
 #include "shell/browser/ui/cocoa/electron_touch_bar.h"
 #include "shell/browser/ui/cocoa/root_view_mac.h"
+#include "shell/browser/ui/cocoa/window_buttons_view.h"
 #include "shell/browser/ui/inspectable_web_contents.h"
 #include "shell/browser/ui/inspectable_web_contents_view.h"
 #include "shell/browser/window_list.h"
@@ -115,106 +116,6 @@
 // This is less than ideal, and should eventually be removed.
 - (void)viewDidMoveToSuperview {
   [self setFrame:[[self superview] bounds]];
-}
-
-@end
-
-// Custom Quit, Minimize and Full Screen button container for frameless
-// windows.
-@interface CustomWindowButtonView : NSView {
- @private
-  BOOL mouse_inside_;
-  gfx::Point margin_;
-}
-
-- (id)initWithMargin:(const base::Optional<gfx::Point>&)margin;
-- (void)setMargin:(const base::Optional<gfx::Point>&)margin;
-@end
-
-@implementation CustomWindowButtonView
-
-- (id)initWithMargin:(const base::Optional<gfx::Point>&)margin {
-  self = [super initWithFrame:NSZeroRect];
-  [self setMargin:margin];
-
-  NSButton* close_button =
-      [NSWindow standardWindowButton:NSWindowCloseButton
-                        forStyleMask:NSWindowStyleMaskTitled];
-  [close_button setTag:1];
-  NSButton* miniaturize_button =
-      [NSWindow standardWindowButton:NSWindowMiniaturizeButton
-                        forStyleMask:NSWindowStyleMaskTitled];
-  [miniaturize_button setTag:2];
-
-  CGFloat x = 0;
-  const CGFloat space_between = 20;
-
-  [close_button setFrameOrigin:NSMakePoint(x, 0)];
-  x += space_between;
-  [self addSubview:close_button];
-
-  [miniaturize_button setFrameOrigin:NSMakePoint(x, 0)];
-  x += space_between;
-  [self addSubview:miniaturize_button];
-
-  const auto last_button_frame = miniaturize_button.frame;
-  [self setFrameSize:NSMakeSize(last_button_frame.origin.x +
-                                    last_button_frame.size.width,
-                                last_button_frame.size.height)];
-
-  mouse_inside_ = NO;
-  [self setNeedsDisplayForButtons];
-
-  return self;
-}
-
-- (void)setMargin:(const base::Optional<gfx::Point>&)margin {
-  margin_ = margin.value_or(gfx::Point(7, 3));
-}
-
-- (void)viewDidMoveToWindow {
-  if (!self.window) {
-    return;
-  }
-
-  // Stay in upper left corner.
-  [self setAutoresizingMask:NSViewMaxXMargin | NSViewMinYMargin];
-  [self setFrameOrigin:NSMakePoint(margin_.x(), self.window.frame.size.height -
-                                                    self.frame.size.height -
-                                                    margin_.y())];
-}
-
-- (BOOL)_mouseInGroup:(NSButton*)button {
-  return mouse_inside_;
-}
-
-- (void)updateTrackingAreas {
-  auto tracking_area = [[[NSTrackingArea alloc]
-      initWithRect:NSZeroRect
-           options:NSTrackingMouseEnteredAndExited | NSTrackingActiveAlways |
-                   NSTrackingInVisibleRect
-             owner:self
-          userInfo:nil] autorelease];
-  [self addTrackingArea:tracking_area];
-}
-
-- (void)mouseEntered:(NSEvent*)event {
-  [super mouseEntered:event];
-  mouse_inside_ = YES;
-  [self setNeedsDisplayForButtons];
-}
-
-- (void)mouseExited:(NSEvent*)event {
-  [super mouseExited:event];
-  mouse_inside_ = NO;
-  [self setNeedsDisplayForButtons];
-}
-
-- (void)setNeedsDisplayForButtons {
-  for (NSView* subview in self.subviews) {
-    [subview setHidden:!mouse_inside_];
-    [subview setNeedsDisplay:YES];
-  }
 }
 
 @end
@@ -370,10 +271,15 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   options.Get(options::kResizable, &resizable_);
   options.Get(options::kTitleBarStyle, &title_bar_style_);
   options.Get(options::kZoomToPageWidth, &zoom_to_page_width_);
-  options.Get(options::kFullscreenWindowTitle, &fullscreen_window_title_);
   options.Get(options::kSimpleFullScreen, &always_simple_fullscreen_);
   options.GetOptional(options::kTrafficLightPosition, &traffic_light_position_);
   options.Get(options::kVisualEffectState, &visual_effect_state_);
+
+  // The hiddenInset style does not show title in fullscreen mode by default.
+  if (title_bar_style_ == TitleBarStyle::kHiddenInset)
+    fullscreen_window_title_ = false;
+
+  options.Get(options::kFullscreenWindowTitle, &fullscreen_window_title_);
 
   bool minimizable = true;
   options.Get(options::kMinimizable, &minimizable);
@@ -457,6 +363,8 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
     [window_ setTitleVisibility:NSWindowTitleHidden];
     // Remove non-transparent corners, see http://git.io/vfonD.
     [window_ setOpaque:NO];
+    // Hide the window buttons.
+    InternalSetStandardButtonsVisibility(false);
   }
 
   // Create a tab only if tabbing identifier is specified and window has
@@ -469,14 +377,6 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
     if (@available(macOS 10.12, *)) {
       [window_ setTabbingIdentifier:base::SysUTF8ToNSString(tabbingIdentifier)];
     }
-  }
-
-  // Hide the title bar.
-  if (title_bar_style_ == TitleBarStyle::kHiddenInset) {
-    base::scoped_nsobject<NSToolbar> toolbar(
-        [[NSToolbar alloc] initWithIdentifier:@"titlebarStylingToolbar"]);
-    [toolbar setShowsBaselineSeparator:NO];
-    [window_ setToolbar:toolbar];
   }
 
   // Resize to content bounds.
@@ -940,9 +840,6 @@ void NativeWindowMac::Invalidate() {
 
 void NativeWindowMac::SetTitle(const std::string& title) {
   [window_ setTitle:base::SysUTF8ToNSString(title)];
-  if (title_bar_style_ == TitleBarStyle::kHidden) {
-    RedrawTrafficLights();
-  }
 }
 
 std::string NativeWindowMac::GetTitle() {
@@ -1004,7 +901,7 @@ void NativeWindowMac::SetSimpleFullScreen(bool simple_fullscreen) {
       window.level = NSPopUpMenuWindowLevel;
     }
 
-    if (!fullscreen_window_title()) {
+    if (!fullscreen_window_title_) {
       // Hide the titlebar
       SetStyleMask(false, NSWindowStyleMaskTitled);
 
@@ -1027,7 +924,7 @@ void NativeWindowMac::SetSimpleFullScreen(bool simple_fullscreen) {
   } else if (!simple_fullscreen && is_simple_fullscreen_) {
     is_simple_fullscreen_ = false;
 
-    if (!fullscreen_window_title()) {
+    if (!fullscreen_window_title_) {
       // Restore the titlebar
       SetStyleMask(true, NSWindowStyleMaskTitled);
     }
@@ -1450,9 +1347,7 @@ bool NativeWindowMac::GetWindowButtonVisibility() const {
 void NativeWindowMac::SetTrafficLightPosition(
     base::Optional<gfx::Point> position) {
   traffic_light_position_ = std::move(position);
-  if (title_bar_style_ == TitleBarStyle::kHidden) {
-    RedrawTrafficLights();
-  } else if (title_bar_style_ == TitleBarStyle::kCustomButtonsOnHover) {
+  if (buttons_view_) {
     [buttons_view_ setMargin:position];
     [buttons_view_ viewDidMoveToWindow];
   }
@@ -1463,64 +1358,8 @@ base::Optional<gfx::Point> NativeWindowMac::GetTrafficLightPosition() const {
 }
 
 void NativeWindowMac::RedrawTrafficLights() {
-  // Ensure maximizable options retain pre-existing state.
-  SetMaximizable(maximizable_);
-
-  // Changing system titlebar is only allowed for "hidden" titleBarStyle.
-  if (!traffic_light_position_ || title_bar_style_ != TitleBarStyle::kHidden)
-    return;
-
-  if (IsFullscreen())
-    return;
-
-  NSWindow* window = window_;
-  NSButton* close = [window standardWindowButton:NSWindowCloseButton];
-  NSButton* miniaturize =
-      [window standardWindowButton:NSWindowMiniaturizeButton];
-  NSButton* zoom = [window standardWindowButton:NSWindowZoomButton];
-  // Safety check just in case apple changes the view structure in a macOS
-  // update
-  DCHECK(close.superview);
-  DCHECK(close.superview.superview);
-  if (!close.superview || !close.superview.superview)
-    return;
-  NSView* titleBarContainerView = close.superview.superview;
-
-  // Hide the container when exiting fullscreen, otherwise traffic light buttons
-  // jump
-  if (exiting_fullscreen_) {
-    [titleBarContainerView setHidden:YES];
-    return;
-  }
-
-  [titleBarContainerView setHidden:NO];
-  CGFloat buttonHeight = [close frame].size.height;
-  CGFloat titleBarFrameHeight = buttonHeight + traffic_light_position_->y();
-  CGRect titleBarRect = titleBarContainerView.frame;
-  CGFloat titleBarWidth = NSWidth(titleBarRect);
-  titleBarRect.size.height = titleBarFrameHeight;
-  titleBarRect.origin.y = window.frame.size.height - titleBarFrameHeight;
-  [titleBarContainerView setFrame:titleBarRect];
-
-  BOOL isRTL = [titleBarContainerView userInterfaceLayoutDirection] ==
-               NSUserInterfaceLayoutDirectionRightToLeft;
-  NSArray* windowButtons = @[ close, miniaturize, zoom ];
-  const CGFloat space_between =
-      [miniaturize frame].origin.x - [close frame].origin.x;
-  for (NSUInteger i = 0; i < windowButtons.count; i++) {
-    NSView* view = [windowButtons objectAtIndex:i];
-    CGRect rect = [view frame];
-    if (isRTL) {
-      CGFloat buttonWidth = NSWidth(rect);
-      // origin is always top-left, even in RTL
-      rect.origin.x = titleBarWidth - traffic_light_position_->x() +
-                      (i * space_between) - buttonWidth;
-    } else {
-      rect.origin.x = traffic_light_position_->x() + (i * space_between);
-    }
-    rect.origin.y = (titleBarFrameHeight - rect.size.height) / 2;
-    [view setFrameOrigin:rect.origin];
-  }
+  if (buttons_view_)
+    [buttons_view_ setNeedsDisplayForButtons];
 }
 
 void NativeWindowMac::SetTouchBar(
@@ -1642,6 +1481,41 @@ gfx::Rect NativeWindowMac::WindowBoundsToContentBounds(
   }
 }
 
+void NativeWindowMac::NotifyWindowEnterFullScreen() {
+  NativeWindow::NotifyWindowEnterFullScreen();
+  // Restore the window title under fullscreen mode.
+  if (buttons_view_ && fullscreen_window_title_)
+    [window_ setTitleVisibility:NSWindowTitleVisible];
+  RedrawTrafficLights();
+}
+
+void NativeWindowMac::NotifyWindowLeaveFullScreen() {
+  NativeWindow::NotifyWindowLeaveFullScreen();
+  exiting_fullscreen_ = false;
+  // Add back buttonsView after leaving fullscreen mode.
+  if (buttons_view_) {
+    InternalSetStandardButtonsVisibility(false);
+    [[window_ contentView] addSubview:buttons_view_];
+  }
+}
+
+void NativeWindowMac::NoitfyWindowWillEnterFullScreen() {
+  // Remove the buttonsView otherwise window buttons won't show under
+  // fullscreen mode.
+  if (buttons_view_) {
+    [buttons_view_ removeFromSuperview];
+    InternalSetStandardButtonsVisibility(true);
+  }
+}
+
+void NativeWindowMac::NoitfyWindowWillLeaveFullScreen() {
+  // Hide window title after leaving fullscreen.
+  if (buttons_view_)
+    [window_ setTitleVisibility:NSWindowTitleHidden];
+  exiting_fullscreen_ = true;
+  RedrawTrafficLights();
+}
+
 void NativeWindowMac::Cleanup() {
   DCHECK(!IsClosed());
   ui::NativeTheme::GetInstanceForNativeUi()->RemoveObserver(this);
@@ -1692,10 +1566,6 @@ void NativeWindowMac::SetCollectionBehavior(bool on, NSUInteger flag) {
   SetMaximizable(was_maximizable);
 }
 
-void NativeWindowMac::SetExitingFullScreen(bool flag) {
-  exiting_fullscreen_ = flag;
-}
-
 bool NativeWindowMac::CanResize() const {
   return resizable_;
 }
@@ -1742,46 +1612,37 @@ void NativeWindowMac::AddContentViewLayers(bool minimizable, bool closable) {
       [[window_ contentView] viewDidMoveToWindow];
     }
 
-    // The fullscreen button should always be hidden for frameless window.
-    [[window_ standardWindowButton:NSWindowFullScreenButton] setHidden:YES];
-
-    // Create a custom window buttons view for kCustomButtonsOnHover.
-    if (title_bar_style_ == TitleBarStyle::kCustomButtonsOnHover) {
-      buttons_view_.reset([[CustomWindowButtonView alloc]
-          initWithMargin:traffic_light_position_]);
-
-      if (!minimizable)
-        [[buttons_view_ viewWithTag:2] removeFromSuperview];
-      if (!closable)
-        [[buttons_view_ viewWithTag:1] removeFromSuperview];
-
-      [[window_ contentView] addSubview:buttons_view_];
-    }
-
-    // Hide the window buttons except for kHidden and kHiddenInset.
-    if (title_bar_style_ == TitleBarStyle::kNormal ||
-        title_bar_style_ == TitleBarStyle::kCustomButtonsOnHover) {
-      [[window_ standardWindowButton:NSWindowZoomButton] setHidden:YES];
-      [[window_ standardWindowButton:NSWindowMiniaturizeButton] setHidden:YES];
-      [[window_ standardWindowButton:NSWindowCloseButton] setHidden:YES];
-
+    if (title_bar_style_ == TitleBarStyle::kNormal) {
       // Some third-party macOS utilities check the zoom button's enabled state
       // to determine whether to show custom UI on hover, so we disable it here
       // to prevent them from doing so in a frameless app window.
       SetMaximizable(false);
+    } else {
+      // Create a custom window buttons view.
+      buttons_view_.reset(
+          [[WindowButtonsView alloc] initWithMargin:traffic_light_position_]);
+      if (title_bar_style_ == TitleBarStyle::kCustomButtonsOnHover)
+        [buttons_view_ setShowOnHover:YES];
+      if (!minimizable)
+        [[buttons_view_ viewWithTag:2] removeFromSuperview];
+      if (!closable)
+        [[buttons_view_ viewWithTag:1] removeFromSuperview];
+      [[window_ contentView] addSubview:buttons_view_];
     }
   }
 }
 
 void NativeWindowMac::InternalSetWindowButtonVisibility(bool visible) {
-  if (buttons_view_) {
+  if (buttons_view_)
     [buttons_view_ setHidden:!visible];
-  } else {
-    [[window_ standardWindowButton:NSWindowCloseButton] setHidden:!visible];
-    [[window_ standardWindowButton:NSWindowMiniaturizeButton]
-        setHidden:!visible];
-    [[window_ standardWindowButton:NSWindowZoomButton] setHidden:!visible];
-  }
+  else
+    InternalSetStandardButtonsVisibility(visible);
+}
+
+void NativeWindowMac::InternalSetStandardButtonsVisibility(bool visible) {
+  [[window_ standardWindowButton:NSWindowCloseButton] setHidden:!visible];
+  [[window_ standardWindowButton:NSWindowMiniaturizeButton] setHidden:!visible];
+  [[window_ standardWindowButton:NSWindowZoomButton] setHidden:!visible];
 }
 
 void NativeWindowMac::InternalSetParentWindow(NativeWindow* parent,

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1605,10 +1605,13 @@ void NativeWindowMac::AddContentViewLayers(bool minimizable, bool closable) {
           [[WindowButtonsView alloc] initWithMargin:traffic_light_position_]);
       if (title_bar_style_ == TitleBarStyle::kCustomButtonsOnHover)
         [buttons_view_ setShowOnHover:YES];
-      if (!minimizable)
-        [[buttons_view_ viewWithTag:2] removeFromSuperview];
+      if (title_bar_style_ == TitleBarStyle::kHiddenInset &&
+          !traffic_light_position_)
+        [buttons_view_ setMargin:gfx::Point(12, 11)];
       if (!closable)
         [[buttons_view_ viewWithTag:1] removeFromSuperview];
+      if (!minimizable)
+        [[buttons_view_ viewWithTag:2] removeFromSuperview];
       [[window_ contentView] addSubview:buttons_view_];
     }
   }

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1487,7 +1487,7 @@ void NativeWindowMac::NotifyWindowLeaveFullScreen() {
   }
 }
 
-void NativeWindowMac::NoitfyWindowWillEnterFullScreen() {
+void NativeWindowMac::NotifyWindowWillEnterFullScreen() {
   // Remove the buttonsView otherwise window buttons won't show under
   // fullscreen mode.
   if (buttons_view_) {
@@ -1496,7 +1496,7 @@ void NativeWindowMac::NoitfyWindowWillEnterFullScreen() {
   }
 }
 
-void NativeWindowMac::NoitfyWindowWillLeaveFullScreen() {
+void NativeWindowMac::NotifyWindowWillLeaveFullScreen() {
   // Hide window title after leaving fullscreen.
   if (buttons_view_)
     [window_ setTitleVisibility:NSWindowTitleHidden];

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -275,12 +275,6 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   options.GetOptional(options::kTrafficLightPosition, &traffic_light_position_);
   options.Get(options::kVisualEffectState, &visual_effect_state_);
 
-  // The hiddenInset style does not show title in fullscreen mode by default.
-  if (title_bar_style_ == TitleBarStyle::kHiddenInset)
-    fullscreen_window_title_ = false;
-
-  options.Get(options::kFullscreenWindowTitle, &fullscreen_window_title_);
-
   bool minimizable = true;
   options.Get(options::kMinimizable, &minimizable);
 
@@ -901,14 +895,7 @@ void NativeWindowMac::SetSimpleFullScreen(bool simple_fullscreen) {
       window.level = NSPopUpMenuWindowLevel;
     }
 
-    if (!fullscreen_window_title_) {
-      // Hide the titlebar
-      SetStyleMask(false, NSWindowStyleMaskTitled);
-
-      // Resize the window to accommodate the _entire_ screen size
-      fullscreenFrame.size.height -=
-          [[[NSApplication sharedApplication] mainMenu] menuBarHeight];
-    } else if (!window_button_visibility_.has_value()) {
+    if (!window_button_visibility_.has_value()) {
       // Lets keep previous behaviour - hide window controls in titled
       // fullscreen mode when not specified otherwise.
       InternalSetWindowButtonVisibility(false);
@@ -923,11 +910,6 @@ void NativeWindowMac::SetSimpleFullScreen(bool simple_fullscreen) {
     SetMovable(false);
   } else if (!simple_fullscreen && is_simple_fullscreen_) {
     is_simple_fullscreen_ = false;
-
-    if (!fullscreen_window_title_) {
-      // Restore the titlebar
-      SetStyleMask(true, NSWindowStyleMaskTitled);
-    }
 
     // Restore default window controls visibility state.
     if (!window_button_visibility_.has_value()) {
@@ -1484,7 +1466,7 @@ gfx::Rect NativeWindowMac::WindowBoundsToContentBounds(
 void NativeWindowMac::NotifyWindowEnterFullScreen() {
   NativeWindow::NotifyWindowEnterFullScreen();
   // Restore the window title under fullscreen mode.
-  if (buttons_view_ && fullscreen_window_title_)
+  if (buttons_view_)
     [window_ setTitleVisibility:NSWindowTitleVisible];
   RedrawTrafficLights();
 }

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -213,7 +213,7 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
 }
 
 - (void)windowWillEnterFullScreen:(NSNotification*)notification {
-  shell_->NoitfyWindowWillEnterFullScreen();
+  shell_->NotifyWindowWillEnterFullScreen();
   // Setting resizable to true before entering fullscreen.
   is_resizable_ = shell_->IsResizable();
   shell_->SetResizable(true);
@@ -224,7 +224,7 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
 }
 
 - (void)windowWillExitFullScreen:(NSNotification*)notification {
-  shell_->NoitfyWindowWillLeaveFullScreen();
+  shell_->NotifyWindowWillLeaveFullScreen();
 }
 
 - (void)windowDidExitFullScreen:(NSNotification*)notification {

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -91,14 +91,17 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
 
 - (void)windowDidBecomeMain:(NSNotification*)notification {
   shell_->NotifyWindowFocus();
+  shell_->RedrawTrafficLights();
 }
 
 - (void)windowDidResignMain:(NSNotification*)notification {
   shell_->NotifyWindowBlur();
+  shell_->RedrawTrafficLights();
 }
 
 - (void)windowDidBecomeKey:(NSNotification*)notification {
   shell_->NotifyWindowIsKeyChanged(true);
+  shell_->RedrawTrafficLights();
 }
 
 - (void)windowDidResignKey:(NSNotification*)notification {
@@ -110,6 +113,7 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
     return;
 
   shell_->NotifyWindowIsKeyChanged(false);
+  shell_->RedrawTrafficLights();
 }
 
 - (NSSize)windowWillResize:(NSWindow*)sender toSize:(NSSize)frameSize {
@@ -151,9 +155,6 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
 - (void)windowDidResize:(NSNotification*)notification {
   [super windowDidResize:notification];
   shell_->NotifyWindowResize();
-  if (shell_->title_bar_style() == TitleBarStyle::kHidden) {
-    shell_->RedrawTrafficLights();
-  }
 }
 
 - (void)windowWillMove:(NSNotification*)notification {
@@ -212,75 +213,23 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
 }
 
 - (void)windowWillEnterFullScreen:(NSNotification*)notification {
-  // Setting resizable to true before entering fullscreen
+  shell_->NoitfyWindowWillEnterFullScreen();
+  // Setting resizable to true before entering fullscreen.
   is_resizable_ = shell_->IsResizable();
   shell_->SetResizable(true);
-  // Hide the native toolbar before entering fullscreen, so there is no visual
-  // artifacts.
-  if (shell_->title_bar_style() == TitleBarStyle::kHiddenInset) {
-    NSWindow* window = shell_->GetNativeWindow().GetNativeNSWindow();
-    [window setToolbar:nil];
-  }
 }
 
 - (void)windowDidEnterFullScreen:(NSNotification*)notification {
   shell_->NotifyWindowEnterFullScreen();
-
-  // For frameless window we don't show set title for normal mode since the
-  // titlebar is expected to be empty, but after entering fullscreen mode we
-  // have to set one, because title bar is visible here.
-  NSWindow* window = shell_->GetNativeWindow().GetNativeNSWindow();
-  if ((shell_->transparent() || !shell_->has_frame()) &&
-      // FIXME(zcbenz): Showing titlebar for hiddenInset window is weird under
-      // fullscreen mode.
-      // Show title if fullscreen_window_title flag is set
-      (shell_->title_bar_style() != TitleBarStyle::kHiddenInset ||
-       shell_->fullscreen_window_title())) {
-    [window setTitleVisibility:NSWindowTitleVisible];
-  }
-
-  // Restore the native toolbar immediately after entering fullscreen, if we
-  // do this before leaving fullscreen, traffic light buttons will be jumping.
-  if (shell_->title_bar_style() == TitleBarStyle::kHiddenInset) {
-    base::scoped_nsobject<NSToolbar> toolbar(
-        [[NSToolbar alloc] initWithIdentifier:@"titlebarStylingToolbar"]);
-    [toolbar setShowsBaselineSeparator:NO];
-    [window setToolbar:toolbar];
-
-    // Set window style to hide the toolbar, otherwise the toolbar will show
-    // in fullscreen mode.
-    [window setTitlebarAppearsTransparent:NO];
-    shell_->SetStyleMask(true, NSWindowStyleMaskFullSizeContentView);
-  }
 }
 
 - (void)windowWillExitFullScreen:(NSNotification*)notification {
-  // Restore the titlebar visibility.
-  NSWindow* window = shell_->GetNativeWindow().GetNativeNSWindow();
-  if ((shell_->transparent() || !shell_->has_frame()) &&
-      (shell_->title_bar_style() != TitleBarStyle::kHiddenInset ||
-       shell_->fullscreen_window_title())) {
-    [window setTitleVisibility:NSWindowTitleHidden];
-  }
-
-  // Turn off the style for toolbar.
-  if (shell_->title_bar_style() == TitleBarStyle::kHiddenInset) {
-    shell_->SetStyleMask(false, NSWindowStyleMaskFullSizeContentView);
-    [window setTitlebarAppearsTransparent:YES];
-  }
-  shell_->SetExitingFullScreen(true);
-  if (shell_->title_bar_style() == TitleBarStyle::kHidden) {
-    shell_->RedrawTrafficLights();
-  }
+  shell_->NoitfyWindowWillLeaveFullScreen();
 }
 
 - (void)windowDidExitFullScreen:(NSNotification*)notification {
-  shell_->SetResizable(is_resizable_);
   shell_->NotifyWindowLeaveFullScreen();
-  shell_->SetExitingFullScreen(false);
-  if (shell_->title_bar_style() == TitleBarStyle::kHidden) {
-    shell_->RedrawTrafficLights();
-  }
+  shell_->SetResizable(is_resizable_);
 }
 
 - (void)windowWillClose:(NSNotification*)notification {

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -228,8 +228,8 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
 }
 
 - (void)windowDidExitFullScreen:(NSNotification*)notification {
-  shell_->NotifyWindowLeaveFullScreen();
   shell_->SetResizable(is_resizable_);
+  shell_->NotifyWindowLeaveFullScreen();
 }
 
 - (void)windowWillClose:(NSNotification*)notification {

--- a/shell/browser/ui/cocoa/window_buttons_view.h
+++ b/shell/browser/ui/cocoa/window_buttons_view.h
@@ -17,6 +17,7 @@
  @private
   BOOL mouse_inside_;
   BOOL show_on_hover_;
+  BOOL is_rtl_;
   gfx::Point margin_;
   base::scoped_nsobject<NSTrackingArea> tracking_area_;
 }

--- a/shell/browser/ui/cocoa/window_buttons_view.h
+++ b/shell/browser/ui/cocoa/window_buttons_view.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 Microsoft, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_BROWSER_UI_COCOA_WINDOW_BUTTONS_VIEW_H_
+#define SHELL_BROWSER_UI_COCOA_WINDOW_BUTTONS_VIEW_H_
+
+#import <Cocoa/Cocoa.h>
+
+#include "base/mac/scoped_nsobject.h"
+#include "base/optional.h"
+#include "ui/gfx/geometry/point.h"
+
+// Custom Quit, Minimize and Full Screen button container for frameless
+// windows.
+@interface WindowButtonsView : NSView {
+ @private
+  BOOL mouse_inside_;
+  BOOL show_on_hover_;
+  gfx::Point margin_;
+  base::scoped_nsobject<NSTrackingArea> tracking_area_;
+}
+
+- (id)initWithMargin:(const base::Optional<gfx::Point>&)margin;
+- (void)setMargin:(const base::Optional<gfx::Point>&)margin;
+- (void)setShowOnHover:(BOOL)yes;
+- (void)setNeedsDisplayForButtons;
+@end
+
+#endif  // SHELL_BROWSER_UI_COCOA_WINDOW_BUTTONS_VIEW_H_

--- a/shell/browser/ui/cocoa/window_buttons_view.mm
+++ b/shell/browser/ui/cocoa/window_buttons_view.mm
@@ -1,0 +1,113 @@
+// Copyright (c) 2021 Microsoft, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/ui/cocoa/window_buttons_view.h"
+
+@implementation WindowButtonsView
+
+- (id)initWithMargin:(const base::Optional<gfx::Point>&)margin {
+  self = [super initWithFrame:NSZeroRect];
+  [self setMargin:margin];
+
+  mouse_inside_ = false;
+  show_on_hover_ = false;
+
+  NSButton* close_button =
+      [NSWindow standardWindowButton:NSWindowCloseButton
+                        forStyleMask:NSWindowStyleMaskTitled];
+  [close_button setTag:1];
+  NSButton* miniaturize_button =
+      [NSWindow standardWindowButton:NSWindowMiniaturizeButton
+                        forStyleMask:NSWindowStyleMaskTitled];
+  [miniaturize_button setTag:2];
+  NSButton* zoom_button =
+      [NSWindow standardWindowButton:NSWindowZoomButton
+                        forStyleMask:NSWindowStyleMaskTitled];
+  [zoom_button setTag:3];
+
+  CGFloat x = 0;
+  const CGFloat space_between = 20;
+
+  [close_button setFrameOrigin:NSMakePoint(x, 0)];
+  x += space_between;
+  [self addSubview:close_button];
+
+  [miniaturize_button setFrameOrigin:NSMakePoint(x, 0)];
+  x += space_between;
+  [self addSubview:miniaturize_button];
+
+  [zoom_button setFrameOrigin:NSMakePoint(x, 0)];
+  x += space_between;
+  [self addSubview:zoom_button];
+
+  const auto last_button_frame = zoom_button.frame;
+  [self setFrameSize:NSMakeSize(last_button_frame.origin.x +
+                                    last_button_frame.size.width,
+                                last_button_frame.size.height)];
+
+  [self setNeedsDisplayForButtons];
+
+  return self;
+}
+
+- (void)setMargin:(const base::Optional<gfx::Point>&)margin {
+  margin_ = margin.value_or(gfx::Point(7, 3));
+}
+
+- (void)setShowOnHover:(BOOL)yes {
+  show_on_hover_ = yes;
+  [self setNeedsDisplayForButtons];
+}
+
+- (void)setNeedsDisplayForButtons {
+  for (NSView* subview in self.subviews) {
+    [subview setHidden:(show_on_hover_ && !mouse_inside_)];
+    [subview setNeedsDisplay:YES];
+  }
+}
+
+- (void)removeFromSuperview {
+  [super removeFromSuperview];
+  mouse_inside_ = NO;
+}
+
+- (void)viewDidMoveToWindow {
+  // Stay in upper left corner.
+  [self setAutoresizingMask:NSViewMaxXMargin | NSViewMinYMargin];
+  [self setFrameOrigin:NSMakePoint(margin_.x(), self.window.frame.size.height -
+                                                    self.frame.size.height -
+                                                    margin_.y())];
+}
+
+- (BOOL)_mouseInGroup:(NSButton*)button {
+  return mouse_inside_;
+}
+
+- (void)updateTrackingAreas {
+  [super updateTrackingAreas];
+  if (tracking_area_)
+    [self removeTrackingArea:tracking_area_.get()];
+
+  tracking_area_.reset([[NSTrackingArea alloc]
+      initWithRect:NSZeroRect
+           options:NSTrackingMouseEnteredAndExited | NSTrackingActiveAlways |
+                   NSTrackingInVisibleRect
+             owner:self
+          userInfo:nil]);
+  [self addTrackingArea:tracking_area_.get()];
+}
+
+- (void)mouseEntered:(NSEvent*)event {
+  [super mouseEntered:event];
+  mouse_inside_ = YES;
+  [self setNeedsDisplayForButtons];
+}
+
+- (void)mouseExited:(NSEvent*)event {
+  [super mouseExited:event];
+  mouse_inside_ = NO;
+  [self setNeedsDisplayForButtons];
+}
+
+@end


### PR DESCRIPTION
#### Description of Change

This PR cleans up the implementations of titleBarStyle, by making them share the same core implementation that uses a custom buttons view.

With this PR:
1. 3 unique code paths of titleBarStyle are merged to one, with lots of hacks removed.
2. The weird behaviors of `hiddenInset` titleBarStyle are gone (will be explained bellow).
3. It becomes possible to toggle the rounded corners of frameless window.
4. It becomes possible to precisely control the traffic lights.
5. It becomes possible to dynamically change between different titleBarStyles.

As you can see in the screenshots bellow, with current implementation of `hiddenInset`, the titlebar under fullscreen has to be either a tall titlebar with aligned traffic lights and no title, or a tall titlebar that has traffic lights and title taking only the top half of its space. And the `fullscreenWindowTitle` option was introduced to let users choose between the 2 broken titlebars (https://github.com/electron/electron/pull/9788).

_hiddenInset with title_

<img width="1440" alt="Screen Shot 2021-01-26 at 16 21 24" src="https://user-images.githubusercontent.com/639601/105813431-2822e800-5ff3-11eb-854e-632a233904a4.png">

_hiddenInset without title_

<img width="1440" alt="Screen Shot 2021-01-26 at 16 21 48" src="https://user-images.githubusercontent.com/639601/105813463-340eaa00-5ff3-11eb-987c-56173bf945be.png">

With the fix in the PR, the titlebar under fullscreen would become normal. So apps using `hiddenInset` will have a correct fullscreen titlebar no matter what `fullscreenWindowTitle` option they were using, there is nothing broken and no side effects.

<img width="1440" alt="Screen Shot 2021-01-26 at 16 21 58" src="https://user-images.githubusercontent.com/639601/105813487-3d981200-5ff3-11eb-822f-49f603da23cb.png">

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix `hiddenInset` titleBarStyle's abnormal fullscreen titlebar. Fix `hiddenInset` titleBarStyle not working with `trafficLightPosition` option.