### PR TITLE
fix: crash in NativeWindowMac::IsVisible when closing window early

### DIFF
--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -259,7 +259,7 @@ class NativeWindow : public base::SupportsUserData,
   // related notifications.
   void NotifyWindowRequestPreferredWith(int* width);
   void NotifyWindowCloseButtonClicked();
-  void NotifyWindowClosed();
+  virtual void NotifyWindowClosed();
   void NotifyWindowEndSession();
   void NotifyWindowBlur();
   void NotifyWindowFocus();

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -39,6 +39,7 @@ class NativeWindowMac : public NativeWindow,
   void SetContentView(views::View* view) override;
   void Close() override;
   void CloseImmediately() override;
+  void NotifyWindowClosed() override;
   void Focus(bool focus) override;
   bool IsFocused() override;
   void Show() override;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -472,7 +472,6 @@ void NativeWindowMac::Close() {
   }
 
   [window_ performClose:nil];
-  window_ = nil;
 
   // Closing a sheet doesn't trigger windowShouldClose,
   // so we need to manually call it ourselves here.

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -487,6 +487,10 @@ void NativeWindowMac::CloseImmediately() {
   base::scoped_nsobject<NSWindow> child_window(window_,
                                                base::scoped_policy::RETAIN);
   [window_ close];
+}
+
+void NativeWindowMac::NotifyWindowClosed() {
+  NativeWindow::NotifyWindowClosed();
   window_ = nil;
 }
 

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -472,6 +472,7 @@ void NativeWindowMac::Close() {
   }
 
   [window_ performClose:nil];
+  window_ = nil;
 
   // Closing a sheet doesn't trigger windowShouldClose,
   // so we need to manually call it ourselves here.
@@ -487,6 +488,7 @@ void NativeWindowMac::CloseImmediately() {
   base::scoped_nsobject<NSWindow> child_window(window_,
                                                base::scoped_policy::RETAIN);
   [window_ close];
+  window_ = nil;
 }
 
 void NativeWindowMac::Focus(bool focus) {
@@ -549,7 +551,7 @@ void NativeWindowMac::Hide() {
 }
 
 bool NativeWindowMac::IsVisible() {
-  bool occluded = [window_ occlusionState] == NSWindowOcclusionStateVisible;
+  bool occluded = [window_ occlusionState] & NSWindowOcclusionStateVisible;
 
   // For a window to be visible, it must be visible to the user in the
   // foreground of the app, which means that it should not be minimized or

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -234,7 +234,6 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
 
 - (void)windowWillClose:(NSNotification*)notification {
   shell_->Cleanup();
-  shell_->NotifyWindowClosed();
 
   // Something called -[NSWindow close] on a sheet rather than calling
   // -[NSWindow endSheet:] on its parent. If the modal session is not ended
@@ -256,6 +255,7 @@ using TitleBarStyle = electron::NativeWindowMac::TitleBarStyle;
       shell_->GetNativeWindow());
   auto* bridged_view = bridge_host->GetInProcessNSWindowBridge();
   bridged_view->OnWindowWillClose();
+  shell_->NotifyWindowClosed();
 }
 
 - (BOOL)windowShouldClose:(id)window {


### PR DESCRIPTION
#### Description of Change
This fixes a crash when IsVisible is called from DidFirstVisuallyNonEmptyPaint
but the window has been closed. Running with NSZombieEnabled=YES reveals that
`[window_ occlusionState]` is sending a message to a deallocated instance:

```
2021-04-05 16:30:37.363 Electron[30671:1796189] *** -[ElectronNSWindow description]: message sent to deallocated instance 0x614000126a40
Received signal 4 <unknown> 7fff2ff66dc7
0   Electron Framework                  0x000000011defc799 base::debug::CollectStackTrace(void**, unsigned long) + 9
1   Electron Framework                  0x000000011dc0b6c3 base::debug::StackTrace::StackTrace() + 19
2   Electron Framework                  0x000000011defc3fb base::debug::(anonymous namespace)::StackDumpSignalHandler(int, __siginfo*, void*) + 2875
3   libsystem_platform.dylib            0x00007fff6a0cf5fd _sigtramp + 29
4   ???                                 0x0000000000000000 0x0 + 0
5   CoreFoundation                      0x00007fff2fe172d2 ___forwarding___ + 1194
6   CoreFoundation                      0x00007fff2fe16d98 _CF_forwarding_prep_0 + 120
7   Electron Framework                  0x000000011df2dc9f operator<<(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, objc_object*) + 63
8   Electron Framework                  0x00000001101438c3 electron::NativeWindowMac::IsVisible() + 419
9   Electron Framework                  0x000000010fb5db0e non-virtual thunk to electron::api::BrowserWindow::DidFirstVisuallyNonEmptyPaint() + 238
10  Electron Framework                  0x000000011b0a10dd void content::WebContentsImpl::WebContentsObserverList::NotifyObservers<void (content::WebContentsObserver::*)()>(void (content::WebContentsObserver::*)()) + 845
11  Electron Framework                  0x000000011b10f02f content::WebContentsImpl::DidFirstVisuallyNonEmptyPaint(content::RenderViewHostImpl*) + 271
12  Electron Framework                  0x00000001138fbd25 blink::mojom::FrameWidgetHostStubDispatch::Accept(blink::mojom::FrameWidgetHost*, mojo::Message*) + 3349
[...]
```

This patch resets `window_` to `nil` on close to prevent the UAF.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash that could occur on macOS when closing a window early while loading a page.
