### PR TITLE
fix: guard against missing native view

### DIFF
--- a/shell/browser/api/electron_api_browser_window_views.cc
+++ b/shell/browser/api/electron_api_browser_window_views.cc
@@ -17,14 +17,16 @@ void BrowserWindow::UpdateDraggableRegions(
     return;
 
   if (&draggable_regions_ != &regions) {
-    auto const offset =
-        web_contents()->GetNativeView()->GetBoundsInRootWindow();
-    auto snapped_regions = mojo::Clone(regions);
-    for (auto& snapped_region : snapped_regions) {
-      snapped_region->bounds.Offset(offset.x(), offset.y());
-    }
+    auto* nv = web_contents()->GetNativeView();
+    if (nv) {
+      auto const offset = nv->GetBoundsInRootWindow();
+      auto snapped_regions = mojo::Clone(regions);
+      for (auto& snapped_region : snapped_regions) {
+        snapped_region->bounds.Offset(offset.x(), offset.y());
+      }
 
-    draggable_regions_ = mojo::Clone(snapped_regions);
+      draggable_regions_ = mojo::Clone(snapped_regions);
+    }
   }
 
   static_cast<NativeWindowViews*>(window_.get())


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/30287.

Fixes a potential crash that would occur if there was no `NativeView` - e.g. if a window had just been closed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes a potential crash that would occur with draggable regions on Windows.
