### PR TITLE
docs: Added loadFile instead of loadURL in BrowserWindow documentation example

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -14,7 +14,7 @@ const win = new BrowserWindow({ width: 800, height: 600 })
 win.loadURL('https://github.com')
 
 // Or load a local HTML file
-win.loadFile(`index.html`)
+win.loadFile('index.html')
 ```
 
 ## Frameless window

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -14,7 +14,7 @@ const win = new BrowserWindow({ width: 800, height: 600 })
 win.loadURL('https://github.com')
 
 // Or load a local HTML file
-win.loadURL(`file://${__dirname}/app/index.html`)
+win.loadFile(`index.html`)
 ```
 
 ## Frameless window


### PR DESCRIPTION
For loading a local file the loadFile API is a better way to load any html file in the Renderer process.

Have changed it in the example.

#### Description of Change

Have edited a example in BrowserWindow section of electron docs, to load local files using loadFile() api instead of loadURL() api. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none.