### PR TITLE
chore: fix malformed mojom::CreateNewWindowParams patch

### DIFF
--- a/patches/chromium/chore_provide_iswebcontentscreationoverridden_with_full_params.patch
+++ b/patches/chromium/chore_provide_iswebcontentscreationoverridden_with_full_params.patch
@@ -7,7 +7,7 @@ Pending upstream patch, this gives us fuller access to the window.open params
 so that we will be able to decide whether to cancel it or not.
 
 diff --git a/chrome/browser/android/document/document_web_contents_delegate.cc b/chrome/browser/android/document/document_web_contents_delegate.cc
-index 0e90487923c57c0570e73ef0f0e8c5acc2576932..fcdc88233b2277f3b37a2a2b0bdee7d71b721bf8 100644
+index 0e90487923c57c0570e73ef0f0e8c5acc2576932..20fece7e761c28d8d13f53de5b5b521a73f4f168 100644
 --- a/chrome/browser/android/document/document_web_contents_delegate.cc
 +++ b/chrome/browser/android/document/document_web_contents_delegate.cc
 @@ -46,8 +46,7 @@ bool DocumentWebContentsDelegate::IsWebContentsCreationOverridden(
@@ -21,7 +21,7 @@ index 0e90487923c57c0570e73ef0f0e8c5acc2576932..fcdc88233b2277f3b37a2a2b0bdee7d7
    return true;
  }
 diff --git a/chrome/browser/android/document/document_web_contents_delegate.h b/chrome/browser/android/document/document_web_contents_delegate.h
-index 5b4d70991e19edcdfee731c56251932bf43e535f..fe1977c5e6ce0f5b30e8be529b9efa51785db57f 100644
+index 5b4d70991e19edcdfee731c56251932bf43e535f..4d996e3821410b2325ef85499f8c307c6e043b2a 100644
 --- a/chrome/browser/android/document/document_web_contents_delegate.h
 +++ b/chrome/browser/android/document/document_web_contents_delegate.h
 @@ -41,8 +41,7 @@ class DocumentWebContentsDelegate
@@ -35,7 +35,7 @@ index 5b4d70991e19edcdfee731c56251932bf43e535f..fe1977c5e6ce0f5b30e8be529b9efa51
  
  #endif  // CHROME_BROWSER_ANDROID_DOCUMENT_DOCUMENT_WEB_CONTENTS_DELEGATE_H_
 diff --git a/chrome/browser/media/offscreen_tab.cc b/chrome/browser/media/offscreen_tab.cc
-index 363a0d6979aaa8fb1047f6e0ed8b4bf58f547c6f..0a1279bca644158a6a17662eba9404323685b38f 100644
+index 363a0d6979aaa8fb1047f6e0ed8b4bf58f547c6f..5f155518a179d4556c3993711e688f88e3f04091 100644
 --- a/chrome/browser/media/offscreen_tab.cc
 +++ b/chrome/browser/media/offscreen_tab.cc
 @@ -284,8 +284,7 @@ bool OffscreenTab::IsWebContentsCreationOverridden(
@@ -49,7 +49,7 @@ index 363a0d6979aaa8fb1047f6e0ed8b4bf58f547c6f..0a1279bca644158a6a17662eba940432
    // uses this to spawn new windows/tabs, which is also not allowed for
    // offscreen tabs.
 diff --git a/chrome/browser/media/offscreen_tab.h b/chrome/browser/media/offscreen_tab.h
-index c80128b816cc77b95af215384fdc36b2150f95ea..3fe773e671d1c087eaf1303ca60883597c0c3907 100644
+index c80128b816cc77b95af215384fdc36b2150f95ea..2063233f6f36829e91ba503d0d66fa5cde994cf3 100644
 --- a/chrome/browser/media/offscreen_tab.h
 +++ b/chrome/browser/media/offscreen_tab.h
 @@ -107,8 +107,7 @@ class OffscreenTab final : public ProfileObserver,
@@ -63,7 +63,7 @@ index c80128b816cc77b95af215384fdc36b2150f95ea..3fe773e671d1c087eaf1303ca6088359
        content::RenderFrameHost* requesting_frame,
        const blink::mojom::FullscreenOptions& options) final;
 diff --git a/chrome/browser/ui/ash/assistant/assistant_web_view_impl.cc b/chrome/browser/ui/ash/assistant/assistant_web_view_impl.cc
-index e4f3632c84ebe4dcbbc3deb2f49e351c75ec93fd..58902fdaf316ad371ddb3e79e6ebc74cbbafc138 100644
+index e4f3632c84ebe4dcbbc3deb2f49e351c75ec93fd..08227615c2370bf55edfc373a40d9b488d775ba7 100644
 --- a/chrome/browser/ui/ash/assistant/assistant_web_view_impl.cc
 +++ b/chrome/browser/ui/ash/assistant/assistant_web_view_impl.cc
 @@ -77,10 +77,9 @@ bool AssistantWebViewImpl::IsWebContentsCreationOverridden(
@@ -80,7 +80,7 @@ index e4f3632c84ebe4dcbbc3deb2f49e351c75ec93fd..58902fdaf316ad371ddb3e79e6ebc74c
                                  /*from_user_gesture=*/true);
      return true;
 diff --git a/chrome/browser/ui/ash/assistant/assistant_web_view_impl.h b/chrome/browser/ui/ash/assistant/assistant_web_view_impl.h
-index 07014765f33bdddebcc5bc32a2713d6523faf394..f866f69f9c810d89f1a0e9e4952293f66804602a 100644
+index 07014765f33bdddebcc5bc32a2713d6523faf394..b76a6e4f5d79ad53caba3044c1d9d6e6b9e066f8 100644
 --- a/chrome/browser/ui/ash/assistant/assistant_web_view_impl.h
 +++ b/chrome/browser/ui/ash/assistant/assistant_web_view_impl.h
 @@ -48,8 +48,7 @@ class AssistantWebViewImpl : public ash::AssistantWebView,
@@ -94,7 +94,7 @@ index 07014765f33bdddebcc5bc32a2713d6523faf394..f866f69f9c810d89f1a0e9e4952293f6
        content::WebContents* source,
        const content::OpenURLParams& params) override;
 diff --git a/chrome/browser/ui/ash/keyboard/chrome_keyboard_web_contents.cc b/chrome/browser/ui/ash/keyboard/chrome_keyboard_web_contents.cc
-index ba376cca99e6b8b367c6a4cfc9925b940728b9fc..f1b831507d628d35cc65f697ffc832568fc28193 100644
+index ba376cca99e6b8b367c6a4cfc9925b940728b9fc..51731a94efdbba6b582a1a317303c26dd7f06c6c 100644
 --- a/chrome/browser/ui/ash/keyboard/chrome_keyboard_web_contents.cc
 +++ b/chrome/browser/ui/ash/keyboard/chrome_keyboard_web_contents.cc
 @@ -72,8 +72,7 @@ class ChromeKeyboardContentsDelegate : public content::WebContentsDelegate,
@@ -108,7 +108,7 @@ index ba376cca99e6b8b367c6a4cfc9925b940728b9fc..f1b831507d628d35cc65f697ffc83256
    }
  
 diff --git a/chrome/browser/ui/browser.cc b/chrome/browser/ui/browser.cc
-index c764e3607d274b9ec3f645c2b5fc9c8c1e98ad47..1199199a14ad745a2dde2e2a8bfc0a0dd783c23e 100644
+index c764e3607d274b9ec3f645c2b5fc9c8c1e98ad47..9c177080b4aee8ad71dd9a4c438d5a6daec2c25d 100644
 --- a/chrome/browser/ui/browser.cc
 +++ b/chrome/browser/ui/browser.cc
 @@ -1789,12 +1789,11 @@ bool Browser::IsWebContentsCreationOverridden(
@@ -127,7 +127,7 @@ index c764e3607d274b9ec3f645c2b5fc9c8c1e98ad47..1199199a14ad745a2dde2e2a8bfc0a0d
  
  WebContents* Browser::CreateCustomWebContents(
 diff --git a/chrome/browser/ui/browser.h b/chrome/browser/ui/browser.h
-index 69911da4fe7b9894f718fac8d59af1dcc9d18593..1a5668edcbfee23a12fc3e9b70a54673c99484dd 100644
+index 69911da4fe7b9894f718fac8d59af1dcc9d18593..eeeef53bd967131d77d440cc61ad3acbb07bd9d7 100644
 --- a/chrome/browser/ui/browser.h
 +++ b/chrome/browser/ui/browser.h
 @@ -813,8 +813,7 @@ class Browser : public TabStripModelObserver,
@@ -141,7 +141,7 @@ index 69911da4fe7b9894f718fac8d59af1dcc9d18593..1a5668edcbfee23a12fc3e9b70a54673
        content::RenderFrameHost* opener,
        content::SiteInstance* source_site_instance,
 diff --git a/chrome/browser/ui/media_router/presentation_receiver_window_controller.cc b/chrome/browser/ui/media_router/presentation_receiver_window_controller.cc
-index ff97ac6e97c688d677053a5f01546a4c2d91ff1d..1da6a9c32b883a17975e61d60363918251c78ffd 100644
+index ff97ac6e97c688d677053a5f01546a4c2d91ff1d..c095be21525d85e3d6c1f4a0c1dda5c8579e1ec3 100644
 --- a/chrome/browser/ui/media_router/presentation_receiver_window_controller.cc
 +++ b/chrome/browser/ui/media_router/presentation_receiver_window_controller.cc
 @@ -201,8 +201,7 @@ bool PresentationReceiverWindowController::IsWebContentsCreationOverridden(
@@ -155,7 +155,7 @@ index ff97ac6e97c688d677053a5f01546a4c2d91ff1d..1da6a9c32b883a17975e61d603639182
    // uses this to spawn new windows/tabs, which is also not allowed for
    // local presentations.
 diff --git a/chrome/browser/ui/media_router/presentation_receiver_window_controller.h b/chrome/browser/ui/media_router/presentation_receiver_window_controller.h
-index 45cd02ecf7b7acb107f95656b3fa07a5fca2ea95..b06ca2dbdd0c21554802ab3b99576b381d0e4ddb 100644
+index 45cd02ecf7b7acb107f95656b3fa07a5fca2ea95..953ea8ae44f7f2bd0623591249cb85f9d0eda543 100644
 --- a/chrome/browser/ui/media_router/presentation_receiver_window_controller.h
 +++ b/chrome/browser/ui/media_router/presentation_receiver_window_controller.h
 @@ -104,8 +104,7 @@ class PresentationReceiverWindowController final
@@ -169,7 +169,7 @@ index 45cd02ecf7b7acb107f95656b3fa07a5fca2ea95..b06ca2dbdd0c21554802ab3b99576b38
    // The profile used for the presentation.
    Profile* otr_profile_;
 diff --git a/components/embedder_support/android/delegate/web_contents_delegate_android.cc b/components/embedder_support/android/delegate/web_contents_delegate_android.cc
-index 9364a722de5183c077a9c50b8c8a48ffa3a0fea6..ddde17de38bc5ca904046702a28a88d7c00f18c4 100644
+index 9364a722de5183c077a9c50b8c8a48ffa3a0fea6..58d9e6c24d70dbedeb41f0b29ed1cb03a1bdcde3 100644
 --- a/components/embedder_support/android/delegate/web_contents_delegate_android.cc
 +++ b/components/embedder_support/android/delegate/web_contents_delegate_android.cc
 @@ -170,14 +170,13 @@ bool WebContentsDelegateAndroid::IsWebContentsCreationOverridden(
@@ -190,7 +190,7 @@ index 9364a722de5183c077a9c50b8c8a48ffa3a0fea6..ddde17de38bc5ca904046702a28a88d7
                                                                    java_gurl);
  }
 diff --git a/components/embedder_support/android/delegate/web_contents_delegate_android.h b/components/embedder_support/android/delegate/web_contents_delegate_android.h
-index 4b832f4c3a051eefca57909958334631335e03e1..8aed42112d8fad7df813524cf700d8082ad75c47 100644
+index 4b832f4c3a051eefca57909958334631335e03e1..b665a3cac289409280e61f75eb7d7eb83517f603 100644
 --- a/components/embedder_support/android/delegate/web_contents_delegate_android.h
 +++ b/components/embedder_support/android/delegate/web_contents_delegate_android.h
 @@ -78,8 +78,7 @@ class WebContentsDelegateAndroid : public content::WebContentsDelegate {
@@ -204,7 +204,7 @@ index 4b832f4c3a051eefca57909958334631335e03e1..8aed42112d8fad7df813524cf700d808
    void SetContentsBounds(content::WebContents* source,
                           const gfx::Rect& bounds) override;
 diff --git a/components/offline_pages/content/background_loader/background_loader_contents.cc b/components/offline_pages/content/background_loader/background_loader_contents.cc
-index 53fad64f87a952fd0d7398958288ecde259b57bf..0b8359b6179bf16e58978e5f3e51a911ad3d0a3f 100644
+index 53fad64f87a952fd0d7398958288ecde259b57bf..26f64dabcbee575034e97ada29c7de48b315080f 100644
 --- a/components/offline_pages/content/background_loader/background_loader_contents.cc
 +++ b/components/offline_pages/content/background_loader/background_loader_contents.cc
 @@ -80,8 +80,7 @@ bool BackgroundLoaderContents::IsWebContentsCreationOverridden(
@@ -218,7 +218,7 @@ index 53fad64f87a952fd0d7398958288ecde259b57bf..0b8359b6179bf16e58978e5f3e51a911
    return true;
  }
 diff --git a/components/offline_pages/content/background_loader/background_loader_contents.h b/components/offline_pages/content/background_loader/background_loader_contents.h
-index 75eff96958b086ebfe7f99adf0d986213074c45b..83b2c95c1ae46394d0c483dfbe0cd81c73fb8cd2 100644
+index 75eff96958b086ebfe7f99adf0d986213074c45b..ae1f59db9569cd65a5ae92a37af19f9e47eee0aa 100644
 --- a/components/offline_pages/content/background_loader/background_loader_contents.h
 +++ b/components/offline_pages/content/background_loader/background_loader_contents.h
 @@ -64,8 +64,7 @@ class BackgroundLoaderContents : public content::WebContentsDelegate {
@@ -330,7 +330,7 @@ index 663322919d45362718399b5265f9dd16acaea894..e4e599c2ee10ed0a650d6d77c6cfdfd6
        content::RenderFrameHost* opener,
        content::SiteInstance* source_site_instance,
 diff --git a/fuchsia/engine/browser/frame_impl.cc b/fuchsia/engine/browser/frame_impl.cc
-index 264846f62b075fd31be93d65b033ad65fb865b90..a00bae25768573878b6c372cf620c9c4ab7666d4 100644
+index 264846f62b075fd31be93d65b033ad65fb865b90..1325f58e02f7f28fd58d58c3d8317587c4827e19 100644
 --- a/fuchsia/engine/browser/frame_impl.cc
 +++ b/fuchsia/engine/browser/frame_impl.cc
 @@ -379,8 +379,7 @@ bool FrameImpl::IsWebContentsCreationOverridden(
@@ -344,7 +344,7 @@ index 264846f62b075fd31be93d65b033ad65fb865b90..a00bae25768573878b6c372cf620c9c4
    // can catch bad client behavior while not interfering with normal operation.
    constexpr size_t kMaxPendingWebContentsCount = 10;
 diff --git a/fuchsia/engine/browser/frame_impl.h b/fuchsia/engine/browser/frame_impl.h
-index 90fe755aa7dddee8c1f129a4e125efba060ce055..301dd436259ea35377c6a0336789c524fb0ecc54 100644
+index 90fe755aa7dddee8c1f129a4e125efba060ce055..7be424f7b49e37f6d67a4d5d4e105dc292a2f816 100644
 --- a/fuchsia/engine/browser/frame_impl.h
 +++ b/fuchsia/engine/browser/frame_impl.h
 @@ -247,8 +247,7 @@ class FrameImpl : public fuchsia::web::Frame,


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/pull/31572.

Fixes a compilation issue which was only surfaced when we pulled in some files that were previously not depended on and thus hid compilation failures.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none.
