### PR TITLE
fix: titlebar and window buttons under simple fullscreen

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1007,6 +1007,13 @@ void NativeWindowMac::SetSimpleFullScreen(bool simple_fullscreen) {
       window.level = NSPopUpMenuWindowLevel;
     }
 
+    // Always hide the titlebar in simple fullscreen mode.
+    //
+    // Note that we must remove the NSWindowStyleMaskTitled style instead of
+    // using the [window_ setTitleVisibility:], as the latter would leave the
+    // window with rounded corners.
+    SetStyleMask(false, NSWindowStyleMaskTitled);
+
     if (!window_button_visibility_.has_value()) {
       // Lets keep previous behaviour - hide window controls in titled
       // fullscreen mode when not specified otherwise.
@@ -1023,16 +1030,6 @@ void NativeWindowMac::SetSimpleFullScreen(bool simple_fullscreen) {
   } else if (!simple_fullscreen && is_simple_fullscreen_) {
     is_simple_fullscreen_ = false;
 
-    // Restore default window controls visibility state.
-    if (!window_button_visibility_.has_value()) {
-      bool visibility;
-      if (has_frame())
-        visibility = true;
-      else
-        visibility = title_bar_style_ != TitleBarStyle::kNormal;
-      InternalSetWindowButtonVisibility(visibility);
-    }
-
     [window setFrame:original_frame_ display:YES animate:YES];
     window.level = original_level_;
 
@@ -1045,6 +1042,19 @@ void NativeWindowMac::SetSimpleFullScreen(bool simple_fullscreen) {
     // Restore window manipulation abilities
     SetMaximizable(was_maximizable_);
     SetMovable(was_movable_);
+
+    // Restore default window controls visibility state.
+    if (!window_button_visibility_.has_value()) {
+      bool visibility;
+      if (has_frame())
+        visibility = true;
+      else
+        visibility = title_bar_style_ != TitleBarStyle::kNormal;
+      InternalSetWindowButtonVisibility(visibility);
+    }
+
+    if (buttons_proxy_)
+      [buttons_proxy_ redraw];
   }
 }
 

--- a/shell/browser/ui/cocoa/window_buttons_proxy.h
+++ b/shell/browser/ui/cocoa/window_buttons_proxy.h
@@ -25,13 +25,6 @@
 @interface WindowButtonsProxy : NSObject {
  @private
   NSWindow* window_;
-  // The view that contains the window buttons and title.
-  NSView* titlebar_container_;
-
-  // The window buttons.
-  NSButton* left_;
-  NSButton* right_;
-  NSButton* middle_;
 
   // Current left-top margin of buttons.
   gfx::Point margin_;


### PR DESCRIPTION
#### Description of Change

Fix 2 problems:

* After entering simple fullscreen, the titlebar should be hidden.
* After leaving simple fullscreen, the window buttons should be hidden for normal frameless window.

Close https://github.com/electron/electron/issues/30536.

#### Release Notes

Notes: Fix titlebar showing under simple fullscreen mode.