### PR TITLE
fix: only set backgroundColor in default-app for default index.html

### DIFF
--- a/default_app/default_app.ts
+++ b/default_app/default_app.ts
@@ -41,14 +41,14 @@ ipcMain.handle('bootstrap', (event) => {
   return isTrustedSender(event.sender) ? electronPath : null;
 });
 
-async function createWindow () {
+async function createWindow (backgroundColor?: string) {
   await app.whenReady();
 
   const options: Electron.BrowserWindowConstructorOptions = {
     width: 960,
     height: 620,
     autoHideMenuBar: true,
-    backgroundColor: '#2f3241',
+    backgroundColor,
     webPreferences: {
       preload: path.resolve(__dirname, 'preload.js'),
       contextIsolation: true,
@@ -95,7 +95,7 @@ export const loadURL = async (appUrl: string) => {
 };
 
 export const loadFile = async (appPath: string) => {
-  mainWindow = await createWindow();
+  mainWindow = await createWindow(appPath === 'index.html' ? '#2f3241' : undefined);
   mainWindow.loadFile(appPath);
   mainWindow.focus();
 };


### PR DESCRIPTION
#### Description of Change
We should not set the backgroundColor when opening a custom file / URL in the default-app. Otherwise this happens:
<img width="1072" alt="Screen Shot 2021-04-23 at 3 26 03 AM" src="https://user-images.githubusercontent.com/1281234/115805127-9b66ab00-a3e4-11eb-9509-9a3dc5f7f082.png">
Regression from #22675

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: No longer set backgroundColor in default-app when opening custom files / URLs.