### PR TITLE
docs: fix broken context isolation link in sandbox docs

### DIFF
--- a/docs/tutorial/sandbox.md
+++ b/docs/tutorial/sandbox.md
@@ -79,7 +79,7 @@ or [Parcel][parcel].
 Note that because the environment presented to the `preload` script is substantially
 more privileged than that of a sandboxed renderer, it is still possible to leak
 privileged APIs to untrusted code running in the renderer process unless
-[`contextIsolation`][contextIsolation] is enabled.
+[`contextIsolation`][context-isolation] is enabled.
 
 ## Configuring the sandbox
 


### PR DESCRIPTION
#### Description of Change

Fixes broken context isolation link in the [sandbox](https://www.electronjs.org/docs/tutorial/sandbox#preload-scripts) documentation.
The link is named `context-isolation` at the end of the file but `contextIsolation` is being used instead.

#### Checklist

- [x] relevant documentation is changed or added

#### Release Notes

Notes: none
