### PR TITLE
fix: free IsolateData in ~NodeEnvironment

### DIFF
--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -363,7 +363,9 @@ void JavascriptEnvironment::OnMessageLoopDestroying() {
 NodeEnvironment::NodeEnvironment(node::Environment* env) : env_(env) {}
 
 NodeEnvironment::~NodeEnvironment() {
+  auto* isolate_data = env_->isolate_data();
   node::FreeEnvironment(env_);
+  node::FreeIsolateData(isolate_data);
 }
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

This seems to just have been missing here, leaking memory
(and breaking the API contract for Node.js embedding).

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
