### PR TITLE
fix: crash dump location on Linux

### DIFF
--- a/shell/app/electron_main_delegate.cc
+++ b/shell/app/electron_main_delegate.cc
@@ -127,11 +127,7 @@ bool ElectronPathProvider(int key, base::FilePath* result) {
     case DIR_CRASH_DUMPS:
       if (!base::PathService::Get(chrome::DIR_USER_DATA, &cur))
         return false;
-#if defined(OS_MAC) || defined(OS_WIN)
       cur = cur.Append(FILE_PATH_LITERAL("Crashpad"));
-#else
-      cur = cur.Append(FILE_PATH_LITERAL("Crash Reports"));
-#endif
       create_dir = true;
       break;
     case chrome::DIR_APP_DICTIONARIES:

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -559,7 +559,7 @@ void ElectronBrowserClient::AppendExtraCommandLineSwitches(
     enable_crash_reporter = breakpad::IsCrashReporterEnabled();
   }
 
-  if (enable_crash_reporter) {
+  if (enable_crash_reporter && process_type != ::switches::kZygoteProcess) {
     std::string switch_value =
         api::crash_reporter::GetClientId() + ",no_channel";
     command_line->AppendSwitchASCII(::switches::kEnableCrashReporter,

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -559,6 +559,10 @@ void ElectronBrowserClient::AppendExtraCommandLineSwitches(
     enable_crash_reporter = breakpad::IsCrashReporterEnabled();
   }
 
+  // Zygote Process gets booted before any JS runs, accessing GetClientId
+  // will end up touching DIR_USER_DATA path provider and this will
+  // configure default value because app.name from browser_init has
+  // not run yet.
   if (enable_crash_reporter && process_type != ::switches::kZygoteProcess) {
     std::string switch_value =
         api::crash_reporter::GetClientId() + ",no_channel";


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/31643.
Closes https://github.com/electron/electron/issues/31565

Refs https://github.com/electron/electron/pull/30278 - now that Electron has switched to Crashpad by default on Linux `DIR_CRASH_DUMPS` should be the same across supported platforms.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes:  Fixed an issue where `app.getPath('crashDumps')` returned an incorrect path for Linux.