### PR TITLE
fix: disable CET on 11th gen intel

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -31,3 +31,5 @@ is_cfi = false
 
 # Make application name configurable at runtime for cookie crypto
 allow_runtime_configurable_key_storage = true
+
+enable_cet_shadow_stack = false


### PR DESCRIPTION
This is causing uncatchable crashs.  See #29335

Notes: Fixed crashes on Intel 11th gen CPUs