### PR TITLE
fix: DesktopCapturer gc'd prior to capture completion

### DIFF
--- a/shell/browser/api/electron_api_desktop_capturer.cc
+++ b/shell/browser/api/electron_api_desktop_capturer.cc
@@ -162,6 +162,9 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
         v8::Locker locker(isolate);
         v8::HandleScope scope(isolate);
         gin_helper::CallMethod(this, "_onerror", "Failed to get sources.");
+
+        Unpin();
+
         return;
       }
 
@@ -195,12 +198,19 @@ void DesktopCapturer::UpdateSourcesList(DesktopMediaList* list) {
     v8::Locker locker(isolate);
     v8::HandleScope scope(isolate);
     gin_helper::CallMethod(this, "_onfinished", captured_sources_);
+
+    Unpin();
   }
 }
 
 // static
 gin::Handle<DesktopCapturer> DesktopCapturer::Create(v8::Isolate* isolate) {
-  return gin::CreateHandle(isolate, new DesktopCapturer(isolate));
+  auto handle = gin::CreateHandle(isolate, new DesktopCapturer(isolate));
+
+  // Keep reference alive until capturing has finished.
+  handle->Pin(isolate);
+
+  return handle;
 }
 
 gin::ObjectTemplateBuilder DesktopCapturer::GetObjectTemplateBuilder(

--- a/shell/browser/api/electron_api_desktop_capturer.h
+++ b/shell/browser/api/electron_api_desktop_capturer.h
@@ -13,12 +13,14 @@
 #include "chrome/browser/media/webrtc/native_desktop_media_list.h"
 #include "gin/handle.h"
 #include "gin/wrappable.h"
+#include "shell/common/gin_helper/pinnable.h"
 
 namespace electron {
 
 namespace api {
 
 class DesktopCapturer : public gin::Wrappable<DesktopCapturer>,
+                        public gin_helper::Pinnable<DesktopCapturer>,
                         public DesktopMediaListObserver {
  public:
   struct Source {


### PR DESCRIPTION
#### Description of Change

`desktopCapturer.getSources()` returns a promise which should resolve
when capturing finishes. Internally it creates an instance of
DesktopCapturer which is responsible for resolving or rejecting
the promise.

Between the time DesktopCapturer starts capturing frames and when
it finishes, it's possible for its handle to be GC'd leading to
it never resolving.

These changes pin the instance of DesktopCapturer until it either
finishes or errors.

fixes #25595

------

To verify the fix, I ran this Fiddle gist which normally fails after 10-30 seconds without the fix
https://gist.github.com/90f43a52e7c48a531a57bec77428e11a

cc @codebytere 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed `desktopCapturer.getSources()` promise result sometimes never resolving.
