### PR TITLE
fix: add support for title change with window history navigation

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1636,8 +1636,11 @@ void WebContents::DidStartNavigation(
     content::NavigationHandle* navigation_handle) {
   content::NavigationEntry* entry =
       web_contents()->GetController().GetPendingEntry();
-  if (entry)
+  // If a history entry has been made and the current window title is different,
+  // proceed with setting the new title
+  if (entry && (WebContents::GetTitle() != entry->GetTitle())) {
     WebContents::TitleWasSet(entry);
+  }
   EmitNavigationEvent("did-start-navigation", navigation_handle);
 }
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1703,11 +1703,11 @@ void WebContents::DidFinishNavigation(
 
   // If a history entry has been made and the forward/back call has been made,
   // proceed with setting the new title
-  if (entry &&
-      ui::PageTransitionTypeIncludingQualifiersIs(
-          ui::PAGE_TRANSITION_FORWARD_BACK,
-          ui::PageTransitionFromInt(navigation_handle->GetPageTransition() &
-                                    ui::PAGE_TRANSITION_FORWARD_BACK)))
+  ui::PageTransition transition =
+      ui::PageTransitionFromInt(navigation_handle->GetPageTransition() &
+                                ui::PAGE_TRANSITION_FORWARD_BACK);
+  if (entry && ui::PageTransitionTypeIncludingQualifiersIs(
+                   ui::PAGE_TRANSITION_FORWARD_BACK, transition))
     WebContents::TitleWasSet(entry);
 }
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1702,8 +1702,7 @@ void WebContents::DidFinishNavigation(
 
   // If a history entry has been made and the forward/back call has been made,
   // proceed with setting the new title
-  if (entry &&
-      (entry->GetTransitionType() & ui::PAGE_TRANSITION_FORWARD_BACK))
+  if (entry && (entry->GetTransitionType() & ui::PAGE_TRANSITION_FORWARD_BACK))
     WebContents::TitleWasSet(entry);
 }
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1702,11 +1702,8 @@ void WebContents::DidFinishNavigation(
 
   // If a history entry has been made and the forward/back call has been made,
   // proceed with setting the new title
-  ui::PageTransition transition =
-      ui::PageTransitionFromInt(navigation_handle->GetPageTransition() &
-                                ui::PAGE_TRANSITION_FORWARD_BACK);
-  if (entry && ui::PageTransitionTypeIncludingQualifiersIs(
-                   ui::PAGE_TRANSITION_FORWARD_BACK, transition))
+  if (entry &&
+      (entry->GetTransitionType() & ui::PAGE_TRANSITION_FORWARD_BACK))
     WebContents::TitleWasSet(entry);
 }
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1700,6 +1700,9 @@ void WebContents::DidFinishNavigation(
   }
   content::NavigationEntry* entry = navigation_handle->GetNavigationEntry();
 
+  // This check is needed due to an issue in Chromium
+  // Check the Chromium issue to keep updated:
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=1178663
   // If a history entry has been made and the forward/back call has been made,
   // proceed with setting the new title
   if (entry && (entry->GetTransitionType() & ui::PAGE_TRANSITION_FORWARD_BACK))

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1634,6 +1634,10 @@ void WebContents::RenderFrameDeleted(
 
 void WebContents::DidStartNavigation(
     content::NavigationHandle* navigation_handle) {
+  content::NavigationEntry* entry =
+      web_contents()->GetController().GetPendingEntry();
+  if (entry)
+    WebContents::TitleWasSet(entry);
   EmitNavigationEvent("did-start-navigation", navigation_handle);
 }
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include "shell/browser/api/electron_api_web_contents.h"
-#include "ui/base/page_transition_types.h"  //FIXME(@mlaurencin): Decide if I need this or to include something else for the enums
 
 #include <limits>
 #include <memory>


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

I am still working on improving this PR, so any additional insights into better ways to accomplish this (or other general review) would be appreciated.

Closes https://github.com/electron/electron/issues/27188

This PR restores the functionality where the title of a browser window is properly updated when navigating through its session history. Before, when you tried to navigate to a previously loaded page in the window history (such as with commands like `window.history.back()`) the title of the page would not be updated to reflect this navigation. Now the window's title will be properly updated.

cc @MarshallOfSound , @nornagon , @zcbenz  

**Further Notes (for more context):**

The code path that these navigation commands were initially following was changed with [this PR](https://github.com/electron/electron/pull/22336), specifically with [this commit](https://github.com/electron/electron/pull/22336/commits/56ea879a33b581e7ac3cff4e21df68375281f8b4) to enable reusing renderer processes by default. 

Where this change matters is in [this function](https://source.chromium.org/chromium/chromium/src/+/master:content/browser/web_contents/web_contents_impl.cc;l=5996;drc=2ac64302ae161cd6b5e4b1254497bdf5fd6d3415?ss=chromium&start=21) `WebContentsImpl::UpdateTitleForEntry` in Chromium. What I have determined is that when the navigation takes place, the information of the pending page is passed into the function by `NavigationEntryImpl* entry`. Then when the function checks the title that is trying to be set, `final_title`, it sees that it is the same as the entry's title and does not set it. However, [the line at the end here](https://source.chromium.org/chromium/chromium/src/+/master:content/browser/web_contents/web_contents_impl.cc;l=6024;drc=2ac64302ae161cd6b5e4b1254497bdf5fd6d3415?ss=chromium&start=21) `observers_.NotifyObservers(&WebContentsObserver::TitleWasSet, entry);` informs the observers that a title was set, so by bailing early the window is not informed that it needs to update its title. Thus the title stays the same as the one from before.

This was not a problem previously as a new url was loaded rather than actually navigating in the history. In this way, the `entry` did not yet have its title set, thus making the title `""` and the function did not return early.

**Current Issues:**

1.  In the case that `final_title` and `entry->GetTitle()` are different, `TitleWasSet` will be called twice: once on the Electron side and once on the Chromium side.
2.  Since I added this change into `WebContents::DidStartNavigation` I noticed that it gets called quite often (even in some cases where it appears that you did not initiate navigation).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> None
