### PR TITLE
fix: Building on macOS with is_debug true

### DIFF
--- a/shell/common/platform_util_mac.mm
+++ b/shell/common/platform_util_mac.mm
@@ -118,15 +118,16 @@ void OpenExternal(const GURL& url,
                  });
 }
 
+// The following function helps with debug builds on the Mac
 gfx::NativeView GetViewForWindow(gfx::NativeWindow native_window) {
-  NSWindow* window = native_window.GetNativeNSWindow();
-  DCHECK(window);
-  DCHECK([window contentView]);
-  return gfx::NativeView([window contentView]);
+  NOTREACHED();
+  return nil;
 }
 
+// The following function helps with debug builds on the Mac
 gfx::NativeView GetParent(gfx::NativeView view) {
-  return gfx::NativeView(nil);
+  NOTREACHED();
+  return nil;
 }
 
 bool MoveItemToTrashWithError(const base::FilePath& full_path,

--- a/shell/common/platform_util_mac.mm
+++ b/shell/common/platform_util_mac.mm
@@ -21,6 +21,7 @@
 #include "base/strings/stringprintf.h"
 #include "base/strings/sys_string_conversions.h"
 #include "net/base/mac/url_conversions.h"
+#include "ui/views/widget/widget.h"
 #include "url/gurl.h"
 
 namespace {
@@ -115,6 +116,17 @@ void OpenExternal(const GURL& url,
                      std::move(c).Run(error);
                    });
                  });
+}
+
+gfx::NativeView GetViewForWindow(gfx::NativeWindow native_window) {
+  NSWindow* window = native_window.GetNativeNSWindow();
+  DCHECK(window);
+  DCHECK([window contentView]);
+  return gfx::NativeView([window contentView]);
+}
+
+gfx::NativeView GetParent(gfx::NativeView view) {
+  return gfx::NativeView(nil);
 }
 
 bool MoveItemToTrashWithError(const base::FilePath& full_path,


### PR DESCRIPTION
#### Description of Change

I added some methods from https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/platform_util_mac.mm so that Electron builds when building with `is_debug = true` on macOS.

CC @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
