### PR TITLE
feat: add scripts to sync patches

### DIFF
--- a/script/git-sync-patches
+++ b/script/git-sync-patches
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import sys
+
+from lib import git
+
+
+def parse_args(argv):
+  parser = argparse.ArgumentParser()
+  parser.add_argument("patch_dir",
+      help="directory containing patches to apply")
+  parser.add_argument("-3", "--3way",
+      action="store_true", dest='threeway',
+      help="use 3-way merge to resolve conflicts")
+  parser.add_argument("-d", "--dry-run",
+      action="store_true", dest='dry_run',
+      help="perform dry run")
+  return parser.parse_args(argv)
+
+
+def main(argv):
+  args = parse_args(argv)
+
+  git.sync_patches(
+      repo='.',
+      patch_dir=args.patch_dir,
+      threeway=args.threeway,
+      dry_run=args.dry_run,
+  )
+
+
+if __name__ == '__main__':
+  main(sys.argv[1:])

--- a/script/sync_all_patches.py
+++ b/script/sync_all_patches.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+import argparse
+import json
+import os
+import sys
+
+from lib import git
+
+
+def sync_patches(dirs):
+  threeway = os.environ.get("ELECTRON_USE_THREE_WAY_MERGE_FOR_PATCHES")
+  for patch_dir, repo in dirs.iteritems():
+    git.sync_patches(repo=repo, patch_dir=patch_dir,
+      threeway=threeway is not None)
+
+
+def parse_args():
+  parser = argparse.ArgumentParser(description='Sync Electron patches')
+  parser.add_argument('config', nargs='+',
+                      type=argparse.FileType('r'),
+                      help='patches\' config(s) in the JSON format')
+  return parser.parse_args()
+
+
+def main():
+  configs = parse_args().config
+  for config_json in configs:
+    sync_patches(json.load(config_json))
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
#### Description of Change

Running `e sync` clears all applied patches and resets Chromium to
its targeted version commit. Running this when only a few patches
have changed will trigger many objects to be unnecessarily rebuilt.

These new scripts will sync only modified patches, applying the
minimum amount of changes to reduce the number of objects requiring
to be rebuilt.

Usage:
```
./src/electron/scripts/sync_all_patches.py ./src/electron/patches/config.json
./src/electron/script/git-sync-patches ./src/electron/patches/chromium
```

------

At Around, we work with a lot of patches for Chromium and WebRTC. Patches are modified at a much higher frequency than our Chromium target commit. I've created these new scripts to bring applied patches up to date without clearing all of them. This leads to much faster build times for us as a result of having less objects to build.

I'd like to also create an `e sync-patches` shortcut after this work is able to be merged.

<details>
<summary>Example output when run on my out of date repo</summary>

```
$ ./src/electron/script/sync_all_patches.py ./src/electron/patches/config.json
Syncing 10 patches since 74ef1d1cf560c22c37a43f202a6275c8ed92ae97 in src/electron/patches/v8
Syncing 1 patches since 78d3966b3c331292ea29ec38661b25df0a245948 in src/electron/patches/Mantle
Syncing 1 patches since fade894c7e0cbf760cc9c0f48053b64f2babb0ba in src/electron/patches/depot_tools
Syncing 35 patches since 04509d6847a2d164b223a77aed0c41fe9ca60e57 in src/electron/patches/node
build_add_gn_build_files.patch does't match applied patch
Patches not up to date: 29 patches need to be reverted
HEAD is now at 43985ea564 Expose `get_linked_module` function
27 patches need to be applied
Applying: build: add GN build files
Applying: fix: add default values for 'enable_lto' and 'build_v8_with_gn' in common.gypi
Applying: feat: add new built_with_electron variable to config.gypi
Applying: feat: add flags for low-level hooks and exceptions
Applying: fix: expose tracing::Agent and use tracing::TracingController instead of v8::TracingController
Applying: Pass all globals through "require"
Applying: fixme: Comment trace event macro
Applying: fix: key gen APIs are not available in BoringSSL
Applying: build: modify js2c.py to allow injection of original-fs and custom embedder JS
Applying: refactor: allow embedder overriding of internal FS calls
Applying: chore: prevent / warn non context-aware native modules being loaded
Applying: chore: read _noBrowserGlobals from global not config
Applying: build: bring back node_with_ltcg configuration
Applying: enable 31 bit smis on 64bit arch and ptr compression
Applying: fix: use crypto impls for compat
Applying: fix: comment out incompatible crypto modules
Applying: Update tests after increasing typed array size
Applying: feat: add implementation of v8::Platform::PostJob
Applying: fix: -Wincompatible-pointer-types-discards-qualifiers error
Applying: fix: add v8_enable_reverse_jsargs defines in common.gypi
Applying: fix: allow preventing InitializeInspector in env
Applying: src: allow embedders to provide a custom PageAllocator to NodePlatform
Applying: Allow preventing PrepareStackTraceCallback
Applying: fix: add SafeForTerminationScopes for SIGINT interruptions
Applying: Remove MakeExternal case for uncached internal strings
Applying: fix: remove outdated --experimental-wasm-bigint flag
Applying: fix crypto tests to run with bssl
Syncing 2 patches since cdc0729c8bf8576bfef18629186e1e9ecf1b0d9f in src/electron/patches/squirrel.mac
Syncing 1 patches since 74ab5baccc6f7202c8ac69a8d1e152c29dc1ea76 in src/electron/patches/ReactiveObjC
Syncing 108 patches since 1f252b391a40e2681b0d9aff6497b7401863d1fc in src/electron/patches/chromium
feat_enable_offscreen_rendering_with_viz_compositor.patch does't match applied patch
Patches not up to date: 32 patches need to be reverted
HEAD is now at 744461fa3e1a feat: add support for overriding the base spellchecker download URL
33 patches need to be applied
Applying: feat: enable off-screen rendering with viz compositor
Applying: content: allow embedder to prevent locking scheme registry
Applying: gpu: notify when dxdiag request for gpu info fails
Applying: feat: allow embedders to add observers on created hunspell dictionaries
Applying: feat: add onclose to MessagePort
Applying: ui_gtk_public_header.patch
Applying: allow in-process windows to have different web prefs
Applying: refactor: expose cursor changes to the WebContentsObserver
Applying: crash: allow setting more options
Applying: breakpad: treat node processes as browser processes
Applying: upload_list: add LoadSync method
Applying: breakpad: allow getting string values for crash keys
Applying: crash: allow disabling compression on linux
Applying: Allow setting secondary label via SimpleMenuModel
Applying: feat: add streaming-protocol registry to multibuffer_data_source
Applying: fix: patch out Profile refs in accessibility_ui
Applying: remove some deps that do not work on arm64
Applying: fix: check IsSecureEventInputEnabled in constructor before setting SetPasswordInputEnabled to true
Applying: skip atk toolchain check
Applying: feat: add hook to notify script ready from WorkerScriptController
Applying: chore: provide IsWebContentsCreationOverridden with full params
Applying: fix: properly honor printing page ranges
Applying: fix: use electron generated resources
Applying: chore: expose v8 initialization isolate callbacks
Applying: export gin::V8Platform::PageAllocator for usage outside of the gin platform
Applying: use public APIs to determine if a font is a system font in MAS build
Applying: fix crash in NativeViewHost::SetParentAccessible
Applying: fix: export zlib symbols
Applying: Don't use potentially null "GetWebFrame()->View()" when get blink prefs
Applying: web_contents.patch
Applying: add TrustedAuthClient to URLLoaderFactory
Applying: fix: route mouse event navigations through the web_contents delegate
Applying: fix: disable unload metrics
Syncing 2 patches since c47bfce062cc5a1b462176be626338224ae2a346 in src/electron/patches/boringssl
Syncing 1 patches since 2c4ee8a32a299eada3cd6e468bbd0a473bfea96d in src/electron/patches/nan
```
</details>

cc @codebytere @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none
