### PR TITLE
fix: potential crash on macOS app exit

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -415,7 +415,7 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   // Use an NSEvent monitor to listen for the wheel event.
   BOOL __block began = NO;
   wheel_event_monitor_ = [NSEvent
-      addLocalMonitorForEventsMatchingMask:NSScrollWheelMask
+      addLocalMonitorForEventsMatchingMask:NSEventMaskScrollWheel
                                    handler:^(NSEvent* event) {
                                      if ([[event window] windowNumber] !=
                                          [window_ windowNumber])
@@ -1699,7 +1699,10 @@ void NativeWindowMac::Cleanup() {
   DCHECK(!IsClosed());
   ui::NativeTheme::GetInstanceForNativeUi()->RemoveObserver(this);
   display::Screen::GetScreen()->RemoveObserver(this);
-  [NSEvent removeMonitor:wheel_event_monitor_];
+  if (wheel_event_monitor_) {
+    [NSEvent removeMonitor:wheel_event_monitor_];
+    wheel_event_monitor_ = nil;
+  }
 }
 
 void NativeWindowMac::OverrideNSWindowContentView() {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/29260.

Fixes an issue where Electron could crash after calling `app.quit()` on macOS. This can happen as a result of `[NSEvent removeMonitor:]`(https://developer.apple.com/documentation/appkit/nsevent/1533709-removemonitor?language=objc) being called twice; from the documentation discussion:

> You must ensure that eventMonitor is removed only once. Removing the same eventMonitor instance multiple times results in an over-release condition, even in a Garbage Collected environment

This fixes any potential issues by ensuring that we only call `[NSEvent removeMonitor:]` on a non-nil `id`. Chromium uses a similar approach [here](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/views/eye_dropper/eye_dropper_view_mac.mm;l=62-65).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes a potential crash when calling `app.quit()` on macOS.
