### PR TITLE
fix: FileFilter.name is optional

### DIFF
--- a/docs/api/structures/file-filter.md
+++ b/docs/api/structures/file-filter.md
@@ -1,4 +1,4 @@
 # FileFilter Object
 
-* `name` String
+* `name` String (optional)
 * `extensions` String[]

--- a/lib/browser/api/dialog.ts
+++ b/lib/browser/api/dialog.ts
@@ -287,5 +287,8 @@ export function showCertificateTrustDialog (windowOrOptions: BrowserWindow | Cer
 
   if (typeof message !== 'string') throw new TypeError('message must be a string');
 
-  return dialogBinding.showCertificateTrustDialog?.(window, certificate, message);
+  if (!dialogBinding.showCertificateTrustDialog) {
+    throw new Error(`showCertificateTrustDialog is not supported on ${process.platform}`);
+  }
+  return dialogBinding.showCertificateTrustDialog(window, certificate, message);
 }

--- a/lib/browser/api/dialog.ts
+++ b/lib/browser/api/dialog.ts
@@ -287,5 +287,5 @@ export function showCertificateTrustDialog (windowOrOptions: BrowserWindow | Cer
 
   if (typeof message !== 'string') throw new TypeError('message must be a string');
 
-  return dialogBinding.showCertificateTrustDialog(window, certificate, message);
+  return dialogBinding.showCertificateTrustDialog?.(window, certificate, message);
 }

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -7,7 +7,7 @@ declare var isolatedApi: {
   allowGuestViewElementDefinition: NodeJS.InternalWebFrame['allowGuestViewElementDefinition'];
   setIsWebView: (iframe: HTMLIFrameElement) => void;
   createNativeImage: typeof Electron.nativeImage['createEmpty'];
-}
+};
 
 declare const BUILDFLAG: (flag: boolean) => boolean;
 
@@ -209,6 +209,17 @@ declare namespace NodeJS {
     };
     _linkedBinding(name: 'electron_browser_desktop_capturer'): {
       createDesktopCapturer(): ElectronInternal.DesktopCapturer;
+    };
+    _linkedBinding(name: 'electron_browser_dialog'): {
+      /** only available on mac and windows */
+      showCertificateTrustDialog?: (window: BrowserWindow, settings: CertificateTrustDialogOptions, message: string) => void;
+      showErrorBox: (...args: any[]) => void;
+      showMessageBox: (settings: any) => void;
+      showMessageBoxSync: (settings: any) => void;
+      showOpenDialog: (settings: any) => void;
+      showOpenDialogSync: (settings: any) => void;
+      showSaveDialog: (settings: any) => void;
+      showSaveDialogSync: (settings: any) => void;
     };
     _linkedBinding(name: 'electron_browser_event'): {
       createWithSender(sender: Electron.WebContents): Electron.Event;

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -1,3 +1,6 @@
+import { BrowserWindow } from 'electron';
+import { CertificateTrustDialogOptions, OpenDialogReturnValue } from 'electron/main';
+
 /* eslint-disable no-var */
 declare var internalBinding: any;
 declare var binding: { get: (name: string) => any; process: NodeJS.Process; createPreloadScript: (src: string) => Function };
@@ -213,7 +216,7 @@ declare namespace NodeJS {
     _linkedBinding(name: 'electron_browser_dialog'): {
       /** only available on mac and windows */
       showCertificateTrustDialog?: (window: BrowserWindow, settings: CertificateTrustDialogOptions, message: string) => void;
-      showErrorBox: (...args: any[]) => void;
+      showErrorBox: (...args: any[]) => OpenDialogReturnValue;
       showMessageBox: (settings: any) => void;
       showMessageBoxSync: (settings: any) => void;
       showOpenDialog: (settings: any) => void;


### PR DESCRIPTION
#### Description of Change
Over on [insomnia](insomnia.rest) we got a bug related to this https://github.com/Kong/insomnia/pull/3348 that results in an error due to FileFIlter.name being listed as required, when (so far as I can tell by reviewing the source code) it is actually optional.

In Linux, https://github.com/dimitropoulos/electron/blob/master/shell/browser/ui/file_dialog_gtk.cc#L365 calls out to https://developer.gnome.org/gtk3/stable/GtkFileFilter.html#gtk-file-filter-set-name which is clear that `allow-null` is accepted.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: FileFilter.name is now correctly typed as being optional
