### PR TITLE
fix: failing Node.js certificate spec

### DIFF
--- a/patches/node/.patches
+++ b/patches/node/.patches
@@ -25,3 +25,4 @@ fix_readbarrier_undefined_symbol_error_on_woa_arm64.patch
 chore_fix_-wimplicit-fallthrough.patch
 fix_event_with_invalid_timestamp_in_trace_log.patch
 test_fix_test-datetime-change-notify_after_daylight_change.patch
+test_add_fixture_trim_option.patch

--- a/patches/node/test_add_fixture_trim_option.patch
+++ b/patches/node/test_add_fixture_trim_option.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Mon, 8 Nov 2021 15:52:17 +0100
+Subject: test: add fixture trim option
+
+Fixes a spec failure originating with a strict requirement in BoringSSL
+that base64 strings be evenly divisible by 4 in their implementation of
+`NETSCAPE_SPKI_b64_decode`.
+
+Fixes that issue by trimming the newlines out of the file.
+
+Upstreamed at https://github.com/nodejs/node/pull/40757.
+
+diff --git a/test/common/fixtures.js b/test/common/fixtures.js
+index e5e1d887df525e493989a4aa8df6952a0e5b6c47..2da8aeb6a694e4b45d76bc3908284783d83f6755 100644
+--- a/test/common/fixtures.js
++++ b/test/common/fixtures.js
+@@ -15,8 +15,13 @@ function readFixtureSync(args, enc) {
+   return fs.readFileSync(fixturesPath(args), enc);
+ }
+ 
+-function readFixtureKey(name, enc) {
+-  return fs.readFileSync(fixturesPath('keys', name), enc);
++function readFixtureKey(name, enc, trim) {
++  let result = fs.readFileSync(fixturesPath('keys', name), enc);
++  if (trim) {
++    result = Buffer.from(result.toString().trim(), 'utf8');
++  }
++
++  return result;
+ }
+ 
+ function readFixtureKeys(enc, ...names) {
+diff --git a/test/parallel/test-crypto-certificate.js b/test/parallel/test-crypto-certificate.js
+index 4a5f1f149fe6c739f7f1d2ee17df6e61a942d621..a21fbff81c840da29034cb07ae2bd711cfe78b0a 100644
+--- a/test/parallel/test-crypto-certificate.js
++++ b/test/parallel/test-crypto-certificate.js
+@@ -30,9 +30,9 @@ const { Certificate } = crypto;
+ const fixtures = require('../common/fixtures');
+ 
+ // Test Certificates
+-const spkacValid = fixtures.readKey('rsa_spkac.spkac');
++const spkacValid = fixtures.readKey('rsa_spkac.spkac', null, true);
+ const spkacChallenge = 'this-is-a-challenge';
+-const spkacFail = fixtures.readKey('rsa_spkac_invalid.spkac');
++const spkacFail = fixtures.readKey('rsa_spkac_invalid.spkac', null, true);
+ const spkacPublicPem = fixtures.readKey('rsa_public.pem');
+ 
+ function copyArrayBuffer(buf) {

--- a/script/node-disabled-tests.json
+++ b/script/node-disabled-tests.json
@@ -14,7 +14,6 @@
   "parallel/test-code-cache",
   "parallel/test-crypto-aes-wrap",
   "parallel/test-crypto-authenticated-stream",
-  "parallel/test-crypto-certificate",
   "parallel/test-crypto-des3-wrap",
   "parallel/test-crypto-dh-stateless",
   "parallel/test-crypto-ecb",


### PR DESCRIPTION
#### Description of Change

Fixes a spec failure originating with a strict requirement in BoringSSL
that base64 strings be evenly divisible by 4 in their implementation of
`NETSCAPE_SPKI_b64_decode`.

Fixes that issue by trimming the newlines out of the file.

Upstreamed at https://github.com/nodejs/node/pull/40757.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none.
