### PR TITLE
chore: remove redundant 10.11 @available checks

### DIFF
--- a/shell/browser/mac/electron_application.mm
+++ b/shell/browser/mac/electron_application.mm
@@ -99,10 +99,8 @@ inline void dispatch_sync_main(dispatch_block_t block) {
 }
 
 - (void)resignCurrentActivity {
-  if (@available(macOS 10.11, *)) {
-    if (currentActivity_)
-      [currentActivity_ resignCurrent];
-  }
+  if (currentActivity_)
+    [currentActivity_ resignCurrent];
 }
 
 - (void)updateCurrentActivity:(NSString*)type

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1408,24 +1408,21 @@ void NativeWindowMac::SetVibrancy(const std::string& type) {
     vibrancyType = NSVisualEffectMaterialTitlebar;
   }
 
-  if (@available(macOS 10.11, *)) {
-    if (type == "selection") {
-      vibrancyType = NSVisualEffectMaterialSelection;
-    } else if (type == "menu") {
-      vibrancyType = NSVisualEffectMaterialMenu;
-    } else if (type == "popover") {
-      vibrancyType = NSVisualEffectMaterialPopover;
-    } else if (type == "sidebar") {
-      vibrancyType = NSVisualEffectMaterialSidebar;
-    } else if (type == "medium-light") {
-      EmitWarning(env, "NSVisualEffectMaterialMediumLight" + dep_warn,
-                  "electron");
-      vibrancyType = NSVisualEffectMaterialMediumLight;
-    } else if (type == "ultra-dark") {
-      EmitWarning(env, "NSVisualEffectMaterialUltraDark" + dep_warn,
-                  "electron");
-      vibrancyType = NSVisualEffectMaterialUltraDark;
-    }
+  if (type == "selection") {
+    vibrancyType = NSVisualEffectMaterialSelection;
+  } else if (type == "menu") {
+    vibrancyType = NSVisualEffectMaterialMenu;
+  } else if (type == "popover") {
+    vibrancyType = NSVisualEffectMaterialPopover;
+  } else if (type == "sidebar") {
+    vibrancyType = NSVisualEffectMaterialSidebar;
+  } else if (type == "medium-light") {
+    EmitWarning(env, "NSVisualEffectMaterialMediumLight" + dep_warn,
+                "electron");
+    vibrancyType = NSVisualEffectMaterialMediumLight;
+  } else if (type == "ultra-dark") {
+    EmitWarning(env, "NSVisualEffectMaterialUltraDark" + dep_warn, "electron");
+    vibrancyType = NSVisualEffectMaterialUltraDark;
   }
 
   if (@available(macOS 10.14, *)) {

--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -125,16 +125,13 @@
                   range:NSMakeRange(0, [attributed_title length])];
     }
   } else if ([font_type isEqualToString:@"monospacedDigit"]) {
-    if (@available(macOS 10.11, *)) {
-      NSDictionary* attributes = @{
-        NSFontAttributeName :
-            [NSFont monospacedDigitSystemFontOfSize:existing_size
-                                             weight:NSFontWeightRegular]
-      };
-      [attributed_title
-          addAttributes:attributes
-                  range:NSMakeRange(0, [attributed_title length])];
-    }
+    NSDictionary* attributes = @{
+      NSFontAttributeName :
+          [NSFont monospacedDigitSystemFontOfSize:existing_size
+                                           weight:NSFontWeightRegular]
+    };
+    [attributed_title addAttributes:attributes
+                              range:NSMakeRange(0, [attributed_title length])];
   }
 
   // Set title


### PR DESCRIPTION
#### Description of Change

The minimum supported deploy target is 10.11, so these are no longer necessary.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none