### PR TITLE
fix: honor user-defined Downloads directory

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1017,12 +1017,10 @@ ElectronBrowserClient::GetPlatformNotificationService(
 }
 
 base::FilePath ElectronBrowserClient::GetDefaultDownloadDirectory() {
-  // ~/Downloads
-  base::FilePath path;
-  if (base::PathService::Get(base::DIR_HOME, &path))
-    path = path.Append(FILE_PATH_LITERAL("Downloads"));
-
-  return path;
+  base::FilePath download_path;
+  if (base::PathService::Get(chrome::DIR_DEFAULT_DOWNLOADS, &download_path))
+    return download_path;
+  return base::FilePath();
 }
 
 scoped_refptr<network::SharedURLLoaderFactory>


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/29909.

Makes it such that `ElectronBrowserClient::GetDefaultDownloadDirectory()` honors user-defined Downloads directories by calling out to platform-specific download logic defined [in Chromium](https://source.chromium.org/chromium/chromium/src/+/main:chrome/common/chrome_paths_internal.h;drc=c14f6f4b9c44fe479a8d004576b42723b2a5feb6;bpv=1;bpt=1;l=54)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue where Electron would sometimes not honor the user-defined Downloads directory.
