### PR TITLE
doc: desktopCapturer only for renderer process

### DIFF
--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -3,7 +3,7 @@
 > Access information about media sources that can be used to capture audio and
 > video from the desktop using the [`navigator.mediaDevices.getUserMedia`] API.
 
-Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process)
+Process: [Renderer](../glossary.md#renderer-process)
 
 The following example shows how to capture video from a desktop window whose
 title is `Electron`:


### PR DESCRIPTION
#### Description of Change
One can require `desktopCapturer` in main process
but when run these code in main process app will crash silently.
```js
let {desktopCapturer} = require("electron")
desktopCapturer
  .getSources({
    types: ['screen'],
    thumbnailSize: { width: 1920, height: 1080 },
  })
  .then((imgs) => {
    console.log(imgs[0].thumbnail.toDataURL())
  })
```
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: doc: desktopCapturer only for renderer process
