### PR TITLE
refactor: use upstream AutofillDriverFactory diffs

### DIFF
--- a/shell/browser/electron_autofill_driver.cc
+++ b/shell/browser/electron_autofill_driver.cc
@@ -15,16 +15,8 @@
 
 namespace electron {
 
-AutofillDriver::AutofillDriver(
-#if 0  // TESTING(ckerr)
-    content::RenderFrameHost* render_frame_host,
-    mojo::PendingAssociatedReceiver<mojom::ElectronAutofillDriver> request)
-    : render_frame_host_(render_frame_host),
-      receiver_(this, std::move(request)) {
-#else
-    content::RenderFrameHost* render_frame_host)
+AutofillDriver::AutofillDriver(content::RenderFrameHost* render_frame_host)
     : render_frame_host_(render_frame_host) {
-#endif
   autofill_popup_ = std::make_unique<AutofillPopup>();
 }  // namespace electron
 

--- a/shell/browser/electron_autofill_driver.cc
+++ b/shell/browser/electron_autofill_driver.cc
@@ -30,6 +30,12 @@ AutofillDriver::AutofillDriver(
 
 AutofillDriver::~AutofillDriver() = default;
 
+void AutofillDriver::BindPendingReceiver(
+    mojo::PendingAssociatedReceiver<mojom::ElectronAutofillDriver>
+        pending_receiver) {
+  receiver_.Bind(std::move(pending_receiver));
+}
+
 void AutofillDriver::ShowAutofillPopup(
     const gfx::RectF& bounds,
     const std::vector<std::u16string>& values,

--- a/shell/browser/electron_autofill_driver.cc
+++ b/shell/browser/electron_autofill_driver.cc
@@ -16,12 +16,17 @@
 namespace electron {
 
 AutofillDriver::AutofillDriver(
+#if 0  // TESTING(ckerr)
     content::RenderFrameHost* render_frame_host,
     mojo::PendingAssociatedReceiver<mojom::ElectronAutofillDriver> request)
     : render_frame_host_(render_frame_host),
       receiver_(this, std::move(request)) {
+#else
+    content::RenderFrameHost* render_frame_host)
+    : render_frame_host_(render_frame_host) {
+#endif
   autofill_popup_ = std::make_unique<AutofillPopup>();
-}
+}  // namespace electron
 
 AutofillDriver::~AutofillDriver() = default;
 

--- a/shell/browser/electron_autofill_driver.h
+++ b/shell/browser/electron_autofill_driver.h
@@ -20,15 +20,9 @@ namespace electron {
 
 class AutofillDriver : public mojom::ElectronAutofillDriver {
  public:
-#if 0  // TESTING(ckerr)
-  AutofillDriver(
-      content::RenderFrameHost* render_frame_host,
-      mojo::PendingAssociatedReceiver<mojom::ElectronAutofillDriver> request);
-#else
   AutofillDriver(content::RenderFrameHost* render_frame_host);
   AutofillDriver(const AutofillDriver&) = delete;
   AutofillDriver& operator=(const AutofillDriver&) = delete;
-#endif
   ~AutofillDriver() override;
 
   void BindPendingReceiver(
@@ -47,11 +41,7 @@ class AutofillDriver : public mojom::ElectronAutofillDriver {
   std::unique_ptr<AutofillPopup> autofill_popup_;
 #endif
 
-#if 0  // TESTING(ckerr)
-  mojo::AssociatedReceiver<mojom::ElectronAutofillDriver> receiver_;
-#else
   mojo::AssociatedReceiver<mojom::ElectronAutofillDriver> receiver_{this};
-#endif
 };
 
 }  // namespace electron

--- a/shell/browser/electron_autofill_driver.h
+++ b/shell/browser/electron_autofill_driver.h
@@ -20,7 +20,7 @@ namespace electron {
 
 class AutofillDriver : public mojom::ElectronAutofillDriver {
  public:
-  AutofillDriver(content::RenderFrameHost* render_frame_host);
+  explicit AutofillDriver(content::RenderFrameHost* render_frame_host);
   AutofillDriver(const AutofillDriver&) = delete;
   AutofillDriver& operator=(const AutofillDriver&) = delete;
   ~AutofillDriver() override;

--- a/shell/browser/electron_autofill_driver.h
+++ b/shell/browser/electron_autofill_driver.h
@@ -20,15 +20,20 @@ namespace electron {
 
 class AutofillDriver : public mojom::ElectronAutofillDriver {
  public:
-  AutofillDriver(
 #if 0  // TESTING(ckerr)
+  AutofillDriver(
       content::RenderFrameHost* render_frame_host,
       mojo::PendingAssociatedReceiver<mojom::ElectronAutofillDriver> request);
 #else
-      content::RenderFrameHost* render_frame_host);
+  AutofillDriver(content::RenderFrameHost* render_frame_host);
+  AutofillDriver(const AutofillDriver&) = delete;
+  AutofillDriver& operator=(const AutofillDriver&) = delete;
 #endif
-
   ~AutofillDriver() override;
+
+  void BindPendingReceiver(
+      mojo::PendingAssociatedReceiver<mojom::ElectronAutofillDriver>
+          pending_receiver);
 
   void ShowAutofillPopup(const gfx::RectF& bounds,
                          const std::vector<std::u16string>& values,
@@ -44,6 +49,8 @@ class AutofillDriver : public mojom::ElectronAutofillDriver {
 
 #if 0  // TESTING(ckerr)
   mojo::AssociatedReceiver<mojom::ElectronAutofillDriver> receiver_;
+#else
+  mojo::AssociatedReceiver<mojom::ElectronAutofillDriver> receiver_{this};
 #endif
 };
 

--- a/shell/browser/electron_autofill_driver.h
+++ b/shell/browser/electron_autofill_driver.h
@@ -21,8 +21,12 @@ namespace electron {
 class AutofillDriver : public mojom::ElectronAutofillDriver {
  public:
   AutofillDriver(
+#if 0  // TESTING(ckerr)
       content::RenderFrameHost* render_frame_host,
       mojo::PendingAssociatedReceiver<mojom::ElectronAutofillDriver> request);
+#else
+      content::RenderFrameHost* render_frame_host);
+#endif
 
   ~AutofillDriver() override;
 
@@ -38,7 +42,9 @@ class AutofillDriver : public mojom::ElectronAutofillDriver {
   std::unique_ptr<AutofillPopup> autofill_popup_;
 #endif
 
+#if 0  // TESTING(ckerr)
   mojo::AssociatedReceiver<mojom::ElectronAutofillDriver> receiver_;
+#endif
 };
 
 }  // namespace electron

--- a/shell/browser/electron_autofill_driver_factory.cc
+++ b/shell/browser/electron_autofill_driver_factory.cc
@@ -17,41 +17,9 @@
 
 namespace electron {
 
-#if 0  // TESTING(ckerr)
-namespace {
-
-std::unique_ptr<AutofillDriver> CreateDriver(
-    content::RenderFrameHost* render_frame_host,
-    mojom::ElectronAutofillDriverAssociatedRequest request) {
-  return std::make_unique<AutofillDriver>(render_frame_host,
-                                          std::move(request));
-}  // namespace
-#endif
-
 AutofillDriverFactory::~AutofillDriverFactory() = default;
 
 // static
-#if 0  // TESTING(ckerr)
-void AutofillDriverFactory::BindAutofillDriver(
-    mojom::ElectronAutofillDriverAssociatedRequest request,
-    content::RenderFrameHost* render_frame_host) {
-  content::WebContents* web_contents =
-      content::WebContents::FromRenderFrameHost(render_frame_host);
-  if (!web_contents)
-    return;
-
-  AutofillDriverFactory* factory =
-      AutofillDriverFactory::FromWebContents(web_contents);
-  if (!factory)
-    return;
-
-  AutofillDriver* driver = factory->DriverForFrame(render_frame_host);
-  if (!driver)
-    factory->AddDriverForFrame(
-        render_frame_host,
-        base::BindOnce(CreateDriver, render_frame_host, std::move(request)));
-}
-#else
 void AutofillDriverFactory::BindAutofillDriver(
     mojo::PendingAssociatedReceiver<mojom::ElectronAutofillDriver>
         pending_receiver,
@@ -72,19 +40,9 @@ void AutofillDriverFactory::BindAutofillDriver(
   if (auto* driver = factory->DriverForFrame(render_frame_host))
     driver->BindPendingReceiver(std::move(pending_receiver));
 }
-#endif
 
 AutofillDriverFactory::AutofillDriverFactory(content::WebContents* web_contents)
-    : content::WebContentsObserver(web_contents) {
-#if 0  // TESTING(ckerr)
-  const std::vector<content::RenderFrameHost*> frames =
-      web_contents->GetAllFrames();
-  for (content::RenderFrameHost* frame : frames) {
-    if (frame->IsRenderFrameLive())
-      RenderFrameCreated(frame);
-  }
-#endif
-}
+    : content::WebContentsObserver(web_contents) {}
 
 void AutofillDriverFactory::RenderFrameDeleted(
     content::RenderFrameHost* render_frame_host) {
@@ -105,10 +63,6 @@ void AutofillDriverFactory::DidFinishNavigation(
 
 AutofillDriver* AutofillDriverFactory::DriverForFrame(
     content::RenderFrameHost* render_frame_host) {
-#if 0  // TESTING(ckerr)
-  auto mapping = driver_map_.find(render_frame_host);
-  return mapping == driver_map_.end() ? nullptr : mapping->second.get();
-#else
   auto insertion_result = driver_map_.emplace(render_frame_host, nullptr);
   std::unique_ptr<AutofillDriver>& driver = insertion_result.first->second;
   bool insertion_happened = insertion_result.second;
@@ -137,7 +91,6 @@ AutofillDriver* AutofillDriverFactory::DriverForFrame(
   }
   DCHECK(driver.get());
   return driver.get();
-#endif
 }
 
 void AutofillDriverFactory::AddDriverForFrame(

--- a/shell/browser/electron_autofill_driver_factory.h
+++ b/shell/browser/electron_autofill_driver_factory.h
@@ -26,16 +26,10 @@ class AutofillDriverFactory
 
   ~AutofillDriverFactory() override;
 
-#if 0  // TESTING(ckerr)
-  static void BindAutofillDriver(
-      mojom::ElectronAutofillDriverAssociatedRequest request,
-      content::RenderFrameHost* render_frame_host);
-#else
   static void BindAutofillDriver(
       mojo::PendingAssociatedReceiver<mojom::ElectronAutofillDriver>
           pending_receiver,
       content::RenderFrameHost* render_frame_host);
-#endif
 
   // content::WebContentsObserver:
   void RenderFrameDeleted(content::RenderFrameHost* render_frame_host) override;

--- a/shell/browser/electron_autofill_driver_factory.h
+++ b/shell/browser/electron_autofill_driver_factory.h
@@ -26,9 +26,16 @@ class AutofillDriverFactory
 
   ~AutofillDriverFactory() override;
 
+#if 0  // TESTING(ckerr)
   static void BindAutofillDriver(
       mojom::ElectronAutofillDriverAssociatedRequest request,
       content::RenderFrameHost* render_frame_host);
+#else
+  static void BindAutofillDriver(
+      mojo::PendingAssociatedReceiver<mojom::ElectronAutofillDriver>
+          pending_receiver,
+      content::RenderFrameHost* render_frame_host);
+#endif
 
   // content::WebContentsObserver:
   void RenderFrameDeleted(content::RenderFrameHost* render_frame_host) override;

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1450,16 +1450,10 @@ bool ElectronBrowserClient::BindAssociatedReceiverFromFrame(
     const std::string& interface_name,
     mojo::ScopedInterfaceEndpointHandle* handle) {
   if (interface_name == mojom::ElectronAutofillDriver::Name_) {
-#if 0  // TESTING(ckerr)
-    AutofillDriverFactory::BindAutofillDriver(
-        mojom::ElectronAutofillDriverAssociatedRequest(std::move(*handle)),
-        render_frame_host);
-#else
     AutofillDriverFactory::BindAutofillDriver(
         mojo::PendingAssociatedReceiver<mojom::ElectronAutofillDriver>(
             std::move(*handle)),
         render_frame_host);
-#endif
     return true;
   }
 #if BUILDFLAG(ENABLE_PRINTING)

--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -1450,9 +1450,16 @@ bool ElectronBrowserClient::BindAssociatedReceiverFromFrame(
     const std::string& interface_name,
     mojo::ScopedInterfaceEndpointHandle* handle) {
   if (interface_name == mojom::ElectronAutofillDriver::Name_) {
+#if 0  // TESTING(ckerr)
     AutofillDriverFactory::BindAutofillDriver(
         mojom::ElectronAutofillDriverAssociatedRequest(std::move(*handle)),
         render_frame_host);
+#else
+    AutofillDriverFactory::BindAutofillDriver(
+        mojo::PendingAssociatedReceiver<mojom::ElectronAutofillDriver>(
+            std::move(*handle)),
+        render_frame_host);
+#endif
     return true;
   }
 #if BUILDFLAG(ENABLE_PRINTING)


### PR DESCRIPTION
Update our AutofillDriver and AutofillDriverFactory code to match upstream.

This was prompted by an upstream change that removes API that we were using. Specifically, https://github.com/electron/electron/pull/31555 includes https://chromium-review.googlesource.com/c/chromium/src/+/3241451 removes the getAllFrames() API that our AutofillDriverFactory uses.

Our code appears to be derived from [components/autofill/content/browser/content_autfill_driver*[cc,h]](components/autofill/content/browser/content_autofill_driver), whose identical use of getAllFrames()  removed in 2019 by https://chromium-review.googlesource.com/c/chromium/src/+/1826885. In that change, the upstream factory was changed to create and bind the autofill drivers on command. This PR tries to follow that approach in our derived factory, copying the relevant upstream code from [our current roll](https://github.com/electron/electron/pull/31555) (97.0.4689.0).

This is a medium-sized refactor, so I've split it out into its own PR (a) to make CI / manual testing possible (since this isn't the only break in the Chromium roll) and (b) for easier code review.

Looks like these files haven't been changed in a substantial way in awhile, so CC'ing @brenca who did the last [major work](https://github.com/electron/electron/pull/18760) on them, but review welcome from anyone including @electron/wg-upgrades 

Notes: none.