### PR TITLE
fix: in GTK open dialog, do not preview huge files

### DIFF
--- a/shell/browser/ui/file_dialog_gtk.cc
+++ b/shell/browser/ui/file_dialog_gtk.cc
@@ -380,11 +380,7 @@ bool CanPreview(const struct stat& st) {
   // https://github.com/electron/electron/issues/31630
   // Setting an arbitrary filesize max t at 100 MB here.
   constexpr off_t ArbitraryMax = 100000000ULL;
-  if (st.st_size >= ArbitraryMax) {
-    return false;
-  }
-
-  return true;
+  return st.st_size < ArbitraryMax;
 }
 
 void FileChooserDialog::OnUpdatePreview(GtkFileChooser* chooser) {

--- a/shell/browser/ui/file_dialog_gtk.cc
+++ b/shell/browser/ui/file_dialog_gtk.cc
@@ -369,6 +369,24 @@ void FileChooserDialog::AddFilters(const Filters& filters) {
   }
 }
 
+bool CanPreview(const struct stat& st) {
+  // Only preview regular files; pipes may hang.
+  // See https://crbug.com/534754.
+  if (!S_ISREG(st.st_mode)) {
+    return false;
+  }
+
+  // Don't preview huge files; they may crash.
+  // https://github.com/electron/electron/issues/31630
+  // Setting an arbitrary filesize max t at 100 MB here.
+  constexpr off_t ArbitraryMax = 100000000ULL;
+  if (st.st_size >= ArbitraryMax) {
+    return false;
+  }
+
+  return true;
+}
+
 void FileChooserDialog::OnUpdatePreview(GtkFileChooser* chooser) {
   CHECK(!*supports_gtk_file_chooser_native);
   gchar* filename = gtk_file_chooser_get_preview_filename(chooser);
@@ -377,10 +395,8 @@ void FileChooserDialog::OnUpdatePreview(GtkFileChooser* chooser) {
     return;
   }
 
-  // Don't attempt to open anything which isn't a regular file. If a named
-  // pipe, this may hang. See https://crbug.com/534754.
-  struct stat stat_buf;
-  if (stat(filename, &stat_buf) != 0 || !S_ISREG(stat_buf.st_mode)) {
+  struct stat sb;
+  if (stat(filename, &sb) != 0 || !CanPreview(sb)) {
     g_free(filename);
     gtk_file_chooser_set_preview_widget_active(chooser, FALSE);
     return;


### PR DESCRIPTION
#### Description of Change

Fixes #31630.

Adds a size check to the image file before previewing it. I've set the cutoff at 100 MB since "100 MB ought to be enough for anybody" but if there's a strong use case for previewing 100 MB image files we could increase it.

CC @codebytere 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed crash in GTK open dialog when trying to preview huge image files.
