### PR TITLE
refactor: tune-up electron::api::NetLog

### DIFF
--- a/shell/browser/api/electron_api_net_log.cc
+++ b/shell/browser/api/electron_api_net_log.cc
@@ -7,13 +7,17 @@
 #include <string>
 #include <utility>
 
+#include "base/bind.h"
 #include "base/command_line.h"
+#include "base/files/file_path.h"
 #include "base/task/thread_pool.h"
+#include "base/task_runner_util.h"
 #include "chrome/browser/browser_process.h"
 #include "components/net_log/chrome_net_log.h"
 #include "content/public/browser/storage_partition.h"
 #include "electron/electron_version.h"
 #include "gin/object_template_builder.h"
+#include "net/log/net_log_capture_mode.h"
 #include "shell/browser/electron_browser_context.h"
 #include "shell/browser/net/system_network_context_manager.h"
 #include "shell/common/gin_converters/file_path_converter.h"
@@ -135,9 +139,10 @@ v8::Local<v8::Promise> NetLog::StartLogging(base::FilePath log_path,
   auto* network_context =
       browser_context_->GetDefaultStoragePartition()->GetNetworkContext();
 
-  network_context->CreateNetLogExporter(mojo::MakeRequest(&net_log_exporter_));
-  net_log_exporter_.set_connection_error_handler(base::BindOnce(
-      &NetLog::OnConnectionError, weak_ptr_factory_.GetWeakPtr()));
+  network_context->CreateNetLogExporter(
+      net_log_exporter_.BindNewPipeAndPassReceiver());
+  net_log_exporter_.set_disconnect_handler(
+      base::BindOnce(&NetLog::OnConnectionError, base::Unretained(this)));
 
   base::PostTaskAndReplyWithResult(
       file_task_runner_.get(), FROM_HERE,
@@ -201,7 +206,7 @@ v8::Local<v8::Promise> NetLog::StopLogging(gin::Arguments* args) {
     net_log_exporter_->Stop(
         base::Value(base::Value::Type::DICTIONARY),
         base::BindOnce(
-            [](network::mojom::NetLogExporterPtr,
+            [](mojo::Remote<network::mojom::NetLogExporter>,
                gin_helper::Promise<void> promise, int32_t error) {
               ResolvePromiseWithNetError(std::move(promise), error);
             },

--- a/shell/browser/api/electron_api_net_log.h
+++ b/shell/browser/api/electron_api_net_log.h
@@ -6,9 +6,14 @@
 #define SHELL_BROWSER_API_ELECTRON_API_NET_LOG_H_
 
 #include "base/callback.h"
+#include "base/files/file_path.h"
+#include "base/macros.h"
+#include "base/memory/weak_ptr.h"
 #include "base/values.h"
 #include "gin/handle.h"
 #include "gin/wrappable.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "net/log/net_log_capture_mode.h"
 #include "services/network/public/mojom/net_log.mojom.h"
 #include "shell/common/gin_helper/promise.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
@@ -23,6 +28,7 @@ class ElectronBrowserContext;
 
 namespace api {
 
+// The code is referenced from the net_log::NetExportFileWriter class.
 class NetLog : public gin::Wrappable<NetLog> {
  public:
   static gin::Handle<NetLog> Create(v8::Isolate* isolate,
@@ -55,7 +61,7 @@ class NetLog : public gin::Wrappable<NetLog> {
  private:
   ElectronBrowserContext* browser_context_;
 
-  network::mojom::NetLogExporterPtr net_log_exporter_;
+  mojo::Remote<network::mojom::NetLogExporter> net_log_exporter_;
 
   absl::optional<gin_helper::Promise<void>> pending_start_promise_;
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Apologies for the nondescript title, couldn't think of a proper name since it's a bag of a couple of changes. Main one is land [45d3c7fe83f4c11c556734093236ab47efce01c5](https://source.chromium.org/chromium/chromium/src/+/45d3c7fe83f4c11c556734093236ab47efce01c5) from upstream, to use newer Mojo types, then there's an added comment to document which upstream class it's referencing code from, and adding some headers in an attempt to get some better IWYU going on.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
