### PR TITLE
fix: Enable X509_V_FLAG_TRUSTED_FIRST flag in BoringSSL

### DIFF
--- a/patches/boringssl/.patches
+++ b/patches/boringssl/.patches
@@ -3,3 +3,4 @@ expose_aes-cfb.patch
 expose_des-ede3.patch
 fix_sync_evp_get_cipherbynid_and_evp_get_cipherbyname.patch
 add_maskhash_to_rsa_pss_params_st_for_compat.patch
+enable_x509_v_flag_trusted_first_flag.patch

--- a/patches/boringssl/enable_x509_v_flag_trusted_first_flag.patch
+++ b/patches/boringssl/enable_x509_v_flag_trusted_first_flag.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Juan Cruz Viotti <jv@jviotti.com>
+Date: Thu, 30 Sep 2021 13:39:23 -0400
+Subject: Enable X509_V_FLAG_TRUSTED_FIRST flag
+
+Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+
+diff --git a/crypto/x509/x509_vpm.c b/crypto/x509/x509_vpm.c
+index 5a881d64c30076404cc800fff9e943bb0b30d2ac..29d5341efc8eb7ae6f90bdde5a8032e99f75c98e 100644
+--- a/crypto/x509/x509_vpm.c
++++ b/crypto/x509/x509_vpm.c
+@@ -528,7 +528,7 @@ static const X509_VERIFY_PARAM default_table[] = {
+      (char *)"default",         /* X509 default parameters */
+      0,                         /* Check time */
+      0,                         /* internal flags */
+-     0,                         /* flags */
++     X509_V_FLAG_TRUSTED_FIRST, /* flags */
+      0,                         /* purpose */
+      0,                         /* trust */
+      100,                       /* depth */


### PR DESCRIPTION
This flag is set by default on OpenSSL.

Fixes: https://github.com/electron/electron/issues/31212
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix Let's Encrypt DST Root CA X3 certificate expiration.
