### PR TITLE
docs(quick-start): make import command npm 7-compatible

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -167,7 +167,8 @@ The simplest and the fastest way to distribute your newly created app is using
 1. Import Electron Forge to your app folder:
 
     ```sh
-    npx @electron-forge/cli import
+    npm install --save-dev @electron-forge/cli
+    npx electron-forge import
 
     ✔ Checking your system
     ✔ Initializing Git Repository


### PR DESCRIPTION
#### Description of Change
With npm 7, just running `npx @electron-forge/cli import` results in:

```
npm ERR! could not determine executable to run
```

I tested this very quickly on Linux with Node 15.11.0 / npm 7.6.0, and the [associated Electron Forge docs](https://www.electronforge.io/import-existing-project) have also been updated.

CC: @electron/wg-ecosystem 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
