### PR TITLE
fix: reset render_frame_disposed_ after render frame host change

### DIFF
--- a/lib/browser/api/web-frame-main.ts
+++ b/lib/browser/api/web-frame-main.ts
@@ -7,7 +7,11 @@ WebFrameMain.prototype.send = function (channel, ...args) {
     throw new Error('Missing required channel argument');
   }
 
-  return this._send(false /* internal */, channel, args);
+  try {
+    return this._send(false /* internal */, channel, args);
+  } catch (e) {
+    console.error('Error sending from webFrameMain: ', e);
+  }
 };
 
 WebFrameMain.prototype._sendInternal = function (channel, ...args) {
@@ -15,7 +19,11 @@ WebFrameMain.prototype._sendInternal = function (channel, ...args) {
     throw new Error('Missing required channel argument');
   }
 
-  return this._send(true /* internal */, channel, args);
+  try {
+    return this._send(true /* internal */, channel, args);
+  } catch (e) {
+    console.error('Error sending from webFrameMain: ', e);
+  }
 };
 
 WebFrameMain.prototype.postMessage = function (...args) {

--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -100,11 +100,7 @@ void WebFrameMain::MarkRenderFrameDisposed() {
 
 void WebFrameMain::UpdateRenderFrameHost(content::RenderFrameHost* rfh) {
   // Should only be called when swapping frames.
-  if (!render_frame_disposed_) {
-    DCHECK(render_frame_);
-  } else {
-    render_frame_disposed_ = false;
-  }
+  render_frame_disposed_ = false;
   render_frame_ = rfh;
   renderer_api_.reset();
 }
@@ -162,7 +158,7 @@ v8::Local<v8::Promise> WebFrameMain::ExecuteJavaScript(
 }
 
 bool WebFrameMain::Reload() {
-  if (render_frame_disposed_)
+  if (!CheckRenderFrame())
     return false;
   return render_frame_->Reload();
 }
@@ -178,7 +174,7 @@ void WebFrameMain::Send(v8::Isolate* isolate,
     return;
   }
 
-  if (render_frame_disposed_)
+  if (!CheckRenderFrame())
     return;
 
   GetRendererApi()->Message(internal, channel, std::move(message),


### PR DESCRIPTION
#### Description of Change

This PR fixes a JavaScript crash that occurs if a webContents is trying to send or reload when a render frame has been marked as disposed. Previously, if this occurred, the send would fail silently and eventually recover and reload. Now, we throw an error in `CheckRenderFrame`, which appears to an app user as a hard crash.

This PR resets the value of `render_frame_disposed_` after the render frame host has been updated, and prevents throwing a hard error on webFrameMain.send or webFrameMain.reload, while still checking for the existence of the `render_frame_`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a JavaScript exception from webContents if render frame was disposed in WebFrameMain, resets the value of `render_frame_disposed_` after updating render frame host
