### PR TITLE
fix: escape URL passed to shell.openExternal on windows

### DIFF
--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -32,6 +32,7 @@
 #include "base/win/windows_version.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
+#include "net/base/escape.h"
 #include "shell/common/electron_paths.h"
 #include "ui/base/win/shell.h"
 #include "url/gurl.h"
@@ -241,7 +242,9 @@ std::string OpenExternalOnWorkerThread(
   // Quote the input scheme to be sure that the command does not have
   // parameters unexpected by the external program. This url should already
   // have been escaped.
-  base::string16 escaped_url = L"\"" + base::UTF8ToUTF16(url.spec()) + L"\"";
+  base::string16 escaped_url =
+      L"\"" + base::UTF8ToUTF16(net::EscapeExternalHandlerValue(url.spec())) +
+      L"\"";
   base::string16 working_dir = options.working_dir.value();
 
   if (reinterpret_cast<ULONG_PTR>(


### PR DESCRIPTION
This aligns our `openExternal` behavior with upstream where the URL should be escaped before being sent to the external handler.  Most applications expect a spec-compliant URI, this ensures they receive one.

Notes: URLS passed to `shell.openExternal` on windows are now correctly URI encoded.  This was already occurring on macOS and Linux.