### PR TITLE
fix: disable unload metrics to fix CI failure

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -106,3 +106,4 @@ don_t_use_potentially_null_getwebframe_-_view_when_get_blink.patch
 web_contents.patch
 add_trustedauthclient_to_urlloaderfactory.patch
 fix_route_mouse_event_navigations_through_the_web_contents_delegate.patch
+disable_unload_metrics.patch

--- a/patches/chromium/disable_unload_metrics.patch
+++ b/patches/chromium/disable_unload_metrics.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Thu, 20 Sep 2018 17:45:47 -0700
+Subject: fix: disable unload metrics
+
+Chromium introduced unload metrics in:
+https://chromium-review.googlesource.com/c/chromium/src/+/2314877
+
+Which would cause some DCHECKs to assert in Electron:
+https://github.com/electron/electron/issues/27717
+
+And it would then crash and make some tests fail:
+crashReporter module should send minidump when sandboxed renderer crashes api-crash-reporter-spec.ts 643 ms
+Error message:
+ptype: expected 'browser' to equal 'renderer'
+Error stack trace:
+AssertionError: ptype: expected 'browser' to equal 'renderer'
+    at checkCrash (electron\spec-main\api-crash-reporter-spec.ts:39:35)
+    at Context.<anonymous> (electron\spec-main\api-crash-reporter-spec.ts:154:7)
+    at runMicrotasks (<anonymous>)
+    at processTicksAndRejections (internal/process/task_queues.js:93:5)
+
+This patch temporarily disables the metrics so we can have green CI, and we
+should continue seeking for a real fix.
+
+diff --git a/content/browser/renderer_host/navigator.cc b/content/browser/renderer_host/navigator.cc
+index f9fe438fbc14..c57156ab68a6 100644
+--- a/content/browser/renderer_host/navigator.cc
++++ b/content/browser/renderer_host/navigator.cc
+@@ -960,6 +960,7 @@ void Navigator::RecordNavigationMetrics(
+             .InMilliseconds());
+   }
+ 
++#if 0
+   // If this is a same-process navigation and we have timestamps for unload
+   // durations, fill those metrics out as well.
+   if (params.unload_start && params.unload_end &&
+@@ -1006,6 +1007,7 @@ void Navigator::RecordNavigationMetrics(
+          first_before_unload_start_time)
+             .InMilliseconds());
+   }
++#endif
+ 
+   builder.Record(ukm::UkmRecorder::Get());
+   navigation_data_.reset();

--- a/patches/chromium/disable_unload_metrics.patch
+++ b/patches/chromium/disable_unload_metrics.patch
@@ -24,7 +24,7 @@ This patch temporarily disables the metrics so we can have green CI, and we
 should continue seeking for a real fix.
 
 diff --git a/content/browser/renderer_host/navigator.cc b/content/browser/renderer_host/navigator.cc
-index f9fe438fbc14..c57156ab68a6 100644
+index f9fe438fbc14c5097c665c1e81209285646f578c..c57156ab68a65440a0ed101fbceaf5246c59e9cd 100644
 --- a/content/browser/renderer_host/navigator.cc
 +++ b/content/browser/renderer_host/navigator.cc
 @@ -960,6 +960,7 @@ void Navigator::RecordNavigationMetrics(

--- a/spec-main/fixtures/apps/crash/main.js
+++ b/spec-main/fixtures/apps/crash/main.js
@@ -38,7 +38,7 @@ app.whenReady().then(() => {
       `);
     }
     w.webContents.executeJavaScript('process.crash()');
-    w.webContents.on('crashed', () => process.exit(0));
+    w.webContents.on('render-process-gone', () => process.exit(0));
   } else if (crashType === 'sandboxed-renderer') {
     const w = new BrowserWindow({
       show: false,
@@ -48,7 +48,7 @@ app.whenReady().then(() => {
       }
     });
     w.loadURL(`about:blank?set_extra=${setExtraParameters ? 1 : 0}`);
-    w.webContents.on('crashed', () => process.exit(0));
+    w.webContents.on('render-process-gone', () => process.exit(0));
   } else if (crashType === 'node') {
     const crashesDir = path.join(app.getPath('temp'), `${app.name} Crashes`);
     const version = app.getVersion();


### PR DESCRIPTION
#### Description of Change

Chromium introduced metrics to measure unload performance in:
https://chromium-review.googlesource.com/c/chromium/src/+/2314877

Which would cause some DCHECKs to assert in Electron in some cases: https://github.com/electron/electron/issues/27717.

And it would result in failing tests, because it caused the main process to crash:

```
crashReporter module should send minidump when sandboxed renderer crashes api-crash-reporter-spec.ts 643 ms
Error message:
ptype: expected 'browser' to equal 'renderer'
Error stack trace:
AssertionError: ptype: expected 'browser' to equal 'renderer'
    at checkCrash (electron\spec-main\api-crash-reporter-spec.ts:39:35)
    at Context.<anonymous> (electron\spec-main\api-crash-reporter-spec.ts:154:7)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
```

This patch temporarily disables the metrics so we can have green CI, before finding out a real fix.

Note that this PR also replaced uses of deprecated `crashed` events to avoid running into the crash in https://github.com/electron/electron/pull/27730.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none