### PR TITLE
chore: cherry-pick f8a74d72f328 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -104,3 +104,4 @@ hack_to_allow_gclient_sync_with_host_os_mac_on_linux_in_ci.patch
 revert_roll_clang_llvmorg-13-init-14732-g8a7b5ebf-2.patch
 logging_win32_only_create_a_console_if_logging_to_stderr.patch
 fix_media_key_usage_with_globalshortcuts.patch
+cherry-pick-f8a74d72f328.patch

--- a/patches/chromium/cherry-pick-f8a74d72f328.patch
+++ b/patches/chromium/cherry-pick-f8a74d72f328.patch
@@ -1,7 +1,10 @@
-From f8a74d72f328523399e23712269e46f3ec6b2004 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Vladimir Levin <vmpstr@chromium.org>
 Date: Tue, 14 Sep 2021 00:06:00 +0000
-Subject: [PATCH] content-visibility: Add a clipper fix for content-visibility.
+Subject: content-visibility: Add a clipper fix for content-visibility.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 This patch adds a few checks in the svg painting code which may access
 a content-visibility locked element via an svg reference.
@@ -24,13 +27,12 @@ Auto-Submit: Joey Arhar <jarhar@chromium.org>
 Reviewed-by: Mason Freed <masonf@chromium.org>
 Cr-Commit-Position: refs/branch-heads/4606@{#1011}
 Cr-Branched-From: 35b0d5a9dc8362adfd44e2614f0d5b7402ef63d0-refs/heads/master@{#911515}
----
 
 diff --git a/third_party/blink/renderer/core/layout/svg/layout_svg_container_test.cc b/third_party/blink/renderer/core/layout/svg/layout_svg_container_test.cc
-index 57e3540..a625a03d 100644
+index 57e3540f9dc9419261ed7be84bd951df75380009..a625a03d0cc3e120e26f104d564db10ef78601e4 100644
 --- a/third_party/blink/renderer/core/layout/svg/layout_svg_container_test.cc
 +++ b/third_party/blink/renderer/core/layout/svg/layout_svg_container_test.cc
-@@ -117,4 +117,34 @@
+@@ -117,4 +117,34 @@ TEST_F(LayoutSVGContainerTest,
    EXPECT_TRUE(use->SlowFirstChild()->TransformAffectsVectorEffect());
  }
  
@@ -66,7 +68,7 @@ index 57e3540..a625a03d 100644
 +
  }  // namespace blink
 diff --git a/third_party/blink/renderer/core/layout/svg/layout_svg_resource_clipper.cc b/third_party/blink/renderer/core/layout/svg/layout_svg_resource_clipper.cc
-index fd437a7..b55cb3b 100644
+index 616403176b056cc31721e7779e02742703e11f9a..cce90a9aa24249f00272b7b58b7f0ba8991f5f71 100644
 --- a/third_party/blink/renderer/core/layout/svg/layout_svg_resource_clipper.cc
 +++ b/third_party/blink/renderer/core/layout/svg/layout_svg_resource_clipper.cc
 @@ -22,6 +22,7 @@
@@ -77,7 +79,7 @@ index fd437a7..b55cb3b 100644
  #include "third_party/blink/renderer/core/dom/element_traversal.h"
  #include "third_party/blink/renderer/core/layout/hit_test_result.h"
  #include "third_party/blink/renderer/core/layout/layout_box_model_object.h"
-@@ -54,6 +55,8 @@
+@@ -54,6 +55,8 @@ ClipStrategy DetermineClipStrategy(const SVGGraphicsElement& element) {
    const LayoutObject* layout_object = element.GetLayoutObject();
    if (!layout_object)
      return ClipStrategy::kNone;
@@ -86,7 +88,7 @@ index fd437a7..b55cb3b 100644
    const ComputedStyle& style = layout_object->StyleRef();
    if (style.Display() == EDisplay::kNone ||
        style.Visibility() != EVisibility::kVisible)
-@@ -74,8 +77,12 @@
+@@ -74,8 +77,12 @@ ClipStrategy DetermineClipStrategy(const SVGElement& element) {
    // (https://drafts.fxtf.org/css-masking/#ClipPathElement)
    if (auto* svg_use_element = DynamicTo<SVGUseElement>(element)) {
      const LayoutObject* use_layout_object = element.GetLayoutObject();
@@ -101,7 +103,7 @@ index fd437a7..b55cb3b 100644
        return ClipStrategy::kNone;
      const SVGGraphicsElement* shape_element =
          svg_use_element->VisibleTargetGraphicsElementForClipping();
-@@ -270,7 +277,7 @@
+@@ -270,7 +277,7 @@ bool LayoutSVGResourceClipper::HitTestClipContent(
  FloatRect LayoutSVGResourceClipper::ResourceBoundingBox(
      const FloatRect& reference_box) {
    NOT_DESTROYED();
@@ -111,7 +113,7 @@ index fd437a7..b55cb3b 100644
    if (local_clip_bounds_.IsEmpty())
      CalculateLocalClipBounds();
 diff --git a/third_party/blink/renderer/core/layout/svg/layout_svg_resource_masker.cc b/third_party/blink/renderer/core/layout/svg/layout_svg_resource_masker.cc
-index f8f04a7..8d7fb11 100644
+index f8f04a77ec0160e42c1ddc4a8987dca530e7d995..8d7fb110b55610c92db40e879e0df509ffff1329 100644
 --- a/third_party/blink/renderer/core/layout/svg/layout_svg_resource_masker.cc
 +++ b/third_party/blink/renderer/core/layout/svg/layout_svg_resource_masker.cc
 @@ -19,6 +19,7 @@
@@ -122,7 +124,7 @@ index f8f04a7..8d7fb11 100644
  #include "third_party/blink/renderer/core/dom/element_traversal.h"
  #include "third_party/blink/renderer/core/layout/svg/svg_layout_support.h"
  #include "third_party/blink/renderer/core/paint/svg_object_painter.h"
-@@ -64,7 +65,9 @@
+@@ -64,7 +65,9 @@ sk_sp<const PaintRecord> LayoutSVGResourceMasker::CreatePaintRecord(
    for (const SVGElement& child_element :
         Traversal<SVGElement>::ChildrenOf(*GetElement())) {
      const LayoutObject* layout_object = child_element.GetLayoutObject();
@@ -133,7 +135,7 @@ index f8f04a7..8d7fb11 100644
          layout_object->StyleRef().Display() == EDisplay::kNone)
        continue;
      SVGObjectPainter(*layout_object).PaintResourceSubtree(builder.Context());
-@@ -90,7 +93,7 @@
+@@ -90,7 +93,7 @@ FloatRect LayoutSVGResourceMasker::ResourceBoundingBox(
      const FloatRect& reference_box,
      float reference_box_zoom) {
    NOT_DESTROYED();
@@ -143,7 +145,7 @@ index f8f04a7..8d7fb11 100644
    DCHECK(mask_element);
  
 diff --git a/third_party/blink/renderer/core/layout/svg/layout_svg_resource_pattern.cc b/third_party/blink/renderer/core/layout/svg/layout_svg_resource_pattern.cc
-index a439785..a144578 100644
+index 1edd62a9f1089b8fa7889223319fbf859ef146bf..1750cff677a1aa910234b273a9640d34925f6912 100644
 --- a/third_party/blink/renderer/core/layout/svg/layout_svg_resource_pattern.cc
 +++ b/third_party/blink/renderer/core/layout/svg/layout_svg_resource_pattern.cc
 @@ -24,6 +24,7 @@
@@ -154,7 +156,7 @@ index a439785..a144578 100644
  #include "third_party/blink/renderer/core/layout/svg/svg_layout_support.h"
  #include "third_party/blink/renderer/core/layout/svg/svg_resources.h"
  #include "third_party/blink/renderer/core/paint/svg_object_painter.h"
-@@ -204,8 +205,20 @@
+@@ -204,8 +205,20 @@ sk_sp<PaintRecord> LayoutSVGResourcePattern::AsPaintRecord(
      content_transform = tile_transform;
  
    FloatRect bounds(FloatPoint(), size);
@@ -176,7 +178,7 @@ index a439785..a144578 100644
    DCHECK(pattern_layout_object);
    DCHECK(!pattern_layout_object->NeedsLayout());
  
-@@ -215,8 +228,6 @@
+@@ -215,8 +228,6 @@ sk_sp<PaintRecord> LayoutSVGResourcePattern::AsPaintRecord(
    for (LayoutObject* child = pattern_layout_object->FirstChild(); child;
         child = child->NextSibling())
      SVGObjectPainter(*child).PaintResourceSubtree(builder.Context());
@@ -186,7 +188,7 @@ index a439785..a144578 100644
    canvas->concat(AffineTransformToSkMatrix(tile_transform));
    builder.EndRecording(*canvas);
 diff --git a/third_party/blink/renderer/core/paint/clip_path_clipper.cc b/third_party/blink/renderer/core/paint/clip_path_clipper.cc
-index c842ba1..99d2790 100644
+index 666eefb37dac7bfd80ad067a3bb3332268ec6505..438435e57c1c47c2f7c3fa0d338976d0c00a1cec 100644
 --- a/third_party/blink/renderer/core/paint/clip_path_clipper.cc
 +++ b/third_party/blink/renderer/core/paint/clip_path_clipper.cc
 @@ -5,6 +5,7 @@
@@ -197,7 +199,7 @@ index c842ba1..99d2790 100644
  #include "third_party/blink/renderer/core/frame/local_frame.h"
  #include "third_party/blink/renderer/core/layout/layout_box.h"
  #include "third_party/blink/renderer/core/layout/layout_inline.h"
-@@ -43,10 +44,14 @@
+@@ -43,10 +44,14 @@ LayoutSVGResourceClipper* ResolveElementReference(
      return nullptr;
    LayoutSVGResourceClipper* resource_clipper =
        GetSVGResourceAsType(*client, reference_clip_path_operation);
@@ -217,7 +219,7 @@ index c842ba1..99d2790 100644
  }
  
 diff --git a/third_party/blink/renderer/core/paint/svg_mask_painter.cc b/third_party/blink/renderer/core/paint/svg_mask_painter.cc
-index 72f23f4..893109d 100644
+index 72f23f43e38b19a6ba4a70637921f808dc5c29f1..893109d449b2b815a6cc6e01beabdb4cb66a39fe 100644
 --- a/third_party/blink/renderer/core/paint/svg_mask_painter.cc
 +++ b/third_party/blink/renderer/core/paint/svg_mask_painter.cc
 @@ -4,6 +4,7 @@
@@ -228,7 +230,7 @@ index 72f23f4..893109d 100644
  #include "third_party/blink/renderer/core/layout/svg/layout_svg_resource_masker.h"
  #include "third_party/blink/renderer/core/layout/svg/svg_resources.h"
  #include "third_party/blink/renderer/core/paint/object_paint_properties.h"
-@@ -46,7 +47,9 @@
+@@ -46,7 +47,9 @@ void SVGMaskPainter::Paint(GraphicsContext& context,
    auto* masker = GetSVGResourceAsType<LayoutSVGResourceMasker>(
        *client, style.MaskerResource());
    DCHECK(masker);
@@ -240,10 +242,10 @@ index 72f23f4..893109d 100644
  
    FloatRect reference_box = SVGResources::ReferenceBoxForEffects(layout_object);
 diff --git a/third_party/blink/renderer/core/paint/svg_object_painter.cc b/third_party/blink/renderer/core/paint/svg_object_painter.cc
-index 027ee7b..f675b25 100644
+index 027ee7bbeeaf2922b2fae7aeb17492400dc1528f..f675b25f63dea8710443d3d81fcea9178c1a3bd4 100644
 --- a/third_party/blink/renderer/core/paint/svg_object_painter.cc
 +++ b/third_party/blink/renderer/core/paint/svg_object_painter.cc
-@@ -32,7 +32,7 @@
+@@ -32,7 +32,7 @@ void CopyStateFromGraphicsContext(const GraphicsContext& context,
  }  // namespace
  
  void SVGObjectPainter::PaintResourceSubtree(GraphicsContext& context) {
@@ -254,7 +256,7 @@ index 027ee7b..f675b25 100644
                   kGlobalPaintNormalPhase | kGlobalPaintFlattenCompositingLayers,
 diff --git a/third_party/blink/web_tests/external/wpt/css/css-contain/content-visibility/content-visibility-in-svg-000-crash.html b/third_party/blink/web_tests/external/wpt/css/css-contain/content-visibility/content-visibility-in-svg-000-crash.html
 new file mode 100644
-index 0000000..d1084f72
+index 0000000000000000000000000000000000000000..d1084f7216510386f159033e2f7b0e3966bd2758
 --- /dev/null
 +++ b/third_party/blink/web_tests/external/wpt/css/css-contain/content-visibility/content-visibility-in-svg-000-crash.html
 @@ -0,0 +1,30 @@

--- a/patches/chromium/cherry-pick-f8a74d72f328.patch
+++ b/patches/chromium/cherry-pick-f8a74d72f328.patch
@@ -1,0 +1,290 @@
+From f8a74d72f328523399e23712269e46f3ec6b2004 Mon Sep 17 00:00:00 2001
+From: Vladimir Levin <vmpstr@chromium.org>
+Date: Tue, 14 Sep 2021 00:06:00 +0000
+Subject: [PATCH] content-visibility: Add a clipper fix for content-visibility.
+
+This patch adds a few checks in the svg painting code which may access
+a content-visibility locked element via an svg reference.
+
+R=​fs@opera.com,jarhar@chromium.org
+
+(cherry picked from commit e0d8a4f20bf98bbda2dc58199fca5caf0add1b00)
+
+Bug: 1247196
+Change-Id: I4dcb4ef298fb8d51aa0ec1a3b3bc130cfb560791
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3149811
+Reviewed-by: Fredrik Söderquist <fs@opera.com>
+Reviewed-by: Joey Arhar <jarhar@chromium.org>
+Commit-Queue: vmpstr <vmpstr@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#920209}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3158958
+Commit-Queue: Joey Arhar <jarhar@chromium.org>
+Commit-Queue: Mason Freed <masonf@chromium.org>
+Auto-Submit: Joey Arhar <jarhar@chromium.org>
+Reviewed-by: Mason Freed <masonf@chromium.org>
+Cr-Commit-Position: refs/branch-heads/4606@{#1011}
+Cr-Branched-From: 35b0d5a9dc8362adfd44e2614f0d5b7402ef63d0-refs/heads/master@{#911515}
+---
+
+diff --git a/third_party/blink/renderer/core/layout/svg/layout_svg_container_test.cc b/third_party/blink/renderer/core/layout/svg/layout_svg_container_test.cc
+index 57e3540..a625a03d 100644
+--- a/third_party/blink/renderer/core/layout/svg/layout_svg_container_test.cc
++++ b/third_party/blink/renderer/core/layout/svg/layout_svg_container_test.cc
+@@ -117,4 +117,34 @@
+   EXPECT_TRUE(use->SlowFirstChild()->TransformAffectsVectorEffect());
+ }
+ 
++TEST_F(LayoutSVGContainerTest, PatternWithContentVisibility) {
++  SetBodyInnerHTML(R"HTML(
++    <svg viewBox="0 0 230 100" xmlns="http://www.w3.org/2000/svg">
++      <defs>
++        <pattern id="pattern" viewBox="0,0,10,10" width="10%" height="10%">
++          <polygon id="polygon" points="0,0 2,5 0,10 5,8 10,10 8,5 10,0 5,2"/>
++        </pattern>
++      </defs>
++
++      <circle id="circle" cx="50"  cy="50" r="50" fill="url(#pattern)"/>
++    </svg>
++  )HTML");
++
++  auto* pattern = GetDocument().getElementById("pattern");
++  auto* polygon = GetDocument().getElementById("polygon");
++
++  pattern->setAttribute("style", "contain: strict; content-visibility: hidden");
++
++  UpdateAllLifecyclePhasesForTest();
++
++  polygon->setAttribute("points", "0,0 2,5 0,10");
++
++  // This shouldn't cause a DCHECK, even though the pattern needs layout because
++  // it's under a content-visibility: hidden subtree.
++  UpdateAllLifecyclePhasesForTest();
++
++  EXPECT_TRUE(pattern->GetLayoutObject()->NeedsLayout());
++  EXPECT_FALSE(pattern->GetLayoutObject()->SelfNeedsLayout());
++}
++
+ }  // namespace blink
+diff --git a/third_party/blink/renderer/core/layout/svg/layout_svg_resource_clipper.cc b/third_party/blink/renderer/core/layout/svg/layout_svg_resource_clipper.cc
+index fd437a7..b55cb3b 100644
+--- a/third_party/blink/renderer/core/layout/svg/layout_svg_resource_clipper.cc
++++ b/third_party/blink/renderer/core/layout/svg/layout_svg_resource_clipper.cc
+@@ -22,6 +22,7 @@
+ 
+ #include "third_party/blink/renderer/core/layout/svg/layout_svg_resource_clipper.h"
+ 
++#include "third_party/blink/renderer/core/display_lock/display_lock_utilities.h"
+ #include "third_party/blink/renderer/core/dom/element_traversal.h"
+ #include "third_party/blink/renderer/core/layout/hit_test_result.h"
+ #include "third_party/blink/renderer/core/layout/layout_box_model_object.h"
+@@ -54,6 +55,8 @@
+   const LayoutObject* layout_object = element.GetLayoutObject();
+   if (!layout_object)
+     return ClipStrategy::kNone;
++  if (DisplayLockUtilities::LockedAncestorPreventingLayout(*layout_object))
++    return ClipStrategy::kNone;
+   const ComputedStyle& style = layout_object->StyleRef();
+   if (style.Display() == EDisplay::kNone ||
+       style.Visibility() != EVisibility::kVisible)
+@@ -74,8 +77,12 @@
+   // (https://drafts.fxtf.org/css-masking/#ClipPathElement)
+   if (auto* svg_use_element = DynamicTo<SVGUseElement>(element)) {
+     const LayoutObject* use_layout_object = element.GetLayoutObject();
+-    if (!use_layout_object ||
+-        use_layout_object->StyleRef().Display() == EDisplay::kNone)
++    if (!use_layout_object)
++      return ClipStrategy::kNone;
++    if (DisplayLockUtilities::LockedAncestorPreventingLayout(
++            *use_layout_object))
++      return ClipStrategy::kNone;
++    if (use_layout_object->StyleRef().Display() == EDisplay::kNone)
+       return ClipStrategy::kNone;
+     const SVGGraphicsElement* shape_element =
+         svg_use_element->VisibleTargetGraphicsElementForClipping();
+@@ -270,7 +277,7 @@
+ FloatRect LayoutSVGResourceClipper::ResourceBoundingBox(
+     const FloatRect& reference_box) {
+   NOT_DESTROYED();
+-  DCHECK(!NeedsLayout());
++  DCHECK(!SelfNeedsLayout());
+ 
+   if (local_clip_bounds_.IsEmpty())
+     CalculateLocalClipBounds();
+diff --git a/third_party/blink/renderer/core/layout/svg/layout_svg_resource_masker.cc b/third_party/blink/renderer/core/layout/svg/layout_svg_resource_masker.cc
+index f8f04a7..8d7fb11 100644
+--- a/third_party/blink/renderer/core/layout/svg/layout_svg_resource_masker.cc
++++ b/third_party/blink/renderer/core/layout/svg/layout_svg_resource_masker.cc
+@@ -19,6 +19,7 @@
+ 
+ #include "third_party/blink/renderer/core/layout/svg/layout_svg_resource_masker.h"
+ 
++#include "third_party/blink/renderer/core/display_lock/display_lock_utilities.h"
+ #include "third_party/blink/renderer/core/dom/element_traversal.h"
+ #include "third_party/blink/renderer/core/layout/svg/svg_layout_support.h"
+ #include "third_party/blink/renderer/core/paint/svg_object_painter.h"
+@@ -64,7 +65,9 @@
+   for (const SVGElement& child_element :
+        Traversal<SVGElement>::ChildrenOf(*GetElement())) {
+     const LayoutObject* layout_object = child_element.GetLayoutObject();
+-    if (!layout_object ||
++    if (!layout_object)
++      continue;
++    if (DisplayLockUtilities::LockedAncestorPreventingLayout(*layout_object) ||
+         layout_object->StyleRef().Display() == EDisplay::kNone)
+       continue;
+     SVGObjectPainter(*layout_object).PaintResourceSubtree(builder.Context());
+@@ -90,7 +93,7 @@
+     const FloatRect& reference_box,
+     float reference_box_zoom) {
+   NOT_DESTROYED();
+-  DCHECK(!NeedsLayout());
++  DCHECK(!SelfNeedsLayout());
+   auto* mask_element = To<SVGMaskElement>(GetElement());
+   DCHECK(mask_element);
+ 
+diff --git a/third_party/blink/renderer/core/layout/svg/layout_svg_resource_pattern.cc b/third_party/blink/renderer/core/layout/svg/layout_svg_resource_pattern.cc
+index a439785..a144578 100644
+--- a/third_party/blink/renderer/core/layout/svg/layout_svg_resource_pattern.cc
++++ b/third_party/blink/renderer/core/layout/svg/layout_svg_resource_pattern.cc
+@@ -24,6 +24,7 @@
+ #include <memory>
+ 
+ #include "base/memory/ptr_util.h"
++#include "third_party/blink/renderer/core/display_lock/display_lock_utilities.h"
+ #include "third_party/blink/renderer/core/layout/svg/svg_layout_support.h"
+ #include "third_party/blink/renderer/core/layout/svg/svg_resources.h"
+ #include "third_party/blink/renderer/core/paint/svg_object_painter.h"
+@@ -204,8 +205,20 @@
+     content_transform = tile_transform;
+ 
+   FloatRect bounds(FloatPoint(), size);
++  PaintRecorder paint_recorder;
++  cc::PaintCanvas* canvas = paint_recorder.beginRecording(bounds);
++
++  auto* pattern_content_element = Attributes().PatternContentElement();
++  DCHECK(pattern_content_element);
++  // If the element or some of its ancestor prevents us from doing paint, we can
++  // early out. Note that any locked ancestor would prevent paint.
++  if (DisplayLockUtilities::NearestLockedInclusiveAncestor(
++          *pattern_content_element)) {
++    return paint_recorder.finishRecordingAsPicture();
++  }
++
+   const auto* pattern_layout_object = To<LayoutSVGResourceContainer>(
+-      Attributes().PatternContentElement()->GetLayoutObject());
++      pattern_content_element->GetLayoutObject());
+   DCHECK(pattern_layout_object);
+   DCHECK(!pattern_layout_object->NeedsLayout());
+ 
+@@ -215,8 +228,6 @@
+   for (LayoutObject* child = pattern_layout_object->FirstChild(); child;
+        child = child->NextSibling())
+     SVGObjectPainter(*child).PaintResourceSubtree(builder.Context());
+-  PaintRecorder paint_recorder;
+-  cc::PaintCanvas* canvas = paint_recorder.beginRecording(bounds);
+   canvas->save();
+   canvas->concat(AffineTransformToSkMatrix(tile_transform));
+   builder.EndRecording(*canvas);
+diff --git a/third_party/blink/renderer/core/paint/clip_path_clipper.cc b/third_party/blink/renderer/core/paint/clip_path_clipper.cc
+index c842ba1..99d2790 100644
+--- a/third_party/blink/renderer/core/paint/clip_path_clipper.cc
++++ b/third_party/blink/renderer/core/paint/clip_path_clipper.cc
+@@ -5,6 +5,7 @@
+ #include "third_party/blink/renderer/core/paint/clip_path_clipper.h"
+ 
+ #include "third_party/blink/renderer/core/css/clip_path_paint_image_generator.h"
++#include "third_party/blink/renderer/core/display_lock/display_lock_utilities.h"
+ #include "third_party/blink/renderer/core/frame/local_frame.h"
+ #include "third_party/blink/renderer/core/layout/layout_box.h"
+ #include "third_party/blink/renderer/core/layout/layout_inline.h"
+@@ -43,10 +44,14 @@
+     return nullptr;
+   LayoutSVGResourceClipper* resource_clipper =
+       GetSVGResourceAsType(*client, reference_clip_path_operation);
+-  if (resource_clipper) {
+-    SECURITY_DCHECK(!resource_clipper->NeedsLayout());
+-    resource_clipper->ClearInvalidationMask();
+-  }
++  if (!resource_clipper)
++    return nullptr;
++
++  resource_clipper->ClearInvalidationMask();
++  if (DisplayLockUtilities::LockedAncestorPreventingLayout(*resource_clipper))
++    return nullptr;
++
++  SECURITY_DCHECK(!resource_clipper->SelfNeedsLayout());
+   return resource_clipper;
+ }
+ 
+diff --git a/third_party/blink/renderer/core/paint/svg_mask_painter.cc b/third_party/blink/renderer/core/paint/svg_mask_painter.cc
+index 72f23f4..893109d 100644
+--- a/third_party/blink/renderer/core/paint/svg_mask_painter.cc
++++ b/third_party/blink/renderer/core/paint/svg_mask_painter.cc
+@@ -4,6 +4,7 @@
+ 
+ #include "third_party/blink/renderer/core/paint/svg_mask_painter.h"
+ 
++#include "third_party/blink/renderer/core/display_lock/display_lock_utilities.h"
+ #include "third_party/blink/renderer/core/layout/svg/layout_svg_resource_masker.h"
+ #include "third_party/blink/renderer/core/layout/svg/svg_resources.h"
+ #include "third_party/blink/renderer/core/paint/object_paint_properties.h"
+@@ -46,7 +47,9 @@
+   auto* masker = GetSVGResourceAsType<LayoutSVGResourceMasker>(
+       *client, style.MaskerResource());
+   DCHECK(masker);
+-  SECURITY_DCHECK(!masker->NeedsLayout());
++  if (DisplayLockUtilities::LockedAncestorPreventingLayout(*masker))
++    return;
++  SECURITY_DCHECK(!masker->SelfNeedsLayout());
+   masker->ClearInvalidationMask();
+ 
+   FloatRect reference_box = SVGResources::ReferenceBoxForEffects(layout_object);
+diff --git a/third_party/blink/renderer/core/paint/svg_object_painter.cc b/third_party/blink/renderer/core/paint/svg_object_painter.cc
+index 027ee7b..f675b25 100644
+--- a/third_party/blink/renderer/core/paint/svg_object_painter.cc
++++ b/third_party/blink/renderer/core/paint/svg_object_painter.cc
+@@ -32,7 +32,7 @@
+ }  // namespace
+ 
+ void SVGObjectPainter::PaintResourceSubtree(GraphicsContext& context) {
+-  DCHECK(!layout_object_.NeedsLayout());
++  DCHECK(!layout_object_.SelfNeedsLayout());
+ 
+   PaintInfo info(context, CullRect::Infinite(), PaintPhase::kForeground,
+                  kGlobalPaintNormalPhase | kGlobalPaintFlattenCompositingLayers,
+diff --git a/third_party/blink/web_tests/external/wpt/css/css-contain/content-visibility/content-visibility-in-svg-000-crash.html b/third_party/blink/web_tests/external/wpt/css/css-contain/content-visibility/content-visibility-in-svg-000-crash.html
+new file mode 100644
+index 0000000..d1084f72
+--- /dev/null
++++ b/third_party/blink/web_tests/external/wpt/css/css-contain/content-visibility/content-visibility-in-svg-000-crash.html
+@@ -0,0 +1,30 @@
++<!DOCTYPE html>
++<html class="test-wait">
++<link rel="author" title="Vladimir Levin" href="mailto:vmpstr@chromium.org">
++<link rel="help" href="https://crbug.com/1247196">
++<meta name="assert" content="Clip path with content-visibility does not cause an assert">
++
++<svg width="138">
++  <defs>
++    <clipPath id="snowglobe_clipPath">
++      <circle cx="34" />
++    </clipPath>
++  </defs>
++  <circle />
++  <g class="group-snow" clip-path="url(#snowglobe_clipPath)">
++    <g class="snowContainer">
++      <circle class="snow" />
++    </g>
++  </g>
++</svg>
++<script type="text/javascript">
++onload = () => {
++  var test0 = document.getElementById("snowglobe_clipPath");
++  test0.style.setProperty("content-visibility", "auto ", "important");
++  test0.innerHTML = "";
++  test0.offsetHeight;
++
++  requestAnimationFrame(() => document.documentElement.classList.remove('test-wait'));
++};
++</script>
++</html>


### PR DESCRIPTION
content-visibility: Add a clipper fix for content-visibility.

This patch adds a few checks in the svg painting code which may access
a content-visibility locked element via an svg reference.

R=​fs@opera.com,jarhar@chromium.org

(cherry picked from commit e0d8a4f20bf98bbda2dc58199fca5caf0add1b00)

Bug: 1247196
Change-Id: I4dcb4ef298fb8d51aa0ec1a3b3bc130cfb560791
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3149811
Reviewed-by: Fredrik Söderquist <fs@opera.com>
Reviewed-by: Joey Arhar <jarhar@chromium.org>
Commit-Queue: vmpstr <vmpstr@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#920209}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3158958
Commit-Queue: Joey Arhar <jarhar@chromium.org>
Commit-Queue: Mason Freed <masonf@chromium.org>
Auto-Submit: Joey Arhar <jarhar@chromium.org>
Reviewed-by: Mason Freed <masonf@chromium.org>
Cr-Commit-Position: refs/branch-heads/4606@{#1011}
Cr-Branched-From: 35b0d5a9dc8362adfd44e2614f0d5b7402ef63d0-refs/heads/master@{#911515}


Notes: Backported fix for CVE-2021-37960.