### PR TITLE
chore: remove unused WebContents method types

### DIFF
--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -58,10 +58,6 @@ declare namespace Electron {
   interface WebContents {
     _getURL(): string;
     _loadURL(url: string, options: ElectronInternal.LoadURLOptions): void;
-    _stop(): void;
-    _goBack(): void;
-    _goForward(): void;
-    _goToOffset(offset: number): void;
     getOwnerBrowserWindow(): Electron.BrowserWindow;
     getWebPreferences(): Electron.WebPreferences;
     getLastWebPreferences(): Electron.WebPreferences;


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/28839.

Removes methods no longer used/needed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none.