### PR TITLE
build: fix building with enable_plugins = false

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -46,7 +46,6 @@
 #include "content/public/browser/navigation_details.h"
 #include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/navigation_handle.h"
-#include "content/public/browser/plugin_service.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_process_host.h"
 #include "content/public/browser/render_view_host.h"
@@ -186,6 +185,10 @@
 #if BUILDFLAG(ENABLE_PDF_VIEWER)
 #include "components/pdf/browser/pdf_web_contents_helper.h"  // nogncheck
 #include "shell/browser/electron_pdf_web_contents_helper_client.h"
+#endif
+
+#if BUILDFLAG(ENABLE_PLUGINS)
+#include "content/public/browser/plugin_service.h"
 #endif
 
 #ifndef MAS_BUILD


### PR DESCRIPTION
#### Description of Change
Follow-up to #20354. Caused by https://source.chromium.org/chromium/chromium/src/+/9bec86a5335c6f8bfbf002ef3c023c8d7e38c143
```
In file included from ../../electron/shell/browser/api/electron_api_web_contents.cc:49:
../../content/public/browser/plugin_service.h:17:2: error: "Plugins should be enabled"
#error "Plugins should be enabled"
 ^
1 error generated.
```

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none