### PR TITLE
docs: fix unintentional emoji in win.getMediaSourceId description

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1292,7 +1292,7 @@ can be be used to listen to changes to tablet mode.
 
 #### `win.getMediaSourceId()`
 
-Returns `String` - Window id in the format of DesktopCapturerSource's id. For example "window:1234:0".
+Returns `String` - Window id in the format of DesktopCapturerSource's id. For example "window:1324:0".
 
 More precisely the format is `window:id:other_id` where `id` is `HWND` on
 Windows, `CGWindowID` (`uint64_t`) on macOS and `Window` (`unsigned long`) on


### PR DESCRIPTION
#### Description of Change
This was showing up as 🔢  in https://www.electronjs.org/docs/api/browser-window#wingetmediasourceid.

Notes: none