### PR TITLE
docs: correct example main.js in quick start

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -61,7 +61,8 @@ function createWindow () {
     width: 800,
     height: 600,
     webPreferences: {
-      nodeIntegration: true
+      nodeIntegration: true,
+      contextIsolation: false
     }
   })
 


### PR DESCRIPTION
#### Description of Change
Add contextIsolation: false to the quick start guide, so the example code works correctly.
Error shown on https://www.electronjs.org/docs/tutorial/quick-start

#### Checklist

- [x] PR description included

#### Release Notes

fix example code in manual for quick start guide.
