### PR TITLE
fix: properly order out child windows on `window.hide()`

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -553,6 +553,15 @@ void NativeWindowMac::Hide() {
     return;
   }
 
+  // Hide all children of the current window before hiding the window.
+  // components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm
+  // expects this when window visibility changes.
+  if ([window_ childWindows]) {
+    for (NSWindow* child in [window_ childWindows]) {
+      [child orderOut:nil];
+    }
+  }
+
   // Deattach the window from the parent before.
   if (parent())
     InternalSetParentWindow(parent(), false);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/29820.

Properly orders out child windows when `window.hide()` is called on a parent window. This should not change any end user behavior, but Chromium specifically DCHECKs for it so we should handle it properly.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none.
