### PR TITLE
refactor: replace v8::Local<T>::Cast() with As<T>()

### DIFF
--- a/shell/common/api/electron_api_v8_util.cc
+++ b/shell/common/api/electron_api_v8_util.cc
@@ -38,7 +38,7 @@ struct Converter<std::pair<Type1, Type2>> {
     if (!val->IsArray())
       return false;
 
-    v8::Local<v8::Array> array(v8::Local<v8::Array>::Cast(val));
+    v8::Local<v8::Array> array = val.As<v8::Array>();
     if (array->Length() != 2)
       return false;
 

--- a/shell/common/gin_converters/net_converter.cc
+++ b/shell/common/gin_converters/net_converter.cc
@@ -191,7 +191,7 @@ bool Converter<net::HttpResponseHeaders*>::FromV8(
   };
 
   auto context = isolate->GetCurrentContext();
-  auto headers = v8::Local<v8::Object>::Cast(val);
+  auto headers = val.As<v8::Object>();
   auto keys = headers->GetOwnPropertyNames(context).ToLocalChecked();
   for (uint32_t i = 0; i < keys->Length(); i++) {
     v8::Local<v8::Value> keyVal;
@@ -203,7 +203,7 @@ bool Converter<net::HttpResponseHeaders*>::FromV8(
 
     auto localVal = headers->Get(context, keyVal).ToLocalChecked();
     if (localVal->IsArray()) {
-      auto values = v8::Local<v8::Array>::Cast(localVal);
+      auto values = localVal.As<v8::Array>();
       for (uint32_t j = 0; j < values->Length(); j++) {
         if (!addHeaderFromValue(key,
                                 values->Get(context, j).ToLocalChecked())) {

--- a/shell/common/gin_converters/std_converter.h
+++ b/shell/common/gin_converters/std_converter.h
@@ -86,7 +86,7 @@ struct Converter<v8::Local<v8::Array>> {
                      v8::Local<v8::Array>* out) {
     if (!val->IsArray())
       return false;
-    *out = v8::Local<v8::Array>::Cast(val);
+    *out = val.As<v8::Array>();
     return true;
   }
 };
@@ -102,7 +102,7 @@ struct Converter<v8::Local<v8::String>> {
                      v8::Local<v8::String>* out) {
     if (!val->IsString())
       return false;
-    *out = v8::Local<v8::String>::Cast(val);
+    *out = val.As<v8::String>();
     return true;
   }
 };
@@ -128,7 +128,7 @@ struct Converter<std::set<T>> {
 
     auto context = isolate->GetCurrentContext();
     std::set<T> result;
-    v8::Local<v8::Array> array(v8::Local<v8::Array>::Cast(val));
+    v8::Local<v8::Array> array = val.As<v8::Array>();
     uint32_t length = array->Length();
     for (uint32_t i = 0; i < length; ++i) {
       T item;

--- a/shell/common/gin_helper/callback.cc
+++ b/shell/common/gin_helper/callback.cc
@@ -86,7 +86,7 @@ class RefCountedGlobal
     : public base::RefCountedThreadSafe<RefCountedGlobal<T>, DeleteOnUIThread> {
  public:
   RefCountedGlobal(v8::Isolate* isolate, v8::Local<v8::Value> value)
-      : handle_(isolate, v8::Local<T>::Cast(value)) {}
+      : handle_(isolate, value.As<T>()) {}
 
   bool IsAlive() const { return !handle_.IsEmpty(); }
 
@@ -147,8 +147,7 @@ v8::Local<v8::Value> BindFunctionWith(v8::Isolate* isolate,
   v8::MaybeLocal<v8::Value> bind =
       func->Get(context, gin::StringToV8(isolate, "bind"));
   CHECK(!bind.IsEmpty());
-  v8::Local<v8::Function> bind_func =
-      v8::Local<v8::Function>::Cast(bind.ToLocalChecked());
+  v8::Local<v8::Function> bind_func = bind.ToLocalChecked().As<v8::Function>();
   v8::Local<v8::Value> converted[] = {func, arg1, arg2};
   return bind_func->Call(context, func, base::size(converted), converted)
       .ToLocalChecked();

--- a/shell/common/gin_helper/event_emitter.cc
+++ b/shell/common/gin_helper/event_emitter.cc
@@ -59,7 +59,7 @@ v8::Local<v8::Object> CreateNativeEvent(
   if (frame && callback) {
     gin::Handle<Event> native_event = Event::Create(isolate);
     native_event->SetCallback(std::move(callback));
-    event = v8::Local<v8::Object>::Cast(native_event.ToV8());
+    event = native_event.ToV8().As<v8::Object>();
   } else {
     // No need to create native event if we do not need to send reply.
     event = CreateEvent(isolate);

--- a/shell/common/gin_helper/persistent_dictionary.h
+++ b/shell/common/gin_helper/persistent_dictionary.h
@@ -53,8 +53,7 @@ struct Converter<gin_helper::PersistentDictionary> {
                      gin_helper::PersistentDictionary* out) {
     if (!val->IsObject())
       return false;
-    *out = gin_helper::PersistentDictionary(isolate,
-                                            v8::Local<v8::Object>::Cast(val));
+    *out = gin_helper::PersistentDictionary(isolate, val.As<v8::Object>());
     return true;
   }
 };

--- a/shell/common/gin_helper/promise.h
+++ b/shell/common/gin_helper/promise.h
@@ -133,7 +133,7 @@ class Promise : public PromiseBase {
     v8::Context::Scope context_scope(GetContext());
 
     v8::Local<v8::Value> value = gin::ConvertToV8(isolate(), std::move(cb));
-    v8::Local<v8::Function> handler = v8::Local<v8::Function>::Cast(value);
+    v8::Local<v8::Function> handler = value.As<v8::Function>();
 
     return GetHandle()->Then(GetContext(), handler);
   }

--- a/shell/common/gin_helper/wrappable.cc
+++ b/shell/common/gin_helper/wrappable.cc
@@ -84,7 +84,7 @@ namespace internal {
 void* FromV8Impl(v8::Isolate* isolate, v8::Local<v8::Value> val) {
   if (!val->IsObject())
     return nullptr;
-  v8::Local<v8::Object> obj = v8::Local<v8::Object>::Cast(val);
+  v8::Local<v8::Object> obj = val.As<v8::Object>();
   if (obj->InternalFieldCount() != 1)
     return nullptr;
   return obj->GetAlignedPointerFromInternalField(0);

--- a/shell/common/v8_value_converter.cc
+++ b/shell/common/v8_value_converter.cc
@@ -282,7 +282,7 @@ v8::Local<v8::Value> V8ValueConverter::ToArrayBuffer(
   }
 
   v8::Local<v8::Value> args[] = {array_buffer};
-  auto func = v8::Local<v8::Function>::Cast(from_value);
+  auto func = from_value.As<v8::Function>();
   auto result = func->Call(context, v8::Null(isolate), 1, args);
   if (!result.IsEmpty()) {
     return result.ToLocalChecked();

--- a/shell/renderer/api/context_bridge/object_cache.cc
+++ b/shell/renderer/api/context_bridge/object_cache.cc
@@ -20,7 +20,7 @@ ObjectCache::~ObjectCache() = default;
 void ObjectCache::CacheProxiedObject(v8::Local<v8::Value> from,
                                      v8::Local<v8::Value> proxy_value) {
   if (from->IsObject() && !from->IsNullOrUndefined()) {
-    auto obj = v8::Local<v8::Object>::Cast(from);
+    auto obj = from.As<v8::Object>();
     int hash = obj->GetIdentityHash();
 
     proxy_map_[hash].push_front(std::make_pair(from, proxy_value));
@@ -32,7 +32,7 @@ v8::MaybeLocal<v8::Value> ObjectCache::GetCachedProxiedObject(
   if (!from->IsObject() || from->IsNullOrUndefined())
     return v8::MaybeLocal<v8::Value>();
 
-  auto obj = v8::Local<v8::Object>::Cast(from);
+  auto obj = from.As<v8::Object>();
   int hash = obj->GetIdentityHash();
   auto iter = proxy_map_.find(hash);
   if (iter == proxy_map_.end())

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -83,7 +83,7 @@ bool DeepFreeze(const v8::Local<v8::Object>& object,
         object->Get(context, property_names->Get(context, i).ToLocalChecked())
             .ToLocalChecked();
     if (child->IsObject() && !child->IsTypedArray()) {
-      if (!DeepFreeze(v8::Local<v8::Object>::Cast(child), context, frozen))
+      if (!DeepFreeze(child.As<v8::Object>(), context, frozen))
         return false;
     }
   }
@@ -181,7 +181,7 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContext(
   // Proxy functions and monitor the lifetime in the new context to release
   // the global handle at the right time.
   if (value->IsFunction()) {
-    auto func = v8::Local<v8::Function>::Cast(value);
+    auto func = value.As<v8::Function>();
     v8::MaybeLocal<v8::Value> maybe_original_fn = GetPrivate(
         source_context, func, context_bridge::kOriginalFunctionPrivateKey);
 
@@ -224,7 +224,7 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContext(
   // Proxy promises as they have a safe and guaranteed memory lifecycle
   if (value->IsPromise()) {
     v8::Context::Scope destination_scope(destination_context);
-    auto source_promise = v8::Local<v8::Promise>::Cast(value);
+    auto source_promise = value.As<v8::Promise>();
     // Make the promise a shared_ptr so that when the original promise is
     // freed the proxy promise is correctly freed as well instead of being
     // left dangling
@@ -290,10 +290,10 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContext(
 
     ignore_result(source_promise->Then(
         source_context,
-        v8::Local<v8::Function>::Cast(
-            gin::ConvertToV8(destination_context->GetIsolate(), then_cb)),
-        v8::Local<v8::Function>::Cast(
-            gin::ConvertToV8(destination_context->GetIsolate(), catch_cb))));
+        gin::ConvertToV8(destination_context->GetIsolate(), then_cb)
+            .As<v8::Function>(),
+        gin::ConvertToV8(destination_context->GetIsolate(), catch_cb)
+            .As<v8::Function>()));
 
     object_cache->CacheProxiedObject(value, proxied_promise_handle);
     return v8::MaybeLocal<v8::Value>(proxied_promise_handle);
@@ -325,7 +325,7 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContext(
   // promises are proxied correctly.
   if (IsPlainArray(value)) {
     v8::Context::Scope destination_context_scope(destination_context);
-    v8::Local<v8::Array> arr = v8::Local<v8::Array>::Cast(value);
+    v8::Local<v8::Array> arr = value.As<v8::Array>();
     size_t length = arr->Length();
     v8::Local<v8::Array> cloned_arr =
         v8::Array::New(destination_context->GetIsolate(), length);
@@ -356,7 +356,7 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContext(
 
   // Proxy all objects
   if (IsPlainObject(value)) {
-    auto object_value = v8::Local<v8::Object>::Cast(value);
+    auto object_value = value.As<v8::Object>();
     auto passed_value = CreateProxyForAPI(
         object_value, source_context, destination_context, object_cache,
         support_dynamic_properties, recursion_depth + 1);
@@ -408,7 +408,7 @@ void ProxyFunctionWrapper(const v8::FunctionCallbackInfo<v8::Value>& info) {
       !maybe_func.ToLocal(&func_value))
     return;
 
-  v8::Local<v8::Function> func = v8::Local<v8::Function>::Cast(func_value);
+  v8::Local<v8::Function> func = func_value.As<v8::Function>();
   v8::Local<v8::Context> func_owning_context = func->CreationContext();
 
   {
@@ -507,7 +507,7 @@ v8::MaybeLocal<v8::Object> CreateProxyForAPI(
       if (support_dynamic_properties) {
         v8::Context::Scope source_context_scope(source_context);
         auto maybe_desc = api.GetHandle()->GetOwnPropertyDescriptor(
-            source_context, v8::Local<v8::Name>::Cast(key));
+            source_context, key.As<v8::Name>());
         v8::Local<v8::Value> desc_value;
         if (!maybe_desc.ToLocal(&desc_value) || !desc_value->IsObject())
           continue;
@@ -600,7 +600,7 @@ void ExposeAPIInMainWorld(v8::Isolate* isolate,
     }
 
     if (proxy->IsObject() && !proxy->IsTypedArray() &&
-        !DeepFreeze(v8::Local<v8::Object>::Cast(proxy), main_context))
+        !DeepFreeze(proxy.As<v8::Object>(), main_context))
       return;
 
     global.SetReadOnlyNonConfigurable(key, proxy);

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -102,9 +102,8 @@ namespace api {
 
 namespace {
 
-content::RenderFrame* GetRenderFrame(v8::Local<v8::Value> value) {
-  v8::Local<v8::Context> context =
-      v8::Local<v8::Object>::Cast(value)->CreationContext();
+content::RenderFrame* GetRenderFrame(v8::Local<v8::Object> value) {
+  v8::Local<v8::Context> context = value->CreationContext();
   if (context.IsEmpty())
     return nullptr;
   blink::WebLocalFrame* frame = blink::WebLocalFrame::FrameForContext(context);
@@ -559,7 +558,7 @@ class WebFrameRenderer : public gin::Wrappable<WebFrameRenderer>,
         nullptr);
   }
 
-  static int GetWebFrameId(v8::Local<v8::Value> content_window) {
+  static int GetWebFrameId(v8::Local<v8::Object> content_window) {
     // Get the WebLocalFrame before (possibly) executing any user-space JS while
     // getting the |params|. We track the status of the RenderFrame via an
     // observer in case it is deleted during user code execution.

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -114,7 +114,7 @@ void InvokeHiddenCallback(v8::Handle<v8::Context> context,
                           .ToLocalChecked();
   auto callback_value = binding->Get(context, callback_key).ToLocalChecked();
   DCHECK(callback_value->IsFunction());  // set by sandboxed_renderer/init.js
-  auto callback = v8::Handle<v8::Function>::Cast(callback_value);
+  auto callback = callback_value.As<v8::Function>();
   ignore_result(callback->Call(context, binding, 0, nullptr));
 }
 


### PR DESCRIPTION
#### Description of Change
A bit more readable perhaps. Also use this style of casting consistently.
Also make `GetWebFrameId` take a `v8::Object` handle to match https://github.com/electron/electron/blob/2b84d79b185a550684d60b3902a2cb02a90e61dc/shell/renderer/api/electron_api_context_bridge.cc#L59-L67

cc @nornagon 

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes