### PR TITLE
fix: remove extension warning that do not have any impact

### DIFF
--- a/shell/browser/extensions/electron_extension_loader.cc
+++ b/shell/browser/extensions/electron_extension_loader.cc
@@ -66,20 +66,25 @@ std::pair<scoped_refptr<const Extension>, std::string> LoadUnpacked(
   std::string warnings;
   // Log warnings.
   if (!extension->install_warnings().empty()) {
+    std::string warning_prefix =
+        "Warnings loading extension at " +
+        base::UTF16ToUTF8(extension_dir.LossyDisplayName());
+
     for (const auto& warning : extension->install_warnings()) {
-      // filter kUnrecognizedManifestKey error. This error does not have any
-      // impact e.g: Unrecognized manifest key 'minimum_chrome_version' etc.
-      std::string check_error = ErrorUtils::FormatErrorMessage(
+      std::string unrecognized_manifest_error = ErrorUtils::FormatErrorMessage(
           manifest_errors::kUnrecognizedManifestKey, warning.key);
-      if (warning.message != check_error) {
+
+      if (warning.message == unrecognized_manifest_error) {
+        // filter kUnrecognizedManifestKey error. This error does not have any
+        // impact e.g: Unrecognized manifest key 'minimum_chrome_version' etc.
+        LOG(WARNING) << warning_prefix << ": " << warning.message;
+      } else {
         warnings += "  " + warning.message + "\n";
       }
     }
 
     if (warnings != "") {
-      warnings = "Warnings loading extension at " +
-                 base::UTF16ToUTF8(extension_dir.LossyDisplayName()) + ":\n" +
-                 warnings;
+      warnings = warning_prefix + ":\n" + warnings;
     }
   }
 


### PR DESCRIPTION
#### Description of Change

Remove meaningless warnings when loadExtension extension

Fixes:
https://github.com/electron/electron/issues/23662
https://github.com/MarshallOfSound/electron-devtools-installer/pull/177
https://github.com/MarshallOfSound/electron-devtools-installer/issues/182

----

`"Unrecognized manifest key '*'."` and `Cannot load extension with file or directory name _metadata.` warnings is there is no point. And they are very annoying...

This change should not be fixed on `chromium`, but downstream of it: `electron`. see: https://bugs.chromium.org/p/chromium/issues/detail?id=377278

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none