### PR TITLE
fix: crash on browserView.webContents.destroy()

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -983,8 +983,7 @@ void WebContents::DeleteThisIfAlive() {
 void WebContents::Destroy() {
   // The content::WebContents should be destroyed asyncronously when possible
   // as user may choose to destroy WebContents during an event of it.
-  if (Browser::Get()->is_shutting_down() || IsGuest() ||
-      type_ == Type::kBrowserView) {
+  if (Browser::Get()->is_shutting_down() || IsGuest()) {
     DeleteThisIfAlive();
   } else {
     base::PostTask(FROM_HERE, {content::BrowserThread::UI},

--- a/spec-main/api-browser-view-spec.ts
+++ b/spec-main/api-browser-view-spec.ts
@@ -151,11 +151,20 @@ describe('BrowserView module', () => {
       w.addBrowserView(view);
     });
 
-    it('does not crash if the BrowserView webContents are destroyed prior to window removal', () => {
+    it('does not crash if the BrowserView webContents are destroyed prior to window addition', () => {
       expect(() => {
         const view1 = new BrowserView();
         (view1.webContents as any).destroy();
         w.addBrowserView(view1);
+      }).to.not.throw();
+    });
+
+    it('does not crash if the webContents is destroyed after a URL is loaded', () => {
+      view = new BrowserView();
+      expect(async () => {
+        view.setBounds({ x: 0, y: 0, width: 400, height: 300 });
+        await view.webContents.loadURL('data:text/html,hello there');
+        view.webContents.destroy();
       }).to.not.throw();
     });
 


### PR DESCRIPTION
#### Description of Change

Fixes an issue where `BrowserView`s crashed if `view.webContents.destroy()` is called after loading a URL. This happened because when the webContents closed synchronously, the `InspectableWebContents` was forced to close before all observers had been notified, causing a CHECK [here](https://source.chromium.org/chromium/chromium/src/+/main:content/browser/web_contents/web_contents_impl.cc;l=988?q=is_notifying_observers&ss=chromium).

To fix this, I chose to remove the `BrowserView` type from the synchronous conditions, though if there is a preferred approach I'm happy to modify this.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue where `BrowserView`s crashed if `view.webContents.destroy()` is called after loading a URL.