### PR TITLE
chore: add logging for print_backend failures

### DIFF
--- a/shell/browser/api/electron_api_printing.cc
+++ b/shell/browser/api/electron_api_printing.cc
@@ -47,7 +47,10 @@ printing::PrinterList GetPrinterList() {
     // TODO(deepak1556): Deprecate this api in favor of an
     // async version and post a non blocing task call.
     base::ThreadRestrictions::ScopedAllowIO allow_io;
-    print_backend->EnumeratePrinters(&printers);
+    printing::mojom::ResultCode code =
+        print_backend->EnumeratePrinters(&printers);
+    if (code != printing::mojom::ResultCode::kSuccess)
+      LOG(INFO) << "Failed to enumerate printers";
   }
   return printers;
 }

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -424,7 +424,7 @@ bool IsDeviceNameValid(const std::u16string& device_name) {
 #endif
 }
 
-std::u16string GetDefaultPrinterAsync() {
+std::pair<std::string, std::u16string> GetDefaultPrinterAsync() {
 #if defined(OS_WIN)
   // Blocking is needed here because Windows printer drivers are oftentimes
   // not thread-safe and have to be accessed on the UI thread.
@@ -435,18 +435,25 @@ std::u16string GetDefaultPrinterAsync() {
       printing::PrintBackend::CreateInstance(
           g_browser_process->GetApplicationLocale());
   std::string printer_name;
-  print_backend->GetDefaultPrinterName(printer_name);
+  printing::mojom::ResultCode code =
+      print_backend->GetDefaultPrinterName(printer_name);
 
-  // Some devices won't have a default printer, so we should
-  // also check for existing printers and pick the first
-  // one should it exist.
+  // We don't want to return if this fails since some devices won't have a
+  // default printer.
+  if (code != printing::mojom::ResultCode::kSuccess)
+    LOG(ERROR) << "Failed to get default printer name";
+
+  // Check for existing printers and pick the first one should it exist.
   if (printer_name.empty()) {
     printing::PrinterList printers;
-    print_backend->EnumeratePrinters(&printers);
+    if (print_backend->EnumeratePrinters(&printers) !=
+        printing::mojom::ResultCode::kSuccess)
+      return std::make_pair("Failed to enumerate printers", std::u16string());
     if (!printers.empty())
       printer_name = printers.front().printer_name;
   }
-  return base::UTF8ToUTF16(printer_name);
+
+  return std::make_pair(std::string(), base::UTF8ToUTF16(printer_name));
 }
 
 // Copied from
@@ -2435,7 +2442,8 @@ void WebContents::OnGetDefaultPrinter(
     printing::CompletionCallback print_callback,
     std::u16string device_name,
     bool silent,
-    std::u16string default_printer) {
+    // <error, default_printer>
+    std::pair<std::string, std::u16string> info) {
   // The content::WebContents might be already deleted at this point, and the
   // PrintViewManagerElectron class does not do null check.
   if (!web_contents()) {
@@ -2444,8 +2452,14 @@ void WebContents::OnGetDefaultPrinter(
     return;
   }
 
-  std::u16string printer_name =
-      device_name.empty() ? default_printer : device_name;
+  if (!info.first.empty()) {
+    if (print_callback)
+      std::move(print_callback).Run(false, info.first);
+    return;
+  }
+
+  // If the user has passed a deviceName use it, otherwise use default printer.
+  std::u16string printer_name = device_name.empty() ? info.second : device_name;
 
   // If there are no valid printers available on the network, we bail.
   if (printer_name.empty() || !IsDeviceNameValid(printer_name)) {

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -221,7 +221,8 @@ class WebContents : public gin::Wrappable<WebContents>,
                            printing::CompletionCallback print_callback,
                            std::u16string device_name,
                            bool silent,
-                           std::u16string default_printer);
+                           // <error, default_printer_name>
+                           std::pair<std::string, std::u16string> info);
   void Print(gin::Arguments* args);
   // Print current page as PDF.
   v8::Local<v8::Promise> PrintToPDF(base::DictionaryValue settings);


### PR DESCRIPTION
#### Description of Change

Refs:
- https://chromium-review.googlesource.com/c/chromium/src/+/2796126
- https://chromium-review.googlesource.com/c/chromium/src/+/2932396

Chromium recently added the ability to  distinguish between no printer(s) and a query failure. I don't think a failure to enumerate printers should result in a user-facing error, but we should at least log this nuance instead of dropping it on the ground.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
