### PR TITLE
feat: undo nativeWindowOpen default change, warn instead

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -343,8 +343,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       entry in the combo box at the top of the Console tab.
     * `nativeWindowOpen` Boolean (optional) - Whether to use native
       `window.open()`. Defaults to `false`. Child windows will always have node
-      integration disabled unless `nodeIntegrationInSubFrames` is true. **Note:** This option is currently
-      experimental.
+      integration disabled unless `nodeIntegrationInSubFrames` is true. **Note:** The default
+      value will be changing to `true` in Electron 15.
     * `webviewTag` Boolean (optional) - Whether to enable the [`<webview>` tag](webview-tag.md).
       Defaults to `false`. **Note:** The
       `preload` script configured for the `<webview>` will have node integration

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -342,8 +342,9 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
       context in the dev tools by selecting the 'Electron Isolated Context'
       entry in the combo box at the top of the Console tab.
     * `nativeWindowOpen` Boolean (optional) - Whether to use native
-      `window.open()`. Defaults to `true`. Child windows will always have node
-      integration disabled unless `nodeIntegrationInSubFrames` is true.
+      `window.open()`. Defaults to `false`. Child windows will always have node
+      integration disabled unless `nodeIntegrationInSubFrames` is true. **Note:** This option is currently
+      experimental.
     * `webviewTag` Boolean (optional) - Whether to enable the [`<webview>` tag](webview-tag.md).
       Defaults to `false`. **Note:** The
       `preload` script configured for the `<webview>` will have node integration

--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -6,15 +6,16 @@ untrusted content within a renderer. Windows can be created from the renderer in
 * clicking on links or submitting forms adorned with `target=_blank`
 * JavaScript calling `window.open()`
 
-For same-origin content, the new window is created within the same process,
-enabling the parent to access the child window directly. This can be very
-useful for app sub-windows that act as preference panels, or similar, as the
-parent can render to the sub-window directly, as if it were a `div` in the
-parent. This is the same behavior as in the browser.
+In non-sandboxed renderers, or when `nativeWindowOpen` is false (the default), this results in the creation of a
+[`BrowserWindowProxy`](browser-window-proxy.md), a light wrapper around
+`BrowserWindow`.
 
-When `nativeWindowOpen` is set to false, `window.open` instead results in the
-creation of a [`BrowserWindowProxy`](browser-window-proxy.md), a light wrapper
-around `BrowserWindow`.
+However, when the `sandbox` (or directly, `nativeWindowOpen`) option is set, a
+`Window` instance is created, as you'd expect in the browser. For same-origin
+content, the new window is created within the same process, enabling the parent
+to access the child window directly. This can be very useful for app sub-windows that act
+as preference panels, or similar, as the parent can render to the sub-window
+directly, as if it were a `div` in the parent.
 
 Electron pairs this native Chrome `Window` with a BrowserWindow under the hood.
 You can take advantage of all the customization available when creating a
@@ -67,18 +68,49 @@ window.open('https://github.com', '_blank', 'top=500,left=200,frame=false,nodeIn
 
 To customize or cancel the creation of the window, you can optionally set an
 override handler with `webContents.setWindowOpenHandler()` from the main
-process. Returning `{ action: 'deny' }` cancels the window. Returning `{
-action: 'allow', overrideBrowserWindowOptions: { ... } }` will allow opening
-the window and setting the `BrowserWindowConstructorOptions` to be used when
-creating the window. Note that this is more powerful than passing options
-through the feature string, as the renderer has more limited privileges in
-deciding security preferences than the main process.
+process. Returning `false` cancels the window, while returning an object sets
+the `BrowserWindowConstructorOptions` used when creating the window. Note that
+this is more powerful than passing options through the feature string, as the
+renderer has more limited privileges in deciding security preferences than the
+main process.
+
+### `BrowserWindowProxy` example
+
+```javascript
+
+// main.js
+const mainWindow = new BrowserWindow()
+
+mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+  if (url.startsWith('https://github.com/')) {
+    return { action: 'allow' }
+  }
+  return { action: 'deny' }
+})
+
+mainWindow.webContents.on('did-create-window', (childWindow) => {
+  // For example...
+  childWindow.webContents.on('will-navigate', (e) => {
+    e.preventDefault()
+  })
+})
+```
+
+```javascript
+// renderer.js
+const windowProxy = window.open('https://github.com/', null, 'minimizable=false')
+windowProxy.postMessage('hi', '*')
+```
 
 ### Native `Window` example
 
 ```javascript
 // main.js
-const mainWindow = new BrowserWindow()
+const mainWindow = new BrowserWindow({
+  webPreferences: {
+    nativeWindowOpen: true
+  }
+})
 
 // In this example, only windows with the `about:blank` url will be created.
 // All other urls will be blocked.
@@ -104,34 +136,4 @@ mainWindow.webContents.setWindowOpenHandler(({ url }) => {
 // renderer process (mainWindow)
 const childWindow = window.open('', 'modal')
 childWindow.document.write('<h1>Hello</h1>')
-```
-
-### `BrowserWindowProxy` example
-
-```javascript
-
-// main.js
-const mainWindow = new BrowserWindow({
-  webPreferences: { nativeWindowOpen: false }
-})
-
-mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-  if (url.startsWith('https://github.com/')) {
-    return { action: 'allow' }
-  }
-  return { action: 'deny' }
-})
-
-mainWindow.webContents.on('did-create-window', (childWindow) => {
-  // For example...
-  childWindow.webContents.on('will-navigate', (e) => {
-    e.preventDefault()
-  })
-})
-```
-
-```javascript
-// renderer.js
-const windowProxy = window.open('https://github.com/', null, 'minimizable=false')
-windowProxy.postMessage('hi', '*')
 ```

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -43,16 +43,6 @@ ensure your code works with this property enabled.  It has been enabled by defau
 
 You will be affected by this change if you use either `webFrame.executeJavaScript` or `webFrame.executeJavaScriptInIsolatedWorld`. You will need to ensure that values returned by either of those methods are supported by the [Context Bridge API](api/context-bridge.md#parameter--error--return-type-support) as these methods use the same value passing semantics.
 
-### Default Changed: `nativeWindowOpen` defaults to `true`
-
-Prior to Electron 14, `window.open` was by default shimmed to use
-`BrowserWindowProxy`. This meant that `window.open('about:blank')` did not work
-to open synchronously scriptable child windows, among other incompatibilities.
-`nativeWindowOpen` is no longer experimental, and is now the default.
-
-See the documentation for [window.open in Electron](api/window-open.md)
-for more details.
-
 ### Removed: BrowserWindowConstructorOptions inheriting from parent windows
 
 Prior to Electron 14, windows opened with `window.open` would inherit

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -12,6 +12,18 @@ This document uses the following convention to categorize breaking changes:
 * **Deprecated:** An API was marked as deprecated. The API will continue to function, but will emit a deprecation warning, and will be removed in a future release.
 * **Removed:** An API or feature was removed, and is no longer supported by Electron.
 
+## Planned Breaking API Changes (15.0)
+
+### Default Changed: `nativeWindowOpen` defaults to `true`
+
+Prior to Electron 15, `window.open` was by default shimmed to use
+`BrowserWindowProxy`. This meant that `window.open('about:blank')` did not work
+to open synchronously scriptable child windows, among other incompatibilities.
+`nativeWindowOpen: true` is no longer experimental, and is now the default.
+
+See the documentation for [window.open in Electron](api/window-open.md)
+for more details.
+
 ## Planned Breaking API Changes (14.0)
 
 ### Removed: `app.allowRendererProcessReuse`

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -141,6 +141,15 @@ WebContentsPreferences::WebContentsPreferences(
   SetDefaultBoolIfUndefined(options::kDisableHtmlFullscreenWindowResize, false);
   SetDefaultBoolIfUndefined(options::kWebviewTag, false);
   SetDefaultBoolIfUndefined(options::kSandbox, false);
+  if (IsUndefined(options::kNativeWindowOpen)) {
+    node::Environment* env = node::Environment::GetCurrent(isolate);
+    EmitWarning(env,
+                "The default of nativeWindowOpen is deprecated and will be "
+                "changing from false to true in Electron 15.  "
+                "See https://github.com/electron/electron/issues/28511 for "
+                "more information.",
+                "electron");
+  }
   SetDefaultBoolIfUndefined(options::kNativeWindowOpen, false);
   SetDefaultBoolIfUndefined(options::kContextIsolation, true);
   SetDefaultBoolIfUndefined(options::kJavaScript, true);

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -141,7 +141,7 @@ WebContentsPreferences::WebContentsPreferences(
   SetDefaultBoolIfUndefined(options::kDisableHtmlFullscreenWindowResize, false);
   SetDefaultBoolIfUndefined(options::kWebviewTag, false);
   SetDefaultBoolIfUndefined(options::kSandbox, false);
-  SetDefaultBoolIfUndefined(options::kNativeWindowOpen, true);
+  SetDefaultBoolIfUndefined(options::kNativeWindowOpen, false);
   SetDefaultBoolIfUndefined(options::kContextIsolation, true);
   SetDefaultBoolIfUndefined(options::kJavaScript, true);
   SetDefaultBoolIfUndefined(options::kImages, true);
@@ -467,7 +467,7 @@ void WebContentsPreferences::OverrideWebkitPrefs(
   GetPreloadPath(&prefs->preload);
 
   // Check if nativeWindowOpen is enabled.
-  prefs->native_window_open = IsEnabled(options::kNativeWindowOpen, true);
+  prefs->native_window_open = IsEnabled(options::kNativeWindowOpen);
 
   // Check if we have node integration specified.
   prefs->node_integration = IsEnabled(options::kNodeIntegration);

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -3115,7 +3115,19 @@ describe('BrowserWindow module', () => {
       expect(url).to.equal('http://example.com/test');
       expect(frameName).to.equal('');
       expect(disposition).to.equal('foreground-tab');
-      expect(options).to.be.an('object').not.null();
+      expect(options).to.deep.equal({
+        show: true,
+        width: 800,
+        height: 600,
+        webPreferences: {
+          contextIsolation: true,
+          nodeIntegration: false,
+          webviewTag: false,
+          nodeIntegrationInSubFrames: false,
+          openerId: options.webPreferences!.openerId
+        },
+        webContents: undefined
+      });
       expect(referrer.policy).to.equal('strict-origin-when-cross-origin');
       expect(referrer.url).to.equal('');
       expect(additionalFeatures).to.deep.equal([]);

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -781,9 +781,7 @@ describe('chromium features', () => {
     }
 
     it('disables node integration when it is disabled on the parent window for chrome devtools URLs', async () => {
-      // NB. webSecurity is disabled because native window.open() is not
-      // allowed to load devtools:// URLs.
-      const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, webSecurity: false } });
+      const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true } });
       w.loadURL('about:blank');
       w.webContents.executeJavaScript(`
         { b = window.open('devtools://devtools/bundled/inspector.html', '', 'nodeIntegration=no,show=no'); null }
@@ -794,8 +792,8 @@ describe('chromium features', () => {
     });
 
     it('disables JavaScript when it is disabled on the parent window', async () => {
-      const w = new BrowserWindow({ show: true, webPreferences: { nodeIntegration: true } });
-      w.webContents.loadFile(path.resolve(__dirname, 'fixtures', 'blank.html'));
+      const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true } });
+      w.webContents.loadURL('about:blank');
       const windowUrl = require('url').format({
         pathname: `${fixturesPath}/pages/window-no-javascript.html`,
         protocol: 'file',
@@ -822,7 +820,7 @@ describe('chromium features', () => {
         targetURL = `file://${fixturesPath}/pages/base-page.html`;
       }
       const w = new BrowserWindow({ show: false });
-      w.webContents.loadFile(path.resolve(__dirname, 'fixtures', 'blank.html'));
+      w.loadURL('about:blank');
       w.webContents.executeJavaScript(`{ b = window.open(${JSON.stringify(targetURL)}); null }`);
       const [, window] = await emittedOnce(app, 'browser-window-created');
       await emittedOnce(window.webContents, 'did-finish-load');
@@ -831,7 +829,7 @@ describe('chromium features', () => {
 
     it('defines a window.location setter', async () => {
       const w = new BrowserWindow({ show: false });
-      w.webContents.loadFile(path.resolve(__dirname, 'fixtures', 'blank.html'));
+      w.loadURL('about:blank');
       w.webContents.executeJavaScript('{ b = window.open("about:blank"); null }');
       const [, { webContents }] = await emittedOnce(app, 'browser-window-created');
       await emittedOnce(webContents, 'did-finish-load');
@@ -842,7 +840,7 @@ describe('chromium features', () => {
 
     it('defines a window.location.href setter', async () => {
       const w = new BrowserWindow({ show: false });
-      w.webContents.loadFile(path.resolve(__dirname, 'fixtures', 'blank.html'));
+      w.loadURL('about:blank');
       w.webContents.executeJavaScript('{ b = window.open("about:blank"); null }');
       const [, { webContents }] = await emittedOnce(app, 'browser-window-created');
       await emittedOnce(webContents, 'did-finish-load');
@@ -1074,7 +1072,7 @@ describe('chromium features', () => {
           // We are testing whether context (3) can access context (2) under various conditions.
 
           // This is context (1), the base window for the test.
-          const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, webviewTag: true, contextIsolation: false, nativeWindowOpen: false } });
+          const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, webviewTag: true, contextIsolation: false } });
           await w.loadURL('about:blank');
 
           const parentCode = `new Promise((resolve) => {

--- a/spec-main/fixtures/snapshots/proxy-window-open.snapshot.txt
+++ b/spec-main/fixtures/snapshots/proxy-window-open.snapshot.txt
@@ -2,7 +2,9 @@
   [
     "top=5,left=10,resizable=no",
     {
-      "sender": "[WebContents]"
+      "sender": "[WebContents]",
+      "frameId": 1,
+      "processId": "placeholder-process-id"
     },
     "about:blank",
     "frame-name",
@@ -18,11 +20,10 @@
       "y": 5,
       "webPreferences": {
         "contextIsolation": true,
-        "nativeWindowOpen": true,
         "nodeIntegration": false,
         "webviewTag": false,
         "nodeIntegrationInSubFrames": false,
-        "openerId": null
+        "openerId": "placeholder-opener-id"
       },
       "webContents": "[WebContents]"
     },
@@ -36,7 +37,9 @@
   [
     "zoomFactor=2,resizable=0,x=0,y=10",
     {
-      "sender": "[WebContents]"
+      "sender": "[WebContents]",
+      "frameId": 1,
+      "processId": "placeholder-process-id"
     },
     "about:blank",
     "frame-name",
@@ -51,11 +54,10 @@
       "webPreferences": {
         "zoomFactor": "2",
         "contextIsolation": true,
-        "nativeWindowOpen": true,
         "nodeIntegration": false,
         "webviewTag": false,
         "nodeIntegrationInSubFrames": false,
-        "openerId": null
+        "openerId": "placeholder-opener-id"
       },
       "webContents": "[WebContents]"
     },
@@ -69,7 +71,9 @@
   [
     "backgroundColor=gray,webPreferences=0,x=100,y=100",
     {
-      "sender": "[WebContents]"
+      "sender": "[WebContents]",
+      "frameId": 1,
+      "processId": "placeholder-process-id"
     },
     "about:blank",
     "frame-name",
@@ -81,11 +85,10 @@
       "backgroundColor": "gray",
       "webPreferences": {
         "contextIsolation": true,
-        "nativeWindowOpen": true,
         "nodeIntegration": false,
         "webviewTag": false,
         "nodeIntegrationInSubFrames": false,
-        "openerId": null,
+        "openerId": "placeholder-opener-id",
         "backgroundColor": "gray"
       },
       "x": 100,
@@ -102,7 +105,9 @@
   [
     "x=50,y=20,title=sup",
     {
-      "sender": "[WebContents]"
+      "sender": "[WebContents]",
+      "frameId": 1,
+      "processId": "placeholder-process-id"
     },
     "about:blank",
     "frame-name",
@@ -116,11 +121,10 @@
       "title": "sup",
       "webPreferences": {
         "contextIsolation": true,
-        "nativeWindowOpen": true,
         "nodeIntegration": false,
         "webviewTag": false,
         "nodeIntegrationInSubFrames": false,
-        "openerId": null
+        "openerId": "placeholder-opener-id"
       },
       "webContents": "[WebContents]"
     },
@@ -134,7 +138,9 @@
   [
     "show=false,top=1,left=1",
     {
-      "sender": "[WebContents]"
+      "sender": "[WebContents]",
+      "frameId": 1,
+      "processId": "placeholder-process-id"
     },
     "about:blank",
     "frame-name",
@@ -149,11 +155,10 @@
       "y": 1,
       "webPreferences": {
         "contextIsolation": true,
-        "nativeWindowOpen": true,
         "nodeIntegration": false,
         "webviewTag": false,
         "nodeIntegrationInSubFrames": false,
-        "openerId": null
+        "openerId": "placeholder-opener-id"
       },
       "webContents": "[WebContents]"
     },

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -109,8 +109,7 @@ app.whenReady().then(async function () {
       backgroundThrottling: false,
       nodeIntegration: true,
       webviewTag: true,
-      contextIsolation: false,
-      nativeWindowOpen: false
+      contextIsolation: false
     }
   });
   window.loadFile('static/index.html', {

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -501,8 +501,7 @@ describe('<webview> tag', function () {
   describe('new-window event', () => {
     it('emits when window.open is called', async () => {
       loadWebView(webview, {
-        src: `file://${fixtures}/pages/window-open.html`,
-        allowpopups: true
+        src: `file://${fixtures}/pages/window-open.html`
       });
       const { url, frameName } = await waitForEvent(webview, 'new-window');
 
@@ -512,8 +511,7 @@ describe('<webview> tag', function () {
 
     it('emits when link with target is called', async () => {
       loadWebView(webview, {
-        src: `file://${fixtures}/pages/target-name.html`,
-        allowpopups: true
+        src: `file://${fixtures}/pages/target-name.html`
       });
       const { url, frameName } = await waitForEvent(webview, 'new-window');
 


### PR DESCRIPTION
#### Description of Change
This reverts #28552, instead warning of the upcoming default change. The
default change will occur instead in 15.x.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Undo the `nativeWindowOpen` default change; delayed until 15.x.
