### PR TITLE
fix: isolate Pepper plugins

### DIFF
--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -361,22 +361,7 @@ bool RendererClientBase::IsPluginHandledExternally(
 
 bool RendererClientBase::IsOriginIsolatedPepperPlugin(
     const base::FilePath& plugin_path) {
-  // Taken from Chrome's own implementation of this same method:
-  // https://source.chromium.org/chromium/chromium/src/+/37893bf803b256be100b1bd1805abcd069c33140:chrome/renderer/chrome_content_renderer_client.cc;l=1341-1363
-  //
-  // NOTE: the logic for NaCl is excluded here as we don't currently support it.
-
-  // Hosting plugins in-process is inherently incompatible with attempting to
-  // process-isolate plugins from different origins.
-  auto* cmdline = base::CommandLine::ForCurrentProcess();
-  if (cmdline->HasSwitch(::switches::kPpapiInProcess)) {
-    // The kPpapiInProcess switch should only be used by tests.
-    CHECK_NE(kPdfPluginPath, plugin_path.value());
-
-    return false;
-  }
-
-  // Isolate all the other plugins (including the PDF plugin + test plugins).
+  // Isolate all Pepper plugins, including the PDF plugin.
   return true;
 }
 

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -361,7 +361,10 @@ bool RendererClientBase::IsPluginHandledExternally(
 
 bool RendererClientBase::IsOriginIsolatedPepperPlugin(
     const base::FilePath& plugin_path) {
-  // Taken from chrome's own implementation of this method.
+  // Taken from Chrome's own implementation of this same method:
+  // https://source.chromium.org/chromium/chromium/src/+/37893bf803b256be100b1bd1805abcd069c33140:chrome/renderer/chrome_content_renderer_client.cc;l=1341-1363
+  //
+  // NOTE: the logic for NaCl is excluded here as we don't currently support it.
 
   // Hosting plugins in-process is inherently incompatible with attempting to
   // process-isolate plugins from different origins.


### PR DESCRIPTION
#### Description of Change

[A recent change in Chromium](https://source.chromium.org/chromium/chromium/src/+/37893bf803b256be100b1bd1805abcd069c33140) started isolating (basically) all Pepper plugins. It seems like the smart thing for us to do is to follow suit and mimic their new behavior in our own `IsOriginIsolatedPepperPlugin` method.

Fixes #28200. See [this deep dive comment](https://github.com/electron/electron/issues/28200#issuecomment-801496222) for more context.

CC @nornagon 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Pepper plugins are now isolated from origins.
