### PR TITLE
fix: make BrowserView aware of owning window

### DIFF
--- a/shell/browser/api/electron_api_browser_view.cc
+++ b/shell/browser/api/electron_api_browser_view.cc
@@ -99,10 +99,18 @@ BrowserView::BrowserView(gin::Arguments* args,
       NativeBrowserView::Create(api_web_contents_->inspectable_web_contents()));
 }
 
+void BrowserView::SetOwnerWindow(NativeWindow* window) {
+  // Ensure WebContents and BrowserView owner windows are in sync.
+  if (web_contents())
+    web_contents()->SetOwnerWindow(window);
+
+  owner_window_ = window ? window->GetWeakPtr() : nullptr;
+}
+
 BrowserView::~BrowserView() {
-  if (api_web_contents_) {  // destroy() called without closing WebContents
-    api_web_contents_->RemoveObserver(this);
-    api_web_contents_->Destroy();
+  if (web_contents()) {  // destroy() called without closing WebContents
+    web_contents()->RemoveObserver(this);
+    web_contents()->Destroy();
   }
 }
 

--- a/shell/browser/api/electron_api_browser_view.h
+++ b/shell/browser/api/electron_api_browser_view.h
@@ -14,6 +14,7 @@
 #include "gin/wrappable.h"
 #include "shell/browser/extended_web_contents_observer.h"
 #include "shell/browser/native_browser_view.h"
+#include "shell/browser/native_window.h"
 #include "shell/common/api/api.mojom.h"
 #include "shell/common/gin_helper/constructible.h"
 #include "shell/common/gin_helper/error_thrower.h"
@@ -52,6 +53,10 @@ class BrowserView : public gin::Wrappable<BrowserView>,
   WebContents* web_contents() const { return api_web_contents_; }
   NativeBrowserView* view() const { return view_.get(); }
 
+  NativeWindow* owner_window() const { return owner_window_.get(); }
+
+  void SetOwnerWindow(NativeWindow* window);
+
   int32_t ID() const { return id_; }
 
   // disable copy
@@ -80,6 +85,7 @@ class BrowserView : public gin::Wrappable<BrowserView>,
   class WebContents* api_web_contents_ = nullptr;
 
   std::unique_ptr<NativeBrowserView> view_;
+  base::WeakPtr<NativeWindow> owner_window_;
 
   int32_t id_;
 };

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -983,8 +983,7 @@ void WebContents::DeleteThisIfAlive() {
 void WebContents::Destroy() {
   // The content::WebContents should be destroyed asyncronously when possible
   // as user may choose to destroy WebContents during an event of it.
-  if (Browser::Get()->is_shutting_down() || IsGuest() ||
-      type_ == Type::kBrowserView) {
+  if (Browser::Get()->is_shutting_down() || IsGuest()) {
     DeleteThisIfAlive();
   } else {
     base::PostTask(FROM_HERE, {content::BrowserThread::UI},


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/29626.

Refactors based on the investigation performed in https://github.com/electron/electron/issues/29626#issuecomment-867088272. Makes it such that we are directly associating each `BrowserView` with its owning window if one exists, such that we don't need to indirectly check the owning window via the `BrowserView`s `webContents`, which may not exist e.g. if it's destroyed.

Should be landed after https://github.com/electron/electron/pull/31794.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where BrowserView may sometimes crash on `browserView.webContents.destroy()`.