### PR TITLE
fix: first mouse not dragging BrowserView

### DIFF
--- a/shell/browser/native_browser_view_mac.mm
+++ b/shell/browser/native_browser_view_mac.mm
@@ -62,6 +62,10 @@ const NSAutoresizingMaskOptions kDefaultAutoResizingMask =
   return NO;
 }
 
+- (BOOL)acceptsFirstMouse:(NSEvent*)event {
+  return YES;
+}
+
 - (BOOL)shouldIgnoreMouseEvent {
   NSEventType type = [[NSApp currentEvent] type];
   return type != NSEventTypeLeftMouseDragged &&


### PR DESCRIPTION
#### Description of Change

Partially addresses https://github.com/electron/electron/issues/31058.

Fixes an issue where the `DragRegionView` did not accept the first mouse click, meaning that the first click would only activate the window and not trigger drag behavior immediately as would occur with a BrowserWindow. This fixes the error by ensuring that `acceptsFirstMouse` returns `YES` for  `DragRegionView`.

Tested with https://gist.github.com/0a371fe58ff8c8b72287629ab6d76d34.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue where out-of-focus BrowserViews could not be immediately dragged.
