### PR TITLE
fix: window ordering on mac

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1679,8 +1679,6 @@ void NativeWindowMac::NotifyWindowWillLeaveFullScreen() {
 }
 
 void NativeWindowMac::SetActive(bool is_key) {
-  if (is_key)
-    widget()->Activate();
   is_active_ = is_key;
 }
 

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -4168,6 +4168,18 @@ describe('BrowserWindow module', () => {
         await leaveFullScreen;
         expect(w.isFullScreen()).to.be.false('isFullScreen');
       });
+
+      it('multiple windows inherit correct fullscreen state', async () => {
+        const w = new BrowserWindow();
+        const enterFullScreen = emittedOnce(w, 'enter-full-screen');
+        w.setFullScreen(true);
+        await enterFullScreen;
+        expect(w.isFullScreen()).to.be.true('isFullScreen');
+        await delay();
+        const w2 = new BrowserWindow();
+        await delay();
+        expect(w2.isFullScreen()).to.be.true('isFullScreen');
+      });
     });
 
     describe('closable state', () => {


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/29758

The call to `NativeWidgetMac::Activate` added in https://github.com/electron/electron/pull/29204 tries to set the visibility state of the window via `NativeWidgetNSWindowBridge` with state [kShowAndActivateWindow](https://source.chromium.org/chromium/chromium/src/+/main:components/remote_cocoa/common/native_widget_ns_window.mojom;l=50-51) which eventually calls `[NSWindow makeKeyAndOrderFront:]`

This is all fine for normal cases, but under the following situations it triggers a series of `windowDidBecomeKey:` notifications that messes with window ordering.

1) When opening panels the main window takes key status and captures the input events
2) When in fullscreen opening a second window does not inherit the fullscreen behavior
3) Custom window switchers are unable to switch between windows

Since we are making the widget call in the key window notification code path, it is safe to remove this redundant call that is causing the above incorrect behaviors.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix key window status on mac when opening panels or using custom window switchers