### PR TITLE
build: make sure fuses.h gets generated for macos builds

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -992,6 +992,7 @@ if (is_mac) {
     deps = [
       ":electron_app_framework_bundle_data",
       ":electron_app_resources",
+      ":electron_fuses",
       "//base",
       "//electron/buildflags",
     ]


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Recently macos release builds started failing with `fatal error: 'electron/fuses.h' file not found`:
https://app.circleci.com/pipelines/github/electron/electron/35682/workflows/2c29722d-5388-481c-aef8-3e8697374bdd/jobs/782479

https://app.circleci.com/pipelines/github/electron/electron/35679/workflows/e16ac8a7-6ec8-4417-aa8d-00106befd854/jobs/782308

I believe this may be related to #27579 so I applied the same fix we did there. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none.
