### PR TITLE
fix: only delete render_frame_host_ after OnDialogDone completes

### DIFF
--- a/shell/browser/file_select_helper.cc
+++ b/shell/browser/file_select_helper.cc
@@ -183,6 +183,7 @@ void FileSelectHelper::OnOpenDialogDone(gin_helper::Dictionary result) {
         browser_context->prefs()->SetFilePath(prefs::kSelectFileLastDirectory,
                                               paths[0].DirName());
       }
+      RunFileChooserEnd();
     }
   }
 }
@@ -214,6 +215,7 @@ void FileSelectHelper::OnSaveDialogDone(gin_helper::Dictionary result) {
     }
     // We should only call this if we have not cancelled the dialog.
     OnFilesSelected(std::move(file_info), base::FilePath());
+    RunFileChooserEnd();
   }
 }
 
@@ -224,10 +226,6 @@ void FileSelectHelper::OnFilesSelected(
     listener_->FileSelected(std::move(file_info), base_dir, mode_);
     listener_.reset();
   }
-
-  render_frame_host_ = nullptr;
-
-  delete this;
 }
 
 void FileSelectHelper::RenderWidgetHostDestroyed(


### PR DESCRIPTION
#### Description of Change

Fixes #30858 

There seems to be a race condition with two functions, `OnFilesSelected` and `OnOpenDialogDone`, when opening or attaching a file from the file dialog. On Windows and Linux, the execution goes something like this:

1. Open dialog is triggered, user selects a file and clicks "Ok"
2. `OnFilesSelected` runs. `render_frame_host_` is set to `nullptr` and `this` is deleted
3. `OnOpenDialogDone` runs. `render_frame_host_` still exists when the function begins, and the `nullptr` checks don't trigger. However, the `render_frame_host_` and `this` are then deleted in `OnFilesSelected`. When we then try to access `render_frame_host_->GetProcess()` at the end of the function, the program hard crashes.

It seems as though the` render_frame_host_` deletion in `OnFilesSelected` was being done primarily for a different function, `OnSaveDialogDone`. This PR removes the nullptr reassignment from `OnFilesSelected` and instead calls `RunFileChooserEnd` in both `[-]DialogDone` functions, to make this behavior more predictable and dispose of the `render_frame_host_` and `web_contents_` properly.

NB: This file has been refactored and more thoroughly improved in @codebytere's PR here: https://github.com/electron/electron/pull/30663 This smaller fix will address the immediate crash behavior and is meant to be backported into 15-x-y, so we don't need to backport the refactor PR if needed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes a crash when selecting files in a native file dialog on Windows and Linux.
