### PR TITLE
fix: clean up base::LinkedList in context_bridge::ObjectCache

### DIFF
--- a/shell/renderer/api/context_bridge/object_cache.cc
+++ b/shell/renderer/api/context_bridge/object_cache.cc
@@ -21,7 +21,15 @@ ObjectCachePairNode::ObjectCachePairNode(ObjectCachePair&& pair) {
 ObjectCachePairNode::~ObjectCachePairNode() = default;
 
 ObjectCache::ObjectCache() {}
-ObjectCache::~ObjectCache() = default;
+ObjectCache::~ObjectCache() {
+  for (const auto& pair : proxy_map_) {
+    while (!pair.second.empty()) {
+      ObjectCachePairNode* node = pair.second.head()->value();
+      node->RemoveFromList();
+      delete node;
+    }
+  }
+}
 
 void ObjectCache::CacheProxiedObject(v8::Local<v8::Value> from,
                                      v8::Local<v8::Value> proxy_value) {


### PR DESCRIPTION
base::LinkedList does not delete its members on destruction. We need to manually ensure the linkedlist is empty when the ObjectCache is destroyed.

Fixes #27039

Notes: Fixed memory leak when sending non-primitives over the context bridge