### PR TITLE
docs: Updated "progress bar" fiddle feature in docs

### DIFF
--- a/docs/fiddles/features/progress-bar/index.html
+++ b/docs/fiddles/features/progress-bar/index.html
@@ -12,5 +12,8 @@
         Chrome <script>document.write(process.versions.chrome)</script>,
         and Electron <script>document.write(process.versions.electron)</script>.
     </p>
+    <p>
+      Keep an eye on the progress bar for this application! It should advance to full and then reset.
+    </p>
 </body>
 </html>

--- a/docs/fiddles/features/progress-bar/index.html
+++ b/docs/fiddles/features/progress-bar/index.html
@@ -7,9 +7,12 @@
 </head>
 <body>
     <h1>Hello World!</h1>
-    <p>
-      Keep an eye on the progress bar for this application! It should advance to full and then
-      reset.
-    </p>
+    <p>Keep an eye on the Dock (Mac)/Task Bar (Windows) for this application!</p>
+    <p>It should indicate a progress that advances from 0 to 100%.</p>
+    <p>For the next 5 seconds, on Windows, it should remain in an indeterminate state, while on
+      Mac it should pin at 100%.</p>
+    <p>Finally, it should disappear entirely.</p>
+
+    <button id="button">Set Indeterminate</button>
 </body>
 </html>

--- a/docs/fiddles/features/progress-bar/index.html
+++ b/docs/fiddles/features/progress-bar/index.html
@@ -8,7 +8,8 @@
 <body>
     <h1>Hello World!</h1>
     <p>
-      Keep an eye on the progress bar for this application! It should advance to full and then reset.
+      Keep an eye on the progress bar for this application! It should advance to full and then
+      reset.
     </p>
 </body>
 </html>

--- a/docs/fiddles/features/progress-bar/index.html
+++ b/docs/fiddles/features/progress-bar/index.html
@@ -8,11 +8,6 @@
 <body>
     <h1>Hello World!</h1>
     <p>
-        We are using node <script>document.write(process.versions.node)</script>,
-        Chrome <script>document.write(process.versions.chrome)</script>,
-        and Electron <script>document.write(process.versions.electron)</script>.
-    </p>
-    <p>
       Keep an eye on the progress bar for this application! It should advance to full and then reset.
     </p>
 </body>

--- a/docs/fiddles/features/progress-bar/index.html
+++ b/docs/fiddles/features/progress-bar/index.html
@@ -7,10 +7,9 @@
 </head>
 <body>
     <h1>Hello World!</h1>
-    <p>Keep an eye on the Dock (Mac)/Task Bar (Windows) for this application!</p>
+    <p>Keep an eye on the dock (Mac) or taskbar (Windows, Unity) for this application!</p>
     <p>It should indicate a progress that advances from 0 to 100%.</p>
-    <p>For the next 5 seconds, on Windows, it should remain in an indeterminate state, while on
-      Mac it should pin at 100%.</p>
-    <p>Finally, it should disappear entirely.</p>
+    <p>It should then show indeterminate (Windows) or pin at 100% (other operating systems)
+      briefly and then loop.</p>
 </body>
 </html>

--- a/docs/fiddles/features/progress-bar/index.html
+++ b/docs/fiddles/features/progress-bar/index.html
@@ -12,7 +12,5 @@
     <p>For the next 5 seconds, on Windows, it should remain in an indeterminate state, while on
       Mac it should pin at 100%.</p>
     <p>Finally, it should disappear entirely.</p>
-
-    <button id="button">Set Indeterminate</button>
 </body>
 </html>

--- a/docs/fiddles/features/progress-bar/main.js
+++ b/docs/fiddles/features/progress-bar/main.js
@@ -3,10 +3,7 @@ const { app, BrowserWindow } = require('electron')
 function createWindow () {
   const win = new BrowserWindow({
     width: 800,
-    height: 600,
-    webPreferences: {
-      nodeIntegration: true
-    }
+    height: 600
   })
 
   win.loadFile('index.html')

--- a/docs/fiddles/features/progress-bar/main.js
+++ b/docs/fiddles/features/progress-bar/main.js
@@ -7,27 +7,24 @@ function createWindow () {
   })
 
   win.loadFile('index.html')
-  
-  const INCREMENT = 0.02;
-  const INTERVAL_DELAY = 100; //ms
-  let c = 0;
-  let interval = setInterval(() => {
-    
-    //update progress bar to next value
-    win.setProgressBar(c);
 
-    if(c > 1) {
-      //progress bar has reached full so reset it and stop the timer
-      win.setProgressBar(-1);
-      clearTimeout(interval);
+  const INCREMENT = 0.02
+  const INTERVAL_DELAY = 100 // ms
+  let c = 0
+  const interval = setInterval(() => {
+    // update progress bar to next value
+    win.setProgressBar(c)
+
+    if (c > 1) {
+      // progress bar has reached full so reset it and stop the timer
+      win.setProgressBar(-1)
+      clearTimeout(interval)
     }
-    c += INCREMENT;
-  }, INTERVAL_DELAY);
+    c += INCREMENT
+  }, INTERVAL_DELAY)
 }
 
-
 app.whenReady().then(createWindow)
-
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {

--- a/docs/fiddles/features/progress-bar/main.js
+++ b/docs/fiddles/features/progress-bar/main.js
@@ -15,8 +15,12 @@ function createWindow () {
   const INTERVAL_DELAY = 100; //ms
   let c = 0;
   let interval = setInterval(() => {
+    
+    //update progress bar to next value
     win.setProgressBar(c);
+
     if(c > 1) {
+      //progress bar has reached full so reset it and stop the timer
       win.setProgressBar(-1);
       clearTimeout(interval);
     }

--- a/docs/fiddles/features/progress-bar/main.js
+++ b/docs/fiddles/features/progress-bar/main.js
@@ -1,5 +1,7 @@
 const { app, BrowserWindow } = require('electron')
 
+let indeterminateTimeout, progressInterval
+
 function createWindow () {
   const win = new BrowserWindow({
     width: 800,
@@ -10,21 +12,35 @@ function createWindow () {
 
   const INCREMENT = 0.02
   const INTERVAL_DELAY = 100 // ms
+  const INDETERMINATE_PAUSE = 5000 // ms
+
   let c = 0
-  const interval = setInterval(() => {
+  progressInterval = setInterval(() => {
+    
     // update progress bar to next value
     win.setProgressBar(c)
 
-    if (c > 1) {
-      // progress bar has reached full so reset it and stop the timer
-      win.setProgressBar(-1)
-      clearTimeout(interval)
-    }
-    c += INCREMENT
+      if (c > 1) {
+        // set to indeterminate state
+        win.setProgressBar(2)
+        
+        // stop the interval
+        clearInterval(progressInterval)
+
+        // and after INDETERMINATE_PAUSE reset the progress bar
+        indeterminateTimeout = setTimeout(() => win.setProgressBar(-1), INDETERMINATE_PAUSE)
+      }
+      c += INCREMENT
   }, INTERVAL_DELAY)
 }
 
 app.whenReady().then(createWindow)
+
+// before the app is terminated, clear both timers
+app.on('before-quit', () => {
+  clearInterval(progressInterval)
+  clearTimeout(indeterminateTimeout)
+})
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {

--- a/docs/fiddles/features/progress-bar/main.js
+++ b/docs/fiddles/features/progress-bar/main.js
@@ -1,6 +1,6 @@
 const { app, BrowserWindow } = require('electron')
 
-let indeterminateTimeout, progressInterval
+let progressInterval
 
 function createWindow () {
   const win = new BrowserWindow({
@@ -10,26 +10,18 @@ function createWindow () {
 
   win.loadFile('index.html')
 
-  const INCREMENT = 0.02
+  const INCREMENT = 0.03
   const INTERVAL_DELAY = 100 // ms
-  const INDETERMINATE_PAUSE = 5000 // ms
 
   let c = 0
   progressInterval = setInterval(() => {
     // update progress bar to next value
+    // values between 0 and 1 will show progress, >1 will show indeterminate or stick at 100%
     win.setProgressBar(c)
-
-    if (c > 1) {
-      // set to indeterminate state
-      win.setProgressBar(2)
-
-      // stop the interval
-      clearInterval(progressInterval)
-
-      // and after INDETERMINATE_PAUSE reset the progress bar
-      indeterminateTimeout = setTimeout(() => win.setProgressBar(-1), INDETERMINATE_PAUSE)
-    }
-    c += INCREMENT
+    
+    // increment or reset progress bar
+    if (c < 2) c += INCREMENT
+    else c = 0
   }, INTERVAL_DELAY)
 }
 
@@ -38,7 +30,6 @@ app.whenReady().then(createWindow)
 // before the app is terminated, clear both timers
 app.on('before-quit', () => {
   clearInterval(progressInterval)
-  clearTimeout(indeterminateTimeout)
 })
 
 app.on('window-all-closed', () => {

--- a/docs/fiddles/features/progress-bar/main.js
+++ b/docs/fiddles/features/progress-bar/main.js
@@ -16,21 +16,20 @@ function createWindow () {
 
   let c = 0
   progressInterval = setInterval(() => {
-    
     // update progress bar to next value
     win.setProgressBar(c)
 
-      if (c > 1) {
-        // set to indeterminate state
-        win.setProgressBar(2)
-        
-        // stop the interval
-        clearInterval(progressInterval)
+    if (c > 1) {
+      // set to indeterminate state
+      win.setProgressBar(2)
 
-        // and after INDETERMINATE_PAUSE reset the progress bar
-        indeterminateTimeout = setTimeout(() => win.setProgressBar(-1), INDETERMINATE_PAUSE)
-      }
-      c += INCREMENT
+      // stop the interval
+      clearInterval(progressInterval)
+
+      // and after INDETERMINATE_PAUSE reset the progress bar
+      indeterminateTimeout = setTimeout(() => win.setProgressBar(-1), INDETERMINATE_PAUSE)
+    }
+    c += INCREMENT
   }, INTERVAL_DELAY)
 }
 

--- a/docs/fiddles/features/progress-bar/main.js
+++ b/docs/fiddles/features/progress-bar/main.js
@@ -10,7 +10,18 @@ function createWindow () {
   })
 
   win.loadFile('index.html')
-  win.setProgressBar(0.5)
+  
+  const INCREMENT = 0.02;
+  const INTERVAL_DELAY = 100; //ms
+  let c = 0;
+  let interval = setInterval(() => {
+    win.setProgressBar(c);
+    if(c > 1) {
+      win.setProgressBar(-1);
+      clearTimeout(interval);
+    }
+    c += INCREMENT;
+  }, INTERVAL_DELAY);
 }
 
 

--- a/docs/fiddles/features/progress-bar/main.js
+++ b/docs/fiddles/features/progress-bar/main.js
@@ -18,10 +18,13 @@ function createWindow () {
     // update progress bar to next value
     // values between 0 and 1 will show progress, >1 will show indeterminate or stick at 100%
     win.setProgressBar(c)
-    
+
     // increment or reset progress bar
-    if (c < 2) c += INCREMENT
-    else c = 0
+    if (c < 2) {
+      c += INCREMENT
+    } else {
+      c = (-INCREMENT * 5) // reset to a bit less than 0 to show reset state
+    }
   }, INTERVAL_DELAY)
 }
 

--- a/docs/tutorial/progress-bar.md
+++ b/docs/tutorial/progress-bar.md
@@ -40,31 +40,50 @@ See the [API documentation for more options and modes][setprogressbar].
 
 ## Example
 
-Add the following lines to the
-`main.js` file:
+Make the following updates to the `main.js` file.
+
+First, add the following declaration line to the top of the file (above the
+`createWindow` function)...
+```
+let indeterminateTimeout, progressInterval
+```
+
+Next, add the following code _inside_ the `createWindow` function just after the call
+to `loadFile`...
 
 ```javascript fiddle='docs/fiddles/features/progress-bar'
-const { BrowserWindow } = require('electron')
-const win = new BrowserWindow()
+  const INCREMENT = 0.02
+  const INTERVAL_DELAY = 100 // ms
+  const INDETERMINATE_PAUSE = 5000 // ms
 
-const INCREMENT = 0.02
-const INTERVAL_DELAY = 100 // ms
-let c = 0
-
-// create an interval timer that fires every INTERVAL_DELAY
-// see docs at https://nodejs.org/api/timers.html#timers_setinterval_callback_delay_args
-const interval = setInterval(() => {
+  let c = 0
+  progressInterval = setInterval(() => {
+    
     // update progress bar to next value
     win.setProgressBar(c)
 
-    if (c > 1) {
-        // progress bar has reached full so reset it and stop the timer
-        win.setProgressBar(-1)
-        clearTimeout(interval)
-    }
-    c += INCREMENT
-}, INTERVAL_DELAY)
+      if (c > 1) {
+        // set to indeterminate state
+        win.setProgressBar(2)
+        
+        // stop the interval
+        clearInterval(progressInterval)
 
+        // and after INDETERMINATE_PAUSE reset the progress bar
+        indeterminateTimeout = setTimeout(() => win.setProgressBar(-1), INDETERMINATE_PAUSE)
+      }
+      c += INCREMENT
+  }, INTERVAL_DELAY)
+```
+
+And finally, add this function _after_ the `createWindow` function...
+
+```
+// before the app is terminated, clear both timers
+app.on('before-quit', () => {
+  clearInterval(progressInterval)
+  clearTimeout(indeterminateTimeout)
+})
 ```
 
 After launching the Electron application, the dock (macOS) or taskbar (Windows, Unity)

--- a/docs/tutorial/progress-bar.md
+++ b/docs/tutorial/progress-bar.md
@@ -45,7 +45,7 @@ Replace the entire contents of your `main.js` file with...
 ```javascript fiddle='docs/fiddles/features/progress-bar'
 const { app, BrowserWindow } = require('electron')
 
-let indeterminateTimeout, progressInterval
+let progressInterval
 
 function createWindow () {
   const win = new BrowserWindow({
@@ -55,26 +55,18 @@ function createWindow () {
 
   win.loadFile('index.html')
 
-  const INCREMENT = 0.02
+  const INCREMENT = 0.03
   const INTERVAL_DELAY = 100 // ms
-  const INDETERMINATE_PAUSE = 5000 // ms
 
   let c = 0
   progressInterval = setInterval(() => {
     // update progress bar to next value
+    // values between 0 and 1 will show progress, >1 will show indeterminate or stick at 100%
     win.setProgressBar(c)
-
-    if (c > 1) {
-      // set to indeterminate state
-      win.setProgressBar(2)
-
-      // stop the interval
-      clearInterval(progressInterval)
-
-      // and after INDETERMINATE_PAUSE reset the progress bar
-      indeterminateTimeout = setTimeout(() => win.setProgressBar(-1), INDETERMINATE_PAUSE)
-    }
-    c += INCREMENT
+    
+    // increment or reset progress bar
+    if (c < 2) c += INCREMENT
+    else c = 0
   }, INTERVAL_DELAY)
 }
 
@@ -83,7 +75,6 @@ app.whenReady().then(createWindow)
 // before the app is terminated, clear both timers
 app.on('before-quit', () => {
   clearInterval(progressInterval)
-  clearTimeout(indeterminateTimeout)
 })
 
 app.on('window-all-closed', () => {
@@ -101,6 +92,8 @@ app.on('activate', () => {
 
 After launching the Electron application, the dock (macOS) or taskbar (Windows, Unity)
 should show a progress bar that starts at zero and progresses through 100% to completion.
+It should then show indeterminate (Windows) or pin to 100% (other operating systems)
+briefly and then loop.
 
 ![macOS dock progress bar](../images/dock-progress-bar.png)
 

--- a/docs/tutorial/progress-bar.md
+++ b/docs/tutorial/progress-bar.md
@@ -40,7 +40,8 @@ See the [API documentation for more options and modes][setprogressbar].
 
 ## Example
 
-Replace the entire contents of your `main.js` file with...
+In this example, we add a progress bar to the main window that increments over time
+using Node.js timers.
 
 ```javascript fiddle='docs/fiddles/features/progress-bar'
 const { app, BrowserWindow } = require('electron')

--- a/docs/tutorial/progress-bar.md
+++ b/docs/tutorial/progress-bar.md
@@ -64,7 +64,7 @@ function createWindow () {
     // update progress bar to next value
     // values between 0 and 1 will show progress, >1 will show indeterminate or stick at 100%
     win.setProgressBar(c)
-    
+
     // increment or reset progress bar
     if (c < 2) c += INCREMENT
     else c = 0

--- a/docs/tutorial/progress-bar.md
+++ b/docs/tutorial/progress-bar.md
@@ -31,7 +31,10 @@ currently at 63% towards completion, you would call it as
 `setProgressBar(0.63)`.
 
 Setting the parameter to negative values (e.g. `-1`) will remove the progress
-bar. Setting it to a value greater than `1` will indicate an indeterminate progress bar in Windows or clamp to 100% in other operating systems. An indeterminate progress bar remains active but does not show an actual percentage, and is used for situations when you do not know how long an operation will take to complete.
+bar. Setting it to a value greater than `1` will indicate an indeterminate progress bar
+in Windows or clamp to 100% in other operating systems. An indeterminate progress bar
+remains active but does not show an actual percentage, and is used for situations when
+you do not know how long an operation will take to complete.
 
 See the [API documentation for more options and modes][setprogressbar].
 
@@ -63,7 +66,8 @@ let interval = setInterval(() => {
 
 ```
 
-After launching the Electron application, the dock (macOS) or taskbar (Windows, Unity) should show a progress bar that starts at zero and progresses through 100% to completion.
+After launching the Electron application, the dock (macOS) or taskbar (Windows, Unity)
+should show a progress bar that starts at zero and progresses through 100% to completion.
 
 ![macOS dock progress bar](../images/dock-progress-bar.png)
 

--- a/docs/tutorial/progress-bar.md
+++ b/docs/tutorial/progress-bar.md
@@ -31,11 +31,7 @@ currently at 63% towards completion, you would call it as
 `setProgressBar(0.63)`.
 
 Setting the parameter to negative values (e.g. `-1`) will remove the progress
-bar, whereas setting it to values greater than `1` (e.g. `2`) will switch the
-progress bar to indeterminate mode (Windows-only -- it will clamp to 100%
-otherwise). In this mode, a progress bar remains active but does not show an
-actual percentage. Use this mode for situations when you do not know how long
-an operation will take to complete.
+bar. Setting it to a value greater than `1` will indicate an indeterminate progress bar in Windows or clamp to 100% in other operating systems. An indeterminate progress bar remains active but does not show an actual percentage, and is used for situations when you do not know how long an operation will take to complete.
 
 See the [API documentation for more options and modes][setprogressbar].
 
@@ -67,9 +63,7 @@ let interval = setInterval(() => {
 
 ```
 
-After launching the Electron application, you should see the bar in
-the dock (macOS) or taskbar (Windows, Unity), indicating the progress
-percentage you just defined.
+After launching the Electron application, the dock (macOS) or taskbar (Windows, Unity) should show a progress bar that starts at zero and progresses through 100% to completion.
 
 ![macOS dock progress bar](../images/dock-progress-bar.png)
 

--- a/docs/tutorial/progress-bar.md
+++ b/docs/tutorial/progress-bar.md
@@ -49,7 +49,22 @@ Starting with a working application from the
 const { BrowserWindow } = require('electron')
 const win = new BrowserWindow()
 
-win.setProgressBar(0.5)
+const INCREMENT = 0.02;
+const INTERVAL_DELAY = 100; //ms
+let c = 0;
+let interval = setInterval(() => {
+
+    //update progress bar to next value
+    win.setProgressBar(c);
+
+    if(c > 1) {
+        //progress bar has reached full so reset it and stop the timer
+        win.setProgressBar(-1);
+        clearTimeout(interval);
+    }
+    c += INCREMENT;
+}, INTERVAL_DELAY);
+
 ```
 
 After launching the Electron application, you should see the bar in

--- a/docs/tutorial/progress-bar.md
+++ b/docs/tutorial/progress-bar.md
@@ -40,49 +40,62 @@ See the [API documentation for more options and modes][setprogressbar].
 
 ## Example
 
-Make the following updates to the `main.js` file.
-
-First, add the following declaration line to the top of the file (above the
-`createWindow` function)...
-```
-let indeterminateTimeout, progressInterval
-```
-
-Next, add the following code _inside_ the `createWindow` function just after the call
-to `loadFile`...
+Replace the entire contents of your `main.js` file with...
 
 ```javascript fiddle='docs/fiddles/features/progress-bar'
+const { app, BrowserWindow } = require('electron')
+
+let indeterminateTimeout, progressInterval
+
+function createWindow () {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600
+  })
+
+  win.loadFile('index.html')
+
   const INCREMENT = 0.02
   const INTERVAL_DELAY = 100 // ms
   const INDETERMINATE_PAUSE = 5000 // ms
 
   let c = 0
   progressInterval = setInterval(() => {
-    
     // update progress bar to next value
     win.setProgressBar(c)
 
-      if (c > 1) {
-        // set to indeterminate state
-        win.setProgressBar(2)
-        
-        // stop the interval
-        clearInterval(progressInterval)
+    if (c > 1) {
+      // set to indeterminate state
+      win.setProgressBar(2)
 
-        // and after INDETERMINATE_PAUSE reset the progress bar
-        indeterminateTimeout = setTimeout(() => win.setProgressBar(-1), INDETERMINATE_PAUSE)
-      }
-      c += INCREMENT
+      // stop the interval
+      clearInterval(progressInterval)
+
+      // and after INDETERMINATE_PAUSE reset the progress bar
+      indeterminateTimeout = setTimeout(() => win.setProgressBar(-1), INDETERMINATE_PAUSE)
+    }
+    c += INCREMENT
   }, INTERVAL_DELAY)
-```
+}
 
-And finally, add this function _after_ the `createWindow` function...
+app.whenReady().then(createWindow)
 
-```
 // before the app is terminated, clear both timers
 app.on('before-quit', () => {
   clearInterval(progressInterval)
   clearTimeout(indeterminateTimeout)
+})
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit()
+  }
+})
+
+app.on('activate', () => {
+  if (BrowserWindow.getAllWindows().length === 0) {
+    createWindow()
+  }
 })
 ```
 

--- a/docs/tutorial/progress-bar.md
+++ b/docs/tutorial/progress-bar.md
@@ -40,29 +40,30 @@ See the [API documentation for more options and modes][setprogressbar].
 
 ## Example
 
-Starting with a working application from the
-[Quick Start Guide](quick-start.md), add the following lines to the
+Add the following lines to the
 `main.js` file:
 
 ```javascript fiddle='docs/fiddles/features/progress-bar'
 const { BrowserWindow } = require('electron')
 const win = new BrowserWindow()
 
-const INCREMENT = 0.02;
-const INTERVAL_DELAY = 100; //ms
-let c = 0;
-let interval = setInterval(() => {
+const INCREMENT = 0.02
+const INTERVAL_DELAY = 100 // ms
+let c = 0
 
-    //update progress bar to next value
-    win.setProgressBar(c);
+// create an interval timer that fires every INTERVAL_DELAY
+// see docs at https://nodejs.org/api/timers.html#timers_setinterval_callback_delay_args
+const interval = setInterval(() => {
+    // update progress bar to next value
+    win.setProgressBar(c)
 
-    if(c > 1) {
-        //progress bar has reached full so reset it and stop the timer
-        win.setProgressBar(-1);
-        clearTimeout(interval);
+    if (c > 1) {
+        // progress bar has reached full so reset it and stop the timer
+        win.setProgressBar(-1)
+        clearTimeout(interval)
     }
-    c += INCREMENT;
-}, INTERVAL_DELAY);
+    c += INCREMENT
+}, INTERVAL_DELAY)
 
 ```
 


### PR DESCRIPTION
#### Description of Change
Updated the `progress-bar` fiddle feature. Improved the sample by adding a little bit of logic to progress the bar through 100% to show not only the behavior of the bar set to an intermediate state, but also set to `-1` to reset.
Updated the tutorial page too to reflect the changes to the fiddle  and improved some of the language.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
