### PR TITLE
fix: change gin::Wrappable crash key type to ScopedCrashKey

### DIFF
--- a/patches/chromium/add_gin_wrappable_crash_key.patch
+++ b/patches/chromium/add_gin_wrappable_crash_key.patch
@@ -15,28 +15,32 @@ This patch should not be upstreamed, and can be removed in Electron 15 and
 beyond once we identify the cause of the crash.
 
 diff --git a/gin/wrappable.cc b/gin/wrappable.cc
-index fe07eb94a8e679859bba6d76ff0d6ee86bd0c67e..d0066fca501eae5be4177440b44dbecc8e34c897 100644
+index fe07eb94a8e679859bba6d76ff0d6ee86bd0c67e..ecb0aa2c4ec57e1814f4c94194e775440f4e35ee 100644
 --- a/gin/wrappable.cc
 +++ b/gin/wrappable.cc
-@@ -8,6 +8,10 @@
+@@ -8,6 +8,11 @@
  #include "gin/object_template_builder.h"
  #include "gin/per_isolate_data.h"
  
 +#if !defined(MAS_BUILD)
++#include "components/crash/core/common/crash_key.h"
 +#include "electron/shell/common/crash_keys.h"
 +#endif
 +
  namespace gin {
  
  WrappableBase::WrappableBase() = default;
-@@ -36,6 +40,12 @@ void WrappableBase::FirstWeakCallback(
+@@ -36,6 +41,15 @@ void WrappableBase::FirstWeakCallback(
  void WrappableBase::SecondWeakCallback(
      const v8::WeakCallbackInfo<WrappableBase>& data) {
    WrappableBase* wrappable = data.GetParameter();
 +
 +#if !defined(MAS_BUILD)
-+  WrapperInfo* info = static_cast<WrapperInfo*>(data.GetInternalField(0));
-+  electron::crash_keys::SetCrashKeyForGinWrappable(info);
++  WrapperInfo* wrapperInfo = static_cast<WrapperInfo*>(data.GetInternalField(0));
++  std::string location = electron::crash_keys::GetCrashValueForGinWrappable(wrapperInfo);
++
++  static crash_reporter::CrashKeyString<32> crash_key("gin-wrappable-fatal.location");
++  crash_reporter::ScopedCrashKeyString auto_clear(&crash_key, location);
 +#endif
 +
    delete wrappable;

--- a/shell/common/crash_keys.cc
+++ b/shell/common/crash_keys.cc
@@ -185,7 +185,7 @@ void SetPlatformCrashKey() {
 #endif
 }
 
-void SetCrashKeyForGinWrappable(gin::WrapperInfo* info) {
+std::string GetCrashValueForGinWrappable(gin::WrapperInfo* info) {
   std::string crash_location;
 
   // Adds a breadcrumb for crashes within gin::WrappableBase::SecondWeakCallback
@@ -254,7 +254,7 @@ void SetCrashKeyForGinWrappable(gin::WrapperInfo* info) {
         "Deleted kWrapperInfo does not match listed component. Please review "
         "listed crash keys.";
 
-  SetCrashKey("gin-wrappable-fatal.location", crash_location);
+  return crash_location;
 }
 
 }  // namespace crash_keys

--- a/shell/common/crash_keys.h
+++ b/shell/common/crash_keys.h
@@ -24,7 +24,8 @@ void GetCrashKeys(std::map<std::string, std::string>* keys);
 
 void SetCrashKeysFromCommandLine(const base::CommandLine& command_line);
 void SetPlatformCrashKey();
-void SetCrashKeyForGinWrappable(gin::WrapperInfo* info);
+
+std::string GetCrashValueForGinWrappable(gin::WrapperInfo* info);
 
 }  // namespace crash_keys
 


### PR DESCRIPTION
#### Description of Change

Changes the added crash key to gin::Wrappable from a set crash key to a scoped crash key. The current crash key will be added to any crash that occurs after SecondWeakCallback runs once. This scoped crash key will keep the crash key from appearing if the crash does not occur in SecondWeakCallback, even if the code path was used prior to the crash.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
