### PR TITLE
fix: put RemoteCertVerifier upstream from the caching and coalescing layers

### DIFF
--- a/patches/chromium/expose_setuseragent_on_networkcontext.patch
+++ b/patches/chromium/expose_setuseragent_on_networkcontext.patch
@@ -33,7 +33,7 @@ index 0ccfe130f00ec3b6c75cd8ee04d5a2777e1fd00c..653829457d58bf92057cc36aa8a28970
    DISALLOW_COPY_AND_ASSIGN(StaticHttpUserAgentSettings);
  };
 diff --git a/services/network/network_context.cc b/services/network/network_context.cc
-index d664ad5844eeeb5cbaa19e1f9da33722dec00249..9c7a7a4b81be568639ef953f32c47381203e64fd 100644
+index e36e5f9306bda8d9523d14d46dd71ea2f3bb8530..a6e1850aabcaf422513c699fb7bc85820b79a219 100644
 --- a/services/network/network_context.cc
 +++ b/services/network/network_context.cc
 @@ -1082,6 +1082,13 @@ void NetworkContext::SetNetworkConditions(

--- a/patches/chromium/expose_setuseragent_on_networkcontext.patch
+++ b/patches/chromium/expose_setuseragent_on_networkcontext.patch
@@ -33,7 +33,7 @@ index 0ccfe130f00ec3b6c75cd8ee04d5a2777e1fd00c..653829457d58bf92057cc36aa8a28970
    DISALLOW_COPY_AND_ASSIGN(StaticHttpUserAgentSettings);
  };
 diff --git a/services/network/network_context.cc b/services/network/network_context.cc
-index 3dc5c6d6027be44c1e799bb8e0b509a03bae963a..b2d9b7a74f71b3127f51ea2c4f4ed0caaa2bff05 100644
+index d664ad5844eeeb5cbaa19e1f9da33722dec00249..9c7a7a4b81be568639ef953f32c47381203e64fd 100644
 --- a/services/network/network_context.cc
 +++ b/services/network/network_context.cc
 @@ -1082,6 +1082,13 @@ void NetworkContext::SetNetworkConditions(

--- a/patches/chromium/network_service_allow_remote_certificate_verification_logic.patch
+++ b/patches/chromium/network_service_allow_remote_certificate_verification_logic.patch
@@ -7,7 +7,7 @@ This adds a callback from the network service that's used to implement
 session.setCertificateVerifyCallback.
 
 diff --git a/services/network/network_context.cc b/services/network/network_context.cc
-index 1e9e1d93cb783c104c2672189df7c8410a3dfbed..3dc5c6d6027be44c1e799bb8e0b509a03bae963a 100644
+index 1e9e1d93cb783c104c2672189df7c8410a3dfbed..d664ad5844eeeb5cbaa19e1f9da33722dec00249 100644
 --- a/services/network/network_context.cc
 +++ b/services/network/network_context.cc
 @@ -115,6 +115,11 @@
@@ -116,64 +116,23 @@ index 1e9e1d93cb783c104c2672189df7c8410a3dfbed..3dc5c6d6027be44c1e799bb8e0b509a0
  void NetworkContext::CreateURLLoaderFactory(
      mojo::PendingReceiver<mojom::URLLoaderFactory> receiver,
      mojom::URLLoaderFactoryParamsPtr params) {
-@@ -1820,8 +1905,9 @@ URLRequestContextOwner NetworkContext::MakeURLRequestContext(
-          "NetworkContext should pass CertVerifierServiceRemoteParams.";
- 
-   std::unique_ptr<net::CertVerifier> cert_verifier;
-+  std::unique_ptr<net::CertVerifier> temp_verifier;
-   if (g_cert_verifier_for_testing) {
--    cert_verifier = std::make_unique<WrappedTestingCertVerifier>();
-+    temp_verifier = std::make_unique<WrappedTestingCertVerifier>();
-   } else {
-     if (params_->cert_verifier_params &&
-         params_->cert_verifier_params->is_remote_params()) {
-@@ -1849,14 +1935,14 @@ URLRequestContextOwner NetworkContext::MakeURLRequestContext(
-         cert_net_fetcher_ =
-             base::MakeRefCounted<net::CertNetFetcherURLRequest>();
- 
--      cert_verifier = CreateCertVerifier(creation_params, cert_net_fetcher_);
-+      temp_verifier = CreateCertVerifier(creation_params, cert_net_fetcher_);
+@@ -1852,6 +1937,10 @@ URLRequestContextOwner NetworkContext::MakeURLRequestContext(
+       cert_verifier = CreateCertVerifier(creation_params, cert_net_fetcher_);
      }
  
++    auto remote_cert_verifier = std::make_unique<RemoteCertVerifier>(std::move(cert_verifier));
++    remote_cert_verifier_ = remote_cert_verifier.get();
++    cert_verifier = std::move(remote_cert_verifier);
++
      // Whether the cert verifier is remote or in-process, we should wrap it in
      // caching and coalescing layers to avoid extra verifications and IPCs.
--    cert_verifier = std::make_unique<net::CachingCertVerifier>(
-+    temp_verifier = std::make_unique<net::CachingCertVerifier>(
-         std::make_unique<net::CoalescingCertVerifier>(
--            std::move(cert_verifier)));
-+            std::move(temp_verifier)));
- 
- #if defined(OS_CHROMEOS)
-     cert_verifier_with_trust_anchors_ =
-@@ -1865,13 +1951,27 @@ URLRequestContextOwner NetworkContext::MakeURLRequestContext(
-     UpdateAdditionalCertificates(
-         std::move(params_->initial_additional_certificates));
-     cert_verifier_with_trust_anchors_->InitializeOnIOThread(
--        std::move(cert_verifier));
--    cert_verifier = base::WrapUnique(cert_verifier_with_trust_anchors_);
-+        std::move(temp_verifier));
-+    temp_verifier = base::WrapUnique(cert_verifier_with_trust_anchors_);
- #endif  // defined(OS_CHROMEOS)
-+    if (!temp_verifier) {
-+#if !defined(OS_LINUX)
-+      temp_verifier = std::make_unique<net::MultiThreadedCertVerifier>(
-+          net::CertVerifyProc::CreateSystemVerifyProc(std::move(cert_net_fetcher_)));
-+#else
-+      temp_verifier = std::make_unique<net::MultiThreadedCertVerifier>(
-+          net::CertVerifyProc::CreateBuiltinVerifyProc(std::move(cert_net_fetcher_)));
-+#endif
-+    }
-+    auto remote_cert_verifier = std::make_unique<RemoteCertVerifier>(std::move(temp_verifier));
-+    remote_cert_verifier_ = remote_cert_verifier.get();
-+    cert_verifier = std::make_unique<net::CachingCertVerifier>(std::move(remote_cert_verifier));
+     cert_verifier = std::make_unique<net::CachingCertVerifier>(
+@@ -1871,7 +1960,7 @@ URLRequestContextOwner NetworkContext::MakeURLRequestContext(
    }
  
--  builder.SetCertVerifier(IgnoreErrorsCertVerifier::MaybeWrapCertVerifier(
+   builder.SetCertVerifier(IgnoreErrorsCertVerifier::MaybeWrapCertVerifier(
 -      *command_line, nullptr, std::move(cert_verifier)));
-+  cert_verifier = IgnoreErrorsCertVerifier::MaybeWrapCertVerifier(
 +      *command_line, nullptr, std::move(cert_verifier));
-+
-+  builder.SetCertVerifier(std::move(cert_verifier));
  
    std::unique_ptr<NetworkServiceNetworkDelegate> network_delegate =
        std::make_unique<NetworkServiceNetworkDelegate>(

--- a/patches/chromium/network_service_allow_remote_certificate_verification_logic.patch
+++ b/patches/chromium/network_service_allow_remote_certificate_verification_logic.patch
@@ -127,15 +127,6 @@ index 1e9e1d93cb783c104c2672189df7c8410a3dfbed..d664ad5844eeeb5cbaa19e1f9da33722
      // Whether the cert verifier is remote or in-process, we should wrap it in
      // caching and coalescing layers to avoid extra verifications and IPCs.
      cert_verifier = std::make_unique<net::CachingCertVerifier>(
-@@ -1871,7 +1960,7 @@ URLRequestContextOwner NetworkContext::MakeURLRequestContext(
-   }
- 
-   builder.SetCertVerifier(IgnoreErrorsCertVerifier::MaybeWrapCertVerifier(
--      *command_line, nullptr, std::move(cert_verifier)));
-+      *command_line, nullptr, std::move(cert_verifier));
- 
-   std::unique_ptr<NetworkServiceNetworkDelegate> network_delegate =
-       std::make_unique<NetworkServiceNetworkDelegate>(
 diff --git a/services/network/network_context.h b/services/network/network_context.h
 index e1a8746bcdaf61c181566369b380af5ead3a7796..1372f6f6ca4899cc7b230a3cd1b26db4c16325b5 100644
 --- a/services/network/network_context.h

--- a/patches/chromium/network_service_allow_remote_certificate_verification_logic.patch
+++ b/patches/chromium/network_service_allow_remote_certificate_verification_logic.patch
@@ -7,7 +7,7 @@ This adds a callback from the network service that's used to implement
 session.setCertificateVerifyCallback.
 
 diff --git a/services/network/network_context.cc b/services/network/network_context.cc
-index 1e9e1d93cb783c104c2672189df7c8410a3dfbed..d664ad5844eeeb5cbaa19e1f9da33722dec00249 100644
+index 1e9e1d93cb783c104c2672189df7c8410a3dfbed..e36e5f9306bda8d9523d14d46dd71ea2f3bb8530 100644
 --- a/services/network/network_context.cc
 +++ b/services/network/network_context.cc
 @@ -115,6 +115,11 @@


### PR DESCRIPTION
Backport of #28358.

Notes: Fixed a network process crash that could happen when using `setCertificateVerifyProc` with many concurrent verification requests.
