### PR TITLE
build: Explicitly pass the project root to cpplint.py

### DIFF
--- a/script/lint.js
+++ b/script/lint.js
@@ -34,6 +34,7 @@ function spawnAndCheckExitCode (cmd, args, opts) {
 }
 
 function cpplint (args) {
+  args.unshift(`--project_root=${SOURCE_ROOT}`);
   const result = childProcess.spawnSync(IS_WINDOWS ? 'cpplint.bat' : 'cpplint.py', args, { encoding: 'utf8', shell: true });
   // cpplint.py writes EVERYTHING to stderr, including status messages
   if (result.stderr) {


### PR DESCRIPTION
In order to validate that header guards match the corresponding file
names, `cpplint.py` determines the root of the project based on the
presence of a `.git` directory.

For space reasons, our Electron.js fork running on CircleCI deletes the
`.git` directories as upstream Electron.js does here:

https://github.com/electron/electron/blob/cd09a5436544ca0610542bc5b14adf992a9d9df2/.circleci/config.yml#L426

If the C++ linter is ran *after* deleting git directories, `cpplint.py`
gets the root wrong and throws errors for every single header guard in
the project.

Making sure we run the C++ linter *before* deleting git directories
fixes the issue. In any case, this commit always manually passes
`--project_root` to `cpplint.py` so that the implicit default is
explicitly declared and saves some confusion for the next person hitting
this.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist

- [x] `npm test` passes

#### Release Notes

Notes: none
