### PR TITLE
docs: Remove mentions of the old external_binaries directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@
 *.xcodeproj
 /.idea/
 /dist/
-/external_binaries/
 /out/
 /vendor/.gclient
 /vendor/debian_jessie_mips64-sysroot/

--- a/docs/development/source-code-directory-structure.md
+++ b/docs/development/source-code-directory-structure.md
@@ -83,8 +83,6 @@ Electron
 * **.github** - GitHub-specific config files including issues templates and CODEOWNERS.
 * **dist** - Temporary directory created by `script/create-dist.py` script
   when creating a distribution.
-* **external_binaries** - Downloaded binaries of third-party frameworks which
-  do not support building with `gn`.
 * **node_modules** - Third party node modules used for building.
 * **npm** - Logic for installation of Electron via npm.
 * **out** - Temporary output directory of `ninja`.


### PR DESCRIPTION
This functionality was removed in
https://github.com/electron/electron/pull/26701.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
Notes: none