### PR TITLE
chore: cherry-pick 13842c96c2 from chromium and 018f85dea1 from angle

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -2,3 +2,4 @@ d3d11_skip_blits_if_there_is_no_intersection_of_dest_areas.patch
 cherry-pick-3d4f87ab5b9b.patch
 cherry-pick-d8cb996.patch
 cherry-pick-1fb846c.patch
+webgl_make_unsuccessful_links_fail_subsequent_draw_calls.patch

--- a/patches/angle/webgl_make_unsuccessful_links_fail_subsequent_draw_calls.patch
+++ b/patches/angle/webgl_make_unsuccessful_links_fail_subsequent_draw_calls.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jamie Madill <jmadill@chromium.org>
+Date: Fri, 3 Sep 2021 09:34:10 -0400
+Subject: WebGL: Make unsuccessful links fail subsequent draw calls.
+
+This protects against incomplete state updates during a failed
+link call that can interfere with draw calls.
+
+Bug: angleproject:6358
+Bug: chromium:1241123
+Change-Id: Ie892654c3a58c69d6e35ba3c41758ab6269d8193
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3140496
+Reviewed-by: Geoff Lang <geofflang@chromium.org>
+Commit-Queue: Yuly Novikov <ynovikov@chromium.org>
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3152556
+Reviewed-by: Jamie Madill <jmadill@chromium.org>
+
+diff --git a/src/libANGLE/validationES.cpp b/src/libANGLE/validationES.cpp
+index 4ed0ea4f47c89090d06f706199d32bb0f5b745b9..40574e58d20363710a1312ddaa39ba2eb685b6b8 100644
+--- a/src/libANGLE/validationES.cpp
++++ b/src/libANGLE/validationES.cpp
+@@ -3881,6 +3881,12 @@ const char *ValidateDrawStates(const Context *context)
+             {
+                 return kVertexBufferBoundForTransformFeedback;
+             }
++
++            // Validate that we are rendering with a linked program.
++            if (!program->isLinked())
++            {
++                return kProgramNotLinked;
++            }
+         }
+     }
+ 

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -151,3 +151,4 @@ cherry-pick-d727013bb543.patch
 cherry-pick-1231134.patch
 merge_m92_speculative_fix_for_crash_in.patch
 content-visibility_force_range_base_extent_when_computing_visual.patch
+skip_webgl_conformance_programs_program-test_html_on_all_platforms.patch

--- a/patches/chromium/skip_webgl_conformance_programs_program-test_html_on_all_platforms.patch
+++ b/patches/chromium/skip_webgl_conformance_programs_program-test_html_on_all_platforms.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yuly Novikov <ynovikov@chromium.org>
+Date: Thu, 9 Sep 2021 20:00:43 +0000
+Subject: Skip WebGL conformance/programs/program-test.html on all platforms
+
+To unblock ANGLE CL http://crrev.com/c/3140496, which modifies behaviour
+to make it an error to draw after the current program fails to re-link.
+
+(cherry picked from commit 8ef1e4544ed5214608039d969940347d8f98e543)
+
+Bug: 1241123
+Bug: angleproject:6358
+Change-Id: I40a1f4843f902533745cc9527379def9d777a578
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3140226
+Auto-Submit: Yuly Novikov <ynovikov@chromium.org>
+Commit-Queue: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+Cr-Original-Commit-Position: refs/heads/main@{#918281}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3150594
+Auto-Submit: Jamie Madill <jmadill@chromium.org>
+Commit-Queue: Yuly Novikov <ynovikov@chromium.org>
+Reviewed-by: Yuly Novikov <ynovikov@chromium.org>
+Cr-Commit-Position: refs/branch-heads/4515@{#2117}
+Cr-Branched-From: 488fc70865ddaa05324ac00a54a6eb783b4bc41c-refs/heads/master@{#885287}
+
+diff --git a/content/test/gpu/gpu_tests/test_expectations/webgl2_conformance_expectations.txt b/content/test/gpu/gpu_tests/test_expectations/webgl2_conformance_expectations.txt
+index 6b91c94495f2aea1b1cc6fa1c5962cea0b94b2a6..4e97412e4873b0ed5b7de6a417dd5e5f1e86f8d3 100644
+--- a/content/test/gpu/gpu_tests/test_expectations/webgl2_conformance_expectations.txt
++++ b/content/test/gpu/gpu_tests/test_expectations/webgl2_conformance_expectations.txt
+@@ -187,6 +187,10 @@ crbug.com/1085222 [ linux intel-0x5912 ] deqp/functional/gles3/shadermatrix/add_
+ crbug.com/1085222 [ catalina intel-0xa2e ] deqp/functional/gles3/shaderoperator/binary_operator_* [ RetryOnFailure ]
+ crbug.com/1085222 [ catalina intel-0xa2e ] deqp/functional/gles3/shaderoperator/unary_operator_* [ RetryOnFailure ]
+ 
++# Temporary suppression while we wait for a spec update.
++# TODO(jmadill): Remove when possible.
++crbug.com/angleproject/6358 conformance/programs/program-test.html [ Failure ]
++
+ ####################
+ # Win failures     #
+ ####################
+diff --git a/content/test/gpu/gpu_tests/test_expectations/webgl_conformance_expectations.txt b/content/test/gpu/gpu_tests/test_expectations/webgl_conformance_expectations.txt
+index 9e2aee0cebecbe83bc6df45fd6e006d95513b2f9..b8ff50068fc419630cab86fb4eb925b0f5e3a05b 100644
+--- a/content/test/gpu/gpu_tests/test_expectations/webgl_conformance_expectations.txt
++++ b/content/test/gpu/gpu_tests/test_expectations/webgl_conformance_expectations.txt
+@@ -238,6 +238,10 @@ crbug.com/1163292 [ win nvidia angle-d3d9 ] conformance/textures/misc/texture-co
+ crbug.com/1105129 [ linux ] conformance/context/context-creation.html [ RetryOnFailure ]
+ crbug.com/1105129 [ win ] conformance/context/context-creation.html [ RetryOnFailure ]
+ 
++# Temporary suppression while we wait for a spec update.
++# TODO(jmadill): Remove when possible.
++crbug.com/angleproject/6358 conformance/programs/program-test.html [ Failure ]
++
+ # Win / AMD / Passthrough command decoder / D3D11
+ crbug.com/772037 [ win amd angle-d3d11 passthrough ] conformance/textures/misc/texture-sub-image-cube-maps.html [ RetryOnFailure ]
+ 


### PR DESCRIPTION
Skip WebGL conformance/programs/program-test.html on all platforms

To unblock ANGLE CL http://crrev.com/c/3140496, which modifies behaviour
to make it an error to draw after the current program fails to re-link.

(cherry picked from commit 8ef1e4544ed5214608039d969940347d8f98e543)

Bug: 1241123
Bug: angleproject:6358
Change-Id: I40a1f4843f902533745cc9527379def9d777a578
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3140226
Auto-Submit: Yuly Novikov <ynovikov@chromium.org>
Commit-Queue: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
Cr-Original-Commit-Position: refs/heads/main@{#918281}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3150594
Auto-Submit: Jamie Madill <jmadill@chromium.org>
Commit-Queue: Yuly Novikov <ynovikov@chromium.org>
Reviewed-by: Yuly Novikov <ynovikov@chromium.org>
Cr-Commit-Position: refs/branch-heads/4515@{#2117}
Cr-Branched-From: 488fc70865ddaa05324ac00a54a6eb783b4bc41c-refs/heads/master@{#885287}

===========================================

WebGL: Make unsuccessful links fail subsequent draw calls.

This protects against incomplete state updates during a failed
link call that can interfere with draw calls.

Bug: angleproject:6358
Bug: chromium:1241123
Change-Id: Ie892654c3a58c69d6e35ba3c41758ab6269d8193
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3140496
Reviewed-by: Geoff Lang <geofflang@chromium.org>
Commit-Queue: Yuly Novikov <ynovikov@chromium.org>
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3152556
Reviewed-by: Jamie Madill <jmadill@chromium.org>

#### Release Notes

Notes: Security: backported fix for CVE-2021-30628.
