### PR TITLE
refactor: remove unused extension content script code

### DIFF
--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -715,9 +715,6 @@ v8::Local<v8::Promise> ExecuteJavaScriptInIsolatedWorld(
 
   auto& prefs = render_frame->GetBlinkPreferences();
 
-  // Debugging tip: if you see a crash stack trace beginning from this call,
-  // then it is very likely that some exception happened when executing the
-  // "content_script/init.js" script.
   render_frame->GetWebFrame()->RequestExecuteScriptInIsolatedWorld(
       world_id, &sources.front(), sources.size(), has_user_gesture,
       scriptExecutionType,

--- a/shell/renderer/electron_render_frame_observer.cc
+++ b/shell/renderer/electron_render_frame_observer.cc
@@ -88,14 +88,6 @@ void ElectronRenderFrameObserver::DidInstallConditionalFeatures(
     if (!renderer_client_->IsWebViewFrame(context, render_frame_))
       renderer_client_->SetupMainWorldOverrides(context, render_frame_);
   }
-
-#if !BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-  if (world_id >= WorldIDs::ISOLATED_WORLD_ID_EXTENSIONS &&
-      world_id <= WorldIDs::ISOLATED_WORLD_ID_EXTENSIONS_END) {
-    renderer_client_->SetupExtensionWorldOverrides(context, render_frame_,
-                                                   world_id);
-  }
-#endif
 }
 
 void ElectronRenderFrameObserver::DraggableRegionsChanged() {

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -254,34 +254,6 @@ void ElectronRendererClient::SetupMainWorldOverrides(
                        &isolated_bundle_params, &isolated_bundle_args, nullptr);
 }
 
-void ElectronRendererClient::SetupExtensionWorldOverrides(
-    v8::Handle<v8::Context> context,
-    content::RenderFrame* render_frame,
-    int world_id) {
-#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-  NOTREACHED();
-#else
-  auto* isolate = context->GetIsolate();
-
-  std::vector<v8::Local<v8::String>> isolated_bundle_params = {
-      node::FIXED_ONE_BYTE_STRING(isolate, "nodeProcess"),
-      node::FIXED_ONE_BYTE_STRING(isolate, "isolatedWorld"),
-      node::FIXED_ONE_BYTE_STRING(isolate, "worldId")};
-
-  auto* env = GetEnvironment(render_frame);
-  if (!env)
-    return;
-
-  std::vector<v8::Local<v8::Value>> isolated_bundle_args = {
-      env->process_object(),
-      GetContext(render_frame->GetWebFrame(), isolate)->Global(),
-      v8::Integer::New(isolate, world_id)};
-
-  util::CompileAndCall(context, "electron/js2c/content_script_bundle",
-                       &isolated_bundle_params, &isolated_bundle_args, nullptr);
-#endif
-}
-
 node::Environment* ElectronRendererClient::GetEnvironment(
     content::RenderFrame* render_frame) const {
   if (injected_frames_.find(render_frame) == injected_frames_.end())

--- a/shell/renderer/electron_renderer_client.h
+++ b/shell/renderer/electron_renderer_client.h
@@ -35,9 +35,6 @@ class ElectronRendererClient : public RendererClientBase {
                                 content::RenderFrame* render_frame) override;
   void SetupMainWorldOverrides(v8::Handle<v8::Context> context,
                                content::RenderFrame* render_frame) override;
-  void SetupExtensionWorldOverrides(v8::Handle<v8::Context> context,
-                                    content::RenderFrame* render_frame,
-                                    int world_id) override;
 
  private:
   // content::ContentRendererClient:

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -263,33 +263,6 @@ void ElectronSandboxedRendererClient::SetupMainWorldOverrides(
                        &isolated_bundle_params, &isolated_bundle_args, nullptr);
 }
 
-void ElectronSandboxedRendererClient::SetupExtensionWorldOverrides(
-    v8::Handle<v8::Context> context,
-    content::RenderFrame* render_frame,
-    int world_id) {
-#if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-  NOTREACHED();
-#else
-  auto* isolate = context->GetIsolate();
-
-  gin_helper::Dictionary process = gin::Dictionary::CreateEmpty(isolate);
-  process.SetMethod("_linkedBinding", GetBinding);
-
-  std::vector<v8::Local<v8::String>> isolated_bundle_params = {
-      node::FIXED_ONE_BYTE_STRING(isolate, "nodeProcess"),
-      node::FIXED_ONE_BYTE_STRING(isolate, "isolatedWorld"),
-      node::FIXED_ONE_BYTE_STRING(isolate, "worldId")};
-
-  std::vector<v8::Local<v8::Value>> isolated_bundle_args = {
-      process.GetHandle(),
-      GetContext(render_frame->GetWebFrame(), isolate)->Global(),
-      v8::Integer::New(isolate, world_id)};
-
-  util::CompileAndCall(context, "electron/js2c/content_script_bundle",
-                       &isolated_bundle_params, &isolated_bundle_args, nullptr);
-#endif
-}
-
 void ElectronSandboxedRendererClient::WillReleaseScriptContext(
     v8::Handle<v8::Context> context,
     content::RenderFrame* render_frame) {

--- a/shell/renderer/electron_sandboxed_renderer_client.h
+++ b/shell/renderer/electron_sandboxed_renderer_client.h
@@ -29,9 +29,6 @@ class ElectronSandboxedRendererClient : public RendererClientBase {
                                 content::RenderFrame* render_frame) override;
   void SetupMainWorldOverrides(v8::Handle<v8::Context> context,
                                content::RenderFrame* render_frame) override;
-  void SetupExtensionWorldOverrides(v8::Handle<v8::Context> context,
-                                    content::RenderFrame* render_frame,
-                                    int world_id) override;
   // content::ContentRendererClient:
   void RenderFrameCreated(content::RenderFrame*) override;
   void RenderViewCreated(content::RenderView*) override;

--- a/shell/renderer/renderer_client_base.h
+++ b/shell/renderer/renderer_client_base.h
@@ -73,9 +73,6 @@ class RendererClientBase : public content::ContentRendererClient
   virtual void DidClearWindowObject(content::RenderFrame* render_frame);
   virtual void SetupMainWorldOverrides(v8::Handle<v8::Context> context,
                                        content::RenderFrame* render_frame) = 0;
-  virtual void SetupExtensionWorldOverrides(v8::Handle<v8::Context> context,
-                                            content::RenderFrame* render_frame,
-                                            int world_id) = 0;
 
   std::unique_ptr<blink::WebPrescientNetworking> CreatePrescientNetworking(
       content::RenderFrame* render_frame) override;


### PR DESCRIPTION
#### Description of Change
This code was leftover from the old JS extensions implementation which was removed in #23340

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
