### PR TITLE
fix: window bounds not scaled from screen coordinates

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -82,6 +82,22 @@
 
 namespace electron {
 
+#if defined(OS_WIN)
+
+// Similar to the ones in display::win::ScreenWin, but with rounded values
+// These help to avoid problems that arise from unresizable windows where the
+// original ceil()-ed values can cause calculation errors, since converting
+// both ways goes through a ceil() call. Related issue: #15816
+gfx::Rect ScreenToDIPRect(HWND hwnd, const gfx::Rect& pixel_bounds) {
+  float scale_factor = display::win::ScreenWin::GetScaleFactorForHWND(hwnd);
+  gfx::Rect dip_rect = ScaleToRoundedRect(pixel_bounds, 1.0f / scale_factor);
+  dip_rect.set_origin(
+      display::win::ScreenWin::ScreenToDIPRect(hwnd, pixel_bounds).origin());
+  return dip_rect;
+}
+
+#endif
+
 namespace {
 
 #if defined(OS_WIN)
@@ -94,18 +110,6 @@ void FlipWindowStyle(HWND handle, bool on, DWORD flag) {
   else
     style &= ~flag;
   ::SetWindowLong(handle, GWL_STYLE, style);
-}
-
-// Similar to the ones in display::win::ScreenWin, but with rounded values
-// These help to avoid problems that arise from unresizable windows where the
-// original ceil()-ed values can cause calculation errors, since converting
-// both ways goes through a ceil() call. Related issue: #15816
-gfx::Rect ScreenToDIPRect(HWND hwnd, const gfx::Rect& pixel_bounds) {
-  float scale_factor = display::win::ScreenWin::GetScaleFactorForHWND(hwnd);
-  gfx::Rect dip_rect = ScaleToRoundedRect(pixel_bounds, 1.0f / scale_factor);
-  dip_rect.set_origin(
-      display::win::ScreenWin::ScreenToDIPRect(hwnd, pixel_bounds).origin());
-  return dip_rect;
 }
 
 gfx::Rect DIPToScreenRect(HWND hwnd, const gfx::Rect& pixel_bounds) {

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -35,6 +35,10 @@ class WindowStateWatcher;
 class EventDisabler;
 #endif
 
+#if defined(OS_WIN)
+gfx::Rect ScreenToDIPRect(HWND hwnd, const gfx::Rect& pixel_bounds);
+#endif
+
 class NativeWindowViews : public NativeWindow,
                           public views::WidgetObserver,
                           public ui::EventHandler {

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -260,11 +260,12 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
     case WM_SIZING: {
       is_resizing_ = true;
       bool prevent_default = false;
-      NotifyWindowWillResize(gfx::Rect(*reinterpret_cast<RECT*>(l_param)),
-                             &prevent_default);
+      gfx::Rect bounds = gfx::Rect(*reinterpret_cast<RECT*>(l_param));
+      HWND hwnd = GetAcceleratedWidget();
+      gfx::Rect dpi_bounds = ScreenToDIPRect(hwnd, bounds);
+      NotifyWindowWillResize(dpi_bounds, &prevent_default);
       if (prevent_default) {
-        ::GetWindowRect(GetAcceleratedWidget(),
-                        reinterpret_cast<RECT*>(l_param));
+        ::GetWindowRect(hwnd, reinterpret_cast<RECT*>(l_param));
         return true;  // Tells Windows that the Sizing is handled.
       }
       return false;
@@ -288,11 +289,12 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
     case WM_MOVING: {
       is_moving_ = true;
       bool prevent_default = false;
-      NotifyWindowWillMove(gfx::Rect(*reinterpret_cast<RECT*>(l_param)),
-                           &prevent_default);
+      gfx::Rect bounds = gfx::Rect(*reinterpret_cast<RECT*>(l_param));
+      HWND hwnd = GetAcceleratedWidget();
+      gfx::Rect dpi_bounds = ScreenToDIPRect(hwnd, bounds);
+      NotifyWindowWillMove(dpi_bounds, &prevent_default);
       if (!movable_ || prevent_default) {
-        ::GetWindowRect(GetAcceleratedWidget(),
-                        reinterpret_cast<RECT*>(l_param));
+        ::GetWindowRect(hwnd, reinterpret_cast<RECT*>(l_param));
         return true;  // Tells Windows that the Move is handled. If not true,
                       // frameless windows can be moved using
                       // -webkit-app-region: drag elements.


### PR DESCRIPTION
#### Description of Change

fixed #25811

possibly related to #25420 #21777

On Windows, the `will-resize` and `will-move` events emit the pending bounds of the window. However, they're reported in screen coordinates which aren't scaled according to the display scale factor.

Here's a clip of a window being moved between a 4k and 1080p monitor which causes its scale factor to change. The width/height of `newBounds` remains the same with this fix.

(as an aside, there seems to be an unrelated rounding bug with the width/height of `currentBounds` you can also see)

https://user-images.githubusercontent.com/1656324/118202321-a9c64680-b427-11eb-82d0-8574ee10eb58.mp4

No tests are included as I'm not sure whether we have a way to test display scale changes.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed `will-resize` and `will-move` events not scaling the emitted `newBounds` rectangle to the appropriate Windows display scale factor.
