### PR TITLE
fix: correctly notify WebViewGuestDelegate when webview is detached

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -939,8 +939,6 @@ WebContents::~WebContents() {
   }
 
   inspectable_web_contents_->GetView()->SetDelegate(nullptr);
-  if (guest_delegate_)
-    guest_delegate_->WillDestroy();
 
   // This event is only for internal use, which is emitted when WebContents is
   // being destroyed.
@@ -1953,6 +1951,10 @@ void WebContents::WebContentsDestroyed() {
   if (!GetWrapper(isolate).ToLocal(&wrapper))
     return;
   wrapper->SetAlignedPointerInInternalField(0, nullptr);
+
+  // Tell WebViewGuestDelegate that the WebContents has been destroyed.
+  if (guest_delegate_)
+    guest_delegate_->WillDestroy();
 
   Observe(nullptr);
   Emit("destroyed");

--- a/spec-main/webview-spec.ts
+++ b/spec-main/webview-spec.ts
@@ -397,6 +397,23 @@ describe('<webview> tag', function () {
       expect(webview.getZoomFactor()).to.equal(1.2);
       await w.loadURL(`${zoomScheme}://host1`);
     });
+
+    it('does not crash when changing zoom level after webview is destroyed', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        webPreferences: {
+          webviewTag: true,
+          nodeIntegration: true,
+          session: webviewSession,
+          contextIsolation: false
+        }
+      });
+      const attachPromise = emittedOnce(w.webContents, 'did-attach-webview');
+      await w.loadFile(path.join(fixtures, 'pages', 'webview-zoom-inherited.html'));
+      await attachPromise;
+      await w.webContents.executeJavaScript('view.remove()');
+      w.webContents.setZoomLevel(0.5);
+    });
   });
 
   describe('requestFullscreen from webview', () => {


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/31332.

Fix a crash caused by https://github.com/electron/electron/pull/27920 that, when webview is detached the  `guest_delegate_->WillDestroy()` is not called, so the zoom level controller still thinks the WebContents is still alive and will crash when zoom level changes.

Moving `guest_delegate_->WillDestroy()` from `~WebContents` destructor back to `WebContentsDestroyed` fixes the crash.

#### Release Notes

Notes: Fix crash when changing zoom level for webview.