### PR TITLE
refactor: 'focus-change' does not need guestInstanceId

### DIFF
--- a/lib/browser/guest-view-manager.ts
+++ b/lib/browser/guest-view-manager.ts
@@ -319,13 +319,8 @@ handleMessageSync(IPC_MESSAGES.GUEST_VIEW_MANAGER_DETACH_GUEST, function (event,
 });
 
 // this message is sent by the actual <webview>
-ipcMainInternal.on(IPC_MESSAGES.GUEST_VIEW_MANAGER_FOCUS_CHANGE, function (event: ElectronInternal.IpcMainInternalEvent, focus: boolean, guestInstanceId: number) {
-  const guest = getGuest(guestInstanceId);
-  if (guest === event.sender) {
-    event.sender.emit('focus-change', {}, focus, guestInstanceId);
-  } else {
-    console.error(`focus-change for guestInstanceId: ${guestInstanceId}`);
-  }
+ipcMainInternal.on(IPC_MESSAGES.GUEST_VIEW_MANAGER_FOCUS_CHANGE, function (event: ElectronInternal.IpcMainInternalEvent, focus: boolean) {
+  event.sender.emit('focus-change', {}, focus);
 });
 
 handleMessage(IPC_MESSAGES.GUEST_VIEW_MANAGER_CALL, function (event, guestInstanceId: number, method: string, args: any[]) {
@@ -372,18 +367,12 @@ handleMessage(IPC_MESSAGES.GUEST_VIEW_MANAGER_CAPTURE_PAGE, async function (even
 
 // Returns WebContents from its guest id hosted in given webContents.
 const getGuestForWebContents = function (guestInstanceId: number, contents: Electron.WebContents) {
-  const guest = getGuest(guestInstanceId);
-  if (!guest) {
+  const guestInstance = guestInstances.get(guestInstanceId);
+  if (!guestInstance) {
     throw new Error(`Invalid guestInstanceId: ${guestInstanceId}`);
   }
-  if (guest.hostWebContents !== contents) {
+  if (guestInstance.guest.hostWebContents !== contents) {
     throw new Error(`Access denied to guestInstanceId: ${guestInstanceId}`);
   }
-  return guest;
-};
-
-// Returns WebContents from its guest id.
-const getGuest = function (guestInstanceId: number) {
-  const guestInstance = guestInstances.get(guestInstanceId);
-  if (guestInstance != null) return guestInstance.guest;
+  return guestInstance.guest;
 };

--- a/lib/browser/guest-view-manager.ts
+++ b/lib/browser/guest-view-manager.ts
@@ -320,7 +320,7 @@ handleMessageSync(IPC_MESSAGES.GUEST_VIEW_MANAGER_DETACH_GUEST, function (event,
 
 // this message is sent by the actual <webview>
 ipcMainInternal.on(IPC_MESSAGES.GUEST_VIEW_MANAGER_FOCUS_CHANGE, function (event: ElectronInternal.IpcMainInternalEvent, focus: boolean) {
-  event.sender.emit('focus-change', {}, focus);
+  event.sender.emit('-focus-change', {}, focus);
 });
 
 handleMessage(IPC_MESSAGES.GUEST_VIEW_MANAGER_CALL, function (event, guestInstanceId: number, method: string, args: any[]) {

--- a/lib/common/web-view-events.ts
+++ b/lib/common/web-view-events.ts
@@ -18,7 +18,7 @@ export const webViewEvents: Record<string, string[]> = {
   'did-navigate': ['url', 'httpResponseCode', 'httpStatusText'],
   'did-frame-navigate': ['url', 'httpResponseCode', 'httpStatusText', 'isMainFrame', 'frameProcessId', 'frameRoutingId'],
   'did-navigate-in-page': ['url', 'isMainFrame', 'frameProcessId', 'frameRoutingId'],
-  'focus-change': ['focus', 'guestInstanceId'],
+  'focus-change': ['focus'],
   close: [],
   crashed: [],
   'render-process-gone': ['details'],

--- a/lib/common/web-view-events.ts
+++ b/lib/common/web-view-events.ts
@@ -18,7 +18,7 @@ export const webViewEvents: Record<string, string[]> = {
   'did-navigate': ['url', 'httpResponseCode', 'httpStatusText'],
   'did-frame-navigate': ['url', 'httpResponseCode', 'httpStatusText', 'isMainFrame', 'frameProcessId', 'frameRoutingId'],
   'did-navigate-in-page': ['url', 'isMainFrame', 'frameProcessId', 'frameRoutingId'],
-  'focus-change': ['focus'],
+  '-focus-change': ['focus'],
   close: [],
   crashed: [],
   'render-process-gone': ['details'],

--- a/lib/renderer/web-view/guest-view-internal.ts
+++ b/lib/renderer/web-view/guest-view-internal.ts
@@ -26,7 +26,7 @@ const dispatchEvent = function (
 
   if (eventName === 'load-commit') {
     webView.onLoadCommit(props);
-  } else if (eventName === 'focus-change') {
+  } else if (eventName === '-focus-change') {
     webView.onFocusChange();
   }
 };

--- a/lib/renderer/web-view/web-view-init.ts
+++ b/lib/renderer/web-view/web-view-init.ts
@@ -3,16 +3,16 @@ import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
 const v8Util = process._linkedBinding('electron_common_v8_util');
 
-function handleFocusBlur (guestInstanceId: number) {
+function handleFocusBlur () {
   // Note that while Chromium content APIs have observer for focus/blur, they
   // unfortunately do not work for webview.
 
   window.addEventListener('focus', () => {
-    ipcRendererInternal.send(IPC_MESSAGES.GUEST_VIEW_MANAGER_FOCUS_CHANGE, true, guestInstanceId);
+    ipcRendererInternal.send(IPC_MESSAGES.GUEST_VIEW_MANAGER_FOCUS_CHANGE, true);
   });
 
   window.addEventListener('blur', () => {
-    ipcRendererInternal.send(IPC_MESSAGES.GUEST_VIEW_MANAGER_FOCUS_CHANGE, false, guestInstanceId);
+    ipcRendererInternal.send(IPC_MESSAGES.GUEST_VIEW_MANAGER_FOCUS_CHANGE, false);
   });
 }
 
@@ -32,6 +32,6 @@ export function webViewInit (
 
   if (guestInstanceId) {
     // Report focus/blur events of webview to browser.
-    handleFocusBlur(guestInstanceId);
+    handleFocusBlur();
   }
 }


### PR DESCRIPTION
#### Description of Change
The `guestInstanceId` is not used in the `focus-change` handler. It is also the same as webContents ID that we already know.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes