### PR TITLE
fix: update NSView radii on fullscreen transition

### DIFF
--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -161,6 +161,8 @@ class NativeWindowMac : public NativeWindow,
   // Use a custom content view instead of Chromium's BridgedContentView.
   void OverrideNSWindowContentView();
 
+  void UpdateVibrancyRadii(bool fullscreen);
+
   // Set the attribute of NSWindow while work around a bug of zoom button.
   void SetStyleMask(bool on, NSUInteger flag);
   void SetCollectionBehavior(bool on, NSUInteger flag);
@@ -271,6 +273,7 @@ class NativeWindowMac : public NativeWindow,
 
   base::scoped_nsobject<NSColor> background_color_before_vibrancy_;
   bool transparency_before_vibrancy_ = false;
+  std::string vibrancy_type_;
 
   // The presentation options before entering simple fullscreen mode.
   NSApplicationPresentationOptions simple_fullscreen_options_;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/29061.

We set the radius on a frameless BrowserWindow with vibrancy and then didn't previously update it when fullscreen transitions happened, which had the potential to create weird side-effects and also to work incorrectly when the window was itself in fullscreen mode.

Before in non-fullscreen:

<img width="89" alt="Screen Shot 2021-05-10 at 2 10 11 PM" src="https://user-images.githubusercontent.com/2036040/117657331-bafa2380-b199-11eb-8496-28ace1cd1ec7.png">

Before in fullscreen (must click, hard to see otherwise that there's a little weird white bit):

<img width="77" alt="Screen Shot 2021-05-10 at 2 10 33 PM" src="https://user-images.githubusercontent.com/2036040/117657484-e67d0e00-b199-11eb-9eda-0d146899a4d9.png">

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed the possibility for incorrect visual artifacts when using vibrancy and making frameless windows fullscreen on macOS.
