### PR TITLE
fix: use shorter paths for creating singleton sockets

### DIFF
--- a/patches/chromium/feat_add_data_parameter_to_processsingleton.patch
+++ b/patches/chromium/feat_add_data_parameter_to_processsingleton.patch
@@ -61,7 +61,7 @@ index eec994c4252f17d9c9c41e66d5dae6509ed98a18..e538c9b76da4d4435e10cd3848438446
  #if defined(OS_WIN)
    bool EscapeVirtualization(const base::FilePath& user_data_dir);
 diff --git a/chrome/browser/process_singleton_posix.cc b/chrome/browser/process_singleton_posix.cc
-index 727333dd6abec99643e31bc77ed2cc8f3d5a0a0b..e5361397f78636816507355e7db6a9e55e6ed234 100644
+index a04d139f958a7aaef9b96e8c29317ccf7c97f009..29188668a69047b3ad3bebd1f0057565a330b509 100644
 --- a/chrome/browser/process_singleton_posix.cc
 +++ b/chrome/browser/process_singleton_posix.cc
 @@ -567,6 +567,7 @@ class ProcessSingleton::LinuxWatcher

--- a/patches/chromium/process_singleton.patch
+++ b/patches/chromium/process_singleton.patch
@@ -76,7 +76,7 @@ index 0d7c1db6489d95a40c66808c3f838b0740e46ff6..eec994c4252f17d9c9c41e66d5dae650
  
  #if defined(OS_MAC)
 diff --git a/chrome/browser/process_singleton_posix.cc b/chrome/browser/process_singleton_posix.cc
-index 4547eb8563e1af57aad991d9d1e2cf02c778380a..727333dd6abec99643e31bc77ed2cc8f3d5a0a0b 100644
+index 4547eb8563e1af57aad991d9d1e2cf02c778380a..a04d139f958a7aaef9b96e8c29317ccf7c97f009 100644
 --- a/chrome/browser/process_singleton_posix.cc
 +++ b/chrome/browser/process_singleton_posix.cc
 @@ -80,6 +80,7 @@
@@ -171,7 +171,7 @@ index 4547eb8563e1af57aad991d9d1e2cf02c778380a..727333dd6abec99643e31bc77ed2cc8f
  ProcessSingleton::NotifyResult
  ProcessSingleton::NotifyOtherProcessWithTimeoutOrCreate(
      const base::CommandLine& command_line,
-@@ -999,12 +1039,26 @@ bool ProcessSingleton::Create() {
+@@ -999,14 +1039,32 @@ bool ProcessSingleton::Create() {
  #endif
    }
  
@@ -180,15 +180,15 @@ index 4547eb8563e1af57aad991d9d1e2cf02c778380a..727333dd6abec99643e31bc77ed2cc8f
 -  // do not support Unix domain sockets.
 -  if (!socket_dir_.CreateUniqueTempDir()) {
 -    LOG(ERROR) << "Failed to create socket directory.";
--    return false;
++  base::FilePath tmp_dir;
++  if (!base::GetTempDir(&tmp_dir)) {
++    LOG(ERROR) << "Failed to get temporary directory.";
+     return false;
+   }
+ 
 +  if (IsAppSandboxed()) {
 +    // For sandboxed applications, the tmp dir could be too long to fit
 +    // addr->sun_path, so we need to make it as short as possible.
-+    base::FilePath tmp_dir;
-+    if (!base::GetTempDir(&tmp_dir)) {
-+      LOG(ERROR) << "Failed to get temporary directory.";
-+      return false;
-+    }
 +    if (!socket_dir_.Set(tmp_dir.Append("S"))) {
 +      LOG(ERROR) << "Failed to set socket directory.";
 +      return false;
@@ -197,14 +197,19 @@ index 4547eb8563e1af57aad991d9d1e2cf02c778380a..727333dd6abec99643e31bc77ed2cc8f
 +    // Create the socket file somewhere in /tmp which is usually mounted as a
 +    // normal filesystem. Some network filesystems (notably AFS) are screwy and
 +    // do not support Unix domain sockets.
-+    if (!socket_dir_.CreateUniqueTempDir()) {
++    // Prefer CreateUniqueTempDirUnderPath rather than CreateUniqueTempDir as
++    // the latter will calculate unique paths based on bundle ids which can
++    // increase the socket path length than what is allowed.
++    if (!socket_dir_.CreateUniqueTempDirUnderPath(tmp_dir)) {
 +      LOG(ERROR) << "Failed to create socket directory.";
 +      return false;
 +    }
-   }
- 
++  }
++
    // Check that the directory was created with the correct permissions.
-@@ -1046,10 +1100,13 @@ bool ProcessSingleton::Create() {
+   int dir_mode = 0;
+   CHECK(base::GetPosixFilePermissions(socket_dir_.GetPath(), &dir_mode) &&
+@@ -1046,10 +1104,13 @@ bool ProcessSingleton::Create() {
    if (listen(sock, 5) < 0)
      NOTREACHED() << "listen failed: " << base::safe_strerror(errno);
  


### PR DESCRIPTION
#### Description of Change

This regressed with https://github.com/electron/electron/pull/30594 where the shortened name for Socket path was not carried over from https://github.com/electron/electron/pull/5236. When app is not sandboxed unique temporary directory for the socket is created via `ScopedTempDir::CreateUniqueTempDir` and this uses the app bundle id on macOS as part of the path https://source.chromium.org/chromium/chromium/src/+/main:base/files/file_util_posix.cc;l=643-652 which can exceed the path limit for longer ids.

This patch switches to use `ScopedTempDir::CreateUniqueTempDirUnderPath` which will still obtain a unique directory based on the template https://source.chromium.org/chromium/chromium/src/+/main:base/files/file_util_posix.cc;l=692-693 but the prefix is fixed and shorter without involving variable length app ids.

Test case https://gist.github.com/deepak1556/a45c54e6467295ec8831a6dd32bd1532

/cc @VerteDinde 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix crash when using singleton api with packaged apps on macOS
