### PR TITLE
docs: fixes issue with reference links

### DIFF
--- a/docs/tutorial/introduction.md
+++ b/docs/tutorial/introduction.md
@@ -49,11 +49,11 @@ is a great place to get advice from other Electron app developers.
 the [GitHub issue tracker][issue-tracker] to see if any existing issues match your
 problem. If not, feel free to fill out our bug report template and submit a new issue.
 
-[chromium](https://www.chromium.org/)
-[node](https://nodejs.org/)
-[mdn-guide](https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web)
-[node-guide](https://nodejs.dev/learn)
-[comic](https://www.google.com/googlebooks/chrome/)
-[fiddle](https://electronjs.org/fiddle)
-[issue-tracker](https://github.com/electron/electron/issues)
-[discord](https://discord.gg/electron)
+[chromium]: https://www.chromium.org/
+[node]: https://nodejs.org/
+[mdn-guide]: https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web
+[node-guide]: https://nodejs.dev/learn
+[comic]: https://www.google.com/googlebooks/chrome/
+[fiddle]: https://electronjs.org/fiddle
+[issue-tracker]: https://github.com/electron/electron/issues
+[discord]: https://discord.gg/electron


### PR DESCRIPTION
#### Description of Change
The reference links on this page weren't working because of wrong md syntax. This PR fixes that

#### Checklist
- [x] relevant documentation is changed or added

#### Release Notes

Notes: The issue was introduced (or may be reproduced) in this [PR](https://github.com/electron/electron/pull/29062)

