### PR TITLE
chore: remove unused element_instance_id_to_guest_map_ from WebViewManager

### DIFF
--- a/lib/browser/guest-view-manager.ts
+++ b/lib/browser/guest-view-manager.ts
@@ -216,7 +216,7 @@ const attachGuest = function (event: Electron.IpcMainInvokeEvent,
 
   watchEmbedder(embedder);
 
-  webViewManager.addGuest(guestInstanceId, elementInstanceId, embedder, guest, webPreferences);
+  webViewManager.addGuest(guestInstanceId, embedder, guest, webPreferences);
   guest.attachToIframe(embedder, embedderFrameId);
 };
 

--- a/shell/browser/api/electron_api_web_view_manager.cc
+++ b/shell/browser/api/electron_api_web_view_manager.cc
@@ -17,14 +17,12 @@ using electron::WebContentsPreferences;
 namespace {
 
 void AddGuest(int guest_instance_id,
-              int element_instance_id,
               content::WebContents* embedder,
               content::WebContents* guest_web_contents,
               const base::DictionaryValue& options) {
   auto* manager = electron::WebViewManager::GetWebViewManager(embedder);
   if (manager)
-    manager->AddGuest(guest_instance_id, element_instance_id, embedder,
-                      guest_web_contents);
+    manager->AddGuest(guest_instance_id, embedder, guest_web_contents);
 
   double zoom_factor;
   if (options.GetDouble(electron::options::kZoomFactor, &zoom_factor)) {

--- a/shell/browser/web_view_manager.cc
+++ b/shell/browser/web_view_manager.cc
@@ -4,8 +4,6 @@
 
 #include "shell/browser/web_view_manager.h"
 
-#include "content/public/browser/render_frame_host.h"
-#include "content/public/browser/render_process_host.h"
 #include "content/public/browser/web_contents.h"
 #include "shell/browser/electron_browser_context.h"
 
@@ -16,27 +14,13 @@ WebViewManager::WebViewManager() = default;
 WebViewManager::~WebViewManager() = default;
 
 void WebViewManager::AddGuest(int guest_instance_id,
-                              int element_instance_id,
                               content::WebContents* embedder,
                               content::WebContents* web_contents) {
   web_contents_embedder_map_[guest_instance_id] = {web_contents, embedder};
-
-  // Map the element in embedder to guest.
-  int owner_process_id = embedder->GetMainFrame()->GetProcess()->GetID();
-  ElementInstanceKey key(owner_process_id, element_instance_id);
-  element_instance_id_to_guest_map_[key] = guest_instance_id;
 }
 
 void WebViewManager::RemoveGuest(int guest_instance_id) {
-  if (web_contents_embedder_map_.erase(guest_instance_id) == 0)
-    return;
-
-  // Remove the record of element in embedder too.
-  for (const auto& element : element_instance_id_to_guest_map_)
-    if (element.second == guest_instance_id) {
-      element_instance_id_to_guest_map_.erase(element.first);
-      break;
-    }
+  web_contents_embedder_map_.erase(guest_instance_id);
 }
 
 content::WebContents* WebViewManager::GetEmbedder(int guest_instance_id) {

--- a/shell/browser/web_view_manager.h
+++ b/shell/browser/web_view_manager.h
@@ -17,7 +17,6 @@ class WebViewManager : public content::BrowserPluginGuestManager {
   ~WebViewManager() override;
 
   void AddGuest(int guest_instance_id,
-                int element_instance_id,
                 content::WebContents* embedder,
                 content::WebContents* web_contents);
   void RemoveGuest(int guest_instance_id);
@@ -37,28 +36,6 @@ class WebViewManager : public content::BrowserPluginGuestManager {
   };
   // guest_instance_id => (web_contents, embedder)
   std::map<int, WebContentsWithEmbedder> web_contents_embedder_map_;
-
-  struct ElementInstanceKey {
-    int embedder_process_id;
-    int element_instance_id;
-
-    ElementInstanceKey(int embedder_process_id, int element_instance_id)
-        : embedder_process_id(embedder_process_id),
-          element_instance_id(element_instance_id) {}
-
-    bool operator<(const ElementInstanceKey& other) const {
-      if (embedder_process_id != other.embedder_process_id)
-        return embedder_process_id < other.embedder_process_id;
-      return element_instance_id < other.element_instance_id;
-    }
-
-    bool operator==(const ElementInstanceKey& other) const {
-      return (embedder_process_id == other.embedder_process_id) &&
-             (element_instance_id == other.element_instance_id);
-    }
-  };
-  // (embedder_process_id, element_instance_id) => guest_instance_id
-  std::map<ElementInstanceKey, int> element_instance_id_to_guest_map_;
 
   DISALLOW_COPY_AND_ASSIGN(WebViewManager);
 };

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -97,7 +97,7 @@ declare namespace NodeJS {
   }
 
   interface WebViewManagerBinding {
-    addGuest(guestInstanceId: number, elementInstanceId: number, embedder: Electron.WebContents, guest: Electron.WebContents, webPreferences: Electron.WebPreferences): void;
+    addGuest(guestInstanceId: number, embedder: Electron.WebContents, guest: Electron.WebContents, webPreferences: Electron.WebPreferences): void;
     removeGuest(embedder: Electron.WebContents, guestInstanceId: number): void;
   }
 


### PR DESCRIPTION
#### Description of Change
`element_instance_id_to_guest_map_` was used by `GetGuestByInstanceID`, which was removed from `BrowserPluginGuestManager` by
https://chromium-review.googlesource.com/c/chromium/src/+/2401031

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes