### PR TITLE
fix: crash when invoking login callback synchronously

### DIFF
--- a/shell/browser/login_handler.cc
+++ b/shell/browser/login_handler.cc
@@ -66,11 +66,15 @@ void LoginHandler::EmitEvent(
   details.Set("firstAuthAttempt", first_auth_attempt);
   details.Set("responseHeaders", response_headers.get());
 
+  auto weak_this = weak_factory_.GetWeakPtr();
   bool default_prevented =
       api_web_contents->Emit("login", std::move(details), auth_info,
                              base::BindOnce(&LoginHandler::CallbackFromJS,
                                             weak_factory_.GetWeakPtr()));
-  if (!default_prevented && auth_required_callback_) {
+  // ⚠️ NB, if CallbackFromJS is called during Emit(), |this| will have been
+  // deleted. Check the weak ptr before accessing any member variables to
+  // prevent UAF.
+  if (weak_this && !default_prevented && auth_required_callback_) {
     std::move(auth_required_callback_).Run(absl::nullopt);
   }
 }


### PR DESCRIPTION
#### Description of Change
Closes #30065.

This is because somehow the LoginHandler is deleted while calling Emit(), so
accessing the `auth_required_callback_` member variable after that is a
segmentation fault.

It looks like calling `cb()` from JS ultimately ends up deleting the
LoginHandler:
https://source.chromium.org/chromium/chromium/src/+/main:content/browser/storage_partition_impl.cc;l=523;drc=ded7717f5252a0c9d9de56bc22483b195d1801e0.

So this crashes: https://github.com/electron/electron/blob/ccfde6c9d44e64621e2c3a92e5113c1d26e61d67/shell/browser/login_handler.cc#L73 because `this` has been deleted.

We can work around that by taking a weak ptr before the `Emit` call and checking it afterwards, to guard against deletion. In that situation, `auth_required_callback_` would have been null anyway, so there shouldn't be any behavior change.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash when calling the `webContents.on('login')` callback synchronously.
