### PR TITLE
build: fix releases that failed halfway through npm publish actions

### DIFF
--- a/script/release/publish-to-npm.js
+++ b/script/release/publish-to-npm.js
@@ -152,7 +152,13 @@ new Promise((resolve, reject) => {
       resolve(tarballPath);
     });
   })
-  .then((tarballPath) => childProcess.execSync(`npm publish ${tarballPath} --tag ${npmTag} --otp=${process.env.ELECTRON_NPM_OTP}`))
+  .then((tarballPath) => {
+    const existingVersionJSON = childProcess.execSync(`npm view electron@${rootPackageJson.version} --json`).toString('utf-8');
+    // It's possible this is a re-run and we already have published the package, if not we just publish like normal
+    if (!existingVersionJSON) {
+      childProcess.execSync(`npm publish ${tarballPath} --tag ${npmTag} --otp=${process.env.ELECTRON_NPM_OTP}`);
+    }
+  })
   .then(() => {
     const currentTags = JSON.parse(childProcess.execSync('npm show electron dist-tags --json').toString());
     const localVersion = rootPackageJson.version;


### PR DESCRIPTION
Sometimes the publish succeeds and the tagging fails, on reruns the publish then fails because you can't publish over an already published release.

This change checks if the npm version is already published before trying to publish it again which will allow reruns of this step in sudowoodo to work correctly.

Notes: no-notes