### PR TITLE
feat: add new imageAnimationPolicy webpref and webContents setter

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -294,6 +294,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     * `allowRunningInsecureContent` Boolean (optional) - Allow an https page to run
       JavaScript, CSS or plugins from http URLs. Default is `false`.
     * `images` Boolean (optional) - Enables image support. Default is `true`.
+    * `imageAnimationPolicy` String (optional) - Specifies how to run image animations (E.g. GIFs).  Can be `animate`, `animateOnce` or `noAnimation`.  Default is `animate`.
     * `textAreasAreResizable` Boolean (optional) - Make TextArea elements resizable. Default
       is `true`.
     * `webgl` Boolean (optional) - Enables WebGL support. Default is `true`.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1923,6 +1923,20 @@ when the page becomes backgrounded. This also affects the Page Visibility API.
 
 Returns `String` - the type of the webContent. Can be `backgroundPage`, `window`, `browserView`, `remote`, `webview` or `offscreen`.
 
+#### `contents.setImageAnimationPolicy(policy)`
+
+* `policy` String - Can be `animate`, `animateOnce` or `noAnimation`.
+
+Sets the image animation policy for this webContents.  The policy only affects
+_new_ images, existing images that are currently being animated are unaffected.
+This is a known limitation in Chromium, you can force image animation to be
+recalculated with `img.src = img.src` which will result in no network traffic
+but will update the animation policy.
+
+This corresponds to the [animationPolicy][] accessibility feature in Chromium.
+
+[animationPolicy]: https://developer.chrome.com/docs/extensions/reference/accessibilityFeatures/#property-animationPolicy
+
 ### Instance Properties
 
 #### `contents.audioMuted`

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3140,6 +3140,13 @@ void WebContents::NotifyUserActivation() {
         blink::mojom::UserActivationNotificationType::kInteraction);
 }
 
+void WebContents::SetImageAnimationPolicy(const std::string& new_policy) {
+  auto* web_preferences = WebContentsPreferences::From(web_contents());
+  web_preferences->preference()->SetKey(options::kImageAnimationPolicy,
+                                        base::Value(new_policy));
+  web_contents()->OnWebPreferencesChanged();
+}
+
 v8::Local<v8::Promise> WebContents::TakeHeapSnapshot(
     v8::Isolate* isolate,
     const base::FilePath& file_path) {
@@ -3687,6 +3694,8 @@ v8::Local<v8::ObjectTemplate> WebContents::FillObjectTemplate(
                  &WebContents::GetWebRTCIPHandlingPolicy)
       .SetMethod("_grantOriginAccess", &WebContents::GrantOriginAccess)
       .SetMethod("takeHeapSnapshot", &WebContents::TakeHeapSnapshot)
+      .SetMethod("setImageAnimationPolicy",
+                 &WebContents::SetImageAnimationPolicy)
       .SetProperty("id", &WebContents::ID)
       .SetProperty("session", &WebContents::Session)
       .SetProperty("hostWebContents", &WebContents::HostWebContents)

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -419,6 +419,7 @@ class WebContents : public gin::Wrappable<WebContents>,
   void SetTemporaryZoomLevel(double level);
   void DoGetZoomLevel(
       electron::mojom::ElectronBrowser::DoGetZoomLevelCallback callback);
+  void SetImageAnimationPolicy(const std::string& new_policy);
 
  private:
   // Does not manage lifetime of |web_contents|.

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -28,6 +28,7 @@
 #include "shell/common/process_util.h"
 #include "third_party/blink/public/common/web_preferences/web_preferences.h"
 #include "third_party/blink/public/mojom/v8_cache_options.mojom.h"
+#include "third_party/blink/public/mojom/webpreferences/web_preferences.mojom-blink.h"  // nogncheck
 
 #if defined(OS_WIN)
 #include "ui/gfx/switches.h"
@@ -105,6 +106,26 @@ bool GetAsAutoplayPolicy(const base::Value* val,
       return true;
     }
     return false;
+  }
+  return false;
+}
+
+bool GetImageAnimationPolicy(const base::Value* val,
+                             blink::mojom::ImageAnimationPolicy* out) {
+  std::string policy;
+  if (GetAsString(val, electron::options::kImageAnimationPolicy, &policy)) {
+    if (policy == "animate") {
+      *out = blink::mojom::ImageAnimationPolicy::kImageAnimationPolicyAllowed;
+      return true;
+    } else if (policy == "animateOnce") {
+      *out =
+          blink::mojom::ImageAnimationPolicy::kImageAnimationPolicyAnimateOnce;
+      return true;
+    } else if (policy == "noAnimation") {
+      *out =
+          blink::mojom::ImageAnimationPolicy::kImageAnimationPolicyNoAnimation;
+      return true;
+    }
   }
   return false;
 }
@@ -367,6 +388,7 @@ void WebContentsPreferences::OverrideWebkitPrefs(
   prefs->javascript_enabled =
       IsEnabled(options::kJavaScript, true /* default_value */);
   prefs->images_enabled = IsEnabled(options::kImages, true /* default_value */);
+  GetImageAnimationPolicy(&preference_, &prefs->animation_policy);
   prefs->text_areas_are_resizable =
       IsEnabled(options::kTextAreasAreResizable, true /* default_value */);
   prefs->navigate_on_drag_drop =

--- a/shell/common/options_switches.cc
+++ b/shell/common/options_switches.cc
@@ -171,6 +171,9 @@ const char kJavaScript[] = "javascript";
 // Enables image support.
 const char kImages[] = "images";
 
+// Image animation policy.
+const char kImageAnimationPolicy[] = "imageAnimationPolicy";
+
 // Make TextArea elements resizable.
 const char kTextAreasAreResizable[] = "textAreasAreResizable";
 

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -84,6 +84,7 @@ extern const char kNodeIntegrationInSubFrames[];
 extern const char kDisableHtmlFullscreenWindowResize[];
 extern const char kJavaScript[];
 extern const char kImages[];
+extern const char kImageAnimationPolicy[];
 extern const char kTextAreasAreResizable[];
 extern const char kWebGL[];
 extern const char kNavigateOnDragDrop[];


### PR DESCRIPTION
As in title, adds a new webpref to map to the Chromium webpref.  Also adds a webContents setter so that this can be set at runtime without having to reload / recreate the webContents.

This is helpful for apps that need to enable / disable animations for accessibility or performance reasons.

Notes: Added new `imageAnimationPolicy` web preference to control how images are animated