### PR TITLE
chore: update chore_add_context_to_context_aware_module_prevention.patch

### DIFF
--- a/patches/node/chore_add_context_to_context_aware_module_prevention.patch
+++ b/patches/node/chore_add_context_to_context_aware_module_prevention.patch
@@ -8,7 +8,7 @@ modules from being used in the renderer process. This should be upstreamed as
 a customizable error message.
 
 diff --git a/src/node_binding.cc b/src/node_binding.cc
-index e323f76261f2028ef58da74066f9112d8a5a8df2..02d8566caffb86d05645fb602ca7b5c6b8c71aa9 100644
+index e323f76261f2028ef58da74066f9112d8a5a8df2..bec34a61e0be78d863e476c75647e3496aa6a2c5 100644
 --- a/src/node_binding.cc
 +++ b/src/node_binding.cc
 @@ -4,6 +4,7 @@
@@ -27,7 +27,7 @@ index e323f76261f2028ef58da74066f9112d8a5a8df2..02d8566caffb86d05645fb602ca7b5c6
 +          char errmsg[1024];
 +          snprintf(errmsg,
 +                   sizeof(errmsg),
-+                   "Loading non-context-aware native module in renderer: '%s', but app.allowRendererProcessReuse is true. See https://github.com/electron/electron/issues/18397.",
++                   "Loading non-context-aware native module in renderer: '%s'. See https://github.com/electron/electron/issues/18397.",
 +                   *filename);
 +          env->ThrowError(errmsg);
            return false;


### PR DESCRIPTION
#### Description of Change
Change
```
"Loading non-context-aware native module in renderer: '%s', but app.allowRendererProcessReuse is true. See https://github.com/electron/electron/issues/18397."
```
to
```
"Loading non-context-aware native module in renderer: '%s'. See https://github.com/electron/electron/issues/18397."
```
as `app.allowRendererProcessReuse` does not exist anymore. Follow-up to #26874

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none
