### PR TITLE
build: fix macOS build

### DIFF
--- a/shell/browser/api/electron_api_app_mac.mm
+++ b/shell/browser/api/electron_api_app_mac.mm
@@ -7,6 +7,8 @@
 #include "base/path_service.h"
 #include "shell/browser/api/electron_api_app.h"
 #include "shell/common/electron_paths.h"
+#include "shell/common/node_includes.h"
+#include "shell/common/process_util.h"
 
 #import <Cocoa/Cocoa.h>
 #import <sys/sysctl.h>


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Looks like merging #29168 broke the macOS build due to some missing `#include`s.

cc @zcbenz @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
