### PR TITLE
feat: add commandLine.removeSwitch

### DIFF
--- a/docs/api/command-line.md
+++ b/docs/api/command-line.md
@@ -53,3 +53,12 @@ Returns `Boolean` - Whether the command-line switch is present.
 Returns `String` - The command-line switch value.
 
 **Note:** When the switch is not present or has no value, it returns empty string.
+
+#### `commandLine.removeSwitch(switch)`
+
+* `switch` String - A command-line switch
+
+Removes the specified switch from Chromium's command line.
+
+**Note:** This will not affect `process.argv`. The intended usage of this function is to
+control Chromium's behavior.

--- a/shell/common/api/electron_api_command_line.cc
+++ b/shell/common/api/electron_api_command_line.cc
@@ -42,6 +42,11 @@ void AppendSwitch(const std::string& switch_string,
     command_line->AppendSwitch(switch_string);
 }
 
+void RemoveSwitch(const std::string& switch_string) {
+  auto* command_line = base::CommandLine::ForCurrentProcess();
+  command_line->RemoveSwitch(switch_string);
+}
+
 void AppendArg(const std::string& arg) {
   auto* command_line = base::CommandLine::ForCurrentProcess();
 
@@ -56,6 +61,7 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("hasSwitch", &HasSwitch);
   dict.SetMethod("getSwitchValue", &GetSwitchValue);
   dict.SetMethod("appendSwitch", &AppendSwitch);
+  dict.SetMethod("removeSwitch", &RemoveSwitch);
   dict.SetMethod("appendArgument", &AppendArg);
 }
 

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -1624,6 +1624,21 @@ describe('app module', () => {
     });
   });
 
+  describe('commandLine.removeSwitch', () => {
+    it('no-ops a non-existent switch', async () => {
+      expect(app.commandLine.hasSwitch('foobar3')).to.equal(false);
+      app.commandLine.removeSwitch('foobar3');
+      expect(app.commandLine.hasSwitch('foobar3')).to.equal(false);
+    });
+
+    it('removes an existing switch', async () => {
+      app.commandLine.appendSwitch('foobar3', 'test');
+      expect(app.commandLine.hasSwitch('foobar3')).to.equal(true);
+      app.commandLine.removeSwitch('foobar3');
+      expect(app.commandLine.hasSwitch('foobar3')).to.equal(false);
+    });
+  });
+
   ifdescribe(process.platform === 'darwin')('app.setSecureKeyboardEntryEnabled', () => {
     it('changes Secure Keyboard Entry is enabled', () => {
       app.setSecureKeyboardEntryEnabled(true);


### PR DESCRIPTION
In some cases apps may want to remove Chromium command line switches to avoid certain Chromium behaviors being used, E.g. remote-debugging-port or gpu-launcher

Notes: Added `commandLine.removeSwitch` to allow apps to remove command line switches from Chromiums internal command line representation