### PR TITLE
ci: create issues helper

### DIFF
--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -1,0 +1,31 @@
+name: Issue Close Require
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  close:
+    runs-on: ubuntu-latest
+    steps:
+      - name: need-repro
+        uses: actions-cool/issues-helper@v2.1.2
+        with:
+          actions: 'close-issues'
+          labels: 'blocked/need-repro'
+          inactive-day: 10
+          body: |
+            Thank you for your issue!
+
+            We haven't gotten a response to our questions in our comment above. With only the information that is currently in the issue, we don't have enough information to take action. I'm going to close this but don't hesitate to reach out if you have or find the answers we need, we'll be happy to reopen the issue.
+
+      - name: need-info
+        uses: actions-cool/issues-helper@v2.1.2
+        with:
+          actions: 'close-issues'
+          labels: 'blocked/need-info ❌'
+          inactive-day: 10
+          body: |
+            Thank you for your issue!
+
+            We haven't gotten a response to our questions in our comment above. With only the information that is currently in the issue, we don't have enough information to take action. I'm going to close this but don't hesitate to reach out if you have or find the answers we need, we'll be happy to reopen the issue.

--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -15,7 +15,7 @@ jobs:
           labels: 'blocked/need-repro'
           inactive-day: 10
           body: |
-            Thank you for your issue!
+            Thanks for your issue!
 
             We haven't gotten a response to our questions in our comment above. With only the information that is currently in the issue, we don't have enough information to take action. I'm going to close this but don't hesitate to reach out if you have or find the answers we need, we'll be happy to reopen the issue.
 
@@ -26,6 +26,6 @@ jobs:
           labels: 'blocked/need-info ❌'
           inactive-day: 10
           body: |
-            Thank you for your issue!
+            Thanks for your issue!
 
             We haven't gotten a response to our questions in our comment above. With only the information that is currently in the issue, we don't have enough information to take action. I'm going to close this but don't hesitate to reach out if you have or find the answers we need, we'll be happy to reopen the issue.

--- a/.github/workflows/issue-reply.yml
+++ b/.github/workflows/issue-reply.yml
@@ -22,7 +22,7 @@ jobs:
 
             Stand-alone test cases make fixing issues go more smoothly: it ensure everyone's looking at the same issue, it removes all unnecessary variables from the equation, and it can also provide the basis for automated regression tests.
 
-            I'm adding the blocked/need-repro label for this reason. After you make a test case, please link to it in a followup comment. This issue will be closed 10 days from now if there is no response.
+            I'm adding the `blocked/need-repro` label for this reason. After you make a test case, please link to it in a followup comment. This issue will be closed 10 days from now if there is no response.
 
             Thanks in advance! Your help is appreciated.
 

--- a/.github/workflows/issue-reply.yml
+++ b/.github/workflows/issue-reply.yml
@@ -1,0 +1,45 @@
+name: Issue Reply
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  reply:
+    runs-on: ubuntu-latest
+    steps:
+      - name: need-repro
+        if: github.event.label.name == 'blocked/need-repro'
+        uses: actions-cool/issues-helper@v2.1.2
+        with:
+          actions: 'create-comment'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Hi @${{ github.event.issue.user.login }}. Thanks for reporting this and helping to make Electron better!
+
+            Would it be possible for you to make a standalone test case with only the code necessary to reproduce the issue? For example, [Electron Fiddle](https://www.electronjs.org/fiddle) is a great tool for making small test cases and makes it easy to publish your test case to a [gist](https://gist.github.com) that Electron maintainers can use.
+
+            Stand-alone test cases make fixing issues go more smoothly: it ensure everyone's looking at the same issue, it removes all unnecessary variables from the equation, and it can also provide the basis for automated regression tests.
+
+            I'm adding the blocked/need-repro label for this reason. After you make a test case, please link to it in a followup comment. This issue will be closed 10 days from now if there is no response.
+
+            Thanks in advance! Your help is appreciated.
+
+      - name: need-info
+        if: github.event.label.name == 'blocked/need-info ❌'
+        uses: actions-cool/issues-helper@v2.1.2
+        with:
+          actions: 'create-comment'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Hi @${{ github.event.issue.user.login }}. Thank you for taking the time to report this issue and helping to make Electron better.
+
+            The version of Electron you reported this on has been superseded by newer releases. See our [supported versions documentation](https://www.electronjs.org/docs/tutorial/support#supported-versions).
+
+            If you're still experiencing this issue in Electron 10.x.y or later, please add a comment specifying the version you're testing with and any other new information that a maintainer trying to reproduce the issue should know.
+
+            I'm setting the `blocked/need-info` label for the above reasons. This issue will be closed 10 days from now if there is no response.
+
+            Thanks in advance! Your help is appreciated.


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

ref: https://github.com/electron/electron/issues/27955 https://github.com/electron/electron/issues/27959 https://github.com/electron/electron/issues/28142 https://github.com/electron/electron/issues/28158

Hi, I found that when you mark the label, you usually need to reply manually. 

This change is to use GitHub Action to help you accomplish this.

I'm sure it will save you time. It support:

1. When you set a label to a issue, it will comment.
2. When the labeled issues has not active 10 days, it will auto close and comment to remind user.

Have a good day~

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> GitHub Actions
