### PR TITLE
docs: nativeWindowOpen default was changed in Electron 15

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -69,6 +69,18 @@ Electron apps.
 See [here](#removed-desktopcapturergetsources-in-the-renderer) for details on
 how to replace this API in your app.
 
+## Planned Breaking API Changes (15.0)
+
+### Default Changed: `nativeWindowOpen` defaults to `true`
+
+Prior to Electron 15, `window.open` was by default shimmed to use
+`BrowserWindowProxy`. This meant that `window.open('about:blank')` did not work
+to open synchronously scriptable child windows, among other incompatibilities.
+`nativeWindowOpen` is no longer experimental, and is now the default.
+
+See the documentation for [window.open in Electron](api/window-open.md)
+for more details.
+
 ## Planned Breaking API Changes (14.0)
 
 ### Removed: `remote` module
@@ -118,16 +130,6 @@ ensure your code works with this property enabled.  It has been enabled by defau
 12.
 
 You will be affected by this change if you use either `webFrame.executeJavaScript` or `webFrame.executeJavaScriptInIsolatedWorld`. You will need to ensure that values returned by either of those methods are supported by the [Context Bridge API](api/context-bridge.md#parameter--error--return-type-support) as these methods use the same value passing semantics.
-
-### Default Changed: `nativeWindowOpen` defaults to `true`
-
-Prior to Electron 14, `window.open` was by default shimmed to use
-`BrowserWindowProxy`. This meant that `window.open('about:blank')` did not work
-to open synchronously scriptable child windows, among other incompatibilities.
-`nativeWindowOpen` is no longer experimental, and is now the default.
-
-See the documentation for [window.open in Electron](api/window-open.md)
-for more details.
 
 ### Removed: BrowserWindowConstructorOptions inheriting from parent windows
 


### PR DESCRIPTION
#### Description of Change
It was added to Electron 14 section of breaking-changes.md by #28552. But then it got postponed to Electron 15.
It was fixed in 14-x-y by #29869, but it's still incorrectly documented in main.

https://www.electronjs.org/blog/electron-15-0#default-changed-nativewindowopen-defaults-to-true

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added

#### Release Notes
Notes: none
