### PR TITLE
docs: --force-fieldtrials was h2 rather than h3

### DIFF
--- a/docs/api/command-line-switches.md
+++ b/docs/api/command-line-switches.md
@@ -75,7 +75,7 @@ This switch can not be used in `app.commandLine.appendSwitch` since it is parsed
 earlier than user's app is loaded, but you can set the `ELECTRON_ENABLE_LOGGING`
 environment variable to achieve the same effect.
 
-## --force-fieldtrials=`trials`
+### --force-fieldtrials=`trials`
 
 Field trials to be forcefully enabled or disabled.
 


### PR DESCRIPTION
#### Description of Change

On the [Supported Command Line Switches page](https://www.electronjs.org/docs/api/command-line-switches), all the other argument headers were H3 (`###`) but `--force-fieldtrials` was H2 (`##`) for some reason. 

I changed it to H3 to make it consistent with the others.

#### Checklist

- [ ] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
(https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
