### PR TITLE
feat: continue-activity event is extended to support webpageURL property

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -161,6 +161,8 @@ Returns:
   [`NSUserActivity.activityType`][activity-type].
 * `userInfo` unknown - Contains app-specific state stored by the activity on
   another device.
+* `details` Object
+  * `webpageURL` String - A string identifying the URL of the webpage accessed by the activity on another device.
 
 Emitted during [Handoff][handoff] when an activity from a different device wants
 to be resumed. You should call `event.preventDefault()` if you want to handle

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -162,7 +162,7 @@ Returns:
 * `userInfo` unknown - Contains app-specific state stored by the activity on
   another device.
 * `details` Object
-  * `webpageURL` String - A string identifying the URL of the webpage accessed by the activity on another device.
+  * `webpageURL` String (optional) - A string identifying the URL of the webpage accessed by the activity on another device, if available.
 
 Emitted during [Handoff][handoff] when an activity from a different device wants
 to be resumed. You should call `event.preventDefault()` if you want to handle

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -716,8 +716,9 @@ void App::OnDidFailToContinueUserActivity(const std::string& type,
 
 void App::OnContinueUserActivity(bool* prevent_default,
                                  const std::string& type,
-                                 const base::DictionaryValue& user_info) {
-  if (Emit("continue-activity", type, user_info)) {
+                                 const base::DictionaryValue& user_info,
+                                 const base::DictionaryValue& details) {
+  if (Emit("continue-activity", type, user_info, details)) {
     *prevent_default = true;
   }
 }

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -102,7 +102,8 @@ class App : public ElectronBrowserClient::Delegate,
                                        const std::string& error) override;
   void OnContinueUserActivity(bool* prevent_default,
                               const std::string& type,
-                              const base::DictionaryValue& user_info) override;
+                              const base::DictionaryValue& user_info,
+                              const base::DictionaryValue& details) override;
   void OnUserActivityWasContinued(
       const std::string& type,
       const base::DictionaryValue& user_info) override;

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -187,7 +187,8 @@ class Browser : public WindowListObserver {
 
   // Resumes an activity via hand-off.
   bool ContinueUserActivity(const std::string& type,
-                            base::DictionaryValue user_info);
+                            base::DictionaryValue user_info,
+                            base::DictionaryValue details);
 
   // Indicates that an activity was continued on another device.
   void UserActivityWasContinued(const std::string& type,

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -277,10 +277,11 @@ void Browser::DidFailToContinueUserActivity(const std::string& type,
 }
 
 bool Browser::ContinueUserActivity(const std::string& type,
-                                   base::DictionaryValue user_info) {
+                                   base::DictionaryValue user_info,
+                                   base::DictionaryValue details) {
   bool prevent_default = false;
   for (BrowserObserver& observer : observers_)
-    observer.OnContinueUserActivity(&prevent_default, type, user_info);
+    observer.OnContinueUserActivity(&prevent_default, type, user_info, details);
   return prevent_default;
 }
 

--- a/shell/browser/browser_observer.h
+++ b/shell/browser/browser_observer.h
@@ -70,7 +70,8 @@ class BrowserObserver : public base::CheckedObserver {
   // The browser wants to resume a user activity via handoff. (macOS only)
   virtual void OnContinueUserActivity(bool* prevent_default,
                                       const std::string& type,
-                                      const base::DictionaryValue& user_info) {}
+                                      const base::DictionaryValue& user_info,
+                                      const base::DictionaryValue& details) {}
   // The browser wants to notify that an user activity was resumed. (macOS only)
   virtual void OnUserActivityWasContinued(
       const std::string& type,

--- a/shell/browser/mac/electron_application_delegate.mm
+++ b/shell/browser/mac/electron_application_delegate.mm
@@ -154,13 +154,16 @@ static NSDictionary* UNNotificationResponseToNSDictionary(
 #endif
               restorationHandler {
   std::string activity_type(base::SysNSStringToUTF8(userActivity.activityType));
+  NSURL* url = userActivity.webpageURL;
+  NSDictionary* details = url ? @{@"webpageURL" : [url absoluteString]} : @{};
   if (!userActivity.userInfo)
     return NO;
 
   electron::Browser* browser = electron::Browser::Get();
   return browser->ContinueUserActivity(
              activity_type,
-             electron::NSDictionaryToDictionaryValue(userActivity.userInfo))
+             electron::NSDictionaryToDictionaryValue(userActivity.userInfo),
+             electron::NSDictionaryToDictionaryValue(details))
              ? YES
              : NO;
 }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
This PR aims to extend the existing `continue-activity` event params to resolve issue https://github.com/electron/electron/issues/29926.
Primarily a new `details` object is added as a parameter to the event, and `webpageURL` is added inside that details object if the userActivity contains `webpageURL`. 
 
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> Extended `continue-activity` event API to support `webpageURL` property from `NSUserActivity`.
