### PR TITLE
fix: BrowserViews not painting their WebContents

### DIFF
--- a/shell/browser/native_browser_view_views.cc
+++ b/shell/browser/native_browser_view_views.cc
@@ -7,7 +7,7 @@
 #include <vector>
 
 #include "shell/browser/ui/drag_util.h"
-#include "shell/browser/ui/inspectable_web_contents_view.h"
+#include "shell/browser/ui/views/inspectable_web_contents_view_views.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/views/background.h"
 #include "ui/views/view.h"
@@ -47,7 +47,7 @@ void NativeBrowserViewViews::SetAutoResizeProportions(
     const gfx::Size& window_size) {
   if ((auto_resize_flags_ & AutoResizeFlags::kAutoResizeHorizontal) &&
       !auto_horizontal_proportion_set_) {
-    auto* iwc_view = GetInspectableWebContentsView();
+    InspectableWebContentsView* iwc_view = GetInspectableWebContentsView();
     if (!iwc_view)
       return;
     auto* view = iwc_view->GetView();
@@ -61,7 +61,7 @@ void NativeBrowserViewViews::SetAutoResizeProportions(
   }
   if ((auto_resize_flags_ & AutoResizeFlags::kAutoResizeVertical) &&
       !auto_vertical_proportion_set_) {
-    auto* iwc_view = GetInspectableWebContentsView();
+    InspectableWebContentsView* iwc_view = GetInspectableWebContentsView();
     if (!iwc_view)
       return;
     auto* view = iwc_view->GetView();
@@ -78,7 +78,7 @@ void NativeBrowserViewViews::SetAutoResizeProportions(
 void NativeBrowserViewViews::AutoResize(const gfx::Rect& new_window,
                                         int width_delta,
                                         int height_delta) {
-  auto* iwc_view = GetInspectableWebContentsView();
+  InspectableWebContentsView* iwc_view = GetInspectableWebContentsView();
   if (!iwc_view)
     return;
   auto* view = iwc_view->GetView();
@@ -122,7 +122,7 @@ void NativeBrowserViewViews::ResetAutoResizeProportions() {
 }
 
 void NativeBrowserViewViews::SetBounds(const gfx::Rect& bounds) {
-  auto* iwc_view = GetInspectableWebContentsView();
+  InspectableWebContentsView* iwc_view = GetInspectableWebContentsView();
   if (!iwc_view)
     return;
   auto* view = iwc_view->GetView();
@@ -131,14 +131,20 @@ void NativeBrowserViewViews::SetBounds(const gfx::Rect& bounds) {
 }
 
 gfx::Rect NativeBrowserViewViews::GetBounds() {
-  auto* iwc_view = GetInspectableWebContentsView();
+  InspectableWebContentsView* iwc_view = GetInspectableWebContentsView();
   if (!iwc_view)
     return gfx::Rect();
   return iwc_view->GetView()->bounds();
 }
 
+void NativeBrowserViewViews::RenderViewReady() {
+  InspectableWebContentsView* iwc_view = GetInspectableWebContentsView();
+  if (iwc_view)
+    iwc_view->GetView()->Layout();
+}
+
 void NativeBrowserViewViews::SetBackgroundColor(SkColor color) {
-  auto* iwc_view = GetInspectableWebContentsView();
+  InspectableWebContentsView* iwc_view = GetInspectableWebContentsView();
   if (!iwc_view)
     return;
   auto* view = iwc_view->GetView();

--- a/shell/browser/native_browser_view_views.h
+++ b/shell/browser/native_browser_view_views.h
@@ -33,6 +33,9 @@ class NativeBrowserViewViews : public NativeBrowserView {
   void UpdateDraggableRegions(
       const std::vector<mojom::DraggableRegionPtr>& regions) override;
 
+  // WebContentsObserver:
+  void RenderViewReady() override;
+
   SkRegion* draggable_region() const { return draggable_region_.get(); }
 
  private:

--- a/shell/browser/ui/views/inspectable_web_contents_view_views.h
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.h
@@ -41,6 +41,9 @@ class InspectableWebContentsViewViews : public InspectableWebContentsView,
       const DevToolsContentsResizingStrategy& strategy) override;
   void SetTitle(const std::u16string& title) override;
 
+  // views::View:
+  void Layout() override;
+
   InspectableWebContents* inspectable_web_contents() {
     return inspectable_web_contents_;
   }
@@ -48,9 +51,6 @@ class InspectableWebContentsViewViews : public InspectableWebContentsView,
   const std::u16string& GetTitle() const { return title_; }
 
  private:
-  // views::View:
-  void Layout() override;
-
   // Owns us.
   InspectableWebContents* inspectable_web_contents_;
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/29859.

Fixes an issue where `BrowserView`s would appear not to load their `webContents`. Further investigation showed that it was in fact not that the `webContents` weren't being loaded, but that they weren't being _painted_ properly. If I tried to open `devTools` on the webContents or called `setBounds` _after_ the initial URL load it would work - this tracked back to `Layout` in `inspectable_web_contents_view_views.h` and to a hierarchy change in https://chromium-review.googlesource.com/c/chromium/src/+/2780032. Essentially, the change meant that `Layout` was no longer called by Chromium in some of the places it was before.

To fix this, I added an override for `RenderViewReady` and called into `Layout()` so that paints would happen properly again when they were supposed to.

To verify:

```js
const { BrowserView, BrowserWindow, app } = require('electron')

app.whenReady().then(async () => {
  let win = new BrowserWindow({ width: 800, height: 600 })
  win.on('closed', () => {
    win = null
  })
  const view = new BrowserView({
    webPreferences: {
      nodeIntegration: false
    }
  })
  win.setBrowserView(view)
  view.setBounds({ x: 0, y: 0, width: 800, height: 600 })
  await view.webContents.loadURL('https://electronjs.org')
})
```


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `BrowserView` webContents would appear not to load in some circumstances.