### PR TITLE
feat: add `process.getWindowsVersionType()` API

### DIFF
--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -218,7 +218,7 @@ that all statistics are reported in Kilobytes.
 
 ### `process.getSystemProductType()`
 
-Returns `String` - Returns `server` if operating system is Windows Server. Otherwise, returns `desktop`.
+Returns `String` - Can be `server` or `desktop`. Returns `server` if operating system is Windows Server. Otherwise, returns `desktop`.
 
 ### `process.getSystemVersion()`
 

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -218,7 +218,8 @@ that all statistics are reported in Kilobytes.
 
 ### `process.getSystemProductType()`
 
-Returns `String` - Can be `server` or `desktop`. Returns `server` if operating system is Windows Server. Otherwise, returns `desktop`.
+Returns `String` - Can be `server` or `desktop`.Returns `server` if operating
+system is Windows Server. Otherwise, returns `desktop`.
 
 ### `process.getSystemVersion()`
 

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -19,6 +19,7 @@ In sandboxed renderers the `process` object contains only a subset of the APIs:
 * `getBlinkMemoryInfo()`
 * `getProcessMemoryInfo()`
 * `getSystemMemoryInfo()`
+* `getSystemProductType()`
 * `getSystemVersion()`
 * `getCPUUsage()`
 * `getIOCounters()`
@@ -214,6 +215,10 @@ Returns `Object`:
 
 Returns an object giving memory usage statistics about the entire system. Note
 that all statistics are reported in Kilobytes.
+
+### `process.getSystemProductType()`
+
+Returns `String` - Returns `server` if operating system is Windows Server. Otherwise, returns `desktop`.
 
 ### `process.getSystemVersion()`
 

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -218,8 +218,8 @@ that all statistics are reported in Kilobytes.
 
 ### `process.getWindowsVersionType()`
 
-Returns `String` - Can be `server` or `desktop`. Returns `server` if operating
-system is Windows Server. Otherwise, returns `desktop`.
+Returns `String` - Returns the type of Windows version running on the host operating system.
+Can be `home`, `professional`, `server`, `enterprise`, `education`, or `educationPro`.
 
 ### `process.getSystemVersion()`
 

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -216,7 +216,7 @@ Returns `Object`:
 Returns an object giving memory usage statistics about the entire system. Note
 that all statistics are reported in Kilobytes.
 
-### `process.getWindowsVersionType()`
+### `process.getWindowsVersionType()` _Windows_
 
 Returns `String` - Returns the type of Windows version running on the host operating system.
 Can be `home`, `professional`, `server`, `enterprise`, `education`, or `educationPro`.

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -19,7 +19,7 @@ In sandboxed renderers the `process` object contains only a subset of the APIs:
 * `getBlinkMemoryInfo()`
 * `getProcessMemoryInfo()`
 * `getSystemMemoryInfo()`
-* `getSystemProductType()`
+* `getWindowsVersionType()`
 * `getSystemVersion()`
 * `getCPUUsage()`
 * `getIOCounters()`
@@ -216,9 +216,9 @@ Returns `Object`:
 Returns an object giving memory usage statistics about the entire system. Note
 that all statistics are reported in Kilobytes.
 
-### `process.getSystemProductType()`
+### `process.getWindowsVersionType()`
 
-Returns `String` - Can be `server` or `desktop`.Returns `server` if operating
+Returns `String` - Can be `server` or `desktop`. Returns `server` if operating
 system is Windows Server. Otherwise, returns `desktop`.
 
 ### `process.getSystemVersion()`

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -59,7 +59,7 @@ void ElectronBindings::BindProcess(v8::Isolate* isolate,
   process->SetMethod("getCPUUsage",
                      base::BindRepeating(&ElectronBindings::GetCPUUsage,
                                          base::Unretained(metrics)));
-  process->SetMethod("erick", &base::win::version_type());
+  process->SetMethod("erick", &Erick);
 
 #if defined(MAS_BUILD)
   process->SetReadOnly("mas", true);
@@ -329,6 +329,11 @@ bool ElectronBindings::TakeHeapSnapshot(v8::Isolate* isolate,
                   base::File::FLAG_CREATE_ALWAYS | base::File::FLAG_WRITE);
 
   return electron::TakeHeapSnapshot(isolate, &file);
+}
+
+// static
+void ElectronBindings::Erick() {
+  LOG(INFO) << "ERICK WAS HERE";
 }
 
 }  // namespace electron

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -211,7 +211,7 @@ v8::Local<v8::Value> ElectronBindings::GetSystemProductType(
     v8::Isolate* isolate) {
   std::string type = "desktop";
 
-// TODO: implement the equivalent API in Linux
+// TODO(erickzhao): implement the equivalent API in Linux
 #if defined(OS_WIN)
   auto* os_info = base::win::OSInfo::GetInstance();
   if (os_info->version_type() == base::win::SUITE_SERVER) {

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -15,6 +15,7 @@
 #include "base/process/process_metrics_iocounters.h"
 #include "base/system/sys_info.h"
 #include "base/threading/thread_restrictions.h"
+#include "base/win/windows_version.h"
 #include "chrome/common/chrome_version.h"
 #include "electron/electron_version.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/global_memory_dump.h"
@@ -58,6 +59,7 @@ void ElectronBindings::BindProcess(v8::Isolate* isolate,
   process->SetMethod("getCPUUsage",
                      base::BindRepeating(&ElectronBindings::GetCPUUsage,
                                          base::Unretained(metrics)));
+  process->SetMethod("erick", &base::win::version_type());
 
 #if defined(MAS_BUILD)
   process->SetReadOnly("mas", true);

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -53,9 +53,9 @@ void ElectronBindings::BindProcess(v8::Isolate* isolate,
   process->SetMethod("getBlinkMemoryInfo", &GetBlinkMemoryInfo);
   process->SetMethod("getProcessMemoryInfo", &GetProcessMemoryInfo);
   process->SetMethod("getSystemMemoryInfo", &GetSystemMemoryInfo);
+  process->SetMethod("getSystemProductType", &GetSystemProductType);
   process->SetMethod("getSystemVersion",
                      &base::SysInfo::OperatingSystemVersion);
-  process->SetMethod("getSystemProductType", &GetSystemProductType);
   process->SetMethod("getIOCounters", &GetIOCounters);
   process->SetMethod("getCPUUsage",
                      base::BindRepeating(&ElectronBindings::GetCPUUsage,
@@ -165,22 +165,6 @@ v8::Local<v8::Value> ElectronBindings::GetHeapStatistics(v8::Isolate* isolate) {
 }
 
 // static
-v8::Local<v8::Value> ElectronBindings::GetSystemProductType(
-    v8::Isolate* isolate) {
-  std::string type = "desktop";
-
-// TODO: implement the equivalent API in Linux
-#if defined(OS_WIN)
-  auto* os_info = base::win::OSInfo::GetInstance();
-  if (os_info->version_type() == base::win::SUITE_SERVER) {
-    type = "server";
-  }
-#endif
-
-  return v8::String::NewFromUtf8(isolate, type.c_str()).ToLocalChecked();
-}
-
-// static
 v8::Local<v8::Value> ElectronBindings::GetCreationTime(v8::Isolate* isolate) {
   auto timeValue = base::Process::Current().CreationTime();
   if (timeValue.is_null()) {
@@ -220,6 +204,22 @@ v8::Local<v8::Value> ElectronBindings::GetSystemMemoryInfo(
 #endif
 
   return dict.GetHandle();
+}
+
+// static
+v8::Local<v8::Value> ElectronBindings::GetSystemProductType(
+    v8::Isolate* isolate) {
+  std::string type = "desktop";
+
+// TODO: implement the equivalent API in Linux
+#if defined(OS_WIN)
+  auto* os_info = base::win::OSInfo::GetInstance();
+  if (os_info->version_type() == base::win::SUITE_SERVER) {
+    type = "server";
+  }
+#endif
+
+  return v8::String::NewFromUtf8(isolate, type.c_str()).ToLocalChecked();
 }
 
 // static

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -5,6 +5,7 @@
 #include "shell/common/api/electron_bindings.h"
 
 #include <algorithm>
+#include <map>
 #include <string>
 #include <utility>
 #include <vector>

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -53,7 +53,7 @@ void ElectronBindings::BindProcess(v8::Isolate* isolate,
   process->SetMethod("getBlinkMemoryInfo", &GetBlinkMemoryInfo);
   process->SetMethod("getProcessMemoryInfo", &GetProcessMemoryInfo);
   process->SetMethod("getSystemMemoryInfo", &GetSystemMemoryInfo);
-  process->SetMethod("getSystemProductType", &GetSystemProductType);
+  process->SetMethod("getWindowsVersionType", &GetWindowsVersionType);
   process->SetMethod("getSystemVersion",
                      &base::SysInfo::OperatingSystemVersion);
   process->SetMethod("getIOCounters", &GetIOCounters);
@@ -207,16 +207,26 @@ v8::Local<v8::Value> ElectronBindings::GetSystemMemoryInfo(
 }
 
 // static
-v8::Local<v8::Value> ElectronBindings::GetSystemProductType(
+v8::Local<v8::Value> ElectronBindings::GetWindowsVersionType(
     v8::Isolate* isolate) {
-  std::string type = "desktop";
+  std::string type;
+  std::map<base::win::VersionType, std::string> versionMap{
+      {base::win::SUITE_HOME, "home"},
+      {base::win::SUITE_PROFESSIONAL, "professional"},
+      {base::win::SUITE_SERVER, "server"},
+      {base::win::SUITE_ENTERPRISE, "enterprise"},
+      {base::win::SUITE_EDUCATION, "education"},
+      {base::win::SUITE_EDUCATION_PRO, "educationPro"},
+      {base::win::SUITE_LAST, "invalid"}};
 
-// TODO(erickzhao): implement the equivalent API in Linux
 #if defined(OS_WIN)
   auto* os_info = base::win::OSInfo::GetInstance();
-  if (os_info->version_type() == base::win::SUITE_SERVER) {
-    type = "server";
-  }
+  type = versionMap[os_info->version_type()];
+#else
+  gin_helper::ErrorThrower(isolate).ThrowError(
+      "No Windows version type for non-Windows OSes");
+  // enum boundary value
+  type = versionMap[base::win::SUITE_LAST];
 #endif
 
   return v8::String::NewFromUtf8(isolate, type.c_str()).ToLocalChecked();

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -210,27 +210,36 @@ v8::Local<v8::Value> ElectronBindings::GetSystemMemoryInfo(
 // static
 v8::Local<v8::Value> ElectronBindings::GetWindowsVersionType(
     v8::Isolate* isolate) {
-  std::string type;
-  std::map<base::win::VersionType, std::string> versionMap{
-      {base::win::SUITE_HOME, "home"},
-      {base::win::SUITE_PROFESSIONAL, "professional"},
-      {base::win::SUITE_SERVER, "server"},
-      {base::win::SUITE_ENTERPRISE, "enterprise"},
-      {base::win::SUITE_EDUCATION, "education"},
-      {base::win::SUITE_EDUCATION_PRO, "educationPro"},
-      {base::win::SUITE_LAST, "invalid"}};
-
 #if defined(OS_WIN)
+  std::string type;
   auto* os_info = base::win::OSInfo::GetInstance();
-  type = versionMap[os_info->version_type()];
+  switch (os_info->version_type()) {
+    case base::win::SUITE_HOME:
+      type = "home";
+      break;
+    case base::win::SUITE_PROFESSIONAL:
+      type = "professional";
+      break;
+    case base::win::SUITE_SERVER:
+      type = "server";
+      break;
+    case base::win::SUITE_ENTERPRISE:
+      type = "enterprise";
+      break;
+    case base::win::SUITE_EDUCATION:
+      type = "education";
+      break;
+    case base::win::SUITE_EDUCATION_PRO:
+      type = "educationPro";
+      break;
+    default:
+      type = "invalid";
+  }
+  return v8::String::NewFromUtf8(isolate, type.c_str()).ToLocalChecked();
 #else
   gin_helper::ErrorThrower(isolate).ThrowError(
       "No Windows version type for non-Windows OSes");
-  // enum boundary value
-  type = versionMap[base::win::SUITE_LAST];
 #endif
-
-  return v8::String::NewFromUtf8(isolate, type.c_str()).ToLocalChecked();
 }
 
 // static

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -210,8 +210,8 @@ v8::Local<v8::Value> ElectronBindings::GetSystemMemoryInfo(
 // static
 v8::Local<v8::Value> ElectronBindings::GetWindowsVersionType(
     v8::Isolate* isolate) {
-#if defined(OS_WIN)
   std::string type;
+#if defined(OS_WIN)
   auto* os_info = base::win::OSInfo::GetInstance();
   switch (os_info->version_type()) {
     case base::win::SUITE_HOME:
@@ -235,11 +235,12 @@ v8::Local<v8::Value> ElectronBindings::GetWindowsVersionType(
     default:
       type = "invalid";
   }
-  return v8::String::NewFromUtf8(isolate, type.c_str()).ToLocalChecked();
 #else
   gin_helper::ErrorThrower(isolate).ThrowError(
       "No Windows version type for non-Windows OSes");
+  type = "invalid";
 #endif
+  return v8::String::NewFromUtf8(isolate, type.c_str()).ToLocalChecked();
 }
 
 // static

--- a/shell/common/api/electron_bindings.h
+++ b/shell/common/api/electron_bindings.h
@@ -55,6 +55,7 @@ class ElectronBindings {
   static v8::Local<v8::Value> GetCreationTime(v8::Isolate* isolate);
   static v8::Local<v8::Value> GetSystemMemoryInfo(v8::Isolate* isolate,
                                                   gin_helper::Arguments* args);
+  static v8::Local<v8::Value> GetSystemProductType(v8::Isolate* isolate);
   static v8::Local<v8::Promise> GetProcessMemoryInfo(v8::Isolate* isolate);
   static v8::Local<v8::Value> GetBlinkMemoryInfo(v8::Isolate* isolate);
   static v8::Local<v8::Value> GetCPUUsage(base::ProcessMetrics* metrics,

--- a/shell/common/api/electron_bindings.h
+++ b/shell/common/api/electron_bindings.h
@@ -55,7 +55,7 @@ class ElectronBindings {
   static v8::Local<v8::Value> GetCreationTime(v8::Isolate* isolate);
   static v8::Local<v8::Value> GetSystemMemoryInfo(v8::Isolate* isolate,
                                                   gin_helper::Arguments* args);
-  static v8::Local<v8::Value> GetSystemProductType(v8::Isolate* isolate);
+  static v8::Local<v8::Value> GetWindowsVersionType(v8::Isolate* isolate);
   static v8::Local<v8::Promise> GetProcessMemoryInfo(v8::Isolate* isolate);
   static v8::Local<v8::Value> GetBlinkMemoryInfo(v8::Isolate* isolate);
   static v8::Local<v8::Value> GetCPUUsage(base::ProcessMetrics* metrics,

--- a/spec/api-process-spec.js
+++ b/spec/api-process-spec.js
@@ -73,6 +73,12 @@ describe('process module', () => {
     });
   });
 
+  describe('process.getSystemProductType()', () => {
+    it('returns a string', () => {
+      expect(process.getSystemProductType()).to.be.a('string');
+    });
+  });
+
   describe('process.getHeapStatistics()', () => {
     it('returns heap statistics object', () => {
       const heapStats = process.getHeapStatistics();

--- a/spec/api-process-spec.js
+++ b/spec/api-process-spec.js
@@ -80,7 +80,7 @@ describe('process module', () => {
     });
 
     ifit(process.platform !== 'win32')('throws if not on Windows', () => {
-      expect(process.getWindowsVersionType()).to.throw('No Windows version type for non-Windows OSes');
+      expect(() => { process.getWindowsVersionType(); }).to.throw('No Windows version type for non-Windows OSes');
     });
   });
 

--- a/spec/api-process-spec.js
+++ b/spec/api-process-spec.js
@@ -1,6 +1,7 @@
 const { ipcRenderer } = require('electron');
 const fs = require('fs');
 const path = require('path');
+const { ifit } = require('./spec-helpers');
 
 const { expect } = require('chai');
 
@@ -73,9 +74,13 @@ describe('process module', () => {
     });
   });
 
-  describe('process.getSystemProductType()', () => {
-    it('returns a string', () => {
-      expect(process.getSystemProductType()).to.be.a('string');
+  describe('process.getWindowsVersionType()', () => {
+    ifit(process.platform === 'win32')('returns a string', () => {
+      expect(process.getWindowsVersionType()).to.be.a('string');
+    });
+
+    ifit(process.platform !== 'win32')('throws if not on Windows', () => {
+      expect(process.getWindowsVersionType()).to.throw('No Windows version type for non-Windows OSes');
     });
   });
 


### PR DESCRIPTION
#### Description of Change

Exposes a new API that returns Chromium's Windows `VersionType` enum.

https://source.chromium.org/chromium/chromium/src/+/master:base/win/windows_version.h;l=57-68;drc=76bb9de1de4e0e52d2d40c2c8d5641f7b20e4b50

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added new `process.getWindowsVersionType()` API.
