### PR TITLE
Update setWindowOpenHandler "features" docs

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1134,7 +1134,7 @@ Ignore application menu shortcuts while this web contents is focused.
   * `details` Object
     * `url` String - The _resolved_ version of the URL passed to `window.open()`. e.g. opening a window with `window.open('foo')` will yield something like `https://the-origin/the/current/path/foo`.
     * `frameName` String - Name of the window provided in `window.open()`
-    * `features` String - Comma separated list of window features provided to `window.open()`.
+    * `features` String - Third argument provided to `window.open()`, usually a comma separated list of window features.
     * `disposition` String - Can be `default`, `foreground-tab`, `background-tab`,
       `new-window`, `save-to-disk` or `other`.
     * `referrer` [Referrer](structures/referrer.md) - The referrer that will be


### PR DESCRIPTION
#### Description of Change

Since the introduction of `setWindowOpenHandler` `features` is no longer parsed but passed as a raw string (see https://github.com/electron/electron/pull/28518#issuecomment-814304970). I've switched to JSON to pass data through `window.open` for my multi-window application. The docs should reflect that this can be an arbitrary string.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added

#### Release Notes

None
