### PR TITLE
chore: remove experimental from navigator.serial implementation

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -180,7 +180,7 @@ Emitted when a hunspell dictionary file download fails.  For details
 on the failure you should collect a netlog and inspect the download
 request.
 
-#### Event: 'select-serial-port' _Experimental_
+#### Event: 'select-serial-port'
 
 Returns:
 
@@ -197,14 +197,10 @@ cancel the request.  Additionally, permissioning on `navigator.serial` can
 be managed by using [ses.setPermissionCheckHandler(handler)](#sessetpermissioncheckhandlerhandler)
 with the `serial` permission.
 
-Because this is an experimental feature it is disabled by default.  To enable this feature, you
-will need to use the `--enable-features=ElectronSerialChooser` command line switch.
-
 ```javascript
 const { app, BrowserWindow } = require('electron')
 
 let win = null
-app.commandLine.appendSwitch('enable-features', 'ElectronSerialChooser')
 
 app.whenReady().then(() => {
   win = new BrowserWindow({
@@ -225,7 +221,7 @@ app.whenReady().then(() => {
 })
 ```
 
-#### Event: 'serial-port-added' _Experimental_
+#### Event: 'serial-port-added'
 
 Returns:
 
@@ -235,7 +231,7 @@ Returns:
 
 Emitted after `navigator.serial.requestPort` has been called and `select-serial-port` has fired if a new serial port becomes available.  For example, this event will fire when a new USB device is plugged in.
 
-#### Event: 'serial-port-removed' _Experimental_
+#### Event: 'serial-port-removed'
 
 Returns:
 

--- a/shell/browser/serial/electron_serial_delegate.cc
+++ b/shell/browser/serial/electron_serial_delegate.cc
@@ -14,12 +14,6 @@
 #include "shell/browser/serial/serial_chooser_controller.h"
 #include "shell/browser/web_contents_permission_helper.h"
 
-namespace features {
-
-const base::Feature kElectronSerialChooser{"ElectronSerialChooser",
-                                           base::FEATURE_DISABLED_BY_DEFAULT};
-}
-
 namespace electron {
 
 SerialChooserContext* GetChooserContext(content::RenderFrameHost* frame) {
@@ -36,16 +30,11 @@ std::unique_ptr<content::SerialChooser> ElectronSerialDelegate::RunChooser(
     content::RenderFrameHost* frame,
     std::vector<blink::mojom::SerialPortFilterPtr> filters,
     content::SerialChooser::Callback callback) {
-  if (base::FeatureList::IsEnabled(features::kElectronSerialChooser)) {
-    SerialChooserController* controller = ControllerForFrame(frame);
-    if (controller) {
-      DeleteControllerForFrame(frame);
-    }
-    AddControllerForFrame(frame, std::move(filters), std::move(callback));
-  } else {
-    // If feature is disabled, immediately return back with no port selected.
-    std::move(callback).Run(nullptr);
+  SerialChooserController* controller = ControllerForFrame(frame);
+  if (controller) {
+    DeleteControllerForFrame(frame);
   }
+  AddControllerForFrame(frame, std::move(filters), std::move(callback));
 
   // Return a nullptr because the return value isn't used for anything, eg
   // there is no mechanism to cancel navigator.serial.requestPort(). The return

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -1643,10 +1643,7 @@ describe('navigator.serial', () => {
   let w: BrowserWindow;
   before(async () => {
     w = new BrowserWindow({
-      show: false,
-      webPreferences: {
-        enableBlinkFeatures: 'Serial'
-      }
+      show: false
     });
     await w.loadFile(path.join(fixturesPath, 'pages', 'blank.html'));
   });

--- a/spec-main/index.js
+++ b/spec-main/index.js
@@ -25,7 +25,6 @@ const { app, protocol } = require('electron');
 
 v8.setFlagsFromString('--expose_gc');
 app.commandLine.appendSwitch('js-flags', '--expose_gc');
-app.commandLine.appendSwitch('enable-features', 'ElectronSerialChooser');
 // Prevent the spec runner quiting when the first window closes
 app.on('window-all-closed', () => null);
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Web Serial API [shipped as enabled by default in Chromium 89](https://www.chromestatus.com/feature/6577673212002304), so we should no longer mark this feature as experimental in Electron.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->Web Serial API is no longer experimental.
