### PR TITLE
fix: crash when loadExtension fails

### DIFF
--- a/shell/browser/extensions/electron_extension_loader.cc
+++ b/shell/browser/extensions/electron_extension_loader.cc
@@ -111,22 +111,22 @@ void ElectronExtensionLoader::FinishExtensionLoad(
   scoped_refptr<const Extension> extension = result.first;
   if (extension) {
     extension_registrar_.AddExtension(extension);
-  }
 
-  // Write extension install time to ExtensionPrefs. This is required by
-  // WebRequestAPI which calls extensions::ExtensionPrefs::GetInstallTime.
-  //
-  // Implementation for writing the pref was based on
-  // PreferenceAPIBase::SetExtensionControlledPref.
-  {
-    ExtensionPrefs* extension_prefs = ExtensionPrefs::Get(browser_context_);
-    ExtensionPrefs::ScopedDictionaryUpdate update(
-        extension_prefs, extension.get()->id(),
-        extensions::pref_names::kPrefPreferences);
-    auto preference = update.Create();
-    const base::Time install_time = base::Time().Now();
-    preference->SetString("install_time",
-                          base::NumberToString(install_time.ToInternalValue()));
+    // Write extension install time to ExtensionPrefs. This is required by
+    // WebRequestAPI which calls extensions::ExtensionPrefs::GetInstallTime.
+    //
+    // Implementation for writing the pref was based on
+    // PreferenceAPIBase::SetExtensionControlledPref.
+    {
+      ExtensionPrefs* extension_prefs = ExtensionPrefs::Get(browser_context_);
+      ExtensionPrefs::ScopedDictionaryUpdate update(
+          extension_prefs, extension.get()->id(),
+          extensions::pref_names::kPrefPreferences);
+      auto preference = update.Create();
+      const base::Time install_time = base::Time().Now();
+      preference->SetString(
+          "install_time", base::NumberToString(install_time.ToInternalValue()));
+    }
   }
 
   std::move(cb).Run(extension.get(), result.second);

--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -107,6 +107,12 @@ describe('chrome extensions', () => {
     expect(bg).to.equal('red');
   });
 
+  it('does not crash when failing to load an extension', async () => {
+    const customSession = session.fromPartition(`persist:${uuid.v4()}`);
+    const promise = customSession.loadExtension(path.join(fixtures, 'extensions', 'load-error'));
+    await expect(promise).to.eventually.be.rejected();
+  });
+
   it('serializes a loaded extension', async () => {
     const extensionPath = path.join(fixtures, 'extensions', 'red-bg');
     const manifest = JSON.parse(fs.readFileSync(path.join(extensionPath, 'manifest.json'), 'utf-8'));

--- a/spec-main/fixtures/extensions/load-error/manifest.json
+++ b/spec-main/fixtures/extensions/load-error/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "load-error",
+  "version": "1.0",
+  "icons": {
+    "16": "/images/error.png"
+  },
+  "manifest_version": 2
+}


### PR DESCRIPTION
#### Description of Change
A segfault occurs when an extension fails to load.

I forgot to check for a nullptr before writing an extension pref in #22655

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed crash when extension fails to load.
