### PR TITLE
fix: export patches not retaining CRLF line endings

### DIFF
--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -47,7 +47,7 @@ def get_repo_root(path):
 
 
 def am(repo, patch_data, threeway=False, directory=None, exclude=None,
-    committer_name=None, committer_email=None):
+    committer_name=None, committer_email=None, keep_cr=True):
   args = []
   if threeway:
     args += ['--3way']
@@ -56,6 +56,10 @@ def am(repo, patch_data, threeway=False, directory=None, exclude=None,
   if exclude is not None:
     for path_pattern in exclude:
       args += ['--exclude', path_pattern]
+  if keep_cr is True:
+    # Keep the CR of CRLF in case any patches target files with Windows line
+    # endings.
+    args += ['--keep-cr']
 
   root_args = ['-C', repo]
   if committer_name is not None:
@@ -230,7 +234,9 @@ def split_patches(patch_data):
   """Split a concatenated series of patches into N separate patches"""
   patches = []
   patch_start = re.compile('^From [0-9a-f]+ ')
-  for line in patch_data.splitlines():
+  # Keep line endings in case any patches target files with CRLF.
+  keep_line_endings = True
+  for line in patch_data.splitlines(keep_line_endings):
     if patch_start.match(line):
       patches.append([])
     patches[-1].append(line)
@@ -246,13 +252,23 @@ def munge_subject_to_filename(subject):
 
 def get_file_name(patch):
   """Return the name of the file to which the patch should be written"""
+  file_name = None
   for line in patch:
     if line.startswith('Patch-Filename: '):
-      return line[len('Patch-Filename: '):]
+      file_name = line[len('Patch-Filename: '):]
+      break
   # If no patch-filename header, munge the subject.
-  for line in patch:
-    if line.startswith('Subject: '):
-      return munge_subject_to_filename(line[len('Subject: '):])
+  if not file_name:
+    for line in patch:
+      if line.startswith('Subject: '):
+        file_name = munge_subject_to_filename(line[len('Subject: '):])
+        break
+  return file_name.rstrip('\n')
+
+
+def join_patch(patch):
+  """Joins and formats patch contents"""
+  return ''.join(remove_patch_filename(patch)).rstrip('\n') + '\n'
 
 
 def remove_patch_filename(patch):
@@ -294,10 +310,8 @@ def export_patches(repo, out_dir, patch_range=None, dry_run=False):
     for patch in patches:
       filename = get_file_name(patch)
       filepath = posixpath.join(out_dir, filename)
-      existing_patch = io.open(filepath, 'r', encoding='utf-8').read()
-      formatted_patch = (
-        '\n'.join(remove_patch_filename(patch)).rstrip('\n') + '\n'
-      )
+      existing_patch = io.open(filepath, 'rb').read()
+      formatted_patch = join_patch(patch)
       if formatted_patch != existing_patch:
         patch_count += 1
     if patch_count > 0:
@@ -322,12 +336,11 @@ def export_patches(repo, out_dir, patch_range=None, dry_run=False):
       for patch in patches:
         filename = get_file_name(patch)
         file_path = posixpath.join(out_dir, filename)
-        formatted_patch = (
-          '\n'.join(remove_patch_filename(patch)).rstrip('\n') + '\n'
-        )
+        formatted_patch = join_patch(patch)
+        # Write in binary mode to retain mixed line endings on write.
         with io.open(
-          file_path, 'w', newline='\n', encoding='utf-8'
+          file_path, 'wb'
         ) as f:
-          f.write(formatted_patch)
+          f.write(formatted_patch.encode('utf-8'))
         pl.write(filename + '\n')
 

--- a/script/lint.js
+++ b/script/lint.js
@@ -207,7 +207,7 @@ const LINTERS = [{
         console.warn(`Patch file '${f}' has no description. Every patch must contain a justification for why the patch exists and the plan for its removal.`);
         return false;
       }
-      const trailingWhitespace = patchText.split('\n').filter(line => line.startsWith('+')).some(line => /\s+$/.test(line));
+      const trailingWhitespace = patchText.split(/\r?\n/).some(line => line.startsWith('+') && /\s+$/.test(line));
       if (trailingWhitespace) {
         console.warn(`Patch file '${f}' has trailing whitespace on some lines.`);
         return false;


### PR DESCRIPTION
#### Description of Change
When a patch targets a file using CRLF line endings, they need to be retained in the exported patch file. Otherwise the patch will fail to apply. `git am` searches for surrounding lines of the initial file before patching, and without matching line endings it will fail to find them.
```
git am ../../electron/patches/webrtc/example.patch --reject
Checking patch modules/desktop_capture/win/wgc_capture_session.cc...
error: while searching for:
...
```

This came about due to the file referenced above containing CRLF line endings. This was probably a mistake upstream, but regardless should ideally still be supported by Electron scripts anyway.

Reasons why this wasn't supported before was
- [`str.splitlines()`](https://docs.python.org/3/library/stdtypes.html#str.splitlines) does not keep line endings by default.
- Patch file handles were opened in non-binary mode which coerces line endings on write.
- [`git am`](https://git-scm.com/docs/git-am#Documentation/git-am.txt---no-keep-cr) seems to default to stripping the `CR` byte from `CRLF`.

-----

To test that all current patches are unaffected by these changes, I ran `e patches all` to re-export them. After doing so, there are no changes detected by Git:
```
/w/electron/testing/src/electron (fix/patch-crlf)
$ e patches all
Exporting 9 patches since 50e0c3a02268852f4c0d73e3b3a24d2f52a7f419 in src/v8
Exporting 1 patches since 78d3966b3c331292ea29ec38661b25df0a245948 in src/third_party/squirrel.mac/vendor/Mantle
Exporting 1 patches since fa32fc9cc931647af5942529b586dcb7e3bec6f1 in src/third_party/depot_tools
Exporting 34 patches since bd60e93357a118204ea238d94e7a9e4209d93062 in src/third_party/electron_node
Exporting 2 patches since cdc0729c8bf8576bfef18629186e1e9ecf1b0d9f in src/third_party/squirrel.mac
Exporting 1 patches since 74ab5baccc6f7202c8ac69a8d1e152c29dc1ea76 in src/third_party/squirrel.mac/vendor/ReactiveObjC
Exporting 111 patches since f5d4325233240f35afaaa1d02c063b735da9dd81 in src
Exporting 3 patches since ce9b002ebd0491a8dd802e208814360ce781f32b in src/third_party/boringssl/src
Exporting 1 patches since 2c4ee8a32a299eada3cd6e468bbd0a473bfea96d in src/third_party/nan

/w/electron/testing/src/electron (fix/patch-crlf)
$ git status
On branch fix/patch-crlf
nothing to commit, working tree clean
```

Following this, running `e sync` again runs without errors during the patch application steps.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none
