### PR TITLE
fix: don't warn about enableRemoteModule when it's undefined

### DIFF
--- a/lib/renderer/security-warnings.ts
+++ b/lib/renderer/security-warnings.ts
@@ -270,7 +270,7 @@ const warnAboutAllowedPopups = function () {
 
 const warnAboutRemoteModuleWithRemoteContent = function (webPreferences?: Electron.WebPreferences) {
   if (!webPreferences || isLocalhost()) return;
-  const remoteModuleEnabled = webPreferences.enableRemoteModule != null ? !!webPreferences.enableRemoteModule : true;
+  const remoteModuleEnabled = webPreferences.enableRemoteModule != null ? !!webPreferences.enableRemoteModule : false;
   if (!remoteModuleEnabled) return;
 
   if (getIsRemoteProtocol()) {

--- a/spec-main/security-warnings-spec.ts
+++ b/spec-main/security-warnings-spec.ts
@@ -228,7 +228,7 @@ describe('security warnings', () => {
       it('should warn about enabled remote module with remote content', async () => {
         w = new BrowserWindow({
           show: false,
-          webPreferences
+          webPreferences: { ...webPreferences, enableRemoteModule: true }
         });
 
         w.loadURL(`${serverUrl}/base-page-security.html`);
@@ -239,7 +239,7 @@ describe('security warnings', () => {
       it('should not warn about enabled remote module with remote content from localhost', async () => {
         w = new BrowserWindow({
           show: false,
-          webPreferences
+          webPreferences: { ...webPreferences, enableRemoteModule: true }
         });
         w.loadURL(`${serverUrl}/base-page-security-onload-message.html`);
         const [,, message] = await emittedUntil(w.webContents, 'console-message', isLoaded);


### PR DESCRIPTION
#### Description of Change
Closes #29020.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an incorrect warning about enableRemoteModule being issued when the option was undefined (and thus defaulting to false).