### PR TITLE
refactor: use WeakMap instead of hidden V8 properties to store WebViewImpl

### DIFF
--- a/lib/isolated_renderer/init.ts
+++ b/lib/isolated_renderer/init.ts
@@ -11,5 +11,5 @@ const webViewImpl = v8Util.getHiddenValue(isolatedWorld, 'web-view-impl');
 if (webViewImpl) {
   // Must setup the WebView element in main world.
   const { setupWebView } = require('@electron/internal/renderer/web-view/web-view-element') as typeof webViewElementModule;
-  setupWebView(v8Util, webViewImpl as any);
+  setupWebView(webViewImpl as any);
 }

--- a/lib/renderer/web-view/web-view-constants.ts
+++ b/lib/renderer/web-view/web-view-constants.ts
@@ -18,5 +18,6 @@ export const enum WEB_VIEW_CONSTANTS {
   // Error messages.
   ERROR_MSG_ALREADY_NAVIGATED = 'The object has already navigated, so its partition cannot be changed.',
   ERROR_MSG_INVALID_PARTITION_ATTRIBUTE = 'Invalid partition attribute.',
-  ERROR_MSG_INVALID_PRELOAD_ATTRIBUTE = 'Only "file:" protocol is supported in "preload" attribute.'
+  ERROR_MSG_INVALID_PRELOAD_ATTRIBUTE = 'Only "file:" protocol is supported in "preload" attribute.',
+  ERROR_MSG_NOT_ATTACHED = 'The WebView must be attached to the DOM and the dom-ready event emitted before this method can be called.'
 }

--- a/lib/renderer/web-view/web-view-impl.ts
+++ b/lib/renderer/web-view/web-view-impl.ts
@@ -64,6 +64,7 @@ export class WebViewImpl {
     iframeElement.style.flex = '1 1 auto';
     iframeElement.style.width = '100%';
     iframeElement.style.border = '0';
+    // used by RendererClientBase::IsWebViewFrame
     v8Util.setHiddenValue(iframeElement, 'internal', this);
     return iframeElement;
   }
@@ -210,14 +211,6 @@ export class WebViewImpl {
 // I wish eslint wasn't so stupid, but it is
 // eslint-disable-next-line
 export const setupMethods = (WebViewElement: typeof ElectronInternal.WebViewElement) => {
-  WebViewElement.prototype.getWebContentsId = function () {
-    const internal = v8Util.getHiddenValue<WebViewImpl>(this, 'internal');
-    if (!internal.guestInstanceId) {
-      throw new Error('The WebView must be attached to the DOM and the dom-ready event emitted before this method can be called.');
-    }
-    return internal.guestInstanceId;
-  };
-
   // Focusing the webview should move page focus to the underlying iframe.
   WebViewElement.prototype.focus = function () {
     this.contentWindow.focus();

--- a/lib/renderer/web-view/web-view-init.ts
+++ b/lib/renderer/web-view/web-view-init.ts
@@ -27,7 +27,7 @@ export function webViewInit (contextIsolation: boolean, webviewTag: boolean, gue
       v8Util.setHiddenValue(window, 'web-view-impl', webViewImplModule);
     } else {
       const { setupWebView } = require('@electron/internal/renderer/web-view/web-view-element') as typeof webViewElement;
-      setupWebView(v8Util, webViewImplModule);
+      setupWebView(webViewImplModule);
     }
   }
 


### PR DESCRIPTION
#### Description of Change
Simpifies `<webview>` implementation for upcoming refactoring to use `contextBridge` when `contextIsolation` is enabled.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes