### PR TITLE
fix: do not handle write errors after request is aborted

### DIFF
--- a/lib/browser/api/net.ts
+++ b/lib/browser/api/net.ts
@@ -188,6 +188,11 @@ class ChunkedBodyStream extends Writable {
     this._downstream = pipe;
     if (this._pendingChunk) {
       const doneWriting = (maybeError: Error | void) => {
+        // If the underlying request has been aborted, we honeslty don't care about the error
+        // all work should cease as soon as we abort anyway, this error is probably a
+        // "mojo pipe disconnected" error (code=9)
+        if (this._clientRequest._aborted) return;
+
         const cb = this._pendingCallback!;
         delete this._pendingCallback;
         delete this._pendingChunk;


### PR DESCRIPTION
This fixes a flake on linux CI which started recently where the "write" promise is being rejected after the request has been aborted / cancelled.  In this case we should drop the error to the floor but instead we pass it down the stack where it eventually emits a now unhandled error event.

Example failure: https://app.circleci.com/pipelines/github/electron/electron/38072/workflows/c1faf19b-aa41-4f99-a564-165729222859/jobs/838813

Verified fix by running the test that caused it 10000 times before fix and 10000 times after.  ~50 failures before, 0 after.

Putting no-notes because I don't think this was ever a released issue and I'm not sure what folks would see in their apps anyway.  It seems like a recent CI flake, I'll send it to all supported versions anyway though.

Notes: no-notes