### PR TITLE
docs: dialog is not defined

### DIFF
--- a/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/main.js
+++ b/docs/fiddles/system/protocol-handler/launch-app-from-URL-in-another-app/main.js
@@ -1,5 +1,5 @@
 // Modules to control application life and create native browser window
-const { app, BrowserWindow, ipcMain, shell } = require('electron')
+const { app, BrowserWindow, ipcMain, shell, dialog } = require('electron')
 const path = require('path')
 
 let mainWindow;


### PR DESCRIPTION
#### Description of Change
Corrects the following error in Electron Fiddle:

```
Uncaught Exception:
ReferenceError: dialog is not defined
...
```

#### Release Notes

Notes: none