### PR TITLE
fix: do not leak NSUUID

### DIFF
--- a/shell/browser/notifications/mac/cocoa_notification.mm
+++ b/shell/browser/notifications/mac/cocoa_notification.mm
@@ -33,7 +33,7 @@ void CocoaNotification::Show(const NotificationOptions& options) {
   NSString* identifier =
       [NSString stringWithFormat:@"%@:notification:%@",
                                  [[NSBundle mainBundle] bundleIdentifier],
-                                 [[[NSUUID alloc] init] UUIDString]];
+                                 [[NSUUID UUID] UUIDString]]];
 
   [notification_ setTitle:base::SysUTF16ToNSString(options.title)];
   [notification_ setSubtitle:base::SysUTF16ToNSString(options.subtitle)];


### PR DESCRIPTION
#### Description of Change

Fix a leak when using `NSUUID` in `Notification`.

#### Release Notes

Notes: Fix memory leak when creating notification on macOS.
