### PR TITLE
chore: uncomment some DCHECKs

### DIFF
--- a/patches/chromium/dcheck.patch
+++ b/patches/chromium/dcheck.patch
@@ -16,35 +16,6 @@ example, the checks might be disabled for a whole build target, but actually
 only one or two specific checks fail. Then it's better to simply comment out the
 failing checks and allow the rest of the target to have them enabled.
 
-diff --git a/content/browser/renderer_host/navigation_controller_impl.cc b/content/browser/renderer_host/navigation_controller_impl.cc
-index 814eebf4b641fe01a29875b9c06aea84b2ab7206..892039c0481c0c66cefbff6a37bf51fe1ae61c6b 100644
---- a/content/browser/renderer_host/navigation_controller_impl.cc
-+++ b/content/browser/renderer_host/navigation_controller_impl.cc
-@@ -1416,8 +1416,10 @@ NavigationType NavigationControllerImpl::ClassifyNavigation(
-     return NAVIGATION_TYPE_NEW_SUBFRAME;
-   }
- 
--  // We only clear the session history in tests when navigating to a new entry.
--  DCHECK(!params.history_list_was_cleared);
-+  // Electron does its own book keeping of navigation entries and we
-+  // expect content to not track any, by clearing history list for
-+  // all navigations.
-+  // DCHECK(!params.history_list_was_cleared);
- 
-   if (rfh->GetParent()) {
-     // All manual subframes would be did_create_new_entry and handled above, so
-@@ -1732,7 +1734,10 @@ void NavigationControllerImpl::RendererDidNavigateToNewEntry(
-     }
-   }
- 
--  DCHECK(!params.history_list_was_cleared || !replace_entry);
-+  // Electron does its own book keeping of navigation entries and we
-+  // expect content to not track any, by clearing history list for
-+  // all navigations.
-+  // DCHECK(!params.history_list_was_cleared || !replace_entry);
-   // The browser requested to clear the session history when it initiated the
-   // navigation. Now we know that the renderer has updated its state accordingly
-   // and it is safe to also clear the browser side history.
 diff --git a/ui/base/clipboard/clipboard_win.cc b/ui/base/clipboard/clipboard_win.cc
 index d1f10922b82e4e0578d1c32978784216117e0696..8f0a750d1a5957b987c5ac506455587a09474461 100644
 --- a/ui/base/clipboard/clipboard_win.cc


### PR DESCRIPTION
#### Description of Change
We now use the built-in navigation controller so these DCHECKs should no longer
fire.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none
