### PR TITLE
fix: documentEdited property on BrowserWindow

### DIFF
--- a/lib/browser/api/top-level-window.js
+++ b/lib/browser/api/top-level-window.js
@@ -45,7 +45,7 @@ Object.defineProperty(TopLevelWindow.prototype, 'kiosk', {
 });
 
 Object.defineProperty(TopLevelWindow.prototype, 'documentEdited', {
-  get: function () { return this.isFullscreen(); },
+  get: function () { return this.isDocumentEdited(); },
   set: function (edited) { this.setDocumentEdited(edited); }
 });
 


### PR DESCRIPTION
Manual backport of #27823

See that PR for details.

Notes: Fixed BrowserWindow.documentEdited property on top level window.