### PR TITLE
feat: support registering MV3 extension service workers

### DIFF
--- a/docs/api/service-workers.md
+++ b/docs/api/service-workers.md
@@ -45,6 +45,15 @@ Returns:
 
 Emitted when a service worker logs something to the console.
 
+#### Event: 'registration-completed'
+
+Returns:
+
+* `event` Event
+* `scope` String - The base URL that a service worker is registered for.
+
+Emitted when a service worker has been registered.
+
 ### Instance Methods
 
 The following methods are available on instances of `ServiceWorkers`:

--- a/docs/api/service-workers.md
+++ b/docs/api/service-workers.md
@@ -50,7 +50,8 @@ Emitted when a service worker logs something to the console.
 Returns:
 
 * `event` Event
-* `scope` String - The base URL that a service worker is registered for.
+* `details` Object - Information about the registered service worker
+  * `scope` String - The base URL that a service worker is registered for
 
 Emitted when a service worker has been registered.
 

--- a/docs/api/service-workers.md
+++ b/docs/api/service-workers.md
@@ -53,7 +53,7 @@ Returns:
 * `details` Object - Information about the registered service worker
   * `scope` String - The base URL that a service worker is registered for
 
-Emitted when a service worker has been registered.
+Emitted when a service worker has been registered. Can occur after a call to [`navigator.serviceWorker.register('/sw.js')`](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register) successfully resolves or when a Chrome extension is loaded.
 
 ### Instance Methods
 

--- a/shell/app/electron_content_client.cc
+++ b/shell/app/electron_content_client.cc
@@ -207,7 +207,15 @@ void ElectronContentClient::AddAdditionalSchemes(Schemes* schemes) {
   }
 
   schemes->service_worker_schemes.emplace_back(url::kFileScheme);
-  schemes->standard_schemes.emplace_back(extensions::kExtensionScheme);
+
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
+  schemes->standard_schemes.push_back(extensions::kExtensionScheme);
+  schemes->savable_schemes.push_back(extensions::kExtensionScheme);
+  schemes->secure_schemes.push_back(extensions::kExtensionScheme);
+  schemes->service_worker_schemes.push_back(extensions::kExtensionScheme);
+  schemes->cors_enabled_schemes.push_back(extensions::kExtensionScheme);
+  schemes->csp_bypassing_schemes.push_back(extensions::kExtensionScheme);
+#endif
 }
 
 void ElectronContentClient::AddPepperPlugins(

--- a/shell/browser/api/electron_api_service_worker_context.cc
+++ b/shell/browser/api/electron_api_service_worker_context.cc
@@ -104,7 +104,10 @@ void ServiceWorkerContext::OnReportConsoleMessage(
 }
 
 void ServiceWorkerContext::OnRegistrationCompleted(const GURL& scope) {
-  Emit("registration-completed", scope);
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope handle_scope(isolate);
+  Emit("registration-completed",
+       gin::DataObjectBuilder(isolate).Set("scope", scope).Build());
 }
 
 void ServiceWorkerContext::OnDestruct(content::ServiceWorkerContext* context) {

--- a/shell/browser/api/electron_api_service_worker_context.cc
+++ b/shell/browser/api/electron_api_service_worker_context.cc
@@ -15,6 +15,7 @@
 #include "gin/object_template_builder.h"
 #include "shell/browser/electron_browser_context.h"
 #include "shell/browser/javascript_environment.h"
+#include "shell/common/gin_converters/gurl_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/function_template_extensions.h"
@@ -100,6 +101,10 @@ void ServiceWorkerContext::OnReportConsoleMessage(
            .Set("lineNumber", message.line_number)
            .Set("sourceUrl", message.source_url.spec())
            .Build());
+}
+
+void ServiceWorkerContext::OnRegistrationCompleted(const GURL& scope) {
+  Emit("registration-completed", scope);
 }
 
 void ServiceWorkerContext::OnDestruct(content::ServiceWorkerContext* context) {

--- a/shell/browser/api/electron_api_service_worker_context.h
+++ b/shell/browser/api/electron_api_service_worker_context.h
@@ -34,6 +34,7 @@ class ServiceWorkerContext
   void OnReportConsoleMessage(int64_t version_id,
                               const GURL& scope,
                               const content::ConsoleMessage& message) override;
+  void OnRegistrationCompleted(const GURL& scope) override;
   void OnDestruct(content::ServiceWorkerContext* context) override;
 
   // gin::Wrappable

--- a/shell/renderer/extensions/electron_extensions_renderer_client.cc
+++ b/shell/renderer/extensions/electron_extensions_renderer_client.cc
@@ -4,6 +4,8 @@
 
 #include "shell/renderer/extensions/electron_extensions_renderer_client.h"
 
+#include <string>
+
 #include "content/public/renderer/render_thread.h"
 #include "extensions/common/constants.h"
 #include "extensions/common/manifest_handlers/background_info.h"

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -427,6 +427,26 @@ void RendererClientBase::RunScriptsAtDocumentEnd(
 #endif
 }
 
+bool RendererClientBase::AllowScriptExtensionForServiceWorker(
+    const url::Origin& script_origin) {
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
+  return script_origin.scheme() == extensions::kExtensionScheme;
+#else
+  return false;
+#endif
+}
+
+void RendererClientBase::DidInitializeServiceWorkerContextOnWorkerThread(
+    blink::WebServiceWorkerContextProxy* context_proxy,
+    const GURL& service_worker_scope,
+    const GURL& script_url) {
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
+  extensions_renderer_client_->GetDispatcher()
+      ->DidInitializeServiceWorkerContextOnWorkerThread(
+          context_proxy, service_worker_scope, script_url);
+#endif
+}
+
 void RendererClientBase::WillEvaluateServiceWorkerOnWorkerThread(
     blink::WebServiceWorkerContextProxy* context_proxy,
     v8::Local<v8::Context> v8_context,
@@ -438,6 +458,29 @@ void RendererClientBase::WillEvaluateServiceWorkerOnWorkerThread(
       ->WillEvaluateServiceWorkerOnWorkerThread(
           context_proxy, v8_context, service_worker_version_id,
           service_worker_scope, script_url);
+#endif
+}
+
+void RendererClientBase::DidStartServiceWorkerContextOnWorkerThread(
+    int64_t service_worker_version_id,
+    const GURL& service_worker_scope,
+    const GURL& script_url) {
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
+  extensions_renderer_client_->GetDispatcher()
+      ->DidStartServiceWorkerContextOnWorkerThread(
+          service_worker_version_id, service_worker_scope, script_url);
+#endif
+}
+
+void RendererClientBase::WillDestroyServiceWorkerContextOnWorkerThread(
+    v8::Local<v8::Context> context,
+    int64_t service_worker_version_id,
+    const GURL& service_worker_scope,
+    const GURL& script_url) {
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
+  extensions_renderer_client_->GetDispatcher()
+      ->WillDestroyServiceWorkerContextOnWorkerThread(
+          context, service_worker_version_id, service_worker_scope, script_url);
 #endif
 }
 

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -427,6 +427,20 @@ void RendererClientBase::RunScriptsAtDocumentEnd(
 #endif
 }
 
+void RendererClientBase::WillEvaluateServiceWorkerOnWorkerThread(
+    blink::WebServiceWorkerContextProxy* context_proxy,
+    v8::Local<v8::Context> v8_context,
+    int64_t service_worker_version_id,
+    const GURL& service_worker_scope,
+    const GURL& script_url) {
+#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
+  extensions_renderer_client_->GetDispatcher()
+      ->WillEvaluateServiceWorkerOnWorkerThread(
+          context_proxy, v8_context, service_worker_version_id,
+          service_worker_scope, script_url);
+#endif
+}
+
 v8::Local<v8::Context> RendererClientBase::GetContext(
     blink::WebLocalFrame* frame,
     v8::Isolate* isolate) const {

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -118,9 +118,6 @@ RendererClientBase::RendererClientBase() {
       ParseSchemesCLISwitch(command_line, switches::kSecureSchemes);
   for (const std::string& scheme : secure_schemes_list)
     url::AddSecureScheme(scheme.data());
-  // In Chrome we should set extension's origins to match the pages they can
-  // work on, but in Electron currently we just let extensions do anything.
-  url::AddSecureScheme(extensions::kExtensionScheme);
   // We rely on the unique process host id which is notified to the
   // renderer process via command line switch from the content layer,
   // if this switch is removed from the content layer for some reason,

--- a/shell/renderer/renderer_client_base.h
+++ b/shell/renderer/renderer_client_base.h
@@ -126,9 +126,24 @@ class RendererClientBase : public content::ContentRendererClient
   void RunScriptsAtDocumentEnd(content::RenderFrame* render_frame) override;
   void RunScriptsAtDocumentIdle(content::RenderFrame* render_frame) override;
 
+  bool AllowScriptExtensionForServiceWorker(
+      const url::Origin& script_origin) override;
+  void DidInitializeServiceWorkerContextOnWorkerThread(
+      blink::WebServiceWorkerContextProxy* context_proxy,
+      const GURL& service_worker_scope,
+      const GURL& script_url) override;
   void WillEvaluateServiceWorkerOnWorkerThread(
       blink::WebServiceWorkerContextProxy* context_proxy,
       v8::Local<v8::Context> v8_context,
+      int64_t service_worker_version_id,
+      const GURL& service_worker_scope,
+      const GURL& script_url) override;
+  void DidStartServiceWorkerContextOnWorkerThread(
+      int64_t service_worker_version_id,
+      const GURL& service_worker_scope,
+      const GURL& script_url) override;
+  void WillDestroyServiceWorkerContextOnWorkerThread(
+      v8::Local<v8::Context> context,
       int64_t service_worker_version_id,
       const GURL& service_worker_scope,
       const GURL& script_url) override;

--- a/shell/renderer/renderer_client_base.h
+++ b/shell/renderer/renderer_client_base.h
@@ -126,6 +126,13 @@ class RendererClientBase : public content::ContentRendererClient
   void RunScriptsAtDocumentEnd(content::RenderFrame* render_frame) override;
   void RunScriptsAtDocumentIdle(content::RenderFrame* render_frame) override;
 
+  void WillEvaluateServiceWorkerOnWorkerThread(
+      blink::WebServiceWorkerContextProxy* context_proxy,
+      v8::Local<v8::Context> v8_context,
+      int64_t service_worker_version_id,
+      const GURL& service_worker_scope,
+      const GURL& script_url) override;
+
  protected:
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   // app_shell embedders may need custom extensions client interfaces.

--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -650,4 +650,16 @@ describe('chrome extensions', () => {
       expect(textContent).to.equal('script loaded ok\n');
     });
   });
+
+  describe('manifest v3', () => {
+    it('registers background service worker', async () => {
+      const customSession = session.fromPartition(`persist:${uuid.v4()}`);
+      const registrationPromise = new Promise<string>(resolve => {
+        customSession.serviceWorkers.once('registration-completed', (event, scope) => resolve(scope));
+      });
+      const extension = await customSession.loadExtension(path.join(fixtures, 'extensions', 'mv3-service-worker'));
+      const swScope = await registrationPromise;
+      expect(swScope).equals(extension.url);
+    });
+  });
 });

--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -655,11 +655,11 @@ describe('chrome extensions', () => {
     it('registers background service worker', async () => {
       const customSession = session.fromPartition(`persist:${uuid.v4()}`);
       const registrationPromise = new Promise<string>(resolve => {
-        customSession.serviceWorkers.once('registration-completed', (event, scope) => resolve(scope));
+        customSession.serviceWorkers.once('registration-completed', (event, { scope }) => resolve(scope));
       });
       const extension = await customSession.loadExtension(path.join(fixtures, 'extensions', 'mv3-service-worker'));
-      const swScope = await registrationPromise;
-      expect(swScope).equals(extension.url);
+      const scope = await registrationPromise;
+      expect(scope).equals(extension.url);
     });
   });
 });

--- a/spec-main/fixtures/extensions/mv3-service-worker/background.js
+++ b/spec-main/fixtures/extensions/mv3-service-worker/background.js
@@ -1,0 +1,1 @@
+console.log('service worker installed');

--- a/spec-main/fixtures/extensions/mv3-service-worker/manifest.json
+++ b/spec-main/fixtures/extensions/mv3-service-worker/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "MV3 Service Worker",
+  "description": "Test for extension service worker support.",
+  "version": "1.0",
+  "manifest_version": 3,
+  "background": {
+    "service_worker": "background.js"
+  },
+  "permissions": ["scripting"]
+}


### PR DESCRIPTION
#### Description of Change
Manifest V3 (MV3) has become [generally available in M88 Beta.](https://blog.chromium.org/2020/12/manifest-v3-now-available-on-m88-beta.html)

This adds the bare minimum in order to run MV3's new service workers meant to replace MV2's background processes.

A new `registration-completed` event is added to `Session.serviceWorkers` for testing whether extension service workers register properly.

cc @electron/wg-api 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes:
* Added support for registering Manifest V3 extension service workers.
* Added 'registration-completed' event to `ServiceWorkers`.
