### PR TITLE
chore: cherry-pick 014e1f857c33 from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -19,3 +19,4 @@ regexp_remove_the_stack_parameter_from_regexp_matchers.patch
 cherry-pick-5c4acf2ae64a.patch
 cherry-pick-6de4e210688e.patch
 cherry-pick-feef10137b16.patch
+cherry-pick-014e1f857c33.patch

--- a/patches/v8/cherry-pick-014e1f857c33.patch
+++ b/patches/v8/cherry-pick-014e1f857c33.patch
@@ -1,0 +1,59 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marja=20H=C3=B6ltt=C3=A4?= <marja@chromium.org>
+Date: Mon, 25 Oct 2021 12:17:15 +0200
+Subject: Merged: [super ic] Fix receiver vs lookup start object confusion
+ related to module exports
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Revision: e4dba97006ca20337deafb85ac00524a94a62fe
+
+BUG=chromium:1260577
+NOTRY=true
+NOPRESUBMIT=true
+NOTREECHECKS=true
+R=ishell@chromium.org
+
+Change-Id: Ia85235fecdb37a5da6a28f7a0092a754a8620552
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3240826
+Reviewed-by: Igor Sheludko <ishell@chromium.org>
+Commit-Queue: Marja Hölttä <marja@chromium.org>
+Cr-Commit-Position: refs/branch-heads/9.4@{#48}
+Cr-Branched-From: 3b51863bc25492549a8bf96ff67ce481b1a3337b-refs/heads/9.4.146@{#1}
+Cr-Branched-From: 2890419fc8fb9bdb507fdd801d76fa7dd9f022b5-refs/heads/master@{#76233}
+
+diff --git a/src/ic/accessor-assembler.cc b/src/ic/accessor-assembler.cc
+index 35d1da5cd92900114a609f4553a738018269ee1e..e489d5a304385e4bafaa2ca4619edadc6108b0be 100644
+--- a/src/ic/accessor-assembler.cc
++++ b/src/ic/accessor-assembler.cc
+@@ -655,8 +655,8 @@ void AccessorAssembler::HandleLoadICSmiHandlerLoadNamedCase(
+     Comment("module export");
+     TNode<UintPtrT> index =
+         DecodeWord<LoadHandler::ExportsIndexBits>(handler_word);
+-    TNode<Module> module = LoadObjectField<Module>(
+-        CAST(p->receiver()), JSModuleNamespace::kModuleOffset);
++    TNode<Module> module =
++        LoadObjectField<Module>(CAST(holder), JSModuleNamespace::kModuleOffset);
+     TNode<ObjectHashTable> exports =
+         LoadObjectField<ObjectHashTable>(module, Module::kExportsOffset);
+     TNode<Cell> cell = CAST(LoadFixedArrayElement(exports, index));
+diff --git a/src/ic/ic.cc b/src/ic/ic.cc
+index 81e31d1c2d83d6a807745234ffdae513e0904cbe..94829bd199a0baa5730889746e3b65797bdae08a 100644
+--- a/src/ic/ic.cc
++++ b/src/ic/ic.cc
+@@ -860,7 +860,13 @@ Handle<Object> LoadIC::ComputeHandler(LookupIterator* lookup) {
+         // We found the accessor, so the entry must exist.
+         DCHECK(entry.is_found());
+         int index = ObjectHashTable::EntryToValueIndex(entry);
+-        return LoadHandler::LoadModuleExport(isolate(), index);
++        Handle<Smi> smi_handler =
++            LoadHandler::LoadModuleExport(isolate(), index);
++        if (holder_is_lookup_start_object) {
++          return smi_handler;
++        }
++        return LoadHandler::LoadFromPrototype(isolate(), map, holder,
++                                              smi_handler);
+       }
+ 
+       Handle<Object> accessors = lookup->GetAccessors();


### PR DESCRIPTION
Merged: [super ic] Fix receiver vs lookup start object confusion related to module exports

Revision: e4dba97006ca20337deafb85ac00524a94a62fe

BUG=chromium:1260577
NOTRY=true
NOPRESUBMIT=true
NOTREECHECKS=true
R=ishell@chromium.org

Change-Id: Ia85235fecdb37a5da6a28f7a0092a754a8620552
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3240826
Reviewed-by: Igor Sheludko <ishell@chromium.org>
Commit-Queue: Marja Hölttä <marja@chromium.org>
Cr-Commit-Position: refs/branch-heads/9.4@{#48}
Cr-Branched-From: 3b51863bc25492549a8bf96ff67ce481b1a3337b-refs/heads/9.4.146@{#1}
Cr-Branched-From: 2890419fc8fb9bdb507fdd801d76fa7dd9f022b5-refs/heads/master@{#76233}


Notes: Backported fix for CVE-2021-38001.