### PR TITLE
build: remove individual release build workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,45 +17,23 @@ parameters:
     type: boolean
     default: true
 
-  run-linux-x64-publish:
-    type: boolean
-    default: false
-
-  run-linux-ia32-publish:
-    type: boolean
-    default: false
-
-  run-linux-arm-publish:
-    type: boolean
-    default: false
-
-  run-linux-arm64-publish:
-    type: boolean
-    default: false
-
-  run-osx-publish:
-    type: boolean
-    default: false
-
-  run-osx-publish-arm64:
-    type: boolean
-    default: false
-
-  run-mas-publish:
-    type: boolean
-    default: false
-
-  run-mas-publish-arm64:
-    type: boolean
-    default: false
-
   run-linux-publish:
     type: boolean
     default: false
 
+  linux-publish-arch-limit:
+    type: enum
+    default: all
+    enum: ["all", "arm", "arm64", "x64", "ia32"]
+
   run-macos-publish:
     type: boolean
     default: false
+
+  macos-publish-arch-limit:
+    type: enum
+    default: all
+    enum: ["all", "osx-x64", "osx-arm64", "mas-x64", "mas-arm64"]
 
 # Executors
 executors:
@@ -1839,9 +1817,15 @@ jobs:
       UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
       <<: *env-ninja-status
     steps:
-      - electron-publish:
-          attach: false
-          checkout: true
+      - when:
+          condition:
+            or:
+              - equal: ["all", << pipeline.parameters.linux-publish-arch-limit >>]
+              - equal: ["x64", << pipeline.parameters.linux-publish-arch-limit >>]
+          steps:
+            - electron-publish:
+                attach: false
+                checkout: true
 
   linux-ia32-testing:
     executor: linux-docker
@@ -1881,9 +1865,15 @@ jobs:
       UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
       <<: *env-ninja-status
     steps:
-      - electron-publish:
-          attach: false
-          checkout: true
+      - when:
+          condition:
+            or:
+              - equal: ["all", << pipeline.parameters.linux-publish-arch-limit >>]
+              - equal: ["ia32", << pipeline.parameters.linux-publish-arch-limit >>]
+          steps:
+            - electron-publish:
+                attach: false
+                checkout: true
 
   linux-arm-testing:
     executor: linux-docker
@@ -1926,9 +1916,15 @@ jobs:
       UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
       <<: *env-ninja-status
     steps:
-      - electron-publish:
-          attach: false
-          checkout: true
+      - when:
+          condition:
+            or:
+              - equal: ["all", << pipeline.parameters.linux-publish-arch-limit >>]
+              - equal: ["arm", << pipeline.parameters.linux-publish-arch-limit >>]
+          steps:
+            - electron-publish:
+                attach: false
+                checkout: true
 
   linux-arm64-testing:
     executor: linux-docker
@@ -1980,9 +1976,15 @@ jobs:
       UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
       <<: *env-ninja-status
     steps:
-      - electron-publish:
-          attach: false
-          checkout: true
+      - when:
+          condition:
+            or:
+              - equal: ["all", << pipeline.parameters.linux-publish-arch-limit >>]
+              - equal: ["arm64", << pipeline.parameters.linux-publish-arch-limit >>]
+          steps:
+            - electron-publish:
+                attach: false
+                checkout: true
 
   osx-testing-x64:
     executor: macos
@@ -2008,31 +2010,6 @@ jobs:
       <<: *env-testing-build
     <<: *steps-electron-gn-check
 
-  osx-publish-x64:
-    executor: macos
-    environment:
-      <<: *env-mac-large-release
-      <<: *env-release-build
-      UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
-      <<: *env-ninja-status
-    steps:
-      - electron-publish:
-          attach: false
-          checkout: true
-
-  osx-publish-arm64:
-    executor: macos
-    environment:
-      <<: *env-mac-large-release
-      <<: *env-release-build
-      <<: *env-apple-silicon
-      UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
-      <<: *env-ninja-status
-    steps:
-      - electron-publish:
-          attach: false
-          checkout: true
-
   osx-publish-x64-skip-checkout:
     executor: macos
     environment:
@@ -2041,9 +2018,15 @@ jobs:
       UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
       <<: *env-ninja-status
     steps:
-      - electron-publish:
-          attach: true
-          checkout: false
+      - when:
+          condition:
+            or:
+              - equal: ["all", << pipeline.parameters.macos-publish-arch-limit >>]
+              - equal: ["osx-x64", << pipeline.parameters.macos-publish-arch-limit >>]
+          steps:
+            - electron-publish:
+                attach: true
+                checkout: false
 
   osx-publish-arm64-skip-checkout:
     executor: macos
@@ -2054,9 +2037,15 @@ jobs:
       UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
       <<: *env-ninja-status
     steps:
-      - electron-publish:
-          attach: true
-          checkout: false
+      - when:
+          condition:
+            or:
+              - equal: ["all", << pipeline.parameters.macos-publish-arch-limit >>]
+              - equal: ["osx-arm64", << pipeline.parameters.macos-publish-arch-limit >>]
+          steps:
+            - electron-publish:
+                attach: true
+                checkout: false
 
   osx-testing-arm64:
     executor: macos
@@ -2100,32 +2089,6 @@ jobs:
       <<: *env-mas
       <<: *env-testing-build
     <<: *steps-electron-gn-check
-  
-  mas-publish:
-    executor: macos
-    environment:
-      <<: *env-mac-large-release
-      <<: *env-mas
-      <<: *env-release-build
-      UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
-      <<: *env-ninja-status
-    steps:
-      - electron-publish:
-          attach: false
-          checkout: true
-
-  mas-publish-arm64:
-    executor: macos
-    environment:
-      <<: *env-mac-large-release
-      <<: *env-mas-apple-silicon
-      <<: *env-release-build
-      UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
-      <<: *env-ninja-status
-    steps:
-      - electron-publish:
-          attach: false
-          checkout: true          
 
   mas-publish-x64-skip-checkout:
     executor: macos
@@ -2135,9 +2098,15 @@ jobs:
       <<: *env-release-build
       UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
     steps:
-      - electron-publish:
-          attach: true
-          checkout: false
+      - when:
+          condition:
+            or:
+              - equal: ["all", << pipeline.parameters.macos-publish-arch-limit >>]
+              - equal: ["mas-x64", << pipeline.parameters.macos-publish-arch-limit >>]
+          steps:
+            - electron-publish:
+                attach: true
+                checkout: false
 
   mas-publish-arm64-skip-checkout:
     executor: macos
@@ -2148,9 +2117,15 @@ jobs:
       UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
       <<: *env-ninja-status
     steps:
-      - electron-publish:
-          attach: true
-          checkout: false
+      - when:
+          condition:
+            or:
+              - equal: ["all", << pipeline.parameters.macos-publish-arch-limit >>]
+              - equal: ["mas-arm64", << pipeline.parameters.macos-publish-arch-limit >>]
+          steps:
+            - electron-publish:
+                attach: true
+                checkout: false
 
   mas-testing-arm64:
     executor: macos
@@ -2371,12 +2346,6 @@ jobs:
 workflows:
   version: 2.1
 
-  # The publish workflows below each contain one job so that they are
-  # compatible with how sudowoodo works today.  If these workflows are
-  # changed to have multiple jobs, then scripts/release/ci-release-build.js
-  # will need to be updated and there will most likely need to be changes to
-  # sudowoodo
-
   publish-linux:
     when: << pipeline.parameters.run-linux-publish >>
     jobs:
@@ -2387,54 +2356,6 @@ workflows:
     - linux-arm-publish:
         context: release-env
     - linux-arm64-publish:
-        context: release-env
-
-  publish-x64-linux:
-    when: << pipeline.parameters.run-linux-x64-publish >>
-    jobs:
-    - linux-x64-publish:
-        context: release-env
-
-  publish-ia32-linux:
-    when: << pipeline.parameters.run-linux-ia32-publish >>
-    jobs:
-    - linux-ia32-publish:
-        context: release-env
-
-  publish-arm-linux:
-    when: << pipeline.parameters.run-linux-arm-publish >>
-    jobs:
-    - linux-arm-publish:
-        context: release-env
-
-  publish-arm64-linux:
-    when: << pipeline.parameters.run-linux-arm64-publish >>
-    jobs:
-    - linux-arm64-publish:
-        context: release-env
-
-  publish-osx:
-    when: << pipeline.parameters.run-osx-publish >>
-    jobs:
-    - osx-publish-x64:
-        context: release-env
-
-  publish-mas:
-    when: << pipeline.parameters.run-mas-publish >>
-    jobs:
-    - mas-publish:
-        context: release-env
-
-  publish-osx-arm64:
-    when: << pipeline.parameters.run-osx-publish-arm64 >>
-    jobs:
-    - osx-publish-arm64:
-        context: release-env
-
-  publish-mas-arm64:
-    when: << pipeline.parameters.run-mas-publish-arm64 >>
-    jobs:
-    - mas-publish-arm64:
         context: release-env
 
   publish-macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1817,6 +1817,7 @@ jobs:
       UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
       <<: *env-ninja-status
     steps:
+      - run: echo running
       - when:
           condition:
             or:
@@ -1865,6 +1866,7 @@ jobs:
       UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
       <<: *env-ninja-status
     steps:
+      - run: echo running
       - when:
           condition:
             or:
@@ -1916,6 +1918,7 @@ jobs:
       UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
       <<: *env-ninja-status
     steps:
+      - run: echo running
       - when:
           condition:
             or:
@@ -1976,6 +1979,7 @@ jobs:
       UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
       <<: *env-ninja-status
     steps:
+      - run: echo running
       - when:
           condition:
             or:
@@ -2018,6 +2022,7 @@ jobs:
       UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
       <<: *env-ninja-status
     steps:
+      - run: echo running
       - when:
           condition:
             or:
@@ -2037,6 +2042,7 @@ jobs:
       UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
       <<: *env-ninja-status
     steps:
+      - run: echo running
       - when:
           condition:
             or:
@@ -2098,6 +2104,7 @@ jobs:
       <<: *env-release-build
       UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
     steps:
+      - run: echo running
       - when:
           condition:
             or:
@@ -2117,6 +2124,7 @@ jobs:
       UPLOAD_TO_S3: << pipeline.parameters.upload-to-s3 >>
       <<: *env-ninja-status
     steps:
+      - run: echo running
       - when:
           condition:
             or:

--- a/script/release/ci-release-build.js
+++ b/script/release/ci-release-build.js
@@ -20,16 +20,10 @@ const circleCIPublishWorkflows = [
   'macos-publish'
 ];
 
-const circleCIJobs = circleCIPublishWorkflows.concat([
-  'linux-arm-publish',
-  'linux-arm64-publish',
-  'linux-ia32-publish',
-  'linux-x64-publish',
-  'mas-publish',
-  'mas-publish-arm64',
-  'osx-publish',
-  'osx-publish-arm64'
-]);
+const circleCIPublishIndividualArches = {
+  'macos-publish': ['osx-x64', 'mas-x64', 'osx-arm64', 'mas-arm64'],
+  'linux-publish': ['arm', 'arm64', 'ia32', 'x64']
+};
 
 const vstsArmJobs = [
   'electron-arm-testing',
@@ -68,8 +62,8 @@ async function makeRequest (requestOptions, parseResponse) {
   });
 }
 
-async function circleCIcall (targetBranch, job, options) {
-  console.log(`Triggering CircleCI to run build job: ${job} on branch: ${targetBranch} with release flag.`);
+async function circleCIcall (targetBranch, workflowName, options) {
+  console.log(`Triggering CircleCI to run build job: ${workflowName} on branch: ${targetBranch} with release flag.`);
   const buildRequest = {
     branch: targetBranch,
     parameters: {
@@ -83,7 +77,13 @@ async function circleCIcall (targetBranch, job, options) {
   } else {
     buildRequest.parameters['upload-to-s3'] = '1';
   }
-  buildRequest.parameters[`run-${job}`] = true;
+  buildRequest.parameters[`run-${workflowName}`] = true;
+  if (options.arch) {
+    const validArches = circleCIPublishIndividualArches[workflowName];
+    assert(validArches.includes(options.arch), `Unknown CircleCI architecture "${options.arch}".  Valid values are ${JSON.stringify(validArches)}`);
+    buildRequest.parameters['macos-publish-arch-limit'] = options.arch;
+  }
+
   jobRequestedCount++;
   // The logic below expects that the CircleCI workflows for releases each
   // contain only one job in order to maintain compatibility with sudowoodo.
@@ -91,22 +91,22 @@ async function circleCIcall (targetBranch, job, options) {
   // also need to be changed as well as possibly changing sudowoodo.
   try {
     const circleResponse = await circleCIRequest(CIRCLECI_PIPELINE_URL, 'POST', buildRequest);
-    console.log(`CircleCI release build pipeline ${circleResponse.id} for ${job} triggered.`);
+    console.log(`CircleCI release build pipeline ${circleResponse.id} for ${workflowName} triggered.`);
     const workflowId = await getCircleCIWorkflowId(circleResponse.id);
     if (workflowId === -1) {
       return;
     }
     const workFlowUrl = `https://circleci.com/workflow-run/${workflowId}`;
     if (options.runningPublishWorkflows) {
-      console.log(`CircleCI release workflow request for ${job} successful.  Check ${workFlowUrl} for status.`);
+      console.log(`CircleCI release workflow request for ${workflowName} successful.  Check ${workFlowUrl} for status.`);
     } else {
-      console.log(`CircleCI release build workflow running at https://circleci.com/workflow-run/${workflowId} for ${job}.`);
+      console.log(`CircleCI release build workflow running at https://circleci.com/workflow-run/${workflowId} for ${workflowName}.`);
       const jobNumber = await getCircleCIJobNumber(workflowId);
       if (jobNumber === -1) {
         return;
       }
       const jobUrl = `https://circleci.com/gh/electron/electron/${jobNumber}`;
-      console.log(`CircleCI release build request for ${job} successful.  Check ${jobUrl} for status.`);
+      console.log(`CircleCI release build request for ${workflowName} successful.  Check ${jobUrl} for status.`);
     }
   } catch (err) {
     console.log('Error calling CircleCI: ', err);
@@ -247,9 +247,10 @@ async function callAppVeyor (targetBranch, job, options) {
 
 function buildCircleCI (targetBranch, options) {
   if (options.job) {
-    assert(circleCIJobs.includes(options.job), `Unknown CircleCI job name: ${options.job}. Valid values are: ${circleCIJobs}.`);
+    assert(circleCIPublishWorkflows.includes(options.job), `Unknown CircleCI workflow name: ${options.job}. Valid values are: ${circleCIPublishWorkflows}.`);
     circleCIcall(targetBranch, options.job, options);
   } else {
+    assert(!options.arch, 'Cannot provide a single architecture while building all workflows, please specify a single workflow via --workflow');
     options.runningPublishWorkflows = true;
     circleCIPublishWorkflows.forEach((job) => circleCIcall(targetBranch, job, options));
   }
@@ -364,7 +365,7 @@ if (require.main === module) {
   const targetBranch = args._[0];
   if (args._.length < 1) {
     console.log(`Trigger CI to build release builds of electron.
-    Usage: ci-release-build.js [--job=CI_JOB_NAME] [--ci=CircleCI|AppVeyor|VSTS|DevOps]
+    Usage: ci-release-build.js [--job=CI_JOB_NAME] [--arch=INDIVIDUAL_ARCH] [--ci=CircleCI|AppVeyor|VSTS|DevOps]
     [--ghRelease] [--armTest] [--circleBuildNum=xxx] [--appveyorJobId=xxx] TARGET_BRANCH
     `);
     process.exit(0);


### PR DESCRIPTION
Continuing circle simplification, this removes our "single job" publish workflows for linux and macOS and replaces them with the primary publish workflow but ensures that the other jobs have no steps if they aren't the selected arch.  This doesn't impact the normal sudowoodo flow, just ad-hoc release builds triggered by `ci-release-builds.js`

Notes: no-notes