### PR TITLE
test: disable shell.trashItem in renderer test on win-ia32

### DIFF
--- a/spec-main/api-shell-spec.ts
+++ b/spec-main/api-shell-spec.ts
@@ -2,6 +2,7 @@ import { BrowserWindow, app } from 'electron/main';
 import { shell } from 'electron/common';
 import { closeAllWindows } from './window-helpers';
 import { emittedOnce } from './events-helpers';
+import { ifit } from './spec-helpers';
 import * as http from 'http';
 import * as fs from 'fs-extra';
 import * as path from 'path';
@@ -77,7 +78,7 @@ describe('shell module', () => {
       await expect(shell.trashItem(filename)).to.eventually.be.rejected();
     });
 
-    it('works in the renderer process', async () => {
+    ifit(!(process.platform === 'win32' && process.arch === 'ia32'))('works in the renderer process', async () => {
       const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, contextIsolation: false } });
       w.loadURL('about:blank');
       await expect(w.webContents.executeJavaScript('require(\'electron\').shell.trashItem(\'does-not-exist\')')).to.be.rejectedWith(/does-not-exist|Failed to move item|Failed to create FileOperation/);


### PR DESCRIPTION
#### Description of Change
This test is timing out consistently on windows / ia32 for unknown reasons. Ref #28748.

Notes: none
