### PR TITLE
docs: menu must be added on whenReady

### DIFF
--- a/docs/tutorial/recent-documents.md
+++ b/docs/tutorial/recent-documents.md
@@ -86,16 +86,16 @@ following code snippet to your menu template:
 Make sure the application menu is added on application 'whenReady' and not before, or 'Open Recent' will be disabled:
 
 ```javascript
-const { app, Menu } = require('electron');
+const { app, Menu } = require('electron')
 
 const template = [
   // Menu template here
-];
+]
 const menu = Menu.buildFromTemplate(template)
 
 app.whenReady().then(() => {
-  Menu.setApplicationMenu(menu);
-});
+  Menu.setApplicationMenu(menu)
+})
 ```
 
 ![macOS Recent Documents menu item][menu-item-image]

--- a/docs/tutorial/recent-documents.md
+++ b/docs/tutorial/recent-documents.md
@@ -83,6 +83,14 @@ following code snippet to your menu template:
 }
 ```
 
+Make sure the application menu is added on application 'whenReady' and not before, or 'Open Recent' will be disabled:
+
+```javascript
+app.whenReady().then(() => {
+  Menu.setApplicationMenu(menu);
+});
+```
+
 ![macOS Recent Documents menu item][menu-item-image]
 
 When a file is requested from the recent documents menu, the `open-file` event

--- a/docs/tutorial/recent-documents.md
+++ b/docs/tutorial/recent-documents.md
@@ -86,6 +86,13 @@ following code snippet to your menu template:
 Make sure the application menu is added on application 'whenReady' and not before, or 'Open Recent' will be disabled:
 
 ```javascript
+const { app, Menu } = require('electron');
+
+const template = [
+  // Menu template here
+];
+const menu = Menu.buildFromTemplate(template)
+
 app.whenReady().then(() => {
   Menu.setApplicationMenu(menu);
 });

--- a/docs/tutorial/recent-documents.md
+++ b/docs/tutorial/recent-documents.md
@@ -83,7 +83,8 @@ following code snippet to your menu template:
 }
 ```
 
-Make sure the application menu is added on application 'whenReady' and not before, or 'Open Recent' will be disabled:
+Make sure the application menu is added after the [`'ready'`](../api/app.md#event-ready)
+event and not before, or the menu item will be disabled:
 
 ```javascript
 const { app, Menu } = require('electron')


### PR DESCRIPTION

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
When an application menu is added before 'whenReady' all items seem to work except 'recent documents'

This causes the issue listed here: https://github.com/electron/electron/issues/17388

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] relevant documentation is changed or added

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
