### PR TITLE
fix(asar): readdir(withFileTypes) fails on deep directory

### DIFF
--- a/lib/common/asar.js
+++ b/lib/common/asar.js
@@ -597,7 +597,13 @@
       if (options.withFileTypes) {
         const dirents = [];
         for (const file of files) {
-          const stats = archive.stat(file);
+          const childPath = path.join(filePath, file);
+          const stats = archive.stat(childPath);
+          if (!stats) {
+            const error = createError(AsarError.NOT_FOUND, { asarPath, filePath: childPath });
+            nextTick(callback, [error]);
+            return;
+          }
           if (stats.isFile) {
             dirents.push(new fs.Dirent(file, fs.constants.UV_DIRENT_FILE));
           } else if (stats.isDirectory) {
@@ -633,7 +639,11 @@
       if (options.withFileTypes) {
         const dirents = [];
         for (const file of files) {
-          const stats = archive.stat(file);
+          const childPath = path.join(filePath, file);
+          const stats = archive.stat(childPath);
+          if (!stats) {
+            throw createError(AsarError.NOT_FOUND, { asarPath, filePath: childPath });
+          }
           if (stats.isFile) {
             dirents.push(new fs.Dirent(file, fs.constants.UV_DIRENT_FILE));
           } else if (stats.isDirectory) {

--- a/spec/asar-spec.js
+++ b/spec/asar-spec.js
@@ -920,6 +920,16 @@ describe('asar package', function () {
         expect(names).to.deep.equal(['dir1', 'dir2', 'dir3', 'file1', 'file2', 'file3', 'link1', 'link2', 'ping.js']);
       });
 
+      it('supports withFileTypes for a deep directory', function () {
+        const p = path.join(asarDir, 'a.asar', 'dir3');
+        const dirs = fs.readdirSync(p, { withFileTypes: true });
+        for (const dir of dirs) {
+          expect(dir instanceof fs.Dirent).to.be.true();
+        }
+        const names = dirs.map(a => a.name);
+        expect(names).to.deep.equal(['file1', 'file2', 'file3']);
+      });
+
       it('reads dirs from a linked dir', function () {
         const p = path.join(asarDir, 'a.asar', 'link2', 'link2');
         const dirs = fs.readdirSync(p);


### PR DESCRIPTION
Backport of #26865

See that PR for details.

Notes: Fixed `readdir`/`readdirSync` (w/ `withFileTypes`) failing on a deep directory within archive.