### PR TITLE
docs: define the name of the preload script

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -123,7 +123,7 @@ The `index.html` page looks as follows:
 
 #### Define a preload script
 
-Your preload script acts as a bridge between Node.js and your web page. It allows you to expose specific APIs and behaviors to your web page rather than insecurely exposing the entire Node.js API. In this example we will use the preload script to read version information from the `process` object and update the web page with that info.
+Your preload script (in our case, the `preload.js` file) acts as a bridge between Node.js and your web page. It allows you to expose specific APIs and behaviors to your web page rather than insecurely exposing the entire Node.js API. In this example we will use the preload script to read version information from the `process` object and update the web page with that info.
 
 ```javascript fiddle='docs/fiddles/quick-start'
 window.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
#### Description of Change
Very small addition - the name of the preload script (`preload.js`) in the [Quick Start Guide] as it's not stated under what name it should be saved.

[Quick Start Guide]: https://www.electronjs.org/docs/tutorial/quick-start#define-a-preload-script

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] relevant documentation is changed or added

#### Release Notes

Notes: none
