### PR TITLE
chore: Browser::SetAppUserModelID is Windows only

### DIFF
--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -83,8 +83,10 @@ class Browser : public WindowListObserver {
   // Clear the recent documents list.
   void ClearRecentDocuments();
 
+#if defined(OS_WIN)
   // Set the application user model ID.
   void SetAppUserModelID(const std::wstring& name);
+#endif
 
   // Remove the default protocol handler registry key
   bool RemoveAsDefaultProtocolClient(const std::string& protocol,

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -88,8 +88,6 @@ void Browser::AddRecentDocument(const base::FilePath& path) {}
 
 void Browser::ClearRecentDocuments() {}
 
-void Browser::SetAppUserModelID(const std::wstring& name) {}
-
 bool Browser::SetAsDefaultProtocolClient(const std::string& protocol,
                                          gin::Arguments* args) {
   return SetDefaultWebClient(protocol);

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -218,8 +218,6 @@ std::u16string Browser::GetApplicationNameForProtocol(const GURL& url) {
   return app_display_name;
 }
 
-void Browser::SetAppUserModelID(const std::wstring& name) {}
-
 bool Browser::SetBadgeCount(base::Optional<int> count) {
   DockSetBadgeText(!count.has_value() || count.value() != 0
                        ? badging::BadgeManager::GetBadgeString(count)


### PR DESCRIPTION
#### Description of Change
After #28127 this is Windows only https://github.com/electron/electron/blob/56c3103e73ac71bd6845a31a2e37f5ffd0810be7/shell/browser/api/electron_api_app.cc#L1538-L1541

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes
