### PR TITLE
feat: add session.storagePath to get path on disk for session data

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -817,6 +817,11 @@ Returns `Extension[]` - A list of all loaded extensions.
 **Note:** This API cannot be called before the `ready` event of the `app` module
 is emitted.
 
+#### `ses.getStoragePath()`
+
+A `String | null` indicating the absolute file system path where data for this
+session is persisted on disk.  For in memory sessions this returns `null`.
+
 ### Instance Properties
 
 The following properties are available on instances of `Session`:
@@ -829,6 +834,11 @@ code to the `setSpellCheckerLanguages` API that isn't in this array will result 
 #### `ses.spellCheckerEnabled`
 
 A `Boolean` indicating whether builtin spell checker is enabled.
+
+#### `ses.storagePath` _Readonly_
+
+A `String | null` indicating the absolute file system path where data for this
+session is persisted on disk.  For in memory sessions this returns `null`.
 
 #### `ses.cookies` _Readonly_
 

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -971,6 +971,13 @@ v8::Local<v8::Promise> Session::CloseAllConnections() {
   return handle;
 }
 
+v8::Local<v8::Value> Session::GetPath(v8::Isolate* isolate) {
+  if (browser_context_->IsOffTheRecord()) {
+    return v8::Null(isolate);
+  }
+  return gin::ConvertToV8(isolate, browser_context_->GetPath());
+}
+
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
 base::Value Session::GetSpellCheckerLanguages() {
   return browser_context_->prefs()
@@ -1195,11 +1202,13 @@ gin::ObjectTemplateBuilder Session::GetObjectTemplateBuilder(
 #endif
       .SetMethod("preconnect", &Session::Preconnect)
       .SetMethod("closeAllConnections", &Session::CloseAllConnections)
+      .SetMethod("getStoragePath", &Session::GetPath)
       .SetProperty("cookies", &Session::Cookies)
       .SetProperty("netLog", &Session::NetLog)
       .SetProperty("protocol", &Session::Protocol)
       .SetProperty("serviceWorkers", &Session::ServiceWorkerContext)
-      .SetProperty("webRequest", &Session::WebRequest);
+      .SetProperty("webRequest", &Session::WebRequest)
+      .SetProperty("storagePath", &Session::GetPath);
 }
 
 const char* Session::GetTypeName() {

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -124,6 +124,7 @@ class Session : public gin::Wrappable<Session>,
   v8::Local<v8::Value> NetLog(v8::Isolate* isolate);
   void Preconnect(const gin_helper::Dictionary& options, gin::Arguments* args);
   v8::Local<v8::Promise> CloseAllConnections();
+  v8::Local<v8::Value> GetPath(v8::Isolate* isolate);
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
   base::Value GetSpellCheckerLanguages();
   void SetSpellCheckerLanguages(gin_helper::ErrorThrower thrower,

--- a/spec-main/api-session-spec.ts
+++ b/spec-main/api-session-spec.ts
@@ -1090,6 +1090,24 @@ describe('session module', () => {
     });
   });
 
+  describe('session.storagePage', () => {
+    it('returns a string', () => {
+      expect(session.defaultSession.storagePath).to.be.a('string');
+    });
+
+    it('returns null for in memory sessions', () => {
+      expect(session.fromPartition('in-memory').storagePath).to.equal(null);
+    });
+
+    it('returns different paths for partitions and the default session', () => {
+      expect(session.defaultSession.storagePath).to.not.equal(session.fromPartition('persist:two').storagePath);
+    });
+
+    it('returns different paths for different partitions', () => {
+      expect(session.fromPartition('persist:one').storagePath).to.not.equal(session.fromPartition('persist:two').storagePath);
+    });
+  });
+
   describe('ses.setSSLConfig()', () => {
     it('can disable cipher suites', async () => {
       const ses = session.fromPartition('' + Math.random());


### PR DESCRIPTION
For apps that have multiple sessions that have their own settings / config storage it is sometimes a requirement to store those settings / config options per-session.  Currently the paths to these sessions are predictable but not guaranteed, this use case is made way safer by just exposing this path.

Notes: Added new `session.storagePath` API to get the path on disk for session-specific data