### PR TITLE
fix: maximized state calculation for non-resizable windows

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -987,7 +987,7 @@ the player itself we would call this function with arguments of 16/9 and
 are within the content view--only that they exist. Sum any extra width and
 height areas you have within the overall content view.
 
-The aspect ratio is not respected when window is resized programmingly with
+The aspect ratio is not respected when window is resized programmatically with
 APIs like `win.setSize`.
 
 #### `win.setBackgroundColor(backgroundColor)`

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -188,6 +188,19 @@ class NativeWindowMac : public NativeWindow,
   bool zoom_to_page_width() const { return zoom_to_page_width_; }
   bool always_simple_fullscreen() const { return always_simple_fullscreen_; }
 
+  // We need to save the result of windowWillUseStandardFrame:defaultFrame
+  // because macOS calls it with what it refers to as the "best fit" frame for a
+  // zoom. This means that even if an aspect ratio is set, macOS might adjust it
+  // to better fit the screen.
+  //
+  // Thus, we can't just calculate the maximized aspect ratio'd sizing from
+  // the current visible screen and compare that to the current window's frame
+  // to determine whether a window is maximized.
+  NSRect default_frame_for_zoom() const { return default_frame_for_zoom_; }
+  void set_default_frame_for_zoom(NSRect frame) {
+    default_frame_for_zoom_ = frame;
+  }
+
  protected:
   // views::WidgetDelegate:
   views::View* GetContentsView() override;
@@ -262,6 +275,7 @@ class NativeWindowMac : public NativeWindow,
   NSRect original_frame_;
   NSInteger original_level_;
   NSUInteger simple_fullscreen_mask_;
+  NSRect default_frame_for_zoom_;
 
   std::string vibrancy_type_;
 

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -612,17 +612,11 @@ bool NativeWindowMac::IsMaximized() {
   if (([window_ styleMask] & NSWindowStyleMaskResizable) != 0)
     return [window_ isZoomed];
 
-  NSRect rectScreen = [[NSScreen mainScreen] visibleFrame];
-  NSRect rectWindow = [window_ frame];
+  NSRect rectScreen = GetAspectRatio() > 0.0
+                          ? default_frame_for_zoom()
+                          : [[NSScreen mainScreen] visibleFrame];
 
-  // If there's an aspect ratio set, update the maximum bounds of the screen.
-  if (GetAspectRatio() > 0.0)
-    rectScreen = default_frame_for_zoom();
-
-  return (rectScreen.origin.x == rectWindow.origin.x &&
-          rectScreen.origin.y == rectWindow.origin.y &&
-          rectScreen.size.width == rectWindow.size.width &&
-          rectScreen.size.height == rectWindow.size.height);
+  return NSEqualRects([window_ frame], rectScreen);
 }
 
 void NativeWindowMac::Minimize() {

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -609,16 +609,20 @@ void NativeWindowMac::Unmaximize() {
 }
 
 bool NativeWindowMac::IsMaximized() {
-  if (([window_ styleMask] & NSWindowStyleMaskResizable) != 0) {
+  if (([window_ styleMask] & NSWindowStyleMaskResizable) != 0)
     return [window_ isZoomed];
-  } else {
-    NSRect rectScreen = [[NSScreen mainScreen] visibleFrame];
-    NSRect rectWindow = [window_ frame];
-    return (rectScreen.origin.x == rectWindow.origin.x &&
-            rectScreen.origin.y == rectWindow.origin.y &&
-            rectScreen.size.width == rectWindow.size.width &&
-            rectScreen.size.height == rectWindow.size.height);
-  }
+
+  NSRect rectScreen = [[NSScreen mainScreen] visibleFrame];
+  NSRect rectWindow = [window_ frame];
+
+  // If there's an aspect ratio set, update the maximum bounds of the screen.
+  if (GetAspectRatio() > 0.0)
+    rectScreen = default_frame_for_zoom();
+
+  return (rectScreen.origin.x == rectWindow.origin.x &&
+          rectScreen.origin.y == rectWindow.origin.y &&
+          rectScreen.size.width == rectWindow.size.width &&
+          rectScreen.size.height == rectWindow.size.height);
 }
 
 void NativeWindowMac::Minimize() {

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.mm
@@ -63,8 +63,11 @@ using FullScreenTransitionState =
 // menu to determine the "standard size" of the window.
 - (NSRect)windowWillUseStandardFrame:(NSWindow*)window
                         defaultFrame:(NSRect)frame {
-  if (!shell_->zoom_to_page_width())
+  if (!shell_->zoom_to_page_width()) {
+    if (shell_->GetAspectRatio() > 0.0)
+      shell_->set_default_frame_for_zoom(frame);
     return frame;
+  }
 
   // If the shift key is down, maximize.
   if ([[NSApp currentEvent] modifierFlags] & NSShiftKeyMask)
@@ -88,6 +91,9 @@ using FullScreenTransitionState =
 
   // Set the width. Don't touch y or height.
   frame.size.width = zoomed_width;
+
+  if (shell_->GetAspectRatio() > 0.0)
+    shell_->set_default_frame_for_zoom(frame);
 
   return frame;
 }

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1113,6 +1113,24 @@ describe('BrowserWindow module', () => {
           await unmaximize;
           expect(w.isMaximized()).to.equal(false);
         });
+        it('returns the correct value for windows with an aspect ratio', async () => {
+          w.destroy();
+          w = new BrowserWindow({
+            show: false,
+            fullscreenable: false
+          });
+
+          w.setAspectRatio(16 / 11);
+
+          const maximize = emittedOnce(w, 'resize');
+          w.show();
+          w.maximize();
+          await maximize;
+
+          expect(w.isMaximized()).to.equal(true);
+          w.resizable = false;
+          expect(w.isMaximized()).to.equal(true);
+        });
       });
 
       ifdescribe(process.platform !== 'linux')('Minimized state', () => {


### PR DESCRIPTION
#### Description of Change

Partially addresses https://github.com/electron/electron/issues/30979.

Fixes an issue where non-resizable non-fullscreenable windows with aspect ratios set could return incorrect results for `isMaximized()`. macOS calls `windowWillUseStandardFrame:defaultFrame` with what it refers to as the "best fit" frame for a
given zoom (see [Discussion Section](https://developer.apple.com/documentation/appkit/nswindowdelegate/1419684-windowwillusestandardframe?language=objc)). This means that even if an aspect ratio is set, macOS might adjust it to better fit the screen. Thus, we can't just calculate the maximized aspect ratio'd sizing from the current visible screen and compare that to the current window's frame to determine whether a window is maximized in `isMaximized`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue where non-resizable non-fullscreenable windows with aspect ratios set could return incorrect results for `isMaximized()`.
