### PR TITLE
build: Store the target_cpu in an "arch" file in the resulting ZIP

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1339,9 +1339,19 @@ copy("electron_version") {
   outputs = [ "$root_build_dir/version" ]
 }
 
+action("electron_architecture") {
+  outputs = [ "$root_build_dir/arch" ]
+  script = "build/arch.py"
+  args = [
+    target_cpu,
+    rebase_path(root_build_dir),
+  ]
+}
+
 dist_zip("electron_dist_zip") {
   data_deps = [
     ":electron_app",
+    ":electron_architecture",
     ":electron_version",
     ":licenses",
   ]

--- a/build/arch.py
+++ b/build/arch.py
@@ -1,0 +1,11 @@
+import sys
+import os
+
+def main():
+  output_path = os.path.join(sys.argv[2], 'arch')
+  arch_file = open(output_path, "w")
+  arch_file.write(sys.argv[1])
+  arch_file.close()
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/script/zip_manifests/dist_zip.linux.arm.manifest
+++ b/script/zip_manifests/dist_zip.linux.arm.manifest
@@ -1,3 +1,4 @@
+arch
 LICENSE
 LICENSES.chromium.html
 chrome-sandbox

--- a/script/zip_manifests/dist_zip.linux.arm64.manifest
+++ b/script/zip_manifests/dist_zip.linux.arm64.manifest
@@ -1,3 +1,4 @@
+arch
 LICENSE
 LICENSES.chromium.html
 chrome-sandbox

--- a/script/zip_manifests/dist_zip.linux.x64.manifest
+++ b/script/zip_manifests/dist_zip.linux.x64.manifest
@@ -1,3 +1,4 @@
+arch
 LICENSE
 LICENSES.chromium.html
 chrome-sandbox

--- a/script/zip_manifests/dist_zip.linux.x86.manifest
+++ b/script/zip_manifests/dist_zip.linux.x86.manifest
@@ -1,3 +1,4 @@
+arch
 LICENSE
 LICENSES.chromium.html
 chrome-sandbox

--- a/script/zip_manifests/dist_zip.mac.arm64.manifest
+++ b/script/zip_manifests/dist_zip.mac.arm64.manifest
@@ -1,3 +1,4 @@
+arch
 Electron.app/
 Electron.app/Contents/
 Electron.app/Contents/Frameworks/

--- a/script/zip_manifests/dist_zip.mac.x64.manifest
+++ b/script/zip_manifests/dist_zip.mac.x64.manifest
@@ -1,3 +1,4 @@
+arch
 Electron.app/
 Electron.app/Contents/
 Electron.app/Contents/Frameworks/

--- a/script/zip_manifests/dist_zip.mac_mas.arm64.manifest
+++ b/script/zip_manifests/dist_zip.mac_mas.arm64.manifest
@@ -1,3 +1,4 @@
+arch
 Electron.app/
 Electron.app/Contents/
 Electron.app/Contents/Frameworks/

--- a/script/zip_manifests/dist_zip.mac_mas.x64.manifest
+++ b/script/zip_manifests/dist_zip.mac_mas.x64.manifest
@@ -1,3 +1,4 @@
+arch
 Electron.app/
 Electron.app/Contents/
 Electron.app/Contents/Frameworks/

--- a/script/zip_manifests/dist_zip.win.arm64.manifest
+++ b/script/zip_manifests/dist_zip.win.arm64.manifest
@@ -1,3 +1,4 @@
+arch
 LICENSE
 LICENSES.chromium.html
 chrome_100_percent.pak

--- a/script/zip_manifests/dist_zip.win.ia32.manifest
+++ b/script/zip_manifests/dist_zip.win.ia32.manifest
@@ -1,3 +1,4 @@
+arch
 LICENSE
 LICENSES.chromium.html
 chrome_100_percent.pak

--- a/script/zip_manifests/dist_zip.win.x64.manifest
+++ b/script/zip_manifests/dist_zip.win.x64.manifest
@@ -1,3 +1,4 @@
+arch
 LICENSE
 LICENSES.chromium.html
 chrome_100_percent.pak


### PR DESCRIPTION
We have an application that interacts with many different versions of
the Electron.js ZIP artifacts at the same time.

The ZIP artifacts currently ship with a `version` text file that matches
the content of the `ELECTRON_VERSION` file present at the root of this
repository. The presence of this file makes it easy for an application
consuming the ZIP artifacts to introspect its contents with regards to
the version information.

This commit extends such pattern to include the value of the GN
`target_cpu` value into an `arch` file to also easily introspect on the
distributable ZIP architecture. For example, building Electron.js on an
Intel 64-bit host results in `arch` containing the string `x64`. This
commit stores the value of `target_cpu` instead of `host_cpu` to produce
the expected result when cross-compiling Electron.js.

Notes: Add an `arch` file to the distributable ZIP artifacts.
See: https://gn.googlesource.com/gn/+/refs/heads/main/docs/reference.md#var_target_cpu
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>