### PR TITLE
refactor: make `InitWithWebContents` and `InspectableWebContents` take a `unique_ptr`

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -786,10 +786,7 @@ void WebContents::InitWithSessionAndOptions(
     gin::Handle<api::Session> session,
     const gin_helper::Dictionary& options) {
   Observe(owned_web_contents.get());
-  // TODO(zcbenz): Make InitWithWebContents take unique_ptr.
-  // At the time of writing we are going through a refactoring and I don't want
-  // to make other people's work harder.
-  InitWithWebContents(owned_web_contents.release(), session->browser_context(),
+  InitWithWebContents(std::move(owned_web_contents), session->browser_context(),
                       IsGuest());
 
   inspectable_web_contents_->GetView()->SetDelegate(this);
@@ -879,37 +876,40 @@ void WebContents::InitWithExtensionView(v8::Isolate* isolate,
 
   // Allow toggling DevTools for background pages
   Observe(web_contents);
-  InitWithWebContents(web_contents, GetBrowserContext(), IsGuest());
+  InitWithWebContents(std::unique_ptr<content::WebContents>(web_contents),
+                      GetBrowserContext(), IsGuest());
   inspectable_web_contents_->GetView()->SetDelegate(this);
 }
 #endif
 
-void WebContents::InitWithWebContents(content::WebContents* web_contents,
-                                      ElectronBrowserContext* browser_context,
-                                      bool is_guest) {
+void WebContents::InitWithWebContents(
+    std::unique_ptr<content::WebContents> web_contents,
+    ElectronBrowserContext* browser_context,
+    bool is_guest) {
   browser_context_ = browser_context;
   web_contents->SetDelegate(this);
 
 #if BUILDFLAG(ENABLE_PRINTING)
-  PrintPreviewMessageHandler::CreateForWebContents(web_contents);
-  PrintViewManagerElectron::CreateForWebContents(web_contents);
-  printing::CreateCompositeClientIfNeeded(web_contents,
+  PrintPreviewMessageHandler::CreateForWebContents(web_contents.get());
+  PrintViewManagerElectron::CreateForWebContents(web_contents.get());
+  printing::CreateCompositeClientIfNeeded(web_contents.get(),
                                           browser_context->GetUserAgent());
 #endif
 
 #if BUILDFLAG(ENABLE_PDF_VIEWER)
   pdf::PDFWebContentsHelper::CreateForWebContentsWithClient(
-      web_contents, std::make_unique<ElectronPDFWebContentsHelperClient>());
+      web_contents.get(),
+      std::make_unique<ElectronPDFWebContentsHelperClient>());
 #endif
 
   // Determine whether the WebContents is offscreen.
-  auto* web_preferences = WebContentsPreferences::From(web_contents);
+  auto* web_preferences = WebContentsPreferences::From(web_contents.get());
   offscreen_ =
       web_preferences && web_preferences->IsEnabled(options::kOffscreen);
 
   // Create InspectableWebContents.
-  inspectable_web_contents_.reset(new InspectableWebContents(
-      web_contents, browser_context->prefs(), is_guest));
+  inspectable_web_contents_ = std::make_unique<InspectableWebContents>(
+      std::move(web_contents), browser_context->prefs(), is_guest);
   inspectable_web_contents_->SetDelegate(this);
 }
 

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -434,7 +434,7 @@ class WebContents : public gin::Wrappable<WebContents>,
 
   // Creates a InspectableWebContents object and takes ownership of
   // |web_contents|.
-  void InitWithWebContents(content::WebContents* web_contents,
+  void InitWithWebContents(std::unique_ptr<content::WebContents> web_contents,
                            ElectronBrowserContext* browser_context,
                            bool is_guest);
 

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -339,11 +339,11 @@ void InspectableWebContents::RegisterPrefs(PrefRegistrySimple* registry) {
 }
 
 InspectableWebContents::InspectableWebContents(
-    content::WebContents* web_contents,
+    std::unique_ptr<content::WebContents> web_contents,
     PrefService* pref_service,
     bool is_guest)
     : pref_service_(pref_service),
-      web_contents_(web_contents),
+      web_contents_(std::move(web_contents)),
       is_guest_(is_guest),
       view_(CreateInspectableContentsView(this)) {
   const base::Value* bounds_dict = pref_service_->Get(kDevToolsBoundsPref);
@@ -356,9 +356,9 @@ InspectableWebContents::InspectableWebContents(
     }
     if (!IsPointInScreen(devtools_bounds_.origin())) {
       gfx::Rect display;
-      if (!is_guest && web_contents->GetNativeView()) {
+      if (!is_guest && web_contents_->GetNativeView()) {
         display = display::Screen::GetScreen()
-                      ->GetDisplayNearestView(web_contents->GetNativeView())
+                      ->GetDisplayNearestView(web_contents_->GetNativeView())
                       .bounds();
       } else {
         display = display::Screen::GetScreen()->GetPrimaryDisplay().bounds();

--- a/shell/browser/ui/inspectable_web_contents.h
+++ b/shell/browser/ui/inspectable_web_contents.h
@@ -44,7 +44,7 @@ class InspectableWebContents
   static const List& GetAll();
   static void RegisterPrefs(PrefRegistrySimple* pref_registry);
 
-  InspectableWebContents(content::WebContents* web_contents,
+  InspectableWebContents(std::unique_ptr<content::WebContents> web_contents,
                          PrefService* pref_service,
                          bool is_guest);
   ~InspectableWebContents() override;


### PR DESCRIPTION
Backport of https://github.com/electron/electron/pull/30920

See that PR for details.

Notes: none