### PR TITLE
fix: explicitly define REFGUID from ::GUID&, not base::GUID

### DIFF
--- a/shell/common/crash_keys.cc
+++ b/shell/common/crash_keys.cc
@@ -41,15 +41,13 @@
 #include "shell/browser/api/electron_api_service_worker_context.h"
 #include "shell/browser/api/electron_api_session.h"
 #include "shell/browser/api/electron_api_system_preferences.h"
+#include "shell/browser/api/electron_api_tray.h"
 #include "shell/browser/api/electron_api_url_loader.h"
 #include "shell/browser/api/electron_api_web_contents.h"
 #include "shell/browser/api/electron_api_web_frame_main.h"
 #include "shell/browser/api/electron_api_web_request.h"
 #include "shell/browser/api/event.h"
 #include "shell/common/api/electron_api_native_image.h"
-#if !defined(OS_WIN)
-#include "shell/browser/api/electron_api_tray.h"
-#endif
 
 namespace electron {
 
@@ -207,10 +205,8 @@ void SetCrashKeyForGinWrappable(gin::WrapperInfo* info) {
   else if (info == &electron::api::DesktopCapturer::kWrapperInfo)
     crash_location = "DesktopCapturer";
 #endif
-#if !defined(OS_WIN)
   else if (info == &electron::api::Tray::kWrapperInfo)
     crash_location = "Tray";
-#endif  // OS_WIN
   else if (info == &electron::api::NetLog::kWrapperInfo)
     crash_location = "NetLog";
   else if (info == &electron::api::NativeImage::kWrapperInfo)

--- a/shell/common/gin_converters/guid_converter.h
+++ b/shell/common/gin_converters/guid_converter.h
@@ -9,6 +9,12 @@
 
 #include "gin/converter.h"
 
+#ifdef _REFGUID_DEFINED
+#undef REFGUID
+#endif
+#define REFGUID const ::GUID&
+#define _REFGUID_DEFINED
+
 #if defined(OS_WIN)
 #include <rpc.h>
 

--- a/shell/common/gin_converters/guid_converter.h
+++ b/shell/common/gin_converters/guid_converter.h
@@ -9,13 +9,18 @@
 
 #include "gin/converter.h"
 
+#if defined(OS_WIN)
+// c.f.:
+// https://chromium-review.googlesource.com/c/chromium/src/+/3076480
+// REFGUID is currently incorrectly inheriting its type
+// from base::GUID, when it should be inheriting from ::GUID.
+// This workaround prevents build errors until the CL is merged
 #ifdef _REFGUID_DEFINED
 #undef REFGUID
 #endif
 #define REFGUID const ::GUID&
 #define _REFGUID_DEFINED
 
-#if defined(OS_WIN)
 #include <rpc.h>
 
 #include "base/strings/sys_string_conversions.h"
@@ -24,7 +29,6 @@
 
 #if defined(OS_WIN)
 typedef GUID UUID;
-const GUID GUID_NULL = {};
 #else
 typedef struct {
 } UUID;
@@ -64,6 +68,7 @@ struct Converter<UUID> {
   }
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, UUID val) {
 #if defined(OS_WIN)
+    const GUID GUID_NULL = {};
     if (val == GUID_NULL) {
       return StringToV8(isolate, "");
     } else {


### PR DESCRIPTION
#### Description of Change

Workaround before this CL merges: https://chromium-review.googlesource.com/c/chromium/src/+/3076480

Currently if you `#include "base/guid.h"` before `#include "base/win/win_util.h"`, clang will throw an error. It turns out `REFGUID `is defined as `#define REFGUID const GUID&`. By the rules of C++ unqualified name lookup, this will first check `base::win::GUID`, then `base::GUID`, followed by `GUID` (aka `::GUID`) if none of the previous ones exist. Thus, our value's type was being set as `base::GUID`.

This PR undefines and redefines `REFGUID`, in case it was incorrectly defined with `base::GUID` in a previous file. We can remove this once the above CL lands/is backported.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
