### PR TITLE
fix: avoid flicker when leaving fullscreen in frameless window

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1487,11 +1487,6 @@ void NativeWindowMac::NotifyWindowEnterFullScreen() {
 void NativeWindowMac::NotifyWindowLeaveFullScreen() {
   NativeWindow::NotifyWindowLeaveFullScreen();
   exiting_fullscreen_ = false;
-  // Add back buttonsView after leaving fullscreen mode.
-  if (buttons_view_) {
-    InternalSetStandardButtonsVisibility(false);
-    [[window_ contentView] addSubview:buttons_view_];
-  }
 }
 
 void NativeWindowMac::NotifyWindowWillEnterFullScreen() {
@@ -1504,9 +1499,12 @@ void NativeWindowMac::NotifyWindowWillEnterFullScreen() {
 }
 
 void NativeWindowMac::NotifyWindowWillLeaveFullScreen() {
-  // Hide window title after leaving fullscreen.
-  if (buttons_view_)
+  // Hide window title and restore buttonsView when leaving fullscreen.
+  if (buttons_view_) {
     [window_ setTitleVisibility:NSWindowTitleHidden];
+    InternalSetStandardButtonsVisibility(false);
+    [[window_ contentView] addSubview:buttons_view_];
+  }
   exiting_fullscreen_ = true;
   RedrawTrafficLights();
 }


### PR DESCRIPTION
#### Description of Change

The buttonsView should be restored before leaving fullscreen instead of after leaving fullscreen, otherwise the traffic light buttons would flicker. This is a regression introduced by https://github.com/electron/electron/pull/27489.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
