### PR TITLE
fix: <webview> focus / blur events don't work with contextIsolation enabled

### DIFF
--- a/lib/renderer/web-view/web-view-impl.ts
+++ b/lib/renderer/web-view/web-view-impl.ts
@@ -162,7 +162,7 @@ export class WebViewImpl {
 
   // Emits focus/blur events.
   onFocusChange () {
-    const hasFocus = document.activeElement === this.webviewNode;
+    const hasFocus = this.webviewNode.ownerDocument.activeElement === this.webviewNode;
     if (hasFocus !== this.hasFocus) {
       this.hasFocus = hasFocus;
       this.dispatchEvent(hasFocus ? 'focus' : 'blur');

--- a/spec-main/webview-spec.ts
+++ b/spec-main/webview-spec.ts
@@ -672,5 +672,27 @@ describe('<webview> tag', function () {
       })`);
       expect(message).to.equal('hi');
     });
+
+    it('emits focus event when contextIsolation is enabled', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          webviewTag: true,
+          contextIsolation: true
+        }
+      });
+      await w.loadURL('about:blank');
+      await w.webContents.executeJavaScript(`new Promise((resolve, reject) => {
+        const webview = new WebView()
+        webview.setAttribute('src', 'about:blank')
+        webview.addEventListener('dom-ready', () => {
+          webview.focus()
+        })
+        webview.addEventListener('focus', () => {
+          resolve();
+        })
+        document.body.appendChild(webview)
+      })`);
+    });
   });
 });


### PR DESCRIPTION
#### Description of Change
https://github.com/electron/electron/blob/961b74b2ac335abf99dcf50ce512f58cb250be80/lib/renderer/web-view/web-view-impl.ts#L165 is not equal when `contextIsolation` is enabled

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed `<webview>` `focus` / `blur` events not working with `contextIsolation` enabled.
