### PR TITLE
docs: remove "Additional information" section from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,3 @@ body:
     label: Testcase Gist URL
     description: If you can reproduce the issue in a standalone test case, please use [Electron Fiddle](https://github.com/electron/fiddle) to create one and to publish it as a [GitHub gist](https://gist.github.com) and put the gist URL here. This is **the best way** to ensure this issue is triaged quickly.
     placeholder: https://gist.github.com/...
-- type: textarea
-  attributes:
-    label: Additional Information
-    description: If your problem needs further explanation, or if the issue you're seeing cannot be reproduced in a gist, please add more information here.


### PR DESCRIPTION
The template includes a comment section at the end anyway:

![image](https://user-images.githubusercontent.com/172800/110837615-4ddc1780-8256-11eb-8db1-5067a3fb9b8d.png)

Notes: none