### PR TITLE
fix: warning when worldSafeExecuteJavaScript is disabled

### DIFF
--- a/lib/renderer/api/web-frame.ts
+++ b/lib/renderer/api/web-frame.ts
@@ -48,8 +48,10 @@ class WebFrame extends EventEmitter {
   }
 }
 
-const { hasSwitch } = process._linkedBinding('electron_common_command_line');
-const worldSafeJS = hasSwitch('world-safe-execute-javascript') && hasSwitch('context-isolation');
+const contextIsolation = binding.getWebPreference(window, 'contextIsolation');
+const worldSafeExecuteJavaScript = binding.getWebPreference(window, 'worldSafeExecuteJavaScript');
+
+const worldSafeJS = worldSafeExecuteJavaScript || !contextIsolation;
 
 // Populate the methods.
 for (const name in binding) {


### PR DESCRIPTION
#### Description of Change
Command-line switches are no longer used to pass `webPreferences` to the renderer, replace with `getWebPreference`.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed warning when `worldSafeExecuteJavaScript` is disabled.