### PR TITLE
docs: use :syntax: for emoji in feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
-about: Suggest an idea for Electron
+description: Suggest an idea for Electron
 title: "[Feature Request]: "
-labels: "enhancement ✨"
+labels: "enhancement :sparkles:"
 body:
 - type: checkboxes
   attributes:


### PR DESCRIPTION
I hope this is the right syntax? the existing one doesn't seem to be working.

Notes: none