### PR TITLE
docs: clarify platform-specific usage of the `acceptFirstMouse` option

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -187,9 +187,9 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `parent` BrowserWindow (optional) - Specify parent window. Default is `null`.
   * `modal` Boolean (optional) - Whether this is a modal window. This only works when the
     window is a child window. Default is `false`.
-  * `acceptFirstMouse` Boolean (optional) - Whether the web view accepts a single
-    mouse-down event that simultaneously activates the window. Default is
-    `false`.
+  * `acceptFirstMouse` Boolean (optional) - Whether clicking an inactive window will also
+  click through to the web contents. Default is `false` on macOS. This option is not
+  configurable on other platforms.
   * `disableAutoHideCursor` Boolean (optional) - Whether to hide cursor when typing.
     Default is `false`.
   * `autoHideMenuBar` Boolean (optional) - Auto hide the menu bar unless the `Alt`


### PR DESCRIPTION
#### Description of Change

The initial implementation of `acceptFirstMouse` was macOS-only (see #215), but the docs never specified this. Current code search for the `kAcceptFirstMouse` switch shows it only being used on macOS as well.

To verify, open https://gist.github.com/erickzhao/4b08e1978146265170938cdc45fe3394 on Windows and click the inactive fiddle window. The click-through will always work.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
