### PR TITLE
docs: `setWindowOpenHandler` should show object return

### DIFF
--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -83,9 +83,9 @@ const mainWindow = new BrowserWindow()
 
 mainWindow.webContents.setWindowOpenHandler(({ url }) => {
   if (url.startsWith('https://github.com/')) {
-    return { action: "allow" }
+    return { action: 'allow' }
   }
-  return { action: "deny" }
+  return { action: 'deny' }
 })
 
 mainWindow.webContents.on('did-create-window', (childWindow) => {

--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -83,9 +83,9 @@ const mainWindow = new BrowserWindow()
 
 mainWindow.webContents.setWindowOpenHandler(({ url }) => {
   if (url.startsWith('https://github.com/')) {
-    return true
+    return { action: "allow" }
   }
-  return false
+  return { action: "deny" }
 })
 
 mainWindow.webContents.on('did-create-window', (childWindow) => {


### PR DESCRIPTION
#### Description of Change
https://github.com/electron/electron/pull/24517 caused the doco here to change, however the doco incorrectly shows using boolean returns instead of object returns as stated in the API.

#### Checklist
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none