### PR TITLE
refactor: replace deprecated DISALLOW_COPY_AND_ASSIGN

### DIFF
--- a/chromium_src/chrome/browser/certificate_manager_model.h
+++ b/chromium_src/chrome/browser/certificate_manager_model.h
@@ -9,7 +9,6 @@
 #include <string>
 
 #include "base/callback.h"
-#include "base/macros.h"
 #include "base/memory/ref_counted.h"
 #include "net/cert/nss_cert_database.h"
 
@@ -30,6 +29,10 @@ class CertificateManagerModel {
   // |browser_context|.
   static void Create(content::BrowserContext* browser_context,
                      CreationCallback callback);
+
+  // disable copy
+  CertificateManagerModel(const CertificateManagerModel&) = delete;
+  CertificateManagerModel& operator=(const CertificateManagerModel&) = delete;
 
   ~CertificateManagerModel();
 
@@ -108,8 +111,6 @@ class CertificateManagerModel {
   // Whether the certificate database has a public slot associated with the
   // profile. If not set, importing certificates is not allowed with this model.
   bool is_user_db_available_;
-
-  DISALLOW_COPY_AND_ASSIGN(CertificateManagerModel);
 };
 
 #endif  // CHROME_BROWSER_CERTIFICATE_MANAGER_MODEL_H_

--- a/shell/app/electron_content_client.h
+++ b/shell/app/electron_content_client.h
@@ -17,6 +17,10 @@ class ElectronContentClient : public content::ContentClient {
   ElectronContentClient();
   ~ElectronContentClient() override;
 
+  // disable copy
+  ElectronContentClient(const ElectronContentClient&) = delete;
+  ElectronContentClient& operator=(const ElectronContentClient&) = delete;
+
  protected:
   // content::ContentClient:
   std::u16string GetLocalizedString(int message_id) override;
@@ -30,9 +34,6 @@ class ElectronContentClient : public content::ContentClient {
   void AddContentDecryptionModules(
       std::vector<content::CdmInfo>* cdms,
       std::vector<media::CdmHostFilePath>* cdm_host_file_paths) override;
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(ElectronContentClient);
 };
 
 }  // namespace electron

--- a/shell/app/electron_crash_reporter_client.h
+++ b/shell/app/electron_crash_reporter_client.h
@@ -9,7 +9,6 @@
 #include <string>
 
 #include "base/compiler_specific.h"
-#include "base/macros.h"
 #include "base/no_destructor.h"
 #include "build/build_config.h"
 #include "components/crash/core/app/crash_reporter_client.h"
@@ -17,6 +16,11 @@
 class ElectronCrashReporterClient : public crash_reporter::CrashReporterClient {
  public:
   static void Create();
+
+  // disable copy
+  ElectronCrashReporterClient(const ElectronCrashReporterClient&) = delete;
+  ElectronCrashReporterClient& operator=(const ElectronCrashReporterClient&) =
+      delete;
 
   static ElectronCrashReporterClient* Get();
   void SetCollectStatsConsent(bool upload_allowed);
@@ -85,8 +89,6 @@ class ElectronCrashReporterClient : public crash_reporter::CrashReporterClient {
 
   ElectronCrashReporterClient();
   ~ElectronCrashReporterClient() override;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronCrashReporterClient);
 };
 
 #endif  // SHELL_APP_ELECTRON_CRASH_REPORTER_CLIENT_H_

--- a/shell/app/electron_main.cc
+++ b/shell/app/electron_main.cc
@@ -24,6 +24,7 @@
 #include <tchar.h>
 
 #include "base/environment.h"
+#include "base/macros.h"
 #include "base/process/launch.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/win/windows_version.h"

--- a/shell/app/electron_main_delegate.h
+++ b/shell/app/electron_main_delegate.h
@@ -26,6 +26,10 @@ class ElectronMainDelegate : public content::ContentMainDelegate {
   ElectronMainDelegate();
   ~ElectronMainDelegate() override;
 
+  // disable copy
+  ElectronMainDelegate(const ElectronMainDelegate&) = delete;
+  ElectronMainDelegate& operator=(const ElectronMainDelegate&) = delete;
+
  protected:
   // content::ContentMainDelegate:
   bool BasicStartupComplete(int* exit_code) override;
@@ -58,8 +62,6 @@ class ElectronMainDelegate : public content::ContentMainDelegate {
   std::unique_ptr<content::ContentRendererClient> renderer_client_;
   std::unique_ptr<content::ContentUtilityClient> utility_client_;
   std::unique_ptr<tracing::TracingSamplerProfiler> tracing_sampler_profiler_;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronMainDelegate);
 };
 
 }  // namespace electron

--- a/shell/app/uv_task_runner.h
+++ b/shell/app/uv_task_runner.h
@@ -22,6 +22,10 @@ class UvTaskRunner : public base::SingleThreadTaskRunner {
  public:
   explicit UvTaskRunner(uv_loop_t* loop);
 
+  // disable copy
+  UvTaskRunner(const UvTaskRunner&) = delete;
+  UvTaskRunner& operator=(const UvTaskRunner&) = delete;
+
   // base::SingleThreadTaskRunner:
   bool PostDelayedTask(const base::Location& from_here,
                        base::OnceClosure task,
@@ -39,8 +43,6 @@ class UvTaskRunner : public base::SingleThreadTaskRunner {
   uv_loop_t* loop_;
 
   std::map<uv_timer_t*, base::OnceClosure> tasks_;
-
-  DISALLOW_COPY_AND_ASSIGN(UvTaskRunner);
 };
 
 }  // namespace electron

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -79,6 +79,10 @@ class App : public ElectronBrowserClient::Delegate,
 
   App();
 
+  // disable copy
+  App(const App&) = delete;
+  App& operator=(const App&) = delete;
+
  private:
   ~App() override;
 
@@ -261,8 +265,6 @@ class App : public ElectronBrowserClient::Delegate,
 
   bool disable_hw_acceleration_ = false;
   bool disable_domain_blocking_for_3DAPIs_ = false;
-
-  DISALLOW_COPY_AND_ASSIGN(App);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_auto_updater.h
+++ b/shell/browser/api/electron_api_auto_updater.h
@@ -30,6 +30,10 @@ class AutoUpdater : public gin::Wrappable<AutoUpdater>,
       v8::Isolate* isolate) override;
   const char* GetTypeName() override;
 
+  // disable copy
+  AutoUpdater(const AutoUpdater&) = delete;
+  AutoUpdater& operator=(const AutoUpdater&) = delete;
+
  protected:
   AutoUpdater();
   ~AutoUpdater() override;
@@ -54,8 +58,6 @@ class AutoUpdater : public gin::Wrappable<AutoUpdater>,
   std::string GetFeedURL();
   void SetFeedURL(gin::Arguments* args);
   void QuitAndInstall();
-
-  DISALLOW_COPY_AND_ASSIGN(AutoUpdater);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_browser_view.h
+++ b/shell/browser/api/electron_api_browser_view.h
@@ -54,6 +54,10 @@ class BrowserView : public gin::Wrappable<BrowserView>,
 
   int32_t ID() const { return id_; }
 
+  // disable copy
+  BrowserView(const BrowserView&) = delete;
+  BrowserView& operator=(const BrowserView&) = delete;
+
  protected:
   BrowserView(gin::Arguments* args, const gin_helper::Dictionary& options);
   ~BrowserView() override;
@@ -78,8 +82,6 @@ class BrowserView : public gin::Wrappable<BrowserView>,
   std::unique_ptr<NativeBrowserView> view_;
 
   int32_t id_;
-
-  DISALLOW_COPY_AND_ASSIGN(BrowserView);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_browser_window.h
+++ b/shell/browser/api/electron_api_browser_window.h
@@ -37,6 +37,10 @@ class BrowserWindow : public BaseWindow,
     return weak_factory_.GetWeakPtr();
   }
 
+  // disable copy
+  BrowserWindow(const BrowserWindow&) = delete;
+  BrowserWindow& operator=(const BrowserWindow&) = delete;
+
  protected:
   BrowserWindow(gin::Arguments* args, const gin_helper::Dictionary& options);
   ~BrowserWindow() override;
@@ -123,8 +127,6 @@ class BrowserWindow : public BaseWindow,
   base::WeakPtr<api::WebContents> api_web_contents_;
 
   base::WeakPtrFactory<BrowserWindow> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(BrowserWindow);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_cookies.h
+++ b/shell/browser/api/electron_api_cookies.h
@@ -41,6 +41,10 @@ class Cookies : public gin::Wrappable<Cookies>,
       v8::Isolate* isolate) override;
   const char* GetTypeName() override;
 
+  // disable copy
+  Cookies(const Cookies&) = delete;
+  Cookies& operator=(const Cookies&) = delete;
+
  protected:
   Cookies(v8::Isolate* isolate, ElectronBrowserContext* browser_context);
   ~Cookies() override;
@@ -62,8 +66,6 @@ class Cookies : public gin::Wrappable<Cookies>,
 
   // Weak reference; ElectronBrowserContext is guaranteed to outlive us.
   ElectronBrowserContext* browser_context_;
-
-  DISALLOW_COPY_AND_ASSIGN(Cookies);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_data_pipe_holder.cc
+++ b/shell/browser/api/electron_api_data_pipe_holder.cc
@@ -57,6 +57,10 @@ class DataPipeReader {
 
   ~DataPipeReader() = default;
 
+  // disable copy
+  DataPipeReader(const DataPipeReader&) = delete;
+  DataPipeReader& operator=(const DataPipeReader&) = delete;
+
  private:
   // Callback invoked by DataPipeGetter::Read.
   void ReadCallback(int32_t status, uint64_t size) {
@@ -137,8 +141,6 @@ class DataPipeReader {
   uint64_t remaining_size_ = 0;
 
   base::WeakPtrFactory<DataPipeReader> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(DataPipeReader);
 };
 
 }  // namespace

--- a/shell/browser/api/electron_api_data_pipe_holder.h
+++ b/shell/browser/api/electron_api_data_pipe_holder.h
@@ -37,14 +37,16 @@ class DataPipeHolder : public gin::Wrappable<DataPipeHolder> {
   // The unique ID that can be used to receive the object.
   const std::string& id() const { return id_; }
 
+  // disable copy
+  DataPipeHolder(const DataPipeHolder&) = delete;
+  DataPipeHolder& operator=(const DataPipeHolder&) = delete;
+
  private:
   explicit DataPipeHolder(const network::DataElement& element);
   ~DataPipeHolder() override;
 
   std::string id_;
   mojo::Remote<network::mojom::DataPipeGetter> data_pipe_;
-
-  DISALLOW_COPY_AND_ASSIGN(DataPipeHolder);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_debugger.h
+++ b/shell/browser/api/electron_api_debugger.h
@@ -40,6 +40,10 @@ class Debugger : public gin::Wrappable<Debugger>,
       v8::Isolate* isolate) override;
   const char* GetTypeName() override;
 
+  // disable copy
+  Debugger(const Debugger&) = delete;
+  Debugger& operator=(const Debugger&) = delete;
+
  protected:
   Debugger(v8::Isolate* isolate, content::WebContents* web_contents);
   ~Debugger() override;
@@ -68,8 +72,6 @@ class Debugger : public gin::Wrappable<Debugger>,
 
   PendingRequestMap pending_requests_;
   int previous_request_id_ = 0;
-
-  DISALLOW_COPY_AND_ASSIGN(Debugger);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_desktop_capturer.h
+++ b/shell/browser/api/electron_api_desktop_capturer.h
@@ -45,6 +45,10 @@ class DesktopCapturer : public gin::Wrappable<DesktopCapturer>,
       v8::Isolate* isolate) override;
   const char* GetTypeName() override;
 
+  // disable copy
+  DesktopCapturer(const DesktopCapturer&) = delete;
+  DesktopCapturer& operator=(const DesktopCapturer&) = delete;
+
  protected:
   explicit DesktopCapturer(v8::Isolate* isolate);
   ~DesktopCapturer() override;
@@ -71,8 +75,6 @@ class DesktopCapturer : public gin::Wrappable<DesktopCapturer>,
 #endif  // defined(OS_WIN)
 
   base::WeakPtrFactory<DesktopCapturer> weak_ptr_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(DesktopCapturer);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_download_item.h
+++ b/shell/browser/api/electron_api_download_item.h
@@ -43,6 +43,10 @@ class DownloadItem : public gin::Wrappable<DownloadItem>,
   base::FilePath GetSavePath() const;
   file_dialog::DialogSettings GetSaveDialogOptions() const;
 
+  // disable copy
+  DownloadItem(const DownloadItem&) = delete;
+  DownloadItem& operator=(const DownloadItem&) = delete;
+
  private:
   DownloadItem(v8::Isolate* isolate, download::DownloadItem* item);
   ~DownloadItem() override;
@@ -81,8 +85,6 @@ class DownloadItem : public gin::Wrappable<DownloadItem>,
   v8::Isolate* isolate_;
 
   base::WeakPtrFactory<DownloadItem> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(DownloadItem);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_global_shortcut.h
+++ b/shell/browser/api/electron_api_global_shortcut.h
@@ -29,6 +29,10 @@ class GlobalShortcut : public extensions::GlobalShortcutListener::Observer,
       v8::Isolate* isolate) override;
   const char* GetTypeName() override;
 
+  // disable copy
+  GlobalShortcut(const GlobalShortcut&) = delete;
+  GlobalShortcut& operator=(const GlobalShortcut&) = delete;
+
  protected:
   explicit GlobalShortcut(v8::Isolate* isolate);
   ~GlobalShortcut() override;
@@ -50,8 +54,6 @@ class GlobalShortcut : public extensions::GlobalShortcutListener::Observer,
   void OnKeyPressed(const ui::Accelerator& accelerator) override;
 
   AcceleratorCallbackMap accelerator_callback_map_;
-
-  DISALLOW_COPY_AND_ASSIGN(GlobalShortcut);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_in_app_purchase.h
+++ b/shell/browser/api/electron_api_in_app_purchase.h
@@ -32,6 +32,10 @@ class InAppPurchase : public gin::Wrappable<InAppPurchase>,
       v8::Isolate* isolate) override;
   const char* GetTypeName() override;
 
+  // disable copy
+  InAppPurchase(const InAppPurchase&) = delete;
+  InAppPurchase& operator=(const InAppPurchase&) = delete;
+
  protected:
   InAppPurchase();
   ~InAppPurchase() override;
@@ -45,9 +49,6 @@ class InAppPurchase : public gin::Wrappable<InAppPurchase>,
   // TransactionObserver:
   void OnTransactionsUpdated(
       const std::vector<in_app_purchase::Transaction>& transactions) override;
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(InAppPurchase);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_menu.h
+++ b/shell/browser/api/electron_api_menu.h
@@ -46,6 +46,10 @@ class Menu : public gin::Wrappable<Menu>,
 
   ElectronMenuModel* model() const { return model_.get(); }
 
+  // disable copy
+  Menu(const Menu&) = delete;
+  Menu& operator=(const Menu&) = delete;
+
  protected:
   explicit Menu(gin::Arguments* args);
   ~Menu() override;
@@ -117,8 +121,6 @@ class Menu : public gin::Wrappable<Menu>,
   bool IsEnabledAt(int index) const;
   bool IsVisibleAt(int index) const;
   bool WorksWhenHiddenAt(int index) const;
-
-  DISALLOW_COPY_AND_ASSIGN(Menu);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_menu_mac.h
+++ b/shell/browser/api/electron_api_menu_mac.h
@@ -48,8 +48,6 @@ class MenuMac : public Menu {
   std::map<int32_t, scoped_nsobject<ElectronMenuController>> popup_controllers_;
 
   base::WeakPtrFactory<MenuMac> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(MenuMac);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_menu_views.h
+++ b/shell/browser/api/electron_api_menu_views.h
@@ -37,8 +37,6 @@ class MenuViews : public Menu {
   std::map<int32_t, std::unique_ptr<views::MenuRunner>> menu_runners_;
 
   base::WeakPtrFactory<MenuViews> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(MenuViews);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_native_theme.h
+++ b/shell/browser/api/electron_api_native_theme.h
@@ -27,6 +27,10 @@ class NativeTheme : public gin::Wrappable<NativeTheme>,
       v8::Isolate* isolate) override;
   const char* GetTypeName() override;
 
+  // disable copy
+  NativeTheme(const NativeTheme&) = delete;
+  NativeTheme& operator=(const NativeTheme&) = delete;
+
  protected:
   NativeTheme(v8::Isolate* isolate,
               ui::NativeTheme* ui_theme,
@@ -50,8 +54,6 @@ class NativeTheme : public gin::Wrappable<NativeTheme>,
  private:
   ui::NativeTheme* ui_theme_;
   ui::NativeTheme* web_theme_;
-
-  DISALLOW_COPY_AND_ASSIGN(NativeTheme);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_net_log.h
+++ b/shell/browser/api/electron_api_net_log.h
@@ -7,7 +7,6 @@
 
 #include "base/callback.h"
 #include "base/files/file_path.h"
-#include "base/macros.h"
 #include "base/memory/weak_ptr.h"
 #include "base/values.h"
 #include "gin/handle.h"
@@ -45,6 +44,10 @@ class NetLog : public gin::Wrappable<NetLog> {
       v8::Isolate* isolate) override;
   const char* GetTypeName() override;
 
+  // disable copy
+  NetLog(const NetLog&) = delete;
+  NetLog& operator=(const NetLog&) = delete;
+
  protected:
   explicit NetLog(v8::Isolate* isolate,
                   ElectronBrowserContext* browser_context);
@@ -68,8 +71,6 @@ class NetLog : public gin::Wrappable<NetLog> {
   scoped_refptr<base::TaskRunner> file_task_runner_;
 
   base::WeakPtrFactory<NetLog> weak_ptr_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(NetLog);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_notification.h
+++ b/shell/browser/api/electron_api_notification.h
@@ -56,6 +56,10 @@ class Notification : public gin::Wrappable<Notification>,
   // gin::Wrappable
   static gin::WrapperInfo kWrapperInfo;
 
+  // disable copy
+  Notification(const Notification&) = delete;
+  Notification& operator=(const Notification&) = delete;
+
  protected:
   explicit Notification(gin::Arguments* args);
   ~Notification() override;
@@ -111,8 +115,6 @@ class Notification : public gin::Wrappable<Notification>,
   electron::NotificationPresenter* presenter_;
 
   base::WeakPtr<electron::Notification> notification_;
-
-  DISALLOW_COPY_AND_ASSIGN(Notification);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_power_monitor.h
+++ b/shell/browser/api/electron_api_power_monitor.h
@@ -33,6 +33,10 @@ class PowerMonitor : public gin::Wrappable<PowerMonitor>,
       v8::Isolate* isolate) override;
   const char* GetTypeName() override;
 
+  // disable copy
+  PowerMonitor(const PowerMonitor&) = delete;
+  PowerMonitor& operator=(const PowerMonitor&) = delete;
+
  private:
   explicit PowerMonitor(v8::Isolate* isolate);
   ~PowerMonitor() override;
@@ -80,8 +84,6 @@ class PowerMonitor : public gin::Wrappable<PowerMonitor>,
 #if defined(OS_LINUX)
   PowerObserverLinux power_observer_linux_{this};
 #endif
-
-  DISALLOW_COPY_AND_ASSIGN(PowerMonitor);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_power_save_blocker.h
+++ b/shell/browser/api/electron_api_power_save_blocker.h
@@ -27,6 +27,10 @@ class PowerSaveBlocker : public gin::Wrappable<PowerSaveBlocker> {
 
   static gin::WrapperInfo kWrapperInfo;
 
+  // disable copy
+  PowerSaveBlocker(const PowerSaveBlocker&) = delete;
+  PowerSaveBlocker& operator=(const PowerSaveBlocker&) = delete;
+
  protected:
   explicit PowerSaveBlocker(v8::Isolate* isolate);
   ~PowerSaveBlocker() override;
@@ -50,8 +54,6 @@ class PowerSaveBlocker : public gin::Wrappable<PowerSaveBlocker> {
   WakeLockTypeMap wake_lock_types_;
 
   mojo::Remote<device::mojom::WakeLock> wake_lock_;
-
-  DISALLOW_COPY_AND_ASSIGN(PowerSaveBlocker);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_screen.h
+++ b/shell/browser/api/electron_api_screen.h
@@ -34,6 +34,10 @@ class Screen : public gin::Wrappable<Screen>,
       v8::Isolate* isolate) override;
   const char* GetTypeName() override;
 
+  // disable copy
+  Screen(const Screen&) = delete;
+  Screen& operator=(const Screen&) = delete;
+
  protected:
   Screen(v8::Isolate* isolate, display::Screen* screen);
   ~Screen() override;
@@ -52,8 +56,6 @@ class Screen : public gin::Wrappable<Screen>,
 
  private:
   display::Screen* screen_;
-
-  DISALLOW_COPY_AND_ASSIGN(Screen);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_service_worker_context.h
+++ b/shell/browser/api/electron_api_service_worker_context.h
@@ -43,6 +43,10 @@ class ServiceWorkerContext
       v8::Isolate* isolate) override;
   const char* GetTypeName() override;
 
+  // disable copy
+  ServiceWorkerContext(const ServiceWorkerContext&) = delete;
+  ServiceWorkerContext& operator=(const ServiceWorkerContext&) = delete;
+
  protected:
   explicit ServiceWorkerContext(v8::Isolate* isolate,
                                 ElectronBrowserContext* browser_context);
@@ -52,8 +56,6 @@ class ServiceWorkerContext
   content::ServiceWorkerContext* service_worker_context_;
 
   base::WeakPtrFactory<ServiceWorkerContext> weak_ptr_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(ServiceWorkerContext);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_session.h
+++ b/shell/browser/api/electron_api_session.h
@@ -155,6 +155,10 @@ class Session : public gin::Wrappable<Session>,
                            extensions::UnloadedExtensionReason reason) override;
 #endif
 
+  // disable copy
+  Session(const Session&) = delete;
+  Session& operator=(const Session&) = delete;
+
  protected:
   Session(v8::Isolate* isolate, ElectronBrowserContext* browser_context);
   ~Session() override;
@@ -187,8 +191,6 @@ class Session : public gin::Wrappable<Session>,
   base::UnguessableToken network_emulation_token_;
 
   ElectronBrowserContext* browser_context_;
-
-  DISALLOW_COPY_AND_ASSIGN(Session);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_system_preferences.h
+++ b/shell/browser/api/electron_api_system_preferences.h
@@ -121,6 +121,10 @@ class SystemPreferences
   bool IsHighContrastColorScheme();
   v8::Local<v8::Value> GetAnimationSettings(v8::Isolate* isolate);
 
+  // disable copy
+  SystemPreferences(const SystemPreferences&) = delete;
+  SystemPreferences& operator=(const SystemPreferences&) = delete;
+
  protected:
   SystemPreferences();
   ~SystemPreferences() override;
@@ -162,7 +166,6 @@ class SystemPreferences
 
   std::unique_ptr<gfx::ScopedSysColorChangeListener> color_change_listener_;
 #endif
-  DISALLOW_COPY_AND_ASSIGN(SystemPreferences);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_tray.h
+++ b/shell/browser/api/electron_api_tray.h
@@ -52,6 +52,10 @@ class Tray : public gin::Wrappable<Tray>,
   // gin::Wrappable
   static gin::WrapperInfo kWrapperInfo;
 
+  // disable copy
+  Tray(const Tray&) = delete;
+  Tray& operator=(const Tray&) = delete;
+
  private:
   Tray(v8::Isolate* isolate,
        v8::Local<v8::Value> image,
@@ -105,8 +109,6 @@ class Tray : public gin::Wrappable<Tray>,
 
   v8::Global<v8::Value> menu_;
   std::unique_ptr<TrayIcon> tray_icon_;
-
-  DISALLOW_COPY_AND_ASSIGN(Tray);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_view.h
+++ b/shell/browser/api/electron_api_view.h
@@ -30,6 +30,10 @@ class View : public gin_helper::Wrappable<View> {
 
   views::View* view() const { return view_; }
 
+  // disable copy
+  View(const View&) = delete;
+  View& operator=(const View&) = delete;
+
  protected:
   explicit View(views::View* view);
   View();
@@ -43,8 +47,6 @@ class View : public gin_helper::Wrappable<View> {
 
   bool delete_view_ = true;
   views::View* view_ = nullptr;
-
-  DISALLOW_COPY_AND_ASSIGN(View);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -15,6 +15,7 @@
 #include "base/containers/id_map.h"
 #include "base/files/file_util.h"
 #include "base/json/json_reader.h"
+#include "base/macros.h"
 #include "base/no_destructor.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/current_thread.h"

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -447,6 +447,10 @@ class WebContents : public ExclusiveAccessContext,
       content::PermissionType permissionType,
       content::RenderFrameHost* render_frame_host);
 
+  // disable copy
+  WebContents(const WebContents&) = delete;
+  WebContents& operator=(const WebContents&) = delete;
+
  private:
   // Does not manage lifetime of |web_contents|.
   WebContents(v8::Isolate* isolate, content::WebContents* web_contents);
@@ -820,8 +824,6 @@ class WebContents : public ExclusiveAccessContext,
   DevicePermissionMap granted_devices_;
 
   base::WeakPtrFactory<WebContents> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(WebContents);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_web_contents_view.h
+++ b/shell/browser/api/electron_api_web_contents_view.h
@@ -51,8 +51,6 @@ class WebContentsView : public View, public content::WebContentsObserver {
   // Keep a reference to v8 wrapper.
   v8::Global<v8::Value> web_contents_;
   api::WebContents* api_web_contents_;
-
-  DISALLOW_COPY_AND_ASSIGN(WebContentsView);
 };
 
 }  // namespace api

--- a/shell/browser/api/electron_api_web_frame_main.h
+++ b/shell/browser/api/electron_api_web_frame_main.h
@@ -59,6 +59,10 @@ class WebFrameMain : public gin::Wrappable<WebFrameMain>,
 
   content::RenderFrameHost* render_frame_host() const { return render_frame_; }
 
+  // disable copy
+  WebFrameMain(const WebFrameMain&) = delete;
+  WebFrameMain& operator=(const WebFrameMain&) = delete;
+
  protected:
   explicit WebFrameMain(content::RenderFrameHost* render_frame);
   ~WebFrameMain() override;
@@ -124,8 +128,6 @@ class WebFrameMain : public gin::Wrappable<WebFrameMain>,
   bool render_frame_disposed_ = false;
 
   base::WeakPtrFactory<WebFrameMain> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(WebFrameMain);
 };
 
 }  // namespace api

--- a/shell/browser/api/event.h
+++ b/shell/browser/api/event.h
@@ -29,6 +29,10 @@ class Event : public gin::Wrappable<Event> {
   // `invoke` calls.
   bool SendReply(v8::Isolate* isolate, v8::Local<v8::Value> result);
 
+  // disable copy
+  Event(const Event&) = delete;
+  Event& operator=(const Event&) = delete;
+
  protected:
   Event();
   ~Event() override;
@@ -41,8 +45,6 @@ class Event : public gin::Wrappable<Event> {
  private:
   // Replyer for the synchronous messages.
   InvokeCallback callback_;
-
-  DISALLOW_COPY_AND_ASSIGN(Event);
 };
 
 }  // namespace gin_helper

--- a/shell/browser/api/frame_subscriber.h
+++ b/shell/browser/api/frame_subscriber.h
@@ -38,6 +38,10 @@ class FrameSubscriber : public content::WebContentsObserver,
                   bool only_dirty);
   ~FrameSubscriber() override;
 
+  // disable copy
+  FrameSubscriber(const FrameSubscriber&) = delete;
+  FrameSubscriber& operator=(const FrameSubscriber&) = delete;
+
  private:
   void AttachToHost(content::RenderWidgetHost* host);
   void DetachFromHost();
@@ -69,8 +73,6 @@ class FrameSubscriber : public content::WebContentsObserver,
   std::unique_ptr<viz::ClientFrameSinkVideoCapturer> video_capturer_;
 
   base::WeakPtrFactory<FrameSubscriber> weak_ptr_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(FrameSubscriber);
 };
 
 }  // namespace api

--- a/shell/browser/api/gpuinfo_manager.h
+++ b/shell/browser/api/gpuinfo_manager.h
@@ -22,6 +22,11 @@ class GPUInfoManager : public content::GpuDataManagerObserver {
 
   GPUInfoManager();
   ~GPUInfoManager() override;
+
+  // disable copy
+  GPUInfoManager(const GPUInfoManager&) = delete;
+  GPUInfoManager& operator=(const GPUInfoManager&) = delete;
+
   bool NeedsCompleteGpuInfoCollection() const;
   void FetchCompleteInfo(gin_helper::Promise<base::DictionaryValue> promise);
   void FetchBasicInfo(gin_helper::Promise<base::DictionaryValue> promise);
@@ -40,8 +45,6 @@ class GPUInfoManager : public content::GpuDataManagerObserver {
   std::vector<gin_helper::Promise<base::DictionaryValue>>
       complete_info_promise_set_;
   content::GpuDataManagerImpl* gpu_data_manager_;
-
-  DISALLOW_COPY_AND_ASSIGN(GPUInfoManager);
 };
 
 }  // namespace electron

--- a/shell/browser/api/views/electron_api_image_view.h
+++ b/shell/browser/api/views/electron_api_image_view.h
@@ -30,9 +30,6 @@ class ImageView : public View {
   views::ImageView* image_view() const {
     return static_cast<views::ImageView*>(view());
   }
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(ImageView);
 };
 
 }  // namespace api

--- a/shell/browser/auto_updater.h
+++ b/shell/browser/auto_updater.h
@@ -8,7 +8,6 @@
 #include <map>
 #include <string>
 
-#include "base/macros.h"
 #include "build/build_config.h"
 
 namespace base {
@@ -53,6 +52,12 @@ class AutoUpdater {
  public:
   typedef std::map<std::string, std::string> HeaderMap;
 
+  AutoUpdater() = delete;
+
+  // disable copy
+  AutoUpdater(const AutoUpdater&) = delete;
+  AutoUpdater& operator=(const AutoUpdater&) = delete;
+
   // Gets/Sets the delegate.
   static Delegate* GetDelegate();
   static void SetDelegate(Delegate* delegate);
@@ -67,8 +72,6 @@ class AutoUpdater {
 
  private:
   static Delegate* delegate_;
-
-  DISALLOW_IMPLICIT_CONSTRUCTORS(AutoUpdater);
 };
 
 }  // namespace auto_updater

--- a/shell/browser/badging/badge_manager.h
+++ b/shell/browser/badging/badge_manager.h
@@ -8,7 +8,6 @@
 #include <memory>
 #include <string>
 
-#include "base/macros.h"
 #include "components/keyed_service/core/keyed_service.h"
 #include "mojo/public/cpp/bindings/receiver_set.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
@@ -31,6 +30,10 @@ class BadgeManager : public KeyedService, public blink::mojom::BadgeService {
  public:
   BadgeManager();
   ~BadgeManager() override;
+
+  // disable copy
+  BadgeManager(const BadgeManager&) = delete;
+  BadgeManager& operator=(const BadgeManager&) = delete;
 
   static void BindFrameReceiver(
       content::RenderFrameHost* frame,
@@ -98,8 +101,6 @@ class BadgeManager : public KeyedService, public blink::mojom::BadgeService {
   // Delegate which handles actual setting and clearing of the badge.
   // Note: This is currently only set on Windows and MacOS.
   // std::unique_ptr<BadgeManagerDelegate> delegate_;
-
-  DISALLOW_COPY_AND_ASSIGN(BadgeManager);
 };
 
 }  // namespace badging

--- a/shell/browser/badging/badge_manager_factory.h
+++ b/shell/browser/badging/badge_manager_factory.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_BADGING_BADGE_MANAGER_FACTORY_H_
 #define SHELL_BROWSER_BADGING_BADGE_MANAGER_FACTORY_H_
 
-#include "base/macros.h"
 #include "components/keyed_service/content/browser_context_keyed_service_factory.h"
 
 namespace base {
@@ -26,6 +25,10 @@ class BadgeManagerFactory : public BrowserContextKeyedServiceFactory {
   // Returns the BadgeManagerFactory singleton.
   static BadgeManagerFactory* GetInstance();
 
+  // disable copy
+  BadgeManagerFactory(const BadgeManagerFactory&) = delete;
+  BadgeManagerFactory& operator=(const BadgeManagerFactory&) = delete;
+
  private:
   friend struct base::DefaultSingletonTraits<BadgeManagerFactory>;
 
@@ -35,8 +38,6 @@ class BadgeManagerFactory : public BrowserContextKeyedServiceFactory {
   // BrowserContextKeyedServiceFactory
   KeyedService* BuildServiceInstanceFor(
       content::BrowserContext* context) const override;
-
-  DISALLOW_COPY_AND_ASSIGN(BadgeManagerFactory);
 };
 
 }  // namespace badging

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "base/compiler_specific.h"
-#include "base/macros.h"
 #include "base/observer_list.h"
 #include "base/task/cancelable_task_tracker.h"
 #include "base/values.h"
@@ -46,6 +45,10 @@ class Browser : public WindowListObserver {
  public:
   Browser();
   ~Browser() override;
+
+  // disable copy
+  Browser(const Browser&) = delete;
+  Browser& operator=(const Browser&) = delete;
 
   static Browser* Get();
 
@@ -371,8 +374,6 @@ class Browser : public WindowListObserver {
   // In charge of running taskbar related APIs.
   TaskbarHost taskbar_host_;
 #endif
-
-  DISALLOW_COPY_AND_ASSIGN(Browser);
 };
 
 }  // namespace electron

--- a/shell/browser/browser_process_impl.h
+++ b/shell/browser/browser_process_impl.h
@@ -14,7 +14,6 @@
 #include <string>
 
 #include "base/command_line.h"
-#include "base/macros.h"
 #include "chrome/browser/browser_process.h"
 #include "components/prefs/pref_service.h"
 #include "components/prefs/value_map_pref_store.h"
@@ -35,6 +34,10 @@ class BrowserProcessImpl : public BrowserProcess {
  public:
   BrowserProcessImpl();
   ~BrowserProcessImpl() override;
+
+  // disable copy
+  BrowserProcessImpl(const BrowserProcessImpl&) = delete;
+  BrowserProcessImpl& operator=(const BrowserProcessImpl&) = delete;
 
   static void ApplyProxyModeFromCommandLine(ValueMapPrefStore* pref_store);
 
@@ -109,8 +112,6 @@ class BrowserProcessImpl : public BrowserProcess {
 #endif
   std::unique_ptr<PrefService> local_state_;
   std::string locale_;
-
-  DISALLOW_COPY_AND_ASSIGN(BrowserProcessImpl);
 };
 
 #endif  // SHELL_BROWSER_BROWSER_PROCESS_IMPL_H_

--- a/shell/browser/child_web_contents_tracker.h
+++ b/shell/browser/child_web_contents_tracker.h
@@ -17,6 +17,10 @@ struct ChildWebContentsTracker
     : public content::WebContentsUserData<ChildWebContentsTracker> {
   ~ChildWebContentsTracker() override;
 
+  // disable copy
+  ChildWebContentsTracker(const ChildWebContentsTracker&) = delete;
+  ChildWebContentsTracker& operator=(const ChildWebContentsTracker&) = delete;
+
   GURL url;
   std::string frame_name;
   content::Referrer referrer;
@@ -28,8 +32,6 @@ struct ChildWebContentsTracker
   friend class content::WebContentsUserData<ChildWebContentsTracker>;
 
   WEB_CONTENTS_USER_DATA_KEY_DECL();
-
-  DISALLOW_COPY_AND_ASSIGN(ChildWebContentsTracker);
 };
 
 }  // namespace electron

--- a/shell/browser/cookie_change_notifier.h
+++ b/shell/browser/cookie_change_notifier.h
@@ -6,7 +6,6 @@
 #define SHELL_BROWSER_COOKIE_CHANGE_NOTIFIER_H_
 
 #include "base/callback_list.h"
-#include "base/macros.h"
 #include "mojo/public/cpp/bindings/receiver.h"
 #include "net/cookies/cookie_change_dispatcher.h"
 #include "services/network/public/mojom/cookie_manager.mojom.h"
@@ -20,6 +19,10 @@ class CookieChangeNotifier : public network::mojom::CookieChangeListener {
  public:
   explicit CookieChangeNotifier(ElectronBrowserContext* browser_context);
   ~CookieChangeNotifier() override;
+
+  // disable copy
+  CookieChangeNotifier(const CookieChangeNotifier&) = delete;
+  CookieChangeNotifier& operator=(const CookieChangeNotifier&) = delete;
 
   // Register callbacks that needs to notified on any cookie store changes.
   base::CallbackListSubscription RegisterCookieChangeCallback(
@@ -38,8 +41,6 @@ class CookieChangeNotifier : public network::mojom::CookieChangeListener {
       cookie_change_sub_list_;
 
   mojo::Receiver<network::mojom::CookieChangeListener> receiver_;
-
-  DISALLOW_COPY_AND_ASSIGN(CookieChangeNotifier);
 };
 
 }  // namespace electron

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1146,6 +1146,10 @@ class FileURLLoaderFactory : public network::SelfDeletingURLLoaderFactory {
     return pending_remote;
   }
 
+  // disable copy
+  FileURLLoaderFactory(const FileURLLoaderFactory&) = delete;
+  FileURLLoaderFactory& operator=(const FileURLLoaderFactory&) = delete;
+
  private:
   explicit FileURLLoaderFactory(
       int child_id,
@@ -1177,8 +1181,6 @@ class FileURLLoaderFactory : public network::SelfDeletingURLLoaderFactory {
   }
 
   int child_id_;
-
-  DISALLOW_COPY_AND_ASSIGN(FileURLLoaderFactory);
 };
 
 }  // namespace

--- a/shell/browser/electron_browser_client.h
+++ b/shell/browser/electron_browser_client.h
@@ -49,6 +49,10 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
   ElectronBrowserClient();
   ~ElectronBrowserClient() override;
 
+  // disable copy
+  ElectronBrowserClient(const ElectronBrowserClient&) = delete;
+  ElectronBrowserClient& operator=(const ElectronBrowserClient&) = delete;
+
   using Delegate = content::ContentBrowserClient;
   void set_delegate(Delegate* delegate) { delegate_ = delegate; }
 
@@ -318,8 +322,6 @@ class ElectronBrowserClient : public content::ContentBrowserClient,
 #if defined(OS_MAC)
   ElectronBrowserMainParts* browser_main_parts_ = nullptr;
 #endif
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronBrowserClient);
 };
 
 }  // namespace electron

--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -48,6 +48,10 @@ class ProtocolRegistry;
 
 class ElectronBrowserContext : public content::BrowserContext {
  public:
+  // disable copy
+  ElectronBrowserContext(const ElectronBrowserContext&) = delete;
+  ElectronBrowserContext& operator=(const ElectronBrowserContext&) = delete;
+
   // partition_id => browser_context
   struct PartitionKey {
     std::string partition;
@@ -184,8 +188,6 @@ class ElectronBrowserContext : public content::BrowserContext {
   mojo::Remote<network::mojom::SSLConfigClient> ssl_config_client_;
 
   base::WeakPtrFactory<ElectronBrowserContext> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronBrowserContext);
 };
 
 }  // namespace electron

--- a/shell/browser/electron_browser_handler_impl.h
+++ b/shell/browser/electron_browser_handler_impl.h
@@ -8,7 +8,6 @@
 #include <string>
 #include <vector>
 
-#include "base/macros.h"
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "electron/shell/common/api/api.mojom.h"
@@ -28,6 +27,11 @@ class ElectronBrowserHandlerImpl : public mojom::ElectronBrowser,
 
   static void Create(content::RenderFrameHost* frame_host,
                      mojo::PendingReceiver<mojom::ElectronBrowser> receiver);
+
+  // disable copy
+  ElectronBrowserHandlerImpl(const ElectronBrowserHandlerImpl&) = delete;
+  ElectronBrowserHandlerImpl& operator=(const ElectronBrowserHandlerImpl&) =
+      delete;
 
   // mojom::ElectronBrowser:
   void Message(bool internal,
@@ -74,8 +78,6 @@ class ElectronBrowserHandlerImpl : public mojom::ElectronBrowser,
   mojo::Receiver<mojom::ElectronBrowser> receiver_{this};
 
   base::WeakPtrFactory<ElectronBrowserHandlerImpl> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronBrowserHandlerImpl);
 };
 }  // namespace electron
 #endif  // SHELL_BROWSER_ELECTRON_BROWSER_HANDLER_IMPL_H_

--- a/shell/browser/electron_browser_main_parts.h
+++ b/shell/browser/electron_browser_main_parts.h
@@ -76,6 +76,10 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
   explicit ElectronBrowserMainParts(const content::MainFunctionParams& params);
   ~ElectronBrowserMainParts() override;
 
+  // disable copy
+  ElectronBrowserMainParts(const ElectronBrowserMainParts&) = delete;
+  ElectronBrowserMainParts& operator=(const ElectronBrowserMainParts&) = delete;
+
   static ElectronBrowserMainParts* Get();
 
   // Sets the exit code, will fail if the message loop is not ready.
@@ -175,8 +179,6 @@ class ElectronBrowserMainParts : public content::BrowserMainParts {
 #endif
 
   static ElectronBrowserMainParts* self_;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronBrowserMainParts);
 };
 
 }  // namespace electron

--- a/shell/browser/electron_browser_main_parts_posix.cc
+++ b/shell/browser/electron_browser_main_parts_posix.cc
@@ -84,6 +84,10 @@ class ShutdownDetector : public base::PlatformThread::Delegate {
       base::OnceCallback<void()> shutdown_callback,
       const scoped_refptr<base::SingleThreadTaskRunner>& task_runner);
 
+  // disable copy
+  ShutdownDetector(const ShutdownDetector&) = delete;
+  ShutdownDetector& operator=(const ShutdownDetector&) = delete;
+
   // base::PlatformThread::Delegate:
   void ThreadMain() override;
 
@@ -91,8 +95,6 @@ class ShutdownDetector : public base::PlatformThread::Delegate {
   const int shutdown_fd_;
   base::OnceCallback<void()> shutdown_callback_;
   const scoped_refptr<base::SingleThreadTaskRunner> task_runner_;
-
-  DISALLOW_COPY_AND_ASSIGN(ShutdownDetector);
 };
 
 ShutdownDetector::ShutdownDetector(

--- a/shell/browser/electron_download_manager_delegate.cc
+++ b/shell/browser/electron_download_manager_delegate.cc
@@ -9,6 +9,7 @@
 
 #include "base/bind.h"
 #include "base/files/file_util.h"
+#include "base/macros.h"
 #include "base/task/post_task.h"
 #include "base/task/thread_pool.h"
 #include "chrome/common/pref_names.h"

--- a/shell/browser/electron_download_manager_delegate.h
+++ b/shell/browser/electron_download_manager_delegate.h
@@ -25,6 +25,12 @@ class ElectronDownloadManagerDelegate
   explicit ElectronDownloadManagerDelegate(content::DownloadManager* manager);
   ~ElectronDownloadManagerDelegate() override;
 
+  // disable copy
+  ElectronDownloadManagerDelegate(const ElectronDownloadManagerDelegate&) =
+      delete;
+  ElectronDownloadManagerDelegate& operator=(
+      const ElectronDownloadManagerDelegate&) = delete;
+
   // content::DownloadManagerDelegate:
   void Shutdown() override;
   bool DetermineDownloadTarget(
@@ -54,8 +60,6 @@ class ElectronDownloadManagerDelegate
 
   content::DownloadManager* download_manager_;
   base::WeakPtrFactory<ElectronDownloadManagerDelegate> weak_ptr_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronDownloadManagerDelegate);
 };
 
 }  // namespace electron

--- a/shell/browser/electron_gpu_client.h
+++ b/shell/browser/electron_gpu_client.h
@@ -13,11 +13,12 @@ class ElectronGpuClient : public content::ContentGpuClient {
  public:
   ElectronGpuClient();
 
+  // disable copy
+  ElectronGpuClient(const ElectronGpuClient&) = delete;
+  ElectronGpuClient& operator=(const ElectronGpuClient&) = delete;
+
   // content::ContentGpuClient:
   void PreCreateMessageLoop() override;
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(ElectronGpuClient);
 };
 
 }  // namespace electron

--- a/shell/browser/electron_navigation_throttle.h
+++ b/shell/browser/electron_navigation_throttle.h
@@ -14,15 +14,17 @@ class ElectronNavigationThrottle : public content::NavigationThrottle {
   explicit ElectronNavigationThrottle(content::NavigationHandle* handle);
   ~ElectronNavigationThrottle() override;
 
+  // disable copy
+  ElectronNavigationThrottle(const ElectronNavigationThrottle&) = delete;
+  ElectronNavigationThrottle& operator=(const ElectronNavigationThrottle&) =
+      delete;
+
   ElectronNavigationThrottle::ThrottleCheckResult WillStartRequest() override;
 
   ElectronNavigationThrottle::ThrottleCheckResult WillRedirectRequest()
       override;
 
   const char* GetNameForLogging() override;
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(ElectronNavigationThrottle);
 };
 
 }  // namespace electron

--- a/shell/browser/electron_permission_manager.h
+++ b/shell/browser/electron_permission_manager.h
@@ -29,6 +29,11 @@ class ElectronPermissionManager : public content::PermissionControllerDelegate {
   ElectronPermissionManager();
   ~ElectronPermissionManager() override;
 
+  // disable copy
+  ElectronPermissionManager(const ElectronPermissionManager&) = delete;
+  ElectronPermissionManager& operator=(const ElectronPermissionManager&) =
+      delete;
+
   using StatusCallback =
       base::OnceCallback<void(blink::mojom::PermissionStatus)>;
   using StatusesCallback = base::OnceCallback<void(
@@ -126,8 +131,6 @@ class ElectronPermissionManager : public content::PermissionControllerDelegate {
   DeviceCheckHandler device_permission_handler_;
 
   PendingRequestsMap pending_requests_;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronPermissionManager);
 };
 
 }  // namespace electron

--- a/shell/browser/electron_quota_permission_context.h
+++ b/shell/browser/electron_quota_permission_context.h
@@ -19,6 +19,12 @@ class ElectronQuotaPermissionContext : public content::QuotaPermissionContext {
 
   ElectronQuotaPermissionContext();
 
+  // disable copy
+  ElectronQuotaPermissionContext(const ElectronQuotaPermissionContext&) =
+      delete;
+  ElectronQuotaPermissionContext& operator=(
+      const ElectronQuotaPermissionContext&) = delete;
+
   // content::QuotaPermissionContext:
   void RequestQuotaPermission(const content::StorageQuotaParams& params,
                               int render_process_id,
@@ -26,8 +32,6 @@ class ElectronQuotaPermissionContext : public content::QuotaPermissionContext {
 
  private:
   ~ElectronQuotaPermissionContext() override;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronQuotaPermissionContext);
 };
 
 }  // namespace electron

--- a/shell/browser/electron_speech_recognition_manager_delegate.h
+++ b/shell/browser/electron_speech_recognition_manager_delegate.h
@@ -7,7 +7,6 @@
 
 #include <vector>
 
-#include "base/macros.h"
 #include "content/public/browser/speech_recognition_event_listener.h"
 #include "content/public/browser/speech_recognition_manager_delegate.h"
 
@@ -19,6 +18,12 @@ class ElectronSpeechRecognitionManagerDelegate
  public:
   ElectronSpeechRecognitionManagerDelegate();
   ~ElectronSpeechRecognitionManagerDelegate() override;
+
+  // disable copy
+  ElectronSpeechRecognitionManagerDelegate(
+      const ElectronSpeechRecognitionManagerDelegate&) = delete;
+  ElectronSpeechRecognitionManagerDelegate& operator=(
+      const ElectronSpeechRecognitionManagerDelegate&) = delete;
 
   // content::SpeechRecognitionEventListener:
   void OnRecognitionStart(int session_id) override;
@@ -45,9 +50,6 @@ class ElectronSpeechRecognitionManagerDelegate
       override;
   content::SpeechRecognitionEventListener* GetEventListener() override;
   bool FilterProfanities(int render_process_id) override;
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(ElectronSpeechRecognitionManagerDelegate);
 };
 
 }  // namespace electron

--- a/shell/browser/electron_web_ui_controller_factory.h
+++ b/shell/browser/electron_web_ui_controller_factory.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 
-#include "base/macros.h"
 #include "base/memory/singleton.h"
 #include "content/public/browser/web_ui_controller_factory.h"
 
@@ -24,6 +23,12 @@ class ElectronWebUIControllerFactory : public content::WebUIControllerFactory {
   ElectronWebUIControllerFactory();
   ~ElectronWebUIControllerFactory() override;
 
+  // disable copy
+  ElectronWebUIControllerFactory(const ElectronWebUIControllerFactory&) =
+      delete;
+  ElectronWebUIControllerFactory& operator=(
+      const ElectronWebUIControllerFactory&) = delete;
+
   // content::WebUIControllerFactory:
   content::WebUI::TypeID GetWebUIType(content::BrowserContext* browser_context,
                                       const GURL& url) override;
@@ -35,8 +40,6 @@ class ElectronWebUIControllerFactory : public content::WebUIControllerFactory {
 
  private:
   friend struct base::DefaultSingletonTraits<ElectronWebUIControllerFactory>;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronWebUIControllerFactory);
 };
 
 }  // namespace electron

--- a/shell/browser/event_emitter_mixin.h
+++ b/shell/browser/event_emitter_mixin.h
@@ -20,6 +20,10 @@ v8::Local<v8::FunctionTemplate> GetEventEmitterTemplate(v8::Isolate* isolate);
 template <typename T>
 class EventEmitterMixin {
  public:
+  // disable copy
+  EventEmitterMixin(const EventEmitterMixin&) = delete;
+  EventEmitterMixin& operator=(const EventEmitterMixin&) = delete;
+
   // this.emit(name, new Event(), args...);
   // Returns true if event.preventDefault() was called during processing.
   template <typename... Args>
@@ -87,8 +91,6 @@ class EventEmitterMixin {
     }
     return false;
   }
-
-  DISALLOW_COPY_AND_ASSIGN(EventEmitterMixin);
 };
 
 }  // namespace gin_helper

--- a/shell/browser/extensions/api/management/electron_management_api_delegate.cc
+++ b/shell/browser/extensions/api/management/electron_management_api_delegate.cc
@@ -10,7 +10,6 @@
 #include <utility>
 
 #include "base/bind.h"
-#include "base/macros.h"
 #include "base/strings/strcat.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
@@ -44,11 +43,15 @@ class ManagementSetEnabledFunctionInstallPromptDelegate
   }
   ~ManagementSetEnabledFunctionInstallPromptDelegate() override = default;
 
+  // disable copy
+  ManagementSetEnabledFunctionInstallPromptDelegate(
+      const ManagementSetEnabledFunctionInstallPromptDelegate&) = delete;
+  ManagementSetEnabledFunctionInstallPromptDelegate& operator=(
+      const ManagementSetEnabledFunctionInstallPromptDelegate&) = delete;
+
  private:
   base::WeakPtrFactory<ManagementSetEnabledFunctionInstallPromptDelegate>
       weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(ManagementSetEnabledFunctionInstallPromptDelegate);
 };
 
 class ManagementUninstallFunctionUninstallDialogDelegate
@@ -63,8 +66,11 @@ class ManagementUninstallFunctionUninstallDialogDelegate
 
   ~ManagementUninstallFunctionUninstallDialogDelegate() override = default;
 
- private:
-  DISALLOW_COPY_AND_ASSIGN(ManagementUninstallFunctionUninstallDialogDelegate);
+  // disable copy
+  ManagementUninstallFunctionUninstallDialogDelegate(
+      const ManagementUninstallFunctionUninstallDialogDelegate&) = delete;
+  ManagementUninstallFunctionUninstallDialogDelegate& operator=(
+      const ManagementUninstallFunctionUninstallDialogDelegate&) = delete;
 };
 
 }  // namespace

--- a/shell/browser/extensions/api/resources_private/resources_private_api.h
+++ b/shell/browser/extensions/api/resources_private/resources_private_api.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_EXTENSIONS_API_RESOURCES_PRIVATE_RESOURCES_PRIVATE_API_H_
 #define SHELL_BROWSER_EXTENSIONS_API_RESOURCES_PRIVATE_RESOURCES_PRIVATE_API_H_
 
-#include "base/macros.h"
 #include "extensions/browser/extension_function.h"
 
 namespace extensions {
@@ -16,14 +15,17 @@ class ResourcesPrivateGetStringsFunction : public ExtensionFunction {
                              RESOURCESPRIVATE_GETSTRINGS)
   ResourcesPrivateGetStringsFunction();
 
+  // disable copy
+  ResourcesPrivateGetStringsFunction(
+      const ResourcesPrivateGetStringsFunction&) = delete;
+  ResourcesPrivateGetStringsFunction& operator=(
+      const ResourcesPrivateGetStringsFunction&) = delete;
+
  protected:
   ~ResourcesPrivateGetStringsFunction() override;
 
   // Override from ExtensionFunction:
   ExtensionFunction::ResponseAction Run() override;
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(ResourcesPrivateGetStringsFunction);
 };
 
 }  // namespace extensions

--- a/shell/browser/extensions/api/runtime/electron_runtime_api_delegate.h
+++ b/shell/browser/extensions/api/runtime/electron_runtime_api_delegate.h
@@ -7,7 +7,6 @@
 
 #include <string>
 
-#include "base/macros.h"
 #include "extensions/browser/api/runtime/runtime_api_delegate.h"
 
 namespace content {
@@ -21,6 +20,11 @@ class ElectronRuntimeAPIDelegate : public RuntimeAPIDelegate {
   explicit ElectronRuntimeAPIDelegate(content::BrowserContext* browser_context);
   ~ElectronRuntimeAPIDelegate() override;
 
+  // disable copy
+  ElectronRuntimeAPIDelegate(const ElectronRuntimeAPIDelegate&) = delete;
+  ElectronRuntimeAPIDelegate& operator=(const ElectronRuntimeAPIDelegate&) =
+      delete;
+
   // RuntimeAPIDelegate implementation.
   void AddUpdateObserver(UpdateObserver* observer) override;
   void RemoveUpdateObserver(UpdateObserver* observer) override;
@@ -33,8 +37,6 @@ class ElectronRuntimeAPIDelegate : public RuntimeAPIDelegate {
 
  private:
   content::BrowserContext* browser_context_;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronRuntimeAPIDelegate);
 };
 
 }  // namespace extensions

--- a/shell/browser/extensions/api/streams_private/streams_private_api.h
+++ b/shell/browser/extensions/api/streams_private/streams_private_api.h
@@ -7,7 +7,6 @@
 
 #include <string>
 
-#include "base/macros.h"
 #include "third_party/blink/public/mojom/loader/transferrable_url_loader.mojom.h"
 
 namespace extensions {

--- a/shell/browser/extensions/electron_component_extension_resource_manager.h
+++ b/shell/browser/extensions/electron_component_extension_resource_manager.h
@@ -11,7 +11,6 @@
 #include <string>
 
 #include "base/files/file_path.h"
-#include "base/macros.h"
 #include "extensions/browser/component_extension_resource_manager.h"
 #include "ui/base/webui/resource_path.h"
 
@@ -24,6 +23,12 @@ class ElectronComponentExtensionResourceManager
  public:
   ElectronComponentExtensionResourceManager();
   ~ElectronComponentExtensionResourceManager() override;
+
+  // disable copy
+  ElectronComponentExtensionResourceManager(
+      const ElectronComponentExtensionResourceManager&) = delete;
+  ElectronComponentExtensionResourceManager& operator=(
+      const ElectronComponentExtensionResourceManager&) = delete;
 
   // Overridden from ComponentExtensionResourceManager:
   bool IsComponentExtensionResource(const base::FilePath& extension_path,
@@ -43,8 +48,6 @@ class ElectronComponentExtensionResourceManager
   // A map from an extension ID to its i18n template replacements.
   std::map<std::string, ui::TemplateReplacements>
       extension_template_replacements_;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronComponentExtensionResourceManager);
 };
 
 }  // namespace extensions

--- a/shell/browser/extensions/electron_display_info_provider.h
+++ b/shell/browser/extensions/electron_display_info_provider.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_EXTENSIONS_ELECTRON_DISPLAY_INFO_PROVIDER_H_
 #define SHELL_BROWSER_EXTENSIONS_ELECTRON_DISPLAY_INFO_PROVIDER_H_
 
-#include "base/macros.h"
 #include "extensions/browser/api/system_display/display_info_provider.h"
 
 namespace extensions {
@@ -14,8 +13,10 @@ class ElectronDisplayInfoProvider : public DisplayInfoProvider {
  public:
   ElectronDisplayInfoProvider();
 
- private:
-  DISALLOW_COPY_AND_ASSIGN(ElectronDisplayInfoProvider);
+  // disable copy
+  ElectronDisplayInfoProvider(const ElectronDisplayInfoProvider&) = delete;
+  ElectronDisplayInfoProvider& operator=(const ElectronDisplayInfoProvider&) =
+      delete;
 };
 
 }  // namespace extensions

--- a/shell/browser/extensions/electron_extension_host_delegate.h
+++ b/shell/browser/extensions/electron_extension_host_delegate.h
@@ -8,7 +8,6 @@
 #include <memory>
 #include <string>
 
-#include "base/macros.h"
 #include "extensions/browser/extension_host_delegate.h"
 
 namespace extensions {
@@ -18,6 +17,11 @@ class ElectronExtensionHostDelegate : public ExtensionHostDelegate {
  public:
   ElectronExtensionHostDelegate();
   ~ElectronExtensionHostDelegate() override;
+
+  // disable copy
+  ElectronExtensionHostDelegate(const ElectronExtensionHostDelegate&) = delete;
+  ElectronExtensionHostDelegate& operator=(
+      const ElectronExtensionHostDelegate&) = delete;
 
   // ExtensionHostDelegate implementation.
   void OnExtensionHostCreated(content::WebContents* web_contents) override;
@@ -41,9 +45,6 @@ class ElectronExtensionHostDelegate : public ExtensionHostDelegate {
       const viz::SurfaceId& surface_id,
       const gfx::Size& natural_size) override;
   void ExitPictureInPicture() override;
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(ElectronExtensionHostDelegate);
 };
 
 }  // namespace extensions

--- a/shell/browser/extensions/electron_extension_loader.h
+++ b/shell/browser/extensions/electron_extension_loader.h
@@ -9,7 +9,6 @@
 #include <utility>
 
 #include "base/callback.h"
-#include "base/macros.h"
 #include "base/memory/ref_counted.h"
 #include "base/memory/weak_ptr.h"
 #include "extensions/browser/extension_registrar.h"
@@ -32,6 +31,10 @@ class ElectronExtensionLoader : public ExtensionRegistrar::Delegate {
  public:
   explicit ElectronExtensionLoader(content::BrowserContext* browser_context);
   ~ElectronExtensionLoader() override;
+
+  // disable copy
+  ElectronExtensionLoader(const ElectronExtensionLoader&) = delete;
+  ElectronExtensionLoader& operator=(const ElectronExtensionLoader&) = delete;
 
   // Loads an unpacked extension from a directory synchronously. Returns the
   // extension on success, or nullptr otherwise.
@@ -91,8 +94,6 @@ class ElectronExtensionLoader : public ExtensionRegistrar::Delegate {
   bool did_schedule_reload_ = false;
 
   base::WeakPtrFactory<ElectronExtensionLoader> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronExtensionLoader);
 };
 
 }  // namespace extensions

--- a/shell/browser/extensions/electron_extension_message_filter.h
+++ b/shell/browser/extensions/electron_extension_message_filter.h
@@ -8,7 +8,6 @@
 #include <string>
 #include <vector>
 
-#include "base/macros.h"
 #include "base/sequenced_task_runner_helpers.h"
 #include "content/public/browser/browser_message_filter.h"
 #include "content/public/browser/browser_thread.h"
@@ -30,6 +29,12 @@ class ElectronExtensionMessageFilter : public content::BrowserMessageFilter {
  public:
   ElectronExtensionMessageFilter(int render_process_id,
                                  content::BrowserContext* browser_context);
+
+  // disable copy
+  ElectronExtensionMessageFilter(const ElectronExtensionMessageFilter&) =
+      delete;
+  ElectronExtensionMessageFilter& operator=(
+      const ElectronExtensionMessageFilter&) = delete;
 
   // content::BrowserMessageFilter methods:
   bool OnMessageReceived(const IPC::Message& message) override;
@@ -59,8 +64,6 @@ class ElectronExtensionMessageFilter : public content::BrowserMessageFilter {
   // may outlive |browser_context_|, so make sure to NULL check if in doubt;
   // async calls and the like.
   content::BrowserContext* browser_context_;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronExtensionMessageFilter);
 };
 
 }  // namespace electron

--- a/shell/browser/extensions/electron_extension_system.h
+++ b/shell/browser/extensions/electron_extension_system.h
@@ -9,7 +9,6 @@
 #include <string>
 
 #include "base/compiler_specific.h"
-#include "base/macros.h"
 #include "base/memory/ref_counted.h"
 #include "base/memory/weak_ptr.h"
 #include "base/one_shot_event.h"
@@ -37,6 +36,10 @@ class ElectronExtensionSystem : public ExtensionSystem {
   using InstallUpdateCallback = ExtensionSystem::InstallUpdateCallback;
   explicit ElectronExtensionSystem(content::BrowserContext* browser_context);
   ~ElectronExtensionSystem() override;
+
+  // disable copy
+  ElectronExtensionSystem(const ElectronExtensionSystem&) = delete;
+  ElectronExtensionSystem& operator=(const ElectronExtensionSystem&) = delete;
 
   // Loads an unpacked extension from a directory. Returns the extension on
   // success, or nullptr otherwise.
@@ -115,8 +118,6 @@ class ElectronExtensionSystem : public ExtensionSystem {
   base::OneShotEvent ready_;
 
   base::WeakPtrFactory<ElectronExtensionSystem> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronExtensionSystem);
 };
 
 }  // namespace extensions

--- a/shell/browser/extensions/electron_extension_system_factory.h
+++ b/shell/browser/extensions/electron_extension_system_factory.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_EXTENSIONS_ELECTRON_EXTENSION_SYSTEM_FACTORY_H_
 #define SHELL_BROWSER_EXTENSIONS_ELECTRON_EXTENSION_SYSTEM_FACTORY_H_
 
-#include "base/macros.h"
 #include "base/memory/singleton.h"
 #include "extensions/browser/extension_system_provider.h"
 
@@ -20,6 +19,12 @@ class ElectronExtensionSystemFactory : public ExtensionSystemProvider {
 
   static ElectronExtensionSystemFactory* GetInstance();
 
+  // disable copy
+  ElectronExtensionSystemFactory(const ElectronExtensionSystemFactory&) =
+      delete;
+  ElectronExtensionSystemFactory& operator=(
+      const ElectronExtensionSystemFactory&) = delete;
+
  private:
   friend struct base::DefaultSingletonTraits<ElectronExtensionSystemFactory>;
 
@@ -32,8 +37,6 @@ class ElectronExtensionSystemFactory : public ExtensionSystemProvider {
   content::BrowserContext* GetBrowserContextToUse(
       content::BrowserContext* context) const override;
   bool ServiceIsCreatedWithBrowserContext() const override;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronExtensionSystemFactory);
 };
 
 }  // namespace extensions

--- a/shell/browser/extensions/electron_extension_web_contents_observer.h
+++ b/shell/browser/extensions/electron_extension_web_contents_observer.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_EXTENSIONS_ELECTRON_EXTENSION_WEB_CONTENTS_OBSERVER_H_
 #define SHELL_BROWSER_EXTENSIONS_ELECTRON_EXTENSION_WEB_CONTENTS_OBSERVER_H_
 
-#include "base/macros.h"
 #include "content/public/browser/web_contents_user_data.h"
 #include "extensions/browser/extension_web_contents_observer.h"
 
@@ -19,6 +18,12 @@ class ElectronExtensionWebContentsObserver
  public:
   ~ElectronExtensionWebContentsObserver() override;
 
+  // disable copy
+  ElectronExtensionWebContentsObserver(
+      const ElectronExtensionWebContentsObserver&) = delete;
+  ElectronExtensionWebContentsObserver& operator=(
+      const ElectronExtensionWebContentsObserver&) = delete;
+
   // Creates and initializes an instance of this class for the given
   // |web_contents|, if it doesn't already exist.
   static void CreateForWebContents(content::WebContents* web_contents);
@@ -31,8 +36,6 @@ class ElectronExtensionWebContentsObserver
       content::WebContents* web_contents);
 
   WEB_CONTENTS_USER_DATA_KEY_DECL();
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronExtensionWebContentsObserver);
 };
 
 }  // namespace extensions

--- a/shell/browser/extensions/electron_extensions_api_client.cc
+++ b/shell/browser/extensions/electron_extensions_api_client.cc
@@ -37,15 +37,18 @@ class ElectronGuestViewManagerDelegate
       : ExtensionsGuestViewManagerDelegate(context) {}
   ~ElectronGuestViewManagerDelegate() override = default;
 
+  // disable copy
+  ElectronGuestViewManagerDelegate(const ElectronGuestViewManagerDelegate&) =
+      delete;
+  ElectronGuestViewManagerDelegate& operator=(
+      const ElectronGuestViewManagerDelegate&) = delete;
+
   // GuestViewManagerDelegate:
   void OnGuestAdded(content::WebContents* guest_web_contents) const override {
     v8::Isolate* isolate = v8::Isolate::GetCurrent();
     v8::HandleScope scope(isolate);
     electron::api::WebContents::FromOrCreate(isolate, guest_web_contents);
   }
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(ElectronGuestViewManagerDelegate);
 };
 
 class ElectronMimeHandlerViewGuestDelegate
@@ -53,6 +56,12 @@ class ElectronMimeHandlerViewGuestDelegate
  public:
   ElectronMimeHandlerViewGuestDelegate() = default;
   ~ElectronMimeHandlerViewGuestDelegate() override = default;
+
+  // disable copy
+  ElectronMimeHandlerViewGuestDelegate(
+      const ElectronMimeHandlerViewGuestDelegate&) = delete;
+  ElectronMimeHandlerViewGuestDelegate& operator=(
+      const ElectronMimeHandlerViewGuestDelegate&) = delete;
 
   // MimeHandlerViewGuestDelegate.
   bool HandleContextMenu(content::WebContents* web_contents,
@@ -63,9 +72,6 @@ class ElectronMimeHandlerViewGuestDelegate
   }
   void RecordLoadMetric(bool in_main_frame,
                         const std::string& mime_type) override {}
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(ElectronMimeHandlerViewGuestDelegate);
 };
 
 ElectronExtensionsAPIClient::ElectronExtensionsAPIClient() = default;

--- a/shell/browser/extensions/electron_extensions_browser_api_provider.h
+++ b/shell/browser/extensions/electron_extensions_browser_api_provider.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_EXTENSIONS_ELECTRON_EXTENSIONS_BROWSER_API_PROVIDER_H_
 #define SHELL_BROWSER_EXTENSIONS_ELECTRON_EXTENSIONS_BROWSER_API_PROVIDER_H_
 
-#include "base/macros.h"
 #include "extensions/browser/extensions_browser_api_provider.h"
 
 namespace extensions {
@@ -16,10 +15,13 @@ class ElectronExtensionsBrowserAPIProvider
   ElectronExtensionsBrowserAPIProvider();
   ~ElectronExtensionsBrowserAPIProvider() override;
 
-  void RegisterExtensionFunctions(ExtensionFunctionRegistry* registry) override;
+  // disable copy
+  ElectronExtensionsBrowserAPIProvider(
+      const ElectronExtensionsBrowserAPIProvider&) = delete;
+  ElectronExtensionsBrowserAPIProvider& operator=(
+      const ElectronExtensionsBrowserAPIProvider&) = delete;
 
- private:
-  DISALLOW_COPY_AND_ASSIGN(ElectronExtensionsBrowserAPIProvider);
+  void RegisterExtensionFunctions(ExtensionFunctionRegistry* registry) override;
 };
 
 }  // namespace extensions

--- a/shell/browser/extensions/electron_extensions_browser_client.h
+++ b/shell/browser/extensions/electron_extensions_browser_client.h
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "base/compiler_specific.h"
-#include "base/macros.h"
 #include "build/build_config.h"
 #include "extensions/browser/extensions_browser_client.h"
 #include "extensions/browser/kiosk/kiosk_delegate.h"
@@ -38,6 +37,12 @@ class ElectronExtensionsBrowserClient
  public:
   ElectronExtensionsBrowserClient();
   ~ElectronExtensionsBrowserClient() override;
+
+  // disable copy
+  ElectronExtensionsBrowserClient(const ElectronExtensionsBrowserClient&) =
+      delete;
+  ElectronExtensionsBrowserClient& operator=(
+      const ElectronExtensionsBrowserClient&) = delete;
 
   // ExtensionsBrowserClient overrides:
   bool IsShuttingDown() override;
@@ -138,8 +143,6 @@ class ElectronExtensionsBrowserClient
 
   std::unique_ptr<extensions::ElectronComponentExtensionResourceManager>
       resource_manager_;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronExtensionsBrowserClient);
 };
 
 }  // namespace electron

--- a/shell/browser/extensions/electron_messaging_delegate.h
+++ b/shell/browser/extensions/electron_messaging_delegate.h
@@ -18,6 +18,11 @@ class ElectronMessagingDelegate : public MessagingDelegate {
   ElectronMessagingDelegate();
   ~ElectronMessagingDelegate() override;
 
+  // disable copy
+  ElectronMessagingDelegate(const ElectronMessagingDelegate&) = delete;
+  ElectronMessagingDelegate& operator=(const ElectronMessagingDelegate&) =
+      delete;
+
   // MessagingDelegate:
   PolicyPermission IsNativeMessagingHostAllowed(
       content::BrowserContext* browser_context,
@@ -48,9 +53,6 @@ class ElectronMessagingDelegate : public MessagingDelegate {
       content::WebContents* source_contents,
       const GURL& url,
       base::OnceCallback<void(bool)> callback) override;
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(ElectronMessagingDelegate);
 };
 
 }  // namespace extensions

--- a/shell/browser/extensions/electron_navigation_ui_data.h
+++ b/shell/browser/extensions/electron_navigation_ui_data.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 
-#include "base/macros.h"
 #include "content/public/browser/navigation_ui_data.h"
 #include "extensions/browser/extension_navigation_ui_data.h"
 
@@ -25,6 +24,10 @@ class ElectronNavigationUIData : public content::NavigationUIData {
       content::NavigationHandle* navigation_handle);
   ~ElectronNavigationUIData() override;
 
+  // disable copy
+  ElectronNavigationUIData(const ElectronNavigationUIData&) = delete;
+  ElectronNavigationUIData& operator=(const ElectronNavigationUIData&) = delete;
+
   // Creates a new ChromeNavigationUIData that is a deep copy of the original.
   // Any changes to the original after the clone is created will not be
   // reflected in the clone.  |extension_data_| is deep copied.
@@ -40,8 +43,6 @@ class ElectronNavigationUIData : public content::NavigationUIData {
  private:
   // Manages the lifetime of optional ExtensionNavigationUIData information.
   std::unique_ptr<ExtensionNavigationUIData> extension_data_;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronNavigationUIData);
 };
 
 }  // namespace extensions

--- a/shell/browser/extensions/electron_process_manager_delegate.h
+++ b/shell/browser/extensions/electron_process_manager_delegate.h
@@ -6,7 +6,6 @@
 #define SHELL_BROWSER_EXTENSIONS_ELECTRON_PROCESS_MANAGER_DELEGATE_H_
 
 #include "base/compiler_specific.h"
-#include "base/macros.h"
 #include "content/public/browser/notification_observer.h"
 #include "content/public/browser/notification_registrar.h"
 #include "extensions/browser/process_manager_delegate.h"
@@ -23,6 +22,12 @@ class ElectronProcessManagerDelegate : public ProcessManagerDelegate {
   ElectronProcessManagerDelegate();
   ~ElectronProcessManagerDelegate() override;
 
+  // disable copy
+  ElectronProcessManagerDelegate(const ElectronProcessManagerDelegate&) =
+      delete;
+  ElectronProcessManagerDelegate& operator=(
+      const ElectronProcessManagerDelegate&) = delete;
+
   // ProcessManagerDelegate implementation:
   bool AreBackgroundPagesAllowedForContext(
       content::BrowserContext* context) const override;
@@ -31,9 +36,6 @@ class ElectronProcessManagerDelegate : public ProcessManagerDelegate {
       const Extension& extension) const override;
   bool DeferCreatingStartupBackgroundHosts(
       content::BrowserContext* context) const override;
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(ElectronProcessManagerDelegate);
 };
 
 }  // namespace extensions

--- a/shell/browser/fake_location_provider.h
+++ b/shell/browser/fake_location_provider.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_FAKE_LOCATION_PROVIDER_H_
 #define SHELL_BROWSER_FAKE_LOCATION_PROVIDER_H_
 
-#include "base/macros.h"
 #include "services/device/public/cpp/geolocation/location_provider.h"
 #include "services/device/public/mojom/geoposition.mojom.h"
 
@@ -15,6 +14,10 @@ class FakeLocationProvider : public device::LocationProvider {
  public:
   FakeLocationProvider();
   ~FakeLocationProvider() override;
+
+  // disable copy
+  FakeLocationProvider(const FakeLocationProvider&) = delete;
+  FakeLocationProvider& operator=(const FakeLocationProvider&) = delete;
 
   // LocationProvider Implementation:
   void SetUpdateCallback(
@@ -27,8 +30,6 @@ class FakeLocationProvider : public device::LocationProvider {
  private:
   device::mojom::Geoposition position_;
   LocationProviderUpdateCallback callback_;
-
-  DISALLOW_COPY_AND_ASSIGN(FakeLocationProvider);
 };
 
 }  // namespace electron

--- a/shell/browser/file_select_helper.h
+++ b/shell/browser/file_select_helper.h
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "base/compiler_specific.h"
-#include "base/macros.h"
 #include "base/scoped_observation.h"
 #include "build/build_config.h"
 #include "content/public/browser/browser_thread.h"
@@ -46,6 +45,10 @@ class FileSelectHelper : public base::RefCountedThreadSafe<
                          public content::RenderWidgetHostObserver,
                          private net::DirectoryLister::DirectoryListerDelegate {
  public:
+  // disable copy
+  FileSelectHelper(const FileSelectHelper&) = delete;
+  FileSelectHelper& operator=(const FileSelectHelper&) = delete;
+
   // Show the file chooser dialog.
   static void RunFileChooser(
       content::RenderFrameHost* render_frame_host,
@@ -224,8 +227,6 @@ class FileSelectHelper : public base::RefCountedThreadSafe<
   // Temporary files only used on OSX. This class is responsible for deleting
   // these files when they are no longer needed.
   std::vector<base::FilePath> temporary_files_;
-
-  DISALLOW_COPY_AND_ASSIGN(FileSelectHelper);
 };
 
 #endif  // SHELL_BROWSER_FILE_SELECT_HELPER_H_

--- a/shell/browser/font/electron_font_access_delegate.h
+++ b/shell/browser/font/electron_font_access_delegate.h
@@ -17,12 +17,15 @@ class ElectronFontAccessDelegate : public content::FontAccessDelegate {
   ElectronFontAccessDelegate();
   ~ElectronFontAccessDelegate() override;
 
+  // disable copy
+  ElectronFontAccessDelegate(const ElectronFontAccessDelegate&) = delete;
+  ElectronFontAccessDelegate& operator=(const ElectronFontAccessDelegate&) =
+      delete;
+
   std::unique_ptr<content::FontAccessChooser> RunChooser(
       content::RenderFrameHost* frame,
       const std::vector<std::string>& selection,
       content::FontAccessChooser::Callback callback) override;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronFontAccessDelegate);
 };
 
 #endif  // SHELL_BROWSER_FONT_ELECTRON_FONT_ACCESS_DELEGATE_H_

--- a/shell/browser/hid/hid_chooser_context_factory.h
+++ b/shell/browser/hid/hid_chooser_context_factory.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_HID_HID_CHOOSER_CONTEXT_FACTORY_H_
 #define SHELL_BROWSER_HID_HID_CHOOSER_CONTEXT_FACTORY_H_
 
-#include "base/macros.h"
 #include "base/no_destructor.h"
 #include "components/keyed_service/content/browser_context_keyed_service_factory.h"
 
@@ -21,6 +20,10 @@ class HidChooserContextFactory : public BrowserContextKeyedServiceFactory {
       content::BrowserContext* context);
   static HidChooserContextFactory* GetInstance();
 
+  // disable copy
+  HidChooserContextFactory(const HidChooserContextFactory&) = delete;
+  HidChooserContextFactory& operator=(const HidChooserContextFactory&) = delete;
+
  private:
   friend base::NoDestructor<HidChooserContextFactory>;
 
@@ -33,8 +36,6 @@ class HidChooserContextFactory : public BrowserContextKeyedServiceFactory {
   content::BrowserContext* GetBrowserContextToUse(
       content::BrowserContext* context) const override;
   void BrowserContextShutdown(content::BrowserContext* context) override;
-
-  DISALLOW_COPY_AND_ASSIGN(HidChooserContextFactory);
 };
 
 }  // namespace electron

--- a/shell/browser/hid/hid_chooser_controller.h
+++ b/shell/browser/hid/hid_chooser_controller.h
@@ -9,7 +9,6 @@
 #include <string>
 #include <vector>
 
-#include "base/macros.h"
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/global_routing_id.h"
 #include "content/public/browser/hid_chooser.h"

--- a/shell/browser/javascript_environment.cc
+++ b/shell/browser/javascript_environment.cc
@@ -35,14 +35,19 @@ class ConvertableToTraceFormatWrapper final
       std::unique_ptr<v8::ConvertableToTraceFormat> inner)
       : inner_(std::move(inner)) {}
   ~ConvertableToTraceFormatWrapper() override = default;
+
+  // disable copy
+  ConvertableToTraceFormatWrapper(const ConvertableToTraceFormatWrapper&) =
+      delete;
+  ConvertableToTraceFormatWrapper& operator=(
+      const ConvertableToTraceFormatWrapper&) = delete;
+
   void AppendAsTraceFormat(std::string* out) const final {
     inner_->AppendAsTraceFormat(out);
   }
 
  private:
   std::unique_ptr<v8::ConvertableToTraceFormat> inner_;
-
-  DISALLOW_COPY_AND_ASSIGN(ConvertableToTraceFormatWrapper);
 };
 
 }  // namespace gin
@@ -183,6 +188,10 @@ class EnabledStateObserverImpl final
         this);
   }
 
+  // disable copy
+  EnabledStateObserverImpl(const EnabledStateObserverImpl&) = delete;
+  EnabledStateObserverImpl& operator=(const EnabledStateObserverImpl&) = delete;
+
   void OnTraceLogEnabled() final {
     base::AutoLock lock(mutex_);
     for (auto* o : observers_) {
@@ -218,8 +227,6 @@ class EnabledStateObserverImpl final
  private:
   base::Lock mutex_;
   std::unordered_set<v8::TracingController::TraceStateObserver*> observers_;
-
-  DISALLOW_COPY_AND_ASSIGN(EnabledStateObserverImpl);
 };
 
 base::LazyInstance<EnabledStateObserverImpl>::Leaky g_trace_state_dispatcher =
@@ -229,6 +236,10 @@ class TracingControllerImpl : public node::tracing::TracingController {
  public:
   TracingControllerImpl() = default;
   ~TracingControllerImpl() override = default;
+
+  // disable copy
+  TracingControllerImpl(const TracingControllerImpl&) = delete;
+  TracingControllerImpl& operator=(const TracingControllerImpl&) = delete;
 
   // TracingController implementation.
   const uint8_t* GetCategoryGroupEnabled(const char* name) override {
@@ -306,9 +317,6 @@ class TracingControllerImpl : public node::tracing::TracingController {
   void RemoveTraceStateObserver(TraceStateObserver* observer) override {
     g_trace_state_dispatcher.Get().RemoveObserver(observer);
   }
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(TracingControllerImpl);
 };
 
 v8::Isolate* JavascriptEnvironment::Initialize(uv_loop_t* event_loop) {

--- a/shell/browser/javascript_environment.h
+++ b/shell/browser/javascript_environment.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 
-#include "base/macros.h"
 #include "gin/public/isolate_holder.h"
 #include "uv.h"  // NOLINT(build/include_directory)
 #include "v8/include/v8-locker.h"
@@ -25,6 +24,10 @@ class JavascriptEnvironment {
  public:
   explicit JavascriptEnvironment(uv_loop_t* event_loop);
   ~JavascriptEnvironment();
+
+  // disable copy
+  JavascriptEnvironment(const JavascriptEnvironment&) = delete;
+  JavascriptEnvironment& operator=(const JavascriptEnvironment&) = delete;
 
   void OnMessageLoopCreated();
   void OnMessageLoopDestroying();
@@ -48,8 +51,6 @@ class JavascriptEnvironment {
   v8::Global<v8::Context> context_;
 
   std::unique_ptr<MicrotasksRunner> microtasks_runner_;
-
-  DISALLOW_COPY_AND_ASSIGN(JavascriptEnvironment);
 };
 
 // Manage the Node Environment automatically.
@@ -58,12 +59,14 @@ class NodeEnvironment {
   explicit NodeEnvironment(node::Environment* env);
   ~NodeEnvironment();
 
+  // disable copy
+  NodeEnvironment(const NodeEnvironment&) = delete;
+  NodeEnvironment& operator=(const NodeEnvironment&) = delete;
+
   node::Environment* env() { return env_; }
 
  private:
   node::Environment* env_;
-
-  DISALLOW_COPY_AND_ASSIGN(NodeEnvironment);
 };
 
 }  // namespace electron

--- a/shell/browser/lib/bluetooth_chooser.h
+++ b/shell/browser/lib/bluetooth_chooser.h
@@ -25,6 +25,10 @@ class BluetoothChooser : public content::BluetoothChooser {
                             const EventHandler& handler);
   ~BluetoothChooser() override;
 
+  // disable copy
+  BluetoothChooser(const BluetoothChooser&) = delete;
+  BluetoothChooser& operator=(const BluetoothChooser&) = delete;
+
   // content::BluetoothChooser:
   void SetAdapterPresence(AdapterPresence presence) override;
   void ShowDiscoveryState(DiscoveryState state) override;
@@ -43,8 +47,6 @@ class BluetoothChooser : public content::BluetoothChooser {
   int num_retries_ = 0;
   bool refreshing_ = false;
   bool rescan_ = false;
-
-  DISALLOW_COPY_AND_ASSIGN(BluetoothChooser);
 };
 
 }  // namespace electron

--- a/shell/browser/lib/power_observer_linux.h
+++ b/shell/browser/lib/power_observer_linux.h
@@ -8,7 +8,6 @@
 #include <string>
 
 #include "base/callback.h"
-#include "base/macros.h"
 #include "base/memory/weak_ptr.h"
 #include "base/power_monitor/power_observer.h"
 #include "dbus/bus.h"
@@ -21,6 +20,10 @@ class PowerObserverLinux {
  public:
   explicit PowerObserverLinux(base::PowerSuspendObserver* suspend_observer);
   ~PowerObserverLinux();
+
+  // disable copy
+  PowerObserverLinux(const PowerObserverLinux&) = delete;
+  PowerObserverLinux& operator=(const PowerObserverLinux&) = delete;
 
   void SetShutdownHandler(base::RepeatingCallback<bool()> should_shutdown);
 
@@ -46,8 +49,6 @@ class PowerObserverLinux {
   base::ScopedFD sleep_lock_;
   base::ScopedFD shutdown_lock_;
   base::WeakPtrFactory<PowerObserverLinux> weak_ptr_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(PowerObserverLinux);
 };
 
 }  // namespace electron

--- a/shell/browser/login_handler.h
+++ b/shell/browser/login_handler.h
@@ -33,6 +33,10 @@ class LoginHandler : public content::LoginDelegate,
                LoginAuthRequiredCallback auth_required_callback);
   ~LoginHandler() override;
 
+  // disable copy
+  LoginHandler(const LoginHandler&) = delete;
+  LoginHandler& operator=(const LoginHandler&) = delete;
+
  private:
   void EmitEvent(net::AuthChallengeInfo auth_info,
                  bool is_main_frame,
@@ -44,8 +48,6 @@ class LoginHandler : public content::LoginDelegate,
   LoginAuthRequiredCallback auth_required_callback_;
 
   base::WeakPtrFactory<LoginHandler> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(LoginHandler);
 };
 
 }  // namespace electron

--- a/shell/browser/mac/in_app_purchase_observer.h
+++ b/shell/browser/mac/in_app_purchase_observer.h
@@ -47,6 +47,10 @@ class TransactionObserver {
   TransactionObserver();
   virtual ~TransactionObserver();
 
+  // disable copy
+  TransactionObserver(const TransactionObserver&) = delete;
+  TransactionObserver& operator=(const TransactionObserver&) = delete;
+
   virtual void OnTransactionsUpdated(
       const std::vector<Transaction>& transactions) = 0;
 
@@ -54,8 +58,6 @@ class TransactionObserver {
   InAppTransactionObserver* observer_;
 
   base::WeakPtrFactory<TransactionObserver> weak_ptr_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(TransactionObserver);
 };
 
 }  // namespace in_app_purchase

--- a/shell/browser/media/media_capture_devices_dispatcher.h
+++ b/shell/browser/media/media_capture_devices_dispatcher.h
@@ -67,6 +67,11 @@ class MediaCaptureDevicesDispatcher : public content::MediaObserver {
                                  blink::mojom::MediaStreamType stream_type,
                                  bool is_secure) override;
 
+  // disable copy
+  MediaCaptureDevicesDispatcher(const MediaCaptureDevicesDispatcher&) = delete;
+  MediaCaptureDevicesDispatcher& operator=(
+      const MediaCaptureDevicesDispatcher&) = delete;
+
  private:
   friend struct base::DefaultSingletonTraits<MediaCaptureDevicesDispatcher>;
 
@@ -81,8 +86,6 @@ class MediaCaptureDevicesDispatcher : public content::MediaObserver {
 
   // Flag used by unittests to disable device enumeration.
   bool is_device_enumeration_disabled_ = false;
-
-  DISALLOW_COPY_AND_ASSIGN(MediaCaptureDevicesDispatcher);
 };
 
 }  // namespace electron

--- a/shell/browser/media/media_device_id_salt.h
+++ b/shell/browser/media/media_device_id_salt.h
@@ -7,7 +7,6 @@
 
 #include <string>
 
-#include "base/macros.h"
 #include "components/prefs/pref_member.h"
 
 class PrefRegistrySimple;
@@ -23,6 +22,10 @@ class MediaDeviceIDSalt {
   explicit MediaDeviceIDSalt(PrefService* pref_service);
   ~MediaDeviceIDSalt();
 
+  // disable copy
+  MediaDeviceIDSalt(const MediaDeviceIDSalt&) = delete;
+  MediaDeviceIDSalt& operator=(const MediaDeviceIDSalt&) = delete;
+
   std::string GetSalt();
 
   static void RegisterPrefs(PrefRegistrySimple* pref_registry);
@@ -30,8 +33,6 @@ class MediaDeviceIDSalt {
 
  private:
   StringPrefMember media_device_id_salt_;
-
-  DISALLOW_COPY_AND_ASSIGN(MediaDeviceIDSalt);
 };
 
 }  // namespace electron

--- a/shell/browser/media/media_stream_devices_controller.h
+++ b/shell/browser/media/media_stream_devices_controller.h
@@ -17,6 +17,11 @@ class MediaStreamDevicesController {
 
   virtual ~MediaStreamDevicesController();
 
+  // disable copy
+  MediaStreamDevicesController(const MediaStreamDevicesController&) = delete;
+  MediaStreamDevicesController& operator=(const MediaStreamDevicesController&) =
+      delete;
+
   // Accept or deny the request based on the default policy.
   bool TakeAction();
 
@@ -37,8 +42,6 @@ class MediaStreamDevicesController {
 
   bool microphone_requested_;
   bool webcam_requested_;
-
-  DISALLOW_COPY_AND_ASSIGN(MediaStreamDevicesController);
 };
 
 }  // namespace electron

--- a/shell/browser/native_browser_view.h
+++ b/shell/browser/native_browser_view.h
@@ -7,7 +7,6 @@
 
 #include <vector>
 
-#include "base/macros.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "shell/common/api/api.mojom.h"
@@ -32,6 +31,10 @@ class InspectableWebContentsView;
 class NativeBrowserView : public content::WebContentsObserver {
  public:
   ~NativeBrowserView() override;
+
+  // disable copy
+  NativeBrowserView(const NativeBrowserView&) = delete;
+  NativeBrowserView& operator=(const NativeBrowserView&) = delete;
 
   static NativeBrowserView* Create(
       InspectableWebContents* inspectable_web_contents);
@@ -65,9 +68,6 @@ class NativeBrowserView : public content::WebContentsObserver {
 
   InspectableWebContents* inspectable_web_contents_;
   std::vector<mojom::DraggableRegionPtr> draggable_regions_;
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(NativeBrowserView);
 };
 
 }  // namespace electron

--- a/shell/browser/native_browser_view_mac.h
+++ b/shell/browser/native_browser_view_mac.h
@@ -29,8 +29,6 @@ class NativeBrowserViewMac : public NativeBrowserView {
 
   void UpdateDraggableRegions(
       const std::vector<gfx::Rect>& drag_exclude_rects) override;
-
-  DISALLOW_COPY_AND_ASSIGN(NativeBrowserViewMac);
 };
 
 }  // namespace electron

--- a/shell/browser/native_browser_view_views.h
+++ b/shell/browser/native_browser_view_views.h
@@ -52,8 +52,6 @@ class NativeBrowserViewViews : public NativeBrowserView {
   float auto_vertical_proportion_top_ = 0.;
 
   std::unique_ptr<SkRegion> draggable_region_;
-
-  DISALLOW_COPY_AND_ASSIGN(NativeBrowserViewViews);
 };
 
 }  // namespace electron

--- a/shell/browser/native_window.h
+++ b/shell/browser/native_window.h
@@ -57,6 +57,10 @@ class NativeWindow : public base::SupportsUserData,
  public:
   ~NativeWindow() override;
 
+  // disable copy
+  NativeWindow(const NativeWindow&) = delete;
+  NativeWindow& operator=(const NativeWindow&) = delete;
+
   // Create window with existing WebContents, the caller is responsible for
   // managing the window's live.
   static NativeWindow* Create(const gin_helper::Dictionary& options,
@@ -412,8 +416,6 @@ class NativeWindow : public base::SupportsUserData,
   gfx::Rect overlay_rect_;
 
   base::WeakPtrFactory<NativeWindow> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(NativeWindow);
 };
 
 // This class provides a hook to get a NativeWindow from a WebContents.

--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -282,8 +282,6 @@ class NativeWindowMac : public NativeWindow,
 
   // The presentation options before entering simple fullscreen mode.
   NSApplicationPresentationOptions simple_fullscreen_options_;
-
-  DISALLOW_COPY_AND_ASSIGN(NativeWindowMac);
 };
 
 }  // namespace electron

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -136,6 +136,10 @@ class NativeWindowClientView : public views::ClientView {
       : views::ClientView(widget, root_view), window_(window) {}
   ~NativeWindowClientView() override = default;
 
+  // disable copy
+  NativeWindowClientView(const NativeWindowClientView&) = delete;
+  NativeWindowClientView& operator=(const NativeWindowClientView&) = delete;
+
   views::CloseRequestResult OnWindowCloseRequested() override {
     window_->NotifyWindowCloseButtonClicked();
     return views::CloseRequestResult::kCannotClose;
@@ -143,8 +147,6 @@ class NativeWindowClientView : public views::ClientView {
 
  private:
   NativeWindowViews* window_;
-
-  DISALLOW_COPY_AND_ASSIGN(NativeWindowClientView);
 };
 
 }  // namespace

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -332,8 +332,6 @@ class NativeWindowViews : public NativeWindow,
   gfx::Size widget_size_;
   double opacity_ = 1.0;
   bool widget_destroyed_ = false;
-
-  DISALLOW_COPY_AND_ASSIGN(NativeWindowViews);
 };
 
 }  // namespace electron

--- a/shell/browser/net/asar/asar_file_validator.h
+++ b/shell/browser/net/asar/asar_file_validator.h
@@ -21,6 +21,10 @@ class AsarFileValidator : public mojo::FilteredDataSource::Filter {
   AsarFileValidator(IntegrityPayload integrity, base::File file);
   ~AsarFileValidator() override;
 
+  // disable copy
+  AsarFileValidator(const AsarFileValidator&) = delete;
+  AsarFileValidator& operator=(const AsarFileValidator&) = delete;
+
   void OnRead(base::span<char> buffer,
               mojo::FileDataSource::ReadResult* result) override;
 
@@ -52,8 +56,6 @@ class AsarFileValidator : public mojo::FilteredDataSource::Filter {
   uint64_t current_hash_byte_count_ = 0;
   uint64_t total_hash_byte_count_ = 0;
   std::unique_ptr<crypto::SecureHash> current_hash_;
-
-  DISALLOW_COPY_AND_ASSIGN(AsarFileValidator);
 };
 
 }  // namespace asar

--- a/shell/browser/net/asar/asar_url_loader.cc
+++ b/shell/browser/net/asar/asar_url_loader.cc
@@ -85,6 +85,10 @@ class AsarURLLoader : public network::mojom::URLLoader {
   void PauseReadingBodyFromNet() override {}
   void ResumeReadingBodyFromNet() override {}
 
+  // disable copy
+  AsarURLLoader(const AsarURLLoader&) = delete;
+  AsarURLLoader& operator=(const AsarURLLoader&) = delete;
+
  private:
   AsarURLLoader() = default;
   ~AsarURLLoader() override = default;
@@ -379,8 +383,6 @@ class AsarURLLoader : public network::mojom::URLLoader {
   // It is used to set some of the URLLoaderCompletionStatus data passed back
   // to the URLLoaderClients (eg SimpleURLLoader).
   size_t total_bytes_written_ = 0;
-
-  DISALLOW_COPY_AND_ASSIGN(AsarURLLoader);
 };
 
 }  // namespace

--- a/shell/browser/net/electron_url_loader_factory.h
+++ b/shell/browser/net/electron_url_loader_factory.h
@@ -64,6 +64,10 @@ class ElectronURLLoaderFactory : public network::SelfDeletingURLLoaderFactory {
             target_factory_remote);
     ~RedirectedRequest() override;
 
+    // disable copy
+    RedirectedRequest(const RedirectedRequest&) = delete;
+    RedirectedRequest& operator=(const RedirectedRequest&) = delete;
+
     // network::mojom::URLLoader:
     void FollowRedirect(
         const std::vector<std::string>& removed_headers,
@@ -89,8 +93,6 @@ class ElectronURLLoaderFactory : public network::SelfDeletingURLLoaderFactory {
     net::MutableNetworkTrafficAnnotationTag traffic_annotation_;
 
     mojo::Remote<network::mojom::URLLoaderFactory> target_factory_remote_;
-
-    DISALLOW_COPY_AND_ASSIGN(RedirectedRequest);
   };
 
   static mojo::PendingRemote<network::mojom::URLLoaderFactory> Create(
@@ -117,6 +119,10 @@ class ElectronURLLoaderFactory : public network::SelfDeletingURLLoaderFactory {
       mojo::PendingRemote<network::mojom::URLLoaderFactory> target_factory,
       ProtocolType type,
       gin::Arguments* args);
+
+  // disable copy
+  ElectronURLLoaderFactory(const ElectronURLLoaderFactory&) = delete;
+  ElectronURLLoaderFactory& operator=(const ElectronURLLoaderFactory&) = delete;
 
  private:
   ElectronURLLoaderFactory(
@@ -167,8 +173,6 @@ class ElectronURLLoaderFactory : public network::SelfDeletingURLLoaderFactory {
 
   ProtocolType type_;
   ProtocolHandler handler_;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronURLLoaderFactory);
 };
 
 }  // namespace electron

--- a/shell/browser/net/node_stream_loader.h
+++ b/shell/browser/net/node_stream_loader.h
@@ -35,6 +35,10 @@ class NodeStreamLoader : public network::mojom::URLLoader {
                    v8::Isolate* isolate,
                    v8::Local<v8::Object> emitter);
 
+  // disable copy
+  NodeStreamLoader(const NodeStreamLoader&) = delete;
+  NodeStreamLoader& operator=(const NodeStreamLoader&) = delete;
+
  private:
   ~NodeStreamLoader() override;
 
@@ -95,8 +99,6 @@ class NodeStreamLoader : public network::mojom::URLLoader {
   std::map<std::string, v8::Global<v8::Value>> handlers_;
 
   base::WeakPtrFactory<NodeStreamLoader> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(NodeStreamLoader);
 };
 
 }  // namespace electron

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -12,7 +12,6 @@
 #include <string>
 #include <vector>
 
-#include "base/macros.h"
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/content_browser_client.h"
 #include "content/public/browser/render_frame_host.h"
@@ -68,6 +67,10 @@ class ProxyingURLLoaderFactory
                       int32_t frame_routing_id,
                       const network::ResourceRequest& request);
     ~InProgressRequest() override;
+
+    // disable copy
+    InProgressRequest(const InProgressRequest&) = delete;
+    InProgressRequest& operator=(const InProgressRequest&) = delete;
 
     void Restart();
 
@@ -175,13 +178,13 @@ class ProxyingURLLoaderFactory
       net::HttpRequestHeaders modified_cors_exempt_headers;
       absl::optional<GURL> new_url;
 
-      DISALLOW_COPY_AND_ASSIGN(FollowRedirectParams);
+      // disable copy
+      FollowRedirectParams(const FollowRedirectParams&) = delete;
+      FollowRedirectParams& operator=(const FollowRedirectParams&) = delete;
     };
     std::unique_ptr<FollowRedirectParams> pending_follow_redirect_params_;
 
     base::WeakPtrFactory<InProgressRequest> weak_factory_{this};
-
-    DISALLOW_COPY_AND_ASSIGN(InProgressRequest);
   };
 
   ProxyingURLLoaderFactory(
@@ -201,6 +204,10 @@ class ProxyingURLLoaderFactory
       content::ContentBrowserClient::URLLoaderFactoryType loader_factory_type);
 
   ~ProxyingURLLoaderFactory() override;
+
+  // disable copy
+  ProxyingURLLoaderFactory(const ProxyingURLLoaderFactory&) = delete;
+  ProxyingURLLoaderFactory& operator=(const ProxyingURLLoaderFactory&) = delete;
 
   // network::mojom::URLLoaderFactory:
   void CreateLoaderAndStart(
@@ -270,8 +277,6 @@ class ProxyingURLLoaderFactory
   std::map<int32_t, uint64_t> network_request_id_to_web_request_id_;
 
   std::vector<std::string> ignore_connections_limit_domains_;
-
-  DISALLOW_COPY_AND_ASSIGN(ProxyingURLLoaderFactory);
 };
 
 }  // namespace electron

--- a/shell/browser/net/proxying_websocket.h
+++ b/shell/browser/net/proxying_websocket.h
@@ -63,6 +63,10 @@ class ProxyingWebSocket : public network::mojom::WebSocketHandshakeClient,
       uint64_t* request_id_generator);
   ~ProxyingWebSocket() override;
 
+  // disable copy
+  ProxyingWebSocket(const ProxyingWebSocket&) = delete;
+  ProxyingWebSocket& operator=(const ProxyingWebSocket&) = delete;
+
   void Start();
 
   // network::mojom::WebSocketHandshakeClient methods:
@@ -170,7 +174,6 @@ class ProxyingWebSocket : public network::mojom::WebSocketHandshakeClient,
   extensions::WebRequestInfo info_;
 
   base::WeakPtrFactory<ProxyingWebSocket> weak_factory_{this};
-  DISALLOW_COPY_AND_ASSIGN(ProxyingWebSocket);
 };
 
 }  // namespace electron

--- a/shell/browser/net/resolve_proxy_helper.h
+++ b/shell/browser/net/resolve_proxy_helper.h
@@ -28,6 +28,10 @@ class ResolveProxyHelper
 
   void ResolveProxy(const GURL& url, ResolveProxyCallback callback);
 
+  // disable copy
+  ResolveProxyHelper(const ResolveProxyHelper&) = delete;
+  ResolveProxyHelper& operator=(const ResolveProxyHelper&) = delete;
+
  protected:
   ~ResolveProxyHelper() override;
 
@@ -40,13 +44,14 @@ class ResolveProxyHelper
     PendingRequest(PendingRequest&& pending_request) noexcept;
     ~PendingRequest();
 
+    // disable copy
+    PendingRequest(const PendingRequest&) = delete;
+    PendingRequest& operator=(const PendingRequest&) = delete;
+
     PendingRequest& operator=(PendingRequest&& pending_request) noexcept;
 
     GURL url;
     ResolveProxyCallback callback;
-
-   private:
-    DISALLOW_COPY_AND_ASSIGN(PendingRequest);
   };
 
   // Starts the first pending request.
@@ -66,8 +71,6 @@ class ResolveProxyHelper
 
   // Weak Ref
   ElectronBrowserContext* browser_context_;
-
-  DISALLOW_COPY_AND_ASSIGN(ResolveProxyHelper);
 };
 
 }  // namespace electron

--- a/shell/browser/net/system_network_context_manager.cc
+++ b/shell/browser/net/system_network_context_manager.cc
@@ -92,6 +92,11 @@ class SystemNetworkContextManager::URLLoaderFactoryForSystem
     DETACH_FROM_SEQUENCE(sequence_checker_);
   }
 
+  // disable copy
+  URLLoaderFactoryForSystem(const URLLoaderFactoryForSystem&) = delete;
+  URLLoaderFactoryForSystem& operator=(const URLLoaderFactoryForSystem&) =
+      delete;
+
   // mojom::URLLoaderFactory implementation:
   void CreateLoaderAndStart(
       mojo::PendingReceiver<network::mojom::URLLoader> request,
@@ -132,8 +137,6 @@ class SystemNetworkContextManager::URLLoaderFactoryForSystem
 
   SEQUENCE_CHECKER(sequence_checker_);
   SystemNetworkContextManager* manager_;
-
-  DISALLOW_COPY_AND_ASSIGN(URLLoaderFactoryForSystem);
 };
 
 network::mojom::NetworkContext* SystemNetworkContextManager::GetContext() {

--- a/shell/browser/net/system_network_context_manager.h
+++ b/shell/browser/net/system_network_context_manager.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_NET_SYSTEM_NETWORK_CONTEXT_MANAGER_H_
 #define SHELL_BROWSER_NET_SYSTEM_NETWORK_CONTEXT_MANAGER_H_
 
-#include "base/macros.h"
 #include "base/memory/ref_counted.h"
 #include "chrome/browser/net/proxy_config_monitor.h"
 #include "mojo/public/cpp/bindings/remote.h"
@@ -34,6 +33,11 @@ network::mojom::HttpAuthDynamicParamsPtr CreateHttpAuthDynamicParams();
 class SystemNetworkContextManager {
  public:
   ~SystemNetworkContextManager();
+
+  // disable copy
+  SystemNetworkContextManager(const SystemNetworkContextManager&) = delete;
+  SystemNetworkContextManager& operator=(const SystemNetworkContextManager&) =
+      delete;
 
   // Creates the global instance of SystemNetworkContextManager. If an
   // instance already exists, this will cause a DCHECK failure.
@@ -92,8 +96,6 @@ class SystemNetworkContextManager {
   // consumers don't all need to create their own factory.
   scoped_refptr<URLLoaderFactoryForSystem> shared_url_loader_factory_;
   mojo::Remote<network::mojom::URLLoaderFactory> url_loader_factory_;
-
-  DISALLOW_COPY_AND_ASSIGN(SystemNetworkContextManager);
 };
 
 #endif  // SHELL_BROWSER_NET_SYSTEM_NETWORK_CONTEXT_MANAGER_H_

--- a/shell/browser/net/url_pipe_loader.h
+++ b/shell/browser/net/url_pipe_loader.h
@@ -41,6 +41,10 @@ class URLPipeLoader : public network::mojom::URLLoader,
                 const net::NetworkTrafficAnnotationTag& annotation,
                 base::DictionaryValue upload_data);
 
+  // disable copy
+  URLPipeLoader(const URLPipeLoader&) = delete;
+  URLPipeLoader& operator=(const URLPipeLoader&) = delete;
+
  private:
   ~URLPipeLoader() override;
 
@@ -77,8 +81,6 @@ class URLPipeLoader : public network::mojom::URLLoader,
   std::unique_ptr<network::SimpleURLLoader> loader_;
 
   base::WeakPtrFactory<URLPipeLoader> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(URLPipeLoader);
 };
 
 }  // namespace electron

--- a/shell/browser/notifications/linux/libnotify_notification.h
+++ b/shell/browser/notifications/linux/libnotify_notification.h
@@ -35,8 +35,6 @@ class LibnotifyNotification : public Notification {
                      char*);
 
   NotifyNotification* notification_ = nullptr;
-
-  DISALLOW_COPY_AND_ASSIGN(LibnotifyNotification);
 };
 
 }  // namespace electron

--- a/shell/browser/notifications/linux/notification_presenter_linux.h
+++ b/shell/browser/notifications/linux/notification_presenter_linux.h
@@ -18,8 +18,6 @@ class NotificationPresenterLinux : public NotificationPresenter {
  private:
   Notification* CreateNotificationObject(
       NotificationDelegate* delegate) override;
-
-  DISALLOW_COPY_AND_ASSIGN(NotificationPresenterLinux);
 };
 
 }  // namespace electron

--- a/shell/browser/notifications/mac/cocoa_notification.h
+++ b/shell/browser/notifications/mac/cocoa_notification.h
@@ -39,8 +39,6 @@ class CocoaNotification : public Notification {
   base::scoped_nsobject<NSUserNotification> notification_;
   std::map<std::string, unsigned> additional_action_indices_;
   unsigned action_index_;
-
-  DISALLOW_COPY_AND_ASSIGN(CocoaNotification);
 };
 
 }  // namespace electron

--- a/shell/browser/notifications/mac/notification_presenter_mac.h
+++ b/shell/browser/notifications/mac/notification_presenter_mac.h
@@ -27,8 +27,6 @@ class NotificationPresenterMac : public NotificationPresenter {
 
   base::scoped_nsobject<NotificationCenterDelegate>
       notification_center_delegate_;
-
-  DISALLOW_COPY_AND_ASSIGN(NotificationPresenterMac);
 };
 
 }  // namespace electron

--- a/shell/browser/notifications/notification.h
+++ b/shell/browser/notifications/notification.h
@@ -72,6 +72,10 @@ class Notification {
   NotificationPresenter* presenter() const { return presenter_; }
   const std::string& notification_id() const { return notification_id_; }
 
+  // disable copy
+  Notification(const Notification&) = delete;
+  Notification& operator=(const Notification&) = delete;
+
  protected:
   Notification(NotificationDelegate* delegate,
                NotificationPresenter* presenter);
@@ -82,8 +86,6 @@ class Notification {
   std::string notification_id_;
 
   base::WeakPtrFactory<Notification> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(Notification);
 };
 
 }  // namespace electron

--- a/shell/browser/notifications/notification_presenter.h
+++ b/shell/browser/notifications/notification_presenter.h
@@ -28,6 +28,10 @@ class NotificationPresenter {
 
   std::set<Notification*> notifications() const { return notifications_; }
 
+  // disable copy
+  NotificationPresenter(const NotificationPresenter&) = delete;
+  NotificationPresenter& operator=(const NotificationPresenter&) = delete;
+
  protected:
   NotificationPresenter();
   virtual Notification* CreateNotificationObject(
@@ -39,8 +43,6 @@ class NotificationPresenter {
   void RemoveNotification(Notification* notification);
 
   std::set<Notification*> notifications_;
-
-  DISALLOW_COPY_AND_ASSIGN(NotificationPresenter);
 };
 
 }  // namespace electron

--- a/shell/browser/notifications/platform_notification_service.cc
+++ b/shell/browser/notifications/platform_notification_service.cc
@@ -46,6 +46,10 @@ class NotificationDelegateImpl final : public electron::NotificationDelegate {
   explicit NotificationDelegateImpl(const std::string& notification_id)
       : notification_id_(notification_id) {}
 
+  // disable copy
+  NotificationDelegateImpl(const NotificationDelegateImpl&) = delete;
+  NotificationDelegateImpl& operator=(const NotificationDelegateImpl&) = delete;
+
   void NotificationDestroyed() override { delete this; }
 
   void NotificationClick() override {
@@ -65,8 +69,6 @@ class NotificationDelegateImpl final : public electron::NotificationDelegate {
 
  private:
   std::string notification_id_;
-
-  DISALLOW_COPY_AND_ASSIGN(NotificationDelegateImpl);
 };
 
 }  // namespace

--- a/shell/browser/notifications/platform_notification_service.h
+++ b/shell/browser/notifications/platform_notification_service.h
@@ -19,6 +19,11 @@ class PlatformNotificationService
   explicit PlatformNotificationService(ElectronBrowserClient* browser_client);
   ~PlatformNotificationService() override;
 
+  // disable copy
+  PlatformNotificationService(const PlatformNotificationService&) = delete;
+  PlatformNotificationService& operator=(const PlatformNotificationService&) =
+      delete;
+
  protected:
   // content::PlatformNotificationService:
   void DisplayNotification(
@@ -46,8 +51,6 @@ class PlatformNotificationService
 
  private:
   ElectronBrowserClient* browser_client_;
-
-  DISALLOW_COPY_AND_ASSIGN(PlatformNotificationService);
 };
 
 }  // namespace electron

--- a/shell/browser/notifications/win/notification_presenter_win.h
+++ b/shell/browser/notifications/win/notification_presenter_win.h
@@ -45,8 +45,6 @@ class NotificationPresenterWin : public NotificationPresenter {
       NotificationDelegate* delegate) override;
 
   base::ScopedTempDir temp_dir_;
-
-  DISALLOW_COPY_AND_ASSIGN(NotificationPresenterWin);
 };
 
 }  // namespace electron

--- a/shell/browser/notifications/win/notification_presenter_win7.h
+++ b/shell/browser/notifications/win/notification_presenter_win7.h
@@ -30,8 +30,6 @@ class NotificationPresenterWin7 : public NotificationPresenter,
 
   void OnNotificationClicked(const Notification& notification) override;
   void OnNotificationDismissed(const Notification& notification) override;
-
-  DISALLOW_COPY_AND_ASSIGN(NotificationPresenterWin7);
 };
 
 }  // namespace electron

--- a/shell/browser/notifications/win/win32_notification.h
+++ b/shell/browser/notifications/win/win32_notification.h
@@ -29,8 +29,6 @@ class Win32Notification : public electron::Notification {
  private:
   DesktopNotificationController::Notification notification_ref_;
   std::string tag_;
-
-  DISALLOW_COPY_AND_ASSIGN(Win32Notification);
 };
 
 }  // namespace electron

--- a/shell/browser/notifications/win/windows_toast_notification.h
+++ b/shell/browser/notifications/win/windows_toast_notification.h
@@ -106,8 +106,6 @@ class WindowsToastNotification : public Notification {
   ComPtr<ToastEventHandler> event_handler_;
   ComPtr<ABI::Windows::UI::Notifications::IToastNotification>
       toast_notification_;
-
-  DISALLOW_COPY_AND_ASSIGN(WindowsToastNotification);
 };
 
 class ToastEventHandler : public RuntimeClass<RuntimeClassFlags<ClassicCom>,
@@ -117,6 +115,10 @@ class ToastEventHandler : public RuntimeClass<RuntimeClassFlags<ClassicCom>,
  public:
   explicit ToastEventHandler(Notification* notification);
   ~ToastEventHandler() override;
+
+  // disable copy
+  ToastEventHandler(const ToastEventHandler&) = delete;
+  ToastEventHandler& operator=(const ToastEventHandler&) = delete;
 
   IFACEMETHODIMP Invoke(
       ABI::Windows::UI::Notifications::IToastNotification* sender,
@@ -130,8 +132,6 @@ class ToastEventHandler : public RuntimeClass<RuntimeClassFlags<ClassicCom>,
 
  private:
   base::WeakPtr<Notification> notification_;  // weak ref.
-
-  DISALLOW_COPY_AND_ASSIGN(ToastEventHandler);
 };
 
 }  // namespace electron

--- a/shell/browser/osr/osr_host_display_client.h
+++ b/shell/browser/osr/osr_host_display_client.h
@@ -27,6 +27,10 @@ class LayeredWindowUpdater : public viz::mojom::LayeredWindowUpdater {
       OnPaintCallback callback);
   ~LayeredWindowUpdater() override;
 
+  // disable copy
+  LayeredWindowUpdater(const LayeredWindowUpdater&) = delete;
+  LayeredWindowUpdater& operator=(const LayeredWindowUpdater&) = delete;
+
   void SetActive(bool active);
 
   // viz::mojom::LayeredWindowUpdater implementation.
@@ -43,8 +47,6 @@ class LayeredWindowUpdater : public viz::mojom::LayeredWindowUpdater {
 #if !defined(WIN32)
   base::WritableSharedMemoryMapping shm_mapping_;
 #endif
-
-  DISALLOW_COPY_AND_ASSIGN(LayeredWindowUpdater);
 };
 
 class OffScreenHostDisplayClient : public viz::HostDisplayClient {
@@ -52,6 +54,11 @@ class OffScreenHostDisplayClient : public viz::HostDisplayClient {
   explicit OffScreenHostDisplayClient(gfx::AcceleratedWidget widget,
                                       OnPaintCallback callback);
   ~OffScreenHostDisplayClient() override;
+
+  // disable copy
+  OffScreenHostDisplayClient(const OffScreenHostDisplayClient&) = delete;
+  OffScreenHostDisplayClient& operator=(const OffScreenHostDisplayClient&) =
+      delete;
 
   void SetActive(bool active);
 
@@ -72,8 +79,6 @@ class OffScreenHostDisplayClient : public viz::HostDisplayClient {
   std::unique_ptr<LayeredWindowUpdater> layered_window_updater_;
   OnPaintCallback callback_;
   bool active_ = false;
-
-  DISALLOW_COPY_AND_ASSIGN(OffScreenHostDisplayClient);
 };
 
 }  // namespace electron

--- a/shell/browser/osr/osr_render_widget_host_view.cc
+++ b/shell/browser/osr/osr_render_widget_host_view.cc
@@ -128,6 +128,12 @@ class ElectronDelegatedFrameHostClient
   explicit ElectronDelegatedFrameHostClient(OffScreenRenderWidgetHostView* view)
       : view_(view) {}
 
+  // disable copy
+  ElectronDelegatedFrameHostClient(const ElectronDelegatedFrameHostClient&) =
+      delete;
+  ElectronDelegatedFrameHostClient& operator=(
+      const ElectronDelegatedFrameHostClient&) = delete;
+
   ui::Layer* DelegatedFrameHostGetLayer() const override {
     return view_->GetRootLayer();
   }
@@ -163,8 +169,6 @@ class ElectronDelegatedFrameHostClient
 
  private:
   OffScreenRenderWidgetHostView* const view_;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronDelegatedFrameHostClient);
 };
 
 OffScreenRenderWidgetHostView::OffScreenRenderWidgetHostView(

--- a/shell/browser/osr/osr_render_widget_host_view.h
+++ b/shell/browser/osr/osr_render_widget_host_view.h
@@ -69,6 +69,11 @@ class OffScreenRenderWidgetHostView : public content::RenderWidgetHostViewBase,
                                 gfx::Size initial_size);
   ~OffScreenRenderWidgetHostView() override;
 
+  // disable copy
+  OffScreenRenderWidgetHostView(const OffScreenRenderWidgetHostView&) = delete;
+  OffScreenRenderWidgetHostView& operator=(
+      const OffScreenRenderWidgetHostView&) = delete;
+
   // content::RenderWidgetHostView:
   void InitAsChild(gfx::NativeView) override;
   void SetSize(const gfx::Size&) override;
@@ -290,8 +295,6 @@ class OffScreenRenderWidgetHostView : public content::RenderWidgetHostViewBase,
   std::unique_ptr<SkBitmap> backing_;
 
   base::WeakPtrFactory<OffScreenRenderWidgetHostView> weak_ptr_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(OffScreenRenderWidgetHostView);
 };
 
 }  // namespace electron

--- a/shell/browser/osr/osr_video_consumer.h
+++ b/shell/browser/osr/osr_video_consumer.h
@@ -26,6 +26,10 @@ class OffScreenVideoConsumer : public viz::mojom::FrameSinkVideoConsumer {
                          OnPaintCallback callback);
   ~OffScreenVideoConsumer() override;
 
+  // disable copy
+  OffScreenVideoConsumer(const OffScreenVideoConsumer&) = delete;
+  OffScreenVideoConsumer& operator=(const OffScreenVideoConsumer&) = delete;
+
   void SetActive(bool active);
   void SetFrameRate(int frame_rate);
   void SizeChanged();
@@ -49,8 +53,6 @@ class OffScreenVideoConsumer : public viz::mojom::FrameSinkVideoConsumer {
   std::unique_ptr<viz::ClientFrameSinkVideoCapturer> video_capturer_;
 
   base::WeakPtrFactory<OffScreenVideoConsumer> weak_ptr_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(OffScreenVideoConsumer);
 };
 
 }  // namespace electron

--- a/shell/browser/plugins/plugin_utils.h
+++ b/shell/browser/plugins/plugin_utils.h
@@ -8,7 +8,6 @@
 #include <string>
 
 #include "base/containers/flat_map.h"
-#include "base/macros.h"
 
 namespace content {
 class BrowserContext;
@@ -16,6 +15,10 @@ class BrowserContext;
 
 class PluginUtils {
  public:
+  // disable copy
+  PluginUtils(const PluginUtils&) = delete;
+  PluginUtils& operator=(const PluginUtils&) = delete;
+
   // If there's an extension that is allowed to handle |mime_type|, returns its
   // ID. Otherwise returns an empty string.
   static std::string GetExtensionIdForMimeType(
@@ -26,9 +29,6 @@ class PluginUtils {
   // keys and the corresponding extensions Ids as values.
   static base::flat_map<std::string, std::string> GetMimeTypeToExtensionIdMap(
       content::BrowserContext* browser_context);
-
- private:
-  DISALLOW_IMPLICIT_CONSTRUCTORS(PluginUtils);
 };
 
 #endif  // SHELL_BROWSER_PLUGINS_PLUGIN_UTILS_H_

--- a/shell/browser/pref_store_delegate.h
+++ b/shell/browser/pref_store_delegate.h
@@ -7,7 +7,6 @@
 
 #include <vector>
 
-#include "base/macros.h"
 #include "base/memory/weak_ptr.h"
 #include "components/prefs/pref_value_store.h"
 
@@ -27,6 +26,10 @@ class PrefStoreDelegate : public PrefValueStore::Delegate {
   explicit PrefStoreDelegate(
       base::WeakPtr<ElectronBrowserContext> browser_context);
   ~PrefStoreDelegate() override;
+
+  // disable copy
+  PrefStoreDelegate(const PrefStoreDelegate&) = delete;
+  PrefStoreDelegate& operator=(const PrefStoreDelegate&) = delete;
 
   void Init(PrefStore* managed_prefs,
             PrefStore* supervised_user_prefs,
@@ -48,8 +51,6 @@ class PrefStoreDelegate : public PrefValueStore::Delegate {
 
  private:
   base::WeakPtr<ElectronBrowserContext> browser_context_;
-
-  DISALLOW_COPY_AND_ASSIGN(PrefStoreDelegate);
 };
 
 }  // namespace electron

--- a/shell/browser/printing/print_preview_message_handler.h
+++ b/shell/browser/printing/print_preview_message_handler.h
@@ -31,6 +31,11 @@ class PrintPreviewMessageHandler
  public:
   ~PrintPreviewMessageHandler() override;
 
+  // disable copy
+  PrintPreviewMessageHandler(const PrintPreviewMessageHandler&) = delete;
+  PrintPreviewMessageHandler& operator=(const PrintPreviewMessageHandler&) =
+      delete;
+
   void PrintToPDF(base::DictionaryValue options,
                   gin_helper::Promise<v8::Local<v8::Value>> promise);
 
@@ -94,8 +99,6 @@ class PrintPreviewMessageHandler
   base::WeakPtrFactory<PrintPreviewMessageHandler> weak_ptr_factory_{this};
 
   WEB_CONTENTS_USER_DATA_KEY_DECL();
-
-  DISALLOW_COPY_AND_ASSIGN(PrintPreviewMessageHandler);
 };
 
 }  // namespace electron

--- a/shell/browser/printing/print_view_manager_electron.h
+++ b/shell/browser/printing/print_view_manager_electron.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_PRINTING_PRINT_VIEW_MANAGER_ELECTRON_H_
 #define SHELL_BROWSER_PRINTING_PRINT_VIEW_MANAGER_ELECTRON_H_
 
-#include "base/macros.h"
 #include "build/build_config.h"
 #include "chrome/browser/printing/print_view_manager_base.h"
 #include "content/public/browser/web_contents_user_data.h"
@@ -17,6 +16,10 @@ class PrintViewManagerElectron
       public content::WebContentsUserData<PrintViewManagerElectron> {
  public:
   ~PrintViewManagerElectron() override;
+
+  // disable copy
+  PrintViewManagerElectron(const PrintViewManagerElectron&) = delete;
+  PrintViewManagerElectron& operator=(const PrintViewManagerElectron&) = delete;
 
   static void BindPrintManagerHost(
       mojo::PendingAssociatedReceiver<printing::mojom::PrintManagerHost>
@@ -37,8 +40,6 @@ class PrintViewManagerElectron
   explicit PrintViewManagerElectron(content::WebContents* web_contents);
 
   WEB_CONTENTS_USER_DATA_KEY_DECL();
-
-  DISALLOW_COPY_AND_ASSIGN(PrintViewManagerElectron);
 };
 
 }  // namespace electron

--- a/shell/browser/serial/electron_serial_delegate.h
+++ b/shell/browser/serial/electron_serial_delegate.h
@@ -22,6 +22,10 @@ class ElectronSerialDelegate : public content::SerialDelegate {
   ElectronSerialDelegate();
   ~ElectronSerialDelegate() override;
 
+  // disable copy
+  ElectronSerialDelegate(const ElectronSerialDelegate&) = delete;
+  ElectronSerialDelegate& operator=(const ElectronSerialDelegate&) = delete;
+
   std::unique_ptr<content::SerialChooser> RunChooser(
       content::RenderFrameHost* frame,
       std::vector<blink::mojom::SerialPortFilterPtr> filters,
@@ -51,8 +55,6 @@ class ElectronSerialDelegate : public content::SerialDelegate {
       controller_map_;
 
   base::WeakPtrFactory<ElectronSerialDelegate> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronSerialDelegate);
 };
 
 }  // namespace electron

--- a/shell/browser/serial/serial_chooser_context.h
+++ b/shell/browser/serial/serial_chooser_context.h
@@ -51,6 +51,10 @@ class SerialChooserContext : public KeyedService,
   SerialChooserContext();
   ~SerialChooserContext() override;
 
+  // disable copy
+  SerialChooserContext(const SerialChooserContext&) = delete;
+  SerialChooserContext& operator=(const SerialChooserContext&) = delete;
+
   // Serial-specific interface for granting and checking permissions.
   void GrantPortPermission(const url::Origin& origin,
                            const device::mojom::SerialPortInfo& port,
@@ -89,8 +93,6 @@ class SerialChooserContext : public KeyedService,
   base::ObserverList<PortObserver> port_observer_list_;
 
   base::WeakPtrFactory<SerialChooserContext> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(SerialChooserContext);
 };
 
 }  // namespace electron

--- a/shell/browser/serial/serial_chooser_context_factory.h
+++ b/shell/browser/serial/serial_chooser_context_factory.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_SERIAL_SERIAL_CHOOSER_CONTEXT_FACTORY_H_
 #define SHELL_BROWSER_SERIAL_SERIAL_CHOOSER_CONTEXT_FACTORY_H_
 
-#include "base/macros.h"
 #include "base/memory/singleton.h"
 #include "components/keyed_service/content/browser_context_keyed_service_factory.h"
 #include "shell/browser/serial/serial_chooser_context.h"
@@ -26,13 +25,16 @@ class SerialChooserContextFactory : public BrowserContextKeyedServiceFactory {
   SerialChooserContextFactory();
   ~SerialChooserContextFactory() override;
 
+  // disable copy
+  SerialChooserContextFactory(const SerialChooserContextFactory&) = delete;
+  SerialChooserContextFactory& operator=(const SerialChooserContextFactory&) =
+      delete;
+
   // BrowserContextKeyedServiceFactory methods:
   KeyedService* BuildServiceInstanceFor(
       content::BrowserContext* context) const override;
   content::BrowserContext* GetBrowserContextToUse(
       content::BrowserContext* context) const override;
-
-  DISALLOW_COPY_AND_ASSIGN(SerialChooserContextFactory);
 };
 
 }  // namespace electron

--- a/shell/browser/serial/serial_chooser_controller.h
+++ b/shell/browser/serial/serial_chooser_controller.h
@@ -8,7 +8,6 @@
 #include <string>
 #include <vector>
 
-#include "base/macros.h"
 #include "base/memory/weak_ptr.h"
 #include "content/public/browser/global_routing_id.h"
 #include "content/public/browser/serial_chooser.h"
@@ -40,6 +39,10 @@ class SerialChooserController final : public SerialChooserContext::PortObserver,
       base::WeakPtr<ElectronSerialDelegate> serial_delegate);
   ~SerialChooserController() override;
 
+  // disable copy
+  SerialChooserController(const SerialChooserController&) = delete;
+  SerialChooserController& operator=(const SerialChooserController&) = delete;
+
   // SerialChooserContext::PortObserver:
   void OnPortAdded(const device::mojom::SerialPortInfo& port) override;
   void OnPortRemoved(const device::mojom::SerialPortInfo& port) override;
@@ -65,8 +68,6 @@ class SerialChooserController final : public SerialChooserContext::PortObserver,
   content::GlobalRenderFrameHostId render_frame_host_id_;
 
   base::WeakPtrFactory<SerialChooserController> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(SerialChooserController);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/autofill_popup.h
+++ b/shell/browser/ui/autofill_popup.h
@@ -23,6 +23,10 @@ class AutofillPopup : public views::ViewObserver {
   AutofillPopup();
   ~AutofillPopup() override;
 
+  // disable copy
+  AutofillPopup(const AutofillPopup&) = delete;
+  AutofillPopup& operator=(const AutofillPopup&) = delete;
+
   void CreateView(content::RenderFrameHost* render_frame,
                   content::RenderFrameHost* embedder_frame,
                   bool offscreen,
@@ -82,8 +86,6 @@ class AutofillPopup : public views::ViewObserver {
 
   // The parent view that the popup view shows on. Weak ref.
   views::View* parent_ = nullptr;
-
-  DISALLOW_COPY_AND_ASSIGN(AutofillPopup);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/cocoa/delayed_native_view_host.h
+++ b/shell/browser/ui/cocoa/delayed_native_view_host.h
@@ -16,14 +16,16 @@ class DelayedNativeViewHost : public views::NativeViewHost {
   explicit DelayedNativeViewHost(gfx::NativeView native_view);
   ~DelayedNativeViewHost() override;
 
+  // disable copy
+  DelayedNativeViewHost(const DelayedNativeViewHost&) = delete;
+  DelayedNativeViewHost& operator=(const DelayedNativeViewHost&) = delete;
+
   // views::View:
   void ViewHierarchyChanged(
       const views::ViewHierarchyChangedDetails& details) override;
 
  private:
   gfx::NativeView native_view_;
-
-  DISALLOW_COPY_AND_ASSIGN(DelayedNativeViewHost);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/cocoa/electron_native_widget_mac.h
+++ b/shell/browser/ui/cocoa/electron_native_widget_mac.h
@@ -18,6 +18,10 @@ class ElectronNativeWidgetMac : public views::NativeWidgetMac {
                           views::internal::NativeWidgetDelegate* delegate);
   ~ElectronNativeWidgetMac() override;
 
+  // disable copy
+  ElectronNativeWidgetMac(const ElectronNativeWidgetMac&) = delete;
+  ElectronNativeWidgetMac& operator=(const ElectronNativeWidgetMac&) = delete;
+
  protected:
   // NativeWidgetMac:
   NativeWidgetMacNSWindow* CreateNSWindow(
@@ -26,8 +30,6 @@ class ElectronNativeWidgetMac : public views::NativeWidgetMac {
  private:
   NativeWindowMac* shell_;
   NSUInteger style_mask_;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronNativeWidgetMac);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/cocoa/root_view_mac.h
+++ b/shell/browser/ui/cocoa/root_view_mac.h
@@ -16,6 +16,10 @@ class RootViewMac : public views::View {
   explicit RootViewMac(NativeWindow* window);
   ~RootViewMac() override;
 
+  // disable copy
+  RootViewMac(const RootViewMac&) = delete;
+  RootViewMac& operator=(const RootViewMac&) = delete;
+
   // views::View:
   void Layout() override;
   gfx::Size GetMinimumSize() const override;
@@ -24,8 +28,6 @@ class RootViewMac : public views::View {
  private:
   // Parent window, weak ref.
   NativeWindow* window_;
-
-  DISALLOW_COPY_AND_ASSIGN(RootViewMac);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/cocoa/views_delegate_mac.h
+++ b/shell/browser/ui/cocoa/views_delegate_mac.h
@@ -14,14 +14,15 @@ class ViewsDelegateMac : public views::ViewsDelegate {
   ViewsDelegateMac();
   ~ViewsDelegateMac() override;
 
+  // disable copy
+  ViewsDelegateMac(const ViewsDelegateMac&) = delete;
+  ViewsDelegateMac& operator=(const ViewsDelegateMac&) = delete;
+
   // ViewsDelegate:
   void OnBeforeWidgetInit(
       views::Widget::InitParams* params,
       views::internal::NativeWidgetDelegate* delegate) override;
   ui::ContextFactory* GetContextFactory() override;
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(ViewsDelegateMac);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/devtools_manager_delegate.cc
+++ b/shell/browser/ui/devtools_manager_delegate.cc
@@ -41,6 +41,10 @@ class TCPServerSocketFactory : public content::DevToolsSocketFactory {
   TCPServerSocketFactory(const std::string& address, int port)
       : address_(address), port_(port) {}
 
+  // disable copy
+  TCPServerSocketFactory(const TCPServerSocketFactory&) = delete;
+  TCPServerSocketFactory& operator=(const TCPServerSocketFactory&) = delete;
+
  private:
   // content::ServerSocketFactory.
   std::unique_ptr<net::ServerSocket> CreateForHttpServer() override {
@@ -58,8 +62,6 @@ class TCPServerSocketFactory : public content::DevToolsSocketFactory {
 
   std::string address_;
   uint16_t port_;
-
-  DISALLOW_COPY_AND_ASSIGN(TCPServerSocketFactory);
 };
 
 std::unique_ptr<content::DevToolsSocketFactory> CreateSocketFactory() {

--- a/shell/browser/ui/devtools_manager_delegate.h
+++ b/shell/browser/ui/devtools_manager_delegate.h
@@ -8,7 +8,6 @@
 #include <string>
 
 #include "base/compiler_specific.h"
-#include "base/macros.h"
 #include "content/public/browser/devtools_manager_delegate.h"
 
 namespace electron {
@@ -20,6 +19,10 @@ class DevToolsManagerDelegate : public content::DevToolsManagerDelegate {
   DevToolsManagerDelegate();
   ~DevToolsManagerDelegate() override;
 
+  // disable copy
+  DevToolsManagerDelegate(const DevToolsManagerDelegate&) = delete;
+  DevToolsManagerDelegate& operator=(const DevToolsManagerDelegate&) = delete;
+
   // DevToolsManagerDelegate implementation.
   void Inspect(content::DevToolsAgentHost* agent_host) override;
   void HandleCommand(content::DevToolsAgentHostClientChannel* channel,
@@ -29,9 +32,6 @@ class DevToolsManagerDelegate : public content::DevToolsManagerDelegate {
       const GURL& url) override;
   std::string GetDiscoveryPageHTML() override;
   bool HasBundledFrontendResources() override;
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(DevToolsManagerDelegate);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/devtools_ui.cc
+++ b/shell/browser/ui/devtools_ui.cc
@@ -70,6 +70,10 @@ class BundledDataSource : public content::URLDataSource {
   BundledDataSource() = default;
   ~BundledDataSource() override = default;
 
+  // disable copy
+  BundledDataSource(const BundledDataSource&) = delete;
+  BundledDataSource& operator=(const BundledDataSource&) = delete;
+
   // content::URLDataSource implementation.
   std::string GetSource() override { return chrome::kChromeUIDevToolsHost; }
 
@@ -113,9 +117,6 @@ class BundledDataSource : public content::URLDataSource {
            "--debug-devtools.";
     std::move(callback).Run(bytes);
   }
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(BundledDataSource);
 };
 
 }  // namespace

--- a/shell/browser/ui/devtools_ui.h
+++ b/shell/browser/ui/devtools_ui.h
@@ -16,8 +16,9 @@ class DevToolsUI : public content::WebUIController {
   explicit DevToolsUI(content::BrowserContext* browser_context,
                       content::WebUI* web_ui);
 
- private:
-  DISALLOW_COPY_AND_ASSIGN(DevToolsUI);
+  // disable copy
+  DevToolsUI(const DevToolsUI&) = delete;
+  DevToolsUI& operator=(const DevToolsUI&) = delete;
 };
 
 }  // namespace electron

--- a/shell/browser/ui/electron_menu_model.h
+++ b/shell/browser/ui/electron_menu_model.h
@@ -74,6 +74,10 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
   explicit ElectronMenuModel(Delegate* delegate);
   ~ElectronMenuModel() override;
 
+  // disable copy
+  ElectronMenuModel(const ElectronMenuModel&) = delete;
+  ElectronMenuModel& operator=(const ElectronMenuModel&) = delete;
+
   void AddObserver(Observer* obs) { observers_.AddObserver(obs); }
   void RemoveObserver(Observer* obs) { observers_.RemoveObserver(obs); }
 
@@ -120,8 +124,6 @@ class ElectronMenuModel : public ui::SimpleMenuModel {
   base::ObserverList<Observer> observers_;
 
   base::WeakPtrFactory<ElectronMenuModel> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronMenuModel);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/file_dialog_gtk.cc
+++ b/shell/browser/ui/file_dialog_gtk.cc
@@ -213,6 +213,10 @@ class FileChooserDialog {
       parent_->SetEnabled(true);
   }
 
+  // disable copy
+  FileChooserDialog(const FileChooserDialog&) = delete;
+  FileChooserDialog& operator=(const FileChooserDialog&) = delete;
+
   void SetupOpenProperties(int properties) {
     const auto hasProp = [properties](OpenFileDialogProperty prop) {
       return gboolean((properties & prop) != 0);
@@ -311,8 +315,6 @@ class FileChooserDialog {
 
   // Callback for when we update the preview for the selection.
   CHROMEG_CALLBACK_0(FileChooserDialog, void, OnUpdatePreview, GtkFileChooser*);
-
-  DISALLOW_COPY_AND_ASSIGN(FileChooserDialog);
 };
 
 void FileChooserDialog::OnFileDialogResponse(GtkWidget* widget, int response) {

--- a/shell/browser/ui/gtk/app_indicator_icon.h
+++ b/shell/browser/ui/gtk/app_indicator_icon.h
@@ -9,7 +9,6 @@
 #include <string>
 
 #include "base/files/file_path.h"
-#include "base/macros.h"
 #include "base/memory/weak_ptr.h"
 #include "base/nix/xdg_util.h"
 #include "ui/base/glib/glib_signal.h"
@@ -43,6 +42,10 @@ class AppIndicatorIcon : public views::StatusIconLinux {
                    const gfx::ImageSkia& image,
                    const std::u16string& tool_tip);
   ~AppIndicatorIcon() override;
+
+  // disable copy
+  AppIndicatorIcon(const AppIndicatorIcon&) = delete;
+  AppIndicatorIcon& operator=(const AppIndicatorIcon&) = delete;
 
   // Indicates whether libappindicator so could be opened.
   static bool CouldOpen();
@@ -105,8 +108,6 @@ class AppIndicatorIcon : public views::StatusIconLinux {
   int icon_change_count_ = 0;
 
   base::WeakPtrFactory<AppIndicatorIcon> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(AppIndicatorIcon);
 };
 
 }  // namespace gtkui

--- a/shell/browser/ui/gtk/app_indicator_icon_menu.h
+++ b/shell/browser/ui/gtk/app_indicator_icon_menu.h
@@ -6,7 +6,6 @@
 #define SHELL_BROWSER_UI_GTK_APP_INDICATOR_ICON_MENU_H_
 
 #include "base/callback.h"
-#include "base/macros.h"
 #include "ui/base/glib/glib_signal.h"
 
 typedef struct _GtkMenu GtkMenu;
@@ -25,6 +24,10 @@ class AppIndicatorIconMenu {
  public:
   explicit AppIndicatorIconMenu(ui::MenuModel* model);
   virtual ~AppIndicatorIconMenu();
+
+  // disable copy
+  AppIndicatorIconMenu(const AppIndicatorIconMenu&) = delete;
+  AppIndicatorIconMenu& operator=(const AppIndicatorIconMenu&) = delete;
 
   // Sets a menu item at the top of |gtk_menu_| as a replacement for the app
   // indicator icon's click action. |callback| is called when the menu item
@@ -65,8 +68,6 @@ class AppIndicatorIconMenu {
   GtkWidget* gtk_menu_ = nullptr;
 
   bool block_activation_ = false;
-
-  DISALLOW_COPY_AND_ASSIGN(AppIndicatorIconMenu);
 };
 
 }  // namespace gtkui

--- a/shell/browser/ui/gtk/gtk_status_icon.h
+++ b/shell/browser/ui/gtk/gtk_status_icon.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 
-#include "base/macros.h"
 #include "ui/base/glib/glib_integers.h"
 #include "ui/base/glib/glib_signal.h"
 #include "ui/views/linux_ui/status_icon_linux.h"
@@ -34,6 +33,10 @@ class GtkStatusIcon : public views::StatusIconLinux {
   GtkStatusIcon(const gfx::ImageSkia& image, const std::u16string& tool_tip);
   ~GtkStatusIcon() override;
 
+  // disable copy
+  GtkStatusIcon(const GtkStatusIcon&) = delete;
+  GtkStatusIcon& operator=(const GtkStatusIcon&) = delete;
+
   // Overridden from views::StatusIconLinux:
   void SetIcon(const gfx::ImageSkia& image) override;
   void SetToolTip(const std::u16string& tool_tip) override;
@@ -53,8 +56,6 @@ class GtkStatusIcon : public views::StatusIconLinux {
   ::GtkStatusIcon* gtk_status_icon_;
 
   std::unique_ptr<AppIndicatorIconMenu> menu_;
-
-  DISALLOW_COPY_AND_ASSIGN(GtkStatusIcon);
 };
 
 }  // namespace gtkui

--- a/shell/browser/ui/inspectable_web_contents.h
+++ b/shell/browser/ui/inspectable_web_contents.h
@@ -51,6 +51,10 @@ class InspectableWebContents
                          bool is_guest);
   ~InspectableWebContents() override;
 
+  // disable copy
+  InspectableWebContents(const InspectableWebContents&) = delete;
+  InspectableWebContents& operator=(const InspectableWebContents&) = delete;
+
   InspectableWebContentsView* GetView() const;
   content::WebContents* GetWebContents() const;
   content::WebContents* GetDevToolsWebContents() const;
@@ -238,8 +242,6 @@ class InspectableWebContents
   base::flat_set<std::string> synced_setting_names_;
 
   base::WeakPtrFactory<InspectableWebContents> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(InspectableWebContents);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/message_box_gtk.cc
+++ b/shell/browser/ui/message_box_gtk.cc
@@ -127,6 +127,10 @@ class GtkMessageBox : public NativeWindowObserver {
     }
   }
 
+  // disable copy
+  GtkMessageBox(const GtkMessageBox&) = delete;
+  GtkMessageBox& operator=(const GtkMessageBox&) = delete;
+
   GtkMessageType GetMessageType(MessageBoxType type) {
     switch (type) {
       case MessageBoxType::kInformation:
@@ -205,8 +209,6 @@ class GtkMessageBox : public NativeWindowObserver {
   NativeWindow* parent_;
   GtkWidget* dialog_;
   MessageBoxCallback callback_;
-
-  DISALLOW_COPY_AND_ASSIGN(GtkMessageBox);
 };
 
 void GtkMessageBox::OnResponseDialog(GtkWidget* widget, int response) {

--- a/shell/browser/ui/tray_icon.h
+++ b/shell/browser/ui/tray_icon.h
@@ -28,6 +28,10 @@ class TrayIcon {
 
   virtual ~TrayIcon();
 
+  // disable copy
+  TrayIcon(const TrayIcon&) = delete;
+  TrayIcon& operator=(const TrayIcon&) = delete;
+
   // Sets the image associated with this status icon.
   virtual void SetImage(ImageType image) = 0;
 
@@ -129,8 +133,6 @@ class TrayIcon {
 
  private:
   base::ObserverList<TrayIconObserver> observers_;
-
-  DISALLOW_COPY_AND_ASSIGN(TrayIcon);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/tray_icon_cocoa.h
+++ b/shell/browser/ui/tray_icon_cocoa.h
@@ -44,8 +44,6 @@ class TrayIconCocoa : public TrayIcon {
   base::scoped_nsobject<ElectronMenuController> menu_;
 
   base::WeakPtrFactory<TrayIconCocoa> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(TrayIconCocoa);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/tray_icon_gtk.h
+++ b/shell/browser/ui/tray_icon_gtk.h
@@ -38,8 +38,6 @@ class TrayIconGtk : public TrayIcon, public views::StatusIconLinux::Delegate {
   gfx::ImageSkia image_;
   std::u16string tool_tip_;
   ui::MenuModel* menu_model_;
-
-  DISALLOW_COPY_AND_ASSIGN(TrayIconGtk);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/views/autofill_popup_view.h
+++ b/shell/browser/ui/views/autofill_popup_view.h
@@ -42,6 +42,10 @@ class AutofillPopupChildView : public views::View {
     SetFocusBehavior(FocusBehavior::ALWAYS);
   }
 
+  // disable copy
+  AutofillPopupChildView(const AutofillPopupChildView&) = delete;
+  AutofillPopupChildView& operator=(const AutofillPopupChildView&) = delete;
+
  private:
   ~AutofillPopupChildView() override {}
 
@@ -49,8 +53,6 @@ class AutofillPopupChildView : public views::View {
   void GetAccessibleNodeData(ui::AXNodeData* node_data) override;
 
   std::u16string suggestion_;
-
-  DISALLOW_COPY_AND_ASSIGN(AutofillPopupChildView);
 };
 
 class AutofillPopupView : public views::WidgetDelegateView,

--- a/shell/browser/ui/views/electron_views_delegate.h
+++ b/shell/browser/ui/views/electron_views_delegate.h
@@ -19,6 +19,10 @@ class ViewsDelegate : public views::ViewsDelegate {
   ViewsDelegate();
   ~ViewsDelegate() override;
 
+  // disable copy
+  ViewsDelegate(const ViewsDelegate&) = delete;
+  ViewsDelegate& operator=(const ViewsDelegate&) = delete;
+
  protected:
   // views::ViewsDelegate:
   void SaveWindowPlacement(const views::Widget* window,
@@ -71,8 +75,6 @@ class ViewsDelegate : public views::ViewsDelegate {
 
   base::WeakPtrFactory<ViewsDelegate> weak_factory_{this};
 #endif
-
-  DISALLOW_COPY_AND_ASSIGN(ViewsDelegate);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/views/frameless_view.h
+++ b/shell/browser/ui/views/frameless_view.h
@@ -21,6 +21,10 @@ class FramelessView : public views::NonClientFrameView {
   FramelessView();
   ~FramelessView() override;
 
+  // disable copy
+  FramelessView(const FramelessView&) = delete;
+  FramelessView& operator=(const FramelessView&) = delete;
+
   virtual void Init(NativeWindowViews* window, views::Widget* frame);
 
   // Returns whether the |point| is on frameless window's resizing border.
@@ -49,9 +53,6 @@ class FramelessView : public views::NonClientFrameView {
   views::Widget* frame_ = nullptr;
 
   friend class NativeWindowsViews;
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(FramelessView);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/views/global_menu_bar_registrar_x11.h
+++ b/shell/browser/ui/views/global_menu_bar_registrar_x11.h
@@ -33,6 +33,11 @@ class GlobalMenuBarRegistrarX11 {
   GlobalMenuBarRegistrarX11();
   ~GlobalMenuBarRegistrarX11();
 
+  // disable copy
+  GlobalMenuBarRegistrarX11(const GlobalMenuBarRegistrarX11&) = delete;
+  GlobalMenuBarRegistrarX11& operator=(const GlobalMenuBarRegistrarX11&) =
+      delete;
+
   // Sends the actual message.
   void RegisterXWindow(x11::Window window);
   void UnregisterXWindow(x11::Window window);
@@ -53,8 +58,6 @@ class GlobalMenuBarRegistrarX11 {
   // x11::Window which want to be registered, but haven't yet been because
   // we're waiting for the proxy to become available.
   std::set<x11::Window> live_windows_;
-
-  DISALLOW_COPY_AND_ASSIGN(GlobalMenuBarRegistrarX11);
 };
 
 #endif  // SHELL_BROWSER_UI_VIEWS_GLOBAL_MENU_BAR_REGISTRAR_X11_H_

--- a/shell/browser/ui/views/global_menu_bar_x11.h
+++ b/shell/browser/ui/views/global_menu_bar_x11.h
@@ -8,7 +8,6 @@
 #include <string>
 
 #include "base/compiler_specific.h"
-#include "base/macros.h"
 #include "shell/browser/ui/electron_menu_model.h"
 #include "ui/base/glib/glib_signal.h"
 #include "ui/gfx/native_widget_types.h"
@@ -40,6 +39,10 @@ class GlobalMenuBarX11 {
  public:
   explicit GlobalMenuBarX11(NativeWindowViews* window);
   virtual ~GlobalMenuBarX11();
+
+  // disable copy
+  GlobalMenuBarX11(const GlobalMenuBarX11&) = delete;
+  GlobalMenuBarX11& operator=(const GlobalMenuBarX11&) = delete;
 
   // Creates the object path for DbusmenuServer which is attached to |window|.
   static std::string GetPathForWindow(x11::Window window);
@@ -73,8 +76,6 @@ class GlobalMenuBarX11 {
   x11::Window xwindow_;
 
   DbusmenuServer* server_ = nullptr;
-
-  DISALLOW_COPY_AND_ASSIGN(GlobalMenuBarX11);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/views/inspectable_web_contents_view_views.cc
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.cc
@@ -41,6 +41,10 @@ class DevToolsWindowDelegate : public views::ClientView,
   }
   ~DevToolsWindowDelegate() override = default;
 
+  // disable copy
+  DevToolsWindowDelegate(const DevToolsWindowDelegate&) = delete;
+  DevToolsWindowDelegate& operator=(const DevToolsWindowDelegate&) = delete;
+
   // views::WidgetDelegate:
   views::View* GetInitiallyFocusedView() override { return view_; }
   std::u16string GetWindowTitle() const override { return shell_->GetTitle(); }
@@ -64,8 +68,6 @@ class DevToolsWindowDelegate : public views::ClientView,
   views::View* view_;
   views::Widget* widget_;
   ui::ImageModel icon_;
-
-  DISALLOW_COPY_AND_ASSIGN(DevToolsWindowDelegate);
 };
 
 }  // namespace

--- a/shell/browser/ui/views/inspectable_web_contents_view_views.h
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.h
@@ -63,8 +63,6 @@ class InspectableWebContentsViewViews : public InspectableWebContentsView,
   bool devtools_visible_ = false;
   views::WidgetDelegate* devtools_window_delegate_ = nullptr;
   std::u16string title_;
-
-  DISALLOW_COPY_AND_ASSIGN(InspectableWebContentsViewViews);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/views/menu_bar.h
+++ b/shell/browser/ui/views/menu_bar.h
@@ -26,6 +26,10 @@ class MenuBar : public views::AccessiblePaneView,
   MenuBar(NativeWindow* window, RootView* root_view);
   ~MenuBar() override;
 
+  // disable copy
+  MenuBar(const MenuBar&) = delete;
+  MenuBar& operator=(const MenuBar&) = delete;
+
   // Replaces current menu with a new one.
   void SetMenu(ElectronMenuModel* menu_model);
 
@@ -84,8 +88,6 @@ class MenuBar : public views::AccessiblePaneView,
   RootView* root_view_;
   ElectronMenuModel* menu_model_ = nullptr;
   bool accelerator_installed_ = false;
-
-  DISALLOW_COPY_AND_ASSIGN(MenuBar);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/views/menu_delegate.h
+++ b/shell/browser/ui/views/menu_delegate.h
@@ -25,6 +25,10 @@ class MenuDelegate : public views::MenuDelegate {
   explicit MenuDelegate(MenuBar* menu_bar);
   ~MenuDelegate() override;
 
+  // disable copy
+  MenuDelegate(const MenuDelegate&) = delete;
+  MenuDelegate& operator=(const MenuDelegate&) = delete;
+
   void RunMenu(ElectronMenuModel* model,
                views::Button* button,
                ui::MenuSourceType source_type);
@@ -72,8 +76,6 @@ class MenuDelegate : public views::MenuDelegate {
   bool hold_first_switch_ = false;
 
   base::ObserverList<Observer>::Unchecked observers_;
-
-  DISALLOW_COPY_AND_ASSIGN(MenuDelegate);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/views/menu_model_adapter.h
+++ b/shell/browser/ui/views/menu_model_adapter.h
@@ -15,13 +15,15 @@ class MenuModelAdapter : public views::MenuModelAdapter {
   explicit MenuModelAdapter(ElectronMenuModel* menu_model);
   ~MenuModelAdapter() override;
 
+  // disable copy
+  MenuModelAdapter(const MenuModelAdapter&) = delete;
+  MenuModelAdapter& operator=(const MenuModelAdapter&) = delete;
+
  protected:
   bool GetAccelerator(int id, ui::Accelerator* accelerator) const override;
 
  private:
   ElectronMenuModel* menu_model_;
-
-  DISALLOW_COPY_AND_ASSIGN(MenuModelAdapter);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/views/native_frame_view.h
+++ b/shell/browser/ui/views/native_frame_view.h
@@ -18,6 +18,10 @@ class NativeFrameView : public views::NativeFrameView {
   static const char kViewClassName[];
   NativeFrameView(NativeWindow* window, views::Widget* widget);
 
+  // disable copy
+  NativeFrameView(const NativeFrameView&) = delete;
+  NativeFrameView& operator=(const NativeFrameView&) = delete;
+
  protected:
   // views::View:
   gfx::Size GetMinimumSize() const override;
@@ -26,8 +30,6 @@ class NativeFrameView : public views::NativeFrameView {
 
  private:
   NativeWindow* window_;  // weak ref.
-
-  DISALLOW_COPY_AND_ASSIGN(NativeFrameView);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/views/root_view.h
+++ b/shell/browser/ui/views/root_view.h
@@ -27,6 +27,10 @@ class RootView : public views::View {
   explicit RootView(NativeWindow* window);
   ~RootView() override;
 
+  // disable copy
+  RootView(const RootView&) = delete;
+  RootView& operator=(const RootView&) = delete;
+
   void SetMenu(ElectronMenuModel* menu_model);
   bool HasMenu() const;
   int GetMenuBarHeight() const;
@@ -61,8 +65,6 @@ class RootView : public views::View {
   accelerator_util::AcceleratorTable accelerator_table_;
 
   std::unique_ptr<views::ViewTracker> last_focused_view_tracker_;
-
-  DISALLOW_COPY_AND_ASSIGN(RootView);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/views/submenu_button.h
+++ b/shell/browser/ui/views/submenu_button.h
@@ -21,6 +21,10 @@ class SubmenuButton : public views::MenuButton {
                 const SkColor& background_color);
   ~SubmenuButton() override;
 
+  // disable copy
+  SubmenuButton(const SubmenuButton&) = delete;
+  SubmenuButton& operator=(const SubmenuButton&) = delete;
+
   void SetAcceleratorVisibility(bool visible);
   void SetUnderlineColor(SkColor color);
 
@@ -50,8 +54,6 @@ class SubmenuButton : public views::MenuButton {
   int text_height_ = 0;
   SkColor underline_color_ = SK_ColorBLACK;
   SkColor background_color_;
-
-  DISALLOW_COPY_AND_ASSIGN(SubmenuButton);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/views/win_frame_view.h
+++ b/shell/browser/ui/views/win_frame_view.h
@@ -81,8 +81,6 @@ class WinFrameView : public FramelessView {
   // May be null if the caption button container is destroyed before the frame
   // view. Always check for validity before using!
   WinCaptionButtonContainer* caption_button_container_;
-
-  DISALLOW_COPY_AND_ASSIGN(WinFrameView);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/webui/accessibility_ui.h
+++ b/shell/browser/ui/webui/accessibility_ui.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_BROWSER_UI_WEBUI_ACCESSIBILITY_UI_H_
 #define SHELL_BROWSER_UI_WEBUI_ACCESSIBILITY_UI_H_
 
-#include "base/macros.h"
 #include "chrome/browser/accessibility/accessibility_ui.h"
 #include "content/public/browser/web_ui_controller.h"
 #include "content/public/browser/web_ui_data_source.h"
@@ -24,12 +23,16 @@ class ElectronAccessibilityUIMessageHandler
  public:
   ElectronAccessibilityUIMessageHandler();
 
+  // disable copy
+  ElectronAccessibilityUIMessageHandler(
+      const ElectronAccessibilityUIMessageHandler&) = delete;
+  ElectronAccessibilityUIMessageHandler& operator=(
+      const ElectronAccessibilityUIMessageHandler&) = delete;
+
   void RegisterMessages() final;
 
  private:
   void RequestNativeUITree(const base::ListValue* args);
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronAccessibilityUIMessageHandler);
 };
 
 #endif  // SHELL_BROWSER_UI_WEBUI_ACCESSIBILITY_UI_H_

--- a/shell/browser/ui/win/electron_desktop_native_widget_aura.h
+++ b/shell/browser/ui/win/electron_desktop_native_widget_aura.h
@@ -19,6 +19,12 @@ class ElectronDesktopNativeWidgetAura : public views::DesktopNativeWidgetAura {
   explicit ElectronDesktopNativeWidgetAura(
       NativeWindowViews* native_window_view);
 
+  // disable copy
+  ElectronDesktopNativeWidgetAura(const ElectronDesktopNativeWidgetAura&) =
+      delete;
+  ElectronDesktopNativeWidgetAura& operator=(
+      const ElectronDesktopNativeWidgetAura&) = delete;
+
   // views::DesktopNativeWidgetAura:
   void InitNativeWidget(views::Widget::InitParams params) override;
 
@@ -34,8 +40,6 @@ class ElectronDesktopNativeWidgetAura : public views::DesktopNativeWidgetAura {
 
   // Owned by DesktopNativeWidgetAura.
   views::DesktopWindowTreeHost* desktop_window_tree_host_;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronDesktopNativeWidgetAura);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
@@ -20,6 +20,12 @@ class ElectronDesktopWindowTreeHostWin
       views::DesktopNativeWidgetAura* desktop_native_widget_aura);
   ~ElectronDesktopWindowTreeHostWin() override;
 
+  // disable copy
+  ElectronDesktopWindowTreeHostWin(const ElectronDesktopWindowTreeHostWin&) =
+      delete;
+  ElectronDesktopWindowTreeHostWin& operator=(
+      const ElectronDesktopWindowTreeHostWin&) = delete;
+
  protected:
   bool PreHandleMSG(UINT message,
                     WPARAM w_param,
@@ -33,8 +39,6 @@ class ElectronDesktopWindowTreeHostWin
 
  private:
   NativeWindowViews* native_window_view_;  // weak ref
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronDesktopWindowTreeHostWin);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/win/jump_list.h
+++ b/shell/browser/ui/win/jump_list.h
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "base/files/file_path.h"
-#include "base/macros.h"
 
 namespace electron {
 
@@ -91,6 +90,10 @@ class JumpList {
   explicit JumpList(const std::wstring& app_id);
   ~JumpList();
 
+  // disable copy
+  JumpList(const JumpList&) = delete;
+  JumpList& operator=(const JumpList&) = delete;
+
   // Starts a new transaction, must be called before appending any categories,
   // aborting or committing. After the method returns |min_items| will indicate
   // the minimum number of items that will be displayed in the Jump List, and
@@ -113,8 +116,6 @@ class JumpList {
  private:
   std::wstring app_id_;
   CComPtr<ICustomDestinationList> destinations_;
-
-  DISALLOW_COPY_AND_ASSIGN(JumpList);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/win/notify_icon.h
+++ b/shell/browser/ui/win/notify_icon.h
@@ -13,7 +13,6 @@
 #include <string>
 
 #include "base/compiler_specific.h"
-#include "base/macros.h"
 #include "base/win/scoped_gdi_object.h"
 #include "shell/browser/ui/tray_icon.h"
 #include "shell/browser/ui/win/notify_icon_host.h"
@@ -104,8 +103,6 @@ class NotifyIcon : public TrayIcon {
   std::unique_ptr<views::MenuRunner> menu_runner_;
 
   base::WeakPtrFactory<NotifyIcon> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(NotifyIcon);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/win/notify_icon_host.h
+++ b/shell/browser/ui/win/notify_icon_host.h
@@ -9,7 +9,6 @@
 
 #include <vector>
 
-#include "base/macros.h"
 #include "shell/common/gin_converters/guid_converter.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
@@ -23,6 +22,10 @@ class NotifyIconHost {
  public:
   NotifyIconHost();
   ~NotifyIconHost();
+
+  // disable copy
+  NotifyIconHost(const NotifyIconHost&) = delete;
+  NotifyIconHost& operator=(const NotifyIconHost&) = delete;
 
   NotifyIcon* CreateNotifyIcon(absl::optional<UUID> guid);
   void Remove(NotifyIcon* notify_icon);
@@ -61,8 +64,6 @@ class NotifyIconHost {
   // The message ID of the "TaskbarCreated" message, sent to us when we need to
   // reset our status icons.
   UINT taskbar_created_message_ = 0;
-
-  DISALLOW_COPY_AND_ASSIGN(NotifyIconHost);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/win/taskbar_host.h
+++ b/shell/browser/ui/win/taskbar_host.h
@@ -35,6 +35,10 @@ class TaskbarHost {
   TaskbarHost();
   virtual ~TaskbarHost();
 
+  // disable copy
+  TaskbarHost(const TaskbarHost&) = delete;
+  TaskbarHost& operator=(const TaskbarHost&) = delete;
+
   // Add or update the buttons in thumbar.
   bool SetThumbarButtons(HWND window,
                          const std::vector<ThumbarButton>& buttons);
@@ -76,8 +80,6 @@ class TaskbarHost {
 
   // Whether we have already added the buttons to thumbar.
   bool thumbar_buttons_added_ = false;
-
-  DISALLOW_COPY_AND_ASSIGN(TaskbarHost);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/x/event_disabler.h
+++ b/shell/browser/ui/x/event_disabler.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 
-#include "base/macros.h"
 #include "ui/events/event_rewriter.h"
 
 namespace electron {
@@ -17,6 +16,10 @@ class EventDisabler : public ui::EventRewriter {
   EventDisabler();
   ~EventDisabler() override;
 
+  // disable copy
+  EventDisabler(const EventDisabler&) = delete;
+  EventDisabler& operator=(const EventDisabler&) = delete;
+
   // ui::EventRewriter:
   ui::EventRewriteStatus RewriteEvent(
       const ui::Event& event,
@@ -24,9 +27,6 @@ class EventDisabler : public ui::EventRewriter {
   ui::EventRewriteStatus NextDispatchEvent(
       const ui::Event& last_event,
       std::unique_ptr<ui::Event>* new_event) override;
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(EventDisabler);
 };
 
 }  // namespace electron

--- a/shell/browser/ui/x/window_state_watcher.h
+++ b/shell/browser/ui/x/window_state_watcher.h
@@ -17,6 +17,10 @@ class WindowStateWatcher : public x11::EventObserver {
   explicit WindowStateWatcher(NativeWindowViews* window);
   ~WindowStateWatcher() override;
 
+  // disable copy
+  WindowStateWatcher(const WindowStateWatcher&) = delete;
+  WindowStateWatcher& operator=(const WindowStateWatcher&) = delete;
+
  protected:
   // x11::EventObserver:
   void OnEvent(const x11::Event& x11_event) override;
@@ -31,8 +35,6 @@ class WindowStateWatcher : public x11::EventObserver {
   const x11::Atom net_wm_state_maximized_vert_atom_;
   const x11::Atom net_wm_state_maximized_horz_atom_;
   const x11::Atom net_wm_state_fullscreen_atom_;
-
-  DISALLOW_COPY_AND_ASSIGN(WindowStateWatcher);
 };
 
 }  // namespace electron

--- a/shell/browser/unresponsive_suppressor.h
+++ b/shell/browser/unresponsive_suppressor.h
@@ -5,8 +5,6 @@
 #ifndef SHELL_BROWSER_UNRESPONSIVE_SUPPRESSOR_H_
 #define SHELL_BROWSER_UNRESPONSIVE_SUPPRESSOR_H_
 
-#include "base/macros.h"
-
 namespace electron {
 
 bool IsUnresponsiveEventSuppressed();
@@ -16,8 +14,9 @@ class UnresponsiveSuppressor {
   UnresponsiveSuppressor();
   ~UnresponsiveSuppressor();
 
- private:
-  DISALLOW_COPY_AND_ASSIGN(UnresponsiveSuppressor);
+  // disable copy
+  UnresponsiveSuppressor(const UnresponsiveSuppressor&) = delete;
+  UnresponsiveSuppressor& operator=(const UnresponsiveSuppressor&) = delete;
 };
 
 }  // namespace electron

--- a/shell/browser/web_contents_permission_helper.h
+++ b/shell/browser/web_contents_permission_helper.h
@@ -19,6 +19,11 @@ class WebContentsPermissionHelper
  public:
   ~WebContentsPermissionHelper() override;
 
+  // disable copy
+  WebContentsPermissionHelper(const WebContentsPermissionHelper&) = delete;
+  WebContentsPermissionHelper& operator=(const WebContentsPermissionHelper&) =
+      delete;
+
   enum class PermissionType {
     POINTER_LOCK = static_cast<int>(content::PermissionType::NUM) + 1,
     FULLSCREEN,
@@ -85,8 +90,6 @@ class WebContentsPermissionHelper
   content::WebContents* web_contents_;
 
   WEB_CONTENTS_USER_DATA_KEY_DECL();
-
-  DISALLOW_COPY_AND_ASSIGN(WebContentsPermissionHelper);
 };
 
 }  // namespace electron

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -36,6 +36,10 @@ class WebContentsPreferences
                          const gin_helper::Dictionary& web_preferences);
   ~WebContentsPreferences() override;
 
+  // disable copy
+  WebContentsPreferences(const WebContentsPreferences&) = delete;
+  WebContentsPreferences& operator=(const WebContentsPreferences&) = delete;
+
   void SetFromDictionary(const gin_helper::Dictionary& new_web_preferences);
 
   // Append command paramters according to preferences.
@@ -140,8 +144,6 @@ class WebContentsPreferences
   base::Value last_web_preferences_;
 
   WEB_CONTENTS_USER_DATA_KEY_DECL();
-
-  DISALLOW_COPY_AND_ASSIGN(WebContentsPreferences);
 };
 
 }  // namespace electron

--- a/shell/browser/web_contents_zoom_controller.h
+++ b/shell/browser/web_contents_zoom_controller.h
@@ -51,6 +51,11 @@ class WebContentsZoomController
   explicit WebContentsZoomController(content::WebContents* web_contents);
   ~WebContentsZoomController() override;
 
+  // disable copy
+  WebContentsZoomController(const WebContentsZoomController&) = delete;
+  WebContentsZoomController& operator=(const WebContentsZoomController&) =
+      delete;
+
   void AddObserver(Observer* observer);
   void RemoveObserver(Observer* observer);
 
@@ -112,8 +117,6 @@ class WebContentsZoomController
   content::HostZoomMap* host_zoom_map_;
 
   WEB_CONTENTS_USER_DATA_KEY_DECL();
-
-  DISALLOW_COPY_AND_ASSIGN(WebContentsZoomController);
 };
 
 }  // namespace electron

--- a/shell/browser/web_view_guest_delegate.h
+++ b/shell/browser/web_view_guest_delegate.h
@@ -21,6 +21,10 @@ class WebViewGuestDelegate : public content::BrowserPluginGuestDelegate,
                        api::WebContents* api_web_contents);
   ~WebViewGuestDelegate() override;
 
+  // disable copy
+  WebViewGuestDelegate(const WebViewGuestDelegate&) = delete;
+  WebViewGuestDelegate& operator=(const WebViewGuestDelegate&) = delete;
+
   // Attach to the iframe.
   void AttachToIframe(content::WebContents* embedder_web_contents,
                       int embedder_frame_id);
@@ -49,8 +53,6 @@ class WebViewGuestDelegate : public content::BrowserPluginGuestDelegate,
   WebContentsZoomController* embedder_zoom_controller_ = nullptr;
 
   api::WebContents* api_web_contents_ = nullptr;
-
-  DISALLOW_COPY_AND_ASSIGN(WebViewGuestDelegate);
 };
 
 }  // namespace electron

--- a/shell/browser/web_view_manager.h
+++ b/shell/browser/web_view_manager.h
@@ -16,6 +16,10 @@ class WebViewManager : public content::BrowserPluginGuestManager {
   WebViewManager();
   ~WebViewManager() override;
 
+  // disable copy
+  WebViewManager(const WebViewManager&) = delete;
+  WebViewManager& operator=(const WebViewManager&) = delete;
+
   void AddGuest(int guest_instance_id,
                 content::WebContents* embedder,
                 content::WebContents* web_contents);
@@ -34,8 +38,6 @@ class WebViewManager : public content::BrowserPluginGuestManager {
   };
   // guest_instance_id => (web_contents, embedder)
   std::map<int, WebContentsWithEmbedder> web_contents_embedder_map_;
-
-  DISALLOW_COPY_AND_ASSIGN(WebViewManager);
 };
 
 }  // namespace electron

--- a/shell/browser/win/scoped_hstring.h
+++ b/shell/browser/win/scoped_hstring.h
@@ -10,8 +10,6 @@
 
 #include <string>
 
-#include "base/macros.h"
-
 namespace electron {
 
 class ScopedHString {
@@ -22,6 +20,10 @@ class ScopedHString {
   // Create empty string.
   ScopedHString();
   ~ScopedHString();
+
+  // disable copy
+  ScopedHString(const ScopedHString&) = delete;
+  ScopedHString& operator=(const ScopedHString&) = delete;
 
   // Sets to |source|.
   void Reset();
@@ -36,8 +38,6 @@ class ScopedHString {
 
  private:
   HSTRING str_ = nullptr;
-
-  DISALLOW_COPY_AND_ASSIGN(ScopedHString);
 };
 
 }  // namespace electron

--- a/shell/browser/window_list.h
+++ b/shell/browser/window_list.h
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include "base/lazy_instance.h"
-#include "base/macros.h"
 #include "base/observer_list.h"
 
 namespace electron {
@@ -18,6 +17,10 @@ class WindowListObserver;
 
 class WindowList {
  public:
+  // disable copy
+  WindowList(const WindowList&) = delete;
+  WindowList& operator=(const WindowList&) = delete;
+
   typedef std::vector<NativeWindow*> WindowVector;
 
   static WindowVector GetWindows();
@@ -55,8 +58,6 @@ class WindowList {
       observers_;
 
   static WindowList* instance_;
-
-  DISALLOW_COPY_AND_ASSIGN(WindowList);
 };
 
 }  // namespace electron

--- a/shell/browser/zoom_level_delegate.h
+++ b/shell/browser/zoom_level_delegate.h
@@ -7,7 +7,6 @@
 
 #include <string>
 
-#include "base/macros.h"
 #include "components/prefs/pref_service.h"
 #include "content/public/browser/host_zoom_map.h"
 #include "content/public/browser/zoom_level_delegate.h"
@@ -35,6 +34,10 @@ class ZoomLevelDelegate : public content::ZoomLevelDelegate {
                     const base::FilePath& partition_path);
   ~ZoomLevelDelegate() override;
 
+  // disable copy
+  ZoomLevelDelegate(const ZoomLevelDelegate&) = delete;
+  ZoomLevelDelegate& operator=(const ZoomLevelDelegate&) = delete;
+
   void SetDefaultZoomLevelPref(double level);
   double GetDefaultZoomLevelPref() const;
 
@@ -54,8 +57,6 @@ class ZoomLevelDelegate : public content::ZoomLevelDelegate {
   content::HostZoomMap* host_zoom_map_ = nullptr;
   base::CallbackListSubscription zoom_subscription_;
   std::string partition_key_;
-
-  DISALLOW_COPY_AND_ASSIGN(ZoomLevelDelegate);
 };
 
 }  // namespace electron

--- a/shell/common/api/electron_api_asar.cc
+++ b/shell/common/api/electron_api_asar.cc
@@ -42,6 +42,10 @@ class Archive : public gin::Wrappable<Archive> {
 
   const char* GetTypeName() override { return "Archive"; }
 
+  // disable copy
+  Archive(const Archive&) = delete;
+  Archive& operator=(const Archive&) = delete;
+
  protected:
   Archive(v8::Isolate* isolate, std::unique_ptr<asar::Archive> archive)
       : archive_(std::move(archive)) {}
@@ -123,8 +127,6 @@ class Archive : public gin::Wrappable<Archive> {
 
  private:
   std::unique_ptr<asar::Archive> archive_;
-
-  DISALLOW_COPY_AND_ASSIGN(Archive);
 };
 
 // static

--- a/shell/common/api/electron_api_clipboard.h
+++ b/shell/common/api/electron_api_clipboard.h
@@ -23,6 +23,10 @@ namespace api {
 
 class Clipboard {
  public:
+  // disable copy
+  Clipboard(const Clipboard&) = delete;
+  Clipboard& operator=(const Clipboard&) = delete;
+
   static ui::ClipboardBuffer GetClipboardBuffer(gin_helper::Arguments* args);
   static std::vector<std::u16string> AvailableFormats(
       gin_helper::Arguments* args);
@@ -61,9 +65,6 @@ class Clipboard {
   static void WriteBuffer(const std::string& format_string,
                           const v8::Local<v8::Value> buffer,
                           gin_helper::Arguments* args);
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(Clipboard);
 };
 
 }  // namespace api

--- a/shell/common/api/electron_api_key_weak_map.h
+++ b/shell/common/api/electron_api_key_weak_map.h
@@ -32,6 +32,10 @@ class KeyWeakMap : public gin_helper::Wrappable<KeyWeakMap<K>> {
         .SetMethod("remove", &KeyWeakMap<K>::Remove);
   }
 
+  // disable copy
+  KeyWeakMap(const KeyWeakMap&) = delete;
+  KeyWeakMap& operator=(const KeyWeakMap&) = delete;
+
  protected:
   explicit KeyWeakMap(v8::Isolate* isolate) {
     gin_helper::Wrappable<KeyWeakMap<K>>::Init(isolate);
@@ -53,8 +57,6 @@ class KeyWeakMap : public gin_helper::Wrappable<KeyWeakMap<K>> {
   void Remove(const K& key) { key_weak_map_.Remove(key); }
 
   electron::KeyWeakMap<K> key_weak_map_;
-
-  DISALLOW_COPY_AND_ASSIGN(KeyWeakMap);
 };
 
 }  // namespace api

--- a/shell/common/api/electron_api_native_image.h
+++ b/shell/common/api/electron_api_native_image.h
@@ -51,6 +51,10 @@ class NativeImage : public gin::Wrappable<NativeImage> {
 #endif
   ~NativeImage() override;
 
+  // disable copy
+  NativeImage(const NativeImage&) = delete;
+  NativeImage& operator=(const NativeImage&) = delete;
+
   static gin::Handle<NativeImage> CreateEmpty(v8::Isolate* isolate);
   static gin::Handle<NativeImage> Create(v8::Isolate* isolate,
                                          const gfx::Image& image);
@@ -132,8 +136,6 @@ class NativeImage : public gin::Wrappable<NativeImage> {
   gfx::Image image_;
 
   v8::Isolate* isolate_;
-
-  DISALLOW_COPY_AND_ASSIGN(NativeImage);
 };
 
 }  // namespace api

--- a/shell/common/api/electron_bindings.h
+++ b/shell/common/api/electron_bindings.h
@@ -9,7 +9,6 @@
 #include <memory>
 
 #include "base/files/file_path.h"
-#include "base/macros.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/process/process_metrics.h"
 #include "shell/common/gin_helper/promise.h"
@@ -35,6 +34,10 @@ class ElectronBindings {
  public:
   explicit ElectronBindings(uv_loop_t* loop);
   virtual ~ElectronBindings();
+
+  // disable copy
+  ElectronBindings(const ElectronBindings&) = delete;
+  ElectronBindings& operator=(const ElectronBindings&) = delete;
 
   // Add process._linkedBinding function, which behaves like process.binding
   // but load native code from Electron instead.
@@ -77,8 +80,6 @@ class ElectronBindings {
   UvHandle<uv_async_t> call_next_tick_async_;
   std::list<node::Environment*> pending_next_ticks_;
   std::unique_ptr<base::ProcessMetrics> metrics_;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronBindings);
 };
 
 }  // namespace electron

--- a/shell/common/api/object_life_monitor.h
+++ b/shell/common/api/object_life_monitor.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_COMMON_API_OBJECT_LIFE_MONITOR_H_
 #define SHELL_COMMON_API_OBJECT_LIFE_MONITOR_H_
 
-#include "base/macros.h"
 #include "base/memory/weak_ptr.h"
 #include "v8/include/v8.h"
 
@@ -16,6 +15,10 @@ class ObjectLifeMonitor {
   ObjectLifeMonitor(v8::Isolate* isolate, v8::Local<v8::Object> target);
   virtual ~ObjectLifeMonitor();
 
+  // disable copy
+  ObjectLifeMonitor(const ObjectLifeMonitor&) = delete;
+  ObjectLifeMonitor& operator=(const ObjectLifeMonitor&) = delete;
+
   virtual void RunDestructor() = 0;
 
  private:
@@ -25,8 +28,6 @@ class ObjectLifeMonitor {
   v8::Global<v8::Object> target_;
 
   base::WeakPtrFactory<ObjectLifeMonitor> weak_ptr_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(ObjectLifeMonitor);
 };
 
 }  // namespace electron

--- a/shell/common/asar/archive.h
+++ b/shell/common/asar/archive.h
@@ -12,7 +12,6 @@
 
 #include "base/files/file.h"
 #include "base/files/file_path.h"
-#include "base/macros.h"
 #include "base/synchronization/lock.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
@@ -63,6 +62,10 @@ class Archive {
   explicit Archive(const base::FilePath& path);
   virtual ~Archive();
 
+  // disable copy
+  Archive(const Archive&) = delete;
+  Archive& operator=(const Archive&) = delete;
+
   // Read and parse the header.
   bool Init();
 
@@ -108,8 +111,6 @@ class Archive {
   std::unordered_map<base::FilePath::StringType,
                      std::unique_ptr<ScopedTemporaryFile>>
       external_files_;
-
-  DISALLOW_COPY_AND_ASSIGN(Archive);
 };
 
 }  // namespace asar

--- a/shell/common/electron_command_line.h
+++ b/shell/common/electron_command_line.h
@@ -6,7 +6,6 @@
 #define SHELL_COMMON_ELECTRON_COMMAND_LINE_H_
 
 #include "base/command_line.h"
-#include "base/macros.h"
 #include "build/build_config.h"
 
 namespace electron {
@@ -14,6 +13,10 @@ namespace electron {
 // Singleton to remember the original "argc" and "argv".
 class ElectronCommandLine {
  public:
+  // disable copy
+  ElectronCommandLine(const ElectronCommandLine&) = delete;
+  ElectronCommandLine& operator=(const ElectronCommandLine&) = delete;
+
   static const base::CommandLine::StringVector& argv() { return argv_; }
 
   static void Init(int argc, base::CommandLine::CharType** argv);
@@ -26,8 +29,6 @@ class ElectronCommandLine {
 
  private:
   static base::CommandLine::StringVector argv_;
-
-  DISALLOW_IMPLICIT_CONSTRUCTORS(ElectronCommandLine);
 };
 
 }  // namespace electron

--- a/shell/common/extensions/electron_extensions_api_provider.h
+++ b/shell/common/extensions/electron_extensions_api_provider.h
@@ -7,7 +7,6 @@
 
 #include <string>
 
-#include "base/macros.h"
 #include "extensions/common/extensions_api_provider.h"
 
 namespace electron {
@@ -16,6 +15,11 @@ class ElectronExtensionsAPIProvider : public extensions::ExtensionsAPIProvider {
  public:
   ElectronExtensionsAPIProvider();
   ~ElectronExtensionsAPIProvider() override;
+
+  // disable copy
+  ElectronExtensionsAPIProvider(const ElectronExtensionsAPIProvider&) = delete;
+  ElectronExtensionsAPIProvider& operator=(
+      const ElectronExtensionsAPIProvider&) = delete;
 
   // ExtensionsAPIProvider:
   void AddAPIFeatures(extensions::FeatureProvider* provider) override;
@@ -29,9 +33,6 @@ class ElectronExtensionsAPIProvider : public extensions::ExtensionsAPIProvider {
   void RegisterPermissions(
       extensions::PermissionsInfo* permissions_info) override;
   void RegisterManifestHandlers() override;
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(ElectronExtensionsAPIProvider);
 };
 
 }  // namespace electron

--- a/shell/common/extensions/electron_extensions_client.cc
+++ b/shell/common/extensions/electron_extensions_client.cc
@@ -9,7 +9,6 @@
 
 #include "base/lazy_instance.h"
 #include "base/logging.h"
-#include "base/macros.h"
 #include "components/version_info/version_info.h"
 #include "content/public/common/user_agent.h"
 #include "extensions/common/core_extensions_api_provider.h"
@@ -33,6 +32,12 @@ class ElectronPermissionMessageProvider
   ElectronPermissionMessageProvider() = default;
   ~ElectronPermissionMessageProvider() override = default;
 
+  // disable copy
+  ElectronPermissionMessageProvider(const ElectronPermissionMessageProvider&) =
+      delete;
+  ElectronPermissionMessageProvider& operator=(
+      const ElectronPermissionMessageProvider&) = delete;
+
   // PermissionMessageProvider implementation.
   extensions::PermissionMessages GetPermissionMessages(
       const extensions::PermissionIDSet& permissions) const override {
@@ -53,9 +58,6 @@ class ElectronPermissionMessageProvider
       extensions::Manifest::Type extension_type) const override {
     return extensions::PermissionIDSet();
   }
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(ElectronPermissionMessageProvider);
 };
 
 base::LazyInstance<ElectronPermissionMessageProvider>::DestructorAtExit

--- a/shell/common/extensions/electron_extensions_client.h
+++ b/shell/common/extensions/electron_extensions_client.h
@@ -8,7 +8,6 @@
 #include <string>
 
 #include "base/compiler_specific.h"
-#include "base/macros.h"
 #include "extensions/common/extensions_client.h"
 #include "url/gurl.h"
 
@@ -29,6 +28,10 @@ class ElectronExtensionsClient : public extensions::ExtensionsClient {
 
   ElectronExtensionsClient();
   ~ElectronExtensionsClient() override;
+
+  // disable copy
+  ElectronExtensionsClient(const ElectronExtensionsClient&) = delete;
+  ElectronExtensionsClient& operator=(const ElectronExtensionsClient&) = delete;
 
   // ExtensionsClient overrides:
   void Initialize() override;
@@ -55,8 +58,6 @@ class ElectronExtensionsClient : public extensions::ExtensionsClient {
 
   const GURL webstore_base_url_;
   const GURL webstore_update_url_;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronExtensionsClient);
 };
 
 }  // namespace electron

--- a/shell/common/gin_helper/callback.cc
+++ b/shell/common/gin_helper/callback.cc
@@ -96,8 +96,6 @@ class RefCountedGlobal
 
  private:
   v8::Global<T> handle_;
-
-  DISALLOW_COPY_AND_ASSIGN(RefCountedGlobal);
 };
 
 SafeV8Function::SafeV8Function(v8::Isolate* isolate, v8::Local<v8::Value> value)

--- a/shell/common/gin_helper/event_emitter.h
+++ b/shell/common/gin_helper/event_emitter.h
@@ -71,6 +71,10 @@ class EventEmitter : public gin_helper::Wrappable<T> {
     return EmitWithEvent(name, event, std::forward<Args>(args)...);
   }
 
+  // disable copy
+  EventEmitter(const EventEmitter&) = delete;
+  EventEmitter& operator=(const EventEmitter&) = delete;
+
  protected:
   EventEmitter() {}
 
@@ -93,8 +97,6 @@ class EventEmitter : public gin_helper::Wrappable<T> {
     }
     return false;
   }
-
-  DISALLOW_COPY_AND_ASSIGN(EventEmitter);
 };
 
 }  // namespace gin_helper

--- a/shell/common/gin_helper/function_template.h
+++ b/shell/common/gin_helper/function_template.h
@@ -52,6 +52,10 @@ class CallbackHolderBase {
  public:
   v8::Local<v8::External> GetHandle(v8::Isolate* isolate);
 
+  // disable copy
+  CallbackHolderBase(const CallbackHolderBase&) = delete;
+  CallbackHolderBase& operator=(const CallbackHolderBase&) = delete;
+
  protected:
   explicit CallbackHolderBase(v8::Isolate* isolate);
   virtual ~CallbackHolderBase();
@@ -63,8 +67,6 @@ class CallbackHolderBase {
       const v8::WeakCallbackInfo<CallbackHolderBase>& data);
 
   v8::Global<v8::External> v8_ref_;
-
-  DISALLOW_COPY_AND_ASSIGN(CallbackHolderBase);
 };
 
 template <typename Sig>
@@ -79,8 +81,6 @@ class CallbackHolder : public CallbackHolderBase {
 
  private:
   virtual ~CallbackHolder() = default;
-
-  DISALLOW_COPY_AND_ASSIGN(CallbackHolder);
 };
 
 template <typename T>

--- a/shell/common/gin_helper/locker.h
+++ b/shell/common/gin_helper/locker.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 
-#include "base/macros.h"
 #include "v8/include/v8.h"
 
 namespace gin_helper {
@@ -18,6 +17,10 @@ class Locker {
   explicit Locker(v8::Isolate* isolate);
   ~Locker();
 
+  // disable copy
+  Locker(const Locker&) = delete;
+  Locker& operator=(const Locker&) = delete;
+
   // Returns whether current process is browser process, currently we detect it
   // by checking whether current has used V8 Lock, but it might be a bad idea.
   static inline bool IsBrowserProcess() { return v8::Locker::IsActive(); }
@@ -27,8 +30,6 @@ class Locker {
   void operator delete(void*, size_t);
 
   std::unique_ptr<v8::Locker> locker_;
-
-  DISALLOW_COPY_AND_ASSIGN(Locker);
 };
 
 }  // namespace gin_helper

--- a/shell/common/gin_helper/microtasks_scope.h
+++ b/shell/common/gin_helper/microtasks_scope.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 
-#include "base/macros.h"
 #include "v8/include/v8.h"
 
 namespace gin_helper {
@@ -22,10 +21,12 @@ class MicrotasksScope {
                                v8::MicrotasksScope::kRunMicrotasks);
   ~MicrotasksScope();
 
+  // disable copy
+  MicrotasksScope(const MicrotasksScope&) = delete;
+  MicrotasksScope& operator=(const MicrotasksScope&) = delete;
+
  private:
   std::unique_ptr<v8::MicrotasksScope> v8_microtasks_scope_;
-
-  DISALLOW_COPY_AND_ASSIGN(MicrotasksScope);
 };
 
 }  // namespace gin_helper

--- a/shell/common/gin_helper/promise.h
+++ b/shell/common/gin_helper/promise.h
@@ -33,6 +33,10 @@ class PromiseBase {
   PromiseBase(v8::Isolate* isolate, v8::Local<v8::Promise::Resolver> handle);
   ~PromiseBase();
 
+  // disable copy
+  PromiseBase(const PromiseBase&) = delete;
+  PromiseBase& operator=(const PromiseBase&) = delete;
+
   // Support moving.
   PromiseBase(PromiseBase&&);
   PromiseBase& operator=(PromiseBase&&);
@@ -75,8 +79,6 @@ class PromiseBase {
   v8::Isolate* isolate_;
   v8::Global<v8::Context> context_;
   v8::Global<v8::Promise::Resolver> resolver_;
-
-  DISALLOW_COPY_AND_ASSIGN(PromiseBase);
 };
 
 // Template implementation that returns values.

--- a/shell/common/gin_helper/trackable_object.cc
+++ b/shell/common/gin_helper/trackable_object.cc
@@ -25,8 +25,6 @@ class IDUserData : public base::SupportsUserData::Data {
 
  private:
   int32_t id_;
-
-  DISALLOW_COPY_AND_ASSIGN(IDUserData);
 };
 
 }  // namespace

--- a/shell/common/gin_helper/trackable_object.h
+++ b/shell/common/gin_helper/trackable_object.h
@@ -24,6 +24,10 @@ class TrackableObjectBase : public CleanedUpAtExit {
  public:
   TrackableObjectBase();
 
+  // disable copy
+  TrackableObjectBase(const TrackableObjectBase&) = delete;
+  TrackableObjectBase& operator=(const TrackableObjectBase&) = delete;
+
   // The ID in weak map.
   int32_t weak_map_id() const { return weak_map_id_; }
 
@@ -45,8 +49,6 @@ class TrackableObjectBase : public CleanedUpAtExit {
   void Destroy();
 
   base::WeakPtrFactory<TrackableObjectBase> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(TrackableObjectBase);
 };
 
 // All instances of TrackableObject will be kept in a weak map and can be got
@@ -125,8 +127,6 @@ class TrackableObject : public TrackableObjectBase, public EventEmitter<T> {
  private:
   static int32_t next_id_;
   static electron::KeyWeakMap<int32_t>* weak_map_;  // leaked on purpose
-
-  DISALLOW_COPY_AND_ASSIGN(TrackableObject);
 };
 
 template <typename T>

--- a/shell/common/gin_helper/wrappable.h
+++ b/shell/common/gin_helper/wrappable.h
@@ -67,8 +67,6 @@ class Wrappable : public WrappableBase {
 
  private:
   static gin::WrapperInfo kWrapperInfo;
-
-  DISALLOW_COPY_AND_ASSIGN(Wrappable);
 };
 
 // static

--- a/shell/common/key_weak_map.h
+++ b/shell/common/key_weak_map.h
@@ -9,7 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/macros.h"
 #include "v8/include/v8.h"
 
 namespace electron {
@@ -29,6 +28,10 @@ class KeyWeakMap {
     for (auto& p : map_)
       p.second.second.ClearWeak();
   }
+
+  // disable copy
+  KeyWeakMap(const KeyWeakMap&) = delete;
+  KeyWeakMap& operator=(const KeyWeakMap&) = delete;
 
   // Sets the object to WeakMap with the given |key|.
   void Set(v8::Isolate* isolate, const K& key, v8::Local<v8::Object> object) {
@@ -78,8 +81,6 @@ class KeyWeakMap {
 
   // Map of stored objects.
   std::unordered_map<K, std::pair<KeyObject, v8::Global<v8::Object>>> map_;
-
-  DISALLOW_COPY_AND_ASSIGN(KeyWeakMap);
 };
 
 }  // namespace electron

--- a/shell/common/node_bindings.h
+++ b/shell/common/node_bindings.h
@@ -8,7 +8,6 @@
 #include <type_traits>
 
 #include "base/files/file_path.h"
-#include "base/macros.h"
 #include "base/memory/weak_ptr.h"
 #include "uv.h"  // NOLINT(build/include_directory)
 #include "v8/include/v8.h"
@@ -109,6 +108,10 @@ class NodeBindings {
 
   bool in_worker_loop() const { return uv_loop_ == &worker_loop_; }
 
+  // disable copy
+  NodeBindings(const NodeBindings&) = delete;
+  NodeBindings& operator=(const NodeBindings&) = delete;
+
  protected:
   explicit NodeBindings(BrowserEnvironment browser_env);
 
@@ -163,8 +166,6 @@ class NodeBindings {
 #endif
 
   base::WeakPtrFactory<NodeBindings> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(NodeBindings);
 };
 
 }  // namespace electron

--- a/shell/common/node_bindings_linux.h
+++ b/shell/common/node_bindings_linux.h
@@ -25,8 +25,6 @@ class NodeBindingsLinux : public NodeBindings {
 
   // Epoll to poll for uv's backend fd.
   int epoll_;
-
-  DISALLOW_COPY_AND_ASSIGN(NodeBindingsLinux);
 };
 
 }  // namespace electron

--- a/shell/common/node_bindings_mac.h
+++ b/shell/common/node_bindings_mac.h
@@ -22,8 +22,6 @@ class NodeBindingsMac : public NodeBindings {
   static void OnWatcherQueueChanged(uv_loop_t* loop);
 
   void PollEvents() override;
-
-  DISALLOW_COPY_AND_ASSIGN(NodeBindingsMac);
 };
 
 }  // namespace electron

--- a/shell/common/node_bindings_win.h
+++ b/shell/common/node_bindings_win.h
@@ -17,8 +17,6 @@ class NodeBindingsWin : public NodeBindings {
 
  private:
   void PollEvents() override;
-
-  DISALLOW_COPY_AND_ASSIGN(NodeBindingsWin);
 };
 
 }  // namespace electron

--- a/shell/common/v8_value_converter.cc
+++ b/shell/common/v8_value_converter.cc
@@ -112,6 +112,10 @@ class V8ValueConverter::ScopedUniquenessGuard {
     }
   }
 
+  // disable copy
+  ScopedUniquenessGuard(const ScopedUniquenessGuard&) = delete;
+  ScopedUniquenessGuard& operator=(const ScopedUniquenessGuard&) = delete;
+
   bool is_valid() const { return is_valid_; }
 
  private:
@@ -119,8 +123,6 @@ class V8ValueConverter::ScopedUniquenessGuard {
   V8ValueConverter::FromV8ValueState* state_;
   v8::Local<v8::Object> value_;
   bool is_valid_;
-
-  DISALLOW_COPY_AND_ASSIGN(ScopedUniquenessGuard);
 };
 
 V8ValueConverter::V8ValueConverter() = default;

--- a/shell/common/v8_value_converter.h
+++ b/shell/common/v8_value_converter.h
@@ -8,7 +8,6 @@
 #include <memory>
 
 #include "base/compiler_specific.h"
-#include "base/macros.h"
 #include "v8/include/v8.h"
 
 namespace base {
@@ -22,6 +21,10 @@ namespace electron {
 class V8ValueConverter {
  public:
   V8ValueConverter();
+
+  // disable copy
+  V8ValueConverter(const V8ValueConverter&) = delete;
+  V8ValueConverter& operator=(const V8ValueConverter&) = delete;
 
   void SetRegExpAllowed(bool val);
   void SetFunctionAllowed(bool val);
@@ -68,8 +71,6 @@ class V8ValueConverter {
   // If true, undefined and null values are ignored when converting v8 objects
   // into Values.
   bool strip_null_from_objects_ = false;
-
-  DISALLOW_COPY_AND_ASSIGN(V8ValueConverter);
 };
 
 }  // namespace electron

--- a/shell/renderer/api/electron_api_context_bridge.cc
+++ b/shell/renderer/api/electron_api_context_bridge.cc
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "base/feature_list.h"
+#include "base/macros.h"
 #include "base/no_destructor.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/trace_event/trace_event.h"

--- a/shell/renderer/api/electron_api_spell_check_client.h
+++ b/shell/renderer/api/electron_api_spell_check_client.h
@@ -36,6 +36,10 @@ class SpellCheckClient : public blink::WebSpellCheckPanelHostClient,
                    v8::Local<v8::Object> provider);
   ~SpellCheckClient() override;
 
+  // disable copy
+  SpellCheckClient(const SpellCheckClient&) = delete;
+  SpellCheckClient& operator=(const SpellCheckClient&) = delete;
+
  private:
   class SpellcheckRequest;
   // blink::WebTextCheckClient:
@@ -103,8 +107,6 @@ class SpellCheckClient : public blink::WebSpellCheckPanelHostClient,
   v8::Global<v8::Context> context_;
   v8::Global<v8::Object> provider_;
   v8::Global<v8::Function> spell_check_;
-
-  DISALLOW_COPY_AND_ASSIGN(SpellCheckClient);
 };
 
 }  // namespace api

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -147,6 +147,10 @@ class ScriptExecutionCallback : public blink::WebScriptExecutionCallback {
 
   ~ScriptExecutionCallback() override = default;
 
+  // disable copy
+  ScriptExecutionCallback(const ScriptExecutionCallback&) = delete;
+  ScriptExecutionCallback& operator=(const ScriptExecutionCallback&) = delete;
+
   void CopyResultToCallingContextAndFinalize(
       v8::Isolate* isolate,
       const v8::Local<v8::Object>& result) {
@@ -248,8 +252,6 @@ class ScriptExecutionCallback : public blink::WebScriptExecutionCallback {
  private:
   gin_helper::Promise<v8::Local<v8::Value>> promise_;
   CompletionCallback callback_;
-
-  DISALLOW_COPY_AND_ASSIGN(ScriptExecutionCallback);
 };
 
 class FrameSetSpellChecker : public content::RenderFrameVisitor {
@@ -260,6 +262,10 @@ class FrameSetSpellChecker : public content::RenderFrameVisitor {
     content::RenderFrame::ForEach(this);
     main_frame->GetWebFrame()->SetSpellCheckPanelHostClient(spell_check_client);
   }
+
+  // disable copy
+  FrameSetSpellChecker(const FrameSetSpellChecker&) = delete;
+  FrameSetSpellChecker& operator=(const FrameSetSpellChecker&) = delete;
 
   bool Visit(content::RenderFrame* render_frame) override {
     if (render_frame->GetMainRenderFrame() == main_frame_ ||
@@ -272,8 +278,6 @@ class FrameSetSpellChecker : public content::RenderFrameVisitor {
  private:
   SpellCheckClient* spell_check_client_;
   content::RenderFrame* main_frame_;
-
-  DISALLOW_COPY_AND_ASSIGN(FrameSetSpellChecker);
 };
 
 class SpellCheckerHolder final : public content::RenderFrameObserver {

--- a/shell/renderer/content_settings_observer.h
+++ b/shell/renderer/content_settings_observer.h
@@ -17,14 +17,16 @@ class ContentSettingsObserver : public content::RenderFrameObserver,
   explicit ContentSettingsObserver(content::RenderFrame* render_frame);
   ~ContentSettingsObserver() override;
 
+  // disable copy
+  ContentSettingsObserver(const ContentSettingsObserver&) = delete;
+  ContentSettingsObserver& operator=(const ContentSettingsObserver&) = delete;
+
   // blink::WebContentSettingsClient implementation.
   bool AllowStorageAccessSync(StorageType storage_type) override;
 
  private:
   // content::RenderFrameObserver implementation.
   void OnDestruct() override;
-
-  DISALLOW_COPY_AND_ASSIGN(ContentSettingsObserver);
 };
 
 }  // namespace electron

--- a/shell/renderer/electron_api_service_impl.h
+++ b/shell/renderer/electron_api_service_impl.h
@@ -26,6 +26,10 @@ class ElectronApiServiceImpl : public mojom::ElectronRenderer,
                          RendererClientBase* renderer_client);
   ~ElectronApiServiceImpl() override;
 
+  // disable copy
+  ElectronApiServiceImpl(const ElectronApiServiceImpl&) = delete;
+  ElectronApiServiceImpl& operator=(const ElectronApiServiceImpl&) = delete;
+
   void BindTo(mojo::PendingReceiver<mojom::ElectronRenderer> receiver);
 
   void Message(bool internal,
@@ -62,8 +66,6 @@ class ElectronApiServiceImpl : public mojom::ElectronRenderer,
 
   RendererClientBase* renderer_client_;
   base::WeakPtrFactory<ElectronApiServiceImpl> weak_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronApiServiceImpl);
 };
 
 }  // namespace electron

--- a/shell/renderer/electron_autofill_agent.h
+++ b/shell/renderer/electron_autofill_agent.h
@@ -29,6 +29,10 @@ class AutofillAgent : public content::RenderFrameObserver,
                          blink::AssociatedInterfaceRegistry* registry);
   ~AutofillAgent() override;
 
+  // disable copy
+  AutofillAgent(const AutofillAgent&) = delete;
+  AutofillAgent& operator=(const AutofillAgent&) = delete;
+
   void BindReceiver(
       mojo::PendingAssociatedReceiver<mojom::ElectronAutofillAgent> receiver);
 
@@ -85,8 +89,6 @@ class AutofillAgent : public content::RenderFrameObserver,
   mojo::AssociatedReceiver<mojom::ElectronAutofillAgent> receiver_{this};
 
   base::WeakPtrFactory<AutofillAgent> weak_ptr_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(AutofillAgent);
 };
 
 }  // namespace electron

--- a/shell/renderer/electron_render_frame_observer.h
+++ b/shell/renderer/electron_render_frame_observer.h
@@ -21,6 +21,11 @@ class ElectronRenderFrameObserver : public content::RenderFrameObserver {
   ElectronRenderFrameObserver(content::RenderFrame* frame,
                               RendererClientBase* renderer_client);
 
+  // disable copy
+  ElectronRenderFrameObserver(const ElectronRenderFrameObserver&) = delete;
+  ElectronRenderFrameObserver& operator=(const ElectronRenderFrameObserver&) =
+      delete;
+
   // content::RenderFrameObserver:
   void DidClearWindowObject() override;
   void DidInstallConditionalFeatures(v8::Handle<v8::Context> context,
@@ -41,8 +46,6 @@ class ElectronRenderFrameObserver : public content::RenderFrameObserver {
 
   content::RenderFrame* render_frame_;
   RendererClientBase* renderer_client_;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronRenderFrameObserver);
 };
 
 }  // namespace electron

--- a/shell/renderer/electron_renderer_client.h
+++ b/shell/renderer/electron_renderer_client.h
@@ -25,6 +25,10 @@ class ElectronRendererClient : public RendererClientBase {
   ElectronRendererClient();
   ~ElectronRendererClient() override;
 
+  // disable copy
+  ElectronRendererClient(const ElectronRendererClient&) = delete;
+  ElectronRendererClient& operator=(const ElectronRendererClient&) = delete;
+
   // electron::RendererClientBase:
   void DidCreateScriptContext(v8::Handle<v8::Context> context,
                               content::RenderFrame* render_frame) override;
@@ -58,8 +62,6 @@ class ElectronRendererClient : public RendererClientBase {
   // its script context. Doing so in a web page without scripts would trigger
   // assertion, so we have to keep a book of injected web frames.
   std::set<content::RenderFrame*> injected_frames_;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronRendererClient);
 };
 
 }  // namespace electron

--- a/shell/renderer/electron_renderer_pepper_host_factory.h
+++ b/shell/renderer/electron_renderer_pepper_host_factory.h
@@ -8,7 +8,6 @@
 #include <memory>
 
 #include "base/compiler_specific.h"
-#include "base/macros.h"
 #include "ppapi/host/host_factory.h"
 
 namespace content {
@@ -20,6 +19,12 @@ class ElectronRendererPepperHostFactory : public ppapi::host::HostFactory {
   explicit ElectronRendererPepperHostFactory(content::RendererPpapiHost* host);
   ~ElectronRendererPepperHostFactory() override;
 
+  // disable copy
+  ElectronRendererPepperHostFactory(const ElectronRendererPepperHostFactory&) =
+      delete;
+  ElectronRendererPepperHostFactory& operator=(
+      const ElectronRendererPepperHostFactory&) = delete;
+
   // HostFactory.
   std::unique_ptr<ppapi::host::ResourceHost> CreateResourceHost(
       ppapi::host::PpapiHost* host,
@@ -30,8 +35,6 @@ class ElectronRendererPepperHostFactory : public ppapi::host::HostFactory {
  private:
   // Not owned by this object.
   content::RendererPpapiHost* host_;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronRendererPepperHostFactory);
 };
 
 #endif  // SHELL_RENDERER_ELECTRON_RENDERER_PEPPER_HOST_FACTORY_H_

--- a/shell/renderer/electron_sandboxed_renderer_client.cc
+++ b/shell/renderer/electron_sandboxed_renderer_client.cc
@@ -9,6 +9,7 @@
 #include "base/base_paths.h"
 #include "base/command_line.h"
 #include "base/files/file_path.h"
+#include "base/macros.h"
 #include "base/path_service.h"
 #include "base/process/process_handle.h"
 #include "base/process/process_metrics.h"

--- a/shell/renderer/electron_sandboxed_renderer_client.h
+++ b/shell/renderer/electron_sandboxed_renderer_client.h
@@ -25,6 +25,12 @@ class ElectronSandboxedRendererClient : public RendererClientBase {
   ElectronSandboxedRendererClient();
   ~ElectronSandboxedRendererClient() override;
 
+  // disable copy
+  ElectronSandboxedRendererClient(const ElectronSandboxedRendererClient&) =
+      delete;
+  ElectronSandboxedRendererClient& operator=(
+      const ElectronSandboxedRendererClient&) = delete;
+
   void InitializeBindings(v8::Local<v8::Object> binding,
                           v8::Local<v8::Context> context,
                           content::RenderFrame* render_frame);
@@ -45,8 +51,6 @@ class ElectronSandboxedRendererClient : public RendererClientBase {
   // its script context. Doing so in a web page without scripts would trigger
   // assertion, so we have to keep a book of injected web frames.
   std::set<content::RenderFrame*> injected_frames_;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronSandboxedRendererClient);
 };
 
 }  // namespace electron

--- a/shell/renderer/extensions/electron_extensions_dispatcher_delegate.h
+++ b/shell/renderer/extensions/electron_extensions_dispatcher_delegate.h
@@ -8,7 +8,6 @@
 #include <set>
 #include <string>
 
-#include "base/macros.h"
 #include "extensions/renderer/dispatcher_delegate.h"
 
 class ElectronExtensionsDispatcherDelegate
@@ -16,6 +15,12 @@ class ElectronExtensionsDispatcherDelegate
  public:
   ElectronExtensionsDispatcherDelegate();
   ~ElectronExtensionsDispatcherDelegate() override;
+
+  // disable copy
+  ElectronExtensionsDispatcherDelegate(
+      const ElectronExtensionsDispatcherDelegate&) = delete;
+  ElectronExtensionsDispatcherDelegate& operator=(
+      const ElectronExtensionsDispatcherDelegate&) = delete;
 
  private:
   // extensions::DispatcherDelegate implementation.
@@ -32,8 +37,6 @@ class ElectronExtensionsDispatcherDelegate
   void InitializeBindingsSystem(
       extensions::Dispatcher* dispatcher,
       extensions::NativeExtensionBindingsSystem* bindings_system) override;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronExtensionsDispatcherDelegate);
 };
 
 #endif  // SHELL_RENDERER_EXTENSIONS_ELECTRON_EXTENSIONS_DISPATCHER_DELEGATE_H_

--- a/shell/renderer/extensions/electron_extensions_renderer_client.h
+++ b/shell/renderer/extensions/electron_extensions_renderer_client.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 
-#include "base/macros.h"
 #include "extensions/renderer/extensions_renderer_client.h"
 
 namespace content {
@@ -26,6 +25,12 @@ class ElectronExtensionsRendererClient
   ElectronExtensionsRendererClient();
   ~ElectronExtensionsRendererClient() override;
 
+  // disable copy
+  ElectronExtensionsRendererClient(const ElectronExtensionsRendererClient&) =
+      delete;
+  ElectronExtensionsRendererClient& operator=(
+      const ElectronExtensionsRendererClient&) = delete;
+
   // ExtensionsRendererClient implementation.
   bool IsIncognitoProcess() const override;
   int GetLowestIsolatedWorldId() const override;
@@ -42,8 +47,6 @@ class ElectronExtensionsRendererClient
 
  private:
   std::unique_ptr<extensions::Dispatcher> dispatcher_;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronExtensionsRendererClient);
 };
 
 }  // namespace electron

--- a/shell/renderer/guest_view_container.h
+++ b/shell/renderer/guest_view_container.h
@@ -24,6 +24,10 @@ class GuestViewContainer {
   explicit GuestViewContainer(content::RenderFrame* render_frame);
   virtual ~GuestViewContainer();
 
+  // disable copy
+  GuestViewContainer(const GuestViewContainer&) = delete;
+  GuestViewContainer& operator=(const GuestViewContainer&) = delete;
+
   static GuestViewContainer* FromID(int element_instance_id);
 
   void RegisterElementResizeCallback(const ResizeCallback& callback);
@@ -36,8 +40,6 @@ class GuestViewContainer {
   ResizeCallback element_resize_callback_;
 
   base::WeakPtrFactory<GuestViewContainer> weak_ptr_factory_{this};
-
-  DISALLOW_COPY_AND_ASSIGN(GuestViewContainer);
 };
 
 }  // namespace electron

--- a/shell/renderer/pepper_helper.h
+++ b/shell/renderer/pepper_helper.h
@@ -7,7 +7,6 @@
 
 #include "base/compiler_specific.h"
 #include "base/component_export.h"
-#include "base/macros.h"
 #include "content/public/renderer/render_frame_observer.h"
 
 // This class listens for Pepper creation events from the RenderFrame and
@@ -17,12 +16,13 @@ class PepperHelper : public content::RenderFrameObserver {
   explicit PepperHelper(content::RenderFrame* render_frame);
   ~PepperHelper() override;
 
+  // disable copy
+  PepperHelper(const PepperHelper&) = delete;
+  PepperHelper& operator=(const PepperHelper&) = delete;
+
   // RenderFrameObserver.
   void DidCreatePepperPlugin(content::RendererPpapiHost* host) override;
   void OnDestruct() override;
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(PepperHelper);
 };
 
 #endif  // SHELL_RENDERER_PEPPER_HELPER_H_

--- a/shell/renderer/printing/print_render_frame_helper_delegate.h
+++ b/shell/renderer/printing/print_render_frame_helper_delegate.h
@@ -5,7 +5,6 @@
 #ifndef SHELL_RENDERER_PRINTING_PRINT_RENDER_FRAME_HELPER_DELEGATE_H_
 #define SHELL_RENDERER_PRINTING_PRINT_RENDER_FRAME_HELPER_DELEGATE_H_
 
-#include "base/macros.h"
 #include "components/printing/renderer/print_render_frame_helper.h"
 
 namespace electron {
@@ -16,13 +15,17 @@ class PrintRenderFrameHelperDelegate
   PrintRenderFrameHelperDelegate();
   ~PrintRenderFrameHelperDelegate() override;
 
+  // disable copy
+  PrintRenderFrameHelperDelegate(const PrintRenderFrameHelperDelegate&) =
+      delete;
+  PrintRenderFrameHelperDelegate& operator=(
+      const PrintRenderFrameHelperDelegate&) = delete;
+
  private:
   // printing::PrintRenderFrameHelper::Delegate:
   blink::WebElement GetPdfElement(blink::WebLocalFrame* frame) override;
   bool IsPrintPreviewEnabled() override;
   bool OverridePrint(blink::WebLocalFrame* frame) override;
-
-  DISALLOW_COPY_AND_ASSIGN(PrintRenderFrameHelperDelegate);
 };
 
 }  // namespace electron

--- a/shell/renderer/web_worker_observer.h
+++ b/shell/renderer/web_worker_observer.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 
-#include "base/macros.h"
 #include "v8/include/v8.h"
 
 namespace electron {
@@ -21,6 +20,10 @@ class WebWorkerObserver {
   // Returns the WebWorkerObserver for current worker thread.
   static WebWorkerObserver* GetCurrent();
 
+  // disable copy
+  WebWorkerObserver(const WebWorkerObserver&) = delete;
+  WebWorkerObserver& operator=(const WebWorkerObserver&) = delete;
+
   void WorkerScriptReadyForEvaluation(v8::Local<v8::Context> context);
   void ContextWillDestroy(v8::Local<v8::Context> context);
 
@@ -30,8 +33,6 @@ class WebWorkerObserver {
 
   std::unique_ptr<NodeBindings> node_bindings_;
   std::unique_ptr<ElectronBindings> electron_bindings_;
-
-  DISALLOW_COPY_AND_ASSIGN(WebWorkerObserver);
 };
 
 }  // namespace electron

--- a/shell/utility/electron_content_utility_client.h
+++ b/shell/utility/electron_content_utility_client.h
@@ -27,6 +27,11 @@ class ElectronContentUtilityClient : public content::ContentUtilityClient {
   ElectronContentUtilityClient();
   ~ElectronContentUtilityClient() override;
 
+  // disable copy
+  ElectronContentUtilityClient(const ElectronContentUtilityClient&) = delete;
+  ElectronContentUtilityClient& operator=(const ElectronContentUtilityClient&) =
+      delete;
+
   void ExposeInterfacesToBrowser(mojo::BinderMap* binders) override;
   void RegisterMainThreadServices(mojo::ServiceFactory& services) override;
   void RegisterIOThreadServices(mojo::ServiceFactory& services) override;
@@ -38,8 +43,6 @@ class ElectronContentUtilityClient : public content::ContentUtilityClient {
 
   // True if the utility process runs with elevated privileges.
   bool utility_process_running_elevated_ = false;
-
-  DISALLOW_COPY_AND_ASSIGN(ElectronContentUtilityClient);
 };
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change
Replace deprecated `DISALLOW_COPY_AND_ASSIGN` macros.
https://source.chromium.org/chromium/chromium/src/+/main:base/macros.h
https://bugs.chromium.org/p/chromium/issues/detail?id=1010217

In case where we own the base class and it's already non-copyable, we don't need to specify that again for a subclass.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none