### PR TITLE
fix: ensure set vibrancy with invalid value is a no-op

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1380,29 +1380,6 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
     return;
   }
 
-  if (vibrantView == nil) {
-    vibrantView = [[[NSVisualEffectView alloc]
-        initWithFrame:[[window_ contentView] bounds]] autorelease];
-    [window_ setVibrantView:vibrantView];
-
-    [vibrantView setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
-    [vibrantView setBlendingMode:NSVisualEffectBlendingModeBehindWindow];
-
-    if (visual_effect_state_ == VisualEffectState::kActive) {
-      [vibrantView setState:NSVisualEffectStateActive];
-    } else if (visual_effect_state_ == VisualEffectState::kInactive) {
-      [vibrantView setState:NSVisualEffectStateInactive];
-    } else {
-      [vibrantView setState:NSVisualEffectStateFollowsWindowActiveState];
-    }
-
-    [[window_ contentView] addSubview:vibrantView
-                           positioned:NSWindowBelow
-                           relativeTo:nil];
-
-    UpdateVibrancyRadii(IsFullscreen());
-  }
-
   std::string dep_warn = " has been deprecated and removed as of macOS 10.15.";
   node::Environment* env =
       node::Environment::GetCurrent(JavascriptEnvironment::GetIsolate());
@@ -1466,6 +1443,31 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
 
   if (vibrancyType) {
     vibrancy_type_ = type;
+
+    if (vibrantView == nil) {
+      vibrantView = [[[NSVisualEffectView alloc]
+          initWithFrame:[[window_ contentView] bounds]] autorelease];
+      [window_ setVibrantView:vibrantView];
+
+      [vibrantView
+          setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
+      [vibrantView setBlendingMode:NSVisualEffectBlendingModeBehindWindow];
+
+      if (visual_effect_state_ == VisualEffectState::kActive) {
+        [vibrantView setState:NSVisualEffectStateActive];
+      } else if (visual_effect_state_ == VisualEffectState::kInactive) {
+        [vibrantView setState:NSVisualEffectStateInactive];
+      } else {
+        [vibrantView setState:NSVisualEffectStateFollowsWindowActiveState];
+      }
+
+      [[window_ contentView] addSubview:vibrantView
+                             positioned:NSWindowBelow
+                             relativeTo:nil];
+
+      UpdateVibrancyRadii(IsFullscreen());
+    }
+
     [vibrantView setMaterial:vibrancyType];
   }
 }

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1329,10 +1329,9 @@ void NativeWindowMac::SetAutoHideCursor(bool auto_hide) {
 }
 
 void NativeWindowMac::UpdateVibrancyRadii(bool fullscreen) {
-  NSView* vibrant_view = [window_ vibrantView];
-  NSVisualEffectView* effect_view = (NSVisualEffectView*)vibrant_view;
+  NSVisualEffectView* vibrantView = [window_ vibrantView];
 
-  if (effect_view != nil && !vibrancy_type_.empty()) {
+  if (vibrantView != nil && !vibrancy_type_.empty()) {
     const bool no_rounded_corner =
         [window_ styleMask] & NSWindowStyleMaskFullSizeContentView;
     if (!has_frame() && !is_modal() && !no_rounded_corner) {
@@ -1362,43 +1361,42 @@ void NativeWindowMac::UpdateVibrancyRadii(bool fullscreen) {
 
       [maskImage setCapInsets:NSEdgeInsetsMake(radius, radius, radius, radius)];
       [maskImage setResizingMode:NSImageResizingModeStretch];
-      [effect_view setMaskImage:maskImage];
+      [vibrantView setMaskImage:maskImage];
       [window_ setCornerMask:maskImage];
     }
   }
 }
 
 void NativeWindowMac::SetVibrancy(const std::string& type) {
-  NSView* vibrant_view = [window_ vibrantView];
+  NSVisualEffectView* vibrantView = [window_ vibrantView];
 
   if (type.empty()) {
-    if (vibrant_view == nil)
+    if (vibrantView == nil)
       return;
 
-    [vibrant_view removeFromSuperview];
+    [vibrantView removeFromSuperview];
     [window_ setVibrantView:nil];
 
     return;
   }
 
-  NSVisualEffectView* effect_view = (NSVisualEffectView*)vibrant_view;
-  if (effect_view == nil) {
-    effect_view = [[[NSVisualEffectView alloc]
+  if (vibrantView == nil) {
+    vibrantView = [[[NSVisualEffectView alloc]
         initWithFrame:[[window_ contentView] bounds]] autorelease];
-    [window_ setVibrantView:(NSView*)effect_view];
+    [window_ setVibrantView:vibrantView];
 
-    [effect_view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
-    [effect_view setBlendingMode:NSVisualEffectBlendingModeBehindWindow];
+    [vibrantView setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
+    [vibrantView setBlendingMode:NSVisualEffectBlendingModeBehindWindow];
 
     if (visual_effect_state_ == VisualEffectState::kActive) {
-      [effect_view setState:NSVisualEffectStateActive];
+      [vibrantView setState:NSVisualEffectStateActive];
     } else if (visual_effect_state_ == VisualEffectState::kInactive) {
-      [effect_view setState:NSVisualEffectStateInactive];
+      [vibrantView setState:NSVisualEffectStateInactive];
     } else {
-      [effect_view setState:NSVisualEffectStateFollowsWindowActiveState];
+      [vibrantView setState:NSVisualEffectStateFollowsWindowActiveState];
     }
 
-    [[window_ contentView] addSubview:effect_view
+    [[window_ contentView] addSubview:vibrantView
                            positioned:NSWindowBelow
                            relativeTo:nil];
 
@@ -1468,7 +1466,7 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
 
   if (vibrancyType) {
     vibrancy_type_ = type;
-    [effect_view setMaterial:vibrancyType];
+    [vibrantView setMaterial:vibrancyType];
   }
 }
 

--- a/shell/browser/ui/cocoa/electron_ns_window.h
+++ b/shell/browser/ui/cocoa/electron_ns_window.h
@@ -35,7 +35,7 @@ class ScopedDisableResize {
 @property BOOL enableLargerThanScreen;
 @property BOOL disableAutoHideCursor;
 @property BOOL disableKeyOrMainWindow;
-@property(nonatomic, retain) NSView* vibrantView;
+@property(nonatomic, retain) NSVisualEffectView* vibrantView;
 @property(nonatomic, retain) NSImage* cornerMask;
 - (id)initWithShell:(electron::NativeWindowMac*)shell
           styleMask:(NSUInteger)styleMask;


### PR DESCRIPTION
Backport of #29795.

Also includes https://github.com/electron/electron/pull/29724 to allow  #29795 to apply cleanly.

See that PR for details.

Notes: none