### PR TITLE
docs: about->description in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-about: Report an Electron bug
+description: Report an Electron bug
 title: "[Bug]: "
 body:
 - type: checkboxes


### PR DESCRIPTION
looks like the top-level `about` is deprecated?

Notes: none