### PR TITLE
chore: update E16 node module version

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -2,7 +2,7 @@ is_electron_build = true
 root_extra_deps = [ "//electron" ]
 
 # Registry of NMVs --> https://github.com/nodejs/node/blob/master/doc/abi_version_registry.json
-node_module_version = 89
+node_module_version = 99
 
 v8_promise_internal_field_count = 1
 v8_typed_array_max_size_in_heap = 0


### PR DESCRIPTION
#### Description of Change

Updates Electron 16 to use the correct NMV number.

Ref (do not merge until this PR has merged): https://github.com/nodejs/node/pull/39950

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none