### PR TITLE
fix: BrowserView rendering flicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     ],
     "docs/api/**/*.md": [
       "ts-node script/gen-filenames.ts",
-      "markdownlint --config .markdownlint.auotfix.json --fix",
+      "markdownlint --config .markdownlint.autofix.json --fix",
       "git add filenames.auto.gni"
     ],
     "{*.patch,.patches}": [


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/27378.

In an `NSView`, `drawRect` draws the view’s image within the specified rectangle. It's invoked _very_ frequently and as such performance is paramount. As calls to `drawRect` need to traverse the whole responder chain, we were adding a costly [`getenv`](https://pubs.opengroup.org/onlinepubs/009695399/functions/getenv.html) call to every invocation, which created a rendering flicker. This was debug-only, so we should not override it at all, but keep it commented out.

See https://developer.apple.com/documentation/appkit/nsview/1483686-drawrect for more details.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an occasional white flicker present when rendering BrowserViews in close succession.
