### PR TITLE
fix: ensure detached devtools are not always draggable

### DIFF
--- a/shell/browser/ui/cocoa/electron_inspectable_web_contents_view.mm
+++ b/shell/browser/ui/cocoa/electron_inspectable_web_contents_view.mm
@@ -169,13 +169,12 @@
 
   // Switch to new state.
   devtools_docked_ = docked;
+  auto* inspectable_web_contents =
+      inspectableWebContentsView_->inspectable_web_contents();
+  auto* devToolsWebContents =
+      inspectable_web_contents->GetDevToolsWebContents();
+  auto devToolsView = devToolsWebContents->GetNativeView().GetNativeNSView();
   if (!docked) {
-    auto* inspectable_web_contents =
-        inspectableWebContentsView_->inspectable_web_contents();
-    auto* devToolsWebContents =
-        inspectable_web_contents->GetDevToolsWebContents();
-    auto devToolsView = devToolsWebContents->GetNativeView().GetNativeNSView();
-
     auto styleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
                      NSMiniaturizableWindowMask | NSWindowStyleMaskResizable |
                      NSTexturedBackgroundWindowMask |
@@ -198,6 +197,9 @@
     devToolsView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
 
     [contentView addSubview:devToolsView];
+    [devToolsView setMouseDownCanMoveWindow:NO];
+  } else {
+    [devToolsView setMouseDownCanMoveWindow:YES];
   }
   [self setDevToolsVisible:YES activate:activate];
 }


### PR DESCRIPTION
We have logic [here](https://github.com/electron/electron/blob/main/shell/browser/ui/cocoa/electron_inspectable_web_contents_view.mm#L121) that ensures that the devtools window is draggable when docked so draggable regions work correctly.  However a docked devtools window can be toggled into detached mode and after that the entire devtools window becomes draggable.

This fixes that by ensuring the "draggable" status is tied to `is_docked`

Notes: no-notes