### PR TITLE
fix: ensure owner window is valid in ResetBrowserViews

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -1118,7 +1118,7 @@ void BaseWindow::ResetBrowserViews() {
       // reset if the owner window is *this* window.
       if (browser_view->web_contents()) {
         auto* owner_window = browser_view->web_contents()->owner_window();
-        if (owner_window == window_.get()) {
+        if (owner_window && owner_window == window_.get()) {
           browser_view->web_contents()->SetOwnerWindow(nullptr);
           owner_window->RemoveBrowserView(browser_view->view());
         }


### PR DESCRIPTION
#### Description of Change

Ensure that the `owner_window` is valid before potentially calling any methods on it. 

In the initial PR we checked it in [`AddBrowserView`](https://github.com/electron/electron/pull/27000/files#diff-9e3935b7f7b31cb73a8e976e9725bab5c20c499dc5d1e33c7c7f62e3f90b72c9R765) but not in [`ResetBrowserViews`](https://github.com/electron/electron/pull/27000/files#diff-9e3935b7f7b31cb73a8e976e9725bab5c20c499dc5d1e33c7c7f62e3f90b72c9R1086) and we should check both.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a potential crash when resetting `BrowserView`s.
