### PR TITLE
fix: early GC of WebFrameMain instances

### DIFF
--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -57,6 +57,9 @@ WebFrameMain::~WebFrameMain() {
 }
 
 void WebFrameMain::MarkRenderFrameDisposed() {
+  if (render_frame_disposed_)
+    return;
+  Unpin();
   g_render_frame_map.Get().erase(render_frame_);
   render_frame_disposed_ = true;
 }
@@ -305,8 +308,14 @@ gin::Handle<WebFrameMain> WebFrameMain::From(v8::Isolate* isolate,
   if (rfh == nullptr)
     return gin::Handle<WebFrameMain>();
   auto* web_frame = FromRenderFrameHost(rfh);
-  auto handle = gin::CreateHandle(
-      isolate, web_frame == nullptr ? new WebFrameMain(rfh) : web_frame);
+  if (web_frame)
+    return gin::CreateHandle(isolate, web_frame);
+
+  auto handle = gin::CreateHandle(isolate, new WebFrameMain(rfh));
+
+  // Prevent garbage collection of frame until it has been deleted internally.
+  handle->Pin(isolate);
+
   return handle;
 }
 

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -13,6 +13,7 @@
 #include "gin/handle.h"
 #include "gin/wrappable.h"
 #include "shell/common/gin_helper/constructible.h"
+#include "shell/common/gin_helper/pinnable.h"
 
 class GURL;
 
@@ -34,6 +35,7 @@ namespace api {
 
 // Bindings for accessing frames from the main process.
 class WebFrameMain : public gin::Wrappable<WebFrameMain>,
+                     public gin_helper::Pinnable<WebFrameMain>,
                      public gin_helper::Constructible<WebFrameMain> {
  public:
   // Create a new WebFrameMain and return the V8 wrapper of it.


### PR DESCRIPTION
#### Description of Change

fixes #26824

Changes `WebFrameMain` to inherit from `gin_helper::Pinnable` so we can keep it in-memory while multiple gin handles to it exist.

This fixes the issue seen in #26824 in which `webContents.mainFrame` would sometimes return `undefined` (and all the flaky tests with it). However, I'm pretty new to the behaviors of v8's garbage collection and I only half-understand why this works. Here's what I think is going on:
1. We request a gin handle to a new `WebFrameMain` instance.
2. We request another gin handle to the existing `WebFrameMain` instance.
3. The first `WebFrameMain` instance gets garbage collected and the memory is freed.
4. We attempt to access the second handle to the now garbage collected `WebFrameMain` instance.
5. We get `undefined` as the value.

So we need to keep the initial `WebFrameMain` instance in-memory until all handles are can be garbage collected. I would love if someone with a better understanding of v8 could help explain what's happening.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed bug in which `WebContents.mainFrame` would sometimes return `undefined`.
