### PR TITLE
fix: replace default frameName title with null check

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -588,7 +588,6 @@ WebContents.prototype._init = function () {
         width: 800,
         height: 600,
         webContents,
-        title: frameName,
         webPreferences,
         ...options
       };

--- a/spec-main/fixtures/snapshots/native-window-open.snapshot.txt
+++ b/spec-main/fixtures/snapshots/native-window-open.snapshot.txt
@@ -6,14 +6,13 @@
       "returnValue": "placeholder-guest-contents-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "show": true,
       "width": 800,
       "height": 600,
       "webContents": "[WebContents]",
-      "title": "frame name",
       "webPreferences": {
         "nativeWindowOpen": true,
         "sandbox": true,
@@ -27,6 +26,7 @@
       "resizable": false,
       "x": 10,
       "y": 5,
+      "title": "cool",
       "backgroundColor": "blue",
       "focusable": false
     },
@@ -44,14 +44,13 @@
       "returnValue": "placeholder-guest-contents-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "show": true,
       "width": 800,
       "height": 600,
       "webContents": "[WebContents]",
-      "title": "frame name",
       "webPreferences": {
         "zoomFactor": "2",
         "nativeWindowOpen": true,
@@ -64,6 +63,7 @@
       "resizable": false,
       "x": 0,
       "y": 10,
+      "title": "cool",
       "backgroundColor": "blue",
       "focusable": false
     },
@@ -81,14 +81,13 @@
       "returnValue": "placeholder-guest-contents-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "show": true,
       "width": 800,
       "height": 600,
       "webContents": "[WebContents]",
-      "title": "frame name",
       "webPreferences": {
         "nativeWindowOpen": true,
         "sandbox": true,
@@ -100,6 +99,7 @@
       "backgroundColor": "gray",
       "x": 100,
       "y": 100,
+      "title": "cool",
       "focusable": false
     },
     [],
@@ -116,14 +116,13 @@
       "returnValue": "placeholder-guest-contents-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "show": true,
       "width": 800,
       "height": 600,
       "webContents": "[WebContents]",
-      "title": "sup",
       "webPreferences": {
         "nativeWindowOpen": true,
         "sandbox": true,
@@ -134,6 +133,7 @@
       },
       "x": 50,
       "y": 20,
+      "title": "sup",
       "backgroundColor": "blue",
       "focusable": false
     },
@@ -151,14 +151,13 @@
       "returnValue": "placeholder-guest-contents-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "show": false,
       "width": 800,
       "height": 600,
       "webContents": "[WebContents]",
-      "title": "frame name",
       "webPreferences": {
         "nativeWindowOpen": true,
         "sandbox": true,
@@ -171,6 +170,7 @@
       "left": 1,
       "x": 1,
       "y": 1,
+      "title": "cool",
       "backgroundColor": "blue",
       "focusable": false
     },

--- a/spec-main/fixtures/snapshots/proxy-window-open.snapshot.txt
+++ b/spec-main/fixtures/snapshots/proxy-window-open.snapshot.txt
@@ -7,7 +7,7 @@
       "processId": "placeholder-process-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "top": 5,
@@ -15,7 +15,7 @@
       "resizable": false,
       "x": 10,
       "y": 5,
-      "title": "frame name",
+      "title": "frame-name",
       "webPreferences": {
         "nodeIntegration": false,
         "webviewTag": false,
@@ -41,13 +41,13 @@
       "processId": "placeholder-process-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "resizable": false,
       "x": 0,
       "y": 10,
-      "title": "frame name",
+      "title": "frame-name",
       "webPreferences": {
         "zoomFactor": "2",
         "nodeIntegration": false,
@@ -74,7 +74,7 @@
       "processId": "placeholder-process-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "backgroundColor": "gray",
@@ -87,7 +87,7 @@
       },
       "x": 100,
       "y": 100,
-      "title": "frame name",
+      "title": "frame-name",
       "width": 800,
       "height": 600,
       "show": false
@@ -107,7 +107,7 @@
       "processId": "placeholder-process-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "x": 50,
@@ -138,7 +138,7 @@
       "processId": "placeholder-process-id"
     },
     "about:blank",
-    "frame name",
+    "frame-name",
     "new-window",
     {
       "show": false,
@@ -146,7 +146,7 @@
       "left": 1,
       "x": 1,
       "y": 1,
-      "title": "frame name",
+      "title": "frame-name",
       "webPreferences": {
         "nodeIntegration": false,
         "webviewTag": false,

--- a/spec-main/guest-window-manager-spec.ts
+++ b/spec-main/guest-window-manager-spec.ts
@@ -9,7 +9,7 @@ function genSnapshot (browserWindow: BrowserWindow, features: string) {
     browserWindow.webContents.on('new-window', (...args: any[]) => {
       resolve([features, ...args]);
     });
-    browserWindow.webContents.executeJavaScript(`window.open('about:blank', 'frame name', '${features}')`);
+    browserWindow.webContents.executeJavaScript(`window.open('about:blank', 'frame-name', '${features}') && true`);
   });
 }
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Backport of #27521

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> Fixed native window.open() to not use _windowName/frameName_ as title by default
