### PR TITLE
fix: return HTNOWHERE in resize hit test to allow draggable regions to kick in when required

### DIFF
--- a/shell/browser/ui/views/frameless_view.cc
+++ b/shell/browser/ui/views/frameless_view.cc
@@ -40,10 +40,10 @@ int FramelessView::ResizingBorderHitTest(const gfx::Point& point) {
                              : false;
 
   // https://github.com/electron/electron/issues/611
-  // If window isn't resizable, we should always return HTCLIENT, otherwise the
+  // If window isn't resizable, we should always return HTNOWHERE, otherwise the
   // hover state of DOM will not be cleared probably.
   if (!can_ever_resize)
-    return HTCLIENT;
+    return HTNOWHERE;
 
   // Don't allow overlapping resize handles when the window is maximized or
   // fullscreen, as it can't be resized in those states.


### PR DESCRIPTION
Theoretical fix, not tested at all

Notes: Fixed issue where non-resizable frameless windows aren't draggable