### PR TITLE
chore: revert webFrameMain.executeJavaScriptInIsolatedWorld method

### DIFF
--- a/docs/api/web-frame-main.md
+++ b/docs/api/web-frame-main.md
@@ -86,17 +86,6 @@ In the browser window some HTML APIs like `requestFullScreen` can only be
 invoked by a gesture from the user. Setting `userGesture` to `true` will remove
 this limitation.
 
-#### `frame.executeJavaScriptInIsolatedWorld(worldId, code[, userGesture])`
-
-* `worldId` Integer - The ID of the world to run the javascript in, `0` is the default world, `999` is the world used by Electron's `contextIsolation` feature.  You can provide any integer here.
-* `code` String
-* `userGesture` Boolean (optional) - Default is `false`.
-
-Returns `Promise<unknown>` - A promise that resolves with the result of the executed
-code or is rejected if execution throws or results in a rejected promise.
-
-Works like `executeJavaScript` but evaluates `scripts` in an isolated context.
-
 #### `frame.reload()`
 
 Returns `boolean` - Whether the reload was initiated successfully. Only results in `false` when the frame has no history.

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -79,10 +79,6 @@ class WebFrameMain : public gin::Wrappable<WebFrameMain>,
 
   v8::Local<v8::Promise> ExecuteJavaScript(gin::Arguments* args,
                                            const base::string16& code);
-  v8::Local<v8::Promise> ExecuteJavaScriptInIsolatedWorld(
-      gin::Arguments* args,
-      int world_id,
-      const base::string16& code);
   bool Reload();
   void Send(v8::Isolate* isolate,
             bool internal,

--- a/spec-main/api-web-frame-main-spec.ts
+++ b/spec-main/api-web-frame-main-spec.ts
@@ -148,19 +148,6 @@ describe('webFrameMain module', () => {
     });
   });
 
-  describe('WebFrame.executeJavaScriptInIsolatedWorld', () => {
-    it('can inject code into any subframe', async () => {
-      const w = new BrowserWindow({ show: false, webPreferences: { contextIsolation: true } });
-      await w.loadFile(path.join(subframesPath, 'frame-with-frame-container.html'));
-      const webFrame = w.webContents.mainFrame;
-
-      const getUrl = (frame: WebFrameMain) => frame.executeJavaScriptInIsolatedWorld(999, 'location.href');
-      expect(await getUrl(webFrame)).to.equal(fileUrl('frame-with-frame-container.html'));
-      expect(await getUrl(webFrame.frames[0])).to.equal(fileUrl('frame-with-frame.html'));
-      expect(await getUrl(webFrame.frames[0].frames[0])).to.equal(fileUrl('frame.html'));
-    });
-  });
-
   describe('WebFrame.reload', () => {
     it('reloads a frame', async () => {
       const w = new BrowserWindow({ show: false, webPreferences: { contextIsolation: true } });


### PR DESCRIPTION
#### Description of Change

Addresses #27862.

The upcoming `WebFrameMain` API implements `executeJavaScriptInIsolatedWorld` with an interface that doesn't match that of `WebContents`. Because we need to reconcile these two APIs, this PR temporarily reverts the API before the Electron 12 stable release. We'll then restore the refactored API both in master and in a 12-x-y minor release.

_Note: I targeted master and a 12-x-y backport to keep master and 12 in sync, but since this is being specifically reverted for 12, happy to change this and only target 12._

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Reverted `WebFrameMain.executeJavaScriptInIsolatedWorld()`
