### PR TITLE
feat: add preloadInWorker API

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -268,6 +268,12 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       When node integration is turned off, the preload script can reintroduce
       Node global symbols back to the global scope. See example
       [here](context-bridge.md#exposing-node-global-symbols).
+    * `preloadInWorker` String (optional) - Specifies a script that will be loaded before other
+      scripts run in worker. This script will always have access to node APIs
+      no matter whether node integration in worker is turned on or off. The value should
+      be the absolute file path to the script.
+      When node integration is turned off, the preload script can reintroduce
+      Node global symbols back to the global scope.
     * `sandbox` Boolean (optional) - If set, this will sandbox the renderer
       associated with the window, making it compatible with the Chromium
       OS-level sandbox and disabling the Node.js engine. This is not the same as

--- a/lib/worker/init.ts
+++ b/lib/worker/init.ts
@@ -12,24 +12,61 @@ require('../common/reset-search-paths');
 // Import common settings.
 require('@electron/internal/common/init');
 
-// Export node bindings to global.
-const { makeRequireFunction } = __non_webpack_require__('internal/modules/cjs/helpers') // eslint-disable-line
-global.module = new Module('electron/js2c/worker_init');
-global.require = makeRequireFunction(global.module);
+// Process command line arguments.
+const { hasSwitch, getSwitchValue } = process._linkedBinding('electron_common_command_line');
 
-// Set the __filename to the path of html file if it is file: protocol.
-if (self.location.protocol === 'file:') {
-  const pathname = process.platform === 'win32' && self.location.pathname[0] === '/' ? self.location.pathname.substr(1) : self.location.pathname;
-  global.__filename = path.normalize(decodeURIComponent(pathname));
-  global.__dirname = path.dirname(global.__filename);
+const parseOption = function (name: string) {
+  return hasSwitch(name) ? getSwitchValue(name) : null;
+};
 
-  // Set module's filename so relative require can work as expected.
-  global.module.filename = global.__filename;
+const nodeIntegration = hasSwitch('node-integration-in-worker');
+const preloadScript = parseOption('preload-in-worker');
 
-  // Also search for module under the html file.
-  global.module.paths = Module._nodeModulePaths(global.__dirname);
+if (nodeIntegration) {
+  // Export node bindings to global.
+  const { makeRequireFunction } = __non_webpack_require__('internal/modules/cjs/helpers') // eslint-disable-line
+  global.module = new Module('electron/js2c/worker_init');
+  global.require = makeRequireFunction(global.module);
+
+  // Set the __filename to the path of html file if it is file: protocol.
+  if (self.location.protocol === 'file:') {
+    const pathname = process.platform === 'win32' && self.location.pathname[0] === '/' ? self.location.pathname.substr(1) : self.location.pathname;
+    global.__filename = path.normalize(decodeURIComponent(pathname));
+    global.__dirname = path.dirname(global.__filename);
+
+    // Set module's filename so relative require can work as expected.
+    global.module.filename = global.__filename;
+
+    // Also search for module under the html file.
+    global.module.paths = Module._nodeModulePaths(global.__dirname);
+  } else {
+    // For backwards compatibility we fake these two paths here
+    global.__filename = path.join(process.resourcesPath, 'electron.asar', 'worker', 'init.js');
+    global.__dirname = path.join(process.resourcesPath, 'electron.asar', 'worker');
+  }
 } else {
-  // For backwards compatibility we fake these two paths here
-  global.__filename = path.join(process.resourcesPath, 'electron.asar', 'worker', 'init.js');
-  global.__dirname = path.join(process.resourcesPath, 'electron.asar', 'worker');
+  // Delete Node's symbols after the Environment has been loaded.
+  process.once('loaded', function () {
+    delete (global as any).process;
+    delete (global as any).Buffer;
+    delete (global as any).setImmediate;
+    delete (global as any).clearImmediate;
+    delete (global as any).global;
+    delete (global as any).root;
+    delete (global as any).GLOBAL;
+  });
+}
+
+const preloadScripts = [];
+if (preloadScript) {
+  preloadScripts.push(preloadScript);
+}
+
+for (const preloadScript of preloadScripts) {
+  try {
+    Module._load(preloadScript);
+  } catch (error) {
+    console.error(`Unable to load preload script: ${preloadScript}`);
+    console.error(error);
+  }
 }

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -276,6 +276,21 @@ bool WebContentsPreferences::GetPreloadPath(base::FilePath* path) const {
   return false;
 }
 
+bool WebContentsPreferences::GetPreloadInWorkerPath(
+    base::FilePath::StringType* path) const {
+  DCHECK(path);
+  base::FilePath::StringType preload;
+  if (GetAsString(&preference_, options::kPreloadScriptInWorker, &preload)) {
+    if (base::FilePath(preload).IsAbsolute()) {
+      *path = std::move(preload);
+      return true;
+    } else {
+      LOG(ERROR) << "preloadInWorker script must have absolute path.";
+    }
+  }
+  return false;
+}
+
 // static
 content::WebContents* WebContentsPreferences::GetWebContentsFromProcessID(
     int process_id) {
@@ -362,6 +377,13 @@ void WebContentsPreferences::AppendCommandLineSwitches(
 
   if (IsEnabled(options::kNodeIntegrationInWorker))
     command_line->AppendSwitch(switches::kNodeIntegrationInWorker);
+
+  // The preload in worker script.
+  base::FilePath::StringType preloadInWorker;
+  if (GetPreloadInWorkerPath(&preloadInWorker)) {
+    command_line->AppendSwitchNative(switches::kPreloadScriptInWorker,
+                                     preloadInWorker);
+  }
 
   // We are appending args to a webContents so let's save the current state
   // of our preferences object so that during the lifetime of the WebContents

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -61,6 +61,9 @@ class WebContentsPreferences
   // Returns the preload script path.
   bool GetPreloadPath(base::FilePath* path) const;
 
+  // Returns the preload script path to be used in worker.
+  bool GetPreloadInWorkerPath(base::FilePath::StringType* path) const;
+
   // Returns the web preferences.
   base::Value* preference() { return &preference_; }
   base::Value* last_preference() { return &last_preference_; }

--- a/shell/common/options_switches.cc
+++ b/shell/common/options_switches.cc
@@ -115,6 +115,9 @@ const char kPreloadScripts[] = "preloadScripts";
 // Like --preload, but the passed argument is an URL.
 const char kPreloadURL[] = "preloadURL";
 
+// Script that will be loaded by guest WebWorker before other scripts.
+const char kPreloadScriptInWorker[] = "preloadInWorker";
+
 // Enable the node integration.
 const char kNodeIntegration[] = "nodeIntegration";
 
@@ -244,6 +247,9 @@ const char kScrollBounce[] = "scroll-bounce";
 
 // Command switch passed to renderer process to control nodeIntegration.
 const char kNodeIntegrationInWorker[] = "node-integration-in-worker";
+
+// Command switch passed to renderer process to define preload script.
+const char kPreloadScriptInWorker[] = "preload-in-worker";
 
 // Widevine options
 // Path to Widevine CDM binaries.

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -63,6 +63,7 @@ extern const char kZoomFactor[];
 extern const char kPreloadScript[];
 extern const char kPreloadScripts[];
 extern const char kPreloadURL[];
+extern const char kPreloadScriptInWorker[];
 extern const char kNodeIntegration[];
 extern const char kContextIsolation[];
 extern const char kGuestInstanceID[];
@@ -121,6 +122,7 @@ extern const char kEnableApiFilteringLogging[];
 
 extern const char kScrollBounce[];
 extern const char kNodeIntegrationInWorker[];
+extern const char kPreloadScriptInWorker[];
 
 extern const char kWidevineCdmPath[];
 extern const char kWidevineCdmVersion[];

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -33,6 +33,20 @@ bool IsDevToolsExtension(content::RenderFrame* render_frame) {
       .SchemeIs("chrome-extension");
 }
 
+bool WorkerHasNodeIntegrationOrPreloadScript() {
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kNodeIntegrationInWorker)) {
+    return true;
+  }
+
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kPreloadScriptInWorker)) {
+    return true;
+  }
+
+  return false;
+}
+
 }  // namespace
 
 // static
@@ -209,8 +223,7 @@ void ElectronRendererClient::WorkerScriptReadyForEvaluationOnWorkerThread(
     v8::Local<v8::Context> context) {
   // TODO(loc): Note that this will not be correct for in-process child windows
   // with webPreferences that have a different value for nodeIntegrationInWorker
-  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kNodeIntegrationInWorker)) {
+  if (WorkerHasNodeIntegrationOrPreloadScript()) {
     WebWorkerObserver::GetCurrent()->WorkerScriptReadyForEvaluation(context);
   }
 }
@@ -219,8 +232,7 @@ void ElectronRendererClient::WillDestroyWorkerContextOnWorkerThread(
     v8::Local<v8::Context> context) {
   // TODO(loc): Note that this will not be correct for in-process child windows
   // with webPreferences that have a different value for nodeIntegrationInWorker
-  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kNodeIntegrationInWorker)) {
+  if (WorkerHasNodeIntegrationOrPreloadScript()) {
     WebWorkerObserver::GetCurrent()->ContextWillDestroy(context);
   }
 }

--- a/spec/fixtures/api/no-leak-worker.html
+++ b/spec/fixtures/api/no-leak-worker.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Document</title>
+</head>
+<body>
+  <script type="text/javascript" charset="utf-8">
+    const {ipcRenderer} = require('electron')
+    let worker = new Worker(`../workers/worker_var.js`)
+    worker.onmessage = function (event) {
+      ipcRenderer.send('var', event.data)
+      worker.terminate()
+    }
+  </script>
+</body>
+</html>

--- a/spec/fixtures/module/preload-worker.js
+++ b/spec/fixtures/module/preload-worker.js
@@ -1,0 +1,1 @@
+self.foo = 'bar';

--- a/spec/fixtures/workers/worker_var.js
+++ b/spec/fixtures/workers/worker_var.js
@@ -1,0 +1,6 @@
+self.postMessage({
+  require: typeof require,
+  process: typeof process,
+  global: typeof global,
+  foo: typeof foo
+});


### PR DESCRIPTION
#### Description of Change
Add `preloadInWorker` for `webPreferences` in `BrowserWindow` to define a script to be loaded first before any other scripts in worker.

cc @codebytere 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added preloadInWorker to define a script to be loaded first before any other scripts in worker.
