### PR TITLE
fix: potential crash when setting vibrancy

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1652,8 +1652,7 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
   node::Environment* env =
       node::Environment::GetCurrent(v8::Isolate::GetCurrent());
 
-  NSVisualEffectMaterial vibrancyType;
-
+  NSVisualEffectMaterial vibrancyType{};
   if (type == "appearance-based") {
     EmitWarning(env, "NSVisualEffectMaterialAppearanceBased" + dep_warn,
                 "electron");
@@ -1710,8 +1709,10 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
     }
   }
 
-  if (vibrancyType)
+  if (vibrancyType) {
+    vibrancy_type_ = type;
     [effect_view setMaterial:vibrancyType];
+  }
 }
 
 void NativeWindowMac::SetTrafficLightPosition(const gfx::Point& position) {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1579,6 +1579,13 @@ describe('BrowserWindow module', () => {
         w.setVibrancy('' as any);
       }).to.not.throw();
     });
+
+    it('does not crash if vibrancy is set to an invalid value', () => {
+      const w = new BrowserWindow({ show: false });
+      expect(() => {
+        w.setVibrancy('i-am-not-a-valid-vibrancy-type' as any);
+      }).to.not.throw();
+    });
   });
 
   ifdescribe(process.platform === 'darwin')('BrowserWindow.getTrafficLightPosition(pos)', () => {


### PR DESCRIPTION
Backport of #29677.

See that PR for details.

Notes: Fixes a potential crash when setting vibrancy on macOS.