### PR TITLE
refactor: remove setupWebViewAttributes gymnastics

### DIFF
--- a/lib/renderer/web-view/web-view-attributes.ts
+++ b/lib/renderer/web-view/web-view-attributes.ts
@@ -1,4 +1,4 @@
-import { WebViewImpl } from '@electron/internal/renderer/web-view/web-view-impl';
+import type { WebViewImpl } from '@electron/internal/renderer/web-view/web-view-impl';
 import { WEB_VIEW_CONSTANTS } from '@electron/internal/renderer/web-view/web-view-constants';
 
 const resolveURL = function (url?: string | null) {
@@ -249,18 +249,20 @@ class WebPreferencesAttribute extends WebViewAttribute {
 }
 
 // Sets up all of the webview attributes.
-WebViewImpl.prototype.setupWebViewAttributes = function () {
-  this.attributes.set(WEB_VIEW_CONSTANTS.ATTRIBUTE_PARTITION, new PartitionAttribute(this));
-  this.attributes.set(WEB_VIEW_CONSTANTS.ATTRIBUTE_SRC, new SrcAttribute(this));
-  this.attributes.set(WEB_VIEW_CONSTANTS.ATTRIBUTE_HTTPREFERRER, new HttpReferrerAttribute(this));
-  this.attributes.set(WEB_VIEW_CONSTANTS.ATTRIBUTE_USERAGENT, new UserAgentAttribute(this));
-  this.attributes.set(WEB_VIEW_CONSTANTS.ATTRIBUTE_NODEINTEGRATION, new BooleanAttribute(WEB_VIEW_CONSTANTS.ATTRIBUTE_NODEINTEGRATION, this));
-  this.attributes.set(WEB_VIEW_CONSTANTS.ATTRIBUTE_NODEINTEGRATIONINSUBFRAMES, new BooleanAttribute(WEB_VIEW_CONSTANTS.ATTRIBUTE_NODEINTEGRATIONINSUBFRAMES, this));
-  this.attributes.set(WEB_VIEW_CONSTANTS.ATTRIBUTE_PLUGINS, new BooleanAttribute(WEB_VIEW_CONSTANTS.ATTRIBUTE_PLUGINS, this));
-  this.attributes.set(WEB_VIEW_CONSTANTS.ATTRIBUTE_DISABLEWEBSECURITY, new BooleanAttribute(WEB_VIEW_CONSTANTS.ATTRIBUTE_DISABLEWEBSECURITY, this));
-  this.attributes.set(WEB_VIEW_CONSTANTS.ATTRIBUTE_ALLOWPOPUPS, new BooleanAttribute(WEB_VIEW_CONSTANTS.ATTRIBUTE_ALLOWPOPUPS, this));
-  this.attributes.set(WEB_VIEW_CONSTANTS.ATTRIBUTE_PRELOAD, new PreloadAttribute(this));
-  this.attributes.set(WEB_VIEW_CONSTANTS.ATTRIBUTE_BLINKFEATURES, new BlinkFeaturesAttribute(this));
-  this.attributes.set(WEB_VIEW_CONSTANTS.ATTRIBUTE_DISABLEBLINKFEATURES, new DisableBlinkFeaturesAttribute(this));
-  this.attributes.set(WEB_VIEW_CONSTANTS.ATTRIBUTE_WEBPREFERENCES, new WebPreferencesAttribute(this));
-};
+export function setupWebViewAttributes (self: WebViewImpl) {
+  return new Map<string, WebViewAttribute>([
+    [WEB_VIEW_CONSTANTS.ATTRIBUTE_PARTITION, new PartitionAttribute(self)],
+    [WEB_VIEW_CONSTANTS.ATTRIBUTE_SRC, new SrcAttribute(self)],
+    [WEB_VIEW_CONSTANTS.ATTRIBUTE_HTTPREFERRER, new HttpReferrerAttribute(self)],
+    [WEB_VIEW_CONSTANTS.ATTRIBUTE_USERAGENT, new UserAgentAttribute(self)],
+    [WEB_VIEW_CONSTANTS.ATTRIBUTE_NODEINTEGRATION, new BooleanAttribute(WEB_VIEW_CONSTANTS.ATTRIBUTE_NODEINTEGRATION, self)],
+    [WEB_VIEW_CONSTANTS.ATTRIBUTE_NODEINTEGRATIONINSUBFRAMES, new BooleanAttribute(WEB_VIEW_CONSTANTS.ATTRIBUTE_NODEINTEGRATIONINSUBFRAMES, self)],
+    [WEB_VIEW_CONSTANTS.ATTRIBUTE_PLUGINS, new BooleanAttribute(WEB_VIEW_CONSTANTS.ATTRIBUTE_PLUGINS, self)],
+    [WEB_VIEW_CONSTANTS.ATTRIBUTE_DISABLEWEBSECURITY, new BooleanAttribute(WEB_VIEW_CONSTANTS.ATTRIBUTE_DISABLEWEBSECURITY, self)],
+    [WEB_VIEW_CONSTANTS.ATTRIBUTE_ALLOWPOPUPS, new BooleanAttribute(WEB_VIEW_CONSTANTS.ATTRIBUTE_ALLOWPOPUPS, self)],
+    [WEB_VIEW_CONSTANTS.ATTRIBUTE_PRELOAD, new PreloadAttribute(self)],
+    [WEB_VIEW_CONSTANTS.ATTRIBUTE_BLINKFEATURES, new BlinkFeaturesAttribute(self)],
+    [WEB_VIEW_CONSTANTS.ATTRIBUTE_DISABLEBLINKFEATURES, new DisableBlinkFeaturesAttribute(self)],
+    [WEB_VIEW_CONSTANTS.ATTRIBUTE_WEBPREFERENCES, new WebPreferencesAttribute(self)]
+  ]);
+}

--- a/lib/renderer/web-view/web-view-element.ts
+++ b/lib/renderer/web-view/web-view-element.ts
@@ -115,7 +115,6 @@ export const setupWebView = (v8Util: NodeJS.V8UtilBinding, webViewImpl: typeof w
       return;
     }
 
-    webViewImpl.setupAttributes();
     registerWebViewElement(v8Util, webViewImpl);
 
     window.removeEventListener(event.type, listener, useCapture);

--- a/lib/renderer/web-view/web-view-impl.ts
+++ b/lib/renderer/web-view/web-view-impl.ts
@@ -4,6 +4,7 @@ import * as guestViewInternal from '@electron/internal/renderer/web-view/guest-v
 import { WEB_VIEW_CONSTANTS } from '@electron/internal/renderer/web-view/web-view-constants';
 import { syncMethods, asyncMethods, properties } from '@electron/internal/common/web-view-methods';
 import type { WebViewAttribute, PartitionAttribute } from '@electron/internal/renderer/web-view/web-view-attributes';
+import { setupWebViewAttributes } from '@electron/internal/renderer/web-view/web-view-attributes';
 import { deserialize } from '@electron/internal/common/type-utils';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
@@ -34,9 +35,7 @@ export class WebViewImpl {
   public on: Record<string, any> = {}
   public internalElement: HTMLIFrameElement
 
-  // Replaced in web-view-attributes
-  public attributes = new Map<string, WebViewAttribute>();
-  public setupWebViewAttributes (): void {}
+  public attributes: Map<string, WebViewAttribute>;
 
   public dispatchEventInMainWorld?: (eventName: string, props: any) => boolean;
 
@@ -47,7 +46,7 @@ export class WebViewImpl {
     const style = shadowRoot.ownerDocument.createElement('style');
     style.textContent = ':host { display: flex; }';
     shadowRoot.appendChild(style);
-    this.setupWebViewAttributes();
+    this.attributes = setupWebViewAttributes(this);
     this.viewInstanceId = getNextId();
     shadowRoot.appendChild(this.internalElement);
 
@@ -207,10 +206,6 @@ export class WebViewImpl {
     this.resizeObserver.observe(this.internalElement);
   }
 }
-
-export const setupAttributes = () => {
-  require('@electron/internal/renderer/web-view/web-view-attributes');
-};
 
 // I wish eslint wasn't so stupid, but it is
 // eslint-disable-next-line


### PR DESCRIPTION
#### Description of Change
Simpifies `<webview>` implementation for upcoming refactoring to use `contextBridge` when `contextIsolation` is enabled.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes