### PR TITLE
docs: auto update downloading multiple times

### DIFF
--- a/docs/api/auto-updater.md
+++ b/docs/api/auto-updater.md
@@ -118,6 +118,9 @@ Returns `String` - The current update feed URL.
 Asks the server whether there is an update. You must call `setFeedURL` before
 using this API.
 
+**Note:** If an update is available it will be downloaded automatically.
+Calling `autoUpdater.checkForUpdates()` twice will download the update two times.
+
 ### `autoUpdater.quitAndInstall()`
 
 Restarts the app and installs the update after it has been downloaded. It


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Checking for updates every minute will cause the autoUpdater to fail if the internet connection is slow. This happens because the autoUpdater will download the update automatically which causes the previous download to be overridden.

This is my attempt to document it a little bit better so other people are not running into this situation. We fixed it by tracking if an update is already downloading and not calling `autoUpdate.checkForUpdates()` in this case.

Currently, the auto-update guide shows a one-minute check for update interval which should probably be improved as well.
https://www.electronjs.org/docs/tutorial/updates#implementing-updates-in-your-app

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added


#### Release Notes

Notes: None