### PR TITLE
fix: remove `NOTREACHED()` from `GetWindowResizeEdge`

### DIFF
--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -158,7 +158,6 @@ gfx::ResizeEdge GetWindowResizeEdge(WPARAM param) {
     case WMSZ_BOTTOMRIGHT:
       return gfx::ResizeEdge::kBottomRight;
     default:
-      NOTREACHED();
       return gfx::ResizeEdge::kBottomRight;
   }
 }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Previously in a test build on Windows, when a window was maximized and restored by moving it to the top edge of the window and subsequently pulling it away, the default case of the switch statement in `GetWindowResizeEdge` would get hit. This would result in a debug check returning false and crashing the program.

By removing this `NOTREACHED()` call, the test build program does not crash.

@deermichel 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: None <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
