### PR TITLE
build: Support building Electron on msys2

### DIFF
--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -6,6 +6,7 @@ import sys
 
 PLATFORM = {
   'cygwin': 'win32',
+  'msys': 'win32',
   'darwin': 'darwin',
   'linux': 'linux',
   'linux2': 'linux',


### PR DESCRIPTION
Electron already seems to support `cygwin`, so `msys` is a natural
addition. This is the only required change as far as I can see on my
local development environment, as otherwise the build scripts don't
realize that msys = windows.

Notes: none
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>