### PR TITLE
build: actually use SSL when downloading things via python

### DIFF
--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -65,9 +65,6 @@ def scoped_env(key, value):
 def download(text, url, path):
   safe_mkdir(os.path.dirname(path))
   with open(path, 'wb') as local_file:
-    if hasattr(ssl, '_create_unverified_context'):
-      ssl._create_default_https_context = ssl._create_unverified_context
-
     print("Downloading %s to %s" % (url, path))
     web_file = urlopen(url)
     info = web_file.info()


### PR DESCRIPTION
This is like 6 year old tech debt that I just stumbled upon, this might blow up the nightly tomorrow but I honestly wouldn't be able to explain why if it does.  Anyway, SSL is a good thing lol.

Notes: none