### PR TITLE
docs: update Node global symbols example to use contextBridge

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -267,7 +267,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       be the absolute file path to the script.
       When node integration is turned off, the preload script can reintroduce
       Node global symbols back to the global scope. See example
-      [here](process.md#event-loaded).
+      [here](context-bridge.md#exposing-node-global-symbols).
     * `sandbox` Boolean (optional) - If set, this will sandbox the renderer
       associated with the window, making it compatible with the Chromium
       OS-level sandbox and disabling the Node.js engine. This is not the same as

--- a/docs/api/context-bridge.md
+++ b/docs/api/context-bridge.md
@@ -122,7 +122,7 @@ Be very cautious about which globals and APIs you expose to untrusted remote con
 const { contextBridge } = require('electron')
 const crypto = require('crypto')
 contextBridge.exposeInMainWorld('nodeCrypto', {
-  sha256sum(data) {
+  sha256sum (data) {
     const hash = crypto.createHash('sha256')
     hash.update(data)
     return hash.digest('hex')

--- a/docs/api/context-bridge.md
+++ b/docs/api/context-bridge.md
@@ -113,8 +113,8 @@ If the type you care about is not in the above table, it is probably not support
 
 ### Exposing Node Global Symbols
 
-The `contextBridge` can be used by the preload script to give your renderer access to Node global symbols.
-The table of supported types described above also applies to Node globals that you expose through `contextBridge`.
+The `contextBridge` can be used by the preload script to give your renderer access to Node APIs.
+The table of supported types described above also applies to Node APIs that you expose through `contextBridge`.
 Please note that many Node APIs grant access to local system resources.
 Be very cautious about which globals and APIs you expose to untrusted remote content.
 

--- a/docs/api/context-bridge.md
+++ b/docs/api/context-bridge.md
@@ -120,6 +120,12 @@ Be very cautious about which globals and APIs you expose to untrusted remote con
 
 ```javascript
 const { contextBridge } = require('electron')
-contextBridge.exposeInMainWorld('setImmediate', setImmediate)
-contextBridge.exposeInMainWorld('clearImmediate', clearImmediate)
+const crypto = require('crypto')
+contextBridge.exposeInMainWorld('nodeCrypto', {
+  sha256sum(data) {
+    const hash = crypto.createHash('sha256')
+    hash.update(data)
+    return hash.digest('hex')
+  }
+})
 ```

--- a/docs/api/context-bridge.md
+++ b/docs/api/context-bridge.md
@@ -33,7 +33,7 @@ page you load in your renderer executes code in this world.
 
 ### Isolated World
 
-When `contextIsolation` is enabled in your `webPreferences`, your `preload` scripts run in an
+When `contextIsolation` is enabled in your `webPreferences` (this is the default behavior since Electron 12.0.0), your `preload` scripts run in an
 "Isolated World".  You can read more about context isolation and what it affects in the
 [security](../tutorial/security.md#3-enable-context-isolation-for-remote-content) docs.
 
@@ -110,3 +110,16 @@ has been included below for completeness:
 | `Symbol` | N/A | ❌ | ❌ | Symbols cannot be copied across contexts so they are dropped |
 
 If the type you care about is not in the above table, it is probably not supported.
+
+### Exposing Node Global Symbols
+
+The `contextBridge` can be used by the preload script to give your renderer access to Node global symbols.
+The table of supported types described above also applies to Node globals that you expose through `contextBridge`.
+Please note that many Node APIs grant access to local system resources.
+Be very cautious about which globals and APIs you expose to untrusted remote content.
+
+```javascript
+const { contextBridge } = require('electron')
+contextBridge.exposeInMainWorld('setImmediate', setImmediate)
+contextBridge.exposeInMainWorld('clearImmediate', clearImmediate)
+```

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -43,19 +43,6 @@ In sandboxed renderers the `process` object contains only a subset of the APIs:
 Emitted when Electron has loaded its internal initialization script and is
 beginning to load the web page or the main script.
 
-It can be used by the preload script to add removed Node global symbols back to
-the global scope when node integration is turned off:
-
-```javascript
-// preload.js
-const _setImmediate = setImmediate
-const _clearImmediate = clearImmediate
-process.once('loaded', () => {
-  global.setImmediate = _setImmediate
-  global.clearImmediate = _clearImmediate
-})
-```
-
 ## Properties
 
 ### `process.defaultApp` _Readonly_


### PR DESCRIPTION
#### Description of Change

This is another piece of example code that no longer works with `contextIsolation: false`. Since you can't expose values through `global` anymore, it no longer made sense to have the example live in the `process` `'loaded'` event docs. I moved it to the `contextBridge` docs since that's what you'd now use to expose Node APIs.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes