### PR TITLE
test: give some time for spellchecker to toggle

### DIFF
--- a/spec-main/spellchecker-spec.ts
+++ b/spec-main/spellchecker-spec.ts
@@ -116,10 +116,12 @@ ifdescribe(features.isBuiltinSpellCheckerEnabled())('spellchecker', () => {
       const callWebFrameFn = (expr: string) => w.webContents.executeJavaScript('require("electron").webFrame.' + expr);
 
       w.webContents.session.spellCheckerEnabled = false;
+      await delay(500);
       expect(w.webContents.session.spellCheckerEnabled).to.be.false();
       expect(await callWebFrameFn('isWordMisspelled("testt")')).to.equal(false);
 
       w.webContents.session.spellCheckerEnabled = true;
+      await delay(500);
       expect(w.webContents.session.spellCheckerEnabled).to.be.true();
       expect(await callWebFrameFn('isWordMisspelled("testt")')).to.equal(true);
     });


### PR DESCRIPTION
#### Description of Change

Toggling spellchecker works asynchronously, the test should wait for a while before checking the result.

#### Release Notes

Notes: none