### PR TITLE
chore: cherry-pick b9ad6a864c79 from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -21,3 +21,4 @@ merged_const-tracking_generalize_constness_when_delete_properties.patch
 merged_liftoff_fix_2gb_memory_accesses_on_32-bit.patch
 reland_compiler_fix_more_truncation_bugs_in_simplifiedlowering.patch
 m90-lts_squashed_multiple_commits.patch
+cherry-pick-b9ad6a864c79.patch

--- a/patches/v8/cherry-pick-b9ad6a864c79.patch
+++ b/patches/v8/cherry-pick-b9ad6a864c79.patch
@@ -1,7 +1,8 @@
-From b9ad6a864c79f06296a87b7747d932d84749daf6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Georg Neis <neis@chromium.org>
 Date: Thu, 27 May 2021 13:04:30 +0200
-Subject: [PATCH] [M90-LTS] Reland "Merged: [compiler] Always record constness dependency for FastDataConstant"
+Subject: Reland "Merged: [compiler] Always record constness dependency for
+ FastDataConstant"
 
 This is a reland of 638d1b238d510a349bdd38648add8d5c85bc5f7d after a
 one-character change. A local variable still has a non-optional type
@@ -45,13 +46,12 @@ Commit-Queue: Victor-Gabriel Savu <vsavu@google.com>
 Cr-Commit-Position: refs/branch-heads/9.0@{#62}
 Cr-Branched-From: bd0108b4c88e0d6f2350cb79b5f363fbd02f3eb7-refs/heads/9.0.257@{#1}
 Cr-Branched-From: 349bcc6a075411f1a7ce2d866c3dfeefc2efa39d-refs/heads/master@{#73001}
----
 
 diff --git a/src/compiler/access-info.cc b/src/compiler/access-info.cc
-index 06806fe..ee82d7d 100644
+index ddf742e7089544807d0565d42d6a26bc0dace56f..74f332456f8bcba4b93ae0f211c299293b9fd5b4 100644
 --- a/src/compiler/access-info.cc
 +++ b/src/compiler/access-info.cc
-@@ -894,7 +894,7 @@
+@@ -897,7 +897,7 @@ PropertyAccessInfo AccessInfoFactory::LookupTransition(
    // Transitioning stores *may* store to const fields. The resulting
    // DataConstant access infos can be distinguished from later, i.e. redundant,
    // stores to the same constant field by the presence of a transition map.

--- a/patches/v8/cherry-pick-b9ad6a864c79.patch
+++ b/patches/v8/cherry-pick-b9ad6a864c79.patch
@@ -1,0 +1,62 @@
+From b9ad6a864c79f06296a87b7747d932d84749daf6 Mon Sep 17 00:00:00 2001
+From: Georg Neis <neis@chromium.org>
+Date: Thu, 27 May 2021 13:04:30 +0200
+Subject: [PATCH] [M90-LTS] Reland "Merged: [compiler] Always record constness dependency for FastDataConstant"
+
+This is a reland of 638d1b238d510a349bdd38648add8d5c85bc5f7d after a
+one-character change. A local variable still has a non-optional type
+in this version of V8.
+
+Original change's description:
+> Merged: [compiler] Always record constness dependency for FastDataConstant
+>
+> Revision: 1bfa5139966fe0c9e8036fe6362b61c483675775
+>
+> BUG=chromium:1209558
+> NOTRY=true
+> NOPRESUBMIT=true
+> NOTREECHECKS=true
+>
+> Change-Id: If4f7243647bcc12ed482796c1353f0717630f6b9
+> Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2919823
+> Commit-Queue: Georg Neis <neis@chromium.org>
+> Reviewed-by: Igor Sheludko <ishell@chromium.org>
+> Cr-Commit-Position: refs/branch-heads/9.1@{#59}
+> Cr-Branched-From: 0e4ac64a8cf298b14034a22f9fe7b085d2cb238d-refs/heads/9.1.269@{#1}
+> Cr-Branched-From: f565e72d5ba88daae35a59d0f978643e2343e912-refs/heads/master@{#73847}
+
+NOTRY=true
+NOPRESUBMIT=true
+NOTREECHECKS=true
+
+(cherry picked from commit 73666e3f6d6bdbc93ab81cf8b3803dd04930e293)
+
+Bug: chromium:1209558
+Change-Id: I0c81353882b0f17942fd92ad4181732f941bcb1d
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2939991
+Commit-Queue: Georg Neis <neis@chromium.org>
+Reviewed-by: Igor Sheludko <ishell@chromium.org>
+Cr-Original-Commit-Position: refs/branch-heads/9.1@{#63}
+Cr-Original-Branched-From: 0e4ac64a8cf298b14034a22f9fe7b085d2cb238d-refs/heads/9.1.269@{#1}
+Cr-Original-Branched-From: f565e72d5ba88daae35a59d0f978643e2343e912-refs/heads/master@{#73847}
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2948651
+Reviewed-by: Artem Sumaneev <asumaneev@google.com>
+Commit-Queue: Victor-Gabriel Savu <vsavu@google.com>
+Cr-Commit-Position: refs/branch-heads/9.0@{#62}
+Cr-Branched-From: bd0108b4c88e0d6f2350cb79b5f363fbd02f3eb7-refs/heads/9.0.257@{#1}
+Cr-Branched-From: 349bcc6a075411f1a7ce2d866c3dfeefc2efa39d-refs/heads/master@{#73001}
+---
+
+diff --git a/src/compiler/access-info.cc b/src/compiler/access-info.cc
+index 06806fe..ee82d7d 100644
+--- a/src/compiler/access-info.cc
++++ b/src/compiler/access-info.cc
+@@ -894,7 +894,7 @@
+   // Transitioning stores *may* store to const fields. The resulting
+   // DataConstant access infos can be distinguished from later, i.e. redundant,
+   // stores to the same constant field by the presence of a transition map.
+-  switch (details.constness()) {
++  switch (dependencies()->DependOnFieldConstness(transition_map_ref, number)) {
+     case PropertyConstness::kMutable:
+       return PropertyAccessInfo::DataField(
+           zone(), map, std::move(unrecorded_dependencies), field_index,


### PR DESCRIPTION
[M90-LTS] Reland "Merged: [compiler] Always record constness dependency for FastDataConstant"

This is a reland of 638d1b238d510a349bdd38648add8d5c85bc5f7d after a
one-character change. A local variable still has a non-optional type
in this version of V8.

Original change's description:
> Merged: [compiler] Always record constness dependency for FastDataConstant
>
> Revision: 1bfa5139966fe0c9e8036fe6362b61c483675775
>
> BUG=chromium:1209558
> NOTRY=true
> NOPRESUBMIT=true
> NOTREECHECKS=true
>
> Change-Id: If4f7243647bcc12ed482796c1353f0717630f6b9
> Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2919823
> Commit-Queue: Georg Neis <neis@chromium.org>
> Reviewed-by: Igor Sheludko <ishell@chromium.org>
> Cr-Commit-Position: refs/branch-heads/9.1@{#59}
> Cr-Branched-From: 0e4ac64a8cf298b14034a22f9fe7b085d2cb238d-refs/heads/9.1.269@{#1}
> Cr-Branched-From: f565e72d5ba88daae35a59d0f978643e2343e912-refs/heads/master@{#73847}

NOTRY=true
NOPRESUBMIT=true
NOTREECHECKS=true

(cherry picked from commit 73666e3f6d6bdbc93ab81cf8b3803dd04930e293)

Bug: chromium:1209558
Change-Id: I0c81353882b0f17942fd92ad4181732f941bcb1d
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2939991
Commit-Queue: Georg Neis <neis@chromium.org>
Reviewed-by: Igor Sheludko <ishell@chromium.org>
Cr-Original-Commit-Position: refs/branch-heads/9.1@{#63}
Cr-Original-Branched-From: 0e4ac64a8cf298b14034a22f9fe7b085d2cb238d-refs/heads/9.1.269@{#1}
Cr-Original-Branched-From: f565e72d5ba88daae35a59d0f978643e2343e912-refs/heads/master@{#73847}
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2948651
Reviewed-by: Artem Sumaneev <asumaneev@google.com>
Commit-Queue: Victor-Gabriel Savu <vsavu@google.com>
Cr-Commit-Position: refs/branch-heads/9.0@{#62}
Cr-Branched-From: bd0108b4c88e0d6f2350cb79b5f363fbd02f3eb7-refs/heads/9.0.257@{#1}
Cr-Branched-From: 349bcc6a075411f1a7ce2d866c3dfeefc2efa39d-refs/heads/master@{#73001}


Notes: Security: backported fix for chromium:1209558.