### PR TITLE
chore: use base::Time::Now() directly

### DIFF
--- a/shell/browser/extensions/electron_extension_loader.cc
+++ b/shell/browser/extensions/electron_extension_loader.cc
@@ -125,7 +125,7 @@ void ElectronExtensionLoader::FinishExtensionLoad(
           extension_prefs, extension.get()->id(),
           extensions::pref_names::kPrefPreferences);
       auto preference = update.Create();
-      const base::Time install_time = base::Time().Now();
+      const base::Time install_time = base::Time::Now();
       preference->SetString(
           "install_time", base::NumberToString(install_time.ToInternalValue()));
     }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Just a code hygiene change, suggested by `clang-tidy`. Access the static method directly through the class instead of creating an instance. Makes this usage consistent with the rest of the code base.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
