### PR TITLE
spec: fix failing http spec

### DIFF
--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -277,12 +277,12 @@ describe('chrome extensions', () => {
       it('can cancel http requests', async () => {
         await w.loadURL(url);
         await customSession.loadExtension(path.join(fixtures, 'extensions', 'chrome-webRequest'));
-        await expect(fetch(w.webContents, url)).to.eventually.be.rejectedWith(TypeError);
+        await expect(fetch(w.webContents, url)).to.eventually.be.rejectedWith('Failed to fetch');
       });
 
       it('does not cancel http requests when no extension loaded', async () => {
         await w.loadURL(url);
-        await expect(fetch(w.webContents, url)).to.not.be.rejectedWith(TypeError);
+        await expect(fetch(w.webContents, url)).to.not.be.rejectedWith('Failed to fetch');
       });
     });
 


### PR DESCRIPTION
#### Description of Change

Fixes failures on 

```
chrome extensions chrome.webRequest onBeforeRequest can cancel http requests - can cancel http requests
```

introduced by https://github.com/electron/electron/commit/db08f08b88c7dca7b03a6d6ebe1e33be1cb473c9.


see https://github.com/electron/electron/pull/27513

#### Release Notes

Notes: none
