### PR TITLE
docs: Remove GoDaddy from Windows code signing options

### DIFF
--- a/docs/tutorial/code-signing.md
+++ b/docs/tutorial/code-signing.md
@@ -190,7 +190,6 @@ it may be worth your time to shop around. Popular resellers include:
 
 * [digicert](https://www.digicert.com/code-signing/microsoft-authenticode.htm)
 * [Sectigo](https://sectigo.com/ssl-certificates-tls/code-signing)
-* [GoDaddy](https://au.godaddy.com/web-security/code-signing-certificate)
 * Amongst others, please shop around to find one that suits your needs, Google
   is your friend 😄
 


### PR DESCRIPTION
#### Description of Change
Closes #28493. GoDaddy no longer offers this service.

Notes: none