### PR TITLE
ci: make arm64 macos test cleanup more resilient

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,8 +219,8 @@ step-maybe-cleanup-arm64-mac: &step-maybe-cleanup-arm64-mac
         killall Safari || echo "No Safari processes left running"
         rm -rf ~/Library/Application\ Support/Electron*
         rm -rf ~/Library/Application\ Support/electron*
-        security delete-generic-password -l "Chromium Safe Storage"
-        security delete-generic-password -l "Electron Test Main Safe Storage"
+        security delete-generic-password -l "Chromium Safe Storage" || echo "✓ Keychain does not contain password from tests"
+        security delete-generic-password -l "Electron Test Main Safe Storage" || echo "✓ Keychain does not contain password from tests"
       elif [ "$TARGET_ARCH" == "arm" ] || [ "$TARGET_ARCH" == "arm64" ]; then
         XVFB=/usr/bin/Xvfb
         /sbin/start-stop-daemon --stop --exec $XVFB || echo "Xvfb not running"


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
This is a followup to #30472. Under certain circumstances the passwords that are being removed from the keychain may not exist and when they don't exist the CircleCI job gets marked as failing when really all that "failed" was that there was nothing to cleanup.  For example this job on the 15-x-y backport of #30472 because of this issue: 
https://app.circleci.com/pipelines/github/electron/electron/43220/workflows/228ab433-52d2-481f-8f2d-c05bfcd44bfa/jobs/967851

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
