### PR TITLE
docs: transparent window opaque while dev tools opened

### DIFF
--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -74,6 +74,7 @@ win.show()
 
 ### Limitations
 
+* The window will not be transparent while dev tools are open.
 * You can not click through the transparent area. We are going to introduce an
   API to set window shape to solve this, see
   [our issue](https://github.com/electron/electron/issues/1335) for details.

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -74,7 +74,6 @@ win.show()
 
 ### Limitations
 
-* The window will not be transparent while dev tools are open.
 * You can not click through the transparent area. We are going to introduce an
   API to set window shape to solve this, see
   [our issue](https://github.com/electron/electron/issues/1335) for details.
@@ -83,6 +82,7 @@ win.show()
 * The `blur` filter only applies to the web page, so there is no way to apply
   blur effect to the content below the window (i.e. other applications open on
   the user's system).
+* The window will not be transparent when DevTools is opened.
 * On Windows operating systems, transparent windows will not work when DWM is
   disabled.
 * On Linux, users have to put `--enable-transparent-visuals --disable-gpu` in


### PR DESCRIPTION
Read that on some external website. I think this should be added to the official docs.

#### Description of Change
Updated docs: Clarifying that window will not be transparent when dev tools are openend .

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none