### PR TITLE
chore: cherry-pick a73237da91de from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -144,3 +144,4 @@ cherry-pick-3feda0244490.patch
 cherry-pick-cd98d7c0dae9.patch
 replace_first_of_two_waitableevents_in_creditcardaccessmanager.patch
 cherry-pick-ac9dc1235e28.patch
+cherry-pick-a73237da91de.patch

--- a/patches/chromium/cherry-pick-a73237da91de.patch
+++ b/patches/chromium/cherry-pick-a73237da91de.patch
@@ -1,0 +1,125 @@
+From a73237da91de8aa49aaa5d9479bae51cf387f090 Mon Sep 17 00:00:00 2001
+From: Robert Flack <flackr@chromium.org>
+Date: Tue, 13 Jul 2021 18:36:42 +0000
+Subject: [PATCH] Forbid script execution for entire lifecycle update
+
+We should not execute script during the lifecycle update except in cases where we we know it is safe to do so, either because we will rerun the lifecycle steps if anything is invalidated (resize observers, intersection observers) or because the script does not have access to invalidate the DOM (e.g. paint worklets).
+
+Bug: 1196853
+Change-Id: Id1fdbbb25107cfdc6c234123f845406c28d32914
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2815619
+Reviewed-by: Stefan Zager <szager@chromium.org>
+Commit-Queue: Robert Flack <flackr@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#901110}
+---
+
+diff --git a/third_party/blink/renderer/core/exported/web_plugin_container_impl.cc b/third_party/blink/renderer/core/exported/web_plugin_container_impl.cc
+index b21bc31..d13f05e 100644
+--- a/third_party/blink/renderer/core/exported/web_plugin_container_impl.cc
++++ b/third_party/blink/renderer/core/exported/web_plugin_container_impl.cc
+@@ -95,6 +95,7 @@
+ #include "third_party/blink/renderer/core/script/classic_script.h"
+ #include "third_party/blink/renderer/core/scroll/scroll_animator_base.h"
+ #include "third_party/blink/renderer/core/scroll/scrollbar_theme.h"
++#include "third_party/blink/renderer/platform/bindings/script_forbidden_scope.h"
+ #include "third_party/blink/renderer/platform/exported/wrapped_resource_response.h"
+ #include "third_party/blink/renderer/platform/geometry/layout_rect.h"
+ #include "third_party/blink/renderer/platform/graphics/graphics_context.h"
+@@ -786,6 +787,8 @@
+   }
+ 
+   if (web_plugin_) {
++    // Plugins may execute script on being detached during the lifecycle update.
++    ScriptForbiddenScope::AllowUserAgentScript allow_script;
+     CHECK(web_plugin_->Container() == this);
+     web_plugin_->Destroy();
+     web_plugin_ = nullptr;
+diff --git a/third_party/blink/renderer/core/frame/local_frame_view.cc b/third_party/blink/renderer/core/frame/local_frame_view.cc
+index e4d8388..b4ff8c6 100644
+--- a/third_party/blink/renderer/core/frame/local_frame_view.cc
++++ b/third_party/blink/renderer/core/frame/local_frame_view.cc
+@@ -2372,6 +2372,7 @@
+ 
+ void LocalFrameView::UpdateLifecyclePhasesInternal(
+     DocumentLifecycle::LifecycleState target_state) {
++  ScriptForbiddenScope forbid_script;
+   // RunScrollTimelineSteps must not run more than once.
+   bool should_run_scroll_timeline_steps = true;
+ 
+@@ -2473,6 +2474,10 @@
+         continue;
+     }
+ 
++    // At this point in time, script is allowed to run as we will repeat the
++    // lifecycle update if anything is invalidated.
++    ScriptForbiddenScope::AllowUserAgentScript allow_script;
++
+     // ResizeObserver and post-layout IntersectionObserver observation
+     // deliveries may dirty style and layout. RunResizeObserverSteps will return
+     // true if any observer ran that may have dirtied style or layout;
+@@ -2724,6 +2729,7 @@
+ }
+ 
+ void LocalFrameView::RunPaintLifecyclePhase(PaintBenchmarkMode benchmark_mode) {
++  DCHECK(ScriptForbiddenScope::IsScriptForbidden());
+   DCHECK(LocalFrameTreeAllowsThrottling());
+   TRACE_EVENT0("blink,benchmark", "LocalFrameView::RunPaintLifecyclePhase");
+   // While printing or capturing a paint preview of a document, the paint walk
+@@ -2763,15 +2769,9 @@
+             area->UpdateCompositorScrollAnimations();
+         }
+         Document& document = frame_view.GetLayoutView()->GetDocument();
+-        {
+-          // Updating animations can notify ready promises which could mutate
+-          // the DOM. We should delay these until we have finished the lifecycle
+-          // update. https://crbug.com/1196781
+-          ScriptForbiddenScope forbid_script;
+-          document.GetDocumentAnimations().UpdateAnimations(
+-              DocumentLifecycle::kPaintClean, paint_artifact_compositor_.get(),
+-              needed_update);
+-        }
++        document.GetDocumentAnimations().UpdateAnimations(
++            DocumentLifecycle::kPaintClean, paint_artifact_compositor_.get(),
++            needed_update);
+         total_animations_count +=
+             document.GetDocumentAnimations().GetAnimationsCount();
+       });
+@@ -4422,6 +4422,7 @@
+     // so painting the tree should just clear the previous painted output.
+     DCHECK(!IsUpdatingLifecycle());
+     AllowThrottlingScope allow_throtting(*this);
++    ScriptForbiddenScope forbid_script;
+     RunPaintLifecyclePhase(PaintBenchmarkMode::kNormal);
+   }
+ 
+@@ -4950,6 +4951,7 @@
+       // quantization when the time is very small.
+       base::LapTimer timer(kWarmupRuns, kTimeLimit, kTimeCheckInterval);
+       do {
++        ScriptForbiddenScope forbid_script;
+         // Force a paint with everything cached before a small invalidation
+         // test to better simulate real-world scenarios.
+         if (mode == PaintBenchmarkMode::kSmallInvalidation)
+diff --git a/third_party/blink/renderer/modules/csspaint/paint_worklet.cc b/third_party/blink/renderer/modules/csspaint/paint_worklet.cc
+index e6e0c5b..618e08f 100644
+--- a/third_party/blink/renderer/modules/csspaint/paint_worklet.cc
++++ b/third_party/blink/renderer/modules/csspaint/paint_worklet.cc
+@@ -17,6 +17,7 @@
+ #include "third_party/blink/renderer/modules/csspaint/paint_worklet_global_scope.h"
+ #include "third_party/blink/renderer/modules/csspaint/paint_worklet_id_generator.h"
+ #include "third_party/blink/renderer/modules/csspaint/paint_worklet_messaging_proxy.h"
++#include "third_party/blink/renderer/platform/bindings/script_forbidden_scope.h"
+ #include "third_party/blink/renderer/platform/graphics/paint_generated_image.h"
+ 
+ namespace blink {
+@@ -126,6 +127,10 @@
+           layout_object.GetDocument(), layout_object.StyleRef(),
+           paint_definition->NativeInvalidationProperties(),
+           paint_definition->CustomInvalidationProperties());
++  // The PaintWorkletGlobalScope is sufficiently isolated that it is safe to
++  // run during the lifecycle update without concern for it causing
++  // invalidations to the lifecycle.
++  ScriptForbiddenScope::AllowUserAgentScript allow_script;
+   sk_sp<PaintRecord> paint_record = paint_definition->Paint(
+       container_size, zoom, style_map, data, device_scale_factor);
+   if (!paint_record)


### PR DESCRIPTION
Forbid script execution for entire lifecycle update

We should not execute script during the lifecycle update except in cases where we we know it is safe to do so, either because we will rerun the lifecycle steps if anything is invalidated (resize observers, intersection observers) or because the script does not have access to invalidate the DOM (e.g. paint worklets).

Bug: 1196853
Change-Id: Id1fdbbb25107cfdc6c234123f845406c28d32914
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2815619
Reviewed-by: Stefan Zager <szager@chromium.org>
Commit-Queue: Robert Flack <flackr@chromium.org>
Cr-Commit-Position: refs/heads/master@{#901110}


Notes: Security: backported fix for 1196853.