### PR TITLE
chore: cherry-pick feef10137b16 from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -18,3 +18,4 @@ regexp_allow_reentrant_irregexp_execution.patch
 regexp_remove_the_stack_parameter_from_regexp_matchers.patch
 cherry-pick-5c4acf2ae64a.patch
 cherry-pick-6de4e210688e.patch
+cherry-pick-feef10137b16.patch

--- a/patches/v8/cherry-pick-feef10137b16.patch
+++ b/patches/v8/cherry-pick-feef10137b16.patch
@@ -1,0 +1,34 @@
+From feef10137b16a4105f12ea88d7a850a8250b3c4a Mon Sep 17 00:00:00 2001
+From: Toon Verwaest <verwaest@chromium.org>
+Date: Wed, 27 Oct 2021 11:02:06 +0200
+Subject: [PATCH] Merged: [runtime] Check if we have a pending exception before returning it
+
+Revision: be55c16e50e714475034b00ed2682f0813794d15
+
+BUG=chromium:1263462
+NOTRY=true
+NOPRESUBMIT=true
+NOTREECHECKS=true
+R=cbruni@chromium.org
+
+Change-Id: Ib7de676fe614403674fcd2745c574f7e91ded23f
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3247033
+Reviewed-by: Camillo Bruni <cbruni@chromium.org>
+Cr-Commit-Position: refs/branch-heads/9.4@{#52}
+Cr-Branched-From: 3b51863bc25492549a8bf96ff67ce481b1a3337b-refs/heads/9.4.146@{#1}
+Cr-Branched-From: 2890419fc8fb9bdb507fdd801d76fa7dd9f022b5-refs/heads/master@{#76233}
+---
+
+diff --git a/src/execution/isolate-inl.h b/src/execution/isolate-inl.h
+index 63f9ea5..48950b6 100644
+--- a/src/execution/isolate-inl.h
++++ b/src/execution/isolate-inl.h
+@@ -50,7 +50,7 @@
+ }
+ 
+ Object Isolate::pending_exception() {
+-  DCHECK(has_pending_exception());
++  CHECK(has_pending_exception());
+   DCHECK(!thread_local_top()->pending_exception_.IsException(this));
+   return thread_local_top()->pending_exception_;
+ }

--- a/patches/v8/cherry-pick-feef10137b16.patch
+++ b/patches/v8/cherry-pick-feef10137b16.patch
@@ -1,7 +1,8 @@
-From feef10137b16a4105f12ea88d7a850a8250b3c4a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Toon Verwaest <verwaest@chromium.org>
 Date: Wed, 27 Oct 2021 11:02:06 +0200
-Subject: [PATCH] Merged: [runtime] Check if we have a pending exception before returning it
+Subject: Merged: [runtime] Check if we have a pending exception before
+ returning it
 
 Revision: be55c16e50e714475034b00ed2682f0813794d15
 
@@ -17,13 +18,12 @@ Reviewed-by: Camillo Bruni <cbruni@chromium.org>
 Cr-Commit-Position: refs/branch-heads/9.4@{#52}
 Cr-Branched-From: 3b51863bc25492549a8bf96ff67ce481b1a3337b-refs/heads/9.4.146@{#1}
 Cr-Branched-From: 2890419fc8fb9bdb507fdd801d76fa7dd9f022b5-refs/heads/master@{#76233}
----
 
 diff --git a/src/execution/isolate-inl.h b/src/execution/isolate-inl.h
-index 63f9ea5..48950b6 100644
+index 96ea770e65b48dbecf7422b49ef4f8d2f0cfe2d0..3486925aed54f03db13554763a6146134e83d2bb 100644
 --- a/src/execution/isolate-inl.h
 +++ b/src/execution/isolate-inl.h
-@@ -50,7 +50,7 @@
+@@ -35,7 +35,7 @@ NativeContext Isolate::raw_native_context() {
  }
  
  Object Isolate::pending_exception() {


### PR DESCRIPTION
Merged: [runtime] Check if we have a pending exception before returning it

Revision: be55c16e50e714475034b00ed2682f0813794d15

BUG=chromium:1263462
NOTRY=true
NOPRESUBMIT=true
NOTREECHECKS=true
R=cbruni@chromium.org

Change-Id: Ib7de676fe614403674fcd2745c574f7e91ded23f
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3247033
Reviewed-by: Camillo Bruni <cbruni@chromium.org>
Cr-Commit-Position: refs/branch-heads/9.4@{#52}
Cr-Branched-From: 3b51863bc25492549a8bf96ff67ce481b1a3337b-refs/heads/9.4.146@{#1}
Cr-Branched-From: 2890419fc8fb9bdb507fdd801d76fa7dd9f022b5-refs/heads/master@{#76233}


Notes: Backported fix for CVE-2021-38003.