### PR TITLE
fix: crash on invalid select-serial-port callback

### DIFF
--- a/shell/browser/serial/serial_chooser_controller.cc
+++ b/shell/browser/serial/serial_chooser_controller.cc
@@ -124,9 +124,13 @@ void SerialChooserController::OnDeviceChosen(const std::string& port_id) {
         std::find_if(ports_.begin(), ports_.end(), [&port_id](const auto& ptr) {
           return ptr->token.ToString() == port_id;
         });
-    chooser_context_->GrantPortPermission(requesting_origin_, embedding_origin_,
-                                          *it->get());
-    RunCallback(it->Clone());
+    if (it != ports_.end()) {
+      chooser_context_->GrantPortPermission(requesting_origin_,
+                                            embedding_origin_, *it->get());
+      RunCallback(it->Clone());
+    } else {
+      RunCallback(/*port=*/nullptr);
+    }
   }
 }
 

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -1586,6 +1586,14 @@ describe('navigator.serial', () => {
     expect(port).to.equal('NotFoundError: No port selected by the user.');
   });
 
+  it('does not crash when select-serial-port is called with an invalid port', async () => {
+    w.webContents.session.on('select-serial-port', (event, portList, webContents, callback) => {
+      callback('i-do-not-exist');
+    });
+    const port = await getPorts();
+    expect(port).to.equal('NotFoundError: No port selected by the user.');
+  });
+
   it('returns a port when select-serial-port event is defined', async () => {
     w.webContents.session.on('select-serial-port', (event, portList, webContents, callback) => {
       callback(portList[0].portId);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/28500.

Fixes an issue where `select-serial-port` callback crashes when called with an invalid serial port ID.

Tested with https://gist.github.com/ntamas/36ce5ef35c2427180b157d2903263846

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `select-serial-port` callback crashes when called with an invalid serial port ID.
