### PR TITLE
fix: PepperFlashFontFileHost not included when disabling pdf viewer

### DIFF
--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -321,17 +321,13 @@ source_set("plugins") {
   sources += [
     "//chrome/renderer/pepper/chrome_renderer_pepper_host_factory.cc",
     "//chrome/renderer/pepper/chrome_renderer_pepper_host_factory.h",
+    "//chrome/renderer/pepper/pepper_flash_font_file_host.cc",
+    "//chrome/renderer/pepper/pepper_flash_font_file_host.h",
     "//chrome/renderer/pepper/pepper_shared_memory_message_filter.cc",
     "//chrome/renderer/pepper/pepper_shared_memory_message_filter.h",
   ]
   if (enable_pdf_viewer) {
-    sources += [
-      "//chrome/renderer/pepper/pepper_flash_font_file_host.cc",
-      "//chrome/renderer/pepper/pepper_flash_font_file_host.h",
-    ]
-    if (enable_pdf_viewer) {
-      deps += [ "//components/pdf/renderer" ]
-    }
+    deps += [ "//components/pdf/renderer" ]
   }
   deps += [
     "//components/strings",


### PR DESCRIPTION
#### Description of Change
If the [`enable_pdf_viewer`](https://github.com/deermichel/electron/blob/06b3b49214d086e8aa747b354509f479036bf261/buildflags/buildflags.gni#L15) build flag is set to false, linking will fail:
```
ld64.lld: error: undefined symbol: PepperFlashFontFileHost::PepperFlashFontFileHost(content::RendererPpapiHost*, int, int, ppapi::proxy::SerializedFontDescription const&, PP_PrivateFontCharset)
>>> referenced by obj/electron/chromium_src/plugins/chrome_renderer_pepper_host_factory.o
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
Traceback (most recent call last):
  File "../../build/toolchain/apple/linker_driver.py", line 305, in <module>
    Main(sys.argv)
  File "../../build/toolchain/apple/linker_driver.py", line 98, in Main
    subprocess.check_call(compiler_driver_args, env=env)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 190, in check_call
    raise CalledProcessError(retcode, cmd)
```

The referenced symbol can be found [here](https://source.chromium.org/chromium/chromium/src/+/main:chrome/renderer/pepper/chrome_renderer_pepper_host_factory.cc;l=63;drc=242fc9ace06b09e2f2fcf80cbd7f2406669e33f4). It was incorrectly excluded when `enable_pdf_viewer` is false, though the relevant code is not only conditioned on PDF permission (see comment by @deepak1556).

cc @zarubond @deepak1556 


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: none