### PR TITLE
chore: fix supported versions automation

### DIFF
--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -73,7 +73,7 @@ until the maintainers feel the maintenance burden is too high to continue doing 
 * 17.x.y
 * 16.x.y
 * 15.x.y
-* 13
+* 14.x.y
 
 ### End-of-life
 

--- a/script/release/version-bumper.js
+++ b/script/release/version-bumper.js
@@ -174,7 +174,7 @@ async function updateWinRC (components) {
 // updates support.md file with new semver values (stable only)
 async function updateSupported (version, filePath) {
   const v = parseInt(version);
-  const newVersions = [`* ${v}.x.y`, `* ${v - 1}.x.y`, `* ${v - 2}.x.y`, `* ${v - 3}`];
+  const newVersions = [`* ${v}.x.y`, `* ${v - 1}.x.y`, `* ${v - 2}.x.y`, `* ${v - 3}.x.y`];
   const contents = await readFile(filePath, 'utf8');
   const previousVersions = contents.split('\n').filter((elem) => {
     return (/[^\n]*\.x\.y[^\n]*/).test(elem);


### PR DESCRIPTION
#### Description of Change
When updating to 4 supported versions (from 3 supported), there was a typo in the supported documentation automation. This PR corrects the typo and fixes the current support.md file so it will correctly bump the version in the future.

_Note: I will manually correct the `support.md` version for backports_

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
