### PR TITLE
build: add support for spawning builds for a specific commit on appveyor

### DIFF
--- a/script/release/ci-release-build.js
+++ b/script/release/ci-release-build.js
@@ -230,6 +230,7 @@ async function callAppVeyor (targetBranch, job, options) {
       accountName: 'electron-bot',
       projectSlug: appVeyorJobs[job],
       branch: targetBranch,
+      commitId: options.commit || undefined,
       environmentVariables
     }),
     method: 'POST'
@@ -366,7 +367,7 @@ if (require.main === module) {
   if (args._.length < 1) {
     console.log(`Trigger CI to build release builds of electron.
     Usage: ci-release-build.js [--job=CI_JOB_NAME] [--arch=INDIVIDUAL_ARCH] [--ci=CircleCI|AppVeyor|VSTS|DevOps]
-    [--ghRelease] [--armTest] [--circleBuildNum=xxx] [--appveyorJobId=xxx] TARGET_BRANCH
+    [--ghRelease] [--armTest] [--circleBuildNum=xxx] [--appveyorJobId=xxx] [--commit=sha] TARGET_BRANCH
     `);
     process.exit(0);
   }


### PR DESCRIPTION
To support accurate after-the-fact reruns of release builds appveyor needs to take in a commit SHA.  Circle we can just use the "rerun" API, we can't do that for apveyor because it loses environment variables between runs.

Notes: no-notes