### PR TITLE
docs: update Xcode / macOS SDK version in build-instructions-macos.md

### DIFF
--- a/docs/development/build-instructions-macos.md
+++ b/docs/development/build-instructions-macos.md
@@ -42,7 +42,7 @@ $ pip install pyobjc
 If you're developing Electron and don't plan to redistribute your
 custom Electron build, you may skip this section.
 
-Official Electron builds are built with [Xcode 9.4.1](http://adcdownload.apple.com/Developer_Tools/Xcode_9.4.1/Xcode_9.4.1.xip), and the macOS 10.13 SDK.  Building with a newer SDK works too, but the releases currently use the 10.13 SDK.
+Official Electron builds are built with [Xcode 12.2](https://download.developer.apple.com/Developer_Tools/Xcode_12.2/Xcode_12.2.xip), and the macOS 11.0 SDK. Building with a newer SDK works too, but the releases currently use the 11.0 SDK.
 
 ## Building Electron
 


### PR DESCRIPTION
#### Description of Change
We are now using Xcode 12.2 / macOS SDK 11.0
https://github.com/electron/electron/blob/f24348485a1a938f7e3173e0a94bee6e29b18104/.circleci/config.yml#L86-L98

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added

#### Release Notes
Notes: no-notes