### PR TITLE
fix: crash when invoking login callback synchronously

### DIFF
--- a/build/npm-run.py
+++ b/build/npm-run.py
@@ -16,5 +16,5 @@ try:
     subprocess.check_output(args, stderr=subprocess.STDOUT)
 except subprocess.CalledProcessError as e:
     error_msg = "NPM script '{}' failed with code '{}':\n".format(sys.argv[2], e.returncode)
-    print(error_msg + e.output.decode('ascii'))
+    print(error_msg + e.output.decode('utf8'))
     sys.exit(e.returncode)

--- a/shell/browser/login_handler.cc
+++ b/shell/browser/login_handler.cc
@@ -69,11 +69,15 @@ void LoginHandler::EmitEvent(
   details.Set("firstAuthAttempt", first_auth_attempt);
   details.Set("responseHeaders", response_headers.get());
 
+  auto weak_this = weak_factory_.GetWeakPtr();
   bool default_prevented =
       api_web_contents->Emit("login", std::move(details), auth_info,
                              base::BindOnce(&LoginHandler::CallbackFromJS,
                                             weak_factory_.GetWeakPtr()));
-  if (!default_prevented && auth_required_callback_) {
+  // ⚠️ NB, if CallbackFromJS is called during Emit(), |this| will have been
+  // deleted. Check the weak ptr before accessing any member variables to
+  // prevent UAF.
+  if (weak_this && !default_prevented && auth_required_callback_) {
     std::move(auth_required_callback_).Run(base::nullopt);
   }
 }


### PR DESCRIPTION
Backport of #30068.

Notes: Fixed a crash when calling the `webContents.on('login')` callback synchronously.
