### PR TITLE
build: add safety net for mac_deployment_target

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -32,6 +32,10 @@ if (is_mac) {
   import("//ui/gl/features.gni")
   import("//v8/gni/v8.gni")
   import("build/rules.gni")
+
+  assert(
+      mac_deployment_target == "10.11.0",
+      "Chromium has updated the mac_deployment_target, please update this assert, update the supported versions documentation (docs/tutorial/support.md) and flag this as a breaking change")
 }
 
 if (is_linux) {


### PR DESCRIPTION
As of #28480 we now dynamically determine the `LSMinimumSystemVersion` value as part of the build process.  To avoid this changing and no one realizing we now have this assert which will trip during a Chromium upgrade if they bump the minimum supported macOS version so we can update our documentation appropriately.

Notes: no-notes