### PR TITLE
fix: libuv hang when nodeIntegrationInSubframes enabled

### DIFF
--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -531,6 +531,18 @@ void NodeBindings::LoadEnvironment(node::Environment* env) {
 }
 
 void NodeBindings::PrepareMessageLoop() {
+#if !defined(OS_WIN)
+  int handle = uv_backend_fd(uv_loop_);
+#else
+  HANDLE handle = uv_loop_->iocp;
+#endif
+
+  // If the backend fd hasn't changed, don't proceed.
+  if (handle == handle_)
+    return;
+
+  handle_ = handle;
+
   // Add dummy handle for libuv, otherwise libuv would quit when there is
   // nothing to do.
   uv_async_init(uv_loop_, dummy_uv_handle_.get(), nullptr);

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -159,6 +159,12 @@ class NodeBindings {
   // Isolate data used in creating the environment
   node::IsolateData* isolate_data_ = nullptr;
 
+#if defined(OS_WIN)
+  HANDLE handle_;
+#else
+  int handle_ = -1;
+#endif
+
   base::WeakPtrFactory<NodeBindings> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(NodeBindings);

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -112,9 +112,8 @@ void ElectronRendererClient::DidCreateScriptContext(
   bool should_load_node =
       (is_main_frame || is_devtools || allow_node_in_subframes) &&
       !IsWebViewFrame(renderer_context, render_frame);
-  if (!should_load_node) {
+  if (!should_load_node)
     return;
-  }
 
   injected_frames_.insert(render_frame);
 


### PR DESCRIPTION
Backport of #27582.

See that PR for details.

Notes: Fixed an issue where libuv might hang with multiple subframes when `nodeIntegrationInSubframes` is enabled.