### PR TITLE
build: manually pull 64bit dugite for 32bit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1209,6 +1209,9 @@ steps-tests: &steps-tests
               (cd electron && node script/yarn test --runners=main --trace-uncaught --enable-logging)
               (cd electron && node script/yarn test --runners=remote --trace-uncaught --enable-logging)
             else
+              if [ "$TARGET_ARCH" == "ia32" ]; then
+                npm_config_arch=x64 node electron/node_modules/dugite/script/download-git.js
+              fi
               (cd electron && node script/yarn test --runners=main --trace-uncaught --enable-logging --files $(circleci tests glob spec-main/*-spec.ts | circleci tests split --split-by=timings))
               (cd electron && node script/yarn test --runners=remote --trace-uncaught --enable-logging --files $(circleci tests glob spec/*-spec.js | circleci tests split --split-by=timings))
             fi


### PR DESCRIPTION
This broke in https://github.com/electron/electron/pull/30492

Notes: none