### PR TITLE
docs: fix camelcase in menu example

### DIFF
--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -152,16 +152,16 @@ const { app, Menu } = require('electron')
 
 const isMac = process.platform === 'darwin'
 
-const template = [            // TypeScript: const template : MenuItemConstructorOptions[] = [
+const template = [
   // { role: 'appMenu' }
   ...(isMac ? [{
     label: app.name,
     submenu: [
-      { role: 'about' },      // TypeScript generalizes here 'about' to type string which
-      { type: 'separator' },  // conflicts with the type definition of MenuItemConstructorOptions.
-      { role: 'services' },   // For TS add "as const" after all role/type identifiers like:
-      { type: 'separator' },  // { type: 'separator' as const },
-      { role: 'hide' },       // in all sub-menus using the "...(isXXX ? [{}] : [])" pattern.
+      { role: 'about' },
+      { type: 'separator' },
+      { role: 'services' },
+      { type: 'separator' },
+      { role: 'hide' },
       { role: 'hideOthers' },
       { role: 'unhide' },
       { type: 'separator' },

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -157,12 +157,12 @@ const template = [
   ...(isMac ? [{
     label: app.name,
     submenu: [
-      { role: 'about' },
-      { type: 'separator' },
-      { role: 'services' },
-      { type: 'separator' },
-      { role: 'hide' },
-      { role: 'hideothers' },
+      { role: 'about' },      // Typescript generalizes here 'about' to type string which
+      { type: 'separator' },  // conflicts with the type definition of MenuItemConstructorOptions.
+      { role: 'services' },   // For TS add "as const" after all role/type identifiers like:
+      { type: 'separator' },  // { type: 'separator' as const },
+      { role: 'hide' },       // in all sub-menus using the "...(isXXX ? [{}] : [])" pattern.
+      { role: 'hideOthers' },
       { role: 'unhide' },
       { type: 'separator' },
       { role: 'quit' }

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -152,12 +152,12 @@ const { app, Menu } = require('electron')
 
 const isMac = process.platform === 'darwin'
 
-const template = [
+const template = [            // TypeScript: const template : MenuItemConstructorOptions[] = [
   // { role: 'appMenu' }
   ...(isMac ? [{
     label: app.name,
     submenu: [
-      { role: 'about' },      // Typescript generalizes here 'about' to type string which
+      { role: 'about' },      // TypeScript generalizes here 'about' to type string which
       { type: 'separator' },  // conflicts with the type definition of MenuItemConstructorOptions.
       { role: 'services' },   // For TS add "as const" after all role/type identifiers like:
       { type: 'separator' },  // { type: 'separator' as const },


### PR DESCRIPTION
hideothers -> hideOthers (the TS compiler caught this)
The TypeScript compiler also did not like the pattern used to
switch between platforms for submenus was loosing the type information
of the literal constants and generalized them as strings which
conflicts with the type definition of MenuItemConstructorOptions.

#### Description of Change
This pull request is about
1) fixing an identifier in the menu template example documentation where the type definition demands camel-case but the example lacked said camel-case in "hideOthers".
2) when tying to use the template example in a TypeScript project the example did not compile as the type definition for MenuItemConstructorOptions used literal constants. The TS compile however can not interfere the correct type in the construct used in the example and generalized the values to string which then caused a compiler type error preventing the compilation. Considering the increasing use of TS (the most popular Electron Angular boilerplate has a main process in TS) and the challenge to identify and fix this type error a hint seemed to be warranted which was added as a comment.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
