### PR TITLE
fix: fsPromises.readFile renderer crash

### DIFF
--- a/patches/node/.patches
+++ b/patches/node/.patches
@@ -35,3 +35,4 @@ src_inline_asynccleanuphookhandle_in_headers.patch
 fix_handle_new_tostring_behavior_in_v8_serdes_test.patch
 fix_the_--harmony-weak-refs_has_been_removed_remove_from_specs.patch
 node-api_faster_threadsafe_function.patch
+src_add_missing_context_scopes.patch

--- a/patches/node/src_add_missing_context_scopes.patch
+++ b/patches/node/src_add_missing_context_scopes.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Anna Henningsen <anna@addaleax.net>
+Date: Sun, 6 Dec 2020 16:35:06 +0100
+Subject: src: add missing context scopes
+
+Add scopes that ensure that the context associated with the
+current Environment is always entered when working with it.
+
+PR-URL: https://github.com/nodejs/node/pull/36413
+Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
+Reviewed-By: Gus Caplan <me@gus.host>
+Reviewed-By: Benjamin Gruenbaum <benjamingr@gmail.com>
+Reviewed-By: Gireesh Punathil <gpunathi@in.ibm.com>
+Reviewed-By: James M Snell <jasnell@gmail.com>
+Reviewed-By: Rich Trott <rtrott@gmail.com>
+
+diff --git a/src/env.cc b/src/env.cc
+index 3ad13dd94a0954a447f5ce342a47823217d8b135..64266ea264448dfbe63a4ecad3cc784608ef3ffa 100644
+--- a/src/env.cc
++++ b/src/env.cc
+@@ -501,6 +501,8 @@ void Environment::InitializeLibuv() {
+       [](uv_async_t* async) {
+         Environment* env = ContainerOf(
+             &Environment::task_queues_async_, async);
++        HandleScope handle_scope(env->isolate());
++        Context::Scope context_scope(env->context());
+         env->RunAndClearNativeImmediates();
+       });
+   uv_unref(reinterpret_cast<uv_handle_t*>(&task_queues_async_));
+diff --git a/src/node_file.cc b/src/node_file.cc
+index de5c455c7a2a85f0676dfa50238c9bf29446ad58..3baf658961a80f91f08e75d728746c4127dab8bc 100644
+--- a/src/node_file.cc
++++ b/src/node_file.cc
+@@ -288,6 +288,7 @@ inline void FileHandle::Close() {
+ void FileHandle::CloseReq::Resolve() {
+   Isolate* isolate = env()->isolate();
+   HandleScope scope(isolate);
++  Context::Scope context_scope(env()->context());
+   InternalCallbackScope callback_scope(this);
+   Local<Promise> promise = promise_.Get(isolate);
+   Local<Promise::Resolver> resolver = promise.As<Promise::Resolver>();
+@@ -297,6 +298,7 @@ void FileHandle::CloseReq::Resolve() {
+ void FileHandle::CloseReq::Reject(Local<Value> reason) {
+   Isolate* isolate = env()->isolate();
+   HandleScope scope(isolate);
++  Context::Scope context_scope(env()->context());
+   InternalCallbackScope callback_scope(this);
+   Local<Promise> promise = promise_.Get(isolate);
+   Local<Promise::Resolver> resolver = promise.As<Promise::Resolver>();


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/29920.

This was occurring because Node.js wasn't properly entering the `v8::Context` before resolving the Promise. This was fixed in https://github.com/nodejs/node/pull/36413 which is present in v14.17.0 and beyond, and so needs to be backported only to v12 and v13.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a possible renderer crash when using `fsPromises.readFile`.