### PR TITLE
fix: enable system maximization for frameless windows except if transparent

### DIFF
--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -83,8 +83,10 @@ win.show()
   blur effect to the content below the window (i.e. other applications open on
   the user's system).
 * The window will not be transparent when DevTools is opened.
-* On Windows operating systems, transparent windows will not work when DWM is
+* On Windows operating systems,
+  * transparent windows will not work when DWM is
   disabled.
+  * transparent windows can not be maximized using the Windows system menu or by double clicking the title bar. The reasoning behind this can be seen on [this pull request](https://github.com/electron/electron/pull/28207).
 * On Linux, users have to put `--enable-transparent-visuals --disable-gpu` in
   the command line to disable GPU and allow ARGB to make transparent window,
   this is caused by an upstream bug that [alpha channel doesn't work on some

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -530,7 +530,7 @@ void NativeWindowViews::Maximize() {
 
 void NativeWindowViews::Unmaximize() {
 #if defined(OS_WIN)
-  if (!(::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE) & WS_THICKFRAME)) {
+  if (transparent()) {
     SetBounds(restore_bounds_, false);
     return;
   }
@@ -543,11 +543,8 @@ bool NativeWindowViews::IsMaximized() {
   if (widget()->IsMaximized()) {
     return true;
   } else {
-    // For window without WS_THICKFRAME style, IsMaximized() will not correctly
-    // check the window state. This path will be used for transparent windows as
-    // well.
 #if defined(OS_WIN)
-    if (!(::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE) & WS_THICKFRAME)) {
+    if (transparent()) {
       // Compare the size of the window with the size of the display
       auto display = display::Screen::GetScreen()->GetDisplayNearestWindow(
           GetNativeWindow());

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -540,10 +540,9 @@ void NativeWindowViews::Unmaximize() {
 }
 
 bool NativeWindowViews::IsMaximized() {
-  if (widget()->IsMaximized())
+  if (widget()->IsMaximized()) {
     return true;
-
-  else {
+  } else {
     // For window without WS_THICKFRAME style, IsMaximized() will not correctly
     // check the window state. This path will be used for transparent windows as
     // well.

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -540,21 +540,26 @@ void NativeWindowViews::Unmaximize() {
 }
 
 bool NativeWindowViews::IsMaximized() {
-  // For window without WS_THICKFRAME style, we can not call IsMaximized().
-  // This path will be used for transparent windows as well.
+  if (widget()->IsMaximized())
+    return true;
 
+  else {
+    // For window without WS_THICKFRAME style, IsMaximized() will not correctly
+    // check the window state. This path will be used for transparent windows as
+    // well.
 #if defined(OS_WIN)
-  if (!(::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE) & WS_THICKFRAME)) {
-    // Compare the size of the window with the size of the display
-    auto display = display::Screen::GetScreen()->GetDisplayNearestWindow(
-        GetNativeWindow());
-    // Maximized if the window is the same dimensions and placement as the
-    // display
-    return GetBounds() == display.work_area();
-  }
+    if (!(::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE) & WS_THICKFRAME)) {
+      // Compare the size of the window with the size of the display
+      auto display = display::Screen::GetScreen()->GetDisplayNearestWindow(
+          GetNativeWindow());
+      // Maximized if the window is the same dimensions and placement as the
+      // display
+      return GetBounds() == display.work_area();
+    }
 #endif
 
-  return widget()->IsMaximized();
+    return false;
+  }
 }
 
 void NativeWindowViews::Minimize() {

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -150,7 +150,7 @@ HHOOK NativeWindowViews::mouse_hook_ = NULL;
 
 void NativeWindowViews::Maximize() {
   // Only use Maximize() when window has WS_THICKFRAME style
-  if (::GetWindowLong(GetAcceleratedWidget(), GWL_STYLE) & WS_THICKFRAME) {
+  if (!transparent()) {
     if (IsVisible())
       widget()->Maximize();
     else
@@ -323,6 +323,12 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
       NotifyWindowSystemContextMenu(GET_X_LPARAM(l_param),
                                     GET_Y_LPARAM(l_param), &prevent_default);
       return prevent_default;
+    }
+    case WM_SYSCOMMAND: {
+      if (transparent() && w_param == SC_MAXIMIZE) {
+        return true;
+      }
+      return false;
     }
     default:
       return false;

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -326,8 +326,27 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
     }
     case WM_SYSCOMMAND: {
       if (transparent() && w_param == SC_MAXIMIZE) {
+        LOG(INFO)
+            << "NativeWindowViews::PreHandleMSG - SYSTEM MAXIMIZE CALLED - "
+            << __LINE__;
         return true;
       }
+      return false;
+    }
+    case WM_INITMENU: {
+#if defined(OS_WIN)
+      // This is handling the scenario where the menu might get triggered by the
+      // user doing "alt + space" resultin in system maximization and restore
+      // being used on transparent windows when that does not work
+      HMENU menu = GetSystemMenu(GetAcceleratedWidget(), false);
+      if (transparent()) {
+        EnableMenuItem(menu, SC_MAXIMIZE,
+                       MF_BYCOMMAND | MF_DISABLED | MF_GRAYED);
+        EnableMenuItem(menu, SC_RESTORE,
+                       MF_BYCOMMAND | MF_DISABLED | MF_GRAYED);
+        return true;
+      }
+#endif
       return false;
     }
     default:

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -336,8 +336,8 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
       // This is handling the scenario where the menu might get triggered by the
       // user doing "alt + space" resulting in system maximization and restore
       // being used on transparent windows when that does not work.
-      HMENU menu = GetSystemMenu(GetAcceleratedWidget(), false);
       if (transparent()) {
+        HMENU menu = GetSystemMenu(GetAcceleratedWidget(), false);
         EnableMenuItem(menu, SC_MAXIMIZE,
                        MF_BYCOMMAND | MF_DISABLED | MF_GRAYED);
         EnableMenuItem(menu, SC_RESTORE,


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/27838
Closes https://github.com/electron/electron/issues/27264

Previously windows without a frame (including transparent windows) used a workaround in order to maximize properly (See these two PRs: https://github.com/electron/electron/pull/6417 & https://github.com/electron/electron/pull/26586). With the latest change however, windows without frames could no longer be properly maximized using the Windows system menu (accessible through `alt + space`).

With this PR, the ability to maximize and unmaximize using the Windows system menu and double clicking the title bar, has been disabled for transparent windows. These windows will only be maximizable through Electron's API. Non-transparent frameless windows no longer use the workaround and can be maximized using Electron's API or the Windows system menu interchangeably.

[Fiddle for testing](https://gist.github.com/mlaurencin/bd78bc0378dc2060a3571797e3169e39)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> Transparent windows cannot be maximized using the Windows system menu or by double clicking the title bar.
