### PR TITLE
fix: links to images

### DIFF
--- a/docs/tutorial/performance.md
+++ b/docs/tutorial/performance.md
@@ -120,9 +120,9 @@ file in the directory you executed it in. Both files can be analyzed using
 the Chrome Developer Tools, using the `Performance` and `Memory` tabs
 respectively.
 
-![Performance CPU Profile][performance-cpu-prof]
+![Performance CPU Profile](../images/performance-cpu-prof.png)
 
-![Performance Heap Memory Profile][performance-heap-prof]
+![Performance Heap Memory Profile](../images/performance-heap-prof.png)
 
 In this example, on the author's machine, we saw that loading `request` took
 almost half a second, whereas `node-fetch` took dramatically less memory
@@ -412,8 +412,6 @@ As of writing this article, the popular choices include [Webpack][webpack],
 [Parcel][parcel], and [rollup.js][rollup].
 
 [security]: ./security.md
-[performance-cpu-prof]: ../images/performance-cpu-prof.png
-[performance-heap-prof]: ../images/performance-heap-prof.png
 [chrome-devtools-tutorial]: https://developers.google.com/web/tools/chrome-devtools/evaluate-performance/
 [worker-threads]: https://nodejs.org/api/worker_threads.html
 [web-workers]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers

--- a/docs/tutorial/progress-bar.md
+++ b/docs/tutorial/progress-bar.md
@@ -7,16 +7,16 @@ without the need of switching to the window itself.
 
 On Windows, you can use a taskbar button to display a progress bar.
 
-![Windows Progress Bar][windows-progress-bar]
+![Windows Progress Bar][https://cloud.githubusercontent.com/assets/639601/5081682/16691fda-6f0e-11e4-9676-49b6418f1264.png]
 
 On macOS, the progress bar will be displayed as a part of the dock icon.
 
-![macOS Progress Bar][macos-progress-bar]
+![macOS Progress Bar](../images/macos-progress-bar.png)
 
 On Linux, the Unity graphical interface also has a similar feature that allows
 you to specify the progress bar in the launcher.
 
-![Linux Progress Bar][linux-progress-bar]
+![Linux Progress Bar](../images/linux-progress-bar.png)
 
 > NOTE: on Windows, each window can have its own progress bar, whereas on macOS
 and Linux (Unity) there can be only one progress bar for the application.
@@ -102,8 +102,4 @@ For macOS, the progress bar will also be indicated for your application
 when using [Mission Control](https://support.apple.com/en-us/HT204100):
 
 ![Mission Control Progress Bar](../images/mission-control-progress-bar.png)
-
-[windows-progress-bar]: https://cloud.githubusercontent.com/assets/639601/5081682/16691fda-6f0e-11e4-9676-49b6418f1264.png
-[macos-progress-bar]: ../images/macos-progress-bar.png
-[linux-progress-bar]: ../images/linux-progress-bar.png
 [setprogressbar]: ../api/browser-window.md#winsetprogressbarprogress-options


### PR DESCRIPTION
#### Description of Change

Images that used the inline link format do not show up on Docusaurus or
the old website infrastructure. There are only 2 guides using it so it
is faster to change the format rather than figuring out why the parsin
logic does not work.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Ref: https://github.com/electron/electronjs.org-new/issues/84

Fixes #30996

CC @erickzhao  @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added

#### Release Notes

Notes: none