### PR TITLE
refactor: eliminate duplicate C++ / JavaScript implementation of app.isPackaged

### DIFF
--- a/lib/browser/api/app.ts
+++ b/lib/browser/api/app.ts
@@ -55,14 +55,6 @@ Object.defineProperty(app, 'applicationMenu', {
   }
 });
 
-(app as any).isPackaged = (() => {
-  const execFile = path.basename(process.execPath).toLowerCase();
-  if (process.platform === 'win32') {
-    return execFile !== 'electron.exe';
-  }
-  return execFile !== 'electron';
-})();
-
 // The native implementation is not provided on non-windows platforms
 app.setAppUserModelId = app.setAppUserModelId || (() => {});
 

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -936,6 +936,20 @@ void App::SetAppLogsPath(gin_helper::ErrorThrower thrower,
 }
 #endif
 
+// static
+bool App::IsPackaged() {
+  base::FilePath exe_path;
+  base::PathService::Get(base::FILE_EXE, &exe_path);
+  base::FilePath::StringType base_name =
+      base::ToLowerASCII(exe_path.BaseName().value());
+
+#if defined(OS_WIN)
+  return base_name != FILE_PATH_LITERAL("electron.exe");
+#else
+  return base_name != FILE_PATH_LITERAL("electron");
+#endif
+}
+
 base::FilePath App::GetPath(gin_helper::ErrorThrower thrower,
                             const std::string& name) {
   bool succeed = false;
@@ -1607,6 +1621,7 @@ gin::ObjectTemplateBuilder App::GetObjectTemplateBuilder(v8::Isolate* isolate) {
       .SetMethod("isUnityRunning",
                  base::BindRepeating(&Browser::IsUnityRunning, browser))
 #endif
+      .SetProperty("isPackaged", &App::IsPackaged)
       .SetMethod("setAppPath", &App::SetAppPath)
       .SetMethod("getAppPath", &App::GetAppPath)
       .SetMethod("setPath", &App::SetPath)

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -75,6 +75,8 @@ class App : public ElectronBrowserClient::Delegate,
   void RenderProcessReady(content::RenderProcessHost* host);
   void RenderProcessExited(content::RenderProcessHost* host);
 
+  static bool IsPackaged();
+
   App();
 
  private:

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -24,6 +24,7 @@
 #include "content/public/browser/browser_thread.h"
 #include "content/public/common/content_paths.h"
 #include "electron/buildflags/buildflags.h"
+#include "shell/browser/api/electron_api_app.h"
 #include "shell/common/api/electron_bindings.h"
 #include "shell/common/electron_command_line.h"
 #include "shell/common/gin_converters/file_path_converter.h"
@@ -129,19 +130,6 @@ void stop_and_close_uv_loop(uv_loop_t* loop) {
 }
 
 bool g_is_initialized = false;
-
-bool IsPackagedApp() {
-  base::FilePath exe_path;
-  base::PathService::Get(base::FILE_EXE, &exe_path);
-  base::FilePath::StringType base_name =
-      base::ToLowerASCII(exe_path.BaseName().value());
-
-#if defined(OS_WIN)
-  return base_name != FILE_PATH_LITERAL("electron.exe");
-#else
-  return base_name != FILE_PATH_LITERAL("electron");
-#endif
-}
 
 void V8FatalErrorCallback(const char* location, const char* message) {
   LOG(ERROR) << "Fatal error in V8: " << location << " " << message;
@@ -257,7 +245,7 @@ void SetNodeOptions(base::Environment* env) {
     std::vector<std::string> parts = base::SplitString(
         options, " ", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
 
-    bool is_packaged_app = IsPackagedApp();
+    bool is_packaged_app = electron::api::App::IsPackaged();
 
     for (const auto& part : parts) {
       // Strip off values passed to individual NODE_OPTIONs


### PR DESCRIPTION
#### Description of Change
There are two implementations, one in JavaScript and one in C++. Let's use the C++ one and expose it to JavaScript.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes
