### PR TITLE
fix: libuv hang when nodeIntegrationInSubframes enabled

### DIFF
--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -531,6 +531,13 @@ void NodeBindings::LoadEnvironment(node::Environment* env) {
 }
 
 void NodeBindings::PrepareMessageLoop() {
+  // If the backend fd hasn't changed, don't proceed.
+  int backend_fd = uv_backend_fd(uv_loop_);
+  if (backend_fd == backend_fd_)
+    return;
+
+  backend_fd_ = backend_fd;
+
   // Add dummy handle for libuv, otherwise libuv would quit when there is
   // nothing to do.
   uv_async_init(uv_loop_, dummy_uv_handle_.get(), nullptr);

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -531,8 +531,12 @@ void NodeBindings::LoadEnvironment(node::Environment* env) {
 }
 
 void NodeBindings::PrepareMessageLoop() {
-  // If the backend fd hasn't changed, don't proceed.
+#if !defined(OS_WIN)
   int backend_fd = uv_backend_fd(uv_loop_);
+#else
+  int backend_fd = uv_loop_->iocp;
+#endif
+  // If the backend fd hasn't changed, don't proceed.
   if (backend_fd == backend_fd_)
     return;
 

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -532,15 +532,16 @@ void NodeBindings::LoadEnvironment(node::Environment* env) {
 
 void NodeBindings::PrepareMessageLoop() {
 #if !defined(OS_WIN)
-  int backend_fd = uv_backend_fd(uv_loop_);
+  int handle = uv_backend_fd(uv_loop_);
 #else
-  int backend_fd = uv_loop_->iocp;
+  HANDLE handle = uv_loop_->iocp;
 #endif
+
   // If the backend fd hasn't changed, don't proceed.
-  if (backend_fd == backend_fd_)
+  if (handle == handle_)
     return;
 
-  backend_fd_ = backend_fd;
+  handle_ = handle;
 
   // Add dummy handle for libuv, otherwise libuv would quit when there is
   // nothing to do.

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -159,6 +159,8 @@ class NodeBindings {
   // Isolate data used in creating the environment
   node::IsolateData* isolate_data_ = nullptr;
 
+  int backend_fd_;
+
   base::WeakPtrFactory<NodeBindings> weak_factory_{this};
 
   DISALLOW_COPY_AND_ASSIGN(NodeBindings);

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -159,7 +159,7 @@ class NodeBindings {
   // Isolate data used in creating the environment
   node::IsolateData* isolate_data_ = nullptr;
 
-  int backend_fd_;
+  int backend_fd_ = -1;
 
   base::WeakPtrFactory<NodeBindings> weak_factory_{this};
 

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -159,7 +159,11 @@ class NodeBindings {
   // Isolate data used in creating the environment
   node::IsolateData* isolate_data_ = nullptr;
 
-  int backend_fd_ = -1;
+#if defined(OS_WIN)
+  HANDLE handle_;
+#else
+  int handle_ = -1;
+#endif
 
   base::WeakPtrFactory<NodeBindings> weak_factory_{this};
 

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -113,7 +113,6 @@ void ElectronRendererClient::DidCreateScriptContext(
   // the integration, that means we're here because a new subframe was created,
   // not because we've reloaded the page. In that case, don't re-prepare the
   // message loop.
-  bool node_in_subframe = !is_main_frame && allow_node_in_subframes;
   bool should_load_node =
       (is_main_frame || is_devtools || allow_node_in_subframes) &&
       !IsWebViewFrame(renderer_context, render_frame);
@@ -126,7 +125,7 @@ void ElectronRendererClient::DidCreateScriptContext(
     node_integration_initialized_ = true;
     node_bindings_->Initialize();
     node_bindings_->PrepareMessageLoop();
-  } else if (reuse_renderer_processes_enabled && !node_in_subframe) {
+  } else if (reuse_renderer_processes_enabled) {
     node_bindings_->PrepareMessageLoop();
   }
 

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -109,10 +109,6 @@ void ElectronRendererClient::DidCreateScriptContext(
                        (is_not_opened || reuse_renderer_processes_enabled);
   bool is_devtools = IsDevToolsExtension(render_frame);
   bool allow_node_in_subframes = prefs.node_integration_in_sub_frames;
-  // If we're loading Node.js into a subframe and we've already initialized
-  // the integration, that means we're here because a new subframe was created,
-  // not because we've reloaded the page. In that case, don't re-prepare the
-  // message loop.
   bool should_load_node =
       (is_main_frame || is_devtools || allow_node_in_subframes) &&
       !IsWebViewFrame(renderer_context, render_frame);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/27457.

Refs https://github.com/electron/electron/commit/13f319eddfe2207558862aa5556da22fea983bd6

If we're loading Node.js into a subframe and we've already initialized the Node.js integration, that means we're in `DidCreateScriptContext` because a new subframe was created, not because we've reloaded the page. If that's the case, that means the last call to `node_bindings_->PrepareMessageLoop()` may still be active and calling it twice in a row can hang the page. In that case, don't re-prepare the message loop.

cc @deepak1556 @zcbenz @MarshallOfSound @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where libuv might hang with multiple subframes when `nodeIntegrationInSubframes` is enabled.
