### PR TITLE
feat: include resize edge with will-resize event

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -523,10 +523,19 @@ Returns:
 
 * `event` Event
 * `newBounds` [Rectangle](structures/rectangle.md) - Size the window is being resized to.
+* `details` Object
+  * `edge` (String) - The edge of the window being dragged for resizing.
 
 Emitted before the window is resized. Calling `event.preventDefault()` will prevent the window from being resized.
 
 Note that this is only emitted when the window is being resized manually. Resizing the window with `setBounds`/`setSize` will not emit this event.
+
+The possible values and behaviors of the `edge` option are platform dependent. Possible values are:
+
+* On Windows, possible values are `bottom`, `top`, `left`, `right`, `top-left`, `top-right`, `bottom-left`, `bottom-right`.
+* On macOS, possible values are `bottom` and `right`.
+  * The value `bottom` is used to denote vertical resizing.
+  * The value `right` is used to denote horizontal resizing.
 
 #### Event: 'resize'
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -524,7 +524,7 @@ Returns:
 * `event` Event
 * `newBounds` [Rectangle](structures/rectangle.md) - Size the window is being resized to.
 * `details` Object
-  * `edge` (String) - The edge of the window being dragged for resizing.
+  * `edge` (String) - The edge of the window being dragged for resizing. Can be `bottom`, `left, `right`, `top-left`, `top-right`, `bottom-left` or `bottom-right`.
 
 Emitted before the window is resized. Calling `event.preventDefault()` will prevent the window from being resized.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -524,7 +524,7 @@ Returns:
 * `event` Event
 * `newBounds` [Rectangle](structures/rectangle.md) - Size the window is being resized to.
 * `details` Object
-  * `edge` (String) - The edge of the window being dragged for resizing. Can be `bottom`, `left, `right`, `top-left`, `top-right`, `bottom-left` or `bottom-right`.
+  * `edge` (String) - The edge of the window being dragged for resizing. Can be `bottom`, `left`, `right`, `top-left`, `top-right`, `bottom-left` or `bottom-right`.
 
 Emitted before the window is resized. Calling `event.preventDefault()` will prevent the window from being resized.
 

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -206,8 +206,15 @@ void BaseWindow::OnWindowRestore() {
 }
 
 void BaseWindow::OnWindowWillResize(const gfx::Rect& new_bounds,
+                                    const gfx::ResizeEdge& edge,
                                     bool* prevent_default) {
-  if (Emit("will-resize", new_bounds)) {
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::Locker locker(isolate);
+  v8::HandleScope handle_scope(isolate);
+  gin_helper::Dictionary info = gin::Dictionary::CreateEmpty(isolate);
+  info.Set("edge", edge);
+
+  if (Emit("will-resize", new_bounds, info)) {
     *prevent_default = true;
   }
 }

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -62,6 +62,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void OnWindowMinimize() override;
   void OnWindowRestore() override;
   void OnWindowWillResize(const gfx::Rect& new_bounds,
+                          const gfx::ResizeEdge& edge,
                           bool* prevent_default) override;
   void OnWindowResize() override;
   void OnWindowResized() override;

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -481,9 +481,10 @@ void NativeWindow::NotifyWindowRestore() {
 }
 
 void NativeWindow::NotifyWindowWillResize(const gfx::Rect& new_bounds,
+                                          const gfx::ResizeEdge& edge,
                                           bool* prevent_default) {
   for (NativeWindowObserver& observer : observers_)
-    observer.OnWindowWillResize(new_bounds, prevent_default);
+    observer.OnWindowWillResize(new_bounds, edge, prevent_default);
 }
 
 void NativeWindow::NotifyWindowWillMove(const gfx::Rect& new_bounds,

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -34,6 +34,7 @@ class Image;
 class Point;
 class Rect;
 class RectF;
+enum class ResizeEdge;
 class Size;
 }  // namespace gfx
 
@@ -277,6 +278,7 @@ class NativeWindow : public base::SupportsUserData,
   void NotifyWindowRestore();
   void NotifyWindowMove();
   void NotifyWindowWillResize(const gfx::Rect& new_bounds,
+                              const gfx::ResizeEdge& edge,
                               bool* prevent_default);
   void NotifyWindowResize();
   void NotifyWindowResized();

--- a/shell/browser/native_window_observer.h
+++ b/shell/browser/native_window_observer.h
@@ -18,7 +18,8 @@
 
 namespace gfx {
 class Rect;
-}
+enum class ResizeEdge;
+}  // namespace gfx
 
 namespace electron {
 
@@ -71,6 +72,7 @@ class NativeWindowObserver : public base::CheckedObserver {
   virtual void OnWindowMinimize() {}
   virtual void OnWindowRestore() {}
   virtual void OnWindowWillResize(const gfx::Rect& new_bounds,
+                                  const gfx::ResizeEdge& edge,
                                   bool* prevent_default) {}
   virtual void OnWindowResize() {}
   virtual void OnWindowResized() {}

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -14,6 +14,7 @@
 #include "ui/display/display.h"
 #include "ui/display/win/screen_win.h"
 #include "ui/gfx/geometry/insets.h"
+#include "ui/gfx/geometry/resize_utils.h"
 #include "ui/views/widget/native_widget_private.h"
 
 // Must be included after other Windows headers.
@@ -134,6 +135,31 @@ const char* AppCommandToString(int command_id) {
       return "dictate-or-command-control-toggle";
     default:
       return "unknown";
+  }
+}
+
+// Copied from ui/views/win/hwnd_message_handler.cc
+gfx::ResizeEdge GetWindowResizeEdge(WPARAM param) {
+  switch (param) {
+    case WMSZ_BOTTOM:
+      return gfx::ResizeEdge::kBottom;
+    case WMSZ_TOP:
+      return gfx::ResizeEdge::kTop;
+    case WMSZ_LEFT:
+      return gfx::ResizeEdge::kLeft;
+    case WMSZ_RIGHT:
+      return gfx::ResizeEdge::kRight;
+    case WMSZ_TOPLEFT:
+      return gfx::ResizeEdge::kTopLeft;
+    case WMSZ_TOPRIGHT:
+      return gfx::ResizeEdge::kTopRight;
+    case WMSZ_BOTTOMLEFT:
+      return gfx::ResizeEdge::kBottomLeft;
+    case WMSZ_BOTTOMRIGHT:
+      return gfx::ResizeEdge::kBottomRight;
+    default:
+      NOTREACHED();
+      return gfx::ResizeEdge::kBottomRight;
   }
 }
 
@@ -263,7 +289,8 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
       gfx::Rect bounds = gfx::Rect(*reinterpret_cast<RECT*>(l_param));
       HWND hwnd = GetAcceleratedWidget();
       gfx::Rect dpi_bounds = ScreenToDIPRect(hwnd, bounds);
-      NotifyWindowWillResize(dpi_bounds, &prevent_default);
+      NotifyWindowWillResize(dpi_bounds, GetWindowResizeEdge(w_param),
+                             &prevent_default);
       if (prevent_default) {
         ::GetWindowRect(hwnd, reinterpret_cast<RECT*>(l_param));
         return true;  // Tells Windows that the Sizing is handled.

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.h
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.h
@@ -8,6 +8,7 @@
 #include <Quartz/Quartz.h>
 
 #include "components/remote_cocoa/app_shim/views_nswindow_delegate.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace electron {
 class NativeWindowMac;
@@ -20,6 +21,11 @@ class NativeWindowMac;
   bool is_zooming_;
   int level_;
   bool is_resizable_;
+
+  // Only valid during a live resize.
+  // Used to keep track of whether a resize is happening horizontally or
+  // vertically, even if physically the user is resizing in both directions.
+  absl::optional<bool> resizingHorizontally_;
 }
 - (id)initWithShell:(electron::NativeWindowMac*)shell;
 @end

--- a/shell/common/gin_converters/gfx_converter.cc
+++ b/shell/common/gin_converters/gfx_converter.cc
@@ -10,6 +10,7 @@
 #include "ui/gfx/geometry/point.h"
 #include "ui/gfx/geometry/point_f.h"
 #include "ui/gfx/geometry/rect.h"
+#include "ui/gfx/geometry/resize_utils.h"
 #include "ui/gfx/geometry/size.h"
 
 namespace gin {
@@ -158,6 +159,31 @@ v8::Local<v8::Value> Converter<display::Display>::ToV8(
   dict.Set("internal", val.IsInternal());
   dict.Set("touchSupport", val.touch_support());
   return dict.GetHandle();
+}
+
+v8::Local<v8::Value> Converter<gfx::ResizeEdge>::ToV8(
+    v8::Isolate* isolate,
+    const gfx::ResizeEdge& val) {
+  switch (val) {
+    case gfx::ResizeEdge::kRight:
+      return StringToV8(isolate, "right");
+    case gfx::ResizeEdge::kBottom:
+      return StringToV8(isolate, "bottom");
+    case gfx::ResizeEdge::kTop:
+      return StringToV8(isolate, "top");
+    case gfx::ResizeEdge::kLeft:
+      return StringToV8(isolate, "left");
+    case gfx::ResizeEdge::kTopLeft:
+      return StringToV8(isolate, "top-left");
+    case gfx::ResizeEdge::kTopRight:
+      return StringToV8(isolate, "top-right");
+    case gfx::ResizeEdge::kBottomLeft:
+      return StringToV8(isolate, "bottom-left");
+    case gfx::ResizeEdge::kBottomRight:
+      return StringToV8(isolate, "bottom-right");
+    default:
+      return StringToV8(isolate, "unknown");
+  }
 }
 
 }  // namespace gin

--- a/shell/common/gin_converters/gfx_converter.h
+++ b/shell/common/gin_converters/gfx_converter.h
@@ -16,6 +16,7 @@ class Point;
 class PointF;
 class Size;
 class Rect;
+enum class ResizeEdge;
 }  // namespace gfx
 
 namespace gin {
@@ -60,6 +61,12 @@ struct Converter<display::Display> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Local<v8::Value> val,
                      display::Display* out);
+};
+
+template <>
+struct Converter<gfx::ResizeEdge> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
+                                   const gfx::ResizeEdge& val);
 };
 
 }  // namespace gin


### PR DESCRIPTION
#### Description of Change

```diff
interface BrowserWindow {
  on(event: 'will-resize', listener: (event: Event,
                                      newBounds: Rectangle,
+                                     details: { edge: string }
                                      ) => void): this;
}
```

When resizing a window, it can be helpful to know which edge of the window is being dragged to resize it. Knowing the resize edge can allow an application to change behavior depending on which is being used. For example, respecting an aspect ratio only when the window is resized vertically.

On Windows, we're able to know exactly which edge/corner is used for resizing.
On macOS, we know whether the window was initially dragged horizontally or vertically.
On Linux, we don't support the `will-resize` event yet. 🤷‍♂️

In lieu of tests (unable to simulate resize), here are previews for both supported platforms.

Fiddle gist: https://gist.github.com/samuelmaddock/32f5d98a4d87a8a806ea57469770fba9

##### Windows
https://user-images.githubusercontent.com/1656324/118572278-0ab68d00-b74e-11eb-9b44-912f88507693.mp4

##### macOS
https://user-images.githubusercontent.com/1656324/118572441-700a7e00-b74e-11eb-90ed-1f1061a16cb4.mov

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added resize `edge` info to `BrowserWindow`'s `will-resize` event.