### PR TITLE
fix: change default background_color from absl::nullopt to transparent

### DIFF
--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -159,7 +159,7 @@ void WebContentsPreferences::Clear() {
   safe_dialogs_ = false;
   safe_dialogs_message_ = absl::nullopt;
   ignore_menu_shortcuts_ = false;
-  background_color_ = absl::nullopt;
+  background_color_ = SK_ColorTRANSPARENT;
   image_animation_policy_ =
       blink::mojom::ImageAnimationPolicy::kImageAnimationPolicyAllowed;
   preload_path_ = absl::nullopt;


### PR DESCRIPTION
#### Description of Change
Fixes #30975

In a [recent PR that fixed background color loading](https://github.com/electron/electron/pull/30777), we reset the default background color to `absl::nullopt`. However, passing `absl::nullopt` into SetPageBaseBackgroundColor results in the color `SK_ColorWHITE` being used, which then breaks loading transparency in child windows and views. This PR resets the default to transparent, which fixes transparency for child windows.

I tested the gist in the new issue, as well as the original two gists from the background color PR, to make sure we didn't regress. Both still appear to work as expected.

Child view background color using https://gist.github.com/c-liang/e04698f37dce36c11ff0ecfa9e64b683 from #30975 (Windows)
![Screenshot (33)](https://user-images.githubusercontent.com/4624411/133486206-7a726f8e-e804-450a-9f10-9f7b10b61ba2.png)

Transparent window using https://gist.github.com/b52f026c763057f97f745fade82758fd from #30136
<img width="838" alt="Screen Shot 2021-09-15 at 10 45 49 AM" src="https://user-images.githubusercontent.com/4624411/133484566-883b10d8-d761-4f39-8968-ceb823dbd555.png">

Background color using https://gist.github.com/4256f388d41ef0d974645a11ab72b1fe from #30759
<img width="825" alt="Screen Shot 2021-09-15 at 10 46 41 AM" src="https://user-images.githubusercontent.com/4624411/133484294-6400eb70-43d6-40d2-b7ea-207847994524.png">

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed child views or windows not inheriting the correct background transparency or background color.
