### PR TITLE
fix: inspector context menu throwing an error

### DIFF
--- a/lib/browser/devtools.ts
+++ b/lib/browser/devtools.ts
@@ -54,7 +54,7 @@ const isChromeDevTools = function (pageURL: string) {
 };
 
 const assertChromeDevTools = function (contents: Electron.WebContents, api: string) {
-  const pageURL = contents._getURL();
+  const pageURL = contents.getURL();
   if (!isChromeDevTools(pageURL)) {
     console.error(`Blocked ${pageURL} from calling ${api}`);
     throw new Error(`Blocked ${api}`);

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -56,7 +56,6 @@ declare namespace Electron {
   }
 
   interface WebContents {
-    _getURL(): string;
     _loadURL(url: string, options: ElectronInternal.LoadURLOptions): void;
     _stop(): void;
     _goBack(): void;


### PR DESCRIPTION
#### Description of Change

Fixes an issue where right-clicking on the inspector throws an error:

```
[84035:0601/000704.374553:ERROR:CONSOLE(57)] "Uncaught (in promise) Error: Error invoking remote method 'INSPECTOR_CONTEXT_MENU': TypeError: e._getURL is not a function", source: electron/js2c/sandbox_bundle.js (57)
Error occurred in handler for 'INSPECTOR_CONTEXT_MENU': TypeError: e._getURL is not a function
    at assertChromeDevTools (electron/js2c/browser_init.js:177:881)
    at electron/js2c/browser_init.js:177:1127
    at new Promise (<anonymous>)
    at electron/js2c/browser_init.js:177:1117
    at electron/js2c/browser_init.js:197:579
    at Object.<anonymous> (electron/js2c/browser_init.js:161:10150)
    at Object.emit (events.js:376:20)
 ```
 
 Tested by running a stock Fiddle and right-clicking in the devtools console.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue where right-clicking in the devtools console throws an error