### PR TITLE
docs: modernize protocol-handler docs

### DIFF
--- a/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/index.html
+++ b/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/index.html
@@ -1,35 +1,81 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="UTF-8">
-    <title>Hello World!</title>
-  </head>
+
+<head>
+  <meta charset="UTF-8">
+  <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'">
+  <meta http-equiv="X-Content-Security-Policy" content="default-src 'self'; script-src 'self'">
+  <title>app.setAsDefaultProtocol Demo</title>
+</head>
+
 <body>
-  <section>
-    <header>
-        <h1>
-          Protocol Handler
-        </h1>
-        <h3>The protocol API allows us to register a custom protocol and intercept existing protocol requests.</h3>
-        <p>These methods allow you to set and unset the protocols your app should be the default app for. Similar to when a browser asks to be your default for viewing web pages.</p>
+  <h1>App Default Protocol Demo</h1>
 
-        <p>Open the <a href="https://www.electronjs.org/docs/api/protocol">full protocol API documentation</a> in your browser.</p>
-    </header>
+  <p>The protocol API allows us to register a custom protocol and intercept existing protocol requests.</p>
+  <p>These methods allow you to set and unset the protocols your app should be the default app for. Similar to when a
+    browser asks to be your default for viewing web pages.</p>
 
-    <div >
-        <section id='open-app-link'>
-          <a href="myapp://open">Now... launch the app from a web link</a>
-        </section>
-        <div >
-          <p>You can set your app as the default app to open for a specific protocol. For instance, in this demo we set this app as the default for <code>myapp://</code>. The link above will launch a page in your default browser with a link. Click that link and it will re-launch this app.</p>
-  
-    </div>
-    <script type="text/javascript">
-        require('./renderer.js')
-    </script>
-</section>
+  <p>Open the <a href="https://www.electronjs.org/docs/api/protocol">full protocol API documentation</a> in your
+    browser.</p>
+
+  -----
+
+  <h3>Demo</h3>
+  <p>
+    First: Launch current page in browser
+    <button id="open-in-browser" class="js-container-target demo-toggle-button">
+        Click to Launch Browser
+      </button>
+  </p>
+
+  <p>
+    Then: Launch the app from a web link!
+    <a href="electron-fiddle://open">Click here to launch the app</a>
+  </p>
+
+  ----
+
+  <p>You can set your app as the default app to open for a specific protocol. For instance, in this demo we set this app
+    as the default for <code>electron-fiddle://</code>. The demo button above will launch a page in your default
+    browser with a link. Click that link and it will re-launch this app.</p>
+
+
+  <h3>Packaging</h3>
+  <p>This feature will only work on macOS when your app is packaged. It will not work when you're launching it in
+    development from the command-line. When you package your app you'll need to make sure the macOS <code>plist</code>
+    for the app is updated to include the new protocol handler. If you're using <code>electron-packager</code> then you
+    can add the flag <code>--extend-info</code> with a path to the <code>plist</code> you've created. The one for this
+    app is below:</p>
+
+  <p>
+  <h5>macOS plist</h5>
+  <pre><code>
+    <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+                <dict>
+                    <key>CFBundleURLTypes</key>
+                    <array>
+                        <dict>
+                            <key>CFBundleURLSchemes</key>
+                            <array>
+                                <string>electron-api-demos</string>
+                            </array>
+                            <key>CFBundleURLName</key>
+                            <string>Electron API Demos Protocol</string>
+                        </dict>
+                    </array>
+                    <key>ElectronTeamID</key>
+                    <string>VEKTX9H2N7</string>
+                </dict>
+            </plist>
+        </code>
+    </pre>
+  <p>
+
+    <!-- You can also require other files to run in this process -->
+    <script src="./renderer.js"></script>
 </body>
-</html>
 
-  </body>
 </html>

--- a/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/index.html
+++ b/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/index.html
@@ -10,76 +10,19 @@
         <h1>
           Protocol Handler
         </h1>
-        <h3>The <code>app</code> module provides methods for handling protocols.</h3>
+        <h3>The protocol API allows us to register a custom protocol and intercept existing protocol requests.</h3>
         <p>These methods allow you to set and unset the protocols your app should be the default app for. Similar to when a browser asks to be your default for viewing web pages.</p>
 
-        <p>Open the <a href="https://electronjs.org/docs/api/app">full app API documentation<span class="u-visible-to-screen-reader">(opens in new window)</span></a> in your browser.</p>
+        <p>Open the <a href="https://www.electronjs.org/docs/api/protocol">full protocol API documentation</a> in your browser.</p>
     </header>
 
     <div >
-        <button id="open-in-browser" class="js-container-target demo-toggle-button">Launch current page in browser
-          <div class="demo-meta u-avoid-clicks">Supports: Win, macOS <span class="demo-meta-divider">|</span> Process: Main</div>
-        </button>
         <section id='open-app-link'>
-          <a href="electron-api-demos://open">Now... launch the app from a web link</a>
+          <a href="myapp://open">Now... launch the app from a web link</a>
         </section>
         <div >
-          <p>You can set your app as the default app to open for a specific protocol. For instance, in this demo we set this app as the default for <code>electron-api-demos://</code>. The demo button above will launch a page in your default browser with a link. Click that link and it will re-launch this app.</p>
-          <h5>Packaging</h5>
-          <p>This feature will only work on macOS when your app is packaged. It will not work when you're launching it in development from the command-line. When you package your app you'll need to make sure the macOS <code>plist</code> for the app is updated to include the new protocol handler. If you're using <code>electron-packager</code> then you can add the flag <code>--extend-info</code> with a path to the <code>plist</code> you've created. The one for this app is below.</p>
-          <h5>Renderer Process</h5>
-          <pre><code>
-            const {shell} = require('electron')
-            const path = require('path')
-            const protocolHandlerBtn = document.getElementById('protocol-handler')
-            protocolHandlerBtn.addEventListener('click', () => {
-                const pageDirectory = __dirname.replace('app.asar', 'app.asar.unpacked')
-                const pagePath = path.join('file://', pageDirectory, '../../sections/system/protocol-link.html')
-                shell.openExternal(pagePath)
-            })
-          </code></pre>
-          <h5>Main Process</h5>
-          <pre><code>
-            const {app, dialog} = require('electron')
-            const path = require('path')
-
-            if (process.defaultApp) {
-                if (process.argv.length >= 2) {
-                    app.setAsDefaultProtocolClient('electron-api-demos', process.execPath, [path.resolve(process.argv[1])])
-                }
-            } else {
-                app.setAsDefaultProtocolClient('electron-api-demos')
-            }
-
-            app.on('open-url', (event, url) => {
-                dialog.showErrorBox('Welcome Back', `You arrived from: ${url}`)
-            })
-
-          </code></pre>
-          <h5>macOS plist</h5>
-          <pre><code>
-            <?xml version="1.0" encoding="UTF-8"?>
-                <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-                    <plist version="1.0">
-                        <dict>
-                            <key>CFBundleURLTypes</key>
-                            <array>
-                                <dict>
-                                    <key>CFBundleURLSchemes</key>
-                                    <array>
-                                        <string>electron-api-demos</string>
-                                    </array>
-                                    <key>CFBundleURLName</key>
-                                    <string>Electron API Demos Protocol</string>
-                                </dict>
-                            </array>
-                            <key>ElectronTeamID</key>
-                            <string>VEKTX9H2N7</string>
-                        </dict>
-                    </plist>
-                </code>
-            </pre>
-        </div>
+          <p>You can set your app as the default app to open for a specific protocol. For instance, in this demo we set this app as the default for <code>myapp://</code>. The link above will launch a page in your default browser with a link. Click that link and it will re-launch this app.</p>
+  
     </div>
     <script type="text/javascript">
         require('./renderer.js')

--- a/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/index.html
+++ b/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/index.html
@@ -51,7 +51,7 @@
   <p>
   <h5>macOS plist</h5>
   <pre><code>
-    <?xml version="1.0" encoding="UTF-8"?>
+    &lt;?xml version="1.0" encoding="UTF-8"?&gt;
     &lt;!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"&gt;
             &lt;plist version="1.0"&gt;
                 &lt;dict&gt;

--- a/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/index.html
+++ b/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/index.html
@@ -51,7 +51,7 @@
   <p>
   <h5>macOS plist</h5>
   <pre><code>
-    &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+    <?xml version="1.0" encoding="UTF-8"?>
     &lt;!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"&gt;
             &lt;plist version="1.0"&gt;
                 &lt;dict&gt;

--- a/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/index.html
+++ b/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/index.html
@@ -51,25 +51,25 @@
   <p>
   <h5>macOS plist</h5>
   <pre><code>
-    <?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-            <plist version="1.0">
-                <dict>
-                    <key>CFBundleURLTypes</key>
-                    <array>
-                        <dict>
-                            <key>CFBundleURLSchemes</key>
-                            <array>
-                                <string>electron-api-demos</string>
-                            </array>
-                            <key>CFBundleURLName</key>
-                            <string>Electron API Demos Protocol</string>
-                        </dict>
-                    </array>
-                    <key>ElectronTeamID</key>
-                    <string>VEKTX9H2N7</string>
-                </dict>
-            </plist>
+    &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+    &lt;!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"&gt;
+            &lt;plist version="1.0"&gt;
+                &lt;dict&gt;
+                    &lt;key&gt;CFBundleURLTypes&lt;/key&gt;
+                    &lt;array&gt;
+                        &lt;dict&gt;
+                            &lt;key&gt;CFBundleURLSchemes&lt;/key&gt;
+                            &lt;array&gt;
+                                &lt;string&gt;electron-api-demos&lt;/string&gt;
+                            &lt;/array&gt;
+                            &lt;key&gt;CFBundleURLName&lt;/key&gt;
+                            &lt;string&gt;Electron API Demos Protocol&lt;/string&gt;
+                        &lt;/dict&gt;
+                    &lt;/array&gt;
+                    &lt;key&gt;ElectronTeamID&lt;/key&gt;
+                    &lt;string&gt;VEKTX9H2N7&lt;/string&gt;
+                &lt;/dict&gt;
+            &lt;/plist&gt;
         </code>
     </pre>
   <p>

--- a/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/main.js
+++ b/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/main.js
@@ -1,69 +1,43 @@
 // Modules to control application life and create native browser window
-const { app, BrowserWindow, dialog } = require('electron')
+const {app, protocol, BrowserWindow, BrowserView} = require('electron')
 const path = require('path')
 
-// Keep a global reference of the window object, if you don't, the window will
-// be closed automatically when the JavaScript object is garbage collected.
-let mainWindow
+protocol.registerSchemesAsPrivileged([
+  { scheme: 'myapp', privileges: { standard: true } }
+])
 
 function createWindow () {
   // Create the browser window.
-  mainWindow = new BrowserWindow({
+  const mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
     webPreferences: {
-      nodeIntegration: true
+      preload: path.join(__dirname, 'preload.js')
     }
   })
 
   // and load the index.html of the app.
   mainWindow.loadFile('index.html')
-
-  // Open the DevTools.
-  mainWindow.webContents.openDevTools()
-
-  // Emitted when the window is closed.
-  mainWindow.on('closed', function () {
-    // Dereference the window object, usually you would store windows
-    // in an array if your app supports multi windows, this is the time
-    // when you should delete the corresponding element.
-    mainWindow = null
-  })
 }
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.whenReady().then(createWindow)
+app.whenReady().then(() => {
+  protocol.registerStringProtocol('myapp', (request, response) => {
+    response('<p>hello from myapp://</p>')
+  })
 
-// Quit when all windows are closed.
+  createWindow()
+  
+  app.on('activate', function () {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow()
+  })
+})
+
+// Quit when all windows are closed, except on macOS. There, it's common
+// for applications and their menu bar to stay active until the user quits
+// explicitly with Cmd + Q.
 app.on('window-all-closed', function () {
-  // On macOS it is common for applications and their menu bar
-  // to stay active until the user quits explicitly with Cmd + Q
-  if (process.platform !== 'darwin') {
-    app.quit()
-  }
-})
-
-app.on('activate', function () {
-  // On macOS it is common to re-create a window in the app when the
-  // dock icon is clicked and there are no other windows open.
-  if (mainWindow === null) {
-    createWindow()
-  }
-})
-
-// In this file you can include the rest of your app's specific main process
-// code. You can also put them in separate files and require them here.
-
-if (process.defaultApp) {
-  if (process.argv.length >= 2) {
-    app.setAsDefaultProtocolClient('electron-api-demos', process.execPath, [path.resolve(process.argv[1])])
-  }
-} else {
-  app.setAsDefaultProtocolClient('electron-api-demos')
-}
-
-app.on('open-url', (event, url) => {
-  dialog.showErrorBox('Welcome Back', `You arrived from: ${url}`)
+  if (process.platform !== 'darwin') app.quit()
 })

--- a/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/main.js
+++ b/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/main.js
@@ -2,6 +2,8 @@
 const { app, BrowserWindow, ipcMain, shell } = require('electron')
 const path = require('path')
 
+let mainWindow;
+
 if (process.defaultApp) {
   if (process.argv.length >= 2) {
     app.setAsDefaultProtocolClient('electron-fiddle', process.execPath, [path.resolve(process.argv[1])])
@@ -10,9 +12,32 @@ if (process.defaultApp) {
     app.setAsDefaultProtocolClient('electron-fiddle')
 }
 
+const gotTheLock = app.requestSingleInstanceLock()
+
+if (!gotTheLock) {
+  app.quit()
+} else {
+  app.on('second-instance', (event, commandLine, workingDirectory) => {
+    // Someone tried to run a second instance, we should focus our window.
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) mainWindow.restore()
+      mainWindow.focus()
+    }
+  })
+
+  // Create mainWindow, load the rest of the app, etc...
+  app.whenReady().then(() => {
+    createWindow()
+  })
+  
+  app.on('open-url', (event, url) => {
+      dialog.showErrorBox('Welcome Back', `You arrived from: ${url}`)
+  })
+}
+
 function createWindow () {
   // Create the browser window.
-  const mainWindow = new BrowserWindow({
+  mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
     webPreferences: {
@@ -28,17 +53,6 @@ function createWindow () {
 // explicitly with Cmd + Q.
 app.on('window-all-closed', function () {
   if (process.platform !== 'darwin') app.quit()
-})
-
-// This method will be called when Electron has finished
-// initialization and is ready to create browser windows.
-// Some APIs can only be used after this event occurs.
-app.whenReady().then(() => {
-  mainWindow = createWindow()
-})
-
-app.on('open-url', (event, url) => {
-    dialog.showErrorBox('Welcome Back', `You arrived from: ${url}`)
 })
 
 // Handle window controls via IPC

--- a/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/main.js
+++ b/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/main.js
@@ -31,7 +31,7 @@ if (!gotTheLock) {
   })
   
   app.on('open-url', (event, url) => {
-      dialog.showErrorBox('Welcome Back', `You arrived from: ${url}`)
+    dialog.showErrorBox('Welcome Back', `You arrived from: ${url}`)
   })
 }
 
@@ -56,7 +56,7 @@ app.on('window-all-closed', function () {
 })
 
 // Handle window controls via IPC
-ipcMain.on('shell:open', (ipcEvent) => {
+ipcMain.on('shell:open', () => {
   const pageDirectory = __dirname.replace('app.asar', 'app.asar.unpacked')
   const pagePath = path.join('file://', pageDirectory, 'index.html')
   shell.openExternal(pagePath)

--- a/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/preload.js
+++ b/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/preload.js
@@ -1,0 +1,12 @@
+// All of the Node.js APIs are available in the preload process.
+// It has the same sandbox as a Chrome extension.
+const { contextBridge, ipcRenderer } = require('electron')
+
+// Set up context bridge between the renderer process and the main process
+contextBridge.exposeInMainWorld(
+  'shell',
+  {
+    open: () => ipcRenderer.send('shell:open'),
+    close: () => ipcRenderer.send('shell:close'),
+  }
+)

--- a/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/preload.js
+++ b/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/preload.js
@@ -7,6 +7,5 @@ contextBridge.exposeInMainWorld(
   'shell',
   {
     open: () => ipcRenderer.send('shell:open'),
-    close: () => ipcRenderer.send('shell:close'),
   }
 )

--- a/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/renderer.js
+++ b/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/renderer.js
@@ -1,14 +1,12 @@
-const { shell } = require('electron')
-const path = require('path')
+// All of the Node.js APIs are available in the preload process.
+// It has the same sandbox as a Chrome extension.
+window.addEventListener('DOMContentLoaded', () => {
+  const replaceText = (selector, text) => {
+    const element = document.getElementById(selector)
+    if (element) element.innerText = text
+  }
 
-const openInBrowserButton = document.getElementById('open-in-browser')
-const openAppLink = document.getElementById('open-app-link')
-// Hides openAppLink when loaded inside Electron
-openAppLink.style.display = 'none'
-
-openInBrowserButton.addEventListener('click', () => {
-  console.log('clicked')
-  const pageDirectory = __dirname.replace('app.asar', 'app.asar.unpacked')
-  const pagePath = path.join('file://', pageDirectory, 'index.html')
-  shell.openExternal(pagePath)
+  for (const type of ['chrome', 'node', 'electron']) {
+    replaceText(`${type}-version`, process.versions[type])
+  }
 })

--- a/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/renderer.js
+++ b/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/renderer.js
@@ -1,12 +1,8 @@
-// All of the Node.js APIs are available in the preload process.
-// It has the same sandbox as a Chrome extension.
-window.addEventListener('DOMContentLoaded', () => {
-  const replaceText = (selector, text) => {
-    const element = document.getElementById(selector)
-    if (element) element.innerText = text
-  }
+// This file is required by the index.html file and will
+// be executed in the renderer process for that window.
+// All APIs exposed by the context bridge are available here.
 
-  for (const type of ['chrome', 'node', 'electron']) {
-    replaceText(`${type}-version`, process.versions[type])
-  }
-})
+// Binds the buttons to the context bridge API.
+document.getElementById('open-in-browser').addEventListener('click', () => {
+  shell.open();
+});

--- a/docs/tutorial/launch-app-from-url-in-another-app.md
+++ b/docs/tutorial/launch-app-from-url-in-another-app.md
@@ -1,0 +1,172 @@
+---
+title: launch-app-from-URL-in-another-app
+description: This guide will take you through the process of setting your electron app as the default handler for a specific protocol.
+slug: launch-app-from-url-in-another-app
+hide_title: true
+---
+
+# launch-app-from-URL-in-another-app
+
+## Overview
+
+<!-- ✍ Update this section if you want to provide more details -->
+
+This guide will take you through the process of setting your electron app as the default handler for a specific [protocol](https://www.electronjs.org/docs/api/protocol).
+
+By the end of this tutorial, we will have set our app to intercept and handle any clicked URLs that start with a specific protocol. In this guide, the protocol we will use will be "`electron-fiddle://`".
+
+## Examples
+
+### Main Process (main.js)
+
+First we will import the required modules from `electron`. These modules help control our application life and create a native browser window.
+
+```js
+const { app, BrowserWindow, shell } = require('electron')
+const path = require('path')
+```
+
+Next, we will proceed to register our application to handle all "`electron-fiddle://`" protocols.
+
+```js
+if (process.defaultApp) {
+  if (process.argv.length >= 2) {
+    app.setAsDefaultProtocolClient('electron-fiddle', process.execPath, [path.resolve(process.argv[1])])
+  }
+} else {
+  app.setAsDefaultProtocolClient('electron-fiddle')
+}
+```
+
+We will now define the function in charge of creating our browser window and load our application's `index.html` file.
+
+```js
+function createWindow () {
+  // Create the browser window.
+  mainWindow = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js')
+    }
+  })
+
+  mainWindow.loadFile('index.html')
+}
+```
+
+In this next step, we will create our  `BrowserWindow` and tell our application how to handle an event in which an external protocol is clicked.
+
+This code will be different in WindowsOS compared to MacOS and Linux. This is due to Windows requiring additional code in order to open the contents of the protocol link within the same electron instance. Read more about this [here](https://www.electronjs.org/docs/api/app#apprequestsingleinstancelock).
+
+### Windows code:
+
+```js
+const gotTheLock = app.requestSingleInstanceLock()
+
+if (!gotTheLock) {
+  app.quit()
+} else {
+  app.on('second-instance', (event, commandLine, workingDirectory) => {
+    // Someone tried to run a second instance, we should focus our window.
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) mainWindow.restore()
+      mainWindow.focus()
+    }
+  })
+
+  // Create mainWindow, load the rest of the app, etc...
+  app.whenReady().then(() => {
+    createWindow()
+  })
+
+  // handling the protocol. In this case, we choose to show an Error Box.
+  app.on('open-url', (event, url) => {
+    dialog.showErrorBox('Welcome Back', `You arrived from: ${url}`)
+  })
+}
+```
+
+### MacOS and Linux code:
+
+```js
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.whenReady().then(() => {
+  createWindow()
+})
+
+// handling the protocol. In this case, we choose to show an Error Box.
+app.on('open-url', (event, url) => {
+  dialog.showErrorBox('Welcome Back', `You arrived from: ${url}`)
+})
+```
+
+Finally, we will add some additional code to handle when someone closes our application
+
+```js
+// Quit when all windows are closed, except on macOS. There, it's common
+// for applications and their menu bar to stay active until the user quits
+// explicitly with Cmd + Q.
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit()
+})
+```
+
+## Important Note:
+
+### Packaging
+
+This feature will only work on macOS when your app is packaged. It will not work when you're launching it in development from the command-line. When you package your app you'll need to make sure the macOS `plist` for the app is updated to include the new protocol handler. If you're using [`electron-packager`](https://github.com/electron/electron-packager) then you
+can add the flag `--extend-info` with a path to the `plist` you've created. The one for this app is below:
+
+### Plist
+
+```XML
+  <p>
+  <h5>macOS plist</h5>
+  <pre><code>
+    <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+                <dict>
+                    <key>CFBundleURLTypes</key>
+                    <array>
+                        <dict>
+                            <key>CFBundleURLSchemes</key>
+                            <array>
+                                <string>electron-api-demos</string>
+                            </array>
+                            <key>CFBundleURLName</key>
+                            <string>Electron API Demos Protocol</string>
+                        </dict>
+                    </array>
+                    <key>ElectronTeamID</key>
+                    <string>VEKTX9H2N7</string>
+                </dict>
+            </plist>
+        </code>
+    </pre>
+  <p>
+```
+
+## Conclusion
+
+After you start your electron app, you can now enter in a URL in your browser that contains the custom protocol, for example `"electron-fiddle://open"` and observe that the application will respond and show an error dialog box.
+
+<!--
+    Because Electron examples usually require multiple files (HTML, CSS, JS
+    for the main and renderer process, etc.), we use this custom code block
+    for Fiddle (https://www.electronjs.org/fiddle).
+    Please modify any of the files in the referenced folder to fit your
+    example.
+    The content in this codeblock will not be rendered in the website so you
+    can leave it empty.
+-->
+
+```fiddle docs/fiddles/system/protocol-handler/launch-app-from-url-in-another-app
+
+```
+
+<!-- ✍ Explanation of the code below -->

--- a/docs/tutorial/launch-app-from-url-in-another-app.md
+++ b/docs/tutorial/launch-app-from-url-in-another-app.md
@@ -5,15 +5,18 @@ slug: launch-app-from-url-in-another-app
 hide_title: true
 ---
 
-# launch-app-from-URL-in-another-app
+# Launching Your Electron App From A URL In Another App
 
 ## Overview
 
 <!-- ✍ Update this section if you want to provide more details -->
 
-This guide will take you through the process of setting your electron app as the default handler for a specific [protocol](https://www.electronjs.org/docs/api/protocol).
+This guide will take you through the process of setting your electron app as the default
+handler for a specific [protocol](https://www.electronjs.org/docs/api/protocol).
 
-By the end of this tutorial, we will have set our app to intercept and handle any clicked URLs that start with a specific protocol. In this guide, the protocol we will use will be "`electron-fiddle://`".
+By the end of this tutorial, we will have set our app to intercept and handle
+any clicked URLs that start with a specific protocol. In this guide, the protocol
+we will use will be "`electron-fiddle://`".
 
 ## Examples
 


### PR DESCRIPTION
#### Description of Change

Changed docs to use `protocol.registerFileProtocol` rather than `app.setAsDefaultProtocol` and removed legacy code from the index.html file.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: update protocol-handler docs to use `protocol.registerFileProtocol`