### PR TITLE
fix: drag region BrowserView calculations on macOS

### DIFF
--- a/shell/browser/native_browser_view_mac.mm
+++ b/shell/browser/native_browser_view_mac.mm
@@ -347,9 +347,7 @@ void NativeBrowserViewMac::UpdateDraggableRegions(
 
   std::vector<gfx::Rect> drag_exclude_rects;
   if (draggable_regions_.empty()) {
-    const auto bounds = GetBounds();
-    drag_exclude_rects.emplace_back(bounds.x(), bounds.y(), webViewWidth,
-                                    webViewHeight);
+    drag_exclude_rects.emplace_back(0, 0, webViewWidth, webViewHeight);
   } else {
     drag_exclude_rects = CalculateNonDraggableRegions(
         DraggableRegionsToSkRegion(draggable_regions_), webViewWidth,


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/28405. This was originally added in https://github.com/electron/electron/pull/27147, but it turns out that solution masked a different root problem, which was what I later solved in https://github.com/electron/electron/pull/28268. However, this meant that the previous PR was relying on incorrect assumptions, and would thus offset the bounds _too far_. This correct it so that all offsetting is handled in a single place for BrowserViews and we can once more safely assume that defaulting to `0, 0` for `x, y` in the case of no drag regions will produce the desired drag configuration. 

Tested with:
- https://gist.github.com/b9c5a45bf59f6ba748041d000414e571
- https://gist.github.com/9dd56c8dae033bcb77cd107259591121
- https://gist.github.com/08f3e56e0a4dc443621bd769e18c7cd6
- https://gist.github.com/c138020abbb7d949608c3c11b1cad253

cc @Kilian 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where drag regions on macOS would be offset incorrectly when no drag regions were set,
