### PR TITLE
fix: toggleDevTools menu role closes devtools window

### DIFF
--- a/lib/browser/api/menu-item-roles.ts
+++ b/lib/browser/api/menu-item-roles.ts
@@ -143,7 +143,10 @@ export const roleList: Record<RoleId, Role> = {
     label: 'Toggle Developer Tools',
     accelerator: isMac ? 'Alt+Command+I' : 'Ctrl+Shift+I',
     nonNativeMacOSRole: true,
-    windowMethod: w => w.webContents.toggleDevTools()
+    webContentsMethod: wc => {
+      const bw = wc.getOwnerBrowserWindow();
+      if (bw) bw.webContents.toggleDevTools();
+    }
   },
   togglefullscreen: {
     label: 'Toggle Full Screen',


### PR DESCRIPTION
#### Description of Change
Fixes #28770.

`webContents.getOwnerBrowserWindow()` when called on a devtools webcontents
seems to return the BrowserWindow containing the webContents to which the
devtools is attached.

This probably doesn't work great for windows with BrowserViews in them, but
then, the previous implementation of this also didn't work correctly for that
case, so it's probably fine?

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed detached DevTools window not closing when a menu item with the toggleDevTools role was triggered.
