### PR TITLE
test: re-enable nan test: typedarrays-test.js

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -662,6 +662,10 @@ step-persist-data-for-tests: &step-persist-data-for-tests
       - src/third_party/electron_node
       - src/third_party/nan
       - src/cross-arch-snapshots
+      - src/third_party/llvm-build
+      - src/build/linux
+      - src/buildtools/third_party/libc++
+      - src/buildtools/third_party/libc++abi
 
 step-electron-dist-unzip: &step-electron-dist-unzip
   run:

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -107,5 +107,4 @@ fix_expose_decrementcapturercount_in_web_contents_impl.patch
 add_setter_for_browsermainloop_result_code.patch
 revert_roll_clang_llvmorg-13-init-7051-gdad5caa5-2.patch
 make_include_of_stack_trace_h_unconditional.patch
-cherry-pick-5d3a047a15e0.patch
 build_libc_as_static_library.patch

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -107,3 +107,5 @@ fix_expose_decrementcapturercount_in_web_contents_impl.patch
 add_setter_for_browsermainloop_result_code.patch
 revert_roll_clang_llvmorg-13-init-7051-gdad5caa5-2.patch
 make_include_of_stack_trace_h_unconditional.patch
+cherry-pick-5d3a047a15e0.patch
+build_libc_as_static_library.patch

--- a/patches/chromium/build_libc_as_static_library.patch
+++ b/patches/chromium/build_libc_as_static_library.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: VerteDinde <keeleymhammond@gmail.com>
+Date: Thu, 13 May 2021 13:27:08 -0700
+Subject: build_libc++_as_static_library
+
+To address differences between libc++ and stdlibc++, we build
+libc++ and libc++abi as static libraries and add them to the
+linker for the nan spec runner
+
+diff --git a/buildtools/third_party/libc++/BUILD.gn b/buildtools/third_party/libc++/BUILD.gn
+index 65f6e8585ad374ad59e7670babfedd2fbdfbaa43..1cfca8c94e7c86a8bc02d520fb97086805a903e3 100644
+--- a/buildtools/third_party/libc++/BUILD.gn
++++ b/buildtools/third_party/libc++/BUILD.gn
+@@ -32,7 +32,7 @@ config("winver") {
+ if (libcxx_is_shared) {
+   _libcxx_target_type = "shared_library"
+ } else {
+-  _libcxx_target_type = "source_set"
++  _libcxx_target_type = "static_library"
+ }
+ target(_libcxx_target_type, "libc++") {
+   # Most things that need to depend on libc++ should do so via the implicit
+diff --git a/buildtools/third_party/libc++abi/BUILD.gn b/buildtools/third_party/libc++abi/BUILD.gn
+index 8b1da01ce87ff6db8e67938d4c083312cfa3101f..1668eba70db1933a434709c0140fe125991249b3 100644
+--- a/buildtools/third_party/libc++abi/BUILD.gn
++++ b/buildtools/third_party/libc++abi/BUILD.gn
+@@ -4,7 +4,7 @@
+ 
+ import("//build/config/c++/c++.gni")
+ 
+-source_set("libc++abi") {
++static_library("libc++abi") {
+   if (export_libcxxabi_from_executables) {
+     visibility = [ "//build/config:executable_deps" ]
+   } else {

--- a/patches/nan/.patches
+++ b/patches/nan/.patches
@@ -1,1 +1,2 @@
 api_simplify_scriptorigin.patch
+nan_string_test_alignment.patch

--- a/patches/nan/nan_string_test_alignment.patch
+++ b/patches/nan/nan_string_test_alignment.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: clavin <clavin@electronjs.org>
+Date: Wed, 12 May 2021 12:43:07 -0600
+Subject: nan_string_test_alignment
+
+Modifies a NAN test to avoid a debug check pertaining to efficient string alignment.
+
+diff --git a/test/cpp/strings.cpp b/test/cpp/strings.cpp
+index 95edeac91a4ec6a5f5cd80aa36dca8a55eb53f2a..0ad5cb7095490ac1eb454318582a9a683cb14be1 100644
+--- a/test/cpp/strings.cpp
++++ b/test/cpp/strings.cpp
+@@ -26,7 +26,9 @@ NAN_METHOD(EncodeHex) {
+ }
+ 
+ NAN_METHOD(EncodeUCS2) {
+-  info.GetReturnValue().Set(Encode("h\0e\0l\0l\0o\0", 10, UCS2));
++  // This odd declaration is to get the string data aligned to a 2-byte boundary
++  const uint16_t str[] = {'h', 'e', 'l', 'l', 'o'};
++  info.GetReturnValue().Set(Encode(reinterpret_cast<const char*>(str), 10, UCS2));
+ }
+ 
+ Persistent<v8::FunctionTemplate> returnUtf8String_persistent;

--- a/script/nan-spec-runner.js
+++ b/script/nan-spec-runner.js
@@ -42,11 +42,21 @@ async function main () {
     `-isystem"${path.resolve(BASE, 'buildtools', 'third_party', 'libc++abi', 'trunk', 'include')}"`
   ].join(' ');
 
+  // needed ldflags for libc++ and libc++abi
+  const ldflags = [
+    '-stdlib=libc++',
+    '-fuse-ld=lld',
+    '-lc++abi',
+    `-L"${path.resolve(BASE, 'out', `${utils.getOutDir({ shouldLog: true })}`, 'obj', 'buildtools', 'third_party', 'libc++abi')}"`,
+    `-L"${path.resolve(BASE, 'out', `${utils.getOutDir({ shouldLog: true })}`, 'obj', 'buildtools', 'third_party', 'libc++')}"`
+  ].join(' ');
+
   if (process.platform !== 'win32') {
     env.CC = cc;
     env.CFLAGS = cxxflags;
     env.CXX = cxx;
     env.CXXFLAGS = cxxflags;
+    env.LDFLAGS = ldflags;
   }
 
   const { status: buildStatus } = cp.spawnSync(NPX_CMD, ['node-gyp', 'rebuild', '--verbose', '--directory', 'test', '-j', 'max'], {

--- a/script/nan-spec-runner.js
+++ b/script/nan-spec-runner.js
@@ -25,7 +25,30 @@ async function main () {
     npm_config_arch: process.env.NPM_CONFIG_ARCH,
     npm_config_yes: 'true'
   });
-  const { status: buildStatus } = cp.spawnSync(NPX_CMD, ['node-gyp', 'rebuild', '--directory', 'test', '-j', 'max'], {
+
+  const clangDir = path.resolve(BASE, 'third_party', 'llvm-build', 'Release+Asserts', 'bin');
+  const cc = path.resolve(clangDir, 'clang');
+  const cxx = path.resolve(clangDir, 'clang++');
+
+  // TODO(ckerr) this is cribbed from read obj/electron/electron_app.ninja.
+  // Maybe it would be better to have this script literally open up that
+  // file and pull cflags_cc from it instead of using bespoke code here?
+  const cxxflags = [
+    '-std=c++14',
+    '-nostdinc++',
+    '-D_LIBCPP_HAS_NO_VENDOR_AVAILABILITY_ANNOTATIONS', // needed by next line
+    `-isystem"${path.resolve(BASE, 'buildtools', 'third_party', 'libc++', 'trunk', 'include')}"`,
+    `-isystem"${path.resolve(BASE, 'buildtools', 'third_party', 'libc++abi', 'trunk', 'include')}"`
+  ].join(' ');
+
+  if (process.platform !== 'win32') {
+    env.CC = cc;
+    env.CFLAGS = cxxflags;
+    env.CXX = cxx;
+    env.CXXFLAGS = cxxflags;
+  }
+
+  const { status: buildStatus } = cp.spawnSync(NPX_CMD, ['node-gyp', 'rebuild', '--verbose', '--directory', 'test', '-j', 'max'], {
     env,
     cwd: NAN_DIR,
     stdio: 'inherit'
@@ -48,8 +71,7 @@ async function main () {
   const onlyTests = args.only && args.only.split(',');
 
   const DISABLED_TESTS = [
-    'nannew-test.js',
-    'typedarrays-test.js' // TODO(nornagon): https://github.com/electron/electron/issues/28414
+    'nannew-test.js'
   ];
   const testsToRun = fs.readdirSync(path.resolve(NAN_DIR, 'test', 'js'))
     .filter(test => !DISABLED_TESTS.includes(test))

--- a/script/nan-spec-runner.js
+++ b/script/nan-spec-runner.js
@@ -33,6 +33,7 @@ async function main () {
   // TODO(ckerr) this is cribbed from read obj/electron/electron_app.ninja.
   // Maybe it would be better to have this script literally open up that
   // file and pull cflags_cc from it instead of using bespoke code here?
+  // I think it's unlikely to work; but if it does, it would be more futureproof
   const cxxflags = [
     '-std=c++14',
     '-nostdinc++',


### PR DESCRIPTION
Fixes #28414 by copying some of the relevant build args from Electron into our nan test runner.

WIP. This fixes `typedarrays-test.js` for me locally on Linux but breaks other tests, so this is still a work in progress. I think this has the includes right but needs to make changes to the linker too. Pushed to a PR to see what CI thinks this does on other platforms.

CC @clavin. Also h/t @MarshallOfSound for pointing me at https://github.com/electron/electron/pull/25561 as a starting point.


#### Release Notes

Notes: none