### PR TITLE
feat: initialize field trials from command line arguments

### DIFF
--- a/docs/api/command-line-switches.md
+++ b/docs/api/command-line-switches.md
@@ -75,6 +75,12 @@ This switch can not be used in `app.commandLine.appendSwitch` since it is parsed
 earlier than user's app is loaded, but you can set the `ELECTRON_ENABLE_LOGGING`
 environment variable to achieve the same effect.
 
+## --force-fieldtrials=`trials`
+
+Field trials to be forcefully enabled or disabled.
+
+For example: `WebRTC-Audio-Red-For-Opus/Enabled/`
+
 ### --host-rules=`rules`
 
 A comma-separated list of `rules` that control how hostnames are mapped.

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -279,6 +279,9 @@ void ElectronBrowserMainParts::PostEarlyInitialization() {
   base::FeatureList::ClearInstanceForTesting();
   InitializeFeatureList();
 
+  // Initialize field trials.
+  InitializeFieldTrials();
+
   // Initialize after user script environment creation.
   fake_browser_process_->PostEarlyInitialization();
 }

--- a/shell/browser/feature_list.cc
+++ b/shell/browser/feature_list.cc
@@ -9,6 +9,7 @@
 #include "base/base_switches.h"
 #include "base/command_line.h"
 #include "base/feature_list.h"
+#include "base/metrics/field_trial.h"
 #include "content/public/common/content_features.h"
 #include "electron/buildflags/buildflags.h"
 #include "media/base/media_switches.h"
@@ -47,6 +48,14 @@ void InitializeFeatureList() {
   disable_features += std::string(",") + media::kPictureInPicture.name;
 #endif
   base::FeatureList::InitializeInstance(enable_features, disable_features);
+}
+
+void InitializeFieldTrials() {
+  auto* cmd_line = base::CommandLine::ForCurrentProcess();
+  auto force_fieldtrials =
+      cmd_line->GetSwitchValueASCII(::switches::kForceFieldTrials);
+
+  base::FieldTrialList::CreateTrialsFromString(force_fieldtrials);
 }
 
 }  // namespace electron

--- a/shell/browser/feature_list.h
+++ b/shell/browser/feature_list.h
@@ -7,6 +7,7 @@
 
 namespace electron {
 void InitializeFeatureList();
-}
+void InitializeFieldTrials();
+}  // namespace electron
 
 #endif  // SHELL_BROWSER_FEATURE_LIST_H_


### PR DESCRIPTION
Fixes: #27877

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Refs: #27877

Initializes field trials so Electron applications can opt-in to trialing specific in-development features. This is quite used in the WebRTC part for instance. Once such field trial is Opus audio redundancy. This PR facilitates testing that.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added ability to enable field trials.
