### PR TITLE
test: deflake <webview> tag loads devtools extensions on WOA

### DIFF
--- a/spec-main/fixtures/devtools-extensions/foo/panel.js
+++ b/spec-main/fixtures/devtools-extensions/foo/panel.js
@@ -54,24 +54,26 @@ testStorage(function (
   syncForRemove, localForRemove,
   syncForClear, localForClear
 ) {
-  const message = JSON.stringify({
-    runtimeId: chrome.runtime.id,
-    tabId: chrome.devtools.inspectedWindow.tabId,
-    i18nString: chrome.i18n.getMessage('foo', ['bar', 'baz']),
-    storageItems: {
-      local: {
-        set: localForSet,
-        remove: localForRemove,
-        clear: localForClear
-      },
-      sync: {
-        set: syncForSet,
-        remove: syncForRemove,
-        clear: syncForClear
+  setTimeout(() => {
+    const message = JSON.stringify({
+      runtimeId: chrome.runtime.id,
+      tabId: chrome.devtools.inspectedWindow.tabId,
+      i18nString: chrome.i18n.getMessage('foo', ['bar', 'baz']),
+      storageItems: {
+        local: {
+          set: localForSet,
+          remove: localForRemove,
+          clear: localForClear
+        },
+        sync: {
+          set: syncForSet,
+          remove: syncForRemove,
+          clear: syncForClear
+        }
       }
-    }
-  });
+    });
 
-  const sendMessage = `require('electron').ipcRenderer.send('answer', ${message})`;
-  window.chrome.devtools.inspectedWindow.eval(sendMessage, function () {});
+    const sendMessage = `require('electron').ipcRenderer.send('answer', ${message})`;
+    window.chrome.devtools.inspectedWindow.eval(sendMessage, function () {});
+  });
 });


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
The test `<webview> tag loads devtools extensions registered on the parent window Link Column Header Test` has been more[ flaky recently on WOA](https://github.visualstudio.com/electron/_test/analytics?definitionId=48&contextType=build) and this PR should make that test less flaky.  I ran it three times on WOA and got green builds:
https://github.visualstudio.com/electron/_build/results?buildId=118722
https://github.visualstudio.com/electron/_build/results?buildId=118715
https://github.visualstudio.com/electron/_build/results?buildId=118729

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
