### PR TITLE
docs: the tools folder does not exist anymore

### DIFF
--- a/docs/development/source-code-directory-structure.md
+++ b/docs/development/source-code-directory-structure.md
@@ -98,7 +98,5 @@ script/ - The set of all scripts Electron runs for a variety of purposes.
     └── uploaders/ - Uploads various release-related files during release.
 ```
 
-* **tools** - Helper scripts used by GN files.
-  * Scripts put here should never be invoked by users directly, unlike those in `script`.
 * **typings** - TypeScript typings for Electron's internal code.
 * **vendor** - Source code for some third party dependencies.


### PR DESCRIPTION
Follow up to #28859 the `tools` directory does not exist anymore either.  We migrated everything to `build/` or `scripts/`

Notes: no-notes