### PR TITLE
test: disable "fs in renderer process" test under ASan

### DIFF
--- a/spec-main/node-spec.ts
+++ b/spec-main/node-spec.ts
@@ -23,7 +23,8 @@ describe('node feature', () => {
     });
   });
 
-  it('does not hang when using the fs module in the renderer process', async () => {
+  // Running child app under ASan might receive SIGKILL because of OOM.
+  ifit(!process.env.IS_ASAN)('does not hang when using the fs module in the renderer process', async () => {
     const appPath = path.join(mainFixturesPath, 'apps', 'libuv-hang', 'main.js');
     const appProcess = childProcess.spawn(process.execPath, [appPath], {
       cwd: path.join(mainFixturesPath, 'apps', 'libuv-hang'),


### PR DESCRIPTION
#### Description of Change

Same with https://github.com/electron/electron/pull/28156, disable this test since spawning child Electron apps may receive SIGKILL because of out of memory.

#### Release Notes

Notes: none