### PR TITLE
docs: update drag and drop tutorial

### DIFF
--- a/docs/fiddles/features/drag-and-drop/index.html
+++ b/docs/fiddles/features/drag-and-drop/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
     <h1>Hello World!</h1>
+    <p>Drag the box below to somewhere in your OS (Finder/Exlplorer, Desktop) to copy an example markdown file.</p>
     <div style="border:2px solid black;border-radius:3px;padding:5px;display:inline-block" draggable="true" id="drag">Drag me</div>
     <script src="renderer.js"></script>
 </body>

--- a/docs/fiddles/features/drag-and-drop/index.html
+++ b/docs/fiddles/features/drag-and-drop/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     <h1>Hello World!</h1>
-    <div style="background:green;padding:10px;display:inline-block" draggable="true" id="drag">Drag me</div>
+    <div style="border:2px solid black;border-radius:3px;padding:5px;display:inline-block" draggable="true" id="drag">Drag me</div>
     <script src="renderer.js"></script>
 </body>
 </html>

--- a/docs/fiddles/features/drag-and-drop/index.html
+++ b/docs/fiddles/features/drag-and-drop/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     <h1>Hello World!</h1>
-    <p>Drag the box below to somewhere in your OS (Finder/Exlplorer, Desktop) to copy an example markdown file.</p>
+    <p>Drag the boxes below to somewhere in your OS (Finder/Exlplorer, Desktop, etc.) to copy an example markdown file.</p>
     <div style="border:2px solid black;border-radius:3px;padding:5px;display:inline-block" draggable="true" id="drag1">Drag me - File 1</div>
     <div style="border:2px solid black;border-radius:3px;padding:5px;display:inline-block" draggable="true" id="drag2">Drag me - File 2</div>
     <script src="renderer.js"></script>

--- a/docs/fiddles/features/drag-and-drop/index.html
+++ b/docs/fiddles/features/drag-and-drop/index.html
@@ -8,7 +8,8 @@
 <body>
     <h1>Hello World!</h1>
     <p>Drag the box below to somewhere in your OS (Finder/Exlplorer, Desktop) to copy an example markdown file.</p>
-    <div style="border:2px solid black;border-radius:3px;padding:5px;display:inline-block" draggable="true" id="drag">Drag me</div>
+    <div style="border:2px solid black;border-radius:3px;padding:5px;display:inline-block" draggable="true" id="drag1">Drag me - File 1</div>
+    <div style="border:2px solid black;border-radius:3px;padding:5px;display:inline-block" draggable="true" id="drag2">Drag me - File 2</div>
     <script src="renderer.js"></script>
 </body>
 </html>

--- a/docs/fiddles/features/drag-and-drop/index.html
+++ b/docs/fiddles/features/drag-and-drop/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     <h1>Hello World!</h1>
-    <p>Drag the boxes below to somewhere in your OS (Finder/Exlplorer, Desktop, etc.) to copy an example markdown file.</p>
+    <p>Drag the boxes below to somewhere in your OS (Finder/Explorer, Desktop, etc.) to copy an example markdown file.</p>
     <div style="border:2px solid black;border-radius:3px;padding:5px;display:inline-block" draggable="true" id="drag1">Drag me - File 1</div>
     <div style="border:2px solid black;border-radius:3px;padding:5px;display:inline-block" draggable="true" id="drag2">Drag me - File 2</div>
     <script src="renderer.js"></script>

--- a/docs/fiddles/features/drag-and-drop/index.html
+++ b/docs/fiddles/features/drag-and-drop/index.html
@@ -7,12 +7,7 @@
 </head>
 <body>
     <h1>Hello World!</h1>
-    <p>
-        We are using node <script>document.write(process.versions.node)</script>,
-        Chrome <script>document.write(process.versions.chrome)</script>,
-        and Electron <script>document.write(process.versions.electron)</script>.
-    </p>
-    <a href="#" id="drag">Drag me</a>
+    <div style="background:green;padding:10px;display:inline-block" draggable="true" id="drag">Drag me</div>
     <script src="renderer.js"></script>
 </body>
 </html>

--- a/docs/fiddles/features/drag-and-drop/main.js
+++ b/docs/fiddles/features/drag-and-drop/main.js
@@ -1,9 +1,9 @@
 const { app, BrowserWindow, ipcMain, nativeImage, NativeImage } = require('electron')
 const path = require('path')
 const fs = require('fs')
-const http = require('http')
+const https = require('https')
 
-function createWindow () {
+function createWindow() {
   const win = new BrowserWindow({
     width: 800,
     height: 600,
@@ -18,7 +18,10 @@ function createWindow () {
 const iconName = path.join(process.cwd(), 'iconForDragAndDrop.png');
 const icon = fs.createWriteStream(iconName);
 
-http.get('http://img.icons8.com/ios/452/drag-and-drop.png', (response) => {
+// Create a new file to copy - you can also copy existing files.
+fs.writeFileSync(path.join(process.cwd(), 'drag-and-drop.md'), '# Test drag and drop')
+
+https.get('https://img.icons8.com/ios/452/drag-and-drop.png', (response) => {
   response.pipe(icon);
 });
 

--- a/docs/fiddles/features/drag-and-drop/main.js
+++ b/docs/fiddles/features/drag-and-drop/main.js
@@ -15,7 +15,7 @@ function createWindow () {
   win.loadFile('index.html')
 }
 
-const iconName = `${process.cwd()}/iconForDragAndDrop.png`;
+const iconName = path.join(process.cwd(), 'iconForDragAndDrop.png');
 const icon = fs.createWriteStream(iconName);
 
 http.get('http://img.icons8.com/ios/452/drag-and-drop.png', (response) => {

--- a/docs/fiddles/features/drag-and-drop/main.js
+++ b/docs/fiddles/features/drag-and-drop/main.js
@@ -1,20 +1,23 @@
 const { app, BrowserWindow, ipcMain, nativeImage, NativeImage } = require('electron')
-const fs = require('fs');
-const http = require('http');
+const path = require('path')
+const fs = require('fs')
+const http = require('http')
 
 function createWindow () {
   const win = new BrowserWindow({
     width: 800,
     height: 600,
     webPreferences: {
-      nodeIntegration: true
+      preload: path.join(__dirname, 'preload.js')
     }
   })
 
   win.loadFile('index.html')
 }
-const iconName = 'iconForDragAndDrop.png';
-const icon = fs.createWriteStream(`${process.cwd()}/${iconName}`);
+
+const iconName = `${process.cwd()}/iconForDragAndDrop.png`;
+const icon = fs.createWriteStream(iconName);
+
 http.get('http://img.icons8.com/ios/452/drag-and-drop.png', (response) => {
   response.pipe(icon);
 });
@@ -24,7 +27,7 @@ app.whenReady().then(createWindow)
 ipcMain.on('ondragstart', (event, filePath) => {
   event.sender.startDrag({
     file: filePath,
-    icon: `${process.cwd()}/${iconName}`
+    icon: iconName,
   })
 })
 

--- a/docs/fiddles/features/drag-and-drop/main.js
+++ b/docs/fiddles/features/drag-and-drop/main.js
@@ -15,11 +15,12 @@ function createWindow() {
   win.loadFile('index.html')
 }
 
-const iconName = path.join(process.cwd(), 'iconForDragAndDrop.png');
+const iconName = path.join(__dirname, 'iconForDragAndDrop.png');
 const icon = fs.createWriteStream(iconName);
 
 // Create a new file to copy - you can also copy existing files.
-fs.writeFileSync(path.join(process.cwd(), 'drag-and-drop.md'), '# Test drag and drop')
+fs.writeFileSync(path.join(__dirname, 'drag-and-drop-1.md'), '# First file to test drag and drop')
+fs.writeFileSync(path.join(__dirname, 'drag-and-drop-2.md'), '# Second file to test drag and drop')
 
 https.get('https://img.icons8.com/ios/452/drag-and-drop.png', (response) => {
   response.pipe(icon);
@@ -29,7 +30,7 @@ app.whenReady().then(createWindow)
 
 ipcMain.on('ondragstart', (event, filePath) => {
   event.sender.startDrag({
-    file: filePath,
+    file: path.join(__dirname, filePath),
     icon: iconName,
   })
 })

--- a/docs/fiddles/features/drag-and-drop/preload.js
+++ b/docs/fiddles/features/drag-and-drop/preload.js
@@ -3,6 +3,6 @@ const path = require('path')
 
 contextBridge.exposeInMainWorld('electron', {
   startDrag: (fileName) => {
-    ipcRenderer.send('ondragstart', path.join(process.cwd(), fileName))
+    ipcRenderer.send('ondragstart', fileName)
   }
 })

--- a/docs/fiddles/features/drag-and-drop/preload.js
+++ b/docs/fiddles/features/drag-and-drop/preload.js
@@ -1,12 +1,8 @@
 const { contextBridge, ipcRenderer } = require('electron')
-const fs = require('fs').promises
 const path = require('path')
 
 contextBridge.exposeInMainWorld('electron', {
-  startDrag: async (fileName) => {
-    // Create a new file to copy - you can also copy existing files.
-    await fs.writeFile(fileName, '# Test drag and drop')
-
+  startDrag: (fileName) => {
     ipcRenderer.send('ondragstart', path.join(process.cwd(), fileName))
   }
 })

--- a/docs/fiddles/features/drag-and-drop/preload.js
+++ b/docs/fiddles/features/drag-and-drop/preload.js
@@ -1,10 +1,10 @@
 const { contextBridge, ipcRenderer } = require('electron')
-const fs = require('fs')
+const fs = require('fs').promises;
 
 contextBridge.exposeInMainWorld('electron', {
-  startDrag: (fileName) => {
+  startDrag: async (fileName) => {
     // Create a new file to copy - you can also copy existing files.
-    fs.writeFileSync(fileName, '# Test drag and drop')
+    await fs.writeFile(fileName, '# Test drag and drop')
 
     ipcRenderer.send('ondragstart', process.cwd() + `/${fileName}`)
   }

--- a/docs/fiddles/features/drag-and-drop/preload.js
+++ b/docs/fiddles/features/drag-and-drop/preload.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 
 contextBridge.exposeInMainWorld('electron', {
   startDrag: (fileName) => {
+    // Create a new file to copy - you can copy something 
     fs.writeFileSync(fileName, '# Test drag and drop');
     ipcRenderer.send('ondragstart', process.cwd() + `/${fileName}`)
   },

--- a/docs/fiddles/features/drag-and-drop/preload.js
+++ b/docs/fiddles/features/drag-and-drop/preload.js
@@ -1,10 +1,11 @@
-const { contextBridge, ipcRenderer } = require('electron');
-const fs = require('fs');
+const { contextBridge, ipcRenderer } = require('electron')
+const fs = require('fs')
 
 contextBridge.exposeInMainWorld('electron', {
   startDrag: (fileName) => {
-    // Create a new file to copy - you can copy something 
-    fs.writeFileSync(fileName, '# Test drag and drop');
+    // Create a new file to copy - you can also copy existing files.
+    fs.writeFileSync(fileName, '# Test drag and drop')
+
     ipcRenderer.send('ondragstart', process.cwd() + `/${fileName}`)
-  },
+  }
 })

--- a/docs/fiddles/features/drag-and-drop/preload.js
+++ b/docs/fiddles/features/drag-and-drop/preload.js
@@ -1,11 +1,12 @@
 const { contextBridge, ipcRenderer } = require('electron')
-const fs = require('fs').promises;
+const fs = require('fs').promises
+const path = require('path')
 
 contextBridge.exposeInMainWorld('electron', {
   startDrag: async (fileName) => {
     // Create a new file to copy - you can also copy existing files.
     await fs.writeFile(fileName, '# Test drag and drop')
 
-    ipcRenderer.send('ondragstart', process.cwd() + `/${fileName}`)
+    ipcRenderer.send('ondragstart', path.join(process.cwd(), fileName))
   }
 })

--- a/docs/fiddles/features/drag-and-drop/preload.js
+++ b/docs/fiddles/features/drag-and-drop/preload.js
@@ -1,0 +1,9 @@
+const { contextBridge, ipcRenderer } = require('electron');
+const fs = require('fs');
+
+contextBridge.exposeInMainWorld('electron', {
+  startDrag: (fileName) => {
+    fs.writeFileSync(fileName, '# Test drag and drop');
+    ipcRenderer.send('ondragstart', process.cwd() + `/${fileName}`)
+  },
+})

--- a/docs/fiddles/features/drag-and-drop/renderer.js
+++ b/docs/fiddles/features/drag-and-drop/renderer.js
@@ -1,9 +1,5 @@
-const { ipcRenderer } = require('electron')
-const fs = require('fs')
-
 document.getElementById('drag').ondragstart = (event) => {
-  const fileName = 'drag-and-drop.md'
-  fs.writeFileSync(fileName, '# Test drag and drop');
+  console.log("draggin...")
   event.preventDefault()
-  ipcRenderer.send('ondragstart', process.cwd() + `/${fileName}`)
+  window.electron.startDrag('drag-and-drop.md')
 }

--- a/docs/fiddles/features/drag-and-drop/renderer.js
+++ b/docs/fiddles/features/drag-and-drop/renderer.js
@@ -1,4 +1,9 @@
-document.getElementById('drag').ondragstart = (event) => {
+document.getElementById('drag1').ondragstart = (event) => {
   event.preventDefault()
-  window.electron.startDrag('drag-and-drop.md')
+  window.electron.startDrag('drag-and-drop-1.md')
+}
+
+document.getElementById('drag2').ondragstart = (event) => {
+  event.preventDefault()
+  window.electron.startDrag('drag-and-drop-2.md')
 }

--- a/docs/fiddles/features/drag-and-drop/renderer.js
+++ b/docs/fiddles/features/drag-and-drop/renderer.js
@@ -1,5 +1,4 @@
 document.getElementById('drag').ondragstart = (event) => {
-  console.log("draggin...")
   event.preventDefault()
   window.electron.startDrag('drag-and-drop.md')
 }

--- a/docs/tutorial/native-file-drag-drop.md
+++ b/docs/tutorial/native-file-drag-drop.md
@@ -18,18 +18,14 @@ An example demonstrating how you can create a file on the fly to be dragged out 
 
 ### Preload.js
 
-In `preload.js` use the [`contextBridge`] to inject a method `window.electron.startDrag(...)` that will send an ipc message to the main process.
+In `preload.js` use the [`contextBridge`] to inject a method `window.electron.startDrag(...)` that will send an IPC message to the main process.
 
 ```js
 const { contextBridge, ipcRenderer } = require('electron')
-const fs = require('fs').promises
 const path = require('path')
 
 contextBridge.exposeInMainWorld('electron', {
-  startDrag: async (fileName) => {
-    // Create a new file to copy - you can also copy existing files.
-    await fs.writeFile(fileName, '# Test drag and drop')
-
+  startDrag: (fileName) => {
     ipcRenderer.send('ondragstart', path.join(process.cwd(), fileName))
   }
 })
@@ -46,7 +42,7 @@ Add a draggable element to `index.html`, and reference your renderer script:
 
 ### Renderer.js
 
-In `renderer.js` setup the renderer process to handle drag events by calling the method you added via the [`contextBridge`] above.
+In `renderer.js` set up the renderer process to handle drag events by calling the method you added via the [`contextBridge`] above.
 
 ```javascript
 document.getElementById('drag').ondragstart = (event) => {

--- a/docs/tutorial/native-file-drag-drop.md
+++ b/docs/tutorial/native-file-drag-drop.md
@@ -18,7 +18,7 @@ An example demonstrating how you can create a file on the fly to be dragged out 
 
 ### Preload.js
 
-In `preload.js` use the [`contextBridge`] to inject a method `window.electron.startDrag(...)` that will trigger an ipc message from to the main process.
+In `preload.js` use the [`contextBridge`] to inject a method `window.electron.startDrag(...)` that will send an ipc message to the main process.
 
 ```js
 const { contextBridge, ipcRenderer } = require('electron')

--- a/docs/tutorial/native-file-drag-drop.md
+++ b/docs/tutorial/native-file-drag-drop.md
@@ -14,7 +14,7 @@ API in response to the `ondragstart` event.
 
 ## Example
 
-A simple example demonstrating how you can create a file on the fly to be dragged out of the window.
+An example demonstrating how you can create a file on the fly to be dragged out of the window.
 
 ### Preload.js
 

--- a/docs/tutorial/native-file-drag-drop.md
+++ b/docs/tutorial/native-file-drag-drop.md
@@ -14,7 +14,11 @@ API in response to the `ondragstart` event.
 
 ## Example
 
-The ipc message from the renderer to the main process needs to come from `preload.js` to stay compliant with security guidelines. Add the following code to `preload.js`:
+A simple example demonstrating how you can create a file on the fly to be dragged out of the window.
+
+### Preload.js
+
+In `preload.js` use the [`contextBridge`](../api/context-bridge.md) to inject a method `window.electron.startDrag(...)` that will trigger an ipc message from to the main process.
 
 ```js
 const { contextBridge, ipcRenderer } = require('electron')
@@ -30,6 +34,8 @@ contextBridge.exposeInMainWorld('electron', {
 })
 ```
 
+### Index.html
+
 Add a draggable element to `index.html`, and reference your renderer script:
 
 ```html
@@ -37,9 +43,9 @@ Add a draggable element to `index.html`, and reference your renderer script:
 <script src="renderer.js"></script>
 ```
 
-and instruct the renderer process (in `renderer.js`) to handle drag events by calling the `contextBridge` method you added in `preload.js`:
+### Renderer.js
 
-`renderer.js`:
+In `renderer.js` setup the renderer process to handle drag events by calling the method you added via the [`contextBridge`](../api/context-bridge.md) above.
 
 ```javascript
 document.getElementById('drag').ondragstart = (event) => {
@@ -47,6 +53,8 @@ document.getElementById('drag').ondragstart = (event) => {
   window.electron.startDrag('drag-and-drop.md')
 }
 ```
+
+### Main.js
 
 In the Main process(`main.js` file), expand the received event with a path to the file that is
 being dragged and an icon:

--- a/docs/tutorial/native-file-drag-drop.md
+++ b/docs/tutorial/native-file-drag-drop.md
@@ -22,14 +22,15 @@ In `preload.js` use the [`contextBridge`] to inject a method `window.electron.st
 
 ```js
 const { contextBridge, ipcRenderer } = require('electron')
-const fs = require('fs')
+const fs = require('fs').promises
+const path = require('path')
 
 contextBridge.exposeInMainWorld('electron', {
-  startDrag: (fileName) => {
+  startDrag: async (fileName) => {
     // Create a new file to copy - you can also copy existing files.
-    fs.writeFileSync(fileName, '# Test drag and drop')
+    await fs.writeFile(fileName, '# Test drag and drop')
 
-    ipcRenderer.send('ondragstart', process.cwd() + `/${fileName}`)
+    ipcRenderer.send('ondragstart', path.join(process.cwd(), fileName))
   }
 })
 ```

--- a/docs/tutorial/native-file-drag-drop.md
+++ b/docs/tutorial/native-file-drag-drop.md
@@ -56,7 +56,7 @@ document.getElementById('drag').ondragstart = (event) => {
 
 ### Main.js
 
-In the Main process(`main.js` file), expand the received event with a path to the file that is
+In the Main process (`main.js` file), expand the received event with a path to the file that is
 being dragged and an icon:
 
 ```javascript fiddle='docs/fiddles/features/drag-and-drop'

--- a/docs/tutorial/native-file-drag-drop.md
+++ b/docs/tutorial/native-file-drag-drop.md
@@ -18,7 +18,7 @@ A simple example demonstrating how you can create a file on the fly to be dragge
 
 ### Preload.js
 
-In `preload.js` use the [`contextBridge`](../api/context-bridge.md) to inject a method `window.electron.startDrag(...)` that will trigger an ipc message from to the main process.
+In `preload.js` use the [`contextBridge`] to inject a method `window.electron.startDrag(...)` that will trigger an ipc message from to the main process.
 
 ```js
 const { contextBridge, ipcRenderer } = require('electron')
@@ -45,7 +45,7 @@ Add a draggable element to `index.html`, and reference your renderer script:
 
 ### Renderer.js
 
-In `renderer.js` setup the renderer process to handle drag events by calling the method you added via the [`contextBridge`](../api/context-bridge.md) above.
+In `renderer.js` setup the renderer process to handle drag events by calling the method you added via the [`contextBridge`] above.
 
 ```javascript
 document.getElementById('drag').ondragstart = (event) => {
@@ -75,3 +75,5 @@ the item from the BrowserWindow onto your desktop. In this guide,
 the item is a Markdown file located in the root of the project:
 
 ![Drag and drop](../images/drag-and-drop.gif)
+
+[`contextBridge`]: ../api/context-bridge.md


### PR DESCRIPTION
#### Description of Change
Update the "Native Files Drag and Drop" tutorial to no longer require nodeIntegration and properly use the preload script to inject IPC methods.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none

cc: @erickzhao 
