### PR TITLE
fix: correctly handle Alt+Key shortcuts

### DIFF
--- a/shell/browser/ui/views/menu_bar.cc
+++ b/shell/browser/ui/views/menu_bar.cc
@@ -56,6 +56,8 @@ void MenuBar::SetAcceleratorVisibility(bool visible) {
 }
 
 MenuBar::View* MenuBar::FindAccelChild(char16_t key) {
+  if (key == 0)
+    return nullptr;
   for (auto* child : GetChildrenInZOrder()) {
     if (static_cast<SubmenuButton*>(child)->accelerator() == key)
       return child;

--- a/shell/browser/ui/views/root_view.cc
+++ b/shell/browser/ui/views/root_view.cc
@@ -119,18 +119,18 @@ void RootView::HandleKeyEvent(const content::NativeWebKeyboardEvent& event) {
 
   // Show the submenu when "Alt+Key" is pressed.
   if (event.GetType() == blink::WebInputEvent::Type::kRawKeyDown &&
-      !IsAltKey(event) && IsAltModifier(event)) {
-    if (menu_bar_->HasAccelerator(event.windows_key_code)) {
-      if (!menu_bar_visible_) {
-        SetMenuBarVisibility(true);
+      event.windows_key_code >= ui::VKEY_A &&
+      event.windows_key_code <= ui::VKEY_Z && IsAltModifier(event) &&
+      menu_bar_->HasAccelerator(event.windows_key_code)) {
+    if (!menu_bar_visible_) {
+      SetMenuBarVisibility(true);
 
-        View* focused_view = GetFocusManager()->GetFocusedView();
-        last_focused_view_tracker_->SetView(focused_view);
-        menu_bar_->RequestFocus();
-      }
-
-      menu_bar_->ActivateAccelerator(event.windows_key_code);
+      View* focused_view = GetFocusManager()->GetFocusedView();
+      last_focused_view_tracker_->SetView(focused_view);
+      menu_bar_->RequestFocus();
     }
+
+    menu_bar_->ActivateAccelerator(event.windows_key_code);
     return;
   }
 


### PR DESCRIPTION
#### Description of Change

Fix pressing keys like `Alt+Shift` wrongly getting captured for menu shortcuts, close https://github.com/electron/electron/issues/28088.

#### Release Notes

Notes: Fix pressing `Alt+Shift` and `Alt+Ctrl` toggling menu bar on KDE.