### PR TITLE
docs:  typo in launch-app-from-url-in-another-app.md

### DIFF
--- a/docs/tutorial/launch-app-from-url-in-another-app.md
+++ b/docs/tutorial/launch-app-from-url-in-another-app.md
@@ -127,25 +127,25 @@ can add the flag `--extend-info` with a path to the `plist` you've created. The 
 ### Plist
 
 ```XML
-    <?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-            <plist version="1.0">
-                <dict>
-                    <key>CFBundleURLTypes</key>
-                    <array>
-                        <dict>
-                            <key>CFBundleURLSchemes</key>
-                            <array>
-                                <string>electron-api-demos</string>
-                            </array>
-                            <key>CFBundleURLName</key>
-                            <string>Electron API Demos Protocol</string>
-                        </dict>
-                    </array>
-                    <key>ElectronTeamID</key>
-                    <string>VEKTX9H2N7</string>
-                </dict>
-            </plist>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>CFBundleURLTypes</key>
+        <array>
+            <dict>
+                <key>CFBundleURLSchemes</key>
+                <array>
+                    <string>electron-api-demos</string>
+                </array>
+                <key>CFBundleURLName</key>
+                <string>Electron API Demos Protocol</string>
+            </dict>
+        </array>
+        <key>ElectronTeamID</key>
+        <string>VEKTX9H2N7</string>
+    </dict>
+</plist>
 ```
 
 ## Conclusion

--- a/docs/tutorial/launch-app-from-url-in-another-app.md
+++ b/docs/tutorial/launch-app-from-url-in-another-app.md
@@ -127,9 +127,6 @@ can add the flag `--extend-info` with a path to the `plist` you've created. The 
 ### Plist
 
 ```XML
-  <p>
-  <h5>macOS plist</h5>
-  <pre><code>
     <?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
             <plist version="1.0">
@@ -149,9 +146,6 @@ can add the flag `--extend-info` with a path to the `plist` you've created. The 
                     <string>VEKTX9H2N7</string>
                 </dict>
             </plist>
-        </code>
-    </pre>
-  <p>
 ```
 
 ## Conclusion


### PR DESCRIPTION
#### Description of Change
Code snippet for the info.plist example had html formatting. Removed.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [X] relevant documentation is changed or added
- [X] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
