### PR TITLE
refactor: use auto env = base::Environment::Create(); everywhere

### DIFF
--- a/shell/app/electron_crash_reporter_client.cc
+++ b/shell/app/electron_crash_reporter_client.cc
@@ -52,7 +52,7 @@ void ElectronCrashReporterClient::Create() {
 
   // By setting the BREAKPAD_DUMP_LOCATION environment variable, an alternate
   // location to write crash dumps can be set.
-  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  auto env = base::Environment::Create();
   std::string alternate_crash_dump_location;
   base::FilePath crash_dumps_dir_path;
   if (env->GetVar("BREAKPAD_DUMP_LOCATION", &alternate_crash_dump_location)) {

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1012,7 +1012,7 @@ void App::SetPath(gin_helper::ErrorThrower thrower,
 
 void App::SetDesktopName(const std::string& desktop_name) {
 #if defined(OS_LINUX)
-  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  auto env = base::Environment::Create();
   env->SetVar("CHROME_DESKTOP", desktop_name);
 #endif
 }

--- a/shell/browser/browser_linux.cc
+++ b/shell/browser/browser_linux.cc
@@ -66,7 +66,7 @@ absl::optional<std::string> GetXdgAppOutput(
 }
 
 bool SetDefaultWebClient(const std::string& protocol) {
-  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  auto env = base::Environment::Create();
 
   std::vector<std::string> argv = {kXdgSettings, "set"};
   if (!protocol.empty()) {
@@ -95,7 +95,7 @@ bool Browser::SetAsDefaultProtocolClient(const std::string& protocol,
 
 bool Browser::IsDefaultProtocolClient(const std::string& protocol,
                                       gin::Arguments* args) {
-  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  auto env = base::Environment::Create();
 
   if (protocol.empty())
     return false;

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -572,7 +572,7 @@ void ElectronBrowserClient::AppendExtraCommandLineSwitches(
       command_line->AppendSwitchPath(switches::kAppPath, app_path);
     }
 
-    std::unique_ptr<base::Environment> env(base::Environment::Create());
+    auto env = base::Environment::Create();
     if (env->HasVar("ELECTRON_PROFILE_INIT_SCRIPTS")) {
       command_line->AppendSwitch("profile-electron-init");
     }
@@ -603,7 +603,7 @@ void ElectronBrowserClient::DidCreatePpapiPlugin(
 
 // attempt to get api key from env
 std::string ElectronBrowserClient::GetGeolocationApiKey() {
-  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  auto env = base::Environment::Create();
   std::string api_key;
   env->GetVar("GOOGLE_API_KEY", &api_key);
   return api_key;

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -160,7 +160,7 @@ void OverrideLinuxAppDataPath() {
   base::FilePath path;
   if (base::PathService::Get(DIR_APP_DATA, &path))
     return;
-  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  auto env = base::Environment::Create();
   path = base::nix::GetXDGDirectory(env.get(), base::nix::kXdgConfigHomeEnvVar,
                                     base::nix::kDotConfigDir);
   base::PathService::Override(DIR_APP_DATA, path);
@@ -313,7 +313,7 @@ int ElectronBrowserMainParts::PreCreateThreads() {
   // which keys off of getenv("LC_ALL").
   // We must set this env first to make ui::ResourceBundle accept the custom
   // locale.
-  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  auto env = base::Environment::Create();
   absl::optional<std::string> lc_all;
   if (!locale.empty()) {
     std::string str;

--- a/shell/browser/linux/unity_service.cc
+++ b/shell/browser/linux/unity_service.cc
@@ -58,7 +58,7 @@ void EnsureLibUnityLoaded() {
     return;
   attempted_load = true;
 
-  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  auto env = base::Environment::Create();
   base::nix::DesktopEnvironment desktop_env = GetDesktopEnvironment(env.get());
 
   // The "icon-tasks" KDE task manager also honors Unity Launcher API.

--- a/shell/browser/ui/gtk/app_indicator_icon.cc
+++ b/shell/browser/ui/gtk/app_indicator_icon.cc
@@ -160,7 +160,7 @@ AppIndicatorIcon::AppIndicatorIcon(std::string id,
                                    const gfx::ImageSkia& image,
                                    const std::u16string& tool_tip)
     : id_(id) {
-  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  auto env = base::Environment::Create();
   desktop_env_ = base::nix::GetDesktopEnvironment(env.get());
 
   EnsureLibAppIndicatorLoaded();

--- a/shell/browser/ui/views/electron_views_delegate.cc
+++ b/shell/browser/ui/views/electron_views_delegate.cc
@@ -19,7 +19,7 @@ namespace {
 
 #if defined(OS_LINUX)
 bool IsDesktopEnvironmentUnity() {
-  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  auto env = base::Environment::Create();
   base::nix::DesktopEnvironment desktop_env =
       base::nix::GetDesktopEnvironment(env.get());
   return desktop_env == base::nix::DESKTOP_ENVIRONMENT_UNITY;

--- a/shell/browser/ui/x/x_window_utils.cc
+++ b/shell/browser/ui/x/x_window_utils.cc
@@ -35,7 +35,7 @@ void SetWindowType(x11::Window window, const std::string& type) {
 
 bool ShouldUseGlobalMenuBar() {
   base::ThreadRestrictions::ScopedAllowIO allow_io;
-  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  auto env = base::Environment::Create();
   if (env->HasVar("ELECTRON_FORCE_WINDOW_MENU_BAR"))
     return false;
 

--- a/shell/common/node_bindings.cc
+++ b/shell/common/node_bindings.cc
@@ -353,7 +353,7 @@ void NodeBindings::Initialize() {
   // Parse and set Node.js cli flags.
   SetNodeCliFlags();
 
-  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  auto env = base::Environment::Create();
   SetNodeOptions(env.get());
 
   std::vector<std::string> argv = {"electron"};

--- a/shell/common/platform_util_linux.cc
+++ b/shell/common/platform_util_linux.cc
@@ -190,7 +190,7 @@ void OpenExternal(const GURL& url,
 }
 
 bool MoveItemToTrash(const base::FilePath& full_path, bool delete_on_fail) {
-  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  auto env = base::Environment::Create();
 
   // find the trash method
   std::string trash;


### PR DESCRIPTION
#### Description of Change
Some code is using `auto env = base::Environment::Create(); ` while other code is using `std::unique_ptr<base::Environment> env(base::Environment::Create());`. Let's unify on the shorter version.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes