### PR TITLE
fix: cap sendInputEvent text length at n-1

### DIFF
--- a/shell/common/gin_converters/blink_converter.cc
+++ b/shell/common/gin_converters/blink_converter.cc
@@ -209,9 +209,9 @@ bool Converter<blink::WebKeyboardEvent>::FromV8(v8::Isolate* isolate,
     size_t text_length_cap = blink::WebKeyboardEvent::kTextLengthCap;
     base::string16 text16 = base::UTF8ToUTF16(str);
 
-    memset(out->text, 0, text_length_cap);
-    memset(out->unmodified_text, 0, text_length_cap);
-    for (size_t i = 0; i < std::min(text_length_cap, text16.size()); ++i) {
+    std::fill_n(out->text, text_length_cap, 0);
+    std::fill_n(out->unmodified_text, text_length_cap, 0);
+    for (size_t i = 0; i < std::min(text_length_cap - 1, text16.size()); ++i) {
       out->text[i] = text16[i];
       out->unmodified_text[i] = text16[i];
     }


### PR DESCRIPTION
#### Description of Change
This fixes two bugs with `sendInputEvent`, detected by ASan.

1. The call to `memset` was not clearing the full buffer, as the size of each
   element of the array is 2 bytes, not 1.
2. This buffer is at some later point passed to string() as a raw char16
   pointer, which causes the length of the string to be computed by seeking for
   a null terminator. However, this results in an out-of-bounds access as we
   often fill all 4 characters of both `text` and `unmodified_text` with
   non-null values.

It looks like this code was inspired by
[BuildCharEvent](https://source.chromium.org/chromium/chromium/src/+/master:content/renderer/pepper/event_conversion.cc;l=442-458;drc=e1f0247fb2114a48a94b60c887b447a939efd64c)
in content/renderer/pepper/event_conversion.cc, so I've updated this to be a
little closer to that code. I think the upstream code _also_ has this issue but
gets away with it because it doesn't set `unmodified_text`, so there's always a
`\0` after `text` due to the struct layout.

I'm not sure if we actually need `unmodified_text`---the pepper converter does
not fill it in.

Further, we fill `text` from `keyCode`, which is a bit of an odd choice. The
value is supposed to represent the text that should be inserted, which for the
key code `Escape` is not `"Esca"`. It's not clear to me what the "right" path
forward is here, but this at least prevents the OOB access.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an out-of-bounds access in `WebContents.sendInputEvent`.
