### PR TITLE
chore: cleanup usages of const char*

### DIFF
--- a/shell/app/electron_main.cc
+++ b/shell/app/electron_main.cc
@@ -116,7 +116,7 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
 
 #ifdef _DEBUG
   // Don't display assert dialog boxes in CI test runs
-  static const char* kCI = "CI";
+  static const char kCI[] = "CI";
   if (IsEnvSet(kCI)) {
     _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_DEBUG | _CRTDBG_MODE_FILE);
     _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);

--- a/shell/app/electron_main_delegate.cc
+++ b/shell/app/electron_main_delegate.cc
@@ -70,7 +70,7 @@ namespace electron {
 
 namespace {
 
-const char* kRelauncherProcess = "relauncher";
+const char kRelauncherProcess[] = "relauncher";
 
 constexpr base::StringPiece kElectronDisableSandbox("ELECTRON_DISABLE_SANDBOX");
 constexpr base::StringPiece kElectronEnableStackDumping(

--- a/shell/browser/api/electron_api_protocol.cc
+++ b/shell/browser/api/electron_api_protocol.cc
@@ -162,7 +162,7 @@ void RegisterSchemesAsPrivileged(gin_helper::ErrorThrower thrower,
 
 namespace {
 
-const char* kBuiltinSchemes[] = {
+const char* const kBuiltinSchemes[] = {
     "about", "file", "http", "https", "data", "filesystem",
 };
 

--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -84,7 +84,7 @@ namespace api {
 
 namespace {
 
-const char* kUserDataKey = "WebRequest";
+const char kUserDataKey[] = "WebRequest";
 
 // BrowserContext <=> WebRequest relationship.
 struct UserData : public base::SupportsUserData::Data {

--- a/shell/browser/api/gpu_info_enumerator.h
+++ b/shell/browser/api/gpu_info_enumerator.h
@@ -17,15 +17,15 @@ namespace electron {
 // This class implements the enumerator for reading all the attributes in
 // GPUInfo into a dictionary.
 class GPUInfoEnumerator final : public gpu::GPUInfo::Enumerator {
-  const char* kGPUDeviceKey = "gpuDevice";
-  const char* kVideoDecodeAcceleratorSupportedProfileKey =
+  const char* const kGPUDeviceKey = "gpuDevice";
+  const char* const kVideoDecodeAcceleratorSupportedProfileKey =
       "videoDecodeAcceleratorSupportedProfile";
-  const char* kVideoEncodeAcceleratorSupportedProfileKey =
+  const char* const kVideoEncodeAcceleratorSupportedProfileKey =
       "videoEncodeAcceleratorSupportedProfile";
-  const char* kImageDecodeAcceleratorSupportedProfileKey =
+  const char* const kImageDecodeAcceleratorSupportedProfileKey =
       "imageDecodeAcceleratorSupportedProfile";
-  const char* kAuxAttributesKey = "auxAttributes";
-  const char* kOverlayInfo = "overlayInfo";
+  const char* const kAuxAttributesKey = "auxAttributes";
+  const char* const kOverlayInfo = "overlayInfo";
 
  public:
   GPUInfoEnumerator();

--- a/shell/common/gin_helper/trackable_object.cc
+++ b/shell/common/gin_helper/trackable_object.cc
@@ -15,7 +15,7 @@ namespace gin_helper {
 
 namespace {
 
-const char* kTrackedObjectKey = "TrackedObjectKey";
+const char kTrackedObjectKey[] = "TrackedObjectKey";
 
 class IDUserData : public base::SupportsUserData::Data {
  public:

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -41,11 +41,10 @@ namespace api {
 
 namespace context_bridge {
 
-const char* const kProxyFunctionPrivateKey = "electron_contextBridge_proxy_fn";
-const char* const kSupportsDynamicPropertiesPrivateKey =
+const char kProxyFunctionPrivateKey[] = "electron_contextBridge_proxy_fn";
+const char kSupportsDynamicPropertiesPrivateKey[] =
     "electron_contextBridge_supportsDynamicProperties";
-const char* const kOriginalFunctionPrivateKey =
-    "electron_contextBridge_original_fn";
+const char kOriginalFunctionPrivateKey[] = "electron_contextBridge_original_fn";
 
 }  // namespace context_bridge
 
@@ -439,7 +438,7 @@ void ProxyFunctionWrapper(const v8::FunctionCallbackInfo<v8::Value>& info) {
         did_error = true;
         v8::Local<v8::Value> exception = try_catch.Exception();
 
-        const char* err_msg =
+        const char err_msg[] =
             "An unknown exception occurred in the isolated context, an error "
             "occurred but a valid exception was not thrown.";
 

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -211,7 +211,7 @@ class ScriptExecutionCallback : public blink::WebScriptExecutionCallback {
           promise_.Resolve(value);
         }
       } else {
-        const char* error_message =
+        const char error_message[] =
             "Script failed to execute, this normally means an error "
             "was thrown. Check the renderer console for the error.";
         if (!callback_.is_null()) {
@@ -226,7 +226,7 @@ class ScriptExecutionCallback : public blink::WebScriptExecutionCallback {
         promise_.RejectWithErrorMessage(error_message);
       }
     } else {
-      const char* error_message =
+      const char error_message[] =
           "WebFrame was removed before script could run. This normally means "
           "the underlying frame was destroyed";
       if (!callback_.is_null()) {
@@ -705,7 +705,7 @@ class WebFrameRenderer : public gin::Wrappable<WebFrameRenderer>,
       script.Get("startLine", &start_line);
 
       if (!script.Get("code", &code)) {
-        const char* error_message = "Invalid 'code'";
+        const char error_message[] = "Invalid 'code'";
         if (!completion_callback.is_null()) {
           std::move(completion_callback)
               .Run(v8::Undefined(isolate),


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Most of the time you just `const char*` is not what you want, for constant strings. More discussion [can be found here](https://groups.google.com/a/chromium.org/g/chromium-dev/c/iyjW0-fXT9A/m/20v1n0eWtFMJ).

For consistency, favor `const char ...[]` over `const char* const` for defining a string constant. The constants in `GPUInfoEnumerator` are an exception I've made here, as they're member variables and wouldn't otherwise compile as `const char ...[]`. They should probably be made static or moved outside of the class, but I decided that was outside the scope of this PR.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
