### PR TITLE
fix: geolocation crashes electron on macOS

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -867,7 +867,13 @@ ElectronBrowserClient::GetSystemNetworkContext() {
 std::unique_ptr<content::BrowserMainParts>
 ElectronBrowserClient::CreateBrowserMainParts(
     const content::MainFunctionParams& params) {
-  return std::make_unique<ElectronBrowserMainParts>(params);
+  auto browser_main_parts = std::make_unique<ElectronBrowserMainParts>(params);
+
+#if defined(OS_MAC)
+  browser_main_parts_ = browser_main_parts.get();
+#endif
+
+  return browser_main_parts;
 }
 
 void ElectronBrowserClient::WebNotificationAllowed(
@@ -1601,6 +1607,14 @@ void ElectronBrowserClient::RegisterBrowserInterfaceBindersForServiceWorker(
         map) {
   map->Add<blink::mojom::BadgeService>(
       base::BindRepeating(&BindBadgeServiceForServiceWorker));
+}
+
+device::GeolocationManager* ElectronBrowserClient::GetGeolocationManager() {
+#if defined(OS_MAC)
+  return browser_main_parts_->GetGeolocationManager();
+#else
+  return nullptr;
+#endif
 }
 
 }  // namespace electron

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -34,6 +34,7 @@ class SSLCertRequestInfo;
 
 namespace electron {
 
+class ElectronBrowserMainParts;
 class NotificationPresenter;
 class PlatformNotificationService;
 
@@ -87,6 +88,8 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
   content::SerialDelegate* GetSerialDelegate() override;
 
   content::BluetoothDelegate* GetBluetoothDelegate() override;
+
+  device::GeolocationManager* GetGeolocationManager() override;
 
  protected:
   void RenderProcessWillLaunch(content::RenderProcessHost* host) override;
@@ -297,6 +300,10 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
 
   std::unique_ptr<ElectronSerialDelegate> serial_delegate_;
   std::unique_ptr<ElectronBluetoothDelegate> bluetooth_delegate_;
+
+#if defined(OS_MAC)
+  ElectronBrowserMainParts* browser_main_parts_ = nullptr;
+#endif
 
   DISALLOW_COPY_AND_ASSIGN(ElectronBrowserClient);
 };

--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -92,6 +92,7 @@
 #endif
 
 #if defined(OS_MAC)
+#include "services/device/public/cpp/geolocation/geolocation_manager.h"
 #include "shell/browser/ui/cocoa/views_delegate_mac.h"
 #else
 #include "shell/browser/ui/views/electron_views_delegate.h"
@@ -542,6 +543,12 @@ ElectronBrowserMainParts::GetGeolocationControl() {
   }
   return geolocation_control_.get();
 }
+
+#if defined(OS_MAC)
+device::GeolocationManager* ElectronBrowserMainParts::GetGeolocationManager() {
+  return geolocation_manager_.get();
+}
+#endif
 
 IconManager* ElectronBrowserMainParts::GetIconManager() {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -40,6 +40,10 @@ class GtkUiPlatform;
 }
 #endif
 
+namespace device {
+class GeolocationManager;
+}  // namespace device
+
 namespace electron {
 
 class ElectronBrowserContext;
@@ -83,6 +87,10 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   // Returns the connection to GeolocationControl which can be
   // used to enable the location services once per client.
   device::mojom::GeolocationControl* GetGeolocationControl();
+
+#if defined(OS_MAC)
+  device::GeolocationManager* GetGeolocationManager();
+#endif
 
   // Returns handle to the class responsible for extracting file icons.
   IconManager* GetIconManager();
@@ -161,6 +169,10 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
 #endif
 
   mojo::Remote<device::mojom::GeolocationControl> geolocation_control_;
+
+#if defined(OS_MAC)
+  std::unique_ptr<device::GeolocationManager> geolocation_manager_;
+#endif
 
   static ElectronBrowserMainParts* self_;
 

--- a/shell/browser/electron_browser_main_parts_mac.mm
+++ b/shell/browser/electron_browser_main_parts_mac.mm
@@ -7,6 +7,7 @@
 #include "base/mac/bundle_locations.h"
 #include "base/mac/foundation_util.h"
 #include "base/path_service.h"
+#include "services/device/public/cpp/geolocation/geolocation_manager_impl_mac.h"
 #import "shell/browser/mac/electron_application.h"
 #include "shell/browser/mac/electron_application_delegate.h"
 #include "shell/common/electron_paths.h"
@@ -27,6 +28,8 @@ void ElectronBrowserMainParts::PreCreateMainMessageLoop() {
   [[NSUserDefaults standardUserDefaults]
       setObject:@"NO"
          forKey:@"NSTreatUnknownArgumentsAsOpen"];
+
+  geolocation_manager_ = device::GeolocationManagerImpl::Create();
 }
 
 void ElectronBrowserMainParts::FreeAppDelegate() {


### PR DESCRIPTION
#### Description of Change

Backport of #29913

#### Release Notes

Notes: Fixed crashes on macOS when `Geolocation` was used.