### PR TITLE
feat: support more color formats for `backgroundColor`

### DIFF
--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -70,7 +70,7 @@ The `bounds` of this BrowserView instance as `Object`.
 
 #### `view.setBackgroundColor(color)` _Experimental_
 
-* `color` string - Color in Hex, RGB, RGBA, HSL, HSLA or named CSS color format. The alpha channel is
+* `color` string - Color in Hex, RGB, ARGB, HSL, HSLA or named CSS color format. The alpha channel is
   optional for the hex type.
 
 Examples of valid `color` values:

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -77,9 +77,9 @@ Examples of valid `color` values:
 
 * Hex
   * #fff (shorthand RGB)
-  * #ffff (shorthand RGBA)
+  * #ffff (shorthand ARGB)
   * #ffffff (RGB)
-  * #ffffffff (RGBA)
+  * #ffffffff (ARGB)
 * RGB
   * rgb\(([\d]+),\s*([\d]+),\s*([\d]+)\)
     * e.g. rgb(255, 255, 255)

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -76,10 +76,10 @@ The `bounds` of this BrowserView instance as `Object`.
 Examples of valid `color` values:
 
 * Hex
-  * #fff (shorthand RGB)
-  * #ffff (shorthand ARGB)
-  * #ffffff (RGB)
-  * #ffffffff (ARGB)
+  * #fff (RGB)
+  * #ffff (ARGB)
+  * #ffffff (RRGGBB)
+  * #ffffffff (AARRGGBB)
 * RGB
   * rgb\(([\d]+),\s*([\d]+),\s*([\d]+)\)
     * e.g. rgb(255, 255, 255)
@@ -96,3 +96,5 @@ Examples of valid `color` values:
   * Options are listed in [SkParseColor.cpp](https://source.chromium.org/chromium/chromium/src/+/main:third_party/skia/src/utils/SkParseColor.cpp;l=11-152;drc=eea4bf52cb0d55e2a39c828b017c80a5ee054148)
   * Similar to CSS Color Module Level 3 keywords, but case-sensitive.
     * e.g. `blueviolet` or `red`
+
+**Note:** Hex format with alpha takes `AARRGGBB` or `ARGB`, _not_ `RRGGBBA` or `RGA`.

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -70,5 +70,18 @@ The `bounds` of this BrowserView instance as `Object`.
 
 #### `view.setBackgroundColor(color)` _Experimental_
 
-* `color` string - Color in `#aarrggbb` or `#argb` form. The alpha channel is
-  optional.
+* `color` string - Color in hex, RBG, HSL, or named CSS color format. The alpha channel is
+  optional for the hex type.
+
+Examples of valid `color` values:
+
+* [Hexadecimal Value Colors](https://www.w3schools.com/colors/colors_names.asp)
+  * `#ff00a3`
+  * `#80FFFFFF`
+* [HSL Colors](https://www.w3schools.com/colors/colors_hsl.asp)
+  * `hsl(230, 100%, 50%)`
+* [CSS Color Names](https://www.w3schools.com/colors/colors_names.asp)
+  * `blueviolet`
+  * `red`
+* [RGB Colors](https://www.w3schools.com/colors/colors_rgb.asp)
+  * `rgb(255, 145, 145)`

--- a/docs/api/browser-view.md
+++ b/docs/api/browser-view.md
@@ -70,18 +70,29 @@ The `bounds` of this BrowserView instance as `Object`.
 
 #### `view.setBackgroundColor(color)` _Experimental_
 
-* `color` string - Color in hex, RBG, HSL, or named CSS color format. The alpha channel is
+* `color` string - Color in Hex, RGB, RGBA, HSL, HSLA or named CSS color format. The alpha channel is
   optional for the hex type.
 
 Examples of valid `color` values:
 
-* [Hexadecimal Value Colors](https://www.w3schools.com/colors/colors_names.asp)
-  * `#ff00a3`
-  * `#80FFFFFF`
-* [HSL Colors](https://www.w3schools.com/colors/colors_hsl.asp)
-  * `hsl(230, 100%, 50%)`
-* [CSS Color Names](https://www.w3schools.com/colors/colors_names.asp)
-  * `blueviolet`
-  * `red`
-* [RGB Colors](https://www.w3schools.com/colors/colors_rgb.asp)
-  * `rgb(255, 145, 145)`
+* Hex
+  * #fff (shorthand RGB)
+  * #ffff (shorthand RGBA)
+  * #ffffff (RGB)
+  * #ffffffff (RGBA)
+* RGB
+  * rgb\(([\d]+),\s*([\d]+),\s*([\d]+)\)
+    * e.g. rgb(255, 255, 255)
+* RGBA
+  * rgba\(([\d]+),\s*([\d]+),\s*([\d]+),\s*([\d.]+)\)
+    * e.g. rgba(255, 255, 255, 1.0)
+* HSL
+  * hsl\((-?[\d.]+),\s*([\d.]+)%,\s*([\d.]+)%\)
+    * e.g. hsl(200, 20%, 50%)
+* HSLA
+  * hsla\((-?[\d.]+),\s*([\d.]+)%,\s*([\d.]+)%,\s*([\d.]+)\)
+    * e.g. hsla(200, 20%, 50%, 0.5)
+* Color name
+  * Options are listed in [SkParseColor.cpp](https://source.chromium.org/chromium/chromium/src/+/main:third_party/skia/src/utils/SkParseColor.cpp;l=11-152;drc=eea4bf52cb0d55e2a39c828b017c80a5ee054148)
+  * Similar to CSS Color Module Level 3 keywords, but case-sensitive.
+    * e.g. `blueviolet` or `red`

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -66,6 +66,23 @@ win.loadURL('https://github.com')
 Note that even for apps that use `ready-to-show` event, it is still recommended
 to set `backgroundColor` to make the app feel more native.
 
+Some examples of valid `backgroundColor` values include:
+
+```js
+const win = new BrowserWindow()
+win.setBackgroundColor('hsl(230, 100%, 50%)')
+win.setBackgroundColor('rgb(255, 145, 145)')
+win.setBackgroundColor('#ff00a3')
+win.setBackgroundColor('blueviolet')
+```
+
+For more information about these color types:
+
+* [Color Names](https://www.w3schools.com/colors/colors_names.asp)
+* [Colors Hex](https://www.w3schools.com/colors/colors_hexadecimal.asp)
+* [Colors RGB](https://www.w3schools.com/colors/colors_rgb.asp)
+* [Colors HSL](https://www.w3schools.com/colors/colors_hsl.asp)
+
 ## Parent and child windows
 
 By using `parent` option, you can create child windows:
@@ -199,9 +216,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `enableLargerThanScreen` boolean (optional) - Enable the window to be resized larger
     than screen. Only relevant for macOS, as other OSes allow
     larger-than-screen windows by default. Default is `false`.
-  * `backgroundColor` string (optional) - Window's background color as a hexadecimal value,
-    like `#66CD00` or `#FFF` or `#80FFFFFF` (alpha in #AARRGGBB format is supported if
-    `transparent` is set to `true`). Default is `#FFF` (white).
+  * `backgroundColor` string (optional) - Window's background color as a hexadecimal value (`#ff00a3` or `#80FFFFFF`), HSL color value (`hsl(230, 100%, 50%)`), CSS color string (`blueviolet`), or RGB color value (`rgb(255, 145, 145)`). Alpha in #AARRGGBB format is supported if `transparent` is set to `true`). Default is `#FFF` (white).
   * `hasShadow` boolean (optional) - Whether window should have a shadow. Default is `true`.
   * `opacity` number (optional) - Set the initial opacity of the window, between 0.0 (fully
     transparent) and 1.0 (fully opaque). This is only implemented on Windows and macOS.
@@ -992,9 +1007,7 @@ APIs like `win.setSize`.
 
 #### `win.setBackgroundColor(backgroundColor)`
 
-* `backgroundColor` string - Window's background color as a hexadecimal value,
-  like `#66CD00` or `#FFF` or `#80FFFFFF` (alpha is supported if `transparent`
-  is `true`). Default is `#FFF` (white).
+* `backgroundColor` string - Window's background color as a hexadecimal value (`#ff00a3` or `#80FFFFFF`), HSL color value (`hsl(230, 100%, 50%)`), CSS color string (`blueviolet`), or RGB color value (`rgb(255, 145, 145)`). Alpha in #AARRGGBB format is supported if `transparent` is set to `true`). Default is `#FFF` (white).
 
 Sets the background color of the window. See [Setting
 `backgroundColor`](#setting-the-backgroundcolor-property).
@@ -1041,8 +1054,8 @@ Returns [`Rectangle`](structures/rectangle.md) - The `bounds` of the window as `
 
 #### `win.getBackgroundColor()`
 
-Returns `string` - Gets the background color of the window. See [Setting
-`backgroundColor`](#setting-the-backgroundcolor-property).
+Returns `string` - Gets the background color of the window as a [Hexadecimal value](https://www.w3schools.com/colors/colors_hexadecimal.asp). See [Setting
+`backgroundColor`](#setting-the-backgroundcolor-property) for more information.
 
 #### `win.setContentBounds(bounds[, animate])`
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1076,6 +1076,8 @@ Returns `string` - Gets the background color of the window in Hex (`#RRGGBB`) fo
 
 See [Setting `backgroundColor`](#setting-the-backgroundcolor-property).
 
+**Note:** The alpha value is _not_ returned alongside the red, green, and blue values.
+
 #### `win.setContentBounds(bounds[, animate])`
 
 * `bounds` [Rectangle](structures/rectangle.md)

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -76,12 +76,7 @@ win.setBackgroundColor('#ff00a3')
 win.setBackgroundColor('blueviolet')
 ```
 
-For more information about these color types:
-
-* [Color Names](https://www.w3schools.com/colors/colors_names.asp)
-* [Colors Hex](https://www.w3schools.com/colors/colors_hexadecimal.asp)
-* [Colors RGB](https://www.w3schools.com/colors/colors_rgb.asp)
-* [Colors HSL](https://www.w3schools.com/colors/colors_hsl.asp)
+For more information about these color types see valid options in [win.setBackgroundColor](browser-window.md#winsetbackgroundcolorbackgroundcolor).
 
 ## Parent and child windows
 
@@ -216,7 +211,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `enableLargerThanScreen` boolean (optional) - Enable the window to be resized larger
     than screen. Only relevant for macOS, as other OSes allow
     larger-than-screen windows by default. Default is `false`.
-  * `backgroundColor` string (optional) - Window's background color as a hexadecimal value (`#ff00a3` or `#80FFFFFF`), HSL color value (`hsl(230, 100%, 50%)`), CSS color string (`blueviolet`), or RGB color value (`rgb(255, 145, 145)`). Alpha in #AARRGGBB format is supported if `transparent` is set to `true`). Default is `#FFF` (white).
+  * `backgroundColor` string (optional) - The window's background color in Hex, RGB, RGBA, HSL, HSLA or named CSS color format. Alpha in #RRGGBBAA format is supported if `transparent` is set to `true`. Default is `#FFF` (white). See [win.setBackgroundColor](browser-window.md#winsetbackgroundcolorbackgroundcolor) for more information.
   * `hasShadow` boolean (optional) - Whether window should have a shadow. Default is `true`.
   * `opacity` number (optional) - Set the initial opacity of the window, between 0.0 (fully
     transparent) and 1.0 (fully opaque). This is only implemented on Windows and macOS.
@@ -1007,7 +1002,31 @@ APIs like `win.setSize`.
 
 #### `win.setBackgroundColor(backgroundColor)`
 
-* `backgroundColor` string - Window's background color as a hexadecimal value (`#ff00a3` or `#80FFFFFF`), HSL color value (`hsl(230, 100%, 50%)`), CSS color string (`blueviolet`), or RGB color value (`rgb(255, 145, 145)`). Alpha in #AARRGGBB format is supported if `transparent` is set to `true`). Default is `#FFF` (white).
+* `backgroundColor` string - Color in Hex, RGB, RGBA, HSL, HSLA or named CSS color format. The alpha channel is optional for the hex type.
+
+Examples of valid `backgroundColor` values:
+
+* Hex
+  * #fff (shorthand RGB)
+  * #ffff (shorthand RGBA)
+  * #ffffff (RGB)
+  * #ffffffff (RGBA)
+* RGB
+  * rgb\(([\d]+),\s*([\d]+),\s*([\d]+)\)
+    * e.g. rgb(255, 255, 255)
+* RGBA
+  * rgba\(([\d]+),\s*([\d]+),\s*([\d]+),\s*([\d.]+)\)
+    * e.g. rgba(255, 255, 255, 1.0)
+* HSL
+  * hsl\((-?[\d.]+),\s*([\d.]+)%,\s*([\d.]+)%\)
+    * e.g. hsl(200, 20%, 50%)
+* HSLA
+  * hsla\((-?[\d.]+),\s*([\d.]+)%,\s*([\d.]+)%,\s*([\d.]+)\)
+    * e.g. hsla(200, 20%, 50%, 0.5)
+* Color name
+  * Options are listed in [SkParseColor.cpp](https://source.chromium.org/chromium/chromium/src/+/main:third_party/skia/src/utils/SkParseColor.cpp;l=11-152;drc=eea4bf52cb0d55e2a39c828b017c80a5ee054148)
+  * Similar to CSS Color Module Level 3 keywords, but case-sensitive.
+    * e.g. `blueviolet` or `red`
 
 Sets the background color of the window. See [Setting `backgroundColor`](#setting-the-backgroundcolor-property).
 
@@ -1053,9 +1072,10 @@ Returns [`Rectangle`](structures/rectangle.md) - The `bounds` of the window as `
 
 #### `win.getBackgroundColor([format])`
 
-* `format` string (optional) - One of either `hex`, `rgb`, or `hsl`.
+* `format` string (optional) - One of either `hex`, `rgb`, `rgba`, `hsl` or `hsla`.
 
-Returns `string` - Gets the background color of the window as a [Hexadecimal value](https://www.w3schools.com/colors/colors_hexadecimal.asp), an [HSL value](https://www.w3schools.com/colors/colors_hsl.asp) or an [RGB value](https://www.w3schools.com/colors/colors_rgb.asp). Default is `hex` if `format` is not passed.
+Returns `string` - Gets the background color in Hex, RBG, RBGA, HSL, or HSLA format. The alpha channel is
+optional for the hex type. Default is `hex` if `format` is not passed.
 
 See [Setting `backgroundColor`](#setting-the-backgroundcolor-property) for more information.
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -211,7 +211,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `enableLargerThanScreen` boolean (optional) - Enable the window to be resized larger
     than screen. Only relevant for macOS, as other OSes allow
     larger-than-screen windows by default. Default is `false`.
-  * `backgroundColor` string (optional) - The window's background color in Hex, RGB, RGBA, HSL, HSLA or named CSS color format. Alpha in #RRGGBBAA format is supported if `transparent` is set to `true`. Default is `#FFF` (white). See [win.setBackgroundColor](browser-window.md#winsetbackgroundcolorbackgroundcolor) for more information.
+  * `backgroundColor` string (optional) - The window's background color in Hex, RGB, RGBA, HSL, HSLA or named CSS color format. Alpha in #AARRGGBB format is supported if `transparent` is set to `true`. Default is `#FFF` (white). See [win.setBackgroundColor](browser-window.md#winsetbackgroundcolorbackgroundcolor) for more information.
   * `hasShadow` boolean (optional) - Whether window should have a shadow. Default is `true`.
   * `opacity` number (optional) - Set the initial opacity of the window, between 0.0 (fully
     transparent) and 1.0 (fully opaque). This is only implemented on Windows and macOS.
@@ -1008,9 +1008,9 @@ Examples of valid `backgroundColor` values:
 
 * Hex
   * #fff (shorthand RGB)
-  * #ffff (shorthand RGBA)
+  * #ffff (shorthand ARGB)
   * #ffffff (RGB)
-  * #ffffffff (RGBA)
+  * #ffffffff (ARGB)
 * RGB
   * rgb\(([\d]+),\s*([\d]+),\s*([\d]+)\)
     * e.g. rgb(255, 255, 255)
@@ -1070,14 +1070,11 @@ console.log(win.getBounds())
 
 Returns [`Rectangle`](structures/rectangle.md) - The `bounds` of the window as `Object`.
 
-#### `win.getBackgroundColor([format])`
+#### `win.getBackgroundColor()`
 
-* `format` string (optional) - One of either `hex`, `rgb`, `rgba`, `hsl` or `hsla`.
+Returns `string` - Gets the background color of the window in Hex (`#RRGGBB`) format.
 
-Returns `string` - Gets the background color in Hex, RBG, RBGA, HSL, or HSLA format. The alpha channel is
-optional for the hex type. Default is `hex` if `format` is not passed.
-
-See [Setting `backgroundColor`](#setting-the-backgroundcolor-property) for more information.
+See [Setting `backgroundColor`](#setting-the-backgroundcolor-property).
 
 #### `win.setContentBounds(bounds[, animate])`
 

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1009,8 +1009,7 @@ APIs like `win.setSize`.
 
 * `backgroundColor` string - Window's background color as a hexadecimal value (`#ff00a3` or `#80FFFFFF`), HSL color value (`hsl(230, 100%, 50%)`), CSS color string (`blueviolet`), or RGB color value (`rgb(255, 145, 145)`). Alpha in #AARRGGBB format is supported if `transparent` is set to `true`). Default is `#FFF` (white).
 
-Sets the background color of the window. See [Setting
-`backgroundColor`](#setting-the-backgroundcolor-property).
+Sets the background color of the window. See [Setting `backgroundColor`](#setting-the-backgroundcolor-property).
 
 #### `win.previewFile(path[, displayName])` _macOS_
 
@@ -1052,10 +1051,13 @@ console.log(win.getBounds())
 
 Returns [`Rectangle`](structures/rectangle.md) - The `bounds` of the window as `Object`.
 
-#### `win.getBackgroundColor()`
+#### `win.getBackgroundColor([format])`
 
-Returns `string` - Gets the background color of the window as a [Hexadecimal value](https://www.w3schools.com/colors/colors_hexadecimal.asp). See [Setting
-`backgroundColor`](#setting-the-backgroundcolor-property) for more information.
+* `format` string (optional) - One of either `hex`, `rgb`, or `hsl`.
+
+Returns `string` - Gets the background color of the window as a [Hexadecimal value](https://www.w3schools.com/colors/colors_hexadecimal.asp), an [HSL value](https://www.w3schools.com/colors/colors_hsl.asp) or an [RGB value](https://www.w3schools.com/colors/colors_rgb.asp). Default is `hex` if `format` is not passed.
+
+See [Setting `backgroundColor`](#setting-the-backgroundcolor-property) for more information.
 
 #### `win.setContentBounds(bounds[, animate])`
 

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -643,7 +643,7 @@ bool BaseWindow::IsTabletMode() const {
 }
 
 void BaseWindow::SetBackgroundColor(const std::string& color_name) {
-  SkColor color = ParseHexColor(color_name);
+  SkColor color = ParseCSSColor(color_name);
   window_->SetBackgroundColor(color);
 }
 

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -648,10 +648,7 @@ void BaseWindow::SetBackgroundColor(const std::string& color_name) {
 }
 
 std::string BaseWindow::GetBackgroundColor(gin_helper::Arguments* args) {
-  std::string format;
-  args->GetNext(&format);
-
-  return SkColorToColorString(window_->GetBackgroundColor(), format);
+  return ToRGBHex(window_->GetBackgroundColor());
 }
 
 void BaseWindow::SetHasShadow(bool has_shadow) {

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -647,8 +647,11 @@ void BaseWindow::SetBackgroundColor(const std::string& color_name) {
   window_->SetBackgroundColor(color);
 }
 
-std::string BaseWindow::GetBackgroundColor() {
-  return ToRGBHex(window_->GetBackgroundColor());
+std::string BaseWindow::GetBackgroundColor(gin_helper::Arguments* args) {
+  std::string format;
+  args->GetNext(&format);
+
+  return SkColorToColorString(window_->GetBackgroundColor(), format);
 }
 
 void BaseWindow::SetHasShadow(bool has_shadow) {

--- a/shell/browser/api/electron_api_base_window.h
+++ b/shell/browser/api/electron_api_base_window.h
@@ -159,7 +159,7 @@ class BaseWindow : public gin_helper::TrackableObject<BaseWindow>,
   bool IsKiosk();
   bool IsTabletMode() const;
   virtual void SetBackgroundColor(const std::string& color_name);
-  std::string GetBackgroundColor();
+  std::string GetBackgroundColor(gin_helper::Arguments* args);
   void SetHasShadow(bool has_shadow);
   bool HasShadow();
   void SetOpacity(const double opacity);

--- a/shell/browser/api/electron_api_browser_view.cc
+++ b/shell/browser/api/electron_api_browser_view.cc
@@ -154,11 +154,11 @@ gfx::Rect BrowserView::GetBounds() {
 }
 
 void BrowserView::SetBackgroundColor(const std::string& color_name) {
-  view_->SetBackgroundColor(ParseHexColor(color_name));
+  view_->SetBackgroundColor(ParseCSSColor(color_name));
 
   if (web_contents()) {
     auto* wc = web_contents()->web_contents();
-    wc->SetPageBaseBackgroundColor(ParseHexColor(color_name));
+    wc->SetPageBaseBackgroundColor(ParseCSSColor(color_name));
   }
 }
 

--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -370,7 +370,7 @@ void BrowserWindow::Blur() {
 
 void BrowserWindow::SetBackgroundColor(const std::string& color_name) {
   BaseWindow::SetBackgroundColor(color_name);
-  SkColor color = ParseHexColor(color_name);
+  SkColor color = ParseCSSColor(color_name);
   web_contents()->SetPageBaseBackgroundColor(color);
   auto* rwhv = web_contents()->GetRenderWidgetHostView();
   if (rwhv) {
@@ -384,7 +384,7 @@ void BrowserWindow::SetBackgroundColor(const std::string& color_name) {
     auto* web_preferences =
         WebContentsPreferences::From(api_web_contents_->web_contents());
     if (web_preferences) {
-      web_preferences->SetBackgroundColor(ParseHexColor(color_name));
+      web_preferences->SetBackgroundColor(ParseCSSColor(color_name));
     }
   }
 }

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -773,7 +773,7 @@ WebContents::WebContents(v8::Isolate* isolate,
     // and we then need to pull it back out and check it here.
     std::string background_color;
     options.GetHidden(options::kBackgroundColor, &background_color);
-    bool transparent = ParseHexColor(background_color) == SK_ColorTRANSPARENT;
+    bool transparent = ParseCSSColor(background_color) == SK_ColorTRANSPARENT;
 
     content::WebContents::CreateParams params(session->browser_context());
     auto* view = new OffScreenWebContentsView(

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -241,7 +241,7 @@ void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
 #endif
   std::string color;
   if (options.Get(options::kBackgroundColor, &color)) {
-    SetBackgroundColor(ParseHexColor(color));
+    SetBackgroundColor(ParseCSSColor(color));
   } else if (!transparent()) {
     // For normal window, use white as default background.
     SetBackgroundColor(SK_ColorWHITE);

--- a/shell/browser/ui/cocoa/electron_touch_bar.mm
+++ b/shell/browser/ui/cocoa/electron_touch_bar.mm
@@ -339,7 +339,7 @@ static NSString* const ImageScrubberItemIdentifier = @"scrubber.image.item";
 }
 
 - (NSColor*)colorFromHexColorString:(const std::string&)colorString {
-  SkColor color = electron::ParseHexColor(colorString);
+  SkColor color = electron::ParseCSSColor(colorString);
   return skia::SkColorToDeviceNSColor(color);
 }
 

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -235,7 +235,7 @@ void WebContentsPreferences::Merge(
   }
   std::string background_color;
   if (web_preferences.GetHidden(options::kBackgroundColor, &background_color))
-    background_color_ = ParseHexColor(background_color);
+    background_color_ = ParseCSSColor(background_color);
   std::string safe_dialogs_message;
   if (web_preferences.Get("safeDialogsMessage", &safe_dialogs_message))
     safe_dialogs_message_ = safe_dialogs_message;

--- a/shell/common/color_util.cc
+++ b/shell/common/color_util.cc
@@ -6,12 +6,32 @@
 
 #include <vector>
 
+#include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
 #include "content/public/common/color_parser.h"
+#include "ui/gfx/color_utils.h"
 
 namespace electron {
+
+std::string SkColorToColorString(SkColor color, const std::string& format) {
+  if (format == "hsl") {
+    color_utils::HSL hsl;
+    color_utils::SkColorToHSL(color, &hsl);
+    // Hue ranges between 0 - 360, and saturation/lightness both range from 0 -
+    // 100%, so multiply appropriately to convert to correct int values.
+    return base::StringPrintf("hsl(%ld, %ld%%, %ld%%)", lround(hsl.h * 360),
+                              lround(hsl.s * 100), lround(hsl.l * 100));
+  } else if (format == "rgb") {
+    return base::StringPrintf("rgb(%d, %d, %d)", SkColorGetR(color),
+                              SkColorGetG(color), SkColorGetB(color));
+  }
+
+  // Return #AARRGGBB hex by default.
+  return base::StringPrintf("#%02X%02X%02X", SkColorGetR(color),
+                            SkColorGetG(color), SkColorGetB(color));
+}
 
 SkColor ParseCSSColor(const std::string& color_string) {
   SkColor color;

--- a/shell/common/color_util.cc
+++ b/shell/common/color_util.cc
@@ -4,8 +4,10 @@
 
 #include "shell/common/color_util.h"
 
+#include <cmath>
 #include <vector>
 
+#include "base/cxx17_backports.h"
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
 #include "content/public/common/color_parser.h"
@@ -14,9 +16,8 @@
 namespace electron {
 
 std::string SkColorToColorString(SkColor color, const std::string& format) {
-  double alpha_double = (double)(SkColorGetA(color)) / 255.0;
-  double alpha =
-      alpha_double <= 0.0 ? 0.0 : alpha_double >= 1.0 ? 1.0 : alpha_double;
+  const double alpha_double = double(SkColorGetA(color)) / 255.0;
+  const double alpha = base::clamp(alpha_double, 0.0, 1.0);
 
   if (format == "hsl" || format == "hsla") {
     color_utils::HSL hsl;
@@ -32,13 +33,19 @@ std::string SkColorToColorString(SkColor color, const std::string& format) {
       return base::StringPrintf("hsl(%ld, %ld%%, %ld%%)", lround(hsl.h * 360),
                                 lround(hsl.s * 100), lround(hsl.l * 100));
     }
-  } else if (format == "rgba") {
+  }
+
+  if (format == "rgba") {
     return base::StringPrintf("rgba(%d, %d, %d, %.1f)", SkColorGetR(color),
                               SkColorGetG(color), SkColorGetB(color), alpha);
-  } else if (format == "rgb") {
+  }
+
+  if (format == "rgb") {
     return base::StringPrintf("rgb(%d, %d, %d)", SkColorGetR(color),
                               SkColorGetG(color), SkColorGetB(color));
-  } else if (alpha != 1.0) {
+  }
+
+  if (alpha != 1.0) {
     return ToRGBAHex(color, true);
   }
 

--- a/shell/common/color_util.cc
+++ b/shell/common/color_util.cc
@@ -14,21 +14,36 @@
 namespace electron {
 
 std::string SkColorToColorString(SkColor color, const std::string& format) {
-  if (format == "hsl") {
+  double alpha_double = (double)(SkColorGetA(color)) / 255.0;
+  double alpha =
+      alpha_double <= 0.0 ? 0.0 : alpha_double >= 1.0 ? 1.0 : alpha_double;
+
+  if (format == "hsl" || format == "hsla") {
     color_utils::HSL hsl;
-    color_utils::SkColorToHSL(color, &hsl);
+
     // Hue ranges between 0 - 360, and saturation/lightness both range from 0 -
     // 100%, so multiply appropriately to convert to correct int values.
-    return base::StringPrintf("hsl(%ld, %ld%%, %ld%%)", lround(hsl.h * 360),
-                              lround(hsl.s * 100), lround(hsl.l * 100));
+    color_utils::SkColorToHSL(color, &hsl);
+    if (format == "hsla") {
+      return base::StringPrintf("hsl(%ld, %ld%%, %ld%%, %.1f)",
+                                lround(hsl.h * 360), lround(hsl.s * 100),
+                                lround(hsl.l * 100), alpha);
+    } else {
+      return base::StringPrintf("hsl(%ld, %ld%%, %ld%%)", lround(hsl.h * 360),
+                                lround(hsl.s * 100), lround(hsl.l * 100));
+    }
+  } else if (format == "rgba") {
+    return base::StringPrintf("rgba(%d, %d, %d, %.1f)", SkColorGetR(color),
+                              SkColorGetG(color), SkColorGetB(color), alpha);
   } else if (format == "rgb") {
     return base::StringPrintf("rgb(%d, %d, %d)", SkColorGetR(color),
                               SkColorGetG(color), SkColorGetB(color));
+  } else if (alpha != 1.0) {
+    return ToRGBAHex(color, true);
   }
 
-  // Return #AARRGGBB hex by default.
-  return base::StringPrintf("#%02X%02X%02X", SkColorGetR(color),
-                            SkColorGetG(color), SkColorGetB(color));
+  // Return hex by default.
+  return ToRGBHex(color);
 }
 
 SkColor ParseCSSColor(const std::string& color_string) {

--- a/shell/common/color_util.cc
+++ b/shell/common/color_util.cc
@@ -5,6 +5,7 @@
 #include "shell/common/color_util.h"
 
 #include <cmath>
+#include <utility>
 #include <vector>
 
 #include "base/cxx17_backports.h"

--- a/shell/common/color_util.cc
+++ b/shell/common/color_util.cc
@@ -6,8 +6,6 @@
 
 #include <vector>
 
-#include "base/logging.h"
-#include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
 #include "content/public/common/color_parser.h"

--- a/shell/common/color_util.cc
+++ b/shell/common/color_util.cc
@@ -9,41 +9,16 @@
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
+#include "content/public/common/color_parser.h"
 
 namespace electron {
 
-SkColor ParseHexColor(const std::string& color_string) {
-  // Check the string for incorrect formatting.
-  if (color_string.empty() || color_string[0] != '#')
-    return SK_ColorWHITE;
+SkColor ParseCSSColor(const std::string& color_string) {
+  SkColor color;
+  if (!content::ParseCssColorString(color_string, &color))
+    color = SK_ColorWHITE;
 
-  // Prepend FF if alpha channel is not specified.
-  std::string source = color_string.substr(1);
-  if (source.size() == 3)
-    source.insert(0, "F");
-  else if (source.size() == 6)
-    source.insert(0, "FF");
-
-  // Convert the string from #FFF format to #FFFFFF format.
-  std::string formatted_color;
-  if (source.size() == 4) {
-    for (size_t i = 0; i < 4; ++i) {
-      formatted_color += source[i];
-      formatted_color += source[i];
-    }
-  } else if (source.size() == 8) {
-    formatted_color = source;
-  } else {
-    return SK_ColorWHITE;
-  }
-
-  // Convert the string to an integer and make sure it is in the correct value
-  // range.
-  std::vector<uint8_t> bytes;
-  if (!base::HexStringToBytes(formatted_color, &bytes))
-    return SK_ColorWHITE;
-
-  return SkColorSetARGB(bytes[0], bytes[1], bytes[2], bytes[3]);
+  return color;
 }
 
 std::string ToRGBHex(SkColor color) {

--- a/shell/common/color_util.h
+++ b/shell/common/color_util.h
@@ -11,8 +11,9 @@
 
 namespace electron {
 
-// Parse hex color like "#FFF" or "#EFEFEF"
-SkColor ParseHexColor(const std::string& color_string);
+// Parses a CSS-style color string from hex (3- or 6-digit), rgb(), rgba(),
+// hsl() or hsla() formats.
+SkColor ParseCSSColor(const std::string& color_string);
 
 // Convert color to RGB hex value like "#ABCDEF"
 std::string ToRGBHex(SkColor color);

--- a/shell/common/color_util.h
+++ b/shell/common/color_util.h
@@ -11,6 +11,7 @@
 
 namespace electron {
 
+// Converts an SKColor to either Hex, HSL, or RGB color string.
 std::string SkColorToColorString(SkColor color, const std::string& format);
 
 // Parses a CSS-style color string from hex (3- or 6-digit), rgb(), rgba(),

--- a/shell/common/color_util.h
+++ b/shell/common/color_util.h
@@ -11,16 +11,17 @@
 
 namespace electron {
 
-// Converts an SKColor to either Hex, HSL, or RGB color string.
+// Converts an SKColor to either Hex, HSL, HSLA, RBG, or RGBA color string.
 std::string SkColorToColorString(SkColor color, const std::string& format);
 
-// Parses a CSS-style color string from hex (3- or 6-digit), rgb(), rgba(),
-// hsl() or hsla() formats.
+// Parses a CSS-style color string from hex, rgb(), rgba(),
+// hsl(), hsla(), or color name formats.
 SkColor ParseCSSColor(const std::string& color_string);
 
-// Convert color to RGB hex value like "#ABCDEF"
+// Convert color to RGB hex value like "#RRGGBB".
 std::string ToRGBHex(SkColor color);
 
+// Convert color to RGBA hex value like "#RRGGBBAA".
 std::string ToRGBAHex(SkColor color, bool include_hash = true);
 
 }  // namespace electron

--- a/shell/common/color_util.h
+++ b/shell/common/color_util.h
@@ -11,9 +11,6 @@
 
 namespace electron {
 
-// Converts an SKColor to either Hex, HSL, HSLA, RBG, or RGBA color string.
-std::string SkColorToColorString(SkColor color, const std::string& format);
-
 // Parses a CSS-style color string from hex, rgb(), rgba(),
 // hsl(), hsla(), or color name formats.
 SkColor ParseCSSColor(const std::string& color_string);

--- a/shell/common/color_util.h
+++ b/shell/common/color_util.h
@@ -11,6 +11,8 @@
 
 namespace electron {
 
+std::string SkColorToColorString(SkColor color, const std::string& format);
+
 // Parses a CSS-style color string from hex (3- or 6-digit), rgb(), rgba(),
 // hsl() or hsla() formats.
 SkColor ParseCSSColor(const std::string& color_string);

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1076,6 +1076,19 @@ describe('BrowserWindow module', () => {
         w.setBackgroundColor(backgroundColor);
         expect(w.getBackgroundColor()).to.equal(backgroundColor);
       });
+      it('returns correct color with multiple passed formats', () => {
+        w.destroy();
+        w = new BrowserWindow({});
+
+        w.setBackgroundColor('blueviolet');
+        expect(w.getBackgroundColor()).to.equal('#8A2BE2');
+
+        w.setBackgroundColor('rgb(255, 0, 185)');
+        expect(w.getBackgroundColor()).to.equal('#FF00B9');
+
+        w.setBackgroundColor('hsl(155, 100%, 50%)');
+        expect(w.getBackgroundColor()).to.equal('#00FF95');
+      });
     });
 
     describe('BrowserWindow.getNormalBounds()', () => {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1082,12 +1082,17 @@ describe('BrowserWindow module', () => {
 
         w.setBackgroundColor('blueviolet');
         expect(w.getBackgroundColor()).to.equal('#8A2BE2');
+        expect(w.getBackgroundColor('rgb')).to.equal('rgb(138, 43, 226)');
+        expect(w.getBackgroundColor('hsl')).to.equal('hsl(271, 76%, 53%)');
 
         w.setBackgroundColor('rgb(255, 0, 185)');
-        expect(w.getBackgroundColor()).to.equal('#FF00B9');
+        expect(w.getBackgroundColor('hex')).to.equal('#FF00B9');
+        expect(w.getBackgroundColor('hsl')).to.equal('hsl(316, 100%, 50%)');
 
         w.setBackgroundColor('hsl(155, 100%, 50%)');
         expect(w.getBackgroundColor()).to.equal('#00FF95');
+        expect(w.getBackgroundColor('rgb')).to.equal('rgb(0, 255, 149)');
+        expect(w.getBackgroundColor('hsl')).to.equal('hsl(155, 100%, 50%)');
       });
     });
 

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1083,11 +1083,24 @@ describe('BrowserWindow module', () => {
         w.setBackgroundColor('blueviolet');
         expect(w.getBackgroundColor()).to.equal('#8A2BE2');
         expect(w.getBackgroundColor('rgb')).to.equal('rgb(138, 43, 226)');
+        expect(w.getBackgroundColor('rgba')).to.equal('rgba(138, 43, 226, 1.0)');
         expect(w.getBackgroundColor('hsl')).to.equal('hsl(271, 76%, 53%)');
+        expect(w.getBackgroundColor('hsla')).to.equal('hsl(271, 76%, 53%, 1.0)');
 
         w.setBackgroundColor('rgb(255, 0, 185)');
         expect(w.getBackgroundColor('hex')).to.equal('#FF00B9');
         expect(w.getBackgroundColor('hsl')).to.equal('hsl(316, 100%, 50%)');
+
+        w.setBackgroundColor('rgba(245, 40, 145, 0.8)');
+        expect(w.getBackgroundColor('hex')).to.equal('#F52891CC');
+        expect(w.getBackgroundColor('hsl')).to.equal('hsl(329, 91%, 56%)');
+        expect(w.getBackgroundColor('hsla')).to.equal('hsl(329, 91%, 56%, 0.8)');
+
+        w.setBackgroundColor('#23853466');
+        expect(w.getBackgroundColor('rgb')).to.equal('rgb(35, 133, 52)');
+        expect(w.getBackgroundColor('rgba')).to.equal('rgba(35, 133, 52, 0.4)');
+        expect(w.getBackgroundColor('hsl')).to.equal('hsl(130, 58%, 33%)');
+        expect(w.getBackgroundColor('hsla')).to.equal('hsl(130, 58%, 33%, 0.4)');
 
         w.setBackgroundColor('hsl(155, 100%, 50%)');
         expect(w.getBackgroundColor()).to.equal('#00FF95');

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1087,10 +1087,10 @@ describe('BrowserWindow module', () => {
         expect(w.getBackgroundColor()).to.equal('#8A2BE2');
 
         w.setBackgroundColor('rgb(255, 0, 185)');
-        expect(w.getBackgroundColor('hex')).to.equal('#FF00B9');
+        expect(w.getBackgroundColor()).to.equal('#FF00B9');
 
         w.setBackgroundColor('rgba(245, 40, 145, 0.8)');
-        expect(w.getBackgroundColor('hex')).to.equal('#F52891');
+        expect(w.getBackgroundColor()).to.equal('#F52891');
 
         w.setBackgroundColor('hsl(155, 100%, 50%)');
         expect(w.getBackgroundColor()).to.equal('#00FF95');

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1080,32 +1080,20 @@ describe('BrowserWindow module', () => {
         w.destroy();
         w = new BrowserWindow({});
 
+        w.setBackgroundColor('#AABBFF');
+        expect(w.getBackgroundColor()).to.equal('#AABBFF');
+
         w.setBackgroundColor('blueviolet');
         expect(w.getBackgroundColor()).to.equal('#8A2BE2');
-        expect(w.getBackgroundColor('rgb')).to.equal('rgb(138, 43, 226)');
-        expect(w.getBackgroundColor('rgba')).to.equal('rgba(138, 43, 226, 1.0)');
-        expect(w.getBackgroundColor('hsl')).to.equal('hsl(271, 76%, 53%)');
-        expect(w.getBackgroundColor('hsla')).to.equal('hsl(271, 76%, 53%, 1.0)');
 
         w.setBackgroundColor('rgb(255, 0, 185)');
         expect(w.getBackgroundColor('hex')).to.equal('#FF00B9');
-        expect(w.getBackgroundColor('hsl')).to.equal('hsl(316, 100%, 50%)');
 
         w.setBackgroundColor('rgba(245, 40, 145, 0.8)');
-        expect(w.getBackgroundColor('hex')).to.equal('#F52891CC');
-        expect(w.getBackgroundColor('hsl')).to.equal('hsl(329, 91%, 56%)');
-        expect(w.getBackgroundColor('hsla')).to.equal('hsl(329, 91%, 56%, 0.8)');
-
-        w.setBackgroundColor('#23853466');
-        expect(w.getBackgroundColor('rgb')).to.equal('rgb(35, 133, 52)');
-        expect(w.getBackgroundColor('rgba')).to.equal('rgba(35, 133, 52, 0.4)');
-        expect(w.getBackgroundColor('hsl')).to.equal('hsl(130, 58%, 33%)');
-        expect(w.getBackgroundColor('hsla')).to.equal('hsl(130, 58%, 33%, 0.4)');
+        expect(w.getBackgroundColor('hex')).to.equal('#F52891');
 
         w.setBackgroundColor('hsl(155, 100%, 50%)');
         expect(w.getBackgroundColor()).to.equal('#00FF95');
-        expect(w.getBackgroundColor('rgb')).to.equal('rgb(0, 255, 149)');
-        expect(w.getBackgroundColor('hsl')).to.equal('hsl(155, 100%, 50%)');
       });
     });
 


### PR DESCRIPTION
#### Description of Change

Refs https://github.com/electron/electron/issues/31019. 

In https://github.com/electron/electron/pull/30193, we unintentionally refactored `WebPreferences` such that `backgroundColor` no longer accepted CSS color values like `red`. However, that only worked for some types of `backgroundColor` methods, since others did enforce that the passed value be hex.

This PR thus adds more official support for the following formats:
- CSS Color Names
- HSL Colors
- RGB Colors
- Hex Color Values

And as a bonus removes some duplicate code from our `color_util` file.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added support for more color formats in `setBackgroundColor`.
