### PR TITLE
build: Improve squirrel.mac BUILD.gn xcrun_action error

### DIFF
--- a/patches/squirrel.mac/build_add_gn_config.patch
+++ b/patches/squirrel.mac/build_add_gn_config.patch
@@ -508,7 +508,7 @@ index 0000000000000000000000000000000000000000..bdfaf95f3eca65b3e0831db1b66f651d
 +}
 diff --git a/build/xcrun.py b/build/xcrun.py
 new file mode 100644
-index 0000000000000000000000000000000000000000..20d0cdb51cc933f56b7a7193c195457e82500870
+index 0000000000000000000000000000000000000000..18ac587f80441106405d00fafd9ee1f25b147772
 --- /dev/null
 +++ b/build/xcrun.py
 @@ -0,0 +1,14 @@
@@ -524,7 +524,7 @@ index 0000000000000000000000000000000000000000..20d0cdb51cc933f56b7a7193c195457e
 +try:
 +    subprocess.check_output(args, stderr=subprocess.STDOUT)
 +except subprocess.CalledProcessError as e:
-+    print("xcrun script '" + sys.argv[2] + "' failed with code '" + str(e.returncode) + "':\n" + e.output)
++    print("xcrun script '" + ' '.join(sys.argv[1:]) + "' failed with code '" + str(e.returncode) + "':\n" + e.output)
 +    sys.exit(e.returncode)
 diff --git a/filenames.gni b/filenames.gni
 new file mode 100644


### PR DESCRIPTION
Right now, if executing `xcrun` fails, then the error message prints the
second argument to the `xcrun.py` script, which is the first argument to
the tool that `xcrun` is executing, making the whole error message quite
confusing.

Consider the following error:

```
python ../../third_party/squirrel.mac/build/xcrun.py dtrace -h -s /private/tmp/20210531211008-def376dc/src/third_party/squirrel.mac/vendor/ReactiveObjC/ReactiveObjC/RACSignalProvider.d -o /private/tmp/20210531211008-def376dc/src/out/release/gen/third_party/squirrel.mac/dtrace/RACSignalProvider.h
xcrun script '-h' failed with code '71':
xcrun: error: can't exec '/tmp/20210531211008-def376dc/dtrace' (errno=Permission denied)
```

The command that `xcrun` is executing is `dtrace`, but the error just
mentions the `-h` flag.

Notes: none
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
