### PR TITLE
fix: exit HTML fullscreen when window leaves fullscreen on all platforms

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -305,10 +305,8 @@ void BrowserWindow::OnWindowResize() {
 }
 
 void BrowserWindow::OnWindowLeaveFullScreen() {
-#if defined(OS_MAC)
   if (web_contents()->IsFullscreen())
     web_contents()->ExitFullscreen(true);
-#endif
   BaseWindow::OnWindowLeaveFullScreen();
 }
 

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -3355,7 +3355,7 @@ describe('BrowserWindow module', () => {
       });
     });
 
-    ifdescribe(process.platform === 'darwin')('BrowserWindow.setFullScreen(false) when HTML fullscreen', () => {
+    describe('BrowserWindow.setFullScreen(false) when HTML fullscreen', () => {
       it('exits HTML fullscreen when window leaves fullscreen', async () => {
         const w = new BrowserWindow();
         await w.loadURL('about:blank');


### PR DESCRIPTION
#### Description of Change
There is no reason for this logic to be Mac specific. The window can be un-full-screened by pressing F11 on Windows, when it should also exit the HTML fullscreen mode. Follow-up to #13090.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Fixed exiting HTML fullscreen when window leaves fullscreen on Windows and Linux.