### PR TITLE
fix: setContentProtection affects BrowserWindow frame

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -1106,6 +1106,8 @@ void NativeWindowViews::SetIgnoreMouseEvents(bool ignore, bool forward) {
 void NativeWindowViews::SetContentProtection(bool enable) {
 #if defined(OS_WIN)
   HWND hwnd = GetAcceleratedWidget();
+  DWORD affinity = enable ? WDA_EXCLUDEFROMCAPTURE : WDA_NONE;
+  ::SetWindowDisplayAffinity(hwnd, affinity);
   if (!layered_) {
     // Workaround to prevent black window on screen capture after hiding and
     // showing the BrowserWindow.
@@ -1114,8 +1116,6 @@ void NativeWindowViews::SetContentProtection(bool enable) {
     ::SetWindowLong(hwnd, GWL_EXSTYLE, ex_style);
     layered_ = true;
   }
-  DWORD affinity = enable ? WDA_EXCLUDEFROMCAPTURE : WDA_NONE;
-  ::SetWindowDisplayAffinity(hwnd, affinity);
 #endif
 }
 


### PR DESCRIPTION
#### Description of Change
Closes #31735. 

If the layered property is set before setting the affinity, the window frame disappears in some cases. Switching the order solves the issue - I believe this is a Windows bug.

cc @KazuyaHayashi

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed window frame glitch when calling `setContentProtection`.
