### PR TITLE
docs: add missing <webview> event documentation

### DIFF
--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -834,6 +834,19 @@ this purpose.
 
 Calling `event.preventDefault()` does __NOT__ have any effect.
 
+### Event: 'did-start-navigation'
+
+Returns:
+
+* `url` String
+* `isInPlace` Boolean
+* `isMainFrame` Boolean
+* `frameProcessId` Integer
+* `frameRoutingId` Integer
+
+Emitted when any frame (including main) starts navigating. `isInPlace` will be
+`true` for in-page navigations.
+
 ### Event: 'did-navigate'
 
 Returns:
@@ -841,6 +854,23 @@ Returns:
 * `url` String
 
 Emitted when a navigation is done.
+
+This event is not emitted for in-page navigations, such as clicking anchor links
+or updating the `window.location.hash`. Use `did-navigate-in-page` event for
+this purpose.
+
+### Event: 'did-frame-navigate'
+
+Returns:
+
+* `url` String
+* `httpResponseCode` Integer - -1 for non HTTP navigations
+* `httpStatusText` String - empty for non HTTP navigations,
+* `isMainFrame` Boolean
+* `frameProcessId` Integer
+* `frameRoutingId` Integer
+
+Emitted when any frame navigation is done.
 
 This event is not emitted for in-page navigations, such as clicking anchor links
 or updating the `window.location.hash`. Use `did-navigate-in-page` event for


### PR DESCRIPTION
#### Description of Change
We are missing the documentation and generated types for these `<webview>` events:
https://github.com/electron/electron/blob/66c458a3530ed857955eb285700156b00bfc0271/lib/common/web-view-events.ts#L17
https://github.com/electron/electron/blob/66c458a3530ed857955eb285700156b00bfc0271/lib/common/web-view-events.ts#L19

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added

#### Release Notes
Notes: none
