### PR TITLE
chore: Add a condition to crashReporter deprecate log

### DIFF
--- a/lib/browser/api/crash-reporter.ts
+++ b/lib/browser/api/crash-reporter.ts
@@ -18,7 +18,7 @@ class CrashReporter {
 
     if (submitURL == null) throw new Error('submitURL is a required option to crashReporter.start');
 
-    if (!compress && submitURL != '') {
+    if (!compress && uploadToServer) {
       deprecate.log('Sending uncompressed crash reports is deprecated and will be removed in a future version of Electron. Set { compress: true } to opt-in to the new behavior. Crash reports will be uploaded gzipped, which most crash reporting servers support.');
     }
 

--- a/lib/browser/api/crash-reporter.ts
+++ b/lib/browser/api/crash-reporter.ts
@@ -18,7 +18,7 @@ class CrashReporter {
 
     if (submitURL == null) throw new Error('submitURL is a required option to crashReporter.start');
 
-    if (!compress) {
+    if (!compress && submitURL != '') {
       deprecate.log('Sending uncompressed crash reports is deprecated and will be removed in a future version of Electron. Set { compress: true } to opt-in to the new behavior. Crash reports will be uploaded gzipped, which most crash reporting servers support.');
     }
 


### PR DESCRIPTION
When developer set  submitURL to '' crash reports will be saved  at `...\AppData\Roaming\...\Crashpad\reports`, will not be uploaded to the server.
So  at this time `deprecate.log('Sending uncompressed crash reports....')`  is  unnecessary.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none.