### PR TITLE
feat: add app.setFirstPartySets

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1351,6 +1351,32 @@ details.
 
 **Note:** Enable `Secure Keyboard Entry` only when it is needed and disable it when it is no longer needed.
 
+### `app.setFirstPartySets(rawSets)` _Experimental_
+
+* `rawSets` String - a JSON string describing first-party sets.
+
+This sets the global list of [first-party
+sets](https://github.com/privacycg/first-party-sets) in the network service.
+Only has an effect if the `FirstPartySets` feature is enabled.
+
+This is marked experimental because first-party sets is a feature still in
+development in Chromium, and as such the API may change without warning.
+
+An example `sets` object is:
+
+```json
+[
+    {
+        "owner": "https://acme-corp-landing-page.example",
+        "members": ["https://acme-corp-online-store.example", "https://acme-corp-network.social"]
+    },
+    {
+        "owner": "https://other-owner.example",
+        "members": ["https://other-owner-news.example"]
+    }
+]
+```
+
 ## Properties
 
 ### `app.accessibilitySupportEnabled` _macOS_ _Windows_

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -27,12 +27,15 @@
 #include "content/public/browser/child_process_data.h"
 #include "content/public/browser/client_certificate_delegate.h"
 #include "content/public/browser/gpu_data_manager.h"
+#include "content/public/browser/network_service_instance.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/common/content_switches.h"
 #include "media/audio/audio_manager.h"
+#include "net/cookies/cookie_util.h"
 #include "net/ssl/client_cert_identity.h"
 #include "net/ssl/ssl_cert_request_info.h"
 #include "sandbox/policy/switches.h"
+#include "services/network/network_service.h"
 #include "shell/browser/api/electron_api_menu.h"
 #include "shell/browser/api/electron_api_session.h"
 #include "shell/browser/api/electron_api_web_contents.h"
@@ -1438,6 +1441,12 @@ void App::SetUserAgentFallback(const std::string& user_agent) {
   ElectronBrowserClient::Get()->SetUserAgent(user_agent);
 }
 
+void SetFirstPartySets(std::string raw_sets) {
+  if (net::cookie_util::IsFirstPartySetsEnabled()) {
+    content::GetNetworkService()->SetFirstPartySets(raw_sets);
+  }
+}
+
 #if defined(OS_WIN)
 
 bool App::IsRunningUnderARM64Translation() const {
@@ -1669,6 +1678,7 @@ gin::ObjectTemplateBuilder App::GetObjectTemplateBuilder(v8::Isolate* isolate) {
 #endif
       .SetProperty("userAgentFallback", &App::GetUserAgentFallback,
                    &App::SetUserAgentFallback)
+      .SetMethod("setFirstPartySets", &SetFirstPartySets)
       .SetMethod("enableSandbox", &App::EnableSandbox);
 }
 


### PR DESCRIPTION
#### Description of Change
This adds experimental support for [first-party
sets](https://github.com/privacycg/first-party-sets). The feature is marked
experimental and is behind the `FirstPartySets` feature, because the feature is
still experimental in Chromium.

Chromium pulls this data through the component\_updater from the extension with
id gonpemdgkjcecdgbnaabipppbmgfggbe.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added experimental support for first-party sets.
