### PR TITLE
fix: provide paths for all NetworkContextFilePaths keys

### DIFF
--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -17,6 +17,8 @@ static_library("chrome") {
     "//chrome/browser/accessibility/accessibility_ui.h",
     "//chrome/browser/app_mode/app_mode_utils.cc",
     "//chrome/browser/app_mode/app_mode_utils.h",
+    "//chrome/browser/browser_features.cc",
+    "//chrome/browser/browser_features.h",
     "//chrome/browser/browser_process.cc",
     "//chrome/browser/browser_process.h",
     "//chrome/browser/devtools/devtools_contents_resizing_strategy.cc",

--- a/shell/browser/net/network_context_service.cc
+++ b/shell/browser/net/network_context_service.cc
@@ -70,7 +70,11 @@ void NetworkContextService::ConfigureNetworkContextParams(
 
     network_context_params->file_paths =
         network::mojom::NetworkContextFilePaths::New();
-    network_context_params->file_paths->data_path = path;
+    network_context_params->file_paths->data_path =
+        path.Append(chrome::kNetworkDataDirname);
+    network_context_params->file_paths->unsandboxed_data_path = path;
+    network_context_params->file_paths->trigger_migration =
+        features::ShouldTriggerNetworkDataMigration();
 
     // Currently this just contains HttpServerProperties
     network_context_params->file_paths->http_server_properties_file_name =
@@ -79,6 +83,12 @@ void NetworkContextService::ConfigureNetworkContextParams(
     // Configure persistent cookie path.
     network_context_params->file_paths->cookie_database_name =
         base::FilePath(chrome::kCookieFilename);
+
+    network_context_params->file_paths->http_server_properties_file_name =
+        base::FilePath(chrome::kNetworkPersistentStateFilename);
+
+    network_context_params->file_paths->trust_token_database_name =
+        base::FilePath(chrome::kTrustTokenFilename);
 
     network_context_params->restore_old_session_cookies = false;
     network_context_params->persist_session_cookies = false;

--- a/shell/browser/net/network_context_service.cc
+++ b/shell/browser/net/network_context_service.cc
@@ -6,6 +6,7 @@
 
 #include <utility>
 
+#include "chrome/browser/browser_features.h"
 #include "chrome/common/chrome_constants.h"
 #include "content/public/browser/network_service_instance.h"
 #include "content/public/browser/shared_cors_origin_access_list.h"

--- a/shell/browser/net/network_context_service.cc
+++ b/shell/browser/net/network_context_service.cc
@@ -20,6 +20,21 @@
 
 namespace electron {
 
+namespace {
+
+bool ShouldTriggerNetworkDataMigration() {
+#if defined(OS_WIN)
+  // On Windows, if sandbox enabled means data must be migrated.
+  if (SystemNetworkContextManager::IsNetworkSandboxEnabled())
+    return true;
+#endif  // defined(OS_WIN)
+  if (base::FeatureList::IsEnabled(features::kTriggerNetworkDataMigration))
+    return true;
+  return false;
+}
+
+}  // namespace
+
 NetworkContextService::NetworkContextService(content::BrowserContext* context)
     : browser_context_(static_cast<ElectronBrowserContext*>(context)),
       proxy_config_monitor_(browser_context_->prefs()) {}
@@ -75,7 +90,7 @@ void NetworkContextService::ConfigureNetworkContextParams(
         path.Append(chrome::kNetworkDataDirname);
     network_context_params->file_paths->unsandboxed_data_path = path;
     network_context_params->file_paths->trigger_migration =
-        features::ShouldTriggerNetworkDataMigration();
+        ShouldTriggerNetworkDataMigration();
 
     // Currently this just contains HttpServerProperties
     network_context_params->file_paths->http_server_properties_file_name =

--- a/shell/browser/net/system_network_context_manager.cc
+++ b/shell/browser/net/system_network_context_manager.cc
@@ -51,11 +51,13 @@
 
 namespace {
 
+#if defined(OS_WIN)
 namespace {
 
 const char kNetworkServiceSandboxEnabled[] = "net.network_service_sandbox";
 
 }
+#endif  // defined(OS_WIN)
 
 // The global instance of the SystemNetworkContextmanager.
 SystemNetworkContextManager* g_system_network_context_manager = nullptr;

--- a/shell/browser/net/system_network_context_manager.cc
+++ b/shell/browser/net/system_network_context_manager.cc
@@ -18,6 +18,7 @@
 #include "chrome/common/chrome_paths.h"
 #include "chrome/common/chrome_switches.h"
 #include "components/os_crypt/os_crypt.h"
+#include "components/prefs/pref_service.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/network_service_instance.h"
 #include "content/public/common/content_features.h"

--- a/shell/browser/net/system_network_context_manager.cc
+++ b/shell/browser/net/system_network_context_manager.cc
@@ -51,6 +51,12 @@
 
 namespace {
 
+namespace {
+
+const char kNetworkServiceSandboxEnabled[] = "net.network_service_sandbox";
+
+}
+
 // The global instance of the SystemNetworkContextmanager.
 SystemNetworkContextManager* g_system_network_context_manager = nullptr;
 
@@ -226,9 +232,8 @@ void SystemNetworkContextManager::DeleteInstance() {
 bool SystemNetworkContextManager::IsNetworkSandboxEnabled() {
 #if defined(OS_WIN)
   auto* local_state = g_browser_process->local_state();
-  if (local_state &&
-      local_state->HasPrefPath(prefs::kNetworkServiceSandboxEnabled)) {
-    return local_state->GetBoolean(prefs::kNetworkServiceSandboxEnabled);
+  if (local_state && local_state->HasPrefPath(kNetworkServiceSandboxEnabled)) {
+    return local_state->GetBoolean(kNetworkServiceSandboxEnabled);
   }
 #endif  // defined(OS_WIN)
   // If no policy is specified, then delegate to global sandbox configuration.

--- a/shell/browser/net/system_network_context_manager.cc
+++ b/shell/browser/net/system_network_context_manager.cc
@@ -220,6 +220,20 @@ void SystemNetworkContextManager::DeleteInstance() {
   delete g_system_network_context_manager;
 }
 
+// c.f.
+// https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/net/system_network_context_manager.cc;l=730-740;drc=15a616c8043551a7cb22c4f73a88e83afb94631c;bpv=1;bpt=1
+bool SystemNetworkContextManager::IsNetworkSandboxEnabled() {
+#if defined(OS_WIN)
+  auto* local_state = g_browser_process->local_state();
+  if (local_state &&
+      local_state->HasPrefPath(prefs::kNetworkServiceSandboxEnabled)) {
+    return local_state->GetBoolean(prefs::kNetworkServiceSandboxEnabled);
+  }
+#endif  // defined(OS_WIN)
+  // If no policy is specified, then delegate to global sandbox configuration.
+  return sandbox::policy::features::IsNetworkSandboxEnabled();
+}
+
 SystemNetworkContextManager::SystemNetworkContextManager(
     PrefService* pref_service)
     : proxy_config_monitor_(pref_service) {

--- a/shell/browser/net/system_network_context_manager.h
+++ b/shell/browser/net/system_network_context_manager.h
@@ -49,6 +49,13 @@ class SystemNetworkContextManager {
   // Destroys the global SystemNetworkContextManager instance.
   static void DeleteInstance();
 
+  // c.f.
+  // https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/net/system_network_context_manager.cc;l=730-740;drc=15a616c8043551a7cb22c4f73a88e83afb94631c;bpv=1;bpt=1
+  // Returns whether the network sandbox is enabled. This depends on  policy but
+  // also feature status from sandbox. Called before there is an instance of
+  // SystemNetworkContextManager.
+  static bool IsNetworkSandboxEnabled();
+
   // Configures default set of parameters for configuring the network context.
   void ConfigureDefaultNetworkContextParams(
       network::mojom::NetworkContextParams* network_context_params);

--- a/shell/browser/net/system_network_context_manager.h
+++ b/shell/browser/net/system_network_context_manager.h
@@ -8,6 +8,7 @@
 #include "base/memory/ref_counted.h"
 #include "chrome/browser/net/proxy_config_monitor.h"
 #include "mojo/public/cpp/bindings/remote.h"
+#include "sandbox/policy/features.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "services/network/public/mojom/network_context.mojom.h"
 #include "services/network/public/mojom/network_service.mojom.h"


### PR DESCRIPTION
Chromium is currently migrating file paths for the network service to a different path, as such a bunch of path calculations were moved into a config struct that we weren't fully populating.

This populates the struct identically to `//chrome`.

Refs: https://source.chromium.org/chromium/chromium/src/+/main:services/network/public/mojom/network_context.mojom;l=219;drc=b6e40f8ab247ea209bcecff994386a70a4169e9d
Refs: https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/net/profile_network_context_service.cc;l=712;drc=b6e40f8ab247ea209bcecff994386a70a4169e9d;bpv=1;bpt=1

Notes: `~/.config/{App Name}` will no longer be incorrectly deleted if it is a symlink on unix systems