### PR TITLE
fix: crash on close window when webContents destroyed

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -254,7 +254,7 @@ void BrowserWindow::OnCloseButtonClicked(bool* prevent_default) {
     ScheduleUnresponsiveEvent(5000);
 
   // Already closed by renderer.
-  if (!web_contents())
+  if (!web_contents() || !api_web_contents_)
     return;
 
   // Required to make beforeunload handler work.

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -110,6 +110,11 @@ describe('BrowserWindow module', () => {
       await closed;
     });
 
+    it('should not crash if called after webContents is destroyed', () => {
+      w.webContents.destroy();
+      w.webContents.on('destroyed', () => w.close());
+    });
+
     it('should emit unload handler', async () => {
       await w.loadFile(path.join(fixtures, 'api', 'unload.html'));
       const closed = emittedOnce(w, 'closed');


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/31337.

Fixes a crash when a `BrowserWindow` is closed subsequent to its `webContents` being destroyed.

We were checking for `web_contents()` being nullptr but not `api_web_contents_`, which would be the case if the `webContents` is destroyed prior to the window.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash when a `BrowserWindow` is closed subsequent to its `webContents` being destroyed.