### PR TITLE
fix: do not return value from `Menu.setApplicationMenu`

### DIFF
--- a/lib/browser/api/menu.ts
+++ b/lib/browser/api/menu.ts
@@ -177,7 +177,7 @@ Menu.setApplicationMenu = function (menu: MenuType) {
     bindings.setApplicationMenu(menu);
   } else {
     const windows = BaseWindow.getAllWindows();
-    return windows.map(w => w.setMenu(menu));
+    windows.map(w => w.setMenu(menu));
   }
 };
 


### PR DESCRIPTION
#### Description of Change

Closes #29088.

Fixed an issue where the void function `Menu.setApplicationMenu` would return a value on some platforms.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes(https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the void function `Menu.setApplicationMenu` would return a value on some platforms.