### PR TITLE
fix: handle an unparsable pdf manifest

### DIFF
--- a/shell/browser/extensions/electron_extension_system.cc
+++ b/shell/browser/extensions/electron_extension_system.cc
@@ -114,13 +114,16 @@ void ElectronExtensionSystem::LoadComponentExtensions() {
   std::string pdf_manifest_string = pdf_extension_util::GetManifest();
   std::unique_ptr<base::DictionaryValue> pdf_manifest =
       ParseManifest(pdf_manifest_string);
-  base::FilePath root_directory;
-  CHECK(base::PathService::Get(chrome::DIR_RESOURCES, &root_directory));
-  root_directory = root_directory.Append(FILE_PATH_LITERAL("pdf"));
-  scoped_refptr<const Extension> pdf_extension = extensions::Extension::Create(
-      root_directory, extensions::Manifest::COMPONENT, *pdf_manifest,
-      extensions::Extension::REQUIRE_KEY, &utf8_error);
-  extension_loader_->registrar()->AddExtension(pdf_extension);
+  if (pdf_manifest) {
+    base::FilePath root_directory;
+    CHECK(base::PathService::Get(chrome::DIR_RESOURCES, &root_directory));
+    root_directory = root_directory.Append(FILE_PATH_LITERAL("pdf"));
+    scoped_refptr<const Extension> pdf_extension =
+        extensions::Extension::Create(
+            root_directory, extensions::Manifest::COMPONENT, *pdf_manifest,
+            extensions::Extension::REQUIRE_KEY, &utf8_error);
+    extension_loader_->registrar()->AddExtension(pdf_extension);
+  }
 #endif
 }
 


### PR DESCRIPTION
This aligns our component extension loading logic with https://source.chromium.org/chromium/chromium/src/+/master:chrome/browser/extensions/component_loader.cc;l=215-216;drc=062c315a858a87f834e16a144c2c8e9591af2beb

Notes: Fixes rare crash when initializing the internal PDF extension