### PR TITLE
fix: Inspector method overrides when contextIsolation enabled

### DIFF
--- a/lib/renderer/inspector.ts
+++ b/lib/renderer/inspector.ts
@@ -52,18 +52,10 @@ const createMenu = function (x: number, y: number, items: ContextMenuItem[]) {
   const isEditMenu = useEditMenuItems(x, y, items);
   ipcRendererInternal.invoke<number>(IPC_MESSAGES.INSPECTOR_CONTEXT_MENU, items, isEditMenu).then(id => {
     if (typeof id === 'number') {
-      if (contextIsolationEnabled) {
-        webFrame.executeJavaScript(`window.DevToolsAPI.contextMenuItemSelected(${JSON.stringify(id)})`);
-      } else {
-        window.DevToolsAPI!.contextMenuItemSelected(id);
-      }
+      webFrame.executeJavaScript(`window.DevToolsAPI.contextMenuItemSelected(${JSON.stringify(id)})`);
     }
 
-    if (contextIsolationEnabled) {
-      webFrame.executeJavaScript('window.DevToolsAPI.contextMenuCleared()');
-    } else {
-      window.DevToolsAPI!.contextMenuCleared();
-    }
+    webFrame.executeJavaScript('window.DevToolsAPI.contextMenuCleared()');
   });
 };
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/29543.

Introduced with the default change from `contextIsolation: false` to `contextIsolation: true`.  When `contextIsolation` is enabled, `window.InspectorFrontendHost`, `window.Persistence`, and `window.UI` are all undefined in the isolated world. We therefore need to set them with the `contextBridge` so that we can override them correctly.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where dropdown menus did not work in DevTools when `contextIsolation` was enabled.