### PR TITLE
fix: illegal access errors with nodeIntegrationInSubFrames

### DIFF
--- a/shell/renderer/electron_render_frame_observer.cc
+++ b/shell/renderer/electron_render_frame_observer.cc
@@ -74,6 +74,7 @@ void ElectronRenderFrameObserver::DidInstallConditionalFeatures(
   bool is_main_world = IsMainWorld(world_id);
   bool is_main_frame = render_frame_->IsMainFrame();
   bool allow_node_in_sub_frames = prefs.node_integration_in_sub_frames;
+
   bool should_create_isolated_context =
       use_context_isolation && is_main_world &&
       (is_main_frame || allow_node_in_sub_frames);
@@ -152,12 +153,23 @@ bool ElectronRenderFrameObserver::IsIsolatedWorld(int world_id) {
 
 bool ElectronRenderFrameObserver::ShouldNotifyClient(int world_id) {
   auto prefs = render_frame_->GetBlinkPreferences();
+
+  // This is necessary because if an iframe is created and a source is not
+  // set, the iframe loads about:blank and creates a script context for the
+  // same. We don't want to create a Node.js environment here because if the src
+  // is later set, the JS necessary to do that triggers illegal access errors
+  // when the initial about:blank Node.js environment is cleaned up. See:
+  // https://source.chromium.org/chromium/chromium/src/+/main:content/renderer/render_frame_impl.h;l=870-892;drc=4b6001440a18740b76a1c63fa2a002cc941db394
+  GURL url = render_frame_->GetWebFrame()->GetDocument().Url();
   bool allow_node_in_sub_frames = prefs.node_integration_in_sub_frames;
+  if (allow_node_in_sub_frames && url.IsAboutBlank())
+    return false;
+
   if (prefs.context_isolation &&
       (render_frame_->IsMainFrame() || allow_node_in_sub_frames))
     return IsIsolatedWorld(world_id);
-  else
-    return IsMainWorld(world_id);
+
+  return IsMainWorld(world_id);
 }
 
 }  // namespace electron

--- a/shell/renderer/electron_render_frame_observer.cc
+++ b/shell/renderer/electron_render_frame_observer.cc
@@ -162,7 +162,8 @@ bool ElectronRenderFrameObserver::ShouldNotifyClient(int world_id) {
   // https://source.chromium.org/chromium/chromium/src/+/main:content/renderer/render_frame_impl.h;l=870-892;drc=4b6001440a18740b76a1c63fa2a002cc941db394
   GURL url = render_frame_->GetWebFrame()->GetDocument().Url();
   bool allow_node_in_sub_frames = prefs.node_integration_in_sub_frames;
-  if (allow_node_in_sub_frames && url.IsAboutBlank())
+  if (allow_node_in_sub_frames && url.IsAboutBlank() &&
+      !render_frame_->IsMainFrame())
     return false;
 
   if (prefs.context_isolation &&

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -85,16 +85,7 @@ void ElectronRendererClient::DidCreateScriptContext(
   auto prefs = render_frame->GetBlinkPreferences();
   bool is_main_frame = render_frame->IsMainFrame();
   bool is_devtools = IsDevToolsExtension(render_frame);
-
-  // This is necessary because if an iframe is created and a source is not
-  // set, the iframe loads about:blank and creates a script context for the
-  // same. We don't want to create a Node.js environment here because if the src
-  // is later set, the JS necessary to do that triggers illegal access errors
-  // when the initial about:blank Node.js environment is cleaned up. See:
-  // https://source.chromium.org/chromium/chromium/src/+/main:content/renderer/render_frame_impl.h;l=870-892;drc=4b6001440a18740b76a1c63fa2a002cc941db394
-  GURL url = render_frame->GetWebFrame()->GetDocument().Url();
-  bool allow_node_in_subframes =
-      prefs.node_integration_in_sub_frames && !url.IsAboutBlank();
+  bool allow_node_in_subframes = prefs.node_integration_in_sub_frames;
 
   bool should_load_node =
       (is_main_frame || is_devtools || allow_node_in_subframes) &&

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -80,12 +80,22 @@ void ElectronRendererClient::DidCreateScriptContext(
   // TODO(zcbenz): Do not create Node environment if node integration is not
   // enabled.
 
-  // Only load node if we are a main frame or a devtools extension
-  // unless node support has been explicitly enabled for sub frames
+  // Only load Node.js if we are a main frame or a devtools extension
+  // unless Node.js support has been explicitly enabled for subframes.
   auto prefs = render_frame->GetBlinkPreferences();
   bool is_main_frame = render_frame->IsMainFrame();
   bool is_devtools = IsDevToolsExtension(render_frame);
-  bool allow_node_in_subframes = prefs.node_integration_in_sub_frames;
+
+  // This is necessary because if an iframe is created and a source is not
+  // set, the iframe loads about:blank and creates a script context for the
+  // same. We don't want to create a Node.js environment here because if the src
+  // is later set, the JS necessary to do that triggers illegal access errors
+  // when the initial about:blank Node.js environment is cleaned up. See:
+  // https://source.chromium.org/chromium/chromium/src/+/main:content/renderer/render_frame_impl.h;l=870-892;drc=4b6001440a18740b76a1c63fa2a002cc941db394
+  GURL url = render_frame->GetWebFrame()->GetDocument().Url();
+  bool allow_node_in_subframes =
+      prefs.node_integration_in_sub_frames && !url.IsAboutBlank();
+
   bool should_load_node =
       (is_main_frame || is_devtools || allow_node_in_subframes) &&
       !IsWebViewFrame(renderer_context, render_frame);

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -204,8 +204,13 @@ void ElectronSandboxedRendererClient::DidCreateScriptContext(
   bool is_main_frame = render_frame->IsMainFrame();
   bool is_devtools =
       IsDevTools(render_frame) || IsDevToolsExtension(render_frame);
+
+  // See comment in ElectronRendererClient::DidCreateScriptContext.
+  GURL url = render_frame->GetWebFrame()->GetDocument().Url();
   bool allow_node_in_sub_frames =
-      render_frame->GetBlinkPreferences().node_integration_in_sub_frames;
+      render_frame->GetBlinkPreferences().node_integration_in_sub_frames &&
+      !url.IsAboutBlank();
+
   bool should_load_preload =
       (is_main_frame || is_devtools || allow_node_in_sub_frames) &&
       !IsWebViewFrame(context, render_frame);

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -205,11 +205,8 @@ void ElectronSandboxedRendererClient::DidCreateScriptContext(
   bool is_devtools =
       IsDevTools(render_frame) || IsDevToolsExtension(render_frame);
 
-  // See comment in ElectronRendererClient::DidCreateScriptContext.
-  GURL url = render_frame->GetWebFrame()->GetDocument().Url();
   bool allow_node_in_sub_frames =
-      render_frame->GetBlinkPreferences().node_integration_in_sub_frames &&
-      !url.IsAboutBlank();
+      render_frame->GetBlinkPreferences().node_integration_in_sub_frames;
 
   bool should_load_preload =
       (is_main_frame || is_devtools || allow_node_in_sub_frames) &&

--- a/spec-main/fixtures/crash-cases/js-execute-iframe/index.html
+++ b/spec-main/fixtures/crash-cases/js-execute-iframe/index.html
@@ -1,0 +1,24 @@
+<html>
+  <body>
+    <iframe id="mainframe"></iframe>
+    <script>
+      const net = require('net')
+
+      document.getElementById("mainframe").src="./page2.html";
+
+      const client = net.createConnection({ path: '/tmp/echo.sock' }, () => {
+        console.log('connected to server');
+        client.write('world!\r\n');
+      });
+
+      client.on('data', (data) => {
+        console.log(data.toString());
+        client.end();
+      });
+
+      client.on('end', () => {
+        console.log('disconnected from server');
+      });
+    </script>
+  </body>
+</html>

--- a/spec-main/fixtures/crash-cases/js-execute-iframe/index.html
+++ b/spec-main/fixtures/crash-cases/js-execute-iframe/index.html
@@ -2,11 +2,16 @@
   <body>
     <iframe id="mainframe"></iframe>
     <script>
-      const net = require('net')
+      const net = require('net');
+      const path = require('path');
 
       document.getElementById("mainframe").src="./page2.html";
 
-      const client = net.createConnection({ path: '/tmp/echo.sock' }, () => {
+      const p = process.platform === 'win32'
+              ? path.join('\\\\?\\pipe', process.cwd(), 'myctl')
+              : '/tmp/echo.sock';
+
+      const client = net.createConnection({ path: p }, () => {
         console.log('connected to server');
         client.write('world!\r\n');
       });

--- a/spec-main/fixtures/crash-cases/js-execute-iframe/index.js
+++ b/spec-main/fixtures/crash-cases/js-execute-iframe/index.js
@@ -1,0 +1,48 @@
+const { app, BrowserWindow } = require('electron');
+const net = require('net');
+const path = require('path');
+
+function createWindow () {
+  const mainWindow = new BrowserWindow({
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+      nodeIntegrationInSubFrames: true,
+      preload: path.resolve(__dirname, 'preload.js')
+    }
+  });
+
+  mainWindow.loadFile('index.html');
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});
+
+const server = net.createServer((c) => {
+  console.log('client connected');
+
+  c.on('end', () => {
+    console.log('client disconnected');
+    app.quit();
+  });
+
+  c.write('hello\r\n');
+  c.pipe(c);
+});
+
+server.on('error', (err) => {
+  throw err;
+});
+
+server.listen('/tmp/echo.sock', () => {
+  console.log('server bound');
+});

--- a/spec-main/fixtures/crash-cases/js-execute-iframe/index.js
+++ b/spec-main/fixtures/crash-cases/js-execute-iframe/index.js
@@ -7,8 +7,7 @@ function createWindow () {
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: false,
-      nodeIntegrationInSubFrames: true,
-      preload: path.resolve(__dirname, 'preload.js')
+      nodeIntegrationInSubFrames: true
     }
   });
 
@@ -43,6 +42,10 @@ server.on('error', (err) => {
   throw err;
 });
 
-server.listen('/tmp/echo.sock', () => {
+const p = process.platform === 'win32'
+  ? path.join('\\\\?\\pipe', process.cwd(), 'myctl')
+  : '/tmp/echo.sock';
+
+server.listen(p, () => {
   console.log('server bound');
 });

--- a/spec-main/fixtures/crash-cases/js-execute-iframe/page2.html
+++ b/spec-main/fixtures/crash-cases/js-execute-iframe/page2.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html>
+	<body>HELLO</body>
+</html>


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/27995.

Fixes an issue where `illegal access error` would be thrown by the V8 isolate in some circumstances where an iframe was loaded and its source set later when Node.js integration is enabled in subframes. This was happening because if an iframe is created and a source is not set, the iframe loads about:blank and creates a script context for the same. We don't want to create a Node.js environment here because if the src is later set, the JS necessary to do that triggers illegal access errors when the initial about:blank Node.js environment is [cleaned up](https://github.com/nodejs/node/blob/73ef3f2f050a874712d1770ddd4e02930a638eda/src/env.cc#L558-L559). 

See this comment: https://source.chromium.org/chromium/chromium/src/+/main:content/renderer/render_frame_impl.h;l=870-892;drc=4b6001440a18740b76a1c63fa2a002cc941db394

cc @MarshallOfSound 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `illegal access error` could be thrown when `nodeIntegrationInSubFrames` is enabled.
