### PR TITLE
feat: add mainFrameName option to webPreferences

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -391,8 +391,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       contain the layout of the document—without requiring scrolling. Enabling
       this will cause the `preferred-size-changed` event to be emitted on the
       `WebContents` when the preferred size changes. Default is `false`.
-    * `frameName` String (optional) - The name assigned to the top-level frame
-      of the `WebContents` instance.
+    * `mainFrameName` String (optional) - The name assigned to the top-level
+      frame of the `WebContents` instance.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -391,6 +391,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       contain the layout of the document—without requiring scrolling. Enabling
       this will cause the `preferred-size-changed` event to be emitted on the
       `WebContents` when the preferred size changes. Default is `false`.
+    * `frameName` String (optional) - The name assigned to the top-level frame
+      of the `WebContents` instance.
 
 When setting minimum or maximum window size with `minWidth`/`maxWidth`/
 `minHeight`/`maxHeight`, it only constrains the users. It won't prevent you from

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -716,6 +716,9 @@ WebContents::WebContents(v8::Isolate* isolate,
   }
   session_.Reset(isolate, session.ToV8());
 
+  std::string frame_name;
+  options.Get("frameName", &frame_name);
+
   std::unique_ptr<content::WebContents> web_contents;
   if (IsGuest()) {
     scoped_refptr<content::SiteInstance> site_instance =
@@ -726,6 +729,7 @@ WebContents::WebContents(v8::Isolate* isolate,
     guest_delegate_ =
         std::make_unique<WebViewGuestDelegate>(embedder_->web_contents(), this);
     params.guest_delegate = guest_delegate_.get();
+    params.main_frame_name = frame_name;
 
 #if BUILDFLAG(ENABLE_OSR)
     if (embedder_ && embedder_->IsOffScreen()) {
@@ -734,6 +738,7 @@ WebContents::WebContents(v8::Isolate* isolate,
           base::BindRepeating(&WebContents::OnPaint, base::Unretained(this)));
       params.view = view;
       params.delegate_view = view;
+      params.main_frame_name = frame_name;
 
       web_contents = content::WebContents::Create(params);
       view->SetWebContents(web_contents.get());
@@ -752,6 +757,7 @@ WebContents::WebContents(v8::Isolate* isolate,
         base::BindRepeating(&WebContents::OnPaint, base::Unretained(this)));
     params.view = view;
     params.delegate_view = view;
+    params.main_frame_name = frame_name;
 
     web_contents = content::WebContents::Create(params);
     view->SetWebContents(web_contents.get());
@@ -759,6 +765,7 @@ WebContents::WebContents(v8::Isolate* isolate,
   } else {
     content::WebContents::CreateParams params(session->browser_context());
     params.initially_hidden = !initially_shown;
+    params.main_frame_name = frame_name;
     web_contents = content::WebContents::Create(params);
   }
 

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -716,8 +716,8 @@ WebContents::WebContents(v8::Isolate* isolate,
   }
   session_.Reset(isolate, session.ToV8());
 
-  std::string frame_name;
-  options.Get("frameName", &frame_name);
+  std::string main_frame_name;
+  options.Get("mainFrameName", &main_frame_name);
 
   std::unique_ptr<content::WebContents> web_contents;
   if (IsGuest()) {
@@ -729,7 +729,7 @@ WebContents::WebContents(v8::Isolate* isolate,
     guest_delegate_ =
         std::make_unique<WebViewGuestDelegate>(embedder_->web_contents(), this);
     params.guest_delegate = guest_delegate_.get();
-    params.main_frame_name = frame_name;
+    params.main_frame_name = main_frame_name;
 
 #if BUILDFLAG(ENABLE_OSR)
     if (embedder_ && embedder_->IsOffScreen()) {
@@ -738,7 +738,7 @@ WebContents::WebContents(v8::Isolate* isolate,
           base::BindRepeating(&WebContents::OnPaint, base::Unretained(this)));
       params.view = view;
       params.delegate_view = view;
-      params.main_frame_name = frame_name;
+      params.main_frame_name = main_frame_name;
 
       web_contents = content::WebContents::Create(params);
       view->SetWebContents(web_contents.get());
@@ -757,7 +757,7 @@ WebContents::WebContents(v8::Isolate* isolate,
         base::BindRepeating(&WebContents::OnPaint, base::Unretained(this)));
     params.view = view;
     params.delegate_view = view;
-    params.main_frame_name = frame_name;
+    params.main_frame_name = main_frame_name;
 
     web_contents = content::WebContents::Create(params);
     view->SetWebContents(web_contents.get());
@@ -765,7 +765,7 @@ WebContents::WebContents(v8::Isolate* isolate,
   } else {
     content::WebContents::CreateParams params(session->browser_context());
     params.initially_hidden = !initially_shown;
-    params.main_frame_name = frame_name;
+    params.main_frame_name = main_frame_name;
     web_contents = content::WebContents::Create(params);
   }
 

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -2743,13 +2743,13 @@ describe('BrowserWindow module', () => {
       });
     });
 
-    describe('"frameName" option', () => {
+    describe('"mainFrameName" option', () => {
       it('sets the main frame name', () => {
-        const frameName = 'main boi';
+        const mainFrameName = 'main boi';
         const w = new BrowserWindow({
-          webPreferences: { frameName }
+          webPreferences: { mainFrameName }
         });
-        expect(w.webContents.mainFrame.name).to.equal(frameName);
+        expect(w.webContents.mainFrame.name).to.equal(mainFrameName);
       });
     });
   });

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -2742,6 +2742,16 @@ describe('BrowserWindow module', () => {
         expect(w.getSize()).to.deep.equal(size);
       });
     });
+
+    describe('"frameName" option', () => {
+      it('sets the main frame name', () => {
+        const frameName = 'main boi';
+        const w = new BrowserWindow({
+          webPreferences: { frameName }
+        });
+        expect(w.webContents.mainFrame.name).to.equal(frameName);
+      });
+    });
   });
 
   describe('nativeWindowOpen + contextIsolation options', () => {


### PR DESCRIPTION
#### Description of Change

In an application relying on `window.open(url, frameName)`, it can be useful to identify windows based on their frame name. However, this isn't possible with windows created using `new BrowserWindow()`.

This adds a new `mainFrameName` option to `webPreferences` which is then applied for the main frame of the window.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `mainFrameName` option to `WebPreferences` to assign the top-level frame name of the `WebContents`.
