### PR TITLE
fix: generate angle brackets in release notes

### DIFF
--- a/script/release/notes/notes.js
+++ b/script/release/notes/notes.js
@@ -114,6 +114,8 @@ const getNoteFromClerk = async (ghKey) => {
         .slice(PERSIST_LEAD.length).trim() // remove PERSIST_LEAD
         .split(/\r?\n/) // split into lines
         .map(line => line.trim())
+        .map(line => line.replace('&lt;', '<'))
+        .map(line => line.replace('&gt;', '>'))
         .filter(line => line.startsWith(QUOTE_LEAD)) // notes are quoted
         .map(line => line.slice(QUOTE_LEAD.length)); // unquote the lines
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Previously the release notes generator produced notes such as:
`Fixed &lt;webview&gt; background transparency regression.`

This fix produces the correct note as follows:
`Fixed <webview> background transparency regression.`

@miniak 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> None
