### PR TITLE
refactor: use std::make_unique<T> / std::make_shared<T>

### DIFF
--- a/chromium_src/chrome/browser/certificate_manager_model.cc
+++ b/chromium_src/chrome/browser/certificate_manager_model.cc
@@ -133,8 +133,8 @@ void CertificateManagerModel::DidGetCertDBOnUIThread(
     CreationCallback callback) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
 
-  std::unique_ptr<CertificateManagerModel> model(
-      new CertificateManagerModel(cert_db, is_user_db_available));
+  auto model =
+      std::make_unique<CertificateManagerModel>(cert_db, is_user_db_available);
   std::move(callback).Run(std::move(model));
 }
 

--- a/shell/browser/extensions/api/tabs/tabs_api.cc
+++ b/shell/browser/extensions/api/tabs/tabs_api.cc
@@ -72,7 +72,7 @@ ExecuteCodeFunction::InitResult ExecuteCodeInTabFunction::Init() {
   base::DictionaryValue* details_value = NULL;
   if (!args_->GetDictionary(1, &details_value))
     return set_init_result(VALIDATION_FAILURE);
-  std::unique_ptr<InjectDetails> details(new InjectDetails());
+  auto details = std::make_unique<InjectDetails>();
   if (!InjectDetails::Populate(*details_value, details.get()))
     return set_init_result(VALIDATION_FAILURE);
 

--- a/shell/browser/extensions/electron_extensions_browser_client.cc
+++ b/shell/browser/extensions/electron_extensions_browser_client.cc
@@ -310,8 +310,8 @@ void ElectronExtensionsBrowserClient::BroadcastEventToRenderers(
     return;
   }
 
-  std::unique_ptr<extensions::Event> event(
-      new extensions::Event(histogram_value, event_name, std::move(args)));
+  auto event = std::make_unique<extensions::Event>(histogram_value, event_name,
+                                                   std::move(args));
   auto& context_map = ElectronBrowserContext::browser_context_map();
   for (auto const& entry : context_map) {
     if (entry.second) {

--- a/shell/browser/ui/gtk/status_icon.cc
+++ b/shell/browser/ui/gtk/status_icon.cc
@@ -46,12 +46,11 @@ std::unique_ptr<views::StatusIconLinux> CreateLinuxStatusIcon(
   if (AppIndicatorIcon::CouldOpen()) {
     ++indicators_count;
 
-    return std::unique_ptr<views::StatusIconLinux>(new AppIndicatorIcon(
+    return std::make_unique<AppIndicatorIcon>(
         base::StringPrintf("%s%d", id_prefix, indicators_count), image,
-        tool_tip));
+        tool_tip);
   } else {
-    return std::unique_ptr<views::StatusIconLinux>(
-        new GtkStatusIcon(image, tool_tip));
+    return std::make_unique<GtkStatusIcon>(image, tool_tip);
   }
   return nullptr;
 #endif

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -613,8 +613,7 @@ void InspectableWebContents::AddDevToolsExtensionsToClient() {
         web_contents_->GetMainFrame()->GetProcess()->GetID(),
         url::Origin::Create(extension->url()));
 
-    std::unique_ptr<base::DictionaryValue> extension_info(
-        new base::DictionaryValue());
+    auto extension_info = std::make_unique<base::DictionaryValue>();
     extension_info->SetString("startPage", devtools_page_url.spec());
     extension_info->SetString("name", extension->name());
     extension_info->SetBoolean(

--- a/shell/browser/ui/webui/accessibility_ui.cc
+++ b/shell/browser/ui/webui/accessibility_ui.cc
@@ -91,8 +91,7 @@ std::unique_ptr<base::DictionaryValue> BuildTargetDescriptor(
     int routing_id,
     ui::AXMode accessibility_mode,
     base::ProcessHandle handle = base::kNullProcessHandle) {
-  std::unique_ptr<base::DictionaryValue> target_data(
-      new base::DictionaryValue());
+  auto target_data = std::make_unique<base::DictionaryValue>();
   target_data->SetInteger(kProcessIdField, process_id);
   target_data->SetInteger(kRoutingIdField, routing_id);
   target_data->SetString(kUrlField, url.spec());
@@ -135,8 +134,7 @@ std::unique_ptr<base::DictionaryValue> BuildTargetDescriptor(
 
 std::unique_ptr<base::DictionaryValue> BuildTargetDescriptor(
     electron::NativeWindow* window) {
-  std::unique_ptr<base::DictionaryValue> target_data(
-      new base::DictionaryValue());
+  auto target_data = std::make_unique<base::DictionaryValue>();
   target_data->SetInteger(kSessionIdField, window->window_id());
   target_data->SetString(kNameField, window->GetTitle());
   target_data->SetString(kTypeField, kBrowser);
@@ -259,7 +257,7 @@ void HandleAccessibilityRequestCallback(
   // Always dump the Accessibility tree.
   data.SetString(kInternal, kOn);
 
-  std::unique_ptr<base::ListValue> rvh_list(new base::ListValue());
+  auto rvh_list = std::make_unique<base::ListValue>();
   std::unique_ptr<content::RenderWidgetHostIterator> widgets(
       content::RenderWidgetHost::GetRenderWidgetHosts());
 
@@ -293,7 +291,7 @@ void HandleAccessibilityRequestCallback(
 
   data.Set(kPagesField, std::move(rvh_list));
 
-  std::unique_ptr<base::ListValue> window_list(new base::ListValue());
+  auto window_list = std::make_unique<base::ListValue>();
   for (auto* window : electron::WindowList::GetWindows()) {
     window_list->Append(BuildTargetDescriptor(window));
   }
@@ -383,7 +381,7 @@ void ElectronAccessibilityUIMessageHandler::RequestNativeUITree(
   }
 
   // No browser with the specified |id| was found.
-  std::unique_ptr<base::DictionaryValue> result(new base::DictionaryValue());
+  auto result = std::make_unique<base::DictionaryValue>();
   result->SetInteger(kSessionIdField, window_id);
   result->SetString(kTypeField, kBrowser);
   result->SetString(kErrorField, "Window no longer exists.");

--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -108,7 +108,7 @@ void WebContentsPermissionHelper::RequestMediaAccessPermission(
       &MediaAccessAllowed, request, std::move(response_callback)));
 
   base::DictionaryValue details;
-  std::unique_ptr<base::ListValue> media_types(new base::ListValue);
+  auto media_types = std::make_unique<base::ListValue>();
   if (request.audio_type ==
       blink::mojom::MediaStreamType::DEVICE_AUDIO_CAPTURE) {
     media_types->AppendString("audio");

--- a/shell/common/v8_value_converter.cc
+++ b/shell/common/v8_value_converter.cc
@@ -391,7 +391,7 @@ std::unique_ptr<base::Value> V8ValueConverter::FromV8Array(
       val->CreationContext() != isolate->GetCurrentContext())
     scope = std::make_unique<v8::Context::Scope>(val->CreationContext());
 
-  std::unique_ptr<base::ListValue> result(new base::ListValue());
+  auto result = std::make_unique<base::ListValue>();
 
   // Only fields with integer keys are carried over to the ListValue.
   for (uint32_t i = 0; i < val->Length(); ++i) {

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -220,9 +220,9 @@ v8::MaybeLocal<v8::Value> PassValueToOtherContext(
     // Make the promise a shared_ptr so that when the original promise is
     // freed the proxy promise is correctly freed as well instead of being
     // left dangling
-    std::shared_ptr<gin_helper::Promise<v8::Local<v8::Value>>> proxied_promise(
-        new gin_helper::Promise<v8::Local<v8::Value>>(
-            destination_context->GetIsolate()));
+    auto proxied_promise =
+        std::make_shared<gin_helper::Promise<v8::Local<v8::Value>>>(
+            destination_context->GetIsolate());
     v8::Local<v8::Promise> proxied_promise_handle =
         proxied_promise->GetHandle();
 

--- a/shell/renderer/extensions/electron_extensions_dispatcher_delegate.cc
+++ b/shell/renderer/extensions/electron_extensions_dispatcher_delegate.cc
@@ -29,8 +29,7 @@ void ElectronExtensionsDispatcherDelegate::RegisterNativeHandlers(
     extensions::ScriptContext* context) {
   module_system->RegisterNativeHandler(
       "lazy_background_page",
-      std::unique_ptr<NativeHandler>(
-          new extensions::LazyBackgroundPageNativeHandler(context)));
+      std::make_unique<extensions::LazyBackgroundPageNativeHandler>(context));
 }
 
 void ElectronExtensionsDispatcherDelegate::PopulateSourceMap(


### PR DESCRIPTION
#### Description of Change
It's more readable, safer and we don't need to repeat the type twice.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes
