### PR TITLE
fix: color select eyedropper not working within DevTools

### DIFF
--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -145,6 +145,8 @@ static_library("chrome") {
 
   if (enable_color_chooser) {
     sources += [
+      "//chrome/browser/devtools/devtools_eye_dropper.cc",
+      "//chrome/browser/devtools/devtools_eye_dropper.h",
       "//chrome/browser/platform_util.cc",
       "//chrome/browser/platform_util.h",
       "//chrome/browser/ui/browser_dialogs.h",

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3469,6 +3469,30 @@ void WebContents::DevToolsSearchInPath(int request_id,
                           file_system_path));
 }
 
+void WebContents::DevToolsSetEyeDropperActive(bool active) {
+  auto* web_contents = GetWebContents();
+  if (!web_contents)
+    return;
+
+  if (active) {
+    eye_dropper_ = std::make_unique<DevToolsEyeDropper>(
+        web_contents, base::BindRepeating(&WebContents::ColorPickedInEyeDropper,
+                                          base::Unretained(this)));
+  } else {
+    eye_dropper_.reset();
+  }
+}
+
+void WebContents::ColorPickedInEyeDropper(int r, int g, int b, int a) {
+  base::DictionaryValue color;
+  color.SetInteger("r", r);
+  color.SetInteger("g", g);
+  color.SetInteger("b", b);
+  color.SetInteger("a", a);
+  inspectable_web_contents_->CallClientFunction(
+      "DevToolsAPI.eyeDropperPickedColor", &color, nullptr, nullptr);
+}
+
 #if defined(TOOLKIT_VIEWS) && !defined(OS_MAC)
 gfx::ImageSkia WebContents::GetDevToolsWindowIcon() {
   if (!owner_window())

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -14,6 +14,7 @@
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 #include "base/observer_list_types.h"
+#include "chrome/browser/devtools/devtools_eye_dropper.h"
 #include "chrome/browser/devtools/devtools_file_system_indexer.h"
 #include "content/common/cursors/webcursor.h"
 #include "content/common/frame.mojom.h"
@@ -663,6 +664,7 @@ class WebContents : public gin::Wrappable<WebContents>,
   void DevToolsSearchInPath(int request_id,
                             const std::string& file_system_path,
                             const std::string& query) override;
+  void DevToolsSetEyeDropperActive(bool active) override;
 
   // InspectableWebContentsViewDelegate:
 #if defined(TOOLKIT_VIEWS) && !defined(OS_MAC)
@@ -675,6 +677,8 @@ class WebContents : public gin::Wrappable<WebContents>,
 
   // Destroy the managed InspectableWebContents object.
   void ResetManagedWebContents(bool async);
+
+  void ColorPickedInEyeDropper(int r, int g, int b, int a);
 
   // DevTools index event callbacks.
   void OnDevToolsIndexingWorkCalculated(int request_id,
@@ -746,6 +750,8 @@ class WebContents : public gin::Wrappable<WebContents>,
   std::unique_ptr<WebDialogHelper> web_dialog_helper_;
 
   scoped_refptr<DevToolsFileSystemIndexer> devtools_file_system_indexer_;
+
+  std::unique_ptr<DevToolsEyeDropper> eye_dropper_;
 
   ElectronBrowserContext* browser_context_;
 

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -784,7 +784,10 @@ void InspectableWebContents::SearchInPath(int request_id,
 void InspectableWebContents::SetWhitelistedShortcuts(
     const std::string& message) {}
 
-void InspectableWebContents::SetEyeDropperActive(bool active) {}
+void InspectableWebContents::SetEyeDropperActive(bool active) {
+  if (delegate_)
+    delegate_->DevToolsSetEyeDropperActive(active);
+}
 void InspectableWebContents::ShowCertificateViewer(
     const std::string& cert_chain) {}
 

--- a/shell/browser/ui/inspectable_web_contents_delegate.h
+++ b/shell/browser/ui/inspectable_web_contents_delegate.h
@@ -35,6 +35,7 @@ class InspectableWebContentsDelegate {
   virtual void DevToolsSearchInPath(int request_id,
                                     const std::string& file_system_path,
                                     const std::string& query) {}
+  virtual void DevToolsSetEyeDropperActive(bool active) {}
 };
 
 }  // namespace electron


### PR DESCRIPTION
Manual backport of #29729

See that PR for details.

Notes: Fixes the color select eyedropper not working within DevTools.