### PR TITLE
fix: apply transparency settings to WebContentsPreferences

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1456,9 +1456,14 @@ void WebContents::HandleNewRenderFrame(
   // Set the background color of RenderWidgetHostView.
   auto* web_preferences = WebContentsPreferences::From(web_contents());
   if (web_preferences) {
-    absl::optional<SkColor> color = web_preferences->GetBackgroundColor();
-    web_contents()->SetPageBaseBackgroundColor(color);
-    rwhv->SetBackgroundColor(color.value_or(SK_ColorWHITE));
+    bool transparent = web_preferences->GetTransparency();
+    if (transparent) {
+      rwhv->SetBackgroundColor(SK_ColorTRANSPARENT);
+    } else {
+      absl::optional<SkColor> color = web_preferences->GetBackgroundColor();
+      web_contents()->SetPageBaseBackgroundColor(color);
+      rwhv->SetBackgroundColor(color.value_or(SK_ColorWHITE));
+    }
   }
 
   if (!background_throttling_)
@@ -4058,9 +4063,6 @@ gin::Handle<WebContents> WebContents::CreateFromWebPreferences(
       absl::optional<SkColor> color =
           existing_preferences->GetBackgroundColor();
       web_contents->web_contents()->SetPageBaseBackgroundColor(color);
-      auto* rwhv = web_contents->web_contents()->GetRenderWidgetHostView();
-      if (rwhv)
-        rwhv->SetBackgroundColor(color.value_or(SK_ColorWHITE));
     }
   } else {
     // Create one if not.

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1456,14 +1456,9 @@ void WebContents::HandleNewRenderFrame(
   // Set the background color of RenderWidgetHostView.
   auto* web_preferences = WebContentsPreferences::From(web_contents());
   if (web_preferences) {
-    bool transparent = web_preferences->GetTransparency();
-    if (transparent) {
-      rwhv->SetBackgroundColor(SK_ColorTRANSPARENT);
-    } else {
-      absl::optional<SkColor> color = web_preferences->GetBackgroundColor();
-      web_contents()->SetPageBaseBackgroundColor(color);
-      rwhv->SetBackgroundColor(color.value_or(SK_ColorWHITE));
-    }
+    absl::optional<SkColor> color = web_preferences->GetBackgroundColor();
+    web_contents()->SetPageBaseBackgroundColor(color);
+    rwhv->SetBackgroundColor(color.value_or(SK_ColorWHITE));
   }
 
   if (!background_throttling_)
@@ -4063,6 +4058,11 @@ gin::Handle<WebContents> WebContents::CreateFromWebPreferences(
       absl::optional<SkColor> color =
           existing_preferences->GetBackgroundColor();
       web_contents->web_contents()->SetPageBaseBackgroundColor(color);
+      // Because web preferences don't recognize transparency,
+      // only set rwhv background color if a color exists
+      auto* rwhv = web_contents->web_contents()->GetRenderWidgetHostView();
+      if (rwhv && color.has_value())
+        rwhv->SetBackgroundColor(color.value());
     }
   } else {
     // Create one if not.

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -159,7 +159,6 @@ void WebContentsPreferences::Clear() {
   safe_dialogs_ = false;
   safe_dialogs_message_ = absl::nullopt;
   ignore_menu_shortcuts_ = false;
-  transparent_ = false;
   background_color_ = absl::nullopt;
   image_animation_policy_ =
       blink::mojom::ImageAnimationPolicy::kImageAnimationPolicyAllowed;
@@ -226,9 +225,11 @@ void WebContentsPreferences::SetFromDictionary(
   web_preferences.Get("disablePopups", &disable_popups_);
   web_preferences.Get("disableDialogs", &disable_dialogs_);
   web_preferences.Get("safeDialogs", &safe_dialogs_);
+  // preferences don't save a transparency option,
+  // apply any existing transparency setting to background_color_
   bool transparent;
   if (web_preferences.Get(options::kTransparent, &transparent)) {
-    transparent_ = true;
+    background_color_ = SK_ColorTRANSPARENT;
   }
   std::string background_color;
   if (web_preferences.GetHidden(options::kBackgroundColor, &background_color))

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -159,6 +159,7 @@ void WebContentsPreferences::Clear() {
   safe_dialogs_ = false;
   safe_dialogs_message_ = absl::nullopt;
   ignore_menu_shortcuts_ = false;
+  transparent_ = false;
   background_color_ = absl::nullopt;
   image_animation_policy_ =
       blink::mojom::ImageAnimationPolicy::kImageAnimationPolicyAllowed;
@@ -225,6 +226,10 @@ void WebContentsPreferences::SetFromDictionary(
   web_preferences.Get("disablePopups", &disable_popups_);
   web_preferences.Get("disableDialogs", &disable_dialogs_);
   web_preferences.Get("safeDialogs", &safe_dialogs_);
+  bool transparent;
+  if (web_preferences.Get(options::kTransparent, &transparent)) {
+    transparent_ = true;
+  }
   std::string background_color;
   if (web_preferences.GetHidden(options::kBackgroundColor, &background_color))
     background_color_ = ParseHexColor(background_color);

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -48,8 +48,6 @@ class WebContentsPreferences
   base::Value* last_preference() { return &last_web_preferences_; }
 
   bool IsOffscreen() const { return offscreen_; }
-  bool GetTransparency() const { return transparent_; }
-  void SetTransparency(bool transparent) { transparent_ = transparent; }
   absl::optional<SkColor> GetBackgroundColor() const {
     return background_color_;
   }
@@ -125,7 +123,6 @@ class WebContentsPreferences
   bool safe_dialogs_;
   absl::optional<std::string> safe_dialogs_message_;
   bool ignore_menu_shortcuts_;
-  bool transparent_;
   absl::optional<SkColor> background_color_;
   blink::mojom::ImageAnimationPolicy image_animation_policy_;
   absl::optional<base::FilePath> preload_path_;

--- a/shell/browser/web_contents_preferences.h
+++ b/shell/browser/web_contents_preferences.h
@@ -48,6 +48,8 @@ class WebContentsPreferences
   base::Value* last_preference() { return &last_web_preferences_; }
 
   bool IsOffscreen() const { return offscreen_; }
+  bool GetTransparency() const { return transparent_; }
+  void SetTransparency(bool transparent) { transparent_ = transparent; }
   absl::optional<SkColor> GetBackgroundColor() const {
     return background_color_;
   }
@@ -123,6 +125,7 @@ class WebContentsPreferences
   bool safe_dialogs_;
   absl::optional<std::string> safe_dialogs_message_;
   bool ignore_menu_shortcuts_;
+  bool transparent_;
   absl::optional<SkColor> background_color_;
   blink::mojom::ImageAnimationPolicy image_animation_policy_;
   absl::optional<base::FilePath> preload_path_;


### PR DESCRIPTION
#### Description of Change

In #30193, we refactored WebContentsPreferences to store its values directly and centralize logic for default values. As part of that refactor, the `transparency` setting was removed, and any transparent values were instead stored in the `background_color_` property (e.g., `background_color_ = SK_ColorTRANSPARENT`. 

We handle for cases like this explicitly for browser windows here:
https://github.com/electron/electron/blob/a2d993c9b48809128ca0d8a6c61f4c5ff7c8e385/shell/browser/api/electron_api_browser_window.cc#L40-L50

However, this transparency handling only applies to browser windows, and does not take into account events where the WebContents or WebContentsPreferences are created independently from the browser window, such as "-will-add-new-contents" events.

This PR adds a transparency check to web_contents_preferences, where any passed-in transparency values are checked and set the background_color_ to `SK_ColorTRANSPARENT`.

It also slightly amends a check in `WebContents::CreateFromWebPreferences` to only set a color to the RenderWidgetHostView if a color value exists. Because we're creating a window from web preferences, which don't recognize transparency, this can override transparent web contents with a white background on the window itself.

This PR has been tested on a series of gists to make sure no regressions were caused:
[Background Color (gist)](https://gist.github.com/4256f388d41ef0d974645a11ab72b1fe)
[Transparent Main Window (gist)](https://gist.github.com/b52f026c763057f97f745fade82758fd)
[Transparent Child Window (gist)](https://gist.github.com/VerteDinde/8877b50b70468debdd3a90615fcd9e47)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue where transparency was not always set correctly on webContents.
