### PR TITLE
fix: get subframes directly rather than from main frame

### DIFF
--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -362,6 +362,18 @@ content::FindRequestManager* WebFrameMain::GetOrCreateFindRequestManager() {
   }
   // Concurrent find sessions must not overlap, so destroy any existing
   // FindRequestManagers in any inner WebFrameMain.
+  // First check parent frames.
+  auto* rfh = render_frame_->GetParent();
+  while (rfh) {
+    auto* web_frame_main = FromRenderFrameHost(rfh);
+    if (web_frame_main && web_frame_main->find_request_manager_) {
+      web_frame_main->find_request_manager_->StopFinding(
+          content::STOP_FIND_ACTION_CLEAR_SELECTION);
+      web_frame_main->find_request_manager_.release();
+    }
+    rfh = rfh->GetParent();
+  }
+  // Now check child frames.
   for (content::RenderFrameHost* rfh : render_frame_->GetFramesInSubtree()) {
     if (rfh == render_frame_)
       continue;

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -362,8 +362,7 @@ content::FindRequestManager* WebFrameMain::GetOrCreateFindRequestManager() {
   }
   // Concurrent find sessions must not overlap, so destroy any existing
   // FindRequestManagers in any inner WebFrameMain.
-  for (content::RenderFrameHost* rfh :
-       render_frame_->GetMainFrame()->GetFramesInSubtree()) {
+  for (content::RenderFrameHost* rfh : render_frame_->GetFramesInSubtree()) {
     if (rfh == render_frame_)
       continue;
     auto* web_frame_main = FromRenderFrameHost(rfh);


### PR DESCRIPTION
#### Description of Change

This change fixes the test case where a concurrent search in two iframes cannot occur.

CC @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
