### PR TITLE
feat: add new runningUnderARM64Translation property to detect x64 translated apps running on Windows ARM

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1427,10 +1427,25 @@ This is the user agent that will be used when no user agent is set at the
 app has the same user agent.  Set to a custom value as early as possible
 in your app's initialization to ensure that your overridden value is used.
 
-### `app.runningUnderRosettaTranslation` _macOS_ _Readonly_
+### `app.runningUnderRosettaTranslation` _macOS_ _Readonly_ _Deprecated_
 
 A `Boolean` which when `true` indicates that the app is currently running
 under the [Rosetta Translator Environment](https://en.wikipedia.org/wiki/Rosetta_(software)).
+
+You can use this property to prompt users to download the arm64 version of
+your application when they are running the x64 version under Rosetta
+incorrectly.
+
+**Deprecated:** This property is superceded by the `runningUnderARM64Translation`
+property which detects when the app is being translated to ARM64 in both macOS
+and Windows.
+
+### `app.runningUnderARM64Translation` _Readonly_ _macOS_ _Windows_
+
+A `Boolean` which when `true` indicates that the app is currently running under
+an ARM64 translator (like the macOS
+[Rosetta Translator Environment](https://en.wikipedia.org/wiki/Rosetta_(software))
+or Windows [WOW](https://en.wikipedia.org/wiki/Windows_on_Windows)).
 
 You can use this property to prompt users to download the arm64 version of
 your application when they are running the x64 version under Rosetta

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1451,11 +1451,12 @@ bool App::IsRunningUnderARM64Translation() const {
   auto IsWow64Process2 = reinterpret_cast<decltype(&::IsWow64Process2)>(
       GetProcAddress(GetModuleHandle(L"kernel32.dll"), "IsWow64Process2"));
 
-  if (IsWow64Process2) {
-    if (!IsWow64Process2(GetCurrentProcess(), &processMachine,
-                         &nativeMachine)) {
-      return false;
-    }
+  if (IsWow64Process2 == nullptr) {
+    return false;
+  }
+
+  if (!IsWow64Process2(GetCurrentProcess(), &processMachine, &nativeMachine)) {
+    return false;
   }
 
   return nativeMachine == IMAGE_FILE_MACHINE_ARM64;

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1444,23 +1444,21 @@ void App::SetUserAgentFallback(const std::string& user_agent) {
 
 #if defined(OS_WIN)
 
-typedef BOOL(WINAPI* LPFN_ISWOW64PROCESS2)(HANDLE, PUSHORT, PUSHORT);
-
 bool App::IsRunningUnderARM64Translation() const {
   USHORT processMachine = 0;
   USHORT nativeMachine = 0;
 
-  LPFN_ISWOW64PROCESS2 fnIsWow64Process2 = (LPFN_ISWOW64PROCESS2)GetProcAddress(
-      GetModuleHandle(L"kernel32"), "IsWow64Process2");
+  auto IsWow64Process2 = reinterpret_cast<decltype(&::IsWow64Process2)>(
+      GetProcAddress(GetModuleHandle(L"kernel32.dll"), "IsWow64Process2"));
 
-  if (fnIsWow64Process2 != NULL) {
-    if (!fnIsWow64Process2(GetCurrentProcess(), &processMachine,
-                           &nativeMachine)) {
+  if (IsWow64Process2) {
+    if (!IsWow64Process2(GetCurrentProcess(), &processMachine,
+                         &nativeMachine)) {
       return false;
     }
   }
 
-  return nativeMachine == 0xaa64;
+  return nativeMachine == IMAGE_FILE_MACHINE_ARM64;
 }
 #endif
 

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -224,6 +224,10 @@ class App : public ElectronBrowserClient::Delegate,
   v8::Global<v8::Value> dock_;
 #endif
 
+#if defined(OS_MAC) || defined(OS_WIN)
+  bool IsRunningUnderARM64Translation() const;
+#endif
+
 #if defined(MAS_BUILD)
   base::RepeatingCallback<void()> StartAccessingSecurityScopedResource(
       gin::Arguments* args);

--- a/shell/browser/api/electron_api_app_mac.mm
+++ b/shell/browser/api/electron_api_app_mac.mm
@@ -60,6 +60,10 @@ void App::SetActivationPolicy(gin_helper::ErrorThrower thrower,
 }
 
 bool App::IsRunningUnderRosettaTranslation() const {
+  return IsRunningUnderARM64Translation();
+}
+
+bool App::IsRunningUnderARM64Translation() const {
   int proc_translated = 0;
   size_t size = sizeof(proc_translated);
   if (sysctlbyname("sysctl.proc_translated", &proc_translated, &size, NULL,

--- a/shell/browser/api/electron_api_app_mac.mm
+++ b/shell/browser/api/electron_api_app_mac.mm
@@ -60,6 +60,13 @@ void App::SetActivationPolicy(gin_helper::ErrorThrower thrower,
 }
 
 bool App::IsRunningUnderRosettaTranslation() const {
+  node::Environment* env =
+      node::Environment::GetCurrent(JavascriptEnvironment::GetIsolate());
+
+  EmitWarning(env,
+              "The app.runningUnderRosettaTranslation API is deprecated, use "
+              "app.runningUnderARM64Translation instead.",
+              "electron");
   return IsRunningUnderARM64Translation();
 }
 

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -1700,6 +1700,19 @@ describe('default behavior', () => {
       expect(webContents).to.equal(w.webContents);
     });
   });
+
+  describe('running under ARM64 translation', () => {
+    it('does not throw an error', () => {
+      if (process.platform === 'darwin' || process.platform === 'win32') {
+        expect(app.runningUnderARM64Translation).not.to.be.undefined();
+        expect(() => {
+          return app.runningUnderARM64Translation;
+        }).not.to.throw();
+      } else {
+        expect(app.runningUnderARM64Translation).to.be.undefined();
+      }
+    });
+  });
 });
 
 async function runTestApp (name: string, ...args: any[]) {


### PR DESCRIPTION
#### Description of Change

This PR adds a new generic property `runningUnderARM64Translation` to `app` that is supposed to supersede `runningUnderRosettaTranslation`, adding support to the same kind of check on Windows: whether or not the app is an x64 build running emulated on a Windows ARM device using [WOW](https://en.wikipedia.org/wiki/Windows_on_Windows). This while keeping the behavior of `runningUnderRosettaTranslation` for macOS.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added new `app.runningUnderARM64Translation` property to detect when running under Rosetta on Apple Silicon, or WOW on Windows for ARM.

