### PR TITLE
build: fix dump_syms.py to work with python 3

### DIFF
--- a/build/dump_syms.py
+++ b/build/dump_syms.py
@@ -39,7 +39,7 @@ def main(dump_syms, binary, out_dir, stamp_file, dsym_file=None):
     args += ["-g", dsym_file]
   args += [binary]
 
-  symbol_data = subprocess.check_output(args)
+  symbol_data = subprocess.check_output(args).decode(sys.stdout.encoding)
   symbol_path = os.path.join(out_dir, get_symbol_path(symbol_data))
   mkdir_p(os.path.dirname(symbol_path))
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
This PR fixes the python 3 error found when generating breakpad symbols on our release builds:
https://app.circleci.com/pipelines/github/electron/electron/38729/workflows/85a2e978-9b30-4540-ad18-74dc974f0f61/jobs/854168

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
