### PR TITLE
fix: select-bluetooth-device on Windows

### DIFF
--- a/shell/browser/lib/bluetooth_chooser.cc
+++ b/shell/browser/lib/bluetooth_chooser.cc
@@ -60,6 +60,7 @@ void BluetoothChooser::SetAdapterPresence(AdapterPresence presence) {
       event_handler_.Run(content::BluetoothChooserEvent::CANCELLED, "");
       break;
     case AdapterPresence::POWERED_ON:
+      rescan_ = true;
       break;
   }
 }
@@ -92,7 +93,7 @@ void BluetoothChooser::ShowDiscoveryState(DiscoveryState state) {
     case DiscoveryState::DISCOVERING:
       // The first time this state fires is due to a rescan triggering so set a
       // flag to ignore devices
-      if (!refreshing_) {
+      if (rescan_ && !refreshing_) {
         refreshing_ = true;
       } else {
         // The second time this state fires we are now safe to pick a device

--- a/shell/browser/lib/bluetooth_chooser.h
+++ b/shell/browser/lib/bluetooth_chooser.h
@@ -42,6 +42,7 @@ class BluetoothChooser : public content::BluetoothChooser {
   EventHandler event_handler_;
   int num_retries_ = 0;
   bool refreshing_ = false;
+  bool rescan_ = false;
 
   DISALLOW_COPY_AND_ASSIGN(BluetoothChooser);
 };


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
#27902 included logic to handle the use case on macOS where BluetoothChooser::ShowDiscoveryState fires twice with a state of `DiscoveryState::DISCOVERING` because there is a [rescan event](https://source.chromium.org/chromium/chromium/src/+/main:content/browser/bluetooth/bluetooth_device_chooser_controller.cc;l=476) that fires on macOS.  This is usually not a problem but if a developer immediately handles the `select-bluetooth-device` event before the second `BluetoothChooser::ShowDiscoveryState` fires, a crash occurs because the BluetoothChooser is destroyed once a bluetooth device is selected.

Unfortunately this logic caused an issue on Windows where the rescan event does not fire.  I was able to fix this issue by adding a flag to only fire the rescan logic when a rescan is triggered.

Fixes #28185
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->fixed `select-bluetooth-device` firing on Windows
