### PR TITLE
fix: persist BrowserView background color when bounds offscreen

### DIFF
--- a/shell/browser/ui/views/inspectable_web_contents_view_views.cc
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.cc
@@ -213,7 +213,7 @@ void InspectableWebContentsViewViews::SetTitle(const std::u16string& title) {
 
 void InspectableWebContentsViewViews::Layout() {
   if (!devtools_web_view_->GetVisible()) {
-    contents_web_view_->SetBoundsRect(GetContentsBounds());
+    contents_web_view_->SetBoundsRect(GetVisibleBounds());
     return;
   }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/29778.

Fixes an issue where background color would not be correctly applied to `BrowserViews` on Windows when either the `x` or `y` coordinate is negative (off-screen).

This was happening because `view::Views` was trying to paint the whole content bounds instead of the visible bounds, which caused issues because when part of the bounds are offscreen the compositor overrides and paints them white. This fixes that by painting the visible bounds.

Before:

<img width="968" alt="Screen Shot 2021-08-12 at 12 38 30 PM" src="https://user-images.githubusercontent.com/2036040/129183386-09fefd19-555a-457f-a585-1ae8925b4503.png">

After:

<img width="935" alt="Screen Shot 2021-08-12 at 12 38 47 PM" src="https://user-images.githubusercontent.com/2036040/129183360-73892b45-38e2-4a4a-99dd-c3b53787e1a6.png">

Tested with https://gist.github.com/712a2fde2757736c9dbf6c3e7e0aa18b.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where background color would not be correctly applied to `BrowserViews` on Windows when either the `x` or `y` coordinate is negative (off-screen).