### PR TITLE
fix: ensure widget size is set correctly on linux on small screens

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -333,6 +333,10 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
   aura::Window* window = GetNativeWindow();
   if (window)
     window->AddPreTargetHandler(this);
+
+  // On linux after the widget is initialized we might have to force set the
+  // bounds if the bounds are smaller than the current display
+  SetBounds(gfx::Rect(GetPosition(), bounds.size()), false);
 #endif
 }
 


### PR DESCRIPTION
When creating a widget on linux the bounds are restricted to the screen size, when calling SetSize / SetBounds they are not.  This fixes this initialization issue by calling SetBounds after widget creation.

Noticed this issue while running linux tests on xvfb with a screen size smaller than the default electron window size (resulted in a failed test).

Notes: no-notes