### PR TITLE
ci: use circleci instead of circleci-agent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1010,7 +1010,7 @@ step-maybe-early-exit-doc-only-change: &step-maybe-early-exit-doc-only-change
     name: Shortcircuit build if doc only change
     command: |
       if [ -s src/electron/.skip-ci-build ]; then
-        circleci-agent step halt
+        circleci step halt
       fi
 
 step-maybe-early-exit-no-doc-change: &step-maybe-early-exit-no-doc-change
@@ -1018,7 +1018,7 @@ step-maybe-early-exit-no-doc-change: &step-maybe-early-exit-no-doc-change
     name: Shortcircuit job if change is not doc only
     command: |
       if [ ! -s src/electron/.skip-ci-build ]; then
-        circleci-agent step halt
+        circleci step halt
       fi
 
 step-ts-compile: &step-ts-compile
@@ -1293,7 +1293,7 @@ commands:
                 name: Halt the job early if the src cache exists
                 command: |
                   if [ -f ".src-cache-marker" ]; then
-                    circleci-agent step halt
+                    circleci step halt
                   fi
       - *step-maybe-restore-src-cache
       - run:


### PR DESCRIPTION
#### Description of Change

This died in [another PR](https://app.circleci.com/pipelines/github/electron/electron/41258/workflows/53d41212-fa6f-4935-9589-180e26257380/jobs/915789):

<img width="660" alt="Screen Shot 2021-06-17 at 11 00 42 AM" src="https://user-images.githubusercontent.com/2036040/122366601-fab3e800-cf5b-11eb-9103-80c29ca34085.png">

and per CircleCI's [own CI config](https://github.com/CircleCI-Public/circleci-cli/commit/e6154bebc0eb0b5035df9a1bf3e03e9fc2eaa468) it looks like we should be using `circleci` as the cli command instead of `circleci-agent`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
