### PR TITLE
docs: Update the macos Dock Instructions

### DIFF
--- a/docs/fiddles/features/macos-dock-menu/index.html
+++ b/docs/fiddles/features/macos-dock-menu/index.html
@@ -8,9 +8,9 @@
 <body>
     <h1>Hello World!</h1>
     <p>
-        We are using node <script>document.write(process.versions.node)</script>,
-        Chrome <script>document.write(process.versions.chrome)</script>,
-        and Electron <script>document.write(process.versions.electron)</script>.
+        We are using node <script>document.write(window.versions.node)</script>,
+        Chrome <script>document.write(window.versions.chrome)</script>,
+        and Electron <script>document.write(window.versions.electron)</script>.
     </p>
 </body>
 </html>

--- a/docs/fiddles/features/macos-dock-menu/index.html
+++ b/docs/fiddles/features/macos-dock-menu/index.html
@@ -7,10 +7,5 @@
 </head>
 <body>
     <h1>Hello World!</h1>
-    <p>
-        We are using node <script>document.write(window.versions.node)</script>,
-        Chrome <script>document.write(window.versions.chrome)</script>,
-        and Electron <script>document.write(window.versions.electron)</script>.
-    </p>
 </body>
 </html>

--- a/docs/fiddles/features/macos-dock-menu/index.html
+++ b/docs/fiddles/features/macos-dock-menu/index.html
@@ -7,5 +7,6 @@
 </head>
 <body>
     <h1>Hello World!</h1>
+    <p>Right click the dock icon to see the custom menu options.</p>
 </body>
 </html>

--- a/docs/fiddles/features/macos-dock-menu/main.js
+++ b/docs/fiddles/features/macos-dock-menu/main.js
@@ -12,7 +12,7 @@ function createWindow () {
 const dockMenu = Menu.buildFromTemplate([
   {
     label: 'New Window',
-    click () { console.log('New Window'); }
+    click () { console.log('New Window') }
   }, {
     label: 'New Window with Settings',
     submenu: [
@@ -25,7 +25,7 @@ const dockMenu = Menu.buildFromTemplate([
 
 app.whenReady().then(() => {
   if (process.platform === 'darwin') {
-    app.dock.setMenu(dockMenu);
+    app.dock.setMenu(dockMenu)
   }
 }).then(createWindow)
 
@@ -37,6 +37,6 @@ app.on('window-all-closed', () => {
 
 app.on('activate', () => {
   if (BrowserWindow.getAllWindows().length === 0) {
-    createWindow();
+    createWindow()
   }
 })

--- a/docs/fiddles/features/macos-dock-menu/main.js
+++ b/docs/fiddles/features/macos-dock-menu/main.js
@@ -1,21 +1,23 @@
-const { app, BrowserWindow, Menu } = require('electron')
+const { app, BrowserWindow, Menu } = require('electron');
+const path = require('path');
+const os = require('os');
 
 function createWindow () {
   const win = new BrowserWindow({
     width: 800,
     height: 600,
     webPreferences: {
-      nodeIntegration: true
+      preload: path.join(__dirname, 'preload.js')
     }
-  })
+  });
 
-  win.loadFile('index.html')
+  win.loadFile('index.html');
 }
 
 const dockMenu = Menu.buildFromTemplate([
   {
     label: 'New Window',
-    click () { console.log('New Window') }
+    click () { console.log('New Window'); }
   }, {
     label: 'New Window with Settings',
     submenu: [
@@ -24,20 +26,22 @@ const dockMenu = Menu.buildFromTemplate([
     ]
   },
   { label: 'New Command...' }
-])
+]);
 
 app.whenReady().then(() => {
-  app.dock.setMenu(dockMenu)
-}).then(createWindow)
+  if (os.platform() === 'darwin') {
+    app.dock.setMenu(dockMenu);
+  }
+}).then(createWindow);
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
-    app.quit()
+    app.quit();
   }
-})
+});
 
 app.on('activate', () => {
   if (BrowserWindow.getAllWindows().length === 0) {
-    createWindow()
+    createWindow();
   }
-})
+});

--- a/docs/fiddles/features/macos-dock-menu/main.js
+++ b/docs/fiddles/features/macos-dock-menu/main.js
@@ -1,17 +1,12 @@
-const { app, BrowserWindow, Menu } = require('electron');
-const path = require('path');
-const os = require('os');
+const { app, BrowserWindow, Menu } = require('electron')
 
 function createWindow () {
   const win = new BrowserWindow({
     width: 800,
     height: 600,
-    webPreferences: {
-      preload: path.join(__dirname, 'preload.js')
-    }
-  });
+  })
 
-  win.loadFile('index.html');
+  win.loadFile('index.html')
 }
 
 const dockMenu = Menu.buildFromTemplate([
@@ -26,22 +21,22 @@ const dockMenu = Menu.buildFromTemplate([
     ]
   },
   { label: 'New Command...' }
-]);
+])
 
 app.whenReady().then(() => {
-  if (os.platform() === 'darwin') {
+  if (process.platform === 'darwin') {
     app.dock.setMenu(dockMenu);
   }
-}).then(createWindow);
+}).then(createWindow)
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
-    app.quit();
+    app.quit()
   }
-});
+})
 
 app.on('activate', () => {
   if (BrowserWindow.getAllWindows().length === 0) {
     createWindow();
   }
-});
+})

--- a/docs/fiddles/features/macos-dock-menu/preload.js
+++ b/docs/fiddles/features/macos-dock-menu/preload.js
@@ -1,0 +1,8 @@
+const { contextBridge } = require('electron');
+
+contextBridge.exposeInMainWorld('versions',
+{
+    'chrome': process.versions.chrome,
+    'electron': process.versions.electron,
+    'node': process.versions.node,
+});

--- a/docs/fiddles/features/macos-dock-menu/preload.js
+++ b/docs/fiddles/features/macos-dock-menu/preload.js
@@ -1,8 +1,0 @@
-const { contextBridge } = require('electron');
-
-contextBridge.exposeInMainWorld('versions',
-{
-    'chrome': process.versions.chrome,
-    'electron': process.versions.electron,
-    'node': process.versions.node,
-});

--- a/docs/tutorial/macos-dock.md
+++ b/docs/tutorial/macos-dock.md
@@ -23,26 +23,21 @@ Starting with a working application from the
  following lines:
 
 ```javascript fiddle='docs/fiddles/features/macos-dock-menu'
-const { app, BrowserWindow, Menu } = require('electron');
-const path = require('path');
-const os = require('os');
+const { app, BrowserWindow, Menu } = require('electron')
 
 function createWindow () {
   const win = new BrowserWindow({
     width: 800,
     height: 600,
-    webPreferences: {
-      preload: path.join(__dirname, 'preload.js')
-    }
-  });
+  })
 
-  win.loadFile('index.html');
+  win.loadFile('index.html')
 }
 
 const dockMenu = Menu.buildFromTemplate([
   {
     label: 'New Window',
-    click () { console.log('New Window'); }
+    click () { console.log('New Window') }
   }, {
     label: 'New Window with Settings',
     submenu: [
@@ -51,25 +46,25 @@ const dockMenu = Menu.buildFromTemplate([
     ]
   },
   { label: 'New Command...' }
-]);
+])
 
 app.whenReady().then(() => {
-  if (os.platform() === 'darwin') {
-    app.dock.setMenu(dockMenu);
+  if (process.platform === 'darwin') {
+    app.dock.setMenu(dockMenu)
   }
-}).then(createWindow);
+}).then(createWindow)
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
-    app.quit();
+    app.quit()
   }
-});
+})
 
 app.on('activate', () => {
   if (BrowserWindow.getAllWindows().length === 0) {
-    createWindow();
+    createWindow()
   }
-});
+})
 
 ```
 

--- a/docs/tutorial/macos-dock.md
+++ b/docs/tutorial/macos-dock.md
@@ -1,6 +1,4 @@
-# macOS Dock
-
-## Overview
+# Configuring the macOS Dock
 
 Electron has APIs to configure the app's icon in the macOS Dock. A macOS-only
 API exists to create a custom dock menu, but Electron also uses the app dock
@@ -25,12 +23,26 @@ Starting with a working application from the
  following lines:
 
 ```javascript fiddle='docs/fiddles/features/macos-dock-menu'
-const { app, Menu } = require('electron')
+const { app, BrowserWindow, Menu } = require('electron');
+const path = require('path');
+const os = require('os');
+
+function createWindow () {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js')
+    }
+  });
+
+  win.loadFile('index.html');
+}
 
 const dockMenu = Menu.buildFromTemplate([
   {
     label: 'New Window',
-    click () { console.log('New Window') }
+    click () { console.log('New Window'); }
   }, {
     label: 'New Window with Settings',
     submenu: [
@@ -39,11 +51,26 @@ const dockMenu = Menu.buildFromTemplate([
     ]
   },
   { label: 'New Command...' }
-])
+]);
 
 app.whenReady().then(() => {
-  app.dock.setMenu(dockMenu)
-})
+  if (os.platform() === 'darwin') {
+    app.dock.setMenu(dockMenu);
+  }
+}).then(createWindow);
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+app.on('activate', () => {
+  if (BrowserWindow.getAllWindows().length === 0) {
+    createWindow();
+  }
+});
+
 ```
 
 After launching the Electron application, right click the application icon.


### PR DESCRIPTION
#### Description of Change
Updates the `fiddle` example for macOs Dock files to work correctly with 12.0.7.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none


cc @erickzhao