### PR TITLE
fix: properly handle optional requestHeaders with onBeforeSendHeaders

### DIFF
--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -214,8 +214,11 @@ void ReadFromResponse(v8::Isolate* isolate,
 void ReadFromResponse(v8::Isolate* isolate,
                       gin::Dictionary* response,
                       net::HttpRequestHeaders* headers) {
-  headers->Clear();
-  response->Get("requestHeaders", headers);
+  v8::Local<v8::Value> value;
+  if (response->Get("requestHeaders", &value) && value->IsObject()) {
+    headers->Clear();
+    gin::Converter<net::HttpRequestHeaders>::FromV8(isolate, value, headers);
+  }
 }
 
 void ReadFromResponse(v8::Isolate* isolate,

--- a/spec-main/api-web-request-spec.ts
+++ b/spec-main/api-web-request-spec.ts
@@ -214,6 +214,18 @@ describe('webRequest module', () => {
       await ajax(defaultURL);
     });
 
+    it('leaves headers unchanged when no requestHeaders in callback', async () => {
+      let originalRequestHeaders: Record<string, string>;
+      ses.webRequest.onBeforeSendHeaders((details, callback) => {
+        originalRequestHeaders = details.requestHeaders;
+        callback({});
+      });
+      ses.webRequest.onSendHeaders((details) => {
+        expect(details.requestHeaders).to.deep.equal(originalRequestHeaders);
+      });
+      await ajax(defaultURL);
+    });
+
     it('works with file:// protocol', async () => {
       const requestHeaders = {
         Test: 'header'


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Fixes #20751.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where request headers were cleared if the optional "requestHeaders" parameter was not included in the webRequest.onBeforeSendHeaders callback response object <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
