### PR TITLE
fix: delay setting background on transparent webContents

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1357,7 +1357,8 @@ void WebContents::RenderViewCreated(content::RenderViewHost* render_view_host) {
   if (!background_throttling_)
     render_view_host->SetSchedulerThrottling(false);
 
-  // Set the background color of RenderWidgetHostView.
+  // If the RenderWidgetHostView contains a background color (is not
+  // transparent), set the background color earlier than .
   auto* const view = web_contents()->GetRenderWidgetHostView();
   auto* web_preferences = WebContentsPreferences::From(web_contents());
   if (view && web_preferences) {
@@ -1365,8 +1366,6 @@ void WebContents::RenderViewCreated(content::RenderViewHost* render_view_host) {
     if (web_preferences->GetPreference(options::kBackgroundColor,
                                        &color_name)) {
       view->SetBackgroundColor(ParseHexColor(color_name));
-    } else {
-      view->SetBackgroundColor(SK_ColorTRANSPARENT);
     }
   }
 }
@@ -2002,6 +2001,22 @@ void WebContents::LoadURL(const GURL& url,
 
   // Required to make beforeunload handler work.
   NotifyUserActivation();
+
+  // For transparent windows, set the background color of RenderWidgetHostView.
+  // We need to set this color after LoadURL, because the RenderViewHost is only
+  // created after loading a page and a default white color is rendered
+  // otherwise.
+  auto* const view = weak_this->web_contents()->GetRenderWidgetHostView();
+  if (view) {
+    auto* web_preferences = WebContentsPreferences::From(web_contents());
+    std::string color_name;
+    if (web_preferences->GetPreference(options::kBackgroundColor,
+                                       &color_name)) {
+      view->SetBackgroundColor(ParseHexColor(color_name));
+    } else {
+      view->SetBackgroundColor(SK_ColorTRANSPARENT);
+    }
+  }
 }
 
 void WebContents::DownloadURL(const GURL& url) {


### PR DESCRIPTION
#### Description of Change

Addresses an issue with loading transparent renderviews introduced by #27593. While #27593 fixed a white flash loading when a new window has a set background color, it unfortunately broke loading for transparent windows. Now, all transparent windows without an explicit background color set load with the default white background. This PR delays setting the background color for transparent windows, similar to how they behaved prior to the fix.

Note: This appears to have already been addressed in 13-x-y and master, partially with a Chromium update and related change.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where transparency was not being respected for child windows created by native window.open path.
