### PR TITLE
feat: add webContents.getResourceUsage()

### DIFF
--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -318,6 +318,8 @@ class WebContents : public gin::Wrappable<WebContents>,
   v8::Local<v8::Promise> TakeHeapSnapshot(v8::Isolate* isolate,
                                           const base::FilePath& file_path);
 
+  v8::Local<v8::Promise> GetResourceUsage(v8::Isolate* isolate);
+
   // Properties.
   int32_t ID() const { return id_; }
   v8::Local<v8::Value> Session(v8::Isolate* isolate);


### PR DESCRIPTION
#### Description of Change
Adds a new API, `webContents.getResourceUsage`, which returns some details
about the underlying process's memory usage. Thin wrapper around
[ResourceUsageReporter](https://source.chromium.org/chromium/chromium/src/+/main:content/public/common/resource_usage_reporter.mojom;l=39;drc=d0b89fe9c3d6ecc1ec4ffaf0baeb6b36c34ba7fd).

Ref #27375.

I'm not sure this API adds much value, given the existence of
`app.getAppMetrics()`, `process.getHeapStatistics()`,
`webFrame.getResourceUsage()` and other related memory-information-related
methods.

The underlying API can also return some information about Blink resource usage.
I haven't included that here, but only because this is just a suggestion.
If I were to flesh this out I would probably add the Blink data that's given in
the reply.

This should probably also be on WebFrameMain instead of (or as well as)
WebContents, since OOPIFs don't get their own WebContents. We don't (yet?) have
an API for enumerating processes, but if we did that would probably be a still
better place for this.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
