### PR TITLE
build: handle release failure by exiting with code 1

### DIFF
--- a/script/release/release.js
+++ b/script/release/release.js
@@ -457,4 +457,8 @@ async function verifyShasumsForRemoteFiles (remoteFilesToHash, filesAreNodeJSArt
   }
 }
 
-makeRelease(args.validateRelease);
+makeRelease(args.validateRelease)
+  .catch((err) => {
+    console.error('Error occurred while making release:', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
This caused a silent failure in our beta release today

Notes: no-notes
