### PR TITLE
test: BrowserWindow backgroundColor and transparency

### DIFF
--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -4858,7 +4858,8 @@ describe('BrowserWindow module', () => {
       expect(w.getBounds()).to.deep.equal(newBounds);
     });
 
-    it('should not display a visible background', async () => {
+    // Linux doesn't return any capture sources.
+    ifit(process.platform !== 'linux')('should not display a visible background', async () => {
       const display = screen.getPrimaryDisplay();
 
       const backgroundWindow = new BrowserWindow({
@@ -4899,7 +4900,8 @@ describe('BrowserWindow module', () => {
   describe('"backgroundColor" option', () => {
     afterEach(closeAllWindows);
 
-    it('should display the set color', async () => {
+    // Linux doesn't return any capture sources.
+    ifit(process.platform !== 'linux')('should display the set color', async () => {
       const display = screen.getPrimaryDisplay();
 
       const w = new BrowserWindow({

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -12,7 +12,7 @@ import { app, BrowserWindow, BrowserView, dialog, ipcMain, OnBeforeSendHeadersLi
 import { emittedOnce, emittedUntil, emittedNTimes } from './events-helpers';
 import { ifit, ifdescribe, defer, delay } from './spec-helpers';
 import { closeWindow, closeAllWindows } from './window-helpers';
-import { areColorsSimilar, CHROMA_COLOR_HEX, colorAtPoint } from './screen-helpers';
+import { areColorsSimilar, captureScreen, CHROMA_COLOR_HEX, getPixelColor } from './screen-helpers';
 
 const features = process._linkedBinding('electron_common_features');
 const fixtures = path.resolve(__dirname, '..', 'spec', 'fixtures');
@@ -4882,12 +4882,12 @@ describe('BrowserWindow module', () => {
       foregroundWindow.loadFile(path.join(__dirname, 'fixtures', 'pages', 'half-background-color.html'));
       await emittedOnce(foregroundWindow, 'ready-to-show');
 
-      const leftHalfColor = await colorAtPoint({
+      const screenCapture = await captureScreen();
+      const leftHalfColor = getPixelColor(screenCapture, {
         x: display.size.width / 4,
         y: display.size.height / 2
       });
-
-      const rightHalfColor = await colorAtPoint({
+      const rightHalfColor = getPixelColor(screenCapture, {
         x: display.size.width - (display.size.width / 4),
         y: display.size.height / 2
       });
@@ -4913,7 +4913,8 @@ describe('BrowserWindow module', () => {
       w.loadURL('about:blank');
       await emittedOnce(w, 'ready-to-show');
 
-      const centerColor = await colorAtPoint({
+      const screenCapture = await captureScreen();
+      const centerColor = getPixelColor(screenCapture, {
         x: display.size.width / 2,
         y: display.size.height / 2
       });

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -12,6 +12,7 @@ import { app, BrowserWindow, BrowserView, dialog, ipcMain, OnBeforeSendHeadersLi
 import { emittedOnce, emittedUntil, emittedNTimes } from './events-helpers';
 import { ifit, ifdescribe, defer, delay } from './spec-helpers';
 import { closeWindow, closeAllWindows } from './window-helpers';
+import { CHROMA_COLOR_HEX, colorAtPoint } from './screen-helpers';
 
 const features = process._linkedBinding('electron_common_features');
 const fixtures = path.resolve(__dirname, '..', 'spec', 'fixtures');
@@ -4855,6 +4856,68 @@ describe('BrowserWindow module', () => {
       const newBounds = { width: 256, height: 256, x: 0, y: 0 };
       w.setBounds(newBounds);
       expect(w.getBounds()).to.deep.equal(newBounds);
+    });
+
+    it('should not display a visible background', async () => {
+      const display = screen.getPrimaryDisplay();
+
+      const backgroundWindow = new BrowserWindow({
+        ...display.bounds,
+        frame: false,
+        backgroundColor: CHROMA_COLOR_HEX
+      });
+
+      await backgroundWindow.loadURL('about:blank');
+
+      const w = new BrowserWindow({
+        ...display.bounds,
+        show: true,
+        transparent: true,
+        frame: false
+      });
+
+      w.loadFile(path.join(__dirname, 'fixtures', 'pages', 'half-background-color.html'));
+      await emittedOnce(w, 'ready-to-show');
+
+      const leftHalfColor = await colorAtPoint({
+        x: display.size.width / 4,
+        y: display.size.height / 2
+      });
+
+      const rightHalfColor = await colorAtPoint({
+        x: display.size.width - (display.size.width / 4),
+        y: display.size.height / 2
+      });
+
+      expect(leftHalfColor).to.equal(CHROMA_COLOR_HEX);
+      expect(rightHalfColor).to.equal('#ff0000');
+    });
+  });
+
+  describe('"backgroundColor" option', () => {
+    afterEach(closeAllWindows);
+
+    it('should display the set color', async () => {
+      const display = screen.getPrimaryDisplay();
+
+      const w = new BrowserWindow({
+        ...display.bounds,
+        show: true,
+        backgroundColor: CHROMA_COLOR_HEX
+      });
+
+      w.loadURL('about:blank');
+      await emittedOnce(w, 'ready-to-show');
+
+      // Need to wait for frame to paint sometimes :(
+      await new Promise(resolve => setTimeout(resolve, 1));
+
+      const centerColor = await colorAtPoint({
+        x: display.size.width / 2,
+        y: display.size.height / 2
+      });
+
+      expect(centerColor).to.equal(CHROMA_COLOR_HEX);
     });
   });
 });

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -12,7 +12,7 @@ import { app, BrowserWindow, BrowserView, dialog, ipcMain, OnBeforeSendHeadersLi
 import { emittedOnce, emittedUntil, emittedNTimes } from './events-helpers';
 import { ifit, ifdescribe, defer, delay } from './spec-helpers';
 import { closeWindow, closeAllWindows } from './window-helpers';
-import { CHROMA_COLOR_HEX, colorAtPoint } from './screen-helpers';
+import { areColorsSimilar, CHROMA_COLOR_HEX, colorAtPoint } from './screen-helpers';
 
 const features = process._linkedBinding('electron_common_features');
 const fixtures = path.resolve(__dirname, '..', 'spec', 'fixtures');
@@ -4864,20 +4864,22 @@ describe('BrowserWindow module', () => {
       const backgroundWindow = new BrowserWindow({
         ...display.bounds,
         frame: false,
-        backgroundColor: CHROMA_COLOR_HEX
+        backgroundColor: CHROMA_COLOR_HEX,
+        hasShadow: false
       });
 
       await backgroundWindow.loadURL('about:blank');
 
-      const w = new BrowserWindow({
+      const foregroundWindow = new BrowserWindow({
         ...display.bounds,
         show: true,
         transparent: true,
-        frame: false
+        frame: false,
+        hasShadow: false
       });
 
-      w.loadFile(path.join(__dirname, 'fixtures', 'pages', 'half-background-color.html'));
-      await emittedOnce(w, 'ready-to-show');
+      foregroundWindow.loadFile(path.join(__dirname, 'fixtures', 'pages', 'half-background-color.html'));
+      await emittedOnce(foregroundWindow, 'ready-to-show');
 
       const leftHalfColor = await colorAtPoint({
         x: display.size.width / 4,
@@ -4889,8 +4891,8 @@ describe('BrowserWindow module', () => {
         y: display.size.height / 2
       });
 
-      expect(leftHalfColor).to.equal(CHROMA_COLOR_HEX);
-      expect(rightHalfColor).to.equal('#ff0000');
+      expect(areColorsSimilar(leftHalfColor, CHROMA_COLOR_HEX)).to.be.true();
+      expect(areColorsSimilar(rightHalfColor, '#ff0000')).to.be.true();
     });
   });
 
@@ -4909,15 +4911,12 @@ describe('BrowserWindow module', () => {
       w.loadURL('about:blank');
       await emittedOnce(w, 'ready-to-show');
 
-      // Need to wait for frame to paint sometimes :(
-      await new Promise(resolve => setTimeout(resolve, 1));
-
       const centerColor = await colorAtPoint({
         x: display.size.width / 2,
         y: display.size.height / 2
       });
 
-      expect(centerColor).to.equal(CHROMA_COLOR_HEX);
+      expect(areColorsSimilar(centerColor, CHROMA_COLOR_HEX)).to.be.true();
     });
   });
 });

--- a/spec-main/fixtures/pages/half-background-color.html
+++ b/spec-main/fixtures/pages/half-background-color.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <style>
+      #main {
+        position: fixed;
+        left: 50%;
+        right: 0;
+        top: 0;
+        bottom: 0;
+        background-color: #ff0000;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="main"></div>
+  </body>
+</html>

--- a/spec-main/screen-helpers.ts
+++ b/spec-main/screen-helpers.ts
@@ -1,0 +1,43 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import { screen, desktopCapturer, NativeImage } from 'electron';
+
+const fixtures = path.resolve(__dirname, '..', 'spec', 'fixtures');
+
+/** Chroma key green. */
+export const CHROMA_COLOR_HEX = '#00b140';
+
+const captureScreen = async (point: Electron.Point = { x: 0, y: 0 }): Promise<NativeImage> => {
+  const display = screen.getDisplayNearestPoint(point);
+  const sources = await desktopCapturer.getSources({ types: ['screen'], thumbnailSize: display.size });
+  // Toggle to save screen captures for debugging.
+  const DEBUG_CAPTURE = false;
+  if (DEBUG_CAPTURE) {
+    for (const source of sources) {
+      await fs.promises.writeFile(path.join(fixtures, `screenshot_${source.display_id}.png`), source.thumbnail.toPNG());
+    }
+  }
+  const screenCapture = sources.find(source => source.display_id === `${display.id}`);
+  // Fails when HDR is enabled on Windows.
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=1247730
+  if (!screenCapture) throw new Error(`Unable to find screen capture for display '${display.id}'`);
+  return screenCapture.thumbnail;
+};
+
+const formatHexByte = (val: number): string => {
+  const str = val.toString(16);
+  return str.length === 2 ? str : `0${str}`;
+};
+
+/**
+ * Get the hex color at the given point.
+ *
+ * NOTE: The color can be off on Windows when using a scale factor different
+ * than 1x.
+ */
+export const colorAtPoint = async (point: Electron.Point): Promise<string> => {
+  const image = await captureScreen(point);
+  const pixel = image.crop({ ...point, width: 1, height: 1 });
+  const [b, g, r] = pixel.toBitmap();
+  return `#${formatHexByte(r)}${formatHexByte(g)}${formatHexByte(b)}`;
+};

--- a/spec-main/screen-helpers.ts
+++ b/spec-main/screen-helpers.ts
@@ -41,6 +41,8 @@ const formatHexByte = (val: number): string => {
 export const colorAtPoint = async (point: Electron.Point): Promise<string> => {
   const image = await captureScreen(point);
   const pixel = image.crop({ ...point, width: 1, height: 1 });
+  // TODO(samuelmaddock): NativeImage.toBitmap() should return the raw pixel
+  // color, but it sometimes differs. Why is that?
   const [b, g, r] = pixel.toBitmap();
   return `#${formatHexByte(r)}${formatHexByte(g)}${formatHexByte(b)}`;
 };

--- a/spec-main/screen-helpers.ts
+++ b/spec-main/screen-helpers.ts
@@ -7,7 +7,12 @@ const fixtures = path.resolve(__dirname, '..', 'spec', 'fixtures');
 /** Chroma key green. */
 export const CHROMA_COLOR_HEX = '#00b140';
 
-const captureScreen = async (point: Electron.Point = { x: 0, y: 0 }): Promise<NativeImage> => {
+/**
+ * Capture the screen at the given point.
+ *
+ * NOTE: Not yet supported on Linux in CI due to empty sources list.
+ */
+export const captureScreen = async (point: Electron.Point = { x: 0, y: 0 }): Promise<NativeImage> => {
   const display = screen.getDisplayNearestPoint(point);
   const sources = await desktopCapturer.getSources({ types: ['screen'], thumbnailSize: display.size });
   // Toggle to save screen captures for debugging.
@@ -33,13 +38,9 @@ const formatHexByte = (val: number): string => {
 };
 
 /**
- * Get the hex color at the given point.
- *
- * NOTE: The color can be off on Windows when using a scale factor different
- * than 1x.
+ * Get the hex color at the given pixel coordinate in an image.
  */
-export const colorAtPoint = async (point: Electron.Point): Promise<string> => {
-  const image = await captureScreen(point);
+export const getPixelColor = (image: Electron.NativeImage, point: Electron.Point): string => {
   const pixel = image.crop({ ...point, width: 1, height: 1 });
   // TODO(samuelmaddock): NativeImage.toBitmap() should return the raw pixel
   // color, but it sometimes differs. Why is that?


### PR DESCRIPTION
#### Description of Change

Adds tests for ensuring `backgroundColor` and `transparent` options work for `BrowserWindow`.

Note:
- No tests for `BrowserView` or WebContents Off-Screen Renderer
- `NativeImage` pixel is sometimes a slightly different color depending on underlying `desktopCapturer` implementation or maybe image compression 🤔 
- `desktopCapturer` tests currently don't support Linux so it's also skipped here for capturing the screen pixel

cc @nornagon @VerteDinde 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)

#### Release Notes

Notes: none
