### PR TITLE
fix: ensure web_contents() is alive before grabbing view

### DIFF
--- a/shell/browser/api/electron_api_browser_window_views.cc
+++ b/shell/browser/api/electron_api_browser_window_views.cc
@@ -17,7 +17,7 @@ void BrowserWindow::UpdateDraggableRegions(
   if (window_->has_frame())
     return;
 
-  if (&draggable_regions_ != &regions) {
+  if (&draggable_regions_ != &regions && web_contents()) {
     auto* view =
         static_cast<content::WebContentsImpl*>(web_contents())->GetView();
     if (view) {


### PR DESCRIPTION
Fast track 13-x-y PR for #30571

Notes: Fixed potential crash when programmatically closing a draggable frameless child window
