### PR TITLE
fix: put RemoteCertVerifier upstream from the caching and coalescing layers

### DIFF
--- a/patches/chromium/expose_setuseragent_on_networkcontext.patch
+++ b/patches/chromium/expose_setuseragent_on_networkcontext.patch
@@ -33,7 +33,7 @@ index 0ccfe130f00ec3b6c75cd8ee04d5a2777e1fd00c..653829457d58bf92057cc36aa8a28970
    DISALLOW_COPY_AND_ASSIGN(StaticHttpUserAgentSettings);
  };
 diff --git a/services/network/network_context.cc b/services/network/network_context.cc
-index 67986e284434115debf6a638b62c9585ac207c1d..ef64b8ab03b39066e1332cb6859c0012dc86e551 100644
+index 1e220456a91ce81a994c611d9ef8efed88846bc0..d2dcb8d7f18e737a75659e103f760e43bb1d7ff3 100644
 --- a/services/network/network_context.cc
 +++ b/services/network/network_context.cc
 @@ -1128,6 +1128,13 @@ void NetworkContext::SetNetworkConditions(

--- a/patches/chromium/network_service_allow_remote_certificate_verification_logic.patch
+++ b/patches/chromium/network_service_allow_remote_certificate_verification_logic.patch
@@ -7,7 +7,7 @@ This adds a callback from the network service that's used to implement
 session.setCertificateVerifyCallback.
 
 diff --git a/services/network/network_context.cc b/services/network/network_context.cc
-index dc1d135df68e8f11619faffb57dfd38b41bc06d1..67986e284434115debf6a638b62c9585ac207c1d 100644
+index dc1d135df68e8f11619faffb57dfd38b41bc06d1..1e220456a91ce81a994c611d9ef8efed88846bc0 100644
 --- a/services/network/network_context.cc
 +++ b/services/network/network_context.cc
 @@ -117,6 +117,11 @@
@@ -116,16 +116,16 @@ index dc1d135df68e8f11619faffb57dfd38b41bc06d1..67986e284434115debf6a638b62c9585
  void NetworkContext::CreateURLLoaderFactory(
      mojo::PendingReceiver<mojom::URLLoaderFactory> receiver,
      mojom::URLLoaderFactoryParamsPtr params) {
-@@ -1917,6 +2002,9 @@ URLRequestContextOwner NetworkContext::MakeURLRequestContext(
-         std::move(cert_verifier));
-     cert_verifier = base::WrapUnique(cert_verifier_with_trust_anchors_);
- #endif  // BUILDFLAG(IS_CHROMEOS_ASH)
+@@ -1900,6 +1985,9 @@ URLRequestContextOwner NetworkContext::MakeURLRequestContext(
+           std::move(cert_verifier), std::move(ct_verifier));
+     }
+ #endif  // BUILDFLAG(IS_CT_SUPPORTED)
 +    auto remote_cert_verifier = std::make_unique<RemoteCertVerifier>(std::move(cert_verifier));
 +    remote_cert_verifier_ = remote_cert_verifier.get();
-+    cert_verifier = std::make_unique<net::CachingCertVerifier>(std::move(remote_cert_verifier));
-   }
++    cert_verifier = std::move(remote_cert_verifier);
  
-   builder.SetCertVerifier(IgnoreErrorsCertVerifier::MaybeWrapCertVerifier(
+     // Whether the cert verifier is remote or in-process, we should wrap it in
+     // caching and coalescing layers to avoid extra verifications and IPCs.
 diff --git a/services/network/network_context.h b/services/network/network_context.h
 index 102548a7f132cd1f7d46421fc2ae941dbff7c29d..34281acc5a2dece3b84666b25f4af423a04bf8df 100644
 --- a/services/network/network_context.h


### PR DESCRIPTION
#### Description of Change
This fixes #28313.

Before this change, the RemoteCertVerifier would receive several concurrent
requests to verify the same domain, and the 2nd one to return would cause a
crash. I'm not totally sure what the exact cause of the crash was, but putting
the RemoteCertVerifier upstream from the coalescing and caching layers means
that only one verification request gets sent to the main process, and by doing
so fixes the crash.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a network process crash that could happen when using `setCertificateVerifyProc` with many concurrent verification requests.
