### PR TITLE
fix: provide no-op implementation of app.setUserModelId

### DIFF
--- a/lib/browser/api/app.ts
+++ b/lib/browser/api/app.ts
@@ -63,6 +63,9 @@ Object.defineProperty(app, 'applicationMenu', {
   return execFile !== 'electron';
 })();
 
+// The native implementation is not provided on non-windows platforms
+app.setAppUserModelId = app.setAppUserModelId || (() => {});
+
 app._setDefaultAppPaths = (packagePath) => {
   // Set the user path according to application's name.
   app.setPath('userData', path.join(app.getPath('appData'), app.name!));


### PR DESCRIPTION
Refs: https://github.com/electron/electron/pull/28909#issuecomment-828739482

Notes: Restored cross-platform noop implementation of `app.setAppUserModelId`