### PR TITLE
fix: delay setting background color for transparent windows

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2006,7 +2006,7 @@ void WebContents::LoadURL(const GURL& url,
   // For transparent windows, set the background color of RenderWidgetHostView.
   // We need to set this color after LoadURL, because the RenderViewHost is only
   // created after loading a page; a default white color is rendered otherwise.
-  auto* const view = weak_this->web_contents()->GetRenderWidgetHostView();
+  auto* const view = this->web_contents()->GetRenderWidgetHostView();
   if (view) {
     auto* web_preferences = WebContentsPreferences::From(web_contents());
     std::string color_name;

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1366,6 +1366,8 @@ void WebContents::RenderViewCreated(content::RenderViewHost* render_view_host) {
     if (web_preferences->GetPreference(options::kBackgroundColor,
                                        &color_name)) {
       view->SetBackgroundColor(ParseHexColor(color_name));
+    } else {
+      view->SetBackgroundColor(SK_ColorTRANSPARENT);
     }
   }
 }

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -550,7 +550,6 @@ class WebContents : public gin::Wrappable<WebContents>,
   // content::WebContentsObserver:
   void BeforeUnloadFired(bool proceed,
                          const base::TimeTicks& proceed_time) override;
-  void RenderViewCreated(content::RenderViewHost* render_view_host) override;
   void RenderFrameCreated(content::RenderFrameHost* render_frame_host) override;
   void RenderViewDeleted(content::RenderViewHost*) override;
   void RenderProcessGone(base::TerminationStatus status) override;

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -408,10 +408,12 @@ void WebContentsPreferences::OverrideWebkitPrefs(
 
   // --background-color.
   std::string color;
-  if (GetAsString(&preference_, options::kBackgroundColor, &color)) {
-    prefs->background_color = color;
-  } else if (!IsEnabled(options::kOffscreen)) {
-    prefs->background_color = "#fff";
+  if (!IsEnabled(options::kTransparent, false)) {
+    if (GetAsString(&preference_, options::kBackgroundColor, &color)) {
+      prefs->background_color = color;
+    } else if (!IsEnabled(options::kOffscreen)) {
+      prefs->background_color = "#fff";
+    }
   }
 
   // Pass the opener's window id.


### PR DESCRIPTION
#### Description of Change

Addresses an issue with loading transparent renderviews introduced by #27593. While #27593 fixed a prolonged white flash while loading a new window has a set background color, it unfortunately broke opacity for certain transparent windows. 

Now, transparent child windows created by window.open without an explicit background color and no external URL load with the default white background. This PR delays setting the background color for transparent windows in LoadURL, similar to how they behaved prior to the fix.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where transparency was not being respected for child windows created by native window.open path.