### PR TITLE
refactor: don't expose deprecate as an internal module

### DIFF
--- a/lib/browser/api/crash-reporter.ts
+++ b/lib/browser/api/crash-reporter.ts
@@ -1,4 +1,5 @@
-import { app, deprecate } from 'electron/main';
+import { app } from 'electron/main';
+import { deprecate } from '@electron/internal/common/deprecate';
 
 const binding = process._linkedBinding('electron_browser_crash_reporter');
 

--- a/lib/common/api/module-list.ts
+++ b/lib/common/api/module-list.ts
@@ -2,7 +2,5 @@
 export const commonModuleList: ElectronInternal.ModuleEntry[] = [
   { name: 'clipboard', loader: () => require('./clipboard') },
   { name: 'nativeImage', loader: () => require('./native-image') },
-  { name: 'shell', loader: () => require('./shell') },
-  // The internal modules, invisible unless you know their names.
-  { name: 'deprecate', loader: () => require('./deprecate'), private: true }
+  { name: 'shell', loader: () => require('./shell') }
 ];

--- a/lib/common/define-properties.ts
+++ b/lib/common/define-properties.ts
@@ -9,7 +9,6 @@ export function defineProperties (targetExports: Object, moduleList: ElectronInt
   const descriptors: PropertyDescriptorMap = {};
   for (const module of moduleList) {
     descriptors[module.name] = {
-      enumerable: !module.private,
       get: handleESModule(module.loader)
     };
   }

--- a/lib/common/deprecate.ts
+++ b/lib/common/deprecate.ts
@@ -13,7 +13,7 @@ function warnOnce (oldName: string, newName?: string) {
   };
 }
 
-const deprecate: ElectronInternal.DeprecationUtil = {
+export const deprecate: ElectronInternal.DeprecationUtil = {
   warnOnce,
   setHandler: (handler) => { deprecationHandler = handler; },
   getHandler: () => deprecationHandler,
@@ -131,5 +131,3 @@ const deprecate: ElectronInternal.DeprecationUtil = {
     });
   }
 };
-
-export default deprecate;

--- a/lib/renderer/api/desktop-capturer.ts
+++ b/lib/renderer/api/desktop-capturer.ts
@@ -1,5 +1,5 @@
 import { ipcRendererInternal } from '@electron/internal/renderer/ipc-renderer-internal';
-import deprecate from '@electron/internal/common/api/deprecate';
+import { deprecate } from '@electron/internal/common/deprecate';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
 const { hasSwitch } = process._linkedBinding('electron_common_command_line');

--- a/lib/sandboxed_renderer/api/module-list.ts
+++ b/lib/sandboxed_renderer/api/module-list.ts
@@ -18,12 +18,6 @@ export const moduleList: ElectronInternal.ModuleEntry[] = [
   {
     name: 'webFrame',
     loader: () => require('@electron/internal/renderer/api/web-frame')
-  },
-  // The internal modules, invisible unless you know their names.
-  {
-    name: 'deprecate',
-    loader: () => require('@electron/internal/common/api/deprecate'),
-    private: true
   }
 ];
 


### PR DESCRIPTION
#### Description of Change
Similar to #19139

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none
