### PR TITLE
chore: cherry-pick a152ce495f8f from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -162,3 +162,4 @@ cherry-pick-37210e5ab006.patch
 reland_reland_fsa_add_issafepathcomponent_checks_to.patch
 css_make_fetches_from_inline_css_use_the_document_s_url_as_referrer.patch
 cherry-pick-3c80bb2a594f.patch
+cherry-pick-a152ce495f8f.patch

--- a/patches/chromium/cherry-pick-a152ce495f8f.patch
+++ b/patches/chromium/cherry-pick-a152ce495f8f.patch
@@ -1,0 +1,103 @@
+From a152ce495f8f69bbf473d56bcbc205c94c57406b Mon Sep 17 00:00:00 2001
+From: Guido Urdaneta <guidou@chromium.org>
+Date: Tue, 13 Apr 2021 16:04:59 +0000
+Subject: [PATCH] Make request IDs 64 bit in PermissionBubbleMediaAccessHandler
+
+This is expected to prevent potential overflows.
+
+(cherry picked from commit b29987b9d50e085a5aefc8d48ad3e4446aaee51e)
+
+Bug: 1178032
+Change-Id: I7422958f66b26f99b2dcfe9f8d3ba0fe796cd8a2
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2797413
+Auto-Submit: Guido Urdaneta <guidou@chromium.org>
+Reviewed-by: Elad Alon <eladalon@chromium.org>
+Commit-Queue: Guido Urdaneta <guidou@chromium.org>
+Cr-Original-Commit-Position: refs/heads/master@{#868216}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2822148
+Reviewed-by: Guido Urdaneta <guidou@chromium.org>
+Reviewed-by: Achuith Bhandarkar <achuith@chromium.org>
+Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
+Commit-Queue: Jana Grill <janagrill@chromium.org>
+Cr-Commit-Position: refs/branch-heads/4240@{#1599}
+Cr-Branched-From: f297677702651916bbf65e59c0d4bbd4ce57d1ee-refs/heads/master@{#800218}
+---
+
+diff --git a/chrome/browser/media/webrtc/permission_bubble_media_access_handler.cc b/chrome/browser/media/webrtc/permission_bubble_media_access_handler.cc
+index fe81c15..5a39005 100644
+--- a/chrome/browser/media/webrtc/permission_bubble_media_access_handler.cc
++++ b/chrome/browser/media/webrtc/permission_bubble_media_access_handler.cc
+@@ -229,7 +229,7 @@
+ 
+   DCHECK(!it->second.empty());
+ 
+-  const int request_id = it->second.begin()->first;
++  const int64_t request_id = it->second.begin()->first;
+   const content::MediaStreamRequest& request =
+       it->second.begin()->second.request;
+ #if defined(OS_ANDROID)
+@@ -290,7 +290,7 @@
+ 
+ void PermissionBubbleMediaAccessHandler::OnMediaStreamRequestResponse(
+     content::WebContents* web_contents,
+-    int request_id,
++    int64_t request_id,
+     content::MediaStreamRequest request,
+     const blink::MediaStreamDevices& devices,
+     blink::mojom::MediaStreamRequestResult result,
+@@ -322,7 +322,7 @@
+ 
+ void PermissionBubbleMediaAccessHandler::OnAccessRequestResponse(
+     content::WebContents* web_contents,
+-    int request_id,
++    int64_t request_id,
+     const blink::MediaStreamDevices& devices,
+     blink::mojom::MediaStreamRequestResult result,
+     std::unique_ptr<content::MediaStreamUI> ui) {
+diff --git a/chrome/browser/media/webrtc/permission_bubble_media_access_handler.h b/chrome/browser/media/webrtc/permission_bubble_media_access_handler.h
+index dabea7e..01dbbec 100644
+--- a/chrome/browser/media/webrtc/permission_bubble_media_access_handler.h
++++ b/chrome/browser/media/webrtc/permission_bubble_media_access_handler.h
+@@ -5,6 +5,8 @@
+ #ifndef CHROME_BROWSER_MEDIA_WEBRTC_PERMISSION_BUBBLE_MEDIA_ACCESS_HANDLER_H_
+ #define CHROME_BROWSER_MEDIA_WEBRTC_PERMISSION_BUBBLE_MEDIA_ACCESS_HANDLER_H_
+ 
++#include <stdint.h>
++
+ #include <map>
+ 
+ #include "base/memory/weak_ptr.h"
+@@ -50,13 +52,13 @@
+ 
+  private:
+   struct PendingAccessRequest;
+-  using RequestsMap = std::map<int, PendingAccessRequest>;
++  using RequestsMap = std::map<int64_t, PendingAccessRequest>;
+   using RequestsMaps = std::map<content::WebContents*, RequestsMap>;
+ 
+   void ProcessQueuedAccessRequest(content::WebContents* web_contents);
+   void OnMediaStreamRequestResponse(
+       content::WebContents* web_contents,
+-      int request_id,
++      int64_t request_id,
+       content::MediaStreamRequest request,
+       const blink::MediaStreamDevices& devices,
+       blink::mojom::MediaStreamRequestResult result,
+@@ -64,7 +66,7 @@
+       ContentSetting audio_setting,
+       ContentSetting video_setting);
+   void OnAccessRequestResponse(content::WebContents* web_contents,
+-                               int request_id,
++                               int64_t request_id,
+                                const blink::MediaStreamDevices& devices,
+                                blink::mojom::MediaStreamRequestResult result,
+                                std::unique_ptr<content::MediaStreamUI> ui);
+@@ -74,7 +76,7 @@
+                const content::NotificationSource& source,
+                const content::NotificationDetails& details) override;
+ 
+-  int next_request_id_ = 0;
++  int64_t next_request_id_ = 0;
+   RequestsMaps pending_requests_;
+   content::NotificationRegistrar notifications_registrar_;
+ 

--- a/patches/chromium/cherry-pick-a152ce495f8f.patch
+++ b/patches/chromium/cherry-pick-a152ce495f8f.patch
@@ -1,7 +1,7 @@
-From a152ce495f8f69bbf473d56bcbc205c94c57406b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Guido Urdaneta <guidou@chromium.org>
 Date: Tue, 13 Apr 2021 16:04:59 +0000
-Subject: [PATCH] Make request IDs 64 bit in PermissionBubbleMediaAccessHandler
+Subject: Make request IDs 64 bit in PermissionBubbleMediaAccessHandler
 
 This is expected to prevent potential overflows.
 
@@ -21,13 +21,12 @@ Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
 Commit-Queue: Jana Grill <janagrill@chromium.org>
 Cr-Commit-Position: refs/branch-heads/4240@{#1599}
 Cr-Branched-From: f297677702651916bbf65e59c0d4bbd4ce57d1ee-refs/heads/master@{#800218}
----
 
 diff --git a/chrome/browser/media/webrtc/permission_bubble_media_access_handler.cc b/chrome/browser/media/webrtc/permission_bubble_media_access_handler.cc
-index fe81c15..5a39005 100644
+index 9e580a8037ad57f8631972d31cb92f0e77f3a2d9..0b20f65478e5739a5721ae57bc6c0056c353019d 100644
 --- a/chrome/browser/media/webrtc/permission_bubble_media_access_handler.cc
 +++ b/chrome/browser/media/webrtc/permission_bubble_media_access_handler.cc
-@@ -229,7 +229,7 @@
+@@ -228,7 +228,7 @@ void PermissionBubbleMediaAccessHandler::ProcessQueuedAccessRequest(
  
    DCHECK(!it->second.empty());
  
@@ -36,7 +35,7 @@ index fe81c15..5a39005 100644
    const content::MediaStreamRequest& request =
        it->second.begin()->second.request;
  #if defined(OS_ANDROID)
-@@ -290,7 +290,7 @@
+@@ -289,7 +289,7 @@ void PermissionBubbleMediaAccessHandler::RegisterProfilePrefs(
  
  void PermissionBubbleMediaAccessHandler::OnMediaStreamRequestResponse(
      content::WebContents* web_contents,
@@ -45,7 +44,7 @@ index fe81c15..5a39005 100644
      content::MediaStreamRequest request,
      const blink::MediaStreamDevices& devices,
      blink::mojom::MediaStreamRequestResult result,
-@@ -322,7 +322,7 @@
+@@ -321,7 +321,7 @@ void PermissionBubbleMediaAccessHandler::OnMediaStreamRequestResponse(
  
  void PermissionBubbleMediaAccessHandler::OnAccessRequestResponse(
      content::WebContents* web_contents,
@@ -55,7 +54,7 @@ index fe81c15..5a39005 100644
      blink::mojom::MediaStreamRequestResult result,
      std::unique_ptr<content::MediaStreamUI> ui) {
 diff --git a/chrome/browser/media/webrtc/permission_bubble_media_access_handler.h b/chrome/browser/media/webrtc/permission_bubble_media_access_handler.h
-index dabea7e..01dbbec 100644
+index dabea7e16a4395a08d1e71030b7d2c0bd882415c..01dbbeccbcd891891d2908aad84f22c22d580d60 100644
 --- a/chrome/browser/media/webrtc/permission_bubble_media_access_handler.h
 +++ b/chrome/browser/media/webrtc/permission_bubble_media_access_handler.h
 @@ -5,6 +5,8 @@
@@ -67,7 +66,7 @@ index dabea7e..01dbbec 100644
  #include <map>
  
  #include "base/memory/weak_ptr.h"
-@@ -50,13 +52,13 @@
+@@ -50,13 +52,13 @@ class PermissionBubbleMediaAccessHandler
  
   private:
    struct PendingAccessRequest;
@@ -83,7 +82,7 @@ index dabea7e..01dbbec 100644
        content::MediaStreamRequest request,
        const blink::MediaStreamDevices& devices,
        blink::mojom::MediaStreamRequestResult result,
-@@ -64,7 +66,7 @@
+@@ -64,7 +66,7 @@ class PermissionBubbleMediaAccessHandler
        ContentSetting audio_setting,
        ContentSetting video_setting);
    void OnAccessRequestResponse(content::WebContents* web_contents,
@@ -92,7 +91,7 @@ index dabea7e..01dbbec 100644
                                 const blink::MediaStreamDevices& devices,
                                 blink::mojom::MediaStreamRequestResult result,
                                 std::unique_ptr<content::MediaStreamUI> ui);
-@@ -74,7 +76,7 @@
+@@ -74,7 +76,7 @@ class PermissionBubbleMediaAccessHandler
                 const content::NotificationSource& source,
                 const content::NotificationDetails& details) override;
  


### PR DESCRIPTION
Make request IDs 64 bit in PermissionBubbleMediaAccessHandler

This is expected to prevent potential overflows.

(cherry picked from commit b29987b9d50e085a5aefc8d48ad3e4446aaee51e)

Bug: 1178032
Change-Id: I7422958f66b26f99b2dcfe9f8d3ba0fe796cd8a2
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2797413
Auto-Submit: Guido Urdaneta <guidou@chromium.org>
Reviewed-by: Elad Alon <eladalon@chromium.org>
Commit-Queue: Guido Urdaneta <guidou@chromium.org>
Cr-Original-Commit-Position: refs/heads/master@{#868216}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2822148
Reviewed-by: Guido Urdaneta <guidou@chromium.org>
Reviewed-by: Achuith Bhandarkar <achuith@chromium.org>
Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
Commit-Queue: Jana Grill <janagrill@chromium.org>
Cr-Commit-Position: refs/branch-heads/4240@{#1599}
Cr-Branched-From: f297677702651916bbf65e59c0d4bbd4ce57d1ee-refs/heads/master@{#800218}


Notes: Security: backported fix for 1178032.