### PR TITLE
chore: cherry-pick e60cc80ff744 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -117,3 +117,4 @@ make_keychain_service_account_optionally_configurable_at_runtime.patch
 don_t_run_pcscan_notifythreadcreated_if_pcscan_is_disabled.patch
 cherry-pick-cc20b36a5845.patch
 set_svgimage_page_after_document_install.patch
+cherry-pick-e60cc80ff744.patch

--- a/patches/chromium/cherry-pick-e60cc80ff744.patch
+++ b/patches/chromium/cherry-pick-e60cc80ff744.patch
@@ -1,7 +1,7 @@
-From e60cc80ff744a88da6076297dbb2b3ff3047d29f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Shrek Shao <shrekshao@google.com>
 Date: Tue, 29 Jun 2021 01:17:03 +0000
-Subject: [PATCH] [M92] Fix multidraw validation drawcount + offset out of bounds
+Subject: Fix multidraw validation drawcount + offset out of bounds
 
 (cherry picked from commit 7d0a12ce19fed024d56b95a692d888fe3ef14e2f)
 
@@ -16,13 +16,12 @@ Reviewed-by: Shrek Shao <shrekshao@google.com>
 Reviewed-by: Austin Eng <enga@chromium.org>
 Cr-Commit-Position: refs/branch-heads/4515@{#1101}
 Cr-Branched-From: 488fc70865ddaa05324ac00a54a6eb783b4bc41c-refs/heads/master@{#885287}
----
 
 diff --git a/third_party/blink/renderer/modules/webgl/webgl_multi_draw_common.cc b/third_party/blink/renderer/modules/webgl/webgl_multi_draw_common.cc
-index fb122d3..e51f2c91 100644
+index e0da2d4c89872387d4a7a0ad98d499252e8494bc..af5352e2cc9f60ceb79170f3ab94318b01942ed7 100644
 --- a/third_party/blink/renderer/modules/webgl/webgl_multi_draw_common.cc
 +++ b/third_party/blink/renderer/modules/webgl/webgl_multi_draw_common.cc
-@@ -37,6 +37,11 @@
+@@ -34,6 +34,11 @@ bool WebGLMultiDrawCommon::ValidateArray(WebGLExtensionScopedContext* scoped,
                                           outOfBoundsDescription);
      return false;
    }

--- a/patches/chromium/cherry-pick-e60cc80ff744.patch
+++ b/patches/chromium/cherry-pick-e60cc80ff744.patch
@@ -1,0 +1,36 @@
+From e60cc80ff744a88da6076297dbb2b3ff3047d29f Mon Sep 17 00:00:00 2001
+From: Shrek Shao <shrekshao@google.com>
+Date: Tue, 29 Jun 2021 01:17:03 +0000
+Subject: [PATCH] [M92] Fix multidraw validation drawcount + offset out of bounds
+
+(cherry picked from commit 7d0a12ce19fed024d56b95a692d888fe3ef14e2f)
+
+Bug: 1219886
+Change-Id: I8a84664150758370d9a77ee22ac5549bead0e37e
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2977850
+Reviewed-by: Kenneth Russell <kbr@chromium.org>
+Commit-Queue: Kenneth Russell <kbr@chromium.org>
+Cr-Original-Commit-Position: refs/heads/master@{#895423}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2988885
+Reviewed-by: Shrek Shao <shrekshao@google.com>
+Reviewed-by: Austin Eng <enga@chromium.org>
+Cr-Commit-Position: refs/branch-heads/4515@{#1101}
+Cr-Branched-From: 488fc70865ddaa05324ac00a54a6eb783b4bc41c-refs/heads/master@{#885287}
+---
+
+diff --git a/third_party/blink/renderer/modules/webgl/webgl_multi_draw_common.cc b/third_party/blink/renderer/modules/webgl/webgl_multi_draw_common.cc
+index fb122d3..e51f2c91 100644
+--- a/third_party/blink/renderer/modules/webgl/webgl_multi_draw_common.cc
++++ b/third_party/blink/renderer/modules/webgl/webgl_multi_draw_common.cc
+@@ -37,6 +37,11 @@
+                                          outOfBoundsDescription);
+     return false;
+   }
++  if (static_cast<uint64_t>(drawcount) + offset > size) {
++    scoped->Context()->SynthesizeGLError(GL_INVALID_OPERATION, function_name,
++                                         "drawcount plus offset out of bounds");
++    return false;
++  }
+   return true;
+ }
+ 


### PR DESCRIPTION
[M92] Fix multidraw validation drawcount + offset out of bounds

(cherry picked from commit 7d0a12ce19fed024d56b95a692d888fe3ef14e2f)

Bug: 1219886
Change-Id: I8a84664150758370d9a77ee22ac5549bead0e37e
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2977850
Reviewed-by: Kenneth Russell <kbr@chromium.org>
Commit-Queue: Kenneth Russell <kbr@chromium.org>
Cr-Original-Commit-Position: refs/heads/master@{#895423}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2988885
Reviewed-by: Shrek Shao <shrekshao@google.com>
Reviewed-by: Austin Eng <enga@chromium.org>
Cr-Commit-Position: refs/branch-heads/4515@{#1101}
Cr-Branched-From: 488fc70865ddaa05324ac00a54a6eb783b4bc41c-refs/heads/master@{#885287}


Notes: Security: backported fix for CVE-2021-30568.