### PR TITLE
build: fix .patch line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,11 @@
 # `git apply` and friends don't understand CRLF, even on windows. Force those
 # files to be checked out with LF endings even if core.autocrlf is true.
-*.patch text eol=lf
+text eol=lf
 patches/**/.patches merge=union
+
+# Patches must use the line endings of their target files. Otherwise they will
+# fail to apply properly.
+*.patch -eol
 
 # Source code and markdown files should always use LF as line ending.
 *.cc text eol=lf


### PR DESCRIPTION
#### Description of Change

Follow up to #28360

If patches are targeting files which contain CLRF line endings, they need not be changed to LF when checked in to the repo. This came up with a few Windows-specific WebRTC patches.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none
