### PR TITLE
fix: increase stack size on windows x86

### DIFF
--- a/shell/app/electron_main.cc
+++ b/shell/app/electron_main.cc
@@ -103,7 +103,75 @@ namespace crash_reporter {
 extern const char kCrashpadProcess[];
 }
 
+// In 32-bit builds, the main thread starts with the default (small) stack size.
+// The ARCH_CPU_32_BITS blocks here and below are in support of moving the main
+// thread to a fiber with a larger stack size.
+#if defined(ARCH_CPU_32_BITS)
+// The information needed to transfer control to the large-stack fiber and later
+// pass the main routine's exit code back to the small-stack fiber prior to
+// termination.
+struct FiberState {
+  HINSTANCE instance;
+  LPVOID original_fiber;
+  int fiber_result;
+};
+
+// A PFIBER_START_ROUTINE function run on a large-stack fiber that calls the
+// main routine, stores its return value, and returns control to the small-stack
+// fiber. |params| must be a pointer to a FiberState struct.
+void WINAPI FiberBinder(void* params) {
+  auto* fiber_state = static_cast<FiberState*>(params);
+  // Call the wWinMain routine from the fiber. Reusing the entry point minimizes
+  // confusion when examining call stacks in crash reports - seeing wWinMain on
+  // the stack is a handy hint that this is the main thread of the process.
+  fiber_state->fiber_result =
+      wWinMain(fiber_state->instance, nullptr, nullptr, 0);
+  // Switch back to the main thread to exit.
+  ::SwitchToFiber(fiber_state->original_fiber);
+}
+#endif  // defined(ARCH_CPU_32_BITS)
+
 int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
+#if defined(ARCH_CPU_32_BITS)
+  enum class FiberStatus { kConvertFailed, kCreateFiberFailed, kSuccess };
+  FiberStatus fiber_status = FiberStatus::kSuccess;
+  // GetLastError result if fiber conversion failed.
+  DWORD fiber_error = ERROR_SUCCESS;
+  if (!::IsThreadAFiber()) {
+    // Make the main thread's stack size 4 MiB so that it has roughly the same
+    // effective size as the 64-bit build's 8 MiB stack.
+    constexpr size_t kStackSize = 4 * 1024 * 1024;  // 4 MiB
+    // Leak the fiber on exit.
+    LPVOID original_fiber =
+        ::ConvertThreadToFiberEx(nullptr, FIBER_FLAG_FLOAT_SWITCH);
+    if (original_fiber) {
+      FiberState fiber_state = {instance, original_fiber};
+      // Create a fiber with a bigger stack and switch to it. Leak the fiber on
+      // exit.
+      LPVOID big_stack_fiber = ::CreateFiberEx(
+          0, kStackSize, FIBER_FLAG_FLOAT_SWITCH, FiberBinder, &fiber_state);
+      if (big_stack_fiber) {
+        ::SwitchToFiber(big_stack_fiber);
+        // The fibers must be cleaned up to avoid obscure TLS-related shutdown
+        // crashes.
+        ::DeleteFiber(big_stack_fiber);
+        ::ConvertFiberToThread();
+        // Control returns here after Chrome has finished running on FiberMain.
+        return fiber_state.fiber_result;
+      }
+      fiber_status = FiberStatus::kCreateFiberFailed;
+    } else {
+      fiber_status = FiberStatus::kConvertFailed;
+    }
+    // If we reach here then creating and switching to a fiber has failed. This
+    // probably means we are low on memory and will soon crash. Try to report
+    // this error once crash reporting is initialized.
+    fiber_error = ::GetLastError();
+    base::debug::Alias(&fiber_error);
+  }
+  // If we are already a fiber then continue normal execution.
+#endif  // defined(ARCH_CPU_32_BITS)
+
   struct Arguments {
     int argc = 0;
     wchar_t** argv = ::CommandLineToArgvW(::GetCommandLineW(), &argc);
@@ -197,6 +265,11 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
     }
     return crashpad_status;
   }
+
+#if defined(ARCH_CPU_32_BITS)
+  // Intentionally crash if converting to a fiber failed.
+  CHECK_EQ(fiber_status, FiberStatus::kSuccess);
+#endif  // defined(ARCH_CPU_32_BITS)
 
   if (!electron::CheckCommandLineArguments(arguments.argc, arguments.argv))
     return -1;

--- a/spec-main/crash-spec.ts
+++ b/spec-main/crash-spec.ts
@@ -13,9 +13,11 @@ const runFixtureAndEnsureCleanExit = (args: string[]) => {
   children.push(child);
   child.stdout.on('data', (chunk: Buffer) => {
     out += chunk.toString();
+    console.error(`stdout: ${out}`);
   });
   child.stderr.on('data', (chunk: Buffer) => {
     out += chunk.toString();
+    console.error(`stderr: ${out}`);
   });
   return new Promise<void>((resolve) => {
     child.on('exit', (code, signal) => {

--- a/spec-main/crash-spec.ts
+++ b/spec-main/crash-spec.ts
@@ -13,11 +13,9 @@ const runFixtureAndEnsureCleanExit = (args: string[]) => {
   children.push(child);
   child.stdout.on('data', (chunk: Buffer) => {
     out += chunk.toString();
-    console.error(`stdout: ${out}`);
   });
   child.stderr.on('data', (chunk: Buffer) => {
     out += chunk.toString();
-    console.error(`stderr: ${out}`);
   });
   return new Promise<void>((resolve) => {
     child.on('exit', (code, signal) => {

--- a/spec-main/fixtures/crash-cases/quit-on-crashed-event/index.js
+++ b/spec-main/fixtures/crash-cases/quit-on-crashed-event/index.js
@@ -15,6 +15,5 @@ app.once('ready', async () => {
       process.exit(details.exitCode);
     }
   });
-  await w.webContents.loadURL('about:blank');
-  w.webContents.executeJavaScript('process.crash()');
+  await w.webContents.loadURL('chrome://checkcrash');
 });

--- a/spec-main/fixtures/crash-cases/quit-on-crashed-event/index.js
+++ b/spec-main/fixtures/crash-cases/quit-on-crashed-event/index.js
@@ -1,6 +1,6 @@
 const { app, BrowserWindow } = require('electron');
 
-app.once('ready', () => {
+app.once('ready', async () => {
   const w = new BrowserWindow({
     show: false,
     webPreferences: {
@@ -8,9 +8,13 @@ app.once('ready', () => {
       nodeIntegration: true
     }
   });
-  w.webContents.once('crashed', () => {
-    app.quit();
+  w.webContents.once('render-process-gone', (_, details) => {
+    if (details.reason === 'crashed') {
+      process.exit(0);
+    } else {
+      process.exit(details.exitCode);
+    }
   });
-  w.webContents.loadURL('about:blank');
+  await w.webContents.loadURL('about:blank');
   w.webContents.executeJavaScript('process.crash()');
 });

--- a/spec-main/fixtures/crash-cases/quit-on-crashed-event/index.js
+++ b/spec-main/fixtures/crash-cases/quit-on-crashed-event/index.js
@@ -8,7 +8,7 @@ app.once('ready', async () => {
       nodeIntegration: true
     }
   });
-  w.webContents.on('render-process-gone', (_, details) => {
+  w.webContents.once('render-process-gone', (_, details) => {
     if (details.reason === 'crashed') {
       process.exit(0);
     } else {
@@ -16,6 +16,5 @@ app.once('ready', async () => {
     }
   });
   await w.webContents.loadURL('about:blank');
-  console.log(await w.webContents.executeJavaScript('42'));
   w.webContents.executeJavaScript('process.crash()');
 });

--- a/spec-main/fixtures/crash-cases/quit-on-crashed-event/index.js
+++ b/spec-main/fixtures/crash-cases/quit-on-crashed-event/index.js
@@ -8,7 +8,7 @@ app.once('ready', async () => {
       nodeIntegration: true
     }
   });
-  w.webContents.once('render-process-gone', (_, details) => {
+  w.webContents.on('render-process-gone', (_, details) => {
     if (details.reason === 'crashed') {
       process.exit(0);
     } else {
@@ -16,5 +16,6 @@ app.once('ready', async () => {
     }
   });
   await w.webContents.loadURL('about:blank');
+  console.log(await w.webContents.executeJavaScript('42'));
   w.webContents.executeJavaScript('process.crash()');
 });


### PR DESCRIPTION
#### Description of Change
Increase main thread stack size to 4MiB on Windows x86, to fix V8 stack overflow (#28487 ).
@deepak1556 increased stack size on Windows x64 to 8MiB, but only 0.5MiB on Windows x86 (#27376 ). It's not enough for V8.

Fixes https://github.com/electron/electron/issues/28487
Fixes https://github.com/electron/electron/issues/29177

callstack while stack overflow.
```
0:000:x86> kbL
 # ChildEBP RetAddr  Args to Child              
00 000ce034 0223dee3 000ce040 03a05afc 95de35b8 electron!v8::internal::Isolate::StackOverflow
01 000ce050 01f77440 00495bd8 0add5360 03a05afc electron!v8::internal::PendingCompilationErrorHandler::ReportErrors+0x33
02 000ce074 01f74ce5 000ce1a8 000ce150 000ce288 electron!v8::internal::`anonymous namespace'::FailWithPreparedPendingException+0x40
03 (Inline) -------- -------- -------- -------- electron!v8::internal::`anonymous namespace'::FailWithPendingException+0x2a
04 000ce128 01f75dcd 0add5360 00000000 00495bd8 electron!v8::internal::`anonymous namespace'::CompileToplevel+0x375
05 (Inline) -------- -------- -------- -------- electron!v8::internal::`anonymous namespace'::CompileToplevel+0x1a
06 000ce1fc 01f758d6 021e0041 00000003 00000200 electron!v8::internal::`anonymous namespace'::CompileScriptOnMainThread+0xed
07 000ce2f0 020d1707 000ce358 00495bd8 0add5354 electron!v8::internal::Compiler::GetSharedFunctionInfoForScript+0x596
08 000ce36c 020d44aa 00495bd8 0ad71038 0add5354 electron!v8::internal::Genesis::CompileExtension+0x1f7
09 000ce3b0 020d4053 00495bd8 004922b0 000ce3c4 electron!v8::internal::Genesis::InstallExtension+0xda
0a (Inline) -------- -------- -------- -------- electron!v8::internal::Genesis::InstallExtension+0x3b
0b (Inline) -------- -------- -------- -------- electron!v8::internal::Genesis::InstallRequestedExtensions+0x43
0c 000ce3e4 020bd8f7 00495bd8 00495bd8 000ce678 electron!v8::internal::Genesis::InstallExtensions+0x113
0d (Inline) -------- -------- -------- -------- electron!v8::internal::Bootstrapper::InstallExtensions+0x2d
0e 000ce440 01edbc8e 000ce4cc 00000000 00000000 electron!v8::internal::Bootstrapper::CreateEnvironment+0x87
0f (Inline) -------- -------- -------- -------- electron!v8::InvokeBootstrapper<v8::internal::Context>::Invoke+0x1d
10 (Inline) -------- -------- -------- -------- electron!v8::CreateEnvironment+0x5d
11 000ce4e8 01edc82e 000ce554 00495bd8 000ce678 electron!v8::NewContext+0x12e
12 000ce520 05ef7a21 000ce554 00495bd8 00000000 electron!v8::Context::FromSnapshot+0x4e
13 000ce60c 0427bfe3 000ce680 00495bd8 42054da0 electron!blink::V8ContextSnapshotImpl::CreateContext+0x121
14 000ce630 04f789dc 000ce680 00495bd8 42054da0 electron!blink::V8ContextSnapshot::CreateContextFromSnapshot+0x23
15 000ce748 04f783e6 06fb24b8 06fb2498 000002db electron!blink::LocalWindowProxy::CreateContext+0xcc
16 000ce804 043a9268 00000000 000ce838 0426c16a electron!blink::LocalWindowProxy::Initialize+0x86
17 (Inline) -------- -------- -------- -------- electron!blink::WindowProxyManager::GetWindowProxy+0x11
18 000ce810 0426c16a 42054da0 00495bd8 00000000 electron!blink::Frame::GetWindowProxy+0x18
19 (Inline) -------- -------- -------- -------- electron!blink::ToV8ContextEvenIfDetached+0x15
1a (Inline) -------- -------- -------- -------- electron!blink::ToScriptStateImpl+0x15
1b (Inline) -------- -------- -------- -------- electron!blink::ToScriptState+0x27
1c 000ce838 03a26dff 2bf81f00 000ce854 000ce874 electron!blink::ToScriptStateForMainWorld+0x4a
1d 000ce848 0343bf46 000ce854 00000038 00495bd8 electron!blink::WebLocalFrameImpl::MainWorldScriptContext+0xf
1e 000ce874 034201e1 0adb1e68 0adf7598 000ce8e4 electron!extensions::ScriptContextSet::GetMainWorldContextForFrame+0x46
1f (Inline) -------- -------- -------- -------- electron!extensions::`anonymous namespace'::GetExtensionFromFrame+0x6
20 000ce884 03b53dfd 00000001 00000000 00000000 electron!extensions::ExtensionFrameHelper::DidCommitProvisionalLoad+0x11
21 000ce8e4 03b5380d 00000001 00000000 00000000 electron!content::RenderFrameImpl::NotifyObserversOfNavigationCommit+0x14d
22 000cea50 04467d6c 000cea64 00000000 00000001 electron!content::RenderFrameImpl::DidCommitNavigation+0xd0d
23 000cea7c 0448f3a4 55823c18 00000000 00000001 electron!blink::LocalFrameClientImpl::DispatchDidCommitLoad+0x4c
24 000cebc4 04421501 000cebf0 00000005 2bf82060 electron!blink::DocumentLoader::CommitNavigation+0x3e4
25 000cebd8 044235ec 2bf89a18 000cec10 00000000 electron!blink::FrameLoader::CommitDocumentLoader+0x81
26 000cecdc 03a2ba3e 00000000 00000000 00000003 electron!blink::FrameLoader::CommitNavigation+0x3fc
27 000ced04 03b4dbdd 00000000 00000000 000ced00 electron!blink::WebLocalFrameImpl::CommitNavigation+0x4e
28 000ceda4 03b648d1 0ae16820 0ae165a0 00000000 electron!content::RenderFrameImpl::CommitNavigationWithParams+0x3ed
29 000cedfc 03b647e0 03b4d7f0 00000000 0ad713b8 electron!base::internal::FunctorTraits<void (content::RenderFrameImpl::*)(mojo::StructPtr<content::mojom::CommonNavigationParams>, mojo::StructPtr<content::mojom::CommitNavigationParams>, std::__1::unique_ptr<blink::PendingURLLoaderFactoryBundle,std::__1::default_delete<blink::PendingURLLoaderFactoryBundle> >, base::Optional<std::__1::vector<mojo::StructPtr<blink::mojom::TransferrableURLLoader>,std::__1::allocator<mojo::StructPtr<blink::mojom::TransferrableURLLoader> > > >, mojo::StructPtr<blink::mojom::ControllerServiceWorkerInfo>, mojo::StructPtr<blink::mojom::ServiceWorkerContainerInfoForClient>, mojo::PendingRemote<network::mojom::URLLoaderFactory>, std::__1::unique_ptr<content::DocumentState,std::__1::default_delete<content::DocumentState> >, std::__1::unique_ptr<blink::WebNavigationParams,std::__1::default_delete<blink::WebNavigationParams> >) __attribute__((thiscall)),void>::Invoke<void (content::RenderFrameImpl::*)(mojo::StructPtr<content::mojom::CommonNavigationParams>, mojo::StructPtr<content::mojom::CommitNavigationParams>, std::__1::unique_ptr<blink::PendingURLLoaderFactoryBundle,std::__1::default_delete<blink::PendingURLLoaderFactoryBundle> >, base::Optional<std::__1::vector<mojo::StructPtr<blink::mojom::TransferrableURLLoader>,std::__1::allocator<mojo::StructPtr<blink::mojom::TransferrableURLLoader> > > >, mojo::StructPtr<blink::mojom::ControllerServiceWorkerInfo>, mojo::StructPtr<blink::mojom::ServiceWorkerContainerInfoForClient>, mojo::PendingRemote<network::mojom::URLLoaderFactory>, std::__1::unique_ptr<content::DocumentState,std::__1::default_delete<content::DocumentState> >, std::__1::unique_ptr<blink::WebNavigationParams,std::__1::default_delete<blink::WebNavigationParams> >) __attribute__((thiscall)),base::WeakPtr<content::RenderFrameImpl>,mojo::StructPtr<content::mojom::CommonNavigationParams>,mojo::StructPtr<content::mojom::CommitNavigationParams>,std::__1::unique_ptr<blink::PendingURLLoaderFactoryBundle,std::__1::default_delete<blink::PendingURLLoade+0xd1
2a (Inline) -------- -------- -------- -------- electron!base::internal::InvokeHelper<1,void>::MakeItSo+0x87
2b (Inline) -------- -------- -------- -------- electron!base::internal::Invoker<base::internal::BindState<void (content::RenderFrameImpl::*)(mojo::StructPtr<content::mojom::CommonNavigationParams>, mojo::StructPtr<content::mojom::CommitNavigationParams>, std::__1::unique_ptr<blink::PendingURLLoaderFactoryBundle,std::__1::default_delete<blink::PendingURLLoaderFactoryBundle> >, base::Optional<std::__1::vector<mojo::StructPtr<blink::mojom::TransferrableURLLoader>,std::__1::allocator<mojo::StructPtr<blink::mojom::TransferrableURLLoader> > > >, mojo::StructPtr<blink::mojom::ControllerServiceWorkerInfo>, mojo::StructPtr<blink::mojom::ServiceWorkerContainerInfoForClient>, mojo::PendingRemote<network::mojom::URLLoaderFactory>, std::__1::unique_ptr<content::DocumentState,std::__1::default_delete<content::DocumentState> >, std::__1::unique_ptr<blink::WebNavigationParams,std::__1::default_delete<blink::WebNavigationParams> >) __attribute__((thiscall)),base::WeakPtr<content::RenderFrameImpl>,mojo::StructPtr<content::mojom::CommonNavigationParams>,mojo::StructPtr<content::mojom::CommitNavigationParams>,std::__1::unique_ptr<blink::PendingURLLoaderFactoryBundle,std::__1::default_delete<blink::PendingURLLoaderFactoryBundle> >,base::Optional<std::__1::vector<mojo::StructPtr<blink::mojom::TransferrableURLLoader>,std::__1::allocator<mojo::StructPtr<blink::mojom::TransferrableURLLoader> > > >,mojo::StructPtr<blink::mojom::ControllerServiceWorkerInfo>,mojo::StructPtr<blink::mojom::ServiceWorkerContainerInfoForClient>,mojo::PendingRemote<network::mojom::URLLoaderFactory>,std::__1::unique_ptr<content::DocumentState,std::__1::default_delete<content::DocumentState> > >,void (std::__1::unique_ptr<blink::WebNavigationParams,std::__1::default_delete<blink::WebNavigationParams> >)>::RunImpl+0x87
2c 000cee5c 03b4cfab 0ad713a0 000cee6c 00000000 electron!base::internal::Invoker<base::internal::BindState<void (content::RenderFrameImpl::*)(mojo::StructPtr<content::mojom::CommonNavigationParams>, mojo::StructPtr<content::mojom::CommitNavigationParams>, std::__1::unique_ptr<blink::PendingURLLoaderFactoryBundle,std::__1::default_delete<blink::PendingURLLoaderFactoryBundle> >, base::Optional<std::__1::vector<mojo::StructPtr<blink::mojom::TransferrableURLLoader>,std::__1::allocator<mojo::StructPtr<blink::mojom::TransferrableURLLoader> > > >, mojo::StructPtr<blink::mojom::ControllerServiceWorkerInfo>, mojo::StructPtr<blink::mojom::ServiceWorkerContainerInfoForClient>, mojo::PendingRemote<network::mojom::URLLoaderFactory>, std::__1::unique_ptr<content::DocumentState,std::__1::default_delete<content::DocumentState> >, std::__1::unique_ptr<blink::WebNavigationParams,std::__1::default_delete<blink::WebNavigationParams> >) __attribute__((thiscall)),base::WeakPtr<content::RenderFrameImpl>,mojo::StructPtr<content::mojom::CommonNavigationParams>,mojo::StructPtr<content::mojom::CommitNavigationParams>,std::__1::unique_ptr<blink::PendingURLLoaderFactoryBundle,std::__1::default_delete<blink::PendingURLLoaderFactoryBundle> >,base::Optional<std::__1::vector<mojo::StructPtr<blink::mojom::TransferrableURLLoader>,std::__1::allocator<mojo::StructPtr<blink::mojom::TransferrableURLLoader> > > >,mojo::StructPtr<blink::mojom::ControllerServiceWorkerInfo>,mojo::StructPtr<blink::mojom::ServiceWorkerContainerInfoForClient>,mojo::PendingRemote<network::mojom::URLLoaderFactory>,std::__1::unique_ptr<content::DocumentState,std::__1::default_delete<content::DocumentState> > >,void (std::__1::unique_ptr<blink::WebNavigationParams,std::__1::default_delete<blink::WebNavigationParams> >)>::RunOnce+0xa0
2d (Inline) -------- -------- -------- -------- electron!base::OnceCallback<void (std::__1::unique_ptr<blink::WebNavigationParams,std::__1::default_delete<blink::WebNavigationParams> >)>::Run+0x19
2e 000cefb4 045f4823 00000000 00000000 0ad6d850 electron!content::RenderFrameImpl::CommitNavigation+0xc8b
2f 000cf018 01cfd5e4 00000000 00000000 00000000 electron!content::NavigationClient::CommitNavigation+0xb3
30 000cf110 045f4d0e 0ae16308 000cf208 00000000 electron!content::mojom::NavigationClientStubDispatch::AcceptWithResponder+0x954
31 000cf134 0360f17c 000cf208 00000000 06b50430 electron!content::mojom::NavigationClientStub<mojo::RawPtrImplRefTraits<content::mojom::NavigationClient> >::AcceptWithResponder+0x3e
32 000cf178 03daff4d 000cf208 00000000 00000000 electron!mojo::InterfaceEndpointClient::HandleValidatedMessage+0x1ec
33 000cf200 03dae0e4 0047bc28 00000000 00000000 electron!IPC::`anonymous namespace'::ChannelAssociatedGroupController::AcceptOnProxyThread+0xfd
34 000cf254 03dae066 03dafe50 00000000 03dafe50 electron!base::internal::FunctorTraits<void (IPC::(anonymous namespace)::ChannelAssociatedGroupController::*)(mojo::Message) __attribute__((thiscall)),void>::Invoke<void (IPC::(anonymous namespace)::ChannelAssociatedGroupController::*)(mojo::Message) __attribute__((thiscall)),scoped_refptr<IPC::(anonymous namespace)::ChannelAssociatedGroupController>,mojo::Message>+0x64
35 (Inline) -------- -------- -------- -------- electron!base::internal::InvokeHelper<0,void>::MakeItSo+0x1b
36 (Inline) -------- -------- -------- -------- electron!base::internal::Invoker<base::internal::BindState<void (IPC::(anonymous namespace)::ChannelAssociatedGroupController::*)(mojo::Message) __attribute__((thiscall)),scoped_refptr<IPC::(anonymous namespace)::ChannelAssociatedGroupController>,mojo::Message>,void ()>::RunImpl+0x1e
37 000cf274 034d0b7c 0ad67740 0ad83e48 000cf2c0 electron!base::internal::Invoker<base::internal::BindState<void (IPC::(anonymous namespace)::ChannelAssociatedGroupController::*)(mojo::Message) __attribute__((thiscall)),scoped_refptr<IPC::(anonymous namespace)::ChannelAssociatedGroupController>,mojo::Message>,void ()>::RunOnce+0x36
38 (Inline) -------- -------- -------- -------- electron!base::OnceCallback<void ()>::Run+0x10
39 000cf308 03cdaa2c 06f70706 0ad83e48 00000000 electron!base::TaskAnnotator::RunTask+0x12c
3a 000cf3e0 03cda57d 000cf408 000cf410 00459b58 electron!base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl+0x23c
3b 000cf454 03cca988 000cf470 01f70e8c 004540b8 electron!base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork+0x8d
3c 000cf4a4 03cdb0fe 004306e4 ffffffff 00000000 electron!base::MessagePumpDefault::Run+0x68
3d 000cf4e0 034bba6d 00000001 ffffffff 7fffffff electron!base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run+0x6e
3e 000cf538 03b69aa9 ffffff01 00472978 000cf540 electron!base::RunLoop::Run+0x8d
3f 000cf5ec 02980b95 000cf624 080cf638 004055a0 electron!content::RendererMain+0x319
40 000cf608 02981228 000cf638 000cf624 000cf7b0 electron!content::RunOtherNamedProcessTypeMain+0x185
41 000cf654 01e08821 00000000 004055a0 003cda10 electron!content::ContentMainRunnerImpl::Run+0xf8
42 000cf754 01e08adf 000cf790 004055a0 004055a0 electron!content::RunContentProcess+0x2e1
43 000cf774 012d1535 000cf790 00000000 0042b388 electron!content::ContentMain+0x2f
44 000cf878 068c57fa 012d0000 00000000 003c4616 electron!wWinMain+0x405
45 (Inline) -------- -------- -------- -------- electron!invoke_main+0x1a
46 000cf8c4 74e1343d fffde000 000cf910 76f99802 electron!__scrt_common_main_seh+0xf8
47 000cf8d0 76f99802 fffde000 735f4e5a 00000000 KERNEL32!BaseThreadInitThunk+0xe
48 000cf910 76f997d5 068c5880 fffde000 00000000 ntdll_76f60000!__RtlUserThreadStart+0x70
49 000cf928 00000000 068c5880 fffde000 00000000 ntdll_76f60000!_RtlUserThreadStart+0x1b
0:000:x86> dt electron!v8::ExtensionConfiguration 000ce678
   +0x000 name_count_      : 0n1
   +0x004 names_           : 0x3d808ea0  -> 0x06e1d8b4  "extensions::SafeBuiltins"
```
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: fix stack overflow crash in v8 on windows 32-bit builds
