### PR TITLE
chore: clarify new-window fix comment

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -666,9 +666,9 @@ WebContents.prototype._init = function () {
         postBody
       };
       windowOpenOverriddenOptions = this._callWindowOpenHandler(event, details);
-      // if attempting to use this API with the deprecated window.open event,
+      // if attempting to use this API with the deprecated new-window event,
       // windowOpenOverriddenOptions will always return null. This ensures
-      // short-term backwards compatibility until window.open is removed.
+      // short-term backwards compatibility until new-window is removed.
       const parsedFeatures = parseFeatures(rawFeatures);
       const overriddenFeatures: BrowserWindowConstructorOptions = {
         ...parsedFeatures.options,


### PR DESCRIPTION
#### Description of Change

Small PR, follow up to #31031 - the comment above the fix marked `window.open` as being deprecated, when actually it's the `new-window` event that is now deprecated. To avoid adding confusion, this PR fixes that comment, changing `window.open` to `new-window.`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
