### PR TITLE
docs: remove requestHeaders in webRequest.onHeadersReceived

### DIFF
--- a/docs/api/web-request.md
+++ b/docs/api/web-request.md
@@ -155,7 +155,6 @@ response are visible by the time this listener is fired.
     * `timestamp` Double
     * `statusLine` String
     * `statusCode` Integer
-    * `requestHeaders` Record<string, string>
     * `responseHeaders` Record<string, string[]> (optional)
   * `callback` Function
     * `headersReceivedResponse` Object


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Closes #28287.

Per discussion with @zcbenz, since it doesn't look like this has ever worked (the original bug goes back to 8.2.2 and I tested back to 6 as well), just update the documentation to reflect this reality. This is also consistent with `chrome.webRequest.onHeadersReceived` which does not provide `requestHeaders`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
