### PR TITLE
chore: correct spelling of is_quitting in electron::Browser

### DIFF
--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -78,11 +78,11 @@ void Browser::Focus(gin::Arguments* args) {
 #endif
 
 void Browser::Quit() {
-  if (is_quiting_)
+  if (is_quitting_)
     return;
 
-  is_quiting_ = HandleBeforeQuit();
-  if (!is_quiting_)
+  is_quitting_ = HandleBeforeQuit();
+  if (!is_quitting_)
     return;
 
   if (electron::WindowList::IsEmpty())
@@ -100,7 +100,7 @@ void Browser::Exit(gin::Arguments* args) {
     exit(code);
   } else {
     // Prepare to quit when all windows have been closed.
-    is_quiting_ = true;
+    is_quitting_ = true;
 
     // Remember this caller so that we don't emit unrelated events.
     is_exiting_ = true;
@@ -121,7 +121,7 @@ void Browser::Shutdown() {
     return;
 
   is_shutdown_ = true;
-  is_quiting_ = true;
+  is_quitting_ = true;
 
   for (BrowserObserver& observer : observers_)
     observer.OnQuit();
@@ -242,7 +242,7 @@ void Browser::NotifyAndShutdown() {
     observer.OnWillQuit(&prevent_default);
 
   if (prevent_default) {
-    is_quiting_ = false;
+    is_quitting_ = false;
     return;
   }
 
@@ -258,16 +258,16 @@ bool Browser::HandleBeforeQuit() {
 }
 
 void Browser::OnWindowCloseCancelled(NativeWindow* window) {
-  if (is_quiting_)
+  if (is_quitting_)
     // Once a beforeunload handler has prevented the closing, we think the quit
     // is cancelled too.
-    is_quiting_ = false;
+    is_quitting_ = false;
 }
 
 void Browser::OnWindowAllClosed() {
   if (is_exiting_) {
     Shutdown();
-  } else if (is_quiting_) {
+  } else if (is_quitting_) {
     NotifyAndShutdown();
   } else {
     for (BrowserObserver& observer : observers_)

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -309,7 +309,7 @@ class Browser : public WindowListObserver {
 #endif
 
   bool is_shutting_down() const { return is_shutdown_; }
-  bool is_quiting() const { return is_quiting_; }
+  bool is_quitting() const { return is_quitting_; }
   bool is_ready() const { return is_ready_; }
   v8::Local<v8::Value> WhenReady(v8::Isolate* isolate);
 
@@ -326,7 +326,7 @@ class Browser : public WindowListObserver {
   // Send the before-quit message and start closing windows.
   bool HandleBeforeQuit();
 
-  bool is_quiting_ = false;
+  bool is_quitting_ = false;
 
  private:
   // WindowListObserver implementations:


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Just a typo in the member variable and getter names.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
