### PR TITLE
fix: use `contentAspectRatio` in `setAspectRatio()` on macOS

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1601,7 +1601,7 @@ void NativeWindowMac::SetAspectRatio(double aspect_ratio,
 
   // Reset the behaviour to default if aspect_ratio is set to 0 or less.
   if (aspect_ratio > 0.0)
-    [window_ setAspectRatio:NSMakeSize(aspect_ratio, 1.0)];
+    [window_ setContentAspectRatio:NSMakeSize(aspect_ratio, 1.0)];
   else
     [window_ setResizeIncrements:NSMakeSize(1.0, 1.0)];
 }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/30277.

Fixes an issue where the aspect ratio would (incorrectly) take the height of the title bar into account when maximizing the window.

This fixes the issue by instead using a more specific `setContentAspectRatio` method such that macOS considers only the content view and not the whole NSWindow when calculating width.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue where a specified aspect ratio could become incorrect when maximizing a window on macOS.