### PR TITLE
fix: BrowserView drag now delegates to the OS when possible

### DIFF
--- a/shell/browser/native_browser_view_mac.mm
+++ b/shell/browser/native_browser_view_mac.mm
@@ -59,7 +59,8 @@ const NSAutoresizingMaskOptions kDefaultAutoResizingMask =
 }
 
 - (BOOL)mouseDownCanMoveWindow {
-  return NO;
+  return
+      [self.window respondsToSelector:@selector(performWindowDragWithEvent:)];
 }
 
 - (BOOL)acceptsFirstMouse:(NSEvent*)event {
@@ -85,16 +86,15 @@ const NSAutoresizingMaskOptions kDefaultAutoResizingMask =
 - (void)mouseDown:(NSEvent*)event {
   [super mouseDown:event];
 
-  if ([self.window respondsToSelector:@selector(performWindowDragWithEvent)]) {
+  if ([self.window respondsToSelector:@selector(performWindowDragWithEvent:)]) {
     // According to Google, using performWindowDragWithEvent:
     // does not generate a NSWindowWillMoveNotification. Hence post one.
     [[NSNotificationCenter defaultCenter]
         postNotificationName:NSWindowWillMoveNotification
                       object:self];
 
-    if (@available(macOS 10.11, *)) {
-      [self.window performWindowDragWithEvent:event];
-    }
+    [self.window performWindowDragWithEvent:event];
+
     return;
   }
 
@@ -106,7 +106,7 @@ const NSAutoresizingMaskOptions kDefaultAutoResizingMask =
 }
 
 - (void)mouseDragged:(NSEvent*)event {
-  if ([self.window respondsToSelector:@selector(performWindowDragWithEvent)]) {
+  if ([self.window respondsToSelector:@selector(performWindowDragWithEvent:)]) {
     return;
   }
 


### PR DESCRIPTION
#### Description of Change
This PR fixes issue #31058, inconsistent window dragging behavior between `BrowserWindow`s and `BrowserView`s. The root cause was a malformed selector, which no `view.window` instances could respond to.

https://www.loom.com/share/3ab47d45a0be4223af88b3377a800cd9

[Guidance appreciated for the Checklist and Release Notes sections. This change should help Electron better implement its current documentation; no new docs or userland education is expected. `npm test` is failing for me on node-gyp rebuilds, so hoping CI can confirm this is safe.]

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue where BrowserView dragging behavior was inconsistent with MacOS window dragging.
