### PR TITLE
perf: do not double-proxy methods being return over the contextBridge

### DIFF
--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -34,6 +34,8 @@ namespace context_bridge {
 const char* const kProxyFunctionPrivateKey = "electron_contextBridge_proxy_fn";
 const char* const kSupportsDynamicPropertiesPrivateKey =
     "electron_contextBridge_supportsDynamicProperties";
+const char* const kOriginalFunctionPrivateKey =
+    "electron_contextBridge_original_fn";
 
 }  // namespace context_bridge
 
@@ -172,9 +174,26 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContext(
   // the global handle at the right time.
   if (value->IsFunction()) {
     auto func = v8::Local<v8::Function>::Cast(value);
+    v8::MaybeLocal<v8::Value> maybe_original_fn = GetPrivate(
+        source_context, func, context_bridge::kOriginalFunctionPrivateKey);
 
     {
       v8::Context::Scope destination_scope(destination_context);
+      v8::Local<v8::Value> proxy_func;
+
+      // If this function has already been sent over the bridge,
+      // then it is being sent _back_ over the bridge and we can
+      // simply return the original method here for performance reasons
+
+      // For safety reasons we check if the destination context is the
+      // creation context of the original method.  If it's not we proceed
+      // with the proxy logic
+      if (maybe_original_fn.ToLocal(&proxy_func) && proxy_func->IsFunction() &&
+          proxy_func.As<v8::Object>()->CreationContext() ==
+              destination_context) {
+        return v8::MaybeLocal<v8::Value>(proxy_func);
+      }
+
       v8::Local<v8::Object> state =
           v8::Object::New(destination_context->GetIsolate());
       SetPrivate(destination_context, state,
@@ -183,10 +202,12 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContext(
                  context_bridge::kSupportsDynamicPropertiesPrivateKey,
                  gin::ConvertToV8(destination_context->GetIsolate(),
                                   support_dynamic_properties));
-      v8::Local<v8::Value> proxy_func;
+
       if (!v8::Function::New(destination_context, ProxyFunctionWrapper, state)
                .ToLocal(&proxy_func))
         return v8::MaybeLocal<v8::Value>();
+      SetPrivate(destination_context, proxy_func.As<v8::Object>(),
+                 context_bridge::kOriginalFunctionPrivateKey, func);
       object_cache->CacheProxiedObject(value, proxy_func);
       return v8::MaybeLocal<v8::Value>(proxy_func);
     }

--- a/spec-main/api-context-bridge-spec.ts
+++ b/spec-main/api-context-bridge-spec.ts
@@ -352,6 +352,17 @@ describe('contextBridge', () => {
         expect(result).equal('return-value');
       });
 
+      it('should not double-proxy functions when they are returned to their origin side of the bridge', async () => {
+        await makeBindingWindow(() => {
+          contextBridge.exposeInMainWorld('example', (fn: any) => fn);
+        });
+        const result = await callWithBindings(async (root: any) => {
+          const fn = () => null;
+          return root.example(fn) === fn;
+        });
+        expect(result).equal(true);
+      });
+
       it('should proxy methods that are callable multiple times', async () => {
         await makeBindingWindow(() => {
           contextBridge.exposeInMainWorld('example', {


### PR DESCRIPTION
Previously a function sent over the bridge would result in a proxy function existing in the other context, sending it back would create a proxy-of-a-proxy and so on.  With each successive pass over the bridge it would add another layer of proxy'ing which would get slower and slower.  This change ensures that when a method is cleanly passed back over the bridge to it's origin we use the stored "original function" as the return value thus ensuring a max proxy depth of 1.

This is safe to do for function because the lifetime of the proxy function is _already_ tied to the lifetime of the original function.  We can't do this for others objects / types without some smarts and last time we tried to implement those smarts it caused massive issues.

Notes: Improved performance characteristics of functions being sent back and forth over the contextBridge.