### PR TITLE
docs: remove checkbox options in dialog.showMessageBoxSync

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -233,10 +233,6 @@ expanding and collapsing the dialog.
     be selected by default when the message box opens.
   * `title` String (optional) - Title of the message box, some platforms will not show it.
   * `detail` String (optional) - Extra information of the message.
-  * `checkboxLabel` String (optional) - If provided, the message box will
-    include a checkbox with the given label.
-  * `checkboxChecked` Boolean (optional) - Initial checked state of the
-    checkbox. `false` by default.
   * `icon` ([NativeImage](native-image.md) | String) (optional)
   * `cancelId` Integer (optional) - The index of the button to be used to cancel the dialog, via
     the `Esc` key. By default this is assigned to the first button with "cancel" or "no" as the


### PR DESCRIPTION
#### Description of Change

Undocument the `checkboxLabel` and `checkboxChecked` within `dialog.showMessageBoxSync` to avoid confusion as the result is not accessible with that API

View #28394

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none