### PR TITLE
fix: recalibrate simpleFullscreen when display metrics change

### DIFF
--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -147,6 +147,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual bool IsExcludedFromShownWindowsMenu() = 0;
   virtual void SetSimpleFullScreen(bool simple_fullscreen) = 0;
   virtual bool IsSimpleFullScreen() = 0;
+  virtual void UpdateFrame() = 0;
   virtual void SetKiosk(bool kiosk) = 0;
   virtual bool IsKiosk() = 0;
   virtual bool IsTabletMode() const;

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -147,7 +147,6 @@ class NativeWindow : public base::SupportsUserData,
   virtual bool IsExcludedFromShownWindowsMenu() = 0;
   virtual void SetSimpleFullScreen(bool simple_fullscreen) = 0;
   virtual bool IsSimpleFullScreen() = 0;
-  virtual void UpdateFrame() = 0;
   virtual void SetKiosk(bool kiosk) = 0;
   virtual bool IsKiosk() = 0;
   virtual bool IsTabletMode() const;
@@ -208,6 +207,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetTrafficLightPosition(base::Optional<gfx::Point> position) = 0;
   virtual base::Optional<gfx::Point> GetTrafficLightPosition() const = 0;
   virtual void RedrawTrafficLights() = 0;
+  virtual void UpdateFrame() = 0;
 #endif
 
   // Touchbar API

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -14,6 +14,7 @@
 
 #include "base/mac/scoped_nsobject.h"
 #include "shell/browser/native_window.h"
+#include "ui/display/display_observer.h"
 #include "ui/native_theme/native_theme_observer.h"
 #include "ui/views/controls/native/native_view_host.h"
 
@@ -27,7 +28,9 @@ namespace electron {
 
 class RootViewMac;
 
-class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
+class NativeWindowMac : public NativeWindow,
+                        public ui::NativeThemeObserver,
+                        public display::DisplayObserver {
  public:
   NativeWindowMac(const gin_helper::Dictionary& options, NativeWindow* parent);
   ~NativeWindowMac() override;
@@ -187,6 +190,10 @@ class NativeWindowMac : public NativeWindow, public ui::NativeThemeObserver {
 
   // ui::NativeThemeObserver:
   void OnNativeThemeUpdated(ui::NativeTheme* observed_theme) override;
+
+  // display::DisplayObserver:
+  void OnDisplayMetricsChanged(const display::Display& display,
+                               uint32_t changed_metrics) override;
 
  private:
   // Add custom layers to the content view.

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -89,6 +89,7 @@ class NativeWindowMac : public NativeWindow,
   bool IsExcludedFromShownWindowsMenu() override;
   void SetSimpleFullScreen(bool simple_fullscreen) override;
   bool IsSimpleFullScreen() override;
+  void UpdateFrame() override;
   void SetKiosk(bool kiosk) override;
   bool IsKiosk() override;
   void SetBackgroundColor(SkColor color) override;

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -89,7 +89,6 @@ class NativeWindowMac : public NativeWindow,
   bool IsExcludedFromShownWindowsMenu() override;
   void SetSimpleFullScreen(bool simple_fullscreen) override;
   bool IsSimpleFullScreen() override;
-  void UpdateFrame() override;
   void SetKiosk(bool kiosk) override;
   bool IsKiosk() override;
   void SetBackgroundColor(SkColor color) override;
@@ -128,6 +127,7 @@ class NativeWindowMac : public NativeWindow,
   void SetTrafficLightPosition(base::Optional<gfx::Point> position) override;
   base::Optional<gfx::Point> GetTrafficLightPosition() const override;
   void RedrawTrafficLights() override;
+  void UpdateFrame() override;
   void SetTouchBar(
       std::vector<gin_helper::PersistentDictionary> items) override;
   void RefreshTouchBarItem(const std::string& item_id) override;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -444,9 +444,7 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   original_level_ = [window_ level];
 }
 
-NativeWindowMac::~NativeWindowMac() {
-  display::Screen::GetScreen()->RemoveObserver(this);
-}
+NativeWindowMac::~NativeWindowMac() {}
 
 void NativeWindowMac::SetContentView(views::View* view) {
   views::View* root_view = GetContentsView();
@@ -884,13 +882,6 @@ bool NativeWindowMac::IsExcludedFromShownWindowsMenu() {
 void NativeWindowMac::SetExcludedFromShownWindowsMenu(bool excluded) {
   NSWindow* window = GetNativeWindow().GetNativeNSWindow();
   [window setExcludedFromWindowsMenu:excluded];
-}
-
-// In simpleFullScreen mode, update the frame for new bounds.
-void NativeWindowMac::UpdateFrame() {
-  NSWindow* window = GetNativeWindow().GetNativeNSWindow();
-  NSRect fullscreenFrame = [window.screen frame];
-  [window setFrame:fullscreenFrame display:YES animate:YES];
 }
 
 void NativeWindowMac::OnDisplayMetricsChanged(const display::Display& display,
@@ -1416,6 +1407,13 @@ void NativeWindowMac::RedrawTrafficLights() {
     [buttons_view_ setNeedsDisplayForButtons];
 }
 
+// In simpleFullScreen mode, update the frame for new bounds.
+void NativeWindowMac::UpdateFrame() {
+  NSWindow* window = GetNativeWindow().GetNativeNSWindow();
+  NSRect fullscreenFrame = [window.screen frame];
+  [window setFrame:fullscreenFrame display:YES animate:YES];
+}
+
 void NativeWindowMac::SetTouchBar(
     std::vector<gin_helper::PersistentDictionary> items) {
   if (@available(macOS 10.12.2, *)) {
@@ -1571,6 +1569,7 @@ void NativeWindowMac::NotifyWindowWillLeaveFullScreen() {
 void NativeWindowMac::Cleanup() {
   DCHECK(!IsClosed());
   ui::NativeTheme::GetInstanceForNativeUi()->RemoveObserver(this);
+  display::Screen::GetScreen()->RemoveObserver(this);
   [NSEvent removeMonitor:wheel_event_monitor_];
 }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/15494.

Overrides `OnDisplayMetricsChanged` in `NativeWindowMac` so that when display metrics change and the `BrowserWindow` is in `simpleFullscreen` mode, the frame is recalibrated for the new bounds.

Tested with https://gist.github.com/bpasero/e4013ea83033a8c231f58f94c0df57c3.

cc @bpasero 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where windows in `simpleFullscreen` mode were not properly resizing when display metrics changed.
