### PR TITLE
refactor: use URL API in resolveURL

### DIFF
--- a/lib/renderer/web-view/web-view-attributes.ts
+++ b/lib/renderer/web-view/web-view-attributes.ts
@@ -3,13 +3,8 @@ import { WebViewImpl } from '@electron/internal/renderer/web-view/web-view-impl'
 import { WEB_VIEW_CONSTANTS } from '@electron/internal/renderer/web-view/web-view-constants';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
-// Helper function to resolve url set in attribute.
-const a = document.createElement('a');
-
 const resolveURL = function (url?: string | null) {
-  if (!url) return '';
-  a.href = url;
-  return a.href;
+  return url ? new URL(url, location.href).href : '';
 };
 
 interface MutationHandler {


### PR DESCRIPTION
#### Description of Change

Tiny change i noticed as I was doing some tangential spelunking - we can use the URL API here.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
