### PR TITLE
fix: bad menu position when no positioning item specified

### DIFF
--- a/shell/browser/api/electron_api_menu_mac.mm
+++ b/shell/browser/api/electron_api_menu_mac.mm
@@ -88,7 +88,7 @@ void MenuMac::PopupOnUI(const base::WeakPtr<NativeWindow>& native_window,
   }
 
   // If no preferred item is specified, try to show all of the menu items.
-  if (!positioning_item) {
+  if (!item) {
     CGFloat windowBottom = CGRectGetMinY([view window].frame);
     CGFloat lowestMenuPoint = windowBottom + position.y - [menu size].height;
     CGFloat screenBottom = CGRectGetMinY([view window].screen.frame);


### PR DESCRIPTION
#### Description of Change
Fixes #13279.

This looks like it was a typo. When `positioning_item` isn't specified, it's
`-1`, which evaluates to `true`, so this block wouldn't be invoked.

I've tested manually and it seems to fix the behavior described in the bug.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed context menus not being positioned correctly when near the edge of the screen.
