### PR TITLE
docs: Update Branch Name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,9 +8,9 @@ body:
     label: Preflight Checklist
     description: Please ensure you've completed all of the following.
     options:
-      - label: I have read the [Contributing Guidelines](https://github.com/electron/electron/blob/master/CONTRIBUTING.md) for this project.
+      - label: I have read the [Contributing Guidelines](https://github.com/electron/electron/blob/main/CONTRIBUTING.md) for this project.
         required: true
-      - label: I agree to follow the [Code of Conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project adheres to.
+      - label: I agree to follow the [Code of Conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project adheres to.
         required: true
       - label: I have searched the [issue tracker](https://www.github.com/electron/electron/issues) for a feature request that matches the one I want to file, without success.
         required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,9 +8,9 @@ body:
     label: Preflight Checklist
     description: Please ensure you've completed all of the following.
     options:
-      - label: I have read the [Contributing Guidelines](https://github.com/electron/electron/blob/master/CONTRIBUTING.md) for this project.
+      - label: I have read the [Contributing Guidelines](https://github.com/electron/electron/blob/main/CONTRIBUTING.md) for this project.
         required: true
-      - label: I agree to follow the [Code of Conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project adheres to.
+      - label: I agree to follow the [Code of Conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project adheres to.
         required: true
       - label: I have searched the [issue tracker](https://www.github.com/electron/electron/issues) for a feature request that matches the one I want to file, without success.
         required: true

--- a/.github/ISSUE_TEMPLATE/mac_app_store_private_api_rejection.yml
+++ b/.github/ISSUE_TEMPLATE/mac_app_store_private_api_rejection.yml
@@ -7,9 +7,9 @@ body:
     label: Preflight Checklist
     description: Please ensure you've completed all of the following.
     options:
-      - label: I have read the [Contributing Guidelines](https://github.com/electron/electron/blob/master/CONTRIBUTING.md) for this project.
+      - label: I have read the [Contributing Guidelines](https://github.com/electron/electron/blob/main/CONTRIBUTING.md) for this project.
         required: true
-      - label: I agree to follow the [Code of Conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project adheres to.
+      - label: I agree to follow the [Code of Conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project adheres to.
         required: true
 - type: input
   attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 Thank you for your Pull Request. Please provide a description above and review
 the requirements below.
 
-Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
+Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
 -->
 
 #### Checklist
@@ -11,7 +11,7 @@ Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTIN
 
 - [ ] PR description included and stakeholders cc'd
 - [ ] `npm test` passes
-- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
+- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
 - [ ] relevant documentation is changed or added
 - [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
 

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -2,7 +2,7 @@
 newPRWelcomeComment: |
   💖 Thanks for opening this pull request! 💖
 
-  We use [semantic commit messages](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines) to streamline the release process. Before your pull request can be merged, you should **update your pull request title** to start with a semantic prefix.
+  We use [semantic commit messages](https://github.com/electron/electron/blob/main/docs/development/pull-requests.md#commit-message-guidelines) to streamline the release process. Before your pull request can be merged, you should **update your pull request title** to start with a semantic prefix.
 
   Examples of commit messages with semantic prefixes:
 
@@ -12,9 +12,9 @@ newPRWelcomeComment: |
 
   Things that will help get your PR across the finish line:
 
-  - Follow the JavaScript, C++, and Python [coding style](https://github.com/electron/electron/blob/master/docs/development/coding-style.md).
+  - Follow the JavaScript, C++, and Python [coding style](https://github.com/electron/electron/blob/main/docs/development/coding-style.md).
   - Run `npm run lint` locally to catch formatting errors earlier.
-  - Document any user-facing changes you've made following the [documentation styleguide](https://github.com/electron/electron/blob/master/docs/styleguide.md).
+  - Document any user-facing changes you've made following the [documentation styleguide](https://github.com/electron/electron/blob/main/docs/styleguide.md).
   - Include tests when adding/changing behavior.
   - Include screenshots and animated GIFs whenever possible.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Having the original text _as well as_ the translation can help mitigate translat
 
 Responses to posted issues may or may not be in the original language.
 
-**Please note** that using non-English as an attempt to circumvent our [Code of Conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) will be an immediate, and possibly indefinite, ban from the project.
+**Please note** that using non-English as an attempt to circumvent our [Code of Conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) will be an immediate, and possibly indefinite, ban from the project.
 
 ## [Pull Requests](https://electronjs.org/docs/development/pull-requests)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Electron Logo](https://electronjs.org/images/electron-logo.svg)](https://electronjs.org)
 
-[![CircleCI Build Status](https://circleci.com/gh/electron/electron/tree/master.svg?style=shield)](https://circleci.com/gh/electron/electron/tree/master)
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/4lggi9dpjc1qob7k/branch/master?svg=true)](https://ci.appveyor.com/project/electron-bot/electron-ljo26/branch/master)
+[![CircleCI Build Status](https://circleci.com/gh/electron/electron/tree/main.svg?style=shield)](https://circleci.com/gh/electron/electron/tree/main)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/4lggi9dpjc1qob7k/branch/main?svg=true)](https://ci.appveyor.com/project/electron-bot/electron-ljo26/branch/main)
 [![Electron Discord Invite](https://img.shields.io/discord/745037351163527189?color=%237289DA&label=chat&logo=discord&logoColor=white)](https://discord.com/invite/electron)
 
 :memo: Available Translations: 🇨🇳 🇧🇷 🇪🇸 🇯🇵 🇷🇺 🇫🇷 🇺🇸 🇩🇪.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Follow [@ElectronJS](https://twitter.com/electronjs) on Twitter for important
 announcements.
 
 This project adheres to the Contributor Covenant
-[code of conduct](https://github.com/electron/electron/tree/master/CODE_OF_CONDUCT.md).
+[code of conduct](https://github.com/electron/electron/tree/main/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable
 behavior to [coc@electronjs.org](mailto:coc@electronjs.org).
 
@@ -97,6 +97,6 @@ and more can be found in the [support document](docs/tutorial/support.md#finding
 
 ## License
 
-[MIT](https://github.com/electron/electron/blob/master/LICENSE)
+[MIT](https://github.com/electron/electron/blob/main/LICENSE)
 
 When using the Electron or other GitHub logos, be sure to follow the [GitHub logo guidelines](https://github.com/logos).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ Report security bugs in third-party modules to the person or team maintaining th
 
 ## The Electron Security Notification Process
 
-For context on Electron's security notification process, please see the [Notifications](https://github.com/electron/governance/blob/master/wg-security/membership-and-notifications.md#notifications) section of the Security WG's [Membership and Notifications](https://github.com/electron/governance/blob/master/wg-security/membership-and-notifications.md) Governance document.
+For context on Electron's security notification process, please see the [Notifications](https://github.com/electron/governance/blob/main/wg-security/membership-and-notifications.md#notifications) section of the Security WG's [Membership and Notifications](https://github.com/electron/governance/blob/main/wg-security/membership-and-notifications.md) Governance document.
 
 ## Learning More About Security
 

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -632,7 +632,7 @@ error.
 ### API Changed: `shell.openItem` is now `shell.openPath`
 
 The `shell.openItem` API has been replaced with an asynchronous `shell.openPath` API.
-You can see the original API proposal and reasoning [here](https://github.com/electron/governance/blob/master/wg-api/spec-documents/shell-openitem.md).
+You can see the original API proposal and reasoning [here](https://github.com/electron/governance/blob/main/wg-api/spec-documents/shell-openitem.md).
 
 ## Planned Breaking API Changes (8.0)
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -4,8 +4,8 @@ These guides are intended for people working on the Electron project itself.
 For guides on Electron app development, see
 [/docs/README.md](../README.md#guides-and-tutorials).
 
-* [Code of Conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md)
-* [Contributing to Electron](https://github.com/electron/electron/blob/master/CONTRIBUTING.md)
+* [Code of Conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md)
+* [Contributing to Electron](https://github.com/electron/electron/blob/main/CONTRIBUTING.md)
 * [Issues](issues.md)
 * [Pull Requests](pull-requests.md)
 * [Documentation Styleguide](coding-style.md#documentation)

--- a/docs/development/azure-vm-setup.md
+++ b/docs/development/azure-vm-setup.md
@@ -8,7 +8,7 @@ Example Use Case:
     * We need `VS15.9` and we have `VS15.7` installed; this would require us to update an Azure image.
 
 1. Identify the image you wish to modify.
-    * In [appveyor.yml](https://github.com/electron/electron/blob/master/appveyor.yml), the image is identified by the property *image*.
+    * In [appveyor.yml](https://github.com/electron/electron/blob/main/appveyor.yml), the image is identified by the property *image*.
         * The names used correspond to the *"images"* defined for a build cloud, eg the [libcc-20 cloud](https://windows-ci.electronjs.org/build-clouds/8).
     * Find the image you wish to modify in the build cloud and make note of the **VHD Blob Path** for that image, which is the value for that corresponding key.
         * You will need this URI path to copy into a new image.

--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -65,8 +65,8 @@ origin URLs.
 $ cd src/electron
 $ git remote remove origin
 $ git remote add origin https://github.com/electron/electron
-$ git checkout master
-$ git branch --set-upstream-to=origin/master
+$ git checkout main
+$ git branch --set-upstream-to=origin/main
 $ cd -
 ```
 

--- a/docs/development/electron-vs-nwjs.md
+++ b/docs/development/electron-vs-nwjs.md
@@ -72,4 +72,4 @@ to try NW.js.
 
 [nwjs]: https://nwjs.io/
 [electron-modules]: https://www.npmjs.com/search?q=electron
-[node-bindings]: https://github.com/electron/electron/tree/master/lib/common
+[node-bindings]: https://github.com/electron/electron/tree/main/lib/common

--- a/docs/development/pull-requests.md
+++ b/docs/development/pull-requests.md
@@ -45,10 +45,10 @@ Once you've built the project locally, you're ready to start making changes!
 ### Step 3: Branch
 
 To keep your development environment organized, create local branches to
-hold your work. These should be branched directly off of the `master` branch.
+hold your work. These should be branched directly off of the `main` branch.
 
 ```sh
-$ git checkout -b my-branch -t upstream/master
+$ git checkout -b my-branch -t upstream/main
 ```
 
 ## Making Changes
@@ -134,11 +134,11 @@ Once you have committed your changes, it is a good idea to use `git rebase`
 
 ```sh
 $ git fetch upstream
-$ git rebase upstream/master
+$ git rebase upstream/main
 ```
 
 This ensures that your working branch has the latest changes from `electron/electron`
-master.
+main.
 
 ### Step 7: Test
 
@@ -189,7 +189,7 @@ the requirements below.
 
 Bug fixes and new features should include tests and possibly benchmarks.
 
-Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
+Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
 -->
 ```
 
@@ -222,7 +222,7 @@ seem unfamiliar, refer to this
 #### Approval and Request Changes Workflow
 
 All pull requests require approval from a
-[Code Owner](https://github.com/electron/electron/blob/master/.github/CODEOWNERS)
+[Code Owner](https://github.com/electron/electron/blob/main/.github/CODEOWNERS)
 of the area you modified in order to land. Whenever a maintainer reviews a pull
 request they may request changes. These may be small, such as fixing a typo, or
 may involve substantive changes. Such requests are intended to be helpful, but

--- a/docs/tutorial/fuses.md
+++ b/docs/tutorial/fuses.md
@@ -51,4 +51,4 @@ Somewhere in the Electron binary there will be a sequence of bytes that look lik
 
 To flip a fuse you find its position in the fuse wire and change it to "0" or "1" depending on the state you'd like.
 
-You can view the current schema [here](https://github.com/electron/electron/blob/master/build/fuses/fuses.json5).
+You can view the current schema [here](https://github.com/electron/electron/blob/main/build/fuses/fuses.json5).

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -23,7 +23,7 @@ your responsibility to ensure that the code is not malicious.
 ## Reporting Security Issues
 
 For information on how to properly disclose an Electron vulnerability,
-see [SECURITY.md](https://github.com/electron/electron/tree/master/SECURITY.md)
+see [SECURITY.md](https://github.com/electron/electron/tree/main/SECURITY.md)
 
 ## Chromium Security Issues and Upgrades
 

--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -3,7 +3,7 @@
 ## Finding Support
 
 If you have a security concern,
-please see the [security document](https://github.com/electron/electron/tree/master/SECURITY.md).
+please see the [security document](https://github.com/electron/electron/tree/main/SECURITY.md).
 
 If you're looking for programming help,
 for answers to questions,
@@ -26,7 +26,7 @@ you can interact with the community in these locations:
 * [`electron-pl`](https://electronpl.github.io) *(Poland)*
 
 If you'd like to contribute to Electron,
-see the [contributing document](https://github.com/electron/electron/blob/master/CONTRIBUTING.md).
+see the [contributing document](https://github.com/electron/electron/blob/main/CONTRIBUTING.md).
 
 If you've found a bug in a [supported version](#supported-versions) of Electron,
 please report it with the [issue tracker](../development/issues.md).
@@ -50,13 +50,13 @@ as the 4.2.x series are supported.  We only support the latest minor release
 for each stable release series.  This means that in the case of a security fix
 6.1.x will receive the fix, but we will not release a new version of 6.0.x.
 
-The latest stable release unilaterally receives all fixes from `master`,
+The latest stable release unilaterally receives all fixes from `main`,
 and the version prior to that receives the vast majority of those fixes
 as time and bandwidth warrants. The oldest supported release line will receive
 only security fixes directly.
 
 All supported release lines will accept external pull requests to backport
-fixes previously merged to `master`, though this may be on a case-by-case
+fixes previously merged to `main`, though this may be on a case-by-case
 basis for some older supported lines. All contested decisions around release
 line backports will be resolved by the [Releases Working Group](https://github.com/electron/governance/tree/master/wg-releases) as an agenda item at their weekly meeting the week the backport PR is raised.
 

--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -58,7 +58,7 @@ only security fixes directly.
 All supported release lines will accept external pull requests to backport
 fixes previously merged to `main`, though this may be on a case-by-case
 basis for some older supported lines. All contested decisions around release
-line backports will be resolved by the [Releases Working Group](https://github.com/electron/governance/tree/master/wg-releases) as an agenda item at their weekly meeting the week the backport PR is raised.
+line backports will be resolved by the [Releases Working Group](https://github.com/electron/governance/tree/main/wg-releases) as an agenda item at their weekly meeting the week the backport PR is raised.
 
 When an API is changed or removed in a way that breaks existing functionality, the
 previous functionality will be supported for a minimum of two major versions when


### PR DESCRIPTION
Update references to `master` in the documentation to `main` for `electron/electron` and `electron/governance`.

Notes: none