### PR TITLE
fix: <webview> focus / blur events don't work with contextIsolation enabled

### DIFF
--- a/lib/renderer/web-view/web-view-impl.ts
+++ b/lib/renderer/web-view/web-view-impl.ts
@@ -158,7 +158,7 @@ export class WebViewImpl {
 
   // Emits focus/blur events.
   onFocusChange () {
-    const hasFocus = document.activeElement === this.webviewNode;
+    const hasFocus = this.webviewNode.ownerDocument!.activeElement === this.webviewNode;
     if (hasFocus !== this.hasFocus) {
       this.hasFocus = hasFocus;
       this.dispatchEvent(new Event(hasFocus ? 'focus' : 'blur'));

--- a/spec-main/webview-spec.ts
+++ b/spec-main/webview-spec.ts
@@ -659,4 +659,29 @@ describe('<webview> tag', function () {
     generateSpecs('without sandbox', false);
     generateSpecs('with sandbox', true);
   });
+
+  describe('DOM events', () => {
+    afterEach(closeAllWindows);
+    it('emits focus event when contextIsolation is enabled', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          webviewTag: true,
+          contextIsolation: true
+        }
+      });
+      await w.loadURL('about:blank');
+      await w.webContents.executeJavaScript(`new Promise((resolve, reject) => {
+        const webview = new WebView()
+        webview.setAttribute('src', 'about:blank')
+        webview.addEventListener('dom-ready', () => {
+          webview.focus()
+        })
+        webview.addEventListener('focus', () => {
+          resolve();
+        })
+        document.body.appendChild(webview)
+      })`);
+    });
+  });
 });


### PR DESCRIPTION
Backport of #29004

See that PR for details.

Notes: Fixed `<webview>` `focus` / `blur` events not working with `contextIsolation` enabled.