### PR TITLE
build: ignore ninja summary print failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -932,7 +932,7 @@ step-ninja-summary: &step-ninja-summary
     command: |
       set +e
       set +o pipefail
-      python depot_tools/post_build_ninja_summary.py -C src/out/Default
+      python depot_tools/post_build_ninja_summary.py -C src/out/Default || echo Ninja Summary Failed
 
 step-ninja-report: &step-ninja-report
   store_artifacts:


### PR DESCRIPTION
Followup to #26914 to further mute these errors as they still appear to be happening

Notes: no-notes