### PR TITLE
fix: stop window.open from hanging when prevented

### DIFF
--- a/lib/browser/guest-window-proxy.ts
+++ b/lib/browser/guest-window-proxy.ts
@@ -76,6 +76,7 @@ ipcMainInternal.on(
     const referrer: Electron.Referrer = { url: '', policy: 'strict-origin-when-cross-origin' };
     const browserWindowOptions = event.sender._callWindowOpenHandler(event, { url, frameName, features, disposition: 'new-window', referrer });
     if (event.defaultPrevented) {
+      event.returnValue = null;
       return;
     }
     const guest = openGuestWindow({

--- a/spec-main/guest-window-manager-spec.ts
+++ b/spec-main/guest-window-manager-spec.ts
@@ -263,6 +263,12 @@ describe('webContents.setWindowOpenHandler', () => {
 
         browserWindow.webContents.executeJavaScript("window.open('about:blank', '', 'show=no') && true");
       });
+
+      it('does not hang parent window when denying window.open', async () => {
+        browserWindow.webContents.setWindowOpenHandler(() => ({ action: 'deny' }));
+        browserWindow.webContents.executeJavaScript("window.open('https://127.0.0.1')");
+        expect(await browserWindow.webContents.executeJavaScript('42')).to.equal(42);
+      });
     });
   }
 });


### PR DESCRIPTION
#### Description of Change
Fixes a never-ending `sendSync` when calling `window.open` with
nativeWindowOpen: false and the new window is denied.

Fixes #29509.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a hang when denying a `window.open` using `setWindowOpenHandler` when `nativeWindowOpen: false`.
