### PR TITLE
Update progress-bar.md

### DIFF
--- a/docs/tutorial/progress-bar.md
+++ b/docs/tutorial/progress-bar.md
@@ -104,6 +104,6 @@ when using [Mission Control](https://support.apple.com/en-us/HT204100):
 ![Mission Control Progress Bar](../images/mission-control-progress-bar.png)
 
 [windows-progress-bar]: https://cloud.githubusercontent.com/assets/639601/5081682/16691fda-6f0e-11e4-9676-49b6418f1264.png
-[macos-progress-bar]: ../images/macos-progress-bar.png
-[linux-progress-bar]: ../images/linux-progress-bar.png
+[macos-progress-bar]: ../../images/macos-progress-bar.png
+[linux-progress-bar]: ../../images/linux-progress-bar.png
 [setprogressbar]: ../api/browser-window.md#winsetprogressbarprogress-options


### PR DESCRIPTION
#### Description of Change

Should fix #30996 I think? Not sure how all those pieces fit together, but it's looking for the images in the `tutorials` folder but it's one level up.

https://github.com/electron/electron/blob/6669abf38d87311bf3985553f43295aa4bb00deb/docs/images/macos-progress-bar.png

![Selection_976](https://user-images.githubusercontent.com/679144/133659508-6cd00464-34c4-480a-a54f-e8998fc49b01.png)

#### Checklist

- [x] relevant documentation is changed or added
