### PR TITLE
test: show full object diff

### DIFF
--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -154,15 +154,13 @@ describe('chrome extensions', () => {
       return extension.name !== 'Chromium PDF Viewer';
     });
 
-    // Compare JSON string to print more information if failed.
-    const expected = JSON.stringify(extension);
-    expect(JSON.stringify(loadedExtension)).to.equal(expected);
-    expect(JSON.stringify(readyExtension)).to.equal(expected);
+    expect(loadedExtension).to.deep.equal(extension);
+    expect(readyExtension).to.deep.equal(extension);
 
     const unloadedPromise = emittedOnce(customSession, 'extension-unloaded');
     await customSession.removeExtension(extension.id);
     const [, unloadedExtension] = await unloadedPromise;
-    expect(JSON.stringify(unloadedExtension)).to.equal(expected);
+    expect(unloadedExtension).to.deep.equal(extension);
   });
 
   it('lists loaded extensions in getAllExtensions', async () => {

--- a/spec-main/index.js
+++ b/spec-main/index.js
@@ -131,6 +131,10 @@ app.whenReady().then(async () => {
   chai.use(require('chai-as-promised'));
   chai.use(require('dirty-chai'));
 
+  // Show full object diff
+  // https://github.com/chaijs/chai/issues/469
+  chai.config.truncateThreshold = 0;
+
   const runner = mocha.run(cb);
 }).catch((err) => {
   console.error('An error occurred while running the spec-main spec runner');

--- a/spec/static/index.html
+++ b/spec/static/index.html
@@ -91,6 +91,10 @@
   chai.use(require('chai-as-promised'))
   chai.use(require('dirty-chai'))
 
+  // Show full object diff
+  // https://github.com/chaijs/chai/issues/469
+  chai.config.truncateThreshold = 0;
+
   const runner = mocha.run(() => {
     // Ensure the callback is called after runner is defined
     setTimeout(() => {


### PR DESCRIPTION
#### Description of Change

Show full object diff when test fails, instead of unhelpful message like `expected { Object (openAtLogin, openAsHidden, ...) } to deeply equal { Object (openAtLogin, openAsHidden, ...) }`

#### Release Notes

Notes: none