### PR TITLE
fix: don't create last saved path if none exists

### DIFF
--- a/shell/browser/electron_download_manager_delegate.h
+++ b/shell/browser/electron_download_manager_delegate.h
@@ -52,6 +52,8 @@ class ElectronDownloadManagerDelegate
       content::DownloadTargetCallback download_callback,
       gin_helper::Dictionary result);
 
+  base::FilePath last_saved_directory_;
+
   content::DownloadManager* download_manager_;
   base::WeakPtrFactory<ElectronDownloadManagerDelegate> weak_ptr_factory_{this};
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/27601.

It shouldn't be the case that we create the last saved download directory if it doesn't exist. Only do this if it's the global default.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where deleted download directories would be sometimes recreated by the operating system.
