### PR TITLE
fix: beforeunload and unload firing in BrowserViews

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -375,6 +375,8 @@ win.webContents.on('will-prevent-unload', (event) => {
 })
 ```
 
+**Note:** This will be emitted for `BrowserViews` but will _not_ be respected - this is because we have chosen not to tie the `BrowserView` lifecycle to its owning BrowserWindow should one exist per the [specification](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event).
+
 #### Event: 'crashed' _Deprecated_
 
 Returns:

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -238,35 +238,35 @@ void BrowserWindow::OnCloseButtonClicked(bool* prevent_default) {
   if (window_unresponsive_closure_.IsCancelled())
     ScheduleUnresponsiveEvent(5000);
 
-  if (!web_contents()) {
-    // Already closed by renderer.
+  // Already closed by renderer.
+  if (!web_contents())
     return;
-  }
 
   // Required to make beforeunload handler work.
   api_web_contents_->NotifyUserActivation();
 
+  // Trigger beforeunload events for associated BrowserViews.
   for (NativeBrowserView* view : window_->browser_views()) {
-    auto* api_web_contents = api::WebContents::From(view->web_contents());
+    auto* vwc = view->web_contents();
+    auto* api_web_contents = api::WebContents::From(vwc);
+
+    // Required to make beforeunload handler work.
     if (api_web_contents)
       api_web_contents->NotifyUserActivation();
+
+    if (vwc) {
+      if (vwc->NeedToFireBeforeUnloadOrUnloadEvents()) {
+        vwc->DispatchBeforeUnload(false /* auto_cancel */);
+      }
+    }
   }
 
   if (web_contents()->NeedToFireBeforeUnloadOrUnloadEvents()) {
     web_contents()->DispatchBeforeUnload(false /* auto_cancel */);
   } else {
-    bool should_close = true;
-    for (NativeBrowserView* view : window_->browser_views()) {
-      if (view->web_contents()->NeedToFireBeforeUnloadOrUnloadEvents()) {
-        view->web_contents()->DispatchBeforeUnload(false /* auto_cancel */);
-        should_close = false;
-      }
-    }
-
-    if (should_close)
-      web_contents()->Close();
+    web_contents()->Close();
   }
-}
+}  // namespace api
 
 void BrowserWindow::OnWindowBlur() {
   if (api_web_contents_)

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -245,10 +245,20 @@ void BrowserWindow::OnCloseButtonClicked(bool* prevent_default) {
   // Required to make beforeunload handler work.
   api_web_contents_->NotifyUserActivation();
 
-  if (web_contents()->NeedToFireBeforeUnloadOrUnloadEvents())
+  if (web_contents()->NeedToFireBeforeUnloadOrUnloadEvents()) {
     web_contents()->DispatchBeforeUnload(false /* auto_cancel */);
-  else
-    web_contents()->Close();
+  } else {
+    bool should_close = true;
+    for (NativeBrowserView* view : window_->browser_views()) {
+      if (view->web_contents()->NeedToFireBeforeUnloadOrUnloadEvents()) {
+        view->web_contents()->DispatchBeforeUnload(false /* auto_cancel */);
+        should_close = false;
+      }
+    }
+
+    if (should_close)
+      web_contents()->Close();
+  }
 }
 
 void BrowserWindow::OnWindowBlur() {

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -238,12 +238,19 @@ void BrowserWindow::OnCloseButtonClicked(bool* prevent_default) {
   if (window_unresponsive_closure_.IsCancelled())
     ScheduleUnresponsiveEvent(5000);
 
-  if (!web_contents())
-    // Already closed by renderer
+  if (!web_contents()) {
+    // Already closed by renderer.
     return;
+  }
 
   // Required to make beforeunload handler work.
   api_web_contents_->NotifyUserActivation();
+
+  for (NativeBrowserView* view : window_->browser_views()) {
+    auto* api_web_contents = api::WebContents::From(view->web_contents());
+    if (api_web_contents)
+      api_web_contents->NotifyUserActivation();
+  }
 
   if (web_contents()->NeedToFireBeforeUnloadOrUnloadEvents()) {
     web_contents()->DispatchBeforeUnload(false /* auto_cancel */);

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1119,7 +1119,8 @@ content::WebContents* WebContents::OpenURLFromTab(
 void WebContents::BeforeUnloadFired(content::WebContents* tab,
                                     bool proceed,
                                     bool* proceed_to_fire_unload) {
-  if (type_ == Type::kBrowserWindow || type_ == Type::kOffScreen)
+  if (type_ == Type::kBrowserWindow || type_ == Type::kOffScreen ||
+      type_ == Type::kBrowserView)
     *proceed_to_fire_unload = proceed;
   else
     *proceed_to_fire_unload = true;

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -102,20 +102,6 @@ describe('webContents module', () => {
       w.close();
       await wait;
     });
-
-    it('supports calling preventDefault on will-prevent-unload events in a BrowserView', async () => {
-      const w = new BrowserWindow({ show: false });
-      const view = new BrowserView();
-      w.setBrowserView(view);
-      view.setBounds(w.getBounds());
-
-      view.webContents.once('will-prevent-unload', event => event.preventDefault());
-      await view.webContents.loadFile(path.join(__dirname, 'fixtures', 'api', 'beforeunload-false.html'));
-
-      const wait = emittedOnce(w, 'closed');
-      w.close();
-      await wait;
-    });
   });
 
   describe('webContents.send(channel, args...)', () => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/20746.
Closes https://github.com/electron/electron/issues/27722.

Fixes an issue where `beforeunload` and `unload` weren't firing at all in `BrowserView`s. This was happening because we were only checking the BrowserWindow's `webContents` to see whether or not the events needed to be fired, and we also needed to check the `BrowserView`s WebContents.

However, this change makes it such that the event will be emitted for `BrowserViews` but will _not_ be respected - I've chosen not to tie the `BrowserView` lifecycle to its owning BrowserWindow should one exist per the [specification](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event). Either way this is undefined behavior, and the alternative would be to wait until _all_ associated `BrowserViews` for a `BrowserWindow` had their `webContents` destroyed, and given that a `BrowserView` doesn't _need_ to be associated with a `BrowserWindow` this would ultimately be more confusing for end users.

cc @zcbenz @deepak1556 @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `beforeunload` and `unload` weren't firing properly in `BrowserView`s.
