### PR TITLE
test: fix flaky did-change-theme-color test

### DIFF
--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -1383,8 +1383,7 @@ describe('webContents module', () => {
     }
   });
 
-  // TODO (jkleinsc) - reenable this test on WOA once https://github.com/electron/electron/issues/26045 is resolved
-  ifdescribe(process.platform !== 'win32' || process.arch !== 'arm64')('did-change-theme-color event', () => {
+  describe('did-change-theme-color event', () => {
     afterEach(closeAllWindows);
     it('is triggered with correct theme color', (done) => {
       const w = new BrowserWindow({ show: true });

--- a/spec-main/webview-spec.ts
+++ b/spec-main/webview-spec.ts
@@ -182,8 +182,7 @@ describe('<webview> tag', function () {
     });
   });
 
-  // TODO (jkleinsc) - reenable this test on WOA once https://github.com/electron/electron/issues/26045 is resolved
-  ifdescribe(process.platform !== 'win32' || process.arch !== 'arm64')('did-change-theme-color event', () => {
+  describe('did-change-theme-color event', () => {
     it('emits when theme color changes', async () => {
       const w = new BrowserWindow({
         webPreferences: {

--- a/spec-main/webview-spec.ts
+++ b/spec-main/webview-spec.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as url from 'url';
 import { BrowserWindow, session, ipcMain, app, WebContents } from 'electron/main';
 import { closeAllWindows } from './window-helpers';
 import { emittedOnce, emittedUntil } from './events-helpers';
@@ -178,6 +179,32 @@ describe('<webview> tag', function () {
       const [, webContents] = await didAttachWebview;
       const [, id] = await webviewDomReady;
       expect(webContents.id).to.equal(id);
+    });
+  });
+
+  // TODO (jkleinsc) - reenable this test on WOA once https://github.com/electron/electron/issues/26045 is resolved
+  ifdescribe(process.platform !== 'win32' || process.arch !== 'arm64')('did-change-theme-color event', () => {
+    it('emits when theme color changes', async () => {
+      const w = new BrowserWindow({
+        webPreferences: {
+          webviewTag: true
+        }
+      });
+      await w.loadURL('about:blank');
+      const src = url.format({
+        pathname: `${fixtures.replace(/\\/g, '/')}/pages/theme-color.html`,
+        protocol: 'file',
+        slashes: true
+      });
+      const message = await w.webContents.executeJavaScript(`new Promise((resolve, reject) => {
+        const webview = new WebView()
+        webview.setAttribute('src', '${src}')
+        webview.addEventListener('did-change-theme-color', (e) => {
+          resolve('ok')
+        })
+        document.body.appendChild(webview)
+      })`);
+      expect(message).to.equal('ok');
     });
   });
 

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -992,16 +992,6 @@ describe('<webview> tag', function () {
     });
   });
 
-  // TODO (jkleinsc) - reenable this test on WOA once https://github.com/electron/electron/issues/26045 is resolved
-  ifdescribe(process.platform !== 'win32' || process.arch !== 'arm64')('did-change-theme-color event', () => {
-    it('emits when theme color changes', async () => {
-      loadWebView(webview, {
-        src: `file://${fixtures}/pages/theme-color.html`
-      });
-      await waitForEvent(webview, 'did-change-theme-color');
-    });
-  });
-
   describe('<webview>.getWebContentsId', () => {
     it('can return the WebContents ID', async () => {
       const src = 'about:blank';


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/26045.

The `did-change-theme-color` event is only emitted when the page has been painted, so for webview the event is usually only emitted when the parent BrowserWindow is visible.

This PR moves the webview `did-change-theme-color` test to main process and makes sure its parent window is visible, to fix the flaky test.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none