### PR TITLE
fix: handle a nil backgroundColor in win.getBackgroundColor()

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -996,8 +996,10 @@ void NativeWindowMac::SetBackgroundColor(SkColor color) {
 }
 
 SkColor NativeWindowMac::GetBackgroundColor() {
-  return skia::CGColorRefToSkColor(
-      [[[window_ contentView] layer] backgroundColor]);
+  CGColorRef color = [[[window_ contentView] layer] backgroundColor];
+  if (!color)
+    return SK_ColorTRANSPARENT;
+  return skia::CGColorRefToSkColor(color);
 }
 
 void NativeWindowMac::SetHasShadow(bool has_shadow) {

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -957,7 +957,8 @@ bool NativeWindowViews::IsTabletMode() const {
 
 SkColor NativeWindowViews::GetBackgroundColor() {
   auto* background = root_view_->background();
-  if (!background) return SK_ColorTRANSPARENT;
+  if (!background)
+    return SK_ColorTRANSPARENT;
   return background->get_color();
 }
 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -956,7 +956,9 @@ bool NativeWindowViews::IsTabletMode() const {
 }
 
 SkColor NativeWindowViews::GetBackgroundColor() {
-  return root_view_->background()->get_color();
+  auto* background = root_view_->background();
+  if (!background) return SK_ColorTRANSPARENT;
+  return background->get_color();
 }
 
 void NativeWindowViews::SetBackgroundColor(SkColor background_color) {

--- a/spec-main/fixtures/crash-cases/transparent-window-get-background-color/index.js
+++ b/spec-main/fixtures/crash-cases/transparent-window-get-background-color/index.js
@@ -1,0 +1,14 @@
+const { app, BrowserWindow } = require('electron');
+
+function createWindow () {
+  // Create the browser window.
+  const mainWindow = new BrowserWindow({
+    transparent: true
+  });
+  mainWindow.getBackgroundColor();
+}
+
+app.on('ready', () => {
+  createWindow();
+  setTimeout(() => app.quit());
+});


### PR DESCRIPTION
Fixes #28104

`[CALayer backgroundColor]` is `nil` by default.  When we are transparent and don't assign a background color this would crash inside the skia helper

Notes: Fixed crash when calling `getBackgroundColor` on a transparent window with no assigned background color.