### PR TITLE
build: merge double space in SHASUM validation logic

### DIFF
--- a/script/release/release.js
+++ b/script/release/release.js
@@ -409,7 +409,7 @@ async function getShaSumMappingFromUrl (shaSumFileUrl, fileNamePrefix) {
   const response = await got(shaSumFileUrl);
   const raw = response.body;
   return raw.split('\n').map(line => line.trim()).filter(Boolean).reduce((map, line) => {
-    const [sha, file] = line.split(' ');
+    const [sha, file] = line.replace('  ', ' ').split(' ');
     map[file.slice(fileNamePrefix.length)] = sha;
     return map;
   }, {});


### PR DESCRIPTION
The node.js SHASUM file is subtly different to SHASUM256 for Electron

Notes: none