### PR TITLE
fix: add casing for WCO edge

### DIFF
--- a/shell/browser/ui/views/win_frame_view.cc
+++ b/shell/browser/ui/views/win_frame_view.cc
@@ -235,9 +235,10 @@ void WinFrameView::LayoutCaptionButtons() {
   // portion to return the correct hit test and be manually resized properly.
   // Alternatives can be explored, but the differences in view structures
   // between Electron and Chromium may result in this as the best option.
+  int variable_width =
+      IsMaximized() ? preferred_size.width() : preferred_size.width() - 1;
   caption_button_container_->SetBounds(width() - preferred_size.width(),
-                                       WindowTopY(), preferred_size.width() - 1,
-                                       height);
+                                       WindowTopY(), variable_width, height);
 }
 
 void WinFrameView::LayoutWindowControlsOverlay() {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Closes #30828

Previously, an extra 1 pixel edge existed between the border of the screen and the WCO when maximized. Though this pixel is needed for manual resizing, as explained in the code, it is not needed in the maximized state.

This PR adds a check that only adds the pixel edge when the window is not maximized.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> None
