### PR TITLE
build: read node files as binary files

### DIFF
--- a/script/release/uploaders/upload-node-checksums.py
+++ b/script/release/uploaders/upload-node-checksums.py
@@ -88,7 +88,7 @@ def create_checksum(algorithm, directory, filename, files):
   lines = []
   for path in files:
     h = hashlib.new(algorithm)
-    with open(path, 'r') as f:
+    with open(path, 'rb') as f:
       h.update(f.read())
       lines.append(h.hexdigest() + '  ' + os.path.relpath(path, directory))
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Recently our releases started failing while uploading the node checksums due to the following error:
 "UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte\n"

This error was happening because the python script was trying to read the node files as utf-8 instead of binary.  This PR updates that python script to instead read those files as binary.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
