### PR TITLE
fix: pass button callback in constructor

### DIFF
--- a/shell/browser/ui/views/menu_bar.h
+++ b/shell/browser/ui/views/menu_bar.h
@@ -80,7 +80,7 @@ class MenuBar : public views::AccessiblePaneView,
   // views::View:
   const char* GetClassName() const override;
 
-  void ButtonPressed(views::Button* source, const ui::Event& event);
+  void ButtonPressed(int id, const ui::Event& event);
 
   void RebuildChildren();
   void UpdateViewColors();

--- a/shell/browser/ui/views/submenu_button.cc
+++ b/shell/browser/ui/views/submenu_button.cc
@@ -20,9 +20,10 @@
 
 namespace electron {
 
-SubmenuButton::SubmenuButton(const base::string16& title,
+SubmenuButton::SubmenuButton(PressedCallback callback,
+                             const base::string16& title,
                              const SkColor& background_color)
-    : views::MenuButton(PressedCallback(), gfx::RemoveAccelerator(title)),
+    : views::MenuButton(callback, gfx::RemoveAccelerator(title)),
       background_color_(background_color) {
 #if defined(OS_LINUX)
   // Dont' use native style border.

--- a/shell/browser/ui/views/submenu_button.h
+++ b/shell/browser/ui/views/submenu_button.h
@@ -16,7 +16,9 @@ namespace electron {
 // Special button that used by menu bar to show submenus.
 class SubmenuButton : public views::MenuButton {
  public:
-  SubmenuButton(const base::string16& title, const SkColor& background_color);
+  SubmenuButton(PressedCallback callback,
+                const base::string16& title,
+                const SkColor& background_color);
   ~SubmenuButton() override;
 
   void SetAcceleratorVisibility(bool visible);


### PR DESCRIPTION
#### Description of Change

Fix https://github.com/electron/electron/issues/26717.

Some recent changes in Chromium made `views::Button::SetCallback` stop working in `views::MenuButton`, pass the callback in constructor to make the callback work again. Also this is a better tested code path in Chromium and we will have much less chance running into problems with it.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix menubar not clickable on Windows and Linux.