### PR TITLE
fix: show maximized frameless window

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1629,8 +1629,17 @@ void NativeWindowViews::OnMouseEvent(ui::MouseEvent* event) {
 }
 
 ui::WindowShowState NativeWindowViews::GetRestoredState() {
-  if (IsMaximized())
+  if (IsMaximized()) {
+#if defined(OS_WIN)
+    // Only restore Maximized state when window is NOT transparent style
+    if (!transparent()) {
+      return ui::SHOW_STATE_MAXIMIZED;
+    }
+#else
     return ui::SHOW_STATE_MAXIMIZED;
+#endif
+  }
+
   if (IsFullscreen())
     return ui::SHOW_STATE_FULLSCREEN;
 

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -4647,4 +4647,32 @@ describe('BrowserWindow module', () => {
       });
     });
   });
+
+  describe('"transparent" option', () => {
+    afterEach(closeAllWindows);
+
+    // Only applicable on Windows where transparent windows can't be maximized.
+    ifit(process.platform === 'win32')('can show maximized frameless window', async () => {
+      const display = screen.getPrimaryDisplay();
+
+      const w = new BrowserWindow({
+        ...display.bounds,
+        frame: false,
+        transparent: true,
+        show: true
+      });
+
+      w.loadURL('about:blank');
+      await emittedOnce(w, 'ready-to-show');
+
+      expect(w.isMaximized()).to.be.true();
+
+      // Fails when the transparent HWND is in an invalid maximized state.
+      expect(w.getBounds()).to.deep.equal(display.bounds);
+
+      const newBounds = { width: 256, height: 256, x: 0, y: 0 };
+      w.setBounds(newBounds);
+      expect(w.getBounds()).to.deep.equal(newBounds);
+    });
+  });
 });

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -4668,7 +4668,7 @@ describe('BrowserWindow module', () => {
       expect(w.isMaximized()).to.be.true();
 
       // Fails when the transparent HWND is in an invalid maximized state.
-      expect(w.getBounds()).to.deep.equal(display.bounds);
+      expect(w.getBounds()).to.deep.equal(display.workArea);
 
       const newBounds = { width: 256, height: 256, x: 0, y: 0 };
       w.setBounds(newBounds);


### PR DESCRIPTION
#### Description of Change

fixes #30798

Transparent frameless windows do not support being maximized.

We approximate the maximized state by checking if the window takes up the nearest screen's bounds: https://github.com/electron/electron/blob/49e62f1261d289500e5e85973fb4962fea3f7cab/shell/browser/native_window_views.cc#L597-L610

If that's the case, `browserWindow.show()` attempts to restore the window to a maximized state which will break its transparency and bounds. See https://github.com/electron/electron/issues/30798#issuecomment-910834940 for more details.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed transparent frameless windows having an opaque background when opened in a maximized state.
