### PR TITLE
test: re-enable some skipped tests

### DIFF
--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -406,8 +406,7 @@ describe('BrowserWindow module', () => {
       await expect(p).to.eventually.be.fulfilled;
     });
 
-    // FIXME(robo/nornagon): re-enable these once service workers work
-    describe.skip('POST navigations', () => {
+    describe('POST navigations', () => {
       afterEach(() => { w.webContents.session.webRequest.onBeforeSendHeaders(null); });
 
       it('supports specifying POST data', async () => {

--- a/spec-main/api-protocol-spec.ts
+++ b/spec-main/api-protocol-spec.ts
@@ -835,7 +835,7 @@ describe('protocol module', () => {
     });
   });
 
-  describe.skip('protocol.registerSchemesAsPrivileged cors-fetch', function () {
+  describe('protocol.registerSchemesAsPrivileged cors-fetch', function () {
     const standardScheme = (global as any).standardScheme;
     let w: BrowserWindow = null as unknown as BrowserWindow;
     beforeEach(async () => {
@@ -868,7 +868,8 @@ describe('protocol module', () => {
       });
     });
 
-    it('disallows CORS and fetch requests when only supportFetchAPI is specified', async () => {
+    // FIXME: Figure out why this test is failing
+    it.skip('disallows CORS and fetch requests when only supportFetchAPI is specified', async () => {
       await allowsCORSRequests('no-cors', ['failed xhr', 'failed fetch'], /has been blocked by CORS policy/, () => {
         const { ipcRenderer } = require('electron');
         Promise.all([
@@ -916,7 +917,7 @@ describe('protocol module', () => {
         callback('');
       });
 
-      const newContents: WebContents = (webContents as any).create({ nodeIntegration: true });
+      const newContents: WebContents = (webContents as any).create({ nodeIntegration: true, contextIsolation: false });
       const consoleMessages: string[] = [];
       newContents.on('console-message', (e, level, message) => consoleMessages.push(message));
       try {

--- a/spec-main/api-protocol-spec.ts
+++ b/spec-main/api-protocol-spec.ts
@@ -754,7 +754,7 @@ describe('protocol module', () => {
     });
   });
 
-  describe.skip('protocol.registerSchemesAsPrivileged standard', () => {
+  describe('protocol.registerSchemesAsPrivileged standard', () => {
     const standardScheme = (global as any).standardScheme;
     const origin = `${standardScheme}://fake-host`;
     const imageURL = `${origin}/test.png`;
@@ -766,7 +766,8 @@ describe('protocol module', () => {
       w = new BrowserWindow({
         show: false,
         webPreferences: {
-          nodeIntegration: true
+          nodeIntegration: true,
+          contextIsolation: false
         }
       });
     });

--- a/spec/fixtures/pages/cache-storage.html
+++ b/spec/fixtures/pages/cache-storage.html
@@ -1,5 +1,5 @@
 <script>
-  const ipcRenderer = require('electron').ipcRenderer;
+  const { ipcRenderer } = require('electron');
   caches.open('foo').then(
     () => ipcRenderer.send('success'),
     err => ipcRenderer.send('failure', err)


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

These tests were marked as skip, but pass on `main` on macOS. I think they may have just never been re-enabled. One test in a `describe` still failed so I marked it as `it.skip`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
