### PR TITLE
fix: [net] no errors on response stream

### DIFF
--- a/lib/browser/api/net.ts
+++ b/lib/browser/api/net.ts
@@ -432,9 +432,7 @@ export class ClientRequest extends Writable implements Electron.ClientRequest {
       if (this._response) { this._response._storeInternalData(null, null); }
     });
     this._urlLoader.on('error', (event, netErrorString) => {
-      const error = new Error(netErrorString);
-      if (this._response) this._response.destroy(error);
-      this._die(error);
+      this._die(new Error(netErrorString));
     });
 
     this._urlLoader.on('login', (event, authInfo, callback) => {
@@ -515,7 +513,7 @@ export class ClientRequest extends Writable implements Electron.ClientRequest {
     this.destroy(err);
     if (this._urlLoader) {
       this._urlLoader.cancel();
-      if (this._response) this._response.destroy(err);
+      if (this._response) this._response.destroy();
     }
   }
 

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { net, session, ClientRequest, BrowserWindow, ClientRequestConstructorOptions } from 'electron/main';
 import * as http from 'http';
 import * as url from 'url';
-import { AddressInfo, Socket } from 'net';
+import { AddressInfo, Socket, createServer } from 'net';
 import { emittedOnce } from './events-helpers';
 import { defer, delay } from './spec-helpers';
 
@@ -1535,6 +1535,33 @@ describe('net module', () => {
       const response = await getResponse(urlRequest);
       expect(response.statusCode).to.equal(200);
       await collectStreamBody(response);
+    });
+
+    it('should not trigger errors on the response stream', async () => {
+      const ses = session.fromPartition(`${Math.random()}`);
+      const statusCode = await new Promise<number>((resolve, reject) => {
+        const server = createServer((c) => {
+          c.end('HTTP/1.1 407 Authentication Required\nProxy-Authenticate: Basic realm="Foo"\n\n');
+        }).listen(0, '127.0.0.1', async () => {
+          const port = (server.address() as AddressInfo).port;
+          await ses.setProxy({ proxyRules: `localhost:${port}` });
+          net
+            .request({ method: 'GET', url: 'https://example.com', session: ses })
+            .once('response', (res) => {
+              resolve(res.statusCode);
+              res.on('error', () => {
+                reject(new Error('response stream should not emit error'));
+              });
+            })
+            .once('abort', () => resolve(-1))
+            .once('error', () => {
+              reject(new Error('request stream should not emit error'));
+            })
+            .once('login', (_, callback) => { callback('username', 'password'); })
+            .end();
+        });
+      });
+      expect(statusCode).to.equal(407);
     });
   });
 


### PR DESCRIPTION
#### Description of Change
Fixes #24948. To better match Node, don't emit errors on the response stream
(only the request stream).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed errors being emitted on the response stream of requests created with the 'net' module in some cases.
