### PR TITLE
feat: add BrowserWindow.visibleOnFullScreen

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -766,6 +766,14 @@ A `Boolean` property that determines whether the window is visible on all worksp
 
 **Note:** Always returns false on Windows.
 
+#### `win.visibleOnFullScreen` _macOS_
+
+A `Boolean` property that determines whether the window is visible on full
+screen app workspaces.
+
+**Note:** Requires `win.visibleOnAllWorkspaces` to be enabled for the window
+to move into app workspaces.
+
 #### `win.shadow`
 
 A `Boolean` property that determines whether the window has a shadow.
@@ -1623,10 +1631,10 @@ Returns `Boolean` - Whether the menu bar is visible.
 #### `win.setVisibleOnAllWorkspaces(visible[, options])`
 
 * `visible` Boolean
-* `options` Object (optional)
-  * `visibleOnFullScreen` Boolean (optional) _macOS_ - Sets whether
+* `options` Object (optional) _Deprecated_
+  * `visibleOnFullScreen` Boolean (optional) _Deprecated_ _macOS_ - Sets whether
     the window should be visible above fullscreen windows.
-  * `skipTransformProcessType` Boolean (optional) _macOS_ - Calling
+  * `skipTransformProcessType` Boolean (optional) _Deprecated_ _macOS_ - Calling
     setVisibleOnAllWorkspaces will by default transform the process
     type between UIElementApplication and ForegroundApplication to
     ensure the correct behavior. However, this will hide the window
@@ -1637,12 +1645,33 @@ Returns `Boolean` - Whether the menu bar is visible.
 Sets whether the window should be visible on all workspaces.
 
 **Note:** This API does nothing on Windows.
+**Note:** The `visibleOnFullScreen` and `skipTransformProcessType` options have
+been deprecated in favor of `win.setVisibleOnFullScreen()`.
 
 #### `win.isVisibleOnAllWorkspaces()`
 
 Returns `Boolean` - Whether the window is visible on all workspaces.
 
 **Note:** This API always returns false on Windows.
+
+#### `win.setVisibleOnFullScreen(visible[, options])` _macOS_
+
+* `visible` Boolean - Sets whether the window should be visible above
+  fullscreen windows.
+* `options` Object (optional)
+  * `skipTransformProcessType` Boolean (optional) - Calling
+    setVisibleOnFullScreen will by default transform the process
+    type between UIElementApplication and ForegroundApplication to
+    ensure the correct behavior. However, this will hide the window
+    and dock for a short time every time it is called. If your window
+    is already of type UIElementApplication, you can bypass this
+    transformation by passing true to skipTransformProcessType.
+
+Sets whether the window should be visible above full screen app workspaces.
+
+#### `win.isVisibleOnFullScreen()` _macOS_
+
+Returns `Boolean` - Whether the window is visible above full screen app workspaces.
 
 #### `win.setIgnoreMouseEvents(ignore[, options])`
 

--- a/lib/browser/api/base-window.ts
+++ b/lib/browser/api/base-window.ts
@@ -27,6 +27,13 @@ Object.defineProperty(BaseWindow.prototype, 'visibleOnAllWorkspaces', {
   set: function (visible) { this.setVisibleOnAllWorkspaces(visible); }
 });
 
+if (process.platform === 'darwin') {
+  Object.defineProperty(BaseWindow.prototype, 'visibleOnFullScreen', {
+    get: function () { return this.isVisibleOnFullScreen(); },
+    set: function (visible) { this.setVisibleOnFullScreen(visible); }
+  });
+}
+
 Object.defineProperty(BaseWindow.prototype, 'fullScreen', {
   get: function () { return this.isFullScreen(); },
   set: function (full) { this.setFullScreen(full); }

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -846,20 +846,42 @@ void BaseWindow::SetOverlayIcon(const gfx::Image& overlay,
 
 void BaseWindow::SetVisibleOnAllWorkspaces(bool visible,
                                            gin_helper::Arguments* args) {
+#if defined(OS_MAC)
   gin_helper::Dictionary options;
-  bool visibleOnFullScreen = false;
-  bool skipTransformProcessType = false;
-  args->GetNext(&options) &&
-      options.Get("visibleOnFullScreen", &visibleOnFullScreen);
-  args->GetNext(&options) &&
-      options.Get("skipTransformProcessType", &skipTransformProcessType);
-  return window_->SetVisibleOnAllWorkspaces(visible, visibleOnFullScreen,
-                                            skipTransformProcessType);
+
+  if (args->GetNext(&options)) {
+    bool visibleOnFullScreen = false;
+    bool skipTransformProcessType = false;
+    options.Get("visibleOnFullScreen", &visibleOnFullScreen);
+    options.Get("skipTransformProcessType", &skipTransformProcessType);
+    window_->SetVisibleOnFullScreen(visibleOnFullScreen,
+                                    skipTransformProcessType);
+  }
+#endif
+
+  window_->SetVisibleOnAllWorkspaces(visible);
 }
 
 bool BaseWindow::IsVisibleOnAllWorkspaces() {
   return window_->IsVisibleOnAllWorkspaces();
 }
+
+#if defined(OS_MAC)
+void BaseWindow::SetVisibleOnFullScreen(bool visible,
+                                        gin_helper::Arguments* args) {
+  gin_helper::Dictionary options;
+  bool skipTransformProcessType = false;
+
+  if (args->GetNext(&options))
+    options.Get("skipTransformProcessType", &skipTransformProcessType);
+
+  window_->SetVisibleOnFullScreen(visible, skipTransformProcessType);
+}
+
+bool BaseWindow::IsVisibleOnFullScreen() {
+  return window_->IsVisibleOnFullScreen();
+}
+#endif
 
 void BaseWindow::SetAutoHideCursor(bool auto_hide) {
   window_->SetAutoHideCursor(auto_hide);
@@ -1259,6 +1281,8 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("isVisibleOnAllWorkspaces",
                  &BaseWindow::IsVisibleOnAllWorkspaces)
 #if defined(OS_MAC)
+      .SetMethod("setVisibleOnFullScreen", &BaseWindow::SetVisibleOnFullScreen)
+      .SetMethod("isVisibleOnFullScreen", &BaseWindow::IsVisibleOnFullScreen)
       .SetMethod("setAutoHideCursor", &BaseWindow::SetAutoHideCursor)
 #endif
       .SetMethod("setVibrancy", &BaseWindow::SetVibrancy)

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -188,6 +188,10 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
                       const std::string& description);
   void SetVisibleOnAllWorkspaces(bool visible, gin_helper::Arguments* args);
   bool IsVisibleOnAllWorkspaces();
+#if defined(OS_MAC)
+  void SetVisibleOnFullScreen(bool visible, gin_helper::Arguments* args);
+  bool IsVisibleOnFullScreen();
+#endif
   void SetAutoHideCursor(bool auto_hide);
   virtual void SetVibrancy(v8::Isolate* isolate, v8::Local<v8::Value> value);
 

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -188,12 +188,17 @@ class NativeWindow : public base::SupportsUserData,
                               const std::string& description) = 0;
 
   // Workspace APIs.
-  virtual void SetVisibleOnAllWorkspaces(
-      bool visible,
-      bool visibleOnFullScreen = false,
-      bool skipTransformProcessType = false) = 0;
+  virtual void SetVisibleOnAllWorkspaces(bool visible) = 0;
 
   virtual bool IsVisibleOnAllWorkspaces() = 0;
+
+#if defined(OS_MAC)
+  virtual void SetVisibleOnFullScreen(
+      bool visible,
+      bool skipTransformProcessType = false) = 0;
+
+  virtual bool IsVisibleOnFullScreen() = 0;
+#endif
 
   virtual void SetAutoHideCursor(bool auto_hide);
 

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -116,10 +116,11 @@ class NativeWindowMac : public NativeWindow,
   void SetProgressBar(double progress, const ProgressState state) override;
   void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description) override;
-  void SetVisibleOnAllWorkspaces(bool visible,
-                                 bool visibleOnFullScreen,
-                                 bool skipTransformProcessType) override;
+  void SetVisibleOnAllWorkspaces(bool visible) override;
   bool IsVisibleOnAllWorkspaces() override;
+  void SetVisibleOnFullScreen(bool visibleOnFullScreen,
+                              bool skipTransformProcessType) override;
+  bool IsVisibleOnFullScreen() override;
   void SetAutoHideCursor(bool auto_hide) override;
   void SetVibrancy(const std::string& type) override;
   void SetWindowButtonVisibility(bool visible) override;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1209,9 +1209,17 @@ void NativeWindowMac::SetProgressBar(double progress,
 void NativeWindowMac::SetOverlayIcon(const gfx::Image& overlay,
                                      const std::string& description) {}
 
-void NativeWindowMac::SetVisibleOnAllWorkspaces(bool visible,
-                                                bool visibleOnFullScreen,
-                                                bool skipTransformProcessType) {
+void NativeWindowMac::SetVisibleOnAllWorkspaces(bool visible) {
+  SetCollectionBehavior(visible, NSWindowCollectionBehaviorCanJoinAllSpaces);
+}
+
+bool NativeWindowMac::IsVisibleOnAllWorkspaces() {
+  NSUInteger collectionBehavior = [window_ collectionBehavior];
+  return collectionBehavior & NSWindowCollectionBehaviorCanJoinAllSpaces;
+}
+
+void NativeWindowMac::SetVisibleOnFullScreen(bool visibleOnFullScreen,
+                                             bool skipTransformProcessType) {
   // In order for NSWindows to be visible on fullscreen we need to functionally
   // mimic app.dock.hide() since Apple changed the underlying functionality of
   // NSWindows starting with 10.14 to disallow NSWindows from floating on top of
@@ -1227,14 +1235,13 @@ void NativeWindowMac::SetVisibleOnAllWorkspaces(bool visible,
     }
   }
 
-  SetCollectionBehavior(visible, NSWindowCollectionBehaviorCanJoinAllSpaces);
   SetCollectionBehavior(visibleOnFullScreen,
                         NSWindowCollectionBehaviorFullScreenAuxiliary);
 }
 
-bool NativeWindowMac::IsVisibleOnAllWorkspaces() {
+bool NativeWindowMac::IsVisibleOnFullScreen() {
   NSUInteger collectionBehavior = [window_ collectionBehavior];
-  return collectionBehavior & NSWindowCollectionBehaviorCanJoinAllSpaces;
+  return collectionBehavior & NSWindowCollectionBehaviorFullScreenAuxiliary;
 }
 
 void NativeWindowMac::SetAutoHideCursor(bool auto_hide) {

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1258,10 +1258,7 @@ bool NativeWindowViews::IsMenuBarVisible() {
   return root_view_->IsMenuBarVisible();
 }
 
-void NativeWindowViews::SetVisibleOnAllWorkspaces(
-    bool visible,
-    bool visibleOnFullScreen,
-    bool skipTransformProcessType) {
+void NativeWindowViews::SetVisibleOnAllWorkspaces(bool visible) {
   widget()->SetVisibleOnAllWorkspaces(visible);
 }
 

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -127,9 +127,7 @@ class NativeWindowViews : public NativeWindow,
   void SetMenuBarVisibility(bool visible) override;
   bool IsMenuBarVisible() override;
 
-  void SetVisibleOnAllWorkspaces(bool visible,
-                                 bool visibleOnFullScreen,
-                                 bool skipTransformProcessType) override;
+  void SetVisibleOnAllWorkspaces(bool visible) override;
 
   bool IsVisibleOnAllWorkspaces() override;
 

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -3685,6 +3685,26 @@ describe('BrowserWindow module', () => {
       });
     });
 
+    ifdescribe(process.platform === 'darwin')('visibleOnFullScreen state', () => {
+      it('with properties', () => {
+        it('can be changed', () => {
+          const w = new BrowserWindow({ show: false });
+          expect(w.visibleOnFullScreen).to.be.false();
+          w.visibleOnFullScreen = true;
+          expect(w.visibleOnFullScreen).to.be.true();
+        });
+      });
+
+      it('with functions', () => {
+        it('can be changed', () => {
+          const w = new BrowserWindow({ show: false });
+          expect(w.isVisibleOnFullScreen()).to.be.false();
+          w.setVisibleOnFullScreen(true);
+          expect(w.isVisibleOnFullScreen()).to.be.true();
+        });
+      });
+    });
+
     ifdescribe(process.platform === 'darwin')('documentEdited state', () => {
       it('with properties', () => {
         it('can be changed', () => {


### PR DESCRIPTION
#### Description of Change

Refs #24956 #14122

`BrowserWindow.setVisibleOnAllWorkspaces()` accepts an optional second parameter to enable `visibleOnFullScreen`. However, there's no option to check whether it's enabled and to update it independently.

Due to the undesired behavior of `visibleOnFullScreen` hiding the app's dock icon when enabled, I'm working to enable it only under special app contexts. Thus I'd like to toggle it without knowledge of `win.visibleOnAllWorkspaces`'s current value.

This creates some API awkwardness which I'm unsure about:
- Enabling `visibleOnFullScreen` won't have a desired effect when `visibleOnAllWorkspaces` is disabled. I've noted this in the docs for now.
- An alternative could be a read-only `visibleOnFullScreen`, but still makes toggling it not ideal
   ```ts
   win.setVisibleOnAllWorkspaces(win.visibleOnAllWorkspaces, { visibleOnFullScreen: !win.visibleOnFullScreen })
   ```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `BrowserWindow.visibleOnFullScreen`, `BrowserWindow.setVisibleOnFullScreen(visible)`, and `BrowserWindow.isVisibleOnFullScreen()`.
