### PR TITLE
fix: update crash-reporter.md,crashReporter.start() is not supported in the renderer

### DIFF
--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -2,7 +2,7 @@
 
 > Submit crash reports to a remote server.
 
-Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process)
+Process: [Main](../glossary.md#main-process)
 
 The following is an example of setting up Electron to automatically submit
 crash reports to a remote server:


### PR DESCRIPTION
The latest version（12.0.2） does not support the renderer process
