### PR TITLE
fix: correct libcxx_objects build action name

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1427,7 +1427,7 @@ dist_zip("libcxxabi_headers_zip") {
   outputs = [ "$root_build_dir/libcxxabi_headers.zip" ]
 }
 
-action("libcxx_zip") {
+action("libcxx_objects_zip") {
   deps = [ "//buildtools/third_party/libc++" ]
   script = "build/zip_libcxx.py"
   outputs = [ "$root_build_dir/libcxx_objects.zip" ]

--- a/patches/chromium/build_libc_as_static_library.patch
+++ b/patches/chromium/build_libc_as_static_library.patch
@@ -7,7 +7,7 @@ Build libc++ as static library to compile and pass
 nan tests
 
 diff --git a/buildtools/third_party/libc++/BUILD.gn b/buildtools/third_party/libc++/BUILD.gn
-index 65f6e8585ad374ad59e7670babfedd2fbdfbaa43..0b1333bc8de626db056567f599be27808e1495e5 100644
+index 65f6e8585ad374ad59e7670babfedd2fbdfbaa43..7928a03447347f441e1e7dfc43f7a8e475eb120b 100644
 --- a/buildtools/third_party/libc++/BUILD.gn
 +++ b/buildtools/third_party/libc++/BUILD.gn
 @@ -32,7 +32,11 @@ config("winver") {
@@ -27,7 +27,7 @@ index 65f6e8585ad374ad59e7670babfedd2fbdfbaa43..0b1333bc8de626db056567f599be2780
    # need to explicitly depend on libc++.
    visibility = [
      "//build/config:common_deps",
-+    "//electron:libcxx_zip",
++    "//electron:libcxx_objects_zip",
      "//third_party/catapult/devil:devil",
    ]
    if (is_linux && !is_chromeos) {


### PR DESCRIPTION
#### Description of Change

Follow up to #29281, the build generation step in BUILD.gn needs to be updated to `libcxx_objects_zip`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
