### PR TITLE
fix: media key globalShortcuts on macOS

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -105,3 +105,4 @@ add_gin_wrappable_crash_key.patch
 logging_win32_only_create_a_console_if_logging_to_stderr.patch
 disable_use_lld_for_macos.patch
 fix_fix_the_build_on_windows_on_arm.patch
+fix_media_key_usage_with_globalshortcuts.patch

--- a/patches/chromium/fix_media_key_usage_with_globalshortcuts.patch
+++ b/patches/chromium/fix_media_key_usage_with_globalshortcuts.patch
@@ -1,0 +1,64 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Mon, 16 Aug 2021 17:55:32 +0200
+Subject: fix: media key usage with globalShortcuts
+
+This patch enables media keys to work properly with Electron's globalShortcut
+module. Chromium's default usage of RemoteCommandCenterDelegate on macOS falls
+down into MPRemoteCommandCenter, which makes it such that an app will not
+receive remote control events until it begins playing audio. This runs
+counter to the design of globalShortcuts, and so we need to instead
+use `ui::MediaKeysListener`.
+
+diff --git a/content/browser/media/media_keys_listener_manager_impl.cc b/content/browser/media/media_keys_listener_manager_impl.cc
+index 5938f75742b793868638e693a9a8c8dc686dfc46..bf8782c23095a09dec62c68d7d902df24abcb13e 100644
+--- a/content/browser/media/media_keys_listener_manager_impl.cc
++++ b/content/browser/media/media_keys_listener_manager_impl.cc
+@@ -231,7 +231,7 @@ void MediaKeysListenerManagerImpl::StartListeningForMediaKeysIfNecessary() {
+       media::AudioManager::GetGlobalAppName());
+ #endif
+ 
+-  if (system_media_controls_) {
++  if (/* DISABLES CODE */ (0)) {
+     system_media_controls_->AddObserver(this);
+     system_media_controls_notifier_ =
+         std::make_unique<SystemMediaControlsNotifier>(
+@@ -239,8 +239,13 @@ void MediaKeysListenerManagerImpl::StartListeningForMediaKeysIfNecessary() {
+   } else {
+     // If we can't access system media controls, then directly listen for media
+     // key keypresses instead.
++#if defined(OS_MAC)
++  media_keys_listener_ = ui::MediaKeysListener::Create(
++        this, ui::MediaKeysListener::Scope::kGlobalRequiresAccessibility);
++#else
+     media_keys_listener_ = ui::MediaKeysListener::Create(
+         this, ui::MediaKeysListener::Scope::kGlobal);
++#endif
+     DCHECK(media_keys_listener_);
+   }
+ 
+diff --git a/ui/base/accelerators/media_keys_listener.h b/ui/base/accelerators/media_keys_listener.h
+index c2b03328c0e508995bdc135031500783f500ceba..1b6b14dc2999c99445cef6ffc04d49a7c1728a54 100644
+--- a/ui/base/accelerators/media_keys_listener.h
++++ b/ui/base/accelerators/media_keys_listener.h
+@@ -20,6 +20,7 @@ class Accelerator;
+ class COMPONENT_EXPORT(UI_BASE) MediaKeysListener {
+  public:
+   enum class Scope {
++    kGlobalRequiresAccessibility, // Listener works whenever application in focus or not but requires accessibility permissions on macOS
+     kGlobal,   // Listener works whenever application in focus or not.
+     kFocused,  // Listener only works whan application has focus.
+   };
+diff --git a/ui/base/accelerators/media_keys_listener_win.cc b/ui/base/accelerators/media_keys_listener_win.cc
+index 6c63a88cbb13cfcc9a8ba652554839275ae1ee04..1643eafc094dce77e4ba8752cd02e1ae6c488b56 100644
+--- a/ui/base/accelerators/media_keys_listener_win.cc
++++ b/ui/base/accelerators/media_keys_listener_win.cc
+@@ -13,7 +13,7 @@ std::unique_ptr<MediaKeysListener> MediaKeysListener::Create(
+     MediaKeysListener::Scope scope) {
+   DCHECK(delegate);
+ 
+-  if (scope == Scope::kGlobal) {
++  if (scope == Scope::kGlobal || scope == Scope::kGlobalRequiresAccessibility) {
+     // We should never have more than one global media keys listener.
+     if (!GlobalMediaKeysListenerWin::has_instance())
+       return std::make_unique<GlobalMediaKeysListenerWin>(delegate);

--- a/spec-main/api-global-shortcut-spec.ts
+++ b/spec-main/api-global-shortcut-spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { globalShortcut } from 'electron/main';
+import { globalShortcut, BrowserWindow } from 'electron/main';
 import { ifdescribe } from './spec-helpers';
 
 ifdescribe(process.platform !== 'win32')('globalShortcut module', () => {
@@ -54,5 +54,21 @@ ifdescribe(process.platform !== 'win32')('globalShortcut module', () => {
     }).to.not.throw();
 
     globalShortcut.unregisterAll();
+  });
+
+  it('successfully registers and calls the callback for media keys', function (done) {
+    let robotjs;
+    try {
+      robotjs = require('robotjs');
+    } catch (err) {
+      this.skip();
+    }
+
+    globalShortcut.register('MediaPlayPause', () => done());
+
+    const w = new BrowserWindow({ show: false });
+    w.loadURL('about:blank');
+
+    robotjs.keyTap('audio_play');
   });
 });


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/30543.
Refs https://github.com/electron/electron/pull/27475.

[This CL](https://chromium-review.googlesource.com/c/chromium/src/+/2606785/1) moved around the location for media key listener logic in Chromium, and as a result [this patch](https://github.com/electron/electron/pull/27475/files#diff-715074556fc5163e2e7faeaba16111a69fa68add0ff58cd934188c38f8167ea7) was fully removed instead of being updated (regressing https://github.com/electron/electron/pull/21959).

This fixes the issue by reinvigorating the patch in accordance with latest upstream logic.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed media key `globalShortcut`s on macOS.
