### PR TITLE
fix: do not trigger CSP violations when checking eval

### DIFF
--- a/lib/renderer/security-warnings.ts
+++ b/lib/renderer/security-warnings.ts
@@ -77,15 +77,8 @@ const isLocalhost = function () {
  *
  * @returns {boolean} Is a CSP with `unsafe-eval` set?
  */
-const isUnsafeEvalEnabled: () => Promise<boolean> = function () {
-  return webFrame.executeJavaScript(`(${(() => {
-    try {
-      eval(window.trustedTypes.emptyScript); // eslint-disable-line no-eval
-    } catch {
-      return false;
-    }
-    return true;
-  }).toString()})()`, false);
+const isUnsafeEvalEnabled = () => {
+  return webFrame._isEvalAllowed();
 };
 
 const moreInformation = `\nFor more information and help, consult
@@ -170,16 +163,14 @@ const warnAboutDisabledWebSecurity = function (webPreferences?: Electron.WebPref
  * Logs a warning message about unset or insecure CSP
  */
 const warnAboutInsecureCSP = function () {
-  isUnsafeEvalEnabled().then((enabled) => {
-    if (!enabled) return;
+  if (!isUnsafeEvalEnabled()) return;
 
-    const warning = `This renderer process has either no Content Security
-    Policy set or a policy with "unsafe-eval" enabled. This exposes users of
-    this app to unnecessary security risks.\n${moreInformation}`;
+  const warning = `This renderer process has either no Content Security
+  Policy set or a policy with "unsafe-eval" enabled. This exposes users of
+  this app to unnecessary security risks.\n${moreInformation}`;
 
-    console.warn('%cElectron Security Warning (Insecure Content-Security-Policy)',
-      'font-weight: bold;', warning);
-  }).catch(() => {});
+  console.warn('%cElectron Security Warning (Insecure Content-Security-Policy)',
+    'font-weight: bold;', warning);
 };
 
 /**

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -49,6 +49,8 @@
 #include "third_party/blink/public/web/web_script_execution_callback.h"
 #include "third_party/blink/public/web/web_script_source.h"
 #include "third_party/blink/public/web/web_view.h"
+#include "third_party/blink/renderer/core/execution_context/execution_context.h"
+#include "third_party/blink/renderer/core/frame/csp/content_security_policy.h"
 #include "ui/base/ime/ime_text_span.h"
 #include "url/url_util.h"
 
@@ -368,6 +370,7 @@ class WebFrameRenderer : public gin::Wrappable<WebFrameRenderer>,
         .SetMethod("insertText", &WebFrameRenderer::InsertText)
         .SetMethod("insertCSS", &WebFrameRenderer::InsertCSS)
         .SetMethod("removeInsertedCSS", &WebFrameRenderer::RemoveInsertedCSS)
+        .SetMethod("_isEvalAllowed", &WebFrameRenderer::IsEvalAllowed)
         .SetMethod("executeJavaScript", &WebFrameRenderer::ExecuteJavaScript)
         .SetMethod("executeJavaScriptInIsolatedWorld",
                    &WebFrameRenderer::ExecuteJavaScriptInIsolatedWorld)
@@ -634,6 +637,16 @@ class WebFrameRenderer : public gin::Wrappable<WebFrameRenderer>,
       web_frame->ToWebLocalFrame()->GetDocument().RemoveInsertedStyleSheet(
           blink::WebString::FromUTF16(key));
     }
+  }
+
+  bool IsEvalAllowed(v8::Isolate* isolate) {
+    content::RenderFrame* render_frame;
+    if (!MaybeGetRenderFrame(isolate, "isEvalAllowed", &render_frame))
+      return true;
+
+    auto* context = blink::ExecutionContext::From(
+        render_frame->GetWebFrame()->MainWorldScriptContext());
+    return !context->GetContentSecurityPolicy()->ShouldCheckEval();
   }
 
   v8::Local<v8::Promise> ExecuteJavaScript(gin::Arguments* gin_args,

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -88,6 +88,10 @@ declare namespace Electron {
     _postMessage(channel: string, message: any, transfer?: any[]): void;
   }
 
+  interface WebFrame {
+    _isEvalAllowed(): boolean;
+  }
+
   interface WebPreferences {
     openerId?: number | null;
     disablePopups?: boolean;


### PR DESCRIPTION
Notes: Having a secure CSP will no longer cause a CSP violation warning to appear in console