### PR TITLE
fix: AdjustAmountOfExternalAllocatedMemory regression in NativeImage destructor

### DIFF
--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -139,7 +139,7 @@ NativeImage::~NativeImage() {
     auto* const image_skia = image_.ToImageSkia();
     if (!image_skia->isNull()) {
       isolate_->AdjustAmountOfExternalAllocatedMemory(
-          image_skia->bitmap()->computeByteSize());
+          -static_cast<int64_t>(image_skia->bitmap()->computeByteSize()));
     }
   }
 }


### PR DESCRIPTION
#### Description of Change
The amount of memory used needs to be subtracted in the `NativeImage` destructor.

This regressed in #27111
Originally added by https://github.com/electron/electron/commit/1fcf6ea73f5a0412774197e405fa47ad8d5d6143
Discovered randomly when working on #29174

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes
