### PR TITLE
build: remove redundant --ignore_locks from appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -112,7 +112,7 @@ build_script:
           }
         }
       }
-  - if "%RUN_GCLIENT_SYNC%"=="true" ( gclient sync --with_branch_heads --with_tags --ignore_locks)
+  - if "%RUN_GCLIENT_SYNC%"=="true" ( gclient sync --with_branch_heads --with_tags)
   - ps: >-
       if ($env:SAVE_GCLIENT_SRC -eq 'true') {
         # archive current source for future use 


### PR DESCRIPTION
From CI:

```
if "%RUN_GCLIENT_SYNC%"=="true" ( gclient sync --with_branch_heads --with_tags --ignore_locks)
Warning: ignore_locks is no longer used. Please remove its usage.
```

Notes: none.