### PR TITLE
feat: enable window controls overlay on macOS

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -219,12 +219,14 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       bar.
     * `hidden` - Results in a hidden title bar and a full size content window, yet
       the title bar still has the standard window controls ("traffic lights") in
-      the top left.  Using this value will also enable the Window Controls Overlay
+      the top left.  If `enableBlinkFeatures: 'WebAppWindowControlsOverlay'` is set,
+      using this value will also enable the Window Controls Overlay
       [JavaScript APIs][overlay-javascript-apis] and
       [CSS Environment Variables][overlay-css-env-vars].
     * `hiddenInset` - Results in a hidden title bar with an alternative look
       where the traffic light buttons are slightly more inset from the window edge.
-      Using this value will also enable the Window Controls Overlay
+      If `enableBlinkFeatures: 'WebAppWindowControlsOverlay'` is set, using this
+      value will also enable the Window Controls Overlay
       [JavaScript APIs][overlay-javascript-apis] and
       [CSS Environment Variables][overlay-css-env-vars].
     * `customButtonsOnHover` - Results in a hidden title bar and a full size

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -219,9 +219,14 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       bar.
     * `hidden` - Results in a hidden title bar and a full size content window, yet
       the title bar still has the standard window controls ("traffic lights") in
-      the top left.
+      the top left.  Using this value will also enable the Window Controls Overlay
+      [JavaScript APIs][overlay-javascript-apis] and
+      [CSS Environment Variables][overlay-css-env-vars].
     * `hiddenInset` - Results in a hidden title bar with an alternative look
       where the traffic light buttons are slightly more inset from the window edge.
+      Using this value will also enable the Window Controls Overlay
+      [JavaScript APIs][overlay-javascript-apis] and
+      [CSS Environment Variables][overlay-css-env-vars].
     * `customButtonsOnHover` - Results in a hidden title bar and a full size
       content window, the traffic light buttons will display when being hovered
       over in the top left of the window.  **Note:** This option is currently
@@ -1815,3 +1820,5 @@ removed in future Electron releases.
 [window-levels]: https://developer.apple.com/documentation/appkit/nswindow/level
 [chrome-content-scripts]: https://developer.chrome.com/extensions/content_scripts#execution-environment
 [event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter
+[overlay-javascript-apis]: https://github.com/WICG/window-controls-overlay/blob/main/explainer.md#javascript-apis
+[overlay-css-env-vars]: https://github.com/WICG/window-controls-overlay/blob/main/explainer.md#css-environment-variables

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -219,13 +219,14 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       bar.
     * `hidden` - Results in a hidden title bar and a full size content window, yet
       the title bar still has the standard window controls ("traffic lights") in
-      the top left.
+      the top left.  If `enableBlinkFeatures: 'WebAppWindowControlsOverlay'` is set,
+      using this value will also enable the Window Controls Overlay
+      [JavaScript APIs][overlay-javascript-apis] and
+      [CSS Environment Variables][overlay-css-env-vars].
     * `hiddenInset` - Results in a hidden title bar with an alternative look
       where the traffic light buttons are slightly more inset from the window edge.
-    * `overlay` - Results in a hidden title bar and a full size content window, yet
-       the title bar still has the standard window controls ("traffic lights" on macOS).
-       If `enableBlinkFeatures: 'WebAppWindowControlsOverlay'` is set,
-      using this value will also enable the Window Controls Overlay
+      If `enableBlinkFeatures: 'WebAppWindowControlsOverlay'` is set, using this
+      value will also enable the Window Controls Overlay
       [JavaScript APIs][overlay-javascript-apis] and
       [CSS Environment Variables][overlay-css-env-vars].
     * `customButtonsOnHover` - Results in a hidden title bar and a full size

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -219,16 +219,9 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       bar.
     * `hidden` - Results in a hidden title bar and a full size content window, yet
       the title bar still has the standard window controls ("traffic lights") in
-      the top left.  If `enableBlinkFeatures: 'WebAppWindowControlsOverlay'` is set,
-      using this value will also enable the Window Controls Overlay
-      [JavaScript APIs][overlay-javascript-apis] and
-      [CSS Environment Variables][overlay-css-env-vars].
+      the top left.
     * `hiddenInset` - Results in a hidden title bar with an alternative look
       where the traffic light buttons are slightly more inset from the window edge.
-      If `enableBlinkFeatures: 'WebAppWindowControlsOverlay'` is set, using this
-      value will also enable the Window Controls Overlay
-      [JavaScript APIs][overlay-javascript-apis] and
-      [CSS Environment Variables][overlay-css-env-vars].
     * `customButtonsOnHover` - Results in a hidden title bar and a full size
       content window, the traffic light buttons will display when being hovered
       over in the top left of the window.  **Note:** This option is currently
@@ -399,6 +392,10 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       contain the layout of the document—without requiring scrolling. Enabling
       this will cause the `preferred-size-changed` event to be emitted on the
       `WebContents` when the preferred size changes. Default is `false`.
+  * `titleBarOverlay` Boolean (optional) -  On macOS, when using a frameless window in conjunction with
+    `win.setWindowButtonVisibility(true)` or using a `titleBarStyle` so that the traffic lights are visibile,
+    this property enables the Window Controls Overlay [JavaScript APIs][overlay-javascript-apis] and
+    [CSS Environment Variables][overlay-css-env-vars].  Default is `false`.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -393,7 +393,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       this will cause the `preferred-size-changed` event to be emitted on the
       `WebContents` when the preferred size changes. Default is `false`.
   * `titleBarOverlay` Boolean (optional) -  On macOS, when using a frameless window in conjunction with
-    `win.setWindowButtonVisibility(true)` or using a `titleBarStyle` so that the traffic lights are visibile,
+    `win.setWindowButtonVisibility(true)` or using a `titleBarStyle` so that the traffic lights are visible,
     this property enables the Window Controls Overlay [JavaScript APIs][overlay-javascript-apis] and
     [CSS Environment Variables][overlay-css-env-vars].  Default is `false`.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -219,14 +219,13 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       bar.
     * `hidden` - Results in a hidden title bar and a full size content window, yet
       the title bar still has the standard window controls ("traffic lights") in
-      the top left.  If `enableBlinkFeatures: 'WebAppWindowControlsOverlay'` is set,
-      using this value will also enable the Window Controls Overlay
-      [JavaScript APIs][overlay-javascript-apis] and
-      [CSS Environment Variables][overlay-css-env-vars].
+      the top left.
     * `hiddenInset` - Results in a hidden title bar with an alternative look
       where the traffic light buttons are slightly more inset from the window edge.
-      If `enableBlinkFeatures: 'WebAppWindowControlsOverlay'` is set, using this
-      value will also enable the Window Controls Overlay
+    * `overlay` - Results in a hidden title bar and a full size content window, yet
+       the title bar still has the standard window controls ("traffic lights" on macOS).
+       If `enableBlinkFeatures: 'WebAppWindowControlsOverlay'` is set,
+      using this value will also enable the Window Controls Overlay
       [JavaScript APIs][overlay-javascript-apis] and
       [CSS Environment Variables][overlay-css-env-vars].
     * `customButtonsOnHover` - Results in a hidden title bar and a full size

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -29,8 +29,6 @@ You can do so by specifying the `titleBarStyle` option:
 #### `hidden`
 
 Results in a hidden title bar and a full size content window, yet the title bar still has the standard window controls (“traffic lights”) in the top left.
-Additionally, if `enableBlinkFeatures: 'WebAppWindowControlsOverlay'` is set, the Window Controls Overlay [JavaScript APIs][overlay-javascript-apis] and
-[CSS Environment Variables][overlay-css-env-vars] will be enabled.
 
 ```javascript
 const { BrowserWindow } = require('electron')
@@ -41,8 +39,6 @@ win.show()
 #### `hiddenInset`
 
 Results in a hidden title bar with an alternative look where the traffic light buttons are slightly more inset from the window edge.
-Additionally, if `enableBlinkFeatures: 'WebAppWindowControlsOverlay'` is set, the Window Controls Overlay
-[JavaScript APIs][overlay-javascript-apis] and [CSS Environment Variables][overlay-css-env-vars] will be enabled.
 
 ```javascript
 const { BrowserWindow } = require('electron')
@@ -64,6 +60,13 @@ const { BrowserWindow } = require('electron')
 const win = new BrowserWindow({ titleBarStyle: 'customButtonsOnHover', frame: false })
 win.show()
 ```
+
+## Windows Control Overlay
+
+On macOS, when using a frameless window in conjuction with `win.setWindowButtonVisibility(true)` or using one of the `titleBarStyle`s described above so
+that the traffic lights are visibile, you can access the Window Controls Overlay [JavaScript APIs][overlay-javascript-apis] and
+[CSS Environment Variables][overlay-css-env-vars] by setting the blink feature `'WebAppWindowControlsOverlay`
+(eg `enableBlinkFeatures: 'WebAppWindowControlsOverlay'`).
 
 ## Transparent window
 

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -29,6 +29,7 @@ You can do so by specifying the `titleBarStyle` option:
 #### `hidden`
 
 Results in a hidden title bar and a full size content window, yet the title bar still has the standard window controls (“traffic lights”) in the top left.
+Additionally the Window Controls Overlay [JavaScript APIs][overlay-javascript-apis] and [CSS Environment Variables][overlay-css-env-vars] will be enabled.
 
 ```javascript
 const { BrowserWindow } = require('electron')
@@ -39,6 +40,7 @@ win.show()
 #### `hiddenInset`
 
 Results in a hidden title bar with an alternative look where the traffic light buttons are slightly more inset from the window edge.
+Additionally the Window Controls Overlay [JavaScript APIs][overlay-javascript-apis] and [CSS Environment Variables][overlay-css-env-vars] will be enabled.
 
 ```javascript
 const { BrowserWindow } = require('electron')
@@ -186,3 +188,5 @@ behave correctly on all platforms you should never use a custom context menu on
 draggable areas.
 
 [ignore-mouse-events]: browser-window.md#winsetignoremouseeventsignore-options
+[overlay-javascript-apis]: https://github.com/WICG/window-controls-overlay/blob/main/explainer.md#javascript-apis
+[overlay-css-env-vars]: https://github.com/WICG/window-controls-overlay/blob/main/explainer.md#css-environment-variables

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -29,7 +29,8 @@ You can do so by specifying the `titleBarStyle` option:
 #### `hidden`
 
 Results in a hidden title bar and a full size content window, yet the title bar still has the standard window controls (“traffic lights”) in the top left.
-Additionally the Window Controls Overlay [JavaScript APIs][overlay-javascript-apis] and [CSS Environment Variables][overlay-css-env-vars] will be enabled.
+Additionally, if `enableBlinkFeatures: 'WebAppWindowControlsOverlay'` is set, the Window Controls Overlay [JavaScript APIs][overlay-javascript-apis] and
+[CSS Environment Variables][overlay-css-env-vars] will be enabled.
 
 ```javascript
 const { BrowserWindow } = require('electron')
@@ -40,7 +41,8 @@ win.show()
 #### `hiddenInset`
 
 Results in a hidden title bar with an alternative look where the traffic light buttons are slightly more inset from the window edge.
-Additionally the Window Controls Overlay [JavaScript APIs][overlay-javascript-apis] and [CSS Environment Variables][overlay-css-env-vars] will be enabled.
+Additionally, if `enableBlinkFeatures: 'WebAppWindowControlsOverlay'` is set, the Window Controls Overlay
+[JavaScript APIs][overlay-javascript-apis] and [CSS Environment Variables][overlay-css-env-vars] will be enabled.
 
 ```javascript
 const { BrowserWindow } = require('electron')

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -65,8 +65,13 @@ win.show()
 
 On macOS, when using a frameless window in conjuction with `win.setWindowButtonVisibility(true)` or using one of the `titleBarStyle`s described above so
 that the traffic lights are visibile, you can access the Window Controls Overlay [JavaScript APIs][overlay-javascript-apis] and
-[CSS Environment Variables][overlay-css-env-vars] by setting the blink feature `'WebAppWindowControlsOverlay`
-(eg `enableBlinkFeatures: 'WebAppWindowControlsOverlay'`).
+[CSS Environment Variables][overlay-css-env-vars] by setting the `titleBarOverlay` option to true:
+
+```javascript
+const { BrowserWindow } = require('electron')
+const win = new BrowserWindow({ titleBarStyle: 'hiddenInset', titleBarOverlay: true })
+win.show()
+```
 
 ## Transparent window
 

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -64,7 +64,7 @@ win.show()
 ## Windows Control Overlay
 
 On macOS, when using a frameless window in conjuction with `win.setWindowButtonVisibility(true)` or using one of the `titleBarStyle`s described above so
-that the traffic lights are visibile, you can access the Window Controls Overlay [JavaScript APIs][overlay-javascript-apis] and
+that the traffic lights are visible, you can access the Window Controls Overlay [JavaScript APIs][overlay-javascript-apis] and
 [CSS Environment Variables][overlay-css-env-vars] by setting the `titleBarOverlay` option to true:
 
 ```javascript

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -69,7 +69,10 @@ that the traffic lights are visible, you can access the Window Controls Overlay 
 
 ```javascript
 const { BrowserWindow } = require('electron')
-const win = new BrowserWindow({ titleBarStyle: 'hiddenInset', titleBarOverlay: true })
+const win = new BrowserWindow({
+  titleBarStyle: 'hiddenInset',
+  titleBarOverlay: true
+})
 win.show()
 ```
 

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -61,12 +61,15 @@ const win = new BrowserWindow({ titleBarStyle: 'customButtonsOnHover', frame: fa
 win.show()
 ```
 
-## Windows Control Overlay
+#### `overlay`
 
-On macOS, when using a frameless window in conjuction with `win.setWindowButtonVisibility(true)` or using one of the `titleBarStyle`s described above so
-that the traffic lights are visibile, you can access the Window Controls Overlay [JavaScript APIs][overlay-javascript-apis] and
-[CSS Environment Variables][overlay-css-env-vars] by setting the blink feature `'WebAppWindowControlsOverlay`
-(eg `enableBlinkFeatures: 'WebAppWindowControlsOverlay'`).
+Results in a hidden title bar and a full size content window, yet the title bar still has the standard window controls ("traffic lights" on macOS). These controls are in the top left on macOS and top right for Windows.  If `enableBlinkFeatures: 'WebAppWindowControlsOverlay'` is set, using this value will also enable the Window Controls Overlay [JavaScript APIs][overlay-javascript-apis] and [CSS Environment Variables][overlay-css-env-vars].
+
+```javascript
+const { BrowserWindow } = require('electron')
+const win = new BrowserWindow({ titleBarStyle: 'overlay' })
+win.show()
+```
 
 ## Transparent window
 

--- a/docs/api/frameless-window.md
+++ b/docs/api/frameless-window.md
@@ -61,15 +61,12 @@ const win = new BrowserWindow({ titleBarStyle: 'customButtonsOnHover', frame: fa
 win.show()
 ```
 
-#### `overlay`
+## Windows Control Overlay
 
-Results in a hidden title bar and a full size content window, yet the title bar still has the standard window controls ("traffic lights" on macOS). These controls are in the top left on macOS and top right for Windows.  If `enableBlinkFeatures: 'WebAppWindowControlsOverlay'` is set, using this value will also enable the Window Controls Overlay [JavaScript APIs][overlay-javascript-apis] and [CSS Environment Variables][overlay-css-env-vars].
-
-```javascript
-const { BrowserWindow } = require('electron')
-const win = new BrowserWindow({ titleBarStyle: 'overlay' })
-win.show()
-```
+On macOS, when using a frameless window in conjuction with `win.setWindowButtonVisibility(true)` or using one of the `titleBarStyle`s described above so
+that the traffic lights are visibile, you can access the Window Controls Overlay [JavaScript APIs][overlay-javascript-apis] and
+[CSS Environment Variables][overlay-css-env-vars] by setting the blink feature `'WebAppWindowControlsOverlay`
+(eg `enableBlinkFeatures: 'WebAppWindowControlsOverlay'`).
 
 ## Transparent window
 

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -312,6 +312,10 @@ void BrowserWindow::OnWindowLeaveFullScreen() {
   BaseWindow::OnWindowLeaveFullScreen();
 }
 
+void BrowserWindow::UpdateWindowControlsOverlay(gfx::Rect bounding_rect) {
+  web_contents()->UpdateWindowControlsOverlay(bounding_rect);
+}
+
 void BrowserWindow::CloseImmediately() {
   // Close all child windows before closing current window.
   v8::Locker locker(isolate());

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -312,7 +312,8 @@ void BrowserWindow::OnWindowLeaveFullScreen() {
   BaseWindow::OnWindowLeaveFullScreen();
 }
 
-void BrowserWindow::UpdateWindowControlsOverlay(gfx::Rect bounding_rect) {
+void BrowserWindow::UpdateWindowControlsOverlay(
+    const gfx::Rect& bounding_rect) {
   web_contents()->UpdateWindowControlsOverlay(bounding_rect);
 }
 

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -57,6 +57,17 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
     web_preferences.Set(options::kShow, show);
   }
 
+  bool titleBarOverlay = false;
+  options.Get(options::ktitleBarOverlay, &titleBarOverlay);
+  if (titleBarOverlay) {
+    std::string enabled_features = "";
+    if (web_preferences.Get(options::kEnableBlinkFeatures, &enabled_features)) {
+      enabled_features += ",";
+    }
+    enabled_features += "WebAppWindowControlsOverlay";
+    web_preferences.Set(options::kEnableBlinkFeatures, enabled_features);
+  }
+
   // Copy the webContents option to webPreferences. This is only used internally
   // to implement nativeWindowOpen option.
   if (options.Get("webContents", &value)) {

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -64,7 +64,7 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
     if (web_preferences.Get(options::kEnableBlinkFeatures, &enabled_features)) {
       enabled_features += ",";
     }
-    enabled_features += "WebAppWindowControlsOverlay";
+    enabled_features += kWebAppWindowControlsOverlay.name;
     web_preferences.Set(options::kEnableBlinkFeatures, enabled_features);
   }
 

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -64,7 +64,7 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
     if (web_preferences.Get(options::kEnableBlinkFeatures, &enabled_features)) {
       enabled_features += ",";
     }
-    enabled_features += kWebAppWindowControlsOverlay.name;
+    enabled_features += features::kWebAppWindowControlsOverlay.name;
     web_preferences.Set(options::kEnableBlinkFeatures, enabled_features);
   }
 

--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -71,7 +71,7 @@ class BrowserWindow : public BaseWindow,
   void RequestPreferredWidth(int* width) override;
   void OnCloseButtonClicked(bool* prevent_default) override;
   void OnWindowIsKeyChanged(bool is_key) override;
-  void UpdateWindowControlsOverlay(const gfx::Rect bounding_rect) override;
+  void UpdateWindowControlsOverlay(const gfx::Rect& bounding_rect) override;
 
   // BaseWindow:
   void OnWindowBlur() override;

--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -71,6 +71,7 @@ class BrowserWindow : public BaseWindow,
   void RequestPreferredWidth(int* width) override;
   void OnCloseButtonClicked(bool* prevent_default) override;
   void OnWindowIsKeyChanged(bool is_key) override;
+  void UpdateWindowControlsOverlay(gfx::Rect bounding_rect) override;
 
   // BaseWindow:
   void OnWindowBlur() override;

--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -71,7 +71,7 @@ class BrowserWindow : public BaseWindow,
   void RequestPreferredWidth(int* width) override;
   void OnCloseButtonClicked(bool* prevent_default) override;
   void OnWindowIsKeyChanged(bool is_key) override;
-  void UpdateWindowControlsOverlay(gfx::Rect bounding_rect) override;
+  void UpdateWindowControlsOverlay(const gfx::Rect bounding_rect) override;
 
   // BaseWindow:
   void OnWindowBlur() override;

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1677,6 +1677,10 @@ void WebContents::ReadyToCommitNavigation(
 
 void WebContents::DidFinishNavigation(
     content::NavigationHandle* navigation_handle) {
+  if (owner_window_) {
+    owner_window_->NotifyLayoutWindowControlsOverlay();
+  }
+
   if (!navigation_handle->HasCommitted())
     return;
   bool is_main_frame = navigation_handle->IsInMainFrame();

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -394,6 +394,14 @@ void NativeWindow::PreviewFile(const std::string& path,
 
 void NativeWindow::CloseFilePreview() {}
 
+gfx::Rect NativeWindow::GetWindowControlsOverlayRect() {
+  return overlay_rect_;
+}
+
+void NativeWindow::SetWindowControlsOverlayRect(const gfx::Rect& overlay_rect) {
+  overlay_rect_ = overlay_rect;
+}
+
 void NativeWindow::NotifyWindowRequestPreferredWith(int* width) {
   for (NativeWindowObserver& observer : observers_)
     observer.RequestPreferredWidth(width);
@@ -493,6 +501,7 @@ void NativeWindow::NotifyWindowWillMove(const gfx::Rect& new_bounds,
 }
 
 void NativeWindow::NotifyWindowResize() {
+  NotifyLayoutWindowControlsOverlay();
   for (NativeWindowObserver& observer : observers_)
     observer.OnWindowResize();
 }
@@ -589,6 +598,14 @@ void NativeWindow::NotifyWindowSystemContextMenu(int x,
                                                  bool* prevent_default) {
   for (NativeWindowObserver& observer : observers_)
     observer.OnSystemContextMenu(x, y, prevent_default);
+}
+
+void NativeWindow::NotifyLayoutWindowControlsOverlay() {
+  gfx::Rect bounding_rect = GetWindowControlsOverlayRect();
+  if (!bounding_rect.IsEmpty()) {
+    for (NativeWindowObserver& observer : observers_)
+      observer.UpdateWindowControlsOverlay(bounding_rect);
+  }
 }
 
 #if defined(OS_WIN)

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -53,6 +53,7 @@ NativeWindow::NativeWindow(const gin_helper::Dictionary& options,
   options.Get(options::kFrame, &has_frame_);
   options.Get(options::kTransparent, &transparent_);
   options.Get(options::kEnableLargerThanScreen, &enable_larger_than_screen_);
+  options.Get(options::ktitleBarOverlay, &titlebar_overlay_);
 
   if (parent)
     options.Get("modal", &is_modal_);

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -254,6 +254,9 @@ class NativeWindow : public base::SupportsUserData,
     return weak_factory_.GetWeakPtr();
   }
 
+  virtual gfx::Rect GetWindowControlsOverlayRect();
+  virtual void SetWindowControlsOverlayRect(const gfx::Rect& overlay_rect);
+
   // Methods called by the WebContents.
   virtual void HandleKeyboardEvent(
       content::WebContents*,
@@ -298,6 +301,7 @@ class NativeWindow : public base::SupportsUserData,
                                      const base::DictionaryValue& details);
   void NotifyNewWindowForTab();
   void NotifyWindowSystemContextMenu(int x, int y, bool* prevent_default);
+  void NotifyLayoutWindowControlsOverlay();
 
 #if defined(OS_WIN)
   void NotifyWindowMessage(UINT message, WPARAM w_param, LPARAM l_param);
@@ -389,6 +393,8 @@ class NativeWindow : public base::SupportsUserData,
 
   // Accessible title.
   std::u16string accessible_title_;
+
+  gfx::Rect overlay_rect_;
 
   base::WeakPtrFactory<NativeWindow> weak_factory_{this};
 

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -346,6 +346,8 @@ class NativeWindow : public base::SupportsUserData,
         [&browser_view](NativeBrowserView* n) { return (n == browser_view); });
   }
 
+  bool titlebar_overlay_ = false;
+
  private:
   std::unique_ptr<views::Widget> widget_;
 

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -146,6 +146,7 @@ class NativeWindowMac : public NativeWindow,
   void CloseFilePreview() override;
   gfx::Rect ContentBoundsToWindowBounds(const gfx::Rect& bounds) const override;
   gfx::Rect WindowBoundsToContentBounds(const gfx::Rect& bounds) const override;
+  gfx::Rect GetWindowControlsOverlayRect() override;
   void NotifyWindowEnterFullScreen() override;
   void NotifyWindowLeaveFullScreen() override;
   void SetActive(bool is_key) override;

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -187,7 +187,6 @@ class NativeWindowMac : public NativeWindow,
     kHidden,
     kHiddenInset,
     kCustomButtonsOnHover,
-    kOverlay
   };
   TitleBarStyle title_bar_style() const { return title_bar_style_; }
 

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -277,6 +277,8 @@ class NativeWindowMac : public NativeWindow,
   // The presentation options before entering simple fullscreen mode.
   NSApplicationPresentationOptions simple_fullscreen_options_;
 
+  bool titlebar_overlay_ = false;
+
   DISALLOW_COPY_AND_ASSIGN(NativeWindowMac);
 };
 

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -277,8 +277,6 @@ class NativeWindowMac : public NativeWindow,
   // The presentation options before entering simple fullscreen mode.
   NSApplicationPresentationOptions simple_fullscreen_options_;
 
-  bool titlebar_overlay_ = false;
-
   DISALLOW_COPY_AND_ASSIGN(NativeWindowMac);
 };
 

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -187,6 +187,7 @@ class NativeWindowMac : public NativeWindow,
     kHidden,
     kHiddenInset,
     kCustomButtonsOnHover,
+    kOverlay
   };
   TitleBarStyle title_bar_style() const { return title_bar_style_; }
 

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1809,6 +1809,22 @@ void NativeWindowMac::SetForwardMouseMessages(bool forward) {
   [window_ setAcceptsMouseMovedEvents:forward];
 }
 
+gfx::Rect NativeWindowMac::GetWindowControlsOverlayRect() {
+  gfx::Rect bounding_rect;
+  if (title_bar_style_ == TitleBarStyle::kHidden ||
+      title_bar_style_ == TitleBarStyle::kHiddenInset) {
+    NSRect button_frame = [buttons_view_ frame];
+    const int overlay_width = GetContentSize().width() - NSWidth(button_frame);
+    int overlay_height = NSHeight(button_frame) + 6;
+    if (title_bar_style_ == TitleBarStyle::kHiddenInset) {
+      overlay_height += 15;
+    }
+    bounding_rect =
+        gfx::Rect(button_frame.size.width, 0, overlay_width, overlay_height);
+  }
+  return bounding_rect;
+}
+
 // static
 NativeWindow* NativeWindow::Create(const gin_helper::Dictionary& options,
                                    NativeWindow* parent) {

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1813,20 +1813,19 @@ void NativeWindowMac::SetForwardMouseMessages(bool forward) {
 
 gfx::Rect NativeWindowMac::GetWindowControlsOverlayRect() {
   gfx::Rect bounding_rect;
-  if (!has_frame() && buttons_view_ && ![buttons_view_ isHidden] &&
-      !traffic_light_position_) {
+  if (!has_frame() && buttons_view_ && ![buttons_view_ isHidden]) {
     NSRect button_frame = [buttons_view_ frame];
-    const int overlay_width = GetContentSize().width() - NSWidth(button_frame);
-    int overlay_height = NSHeight(button_frame) + 6;
-    if (title_bar_style_ == TitleBarStyle::kHiddenInset) {
-      overlay_height += 15;
-    }
+    gfx::Point buttons_view_margin = [buttons_view_ getMargin];
+    const int overlay_width = GetContentSize().width() - NSWidth(button_frame) -
+                              buttons_view_margin.x();
+    CGFloat overlay_height =
+        NSHeight(button_frame) + buttons_view_margin.y() * 2;
     if (base::i18n::IsRTL()) {
-      bounding_rect = gfx::Rect(0, 0, overlay_width - button_frame.size.width,
-                                overlay_height);
+      bounding_rect = gfx::Rect(0, 0, overlay_width, overlay_height);
     } else {
       bounding_rect =
-          gfx::Rect(button_frame.size.width, 0, overlay_width, overlay_height);
+          gfx::Rect(button_frame.size.width + buttons_view_margin.x(), 0,
+                    overlay_width, overlay_height);
     }
   }
   return bounding_rect;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -179,6 +179,8 @@ struct Converter<electron::NativeWindowMac::TitleBarStyle> {
       *out = TitleBarStyle::kHiddenInset;
     } else if (title_bar_style == "customButtonsOnHover") {
       *out = TitleBarStyle::kCustomButtonsOnHover;
+    } else if (title_bar_style == "overlay") {
+      *out = TitleBarStyle::kOverlay;
     } else {
       return false;
     }
@@ -1754,7 +1756,8 @@ void NativeWindowMac::AddContentViewLayers() {
           [[WindowButtonsView alloc] initWithMargin:traffic_light_position_]);
       if (title_bar_style_ == TitleBarStyle::kCustomButtonsOnHover)
         [buttons_view_ setShowOnHover:YES];
-      if (title_bar_style_ == TitleBarStyle::kHiddenInset &&
+      if ((title_bar_style_ == TitleBarStyle::kHiddenInset ||
+           title_bar_style_ == TitleBarStyle::kOverlay) &&
           !traffic_light_position_)
         [buttons_view_ setMargin:gfx::Point(12, 11)];
 
@@ -1813,7 +1816,7 @@ void NativeWindowMac::SetForwardMouseMessages(bool forward) {
 
 gfx::Rect NativeWindowMac::GetWindowControlsOverlayRect() {
   gfx::Rect bounding_rect;
-  if (!has_frame() && buttons_view_ && ![buttons_view_ isHidden]) {
+  if (title_bar_style_ == TitleBarStyle::kOverlay) {
     NSRect button_frame = [buttons_view_ frame];
     gfx::Point buttons_view_margin = [buttons_view_ getMargin];
     const int overlay_width = GetContentSize().width() - NSWidth(button_frame) -

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -280,6 +280,7 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   options.Get(options::kSimpleFullScreen, &always_simple_fullscreen_);
   options.GetOptional(options::kTrafficLightPosition, &traffic_light_position_);
   options.Get(options::kVisualEffectState, &visual_effect_state_);
+  options.Get(options::ktitleBarOverlay, &titlebar_overlay_);
 
   if (options.Has(options::kFullscreenWindowTitle)) {
     EmitWarning(
@@ -1813,7 +1814,8 @@ void NativeWindowMac::SetForwardMouseMessages(bool forward) {
 
 gfx::Rect NativeWindowMac::GetWindowControlsOverlayRect() {
   gfx::Rect bounding_rect;
-  if (!has_frame() && buttons_view_ && ![buttons_view_ isHidden]) {
+  if (titlebar_overlay_ && !has_frame() && buttons_view_ &&
+      ![buttons_view_ isHidden]) {
     NSRect button_frame = [buttons_view_ frame];
     gfx::Point buttons_view_margin = [buttons_view_ getMargin];
     const int overlay_width = GetContentSize().width() - NSWidth(button_frame) -

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -179,8 +179,6 @@ struct Converter<electron::NativeWindowMac::TitleBarStyle> {
       *out = TitleBarStyle::kHiddenInset;
     } else if (title_bar_style == "customButtonsOnHover") {
       *out = TitleBarStyle::kCustomButtonsOnHover;
-    } else if (title_bar_style == "overlay") {
-      *out = TitleBarStyle::kOverlay;
     } else {
       return false;
     }
@@ -1756,8 +1754,7 @@ void NativeWindowMac::AddContentViewLayers() {
           [[WindowButtonsView alloc] initWithMargin:traffic_light_position_]);
       if (title_bar_style_ == TitleBarStyle::kCustomButtonsOnHover)
         [buttons_view_ setShowOnHover:YES];
-      if ((title_bar_style_ == TitleBarStyle::kHiddenInset ||
-           title_bar_style_ == TitleBarStyle::kOverlay) &&
+      if (title_bar_style_ == TitleBarStyle::kHiddenInset &&
           !traffic_light_position_)
         [buttons_view_ setMargin:gfx::Point(12, 11)];
 
@@ -1816,7 +1813,7 @@ void NativeWindowMac::SetForwardMouseMessages(bool forward) {
 
 gfx::Rect NativeWindowMac::GetWindowControlsOverlayRect() {
   gfx::Rect bounding_rect;
-  if (title_bar_style_ == TitleBarStyle::kOverlay) {
+  if (!has_frame() && buttons_view_ && ![buttons_view_ isHidden]) {
     NSRect button_frame = [buttons_view_ frame];
     gfx::Point buttons_view_margin = [buttons_view_ getMargin];
     const int overlay_width = GetContentSize().width() - NSWidth(button_frame) -

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -280,7 +280,6 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   options.Get(options::kSimpleFullScreen, &always_simple_fullscreen_);
   options.GetOptional(options::kTrafficLightPosition, &traffic_light_position_);
   options.Get(options::kVisualEffectState, &visual_effect_state_);
-  options.Get(options::ktitleBarOverlay, &titlebar_overlay_);
 
   if (options.Has(options::kFullscreenWindowTitle)) {
     EmitWarning(

--- a/shell/browser/native_window_observer.h
+++ b/shell/browser/native_window_observer.h
@@ -104,6 +104,8 @@ class NativeWindowObserver : public base::CheckedObserver {
   // Called on Windows when App Commands arrive (WM_APPCOMMAND)
   // Some commands are implemented on on other platforms as well
   virtual void OnExecuteAppCommand(const std::string& command_name) {}
+
+  virtual void UpdateWindowControlsOverlay(gfx::Rect bounding_rect) {}
 };
 
 }  // namespace electron

--- a/shell/browser/native_window_observer.h
+++ b/shell/browser/native_window_observer.h
@@ -105,7 +105,7 @@ class NativeWindowObserver : public base::CheckedObserver {
   // Some commands are implemented on on other platforms as well
   virtual void OnExecuteAppCommand(const std::string& command_name) {}
 
-  virtual void UpdateWindowControlsOverlay(gfx::Rect bounding_rect) {}
+  virtual void UpdateWindowControlsOverlay(const gfx::Rect bounding_rect) {}
 };
 
 }  // namespace electron

--- a/shell/browser/native_window_observer.h
+++ b/shell/browser/native_window_observer.h
@@ -105,7 +105,7 @@ class NativeWindowObserver : public base::CheckedObserver {
   // Some commands are implemented on on other platforms as well
   virtual void OnExecuteAppCommand(const std::string& command_name) {}
 
-  virtual void UpdateWindowControlsOverlay(const gfx::Rect bounding_rect) {}
+  virtual void UpdateWindowControlsOverlay(const gfx::Rect& bounding_rect) {}
 };
 
 }  // namespace electron

--- a/shell/browser/ui/cocoa/window_buttons_view.h
+++ b/shell/browser/ui/cocoa/window_buttons_view.h
@@ -26,6 +26,7 @@
 - (void)setMargin:(const absl::optional<gfx::Point>&)margin;
 - (void)setShowOnHover:(BOOL)yes;
 - (void)setNeedsDisplayForButtons;
+- (gfx::Point)getMargin;
 @end
 
 #endif  // SHELL_BROWSER_UI_COCOA_WINDOW_BUTTONS_VIEW_H_

--- a/shell/browser/ui/cocoa/window_buttons_view.mm
+++ b/shell/browser/ui/cocoa/window_buttons_view.mm
@@ -116,4 +116,8 @@ const NSWindowButton kButtonTypes[] = {
   [self setNeedsDisplayForButtons];
 }
 
+- (gfx::Point)getMargin {
+  return margin_;
+}
+
 @end

--- a/shell/common/options_switches.cc
+++ b/shell/common/options_switches.cc
@@ -194,6 +194,8 @@ const char kEnableWebSQL[] = "enableWebSQL";
 
 const char kEnablePreferredSizeMode[] = "enablePreferredSizeMode";
 
+const char ktitleBarOverlay[] = "titleBarOverlay";
+
 }  // namespace options
 
 namespace switches {

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -57,6 +57,7 @@ extern const char kVibrancyType[];
 extern const char kVisualEffectState[];
 extern const char kTrafficLightPosition[];
 extern const char kRoundedCorners[];
+extern const char ktitleBarOverlay[];
 
 // WebPreferences.
 extern const char kZoomFactor[];

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1870,10 +1870,10 @@ describe('BrowserWindow module', () => {
         height: 400,
         titleBarStyle: style,
         webPreferences: {
-          enableBlinkFeatures: 'WebAppWindowControlsOverlay',
           nodeIntegration: true,
           contextIsolation: false
-        }
+        },
+        titleBarOverlay: true
       });
       const overlayHTML = path.join(__dirname, 'fixtures', 'pages', 'overlay.html');
       await w.loadFile(overlayHTML);

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1913,8 +1913,11 @@ describe('BrowserWindow module', () => {
       const contentSize = w.getContentSize();
       expect(contentSize).to.deep.equal([400, 400]);
     });
-    it('sets Window Control Overlay with overlay title bar style', async () => {
-      await testWindowsOverlay('overlay');
+    it('sets Window Control Overlay with hidden title bar', async () => {
+      await testWindowsOverlay('hidden');
+    });
+    it('sets Window Control Overlay with hidden inset title bar', async () => {
+      await testWindowsOverlay('hiddenInset');
     });
   });
 

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1913,11 +1913,8 @@ describe('BrowserWindow module', () => {
       const contentSize = w.getContentSize();
       expect(contentSize).to.deep.equal([400, 400]);
     });
-    it('sets Window Control Overlay with hidden title bar', async () => {
-      await testWindowsOverlay('hidden');
-    });
-    it('sets Window Control Overlay with hidden inset title bar', async () => {
-      await testWindowsOverlay('hiddenInset');
+    it('sets Window Control Overlay with overlay title bar style', async () => {
+      await testWindowsOverlay('overlay');
     });
   });
 

--- a/spec-main/fixtures/pages/overlay.html
+++ b/spec-main/fixtures/pages/overlay.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <style>
+      :root {
+        --fallback-title-bar-height: 40px;
+      }
+
+      .draggable {
+        app-region: drag;
+        /* Pre-fix app-region during standardization process */
+        -webkit-app-region: drag;
+      }
+
+      .nonDraggable {
+        app-region: no-drag;
+        /* Pre-fix app-region during standardization process */
+        -webkit-app-region: no-drag;
+      }
+
+
+      #titleBarContainer {
+        position: absolute;
+        top: env(titlebar-area-y, 0);
+        height: env(titlebar-area-height, var(--fallback-title-bar-height));
+        width: 100%;
+      }
+
+      #titleBar {
+        position: absolute;
+        top: 0;
+        display: flex;
+        user-select: none;
+        height: 100%;
+        left: env(titlebar-area-x, 0);
+        width: env(titlebar-area-width, 100%);
+      }
+
+      #mainContent {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        top: env(titlebar-area-height, var(--fallback-title-bar-height));
+        overflow-y: scroll;
+      }
+    </style>
+  </head>
+  <body>
+    <script>
+      const {ipcRenderer} = require('electron');
+      navigator.windowControlsOverlay.ongeometrychange = function() {
+        const {x, y, width, height} = navigator.windowControlsOverlay.getBoundingClientRect();
+        ipcRenderer.send('geometrychange', {x, y, width, height});
+      };
+    </script>      
+    <div id="titleBarContainer">
+      <div id="titleBar" class=" draggable">
+        <span class="draggable">Title goes here</span>
+        <input class="nonDraggable" type="text" placeholder="Search"></input>
+      </div>
+    </div>
+    <div id="mainContent"><!-- The rest of the webpage --></div>
+    <script>
+      function getCssOverlayProperties() {
+        const cssOverlayProps = {};
+        const titleBarContainer = document.getElementById('titleBarContainer');
+        const titleBar = document.getElementById('titleBar');
+        cssOverlayProps.y = titleBarContainer.computedStyleMap().get('top').value;
+        cssOverlayProps.height = titleBarContainer.computedStyleMap().get('height').value;
+        cssOverlayProps.x = titleBar.computedStyleMap().get('left').value;
+        cssOverlayProps.width = titleBar.computedStyleMap().get('width').value;
+        return cssOverlayProps;
+      }
+
+      function getJSOverlayProperties() {
+        const {x, y, width, height} = navigator.windowControlsOverlay.getBoundingClientRect(); 
+        return {x, y, width, height};
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
This PR adds a new property `titleBarOverlay` to `BrowserWindow` on macOS to support [Window Controls Overlay](https://github.com/WICG/window-controls-overlay/blob/main/explainer.md).   On macOS, when using a frameless window in conjunction with `win.setWindowButtonVisibility(true)` or using a `titleBarStyle` so that the traffic lights are visible, this property enables the Window Controls Overlay [JavaScript APIs ](https://github.com/WICG/window-controls-overlay/blob/main/explainer.md#javascript-apis) and [CSS Environment Variables](https://github.com/WICG/window-controls-overlay/blob/main/explainer.md#css-environment-variables) will be available for developers to use to better style custom titlebars.

There will be another PR forthcoming that will enable this capability on Windows.  Windows needs `NativeWindow::SetWindowControlsOverlayRect(const gfx::Rect& overlay_rect)`, but this newly added method is not used on macOS.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->Added support for Windows Control Overlay on macOS.
