### PR TITLE
feat: add WebFrameMain.visibilityState

### DIFF
--- a/docs/api/web-frame-main.md
+++ b/docs/api/web-frame-main.md
@@ -185,4 +185,6 @@ have the same `routingId`.
 
 #### `frame.visibilityState` _Readonly_
 
-A `string` representing the [visibility state](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API) of the frame.
+A `string` representing the [visibility state](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState) of the frame.
+
+See also how the [Page Visibility API](browser-window.md#page-visibility) is affected by other Electron APIs.

--- a/docs/api/web-frame-main.md
+++ b/docs/api/web-frame-main.md
@@ -182,3 +182,7 @@ This is not the same as the OS process ID; to read that use `frame.osProcessId`.
 An `Integer` representing the unique frame id in the current renderer process.
 Distinct `WebFrameMain` instances that refer to the same underlying frame will
 have the same `routingId`.
+
+#### `frame.visibilityState` _Readonly_
+
+A `string` representing the [visibility state](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API) of the frame.

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -15,6 +15,7 @@
 #include "gin/wrappable.h"
 #include "shell/common/gin_helper/constructible.h"
 #include "shell/common/gin_helper/pinnable.h"
+#include "third_party/blink/public/mojom/page/page_visibility_state.mojom-forward.h"
 
 class GURL;
 
@@ -95,6 +96,7 @@ class WebFrameMain : public gin::Wrappable<WebFrameMain>,
   int ProcessID() const;
   int RoutingID() const;
   GURL URL() const;
+  blink::mojom::PageVisibilityState VisibilityState() const;
 
   content::RenderFrameHost* Top() const;
   content::RenderFrameHost* Parent() const;

--- a/spec-main/api-web-frame-main-spec.ts
+++ b/spec-main/api-web-frame-main-spec.ts
@@ -143,6 +143,11 @@ describe('webFrameMain module', () => {
 
       expect(webFrame.visibilityState).to.equal('visible');
       w.hide();
+
+      // Wait for visibility to propagate. If this ends up being flaky, we can
+      // look into binding WebContentsObserver::OnVisibilityChanged.
+      await new Promise(resolve => setTimeout(resolve, 10));
+
       expect(webFrame.visibilityState).to.equal('hidden');
     });
   });

--- a/spec-main/api-web-frame-main-spec.ts
+++ b/spec-main/api-web-frame-main-spec.ts
@@ -6,6 +6,7 @@ import { BrowserWindow, WebFrameMain, webFrameMain, ipcMain } from 'electron/mai
 import { closeAllWindows } from './window-helpers';
 import { emittedOnce, emittedNTimes } from './events-helpers';
 import { AddressInfo } from 'net';
+import { waitForTrue } from './spec-helpers';
 
 describe('webFrameMain module', () => {
   const fixtures = path.resolve(__dirname, '..', 'spec-main', 'fixtures');
@@ -143,12 +144,9 @@ describe('webFrameMain module', () => {
 
       expect(webFrame.visibilityState).to.equal('visible');
       w.hide();
-
-      // Wait for visibility to propagate. If this ends up being flaky, we can
-      // look into binding WebContentsObserver::OnVisibilityChanged.
-      await new Promise(resolve => setTimeout(resolve, 10));
-
-      expect(webFrame.visibilityState).to.equal('hidden');
+      await expect(
+        waitForTrue(() => webFrame.visibilityState === 'hidden')
+      ).to.eventually.be.fulfilled();
     });
   });
 

--- a/spec-main/api-web-frame-main-spec.ts
+++ b/spec-main/api-web-frame-main-spec.ts
@@ -135,6 +135,18 @@ describe('webFrameMain module', () => {
     });
   });
 
+  describe('WebFrame.visibilityState', () => {
+    it('should match window state', async () => {
+      const w = new BrowserWindow({ show: true });
+      await w.loadURL('about:blank');
+      const webFrame = w.webContents.mainFrame;
+
+      expect(webFrame.visibilityState).to.equal('visible');
+      w.hide();
+      expect(webFrame.visibilityState).to.equal('hidden');
+    });
+  });
+
   describe('WebFrame.executeJavaScript', () => {
     it('can inject code into any subframe', async () => {
       const w = new BrowserWindow({ show: false, webPreferences: { contextIsolation: true } });

--- a/spec-main/api-web-frame-main-spec.ts
+++ b/spec-main/api-web-frame-main-spec.ts
@@ -6,7 +6,7 @@ import { BrowserWindow, WebFrameMain, webFrameMain, ipcMain } from 'electron/mai
 import { closeAllWindows } from './window-helpers';
 import { emittedOnce, emittedNTimes } from './events-helpers';
 import { AddressInfo } from 'net';
-import { waitForTrue } from './spec-helpers';
+import { waitUntil } from './spec-helpers';
 
 describe('webFrameMain module', () => {
   const fixtures = path.resolve(__dirname, '..', 'spec-main', 'fixtures');
@@ -145,7 +145,7 @@ describe('webFrameMain module', () => {
       expect(webFrame.visibilityState).to.equal('visible');
       w.hide();
       await expect(
-        waitForTrue(() => webFrame.visibilityState === 'hidden')
+        waitUntil(() => webFrame.visibilityState === 'hidden')
       ).to.eventually.be.fulfilled();
     });
   });

--- a/spec-main/spec-helpers.ts
+++ b/spec-main/spec-helpers.ts
@@ -87,7 +87,7 @@ export async function startRemoteControlApp () {
   return new RemoteControlApp(appProcess, port);
 }
 
-export function waitForTrue (
+export function waitUntil (
   callback: () => boolean,
   opts: { rate?: number, timeout?: number } = {}
 ) {
@@ -115,8 +115,8 @@ export function waitForTrue (
       if (result === true) {
         cleanup();
         resolve();
+        return true;
       }
-      return result;
     };
 
     if (check()) {
@@ -128,7 +128,7 @@ export function waitForTrue (
     timeoutId = setTimeout(() => {
       timeoutId = undefined;
       cleanup();
-      reject(new Error(`waitForTrue timed out after ${timeout}ms`));
+      reject(new Error(`waitUntil timed out after ${timeout}ms`));
     }, timeout);
   });
 }


### PR DESCRIPTION
#### Description of Change

Adds `WebFrameMain.visibilityState` instance property which aligns with `document.visibilityState` in the renderer.

This can be useful for telling whether a frame is visible without needing to execute any JS in the renderer.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `WebFrameMain.visibilityState` instance property.
