### PR TITLE
fix: don't propagate GDK_BACKEND to subprocs

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -156,7 +156,7 @@ std::u16string MediaStringProvider(media::MessageId id) {
 
 #if defined(OS_LINUX)
 
-std::string gdk_backend;
+const char* gdk_backend;
 
 void OverrideLinuxAppDataPath() {
   base::FilePath path;
@@ -380,7 +380,7 @@ void ElectronBrowserMainParts::PostDestroyThreads() {
 
 #if defined(OS_LINUX)
 // static
-std::string ElectronBrowserMainParts::GetGDKBackend() {
+const char* ElectronBrowserMainParts::GetGDKBackend() {
   return gdk_backend;
 }
 #endif
@@ -391,7 +391,9 @@ void ElectronBrowserMainParts::ToolkitInitialized() {
   // https://chromium-review.googlesource.com/c/chromium/src/+/2586184
   // and can detrimentally affect external app behaviors, so we want to
   // check if the user has set it so we can use it later.
-  base::Environment::Create()->GetVar("GDK_BACKEND", &gdk_backend);
+  std::string backend;
+  if (base::Environment::Create()->GetVar("GDK_BACKEND", &backend))
+    gdk_backend = backend.c_str();
 
   auto linux_ui = BuildGtkUi();
   linux_ui->Initialize();

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -155,6 +155,9 @@ std::u16string MediaStringProvider(media::MessageId id) {
 }
 
 #if defined(OS_LINUX)
+
+std::string gdk_backend;
+
 void OverrideLinuxAppDataPath() {
   base::FilePath path;
   if (base::PathService::Get(DIR_APP_DATA, &path))
@@ -375,8 +378,21 @@ void ElectronBrowserMainParts::PostDestroyThreads() {
   fake_browser_process_->PostDestroyThreads();
 }
 
+#if defined(OS_LINUX)
+// static
+std::string ElectronBrowserMainParts::GetGDKBackend() {
+  return gdk_backend;
+}
+#endif
+
 void ElectronBrowserMainParts::ToolkitInitialized() {
 #if defined(OS_LINUX)
+  // This is set by Chromium here:
+  // https://chromium-review.googlesource.com/c/chromium/src/+/2586184
+  // and can detrimentally affect external app behaviors, so we want to
+  // check if the user has set it so we can use it later.
+  base::Environment::Create()->GetVar("GDK_BACKEND", &gdk_backend);
+
   auto linux_ui = BuildGtkUi();
   linux_ui->Initialize();
 

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -156,8 +156,6 @@ std::u16string MediaStringProvider(media::MessageId id) {
 
 #if defined(OS_LINUX)
 
-const char* gdk_backend;
-
 void OverrideLinuxAppDataPath() {
   base::FilePath path;
   if (base::PathService::Get(DIR_APP_DATA, &path))
@@ -380,7 +378,8 @@ void ElectronBrowserMainParts::PostDestroyThreads() {
 
 #if defined(OS_LINUX)
 // static
-const char* ElectronBrowserMainParts::GetGDKBackend() {
+base::Optional<std::string>& ElectronBrowserMainParts::GetGDKBackend() {
+  static base::Optional<std::string> gdk_backend;
   return gdk_backend;
 }
 #endif
@@ -393,7 +392,7 @@ void ElectronBrowserMainParts::ToolkitInitialized() {
   // check if the user has set it so we can use it later.
   std::string backend;
   if (base::Environment::Create()->GetVar("GDK_BACKEND", &backend))
-    gdk_backend = backend.c_str();
+    GetGDKBackend().reset(backend);
 
   auto linux_ui = BuildGtkUi();
   linux_ui->Initialize();

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -88,6 +88,11 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   Browser* browser() { return browser_.get(); }
   BrowserProcessImpl* browser_process() { return fake_browser_process_.get(); }
 
+#if defined(OS_LINUX)
+  // Used by platform_util to set GDK_BACKEND.
+  static const char* GetGDKBackend();
+#endif
+
  protected:
   // content::BrowserMainParts:
   int PreEarlyInitialization() override;
@@ -132,9 +137,6 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
 #endif
 
 #if defined(OS_LINUX)
-  // Used by platform_util to set GDK_BACKEND.
-  static std::string GetGDKBackend();
-
   // Used to notify the native theme of changes to dark mode.
   std::unique_ptr<DarkThemeObserver> dark_theme_observer_;
 #endif

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -132,6 +132,9 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
 #endif
 
 #if defined(OS_LINUX)
+  // Used by platform_util to set GDK_BACKEND.
+  static std::string GetGDKBackend();
+
   // Used to notify the native theme of changes to dark mode.
   std::unique_ptr<DarkThemeObserver> dark_theme_observer_;
 #endif

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -90,7 +90,7 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
 
 #if defined(OS_LINUX)
   // Used by platform_util to set GDK_BACKEND.
-  static const char* GetGDKBackend();
+  static base::Optional<std::string>& GetGDKBackend();
 #endif
 
  protected:

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -19,6 +19,7 @@
 #include "dbus/bus.h"
 #include "dbus/message.h"
 #include "dbus/object_proxy.h"
+#include "shell/browser/electron_browser_main_parts.h"
 #include "shell/common/platform_util_internal.h"
 #include "ui/gtk/gtk_util.h"
 #include "url/gurl.h"
@@ -126,9 +127,9 @@ bool XDGUtil(const std::vector<std::string>& argv,
   // otherwise unset it. Setting values in EnvironmentMap to an empty-string
   // will make sure that they get unset from the environment via
   // AlterEnvironment().
-  std::string gdk_backend = ElectronBrowserMainParts::GetGDKBackend();
+  const char* gdk_backend = electron::ElectronBrowserMainParts::GetGDKBackend();
   options.environment["GDK_BACKEND"] =
-      gdk_backend ? gdk_backend.c_str() : base::NativeEnvironmentString();
+      gdk_backend ? gdk_backend : base::NativeEnvironmentString();
 
   base::Process process = base::LaunchProcess(argv, options);
   if (!process.IsValid())

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -124,12 +124,16 @@ bool XDGUtil(const std::vector<std::string>& argv,
   options.environment["MM_NOTTTY"] = "1";
 
   // If the user set a GDK_BACKEND value of their own, use that,
-  // otherwise unset it. Setting values in EnvironmentMap to an empty-string
+  // otherwise unset it becuase Chromium is setting GDK_BACKEND
+  // during GTK initialization and we want to respect user preference.
+  // Setting values in EnvironmentMap to an empty-string
   // will make sure that they get unset from the environment via
   // AlterEnvironment().
-  const char* gdk_backend = electron::ElectronBrowserMainParts::GetGDKBackend();
-  options.environment["GDK_BACKEND"] =
-      gdk_backend ? gdk_backend : base::NativeEnvironmentString();
+  const base::Optional<std::string>& gdk_backend =
+      electron::ElectronBrowserMainParts::GetGDKBackend();
+  options.environment["GDK_BACKEND"] = gdk_backend.has_value()
+                                           ? gdk_backend.value().c_str()
+                                           : base::NativeEnvironmentString();
 
   base::Process process = base::LaunchProcess(argv, options);
   if (!process.IsValid())

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -122,18 +122,13 @@ bool XDGUtil(const std::vector<std::string>& argv,
   // bring up a new terminal if necessary.  See "man mailcap".
   options.environment["MM_NOTTTY"] = "1";
 
-  // This is set by Chromium here:
-  // https://chromium-review.googlesource.com/c/chromium/src/+/2586184
-  // and can detrimentally affect external app behaviors, so we want to
-  // unset it and replace with the user's setting if one exists.
-  std::string gdk_backend;
-  if (base::Environment::Create()->GetVar("GDK_BACKEND", &gdk_backend)) {
-    options.environment["GDK_BACKEND"] = gdk_backend.c_str();
-  } else {
-    // Setting values in EnvironmentMap to an empty-string will make
-    // sure that they get unset from the environment via AlterEnvironment().
-    options.environment["GDK_BACKEND"] = base::NativeEnvironmentString();
-  }
+  // If the user set a GDK_BACKEND value of their own, use that,
+  // otherwise unset it. Setting values in EnvironmentMap to an empty-string
+  // will make sure that they get unset from the environment via
+  // AlterEnvironment().
+  std::string gdk_backend = ElectronBrowserMainParts::GetGDKBackend();
+  options.environment["GDK_BACKEND"] =
+      gdk_backend ? gdk_backend.c_str() : base::NativeEnvironmentString();
 
   base::Process process = base::LaunchProcess(argv, options);
   if (!process.IsValid())

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -122,6 +122,19 @@ bool XDGUtil(const std::vector<std::string>& argv,
   // bring up a new terminal if necessary.  See "man mailcap".
   options.environment["MM_NOTTTY"] = "1";
 
+  // This is set by Chromium here:
+  // https://chromium-review.googlesource.com/c/chromium/src/+/2586184
+  // and can detrimentally affect external app behaviors, so we want to
+  // unset it and replace with the user's setting if one exists.
+  std::string gdk_backend;
+  if (base::Environment::Create()->GetVar("GDK_BACKEND", &gdk_backend)) {
+    options.environment["GDK_BACKEND"] = gdk_backend.c_str();
+  } else {
+    // Setting values in EnvironmentMap to an empty-string will make
+    // sure that they get unset from the environment via AlterEnvironment().
+    options.environment["GDK_BACKEND"] = base::NativeEnvironmentString();
+  }
+
   base::Process process = base::LaunchProcess(argv, options);
   if (!process.IsValid())
     return false;

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -367,6 +367,13 @@ describe('web security', () => {
   });
 });
 
+ifdescribe(process.platform === 'linux')('subprocesses', () => {
+  it('does not propagate GDK_BACKEND', () => {
+    const backend = process.env.GDK_BACKEND;
+    expect(backend).to.eq(null);
+  });
+});
+
 describe('command line switches', () => {
   let appProcess: ChildProcess.ChildProcessWithoutNullStreams | undefined;
   afterEach(() => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/28436.

`GDK_BACKEND` is set by Chromium as of [this CL](https://chromium-review.googlesource.com/c/chromium/src/+/2586184) and can detrimentally affect external app behaviors, so we want to unset it and replace with the user's setting if one exists.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `GDK_BACKEND` was being propagated to subprocesses on Linux.
