### PR TITLE
fix: ignore non-empty release note with no further info

### DIFF
--- a/script/release/notes/notes.js
+++ b/script/release/notes/notes.js
@@ -21,6 +21,8 @@ const TROP_LOGIN = 'trop[bot]';
 
 const NO_NOTES = 'No notes';
 
+const ignoreNotes = new Set(['none', 'no notes', 'notes']);
+
 const docTypes = new Set(['doc', 'docs']);
 const featTypes = new Set(['feat', 'feature']);
 const fixTypes = new Set(['fix']);
@@ -124,6 +126,10 @@ const getNoteFromClerk = async (ghKey) => {
       // multiline notes with their own sub-lists don't get
       // parsed in the markdown as part of the top-level list
       // (example: https://github.com/electron/electron/pull/25216)
+
+      if (ignoreNotes.has(firstLine.toLowerCase())) {
+        return NO_NOTES;
+      }
       lines = lines.map(line => '  ' + line);
       return [firstLine, ...lines]
         .join('\n') // join the lines


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Previously the release notes generator notes did not filter out release notes such as `None`, `No notes`, and `Notes`. Now these are not included in the final notes.

Note: This maybe something that should be modified in the bot instead, but in the meantime, I think this can provide a solution.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples --> None
