### PR TITLE
feat: add session display-capture api option

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -492,6 +492,7 @@ win.webContents.session.setCertificateVerifyProc((request, callback) => {
   * `permission` String - The type of requested permission.
     * `clipboard-read` - Request access to read from the clipboard.
     * `media` -  Request access to media devices such as camera, microphone and speakers.
+    * `display-capture` - Request access to capture the screen.
     * `mediaKeySystem` - Request access to DRM protected content.
     * `geolocation` - Request access to user's current location.
     * `notifications` - Request notification creation and the ability to display them in the user's system tray.


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/27576.

Chromium introduced a new permission option, display-capture, for sessions. `display-capture` requests access to capture the screen. 

This API is currently in master and was introduced in the 12-x-y line, but as it is a minor change, it is undocumented. This PR documents this change  and commits it as a semver minor.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added display-capture API for session.setPermissionRequestHandler