### PR TITLE
build: re-enable CalculateNativeWinOcclusion for windows CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -208,8 +208,7 @@ test_script:
         echo "Skipping tests for $env:GN_CONFIG build"
       }
   - cd electron
-  # CalculateNativeWinOcclusion is disabled due to https://bugs.chromium.org/p/chromium/issues/detail?id=1139022
-  - if "%RUN_TESTS%"=="true" ( echo Running test suite & node script/yarn test -- --trace-uncaught --enable-logging --disable-features=CalculateNativeWinOcclusion )
+  - if "%RUN_TESTS%"=="true" ( echo Running test suite & node script/yarn test -- --trace-uncaught --enable-logging )
   - cd ..
   - if "%RUN_TESTS%"=="true" ( echo Verifying non proprietary ffmpeg & python electron\script\verify-ffmpeg.py --build-dir out\Default --source-root %cd% --ffmpeg-path out\ffmpeg )
   - echo "About to verify mksnapshot"

--- a/azure-pipelines-woa.yml
+++ b/azure-pipelines-woa.yml
@@ -63,8 +63,7 @@ steps:
     set npm_config_nodedir=%cd%\out\Default\gen\node_headers
     set npm_config_arch=arm64
     cd electron
-    # CalculateNativeWinOcclusion is disabled due to https://bugs.chromium.org/p/chromium/issues/detail?id=1139022
-    node script/yarn test -- --enable-logging --verbose --disable-features=CalculateNativeWinOcclusion
+    node script/yarn test -- --enable-logging --verbose
   displayName: 'Run Electron tests'
   env:
     ELECTRON_OUT_DIR: Default


### PR DESCRIPTION
The attached bug was fixed a while ago, we should be able to enable this on CI now 👍 

Notes: no-notes