### PR TITLE
fix: incorrect Content-Disposition serialization

### DIFF
--- a/shell/browser/api/electron_api_web_request.cc
+++ b/shell/browser/api/electron_api_web_request.cc
@@ -133,8 +133,10 @@ v8::Local<v8::Value> HttpResponseHeadersToV8(
         net::HttpContentDisposition header(value, std::string());
         std::string decodedFilename =
             header.is_attachment() ? " attachment" : " inline";
-        decodedFilename += "; filename=" + header.filename();
-        value = decodedFilename;
+        // The filename must be encased in double quotes for serialization
+        // to happen correctly.
+        std::string filename = "\"" + header.filename() + "\"";
+        value = decodedFilename + "; filename=" + filename;
       }
       if (!values)
         values = response_headers.SetKey(key, base::ListValue());

--- a/spec-main/api-web-request-spec.ts
+++ b/spec-main/api-web-request-spec.ts
@@ -354,7 +354,7 @@ describe('webRequest module', () => {
 
     it('does not change content-disposition header by default', async () => {
       ses.webRequest.onHeadersReceived((details, callback) => {
-        expect(details.responseHeaders!['content-disposition']).to.deep.equal([' attachment; filename=aa中aa.txt']);
+        expect(details.responseHeaders!['content-disposition']).to.deep.equal([' attachment; filename="aa中aa.txt"']);
         callback({});
       });
       const { data, headers } = await ajax(defaultURL + 'contentDisposition');


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/31662.
Refs https://github.com/electron/electron/pull/25961.

Fixes an issue where `Content-Disposition` filenames would be incorrectly truncated at the first comma for filename attachments which contained one. This was happening becuase the filename in the parse `net::HttpContentDisposition` header was not being correctly wrapped in double quotes, thereby breaking serialization.

Tested with the repro provided in the above linked issue:

<details>
<summary>Before</summary>
<img width="953" alt="Screen Shot 2021-11-02 at 2 35 19 PM" src="https://user-images.githubusercontent.com/2036040/139857313-727df57c-df9f-4ecc-b6aa-c99379715c53.png">
</details>

<details>
<summary>After</summary>
<img width="953" alt="Screen Shot 2021-11-02 at 2 31 23 PM" src="https://user-images.githubusercontent.com/2036040/139857332-66007b42-b272-4218-983c-e341288c1ca4.png">
</details>

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue where `Content-Disposition` filenames would be incorrectly truncated at the first comma for a filename attachment which contained one. 
