### PR TITLE
fix: draggable regions in `BrowserView`s are independent

### DIFF
--- a/shell/browser/api/electron_api_browser_window_mac.mm
+++ b/shell/browser/api/electron_api_browser_window_mac.mm
@@ -39,10 +39,7 @@ void BrowserWindow::OverrideNSWindowContentView(
 
 void BrowserWindow::UpdateDraggableRegions(
     const std::vector<mojom::DraggableRegionPtr>& regions) {
-  if (window_->has_frame())
-    return;
-
-  if (!web_contents())
+  if (window_->has_frame() || !web_contents())
     return;
 
   // All ControlRegionViews should be added as children of the WebContentsView,
@@ -78,8 +75,13 @@ void BrowserWindow::UpdateDraggableRegions(
         DraggableRegionsToSkRegion(regions), webViewWidth, webViewHeight);
   }
 
+  // Draggable regions on BrowserViews are independent from those of
+  // BrowserWindows, so if a BrowserView with different draggable regions than
+  // the BrowserWindow it belongs to is superimposed on top of that window, the
+  // draggable regions of the BrowserView take precedence over those of the
+  // BrowserWindow.
   for (NativeBrowserView* view : window_->browser_views()) {
-    view->UpdateDraggableRegions(drag_exclude_rects);
+    view->UpdateDraggableRegions(view->GetDraggableRegions());
   }
 
   // Create and add a ControlRegionView for each region that needs to be


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/31068
Closes https://github.com/electron/electron/issues/31052.

After https://github.com/electron/electron/pull/26145, it was possible to make draggable regions on BrowserViews independent from those of BrowserWindows. As such, if a BrowserView with different draggable regions than the BrowserWindow it belongs to is superimposed on top of that window, the draggable regions of the BrowserView take precedence over those of the BrowserWindow. This is fixed by having each BrowseView update its own draggable regions in `BrowserWindow::UpdateDraggableRegions` instead of inheriting those coming in from `BrowserWindow::UpdateDraggableRegions`.

Tested with https://gist.github.com/0a53108546ef22e4d03e1b6dea55a79a and https://github.com/devinbinnie/electron-quick-start/tree/draggable_areas_bv_macos

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where changes to draggable regions in a `BrowserWindow` incorrectly affected those in an attached `BrowserView`.
