### PR TITLE
build: save the ninja log for release builds too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -532,6 +532,7 @@ step-electron-build: &step-electron-build
         gn gen out/Default --args="import(\"$GN_CONFIG\") import(\"$GN_GOMA_FILE\") $GN_EXTRA_ARGS $GN_BUILDFLAG_ARGS"
       fi
       NINJA_SUMMARIZE_BUILD=1 autoninja -C out/Default electron -j $NUMBER_OF_NINJA_PROCESSES
+      cp out/Default/.ninja_log out/electron_ninja_log
       node electron/script/check-symlinks.js
 
 step-native-unittests-build: &step-native-unittests-build
@@ -877,11 +878,6 @@ step-fix-known-hosts-linux: &step-fix-known-hosts-linux
       if [ "`uname`" == "Linux" ]; then
         ./src/electron/.circleci/fix-known-hosts.sh
       fi
-
-step-ninja-report: &step-ninja-report
-  store_artifacts:
-    path: src/out/Default/.ninja_log
-    destination: ninja_log
 
 # Checkout Steps
 step-generate-deps-hash: &step-generate-deps-hash
@@ -1344,6 +1340,7 @@ commands:
             mv_if_exist src/out/ffmpeg/ffmpeg.zip
             mv_if_exist src/out/Default/hunspell_dictionaries.zip
             mv_if_exist src/cross-arch-snapshots
+            mv_if_exist src/out/electron_ninja_log
           when: always
       - store_artifacts:
           path: generated_artifacts
@@ -1497,7 +1494,6 @@ commands:
                   - *step-restore-out-cache
             - *step-gn-gen-default
             - *step-electron-build
-            - *step-ninja-report
             - *step-maybe-electron-dist-strip
             - *step-electron-dist-build
 


### PR DESCRIPTION
Moves the logic that saves the `.ninja_log` to our unified artifacts store step so that we persist the ninja log in release builds too.  This will be helpful for debugging release build performance issues.

Notes: no-notes