### PR TITLE
fix: check WebContents before emitting render-process-gone event

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1098,7 +1098,13 @@ void WebContents::RenderViewDeleted(content::RenderViewHost* render_view_host) {
 }
 
 void WebContents::RenderProcessGone(base::TerminationStatus status) {
+  auto weak_this = GetWeakPtr();
   Emit("crashed", status == base::TERMINATION_STATUS_PROCESS_WAS_KILLED);
+
+  // User might destroy WebContents in the crashed event.
+  if (!weak_this)
+    return;
+
   v8::HandleScope handle_scope(isolate());
   gin_helper::Dictionary details =
       gin_helper::Dictionary::CreateEmpty(isolate());


### PR DESCRIPTION
Backport of #27730

See that PR for details.

Notes: Fix crash when destroying WebContents in the `crashed` event.