### PR TITLE
fix: aspect ratio when max width/height is set

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -111,3 +111,4 @@ feat_add_data_parameter_to_processsingleton.patch
 mas_gate_private_enterprise_APIs
 load_v8_snapshot_in_browser_process.patch
 fix_patch_out_permissions_checks_in_exclusive_access.patch
+fix_aspect_ratio_with_max_size.patch

--- a/patches/chromium/fix_aspect_ratio_with_max_size.patch
+++ b/patches/chromium/fix_aspect_ratio_with_max_size.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cezary Kulakowski <cezary@openfin.co>
+Date: Tue, 11 May 2021 11:14:06 +0200
+Subject: fix: fix aspect ratio when max width/height is set
+
+Add the native frame border size to the minimum and maximum size if
+the view reports its size as the client size. It allows to enlarge
+window to proper values when aspect ratio and max width/height are
+set. It also fixes DCHECK which was triggered when user tried to
+enlarge window above dimensions set during creation of the
+BrowserWindow.
+
+diff --git a/ui/views/win/hwnd_message_handler.cc b/ui/views/win/hwnd_message_handler.cc
+index a235cab941ec583a8dc9cb5e4105c2d7baae02df..f7c1232b0893c366aeeb77e6df0bbd275b6f7bd4 100644
+--- a/ui/views/win/hwnd_message_handler.cc
++++ b/ui/views/win/hwnd_message_handler.cc
+@@ -3569,6 +3569,21 @@ void HWNDMessageHandler::SizeWindowToAspectRatio(UINT param,
+   delegate_->GetMinMaxSize(&min_window_size, &max_window_size);
+   min_window_size = delegate_->DIPToScreenSize(min_window_size);
+   max_window_size = delegate_->DIPToScreenSize(max_window_size);
++  // Add the native frame border size to the minimum and maximum size if the
++  // view reports its size as the client size.
++  if (delegate_->WidgetSizeIsClientSize()) {
++    RECT client_rect, rect;
++    GetClientRect(hwnd(), &client_rect);
++    GetWindowRect(hwnd(), &rect);
++    CR_DEFLATE_RECT(&rect, &client_rect);
++    min_window_size.Enlarge(rect.right - rect.left,
++                            rect.bottom - rect.top);
++    // Either axis may be zero, so enlarge them independently.
++    if (max_window_size.width())
++      max_window_size.Enlarge(rect.right - rect.left, 0);
++    if (max_window_size.height())
++      max_window_size.Enlarge(0, rect.bottom - rect.top);
++  }
+   gfx::SizeRectToAspectRatio(GetWindowResizeEdge(param), aspect_ratio_.value(),
+                              min_window_size, max_window_size, window_rect);
+ }

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -952,6 +952,17 @@ describe('BrowserWindow module', () => {
         await resize;
         expectBoundsEqual(w.getSize(), size);
       });
+
+      it('doesn\'t change bounds when maximum size is set', () => {
+        w.setMenu(null);
+        w.setMaximumSize(400, 400);
+        // Without https://github.com/electron/electron/pull/29101
+        // following call would shrink the window to 384x361.
+        // There would be also DCHECK in resize_utils.cc on
+        // debug build.
+        w.setAspectRatio(1.0);
+        expectBoundsEqual(w.getSize(), [400, 400]);
+      });
     });
 
     describe('BrowserWindow.setPosition(x, y)', () => {


### PR DESCRIPTION
Add the native frame border size to the minimum and maximum size if
the view reports its size as the client size. It allows to enlarge
window to proper values when aspect ratio and max width/height are
set. It also fixes DCHECK which was triggered when user tried to
enlarge window above dimensions set during creation of the
BrowserWindow.

Fixes https://github.com/electron/electron/issues/29100

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fixed respecting aspect ratio when maximum size is set on BrowserWindow
