### PR TITLE
chore: upstream changes from 15-x-y ASAR validation PR

### DIFF
--- a/shell/browser/net/asar/asar_file_validator.cc
+++ b/shell/browser/net/asar/asar_file_validator.cc
@@ -24,6 +24,8 @@ AsarFileValidator::AsarFileValidator(IntegrityPayload integrity,
   max_block_ = integrity_.blocks.size() - 1;
 }
 
+AsarFileValidator::~AsarFileValidator() = default;
+
 void AsarFileValidator::OnRead(base::span<char> buffer,
                                mojo::FileDataSource::ReadResult* result) {
   DCHECK(!done_reading_);

--- a/shell/browser/net/asar/asar_file_validator.h
+++ b/shell/browser/net/asar/asar_file_validator.h
@@ -19,11 +19,12 @@ namespace asar {
 class AsarFileValidator : public mojo::FilteredDataSource::Filter {
  public:
   AsarFileValidator(IntegrityPayload integrity, base::File file);
+  ~AsarFileValidator() override;
 
   void OnRead(base::span<char> buffer,
-              mojo::FileDataSource::ReadResult* result);
+              mojo::FileDataSource::ReadResult* result) override;
 
-  void OnDone();
+  void OnDone() override;
 
   void SetRange(uint64_t read_start, uint64_t extra_read, uint64_t read_max);
   void SetCurrentBlock(int current_block);

--- a/shell/common/asar/archive.cc
+++ b/shell/common/asar/archive.cc
@@ -157,6 +157,15 @@ bool FillFileInfoWithNode(Archive::FileInfo* info,
 
 }  // namespace
 
+IntegrityPayload::IntegrityPayload()
+    : algorithm(HashAlgorithm::NONE), block_size(0) {}
+IntegrityPayload::~IntegrityPayload() = default;
+IntegrityPayload::IntegrityPayload(const IntegrityPayload& other) = default;
+
+Archive::FileInfo::FileInfo()
+    : unpacked(false), executable(false), size(0), offset(0) {}
+Archive::FileInfo::~FileInfo() = default;
+
 Archive::Archive(const base::FilePath& path)
     : initialized_(false), path_(path), file_(base::File::FILE_OK) {
   base::ThreadRestrictions::ScopedAllowIO allow_io;
@@ -270,11 +279,11 @@ bool Archive::Init() {
 
 #if !defined(OS_MAC)
 absl::optional<IntegrityPayload> Archive::HeaderIntegrity() const {
-  return absl::optional<IntegrityPayload>();
+  return absl::nullopt;
 }
 
 absl::optional<base::FilePath> Archive::RelativePath() const {
-  return absl::optional<base::FilePath>();
+  return absl::nullopt;
 }
 #endif
 

--- a/shell/common/asar/archive.h
+++ b/shell/common/asar/archive.h
@@ -29,7 +29,9 @@ enum HashAlgorithm {
 };
 
 struct IntegrityPayload {
-  IntegrityPayload() : algorithm(HashAlgorithm::NONE), block_size(0) {}
+  IntegrityPayload();
+  ~IntegrityPayload();
+  IntegrityPayload(const IntegrityPayload& other);
   HashAlgorithm algorithm;
   std::string hash;
   uint32_t block_size;
@@ -41,7 +43,8 @@ struct IntegrityPayload {
 class Archive {
  public:
   struct FileInfo {
-    FileInfo() : unpacked(false), executable(false), size(0), offset(0) {}
+    FileInfo();
+    ~FileInfo();
     bool unpacked;
     bool executable;
     uint32_t size;


### PR DESCRIPTION
The 15-x-y backport of #30667 had some compile failures and a potential use-after-move, this just takes the commit in that backport and lands it to `main` as well 👍 

Notes: no-notes