### PR TITLE
fix: avoid double free when destroying WebContents

### DIFF
--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -451,6 +451,9 @@ class WebContents : public gin::Wrappable<WebContents>,
   WebContents(v8::Isolate* isolate, const gin_helper::Dictionary& options);
   ~WebContents() override;
 
+  // Delete this if garbage collection has not started.
+  void DeleteThisIfAlive();
+
   // Creates a InspectableWebContents object and takes ownership of
   // |web_contents|.
   void InitWithWebContents(std::unique_ptr<content::WebContents> web_contents,


### PR DESCRIPTION
#### Description of Change

Fix a race condition when destroying WebContents that, if the `FirstWeakCallback` of `gin::Wrapper` has been called but the `SecondWeakCallback` has not, the `api::WebContents::Destroy` will still call `delete this` while unable to prevent `SecondWeakCallback` from calling `delete this`, which will result in double free.

#### Release Notes

Notes: Fix crash caused by double free when destroying WebContents.
