### PR TITLE
docs: fix `source` typo

### DIFF
--- a/docs/tutorial/dark-mode.md
+++ b/docs/tutorial/dark-mode.md
@@ -154,7 +154,7 @@ function createWindow () {
   })
 
   ipcMain.handle('dark-mode:system', () => {
-    nativeTheme.themeSouce = 'system'
+    nativeTheme.themeSource = 'system'
   })
 }
 


### PR DESCRIPTION
#### Description of Change

Fixing a typo in a tutorial

Notes: no-notes