### PR TITLE
refactor: remove duplicate contextIsolation from getWebPreference()

### DIFF
--- a/lib/renderer/api/context-bridge.ts
+++ b/lib/renderer/api/context-bridge.ts
@@ -1,10 +1,7 @@
-const { mainFrame } = process._linkedBinding('electron_renderer_web_frame');
 const binding = process._linkedBinding('electron_renderer_context_bridge');
 
-const contextIsolationEnabled = mainFrame.getWebPreference('contextIsolation');
-
 const checkContextIsolationEnabled = () => {
-  if (!contextIsolationEnabled) throw new Error('contextBridge API can only be used when contextIsolation is enabled');
+  if (!process.contextIsolated) throw new Error('contextBridge API can only be used when contextIsolation is enabled');
 };
 
 const contextBridge: Electron.ContextBridge = {
@@ -17,7 +14,7 @@ const contextBridge: Electron.ContextBridge = {
 export default contextBridge;
 
 export const internalContextBridge = {
-  contextIsolationEnabled,
+  contextIsolationEnabled: process.contextIsolated,
   overrideGlobalValueFromIsolatedWorld: (keys: string[], value: any) => {
     return binding._overrideGlobalValueFromIsolatedWorld(keys, value, false);
   },

--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -71,7 +71,6 @@ webFrameInit();
 const { hasSwitch, getSwitchValue } = process._linkedBinding('electron_common_command_line');
 const { mainFrame } = process._linkedBinding('electron_renderer_web_frame');
 
-const contextIsolation = mainFrame.getWebPreference('contextIsolation');
 const nodeIntegration = mainFrame.getWebPreference('nodeIntegration');
 const webviewTag = mainFrame.getWebPreference('webviewTag');
 const isHiddenPage = mainFrame.getWebPreference('hiddenPage');
@@ -109,7 +108,7 @@ switch (window.location.protocol) {
 // Load webview tag implementation.
 if (process.isMainFrame) {
   const { webViewInit } = require('@electron/internal/renderer/web-view/web-view-init') as typeof webViewInitModule;
-  webViewInit(contextIsolation, webviewTag, isWebView);
+  webViewInit(webviewTag, isWebView);
 }
 
 if (nodeIntegration) {
@@ -166,7 +165,7 @@ if (nodeIntegration) {
 } else {
   // Delete Node's symbols after the Environment has been loaded in a
   // non context-isolated environment
-  if (!contextIsolation) {
+  if (!process.contextIsolated) {
     process.once('loaded', function () {
       delete (global as any).process;
       delete (global as any).Buffer;

--- a/lib/renderer/web-view/web-view-init.ts
+++ b/lib/renderer/web-view/web-view-init.ts
@@ -20,11 +20,11 @@ function handleFocusBlur () {
   });
 }
 
-export function webViewInit (contextIsolation: boolean, webviewTag: boolean, isWebView: boolean) {
+export function webViewInit (webviewTag: boolean, isWebView: boolean) {
   // Don't allow recursive `<webview>`.
   if (webviewTag && !isWebView) {
     const guestViewInternal = require('@electron/internal/renderer/web-view/guest-view-internal') as typeof guestViewInternalModule;
-    if (contextIsolation) {
+    if (process.contextIsolated) {
       v8Util.setHiddenValue(window, 'guestViewInternal', guestViewInternal);
     } else {
       const { setupWebView } = require('@electron/internal/renderer/web-view/web-view-element') as typeof webViewElementModule;

--- a/lib/sandboxed_renderer/init.ts
+++ b/lib/sandboxed_renderer/init.ts
@@ -127,7 +127,6 @@ if (hasSwitch('unsafely-expose-electron-internals-for-testing')) {
   preloadProcess._linkedBinding = process._linkedBinding;
 }
 
-const contextIsolation = mainFrame.getWebPreference('contextIsolation');
 const webviewTag = mainFrame.getWebPreference('webviewTag');
 const isHiddenPage = mainFrame.getWebPreference('hiddenPage');
 const usesNativeWindowOpen = true;
@@ -156,7 +155,7 @@ switch (window.location.protocol) {
 // Load webview tag implementation.
 if (process.isMainFrame) {
   const { webViewInit } = require('@electron/internal/renderer/web-view/web-view-init') as typeof webViewInitModule;
-  webViewInit(contextIsolation, webviewTag, isWebView);
+  webViewInit(webviewTag, isWebView);
 }
 
 // Wrap the script into a function executed in global scope. It won't have

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -499,8 +499,6 @@ class WebFrameRenderer : public gin::Wrappable<WebFrameRenderer>,
     } else if (pref_name == options::kOpenerID) {
       // NOTE: openerId is internal-only.
       return gin::ConvertToV8(isolate, prefs.opener_id);
-    } else if (pref_name == options::kContextIsolation) {
-      return gin::ConvertToV8(isolate, prefs.context_isolation);
     } else if (pref_name == "isWebView") {
       return gin::ConvertToV8(isolate, prefs.is_webview);
     } else if (pref_name == options::kHiddenPage) {

--- a/spec/fixtures/api/window-open-preload.js
+++ b/spec/fixtures/api/window-open-preload.js
@@ -6,7 +6,6 @@ setImmediate(function () {
     ipcRenderer.send('answer', {
       nativeWindowOpen: webFrame.getWebPreference('nativeWindowOpen'),
       nodeIntegration: webFrame.getWebPreference('nodeIntegration'),
-      sandbox: webFrame.getWebPreference('sandbox'),
       typeofProcess: typeof global.process,
       windowOpenerIsNull
     });

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -106,7 +106,6 @@ declare namespace NodeJS {
   }
 
   interface InternalWebPreferences {
-    contextIsolation: boolean;
     isWebView: boolean;
     hiddenPage: boolean;
     nativeWindowOpen: boolean;


### PR DESCRIPTION
#### Description of Change
We can use `process.contextIsolated` instead.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none