### PR TITLE
build: add release-env context to publish-macos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2369,9 +2369,11 @@ workflows:
     - osx-publish-skip-checkout:
         requires:
           - mac-checkout
+        context: release-env
     - mas-publish-skip-checkout:
         requires:
           - mac-checkout
+        context: release-env
 
   lint:
     when: << pipeline.parameters.run-lint >>


### PR DESCRIPTION
Manual backport of #28937 

See that PR for details.

Notes: none