### PR TITLE
feat: add process.setWasmCodegenAllowed API

### DIFF
--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -14,6 +14,7 @@ In sandboxed renderers the `process` object contains only a subset of the APIs:
 
 * `crash()`
 * `hang()`
+* `setWasmCodegenAllowed()`
 * `getCreationTime()`
 * `getHeapStatistics()`
 * `getBlinkMemoryInfo()`
@@ -242,6 +243,12 @@ Takes a V8 heap snapshot and saves it to `filePath`.
 ### `process.hang()`
 
 Causes the main thread of the current process hang.
+
+### `process.setWasmCodegenAllowed(allowed)`
+
+* `allowed` Boolean
+
+Override the default check routine to force enabling/disabling wasm code generation.
 
 ### `process.setFdLimit(maxDescriptors)` _macOS_ _Linux_
 

--- a/shell/common/api/electron_bindings.h
+++ b/shell/common/api/electron_bindings.h
@@ -51,6 +51,7 @@ class ElectronBindings {
 
  private:
   static void Hang();
+  static void SetWasmCodegenAllowed(v8::Isolate* isolate, bool allowed);
   static v8::Local<v8::Value> GetHeapStatistics(v8::Isolate* isolate);
   static v8::Local<v8::Value> GetCreationTime(v8::Isolate* isolate);
   static v8::Local<v8::Value> GetSystemMemoryInfo(v8::Isolate* isolate,

--- a/spec/fixtures/module/preload-setWasmCodegenAllowed.js
+++ b/spec/fixtures/module/preload-setWasmCodegenAllowed.js
@@ -1,0 +1,1 @@
+process.setWasmCodegenAllowed(true);


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/23252.

Currently according to WebAssembly/content-security-policy#7, the only way to be able to use wasm is to add 'unsafe-eval' to the CSP, which makes wasm unavailable to apps that want to have safe content security policies.

This PR adds a `process.setWasmCodegenAllowed` API that override the default check routine to force enabling/disabling wasm code generation.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Add `process.setWasmCodegenAllowed` API.