### PR TITLE
fix: pdf viewer missing resources

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -648,6 +648,7 @@ source_set("electron_lib") {
   }
   if (enable_pdf_viewer) {
     deps += [
+      "//chrome/browser/resources/pdf:pdf_resources",
       "//components/pdf/browser",
       "//components/pdf/renderer",
       "//pdf:pdf_ppapi",

--- a/electron_paks.gni
+++ b/electron_paks.gni
@@ -96,6 +96,10 @@ template("electron_extra_paks") {
       "$root_gen_dir/ui/resources/webui_generated_resources.pak",
     ]
     deps += [ "//content/browser/devtools:devtools_resources" ]
+    if (enable_pdf_viewer) {
+      sources += [ "$root_gen_dir/chrome/pdf_resources.pak" ]
+      deps += [ "//chrome/browser/resources/pdf:pdf_resources" ]
+    }
     if (enable_print_preview) {
       sources += [ "$root_gen_dir/chrome/print_preview_resources.pak" ]
       deps +=

--- a/shell/browser/extensions/api/resources_private/resources_private_api.cc
+++ b/shell/browser/extensions/api/resources_private/resources_private_api.cc
@@ -66,11 +66,9 @@ void AddAdditionalDataForPdf(base::DictionaryValue* dict) {
   dict->SetKey("pdfFormSaveEnabled",
                base::Value(base::FeatureList::IsEnabled(
                    chrome_pdf::features::kSaveEditedPDFForm)));
-  dict->SetStringKey(
-      "pdfViewerUpdateEnabledAttribute",
-      base::FeatureList::IsEnabled(chrome_pdf::features::kPDFViewerUpdate)
-          ? "pdf-viewer-update-enabled"
-          : "");
+  dict->SetKey("documentPropertiesEnabled",
+               base::Value(base::FeatureList::IsEnabled(
+                   chrome_pdf::features::kPdfViewerDocumentProperties)));
   dict->SetKey("presentationModeEnabled",
                base::Value(base::FeatureList::IsEnabled(
                    chrome_pdf::features::kPdfViewerPresentationMode)));

--- a/shell/browser/extensions/api/resources_private/resources_private_api.cc
+++ b/shell/browser/extensions/api/resources_private/resources_private_api.cc
@@ -39,6 +39,7 @@ void AddStringsForPdf(base::DictionaryValue* dict) {
       {"passwordDialogTitle", IDS_PDF_PASSWORD_DIALOG_TITLE},
       {"passwordPrompt", IDS_PDF_NEED_PASSWORD},
       {"passwordSubmit", IDS_PDF_PASSWORD_SUBMIT},
+      {"thumbnailPageAriaLabel", IDS_PDF_THUMBNAIL_PAGE_ARIA_LABEL},
       {"passwordInvalid", IDS_PDF_PASSWORD_INVALID},
       {"pageLoading", IDS_PDF_PAGE_LOADING},
       {"pageLoadFailed", IDS_PDF_PAGE_LOAD_FAILED},

--- a/shell/browser/extensions/electron_component_extension_resource_manager.cc
+++ b/shell/browser/extensions/electron_component_extension_resource_manager.cc
@@ -18,6 +18,7 @@
 
 #if BUILDFLAG(ENABLE_PDF_VIEWER)
 #include "chrome/browser/pdf/pdf_extension_util.h"  // nogncheck
+#include "chrome/grit/pdf_resources_map.h"
 #include "extensions/common/constants.h"
 #endif
 
@@ -28,6 +29,8 @@ ElectronComponentExtensionResourceManager::
   AddComponentResourceEntries(kComponentExtensionResources,
                               kComponentExtensionResourcesSize);
 #if BUILDFLAG(ENABLE_PDF_VIEWER)
+  AddComponentResourceEntries(kPdfResources, kPdfResourcesSize);
+
   // Register strings for the PDF viewer, so that $i18n{} replacements work.
   base::Value pdf_strings(base::Value::Type::DICTIONARY);
   pdf_extension_util::AddStrings(

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -1280,6 +1280,13 @@ describe('chromium features', () => {
       slashes: true
     });
 
+    it('successfully loads a PDF file', async () => {
+      const w = new BrowserWindow({ show: false });
+
+      w.loadURL(pdfSource);
+      await emittedOnce(w.webContents, 'did-finish-load');
+    });
+
     it('opens when loading a pdf resource as top level navigation', async () => {
       const w = new BrowserWindow({ show: false });
       w.loadURL(pdfSource);


### PR DESCRIPTION
#### Description of Change

Refs https://chromium-review.googlesource.com/c/chromium/src/+/2614504.

Died in https://github.com/electron/electron/commit/adf0a7354369a1d0387b66ed547b59cfbee185d8.

Tested by adding `mainWindow.loadURL('http://www.africau.edu/images/default/sample.pdf')` to an arbitrary Fiddle gist.

After:
<img width="912" alt="Screen Shot 2021-01-26 at 12 40 15 PM" src="https://user-images.githubusercontent.com/2036040/105902622-bedfac80-5fd3-11eb-9703-40c0acf8434d.png">


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed PDF viewer failing to load resources.
