### PR TITLE
fix: BrowserView setBackgroundColor()

### DIFF
--- a/shell/browser/api/electron_api_browser_view.cc
+++ b/shell/browser/api/electron_api_browser_view.cc
@@ -147,7 +147,11 @@ gfx::Rect BrowserView::GetBounds() {
 }
 
 void BrowserView::SetBackgroundColor(const std::string& color_name) {
-  view_->SetBackgroundColor(ParseHexColor(color_name));
+  if (!web_contents())
+    return;
+
+  auto* wc = web_contents()->web_contents();
+  wc->SetPageBaseBackgroundColor(ParseHexColor(color_name));
 }
 
 v8::Local<v8::Value> BrowserView::GetWebContents(v8::Isolate* isolate) {

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1457,8 +1457,9 @@ void WebContents::HandleNewRenderFrame(
   // Set the background color of RenderWidgetHostView.
   auto* web_preferences = WebContentsPreferences::From(web_contents());
   if (web_preferences) {
+    bool guest = IsGuest() || type_ == Type::kBrowserView;
     absl::optional<SkColor> color =
-        IsGuest() ? SK_ColorTRANSPARENT : web_preferences->GetBackgroundColor();
+        guest ? SK_ColorTRANSPARENT : web_preferences->GetBackgroundColor();
     web_contents()->SetPageBaseBackgroundColor(color);
     rwhv->SetBackgroundColor(color.value_or(SK_ColorWHITE));
   }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/31742.

Applies fix from https://github.com/electron/electron/pull/30777 to `BrowserView`s. Also updates https://github.com/electron/electron/pull/31722 to include `BrowserView`s.

Tested with https://gist.github.com/kevinlinv/2de60478ffec6a2f18f1ec0fc6f5add9

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix `BrowserView.setBackgroundColor()` not working correctly.