### PR TITLE
chore: cherry-pick 45f9dcf5021d from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -118,3 +118,4 @@ speculative_fix_for_eye_dropper_getcolor_crash.patch
 cherry-pick-0894af410c4e.patch
 move_networkstateobserver_from_document_to_window.patch
 cherry-pick-8af66de55aad.patch
+cherry-pick-45f9dcf5021d.patch

--- a/patches/chromium/cherry-pick-45f9dcf5021d.patch
+++ b/patches/chromium/cherry-pick-45f9dcf5021d.patch
@@ -1,0 +1,52 @@
+From 45f9dcf5021da2f53812c769ec67f033a636b9cc Mon Sep 17 00:00:00 2001
+From: Victor Vasiliev <vasilvv@chromium.org>
+Date: Tue, 26 Oct 2021 04:50:35 +0000
+Subject: [PATCH] Disable QuicTransport explicitly in the Network Service
+
+(cherry picked from commit b1997bdadcda9738a19773f82605f65832acedac)
+
+Bug: 1260940
+Change-Id: I6689fbce8115eda19e68414d7c03691704749b17
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3242207
+Auto-Submit: Victor Vasiliev <vasilvv@chromium.org>
+Commit-Queue: Yutaka Hirano <yhirano@chromium.org>
+Reviewed-by: Yutaka Hirano <yhirano@chromium.org>
+Cr-Commit-Position: refs/branch-heads/4606@{#1411}
+Cr-Branched-From: 35b0d5a9dc8362adfd44e2614f0d5b7402ef63d0-refs/heads/master@{#911515}
+---
+
+diff --git a/services/network/web_transport.cc b/services/network/web_transport.cc
+index 8eaba815..1501da7 100644
+--- a/services/network/web_transport.cc
++++ b/services/network/web_transport.cc
+@@ -27,7 +27,7 @@
+     const std::vector<mojom::WebTransportCertificateFingerprintPtr>&
+         fingerprints) {
+   net::WebTransportParameters params;
+-  params.enable_quic_transport = true;
++  params.enable_quic_transport = false;
+   params.enable_web_transport_http3 = true;
+ 
+   for (const auto& fingerprint : fingerprints) {
+diff --git a/services/network/web_transport_unittest.cc b/services/network/web_transport_unittest.cc
+index 1c02da1..a85359be 100644
+--- a/services/network/web_transport_unittest.cc
++++ b/services/network/web_transport_unittest.cc
+@@ -364,7 +364,7 @@
+ 
+ INSTANTIATE_TEST_SUITE_P(WebTransportTests,
+                          WebTransportTest,
+-                         testing::Values("quic-transport", "https"),
++                         testing::Values("https"),
+                          PrintStringPiece());
+ 
+ TEST_P(WebTransportTest, ConnectSuccessfully) {
+@@ -703,7 +703,7 @@
+ 
+ INSTANTIATE_TEST_SUITE_P(WebTransportWithCustomCertificateTests,
+                          WebTransportWithCustomCertificateTest,
+-                         testing::Values("quic-transport", "https"),
++                         testing::Values("https"),
+                          PrintStringPiece());
+ 
+ TEST_P(WebTransportWithCustomCertificateTest, WithValidFingerprint) {

--- a/patches/chromium/cherry-pick-45f9dcf5021d.patch
+++ b/patches/chromium/cherry-pick-45f9dcf5021d.patch
@@ -1,7 +1,7 @@
-From 45f9dcf5021da2f53812c769ec67f033a636b9cc Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Victor Vasiliev <vasilvv@chromium.org>
 Date: Tue, 26 Oct 2021 04:50:35 +0000
-Subject: [PATCH] Disable QuicTransport explicitly in the Network Service
+Subject: Disable QuicTransport explicitly in the Network Service
 
 (cherry picked from commit b1997bdadcda9738a19773f82605f65832acedac)
 
@@ -13,13 +13,12 @@ Commit-Queue: Yutaka Hirano <yhirano@chromium.org>
 Reviewed-by: Yutaka Hirano <yhirano@chromium.org>
 Cr-Commit-Position: refs/branch-heads/4606@{#1411}
 Cr-Branched-From: 35b0d5a9dc8362adfd44e2614f0d5b7402ef63d0-refs/heads/master@{#911515}
----
 
 diff --git a/services/network/web_transport.cc b/services/network/web_transport.cc
-index 8eaba815..1501da7 100644
+index 8eaba815d063c41588ac792dde914b41f04dde6a..1501da757db07294cf55d631b91fbc5b403d01ed 100644
 --- a/services/network/web_transport.cc
 +++ b/services/network/web_transport.cc
-@@ -27,7 +27,7 @@
+@@ -27,7 +27,7 @@ net::WebTransportParameters CreateParameters(
      const std::vector<mojom::WebTransportCertificateFingerprintPtr>&
          fingerprints) {
    net::WebTransportParameters params;
@@ -29,10 +28,10 @@ index 8eaba815..1501da7 100644
  
    for (const auto& fingerprint : fingerprints) {
 diff --git a/services/network/web_transport_unittest.cc b/services/network/web_transport_unittest.cc
-index 1c02da1..a85359be 100644
+index 1c02da12001499d0a6509ae71e59e3dd189b06e1..a85359bef06200cc60e8f6fbd7dc4637ef30fd9c 100644
 --- a/services/network/web_transport_unittest.cc
 +++ b/services/network/web_transport_unittest.cc
-@@ -364,7 +364,7 @@
+@@ -364,7 +364,7 @@ struct PrintStringPiece {
  
  INSTANTIATE_TEST_SUITE_P(WebTransportTests,
                           WebTransportTest,
@@ -41,7 +40,7 @@ index 1c02da1..a85359be 100644
                           PrintStringPiece());
  
  TEST_P(WebTransportTest, ConnectSuccessfully) {
-@@ -703,7 +703,7 @@
+@@ -703,7 +703,7 @@ class WebTransportWithCustomCertificateTest : public WebTransportTest {
  
  INSTANTIATE_TEST_SUITE_P(WebTransportWithCustomCertificateTests,
                           WebTransportWithCustomCertificateTest,


### PR DESCRIPTION
Disable QuicTransport explicitly in the Network Service

(cherry picked from commit b1997bdadcda9738a19773f82605f65832acedac)

Bug: 1260940
Change-Id: I6689fbce8115eda19e68414d7c03691704749b17
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3242207
Auto-Submit: Victor Vasiliev <vasilvv@chromium.org>
Commit-Queue: Yutaka Hirano <yhirano@chromium.org>
Reviewed-by: Yutaka Hirano <yhirano@chromium.org>
Cr-Commit-Position: refs/branch-heads/4606@{#1411}
Cr-Branched-From: 35b0d5a9dc8362adfd44e2614f0d5b7402ef63d0-refs/heads/master@{#911515}


Notes: Backported fix for CVE-2021-38002.