### PR TITLE
chore: emove BoringSSL patch redundancy

### DIFF
--- a/patches/node/fix_handle_boringssl_and_openssl_incompatibilities.patch
+++ b/patches/node/fix_handle_boringssl_and_openssl_incompatibilities.patch
@@ -225,15 +225,6 @@ diff --git a/src/crypto/crypto_rsa.cc b/src/crypto/crypto_rsa.cc
 index d2307c33f5de8733b1343225a3fe6a700d1f51e4..fd31caa1355cd7be98992411b9cda2dbb500f211 100644
 --- a/src/crypto/crypto_rsa.cc
 +++ b/src/crypto/crypto_rsa.cc
-@@ -580,7 +580,7 @@ Maybe<bool> GetRsaKeyDetail(
-     // In that case, RSA_get0_pss_params does not return nullptr but all fields
-     // of the returned RSA_PSS_PARAMS will be set to nullptr.
- 
--    const RSA_PSS_PARAMS* params = RSA_get0_pss_params(rsa);
-+    const RSA_PSS_PARAMS* params = nullptr; // RSA_get0_pss_params(rsa);
-     if (params != nullptr) {
-       int hash_nid = NID_sha1;
-       int mgf_nid = NID_mgf1;
 @@ -621,10 +621,11 @@ Maybe<bool> GetRsaKeyDetail(
        }
  


### PR DESCRIPTION
#### Description of Change

Updates BoringSSL patchfile following https://boringssl-review.googlesource.com/c/boringssl/+/49365.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none