### PR TITLE
refactor: call allowGuestViewElementDefinition / getWebFrameId via binding

### DIFF
--- a/lib/renderer/web-view/guest-view-internal.ts
+++ b/lib/renderer/web-view/guest-view-internal.ts
@@ -1,10 +1,11 @@
-import { webFrame } from 'electron';
 import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
 import * as ipcRendererUtils from '@electron/internal/renderer/ipc-renderer-internal-utils';
 import { webViewEvents } from '@electron/internal/common/web-view-events';
 
 import { WebViewImpl } from '@electron/internal/renderer/web-view/web-view-impl';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
+
+const { mainFrame } = process._linkedBinding('electron_renderer_web_frame');
 
 const DEPRECATED_EVENTS: Record<string, string> = {
   'page-title-updated': 'page-title-set'
@@ -60,7 +61,7 @@ export function createGuest (params: Record<string, any>): Promise<number> {
 export function attachGuest (
   elementInstanceId: number, guestInstanceId: number, params: Record<string, any>, contentWindow: Window
 ) {
-  const embedderFrameId = webFrame.getWebFrameId(contentWindow);
+  const embedderFrameId = mainFrame.getWebFrameId(contentWindow);
   if (embedderFrameId < 0) { // this error should not happen.
     throw new Error('Invalid embedder frame');
   }

--- a/lib/renderer/web-view/web-view-element.ts
+++ b/lib/renderer/web-view/web-view-element.ts
@@ -14,6 +14,8 @@ import type { SrcAttribute } from '@electron/internal/renderer/web-view/web-view
 
 type IWebViewImpl = webViewImplModule.WebViewImpl;
 
+const { mainFrame } = process._linkedBinding('electron_renderer_web_frame');
+
 // Return a WebViewElement class that is defined in this context.
 const defineWebViewElement = (v8Util: NodeJS.V8UtilBinding, webViewImpl: typeof webViewImplModule) => {
   const { guestViewInternal, WebViewImpl } = webViewImpl;
@@ -93,7 +95,7 @@ const registerWebViewElement = (v8Util: NodeJS.V8UtilBinding, webViewImpl: typeo
   webViewImpl.setupMethods(WebViewElement);
 
   // The customElements.define has to be called in a special scope.
-  webViewImpl.webFrame.allowGuestViewElementDefinition(window, () => {
+  mainFrame.allowGuestViewElementDefinition(window, () => {
     window.customElements.define('webview', WebViewElement);
     window.WebView = WebViewElement;
 

--- a/lib/renderer/web-view/web-view-impl.ts
+++ b/lib/renderer/web-view/web-view-impl.ts
@@ -7,7 +7,6 @@ import type { WebViewAttribute, PartitionAttribute } from '@electron/internal/re
 import { deserialize } from '@electron/internal/common/type-utils';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
-export { webFrame } from 'electron';
 export * as guestViewInternal from '@electron/internal/renderer/web-view/guest-view-internal';
 
 const v8Util = process._linkedBinding('electron_common_v8_util');

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -115,6 +115,8 @@ declare namespace NodeJS {
 
   interface InternalWebFrame extends Electron.WebFrame {
     getWebPreference<K extends keyof InternalWebPreferences>(name: K): InternalWebPreferences[K];
+    getWebFrameId(window: Window): number;
+    allowGuestViewElementDefinition(context: object, callback: Function): void;
   }
 
   interface WebFrameBinding {

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -91,11 +91,6 @@ declare namespace Electron {
     viewInstanceId: number;
   }
 
-  interface WebFrame {
-    getWebFrameId(window: Window): number;
-    allowGuestViewElementDefinition(window: Window, context: any): void;
-  }
-
   interface WebFrameMain {
     _send(internal: boolean, channel: string, args: any): void;
     _sendInternal(channel: string, ...args: any[]): void;


### PR DESCRIPTION
#### Description of Change
Simpifies `<webview>` implementation for upcoming refactoring to use `contextBridge` when `contextIsolation` is enabled.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes