### PR TITLE
docs: update menu item '&' escaping

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -22,8 +22,10 @@ Sets `menu` as the application menu on macOS. On Windows and Linux, the
 Also on Windows and Linux, you can use a `&` in the top-level item name to
 indicate which letter should get a generated accelerator. For example, using
 `&File` for the file menu would result in a generated `Alt-F` accelerator that
-opens the associated menu. The indicated character in the button label gets an
-underline. The `&` character is not displayed on the button label.
+opens the associated menu. The indicated character in the button label then gets an
+underline, and the `&` character is not displayed on the button label.
+
+In order to escape the `&` character in an item name, add a proceeding `&`. For example, `&&File` would result in `&File` displayed on the button label.
 
 Passing `null` will suppress the default menu. On Windows and Linux,
 this has the additional effect of removing the menu bar from the window.


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Closes https://github.com/electron/electron/issues/25028

Previously it was not documented on Electron that an '&' was needed to escape an '&' for a menu item name. 

Gist: https://gist.github.com/mlaurencin/b9f5968c70c3e8628150e11fa88e81cb

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> None
