### PR TITLE
chore: add DumpsWithoutCrashing crash key

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -106,3 +106,4 @@ logging_win32_only_create_a_console_if_logging_to_stderr.patch
 disable_use_lld_for_macos.patch
 fix_fix_the_build_on_windows_on_arm.patch
 fix_media_key_usage_with_globalshortcuts.patch
+add_dumps_without_crashing_crash_key

--- a/patches/chromium/add_dumps_without_crashing_crash_key
+++ b/patches/chromium/add_dumps_without_crashing_crash_key
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: VerteDinde <khammond@slack-corp.com>
+Date: Tue, 17 Aug 2021 10:29:59 -0700
+Subject: chore: add dumpswithoutcrashing crash key
+
+This patch adds an additional crash key for DumpsWithoutCrashing, a crash
+that is often not user facing for Electron apps. There is currently no easy
+way to filter out these crashes from error-reporters such as Sentry. Adding
+this crash key will allow Electron developers to more easily filter out
+DWoC exceptions from their error reporting tools.
+
+This patch should not be upstreamed. It can be removed if we can more easily
+identify DWoC crashes within Electron itself.
+
+diff --git a/base/debug/dump_without_crashing.cc b/base/debug/dump_without_crashing.cc
+index b7ce35349e3c1bb80a2234e4a28f7c49f8586527..64b15d2e71d88f7002015d12f01c17cbbfa3a18b 100644
+--- a/base/debug/dump_without_crashing.cc
++++ b/base/debug/dump_without_crashing.cc
+@@ -6,6 +6,7 @@
+ 
+ #include "base/check.h"
+ #include "base/trace_event/base_tracing.h"
++#include "components/crash/core/common/crash_key.h"
+ 
+ namespace {
+ 
+@@ -22,6 +23,9 @@ namespace debug {
+ bool DumpWithoutCrashing() {
+   TRACE_EVENT0("base", "DumpWithoutCrashing");
+   if (dump_without_crashing_function_) {
++    static crash_reporter::CrashKeyString<32> crash_key("dumps-without-crashing");
++    crash_reporter::ScopedCrashKeyString auto_clear(&crash_key, "true");
++
+     (*dump_without_crashing_function_)();
+     return true;
+   }


### PR DESCRIPTION
#### Description of Change

There is a category of crashes within Chromium, "DumpsWithoutCrashing", that cause an exception to be thrown in the background without a user-facing exception being thrown. However, there's currently no easy way for an app developer to filter out these crashes from error reporters.

This PR adds a scoped crash key to help identify (and possibly filter out) DumpsWithoutCrashing exceptions.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Adds a scoped crash key to identify DumpsWithoutCrashing exceptions.
