### PR TITLE
fix: correct default text for button labels in gtk dialogs

### DIFF
--- a/shell/browser/ui/gtk_util.cc
+++ b/shell/browser/ui/gtk_util.cc
@@ -33,6 +33,8 @@ const char* GtkGettext(const char* str) {
   return g_dgettext(GettextPackage(), str);
 }
 
+}  // namespace
+
 const char* GetCancelLabel() {
   static const char* cancel = GtkGettext("_Cancel");
   return cancel;
@@ -103,4 +105,4 @@ GdkPixbuf* GdkPixbufFromSkBitmap(const SkBitmap& bitmap) {
   return pixbuf;
 }
 
-}  // namespace
+}  // namespace gtk_util

--- a/shell/browser/ui/gtk_util.cc
+++ b/shell/browser/ui/gtk_util.cc
@@ -33,43 +33,31 @@ const char* GtkGettext(const char* str) {
 }
 
 const char* GetCancelLabel() {
-  if (!gtk::GtkCheckVersion(4))
-    return "gtk-cancel";  // In GTK3, this is GTK_STOCK_CANCEL.
   static const char* cancel = GtkGettext("_Cancel");
   return cancel;
 }
 
 const char* GetOpenLabel() {
-  if (!gtk::GtkCheckVersion(4))
-    return "gtk-open";  // In GTK3, this is GTK_STOCK_OPEN.
   static const char* open = GtkGettext("_Open");
   return open;
 }
 
 const char* GetSaveLabel() {
-  if (!gtk::GtkCheckVersion(4))
-    return "gtk-save";  // In GTK3, this is GTK_STOCK_SAVE.
   static const char* save = GtkGettext("_Save");
   return save;
 }
 
 const char* GetOkLabel() {
-  if (!gtk::GtkCheckVersion(4))
-    return "gtk-ok";  // In GTK3, this is GTK_STOCK_OK.
   static const char* ok = GtkGettext("_Ok");
   return ok;
 }
 
 const char* GetNoLabel() {
-  if (!gtk::GtkCheckVersion(4))
-    return "gtk-no";  // In GTK3, this is GTK_STOCK_NO.
   static const char* no = GtkGettext("_No");
   return no;
 }
 
 const char* GetYesLabel() {
-  if (!gtk::GtkCheckVersion(4))
-    return "gtk-yes";  // In GTK3, this is GTK_STOCK_YES.
   static const char* yes = GtkGettext("_Yes");
   return yes;
 }

--- a/shell/browser/ui/gtk_util.cc
+++ b/shell/browser/ui/gtk_util.cc
@@ -17,10 +17,11 @@
 #include "third_party/skia/include/core/SkUnPreMultiply.h"
 #include "ui/gtk/gtk_compat.h"  // nogncheck
 
-namespace gtk_util {
-
 // The following utilities are pulled from
 // https://source.chromium.org/chromium/chromium/src/+/main:ui/gtk/select_file_dialog_impl_gtk.cc;l=43-74
+namespace gtk_util {
+
+namespace {
 
 const char* GettextPackage() {
   static base::NoDestructor<std::string> gettext_package(
@@ -102,4 +103,4 @@ GdkPixbuf* GdkPixbufFromSkBitmap(const SkBitmap& bitmap) {
   return pixbuf;
 }
 
-}  // namespace gtk_util
+}  // namespace

--- a/shell/browser/ui/gtk_util.h
+++ b/shell/browser/ui/gtk_util.h
@@ -11,9 +11,6 @@ class SkBitmap;
 
 namespace gtk_util {
 
-const char* GettextPackage();
-const char* GtkGettext(const char* str);
-
 const char* GetCancelLabel();
 const char* GetOpenLabel();
 const char* GetSaveLabel();


### PR DESCRIPTION
Fixes https://github.com/electron/electron/issues/31797. Default text labels in GTK dialogs broke as a side-effect of switching to GtkNativeDialogs.

CC @codebytere, this is the other issue I was talking about looking at when I came across 31630 :smile_cat: 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed default label text in GTK dialogs.