### PR TITLE
refactor: use `locale` functions in `command_line_args.cc`

### DIFF
--- a/shell/app/command_line_args.cc
+++ b/shell/app/command_line_args.cc
@@ -3,13 +3,14 @@
 // found in the LICENSE file.
 
 #include "shell/app/command_line_args.h"
+#include <locale>
 
 namespace {
 
 bool IsUrlArg(const base::CommandLine::CharType* arg) {
   // the first character must be a letter for this to be a URL
   auto c = *arg;
-  if (('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')) {
+  if (std::isalpha(c, std::locale::classic())) {
     for (auto* p = arg + 1; *p; ++p) {
       c = *p;
 
@@ -23,7 +24,7 @@ bool IsUrlArg(const base::CommandLine::CharType* arg) {
       }
 
       // white-space before a colon means it's not a URL
-      if (c == ' ' || (0x9 <= c && c <= 0xD))
+      if (std::isspace(c, std::locale::classic()))
         break;
     }
   }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
This change refactors the code to use `isalpha()` and
`isspace()` so that the code is more readable.

Signed-off-by: Darshan Sen <raisinten@gmail.com>

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
