### PR TITLE
fix: ninja build failed on some system

### DIFF
--- a/script/generate-config-gypi.py
+++ b/script/generate-config-gypi.py
@@ -17,10 +17,10 @@ def run_node_configure(target_cpu):
   # Enabled in Chromium's V8.
   if target_cpu == 'arm64' or target_cpu == 'x64':
     args += ['--experimental-enable-pointer-compression']
-  # Work around "No acceptable ASM compiler found" error on some Windows
-  # machines, it breaks nothing since Electron does not use OpenSSL.
-  if sys.platform == 'win32':
-    args += ['--openssl-no-asm']
+
+  # Work around "No acceptable ASM compiler found" error on some System,
+  # it breaks nothing since Electron does not use OpenSSL.
+  args += ['--openssl-no-asm']
   subprocess.check_call([sys.executable, configure] + args)
 
 def read_node_config_gypi():


### PR DESCRIPTION
#### Description of Change
enabling `--openssl-no-asm` for all platforms

Related PR: https://github.com/electron/electron/pull/31404

cc: @zcbenz 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
