### PR TITLE
chore: cherry-pick 3c80bb2a594f from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -161,3 +161,4 @@ cherry-pick-c6d6f7aee733.patch
 cherry-pick-37210e5ab006.patch
 reland_reland_fsa_add_issafepathcomponent_checks_to.patch
 css_make_fetches_from_inline_css_use_the_document_s_url_as_referrer.patch
+cherry-pick-3c80bb2a594f.patch

--- a/patches/chromium/cherry-pick-3c80bb2a594f.patch
+++ b/patches/chromium/cherry-pick-3c80bb2a594f.patch
@@ -1,7 +1,7 @@
-From 3c80bb2a594f676ac4c3f2592091d90346196d01 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jana Grill <janagrill@google.com>
 Date: Wed, 14 Apr 2021 08:40:10 +0000
-Subject: [PATCH] Forbid script execution while updating the paint lifecycle.
+Subject: Forbid script execution while updating the paint lifecycle.
 
 (cherry picked from commit 5425d3b100fab533ea9ddc2ed8fbfc4870db0587)
 
@@ -19,13 +19,12 @@ Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
 Commit-Queue: Jana Grill <janagrill@chromium.org>
 Cr-Commit-Position: refs/branch-heads/4240@{#1601}
 Cr-Branched-From: f297677702651916bbf65e59c0d4bbd4ce57d1ee-refs/heads/master@{#800218}
----
 
 diff --git a/third_party/blink/renderer/core/frame/local_frame_view.cc b/third_party/blink/renderer/core/frame/local_frame_view.cc
-index 030ac81..7851acd 100644
+index 9a4c7a5249424b021759bf7895dd3f343b9641e6..37054d34157e7f4b4d65b022cdb83c832deb26a8 100644
 --- a/third_party/blink/renderer/core/frame/local_frame_view.cc
 +++ b/third_party/blink/renderer/core/frame/local_frame_view.cc
-@@ -2758,11 +2758,14 @@
+@@ -2648,11 +2648,14 @@ void LocalFrameView::RunPaintLifecyclePhase() {
          for (PaintLayerScrollableArea* area : *animating_scrollable_areas)
            area->UpdateCompositorScrollAnimations();
        }

--- a/patches/chromium/cherry-pick-3c80bb2a594f.patch
+++ b/patches/chromium/cherry-pick-3c80bb2a594f.patch
@@ -1,0 +1,47 @@
+From 3c80bb2a594f676ac4c3f2592091d90346196d01 Mon Sep 17 00:00:00 2001
+From: Jana Grill <janagrill@google.com>
+Date: Wed, 14 Apr 2021 08:40:10 +0000
+Subject: [PATCH] Forbid script execution while updating the paint lifecycle.
+
+(cherry picked from commit 5425d3b100fab533ea9ddc2ed8fbfc4870db0587)
+
+Bug: 1196781
+Change-Id: Idc8d24792d5c413691977b09ca821de4e13887ad
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2812000
+Commit-Queue: Adrian Taylor <adetaylor@chromium.org>
+Commit-Queue: Robert Flack <flackr@chromium.org>
+Reviewed-by: Xianzhu Wang <wangxianzhu@chromium.org>
+Cr-Original-Commit-Position: refs/heads/master@{#870275}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2821879
+Reviewed-by: Robert Flack <flackr@chromium.org>
+Reviewed-by: Achuith Bhandarkar <achuith@chromium.org>
+Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
+Commit-Queue: Jana Grill <janagrill@chromium.org>
+Cr-Commit-Position: refs/branch-heads/4240@{#1601}
+Cr-Branched-From: f297677702651916bbf65e59c0d4bbd4ce57d1ee-refs/heads/master@{#800218}
+---
+
+diff --git a/third_party/blink/renderer/core/frame/local_frame_view.cc b/third_party/blink/renderer/core/frame/local_frame_view.cc
+index 030ac81..7851acd 100644
+--- a/third_party/blink/renderer/core/frame/local_frame_view.cc
++++ b/third_party/blink/renderer/core/frame/local_frame_view.cc
+@@ -2758,11 +2758,14 @@
+         for (PaintLayerScrollableArea* area : *animating_scrollable_areas)
+           area->UpdateCompositorScrollAnimations();
+       }
+-      frame_view.GetLayoutView()
+-          ->GetDocument()
+-          .GetDocumentAnimations()
+-          .UpdateAnimations(DocumentLifecycle::kPaintClean,
+-                            paint_artifact_compositor_.get());
++      {
++        ScriptForbiddenScope forbid_script;
++        frame_view.GetLayoutView()
++            ->GetDocument()
++            .GetDocumentAnimations()
++            .UpdateAnimations(DocumentLifecycle::kPaintClean,
++                              paint_artifact_compositor_.get());
++      }
+     });
+ 
+     // Initialize animation properties in the newly created paint property


### PR DESCRIPTION
Forbid script execution while updating the paint lifecycle.

(cherry picked from commit 5425d3b100fab533ea9ddc2ed8fbfc4870db0587)

Bug: 1196781
Change-Id: Idc8d24792d5c413691977b09ca821de4e13887ad
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2812000
Commit-Queue: Adrian Taylor <adetaylor@chromium.org>
Commit-Queue: Robert Flack <flackr@chromium.org>
Reviewed-by: Xianzhu Wang <wangxianzhu@chromium.org>
Cr-Original-Commit-Position: refs/heads/master@{#870275}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2821879
Reviewed-by: Robert Flack <flackr@chromium.org>
Reviewed-by: Achuith Bhandarkar <achuith@chromium.org>
Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
Commit-Queue: Jana Grill <janagrill@chromium.org>
Cr-Commit-Position: refs/branch-heads/4240@{#1601}
Cr-Branched-From: f297677702651916bbf65e59c0d4bbd4ce57d1ee-refs/heads/master@{#800218}


Notes: Security: backported fix for CVE-2021-21206.