### PR TITLE
docs: fix wrong code example for preload property

### DIFF
--- a/docs/tutorial/process-model.md
+++ b/docs/tutorial/process-model.md
@@ -148,7 +148,9 @@ A preload script can be attached to the main process in the `BrowserWindow` cons
 const { BrowserWindow } = require('electron')
 //...
 const win = new BrowserWindow({
-  preload: 'path/to/preload.js'
+  webPreferences: {
+    preload: 'path/to/preload.js'
+  }
 })
 //...
 ```


### PR DESCRIPTION
#### Description of Change
The docs for the process model mention that `preload` should be a property of `webPreferences`, but the code example showed something else.

notes: none