### PR TITLE
docs: Update docs for keyboard shortcuts

### DIFF
--- a/docs/fiddles/features/keyboard-shortcuts/global/index.html
+++ b/docs/fiddles/features/keyboard-shortcuts/global/index.html
@@ -7,10 +7,5 @@
 </head>
 <body>
     <h1>Hello World!</h1>
-    <p>
-        We are using node <script>document.write(process.versions.node)</script>,
-        Chrome <script>document.write(process.versions.chrome)</script>,
-        and Electron <script>document.write(process.versions.electron)</script>.
-    </p>
 </body>
 </html>

--- a/docs/fiddles/features/keyboard-shortcuts/global/index.html
+++ b/docs/fiddles/features/keyboard-shortcuts/global/index.html
@@ -7,5 +7,6 @@
 </head>
 <body>
     <h1>Hello World!</h1>
+    <p>Hit Alt+Ctrl+I on Windows or Opt+Cmd+I on Mac to see a message printed to the console.</p>
 </body>
 </html>

--- a/docs/fiddles/features/keyboard-shortcuts/global/main.js
+++ b/docs/fiddles/features/keyboard-shortcuts/global/main.js
@@ -4,9 +4,6 @@ function createWindow () {
   const win = new BrowserWindow({
     width: 800,
     height: 600,
-    webPreferences: {
-      nodeIntegration: true
-    }
   })
 
   win.loadFile('index.html')

--- a/docs/fiddles/features/keyboard-shortcuts/interception-from-main/index.html
+++ b/docs/fiddles/features/keyboard-shortcuts/interception-from-main/index.html
@@ -7,8 +7,5 @@
 </head>
 <body>
     <h1>Hello World!</h1>
-    We are using node <script>document.write(process.versions.node)</script>,
-    Chrome <script>document.write(process.versions.chrome)</script>,
-    and Electron <script>document.write(process.versions.electron)</script>.
 </body>
 </html>

--- a/docs/fiddles/features/keyboard-shortcuts/interception-from-main/index.html
+++ b/docs/fiddles/features/keyboard-shortcuts/interception-from-main/index.html
@@ -7,5 +7,6 @@
 </head>
 <body>
     <h1>Hello World!</h1>
+    <p>Hit Ctrl+I to see a message printed to the console.</p>
 </body>
 </html>

--- a/docs/fiddles/features/keyboard-shortcuts/interception-from-main/main.js
+++ b/docs/fiddles/features/keyboard-shortcuts/interception-from-main/main.js
@@ -1,7 +1,7 @@
 const { app, BrowserWindow } = require('electron')
 
 app.whenReady().then(() => {
-  const win = new BrowserWindow({ width: 800, height: 600, webPreferences: { nodeIntegration: true } })
+  const win = new BrowserWindow({ width: 800, height: 600 })
 
   win.loadFile('index.html')
   win.webContents.on('before-input-event', (event, input) => {

--- a/docs/fiddles/features/keyboard-shortcuts/local/index.html
+++ b/docs/fiddles/features/keyboard-shortcuts/local/index.html
@@ -7,5 +7,6 @@
 </head>
 <body>
     <h1>Hello World!</h1>
+    <p>Hit Alt+Shift+I on Windows, or Opt+Cmd+I on mac to see a message printed to the console.</p>
 </body>
 </html>

--- a/docs/fiddles/features/keyboard-shortcuts/local/index.html
+++ b/docs/fiddles/features/keyboard-shortcuts/local/index.html
@@ -7,10 +7,5 @@
 </head>
 <body>
     <h1>Hello World!</h1>
-    <p>
-        We are using node <script>document.write(process.versions.node)</script>,
-        Chrome <script>document.write(process.versions.chrome)</script>,
-        and Electron <script>document.write(process.versions.electron)</script>.
-    </p>
 </body>
 </html>

--- a/docs/fiddles/features/keyboard-shortcuts/local/main.js
+++ b/docs/fiddles/features/keyboard-shortcuts/local/main.js
@@ -4,9 +4,6 @@ function createWindow () {
   const win = new BrowserWindow({
     width: 800,
     height: 600,
-    webPreferences: {
-      nodeIntegration: true
-    }
   })
 
   win.loadFile('index.html')

--- a/docs/fiddles/features/keyboard-shortcuts/web-apis/index.html
+++ b/docs/fiddles/features/keyboard-shortcuts/web-apis/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'">
+    <meta http-equiv="X-Content-Security-Policy" content="default-src 'self'; script-src 'self'">
+    <title>Hello World!</title>
+  </head>
+  <body>
+    <h1>Hello World!</h1>
+    
+    <div><span>Last Key Pressed: </span><span id="last-keypress"></span>
+    </div>
+    <script src="./renderer.js"></script>
+  </body>
+</html>

--- a/docs/fiddles/features/keyboard-shortcuts/web-apis/index.html
+++ b/docs/fiddles/features/keyboard-shortcuts/web-apis/index.html
@@ -10,8 +10,8 @@
   <body>
     <h1>Hello World!</h1>
     
-    <div><span>Last Key Pressed: </span><span id="last-keypress"></span>
-    </div>
+    <p>Hit any key with this window focused to see it captured here.</p>
+    <div><span>Last Key Pressed: </span><span id="last-keypress"></span></div>
     <script src="./renderer.js"></script>
   </body>
 </html>

--- a/docs/fiddles/features/keyboard-shortcuts/web-apis/main.js
+++ b/docs/fiddles/features/keyboard-shortcuts/web-apis/main.js
@@ -1,0 +1,37 @@
+// Modules to control application life and create native browser window
+const {app, BrowserWindow} = require('electron')
+const path = require('path')
+
+function createWindow () {
+  // Create the browser window.
+  const mainWindow = new BrowserWindow({
+    width: 800,
+    height: 600,
+  })
+
+  // and load the index.html of the app.
+  mainWindow.loadFile('index.html')
+
+  // Open the DevTools.
+  // mainWindow.webContents.openDevTools()
+}
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.whenReady().then(() => {
+  createWindow()
+  
+  app.on('activate', function () {
+    // On macOS it's common to re-create a window in the app when the
+    // dock icon is clicked and there are no other windows open.
+    if (BrowserWindow.getAllWindows().length === 0) createWindow()
+  })
+})
+
+// Quit when all windows are closed, except on macOS. There, it's common
+// for applications and their menu bar to stay active until the user quits
+// explicitly with Cmd + Q.
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit()
+})

--- a/docs/fiddles/features/keyboard-shortcuts/web-apis/main.js
+++ b/docs/fiddles/features/keyboard-shortcuts/web-apis/main.js
@@ -12,8 +12,6 @@ function createWindow () {
   // and load the index.html of the app.
   mainWindow.loadFile('index.html')
 
-  // Open the DevTools.
-  // mainWindow.webContents.openDevTools()
 }
 
 // This method will be called when Electron has finished

--- a/docs/fiddles/features/keyboard-shortcuts/web-apis/renderer.js
+++ b/docs/fiddles/features/keyboard-shortcuts/web-apis/renderer.js
@@ -1,7 +1,7 @@
-function handleKeyPress(event) {
+function handleKeyPress (event) {
   // You can put code here to handle the keypress.
-  document.getElementById("last-keypress").innerText = event.key;
-  console.log(`You pressed ${event.key}`);
+  document.getElementById("last-keypress").innerText = event.key
+  console.log(`You pressed ${event.key}`)
 }
 
-window.addEventListener('keyup', handleKeyPress, true);
+window.addEventListener('keyup', handleKeyPress, true)

--- a/docs/fiddles/features/keyboard-shortcuts/web-apis/renderer.js
+++ b/docs/fiddles/features/keyboard-shortcuts/web-apis/renderer.js
@@ -1,0 +1,7 @@
+function handleKeyPress(event) {
+  // You can put code here to handle the keypress.
+  document.getElementById("last-keypress").innerText = event.key;
+  console.log(`You pressed ${event.key}`);
+}
+
+window.addEventListener('keyup', handleKeyPress, true);

--- a/docs/tutorial/keyboard-shortcuts.md
+++ b/docs/tutorial/keyboard-shortcuts.md
@@ -91,7 +91,7 @@ function handleKeyPress(event) {
 window.addEventListener('keyup', handleKeyPress, true);
 ```
 
-> Note the third parameter `true` indicates that the listener will always receive
+> Note:  the third parameter `true` indicates that the listener will always receive
 key presses before other listeners so they can't have `stopPropagation()`
 called on them.
 

--- a/docs/tutorial/keyboard-shortcuts.md
+++ b/docs/tutorial/keyboard-shortcuts.md
@@ -81,15 +81,21 @@ If you want to handle keyboard shortcuts within a [BrowserWindow], you can
 listen for the `keyup` and `keydown` [DOM events][dom-events] inside the
 renderer process using the [addEventListener() API][addEventListener-api].
 
-```js
-window.addEventListener('keyup', doSomething, true)
+```javascript fiddle='docs/fiddles/features/keyboard-shortcuts/web-apis'
+function handleKeyPress(event) {
+  // You can put code here to handle the keypress.
+  document.getElementById("last-keypress").innerText = event.key;
+  console.log(`You pressed ${event.key}`);
+}
+
+window.addEventListener('keyup', handleKeyPress, true);
 ```
 
-Note the third parameter `true` indicates that the listener will always receive
+> Note the third parameter `true` indicates that the listener will always receive
 key presses before other listeners so they can't have `stopPropagation()`
 called on them.
 
-#### Intercepting events in the main process
+### Intercepting events in the main process
 
 The [`before-input-event`](../api/web-contents.md#event-before-input-event) event
 is emitted before dispatching `keydown` and `keyup` events in the page. It can

--- a/docs/tutorial/keyboard-shortcuts.md
+++ b/docs/tutorial/keyboard-shortcuts.md
@@ -81,7 +81,7 @@ If you want to handle keyboard shortcuts within a [BrowserWindow], you can
 listen for the `keyup` and `keydown` [DOM events][dom-events] inside the
 renderer process using the [addEventListener() API][addEventListener-api].
 
-```javascript fiddle='docs/fiddles/features/keyboard-shortcuts/web-apis'
+```javascript fiddle='docs/fiddles/features/keyboard-shortcuts/web-apis|focus=renderer.js'
 function handleKeyPress(event) {
   // You can put code here to handle the keypress.
   document.getElementById("last-keypress").innerText = event.key;

--- a/docs/tutorial/keyboard-shortcuts.md
+++ b/docs/tutorial/keyboard-shortcuts.md
@@ -95,13 +95,11 @@ window.addEventListener('keyup', handleKeyPress, true);
 key presses before other listeners so they can't have `stopPropagation()`
 called on them.
 
-### Intercepting events in the main process
+#### Intercepting events in the main process
 
 The [`before-input-event`](../api/web-contents.md#event-before-input-event) event
 is emitted before dispatching `keydown` and `keyup` events in the page. It can
 be used to catch and handle custom shortcuts that are not visible in the menu.
-
-##### Example
 
 Starting with a working application from the
 [Quick Start Guide](quick-start.md), update the `main.js` file with the
@@ -111,7 +109,7 @@ following lines:
 const { app, BrowserWindow } = require('electron')
 
 app.whenReady().then(() => {
-  const win = new BrowserWindow({ width: 800, height: 600, webPreferences: { nodeIntegration: true } })
+  const win = new BrowserWindow({ width: 800, height: 600 })
 
   win.loadFile('index.html')
   win.webContents.on('before-input-event', (event, input) => {


### PR DESCRIPTION
#### Description of Change
Updates the fiddles for Keyboard shortcuts. (local, global, and main-intercept).

The fiddles work as is so this PR:
* removes `nodeIntegration: true` from the `BrowserWindow`
* removes the version display from the home page.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none

cc @erickzhao 