### PR TITLE
fix: double traffic lights on exit fullscreen

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1690,7 +1690,7 @@ bool NativeWindowMac::IsActive() const {
 }
 
 void NativeWindowMac::ReorderButtonsView() {
-  if (buttons_view_) {
+  if (buttons_view_ && !IsFullscreen()) {
     [buttons_view_ removeFromSuperview];
     [[window_ contentView] addSubview:buttons_view_];
   }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/30026.

Fixes an issue where the traffic lights would get double-drawn when exiting fullscreen and adding a `BrowserView` on macOS. In https://github.com/electron/electron/commit/8bf66f8974c6dc0aecdc22e4ddce2881e1836840 the original code did not redraw traffic lights when the window was fullscreened, but this logic did not perisist and then when I merged https://github.com/electron/electron/pull/29595 this created the issue.

We fix this by not reordering the buttons in the view hierarchy when we're in fullscreen mode.

Tested with https://gist.github.com/45f0a58d69bec2834535e57768363572 and confirmed not to regress https://github.com/electron/electron/issues/29541.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue where the traffic lights would get double-drawn when exiting fullscreen and adding a `BrowserView` on macOS.
