### PR TITLE
docs: Fix error in code snippet

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -66,7 +66,7 @@ Your `package.json` file should look something like this:
 Then, install the `electron` package into your app's `devDependencies`.
 
 ```sh npm2yarn
-$ npm install --save-dev electron
+npm install --save-dev electron
 ```
 
 > Note: If you're encountering any issues with installing Electron, please


### PR DESCRIPTION
The code snippet contains a `$` character which leads to an invalid command if users press the *copy* button and try to execute the copied code in their terminal.

#### Release Notes

Notes: none