### PR TITLE
fix: remove conflicting RunFileChooserEnd for Mac

### DIFF
--- a/shell/browser/file_select_helper.cc
+++ b/shell/browser/file_select_helper.cc
@@ -183,7 +183,9 @@ void FileSelectHelper::OnOpenDialogDone(gin_helper::Dictionary result) {
         browser_context->prefs()->SetFilePath(prefs::kSelectFileLastDirectory,
                                               paths[0].DirName());
       }
+#if !defined(OS_MAC)
       RunFileChooserEnd();
+#endif
     }
   }
 }


### PR DESCRIPTION
#### Description of Change

Follow up to #30916, which fixed the file picker crash for Windows and Linux, but regressed and caused the crash to start occurring on Mac.

`RunFileChooserEnd` does not need to run on Mac after selecting files and opening the dialog, because 1) on Mac only, we bind the `ProcessSelectedFilesMac` function to run and block the thread, and 2) `RunFileChooserEnd` is already run in `ProcessSelectedFilesMac` within `file_select_helper_mac.mm` at the appropriate time.

This PR gates the function to only run on non-Mac OSes.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Notes: Fixed a crash when selecting and opening files in a native file dialog on Mac.
