### PR TITLE
fix: generate valid config.gypi

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -187,6 +187,12 @@ action("electron_js2c") {
          rebase_path(sources, root_build_dir)
 }
 
+action("generate_config_gypi") {
+  outputs = [ "$root_gen_dir/config.gypi" ]
+  script = "script/generate-config-gypi.py"
+  args = rebase_path(outputs) + [ target_cpu ]
+}
+
 target_gen_default_app_js = "$target_gen_dir/js/default_app"
 
 typescript_build("default_app_js") {

--- a/patches/node/build_add_gn_build_files.patch
+++ b/patches/node/build_add_gn_build_files.patch
@@ -7,10 +7,10 @@ This adds GN build files for Node, so we don't have to build with GYP.
 
 diff --git a/BUILD.gn b/BUILD.gn
 new file mode 100644
-index 0000000000000000000000000000000000000000..52fb22305bb67c75c9a1cf4bc39cd901420cf7a9
+index 0000000000000000000000000000000000000000..d0641c5cbc3c527ce7a73d12118fb42db325be01
 --- /dev/null
 +++ b/BUILD.gn
-@@ -0,0 +1,401 @@
+@@ -0,0 +1,393 @@
 +import("//electron/build/asar.gni")
 +import("//v8/gni/v8.gni")
 +
@@ -75,20 +75,12 @@ index 0000000000000000000000000000000000000000..52fb22305bb67c75c9a1cf4bc39cd901
 +  ]
 +}
 +
-+action("generate_config_gypi") {
-+  outputs = [
-+    "$target_gen_dir/config.gypi",
-+  ]
-+  script = "tools/generate_config_gypi.py"
-+  args = rebase_path(outputs, root_build_dir)
-+}
-+
 +chdir_action("node_js2c") {
 +  deps = [
-+    ":generate_config_gypi",
++    "//electron:generate_config_gypi",
 +    ":node_js2c_inputs",
 +  ]
-+  config_gypi = [ "$target_gen_dir/config.gypi" ]
++  config_gypi = [ "$root_gen_dir/config.gypi" ]
 +  inputs = library_files + config_gypi
 +  outputs = [
 +    "$target_gen_dir/node_javascript.cc",
@@ -360,10 +352,10 @@ index 0000000000000000000000000000000000000000..52fb22305bb67c75c9a1cf4bc39cd901
 +
 +copy("node_gypi_headers") {
 +  deps = [
-+    ":generate_config_gypi",
++    "//electron:generate_config_gypi",
 +  ]
 +  sources = [
-+    "$target_gen_dir/config.gypi",
++    "$root_gen_dir/config.gypi",
 +    "common.gypi",
 +  ]
 +  outputs = [
@@ -1795,34 +1787,6 @@ index a572d9b95853730a29a67349b46d47d6180586f3..888a95f93411a9168b75751e0af12c74
  
  // The NAPI_VERSION provided by this version of the runtime. This is the version
  // which the Node binary being built supports.
-diff --git a/tools/generate_config_gypi.py b/tools/generate_config_gypi.py
-new file mode 100755
-index 0000000000000000000000000000000000000000..c12dcb2b844f7f415318d81115ff697fd8eb4689
---- /dev/null
-+++ b/tools/generate_config_gypi.py
-@@ -0,0 +1,22 @@
-+import sys
-+import json
-+
-+def main(args):
-+  out = args[0]
-+  output = {
-+    'variables': {
-+      'built_with_electron': 1,
-+      'v8_enable_i18n_support': 1,
-+    },
-+    'include_dirs': [],
-+    'libraries': [],
-+    'defines': [],
-+    'cflags': [],
-+  }
-+
-+  with open(out, 'w') as f:
-+    f.write(json.dumps(output))
-+    f.write("\n")
-+
-+if __name__ == '__main__':
-+  main(sys.argv[1:])
 diff --git a/tools/generate_gn_filenames_json.py b/tools/generate_gn_filenames_json.py
 new file mode 100755
 index 0000000000000000000000000000000000000000..8f884a41f57630ac432eb85ebfc9b8bc82cddaca

--- a/script/generate-config-gypi.py
+++ b/script/generate-config-gypi.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import ast
+import os
+import pprint
+import re
+import subprocess
+import sys
+
+ELECTRON_DIR = os.path.abspath(os.path.join(__file__, '..', '..'))
+NODE_DIR = os.path.join(ELECTRON_DIR, '..', 'third_party', 'electron_node')
+
+def run_node_configure(target_cpu):
+  configure = os.path.join(NODE_DIR, 'configure.py')
+  args = ['--dest-cpu', target_cpu]
+  # Enabled in Chromium's V8.
+  if target_cpu == 'arm64' or target_cpu == 'x64':
+    args += ['--experimental-enable-pointer-compression']
+  # Work around "No acceptable ASM compiler found" error on some Windows
+  # machines, it breaks nothing since Electron does not use OpenSSL.
+  if sys.platform == 'win32':
+    args += ['--openssl-no-asm']
+  subprocess.check_call([sys.executable, configure] + args)
+
+def read_node_config_gypi():
+  config_gypi = os.path.join(NODE_DIR, 'config.gypi')
+  with open(config_gypi, 'r') as f:
+    content = f.read()
+    return ast.literal_eval(content)
+
+def read_electron_args():
+  all_gn = os.path.join(ELECTRON_DIR, 'build', 'args', 'all.gn')
+  args = {}
+  with open(all_gn, 'r') as f:
+    for line in f:
+      if line.startswith('#'):
+        continue
+      m = re.match('([\w_]+) = (.+)', line)
+      if m == None:
+        continue
+      args[m.group(1)] = m.group(2)
+  return args
+
+def main(target_file, target_cpu):
+  run_node_configure(target_cpu)
+  config = read_node_config_gypi()
+  args = read_electron_args()
+
+  # Remove the generated config.gypi to make the parallel/test-process-config
+  # test pass.
+  os.remove(os.path.join(NODE_DIR, 'config.gypi'))
+
+  v = config['variables']
+  # Electron specific variables:
+  v['built_with_electron'] = 1
+  v['node_module_version'] = int(args['node_module_version'])
+  # Used by certain versions of node-gyp.
+  v['build_v8_with_gn'] = 'false'
+
+  with open(target_file, 'w+') as f:
+    f.write(pprint.pformat(config, indent=2))
+
+if __name__ == '__main__':
+  sys.exit(main(*sys.argv[1:]))


### PR DESCRIPTION
#### Description of Change

Currently Electron generates a malformed `config.gypi` file in Node headers, which is fine since it is actually ignored by node-gyp when building modules.

However with https://github.com/nodejs/node-gyp/pull/2497, the `config.gypi` file in Node headers is going to be respected, and with it we will finally be able to get rid of our patches on Node's `common.gypi` file. And to make Electron's Node headers work correctly with node-gyp, we must generated a valid `config.gypi` file.

#### Release Notes

Notes: Generate valid config.gypi file in Node.js headers.