### PR TITLE
fix: values return from the ctx bridge with dynamic property support should themselves support dynamic properties

### DIFF
--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -475,13 +475,15 @@ v8::MaybeLocal<v8::Object> CreateProxyForAPI(
             v8::Local<v8::Value> setter_proxy;
             if (!getter.IsEmpty()) {
               if (!PassValueToOtherContext(source_context, destination_context,
-                                           getter, object_cache, false, 1)
+                                           getter, object_cache,
+                                           support_dynamic_properties, 1)
                        .ToLocal(&getter_proxy))
                 continue;
             }
             if (!setter.IsEmpty()) {
               if (!PassValueToOtherContext(source_context, destination_context,
-                                           setter, object_cache, false, 1)
+                                           setter, object_cache,
+                                           support_dynamic_properties, 1)
                        .ToLocal(&setter_proxy))
                 continue;
             }

--- a/spec-main/api-context-bridge-spec.ts
+++ b/spec-main/api-context-bridge-spec.ts
@@ -1053,6 +1053,24 @@ describe('contextBridge', () => {
             expect(result).to.equal('hi there');
           });
 
+          it('should work with nested getters', async () => {
+            await makeBindingWindow(() => {
+              contextBridge.internalContextBridge!.overrideGlobalValueWithDynamicPropsFromIsolatedWorld(['thing'], {
+                get foo () {
+                  return {
+                    get bar () {
+                      return 'hi there';
+                    }
+                  };
+                }
+              });
+            });
+            const result = await callWithBindings(async (root: any) => {
+              return root.thing.foo.bar;
+            });
+            expect(result).to.equal('hi there');
+          });
+
           it('should work with setters', async () => {
             await makeBindingWindow(() => {
               let a: any = null;
@@ -1068,6 +1086,29 @@ describe('contextBridge', () => {
             const result = await callWithBindings(async (root: any) => {
               root.thing.foo = 123;
               return root.thing.foo;
+            });
+            expect(result).to.equal(124);
+          });
+
+          it('should work with nested getter / setter combos', async () => {
+            await makeBindingWindow(() => {
+              let a: any = null;
+              contextBridge.internalContextBridge!.overrideGlobalValueWithDynamicPropsFromIsolatedWorld(['thing'], {
+                get thingy () {
+                  return {
+                    get foo () {
+                      return a;
+                    },
+                    set foo (arg: any) {
+                      a = arg + 1;
+                    }
+                  };
+                }
+              });
+            });
+            const result = await callWithBindings(async (root: any) => {
+              root.thing.thingy.foo = 123;
+              return root.thing.thingy.foo;
             });
             expect(result).to.equal(124);
           });


### PR DESCRIPTION
Backport of #27899.

See that PR for details.

Notes: Fixed issue where window.open() would not return an object with a location.href setter when contextIsolation is enabled and nativeWindowOpen is disabled.