### PR TITLE
chore: use consistent parameter names

### DIFF
--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -126,7 +126,7 @@ class App : public ElectronBrowserClient::Delegate,
   base::OnceClosure SelectClientCertificate(
       content::WebContents* web_contents,
       net::SSLCertRequestInfo* cert_request_info,
-      net::ClientCertIdentityList client_certs,
+      net::ClientCertIdentityList identities,
       std::unique_ptr<content::ClientCertificateDelegate> delegate) override;
   bool CanCreateWindow(content::RenderFrameHost* opener,
                        const GURL& opener_url,

--- a/shell/browser/api/electron_api_auto_updater.h
+++ b/shell/browser/api/electron_api_auto_updater.h
@@ -35,7 +35,7 @@ class AutoUpdater : public gin::Wrappable<AutoUpdater>,
   ~AutoUpdater() override;
 
   // Delegate implementations.
-  void OnError(const std::string& error) override;
+  void OnError(const std::string& message) override;
   void OnError(const std::string& message,
                const int code,
                const std::string& domain) override;

--- a/shell/browser/api/electron_api_download_item.cc
+++ b/shell/browser/api/electron_api_download_item.cc
@@ -74,17 +74,15 @@ const void* kElectronApiDownloadItemKey = &kElectronApiDownloadItemKey;
 gin::WrapperInfo DownloadItem::kWrapperInfo = {gin::kEmbedderNativeGin};
 
 // static
-DownloadItem* DownloadItem::FromDownloadItem(
-    download::DownloadItem* download_item) {
+DownloadItem* DownloadItem::FromDownloadItem(download::DownloadItem* item) {
   // ^- say that 7 times fast in a row
   auto* data = static_cast<UserDataLink*>(
-      download_item->GetUserData(kElectronApiDownloadItemKey));
+      item->GetUserData(kElectronApiDownloadItemKey));
   return data ? data->download_item.get() : nullptr;
 }
 
-DownloadItem::DownloadItem(v8::Isolate* isolate,
-                           download::DownloadItem* download_item)
-    : download_item_(download_item), isolate_(isolate) {
+DownloadItem::DownloadItem(v8::Isolate* isolate, download::DownloadItem* item)
+    : download_item_(item), isolate_(isolate) {
   download_item_->AddObserver(this);
   download_item_->SetUserData(
       kElectronApiDownloadItemKey,
@@ -119,7 +117,7 @@ void DownloadItem::OnDownloadUpdated(download::DownloadItem* item) {
   }
 }
 
-void DownloadItem::OnDownloadDestroyed(download::DownloadItem* download_item) {
+void DownloadItem::OnDownloadDestroyed(download::DownloadItem* /*item*/) {
   download_item_ = nullptr;
   Unpin();
 }

--- a/shell/browser/api/electron_api_download_item.h
+++ b/shell/browser/api/electron_api_download_item.h
@@ -30,7 +30,7 @@ class DownloadItem : public gin::Wrappable<DownloadItem>,
   static gin::Handle<DownloadItem> FromOrCreate(v8::Isolate* isolate,
                                                 download::DownloadItem* item);
 
-  static DownloadItem* FromDownloadItem(download::DownloadItem*);
+  static DownloadItem* FromDownloadItem(download::DownloadItem* item);
 
   // gin::Wrappable
   static gin::WrapperInfo kWrapperInfo;
@@ -44,14 +44,14 @@ class DownloadItem : public gin::Wrappable<DownloadItem>,
   file_dialog::DialogSettings GetSaveDialogOptions() const;
 
  private:
-  DownloadItem(v8::Isolate* isolate, download::DownloadItem* download_item);
+  DownloadItem(v8::Isolate* isolate, download::DownloadItem* item);
   ~DownloadItem() override;
 
   bool CheckAlive() const;
 
   // download::DownloadItem::Observer
-  void OnDownloadUpdated(download::DownloadItem* download) override;
-  void OnDownloadDestroyed(download::DownloadItem* download) override;
+  void OnDownloadUpdated(download::DownloadItem* item) override;
+  void OnDownloadDestroyed(download::DownloadItem* item) override;
 
   // JS API
   void Pause();

--- a/shell/browser/api/electron_api_notification.h
+++ b/shell/browser/api/electron_api_notification.h
@@ -86,7 +86,7 @@ class Notification : public gin::Wrappable<Notification>,
   void SetHasReply(bool new_has_reply);
   void SetUrgency(const std::u16string& new_urgency);
   void SetTimeoutType(const std::u16string& new_timeout_type);
-  void SetReplyPlaceholder(const std::u16string& new_reply_placeholder);
+  void SetReplyPlaceholder(const std::u16string& new_placeholder);
   void SetSound(const std::u16string& sound);
   void SetActions(const std::vector<electron::NotificationAction>& actions);
   void SetCloseButtonText(const std::u16string& text);

--- a/shell/browser/api/electron_api_url_loader.h
+++ b/shell/browser/api/electron_api_url_loader.h
@@ -97,7 +97,7 @@ class SimpleURLLoaderWrapper
                        int64_t sent_bytes) override {}
   void Clone(
       mojo::PendingReceiver<network::mojom::URLLoaderNetworkServiceObserver>
-          listener) override;
+          observer) override;
 
   // SimpleURLLoader callbacks
   void OnResponseStarted(const GURL& final_url,

--- a/shell/browser/auto_updater.h
+++ b/shell/browser/auto_updater.h
@@ -24,9 +24,9 @@ namespace auto_updater {
 class Delegate {
  public:
   // An error happened.
-  virtual void OnError(const std::string& error) {}
+  virtual void OnError(const std::string& message) {}
 
-  virtual void OnError(const std::string& error,
+  virtual void OnError(const std::string& message,
                        const int code,
                        const std::string& domain) {}
 

--- a/shell/browser/extensions/electron_messaging_delegate.h
+++ b/shell/browser/extensions/electron_messaging_delegate.h
@@ -45,7 +45,7 @@ class ElectronMessagingDelegate : public MessagingDelegate {
   void QueryIncognitoConnectability(
       content::BrowserContext* context,
       const Extension* extension,
-      content::WebContents* web_contents,
+      content::WebContents* source_contents,
       const GURL& url,
       base::OnceCallback<void(bool)> callback) override;
 

--- a/shell/browser/file_select_helper.h
+++ b/shell/browser/file_select_helper.h
@@ -74,11 +74,11 @@ class FileSelectHelper : public content::WebContentsObserver,
   // of the package.
   void ProcessSelectedFilesMac(const std::vector<ui::SelectedFileInfo>& files);
 
-  // Saves the paths of |zipped_files| for later deletion. Passes |files| to the
-  // render view host.
+  // Saves the paths of |temporary_files| for later deletion. Passes |files| to
+  // the render view host.
   void ProcessSelectedFilesMacOnUIThread(
       const std::vector<ui::SelectedFileInfo>& files,
-      const std::vector<base::FilePath>& zipped_files);
+      const std::vector<base::FilePath>& temporary_files);
 
   // Zips the package at |path| into a temporary destination. Returns the
   // temporary destination, if the zip was successful. Otherwise returns an

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -99,7 +99,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual bool IsNormal();
   virtual gfx::Rect GetNormalBounds() = 0;
   virtual void SetSizeConstraints(
-      const extensions::SizeConstraints& size_constraints);
+      const extensions::SizeConstraints& window_constraints);
   virtual extensions::SizeConstraints GetSizeConstraints() const;
   virtual void SetContentSizeConstraints(
       const extensions::SizeConstraints& size_constraints);

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -78,7 +78,7 @@ class NativeWindowMac : public NativeWindow,
   bool IsClosable() override;
   void SetAlwaysOnTop(ui::ZOrderLevel z_order,
                       const std::string& level,
-                      int relativeLevel) override;
+                      int relative_level) override;
   ui::ZOrderLevel GetZOrderLevel() override;
   void Center() override;
   void Invalidate() override;

--- a/shell/browser/notifications/mac/notification_presenter_mac.h
+++ b/shell/browser/notifications/mac/notification_presenter_mac.h
@@ -16,7 +16,7 @@ class CocoaNotification;
 
 class NotificationPresenterMac : public NotificationPresenter {
  public:
-  CocoaNotification* GetNotification(NSUserNotification* notif);
+  CocoaNotification* GetNotification(NSUserNotification* ns_notification);
 
   NotificationPresenterMac();
   ~NotificationPresenterMac() override;

--- a/shell/browser/osr/osr_render_widget_host_view.h
+++ b/shell/browser/osr/osr_render_widget_host_view.h
@@ -113,7 +113,7 @@ class OffScreenRenderWidgetHostView : public content::RenderWidgetHostViewBase,
   // content::RenderWidgetHostViewBase:
 
   void ResetFallbackToFirstNavigationSurface() override;
-  void InitAsPopup(content::RenderWidgetHostView* rwhv,
+  void InitAsPopup(content::RenderWidgetHostView* parent_host_view,
                    const gfx::Rect& rect) override;
   void UpdateCursor(const content::WebCursor&) override;
   void SetIsLoading(bool is_loading) override;
@@ -127,7 +127,7 @@ class OffScreenRenderWidgetHostView : public content::RenderWidgetHostViewBase,
       const gfx::Rect& src_rect,
       const gfx::Size& output_size,
       base::OnceCallback<void(const SkBitmap&)> callback) override;
-  void GetScreenInfo(blink::ScreenInfo* results) override;
+  void GetScreenInfo(blink::ScreenInfo* screen_info) override;
   void TransformPointToRootSurface(gfx::PointF* point) override;
   gfx::Rect GetBoundsInRootWindow(void) override;
   base::Optional<content::DisplayFeature> GetDisplayFeature() override;

--- a/shell/browser/relauncher.h
+++ b/shell/browser/relauncher.h
@@ -50,10 +50,10 @@ using StringVector = base::CommandLine::StringVector;
 
 // Relaunches the application using the helper application associated with the
 // currently running instance of Chrome in the parent browser process as the
-// executable for the relauncher process. |args| is an argv-style vector of
-// command line arguments of the form normally passed to execv. args[0] is
+// executable for the relauncher process. |argv| is an argv-style vector of
+// command line arguments of the form normally passed to execv. argv[0] is
 // also the path to the relaunched process. Because the relauncher process
-// will ultimately launch the relaunched process via Launch Services, args[0]
+// will ultimately launch the relaunched process via Launch Services, argv[0]
 // may be either a pathname to an executable file or a pathname to an .app
 // bundle directory. The caller should exit soon after RelaunchApp returns
 // successfully. Returns true on success, although some failures can occur
@@ -63,7 +63,7 @@ bool RelaunchApp(const StringVector& argv);
 
 // Identical to RelaunchApp, but uses |helper| as the path to the relauncher
 // process, and allows additional arguments to be supplied to the relauncher
-// process in relauncher_args. Unlike args[0], |helper| must be a pathname to
+// process in relauncher_args. Unlike argv[0], |helper| must be a pathname to
 // an executable file. The helper path given must be from the same version of
 // Chrome as the running parent browser process, as there are no guarantees
 // that the parent and relauncher processes from different versions will be
@@ -72,7 +72,7 @@ bool RelaunchApp(const StringVector& argv);
 // location's helper.
 bool RelaunchAppWithHelper(const base::FilePath& helper,
                            const StringVector& relauncher_args,
-                           const StringVector& args);
+                           const StringVector& argv);
 
 // The entry point from ChromeMain into the relauncher process.
 int RelauncherMain(const content::MainFunctionParams& main_parameters);

--- a/shell/browser/ui/accelerator_util.h
+++ b/shell/browser/ui/accelerator_util.h
@@ -20,7 +20,7 @@ typedef struct {
 typedef std::map<ui::Accelerator, MenuItem> AcceleratorTable;
 
 // Parse a string as an accelerator.
-bool StringToAccelerator(const std::string& description,
+bool StringToAccelerator(const std::string& shortcut,
                          ui::Accelerator* accelerator);
 
 // Generate a table that contains memu model's accelerators and command ids.

--- a/shell/browser/web_dialog_helper.h
+++ b/shell/browser/web_dialog_helper.h
@@ -35,7 +35,7 @@ class WebDialogHelper {
                       const blink::mojom::FileChooserParams& params);
   void EnumerateDirectory(content::WebContents* web_contents,
                           scoped_refptr<content::FileSelectListener> listener,
-                          const base::FilePath& path);
+                          const base::FilePath& dir);
 
  private:
   NativeWindow* window_;

--- a/shell/common/asar/archive.cc
+++ b/shell/common/asar/archive.cc
@@ -237,7 +237,7 @@ bool Archive::Stat(const base::FilePath& path, Stats* stats) {
 }
 
 bool Archive::Readdir(const base::FilePath& path,
-                      std::vector<base::FilePath>* list) {
+                      std::vector<base::FilePath>* files) {
   if (!header_)
     return false;
 
@@ -245,13 +245,13 @@ bool Archive::Readdir(const base::FilePath& path,
   if (!GetNodeFromPath(path.AsUTF8Unsafe(), header_.get(), &node))
     return false;
 
-  const base::DictionaryValue* files;
-  if (!GetFilesNode(header_.get(), node, &files))
+  const base::DictionaryValue* files_node;
+  if (!GetFilesNode(header_.get(), node, &files_node))
     return false;
 
-  base::DictionaryValue::Iterator iter(*files);
+  base::DictionaryValue::Iterator iter(*files_node);
   while (!iter.IsAtEnd()) {
-    list->push_back(base::FilePath::FromUTF8Unsafe(iter.key()));
+    files->push_back(base::FilePath::FromUTF8Unsafe(iter.key()));
     iter.Advance();
   }
   return true;

--- a/shell/renderer/api/electron_api_spell_check_client.h
+++ b/shell/renderer/api/electron_api_spell_check_client.h
@@ -76,7 +76,7 @@ class SpellCheckClient : public blink::WebSpellCheckPanelHostClient,
   // Output variable contraction_words will contain individual
   // words in the contraction.
   bool IsContraction(const SpellCheckScope& scope,
-                     const std::u16string& word,
+                     const std::u16string& contraction,
                      std::vector<std::u16string>* contraction_words);
 
   // Callback for the JS API which returns the list of misspelled words.

--- a/shell/renderer/renderer_client_base.h
+++ b/shell/renderer/renderer_client_base.h
@@ -65,7 +65,7 @@ class RendererClientBase : public content::ContentRendererClient
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
   // service_manager::LocalInterfaceProvider implementation.
   void GetInterface(const std::string& name,
-                    mojo::ScopedMessagePipeHandle request_handle) override;
+                    mojo::ScopedMessagePipeHandle interface_pipe) override;
 #endif
 
   virtual void DidCreateScriptContext(v8::Handle<v8::Context> context,


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Another PR like #26162. Aims to keep parameter names consistent between declaration and definition. Some of them are judgement calls, where I tended to go with the path of least resistance which was change the name in the declaration.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
