### PR TITLE
test: ignore the ready event from PDF Viewer

### DIFF
--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -6,7 +6,7 @@ import { AddressInfo } from 'net';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as WebSocket from 'ws';
-import { emittedOnce, emittedNTimes } from './events-helpers';
+import { emittedOnce, emittedNTimes, emittedUntil } from './events-helpers';
 
 const uuid = require('uuid');
 
@@ -150,7 +150,9 @@ describe('chrome extensions', () => {
     const loadedPromise = emittedOnce(customSession, 'extension-loaded');
     const extension = await customSession.loadExtension(path.join(fixtures, 'extensions', 'red-bg'));
     const [, loadedExtension] = await loadedPromise;
-    const [, readyExtension] = await emittedOnce(customSession, 'extension-ready');
+    const [, readyExtension] = await emittedUntil(customSession, 'extension-ready', (event: Event, extension: Extension) => {
+      return extension.name !== 'Chromium PDF Viewer';
+    });
 
     // Compare JSON string to print more information if failed.
     const expected = JSON.stringify(extension);


### PR DESCRIPTION
#### Description of Change

The `extension-ready` event may also be emitted by the "Chromium PDF Viewer".

#### Release Notes

Notes: none