### PR TITLE
chore: cherry-pick 8089dbfc616f from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -106,3 +106,4 @@ extend_apply_webpreferences.patch
 fix_expose_decrementcapturercount_in_web_contents_impl.patch
 add_setter_for_browsermainloop_result_code.patch
 revert_roll_clang_llvmorg-13-init-7051-gdad5caa5-2.patch
+cherry-pick-8089dbfc616f.patch

--- a/patches/chromium/cherry-pick-8089dbfc616f.patch
+++ b/patches/chromium/cherry-pick-8089dbfc616f.patch
@@ -1,0 +1,57 @@
+From 8089dbfc616f4f9e71cf9f63c28d8cfbcc228ab8 Mon Sep 17 00:00:00 2001
+From: Francois Doray <fdoray@chromium.org>
+Date: Mon, 26 Apr 2021 19:48:20 +0000
+Subject: [PATCH] [threadpool] Cleanup the "NoDetachBelowInitialCapacity" feature.
+
+Motivation: The feature is not used since 2019.
+
+Bug: 847501
+Change-Id: Ic6fde174ef8d742f7beb57d0c67ae2477dc96cc2
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2845241
+Reviewed-by: Etienne Pierre-Doray <etiennep@chromium.org>
+Commit-Queue: François Doray <fdoray@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#876279}
+---
+
+diff --git a/base/task/task_features.cc b/base/task/task_features.cc
+index c7d2eb1..3bccd84 100644
+--- a/base/task/task_features.cc
++++ b/base/task/task_features.cc
+@@ -8,9 +8,6 @@
+ 
+ namespace base {
+ 
+-const Feature kNoDetachBelowInitialCapacity = {
+-    "NoDetachBelowInitialCapacity", base::FEATURE_DISABLED_BY_DEFAULT};
+-
+ const Feature kMayBlockWithoutDelay = {"MayBlockWithoutDelay",
+                                        base::FEATURE_DISABLED_BY_DEFAULT};
+ 
+diff --git a/base/task/task_features.h b/base/task/task_features.h
+index 4ffe773..6d039db 100644
+--- a/base/task/task_features.h
++++ b/base/task/task_features.h
+@@ -13,10 +13,6 @@
+ 
+ struct Feature;
+ 
+-// Under this feature, unused threads in ThreadGroup are only detached
+-// if the total number of threads in the pool is above the initial capacity.
+-extern const BASE_EXPORT Feature kNoDetachBelowInitialCapacity;
+-
+ // Under this feature, workers blocked with MayBlock are replaced immediately
+ // instead of waiting for a threshold in the foreground thread group.
+ extern const BASE_EXPORT Feature kMayBlockWithoutDelay;
+diff --git a/base/task/thread_pool/thread_group_impl.cc b/base/task/thread_pool/thread_group_impl.cc
+index 0aa268d..4f5b6f3 100644
+--- a/base/task/thread_pool/thread_group_impl.cc
++++ b/base/task/thread_pool/thread_group_impl.cc
+@@ -713,8 +713,6 @@
+   return !last_used_time.is_null() &&
+          subtle::TimeTicksNowIgnoringOverride() - last_used_time >=
+              outer_->after_start().suggested_reclaim_time &&
+-         (outer_->workers_.size() > outer_->after_start().initial_max_tasks ||
+-          !FeatureList::IsEnabled(kNoDetachBelowInitialCapacity)) &&
+          LIKELY(!outer_->worker_cleanup_disallowed_for_testing_);
+ }
+ 


### PR DESCRIPTION
[threadpool] Cleanup the "NoDetachBelowInitialCapacity" feature.

Motivation: The feature is not used since 2019.

Bug: 847501
Change-Id: Ic6fde174ef8d742f7beb57d0c67ae2477dc96cc2
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2845241
Reviewed-by: Etienne Pierre-Doray <etiennep@chromium.org>
Commit-Queue: François Doray <fdoray@chromium.org>
Cr-Commit-Position: refs/heads/master@{#876279}


Notes: Security: backported fix for 847501.