### PR TITLE
build: embed binary checksums in the npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ compile_commands.json
 # npm package
 /npm/dist
 /npm/path.txt
+/npm/checksums.json
 
 .npmrc
 

--- a/docs/tutorial/installation.md
+++ b/docs/tutorial/installation.md
@@ -90,7 +90,7 @@ ELECTRON_CUSTOM_DIR="{{ version }}"
 The above configuration will download from URLs such as
 `https://npm.taobao.org/mirrors/electron/8.0.0/electron-v8.0.0-linux-x64.zip`.
 
-If you're mirror serves artifacts with different checksums to the official,
+If your mirror serves artifacts with different checksums to the official
 Electron release you may have to set `ELECTRON_USE_REMOTE_CHECKSUMS=1` to
 force Electron to use the remote `SHASUMS256.txt` file to verify the checksum
 instead of the embedded checksums.

--- a/docs/tutorial/installation.md
+++ b/docs/tutorial/installation.md
@@ -90,6 +90,11 @@ ELECTRON_CUSTOM_DIR="{{ version }}"
 The above configuration will download from URLs such as
 `https://npm.taobao.org/mirrors/electron/8.0.0/electron-v8.0.0-linux-x64.zip`.
 
+If you're mirror serves artifacts with different checksums to the official,
+Electron release you may have to set `ELECTRON_USE_REMOTE_CHECKSUMS=1` to
+force Electron to use the remote `SHASUMS256.txt` file to verify the checksum
+instead of the embedded checksums.
+
 #### Cache
 
 Alternatively, you can override the local cache. `@electron/get` will cache

--- a/npm/install.js
+++ b/npm/install.js
@@ -41,6 +41,7 @@ downloadArtifact({
   artifactName: 'electron',
   force: process.env.force_no_cache === 'true',
   cacheRoot: process.env.electron_config_cache,
+  checksums: process.env.electron_use_remote_checksums ? undefined : require('./checksums.json'),
   platform,
   arch
 }).then(extractFile).catch(err => {

--- a/npm/package.json
+++ b/npm/package.json
@@ -8,7 +8,7 @@
     "postinstall": "node install.js"
   },
   "dependencies": {
-    "@electron/get": "^1.0.1",
+    "@electron/get": "^1.13.0",
     "@types/node": "^14.6.2",
     "extract-zip": "^1.0.3"
   },

--- a/script/release/publish-to-npm.js
+++ b/script/release/publish-to-npm.js
@@ -114,13 +114,11 @@ new Promise((resolve, reject) => {
       checksumsAsset.id
     );
 
-    const checksumsObject = checksumsContent.trim().split('\n').reduce((checksums, line) => {
+    const checksumsObject = {};
+    for (const line of checksumsContent.trim().split('\n')) {
       const [checksum, file] = line.split(' *');
-      return {
-        [file]: checksum,
-        ...checksums
-      };
-    }, {});
+      checksumsObject[file] = checksum;
+    }
 
     fs.writeFileSync(path.join(tempDir, 'checksums.json'), JSON.stringify(checksumsObject, null, 2));
 

--- a/script/release/publish-to-npm.js
+++ b/script/release/publish-to-npm.js
@@ -104,6 +104,29 @@ new Promise((resolve, reject) => {
     return release;
   })
   .then(async (release) => {
+    const checksumsAsset = release.assets.find((asset) => asset.name === 'SHASUMS256.txt');
+    if (!checksumsAsset) {
+      throw new Error(`cannot find SHASUMS256.txt from v${rootPackageJson.version} release assets`);
+    }
+
+    const checksumsContent = await getAssetContents(
+      rootPackageJson.version.indexOf('nightly') > 0 ? 'nightlies' : 'electron',
+      checksumsAsset.id
+    );
+
+    const checksumsObject = checksumsContent.trim().split('\n').reduce((checksums, line) => {
+      const [checksum, file] = line.split(' *');
+      return {
+        [file]: checksum,
+        ...checksums
+      };
+    }, {});
+
+    fs.writeFileSync(path.join(tempDir, 'checksums.json'), JSON.stringify(checksumsObject, null, 2));
+
+    return release;
+  })
+  .then(async (release) => {
     const currentBranch = await getCurrentBranch();
 
     if (release.tag_name.indexOf('nightly') > 0) {
@@ -145,10 +168,26 @@ new Promise((resolve, reject) => {
   // test that the package can install electron prebuilt from github release
     const tarballPath = path.join(tempDir, `${rootPackageJson.name}-${rootPackageJson.version}.tgz`);
     return new Promise((resolve, reject) => {
-      childProcess.execSync(`npm install ${tarballPath} --force --silent`, {
+      const result = childProcess.spawnSync('npm', ['install', tarballPath, '--force', '--silent'], {
         env: Object.assign({}, process.env, { electron_config_cache: tempDir }),
-        cwd: tempDir
+        cwd: tempDir,
+        stdio: 'inherit'
       });
+      if (result.status !== 0) {
+        return reject(new Error(`npm install failed with status ${result.status}`));
+      }
+      try {
+        const electronPath = require(path.resolve(tempDir, 'node_modules', rootPackageJson.name));
+        if (typeof electronPath !== 'string') {
+          return reject(new Error(`path to electron binary (${electronPath}) returned by the ${rootPackageJson.name} module is not a string`));
+        }
+        if (!fs.existsSync(electronPath)) {
+          return reject(new Error(`path to electron binary (${electronPath}) returned by the ${rootPackageJson.name} module does not exist on disk`));
+        }
+      } catch (e) {
+        console.error(e);
+        return reject(new Error(`loading the generated ${rootPackageJson.name} module failed with an error`));
+      }
       resolve(tarballPath);
     });
   })
@@ -181,6 +220,6 @@ new Promise((resolve, reject) => {
     }
   })
   .catch((err) => {
-    console.error(`Error: ${err}`);
+    console.error('Error:', err);
     process.exit(1);
   });


### PR DESCRIPTION
In theory this isn't user facing.

Currently we download `SHASUMS256.txt` and the target Electron binary from GH releases and then use one to validate the other.  In terms of "did the download get the right thing" it's a valid check, from a security perspective it's a little bit too close to self-validation than I'd like.  The only thing protecting the `SHASUMS256.txt` file is GH write access and SSL during the download.

This change embeds the `SHASUMS256.txt` content in our `electron` npm package at publish time.  This means the checksums are now (a) stored separately to the actual Electron binary and (b) protected by the integrity SHA in your `yarn.lock` / `package-lock.json` lockfile.

Tested locally, and we can test this on tomorrows nightly.

Notes: no-notes