### PR TITLE
docs: remove unnecessary enableBlinkFeatures

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -197,9 +197,7 @@ be managed by using [ses.setPermissionCheckHandler(handler)](#sessetpermissionch
 with the `serial` permission.
 
 Because this is an experimental feature it is disabled by default.  To enable this feature, you
-will need to use the `--enable-features=ElectronSerialChooser` command line switch.  Additionally
-because this is an experimental Chromium feature you will need to set `enableBlinkFeatures: 'Serial'`
-on the `webPreferences` property when opening a BrowserWindow.
+will need to use the `--enable-features=ElectronSerialChooser` command line switch.
 
 ```javascript
 const { app, BrowserWindow } = require('electron')
@@ -211,9 +209,6 @@ app.whenReady().then(() => {
   win = new BrowserWindow({
     width: 800,
     height: 600,
-    webPreferences: {
-      enableBlinkFeatures: 'Serial'
-    }
   })
   win.webContents.session.on('select-serial-port', (event, portList, webContents, callback) => {
     event.preventDefault()

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -208,7 +208,7 @@ app.commandLine.appendSwitch('enable-features', 'ElectronSerialChooser')
 app.whenReady().then(() => {
   win = new BrowserWindow({
     width: 800,
-    height: 600,
+    height: 600
   })
   win.webContents.session.on('select-serial-port', (event, portList, webContents, callback) => {
     event.preventDefault()


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
The Web Serial API was released in Chromium v89, so it's not considered an experimental feature anymore and does not require `enableBlinkFeatures`.

/cc @jkleinsc

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added

#### Release Notes

Notes: none<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
