### PR TITLE
fix: media shouldn't open permissions dialog

### DIFF
--- a/patches/chromium/fix_media_key_usage_with_globalshortcuts.patch
+++ b/patches/chromium/fix_media_key_usage_with_globalshortcuts.patch
@@ -46,10 +46,10 @@ index bc009606d01469125052e68a9cdc82aaa697c764..ff18043cb07d748a49adea9874517fb2
    CHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
    if (IsShortcutHandlingSuspended())
 diff --git a/chrome/browser/extensions/global_shortcut_listener.h b/chrome/browser/extensions/global_shortcut_listener.h
-index 9aec54a3263d24491d24013a80b719dfc834ecd4..001a6cb2a5eb701351fa924109b43fab6f30748d 100644
+index 554930bc33d87ee88a9bcc5f0cf17cef09c27ef0..8df4f91d3db453afb9f73bcaeb82c919ca8d1841 100644
 --- a/chrome/browser/extensions/global_shortcut_listener.h
 +++ b/chrome/browser/extensions/global_shortcut_listener.h
-@@ -31,6 +31,8 @@ class GlobalShortcutListener {
+@@ -34,6 +34,8 @@ class GlobalShortcutListener {
  
    static GlobalShortcutListener* GetInstance();
  

--- a/patches/chromium/fix_media_key_usage_with_globalshortcuts.patch
+++ b/patches/chromium/fix_media_key_usage_with_globalshortcuts.patch
@@ -46,10 +46,10 @@ index bc009606d01469125052e68a9cdc82aaa697c764..ff18043cb07d748a49adea9874517fb2
    CHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
    if (IsShortcutHandlingSuspended())
 diff --git a/chrome/browser/extensions/global_shortcut_listener.h b/chrome/browser/extensions/global_shortcut_listener.h
-index 554930bc33d87ee88a9bcc5f0cf17cef09c27ef0..8df4f91d3db453afb9f73bcaeb82c919ca8d1841 100644
+index 9aec54a3263d24491d24013a80b719dfc834ecd4..001a6cb2a5eb701351fa924109b43fab6f30748d 100644
 --- a/chrome/browser/extensions/global_shortcut_listener.h
 +++ b/chrome/browser/extensions/global_shortcut_listener.h
-@@ -34,6 +34,8 @@ class GlobalShortcutListener {
+@@ -31,6 +31,8 @@ class GlobalShortcutListener {
  
    static GlobalShortcutListener* GetInstance();
  
@@ -59,10 +59,24 @@ index 554930bc33d87ee88a9bcc5f0cf17cef09c27ef0..8df4f91d3db453afb9f73bcaeb82c919
    // true if register successfully, or false if 1) the specificied |accelerator|
    // has been registered by another caller or other native applications, or
 diff --git a/content/browser/media/media_keys_listener_manager_impl.cc b/content/browser/media/media_keys_listener_manager_impl.cc
-index 5938f75742b793868638e693a9a8c8dc686dfc46..1263d679a5174beb960265989c370dd4a58ae7b4 100644
+index 5938f75742b793868638e693a9a8c8dc686dfc46..1137ea6c6b2b14f912b400e3cc43dc6fd0243407 100644
 --- a/content/browser/media/media_keys_listener_manager_impl.cc
 +++ b/content/browser/media/media_keys_listener_manager_impl.cc
-@@ -231,18 +231,24 @@ void MediaKeysListenerManagerImpl::StartListeningForMediaKeysIfNecessary() {
+@@ -55,7 +55,12 @@ bool MediaKeysListenerManagerImpl::StartWatchingMediaKey(
+                                CanActiveMediaSessionControllerReceiveEvents();
+ 
+   // Tell the underlying MediaKeysListener to listen for the key.
+-  if (should_start_watching && media_keys_listener_ &&
++  if (
++#if defined(OS_MAC)
++      !media_key_handling_enabled_ &&
++#endif  // defined(OS_MAC)
++      should_start_watching &&
++      media_keys_listener_ &&
+       !media_keys_listener_->StartWatchingMediaKey(key_code)) {
+     return false;
+   }
+@@ -231,18 +236,16 @@ void MediaKeysListenerManagerImpl::StartListeningForMediaKeysIfNecessary() {
        media::AudioManager::GetGlobalAppName());
  #endif
  
@@ -74,6 +88,10 @@ index 5938f75742b793868638e693a9a8c8dc686dfc46..1263d679a5174beb960265989c370dd4
 -  } else {
 -    // If we can't access system media controls, then directly listen for media
 -    // key keypresses instead.
+-    media_keys_listener_ = ui::MediaKeysListener::Create(
+-        this, ui::MediaKeysListener::Scope::kGlobal);
+-    DCHECK(media_keys_listener_);
+-  }
 +  // This is required for proper functioning of MediaMetadata.
 +  system_media_controls_->AddObserver(this);
 +  system_media_controls_notifier_ =
@@ -81,45 +99,9 @@ index 5938f75742b793868638e693a9a8c8dc686dfc46..1263d679a5174beb960265989c370dd4
 +          system_media_controls_.get());
 +
 +  // Directly listen for media key keypresses when using GlobalShortcuts.
-+#if defined(OS_MACOS)
-+  auto scope = media_key_handling_enabled_ ?
-+    ui::MediaKeysListener::Scope::kGlobal :
-+    ui::MediaKeysListener::Scope::kGlobalRequiresAccessibility;
-     media_keys_listener_ = ui::MediaKeysListener::Create(
--        this, ui::MediaKeysListener::Scope::kGlobal);
--    DCHECK(media_keys_listener_);
--  }
-+      this, scope);
-+#else
 +  media_keys_listener_ = ui::MediaKeysListener::Create(
 +    this, ui::MediaKeysListener::Scope::kGlobal);
-+#endif
 +  DCHECK(media_keys_listener_);
  
    EnsureAuxiliaryServices();
  }
-diff --git a/ui/base/accelerators/media_keys_listener.h b/ui/base/accelerators/media_keys_listener.h
-index c2b03328c0e508995bdc135031500783f500ceba..1b6b14dc2999c99445cef6ffc04d49a7c1728a54 100644
---- a/ui/base/accelerators/media_keys_listener.h
-+++ b/ui/base/accelerators/media_keys_listener.h
-@@ -20,6 +20,7 @@ class Accelerator;
- class COMPONENT_EXPORT(UI_BASE) MediaKeysListener {
-  public:
-   enum class Scope {
-+    kGlobalRequiresAccessibility, // Listener works whenever application in focus or not but requires accessibility permissions on macOS
-     kGlobal,   // Listener works whenever application in focus or not.
-     kFocused,  // Listener only works whan application has focus.
-   };
-diff --git a/ui/base/accelerators/media_keys_listener_win.cc b/ui/base/accelerators/media_keys_listener_win.cc
-index 6c63a88cbb13cfcc9a8ba652554839275ae1ee04..1643eafc094dce77e4ba8752cd02e1ae6c488b56 100644
---- a/ui/base/accelerators/media_keys_listener_win.cc
-+++ b/ui/base/accelerators/media_keys_listener_win.cc
-@@ -13,7 +13,7 @@ std::unique_ptr<MediaKeysListener> MediaKeysListener::Create(
-     MediaKeysListener::Scope scope) {
-   DCHECK(delegate);
- 
--  if (scope == Scope::kGlobal) {
-+  if (scope == Scope::kGlobal || scope == Scope::kGlobalRequiresAccessibility) {
-     // We should never have more than one global media keys listener.
-     if (!GlobalMediaKeysListenerWin::has_instance())
-       return std::make_unique<GlobalMediaKeysListenerWin>(delegate);


### PR DESCRIPTION
#### Description of Change

Playing media shouldn't open Accessibility permissions dialog on macOS.
However, we still need to watch for media events, just not globally and
`media_keys_listener_` is an API over global capture of the media keys.

The fix is to let chromium call `UpdateWhichKeysAreListenedFor` which
will call `UpdateSystemMediaControlsEnabledControls` and watch for
events on `system_media_controls_` without triggering permissions popup.

Fix: #31558

cc @codebytere 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where playing media would open Accessibility permissions dialog on macOS.