### PR TITLE
docs: feature_request additional information not required

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -37,4 +37,4 @@ body:
     label: Additional Information
     description: Add any other context about the problem here.
   validations:
-    required: true
+    required: false


### PR DESCRIPTION
We shouldn't require anything in the "additional information" field of a feature request.

Notes: none