### PR TITLE
fix: disappearing thumbar after win.hide()

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -444,6 +444,10 @@ void NativeWindowViews::Hide() {
 #endif
 
 #if defined(OS_WIN)
+  // When the window is removed from the taskbar via win.hide(),
+  // the thumbnail buttons need to be set up again.
+  // Ensure that when the window is hidden,
+  // the taskbar host is notified that it should re-add them.
   taskbar_host_.SetThumbarButtonsAdded(false);
 #endif
 }

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -442,6 +442,10 @@ void NativeWindowViews::Hide() {
   if (!features::IsUsingOzonePlatform() && global_menu_bar_)
     global_menu_bar_->OnWindowUnmapped();
 #endif
+
+#if defined(OS_WIN)
+  taskbar_host_.SetThumbarButtonsAdded(false);
+#endif
 }
 
 bool NativeWindowViews::IsVisible() {

--- a/shell/browser/ui/win/taskbar_host.cc
+++ b/shell/browser/ui/win/taskbar_host.cc
@@ -114,11 +114,12 @@ bool TaskbarHost::SetThumbarButtons(HWND window,
 
   // Finally add them to taskbar.
   HRESULT r;
-  if (thumbar_buttons_added_)
+  if (thumbar_buttons_added_) {
     r = taskbar_->ThumbBarUpdateButtons(window, kMaxButtonsCount,
                                         thumb_buttons);
-  else
+  } else {
     r = taskbar_->ThumbBarAddButtons(window, kMaxButtonsCount, thumb_buttons);
+  }
 
   thumbar_buttons_added_ = true;
   last_buttons_ = buttons;

--- a/shell/browser/ui/win/taskbar_host.h
+++ b/shell/browser/ui/win/taskbar_host.h
@@ -60,6 +60,8 @@ class TaskbarHost {
   // Called by the window that there is a button in thumbar clicked.
   bool HandleThumbarButtonEvent(int button_id);
 
+  void SetThumbarButtonsAdded(bool added) { thumbar_buttons_added_ = added; }
+
  private:
   // Initialize the taskbar object.
   bool InitializeTaskbar();


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/28319.

When the window is removed from the taskbar via `win.hide()`, the thumbnail buttons need to be set up again. Ensure that when the window is hidden, the taskbar host is notified that it should re-add them.

Tested with https://gist.github.com/883fa102da7c81e47bb866aa20089292.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the thumbar disappeared after `win.hide()` on Windows.
