### PR TITLE
docs: improve documentation about macOS entitlement usage security

### DIFF
--- a/docs/tutorial/code-signing.md
+++ b/docs/tutorial/code-signing.md
@@ -88,13 +88,14 @@ without meaning any harm:
   <dict>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
     <key>com.apple.security.cs.debugger</key>
     <true/>
   </dict>
 </plist>
 ```
+
+Note that up until Electron 12, the `com.apple.security.cs.allow-unsigned-executable-memory` entitlement was required
+as well. However, it should not be used anymore if it can be avoided.
 
 To see all of this in action, check out Electron Fiddle's source code,
 [especially its `electron-forge` configuration
@@ -165,13 +166,14 @@ without meaning any harm:
   <dict>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
     <key>com.apple.security.cs.debugger</key>
     <true/>
   </dict>
 </plist>
 ```
+
+Up until Electron 12, the `com.apple.security.cs.allow-unsigned-executable-memory` entitlement was required
+as well. However, it should not be used anymore if it can be avoided.
 
 ## Mac App Store
 


### PR DESCRIPTION
This PR improves the macOS code signing documentation to take into account the changes made to how memory allocation is done in Electron 12. With the changes, Electron applications no longer need the unsafe memory entitlement. 

Notes: none