### PR TITLE
fix: {exit|enter}-html-fullscreen emitted after esc in webview

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1239,31 +1239,29 @@ void WebContents::OnEnterFullscreenModeForTab(
     content::RenderFrameHost* requesting_frame,
     const blink::mojom::FullscreenOptions& options,
     bool allowed) {
-  if (!allowed)
+  if (!allowed || !owner_window_)
     return;
-  if (!owner_window_)
-    return;
+
   auto* source = content::WebContents::FromRenderFrameHost(requesting_frame);
   if (IsFullscreenForTabOrPending(source)) {
     DCHECK_EQ(fullscreen_frame_, source->GetFocusedFrame());
     return;
   }
+
   SetHtmlApiFullscreen(true);
-  owner_window_->NotifyWindowEnterHtmlFullScreen();
 
   if (native_fullscreen_) {
     // Explicitly trigger a view resize, as the size is not actually changing if
     // the browser is fullscreened, too.
     source->GetRenderViewHost()->GetWidget()->SynchronizeVisualProperties();
   }
-  Emit("enter-html-full-screen");
 }
 
 void WebContents::ExitFullscreenModeForTab(content::WebContents* source) {
   if (!owner_window_)
     return;
+
   SetHtmlApiFullscreen(false);
-  owner_window_->NotifyWindowLeaveHtmlFullScreen();
 
   if (native_fullscreen_) {
     // Explicitly trigger a view resize, as the size is not actually changing if
@@ -1271,7 +1269,6 @@ void WebContents::ExitFullscreenModeForTab(content::WebContents* source) {
     // `chrome/browser/ui/exclusive_access/fullscreen_controller.cc`.
     source->GetRenderViewHost()->GetWidget()->SynchronizeVisualProperties();
   }
-  Emit("leave-html-full-screen");
 }
 
 void WebContents::RendererUnresponsive(
@@ -3564,7 +3561,7 @@ void WebContents::SetHtmlApiFullscreen(bool enter_fullscreen) {
 }
 
 void WebContents::UpdateHtmlApiFullscreen(bool fullscreen) {
-  if (fullscreen == html_fullscreen_)
+  if (fullscreen == is_html_fullscreen())
     return;
 
   html_fullscreen_ = fullscreen;
@@ -3575,10 +3572,18 @@ void WebContents::UpdateHtmlApiFullscreen(bool fullscreen) {
       ->GetWidget()
       ->SynchronizeVisualProperties();
 
-  // The embedder WebContents is spearated from the frame tree of webview, so
+  // The embedder WebContents is separated from the frame tree of webview, so
   // we must manually sync their fullscreen states.
   if (embedder_)
     embedder_->SetHtmlApiFullscreen(fullscreen);
+
+  if (fullscreen) {
+    Emit("enter-html-full-screen");
+    owner_window_->NotifyWindowEnterHtmlFullScreen();
+  } else {
+    Emit("leave-html-full-screen");
+    owner_window_->NotifyWindowLeaveHtmlFullScreen();
+  }
 
   // Make sure all child webviews quit html fullscreen.
   if (!fullscreen && !IsGuest()) {

--- a/spec-main/webview-spec.ts
+++ b/spec-main/webview-spec.ts
@@ -456,6 +456,34 @@ describe('<webview> tag', function () {
       await delay(0);
       expect(w.isFullScreen()).to.be.false();
     });
+
+    it('pressing ESC should emit the leave-html-full-screen event', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          webviewTag: true,
+          nodeIntegration: true,
+          contextIsolation: false
+        }
+      });
+
+      const didAttachWebview = emittedOnce(w.webContents, 'did-attach-webview');
+      w.loadFile(path.join(fixtures, 'pages', 'webview-did-attach-event.html'));
+
+      const [, webContents] = await didAttachWebview;
+
+      const enterFSWindow = emittedOnce(w, 'enter-html-full-screen');
+      const enterFSWebview = emittedOnce(webContents, 'enter-html-full-screen');
+      await webContents.executeJavaScript('document.getElementById("div").requestFullscreen()', true);
+      await enterFSWindow;
+      await enterFSWebview;
+
+      const leaveFSWindow = emittedOnce(w, 'leave-html-full-screen');
+      const leaveFSWebview = emittedOnce(webContents, 'leave-html-full-screen');
+      webContents.sendInputEvent({ type: 'keyDown', keyCode: 'Escape' });
+      await leaveFSWindow;
+      await leaveFSWebview;
+    });
   });
 
   describe('nativeWindowOpen option', () => {

--- a/spec/fixtures/pages/a.html
+++ b/spec/fixtures/pages/a.html
@@ -3,6 +3,7 @@
 <link rel="icon" type="image/png" href="http://test.com/favicon.png"/>
 <meta http-equiv="content-security-policy" content="script-src 'self' 'unsafe-inline'" />
 <body>
+<div id="div">Hello World</div>
 <script type="text/javascript" charset="utf-8">
   console.log('a');
   document.title = "test"


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/30509.

Fixes an issue present in `webView` where the `leave-html-full-screen` event is not emitted if the user exits fullscreen with `esc` instead of by clicking into the webView.

This was happening because when the user exits by clicking into the webview, we call into `ExitFullScreenModeFromTab` on the webcontents of the webview - meaning the event is emitted correctly to the webview. When we do so from esc, however, this happens from the wrong `webContents` and so then go and loop through each child webview to ensure they all exit properly with `api_web_contents->SetHtmlApiFullscreen(false);`. Since the emit happens in `ExitFullScreenModeFromTab` though, `leave-html-full-screen` is not emitted again.

This fixes the issue by centralizing calls to `Emit("enter-html-full-screen")` and `owner_window_->NotifyWindow{Enter|Leave}HtmlFullScreen()`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue present in `webView` where the `leave-html-full-screen` event is not emitted if the user exits fullscreen with `esc` instead of by clicking into the `webView`. 
