### PR TITLE
feat: implement allowFileAccess loadExtension option

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -775,7 +775,7 @@ The method will also not return if the extension's manifest is missing or incomp
 is emitted.
 
 **Note:** This method is deprecated. Instead, use
-[`ses.loadExtension(path)`](session.md#sesloadextensionpath).
+[`ses.loadExtension(path)`](session.md#sesloadextensionpath-options).
 
 #### `BrowserWindow.removeDevToolsExtension(name)` _Deprecated_
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -733,7 +733,7 @@ The method will also not return if the extension's manifest is missing or incomp
 is emitted.
 
 **Note:** This method is deprecated. Instead, use
-[`ses.loadExtension(path)`](session.md#sesloadextensionpath).
+[`ses.loadExtension(path)`](session.md#sesloadextensionpath-options).
 
 #### `BrowserWindow.removeExtension(name)` _Deprecated_
 

--- a/docs/api/extensions.md
+++ b/docs/api/extensions.md
@@ -15,7 +15,7 @@ extension capabilities.
 
 Electron only supports loading unpacked extensions (i.e., `.crx` files do not
 work). Extensions are installed per-`session`. To load an extension, call
-[`ses.loadExtension`](session.md#sesloadextensionpath):
+[`ses.loadExtension`](session.md#sesloadextensionpath-options):
 
 ```js
 const { session } = require('electron')

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -568,9 +568,13 @@ will not work on non-persistent (in-memory) sessions.
 
 **Note:** On macOS and Windows 10 this word will be removed from the OS custom dictionary as well
 
-#### `ses.loadExtension(path)`
+#### `ses.loadExtension(path[, options])`
 
 * `path` String - Path to a directory containing an unpacked Chrome extension
+* `options` Object (optional)
+  * `allowFileAccess` Boolean - Whether to allow the extension to read local files over `file://`
+    protocol and inject content scripts into `file://` pages. This is required e.g. for loading
+    devtools extensions on `file://` URLs. Defaults to false.
 
 Returns `Promise<Extension>` - resolves when the extension is loaded.
 
@@ -593,7 +597,11 @@ const { app, session } = require('electron')
 const path = require('path')
 
 app.on('ready', async () => {
-  await session.defaultSession.loadExtension(path.join(__dirname, 'react-devtools'))
+  await session.defaultSession.loadExtension(
+    path.join(__dirname, 'react-devtools'),
+    // allowFileAccess is required to load the devtools extension on file:// URLs.
+    { allowFileAccess: true }
+  )
   // Note that in order to use the React DevTools extension, you'll need to
   // download and unzip a copy of the extension.
 })

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -122,7 +122,8 @@ class Session : public gin::Wrappable<Session>,
 #endif
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
-  v8::Local<v8::Promise> LoadExtension(const base::FilePath& extension_path);
+  v8::Local<v8::Promise> LoadExtension(const base::FilePath& extension_path,
+                                       gin::Arguments* args);
   void RemoveExtension(const std::string& extension_id);
   v8::Local<v8::Value> GetExtension(const std::string& extension_id);
   v8::Local<v8::Value> GetAllExtensions();

--- a/shell/browser/extensions/electron_extension_loader.h
+++ b/shell/browser/extensions/electron_extension_loader.h
@@ -37,6 +37,7 @@ class ElectronExtensionLoader : public ExtensionRegistrar::Delegate {
   // Loads an unpacked extension from a directory synchronously. Returns the
   // extension on success, or nullptr otherwise.
   void LoadExtension(const base::FilePath& extension_dir,
+                     int load_flags,
                      base::OnceCallback<void(const Extension* extension,
                                              const std::string&)> cb);
 

--- a/shell/browser/extensions/electron_extension_system.cc
+++ b/shell/browser/extensions/electron_extension_system.cc
@@ -56,8 +56,9 @@ ElectronExtensionSystem::~ElectronExtensionSystem() = default;
 
 void ElectronExtensionSystem::LoadExtension(
     const base::FilePath& extension_dir,
+    int load_flags,
     base::OnceCallback<void(const Extension*, const std::string&)> cb) {
-  extension_loader_->LoadExtension(extension_dir, std::move(cb));
+  extension_loader_->LoadExtension(extension_dir, load_flags, std::move(cb));
 }
 
 void ElectronExtensionSystem::FinishInitialization() {

--- a/shell/browser/extensions/electron_extension_system.h
+++ b/shell/browser/extensions/electron_extension_system.h
@@ -41,6 +41,7 @@ class ElectronExtensionSystem : public ExtensionSystem {
   // success, or nullptr otherwise.
   void LoadExtension(
       const base::FilePath& extension_dir,
+      int load_flags,
       base::OnceCallback<void(const Extension*, const std::string&)> cb);
 
   // Finish initialization for the shell extension system.


### PR DESCRIPTION
Backport of #25198.

Notes: Added `allowFileAccess` option to `loadExtension()` API.
