### PR TITLE
feat: switch to crashpad on linux

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -12,6 +12,21 @@ This document uses the following convention to categorize breaking changes:
 * **Deprecated:** An API was marked as deprecated. The API will continue to function, but will emit a deprecation warning, and will be removed in a future release.
 * **Removed:** An API or feature was removed, and is no longer supported by Electron.
 
+## Planned Breaking API Changes (15.0)
+
+### Behavior Changed: `crashReporter` implementation switched to Crashpad on Linux
+
+The underlying implementation of the `crashReporter` API on Linux has changed
+from Breakpad to Crashpad, bringing it in line with Windows and Mac. As a
+result of this, child processes are now automatically monitored, and calling
+`process.crashReporter.start` in Node child processes is no longer needed (and
+is not advisable, as it will start a second instance of the Crashpad reporter).
+
+There are also some subtle changes to how annotations will be reported on
+Linux, including that long values will no longer be split between annotations
+appended with `__1`, `__2` and so on, and instead will be truncated at the
+(new, longer) annotation value limit.
+
 ## Planned Breaking API Changes (14.0)
 
 ### Removed: `app.allowRendererProcessReuse`

--- a/patches/config.json
+++ b/patches/config.json
@@ -3,6 +3,8 @@
 
   "src/electron/patches/boringssl": "src/third_party/boringssl/src",
 
+  "src/electron/patches/webrtc": "src/third_party/webrtc",
+
   "src/electron/patches/v8":  "src/v8",
 
   "src/electron/patches/node": "src/third_party/electron_node",

--- a/patches/webrtc/.patches
+++ b/patches/webrtc/.patches
@@ -1,0 +1,1 @@
+add_thread_local_to_x_error_trap_cc.patch

--- a/patches/webrtc/add_thread_local_to_x_error_trap_cc.patch
+++ b/patches/webrtc/add_thread_local_to_x_error_trap_cc.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jeremy Rose <nornagon@nornagon.net>
+Date: Tue, 27 Jul 2021 10:32:54 -0700
+Subject: add thread_local to x_error_trap.cc
+
+Per https://bugs.chromium.org/p/chromium/issues/detail?id=781618#c6.
+
+To fix this DCHECK firing: https://source.chromium.org/chromium/chromium/src/+/main:third_party/webrtc/modules/desktop_capture/linux/x_error_trap.cc;l=35;drc=25ab3228f3e473f2226f219531ec617d2daa175e
+
+diff --git a/modules/desktop_capture/linux/x_error_trap.cc b/modules/desktop_capture/linux/x_error_trap.cc
+index 13233d827470d9d42be0333c3080e3d107f86fd5..62efb5b5b5194fc8961a27fe2a1efcd77e385d08 100644
+--- a/modules/desktop_capture/linux/x_error_trap.cc
++++ b/modules/desktop_capture/linux/x_error_trap.cc
+@@ -19,8 +19,8 @@ namespace webrtc {
+ namespace {
+ 
+ // TODO(sergeyu): This code is not thread safe. Fix it. Bug 2202.
+-static bool g_xserver_error_trap_enabled = false;
+-static int g_last_xserver_error_code = 0;
++static thread_local bool g_xserver_error_trap_enabled = false;
++static thread_local int g_last_xserver_error_code = 0;
+ 
+ int XServerErrorHandler(Display* display, XErrorEvent* error_event) {
+   RTC_DCHECK(g_xserver_error_trap_enabled);

--- a/shell/app/electron_main.cc
+++ b/shell/app/electron_main.cc
@@ -39,6 +39,7 @@
 #elif defined(OS_LINUX)  // defined(OS_WIN)
 #include <unistd.h>
 #include <cstdio>
+#include "base/base_switches.h"
 #include "content/public/app/content_main.h"
 #include "shell/app/electron_main_delegate.h"  // NOLINT
 #else                                          // defined(OS_LINUX)

--- a/shell/app/electron_main.cc
+++ b/shell/app/electron_main.cc
@@ -307,6 +307,10 @@ int main(int argc, char* argv[]) {
   params.argc = argc;
   params.argv = const_cast<const char**>(argv);
   electron::ElectronCommandLine::Init(argc, argv);
+  // TODO(https://crbug.com/1176772): Remove when Chrome Linux is fully migrated
+  // to Crashpad.
+  base::CommandLine::ForCurrentProcess()->AppendSwitch(
+      ::switches::kEnableCrashpad);
   return content::ContentMain(params);
 }
 

--- a/shell/app/electron_main.cc
+++ b/shell/app/electron_main.cc
@@ -40,6 +40,7 @@
 #include <unistd.h>
 #include <cstdio>
 #include "base/base_switches.h"
+#include "base/command_line.h"
 #include "content/public/app/content_main.h"
 #include "shell/app/electron_main_delegate.h"  // NOLINT
 #else                                          // defined(OS_LINUX)
@@ -305,9 +306,10 @@ int main(int argc, char* argv[]) {
 
   electron::ElectronMainDelegate delegate;
   content::ContentMainParams params(&delegate);
+  electron::ElectronCommandLine::Init(argc, argv);
   params.argc = argc;
   params.argv = const_cast<const char**>(argv);
-  electron::ElectronCommandLine::Init(argc, argv);
+  base::CommandLine::Init(params.argc, params.argv);
   // TODO(https://crbug.com/1176772): Remove when Chrome Linux is fully migrated
   // to Crashpad.
   base::CommandLine::ForCurrentProcess()->AppendSwitch(

--- a/spec-main/api-crash-reporter-spec.ts
+++ b/spec-main/api-crash-reporter-spec.ts
@@ -138,8 +138,11 @@ function waitForNewFileInDir (dir: string): Promise<string[]> {
 
 // TODO(nornagon): Fix tests on linux/arm.
 ifdescribe(!isLinuxOnArm && !process.mas && !process.env.DISABLE_CRASH_REPORTER_TESTS)('crashReporter module', function () {
-  for (const withLinuxCrashpad of (process.platform === 'linux' ? [false, true] : [false])) {
-    const crashpadExtraArgs = withLinuxCrashpad ? ['--enable-crashpad'] : [];
+  // TODO(nornagon): remove linux/breakpad tests once breakpad support is fully
+  // removed.
+  for (const enableLinuxCrashpad of (process.platform === 'linux' ? [false] : [false])) {
+    const withLinuxCrashpad = enableLinuxCrashpad || (process.platform === 'linux');
+    const crashpadExtraArgs = enableLinuxCrashpad ? ['--enable-crashpad'] : [];
     describe(withLinuxCrashpad ? '(with crashpad)' : '', () => {
       describe('should send minidump', () => {
         it('when renderer crashes', async () => {


### PR DESCRIPTION
#### Description of Change
This enables crashpad by default on Linux, matching Chrome.

Closes #27859.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: The `crashReporter` API is now powered by Crashpad on Linux.
