### PR TITLE
fix: prevent race-condition in electron.net

### DIFF
--- a/lib/browser/api/net.ts
+++ b/lib/browser/api/net.ts
@@ -119,10 +119,13 @@ class IncomingMessage extends Readable {
       this._shouldPush = this.push(chunk);
     }
     if (this._shouldPush && this._resume) {
-      this._resume();
       // Reset the callback, so that a new one is used for each
-      // batch of throttled data
+      // batch of throttled data. Do this before calling resume to avoid a
+      // potential race-condition
+      const resume = this._resume;
       this._resume = null;
+
+      resume();
     }
   }
 


### PR DESCRIPTION
#### Description of Change

Fixes a race-condition in electron.net reported in issue https://github.com/electron/electron/issues/27805.

The race exists in the implementation of [IncomingMessage](https://github.com/electron/electron/blob/master/lib/browser/api/net.ts#L38) in the [_pushInternalData](https://github.com/electron/electron/blob/master/lib/browser/api/net.ts#L122) function. Under some circumstances, e.g. when a pipe throttles the response data, the callback stored in `this._resume` can be updated by [_storeInternalData](https://github.com/electron/electron/blob/master/lib/browser/api/net.ts#L109), triggered by the callback itself, before it is [reset to `null`](https://github.com/electron/electron/blob/master/lib/browser/api/net.ts#L125). This results in it being overwritten with `null`, effectively stalling the download indefinitely waiting for permission to continue.

The suggested fix simply uses a local proxy variable to cache the callback value and reset it before actually executing the callback, preventing the race.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed race condition in electron.net implementation.
