### PR TITLE
docs: fix fiddle path

### DIFF
--- a/docs/tutorial/launch-app-from-url-in-another-app.md
+++ b/docs/tutorial/launch-app-from-url-in-another-app.md
@@ -168,7 +168,7 @@ After you start your electron app, you can now enter in a URL in your browser th
     can leave it empty.
 -->
 
-```fiddle docs/fiddles/system/protocol-handler/launch-app-from-url-in-another-app
+```fiddle docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app
 
 ```
 


### PR DESCRIPTION
#### Description of Change

This is breaking the build in `electron/electronjs.org-new` and will
most likely not work when clicking the "Fiddle" button.

Rel: https://github.com/electron/electronjs.org-new/pull/65

cc @erickzhao 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none