### PR TITLE
build: retry hasher function if it fails first time

### DIFF
--- a/script/release/get-url-hash.js
+++ b/script/release/get-url-hash.js
@@ -8,24 +8,32 @@ const lambda = new AWS.Lambda({
   region: 'us-east-1'
 });
 
-module.exports = function getUrlHash (targetUrl, algorithm = 'sha256') {
-  return new Promise((resolve, reject) => {
-    lambda.invoke({
-      FunctionName: 'hasher',
-      Payload: JSON.stringify({
-        targetUrl,
-        algorithm
-      })
-    }, (err, data) => {
-      if (err) return reject(err);
-      try {
-        const response = JSON.parse(data.Payload);
-        if (response.statusCode !== 200) return reject(new Error('non-200 status code received from hasher function'));
-        if (!response.hash) return reject(new Error('Successful lambda call but failed to get valid hash'));
-        resolve(response.hash);
-      } catch (err) {
-        return reject(err);
-      }
+module.exports = async function getUrlHash (targetUrl, algorithm = 'sha256', attempts = 3) {
+  try {
+    await new Promise((resolve, reject) => {
+      lambda.invoke({
+        FunctionName: 'hasher',
+        Payload: JSON.stringify({
+          targetUrl,
+          algorithm
+        })
+      }, (err, data) => {
+        if (err) return reject(err);
+        try {
+          const response = JSON.parse(data.Payload);
+          if (response.statusCode !== 200) return reject(new Error('non-200 status code received from hasher function'));
+          if (!response.hash) return reject(new Error('Successful lambda call but failed to get valid hash'));
+          resolve(response.hash);
+        } catch (err) {
+          return reject(err);
+        }
+      });
     });
-  });
+  } catch (err) {
+    if (attempts > 1) {
+      console.error('Failed to get URL hash for', targetUrl, 'we will retry', err);
+      return getUrlHash(targetUrl, algorithm, attempts - 1);
+    }
+    throw err;
+  }
 };


### PR DESCRIPTION
In release `7_50g5hhf` we saw the hasher function flake once, kicking the release resulted in a successful publish but we can probably avoid the flake by just retrying the hash function if it fails.

Notes: no-notes
