### PR TITLE
docs: add runtime.reload as supported extension api

### DIFF
--- a/docs/api/extensions.md
+++ b/docs/api/extensions.md
@@ -78,6 +78,7 @@ The following methods of `chrome.runtime` are supported:
 - `chrome.runtime.getURL`
 - `chrome.runtime.connect`
 - `chrome.runtime.sendMessage`
+- `chrome.runtime.reload` (only supported in background page/script)
 
 The following events of `chrome.runtime` are supported:
 

--- a/docs/api/extensions.md
+++ b/docs/api/extensions.md
@@ -78,7 +78,7 @@ The following methods of `chrome.runtime` are supported:
 - `chrome.runtime.getURL`
 - `chrome.runtime.connect`
 - `chrome.runtime.sendMessage`
-- `chrome.runtime.reload` (only supported in background page/script)
+- `chrome.runtime.reload`
 
 The following events of `chrome.runtime` are supported:
 


### PR DESCRIPTION
According to the extensions support docs, https://www.electronjs.org/docs/api/extensions , chrome.runtime.reload in not available/supported in electron apps. Mentioning this as a possible cause for `extension-loaded` event getting fired seems incorrect if the API can't be triggered inside electron app.

**Edit**: As @nornagon pointed out, it seems like runtime.reload is available but only for background scripts. It makes sense to mention this as a cause for `extension-loaded` event in session docs. And it should also be specified as supported extension API accordingly here https://www.electronjs.org/docs/api/extensions

Notes: none