### PR TITLE
chore: fix typo in electron_api_base_window.cc

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -857,7 +857,7 @@ bool BaseWindow::GetWindowButtonVisibility() const {
 }
 
 void BaseWindow::SetTrafficLightPosition(const gfx::Point& position) {
-  // For backward compatibility we treat (0, 0) as reseting to default.
+  // For backward compatibility we treat (0, 0) as resetting to default.
   if (position.IsOrigin())
     window_->SetTrafficLightPosition(base::nullopt);
   else


### PR DESCRIPTION
#### Description of Change

fixed typo.
```
reseting -> resetting
```

#### Release Notes
 
notes: none