### PR TITLE
fix: delay emitting NotifyIcon events on Windows

### DIFF
--- a/shell/browser/ui/win/notify_icon.h
+++ b/shell/browser/ui/win/notify_icon.h
@@ -71,6 +71,8 @@ class NotifyIcon : public TrayIcon {
   void SetContextMenu(ElectronMenuModel* menu_model) override;
   gfx::Rect GetBounds() override;
 
+  base::WeakPtr<NotifyIcon> GetWeakPtr() { return weak_factory_.GetWeakPtr(); }
+
  private:
   void InitIconData(NOTIFYICONDATA* icon_data);
 
@@ -100,6 +102,8 @@ class NotifyIcon : public TrayIcon {
 
   // Context menu associated with this icon (if any).
   std::unique_ptr<views::MenuRunner> menu_runner_;
+
+  base::WeakPtrFactory<NotifyIcon> weak_factory_{this};
 
   DISALLOW_COPY_AND_ASSIGN(NotifyIcon);
 };


### PR DESCRIPTION
#### Description
Backport of #26668.

See that PR for details.

cc @nornagon 

#### Release Notes
Notes: Fixed a rare crash on Windows that could occur when emitting certain Tray events.