### PR TITLE
chore: cherry-pick ba7a4d021741 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -147,3 +147,4 @@ cherry-pick-ac9dc1235e28.patch
 cherry-pick-4ce2abc17078.patch
 cherry-pick-e2123a8e0943.patch
 cherry-pick-1227933.patch
+cherry-pick-ba7a4d021741.patch

--- a/patches/chromium/cherry-pick-ba7a4d021741.patch
+++ b/patches/chromium/cherry-pick-ba7a4d021741.patch
@@ -1,0 +1,78 @@
+From ba7a4d0217412c58477362c5eb8e11b277ae961f Mon Sep 17 00:00:00 2001
+From: Hongchan Choi <hongchan@chromium.org>
+Date: Fri, 20 Aug 2021 17:19:58 +0000
+Subject: [PATCH] [M90-LTS] Protect HRTF database loader thread from access by different threads
+
+This patch add a new mutex locker around the HRTF database loader
+thread to ensure the safe exclusive access of the loader thread
+and the HRTF database.
+
+(cherry picked from commit 6811e850ee10847da16c4d5fdc0f845494586b65)
+
+Bug: 1233564
+Change-Id: Ie12b99ffe520d3747e34af387a37637a10aab38a
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3068260
+Auto-Submit: Hongchan Choi <hongchan@chromium.org>
+Commit-Queue: Kentaro Hara <haraken@chromium.org>
+Cr-Original-Commit-Position: refs/heads/master@{#908269}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3097764
+Reviewed-by: Artem Sumaneev <asumaneev@google.com>
+Owners-Override: Artem Sumaneev <asumaneev@google.com>
+Commit-Queue: Roger Felipe Zanoni da Silva <rzanoni@google.com>
+Cr-Commit-Position: refs/branch-heads/4430@{#1568}
+Cr-Branched-From: e5ce7dc4f7518237b3d9bb93cccca35d25216cbe-refs/heads/master@{#857950}
+---
+
+diff --git a/third_party/blink/renderer/platform/audio/hrtf_database_loader.cc b/third_party/blink/renderer/platform/audio/hrtf_database_loader.cc
+index 034ded0..01cb98a 100644
+--- a/third_party/blink/renderer/platform/audio/hrtf_database_loader.cc
++++ b/third_party/blink/renderer/platform/audio/hrtf_database_loader.cc
+@@ -86,6 +86,8 @@
+ void HRTFDatabaseLoader::LoadAsynchronously() {
+   DCHECK(IsMainThread());
+ 
++  MutexLocker locker(lock_);
++
+   // m_hrtfDatabase and m_thread should both be unset because this should be a
+   // new HRTFDatabaseLoader object that was just created by
+   // createAndLoadAsynchronouslyIfNecessary and because we haven't started
+@@ -122,6 +124,10 @@
+ }
+ 
+ void HRTFDatabaseLoader::WaitForLoaderThreadCompletion() {
++  // We can lock this because this is called from either the main thread or
++  // the offline audio rendering thread.
++  MutexLocker locker(lock_);
++
+   if (!thread_)
+     return;
+ 
+diff --git a/third_party/blink/renderer/platform/audio/hrtf_database_loader.h b/third_party/blink/renderer/platform/audio/hrtf_database_loader.h
+index 3ce476f..a94997b4 100644
+--- a/third_party/blink/renderer/platform/audio/hrtf_database_loader.h
++++ b/third_party/blink/renderer/platform/audio/hrtf_database_loader.h
+@@ -64,8 +64,8 @@
+   // must be called from the audio thread.
+   bool IsLoaded() { return Database(); }
+ 
+-  // waitForLoaderThreadCompletion() may be called more than once and is
+-  // thread-safe.
++  // May be called from both main and audio thread, and also can be called more
++  // than once.
+   void WaitForLoaderThreadCompletion();
+ 
+   // Returns the database or nullptr if the database doesn't yet exist.  Must
+@@ -87,11 +87,10 @@
+   void LoadTask();
+   void CleanupTask(base::WaitableEvent*);
+ 
+-  // Holding a m_lock is required when accessing m_hrtfDatabase since we access
+-  // it from multiple threads.
++  // |lock_| MUST be held when accessing |hrtf_database_| or |thread_| because
++  // it can be accessed by multiple threads (e.g multiple AudioContexts).
+   Mutex lock_;
+   std::unique_ptr<HRTFDatabase> hrtf_database_;
+-
+   std::unique_ptr<Thread> thread_;
+ 
+   float database_sample_rate_;


### PR DESCRIPTION
[M90-LTS] Protect HRTF database loader thread from access by different threads

This patch add a new mutex locker around the HRTF database loader
thread to ensure the safe exclusive access of the loader thread
and the HRTF database.

(cherry picked from commit 6811e850ee10847da16c4d5fdc0f845494586b65)

Bug: 1233564
Change-Id: Ie12b99ffe520d3747e34af387a37637a10aab38a
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3068260
Auto-Submit: Hongchan Choi <hongchan@chromium.org>
Commit-Queue: Kentaro Hara <haraken@chromium.org>
Cr-Original-Commit-Position: refs/heads/master@{#908269}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3097764
Reviewed-by: Artem Sumaneev <asumaneev@google.com>
Owners-Override: Artem Sumaneev <asumaneev@google.com>
Commit-Queue: Roger Felipe Zanoni da Silva <rzanoni@google.com>
Cr-Commit-Position: refs/branch-heads/4430@{#1568}
Cr-Branched-From: e5ce7dc4f7518237b3d9bb93cccca35d25216cbe-refs/heads/master@{#857950}


Notes: Security: backported fix for 1233564.