### PR TITLE
chore: cherry-pick 668cf831e912 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -156,3 +156,4 @@ cherry-pick-6b84dc72351b.patch
 cherry-pick-1028ffc9bd83.patch
 privacy_budget_remove_unnecessary_kcanvasreadback_metrics.patch
 cherry-pick-406ae3e8a9a8.patch
+cherry-pick-668cf831e912.patch

--- a/patches/chromium/cherry-pick-668cf831e912.patch
+++ b/patches/chromium/cherry-pick-668cf831e912.patch
@@ -1,0 +1,58 @@
+From 668cf831e91210d4f23e815e07ff1421f3ee9747 Mon Sep 17 00:00:00 2001
+From: Ken Rockot <rockot@google.com>
+Date: Tue, 23 Mar 2021 21:13:00 +0000
+Subject: [PATCH] Never fail in ReceiverSet::Add
+
+Because of how UniqueReceiverSet is implemented and used, it is
+dangerous to allow Add() to fail: callers reasonably assume that added
+objects are still alive immediately after the Add() call.
+
+This changes ReceiverId to a uint64 and simply CHECK-fails on
+insert collision.
+
+This fundamentally increases binary size of 32-bit builds, because
+a widely used 32-bit data type is expanding to 64 bits for the sake
+of security and stability. It is effectively unavoidable for now, and
+also just barely above the tolerable threshold.
+
+A follow-up (but less backwards-mergeable) change should be able to
+reduce binary size beyond this increase by consolidating shared
+code among ReceiverSet template instantiations.
+
+Fixed: 1185732
+Change-Id: I9acf6aaaa36e10fdce5aa49a890173caddc13c52
+Binary-Size: Unavoidable (see above)
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2778871
+Commit-Queue: Ken Rockot <rockot@google.com>
+Auto-Submit: Ken Rockot <rockot@google.com>
+Reviewed-by: Robert Sesek <rsesek@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#865815}
+---
+
+diff --git a/mojo/public/cpp/bindings/receiver_set.h b/mojo/public/cpp/bindings/receiver_set.h
+index 97049ab..ad94072 100644
+--- a/mojo/public/cpp/bindings/receiver_set.h
++++ b/mojo/public/cpp/bindings/receiver_set.h
+@@ -24,7 +24,7 @@
+ 
+ namespace mojo {
+ 
+-using ReceiverId = size_t;
++using ReceiverId = uint64_t;
+ 
+ template <typename ReceiverType>
+ struct ReceiverSetTraits;
+@@ -360,11 +360,11 @@
+                      scoped_refptr<base::SequencedTaskRunner> task_runner) {
+     DCHECK(receiver.is_valid());
+     ReceiverId id = next_receiver_id_++;
+-    DCHECK_GE(next_receiver_id_, 0u);
+     auto entry =
+         std::make_unique<Entry>(std::move(impl), std::move(receiver), this, id,
+                                 std::move(context), std::move(task_runner));
+-    receivers_.insert(std::make_pair(id, std::move(entry)));
++    auto result = receivers_.insert(std::make_pair(id, std::move(entry)));
++    CHECK(result.second) << "ReceiverId overflow with collision";
+     return id;
+   }
+ 

--- a/patches/chromium/cherry-pick-668cf831e912.patch
+++ b/patches/chromium/cherry-pick-668cf831e912.patch
@@ -1,7 +1,7 @@
-From 668cf831e91210d4f23e815e07ff1421f3ee9747 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ken Rockot <rockot@google.com>
 Date: Tue, 23 Mar 2021 21:13:00 +0000
-Subject: [PATCH] Never fail in ReceiverSet::Add
+Subject: Never fail in ReceiverSet::Add
 
 Because of how UniqueReceiverSet is implemented and used, it is
 dangerous to allow Add() to fail: callers reasonably assume that added
@@ -27,10 +27,9 @@ Commit-Queue: Ken Rockot <rockot@google.com>
 Auto-Submit: Ken Rockot <rockot@google.com>
 Reviewed-by: Robert Sesek <rsesek@chromium.org>
 Cr-Commit-Position: refs/heads/master@{#865815}
----
 
 diff --git a/mojo/public/cpp/bindings/receiver_set.h b/mojo/public/cpp/bindings/receiver_set.h
-index 97049ab..ad94072 100644
+index 8d7d73231543c70b67913fdf735c1a16cc6170b1..56027d1f3e6393f739c3b51330137d54ae3fc0d2 100644
 --- a/mojo/public/cpp/bindings/receiver_set.h
 +++ b/mojo/public/cpp/bindings/receiver_set.h
 @@ -24,7 +24,7 @@
@@ -42,9 +41,9 @@ index 97049ab..ad94072 100644
  
  template <typename ReceiverType>
  struct ReceiverSetTraits;
-@@ -360,11 +360,11 @@
+@@ -359,11 +359,11 @@ class ReceiverSetBase {
+                      Context context,
                       scoped_refptr<base::SequencedTaskRunner> task_runner) {
-     DCHECK(receiver.is_valid());
      ReceiverId id = next_receiver_id_++;
 -    DCHECK_GE(next_receiver_id_, 0u);
      auto entry =


### PR DESCRIPTION
Never fail in ReceiverSet::Add

Because of how UniqueReceiverSet is implemented and used, it is
dangerous to allow Add() to fail: callers reasonably assume that added
objects are still alive immediately after the Add() call.

This changes ReceiverId to a uint64 and simply CHECK-fails on
insert collision.

This fundamentally increases binary size of 32-bit builds, because
a widely used 32-bit data type is expanding to 64 bits for the sake
of security and stability. It is effectively unavoidable for now, and
also just barely above the tolerable threshold.

A follow-up (but less backwards-mergeable) change should be able to
reduce binary size beyond this increase by consolidating shared
code among ReceiverSet template instantiations.

Fixed: 1185732
Change-Id: I9acf6aaaa36e10fdce5aa49a890173caddc13c52
Binary-Size: Unavoidable (see above)
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2778871
Commit-Queue: Ken Rockot <rockot@google.com>
Auto-Submit: Ken Rockot <rockot@google.com>
Reviewed-by: Robert Sesek <rsesek@chromium.org>
Cr-Commit-Position: refs/heads/master@{#865815}


Notes: Security: backported fix to CVE-2021-21207.