### PR TITLE
docs: note that new-window event is deprecated

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -136,6 +136,22 @@ systemPreferences.isHighContrastColorScheme()
 nativeTheme.shouldUseHighContrastColors
 ```
 
+### Deprecated: WebContents `new-window` event
+
+The `new-window` event of WebContents has been deprecated. It is replaced by [`webContents.setWindowOpenHandler()`](/docs/api/web-contents#contentssetwindowopenhandlerhandler).
+
+```js
+// Deprecated in Electron 13
+webContents.on('new-window', (event) => {
+  event.preventDefault()
+})
+
+// Replace with
+webContents.setWindowOpenHandler((details) => {
+  return { action: 'deny' }
+})
+```
+
 ## Planned Breaking API Changes (12.0)
 
 ### Removed: Pepper Flash support

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -138,7 +138,7 @@ nativeTheme.shouldUseHighContrastColors
 
 ### Deprecated: WebContents `new-window` event
 
-The `new-window` event of WebContents has been deprecated. It is replaced by [`webContents.setWindowOpenHandler()`](/docs/api/web-contents#contentssetwindowopenhandlerhandler).
+The `new-window` event of WebContents has been deprecated. It is replaced by [`webContents.setWindowOpenHandler()`](api/web-contents#contentssetwindowopenhandlerhandler).
 
 ```js
 // Deprecated in Electron 13

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -138,7 +138,7 @@ nativeTheme.shouldUseHighContrastColors
 
 ### Deprecated: WebContents `new-window` event
 
-The `new-window` event of WebContents has been deprecated. It is replaced by [`webContents.setWindowOpenHandler()`](api/web-contents#contentssetwindowopenhandlerhandler).
+The `new-window` event of WebContents has been deprecated. It is replaced by [`webContents.setWindowOpenHandler()`](api/web-contents.md#contentssetwindowopenhandlerhandler).
 
 ```js
 // Deprecated in Electron 13


### PR DESCRIPTION
I think this was technically marked deprecated in 12, but it wasn't added to breaking-changes, so doing that now.

Notes: none