### PR TITLE
fix: enableBlinkFeatures warning in webviews

### DIFF
--- a/lib/renderer/security-warnings.ts
+++ b/lib/renderer/security-warnings.ts
@@ -225,7 +225,7 @@ const warnAboutExperimentalFeatures = function (webPreferences?: Electron.WebPre
 const warnAboutEnableBlinkFeatures = function (webPreferences?: Electron.WebPreferences) {
   if (!webPreferences ||
     !Object.prototype.hasOwnProperty.call(webPreferences, 'enableBlinkFeatures') ||
-    (webPreferences.enableBlinkFeatures && webPreferences.enableBlinkFeatures.length === 0)) {
+    (webPreferences.enableBlinkFeatures != null && webPreferences.enableBlinkFeatures.length === 0)) {
     return;
   }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/23163.

The security warnings logic was checking:

```js
webPreferences.enableBlinkFeatures && webPreferences.enableBlinkFeatures.length === 0
```

as a way to rule out whether or not to show `enableBlinkFeatures` security warning. This presented an issue because the `&&` operator actually returns the value of one of the specified operands and so if this operator is used with non-Boolean values, it will return a non-Boolean value. In this case `webPreferences.enableBlinkFeatures` is `string | undefined`, and so if the first operand in the expression is falsy, as it would be for empty string, it would simply return `''` and show the warning where none should be shown.

This can be verified in the Node.js repl:
```console
Welcome to Node.js v14.11.0.
Type ".help" for more information.
> const s = ''
undefined
> s && s.length === 0
''
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an erroneous `enableBlinkFeatures` warning shown webviews which enabled no Blink features.