### PR TITLE
fix: disable kWindowCaptureMacV2 for desktop capturer

### DIFF
--- a/shell/browser/feature_list.cc
+++ b/shell/browser/feature_list.cc
@@ -49,6 +49,12 @@ void InitializeFeatureList() {
   disable_features +=
       std::string(",") + spellcheck::kWinRetrieveSuggestionsOnlyOnDemand.name;
 #endif
+#if defined(OS_MAC)
+  // Disable kWindowCaptureMacV2, which causes the wrong window id to
+  // be returned (this has been disabled in upstream Chromium here):
+  // https://chromium-review.googlesource.com/c/chromium/src/+/3069272
+  disable_features += std::string(",") + features::kWindowCaptureMacV2.name;
+#endif
   base::FeatureList::InitializeInstance(enable_features, disable_features);
 }
 


### PR DESCRIPTION
#### Description of Change

Fixes #29458

When trying to screen capture an Electron application's own window, the screen will show as blank. This is because when `kWindowCaptureMacV2` is enabled, the latter portion of the DesktopMediaID is incorrectly replaced. For example: the DesktopMediaID is changed from `window:626:0` (correct) to `window:626:626` (incorrect). Passing the incorrect id into the desktop capture API results in the window not being found, and a blank or default-colored screen.

`kWindowCaptureMacV2` is already disabled by default in upstream Chromium (see here: https://chromium-review.googlesource.com/c/chromium/src/+/3069272). This PR also disables the feature by default until the upstream fix is in main. It also adds a new desktop capture test to keep the issue from happening again.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue on Mac where an application could not capture its own window using the desktop capture or getMediaSourceId APIs.
