### PR TITLE
chore: add typings for `process.resourcesPath` and `app.getAppPath()`

### DIFF
--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -258,6 +258,7 @@ declare namespace NodeJS {
     _firstFileName?: string;
 
     helperExecPath: string;
+    readonly resourcesPath: string;
     mainModule: NodeJS.Module;
   }
 }

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -16,6 +16,7 @@ declare namespace Electron {
     setVersion(version: string): void;
     setDesktopName(name: string): void;
     setAppPath(path: string | null): void;
+    getAppPath(): string;
   }
 
   type TouchBarItemType = NonNullable<Electron.TouchBarConstructorOptions['items']>[0];


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

We didn't have typings for `process.resourcePath` and `app.getAppPath()`, so I thought of adding them in.

cc @miniak

Signed-off-by: Darshan Sen <darshan.sen@postman.com>

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes a couple of potential `Property does not exist on type` TypeScript compilation errors <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
