### PR TITLE
fix: end attached sheet when calling window.hide()

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -535,6 +535,12 @@ void NativeWindowMac::ShowInactive() {
 }
 
 void NativeWindowMac::Hide() {
+  // If a sheet is attached to the window when we call [window_ orderOut:nil],
+  // the sheet won't be able to show again on the same window.
+  // Ensure it's closed before calling [window_ orderOut:nil].
+  if ([window_ attachedSheet])
+    [window_ endSheet:[window_ attachedSheet]];
+
   if (is_modal() && parent()) {
     [window_ orderOut:nil];
     [parent()->GetNativeWindow().GetNativeNSWindow() endSheet:window_];


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/28658.

If a sheet is attached to the window when we call `[window_ orderOut:nil]` in `window.hide()` on macOS, the sheet won't be able to show again on the same window. We therefore should be closing the attached sheet before calling `[window_ orderOut:nil]` on the `NSWindow` being hidden.

Tested with https://github.com/tsminh/electron-dialog-missing-after-hide

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes:  Fixed an issue where some dialogs would stop working on macOS if `window.hide()` was called while they were open.