### PR TITLE
docs: uniformize tutorial titles

### DIFF
--- a/docs/tutorial/in-app-purchases.md
+++ b/docs/tutorial/in-app-purchases.md
@@ -1,4 +1,4 @@
-# In-App Purchase (macOS)
+# In-App Purchases (macOS)
 
 ## Preparing
 

--- a/docs/tutorial/installation.md
+++ b/docs/tutorial/installation.md
@@ -1,4 +1,4 @@
-# Installation
+# Advanced Installation Instructions
 
 To install prebuilt Electron binaries, use [`npm`][npm].
 The preferred method is to install Electron as a development dependency in your

--- a/docs/tutorial/linux-desktop-actions.md
+++ b/docs/tutorial/linux-desktop-actions.md
@@ -1,4 +1,4 @@
-# Custom Linux Desktop Launcher Actions
+# Desktop Launcher Actions (Linux)
 
 ## Overview
 

--- a/docs/tutorial/macos-dock.md
+++ b/docs/tutorial/macos-dock.md
@@ -1,4 +1,4 @@
-# Configuring the macOS Dock
+# Dock (macOS)
 
 Electron has APIs to configure the app's icon in the macOS Dock. A macOS-only
 API exists to create a custom dock menu, but Electron also uses the app dock

--- a/docs/tutorial/notifications.md
+++ b/docs/tutorial/notifications.md
@@ -1,4 +1,4 @@
-# Notifications (Windows, Linux, macOS)
+# Notifications
 
 ## Overview
 

--- a/docs/tutorial/progress-bar.md
+++ b/docs/tutorial/progress-bar.md
@@ -1,4 +1,4 @@
-# Progress Bar in Taskbar (Windows, macOS, Unity)
+# Taskbar Progress Bar (Windows & macOS)
 
 ## Overview
 

--- a/docs/tutorial/represented-file.md
+++ b/docs/tutorial/represented-file.md
@@ -1,4 +1,4 @@
-# Represented File for macOS BrowserWindows
+# Representing Files in a BrowserWindow (macOS)
 
 ## Overview
 

--- a/docs/tutorial/snapcraft.md
+++ b/docs/tutorial/snapcraft.md
@@ -1,4 +1,4 @@
-# Snapcraft Guide (Ubuntu Software Center & More)
+# Snapcraft Guide (Linux)
 
 This guide provides information on how to package your Electron application
 for any Snapcraft environment, including the Ubuntu Software Center.

--- a/docs/tutorial/using-native-node-modules.md
+++ b/docs/tutorial/using-native-node-modules.md
@@ -1,4 +1,4 @@
-# Using Native Node Modules
+# Native Node Modules
 
 Native Node.js modules are supported by Electron, but since Electron has a different
 [application binary interface (ABI)][abi] from a given Node.js binary (due to

--- a/docs/tutorial/using-pepper-flash-plugin.md
+++ b/docs/tutorial/using-pepper-flash-plugin.md
@@ -1,4 +1,4 @@
-# Using Pepper Flash Plugin
+# Pepper Flash Plugin
 
 Electron no longer supports the Pepper Flash plugin, as Chrome has removed support.
 

--- a/docs/tutorial/using-selenium-and-webdriver.md
+++ b/docs/tutorial/using-selenium-and-webdriver.md
@@ -1,4 +1,4 @@
-# Using Selenium and WebDriver
+# Selenium and WebDriver
 
 From [ChromeDriver - WebDriver for Chrome][chrome-driver]:
 

--- a/docs/tutorial/web-embeds.md
+++ b/docs/tutorial/web-embeds.md
@@ -1,4 +1,4 @@
-# Web embeds
+# Web Embeds
 
 ## Overview
 

--- a/docs/tutorial/windows-arm.md
+++ b/docs/tutorial/windows-arm.md
@@ -1,4 +1,4 @@
-# Windows 10 on Arm
+# Windows on ARM
 
 If your app runs with Electron 6.0.8 or later, you can now build it for Windows 10 on Arm. This considerably improves performance, but requires recompilation of any native modules used in your app. It may also require small fixups to your build and packaging scripts.
 

--- a/docs/tutorial/windows-taskbar.md
+++ b/docs/tutorial/windows-taskbar.md
@@ -1,4 +1,4 @@
-# Windows Taskbar
+# Taskbar Customization (Windows)
 
 ## Overview
 


### PR DESCRIPTION
#### Description of Change

Tidies up the doc names within the `/tutorial/` folder.

* Title case enforced for titles (as per style guide)
* Made some titles more concise (e.g. `Using Native Node Modules` becomes `Native Node Modules`)
* Made platform-specific titles consistent


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none