### PR TITLE
chore: set python interpreter to python3 in script/spec-runner.js

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ executors:
         type: enum
         enum: ["medium", "xlarge", "2xlarge+"]
     docker:
-      - image: electron.azurecr.io/build:6555a80939fb4c3ddf9343b3f140e573f40de225
+      - image: electron.azurecr.io/build:4fc81b50f9c0980699d329bc32062fac20a26701
     resource_class: << parameters.size >>
 
   macos:

--- a/script/spec-runner.js
+++ b/script/spec-runner.js
@@ -128,7 +128,7 @@ async function runRemoteBasedElectronTests () {
   const runnerArgs = ['electron/spec', ...unknownArgs.slice(2)];
   if (process.platform === 'linux') {
     runnerArgs.unshift(path.resolve(__dirname, 'dbus_mock.py'), exe);
-    exe = 'python';
+    exe = 'python3';
   }
 
   const { status } = childProcess.spawnSync(exe, runnerArgs, {
@@ -199,7 +199,7 @@ async function runMainProcessElectronTests () {
   const runnerArgs = ['electron/spec-main', ...unknownArgs.slice(2)];
   if (process.platform === 'linux') {
     runnerArgs.unshift(path.resolve(__dirname, 'dbus_mock.py'), exe);
-    exe = 'python';
+    exe = 'python3';
   }
 
   const { status, signal } = childProcess.spawnSync(exe, runnerArgs, {

--- a/vsts-arm32v7.yml
+++ b/vsts-arm32v7.yml
@@ -1,7 +1,7 @@
 resources:
   containers:
   - container: arm32v7-test-container
-    image: electron.azurecr.io/build:arm32v7-6555a80939fb4c3ddf9343b3f140e573f40de225
+    image: electron.azurecr.io/build:arm32v7-4fc81b50f9c0980699d329bc32062fac20a26701
     options: --shm-size 128m
 
 jobs:

--- a/vsts-arm64v8.yml
+++ b/vsts-arm64v8.yml
@@ -1,7 +1,7 @@
 resources:
   containers:
   - container: arm64v8-test-container
-    image: electron.azurecr.io/build:arm64v8-6555a80939fb4c3ddf9343b3f140e573f40de225
+    image: electron.azurecr.io/arm64v8-4fc81b50f9c0980699d329bc32062fac20a26701
     options: --shm-size 128m
 
 jobs:


### PR DESCRIPTION
The new installs of python module, python-dbusmock, is broken for python2. The tests still run fine on linux machine in Electron's pipeline setup on CircleCI, because the docker image used has the non-broken version of python-dbusmock for python2 installed. But running electron tests on any other linux machine would fail if they don't have this non-broken version of python-dbusmock for python2 installed, already, which is the case for most of the machines.
Moreover, Python2 is deprecated now. So it would be better if we change the python interpreter in script/spec-runner.js file to python3, for which all the python modules are updated and working.

Notes: none