### PR TITLE
build: give ASAN tests more memory to avoid SIGKILL or disabling tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2326,7 +2326,7 @@ jobs:
     <<: *steps-tests
 
   linux-x64-testing-asan-tests:
-    <<: *machine-linux-medium
+    <<: *machine-linux-xlarge
     environment:
       <<: *env-linux-medium
       <<: *env-headless-testing

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -143,8 +143,7 @@ describe('app module', () => {
     });
   });
 
-  // Running child app under ASan might receive SIGKILL because of OOM.
-  ifdescribe(!process.env.IS_ASAN)('app.exit(exitCode)', () => {
+  describe('app.exit(exitCode)', () => {
     let appProcess: cp.ChildProcess | null = null;
 
     afterEach(() => {
@@ -210,8 +209,7 @@ describe('app module', () => {
     });
   });
 
-  // Running child app under ASan might receive SIGKILL because of OOM.
-  ifdescribe(!process.env.IS_ASAN)('app.requestSingleInstanceLock', () => {
+  describe('app.requestSingleInstanceLock', () => {
     it('prevents the second launch of app', async function () {
       this.timeout(120000);
       const appPath = path.join(fixturesPath, 'api', 'singleton');
@@ -253,8 +251,7 @@ describe('app module', () => {
     });
   });
 
-  // Running child app under ASan might receive SIGKILL because of OOM.
-  ifdescribe(!process.env.IS_ASAN)('app.relaunch', () => {
+  describe('app.relaunch', () => {
     let server: net.Server | null = null;
     const socketPath = process.platform === 'win32' ? '\\\\.\\pipe\\electron-app-relaunch' : '/tmp/electron-app-relaunch';
 
@@ -854,8 +851,7 @@ describe('app module', () => {
     });
   });
 
-  // Running child app under ASan might receive SIGKILL because of OOM.
-  ifdescribe(!process.env.IS_ASAN)('getAppPath', () => {
+  describe('getAppPath', () => {
     it('works for directories with package.json', async () => {
       const { appPath } = await runTestApp('app-path');
       expect(appPath).to.equal(path.resolve(fixturesPath, 'api/app-path'));
@@ -1331,8 +1327,7 @@ describe('app module', () => {
     });
   });
 
-  // Running child app under ASan might receive SIGKILL because of OOM.
-  ifdescribe(!process.env.IS_ASAN)('sandbox options', () => {
+  describe('sandbox options', () => {
     let appProcess: cp.ChildProcess = null as any;
     let server: net.Server = null as any;
     const socketPath = process.platform === 'win32' ? '\\\\.\\pipe\\electron-mixed-sandbox' : '/tmp/electron-mixed-sandbox';
@@ -1557,8 +1552,7 @@ describe('app module', () => {
     });
   });
 
-  // Running child app under ASan might receive SIGKILL because of OOM.
-  ifdescribe(!process.env.IS_ASAN)('commandLine.hasSwitch (existing argv)', () => {
+  describe('commandLine.hasSwitch (existing argv)', () => {
     it('returns true when present', async () => {
       const { hasSwitch } = await runTestApp('command-line', '--foobar');
       expect(hasSwitch).to.equal(true);
@@ -1586,8 +1580,7 @@ describe('app module', () => {
     });
   });
 
-  // Running child app under ASan might receive SIGKILL because of OOM.
-  ifdescribe(!process.env.IS_ASAN)('commandLine.getSwitchValue (existing argv)', () => {
+  describe('commandLine.getSwitchValue (existing argv)', () => {
     it('returns the value when present', async () => {
       const { getSwitchValue } = await runTestApp('command-line', '--foobar=test');
       expect(getSwitchValue).to.equal('test');
@@ -1614,8 +1607,7 @@ describe('app module', () => {
   });
 });
 
-// Running child app under ASan might receive SIGKILL because of OOM.
-ifdescribe(!process.env.IS_ASAN)('default behavior', () => {
+describe('default behavior', () => {
   describe('application menu', () => {
     it('creates the default menu if the app does not set it', async () => {
       const result = await runTestApp('default-menu');

--- a/spec-main/api-protocol-spec.ts
+++ b/spec-main/api-protocol-spec.ts
@@ -12,7 +12,7 @@ import { EventEmitter } from 'events';
 import { closeWindow } from './window-helpers';
 import { emittedOnce } from './events-helpers';
 import { WebmGenerator } from './video-helpers';
-import { delay, ifit } from './spec-helpers';
+import { delay } from './spec-helpers';
 
 const fixturesPath = path.resolve(__dirname, '..', 'spec', 'fixtures');
 
@@ -705,8 +705,7 @@ describe('protocol module', () => {
   });
 
   describe('protocol.registerSchemeAsPrivileged', () => {
-    // Running child app under ASan might receive SIGKILL because of OOM.
-    ifit(!process.env.IS_ASAN)('does not crash on exit', async () => {
+    it('does not crash on exit', async () => {
       const appPath = path.join(__dirname, 'fixtures', 'api', 'custom-protocol-shutdown.js');
       const appProcess = ChildProcess.spawn(process.execPath, ['--enable-logging', appPath]);
       let stdout = '';

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -367,8 +367,7 @@ describe('web security', () => {
   });
 });
 
-// Running child app under ASan might receive SIGKILL because of OOM.
-ifdescribe(!process.env.IS_ASAN)('command line switches', () => {
+describe('command line switches', () => {
   let appProcess: ChildProcess.ChildProcessWithoutNullStreams | undefined;
   afterEach(() => {
     if (appProcess && !appProcess.killed) {

--- a/spec-main/crash-spec.ts
+++ b/spec-main/crash-spec.ts
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import { ifdescribe } from './spec-helpers';
 
 const fixturePath = path.resolve(__dirname, 'fixtures', 'crash-cases');
 
@@ -31,8 +30,7 @@ const runFixtureAndEnsureCleanExit = (args: string[]) => {
   });
 };
 
-// Running child app under ASan might receive SIGKILL because of OOM.
-ifdescribe(!process.env.IS_ASAN)('crash cases', () => {
+describe('crash cases', () => {
   afterEach(() => {
     for (const child of children) {
       child.kill();

--- a/spec-main/node-spec.ts
+++ b/spec-main/node-spec.ts
@@ -23,8 +23,7 @@ describe('node feature', () => {
     });
   });
 
-  // Running child app under ASan might receive SIGKILL because of OOM.
-  ifit(!process.env.IS_ASAN)('does not hang when using the fs module in the renderer process', async () => {
+  it('does not hang when using the fs module in the renderer process', async () => {
     const appPath = path.join(mainFixturesPath, 'apps', 'libuv-hang', 'main.js');
     const appProcess = childProcess.spawn(process.execPath, [appPath], {
       cwd: path.join(mainFixturesPath, 'apps', 'libuv-hang'),
@@ -135,8 +134,7 @@ describe('node feature', () => {
     });
   });
 
-  // Running child app under ASan might receive SIGKILL because of OOM.
-  ifdescribe(features.isRunAsNodeEnabled() && !process.env.IS_ASAN)('Node.js cli flags', () => {
+  ifdescribe(features.isRunAsNodeEnabled())('Node.js cli flags', () => {
     let child: childProcess.ChildProcessWithoutNullStreams;
     let exitPromise: Promise<any[]>;
 
@@ -178,8 +176,7 @@ describe('node feature', () => {
     });
   });
 
-  // Running child app under ASan might receive SIGKILL because of OOM.
-  ifdescribe(features.isRunAsNodeEnabled() && !process.env.IS_ASAN)('inspector', () => {
+  ifdescribe(features.isRunAsNodeEnabled())('inspector', () => {
     let child: childProcess.ChildProcessWithoutNullStreams;
     let exitPromise: Promise<any[]>;
 
@@ -317,8 +314,7 @@ describe('node feature', () => {
     });
   });
 
-  // Running child app under ASan might receive SIGKILL because of OOM.
-  ifit(!process.env.IS_ASAN)('Can find a module using a package.json main field', () => {
+  it('Can find a module using a package.json main field', () => {
     const result = childProcess.spawnSync(process.execPath, [path.resolve(fixtures, 'api', 'electron-main-module', 'app.asar')]);
     expect(result.status).to.equal(0);
   });

--- a/spec-main/webview-spec.ts
+++ b/spec-main/webview-spec.ts
@@ -3,7 +3,6 @@ import * as url from 'url';
 import { BrowserWindow, session, ipcMain, app, WebContents } from 'electron/main';
 import { closeAllWindows } from './window-helpers';
 import { emittedOnce, emittedUntil } from './events-helpers';
-import { ifdescribe } from './spec-helpers';
 import { expect } from 'chai';
 
 async function loadWebView (w: WebContents, attributes: Record<string, string>, openDevTools: boolean = false): Promise<void> {
@@ -26,8 +25,7 @@ async function loadWebView (w: WebContents, attributes: Record<string, string>, 
   `);
 }
 
-// The render process of webview might receive SIGKILL because of OOM.
-ifdescribe(!process.env.IS_ASAN)('<webview> tag', function () {
+describe('<webview> tag', function () {
   const fixtures = path.join(__dirname, '..', 'spec', 'fixtures');
 
   afterEach(closeAllWindows);


### PR DESCRIPTION
Reverts #28156 and #28509 in favor of just giving the ASAN tests a bigger box with more memory, previously they had a 4GB box.  They now get a 16GB box (with potential for us to go all the way to 40GB if we wanted to, but we really shouldn't need to.

Notes: no-notes