### PR TITLE
chore: remove no-op EnableWebComponentsV0 feature

### DIFF
--- a/shell/browser/feature_list.cc
+++ b/shell/browser/feature_list.cc
@@ -38,12 +38,6 @@ void InitializeFeatureList() {
       std::string(",") +
       net::features::kCookiesWithoutSameSiteMustBeSecure.name;
 
-  // https://www.polymer-project.org/blog/2018-10-02-webcomponents-v0-deprecations
-  // https://chromium-review.googlesource.com/c/chromium/src/+/1869562
-  // Any website which uses older WebComponents will fail in without this
-  // enabled, since Electron does not support origin trials.
-  enable_features += std::string(",") + "WebComponentsV0Enabled";
-
 #if !BUILDFLAG(ENABLE_PICTURE_IN_PICTURE)
   disable_features += std::string(",") + media::kPictureInPicture.name;
 #endif


### PR DESCRIPTION
#### Description of Change
This feature no longer has any effect.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd


#### Release Notes

Notes: none
