### PR TITLE
docs: Update Readme, don't mention Electron < 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ npm install electron --save-dev
 ```
 
 For more installation options and troubleshooting tips, see
-[installation](docs/tutorial/installation.md).
+[installation](docs/tutorial/installation.md). For info on how to manage Electron versions in your apps, see
+[Electron versioning](docs/tutorial/electron-versioning.md).
 
 ## Quick start & Electron Fiddle
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,8 @@ The preferred method is to install Electron as a development dependency in your
 app:
 
 ```sh
-npm install electron --save-dev [--save-exact]
+npm install electron --save-dev
 ```
-
-The `--save-exact` flag is recommended for Electron prior to version 2, as it does not follow semantic
-versioning. As of version 2.0.0, Electron follows semver, so you don't need `--save-exact` flag. For info on how to manage Electron versions in your apps, see
-[Electron versioning](docs/tutorial/electron-versioning.md).
 
 For more installation options and troubleshooting tips, see
 [installation](docs/tutorial/installation.md).


### PR DESCRIPTION
#### Description of Change

We're still telling people what to do when you're installing Electron < 2. Maybe we shouldn't!

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
