### PR TITLE
fix: crash on win7 casued by "GetHostNameW" function

### DIFF
--- a/patches/node/.patches
+++ b/patches/node/.patches
@@ -25,3 +25,4 @@ add_should_read_node_options_from_env_option_to_disable_node_options.patch
 repl_fix_crash_when_sharedarraybuffer_disabled.patch
 fix_readbarrier_undefined_symbol_error_on_woa_arm64.patch
 fix_-wunreachable-code-return.patch
+deps-uv-src-win-util.c.patch

--- a/patches/node/deps-uv-src-win-util.c.patch
+++ b/patches/node/deps-uv-src-win-util.c.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tomasz <tomasz@openfin.co>
+Date: Fri, 17 Sep 2021 14:18:11 -0700
+Subject: Fix proablem with "GetHostNameW" on Windows 7.
+
+
+diff --git a/deps/uv/src/win/util.c b/deps/uv/src/win/util.c
+index 88602c7ee8..aad8f1a15e 100644
+--- a/deps/uv/src/win/util.c
++++ b/deps/uv/src/win/util.c
+@@ -1664,33 +1664,26 @@ int uv_os_unsetenv(const char* name) {
+
+
+ int uv_os_gethostname(char* buffer, size_t* size) {
+-  WCHAR buf[UV_MAXHOSTNAMESIZE];
++  char buf[UV_MAXHOSTNAMESIZE];
+   size_t len;
+-  char* utf8_str;
+-  int convert_result;
+
+   if (buffer == NULL || size == NULL || *size == 0)
+     return UV_EINVAL;
+
+   uv__once_init(); /* Initialize winsock */
+
+-  if (GetHostNameW(buf, UV_MAXHOSTNAMESIZE) != 0)
++  if (gethostname(buf, sizeof(buf)) != 0)
+     return uv_translate_sys_error(WSAGetLastError());
+
+-  convert_result = uv__convert_utf16_to_utf8(buf, -1, &utf8_str);
++  buf[sizeof(buf) - 1] = '\0'; /* Null terminate, just to be safe. */
++  len = strlen(buf);
+
+-  if (convert_result != 0)
+-    return convert_result;
+-
+-  len = strlen(utf8_str);
+   if (len >= *size) {
+     *size = len + 1;
+-    uv__free(utf8_str);
+     return UV_ENOBUFS;
+   }
+
+-  memcpy(buffer, utf8_str, len + 1);
+-  uv__free(utf8_str);
++  memcpy(buffer, buf, len + 1);
+   *size = len;
+   return 0;
+ }


### PR DESCRIPTION
uv lib dosen't support windows 7 anymore. Current version of uv lib
(1.42.0) is using "GetHostNameW" function which is not present in
windows 7 Ws2_32/64.dll. Revert "uv_os_gethostname" function to 1.41.0
version, which works fine on windows 7 and higher.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Resolves problem with crash on windows 7 caused by uv lib which is using "GetHostNameW" function.<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
