### PR TITLE
fix: undocked devtools not resizable on Windows

### DIFF
--- a/shell/browser/ui/views/inspectable_web_contents_view_views.cc
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.cc
@@ -43,8 +43,6 @@ class DevToolsWindowDelegate : public views::ClientView,
 
   // views::WidgetDelegate:
   views::View* GetInitiallyFocusedView() override { return view_; }
-  bool CanMaximize() const override { return true; }
-  bool CanMinimize() const override { return true; }
   std::u16string GetWindowTitle() const override { return shell_->GetTitle(); }
   ui::ImageModel GetWindowAppIcon() override { return GetWindowIcon(); }
   ui::ImageModel GetWindowIcon() override { return icon_; }
@@ -193,6 +191,7 @@ void InspectableWebContentsViewViews::SetIsDocked(bool docked, bool activate) {
 
     devtools_window_->Init(std::move(params));
     devtools_window_->UpdateWindowIcon();
+    devtools_window_->widget_delegate()->SetHasWindowSizeControls(true);
   }
 
   ShowDevTools(activate);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/30803.

Refs https://chromium-review.googlesource.com/c/chromium/src/+/2228988.

Fixes an issue where undocked devtools was not resizable on Windows. This was because Chromium de-virtualized `CanResize`, and the default is false. In the above CL, Chromium introduced a convenience method to handle all three of `CanMaximize`, `CanMinimize`, and `CanResize`, so remove our other two overrides here as well.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where undocked devtools was not resizable on Windows.