### PR TITLE
refactor: move certificate_manager_model to shell

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -420,7 +420,6 @@ source_set("electron_lib") {
   ]
 
   include_dirs = [
-    "chromium_src",
     ".",
     "$target_gen_dir",
 
@@ -554,8 +553,9 @@ source_set("electron_lib") {
       "GLIB_DISABLE_DEPRECATION_WARNINGS",
     ]
 
-    sources += filenames.lib_sources_nss
     sources += [
+      "shell/browser/certificate_manager_model.cc",
+      "shell/browser/certificate_manager_model.h",
       "shell/browser/ui/gtk/app_indicator_icon.cc",
       "shell/browser/ui/gtk/app_indicator_icon.h",
       "shell/browser/ui/gtk/app_indicator_icon_menu.cc",

--- a/filenames.gni
+++ b/filenames.gni
@@ -675,11 +675,6 @@ filenames = {
     "shell/utility/electron_content_utility_client.h",
   ]
 
-  lib_sources_nss = [
-    "chromium_src/chrome/browser/certificate_manager_model.cc",
-    "chromium_src/chrome/browser/certificate_manager_model.h",
-  ]
-
   lib_sources_extensions = [
     "shell/browser/extensions/api/i18n/i18n_api.cc",
     "shell/browser/extensions/api/i18n/i18n_api.h",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "generate-version-json": "node script/generate-version-json.js",
     "lint": "node ./script/lint.js && npm run lint:clang-format && npm run lint:docs",
     "lint:js": "node ./script/lint.js --js",
-    "lint:clang-format": "python script/run-clang-format.py -r -c chromium_src/ shell/ || (echo \"\\nCode not formatted correctly.\" && exit 1)",
+    "lint:clang-format": "python script/run-clang-format.py -r -c shell/ || (echo \"\\nCode not formatted correctly.\" && exit 1)",
     "lint:clang-tidy": "ts-node ./script/run-clang-tidy.ts",
     "lint:cpp": "node ./script/lint.js --cc",
     "lint:objc": "node ./script/lint.js --objc",

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -30,7 +30,7 @@
 #include "shell/common/gin_helper/promise.h"
 
 #if defined(USE_NSS_CERTS)
-#include "chrome/browser/certificate_manager_model.h"
+#include "shell/browser/certificate_manager_model.h"
 #endif
 
 namespace base {

--- a/shell/browser/certificate_manager_model.cc
+++ b/shell/browser/certificate_manager_model.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "chrome/browser/certificate_manager_model.h"
+#include "shell/browser/certificate_manager_model.h"
 
 #include <utility>
 

--- a/shell/browser/certificate_manager_model.h
+++ b/shell/browser/certificate_manager_model.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef CHROME_BROWSER_CERTIFICATE_MANAGER_MODEL_H_
-#define CHROME_BROWSER_CERTIFICATE_MANAGER_MODEL_H_
+#ifndef SHELL_BROWSER_CERTIFICATE_MANAGER_MODEL_H_
+#define SHELL_BROWSER_CERTIFICATE_MANAGER_MODEL_H_
 
 #include <memory>
 #include <string>
@@ -113,4 +113,4 @@ class CertificateManagerModel {
   bool is_user_db_available_;
 };
 
-#endif  // CHROME_BROWSER_CERTIFICATE_MANAGER_MODEL_H_
+#endif  // SHELL_BROWSER_CERTIFICATE_MANAGER_MODEL_H_


### PR DESCRIPTION
#### Description of Change
These are the last source files in chromium_src, just move them to shell. Follow-up to #30837

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none