### PR TITLE
docs: suspend and resume are available on Linux

### DIFF
--- a/docs/api/power-monitor.md
+++ b/docs/api/power-monitor.md
@@ -8,11 +8,11 @@ Process: [Main](../glossary.md#main-process)
 
 The `powerMonitor` module emits the following events:
 
-### Event: 'suspend' _macOS_ _Windows_
+### Event: 'suspend' _Linux_ _macOS_ _Windows_
 
 Emitted when the system is suspending.
 
-### Event: 'resume' _macOS_ _Windows_
+### Event: 'resume' _Linux_ _macOS_ _Windows_
 
 Emitted when system is resuming.
 

--- a/docs/api/power-monitor.md
+++ b/docs/api/power-monitor.md
@@ -8,11 +8,11 @@ Process: [Main](../glossary.md#main-process)
 
 The `powerMonitor` module emits the following events:
 
-### Event: 'suspend' _Linux_ _macOS_ _Windows_
+### Event: 'suspend'
 
 Emitted when the system is suspending.
 
-### Event: 'resume' _Linux_ _macOS_ _Windows_
+### Event: 'resume'
 
 Emitted when system is resuming.
 


### PR DESCRIPTION
#### Description of Change
Closes #27761. 

Updates accordingly PowerMonitor documentation for `suspend` and `resume`, which were added on Linux by #25149.

#### Checklist
- [x] relevant documentation is changed or added

#### Release Notes

Notes: None
