### PR TITLE
chore: cherry-pick 8ebd894186 and 1e35f64725 from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -20,3 +20,5 @@ regexp_throw_when_length_of_text_nodes_in_alternatives_is_too.patch
 cherry-pick-02f84c745fc0.patch
 merged_deoptimizer_fix_bug_in_optimizedframe_summarize.patch
 cherry-pick-512cd5e179f4.patch
+lts-m86_builtins_fix_array_prototype_concat_with_species.patch
+lts-m86_builtins_harden_array_prototype_concat.patch

--- a/patches/v8/lts-m86_builtins_fix_array_prototype_concat_with_species.patch
+++ b/patches/v8/lts-m86_builtins_fix_array_prototype_concat_with_species.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Igor Sheludko <ishell@chromium.org>
 Date: Wed, 7 Apr 2021 19:12:32 +0200
-Subject: [LTS-M86][builtins] Fix Array.prototype.concat with @@species
+Subject: Fix Array.prototype.concat with @@species
 
 (cherry picked from commit 7989e04979c3195e60a6814e8263063eb91f7b47)
 

--- a/patches/v8/lts-m86_builtins_fix_array_prototype_concat_with_species.patch
+++ b/patches/v8/lts-m86_builtins_fix_array_prototype_concat_with_species.patch
@@ -1,0 +1,96 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Sheludko <ishell@chromium.org>
+Date: Wed, 7 Apr 2021 19:12:32 +0200
+Subject: [LTS-M86][builtins] Fix Array.prototype.concat with @@species
+
+(cherry picked from commit 7989e04979c3195e60a6814e8263063eb91f7b47)
+
+No-Try: true
+No-Presubmit: true
+No-Tree-Checks: true
+Bug: chromium:1195977
+Change-Id: I16843bce2e9f776abca0f2b943b898ab5e597e42
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2810787
+Reviewed-by: Camillo Bruni <cbruni@chromium.org>
+Commit-Queue: Igor Sheludko <ishell@chromium.org>
+Cr-Original-Commit-Position: refs/heads/master@{#73842}
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2823829
+Commit-Queue: Jana Grill <janagrill@chromium.org>
+Reviewed-by: Igor Sheludko <ishell@chromium.org>
+Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
+Cr-Commit-Position: refs/branch-heads/8.6@{#77}
+Cr-Branched-From: a64aed2333abf49e494d2a5ce24bbd14fff19f60-refs/heads/8.6.395@{#1}
+Cr-Branched-From: a626bc036236c9bf92ac7b87dc40c9e538b087e3-refs/heads/master@{#69472}
+
+diff --git a/src/builtins/builtins-array.cc b/src/builtins/builtins-array.cc
+index 3c2fe33c5b4b330c509d2926bc1e30daa1e09dba..938fb96c1d42d8152f974df33c3bed4cc1b542d3 100644
+--- a/src/builtins/builtins-array.cc
++++ b/src/builtins/builtins-array.cc
+@@ -649,11 +649,14 @@ class ArrayConcatVisitor {
+         index_offset_(0u),
+         bit_field_(FastElementsField::encode(fast_elements) |
+                    ExceedsLimitField::encode(false) |
+-                   IsFixedArrayField::encode(storage->IsFixedArray()) |
++                   IsFixedArrayField::encode(storage->IsFixedArray(isolate)) |
+                    HasSimpleElementsField::encode(
+-                       storage->IsFixedArray() ||
+-                       !storage->map().IsCustomElementsReceiverMap())) {
+-    DCHECK(!(this->fast_elements() && !is_fixed_array()));
++                       storage->IsFixedArray(isolate) ||
++                       // Don't take fast path for storages that might have
++                       // side effects when storing to them.
++                       (!storage->map(isolate).IsCustomElementsReceiverMap() &&
++                        !storage->IsJSTypedArray(isolate)))) {
++    DCHECK_IMPLIES(this->fast_elements(), is_fixed_array());
+   }
+ 
+   ~ArrayConcatVisitor() { clear_storage(); }
+@@ -1063,8 +1066,8 @@ bool IterateElements(Isolate* isolate, Handle<JSReceiver> receiver,
+     return IterateElementsSlow(isolate, receiver, length, visitor);
+   }
+ 
+-  if (!HasOnlySimpleElements(isolate, *receiver) ||
+-      !visitor->has_simple_elements()) {
++  if (!visitor->has_simple_elements() ||
++      !HasOnlySimpleElements(isolate, *receiver)) {
+     return IterateElementsSlow(isolate, receiver, length, visitor);
+   }
+   Handle<JSObject> array = Handle<JSObject>::cast(receiver);
+diff --git a/src/objects/fixed-array-inl.h b/src/objects/fixed-array-inl.h
+index e60224315826c793ea8e9327db6c7a62786530c3..e4796b00a33ab56c1bdf7b9db570bf5add406a27 100644
+--- a/src/objects/fixed-array-inl.h
++++ b/src/objects/fixed-array-inl.h
+@@ -336,7 +336,7 @@ int Search(T* array, Name name, int valid_entries, int* out_insertion_index,
+ double FixedDoubleArray::get_scalar(int index) {
+   DCHECK(map() != GetReadOnlyRoots().fixed_cow_array_map() &&
+          map() != GetReadOnlyRoots().fixed_array_map());
+-  DCHECK(index >= 0 && index < this->length());
++  DCHECK_LT(static_cast<unsigned>(index), static_cast<unsigned>(length()));
+   DCHECK(!is_the_hole(index));
+   return ReadField<double>(kHeaderSize + index * kDoubleSize);
+ }
+@@ -344,7 +344,7 @@ double FixedDoubleArray::get_scalar(int index) {
+ uint64_t FixedDoubleArray::get_representation(int index) {
+   DCHECK(map() != GetReadOnlyRoots().fixed_cow_array_map() &&
+          map() != GetReadOnlyRoots().fixed_array_map());
+-  DCHECK(index >= 0 && index < this->length());
++  DCHECK_LT(static_cast<unsigned>(index), static_cast<unsigned>(length()));
+   int offset = kHeaderSize + index * kDoubleSize;
+   // Bug(v8:8875): Doubles may be unaligned.
+   return base::ReadUnalignedValue<uint64_t>(field_address(offset));
+@@ -362,6 +362,7 @@ Handle<Object> FixedDoubleArray::get(FixedDoubleArray array, int index,
+ void FixedDoubleArray::set(int index, double value) {
+   DCHECK(map() != GetReadOnlyRoots().fixed_cow_array_map() &&
+          map() != GetReadOnlyRoots().fixed_array_map());
++  DCHECK_LT(static_cast<unsigned>(index), static_cast<unsigned>(length()));
+   int offset = kHeaderSize + index * kDoubleSize;
+   if (std::isnan(value)) {
+     WriteField<double>(offset, std::numeric_limits<double>::quiet_NaN());
+@@ -378,6 +379,7 @@ void FixedDoubleArray::set_the_hole(Isolate* isolate, int index) {
+ void FixedDoubleArray::set_the_hole(int index) {
+   DCHECK(map() != GetReadOnlyRoots().fixed_cow_array_map() &&
+          map() != GetReadOnlyRoots().fixed_array_map());
++  DCHECK_LT(static_cast<unsigned>(index), static_cast<unsigned>(length()));
+   int offset = kHeaderSize + index * kDoubleSize;
+   base::WriteUnalignedValue<uint64_t>(field_address(offset), kHoleNanInt64);
+ }

--- a/patches/v8/lts-m86_builtins_harden_array_prototype_concat.patch
+++ b/patches/v8/lts-m86_builtins_harden_array_prototype_concat.patch
@@ -1,0 +1,79 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jana Grill <janagrill@google.com>
+Date: Tue, 13 Apr 2021 16:54:14 +0200
+Subject: [LTS-M86][builtins] Harden Array.prototype.concat.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Defence in depth patch to prevent JavaScript from executing
+from within IterateElements.
+
+R=​ishell@chromium.org
+R=​cbruni@chromium.org
+
+(cherry picked from commit 8284359ed0607e452a4dda2ce89811fb019b4aaa)
+
+No-Try: true
+No-Presubmit: true
+No-Tree-Checks: true
+Bug: chromium:1195977
+Change-Id: Ie59d468b73b94818cea986a3ded0804f6dddd10b
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2819941
+Reviewed-by: Camillo Bruni <cbruni@chromium.org>
+Reviewed-by: Igor Sheludko <ishell@chromium.org>
+Commit-Queue: Igor Sheludko <ishell@chromium.org>
+Cr-Original-Commit-Position: refs/heads/master@{#73898}
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2821961
+Commit-Queue: Jana Grill <janagrill@chromium.org>
+Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
+Cr-Commit-Position: refs/branch-heads/8.6@{#76}
+Cr-Branched-From: a64aed2333abf49e494d2a5ce24bbd14fff19f60-refs/heads/8.6.395@{#1}
+Cr-Branched-From: a626bc036236c9bf92ac7b87dc40c9e538b087e3-refs/heads/master@{#69472}
+
+diff --git a/AUTHORS b/AUTHORS
+index 054e2bee4b6e2a5ee99cb3229c98095fce52f0a5..209548ea4b67d13826fea1f1b93e7320f8279fc0 100644
+--- a/AUTHORS
++++ b/AUTHORS
+@@ -69,6 +69,7 @@ Ben Newman <ben@meteor.com>
+ Ben Noordhuis <info@bnoordhuis.nl>
+ Benjamin Tan <demoneaux@gmail.com>
+ Bert Belder <bertbelder@gmail.com>
++Brendon Tiszka <btiszka@gmail.com>
+ Burcu Dogan <burcujdogan@gmail.com>
+ Caitlin Potter <caitpotter88@gmail.com>
+ Craig Schlenter <craig.schlenter@gmail.com>
+diff --git a/src/builtins/builtins-array.cc b/src/builtins/builtins-array.cc
+index 938fb96c1d42d8152f974df33c3bed4cc1b542d3..8055d8382d48f618d8fcd3b18f48b2da04fa3f69 100644
+--- a/src/builtins/builtins-array.cc
++++ b/src/builtins/builtins-array.cc
+@@ -1083,6 +1083,9 @@ bool IterateElements(Isolate* isolate, Handle<JSReceiver> receiver,
+     case HOLEY_SEALED_ELEMENTS:
+     case HOLEY_NONEXTENSIBLE_ELEMENTS:
+     case HOLEY_ELEMENTS: {
++      // Disallow execution so the cached elements won't change mid execution.
++      DisallowJavascriptExecution no_js(isolate);
++
+       // Run through the elements FixedArray and use HasElement and GetElement
+       // to check the prototype for missing elements.
+       Handle<FixedArray> elements(FixedArray::cast(array->elements()), isolate);
+@@ -1109,6 +1112,9 @@ bool IterateElements(Isolate* isolate, Handle<JSReceiver> receiver,
+     }
+     case HOLEY_DOUBLE_ELEMENTS:
+     case PACKED_DOUBLE_ELEMENTS: {
++      // Disallow execution so the cached elements won't change mid execution.
++      DisallowJavascriptExecution no_js(isolate);
++
+       // Empty array is FixedArray but not FixedDoubleArray.
+       if (length == 0) break;
+       // Run through the elements FixedArray and use HasElement and GetElement
+@@ -1145,6 +1151,9 @@ bool IterateElements(Isolate* isolate, Handle<JSReceiver> receiver,
+     }
+ 
+     case DICTIONARY_ELEMENTS: {
++      // Disallow execution so the cached dictionary won't change mid execution.
++      DisallowJavascriptExecution no_js(isolate);
++
+       Handle<NumberDictionary> dict(array->element_dictionary(), isolate);
+       std::vector<uint32_t> indices;
+       indices.reserve(dict->Capacity() / 2);

--- a/patches/v8/lts-m86_builtins_harden_array_prototype_concat.patch
+++ b/patches/v8/lts-m86_builtins_harden_array_prototype_concat.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jana Grill <janagrill@google.com>
 Date: Tue, 13 Apr 2021 16:54:14 +0200
-Subject: [LTS-M86][builtins] Harden Array.prototype.concat.
+Subject: Harden Array.prototype.concat.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit


### PR DESCRIPTION
[LTS-M86][builtins] Fix Array.prototype.concat with @@species

(cherry picked from commit 7989e04979c3195e60a6814e8263063eb91f7b47)

No-Try: true
No-Presubmit: true
No-Tree-Checks: true
Bug: chromium:1195977
Change-Id: I16843bce2e9f776abca0f2b943b898ab5e597e42
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2810787
Reviewed-by: Camillo Bruni <cbruni@chromium.org>
Commit-Queue: Igor Sheludko <ishell@chromium.org>
Cr-Original-Commit-Position: refs/heads/master@{#73842}
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2823829
Commit-Queue: Jana Grill <janagrill@chromium.org>
Reviewed-by: Igor Sheludko <ishell@chromium.org>
Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
Cr-Commit-Position: refs/branch-heads/8.6@{#77}
Cr-Branched-From: a64aed2333abf49e494d2a5ce24bbd14fff19f60-refs/heads/8.6.395@{#1}
Cr-Branched-From: a626bc036236c9bf92ac7b87dc40c9e538b087e3-refs/heads/master@{#69472}

==========

[LTS-M86][builtins] Harden Array.prototype.concat.

Defence in depth patch to prevent JavaScript from executing
from within IterateElements.

R=​ishell@chromium.org
R=​cbruni@chromium.org

(cherry picked from commit 8284359ed0607e452a4dda2ce89811fb019b4aaa)

No-Try: true
No-Presubmit: true
No-Tree-Checks: true
Bug: chromium:1195977
Change-Id: Ie59d468b73b94818cea986a3ded0804f6dddd10b
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2819941
Reviewed-by: Camillo Bruni <cbruni@chromium.org>
Reviewed-by: Igor Sheludko <ishell@chromium.org>
Commit-Queue: Igor Sheludko <ishell@chromium.org>
Cr-Original-Commit-Position: refs/heads/master@{#73898}
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2821961
Commit-Queue: Jana Grill <janagrill@chromium.org>
Reviewed-by: Victor-Gabriel Savu <vsavu@google.com>
Cr-Commit-Position: refs/branch-heads/8.6@{#76}
Cr-Branched-From: a64aed2333abf49e494d2a5ce24bbd14fff19f60-refs/heads/8.6.395@{#1}
Cr-Branched-From: a626bc036236c9bf92ac7b87dc40c9e538b087e3-refs/heads/master@{#69472}


Notes: Security: backported fix to CVE-2021-21225.
