### PR TITLE
chore: remove unused and broken ipcRendererInternal.sendTo()

### DIFF
--- a/lib/renderer/api/ipc-renderer.ts
+++ b/lib/renderer/api/ipc-renderer.ts
@@ -18,7 +18,7 @@ ipcRenderer.sendToHost = function (channel, ...args) {
 };
 
 ipcRenderer.sendTo = function (webContentsId, channel, ...args) {
-  return ipc.sendTo(internal, webContentsId, channel, args);
+  return ipc.sendTo(webContentsId, channel, args);
 };
 
 ipcRenderer.invoke = async function (channel, ...args) {

--- a/lib/renderer/ipc-renderer-internal.ts
+++ b/lib/renderer/ipc-renderer-internal.ts
@@ -4,17 +4,14 @@ const { ipc } = process._linkedBinding('electron_renderer_ipc');
 
 const internal = true;
 
-const ipcRendererInternal = new EventEmitter() as any as ElectronInternal.IpcRendererInternal;
+export const ipcRendererInternal = new EventEmitter() as any as ElectronInternal.IpcRendererInternal;
+
 ipcRendererInternal.send = function (channel, ...args) {
   return ipc.send(internal, channel, args);
 };
 
 ipcRendererInternal.sendSync = function (channel, ...args) {
   return ipc.sendSync(internal, channel, args);
-};
-
-ipcRendererInternal.sendTo = function (webContentsId, channel, ...args) {
-  return ipc.sendTo(internal, webContentsId, channel, args);
 };
 
 ipcRendererInternal.invoke = async function<T> (channel: string, ...args: any[]) {
@@ -24,5 +21,3 @@ ipcRendererInternal.invoke = async function<T> (channel: string, ...args: any[])
   }
   return result;
 };
-
-export { ipcRendererInternal };

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1601,8 +1601,7 @@ void WebContents::MessageSync(
                  internal, channel, std::move(arguments));
 }
 
-void WebContents::MessageTo(bool internal,
-                            int32_t web_contents_id,
+void WebContents::MessageTo(int32_t web_contents_id,
                             const std::string& channel,
                             blink::CloneableMessage arguments) {
   TRACE_EVENT1("electron", "WebContents::MessageTo", "channel", channel);
@@ -1617,7 +1616,7 @@ void WebContents::MessageTo(bool internal,
         WebFrameMain::From(JavascriptEnvironment::GetIsolate(), frame);
 
     int32_t sender_id = ID();
-    web_frame_main->GetRendererApi()->Message(internal, channel,
+    web_frame_main->GetRendererApi()->Message(false /* internal */, channel,
                                               std::move(arguments), sender_id);
   }
 }

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -409,8 +409,7 @@ class WebContents : public gin::Wrappable<WebContents>,
       blink::CloneableMessage arguments,
       electron::mojom::ElectronBrowser::MessageSyncCallback callback,
       content::RenderFrameHost* render_frame_host);
-  void MessageTo(bool internal,
-                 int32_t web_contents_id,
+  void MessageTo(int32_t web_contents_id,
                  const std::string& channel,
                  blink::CloneableMessage arguments);
   void MessageHost(const std::string& channel,

--- a/shell/browser/electron_browser_handler_impl.cc
+++ b/shell/browser/electron_browser_handler_impl.cc
@@ -86,14 +86,12 @@ void ElectronBrowserHandlerImpl::MessageSync(bool internal,
   }
 }
 
-void ElectronBrowserHandlerImpl::MessageTo(bool internal,
-                                           int32_t web_contents_id,
+void ElectronBrowserHandlerImpl::MessageTo(int32_t web_contents_id,
                                            const std::string& channel,
                                            blink::CloneableMessage arguments) {
   api::WebContents* api_web_contents = api::WebContents::From(web_contents());
   if (api_web_contents) {
-    api_web_contents->MessageTo(internal, web_contents_id, channel,
-                                std::move(arguments));
+    api_web_contents->MessageTo(web_contents_id, channel, std::move(arguments));
   }
 }
 

--- a/shell/browser/electron_browser_handler_impl.h
+++ b/shell/browser/electron_browser_handler_impl.h
@@ -44,8 +44,7 @@ class ElectronBrowserHandlerImpl : public mojom::ElectronBrowser,
                    const std::string& channel,
                    blink::CloneableMessage arguments,
                    MessageSyncCallback callback) override;
-  void MessageTo(bool internal,
-                 int32_t web_contents_id,
+  void MessageTo(int32_t web_contents_id,
                  const std::string& channel,
                  blink::CloneableMessage arguments) override;
   void MessageHost(const std::string& channel,

--- a/shell/common/api/api.mojom
+++ b/shell/common/api/api.mojom
@@ -63,7 +63,6 @@ interface ElectronBrowser {
   // Emits an event from the |ipcRenderer| JavaScript object in the target
   // WebContents's main frame, specified by |web_contents_id|.
   MessageTo(
-    bool internal,
     int32 web_contents_id,
     string channel,
     blink.mojom.CloneableMessage arguments);

--- a/shell/renderer/api/electron_api_ipc_renderer.cc
+++ b/shell/renderer/api/electron_api_ipc_renderer.cc
@@ -172,7 +172,6 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
 
   void SendTo(v8::Isolate* isolate,
               gin_helper::ErrorThrower thrower,
-              bool internal,
               int32_t web_contents_id,
               const std::string& channel,
               v8::Local<v8::Value> arguments) {
@@ -184,7 +183,7 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
     if (!electron::SerializeV8Value(isolate, arguments, &message)) {
       return;
     }
-    electron_browser_remote_->MessageTo(internal, web_contents_id, channel,
+    electron_browser_remote_->MessageTo(web_contents_id, channel,
                                         std::move(message));
   }
 

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -35,7 +35,7 @@ declare namespace NodeJS {
     send(internal: boolean, channel: string, args: any[]): void;
     sendSync(internal: boolean, channel: string, args: any[]): any;
     sendToHost(channel: string, args: any[]): void;
-    sendTo(internal: boolean, webContentsId: number, channel: string, args: any[]): void;
+    sendTo(webContentsId: number, channel: string, args: any[]): void;
     invoke<T>(internal: boolean, channel: string, args: any[]): Promise<{ error: string, result: T }>;
     postMessage(channel: string, message: any, transferables: MessagePort[]): void;
   }

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -229,11 +229,10 @@ declare namespace ElectronInternal {
     appIcon: Electron.NativeImage | null;
   }
 
-  interface IpcRendererInternal extends Electron.IpcRenderer {
+  interface IpcRendererInternal extends NodeJS.EventEmitter, Pick<Electron.IpcRenderer, 'send' | 'sendSync' | 'invoke'> {
     invoke<T>(channel: string, ...args: any[]): Promise<T>;
   }
 
-  // Internal IPC has _replyInternal and NO reply method
   interface IpcMainInternalEvent extends Omit<Electron.IpcMainEvent, 'reply'> {
   }
 


### PR DESCRIPTION
#### Description of Change
It no longer works after #27676

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: no-notes
