### PR TITLE
refactor: use native WeakRef instead of v8util.weaklyTrackValue()

### DIFF
--- a/shell/common/api/electron_api_v8_util.cc
+++ b/shell/common/api/electron_api_v8_util.cc
@@ -106,28 +106,6 @@ bool IsSameOrigin(const GURL& l, const GURL& r) {
   return url::Origin::Create(l).IsSameOriginWith(url::Origin::Create(r));
 }
 
-#if DCHECK_IS_ON()
-std::vector<v8::Global<v8::Value>> weakly_tracked_values;
-
-void WeaklyTrackValue(v8::Isolate* isolate, v8::Local<v8::Value> value) {
-  v8::Global<v8::Value> global_value(isolate, value);
-  global_value.SetWeak();
-  weakly_tracked_values.push_back(std::move(global_value));
-}
-
-void ClearWeaklyTrackedValues() {
-  weakly_tracked_values.clear();
-}
-
-std::vector<v8::Local<v8::Value>> GetWeaklyTrackedValues(v8::Isolate* isolate) {
-  std::vector<v8::Local<v8::Value>> locals;
-  for (const auto& value : weakly_tracked_values) {
-    if (!value.IsEmpty())
-      locals.push_back(value.Get(isolate));
-  }
-  return locals;
-}
-
 // This causes a fatal error by creating a circular extension dependency.
 void TriggerFatalErrorForTesting(v8::Isolate* isolate) {
   static const char* aDeps[] = {"B"};
@@ -141,7 +119,6 @@ void TriggerFatalErrorForTesting(v8::Isolate* isolate) {
 void RunUntilIdle() {
   base::RunLoop().RunUntilIdle();
 }
-#endif
 
 void Initialize(v8::Local<v8::Object> exports,
                 v8::Local<v8::Value> unused,
@@ -157,9 +134,6 @@ void Initialize(v8::Local<v8::Object> exports,
                  &RequestGarbageCollectionForTesting);
   dict.SetMethod("isSameOrigin", &IsSameOrigin);
   dict.SetMethod("triggerFatalErrorForTesting", &TriggerFatalErrorForTesting);
-  dict.SetMethod("getWeaklyTrackedValues", &GetWeaklyTrackedValues);
-  dict.SetMethod("clearWeaklyTrackedValues", &ClearWeaklyTrackedValues);
-  dict.SetMethod("weaklyTrackValue", &WeaklyTrackValue);
   dict.SetMethod("runUntilIdle", &RunUntilIdle);
 }
 

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -44,9 +44,6 @@ declare namespace NodeJS {
     setHiddenValue<T>(obj: any, key: string, value: T): void;
     deleteHiddenValue(obj: any, key: string): void;
     requestGarbageCollectionForTesting(): void;
-    weaklyTrackValue(value: any): void;
-    clearWeaklyTrackedValues(): void;
-    getWeaklyTrackedValues(): any[];
     runUntilIdle(): void;
     isSameOrigin(a: string, b: string): boolean;
     triggerFatalErrorForTesting(): void;


### PR DESCRIPTION
#### Description of Change
Follow-up to #31092. It also fixes the release builds, which the previous PR broke.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes
Notes: none
