### PR TITLE
build: rebase release branch before reverting bump

### DIFF
--- a/script/release/release-artifact-cleanup.js
+++ b/script/release/release-artifact-cleanup.js
@@ -26,6 +26,7 @@ function getLastBumpCommit (tag) {
 async function revertBumpCommit (tag) {
   const branch = await getCurrentBranch();
   const commitToRevert = getLastBumpCommit(tag).hash;
+  await GitProcess.exec(['pull', '--rebase']);
   await GitProcess.exec(['revert', commitToRevert], ELECTRON_DIR);
   const pushDetails = await GitProcess.exec(['push', 'origin', `HEAD:${branch}`, '--follow-tags'], ELECTRON_DIR);
   if (pushDetails.exitCode === 0) {


### PR DESCRIPTION
Ensures that we rebase to the current upstream before trying to push a revert commit, handles a race condition between a release failing and a new commit landing on the upstream that would have prevented the revert being pushed.

Pairs up with https://github.com/electron/sudowoodo/pull/214

Notes: no-notes