### PR TITLE
fix: drag region offsets in BrowserViews

### DIFF
--- a/shell/browser/native_browser_view_mac.mm
+++ b/shell/browser/native_browser_view_mac.mm
@@ -317,8 +317,9 @@ void NativeBrowserViewMac::UpdateDraggableRegions(
   const auto window_content_view_height = NSHeight(window_content_view.bounds);
   for (const auto& rect : drag_exclude_rects) {
     const auto x = rect.x() + offset.x();
-    const auto y = window_content_view_height - rect.bottom() + offset.y();
+    const auto y = window_content_view_height - (rect.bottom() + offset.y());
     const auto exclude_rect = NSMakeRect(x, y, rect.width(), rect.height());
+
     const auto drag_region_view_exclude_rect =
         [window_content_view convertRect:exclude_rect toView:drag_region_view];
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/28228.

Our y-axis offset calculation was slightly off - this corrects that.

Tested with https://gist.github.com/c138020abbb7d949608c3c11b1cad253 and also with https://gist.github.com/08f3e56e0a4dc443621bd769e18c7cd6 to ensure no regressions.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the drag regions in BrowserViews on macOS could be off in their y-axis. 
