### PR TITLE
docs: fix code example in process-model.md

### DIFF
--- a/docs/tutorial/process-model.md
+++ b/docs/tutorial/process-model.md
@@ -83,7 +83,7 @@ As a practical example, the app shown in the [quick start guide][quick-start-lif
 uses `app` APIs to create a more native application window experience.
 
 ```js title='main.js'
-// quitting the app when no windows are open on macOS
+// quitting the app when no windows are open on non-macOS
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit()
 })
@@ -148,7 +148,9 @@ A preload script can be attached to the main process in the `BrowserWindow` cons
 const { BrowserWindow } = require('electron')
 //...
 const win = new BrowserWindow({
-  preload: 'path/to/preload.js'
+  webPreferences: {
+    preload: 'path/to/preload.js'
+  }
 })
 //...
 ```

--- a/docs/tutorial/process-model.md
+++ b/docs/tutorial/process-model.md
@@ -83,7 +83,7 @@ As a practical example, the app shown in the [quick start guide][quick-start-lif
 uses `app` APIs to create a more native application window experience.
 
 ```js title='main.js'
-// quitting the app when no windows are open on non-macOS
+// quitting the app when no windows are open on non-macOS platforms
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit()
 })


### PR DESCRIPTION
the demo have two error: 
- at macos, close all window, the app will not quite, unless press `cmd` + `q`
- attach preload.js, use preload prop that is member of `webPreferences` property of `BrowserWindow` controller argument

Notes: none