### PR TITLE
docs: Improve description of findInPage options

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1281,8 +1281,7 @@ Inserts `text` to the focused element.
 * `text` String - Content to be searched, must not be empty.
 * `options` Object (optional)
   * `forward` Boolean (optional) - Whether to search forward or backward, defaults to `true`.
-  * `findNext` Boolean (optional) - Whether the operation is first request or a follow up,
-    defaults to `false`.
+  * `findNext` Boolean (optional) - Whether to begin a new text finding session with this request. Should be `true` for initial requests, and `false` for follow-up requests. Defaults to `false`.
   * `matchCase` Boolean (optional) - Whether search should be case-sensitive,
     defaults to `false`.
 

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -506,8 +506,7 @@ Inserts `text` to the focused element.
 * `text` String - Content to be searched, must not be empty.
 * `options` Object (optional)
   * `forward` Boolean (optional) - Whether to search forward or backward, defaults to `true`.
-  * `findNext` Boolean (optional) - Whether the operation is first request or a follow up,
-    defaults to `false`.
+  * `findNext` Boolean (optional) - Whether to begin a new text finding session with this request. Should be `true` for initial requests, and `false` for follow-up requests. Defaults to `false`.
   * `matchCase` Boolean (optional) - Whether search should be case-sensitive,
     defaults to `false`.
 


### PR DESCRIPTION
#### Description of Change

The existing documentation for the `findNext` option of `findInPage` reads as if `findNext: false` is for a first request, and `findNext: true` is for a follow up request. However, it's actually the opposite - `findNext: true` maps to Chromium's `new_session` option ([code](https://github.com/electron/electron/blob/0a1b26b1d5d99f22c2b837176c28b66d7b050227/shell/browser/api/electron_api_web_contents.cc#L2647)), which should only be used for first requests. I've tried to make the description more specific so it's clear which value to use.

#### Release Notes

Notes: none