### PR TITLE
docs: fix setWindowOpenHandler invocation in window.open example

### DIFF
--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -85,15 +85,18 @@ const mainWindow = new BrowserWindow()
 mainWindow.webContents.setWindowOpenHandler(({ url }) => {
   if (url === 'about:blank') {
     return {
-      frame: false,
-      fullscreenable: false,
-      backgroundColor: 'black',
-      webPreferences: {
-        preload: 'my-child-window-preload-script.js'
+      action: 'allow',
+      overrideBrowserWindowOptions: {
+        frame: false,
+        fullscreenable: false,
+        backgroundColor: 'black',
+        webPreferences: {
+          preload: 'my-child-window-preload-script.js'
+        }
       }
     }
   }
-  return false
+  return { action: 'deny' }
 })
 ```
 


### PR DESCRIPTION
#### Description of Change
The "Native `Window` example" in `docs/api/window-open.md` calls `webContents.setWindowOpenHandler` incorrectly. This PR fixes the call, in line with previous fixes to other calls in this document.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed invocation of `webContents.setWindowOpenHandler` in `window.open` example.
