### PR TITLE
fix: Revert "fix: DCHECK on reload when forcefullyCrashRenderer() is called"

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -951,9 +951,9 @@ void ElectronBrowserClient::RenderProcessReady(
 void ElectronBrowserClient::RenderProcessExited(
     content::RenderProcessHost* host,
     const content::ChildProcessTerminationInfo& info) {
-  if (delegate_)
+  if (delegate_) {
     static_cast<api::App*>(delegate_)->RenderProcessExited(host);
-  host->RemoveObserver(this);
+  }
 }
 
 void OnOpenExternal(const GURL& escaped_url, bool allowed) {

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -1330,13 +1330,6 @@ describe('webContents module', () => {
         w.webContents.reload();
         expect(w.webContents.isCrashed()).to.equal(false);
       });
-
-      it('does not crash when a new page is loaded after forcefullyCrashRenderer()', async () => {
-        expect(w.webContents.isCrashed()).to.equal(false);
-        w.webContents.forcefullyCrashRenderer();
-        await w.loadFile(path.join(fixturesPath, 'pages', 'base-page.html'));
-        expect(w.webContents.isCrashed()).to.equal(false);
-      });
     });
   }
 


### PR DESCRIPTION
Reverts electron/electron#30544

Test failures caused by original PR https://electronhq.slack.com/archives/C6JSJ9FS5/p1629325475019900

Notes: none