### PR TITLE
feat: also pass securityOrigin to media permissions request handler

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -618,6 +618,7 @@ win.webContents.session.setCertificateVerifyProc((request, callback) => {
     * `permissionGranted` Boolean - Allow or deny the permission.
   * `details` Object - Some properties are only available on certain permission types.
     * `externalURL` String (optional) - The url of the `openExternal` request.
+    * `securityOrigin` String (optional) - The security origin of the `media` request.
     * `mediaTypes` String[] (optional) - The types of media access being requested, elements can be `video`
       or `audio`
     * `requestingUrl` String - The last URL the requesting frame loaded

--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -140,6 +140,7 @@ void WebContentsPermissionHelper::RequestMediaAccessPermission(
     media_types->Append("video");
   }
   details.SetList("mediaTypes", std::move(media_types));
+  details.SetString("securityOrigin", request.security_origin.spec());
 
   // The permission type doesn't matter here, AUDIO_CAPTURE/VIDEO_CAPTURE
   // are presented as same type in content_converter.h.

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -947,6 +947,7 @@ describe('chromium features', () => {
     afterEach(closeAllWindows);
     afterEach(() => {
       session.defaultSession.setPermissionCheckHandler(null);
+      session.defaultSession.setPermissionRequestHandler(null);
     });
 
     it('can return labels of enumerated devices', async () => {
@@ -995,6 +996,32 @@ describe('chromium features', () => {
       await ses.clearStorageData({ storages: ['cookies'] });
       const [, secondDeviceIds] = await emittedOnce(ipcMain, 'deviceIds', () => w.webContents.reload());
       expect(firstDeviceIds).to.not.deep.equal(secondDeviceIds);
+    });
+
+    it('provides a securityOrigin to the request handler', async () => {
+      session.defaultSession.setPermissionRequestHandler(
+        (wc, permission, callback, details) => {
+          if (details.securityOrigin !== undefined) {
+            callback(true);
+          } else {
+            callback(false);
+          }
+        }
+      );
+      const w = new BrowserWindow({ show: false });
+      w.loadFile(path.join(fixturesPath, 'pages', 'blank.html'));
+      const labels = await w.webContents.executeJavaScript(`navigator.mediaDevices.getUserMedia({
+          video: {
+            mandatory: {
+              chromeMediaSource: "desktop",
+              minWidth: 1280,
+              maxWidth: 1280,
+              minHeight: 720,
+              maxHeight: 720
+            }
+          }
+        }).then((stream) => stream.getVideoTracks())`);
+      expect(labels.some((l: any) => l)).to.be.true();
     });
   });
 


### PR DESCRIPTION
For `media` requests, the handler passed to `setPermissionRequestHandler` seems to always get a reference to the top-level frame and the top-level URL, and is not passed the request's `security_origin`. For consistency with `setPermissionCheckHandler`'s handling of this case for `media` requests, pass the request's `security_origin` as a new `securityOrigin` field in details to enable disambiguation.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes -> ran under `e test --runners=main`, everything seemed to behave just as it did before the change
- [x] tests are added
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Began passing securityOrigin in details for permission request handlers for media requests in addition to permission check handlers.