### PR TITLE
fix: child window alwaysOnTop level persistence

### DIFF
--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -559,10 +559,6 @@ bool BaseWindow::IsAlwaysOnTop() {
   return window_->GetZOrderLevel() != ui::ZOrderLevel::kNormal;
 }
 
-std::string BaseWindow::GetAlwaysOnTopLevel() {
-  return window_->GetAlwaysOnTopLevel();
-}
-
 void BaseWindow::Center() {
   window_->Center();
 }
@@ -886,6 +882,10 @@ void BaseWindow::SetVibrancy(v8::Isolate* isolate, v8::Local<v8::Value> value) {
 }
 
 #if defined(OS_MAC)
+std::string BaseWindow::GetAlwaysOnTopLevel() {
+  return window_->GetAlwaysOnTopLevel();
+}
+
 void BaseWindow::SetWindowButtonVisibility(bool visible) {
   window_->SetWindowButtonVisibility(visible);
 }
@@ -1275,7 +1275,7 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("isVisibleOnAllWorkspaces",
                  &BaseWindow::IsVisibleOnAllWorkspaces)
 #if defined(OS_MAC)
-      .SetMethod("getAlwaysOnTopLevel", &BaseWindow::GetAlwaysOnTopLevel)
+      .SetMethod("_getAlwaysOnTopLevel", &BaseWindow::GetAlwaysOnTopLevel)
       .SetMethod("setAutoHideCursor", &BaseWindow::SetAutoHideCursor)
 #endif
       .SetMethod("setVibrancy", &BaseWindow::SetVibrancy)

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -563,10 +563,6 @@ std::string BaseWindow::GetAlwaysOnTopLevel() {
   return window_->GetAlwaysOnTopLevel();
 }
 
-int BaseWindow::GetZOrderLevel() {
-  return static_cast<int>(window_->GetZOrderLevel());
-}
-
 void BaseWindow::Center() {
   window_->Center();
 }
@@ -1234,8 +1230,6 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("isClosable", &BaseWindow::IsClosable)
       .SetMethod("setAlwaysOnTop", &BaseWindow::SetAlwaysOnTop)
       .SetMethod("isAlwaysOnTop", &BaseWindow::IsAlwaysOnTop)
-      .SetMethod("getAlwaysOnTopLevel", &BaseWindow::GetAlwaysOnTopLevel)
-      .SetMethod("getZOrderLevel", &BaseWindow::GetZOrderLevel)
       .SetMethod("center", &BaseWindow::Center)
       .SetMethod("setPosition", &BaseWindow::SetPosition)
       .SetMethod("getPosition", &BaseWindow::GetPosition)
@@ -1280,16 +1274,21 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
                  &BaseWindow::SetVisibleOnAllWorkspaces)
       .SetMethod("isVisibleOnAllWorkspaces",
                  &BaseWindow::IsVisibleOnAllWorkspaces)
-      .SetMethod("setVibrancy", &BaseWindow::SetVibrancy)
-      .SetMethod("_setTouchBarItems", &BaseWindow::SetTouchBar)
-      .SetMethod("_refreshTouchBarItem", &BaseWindow::RefreshTouchBarItem)
-      .SetMethod("_setEscapeTouchBarItem", &BaseWindow::SetEscapeTouchBarItem)
 #if defined(OS_MAC)
+      .SetMethod("getAlwaysOnTopLevel", &BaseWindow::GetAlwaysOnTopLevel)
       .SetMethod("setAutoHideCursor", &BaseWindow::SetAutoHideCursor)
+#endif
+      .SetMethod("setVibrancy", &BaseWindow::SetVibrancy)
+#if defined(OS_MAC)
       .SetMethod("setTrafficLightPosition",
                  &BaseWindow::SetTrafficLightPosition)
       .SetMethod("getTrafficLightPosition",
                  &BaseWindow::GetTrafficLightPosition)
+#endif
+      .SetMethod("_setTouchBarItems", &BaseWindow::SetTouchBar)
+      .SetMethod("_refreshTouchBarItem", &BaseWindow::RefreshTouchBarItem)
+      .SetMethod("_setEscapeTouchBarItem", &BaseWindow::SetEscapeTouchBarItem)
+#if defined(OS_MAC)
       .SetMethod("selectPreviousTab", &BaseWindow::SelectPreviousTab)
       .SetMethod("selectNextTab", &BaseWindow::SelectNextTab)
       .SetMethod("mergeAllWindows", &BaseWindow::MergeAllWindows)

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -559,6 +559,14 @@ bool BaseWindow::IsAlwaysOnTop() {
   return window_->GetZOrderLevel() != ui::ZOrderLevel::kNormal;
 }
 
+std::string BaseWindow::GetAlwaysOnTopLevel() {
+  return window_->GetAlwaysOnTopLevel();
+}
+
+int BaseWindow::GetZOrderLevel() {
+  return static_cast<int>(window_->GetZOrderLevel());
+}
+
 void BaseWindow::Center() {
   window_->Center();
 }
@@ -1226,6 +1234,8 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("isClosable", &BaseWindow::IsClosable)
       .SetMethod("setAlwaysOnTop", &BaseWindow::SetAlwaysOnTop)
       .SetMethod("isAlwaysOnTop", &BaseWindow::IsAlwaysOnTop)
+      .SetMethod("getAlwaysOnTopLevel", &BaseWindow::GetAlwaysOnTopLevel)
+      .SetMethod("getZOrderLevel", &BaseWindow::GetZOrderLevel)
       .SetMethod("center", &BaseWindow::Center)
       .SetMethod("setPosition", &BaseWindow::SetPosition)
       .SetMethod("getPosition", &BaseWindow::GetPosition)
@@ -1270,20 +1280,16 @@ void BaseWindow::BuildPrototype(v8::Isolate* isolate,
                  &BaseWindow::SetVisibleOnAllWorkspaces)
       .SetMethod("isVisibleOnAllWorkspaces",
                  &BaseWindow::IsVisibleOnAllWorkspaces)
-#if defined(OS_MAC)
-      .SetMethod("setAutoHideCursor", &BaseWindow::SetAutoHideCursor)
-#endif
       .SetMethod("setVibrancy", &BaseWindow::SetVibrancy)
-#if defined(OS_MAC)
-      .SetMethod("setTrafficLightPosition",
-                 &BaseWindow::SetTrafficLightPosition)
-      .SetMethod("getTrafficLightPosition",
-                 &BaseWindow::GetTrafficLightPosition)
-#endif
       .SetMethod("_setTouchBarItems", &BaseWindow::SetTouchBar)
       .SetMethod("_refreshTouchBarItem", &BaseWindow::RefreshTouchBarItem)
       .SetMethod("_setEscapeTouchBarItem", &BaseWindow::SetEscapeTouchBarItem)
 #if defined(OS_MAC)
+      .SetMethod("setAutoHideCursor", &BaseWindow::SetAutoHideCursor)
+      .SetMethod("setTrafficLightPosition",
+                 &BaseWindow::SetTrafficLightPosition)
+      .SetMethod("getTrafficLightPosition",
+                 &BaseWindow::GetTrafficLightPosition)
       .SetMethod("selectPreviousTab", &BaseWindow::SelectPreviousTab)
       .SetMethod("selectNextTab", &BaseWindow::SelectNextTab)
       .SetMethod("mergeAllWindows", &BaseWindow::MergeAllWindows)

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -142,6 +142,8 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   bool IsClosable();
   void SetAlwaysOnTop(bool top, gin_helper::Arguments* args);
   bool IsAlwaysOnTop();
+  std::string GetAlwaysOnTopLevel();
+  int GetZOrderLevel();
   void Center();
   void SetPosition(int x, int y, gin_helper::Arguments* args);
   std::vector<int> GetPosition();

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -142,7 +142,6 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   bool IsClosable();
   void SetAlwaysOnTop(bool top, gin_helper::Arguments* args);
   bool IsAlwaysOnTop();
-  std::string GetAlwaysOnTopLevel();
   void Center();
   void SetPosition(int x, int y, gin_helper::Arguments* args);
   std::vector<int> GetPosition();
@@ -195,6 +194,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   virtual void SetVibrancy(v8::Isolate* isolate, v8::Local<v8::Value> value);
 
 #if defined(OS_MAC)
+  std::string GetAlwaysOnTopLevel();
   void SetWindowButtonVisibility(bool visible);
   bool GetWindowButtonVisibility() const;
   void SetTrafficLightPosition(const gfx::Point& position);

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -143,7 +143,6 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   void SetAlwaysOnTop(bool top, gin_helper::Arguments* args);
   bool IsAlwaysOnTop();
   std::string GetAlwaysOnTopLevel();
-  int GetZOrderLevel();
   void Center();
   void SetPosition(int x, int y, gin_helper::Arguments* args);
   std::vector<int> GetPosition();

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -129,13 +129,13 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetAlwaysOnTop(ui::ZOrderLevel z_order,
                               const std::string& level = "floating",
                               int relativeLevel = 0) = 0;
-  virtual std::string GetAlwaysOnTopLevel() = 0;
   virtual ui::ZOrderLevel GetZOrderLevel() = 0;
   virtual void Center() = 0;
   virtual void Invalidate() = 0;
   virtual void SetTitle(const std::string& title) = 0;
   virtual std::string GetTitle() = 0;
 #if defined(OS_MAC)
+  virtual std::string GetAlwaysOnTopLevel() = 0;
   virtual void SetActive(bool is_key) = 0;
   virtual bool IsActive() const = 0;
 #endif

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -129,6 +129,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetAlwaysOnTop(ui::ZOrderLevel z_order,
                               const std::string& level = "floating",
                               int relativeLevel = 0) = 0;
+  virtual std::string GetAlwaysOnTopLevel() = 0;
   virtual ui::ZOrderLevel GetZOrderLevel() = 0;
   virtual void Center() = 0;
   virtual void Invalidate() = 0;

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -78,6 +78,7 @@ class NativeWindowMac : public NativeWindow,
   void SetAlwaysOnTop(ui::ZOrderLevel z_order,
                       const std::string& level,
                       int relative_level) override;
+  std::string GetAlwaysOnTopLevel() override;
   ui::ZOrderLevel GetZOrderLevel() override;
   void Center() override;
   void Invalidate() override;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1805,10 +1805,15 @@ void NativeWindowMac::InternalSetParentWindow(NativeWindow* parent,
 
   // Set new parent window.
   // Note that this method will force the window to become visible.
-  if (parent && attach)
+  if (parent && attach) {
+    // Attaching a window as a child window resets its window level, so
+    // save and restore it afterwards.
+    NSInteger level = window_.level;
     [parent->GetNativeWindow().GetNativeNSWindow()
         addChildWindow:window_
                ordered:NSWindowAbove];
+    [window_ setLevel:level];
+  }
 }
 
 void NativeWindowMac::SetForwardMouseMessages(bool forward) {

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -869,6 +869,31 @@ void NativeWindowMac::SetAlwaysOnTop(ui::ZOrderLevel z_order,
   SetWindowLevel(level + relative_level);
 }
 
+std::string NativeWindowMac::GetAlwaysOnTopLevel() {
+  std::string level_name = "normal";
+
+  int level = [window_ level];
+  if (level == NSFloatingWindowLevel) {
+    level_name = "floating";
+  } else if (level == NSTornOffMenuWindowLevel) {
+    level_name = "torn-off-menu";
+  } else if (level == NSModalPanelWindowLevel) {
+    level_name = "modal-panel";
+  } else if (level == NSMainMenuWindowLevel) {
+    level_name = "main-menu";
+  } else if (level == NSStatusWindowLevel) {
+    level_name = "status";
+  } else if (level == NSPopUpMenuWindowLevel) {
+    level_name = "pop-up-menu";
+  } else if (level == NSScreenSaverWindowLevel) {
+    level_name = "screen-saver";
+  } else if (level == NSDockWindowLevel) {
+    level_name = "dock";
+  }
+
+  return level_name;
+}
+
 void NativeWindowMac::SetWindowLevel(int unbounded_level) {
   int level = std::min(
       std::max(unbounded_level, CGWindowLevelForKey(kCGMinimumWindowLevelKey)),

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -93,6 +93,7 @@ class NativeWindowViews : public NativeWindow,
   void SetAlwaysOnTop(ui::ZOrderLevel z_order,
                       const std::string& level,
                       int relativeLevel) override;
+  std::string GetAlwaysOnTopLevel() override;
   ui::ZOrderLevel GetZOrderLevel() override;
   void Center() override;
   void Invalidate() override;

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -93,7 +93,6 @@ class NativeWindowViews : public NativeWindow,
   void SetAlwaysOnTop(ui::ZOrderLevel z_order,
                       const std::string& level,
                       int relativeLevel) override;
-  std::string GetAlwaysOnTopLevel() override;
   ui::ZOrderLevel GetZOrderLevel() override;
   void Center() override;
   void Invalidate() override;

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1471,7 +1471,7 @@ describe('BrowserWindow module', () => {
 
       expect(w.isAlwaysOnTop()).to.be.false();
       expect(c.isAlwaysOnTop()).to.be.true('child is not always on top');
-      expect((c as any).getAlwaysOnTopLevel()).to.equal('screen-saver');
+      expect((c as any)._getAlwaysOnTopLevel()).to.equal('screen-saver');
     });
   });
 

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1430,13 +1430,10 @@ describe('BrowserWindow module', () => {
   describe('BrowserWindow.setAlwaysOnTop(flag, level)', () => {
     let w = null as unknown as BrowserWindow;
 
+    afterEach(closeAllWindows);
+
     beforeEach(() => {
       w = new BrowserWindow({ show: true });
-    });
-
-    afterEach(async () => {
-      await closeWindow(w);
-      w = null as unknown as BrowserWindow;
     });
 
     it('sets the window as always on top', () => {
@@ -1465,6 +1462,16 @@ describe('BrowserWindow module', () => {
       w.setAlwaysOnTop(true);
       const [, alwaysOnTop] = await alwaysOnTopChanged;
       expect(alwaysOnTop).to.be.true('is not alwaysOnTop');
+    });
+
+    ifit(process.platform === 'darwin')('honors the alwaysOnTop level of a child window', () => {
+      w = new BrowserWindow({ show: false });
+      const c = new BrowserWindow({ parent: w });
+      c.setAlwaysOnTop(true, 'screen-saver');
+
+      expect(w.isAlwaysOnTop()).to.be.false();
+      expect(c.isAlwaysOnTop()).to.be.true('child is not always on top');
+      expect((c as any).getAlwaysOnTopLevel()).to.equal('screen-saver');
     });
   });
 


### PR DESCRIPTION
#### Description of Change

Fixes an issue found while debugging https://github.com/electron/electron/issues/29732 - when a child window is attached to a parent `NSWindow`, the child window's level will be reset. E.g if one calls `childWindow.setAlwaysOnTop(true, 'screen-saver')`, this will not be honored. This fixes that by preserving the window level before it's attached to the parent and then restoring it.

Tested with https://gist.github.com/f2a3a5e8d9130223f18b8ddade390f20.

A test can't be added here because `isAlwaysOnTop` is true for all child windows, and while `setAlwaysOnTop` differentiates between different window levels the getter does not, and so it's not possible at present to tell whether or not a window level is for ex. `screen-saver` or `pop-up-menu` since `isAlwaysOnTop` would be true for both. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the `setAlwaysOnTop` value would sometimes not be preserved for child windows on macOS.
