### PR TITLE
fix: disabling and enabling resizability on macOS

### DIFF
--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -191,6 +191,7 @@ class NativeWindowMac : public NativeWindow,
  protected:
   // views::WidgetDelegate:
   views::View* GetContentsView() override;
+  bool CanMaximize() const override;
 
   // ui::NativeThemeObserver:
   void OnNativeThemeUpdated(ui::NativeTheme* observed_theme) override;

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1715,29 +1715,33 @@ void NativeWindowMac::SetStyleMask(bool on, NSUInteger flag) {
   // we explicitly disable resizing while setting it.
   ScopedDisableResize disable_resize;
 
-  bool was_maximizable = IsMaximizable();
   if (on)
     [window_ setStyleMask:[window_ styleMask] | flag];
   else
     [window_ setStyleMask:[window_ styleMask] & (~flag)];
+
   // Change style mask will make the zoom button revert to default, probably
   // a bug of Cocoa or macOS.
-  SetMaximizable(was_maximizable);
+  SetMaximizable(maximizable_);
 }
 
 void NativeWindowMac::SetCollectionBehavior(bool on, NSUInteger flag) {
-  bool was_maximizable = IsMaximizable();
   if (on)
     [window_ setCollectionBehavior:[window_ collectionBehavior] | flag];
   else
     [window_ setCollectionBehavior:[window_ collectionBehavior] & (~flag)];
+
   // Change collectionBehavior will make the zoom button revert to default,
   // probably a bug of Cocoa or macOS.
-  SetMaximizable(was_maximizable);
+  SetMaximizable(maximizable_);
 }
 
 views::View* NativeWindowMac::GetContentsView() {
   return root_view_.get();
+}
+
+bool NativeWindowMac::CanMaximize() const {
+  return maximizable_;
 }
 
 void NativeWindowMac::OnNativeThemeUpdated(ui::NativeTheme* observed_theme) {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -3669,6 +3669,18 @@ describe('BrowserWindow module', () => {
         }
       });
 
+      // On Linux there is no "resizable" property of a window.
+      ifit(process.platform !== 'linux')('does affect maximizability when disabled and enabled', () => {
+        const w = new BrowserWindow({ show: false });
+        expect(w.resizable).to.be.true('resizable');
+
+        expect(w.maximizable).to.be.true('maximizable');
+        w.resizable = false;
+        expect(w.maximizable).to.be.false('not maximizable');
+        w.resizable = true;
+        expect(w.maximizable).to.be.true('maximizable');
+      });
+
       ifit(process.platform === 'win32')('works for a window smaller than 64x64', () => {
         const w = new BrowserWindow({
           show: false,


### PR DESCRIPTION
#### Description of Change

Refs CL:2485774
Refs https://github.com/electron/electron/pull/29256/commits/a5628cac3e1290a08f3ef75a5fc6356e5a0720a6

Fixes an issue wherein when `mainWindow.setResizable(false)` is called and immediately followed by `mainWindow.setResizable(true)` on macOS, the zoom button remains disabled.

When `SetCanResize` was de-virtualized we started calling it in `SetResizable` - this eventually alters the titlebar controls on macOS when it falls down to [`SetSizeConstraints`](https://source.chromium.org/chromium/chromium/src/+/main:components/remote_cocoa/app_shim/native_widget_ns_window_bridge.mm;l=1037-1054?q=SetSizeConstraints%20nswindow&ss=chromium%2Fchromium%2Fsrc). Fullscreen controls are enabled depending on whether both maximizable and resizable are true. Since we didn't override `views::WidgetDelegate::CanMaximize`, the default value for `can_maximize` would be false and thus the fullscreen control would not be re-enabled. Fix this issue by overriding `views::WidgetDelegate::CanMaximize`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue where multiple calls to`BrowserWindow.setResizable()` can cause the zoom button to incorrectly be disabled on macOS.
