### PR TITLE
fix: load source maps from custom protocols and asar bundles

### DIFF
--- a/filenames.gni
+++ b/filenames.gni
@@ -402,6 +402,8 @@ filenames = {
     "shell/browser/native_window_observer.h",
     "shell/browser/net/asar/asar_url_loader.cc",
     "shell/browser/net/asar/asar_url_loader.h",
+    "shell/browser/net/asar/asar_url_loader_factory.cc",
+    "shell/browser/net/asar/asar_url_loader_factory.h",
     "shell/browser/net/cert_verifier_client.cc",
     "shell/browser/net/cert_verifier_client.h",
     "shell/browser/net/electron_url_loader_factory.cc",

--- a/shell/browser/net/asar/asar_url_loader_factory.cc
+++ b/shell/browser/net/asar/asar_url_loader_factory.cc
@@ -1,0 +1,42 @@
+// Copyright (c) 2021 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "shell/browser/net/asar/asar_url_loader_factory.h"
+
+#include <utility>
+
+#include "shell/browser/net/asar/asar_url_loader.h"
+
+namespace electron {
+
+// static
+mojo::PendingRemote<network::mojom::URLLoaderFactory>
+AsarURLLoaderFactory::Create() {
+  mojo::PendingRemote<network::mojom::URLLoaderFactory> pending_remote;
+
+  // The AsarURLLoaderFactory will delete itself when there are no more
+  // receivers - see the SelfDeletingURLLoaderFactory::OnDisconnect method.
+  new AsarURLLoaderFactory(pending_remote.InitWithNewPipeAndPassReceiver());
+
+  return pending_remote;
+}
+
+AsarURLLoaderFactory::AsarURLLoaderFactory(
+    mojo::PendingReceiver<network::mojom::URLLoaderFactory> factory_receiver)
+    : content::NonNetworkURLLoaderFactoryBase(std::move(factory_receiver)) {}
+AsarURLLoaderFactory::~AsarURLLoaderFactory() = default;
+
+void AsarURLLoaderFactory::CreateLoaderAndStart(
+    mojo::PendingReceiver<network::mojom::URLLoader> loader,
+    int32_t routing_id,
+    int32_t request_id,
+    uint32_t options,
+    const network::ResourceRequest& request,
+    mojo::PendingRemote<network::mojom::URLLoaderClient> client,
+    const net::MutableNetworkTrafficAnnotationTag& traffic_annotation) {
+  asar::CreateAsarURLLoader(request, std::move(loader), std::move(client),
+                            new net::HttpResponseHeaders(""));
+}
+
+}  // namespace electron

--- a/shell/browser/net/asar/asar_url_loader_factory.h
+++ b/shell/browser/net/asar/asar_url_loader_factory.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_BROWSER_NET_ASAR_ASAR_URL_LOADER_FACTORY_H_
+#define SHELL_BROWSER_NET_ASAR_ASAR_URL_LOADER_FACTORY_H_
+
+#include "content/public/browser/non_network_url_loader_factory_base.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+
+namespace electron {
+
+// Provide support for accessing asar archives in file:// protocol.
+class AsarURLLoaderFactory : public content::NonNetworkURLLoaderFactoryBase {
+ public:
+  static mojo::PendingRemote<network::mojom::URLLoaderFactory> Create();
+
+ private:
+  AsarURLLoaderFactory(
+      mojo::PendingReceiver<network::mojom::URLLoaderFactory> factory_receiver);
+  ~AsarURLLoaderFactory() override;
+
+  // network::mojom::URLLoaderFactory:
+  void CreateLoaderAndStart(
+      mojo::PendingReceiver<network::mojom::URLLoader> loader,
+      int32_t routing_id,
+      int32_t request_id,
+      uint32_t options,
+      const network::ResourceRequest& request,
+      mojo::PendingRemote<network::mojom::URLLoaderClient> client,
+      const net::MutableNetworkTrafficAnnotationTag& traffic_annotation)
+      override;
+};
+
+}  // namespace electron
+
+#endif  // SHELL_BROWSER_NET_ASAR_ASAR_URL_LOADER_FACTORY_H_

--- a/shell/browser/protocol_registry.cc
+++ b/shell/browser/protocol_registry.cc
@@ -2,54 +2,16 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+#include "shell/browser/protocol_registry.h"
+
 #include <memory>
 #include <utility>
 
-#include "content/public/browser/non_network_url_loader_factory_base.h"
 #include "content/public/browser/web_contents.h"
 #include "shell/browser/electron_browser_context.h"
-#include "shell/browser/net/asar/asar_url_loader.h"
-#include "shell/browser/protocol_registry.h"
+#include "shell/browser/net/asar/asar_url_loader_factory.h"
 
 namespace electron {
-
-namespace {
-
-// Provide support for accessing asar archives in file:// protocol.
-class AsarURLLoaderFactory : public content::NonNetworkURLLoaderFactoryBase {
- public:
-  static mojo::PendingRemote<network::mojom::URLLoaderFactory> Create() {
-    mojo::PendingRemote<network::mojom::URLLoaderFactory> pending_remote;
-
-    // The AsarURLLoaderFactory will delete itself when there are no more
-    // receivers - see the NonNetworkURLLoaderFactoryBase::OnDisconnect method.
-    new AsarURLLoaderFactory(pending_remote.InitWithNewPipeAndPassReceiver());
-
-    return pending_remote;
-  }
-
- private:
-  AsarURLLoaderFactory(
-      mojo::PendingReceiver<network::mojom::URLLoaderFactory> factory_receiver)
-      : content::NonNetworkURLLoaderFactoryBase(std::move(factory_receiver)) {}
-  ~AsarURLLoaderFactory() override = default;
-
-  // network::mojom::URLLoaderFactory:
-  void CreateLoaderAndStart(
-      mojo::PendingReceiver<network::mojom::URLLoader> loader,
-      int32_t routing_id,
-      int32_t request_id,
-      uint32_t options,
-      const network::ResourceRequest& request,
-      mojo::PendingRemote<network::mojom::URLLoaderClient> client,
-      const net::MutableNetworkTrafficAnnotationTag& traffic_annotation)
-      override {
-    asar::CreateAsarURLLoader(request, std::move(loader), std::move(client),
-                              new net::HttpResponseHeaders(""));
-  }
-};
-
-}  // namespace
 
 // static
 ProtocolRegistry* ProtocolRegistry::FromBrowserContext(

--- a/shell/browser/protocol_registry.h
+++ b/shell/browser/protocol_registry.h
@@ -30,6 +30,7 @@ class ProtocolRegistry {
       bool allow_file_access);
 
   const HandlersMap& intercept_handlers() const { return intercept_handlers_; }
+  const HandlersMap& handlers() const { return handlers_; }
 
   bool RegisterProtocol(ProtocolType type,
                         const std::string& scheme,

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -41,6 +41,8 @@
 #include "services/network/public/cpp/simple_url_loader.h"
 #include "services/network/public/cpp/simple_url_loader_stream_consumer.h"
 #include "services/network/public/cpp/wrapper_shared_url_loader_factory.h"
+#include "shell/browser/net/asar/asar_url_loader_factory.h"
+#include "shell/browser/protocol_registry.h"
 #include "shell/browser/ui/inspectable_web_contents_delegate.h"
 #include "shell/browser/ui/inspectable_web_contents_view.h"
 #include "shell/browser/ui/inspectable_web_contents_view_delegate.h"
@@ -680,12 +682,20 @@ void InspectableWebContents::LoadNetworkResource(DispatchCallback callback,
   resource_request.site_for_cookies = net::SiteForCookies::FromUrl(gurl);
   resource_request.headers.AddHeadersFromString(headers);
 
+  auto* protocol_registry = ProtocolRegistry::FromBrowserContext(
+      GetDevToolsWebContents()->GetBrowserContext());
   NetworkResourceLoader::URLLoaderFactoryHolder url_loader_factory;
   if (gurl.SchemeIsFile()) {
     mojo::PendingRemote<network::mojom::URLLoaderFactory> pending_remote =
-        content::CreateFileURLLoaderFactory(
-            base::FilePath() /* profile_path */,
-            nullptr /* shared_cors_origin_access_list */);
+        AsarURLLoaderFactory::Create();
+    url_loader_factory = network::SharedURLLoaderFactory::Create(
+        std::make_unique<network::WrapperPendingSharedURLLoaderFactory>(
+            std::move(pending_remote)));
+  } else if (protocol_registry->IsProtocolRegistered(gurl.scheme())) {
+    auto& protocol_handler = protocol_registry->handlers().at(gurl.scheme());
+    mojo::PendingRemote<network::mojom::URLLoaderFactory> pending_remote =
+        ElectronURLLoaderFactory::Create(protocol_handler.first,
+                                         protocol_handler.second);
     url_loader_factory = network::SharedURLLoaderFactory::Create(
         std::make_unique<network::WrapperPendingSharedURLLoaderFactory>(
             std::move(pending_remote)));


### PR DESCRIPTION
Backport of #28573

See that PR for details.

Notes: Allow loading source maps from custom protocols and asar bundles