### PR TITLE
chore: remove unused _grantOriginAccess method

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3129,12 +3129,6 @@ content::RenderFrameHost* WebContents::MainFrame() {
   return web_contents()->GetMainFrame();
 }
 
-void WebContents::GrantOriginAccess(const GURL& url) {
-  content::ChildProcessSecurityPolicy::GetInstance()->GrantCommitOrigin(
-      web_contents()->GetMainFrame()->GetProcess()->GetID(),
-      url::Origin::Create(url));
-}
-
 void WebContents::NotifyUserActivation() {
   content::RenderFrameHost* frame = web_contents()->GetMainFrame();
   if (frame)
@@ -3716,7 +3710,6 @@ v8::Local<v8::ObjectTemplate> WebContents::FillObjectTemplate(
                  &WebContents::SetWebRTCIPHandlingPolicy)
       .SetMethod("getWebRTCIPHandlingPolicy",
                  &WebContents::GetWebRTCIPHandlingPolicy)
-      .SetMethod("_grantOriginAccess", &WebContents::GrantOriginAccess)
       .SetMethod("takeHeapSnapshot", &WebContents::TakeHeapSnapshot)
       .SetMethod("setImageAnimationPolicy",
                  &WebContents::SetImageAnimationPolicy)

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -310,10 +310,6 @@ class WebContents : public gin::Wrappable<WebContents>,
   // Returns the owner window.
   v8::Local<v8::Value> GetOwnerBrowserWindow(v8::Isolate* isolate) const;
 
-  // Grants the child process the capability to access URLs with the origin of
-  // the specified URL.
-  void GrantOriginAccess(const GURL& url);
-
   // Notifies the web page that there is user interaction.
   void NotifyUserActivation();
 


### PR DESCRIPTION
#### Description of Change

There is no more code using `WebContents. _grantOriginAccess`.

#### Release Notes

Notes: none