### PR TITLE
test: increase timeout for spellchecker under ASan

### DIFF
--- a/spec-main/spellchecker-spec.ts
+++ b/spec-main/spellchecker-spec.ts
@@ -13,7 +13,7 @@ const features = process._linkedBinding('electron_common_features');
 const v8Util = process._linkedBinding('electron_common_v8_util');
 
 ifdescribe(features.isBuiltinSpellCheckerEnabled())('spellchecker', function () {
-  this.timeout((process.env.IS_ASAN ? 100 : 20) * 1000);
+  this.timeout((process.env.IS_ASAN ? 200 : 20) * 1000);
 
   let w: BrowserWindow;
 
@@ -33,7 +33,7 @@ ifdescribe(features.isBuiltinSpellCheckerEnabled())('spellchecker', function () 
   // to detect spellchecker is to keep checking with a busy loop.
   async function rightClickUntil (fn: (params: Electron.ContextMenuParams) => boolean) {
     const now = Date.now();
-    const timeout = 10 * 1000;
+    const timeout = (process.env.IS_ASAN ? 180 : 10) * 1000;
     let contextMenuParams = await rightClick();
     while (!fn(contextMenuParams) && (Date.now() - now < timeout)) {
       await delay(100);


### PR DESCRIPTION
#### Description of Change

Even with https://github.com/electron/electron/pull/28386 the spellchecker may still take more than a minute to load under ASan, so increate the timeout of spellchecker to 3 minutes for ASan.

This is my last try to make spellchecker test work under ASan, if it is still flaky, I think we should just disable it for ASan.

#### Release Notes

Notes: none