### PR TITLE
fix: don't use private enterprise APIs in MAS build

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -106,3 +106,4 @@ feat_expose_raw_response_headers_from_urlloader.patch
 fix_media_key_usage_with_globalshortcuts.patch
 cherry-pick-ec42dfd3545f.patch
 cherry-pick-39090918efac.patch
+mas_gate_private_enterprise_APIs

--- a/patches/chromium/mas_gate_private_enterprise_APIs
+++ b/patches/chromium/mas_gate_private_enterprise_APIs
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: VerteDinde <keeleymhammond@gmail.com>
+Date: Tue, 19 Oct 2021 17:55:57 -0700
+Subject: fix: mas gate private enterprise APIs
+
+Beginning in Electron 15.2.0, Chromium moved several formerly public
+APIs into the AreDeviceAndUserJoinedToDomain method. Using these APIs
+in a MAS build will result in rejection from the Apple Store. This
+patch gates those APIs to non-MAS builds to comply with Apple
+Store requirements, and returns the default state for MAS builds.
+
+diff --git a/base/enterprise_util_mac.mm b/base/enterprise_util_mac.mm
+index bbb851e1cafb37ebaa67e4577598fab25c90fde6..6ab12e5505b5ba545e7e0cc8c93d3ba9a6d0bacc 100644
+--- a/base/enterprise_util_mac.mm
++++ b/base/enterprise_util_mac.mm
+@@ -168,6 +168,13 @@ MacDeviceManagementStateNew IsDeviceRegisteredWithManagementNew() {
+ DeviceUserDomainJoinState AreDeviceAndUserJoinedToDomain() {
+   static DeviceUserDomainJoinState state = [] {
+     DeviceUserDomainJoinState state{false, false};
++#if defined(MAS_BUILD)
++    return state;
++  }();
++
++  return state;
++}
++#else
+ 
+     @autoreleasepool {
+       ODSession* session = [ODSession defaultSession];
+@@ -274,5 +281,6 @@ DeviceUserDomainJoinState AreDeviceAndUserJoinedToDomain() {
+ 
+   return state;
+ }
++#endif
+ 
+ }  // namespace base


### PR DESCRIPTION
#### Description of Change

Manual backport of #31482 

See that PR for details.

Notes: Removes several Chromium private APIs from Mac Apple Store builds.
