### PR TITLE
docs: add frameName note for window.open

### DIFF
--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -65,6 +65,7 @@ window.open('https://github.com', '_blank', 'top=500,left=200,frame=false,nodeIn
 * Non-standard features (that are not handled by Chromium or Electron) given in
   `features` will be passed to any registered `webContents`'s
   `did-create-window` event handler in the `additionalFeatures` argument.
+* `frameName` follows the specification of `windowName` located in the [native documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#parameters).
 
 To customize or cancel the creation of the window, you can optionally set an
 override handler with `webContents.setWindowOpenHandler()` from the main


### PR DESCRIPTION
#### Description of Change

There was no update to the `window.open` documentation when https://github.com/electron/electron/pull/27481 was merged. This PR adds a note for how `frameName` is related to `windowName` in the [native documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#parameters).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> None
