### PR TITLE
fix: geolocation crashes electron on macOS

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -882,7 +882,13 @@ ElectronBrowserClient::GetSystemNetworkContext() {
 std::unique_ptr<content::BrowserMainParts>
 ElectronBrowserClient::CreateBrowserMainParts(
     const content::MainFunctionParams& params) {
-  return std::make_unique<ElectronBrowserMainParts>(params);
+  auto browser_main_parts = std::make_unique<ElectronBrowserMainParts>(params);
+
+#if defined(OS_MAC)
+  browser_main_parts_ = browser_main_parts.get();
+#endif
+
+  return browser_main_parts;
 }
 
 void ElectronBrowserClient::WebNotificationAllowed(
@@ -1616,6 +1622,14 @@ void ElectronBrowserClient::RegisterBrowserInterfaceBindersForServiceWorker(
         map) {
   map->Add<blink::mojom::BadgeService>(
       base::BindRepeating(&BindBadgeServiceForServiceWorker));
+}
+
+device::GeolocationManager* ElectronBrowserClient::GetGeolocationManager() {
+#if defined(OS_MAC)
+  return browser_main_parts_->GetGeolocationManager();
+#else
+  return nullptr;
+#endif
 }
 
 }  // namespace electron

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -34,6 +34,7 @@ class SSLCertRequestInfo;
 
 namespace electron {
 
+class ElectronBrowserMainParts;
 class NotificationPresenter;
 class PlatformNotificationService;
 
@@ -87,6 +88,8 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
   content::SerialDelegate* GetSerialDelegate() override;
 
   content::BluetoothDelegate* GetBluetoothDelegate() override;
+
+  device::GeolocationManager* GetGeolocationManager() override;
 
  protected:
   void RenderProcessWillLaunch(content::RenderProcessHost* host) override;
@@ -298,6 +301,10 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
 
   std::unique_ptr<ElectronSerialDelegate> serial_delegate_;
   std::unique_ptr<ElectronBluetoothDelegate> bluetooth_delegate_;
+
+#if defined(OS_MAC)
+  ElectronBrowserMainParts* browser_main_parts_ = nullptr;
+#endif
 
   DISALLOW_COPY_AND_ASSIGN(ElectronBrowserClient);
 };

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -93,6 +93,7 @@
 #endif
 
 #if defined(OS_MAC)
+#include "services/device/public/cpp/geolocation/geolocation_manager.h"
 #include "shell/browser/ui/cocoa/views_delegate_mac.h"
 #else
 #include "shell/browser/ui/views/electron_views_delegate.h"
@@ -552,6 +553,12 @@ ElectronBrowserMainParts::GetGeolocationControl() {
   }
   return geolocation_control_.get();
 }
+
+#if defined(OS_MAC)
+device::GeolocationManager* ElectronBrowserMainParts::GetGeolocationManager() {
+  return geolocation_manager_.get();
+}
+#endif
 
 IconManager* ElectronBrowserMainParts::GetIconManager() {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -39,6 +39,10 @@ class GtkUiPlatform;
 }
 #endif
 
+namespace device {
+class GeolocationManager;
+}  // namespace device
+
 namespace electron {
 
 class ElectronBrowserContext;
@@ -82,6 +86,10 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   // Returns the connection to GeolocationControl which can be
   // used to enable the location services once per client.
   device::mojom::GeolocationControl* GetGeolocationControl();
+
+#if defined(OS_MAC)
+  device::GeolocationManager* GetGeolocationManager();
+#endif
 
   // Returns handle to the class responsible for extracting file icons.
   IconManager* GetIconManager();
@@ -160,6 +168,10 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
 #endif
 
   mojo::Remote<device::mojom::GeolocationControl> geolocation_control_;
+
+#if defined(OS_MAC)
+  std::unique_ptr<device::GeolocationManager> geolocation_manager_;
+#endif
 
   static ElectronBrowserMainParts* self_;
 

--- a/shell/browser/electron_browser_main_parts_mac.mm
+++ b/shell/browser/electron_browser_main_parts_mac.mm
@@ -7,6 +7,7 @@
 #include "base/mac/bundle_locations.h"
 #include "base/mac/foundation_util.h"
 #include "base/path_service.h"
+#include "services/device/public/cpp/geolocation/geolocation_manager_impl_mac.h"
 #import "shell/browser/mac/electron_application.h"
 #include "shell/browser/mac/electron_application_delegate.h"
 #include "shell/common/electron_paths.h"
@@ -27,6 +28,8 @@ void ElectronBrowserMainParts::PreCreateMainMessageLoop() {
   [[NSUserDefaults standardUserDefaults]
       setObject:@"NO"
          forKey:@"NSTreatUnknownArgumentsAsOpen"];
+
+  geolocation_manager_ = device::GeolocationManagerImpl::Create();
 }
 
 void ElectronBrowserMainParts::FreeAppDelegate() {


### PR DESCRIPTION
#### Description of Change

Geolocation was crashing in Release builds with a backtrace that seemed to implicate WASM SIMD.

```
$ lldb --debug ./Electron.app/Contents/MacOS/Electron 
(lldb) target create "./Electron.app/Contents/MacOS/Electron"
Current executable set to '/Users/omar/Downloads/electron-v13/Electron.app/Contents/MacOS/Electron' (x86_64).
(lldb) r https://www.google.com/
Process 67072 launched: '/Users/omar/Downloads/electron-v13/Electron.app/Contents/MacOS/Electron' (x86_64)
2021-06-27 10:10:30.780668-0700 Electron[67072:11102508] +[MTLIOAccelDevice registerDevices]: Zero Metal services found
Process 67072 stopped
* thread #39, name = 'Geolocation', stop reason = EXC_BAD_ACCESS (code=1, address=0x8)
    frame #0: 0x0000000106a8e3e4 Electron Framework`___lldb_unnamed_symbol4$$Electron Framework + 53326868
Electron Framework`v8::internal::compiler::GetI32WasmCallDescriptorForSimd:
->  0x106a8e3e4 <+40987940>: movq   0x8(%rdi), %rax
    0x106a8e3e8 <+40987944>: testq  %rax, %rax
    0x106a8e3eb <+40987947>: je     0x106a8e3f1               ; <+40987953>
    0x106a8e3ed <+40987949>: lock   
Target 0: (Electron) stopped.
(lldb) bt
* thread #39, name = 'Geolocation', stop reason = EXC_BAD_ACCESS (code=1, address=0x8)
  * frame #0: 0x0000000106a8e3e4 Electron Framework`___lldb_unnamed_symbol4$$Electron Framework + 53326868
    frame #1: 0x00000001037af356 Electron Framework`node::SetTracingController(v8::TracingController*) + 1008182
    frame #2: 0x000000010480ce19 Electron Framework`v8::internal::compiler::GetI32WasmCallDescriptorForSimd(v8::internal::Zone*, v8::internal::compiler::CallDescriptor*) + 4806489
    frame #3: 0x000000010480a952 Electron Framework`v8::internal::compiler::GetI32WasmCallDescriptorForSimd(v8::internal::Zone*, v8::internal::compiler::CallDescriptor*) + 4797074
    frame #4: 0x000000010185ee95 Electron Framework`v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) + 7115717
    frame #5: 0x000000010480a636 Electron Framework`v8::internal::compiler::GetI32WasmCallDescriptorForSimd(v8::internal::Zone*, v8::internal::compiler::CallDescriptor*) + 4796278
    frame #6: 0x0000000101aed0fc Electron Framework`v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) + 9795116
    frame #7: 0x0000000101b053d6 Electron Framework`v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) + 9894150
    frame #8: 0x0000000101b3d3e0 Electron Framework`v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) + 10123536
    frame #9: 0x0000000101b399c2 Electron Framework`v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) + 10108658
    frame #10: 0x0000000101b3cbff Electron Framework`v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) + 10121519
    frame #11: 0x00007fff204626dc CoreFoundation`__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 17
    frame #12: 0x00007fff20462644 CoreFoundation`__CFRunLoopDoSource0 + 180
    frame #13: 0x00007fff204623ba CoreFoundation`__CFRunLoopDoSources0 + 242
    frame #14: 0x00007fff20460dc8 CoreFoundation`__CFRunLoopRun + 897
    frame #15: 0x00007fff20460380 CoreFoundation`CFRunLoopRunSpecific + 567
    frame #16: 0x00007fff21118647 Foundation`-[NSRunLoop(NSRunLoop) runMode:beforeDate:] + 212
    frame #17: 0x0000000101b3d9d9 Electron Framework`v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) + 10125065
    frame #18: 0x0000000101b3c6db Electron Framework`v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) + 10120203
    frame #19: 0x0000000101b067af Electron Framework`v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) + 9899231
    frame #20: 0x0000000101ad8e0c Electron Framework`v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) + 9712444
    frame #21: 0x0000000101b231c8 Electron Framework`v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) + 10016504
    frame #22: 0x0000000101b233c7 Electron Framework`v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) + 10017015
    frame #23: 0x0000000101b380d8 Electron Framework`v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) + 10102280
    frame #24: 0x00007fff203698fc libsystem_pthread.dylib`_pthread_start + 224
    frame #25: 0x00007fff20365443 libsystem_pthread.dylib`thread_start + 15
(lldb) 
```

And because Chrome 91 enabled WASM SIMD by default and the crash occurred between 13.0.0-beta13 and 13.0.0-beta14 (https://github.com/electron/electron/commit/66a22187233edbf33030d69458975531852fc858#diff-42a9b04f836798e53829385d847f016f600b92336c532d9c7f7a18acc4937d26L118), it seemed to be the culprit and sort of lead me down the wrong path.

However, when dSYMs were available and loaded into lldb, it was able to produce a real backtrace:

```
$ lldb --debug ./Electron.app/Contents/MacOS/Electron 
(lldb) target create "./Electron.app/Contents/MacOS/Electron"
Current executable set to '/Users/omar/Downloads/electron-v13/Electron.app/Contents/MacOS/Electron' (x86_64).
(lldb) add-dsym Electron.dSYM
symbol file '/Users/omar/Downloads/electron-v13/Electron.dSYM/Contents/Resources/DWARF/Electron' has been added to '/Users/omar/Downloads/electron-v13/Electron.app/Contents/MacOS/Electron'
(lldb) add-dsym Electron\ Framework.dSYM
symbol file '/Users/omar/Downloads/electron-v13/Electron Framework.dSYM/Contents/Resources/DWARF/Electron Framework' has been added to '/Users/omar/Downloads/electron-v13/Electron.app/Contents/Frameworks/Electron Framework.framework/Electron Framework'
(lldb) r https://www.google.com/
Process 69270 launched: '/Users/omar/Downloads/electron-v13/Electron.app/Contents/MacOS/Electron' (x86_64)
2021-06-27 10:12:53.149980-0700 Electron[69270:11119528] +[MTLIOAccelDevice registerDevices]: Zero Metal services found
Electron Framework was compiled with optimization - stepping may behave oddly; variables may not be available.
Process 69270 stopped
* thread #39, name = 'Geolocation', stop reason = EXC_BAD_ACCESS (code=1, address=0x8)
    frame #0: 0x0000000106a8e3e4 Electron Framework`device::GeolocationSystemPermissionManager::GetObserverList() [inlined] scoped_refptr<base::ObserverListThreadSafe<device::GeolocationSystemPermissionManager::GeolocationPermissionObserver> >::scoped_refptr(r=0x0000000000000008) at scoped_refptr.h:197:59 [opt]
Target 0: (Electron) stopped.
(lldb) bt
* thread #39, name = 'Geolocation', stop reason = EXC_BAD_ACCESS (code=1, address=0x8)
  * frame #0: 0x0000000106a8e3e4 Electron Framework`device::GeolocationSystemPermissionManager::GetObserverList() [inlined] scoped_refptr<base::ObserverListThreadSafe<device::GeolocationSystemPermissionManager::GeolocationPermissionObserver> >::scoped_refptr(r=0x0000000000000008) at scoped_refptr.h:197:59 [opt]
    frame #1: 0x0000000106a8e3e4 Electron Framework`device::GeolocationSystemPermissionManager::GetObserverList(this=0x0000000000000000) at geolocation_system_permission_mac.mm:97 [opt]
    frame #2: 0x000000010480ce19 Electron Framework`device::NetworkLocationProvider::NetworkLocationProvider(this=0x0000000109977ce0, url_loader_factory=<unavailable>, geolocation_system_permission_manager=0x0000000000000000, main_task_runner=const scoped_refptr<base::SingleThreadTaskRunner> @ 0x0000700016c35960, api_key=<unavailable>, position_cache=<unavailable>) at network_location_provider.cc:64:46 [opt]
    frame #3: 0x000000010480a952 Electron Framework`device::LocationArbitrator::NewNetworkLocationProvider(scoped_refptr<network::SharedURLLoaderFactory>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) [inlined] std::__1::__unique_if<device::NetworkLocationProvider>::__unique_single std::__1::make_unique<device::NetworkLocationProvider, scoped_refptr<network::SharedURLLoaderFactory>, device::GeolocationSystemPermissionManager*&, scoped_refptr<base::SingleThreadTaskRunner>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, device::PositionCache*>(__args=0x0000000109980ca0, __args=0x0000000109980ca8) at memory:2006:32 [opt]
    frame #4: 0x000000010480a922 Electron Framework`device::LocationArbitrator::NewNetworkLocationProvider(this=0x0000000109980c90, url_loader_factory=scoped_refptr<network::SharedURLLoaderFactory> @ scalar, api_key="") at location_arbitrator.cc:157 [opt]
    frame #5: 0x000000010185ee95 Electron Framework`device::LocationArbitrator::RegisterProviders(this=0x0000000109980c90) at location_arbitrator.cc:122:22 [opt]
    frame #6: 0x000000010480a636 Electron Framework`device::LocationArbitrator::StartProvider(this=0x0000000109980c90, enable_high_accuracy=<unavailable>) at location_arbitrator.cc:65:5 [opt]
    frame #7: 0x0000000101aed0fc Electron Framework`base::TaskAnnotator::RunTask(char const*, base::PendingTask*) [inlined] base::OnceCallback<void ()>::Run() && at callback.h:101:12 [opt]
    frame #8: 0x0000000101aed0da Electron Framework`base::TaskAnnotator::RunTask(this=<unavailable>, trace_event_name=<unavailable>, pending_task=0x000000011109a000) at task_annotator.cc:173 [opt]
    frame #9: 0x0000000101b053d6 Electron Framework`non-virtual thunk to base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() at thread_controller_with_message_pump_impl.cc:351:25 [opt]
    frame #10: 0x0000000101b04f8b Electron Framework`non-virtual thunk to base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() [inlined] base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork(this=0x0000000109eb4980) at thread_controller_with_message_pump_impl.cc:264 [opt]
    frame #11: 0x0000000101b04ee6 Electron Framework`non-virtual thunk to base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() at thread_controller_with_message_pump_impl.cc:0 [opt]
    frame #12: 0x0000000101b3d3e0 Electron Framework`invocation function for block in base::MessagePumpCFRunLoopBase::RunWorkSource(void*) [inlined] base::MessagePumpCFRunLoopBase::RunWork(this=0x0000000109971e20) at message_pump_mac.mm:384:54 [opt]
    frame #13: 0x0000000101b3d3b2 Electron Framework`invocation function for block in base::MessagePumpCFRunLoopBase::RunWorkSource(.block_descriptor=<unavailable>) at message_pump_mac.mm:361 [opt]
    frame #14: 0x0000000101b399c2 Electron Framework`v8::internal::SetupIsolateDelegate::SetupHeap(v8::internal::Heap*) + 10108658
    frame #15: 0x0000000101b3cbff Electron Framework`base::MessagePumpCFRunLoopBase::RunWorkSource(info=<unavailable>) at message_pump_mac.mm:360:3 [opt]
    frame #16: 0x00007fff204626dc CoreFoundation`__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 17
    frame #17: 0x00007fff20462644 CoreFoundation`__CFRunLoopDoSource0 + 180
    frame #18: 0x00007fff204623ba CoreFoundation`__CFRunLoopDoSources0 + 242
    frame #19: 0x00007fff20460dc8 CoreFoundation`__CFRunLoopRun + 897
    frame #20: 0x00007fff20460380 CoreFoundation`CFRunLoopRunSpecific + 567
    frame #21: 0x00007fff21118647 Foundation`-[NSRunLoop(NSRunLoop) runMode:beforeDate:] + 212
    frame #22: 0x0000000101b3d9d9 Electron Framework`base::MessagePumpNSRunLoop::DoRun(this=0x0000000109971e20, delegate=<unavailable>) at message_pump_mac.mm:630:5 [opt]
    frame #23: 0x0000000101b3c6db Electron Framework`base::MessagePumpCFRunLoopBase::Run(this=0x0000000109971e20, delegate=0x0000000109eb4980) at message_pump_mac.mm:157:3 [opt]
    frame #24: 0x0000000101b067af Electron Framework`base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(this=0x0000000109eb4980, application_tasks_allowed=true, timeout=<unavailable>) at thread_controller_with_message_pump_impl.cc:460:12 [opt]
    frame #25: 0x0000000101ad8e0c Electron Framework`base::RunLoop::Run(this=0x0000700016c36f30, location=<unavailable>) at run_loop.cc:133:14 [opt]
    frame #26: 0x0000000101b231c8 Electron Framework`base::Thread::Run(this=<unavailable>, run_loop=<unavailable>) at thread.cc:312:13 [opt]
    frame #27: 0x0000000101b233c7 Electron Framework`base::Thread::ThreadMain(this=0x0000000109ead3c0) at thread.cc:383:3 [opt]
    frame #28: 0x0000000101b380d8 Electron Framework`base::(anonymous namespace)::ThreadFunc(params=<unavailable>) at platform_thread_posix.cc:87:13 [opt]
    frame #29: 0x00007fff203698fc libsystem_pthread.dylib`_pthread_start + 224
    frame #30: 0x00007fff20365443 libsystem_pthread.dylib`thread_start + 15
(lldb) 
```

One of the participants in #29343, @TheCleric, happened to stumble upon a Chrome commit that seemed related.

Chrome had merged a change to NetworkLocationProvider:

https://chromium.googlesource.com/chromium/src/+/36d366175fee2d4f0fd0a8ccf53338984da9b531%5E%21/

That had caused a crash in headless Chrome:

https://bugs.chromium.org/p/chromium/issues/detail?id=1195664&q=OS%3DMac%20component%3ABlink%3EGeolocation&can=1

For which a fix was committed:

https://chromium.googlesource.com/chromium/src/+/39cabc596fccd3e79b71cd8ddd0f3348cc2975d9%5E%21/

The reason it affected Electron past 13.0.0-beta13 was because 13.0.0-beta14 bumped Chromium to 91.0.4448.0 , while the changed was landed in Chromium 91.0.4437.0:

https://chromiumdash.appspot.com/commit/36d366175fee2d4f0fd0a8ccf53338984da9b531

This PR / commit implements an Electron specific version of this fix, modified for changes to GeolocationManager in Chrome 93.

I've tested the fix for cases where no system permissions have been granted, where system permissions have been granted with no Google API key, and where system permissions have been granted with a Google API key. Seems to work like it used to.

Closes #29343 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed crashes on macOS when `Geolocation` was used.