### PR TITLE
feat: support vibrancy on Windows

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1742,17 +1742,47 @@ there is only one tab in the current window.
 
 Adds a window as a tab on this window, after the tab for the window instance.
 
-#### `win.setVibrancy(type)` _macOS_
+#### `win.setVibrancy(type)` _macOS_ _Windows_
 
 * `type` String | null - Can be `appearance-based`, `light`, `dark`, `titlebar`,
-  `selection`, `menu`, `popover`, `sidebar`, `medium-light`, `ultra-dark`, `header`, `sheet`, `window`, `hud`, `fullscreen-ui`, `tooltip`, `content`, `under-window`, or `under-page`. See
-  the [macOS documentation][vibrancy-docs] for more details.
+  `selection`, `menu`, `popover`, `sidebar`, `medium-light`, `ultra-dark`, `header`, `sheet`, `window`, `hud`, `fullscreen-ui`, `tooltip`, `content`, `under-window`, `under-page`, `gradient`, `transparentGradient`, `blur`, or a hex color string with alpha (`#AARRGGBB`).
 
 Adds a vibrancy effect to the browser window. Passing `null` or an empty string
 will remove the vibrancy effect on the window.
 
+The following work exclusively on macOS:
+
+* `appearance-based`
+* `light`
+* `dark`
+* `titlebar`
+* `selection`
+* `menu`
+* `popover`
+* `sidebar`
+* `medium-light`
+* `ultra-dark`
+* `header`
+* `sheet`
+* `window`
+* `hud`
+* `fullscreen-ui`
+* `tooltip`
+* `content`
+* `under-window`
+* `under-page`
+
+See the [macOS documentation][vibrancy-docs] for more details.
+
 Note that `appearance-based`, `light`, `dark`, `medium-light`, and `ultra-dark` have been
 deprecated and will be removed in an upcoming version of macOS.
+
+The following work exclusively on Windows 10 and above:
+
+* `blur`
+* a hex color string with alpha (`#AARRGGBB` e.g. `#18A558FF`)
+
+Note that the newer [acrylic blur style](https://docs.microsoft.com/en-us/windows/apps/design/style/acrylic) only works on Windows 10 RS3 and above - if a hex string is passed, this method will use the acrylic style if it is supported, otherwise it will fall back to `blur`.
 
 #### `win.setTrafficLightPosition(position)` _macOS_
 

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -158,7 +158,7 @@ void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
   if (options.Get(options::kKiosk, &kiosk) && kiosk) {
     SetKiosk(kiosk);
   }
-#if defined(OS_MAC)
+#if defined(OS_MAC) || defined(OS_WIN)
   std::string type;
   if (options.Get(options::kVibrancyType, &type)) {
     SetVibrancy(type);
@@ -354,8 +354,6 @@ void NativeWindow::ToggleTabBar() {}
 bool NativeWindow::AddTabbedWindow(NativeWindow* window) {
   return true;  // for non-Mac platforms
 }
-
-void NativeWindow::SetVibrancy(const std::string& type) {}
 
 void NativeWindow::SetTouchBar(
     std::vector<gin_helper::PersistentDictionary> items) {}

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -202,7 +202,7 @@ class NativeWindow : public base::SupportsUserData,
   virtual void SetAutoHideCursor(bool auto_hide);
 
   // Vibrancy API
-  virtual void SetVibrancy(const std::string& type);
+  virtual void SetVibrancy(const std::string& type) = 0;
 
   // Traffic Light API
 #if defined(OS_MAC)

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -137,6 +137,8 @@ class NativeWindowViews : public NativeWindow,
 
   bool IsVisibleOnAllWorkspaces() override;
 
+  void SetVibrancy(const std::string& type) override;
+
   void SetGTKDarkThemeEnabled(bool use_dark_theme) override;
 
   content::DesktopMediaID GetDesktopMediaID() const override;

--- a/shell/common/color_util.cc
+++ b/shell/common/color_util.cc
@@ -55,10 +55,7 @@ std::string ToRGBAHex(SkColor color, bool include_hash) {
   std::string color_str = base::StringPrintf(
       "%02X%02X%02X%02X", SkColorGetR(color), SkColorGetG(color),
       SkColorGetB(color), SkColorGetA(color));
-  if (include_hash) {
-    return "#" + color_str;
-  }
-  return color_str;
+  return include_hash ? "#" + color_str : color_str;
 }
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/16391.
Closes https://github.com/electron/electron/issues/29937.

Adds vibrancy support for BrowserWindows on Windows.

Screenshot (`vibrancy: 'blur'`):

<img width="823" alt="Screen Shot 2021-07-28 at 1 11 12 AM" src="https://user-images.githubusercontent.com/2036040/127239079-b51e45a2-223b-4837-92e8-8884e65e924c.png">

Screenshot (`vibrancy: '#1F1F0BE5'`):

<img width="851" alt="Screen Shot 2021-07-28 at 9 45 09 AM" src="https://user-images.githubusercontent.com/2036040/127284138-c486bc3c-0c53-451b-a38a-ecb7b8638326.png">

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Adds vibrancy support for BrowserWindows on Windows.