### PR TITLE
feat: add process.contextId used by @electron/remote

### DIFF
--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -35,6 +35,7 @@ In sandboxed renderers the `process` object contains only a subset of the APIs:
 * `versions`
 * `mas`
 * `windowsStore`
+* `contextId`
 
 ## Events
 
@@ -132,6 +133,11 @@ A `String` representing Electron's version string.
 
 A `Boolean`. If the app is running as a Windows Store app (appx), this property is `true`,
 for otherwise it is `undefined`.
+
+### `process.contextId` _Readonly_
+
+A `String` (optional) representing a globally unique ID of the current JavaScript context.
+This property is only available in the renderer process.
 
 ## Methods
 

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -137,6 +137,8 @@ for otherwise it is `undefined`.
 ### `process.contextId` _Readonly_
 
 A `String` (optional) representing a globally unique ID of the current JavaScript context.
+Each frame has its own JavaScript context. When contextIsolation is enabled, the isolated
+world also has a separate JavaScript context.
 This property is only available in the renderer process.
 
 ## Methods

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -39,6 +39,10 @@ require('@electron/internal/common/init');
 // The global variable will be used by ipc for event dispatching
 const v8Util = process._linkedBinding('electron_common_v8_util');
 
+// Expose process.contextId
+const contextId = v8Util.getHiddenValue<string>(global, 'contextId');
+Object.defineProperty(process, 'contextId', { enumerable: true, value: contextId });
+
 const { ipcRendererInternal } = require('@electron/internal/renderer/ipc-renderer-internal');
 const ipcRenderer = require('@electron/internal/renderer/api/ipc-renderer').default;
 

--- a/lib/sandboxed_renderer/init.ts
+++ b/lib/sandboxed_renderer/init.ts
@@ -89,6 +89,10 @@ Object.defineProperty(preloadProcess, 'noDeprecation', {
   }
 });
 
+// Expose process.contextId
+const contextId = v8Util.getHiddenValue<string>(global, 'contextId');
+Object.defineProperty(preloadProcess, 'contextId', { enumerable: true, value: contextId });
+
 process.on('loaded', () => (preloadProcess as events.EventEmitter).emit('loaded'));
 process.on('exit', () => (preloadProcess as events.EventEmitter).emit('exit'));
 (process as events.EventEmitter).on('document-start', () => (preloadProcess as events.EventEmitter).emit('document-start'));

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -2623,6 +2623,7 @@ describe('BrowserWindow module', () => {
         expect(test.type).to.equal('renderer');
         expect(test.version).to.equal(process.version);
         expect(test.versions).to.deep.equal(process.versions);
+        expect(test.contextId).to.be.a('string');
 
         if (process.platform === 'linux' && test.osSandbox) {
           expect(test.creationTime).to.be.null('creation time');

--- a/spec-main/fixtures/module/preload-sandbox.js
+++ b/spec-main/fixtures/module/preload-sandbox.js
@@ -42,7 +42,8 @@
         sandboxed: process.sandboxed,
         type: process.type,
         version: process.version,
-        versions: process.versions
+        versions: process.versions,
+        contextId: process.contextId
       };
     }
   } else if (location.href !== 'about:blank') {

--- a/spec/api-process-spec.js
+++ b/spec/api-process-spec.js
@@ -115,4 +115,10 @@ describe('process module', () => {
       expect(success).to.be.false();
     });
   });
+
+  describe('process.contextId', () => {
+    it('is a string', () => {
+      expect(process.contextId).to.be.a('string');
+    });
+  });
 });


### PR DESCRIPTION
#### Description of Change
The built-in remote module is usable in sandboxed renderers. However the standalone https://github.com/electron/remote version is not due to `process._linkedBinding` not being available to the preload script. Expose public API for that.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `process.contextId` used by `@electron/remote`.