### PR TITLE
fix: crash when navigating with render process reuse disabled

### DIFF
--- a/spec-main/fixtures/crash-cases/api-web-frame-main-connect/index.html
+++ b/spec-main/fixtures/crash-cases/api-web-frame-main-connect/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'">
+    <meta http-equiv="X-Content-Security-Policy" content="default-src 'self'; script-src 'self'">
+    <title>Hello One!</title>
+  </head>
+  <body>
+    <h1>Hello World!</h1>
+  </body>
+</html>

--- a/spec-main/fixtures/crash-cases/api-web-frame-main-connect/index.js
+++ b/spec-main/fixtures/crash-cases/api-web-frame-main-connect/index.js
@@ -1,0 +1,37 @@
+const { app, BrowserWindow, webContents, protocol } = require('electron');
+const path = require('path');
+
+app.allowRendererProcessReuse = false;
+
+protocol.registerSchemesAsPrivileged([
+  { scheme: 'foo', privileges: { standard: true, secure: true } }
+]);
+
+function createWindow () {
+  const mainWindow = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false
+    }
+  });
+
+  mainWindow.webContents.session.protocol.registerFileProtocol('foo', (request, callback) => {
+    const url = new URL(request.url);
+    callback({ path: `${__dirname}${url.pathname}` });
+  });
+
+  mainWindow.webContents.on('did-finish-load', () => {
+    setImmediate(() => app.quit());
+  });
+
+  // Creates WebFrameMain instance before initiating the navigation.
+  mainWindow.webContents.send('test', 'ping');
+
+  mainWindow.loadURL('foo://app/index.html');
+}
+
+app.whenReady().then(() => {
+  createWindow();
+});


### PR DESCRIPTION
#### Description of Change

Regressed with https://github.com/electron/electron/pull/30598

Refs https://github.com/microsoft/vscode/issues/132238

This is only needed for 13-x-y branch were process reuse can be disabled.

<details>
<summary>
Stack Trace
</summary>

```
:FATAL:render_frame_host_impl.cc(1921)] Check failed: IsRenderFrameCreated().
Backtrace:
        base::debug::CollectStackTrace [0x00007FF725426128+32] (o:\base\debug\stack_trace_win.cc:303)
        base::debug::StackTrace::StackTrace [0x00007FF7253919A4+24] (o:\base\debug\stack_trace.cc:195)
        logging::LogMessage::~LogMessage [0x00007FF7253A5874+184] (o:\base\logging.cc:566)
        logging::LogMessage::~LogMessage [0x00007FF7253A66B8+24] (o:\base\logging.cc:559)
        content::RenderFrameHostImpl::GetRemoteInterfaces [0x00007FF72498D7EC+92] (o:\content\browser\renderer_host\render_frame_host_impl.cc:1922)
        electron::api::WebFrameMain::Connect [0x00007FF7224FCDE8+56] (o:\electron\shell\browser\api\electron_api_web_frame_main.cc:287)
        electron::api::WebContents::HandleNewRenderFrame [0x00007FF7224D7314+564] (o:\electron\shell\browser\api\electron_api_web_contents.cc:1394)
        electron::api::WebContents::RenderFrameCreated [0x00007FF7224D9168+312] (o:\electron\shell\browser\api\electron_api_web_contents.cc:1400)
        content::WebContentsImpl::WebContentsObserverList::NotifyObservers<void (content::WebContentsObserver::*)(content::RenderProcessHost *),content::RenderProcessHost *> [0x00007FF724AE0F3C+312] (o:\content\browser\web_contents\web_contents_impl.h:1422)
        content::WebContentsImpl::RenderFrameCreated [0x00007FF724AF6750+256] (o:\content\browser\web_contents\web_contents_impl.cc:6344)
        content::RenderFrameHostImpl::RenderFrameCreated [0x00007FF72498FAB0+480] (o:\content\browser\renderer_host\render_frame_host_impl.cc:2574)
        content::RenderViewHostImpl::CreateRenderView [0x00007FF7249DD29C+1884] (o:\content\browser\renderer_host\render_view_host_impl.cc:510)
        content::WebContentsImpl::CreateRenderViewForRenderManager [0x00007FF724AFD184+180] (o:\content\browser\web_contents\web_contents_impl.cc:7642)
        content::RenderFrameHostManager::InitRenderView [0x00007FF7249C05F0+204] (o:\content\browser\renderer_host\render_frame_host_manager.cc:2816)
        content::RenderFrameHostManager::CreateSpeculativeRenderFrame [0x00007FF7249C0364+512] (o:\content\browser\renderer_host\render_frame_host_manager.cc:2651)
        content::RenderFrameHostManager::CreateSpeculativeRenderFrameHost [0x00007FF7249BCFFC+244] (o:\content\browser\renderer_host\render_frame_host_manager.cc:2596)
        content::RenderFrameHostManager::GetFrameHostForNavigation [0x00007FF7249BC2A8+1224] (o:\content\browser\renderer_host\render_frame_host_manager.cc:986)
        content::RenderFrameHostManager::DidCreateNavigationRequest [0x00007FF7249BBCF0+184] (o:\content\browser\renderer_host\render_frame_host_manager.cc:810)
        content::FrameTreeNode::CreatedNavigationRequest [0x00007FF7248E698C+272] (o:\content\browser\renderer_host\frame_tree_node.cc:540)
        content::Navigator::Navigate [0x00007FF72497EFE8+472] (o:\content\browser\renderer_host\navigator.cc:588)
        content::NavigationControllerImpl::NavigateWithoutEntry [0x00007FF724955040+2588] (o:\content\browser\renderer_host\navigation_controller_impl.cc:3287)
        content::NavigationControllerImpl::LoadURLWithParams [0x00007FF724954550+272] (o:\content\browser\renderer_host\navigation_controller_impl.cc:1117)
        electron::api::WebContents::LoadURL [0x00007FF7224DD4DC+876] (o:\electron\shell\browser\api\electron_api_web_contents.cc:2088)
        gin_helper::Invoker<gin_helper::IndicesHolder<0,1,2>,electron::api::WebContents *,const GURL &,const gin_helper::Dictionary &>::DispatchToCallback [0x00007FF7224F478C+116] (o:\electron\shell\common\gin_helper\function_template.h:229)
```
</details>

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix crash when navigating with render process reuse disabled
