### PR TITLE
fix: allow colored tray titles when font type is specified

### DIFF
--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -121,7 +121,7 @@
                                         weight:NSFontWeightRegular]
       };
       [attributed_title
-          setAttributes:attributes
+          addAttributes:attributes
                   range:NSMakeRange(0, [attributed_title length])];
     }
   } else if ([font_type isEqualToString:@"monospacedDigit"]) {
@@ -132,7 +132,7 @@
                                              weight:NSFontWeightRegular]
       };
       [attributed_title
-          setAttributes:attributes
+          addAttributes:attributes
                   range:NSMakeRange(0, [attributed_title length])];
     }
   }


### PR DESCRIPTION
#### Description of Change
Fixes #29287.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed tray.setTitle not respecting ANSI colors if a font type was specified.
