### PR TITLE
fix: [webview] fix missing properties on events when contextIsolation: true

### DIFF
--- a/lib/renderer/web-view/web-view-element.ts
+++ b/lib/renderer/web-view/web-view-element.ts
@@ -39,7 +39,13 @@ const defineWebViewElement = (v8Util: NodeJS.V8UtilBinding, webViewImpl: typeof 
 
     constructor () {
       super();
-      v8Util.setHiddenValue(this, 'internal', new WebViewImpl(this));
+      const internal = new WebViewImpl(this);
+      internal.dispatchEventInMainWorld = (eventName, props) => {
+        const event = new Event(eventName);
+        Object.assign(event, props);
+        return internal.webviewNode.dispatchEvent(event);
+      };
+      v8Util.setHiddenValue(this, 'internal', internal);
     }
 
     connectedCallback () {

--- a/spec-main/webview-spec.ts
+++ b/spec-main/webview-spec.ts
@@ -687,6 +687,26 @@ describe('<webview> tag', function () {
 
   describe('DOM events', () => {
     afterEach(closeAllWindows);
+    it('receives extra properties on DOM events when contextIsolation is enabled', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          webviewTag: true,
+          contextIsolation: true
+        }
+      });
+      await w.loadURL('about:blank');
+      const message = await w.webContents.executeJavaScript(`new Promise((resolve, reject) => {
+        const webview = new WebView()
+        webview.setAttribute('src', 'data:text/html,<script>console.log("hi")</script>')
+        webview.addEventListener('console-message', (e) => {
+          resolve(e.message)
+        })
+        document.body.appendChild(webview)
+      })`);
+      expect(message).to.equal('hi');
+    });
+
     it('emits focus event when contextIsolation is enabled', async () => {
       const w = new BrowserWindow({
         show: false,

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -277,16 +277,6 @@ declare namespace ElectronInternal {
     allowGuestViewElementDefinition(window: Window, context: any): void;
   }
 
-  interface WebFrameResizeEvent extends Electron.Event {
-    newWidth: number;
-    newHeight: number;
-  }
-
-  interface WebViewEvent extends Event {
-    url: string;
-    isMainFrame: boolean;
-  }
-
   class WebViewElement extends HTMLElement {
     static observedAttributes: Array<string>;
 


### PR DESCRIPTION
Backport of #26289

Notes: Fixed an issue where events on webview elements were missing properties if contextIsolation was enabled.