### PR TITLE
docs: remove freenode channel from support list

### DIFF
--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -16,7 +16,6 @@ you can interact with the community in these locations:
   * Sharing ideas with other Electron app developers
   * And more!
 * [`electron`](https://discuss.atom.io/c/electron) category on the Atom forums
-* `#atom-shell` channel on Freenode
 * `#electron` channel on [Atom's Slack](https://discuss.atom.io/t/join-us-on-slack/16638?source_topic_id=25406)
 * [`electron-ru`](https://telegram.me/electron_ru) *(Russian)*
 * [`electron-br`](https://electron-br.slack.com) *(Brazilian Portuguese)*


### PR DESCRIPTION
#### Description of Change
Freenode has been [taken over by a malicious actor](https://gist.github.com/joepie91/df80d8d36cd9d1bde46ba018af497409). Further, that channel was only very lightly used. Let's not recommend it any more.

Notes: none