### PR TITLE
feat: deprecate desktopCapturer.getSources in the renderer

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -12,6 +12,39 @@ This document uses the following convention to categorize breaking changes:
 * **Deprecated:** An API was marked as deprecated. The API will continue to function, but will emit a deprecation warning, and will be removed in a future release.
 * **Removed:** An API or feature was removed, and is no longer supported by Electron.
 
+## Planned Breaking API Changes (17.0)
+
+### Removed: `desktopCapturer.getSources` in the renderer
+
+The `desktopCapturer.getSources` API is now only available in the main process.
+This has been changed in order to improve the default security of Electron
+apps.
+
+If you need this functionality, it can be replaced as follows:
+
+```js
+// Main process
+const { ipcMain, desktopCapturer } = require('electron')
+
+ipcMain.handle(
+  'DESKTOP_CAPTURER_GET_SOURCES',
+  (event, opts) => desktopCapturer.getSources(opts)
+)
+```
+
+```js
+// Renderer process
+const { ipcRenderer } = require('electron')
+
+const desktopCapturer = {
+  getSources: (opts) => ipcRenderer.invoke('DESKTOP_CAPTURER_GET_SOURCES', opts)
+}
+```
+
+However, you should consider further restricting the information returned to
+the renderer; for instance, displaying a source selector to the user and only
+returning the selected source.
+
 ## Planned Breaking API Changes (16.0)
 
 ### Behavior Changed: `crashReporter` implementation switched to Crashpad on Linux
@@ -26,6 +59,15 @@ There are also some subtle changes to how annotations will be reported on
 Linux, including that long values will no longer be split between annotations
 appended with `__1`, `__2` and so on, and instead will be truncated at the
 (new, longer) annotation value limit.
+
+### Deprecated: `desktopCapturer.getSources` in the renderer
+
+Usage of the `desktopCapturer.getSources` API in the renderer has been
+deprecated and will be removed. This change improves the default security of
+Electron apps.
+
+See [here](#removed-desktopcapturergetsources-in-the-renderer) for details on
+how to replace this API in your app.
 
 ## Planned Breaking API Changes (14.0)
 

--- a/lib/renderer/api/desktop-capturer.ts
+++ b/lib/renderer/api/desktop-capturer.ts
@@ -1,5 +1,6 @@
 import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
 import { deserialize } from '@electron/internal/common/type-utils';
+import { deprecate } from '@electron/internal/common/api/deprecate';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
 const { hasSwitch } = process._linkedBinding('electron_common_command_line');
@@ -14,6 +15,11 @@ function getCurrentStack () {
   return (target as any).stack;
 }
 
+let warned = process.noDeprecation;
 export async function getSources (options: Electron.SourcesOptions) {
+  if (!warned) {
+    deprecate.log('The use of \'desktopCapturer.getSources\' in the renderer process is deprecated and will be removed. See https://www.electronjs.org/docs/breaking-changes#removed-desktopcapturergetsources-in-the-renderer for more details.');
+    warned = true;
+  }
   return deserialize(await ipcRendererInternal.invoke(IPC_MESSAGES.DESKTOP_CAPTURER_GET_SOURCES, options, getCurrentStack()));
 }

--- a/lib/renderer/api/desktop-capturer.ts
+++ b/lib/renderer/api/desktop-capturer.ts
@@ -1,6 +1,6 @@
 import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
 import { deserialize } from '@electron/internal/common/type-utils';
-import { deprecate } from '@electron/internal/common/api/deprecate';
+import deprecate from '@electron/internal/common/api/deprecate';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
 const { hasSwitch } = process._linkedBinding('electron_common_command_line');


### PR DESCRIPTION
#### Description of Change
Deprecates desktopCapturer.getSources in the renderer. See #30720 for more
details.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Usage of the `desktopCapturer.getSources` API from the renderer process has been deprecated and will be removed.
