### PR TITLE
fix: libuv hang on Windows

### DIFF
--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -534,15 +534,13 @@ void NodeBindings::LoadEnvironment(node::Environment* env) {
 void NodeBindings::PrepareMessageLoop() {
 #if !defined(OS_WIN)
   int handle = uv_backend_fd(uv_loop_);
-#else
-  HANDLE handle = uv_loop_->iocp;
-#endif
 
   // If the backend fd hasn't changed, don't proceed.
   if (handle == handle_)
     return;
 
   handle_ = handle;
+#endif
 
   // Add dummy handle for libuv, otherwise libuv would quit when there is
   // nothing to do.

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -159,9 +159,7 @@ class NodeBindings {
   // Isolate data used in creating the environment
   node::IsolateData* isolate_data_ = nullptr;
 
-#if defined(OS_WIN)
-  HANDLE handle_;
-#else
+#if !defined(OS_WIN)
   int handle_ = -1;
 #endif
 

--- a/spec-main/fixtures/apps/libuv-hang/index.html
+++ b/spec-main/fixtures/apps/libuv-hang/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'">
+    <meta http-equiv="X-Content-Security-Policy" content="default-src 'self'; script-src 'self'">
+    <title>Hello World!</title>
+  </head>
+  <body>
+    <h1>Hello World!</h1>
+    <script src="./renderer.js"></script>
+  </body>
+</html>

--- a/spec-main/fixtures/apps/libuv-hang/main.js
+++ b/spec-main/fixtures/apps/libuv-hang/main.js
@@ -1,0 +1,36 @@
+const { app, BrowserWindow, ipcMain } = require('electron');
+const path = require('path');
+
+async function createWindow () {
+  const mainWindow = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js')
+    }
+  });
+
+  await mainWindow.loadFile('index.html');
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  app.on('activate', function () {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+let count = 0;
+ipcMain.handle('reload-successful', () => {
+  if (count === 2) {
+    app.quit();
+  } else {
+    count++;
+    return count;
+  }
+});
+
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/spec-main/fixtures/apps/libuv-hang/preload.js
+++ b/spec-main/fixtures/apps/libuv-hang/preload.js
@@ -1,0 +1,16 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('api', {
+  ipcRenderer,
+  run: async () => {
+    const { promises: fs } = require('fs');
+    for (let i = 0; i < 10; i++) {
+      const list = await fs.readdir('.', { withFileTypes: true });
+      for (const file of list) {
+        if (file.isFile()) {
+          await fs.readFile(file.name, 'utf-8');
+        }
+      }
+    }
+  }
+});

--- a/spec-main/fixtures/apps/libuv-hang/renderer.js
+++ b/spec-main/fixtures/apps/libuv-hang/renderer.js
@@ -1,0 +1,8 @@
+const count = localStorage.getItem('count');
+
+const { run, ipcRenderer } = window.api;
+
+run().then(async () => {
+  const count = await ipcRenderer.invoke('reload-successful');
+  if (count < 3) location.reload();
+}).catch(console.log);

--- a/spec-main/node-spec.ts
+++ b/spec-main/node-spec.ts
@@ -7,6 +7,7 @@ import { ifdescribe, ifit } from './spec-helpers';
 import { webContents, WebContents } from 'electron/main';
 
 const features = process._linkedBinding('electron_common_features');
+const mainFixturesPath = path.resolve(__dirname, 'fixtures');
 
 describe('node feature', () => {
   const fixtures = path.join(__dirname, '..', 'spec', 'fixtures');
@@ -20,6 +21,16 @@ describe('node feature', () => {
         expect(msg).to.equal('message');
       });
     });
+  });
+
+  it('does not hang when using the fs module in the renderer process', async () => {
+    const appPath = path.join(mainFixturesPath, 'apps', 'libuv-hang', 'main.js');
+    const appProcess = childProcess.spawn(process.execPath, [appPath], {
+      cwd: path.join(mainFixturesPath, 'apps', 'libuv-hang'),
+      stdio: 'inherit'
+    });
+    const [code] = await emittedOnce(appProcess, 'close');
+    expect(code).to.equal(0);
   });
 
   describe('contexts', () => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/28154.

https://github.com/electron/electron/pull/25869 used `uv_loop_->iocp` to decide whether to re-prep the message loop, and it turns out not to be the case that it works and updates the same way that `uv_backend_fd` does, so what resulted was that when `allowRendererProcessReuse` was true the loop would not re-prep on reload and libuv would hang.

This fixes that by only handling this case on non-Windows systems.

Tested with https://gist.github.com/codebytere/2face1c26d09e38c06f49111c3fca13f.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where some Node.js modules would hang on page reload on Windows.