### PR TITLE
fix: change #if defined(OS_MACOSX) to #if defined(OS_MAC)

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -372,7 +372,7 @@ void BrowserWindow::RemoveBrowserView(v8::Local<v8::Value> value) {
 void BrowserWindow::SetTopBrowserView(v8::Local<v8::Value> value,
                                       gin_helper::Arguments* args) {
   BaseWindow::SetTopBrowserView(value, args);
-#if defined(OS_MACOSX)
+#if defined(OS_MAC)
   UpdateDraggableRegions(draggable_regions_);
 #endif
 }


### PR DESCRIPTION
#### Description of Change
Chromium in Electron 11 renamed `OS_MACOSX` to `OS_MAC`.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes