### PR TITLE
fix: vibrant window should have transparent background

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -37,14 +37,22 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
       gin::Dictionary::CreateEmpty(isolate);
   options.Get(options::kWebPreferences, &web_preferences);
 
-  // Copy the backgroundColor to webContents.
   v8::Local<v8::Value> value;
   bool transparent = false;
+  options.Get(options::kTransparent, &transparent);
+
+  std::string vibrancy_type;
+#if defined(OS_MAC)
+  options.Get(options::kVibrancyType, &vibrancy_type);
+#endif
+
+  // Copy the backgroundColor to webContents.
   if (options.Get(options::kBackgroundColor, &value)) {
     web_preferences.SetHidden(options::kBackgroundColor, value);
-  } else if (options.Get(options::kTransparent, &transparent) && transparent) {
-    // If the BrowserWindow is transparent, also propagate transparency to the
-    // WebContents unless a separate backgroundColor has been set.
+  } else if (!vibrancy_type.empty() || transparent) {
+    // If the BrowserWindow is transparent or a vibrancy type has been set,
+    // also propagate transparency to the WebContents unless a separate
+    // backgroundColor has been set.
     web_preferences.SetHidden(options::kBackgroundColor,
                               ToRGBAHex(SK_ColorTRANSPARENT));
   }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/31461.

Fixes an issue where windows with vibrancy types set on them would incorrectly have a white instead of transparent background. This was caused by changes to defaults in webContents that Chromium performed, which were partially addressed in https://github.com/electron/electron/pull/30777.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where windows with vibrancy types set on them would incorrectly have a white instead of transparent background.