### PR TITLE
feat: support memlog switch for heap profiling

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -323,6 +323,7 @@ source_set("electron_lib") {
     "//chrome/app:command_ids",
     "//chrome/app/resources:platform_locale_settings",
     "//components/certificate_transparency",
+    "//components/heap_profiling/multi_process",
     "//components/language/core/browser",
     "//components/net_log",
     "//components/network_hints/browser",


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/24280
Refs https://github.com/electron/electron/issues/26922

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: added support for `--memlog` switch