### PR TITLE
chore: cherry-pick 5487040a284a from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -117,3 +117,4 @@ make_keychain_service_account_optionally_configurable_at_runtime.patch
 don_t_run_pcscan_notifythreadcreated_if_pcscan_is_disabled.patch
 cherry-pick-cc20b36a5845.patch
 set_svgimage_page_after_document_install.patch
+cherry-pick-5487040a284a.patch

--- a/patches/chromium/cherry-pick-5487040a284a.patch
+++ b/patches/chromium/cherry-pick-5487040a284a.patch
@@ -1,7 +1,7 @@
-From 5487040a284a0cbac172520052e7b54c8e48596e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Dale Curtis <dalecurtis@chromium.org>
 Date: Mon, 12 Jul 2021 19:29:39 +0000
-Subject: [PATCH] Don't TexImage via GPU when OOP raster is disabled on Windows.
+Subject: Don't TexImage via GPU when OOP raster is disabled on Windows.
 
 For some reason it's much slower than the the non-GPU based path. The
 test page https://koush.github.io/webcodecs/ goes from ~270fps decoding
@@ -16,13 +16,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3018801
 Commit-Queue: Dale Curtis <dalecurtis@chromium.org>
 Reviewed-by: Kenneth Russell <kbr@chromium.org>
 Cr-Commit-Position: refs/heads/master@{#900587}
----
 
 diff --git a/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc b/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
-index 4b6c92a..901eca9 100644
+index 31a22fa48c001a07d1b848c107d22c7d1342c2a6..f70dd9b9d0eb405736e8830feb9cb32bbdb5af4a 100644
 --- a/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
 +++ b/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
-@@ -5981,6 +5981,14 @@
+@@ -5955,6 +5955,14 @@ void WebGLRenderingContextBase::TexImageHelperMediaVideoFrame(
        CanUseTexImageViaGPU(format, type) &&
        transform == media::kNoTransformation;
  
@@ -37,7 +36,7 @@ index 4b6c92a..901eca9 100644
    // Callers may chose to provide a renderer which ensures that generated
    // intermediates will be cached across TexImage calls for the same frame.
    std::unique_ptr<media::PaintCanvasVideoRenderer> local_video_renderer;
-@@ -6026,7 +6034,7 @@
+@@ -6000,7 +6008,7 @@ void WebGLRenderingContextBase::TexImageHelperMediaVideoFrame(
      // TODO(crbug.com/1180879): I420A should be supported, but currently fails
      // conformance/textures/misc/texture-video-transparent.html.
      if (!media_video_frame->HasTextures() &&
@@ -46,7 +45,7 @@ index 4b6c92a..901eca9 100644
          video_renderer->CopyVideoFrameYUVDataToGLTexture(
              raster_context_provider, ContextGL(), media_video_frame, target,
              texture->Object(), adjusted_internalformat, format, type, level,
-@@ -6094,9 +6102,9 @@
+@@ -6068,9 +6076,9 @@ void WebGLRenderingContextBase::TexImageHelperMediaVideoFrame(
        function_id == kTexImage2D || function_id == kTexSubImage2D;
  #endif
  

--- a/patches/chromium/cherry-pick-5487040a284a.patch
+++ b/patches/chromium/cherry-pick-5487040a284a.patch
@@ -1,0 +1,61 @@
+From 5487040a284a0cbac172520052e7b54c8e48596e Mon Sep 17 00:00:00 2001
+From: Dale Curtis <dalecurtis@chromium.org>
+Date: Mon, 12 Jul 2021 19:29:39 +0000
+Subject: [PATCH] Don't TexImage via GPU when OOP raster is disabled on Windows.
+
+For some reason it's much slower than the the non-GPU based path. The
+test page https://koush.github.io/webcodecs/ goes from ~270fps decoding
+and ~5fps rendering to ~300fps decoding and >> 60fps rendering when
+running with --disable-oop-rasterization.
+
+R=kbr
+
+Bug: 1227921
+Change-Id: I1abbcfd5c4a515540753c8c5e681949f6f236c9c
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3018801
+Commit-Queue: Dale Curtis <dalecurtis@chromium.org>
+Reviewed-by: Kenneth Russell <kbr@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#900587}
+---
+
+diff --git a/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc b/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
+index 4b6c92a..901eca9 100644
+--- a/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
++++ b/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
+@@ -5981,6 +5981,14 @@
+       CanUseTexImageViaGPU(format, type) &&
+       transform == media::kNoTransformation;
+ 
++#if defined(OS_WIN)
++  // TODO(crbug.com/1227921): When OOP GPU rasterization is disabled, uploading
++  // via the GPU becomes extremely slow.
++  const bool gpu_teximage_is_slow = !caps.supports_oop_raster;
++#else
++  const bool gpu_teximage_is_slow = false;
++#endif
++
+   // Callers may chose to provide a renderer which ensures that generated
+   // intermediates will be cached across TexImage calls for the same frame.
+   std::unique_ptr<media::PaintCanvasVideoRenderer> local_video_renderer;
+@@ -6026,7 +6034,7 @@
+     // TODO(crbug.com/1180879): I420A should be supported, but currently fails
+     // conformance/textures/misc/texture-video-transparent.html.
+     if (!media_video_frame->HasTextures() &&
+-        media::IsOpaque(media_video_frame->format()) &&
++        media::IsOpaque(media_video_frame->format()) && !gpu_teximage_is_slow &&
+         video_renderer->CopyVideoFrameYUVDataToGLTexture(
+             raster_context_provider, ContextGL(), media_video_frame, target,
+             texture->Object(), adjusted_internalformat, format, type, level,
+@@ -6094,9 +6102,9 @@
+       function_id == kTexImage2D || function_id == kTexSubImage2D;
+ #endif
+ 
+-  const bool can_upload_via_gpu = function_supports_gpu_teximage &&
+-                                  CanUseTexImageViaGPU(format, type) &&
+-                                  source_image_rect_is_default;
++  const bool can_upload_via_gpu =
++      function_supports_gpu_teximage && CanUseTexImageViaGPU(format, type) &&
++      source_image_rect_is_default && !gpu_teximage_is_slow;
+ 
+   // If we can upload via GPU, try to to use an accelerated resource provider
+   // configured appropriately for video. Otherwise use the software cache.


### PR DESCRIPTION
Closes https://github.com/electron/electron/issues/30173.

Don't TexImage via GPU when OOP raster is disabled on Windows.

For some reason it's much slower than the the non-GPU based path. The
test page https://koush.github.io/webcodecs/ goes from ~270fps decoding
and ~5fps rendering to ~300fps decoding and >> 60fps rendering when
running with --disable-oop-rasterization.

R=kbr

Bug: 1227921
Change-Id: I1abbcfd5c4a515540753c8c5e681949f6f236c9c
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3018801
Commit-Queue: Dale Curtis <dalecurtis@chromium.org>
Reviewed-by: Kenneth Russell <kbr@chromium.org>
Cr-Commit-Position: refs/heads/master@{#900587}


Closes #30173.

Notes: Backported fix for https://crbug.com/1227921.