### PR TITLE
fix: use disable-hid-blocklist to allow FIDO devices

### DIFF
--- a/shell/browser/hid/electron_hid_delegate.cc
+++ b/shell/browser/hid/electron_hid_delegate.cc
@@ -7,7 +7,9 @@
 #include <string>
 #include <utility>
 
+#include "base/command_line.h"
 #include "content/public/browser/web_contents.h"
+#include "services/device/public/cpp/hid/hid_switches.h"
 #include "shell/browser/hid/hid_chooser_context.h"
 #include "shell/browser/hid/hid_chooser_context_factory.h"
 #include "shell/browser/hid/hid_chooser_controller.h"
@@ -103,7 +105,8 @@ const device::mojom::HidDeviceInfo* ElectronHidDelegate::GetDeviceInfo(
 }
 
 bool ElectronHidDelegate::IsFidoAllowedForOrigin(const url::Origin& origin) {
-  return false;
+  return base::CommandLine::ForCurrentProcess()->HasSwitch(
+      switches::kDisableHidBlocklist);
 }
 
 void ElectronHidDelegate::OnDeviceAdded(


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
This PR changes WebHID to use the `disable-hid-blocklist` flag to enable access to FIDO devices.  The original WebHID implementation disallowed access to all FIDO devices for security reasons, but using the `disable-hid-blocklist` flag (which is by default false) allow developers to opt-in to FIDO device access while maintaining the default of disabling access to FIDO devices via WebHID. 

Closes #31595
 
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->changed WebHID to use `disable-hid-blocklist` flag to enable FIDO devices.
