### PR TITLE
docs: add link to @electron/fuses

### DIFF
--- a/docs/tutorial/fuses.md
+++ b/docs/tutorial/fuses.md
@@ -12,7 +12,7 @@ Fuses are the solution to this problem, at a high level they are "magic bits" in
 
 ### The easy way
 
-We've made a handy module `@electron/fuses` to make flipping these fuses easy.  Check out the README of that module for more details on usage and potential error cases.
+We've made a handy module, [`@electron/fuses`](https://npmjs.com/package/@electron/fuses), to make flipping these fuses easy.  Check out the README of that module for more details on usage and potential error cases.
 
 ```js
 require('@electron/fuses').flipFuses(


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

Adds a link to the fuses documentation where we suggest people read the README without actually linking it. I assume @MarshallOfSound would be a good person to ping for this since I see his name as the last committer for fuses :)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added

#### Release Notes

Notes: none<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
