### PR TITLE
chore: use HTTP method constants

### DIFF
--- a/shell/browser/net/electron_url_loader_factory.cc
+++ b/shell/browser/net/electron_url_loader_factory.cc
@@ -16,6 +16,7 @@
 #include "mojo/public/cpp/system/data_pipe_producer.h"
 #include "mojo/public/cpp/system/string_data_source.h"
 #include "net/base/filename_util.h"
+#include "net/http/http_request_headers.h"
 #include "net/http/http_status_code.h"
 #include "net/url_request/redirect_util.h"
 #include "services/network/public/cpp/url_loader_completion_status.h"
@@ -455,7 +456,8 @@ void ElectronURLLoaderFactory::StartLoadingHttp(
     request->method = original_request.method;
 
   base::DictionaryValue upload_data;
-  if (request->method != "GET" && request->method != "HEAD")
+  if (request->method != net::HttpRequestHeaders::kGetMethod &&
+      request->method != net::HttpRequestHeaders::kHeadMethod)
     dict.Get("uploadData", &upload_data);
 
   ElectronBrowserContext* browser_context =

--- a/shell/renderer/electron_renderer_client.cc
+++ b/shell/renderer/electron_renderer_client.cc
@@ -9,6 +9,7 @@
 #include "base/command_line.h"
 #include "content/public/renderer/render_frame.h"
 #include "electron/buildflags/buildflags.h"
+#include "net/http/http_request_headers.h"
 #include "shell/common/api/electron_bindings.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/event_emitter_caller.h"
@@ -169,7 +170,7 @@ bool ElectronRendererClient::ShouldFork(blink::WebLocalFrame* frame,
   // FIXME We only support GET here because http method will be ignored when
   // the OpenURLFromTab is triggered, which means form posting would not work,
   // we should solve this by patching Chromium in future.
-  return http_method == "GET";
+  return http_method == net::HttpRequestHeaders::kGetMethod;
 }
 
 void ElectronRendererClient::WorkerScriptReadyForEvaluationOnWorkerThread(


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Code hygiene change, make use of the HTTP method constants from `net/http/http_request_headers.h`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
