### PR TITLE
fix: use correct userData path when unbundled

### DIFF
--- a/shell/app/electron_main_delegate.cc
+++ b/shell/app/electron_main_delegate.cc
@@ -123,7 +123,8 @@ bool ElectronPathProvider(int key, base::FilePath* result) {
     case chrome::DIR_USER_DATA:
       if (!base::PathService::Get(DIR_APP_DATA, &cur))
         return false;
-      cur = cur.Append(base::FilePath::FromUTF8Unsafe(GetApplicationName()));
+      cur = cur.Append(base::FilePath::FromUTF8Unsafe(
+          GetPossiblyOverriddenApplicationName()));
       create_dir = true;
       break;
     case DIR_CRASH_DUMPS:
@@ -153,7 +154,8 @@ bool ElectronPathProvider(int key, base::FilePath* result) {
 #endif
       if (!base::PathService::Get(parent_key, &cur))
         return false;
-      cur = cur.Append(base::FilePath::FromUTF8Unsafe(GetApplicationName()));
+      cur = cur.Append(base::FilePath::FromUTF8Unsafe(
+          GetPossiblyOverriddenApplicationName()));
       create_dir = true;
       break;
     }
@@ -178,7 +180,8 @@ bool ElectronPathProvider(int key, base::FilePath* result) {
         return false;
       cur = cur.Append(FILE_PATH_LITERAL("Library"));
       cur = cur.Append(FILE_PATH_LITERAL("Logs"));
-      cur = cur.Append(base::FilePath::FromUTF8Unsafe(GetApplicationName()));
+      cur = cur.Append(base::FilePath::FromUTF8Unsafe(
+          GetPossiblyOverriddenApplicationName()));
 #else
       if (!base::PathService::Get(chrome::DIR_USER_DATA, &cur))
         return false;

--- a/shell/browser/browser.cc
+++ b/shell/browser/browser.cc
@@ -136,25 +136,25 @@ void Browser::Shutdown() {
 }
 
 std::string Browser::GetVersion() const {
-  std::string ret = GetOverriddenApplicationVersion();
+  std::string ret = OverriddenApplicationVersion();
   if (ret.empty())
     ret = GetExecutableFileVersion();
   return ret;
 }
 
 void Browser::SetVersion(const std::string& version) {
-  OverrideApplicationVersion(version);
+  OverriddenApplicationVersion() = version;
 }
 
 std::string Browser::GetName() const {
-  std::string ret = GetOverriddenApplicationName();
+  std::string ret = OverriddenApplicationName();
   if (ret.empty())
     ret = GetExecutableFileProductName();
   return ret;
 }
 
 void Browser::SetName(const std::string& name) {
-  OverrideApplicationName(name);
+  OverriddenApplicationName() = name;
 }
 
 int Browser::GetBadgeCount() {

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -118,11 +118,7 @@ ElectronBrowserContext::ElectronBrowserContext(const std::string& partition,
   base::StringToInt(command_line->GetSwitchValueASCII(switches::kDiskCacheSize),
                     &max_cache_size_);
 
-  if (!base::PathService::Get(chrome::DIR_USER_DATA, &path_)) {
-    base::PathService::Get(DIR_APP_DATA, &path_);
-    path_ = path_.Append(base::FilePath::FromUTF8Unsafe(GetApplicationName()));
-    base::PathService::Override(chrome::DIR_USER_DATA, path_);
-  }
+  CHECK(base::PathService::Get(chrome::DIR_USER_DATA, &path_));
 
   if (!in_memory && !partition.empty())
     path_ = path_.Append(FILE_PATH_LITERAL("Partitions"))

--- a/shell/common/application_info.cc
+++ b/shell/common/application_info.cc
@@ -13,27 +13,21 @@
 
 namespace electron {
 
-namespace {
-
-base::NoDestructor<std::string> g_overridden_application_name;
-base::NoDestructor<std::string> g_overridden_application_version;
-
-}  // namespace
-
-// name
-void OverrideApplicationName(const std::string& name) {
-  *g_overridden_application_name = name;
-}
-std::string GetOverriddenApplicationName() {
-  return *g_overridden_application_name;
+std::string& OverriddenApplicationName() {
+  static base::NoDestructor<std::string> overridden_application_name;
+  return *overridden_application_name;
 }
 
-// version
-void OverrideApplicationVersion(const std::string& version) {
-  *g_overridden_application_version = version;
+std::string& OverriddenApplicationVersion() {
+  static base::NoDestructor<std::string> overridden_application_version;
+  return *overridden_application_version;
 }
-std::string GetOverriddenApplicationVersion() {
-  return *g_overridden_application_version;
+
+std::string GetPossiblyOverriddenApplicationName() {
+  std::string ret = OverriddenApplicationName();
+  if (!ret.empty())
+    return ret;
+  return GetApplicationName();
 }
 
 std::string GetApplicationUserAgent() {

--- a/shell/common/application_info.h
+++ b/shell/common/application_info.h
@@ -13,11 +13,10 @@
 
 namespace electron {
 
-void OverrideApplicationName(const std::string& name);
-std::string GetOverriddenApplicationName();
+std::string& OverriddenApplicationName();
+std::string& OverriddenApplicationVersion();
 
-void OverrideApplicationVersion(const std::string& version);
-std::string GetOverriddenApplicationVersion();
+std::string GetPossiblyOverriddenApplicationName();
 
 std::string GetApplicationName();
 std::string GetApplicationVersion();

--- a/shell/common/application_info_linux.cc
+++ b/shell/common/application_info_linux.cc
@@ -33,7 +33,7 @@ namespace electron {
 
 std::string GetApplicationName() {
   // attempt #1: the string set in app.setName()
-  std::string ret = GetOverriddenApplicationName();
+  std::string ret = OverriddenApplicationName();
 
   // attempt #2: the 'Name' entry from .desktop file's [Desktop] section
   if (ret.empty()) {
@@ -64,7 +64,7 @@ std::string GetApplicationVersion() {
 
   // try to use the string set in app.setVersion()
   if (ret.empty())
-    ret = GetOverriddenApplicationVersion();
+    ret = OverriddenApplicationVersion();
 
   // no known version number; return some safe fallback
   if (ret.empty()) {

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -924,6 +924,10 @@ describe('app module', () => {
         expect(app.getPath('recent')).to.equal('C:\\fake-path');
       });
     }
+
+    it('uses the app name in getPath(userData)', () => {
+      expect(app.getPath('userData')).to.include(app.name);
+    });
   });
 
   describe('setPath(name, path)', () => {


### PR DESCRIPTION
#### Description of Change
Fixes #30112.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the user-data directory was incorrect in unpackaged apps.
