### PR TITLE
test: fix contextIsolation value for later added test

### DIFF
--- a/spec-main/fixtures/apps/quit/main.js
+++ b/spec-main/fixtures/apps/quit/main.js
@@ -1,7 +1,13 @@
 const { app, BrowserWindow } = require('electron');
 
 app.once('ready', () => {
-  const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true } });
+  const w = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      contextIsolation: false,
+      nodeIntegration: true
+    }
+  });
   w.webContents.once('crashed', () => {
     app.quit();
   });


### PR DESCRIPTION
#### Description of Change

The https://github.com/electron/electron/pull/27815 relies on `contextIsolation` being false by default and fails after the default value is flipped.

#### Release Notes

Notes: none