### PR TITLE
docs: update Windows build instructions

### DIFF
--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -24,7 +24,7 @@ creating a full distribution since `symstore.exe` is used for creating a symbol
 store from `.pdb` files.
   * Different versions of the SDK can be installed side by side. To install the
   SDK, open Visual Studio Installer, select
-  `Change` → `Individual Components`, scroll down and select the appropriate
+  `Modify` → `Individual Components`, scroll down and select the appropriate
   Windows SDK to install. Another option would be to look at the
   [Windows SDK and emulator archive](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive)
   and download the standalone version of the SDK respectively.


### PR DESCRIPTION

#### Description of Change
Opening VS installer gives the option to "Modify" (and launch/open more options) rather than "Change" Visual Studio. Reflected this in the docs as as result.

![image](https://user-images.githubusercontent.com/33054982/119702075-e91e6b00-be09-11eb-9aea-7da901533dce.png)


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: changed wording in the Visual Studio Installer step.