### PR TITLE
docs: fix link to `docs/fiddle/quick-start`

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -440,7 +440,7 @@ window.addEventListener('DOMContentLoaded', () => {
 </html>
 ```
 
-```fiddle docs/fiddles/quickstart
+```fiddle docs/fiddles/quick-start
 ```
 
 To summarize all the steps we've done:


### PR DESCRIPTION
#### Description of Change

Fixes the Fiddle meta link for `docs/fiddle/quick-start`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
