### PR TITLE
docs: fix frontmatter for Tray tutorial

### DIFF
--- a/docs/tutorial/tray.md
+++ b/docs/tutorial/tray.md
@@ -1,7 +1,7 @@
 ---
 title: Tray
 description: This guide will take you through the process of creating
-a Tray icon with its own context menu to the system's notification area.
+  a Tray icon with its own context menu to the system's notification area.
 slug: tray
 hide_title: true
 ---


### PR DESCRIPTION
#### Description of Change

Fixing a little mishap with the formatting slipped through the previous PR. Without this whitespace fix, Markdown parsers won't correctly detect the frontmatter.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
