### PR TITLE
build: fix buildflags.h generation on macos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -452,10 +452,6 @@ step-fix-sync-on-mac: &step-fix-sync-on-mac
         # Fix Clang Install (wrong binary)
         rm -rf src/third_party/llvm-build
         python src/tools/clang/scripts/update.py
-        # Temporarily use an older version of gn
-        unset CI
-        python src/buildtools/ensure_gn_version.py git_revision:53d92014bf94c3893886470a1c7c1289f8818db0
-        export CI=true
       fi
 
 step-install-signing-cert-on-mac: &step-install-signing-cert-on-mac

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -992,6 +992,8 @@ if (is_mac) {
     deps = [
       ":electron_app_framework_bundle_data",
       ":electron_app_resources",
+      "//base",
+      "//electron/buildflags",
     ]
     if (is_mas_build) {
       deps += [ ":electron_login_helper_app" ]


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
This fixes the buildflags.h generation issue that happened in the roll here:  #27111.

That roll updated GN which included this change:
https://gn.googlesource.com/gn/+/0ae75f90df148d19083055b29c4c940b136904b4

In order to resolve the issue we needed to include 
"//base" and "//electron/buildflags" in the deps for electron_app because otherwise gn thinks that there are just data dependencies and won't properly generate buildflags.h

Thanks to @codebytere and @nornagon for helping out on this.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
