### PR TITLE
fix: window.print() in pdf plugin

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -94,6 +94,7 @@ const defaultPrintingSetting = {
   pagesPerSheet: 1,
   isFirstRequest: false,
   previewUIID: 0,
+  // True, if the document source is modifiable. e.g. HTML and not PDF.
   previewModifiable: true,
   printToPDF: true,
   deviceName: 'Save as PDF',


### PR DESCRIPTION
#### Description of Change

Fixes an issue where `window.print()` did not work properly when printing a pdf from the pdf plugin. Pulled from Chromium's [corresponding impl](https://source.chromium.org/chromium/chromium/src/+/master:chrome/renderer/printing/chrome_print_render_frame_helper_delegate.cc;l=64-81;drc=ce83ee3f482ef49409bf97c28dd28cd8da8072c7;bpv=1;bpt=1). 

Tested with https://gist.github.com/293b0a64d8564da954fc222b9aba9ce1.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `window.print()` did not work properly when printing a pdf from the pdf plugin.
