### PR TITLE
fix: clipboard.read() to work consistently with clipboard.readBuffer()

### DIFF
--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -197,7 +197,7 @@ Returns `Boolean` - Whether the clipboard supports the specified `format`.
 ```js
 const { clipboard } = require('electron')
 
-const hasFormat = clipboard.has('<p>selection</p>')
+const hasFormat = clipboard.has('public/utf8-plain-text')
 console.log(hasFormat)
 // 'true' or 'false'
 ```

--- a/shell/common/api/electron_api_clipboard.cc
+++ b/shell/common/api/electron_api_clipboard.cc
@@ -51,17 +51,7 @@ bool Clipboard::Has(const std::string& format_string,
 
 std::string Clipboard::Read(const std::string& format_string) {
   ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
-  ui::ClipboardFormatType format(
-      ui::ClipboardFormatType::CustomPlatformType(format_string));
 
-  std::string data;
-  clipboard->ReadData(format, /* data_dst = */ nullptr, &data);
-  return data;
-}
-
-v8::Local<v8::Value> Clipboard::ReadBuffer(const std::string& format_string,
-                                           gin_helper::Arguments* args) {
-  ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
   std::map<std::string, std::string> custom_format_names;
   custom_format_names =
       clipboard->ExtractCustomPlatformNames(ui::ClipboardBuffer::kCopyPaste,
@@ -73,12 +63,24 @@ v8::Local<v8::Value> Clipboard::ReadBuffer(const std::string& format_string,
                                               /* data_dst = */ nullptr);
   }
 #endif
-  CHECK(custom_format_names.find(format_string) != custom_format_names.end());
-  ui::ClipboardFormatType format(ui::ClipboardFormatType::CustomPlatformType(
-      custom_format_names[format_string]));
 
+  ui::ClipboardFormatType format;
+  if (custom_format_names.find(format_string) != custom_format_names.end()) {
+    format =
+        ui::ClipboardFormatType(ui::ClipboardFormatType::CustomPlatformType(
+            custom_format_names[format_string]));
+  } else {
+    format = ui::ClipboardFormatType(
+        ui::ClipboardFormatType::CustomPlatformType(format_string));
+  }
   std::string data;
   clipboard->ReadData(format, /* data_dst = */ nullptr, &data);
+  return data;
+}
+
+v8::Local<v8::Value> Clipboard::ReadBuffer(const std::string& format_string,
+                                           gin_helper::Arguments* args) {
+  std::string data = Read(format_string);
   return node::Buffer::Copy(args->isolate(), data.data(), data.length())
       .ToLocalChecked();
 }

--- a/spec/api-clipboard-spec.js
+++ b/spec/api-clipboard-spec.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const path = require('path');
 const { Buffer } = require('buffer');
-const { ifdescribe } = require('./spec-helpers');
+const { ifdescribe, ifit } = require('./spec-helpers');
 
 const { clipboard, nativeImage } = require('electron');
 
@@ -62,13 +62,19 @@ ifdescribe(process.platform !== 'win32' || process.arch !== 'arm64')('clipboard 
     });
   });
 
-  ifdescribe(process.platform !== 'linux')('clipboard.read()', () => {
-    it('does not crash when reading various custom clipboard types', () => {
+  describe('clipboard.read()', () => {
+    ifit(process.platform !== 'linux')('does not crash when reading various custom clipboard types', () => {
       const type = process.platform === 'darwin' ? 'NSFilenamesPboardType' : 'FileNameW';
 
       expect(() => {
         const result = clipboard.read(type);
       }).to.not.throw();
+    });
+    it('can read data written with writeBuffer', () => {
+      const testText = 'Testing read';
+      const buffer = Buffer.from(testText, 'utf8');
+      clipboard.writeBuffer('public/utf8-plain-text', buffer);
+      expect(clipboard.read('public/utf8-plain-text')).to.equal(testText);
     });
   });
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
 #31566 incorrectly assumed that `clipboard.read` and `clipboard.readBuffer` should operate differently, but after testing earlier versions of Electron, the only difference between these two functions is that `clipboard.read` returns a String and `clipboard.readBuffer` returns a Buffer.

- fixes #31130

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->fixed clipboard.read to once again work like clipboard.readBuffer.
