### PR TITLE
feat: add BrowserWindow.isFocusable()

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -758,6 +758,10 @@ A `Boolean` property that determines whether the window is in simple (pre-Lion) 
 
 A `Boolean` property that determines whether the window is in fullscreen mode.
 
+#### `win.focusable` _Windows_ _macOS_
+
+A `Boolean` property that determines whether the window is focusable.
+
 #### `win.visibleOnAllWorkspaces`
 
 A `Boolean` property that determines whether the window is visible on all workspaces.
@@ -1675,6 +1679,10 @@ older Windows versions behave as if `WDA_MONITOR` is applied capturing a black w
 Changes whether the window can be focused.
 
 On macOS it does not remove the focus from the window.
+
+#### `win.isFocusable()` _macOS_ _Windows_
+
+Returns whether the window can be focused.
 
 #### `win.setParentWindow(parent)`
 

--- a/lib/browser/api/base-window.ts
+++ b/lib/browser/api/base-window.ts
@@ -37,6 +37,11 @@ Object.defineProperty(BaseWindow.prototype, 'simpleFullScreen', {
   set: function (simple) { this.setSimpleFullScreen(simple); }
 });
 
+Object.defineProperty(BaseWindow.prototype, 'focusable', {
+  get: function () { return this.isFocusable(); },
+  set: function (focusable) { this.setFocusable(focusable); }
+});
+
 Object.defineProperty(BaseWindow.prototype, 'kiosk', {
   get: function () { return this.isKiosk(); },
   set: function (kiosk) { this.setKiosk(kiosk); }

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -696,6 +696,10 @@ void BaseWindow::SetFocusable(bool focusable) {
   return window_->SetFocusable(focusable);
 }
 
+bool BaseWindow::IsFocusable() {
+  return window_->IsFocusable();
+}
+
 void BaseWindow::SetMenu(v8::Isolate* isolate, v8::Local<v8::Value> value) {
   auto context = isolate->GetCurrentContext();
   gin::Handle<Menu> menu;
@@ -1243,6 +1247,7 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("setIgnoreMouseEvents", &BaseWindow::SetIgnoreMouseEvents)
       .SetMethod("setContentProtection", &BaseWindow::SetContentProtection)
       .SetMethod("setFocusable", &BaseWindow::SetFocusable)
+      .SetMethod("isFocusable", &BaseWindow::IsFocusable)
       .SetMethod("setMenu", &BaseWindow::SetMenu)
       .SetMethod("removeMenu", &BaseWindow::RemoveMenu)
       .SetMethod("setParentWindow", &BaseWindow::SetParentWindow)

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -171,6 +171,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void SetIgnoreMouseEvents(bool ignore, gin_helper::Arguments* args);
   void SetContentProtection(bool enable);
   void SetFocusable(bool focusable);
+  bool IsFocusable();
   void SetMenu(v8::Isolate* isolate, v8::Local<v8::Value> menu);
   void RemoveMenu();
   void SetParentWindow(v8::Local<v8::Value> value, gin_helper::Arguments* args);

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -328,6 +328,10 @@ bool NativeWindow::IsDocumentEdited() {
 
 void NativeWindow::SetFocusable(bool focusable) {}
 
+bool NativeWindow::IsFocusable() {
+  return false;
+}
+
 void NativeWindow::SetMenu(ElectronMenuModel* menu) {}
 
 void NativeWindow::SetParentWindow(NativeWindow* parent) {

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -162,6 +162,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetIgnoreMouseEvents(bool ignore, bool forward) = 0;
   virtual void SetContentProtection(bool enable) = 0;
   virtual void SetFocusable(bool focusable);
+  virtual bool IsFocusable();
   virtual void SetMenu(ElectronMenuModel* menu);
   virtual void SetParentWindow(NativeWindow* parent);
   virtual void AddBrowserView(NativeBrowserView* browser_view) = 0;

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -104,6 +104,7 @@ class NativeWindowMac : public NativeWindow,
   void SetIgnoreMouseEvents(bool ignore, bool forward) override;
   void SetContentProtection(bool enable) override;
   void SetFocusable(bool focusable) override;
+  bool IsFocusable() override;
   void AddBrowserView(NativeBrowserView* browser_view) override;
   void RemoveBrowserView(NativeBrowserView* browser_view) override;
   void SetTopBrowserView(NativeBrowserView* browser_view) override;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1072,6 +1072,10 @@ void NativeWindowMac::SetFocusable(bool focusable) {
   [window_ setDisableKeyOrMainWindow:!focusable];
 }
 
+bool NativeWindowMac::IsFocusable() {
+  return ![window_ disableKeyOrMainWindow];
+}
+
 void NativeWindowMac::AddBrowserView(NativeBrowserView* view) {
   [CATransaction begin];
   [CATransaction setDisableActions:YES];

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1083,6 +1083,17 @@ void NativeWindowViews::SetFocusable(bool focusable) {
 #endif
 }
 
+bool NativeWindowViews::IsFocusable() {
+  bool can_activate = widget()->widget_delegate()->CanActivate();
+#if defined(OS_WIN)
+  LONG ex_style = ::GetWindowLong(GetAcceleratedWidget(), GWL_EXSTYLE);
+  bool no_activate = ex_style & WS_EX_NOACTIVATE;
+  return !no_activate && can_activate;
+#else
+  return can_activate;
+#endif
+}
+
 void NativeWindowViews::SetMenu(ElectronMenuModel* menu_model) {
 #if defined(USE_X11)
   if (!features::IsUsingOzonePlatform()) {

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -112,6 +112,7 @@ class NativeWindowViews : public NativeWindow,
   void SetIgnoreMouseEvents(bool ignore, bool forward) override;
   void SetContentProtection(bool enable) override;
   void SetFocusable(bool focusable) override;
+  bool IsFocusable() override;
   void SetMenu(ElectronMenuModel* menu_model) override;
   void AddBrowserView(NativeBrowserView* browser_view) override;
   void RemoveBrowserView(NativeBrowserView* browser_view) override;

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -838,6 +838,17 @@ describe('BrowserWindow module', () => {
         await closeWindow(w2, { assertNotWindows: false });
       });
     });
+
+    describe('BrowserWindow.isFocusable()', () => {
+      it('correctly returns whether a window is focusable', async () => {
+        const w2 = new BrowserWindow({ focusable: false });
+        expect(w2.isFocusable()).to.be.false();
+
+        w2.setFocusable(true);
+        expect(w2.isFocusable()).to.be.true();
+        await closeWindow(w2, { assertNotWindows: false });
+      });
+    });
   });
 
   describe('sizing', () => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/28623.

Adds the corresponding `isFocusable` method to existing `BrowserWindow.setFocusable()`. As noted in the issue, there are myriad use cases where one would want to know the value of a   window's focusability without needing to manually keep track of various calls to `setFocusable`.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `BrowserWindow.isFocusable()` to determine whether a window is focusable.
