### PR TITLE
fix: destroy MessageDispatcher before WebContents

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -914,6 +914,7 @@ WebContents::~WebContents() {
     return;
   }
 
+  inspectable_web_contents_->GetView()->SetDelegate(nullptr);
   if (guest_delegate_)
     guest_delegate_->WillDestroy();
 
@@ -1760,6 +1761,7 @@ void WebContents::DevToolsOpened() {
   v8::Locker locker(isolate);
   v8::HandleScope handle_scope(isolate);
   DCHECK(inspectable_web_contents_);
+  DCHECK(inspectable_web_contents_->GetDevToolsWebContents());
   auto handle = FromOrCreate(
       isolate, inspectable_web_contents_->GetDevToolsWebContents());
   devtools_web_contents_.Reset(isolate, handle.ToV8());

--- a/shell/browser/ui/inspectable_web_contents.h
+++ b/shell/browser/ui/inspectable_web_contents.h
@@ -201,12 +201,6 @@ class InspectableWebContents
   void AddDevToolsExtensionsToClient();
 #endif
 
-  bool frontend_loaded_ = false;
-  scoped_refptr<content::DevToolsAgentHost> agent_host_;
-  std::unique_ptr<content::DevToolsFrontendHost> frontend_host_;
-  std::unique_ptr<DevToolsEmbedderMessageDispatcher>
-      embedder_message_dispatcher_;
-
   DevToolsContentsResizingStrategy contents_resizing_strategy_;
   gfx::Rect devtools_bounds_;
   bool can_dock_ = true;
@@ -227,6 +221,12 @@ class InspectableWebContents
 
   bool is_guest_;
   std::unique_ptr<InspectableWebContentsView> view_;
+
+  bool frontend_loaded_ = false;
+  scoped_refptr<content::DevToolsAgentHost> agent_host_;
+  std::unique_ptr<content::DevToolsFrontendHost> frontend_host_;
+  std::unique_ptr<DevToolsEmbedderMessageDispatcher>
+      embedder_message_dispatcher_;
 
   class NetworkResourceLoader;
   std::set<std::unique_ptr<NetworkResourceLoader>, base::UniquePtrComparator>


### PR DESCRIPTION
#### Description of Change

The `DevToolsEmbedderMessageDispatcher` and `DevToolsFrontendHost` instances should be destroyed before destroying the WebContents, otherwise there might be race conditions when handling messages from the WebContents. This matches the destruction order in Chromium's `chrome/browser/devtools/devtools_ui_bindings.h`.

This should be able to fix the crash when testing devtools in CI:

```
0   Electron Framework                  0x0000000110427549 base::debug::CollectStackTrace(void**, unsigned long) + 9
1   Electron Framework                  0x0000000110343a43 base::debug::StackTrace::StackTrace() + 19
2   Electron Framework                  0x0000000110427471 base::debug::(anonymous namespace)::StackDumpSignalHandler(int, __siginfo*, void*) + 2385
3   libsystem_platform.dylib            0x00007fff69ef05fd _sigtramp + 29
4   ???                                 0x0000000000000030 0x0 + 48
5   Electron Framework                  0x000000010bb70241 electron::api::WebContents::DevToolsOpened() + 545
6   Electron Framework                  0x000000010bc23ce8 electron::InspectableWebContents::LoadCompleted() + 904
7   Electron Framework                  0x0000000115533238 bool (anonymous namespace)::ParseAndHandle<>(base::RepeatingCallback<void ()> const&, base::OnceCallback<void (base::Value const*)>, base::ListValue const&) + 216
8   Electron Framework                  0x000000011553327a base::internal::Invoker<base::internal::BindState<bool (*)(base::RepeatingCallback<void ()> const&, base::OnceCallback<void (base::Value const*)>, base::ListValue const&), base::RepeatingCallback<void ()> >, bool (base::OnceCallback<void (base::Value const*)>, base::ListValue const&)>::Run(base::internal::BindStateBase*, base::OnceCallback<void (base::Value const*)>&&, base::ListValue const&) + 42
9   Electron Framework                  0x0000000115532f29 DispatcherImpl::Dispatch(base::OnceCallback<void (base::Value const*)>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, base::ListValue const*) + 137
10  Electron Framework                  0x000000010bc26742 electron::InspectableWebContents::HandleMessageFromDevToolsFrontend(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) + 450
```

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none