### PR TITLE
fix: respect image animation policy pref

### DIFF
--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -423,7 +423,7 @@ void WebContentsPreferences::OverrideWebkitPrefs(
     blink::web_pref::WebPreferences* prefs) {
   prefs->javascript_enabled = javascript_;
   prefs->images_enabled = images_;
-  // GetImageAnimationPolicy(&preference_, &prefs->animation_policy);
+  prefs->animation_policy = image_animation_policy_;
   prefs->text_areas_are_resizable = text_areas_are_resizable_;
   prefs->navigate_on_drag_drop = navigate_on_drag_drop_;
   prefs->autoplay_policy = autoplay_policy_;


### PR DESCRIPTION
#### Description of Change
This was broken by the refactor in #30193.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed imageAnimationPolicy not being respected.
