### PR TITLE
fix: handle nullish WebContentsView in UpdateDraggableRegions

### DIFF
--- a/shell/browser/api/electron_api_browser_window_views.cc
+++ b/shell/browser/api/electron_api_browser_window_views.cc
@@ -4,7 +4,7 @@
 
 #include "shell/browser/api/electron_api_browser_window.h"
 
-#include "content/browser/web_contents/web_contents_impl.h"
+#include "content/browser/web_contents/web_contents_impl.h"  // nogncheck
 #include "shell/browser/native_window_views.h"
 #include "ui/aura/window.h"
 

--- a/shell/browser/api/electron_api_browser_window_views.cc
+++ b/shell/browser/api/electron_api_browser_window_views.cc
@@ -4,6 +4,7 @@
 
 #include "shell/browser/api/electron_api_browser_window.h"
 
+#include "content/browser/web_contents/web_contents_impl.h"
 #include "shell/browser/native_window_views.h"
 #include "ui/aura/window.h"
 
@@ -17,8 +18,10 @@ void BrowserWindow::UpdateDraggableRegions(
     return;
 
   if (&draggable_regions_ != &regions) {
-    auto* nv = web_contents()->GetNativeView();
-    if (nv) {
+    auto* view =
+        static_cast<content::WebContentsImpl*>(web_contents())->GetView();
+    if (view) {
+      const gfx::NativeView nv = view->GetNativeView();
       auto const offset = nv->GetBoundsInRootWindow();
       auto snapped_regions = mojo::Clone(regions);
       for (auto& snapped_region : snapped_regions) {


### PR DESCRIPTION
Follow up to https://github.com/electron/electron/pull/30304 the issue was not that the NativeView was missing (it's stack allocated anyway, so truthy checking it didn't do anything).  The crash shows a failure in the pointer indirection of the `unique_ptr` for the `view`.  i.e. the `view` was nullptr.

Notes: Fixed rare crash in UpdateDraggableRegions