### PR TITLE
build: update version-bumper to support alpha

### DIFF
--- a/script/release/notes/index.js
+++ b/script/release/notes/index.js
@@ -25,8 +25,9 @@ const runGit = async (args) => {
 };
 
 const tagIsSupported = tag => tag && !tag.includes('nightly') && !tag.includes('unsupported');
+const tagIsAlpha = tag => tag && tag.includes('alpha');
 const tagIsBeta = tag => tag && tag.includes('beta');
-const tagIsStable = tag => tagIsSupported(tag) && !tagIsBeta(tag);
+const tagIsStable = tag => tagIsSupported(tag) && !tagIsBeta(tag) && !tagIsAlpha(tag);
 
 const getTagsOf = async (point) => {
   try {

--- a/script/release/prepare-release.js
+++ b/script/release/prepare-release.js
@@ -25,7 +25,7 @@ const pass = '✓'.green;
 const fail = '✗'.red;
 
 if (!bumpType && !args.notesOnly) {
-  console.log('Usage: prepare-release [stable | minor | beta | nightly]' +
+  console.log('Usage: prepare-release [stable | minor | beta | alpha | nightly]' +
      ' (--stable) (--notesOnly) (--automaticRelease) (--branch)');
   process.exit(1);
 }
@@ -93,6 +93,11 @@ async function createRelease (branchToTarget, isBeta) {
         'for any bugs you find in it.\n \n This release is published to npm ' +
         'under the electron-nightly package and can be installed via `npm install electron-nightly`, ' +
         `or \`npm install electron-nightly@${newVersion.substr(1)}\`.\n \n ${releaseNotes.text}`;
+    } else if (newVersion.indexOf('alpha') > 0) {
+      releaseBody = 'Note: This is an alpha release.  Please file new issues ' +
+        'for any bugs you find in it.\n \n This release is published to npm ' +
+        'under the alpha tag and can be installed via `npm install electron@alpha`, ' +
+        `or \`npm install electron@${newVersion.substr(1)}\`.\n \n ${releaseNotes.text}`;
     } else {
       releaseBody = 'Note: This is a beta release.  Please file new issues ' +
         'for any bugs you find in it.\n \n This release is published to npm ' +
@@ -182,7 +187,7 @@ async function promptForVersion (version) {
 
 // function to determine if there have been commits to main since the last release
 async function changesToRelease () {
-  const lastCommitWasRelease = new RegExp('^Bump v[0-9.]*(-beta[0-9.]*)?(-nightly[0-9.]*)?$', 'g');
+  const lastCommitWasRelease = new RegExp('^Bump v[0-9.]*(-beta[0-9.]*)?(-alpha[0-9.]*)?(-nightly[0-9.]*)?$', 'g');
   const lastCommit = await GitProcess.exec(['log', '-n', '1', '--pretty=format:\'%s\''], ELECTRON_DIR);
   return !lastCommitWasRelease.test(lastCommit.stdout);
 }

--- a/script/release/prepare-release.js
+++ b/script/release/prepare-release.js
@@ -187,7 +187,8 @@ async function promptForVersion (version) {
 
 // function to determine if there have been commits to main since the last release
 async function changesToRelease () {
-  const lastCommitWasRelease = new RegExp('^Bump v[0-9.]*(-beta[0-9.]*)?(-alpha[0-9.]*)?(-nightly[0-9.]*)?$', 'g');
+  // eslint-disable-next-line no-useless-escape
+  const lastCommitWasRelease = new RegExp('^Bump v[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?(-alpha\.[0-9]+)?(-nightly\.[0-9]+)?$', 'g');
   const lastCommit = await GitProcess.exec(['log', '-n', '1', '--pretty=format:\'%s\''], ELECTRON_DIR);
   return !lastCommitWasRelease.test(lastCommit.stdout);
 }

--- a/script/release/publish-to-npm.js
+++ b/script/release/publish-to-npm.js
@@ -175,6 +175,10 @@ new Promise((resolve, reject) => {
             semver.gt(localVersion, currentTags.beta)) {
         childProcess.execSync(`npm dist-tag add electron@${localVersion} beta --otp=${process.env.ELECTRON_NPM_OTP}`);
       }
+      if (parsedLocalVersion.prerelease[0] === 'alpha' &&
+            semver.gt(localVersion, currentTags.alpha)) {
+        childProcess.execSync(`npm dist-tag add electron@${localVersion} alpha --otp=${process.env.ELECTRON_NPM_OTP}`);
+      }
     }
   })
   .catch((err) => {

--- a/script/release/publish-to-npm.js
+++ b/script/release/publish-to-npm.js
@@ -136,7 +136,7 @@ new Promise((resolve, reject) => {
         // Tag the release with a `2-0-x` style tag
         npmTag = currentBranch;
       } else if (release.tag_name.indexOf('alpha') > 0) {
-        // Tag the release with a `alpha-3-0-x` style tag
+        // Tag the release with an `alpha-3-0-x` style tag
         npmTag = `alpha-${currentBranch}`;
       } else {
         // Tag the release with a `beta-3-0-x` style tag

--- a/script/release/publish-to-npm.js
+++ b/script/release/publish-to-npm.js
@@ -135,6 +135,9 @@ new Promise((resolve, reject) => {
       } else if (!release.prerelease) {
         // Tag the release with a `2-0-x` style tag
         npmTag = currentBranch;
+      } else if (release.tag_name.indexOf('alpha') > 0) {
+        // Tag the release with a `alpha-3-0-x` style tag
+        npmTag = `alpha-${currentBranch}`;
       } else {
         // Tag the release with a `beta-3-0-x` style tag
         npmTag = `beta-${currentBranch}`;

--- a/script/release/version-bumper.js
+++ b/script/release/version-bumper.js
@@ -71,12 +71,19 @@ async function main () {
   console.log(`Bumped to version: ${version}`);
 }
 
-// get next version for release based on [nightly, beta, stable]
+// get next version for release based on [nightly, alpha, beta, stable]
 async function nextVersion (bumpType, version) {
-  if (versionUtils.isNightly(version) || versionUtils.isBeta(version)) {
+  if (
+    versionUtils.isNightly(version) ||
+    versionUtils.isAlpha(version) ||
+    versionUtils.isBeta(version)
+  ) {
     switch (bumpType) {
       case 'nightly':
         version = await versionUtils.nextNightly(version);
+        break;
+      case 'alpha':
+        version = await versionUtils.nextAlpha(version);
         break;
       case 'beta':
         version = await versionUtils.nextBeta(version);
@@ -92,6 +99,8 @@ async function nextVersion (bumpType, version) {
       case 'nightly':
         version = versionUtils.nextNightly(version);
         break;
+      case 'alpha':
+        throw new Error('Cannot bump to alpha from stable.');
       case 'beta':
         throw new Error('Cannot bump to beta from stable.');
       case 'minor':

--- a/script/release/version-utils.js
+++ b/script/release/version-utils.js
@@ -23,6 +23,7 @@ const getCurrentDate = () => {
 };
 
 const isNightly = v => v.includes('nightly');
+const isAlpha = v => v.includes('alpha');
 const isBeta = v => v.includes('beta');
 const isStable = v => {
   const parsed = semver.parse(v);
@@ -39,9 +40,22 @@ const makeVersion = (components, delim, pre = preType.NONE) => {
   return version;
 };
 
+async function nextAlpha (v) {
+  const next = semver.coerce(semver.clean(v));
+  const tagBlob = await GitProcess.exec(['tag', '--list', '-l', `v${next}-alpha.*`], ELECTRON_DIR);
+  const tags = tagBlob.stdout.split('\n').filter(e => e !== '');
+  tags.sort((t1, t2) => {
+    const a = parseInt(t1.split('.').pop(), 10);
+    const b = parseInt(t2.split('.').pop(), 10);
+    return a - b;
+  });
+
+  // increment the latest existing alpha tag or start at alpha.1 if it's a new alpha line
+  return tags.length === 0 ? `${next}-alpha.1` : semver.inc(tags.pop(), 'prerelease');
+}
+
 async function nextBeta (v) {
   const next = semver.coerce(semver.clean(v));
-
   const tagBlob = await GitProcess.exec(['tag', '--list', '-l', `v${next}-beta.*`], ELECTRON_DIR);
   const tags = tagBlob.stdout.split('\n').filter(e => e !== '');
   tags.sort((t1, t2) => {
@@ -94,8 +108,10 @@ function getNextReleaseBranch (branches) {
 
 module.exports = {
   isStable,
+  isAlpha,
   isBeta,
   isNightly,
+  nextAlpha,
   nextBeta,
   makeVersion,
   getElectronVersion,

--- a/spec-main/version-bump-spec.ts
+++ b/spec-main/version-bump-spec.ts
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
+import { GitProcess, IGitExecutionOptions, IGitResult } from 'dugite';
 import { nextVersion, shouldUpdateSupported, updateSupported } from '../script/release/version-bumper';
 import * as utils from '../script/release/version-utils';
+import * as sinon from 'sinon';
 import { ifdescribe } from './spec-helpers';
 const { promises: fs } = require('fs');
 const path = require('path');
@@ -8,6 +10,53 @@ const path = require('path');
 const fixtureDir = path.resolve(__dirname, 'fixtures', 'version-bumper', 'fixture_support.md');
 const readFile = fs.readFile;
 const writeFile = fs.writeFile;
+
+class GitFake {
+  branches: {
+    [key: string]: string[],
+  };
+
+  constructor () {
+    this.branches = {};
+  }
+
+  setBranch (channel: string): void {
+    this.branches[channel] = [];
+  }
+
+  setVersion (channel: string, latestTag: string): void {
+    const tags = [latestTag];
+    if (channel !== 'stable') {
+      const versionStrs = latestTag.split(`${channel}.`);
+      const latest = parseInt(versionStrs[1]);
+
+      for (let i = latest; i >= 1; i--) {
+        tags.push(`${versionStrs[0]}${channel}.${latest - i}`);
+      }
+    }
+
+    this.branches[channel] = tags;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  exec (args: string[], path: string, options?: IGitExecutionOptions | undefined): Promise<IGitResult> {
+    let stdout = '';
+    const stderr = '';
+    const exitCode = 0;
+
+    // handle for promoting from current master HEAD
+    let branch = 'stable';
+    const v = (args[2] === 'HEAD') ? 'stable' : args[3];
+    if (v.includes('nightly')) branch = 'nightly';
+    if (v.includes('alpha')) branch = 'alpha';
+    if (v.includes('beta')) branch = 'beta';
+
+    if (!this.branches[branch]) this.setBranch(branch);
+
+    stdout = this.branches[branch].join('\n');
+    return Promise.resolve({ exitCode, stdout, stderr });
+  }
+}
 
 describe('version-bumper', () => {
   describe('makeVersion', () => {
@@ -138,101 +187,157 @@ describe('version-bumper', () => {
   // On macOS Circle CI we don't have a real git environment due to running
   // gclient sync on a linux machine. These tests therefore don't run as expected.
   ifdescribe(!(process.platform === 'linux' && process.arch.indexOf('arm') === 0) && process.platform !== 'darwin')('nextVersion', () => {
-    const nightlyPattern = /[0-9.]*(-nightly.(\d{4})(\d{2})(\d{2}))$/g;
-    const betaPattern = /[0-9.]*(-beta[0-9.]*)/g;
+    describe('bump versions', () => {
+      const nightlyPattern = /[0-9.]*(-nightly.(\d{4})(\d{2})(\d{2}))$/g;
+      const alphaPattern = /[0-9.]*(-alpha[0-9.]*)/g;
+      const betaPattern = /[0-9.]*(-beta[0-9.]*)/g;
 
-    it('bumps to nightly from stable', async () => {
-      const version = 'v2.0.0';
-      const next = await nextVersion('nightly', version);
-      const matches = next.match(nightlyPattern);
-      expect(matches).to.have.lengthOf(1);
-    });
+      const sandbox = sinon.createSandbox();
+      const gitFake = new GitFake();
 
-    it('bumps to nightly from beta', async () => {
-      const version = 'v2.0.0-beta.1';
-      const next = await nextVersion('nightly', version);
-      const matches = next.match(nightlyPattern);
-      expect(matches).to.have.lengthOf(1);
-    });
+      beforeEach(() => {
+        const wrapper = (args: string[], path: string, options?: IGitExecutionOptions | undefined) => gitFake.exec(args, path, options);
+        sandbox.replace(GitProcess, 'exec', wrapper);
+      });
 
-    it('bumps to nightly from nightly', async () => {
-      const version = 'v2.0.0-nightly.19950901';
-      const next = await nextVersion('nightly', version);
-      const matches = next.match(nightlyPattern);
-      expect(matches).to.have.lengthOf(1);
-    });
+      afterEach(() => {
+        gitFake.branches = {};
+        sandbox.restore();
+      });
 
-    it('bumps to a nightly version above our switch from N-0-x to N-x-y branch names', async () => {
-      const version = 'v2.0.0-nightly.19950901';
-      const next = await nextVersion('nightly', version);
-      // If it starts with v8 then we didn't bump above the 8-x-y branch
-      expect(next.startsWith('v8')).to.equal(false);
-    });
+      it('bumps to nightly from stable', async () => {
+        const version = 'v2.0.0';
+        gitFake.setVersion('stable', version);
+        const next = await nextVersion('nightly', version);
+        const matches = next.match(nightlyPattern);
+        expect(matches).to.have.lengthOf(1);
+      });
 
-    it('throws error when bumping to beta from stable', () => {
-      const version = 'v2.0.0';
-      return expect(
-        nextVersion('beta', version)
-      ).to.be.rejectedWith('Cannot bump to beta from stable.');
-    });
+      it('bumps to nightly from beta', async () => {
+        const version = 'v2.0.0-beta.1';
+        gitFake.setVersion('beta', version);
+        const next = await nextVersion('nightly', version);
+        const matches = next.match(nightlyPattern);
+        expect(matches).to.have.lengthOf(1);
+      });
 
-    it('bumps to beta from nightly', async () => {
-      const version = 'v2.0.0-nightly.19950901';
-      const next = await nextVersion('beta', version);
-      const matches = next.match(betaPattern);
-      expect(matches).to.have.lengthOf(1);
-    });
+      it('bumps to nightly from nightly', async () => {
+        const version = 'v2.0.0-nightly.19950901';
+        gitFake.setVersion('nightly', version);
+        const next = await nextVersion('nightly', version);
+        const matches = next.match(nightlyPattern);
+        expect(matches).to.have.lengthOf(1);
+      });
 
-    it('bumps to beta from beta', async () => {
-      const version = 'v2.0.0-beta.8';
-      const next = await nextVersion('beta', version);
-      expect(next).to.equal('2.0.0-beta.9');
-    });
+      it('bumps to a nightly version above our switch from N-0-x to N-x-y branch names', async () => {
+        const version = 'v2.0.0-nightly.19950901';
+        gitFake.setVersion('nightly', version);
+        const next = await nextVersion('nightly', version);
+        // If it starts with v8 then we didn't bump above the 8-x-y branch
+        expect(next.startsWith('v8')).to.equal(false);
+      });
 
-    it('bumps to beta from beta if the previous beta is at least beta.10', async () => {
-      const version = 'v6.0.0-beta.10';
-      const next = await nextVersion('beta', version);
-      // Last 6.0.0 beta we did was beta.15
-      // So we expect a beta.16 here
-      expect(next).to.equal('6.0.0-beta.16');
-    });
+      it('throws error when bumping to beta from stable', () => {
+        const version = 'v2.0.0';
+        gitFake.setVersion('stable', version);
+        return expect(
+          nextVersion('beta', version)
+        ).to.be.rejectedWith('Cannot bump to beta from stable.');
+      });
 
-    it('bumps to stable from beta', async () => {
-      const version = 'v2.0.0-beta.1';
-      const next = await nextVersion('stable', version);
-      expect(next).to.equal('2.0.0');
-    });
+      it('bumps to alpha from nightly', async () => {
+        const version = 'v2.0.0-nightly.19950901';
+        gitFake.setVersion('nightly', version);
+        const next = await nextVersion('alpha', version);
+        const matches = next.match(alphaPattern);
+        expect(matches).to.have.lengthOf(1);
+      });
 
-    it('bumps to stable from stable', async () => {
-      const version = 'v2.0.0';
-      const next = await nextVersion('stable', version);
-      expect(next).to.equal('2.0.1');
-    });
+      it('bumps to alpha from alpha', async () => {
+        const version = 'v2.0.0-alpha.8';
+        gitFake.setVersion('alpha', version);
+        const next = await nextVersion('alpha', version);
+        expect(next).to.equal('2.0.0-alpha.9');
+      });
 
-    it('bumps to minor from stable', async () => {
-      const version = 'v2.0.0';
-      const next = await nextVersion('minor', version);
-      expect(next).to.equal('2.1.0');
-    });
+      it('bumps to alpha from alpha if the previous alpha is at least alpha.10', async () => {
+        const version = 'v6.0.0-alpha.15';
+        gitFake.setVersion('alpha', version);
+        const next = await nextVersion('alpha', version);
+        expect(next).to.equal('6.0.0-alpha.16');
+      });
 
-    it('bumps to stable from nightly', async () => {
-      const version = 'v2.0.0-nightly.19950901';
-      const next = await nextVersion('stable', version);
-      expect(next).to.equal('2.0.0');
-    });
+      it('bumps to beta from alpha', async () => {
+        const version = 'v2.0.0-alpha.8';
+        gitFake.setVersion('alpha', version);
+        const next = await nextVersion('beta', version);
+        const matches = next.match(betaPattern);
+        expect(matches).to.have.lengthOf(1);
+        expect(next).to.equal('2.0.0-beta.1');
+      });
 
-    it('throws on an invalid version', () => {
-      const version = 'vI.AM.INVALID';
-      return expect(
-        nextVersion('beta', version)
-      ).to.be.rejectedWith(`Invalid current version: ${version}`);
-    });
+      // TODO ELECTRON 15: Re-enable after Electron 15 alpha has released
+      // it('bumps to beta from nightly', async () => {
+      //   const version = 'v2.0.0-nightly.19950901';
+      //   gitFake.setVersion('nightly', version);
+      //   const next = await nextVersion('beta', version);
+      //   const matches = next.match(betaPattern);
+      //   expect(matches).to.have.lengthOf(1);
+      // });
 
-    it('throws on an invalid bump type', () => {
-      const version = 'v2.0.0';
-      return expect(
-        nextVersion('WRONG', version)
-      ).to.be.rejectedWith('Invalid bump type.');
+      it('bumps to beta from beta', async () => {
+        const version = 'v2.0.0-beta.8';
+        gitFake.setVersion('beta', version);
+        const next = await nextVersion('beta', version);
+        expect(next).to.equal('2.0.0-beta.9');
+      });
+
+      it('bumps to beta from beta if the previous beta is at least beta.10', async () => {
+        const version = 'v6.0.0-beta.15';
+        gitFake.setVersion('beta', version);
+        const next = await nextVersion('beta', version);
+        expect(next).to.equal('6.0.0-beta.16');
+      });
+
+      it('bumps to stable from beta', async () => {
+        const version = 'v2.0.0-beta.1';
+        gitFake.setVersion('beta', version);
+        const next = await nextVersion('stable', version);
+        expect(next).to.equal('2.0.0');
+      });
+
+      it('bumps to stable from stable', async () => {
+        const version = 'v2.0.0';
+        const next = await nextVersion('stable', version);
+        expect(next).to.equal('2.0.1');
+      });
+
+      it('bumps to minor from stable', async () => {
+        const version = 'v2.0.0';
+        const next = await nextVersion('minor', version);
+        expect(next).to.equal('2.1.0');
+      });
+
+      it('bumps to stable from nightly', async () => {
+        const version = 'v2.0.0-nightly.19950901';
+        gitFake.setVersion('nightly', version);
+        const next = await nextVersion('stable', version);
+        expect(next).to.equal('2.0.0');
+      });
+
+      it('throws on an invalid version', () => {
+        const version = 'vI.AM.INVALID';
+        return expect(
+          nextVersion('beta', version)
+        ).to.be.rejectedWith(`Invalid current version: ${version}`);
+      });
+
+      it('throws on an invalid bump type', () => {
+        const version = 'v2.0.0';
+        return expect(
+          nextVersion('WRONG', version)
+        ).to.be.rejectedWith('Invalid bump type.');
+      });
     });
   });
 });


### PR DESCRIPTION
#### Description of Change

Updates the version-bumper script and supporting utils to support an alpha build for Electron 15.

This PR also adds a mock to support new version-bumper tests for alpha tags. Because we don't currently have alpha tags and were previously using Electron's actual git tags from 2.x.x, a mock was required to test for alphas. These tests are currently separated from the rest to make them easier to delete, but they can easily be integrated with the main tests if we decide we want to keep the alpha channel.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
