### PR TITLE
chore: correct hierarchy of BrowserWindow headings

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -24,10 +24,11 @@ you can use the [Frameless Window](frameless-window.md) API.
 
 ## Showing window gracefully
 
-When loading a page in the window directly, users may see the page load incrementally, which is not a good experience for a native app. To make the window display
-without visual flash, there are two solutions for different situations.
+When loading a page in the window directly, users may see the page load incrementally,
+which is not a good experience for a native app. To make the window display
+without a visual flash, there are two solutions for different situations.
 
-## Using `ready-to-show` event
+### Using `ready-to-show` event
 
 While loading the page, the `ready-to-show` event will be emitted when the renderer
 process has rendered the page for the first time if the window has not been shown yet. Showing
@@ -48,7 +49,7 @@ event.
 Please note that using this event implies that the renderer will be considered "visible" and
 paint even though `show` is false.  This event will never fire if you use `paintWhenInitiallyHidden: false`
 
-## Setting `backgroundColor`
+### Setting `backgroundColor`
 
 For a complex app, the `ready-to-show` event could be emitted too late, making
 the app feel slow. In this case, it is recommended to show the window

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -49,7 +49,7 @@ event.
 Please note that using this event implies that the renderer will be considered "visible" and
 paint even though `show` is false.  This event will never fire if you use `paintWhenInitiallyHidden: false`
 
-### Setting `backgroundColor`
+### Setting the `backgroundColor` property
 
 For a complex app, the `ready-to-show` event could be emitted too late, making
 the app feel slow. In this case, it is recommended to show the window

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -28,7 +28,7 @@ When loading a page in the window directly, users may see the page load incremen
 which is not a good experience for a native app. To make the window display
 without a visual flash, there are two solutions for different situations.
 
-### Using `ready-to-show` event
+### Using the `ready-to-show` event
 
 While loading the page, the `ready-to-show` event will be emitted when the renderer
 process has rendered the page for the first time if the window has not been shown yet. Showing

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -22,7 +22,7 @@ win.loadFile('index.html')
 To create a window without chrome, or a transparent window in arbitrary shape,
 you can use the [Frameless Window](frameless-window.md) API.
 
-## Showing window gracefully
+## Showing the window gracefully
 
 When loading a page in the window directly, users may see the page load incrementally,
 which is not a good experience for a native app. To make the window display


### PR DESCRIPTION
#### Description of Change

Reverts some of the changes in #19196 where two headings were moved up a level by accident.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
