### PR TITLE
chore: refactor persisting permission granted to serial ports

### DIFF
--- a/docs/tutorial/devices.md
+++ b/docs/tutorial/devices.md
@@ -84,13 +84,22 @@ There are several additional APIs for working with the Web Serial API:
   and [`serial-port-removed`](../api/session.md#event-serial-port-removed) events
   on the Session can be used to handle devices being plugged in or unplugged during the
   `navigator.serial.requestPort` process.
+* [`ses.setDevicePermissionHandler(handler)`](../api/session.md#sessetdevicepermissionhandlerhandler)
+  can be used to provide default permissioning to devices without first calling
+  for permission to devices via `navigator.serial.requestPort`.  Additionally,
+  the default behavior of Electron is to store granted device permision through
+  the lifetime of the corresponding WebContents.  If longer term storage is
+  needed, a developer can store granted device permissions (eg when handling
+  the `select-serial-port` event) and then read from that storage with
+  `setDevicePermissionHandler`.
 * [`ses.setPermissionCheckHandler(handler)`](../api/session.md#sessetpermissioncheckhandlerhandler)
   can be used to disable serial access for specific origins.
 
 ### Example
 
 This example demonstrates an Electron application that automatically selects
-the first available Arduino Uno serial device (if connected) through
+serial devices through [`ses.setDevicePermissionHandler(handler)`](../api/session.md#sessetdevicepermissionhandlerhandler)
+as well as demonstrating selecting the first available Arduino Uno serial device (if connected) through
 [`select-serial-port` event on the Session](../api/session.md#event-select-serial-port)
 when the `Test Web Serial` button is clicked.
 

--- a/shell/browser/electron_browser_context.cc
+++ b/shell/browser/electron_browser_context.cc
@@ -8,8 +8,6 @@
 
 #include <utility>
 
-#include <vector>
-
 #include "base/barrier_closure.h"
 #include "base/base_paths.h"
 #include "base/command_line.h"
@@ -94,9 +92,6 @@ std::string MakePartitionName(const std::string& input) {
 }
 
 }  // namespace
-
-const char kSerialGrantedDevicesPref[] =
-    "profile.content_settings.exceptions.serial-chooser-data";
 
 // static
 ElectronBrowserContext::BrowserContextMap&
@@ -194,7 +189,6 @@ void ElectronBrowserContext::InitPrefs() {
   registry->RegisterFilePathPref(prefs::kDownloadDefaultDirectory,
                                  download_dir);
   registry->RegisterDictionaryPref(prefs::kDevToolsFileSystemPaths);
-  registry->RegisterDictionaryPref(kSerialGrantedDevicesPref);
   InspectableWebContents::RegisterPrefs(registry.get());
   MediaDeviceIDSalt::RegisterPrefs(registry.get());
   ZoomLevelDelegate::RegisterPrefs(registry.get());
@@ -413,54 +407,6 @@ void ElectronBrowserContext::SetSSLConfig(network::mojom::SSLConfigPtr config) {
 void ElectronBrowserContext::SetSSLConfigClient(
     mojo::Remote<network::mojom::SSLConfigClient> client) {
   ssl_config_client_ = std::move(client);
-}
-
-void ElectronBrowserContext::GrantObjectPermission(
-    const url::Origin& origin,
-    base::Value object,
-    const std::string& pref_key) {
-  std::string origin_string = origin.Serialize();
-  DictionaryPrefUpdate update(prefs(), pref_key);
-  base::Value* const current_objects = update.Get();
-  if (!current_objects || !current_objects->is_dict()) {
-    base::ListValue objects_for_origin;
-    objects_for_origin.Append(std::move(object));
-    base::DictionaryValue objects_by_origin;
-    objects_by_origin.SetPath(origin_string, std::move(objects_for_origin));
-    prefs()->Set(pref_key, std::move(objects_by_origin));
-  } else {
-    base::Value* const objects_mutable =
-        current_objects->FindListKey(origin_string);
-    if (objects_mutable) {
-      base::Value::ListStorage objects = std::move(*objects_mutable).TakeList();
-      objects.push_back(std::move(object));
-      *objects_mutable = base::Value(std::move(objects));
-    } else {
-      base::Value new_objects(base::Value::Type::LIST);
-      new_objects.Append(std::move(object));
-      current_objects->SetKey(origin_string, std::move(new_objects));
-    }
-  }
-}
-
-std::vector<std::unique_ptr<base::Value>>
-ElectronBrowserContext::GetGrantedObjects(const url::Origin& origin,
-                                          const std::string& pref_key) {
-  auto* current_objects = prefs()->Get(pref_key);
-  if (!current_objects || !current_objects->is_dict()) {
-    return {};
-  }
-
-  const base::Value* objects_for_origin =
-      current_objects->FindPath(origin.Serialize());
-  if (!objects_for_origin)
-    return {};
-
-  std::vector<std::unique_ptr<base::Value>> results;
-  for (const auto& object : objects_for_origin->GetList())
-    results.push_back(std::make_unique<base::Value>(object.Clone()));
-
-  return results;
 }
 
 // static

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -8,7 +8,6 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "base/memory/weak_ptr.h"
 #include "chrome/browser/predictors/preconnect_manager.h"
@@ -46,9 +45,6 @@ class CookieChangeNotifier;
 class ResolveProxyHelper;
 class WebViewManager;
 class ProtocolRegistry;
-
-// Preference keys for device apis
-extern const char kSerialGrantedDevicesPref[];
 
 class ElectronBrowserContext : public content::BrowserContext {
  public:
@@ -143,19 +139,6 @@ class ElectronBrowserContext : public content::BrowserContext {
   void SetSSLConfig(network::mojom::SSLConfigPtr config);
   network::mojom::SSLConfigPtr GetSSLConfig();
   void SetSSLConfigClient(mojo::Remote<network::mojom::SSLConfigClient> client);
-
-  // Grants |origin| access to |object| by writing it into the browser context.
-  // To be used in place of ObjectPermissionContextBase::GrantObjectPermission.
-  void GrantObjectPermission(const url::Origin& origin,
-                             base::Value object,
-                             const std::string& pref_key);
-
-  // Returns the list of objects that |origin| has been granted permission to
-  // access. To be used in place of
-  // ObjectPermissionContextBase::GetGrantedObjects.
-  std::vector<std::unique_ptr<base::Value>> GetGrantedObjects(
-      const url::Origin& origin,
-      const std::string& pref_key);
 
   ~ElectronBrowserContext() override;
 

--- a/shell/browser/serial/electron_serial_delegate.cc
+++ b/shell/browser/serial/electron_serial_delegate.cc
@@ -60,7 +60,7 @@ bool ElectronSerialDelegate::HasPortPermission(
   auto* chooser_context =
       SerialChooserContextFactory::GetForBrowserContext(browser_context);
   return chooser_context->HasPortPermission(
-      web_contents->GetMainFrame()->GetLastCommittedOrigin(), port);
+      web_contents->GetMainFrame()->GetLastCommittedOrigin(), port, frame);
 }
 
 device::mojom::SerialPortManager* ElectronSerialDelegate::GetPortManager(

--- a/shell/browser/serial/serial_chooser_context.h
+++ b/shell/browser/serial/serial_chooser_context.h
@@ -29,19 +29,35 @@ class Value;
 
 namespace electron {
 
+extern const char kHidVendorIdKey[];
+extern const char kHidProductIdKey[];
+
+#if defined(OS_WIN)
+extern const char kDeviceInstanceIdKey[];
+#else
+extern const char kVendorIdKey[];
+extern const char kProductIdKey[];
+extern const char kSerialNumberKey[];
+#if defined(OS_MAC)
+extern const char kUsbDriverKey[];
+#endif  // defined(OS_MAC)
+#endif  // defined(OS_WIN)
+
 class SerialChooserContext : public KeyedService,
                              public device::mojom::SerialPortManagerClient {
  public:
   using PortObserver = content::SerialDelegate::Observer;
 
-  explicit SerialChooserContext(ElectronBrowserContext* browser_context);
+  SerialChooserContext();
   ~SerialChooserContext() override;
 
   // Serial-specific interface for granting and checking permissions.
   void GrantPortPermission(const url::Origin& origin,
-                           const device::mojom::SerialPortInfo& port);
+                           const device::mojom::SerialPortInfo& port,
+                           content::RenderFrameHost* render_frame_host);
   bool HasPortPermission(const url::Origin& origin,
-                         const device::mojom::SerialPortInfo& port);
+                         const device::mojom::SerialPortInfo& port,
+                         content::RenderFrameHost* render_frame_host);
   static bool CanStorePersistentEntry(
       const device::mojom::SerialPortInfo& port);
 
@@ -61,8 +77,6 @@ class SerialChooserContext : public KeyedService,
   void SetUpPortManagerConnection(
       mojo::PendingRemote<device::mojom::SerialPortManager> manager);
   void OnPortManagerConnectionError();
-
-  ElectronBrowserContext* browser_context_;
 
   // Tracks the set of ports to which an origin has access to.
   std::map<url::Origin, std::set<base::UnguessableToken>> ephemeral_ports_;

--- a/shell/browser/serial/serial_chooser_context_factory.cc
+++ b/shell/browser/serial/serial_chooser_context_factory.cc
@@ -19,9 +19,7 @@ SerialChooserContextFactory::~SerialChooserContextFactory() = default;
 
 KeyedService* SerialChooserContextFactory::BuildServiceInstanceFor(
     content::BrowserContext* context) const {
-  auto* browser_context =
-      static_cast<electron::ElectronBrowserContext*>(context);
-  return new SerialChooserContext(browser_context);
+  return new SerialChooserContext();
 }
 
 // static

--- a/shell/browser/serial/serial_chooser_controller.cc
+++ b/shell/browser/serial/serial_chooser_controller.cc
@@ -67,7 +67,8 @@ SerialChooserController::SerialChooserController(
     : WebContentsObserver(web_contents),
       filters_(std::move(filters)),
       callback_(std::move(callback)),
-      serial_delegate_(serial_delegate) {
+      serial_delegate_(serial_delegate),
+      render_frame_host_id_(render_frame_host->GetGlobalId()) {
   origin_ = web_contents->GetMainFrame()->GetLastCommittedOrigin();
 
   chooser_context_ = SerialChooserContextFactory::GetForBrowserContext(
@@ -124,7 +125,8 @@ void SerialChooserController::OnDeviceChosen(const std::string& port_id) {
           return ptr->token.ToString() == port_id;
         });
     if (it != ports_.end()) {
-      chooser_context_->GrantPortPermission(origin_, *it->get());
+      auto* rfh = content::RenderFrameHost::FromID(render_frame_host_id_);
+      chooser_context_->GrantPortPermission(origin_, *it->get(), rfh);
       RunCallback(it->Clone());
     } else {
       RunCallback(/*port=*/nullptr);

--- a/shell/browser/serial/serial_chooser_controller.h
+++ b/shell/browser/serial/serial_chooser_controller.h
@@ -10,6 +10,7 @@
 
 #include "base/macros.h"
 #include "base/memory/weak_ptr.h"
+#include "content/public/browser/global_routing_id.h"
 #include "content/public/browser/serial_chooser.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_contents_observer.h"
@@ -60,6 +61,8 @@ class SerialChooserController final : public SerialChooserContext::PortObserver,
   std::vector<device::mojom::SerialPortInfoPtr> ports_;
 
   base::WeakPtr<ElectronSerialDelegate> serial_delegate_;
+
+  content::GlobalRenderFrameHostId render_frame_host_id_;
 
   base::WeakPtrFactory<SerialChooserController> weak_factory_{this};
 

--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -190,6 +190,24 @@ bool WebContentsPermissionHelper::CheckSerialAccessPermission(
       static_cast<content::PermissionType>(PermissionType::SERIAL), &details);
 }
 
+bool WebContentsPermissionHelper::CheckSerialPortPermission(
+    const url::Origin& origin,
+    base::Value device,
+    content::RenderFrameHost* render_frame_host) const {
+  return CheckDevicePermission(
+      static_cast<content::PermissionType>(PermissionType::SERIAL), origin,
+      &device, render_frame_host);
+}
+
+void WebContentsPermissionHelper::GrantSerialPortPermission(
+    const url::Origin& origin,
+    base::Value device,
+    content::RenderFrameHost* render_frame_host) const {
+  return GrantDevicePermission(
+      static_cast<content::PermissionType>(PermissionType::SERIAL), origin,
+      &device, render_frame_host);
+}
+
 bool WebContentsPermissionHelper::CheckHIDAccessPermission(
     const url::Origin& embedding_origin) const {
   base::DictionaryValue details;

--- a/shell/browser/web_contents_permission_helper.h
+++ b/shell/browser/web_contents_permission_helper.h
@@ -42,6 +42,14 @@ class WebContentsPermissionHelper
   bool CheckMediaAccessPermission(const GURL& security_origin,
                                   blink::mojom::MediaStreamType type) const;
   bool CheckSerialAccessPermission(const url::Origin& embedding_origin) const;
+  bool CheckSerialPortPermission(
+      const url::Origin& origin,
+      base::Value device,
+      content::RenderFrameHost* render_frame_host) const;
+  void GrantSerialPortPermission(
+      const url::Origin& origin,
+      base::Value device,
+      content::RenderFrameHost* render_frame_host) const;
   bool CheckHIDAccessPermission(const url::Origin& embedding_origin) const;
   bool CheckHIDDevicePermission(
       const url::Origin& origin,


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
This is a refactor of #30209 to use the same permissioning that was implemented for [WebHID](#21311).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->Changed Web Serial to use `ses.setDevicePermissionHandler` to allow developers more control over Web Serial permissioning.
