### PR TITLE
fix: change ASAR archive cache to per-process to fix leak

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -44,7 +44,6 @@
 #include "shell/browser/ui/devtools_manager_delegate.h"
 #include "shell/common/api/electron_bindings.h"
 #include "shell/common/application_info.h"
-#include "shell/common/asar/asar_util.h"
 #include "shell/common/electron_paths.h"
 #include "shell/common/gin_helper/trackable_object.h"
 #include "shell/common/node_bindings.h"
@@ -209,9 +208,7 @@ ElectronBrowserMainParts::ElectronBrowserMainParts(
   self_ = this;
 }
 
-ElectronBrowserMainParts::~ElectronBrowserMainParts() {
-  asar::ClearArchives();
-}
+ElectronBrowserMainParts::~ElectronBrowserMainParts() = default;
 
 // static
 ElectronBrowserMainParts* ElectronBrowserMainParts::Get() {

--- a/shell/common/asar/archive.h
+++ b/shell/common/asar/archive.h
@@ -69,6 +69,7 @@ class Archive {
   base::FilePath path() const { return path_; }
 
  private:
+  // Lock protects archive initialization, and |external_files_|
   base::Lock lock_;
   base::FilePath path_;
   base::File file_;

--- a/shell/common/asar/archive.h
+++ b/shell/common/asar/archive.h
@@ -69,8 +69,7 @@ class Archive {
   base::FilePath path() const { return path_; }
 
  private:
-  // Lock protects |external_files_|
-  base::Lock lock_;
+  bool initialized_;
   const base::FilePath path_;
   base::File file_;
   int fd_ = -1;
@@ -78,6 +77,7 @@ class Archive {
   std::unique_ptr<base::DictionaryValue> header_;
 
   // Cached external temporary files.
+  base::Lock external_files_lock_;
   std::unordered_map<base::FilePath::StringType,
                      std::unique_ptr<ScopedTemporaryFile>>
       external_files_;

--- a/shell/common/asar/archive.h
+++ b/shell/common/asar/archive.h
@@ -5,6 +5,7 @@
 #ifndef SHELL_COMMON_ASAR_ARCHIVE_H_
 #define SHELL_COMMON_ASAR_ARCHIVE_H_
 
+#include <atomic>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -71,7 +72,8 @@ class Archive {
  private:
   // Lock protects archive initialization, and |external_files_|
   base::Lock lock_;
-  base::FilePath path_;
+  std::atomic_bool initialized_;
+  const base::FilePath path_;
   base::File file_;
   int fd_ = -1;
   uint32_t header_size_ = 0;

--- a/shell/common/asar/archive.h
+++ b/shell/common/asar/archive.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_COMMON_ASAR_ARCHIVE_H_
 #define SHELL_COMMON_ASAR_ARCHIVE_H_
 
-#include <atomic>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -23,7 +22,7 @@ namespace asar {
 class ScopedTemporaryFile;
 
 // This class represents an asar package, and provides methods to read
-// information from it. It is thread-safe.
+// information from it. It is thread-safe after |Init| has been called.
 class Archive {
  public:
   struct FileInfo {
@@ -70,9 +69,8 @@ class Archive {
   base::FilePath path() const { return path_; }
 
  private:
-  // Lock protects archive initialization, and |external_files_|
+  // Lock protects |external_files_|
   base::Lock lock_;
-  std::atomic_bool initialized_;
   const base::FilePath path_;
   base::File file_;
   int fd_ = -1;

--- a/shell/common/asar/archive.h
+++ b/shell/common/asar/archive.h
@@ -11,6 +11,7 @@
 
 #include "base/files/file.h"
 #include "base/files/file_path.h"
+#include "base/synchronization/lock.h"
 
 namespace base {
 class DictionaryValue;
@@ -21,7 +22,7 @@ namespace asar {
 class ScopedTemporaryFile;
 
 // This class represents an asar package, and provides methods to read
-// information from it.
+// information from it. It is thread-safe.
 class Archive {
  public:
   struct FileInfo {
@@ -46,16 +47,17 @@ class Archive {
   bool Init();
 
   // Get the info of a file.
-  bool GetFileInfo(const base::FilePath& path, FileInfo* info);
+  bool GetFileInfo(const base::FilePath& path, FileInfo* info) const;
 
   // Fs.stat(path).
-  bool Stat(const base::FilePath& path, Stats* stats);
+  bool Stat(const base::FilePath& path, Stats* stats) const;
 
   // Fs.readdir(path).
-  bool Readdir(const base::FilePath& path, std::vector<base::FilePath>* files);
+  bool Readdir(const base::FilePath& path,
+               std::vector<base::FilePath>* files) const;
 
   // Fs.realpath(path).
-  bool Realpath(const base::FilePath& path, base::FilePath* realpath);
+  bool Realpath(const base::FilePath& path, base::FilePath* realpath) const;
 
   // Copy the file into a temporary file, and return the new path.
   // For unpacked file, this method will return its real path.
@@ -65,9 +67,9 @@ class Archive {
   int GetFD() const;
 
   base::FilePath path() const { return path_; }
-  base::DictionaryValue* header() const { return header_.get(); }
 
  private:
+  base::Lock lock_;
   base::FilePath path_;
   base::File file_;
   int fd_ = -1;

--- a/shell/common/asar/asar_util.cc
+++ b/shell/common/asar/asar_util.cc
@@ -6,11 +6,14 @@
 
 #include <map>
 #include <string>
+#include <utility>
 
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
 #include "base/lazy_instance.h"
+#include "base/no_destructor.h"
 #include "base/stl_util.h"
+#include "base/synchronization/lock.h"
 #include "base/threading/thread_local.h"
 #include "base/threading/thread_restrictions.h"
 #include "shell/common/asar/archive.h"
@@ -19,30 +22,39 @@ namespace asar {
 
 namespace {
 
-// The global instance of ArchiveMap, will be destroyed on exit.
 typedef std::map<base::FilePath, std::shared_ptr<Archive>> ArchiveMap;
-base::LazyInstance<base::ThreadLocalPointer<ArchiveMap>>::Leaky
-    g_archive_map_tls = LAZY_INSTANCE_INITIALIZER;
 
 const base::FilePath::CharType kAsarExtension[] = FILE_PATH_LITERAL(".asar");
 
-std::map<base::FilePath, bool> g_is_directory_cache;
-
 bool IsDirectoryCached(const base::FilePath& path) {
-  auto it = g_is_directory_cache.find(path);
-  if (it != g_is_directory_cache.end()) {
+  static base::NoDestructor<std::map<base::FilePath, bool>>
+      s_is_directory_cache;
+  static base::NoDestructor<base::Lock> lock;
+
+  base::AutoLock auto_lock(*lock);
+  auto& is_directory_cache = *s_is_directory_cache;
+
+  auto it = is_directory_cache.find(path);
+  if (it != is_directory_cache.end()) {
     return it->second;
   }
   base::ThreadRestrictions::ScopedAllowIO allow_io;
-  return g_is_directory_cache[path] = base::DirectoryExists(path);
+  return is_directory_cache[path] = base::DirectoryExists(path);
 }
 
 }  // namespace
 
+std::pair<ArchiveMap&, base::Lock&> GetArchiveCache() {
+  static base::NoDestructor<ArchiveMap> s_archive_map;
+  static base::NoDestructor<base::Lock> lock;
+
+  return std::pair<ArchiveMap&, base::Lock&>(*s_archive_map, *lock);
+}
+
 std::shared_ptr<Archive> GetOrCreateAsarArchive(const base::FilePath& path) {
-  if (!g_archive_map_tls.Pointer()->Get())
-    g_archive_map_tls.Pointer()->Set(new ArchiveMap);
-  ArchiveMap& map = *g_archive_map_tls.Pointer()->Get();
+  std::pair<ArchiveMap&, base::Lock&> archiveMapAndLock = GetArchiveCache();
+  ArchiveMap& map = archiveMapAndLock.first;
+  base::AutoLock auto_lock(archiveMapAndLock.second);
 
   // if we have it, return it
   const auto lower = map.lower_bound(path);
@@ -61,8 +73,11 @@ std::shared_ptr<Archive> GetOrCreateAsarArchive(const base::FilePath& path) {
 }
 
 void ClearArchives() {
-  if (g_archive_map_tls.Pointer()->Get())
-    delete g_archive_map_tls.Pointer()->Get();
+  std::pair<ArchiveMap&, base::Lock&> archiveMapAndLock = GetArchiveCache();
+  ArchiveMap& map = archiveMapAndLock.first;
+  base::AutoLock auto_lock(archiveMapAndLock.second);
+
+  map.clear();
 }
 
 bool GetAsarArchivePath(const base::FilePath& full_path,

--- a/shell/common/asar/asar_util.h
+++ b/shell/common/asar/asar_util.h
@@ -16,7 +16,7 @@ namespace asar {
 
 class Archive;
 
-// Gets or creates a new Archive from the path.
+// Gets or creates and caches a new Archive from the path.
 std::shared_ptr<Archive> GetOrCreateAsarArchive(const base::FilePath& path);
 
 // Destroy cached Archive objects.

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -10,7 +10,6 @@
 #include "content/public/renderer/render_frame.h"
 #include "electron/buildflags/buildflags.h"
 #include "shell/common/api/electron_bindings.h"
-#include "shell/common/asar/asar_util.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/event_emitter_caller.h"
 #include "shell/common/node_bindings.h"
@@ -38,9 +37,7 @@ ElectronRendererClient::ElectronRendererClient()
           NodeBindings::Create(NodeBindings::BrowserEnvironment::kRenderer)),
       electron_bindings_(new ElectronBindings(node_bindings_->uv_loop())) {}
 
-ElectronRendererClient::~ElectronRendererClient() {
-  asar::ClearArchives();
-}
+ElectronRendererClient::~ElectronRendererClient() = default;
 
 void ElectronRendererClient::RenderFrameCreated(
     content::RenderFrame* render_frame) {

--- a/shell/renderer/web_worker_observer.cc
+++ b/shell/renderer/web_worker_observer.cc
@@ -7,7 +7,6 @@
 #include "base/lazy_instance.h"
 #include "base/threading/thread_local.h"
 #include "shell/common/api/electron_bindings.h"
-#include "shell/common/asar/asar_util.h"
 #include "shell/common/gin_helper/event_emitter_caller.h"
 #include "shell/common/node_bindings.h"
 #include "shell/common/node_includes.h"
@@ -39,7 +38,6 @@ WebWorkerObserver::~WebWorkerObserver() {
   lazy_tls.Pointer()->Set(nullptr);
   node::FreeEnvironment(node_bindings_->uv_env());
   node::FreeIsolateData(node_bindings_->isolate_data());
-  asar::ClearArchives();
 }
 
 void WebWorkerObserver::WorkerScriptReadyForEvaluation(


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Close #29292.

This PR changes the ASAR archive cache in `shell/common/asar/asar_util.cc` to be process-wide instead of in thread-locals to prevent the `asar::Archive` from being leaked on worker thread exit. See issue #29292 for the technical details about the bug.

Changing the cache to being process-wide means that thread-safety had to be added to `asar::Archive` and `asar::GetOrCreateAsarArchive`. This is (unfortunately?) accomplished with locks, as `asar::GetOrCreateAsarArchive` is used in both async (`AsarURLLoader`) and sync (`NativeImage`) contexts. I know in Chromium locks are frowned upon, but using them here allows the code to continue to be used where it is currently in synchronous code.

Other changes include making `asar::IsDirectoryCached` thread-safe, where it wasn't before, and removing all current usages of `asar::ClearArchives` since it was being used in spots that weren't really accomplishing anything (when processes are being torn down anyway). `asar::ClearArchives` was left in the code base though for potential future use in manually clearing the cache. The `asar::Archive::header` method was also removed since it is not currently used, and it could be used to modify the parsed header which would make `asar::Archive` not thread-safe.

#### Alternatives Considered

Quite a few alternatives were considered, in an attempt to avoid locking for thread-safety, in no particular order:

##### Use `base::ThreadLocalOwnedPointer` To Fix Leak

This was initially attempted as the most concise fix for the leak, as it would destruct the cache on thread exit. However, this change led to a crash on thread exit, through the `File::Close` code path. This is due to another thread-local storage in the Chromium code base, which appears to have already been destructed by the time the archive cache is being destructed, but the code in `File::Close` needs to use that other thread-local storage. Ensuring the order of destruction of disconnected thread-local storages seems fragile and bug prone. Per-thread caches are also redundant, and make it very difficult to clear the cache.

##### Eliminate Archive Cache All Together

The bug could be fixed by simply eliminating the archive cache and letting each interaction with an ASAR archive load and parse the header. However, that parsing of the header can be rather slow, in my testing I was seeing ~40ms with an ASAR archive header which was about 850KB. Eliminating the cache would lead to a lot of redundant processing, and more resource thrash since each request would temporarily store the parsed header in memory, and would open a new file handle.

##### Don't Use Archive Cache for Sync Code Paths, Use A Sequence Instead of Locks

This has the same shortcomings as eliminating the cache, but isolated to sync code (like `NativeImage`). The sync code path is accessed from JavaScript, so it likely currently benefits from the cache consistently since all access will be on the same thread. As such, not using the archive cache would be a performance regression for those code paths.

##### Use `base::SequenceLocalStorageSlot` Instead of Thread-Local Storage

`base:: SequenceLocalStorageSlot` is like thread-local storage, but it's per-sequence. That means all worker threads using the same sequence would get the same archive cache, and it would be destructed when the sequence was destructed. This approach isn't viable because `AsarURLLoader` runs on a new sequence for each request, and running all the loaders on the same sequence could be a bottleneck.

cc @nornagon, @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed memory leak when requesting files in ASAR archive from renderer
