### PR TITLE
fix: update traffic lights position for macOS 11

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1800,7 +1800,7 @@ void NativeWindowMac::AddContentViewLayers() {
         [buttons_view_ setShowOnHover:YES];
       if (title_bar_style_ == TitleBarStyle::kHiddenInset &&
           !traffic_light_position_)
-        [buttons_view_ setMargin:gfx::Point(12, 11)];
+        [buttons_view_ setMargin:[WindowButtonsView hiddenInsetMargin]];
 
       if (!IsClosable())
         [[buttons_view_ viewWithTag:0] setEnabled:NO];

--- a/shell/browser/ui/cocoa/window_buttons_view.h
+++ b/shell/browser/ui/cocoa/window_buttons_view.h
@@ -22,6 +22,8 @@
   base::scoped_nsobject<NSTrackingArea> tracking_area_;
 }
 
++ (gfx::Point)defaultMargin;
++ (gfx::Point)hiddenInsetMargin;
 - (id)initWithMargin:(const absl::optional<gfx::Point>&)margin;
 - (void)setMargin:(const absl::optional<gfx::Point>&)margin;
 - (void)setShowOnHover:(BOOL)yes;

--- a/shell/browser/ui/cocoa/window_buttons_view.mm
+++ b/shell/browser/ui/cocoa/window_buttons_view.mm
@@ -23,6 +23,21 @@ const NSWindowButton kButtonTypes[] = {
 
 @implementation WindowButtonsView
 
++ (gfx::Point)defaultMargin {
+  if (@available(macOS 11.0, *)) {
+    return gfx::Point(7, 6);
+  } else {
+    return gfx::Point(7, 3);
+  }
+}
+
++ (gfx::Point)hiddenInsetMargin {
+  // For macOS >= 11, while this value does not match offical macOS apps like
+  // Safari or Notes, it matches titleBarStyle's old implementation before
+  // Electron <= 12.
+  return gfx::Point(12, 11);
+}
+
 - (id)initWithMargin:(const absl::optional<gfx::Point>&)margin {
   self = [super initWithFrame:NSZeroRect];
   [self setMargin:margin];
@@ -51,7 +66,7 @@ const NSWindowButton kButtonTypes[] = {
 }
 
 - (void)setMargin:(const absl::optional<gfx::Point>&)margin {
-  margin_ = margin.value_or(gfx::Point(7, 3));
+  margin_ = margin.value_or([WindowButtonsView defaultMargin]);
 }
 
 - (void)setShowOnHover:(BOOL)yes {


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/30230.

Since macOS 11 the default position of traffic lights has changed, but #27489 did not take account of it. This PR updates the position of traffic lights for `titleBarStyle: 'hidden'`, so the behavior matches Electron <= 12.

#### Release Notes

Notes: Fix frameless window having wrong traffic lights position on macOS 11.