### PR TITLE
build: update support.md on stable version bumps

### DIFF
--- a/script/release/version-bumper.js
+++ b/script/release/version-bumper.js
@@ -61,6 +61,11 @@ async function main () {
     updateWinRC(components)
   ]);
 
+  // if bumping stable, update supported versions
+  if (opts.bump === 'stable') {
+    await Promise(updateSupported(version));
+  }
+
   // commit all updated version-related files
   await commitVersionBump(version);
 
@@ -140,6 +145,21 @@ async function updateWinRC (components) {
     }
   });
   await writeFile(filePath, arr.join('\n'));
+}
+
+// updates support.md file with new semver values (stable only)
+async function updateSupported (version) {
+  const v = parseInt(version);
+  const newVersions = [`${v}.x.y`, `${v - 1}.x.y`, `${v - 2}.x.y`];
+  const previousVersions = [`${v - 1}.x.y`, `${v - 2}.x.y`, `${v - 3}.x.y`];
+
+  const filePath = path.resolve(ELECTRON_DIR, 'docs', 'tutorial', 'support.md');
+  const contents = await readFile(filePath, 'utf8');
+  const newContents = previousVersions.reduce((contents, current, i) => {
+    return contents.replace(current, newVersions[i]);
+  }, contents);
+
+  await writeFile(filePath, newContents, 'utf8');
 }
 
 if (process.mainModule === module) {

--- a/script/release/version-bumper.js
+++ b/script/release/version-bumper.js
@@ -1,18 +1,17 @@
 #!/usr/bin/env node
 
 const { GitProcess } = require('dugite');
-const fs = require('fs');
+const { promises: fs } = require('fs');
 const semver = require('semver');
 const path = require('path');
-const { promisify } = require('util');
 const minimist = require('minimist');
 
 const { ELECTRON_DIR } = require('../lib/utils');
 const versionUtils = require('./version-utils');
 const supported = path.resolve(ELECTRON_DIR, 'docs', 'tutorial', 'support.md');
 
-const writeFile = promisify(fs.writeFile);
-const readFile = promisify(fs.readFile);
+const writeFile = fs.writeFile;
+const readFile = fs.readFile;
 
 function parseCommandLine () {
   let help;

--- a/script/release/version-bumper.js
+++ b/script/release/version-bumper.js
@@ -40,7 +40,6 @@ async function main () {
   const opts = parseCommandLine();
   const currentVersion = await versionUtils.getElectronVersion();
   const version = await nextVersion(opts.bump, currentVersion);
-  const shouldUpdateSupported = (opts.bump, currentVersion, version);
 
   const parsed = semver.parse(version);
   const components = {
@@ -56,16 +55,16 @@ async function main () {
     return 0;
   }
 
+  if (shouldUpdateSupported(opts.bump, currentVersion, version)) {
+    await updateSupported(version, supported);
+  }
+
   // update all version-related files
   await Promise.all([
     updateVersion(version),
     updatePackageJSON(version),
     updateWinRC(components)
   ]);
-
-  if (shouldUpdateSupported) {
-    await Promise(updateSupported(version, supported));
-  }
 
   // commit all updated version-related files
   await commitVersionBump(version);

--- a/spec-main/fixtures/version-bumper/fixture_support.md
+++ b/spec-main/fixtures/version-bumper/fixture_support.md
@@ -1,0 +1,121 @@
+# Electron Support
+
+## Finding Support
+
+If you have a security concern,
+please see the [security document](https://github.com/electron/electron/tree/master/SECURITY.md).
+
+If you're looking for programming help,
+for answers to questions,
+or to join in discussion with other developers who use Electron,
+you can interact with the community in these locations:
+
+* [`Electron's Discord`](https://discord.com/invite/electron) has channels for:
+  * Getting help
+  * Ecosystem apps like [Electron Forge](https://github.com/electron-userland/electron-forge) and [Electron Fiddle](https://github.com/electron/fiddle)
+  * Sharing ideas with other Electron app developers
+  * And more!
+* [`electron`](https://discuss.atom.io/c/electron) category on the Atom forums
+* `#atom-shell` channel on Freenode
+* `#electron` channel on [Atom's Slack](https://discuss.atom.io/t/join-us-on-slack/16638?source_topic_id=25406)
+* [`electron-ru`](https://telegram.me/electron_ru) *(Russian)*
+* [`electron-br`](https://electron-br.slack.com) *(Brazilian Portuguese)*
+* [`electron-kr`](https://electron-kr.github.io/electron-kr) *(Korean)*
+* [`electron-jp`](https://electron-jp.slack.com) *(Japanese)*
+* [`electron-tr`](https://electron-tr.herokuapp.com) *(Turkish)*
+* [`electron-id`](https://electron-id.slack.com) *(Indonesia)*
+* [`electron-pl`](https://electronpl.github.io) *(Poland)*
+
+If you'd like to contribute to Electron,
+see the [contributing document](https://github.com/electron/electron/blob/master/CONTRIBUTING.md).
+
+If you've found a bug in a [supported version](#supported-versions) of Electron,
+please report it with the [issue tracker](../development/issues.md).
+
+[awesome-electron](https://github.com/sindresorhus/awesome-electron)
+is a community-maintained list of useful example apps,
+tools and resources.
+
+## Supported Versions
+
+The latest three *stable* major versions are supported by the Electron team.
+For example, if the latest release is 6.1.x, then the 5.0.x as well
+as the 4.2.x series are supported.  We only support the latest minor release
+for each stable release series.  This means that in the case of a security fix
+6.1.x will receive the fix, but we will not release a new version of 6.0.x.
+
+The latest stable release unilaterally receives all fixes from `master`,
+and the version prior to that receives the vast majority of those fixes
+as time and bandwidth warrants. The oldest supported release line will receive
+only security fixes directly.
+
+All supported release lines will accept external pull requests to backport
+fixes previously merged to `master`, though this may be on a case-by-case
+basis for some older supported lines. All contested decisions around release
+line backports will be resolved by the [Releases Working Group](https://github.com/electron/governance/tree/master/wg-releases) as an agenda item at their weekly meeting the week the backport PR is raised.
+
+When an API is changed or removed in a way that breaks existing functionality, the
+previous functionality will be supported for a minimum of two major versions when
+possible before being removed. For example, if a function takes three arguments,
+and that number is reduced to two in major version 10, the three-argument version would
+continue to work until, at minimum, major version 12. Past the minimum two-version
+threshold, we will attempt to support backwards compatibility beyond two versions
+until the maintainers feel the maintenance burden is too high to continue doing so.
+
+### Currently supported versions
+
+* 3.x.y
+* 2.x.y
+* 1.x.y
+
+### End-of-life
+
+When a release branch reaches the end of its support cycle, the series
+will be deprecated in NPM and a final end-of-support release will be
+made. This release will add a warning to inform that an unsupported
+version of Electron is in use.
+
+These steps are to help app developers learn when a branch they're
+using becomes unsupported, but without being excessively intrusive
+to end users.
+
+If an application has exceptional circumstances and needs to stay
+on an unsupported series of Electron, developers can silence the
+end-of-support warning by omitting the final release from the app's
+`package.json` `devDependencies`. For example, since the 1-6-x series
+ended with an end-of-support 1.6.18 release, developers could choose
+to stay in the 1-6-x series without warnings with `devDependency` of
+`"electron": 1.6.0 - 1.6.17`.
+
+## Supported Platforms
+
+Following platforms are supported by Electron:
+
+### macOS
+
+Only 64bit binaries are provided for macOS, and the minimum macOS version
+supported is macOS 10.11 (El Capitan).
+
+Native support for Apple Silicon (`arm64`) devices was added in Electron 11.0.0.
+
+### Windows
+
+Windows 7 and later are supported, older operating systems are not supported
+(and do not work).
+
+Both `ia32` (`x86`) and `x64` (`amd64`) binaries are provided for Windows.
+[Native support for Windows on Arm (`arm64`) devices was added in Electron 6.0.8.](windows-arm.md).
+Running apps packaged with previous versions is possible using the ia32 binary.
+
+### Linux
+
+The prebuilt binaries of Electron are built on Ubuntu 18.04.
+
+Whether the prebuilt binary can run on a distribution depends on whether the
+distribution includes the libraries that Electron is linked to on the building
+platform, so only Ubuntu 18.04 is guaranteed to work, but following platforms
+are also verified to be able to run the prebuilt binaries of Electron:
+
+* Ubuntu 14.04 and newer
+* Fedora 24 and newer
+* Debian 8 and newer

--- a/spec-main/version-bump-spec.ts
+++ b/spec-main/version-bump-spec.ts
@@ -2,13 +2,12 @@ import { expect } from 'chai';
 import { nextVersion, shouldUpdateSupported, updateSupported } from '../script/release/version-bumper';
 import * as utils from '../script/release/version-utils';
 import { ifdescribe } from './spec-helpers';
-const fs = require('fs');
+const { promises: fs } = require('fs');
 const path = require('path');
-const { promisify } = require('util');
 
 const fixtureDir = path.resolve(__dirname, 'fixtures', 'version-bumper', 'fixture_support.md');
-const readFile = promisify(fs.readFile);
-const writeFile = promisify(fs.writeFile);
+const readFile = fs.readFile;
+const writeFile = fs.writeFile;
 
 describe('version-bumper', () => {
   describe('makeVersion', () => {


### PR DESCRIPTION
#### Description of Change

Following up on a great suggestion by @MarshallOfSound in #29377, this PR adds a function to our version bump script that changes the `support.md` file on two conditions:

1. When we promote a new major nightly version (i.e. 14.0.0-nightly.xx -> 15.0.0-nightly.xx)
2. When we promote a new major stable version (e.g. 14.x.x -> 15.0.0)

Ideally, we could simplify this to _only_ bump when a new nightly is created. The website bases it's public information off of the latest stable branch, so the currently supported versions will appear correctly as each nightly goes through the nightly -> stable cycle and eventually becomes stable.

However, I left in the new major stable bump for 1) backwards compatibility, so we don't need to manually update current nightly and beta, and 2) having an additional check before promoting a new stable release seems like a good safety check. 🙂 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md) (~_I don't think we have tests for the release script, but happy to add one here if I'm wrong_~ I was wrong, tests added!)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
