### PR TITLE
fix: warnAboutRemoteModuleWithRemoteContent

### DIFF
--- a/lib/renderer/security-warnings.ts
+++ b/lib/renderer/security-warnings.ts
@@ -270,9 +270,7 @@ const warnAboutAllowedPopups = function () {
 // Logs a warning message about the remote module
 
 const warnAboutRemoteModuleWithRemoteContent = function (webPreferences?: Electron.WebPreferences) {
-  if (!webPreferences || isLocalhost()) return;
-  const remoteModuleEnabled = webPreferences.enableRemoteModule != null ? !!webPreferences.enableRemoteModule : true;
-  if (!remoteModuleEnabled) return;
+  if (!webPreferences || !webPreferences.enableRemoteModule || isLocalhost()) return;
 
   if (getIsRemoteProtocol()) {
     const warning = `This renderer process has "enableRemoteModule" enabled
@@ -298,7 +296,9 @@ const logSecurityWarnings = function (
   warnAboutEnableBlinkFeatures(webPreferences);
   warnAboutInsecureCSP();
   warnAboutAllowedPopups();
-  warnAboutRemoteModuleWithRemoteContent(webPreferences);
+  if (BUILDFLAG(ENABLE_REMOTE_MODULE)) {
+    warnAboutRemoteModuleWithRemoteContent(webPreferences);
+  }
 };
 
 const getWebPreferences = async function () {

--- a/spec-main/security-warnings-spec.ts
+++ b/spec-main/security-warnings-spec.ts
@@ -9,6 +9,9 @@ import { BrowserWindow, WebPreferences } from 'electron/main';
 import { closeWindow } from './window-helpers';
 import { AddressInfo } from 'net';
 import { emittedUntil } from './events-helpers';
+import { ifit } from './spec-helpers';
+
+const features = process._linkedBinding('electron_common_features');
 
 const messageContainsSecurityWarning = (event: Event, level: number, message: string) => {
   return message.indexOf('Electron Security Warning') > -1;
@@ -226,10 +229,13 @@ describe('security warnings', () => {
         expect(message).to.not.include('insecure-resources.html');
       });
 
-      it('should warn about enabled remote module with remote content', async () => {
+      ifit(features.isRemoteModuleEnabled())('should warn about enabled remote module with remote content', async () => {
         w = new BrowserWindow({
           show: false,
-          webPreferences
+          webPreferences: {
+            enableRemoteModule: true,
+            ...webPreferences
+          }
         });
 
         w.loadURL(`${serverUrl}/base-page-security.html`);
@@ -237,10 +243,13 @@ describe('security warnings', () => {
         expect(message).to.include('enableRemoteModule');
       });
 
-      it('should not warn about enabled remote module with remote content from localhost', async () => {
+      ifit(features.isRemoteModuleEnabled())('should not warn about enabled remote module with remote content from localhost', async () => {
         w = new BrowserWindow({
           show: false,
-          webPreferences
+          webPreferences: {
+            enableRemoteModule: true,
+            ...webPreferences
+          }
         });
         w.loadURL(`${serverUrl}/base-page-security-onload-message.html`);
         const [,, message] = await emittedUntil(w.webContents, 'console-message', isLoaded);


### PR DESCRIPTION
#### Description of Change
The `remote` module is disabled by default since Electron 10.
Also skip the warning logic when `enable_remote_module` is disabled in build options.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed `warnAboutRemoteModuleWithRemoteContent` for the new default value of `enableRemoteModule`.