### PR TITLE
fix: memory leak in TrackableObject

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -231,14 +231,6 @@ int ElectronBrowserMainParts::GetExitCode() {
   return exit_code_ != nullptr ? *exit_code_ : 0;
 }
 
-void ElectronBrowserMainParts::RegisterDestructionCallback(
-    base::OnceClosure callback) {
-  // The destructors should be called in reversed order, so dependencies between
-  // JavaScript objects can be correctly resolved.
-  // For example WebContentsView => WebContents => Session.
-  destructors_.insert(destructors_.begin(), std::move(callback));
-}
-
 int ElectronBrowserMainParts::PreEarlyInitialization() {
   field_trial_list_ = std::make_unique<base::FieldTrialList>(nullptr);
 #if defined(OS_LINUX)
@@ -528,18 +520,6 @@ void ElectronBrowserMainParts::PostMainMessageLoopRun() {
     if (download_manager) {
       download_manager->Shutdown();
     }
-  }
-
-  // Make sure destruction callbacks are called before message loop is
-  // destroyed, otherwise some objects that need to be deleted on IO thread
-  // won't be freed.
-  // We don't use ranged for loop because iterators are getting invalided when
-  // the callback runs.
-  for (auto iter = destructors_.begin(); iter != destructors_.end();) {
-    base::OnceClosure callback = std::move(*iter);
-    if (!callback.is_null())
-      std::move(callback).Run();
-    ++iter;
   }
 
   // Destroy node platform after all destructors_ are executed, as they may

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -75,11 +75,6 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   // Gets the exit code
   int GetExitCode();
 
-  // Register a callback that should be destroyed before JavaScript environment
-  // gets destroyed.
-  // Returns a closure that can be used to remove |callback| from the list.
-  void RegisterDestructionCallback(base::OnceClosure callback);
-
   // Returns the connection to GeolocationControl which can be
   // used to enable the location services once per client.
   device::mojom::GeolocationControl* GetGeolocationControl();
@@ -161,9 +156,6 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   std::unique_ptr<ElectronExtensionsClient> extensions_client_;
   std::unique_ptr<ElectronExtensionsBrowserClient> extensions_browser_client_;
 #endif
-
-  // List of callbacks should be executed before destroying JS env.
-  std::list<base::OnceClosure> destructors_;
 
   mojo::Remote<device::mojom::GeolocationControl> geolocation_control_;
 

--- a/shell/common/gin_helper/trackable_object.cc
+++ b/shell/common/gin_helper/trackable_object.cc
@@ -35,9 +35,6 @@ TrackableObjectBase::TrackableObjectBase() {
   // TODO(zcbenz): Make TrackedObject work in renderer process.
   DCHECK(gin_helper::Locker::IsBrowserProcess())
       << "This class only works for browser process";
-
-  electron::ElectronBrowserMainParts::Get()->RegisterDestructionCallback(
-      GetDestroyClosure());
 }
 
 TrackableObjectBase::~TrackableObjectBase() = default;

--- a/shell/common/gin_helper/trackable_object.h
+++ b/shell/common/gin_helper/trackable_object.h
@@ -9,6 +9,7 @@
 
 #include "base/bind.h"
 #include "base/memory/weak_ptr.h"
+#include "shell/common/gin_helper/cleaned_up_at_exit.h"
 #include "shell/common/gin_helper/event_emitter.h"
 #include "shell/common/key_weak_map.h"
 
@@ -19,7 +20,7 @@ class SupportsUserData;
 namespace gin_helper {
 
 // Users should use TrackableObject instead.
-class TrackableObjectBase {
+class TrackableObjectBase : public CleanedUpAtExit {
  public:
   TrackableObjectBase();
 
@@ -33,7 +34,7 @@ class TrackableObjectBase {
   static int32_t GetIDFromWrappedClass(base::SupportsUserData* wrapped);
 
  protected:
-  virtual ~TrackableObjectBase();
+  ~TrackableObjectBase() override;
 
   // Returns a closure that can destroy the native class.
   base::OnceClosure GetDestroyClosure();


### PR DESCRIPTION
#### Description of Change
This fixes a memory leak in TrackableObject (of which BaseWindow and
BrowserWindow are the only subclasses). It was registering an exit-time
destructor for every TrackableObject, and never removing them. This is replaced
by the gin_helper::CleanedUpAtExit helper class, which removes the destructor
from the list when the object is destroyed.

Ref #21586.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a memory leak when creating BrowserWindows.
