### PR TITLE
docs: systemPreferences.subscribeWorkspaceNotification return type

### DIFF
--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -130,6 +130,8 @@ This is necessary for events such as `NSUserDefaultsDidChangeNotification`.
   * `userInfo` Record<String, unknown>
   * `object` String
 
+Returns `Number` - The ID of this subscription
+
 Same as `subscribeNotification`, but uses `NSWorkspace.sharedWorkspace.notificationCenter`.
 This is necessary for events such as `NSWorkspaceDidActivateApplicationNotification`.
 


### PR DESCRIPTION
#### Description of Change
Added missing return type to the docs for `systemPreferences.subscribeWorkspaceNotification`

https://github.com/electron/electron/blob/f73d09374eb8399541070796a2ac1a0de63e95f9/shell/browser/api/electron_api_system_preferences_mac.mm#L184-L189

Not sure whether to go with semver patch or none for this change. I went with patch since technically a project using TypeScript might not be expecting a return type after this change.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added

#### Release Notes

Notes: none
