### PR TITLE
fix: copy received data in URLPipeLoader to prevent corruption

### DIFF
--- a/shell/browser/net/url_pipe_loader.cc
+++ b/shell/browser/net/url_pipe_loader.cc
@@ -85,7 +85,7 @@ void URLPipeLoader::OnDataReceived(base::StringPiece string_piece,
   producer_->Write(
       std::make_unique<mojo::StringDataSource>(
           string_piece, mojo::StringDataSource::AsyncWritingMode::
-                            STRING_STAYS_VALID_UNTIL_COMPLETION),
+                            STRING_MAY_BE_INVALIDATED_BEFORE_COMPLETION),
       base::BindOnce(&URLPipeLoader::OnWrite, weak_factory_.GetWeakPtr(),
                      std::move(resume)));
 }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Fixes #27426.

From the comment for `SimpleURLLoaderStreamConsumer::OnDataReceived`, which `URLPipeLoader::OnDataReceived` overrides:

```
  // |string_piece| will only be valid for the duration of the OnDataReceived()
  // call, but does remain valid during that call even if the SimpleURLLoader
  // is destroyed. |string_piece| will never be of length 0.
```

cc @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed potential corruption of piped response data when using interceptHttpProtocol/registerHttpProtocol <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
