### PR TITLE
fix: add service worker schemes from command line in renderer

### DIFF
--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -89,6 +89,16 @@ std::vector<std::string> GetStandardSchemes() {
   return g_standard_schemes;
 }
 
+void AddServiceWorkerScheme(const std::string& scheme) {
+  // There is no API to add service worker scheme, but there is an API to
+  // return const reference to the schemes vector.
+  // If in future the API is changed to return a copy instead of reference,
+  // the compilation will fail, and we should add a patch at that time.
+  auto& mutable_schemes =
+      const_cast<std::vector<std::string>&>(content::GetServiceWorkerSchemes());
+  mutable_schemes.push_back(scheme);
+}
+
 void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
                                  v8::Local<v8::Value> val) {
   std::vector<CustomScheme> custom_schemes;
@@ -125,13 +135,7 @@ void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
     }
     if (custom_scheme.options.allowServiceWorkers) {
       service_worker_schemes.push_back(custom_scheme.scheme);
-      // There is no API to add service worker scheme, but there is an API to
-      // return const reference to the schemes vector.
-      // If in future the API is changed to return a copy instead of reference,
-      // the compilation will fail, and we should add a patch at that time.
-      auto& mutable_schemes = const_cast<std::vector<std::string>&>(
-          content::GetServiceWorkerSchemes());
-      mutable_schemes.push_back(custom_scheme.scheme);
+      AddServiceWorkerScheme(custom_scheme.scheme);
     }
     if (custom_scheme.options.stream) {
       g_streaming_schemes.push_back(custom_scheme.scheme);

--- a/shell/browser/api/electron_api_protocol.h
+++ b/shell/browser/api/electron_api_protocol.h
@@ -22,6 +22,8 @@ namespace api {
 
 std::vector<std::string> GetStandardSchemes();
 
+void AddServiceWorkerScheme(const std::string& scheme);
+
 void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
                                  v8::Local<v8::Value> val);
 

--- a/shell/renderer/renderer_client_base.cc
+++ b/shell/renderer/renderer_client_base.cc
@@ -22,6 +22,7 @@
 #include "electron/buildflags/buildflags.h"
 #include "media/blink/multibuffer_data_source.h"
 #include "printing/buildflags/buildflags.h"
+#include "shell/browser/api/electron_api_protocol.h"
 #include "shell/common/api/electron_api_native_image.h"
 #include "shell/common/color_util.h"
 #include "shell/common/gin_helper/dictionary.h"
@@ -111,6 +112,11 @@ RendererClientBase* g_renderer_client_base = nullptr;
 
 RendererClientBase::RendererClientBase() {
   auto* command_line = base::CommandLine::ForCurrentProcess();
+  // Parse --service-worker-schemes=scheme1,scheme2
+  std::vector<std::string> service_worker_schemes_list =
+      ParseSchemesCLISwitch(command_line, switches::kServiceWorkerSchemes);
+  for (const std::string& scheme : service_worker_schemes_list)
+    electron::api::AddServiceWorkerScheme(scheme);
   // Parse --standard-schemes=scheme1,scheme2
   std::vector<std::string> standard_schemes_list =
       ParseSchemesCLISwitch(command_line, switches::kStandardSchemes);

--- a/spec/fixtures/pages/service-worker/custom-scheme-index.html
+++ b/spec/fixtures/pages/service-worker/custom-scheme-index.html
@@ -1,0 +1,21 @@
+<script>
+  const ipcRenderer = require('electron').ipcRenderer;
+  navigator.serviceWorker.register('service-worker.js', {scope: './'}).then(() => {
+    if (navigator.serviceWorker.controller) {
+      var xhr = new XMLHttpRequest();
+      xhr.open('GET', 'sw://dummy/echo');
+      xhr.setRequestHeader('X-Mock-Response', 'yes');
+      xhr.addEventListener('error', error => {
+        ipcRenderer.send('error', `${error.message}\n${error.stack}`);
+      })
+      xhr.addEventListener('load', () => {
+        ipcRenderer.send('response', xhr.responseText);
+      });
+      xhr.send();
+    } else {
+      ipcRenderer.send('reload');
+    }
+  }).catch(error => {
+    ipcRenderer.send('error', `${error.message}\n${error.stack}`);
+  })
+</script>


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Closes #28528. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed missing 'fetch' event in service workers for requests using a registered protocol <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
