### PR TITLE
feat: Added ability to configure if window should close when opener closes

### DIFF
--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -1,4 +1,4 @@
-# Opening windows from the renderer
+# Opening windows from the renderer 
 
 There are several ways to control how windows are created from trusted or
 untrusted content within a renderer. Windows can be created from the renderer in two ways:

--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -74,9 +74,9 @@ through the feature string, as the renderer has more limited privileges in
 deciding security preferences than the main process.
 
 In addition to passing in `action` and `overrideBrowserWindowOptions`,
-`closeWithOpener` can be passed like: `{ action: 'allow', closeWithOpener: false,
-overrideBrowserWindowOptions: { ... } }`. If set to `false`, child windows will not
-be closed when the opener window closes. The default value is `true`.
+`outlivesOpener` can be passed like: `{ action: 'allow', outlivesOpener: true,
+overrideBrowserWindowOptions: { ... } }`. If set to `true`, the newly created
+window will not close when the opener window closes. The default value is `false`.
 
 ### Native `Window` example
 

--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -73,6 +73,11 @@ creating the window. Note that this is more powerful than passing options
 through the feature string, as the renderer has more limited privileges in
 deciding security preferences than the main process.
 
+Additionally to `{ action: 'allow', overrideBrowserWindowOptions: { ... } }`,
+`closeWithOpener` can be passed like: `{ action: 'allow', closeWithOpener: false,
+overrideBrowserWindowOptions: { ... } }`. If set to `false`, child windows will not
+be closed when the opener window closes. The default value is `true`.
+
 ### Native `Window` example
 
 ```javascript

--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -73,7 +73,7 @@ creating the window. Note that this is more powerful than passing options
 through the feature string, as the renderer has more limited privileges in
 deciding security preferences than the main process.
 
-Additionally to `{ action: 'allow', overrideBrowserWindowOptions: { ... } }`,
+In addition to passing in `action` and `overrideBrowserWindowOptions`,
 `closeWithOpener` can be passed like: `{ action: 'allow', closeWithOpener: false,
 overrideBrowserWindowOptions: { ... } }`. If set to `false`, child windows will not
 be closed when the opener window closes. The default value is `true`.

--- a/docs/api/window-open.md
+++ b/docs/api/window-open.md
@@ -1,4 +1,4 @@
-# Opening windows from the renderer 
+# Opening windows from the renderer
 
 There are several ways to control how windows are created from trusted or
 untrusted content within a renderer. Windows can be created from the renderer in two ways:

--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -499,7 +499,7 @@ WebContents.prototype.setWindowOpenHandler = function (handler: (details: Electr
 WebContents.prototype._callWindowOpenHandler = function (event: Electron.Event, details: Electron.HandlerDetails): {browserWindowConstructorOptions: BrowserWindowConstructorOptions | null, closeWithOpener: boolean} {
   const defaultResponse = {
     browserWindowConstructorOptions: null,
-    closeWithOpener: true,
+    closeWithOpener: true
   };
   if (!this._windowOpenHandler) {
     return defaultResponse;
@@ -525,12 +525,12 @@ WebContents.prototype._callWindowOpenHandler = function (event: Electron.Event, 
     if (typeof response.overrideBrowserWindowOptions === 'object' && response.overrideBrowserWindowOptions !== null) {
       return {
         browserWindowConstructorOptions: response.overrideBrowserWindowOptions,
-        closeWithOpener: typeof response.closeWithOpener === "boolean" ? response.closeWithOpener : true,
+        closeWithOpener: typeof response.closeWithOpener === 'boolean' ? response.closeWithOpener : true
       };
     } else {
       return {
         browserWindowConstructorOptions: {},
-        closeWithOpener: typeof response.closeWithOpener === "boolean" ? response.closeWithOpener : true,
+        closeWithOpener: typeof response.closeWithOpener === 'boolean' ? response.closeWithOpener : true
       };
     }
   } else {
@@ -672,7 +672,7 @@ WebContents.prototype._init = function () {
           postData,
           overrideBrowserWindowOptions: options || {},
           windowOpenArgs: details,
-          closeWithOpener: result.closeWithOpener,
+          closeWithOpener: result.closeWithOpener
         });
       }
     });
@@ -725,6 +725,7 @@ WebContents.prototype._init = function () {
       _userGesture: boolean, _left: number, _top: number, _width: number, _height: number, url: string, frameName: string,
       referrer: Electron.Referrer, rawFeatures: string, postData: PostData) => {
       const overriddenOptions = windowOpenOverriddenOptions || undefined;
+      const closeWithOpener = windowOpenCloseWithOpenerOption;
       windowOpenOverriddenOptions = null;
       // true is the default
       windowOpenCloseWithOpenerOption = true;
@@ -748,7 +749,7 @@ WebContents.prototype._init = function () {
           frameName,
           features: rawFeatures
         },
-        closeWithOpener: windowOpenCloseWithOpenerOption,
+        closeWithOpener
       });
     });
   }

--- a/lib/browser/guest-window-manager.ts
+++ b/lib/browser/guest-window-manager.ts
@@ -104,10 +104,8 @@ const handleWindowLifecycleEvents = function ({ embedder, guest, frameName, clos
 
   const closedByUser = function () {
     // Embedder might have been closed
-    if (!embedder.isDestroyed()) {
-      if (closeWithOpener) {
-        embedder.removeListener('current-render-view-deleted' as any, closedByEmbedder);
-      }
+    if (!embedder.isDestroyed() && closeWithOpener) {
+      embedder.removeListener('current-render-view-deleted' as any, closedByEmbedder);
     }
   };
   if (closeWithOpener) {

--- a/lib/browser/guest-window-manager.ts
+++ b/lib/browser/guest-window-manager.ts
@@ -103,8 +103,11 @@ const handleWindowLifecycleEvents = function ({ embedder, guest, frameName, clos
   };
 
   const closedByUser = function () {
-    if (closeWithOpener) {
-      embedder.removeListener('current-render-view-deleted' as any, closedByEmbedder);
+    // Embedder might have been closed
+    if (!embedder.isDestroyed()) {
+      if (closeWithOpener) {
+        embedder.removeListener('current-render-view-deleted' as any, closedByEmbedder);
+      }
     }
   };
   if (closeWithOpener) {
@@ -170,7 +173,7 @@ function emitDeprecatedNewWindowEvent ({ event, embedder, guest, windowOpenArgs,
         embedder: event.sender,
         guest: newGuest,
         frameName,
-        closeWithOpener: true,
+        closeWithOpener: true
       });
     }
     return true;

--- a/lib/browser/guest-window-manager.ts
+++ b/lib/browser/guest-window-manager.ts
@@ -29,7 +29,7 @@ const getGuestWindowByFrameName = (name: string) => frameNamesToWindow.get(name)
  * user to preventDefault() on the passed event (which ends up calling
  * DestroyWebContents).
  */
-export function openGuestWindow ({ event, embedder, guest, referrer, disposition, postData, overrideBrowserWindowOptions, windowOpenArgs }: {
+export function openGuestWindow ({ event, embedder, guest, referrer, disposition, postData, overrideBrowserWindowOptions, windowOpenArgs, closeWithOpener }: {
   event: { sender: WebContents, defaultPrevented: boolean },
   embedder: WebContents,
   guest?: WebContents,
@@ -38,6 +38,7 @@ export function openGuestWindow ({ event, embedder, guest, referrer, disposition
   postData?: PostData,
   overrideBrowserWindowOptions?: BrowserWindowConstructorOptions,
   windowOpenArgs: WindowOpenArgs,
+  closeWithOpener: boolean,
 }): BrowserWindow | undefined {
   const { url, frameName, features } = windowOpenArgs;
   const { options: browserWindowOptions } = makeBrowserWindowOptions({
@@ -77,7 +78,7 @@ export function openGuestWindow ({ event, embedder, guest, referrer, disposition
     ...browserWindowOptions
   });
 
-  handleWindowLifecycleEvents({ embedder, frameName, guest: window });
+  handleWindowLifecycleEvents({ embedder, frameName, guest: window, closeWithOpener });
 
   embedder.emit('did-create-window', window, { url, frameName, options: browserWindowOptions, disposition, referrer, postData });
 
@@ -90,10 +91,11 @@ export function openGuestWindow ({ event, embedder, guest, referrer, disposition
  * too is the guest destroyed; this is Electron convention and isn't based in
  * browser behavior.
  */
-const handleWindowLifecycleEvents = function ({ embedder, guest, frameName }: {
+const handleWindowLifecycleEvents = function ({ embedder, guest, frameName, closeWithOpener }: {
   embedder: WebContents,
   guest: BrowserWindow,
-  frameName: string
+  frameName: string,
+  closeWithOpener: boolean
 }) {
   const closedByEmbedder = function () {
     guest.removeListener('closed', closedByUser);
@@ -101,9 +103,13 @@ const handleWindowLifecycleEvents = function ({ embedder, guest, frameName }: {
   };
 
   const closedByUser = function () {
-    embedder.removeListener('current-render-view-deleted' as any, closedByEmbedder);
+    if (closeWithOpener) {
+      embedder.removeListener('current-render-view-deleted' as any, closedByEmbedder);
+    }
   };
-  embedder.once('current-render-view-deleted' as any, closedByEmbedder);
+  if (closeWithOpener) {
+    embedder.once('current-render-view-deleted' as any, closedByEmbedder);
+  }
   guest.once('closed', closedByUser);
 
   if (frameName) {
@@ -163,7 +169,8 @@ function emitDeprecatedNewWindowEvent ({ event, embedder, guest, windowOpenArgs,
       handleWindowLifecycleEvents({
         embedder: event.sender,
         guest: newGuest,
-        frameName
+        frameName,
+        closeWithOpener: true,
       });
     }
     return true;

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -63,7 +63,7 @@ declare namespace Electron {
     equal(other: WebContents): boolean;
     browserWindowOptions: BrowserWindowConstructorOptions;
     _windowOpenHandler: ((details: Electron.HandlerDetails) => any) | null;
-    _callWindowOpenHandler(event: any, details: Electron.HandlerDetails): Electron.BrowserWindowConstructorOptions | null;
+    _callWindowOpenHandler(event: any, details: Electron.HandlerDetails): {browserWindowConstructorOptions: Electron.BrowserWindowConstructorOptions | null, closeWithOpener: boolean};
     _setNextChildWebPreferences(prefs: Partial<Electron.BrowserWindowConstructorOptions['webPreferences']> & Pick<Electron.BrowserWindowConstructorOptions, 'backgroundColor'>): void;
     _send(internal: boolean, channel: string, args: any): boolean;
     _sendToFrameInternal(frameId: number | [number, number], channel: string, ...args: any[]): boolean;

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -63,7 +63,7 @@ declare namespace Electron {
     equal(other: WebContents): boolean;
     browserWindowOptions: BrowserWindowConstructorOptions;
     _windowOpenHandler: ((details: Electron.HandlerDetails) => any) | null;
-    _callWindowOpenHandler(event: any, details: Electron.HandlerDetails): {browserWindowConstructorOptions: Electron.BrowserWindowConstructorOptions | null, closeWithOpener: boolean};
+    _callWindowOpenHandler(event: any, details: Electron.HandlerDetails): {browserWindowConstructorOptions: Electron.BrowserWindowConstructorOptions | null, outlivesOpener: boolean};
     _setNextChildWebPreferences(prefs: Partial<Electron.BrowserWindowConstructorOptions['webPreferences']> & Pick<Electron.BrowserWindowConstructorOptions, 'backgroundColor'>): void;
     _send(internal: boolean, channel: string, args: any): boolean;
     _sendToFrameInternal(frameId: number | [number, number], channel: string, ...args: any[]): boolean;


### PR DESCRIPTION
#### Description of Change
Fixes: https://github.com/electron/electron/issues/11128

Currently electron automatically closes child windows when the opener window closes.
This behavior is a left over from the Atom text editor and does not conform with standard browser behavior.
The PR adds the ability to control this behavior, since it is not possible to deactivate this without hacks.
Note: This is not a breaking change since the flag is not required and the default stays the same as it used to be.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added ability to configure if window should close when opener closes
