### PR TITLE
fix: ensure cursor styles are correct in top 22px of the frameless window on macOS

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -315,7 +315,8 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   if (title_bar_style_ != TitleBarStyle::kNormal)
     set_has_frame(false);
 
-  NSUInteger styleMask = NSWindowStyleMaskTitled;
+  NSUInteger styleMask =
+      has_frame() ? NSWindowStyleMaskTitled : NSBorderlessWindowMask;
 
   // The NSWindowStyleMaskFullSizeContentView style removes rounded corners
   // for framless window.


### PR DESCRIPTION
I swear I try the same thing every 6 months or so expecting it to magically work.  This time, it did??? I think this works now as a result of @zcbenz 's refactor of how hidden and hiddenInset styles work.

Gonna give this a wider sweep of manual testing tomorrow 🤷 

Notes: Fixed cursor style issues in top 22 pixels of frameless windows on macOS