### PR TITLE
fix: dont try to serialize WasmModuleObjects

### DIFF
--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -96,7 +96,8 @@ bool IsPlainObject(const v8::Local<v8::Value>& object) {
            object->IsArrayBuffer() || object->IsArrayBufferView() ||
            object->IsArray() || object->IsDataView() ||
            object->IsSharedArrayBuffer() || object->IsProxy() ||
-           object->IsWasmModuleObject() || object->IsModuleNamespaceObject());
+           object->IsWasmModuleObject() || object->IsWasmMemoryObject() ||
+           object->IsModuleNamespaceObject());
 }
 
 bool IsPlainArray(const v8::Local<v8::Value>& arr) {


### PR DESCRIPTION
#### Description of Change

Refs https://chromium-review.googlesource.com/c/v8/v8/+/2574699.

Ensure that the `contextBridge` doesn't try to serialize `WasmMemoryObject`s as plain objects.

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `contextBridge` might incorrectly try to serialize some WebAssembly objects.
