### PR TITLE
refactor: use "as const" for constant mappings

### DIFF
--- a/lib/browser/api/dialog.ts
+++ b/lib/browser/api/dialog.ts
@@ -2,10 +2,10 @@ import { app, BrowserWindow } from 'electron/main';
 import type { OpenDialogOptions, OpenDialogReturnValue, MessageBoxOptions, SaveDialogOptions, SaveDialogReturnValue, MessageBoxReturnValue, CertificateTrustDialogOptions } from 'electron/main';
 const dialogBinding = process._linkedBinding('electron_browser_dialog');
 
-const DialogType = {
-  OPEN: 'OPEN' as 'OPEN',
-  SAVE: 'SAVE' as 'SAVE'
-};
+enum DialogType {
+  OPEN = 'OPEN',
+  SAVE = 'SAVE'
+}
 
 enum SaveFileDialogProperties {
   createDirectory = 1 << 0,
@@ -72,7 +72,7 @@ const setupSaveDialogProperties = (properties: (keyof typeof SaveFileDialogPrope
   return dialogProperties;
 };
 
-const setupDialogProperties = (type: keyof typeof DialogType, properties: string[]): number => {
+const setupDialogProperties = (type: DialogType, properties: string[]): number => {
   if (type === DialogType.OPEN) {
     return setupOpenDialogProperties(properties as (keyof typeof OpenFileDialogProperties)[]);
   } else if (type === DialogType.SAVE) {

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -60,7 +60,7 @@ const PDFPageSizes: Record<string, ElectronInternal.MediaSize> = {
     width_microns: 279400,
     custom_display_name: 'Tabloid'
   }
-};
+} as const;
 
 // The minimum micron size Chromium accepts is that where:
 // Per printing/units.h:
@@ -109,7 +109,7 @@ const defaultPrintingSetting = {
   printerType: 2,
   title: undefined as string | undefined,
   url: undefined as string | undefined
-};
+} as const;
 
 // JavaScript implementations of WebContents.
 const binding = process._linkedBinding('electron_browser_web_contents');
@@ -191,7 +191,7 @@ WebContents.prototype.executeJavaScriptInIsolatedWorld = async function (worldId
 
 let pendingPromise: Promise<any> | undefined;
 WebContents.prototype.printToPDF = async function (options) {
-  const printSettings = {
+  const printSettings: Record<string, any> = {
     ...defaultPrintingSetting,
     requestID: getNextId()
   };

--- a/lib/common/web-view-events.ts
+++ b/lib/common/web-view-events.ts
@@ -1,4 +1,4 @@
-export const webViewEvents: Record<string, string[]> = {
+export const webViewEvents: Record<string, readonly string[]> = {
   'load-commit': ['url', 'isMainFrame'],
   'did-attach': [],
   'did-finish-load': [],
@@ -33,4 +33,4 @@ export const webViewEvents: Record<string, string[]> = {
   'found-in-page': ['result'],
   'did-change-theme-color': ['themeColor'],
   'update-target-url': ['url']
-};
+} as const;

--- a/lib/renderer/web-view/guest-view-internal.ts
+++ b/lib/renderer/web-view/guest-view-internal.ts
@@ -8,7 +8,7 @@ import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
 const DEPRECATED_EVENTS: Record<string, string> = {
   'page-title-updated': 'page-title-set'
-};
+} as const;
 
 const dispatchEvent = function (
   webView: WebViewImpl, eventName: string, eventKey: string, ...args: Array<any>


### PR DESCRIPTION
#### Description of Change
A bit more type safety

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes
