### PR TITLE
docs: add missing curly brace to quick start example code

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -78,7 +78,7 @@ app.whenReady().then(() => {
       createWindow()
     }
   })
-)
+})
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {


### PR DESCRIPTION
#### Description of Change

Embarrassingly, #28223 merged with a typo in `quick-start.md`. I had tested the code from the Fiddle code sample, but not from the markdown file, so I missed the typo. This change fixes the typo.

I've now tested both the Fiddle example *and* the example code from `quick-start.md` in Fiddle, and they both run successfully.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
