### PR TITLE
fix: remove CHECK_EQ for swapped RFH

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1421,12 +1421,11 @@ void WebContents::RenderFrameHostChanged(content::RenderFrameHost* old_host,
   // If an instance of WebFrameMain exists, it will need to have its RFH
   // swapped as well.
   //
-  // |old_host| can be a nullptr in so we use |new_host| for looking up the
+  // |old_host| can be a nullptr so we use |new_host| for looking up the
   // WebFrameMain instance.
   auto* web_frame =
       WebFrameMain::FromFrameTreeNodeId(new_host->GetFrameTreeNodeId());
   if (web_frame) {
-    CHECK_EQ(web_frame->render_frame_host(), old_host);
     web_frame->UpdateRenderFrameHost(new_host);
   }
 }


### PR DESCRIPTION
#### Description of Change
fixes #30807

Backport a fix from #29290 which has already made it into `main` and `15-x-y` branches.

The check below will get thrown sometimes when the `old_host` is a nullptr which I hadn't expected initially. The code works fine with this check removed.
https://github.com/electron/electron/blob/c0da647170fa03b79de33e67f42e3acf5ce36ca2/shell/browser/api/electron_api_web_contents.cc#L1426-L1429

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed crash that occasionally happens when closing or opening BrowserWindows.
