### PR TITLE
fix: BrowserWindow backgroundColor

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -360,9 +360,7 @@ void BrowserWindow::Blur() {
 
 void BrowserWindow::SetBackgroundColor(const std::string& color_name) {
   BaseWindow::SetBackgroundColor(color_name);
-  auto* view = web_contents()->GetRenderWidgetHostView();
-  if (view)
-    view->SetBackgroundColor(ParseHexColor(color_name));
+  web_contents()->SetPageBaseBackgroundColor(ParseHexColor(color_name));
   // Also update the web preferences object otherwise the view will be reset on
   // the next load URL call
   if (api_web_contents_) {

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1377,8 +1377,16 @@ void WebContents::HandleNewRenderFrame(
     std::string color_name;
     if (web_preferences->GetPreference(options::kBackgroundColor,
                                        &color_name)) {
-      rwhv->SetBackgroundColor(ParseHexColor(color_name));
+      web_contents()->SetPageBaseBackgroundColor(ParseHexColor(color_name));
     } else {
+      web_contents()->SetPageBaseBackgroundColor(absl::nullopt);
+    }
+
+    // When a page base background color is set, transparency needs to be
+    // explicitly set by calling
+    // RenderWidgetHostOwnerDelegate::SetBackgroundOpaque(false).
+    // RenderWidgetHostViewBase::SetBackgroundColor() will do this for us.
+    if (web_preferences->IsEnabled(options::kTransparent)) {
       rwhv->SetBackgroundColor(SK_ColorTRANSPARENT);
     }
   }


### PR DESCRIPTION
#### Description of Change

fixes #30759

The renderer in Blink now sets its own background color which is determined from the logic in [`WebViewImpl::BaseBackgroundColor()`](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/exported/web_view_impl.cc;l=3049-3058;drc=98898daa2e8f46ff098cea1f2e218f8a8266c838).

To set this background color for the main frame, we must use `WebContents::SetPageBaseBackgroundColor(SkColor)`.

In #30136, we had reverted using this API because it ended up breaking BrowserWindow transparency. To get this to work, we can see from `WebViewImpl::BaseBackgroundColor()` that there's a property to enable transparency, `override_base_background_color_to_transparent_`.

To override the base background color to be transparent, we must call `RenderWidgetHostOwnerDelegate::SetBackgroundOpaque(false)` which we can do by invoking [`RenderWidgetHostViewBase::SetBackgroundColor(SK_ColorTRANSPARENT)`](https://source.chromium.org/chromium/chromium/src/+/main:content/browser/renderer_host/render_widget_host_view_base.cc;l=333-338;drc=98898daa2e8f46ff098cea1f2e218f8a8266c838).

cc @codebytere 

Transparent window using https://gist.github.com/b52f026c763057f97f745fade82758fd from #30136
![image](https://user-images.githubusercontent.com/1656324/131588886-fdcd2cf0-feb3-4f64-b453-47b7bbf5945e.png)

Background color using https://gist.github.com/4256f388d41ef0d974645a11ab72b1fe from #30759
![image](https://user-images.githubusercontent.com/1656324/131588990-90d7308a-ae9b-4226-8f63-8d127054e553.png)


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed BrowserWindow's backgroundColor option not having an effect.
