### PR TITLE
fix: MediaMetadata not working properly

### DIFF
--- a/patches/chromium/fix_media_key_usage_with_globalshortcuts.patch
+++ b/patches/chromium/fix_media_key_usage_with_globalshortcuts.patch
@@ -10,33 +10,94 @@ receive remote control events until it begins playing audio. This runs
 counter to the design of globalShortcuts, and so we need to instead
 use `ui::MediaKeysListener`.
 
+diff --git a/chrome/browser/extensions/global_shortcut_listener.cc b/chrome/browser/extensions/global_shortcut_listener.cc
+index bc009606d01469125052e68a9cdc82aaa697c764..ff18043cb07d748a49adea9874517fb29e3e7f9f 100644
+--- a/chrome/browser/extensions/global_shortcut_listener.cc
++++ b/chrome/browser/extensions/global_shortcut_listener.cc
+@@ -7,6 +7,7 @@
+ #include "base/check.h"
+ #include "base/notreached.h"
+ #include "content/public/browser/browser_thread.h"
++#include "content/public/browser/media_keys_listener_manager.h"
+ #include "ui/base/accelerators/accelerator.h"
+ 
+ using content::BrowserThread;
+@@ -66,6 +67,22 @@ void GlobalShortcutListener::UnregisterAccelerator(
+     StopListening();
+ }
+ 
++// static
++void GlobalShortcutListener::SetShouldUseInternalMediaKeyHandling(bool should_use) {
++  if (content::MediaKeysListenerManager::
++            IsMediaKeysListenerManagerEnabled()) {
++    content::MediaKeysListenerManager* media_keys_listener_manager =
++        content::MediaKeysListenerManager::GetInstance();
++    DCHECK(media_keys_listener_manager);
++
++    if (should_use) {
++      media_keys_listener_manager->EnableInternalMediaKeyHandling();
++    } else {
++      media_keys_listener_manager->DisableInternalMediaKeyHandling();
++    }
++  }
++}
++
+ void GlobalShortcutListener::UnregisterAccelerators(Observer* observer) {
+   CHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
+   if (IsShortcutHandlingSuspended())
+diff --git a/chrome/browser/extensions/global_shortcut_listener.h b/chrome/browser/extensions/global_shortcut_listener.h
+index 554930bc33d87ee88a9bcc5f0cf17cef09c27ef0..8df4f91d3db453afb9f73bcaeb82c919ca8d1841 100644
+--- a/chrome/browser/extensions/global_shortcut_listener.h
++++ b/chrome/browser/extensions/global_shortcut_listener.h
+@@ -34,6 +34,8 @@ class GlobalShortcutListener {
+ 
+   static GlobalShortcutListener* GetInstance();
+ 
++  static void SetShouldUseInternalMediaKeyHandling(bool should_use);
++
+   // Register an observer for when a certain |accelerator| is struck. Returns
+   // true if register successfully, or false if 1) the specificied |accelerator|
+   // has been registered by another caller or other native applications, or
 diff --git a/content/browser/media/media_keys_listener_manager_impl.cc b/content/browser/media/media_keys_listener_manager_impl.cc
-index 5938f75742b793868638e693a9a8c8dc686dfc46..bf8782c23095a09dec62c68d7d902df24abcb13e 100644
+index 5938f75742b793868638e693a9a8c8dc686dfc46..1263d679a5174beb960265989c370dd4a58ae7b4 100644
 --- a/content/browser/media/media_keys_listener_manager_impl.cc
 +++ b/content/browser/media/media_keys_listener_manager_impl.cc
-@@ -231,7 +231,7 @@ void MediaKeysListenerManagerImpl::StartListeningForMediaKeysIfNecessary() {
+@@ -231,18 +231,24 @@ void MediaKeysListenerManagerImpl::StartListeningForMediaKeysIfNecessary() {
        media::AudioManager::GetGlobalAppName());
  #endif
  
 -  if (system_media_controls_) {
-+  if (/* DISABLES CODE */ (0)) {
-     system_media_controls_->AddObserver(this);
-     system_media_controls_notifier_ =
-         std::make_unique<SystemMediaControlsNotifier>(
-@@ -239,8 +239,13 @@ void MediaKeysListenerManagerImpl::StartListeningForMediaKeysIfNecessary() {
-   } else {
-     // If we can't access system media controls, then directly listen for media
-     // key keypresses instead.
-+#if defined(OS_MAC)
-+  media_keys_listener_ = ui::MediaKeysListener::Create(
-+        this, ui::MediaKeysListener::Scope::kGlobalRequiresAccessibility);
-+#else
+-    system_media_controls_->AddObserver(this);
+-    system_media_controls_notifier_ =
+-        std::make_unique<SystemMediaControlsNotifier>(
+-            system_media_controls_.get());
+-  } else {
+-    // If we can't access system media controls, then directly listen for media
+-    // key keypresses instead.
++  // This is required for proper functioning of MediaMetadata.
++  system_media_controls_->AddObserver(this);
++  system_media_controls_notifier_ =
++      std::make_unique<SystemMediaControlsNotifier>(
++          system_media_controls_.get());
++
++  // Directly listen for media key keypresses when using GlobalShortcuts.
++#if defined(OS_MACOS)
++  auto scope = media_key_handling_enabled_ ?
++    ui::MediaKeysListener::Scope::kGlobal :
++    ui::MediaKeysListener::Scope::kGlobalRequiresAccessibility;
      media_keys_listener_ = ui::MediaKeysListener::Create(
-         this, ui::MediaKeysListener::Scope::kGlobal);
+-        this, ui::MediaKeysListener::Scope::kGlobal);
+-    DCHECK(media_keys_listener_);
+-  }
++      this, scope);
++#else
++  media_keys_listener_ = ui::MediaKeysListener::Create(
++    this, ui::MediaKeysListener::Scope::kGlobal);
 +#endif
-     DCHECK(media_keys_listener_);
-   }
++  DCHECK(media_keys_listener_);
  
+   EnsureAuxiliaryServices();
+ }
 diff --git a/ui/base/accelerators/media_keys_listener.h b/ui/base/accelerators/media_keys_listener.h
 index c2b03328c0e508995bdc135031500783f500ceba..1b6b14dc2999c99445cef6ffc04d49a7c1728a54 100644
 --- a/ui/base/accelerators/media_keys_listener.h


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/31448.
Closes https://github.com/electron/electron/issues/30860.

Fixes an issue where MediaMetadata would not show up properly, and also ensures that this works properly in conjuction with `globalShortcut` handling for media keys. As of this PR: if a video element is played and no global shortcuts are registered, all media key handling works as it should be default. If a global shortcut is registered for a media key, then that takes precedence. 

Tested with https://gist.github.com/5ba749964fcd7576b677a3ca93093edd.

Running gist before:
<img width="338" alt="Screen Shot 2021-10-20 at 4 05 10 PM" src="https://user-images.githubusercontent.com/2036040/138108586-184ec489-ad56-4123-a073-7dbda9d3ed71.png">

Running gist after:
<img width="323" alt="Screen Shot 2021-10-20 at 4 04 55 PM" src="https://user-images.githubusercontent.com/2036040/138108733-020ff409-5760-48f6-8f87-6ac9e953bd9d.png">

The global shortcut behavior around media keys can also be verified by adding:

```js
  globalShortcut.register('MediaPlayPause', () => {
    console.log('The global shortkey MediaPlayPause was pressed!')
  })
```

to the above provided gist and observing that the string is logged to console.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `MediaMetadata` did not work properly.
