### PR TITLE
feat: add 'dom-ready' event to WebFrameMain

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -884,7 +884,7 @@ Returns:
 * `details` Object
   * `frame` WebFrameMain
 
-Emitted when an `<iframe>` is loaded within the main page or a nested `<iframe>`.
+Emitted when the [mainFrame](web-contents.md#contentsmainframe-readonly), an `<iframe>`, or a nested `<iframe>` is loaded within the page.
 
 ### Instance Methods
 

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -134,7 +134,7 @@ Returns:
 
 * `event` Event
 
-Emitted when the document in the given frame is loaded.
+Emitted when the document in the top-level frame is loaded.
 
 #### Event: 'page-title-updated'
 
@@ -875,6 +875,16 @@ Emitted when the `WebContents` preferred size has changed.
 
 This event will only be emitted when `enablePreferredSizeMode` is set to `true`
 in `webPreferences`.
+
+#### Event: 'frame-created'
+
+Returns:
+
+* `event` Event
+* `details` Object
+  * `frame` WebFrameMain
+
+Emitted when an `<iframe>` is loaded within the main page or a nested `<iframe>`.
 
 ### Instance Methods
 
@@ -2012,11 +2022,6 @@ when the DevTools has been closed.
 
 A [`Debugger`](debugger.md) instance for this webContents.
 
-[keyboardevent]: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
-[event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter
-[SCA]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
-[`postMessage`]: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
-
 #### `contents.backgroundThrottling`
 
 A `Boolean` property that determines whether or not this WebContents will throttle animations and timers
@@ -2025,3 +2030,8 @@ when the page becomes backgrounded. This also affects the Page Visibility API.
 #### `contents.mainFrame` _Readonly_
 
 A [`WebFrameMain`](web-frame-main.md) property that represents the top frame of the page's frame hierarchy.
+
+[keyboardevent]: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
+[event-emitter]: https://nodejs.org/api/events.html#events_class_eventemitter
+[SCA]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
+[`postMessage`]: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage

--- a/docs/api/web-frame-main.md
+++ b/docs/api/web-frame-main.md
@@ -71,6 +71,16 @@ or `undefined` if there is no WebFrameMain associated with the given IDs.
 Process: [Main](../glossary.md#main-process)<br />
 _This class is not exported from the `'electron'` module. It is only available as a return value of other methods in the Electron API._
 
+### Instance Events
+
+#### Event: 'dom-ready'
+
+Returns:
+
+* `event` Event
+
+Emitted when the document is loaded.
+
 ### Instance Methods
 
 #### `frame.executeJavaScript(code[, userGesture])`

--- a/docs/api/web-frame-main.md
+++ b/docs/api/web-frame-main.md
@@ -75,10 +75,6 @@ _This class is not exported from the `'electron'` module. It is only available a
 
 #### Event: 'dom-ready'
 
-Returns:
-
-* `event` Event
-
 Emitted when the document is loaded.
 
 ### Instance Methods

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1442,12 +1442,11 @@ void WebContents::RenderFrameHostChanged(content::RenderFrameHost* old_host,
   // If an instance of WebFrameMain exists, it will need to have its RFH
   // swapped as well.
   //
-  // |old_host| can be a nullptr in so we use |new_host| for looking up the
+  // |old_host| can be a nullptr so we use |new_host| for looking up the
   // WebFrameMain instance.
   auto* web_frame =
       WebFrameMain::FromFrameTreeNodeId(new_host->GetFrameTreeNodeId());
   if (web_frame) {
-    CHECK_EQ(web_frame->render_frame_host(), old_host);
     web_frame->UpdateRenderFrameHost(new_host);
   }
 }

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1393,6 +1393,12 @@ void WebContents::HandleNewRenderFrame(
 void WebContents::RenderFrameCreated(
     content::RenderFrameHost* render_frame_host) {
   HandleNewRenderFrame(render_frame_host);
+
+  v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+  v8::HandleScope handle_scope(isolate);
+  gin_helper::Dictionary details = gin_helper::Dictionary::CreateEmpty(isolate);
+  details.SetGetter("frame", render_frame_host);
+  Emit("frame-created", details);
 }
 
 void WebContents::RenderFrameDeleted(
@@ -1504,6 +1510,10 @@ void WebContents::DidAcquireFullscreen(content::RenderFrameHost* rfh) {
 
 void WebContents::DOMContentLoaded(
     content::RenderFrameHost* render_frame_host) {
+  auto* web_frame = WebFrameMain::FromRenderFrameHost(render_frame_host);
+  if (web_frame)
+    web_frame->DOMContentLoaded();
+
   if (!render_frame_host->GetParent())
     Emit("dom-ready");
 }

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -317,6 +317,10 @@ void WebFrameMain::Connect() {
   }
 }
 
+void WebFrameMain::DOMContentLoaded() {
+  Emit("dom-ready");
+}
+
 // static
 gin::Handle<WebFrameMain> WebFrameMain::New(v8::Isolate* isolate) {
   return gin::Handle<WebFrameMain>();

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -13,6 +13,7 @@
 #include "gin/handle.h"
 #include "gin/wrappable.h"
 #include "mojo/public/cpp/bindings/remote.h"
+#include "shell/browser/event_emitter_mixin.h"
 #include "shell/common/gin_helper/constructible.h"
 #include "shell/common/gin_helper/pinnable.h"
 #include "third_party/blink/public/mojom/page/page_visibility_state.mojom-forward.h"
@@ -35,6 +36,7 @@ class WebContents;
 
 // Bindings for accessing frames from the main process.
 class WebFrameMain : public gin::Wrappable<WebFrameMain>,
+                     public gin_helper::EventEmitterMixin<WebFrameMain>,
                      public gin_helper::Pinnable<WebFrameMain>,
                      public gin_helper::Constructible<WebFrameMain> {
  public:
@@ -80,7 +82,6 @@ class WebFrameMain : public gin::Wrappable<WebFrameMain>,
   // WebFrameMain can outlive its RenderFrameHost pointer so we need to check
   // whether its been disposed of prior to accessing it.
   bool CheckRenderFrame() const;
-  void Connect();
 
   v8::Local<v8::Promise> ExecuteJavaScript(gin::Arguments* args,
                                            const std::u16string& code);
@@ -108,6 +109,8 @@ class WebFrameMain : public gin::Wrappable<WebFrameMain>,
   std::vector<content::RenderFrameHost*> FramesInSubtree() const;
 
   void OnRendererConnectionError();
+  void Connect();
+  void DOMContentLoaded();
 
   mojo::Remote<mojom::ElectronRenderer> renderer_api_;
   mojo::PendingReceiver<mojom::ElectronRenderer> pending_receiver_;

--- a/shell/common/gin_converters/frame_converter.cc
+++ b/shell/common/gin_converters/frame_converter.cc
@@ -5,9 +5,17 @@
 #include "shell/common/gin_converters/frame_converter.h"
 
 #include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/render_process_host.h"
 #include "shell/browser/api/electron_api_web_frame_main.h"
+#include "shell/common/gin_helper/accessor.h"
 
 namespace gin {
+
+namespace {
+
+v8::Persistent<v8::ObjectTemplate> rfh_templ;
+
+}  // namespace
 
 // static
 v8::Local<v8::Value> Converter<content::RenderFrameHost*>::ToV8(
@@ -16,6 +24,66 @@ v8::Local<v8::Value> Converter<content::RenderFrameHost*>::ToV8(
   if (!val)
     return v8::Null(isolate);
   return electron::api::WebFrameMain::From(isolate, val).ToV8();
+}
+
+// static
+v8::Local<v8::Value>
+Converter<gin_helper::AccessorValue<content::RenderFrameHost*>>::ToV8(
+    v8::Isolate* isolate,
+    gin_helper::AccessorValue<content::RenderFrameHost*> val) {
+  content::RenderFrameHost* rfh = val.Value;
+  if (!rfh)
+    return v8::Null(isolate);
+
+  const int process_id = rfh->GetProcess()->GetID();
+  const int routing_id = rfh->GetRoutingID();
+
+  if (rfh_templ.IsEmpty()) {
+    v8::EscapableHandleScope inner(isolate);
+    v8::Local<v8::ObjectTemplate> local = v8::ObjectTemplate::New(isolate);
+    local->SetInternalFieldCount(2);
+    rfh_templ.Reset(isolate, inner.Escape(local));
+  }
+
+  v8::Local<v8::Object> rfh_obj =
+      v8::Local<v8::ObjectTemplate>::New(isolate, rfh_templ)
+          ->NewInstance(isolate->GetCurrentContext())
+          .ToLocalChecked();
+
+  rfh_obj->SetInternalField(0, v8::Number::New(isolate, process_id));
+  rfh_obj->SetInternalField(1, v8::Number::New(isolate, routing_id));
+
+  return rfh_obj;
+}
+
+// static
+bool Converter<gin_helper::AccessorValue<content::RenderFrameHost*>>::FromV8(
+    v8::Isolate* isolate,
+    v8::Local<v8::Value> val,
+    gin_helper::AccessorValue<content::RenderFrameHost*>* out) {
+  v8::Local<v8::Object> rfh_obj;
+  if (!ConvertFromV8(isolate, val, &rfh_obj))
+    return false;
+
+  if (rfh_obj->InternalFieldCount() != 2)
+    return false;
+
+  v8::Local<v8::Value> process_id_wrapper = rfh_obj->GetInternalField(0);
+  v8::Local<v8::Value> routing_id_wrapper = rfh_obj->GetInternalField(1);
+
+  if (process_id_wrapper.IsEmpty() || !process_id_wrapper->IsNumber() ||
+      routing_id_wrapper.IsEmpty() || !routing_id_wrapper->IsNumber())
+    return false;
+
+  const int process_id = process_id_wrapper.As<v8::Number>()->Value();
+  const int routing_id = routing_id_wrapper.As<v8::Number>()->Value();
+
+  auto* rfh = content::RenderFrameHost::FromID(process_id, routing_id);
+  if (!rfh)
+    return false;
+
+  out->Value = rfh;
+  return true;
 }
 
 }  // namespace gin

--- a/shell/common/gin_converters/frame_converter.h
+++ b/shell/common/gin_converters/frame_converter.h
@@ -6,6 +6,7 @@
 #define SHELL_COMMON_GIN_CONVERTERS_FRAME_CONVERTER_H_
 
 #include "gin/converter.h"
+#include "shell/common/gin_helper/accessor.h"
 
 namespace content {
 class RenderFrameHost;
@@ -17,6 +18,16 @@ template <>
 struct Converter<content::RenderFrameHost*> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                    content::RenderFrameHost* val);
+};
+
+template <>
+struct Converter<gin_helper::AccessorValue<content::RenderFrameHost*>> {
+  static v8::Local<v8::Value> ToV8(
+      v8::Isolate* isolate,
+      gin_helper::AccessorValue<content::RenderFrameHost*> val);
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Local<v8::Value> val,
+                     gin_helper::AccessorValue<content::RenderFrameHost*>* out);
 };
 
 }  // namespace gin

--- a/shell/common/gin_helper/accessor.h
+++ b/shell/common/gin_helper/accessor.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 Samuel Maddock <sam@samuelmaddock.com>.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_COMMON_GIN_HELPER_ACCESSOR_H_
+#define SHELL_COMMON_GIN_HELPER_ACCESSOR_H_
+
+namespace gin_helper {
+
+// Wrapper for a generic value to be used as an accessor in a
+// gin_helper::Dictionary.
+template <typename T>
+struct AccessorValue {
+  T Value;
+};
+template <typename T>
+struct AccessorValue<const T&> {
+  T Value;
+};
+template <typename T>
+struct AccessorValue<const T*> {
+  T* Value;
+};
+
+}  // namespace gin_helper
+
+#endif  // SHELL_COMMON_GIN_HELPER_ACCESSOR_H_

--- a/spec-main/fixtures/sub-frames/frame-container.html
+++ b/spec-main/fixtures/sub-frames/frame-container.html
@@ -8,6 +8,6 @@
 </head>
 <body>
   This is the root page
-  <iframe src="./frame.html"></iframe>
+  <iframe src="./frame.html" name="frameA"></iframe>
 </body>
 </html>

--- a/spec-main/fixtures/sub-frames/frame-with-frame.html
+++ b/spec-main/fixtures/sub-frames/frame-with-frame.html
@@ -8,6 +8,6 @@
 </head>
 <body>
   This is a frame, is has one child
-  <iframe src="./frame.html"></iframe>
+  <iframe src="./frame.html" name="frameA"></iframe>
 </body>
 </html>


### PR DESCRIPTION
#### Description of Change

resolves #27344

~~WebContents now emits a 'frame-dom-ready' event when either the top-level frame or a sub frame's document is ready.~~

WebFrameMain now emits a 'dom-ready' event when the frame's document is ready.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes:
* Added 'dom-ready' event to `WebFrameMain` which emits when the frame's document is ready.
* Added 'frame-created' event to `WebContents` which emits when a frame is created in the page.
