### PR TITLE
ci: ignore pdb download failure on WOA

### DIFF
--- a/azure-pipelines-woa.yml
+++ b/azure-pipelines-woa.yml
@@ -54,11 +54,17 @@ steps:
     APPVEYOR_TOKEN: $(APPVEYOR_TOKEN)
 
 - powershell: |
-    $localArtifactPath = "$pwd\src\pdb.zip"
-    $serverArtifactPath = "$env:APPVEYOR_URL/buildjobs/$env:APPVEYOR_JOB_ID/artifacts/pdb.zip"
-    Invoke-RestMethod -Method Get -Uri $serverArtifactPath -OutFile $localArtifactPath -Headers @{ "Authorization" = "Bearer $env:APPVEYOR_TOKEN" }
-    cd src
-    & "${env:ProgramFiles(x86)}\7-Zip\7z.exe" x -y pdb.zip
+    try {
+      $localArtifactPath = "$pwd\src\pdb.zip"
+      $serverArtifactPath = "$env:APPVEYOR_URL/buildjobs/$env:APPVEYOR_JOB_ID/artifacts/pdb.zip"
+      Invoke-RestMethod -Method Get -Uri $serverArtifactPath -OutFile $localArtifactPath -Headers @{ "Authorization" = "Bearer $env:APPVEYOR_TOKEN" }
+      cd src
+      & "${env:ProgramFiles(x86)}\7-Zip\7z.exe" x -y pdb.zip
+    } catch {
+      Write-Host "There was an exception encountered while downloading pdb files:" $_.Exception.Message
+    } finally {
+      $global:LASTEXITCODE = 0
+    }
   displayName: 'Download pdb files for detailed stacktraces'
   env:
     APPVEYOR_TOKEN: $(APPVEYOR_TOKEN)


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->
Recently in 1de8f746b5c304d45002731283552ef2bf6ba0f9 I added a step to our WOA tests to download the PDB files so that we get better stack traces on WOA testing.  Unfortunately sometimes this step fails (possibly because of how large the file is) and ends up marking the whole test run as a failure, eg:
https://github.visualstudio.com/electron/_build/results?buildId=115579&view=logs&j=6b902995-b73d-5f5c-66fd-a7f66c857d2c&t=de3312e4-438d-59aa-78f3-46bf3faba2ab&s=b15d9194-8f26-5328-b47f-5968c76b37e7

Since these pdb files are not needed for testing (but are useful if there), I've changed the WOA job to ignore failures downloading the pdb files.  I did some testing here to verify that a download error doesn't mark the job as failed:
https://github.visualstudio.com/electron/_build/results?buildId=115773&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=72c3483f-759b-5fe1-97d0-7523409e045c

Resolves the issue in https://electronhq.slack.com/archives/C6JSJ9FS5/p1627336617050900

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
