### PR TITLE
chore: prefer empty() check for readability

### DIFF
--- a/shell/browser/api/message_port.cc
+++ b/shell/browser/api/message_port.cc
@@ -177,7 +177,7 @@ std::vector<blink::MessagePortChannel> MessagePort::DisentanglePorts(
     v8::Isolate* isolate,
     const std::vector<gin::Handle<MessagePort>>& ports,
     bool* threw_exception) {
-  if (!ports.size())
+  if (ports.empty())
     return std::vector<blink::MessagePortChannel>();
 
   std::unordered_set<MessagePort*> visited;

--- a/shell/browser/extensions/electron_extension_loader.cc
+++ b/shell/browser/extensions/electron_extension_loader.cc
@@ -54,7 +54,7 @@ std::pair<scoped_refptr<const Extension>, std::string> LoadUnpacked(
 
   std::string warnings;
   // Log warnings.
-  if (extension->install_warnings().size()) {
+  if (!extension->install_warnings().empty()) {
     warnings += "Warnings loading extension at " +
                 base::UTF16ToUTF8(extension_dir.LossyDisplayName()) + ":\n";
     for (const auto& warning : extension->install_warnings()) {

--- a/shell/browser/file_select_helper.cc
+++ b/shell/browser/file_select_helper.cc
@@ -162,8 +162,7 @@ void FileSelectHelper::OnOpenDialogDone(gin_helper::Dictionary result) {
       std::vector<ui::SelectedFileInfo> files =
           ui::FilePathListToSelectedFileInfoList(paths);
       // If we are uploading a folder we need to enumerate its contents
-      if (mode_ == FileChooserParams::Mode::kUploadFolder &&
-          paths.size() >= 1) {
+      if (mode_ == FileChooserParams::Mode::kUploadFolder && !paths.empty()) {
         lister_base_dir_ = paths[0];
         EnumerateDirectory();
       } else {

--- a/shell/common/asar/archive.cc
+++ b/shell/common/asar/archive.cc
@@ -58,7 +58,7 @@ bool GetChildNode(const base::DictionaryValue* root,
                   const std::string& name,
                   const base::DictionaryValue* dir,
                   const base::DictionaryValue** out) {
-  if (name == "") {
+  if (name.empty()) {
     *out = root;
     return true;
   }
@@ -72,7 +72,7 @@ bool GetChildNode(const base::DictionaryValue* root,
 bool GetNodeFromPath(std::string path,
                      const base::DictionaryValue* root,
                      const base::DictionaryValue** out) {
-  if (path == "") {
+  if (path.empty()) {
     *out = root;
     return true;
   }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Another PR like #26109. Prefer using `empty()` for checks instead of `size()` or comparison to an empty string.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
