### PR TITLE
chore: cherry-pick 1fe571a from node

### DIFF
--- a/patches/node/.patches
+++ b/patches/node/.patches
@@ -32,3 +32,4 @@ remove_makeexternal_case_for_uncached_internal_strings.patch
 fix_remove_outdated_--experimental-wasm-bigint_flag.patch
 fix_crypto_tests_to_run_with_bssl.patch
 build_add_mjs_support_to_js2c.patch
+src_inline_asynccleanuphookhandle_in_headers.patch

--- a/patches/node/src_inline_asynccleanuphookhandle_in_headers.patch
+++ b/patches/node/src_inline_asynccleanuphookhandle_in_headers.patch
@@ -1,0 +1,73 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tyler Ang-Wanek <tylerw@axosoft.com>
+Date: Tue, 19 Jan 2021 07:39:14 -0700
+Subject: src: inline AsyncCleanupHookHandle in headers
+
+Fixes: https://github.com/nodejs/node/issues/36349
+
+PR-URL: https://github.com/nodejs/node/pull/37000
+Reviewed-By: Anna Henningsen <anna@addaleax.net>
+Reviewed-By: Rich Trott <rtrott@gmail.com>
+Reviewed-By: James M Snell <jasnell@gmail.com>
+
+diff --git a/src/api/hooks.cc b/src/api/hooks.cc
+index a719a861dbe9d8d9ca67c3bb5920b14b0df16d83..8f191aad7e2dcfbedddeaeb88f47ed721ef51cf1 100644
+--- a/src/api/hooks.cc
++++ b/src/api/hooks.cc
+@@ -133,7 +133,7 @@ static void RunAsyncCleanupHook(void* arg) {
+   info->fun(info->arg, FinishAsyncCleanupHook, info);
+ }
+ 
+-AsyncCleanupHookHandle AddEnvironmentCleanupHook(
++ACHHandle* AddEnvironmentCleanupHookInternal(
+     Isolate* isolate,
+     AsyncCleanupHook fun,
+     void* arg) {
+@@ -145,11 +145,11 @@ AsyncCleanupHookHandle AddEnvironmentCleanupHook(
+   info->arg = arg;
+   info->self = info;
+   env->AddCleanupHook(RunAsyncCleanupHook, info.get());
+-  return AsyncCleanupHookHandle(new ACHHandle { info });
++  return new ACHHandle { info };
+ }
+ 
+-void RemoveEnvironmentCleanupHook(
+-    AsyncCleanupHookHandle handle) {
++void RemoveEnvironmentCleanupHookInternal(
++    ACHHandle* handle) {
+   if (handle->info->started) return;
+   handle->info->self.reset();
+   handle->info->env->RemoveCleanupHook(RunAsyncCleanupHook, handle->info.get());
+diff --git a/src/node.h b/src/node.h
+index f150725b54ee1315476d202797963369490d5152..7ab2ed9345c83cb4c1f51c0cc3050abc6571e3fa 100644
+--- a/src/node.h
++++ b/src/node.h
+@@ -905,12 +905,26 @@ struct ACHHandle;
+ struct NODE_EXTERN DeleteACHHandle { void operator()(ACHHandle*) const; };
+ typedef std::unique_ptr<ACHHandle, DeleteACHHandle> AsyncCleanupHookHandle;
+ 
+-NODE_EXTERN AsyncCleanupHookHandle AddEnvironmentCleanupHook(
++/* This function is not intended to be used externally, it exists to aid in
++ * keeping ABI compatibility between Node and Electron. */
++NODE_EXTERN ACHHandle* AddEnvironmentCleanupHookInternal(
+     v8::Isolate* isolate,
+     void (*fun)(void* arg, void (*cb)(void*), void* cbarg),
+     void* arg);
++inline AsyncCleanupHookHandle AddEnvironmentCleanupHook(
++    v8::Isolate* isolate,
++    void (*fun)(void* arg, void (*cb)(void*), void* cbarg),
++    void* arg) {
++  return AsyncCleanupHookHandle(AddEnvironmentCleanupHookInternal(isolate, fun,
++      arg));
++}
+ 
+-NODE_EXTERN void RemoveEnvironmentCleanupHook(AsyncCleanupHookHandle holder);
++/* This function is not intended to be used externally, it exists to aid in
++ * keeping ABI compatibility between Node and Electron. */
++NODE_EXTERN void RemoveEnvironmentCleanupHookInternal(ACHHandle* holder);
++inline void RemoveEnvironmentCleanupHook(AsyncCleanupHookHandle holder) {
++  RemoveEnvironmentCleanupHookInternal(holder.get());
++}
+ 
+ /* Returns the id of the current execution context. If the return value is
+  * zero then no execution has been set. This will happen if the user handles


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/28043

Backports https://github.com/nodejs/node/pull/37000

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix native module compilation with AsyncCleanupHooks on windows
