### PR TITLE
build: update docker images to node 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ parameters:
 # Build machines configs.
 docker-image: &docker-image
   docker:
-    - image: electron.azurecr.io/build:af55efcef6f32033def26b19ad307eca1e85d1e9
+    - image: electron.azurecr.io/build:6555a80939fb4c3ddf9343b3f140e573f40de225
 
 machine-linux-medium: &machine-linux-medium
   <<: *docker-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ parameters:
 # Build machines configs.
 docker-image: &docker-image
   docker:
-    - image: electron.azurecr.io/build:4cec2c5ab66765caa724e37bae2bffb9b29722a5
+    - image: electron.azurecr.io/build:af55efcef6f32033def26b19ad307eca1e85d1e9
 
 machine-linux-medium: &machine-linux-medium
   <<: *docker-image

--- a/vsts-arm32v7.yml
+++ b/vsts-arm32v7.yml
@@ -1,7 +1,7 @@
 resources:
   containers:
   - container: arm32v7-test-container
-    image: electron.azurecr.io/build:arm32v7-4cec2c5ab66765caa724e37bae2bffb9b29722a5
+    image: electron.azurecr.io/build:arm32v7-af55efcef6f32033def26b19ad307eca1e85d1e9
     options: --shm-size 128m
 
 jobs:

--- a/vsts-arm32v7.yml
+++ b/vsts-arm32v7.yml
@@ -1,7 +1,7 @@
 resources:
   containers:
   - container: arm32v7-test-container
-    image: electron.azurecr.io/build:arm32v7-af55efcef6f32033def26b19ad307eca1e85d1e9
+    image: electron.azurecr.io/build:arm32v7-6555a80939fb4c3ddf9343b3f140e573f40de225
     options: --shm-size 128m
 
 jobs:

--- a/vsts-arm64v8.yml
+++ b/vsts-arm64v8.yml
@@ -1,7 +1,7 @@
 resources:
   containers:
   - container: arm64v8-test-container
-    image: electron.azurecr.io/build:arm64v8-4cec2c5ab66765caa724e37bae2bffb9b29722a5
+    image: electron.azurecr.io/build:arm64v8-af55efcef6f32033def26b19ad307eca1e85d1e9
     options: --shm-size 128m
 
 jobs:

--- a/vsts-arm64v8.yml
+++ b/vsts-arm64v8.yml
@@ -1,7 +1,7 @@
 resources:
   containers:
   - container: arm64v8-test-container
-    image: electron.azurecr.io/build:arm64v8-af55efcef6f32033def26b19ad307eca1e85d1e9
+    image: electron.azurecr.io/build:arm64v8-6555a80939fb4c3ddf9343b3f140e573f40de225
     options: --shm-size 128m
 
 jobs:


### PR DESCRIPTION
Pulls in https://github.com/electron/build-images/pull/5 which updates our CI to use node 14

Notes: none