### PR TITLE
fix: BrowserView setBackgroundColor needs two calls

### DIFF
--- a/shell/browser/api/electron_api_browser_view.cc
+++ b/shell/browser/api/electron_api_browser_view.cc
@@ -155,11 +155,12 @@ gfx::Rect BrowserView::GetBounds() {
 }
 
 void BrowserView::SetBackgroundColor(const std::string& color_name) {
-  if (!web_contents())
-    return;
+  view_->SetBackgroundColor(ParseHexColor(color_name));
 
-  auto* wc = web_contents()->web_contents();
-  wc->SetPageBaseBackgroundColor(ParseHexColor(color_name));
+  if (web_contents()) {
+    auto* wc = web_contents()->web_contents();
+    wc->SetPageBaseBackgroundColor(ParseHexColor(color_name));
+  }
 }
 
 v8::Local<v8::Value> BrowserView::GetWebContents(v8::Isolate* isolate) {


### PR DESCRIPTION
#### Description of Change

I determined in testing that https://github.com/electron/electron/pull/31746 regressed https://github.com/electron/electron/issues/29778. 

It remains the case that we want to call `SetPageBaseBackgroundColor` on the `BrowserView`'s webContents, but we don't want to do this at the expense of calling `SetBackgroundColor` on the `RenderWidgetHostView`. We need to do both calls - similar to what's done here: https://github.com/electron/electron/blob/7e328c4b87399e36b6d7173eac5332a5255ee3cc/shell/browser/api/electron_api_web_contents.cc#L1462-L1463

Tested with
 - https://gist.github.com/kevinlinv/2de60478ffec6a2f18f1ec0fc6f5add9 to ensure default transparency
 - https://gist.github.com/712a2fde2757736c9dbf6c3e7e0aa18b

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a potential issue when setting backgroundColor on `BrowserView`s.