### PR TITLE
build: disable pseudolocales in Electron

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -22,7 +22,8 @@ dawn_enable_vulkan_validation_layers = false
 # This breaks native node modules
 libcxx_abi_unstable = false
 
-# Electron does not use these.
+# These are disabled because they cause the zip manifest to differ between
+# testing and release builds.
 # See https://chromium-review.googlesource.com/c/chromium/src/+/2774898.
 enable_pseudolocales = false
 

--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -22,4 +22,8 @@ dawn_enable_vulkan_validation_layers = false
 # This breaks native node modules
 libcxx_abi_unstable = false
 
+# Electron does not use these.
+# See https://chromium-review.googlesource.com/c/chromium/src/+/2774898.
+enable_pseudolocales = false
+
 is_cfi = false

--- a/script/zip_manifests/dist_zip.linux.arm.manifest
+++ b/script/zip_manifests/dist_zip.linux.arm.manifest
@@ -12,7 +12,6 @@ libvk_swiftshader.so
 libvulkan.so.1
 locales/am.pak
 locales/ar.pak
-locales/ar-XB.pak
 locales/bg.pak
 locales/bn.pak
 locales/ca.pak
@@ -22,7 +21,6 @@ locales/de.pak
 locales/el.pak
 locales/en-GB.pak
 locales/en-US.pak
-locales/en-XA.pak
 locales/es-419.pak
 locales/es.pak
 locales/et.pak

--- a/script/zip_manifests/dist_zip.linux.arm64.manifest
+++ b/script/zip_manifests/dist_zip.linux.arm64.manifest
@@ -12,7 +12,6 @@ libvk_swiftshader.so
 libvulkan.so.1
 locales/am.pak
 locales/ar.pak
-locales/ar-XB.pak
 locales/bg.pak
 locales/bn.pak
 locales/ca.pak
@@ -22,7 +21,6 @@ locales/de.pak
 locales/el.pak
 locales/en-GB.pak
 locales/en-US.pak
-locales/en-XA.pak
 locales/es-419.pak
 locales/es.pak
 locales/et.pak

--- a/script/zip_manifests/dist_zip.linux.x64.manifest
+++ b/script/zip_manifests/dist_zip.linux.x64.manifest
@@ -12,7 +12,6 @@ libvk_swiftshader.so
 libvulkan.so.1
 locales/am.pak
 locales/ar.pak
-locales/ar-XB.pak
 locales/bg.pak
 locales/bn.pak
 locales/ca.pak
@@ -22,7 +21,6 @@ locales/de.pak
 locales/el.pak
 locales/en-GB.pak
 locales/en-US.pak
-locales/en-XA.pak
 locales/es-419.pak
 locales/es.pak
 locales/et.pak

--- a/script/zip_manifests/dist_zip.linux.x86.manifest
+++ b/script/zip_manifests/dist_zip.linux.x86.manifest
@@ -12,7 +12,6 @@ libvk_swiftshader.so
 libvulkan.so.1
 locales/am.pak
 locales/ar.pak
-locales/ar-XB.pak
 locales/bg.pak
 locales/bn.pak
 locales/ca.pak
@@ -22,7 +21,6 @@ locales/de.pak
 locales/el.pak
 locales/en-GB.pak
 locales/en-US.pak
-locales/en-XA.pak
 locales/es-419.pak
 locales/es.pak
 locales/et.pak

--- a/script/zip_manifests/dist_zip.mac.arm64.manifest
+++ b/script/zip_manifests/dist_zip.mac.arm64.manifest
@@ -26,8 +26,6 @@ Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resourc
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/am.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/ar.lproj/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/ar.lproj/locale.pak
-Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/ar_XB.lproj/
-Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/ar_XB.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/bg.lproj/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/bg.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/bn.lproj/
@@ -48,8 +46,6 @@ Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resourc
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/en.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/en_GB.lproj/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/en_GB.lproj/locale.pak
-Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/en_XA.lproj/
-Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/en_XA.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/es.lproj/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/es.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/es_419.lproj/
@@ -197,7 +193,6 @@ Electron.app/Contents/PkgInfo
 Electron.app/Contents/Resources/
 Electron.app/Contents/Resources/am.lproj/
 Electron.app/Contents/Resources/ar.lproj/
-Electron.app/Contents/Resources/ar_XB.lproj/
 Electron.app/Contents/Resources/bg.lproj/
 Electron.app/Contents/Resources/bn.lproj/
 Electron.app/Contents/Resources/ca.lproj/
@@ -209,7 +204,6 @@ Electron.app/Contents/Resources/el.lproj/
 Electron.app/Contents/Resources/electron.icns
 Electron.app/Contents/Resources/en.lproj/
 Electron.app/Contents/Resources/en_GB.lproj/
-Electron.app/Contents/Resources/en_XA.lproj/
 Electron.app/Contents/Resources/es.lproj/
 Electron.app/Contents/Resources/es_419.lproj/
 Electron.app/Contents/Resources/et.lproj/

--- a/script/zip_manifests/dist_zip.mac.x64.manifest
+++ b/script/zip_manifests/dist_zip.mac.x64.manifest
@@ -26,8 +26,6 @@ Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resourc
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/am.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/ar.lproj/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/ar.lproj/locale.pak
-Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/ar_XB.lproj/
-Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/ar_XB.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/bg.lproj/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/bg.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/bn.lproj/
@@ -48,8 +46,6 @@ Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resourc
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/en.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/en_GB.lproj/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/en_GB.lproj/locale.pak
-Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/en_XA.lproj/
-Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/en_XA.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/es.lproj/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/es.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/es_419.lproj/
@@ -197,7 +193,6 @@ Electron.app/Contents/PkgInfo
 Electron.app/Contents/Resources/
 Electron.app/Contents/Resources/am.lproj/
 Electron.app/Contents/Resources/ar.lproj/
-Electron.app/Contents/Resources/ar_XB.lproj/
 Electron.app/Contents/Resources/bg.lproj/
 Electron.app/Contents/Resources/bn.lproj/
 Electron.app/Contents/Resources/ca.lproj/
@@ -209,7 +204,6 @@ Electron.app/Contents/Resources/el.lproj/
 Electron.app/Contents/Resources/electron.icns
 Electron.app/Contents/Resources/en.lproj/
 Electron.app/Contents/Resources/en_GB.lproj/
-Electron.app/Contents/Resources/en_XA.lproj/
 Electron.app/Contents/Resources/es.lproj/
 Electron.app/Contents/Resources/es_419.lproj/
 Electron.app/Contents/Resources/et.lproj/

--- a/script/zip_manifests/dist_zip.mac_mas.arm64.manifest
+++ b/script/zip_manifests/dist_zip.mac_mas.arm64.manifest
@@ -23,8 +23,6 @@ Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resourc
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/am.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/ar.lproj/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/ar.lproj/locale.pak
-Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/ar_XB.lproj/
-Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/ar_XB.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/bg.lproj/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/bg.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/bn.lproj/
@@ -45,8 +43,6 @@ Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resourc
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/en.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/en_GB.lproj/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/en_GB.lproj/locale.pak
-Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/en_XA.lproj/
-Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/en_XA.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/es.lproj/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/es.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/es_419.lproj/
@@ -174,7 +170,6 @@ Electron.app/Contents/PkgInfo
 Electron.app/Contents/Resources/
 Electron.app/Contents/Resources/am.lproj/
 Electron.app/Contents/Resources/ar.lproj/
-Electron.app/Contents/Resources/ar_XB.lproj/
 Electron.app/Contents/Resources/bg.lproj/
 Electron.app/Contents/Resources/bn.lproj/
 Electron.app/Contents/Resources/ca.lproj/
@@ -186,7 +181,6 @@ Electron.app/Contents/Resources/el.lproj/
 Electron.app/Contents/Resources/electron.icns
 Electron.app/Contents/Resources/en.lproj/
 Electron.app/Contents/Resources/en_GB.lproj/
-Electron.app/Contents/Resources/en_XA.lproj/
 Electron.app/Contents/Resources/es.lproj/
 Electron.app/Contents/Resources/es_419.lproj/
 Electron.app/Contents/Resources/et.lproj/

--- a/script/zip_manifests/dist_zip.mac_mas.x64.manifest
+++ b/script/zip_manifests/dist_zip.mac_mas.x64.manifest
@@ -23,8 +23,6 @@ Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resourc
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/am.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/ar.lproj/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/ar.lproj/locale.pak
-Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/ar_XB.lproj/
-Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/ar_XB.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/bg.lproj/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/bg.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/bn.lproj/
@@ -45,8 +43,6 @@ Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resourc
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/en.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/en_GB.lproj/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/en_GB.lproj/locale.pak
-Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/en_XA.lproj/
-Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/en_XA.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/es.lproj/
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/es.lproj/locale.pak
 Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/es_419.lproj/
@@ -174,7 +170,6 @@ Electron.app/Contents/PkgInfo
 Electron.app/Contents/Resources/
 Electron.app/Contents/Resources/am.lproj/
 Electron.app/Contents/Resources/ar.lproj/
-Electron.app/Contents/Resources/ar_XB.lproj/
 Electron.app/Contents/Resources/bg.lproj/
 Electron.app/Contents/Resources/bn.lproj/
 Electron.app/Contents/Resources/ca.lproj/
@@ -186,7 +181,6 @@ Electron.app/Contents/Resources/el.lproj/
 Electron.app/Contents/Resources/electron.icns
 Electron.app/Contents/Resources/en.lproj/
 Electron.app/Contents/Resources/en_GB.lproj/
-Electron.app/Contents/Resources/en_XA.lproj/
 Electron.app/Contents/Resources/es.lproj/
 Electron.app/Contents/Resources/es_419.lproj/
 Electron.app/Contents/Resources/et.lproj/

--- a/script/zip_manifests/dist_zip.win.arm64.manifest
+++ b/script/zip_manifests/dist_zip.win.arm64.manifest
@@ -9,7 +9,6 @@ libEGL.dll
 libGLESv2.dll
 locales/am.pak
 locales/ar.pak
-locales/ar-XB.pak
 locales/bg.pak
 locales/bn.pak
 locales/ca.pak
@@ -19,7 +18,6 @@ locales/de.pak
 locales/el.pak
 locales/en-GB.pak
 locales/en-US.pak
-locales/en-XA.pak
 locales/es-419.pak
 locales/es.pak
 locales/et.pak

--- a/script/zip_manifests/dist_zip.win.ia32.manifest
+++ b/script/zip_manifests/dist_zip.win.ia32.manifest
@@ -10,7 +10,6 @@ libEGL.dll
 libGLESv2.dll
 locales/am.pak
 locales/ar.pak
-locales/ar-XB.pak
 locales/bg.pak
 locales/bn.pak
 locales/ca.pak
@@ -20,7 +19,6 @@ locales/de.pak
 locales/el.pak
 locales/en-GB.pak
 locales/en-US.pak
-locales/en-XA.pak
 locales/es-419.pak
 locales/es.pak
 locales/et.pak

--- a/script/zip_manifests/dist_zip.win.x64.manifest
+++ b/script/zip_manifests/dist_zip.win.x64.manifest
@@ -10,7 +10,6 @@ libEGL.dll
 libGLESv2.dll
 locales/am.pak
 locales/ar.pak
-locales/ar-XB.pak
 locales/bg.pak
 locales/bn.pak
 locales/ca.pak
@@ -20,7 +19,6 @@ locales/de.pak
 locales/el.pak
 locales/en-GB.pak
 locales/en-US.pak
-locales/en-XA.pak
 locales/es-419.pak
 locales/es.pak
 locales/et.pak


### PR DESCRIPTION
#### Description of Change

Remove pseudocode locales from Electron, which were added in https://chromium-review.googlesource.com/c/chromium/src/+/2774898 and rolled in https://github.com/electron/electron/pull/28462. We don't use these.  

See https://electronhq.slack.com/archives/CC8J5QC00/p1618961550011900?thread_ts=1618932845.005500&cid=CC8J5QC00.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none