### PR TITLE
fix: call `UnregisterIsolate` consistently

### DIFF
--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -279,10 +279,6 @@ int NodeMain(int argc, char* argv[]) {
     node::Stop(env);
     node::FreeEnvironment(env);
     node::FreeIsolateData(isolate_data);
-
-    gin_env.platform()->DrainTasks(isolate);
-    gin_env.platform()->CancelPendingDelayedTasks(isolate);
-    gin_env.platform()->UnregisterIsolate(isolate);
   }
 
   // According to "src/gin/shell/gin_main.cc":

--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -160,6 +160,8 @@ JavascriptEnvironment::JavascriptEnvironment(uv_loop_t* event_loop)
 }
 
 JavascriptEnvironment::~JavascriptEnvironment() {
+  platform_->DrainTasks(isolate_);
+
   {
     v8::Locker locker(isolate_);
     v8::HandleScope scope(isolate_);
@@ -167,6 +169,10 @@ JavascriptEnvironment::~JavascriptEnvironment() {
   }
   isolate_->Exit();
   g_isolate = nullptr;
+
+  DCHECK_NE(platform_, nullptr);
+  platform_->CancelPendingDelayedTasks(isolate_);
+  platform_->UnregisterIsolate(isolate_);
 }
 
 class EnabledStateObserverImpl final

--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -160,6 +160,7 @@ JavascriptEnvironment::JavascriptEnvironment(uv_loop_t* event_loop)
 }
 
 JavascriptEnvironment::~JavascriptEnvironment() {
+  DCHECK_NE(platform_, nullptr);
   platform_->DrainTasks(isolate_);
 
   {
@@ -170,7 +171,6 @@ JavascriptEnvironment::~JavascriptEnvironment() {
   isolate_->Exit();
   g_isolate = nullptr;
 
-  DCHECK_NE(platform_, nullptr);
   platform_->CancelPendingDelayedTasks(isolate_);
   platform_->UnregisterIsolate(isolate_);
 }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

`JavascriptEnvironment` is the class that calls `RegisterIsolate()`
so it should be the one to call `UnregisterIsolate`, and this can happen
right before disposing the aforementioned `isolate`.

See: https://github.com/electron/electron/pull/28468

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

cc @deepak1556 

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: no-notes
