### PR TITLE
chore: update false to use analogous function in SetGroups

### DIFF
--- a/patches/node/fix_handle_boringssl_and_openssl_incompatibilities.patch
+++ b/patches/node/fix_handle_boringssl_and_openssl_incompatibilities.patch
@@ -17,7 +17,7 @@ Upstreams:
 - https://github.com/nodejs/node/pull/39136
 
 diff --git a/src/crypto/crypto_common.cc b/src/crypto/crypto_common.cc
-index f4b7bd3ad8548a0b69943ddea669e6f1991b7a49..221d652fa7de246e5f69fcf392e334087bac0199 100644
+index f4b7bd3ad8548a0b69943ddea669e6f1991b7a49..dc4f6737d7709fda9bb1350a0d3ed342d83b7044 100644
 --- a/src/crypto/crypto_common.cc
 +++ b/src/crypto/crypto_common.cc
 @@ -242,7 +242,7 @@ const char* GetClientHelloALPN(const SSLPointer& ssl) {
@@ -62,7 +62,7 @@ index f4b7bd3ad8548a0b69943ddea669e6f1991b7a49..221d652fa7de246e5f69fcf392e33408
 +#ifndef OPENSSL_IS_BORINGSSL
    return SSL_CTX_set1_groups_list(**sc, groups) == 1;
 +#endif
-+  return false;
++  return SSL_CTX_set1_curves_list(**sc, groups) == 1;
  }
  
  const char* X509ErrorCode(long err) {  // NOLINT(runtime/int)


### PR DESCRIPTION
#### Description of Change

Updates our BoringSSL patch to replace a previously unilateral `false` return value with a function that does the same thing but compiles in BoringSSL. Per [documentation](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set1_groups_list.html):

> The curve functions are synonyms for the equivalently named group functions and are identical in every respect. They exist because, prior to TLS1.3, there was only the concept of supported curves. In TLS1.3 this was renamed to supported groups, and extended to include Diffie Hellman groups. The group functions should be used in preference.

It seems that BoringSSL has not yet updated to include these preferable functions, and this will be upstreamed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none.