### PR TITLE
fix: errors thrown in functions over the `contextBridge`

### DIFF
--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -438,17 +438,22 @@ void ProxyFunctionWrapper(const v8::FunctionCallbackInfo<v8::Value>& info) {
         did_error = true;
         v8::Local<v8::Value> exception = try_catch.Exception();
 
-        v8::MaybeLocal<v8::Value> maybe_message =
-            exception.As<v8::Object>()->Get(
-                func_owning_context,
-                gin::ConvertToV8(args.isolate(), "message"));
+        const char* err_msg =
+            "An unknown exception occurred in the isolated context, an error "
+            "occurred but a valid exception was not thrown.";
 
-        if (!maybe_message.ToLocal(&error_message) ||
-            !error_message->IsString()) {
-          error_message = gin::StringToV8(
-              args.isolate(),
-              "An unknown exception occurred in the isolated context, an error "
-              "occurred but a valid exception was not thrown.");
+        if (!exception->IsNull() && exception->IsObject()) {
+          v8::MaybeLocal<v8::Value> maybe_message =
+              exception.As<v8::Object>()->Get(
+                  func_owning_context,
+                  gin::ConvertToV8(args.isolate(), "message"));
+
+          if (!maybe_message.ToLocal(&error_message) ||
+              !error_message->IsString()) {
+            error_message = gin::StringToV8(args.isolate(), err_msg);
+          }
+        } else {
+          error_message = gin::StringToV8(args.isolate(), err_msg);
         }
       }
     }

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -429,21 +429,26 @@ void ProxyFunctionWrapper(const v8::FunctionCallbackInfo<v8::Value>& info) {
 
     v8::MaybeLocal<v8::Value> maybe_return_value;
     bool did_error = false;
-    std::string error_message;
+    v8::Local<v8::Value> error_message;
     {
       v8::TryCatch try_catch(args.isolate());
       maybe_return_value = func->Call(func_owning_context, func,
                                       proxied_args.size(), proxied_args.data());
       if (try_catch.HasCaught()) {
         did_error = true;
-        auto message = try_catch.Message();
+        v8::Local<v8::Value> exception = try_catch.Exception();
 
-        if (message.IsEmpty() ||
-            !gin::ConvertFromV8(args.isolate(), message->Get(),
-                                &error_message)) {
-          error_message =
+        v8::MaybeLocal<v8::Value> maybe_message =
+            exception.As<v8::Object>()->Get(
+                func_owning_context,
+                gin::ConvertToV8(args.isolate(), "message"));
+
+        if (!maybe_message.ToLocal(&error_message) ||
+            !error_message->IsString()) {
+          error_message = gin::StringToV8(
+              args.isolate(),
               "An unknown exception occurred in the isolated context, an error "
-              "occurred but a valid exception was not thrown.";
+              "occurred but a valid exception was not thrown.");
         }
       }
     }
@@ -451,7 +456,7 @@ void ProxyFunctionWrapper(const v8::FunctionCallbackInfo<v8::Value>& info) {
     if (did_error) {
       v8::Context::Scope calling_context_scope(calling_context);
       args.isolate()->ThrowException(
-          v8::Exception::Error(gin::StringToV8(args.isolate(), error_message)));
+          v8::Exception::Error(error_message.As<v8::String>()));
       return;
     }
 

--- a/spec-main/api-context-bridge-spec.ts
+++ b/spec-main/api-context-bridge-spec.ts
@@ -364,6 +364,20 @@ describe('contextBridge', () => {
         expect(result).equal(true);
       });
 
+      it('should properly handle errors thrown in proxied functions', async () => {
+        await makeBindingWindow(() => {
+          contextBridge.exposeInMainWorld('example', () => { throw new Error('oh no'); });
+        });
+        const result = await callWithBindings(async (root: any) => {
+          try {
+            root.example();
+          } catch (e) {
+            return e.message;
+          }
+        });
+        expect(result).equal('oh no');
+      });
+
       it('should proxy methods that are callable multiple times', async () => {
         await makeBindingWindow(() => {
           contextBridge.exposeInMainWorld('example', {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/28327.

Fixes an issue where errors thrown in functions passed over the `contextBridge` would be prefixed with `Uncaught Error` so that the error message then incorrectly displayed as `Error: Uncaught Error: test`. This is owed to the fact that errors aren't serializable as-is, so we should be pulling the message off the exception and re-constructing and throwing it in the destination context

Tested with https://gist.github.com/f11c77f9bc2cbf98d42a9fcaf477c80a.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where errors thrown in functions passed over the `contextBridge` could be displayed incorrectly.
