### PR TITLE
fix: use correct Node.js shutdown order

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -523,9 +523,9 @@ void ElectronBrowserMainParts::PostMainMessageLoopRun() {
   // Destroy node platform after all destructors_ are executed, as they may
   // invoke Node/V8 APIs inside them.
   node_env_->env()->set_trace_sync_io(false);
-  js_env_->OnMessageLoopDestroying();
   node::Stop(node_env_->env());
   node_env_.reset();
+  js_env_->OnMessageLoopDestroying();
 
   auto default_context_key = ElectronBrowserContext::PartitionKey("", false);
   std::unique_ptr<ElectronBrowserContext> default_context = std::move(


### PR DESCRIPTION

#### Description of Change

The Environment is created after the Isolate and its platform data,
so it also needs to be torn down before it. This fixes the crash
mentioned below.

(Thanks to @indutny for debugging this!)

Fixes: https://github.com/electron/electron/issues/23315

The crash itself affects versions based on Node.js 12.x, but the order is also wrong on master (diff applies cleanly everywhere I checked), so I opened a PR against master in the hope that it goes into at least Electron 11.x soon as well (or, rather, that’s what @indutny would like to see :))

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

(I did none of these things because buildig Electron takes forever and I don’t plan on doing that anytime soon, sorry – still :blue_heart: the Electron team)

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
