### PR TITLE
fix: crash when clicking links with target=_blank from webview

### DIFF
--- a/spec-main/webview-spec.ts
+++ b/spec-main/webview-spec.ts
@@ -488,6 +488,15 @@ describe('<webview> tag', function () {
 
       await webContentsCreated;
     });
+
+    it('does not crash when creating window with noopener', async () => {
+      loadWebView(w.webContents, {
+        allowpopups: 'on',
+        webpreferences: 'nativeWindowOpen=1',
+        src: `file://${path.join(fixtures, 'api', 'native-window-open-noopener.html')}`
+      });
+      await emittedOnce(app, 'browser-window-created');
+    });
   });
 
   describe('webpreferences attribute', () => {

--- a/spec/fixtures/api/native-window-open-noopener.html
+++ b/spec/fixtures/api/native-window-open-noopener.html
@@ -1,0 +1,10 @@
+<html>
+<body>
+<a href="blank.html" target="_blank">noopener example</a>
+</body>
+<script type="text/javascript" charset="utf-8">
+window.onload = () => {
+    document.querySelector('a').click()
+}
+</script>
+</html>


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/28348

When running the test case in debug build, it will be seen that `RWHV::SetActive` call fails because it tries to access an interface [blink::FrameWidget](https://source.chromium.org/chromium/chromium/src/+/main:content/browser/renderer_host/render_widget_host_impl.cc;l=1301) that is not bound.

The interface usually gets bound when `RenderView` gets created during navigation

```
RenderWidgetHostImpl::BindAndGenerateCreateFrameWidgetParams
RenderViewHostImpl::CreateRenderView
WebContentsImpl::CreateRenderViewForRenderManager
RenderFrameHostManager::InitRenderView
```

When starting with window.opener suppressed, `WebViewGuestDelegate::CreateNewGuestWindow` created NSView for page which is going to be navigated [immediately](https://source.chromium.org/chromium/chromium/src/+/main:content/browser/web_contents/web_contents_impl.cc;l=3846-3861). Since the view was setup, it was receiving the events from the UI loop that led to the above crash.

This change removes the eager widget creation call for this case and lets chromium handle it as expected.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix crash when clicking links with `target=_blank` from webview