### PR TITLE
fix: black window on screen capture when content protection is enabled

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1105,8 +1105,17 @@ void NativeWindowViews::SetIgnoreMouseEvents(bool ignore, bool forward) {
 
 void NativeWindowViews::SetContentProtection(bool enable) {
 #if defined(OS_WIN)
+  HWND hwnd = GetAcceleratedWidget();
+  if (!layered_) {
+    // Workaround to prevent black window on screen capture after hiding and
+    // showing the BrowserWindow.
+    LONG ex_style = ::GetWindowLong(hwnd, GWL_EXSTYLE);
+    ex_style |= WS_EX_LAYERED;
+    ::SetWindowLong(hwnd, GWL_EXSTYLE, ex_style);
+    layered_ = true;
+  }
   DWORD affinity = enable ? WDA_EXCLUDEFROMCAPTURE : WDA_NONE;
-  ::SetWindowDisplayAffinity(GetAcceleratedWidget(), affinity);
+  ::SetWindowDisplayAffinity(hwnd, affinity);
 #endif
 }
 


### PR DESCRIPTION
#### Description of Change

Closes #29085.

When screen sharing, BrowserWindows with enabled content protection should be transparent on supported Win 10 versions. However, after hiding and showing the window, Windows falls back to a black rectangle as known from the old [`WDA_MONITOR`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowdisplayaffinity) affinity (though `GetWindowDisplayAffinity` still returns `WDA_EXCLUDEFROMCAPTURE`). This workaround mitigates the issue by setting the `WS_EX_LAYERED` flag on the window.

Please backport to v15 & v16.

Repro fiddle: https://gist.github.com/012544e8dbde6143d809dd82b201b236
Repro steps: run -> aux window will be hidden; press hide & show -> black/transparent rect

cc @codebytere @miniak @zarubond 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed black window when screen capturing a content-protected BrowserWindow on Windows 10.