### PR TITLE
fix: transparency on child windows being lost

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -363,6 +363,8 @@ void BrowserWindow::Blur() {
 void BrowserWindow::SetBackgroundColor(const std::string& color_name) {
   BaseWindow::SetBackgroundColor(color_name);
   web_contents()->SetPageBaseBackgroundColor(ParseHexColor(color_name));
+  web_contents()->GetRenderWidgetHostView()->SetBackgroundColor(
+      ParseHexColor(color_name));
   // Also update the web preferences object otherwise the view will be reset on
   // the next load URL call
   if (api_web_contents_) {

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -362,9 +362,11 @@ void BrowserWindow::Blur() {
 
 void BrowserWindow::SetBackgroundColor(const std::string& color_name) {
   BaseWindow::SetBackgroundColor(color_name);
-  web_contents()->SetPageBaseBackgroundColor(ParseHexColor(color_name));
-  web_contents()->GetRenderWidgetHostView()->SetBackgroundColor(
-      ParseHexColor(color_name));
+  SkColor color = ParseHexColor(color_name);
+  web_contents()->SetPageBaseBackgroundColor(color);
+  auto* rwhv = web_contents()->GetRenderWidgetHostView();
+  if (rwhv)
+    rwhv->SetBackgroundColor(color);
   // Also update the web preferences object otherwise the view will be reset on
   // the next load URL call
   if (api_web_contents_) {

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3876,9 +3876,9 @@ gin::Handle<WebContents> WebContents::CreateFromWebPreferences(
       absl::optional<SkColor> color =
           existing_preferences->GetBackgroundColor();
       web_contents->web_contents()->SetPageBaseBackgroundColor(color);
-      web_contents->web_contents()
-          ->GetRenderWidgetHostView()
-          ->SetBackgroundColor(color.value_or(SK_ColorWHITE));
+      auto* rwhv = web_contents->web_contents()->GetRenderWidgetHostView();
+      if (rwhv)
+        rwhv->SetBackgroundColor(color.value_or(SK_ColorWHITE));
     }
   } else {
     // Create one if not.

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1375,8 +1375,7 @@ void WebContents::HandleNewRenderFrame(
   if (web_preferences) {
     absl::optional<SkColor> color = web_preferences->GetBackgroundColor();
     web_contents()->SetPageBaseBackgroundColor(color);
-    web_contents()->GetRenderWidgetHostView()->SetBackgroundColor(
-        color.value_or(SK_ColorWHITE));
+    rwhv->SetBackgroundColor(color.value_or(SK_ColorWHITE));
   }
 
   if (!background_throttling_)

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1373,8 +1373,10 @@ void WebContents::HandleNewRenderFrame(
   // Set the background color of RenderWidgetHostView.
   auto* web_preferences = WebContentsPreferences::From(web_contents());
   if (web_preferences) {
-    web_contents()->SetPageBaseBackgroundColor(
-        web_preferences->GetBackgroundColor());
+    absl::optional<SkColor> color = web_preferences->GetBackgroundColor();
+    web_contents()->SetPageBaseBackgroundColor(color);
+    web_contents()->GetRenderWidgetHostView()->SetBackgroundColor(
+        color.value_or(SK_ColorWHITE));
   }
 
   if (!background_throttling_)
@@ -3872,6 +3874,12 @@ gin::Handle<WebContents> WebContents::CreateFromWebPreferences(
     if (gin::ConvertFromV8(isolate, web_preferences.GetHandle(),
                            &web_preferences_dict)) {
       existing_preferences->SetFromDictionary(web_preferences_dict);
+      absl::optional<SkColor> color =
+          existing_preferences->GetBackgroundColor();
+      web_contents->web_contents()->SetPageBaseBackgroundColor(color);
+      web_contents->web_contents()
+          ->GetRenderWidgetHostView()
+          ->SetBackgroundColor(color.value_or(SK_ColorWHITE));
     }
   } else {
     // Create one if not.


### PR DESCRIPTION
#### Description of Change
This fixes a couple of issues with transparent windows that were introduced
with #30778.

1. Sometimes, transparent windows would be white until a repaint (e.g. resize)
   happened. This seems to be an issue with the `SetPageBaseBackgroundColor`
   API, possibly will eventually be resolved with
   https://chromium-review.googlesource.com/c/chromium/src/+/2958369 or
   similar.
2. Child windows don't have their WebPreferences set immediately, so the
   background color was nullopt at the time that HandleNewRenderFrame was
   called. We fix this by updating the background color when the WebContents
   wrapper is created in `WebContents::CreateFromWebPreferences`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where some transparent windows would show with a white background.
