### PR TITLE
fix: mouse doesn't work on frameless browserwindows

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -217,9 +217,7 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
 #endif
 
   widget()->Init(std::move(params));
-#if defined(OS_WIN)
   SetCanResize(resizable_);
-#endif
 
   bool fullscreen = false;
   options.Get(options::kFullscreen, &fullscreen);


### PR DESCRIPTION
#### Description of Change

Fixes #30402. This the issue that @electron/wg-releases marked as a stable blocker last week.

This bug is from the "CanResize has been de-virtualized" refactor in https://github.com/electron/electron/pull/29256

One-sentence summary: In order for [CanResize()](https://source.chromium.org/chromium/chromium/src/+/main:ui/views/widget/widget_delegate.cc;l=97?q=SetCanResize&ss=chromium%2Fchromium%2Fsrc) to return the right value [here](https://github.com/electron/electron/pull/29721/files#diff-5e25c7662c97f9f68ed2d91bac1c44f260b62c541617e4f115236cc7f4a73ab9R39), we need to call [SetCanResize()](https://source.chromium.org/chromium/chromium/src/+/main:ui/views/widget/widget_delegate.cc;l=321?q=SetCanResize&ss=chromium%2Fchromium%2Fsrc) first.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix beta-only bug that caused mouse clicks to not be processed in frameless windows.