### PR TITLE
chore: import base/macros.h into asar/archive.h

### DIFF
--- a/shell/common/asar/archive.h
+++ b/shell/common/asar/archive.h
@@ -12,6 +12,7 @@
 
 #include "base/files/file.h"
 #include "base/files/file_path.h"
+#include "base/macros.h"
 #include "base/synchronization/lock.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 


### PR DESCRIPTION
#### Description of Change

Should correct a failure on Mac and Linux publish steps - this PR adds a header file import for a deprecated method, `DISALLOW_COPY_AND_ASSIGN`. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
