### PR TITLE
chore: rename process.contextIsolation to process.contextIsolated

### DIFF
--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -30,7 +30,7 @@ In sandboxed renderers the `process` object contains only a subset of the APIs:
 * `arch`
 * `platform`
 * `sandboxed`
-* `contextIsolation`
+* `contextIsolated`
 * `type`
 * `version`
 * `versions`
@@ -95,7 +95,7 @@ A `String` representing the path to the resources directory.
 A `Boolean`. When the renderer process is sandboxed, this property is `true`,
 otherwise it is `undefined`.
 
-### `process.contextIsolation` _Readonly_
+### `process.contextIsolated` _Readonly_
 
 A `Boolean` that indicates whether the current renderer context has `contextIsolation` enabled.
 It is `undefined` in the main process.

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -141,7 +141,7 @@ void RendererClientBase::BindProcess(v8::Isolate* isolate,
                                      gin_helper::Dictionary* process,
                                      content::RenderFrame* render_frame) {
   process->SetReadOnly("isMainFrame", render_frame->IsMainFrame());
-  process->SetReadOnly("contextIsolation",
+  process->SetReadOnly("contextIsolated",
                        render_frame->GetBlinkPreferences().context_isolation);
 }
 

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -4306,7 +4306,7 @@ describe('BrowserWindow module', () => {
       const [, data] = await p;
       expect(data.pageContext.openedLocation).to.equal('about:blank');
     });
-    it('reports process.contextIsolation', async () => {
+    it('reports process.contextIsolated', async () => {
       const iw = new BrowserWindow({
         show: false,
         webPreferences: {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -2487,7 +2487,7 @@ describe('BrowserWindow module', () => {
         expect(test.env).to.deep.equal(process.env);
         expect(test.execPath).to.equal(process.helperExecPath);
         expect(test.sandboxed).to.be.true('sandboxed');
-        expect(test.contextIsolation).to.be.false('contextIsolation');
+        expect(test.contextIsolated).to.be.false('contextIsolated');
         expect(test.type).to.equal('renderer');
         expect(test.version).to.equal(process.version);
         expect(test.versions).to.deep.equal(process.versions);

--- a/spec-main/fixtures/module/preload-sandbox.js
+++ b/spec-main/fixtures/module/preload-sandbox.js
@@ -40,7 +40,7 @@
         arch: process.arch,
         platform: process.platform,
         sandboxed: process.sandboxed,
-        contextIsolation: process.contextIsolation,
+        contextIsolated: process.contextIsolated,
         type: process.type,
         version: process.version,
         versions: process.versions,

--- a/spec/fixtures/api/isolated-process.js
+++ b/spec/fixtures/api/isolated-process.js
@@ -1,3 +1,3 @@
 const { ipcRenderer } = require('electron');
 
-ipcRenderer.send('context-isolation', process.contextIsolation);
+ipcRenderer.send('context-isolation', process.contextIsolated);


### PR DESCRIPTION
Discussed in api-wg --> https://electronhq.slack.com/archives/CNL6E1GJD/p1616022446002700

I've updated the notes of the original PR (#28030) and will cherry pick this commit onto the backport shortly

Notes: no-notes