### PR TITLE
feat: add process.contextIsolation property

### DIFF
--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -30,6 +30,7 @@ In sandboxed renderers the `process` object contains only a subset of the APIs:
 * `arch`
 * `platform`
 * `sandboxed`
+* `contextIsolation`
 * `type`
 * `version`
 * `versions`
@@ -92,6 +93,11 @@ A `String` representing the path to the resources directory.
 
 A `Boolean`. When the renderer process is sandboxed, this property is `true`,
 otherwise it is `undefined`.
+
+### `process.contextIsolation` _Readonly_
+
+A `Boolean` that indicates whether the current renderer context has `contextIsolation` enabled.
+It is `undefined` in the main process.
 
 ### `process.throwDeprecation`
 

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -146,9 +146,8 @@ void ElectronRendererClient::DidCreateScriptContext(
 
   // Add Electron extended APIs.
   electron_bindings_->BindTo(env->isolate(), env->process_object());
-  AddRenderBindings(env->isolate(), env->process_object());
   gin_helper::Dictionary process_dict(env->isolate(), env->process_object());
-  process_dict.SetReadOnly("isMainFrame", render_frame->IsMainFrame());
+  BindProcess(env->isolate(), &process_dict, render_frame);
 
   // Load everything.
   node_bindings_->LoadEnvironment(env);

--- a/shell/renderer/electron_sandboxed_renderer_client.h
+++ b/shell/renderer/electron_sandboxed_renderer_client.h
@@ -21,7 +21,7 @@ class ElectronSandboxedRendererClient : public RendererClientBase {
 
   void InitializeBindings(v8::Local<v8::Object> binding,
                           v8::Local<v8::Context> context,
-                          bool is_main_frame);
+                          content::RenderFrame* render_frame);
   // electron::RendererClientBase:
   void DidCreateScriptContext(v8::Handle<v8::Context> context,
                               content::RenderFrame* render_frame) override;

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -137,9 +137,13 @@ void RendererClientBase::DidCreateScriptContext(
   global.SetHidden("contextId", context_id);
 }
 
-void RendererClientBase::AddRenderBindings(
-    v8::Isolate* isolate,
-    v8::Local<v8::Object> binding_object) {}
+void RendererClientBase::BindProcess(v8::Isolate* isolate,
+                                     gin_helper::Dictionary* process,
+                                     content::RenderFrame* render_frame) {
+  process->SetReadOnly("isMainFrame", render_frame->IsMainFrame());
+  process->SetReadOnly("contextIsolation",
+                       render_frame->GetBlinkPreferences().context_isolation);
+}
 
 void RendererClientBase::RenderThreadStarted() {
   auto* command_line = base::CommandLine::ForCurrentProcess();

--- a/shell/renderer/renderer_client_base.h
+++ b/shell/renderer/renderer_client_base.h
@@ -13,6 +13,7 @@
 #include "content/public/renderer/content_renderer_client.h"
 #include "electron/buildflags/buildflags.h"
 #include "printing/buildflags/buildflags.h"
+#include "shell/common/gin_helper/dictionary.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 // In SHARED_INTERMEDIATE_DIR.
 #include "widevine_cdm_version.h"  // NOLINT(build/include_directory)
@@ -92,8 +93,9 @@ class RendererClientBase : public content::ContentRendererClient
 #endif
 
  protected:
-  void AddRenderBindings(v8::Isolate* isolate,
-                         v8::Local<v8::Object> binding_object);
+  void BindProcess(v8::Isolate* isolate,
+                   gin_helper::Dictionary* process,
+                   content::RenderFrame* render_frame);
 
   // content::ContentRendererClient:
   void RenderThreadStarted() override;

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -2620,6 +2620,7 @@ describe('BrowserWindow module', () => {
         expect(test.env).to.deep.equal(process.env);
         expect(test.execPath).to.equal(process.helperExecPath);
         expect(test.sandboxed).to.be.true('sandboxed');
+        expect(test.contextIsolation).to.be.false('contextIsolation');
         expect(test.type).to.equal('renderer');
         expect(test.version).to.equal(process.version);
         expect(test.versions).to.deep.equal(process.versions);
@@ -4436,6 +4437,19 @@ describe('BrowserWindow module', () => {
       `);
       const [, data] = await p;
       expect(data.pageContext.openedLocation).to.equal('about:blank');
+    });
+    it('reports process.contextIsolation', async () => {
+      const iw = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          contextIsolation: true,
+          preload: path.join(fixtures, 'api', 'isolated-process.js')
+        }
+      });
+      const p = emittedOnce(ipcMain, 'context-isolation');
+      iw.loadURL('about:blank');
+      const [, contextIsolation] = await p;
+      expect(contextIsolation).to.be.true('contextIsolation');
     });
   });
 

--- a/spec-main/fixtures/module/preload-sandbox.js
+++ b/spec-main/fixtures/module/preload-sandbox.js
@@ -40,6 +40,7 @@
         arch: process.arch,
         platform: process.platform,
         sandboxed: process.sandboxed,
+        contextIsolation: process.contextIsolation,
         type: process.type,
         version: process.version,
         versions: process.versions

--- a/spec/fixtures/api/isolated-process.js
+++ b/spec/fixtures/api/isolated-process.js
@@ -1,0 +1,3 @@
+const { ipcRenderer } = require('electron');
+
+ipcRenderer.send('context-isolation', process.contextIsolation);


### PR DESCRIPTION
#### Description of Change
It is currently not possible to determine whether `contextIsolation` is enabled in the renderer process without passing a flag from the main process. Add a property for that.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `process.contextIsolation` property that indicates whether the current renderer context has `contextIsolation` enabled.
