### PR TITLE
fix: restore window event redispatching on mac

### DIFF
--- a/shell/browser/common_web_contents_delegate_mac.mm
+++ b/shell/browser/common_web_contents_delegate_mac.mm
@@ -9,6 +9,7 @@
 #include "content/public/browser/native_web_keyboard_event.h"
 #include "shell/browser/ui/cocoa/event_dispatching_window.h"
 #include "shell/browser/web_contents_preferences.h"
+#include "ui/base/cocoa/command_dispatcher.h"
 #include "ui/events/keycodes/keyboard_codes.h"
 
 @interface NSWindow (EventDispatchingWindow)
@@ -47,6 +48,16 @@ bool CommonWebContentsDelegate::HandleKeyboardEvent(
     // FIXME(nornagon): this isn't the right return value; we should implement
     // devtools windows as Widgets in order to take advantage of the
     // pre-existing redispatch code in bridged_native_widget.
+    return false;
+  } else if (event.os_event.window &&
+             [event.os_event.window
+                 conformsToProtocol:@protocol(CommandDispatchingWindow)]) {
+    NSObject<CommandDispatchingWindow>* window =
+        static_cast<NSObject<CommandDispatchingWindow>*>(event.os_event.window);
+    [[window commandDispatcher] redispatchKeyEvent:event.os_event];
+    // FIXME(clavin): Not exactly sure what to return here, likely the same
+    // situation as the branch above. If a future refactor removes
+    // |EventDispatchingWindow| then only this branch will need to remain.
     return false;
   }
 


### PR DESCRIPTION
Backport of #27701

See that PR for details.

Notes: Fixed OS-level shortcuts on macOS (e.g. Ctrl + F2, ⌘ + ~).