### PR TITLE
fix: select element not working on Windows

### DIFF
--- a/patches/chromium/extend_apply_webpreferences.patch
+++ b/patches/chromium/extend_apply_webpreferences.patch
@@ -12,7 +12,7 @@ Ideally we could add an embedder observer pattern here but that can be
 done in future work.
 
 diff --git a/third_party/blink/renderer/core/exported/web_view_impl.cc b/third_party/blink/renderer/core/exported/web_view_impl.cc
-index b627f400d16ee1c605ef7657dc3ba63319c5fd56..455b0fd461d0c32de39800d4d7cef2ceb30dc7fb 100644
+index b627f400d16ee1c605ef7657dc3ba63319c5fd56..72f7e877a9601f7b2277d109aaae13eda4277076 100644
 --- a/third_party/blink/renderer/core/exported/web_view_impl.cc
 +++ b/third_party/blink/renderer/core/exported/web_view_impl.cc
 @@ -155,6 +155,7 @@
@@ -23,7 +23,15 @@ index b627f400d16ee1c605ef7657dc3ba63319c5fd56..455b0fd461d0c32de39800d4d7cef2ce
  #include "third_party/blink/renderer/platform/graphics/image.h"
  #include "third_party/blink/renderer/platform/graphics/paint/cull_rect.h"
  #include "third_party/blink/renderer/platform/graphics/paint/paint_record_builder.h"
-@@ -1792,6 +1793,16 @@ void WebView::ApplyWebPreferences(const web_pref::WebPreferences& prefs,
+@@ -1784,6 +1785,7 @@ void WebView::ApplyWebPreferences(const web_pref::WebPreferences& prefs,
+ #if defined(OS_MAC)
+   web_view_impl->SetMaximumLegibleScale(
+       prefs.default_maximum_page_scale_factor);
++  SetUseExternalPopupMenus(!prefs.offscreen);
+ #endif
+ 
+ #if defined(OS_WIN)
+@@ -1792,6 +1794,14 @@ void WebView::ApplyWebPreferences(const web_pref::WebPreferences& prefs,
  
    RuntimeEnabledFeatures::SetTranslateServiceEnabled(
        prefs.translate_service_available);
@@ -35,8 +43,6 @@ index b627f400d16ee1c605ef7657dc3ba63319c5fd56..455b0fd461d0c32de39800d4d7cef2ce
 +      color = static_cast<SkColor>(blink_color);
 +  }
 +  web_view->SetBaseBackgroundColor(color);
-+
-+  SetUseExternalPopupMenus(!prefs.offscreen);
  }
  
  void WebViewImpl::ThemeChanged() {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/29665.

Refs https://github.com/electron/electron/pull/28938 - previously the call to `blink::WebView::SetUseExternalPopupMenu` was guarded by `USE_EXTERNAL_POPUP_MENU` - the refactor removed this for the moved call to the selfsame function but that flag is [only defined](https://source.chromium.org/chromium/chromium/src/+/main:content/common/features.gni?q=USE_EXTERNAL_POPUP_MENU&ss=chromium&start=11) on macOS and Android. This caused the element dropdown to stop working on Windows. We don't have access to `USE_EXTERNAL_POPUP_MENU` within Blink so just fix this by moving inside a macOS-only guard.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed the `<select>` element dropdown not appearing on Windows or Linux.
