### PR TITLE
docs(breaking-changes): contextIsolation disables require in renderer 

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -160,6 +160,9 @@ the previous behavior, `contextIsolation: false` must be specified in WebPrefere
 
 We [recommend having contextIsolation enabled](https://github.com/electron/electron/blob/master/docs/tutorial/security.md#3-enable-context-isolation-for-remote-content) for the security of your application.
 
+Another implication is that `require()` cannot be used in the renderer process unless
+`nodeIntegration` is true and `contextIsolation` is `false`.
+
 For more details see: https://github.com/electron/electron/issues/23506
 
 ### Removed: `crashReporter.getCrashesDirectory()`

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -161,7 +161,7 @@ the previous behavior, `contextIsolation: false` must be specified in WebPrefere
 We [recommend having contextIsolation enabled](https://github.com/electron/electron/blob/master/docs/tutorial/security.md#3-enable-context-isolation-for-remote-content) for the security of your application.
 
 Another implication is that `require()` cannot be used in the renderer process unless
-`nodeIntegration` is true and `contextIsolation` is `false`.
+`nodeIntegration` is `true` and `contextIsolation` is `false`.
 
 For more details see: https://github.com/electron/electron/issues/23506
 


### PR DESCRIPTION
#### Description of Change

In the Discord server, we're getting a lot of questions about using `require()` in the renderer with Electron 12 now that `contextIsolation` defaults to `false`, despite them having `nodeIntegration` set to `true`. This is probably the first step in socializing that.

Some discussion will be needed somewhere as to where else to add this sort of information (FAQ? Context Isolation doc?).

CC: @electron/wg-ecosystem

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
