### PR TITLE
fix: running tests with release build

### DIFF
--- a/shell/browser/api/electron_api_menu.cc
+++ b/shell/browser/api/electron_api_menu.cc
@@ -236,13 +236,11 @@ std::u16string Menu::GetToolTipAt(int index) const {
   return model_->GetToolTipAt(index);
 }
 
-#if DCHECK_IS_ON()
 std::u16string Menu::GetAcceleratorTextAtForTesting(int index) const {
   ui::Accelerator accelerator;
   model_->GetAcceleratorAtWithParams(index, true, &accelerator);
   return accelerator.GetShortcutText();
 }
-#endif
 
 bool Menu::IsItemCheckedAt(int index) const {
   return model_->IsItemCheckedAt(index);
@@ -297,9 +295,7 @@ v8::Local<v8::ObjectTemplate> Menu::FillObjectTemplate(
       .SetMethod("isVisibleAt", &Menu::IsVisibleAt)
       .SetMethod("popupAt", &Menu::PopupAt)
       .SetMethod("closePopupAt", &Menu::ClosePopupAt)
-#if DCHECK_IS_ON()
-      .SetMethod("getAcceleratorTextAt", &Menu::GetAcceleratorTextAtForTesting)
-#endif
+      .SetMethod("_getAcceleratorTextAt", &Menu::GetAcceleratorTextAtForTesting)
 #if defined(OS_MAC)
       .SetMethod("_getUserAcceleratorAt", &Menu::GetUserAcceleratorAt)
 #endif

--- a/shell/browser/api/electron_api_menu.h
+++ b/shell/browser/api/electron_api_menu.h
@@ -79,9 +79,7 @@ class Menu : public gin::Wrappable<Menu>,
                        int positioning_item,
                        base::OnceClosure callback) = 0;
   virtual void ClosePopupAt(int32_t window_id) = 0;
-#if DCHECK_IS_ON()
   virtual std::u16string GetAcceleratorTextAtForTesting(int index) const;
-#endif
 
   std::unique_ptr<ElectronMenuModel> model_;
   Menu* parent_ = nullptr;

--- a/shell/browser/api/electron_api_menu_mac.h
+++ b/shell/browser/api/electron_api_menu_mac.h
@@ -34,9 +34,7 @@ class MenuMac : public Menu {
                  int positioning_item,
                  base::OnceClosure callback);
   void ClosePopupAt(int32_t window_id) override;
-#if DCHECK_IS_ON()
   std::u16string GetAcceleratorTextAtForTesting(int index) const override;
-#endif
 
  private:
   friend class Menu;

--- a/shell/browser/api/electron_api_menu_mac.mm
+++ b/shell/browser/api/electron_api_menu_mac.mm
@@ -170,7 +170,6 @@ void MenuMac::ClosePopupAt(int32_t window_id) {
                                                    std::move(close_popup));
 }
 
-#if DCHECK_IS_ON()
 std::u16string MenuMac::GetAcceleratorTextAtForTesting(int index) const {
   // A least effort to get the real shortcut text of NSMenuItem, the code does
   // not need to be perfect since it is test only.
@@ -206,7 +205,6 @@ std::u16string MenuMac::GetAcceleratorTextAtForTesting(int index) const {
     text += key;
   return text;
 }
-#endif
 
 void MenuMac::ClosePopupOnUI(int32_t window_id) {
   auto controller = popup_controllers_.find(window_id);

--- a/shell/common/api/electron_api_v8_util.cc
+++ b/shell/common/api/electron_api_v8_util.cc
@@ -156,13 +156,11 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("requestGarbageCollectionForTesting",
                  &RequestGarbageCollectionForTesting);
   dict.SetMethod("isSameOrigin", &IsSameOrigin);
-#if DCHECK_IS_ON()
   dict.SetMethod("triggerFatalErrorForTesting", &TriggerFatalErrorForTesting);
   dict.SetMethod("getWeaklyTrackedValues", &GetWeaklyTrackedValues);
   dict.SetMethod("clearWeaklyTrackedValues", &ClearWeaklyTrackedValues);
   dict.SetMethod("weaklyTrackValue", &WeaklyTrackValue);
   dict.SetMethod("runUntilIdle", &RunUntilIdle);
-#endif
 }
 
 }  // namespace

--- a/spec-main/api-menu-item-spec.ts
+++ b/spec-main/api-menu-item-spec.ts
@@ -462,9 +462,9 @@ describe('MenuItems', () => {
         { label: 'text', accelerator: 'Alt+A' }
       ]);
 
-      expect(menu.getAcceleratorTextAt(0)).to.equal(isDarwin() ? 'Command+A' : 'Ctrl+A');
-      expect(menu.getAcceleratorTextAt(1)).to.equal('Shift+A');
-      expect(menu.getAcceleratorTextAt(2)).to.equal('Alt+A');
+      expect(menu._getAcceleratorTextAt(0)).to.equal(isDarwin() ? 'Command+A' : 'Ctrl+A');
+      expect(menu._getAcceleratorTextAt(1)).to.equal('Shift+A');
+      expect(menu._getAcceleratorTextAt(2)).to.equal('Alt+A');
     });
 
     it('should display modifiers correctly for special keys', () => {
@@ -474,9 +474,9 @@ describe('MenuItems', () => {
         { label: 'text', accelerator: 'Alt+Tab' }
       ]);
 
-      expect(menu.getAcceleratorTextAt(0)).to.equal(isDarwin() ? 'Command+Tab' : 'Ctrl+Tab');
-      expect(menu.getAcceleratorTextAt(1)).to.equal('Shift+Tab');
-      expect(menu.getAcceleratorTextAt(2)).to.equal('Alt+Tab');
+      expect(menu._getAcceleratorTextAt(0)).to.equal(isDarwin() ? 'Command+Tab' : 'Ctrl+Tab');
+      expect(menu._getAcceleratorTextAt(1)).to.equal('Shift+Tab');
+      expect(menu._getAcceleratorTextAt(2)).to.equal('Alt+Tab');
     });
 
     it('should not display modifiers twice', () => {
@@ -485,8 +485,8 @@ describe('MenuItems', () => {
         { label: 'text', accelerator: 'Shift+Shift+Tab' }
       ]);
 
-      expect(menu.getAcceleratorTextAt(0)).to.equal('Shift+A');
-      expect(menu.getAcceleratorTextAt(1)).to.equal('Shift+Tab');
+      expect(menu._getAcceleratorTextAt(0)).to.equal('Shift+A');
+      expect(menu._getAcceleratorTextAt(1)).to.equal('Shift+Tab');
     });
 
     it('should display correctly for shifted keys', () => {
@@ -499,12 +499,12 @@ describe('MenuItems', () => {
         { label: 'text', accelerator: 'Control+?' }
       ]);
 
-      expect(menu.getAcceleratorTextAt(0)).to.equal('Ctrl+Shift+=');
-      expect(menu.getAcceleratorTextAt(1)).to.equal('Ctrl++');
-      expect(menu.getAcceleratorTextAt(2)).to.equal('Ctrl+Shift+3');
-      expect(menu.getAcceleratorTextAt(3)).to.equal('Ctrl+#');
-      expect(menu.getAcceleratorTextAt(4)).to.equal('Ctrl+Shift+/');
-      expect(menu.getAcceleratorTextAt(5)).to.equal('Ctrl+?');
+      expect(menu._getAcceleratorTextAt(0)).to.equal('Ctrl+Shift+=');
+      expect(menu._getAcceleratorTextAt(1)).to.equal('Ctrl++');
+      expect(menu._getAcceleratorTextAt(2)).to.equal('Ctrl+Shift+3');
+      expect(menu._getAcceleratorTextAt(3)).to.equal('Ctrl+#');
+      expect(menu._getAcceleratorTextAt(4)).to.equal('Ctrl+Shift+/');
+      expect(menu._getAcceleratorTextAt(5)).to.equal('Ctrl+?');
     });
   });
 });

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -123,7 +123,7 @@ declare namespace Electron {
     insertSeparator(index: number): void;
     insertSubMenu(index: number, commandId: number, label: string, submenu?: Menu): void;
     delegate?: any;
-    getAcceleratorTextAt(index: number): string;
+    _getAcceleratorTextAt(index: number): string;
   }
 
   interface MenuItem {


### PR DESCRIPTION
#### Description of Change
Several tests are failing with a release build as they are calling APIs only available when `DCHECK` is on:
```
not ok 783 MenuItems MenuItem accelerators should display modifiers correctly for simple keys
  TypeError: menu.getAcceleratorTextAt is not a function
      at Context.<anonymous> (electron/spec-main/api-menu-item-spec.ts:465:19)
      at processImmediate (node:internal/timers:464:21)

not ok 784 MenuItems MenuItem accelerators should display modifiers correctly for special keys
  TypeError: menu.getAcceleratorTextAt is not a function
      at Context.<anonymous> (electron/spec-main/api-menu-item-spec.ts:477:19)
      at processImmediate (node:internal/timers:464:21)

not ok 785 MenuItems MenuItem accelerators should not display modifiers twice
  TypeError: menu.getAcceleratorTextAt is not a function
      at Context.<anonymous> (electron/spec-main/api-menu-item-spec.ts:488:19)
      at processImmediate (node:internal/timers:464:21)

not ok 786 MenuItems MenuItem accelerators should display correctly for shifted keys
  TypeError: menu.getAcceleratorTextAt is not a function
      at Context.<anonymous> (electron/spec-main/api-menu-item-spec.ts:502:19)
      at processImmediate (node:internal/timers:464:21)

not ok 1788 spellchecker without sandbox spellCheckerEnabled can be dynamically changed
  TypeError: v8Util.runUntilIdle is not a function
      at Context.<anonymous> (electron/spec-main/spellchecker-spec.ts:125:28)

not ok 1801 spellchecker with sandbox spellCheckerEnabled can be dynamically changed
  TypeError: v8Util.runUntilIdle is not a function
      at Context.<anonymous> (electron/spec-main/spellchecker-spec.ts:125:28)
```

Example:
https://github.com/electron/electron/blob/6aece4a83d12b6ec610994895e43560ae1aa77dc/spec-main/spellchecker-spec.ts#L132-L159
https://github.com/electron/electron/blob/6aece4a83d12b6ec610994895e43560ae1aa77dc/shell/common/api/electron_api_v8_util.cc#L159-L165

Let's just expose those APIs regardless of `DCHECK`. The only other option would be to skip these tests when running with a release build.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)

#### Release Notes
Notes: none
