### PR TITLE
chore: remove unneeded conversions between wstring and u16string

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -420,7 +420,7 @@ bool IsDeviceNameValid(const std::u16string& device_name) {
   return printer_exists;
 #elif defined(OS_WIN)
   printing::ScopedPrinterHandle printer;
-  return printer.OpenPrinterWithName(base::UTF16ToWide(device_name).c_str());
+  return printer.OpenPrinterWithName(base::as_wcstr(device_name));
 #endif
   return true;
 }

--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -170,7 +170,7 @@ bool FormatCommandLineString(std::wstring* exe,
   if (!launch_args.empty()) {
     std::u16string joined_launch_args = base::JoinString(launch_args, u" ");
     *exe = base::StringPrintf(L"%ls %ls", exe->c_str(),
-                              base::UTF16ToWide(joined_launch_args).c_str());
+                              base::as_wcstr(joined_launch_args));
   }
 
   return true;
@@ -196,7 +196,7 @@ std::vector<Browser::LaunchItem> GetLoginItemSettingsHelper(
         base::CommandLine::FromString(process_exe_path).GetProgram();
   } else {
     lookup_exe_path =
-        base::CommandLine::FromString(base::UTF16ToWide(options.path))
+        base::CommandLine::FromString(base::as_wcstr(options.path))
             .GetProgram();
   }
 

--- a/shell/browser/notifications/win/win32_desktop_notifications/common.h
+++ b/shell/browser/notifications/win/win32_desktop_notifications/common.h
@@ -12,8 +12,8 @@ namespace electron {
 struct NotificationData {
   DesktopNotificationController* controller = nullptr;
 
-  std::wstring caption;
-  std::wstring body_text;
+  std::u16string caption;
+  std::u16string body_text;
   HBITMAP image = NULL;
 
   NotificationData() = default;

--- a/shell/browser/notifications/win/win32_desktop_notifications/desktop_notification_controller.cc
+++ b/shell/browser/notifications/win/win32_desktop_notifications/desktop_notification_controller.cc
@@ -274,8 +274,8 @@ void DesktopNotificationController::AnimateAll() {
 }
 
 DesktopNotificationController::Notification
-DesktopNotificationController::AddNotification(std::wstring caption,
-                                               std::wstring body_text,
+DesktopNotificationController::AddNotification(std::u16string caption,
+                                               std::u16string body_text,
                                                HBITMAP image) {
   auto data = std::make_shared<NotificationData>();
   data->controller = this;
@@ -395,8 +395,8 @@ void DesktopNotificationController::Notification::Close() {
     data_->controller->CloseNotification(*this);
 }
 
-void DesktopNotificationController::Notification::Set(std::wstring caption,
-                                                      std::wstring body_text,
+void DesktopNotificationController::Notification::Set(std::u16string caption,
+                                                      std::u16string body_text,
                                                       HBITMAP image) {
   // No business calling this when not pointing to a valid instance
   DCHECK(data_);

--- a/shell/browser/notifications/win/win32_desktop_notifications/desktop_notification_controller.h
+++ b/shell/browser/notifications/win/win32_desktop_notifications/desktop_notification_controller.h
@@ -21,8 +21,8 @@ class DesktopNotificationController {
   ~DesktopNotificationController();
 
   class Notification;
-  Notification AddNotification(std::wstring caption,
-                               std::wstring body_text,
+  Notification AddNotification(std::u16string caption,
+                               std::u16string body_text,
                                HBITMAP image);
   void CloseNotification(const Notification& notification);
 
@@ -87,7 +87,7 @@ class DesktopNotificationController::Notification {
   bool operator==(const Notification& other) const;
 
   void Close();
-  void Set(std::wstring caption, std::wstring body_text, HBITMAP image);
+  void Set(std::u16string caption, std::u16string body_text, HBITMAP image);
 
  private:
   std::shared_ptr<NotificationData> data_;

--- a/shell/browser/notifications/win/win32_desktop_notifications/toast.cc
+++ b/shell/browser/notifications/win/win32_desktop_notifications/toast.cc
@@ -17,6 +17,7 @@
 #include <memory>
 
 #include "base/logging.h"
+#include "base/strings/string_util_win.h"
 #include "shell/browser/notifications/win/win32_desktop_notifications/common.h"
 #include "shell/browser/notifications/win/win32_desktop_notifications/toast_uia.h"
 
@@ -479,7 +480,8 @@ void DesktopNotificationController::Toast::Draw() {
 
     SelectFont(hdc_, caption_font);
     SetTextColor(hdc_, fore_color);
-    DrawText(hdc_, data_->caption.data(), (UINT)data_->caption.length(), &rc,
+    DrawText(hdc_, base::as_wcstr(data_->caption),
+             (UINT)data_->caption.length(), &rc,
              DT_SINGLELINE | DT_END_ELLIPSIS | DT_NOPREFIX);
   }
 
@@ -490,8 +492,8 @@ void DesktopNotificationController::Toast::Draw() {
 
     SelectFont(hdc_, body_font);
     SetTextColor(hdc_, dimmed_color);
-    DrawText(hdc_, data_->body_text.data(), (UINT)data_->body_text.length(),
-             &rc,
+    DrawText(hdc_, base::as_wcstr(data_->body_text),
+             (UINT)data_->body_text.length(), &rc,
              DT_LEFT | DT_WORDBREAK | DT_NOPREFIX | DT_END_ELLIPSIS |
                  DT_EDITCONTROL);
   }

--- a/shell/browser/notifications/win/win32_desktop_notifications/toast_uia.cc
+++ b/shell/browser/notifications/win/win32_desktop_notifications/toast_uia.cc
@@ -7,6 +7,7 @@
 #include <UIAutomation.h>
 
 #include "base/check_op.h"
+#include "base/strings/string_util_win.h"
 #include "shell/browser/notifications/win/win32_desktop_notifications/common.h"
 
 #pragma comment(lib, "uiautomationcore.lib")
@@ -19,7 +20,7 @@ DesktopNotificationController::Toast::UIAutomationInterface::
   text_ = toast->data_->caption;
   if (!toast->data_->body_text.empty()) {
     if (!text_.empty())
-      text_.append(L", ");
+      text_.append(u", ");
     text_.append(toast->data_->body_text);
   }
 }
@@ -107,7 +108,7 @@ DesktopNotificationController::Toast::UIAutomationInterface::GetPropertyValue(
   switch (property_id) {
     case UIA_NamePropertyId:
       retval->vt = VT_BSTR;
-      retval->bstrVal = SysAllocString(text_.c_str());
+      retval->bstrVal = SysAllocString(base::as_wcstr(text_));
       break;
 
     case UIA_ClassNamePropertyId:

--- a/shell/browser/notifications/win/win32_desktop_notifications/toast_uia.h
+++ b/shell/browser/notifications/win/win32_desktop_notifications/toast_uia.h
@@ -76,7 +76,7 @@ class DesktopNotificationController::Toast::UIAutomationInterface
  private:
   volatile LONG cref_ = 0;
   HWND hwnd_;
-  std::wstring text_;
+  std::u16string text_;
 };
 
 }  // namespace electron

--- a/shell/browser/notifications/win/win32_notification.cc
+++ b/shell/browser/notifications/win/win32_notification.cc
@@ -48,15 +48,13 @@ void Win32Notification::Show(const NotificationOptions& options) {
     existing->tag_.clear();
 
     this->notification_ref_ = std::move(existing->notification_ref_);
-    this->notification_ref_.Set(base::UTF16ToWide(options.title),
-                                base::UTF16ToWide(options.msg), image);
+    this->notification_ref_.Set(options.title, options.msg, image);
     // Need to remove the entry in the notifications set that
     // NotificationPresenter is holding
     existing->Destroy();
   } else {
     this->notification_ref_ =
-        presenter->AddNotification(base::UTF16ToWide(options.title),
-                                   base::UTF16ToWide(options.msg), image);
+        presenter->AddNotification(options.title, options.msg, image);
   }
 
   this->tag_ = options.tag;

--- a/shell/browser/notifications/win/windows_toast_notification.cc
+++ b/shell/browser/notifications/win/windows_toast_notification.cc
@@ -12,6 +12,7 @@
 #include <wrl\wrappers\corewrappers.h>
 
 #include "base/environment.h"
+#include "base/strings/string_util_win.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/post_task.h"
 #include "content/public/browser/browser_task_traits.h"
@@ -131,18 +132,15 @@ HRESULT WindowsToastNotification::ShowInternal(
   // The custom xml takes priority over the preset template.
   if (!options.toast_xml.empty()) {
     REPORT_AND_RETURN_IF_FAILED(
-        XmlDocumentFromString(base::UTF16ToWide(options.toast_xml).c_str(),
-                              &toast_xml),
+        XmlDocumentFromString(base::as_wcstr(options.toast_xml), &toast_xml),
         "XML: Invalid XML");
   } else {
     auto* presenter_win = static_cast<NotificationPresenterWin*>(presenter());
     std::wstring icon_path =
         presenter_win->SaveIconToFilesystem(options.icon, options.icon_url);
     REPORT_AND_RETURN_IF_FAILED(
-        GetToastXml(toast_manager_.Get(), base::UTF16ToWide(options.title),
-                    base::UTF16ToWide(options.msg), icon_path,
-                    base::UTF16ToWide(options.timeout_type), options.silent,
-                    &toast_xml),
+        GetToastXml(toast_manager_.Get(), options.title, options.msg, icon_path,
+                    options.timeout_type, options.silent, &toast_xml),
         "XML: Failed to create XML document");
   }
 
@@ -174,10 +172,10 @@ HRESULT WindowsToastNotification::ShowInternal(
 HRESULT WindowsToastNotification::GetToastXml(
     ABI::Windows::UI::Notifications::IToastNotificationManagerStatics*
         toastManager,
-    const std::wstring& title,
-    const std::wstring& msg,
+    const std::u16string& title,
+    const std::u16string& msg,
     const std::wstring& icon_path,
-    const std::wstring& timeout_type,
+    const std::u16string& timeout_type,
     bool silent,
     IXmlDocument** toast_xml) {
   ABI::Windows::UI::Notifications::ToastTemplateType template_type;
@@ -191,9 +189,9 @@ HRESULT WindowsToastNotification::GetToastXml(
     REPORT_AND_RETURN_IF_FAILED(
         toast_manager_->GetTemplateContent(template_type, toast_xml),
         "XML: Fetching XML ToastImageAndText01 template failed");
-    std::wstring toastMsg = title.empty() ? msg : title;
+    std::u16string toastMsg = title.empty() ? msg : title;
     // we can't create an empty notification
-    toastMsg = toastMsg.empty() ? L"[no message]" : toastMsg;
+    toastMsg = toastMsg.empty() ? u"[no message]" : toastMsg;
     REPORT_AND_RETURN_IF_FAILED(
         SetXmlText(*toast_xml, toastMsg),
         "XML: Filling XML ToastImageAndText01 template failed");
@@ -213,7 +211,7 @@ HRESULT WindowsToastNotification::GetToastXml(
   }
 
   // Configure the toast's timeout settings
-  if (timeout_type == base::ASCIIToWide("never")) {
+  if (timeout_type == u"never") {
     REPORT_AND_RETURN_IF_FAILED(
         (SetXmlScenarioReminder(*toast_xml)),
         "XML: Setting \"scenario\" option on notification failed");
@@ -455,7 +453,7 @@ HRESULT WindowsToastNotification::SetXmlAudioSilent(IXmlDocument* doc) {
 }
 
 HRESULT WindowsToastNotification::SetXmlText(IXmlDocument* doc,
-                                             const std::wstring& text) {
+                                             const std::u16string& text) {
   ScopedHString tag;
   ComPtr<IXmlNodeList> node_list;
   RETURN_IF_FAILED(GetTextNodeList(&tag, doc, &node_list, 1));
@@ -467,8 +465,8 @@ HRESULT WindowsToastNotification::SetXmlText(IXmlDocument* doc,
 }
 
 HRESULT WindowsToastNotification::SetXmlText(IXmlDocument* doc,
-                                             const std::wstring& title,
-                                             const std::wstring& body) {
+                                             const std::u16string& title,
+                                             const std::u16string& body) {
   ScopedHString tag;
   ComPtr<IXmlNodeList> node_list;
   RETURN_IF_FAILED(GetTextNodeList(&tag, doc, &node_list, 2));
@@ -535,8 +533,8 @@ HRESULT WindowsToastNotification::GetTextNodeList(ScopedHString* tag,
 
 HRESULT WindowsToastNotification::AppendTextToXml(IXmlDocument* doc,
                                                   IXmlNode* node,
-                                                  const std::wstring& text) {
-  ScopedHString str(text);
+                                                  const std::u16string& text) {
+  ScopedHString str(base::as_wcstr(text));
   if (!str.success())
     return E_FAIL;
 

--- a/shell/browser/notifications/win/windows_toast_notification.h
+++ b/shell/browser/notifications/win/windows_toast_notification.h
@@ -61,20 +61,20 @@ class WindowsToastNotification : public Notification {
   HRESULT GetToastXml(
       ABI::Windows::UI::Notifications::IToastNotificationManagerStatics*
           toastManager,
-      const std::wstring& title,
-      const std::wstring& msg,
+      const std::u16string& title,
+      const std::u16string& msg,
       const std::wstring& icon_path,
-      const std::wstring& timeout_type,
+      const std::u16string& timeout_type,
       const bool silent,
       ABI::Windows::Data::Xml::Dom::IXmlDocument** toast_xml);
   HRESULT SetXmlAudioSilent(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc);
   HRESULT SetXmlScenarioReminder(
       ABI::Windows::Data::Xml::Dom::IXmlDocument* doc);
   HRESULT SetXmlText(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
-                     const std::wstring& text);
+                     const std::u16string& text);
   HRESULT SetXmlText(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
-                     const std::wstring& title,
-                     const std::wstring& body);
+                     const std::u16string& title,
+                     const std::u16string& body);
   HRESULT SetXmlImage(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
                       const std::wstring& icon_path);
   HRESULT GetTextNodeList(
@@ -84,7 +84,7 @@ class WindowsToastNotification : public Notification {
       uint32_t req_length);
   HRESULT AppendTextToXml(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
                           ABI::Windows::Data::Xml::Dom::IXmlNode* node,
-                          const std::wstring& text);
+                          const std::u16string& text);
   HRESULT XmlDocumentFromString(
       const wchar_t* xmlString,
       ABI::Windows::Data::Xml::Dom::IXmlDocument** doc);

--- a/shell/browser/ui/message_box_win.cc
+++ b/shell/browser/ui/message_box_win.cc
@@ -82,10 +82,10 @@ DialogResult ShowTaskDialogWstr(NativeWindow* parent,
                                 int default_id,
                                 int cancel_id,
                                 bool no_link,
-                                const std::wstring& title,
-                                const std::wstring& message,
-                                const std::wstring& detail,
-                                const std::wstring& checkbox_label,
+                                const std::u16string& title,
+                                const std::u16string& message,
+                                const std::u16string& detail,
+                                const std::u16string& checkbox_label,
                                 bool checkbox_checked,
                                 const gfx::ImageSkia& icon) {
   TASKDIALOG_FLAGS flags =
@@ -111,7 +111,7 @@ DialogResult ShowTaskDialogWstr(NativeWindow* parent,
     std::wstring app_name = base::UTF8ToWide(Browser::Get()->GetName());
     config.pszWindowTitle = app_name.c_str();
   } else {
-    config.pszWindowTitle = title.c_str();
+    config.pszWindowTitle = base::as_wcstr(title);
   }
 
   base::win::ScopedHICON hicon;
@@ -139,14 +139,14 @@ DialogResult ShowTaskDialogWstr(NativeWindow* parent,
 
   // If "detail" is empty then don't make message highlighted.
   if (detail.empty()) {
-    config.pszContent = message.c_str();
+    config.pszContent = base::as_wcstr(message);
   } else {
-    config.pszMainInstruction = message.c_str();
-    config.pszContent = detail.c_str();
+    config.pszMainInstruction = base::as_wcstr(message);
+    config.pszContent = base::as_wcstr(detail);
   }
 
   if (!checkbox_label.empty()) {
-    config.pszVerificationText = checkbox_label.c_str();
+    config.pszVerificationText = base::as_wcstr(checkbox_label);
     if (checkbox_checked)
       config.dwFlags |= TDF_VERIFICATION_FLAG_CHECKED;
   }
@@ -190,10 +190,11 @@ DialogResult ShowTaskDialogUTF8(const MessageBoxSettings& settings) {
   for (const auto& button : settings.buttons)
     buttons.push_back(base::UTF8ToWide(button));
 
-  const std::wstring title = base::UTF8ToWide(settings.title);
-  const std::wstring message = base::UTF8ToWide(settings.message);
-  const std::wstring detail = base::UTF8ToWide(settings.detail);
-  const std::wstring checkbox_label = base::UTF8ToWide(settings.checkbox_label);
+  const std::u16string title = base::UTF8ToUTF16(settings.title);
+  const std::u16string message = base::UTF8ToUTF16(settings.message);
+  const std::u16string detail = base::UTF8ToUTF16(settings.detail);
+  const std::u16string checkbox_label =
+      base::UTF8ToUTF16(settings.checkbox_label);
 
   return ShowTaskDialogWstr(
       settings.parent_window, settings.type, buttons, settings.default_id,
@@ -222,9 +223,7 @@ void ShowMessageBox(const MessageBoxSettings& settings,
 void ShowErrorBox(const std::u16string& title, const std::u16string& content) {
   electron::UnresponsiveSuppressor suppressor;
   ShowTaskDialogWstr(nullptr, MessageBoxType::kError, {}, -1, 0, false,
-                     base::UTF8ToWide("Error"), base::UTF16ToWide(title),
-                     base::UTF16ToWide(content), base::UTF8ToWide(""), false,
-                     gfx::ImageSkia());
+                     u"Error", title, content, u"", false, gfx::ImageSkia());
 }
 
 }  // namespace electron

--- a/shell/browser/ui/win/notify_icon.cc
+++ b/shell/browser/ui/win/notify_icon.cc
@@ -8,6 +8,7 @@
 
 #include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
+#include "base/strings/string_util_win.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/win/windows_version.h"
 #include "shell/browser/ui/win/notify_icon_host.h"
@@ -150,10 +151,8 @@ void NotifyIcon::DisplayBalloon(const BalloonOptions& options) {
   NOTIFYICONDATA icon_data;
   InitIconData(&icon_data);
   icon_data.uFlags |= NIF_INFO;
-  wcsncpy_s(icon_data.szInfoTitle, base::UTF16ToWide(options.title).c_str(),
-            _TRUNCATE);
-  wcsncpy_s(icon_data.szInfo, base::UTF16ToWide(options.content).c_str(),
-            _TRUNCATE);
+  wcsncpy_s(icon_data.szInfoTitle, base::as_wcstr(options.title), _TRUNCATE);
+  wcsncpy_s(icon_data.szInfo, base::as_wcstr(options.content), _TRUNCATE);
   icon_data.uTimeout = 0;
   icon_data.hBalloonIcon = options.icon;
   icon_data.dwInfoFlags = ConvertIconType(options.icon_type);


### PR DESCRIPTION
#### Description of Change

`base::as_wcstr` is cost free but `base::UTF16ToWide` will do a string copy. So we should use `std::u16string` to store strings when possible, instead of converting them to `std::wstring`s.

#### Release Notes

Notes: none