### PR TITLE
refactor: plumb RFH instead of RPH for notifications

### DIFF
--- a/patches/chromium/disable_color_correct_rendering.patch
+++ b/patches/chromium/disable_color_correct_rendering.patch
@@ -241,7 +241,7 @@ index ed098dec8efc5e5c72dbdbc8e17f1cb5da9f1b1f..a831cd8c40be9f6ac8b63ee702ec2baa
      sandbox::policy::switches::kGpuSandboxAllowSysVShm,
      sandbox::policy::switches::kGpuSandboxFailuresFatal,
 diff --git a/content/browser/renderer_host/render_process_host_impl.cc b/content/browser/renderer_host/render_process_host_impl.cc
-index 33a32d24aa83f655173e532119c3cf3bf18f5f19..6a3b1d9219bd186eae3a3f330cfc03547cdb41ef 100644
+index 5730c695f3106573953c131b6721baabcfbc4226..45046b2d1651ef56c68e59fade9206a71c92fffa 100644
 --- a/content/browser/renderer_host/render_process_host_impl.cc
 +++ b/content/browser/renderer_host/render_process_host_impl.cc
 @@ -212,6 +212,7 @@

--- a/patches/chromium/disable_color_correct_rendering.patch
+++ b/patches/chromium/disable_color_correct_rendering.patch
@@ -241,7 +241,7 @@ index ed098dec8efc5e5c72dbdbc8e17f1cb5da9f1b1f..a831cd8c40be9f6ac8b63ee702ec2baa
      sandbox::policy::switches::kGpuSandboxAllowSysVShm,
      sandbox::policy::switches::kGpuSandboxFailuresFatal,
 diff --git a/content/browser/renderer_host/render_process_host_impl.cc b/content/browser/renderer_host/render_process_host_impl.cc
-index f8772bc8d7e4d54922940601e895cdcf88b53cf1..7141504d8ef33256b21b998130b941228c49fc71 100644
+index 33a32d24aa83f655173e532119c3cf3bf18f5f19..6a3b1d9219bd186eae3a3f330cfc03547cdb41ef 100644
 --- a/content/browser/renderer_host/render_process_host_impl.cc
 +++ b/content/browser/renderer_host/render_process_host_impl.cc
 @@ -212,6 +212,7 @@

--- a/patches/chromium/notification_provenance.patch
+++ b/patches/chromium/notification_provenance.patch
@@ -7,19 +7,19 @@ Pass RenderProcessHost through to PlatformNotificationService
 so Electron can identify which renderer a notification came from.
 
 diff --git a/content/browser/notifications/blink_notification_service_impl.cc b/content/browser/notifications/blink_notification_service_impl.cc
-index cd1f69dfbc76c78411de953c6b2ff7146a323cca..bcd2bd4014fc88a36127cc50ebacec344de4502e 100644
+index cbb8ca59d8609daa4b030e2df6714c1bba7d1cb6..c3d64098df46a1d0165ca758fdb2ca6c88bcf59b 100644
 --- a/content/browser/notifications/blink_notification_service_impl.cc
 +++ b/content/browser/notifications/blink_notification_service_impl.cc
 @@ -89,10 +89,12 @@ BlinkNotificationServiceImpl::BlinkNotificationServiceImpl(
      PlatformNotificationContextImpl* notification_context,
      BrowserContext* browser_context,
      scoped_refptr<ServiceWorkerContextWrapper> service_worker_context,
-+    RenderProcessHost* render_process_host,
++    RenderFrameHost* render_frame_host,
      const url::Origin& origin,
      const GURL& document_url,
      mojo::PendingReceiver<blink::mojom::NotificationService> receiver)
      : notification_context_(notification_context),
-+      render_process_host_(render_process_host),
++      render_frame_host_(render_frame_host),
        browser_context_(browser_context),
        service_worker_context_(std::move(service_worker_context)),
        origin_(origin),
@@ -28,20 +28,20 @@ index cd1f69dfbc76c78411de953c6b2ff7146a323cca..bcd2bd4014fc88a36127cc50ebacec34
  
    GetNotificationService(browser_context_)
 -      ->DisplayNotification(notification_id, origin_.GetURL(), document_url_,
-+      ->DisplayNotification(render_process_host_, notification_id,
++      ->DisplayNotification(render_frame_host_, notification_id,
 +                            origin_.GetURL(), document_url_,
                              platform_notification_data, notification_resources);
  }
  
 diff --git a/content/browser/notifications/blink_notification_service_impl.h b/content/browser/notifications/blink_notification_service_impl.h
-index 19c2beb1f1949f0dc4466a8728f151c035544b24..1c5684c0e5d7957594753de9747144cbc25f2fc8 100644
+index 65421fdadca07e0c4250c8e36023aa730500e5d1..232bb1ab2ba5da865fdf41a0f746958feabb7a2e 100644
 --- a/content/browser/notifications/blink_notification_service_impl.h
 +++ b/content/browser/notifications/blink_notification_service_impl.h
 @@ -41,6 +41,7 @@ class CONTENT_EXPORT BlinkNotificationServiceImpl
        PlatformNotificationContextImpl* notification_context,
        BrowserContext* browser_context,
        scoped_refptr<ServiceWorkerContextWrapper> service_worker_context,
-+      RenderProcessHost* render_process_host,
++      RenderFrameHost* render_frame_host,
        const url::Origin& origin,
        const GURL& document_url,
        mojo::PendingReceiver<blink::mojom::NotificationService> receiver);
@@ -49,7 +49,7 @@ index 19c2beb1f1949f0dc4466a8728f151c035544b24..1c5684c0e5d7957594753de9747144cb
    // The notification context that owns this service instance.
    PlatformNotificationContextImpl* notification_context_;
  
-+  RenderProcessHost* render_process_host_;
++  RenderFrameHost* render_frame_host_;
    BrowserContext* browser_context_;
  
    scoped_refptr<ServiceWorkerContextWrapper> service_worker_context_;
@@ -67,14 +67,14 @@ index e27c23e0aeaf08c903c2fc1f7cb0b24d137b9a7a..4768449379941021c9c2fd388040b753
          /*document_url=*/GURL(),
          notification_service_remote_.BindNewPipeAndPassReceiver());
 diff --git a/content/browser/notifications/platform_notification_context_impl.cc b/content/browser/notifications/platform_notification_context_impl.cc
-index 8db550c4d38132b062eac6eca7862b113de6c780..b53c4a96e482512aeb4bcec2a909b019041d48be 100644
+index 8db550c4d38132b062eac6eca7862b113de6c780..edb5fbd27e4503984a21a310e0ea26395d10b6ab 100644
 --- a/content/browser/notifications/platform_notification_context_impl.cc
 +++ b/content/browser/notifications/platform_notification_context_impl.cc
 @@ -284,13 +284,14 @@ void PlatformNotificationContextImpl::Shutdown() {
  }
  
  void PlatformNotificationContextImpl::CreateService(
-+    RenderProcessHost* render_process_host,
++    RenderFrameHost* render_frame_host,
      const url::Origin& origin,
      const GURL& document_url,
      mojo::PendingReceiver<blink::mojom::NotificationService> receiver) {
@@ -82,33 +82,33 @@ index 8db550c4d38132b062eac6eca7862b113de6c780..b53c4a96e482512aeb4bcec2a909b019
    services_.push_back(std::make_unique<BlinkNotificationServiceImpl>(
 -      this, browser_context_, service_worker_context_, origin, document_url,
 -      std::move(receiver)));
-+      this, browser_context_, service_worker_context_, render_process_host,
++      this, browser_context_, service_worker_context_, render_frame_host,
 +      origin, document_url, std::move(receiver)));
  }
  
  void PlatformNotificationContextImpl::RemoveService(
 diff --git a/content/browser/notifications/platform_notification_context_impl.h b/content/browser/notifications/platform_notification_context_impl.h
-index 71dad766e05ac4726e1e18159f2af5ea01079a91..ff4a73c5e3f9ae8214ebaa3da6c8494a19fefa14 100644
+index 71dad766e05ac4726e1e18159f2af5ea01079a91..ef8e55a4420288fe64c99e68d0a649a9f31a49f8 100644
 --- a/content/browser/notifications/platform_notification_context_impl.h
 +++ b/content/browser/notifications/platform_notification_context_impl.h
-@@ -24,6 +24,7 @@
- #include "content/common/content_export.h"
- #include "content/public/browser/browser_thread.h"
- #include "content/public/browser/platform_notification_context.h"
-+#include "content/public/browser/render_process_host.h"
- #include "mojo/public/cpp/bindings/pending_receiver.h"
- #include "third_party/blink/public/mojom/notifications/notification_service.mojom.h"
+@@ -44,6 +44,7 @@ class BrowserContext;
+ struct NotificationDatabaseData;
+ class PlatformNotificationServiceProxy;
+ class ServiceWorkerContextWrapper;
++class RenderFrameHost;
  
+ // Implementation of the Web Notification storage context. The public methods
+ // defined in this interface must only be called on the UI thread.
 @@ -68,6 +69,7 @@ class CONTENT_EXPORT PlatformNotificationContextImpl
    // Creates a BlinkNotificationServiceImpl that is owned by this context.
    // |document_url| is empty when originating from a worker.
    void CreateService(
-+      RenderProcessHost* render_process_host,
++      RenderFrameHost* render_frame_host,
        const url::Origin& origin,
        const GURL& document_url,
        mojo::PendingReceiver<blink::mojom::NotificationService> receiver);
 diff --git a/content/browser/renderer_host/render_process_host_impl.cc b/content/browser/renderer_host/render_process_host_impl.cc
-index 7f27667bd444e8b6f081c02a8a30aecdd937b122..8b84c49749366c72fe865534cf06f4bf1842e2bd 100644
+index 554f859f2c46829ede73b6cb05a84d26db3e9e70..d11f9a273511d8ee75381d603835c7111cd7ce50 100644
 --- a/content/browser/renderer_host/render_process_host_impl.cc
 +++ b/content/browser/renderer_host/render_process_host_impl.cc
 @@ -2123,7 +2123,7 @@ void RenderProcessHostImpl::CreateNotificationService(
@@ -116,12 +116,12 @@ index 7f27667bd444e8b6f081c02a8a30aecdd937b122..8b84c49749366c72fe865534cf06f4bf
  
    storage_partition_impl_->GetPlatformNotificationContext()->CreateService(
 -      origin, document_url, std::move(receiver));
-+      this, origin, document_url, std::move(receiver));
++      RenderFrameHost::FromID(GetID(), render_frame_id), origin, document_url, std::move(receiver));
  }
  
  void RenderProcessHostImpl::CreateWebSocketConnector(
 diff --git a/content/public/browser/platform_notification_service.h b/content/public/browser/platform_notification_service.h
-index 9646cbeb31141e3518f51482801431f3a6010360..ff5663ca9057f548d85d407ef98bc90e796d94bf 100644
+index 9646cbeb31141e3518f51482801431f3a6010360..adc98738fe0d102233cb2b8ef04fe6e2a789a4d5 100644
 --- a/content/public/browser/platform_notification_service.h
 +++ b/content/public/browser/platform_notification_service.h
 @@ -26,6 +26,8 @@ struct PlatformNotificationData;
@@ -137,7 +137,7 @@ index 9646cbeb31141e3518f51482801431f3a6010360..ff5663ca9057f548d85d407ef98bc90e
    // This method must be called on the UI thread. |document_url| is empty when
    // the display notification originates from a worker.
    virtual void DisplayNotification(
-+      RenderProcessHost* render_process_host,
++      RenderFrameHost* render_frame_host,
        const std::string& notification_id,
        const GURL& origin,
        const GURL& document_url,

--- a/patches/chromium/notification_provenance.patch
+++ b/patches/chromium/notification_provenance.patch
@@ -7,7 +7,7 @@ Pass RenderProcessHost through to PlatformNotificationService
 so Electron can identify which renderer a notification came from.
 
 diff --git a/content/browser/notifications/blink_notification_service_impl.cc b/content/browser/notifications/blink_notification_service_impl.cc
-index cbb8ca59d8609daa4b030e2df6714c1bba7d1cb6..c3d64098df46a1d0165ca758fdb2ca6c88bcf59b 100644
+index cd1f69dfbc76c78411de953c6b2ff7146a323cca..4526b0e632205809858cdc8a88ad973024b63c5d 100644
 --- a/content/browser/notifications/blink_notification_service_impl.cc
 +++ b/content/browser/notifications/blink_notification_service_impl.cc
 @@ -89,10 +89,12 @@ BlinkNotificationServiceImpl::BlinkNotificationServiceImpl(
@@ -34,7 +34,7 @@ index cbb8ca59d8609daa4b030e2df6714c1bba7d1cb6..c3d64098df46a1d0165ca758fdb2ca6c
  }
  
 diff --git a/content/browser/notifications/blink_notification_service_impl.h b/content/browser/notifications/blink_notification_service_impl.h
-index 65421fdadca07e0c4250c8e36023aa730500e5d1..232bb1ab2ba5da865fdf41a0f746958feabb7a2e 100644
+index 19c2beb1f1949f0dc4466a8728f151c035544b24..f7aa5f94d6dea0e6b2c1107b8ef01600bf13903b 100644
 --- a/content/browser/notifications/blink_notification_service_impl.h
 +++ b/content/browser/notifications/blink_notification_service_impl.h
 @@ -41,6 +41,7 @@ class CONTENT_EXPORT BlinkNotificationServiceImpl
@@ -108,7 +108,7 @@ index 71dad766e05ac4726e1e18159f2af5ea01079a91..ef8e55a4420288fe64c99e68d0a649a9
        const GURL& document_url,
        mojo::PendingReceiver<blink::mojom::NotificationService> receiver);
 diff --git a/content/browser/renderer_host/render_process_host_impl.cc b/content/browser/renderer_host/render_process_host_impl.cc
-index 554f859f2c46829ede73b6cb05a84d26db3e9e70..d11f9a273511d8ee75381d603835c7111cd7ce50 100644
+index 7f27667bd444e8b6f081c02a8a30aecdd937b122..9a57706a1f1cfaad240cd1ccc626b548e4c9e0f6 100644
 --- a/content/browser/renderer_host/render_process_host_impl.cc
 +++ b/content/browser/renderer_host/render_process_host_impl.cc
 @@ -2123,7 +2123,7 @@ void RenderProcessHostImpl::CreateNotificationService(
@@ -121,14 +121,14 @@ index 554f859f2c46829ede73b6cb05a84d26db3e9e70..d11f9a273511d8ee75381d603835c711
  
  void RenderProcessHostImpl::CreateWebSocketConnector(
 diff --git a/content/public/browser/platform_notification_service.h b/content/public/browser/platform_notification_service.h
-index 9646cbeb31141e3518f51482801431f3a6010360..adc98738fe0d102233cb2b8ef04fe6e2a789a4d5 100644
+index 9646cbeb31141e3518f51482801431f3a6010360..b13b6ab07b4931b892749c84879d9a6adb3bcb58 100644
 --- a/content/public/browser/platform_notification_service.h
 +++ b/content/public/browser/platform_notification_service.h
 @@ -26,6 +26,8 @@ struct PlatformNotificationData;
  
  namespace content {
  
-+class RenderProcessHost;
++class RenderFrameHost;
 +
  // The service using which notifications can be presented to the user. There
  // should be a unique instance of the PlatformNotificationService depending

--- a/patches/chromium/support_mixed_sandbox_with_zygote.patch
+++ b/patches/chromium/support_mixed_sandbox_with_zygote.patch
@@ -22,7 +22,7 @@ However, the patch would need to be reviewed by the security team, as it
 does touch a security-sensitive class.
 
 diff --git a/content/browser/renderer_host/render_process_host_impl.cc b/content/browser/renderer_host/render_process_host_impl.cc
-index 8b84c49749366c72fe865534cf06f4bf1842e2bd..f8772bc8d7e4d54922940601e895cdcf88b53cf1 100644
+index d11f9a273511d8ee75381d603835c7111cd7ce50..33a32d24aa83f655173e532119c3cf3bf18f5f19 100644
 --- a/content/browser/renderer_host/render_process_host_impl.cc
 +++ b/content/browser/renderer_host/render_process_host_impl.cc
 @@ -389,10 +389,18 @@ class RendererSandboxedProcessLauncherDelegate

--- a/patches/chromium/support_mixed_sandbox_with_zygote.patch
+++ b/patches/chromium/support_mixed_sandbox_with_zygote.patch
@@ -22,7 +22,7 @@ However, the patch would need to be reviewed by the security team, as it
 does touch a security-sensitive class.
 
 diff --git a/content/browser/renderer_host/render_process_host_impl.cc b/content/browser/renderer_host/render_process_host_impl.cc
-index d11f9a273511d8ee75381d603835c7111cd7ce50..33a32d24aa83f655173e532119c3cf3bf18f5f19 100644
+index 9a57706a1f1cfaad240cd1ccc626b548e4c9e0f6..5730c695f3106573953c131b6721baabcfbc4226 100644
 --- a/content/browser/renderer_host/render_process_host_impl.cc
 +++ b/content/browser/renderer_host/render_process_host_impl.cc
 @@ -389,10 +389,18 @@ class RendererSandboxedProcessLauncherDelegate

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -861,10 +861,10 @@ ElectronBrowserClient::CreateBrowserMainParts(
 }
 
 void ElectronBrowserClient::WebNotificationAllowed(
-    int render_process_id,
+    content::RenderFrameHost* rfh,
     base::OnceCallback<void(bool, bool)> callback) {
   content::WebContents* web_contents =
-      WebContentsPreferences::GetWebContentsFromProcessID(render_process_id);
+      content::WebContents::FromRenderFrameHost(rfh);
   if (!web_contents) {
     std::move(callback).Run(false, false);
     return;

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -54,7 +54,7 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
 
   NotificationPresenter* GetNotificationPresenter();
 
-  void WebNotificationAllowed(int render_process_id,
+  void WebNotificationAllowed(content::RenderFrameHost* rfh,
                               base::OnceCallback<void(bool, bool)> callback);
 
   // content::NavigatorDelegate

--- a/shell/browser/notifications/platform_notification_service.cc
+++ b/shell/browser/notifications/platform_notification_service.cc
@@ -78,7 +78,7 @@ PlatformNotificationService::PlatformNotificationService(
 PlatformNotificationService::~PlatformNotificationService() = default;
 
 void PlatformNotificationService::DisplayNotification(
-    content::RenderProcessHost* render_process_host,
+    content::RenderFrameHost* render_frame_host,
     const std::string& notification_id,
     const GURL& origin,
     const GURL& document_url,
@@ -102,7 +102,7 @@ void PlatformNotificationService::DisplayNotification(
   auto notification = presenter->CreateNotification(delegate, notification_id);
   if (notification) {
     browser_client_->WebNotificationAllowed(
-        render_process_host->GetID(),
+        render_frame_host,
         base::BindRepeating(&OnWebNotificationAllowed, notification,
                             notification_resources.notification_icon,
                             notification_data));

--- a/shell/browser/notifications/platform_notification_service.h
+++ b/shell/browser/notifications/platform_notification_service.h
@@ -23,7 +23,7 @@ class PlatformNotificationService
  protected:
   // content::PlatformNotificationService:
   void DisplayNotification(
-      content::RenderProcessHost* render_process_host,
+      content::RenderFrameHost* render_frame_host,
       const std::string& notification_id,
       const GURL& origin,
       const GURL& document_url,


### PR DESCRIPTION
#### Description of Change
This removes another usage of GetWebContentsFromProcessID, by plumbing the
RenderFrameHost instead of the RenderProcessHost through to
DisplayNotification. Depends on
https://chromium-review.googlesource.com/c/chromium/src/+/2781233 so this is
based on the Chromium roll for now. Will re-target once the roll lands.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)

#### Release Notes

Notes: none
