### PR TITLE
fix: missing HandleScope in ResetBrowserViews

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -1112,6 +1112,8 @@ int32_t BaseWindow::GetID() const {
 }
 
 void BaseWindow::ResetBrowserViews() {
+  v8::HandleScope scope(isolate());
+
   for (auto& item : browser_views_) {
     gin::Handle<BrowserView> browser_view;
     if (gin::ConvertFromV8(isolate(),


### PR DESCRIPTION
#### Description of Change

Discovered when triaging https://github.com/electron/electron/issues/28228.

Reproducible with https://gist.github.com/c138020abbb7d949608c3c11b1cad253, when hitting `Stop` in Fiddle. Only shows up in `master`, so I assume gin changed something [here](https://github.com/electron/electron/commit/eb0e55c514866e67b2fd93eb7f94d2151b38a784) recently 🤔 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none.
