### PR TITLE
fix: convert system colors to device color space in systemPreferences

### DIFF
--- a/shell/browser/api/electron_api_system_preferences_mac.mm
+++ b/shell/browser/api/electron_api_system_preferences_mac.mm
@@ -26,9 +26,11 @@
 #include "shell/browser/mac/dict_util.h"
 #include "shell/browser/mac/electron_application.h"
 #include "shell/browser/ui/cocoa/NSColor+Hex.h"
+#include "shell/common/color_util.h"
 #include "shell/common/gin_converters/gurl_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/process_util.h"
+#include "skia/ext/skia_utils_mac.h"
 #include "ui/native_theme/native_theme.h"
 
 namespace gin {
@@ -388,7 +390,8 @@ std::string SystemPreferences::GetAccentColor() {
   if (@available(macOS 10.14, *))
     sysColor = [NSColor controlAccentColor];
 
-  return base::SysNSStringToUTF8([sysColor RGBAValue]);
+  return ToRGBAHex(skia::NSSystemColorToSkColor(sysColor),
+                   false /* include_hash */);
 }
 
 std::string SystemPreferences::GetSystemColor(gin_helper::ErrorThrower thrower,
@@ -417,7 +420,7 @@ std::string SystemPreferences::GetSystemColor(gin_helper::ErrorThrower thrower,
     return "";
   }
 
-  return base::SysNSStringToUTF8([sysColor hexadecimalValue]);
+  return ToRGBHex(skia::NSSystemColorToSkColor(sysColor));
 }
 
 bool SystemPreferences::CanPromptTouchID() {
@@ -575,7 +578,7 @@ std::string SystemPreferences::GetColor(gin_helper::ErrorThrower thrower,
   }
 
   if (sysColor)
-    return base::SysNSStringToUTF8([sysColor hexadecimalValue]);
+    return ToRGBHex(skia::NSSystemColorToSkColor(sysColor));
   return "";
 }
 

--- a/shell/common/color_util.cc
+++ b/shell/common/color_util.cc
@@ -51,4 +51,14 @@ std::string ToRGBHex(SkColor color) {
                             SkColorGetG(color), SkColorGetB(color));
 }
 
+std::string ToRGBAHex(SkColor color, bool include_hash) {
+  std::string color_str = base::StringPrintf(
+      "%02X%02X%02X%02X", SkColorGetR(color), SkColorGetG(color),
+      SkColorGetB(color), SkColorGetA(color));
+  if (include_hash) {
+    return "#" + color_str;
+  }
+  return color_str;
+}
+
 }  // namespace electron

--- a/shell/common/color_util.h
+++ b/shell/common/color_util.h
@@ -17,6 +17,8 @@ SkColor ParseHexColor(const std::string& color_string);
 // Convert color to RGB hex value like "#ABCDEF"
 std::string ToRGBHex(SkColor color);
 
+std::string ToRGBAHex(SkColor color, bool include_hash = true);
+
 }  // namespace electron
 
 #endif  // SHELL_COMMON_COLOR_UTIL_H_


### PR DESCRIPTION
Fixes #27048

There's a helpful `skia` util for doing this so it's not too bad in the end.  Diving down the rabbit hole that is our color related APIs at the moment.  I'll be raising the transparency (missing alpha channel) issue with the API WG soon for discussion 👍 

Notes: Colors returned from `systemPreferences.getAccentColor()`, `getSystemColor` and `getColor` are now correctly converted into the devices color space.  Previously the color would have been subtly incorrect.