### PR TITLE
chore: trim unused STL includes

### DIFF
--- a/chromium_src/chrome/browser/certificate_manager_model.h
+++ b/chromium_src/chrome/browser/certificate_manager_model.h
@@ -5,7 +5,6 @@
 #ifndef CHROME_BROWSER_CERTIFICATE_MANAGER_MODEL_H_
 #define CHROME_BROWSER_CERTIFICATE_MANAGER_MODEL_H_
 
-#include <map>
 #include <memory>
 #include <string>
 

--- a/chromium_src/chrome/browser/process_singleton.h
+++ b/chromium_src/chrome/browser/process_singleton.h
@@ -9,9 +9,6 @@
 #include <windows.h>
 #endif  // defined(OS_WIN)
 
-#include <set>
-#include <vector>
-
 #include "base/callback.h"
 #include "base/command_line.h"
 #include "base/files/file_path.h"

--- a/shell/app/electron_content_client.h
+++ b/shell/app/electron_content_client.h
@@ -5,8 +5,6 @@
 #ifndef SHELL_APP_ELECTRON_CONTENT_CLIENT_H_
 #define SHELL_APP_ELECTRON_CONTENT_CLIENT_H_
 
-#include <set>
-#include <string>
 #include <vector>
 
 #include "base/files/file_path.h"

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -5,8 +5,8 @@
 #include "shell/browser/api/electron_api_app.h"
 
 #include <memory>
-
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "base/callback_helpers.h"

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -8,7 +8,6 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "base/task/cancelable_task_tracker.h"

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -4,8 +4,6 @@
 
 #include "shell/browser/api/electron_api_browser_window.h"
 
-#include <memory>
-
 #include "base/threading/thread_task_runner_handle.h"
 #include "content/browser/renderer_host/render_widget_host_impl.h"  // nogncheck
 #include "content/browser/renderer_host/render_widget_host_owner_delegate.h"  // nogncheck

--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_API_ELECTRON_API_BROWSER_WINDOW_H_
 #define SHELL_BROWSER_API_ELECTRON_API_BROWSER_WINDOW_H_
 
-#include <memory>
 #include <string>
 #include <vector>
 

--- a/shell/browser/api/electron_api_cookies.cc
+++ b/shell/browser/api/electron_api_cookies.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/api/electron_api_cookies.h"
 
-#include <memory>
 #include <utility>
 
 #include "base/time/time.h"

--- a/shell/browser/api/electron_api_cookies.h
+++ b/shell/browser/api/electron_api_cookies.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_API_ELECTRON_API_COOKIES_H_
 #define SHELL_BROWSER_API_ELECTRON_API_COOKIES_H_
 
-#include <memory>
 #include <string>
 
 #include "base/callback_list.h"

--- a/shell/browser/api/electron_api_debugger.h
+++ b/shell/browser/api/electron_api_debugger.h
@@ -6,7 +6,6 @@
 #define SHELL_BROWSER_API_ELECTRON_API_DEBUGGER_H_
 
 #include <map>
-#include <string>
 
 #include "base/callback.h"
 #include "base/values.h"

--- a/shell/browser/api/electron_api_dialog.cc
+++ b/shell/browser/api/electron_api_dialog.cc
@@ -2,7 +2,6 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include <string>
 #include <utility>
 #include <vector>
 

--- a/shell/browser/api/electron_api_download_item.cc
+++ b/shell/browser/api/electron_api_download_item.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/api/electron_api_download_item.h"
 
-#include <map>
 #include <memory>
 
 #include "base/strings/utf_string_conversions.h"

--- a/shell/browser/api/electron_api_download_item.h
+++ b/shell/browser/api/electron_api_download_item.h
@@ -6,7 +6,6 @@
 #define SHELL_BROWSER_API_ELECTRON_API_DOWNLOAD_ITEM_H_
 
 #include <string>
-#include <vector>
 
 #include "base/files/file_path.h"
 #include "base/memory/weak_ptr.h"

--- a/shell/browser/api/electron_api_global_shortcut.cc
+++ b/shell/browser/api/electron_api_global_shortcut.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/api/electron_api_global_shortcut.h"
 
-#include <string>
 #include <vector>
 
 #include "base/stl_util.h"

--- a/shell/browser/api/electron_api_global_shortcut.h
+++ b/shell/browser/api/electron_api_global_shortcut.h
@@ -6,7 +6,6 @@
 #define SHELL_BROWSER_API_ELECTRON_API_GLOBAL_SHORTCUT_H_
 
 #include <map>
-#include <string>
 #include <vector>
 
 #include "base/callback.h"

--- a/shell/browser/api/electron_api_menu.cc
+++ b/shell/browser/api/electron_api_menu.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/api/electron_api_menu.h"
 
-#include <map>
 #include <utility>
 
 #include "shell/browser/api/ui_event.h"

--- a/shell/browser/api/electron_api_menu_mac.h
+++ b/shell/browser/api/electron_api_menu_mac.h
@@ -8,7 +8,6 @@
 #include "shell/browser/api/electron_api_menu.h"
 
 #include <map>
-#include <string>
 
 #import "shell/browser/ui/cocoa/electron_menu_controller.h"
 

--- a/shell/browser/api/electron_api_net_log.cc
+++ b/shell/browser/api/electron_api_net_log.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/api/electron_api_net_log.h"
 
+#include <string>
 #include <utility>
 
 #include "base/command_line.h"

--- a/shell/browser/api/electron_api_net_log.h
+++ b/shell/browser/api/electron_api_net_log.h
@@ -5,10 +5,6 @@
 #ifndef SHELL_BROWSER_API_ELECTRON_API_NET_LOG_H_
 #define SHELL_BROWSER_API_ELECTRON_API_NET_LOG_H_
 
-#include <list>
-#include <memory>
-#include <string>
-
 #include "base/callback.h"
 #include "base/optional.h"
 #include "base/values.h"

--- a/shell/browser/api/electron_api_notification.h
+++ b/shell/browser/api/electron_api_notification.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_API_ELECTRON_API_NOTIFICATION_H_
 #define SHELL_BROWSER_API_ELECTRON_API_NOTIFICATION_H_
 
-#include <memory>
 #include <string>
 #include <vector>
 

--- a/shell/browser/api/electron_api_power_save_blocker.h
+++ b/shell/browser/api/electron_api_power_save_blocker.h
@@ -6,7 +6,6 @@
 #define SHELL_BROWSER_API_ELECTRON_API_POWER_SAVE_BLOCKER_H_
 
 #include <map>
-#include <memory>
 
 #include "gin/handle.h"
 #include "gin/object_template_builder.h"

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -4,8 +4,6 @@
 
 #include "shell/browser/api/electron_api_protocol.h"
 
-#include <memory>
-#include <utility>
 #include <vector>
 
 #include "base/command_line.h"

--- a/shell/browser/api/electron_api_screen.cc
+++ b/shell/browser/api/electron_api_screen.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/api/electron_api_screen.h"
 
-#include <algorithm>
 #include <string>
 
 #include "base/bind.h"

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -5,7 +5,6 @@
 #include "shell/browser/api/electron_api_session.h"
 
 #include <algorithm>
-#include <map>
 #include <memory>
 #include <set>
 #include <string>

--- a/shell/browser/api/electron_api_url_loader.cc
+++ b/shell/browser/api/electron_api_url_loader.cc
@@ -5,7 +5,6 @@
 #include "shell/browser/api/electron_api_url_loader.h"
 
 #include <algorithm>
-#include <map>
 #include <memory>
 #include <string>
 #include <utility>

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_API_ELECTRON_API_VIEW_H_
 #define SHELL_BROWSER_API_ELECTRON_API_VIEW_H_
 
-#include <memory>
 #include <vector>
 
 #include "electron/buildflags/buildflags.h"

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_API_ELECTRON_API_WEB_FRAME_MAIN_H_
 #define SHELL_BROWSER_API_ELECTRON_API_WEB_FRAME_MAIN_H_
 
-#include <memory>
 #include <string>
 #include <vector>
 

--- a/shell/browser/api/gpuinfo_manager.h
+++ b/shell/browser/api/gpuinfo_manager.h
@@ -6,7 +6,6 @@
 #define SHELL_BROWSER_API_GPUINFO_MANAGER_H_
 
 #include <memory>
-#include <unordered_set>
 #include <vector>
 
 #include "content/browser/gpu/gpu_data_manager_impl.h"  // nogncheck

--- a/shell/browser/api/save_page_handler.cc
+++ b/shell/browser/api/save_page_handler.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/api/save_page_handler.h"
 
-#include <string>
 #include <utility>
 
 #include "base/callback.h"

--- a/shell/browser/api/save_page_handler.h
+++ b/shell/browser/api/save_page_handler.h
@@ -5,8 +5,6 @@
 #ifndef SHELL_BROWSER_API_SAVE_PAGE_HANDLER_H_
 #define SHELL_BROWSER_API_SAVE_PAGE_HANDLER_H_
 
-#include <string>
-
 #include "components/download/public/common/download_item.h"
 #include "content/public/browser/download_manager.h"
 #include "content/public/browser/save_page_type.h"

--- a/shell/browser/badging/badge_manager.cc
+++ b/shell/browser/badging/badge_manager.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/badging/badge_manager.h"
 
-#include <tuple>
 #include <utility>
 
 #include "base/i18n/number_formatting.h"

--- a/shell/browser/badging/badge_manager.h
+++ b/shell/browser/badging/badge_manager.h
@@ -5,10 +5,8 @@
 #ifndef SHELL_BROWSER_BADGING_BADGE_MANAGER_H_
 #define SHELL_BROWSER_BADGING_BADGE_MANAGER_H_
 
-#include <map>
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "base/macros.h"
 #include "base/optional.h"

--- a/shell/browser/cookie_change_notifier.cc
+++ b/shell/browser/cookie_change_notifier.cc
@@ -4,8 +4,6 @@
 
 #include "shell/browser/cookie_change_notifier.h"
 
-#include <utility>
-
 #include "base/bind.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/storage_partition.h"

--- a/shell/browser/cookie_change_notifier.h
+++ b/shell/browser/cookie_change_notifier.h
@@ -5,8 +5,6 @@
 #ifndef SHELL_BROWSER_COOKIE_CHANGE_NOTIFIER_H_
 #define SHELL_BROWSER_COOKIE_CHANGE_NOTIFIER_H_
 
-#include <memory>
-
 #include "base/callback_list.h"
 #include "base/macros.h"
 #include "mojo/public/cpp/bindings/receiver.h"

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -8,7 +8,6 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "base/memory/weak_ptr.h"
 #include "chrome/browser/predictors/preconnect_manager.h"

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -5,7 +5,7 @@
 #include "shell/browser/electron_browser_main_parts.h"
 
 #include <memory>
-
+#include <string>
 #include <utility>
 
 #include "base/base_switches.h"

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -5,9 +5,7 @@
 #ifndef SHELL_BROWSER_ELECTRON_BROWSER_MAIN_PARTS_H_
 #define SHELL_BROWSER_ELECTRON_BROWSER_MAIN_PARTS_H_
 
-#include <list>
 #include <memory>
-#include <string>
 
 #include "base/callback.h"
 #include "base/metrics/field_trial.h"

--- a/shell/browser/electron_download_manager_delegate.h
+++ b/shell/browser/electron_download_manager_delegate.h
@@ -5,8 +5,6 @@
 #ifndef SHELL_BROWSER_ELECTRON_DOWNLOAD_MANAGER_DELEGATE_H_
 #define SHELL_BROWSER_ELECTRON_DOWNLOAD_MANAGER_DELEGATE_H_
 
-#include <string>
-
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/download_manager_delegate.h"
 #include "shell/browser/ui/file_dialog.h"

--- a/shell/browser/electron_permission_manager.h
+++ b/shell/browser/electron_permission_manager.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_ELECTRON_PERMISSION_MANAGER_H_
 #define SHELL_BROWSER_ELECTRON_PERMISSION_MANAGER_H_
 
-#include <map>
 #include <memory>
 #include <vector>
 

--- a/shell/browser/electron_speech_recognition_manager_delegate.cc
+++ b/shell/browser/electron_speech_recognition_manager_delegate.cc
@@ -4,7 +4,6 @@
 
 #include "shell/browser/electron_speech_recognition_manager_delegate.h"
 
-#include <string>
 #include <utility>
 
 #include "base/callback.h"

--- a/shell/browser/electron_speech_recognition_manager_delegate.h
+++ b/shell/browser/electron_speech_recognition_manager_delegate.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_ELECTRON_SPEECH_RECOGNITION_MANAGER_DELEGATE_H_
 #define SHELL_BROWSER_ELECTRON_SPEECH_RECOGNITION_MANAGER_DELEGATE_H_
 
-#include <string>
 #include <vector>
 
 #include "base/macros.h"

--- a/shell/browser/electron_web_ui_controller_factory.cc
+++ b/shell/browser/electron_web_ui_controller_factory.cc
@@ -4,8 +4,6 @@
 
 #include "shell/browser/electron_web_ui_controller_factory.h"
 
-#include <string>
-
 #include "chrome/common/webui_url_constants.h"
 #include "content/public/browser/web_contents.h"
 #include "electron/buildflags/buildflags.h"

--- a/shell/browser/extended_web_contents_observer.h
+++ b/shell/browser/extended_web_contents_observer.h
@@ -5,6 +5,7 @@
 #ifndef SHELL_BROWSER_EXTENDED_WEB_CONTENTS_OBSERVER_H_
 #define SHELL_BROWSER_EXTENDED_WEB_CONTENTS_OBSERVER_H_
 
+#include <string>
 #include <vector>
 
 #include "base/observer_list.h"

--- a/shell/browser/extensions/api/streams_private/streams_private_api.cc
+++ b/shell/browser/extensions/api/streams_private/streams_private_api.cc
@@ -4,6 +4,7 @@
 
 #include "electron/shell/browser/extensions/api/streams_private/streams_private_api.h"
 
+#include <memory>
 #include <utility>
 
 #include "content/public/browser/browser_thread.h"

--- a/shell/browser/extensions/api/streams_private/streams_private_api.h
+++ b/shell/browser/extensions/api/streams_private/streams_private_api.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_EXTENSIONS_API_STREAMS_PRIVATE_STREAMS_PRIVATE_API_H_
 #define SHELL_BROWSER_EXTENSIONS_API_STREAMS_PRIVATE_STREAMS_PRIVATE_API_H_
 
-#include <memory>
 #include <string>
 
 #include "base/macros.h"

--- a/shell/browser/extensions/electron_extension_loader.h
+++ b/shell/browser/extensions/electron_extension_loader.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_EXTENSIONS_ELECTRON_EXTENSION_LOADER_H_
 #define SHELL_BROWSER_EXTENSIONS_ELECTRON_EXTENSION_LOADER_H_
 
-#include <memory>
 #include <string>
 #include <utility>
 

--- a/shell/browser/extensions/electron_extension_system.h
+++ b/shell/browser/extensions/electron_extension_system.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "base/compiler_specific.h"
 #include "base/macros.h"

--- a/shell/browser/file_select_helper.cc
+++ b/shell/browser/file_select_helper.cc
@@ -4,7 +4,6 @@
 
 #include <memory>
 
-#include <string>
 #include <utility>
 #include <vector>
 

--- a/shell/browser/file_select_helper.h
+++ b/shell/browser/file_select_helper.h
@@ -6,9 +6,6 @@
 #define SHELL_BROWSER_FILE_SELECT_HELPER_H_
 
 #include <memory>
-
-#include <string>
-#include <utility>
 #include <vector>
 
 #include "base/files/file_path.h"

--- a/shell/browser/lib/power_observer_linux.cc
+++ b/shell/browser/lib/power_observer_linux.cc
@@ -5,7 +5,6 @@
 
 #include <unistd.h>
 #include <uv.h>
-#include <iostream>
 #include <utility>
 
 #include "base/bind.h"

--- a/shell/browser/login_handler.cc
+++ b/shell/browser/login_handler.cc
@@ -4,10 +4,7 @@
 
 #include "shell/browser/login_handler.h"
 
-#include <memory>
-#include <string>
 #include <utility>
-#include <vector>
 
 #include "base/callback.h"
 #include "base/threading/sequenced_task_runner_handle.h"

--- a/shell/browser/native_browser_view.cc
+++ b/shell/browser/native_browser_view.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include <vector>
-
 #include "shell/browser/native_browser_view.h"
 
 #include "shell/browser/api/electron_api_web_contents.h"

--- a/shell/browser/native_browser_view_views.cc
+++ b/shell/browser/native_browser_view_views.cc
@@ -4,8 +4,6 @@
 
 #include "shell/browser/native_browser_view_views.h"
 
-#include <memory>
-#include <utility>
 #include <vector>
 
 #include "shell/browser/ui/drag_util.h"

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "base/memory/ptr_util.h"

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -6,10 +6,8 @@
 #define SHELL_BROWSER_NATIVE_WINDOW_H_
 
 #include <list>
-#include <map>
 #include <memory>
 #include <string>
-#include <tuple>
 #include <vector>
 
 #include "base/memory/weak_ptr.h"

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -10,7 +10,6 @@
 #include <memory>
 #include <queue>
 #include <string>
-#include <tuple>
 #include <vector>
 
 #include "base/mac/scoped_nsobject.h"

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -9,7 +9,6 @@
 #endif
 
 #include <memory>
-#include <tuple>
 #include <utility>
 #include <vector>
 

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -10,7 +10,6 @@
 #include <memory>
 #include <set>
 #include <string>
-#include <tuple>
 #include <vector>
 
 #include "shell/common/api/api.mojom.h"

--- a/shell/browser/net/proxying_websocket.h
+++ b/shell/browser/net/proxying_websocket.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_NET_PROXYING_WEBSOCKET_H_
 #define SHELL_BROWSER_NET_PROXYING_WEBSOCKET_H_
 
-#include <memory>
 #include <set>
 #include <string>
 #include <vector>

--- a/shell/browser/net/system_network_context_manager.cc
+++ b/shell/browser/net/system_network_context_manager.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/net/system_network_context_manager.h"
 
+#include <memory>
 #include <string>
 #include <utility>
 

--- a/shell/browser/net/system_network_context_manager.h
+++ b/shell/browser/net/system_network_context_manager.h
@@ -5,10 +5,6 @@
 #ifndef SHELL_BROWSER_NET_SYSTEM_NETWORK_CONTEXT_MANAGER_H_
 #define SHELL_BROWSER_NET_SYSTEM_NETWORK_CONTEXT_MANAGER_H_
 
-#include <memory>
-#include <string>
-#include <vector>
-
 #include "base/macros.h"
 #include "base/memory/ref_counted.h"
 #include "base/optional.h"

--- a/shell/browser/notifications/linux/libnotify_notification.cc
+++ b/shell/browser/notifications/linux/libnotify_notification.cc
@@ -6,7 +6,6 @@
 
 #include <set>
 #include <string>
-#include <vector>
 
 #include "base/files/file_enumerator.h"
 #include "base/logging.h"

--- a/shell/browser/notifications/linux/libnotify_notification.h
+++ b/shell/browser/notifications/linux/libnotify_notification.h
@@ -5,9 +5,6 @@
 #ifndef SHELL_BROWSER_NOTIFICATIONS_LINUX_LIBNOTIFY_NOTIFICATION_H_
 #define SHELL_BROWSER_NOTIFICATIONS_LINUX_LIBNOTIFY_NOTIFICATION_H_
 
-#include <string>
-#include <vector>
-
 #include "library_loaders/libnotify_loader.h"
 #include "shell/browser/notifications/notification.h"
 #include "ui/base/glib/glib_signal.h"

--- a/shell/browser/notifications/mac/cocoa_notification.h
+++ b/shell/browser/notifications/mac/cocoa_notification.h
@@ -9,7 +9,6 @@
 
 #include <map>
 #include <string>
-#include <vector>
 
 #include "base/mac/scoped_nsobject.h"
 #include "shell/browser/notifications/notification.h"

--- a/shell/browser/notifications/platform_notification_service.h
+++ b/shell/browser/notifications/platform_notification_service.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_NOTIFICATIONS_PLATFORM_NOTIFICATION_SERVICE_H_
 #define SHELL_BROWSER_NOTIFICATIONS_PLATFORM_NOTIFICATION_SERVICE_H_
 
-#include <set>
 #include <string>
 
 #include "content/public/browser/platform_notification_service.h"

--- a/shell/browser/notifications/win/win32_desktop_notifications/desktop_notification_controller.cc
+++ b/shell/browser/notifications/win/win32_desktop_notifications/desktop_notification_controller.cc
@@ -13,9 +13,7 @@
 #include "shell/browser/notifications/win/win32_desktop_notifications/desktop_notification_controller.h"
 
 #include <windowsx.h>
-#include <algorithm>
 #include <utility>
-#include <vector>
 
 #include "base/check.h"
 #include "shell/browser/notifications/win/win32_desktop_notifications/common.h"

--- a/shell/browser/notifications/win/win32_notification.cc
+++ b/shell/browser/notifications/win/win32_notification.cc
@@ -9,9 +9,7 @@
 #include "shell/browser/notifications/win/win32_notification.h"
 
 #include <windows.h>
-#include <string>
 #include <utility>
-#include <vector>
 
 #include "base/strings/utf_string_conversions.h"
 #include "third_party/skia/include/core/SkBitmap.h"

--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -10,7 +10,6 @@
 
 #include <shlobj.h>
 #include <wrl\wrappers\corewrappers.h>
-#include <vector>
 
 #include "base/environment.h"
 #include "base/strings/utf_string_conversions.h"

--- a/shell/browser/osr/osr_view_proxy.h
+++ b/shell/browser/osr/osr_view_proxy.h
@@ -6,7 +6,6 @@
 #define SHELL_BROWSER_OSR_OSR_VIEW_PROXY_H_
 
 #include <memory>
-#include <set>
 
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "ui/events/event.h"

--- a/shell/browser/protocol_registry.cc
+++ b/shell/browser/protocol_registry.cc
@@ -4,9 +4,6 @@
 
 #include "shell/browser/protocol_registry.h"
 
-#include <memory>
-#include <utility>
-
 #include "content/public/browser/web_contents.h"
 #include "shell/browser/electron_browser_context.h"
 #include "shell/browser/net/asar/asar_url_loader_factory.h"

--- a/shell/browser/relauncher.cc
+++ b/shell/browser/relauncher.cc
@@ -4,9 +4,7 @@
 
 #include "shell/browser/relauncher.h"
 
-#include <string>
 #include <utility>
-#include <vector>
 
 #include "base/files/file_util.h"
 #include "base/logging.h"

--- a/shell/browser/relauncher.h
+++ b/shell/browser/relauncher.h
@@ -29,9 +29,6 @@
 // in light of PID reuse, so the parent must remain alive long enough for the
 // relauncher to set up its kqueue.
 
-#include <string>
-#include <vector>
-
 #include "base/command_line.h"
 
 #if defined(OS_WIN)

--- a/shell/browser/serial/serial_chooser_context.cc
+++ b/shell/browser/serial/serial_chooser_context.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/serial/serial_chooser_context.h"
 
+#include <string>
 #include <utility>
 
 #include "base/base64.h"

--- a/shell/browser/serial/serial_chooser_context.h
+++ b/shell/browser/serial/serial_chooser_context.h
@@ -6,9 +6,7 @@
 #define SHELL_BROWSER_SERIAL_SERIAL_CHOOSER_CONTEXT_H_
 
 #include <map>
-#include <memory>
 #include <set>
-#include <string>
 #include <utility>
 #include <vector>
 

--- a/shell/browser/ui/autofill_popup.cc
+++ b/shell/browser/ui/autofill_popup.cc
@@ -4,8 +4,6 @@
 
 #include <algorithm>
 #include <memory>
-
-#include <utility>
 #include <vector>
 
 #include "base/i18n/rtl.h"

--- a/shell/browser/ui/devtools_manager_delegate.cc
+++ b/shell/browser/ui/devtools_manager_delegate.cc
@@ -6,7 +6,6 @@
 
 #include <memory>
 #include <utility>
-#include <vector>
 
 #include "base/bind.h"
 #include "base/command_line.h"

--- a/shell/browser/ui/devtools_manager_delegate.h
+++ b/shell/browser/ui/devtools_manager_delegate.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_UI_DEVTOOLS_MANAGER_DELEGATE_H_
 #define SHELL_BROWSER_UI_DEVTOOLS_MANAGER_DELEGATE_H_
 
-#include <memory>
 #include <string>
 
 #include "base/compiler_specific.h"

--- a/shell/browser/ui/views/submenu_button.cc
+++ b/shell/browser/ui/views/submenu_button.cc
@@ -4,9 +4,6 @@
 
 #include "shell/browser/ui/views/submenu_button.h"
 
-#include <memory>
-#include <utility>
-
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "ui/accessibility/ax_enums.mojom.h"

--- a/shell/browser/ui/webui/accessibility_ui.cc
+++ b/shell/browser/ui/webui/accessibility_ui.cc
@@ -4,7 +4,10 @@
 
 #include "shell/browser/ui/webui/accessibility_ui.h"
 
+#include <memory>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "base/bind.h"
 #include "base/callback_helpers.h"

--- a/shell/browser/ui/webui/accessibility_ui.h
+++ b/shell/browser/ui/webui/accessibility_ui.h
@@ -5,10 +5,6 @@
 #ifndef SHELL_BROWSER_UI_WEBUI_ACCESSIBILITY_UI_H_
 #define SHELL_BROWSER_UI_WEBUI_ACCESSIBILITY_UI_H_
 
-#include <memory>
-#include <string>
-#include <vector>
-
 #include "base/macros.h"
 #include "chrome/browser/accessibility/accessibility_ui.h"
 #include "content/public/browser/web_ui_controller.h"

--- a/shell/browser/ui/win/dialog_thread.h
+++ b/shell/browser/ui/win/dialog_thread.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_UI_WIN_DIALOG_THREAD_H_
 #define SHELL_BROWSER_UI_WIN_DIALOG_THREAD_H_
 
-#include <memory>
 #include <utility>
 
 #include "base/memory/scoped_refptr.h"

--- a/shell/browser/ui/win/notify_icon.cc
+++ b/shell/browser/ui/win/notify_icon.cc
@@ -5,7 +5,6 @@
 #include "shell/browser/ui/win/notify_icon.h"
 
 #include <objbase.h>
-#include <utility>
 
 #include "base/logging.h"
 #include "base/strings/string_number_conversions.h"

--- a/shell/browser/web_contents_zoom_controller.cc
+++ b/shell/browser/web_contents_zoom_controller.cc
@@ -4,6 +4,8 @@
 
 #include "shell/browser/web_contents_zoom_controller.h"
 
+#include <string>
+
 #include "content/public/browser/navigation_details.h"
 #include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/navigation_handle.h"

--- a/shell/browser/web_contents_zoom_controller.h
+++ b/shell/browser/web_contents_zoom_controller.h
@@ -5,9 +5,6 @@
 #ifndef SHELL_BROWSER_WEB_CONTENTS_ZOOM_CONTROLLER_H_
 #define SHELL_BROWSER_WEB_CONTENTS_ZOOM_CONTROLLER_H_
 
-#include <map>
-#include <string>
-
 #include "base/observer_list_types.h"
 #include "content/public/browser/host_zoom_map.h"
 #include "content/public/browser/web_contents_observer.h"

--- a/shell/browser/web_dialog_helper.cc
+++ b/shell/browser/web_dialog_helper.cc
@@ -4,8 +4,6 @@
 
 #include "shell/browser/web_dialog_helper.h"
 
-#include <memory>
-
 #include <string>
 #include <utility>
 #include <vector>

--- a/shell/browser/web_dialog_helper.h
+++ b/shell/browser/web_dialog_helper.h
@@ -5,9 +5,6 @@
 #ifndef SHELL_BROWSER_WEB_DIALOG_HELPER_H_
 #define SHELL_BROWSER_WEB_DIALOG_HELPER_H_
 
-#include <memory>
-#include <vector>
-
 #include "base/memory/weak_ptr.h"
 #include "third_party/blink/public/mojom/choosers/file_chooser.mojom.h"
 

--- a/shell/browser/zoom_level_delegate.h
+++ b/shell/browser/zoom_level_delegate.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_ZOOM_LEVEL_DELEGATE_H_
 #define SHELL_BROWSER_ZOOM_LEVEL_DELEGATE_H_
 
-#include <memory>
 #include <string>
 
 #include "base/files/file_path.h"

--- a/shell/common/api/electron_api_native_image_win.cc
+++ b/shell/common/api/electron_api_native_image_win.cc
@@ -9,9 +9,6 @@
 #include <thumbcache.h>
 #include <wrl/client.h>
 
-#include <string>
-#include <vector>
-
 #include "shell/common/gin_converters/image_converter.h"
 #include "shell/common/gin_helper/promise.h"
 #include "shell/common/skia_util.h"

--- a/shell/common/api/electron_api_v8_util.cc
+++ b/shell/common/api/electron_api_v8_util.cc
@@ -2,7 +2,6 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include <string>
 #include <utility>
 
 #include "base/hash/hash.h"

--- a/shell/common/application_info_linux.cc
+++ b/shell/common/application_info_linux.cc
@@ -7,7 +7,6 @@
 #include <gio/gdesktopappinfo.h>
 #include <gio/gio.h>
 
-#include <memory>
 #include <string>
 
 #include "base/environment.h"

--- a/shell/common/electron_command_line.h
+++ b/shell/common/electron_command_line.h
@@ -5,9 +5,6 @@
 #ifndef SHELL_COMMON_ELECTRON_COMMAND_LINE_H_
 #define SHELL_COMMON_ELECTRON_COMMAND_LINE_H_
 
-#include <string>
-#include <vector>
-
 #include "base/command_line.h"
 #include "base/macros.h"
 #include "build/build_config.h"

--- a/shell/common/extensions/electron_extensions_api_provider.cc
+++ b/shell/common/extensions/electron_extensions_api_provider.cc
@@ -6,7 +6,6 @@
 
 #include <memory>
 #include <string>
-#include <utility>
 
 #include "base/containers/span.h"
 #include "base/strings/utf_string_conversions.h"

--- a/shell/common/gin_converters/blink_converter.cc
+++ b/shell/common/gin_converters/blink_converter.cc
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "base/strings/string_util.h"

--- a/shell/common/gin_converters/content_converter.cc
+++ b/shell/common/gin_converters/content_converter.cc
@@ -5,7 +5,6 @@
 #include "shell/common/gin_converters/content_converter.h"
 
 #include <string>
-#include <vector>
 
 #include "content/public/browser/context_menu_params.h"
 #include "content/public/browser/native_web_keyboard_event.h"

--- a/shell/common/gin_converters/time_converter.h
+++ b/shell/common/gin_converters/time_converter.h
@@ -5,8 +5,6 @@
 #ifndef SHELL_COMMON_GIN_CONVERTERS_TIME_CONVERTER_H_
 #define SHELL_COMMON_GIN_CONVERTERS_TIME_CONVERTER_H_
 
-#include <utility>
-
 #include "gin/converter.h"
 
 namespace base {

--- a/shell/common/skia_util.h
+++ b/shell/common/skia_util.h
@@ -5,8 +5,6 @@
 #ifndef SHELL_COMMON_SKIA_UTIL_H_
 #define SHELL_COMMON_SKIA_UTIL_H_
 
-#include <string>
-
 #include "ui/gfx/image/image_skia.h"
 
 namespace electron {

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -4,7 +4,6 @@
 
 #include "shell/renderer/api/electron_api_context_bridge.h"
 
-#include <map>
 #include <memory>
 #include <set>
 #include <string>

--- a/shell/renderer/api/electron_api_spell_check_client.cc
+++ b/shell/renderer/api/electron_api_spell_check_client.cc
@@ -4,9 +4,7 @@
 
 #include "shell/renderer/api/electron_api_spell_check_client.h"
 
-#include <map>
 #include <memory>
-
 #include <set>
 #include <unordered_set>
 #include <utility>

--- a/shell/renderer/electron_api_service_impl.h
+++ b/shell/renderer/electron_api_service_impl.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_RENDERER_ELECTRON_API_SERVICE_IMPL_H_
 #define SHELL_RENDERER_ELECTRON_API_SERVICE_IMPL_H_
 
-#include <queue>
 #include <string>
 
 #include "base/memory/weak_ptr.h"

--- a/shell/renderer/electron_render_frame_observer.cc
+++ b/shell/renderer/electron_render_frame_observer.cc
@@ -4,7 +4,6 @@
 
 #include "shell/renderer/electron_render_frame_observer.h"
 
-#include <string>
 #include <utility>
 #include <vector>
 

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -5,7 +5,6 @@
 #include "shell/renderer/electron_renderer_client.h"
 
 #include <string>
-#include <vector>
 
 #include "base/command_line.h"
 #include "content/public/renderer/render_frame.h"

--- a/shell/renderer/electron_renderer_client.h
+++ b/shell/renderer/electron_renderer_client.h
@@ -8,7 +8,6 @@
 #include <memory>
 #include <set>
 #include <string>
-#include <vector>
 
 #include "shell/renderer/renderer_client_base.h"
 

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -4,6 +4,8 @@
 
 #include "shell/renderer/electron_sandboxed_renderer_client.h"
 
+#include <vector>
+
 #include "base/base_paths.h"
 #include "base/command_line.h"
 #include "base/files/file_path.h"

--- a/shell/renderer/electron_sandboxed_renderer_client.h
+++ b/shell/renderer/electron_sandboxed_renderer_client.h
@@ -7,7 +7,6 @@
 #include <memory>
 #include <set>
 #include <string>
-#include <vector>
 
 #include "base/process/process_metrics.h"
 #include "shell/renderer/renderer_client_base.h"

--- a/shell/renderer/renderer_client_base.h
+++ b/shell/renderer/renderer_client_base.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include "content/public/renderer/content_renderer_client.h"

--- a/shell/utility/electron_content_utility_client.h
+++ b/shell/utility/electron_content_utility_client.h
@@ -6,8 +6,6 @@
 #define SHELL_UTILITY_ELECTRON_CONTENT_UTILITY_CLIENT_H_
 
 #include <memory>
-#include <string>
-#include <vector>
 
 #include "base/compiler_specific.h"
 #include "content/public/utility/content_utility_client.h"


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

This PR removes unused `#include`s for STL headers.

There's a handful of added lines in `*.cc` files which transitively relied on an `#include` which was trimmed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
