### PR TITLE
chore: cherry-pick 82434206f306 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -106,3 +106,4 @@ extend_apply_webpreferences.patch
 fix_expose_decrementcapturercount_in_web_contents_impl.patch
 add_setter_for_browsermainloop_result_code.patch
 revert_roll_clang_llvmorg-13-init-7051-gdad5caa5-2.patch
+cherry-pick-82434206f306.patch


### PR DESCRIPTION
Revert "Experiment on Canary: Enable BackupRefPtr (15th round, Win & Android)"

This reverts commit 0f25421a49f714ee2553e6b249924ed874cefc9e.

Reason for revert: build triggered, keep the branch clean

Original change's description:
> Experiment on Canary: Enable BackupRefPtr (15th round, Win & Android)
>
> PS1: CheckedPtr rewrite generated by rewrite-multiple-platforms.sh
> on beece242e447f48499bbf0fcc0b71fb21e0c7aba then rebased on top of
> branch-heads/4500 (no conflicts)
> PS2: Enable and configure BRP + clang.gni workaround
> PS3: Apply a build break workaround (crrev.com/c/2879256)
>
> More details here:
> https://docs.google.com/document/d/1zKoTPWl_lEBmQcSSpKtXSjWXMs-1oWRwZp8dCu3KRyA/edit?resourcekey=0-3tbMv2PBZnCHFvHcSPS7NQ#heading=h.c0uts5ftkk58
>
> Bug: 1073933
> Change-Id: I7aa94325c81f017557d5bd532149c764f42afcc8
> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2878241
> Reviewed-by: Keishi Hattori <keishi@chromium.org>
> Owners-Override: Keishi Hattori <keishi@chromium.org>
> Cr-Commit-Position: refs/branch-heads/4500@{#3}
> Cr-Branched-From: f5a12ae8f39eee9ae079f08d0d3c67ab4cc35421-refs/heads/master@{#880109}

Bug: 1073933
Change-Id: I6abbe170f0e86adb0b282324523370edb6874437
No-Presubmit: true
No-Tree-Checks: true
No-Try: true
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2878271
Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Owners-Override: Ben Mason <benmason@chromium.org>
Cr-Commit-Position: refs/branch-heads/4500@{#5}
Cr-Branched-From: f5a12ae8f39eee9ae079f08d0d3c67ab4cc35421-refs/heads/master@{#880109}


Notes: none