### PR TITLE
chore: cherry-pick d8f7a221d014 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -147,3 +147,4 @@ cherry-pick-ac9dc1235e28.patch
 cherry-pick-4ce2abc17078.patch
 cherry-pick-e2123a8e0943.patch
 cherry-pick-1227933.patch
+cherry-pick-d8f7a221d014.patch

--- a/patches/chromium/cherry-pick-d8f7a221d014.patch
+++ b/patches/chromium/cherry-pick-d8f7a221d014.patch
@@ -1,7 +1,8 @@
-From d8f7a221d014da2d7b5a055c98a1e9acf418af32 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Sam McNally <sammc@chromium.org>
 Date: Fri, 20 Aug 2021 17:21:48 +0000
-Subject: [PATCH] [M90-LTS] Defer looking up the WebContents for the directory confirmation dialog.
+Subject: Defer looking up the WebContents for the directory confirmation
+ dialog.
 
 Look up the WebContents to use for the sensitive directory confirmation
 dialog immediately before it's used instead of before performing some
@@ -22,13 +23,12 @@ Owners-Override: Artem Sumaneev <asumaneev@google.com>
 Commit-Queue: Roger Felipe Zanoni da Silva <rzanoni@google.com>
 Cr-Commit-Position: refs/branch-heads/4430@{#1569}
 Cr-Branched-From: e5ce7dc4f7518237b3d9bb93cccca35d25216cbe-refs/heads/master@{#857950}
----
 
 diff --git a/extensions/browser/api/file_system/file_system_api.cc b/extensions/browser/api/file_system/file_system_api.cc
-index 64689a2..79ad9c5 100644
+index a739091fbdeb269648d0bfe28fa457c7f4310d50..e530ac389f6fa883078f237ca870dce9e35f76e1 100644
 --- a/extensions/browser/api/file_system/file_system_api.cc
 +++ b/extensions/browser/api/file_system/file_system_api.cc
-@@ -197,6 +197,9 @@
+@@ -197,6 +197,9 @@ void PassFileInfoToUIThread(FileInfoOptCallback callback,
  content::WebContents* GetWebContentsForRenderFrameHost(
      content::BrowserContext* browser_context,
      content::RenderFrameHost* render_frame_host) {
@@ -38,7 +38,7 @@ index 64689a2..79ad9c5 100644
    content::WebContents* web_contents =
        content::WebContents::FromRenderFrameHost(render_frame_host);
    // Check if there is an app window associated with the web contents; if not,
-@@ -508,15 +511,6 @@
+@@ -508,15 +511,6 @@ void FileSystemChooseEntryFunction::FilesSelected(
    }
  
    if (is_directory_) {
@@ -54,7 +54,7 @@ index 64689a2..79ad9c5 100644
      DCHECK_EQ(paths.size(), 1u);
      bool non_native_path = false;
  #if BUILDFLAG(IS_CHROMEOS_ASH)
-@@ -530,7 +524,7 @@
+@@ -530,7 +524,7 @@ void FileSystemChooseEntryFunction::FilesSelected(
          FROM_HERE, {base::MayBlock(), base::TaskPriority::BEST_EFFORT},
          base::BindOnce(
              &FileSystemChooseEntryFunction::ConfirmDirectoryAccessAsync, this,
@@ -63,7 +63,7 @@ index 64689a2..79ad9c5 100644
      return;
    }
  
-@@ -543,8 +537,7 @@
+@@ -543,8 +537,7 @@ void FileSystemChooseEntryFunction::FileSelectionCanceled() {
  
  void FileSystemChooseEntryFunction::ConfirmDirectoryAccessAsync(
      bool non_native_path,
@@ -73,7 +73,7 @@ index 64689a2..79ad9c5 100644
    const base::FilePath check_path =
        non_native_path ? paths[0] : base::MakeAbsoluteFilePath(paths[0]);
    if (check_path.empty()) {
-@@ -576,7 +569,7 @@
+@@ -576,7 +569,7 @@ void FileSystemChooseEntryFunction::ConfirmDirectoryAccessAsync(
          FROM_HERE,
          base::BindOnce(
              &FileSystemChooseEntryFunction::ConfirmSensitiveDirectoryAccess,
@@ -82,7 +82,7 @@ index 64689a2..79ad9c5 100644
      return;
    }
  
-@@ -587,8 +580,7 @@
+@@ -587,8 +580,7 @@ void FileSystemChooseEntryFunction::ConfirmDirectoryAccessAsync(
  }
  
  void FileSystemChooseEntryFunction::ConfirmSensitiveDirectoryAccess(
@@ -92,7 +92,7 @@ index 64689a2..79ad9c5 100644
    if (ExtensionsBrowserClient::Get()->IsShuttingDown()) {
      FileSelectionCanceled();
      return;
-@@ -601,6 +593,13 @@
+@@ -601,6 +593,13 @@ void FileSystemChooseEntryFunction::ConfirmSensitiveDirectoryAccess(
      return;
    }
  
@@ -107,7 +107,7 @@ index 64689a2..79ad9c5 100644
        app_file_handler_util::HasFileSystemWritePermission(extension_.get()),
        base::UTF8ToUTF16(extension_->name()), web_contents,
 diff --git a/extensions/browser/api/file_system/file_system_api.h b/extensions/browser/api/file_system/file_system_api.h
-index ae1588c..0895a17 100644
+index ae1588ce8536e4cee5474c3d4db370e95018c52e..0895a174a0dd1ba031fa358fe6451a1ebf198594 100644
 --- a/extensions/browser/api/file_system/file_system_api.h
 +++ b/extensions/browser/api/file_system/file_system_api.h
 @@ -19,10 +19,6 @@
@@ -121,7 +121,7 @@ index ae1588c..0895a17 100644
  namespace extensions {
  class ExtensionPrefs;
  
-@@ -168,13 +164,12 @@
+@@ -168,13 +164,12 @@ class FileSystemChooseEntryFunction : public FileSystemEntryFunction {
    // directory. If so, calls ConfirmSensitiveDirectoryAccess. Otherwise, calls
    // OnDirectoryAccessConfirmed.
    void ConfirmDirectoryAccessAsync(bool non_native_path,

--- a/patches/chromium/cherry-pick-d8f7a221d014.patch
+++ b/patches/chromium/cherry-pick-d8f7a221d014.patch
@@ -1,0 +1,140 @@
+From d8f7a221d014da2d7b5a055c98a1e9acf418af32 Mon Sep 17 00:00:00 2001
+From: Sam McNally <sammc@chromium.org>
+Date: Fri, 20 Aug 2021 17:21:48 +0000
+Subject: [PATCH] [M90-LTS] Defer looking up the WebContents for the directory confirmation dialog.
+
+Look up the WebContents to use for the sensitive directory confirmation
+dialog immediately before it's used instead of before performing some
+blocking file access to determine whether it's necessary.
+
+(cherry picked from commit 18236a0db8341302120c60781ae3129e94fbaf1c)
+
+Bug: 1234009
+Change-Id: I5e00c7fa199b3da522e1fdb73242891d7f5f7423
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3063743
+Commit-Queue: Sam McNally <sammc@chromium.org>
+Cr-Original-Commit-Position: refs/heads/master@{#907467}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3097732
+Reviewed-by: Sam McNally <sammc@chromium.org>
+Reviewed-by: Jana Grill <janagrill@google.com>
+Reviewed-by: Artem Sumaneev <asumaneev@google.com>
+Owners-Override: Artem Sumaneev <asumaneev@google.com>
+Commit-Queue: Roger Felipe Zanoni da Silva <rzanoni@google.com>
+Cr-Commit-Position: refs/branch-heads/4430@{#1569}
+Cr-Branched-From: e5ce7dc4f7518237b3d9bb93cccca35d25216cbe-refs/heads/master@{#857950}
+---
+
+diff --git a/extensions/browser/api/file_system/file_system_api.cc b/extensions/browser/api/file_system/file_system_api.cc
+index 64689a2..79ad9c5 100644
+--- a/extensions/browser/api/file_system/file_system_api.cc
++++ b/extensions/browser/api/file_system/file_system_api.cc
+@@ -197,6 +197,9 @@
+ content::WebContents* GetWebContentsForRenderFrameHost(
+     content::BrowserContext* browser_context,
+     content::RenderFrameHost* render_frame_host) {
++  if (!render_frame_host)
++    return nullptr;
++
+   content::WebContents* web_contents =
+       content::WebContents::FromRenderFrameHost(render_frame_host);
+   // Check if there is an app window associated with the web contents; if not,
+@@ -508,15 +511,6 @@
+   }
+ 
+   if (is_directory_) {
+-    // Get the WebContents for the app window to be the parent window of the
+-    // confirmation dialog if necessary.
+-    content::WebContents* const web_contents = GetWebContentsForRenderFrameHost(
+-        browser_context(), render_frame_host());
+-    if (!web_contents) {
+-      Respond(Error(kInvalidCallingPage));
+-      return;
+-    }
+-
+     DCHECK_EQ(paths.size(), 1u);
+     bool non_native_path = false;
+ #if BUILDFLAG(IS_CHROMEOS_ASH)
+@@ -530,7 +524,7 @@
+         FROM_HERE, {base::MayBlock(), base::TaskPriority::BEST_EFFORT},
+         base::BindOnce(
+             &FileSystemChooseEntryFunction::ConfirmDirectoryAccessAsync, this,
+-            non_native_path, paths, web_contents));
++            non_native_path, paths));
+     return;
+   }
+ 
+@@ -543,8 +537,7 @@
+ 
+ void FileSystemChooseEntryFunction::ConfirmDirectoryAccessAsync(
+     bool non_native_path,
+-    const std::vector<base::FilePath>& paths,
+-    content::WebContents* web_contents) {
++    const std::vector<base::FilePath>& paths) {
+   const base::FilePath check_path =
+       non_native_path ? paths[0] : base::MakeAbsoluteFilePath(paths[0]);
+   if (check_path.empty()) {
+@@ -576,7 +569,7 @@
+         FROM_HERE,
+         base::BindOnce(
+             &FileSystemChooseEntryFunction::ConfirmSensitiveDirectoryAccess,
+-            this, paths, web_contents));
++            this, paths));
+     return;
+   }
+ 
+@@ -587,8 +580,7 @@
+ }
+ 
+ void FileSystemChooseEntryFunction::ConfirmSensitiveDirectoryAccess(
+-    const std::vector<base::FilePath>& paths,
+-    content::WebContents* web_contents) {
++    const std::vector<base::FilePath>& paths) {
+   if (ExtensionsBrowserClient::Get()->IsShuttingDown()) {
+     FileSelectionCanceled();
+     return;
+@@ -601,6 +593,13 @@
+     return;
+   }
+ 
++  content::WebContents* const web_contents =
++      GetWebContentsForRenderFrameHost(browser_context(), render_frame_host());
++  if (!web_contents) {
++    Respond(Error(kInvalidCallingPage));
++    return;
++  }
++
+   delegate->ConfirmSensitiveDirectoryAccess(
+       app_file_handler_util::HasFileSystemWritePermission(extension_.get()),
+       base::UTF8ToUTF16(extension_->name()), web_contents,
+diff --git a/extensions/browser/api/file_system/file_system_api.h b/extensions/browser/api/file_system/file_system_api.h
+index ae1588c..0895a17 100644
+--- a/extensions/browser/api/file_system/file_system_api.h
++++ b/extensions/browser/api/file_system/file_system_api.h
+@@ -19,10 +19,6 @@
+ #include "extensions/common/api/file_system.h"
+ #include "ui/shell_dialogs/select_file_dialog.h"
+ 
+-namespace content {
+-class WebContents;
+-}  // namespace content
+-
+ namespace extensions {
+ class ExtensionPrefs;
+ 
+@@ -168,13 +164,12 @@
+   // directory. If so, calls ConfirmSensitiveDirectoryAccess. Otherwise, calls
+   // OnDirectoryAccessConfirmed.
+   void ConfirmDirectoryAccessAsync(bool non_native_path,
+-                                   const std::vector<base::FilePath>& paths,
+-                                   content::WebContents* web_contents);
++                                   const std::vector<base::FilePath>& paths);
+ 
+   // Shows a dialog to confirm whether the user wants to open the directory.
+   // Calls OnDirectoryAccessConfirmed or FileSelectionCanceled.
+-  void ConfirmSensitiveDirectoryAccess(const std::vector<base::FilePath>& paths,
+-                                       content::WebContents* web_contents);
++  void ConfirmSensitiveDirectoryAccess(
++      const std::vector<base::FilePath>& paths);
+ 
+   void OnDirectoryAccessConfirmed(const std::vector<base::FilePath>& paths);
+ 


### PR DESCRIPTION
[M90-LTS] Defer looking up the WebContents for the directory confirmation dialog.

Look up the WebContents to use for the sensitive directory confirmation
dialog immediately before it's used instead of before performing some
blocking file access to determine whether it's necessary.

(cherry picked from commit 18236a0db8341302120c60781ae3129e94fbaf1c)

Bug: 1234009
Change-Id: I5e00c7fa199b3da522e1fdb73242891d7f5f7423
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3063743
Commit-Queue: Sam McNally <sammc@chromium.org>
Cr-Original-Commit-Position: refs/heads/master@{#907467}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3097732
Reviewed-by: Sam McNally <sammc@chromium.org>
Reviewed-by: Jana Grill <janagrill@google.com>
Reviewed-by: Artem Sumaneev <asumaneev@google.com>
Owners-Override: Artem Sumaneev <asumaneev@google.com>
Commit-Queue: Roger Felipe Zanoni da Silva <rzanoni@google.com>
Cr-Commit-Position: refs/branch-heads/4430@{#1569}
Cr-Branched-From: e5ce7dc4f7518237b3d9bb93cccca35d25216cbe-refs/heads/master@{#857950}


Notes: Security: backported fix for 1234009.