### PR TITLE
chore: make raw requires type-safe

### DIFF
--- a/lib/browser/desktop-capturer.ts
+++ b/lib/browser/desktop-capturer.ts
@@ -13,7 +13,7 @@ function isValid (options: Electron.SourcesOptions) {
   return Array.isArray(types);
 }
 
-export const getSourcesImpl = (event: Electron.IpcMainEvent | null, args: Electron.SourcesOptions) => {
+export const getSourcesImpl = (sender: Electron.WebContents | null, args: Electron.SourcesOptions) => {
   if (!isValid(args)) throw new Error('Invalid options');
 
   const captureWindow = args.types.includes('window');
@@ -48,8 +48,8 @@ export const getSourcesImpl = (event: Electron.IpcMainEvent | null, args: Electr
       }
       // Remove from currentlyRunning once we resolve or reject
       currentlyRunning = currentlyRunning.filter(running => running.options !== options);
-      if (event) {
-        event.sender.removeListener('destroyed', stopRunning);
+      if (sender) {
+        sender.removeListener('destroyed', stopRunning);
       }
     };
 
@@ -68,8 +68,8 @@ export const getSourcesImpl = (event: Electron.IpcMainEvent | null, args: Electr
     // If the WebContents is destroyed before receiving result, just remove the
     // reference to emit and the capturer itself so that it never dispatches
     // back to the renderer
-    if (event) {
-      event.sender.once('destroyed', stopRunning);
+    if (sender) {
+      sender.once('destroyed', stopRunning);
     }
   });
 

--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -2,6 +2,8 @@ import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import * as path from 'path';
 
+import type * as defaultMenuModule from '@electron/internal/browser/default-menu';
+
 const Module = require('module');
 
 // We modified the original process.argv to let node.js load the init.js,
@@ -172,7 +174,7 @@ app.on('window-all-closed', () => {
   }
 });
 
-const { setDefaultApplicationMenu } = require('@electron/internal/browser/default-menu');
+const { setDefaultApplicationMenu } = require('@electron/internal/browser/default-menu') as typeof defaultMenuModule;
 
 // Create default menu.
 //

--- a/lib/browser/rpc-server.ts
+++ b/lib/browser/rpc-server.ts
@@ -7,6 +7,8 @@ import * as ipcMainUtils from '@electron/internal/browser/ipc-main-internal-util
 import * as typeUtils from '@electron/internal/common/type-utils';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
+import type * as desktopCapturerModule from '@electron/internal/browser/desktop-capturer';
+
 const eventBinding = process._linkedBinding('electron_browser_event');
 
 const emitCustomEvent = function (contents: WebContents, eventName: string, ...args: any[]) {
@@ -58,7 +60,7 @@ ipcMainUtils.handleSync(IPC_MESSAGES.BROWSER_CLIPBOARD_SYNC, function (event, me
 });
 
 if (BUILDFLAG(ENABLE_DESKTOP_CAPTURER)) {
-  const desktopCapturer = require('@electron/internal/browser/desktop-capturer');
+  const desktopCapturer = require('@electron/internal/browser/desktop-capturer') as typeof desktopCapturerModule;
 
   ipcMainInternal.handle(IPC_MESSAGES.DESKTOP_CAPTURER_GET_SOURCES, async function (event, options: Electron.SourcesOptions, stack: string) {
     logStack(event.sender, 'desktopCapturer.getSources()', stack);
@@ -69,7 +71,7 @@ if (BUILDFLAG(ENABLE_DESKTOP_CAPTURER)) {
       return [];
     }
 
-    return typeUtils.serialize(await desktopCapturer.getSourcesImpl(event, options));
+    return typeUtils.serialize(await desktopCapturer.getSourcesImpl(event.sender, options));
   });
 }
 

--- a/lib/common/api/clipboard.ts
+++ b/lib/common/api/clipboard.ts
@@ -1,10 +1,13 @@
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
+import type * as ipcRendererUtilsModule from '@electron/internal/renderer/ipc-renderer-internal-utils';
+import type * as typeUtilsModule from '@electron/internal/common/type-utils';
+
 const clipboard = process._linkedBinding('electron_common_clipboard');
 
 if (process.type === 'renderer') {
-  const ipcRendererUtils = require('@electron/internal/renderer/ipc-renderer-internal-utils');
-  const typeUtils = require('@electron/internal/common/type-utils');
+  const ipcRendererUtils = require('@electron/internal/renderer/ipc-renderer-internal-utils') as typeof ipcRendererUtilsModule;
+  const typeUtils = require('@electron/internal/common/type-utils') as typeof typeUtilsModule;
 
   const makeRemoteMethod = function (method: keyof Electron.Clipboard) {
     return (...args: any[]) => {

--- a/lib/isolated_renderer/init.ts
+++ b/lib/isolated_renderer/init.ts
@@ -1,5 +1,7 @@
 /* global nodeProcess, isolatedWorld */
 
+import type * as webViewElementModule from '@electron/internal/renderer/web-view/web-view-element';
+
 process._linkedBinding = nodeProcess._linkedBinding;
 
 const v8Util = process._linkedBinding('electron_common_v8_util');
@@ -8,6 +10,6 @@ const webViewImpl = v8Util.getHiddenValue(isolatedWorld, 'web-view-impl');
 
 if (webViewImpl) {
   // Must setup the WebView element in main world.
-  const { setupWebView } = require('@electron/internal/renderer/web-view/web-view-element');
-  setupWebView(v8Util, webViewImpl);
+  const { setupWebView } = require('@electron/internal/renderer/web-view/web-view-element') as typeof webViewElementModule;
+  setupWebView(v8Util, webViewImpl as any);
 }

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -1,6 +1,12 @@
 import * as path from 'path';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
+import type * as ipcRendererInternalModule from '@electron/internal/renderer/ipc-renderer-internal';
+import type * as webFrameInitModule from '@electron/internal/renderer/web-frame-init';
+import type * as webViewInitModule from '@electron/internal/renderer/web-view/web-view-init';
+import type * as windowSetupModule from '@electron/internal/renderer/window-setup';
+import type * as securityWarningsModule from '@electron/internal/renderer/security-warnings';
+
 const Module = require('module');
 
 // Make sure globals like "process" and "global" are always available in preload
@@ -43,7 +49,7 @@ const v8Util = process._linkedBinding('electron_common_v8_util');
 const contextId = v8Util.getHiddenValue<string>(global, 'contextId');
 Object.defineProperty(process, 'contextId', { enumerable: true, value: contextId });
 
-const { ipcRendererInternal } = require('@electron/internal/renderer/ipc-renderer-internal');
+const { ipcRendererInternal } = require('@electron/internal/renderer/ipc-renderer-internal') as typeof ipcRendererInternalModule;
 const ipcRenderer = require('@electron/internal/renderer/api/ipc-renderer').default;
 
 v8Util.setHiddenValue(global, 'ipcNative', {
@@ -58,7 +64,7 @@ v8Util.setHiddenValue(global, 'ipcNative', {
 });
 
 // Use electron module after everything is ready.
-const { webFrameInit } = require('@electron/internal/renderer/web-frame-init');
+const { webFrameInit } = require('@electron/internal/renderer/web-frame-init') as typeof webFrameInitModule;
 webFrameInit();
 
 // Process command line arguments.
@@ -72,8 +78,8 @@ const isHiddenPage = mainFrame.getWebPreference('hiddenPage');
 const usesNativeWindowOpen = mainFrame.getWebPreference('nativeWindowOpen');
 const preloadScript = mainFrame.getWebPreference('preload');
 const preloadScripts = mainFrame.getWebPreference('preloadScripts');
-const guestInstanceId = mainFrame.getWebPreference('guestInstanceId') || null;
-const openerId = mainFrame.getWebPreference('openerId') || null;
+const guestInstanceId = mainFrame.getWebPreference('guestInstanceId');
+const openerId = mainFrame.getWebPreference('openerId');
 const appPath = hasSwitch('app-path') ? getSwitchValue('app-path') : null;
 
 // The webContents preload script is loaded after the session preload scripts.
@@ -95,14 +101,14 @@ switch (window.location.protocol) {
   }
   default: {
     // Override default web functions.
-    const { windowSetup } = require('@electron/internal/renderer/window-setup');
+    const { windowSetup } = require('@electron/internal/renderer/window-setup') as typeof windowSetupModule;
     windowSetup(guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen);
   }
 }
 
 // Load webview tag implementation.
 if (process.isMainFrame) {
-  const { webViewInit } = require('@electron/internal/renderer/web-view/web-view-init');
+  const { webViewInit } = require('@electron/internal/renderer/web-view/web-view-init') as typeof webViewInitModule;
   webViewInit(contextIsolation, webviewTag, guestInstanceId);
 }
 
@@ -187,6 +193,6 @@ for (const preloadScript of preloadScripts) {
 
 // Warn about security issues
 if (process.isMainFrame) {
-  const { securityWarnings } = require('@electron/internal/renderer/security-warnings');
+  const { securityWarnings } = require('@electron/internal/renderer/security-warnings') as typeof securityWarningsModule;
   securityWarnings(nodeIntegration);
 }

--- a/lib/renderer/security-warnings.ts
+++ b/lib/renderer/security-warnings.ts
@@ -286,7 +286,7 @@ const getWebPreferences = async function () {
   }
 };
 
-export function securityWarnings (nodeIntegration: boolean) {
+export function securityWarnings (nodeIntegration = false) {
   const loadHandler = async function () {
     if (shouldLogSecurityWarnings()) {
       const webPreferences = await getWebPreferences();

--- a/lib/renderer/web-view/guest-view-internal.ts
+++ b/lib/renderer/web-view/guest-view-internal.ts
@@ -70,10 +70,3 @@ export function attachGuest (
 export function detachGuest (guestInstanceId: number) {
   return ipcRendererUtils.invokeSync(IPC_MESSAGES.GUEST_VIEW_MANAGER_DETACH_GUEST, guestInstanceId);
 }
-
-export const guestViewInternalModule = {
-  deregisterEvents,
-  createGuest,
-  attachGuest,
-  detachGuest
-};

--- a/lib/renderer/web-view/web-view-element.ts
+++ b/lib/renderer/web-view/web-view-element.ts
@@ -9,8 +9,10 @@
 // modules must be passed from outside, all included files must be plain JS.
 
 import { WEB_VIEW_CONSTANTS } from '@electron/internal/renderer/web-view/web-view-constants';
-import { WebViewImpl as IWebViewImpl, webViewImplModule } from '@electron/internal/renderer/web-view/web-view-impl';
+import type * as webViewImplModule from '@electron/internal/renderer/web-view/web-view-impl';
 import type { SrcAttribute } from '@electron/internal/renderer/web-view/web-view-attributes';
+
+type IWebViewImpl = webViewImplModule.WebViewImpl;
 
 // Return a WebViewElement class that is defined in this context.
 const defineWebViewElement = (v8Util: NodeJS.V8UtilBinding, webViewImpl: typeof webViewImplModule) => {

--- a/lib/renderer/web-view/web-view-impl.ts
+++ b/lib/renderer/web-view/web-view-impl.ts
@@ -1,5 +1,3 @@
-import * as electron from 'electron';
-
 import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
 import * as ipcRendererUtils from '@electron/internal/renderer/ipc-renderer-internal-utils';
 import * as guestViewInternal from '@electron/internal/renderer/web-view/guest-view-internal';
@@ -8,7 +6,9 @@ import { syncMethods, asyncMethods, properties } from '@electron/internal/common
 import type { WebViewAttribute, PartitionAttribute } from '@electron/internal/renderer/web-view/web-view-attributes';
 import { deserialize } from '@electron/internal/common/type-utils';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
-const { webFrame } = electron;
+
+export { webFrame } from 'electron';
+export * as guestViewInternal from '@electron/internal/renderer/web-view/guest-view-internal';
 
 const v8Util = process._linkedBinding('electron_common_v8_util');
 
@@ -271,12 +271,4 @@ export const setupMethods = (WebViewElement: typeof ElectronInternal.WebViewElem
       set: createPropertySetter(property)
     });
   }
-};
-
-export const webViewImplModule = {
-  setupAttributes,
-  setupMethods,
-  guestViewInternal,
-  webFrame,
-  WebViewImpl
 };

--- a/lib/renderer/web-view/web-view-init.ts
+++ b/lib/renderer/web-view/web-view-init.ts
@@ -1,6 +1,9 @@
 import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
+import type * as webViewImpl from '@electron/internal/renderer/web-view/web-view-impl';
+import type * as webViewElement from '@electron/internal/renderer/web-view/web-view-element';
+
 const v8Util = process._linkedBinding('electron_common_v8_util');
 
 function handleFocusBlur () {
@@ -16,16 +19,14 @@ function handleFocusBlur () {
   });
 }
 
-export function webViewInit (
-  contextIsolation: boolean, webviewTag: ElectronInternal.WebViewElement, guestInstanceId: number
-) {
+export function webViewInit (contextIsolation: boolean, webviewTag: boolean, guestInstanceId: number) {
   // Don't allow recursive `<webview>`.
-  if (webviewTag && guestInstanceId == null) {
-    const { webViewImplModule } = require('@electron/internal/renderer/web-view/web-view-impl');
+  if (webviewTag && !guestInstanceId) {
+    const { webViewImplModule } = require('@electron/internal/renderer/web-view/web-view-impl') as typeof webViewImpl;
     if (contextIsolation) {
       v8Util.setHiddenValue(window, 'web-view-impl', webViewImplModule);
     } else {
-      const { setupWebView } = require('@electron/internal/renderer/web-view/web-view-element');
+      const { setupWebView } = require('@electron/internal/renderer/web-view/web-view-element') as typeof webViewElement;
       setupWebView(v8Util, webViewImplModule);
     }
   }

--- a/lib/renderer/web-view/web-view-init.ts
+++ b/lib/renderer/web-view/web-view-init.ts
@@ -22,7 +22,7 @@ function handleFocusBlur () {
 export function webViewInit (contextIsolation: boolean, webviewTag: boolean, guestInstanceId: number) {
   // Don't allow recursive `<webview>`.
   if (webviewTag && !guestInstanceId) {
-    const { webViewImplModule } = require('@electron/internal/renderer/web-view/web-view-impl') as typeof webViewImpl;
+    const webViewImplModule = require('@electron/internal/renderer/web-view/web-view-impl') as typeof webViewImpl;
     if (contextIsolation) {
       v8Util.setHiddenValue(window, 'web-view-impl', webViewImplModule);
     } else {

--- a/lib/renderer/window-setup.ts
+++ b/lib/renderer/window-setup.ts
@@ -244,7 +244,7 @@ class BrowserWindowProxy {
 
 export const windowSetup = (
   guestInstanceId: number, openerId: number, isHiddenPage: boolean, usesNativeWindowOpen: boolean) => {
-  if (!process.sandboxed && guestInstanceId == null) {
+  if (!process.sandboxed && !guestInstanceId) {
     // Override default window.close.
     window.close = function () {
       ipcRendererInternal.send(IPC_MESSAGES.BROWSER_WINDOW_CLOSE);
@@ -284,9 +284,9 @@ export const windowSetup = (
   // [ grandparent window ] --> [ parent window ] --> [ child window ]
   //     n.W.O = false             n.W.O = true         n.W.O = true
   //        id = 1                    id = 2               id = 3
-  //  openerId = null           openerId = 1         openerId = 1  <- !!wrong!!
+  //  openerId = 0              openerId = 1         openerId = 1  <- !!wrong!!
   //    opener = null             opener = null        opener = [parent window]
-  if (openerId != null && !window.opener) {
+  if (openerId && !window.opener) {
     window.opener = getOrCreateProxy(openerId);
     if (contextIsolationEnabled) internalContextBridge.overrideGlobalValueWithDynamicPropsFromIsolatedWorld(['opener'], window.opener);
   }
@@ -297,7 +297,7 @@ export const windowSetup = (
   };
   if (contextIsolationEnabled) internalContextBridge.overrideGlobalValueFromIsolatedWorld(['prompt'], window.prompt);
 
-  if (!usesNativeWindowOpen || openerId != null) {
+  if (!usesNativeWindowOpen || openerId) {
     ipcRendererInternal.on(IPC_MESSAGES.GUEST_WINDOW_POSTMESSAGE, function (
       _event, sourceId: number, message: any, sourceOrigin: string
     ) {
@@ -318,7 +318,7 @@ export const windowSetup = (
     });
   }
 
-  if (guestInstanceId != null) {
+  if (guestInstanceId) {
     // Webview `document.visibilityState` tracks window visibility (and ignores
     // the actual <webview> element visibility) for backwards compatibility.
     // See discussion in #9178.

--- a/lib/sandboxed_renderer/init.ts
+++ b/lib/sandboxed_renderer/init.ts
@@ -3,6 +3,13 @@
 import * as events from 'events';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
+import type * as ipcRendererUtilsModule from '@electron/internal/renderer/ipc-renderer-internal-utils';
+import type * as ipcRendererInternalModule from '@electron/internal/renderer/ipc-renderer-internal';
+import type * as webFrameInitModule from '@electron/internal/renderer/web-frame-init';
+import type * as webViewInitModule from '@electron/internal/renderer/web-view/web-view-init';
+import type * as windowSetupModule from '@electron/internal/renderer/window-setup';
+import type * as securityWarningsModule from '@electron/internal/renderer/security-warnings';
+
 const { EventEmitter } = events;
 
 process._linkedBinding = binding.get;
@@ -20,8 +27,8 @@ for (const prop of Object.keys(EventEmitter.prototype) as (keyof typeof process)
 }
 Object.setPrototypeOf(process, EventEmitter.prototype);
 
-const { ipcRendererInternal } = require('@electron/internal/renderer/ipc-renderer-internal');
-const ipcRendererUtils = require('@electron/internal/renderer/ipc-renderer-internal-utils');
+const { ipcRendererInternal } = require('@electron/internal/renderer/ipc-renderer-internal') as typeof ipcRendererInternalModule;
+const ipcRendererUtils = require('@electron/internal/renderer/ipc-renderer-internal-utils') as typeof ipcRendererUtilsModule;
 
 const { preloadScripts, process: processProps } = ipcRendererUtils.invokeSync(IPC_MESSAGES.BROWSER_SANDBOX_LOAD);
 
@@ -68,7 +75,7 @@ v8Util.setHiddenValue(global, 'lifecycle', {
   }
 });
 
-const { webFrameInit } = require('@electron/internal/renderer/web-frame-init');
+const { webFrameInit } = require('@electron/internal/renderer/web-frame-init') as typeof webFrameInitModule;
 webFrameInit();
 
 // Pass different process object to the preload script.
@@ -125,8 +132,8 @@ const contextIsolation = mainFrame.getWebPreference('contextIsolation');
 const webviewTag = mainFrame.getWebPreference('webviewTag');
 const isHiddenPage = mainFrame.getWebPreference('hiddenPage');
 const usesNativeWindowOpen = true;
-const guestInstanceId = mainFrame.getWebPreference('guestInstanceId') || null;
-const openerId = mainFrame.getWebPreference('openerId') || null;
+const guestInstanceId = mainFrame.getWebPreference('guestInstanceId');
+const openerId = mainFrame.getWebPreference('openerId');
 
 switch (window.location.protocol) {
   case 'devtools:': {
@@ -142,14 +149,14 @@ switch (window.location.protocol) {
   }
   default: {
     // Override default web functions.
-    const { windowSetup } = require('@electron/internal/renderer/window-setup');
+    const { windowSetup } = require('@electron/internal/renderer/window-setup') as typeof windowSetupModule;
     windowSetup(guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen);
   }
 }
 
 // Load webview tag implementation.
 if (process.isMainFrame) {
-  const { webViewInit } = require('@electron/internal/renderer/web-view/web-view-init');
+  const { webViewInit } = require('@electron/internal/renderer/web-view/web-view-init') as typeof webViewInitModule;
   webViewInit(contextIsolation, webviewTag, guestInstanceId);
 }
 
@@ -189,6 +196,6 @@ for (const { preloadPath, preloadSrc, preloadError } of preloadScripts) {
 
 // Warn about security issues
 if (process.isMainFrame) {
-  const { securityWarnings } = require('@electron/internal/renderer/security-warnings');
+  const { securityWarnings } = require('@electron/internal/renderer/security-warnings') as typeof securityWarningsModule;
   securityWarnings();
 }


### PR DESCRIPTION
#### Description of Change
`require` returns `any`, which is dangerous. Let's use `as typeof` with `import type` trick to solve this.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes
