### PR TITLE
docs: link to Apple developer docs for `app.ready` event

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -36,10 +36,10 @@ Returns:
 * `launchInfo` Record<string, any> | [NotificationResponse](structures/notification-response.md) _macOS_
 
 Emitted once, when Electron has finished initializing. On macOS, `launchInfo`
-holds the `userInfo` of the `NSUserNotification` or information from
-[`UNNotificationResponse`](structures/notification-response.md) that was used to open the
-application, if it was launched from Notification Center. You can also call
-`app.isReady()` to check if this event has already fired and `app.whenReady()`
+holds the `userInfo` of the [`NSUserNotification`](https://developer.apple.com/documentation/foundation/nsusernotification)
+or information from [`UNNotificationResponse`](https://developer.apple.com/documentation/usernotifications/unnotificationresponse)
+that was used to open the application, if it was launched from Notification Center.
+You can also call `app.isReady()` to check if this event has already fired and `app.whenReady()`
 to get a Promise that is fulfilled when Electron is initialized.
 
 ### Event: 'window-all-closed'


### PR DESCRIPTION
#### Description of Change

Changes some links around. There was no link for `NSUserNotification`, and
`UNNotificationResponse` incorrectly linked to our own `NotificationResponse`
API structure doc.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
