### PR TITLE
docs: fix cookies event documentation for type generation

### DIFF
--- a/docs/api/cookies.md
+++ b/docs/api/cookies.md
@@ -45,6 +45,8 @@ The following events are available on instances of `Cookies`:
 
 #### Event: 'changed'
 
+Returns:
+
 * `event` Event
 * `cookie` [Cookie](structures/cookie.md) - The cookie that was changed.
 * `cause` String - The cause of the change with one of the following values:


### PR DESCRIPTION
The docs were wrong, now they right.  Simple enuf

Notes: no-notes