### PR TITLE
fix: crash when using TouchBarScrubber arrow button

### DIFF
--- a/docs/api/touch-bar-scrubber.md
+++ b/docs/api/touch-bar-scrubber.md
@@ -15,7 +15,7 @@ _This class is not exported from the `'electron'` module. It is only available a
     * `highlightedIndex` Integer - The index of the item the user touched.
   * `selectedStyle` String (optional) - Selected item style. Can be `background`, `outline` or `none`. Defaults to `none`.
   * `overlayStyle` String (optional) - Selected overlay item style. Can be `background`, `outline` or `none`. Defaults to `none`.
-  * `showArrowButtons` Boolean (optional) - Defaults to `false`.
+  * `showArrowButtons` Boolean (optional) - Whether to show arrow buttons. Defaults to `false` and is only shown if `items` is non-empty.
   * `mode` String (optional) - Can be `fixed` or `free`. The default is `free`.
   * `continuous` Boolean (optional) - Defaults to `true`.
 

--- a/shell/browser/ui/cocoa/electron_touch_bar.mm
+++ b/shell/browser/ui/cocoa/electron_touch_bar.mm
@@ -735,7 +735,10 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 
   bool showsArrowButtons = false;
   settings.Get("showArrowButtons", &showsArrowButtons);
-  scrubber.showsArrowButtons = showsArrowButtons;
+  // The scrubber will crash if the user tries to scroll
+  // and there are no items.
+  if ([self numberOfItemsForScrubber:scrubber] > 0)
+    scrubber.showsArrowButtons = showsArrowButtons;
 
   std::string selectedStyle;
   std::string overlayStyle;


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/30658.

Fixes an issue where the TouchBarScrubber crashes if `items` is an empty array.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the TouchBarScrubber crashes when `showArrowButtons` is enabled if `items` is an empty array.
