### PR TITLE
chore: update links of documentation of chromes in comments

### DIFF
--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -288,7 +288,7 @@ declare namespace ElectronInternal {
 
 declare namespace Chrome {
   namespace Tabs {
-    // https://developer.chrome.com/extensions/tabs#method-executeScript
+    // https://developer.chrome.com/docs/extensions/tabs#method-executeScript
     interface ExecuteScriptDetails {
       code?: string;
       file?: string;
@@ -301,7 +301,7 @@ declare namespace Chrome {
 
     type ExecuteScriptCallback = (result: Array<any>) => void;
 
-    // https://developer.chrome.com/extensions/tabs#method-sendMessage
+    // https://developer.chrome.com/docs/extensions/tabs#method-sendMessage
     interface SendMessageDetails {
       frameId?: number;
     }


### PR DESCRIPTION
#### Description of Change
Chrome now use developer.chrome.com/docs/extensions/* instead of developer.chrome.com/extensions/* to host their documentation of chrome extensions.
The old links may deprecate in the future.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none