### PR TITLE
chore: cherry-pick e4abe032f3ad from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -113,3 +113,4 @@ word_break_between_space_and_alphanumeric.patch
 moves_background_color_setter_of_webview_to_blinks_webprefs_logic.patch
 blink_wasm_eval_csp.patch
 cherry-pick-162efe98330e.patch
+cherry-pick-e4abe032f3ad.patch

--- a/patches/chromium/cherry-pick-e4abe032f3ad.patch
+++ b/patches/chromium/cherry-pick-e4abe032f3ad.patch
@@ -1,0 +1,85 @@
+From e4abe032f3ad1921f38ce255699968608bca9494 Mon Sep 17 00:00:00 2001
+From: Brendon Tiszka <btiszka@gmail.com>
+Date: Fri, 16 Apr 2021 18:14:13 +0000
+Subject: [PATCH] Ensure that BrowserContext is not used after it has been freed
+
+Previously, it was possible for the BrowserContext to be destroyed
+before ReportAnchorElementMetricsOnClick attempted to access it.
+
+The fix uses the fact that NavigationPredictor extends
+WebContentsObserver and checks that web_contents is still alive
+before dereferencing BrowserContext. WebContents will always
+outlive BrowserContext.
+
+R=​​lukasza@chromium.org, ryansturm@chromium.org
+
+(cherry picked from commit 7313a810ae0b1361cbe8453bc5496654dee24c76)
+
+(cherry picked from commit f782a440339fa19a44422ca5e7165cddd1cffcc9)
+
+Bug: 1197904
+Change-Id: Iee4f126e92670a84d57c7a4ec7d6f702fb975c7e
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2821639
+Reviewed-by: Ryan Sturm <ryansturm@chromium.org>
+Reviewed-by: Łukasz Anforowicz <lukasza@chromium.org>
+Commit-Queue: Łukasz Anforowicz <lukasza@chromium.org>
+Cr-Original-Original-Commit-Position: refs/heads/master@{#872021}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2827043
+Auto-Submit: Robert Ogden <robertogden@chromium.org>
+Commit-Queue: Ryan Sturm <ryansturm@chromium.org>
+Cr-Original-Commit-Position: refs/branch-heads/4472@{#77}
+Cr-Original-Branched-From: 3d60439cfb36485e76a1c5bb7f513d3721b20da1-refs/heads/master@{#870763}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2830308
+Reviewed-by: Tarun Bansal <tbansal@chromium.org>
+Commit-Queue: Tarun Bansal <tbansal@chromium.org>
+Commit-Queue: Robert Ogden <robertogden@chromium.org>
+Cr-Commit-Position: refs/branch-heads/4430@{#1297}
+Cr-Branched-From: e5ce7dc4f7518237b3d9bb93cccca35d25216cbe-refs/heads/master@{#857950}
+---
+
+diff --git a/AUTHORS b/AUTHORS
+index b0b6777..064497a 100644
+--- a/AUTHORS
++++ b/AUTHORS
+@@ -150,6 +150,7 @@
+ Branden Archer <bma4@zips.uakron.edu>
+ Brendan Kirby <brendan.kirby@imgtec.com>
+ Brendan Long <self@brendanlong.com>
++Brendon Tiszka <btiszka@gmail.com>
+ Brian Clifton <clifton@brave.com>
+ Brian G. Merrell <bgmerrell@gmail.com>
+ Brian Konzman, SJ <b.g.konzman@gmail.com>
+diff --git a/chrome/browser/navigation_predictor/navigation_predictor.cc b/chrome/browser/navigation_predictor/navigation_predictor.cc
+index becdb8a..6c5e4a9 100644
+--- a/chrome/browser/navigation_predictor/navigation_predictor.cc
++++ b/chrome/browser/navigation_predictor/navigation_predictor.cc
+@@ -506,6 +506,9 @@
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+   DCHECK(base::FeatureList::IsEnabled(blink::features::kNavigationPredictor));
+ 
++  if (!web_contents())
++    return;
++
+   if (browser_context_->IsOffTheRecord())
+     return;
+ 
+@@ -652,6 +655,9 @@
+   // Each document should only report metrics once when page is loaded.
+   DCHECK(navigation_scores_map_.empty());
+ 
++  if (!web_contents())
++    return;
++
+   if (browser_context_->IsOffTheRecord())
+     return;
+ 
+@@ -897,6 +903,9 @@
+ }
+ 
+ void NavigationPredictor::MaybePrefetch() {
++  if (!web_contents())
++    return;
++
+   // If prefetches aren't allowed here, this URL has already
+   // been prefetched, or the current tab is hidden,
+   // we shouldn't prefetch again.

--- a/patches/chromium/cherry-pick-e4abe032f3ad.patch
+++ b/patches/chromium/cherry-pick-e4abe032f3ad.patch
@@ -1,7 +1,10 @@
-From e4abe032f3ad1921f38ce255699968608bca9494 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Brendon Tiszka <btiszka@gmail.com>
 Date: Fri, 16 Apr 2021 18:14:13 +0000
-Subject: [PATCH] Ensure that BrowserContext is not used after it has been freed
+Subject: Ensure that BrowserContext is not used after it has been freed
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 Previously, it was possible for the BrowserContext to be destroyed
 before ReportAnchorElementMetricsOnClick attempted to access it.
@@ -35,13 +38,12 @@ Commit-Queue: Tarun Bansal <tbansal@chromium.org>
 Commit-Queue: Robert Ogden <robertogden@chromium.org>
 Cr-Commit-Position: refs/branch-heads/4430@{#1297}
 Cr-Branched-From: e5ce7dc4f7518237b3d9bb93cccca35d25216cbe-refs/heads/master@{#857950}
----
 
 diff --git a/AUTHORS b/AUTHORS
-index b0b6777..064497a 100644
+index 599cd0fbf5dce0536891ce3fb90ccf9efbbfd5c5..296c220888df0c421e1659d08c546fdde11e60af 100644
 --- a/AUTHORS
 +++ b/AUTHORS
-@@ -150,6 +150,7 @@
+@@ -149,6 +149,7 @@ Bobby Powers <bobbypowers@gmail.com>
  Branden Archer <bma4@zips.uakron.edu>
  Brendan Kirby <brendan.kirby@imgtec.com>
  Brendan Long <self@brendanlong.com>
@@ -50,10 +52,10 @@ index b0b6777..064497a 100644
  Brian G. Merrell <bgmerrell@gmail.com>
  Brian Konzman, SJ <b.g.konzman@gmail.com>
 diff --git a/chrome/browser/navigation_predictor/navigation_predictor.cc b/chrome/browser/navigation_predictor/navigation_predictor.cc
-index becdb8a..6c5e4a9 100644
+index 2e3e9a068cb56973e587eb5c46fd0571f028685e..3d5db56ca1f9a2d7bbc7ebb5af94142a648f0906 100644
 --- a/chrome/browser/navigation_predictor/navigation_predictor.cc
 +++ b/chrome/browser/navigation_predictor/navigation_predictor.cc
-@@ -506,6 +506,9 @@
+@@ -506,6 +506,9 @@ void NavigationPredictor::ReportAnchorElementMetricsOnClick(
    DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
    DCHECK(base::FeatureList::IsEnabled(blink::features::kNavigationPredictor));
  
@@ -63,7 +65,7 @@ index becdb8a..6c5e4a9 100644
    if (browser_context_->IsOffTheRecord())
      return;
  
-@@ -652,6 +655,9 @@
+@@ -652,6 +655,9 @@ void NavigationPredictor::ReportAnchorElementMetricsOnLoad(
    // Each document should only report metrics once when page is loaded.
    DCHECK(navigation_scores_map_.empty());
  
@@ -73,7 +75,7 @@ index becdb8a..6c5e4a9 100644
    if (browser_context_->IsOffTheRecord())
      return;
  
-@@ -897,6 +903,9 @@
+@@ -897,6 +903,9 @@ void NavigationPredictor::MaybeTakeActionOnLoad(
  }
  
  void NavigationPredictor::MaybePrefetch() {


### PR DESCRIPTION
Ensure that BrowserContext is not used after it has been freed

Previously, it was possible for the BrowserContext to be destroyed
before ReportAnchorElementMetricsOnClick attempted to access it.

The fix uses the fact that NavigationPredictor extends
WebContentsObserver and checks that web_contents is still alive
before dereferencing BrowserContext. WebContents will always
outlive BrowserContext.

R=​​lukasza@chromium.org, ryansturm@chromium.org

(cherry picked from commit 7313a810ae0b1361cbe8453bc5496654dee24c76)

(cherry picked from commit f782a440339fa19a44422ca5e7165cddd1cffcc9)

Bug: 1197904
Change-Id: Iee4f126e92670a84d57c7a4ec7d6f702fb975c7e
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2821639
Reviewed-by: Ryan Sturm <ryansturm@chromium.org>
Reviewed-by: Łukasz Anforowicz <lukasza@chromium.org>
Commit-Queue: Łukasz Anforowicz <lukasza@chromium.org>
Cr-Original-Original-Commit-Position: refs/heads/master@{#872021}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2827043
Auto-Submit: Robert Ogden <robertogden@chromium.org>
Commit-Queue: Ryan Sturm <ryansturm@chromium.org>
Cr-Original-Commit-Position: refs/branch-heads/4472@{#77}
Cr-Original-Branched-From: 3d60439cfb36485e76a1c5bb7f513d3721b20da1-refs/heads/master@{#870763}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2830308
Reviewed-by: Tarun Bansal <tbansal@chromium.org>
Commit-Queue: Tarun Bansal <tbansal@chromium.org>
Commit-Queue: Robert Ogden <robertogden@chromium.org>
Cr-Commit-Position: refs/branch-heads/4430@{#1297}
Cr-Branched-From: e5ce7dc4f7518237b3d9bb93cccca35d25216cbe-refs/heads/master@{#857950}


Notes: Security: backported fix for CVE-2021-21226.