### PR TITLE
refactor: expose process.contextId directly

### DIFF
--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -45,10 +45,6 @@ require('@electron/internal/common/init');
 // The global variable will be used by ipc for event dispatching
 const v8Util = process._linkedBinding('electron_common_v8_util');
 
-// Expose process.contextId
-const contextId = v8Util.getHiddenValue<string>(global, 'contextId');
-Object.defineProperty(process, 'contextId', { enumerable: true, value: contextId });
-
 const { ipcRendererInternal } = require('@electron/internal/renderer/ipc-renderer-internal') as typeof ipcRendererInternalModule;
 const ipcRenderer = require('@electron/internal/renderer/api/ipc-renderer').default;
 

--- a/lib/sandboxed_renderer/init.ts
+++ b/lib/sandboxed_renderer/init.ts
@@ -96,10 +96,6 @@ Object.defineProperty(preloadProcess, 'noDeprecation', {
   }
 });
 
-// Expose process.contextId
-const contextId = v8Util.getHiddenValue<string>(global, 'contextId');
-Object.defineProperty(preloadProcess, 'contextId', { enumerable: true, value: contextId });
-
 process.on('loaded', () => (preloadProcess as events.EventEmitter).emit('loaded'));
 process.on('exit', () => (preloadProcess as events.EventEmitter).emit('exit'));
 (process as events.EventEmitter).on('document-start', () => (preloadProcess as events.EventEmitter).emit('document-start'));

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -74,8 +74,6 @@ void ElectronRendererClient::RunScriptsAtDocumentEnd(
 void ElectronRendererClient::DidCreateScriptContext(
     v8::Handle<v8::Context> renderer_context,
     content::RenderFrame* render_frame) {
-  RendererClientBase::DidCreateScriptContext(renderer_context, render_frame);
-
   // TODO(zcbenz): Do not create Node environment if node integration is not
   // enabled.
 

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -201,8 +201,6 @@ void ElectronSandboxedRendererClient::RunScriptsAtDocumentEnd(
 void ElectronSandboxedRendererClient::DidCreateScriptContext(
     v8::Handle<v8::Context> context,
     content::RenderFrame* render_frame) {
-  RendererClientBase::DidCreateScriptContext(context, render_frame);
-
   // Only allow preload for the main frame or
   // For devtools we still want to run the preload_bundle script
   // Or when nodeSupport is explicitly enabled in sub frames

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -154,16 +154,6 @@ RendererClientBase::~RendererClientBase() {
   g_renderer_client_base = nullptr;
 }
 
-void RendererClientBase::DidCreateScriptContext(
-    v8::Handle<v8::Context> context,
-    content::RenderFrame* render_frame) {
-  // global.setHidden("contextId", `${processHostId}-${++next_context_id_}`)
-  auto context_id = base::StringPrintf(
-      "%s-%" PRId64, renderer_client_id_.c_str(), ++next_context_id_);
-  gin_helper::Dictionary global(context->GetIsolate(), context->Global());
-  global.SetHidden("contextId", context_id);
-}
-
 // static
 RendererClientBase* RendererClientBase::Get() {
   DCHECK(g_renderer_client_base);
@@ -173,9 +163,13 @@ RendererClientBase* RendererClientBase::Get() {
 void RendererClientBase::BindProcess(v8::Isolate* isolate,
                                      gin_helper::Dictionary* process,
                                      content::RenderFrame* render_frame) {
+  auto context_id = base::StringPrintf(
+      "%s-%" PRId64, renderer_client_id_.c_str(), ++next_context_id_);
+
   process->SetReadOnly("isMainFrame", render_frame->IsMainFrame());
   process->SetReadOnly("contextIsolated",
                        render_frame->GetBlinkPreferences().context_isolation);
+  process->SetReadOnly("contextId", context_id);
 }
 
 void RendererClientBase::RenderThreadStarted() {

--- a/shell/renderer/renderer_client_base.h
+++ b/shell/renderer/renderer_client_base.h
@@ -69,7 +69,7 @@ class RendererClientBase : public content::ContentRendererClient
 #endif
 
   virtual void DidCreateScriptContext(v8::Handle<v8::Context> context,
-                                      content::RenderFrame* render_frame);
+                                      content::RenderFrame* render_frame) = 0;
   virtual void WillReleaseScriptContext(v8::Handle<v8::Context> context,
                                         content::RenderFrame* render_frame) = 0;
   virtual void DidClearWindowObject(content::RenderFrame* render_frame);


### PR DESCRIPTION
#### Description of Change
@electron/remote is now using `process.contextId` (https://github.com/electron/remote/pull/44)

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes