### PR TITLE
fix: draggable regions with devtools open

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -396,6 +396,10 @@ void BrowserWindow::ResetBrowserViews() {
 #endif
 }
 
+void BrowserWindow::OnDevToolsResized() {
+  UpdateDraggableRegions(draggable_regions_);
+}
+
 void BrowserWindow::SetVibrancy(v8::Isolate* isolate,
                                 v8::Local<v8::Value> value) {
   std::string type = gin::V8ToString(isolate, value);

--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -63,9 +63,7 @@ class BrowserWindow : public BaseWindow,
   void OnActivateContents() override;
   void OnPageTitleUpdated(const std::u16string& title,
                           bool explicit_set) override;
-#if defined(OS_MAC)
   void OnDevToolsResized() override;
-#endif
 
   // NativeWindowObserver:
   void RequestPreferredWidth(int* width) override;
@@ -118,9 +116,7 @@ class BrowserWindow : public BaseWindow,
   // it should be cancelled when we can prove that the window is responsive.
   base::CancelableRepeatingClosure window_unresponsive_closure_;
 
-#if defined(OS_MAC)
   std::vector<mojom::DraggableRegionPtr> draggable_regions_;
-#endif
 
   v8::Global<v8::Value> web_contents_;
   base::WeakPtr<api::WebContents> api_web_contents_;

--- a/shell/browser/api/electron_api_browser_window_mac.mm
+++ b/shell/browser/api/electron_api_browser_window_mac.mm
@@ -37,10 +37,6 @@ void BrowserWindow::OverrideNSWindowContentView(
   [contentView viewDidMoveToWindow];
 }
 
-void BrowserWindow::OnDevToolsResized() {
-  UpdateDraggableRegions(draggable_regions_);
-}
-
 void BrowserWindow::UpdateDraggableRegions(
     const std::vector<mojom::DraggableRegionPtr>& regions) {
   if (window_->has_frame())

--- a/shell/browser/api/electron_api_browser_window_views.cc
+++ b/shell/browser/api/electron_api_browser_window_views.cc
@@ -5,6 +5,7 @@
 #include "shell/browser/api/electron_api_browser_window.h"
 
 #include "shell/browser/native_window_views.h"
+#include "ui/aura/window.h"
 
 namespace electron {
 
@@ -14,8 +15,20 @@ void BrowserWindow::UpdateDraggableRegions(
     const std::vector<mojom::DraggableRegionPtr>& regions) {
   if (window_->has_frame())
     return;
+
+  if (&draggable_regions_ != &regions) {
+    auto const offset =
+        web_contents()->GetNativeView()->GetBoundsInRootWindow();
+    auto snapped_regions = mojo::Clone(regions);
+    for (auto& snapped_region : snapped_regions) {
+      snapped_region->bounds.Offset(offset.x(), offset.y());
+    }
+
+    draggable_regions_ = mojo::Clone(snapped_regions);
+  }
+
   static_cast<NativeWindowViews*>(window_.get())
-      ->UpdateDraggableRegions(regions);
+      ->UpdateDraggableRegions(draggable_regions_);
 }
 
 }  // namespace api

--- a/shell/browser/ui/views/inspectable_web_contents_view_views.cc
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.cc
@@ -127,6 +127,10 @@ void InspectableWebContentsViewViews::ShowDevTools(bool activate) {
     } else {
       devtools_window_->ShowInactive();
     }
+
+    // Update draggable regions to account for the new dock position.
+    if (GetDelegate())
+      GetDelegate()->DevToolsResized();
   } else {
     devtools_web_view_->SetVisible(true);
     devtools_web_view_->SetWebContents(
@@ -227,6 +231,9 @@ void InspectableWebContentsViewViews::Layout() {
 
   devtools_web_view_->SetBoundsRect(new_devtools_bounds);
   contents_web_view_->SetBoundsRect(new_contents_bounds);
+
+  if (GetDelegate())
+    GetDelegate()->DevToolsResized();
 }
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/29159.

We addressed a similar problem in https://github.com/electron/electron/pull/26361 but draggable regions are implemented differently enough across platforms that one solution rarely addresses all of them. Windows and Linux work such that we check the current cursor position and then check to see if that falls inside draggable region bounds. On `BrowserView`s, we considered that the `BrowserView` bounds may not begin at (0,0) and accounted for that by offsetting the bounds when performing that calculation, but failed to take into account that this may also be the case for draggable regions inside the primary `BrowserWindow`'s `WebContents.` When a DevTools instance is open, for example, this would mean the draggable region would be offset - this PR fixes the oversight by always ensuring that the cursor location logic is performed according to the relative bounds of the `WebContents` containing the draggable region.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where draggable regions sometimes did not work properly when DevTools is open.