### PR TITLE
fix: BrowserWindow backgroundColor

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -39,13 +39,15 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
 
   // Copy the backgroundColor to webContents.
   v8::Local<v8::Value> value;
-  if (options.Get(options::kBackgroundColor, &value))
-    web_preferences.Set(options::kBackgroundColor, value);
-
-  // Copy the transparent setting to webContents
-  v8::Local<v8::Value> transparent;
-  if (options.Get(options::kTransparent, &transparent))
-    web_preferences.Set(options::kTransparent, transparent);
+  bool transparent = false;
+  if (options.Get(options::kBackgroundColor, &value)) {
+    web_preferences.SetHidden(options::kBackgroundColor, value);
+  } else if (options.Get(options::kTransparent, &transparent) && transparent) {
+    // If the BrowserWindow is transparent, also propagate transparency to the
+    // WebContents unless a separate backgroundColor has been set.
+    web_preferences.SetHidden(options::kBackgroundColor,
+                              ToRGBAHex(SK_ColorTRANSPARENT));
+  }
 
   // Copy the show setting to webContents, but only if we don't want to paint
   // when initially hidden

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -44,8 +44,8 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
 
   // Copy the transparent setting to webContents
   v8::Local<v8::Value> transparent;
-  if (options.Get("transparent", &transparent))
-    web_preferences.Set("transparent", transparent);
+  if (options.Get(options::kTransparent, &transparent))
+    web_preferences.Set(options::kTransparent, transparent);
 
   // Copy the show setting to webContents, but only if we don't want to paint
   // when initially hidden
@@ -360,9 +360,7 @@ void BrowserWindow::Blur() {
 
 void BrowserWindow::SetBackgroundColor(const std::string& color_name) {
   BaseWindow::SetBackgroundColor(color_name);
-  auto* view = web_contents()->GetRenderWidgetHostView();
-  if (view)
-    view->SetBackgroundColor(ParseHexColor(color_name));
+  web_contents()->SetPageBaseBackgroundColor(ParseHexColor(color_name));
   // Also update the web preferences object otherwise the view will be reset on
   // the next load URL call
   if (api_web_contents_) {

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1375,14 +1375,6 @@ void WebContents::HandleNewRenderFrame(
   if (web_preferences) {
     web_contents()->SetPageBaseBackgroundColor(
         web_preferences->GetBackgroundColor());
-
-    // When a page base background color is set, transparency needs to be
-    // explicitly set by calling
-    // RenderWidgetHostOwnerDelegate::SetBackgroundOpaque(false).
-    // RenderWidgetHostViewBase::SetBackgroundColor() will do this for us.
-    if (web_preferences->IsTransparent()) {
-      rwhv->SetBackgroundColor(SK_ColorTRANSPARENT);
-    }
   }
 
   if (!background_throttling_)

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -159,7 +159,6 @@ void WebContentsPreferences::Clear() {
   safe_dialogs_ = false;
   safe_dialogs_message_ = absl::nullopt;
   ignore_menu_shortcuts_ = false;
-  transparent_ = false;
   background_color_ = absl::nullopt;
   image_animation_policy_ =
       blink::mojom::ImageAnimationPolicy::kImageAnimationPolicyAllowed;
@@ -226,9 +225,8 @@ void WebContentsPreferences::SetFromDictionary(
   web_preferences.Get("disablePopups", &disable_popups_);
   web_preferences.Get("disableDialogs", &disable_dialogs_);
   web_preferences.Get("safeDialogs", &safe_dialogs_);
-  web_preferences.Get(options::kTransparent, &transparent_);
   std::string background_color;
-  if (web_preferences.Get(options::kBackgroundColor, &background_color))
+  if (web_preferences.GetHidden(options::kBackgroundColor, &background_color))
     background_color_ = ParseHexColor(background_color);
   std::string safe_dialogs_message;
   if (web_preferences.Get("safeDialogsMessage", &safe_dialogs_message))

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -22,6 +22,7 @@
 #include "shell/browser/api/electron_api_web_contents.h"
 #include "shell/browser/native_window.h"
 #include "shell/browser/session_preferences.h"
+#include "shell/common/color_util.h"
 #include "shell/common/gin_converters/value_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/options_switches.h"
@@ -158,7 +159,8 @@ void WebContentsPreferences::Clear() {
   safe_dialogs_ = false;
   safe_dialogs_message_ = absl::nullopt;
   ignore_menu_shortcuts_ = false;
-  background_color_ = SK_ColorTRANSPARENT;
+  transparent_ = false;
+  background_color_ = absl::nullopt;
   image_animation_policy_ =
       blink::mojom::ImageAnimationPolicy::kImageAnimationPolicyAllowed;
   preload_path_ = absl::nullopt;
@@ -224,7 +226,10 @@ void WebContentsPreferences::SetFromDictionary(
   web_preferences.Get("disablePopups", &disable_popups_);
   web_preferences.Get("disableDialogs", &disable_dialogs_);
   web_preferences.Get("safeDialogs", &safe_dialogs_);
-  web_preferences.Get(options::kBackgroundColor, &background_color_);
+  web_preferences.Get(options::kTransparent, &transparent_);
+  std::string background_color;
+  if (web_preferences.Get(options::kBackgroundColor, &background_color))
+    background_color_ = ParseHexColor(background_color);
   std::string safe_dialogs_message;
   if (web_preferences.Get("safeDialogsMessage", &safe_dialogs_message))
     safe_dialogs_message_ = safe_dialogs_message;

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -48,8 +48,13 @@ class WebContentsPreferences
   base::Value* last_preference() { return &last_web_preferences_; }
 
   bool IsOffscreen() const { return offscreen_; }
-  SkColor GetBackgroundColor() const { return background_color_; }
-  void SetBackgroundColor(SkColor color) { background_color_ = color; }
+  bool IsTransparent() const { return transparent_; }
+  absl::optional<SkColor> GetBackgroundColor() const {
+    return background_color_;
+  }
+  void SetBackgroundColor(absl::optional<SkColor> color) {
+    background_color_ = color;
+  }
   bool ShouldUsePreferredSizeMode() const {
     return enable_preferred_size_mode_;
   }
@@ -119,7 +124,8 @@ class WebContentsPreferences
   bool safe_dialogs_;
   absl::optional<std::string> safe_dialogs_message_;
   bool ignore_menu_shortcuts_;
-  SkColor background_color_;
+  bool transparent_;
+  absl::optional<SkColor> background_color_;
   blink::mojom::ImageAnimationPolicy image_animation_policy_;
   absl::optional<base::FilePath> preload_path_;
   blink::mojom::V8CacheOptions v8_cache_options_;

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -48,7 +48,6 @@ class WebContentsPreferences
   base::Value* last_preference() { return &last_web_preferences_; }
 
   bool IsOffscreen() const { return offscreen_; }
-  bool IsTransparent() const { return transparent_; }
   absl::optional<SkColor> GetBackgroundColor() const {
     return background_color_;
   }
@@ -124,7 +123,6 @@ class WebContentsPreferences
   bool safe_dialogs_;
   absl::optional<std::string> safe_dialogs_message_;
   bool ignore_menu_shortcuts_;
-  bool transparent_;
   absl::optional<SkColor> background_color_;
   blink::mojom::ImageAnimationPolicy image_animation_policy_;
   absl::optional<base::FilePath> preload_path_;

--- a/spec-main/fixtures/snapshots/native-window-open.snapshot.txt
+++ b/spec-main/fixtures/snapshots/native-window-open.snapshot.txt
@@ -88,8 +88,7 @@
         "sandbox": true,
         "webviewTag": false,
         "nodeIntegrationInSubFrames": false,
-        "openerId": null,
-        "backgroundColor": "gray"
+        "openerId": null
       },
       "x": 100,
       "y": 100,

--- a/spec-main/fixtures/snapshots/proxy-window-open.snapshot.txt
+++ b/spec-main/fixtures/snapshots/proxy-window-open.snapshot.txt
@@ -88,8 +88,7 @@
         "nodeIntegration": false,
         "webviewTag": false,
         "nodeIntegrationInSubFrames": false,
-        "openerId": "placeholder-opener-id",
-        "backgroundColor": "gray"
+        "openerId": "placeholder-opener-id"
       },
       "x": 100,
       "y": 100,


### PR DESCRIPTION
#### Description of Change

fixes #30759

Port of #30777 which targets v14+15. I manually ported this to latest because of the changes to WebPreferences in https://github.com/electron/electron/pull/30193

The code below would fail to convert a hex string to an `SkColor` which resulted in the RVHW's background color always being set to transparent.

https://github.com/electron/electron/blob/dd7aeda6fbcd72de4029f946a57e6c96d8abfba7/shell/browser/web_contents_preferences.cc#L227

cc @codebytere @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
