### PR TITLE
fix: DCHECK on reload when forcefullyCrashRenderer() is called

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -951,9 +951,9 @@ void ElectronBrowserClient::RenderProcessReady(
 void ElectronBrowserClient::RenderProcessExited(
     content::RenderProcessHost* host,
     const content::ChildProcessTerminationInfo& info) {
-  if (delegate_) {
+  if (delegate_)
     static_cast<api::App*>(delegate_)->RenderProcessExited(host);
-  }
+  host->RemoveObserver(this);
 }
 
 void OnOpenExternal(const GURL& escaped_url, bool allowed) {

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -1330,6 +1330,13 @@ describe('webContents module', () => {
         w.webContents.reload();
         expect(w.webContents.isCrashed()).to.equal(false);
       });
+
+      it('does not crash when a new page is loaded after forcefullyCrashRenderer()', async () => {
+        expect(w.webContents.isCrashed()).to.equal(false);
+        w.webContents.forcefullyCrashRenderer();
+        await w.loadFile(path.join(fixturesPath, 'pages', 'base-page.html'));
+        expect(w.webContents.isCrashed()).to.equal(false);
+      });
     });
   }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/30514.

Fixed an issue where loading a url, calling `forcefullyCrashRenderer()`, then reloading the page would cause an Observer DCHECK. This is happening because we previously added an observer in  [`RenderProcessWillLaunch`](https://github.com/electron/electron/commit/d9321f4df751fa32813fab1b6387bbd61bd681d0) and then ensured its removal in [`RenderProcessHostDestroyed`](https://github.com/electron/electron/commit/d9321f4df751fa32813fab1b6387bbd61bd681d0). However, the codepath taken in `forcefullyCrashRenderer()` is a bit of a misonomer, in that it results in a clean exit and so [`RenderProcessExited`](https://github.com/electron/electron/commit/d9321f4df751fa32813fab1b6387bbd61bd681d0) is called instead of [`RenderProcessHostDestroyed`](https://github.com/electron/electron/commit/d9321f4df751fa32813fab1b6387bbd61bd681d0). 
This fixes the issue by ensuring the added observer is removed for both potential exit codepaths.

Tested with https://gist.github.com/88d2828d06ce1fda4f9c1770db000923.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where loading a url, calling `forcefullyCrashRenderer()`, then reloading the page would cause an Observer `DCHECK`.
