### PR TITLE
fix: .lldbinit config stale (unavailable)

### DIFF
--- a/docs/development/debugging-instructions-macos.md
+++ b/docs/development/debugging-instructions-macos.md
@@ -26,7 +26,9 @@ you prefer a graphical interface.
 * **.lldbinit**: Create or edit `~/.lldbinit` to allow Chromium code to be properly source-mapped.
 
    ```text
-   command script import ~/electron/src/tools/lldb/lldbinit.py
+   # e.g: ['~/electron/src/tools/lldb']
+   script sys.path[:0] = ['<...path/to/electron/src/tools/lldb>']
+   script import lldbinit
    ```
 
 ## Attaching to and Debugging Electron


### PR DESCRIPTION
#### Description of Change

.lldbinit config stale (unavailable)

see: https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/lldbinit.md

the previous document has no effect

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none

cc: @felixrieseberg @kevinsawicki 