### PR TITLE
fix: documentEdited with non-default titlebarStyle

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1117,6 +1117,8 @@ std::string NativeWindowMac::GetRepresentedFilename() {
 
 void NativeWindowMac::SetDocumentEdited(bool edited) {
   [window_ setDocumentEdited:edited];
+  if (buttons_proxy_)
+    [buttons_proxy_ redraw];
 }
 
 bool NativeWindowMac::IsDocumentEdited() {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/30564.

Fixes an issue where toggling `documentEdited` status on macOS with `titlebarStyle: 'hiddenInset'` inadvertently moves the traffic light location. Fix this by ensuring the traffic lights are redrawn according to the current `titleBarStyle` when `documentEdited` status is changed.

Tested with https://gist.github.com/166ffcd98c950e6e97fec05ae4f2683b.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where toggling `documentEdited` status on macOS with `titlebarStyle: 'hiddenInset'` inadvertently moves the traffic light location. 