### PR TITLE
docs: update REPL guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,7 @@ an issue:
   * [Testing on Headless CI Systems (Travis, Jenkins)](tutorial/testing-on-headless-ci.md)
   * [DevTools Extension](tutorial/devtools-extension.md)
   * [Automated Testing with a Custom Driver](tutorial/automated-testing-with-a-custom-driver.md)
+  * [REPL](tutorial/repl.md)
 * [Distribution](tutorial/application-distribution.md)
   * [Supported Platforms](tutorial/support.md#supported-platforms)
   * [Code Signing](tutorial/code-signing.md)

--- a/docs/tutorial/repl.md
+++ b/docs/tutorial/repl.md
@@ -1,27 +1,23 @@
 # REPL
 
-Read-Eval-Print-Loop (REPL) is a simple, interactive computer programming
-environment that takes single user inputs (i.e. single expressions), evaluates
-them, and returns the result to the user.
+[Read-Eval-Print-Loop](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop) (REPL)
+is a simple, interactive computer programming environment that takes single user
+inputs (i.e. single expressions), evaluates them, and returns the result to the user.
 
-The `repl` module provides a REPL implementation that can be accessed using:
+## Main process
 
-* Assuming you have `electron` or `electron-prebuilt` installed as a local
-  project dependency:
+Electron exposes the [Node.js `repl` module](https://nodejs.org/dist/latest/docs/api/repl.html)
+through the `--interactive` CLI flag. Assuming you have `electron` installed as a local project
+dependency, you should be able to access the REPL with the following command:
 
   ```sh
   ./node_modules/.bin/electron --interactive
   ```
 
-* Assuming you have `electron` or `electron-prebuilt` installed globally:
+**Note:** `electron --interactive` is not available on Windows
+(see [electron/electron#5776](https://github.com/electron/electron/pull/5776) for more details).
 
-  ```sh
-  electron --interactive
-  ```
+## Renderer process
 
-This only creates a REPL for the main process. You can use the Console
-tab of the Dev Tools to get a REPL for the renderer processes.
-
-**Note:** `electron --interactive` is not available on Windows.
-
-More information can be found in the [Node.js REPL docs](https://nodejs.org/dist/latest/docs/api/repl.html).
+You can use the Console tab of the Dev Tools to get a REPL for any renderer process.
+To learn more, read [the Chrome documentation](https://developer.chrome.com/docs/devtools/console/).

--- a/docs/tutorial/repl.md
+++ b/docs/tutorial/repl.md
@@ -19,5 +19,5 @@ dependency, you should be able to access the REPL with the following command:
 
 ## Renderer process
 
-You can use the Console tab of the Dev Tools to get a REPL for any renderer process.
+You can use the DevTools Console tab to get a REPL for any renderer process.
 To learn more, read [the Chrome documentation](https://developer.chrome.com/docs/devtools/console/).


### PR DESCRIPTION
#### Description of Change

Looks like this guide has been outdated for a while. A few changes:
* Removed global install commands
* Adds link to why REPL doesn't work on Windows
* Removes reference to ancient `electron-prebuilt` module
* Adds this doc under "Debugging and Testing"

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
