### PR TITLE
fix: determines resizing edge based on current cursor on macOS

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -535,9 +535,11 @@ Note that this is only emitted when the window is being resized manually. Resizi
 The possible values and behaviors of the `edge` option are platform dependent. Possible values are:
 
 * On Windows, possible values are `bottom`, `top`, `left`, `right`, `top-left`, `top-right`, `bottom-left`, `bottom-right`.
-* On macOS, possible values are `bottom` and `right`.
+* On macOS, possible values are `bottom`, `right`, `bottom-left` and `bottom-right`.
   * The value `bottom` is used to denote vertical resizing.
   * The value `right` is used to denote horizontal resizing.
+  * The value `bottom-left` is also used to denote diagonal resizing in the `top-right` case.
+  * The value `bottom-right` is also used to denote diagonal resizing in the `top-left` case.
 
 #### Event: 'resize'
 

--- a/shell/browser/ui/cocoa/electron_ns_window_delegate.h
+++ b/shell/browser/ui/cocoa/electron_ns_window_delegate.h
@@ -9,6 +9,7 @@
 
 #include "components/remote_cocoa/app_shim/views_nswindow_delegate.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
+#include "ui/gfx/geometry/resize_utils.h"
 
 namespace electron {
 class NativeWindowMac;
@@ -26,6 +27,8 @@ class NativeWindowMac;
   // Used to keep track of whether a resize is happening horizontally or
   // vertically, even if physically the user is resizing in both directions.
   absl::optional<bool> resizingHorizontally_;
+
+  absl::optional<gfx::ResizeEdge> resizeDirection_;
 }
 - (id)initWithShell:(electron::NativeWindowMac*)shell;
 @end


### PR DESCRIPTION
#### Description of Change

Previously https://github.com/electron/electron/pull/29199 introduced resize edge infos to the will-resize events, but it had a limitation that on macOS it could only detect horizontal or vertical directions, so diagonal directions couldn't be detected.

This PR adds detection of diagonal resize edge directions for macOS with the help of checking what the current cursor is and comparing it to different types of cursors. It tries to call some undocumented macOS methods to query for the resizing cursor types, but if that doesn't succeed, it will fallback to the previous implementation.

The API in Electron for this includes different values for all edges and corners, but the macOS implementation uses the same values for edges opposite of each other, meaning that top and bottom is the same value as well as left and right etc.

Because resize events cannot be simulated, here is a recording:

Fiddle gist: [https://gist.github.com/samuelmaddock/32f5d98a4d87a8a806ea57469770fba9](https://gist.github.com/samuelmaddock/32f5d98a4d87a8a806ea57469770fba9)

https://user-images.githubusercontent.com/1059699/138691809-1ef91e26-726f-43c6-98b4-62d2307f0f51.mov

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Resizing edge on macOS is determined based on current cursor on macOS.
