### PR TITLE
fix: update Squirel.Mac to fix CPU spin during update

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -23,7 +23,7 @@ vars = {
     # available.
     '65b32af46e9d7fab2e4ff657751205b3865f4920',
   'squirrel.mac_version':
-    'cdc0729c8bf8576bfef18629186e1e9ecf1b0d9f',
+    '0e5d146ba13101a1302d59ea6e6e0b3cace4ae38',
 
   'pyyaml_version': '3.12',
 

--- a/patches/squirrel.mac/build_add_gn_config.patch
+++ b/patches/squirrel.mac/build_add_gn_config.patch
@@ -452,7 +452,7 @@ index 85073b2f5d58d3e071fb6ef30598973b4d00eda8..c81c820d61da3c7d1cfd2c516147c954
  
  NSString * const SQRLUpdaterErrorDomain = @"SQRLUpdaterErrorDomain";
 diff --git a/Squirrel/SQRLZipArchiver.m b/Squirrel/SQRLZipArchiver.m
-index f84127f642516078249925953e97621909265deb..478509cdd528db4fcfa340c6f93fa58a446957e6 100644
+index cbc8fb61c66184c1d76e8b9f52a89292b4e9939c..d0f20f022a4ff392b596bcf0be96ab3e3c835285 100644
 --- a/Squirrel/SQRLZipArchiver.m
 +++ b/Squirrel/SQRLZipArchiver.m
 @@ -7,8 +7,8 @@

--- a/patches/squirrel.mac/fix_ensure_that_self_is_retained_until_the_racsignal_is_complete.patch
+++ b/patches/squirrel.mac/fix_ensure_that_self_is_retained_until_the_racsignal_is_complete.patch
@@ -6,10 +6,10 @@ Subject: fix: ensure that self is retained until the RACSignal is complete
 Looks like the clang that Chromium uses is slightly smarter with ARC than whatever Squirrel was built with previously.  We now need to keep a reference to self to keep it alive into the "then" of the RACSignal.
 
 diff --git a/Squirrel/SQRLZipArchiver.m b/Squirrel/SQRLZipArchiver.m
-index 478509cdd528db4fcfa340c6f93fa58a446957e6..7c279bf73c368453bff4f922d76908c06dc378cd 100644
+index d0f20f022a4ff392b596bcf0be96ab3e3c835285..68f5dac8e553638f41306956df9d38eeda18f8f2 100644
 --- a/Squirrel/SQRLZipArchiver.m
 +++ b/Squirrel/SQRLZipArchiver.m
-@@ -134,7 +134,7 @@ - (RACSignal *)launchWithArguments:(NSArray *)arguments {
+@@ -135,7 +135,7 @@ - (RACSignal *)launchWithArguments:(NSArray *)arguments {
  			return [RACSignal
  				zip:@[ self.taskTerminated, self.standardErrorData ]
  				reduce:^(NSNumber *exitStatus, NSData *errorData) {


### PR DESCRIPTION
Refs: https://github.com/Squirrel/Squirrel.Mac/pull/259
Closes: #29119

Notes: Fixed issue where the update permission prompt would cause 100% CPU spin while the prompt was open