### PR TITLE
fix: check DCHECK_IS_ON() instead of #ifdef DCHECK_IS_ON

### DIFF
--- a/shell/browser/api/electron_api_menu.cc
+++ b/shell/browser/api/electron_api_menu.cc
@@ -236,7 +236,7 @@ std::u16string Menu::GetToolTipAt(int index) const {
   return model_->GetToolTipAt(index);
 }
 
-#ifdef DCHECK_IS_ON
+#if DCHECK_IS_ON()
 std::u16string Menu::GetAcceleratorTextAtForTesting(int index) const {
   ui::Accelerator accelerator;
   model_->GetAcceleratorAtWithParams(index, true, &accelerator);
@@ -297,7 +297,7 @@ v8::Local<v8::ObjectTemplate> Menu::FillObjectTemplate(
       .SetMethod("isVisibleAt", &Menu::IsVisibleAt)
       .SetMethod("popupAt", &Menu::PopupAt)
       .SetMethod("closePopupAt", &Menu::ClosePopupAt)
-#ifdef DCHECK_IS_ON
+#if DCHECK_IS_ON()
       .SetMethod("getAcceleratorTextAt", &Menu::GetAcceleratorTextAtForTesting)
 #endif
       .Build();

--- a/shell/browser/api/electron_api_menu.h
+++ b/shell/browser/api/electron_api_menu.h
@@ -78,7 +78,7 @@ class Menu : public gin::Wrappable<Menu>,
                        int positioning_item,
                        base::OnceClosure callback) = 0;
   virtual void ClosePopupAt(int32_t window_id) = 0;
-#ifdef DCHECK_IS_ON
+#if DCHECK_IS_ON()
   virtual std::u16string GetAcceleratorTextAtForTesting(int index) const;
 #endif
 

--- a/shell/browser/api/electron_api_menu_mac.h
+++ b/shell/browser/api/electron_api_menu_mac.h
@@ -34,7 +34,7 @@ class MenuMac : public Menu {
                  int positioning_item,
                  base::OnceClosure callback);
   void ClosePopupAt(int32_t window_id) override;
-#ifdef DCHECK_IS_ON
+#if DCHECK_IS_ON()
   std::u16string GetAcceleratorTextAtForTesting(int index) const override;
 #endif
 

--- a/shell/browser/api/electron_api_menu_mac.mm
+++ b/shell/browser/api/electron_api_menu_mac.mm
@@ -127,7 +127,7 @@ void MenuMac::ClosePopupAt(int32_t window_id) {
                                                    std::move(close_popup));
 }
 
-#ifdef DCHECK_IS_ON
+#if DCHECK_IS_ON()
 std::u16string MenuMac::GetAcceleratorTextAtForTesting(int index) const {
   // A least effort to get the real shortcut text of NSMenuItem, the code does
   // not need to be perfect since it is test only.

--- a/shell/common/api/electron_api_v8_util.cc
+++ b/shell/common/api/electron_api_v8_util.cc
@@ -106,7 +106,7 @@ bool IsSameOrigin(const GURL& l, const GURL& r) {
   return url::Origin::Create(l).IsSameOriginWith(url::Origin::Create(r));
 }
 
-#ifdef DCHECK_IS_ON
+#if DCHECK_IS_ON()
 std::vector<v8::Global<v8::Value>> weakly_tracked_values;
 
 void WeaklyTrackValue(v8::Isolate* isolate, v8::Local<v8::Value> value) {
@@ -156,7 +156,7 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("requestGarbageCollectionForTesting",
                  &RequestGarbageCollectionForTesting);
   dict.SetMethod("isSameOrigin", &IsSameOrigin);
-#ifdef DCHECK_IS_ON
+#if DCHECK_IS_ON()
   dict.SetMethod("triggerFatalErrorForTesting", &TriggerFatalErrorForTesting);
   dict.SetMethod("getWeaklyTrackedValues", &GetWeaklyTrackedValues);
   dict.SetMethod("clearWeaklyTrackedValues", &ClearWeaklyTrackedValues);

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -723,7 +723,7 @@ void Initialize(v8::Local<v8::Object> exports,
                  &electron::api::OverrideGlobalPropertyFromIsolatedWorld);
   dict.SetMethod("_isCalledFromMainWorld",
                  &electron::api::IsCalledFromMainWorld);
-#ifdef DCHECK_IS_ON
+#if DCHECK_IS_ON()
   dict.Set("_isDebug", true);
 #endif
 }


### PR DESCRIPTION
#### Description of Change
`DCHECK_IS_ON` is always defined, so this was always evaluating to true.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none
