### PR TITLE
fix: make intermediates work with 'select-client-certificate'

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -536,10 +536,16 @@ void OnClientCertificateSelected(
   if (!certs.empty()) {
     scoped_refptr<net::X509Certificate> cert(certs[0].get());
     for (auto& identity : *identities) {
-      if (cert->EqualsExcludingChain(identity->certificate())) {
+      scoped_refptr<net::X509Certificate> identity_cert =
+          identity->certificate();
+      // Since |cert| was recreated from |data|, it won't include any
+      // intermediates. That's fine for checking equality, but once a match is
+      // found then |identity_cert| should be used since it will include the
+      // intermediates which would otherwise be lost.
+      if (cert->EqualsExcludingChain(identity_cert.get())) {
         net::ClientCertIdentity::SelfOwningAcquirePrivateKey(
-            std::move(identity),
-            base::BindRepeating(&GotPrivateKey, delegate, std::move(cert)));
+            std::move(identity), base::BindRepeating(&GotPrivateKey, delegate,
+                                                     std::move(identity_cert)));
         break;
       }
     }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Fixes #28553.

cc @zcbenz @deepak1556 

No test added because I wasn't sure there's a viable way to make one (no current tests for this functionality) since it pulls client certificates from the system store. See #21980.

Manually reproduced and tested the fix. The fix is straight forward, but if anyone else really feels like confirming it themselves, these are the steps I used on macOS, it was a bit of a pain:

1. In `Keychain Access`, use `Keychain Access -> Certificate Assistant` to create a certificate chain, using 'SSL Client' for the type for all certificates. Create:
    1. A self-signed root CA.
    2. An intermediate CA.
    3. A leaf certificate.
2. Apply the Chromium patch provided below, which ensures Chromium will include intermediates on macOS, otherwise they are only included when the server is limiting the trusted root CAs to a specific list.
3. Run [this gist](https://gist.github.com/5cb21384e8055f5172d9af59e3c71ba1) in Electron Fiddle.
4. Should see that the `SSL_CLIENT_CERT_CHAIN_1` field is populated if the chain was sent to the server.

<details>
<summary>Chromium Patch for Manual Testing (macOS)</summary>
<p> 

```patch
diff --git a/net/ssl/client_cert_store_mac.cc b/net/ssl/client_cert_store_mac.cc
index 7d97f1d090417..62d8e4f1675e3 100644
--- a/net/ssl/client_cert_store_mac.cc
+++ b/net/ssl/client_cert_store_mac.cc
@@ -133,15 +133,16 @@ bool IsIssuedByInKeychain(const std::vector<std::string>& valid_issuers,
                                                          options));
   CFRelease(cert_chain);  // Also frees |intermediates|.
 
-  if (!new_cert || !new_cert->IsIssuedByEncoded(valid_issuers))
-    return false;
-
   std::vector<bssl::UniquePtr<CRYPTO_BUFFER>> intermediate_buffers;
   intermediate_buffers.reserve(new_cert->intermediate_buffers().size());
   for (const auto& intermediate : new_cert->intermediate_buffers()) {
     intermediate_buffers.push_back(bssl::UpRef(intermediate.get()));
   }
   identity->SetIntermediates(std::move(intermediate_buffers));
+
+  if (!new_cert || !new_cert->IsIssuedByEncoded(valid_issuers))
+    return false;
+
   return true;
 }
 
@@ -235,6 +236,8 @@ void GetClientCertsImpl(std::unique_ptr<ClientCertIdentity> preferred_identity,
     if (cert_iter != selected_identities->end())
       continue;
 
+    IsIssuedByInKeychain(request.cert_authorities, cert.get());
+
     // Check if the certificate issuer is allowed by the server.
     if (request.cert_authorities.empty() ||
         cert->certificate()->IsIssuedByEncoded(request.cert_authorities) ||
```

</p>
</details> 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: Fixed sending intermediate certificates with 'select-client-certificate' event callback <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
