### PR TITLE
fix: webview should maximize on requestFullscreen

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -89,6 +89,7 @@ export_gin_v8platform_pageallocator_for_usage_outside_of_the_gin.patch
 fix_export_zlib_symbols.patch
 don_t_use_potentially_null_getwebframe_-_view_when_get_blink.patch
 web_contents.patch
+webview_fullscreen.patch
 disable_unload_metrics.patch
 fix_add_check_for_sandbox_then_result.patch
 extend_apply_webpreferences.patch

--- a/patches/chromium/webview_fullscreen.patch
+++ b/patches/chromium/webview_fullscreen.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cheng Zhao <zcbenz@gmail.com>
+Date: Thu, 4 Oct 2018 14:57:02 -0700
+Subject: fix: also propagate fullscreen state for outer frame
+
+When entering fullscreen with Element.requestFullscreen in child frames,
+the parent frame should also enter fullscreen mode too. Chromium handles
+this for iframes, but not for webviews as they are essentially main
+frames instead of child frames.
+
+This patch makes webviews propagate the fullscreen state to embedder.
+
+Note that we also need to manually update embedder's
+`api::WebContents::IsFullscreenForTabOrPending` value.
+
+diff --git a/content/browser/renderer_host/render_frame_host_impl.cc b/content/browser/renderer_host/render_frame_host_impl.cc
+index 5c16a9ee9bbf461c24456613ff709f4f608e3441..4e4d1fdf50e2d480e099c9af71a45fc864d2cf56 100644
+--- a/content/browser/renderer_host/render_frame_host_impl.cc
++++ b/content/browser/renderer_host/render_frame_host_impl.cc
+@@ -5520,6 +5520,15 @@ void RenderFrameHostImpl::EnterFullscreen(
+     notified_instances.insert(parent_site_instance);
+   }
+ 
++  // Entering fullscreen from webview should also notify its outer frame.
++  if (frame_tree_node()->render_manager()->IsMainFrameForInnerDelegate()) {
++    RenderFrameProxyHost* outer_proxy =
++        frame_tree_node()->render_manager()->GetProxyToOuterDelegate();
++    DCHECK(outer_proxy);
++    outer_proxy->GetAssociatedRemoteFrame()->WillEnterFullscreen(
++        options.Clone());
++  }
++
+   delegate_->EnterFullscreenMode(this, *options);
+   delegate_->FullscreenStateChanged(this, true /* is_fullscreen */,
+                                     std::move(options));

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -99,6 +99,7 @@
 #include "shell/browser/web_contents_zoom_controller.h"
 #include "shell/browser/web_dialog_helper.h"
 #include "shell/browser/web_view_guest_delegate.h"
+#include "shell/browser/web_view_manager.h"
 #include "shell/common/api/electron_api_native_image.h"
 #include "shell/common/color_util.h"
 #include "shell/common/electron_constants.h"
@@ -3562,13 +3563,13 @@ void WebContents::SetHtmlApiFullscreen(bool enter_fullscreen) {
   // Window is already in fullscreen mode, save the state.
   if (enter_fullscreen && owner_window_->IsFullscreen()) {
     native_fullscreen_ = true;
-    html_fullscreen_ = true;
+    UpdateHtmlApiFullscreen(true);
     return;
   }
 
   // Exit html fullscreen state but not window's fullscreen mode.
   if (!enter_fullscreen && native_fullscreen_) {
-    html_fullscreen_ = false;
+    UpdateHtmlApiFullscreen(false);
     return;
   }
 
@@ -3583,8 +3584,39 @@ void WebContents::SetHtmlApiFullscreen(bool enter_fullscreen) {
     owner_window_->SetFullScreen(enter_fullscreen);
   }
 
-  html_fullscreen_ = enter_fullscreen;
+  UpdateHtmlApiFullscreen(enter_fullscreen);
   native_fullscreen_ = false;
+}
+
+void WebContents::UpdateHtmlApiFullscreen(bool fullscreen) {
+  if (fullscreen == html_fullscreen_)
+    return;
+
+  html_fullscreen_ = fullscreen;
+
+  // Notify renderer of the html fullscreen change.
+  web_contents()
+      ->GetRenderViewHost()
+      ->GetWidget()
+      ->SynchronizeVisualProperties();
+
+  // The embedder WebContents is spearated from the frame tree of webview, so
+  // we must manually sync their fullscreen states.
+  if (embedder_)
+    embedder_->SetHtmlApiFullscreen(fullscreen);
+
+  // Make sure all child webviews quit html fullscreen.
+  if (!fullscreen && !IsGuest()) {
+    auto* manager = WebViewManager::GetWebViewManager(web_contents());
+    manager->ForEachGuest(
+        web_contents(), base::BindRepeating([](content::WebContents* guest) {
+          WebContents* api_web_contents = WebContents::From(guest);
+          // Use UpdateHtmlApiFullscreen instead of SetXXX becuase there is no
+          // need to interact with the owner window.
+          api_web_contents->UpdateHtmlApiFullscreen(false);
+          return false;
+        }));
+  }
 }
 
 // static

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -686,6 +686,8 @@ class WebContents : public gin::Wrappable<WebContents>,
 
   // Set fullscreen mode triggered by html api.
   void SetHtmlApiFullscreen(bool enter_fullscreen);
+  // Update the html fullscreen flag in both browser and renderer.
+  void UpdateHtmlApiFullscreen(bool fullscreen);
 
   v8::Global<v8::Value> session_;
   v8::Global<v8::Value> devtools_web_contents_;

--- a/shell/browser/web_view_manager.h
+++ b/shell/browser/web_view_manager.h
@@ -24,7 +24,6 @@ class WebViewManager : public content::BrowserPluginGuestManager {
 
   static WebViewManager* GetWebViewManager(content::WebContents* web_contents);
 
- protected:
   // content::BrowserPluginGuestManager:
   bool ForEachGuest(content::WebContents* embedder,
                     const GuestCallback& callback) override;

--- a/spec-main/fixtures/webview/fullscreen/frame.html
+++ b/spec-main/fixtures/webview/fullscreen/frame.html
@@ -1,0 +1,12 @@
+<body>
+  <div id="div">
+    WebView
+  </div>
+  <script type="text/javascript" charset="utf-8">
+    const {ipcRenderer} = require('electron')
+    ipcRenderer.send('webview-ready')
+    document.addEventListener('fullscreenchange', () => {
+      ipcRenderer.send('webview-fullscreenchange')
+    })
+  </script>
+</body>

--- a/spec-main/fixtures/webview/fullscreen/main.html
+++ b/spec-main/fixtures/webview/fullscreen/main.html
@@ -1,0 +1,12 @@
+<body>
+  <webview id="webview" nodeintegration="on" webpreferences="contextIsolation=no" src="frame.html"/>
+  <script type="text/javascript" charset="utf-8">
+    document.addEventListener('fullscreenchange', () => {
+      require('electron').ipcRenderer.send('fullscreenchange')
+    })
+
+    function isIframeFullscreen() {
+      return document.getElementById('webview').shadowRoot.lastElementChild.matches(':fullscreen')
+    }
+  </script>
+</body>


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/27719.

When entering fullscreen with Element.requestFullscreen in child frames, the parent frame should also enter fullscreen mode too. Chromium handles this for iframes, but not for webviews, as the latter are essentially main frames instead of child frames.

This PR makes sure webviews propagate the fullscreen state to embedder.

Note that the patch itself in this PR is not enough to fix the issue, to fix it we have to make the fullscreen state sync between the webview and its embedder frame, and in Electron we are just manually synchronizing the states. A decent patch should change callers or callees of `IsFullscreenForTabOrPending` to be aware of outer frames (webviews), but it would require much more refactoring. I think it does not worth such efforts upstreaming the patch to Chromium, because very few people would encounter this problem in Chrome browser and the patch in this PR is very easy to maintain.

#### Release Notes

Notes: Fix `requestFullscreen` inside webview does not make the element take fullscreen.