### PR TITLE
feat: add textWidth option to dialog.showMessageBox()

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -234,6 +234,7 @@ expanding and collapsing the dialog.
   * `title` String (optional) - Title of the message box, some platforms will not show it.
   * `detail` String (optional) - Extra information of the message.
   * `icon` ([NativeImage](native-image.md) | String) (optional)
+  * `textWidth` Integer (optional) _macOS_ - Custom width of the text in the message box.
   * `cancelId` Integer (optional) - The index of the button to be used to cancel the dialog, via
     the `Esc` key. By default this is assigned to the first button with "cancel" or "no" as the
     label. If no such labeled buttons exist and this option is not set, `0` will be used as the
@@ -285,6 +286,7 @@ If `browserWindow` is not shown dialog will not be attached to it. In such case 
   * `checkboxChecked` Boolean (optional) - Initial checked state of the
     checkbox. `false` by default.
   * `icon` [NativeImage](native-image.md) (optional)
+  * `textWidth` Integer (optional) _macOS_ - Custom width of the text in the message box.
   * `cancelId` Integer (optional) - The index of the button to be used to cancel the dialog, via
     the `Esc` key. By default this is assigned to the first button with "cancel" or "no" as the
     label. If no such labeled buttons exist and this option is not set, `0` will be used as the

--- a/lib/browser/api/dialog.ts
+++ b/lib/browser/api/dialog.ts
@@ -168,6 +168,7 @@ const messageBox = (sync: boolean, window: BrowserWindow | null, options?: Messa
     defaultId = -1,
     detail = '',
     icon = null,
+    textWidth = 0,
     noLink = false,
     message = '',
     title = '',
@@ -225,7 +226,8 @@ const messageBox = (sync: boolean, window: BrowserWindow | null, options?: Messa
     detail,
     checkboxLabel,
     checkboxChecked,
-    icon
+    icon,
+    textWidth
   };
 
   if (sync) {

--- a/shell/browser/ui/message_box.h
+++ b/shell/browser/ui/message_box.h
@@ -38,6 +38,7 @@ struct MessageBoxSettings {
   std::string checkbox_label;
   bool checkbox_checked = false;
   gfx::ImageSkia icon;
+  int text_width = 0;
 
   MessageBoxSettings();
   MessageBoxSettings(const MessageBoxSettings&);

--- a/shell/browser/ui/message_box_mac.mm
+++ b/shell/browser/ui/message_box_mac.mm
@@ -98,6 +98,12 @@ NSAlert* CreateNSAlert(const MessageBoxSettings& settings) {
     [alert setIcon:image];
   }
 
+  if (settings.text_width > 0) {
+    NSRect rect = NSMakeRect(0, 0, settings.text_width, 0);
+    NSView* accessoryView = [[NSView alloc] initWithFrame:rect];
+    [alert setAccessoryView:[accessoryView autorelease]];
+  }
+
   return alert;
 }
 

--- a/shell/common/gin_converters/message_box_converter.cc
+++ b/shell/common/gin_converters/message_box_converter.cc
@@ -32,6 +32,7 @@ bool Converter<electron::MessageBoxSettings>::FromV8(
   dict.Get("noLink", &out->no_link);
   dict.Get("checkboxChecked", &out->checkbox_checked);
   dict.Get("icon", &out->icon);
+  dict.Get("textWidth", &out->text_width);
   return true;
 }
 


### PR DESCRIPTION
#### Description of Change
This allows working around the overly narrow `NSAlert` dialogs on macOS Big Sur. Default:
<img width="912" alt="Screen Shot 2021-08-10 at 8 50 33 PM" src="https://user-images.githubusercontent.com/1281234/128918328-d97d4787-ac59-401d-8e8e-a0818149bd17.png">

textWidth = 420:
<img width="912" alt="Screen Shot 2021-08-10 at 8 51 24 PM" src="https://user-images.githubusercontent.com/1281234/128918310-19d2a94e-5258-4288-b2ee-ef137e71641e.png">

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `textWidth` option to `dialog.showMessageBox()` / `dialog.showMessageBoxSync()`.