### PR TITLE
fix: make sure service worker scheme is registered with allowServiceWorkers

### DIFF
--- a/shell/app/electron_content_client.cc
+++ b/shell/app/electron_content_client.cc
@@ -187,9 +187,13 @@ void ElectronContentClient::AddAdditionalSchemes(Schemes* schemes) {
   auto* command_line = base::CommandLine::ForCurrentProcess();
   std::string process_type =
       command_line->GetSwitchValueASCII(::switches::kProcessType);
-  // Register schemes for browser process and network utility process, the
-  // registration for renderer process happens in `RendererClientBase`.
-  if (process_type.empty() || process_type == ::switches::kUtilityProcess) {
+  // Browser Process registration happens in
+  // `api::Protocol::RegisterSchemesAsPrivileged`
+  //
+  // Renderer Process registration happens in `RendererClientBase`
+  //
+  // We use this for registration to network utility process
+  if (process_type == ::switches::kUtilityProcess) {
     AppendDelimitedSwitchToVector(switches::kServiceWorkerSchemes,
                                   &schemes->service_worker_schemes);
     AppendDelimitedSwitchToVector(switches::kStandardSchemes,

--- a/shell/app/electron_content_client.cc
+++ b/shell/app/electron_content_client.cc
@@ -187,13 +187,9 @@ void ElectronContentClient::AddAdditionalSchemes(Schemes* schemes) {
   auto* command_line = base::CommandLine::ForCurrentProcess();
   std::string process_type =
       command_line->GetSwitchValueASCII(::switches::kProcessType);
-  // Browser Process registration happens in
-  // `api::Protocol::RegisterSchemesAsPrivileged`
-  //
-  // Renderer Process registration happens in `RendererClientBase`
-  //
-  // We use this for registration to network utility process
-  if (process_type == ::switches::kUtilityProcess) {
+  // Register schemes for browser process and network utility process, the
+  // registration for renderer process happens in `RendererClientBase`.
+  if (process_type.empty() || process_type == ::switches::kUtilityProcess) {
     AppendDelimitedSwitchToVector(switches::kServiceWorkerSchemes,
                                   &schemes->service_worker_schemes);
     AppendDelimitedSwitchToVector(switches::kStandardSchemes,

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -10,6 +10,7 @@
 
 #include "base/command_line.h"
 #include "base/stl_util.h"
+#include "content/common/url_schemes.h"
 #include "content/public/browser/child_process_security_policy.h"
 #include "gin/object_template_builder.h"
 #include "shell/browser/browser.h"
@@ -124,6 +125,13 @@ void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
     }
     if (custom_scheme.options.allowServiceWorkers) {
       service_worker_schemes.push_back(custom_scheme.scheme);
+      // There is no API to add service worker scheme, but there is an API to
+      // return const reference to the schemes vector.
+      // If in future the API is changed to return a copy instead of reference,
+      // the compilation will fail, and we should add a patch at that time.
+      auto& mutable_schemes = const_cast<std::vector<std::string>&>(
+          content::GetServiceWorkerSchemes());
+      mutable_schemes.push_back(custom_scheme.scheme);
     }
     if (custom_scheme.options.stream) {
       g_streaming_schemes.push_back(custom_scheme.scheme);

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -10,7 +10,6 @@
 
 #include "base/command_line.h"
 #include "base/stl_util.h"
-#include "content/common/url_schemes.h"
 #include "content/public/browser/child_process_security_policy.h"
 #include "gin/object_template_builder.h"
 #include "shell/browser/browser.h"
@@ -150,14 +149,6 @@ void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
                          g_standard_schemes);
   AppendSchemesToCmdLine(electron::switches::kStreamingSchemes,
                          g_streaming_schemes);
-
-  // The scheme registration happens before user's main script is executed, so
-  // we have to explicitly do a re-registration to make the new scheme
-  // effective.
-  // Note that while the API is marked as ForTests, it is safe to call in this
-  // use case, and it has DCHECK to ensure we are not making changes to schemes
-  // _after_ any code has read the scheme registry.
-  content::ReRegisterContentSchemesForTests();
 }
 
 namespace {

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -10,6 +10,7 @@
 
 #include "base/command_line.h"
 #include "base/stl_util.h"
+#include "content/common/url_schemes.h"
 #include "content/public/browser/child_process_security_policy.h"
 #include "gin/object_template_builder.h"
 #include "shell/browser/browser.h"
@@ -149,6 +150,14 @@ void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
                          g_standard_schemes);
   AppendSchemesToCmdLine(electron::switches::kStreamingSchemes,
                          g_streaming_schemes);
+
+  // The scheme registration happens before user's main script is executed, so
+  // we have to explicitly do a re-registration to make the new scheme
+  // effective.
+  // Note that while the API is marked as ForTests, it is safe to call in this
+  // use case, and it has DCHECK to ensure we are not making changes to schemes
+  // _after_ any code has read the scheme registry.
+  content::ReRegisterContentSchemesForTests();
 }
 
 namespace {

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1352,22 +1352,26 @@ void ElectronBrowserClient::RegisterNonNetworkSubresourceURLLoaderFactories(
     int render_process_id,
     int render_frame_id,
     NonNetworkURLLoaderFactoryMap* factories) {
-  content::RenderFrameHost* frame_host =
-      content::RenderFrameHost::FromID(render_process_id, render_frame_id);
-  content::WebContents* web_contents =
-      content::WebContents::FromRenderFrameHost(frame_host);
+  auto* render_process_host =
+      content::RenderProcessHost::FromID(render_process_id);
+  DCHECK(render_process_host);
+  if (!render_process_host || !render_process_host->GetBrowserContext())
+    return;
 
-  if (web_contents) {
-    ProtocolRegistry::FromBrowserContext(web_contents->GetBrowserContext())
-        ->RegisterURLLoaderFactories(URLLoaderFactoryType::kDocumentSubResource,
-                                     factories);
-  }
+  ProtocolRegistry::FromBrowserContext(render_process_host->GetBrowserContext())
+      ->RegisterURLLoaderFactories(URLLoaderFactoryType::kDocumentSubResource,
+                                   factories);
+
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   auto factory = extensions::CreateExtensionURLLoaderFactory(render_process_id,
                                                              render_frame_id);
   if (factory)
     factories->emplace(extensions::kExtensionScheme, std::move(factory));
 
+  content::RenderFrameHost* frame_host =
+      content::RenderFrameHost::FromID(render_process_id, render_frame_id);
+  content::WebContents* web_contents =
+      content::WebContents::FromRenderFrameHost(frame_host);
   if (!web_contents)
     return;
 

--- a/spec-main/api-protocol-spec.ts
+++ b/spec-main/api-protocol-spec.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { v4 } from 'uuid';
 import { protocol, webContents, WebContents, session, BrowserWindow, ipcMain } from 'electron/main';
 import { AddressInfo } from 'net';
 import * as ChildProcess from 'child_process';
@@ -721,6 +722,36 @@ describe('protocol module', () => {
       expect(code).to.equal(0);
       expect(stdout).to.not.contain('VALIDATION_ERROR_DESERIALIZATION_FAILED');
       expect(stderr).to.not.contain('VALIDATION_ERROR_DESERIALIZATION_FAILED');
+    });
+  });
+
+  describe('protocol.registerSchemesAsPrivileged allowServiceWorkers', () => {
+    const { serviceWorkerScheme } = global as any;
+    protocol.registerStringProtocol(serviceWorkerScheme, (request, cb) => {
+      if (request.url.endsWith('.js')) {
+        cb({
+          mimeType: 'text/javascript',
+          charset: 'utf-8',
+          data: 'console.log("Loaded")'
+        });
+      } else {
+        cb({
+          mimeType: 'text/html',
+          charset: 'utf-8',
+          data: '<!DOCTYPE html>'
+        });
+      }
+    });
+    after(() => protocol.unregisterProtocol(serviceWorkerScheme));
+
+    it('should fail when registering invalid service worker', async () => {
+      await contents.loadURL(`${serviceWorkerScheme}://${v4()}.com`);
+      await expect(contents.executeJavaScript(`navigator.serviceWorker.register('${v4()}.notjs', {scope: './'})`)).to.be.rejected();
+    });
+
+    it('should be able to register service worker for custom scheme', async () => {
+      await contents.loadURL(`${serviceWorkerScheme}://${v4()}.com`);
+      await contents.executeJavaScript(`navigator.serviceWorker.register('${v4()}.js', {scope: './'})`);
     });
   });
 

--- a/spec-main/index.js
+++ b/spec-main/index.js
@@ -34,9 +34,11 @@ app.commandLine.appendSwitch('use-fake-device-for-media-stream');
 
 global.standardScheme = 'app';
 global.zoomScheme = 'zoom';
+global.serviceWorkerScheme = 'sw';
 protocol.registerSchemesAsPrivileged([
   { scheme: global.standardScheme, privileges: { standard: true, secure: true, stream: false } },
   { scheme: global.zoomScheme, privileges: { standard: true, secure: true } },
+  { scheme: global.serviceWorkerScheme, privileges: { allowServiceWorkers: true, standard: true, secure: true } },
   { scheme: 'cors-blob', privileges: { corsEnabled: true, supportFetchAPI: true } },
   { scheme: 'cors', privileges: { corsEnabled: true, supportFetchAPI: true } },
   { scheme: 'no-cors', privileges: { supportFetchAPI: true } },


### PR DESCRIPTION
#### Description of Change

Fix https://github.com/electron/electron/issues/20248.

The bug was caused by 2 reasons:
1. ServiceWorker loader does not have WebContents associated, so it did not get custom protocols registered.
2. `registerSchemesAsPrivileged` is called after service worker schemes get registered, so the custom scheme could not be recognized as service worker scheme.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix service worker not working with custom protocol.