### PR TITLE
fix: WebFrameMain mojo pipe not reset

### DIFF
--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -102,6 +102,7 @@ void WebFrameMain::UpdateRenderFrameHost(content::RenderFrameHost* rfh) {
   // Should only be called when swapping frames.
   DCHECK(render_frame_);
   render_frame_ = rfh;
+  renderer_api_.reset();
 }
 
 bool WebFrameMain::CheckRenderFrame() const {


### PR DESCRIPTION
#### Description of Change

Follow up to #30076 which introduced a bug failing a test. See https://github.com/electron/electron/pull/30076#issuecomment-901583229

I propose we merge the previous backport PRs from #30076, then merge this and backport it to each target version.

Unfortunately I wasn't able to find a way to test this with a consistent failure case. I tried triggering cross-origin navigation and calling `webContents.executeJavaScript()` before and after, but the mojo pipe never disconnected.

cc @zcbenz @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none
