### PR TITLE
fix: WebContents.capturePage can freeze browser process

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -381,6 +381,13 @@ base::IDMap<WebContents*>& GetAllWebContents() {
 // Called when CapturePage is done.
 void OnCapturePageDone(gin_helper::Promise<gfx::Image> promise,
                        const SkBitmap& bitmap) {
+  auto ui_task_runner = content::GetUIThreadTaskRunner({});
+  if (!ui_task_runner->RunsTasksInCurrentSequence()) {
+    ui_task_runner->PostTask(
+        FROM_HERE,
+        base::BindOnce(&OnCapturePageDone, std::move(promise), bitmap));
+    return;
+  }
   // Hack to enable transparency in captured image
   promise.Resolve(gfx::Image::CreateFrom1xBitmap(bitmap));
 }

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1353,6 +1353,22 @@ describe('BrowserWindow module', () => {
       // Values can be 0,2,3,4, or 6. We want 6, which is RGB + Alpha
       expect(imgBuffer[25]).to.equal(6);
     });
+
+    it('does not freeze browser process when called on hidden page', async() => {
+      await new Promise<void>((resolve) => {
+        const w = new BrowserWindow({ show: true });
+        w.on('hide', () => {
+          // We have to wait a moment as 'hide' is called too soon
+          // and windows isn't really hidden at this point.
+          setTimeout( async () => {
+            await w.webContents.capturePage();
+            resolve();
+          }, 100);
+        });
+        w.webContents.loadURL('about:blank');
+        w.hide();
+      });
+    });
   });
 
   describe('BrowserWindow.setProgressBar(progress)', () => {


### PR DESCRIPTION
When BrowserWindow.webContents.capturePage is called on hidden
page we try to resolve its promise on the worker thread instead of
the main thread of the browser process. It happens because when page
is hidden compositor calls the callback OnCapturePageDone immediately
without posting it to the main thread). When it happens worker thread
dead locks as it tries to acquire lock kept by the main thread (the
lock which guards the promise returned by capturePage).

This change fixes the problem by assuring that promise is always
resolved on the main thread of the browser process.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed possible dead lock on call to WebContents.capturePage