### PR TITLE
chore: remove bunch of usages of any

### DIFF
--- a/lib/asar/fs-wrapper.ts
+++ b/lib/asar/fs-wrapper.ts
@@ -639,8 +639,10 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
 
   fs.promises.readdir = util.promisify(fs.readdir);
 
+  type ReaddirSyncOptions = { encoding: BufferEncoding | null; withFileTypes?: false };
+
   const { readdirSync } = fs;
-  fs.readdirSync = function (pathArgument: string, options: { encoding: BufferEncoding | null; withFileTypes?: false } | BufferEncoding | null) {
+  fs.readdirSync = function (pathArgument: string, options: ReaddirSyncOptions | BufferEncoding | null) {
     const pathInfo = splitPath(pathArgument);
     if (!pathInfo.isAsar) return readdirSync.apply(this, arguments);
     const { asarPath, filePath } = pathInfo;
@@ -655,7 +657,7 @@ export const wrapFsWithAsar = (fs: Record<string, any>) => {
       throw createError(AsarError.NOT_FOUND, { asarPath, filePath });
     }
 
-    if (options && (options as any).withFileTypes) {
+    if (options && (options as ReaddirSyncOptions).withFileTypes) {
       const dirents = [];
       for (const file of files) {
         const childPath = path.join(filePath, file);

--- a/lib/browser/api/menu.ts
+++ b/lib/browser/api/menu.ts
@@ -231,12 +231,12 @@ function sortTemplate (template: (MenuItemConstructorOptions | MenuItem)[]) {
 function generateGroupId (items: (MenuItemConstructorOptions | MenuItem)[], pos: number) {
   if (pos > 0) {
     for (let idx = pos - 1; idx >= 0; idx--) {
-      if (items[idx].type === 'radio') return (items[idx] as any).groupId;
+      if (items[idx].type === 'radio') return (items[idx] as MenuItem).groupId;
       if (items[idx].type === 'separator') break;
     }
   } else if (pos < items.length) {
     for (let idx = pos; idx <= items.length - 1; idx++) {
-      if (items[idx].type === 'radio') return (items[idx] as any).groupId;
+      if (items[idx].type === 'radio') return (items[idx] as MenuItem).groupId;
       if (items[idx].type === 'separator') break;
     }
   }

--- a/lib/browser/api/touch-bar.ts
+++ b/lib/browser/api/touch-bar.ts
@@ -13,14 +13,14 @@ const extendConstructHook = (target: any, hook: Function) => {
 };
 
 const ImmutableProperty = <T extends TouchBarItem<any>>(def: (config: T extends TouchBarItem<infer C> ? C : never, setInternalProp: <K extends keyof T>(k: K, v: T[K]) => void) => any) => (target: T, propertyKey: keyof T) => {
-  extendConstructHook(target as any, function (this: T) {
+  extendConstructHook(target, function (this: T) {
     (this as any)[hiddenProperties][propertyKey] = def((this as any)._config, (k, v) => {
       (this as any)[hiddenProperties][k] = v;
     });
   });
   Object.defineProperty(target, propertyKey, {
     get: function () {
-      return (this as any)[hiddenProperties][propertyKey];
+      return this[hiddenProperties][propertyKey];
     },
     set: function () {
       throw new Error(`Cannot override property ${name}`);
@@ -31,7 +31,7 @@ const ImmutableProperty = <T extends TouchBarItem<any>>(def: (config: T extends 
 };
 
 const LiveProperty = <T extends TouchBarItem<any>>(def: (config: T extends TouchBarItem<infer C> ? C : never) => any, onMutate?: (self: T, newValue: any) => void) => (target: T, propertyKey: keyof T) => {
-  extendConstructHook(target as any, function (this: T) {
+  extendConstructHook(target, function (this: T) {
     (this as any)[hiddenProperties][propertyKey] = def((this as any)._config);
     if (onMutate) onMutate((this as any), (this as any)[hiddenProperties][propertyKey]);
   });
@@ -59,7 +59,7 @@ abstract class TouchBarItem<ConfigType> extends EventEmitter {
 
   constructor (config: ConfigType) {
     super();
-    this._config = this._config || config || {} as any;
+    this._config = this._config || config || {} as ConfigType;
     (this as any)[hiddenProperties] = {};
     const hook = (this as any)._hook;
     if (hook) hook.call(this);

--- a/lib/browser/guest-view-manager.ts
+++ b/lib/browser/guest-view-manager.ts
@@ -197,7 +197,7 @@ const attachGuest = function (event: Electron.IpcMainInvokeEvent,
   // Inherit certain option values from embedder
   const lastWebPreferences = embedder.getLastWebPreferences();
   for (const [name, value] of inheritedWebPreferences) {
-    if ((lastWebPreferences as any)[name] === value) {
+    if (lastWebPreferences[name as keyof Electron.WebPreferences] === value) {
       (webPreferences as any)[name] = value;
     }
   }

--- a/lib/browser/guest-window-manager.ts
+++ b/lib/browser/guest-window-manager.ts
@@ -84,7 +84,7 @@ export function openGuestWindow ({ event, embedder, guest, referrer, disposition
       httpReferrer: referrer,
       ...(postData && {
         postData,
-        extraHeaders: formatPostDataHeaders(postData)
+        extraHeaders: formatPostDataHeaders(postData as Electron.UploadRawData[])
       })
     });
   }
@@ -133,7 +133,7 @@ const handleWindowLifecycleEvents = function ({ embedder, guest, frameName }: {
  * `did-create-window` in 11.0.0. Will be removed in 12.0.0.
  */
 function emitDeprecatedNewWindowEvent ({ event, embedder, guest, windowOpenArgs, browserWindowOptions, additionalFeatures, disposition, referrer, postData }: {
-  event: { sender: WebContents, defaultPrevented: boolean },
+  event: { sender: WebContents, defaultPrevented: boolean, newGuest?: BrowserWindow },
   embedder: WebContents,
   guest?: WebContents,
   windowOpenArgs: WindowOpenArgs,
@@ -144,10 +144,10 @@ function emitDeprecatedNewWindowEvent ({ event, embedder, guest, windowOpenArgs,
   postData?: PostData,
 }): boolean {
   const { url, frameName } = windowOpenArgs;
-  const isWebViewWithPopupsDisabled = embedder.getType() === 'webview' && (embedder as any).getLastWebPreferences().disablePopups;
+  const isWebViewWithPopupsDisabled = embedder.getType() === 'webview' && embedder.getLastWebPreferences().disablePopups;
   const postBody = postData ? {
     data: postData,
-    headers: formatPostDataHeaders(postData)
+    headers: formatPostDataHeaders(postData as Electron.UploadRawData[])
   } : null;
 
   embedder.emit(
@@ -165,14 +165,14 @@ function emitDeprecatedNewWindowEvent ({ event, embedder, guest, windowOpenArgs,
     postBody
   );
 
-  const { newGuest } = event as any;
+  const { newGuest } = event;
   if (isWebViewWithPopupsDisabled) return true;
   if (event.defaultPrevented) {
     if (newGuest) {
       if (guest === newGuest.webContents) {
         // The webContents is not changed, so set defaultPrevented to false to
         // stop the callers of this event from destroying the webContents.
-        (event as any).defaultPrevented = false;
+        event.defaultPrevented = false;
       }
 
       handleWindowLifecycleEvents({
@@ -222,7 +222,7 @@ function makeBrowserWindowOptions ({ embedder, features, frameName, overrideOpti
       ...parsedOptions,
       ...overrideOptions,
       webPreferences: makeWebPreferences({ embedder, insecureParsedWebPreferences: parsedWebPreferences, secureOverrideWebPreferences: overrideOptions && overrideOptions.webPreferences, useDeprecatedBehaviorForOptionInheritance: true })
-    }
+    } as Electron.BrowserViewConstructorOptions
   };
 }
 
@@ -237,13 +237,13 @@ export function makeWebPreferences ({ embedder, secureOverrideWebPreferences = {
   useDeprecatedBehaviorForOptionInheritance?: boolean
 }) {
   const deprecatedInheritedOptions = getDeprecatedInheritedOptions(embedder);
-  const parentWebPreferences = (embedder as any).getLastWebPreferences();
-  const securityWebPreferencesFromParent = Object.keys(securityWebPreferences).reduce((map, key) => {
-    if (securityWebPreferences[key] === parentWebPreferences[key]) {
-      map[key] = parentWebPreferences[key];
+  const parentWebPreferences = embedder.getLastWebPreferences();
+  const securityWebPreferencesFromParent = (Object.keys(securityWebPreferences).reduce((map, key) => {
+    if (securityWebPreferences[key] === parentWebPreferences[key as keyof Electron.WebPreferences]) {
+      (map as any)[key] = parentWebPreferences[key as keyof Electron.WebPreferences];
     }
     return map;
-  }, {} as any);
+  }, {} as Electron.WebPreferences));
   const openerId = parentWebPreferences.nativeWindowOpen ? null : embedder.id;
 
   return {
@@ -268,18 +268,18 @@ export function makeWebPreferences ({ embedder, secureOverrideWebPreferences = {
  * only critical security preferences will be inherited by default.
  */
 function getDeprecatedInheritedOptions (embedder: WebContents) {
-  if (!(embedder as any).browserWindowOptions) {
+  if (!embedder.browserWindowOptions) {
     // If it's a webview, return just the webPreferences.
     return {
-      webPreferences: (embedder as any).getLastWebPreferences()
+      webPreferences: embedder.getLastWebPreferences()
     };
   }
 
-  const { type, show, ...inheritableOptions } = (embedder as any).browserWindowOptions;
+  const { type, show, ...inheritableOptions } = embedder.browserWindowOptions;
   return inheritableOptions;
 }
 
-function formatPostDataHeaders (postData: any) {
+function formatPostDataHeaders (postData: Electron.UploadRawData[]) {
   if (!postData) return;
 
   let extraHeaders = 'content-type: application/x-www-form-urlencoded';

--- a/lib/browser/guest-window-proxy.ts
+++ b/lib/browser/guest-window-proxy.ts
@@ -28,7 +28,7 @@ const getGuestWindow = function (guestContents: WebContents) {
 };
 
 const isChildWindow = function (sender: WebContents, target: WebContents) {
-  return (target as any).getLastWebPreferences().openerId === sender.id;
+  return target.getLastWebPreferences().openerId === sender.id;
 };
 
 const isRelatedWindow = function (sender: WebContents, target: WebContents) {
@@ -43,7 +43,7 @@ const isScriptableWindow = function (sender: WebContents, target: WebContents) {
 };
 
 const isNodeIntegrationEnabled = function (sender: WebContents) {
-  return (sender as any).getLastWebPreferences().nodeIntegration === true;
+  return sender.getLastWebPreferences().nodeIntegration === true;
 };
 
 // Checks whether |sender| can access the |target|:
@@ -65,15 +65,15 @@ ipcMainInternal.on(
     features: string
   ) => {
     // This should only be allowed for senders that have nativeWindowOpen: false
-    const lastWebPreferences = (event.sender as any).getLastWebPreferences();
+    const lastWebPreferences = event.sender.getLastWebPreferences();
     if (lastWebPreferences.nativeWindowOpen || lastWebPreferences.sandbox) {
-      (event as any).returnValue = null;
+      event.returnValue = null;
       throw new Error(
         'GUEST_WINDOW_MANAGER_WINDOW_OPEN denied: expected native window.open'
       );
     }
 
-    const browserWindowOptions = (event.sender as any)._callWindowOpenHandler(event, url, frameName, features);
+    const browserWindowOptions = event.sender._callWindowOpenHandler(event, url, frameName, features);
     if (event.defaultPrevented) {
       return;
     }
@@ -82,7 +82,7 @@ ipcMainInternal.on(
       embedder: event.sender,
       referrer: { url: '', policy: 'default' },
       disposition: 'new-window',
-      overrideBrowserWindowOptions: browserWindowOptions,
+      overrideBrowserWindowOptions: browserWindowOptions!,
       windowOpenArgs: {
         url: url || 'about:blank',
         frameName: frameName || '',
@@ -90,7 +90,7 @@ ipcMainInternal.on(
       }
     });
 
-    (event as any).returnValue = guest ? guest.webContents.id : null;
+    event.returnValue = guest ? guest.webContents.id : null;
   }
 );
 

--- a/lib/browser/remote/server.ts
+++ b/lib/browser/remote/server.ts
@@ -206,7 +206,7 @@ const removeRemoteListenersAndLogWarning = (sender: any, callIntoRenderer: (...a
     if (remoteEvents.length > 0) {
       message += `\nRemote event names: ${remoteEvents.join(', ')}`;
       remoteEvents.forEach((eventName) => {
-        sender.removeListener(eventName as any, callIntoRenderer);
+        sender.removeListener(eventName, callIntoRenderer);
       });
     }
   }
@@ -365,7 +365,7 @@ handleRemoteCommand(IPC_MESSAGES.BROWSER_REQUIRE, function (event, contextId, mo
     if (customEvent.defaultPrevented) {
       throw new Error(`Blocked remote.require('${moduleName}')`);
     } else {
-      customEvent.returnValue = (process as any).mainModule.require(moduleName);
+      customEvent.returnValue = process.mainModule.require(moduleName);
     }
   }
 

--- a/lib/renderer/api/context-bridge.ts
+++ b/lib/renderer/api/context-bridge.ts
@@ -12,7 +12,7 @@ const contextBridge: Electron.ContextBridge = {
     checkContextIsolationEnabled();
     return binding.exposeAPIInMainWorld(key, api);
   }
-} as any;
+};
 
 export default contextBridge;
 

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -144,7 +144,7 @@ if (nodeIntegration) {
       // We do not want to add `uncaughtException` to our definitions
       // because we don't want anyone else (anywhere) to throw that kind
       // of error.
-      global.process.emit('uncaughtException' as any, error as any);
+      global.process.emit('uncaughtException', error as any);
       return true;
     } else {
       return false;

--- a/lib/renderer/security-warnings.ts
+++ b/lib/renderer/security-warnings.ts
@@ -79,7 +79,7 @@ const isLocalhost = function () {
  */
 const isUnsafeEvalEnabled: () => Promise<boolean> = function () {
   // Call _executeJavaScript to bypass the world-safe deprecation warning
-  return (webFrame as any)._executeJavaScript(`(${(() => {
+  return webFrame._executeJavaScript(`(${(() => {
     try {
       eval(window.trustedTypes.emptyScript); // eslint-disable-line no-eval
     } catch {

--- a/lib/renderer/web-view/web-view-attributes.ts
+++ b/lib/renderer/web-view/web-view-attributes.ts
@@ -60,7 +60,7 @@ export class WebViewAttribute implements MutationHandler {
   }
 
   // Called when the attribute's value changes.
-  public handleMutation: MutationHandler['handleMutation'] = () => undefined as any
+  public handleMutation: MutationHandler['handleMutation'] = () => undefined
 }
 
 // An attribute that is treated as a Boolean.

--- a/lib/renderer/web-view/web-view-element.ts
+++ b/lib/renderer/web-view/web-view-element.ts
@@ -94,7 +94,7 @@ const registerWebViewElement = (v8Util: NodeJS.V8UtilBinding, webViewImpl: typeo
   // The customElements.define has to be called in a special scope.
   webViewImpl.webFrame.allowGuestViewElementDefinition(window, () => {
     window.customElements.define('webview', WebViewElement);
-    (window as any).WebView = WebViewElement;
+    window.WebView = WebViewElement;
 
     // Delete the callbacks so developers cannot call them and produce unexpected
     // behavior.

--- a/spec-main/api-context-bridge-spec.ts
+++ b/spec-main/api-context-bridge-spec.ts
@@ -981,7 +981,7 @@ describe('contextBridge', () => {
         describe('overrideGlobalValueFromIsolatedWorld', () => {
           it('should override top level properties', async () => {
             await makeBindingWindow(() => {
-              contextBridge.internalContextBridge.overrideGlobalValueFromIsolatedWorld(['open'], () => ({ you: 'are a wizard' }));
+              contextBridge.internalContextBridge!.overrideGlobalValueFromIsolatedWorld(['open'], () => ({ you: 'are a wizard' }));
             });
             const result = await callWithBindings(async (root: any) => {
               return root.open();
@@ -991,7 +991,7 @@ describe('contextBridge', () => {
 
           it('should override deep properties', async () => {
             await makeBindingWindow(() => {
-              contextBridge.internalContextBridge.overrideGlobalValueFromIsolatedWorld(['document', 'foo'], () => 'I am foo');
+              contextBridge.internalContextBridge!.overrideGlobalValueFromIsolatedWorld(['document', 'foo'], () => 'I am foo');
             });
             const result = await callWithBindings(async (root: any) => {
               return root.document.foo();
@@ -1008,7 +1008,7 @@ describe('contextBridge', () => {
                 callCount++;
                 return true;
               };
-              contextBridge.internalContextBridge.overrideGlobalPropertyFromIsolatedWorld(['isFun'], getter);
+              contextBridge.internalContextBridge!.overrideGlobalPropertyFromIsolatedWorld(['isFun'], getter);
               contextBridge.exposeInMainWorld('foo', {
                 callCount: () => callCount
               });
@@ -1022,7 +1022,7 @@ describe('contextBridge', () => {
 
           it('should not make a setter if none is provided', async () => {
             await makeBindingWindow(() => {
-              contextBridge.internalContextBridge.overrideGlobalPropertyFromIsolatedWorld(['isFun'], () => true);
+              contextBridge.internalContextBridge!.overrideGlobalPropertyFromIsolatedWorld(['isFun'], () => true);
             });
             const result = await callWithBindings(async (root: any) => {
               root.isFun = 123;
@@ -1038,7 +1038,7 @@ describe('contextBridge', () => {
                 callArgs.push(args);
                 return true;
               };
-              contextBridge.internalContextBridge.overrideGlobalPropertyFromIsolatedWorld(['isFun'], () => true, setter);
+              contextBridge.internalContextBridge!.overrideGlobalPropertyFromIsolatedWorld(['isFun'], () => true, setter);
               contextBridge.exposeInMainWorld('foo', {
                 callArgs: () => callArgs
               });
@@ -1056,7 +1056,7 @@ describe('contextBridge', () => {
         describe('overrideGlobalValueWithDynamicPropsFromIsolatedWorld', () => {
           it('should not affect normal values', async () => {
             await makeBindingWindow(() => {
-              contextBridge.internalContextBridge.overrideGlobalValueWithDynamicPropsFromIsolatedWorld(['thing'], {
+              contextBridge.internalContextBridge!.overrideGlobalValueWithDynamicPropsFromIsolatedWorld(['thing'], {
                 a: 123,
                 b: () => 2,
                 c: () => ({ d: 3 })
@@ -1070,7 +1070,7 @@ describe('contextBridge', () => {
 
           it('should work with getters', async () => {
             await makeBindingWindow(() => {
-              contextBridge.internalContextBridge.overrideGlobalValueWithDynamicPropsFromIsolatedWorld(['thing'], {
+              contextBridge.internalContextBridge!.overrideGlobalValueWithDynamicPropsFromIsolatedWorld(['thing'], {
                 get foo () {
                   return 'hi there';
                 }
@@ -1085,7 +1085,7 @@ describe('contextBridge', () => {
           it('should work with setters', async () => {
             await makeBindingWindow(() => {
               let a: any = null;
-              contextBridge.internalContextBridge.overrideGlobalValueWithDynamicPropsFromIsolatedWorld(['thing'], {
+              contextBridge.internalContextBridge!.overrideGlobalValueWithDynamicPropsFromIsolatedWorld(['thing'], {
                 get foo () {
                   return a;
                 },
@@ -1103,7 +1103,7 @@ describe('contextBridge', () => {
 
           it('should work with deep properties', async () => {
             await makeBindingWindow(() => {
-              contextBridge.internalContextBridge.overrideGlobalValueWithDynamicPropsFromIsolatedWorld(['thing'], {
+              contextBridge.internalContextBridge!.overrideGlobalValueWithDynamicPropsFromIsolatedWorld(['thing'], {
                 a: () => ({
                   get foo () {
                     return 'still here';

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -232,6 +232,7 @@ declare namespace NodeJS {
     _firstFileName?: string;
 
     helperExecPath: string;
+    mainModule: NodeJS.Module;
   }
 }
 
@@ -271,6 +272,7 @@ declare interface Window {
       completeURL: (project: string, path: string) => string;
     }
   };
+  WebView: typeof ElectronInternal.WebViewElement;
   ResizeObserver: ResizeObserver;
   trustedTypes: TrustedTypePolicyFactory;
 }

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -37,8 +37,12 @@ declare namespace Electron {
     removeListener(event: '-touch-bar-interaction', listener: (event: Event, itemID: string, details: any) => void): this;
   }
 
+  interface BrowserWindowConstructorOptions {
+    webContents?: WebContents;
+  }
+
   interface ContextBridge {
-    internalContextBridge: {
+    internalContextBridge?: {
       contextIsolationEnabled: boolean;
       overrideGlobalValueFromIsolatedWorld(keys: string[], value: any): void;
       overrideGlobalValueWithDynamicPropsFromIsolatedWorld(keys: string[], value: any): void;
@@ -88,6 +92,7 @@ declare namespace Electron {
   }
 
   interface WebFrame {
+    _executeJavaScript(code: string, userGesture?: boolean): Promise<any>;
     getWebFrameId(window: Window): number;
     allowGuestViewElementDefinition(window: Window, context: any): void;
   }
@@ -100,7 +105,7 @@ declare namespace Electron {
 
   interface WebPreferences {
     guestInstanceId?: number;
-    openerId?: number;
+    openerId?: number | null;
     disablePopups?: boolean;
     preloadURL?: string;
     embedder?: Electron.WebContents;
@@ -147,9 +152,14 @@ declare namespace Electron {
     acceleratorWorksWhenHidden?: boolean;
   }
 
+  interface IpcMainEvent {
+    sendReply(value: any): void;
+  }
+
   interface IpcMainInvokeEvent {
+    sendReply(value: any): void;
     _reply(value: any): void;
-    _throw(error: Error): void;
+    _throw(error: Error | string): void;
   }
 
   const deprecate: ElectronInternal.DeprecationUtil;
@@ -250,8 +260,24 @@ declare namespace ElectronInternal {
     once(channel: string, listener: (event: IpcMainInternalEvent, ...args: any[]) => void): this;
   }
 
+  interface Event extends Electron.Event {
+    sender: WebContents;
+  }
+
   interface LoadURLOptions extends Electron.LoadURLOptions {
     reloadIgnoringCache?: boolean;
+  }
+
+  interface WebContentsPrintOptions extends Electron.WebContentsPrintOptions {
+    mediaSize?: MediaSize;
+  }
+
+  type MediaSize = {
+    name: string,
+    custom_display_name: string,
+    height_microns: number,
+    width_microns: number,
+    is_default?: 'true',
   }
 
   type ModuleLoader = () => any;


### PR DESCRIPTION
#### Description of Change
Improves type safety. `any` was used 377 times in lib, lowered to 333 times.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes
