### PR TITLE
fix: replace default frameName title with null check

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -605,7 +605,6 @@ WebContents.prototype._init = function () {
         width: 800,
         height: 600,
         webContents,
-        title: frameName,
         webPreferences,
         ...options
       };

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -247,8 +247,6 @@ function internalWindowOpen (event, url, referrer, frameName, disposition, optio
     ...parseContentTypeFormat(postData)
   } : null;
 
-  if (options.webPreferences.nativeWindowOpen && options.title === frameName) options.title = null;
-
   event.sender.emit('new-window', event, url, frameName, disposition, options, additionalFeatures, referrer, postBody);
   const { newGuest } = event;
   if ((event.sender.getType() === 'webview' && event.sender.getLastWebPreferences().disablePopups) || event.defaultPrevented) {

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -247,7 +247,7 @@ function internalWindowOpen (event, url, referrer, frameName, disposition, optio
     ...parseContentTypeFormat(postData)
   } : null;
 
-  if (options.webPreferences.nativeWindowOpen && options.title == frameName) options.title = null;
+  if (options.webPreferences.nativeWindowOpen && options.title === frameName) options.title = null;
 
   event.sender.emit('new-window', event, url, frameName, disposition, options, additionalFeatures, referrer, postBody);
   const { newGuest } = event;

--- a/lib/browser/guest-window-manager.js
+++ b/lib/browser/guest-window-manager.js
@@ -247,6 +247,8 @@ function internalWindowOpen (event, url, referrer, frameName, disposition, optio
     ...parseContentTypeFormat(postData)
   } : null;
 
+  if (options.webPreferences.nativeWindowOpen && options.title == frameName) options.title = null;
+
   event.sender.emit('new-window', event, url, frameName, disposition, options, additionalFeatures, referrer, postBody);
   const { newGuest } = event;
   if ((event.sender.getType() === 'webview' && event.sender.getLastWebPreferences().disablePopups) || event.defaultPrevented) {

--- a/spec-main/fixtures/snapshots/native-window-open.snapshot.txt
+++ b/spec-main/fixtures/snapshots/native-window-open.snapshot.txt
@@ -11,9 +11,9 @@
     {
       "show": true,
       "width": 800,
+      "height": 600,
+      "webContents": "[WebContents]",
       "title": "cool",
-      "backgroundColor": "blue",
-      "focusable": false,
       "webPreferences": {
         "nativeWindowOpen": true,
         "sandbox": true,
@@ -26,7 +26,9 @@
       "left": 10,
       "resizable": false,
       "x": 10,
-      "y": 5
+      "y": 5,
+      "backgroundColor": "blue",
+      "focusable": false
     },
     [],
     {
@@ -47,9 +49,9 @@
     {
       "show": true,
       "width": 800,
+      "height": 600,
+      "webContents": "[WebContents]",
       "title": "cool",
-      "backgroundColor": "blue",
-      "focusable": false,
       "webPreferences": {
         "zoomFactor": "2",
         "nativeWindowOpen": true,
@@ -61,7 +63,9 @@
       },
       "resizable": false,
       "x": 0,
-      "y": 10
+      "y": 10,
+      "backgroundColor": "blue",
+      "focusable": false
     },
     [],
     {
@@ -82,9 +86,9 @@
     {
       "show": true,
       "width": 800,
+      "height": 600,
+      "webContents": "[WebContents]",
       "title": "cool",
-      "backgroundColor": "gray",
-      "focusable": false,
       "webPreferences": {
         "nativeWindowOpen": true,
         "sandbox": true,
@@ -93,8 +97,10 @@
         "webviewTag": false,
         "nodeIntegrationInSubFrames": false
       },
+      "backgroundColor": "gray",
       "x": 100,
-      "y": 100
+      "y": 100,
+      "focusable": false
     },
     [],
     {
@@ -150,9 +156,9 @@
     {
       "show": false,
       "width": 800,
+      "height": 600,
+      "webContents": "[WebContents]",
       "title": "cool",
-      "backgroundColor": "blue",
-      "focusable": false,
       "webPreferences": {
         "nativeWindowOpen": true,
         "sandbox": true,
@@ -164,7 +170,9 @@
       "top": 1,
       "left": 1,
       "x": 1,
-      "y": 1
+      "y": 1,
+      "backgroundColor": "blue",
+      "focusable": false
     },
     [],
     {

--- a/spec-main/fixtures/snapshots/native-window-open.snapshot.txt
+++ b/spec-main/fixtures/snapshots/native-window-open.snapshot.txt
@@ -6,14 +6,14 @@
       "returnValue": "placeholder-guest-contents-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "show": true,
       "width": 800,
-      "height": 600,
-      "webContents": "[WebContents]",
-      "title": "frame name",
+      "title": "cool",
+      "backgroundColor": "blue",
+      "focusable": false,
       "webPreferences": {
         "nativeWindowOpen": true,
         "sandbox": true,
@@ -26,9 +26,7 @@
       "left": 10,
       "resizable": false,
       "x": 10,
-      "y": 5,
-      "backgroundColor": "blue",
-      "focusable": false
+      "y": 5
     },
     [],
     {
@@ -44,14 +42,14 @@
       "returnValue": "placeholder-guest-contents-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "show": true,
       "width": 800,
-      "height": 600,
-      "webContents": "[WebContents]",
-      "title": "frame name",
+      "title": "cool",
+      "backgroundColor": "blue",
+      "focusable": false,
       "webPreferences": {
         "zoomFactor": "2",
         "nativeWindowOpen": true,
@@ -63,9 +61,7 @@
       },
       "resizable": false,
       "x": 0,
-      "y": 10,
-      "backgroundColor": "blue",
-      "focusable": false
+      "y": 10
     },
     [],
     {
@@ -81,14 +77,14 @@
       "returnValue": "placeholder-guest-contents-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "show": true,
       "width": 800,
-      "height": 600,
-      "webContents": "[WebContents]",
-      "title": "frame name",
+      "title": "cool",
+      "backgroundColor": "gray",
+      "focusable": false,
       "webPreferences": {
         "nativeWindowOpen": true,
         "sandbox": true,
@@ -96,11 +92,9 @@
         "nodeIntegration": false,
         "webviewTag": false,
         "nodeIntegrationInSubFrames": false
-      },
-      "backgroundColor": "gray",
+      }
       "x": 100,
-      "y": 100,
-      "focusable": false
+      "y": 100
     },
     [],
     {
@@ -116,7 +110,7 @@
       "returnValue": "placeholder-guest-contents-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "show": true,
@@ -151,14 +145,14 @@
       "returnValue": "placeholder-guest-contents-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "show": false,
       "width": 800,
-      "height": 600,
-      "webContents": "[WebContents]",
-      "title": "frame name",
+      "title": "cool",
+      "backgroundColor": "blue",
+      "focusable": false,
       "webPreferences": {
         "nativeWindowOpen": true,
         "sandbox": true,
@@ -170,9 +164,7 @@
       "top": 1,
       "left": 1,
       "x": 1,
-      "y": 1,
-      "backgroundColor": "blue",
-      "focusable": false
+      "y": 1
     },
     [],
     {

--- a/spec-main/fixtures/snapshots/native-window-open.snapshot.txt
+++ b/spec-main/fixtures/snapshots/native-window-open.snapshot.txt
@@ -13,7 +13,6 @@
       "width": 800,
       "height": 600,
       "webContents": "[WebContents]",
-      "title": "cool",
       "webPreferences": {
         "nativeWindowOpen": true,
         "sandbox": true,
@@ -27,6 +26,7 @@
       "resizable": false,
       "x": 10,
       "y": 5,
+      "title": "cool",
       "backgroundColor": "blue",
       "focusable": false
     },
@@ -51,7 +51,6 @@
       "width": 800,
       "height": 600,
       "webContents": "[WebContents]",
-      "title": "cool",
       "webPreferences": {
         "zoomFactor": "2",
         "nativeWindowOpen": true,
@@ -64,6 +63,7 @@
       "resizable": false,
       "x": 0,
       "y": 10,
+      "title": "cool",
       "backgroundColor": "blue",
       "focusable": false
     },
@@ -88,7 +88,6 @@
       "width": 800,
       "height": 600,
       "webContents": "[WebContents]",
-      "title": "cool",
       "webPreferences": {
         "nativeWindowOpen": true,
         "sandbox": true,
@@ -100,6 +99,7 @@
       "backgroundColor": "gray",
       "x": 100,
       "y": 100,
+      "title": "cool",
       "focusable": false
     },
     [],
@@ -123,7 +123,6 @@
       "width": 800,
       "height": 600,
       "webContents": "[WebContents]",
-      "title": "sup",
       "webPreferences": {
         "nativeWindowOpen": true,
         "sandbox": true,
@@ -134,6 +133,7 @@
       },
       "x": 50,
       "y": 20,
+      "title": "sup",
       "backgroundColor": "blue",
       "focusable": false
     },
@@ -158,7 +158,6 @@
       "width": 800,
       "height": 600,
       "webContents": "[WebContents]",
-      "title": "cool",
       "webPreferences": {
         "nativeWindowOpen": true,
         "sandbox": true,
@@ -171,6 +170,7 @@
       "left": 1,
       "x": 1,
       "y": 1,
+      "title": "cool",
       "backgroundColor": "blue",
       "focusable": false
     },

--- a/spec-main/fixtures/snapshots/native-window-open.snapshot.txt
+++ b/spec-main/fixtures/snapshots/native-window-open.snapshot.txt
@@ -92,7 +92,7 @@
         "nodeIntegration": false,
         "webviewTag": false,
         "nodeIntegrationInSubFrames": false
-      }
+      },
       "x": 100,
       "y": 100
     },

--- a/spec-main/fixtures/snapshots/proxy-window-open.snapshot.txt
+++ b/spec-main/fixtures/snapshots/proxy-window-open.snapshot.txt
@@ -7,24 +7,24 @@
       "processId": "placeholder-process-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
+      "show": true,
+      "width": 800,
+      "height": 600,
+      "title": "frame-name",
       "top": 5,
       "left": 10,
       "resizable": false,
       "x": 10,
       "y": 5,
-      "title": "frame name",
       "webPreferences": {
         "nodeIntegration": false,
         "webviewTag": false,
         "nodeIntegrationInSubFrames": false,
         "openerId": "placeholder-opener-id"
-      },
-      "width": 800,
-      "height": 600,
-      "show": false
+      }
     },
     [],
     {
@@ -41,23 +41,23 @@
       "processId": "placeholder-process-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
+      "show": true,
+      "width": 800,
+      "height": 600,
+      "title": "frame-name",
       "resizable": false,
       "x": 0,
       "y": 10,
-      "title": "frame name",
       "webPreferences": {
         "zoomFactor": "2",
         "nodeIntegration": false,
         "webviewTag": false,
         "nodeIntegrationInSubFrames": false,
         "openerId": "placeholder-opener-id"
-      },
-      "width": 800,
-      "height": 600,
-      "show": false
+      }
     },
     [],
     {
@@ -74,9 +74,13 @@
       "processId": "placeholder-process-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
+      "show": true,
+      "width": 800,
+      "height": 600,
+      "title": "frame-name",
       "backgroundColor": "gray",
       "webPreferences": {
         "nodeIntegration": false,
@@ -87,10 +91,6 @@
       },
       "x": 100,
       "y": 100,
-      "title": "frame name",
-      "width": 800,
-      "height": 600,
-      "show": false
     },
     [],
     {
@@ -107,21 +107,21 @@
       "processId": "placeholder-process-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
+      "show": true,
+      "width": 800,
+      "height": 600,
+      "title": "sup",
       "x": 50,
       "y": 20,
-      "title": "sup",
       "webPreferences": {
         "nodeIntegration": false,
         "webviewTag": false,
         "nodeIntegrationInSubFrames": false,
         "openerId": "placeholder-opener-id"
-      },
-      "width": 800,
-      "height": 600,
-      "show": false
+      }
     },
     [],
     {
@@ -138,23 +138,23 @@
       "processId": "placeholder-process-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "show": false,
+      "width": 800,
+      "height": 600,
+      "title": "frame-name",
       "top": 1,
       "left": 1,
       "x": 1,
       "y": 1,
-      "title": "frame name",
       "webPreferences": {
         "nodeIntegration": false,
         "webviewTag": false,
         "nodeIntegrationInSubFrames": false,
         "openerId": "placeholder-opener-id"
-      },
-      "width": 800,
-      "height": 600
+      }
     },
     [],
     {

--- a/spec-main/fixtures/snapshots/proxy-window-open.snapshot.txt
+++ b/spec-main/fixtures/snapshots/proxy-window-open.snapshot.txt
@@ -154,7 +154,7 @@
         "openerId": "placeholder-opener-id"
       },
       "width": 800,
-      "height": 600,
+      "height": 600
     },
     [],
     {

--- a/spec-main/fixtures/snapshots/proxy-window-open.snapshot.txt
+++ b/spec-main/fixtures/snapshots/proxy-window-open.snapshot.txt
@@ -90,7 +90,7 @@
         "backgroundColor": "gray"
       },
       "x": 100,
-      "y": 100,
+      "y": 100
     },
     [],
     {

--- a/spec-main/fixtures/snapshots/proxy-window-open.snapshot.txt
+++ b/spec-main/fixtures/snapshots/proxy-window-open.snapshot.txt
@@ -10,21 +10,21 @@
     "frame-name",
     "new-window",
     {
-      "show": true,
-      "width": 800,
-      "height": 600,
-      "title": "frame-name",
       "top": 5,
       "left": 10,
       "resizable": false,
       "x": 10,
       "y": 5,
+      "title": "frame-name",
       "webPreferences": {
         "nodeIntegration": false,
         "webviewTag": false,
         "nodeIntegrationInSubFrames": false,
         "openerId": "placeholder-opener-id"
-      }
+      },
+      "width": 800,
+      "height": 600,
+      "show": false
     },
     [],
     {
@@ -44,20 +44,20 @@
     "frame-name",
     "new-window",
     {
-      "show": true,
-      "width": 800,
-      "height": 600,
-      "title": "frame-name",
       "resizable": false,
       "x": 0,
       "y": 10,
+      "title": "frame-name",
       "webPreferences": {
         "zoomFactor": "2",
         "nodeIntegration": false,
         "webviewTag": false,
         "nodeIntegrationInSubFrames": false,
         "openerId": "placeholder-opener-id"
-      }
+      },
+      "width": 800,
+      "height": 600,
+      "show": false
     },
     [],
     {
@@ -77,10 +77,6 @@
     "frame-name",
     "new-window",
     {
-      "show": true,
-      "width": 800,
-      "height": 600,
-      "title": "frame-name",
       "backgroundColor": "gray",
       "webPreferences": {
         "nodeIntegration": false,
@@ -90,7 +86,11 @@
         "backgroundColor": "gray"
       },
       "x": 100,
-      "y": 100
+      "y": 100,
+      "title": "frame-name",
+      "width": 800,
+      "height": 600,
+      "show": false
     },
     [],
     {
@@ -110,18 +110,18 @@
     "frame-name",
     "new-window",
     {
-      "show": true,
-      "width": 800,
-      "height": 600,
-      "title": "sup",
       "x": 50,
       "y": 20,
+      "title": "sup",
       "webPreferences": {
         "nodeIntegration": false,
         "webviewTag": false,
         "nodeIntegrationInSubFrames": false,
         "openerId": "placeholder-opener-id"
-      }
+      },
+      "width": 800,
+      "height": 600,
+      "show": false
     },
     [],
     {
@@ -142,19 +142,19 @@
     "new-window",
     {
       "show": false,
-      "width": 800,
-      "height": 600,
-      "title": "frame-name",
       "top": 1,
       "left": 1,
       "x": 1,
       "y": 1,
+      "title": "frame-name",
       "webPreferences": {
         "nodeIntegration": false,
         "webviewTag": false,
         "nodeIntegrationInSubFrames": false,
         "openerId": "placeholder-opener-id"
-      }
+      },
+      "width": 800,
+      "height": 600,
     },
     [],
     {

--- a/spec-main/guest-window-manager-spec.ts
+++ b/spec-main/guest-window-manager-spec.ts
@@ -9,7 +9,7 @@ function genSnapshot (browserWindow: BrowserWindow, features: string) {
     browserWindow.webContents.on('new-window', (...args: any[]) => {
       resolve([features, ...args]);
     });
-    browserWindow.webContents.executeJavaScript(`window.open('about:blank', 'frame name', '${features}')`);
+    browserWindow.webContents.executeJavaScript(`window.open('about:blank', 'frame-name', '${features}') && true`);
   });
 }
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Backport of https://github.com/electron/electron/pull/27521

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> Fixed native window.open() to not use _windowName/frameName_ as title by default
