### PR TITLE
refactor: remove guestInstanceId from WebPreferences

### DIFF
--- a/lib/browser/guest-view-manager.ts
+++ b/lib/browser/guest-view-manager.ts
@@ -28,7 +28,7 @@ function sanitizeOptionsForGuest (options: Record<string, any>) {
   return ret;
 }
 
-function makeWebPreferences (embedder: Electron.WebContents, params: Record<string, any>, guestInstanceId: number) {
+function makeWebPreferences (embedder: Electron.WebContents, params: Record<string, any>) {
   // parse the 'webpreferences' attribute string, if set
   // this uses the same parsing rules as window.open uses for its features
   const parsedWebPreferences =
@@ -37,7 +37,6 @@ function makeWebPreferences (embedder: Electron.WebContents, params: Record<stri
       : null;
 
   const webPreferences: Electron.WebPreferences = {
-    guestInstanceId,
     nodeIntegration: params.nodeintegration != null ? params.nodeintegration : false,
     nodeIntegrationInSubFrames: params.nodeintegrationinsubframes != null ? params.nodeintegrationinsubframes : false,
     plugins: params.plugins,
@@ -204,7 +203,7 @@ const attachGuest = function (event: Electron.IpcMainInvokeEvent,
     }
   }
 
-  const webPreferences = makeWebPreferences(embedder, params, guestInstanceId);
+  const webPreferences = makeWebPreferences(embedder, params);
 
   embedder.emit('will-attach-webview', event, webPreferences, params);
   if (event.defaultPrevented) {

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -74,7 +74,7 @@ const isHiddenPage = mainFrame.getWebPreference('hiddenPage');
 const usesNativeWindowOpen = mainFrame.getWebPreference('nativeWindowOpen');
 const preloadScript = mainFrame.getWebPreference('preload');
 const preloadScripts = mainFrame.getWebPreference('preloadScripts');
-const guestInstanceId = mainFrame.getWebPreference('guestInstanceId');
+const isWebView = mainFrame.getWebPreference('isWebView');
 const openerId = mainFrame.getWebPreference('openerId');
 const appPath = hasSwitch('app-path') ? getSwitchValue('app-path') : null;
 
@@ -98,14 +98,14 @@ switch (window.location.protocol) {
   default: {
     // Override default web functions.
     const { windowSetup } = require('@electron/internal/renderer/window-setup') as typeof windowSetupModule;
-    windowSetup(guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen);
+    windowSetup(isWebView, openerId, isHiddenPage, usesNativeWindowOpen);
   }
 }
 
 // Load webview tag implementation.
 if (process.isMainFrame) {
   const { webViewInit } = require('@electron/internal/renderer/web-view/web-view-init') as typeof webViewInitModule;
-  webViewInit(contextIsolation, webviewTag, guestInstanceId);
+  webViewInit(contextIsolation, webviewTag, isWebView);
 }
 
 if (nodeIntegration) {

--- a/lib/renderer/web-view/web-view-init.ts
+++ b/lib/renderer/web-view/web-view-init.ts
@@ -20,9 +20,9 @@ function handleFocusBlur () {
   });
 }
 
-export function webViewInit (contextIsolation: boolean, webviewTag: boolean, guestInstanceId: number) {
+export function webViewInit (contextIsolation: boolean, webviewTag: boolean, isWebView: boolean) {
   // Don't allow recursive `<webview>`.
-  if (webviewTag && !guestInstanceId) {
+  if (webviewTag && !isWebView) {
     const guestViewInternal = require('@electron/internal/renderer/web-view/guest-view-internal') as typeof guestViewInternalModule;
     if (contextIsolation) {
       v8Util.setHiddenValue(window, 'guestViewInternal', guestViewInternal);
@@ -36,7 +36,7 @@ export function webViewInit (contextIsolation: boolean, webviewTag: boolean, gue
     }
   }
 
-  if (guestInstanceId) {
+  if (isWebView) {
     // Report focus/blur events of webview to browser.
     handleFocusBlur();
   }

--- a/lib/renderer/window-setup.ts
+++ b/lib/renderer/window-setup.ts
@@ -243,8 +243,8 @@ class BrowserWindowProxy {
 }
 
 export const windowSetup = (
-  guestInstanceId: number, openerId: number, isHiddenPage: boolean, usesNativeWindowOpen: boolean) => {
-  if (!process.sandboxed && !guestInstanceId) {
+  isWebView: boolean, openerId: number, isHiddenPage: boolean, usesNativeWindowOpen: boolean) => {
+  if (!process.sandboxed && !isWebView) {
     // Override default window.close.
     window.close = function () {
       ipcRendererInternal.send(IPC_MESSAGES.BROWSER_WINDOW_CLOSE);
@@ -318,7 +318,7 @@ export const windowSetup = (
     });
   }
 
-  if (guestInstanceId) {
+  if (isWebView) {
     // Webview `document.visibilityState` tracks window visibility (and ignores
     // the actual <webview> element visibility) for backwards compatibility.
     // See discussion in #9178.

--- a/lib/sandboxed_renderer/init.ts
+++ b/lib/sandboxed_renderer/init.ts
@@ -127,7 +127,7 @@ const contextIsolation = mainFrame.getWebPreference('contextIsolation');
 const webviewTag = mainFrame.getWebPreference('webviewTag');
 const isHiddenPage = mainFrame.getWebPreference('hiddenPage');
 const usesNativeWindowOpen = true;
-const guestInstanceId = mainFrame.getWebPreference('guestInstanceId');
+const isWebView = mainFrame.getWebPreference('isWebView');
 const openerId = mainFrame.getWebPreference('openerId');
 
 switch (window.location.protocol) {
@@ -145,14 +145,14 @@ switch (window.location.protocol) {
   default: {
     // Override default web functions.
     const { windowSetup } = require('@electron/internal/renderer/window-setup') as typeof windowSetupModule;
-    windowSetup(guestInstanceId, openerId, isHiddenPage, usesNativeWindowOpen);
+    windowSetup(isWebView, openerId, isHiddenPage, usesNativeWindowOpen);
   }
 }
 
 // Load webview tag implementation.
 if (process.isMainFrame) {
   const { webViewInit } = require('@electron/internal/renderer/web-view/web-view-init') as typeof webViewInitModule;
-  webViewInit(contextIsolation, webviewTag, guestInstanceId);
+  webViewInit(contextIsolation, webviewTag, isWebView);
 }
 
 // Wrap the script into a function executed in global scope. It won't have

--- a/patches/chromium/allow_in-process_windows_to_have_different_web_prefs.patch
+++ b/patches/chromium/allow_in-process_windows_to_have_different_web_prefs.patch
@@ -8,7 +8,7 @@ WebPreferences of in-process child windows, rather than relying on
 process-level command line switches, as before.
 
 diff --git a/third_party/blink/common/web_preferences/web_preferences.cc b/third_party/blink/common/web_preferences/web_preferences.cc
-index 8a1315f7f89588bb21c6d3c21a7de7c07fed9679..51cc790f7e1ba1440a6ffaa56c9e01687fc35c06 100644
+index 8a1315f7f89588bb21c6d3c21a7de7c07fed9679..c23443c7816e38836b2f4233ca3a742693888f39 100644
 --- a/third_party/blink/common/web_preferences/web_preferences.cc
 +++ b/third_party/blink/common/web_preferences/web_preferences.cc
 @@ -148,6 +148,22 @@ WebPreferences::WebPreferences()
@@ -18,7 +18,7 @@ index 8a1315f7f89588bb21c6d3c21a7de7c07fed9679..51cc790f7e1ba1440a6ffaa56c9e0168
 +      // Begin Electron-specific WebPreferences.
 +      opener_id(0),
 +      context_isolation(false),
-+      guest_instance_id(0),
++      is_webview(false),
 +      hidden_page(false),
 +      offscreen(false),
 +      preload(base::FilePath::StringType()),
@@ -35,7 +35,7 @@ index 8a1315f7f89588bb21c6d3c21a7de7c07fed9679..51cc790f7e1ba1440a6ffaa56c9e0168
        accelerated_video_decode_enabled(false),
        animation_policy(
 diff --git a/third_party/blink/common/web_preferences/web_preferences_mojom_traits.cc b/third_party/blink/common/web_preferences/web_preferences_mojom_traits.cc
-index a264ef99beb81dd6b1f55c1b0f57f6055b4ab771..ff4d5c5245ba0641b4ef02cdaf5d50be537b709e 100644
+index a264ef99beb81dd6b1f55c1b0f57f6055b4ab771..16b734cb371d22dbe99b4ae397126f240b9f686c 100644
 --- a/third_party/blink/common/web_preferences/web_preferences_mojom_traits.cc
 +++ b/third_party/blink/common/web_preferences/web_preferences_mojom_traits.cc
 @@ -23,6 +23,10 @@ bool StructTraits<blink::mojom::WebPreferencesDataView,
@@ -56,7 +56,7 @@ index a264ef99beb81dd6b1f55c1b0f57f6055b4ab771..ff4d5c5245ba0641b4ef02cdaf5d50be
 +  // Begin Electron-specific WebPreferences.
 +  out->opener_id = data.opener_id();
 +  out->context_isolation = data.context_isolation();
-+  out->guest_instance_id = data.guest_instance_id();
++  out->is_webview = data.is_webview();
 +  out->hidden_page = data.hidden_page();
 +  out->offscreen = data.offscreen();
 +  out->native_window_open = data.native_window_open();
@@ -72,7 +72,7 @@ index a264ef99beb81dd6b1f55c1b0f57f6055b4ab771..ff4d5c5245ba0641b4ef02cdaf5d50be
    out->accelerated_video_decode_enabled =
        data.accelerated_video_decode_enabled();
 diff --git a/third_party/blink/public/common/web_preferences/web_preferences.h b/third_party/blink/public/common/web_preferences/web_preferences.h
-index 4517bf43c1b80f1aa0f3ba8e67e78b8b91e19f8a..492f6c948af74bb925826a1075e6343f147f0eb2 100644
+index 4517bf43c1b80f1aa0f3ba8e67e78b8b91e19f8a..5dc73459f424ad0a01b4ea18e4de196e20d24ae5 100644
 --- a/third_party/blink/public/common/web_preferences/web_preferences.h
 +++ b/third_party/blink/public/common/web_preferences/web_preferences.h
 @@ -10,6 +10,7 @@
@@ -91,7 +91,7 @@ index 4517bf43c1b80f1aa0f3ba8e67e78b8b91e19f8a..492f6c948af74bb925826a1075e6343f
 +  std::vector<base::FilePath> preloads;
 +  int opener_id;
 +  bool context_isolation;
-+  int guest_instance_id;
++  bool is_webview;
 +  bool hidden_page;
 +  bool offscreen;
 +  base::FilePath preload;
@@ -109,7 +109,7 @@ index 4517bf43c1b80f1aa0f3ba8e67e78b8b91e19f8a..492f6c948af74bb925826a1075e6343f
    // only controls whether or not the "document.cookie" field is properly
    // connected to the backing store, for instance if you wanted to be able to
 diff --git a/third_party/blink/public/common/web_preferences/web_preferences_mojom_traits.h b/third_party/blink/public/common/web_preferences/web_preferences_mojom_traits.h
-index 9dbbb581a8876430c3e0a39df1ff655d3ddc6d2d..fd6cbcfa1992a75bf660fb9eb47a9099acb3834f 100644
+index 9dbbb581a8876430c3e0a39df1ff655d3ddc6d2d..98c5c4ac5ee3130581c8576e5ef810a78939f50e 100644
 --- a/third_party/blink/public/common/web_preferences/web_preferences_mojom_traits.h
 +++ b/third_party/blink/public/common/web_preferences/web_preferences_mojom_traits.h
 @@ -6,6 +6,7 @@
@@ -137,8 +137,8 @@ index 9dbbb581a8876430c3e0a39df1ff655d3ddc6d2d..fd6cbcfa1992a75bf660fb9eb47a9099
 +    return r.context_isolation;
 +  }
 +
-+  static int guest_instance_id(const blink::web_pref::WebPreferences& r) {
-+    return r.guest_instance_id;
++  static int is_webview(const blink::web_pref::WebPreferences& r) {
++    return r.is_webview;
 +  }
 +
 +  static bool hidden_page(const blink::web_pref::WebPreferences& r) {
@@ -190,7 +190,7 @@ index 9dbbb581a8876430c3e0a39df1ff655d3ddc6d2d..fd6cbcfa1992a75bf660fb9eb47a9099
      return r.cookie_enabled;
    }
 diff --git a/third_party/blink/public/mojom/webpreferences/web_preferences.mojom b/third_party/blink/public/mojom/webpreferences/web_preferences.mojom
-index eaecb8c2b7dadaf7650bc8ac85cbad4383035e67..7863c865df17fa95965b5a4e543579bac22af90b 100644
+index eaecb8c2b7dadaf7650bc8ac85cbad4383035e67..64d83af36d384d2eb7fdd89a3a0d3665a40354a1 100644
 --- a/third_party/blink/public/mojom/webpreferences/web_preferences.mojom
 +++ b/third_party/blink/public/mojom/webpreferences/web_preferences.mojom
 @@ -10,6 +10,7 @@ import "third_party/blink/public/mojom/v8_cache_options.mojom";
@@ -209,7 +209,7 @@ index eaecb8c2b7dadaf7650bc8ac85cbad4383035e67..7863c865df17fa95965b5a4e543579ba
 +  array<mojo_base.mojom.FilePath> preloads;
 +  int32 opener_id;
 +  bool context_isolation;
-+  int32 guest_instance_id;
++  bool is_webview;
 +  bool hidden_page;
 +  bool offscreen;
 +  mojo_base.mojom.FilePath preload;

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -110,7 +110,7 @@ class WebContentsPreferences
   absl::optional<int> minimum_font_size_;
   absl::optional<std::string> default_encoding_;
   int opener_id_;
-  int guest_instance_id_;
+  bool is_webview_;
   std::vector<std::string> custom_args_;
   std::vector<std::string> custom_switches_;
   absl::optional<std::string> enable_blink_features_;

--- a/shell/browser/web_view_manager.cc
+++ b/shell/browser/web_view_manager.cc
@@ -23,10 +23,13 @@ void WebViewManager::RemoveGuest(int guest_instance_id) {
   web_contents_embedder_map_.erase(guest_instance_id);
 }
 
-content::WebContents* WebViewManager::GetEmbedder(int guest_instance_id) {
-  const auto iter = web_contents_embedder_map_.find(guest_instance_id);
-  return iter == std::end(web_contents_embedder_map_) ? nullptr
-                                                      : iter->second.embedder;
+content::WebContents* WebViewManager::GetEmbedder(
+    content::WebContents* web_contents) {
+  for (auto& item : web_contents_embedder_map_) {
+    if (item.second.web_contents == web_contents)
+      return item.second.embedder;
+  }
+  return nullptr;
 }
 
 bool WebViewManager::ForEachGuest(content::WebContents* embedder_web_contents,

--- a/shell/browser/web_view_manager.cc
+++ b/shell/browser/web_view_manager.cc
@@ -23,15 +23,6 @@ void WebViewManager::RemoveGuest(int guest_instance_id) {
   web_contents_embedder_map_.erase(guest_instance_id);
 }
 
-content::WebContents* WebViewManager::GetEmbedder(
-    content::WebContents* web_contents) {
-  for (auto& item : web_contents_embedder_map_) {
-    if (item.second.web_contents == web_contents)
-      return item.second.embedder;
-  }
-  return nullptr;
-}
-
 bool WebViewManager::ForEachGuest(content::WebContents* embedder_web_contents,
                                   const GuestCallback& callback) {
   for (auto& item : web_contents_embedder_map_) {

--- a/shell/browser/web_view_manager.h
+++ b/shell/browser/web_view_manager.h
@@ -20,7 +20,6 @@ class WebViewManager : public content::BrowserPluginGuestManager {
                 content::WebContents* embedder,
                 content::WebContents* web_contents);
   void RemoveGuest(int guest_instance_id);
-  content::WebContents* GetEmbedder(content::WebContents* web_contents);
 
   static WebViewManager* GetWebViewManager(content::WebContents* web_contents);
 

--- a/shell/browser/web_view_manager.h
+++ b/shell/browser/web_view_manager.h
@@ -20,7 +20,7 @@ class WebViewManager : public content::BrowserPluginGuestManager {
                 content::WebContents* embedder,
                 content::WebContents* web_contents);
   void RemoveGuest(int guest_instance_id);
-  content::WebContents* GetEmbedder(int guest_instance_id);
+  content::WebContents* GetEmbedder(content::WebContents* web_contents);
 
   static WebViewManager* GetWebViewManager(content::WebContents* web_contents);
 

--- a/shell/common/options_switches.cc
+++ b/shell/common/options_switches.cc
@@ -121,9 +121,6 @@ const char kNodeIntegration[] = "nodeIntegration";
 // Enable context isolation of Electron APIs and preload script
 const char kContextIsolation[] = "contextIsolation";
 
-// Instance ID of guest WebContents.
-const char kGuestInstanceID[] = "guestInstanceId";
-
 // Web runtime features.
 const char kExperimentalFeatures[] = "experimentalFeatures";
 

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -66,7 +66,6 @@ extern const char kPreloadScripts[];
 extern const char kPreloadURL[];
 extern const char kNodeIntegration[];
 extern const char kContextIsolation[];
-extern const char kGuestInstanceID[];
 extern const char kExperimentalFeatures[];
 extern const char kOpenerID[];
 extern const char kScrollBounce[];

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -493,9 +493,8 @@ class WebFrameRenderer : public gin::Wrappable<WebFrameRenderer>,
       return gin::ConvertToV8(isolate, prefs.opener_id);
     } else if (pref_name == options::kContextIsolation) {
       return gin::ConvertToV8(isolate, prefs.context_isolation);
-    } else if (pref_name == options::kGuestInstanceID) {
-      // NOTE: guestInstanceId is internal-only.
-      return gin::ConvertToV8(isolate, prefs.guest_instance_id);
+    } else if (pref_name == "isWebView") {
+      return gin::ConvertToV8(isolate, prefs.is_webview);
     } else if (pref_name == options::kHiddenPage) {
       // NOTE: hiddenPage is internal-only.
       return gin::ConvertToV8(isolate, prefs.hidden_page);

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -108,7 +108,7 @@ declare namespace NodeJS {
 
   interface InternalWebPreferences {
     contextIsolation: boolean;
-    guestInstanceId: number;
+    isWebView: boolean;
     hiddenPage: boolean;
     nativeWindowOpen: boolean;
     nodeIntegration: boolean;

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -90,7 +90,6 @@ declare namespace Electron {
   }
 
   interface WebPreferences {
-    guestInstanceId?: number;
     openerId?: number | null;
     disablePopups?: boolean;
     preloadURL?: string;


### PR DESCRIPTION
#### Description of Change
This is going to allow creating the webContents for webview with all webPreferences right away, removing the need for `WebContentsPreferences::Merge`. Enables #30311.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none
