### PR TITLE
docs: remove mention of node-mac-notifier

### DIFF
--- a/docs/tutorial/notifications.md
+++ b/docs/tutorial/notifications.md
@@ -130,14 +130,6 @@ if you exceed that limit.
 
 [apple-notification-guidelines]: https://developer.apple.com/macos/human-interface-guidelines/system-capabilities/notifications/
 
-#### Advanced Notifications
-
-Later versions of macOS allow for notifications with an input field, allowing the user
-to quickly reply to a notification. In order to send notifications with an input field,
-use the userland module [node-mac-notifier][node-mac-notifier].
-
-[node-mac-notifier]: https://github.com/CharlieHess/node-mac-notifier
-
 #### Do not disturb / Session State
 
 To detect whether or not you're allowed to send a notification, use the userland module


### PR DESCRIPTION
#### Description of Change

Electron's Notification API now has the `hasReply` feature, there is no more need to mention the third party module.

#### Release Notes

Notes: none