### PR TITLE
chore: use =default for default constructors/destructors

### DIFF
--- a/shell/app/electron_crash_reporter_client.cc
+++ b/shell/app/electron_crash_reporter_client.cc
@@ -92,9 +92,9 @@ void ElectronCrashReporterClient::SetGlobalAnnotations(
   global_annotations_ = annotations;
 }
 
-ElectronCrashReporterClient::ElectronCrashReporterClient() {}
+ElectronCrashReporterClient::ElectronCrashReporterClient() = default;
 
-ElectronCrashReporterClient::~ElectronCrashReporterClient() {}
+ElectronCrashReporterClient::~ElectronCrashReporterClient() = default;
 
 #if defined(OS_LINUX)
 void ElectronCrashReporterClient::SetCrashReporterClientIdFromGUID(

--- a/shell/browser/api/electron_api_in_app_purchase.cc
+++ b/shell/browser/api/electron_api_in_app_purchase.cc
@@ -105,9 +105,9 @@ const char* InAppPurchase::GetTypeName() {
   return "InAppPurchase";
 }
 
-InAppPurchase::InAppPurchase() {}
+InAppPurchase::InAppPurchase() = default;
 
-InAppPurchase::~InAppPurchase() {}
+InAppPurchase::~InAppPurchase() = default;
 
 v8::Local<v8::Promise> InAppPurchase::PurchaseProduct(
     const std::string& product_id,

--- a/shell/browser/api/event.cc
+++ b/shell/browser/api/event.cc
@@ -16,7 +16,7 @@ namespace gin_helper {
 
 gin::WrapperInfo Event::kWrapperInfo = {gin::kEmbedderNativeGin};
 
-Event::Event() {}
+Event::Event() = default;
 
 Event::~Event() {
   if (callback_) {

--- a/shell/browser/api/views/electron_api_image_view.cc
+++ b/shell/browser/api/views/electron_api_image_view.cc
@@ -18,7 +18,7 @@ ImageView::ImageView() : View(new views::ImageView()) {
   view()->set_owned_by_client();
 }
 
-ImageView::~ImageView() {}
+ImageView::~ImageView() = default;
 
 void ImageView::SetImage(const gfx::Image& image) {
   image_view()->SetImage(image.AsImageSkia());

--- a/shell/browser/badging/badge_manager_factory.cc
+++ b/shell/browser/badging/badge_manager_factory.cc
@@ -31,7 +31,7 @@ BadgeManagerFactory::BadgeManagerFactory()
           "BadgeManager",
           BrowserContextDependencyManager::GetInstance()) {}
 
-BadgeManagerFactory::~BadgeManagerFactory() {}
+BadgeManagerFactory::~BadgeManagerFactory() = default;
 
 KeyedService* BadgeManagerFactory::BuildServiceInstanceFor(
     content::BrowserContext* context) const {

--- a/shell/browser/child_web_contents_tracker.cc
+++ b/shell/browser/child_web_contents_tracker.cc
@@ -9,7 +9,7 @@ namespace electron {
 ChildWebContentsTracker::ChildWebContentsTracker(
     content::WebContents* web_contents) {}
 
-ChildWebContentsTracker::~ChildWebContentsTracker() {}
+ChildWebContentsTracker::~ChildWebContentsTracker() = default;
 
 WEB_CONTENTS_USER_DATA_KEY_IMPL(ChildWebContentsTracker)
 

--- a/shell/browser/electron_javascript_dialog_manager.cc
+++ b/shell/browser/electron_javascript_dialog_manager.cc
@@ -27,7 +27,7 @@ constexpr int kUserWantsNoMoreDialogs = -1;
 
 }  // namespace
 
-ElectronJavaScriptDialogManager::ElectronJavaScriptDialogManager() {}
+ElectronJavaScriptDialogManager::ElectronJavaScriptDialogManager() = default;
 ElectronJavaScriptDialogManager::~ElectronJavaScriptDialogManager() = default;
 
 void ElectronJavaScriptDialogManager::RunJavaScriptDialog(

--- a/shell/browser/electron_pdf_web_contents_helper_client.cc
+++ b/shell/browser/electron_pdf_web_contents_helper_client.cc
@@ -4,7 +4,8 @@
 
 #include "shell/browser/electron_pdf_web_contents_helper_client.h"
 
-ElectronPDFWebContentsHelperClient::ElectronPDFWebContentsHelperClient() {}
+ElectronPDFWebContentsHelperClient::ElectronPDFWebContentsHelperClient() =
+    default;
 ElectronPDFWebContentsHelperClient::~ElectronPDFWebContentsHelperClient() =
     default;
 

--- a/shell/browser/extensions/api/management/electron_management_api_delegate.cc
+++ b/shell/browser/extensions/api/management/electron_management_api_delegate.cc
@@ -42,7 +42,7 @@ class ManagementSetEnabledFunctionInstallPromptDelegate
       base::OnceCallback<void(bool)> callback) {
     // TODO(sentialx): emit event
   }
-  ~ManagementSetEnabledFunctionInstallPromptDelegate() override {}
+  ~ManagementSetEnabledFunctionInstallPromptDelegate() override = default;
 
  private:
   base::WeakPtrFactory<ManagementSetEnabledFunctionInstallPromptDelegate>
@@ -61,7 +61,7 @@ class ManagementUninstallFunctionUninstallDialogDelegate
     // TODO(sentialx): emit event
   }
 
-  ~ManagementUninstallFunctionUninstallDialogDelegate() override {}
+  ~ManagementUninstallFunctionUninstallDialogDelegate() override = default;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(ManagementUninstallFunctionUninstallDialogDelegate);
@@ -69,9 +69,9 @@ class ManagementUninstallFunctionUninstallDialogDelegate
 
 }  // namespace
 
-ElectronManagementAPIDelegate::ElectronManagementAPIDelegate() {}
+ElectronManagementAPIDelegate::ElectronManagementAPIDelegate() = default;
 
-ElectronManagementAPIDelegate::~ElectronManagementAPIDelegate() {}
+ElectronManagementAPIDelegate::~ElectronManagementAPIDelegate() = default;
 
 void ElectronManagementAPIDelegate::LaunchAppFunctionDelegate(
     const extensions::Extension* extension,

--- a/shell/browser/extensions/api/resources_private/resources_private_api.cc
+++ b/shell/browser/extensions/api/resources_private/resources_private_api.cc
@@ -79,9 +79,11 @@ void AddAdditionalDataForPdf(base::DictionaryValue* dict) {
 
 namespace get_strings = api::resources_private::GetStrings;
 
-ResourcesPrivateGetStringsFunction::ResourcesPrivateGetStringsFunction() {}
+ResourcesPrivateGetStringsFunction::ResourcesPrivateGetStringsFunction() =
+    default;
 
-ResourcesPrivateGetStringsFunction::~ResourcesPrivateGetStringsFunction() {}
+ResourcesPrivateGetStringsFunction::~ResourcesPrivateGetStringsFunction() =
+    default;
 
 ExtensionFunction::ResponseAction ResourcesPrivateGetStringsFunction::Run() {
   std::unique_ptr<get_strings::Params> params(

--- a/shell/browser/extensions/api/tabs/tabs_api.cc
+++ b/shell/browser/extensions/api/tabs/tabs_api.cc
@@ -57,7 +57,7 @@ void ZoomModeToZoomSettings(WebContentsZoomController::ZoomMode zoom_mode,
 
 ExecuteCodeInTabFunction::ExecuteCodeInTabFunction() : execute_tab_id_(-1) {}
 
-ExecuteCodeInTabFunction::~ExecuteCodeInTabFunction() {}
+ExecuteCodeInTabFunction::~ExecuteCodeInTabFunction() = default;
 
 ExecuteCodeFunction::InitResult ExecuteCodeInTabFunction::Init() {
   if (init_result_)

--- a/shell/browser/extensions/electron_component_extension_resource_manager.cc
+++ b/shell/browser/extensions/electron_component_extension_resource_manager.cc
@@ -46,7 +46,7 @@ ElectronComponentExtensionResourceManager::
 }
 
 ElectronComponentExtensionResourceManager::
-    ~ElectronComponentExtensionResourceManager() {}
+    ~ElectronComponentExtensionResourceManager() = default;
 
 bool ElectronComponentExtensionResourceManager::IsComponentExtensionResource(
     const base::FilePath& extension_path,

--- a/shell/browser/extensions/electron_extension_host_delegate.cc
+++ b/shell/browser/extensions/electron_extension_host_delegate.cc
@@ -17,9 +17,9 @@
 
 namespace extensions {
 
-ElectronExtensionHostDelegate::ElectronExtensionHostDelegate() {}
+ElectronExtensionHostDelegate::ElectronExtensionHostDelegate() = default;
 
-ElectronExtensionHostDelegate::~ElectronExtensionHostDelegate() {}
+ElectronExtensionHostDelegate::~ElectronExtensionHostDelegate() = default;
 
 void ElectronExtensionHostDelegate::OnExtensionHostCreated(
     content::WebContents* web_contents) {

--- a/shell/browser/extensions/electron_extension_system_factory.cc
+++ b/shell/browser/extensions/electron_extension_system_factory.cc
@@ -31,7 +31,7 @@ ElectronExtensionSystemFactory::ElectronExtensionSystemFactory()
   DependsOn(ExtensionRegistryFactory::GetInstance());
 }
 
-ElectronExtensionSystemFactory::~ElectronExtensionSystemFactory() {}
+ElectronExtensionSystemFactory::~ElectronExtensionSystemFactory() = default;
 
 KeyedService* ElectronExtensionSystemFactory::BuildServiceInstanceFor(
     BrowserContext* context) const {

--- a/shell/browser/extensions/electron_extension_web_contents_observer.cc
+++ b/shell/browser/extensions/electron_extension_web_contents_observer.cc
@@ -10,7 +10,8 @@ ElectronExtensionWebContentsObserver::ElectronExtensionWebContentsObserver(
     content::WebContents* web_contents)
     : ExtensionWebContentsObserver(web_contents) {}
 
-ElectronExtensionWebContentsObserver::~ElectronExtensionWebContentsObserver() {}
+ElectronExtensionWebContentsObserver::~ElectronExtensionWebContentsObserver() =
+    default;
 
 void ElectronExtensionWebContentsObserver::CreateForWebContents(
     content::WebContents* web_contents) {

--- a/shell/browser/extensions/electron_extensions_api_client.cc
+++ b/shell/browser/extensions/electron_extensions_api_client.cc
@@ -51,8 +51,8 @@ class ElectronGuestViewManagerDelegate
 class ElectronMimeHandlerViewGuestDelegate
     : public MimeHandlerViewGuestDelegate {
  public:
-  ElectronMimeHandlerViewGuestDelegate() {}
-  ~ElectronMimeHandlerViewGuestDelegate() override {}
+  ElectronMimeHandlerViewGuestDelegate() = default;
+  ~ElectronMimeHandlerViewGuestDelegate() override = default;
 
   // MimeHandlerViewGuestDelegate.
   bool HandleContextMenu(content::WebContents* web_contents,

--- a/shell/browser/extensions/electron_extensions_browser_client.cc
+++ b/shell/browser/extensions/electron_extensions_browser_client.cc
@@ -72,7 +72,7 @@ ElectronExtensionsBrowserClient::ElectronExtensionsBrowserClient()
       std::make_unique<extensions::ElectronExtensionsBrowserAPIProvider>());
 }
 
-ElectronExtensionsBrowserClient::~ElectronExtensionsBrowserClient() {}
+ElectronExtensionsBrowserClient::~ElectronExtensionsBrowserClient() = default;
 
 bool ElectronExtensionsBrowserClient::IsShuttingDown() {
   return electron::Browser::Get()->is_shutting_down();

--- a/shell/browser/extensions/electron_kiosk_delegate.cc
+++ b/shell/browser/extensions/electron_kiosk_delegate.cc
@@ -6,9 +6,9 @@
 
 namespace electron {
 
-ElectronKioskDelegate::ElectronKioskDelegate() {}
+ElectronKioskDelegate::ElectronKioskDelegate() = default;
 
-ElectronKioskDelegate::~ElectronKioskDelegate() {}
+ElectronKioskDelegate::~ElectronKioskDelegate() = default;
 
 bool ElectronKioskDelegate::IsAutoLaunchedKioskApp(
     const extensions::ExtensionId& id) const {

--- a/shell/browser/extensions/electron_navigation_ui_data.cc
+++ b/shell/browser/extensions/electron_navigation_ui_data.cc
@@ -11,7 +11,7 @@
 
 namespace extensions {
 
-ElectronNavigationUIData::ElectronNavigationUIData() {}
+ElectronNavigationUIData::ElectronNavigationUIData() = default;
 
 ElectronNavigationUIData::ElectronNavigationUIData(
     content::NavigationHandle* navigation_handle) {
@@ -20,7 +20,7 @@ ElectronNavigationUIData::ElectronNavigationUIData(
       extension_misc::kUnknownWindowId);
 }
 
-ElectronNavigationUIData::~ElectronNavigationUIData() {}
+ElectronNavigationUIData::~ElectronNavigationUIData() = default;
 
 std::unique_ptr<content::NavigationUIData> ElectronNavigationUIData::Clone() {
   std::unique_ptr<ElectronNavigationUIData> copy =

--- a/shell/browser/native_browser_view_mac.mm
+++ b/shell/browser/native_browser_view_mac.mm
@@ -225,7 +225,7 @@ NativeBrowserViewMac::NativeBrowserViewMac(
   view.autoresizingMask = kDefaultAutoResizingMask;
 }
 
-NativeBrowserViewMac::~NativeBrowserViewMac() {}
+NativeBrowserViewMac::~NativeBrowserViewMac() = default;
 
 void NativeBrowserViewMac::SetAutoResizeFlags(uint8_t flags) {
   NSAutoresizingMaskOptions autoresizing_mask = kDefaultAutoResizingMask;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -448,7 +448,7 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   original_level_ = [window_ level];
 }
 
-NativeWindowMac::~NativeWindowMac() {}
+NativeWindowMac::~NativeWindowMac() = default;
 
 void NativeWindowMac::SetContentView(views::View* view) {
   views::View* root_view = GetContentsView();

--- a/shell/browser/net/asar/asar_url_loader.cc
+++ b/shell/browser/net/asar/asar_url_loader.cc
@@ -83,7 +83,7 @@ class AsarURLLoader : public network::mojom::URLLoader {
   void ResumeReadingBodyFromNet() override {}
 
  private:
-  AsarURLLoader() {}
+  AsarURLLoader() = default;
   ~AsarURLLoader() override = default;
 
   void Start(const network::ResourceRequest& request,

--- a/shell/browser/notifications/win/notification_presenter_win.cc
+++ b/shell/browser/notifications/win/notification_presenter_win.cc
@@ -63,9 +63,9 @@ NotificationPresenter* NotificationPresenter::Create() {
   return presenter.release();
 }
 
-NotificationPresenterWin::NotificationPresenterWin() {}
+NotificationPresenterWin::NotificationPresenterWin() = default;
 
-NotificationPresenterWin::~NotificationPresenterWin() {}
+NotificationPresenterWin::~NotificationPresenterWin() = default;
 
 bool NotificationPresenterWin::Init() {
   base::ThreadRestrictions::ScopedAllowIO allow_io;

--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -596,7 +596,7 @@ bool WindowsToastNotification::RemoveCallbacks(
 ToastEventHandler::ToastEventHandler(Notification* notification)
     : notification_(notification->GetWeakPtr()) {}
 
-ToastEventHandler::~ToastEventHandler() {}
+ToastEventHandler::~ToastEventHandler() = default;
 
 IFACEMETHODIMP ToastEventHandler::Invoke(
     ABI::Windows::UI::Notifications::IToastNotification* sender,

--- a/shell/browser/printing/print_view_manager_electron.cc
+++ b/shell/browser/printing/print_view_manager_electron.cc
@@ -14,7 +14,7 @@ PrintViewManagerElectron::PrintViewManagerElectron(
     content::WebContents* web_contents)
     : PrintViewManagerBase(web_contents) {}
 
-PrintViewManagerElectron::~PrintViewManagerElectron() {}
+PrintViewManagerElectron::~PrintViewManagerElectron() = default;
 
 void PrintViewManagerElectron::SetupScriptedPrintPreview(
     SetupScriptedPrintPreviewCallback callback) {

--- a/shell/browser/protocol_registry.cc
+++ b/shell/browser/protocol_registry.cc
@@ -16,7 +16,7 @@ ProtocolRegistry* ProtocolRegistry::FromBrowserContext(
   return static_cast<ElectronBrowserContext*>(context)->protocol_registry();
 }
 
-ProtocolRegistry::ProtocolRegistry() {}
+ProtocolRegistry::ProtocolRegistry() = default;
 
 ProtocolRegistry::~ProtocolRegistry() = default;
 

--- a/shell/browser/serial/serial_chooser_context_factory.cc
+++ b/shell/browser/serial/serial_chooser_context_factory.cc
@@ -14,7 +14,7 @@ SerialChooserContextFactory::SerialChooserContextFactory()
           "SerialChooserContext",
           BrowserContextDependencyManager::GetInstance()) {}
 
-SerialChooserContextFactory::~SerialChooserContextFactory() {}
+SerialChooserContextFactory::~SerialChooserContextFactory() = default;
 
 KeyedService* SerialChooserContextFactory::BuildServiceInstanceFor(
     content::BrowserContext* context) const {

--- a/shell/browser/ui/cocoa/delayed_native_view_host.cc
+++ b/shell/browser/ui/cocoa/delayed_native_view_host.cc
@@ -9,7 +9,7 @@ namespace electron {
 DelayedNativeViewHost::DelayedNativeViewHost(gfx::NativeView native_view)
     : native_view_(native_view) {}
 
-DelayedNativeViewHost::~DelayedNativeViewHost() {}
+DelayedNativeViewHost::~DelayedNativeViewHost() = default;
 
 void DelayedNativeViewHost::ViewHierarchyChanged(
     const views::ViewHierarchyChangedDetails& details) {

--- a/shell/browser/ui/cocoa/electron_native_widget_mac.mm
+++ b/shell/browser/ui/cocoa/electron_native_widget_mac.mm
@@ -16,7 +16,7 @@ ElectronNativeWidgetMac::ElectronNativeWidgetMac(
       shell_(shell),
       style_mask_(style_mask) {}
 
-ElectronNativeWidgetMac::~ElectronNativeWidgetMac() {}
+ElectronNativeWidgetMac::~ElectronNativeWidgetMac() = default;
 
 NativeWidgetMacNSWindow* ElectronNativeWidgetMac::CreateNSWindow(
     const remote_cocoa::mojom::CreateWindowParams* params) {

--- a/shell/browser/ui/cocoa/root_view_mac.mm
+++ b/shell/browser/ui/cocoa/root_view_mac.mm
@@ -12,7 +12,7 @@ RootViewMac::RootViewMac(NativeWindow* window) : window_(window) {
   set_owned_by_client();
 }
 
-RootViewMac::~RootViewMac() {}
+RootViewMac::~RootViewMac() = default;
 
 void RootViewMac::Layout() {
   if (!window_->content_view())  // Not ready yet.

--- a/shell/browser/ui/cocoa/views_delegate_mac.mm
+++ b/shell/browser/ui/cocoa/views_delegate_mac.mm
@@ -9,9 +9,9 @@
 
 namespace electron {
 
-ViewsDelegateMac::ViewsDelegateMac() {}
+ViewsDelegateMac::ViewsDelegateMac() = default;
 
-ViewsDelegateMac::~ViewsDelegateMac() {}
+ViewsDelegateMac::~ViewsDelegateMac() = default;
 
 void ViewsDelegateMac::OnBeforeWidgetInit(
     views::Widget::InitParams* params,

--- a/shell/browser/ui/views/win_frame_view.cc
+++ b/shell/browser/ui/views/win_frame_view.cc
@@ -13,9 +13,9 @@ namespace electron {
 
 const char WinFrameView::kViewClassName[] = "WinFrameView";
 
-WinFrameView::WinFrameView() {}
+WinFrameView::WinFrameView() = default;
 
-WinFrameView::~WinFrameView() {}
+WinFrameView::~WinFrameView() = default;
 
 gfx::Rect WinFrameView::GetWindowBoundsForClientBounds(
     const gfx::Rect& client_bounds) const {

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -23,7 +23,7 @@ ElectronDesktopWindowTreeHostWin::ElectronDesktopWindowTreeHostWin(
                                       desktop_native_widget_aura),
       native_window_view_(native_window_view) {}
 
-ElectronDesktopWindowTreeHostWin::~ElectronDesktopWindowTreeHostWin() {}
+ElectronDesktopWindowTreeHostWin::~ElectronDesktopWindowTreeHostWin() = default;
 
 bool ElectronDesktopWindowTreeHostWin::PreHandleMSG(UINT message,
                                                     WPARAM w_param,

--- a/shell/browser/ui/win/taskbar_host.cc
+++ b/shell/browser/ui/win/taskbar_host.cc
@@ -55,9 +55,9 @@ TaskbarHost::ThumbarButton::ThumbarButton(const TaskbarHost::ThumbarButton&) =
     default;
 TaskbarHost::ThumbarButton::~ThumbarButton() = default;
 
-TaskbarHost::TaskbarHost() {}
+TaskbarHost::TaskbarHost() = default;
 
-TaskbarHost::~TaskbarHost() {}
+TaskbarHost::~TaskbarHost() = default;
 
 bool TaskbarHost::SetThumbarButtons(HWND window,
                                     const std::vector<ThumbarButton>& buttons) {

--- a/shell/browser/win/scoped_hstring.cc
+++ b/shell/browser/win/scoped_hstring.cc
@@ -16,7 +16,7 @@ ScopedHString::ScopedHString(const std::wstring& source) {
   Reset(source);
 }
 
-ScopedHString::ScopedHString() {}
+ScopedHString::ScopedHString() = default;
 
 ScopedHString::~ScopedHString() {
   Reset();

--- a/shell/common/api/electron_bindings.cc
+++ b/shell/common/api/electron_bindings.cc
@@ -38,7 +38,7 @@ ElectronBindings::ElectronBindings(uv_loop_t* loop) {
   metrics_ = base::ProcessMetrics::CreateCurrentProcessMetrics();
 }
 
-ElectronBindings::~ElectronBindings() {}
+ElectronBindings::~ElectronBindings() = default;
 
 // static
 void ElectronBindings::BindProcess(v8::Isolate* isolate,

--- a/shell/common/extensions/electron_extensions_client.cc
+++ b/shell/common/extensions/electron_extensions_client.cc
@@ -30,8 +30,8 @@ namespace {
 class ElectronPermissionMessageProvider
     : public extensions::PermissionMessageProvider {
  public:
-  ElectronPermissionMessageProvider() {}
-  ~ElectronPermissionMessageProvider() override {}
+  ElectronPermissionMessageProvider() = default;
+  ~ElectronPermissionMessageProvider() override = default;
 
   // PermissionMessageProvider implementation.
   extensions::PermissionMessages GetPermissionMessages(
@@ -70,7 +70,7 @@ ElectronExtensionsClient::ElectronExtensionsClient()
   AddAPIProvider(std::make_unique<ElectronExtensionsAPIProvider>());
 }
 
-ElectronExtensionsClient::~ElectronExtensionsClient() {}
+ElectronExtensionsClient::~ElectronExtensionsClient() = default;
 
 void ElectronExtensionsClient::Initialize() {
   // TODO(jamescook): Do we need to whitelist any extensions?

--- a/shell/common/node_bindings_mac.cc
+++ b/shell/common/node_bindings_mac.cc
@@ -17,7 +17,7 @@ namespace electron {
 NodeBindingsMac::NodeBindingsMac(BrowserEnvironment browser_env)
     : NodeBindings(browser_env) {}
 
-NodeBindingsMac::~NodeBindingsMac() {}
+NodeBindingsMac::~NodeBindingsMac() = default;
 
 void NodeBindingsMac::RunMessageLoop() {
   // Get notified when libuv's watcher queue changes.

--- a/shell/common/node_bindings_win.cc
+++ b/shell/common/node_bindings_win.cc
@@ -27,7 +27,7 @@ NodeBindingsWin::NodeBindingsWin(BrowserEnvironment browser_env)
   }
 }
 
-NodeBindingsWin::~NodeBindingsWin() {}
+NodeBindingsWin::~NodeBindingsWin() = default;
 
 void NodeBindingsWin::PollEvents() {
   // If there are other kinds of events pending, uv_backend_timeout will

--- a/shell/renderer/api/context_bridge/object_cache.cc
+++ b/shell/renderer/api/context_bridge/object_cache.cc
@@ -14,7 +14,7 @@ namespace api {
 
 namespace context_bridge {
 
-ObjectCache::ObjectCache() {}
+ObjectCache::ObjectCache() = default;
 ObjectCache::~ObjectCache() = default;
 
 void ObjectCache::CacheProxiedObject(v8::Local<v8::Value> from,

--- a/shell/renderer/electron_renderer_pepper_host_factory.cc
+++ b/shell/renderer/electron_renderer_pepper_host_factory.cc
@@ -79,7 +79,8 @@ ElectronRendererPepperHostFactory::ElectronRendererPepperHostFactory(
     content::RendererPpapiHost* host)
     : host_(host) {}
 
-ElectronRendererPepperHostFactory::~ElectronRendererPepperHostFactory() {}
+ElectronRendererPepperHostFactory::~ElectronRendererPepperHostFactory() =
+    default;
 
 std::unique_ptr<ResourceHost>
 ElectronRendererPepperHostFactory::CreateResourceHost(

--- a/shell/renderer/extensions/electron_extensions_dispatcher_delegate.cc
+++ b/shell/renderer/extensions/electron_extensions_dispatcher_delegate.cc
@@ -18,9 +18,11 @@
 
 using extensions::NativeHandler;
 
-ElectronExtensionsDispatcherDelegate::ElectronExtensionsDispatcherDelegate() {}
+ElectronExtensionsDispatcherDelegate::ElectronExtensionsDispatcherDelegate() =
+    default;
 
-ElectronExtensionsDispatcherDelegate::~ElectronExtensionsDispatcherDelegate() {}
+ElectronExtensionsDispatcherDelegate::~ElectronExtensionsDispatcherDelegate() =
+    default;
 
 void ElectronExtensionsDispatcherDelegate::RegisterNativeHandlers(
     extensions::Dispatcher* dispatcher,

--- a/shell/renderer/extensions/electron_extensions_renderer_client.cc
+++ b/shell/renderer/extensions/electron_extensions_renderer_client.cc
@@ -21,7 +21,7 @@ ElectronExtensionsRendererClient::ElectronExtensionsRendererClient()
   dispatcher_->OnRenderThreadStarted(content::RenderThread::Get());
 }
 
-ElectronExtensionsRendererClient::~ElectronExtensionsRendererClient() {}
+ElectronExtensionsRendererClient::~ElectronExtensionsRendererClient() = default;
 
 bool ElectronExtensionsRendererClient::IsIncognitoProcess() const {
   // app_shell doesn't support off-the-record contexts.

--- a/shell/renderer/pepper_helper.cc
+++ b/shell/renderer/pepper_helper.cc
@@ -15,7 +15,7 @@
 PepperHelper::PepperHelper(content::RenderFrame* render_frame)
     : RenderFrameObserver(render_frame) {}
 
-PepperHelper::~PepperHelper() {}
+PepperHelper::~PepperHelper() = default;
 
 void PepperHelper::DidCreatePepperPlugin(content::RendererPpapiHost* host) {
   // TODO(brettw) figure out how to hook up the host factory. It needs some


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Per the [Chromium style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++-dos-and-donts.md#prefer-to-use), and one of the `clang-tidy` checks which Chromium has enabled.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
