### PR TITLE
test: fix test-datetime-change-notify after daylight change

### DIFF
--- a/patches/node/.patches
+++ b/patches/node/.patches
@@ -24,3 +24,4 @@ repl_fix_crash_when_sharedarraybuffer_disabled.patch
 fix_readbarrier_undefined_symbol_error_on_woa_arm64.patch
 chore_fix_-wimplicit-fallthrough.patch
 fix_event_with_invalid_timestamp_in_trace_log.patch
+test_fix_test-datetime-change-notify_after_daylight_change.patch

--- a/patches/node/test_fix_test-datetime-change-notify_after_daylight_change.patch
+++ b/patches/node/test_fix_test-datetime-change-notify_after_daylight_change.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Piotr Rybak <rybak.piotr@yahoo.com>
+Date: Sun, 31 Oct 2021 17:58:09 +0900
+Subject: test: fix test-datetime-change-notify after daylight change
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add standard timezone name for Dublin without daylight saving
+
+PR-URL: https://github.com/nodejs/node/pull/40684
+Reviewed-By: Michaël Zasso <targos@protonmail.com>
+Reviewed-By: Tobias Nießen <tniessen@tnie.de>
+Reviewed-By: Voltrex <mohammadkeyvanzade94@gmail.com>
+(cherry picked from commit 747ef34fb0c9c1f2924ab1b79ea000c87e67a8eb)
+
+diff --git a/test/parallel/test-datetime-change-notify.js b/test/parallel/test-datetime-change-notify.js
+index 9cd6d7abfd898ac6781b04422362a6b459b7dc2c..01843511907077857be22c9bc7e7f8568fc677d1 100644
+--- a/test/parallel/test-datetime-change-notify.js
++++ b/test/parallel/test-datetime-change-notify.js
+@@ -18,15 +18,15 @@ const cases = [
+   },
+   {
+     timeZone: 'America/New_York',
+-    expected: /Eastern (Standard|Daylight) Time/,
++    expected: /Eastern (?:Standard|Daylight) Time/,
+   },
+   {
+     timeZone: 'America/Los_Angeles',
+-    expected: /Pacific (Standard|Daylight) Time/,
++    expected: /Pacific (?:Standard|Daylight) Time/,
+   },
+   {
+     timeZone: 'Europe/Dublin',
+-    expected: /Irish/,
++    expected: /Irish Standard Time|Greenwich Mean Time/,
+   },
+ ];
+ 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
The node test `parallel/test-datetime-change-notify` started failing recently due to a daylight savings change.  This PR backports https://github.com/nodejs/node/commit/747ef34fb0c9c1f2924ab1b79ea000c87e67a8eb to fix that issue.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
