### PR TITLE
refactor: use getter for frame in webrequest details

### DIFF
--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -26,6 +26,7 @@
 #include "shell/common/gin_converters/net_converter.h"
 #include "shell/common/gin_converters/std_converter.h"
 #include "shell/common/gin_converters/value_converter.h"
+#include "shell/common/gin_helper/dictionary.h"
 
 namespace gin {
 
@@ -144,7 +145,8 @@ v8::Local<v8::Value> HttpResponseHeadersToV8(
 }
 
 // Overloaded by multiple types to fill the |details| object.
-void ToDictionary(gin::Dictionary* details, extensions::WebRequestInfo* info) {
+void ToDictionary(gin_helper::Dictionary* details,
+                  extensions::WebRequestInfo* info) {
   details->Set("id", info->id);
   details->Set("url", info->url);
   details->Set("method", info->method);
@@ -163,7 +165,7 @@ void ToDictionary(gin::Dictionary* details, extensions::WebRequestInfo* info) {
   auto* render_frame_host =
       content::RenderFrameHost::FromID(info->render_process_id, info->frame_id);
   if (render_frame_host) {
-    details->Set("frame", render_frame_host);
+    details->SetGetter("frame", render_frame_host);
     auto* web_contents =
         content::WebContents::FromRenderFrameHost(render_frame_host);
     auto* api_web_contents = WebContents::From(web_contents);
@@ -174,34 +176,34 @@ void ToDictionary(gin::Dictionary* details, extensions::WebRequestInfo* info) {
   }
 }
 
-void ToDictionary(gin::Dictionary* details,
+void ToDictionary(gin_helper::Dictionary* details,
                   const network::ResourceRequest& request) {
   details->Set("referrer", request.referrer);
   if (request.request_body)
     details->Set("uploadData", *request.request_body);
 }
 
-void ToDictionary(gin::Dictionary* details,
+void ToDictionary(gin_helper::Dictionary* details,
                   const net::HttpRequestHeaders& headers) {
   details->Set("requestHeaders", headers);
 }
 
-void ToDictionary(gin::Dictionary* details, const GURL& location) {
+void ToDictionary(gin_helper::Dictionary* details, const GURL& location) {
   details->Set("redirectURL", location);
 }
 
-void ToDictionary(gin::Dictionary* details, int net_error) {
+void ToDictionary(gin_helper::Dictionary* details, int net_error) {
   details->Set("error", net::ErrorToString(net_error));
 }
 
 // Helper function to fill |details| with arbitrary |args|.
 template <typename Arg>
-void FillDetails(gin::Dictionary* details, Arg arg) {
+void FillDetails(gin_helper::Dictionary* details, Arg arg) {
   ToDictionary(details, arg);
 }
 
 template <typename Arg, typename... Args>
-void FillDetails(gin::Dictionary* details, Arg arg, Args... args) {
+void FillDetails(gin_helper::Dictionary* details, Arg arg, Args... args) {
   ToDictionary(details, arg);
   FillDetails(details, args...);
 }
@@ -446,7 +448,7 @@ void WebRequest::HandleSimpleEvent(SimpleEvent event,
 
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope handle_scope(isolate);
-  gin::Dictionary details(isolate, v8::Object::New(isolate));
+  gin_helper::Dictionary details(isolate, v8::Object::New(isolate));
   FillDetails(&details, request_info, args...);
   info.listener.Run(gin::ConvertToV8(isolate, details));
 }
@@ -469,7 +471,7 @@ int WebRequest::HandleResponseEvent(ResponseEvent event,
 
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::HandleScope handle_scope(isolate);
-  gin::Dictionary details(isolate, v8::Object::New(isolate));
+  gin_helper::Dictionary details(isolate, v8::Object::New(isolate));
   FillDetails(&details, request_info, args...);
 
   ResponseCallback response =


### PR DESCRIPTION
#### Description of Change

Refactors the `webRequest` module to use a getter for lazily serializing WebFrameMain instances.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none
