### PR TITLE
fix: isFullScreen typo

### DIFF
--- a/lib/browser/api/base-window.ts
+++ b/lib/browser/api/base-window.ts
@@ -43,7 +43,7 @@ Object.defineProperty(BaseWindow.prototype, 'kiosk', {
 });
 
 Object.defineProperty(BaseWindow.prototype, 'documentEdited', {
-  get: function () { return this.isFullscreen(); },
+  get: function () { return this.isFullScreen(); },
   set: function (edited) { this.setDocumentEdited(edited); }
 });
 

--- a/lib/browser/api/base-window.ts
+++ b/lib/browser/api/base-window.ts
@@ -43,7 +43,7 @@ Object.defineProperty(BaseWindow.prototype, 'kiosk', {
 });
 
 Object.defineProperty(BaseWindow.prototype, 'documentEdited', {
-  get: function () { return this.isFullScreen(); },
+  get: function () { return this.isDocumentEdited(); },
   set: function (edited) { this.setDocumentEdited(edited); }
 });
 


### PR DESCRIPTION
#### Description of Change
`TypeError: this.isFullscreen is not a function`
I believe this should fix `isDocumentEdited()` api

#### Checklist 
* [x]  PR description included and stakeholders cc'd

#### Release Notes
Notes: none
