### PR TITLE
chore: update releases to 8 weeks in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Issues are created [here](https://github.com/electron/electron/issues/new).
 
 ### Issue Closure
 
-Bug reports will be closed if the issue has been inactive and the latest affected version no longer receives support. At the moment, Electron maintains its three latest major versions, with a new major version being released every 12 weeks. (For more information on Electron's release cadence, see [this blog post](https://electronjs.org/blog/12-week-cadence).)
+Bug reports will be closed if the issue has been inactive and the latest affected version no longer receives support. At the moment, Electron maintains its three latest major versions, with a new major version being released every 8 weeks. (For more information on Electron's release cadence, see [this blog post](https://electronjs.org/blog/8-week-cadence).)
 
 _If an issue has been closed and you still feel it's relevant, feel free to ping a maintainer or add a comment!_
 

--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -37,6 +37,13 @@ tools and resources.
 
 ## Supported Versions
 
+_**Note:** Beginning in September 2021 with Electron 15, the Electron team
+will temporarily support the latest **four** stable major versions. This
+extended support is intended to help Electron developers transition to
+the [new eight week release cadence](https://electronjs.org/blog/8-week-cadence), and will continue until May 2022, with
+the release of Electron 19. At that time, the Electron team will drop support
+back to the latest three stable major versions._
+
 The latest three *stable* major versions are supported by the Electron team.
 For example, if the latest release is 6.1.x, then the 5.0.x as well
 as the 4.2.x series are supported.  We only support the latest minor release


### PR DESCRIPTION
#### Description of Change

Merge after 8 week release cadence blog: https://github.com/electron/electronjs.org/pull/5463

Updates our release cadence from 12 weeks to 8 weeks in CONTRIBUTING.md.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
