### PR TITLE
fix: BrowserWindow transparency not working

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -914,16 +914,6 @@ void WebContents::InitWithWebContents(content::WebContents* web_contents,
   inspectable_web_contents_ = std::make_unique<InspectableWebContents>(
       web_contents, browser_context->prefs(), is_guest);
   inspectable_web_contents_->SetDelegate(this);
-
-  if (web_preferences) {
-    std::string color_name;
-    if (web_preferences->GetPreference(options::kBackgroundColor,
-                                       &color_name)) {
-      web_contents->SetPageBaseBackgroundColor(ParseHexColor(color_name));
-    } else {
-      web_contents->SetPageBaseBackgroundColor(SK_ColorTRANSPARENT);
-    }
-  }
 }
 
 WebContents::~WebContents() {
@@ -1382,6 +1372,18 @@ void WebContents::HandleNewRenderFrame(
   auto* rwhv = render_frame_host->GetView();
   if (!rwhv)
     return;
+
+  // Set the background color of RenderWidgetHostView.
+  auto* web_preferences = WebContentsPreferences::From(web_contents());
+  if (web_preferences) {
+    std::string color_name;
+    if (web_preferences->GetPreference(options::kBackgroundColor,
+                                       &color_name)) {
+      rwhv->SetBackgroundColor(ParseHexColor(color_name));
+    } else {
+      rwhv->SetBackgroundColor(SK_ColorTRANSPARENT);
+    }
+  }
 
   if (!background_throttling_)
     render_frame_host->GetRenderViewHost()->SetSchedulerThrottling(false);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/30082.

Fixes an issue where BrowserWindows would not properly honor `transparency: true` or a `backgroundColor` being set in their constructor options. This happened as a result of [this CL](https://chromium-review.googlesource.com/c/chromium/src/+/2695928) rolled into Electron via https://github.com/electron/electron/pull/29751. The new method `SetPageBaseBackgroundColor` set the default content background color - i.e, the color that would appear behind the content unless the content overrode it. What then happened was that when we changed our logic to call this method, it was eventually [overridden by Blink](https://source.chromium.org/chromium/chromium/src/+/main:content/browser/renderer_host/render_widget_host_view_base.cc;drc=3bfd3ba3af617152dfee61d03e93a773ddd3443b;l=340), and so would show as transparent or with the supplied color for a flash and then revert to white. We fix this by directly calling the background color method in `RenderWidgetHostViewBase`.

Tested with https://gist.github.com/b52f026c763057f97f745fade82758fd.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where BrowserWindows would not properly honor `transparency: true` or a `backgroundColor` being set in their constructor options.