### PR TITLE
fix: pdf viewer permissions

### DIFF
--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -851,7 +851,7 @@ v8::Local<v8::Value> Session::GetAllExtensions() {
   std::vector<const extensions::Extension*> extensions_vector;
   for (const auto& extension : *installed_extensions) {
     if (extension->location() !=
-        extensions::mojom::ManifestLocation::kExternalComponent)
+        extensions::mojom::ManifestLocation::kComponent)
       extensions_vector.emplace_back(extension.get());
   }
   return gin::ConvertToV8(isolate_, extensions_vector);

--- a/shell/browser/extensions/electron_extension_system.cc
+++ b/shell/browser/extensions/electron_extension_system.cc
@@ -119,8 +119,7 @@ void ElectronExtensionSystem::LoadComponentExtensions() {
     root_directory = root_directory.Append(FILE_PATH_LITERAL("pdf"));
     scoped_refptr<const Extension> pdf_extension =
         extensions::Extension::Create(
-            root_directory,
-            extensions::mojom::ManifestLocation::kExternalComponent,
+            root_directory, extensions::mojom::ManifestLocation::kComponent,
             *pdf_manifest, extensions::Extension::REQUIRE_KEY, &utf8_error);
     extension_loader_->registrar()->AddExtension(pdf_extension);
   }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Fixes #29191.  The chromium roll #28462 included a change to [shell/browser/extensions/electron_extension_system.cc](https://github.com/electron/electron/pull/28462/files#diff-8e14b16934c07d35e6a4cf41d9a071c63d6f018e10dd09e190ba1cc46bf673deR122) to address https://chromium-review.googlesource.com/c/chromium/src/+/2771320, but the wrong `extensions::mojom::ManifestLocation` was used which caused a permissioning error which prevented the PDF viewer from displaying.  This PR updates shell/browser/extensions/electron_extension_system.cc to use the proper `extensions::mojom::ManifestLocation`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->Fixed permissions issue that was preventing the PDF viewer from displaying.
