### PR TITLE
feat: add isMainFrame argument to 'certificate-error' event

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -277,6 +277,7 @@ Returns:
 * `certificate` [Certificate](structures/certificate.md)
 * `callback` Function
   * `isTrusted` Boolean - Whether to consider the certificate as trusted
+* `isMainFrame` Boolean
 
 Emitted when failed to verify the `certificate` for `url`, to trust the
 certificate you should prevent the default behavior with

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -530,6 +530,7 @@ Returns:
 * `certificate` [Certificate](structures/certificate.md)
 * `callback` Function
   * `isTrusted` Boolean - Indicates whether the certificate can be considered trusted.
+* `isMainFrame` Boolean
 
 Emitted when failed to verify the `certificate` for `url`.
 

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -817,10 +817,10 @@ void App::AllowCertificateError(
   v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
   v8::Locker locker(isolate);
   v8::HandleScope handle_scope(isolate);
-  bool prevent_default =
-      Emit("certificate-error",
-           WebContents::FromOrCreate(isolate, web_contents), request_url,
-           net::ErrorToString(cert_error), ssl_info.cert, adapted_callback);
+  bool prevent_default = Emit(
+      "certificate-error", WebContents::FromOrCreate(isolate, web_contents),
+      request_url, net::ErrorToString(cert_error), ssl_info.cert,
+      adapted_callback, is_main_frame_request);
 
   // Deny the certificate by default.
   if (!prevent_default)


### PR DESCRIPTION
#### Description of Change
Fixes #30662

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `isMainFrame` argument to `'certificate-error'` event.