### PR TITLE
fix: ensure fuse order is read in a stable way

### DIFF
--- a/build/fuses/build.py
+++ b/build/fuses/build.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+from collections import OrderedDict
 import json
 import os
 import sys
@@ -50,7 +51,7 @@ const volatile char kFuseWire[] = { /* sentinel */ {sentinel}, /* fuse_version *
 """
 
 with open(os.path.join(dir_path, "fuses.json5"), 'r') as f:
-  fuse_defaults = json.loads(''.join(line for line in f.readlines() if not line.strip()[0] == "/"))
+  fuse_defaults = json.loads(''.join(line for line in f.readlines() if not line.strip()[0] == "/"), object_pairs_hook=OrderedDict)
 
 fuse_version = fuse_defaults['_version']
 del fuse_defaults['_version']


### PR DESCRIPTION
python2 and python3 have subtley different behavior when getting `keys()` from a JSON parsed dictionary.  Forcing the dictionary to be an `OrderedDict` ensures the behavior is consistent (and what we have documented).

Notes: Electron Fuses are now in a consistent order across platforms