### PR TITLE
fix: build SetCrashKeyGW without tray on Windows

### DIFF
--- a/shell/common/crash_keys.cc
+++ b/shell/common/crash_keys.cc
@@ -41,13 +41,15 @@
 #include "shell/browser/api/electron_api_service_worker_context.h"
 #include "shell/browser/api/electron_api_session.h"
 #include "shell/browser/api/electron_api_system_preferences.h"
-#include "shell/browser/api/electron_api_tray.h"
 #include "shell/browser/api/electron_api_url_loader.h"
 #include "shell/browser/api/electron_api_web_contents.h"
 #include "shell/browser/api/electron_api_web_frame_main.h"
 #include "shell/browser/api/electron_api_web_request.h"
 #include "shell/browser/api/event.h"
 #include "shell/common/api/electron_api_native_image.h"
+#if !defined(OS_WIN)
+#include "shell/browser/api/electron_api_tray.h"
+#endif
 
 namespace electron {
 
@@ -205,6 +207,10 @@ void SetCrashKeyForGinWrappable(gin::WrapperInfo* info) {
   else if (info == &electron::api::DesktopCapturer::kWrapperInfo)
     crash_location = "DesktopCapturer";
 #endif
+#if !defined(OS_WIN)
+  else if (info == &electron::api::Tray::kWrapperInfo)
+    crash_location = "Tray";
+#endif  // OS_WIN
   else if (info == &electron::api::NetLog::kWrapperInfo)
     crash_location = "NetLog";
   else if (info == &electron::api::NativeImage::kWrapperInfo)
@@ -235,8 +241,6 @@ void SetCrashKeyForGinWrappable(gin::WrapperInfo* info) {
     crash_location = "GlobalShortcut";
   else if (info == &electron::api::InAppPurchase::kWrapperInfo)
     crash_location = "InAppPurchase";
-  else if (info == &electron::api::Tray::kWrapperInfo)
-    crash_location = "Tray";
   else if (info == &electron::api::DataPipeHolder::kWrapperInfo)
     crash_location = "DataPipeHolder";
   else if (info == &electron::api::AutoUpdater::kWrapperInfo)


### PR DESCRIPTION
#### Description of Change

Changed here: #30404  When trying to build on Windows, the tray_icon.h include within crash_keys.cc causes build errors. This PR fixes the build on master by gating the import to non-Windows OS'es.

(Marking as no backport because the backport PRs for the original PR have not been merged yet, so we can add the fix to them directly 🙂)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
