### PR TITLE
docs: update Xcode / macOS SDK version in build-instructions-macos.md

### DIFF
--- a/docs/development/build-instructions-macos.md
+++ b/docs/development/build-instructions-macos.md
@@ -42,7 +42,7 @@ $ pip install pyobjc
 If you're developing Electron and don't plan to redistribute your
 custom Electron build, you may skip this section.
 
-Official Electron builds are built with [Xcode 9.4.1](http://adcdownload.apple.com/Developer_Tools/Xcode_9.4.1/Xcode_9.4.1.xip), and the macOS 10.13 SDK.  Building with a newer SDK works too, but the releases currently use the 10.13 SDK.
+Official Electron builds are built with [Xcode 11.1](https://download.developer.apple.com/Developer_Tools/Xcode_11.1/Xcode_11.1.xip), and the macOS 10.15 SDK. Building with a newer SDK works too, but the releases currently use the 10.15 SDK.
 
 ## Building Electron
 


### PR DESCRIPTION
#### Description of Change

Backport of #27513

We are now using Xcode 11.1 / macOS SDK 10.15
https://github.com/electron/electron/blob/a5a6f12e1d68d1945739e55e9f0ef277131f2cee/.circleci/config.yml#L78-L85

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added

#### Release Notes
Notes: no-notes
