### PR TITLE
fix: self.module.paths not working in web workers

### DIFF
--- a/lib/worker/init.ts
+++ b/lib/worker/init.ts
@@ -40,6 +40,5 @@ if (self.location.protocol === 'file:') {
   if (appPath) {
     // Search for module under the app directory.
     global.module.paths = Module._nodeModulePaths(appPath);
-    console.log(global.module.paths);
   }
 }

--- a/lib/worker/init.ts
+++ b/lib/worker/init.ts
@@ -12,6 +12,9 @@ require('../common/reset-search-paths');
 // Import common settings.
 require('@electron/internal/common/init');
 
+// Process command line arguments.
+const { hasSwitch, getSwitchValue } = process._linkedBinding('electron_common_command_line');
+
 // Export node bindings to global.
 const { makeRequireFunction } = __non_webpack_require__('internal/modules/cjs/helpers') // eslint-disable-line
 global.module = new Module('electron/js2c/worker_init');
@@ -32,4 +35,11 @@ if (self.location.protocol === 'file:') {
   // For backwards compatibility we fake these two paths here
   global.__filename = path.join(process.resourcesPath, 'electron.asar', 'worker', 'init.js');
   global.__dirname = path.join(process.resourcesPath, 'electron.asar', 'worker');
+
+  const appPath = hasSwitch('app-path') ? getSwitchValue('app-path') : null;
+  if (appPath) {
+    // Search for module under the app directory.
+    global.module.paths = Module._nodeModulePaths(appPath);
+    console.log(global.module.paths);
+  }
 }

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -682,6 +682,26 @@ describe('chromium features', () => {
     });
   });
 
+  describe('web workers', () => {
+    let appProcess: ChildProcess.ChildProcessWithoutNullStreams | undefined;
+
+    afterEach(() => {
+      if (appProcess && !appProcess.killed) {
+        appProcess.kill();
+        appProcess = undefined;
+      }
+    });
+
+    it('Worker with nodeIntegrationInWorker has access to self.module.paths', async () => {
+      const appPath = path.join(__dirname, 'fixtures', 'apps', 'self-module-paths');
+
+      appProcess = ChildProcess.spawn(process.execPath, [appPath]);
+
+      const [code] = await emittedOnce(appProcess, 'exit');
+      expect(code).to.equal(0);
+    });
+  });
+
   describe('form submit', () => {
     let server: http.Server;
     let serverUrl: string;

--- a/spec-main/fixtures/apps/self-module-paths/index.html
+++ b/spec-main/fixtures/apps/self-module-paths/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <h1>Hello World!</h1>
+    <script src="./renderer.js"></script>
+  </body>
+</html>

--- a/spec-main/fixtures/apps/self-module-paths/main.js
+++ b/spec-main/fixtures/apps/self-module-paths/main.js
@@ -1,0 +1,34 @@
+// Modules to control application life and create native browser window
+const { app, BrowserWindow, ipcMain } = require('electron');
+const path = require('path');
+
+function createWindow () {
+  const mainWindow = new BrowserWindow({
+    width: 800,
+    height: 600,
+    show: false,
+    webPreferences: {
+      nodeIntegration: true,
+      nodeIntegrationInWorker: true,
+      contextIsolation: false
+    }
+  });
+
+  mainWindow.loadFile('index.html');
+}
+
+ipcMain.handle('module-paths', (e, success) => {
+  process.exit(success ? 0 : 1);
+});
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', function () {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/spec-main/fixtures/apps/self-module-paths/package.json
+++ b/spec-main/fixtures/apps/self-module-paths/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "electron-test-self-module-paths",
+  "main": "main.js"
+}

--- a/spec-main/fixtures/apps/self-module-paths/renderer.js
+++ b/spec-main/fixtures/apps/self-module-paths/renderer.js
@@ -1,0 +1,12 @@
+const { ipcRenderer } = require('electron');
+
+const worker = new Worker('worker.js');
+
+worker.onmessage = (event) => {
+  const workerPaths = event.data.sort().toString();
+  const rendererPaths = self.module.paths.sort().toString();
+  const validModulePaths = workerPaths === rendererPaths && workerPaths !== 0;
+
+  ipcRenderer.invoke('module-paths', validModulePaths);
+  worker.terminate();
+};

--- a/spec-main/fixtures/apps/self-module-paths/worker.js
+++ b/spec-main/fixtures/apps/self-module-paths/worker.js
@@ -1,0 +1,1 @@
+self.postMessage(self.module.paths);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/24735.

Fixes an issue where `self.module.paths` didn't work in a web worker context. Fixed with the same logic as is present in `renderer/init.ts`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `self.module.paths` wouldn't work in Workers.