### PR TITLE
refactor: precache atoms in window-state-watcher

### DIFF
--- a/shell/browser/ui/x/window_state_watcher.cc
+++ b/shell/browser/ui/x/window_state_watcher.cc
@@ -15,7 +15,13 @@ namespace electron {
 WindowStateWatcher::WindowStateWatcher(NativeWindowViews* window)
     : window_(window),
       widget_(window->GetAcceleratedWidget()),
-      window_state_atom_(x11::GetAtom("_NET_WM_STATE")) {
+      net_wm_state_atom_(x11::GetAtom("_NET_WM_STATE")),
+      net_wm_state_hidden_atom_(x11::GetAtom("_NET_WM_STATE_HIDDEN")),
+      net_wm_state_maximized_vert_atom_(
+          x11::GetAtom("_NET_WM_STATE_MAXIMIZED_VERT")),
+      net_wm_state_maximized_horz_atom_(
+          x11::GetAtom("_NET_WM_STATE_MAXIMIZED_HORZ")),
+      net_wm_state_fullscreen_atom_(x11::GetAtom("_NET_WM_STATE_FULLSCREEN")) {
   ui::X11EventSource::GetInstance()->connection()->AddEventObserver(this);
 }
 
@@ -25,25 +31,20 @@ WindowStateWatcher::~WindowStateWatcher() {
 
 void WindowStateWatcher::OnEvent(const x11::Event& x11_event) {
   if (IsWindowStateEvent(x11_event)) {
-    bool was_minimized_ = window_->IsMinimized();
-    bool was_maximized_ = window_->IsMaximized();
+    const bool was_minimized_ = window_->IsMinimized();
+    const bool was_maximized_ = window_->IsMaximized();
 
     std::vector<x11::Atom> wm_states;
-
     if (GetArrayProperty(
             static_cast<x11::Window>(window_->GetAcceleratedWidget()),
-            x11::GetAtom("_NET_WM_STATE"), &wm_states)) {
-      auto props =
+            net_wm_state_atom_, &wm_states)) {
+      const auto props =
           base::flat_set<x11::Atom>(std::begin(wm_states), std::end(wm_states));
-      bool is_minimized =
-          props.find(x11::GetAtom("_NET_WM_STATE_HIDDEN")) != props.end();
-      bool is_maximized =
-          props.find(x11::GetAtom("_NET_WM_STATE_MAXIMIZED_VERT")) !=
-              props.end() &&
-          props.find(x11::GetAtom("_NET_WM_STATE_MAXIMIZED_HORZ")) !=
-              props.end();
-      bool is_fullscreen =
-          props.find(x11::GetAtom("_NET_WM_STATE_FULLSCREEN")) != props.end();
+      const bool is_minimized = props.contains(net_wm_state_hidden_atom_);
+      const bool is_maximized =
+          props.contains(net_wm_state_maximized_vert_atom_) &&
+          props.contains(net_wm_state_maximized_horz_atom_);
+      const bool is_fullscreen = props.contains(net_wm_state_fullscreen_atom_);
 
       if (is_minimized != was_minimized_) {
         if (is_minimized)
@@ -72,7 +73,7 @@ void WindowStateWatcher::OnEvent(const x11::Event& x11_event) {
 
 bool WindowStateWatcher::IsWindowStateEvent(const x11::Event& x11_event) const {
   auto* property = x11_event.As<x11::PropertyNotifyEvent>();
-  return (property && property->atom == window_state_atom_ &&
+  return (property && property->atom == net_wm_state_atom_ &&
           static_cast<uint32_t>(property->window) == widget_);
 }
 

--- a/shell/browser/ui/x/window_state_watcher.h
+++ b/shell/browser/ui/x/window_state_watcher.h
@@ -26,7 +26,11 @@ class WindowStateWatcher : public x11::EventObserver {
 
   NativeWindowViews* window_;
   gfx::AcceleratedWidget widget_;
-  const x11::Atom window_state_atom_;
+  const x11::Atom net_wm_state_atom_;
+  const x11::Atom net_wm_state_hidden_atom_;
+  const x11::Atom net_wm_state_maximized_vert_atom_;
+  const x11::Atom net_wm_state_maximized_horz_atom_;
+  const x11::Atom net_wm_state_fullscreen_atom_;
 
   DISALLOW_COPY_AND_ASSIGN(WindowStateWatcher);
 };


### PR DESCRIPTION
#### Description of Change

A minor cleanup to the X11 window state watcher: We're already precaching _NET_WM_STATE but now use other atoms too, so let's precache them. Atoms are X11 versions of the same idea as interned strings & Symbols -- they never change their values, and so precaching & holding forever is safe. This avoids unnecessary string lookups when processing X11 events.

The code branches that use these atoms are not reached as often as the ones using _NET_WM_STATE, so this is a smaller win than  83d5833 [was](https://github.com/electron/electron/pull/22706#issuecomment-600364289).

No particular stakeholder; any reviewer welcomed

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none