### PR TITLE
fix: respect LogJsConsoleMessages feature in InspectableWebContents::DidAddMessageToConsole

### DIFF
--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -9,7 +9,6 @@
 #include <utility>
 
 #include "base/base64.h"
-#include "base/feature_list.h"
 #include "base/guid.h"
 #include "base/json/json_reader.h"
 #include "base/json/json_writer.h"
@@ -28,7 +27,6 @@
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
-#include "content/public/browser/console_message.h"
 #include "content/public/browser/file_select_listener.h"
 #include "content/public/browser/file_url_loader.h"
 #include "content/public/browser/host_zoom_map.h"
@@ -37,8 +35,6 @@
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/shared_cors_origin_access_list.h"
 #include "content/public/browser/storage_partition.h"
-#include "content/public/common/content_features.h"
-#include "content/public/common/url_utils.h"
 #include "content/public/common/user_agent.h"
 #include "ipc/ipc_channel.h"
 #include "net/http/http_response_headers.h"
@@ -973,29 +969,6 @@ void InspectableWebContents::WebContentsDestroyed() {
 
   if (view_ && view_->GetDelegate())
     view_->GetDelegate()->DevToolsClosed();
-}
-
-bool InspectableWebContents::DidAddMessageToConsole(
-    content::WebContents* source,
-    blink::mojom::ConsoleMessageLevel level,
-    const std::u16string& message,
-    int32_t line_no,
-    const std::u16string& source_id) {
-  // cf.
-  // https://source.chromium.org/chromium/chromium/src/+/main:content/browser/log_console_message.cc;l=15;drc=e99bf3c8e0f35f1f82a12338cd1f9f064b5408c5
-  bool is_builtin_component = HasWebUIScheme(source->GetLastCommittedURL());
-  const int32_t resolved_level =
-      is_builtin_component
-          ? content::ConsoleMessageLevelToLogSeverity(log_level)
-          : ::logging::LOG_INFO;
-  if (::logging::GetMinLogLevel() > resolved_level)
-    return;
-  if (!base::FeatureList::IsEnabled(features::kLogJsConsoleMessages))
-    return;
-  logging::LogMessage("CONSOLE", line_no, resolved_level).stream()
-      << "\"" << message << "\", source: " << source_id << " (" << line_no
-      << ")";
-  return true;
 }
 
 bool InspectableWebContents::HandleKeyboardEvent(

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "base/base64.h"
+#include "base/feature_list.h"
 #include "base/guid.h"
 #include "base/json/json_reader.h"
 #include "base/json/json_writer.h"
@@ -27,6 +28,7 @@
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
+#include "content/public/browser/console_message.h"
 #include "content/public/browser/file_select_listener.h"
 #include "content/public/browser/file_url_loader.h"
 #include "content/public/browser/host_zoom_map.h"
@@ -35,6 +37,8 @@
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/shared_cors_origin_access_list.h"
 #include "content/public/browser/storage_partition.h"
+#include "content/public/common/content_features.h"
+#include "content/public/common/url_utils.h"
 #include "content/public/common/user_agent.h"
 #include "ipc/ipc_channel.h"
 #include "net/http/http_response_headers.h"
@@ -977,9 +981,18 @@ bool InspectableWebContents::DidAddMessageToConsole(
     const std::u16string& message,
     int32_t line_no,
     const std::u16string& source_id) {
-  logging::LogMessage("CONSOLE", line_no,
-                      blink::ConsoleMessageLevelToLogSeverity(level))
-          .stream()
+  // cf.
+  // https://source.chromium.org/chromium/chromium/src/+/main:content/browser/log_console_message.cc;l=15;drc=e99bf3c8e0f35f1f82a12338cd1f9f064b5408c5
+  bool is_builtin_component = HasWebUIScheme(source->GetLastCommittedURL());
+  const int32_t resolved_level =
+      is_builtin_component
+          ? content::ConsoleMessageLevelToLogSeverity(log_level)
+          : ::logging::LOG_INFO;
+  if (::logging::GetMinLogLevel() > resolved_level)
+    return;
+  if (!base::FeatureList::IsEnabled(features::kLogJsConsoleMessages))
+    return;
+  logging::LogMessage("CONSOLE", line_no, resolved_level).stream()
       << "\"" << message << "\", source: " << source_id << " (" << line_no
       << ")";
   return true;

--- a/shell/browser/ui/inspectable_web_contents.h
+++ b/shell/browser/ui/inspectable_web_contents.h
@@ -175,11 +175,6 @@ class InspectableWebContents
       content::NavigationHandle* navigation_handle) override;
 
   // content::WebContentsDelegate:
-  bool DidAddMessageToConsole(content::WebContents* source,
-                              blink::mojom::ConsoleMessageLevel level,
-                              const std::u16string& message,
-                              int32_t line_no,
-                              const std::u16string& source_id) override;
   bool HandleKeyboardEvent(content::WebContents*,
                            const content::NativeWebKeyboardEvent&) override;
   void CloseContents(content::WebContents* source) override;


### PR DESCRIPTION
#### Description of Change
The LogJsConsoleMessages feature is supposed to control whether `CONSOLE`
messages are printed to logs.

RFH::DidAddMessageToConsole respects this: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/renderer_host/render_frame_host_impl.cc;l=3275;drc=e99bf3c8e0f35f1f82a12338cd1f9f064b5408c5

but InspectableWebContents::DidAddMessageToConsole didn't.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed some console messages still being printed to logs when the LogJsConsoleMessages feature was disabled.
