### PR TITLE
fix: don't warn about enableRemoteModule when it's disabled at build time

### DIFF
--- a/lib/renderer/security-warnings.ts
+++ b/lib/renderer/security-warnings.ts
@@ -298,7 +298,9 @@ const logSecurityWarnings = function (
   warnAboutEnableBlinkFeatures(webPreferences);
   warnAboutInsecureCSP();
   warnAboutAllowedPopups();
-  warnAboutRemoteModuleWithRemoteContent(webPreferences);
+  if (BUILDFLAG(ENABLE_REMOTE_MODULE)) {
+    warnAboutRemoteModuleWithRemoteContent(webPreferences);
+  }
 };
 
 const getWebPreferences = async function () {

--- a/spec-main/security-warnings-spec.ts
+++ b/spec-main/security-warnings-spec.ts
@@ -9,6 +9,9 @@ import { BrowserWindow, WebPreferences } from 'electron/main';
 import { closeWindow } from './window-helpers';
 import { AddressInfo } from 'net';
 import { emittedUntil } from './events-helpers';
+import { ifit } from './spec-helpers';
+
+const features = process._linkedBinding('electron_common_features');
 
 const messageContainsSecurityWarning = (event: Event, level: number, message: string) => {
   return message.indexOf('Electron Security Warning') > -1;
@@ -226,7 +229,7 @@ describe('security warnings', () => {
         expect(message).to.not.include('insecure-resources.html');
       });
 
-      it('should warn about enabled remote module with remote content', async () => {
+      ifit(features.isRemoteModuleEnabled())('should warn about enabled remote module with remote content', async () => {
         w = new BrowserWindow({
           show: false,
           webPreferences
@@ -237,7 +240,7 @@ describe('security warnings', () => {
         expect(message).to.include('enableRemoteModule');
       });
 
-      it('should not warn about enabled remote module with remote content from localhost', async () => {
+      ifit(features.isRemoteModuleEnabled())('should not warn about enabled remote module with remote content from localhost', async () => {
         w = new BrowserWindow({
           show: false,
           webPreferences


### PR DESCRIPTION
#### Description of Change
Port #29691 without #29023

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)

#### Release Notes
Notes: no-notes