### PR TITLE
chore: remove unused using and namespace declarations

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -513,7 +513,6 @@ v8::Local<v8::Value> BrowserWindow::From(v8::Isolate* isolate,
 
 namespace {
 
-using electron::api::BaseWindow;
 using electron::api::BrowserWindow;
 
 void Initialize(v8::Local<v8::Object> exports,

--- a/shell/browser/api/electron_api_cookies.cc
+++ b/shell/browser/api/electron_api_cookies.cc
@@ -26,8 +26,6 @@
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/object_template_builder.h"
 
-using content::BrowserThread;
-
 namespace gin {
 
 template <>

--- a/shell/browser/api/electron_api_menu_mac.mm
+++ b/shell/browser/api/electron_api_menu_mac.mm
@@ -18,8 +18,6 @@
 #include "shell/browser/unresponsive_suppressor.h"
 #include "shell/common/node_includes.h"
 
-using content::BrowserThread;
-
 namespace {
 
 static scoped_nsobject<NSMenu> applicationMenu_;

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -1205,9 +1205,6 @@ const char* Session::GetTypeName() {
 
 namespace {
 
-using electron::api::Cookies;
-using electron::api::Protocol;
-using electron::api::ServiceWorkerContext;
 using electron::api::Session;
 
 v8::Local<v8::Value> FromPartition(const std::string& partition,

--- a/shell/browser/electron_browser_main_parts_posix.cc
+++ b/shell/browser/electron_browser_main_parts_posix.cc
@@ -19,8 +19,6 @@
 #include "content/public/browser/browser_thread.h"
 #include "shell/browser/browser.h"
 
-using content::BrowserThread;
-
 namespace electron {
 
 namespace {

--- a/shell/common/extensions/electron_extensions_api_provider.cc
+++ b/shell/common/extensions/electron_extensions_api_provider.cc
@@ -27,9 +27,6 @@
 
 namespace extensions {
 
-namespace keys = manifest_keys;
-namespace errors = manifest_errors;
-
 constexpr APIPermissionInfo::InitInfo permissions_to_register[] = {
     {mojom::APIPermissionID::kDevtools, "devtools",
      APIPermissionInfo::kFlagImpliesFullURLAccess |

--- a/shell/renderer/extensions/electron_extensions_dispatcher_delegate.cc
+++ b/shell/renderer/extensions/electron_extensions_dispatcher_delegate.cc
@@ -16,8 +16,6 @@
 #include "extensions/renderer/native_extension_bindings_system.h"
 #include "extensions/renderer/native_handler.h"
 
-using extensions::NativeHandler;
-
 ElectronExtensionsDispatcherDelegate::ElectronExtensionsDispatcherDelegate() =
     default;
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Trims some unused namespace and using declarations, as suggested by `clang-tidy`'s `misc-unused-using-decls` and `misc-unused-alias-decls` checks.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
