### PR TITLE
test: fix crash in electron::NativeWindowMac::Close()

### DIFF
--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -4162,9 +4162,6 @@ describe('BrowserWindow module', () => {
         const leaveFullScreen = emittedOnce(w, 'leave-full-screen');
         w.setFullScreen(false);
         await leaveFullScreen;
-        const wait = emittedOnce(w, 'closed');
-        w.close();
-        await wait;
       });
 
       it('can be changed with setFullScreen method', async () => {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -4162,8 +4162,9 @@ describe('BrowserWindow module', () => {
         const leaveFullScreen = emittedOnce(w, 'leave-full-screen');
         w.setFullScreen(false);
         await leaveFullScreen;
-
+        const wait = emittedOnce(w, 'closed');
         w.close();
+        await wait;
       });
 
       it('can be changed with setFullScreen method', async () => {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
This fixes a crash that was happening in CI.  Its possible this was originally caused/exposed by:
- #27920
 
The underlying issue is that the test `BrowserWindow module window states (excluding Linux) fullscreen state should not cause a crash if called when exiting fullscreen` calls close on the window, but it doesn't wait for the window to be closed before finishing the test.  When the test finishes, `closeAllWindows` is invoked which ends up [destroying the window](https://github.com/electron/electron/blob/main/spec-main/window-helpers.ts#L20) before the close can complete, thus causing the crash.

- Fixes #28361
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
