### PR TITLE
fix: replace default frameName title with null check

### DIFF
--- a/lib/browser/guest-window-manager.ts
+++ b/lib/browser/guest-window-manager.ts
@@ -47,6 +47,7 @@ export function openGuestWindow ({ event, embedder, guest, referrer, disposition
     embedder,
     features,
     frameName,
+    isNativeWindowOpen,
     overrideOptions: overrideBrowserWindowOptions
   });
 
@@ -199,10 +200,11 @@ const securityWebPreferences: { [key: string]: boolean } = {
   enableWebSQL: false
 };
 
-function makeBrowserWindowOptions ({ embedder, features, frameName, overrideOptions, useDeprecatedBehaviorForBareValues = true, useDeprecatedBehaviorForOptionInheritance = true }: {
+function makeBrowserWindowOptions ({ embedder, features, frameName, isNativeWindowOpen, overrideOptions, useDeprecatedBehaviorForBareValues = true, useDeprecatedBehaviorForOptionInheritance = true }: {
   embedder: WebContents,
   features: string,
   frameName: string,
+  isNativeWindowOpen: boolean,
   overrideOptions?: BrowserWindowConstructorOptions,
   useDeprecatedBehaviorForBareValues?: boolean
   useDeprecatedBehaviorForOptionInheritance?: boolean
@@ -211,8 +213,6 @@ function makeBrowserWindowOptions ({ embedder, features, frameName, overrideOpti
 
   const deprecatedInheritedOptions = getDeprecatedInheritedOptions(embedder);
 
-  if (parsedOptions.title == null) parsedOptions.title = frameName;
-
   return {
     additionalFeatures,
     options: {
@@ -220,6 +220,7 @@ function makeBrowserWindowOptions ({ embedder, features, frameName, overrideOpti
       show: true,
       width: 800,
       height: 600,
+      ...(!isNativeWindowOpen && { title: frameName }),
       ...parsedOptions,
       ...overrideOptions,
       webPreferences: makeWebPreferences({ embedder, insecureParsedWebPreferences: parsedWebPreferences, secureOverrideWebPreferences: overrideOptions && overrideOptions.webPreferences, useDeprecatedBehaviorForOptionInheritance: true })

--- a/lib/browser/guest-window-manager.ts
+++ b/lib/browser/guest-window-manager.ts
@@ -211,12 +211,13 @@ function makeBrowserWindowOptions ({ embedder, features, frameName, overrideOpti
 
   const deprecatedInheritedOptions = getDeprecatedInheritedOptions(embedder);
 
+  if (parsedOptions.title == null) parsedOptions.title = frameName;
+
   return {
     additionalFeatures,
     options: {
       ...(useDeprecatedBehaviorForOptionInheritance && deprecatedInheritedOptions),
       show: true,
-      title: frameName,
       width: 800,
       height: 600,
       ...parsedOptions,

--- a/spec-main/fixtures/snapshots/native-window-open.snapshot.txt
+++ b/spec-main/fixtures/snapshots/native-window-open.snapshot.txt
@@ -5,11 +5,11 @@
       "sender": "[WebContents]"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "width": 800,
-      "title": "frame name",
+      "title": "cool",
       "backgroundColor": "blue",
       "focusable": false,
       "webPreferences": {
@@ -43,11 +43,11 @@
       "sender": "[WebContents]"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "width": 800,
-      "title": "frame name",
+      "title": "cool",
       "backgroundColor": "blue",
       "focusable": false,
       "webPreferences": {
@@ -80,11 +80,11 @@
       "sender": "[WebContents]"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "width": 800,
-      "title": "frame name",
+      "title": "cool",
       "backgroundColor": "gray",
       "focusable": false,
       "webPreferences": {
@@ -115,7 +115,7 @@
       "sender": "[WebContents]"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "width": 800,
@@ -150,11 +150,11 @@
       "sender": "[WebContents]"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "width": 800,
-      "title": "frame name",
+      "title": "cool",
       "backgroundColor": "blue",
       "focusable": false,
       "webPreferences": {

--- a/spec-main/fixtures/snapshots/proxy-window-open.snapshot.txt
+++ b/spec-main/fixtures/snapshots/proxy-window-open.snapshot.txt
@@ -11,9 +11,9 @@
     "new-window",
     {
       "show": true,
-      "title": "frame-name",
       "width": 800,
       "height": 600,
+      "title": "frame-name",
       "top": 5,
       "left": 10,
       "resizable": false,
@@ -46,9 +46,9 @@
     "new-window",
     {
       "show": true,
-      "title": "frame-name",
       "width": 800,
       "height": 600,
+      "title": "frame-name",
       "resizable": false,
       "x": 0,
       "y": 10,
@@ -80,9 +80,9 @@
     "new-window",
     {
       "show": true,
-      "title": "frame-name",
       "width": 800,
       "height": 600,
+      "title": "frame-name",
       "backgroundColor": "gray",
       "webPreferences": {
         "nodeIntegration": false,
@@ -114,9 +114,9 @@
     "new-window",
     {
       "show": true,
-      "title": "sup",
       "width": 800,
       "height": 600,
+      "title": "sup",
       "x": 50,
       "y": 20,
       "webPreferences": {
@@ -146,9 +146,9 @@
     "new-window",
     {
       "show": false,
-      "title": "frame-name",
       "width": 800,
       "height": 600,
+      "title": "frame-name",
       "top": 1,
       "left": 1,
       "x": 1,

--- a/spec-main/fixtures/snapshots/proxy-window-open.snapshot.txt
+++ b/spec-main/fixtures/snapshots/proxy-window-open.snapshot.txt
@@ -7,11 +7,11 @@
       "processId": "placeholder-process-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "show": true,
-      "title": "frame name",
+      "title": "cool",
       "width": 800,
       "height": 600,
       "top": 5,
@@ -42,11 +42,11 @@
       "processId": "placeholder-process-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "show": true,
-      "title": "frame name",
+      "title": "cool",
       "width": 800,
       "height": 600,
       "resizable": false,
@@ -76,11 +76,11 @@
       "processId": "placeholder-process-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "show": true,
-      "title": "frame name",
+      "title": "cool",
       "width": 800,
       "height": 600,
       "backgroundColor": "gray",
@@ -110,7 +110,7 @@
       "processId": "placeholder-process-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "show": true,
@@ -142,11 +142,11 @@
       "processId": "placeholder-process-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "show": false,
-      "title": "frame name",
+      "title": "frame-name",
       "width": 800,
       "height": 600,
       "top": 1,

--- a/spec-main/fixtures/snapshots/proxy-window-open.snapshot.txt
+++ b/spec-main/fixtures/snapshots/proxy-window-open.snapshot.txt
@@ -11,7 +11,7 @@
     "new-window",
     {
       "show": true,
-      "title": "cool",
+      "title": "frame-name",
       "width": 800,
       "height": 600,
       "top": 5,
@@ -46,7 +46,7 @@
     "new-window",
     {
       "show": true,
-      "title": "cool",
+      "title": "frame-name",
       "width": 800,
       "height": 600,
       "resizable": false,
@@ -80,7 +80,7 @@
     "new-window",
     {
       "show": true,
-      "title": "cool",
+      "title": "frame-name",
       "width": 800,
       "height": 600,
       "backgroundColor": "gray",

--- a/spec-main/guest-window-manager-spec.ts
+++ b/spec-main/guest-window-manager-spec.ts
@@ -10,7 +10,7 @@ function genSnapshot (browserWindow: BrowserWindow, features: string) {
     browserWindow.webContents.on('new-window', (...args: any[]) => {
       resolve([features, ...args]);
     });
-    browserWindow.webContents.executeJavaScript(`window.open('about:blank', 'frame name', '${features}') && true`);
+    browserWindow.webContents.executeJavaScript(`window.open('about:blank', 'frame-name', '${features}') && true`);
   });
 }
 


### PR DESCRIPTION
#### Description of Change

Closes #27036

This PR restores the behavior where the native window.open() parameter _windowName_, as named in the [native window.open() documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#parameters) or _frameName_ in the [Electron documentation](https://www.electronjs.org/docs/api/window-open#windowopenurl-framename-features), is not used by default to set the window title. Previously, the title defaulted to use this parameter, caused by a regression occurring in https://github.com/electron/electron/pull/19703. Now the _windowName_ parameter is no longer used by default.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed native window.open() to not use _windowName/frameName_ as title by default
