### PR TITLE
fix: clipboard.read() crash with custom types

### DIFF
--- a/shell/common/api/electron_api_clipboard.cc
+++ b/shell/common/api/electron_api_clipboard.cc
@@ -50,6 +50,17 @@ bool Clipboard::Has(const std::string& format_string,
 
 std::string Clipboard::Read(const std::string& format_string) {
   ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
+  ui::ClipboardFormatType format(
+      ui::ClipboardFormatType::CustomPlatformType(format_string));
+
+  std::string data;
+  clipboard->ReadData(format, /* data_dst = */ nullptr, &data);
+  return data;
+}
+
+v8::Local<v8::Value> Clipboard::ReadBuffer(const std::string& format_string,
+                                           gin_helper::Arguments* args) {
+  ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
   std::map<std::string, std::string> custom_format_names;
   custom_format_names =
       clipboard->ExtractCustomPlatformNames(ui::ClipboardBuffer::kCopyPaste,
@@ -67,12 +78,6 @@ std::string Clipboard::Read(const std::string& format_string) {
 
   std::string data;
   clipboard->ReadData(format, /* data_dst = */ nullptr, &data);
-  return data;
-}
-
-v8::Local<v8::Value> Clipboard::ReadBuffer(const std::string& format_string,
-                                           gin_helper::Arguments* args) {
-  std::string data = Read(format_string);
   return node::Buffer::Copy(args->isolate(), data.data(), data.length())
       .ToLocalChecked();
 }

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -44,13 +44,7 @@ ifdescribe(process.platform !== 'win32' || process.arch !== 'arm64')('clipboard 
     });
   });
 
-  describe('clipboard.readBookmark', () => {
-    before(function () {
-      if (process.platform === 'linux') {
-        this.skip();
-      }
-    });
-
+  ifdescribe(process.platform !== 'linux')('clipboard.readBookmark', () => {
     it('returns title and url', () => {
       clipboard.writeBookmark('a title', 'https://electronjs.org');
 
@@ -65,6 +59,16 @@ ifdescribe(process.platform !== 'win32' || process.arch !== 'arm64')('clipboard 
         title: '',
         url: ''
       });
+    });
+  });
+
+  ifdescribe(process.platform !== 'linux')('clipboard.read()', () => {
+    it('does not crash when reading various custom clipboard types', () => {
+      const type = process.platform === 'darwin' ? 'NSFilenamesPboardType' : 'FileNameW';
+
+      expect(() => {
+        const result = clipboard.read(type);
+      }).to.not.throw();
     });
   });
 
@@ -100,13 +104,7 @@ ifdescribe(process.platform !== 'win32' || process.arch !== 'arm64')('clipboard 
     });
   });
 
-  describe('clipboard.read/writeFindText(text)', () => {
-    before(function () {
-      if (process.platform !== 'darwin') {
-        this.skip();
-      }
-    });
-
+  ifdescribe(process.platform === 'darwin')('clipboard.read/writeFindText(text)', () => {
     it('reads and write text to the find pasteboard', () => {
       clipboard.writeFindText('find this');
       expect(clipboard.readFindText()).to.equal('find this');


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/31556.

Fixes an issue where `clipboard.read()` would cause crashes with custom clipboard formats as a result of https://github.com/electron/electron/pull/30370/commits/2798d15ac01d15fb42dcb72b4f953b067c6a7a88, which was itself added to compensate for CL:3039323. Upon further reading of the CL, it's not clear to me that we need to restrict format types to those returned from `ExtractCustomPlatformNames`, since that is for example empty on macOS and seems to be addressing something other than what we do in `clipboard.read()`. This caused a DCHECK:

<details>
<summary>Stacktrace</summary>

```
[22922:1023/070046.410103:FATAL:electron_api_clipboard.cc(65)] Check failed: custom_format_names.find(format_string) != custom_format_names.end(). 
0   Electron Framework                  0x000000011ba497b9 base::debug::CollectStackTrace(void**, unsigned long) + 9
1   Electron Framework                  0x000000011b9670b3 base::debug::StackTrace::StackTrace() + 19
2   Electron Framework                  0x000000011b9823df logging::LogMessage::~LogMessage() + 175
3   Electron Framework                  0x000000011b9833ae logging::LogMessage::~LogMessage() + 14
4   Electron Framework                  0x000000011732b72c electron::api::Clipboard::Read(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) + 700
5   Electron Framework                  0x000000011732ea92 base::internal::Invoker<base::internal::BindState<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > (*)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)>::Run(base::internal::BindStateBase*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) + 18
6   Electron Framework                  0x000000011732ea15 void gin_helper::Invoker<gin_helper::IndicesHolder<0ul>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>::DispatchToCallback<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >(base::RepeatingCallback<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)>) + 133
7   Electron Framework                  0x000000011732e8f1 gin_helper::Dispatcher<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > (std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)>::DispatchToCallback(v8::FunctionCallbackInfo<v8::Value> const&) + 257
8   Electron Framework                  0x0000000118bcff93 v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo) + 979
9   Electron Framework                  0x0000000118bcde1d v8::internal::MaybeHandle<v8::internal::Object> v8::internal::(anonymous namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::FunctionTemplateInfo>, v8::internal::Handle<v8::internal::Object>, v8::internal::BuiltinArguments) + 1997
10  Electron Framework                  0x0000000118bcb7e3 v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments, v8::internal::Isolate*) + 547
11  Electron Framework                  0x0000000118bcb32d v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) + 109
12  ???                                 0x0000004000093938 0x0 + 274878511416
Task trace:
0   Electron Framework                  0x000000011c132e22 IPC::(anonymous namespace)::ChannelAssociatedGroupController::Accept(mojo::Message*) + 994
```

</details>

since the list is, as mentioned above, empty in our case.

cc @deepak1556 in case i am somehow missing something about the change in the CL.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue where `clipboard.read()` could cause crashes with custom clipboard formats.