### PR TITLE
fix: change cookie default from NO_RESTRICTION to LAX_MODE

### DIFF
--- a/docs/api/cookies.md
+++ b/docs/api/cookies.md
@@ -99,7 +99,7 @@ the response.
   * `expirationDate` Double (optional) - The expiration date of the cookie as the number of
     seconds since the UNIX epoch. If omitted then the cookie becomes a session
     cookie and will not be retained between sessions.
-  * `sameSite` String (optional) - The [Same Site](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies) policy to apply to this cookie.  Can be `unspecified`, `no_restriction`, `lax` or `strict`.  Default is `no_restriction`.
+  * `sameSite` String (optional) - The [Same Site](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies) policy to apply to this cookie.  Can be `unspecified`, `no_restriction`, `lax` or `strict`.  Default is `lax`.
 
 Returns `Promise<void>` - A promise which resolves when the cookie has been set
 

--- a/shell/browser/api/electron_api_cookies.cc
+++ b/shell/browser/api/electron_api_cookies.cc
@@ -192,7 +192,7 @@ std::string InclusionStatusToString(net::CookieInclusionStatus status) {
 std::string StringToCookieSameSite(const std::string* str_ptr,
                                    net::CookieSameSite* same_site) {
   if (!str_ptr) {
-    *same_site = net::CookieSameSite::NO_RESTRICTION;
+    *same_site = net::CookieSameSite::LAX_MODE;
     return "";
   }
   const std::string& str = *str_ptr;

--- a/spec-main/api-net-spec.ts
+++ b/spec-main/api-net-spec.ts
@@ -759,14 +759,18 @@ describe('net module', () => {
           const cookieLocalVal = `${Date.now()}-local`;
           const localhostUrl = serverUrl.replace('127.0.0.1', 'localhost');
           expect(localhostUrl).to.not.equal(serverUrl);
+          // cookies with lax or strict same-site settings will not
+          // persist after redirects. no_restriction must be used
           await Promise.all([
             sess.cookies.set({
               url: serverUrl,
               name: 'wild_cookie',
+              sameSite: 'no_restriction',
               value: cookie127Val
             }), sess.cookies.set({
               url: localhostUrl,
               name: 'wild_cookie',
+              sameSite: 'no_restriction',
               value: cookieLocalVal
             })
           ]);


### PR DESCRIPTION
#### Description of Change
Resolves #31553

Chrome recently [changed the same site default setting for cookies](https://www.chromium.org/updates/same-site) from `NO_RESTRICTION` to `LAX_MODE`.

This PR updates our cookie API to reflect that change, which will allow users to set insecure cookies again. However, cookies with `lax` or `strict` settings would not persist over redirects, which would break an expected default behavior for users.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed default setting used when setting an insecure cookie on a secure site.
