### PR TITLE
build: ensure that mksnapshot for Apple Silicon has all of the needed files for snapshot generation 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -513,6 +513,7 @@ step-electron-build: &step-electron-build
         ninja -C out/Default electron:electron_mksnapshot_zip -j $NUMBER_OF_NINJA_PROCESSES
         ninja -C out/Default tools/v8_context_snapshot -j $NUMBER_OF_NINJA_PROCESSES
         gn desc out/Default v8:run_mksnapshot_default args > out/Default/mksnapshot_args
+        (cd out/Default; zip mksnapshot.zip mksnapshot_args clang_x64_v8_arm64/gen/v8/embedded.S)
         rm -rf out/Default/clang_x64_v8_arm64/obj
 
         # Regenerate because we just deleted some ninja files 


### PR DESCRIPTION
Backport of #29338

See that PR for details.


Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->Fixed using custom v8 snapshots on Apple Silicon.