### PR TITLE
fix: check web_contents() for destroyed WebContents

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1078,7 +1078,7 @@ content::WebContents* WebContents::OpenURLFromTab(
     return nullptr;
   }
 
-  if (!weak_this)
+  if (!weak_this || !web_contents())
     return nullptr;
 
   content::NavigationController::LoadURLParams load_url_params(params.url);
@@ -1411,7 +1411,7 @@ void WebContents::RenderProcessGone(base::TerminationStatus status) {
   Emit("crashed", status == base::TERMINATION_STATUS_PROCESS_WAS_KILLED);
 
   // User might destroy WebContents in the crashed event.
-  if (!weak_this)
+  if (!weak_this || !web_contents())
     return;
 
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
@@ -1482,7 +1482,7 @@ void WebContents::DidFinishLoad(content::RenderFrameHost* render_frame_host,
   // ⚠️WARNING!⚠️
   // Emit() triggers JS which can call destroy() on |this|. It's not safe to
   // assume that |this| points to valid memory at this point.
-  if (is_main_frame && weak_this)
+  if (is_main_frame && weak_this && web_contents())
     Emit("did-finish-load");
 }
 
@@ -1886,6 +1886,7 @@ void WebContents::WebContentsDestroyed() {
   // also do not want any method to be used, so just mark as destroyed here.
   MarkDestroyed();
 
+  Observe(nullptr);  // this->web_contents() will return nullptr
   Emit("destroyed");
 
   // For guest view based on OOPIF, the WebContents is released by the embedder
@@ -2017,7 +2018,7 @@ void WebContents::LoadURL(const GURL& url,
   // ⚠️WARNING!⚠️
   // LoadURLWithParams() triggers JS events which can call destroy() on |this|.
   // It's not safe to assume that |this| points to valid memory at this point.
-  if (!weak_this)
+  if (!weak_this || !web_contents())
     return;
 
   // Required to make beforeunload handler work.

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -2016,6 +2016,13 @@ describe('webContents module', () => {
       });
       contents.loadURL('about:blank').then(() => contents.forcefullyCrashRenderer());
     });
+
+    it('does not crash main process when quiting in it', async () => {
+      const appPath = path.join(mainFixturesPath, 'apps', 'quit', 'main.js');
+      const appProcess = ChildProcess.spawn(process.execPath, [appPath]);
+      const [code] = await emittedOnce(appProcess, 'close');
+      expect(code).to.equal(0);
+    });
   });
 
   it('emits a cancelable event before creating a child webcontents', async () => {

--- a/spec-main/fixtures/apps/quit/main.js
+++ b/spec-main/fixtures/apps/quit/main.js
@@ -1,0 +1,10 @@
+const { app, BrowserWindow } = require('electron');
+
+app.once('ready', () => {
+  const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true } });
+  w.webContents.once('crashed', () => {
+    app.quit();
+  });
+  w.webContents.loadURL('about:blank');
+  w.webContents.executeJavaScript('process.crash()');
+});


### PR DESCRIPTION
#### Description of Change

When Electron is quitting, it may happen that the `content::WebContents` is destroyed while `electron::api::WebContents` is still alive.  This was causing a few CI flakes.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none