### PR TITLE
fix: allow accessing file:// when web security is disabled

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1306,9 +1306,10 @@ void ElectronBrowserClient::RegisterNonNetworkNavigationURLLoaderFactories(
           context, ukm_source_id,
           false /* we don't support extensions::WebViewGuest */));
 #endif
+  // Always allow navigating to file:// URLs.
   auto* protocol_registry = ProtocolRegistry::FromBrowserContext(context);
-  protocol_registry->RegisterURLLoaderFactories(
-      URLLoaderFactoryType::kNavigation, factories);
+  protocol_registry->RegisterURLLoaderFactories(factories,
+                                                true /* allow_file_access */);
 }
 
 void ElectronBrowserClient::
@@ -1317,8 +1318,10 @@ void ElectronBrowserClient::
         NonNetworkURLLoaderFactoryMap* factories) {
   auto* protocol_registry =
       ProtocolRegistry::FromBrowserContext(browser_context);
-  protocol_registry->RegisterURLLoaderFactories(
-      URLLoaderFactoryType::kWorkerMainResource, factories);
+  // Workers are not allowed to request file:// URLs, there is no particular
+  // reason for it, and we could consider supporting it in future.
+  protocol_registry->RegisterURLLoaderFactories(factories,
+                                                false /* allow_file_access */);
 }
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
@@ -1390,9 +1393,22 @@ void ElectronBrowserClient::RegisterNonNetworkSubresourceURLLoaderFactories(
   if (!render_process_host || !render_process_host->GetBrowserContext())
     return;
 
+  content::RenderFrameHost* frame_host =
+      content::RenderFrameHost::FromID(render_process_id, render_frame_id);
+  content::WebContents* web_contents =
+      content::WebContents::FromRenderFrameHost(frame_host);
+
+  // Allow accessing file:// subresources from non-file protocols if web
+  // security is disabled.
+  bool allow_file_access = false;
+  if (web_contents) {
+    const auto& web_preferences = web_contents->GetOrCreateWebPreferences();
+    if (!web_preferences.web_security_enabled)
+      allow_file_access = true;
+  }
+
   ProtocolRegistry::FromBrowserContext(render_process_host->GetBrowserContext())
-      ->RegisterURLLoaderFactories(URLLoaderFactoryType::kDocumentSubResource,
-                                   factories);
+      ->RegisterURLLoaderFactories(factories, allow_file_access);
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   auto factory = extensions::CreateExtensionURLLoaderFactory(render_process_id,
@@ -1400,10 +1416,6 @@ void ElectronBrowserClient::RegisterNonNetworkSubresourceURLLoaderFactories(
   if (factory)
     factories->emplace(extensions::kExtensionScheme, std::move(factory));
 
-  content::RenderFrameHost* frame_host =
-      content::RenderFrameHost::FromID(render_process_id, render_frame_id);
-  content::WebContents* web_contents =
-      content::WebContents::FromRenderFrameHost(frame_host);
   if (!web_contents)
     return;
 

--- a/shell/browser/protocol_registry.cc
+++ b/shell/browser/protocol_registry.cc
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "content/public/browser/non_network_url_loader_factory_base.h"  // nogncheck
+#include "content/public/browser/web_contents.h"
 #include "shell/browser/electron_browser_context.h"
 #include "shell/browser/net/asar/asar_url_loader.h"
 #include "shell/browser/protocol_registry.h"
@@ -61,22 +62,20 @@ ProtocolRegistry::ProtocolRegistry() {}
 ProtocolRegistry::~ProtocolRegistry() = default;
 
 void ProtocolRegistry::RegisterURLLoaderFactories(
-    URLLoaderFactoryType type,
-    content::ContentBrowserClient::NonNetworkURLLoaderFactoryMap* factories) {
-  // Override the default FileURLLoaderFactory to support asar archives.
-  if (type == URLLoaderFactoryType::kNavigation) {
-    // Always allow navigating to file:// URLs.
+    content::ContentBrowserClient::NonNetworkURLLoaderFactoryMap* factories,
+    bool allow_file_access) {
+  auto file_factory = factories->find(url::kFileScheme);
+  if (file_factory != factories->end()) {
+    // If Chromium already allows file access then replace the url factory to
+    // also loading asar files.
+    file_factory->second = AsarURLLoaderFactory::Create();
+  } else if (allow_file_access) {
+    // Otherwise only allow file access when it is explicitly allowed.
     //
-    // Note that Chromium calls |emplace| to create the default file factory
-    // after this call, so it won't override our asar factory.
-    DCHECK(!base::Contains(*factories, url::kFileScheme));
+    // Note that Chromium may call |emplace| to create the default file factory
+    // after this call, it won't override our asar factory, but if asar support
+    // breaks in future, please check if Chromium has changed the call.
     factories->emplace(url::kFileScheme, AsarURLLoaderFactory::Create());
-  } else if (type == URLLoaderFactoryType::kDocumentSubResource) {
-    // Only support requesting file:// subresource URLs when Chromium does so,
-    // it is usually supported under file:// or about:blank documents.
-    auto file_factory = factories->find(url::kFileScheme);
-    if (file_factory != factories->end())
-      file_factory->second = AsarURLLoaderFactory::Create();
   }
 
   for (const auto& it : handlers_) {

--- a/shell/browser/protocol_registry.h
+++ b/shell/browser/protocol_registry.h
@@ -26,8 +26,8 @@ class ProtocolRegistry {
       content::ContentBrowserClient::URLLoaderFactoryType;
 
   void RegisterURLLoaderFactories(
-      URLLoaderFactoryType type,
-      content::ContentBrowserClient::NonNetworkURLLoaderFactoryMap* factories);
+      content::ContentBrowserClient::NonNetworkURLLoaderFactoryMap* factories,
+      bool allow_file_access);
 
   const HandlersMap& intercept_handlers() const { return intercept_handlers_; }
 

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -282,6 +282,39 @@ describe('web security', () => {
     expect(response).to.equal('passed');
   });
 
+  describe('accessing file://', () => {
+    async function loadFile (w: BrowserWindow) {
+      const thisFile = url.format({
+        pathname: __filename.replace(/\\/g, '/'),
+        protocol: 'file',
+        slashes: true
+      });
+      await w.loadURL(`data:text/html,<script>
+          function loadFile() {
+            return new Promise((resolve) => {
+              fetch('${thisFile}').then(
+                () => resolve('loaded'),
+                () => resolve('failed')
+              )
+            });
+          }
+        </script>`);
+      return await w.webContents.executeJavaScript('loadFile()');
+    }
+
+    it('is forbidden when web security is enabled', async () => {
+      const w = new BrowserWindow({ show: false, webPreferences: { webSecurity: true } });
+      const result = await loadFile(w);
+      expect(result).to.equal('failed');
+    });
+
+    it('is allowed when web security is disabled', async () => {
+      const w = new BrowserWindow({ show: false, webPreferences: { webSecurity: false } });
+      const result = await loadFile(w);
+      expect(result).to.equal('loaded');
+    });
+  });
+
   describe('wasm-eval csp', () => {
     async function loadWasm (csp: string) {
       const w = new BrowserWindow({


### PR DESCRIPTION
Backport of #28489

See that PR for details.

Notes: Fix failing to request file:// resources when web security is disabled.