### PR TITLE
test: reliably wait for spellchecker to load

### DIFF
--- a/shell/common/api/electron_api_v8_util.cc
+++ b/shell/common/api/electron_api_v8_util.cc
@@ -138,6 +138,10 @@ void TriggerFatalErrorForTesting(v8::Isolate* isolate) {
   v8::ExtensionConfiguration config(1, bDeps);
   v8::Context::New(isolate, &config);
 }
+
+void RunUntilIdle() {
+  base::RunLoop().RunUntilIdle();
+}
 #endif
 
 void Initialize(v8::Local<v8::Object> exports,
@@ -158,6 +162,7 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("getWeaklyTrackedValues", &GetWeaklyTrackedValues);
   dict.SetMethod("clearWeaklyTrackedValues", &ClearWeaklyTrackedValues);
   dict.SetMethod("weaklyTrackValue", &WeaklyTrackValue);
+  dict.SetMethod("runUntilIdle", &RunUntilIdle);
 #endif
 }
 

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -43,6 +43,7 @@ declare namespace NodeJS {
     weaklyTrackValue(value: any): void;
     clearWeaklyTrackedValues(): void;
     getWeaklyTrackedValues(): any[];
+    runUntilIdle(): void;
     isSameOrigin(a: string, b: string): boolean;
     triggerFatalErrorForTesting(): void;
   }


### PR DESCRIPTION
#### Description of Change

Make the spellchecker tests more reliable by using a busy loop to check spellchecker's state instead of waiting for fixed time.

#### Release Notes

Notes: none