### PR TITLE
fix: potential crash when setting vibrancy

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1360,8 +1360,6 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
     return;
   }
 
-  vibrancy_type_ = type;
-
   NSVisualEffectView* effect_view = (NSVisualEffectView*)vibrant_view;
   if (effect_view == nil) {
     effect_view = [[[NSVisualEffectView alloc]
@@ -1390,7 +1388,7 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
   node::Environment* env =
       node::Environment::GetCurrent(JavascriptEnvironment::GetIsolate());
 
-  NSVisualEffectMaterial vibrancyType;
+  NSVisualEffectMaterial vibrancyType{};
   if (type == "appearance-based") {
     EmitWarning(env, "NSVisualEffectMaterialAppearanceBased" + dep_warn,
                 "electron");
@@ -1447,8 +1445,10 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
     }
   }
 
-  if (vibrancyType)
+  if (vibrancyType) {
+    vibrancy_type_ = type;
     [effect_view setMaterial:vibrancyType];
+  }
 }
 
 void NativeWindowMac::SetWindowButtonVisibility(bool visible) {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1610,6 +1610,13 @@ describe('BrowserWindow module', () => {
         w.setVibrancy('' as any);
       }).to.not.throw();
     });
+
+    it('does not crash if vibrancy is set to an invalid value', () => {
+      const w = new BrowserWindow({ show: false });
+      expect(() => {
+        w.setVibrancy('i-am-not-a-valid-vibrancy-type' as any);
+      }).to.not.throw();
+    });
   });
 
   ifdescribe(process.platform === 'darwin')('trafficLightPosition', () => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/29653.

Fixes a potential crash when a value is passed in for the vibrancy type which is not valid either owing to operating system version or the string itself. This will now simply no-op.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes a potential crash when setting vibrancy on macOS.
