### PR TITLE
feat: add webContents.getMediaSourceId() method

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1935,6 +1935,14 @@ Returns `Integer` - The Chromium internal `pid` of the associated renderer. Can
 be compared to the `frameProcessId` passed by frame specific navigation events
 (e.g. `did-frame-navigate`)
 
+#### `contents.getMediaSourceId(requestWebContents)`
+
+* `requestWebContents` WebContents - Web contents that the id will be registered to.
+
+Returns `String` - The identifier of a WebContents stream. This identifier can be used
+with `navigator.mediaDevices.getUserMedia` using a `chromeMediaSource` of `tab`.
+The identifier is restricted to the web contents that it is registered to and is only valid for 10 seconds.
+
 #### `contents.takeHeapSnapshot(filePath)`
 
 * `filePath` String - Path to the output file.

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -393,6 +393,8 @@ class WebContents : public gin::Wrappable<WebContents>,
     fullscreen_frame_ = rfh;
   }
 
+  std::string GetMediaSourceID(content::WebContents* request_web_contents);
+
   // mojom::ElectronBrowser
   void Message(bool internal,
                const std::string& channel,

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -838,6 +838,14 @@ describe('webContents module', () => {
     });
   });
 
+  describe('getMediaSourceId()', () => {
+    afterEach(closeAllWindows);
+    it('returns a valid stream id', () => {
+      const w = new BrowserWindow({ show: false });
+      expect(w.webContents.getMediaSourceId(w.webContents)).to.be.a('string').that.is.not.empty();
+    });
+  });
+
   describe('userAgent APIs', () => {
     it('can set the user agent (functions)', () => {
       const w = new BrowserWindow({ show: false });


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
New feature: add `webContents.getMediaSourceId()` to provide a way to get a MediaStream from a WebContents using getUserMedia.

This aims to fix the issues from https://github.com/electron/electron/pull/22701 which was removed with https://github.com/electron/electron/pull/25414.

The first main issue was with claiming to be available in both the renderer and main process but only working in the renderer.

This is fixed here by moving the api from the DesktopCapturer to a method on a WebContents. This means the API can only be consumed in the main process but I think this is inline with restricting the access for the DesktopCapturer to the main process in v17.

The next issue was with the lack of access control to the caller.

This is fixed here by requiring the user of the api to pass in the web contents that the media source ID will be registered to.
This allows you to restrict access to only the web contents you trust.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes


Notes: Added `webContents.getMediaSourceId()`, can be used with `getUserMedia` to get a stream for a `WebContents`.
<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
