### PR TITLE
docs: mention Meta key in Accelerator

### DIFF
--- a/docs/api/accelerator.md
+++ b/docs/api/accelerator.md
@@ -35,7 +35,7 @@ Linux and Windows to define some accelerators.
 Use `Alt` instead of `Option`. The `Option` key only exists on macOS, whereas
 the `Alt` key is available on all platforms.
 
-The `Super` key is mapped to the `Windows` key on Windows and Linux and
+The `Super` (or `Meta`) key is mapped to the `Windows` key on Windows and Linux and
 `Cmd` on macOS.
 
 ## Available modifiers
@@ -48,6 +48,7 @@ The `Super` key is mapped to the `Windows` key on Windows and Linux and
 * `AltGr`
 * `Shift`
 * `Super`
+* `Meta`
 
 ## Available key codes
 


### PR DESCRIPTION
#### Description of Change

`Meta` is a valid alternative for `Super` and should be listed as an available modifier in the documentation.

See this source line showing that Electron can process `Meta`: https://github.com/electron/electron/blob/da8c35e3b256b4f9ad0c16edfbc2b56748b3a740/shell/common/keyboard_util.cc#L24


#### Checklist

- [x] relevant documentation is changed or added

#### Release Notes

Notes: none
