### PR TITLE
chore: update copyright headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+Copyright (c) Electron contributors
 Copyright (c) 2013-2020 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining


### PR DESCRIPTION
Per discussions with the Foundation, we are making an update to all copyright headers to follow the Linux Foundation guidance on copyright notices. In particular, we are broadening them to cover all contributors, and eliminating the year to avoid the need to keep them up to date.

Notes: no-notes