### PR TITLE
build: fix npm-run python bytes error

### DIFF
--- a/build/npm-run.py
+++ b/build/npm-run.py
@@ -15,12 +15,6 @@ args = [cmd, "run",
 try:
     subprocess.check_output(args, stderr=subprocess.STDOUT)
 except subprocess.CalledProcessError as e:
-    print(
-        "NPM script '"
-        + sys.argv[2]
-        + "' failed with code '"
-        + str(e.returncode)
-        + "':\n"
-        + e.output
-    )
+    error_msg = "NPM script '{}' failed with code '{}':\n".format(sys.argv[2], e.returncode)
+    print(error_msg + e.output.decode('ascii'))
     sys.exit(e.returncode)


### PR DESCRIPTION
#### Description of Change

Fix error seen when building latest master:

<details>
<summary>Build Failure</summary>

```
electron on git:master ❯ e build                                                       2:07PM
Running "e load-xcode --quiet"
Running "ninja -j 200 electron" in /Users/codebytere/Developer/electron-gn/src/out/Testing
[103/4101] ACTION //electron:npm_pre_flight_b..._definitions(//build/toolchain/mac:clang_x64)
FAILED: gen/electron/npm_pre_stamps/npm_pre_flight_build_electron_definitions.stamp
python3 ../../electron/build/npm-run.py --silent pre-flight -- --stamp /Users/codebytere/Developer/electron-gn/src/out/Testing/gen/electron/npm_pre_stamps/npm_pre_flight_build_electron_definitions.stamp
Traceback (most recent call last):
  File "/Users/codebytere/Developer/electron-gn/src/out/Testing/../../electron/build/npm-run.py", line 16, in <module>
    subprocess.check_output(args, stderr=subprocess.STDOUT)
  File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['npm', 'run', '--prefix', '/Users/codebytere/Developer/electron-gn/src/out/Testing/../../electron', '--silent', 'pre-flight', '--', '--stamp', '/Users/codebytere/Developer/electron-gn/src/out/Testing/gen/electron/npm_pre_stamps/npm_pre_flight_build_electron_definitions.stamp']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/codebytere/Developer/electron-gn/src/out/Testing/../../electron/build/npm-run.py", line 19, in <module>
    "NPM script '"
TypeError: can only concatenate str (not "bytes") to str
[104/4101] ACTION //electron:npm_pre_flight_e...derer_bundle(//build/toolchain/mac:clang_x64)
FAILED: gen/electron/npm_pre_stamps/npm_pre_flight_electron_isolated_renderer_bundle.stamp
python3 ../../electron/build/npm-run.py --silent pre-flight -- --stamp /Users/codebytere/Developer/electron-gn/src/out/Testing/gen/electron/npm_pre_stamps/npm_pre_flight_electron_isolated_renderer_bundle.stamp
Traceback (most recent call last):
  File "/Users/codebytere/Developer/electron-gn/src/out/Testing/../../electron/build/npm-run.py", line 16, in <module>
    subprocess.check_output(args, stderr=subprocess.STDOUT)
  File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['npm', 'run', '--prefix', '/Users/codebytere/Developer/electron-gn/src/out/Testing/../../electron', '--silent', 'pre-flight', '--', '--stamp', '/Users/codebytere/Developer/electron-gn/src/out/Testing/gen/electron/npm_pre_stamps/npm_pre_flight_electron_isolated_renderer_bundle.stamp']' returned non-zero exit status 1.
```

</details>

After:

<img width="660" alt="Screen Shot 2021-04-29 at 4 14 43 PM" src="https://user-images.githubusercontent.com/2036040/116565323-0bee5a00-a906-11eb-9045-0b3d68bddd40.png">

#### Release Notes

Notes: none