### PR TITLE
fix: create guest site instances for guest web contents.

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -719,8 +719,8 @@ WebContents::WebContents(v8::Isolate* isolate,
   std::unique_ptr<content::WebContents> web_contents;
   if (IsGuest()) {
     scoped_refptr<content::SiteInstance> site_instance =
-        content::SiteInstance::CreateForURL(session->browser_context(),
-                                            GURL("chrome-guest://fake-host"));
+        content::SiteInstance::CreateForGuest(session->browser_context(),
+                                              GURL("chrome-guest://fake-host"));
     content::WebContents::CreateParams params(session->browser_context(),
                                               site_instance);
     guest_delegate_ =


### PR DESCRIPTION
Chromium does not swap processes for navigations in webview tag guests. Electron apps have come to rely on this for debugging and automated testing of iframes inside webviews.

With [this change](https://chromium.googlesource.com/chromium/src.git/+/bcaccaf3027c66c096d8bcf28dc2c67cf3a40287), Chromium moved from relying on a site instance's URL being a guest scheme to explicitly marking site instances as having been created for guest frames.

Electron must follow this change when creating site instances for web contents used for webviews, so that these site instances are properly marked as guests and the Chromium behaviour of reusing the same process inside webviews is kept.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue that made iframes inside webviews inaccessible to DevTools and automated test tools (#27503).
