### PR TITLE
build: unconditionally include stack_trace.h

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -106,3 +106,4 @@ extend_apply_webpreferences.patch
 fix_expose_decrementcapturercount_in_web_contents_impl.patch
 add_setter_for_browsermainloop_result_code.patch
 revert_roll_clang_llvmorg-13-init-7051-gdad5caa5-2.patch
+make_include_of_stack_trace_h_unconditional.patch

--- a/patches/chromium/make_include_of_stack_trace_h_unconditional.patch
+++ b/patches/chromium/make_include_of_stack_trace_h_unconditional.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Samuel Attard <samuel.r.attard@gmail.com>
+Date: Tue, 11 May 2021 20:41:00 -0700
+Subject: make include of stack_trace.h unconditional
+
+This conditional include throws goma for a loop for no real reason.
+While we work on either upstreaming this or fixing the underlying goma
+issue this makes our builds 33% faster during local testing (11m vs 18m).
+
+diff --git a/base/sequence_checker.h b/base/sequence_checker.h
+index 50a548a759c2dc6d79978741a0c803500d53a9f8..cd5049e8bf59c51b890bcc332f9a1c5f0ec339c9 100644
+--- a/base/sequence_checker.h
++++ b/base/sequence_checker.h
+@@ -10,9 +10,8 @@
+ #include "base/strings/string_piece.h"
+ #include "build/build_config.h"
+ 
+-#if DCHECK_IS_ON()
+ #include "base/debug/stack_trace.h"
+-#endif
++
+ 
+ // SequenceChecker is a helper class used to help verify that some methods of a
+ // class are called sequentially (for thread-safety). It supports thread safety


### PR DESCRIPTION
I'll post a longer explanation in Slack as this is very specific to our goma infra but the TLDR is remove these two lines makes the build 33% faster with no negatives afaik 🤷 Will land just to master initially to see how it goes

Notes: no-notes