### PR TITLE
refactor: eliminate duplicate code calling mainFrame.getWebPreference() in init

### DIFF
--- a/lib/renderer/init.ts
+++ b/lib/renderer/init.ts
@@ -72,13 +72,8 @@ const { hasSwitch, getSwitchValue } = process._linkedBinding('electron_common_co
 const { mainFrame } = process._linkedBinding('electron_renderer_web_frame');
 
 const nodeIntegration = mainFrame.getWebPreference('nodeIntegration');
-const webviewTag = mainFrame.getWebPreference('webviewTag');
-const isHiddenPage = mainFrame.getWebPreference('hiddenPage');
-const usesNativeWindowOpen = mainFrame.getWebPreference('nativeWindowOpen');
 const preloadScript = mainFrame.getWebPreference('preload');
 const preloadScripts = mainFrame.getWebPreference('preloadScripts');
-const isWebView = mainFrame.getWebPreference('isWebView');
-const openerId = mainFrame.getWebPreference('openerId');
 const appPath = hasSwitch('app-path') ? getSwitchValue('app-path') : null;
 
 // The webContents preload script is loaded after the session preload scripts.
@@ -101,14 +96,14 @@ switch (window.location.protocol) {
   default: {
     // Override default web functions.
     const { windowSetup } = require('@electron/internal/renderer/window-setup') as typeof windowSetupModule;
-    windowSetup(isWebView, openerId, isHiddenPage, usesNativeWindowOpen);
+    windowSetup();
   }
 }
 
 // Load webview tag implementation.
 if (process.isMainFrame) {
   const { webViewInit } = require('@electron/internal/renderer/web-view/web-view-init') as typeof webViewInitModule;
-  webViewInit(webviewTag, isWebView);
+  webViewInit();
 }
 
 if (nodeIntegration) {

--- a/lib/renderer/web-view/web-view-init.ts
+++ b/lib/renderer/web-view/web-view-init.ts
@@ -20,7 +20,10 @@ function handleFocusBlur () {
   });
 }
 
-export function webViewInit (webviewTag: boolean, isWebView: boolean) {
+export function webViewInit () {
+  const webviewTag = webFrame.getWebPreference('webviewTag');
+  const isWebView = webFrame.getWebPreference('isWebView');
+
   // Don't allow recursive `<webview>`.
   if (webviewTag && !isWebView) {
     const guestViewInternal = require('@electron/internal/renderer/web-view/guest-view-internal') as typeof guestViewInternalModule;

--- a/lib/renderer/window-setup.ts
+++ b/lib/renderer/window-setup.ts
@@ -3,6 +3,8 @@ import * as ipcRendererUtils from '@electron/internal/renderer/ipc-renderer-inte
 import { internalContextBridge } from '@electron/internal/renderer/api/context-bridge';
 import { IPC_MESSAGES } from '@electron/internal/common/ipc-messages';
 
+const { mainFrame: webFrame } = process._linkedBinding('electron_renderer_web_frame');
+
 const { contextIsolationEnabled } = internalContextBridge;
 
 // This file implements the following APIs over the ctx bridge:
@@ -242,8 +244,12 @@ class BrowserWindowProxy {
   }
 }
 
-export const windowSetup = (
-  isWebView: boolean, openerId: number, isHiddenPage: boolean, usesNativeWindowOpen: boolean) => {
+export const windowSetup = () => {
+  const isWebView = webFrame.getWebPreference('isWebView');
+  const openerId = webFrame.getWebPreference('openerId');
+  const isHiddenPage = webFrame.getWebPreference('hiddenPage');
+  const usesNativeWindowOpen = webFrame.getWebPreference('nativeWindowOpen');
+
   if (!process.sandboxed && !isWebView) {
     // Override default window.close.
     window.close = function () {

--- a/lib/sandboxed_renderer/init.ts
+++ b/lib/sandboxed_renderer/init.ts
@@ -119,19 +119,12 @@ function preloadRequire (module: string) {
 
 // Process command line arguments.
 const { hasSwitch } = process._linkedBinding('electron_common_command_line');
-const { mainFrame } = process._linkedBinding('electron_renderer_web_frame');
 
 // Similar to nodes --expose-internals flag, this exposes _linkedBinding so
 // that tests can call it to get access to some test only bindings
 if (hasSwitch('unsafely-expose-electron-internals-for-testing')) {
   preloadProcess._linkedBinding = process._linkedBinding;
 }
-
-const webviewTag = mainFrame.getWebPreference('webviewTag');
-const isHiddenPage = mainFrame.getWebPreference('hiddenPage');
-const usesNativeWindowOpen = true;
-const isWebView = mainFrame.getWebPreference('isWebView');
-const openerId = mainFrame.getWebPreference('openerId');
 
 switch (window.location.protocol) {
   case 'devtools:': {
@@ -148,14 +141,14 @@ switch (window.location.protocol) {
   default: {
     // Override default web functions.
     const { windowSetup } = require('@electron/internal/renderer/window-setup') as typeof windowSetupModule;
-    windowSetup(isWebView, openerId, isHiddenPage, usesNativeWindowOpen);
+    windowSetup();
   }
 }
 
 // Load webview tag implementation.
 if (process.isMainFrame) {
   const { webViewInit } = require('@electron/internal/renderer/web-view/web-view-init') as typeof webViewInitModule;
-  webViewInit(webviewTag, isWebView);
+  webViewInit();
 }
 
 // Wrap the script into a function executed in global scope. It won't have


### PR DESCRIPTION
#### Description of Change
Read the webPreferences in `lib/renderer/window-setup.ts` and `lib/renderer/web-view/web-view-init.ts`

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none