### PR TITLE
fix: gather crash data for unexpected helper path

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -13,6 +13,7 @@
 
 #include "base/base_switches.h"
 #include "base/command_line.h"
+#include "base/debug/crash_logging.h"
 #include "base/environment.h"
 #include "base/files/file_util.h"
 #include "base/json/json_reader.h"
@@ -718,7 +719,13 @@ void ElectronBrowserClient::AppendExtraCommandLineSwitches(
           << "Aborted from launching unexpected helper executable";
     }
 #else
-    base::PathService::Get(content::CHILD_PROCESS_EXE, &child_path);
+    if (!base::PathService::Get(content::CHILD_PROCESS_EXE, &child_path)) {
+      CHECK(false) << "Unable to get child process binary name.";
+    }
+    SCOPED_CRASH_KEY_STRING256("ChildProcess", "child_process_exe",
+                               child_path.AsUTF8Unsafe());
+    SCOPED_CRASH_KEY_STRING256("ChildProcess", "program",
+                               program.AsUTF8Unsafe());
     CHECK_EQ(program, child_path);
 #endif
   }


### PR DESCRIPTION
#### Description of Change
Adds some crash keys for path data when the child process exe path is found to
be different from the parent's path on win/linux.

We're seeing this CHECK fire in production, and this will hopefully help us
narrow down the cause!

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none
