### PR TITLE
fix: navigator.setAppBadge/clearAppBadge from a service worker

### DIFF
--- a/shell/browser/badging/badge_manager.cc
+++ b/shell/browser/badging/badge_manager.cc
@@ -47,6 +47,27 @@ void BadgeManager::BindFrameReceiver(
                                 std::move(context));
 }
 
+void BadgeManager::BindServiceWorkerReceiver(
+    content::RenderProcessHost* service_worker_process_host,
+    const GURL& service_worker_scope,
+    mojo::PendingReceiver<blink::mojom::BadgeService> receiver) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+
+  auto* browser_context = service_worker_process_host->GetBrowserContext();
+
+  auto* badge_manager =
+      badging::BadgeManagerFactory::GetInstance()->GetForBrowserContext(
+          browser_context);
+  if (!badge_manager)
+    return;
+
+  auto context = std::make_unique<BadgeManager::ServiceWorkerBindingContext>(
+      service_worker_process_host->GetID(), service_worker_scope);
+
+  badge_manager->receivers_.Add(badge_manager, std::move(receiver),
+                                std::move(context));
+}
+
 std::string BadgeManager::GetBadgeString(base::Optional<int> badge_content) {
   if (!badge_content)
     return "•";

--- a/shell/browser/badging/badge_manager.h
+++ b/shell/browser/badging/badge_manager.h
@@ -37,6 +37,10 @@ class BadgeManager : public KeyedService, public blink::mojom::BadgeService {
   static void BindFrameReceiver(
       content::RenderFrameHost* frame,
       mojo::PendingReceiver<blink::mojom::BadgeService> receiver);
+  static void BindServiceWorkerReceiver(
+      content::RenderProcessHost* service_worker_process_host,
+      const GURL& service_worker_scope,
+      mojo::PendingReceiver<blink::mojom::BadgeService> receiver);
 
   // Determines the text to put on the badge based on some badge_content.
   static std::string GetBadgeString(base::Optional<int> badge_content);
@@ -64,6 +68,21 @@ class BadgeManager : public KeyedService, public blink::mojom::BadgeService {
    private:
     int process_id_;
     int frame_id_;
+  };
+
+  // The BindingContext for ServiceWorkerGlobalScope execution contexts.
+  class ServiceWorkerBindingContext final : public BindingContext {
+   public:
+    ServiceWorkerBindingContext(int process_id, const GURL& scope)
+        : process_id_(process_id), scope_(scope) {}
+    ~ServiceWorkerBindingContext() override = default;
+
+    int GetProcessId() { return process_id_; }
+    GURL GetScope() { return scope_; }
+
+   private:
+    int process_id_;
+    GURL scope_;
   };
 
   // blink::mojom::BadgeService:

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1776,4 +1776,12 @@ content::BluetoothDelegate* ElectronBrowserClient::GetBluetoothDelegate() {
   return bluetooth_delegate_.get();
 }
 
+void ElectronBrowserClient::BindBadgeServiceReceiverFromServiceWorker(
+    content::RenderProcessHost* service_worker_process_host,
+    const GURL& service_worker_scope,
+    mojo::PendingReceiver<blink::mojom::BadgeService> receiver) {
+  badging::BadgeManager::BindServiceWorkerReceiver(
+      service_worker_process_host, service_worker_scope, std::move(receiver));
+}
+
 }  // namespace electron

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -73,6 +73,10 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
   void RegisterBrowserInterfaceBindersForFrame(
       content::RenderFrameHost* render_frame_host,
       mojo::BinderMapWithContext<content::RenderFrameHost*>* map) override;
+  void BindBadgeServiceReceiverFromServiceWorker(
+      content::RenderProcessHost* service_worker_process_host,
+      const GURL& service_worker_scope,
+      mojo::PendingReceiver<blink::mojom::BadgeService> receiver) override;
 #if defined(OS_LINUX)
   void GetAdditionalMappedFilesForChildProcess(
       const base::CommandLine& command_line,

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -1578,12 +1578,6 @@ describe('navigator.clipboard', () => {
 
 ifdescribe((process.platform !== 'linux' || app.isUnityRunning()))('navigator.setAppBadge/clearAppBadge', () => {
   let w: BrowserWindow;
-  before(async () => {
-    w = new BrowserWindow({
-      show: false
-    });
-    await w.loadFile(path.join(fixturesPath, 'pages', 'blank.html'));
-  });
 
   const expectedBadgeCount = 42;
 
@@ -1603,30 +1597,96 @@ ifdescribe((process.platform !== 'linux' || app.isUnityRunning()))('navigator.se
     return badgeCount;
   }
 
-  after(() => {
-    app.badgeCount = 0;
-    closeAllWindows();
+  describe('in the renderer', () => {
+    before(async () => {
+      w = new BrowserWindow({
+        show: false
+      });
+      await w.loadFile(path.join(fixturesPath, 'pages', 'blank.html'));
+    });
+
+    after(() => {
+      app.badgeCount = 0;
+      closeAllWindows();
+    });
+
+    it('setAppBadge can set a numerical value', async () => {
+      const result = await fireAppBadgeAction('set', expectedBadgeCount);
+      expect(result).to.equal('success');
+      expect(waitForBadgeCount(expectedBadgeCount)).to.eventually.equal(expectedBadgeCount);
+    });
+
+    it('setAppBadge can set an empty(dot) value', async () => {
+      const result = await fireAppBadgeAction('set');
+      expect(result).to.equal('success');
+      expect(waitForBadgeCount(0)).to.eventually.equal(0);
+    });
+
+    it('clearAppBadge can clear a value', async () => {
+      let result = await fireAppBadgeAction('set', expectedBadgeCount);
+      expect(result).to.equal('success');
+      expect(waitForBadgeCount(expectedBadgeCount)).to.eventually.equal(expectedBadgeCount);
+      result = await fireAppBadgeAction('clear');
+      expect(result).to.equal('success');
+      expect(waitForBadgeCount(0)).to.eventually.equal(0);
+    });
   });
 
-  it('setAppBadge can set a numerical value', async () => {
-    const result = await fireAppBadgeAction('set', expectedBadgeCount);
-    expect(result).to.equal('success');
-    expect(waitForBadgeCount(expectedBadgeCount)).to.eventually.equal(expectedBadgeCount);
-  });
+  describe('in a service worker', () => {
+    beforeEach(async () => {
+      w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          nodeIntegration: true,
+          partition: 'sw-file-scheme-spec',
+          contextIsolation: false
+        }
+      });
+    });
 
-  it('setAppBadge can set an empty(dot) value', async () => {
-    const result = await fireAppBadgeAction('set');
-    expect(result).to.equal('success');
-    expect(waitForBadgeCount(0)).to.eventually.equal(0);
-  });
+    afterEach(() => {
+      app.badgeCount = 0;
+      closeAllWindows();
+    });
 
-  it('clearAppBadge can clear a value', async () => {
-    let result = await fireAppBadgeAction('set', expectedBadgeCount);
-    expect(result).to.equal('success');
-    expect(waitForBadgeCount(expectedBadgeCount)).to.eventually.equal(expectedBadgeCount);
-    result = await fireAppBadgeAction('clear');
-    expect(result).to.equal('success');
-    expect(waitForBadgeCount(0)).to.eventually.equal(0);
+    it('setAppBadge can be called in a ServiceWorker', (done) => {
+      w.webContents.on('ipc-message', (event, channel, message) => {
+        if (channel === 'reload') {
+          w.webContents.reload();
+        } else if (channel === 'error') {
+          done(message);
+        } else if (channel === 'response') {
+          expect(message).to.equal('SUCCESS setting app badge');
+          expect(waitForBadgeCount(expectedBadgeCount)).to.eventually.equal(expectedBadgeCount);
+          session.fromPartition('sw-file-scheme-spec').clearStorageData({
+            storages: ['serviceworkers']
+          }).then(() => done());
+        }
+      });
+      w.webContents.on('crashed', () => done(new Error('WebContents crashed.')));
+      w.loadFile(path.join(fixturesPath, 'pages', 'service-worker', 'badge-index.html'), { search: '?setBadge' });
+    });
+
+    it('clearAppBadge can be called in a ServiceWorker', (done) => {
+      w.webContents.on('ipc-message', (event, channel, message) => {
+        if (channel === 'reload') {
+          w.webContents.reload();
+        } else if (channel === 'setAppBadge') {
+          expect(message).to.equal('SUCCESS setting app badge');
+          expect(waitForBadgeCount(expectedBadgeCount)).to.eventually.equal(expectedBadgeCount);
+        } else if (channel === 'error') {
+          done(message);
+        } else if (channel === 'response') {
+          expect(message).to.equal('SUCCESS clearing app badge');
+          expect(waitForBadgeCount(expectedBadgeCount)).to.eventually.equal(expectedBadgeCount);
+          session.fromPartition('sw-file-scheme-spec').clearStorageData({
+            storages: ['serviceworkers']
+          }).then(() => done());
+        }
+      });
+      w.webContents.on('crashed', () => done(new Error('WebContents crashed.')));
+      w.loadFile(path.join(fixturesPath, 'pages', 'service-worker', 'badge-index.html'), { search: '?clearBadge' });
+    });
   });
 });
 

--- a/spec/fixtures/pages/service-worker/badge-index.html
+++ b/spec/fixtures/pages/service-worker/badge-index.html
@@ -1,0 +1,31 @@
+<script>
+  const ipcRenderer = require('electron').ipcRenderer;
+  let search = (new URL(document.location)).search;  
+
+  async function testIt() {
+    if (search === '?clearBadge') {
+      try {
+        await navigator.setAppBadge(42);
+        ipcRenderer.send('setAppBadge','SUCCESS setting app badge');
+      } catch (error) {
+        ipcRenderer.send('error', `${error.message}\n${error.stack}`);
+      }
+    }
+    navigator.serviceWorker.register('service-worker-badge.js', {scope: './'}).then(function() {
+      if (navigator.serviceWorker.controller) {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', 'http://dummy/echo'+search);
+        xhr.setRequestHeader('X-Mock-Response', 'yes');
+        xhr.addEventListener('load', function() {
+          ipcRenderer.send('response', xhr.responseText);
+        });
+        xhr.send();
+      } else {
+        ipcRenderer.send('reload');
+      }
+    }).catch(function(error) {
+      ipcRenderer.send('error', `${error.message}\n${error.stack}`);
+    })
+  }
+  testIt();
+</script>

--- a/spec/fixtures/pages/service-worker/service-worker-badge.js
+++ b/spec/fixtures/pages/service-worker/service-worker-badge.js
@@ -1,0 +1,33 @@
+self.addEventListener('fetch', async function (event) {
+  const requestUrl = new URL(event.request.url);
+  let responseTxt;
+  if (requestUrl.pathname === '/echo' &&
+    event.request.headers.has('X-Mock-Response')) {
+    if (requestUrl.search === '?setBadge') {
+      if (navigator.setAppBadge()) {
+        try {
+          await navigator.setAppBadge(42);
+          responseTxt = 'SUCCESS setting app badge';
+          await navigator.clearAppBadge();
+        } catch (ex) {
+          responseTxt = 'ERROR setting app badge ' + ex;
+        }
+      } else {
+        responseTxt = 'ERROR navigator.setAppBadge is not available in ServiceWorker!';
+      }
+    } else if (requestUrl.search === '?clearBadge') {
+      if (navigator.clearAppBadge()) {
+        try {
+          await navigator.clearAppBadge();
+          responseTxt = 'SUCCESS clearing app badge';
+        } catch (ex) {
+          responseTxt = 'ERROR clearing app badge ' + ex;
+        }
+      } else {
+        responseTxt = 'ERROR navigator.clearAppBadge is not available in ServiceWorker!';
+      }
+    }
+    const mockResponse = new Response(responseTxt);
+    event.respondWith(mockResponse);
+  }
+});


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
This is a followup to #27067.  As described here: https://web.dev/badging-api/#use, the badging API can be called from a service worker.  This PR fixes that API so that it works in a service worker.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> Fixed using navigator.setAppBadge and navigator.clearAppBadge from a service worker in Electron.
