### PR TITLE
feat: allow omitting submitURL when uploadToServer is false

### DIFF
--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -77,7 +77,8 @@ The `crashReporter` module has the following methods:
 ### `crashReporter.start(options)`
 
 * `options` Object
-  * `submitURL` String - URL that crash reports will be sent to as POST.
+  * `submitURL` String (optional) - URL that crash reports will be sent to as
+    POST. Required unless `uploadToServer` is `false`.
   * `productName` String (optional) - Defaults to `app.name`.
   * `companyName` String (optional) _Deprecated_ - Deprecated alias for
     `{ globalExtra: { _companyName: ... } }`.

--- a/lib/browser/api/crash-reporter.ts
+++ b/lib/browser/api/crash-reporter.ts
@@ -10,13 +10,13 @@ class CrashReporter {
       extra = {},
       globalExtra = {},
       ignoreSystemCrashHandler = false,
-      submitURL,
+      submitURL = '',
       uploadToServer = true,
       rateLimit = false,
       compress = true
     } = options || {};
 
-    if (submitURL == null) throw new Error('submitURL is a required option to crashReporter.start');
+    if (uploadToServer && !submitURL) throw new Error('submitURL must be specified when uploadToServer is true');
 
     if (!compress && uploadToServer) {
       deprecate.log('Sending uncompressed crash reports is deprecated and will be removed in a future version of Electron. Set { compress: true } to opt-in to the new behavior. Crash reports will be uploaded gzipped, which most crash reporting servers support.');

--- a/spec-main/api-crash-reporter-spec.ts
+++ b/spec-main/api-crash-reporter-spec.ts
@@ -361,7 +361,13 @@ ifdescribe(!isLinuxOnArm && !process.mas && !process.env.DISABLE_CRASH_REPORTER_
     it('requires that the submitURL option be specified', () => {
       expect(() => {
         crashReporter.start({} as any);
-      }).to.throw('submitURL is a required option to crashReporter.start');
+      }).to.throw('submitURL must be specified when uploadToServer is true');
+    });
+
+    it('allows the submitURL option to be omitted when uploadToServer is false', () => {
+      expect(() => {
+        crashReporter.start({ uploadToServer: false } as any);
+      }).not.to.throw();
     });
 
     it('can be called twice', async () => {


### PR DESCRIPTION
#### Description of Change
If there's no uploading, no submit URL is needed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: The `submitURL` option for `crashReporter.start` is no longer a required argument when `uploadToServer` is false.
