### PR TITLE
fix: mac window crash native theme update

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -324,6 +324,13 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
   window_ = static_cast<ElectronNSWindow*>(
       widget()->GetNativeWindow().GetNativeNSWindow());
 
+  RegisterDeleteDelegateCallback(base::BindOnce(
+      [](NativeWindowMac* window) {
+        if (window->window_)
+          window->window_ = nil;
+      },
+      this));
+
   [window_ setEnableLargerThanScreen:enable_larger_than_screen()];
 
   window_delegate_.reset([[ElectronNSWindowDelegate alloc] initWithShell:this]);


### PR DESCRIPTION
#### Description of Change

This is potential fix for a crash we're seeing in which updating the native theme can sometimes access the previously deallocated `window_` ptr in `NativeWindowMac`. I'm unable to reproduce the crash, but do have a symbolicated stack trace:

```
Crashed Thread:        0  CrBrowserMain  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       KERN_INVALID_ADDRESS at 0x00000000140109c0
Exception Note:        EXC_CORPSE_NOTIFY

Termination Signal:    Segmentation fault: 11
Termination Reason:    Namespace SIGNAL, Code 0xb
Terminating Process:   exc handler [10315]

VM Regions Near 0x140109c0:
-->
    __TEXT                      1007a8000-10080c000    [  400K] r-x/r-x SM=COW  /Applications/Around-stage.app/Contents/MacOS/Around-stage

Application Specific Information:
objc_msgSend() selector name: styleMask


Thread 0 Crashed:: CrBrowserMain  Dispatch queue: com.apple.main-thread
0   libobjc.A.dylib               	0x00000001905f3240 objc_msgSend
1   com.github.Electron.framework 	0x0000000100bacc48 electron::NativeWindowMac::IsFullscreen() const
2   com.github.Electron.framework 	0x0000000100bafbd0 electron::NativeWindowMac::RedrawTrafficLights()
3   com.github.Electron.framework 	0x000000010339eb78 base::TaskAnnotator::RunTask(char const*, base::PendingTask*)
4   com.github.Electron.framework 	0x00000001033b4a6c base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::sequence_manager::LazyNow*)
5   com.github.Electron.framework 	0x00000001033b57fc non-virtual thunk to base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()
6   com.github.Electron.framework 	0x00000001033f1774 base::MessagePumpCFRunLoopBase::RunWork()
7   com.github.Electron.framework 	0x00000001033f1cbc invocation function for block in base::MessagePumpCFRunLoopBase::RunNestingDeferredWorkSource(void*)
8   com.github.Electron.framework 	0x00000001033f0c60 base::mac::CallWithEHFrame(void () block_pointer)
9   com.github.Electron.framework 	0x00000001033f1298 base::MessagePumpCFRunLoopBase::RunNestingDeferredWorkSource(void*)
10  com.apple.CoreFoundation      	0x000000019085aa84 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
11  com.apple.CoreFoundation      	0x000000019085a9d0 __CFRunLoopDoSource0
12  com.apple.CoreFoundation      	0x000000019085a728 __CFRunLoopDoSources0
13  com.apple.CoreFoundation      	0x0000000190859044 __CFRunLoopRun
14  com.apple.CoreFoundation      	0x0000000190858598 CFRunLoopRunSpecific
15  com.apple.HIToolbox           	0x000000019877b280 RunCurrentEventLoopInMode
16  com.apple.HIToolbox           	0x000000019877af0c ReceiveNextEventCommon
17  com.apple.HIToolbox           	0x000000019877adb4 _BlockUntilNextEventMatchingListInModeWithFilter
18  com.apple.AppKit              	0x0000000193049a64 _DPSNextEvent
19  com.apple.AppKit              	0x0000000193048404 -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:]
20  com.apple.AppKit              	0x000000019303a290 -[NSApplication run]
21  com.github.Electron.framework 	0x00000001033f21c0 base::MessagePumpNSApplication::DoRun(base::MessagePump::Delegate*)
22  com.github.Electron.framework 	0x00000001033f0ce4 base::MessagePumpCFRunLoopBase::Run(base::MessagePump::Delegate*)
23  com.github.Electron.framework 	0x00000001033b5ce0 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool, base::TimeDelta)
24  com.github.Electron.framework 	0x0000000103386aa8 base::RunLoop::Run(base::Location const&)
25  com.github.Electron.framework 	0x000000010266060c content::BrowserMainLoop::RunMainMessageLoop()
26  com.github.Electron.framework 	0x0000000102661f4c content::BrowserMainRunnerImpl::Run()
27  com.github.Electron.framework 	0x000000010265e040 content::BrowserMain(content::MainFunctionParams const&)
28  com.github.Electron.framework 	0x000000010168b010 content::ContentMainRunnerImpl::RunBrowser(content::MainFunctionParams&, bool)
29  com.github.Electron.framework 	0x000000010168ab40 content::ContentMainRunnerImpl::Run(bool)
30  com.github.Electron.framework 	0x00000001016897d8 content::RunContentProcess(content::ContentMainParams const&, content::ContentMainRunner*)
31  com.github.Electron.framework 	0x0000000101689da0 content::ContentMain(content::ContentMainParams const&)
32  com.github.Electron.framework 	0x0000000100a38474 ElectronMain
33  co.teamport.around.stage      	0x00000001007a8dac 0x1007a8000 + 3500
34  libdyld.dylib                 	0x0000000190779430 start
```

The only place where `NativeWindowMac::RedrawTrafficLights` is posted to an async task is from
https://github.com/electron/electron/blob/014ebbd6fab77d323dd262246c9655f0aa790e61/shell/browser/native_window_mac.mm#L1742-L1746

In the case of this crash, `NativeWindowMac` must still exist while `window_` does not. When the async task is processed, `window_` points to a previously deallocated ptr.
https://github.com/electron/electron/blob/014ebbd6fab77d323dd262246c9655f0aa790e61/shell/browser/native_window_mac.mm#L685-L687

With this proposed fix, `window_` would be `nil` which shouldn't elicit a crash.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes a potential crash when setting `nativeTheme.themeSource` on macOS.
