### PR TITLE
feat: allow setting code cache directory

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -872,7 +872,7 @@ registered.
 
 * `path` String - Absolute path to store the v8 generated JS code cache from the renderer.
 
-Sets the directory to store the generated JS [code cache](https://v8.dev/blog/code-caching-for-devs) for this session. The directory is not required to be created by the user before this call, the runtime will create if it does not exit otherwise will use the existing directory. If directory cannot be created, then code cache will not be used and all operations related to code cache will fail silently inside the runtime. By default, the directory will be `Code Cache` under the
+Sets the directory to store the generated JS [code cache](https://v8.dev/blog/code-caching-for-devs) for this session. The directory is not required to be created by the user before this call, the runtime will create if it does not exist otherwise will use the existing directory. If directory cannot be created, then code cache will not be used and all operations related to code cache will fail silently inside the runtime. By default, the directory will be `Code Cache` under the
 respective user data folder.
 
 #### `ses.clearCodeCaches(options)`

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -868,6 +868,21 @@ this session just before normal `preload` scripts run.
 Returns `string[]` an array of paths to preload scripts that have been
 registered.
 
+#### `ses.setCodeCachePath(path)`
+
+* `path` String - The Code cache location.
+
+Sets code cache directory. By default, the directory will be `Code Cache` under the
+respective user data folder.
+
+#### `ses.clearCodeCaches()`
+
+* `options` Object
+  * `urls` String[] (optional) - An array of url corresponding to the resource that needs to
+    be removed. If the list is empty then all entries in the cache will be removed.
+
+Returns `Promise<void>` - resolves when the code cache clear operation is complete.
+
 #### `ses.setSpellCheckerEnabled(enable)`
 
 * `enable` boolean

--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -870,16 +870,15 @@ registered.
 
 #### `ses.setCodeCachePath(path)`
 
-* `path` String - The Code cache location.
+* `path` String - Absolute path to store the v8 generated JS code cache from the renderer.
 
-Sets code cache directory. By default, the directory will be `Code Cache` under the
+Sets the directory to store the generated JS [code cache](https://v8.dev/blog/code-caching-for-devs) for this session. The directory is not required to be created by the user before this call, the runtime will create if it does not exit otherwise will use the existing directory. If directory cannot be created, then code cache will not be used and all operations related to code cache will fail silently inside the runtime. By default, the directory will be `Code Cache` under the
 respective user data folder.
 
-#### `ses.clearCodeCaches()`
+#### `ses.clearCodeCaches(options)`
 
 * `options` Object
-  * `urls` String[] (optional) - An array of url corresponding to the resource that needs to
-    be removed. If the list is empty then all entries in the cache will be removed.
+  * `urls` String[] (optional) - An array of url corresponding to the resource whose generated code cache needs to be removed. If the list is empty then all entries in the cache directory will be removed.
 
 Returns `Promise<void>` - resolves when the code cache clear operation is complete.
 

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -28,6 +28,7 @@
 #include "components/proxy_config/proxy_config_dictionary.h"
 #include "components/proxy_config/proxy_config_pref_names.h"
 #include "components/proxy_config/proxy_prefs.h"
+#include "content/browser/code_cache/generated_code_cache_context.h"  // nogncheck
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/download_item_utils.h"
@@ -976,6 +977,40 @@ v8::Local<v8::Value> Session::GetPath(v8::Isolate* isolate) {
   return gin::ConvertToV8(isolate, browser_context_->GetPath());
 }
 
+void Session::SetCodeCachePath(const base::FilePath& code_cache_path) {
+  auto* storage_partition = browser_context_->GetDefaultStoragePartition();
+  auto* code_cache_context = storage_partition->GetGeneratedCodeCacheContext();
+  if (code_cache_context && !code_cache_path.empty()) {
+    code_cache_context->Initialize(
+        code_cache_path, 0 /* allows disk_cache to choose the size */);
+  }
+}
+
+v8::Local<v8::Promise> Session::ClearCodeCaches(
+    const gin_helper::Dictionary& options) {
+  auto* isolate = JavascriptEnvironment::GetIsolate();
+  gin_helper::Promise<void> promise(isolate);
+  v8::Local<v8::Promise> handle = promise.GetHandle();
+
+  std::set<GURL> url_list;
+  base::RepeatingCallback<bool(const GURL&)> url_matcher = base::NullCallback();
+  if (options.Get("urls", &url_list) && !url_list.empty()) {
+    url_matcher = base::BindRepeating(
+        [](const std::set<GURL>& url_list, const GURL& url) {
+          auto it = url_list.find(url);
+          return it != url_list.end();
+        },
+        url_list);
+  }
+
+  browser_context_->GetDefaultStoragePartition()->ClearCodeCaches(
+      base::Time(), base::Time::Max(), url_matcher,
+      base::BindOnce(gin_helper::Promise<void>::ResolvePromise,
+                     std::move(promise)));
+
+  return handle;
+}
+
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
 base::Value Session::GetSpellCheckerLanguages() {
   return browser_context_->prefs()
@@ -1203,6 +1238,8 @@ gin::ObjectTemplateBuilder Session::GetObjectTemplateBuilder(
       .SetMethod("preconnect", &Session::Preconnect)
       .SetMethod("closeAllConnections", &Session::CloseAllConnections)
       .SetMethod("getStoragePath", &Session::GetPath)
+      .SetMethod("setCodeCachePath", &Session::SetCodeCachePath)
+      .SetMethod("clearCodeCaches", &Session::ClearCodeCaches)
       .SetProperty("cookies", &Session::Cookies)
       .SetProperty("netLog", &Session::NetLog)
       .SetProperty("protocol", &Session::Protocol)

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -1003,8 +1003,7 @@ v8::Local<v8::Promise> Session::ClearCodeCaches(
   if (options.Get("urls", &url_list) && !url_list.empty()) {
     url_matcher = base::BindRepeating(
         [](const std::set<GURL>& url_list, const GURL& url) {
-          auto it = url_list.find(url);
-          return it != url_list.end();
+          return base::Contains(url_list, url);
         },
         url_list);
   }

--- a/shell/browser/api/electron_api_session.cc
+++ b/shell/browser/api/electron_api_session.cc
@@ -977,10 +977,16 @@ v8::Local<v8::Value> Session::GetPath(v8::Isolate* isolate) {
   return gin::ConvertToV8(isolate, browser_context_->GetPath());
 }
 
-void Session::SetCodeCachePath(const base::FilePath& code_cache_path) {
+void Session::SetCodeCachePath(gin::Arguments* args) {
+  base::FilePath code_cache_path;
   auto* storage_partition = browser_context_->GetDefaultStoragePartition();
   auto* code_cache_context = storage_partition->GetGeneratedCodeCacheContext();
-  if (code_cache_context && !code_cache_path.empty()) {
+  if (code_cache_context) {
+    if (!args->GetNext(&code_cache_path) || !code_cache_path.IsAbsolute()) {
+      args->ThrowTypeError(
+          "Absolute path must be provided to store code cache.");
+      return;
+    }
     code_cache_context->Initialize(
         code_cache_path, 0 /* allows disk_cache to choose the size */);
   }

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -127,7 +127,7 @@ class Session : public gin::Wrappable<Session>,
   void Preconnect(const gin_helper::Dictionary& options, gin::Arguments* args);
   v8::Local<v8::Promise> CloseAllConnections();
   v8::Local<v8::Value> GetPath(v8::Isolate* isolate);
-  void SetCodeCachePath(const base::FilePath& code_cache_path);
+  void SetCodeCachePath(gin::Arguments* args);
   v8::Local<v8::Promise> ClearCodeCaches(const gin_helper::Dictionary& options);
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
   base::Value GetSpellCheckerLanguages();

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -127,6 +127,8 @@ class Session : public gin::Wrappable<Session>,
   void Preconnect(const gin_helper::Dictionary& options, gin::Arguments* args);
   v8::Local<v8::Promise> CloseAllConnections();
   v8::Local<v8::Value> GetPath(v8::Isolate* isolate);
+  void SetCodeCachePath(const base::FilePath& code_cache_path);
+  v8::Local<v8::Promise> ClearCodeCaches(const gin_helper::Dictionary& options);
 #if BUILDFLAG(ENABLE_BUILTIN_SPELLCHECKER)
   base::Value GetSpellCheckerLanguages();
   void SetSpellCheckerLanguages(gin_helper::ErrorThrower thrower,

--- a/spec-main/api-session-spec.ts
+++ b/spec-main/api-session-spec.ts
@@ -1121,6 +1121,20 @@ describe('session module', () => {
     });
   });
 
+  describe('session.setCodeCachePath()', () => {
+    it('throws when relative or empty path is provided', () => {
+      expect(() => {
+        session.defaultSession.setCodeCachePath('../fixtures');
+      }).to.throw('Absolute path must be provided to store code cache.');
+      expect(() => {
+        session.defaultSession.setCodeCachePath('');
+      }).to.throw('Absolute path must be provided to store code cache.');
+      expect(() => {
+        session.defaultSession.setCodeCachePath(path.join(app.getPath('userData'), 'test-code-cache'));
+      }).to.not.throw();
+    });
+  });
+
   describe('ses.setSSLConfig()', () => {
     it('can disable cipher suites', async () => {
       const ses = session.fromPartition('' + Math.random());


### PR DESCRIPTION
#### Description of Change
Add `ses.setCodeCachePath()` API for setting code cache directory.

When transitioning to a node-free renderer environment apps which previously relied on creating v8 cached data via the [vm](https://nodejs.org/dist/latest-v14.x/docs/api/vm.html) module would store the data at version based locations of the format like `<user-data-dir>/<commit-sha-or-version>` so that the cache can be invalidated on updates. When relying on blink to now handle the cache creation and invalidation, this api is useful to serve as a hard reset when the cache goes into a non-recoverable state.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Added `ses.setCodeCachePath()` API for setting code cache directory.