### PR TITLE
fix: ensure TracingAgent in place for SWs

### DIFF
--- a/shell/renderer/web_worker_observer.cc
+++ b/shell/renderer/web_worker_observer.cc
@@ -51,6 +51,10 @@ void WebWorkerObserver::WorkerScriptReadyForEvaluation(
   // Start the embed thread.
   node_bindings_->PrepareMessageLoop();
 
+  // Setup node tracing controller.
+  if (!node::tracing::TraceEventHelper::GetAgent())
+    node::tracing::TraceEventHelper::SetAgent(node::CreateAgent());
+
   // Setup node environment for each window.
   bool initialized = node::InitializeContext(worker_context);
   CHECK(initialized);


### PR DESCRIPTION
#### Description of Change

Partially addresses https://github.com/electron/electron/issues/31452. Ensures that a tracing agent is set before the environment is created, which is already done https://github.com/electron/electron/blob/675bbfe0925ec0c1f1d920ed9006167d5606fda9/shell/renderer/electron_renderer_client.cc#L101-L103 and https://github.com/electron/electron/blob/cc01272a8d8fef921508f387e73e2a4ba03af2b1/shell/browser/javascript_environment.cc#L326 but had not been done for Workers.
 
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a tracing agent-related crash when initializing Node.js in service workers.
