### PR TITLE
fix: flaky extension bg page test

### DIFF
--- a/spec-main/extensions-spec.ts
+++ b/spec-main/extensions-spec.ts
@@ -432,12 +432,11 @@ describe('chrome extensions', () => {
     it('has session in background page', async () => {
       const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
       const promise = emittedOnce(app, 'web-contents-created');
-      await customSession.loadExtension(path.join(fixtures, 'extensions', 'persistent-background-page'));
-      const w = new BrowserWindow({ show: false, webPreferences: { session: customSession } });
-      await w.loadURL('about:blank');
+      const { id } = await customSession.loadExtension(path.join(fixtures, 'extensions', 'persistent-background-page'));
       const [, bgPageContents] = await promise;
       expect(bgPageContents.getType()).to.equal('backgroundPage');
-      expect(bgPageContents.getURL()).to.match(/^chrome-extension:\/\/.+\/_generated_background_page.html$/);
+      await emittedOnce(bgPageContents, 'did-finish-load');
+      expect(bgPageContents.getURL()).to.equal(`chrome-extension://${id}/_generated_background_page.html`);
       expect(bgPageContents.session).to.not.equal(undefined);
     });
 
@@ -445,8 +444,6 @@ describe('chrome extensions', () => {
       const customSession = session.fromPartition(`persist:${require('uuid').v4()}`);
       const promise = emittedOnce(app, 'web-contents-created');
       await customSession.loadExtension(path.join(fixtures, 'extensions', 'persistent-background-page'));
-      const w = new BrowserWindow({ show: false, webPreferences: { session: customSession } });
-      await w.loadURL('about:blank');
       const [, bgPageContents] = await promise;
       expect(bgPageContents.getType()).to.equal('backgroundPage');
       bgPageContents.openDevTools();


### PR DESCRIPTION
#### Description of Change

An extension background page test was expecting a certain value for the URL before the URL was guaranteed to be committed and accessible.

```
not ok 1671 chrome extensions background pages has session in background page
  AssertionError: expected '' to match /^chrome-extension:\/\/.+\/_generated_background_page.html$/
      at Context.<anonymous> (electron\spec-main\extensions-spec.ts:440:42)
```
https://ci.appveyor.com/project/electron-bot/electron-x64-testing-pr/builds/39634739#L46419

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)

#### Release Notes

Notes: none