### PR TITLE
chore: cherry-pick b3dc4c4b349d from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -155,3 +155,4 @@ mediarecorder_tolerate_non-gmb_nv12_frames_for_h264.patch
 cherry-pick-6e8856624cbb.patch
 cherry-pick-b772b48067c4.patch
 cherry-pick-3910c9f5cde6.patch
+cherry-pick-b3dc4c4b349d.patch

--- a/patches/chromium/cherry-pick-b3dc4c4b349d.patch
+++ b/patches/chromium/cherry-pick-b3dc4c4b349d.patch
@@ -1,7 +1,7 @@
-From b3dc4c4b349dfddec0295be708010e27fb0884f4 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Hongchan Choi <hongchan@chromium.org>
-Date: Tue, 02 Mar 2021 15:17:19 +0000
-Subject: [PATCH] Introduce AudioBuffers for user access in ScriptProcessorNode
+Date: Tue, 2 Mar 2021 15:17:19 +0000
+Subject: Introduce AudioBuffers for user access in ScriptProcessorNode
 
 This CL adds new AudioBuffers for the access from the user code.
 
@@ -33,10 +33,9 @@ Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
 Commit-Queue: Artem Sumaneev <asumaneev@google.com>
 Cr-Commit-Position: refs/branch-heads/4240@{#1553}
 Cr-Branched-From: f297677702651916bbf65e59c0d4bbd4ce57d1ee-refs/heads/master@{#800218}
----
 
 diff --git a/third_party/blink/renderer/modules/webaudio/script_processor_node.cc b/third_party/blink/renderer/modules/webaudio/script_processor_node.cc
-index 6e80b23..d46e174 100644
+index 6e80b23a32dd1895a0d51d08ee16c8cb2d44fc55..d46e17440a9f3c2de488432bf3efdba5ac01f193 100644
 --- a/third_party/blink/renderer/modules/webaudio/script_processor_node.cc
 +++ b/third_party/blink/renderer/modules/webaudio/script_processor_node.cc
 @@ -42,6 +42,28 @@
@@ -68,7 +67,7 @@ index 6e80b23..d46e174 100644
  ScriptProcessorHandler::ScriptProcessorHandler(
      AudioNode& node,
      float sample_rate,
-@@ -335,6 +357,12 @@
+@@ -335,6 +357,12 @@ ScriptProcessorNode::ScriptProcessorNode(BaseAudioContext& context,
      input_buffers_.push_back(input_buffer);
      output_buffers_.push_back(output_buffer);
    }
@@ -81,7 +80,7 @@ index 6e80b23..d46e174 100644
    SetHandler(ScriptProcessorHandler::Create(
        *this, sample_rate, buffer_size, number_of_input_channels,
        number_of_output_channels, input_buffers_, output_buffers_));
-@@ -476,11 +504,62 @@
+@@ -476,11 +504,62 @@ uint32_t ScriptProcessorNode::bufferSize() const {
  
  void ScriptProcessorNode::DispatchEvent(double playback_time,
                                          uint32_t double_buffer_index) {
@@ -148,7 +147,7 @@ index 6e80b23..d46e174 100644
  }
  
  bool ScriptProcessorNode::HasPendingActivity() const {
-@@ -499,6 +578,8 @@
+@@ -499,6 +578,8 @@ bool ScriptProcessorNode::HasPendingActivity() const {
  void ScriptProcessorNode::Trace(Visitor* visitor) const {
    visitor->Trace(input_buffers_);
    visitor->Trace(output_buffers_);
@@ -158,10 +157,10 @@ index 6e80b23..d46e174 100644
  }
  
 diff --git a/third_party/blink/renderer/modules/webaudio/script_processor_node.h b/third_party/blink/renderer/modules/webaudio/script_processor_node.h
-index b166a04..9ae1789 100644
+index a93dbacc70709c063b452be3e5fe4b56fcaf7c4a..ea5ad1c326d6eb202ba6b8eba0ac5b5d0f1f61b1 100644
 --- a/third_party/blink/renderer/modules/webaudio/script_processor_node.h
 +++ b/third_party/blink/renderer/modules/webaudio/script_processor_node.h
-@@ -168,6 +168,8 @@
+@@ -169,6 +169,8 @@ class ScriptProcessorNode final
   private:
    HeapVector<Member<AudioBuffer>> input_buffers_;
    HeapVector<Member<AudioBuffer>> output_buffers_;

--- a/patches/chromium/cherry-pick-b3dc4c4b349d.patch
+++ b/patches/chromium/cherry-pick-b3dc4c4b349d.patch
@@ -1,0 +1,172 @@
+From b3dc4c4b349dfddec0295be708010e27fb0884f4 Mon Sep 17 00:00:00 2001
+From: Hongchan Choi <hongchan@chromium.org>
+Date: Tue, 02 Mar 2021 15:17:19 +0000
+Subject: [PATCH] Introduce AudioBuffers for user access in ScriptProcessorNode
+
+This CL adds new AudioBuffers for the access from the user code.
+
+(cherry picked from commit b9e60ddc7606689e508f295077656389380288ba)
+
+(cherry picked from commit c281886ca9ff22f6e75c8c1967dab9bf18b9942d)
+
+(cherry picked from commit 33861dcf6d15415b6abf2152440906fafb74a27a)
+
+Bug: 1177465
+Test: The local ASAN build doesn't reproduce on given POCs.
+Change-Id: Id9a3505ddb9ab61b4442385d0b830ef56f65f797
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2718543
+Auto-Submit: Hongchan Choi <hongchan@chromium.org>
+Reviewed-by: Raymond Toy <rtoy@chromium.org>
+Commit-Queue: Hongchan Choi <hongchan@chromium.org>
+Cr-Original-Original-Original-Commit-Position: refs/heads/master@{#857817}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2719239
+Reviewed-by: Krishna Govind <govind@chromium.org>
+Cr-Original-Original-Commit-Position: refs/branch-heads/4429@{#2}
+Cr-Original-Original-Branched-From: 19b974fae7ec51a60e2f1044d81e2e1b32be179b-refs/heads/master@{#857666}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2721252
+Reviewed-by: Adrian Taylor <adetaylor@google.com>
+Commit-Queue: Krishna Govind <govind@chromium.org>
+Cr-Original-Commit-Position: refs/branch-heads/4324@{#2250}
+Cr-Original-Branched-From: c73b5a651d37a6c4d0b8e3262cc4015a5579c6c8-refs/heads/master@{#827102}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2727696
+Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
+Commit-Queue: Artem Sumaneev <asumaneev@google.com>
+Cr-Commit-Position: refs/branch-heads/4240@{#1553}
+Cr-Branched-From: f297677702651916bbf65e59c0d4bbd4ce57d1ee-refs/heads/master@{#800218}
+---
+
+diff --git a/third_party/blink/renderer/modules/webaudio/script_processor_node.cc b/third_party/blink/renderer/modules/webaudio/script_processor_node.cc
+index 6e80b23..d46e174 100644
+--- a/third_party/blink/renderer/modules/webaudio/script_processor_node.cc
++++ b/third_party/blink/renderer/modules/webaudio/script_processor_node.cc
+@@ -42,6 +42,28 @@
+ 
+ namespace blink {
+ 
++namespace {
++
++bool IsAudioBufferDetached(AudioBuffer* buffer) {
++  bool is_buffer_detached = false;
++  for (unsigned channel = 0; channel < buffer->numberOfChannels(); ++channel) {
++    if (buffer->getChannelData(channel)->buffer()->IsDetached()) {
++      is_buffer_detached = true;
++      break;
++    }
++  }
++
++  return is_buffer_detached;
++}
++
++bool BufferTopologyMatches(AudioBuffer* buffer_1, AudioBuffer* buffer_2) {
++  return (buffer_1->numberOfChannels() == buffer_2->numberOfChannels()) &&
++         (buffer_1->length() == buffer_2->length()) &&
++         (buffer_1->sampleRate() == buffer_2->sampleRate());
++}
++
++}  // namespace
++
+ ScriptProcessorHandler::ScriptProcessorHandler(
+     AudioNode& node,
+     float sample_rate,
+@@ -335,6 +357,12 @@
+     input_buffers_.push_back(input_buffer);
+     output_buffers_.push_back(output_buffer);
+   }
++
++  external_input_buffer_ = AudioBuffer::Create(
++      number_of_input_channels, buffer_size, sample_rate);
++  external_output_buffer_ = AudioBuffer::Create(
++      number_of_output_channels, buffer_size, sample_rate);
++
+   SetHandler(ScriptProcessorHandler::Create(
+       *this, sample_rate, buffer_size, number_of_input_channels,
+       number_of_output_channels, input_buffers_, output_buffers_));
+@@ -476,11 +504,62 @@
+ 
+ void ScriptProcessorNode::DispatchEvent(double playback_time,
+                                         uint32_t double_buffer_index) {
+-  AudioBuffer* input_buffer = input_buffers_.at(double_buffer_index).Get();
+-  AudioBuffer* output_buffer = output_buffers_.at(double_buffer_index).Get();
+-  DCHECK(output_buffer);
++  DCHECK(IsMainThread());
++
++  AudioBuffer* backing_input_buffer =
++      input_buffers_.at(double_buffer_index).Get();
++
++  // The backing buffer can be nullptr, when the number of input channels is 0.
++  if (backing_input_buffer) {
++    // Also the author code might have transferred |external_input_buffer| to
++    // other threads or replaced it with a different AudioBuffer object. Then
++    // re-create a new buffer instance.
++    if (IsAudioBufferDetached(external_input_buffer_) ||
++        !BufferTopologyMatches(backing_input_buffer,
++                               external_input_buffer_)) {
++      external_input_buffer_ = AudioBuffer::Create(
++          backing_input_buffer->numberOfChannels(),
++          backing_input_buffer->length(),
++          backing_input_buffer->sampleRate());
++    }
++
++    for (unsigned channel = 0;
++         channel < backing_input_buffer->numberOfChannels(); ++channel) {
++      const float* source = static_cast<float*>(
++          backing_input_buffer->getChannelData(channel)->buffer()->Data());
++      float* destination = static_cast<float*>(
++          external_input_buffer_->getChannelData(channel)->buffer()->Data());
++      memcpy(destination, source,
++             backing_input_buffer->length() * sizeof(float));
++    }
++  }
++
+   AudioNode::DispatchEvent(*AudioProcessingEvent::Create(
+-      input_buffer, output_buffer, playback_time));
++      external_input_buffer_, external_output_buffer_, playback_time));
++
++  AudioBuffer* backing_output_buffer =
++      output_buffers_.at(double_buffer_index).Get();
++
++  if (backing_output_buffer) {
++    if (IsAudioBufferDetached(external_output_buffer_) ||
++        !BufferTopologyMatches(backing_output_buffer,
++                               external_output_buffer_)) {
++      external_output_buffer_ = AudioBuffer::Create(
++          backing_output_buffer->numberOfChannels(),
++          backing_output_buffer->length(),
++          backing_output_buffer->sampleRate());
++    }
++
++    for (unsigned channel = 0;
++         channel < backing_output_buffer->numberOfChannels(); ++channel) {
++      const float* source = static_cast<float*>(
++          external_output_buffer_->getChannelData(channel)->buffer()->Data());
++      float* destination = static_cast<float*>(
++          backing_output_buffer->getChannelData(channel)->buffer()->Data());
++      memcpy(destination, source,
++             backing_output_buffer->length() * sizeof(float));
++    }
++  }
+ }
+ 
+ bool ScriptProcessorNode::HasPendingActivity() const {
+@@ -499,6 +578,8 @@
+ void ScriptProcessorNode::Trace(Visitor* visitor) const {
+   visitor->Trace(input_buffers_);
+   visitor->Trace(output_buffers_);
++  visitor->Trace(external_input_buffer_);
++  visitor->Trace(external_output_buffer_);
+   AudioNode::Trace(visitor);
+ }
+ 
+diff --git a/third_party/blink/renderer/modules/webaudio/script_processor_node.h b/third_party/blink/renderer/modules/webaudio/script_processor_node.h
+index b166a04..9ae1789 100644
+--- a/third_party/blink/renderer/modules/webaudio/script_processor_node.h
++++ b/third_party/blink/renderer/modules/webaudio/script_processor_node.h
+@@ -168,6 +168,8 @@
+  private:
+   HeapVector<Member<AudioBuffer>> input_buffers_;
+   HeapVector<Member<AudioBuffer>> output_buffers_;
++  Member<AudioBuffer> external_input_buffer_;
++  Member<AudioBuffer> external_output_buffer_;
+ };
+ 
+ }  // namespace blink


### PR DESCRIPTION
Introduce AudioBuffers for user access in ScriptProcessorNode

This CL adds new AudioBuffers for the access from the user code.

(cherry picked from commit b9e60ddc7606689e508f295077656389380288ba)

(cherry picked from commit c281886ca9ff22f6e75c8c1967dab9bf18b9942d)

(cherry picked from commit 33861dcf6d15415b6abf2152440906fafb74a27a)

Bug: 1177465
Test: The local ASAN build doesn't reproduce on given POCs.
Change-Id: Id9a3505ddb9ab61b4442385d0b830ef56f65f797
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2718543
Auto-Submit: Hongchan Choi <hongchan@chromium.org>
Reviewed-by: Raymond Toy <rtoy@chromium.org>
Commit-Queue: Hongchan Choi <hongchan@chromium.org>
Cr-Original-Original-Original-Commit-Position: refs/heads/master@{#857817}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2719239
Reviewed-by: Krishna Govind <govind@chromium.org>
Cr-Original-Original-Commit-Position: refs/branch-heads/4429@{#2}
Cr-Original-Original-Branched-From: 19b974fae7ec51a60e2f1044d81e2e1b32be179b-refs/heads/master@{#857666}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2721252
Reviewed-by: Adrian Taylor <adetaylor@google.com>
Commit-Queue: Krishna Govind <govind@chromium.org>
Cr-Original-Commit-Position: refs/branch-heads/4324@{#2250}
Cr-Original-Branched-From: c73b5a651d37a6c4d0b8e3262cc4015a5579c6c8-refs/heads/master@{#827102}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2727696
Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
Commit-Queue: Artem Sumaneev <asumaneev@google.com>
Cr-Commit-Position: refs/branch-heads/4240@{#1553}
Cr-Branched-From: f297677702651916bbf65e59c0d4bbd4ce57d1ee-refs/heads/master@{#800218}


Notes: Security: backported fix for CVE-2021-21166.