### PR TITLE
chore: move destructors to header so they can be trivially destructible

### DIFF
--- a/shell/common/gin_helper/error_thrower.cc
+++ b/shell/common/gin_helper/error_thrower.cc
@@ -15,8 +15,6 @@ ErrorThrower::ErrorThrower(v8::Isolate* isolate) : isolate_(isolate) {}
 // costly to invoke
 ErrorThrower::ErrorThrower() : isolate_(v8::Isolate::GetCurrent()) {}
 
-ErrorThrower::~ErrorThrower() = default;
-
 void ErrorThrower::ThrowError(base::StringPiece err_msg) const {
   Throw(v8::Exception::Error, err_msg);
 }

--- a/shell/common/gin_helper/error_thrower.h
+++ b/shell/common/gin_helper/error_thrower.h
@@ -14,8 +14,7 @@ class ErrorThrower {
  public:
   explicit ErrorThrower(v8::Isolate* isolate);
   ErrorThrower();
-
-  ~ErrorThrower();
+  ~ErrorThrower() = default;
 
   void ThrowError(base::StringPiece err_msg) const;
   void ThrowTypeError(base::StringPiece err_msg) const;

--- a/shell/common/gin_helper/object_template_builder.cc
+++ b/shell/common/gin_helper/object_template_builder.cc
@@ -11,8 +11,6 @@ ObjectTemplateBuilder::ObjectTemplateBuilder(
     v8::Local<v8::ObjectTemplate> templ)
     : isolate_(isolate), template_(templ) {}
 
-ObjectTemplateBuilder::~ObjectTemplateBuilder() = default;
-
 ObjectTemplateBuilder& ObjectTemplateBuilder::SetImpl(
     const base::StringPiece& name,
     v8::Local<v8::Data> val) {

--- a/shell/common/gin_helper/object_template_builder.h
+++ b/shell/common/gin_helper/object_template_builder.h
@@ -21,7 +21,7 @@ class ObjectTemplateBuilder {
  public:
   ObjectTemplateBuilder(v8::Isolate* isolate,
                         v8::Local<v8::ObjectTemplate> templ);
-  ~ObjectTemplateBuilder();
+  ~ObjectTemplateBuilder() = default;
 
   // It's against Google C++ style to return a non-const ref, but we take some
   // poetic license here in order that all calls to Set() can be via the '.'


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Another `clang-tidy` suggestion: `class 'ErrorThrower' can be made trivially destructible by defaulting the destructor on its first declaration [performance-trivially-destructible]`

Moving the default destructors to the header allows these two classes to be trivially destructible, which is nice.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
