### PR TITLE
docs: Update notifications (renderer) docs

### DIFF
--- a/docs/fiddles/features/notifications/renderer/index.html
+++ b/docs/fiddles/features/notifications/renderer/index.html
@@ -7,6 +7,9 @@
 </head>
 <body>
     <h1>Hello World!</h1>
+    <p>After launching this application, you should see the system notification.</p>
+    <p id="output">Click it to see the effect in this interface.</p>
+
     <script src="renderer.js"></script>
 </body>
 </html>

--- a/docs/fiddles/features/notifications/renderer/index.html
+++ b/docs/fiddles/features/notifications/renderer/index.html
@@ -7,11 +7,6 @@
 </head>
 <body>
     <h1>Hello World!</h1>
-    <p>
-        We are using node <script>document.write(process.versions.node)</script>,
-        Chrome <script>document.write(process.versions.chrome)</script>,
-        and Electron <script>document.write(process.versions.electron)</script>.
-    </p>
     <script src="renderer.js"></script>
 </body>
 </html>

--- a/docs/fiddles/features/notifications/renderer/main.js
+++ b/docs/fiddles/features/notifications/renderer/main.js
@@ -3,10 +3,7 @@ const { app, BrowserWindow } = require('electron')
 function createWindow () {
   const win = new BrowserWindow({
     width: 800,
-    height: 600,
-    webPreferences: {
-      nodeIntegration: true
-    }
+    height: 600
   })
 
   win.loadFile('index.html')

--- a/docs/fiddles/features/notifications/renderer/renderer.js
+++ b/docs/fiddles/features/notifications/renderer/renderer.js
@@ -1,7 +1,6 @@
-const myNotification = new Notification('Title', {
-  body: 'Notification from the Renderer process'
-})
+const NOTIFICATION_TITLE = 'Title'
+const NOTIFICATION_BODY = 'Notification from the Renderer process. Click to log to console.'
+const CLICK_MESSAGE = 'Notification clicked'
 
-myNotification.onclick = () => {
-  console.log('Notification clicked')
-}
+new Notification(NOTIFICATION_TITLE, { body: NOTIFICATION_BODY })
+  .onclick = () => console.log(CLICK_MESSAGE)

--- a/docs/fiddles/features/notifications/renderer/renderer.js
+++ b/docs/fiddles/features/notifications/renderer/renderer.js
@@ -1,6 +1,6 @@
 const NOTIFICATION_TITLE = 'Title'
 const NOTIFICATION_BODY = 'Notification from the Renderer process. Click to log to console.'
-const CLICK_MESSAGE = 'Notification clicked'
+const CLICK_MESSAGE = 'Notification clicked!'
 
 new Notification(NOTIFICATION_TITLE, { body: NOTIFICATION_BODY })
-  .onclick = () => console.log(CLICK_MESSAGE)
+  .onclick = () => document.getElementById("output").innerText = CLICK_MESSAGE

--- a/docs/tutorial/notifications.md
+++ b/docs/tutorial/notifications.md
@@ -26,7 +26,7 @@ Assuming you have a working Electron application from the
 <script src="renderer.js"></script>
 ```
 
-and add the `renderer.js` file:
+...and add the `renderer.js` file:
 
 ```javascript fiddle='docs/fiddles/features/notifications/renderer'
 const NOTIFICATION_TITLE = 'Title'
@@ -43,7 +43,7 @@ After launching the Electron application, you should see the notification:
 
 If you open the Console and then click the notification, you will see the
 message that was generated after triggering the `onclick` event. Note that this message will
-appear in the console _in the running Electron app_ - not in Fiddle.
+appear in the developer console _in the running Electron app_ - not in Fiddle.
 
 ![Onclick message for the notification](../images/message-notification-renderer.png)
 

--- a/docs/tutorial/notifications.md
+++ b/docs/tutorial/notifications.md
@@ -41,11 +41,7 @@ After launching the Electron application, you should see the notification:
 
 ![Notification in the Renderer process](../images/notification-renderer.png)
 
-If you open the Console and then click the notification, you will see the
-message that was generated after triggering the `onclick` event. Note that this message will
-appear in the developer console _in the running Electron app_ - not in Fiddle.
-
-![Onclick message for the notification](../images/message-notification-renderer.png)
+Additionally, if you click on the notification, the DOM will update to show "Notification clicked!".
 
 ### Show notifications in the Main process
 

--- a/docs/tutorial/notifications.md
+++ b/docs/tutorial/notifications.md
@@ -1,4 +1,4 @@
-# Notifications (Windows, Linux, macOS)
+****# Notifications (Windows, Linux, macOS)
 
 ## Overview
 
@@ -18,7 +18,7 @@ To show notifications in the Main process, you need to use the
 
 ### Show notifications in the Renderer process
 
-Assuming you have a working Electron application from the
+Starting with a working application from the
 [Quick Start Guide](quick-start.md), add the following line to the
 `index.html` file before the closing `</body>` tag:
 

--- a/docs/tutorial/notifications.md
+++ b/docs/tutorial/notifications.md
@@ -42,7 +42,8 @@ After launching the Electron application, you should see the notification:
 ![Notification in the Renderer process](../images/notification-renderer.png)
 
 If you open the Console and then click the notification, you will see the
-message that was generated after triggering the `onclick` event:
+message that was generated after triggering the `onclick` event. Note that this message will
+appear in the console _in the running Electron app_ - not in Fiddle.
 
 ![Onclick message for the notification](../images/message-notification-renderer.png)
 

--- a/docs/tutorial/notifications.md
+++ b/docs/tutorial/notifications.md
@@ -1,4 +1,4 @@
-****# Notifications (Windows, Linux, macOS)
+# Notifications (Windows, Linux, macOS)
 
 ## Overview
 

--- a/docs/tutorial/notifications.md
+++ b/docs/tutorial/notifications.md
@@ -29,13 +29,12 @@ Assuming you have a working Electron application from the
 and add the `renderer.js` file:
 
 ```javascript fiddle='docs/fiddles/features/notifications/renderer'
-const myNotification = new Notification('Title', {
-  body: 'Notification from the Renderer process'
-})
+const NOTIFICATION_TITLE = 'Title'
+const NOTIFICATION_BODY = 'Notification from the Renderer process. Click to log to console.'
+const CLICK_MESSAGE = 'Notification clicked'
 
-myNotification.onclick = () => {
-  console.log('Notification clicked')
-}
+new Notification(NOTIFICATION_TITLE, { body: NOTIFICATION_BODY })
+  .onclick = () => console.log(CLICK_MESSAGE)
 ```
 
 After launching the Electron application, you should see the notification:


### PR DESCRIPTION
#### Description of Change
Removed `nodeIntegration` and update the logic a little bit for showing how to trigger a notification from the `renderer.js` file and how to handle a click on that notification.

Linted code using `standard`.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes]

#### Release Notes

Notes: none
