### PR TITLE
fix: warning when worldSafeExecuteJavaScript is disabled

### DIFF
--- a/lib/renderer/api/web-frame.ts
+++ b/lib/renderer/api/web-frame.ts
@@ -49,7 +49,7 @@ class WebFrame extends EventEmitter {
 }
 
 const { hasSwitch } = process.electronBinding('command_line');
-const worldSafeJS = hasSwitch('world-safe-execute-javascript') && hasSwitch('context-isolation');
+const worldSafeJS = hasSwitch('world-safe-execute-javascript') || !hasSwitch('context-isolation');
 
 // Populate the methods.
 for (const name in binding) {


### PR DESCRIPTION
Backport of #27928

See that PR for details.

Notes: Fixed warning when `worldSafeExecuteJavaScript` is disabled.