### PR TITLE
fix: pulling and pushing command incorrect in build instructions gn

### DIFF
--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -65,7 +65,9 @@ origin URLs.
 $ cd src/electron
 $ git remote remove origin
 $ git remote add origin https://github.com/electron/electron
-$ git checkout master
+$ git fetch
+$ git checkout main
+$ git pull --rebase origin main
 $ git branch --set-upstream-to=origin/master
 $ cd -
 ```


### PR DESCRIPTION
#### Description of Change

pulling and pushing command incorrect in build instructions gn

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none

cc: @felixrieseberg @ckerr 
