### PR TITLE
docs(build-instructions): clarify that these are for building Electron itself

### DIFF
--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -1,6 +1,8 @@
 # Build Instructions
 
-Follow the guidelines below for building Electron.
+Follow the guidelines below for building **Electron itself**, for the purposes of creating custom Electron binaries. For bundling and distributing your app code with the prebuilt Electron binaries, see the [application distribution][application-distribution] guide.
+
+[application-distribution]: ../tutorial/application-distribution.md
 
 ## Platform prerequisites
 

--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -1,6 +1,8 @@
 # Build Instructions (Linux)
 
-Follow the guidelines below for building Electron on Linux.
+Follow the guidelines below for building **Electron itself** on Linux, for the purposes of creating custom Electron binaries. For bundling and distributing your app code with the prebuilt Electron binaries, see the [application distribution][application-distribution] guide.
+
+[application-distribution]: ../tutorial/application-distribution.md
 
 ## Prerequisites
 

--- a/docs/development/build-instructions-macos.md
+++ b/docs/development/build-instructions-macos.md
@@ -1,6 +1,8 @@
 # Build Instructions (macOS)
 
-Follow the guidelines below for building Electron on macOS.
+Follow the guidelines below for building **Electron itself** on macOS, for the purposes of creating custom Electron binaries. For bundling and distributing your app code with the prebuilt Electron binaries, see the [application distribution][application-distribution] guide.
+
+[application-distribution]: ../tutorial/application-distribution.md
 
 ## Prerequisites
 

--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -1,6 +1,8 @@
 # Build Instructions (Windows)
 
-Follow the guidelines below for building Electron on Windows.
+Follow the guidelines below for building **Electron itself** on Windows, for the purposes of creating custom Electron binaries. For bundling and distributing your app code with the prebuilt Electron binaries, see the [application distribution][application-distribution] guide.
+
+[application-distribution]: ../tutorial/application-distribution.md
 
 ## Prerequisites
 


### PR DESCRIPTION
#### Description of Change

We've gotten a surprising number of folks in the Discord server trying to use the Build Instructions to bundle/distribute their Electron apps. This pull request clarifies on each of the build instructions pages that the pages are for building itself, and points to a different docs page for building apps.

CC: @electron/wg-ecosystem 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
