### PR TITLE
chore: cherry-pick d5d222b6ca and 1627015c84 from webrtc

### DIFF
--- a/patches/config.json
+++ b/patches/config.json
@@ -21,5 +21,7 @@
 
   "src/electron/patches/usrsctp": "src/third_party/usrsctp/usrsctplib",
 
-  "src/electron/patches/pdfium": "src/third_party/pdfium"
+  "src/electron/patches/pdfium": "src/third_party/pdfium",
+
+  "src/electron/patches/webrtc": "src/third_party/webrtc"
 }

--- a/patches/webrtc/.patches
+++ b/patches/webrtc/.patches
@@ -1,0 +1,2 @@
+merge_m86_-_fix_race_with_sctptransport_destruction_and_usrsctp.patch
+merge_m86_-_reland_fix_race_between_destroying_sctptransport_and.patch

--- a/patches/webrtc/merge_m86_-_fix_race_with_sctptransport_destruction_and_usrsctp.patch
+++ b/patches/webrtc/merge_m86_-_fix_race_with_sctptransport_destruction_and_usrsctp.patch
@@ -1,0 +1,247 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Taylor Brandstetter <deadbeef@webrtc.org>
+Date: Tue, 13 Apr 2021 16:11:47 -0700
+Subject: [Merge M86] - Fix race with SctpTransport destruction and usrsctp
+ timer thread.
+
+The race occurs if the transport is being destroyed at the same time as
+a callback occurs on the usrsctp timer thread (for example, for a
+retransmission). Fixed by slightly extending the scope of mutex
+acquisition to include posting a task to the network thread, where it's
+safe to do further work.
+
+Bug: chromium:1162424
+Change-Id: Ia25c96fa51cd4ba2d8690ba03de8af9e9f1605ea
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/202560
+Reviewed-by: Harald Alvestrand <hta@webrtc.org>
+Commit-Queue: Taylor <deadbeef@webrtc.org>
+Cr-Original-Commit-Position: refs/heads/master@{#33048}
+No-Try: True
+No-Presubmit: True
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/215101
+Reviewed-by: Mirko Bonadei <mbonadei@webrtc.org>
+Cr-Commit-Position: refs/branch-heads/4240@{#18}
+Cr-Branched-From: 93a9d19d4eb53b3f4fb4d22e6c54f2e2824437eb-refs/heads/master@{#31969}
+
+diff --git a/media/sctp/sctp_transport.cc b/media/sctp/sctp_transport.cc
+index a74c66431c1625bfa0fb9b6b22d504afb48b0d7f..f97568e95c8068e47fa902546c27851475348c87 100644
+--- a/media/sctp/sctp_transport.cc
++++ b/media/sctp/sctp_transport.cc
+@@ -27,6 +27,7 @@ constexpr int kSctpSuccessReturn = 1;
+ #include <stdio.h>
+ #include <usrsctp.h>
+ 
++#include <functional>
+ #include <memory>
+ #include <unordered_map>
+ 
+@@ -79,58 +80,8 @@ enum {
+   PPID_TEXT_LAST = 51
+ };
+ 
+-// Maps SCTP transport ID to SctpTransport object, necessary in send threshold
+-// callback and outgoing packet callback.
+-// TODO(crbug.com/1076703): Remove once the underlying problem is fixed or
+-// workaround is provided in usrsctp.
+-class SctpTransportMap {
+- public:
+-  SctpTransportMap() = default;
+-
+-  // Assigns a new unused ID to the following transport.
+-  uintptr_t Register(cricket::SctpTransport* transport) {
+-    webrtc::MutexLock lock(&lock_);
+-    // usrsctp_connect fails with a value of 0...
+-    if (next_id_ == 0) {
+-      ++next_id_;
+-    }
+-    // In case we've wrapped around and need to find an empty spot from a
+-    // removed transport. Assumes we'll never be full.
+-    while (map_.find(next_id_) != map_.end()) {
+-      ++next_id_;
+-      if (next_id_ == 0) {
+-        ++next_id_;
+-      }
+-    };
+-    map_[next_id_] = transport;
+-    return next_id_++;
+-  }
+-
+-  // Returns true if found.
+-  bool Deregister(uintptr_t id) {
+-    webrtc::MutexLock lock(&lock_);
+-    return map_.erase(id) > 0;
+-  }
+-
+-  cricket::SctpTransport* Retrieve(uintptr_t id) const {
+-    webrtc::MutexLock lock(&lock_);
+-    auto it = map_.find(id);
+-    if (it == map_.end()) {
+-      return nullptr;
+-    }
+-    return it->second;
+-  }
+-
+- private:
+-  mutable webrtc::Mutex lock_;
+-
+-  uintptr_t next_id_ RTC_GUARDED_BY(lock_) = 0;
+-  std::unordered_map<uintptr_t, cricket::SctpTransport*> map_
+-      RTC_GUARDED_BY(lock_);
+-};
+-
+ // Should only be modified by UsrSctpWrapper.
+-ABSL_CONST_INIT SctpTransportMap* g_transport_map_ = nullptr;
++ABSL_CONST_INIT cricket::SctpTransportMap* g_transport_map_ = nullptr;
+ 
+ // Helper for logging SCTP messages.
+ #if defined(__GNUC__)
+@@ -256,6 +207,83 @@ sctp_sendv_spa CreateSctpSendParams(const cricket::SendDataParams& params) {
+ 
+ namespace cricket {
+ 
++// Maps SCTP transport ID to SctpTransport object, necessary in send threshold
++// callback and outgoing packet callback. It also provides a facility to
++// safely post a task to an SctpTransport's network thread from another thread.
++class SctpTransportMap {
++ public:
++  SctpTransportMap() = default;
++
++  // Assigns a new unused ID to the following transport.
++  uintptr_t Register(cricket::SctpTransport* transport) {
++    webrtc::MutexLock lock(&lock_);
++    // usrsctp_connect fails with a value of 0...
++    if (next_id_ == 0) {
++      ++next_id_;
++    }
++    // In case we've wrapped around and need to find an empty spot from a
++    // removed transport. Assumes we'll never be full.
++    while (map_.find(next_id_) != map_.end()) {
++      ++next_id_;
++      if (next_id_ == 0) {
++        ++next_id_;
++      }
++    };
++    map_[next_id_] = transport;
++    return next_id_++;
++  }
++
++  // Returns true if found.
++  bool Deregister(uintptr_t id) {
++    webrtc::MutexLock lock(&lock_);
++    return map_.erase(id) > 0;
++  }
++
++  // Must be called on the transport's network thread to protect against
++  // simultaneous deletion/deregistration of the transport; if that's not
++  // guaranteed, use ExecuteWithLock.
++  SctpTransport* Retrieve(uintptr_t id) const {
++    webrtc::MutexLock lock(&lock_);
++    SctpTransport* transport = RetrieveWhileHoldingLock(id);
++    if (transport) {
++      RTC_DCHECK_RUN_ON(transport->network_thread());
++    }
++    return transport;
++  }
++
++  // Posts |action| to the network thread of the transport identified by |id|
++  // and returns true if found, all while holding a lock to protect against the
++  // transport being simultaneously deleted/deregistered, or returns false if
++  // not found.
++  bool PostToTransportThread(uintptr_t id,
++                             std::function<void(SctpTransport*)> action) const {
++    webrtc::MutexLock lock(&lock_);
++    SctpTransport* transport = RetrieveWhileHoldingLock(id);
++    if (!transport) {
++      return false;
++    }
++    transport->invoker_.AsyncInvoke<void>(
++        RTC_FROM_HERE, transport->network_thread_, [transport, action]() {
++      action(transport); });
++    return true;
++  }
++
++ private:
++  SctpTransport* RetrieveWhileHoldingLock(uintptr_t id) const
++      RTC_EXCLUSIVE_LOCKS_REQUIRED(lock_) {
++    auto it = map_.find(id);
++    if (it == map_.end()) {
++      return nullptr;
++    }
++    return it->second;
++  }
++
++  mutable webrtc::Mutex lock_;
++
++  uintptr_t next_id_ RTC_GUARDED_BY(lock_) = 0;
++  std::unordered_map<uintptr_t, SctpTransport*> map_ RTC_GUARDED_BY(lock_);
++};
++
+ // Handles global init/deinit, and mapping from usrsctp callbacks to
+ // SctpTransport calls.
+ class SctpTransport::UsrSctpWrapper {
+@@ -357,14 +385,6 @@ class SctpTransport::UsrSctpWrapper {
+           << "OnSctpOutboundPacket called after usrsctp uninitialized?";
+       return EINVAL;
+     }
+-    SctpTransport* transport =
+-        g_transport_map_->Retrieve(reinterpret_cast<uintptr_t>(addr));
+-    if (!transport) {
+-      RTC_LOG(LS_ERROR)
+-          << "OnSctpOutboundPacket: Failed to get transport for socket ID "
+-          << addr;
+-      return EINVAL;
+-    }
+     RTC_LOG(LS_VERBOSE) << "global OnSctpOutboundPacket():"
+                            "addr: "
+                         << addr << "; length: " << length
+@@ -372,13 +392,23 @@ class SctpTransport::UsrSctpWrapper {
+                         << "; set_df: " << rtc::ToHex(set_df);
+ 
+     VerboseLogPacket(data, length, SCTP_DUMP_OUTBOUND);
++
+     // Note: We have to copy the data; the caller will delete it.
+     rtc::CopyOnWriteBuffer buf(reinterpret_cast<uint8_t*>(data), length);
+-    // TODO(deadbeef): Why do we need an AsyncInvoke here? We're already on the
+-    // right thread and don't need to unwind the stack.
+-    transport->invoker_.AsyncInvoke<void>(
+-        RTC_FROM_HERE, transport->network_thread_,
+-        rtc::Bind(&SctpTransport::OnPacketFromSctpToNetwork, transport, buf));
++
++    // PostsToTransportThread protects against the transport being
++    // simultaneously deregistered/deleted, since this callback may come from
++    // the SCTP timer thread and thus race with the network thread.
++    bool found = g_transport_map_->PostToTransportThread(
++        reinterpret_cast<uintptr_t>(addr), [buf](SctpTransport* transport) {
++          transport->OnPacketFromSctpToNetwork(buf);
++        });
++    if (!found) {
++      RTC_LOG(LS_ERROR)
++          << "OnSctpOutboundPacket: Failed to get transport for socket ID "
++          << addr;
++      return EINVAL;
++    }
+     return 0;
+   }
+ 
+diff --git a/media/sctp/sctp_transport.h b/media/sctp/sctp_transport.h
+index 54542af6b3c9664c7af9425b174f9c45a37f3b4f..7aeb6e01bd9a41c903c5ffa08c44b193957f55c4 100644
+--- a/media/sctp/sctp_transport.h
++++ b/media/sctp/sctp_transport.h
+@@ -281,6 +281,8 @@ class SctpTransport : public SctpTransportInternal,
+   // various callbacks.
+   uintptr_t id_ = 0;
+ 
++  friend class SctpTransportMap;
++
+   RTC_DISALLOW_COPY_AND_ASSIGN(SctpTransport);
+ };
+ 
+@@ -299,6 +301,8 @@ class SctpTransportFactory : public webrtc::SctpTransportFactoryInterface {
+   rtc::Thread* network_thread_;
+ };
+ 
++class SctpTransportMap;
++
+ }  // namespace cricket
+ 
+ #endif  // MEDIA_SCTP_SCTP_TRANSPORT_H_

--- a/patches/webrtc/merge_m86_-_fix_race_with_sctptransport_destruction_and_usrsctp.patch
+++ b/patches/webrtc/merge_m86_-_fix_race_with_sctptransport_destruction_and_usrsctp.patch
@@ -1,8 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Taylor Brandstetter <deadbeef@webrtc.org>
 Date: Tue, 13 Apr 2021 16:11:47 -0700
-Subject: [Merge M86] - Fix race with SctpTransport destruction and usrsctp
- timer thread.
+Subject: - Fix race with SctpTransport destruction and usrsctp timer thread.
 
 The race occurs if the transport is being destroyed at the same time as
 a callback occurs on the usrsctp timer thread (for example, for a

--- a/patches/webrtc/merge_m86_-_reland_fix_race_between_destroying_sctptransport_and.patch
+++ b/patches/webrtc/merge_m86_-_reland_fix_race_between_destroying_sctptransport_and.patch
@@ -1,0 +1,454 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Taylor Brandstetter <deadbeef@webrtc.org>
+Date: Wed, 14 Apr 2021 11:09:16 -0700
+Subject: [Merge M86] - Reland "Fix race between destroying SctpTransport and
+ receiving notification on timer thread."
+
+This reverts commit 8a38b1cf681cd77f0d59a68fb45d8dedbd7d4cee.
+
+Reason for reland: Problem was identified; has something to do with
+the unique_ptr with the custom deleter.
+
+Original change's description:
+> Revert "Fix race between destroying SctpTransport and receiving notification on timer thread."
+>
+> This reverts commit a88fe7be146b9b85575504d4d5193c007f2e3de4.
+>
+> Reason for revert: Breaks downstream test, still investigating.
+>
+> Original change's description:
+> > Fix race between destroying SctpTransport and receiving notification on timer thread.
+> >
+> > This gets rid of the SctpTransportMap::Retrieve method and forces
+> > everything to go through PostToTransportThread, which behaves safely
+> > with relation to the transport's destruction.
+> >
+> > Bug: webrtc:12467
+> > Change-Id: Id4a723c2c985be2a368d2cc5c5e62deb04c509ab
+> > Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/208800
+> > Reviewed-by: Niels Moller <nisse@webrtc.org>
+> > Commit-Queue: Taylor <deadbeef@webrtc.org>
+> > Cr-Commit-Position: refs/heads/master@{#33364}
+>
+> TBR=nisse@webrtc.org
+>
+> Bug: webrtc:12467
+> Change-Id: Ib5d815a2cbca4feb25f360bff7ed62c02d1910a0
+> Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/209820
+> Reviewed-by: Taylor <deadbeef@webrtc.org>
+> Commit-Queue: Taylor <deadbeef@webrtc.org>
+> Cr-Commit-Position: refs/heads/master@{#33386}
+
+TBR=nisse@webrtc.org
+
+Bug: webrtc:12467
+Change-Id: I5f9fcd6df7a211e6edfa64577fc953833f4d9b79
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/210040
+Reviewed-by: Niels Moller <nisse@webrtc.org>
+Reviewed-by: Florent Castelli <orphis@webrtc.org>
+Commit-Queue: Taylor <deadbeef@webrtc.org>
+Cr-Original-Commit-Position: refs/heads/master@{#33427}
+No-Try: True
+No-Presubmit: True
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/215060
+Reviewed-by: Taylor <deadbeef@webrtc.org>
+Commit-Queue: Mirko Bonadei <mbonadei@webrtc.org>
+Cr-Commit-Position: refs/branch-heads/4240@{#19}
+Cr-Branched-From: 93a9d19d4eb53b3f4fb4d22e6c54f2e2824437eb-refs/heads/master@{#31969}
+
+diff --git a/media/sctp/sctp_transport.cc b/media/sctp/sctp_transport.cc
+index f97568e95c8068e47fa902546c27851475348c87..a48d97ab75bcf171d8c08d42f8a55a1e5d813249 100644
+--- a/media/sctp/sctp_transport.cc
++++ b/media/sctp/sctp_transport.cc
+@@ -20,6 +20,7 @@ enum PreservedErrno {
+ // Successful return value from usrsctp callbacks. Is not actually used by
+ // usrsctp, but all example programs for usrsctp use 1 as their return value.
+ constexpr int kSctpSuccessReturn = 1;
++constexpr int kSctpErrorReturn = 0;
+ 
+ }  // namespace
+ 
+@@ -27,7 +28,6 @@ constexpr int kSctpSuccessReturn = 1;
+ #include <stdio.h>
+ #include <usrsctp.h>
+ 
+-#include <functional>
+ #include <memory>
+ #include <unordered_map>
+ 
+@@ -83,6 +83,21 @@ enum {
+ // Should only be modified by UsrSctpWrapper.
+ ABSL_CONST_INIT cricket::SctpTransportMap* g_transport_map_ = nullptr;
+ 
++// Helper that will call C's free automatically.
++// TODO(b/181900299): Figure out why unique_ptr with a custom deleter is causing
++// issues in a certain build environment.
++class AutoFreedPointer {
++ public:
++  explicit AutoFreedPointer(void* ptr) : ptr_(ptr) {}
++  AutoFreedPointer(AutoFreedPointer&& o) : ptr_(o.ptr_) { o.ptr_ = nullptr; }
++  ~AutoFreedPointer() { free(ptr_); }
++
++  void* get() const { return ptr_; }
++
++ private:
++  void* ptr_;
++};
++
+ // Helper for logging SCTP messages.
+ #if defined(__GNUC__)
+ __attribute__((__format__(__printf__, 1, 2)))
+@@ -239,32 +254,20 @@ class SctpTransportMap {
+     return map_.erase(id) > 0;
+   }
+ 
+-  // Must be called on the transport's network thread to protect against
+-  // simultaneous deletion/deregistration of the transport; if that's not
+-  // guaranteed, use ExecuteWithLock.
+-  SctpTransport* Retrieve(uintptr_t id) const {
+-    webrtc::MutexLock lock(&lock_);
+-    SctpTransport* transport = RetrieveWhileHoldingLock(id);
+-    if (transport) {
+-      RTC_DCHECK_RUN_ON(transport->network_thread());
+-    }
+-    return transport;
+-  }
+-
+   // Posts |action| to the network thread of the transport identified by |id|
+   // and returns true if found, all while holding a lock to protect against the
+   // transport being simultaneously deleted/deregistered, or returns false if
+   // not found.
+-  bool PostToTransportThread(uintptr_t id,
+-                             std::function<void(SctpTransport*)> action) const {
++  template <typename F>
++  bool PostToTransportThread(uintptr_t id, F action) const {
+     webrtc::MutexLock lock(&lock_);
+     SctpTransport* transport = RetrieveWhileHoldingLock(id);
+     if (!transport) {
+       return false;
+     }
+     transport->invoker_.AsyncInvoke<void>(
+-        RTC_FROM_HERE, transport->network_thread_, [transport, action]() {
+-      action(transport); });
++        RTC_FROM_HERE, transport->network_thread_,
++        [transport, action{std::move(action)}]() { action(transport); });
+     return true;
+   }
+ 
+@@ -406,7 +409,7 @@ class SctpTransport::UsrSctpWrapper {
+     if (!found) {
+       RTC_LOG(LS_ERROR)
+           << "OnSctpOutboundPacket: Failed to get transport for socket ID "
+-          << addr;
++          << addr << "; possibly was already destroyed.";
+       return EINVAL;
+     }
+     return 0;
+@@ -423,27 +426,46 @@ class SctpTransport::UsrSctpWrapper {
+                                  struct sctp_rcvinfo rcv,
+                                  int flags,
+                                  void* ulp_info) {
+-    SctpTransport* transport = GetTransportFromSocket(sock);
+-    if (!transport) {
++    AutoFreedPointer owned_data(data);
++
++    absl::optional<uintptr_t> id = GetTransportIdFromSocket(sock);
++    if (!id) {
+       RTC_LOG(LS_ERROR)
+-          << "OnSctpInboundPacket: Failed to get transport for socket " << sock
+-          << "; possibly was already destroyed.";
+-      return 0;
++          << "OnSctpInboundPacket: Failed to get transport ID from socket "
++          << sock;
++      return kSctpErrorReturn;
++    }
++
++    if (!g_transport_map_) {
++      RTC_LOG(LS_ERROR)
++          << "OnSctpInboundPacket called after usrsctp uninitialized?";
++      return kSctpErrorReturn;
+     }
+-    // Sanity check that both methods of getting the SctpTransport pointer
+-    // yield the same result.
+-    RTC_CHECK_EQ(transport, static_cast<SctpTransport*>(ulp_info));
+-    int result =
+-        transport->OnDataOrNotificationFromSctp(data, length, rcv, flags);
+-    free(data);
+-    return result;
++    // PostsToTransportThread protects against the transport being
++    // simultaneously deregistered/deleted, since this callback may come from
++    // the SCTP timer thread and thus race with the network thread.
++    bool found = g_transport_map_->PostToTransportThread(
++        *id, [owned_data{std::move(owned_data)}, length, rcv,
++              flags](SctpTransport* transport) {
++          transport->OnDataOrNotificationFromSctp(owned_data.get(), length, rcv,
++                                                  flags);
++        });
++    if (!found) {
++      RTC_LOG(LS_ERROR)
++          << "OnSctpInboundPacket: Failed to get transport for socket ID "
++          << *id << "; possibly was already destroyed.";
++      return kSctpErrorReturn;
++    }
++    return kSctpSuccessReturn;
+   }
+ 
+-  static SctpTransport* GetTransportFromSocket(struct socket* sock) {
++  static absl::optional<uintptr_t> GetTransportIdFromSocket(
++      struct socket* sock) {
++    absl::optional<uintptr_t> ret;
+     struct sockaddr* addrs = nullptr;
+     int naddrs = usrsctp_getladdrs(sock, 0, &addrs);
+     if (naddrs <= 0 || addrs[0].sa_family != AF_CONN) {
+-      return nullptr;
++      return ret;
+     }
+     // usrsctp_getladdrs() returns the addresses bound to this socket, which
+     // contains the SctpTransport id as sconn_addr.  Read the id,
+@@ -452,17 +474,10 @@ class SctpTransport::UsrSctpWrapper {
+     // id of the transport that created them, so [0] is as good as any other.
+     struct sockaddr_conn* sconn =
+         reinterpret_cast<struct sockaddr_conn*>(&addrs[0]);
+-    if (!g_transport_map_) {
+-      RTC_LOG(LS_ERROR)
+-          << "GetTransportFromSocket called after usrsctp uninitialized?";
+-      usrsctp_freeladdrs(addrs);
+-      return nullptr;
+-    }
+-    SctpTransport* transport = g_transport_map_->Retrieve(
+-        reinterpret_cast<uintptr_t>(sconn->sconn_addr));
++    ret = reinterpret_cast<uintptr_t>(sconn->sconn_addr);
+     usrsctp_freeladdrs(addrs);
+ 
+-    return transport;
++    return ret;
+   }
+ 
+   // TODO(crbug.com/webrtc/11899): This is a legacy callback signature, remove
+@@ -471,14 +486,26 @@ class SctpTransport::UsrSctpWrapper {
+     // Fired on our I/O thread. SctpTransport::OnPacketReceived() gets
+     // a packet containing acknowledgments, which goes into usrsctp_conninput,
+     // and then back here.
+-    SctpTransport* transport = GetTransportFromSocket(sock);
+-    if (!transport) {
++    absl::optional<uintptr_t> id = GetTransportIdFromSocket(sock);
++    if (!id) {
++      RTC_LOG(LS_ERROR)
++          << "SendThresholdCallback: Failed to get transport ID from socket "
++          << sock;
++      return 0;
++    }
++    if (!g_transport_map_) {
+       RTC_LOG(LS_ERROR)
+-          << "SendThresholdCallback: Failed to get transport for socket "
+-          << sock << "; possibly was already destroyed.";
++          << "SendThresholdCallback called after usrsctp uninitialized?";
+       return 0;
+     }
+-    transport->OnSendThresholdCallback();
++    bool found = g_transport_map_->PostToTransportThread(
++        *id,
++        [](SctpTransport* transport) { transport->OnSendThresholdCallback(); });
++    if (!found) {
++      RTC_LOG(LS_ERROR)
++          << "SendThresholdCallback: Failed to get transport for socket ID "
++          << *id << "; possibly was already destroyed.";
++    }
+     return 0;
+   }
+ 
+@@ -488,17 +515,26 @@ class SctpTransport::UsrSctpWrapper {
+     // Fired on our I/O thread. SctpTransport::OnPacketReceived() gets
+     // a packet containing acknowledgments, which goes into usrsctp_conninput,
+     // and then back here.
+-    SctpTransport* transport = GetTransportFromSocket(sock);
+-    if (!transport) {
++    absl::optional<uintptr_t> id = GetTransportIdFromSocket(sock);
++    if (!id) {
+       RTC_LOG(LS_ERROR)
+-          << "SendThresholdCallback: Failed to get transport for socket "
+-          << sock << "; possibly was already destroyed.";
++          << "SendThresholdCallback: Failed to get transport ID from socket "
++          << sock;
+       return 0;
+     }
+-    // Sanity check that both methods of getting the SctpTransport pointer
+-    // yield the same result.
+-    RTC_CHECK_EQ(transport, static_cast<SctpTransport*>(ulp_info));
+-    transport->OnSendThresholdCallback();
++    if (!g_transport_map_) {
++      RTC_LOG(LS_ERROR)
++          << "SendThresholdCallback called after usrsctp uninitialized?";
++      return 0;
++    }
++    bool found = g_transport_map_->PostToTransportThread(
++        *id,
++        [](SctpTransport* transport) { transport->OnSendThresholdCallback(); });
++    if (!found) {
++      RTC_LOG(LS_ERROR)
++          << "SendThresholdCallback: Failed to get transport for socket ID "
++          << *id << "; possibly was already destroyed.";
++    }
+     return 0;
+   }
+ };
+@@ -1149,24 +1185,25 @@ void SctpTransport::OnPacketFromSctpToNetwork(
+                          rtc::PacketOptions(), PF_NORMAL);
+ }
+ 
+-int SctpTransport::InjectDataOrNotificationFromSctpForTesting(
++void SctpTransport::InjectDataOrNotificationFromSctpForTesting(
+     void* data,
+     size_t length,
+     struct sctp_rcvinfo rcv,
+     int flags) {
+-  return OnDataOrNotificationFromSctp(data, length, rcv, flags);
++  OnDataOrNotificationFromSctp(data, length, rcv, flags);
+ }
+ 
+-int SctpTransport::OnDataOrNotificationFromSctp(void* data,
+-                                                size_t length,
+-                                                struct sctp_rcvinfo rcv,
+-                                                int flags) {
++void SctpTransport::OnDataOrNotificationFromSctp(void* data,
++                                                 size_t length,
++                                                 struct sctp_rcvinfo rcv,
++                                                 int flags) {
++  RTC_DCHECK_RUN_ON(network_thread_);
+   // If data is NULL, the SCTP association has been closed.
+   if (!data) {
+     RTC_LOG(LS_INFO) << debug_name_
+                      << "->OnDataOrNotificationFromSctp(...): "
+                         "No data; association closed.";
+-    return kSctpSuccessReturn;
++    return;
+   }
+ 
+   // Handle notifications early.
+@@ -1179,13 +1216,10 @@ int SctpTransport::OnDataOrNotificationFromSctp(void* data,
+         << "->OnDataOrNotificationFromSctp(...): SCTP notification"
+         << " length=" << length;
+ 
+-    // Copy and dispatch asynchronously
+     rtc::CopyOnWriteBuffer notification(reinterpret_cast<uint8_t*>(data),
+                                         length);
+-    invoker_.AsyncInvoke<void>(
+-        RTC_FROM_HERE, network_thread_,
+-        rtc::Bind(&SctpTransport::OnNotificationFromSctp, this, notification));
+-    return kSctpSuccessReturn;
++    OnNotificationFromSctp(notification);
++    return;
+   }
+ 
+   // Log data chunk
+@@ -1203,7 +1237,7 @@ int SctpTransport::OnDataOrNotificationFromSctp(void* data,
+     // Unexpected PPID, dropping
+     RTC_LOG(LS_ERROR) << "Received an unknown PPID " << ppid
+                       << " on an SCTP packet.  Dropping.";
+-    return kSctpSuccessReturn;
++    return;
+   }
+ 
+   // Expect only continuation messages belonging to the same SID. The SCTP
+@@ -1239,7 +1273,7 @@ int SctpTransport::OnDataOrNotificationFromSctp(void* data,
+     if (partial_incoming_message_.size() < kSctpSendBufferSize) {
+       // We still have space in the buffer. Continue buffering chunks until
+       // the message is complete before handing it out.
+-      return kSctpSuccessReturn;
++      return;
+     } else {
+       // The sender is exceeding the maximum message size that we announced.
+       // Spit out a warning but still hand out the partial message. Note that
+@@ -1253,17 +1287,9 @@ int SctpTransport::OnDataOrNotificationFromSctp(void* data,
+     }
+   }
+ 
+-  // Dispatch the complete message.
+-  // The ownership of the packet transfers to |invoker_|. Using
+-  // CopyOnWriteBuffer is the most convenient way to do this.
+-  invoker_.AsyncInvoke<void>(
+-      RTC_FROM_HERE, network_thread_,
+-      rtc::Bind(&SctpTransport::OnDataFromSctpToTransport, this, params,
+-                partial_incoming_message_));
+-
+-  // Reset the message buffer
++  // Dispatch the complete message and reset the message buffer.
++  OnDataFromSctpToTransport(params, partial_incoming_message_);
+   partial_incoming_message_.Clear();
+-  return kSctpSuccessReturn;
+ }
+ 
+ void SctpTransport::OnDataFromSctpToTransport(
+diff --git a/media/sctp/sctp_transport.h b/media/sctp/sctp_transport.h
+index 7aeb6e01bd9a41c903c5ffa08c44b193957f55c4..2e31718b0d07b78f4adf1f7339b6718d7b5268bb 100644
+--- a/media/sctp/sctp_transport.h
++++ b/media/sctp/sctp_transport.h
+@@ -96,11 +96,10 @@ class SctpTransport : public SctpTransportInternal,
+   void set_debug_name_for_testing(const char* debug_name) override {
+     debug_name_ = debug_name;
+   }
+-  int InjectDataOrNotificationFromSctpForTesting(void* data,
+-                                                 size_t length,
+-                                                 struct sctp_rcvinfo rcv,
+-                                                 int flags);
+-
++  void InjectDataOrNotificationFromSctpForTesting(void* data,
++                                                  size_t length,
++                                                  struct sctp_rcvinfo rcv,
++                                                  int flags);
+   // Exposed to allow Post call from c-callbacks.
+   // TODO(deadbeef): Remove this or at least make it return a const pointer.
+   rtc::Thread* network_thread() const { return network_thread_; }
+@@ -180,12 +179,12 @@ class SctpTransport : public SctpTransportInternal,
+   // Called using |invoker_| to send packet on the network.
+   void OnPacketFromSctpToNetwork(const rtc::CopyOnWriteBuffer& buffer);
+ 
+-  // Called on the SCTP thread.
++  // Called on the network thread.
+   // Flags are standard socket API flags (RFC 6458).
+-  int OnDataOrNotificationFromSctp(void* data,
+-                                   size_t length,
+-                                   struct sctp_rcvinfo rcv,
+-                                   int flags);
++  void OnDataOrNotificationFromSctp(void* data,
++                                    size_t length,
++                                    struct sctp_rcvinfo rcv,
++                                    int flags);
+   // Called using |invoker_| to decide what to do with the data.
+   void OnDataFromSctpToTransport(const ReceiveDataParams& params,
+                                  const rtc::CopyOnWriteBuffer& buffer);
+diff --git a/media/sctp/sctp_transport_unittest.cc b/media/sctp/sctp_transport_unittest.cc
+index 46fbbc8f13b87437c4f628342f3dbf39f00b44e5..b15a72bc83a1dbb3887f5caf8fb5c602235019f4 100644
+--- a/media/sctp/sctp_transport_unittest.cc
++++ b/media/sctp/sctp_transport_unittest.cc
+@@ -282,8 +282,8 @@ TEST_F(SctpTransportTest, MessageInterleavedWithNotification) {
+   meta.rcv_tsn = 42;
+   meta.rcv_cumtsn = 42;
+   chunk.SetData("meow?", 5);
+-  EXPECT_EQ(1, transport1->InjectDataOrNotificationFromSctpForTesting(
+-                   chunk.data(), chunk.size(), meta, 0));
++  transport1->InjectDataOrNotificationFromSctpForTesting(chunk.data(),
++                                                         chunk.size(), meta, 0);
+ 
+   // Inject a notification in between chunks.
+   union sctp_notification notification;
+@@ -292,15 +292,15 @@ TEST_F(SctpTransportTest, MessageInterleavedWithNotification) {
+   notification.sn_header.sn_type = SCTP_PEER_ADDR_CHANGE;
+   notification.sn_header.sn_flags = 0;
+   notification.sn_header.sn_length = sizeof(notification);
+-  EXPECT_EQ(1, transport1->InjectDataOrNotificationFromSctpForTesting(
+-                   &notification, sizeof(notification), {0}, MSG_NOTIFICATION));
++  transport1->InjectDataOrNotificationFromSctpForTesting(
++      &notification, sizeof(notification), {0}, MSG_NOTIFICATION);
+ 
+   // Inject chunk 2/2
+   meta.rcv_tsn = 42;
+   meta.rcv_cumtsn = 43;
+   chunk.SetData(" rawr!", 6);
+-  EXPECT_EQ(1, transport1->InjectDataOrNotificationFromSctpForTesting(
+-                   chunk.data(), chunk.size(), meta, MSG_EOR));
++  transport1->InjectDataOrNotificationFromSctpForTesting(
++      chunk.data(), chunk.size(), meta, MSG_EOR);
+ 
+   // Expect the message to contain both chunks.
+   EXPECT_TRUE_WAIT(ReceivedData(&recv1, 1, "meow? rawr!"), kDefaultTimeout);

--- a/patches/webrtc/merge_m86_-_reland_fix_race_between_destroying_sctptransport_and.patch
+++ b/patches/webrtc/merge_m86_-_reland_fix_race_between_destroying_sctptransport_and.patch
@@ -1,8 +1,8 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Taylor Brandstetter <deadbeef@webrtc.org>
 Date: Wed, 14 Apr 2021 11:09:16 -0700
-Subject: [Merge M86] - Reland "Fix race between destroying SctpTransport and
- receiving notification on timer thread."
+Subject: - Reland "Fix race between destroying SctpTransport and receiving
+ notification on timer thread."
 
 This reverts commit 8a38b1cf681cd77f0d59a68fb45d8dedbd7d4cee.
 


### PR DESCRIPTION
[Merge M86] - Fix race with SctpTransport destruction and usrsctp timer thread.

The race occurs if the transport is being destroyed at the same time as
a callback occurs on the usrsctp timer thread (for example, for a
retransmission). Fixed by slightly extending the scope of mutex
acquisition to include posting a task to the network thread, where it's
safe to do further work.

Bug: chromium:1162424
Change-Id: Ia25c96fa51cd4ba2d8690ba03de8af9e9f1605ea
Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/202560
Reviewed-by: Harald Alvestrand <hta@webrtc.org>
Commit-Queue: Taylor <deadbeef@webrtc.org>
Cr-Original-Commit-Position: refs/heads/master@{#33048}
No-Try: True
No-Presubmit: True
Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/215101
Reviewed-by: Mirko Bonadei <mbonadei@webrtc.org>
Cr-Commit-Position: refs/branch-heads/4240@{#18}
Cr-Branched-From: 93a9d19d4eb53b3f4fb4d22e6c54f2e2824437eb-refs/heads/master@{#31969}

=============

[Merge M86] - Reland "Fix race between destroying SctpTransport and receiving notification on timer thread."

This reverts commit 8a38b1cf681cd77f0d59a68fb45d8dedbd7d4cee.

Reason for reland: Problem was identified; has something to do with
the unique_ptr with the custom deleter.

Original change's description:
> Revert "Fix race between destroying SctpTransport and receiving notification on timer thread."
>
> This reverts commit a88fe7be146b9b85575504d4d5193c007f2e3de4.
>
> Reason for revert: Breaks downstream test, still investigating.
>
> Original change's description:
> > Fix race between destroying SctpTransport and receiving notification on timer thread.
> >
> > This gets rid of the SctpTransportMap::Retrieve method and forces
> > everything to go through PostToTransportThread, which behaves safely
> > with relation to the transport's destruction.
> >
> > Bug: webrtc:12467
> > Change-Id: Id4a723c2c985be2a368d2cc5c5e62deb04c509ab
> > Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/208800
> > Reviewed-by: Niels Moller <nisse@webrtc.org>
> > Commit-Queue: Taylor <deadbeef@webrtc.org>
> > Cr-Commit-Position: refs/heads/master@{#33364}
>
> TBR=nisse@webrtc.org
>
> Bug: webrtc:12467
> Change-Id: Ib5d815a2cbca4feb25f360bff7ed62c02d1910a0
> Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/209820
> Reviewed-by: Taylor <deadbeef@webrtc.org>
> Commit-Queue: Taylor <deadbeef@webrtc.org>
> Cr-Commit-Position: refs/heads/master@{#33386}

TBR=nisse@webrtc.org

Bug: webrtc:12467
Change-Id: I5f9fcd6df7a211e6edfa64577fc953833f4d9b79
Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/210040
Reviewed-by: Niels Moller <nisse@webrtc.org>
Reviewed-by: Florent Castelli <orphis@webrtc.org>
Commit-Queue: Taylor <deadbeef@webrtc.org>
Cr-Original-Commit-Position: refs/heads/master@{#33427}
No-Try: True
No-Presubmit: True
Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/215060
Reviewed-by: Taylor <deadbeef@webrtc.org>
Commit-Queue: Mirko Bonadei <mbonadei@webrtc.org>
Cr-Commit-Position: refs/branch-heads/4240@{#19}
Cr-Branched-From: 93a9d19d4eb53b3f4fb4d22e6c54f2e2824437eb-refs/heads/master@{#31969}

#### Release Notes

Notes: Security: backported fix to chromium:1184441.
