### PR TITLE
chore: cherry-pick 5651fb858b75 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -134,3 +134,4 @@ cherry-pick-eb0c0353bf24.patch
 mediarecorder_tolerate_non-gmb_nv12_frames_for_h264.patch
 cherry-pick-18d3f86206e8.patch
 cherry-pick-6e8856624cbb.patch
+cherry-pick-5651fb858b75.patch

--- a/patches/chromium/cherry-pick-5651fb858b75.patch
+++ b/patches/chromium/cherry-pick-5651fb858b75.patch
@@ -1,7 +1,10 @@
-From 5651fb858b754b6bdee525b9a0c7b65616c4f93e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Harald Alvestrand <hta@chromium.org>
 Date: Thu, 11 Mar 2021 18:54:23 +0000
-Subject: [PATCH] [Merge to M89] Iterate more carefully over DTLS transports at close
+Subject: Iterate more carefully over DTLS transports at close
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 Ensure that even if the set of DTLS transports is modified during
 callbacks called from close, the process will be well-defined.
@@ -18,13 +21,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2752880
 Reviewed-by: Adrian Taylor <adetaylor@chromium.org>
 Cr-Commit-Position: refs/branch-heads/4389@{#1521}
 Cr-Branched-From: 9251c5db2b6d5a59fe4eac7aafa5fed37c139bb7-refs/heads/master@{#843830}
----
 
 diff --git a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc
-index a10aa12..463a99e 100644
+index 47a1fa272e0f077998241c771c307704fac2425a..451be645fc92dee9cae2e4caf67fda80ad69acb3 100644
 --- a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc
 +++ b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc
-@@ -3578,8 +3578,14 @@
+@@ -3519,8 +3519,14 @@ void RTCPeerConnection::CloseInternal() {
    if (sctp_transport_) {
      sctp_transport_->Close();
    }

--- a/patches/chromium/cherry-pick-5651fb858b75.patch
+++ b/patches/chromium/cherry-pick-5651fb858b75.patch
@@ -1,0 +1,43 @@
+From 5651fb858b754b6bdee525b9a0c7b65616c4f93e Mon Sep 17 00:00:00 2001
+From: Harald Alvestrand <hta@chromium.org>
+Date: Thu, 11 Mar 2021 18:54:23 +0000
+Subject: [PATCH] [Merge to M89] Iterate more carefully over DTLS transports at close
+
+Ensure that even if the set of DTLS transports is modified during
+callbacks called from close, the process will be well-defined.
+
+(cherry picked from commit 4f62c7bb28b0ce77b773a611c6ba02b361db1c85)
+
+Bug: chromium:1167357
+Change-Id: I712280e7382a647027912178156127831b437f75
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2639893
+Reviewed-by: Henrik Boström <hbos@chromium.org>
+Commit-Queue: Harald Alvestrand <hta@chromium.org>
+Cr-Original-Commit-Position: refs/heads/master@{#845122}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2752880
+Reviewed-by: Adrian Taylor <adetaylor@chromium.org>
+Cr-Commit-Position: refs/branch-heads/4389@{#1521}
+Cr-Branched-From: 9251c5db2b6d5a59fe4eac7aafa5fed37c139bb7-refs/heads/master@{#843830}
+---
+
+diff --git a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc
+index a10aa12..463a99e 100644
+--- a/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc
++++ b/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc
+@@ -3578,8 +3578,14 @@
+   if (sctp_transport_) {
+     sctp_transport_->Close();
+   }
+-  for (auto& dtls_transport_iter : dtls_transports_by_native_transport_) {
+-    dtls_transport_iter.value->Close();
++  // Since Close() can trigger JS-level callbacks, iterate over a copy
++  // of the transports list.
++  auto dtls_transports_copy = dtls_transports_by_native_transport_;
++  for (auto& dtls_transport_iter : dtls_transports_copy) {
++    // Since "value" is a WeakPtr, check if it's still valid.
++    if (dtls_transport_iter.value) {
++      dtls_transport_iter.value->Close();
++    }
+   }
+ 
+   feature_handle_for_scheduler_.reset();


### PR DESCRIPTION
[Merge to M89] Iterate more carefully over DTLS transports at close

Ensure that even if the set of DTLS transports is modified during
callbacks called from close, the process will be well-defined.

(cherry picked from commit 4f62c7bb28b0ce77b773a611c6ba02b361db1c85)

Bug: chromium:1167357
Change-Id: I712280e7382a647027912178156127831b437f75
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2639893
Reviewed-by: Henrik Boström <hbos@chromium.org>
Commit-Queue: Harald Alvestrand <hta@chromium.org>
Cr-Original-Commit-Position: refs/heads/master@{#845122}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2752880
Reviewed-by: Adrian Taylor <adetaylor@chromium.org>
Cr-Commit-Position: refs/branch-heads/4389@{#1521}
Cr-Branched-From: 9251c5db2b6d5a59fe4eac7aafa5fed37c139bb7-refs/heads/master@{#843830}


Notes: Security: backported fix for chromium:1167357.