### PR TITLE
fix: disable CET as v8 deoptimization is incompatible with it

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -31,3 +31,5 @@ is_cfi = false
 
 # Make application name configurable at runtime for cookie crypto
 allow_runtime_configurable_key_storage = true
+
+enable_cet_shadow_stack = false


### PR DESCRIPTION
For info ping me in Slack, I'll fill out this PR body later.

Notes: Fixed crashes on latest gen Intel and Ryzen processors