### PR TITLE
test: fix check for electron_common_testing binding in logging-spec.ts

### DIFF
--- a/spec-main/logging-spec.ts
+++ b/spec-main/logging-spec.ts
@@ -7,8 +7,17 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as uuid from 'uuid';
 
+function isTestingBindingAvailable () {
+  try {
+    process._linkedBinding('electron_common_testing');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // This test depends on functions that are only available when DCHECK_IS_ON.
-ifdescribe(process._linkedBinding('electron_common_testing'))('logging', () => {
+ifdescribe(isTestingBindingAvailable())('logging', () => {
   it('does not log by default', async () => {
     // ELECTRON_ENABLE_LOGGING is turned on in the appveyor config.
     const { ELECTRON_ENABLE_LOGGING: _, ...envWithoutEnableLogging } = process.env;


### PR DESCRIPTION
#### Description of Change
When running tests with the release build of Electron we are getting this error:
```
An error occurred while running the spec-main spec runner
Error: No such module was linked: electron_common_testing
    at process._linkedBinding (internal/bootstrap/loaders.js:127:34)
    at Object.<anonymous> (C:\agent\_work\283\b\src\electron\spec-main\logging-spec.ts:11:20)
    at Module._compile (internal/modules/cjs/loader.js:1125:30)
    at Module.m._compile (C:\agent\_work\283\b\src\electron\node_modules\ts-node\src\index.ts:435:23)
    at Module._extensions..js (internal/modules/cjs/loader.js:1155:10)
    at Object.require.extensions.<computed> [as .ts] (C:\agent\_work\283\b\src\electron\node_modules\ts-node\src\index.ts:438:12)
    at Module.load (internal/modules/cjs/loader.js:982:32)
    at Module._load (internal/modules/cjs/loader.js:823:14)
    at Function.f._load (electron/js2c/asar_bundle.js:5:12913)
    at Module.require (internal/modules/cjs/loader.js:1006:19)
```
Related to #25089

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)

#### Release Notes
Notes: none
