### PR TITLE
fix: removed the unsafe-eval warning

### DIFF
--- a/lib/renderer/security-warnings.ts
+++ b/lib/renderer/security-warnings.ts
@@ -1,4 +1,3 @@
-import { webFrame } from 'electron';
 import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
@@ -70,22 +69,6 @@ const isLocalhost = function () {
   }
 
   return window.location.hostname === 'localhost';
-};
-
-/**
- * Tries to determine whether a CSP without `unsafe-eval` is set.
- *
- * @returns {boolean} Is a CSP with `unsafe-eval` set?
- */
-const isUnsafeEvalEnabled: () => Promise<boolean> = function () {
-  return webFrame.executeJavaScript(`(${(() => {
-    try {
-      eval(window.trustedTypes.emptyScript); // eslint-disable-line no-eval
-    } catch {
-      return false;
-    }
-    return true;
-  }).toString()})()`, false);
 };
 
 const moreInformation = `\nFor more information and help, consult
@@ -161,25 +144,6 @@ const warnAboutDisabledWebSecurity = function (webPreferences?: Electron.WebPref
 
   console.warn('%cElectron Security Warning (Disabled webSecurity)',
     'font-weight: bold;', warning);
-};
-
-/**
- * #6 on the checklist: Define a Content-Security-Policy and use restrictive
- * rules (i.e. script-src 'self')
- *
- * Logs a warning message about unset or insecure CSP
- */
-const warnAboutInsecureCSP = function () {
-  isUnsafeEvalEnabled().then((enabled) => {
-    if (!enabled) return;
-
-    const warning = `This renderer process has either no Content Security
-    Policy set or a policy with "unsafe-eval" enabled. This exposes users of
-    this app to unnecessary security risks.\n${moreInformation}`;
-
-    console.warn('%cElectron Security Warning (Insecure Content-Security-Policy)',
-      'font-weight: bold;', warning);
-  }).catch(() => {});
 };
 
 /**
@@ -274,7 +238,6 @@ const logSecurityWarnings = function (
   warnAboutInsecureContentAllowed(webPreferences);
   warnAboutExperimentalFeatures(webPreferences);
   warnAboutEnableBlinkFeatures(webPreferences);
-  warnAboutInsecureCSP();
   warnAboutAllowedPopups();
 };
 

--- a/spec-main/security-warnings-spec.ts
+++ b/spec-main/security-warnings-spec.ts
@@ -21,8 +21,6 @@ const isLoaded = (event: Event, level: number, message: string) => {
 describe('security warnings', () => {
   let server: http.Server;
   let w: BrowserWindow;
-  let useCsp = true;
-  let useTrustedTypes = false;
   let serverUrl: string;
 
   before((done) => {
@@ -49,11 +47,6 @@ describe('security warnings', () => {
             return;
           }
 
-          const cspHeaders = [
-            ...(useCsp ? ['script-src \'self\' \'unsafe-inline\''] : []),
-            ...(useTrustedTypes ? ['require-trusted-types-for \'script\'; trusted-types *'] : [])
-          ];
-          response.writeHead(200, { 'Content-Security-Policy': cspHeaders });
           response.write(file, 'binary');
           response.end();
         });
@@ -71,8 +64,6 @@ describe('security warnings', () => {
   });
 
   afterEach(async () => {
-    useCsp = true;
-    useTrustedTypes = false;
     await closeWindow(w);
     w = null as unknown as any;
   });
@@ -118,31 +109,6 @@ describe('security warnings', () => {
         w.loadURL(`${serverUrl}/base-page-security.html`);
         const [,, message] = await emittedUntil(w.webContents, 'console-message', messageContainsSecurityWarning);
         expect(message).to.include('Disabled webSecurity');
-      });
-
-      it('should warn about insecure Content-Security-Policy', async () => {
-        w = new BrowserWindow({
-          show: false,
-          webPreferences
-        });
-
-        useCsp = false;
-        w.loadURL(`${serverUrl}/base-page-security.html`);
-        const [,, message] = await emittedUntil(w.webContents, 'console-message', messageContainsSecurityWarning);
-        expect(message).to.include('Insecure Content-Security-Policy');
-      });
-
-      it('should warn about insecure Content-Security-Policy (Trusted Types)', async () => {
-        w = new BrowserWindow({
-          show: false,
-          webPreferences
-        });
-
-        useCsp = false;
-        useTrustedTypes = true;
-        w.loadURL(`${serverUrl}/base-page-security.html`);
-        const [,, message] = await emittedUntil(w.webContents, 'console-message', messageContainsSecurityWarning);
-        expect(message).to.include('Insecure Content-Security-Policy');
       });
 
       it('should warn about allowRunningInsecureContent', async () => {


### PR DESCRIPTION
#### Description of Change
Electron warns about not having a CSP set or having unsafe-eval enabled, but if you do set a CSP to disable unsafe-eval you then get an error about eval being used because Electron calls eval() to make the check in the first place. This error shows up even on the [quick start](https://www.electronjs.org/docs/latest/tutorial/quick-start) project. Having this error always show up in the console makes people think there is a problem with their code when there is none. As for the warning that is thrown for not disabling unsafe-eval, there are times where you want to or have to use unsafe-eval such as with WebAssembly. Although it isn't best practice in most cases, it is necessary for some projects and so always putting out a warning is an annoyance in those cases. Given that the warning does not apply to everyone and that it produces an error since it calls eval() in doing its check, I think overall it does more harm than good and should be removed. It is better to guide inexperienced programmers in the documentation (as is already done in the [security checklist](https://www.electronjs.org/docs/latest/tutorial/security) page) rather than throwing these warnings and errors for everyone. This addresses #26973.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Removed the check for unset or unsafe-eval CSP.
