### PR TITLE
docs: crashpad on linux lands in 16, not 15

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -12,7 +12,7 @@ This document uses the following convention to categorize breaking changes:
 * **Deprecated:** An API was marked as deprecated. The API will continue to function, but will emit a deprecation warning, and will be removed in a future release.
 * **Removed:** An API or feature was removed, and is no longer supported by Electron.
 
-## Planned Breaking API Changes (15.0)
+## Planned Breaking API Changes (16.0)
 
 ### Behavior Changed: `crashReporter` implementation switched to Crashpad on Linux
 


### PR DESCRIPTION
#### Description of Change
I got confused about which release this was landing in.

Notes: none