### PR TITLE
fix: type internal APIs that can return null properly

### DIFF
--- a/lib/browser/devtools.ts
+++ b/lib/browser/devtools.ts
@@ -67,7 +67,7 @@ ipcMainInternal.handle(IPC_MESSAGES.INSPECTOR_CONTEXT_MENU, function (event, ite
 
     const template = isEditMenu ? getEditMenuItems() : convertToMenuTemplate(items, resolve);
     const menu = Menu.buildFromTemplate(template);
-    const window = event.sender.getOwnerBrowserWindow();
+    const window = event.sender.getOwnerBrowserWindow()!;
 
     menu.popup({ window, callback: () => resolve() });
   });
@@ -94,7 +94,7 @@ ipcMainUtils.handleSync(IPC_MESSAGES.INSPECTOR_CONFIRM, async function (event, m
     buttons: ['OK', 'Cancel'],
     cancelId: 1
   };
-  const window = event.sender.getOwnerBrowserWindow();
+  const window = event.sender.getOwnerBrowserWindow()!;
   const { response } = await dialog.showMessageBox(window, options);
   return response === 0;
 });

--- a/lib/browser/guest-view-manager.ts
+++ b/lib/browser/guest-view-manager.ts
@@ -193,7 +193,7 @@ const attachGuest = function (event: Electron.IpcMainInvokeEvent,
   ]);
 
   // Inherit certain option values from embedder
-  const lastWebPreferences = embedder.getLastWebPreferences();
+  const lastWebPreferences = embedder.getLastWebPreferences()!;
   for (const [name, value] of inheritedWebPreferences) {
     if (lastWebPreferences[name as keyof Electron.WebPreferences] === value) {
       (webPreferences as any)[name] = value;

--- a/lib/browser/guest-window-manager.ts
+++ b/lib/browser/guest-window-manager.ts
@@ -144,7 +144,7 @@ function emitDeprecatedNewWindowEvent ({ event, embedder, guest, windowOpenArgs,
   postData?: PostData,
 }): boolean {
   const { url, frameName } = windowOpenArgs;
-  const isWebViewWithPopupsDisabled = embedder.getType() === 'webview' && embedder.getLastWebPreferences().disablePopups;
+  const isWebViewWithPopupsDisabled = embedder.getType() === 'webview' && embedder.getLastWebPreferences()!.disablePopups;
   const postBody = postData ? {
     data: postData,
     ...parseContentTypeFormat(postData)
@@ -229,7 +229,7 @@ export function makeWebPreferences ({ embedder, secureOverrideWebPreferences = {
   // have unvetted prefs, use parsedWebPreferences.
   secureOverrideWebPreferences?: BrowserWindowConstructorOptions['webPreferences'],
 }) {
-  const parentWebPreferences = embedder.getLastWebPreferences();
+  const parentWebPreferences = embedder.getLastWebPreferences()!;
   const securityWebPreferencesFromParent = (Object.keys(securityWebPreferences).reduce((map, key) => {
     if (securityWebPreferences[key] === parentWebPreferences[key as keyof Electron.WebPreferences]) {
       (map as any)[key] = parentWebPreferences[key as keyof Electron.WebPreferences];

--- a/lib/browser/guest-window-proxy.ts
+++ b/lib/browser/guest-window-proxy.ts
@@ -28,7 +28,7 @@ const getGuestWindow = function (guestContents: WebContents) {
 };
 
 const isChildWindow = function (sender: WebContents, target: WebContents) {
-  return target.getLastWebPreferences().openerId === sender.id;
+  return target.getLastWebPreferences()!.openerId === sender.id;
 };
 
 const isRelatedWindow = function (sender: WebContents, target: WebContents) {
@@ -43,7 +43,7 @@ const isScriptableWindow = function (sender: WebContents, target: WebContents) {
 };
 
 const isNodeIntegrationEnabled = function (sender: WebContents) {
-  return sender.getLastWebPreferences().nodeIntegration === true;
+  return sender.getLastWebPreferences()!.nodeIntegration === true;
 };
 
 // Checks whether |sender| can access the |target|:
@@ -65,7 +65,7 @@ ipcMainInternal.on(
     features: string
   ) => {
     // This should only be allowed for senders that have nativeWindowOpen: false
-    const lastWebPreferences = event.sender.getLastWebPreferences();
+    const lastWebPreferences = event.sender.getLastWebPreferences()!;
     if (lastWebPreferences.nativeWindowOpen || lastWebPreferences.sandbox) {
       event.returnValue = null;
       throw new Error(

--- a/spec-main/ambient.d.ts
+++ b/spec-main/ambient.d.ts
@@ -2,8 +2,8 @@ declare let standardScheme: string;
 
 declare namespace Electron {
   interface WebContents {
-    getOwnerBrowserWindow(): BrowserWindow;
-    getWebPreferences(): any;
+    getOwnerBrowserWindow(): BrowserWindow | null;
+    getWebPreferences(): WebPreferences | null;
   }
 
   interface Session {

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -56,8 +56,8 @@ declare namespace Electron {
 
   interface WebContents {
     _loadURL(url: string, options: ElectronInternal.LoadURLOptions): void;
-    getOwnerBrowserWindow(): Electron.BrowserWindow;
-    getLastWebPreferences(): Electron.WebPreferences;
+    getOwnerBrowserWindow(): Electron.BrowserWindow | null;
+    getLastWebPreferences(): Electron.WebPreferences | null;
     _getPreloadPaths(): string[];
     equal(other: WebContents): boolean;
     browserWindowOptions: BrowserWindowConstructorOptions;


### PR DESCRIPTION
#### Description of Change
The following APIs can return `null`:
https://github.com/electron/electron/blob/b8261f15916eb94428d5672716f85c56720b1501/shell/browser/api/electron_api_web_contents.cc#L3043-L3065

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none
