### PR TITLE
fix: remove background color hack in vibrancy

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -238,7 +238,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     window shadow and window animations. Default is `true`.
   * `vibrancy` String (optional) - Add a type of vibrancy effect to the window, only on
     macOS. Can be `appearance-based`, `light`, `dark`, `titlebar`, `selection`,
-    `menu`, `popover`, `sidebar`, `medium-light`, `ultra-dark`, `header`, `sheet`, `window`, `hud`, `fullscreen-ui`, `tooltip`, `content`, `under-window`, or `under-page`.  Please note that using `frame: false` in combination with a vibrancy value requires that you use a non-default `titleBarStyle` as well. Also note that `appearance-based`, `light`, `dark`, `medium-light`, and `ultra-dark` are deprecated and have been removed in macOS Catalina (10.15).
+    `menu`, `popover`, `sidebar`, `medium-light`, `ultra-dark`, `header`, `sheet`, `window`, `hud`, `fullscreen-ui`, `tooltip`, `content`, `under-window`, or `under-page`. Please note that `appearance-based`, `light`, `dark`, `medium-light`, and `ultra-dark` are deprecated and have been removed in macOS Catalina (10.15).
   * `zoomToPageWidth` Boolean (optional) - Controls the behavior on macOS when
     option-clicking the green stoplight button on the toolbar or by clicking the
     Window > Zoom menu item. If `true`, the window will grow to the preferred

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -271,8 +271,6 @@ class NativeWindowMac : public NativeWindow,
   NSInteger original_level_;
   NSUInteger simple_fullscreen_mask_;
 
-  base::scoped_nsobject<NSColor> background_color_before_vibrancy_;
-  bool transparency_before_vibrancy_ = false;
   std::string vibrancy_type_;
 
   // The presentation options before entering simple fullscreen mode.

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1338,6 +1338,7 @@ void NativeWindowMac::UpdateVibrancyRadii(bool fullscreen) {
       [maskImage setCapInsets:NSEdgeInsetsMake(radius, radius, radius, radius)];
       [maskImage setResizingMode:NSImageResizingModeStretch];
       [effect_view setMaskImage:maskImage];
+      [window_ setCornerMask:maskImage];
     }
   }
 }
@@ -1346,10 +1347,6 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
   NSView* vibrant_view = [window_ vibrantView];
 
   if (type.empty()) {
-    if (background_color_before_vibrancy_) {
-      [window_ setBackgroundColor:background_color_before_vibrancy_];
-      [window_ setTitlebarAppearsTransparent:transparency_before_vibrancy_];
-    }
     if (vibrant_view == nil)
       return;
 
@@ -1360,13 +1357,6 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
   }
 
   vibrancy_type_ = type;
-  background_color_before_vibrancy_.reset([[window_ backgroundColor] retain]);
-  transparency_before_vibrancy_ = [window_ titlebarAppearsTransparent];
-
-  if (title_bar_style_ != TitleBarStyle::kNormal) {
-    [window_ setTitlebarAppearsTransparent:YES];
-    [window_ setBackgroundColor:[NSColor clearColor]];
-  }
 
   NSVisualEffectView* effect_view = (NSVisualEffectView*)vibrant_view;
   if (effect_view == nil) {


### PR DESCRIPTION
#### Description of Change

For Electron <= 12, using vibrancy with titleBarStyle together requires a small hack added by https://github.com/electron/electron/pull/11886 and https://github.com/electron/electron/pull/12157, because titleBarStyle was implemented by force showing original titlebar buttons.

But after https://github.com/electron/electron/pull/27489, the implementation of titleBarStyle no longer uses original titlebar buttons, and the old hack can be removed, which will fix https://github.com/electron/electron/issues/28782.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix using vibrancy with titleBarStyle together resulting in weird window shadow on macOS.