### PR TITLE
docs: cmake-js instructions for `win_delay_load_hook`

### DIFF
--- a/docs/tutorial/using-native-node-modules.md
+++ b/docs/tutorial/using-native-node-modules.md
@@ -144,7 +144,7 @@ In particular, it's important that:
 See [`node-gyp`](https://github.com/nodejs/node-gyp/blob/e2401e1395bef1d3c8acec268b42dc5fb71c4a38/src/win_delay_load_hook.cc)
 for an example delay-load hook if you're implementing your own.
 
-#### When using cmake-js
+#### When using `cmake-js`
 
 [`cmake-js`](https://github.com/cmake-js/cmake-js) automatically includes the
 `/DELAYLOAD:node.exe` linking flag. However, for the `win_delay_load_hook` to be

--- a/docs/tutorial/using-native-node-modules.md
+++ b/docs/tutorial/using-native-node-modules.md
@@ -146,10 +146,10 @@ for an example delay-load hook if you're implementing your own.
 
 #### When using cmake-js
 
-[`cmake-js`](https://github.com/cmake-js/cmake-js) automatically includes the
+[`cmake-js`](https://github.com/cmake-js/cmake-js) automatically includes the 
 `/DELAYLOAD:node.exe` linking flag. However, for the `win_delay_load_hook` to be
-compiled in and for the `.node` module to load without the:
-"A dynamic link library (DLL) initialization routine failed." error, one must add
+compiled in and for the `.node` module to load without the: 
+"A dynamic link library (DLL) initialization routine failed." error, one must add 
 the following directive to the CMakeLists.txt `add_library` source file list.
 
 ```plaintext

--- a/docs/tutorial/using-native-node-modules.md
+++ b/docs/tutorial/using-native-node-modules.md
@@ -144,6 +144,18 @@ In particular, it's important that:
 See [`node-gyp`](https://github.com/nodejs/node-gyp/blob/e2401e1395bef1d3c8acec268b42dc5fb71c4a38/src/win_delay_load_hook.cc)
 for an example delay-load hook if you're implementing your own.
 
+#### When using cmake-js
+
+[`cmake-js`](https://github.com/cmake-js/cmake-js) automatically includes the 
+`/DELAYLOAD:node.exe` linking flag. However, for the `win_delay_load_hook` to be
+compiled in and for the `.node` module to load without the: 
+"A dynamic link library (DLL) initialization routine failed." error, one must add 
+the following directive to the CMakeLists.txt `add_library` source file list.
+
+```plaintext
+    ${CMAKE_JS_SRC}
+```
+
 ## Modules that rely on `prebuild`
 
 [`prebuild`](https://github.com/prebuild/prebuild) provides a way to publish

--- a/docs/tutorial/using-native-node-modules.md
+++ b/docs/tutorial/using-native-node-modules.md
@@ -146,10 +146,10 @@ for an example delay-load hook if you're implementing your own.
 
 #### When using cmake-js
 
-[`cmake-js`](https://github.com/cmake-js/cmake-js) automatically includes the 
+[`cmake-js`](https://github.com/cmake-js/cmake-js) automatically includes the
 `/DELAYLOAD:node.exe` linking flag. However, for the `win_delay_load_hook` to be
-compiled in and for the `.node` module to load without the: 
-"A dynamic link library (DLL) initialization routine failed." error, one must add 
+compiled in and for the `.node` module to load without the:
+"A dynamic link library (DLL) initialization routine failed." error, one must add
 the following directive to the CMakeLists.txt `add_library` source file list.
 
 ```plaintext

--- a/package.json
+++ b/package.json
@@ -147,5 +147,8 @@
     "DEPS": [
       "node script/gen-hunspell-filenames.js"
     ]
+  },
+  "dependencies": {
+    "remark": "^13.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -147,8 +147,5 @@
     "DEPS": [
       "node script/gen-hunspell-filenames.js"
     ]
-  },
-  "dependencies": {
-    "remark": "^13.0.0"
   }
 }


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/22799.

Documentation update only, `win_delay_load_hook` quirks for `cmake-js` users.

#### Checklist

- [x] relevant documentation is changed or added

#### Release Notes
Notes: None