### PR TITLE
fix: do not run display check on "closed" windows in tray

### DIFF
--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -230,7 +230,7 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
       // previously on (but the leftmost one instead). We restore the position
       // of the window during the restore operation, this way chromium can
       // use the proper display to calculate the scale factor to use.
-      if (!last_normal_placement_bounds_.IsEmpty() &&
+      if (!last_normal_placement_bounds_.IsEmpty() && IsMinimized() &&
           GetWindowPlacement(GetAcceleratedWidget(), &wp)) {
         wp.rcNormalPosition = last_normal_placement_bounds_.ToRECT();
 

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -230,7 +230,8 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
       // previously on (but the leftmost one instead). We restore the position
       // of the window during the restore operation, this way chromium can
       // use the proper display to calculate the scale factor to use.
-      if (!last_normal_placement_bounds_.IsEmpty() && IsMinimized() &&
+      if (!last_normal_placement_bounds_.IsEmpty() &&
+          (IsVisible() || IsMinimized()) &&
           GetWindowPlacement(GetAcceleratedWidget(), &wp)) {
         wp.rcNormalPosition = last_normal_placement_bounds_.ToRECT();
 


### PR DESCRIPTION
#### Description of Change
Electron currently has a Windows-specific workaround, to help a minimized window correctly restore itself to the closest display (rather than the default left-most display). We hijack and reset the position of the window during the restore operation.

However, this workaround was incorrectly catching windows that were not just minimized, but closed; because the closed window also reported it's `last_normal_placement_bounds` as empty, similar to a minimized window. When this closed window is "restored", it is unresponsive and the affected app has to be hard quit.

This PR adds a check to make sure the window is minimized, not just hidden, before performing the restore position operation.

Fixes #26899 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes native window freeze on Windows when Electron app is sent to tray and external display changes.