### PR TITLE
chore: cherry-pick 5d2b5e7c006c from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -12,3 +12,4 @@ regexp_allow_reentrant_irregexp_execution.patch
 regexp_remove_the_stack_parameter_from_regexp_matchers.patch
 cherry-pick-6de4e210688e.patch
 merge_inspector_use_ephemeron_table_for_exception_metadata.patch
+cherry-pick-5d2b5e7c006c.patch

--- a/patches/v8/cherry-pick-5d2b5e7c006c.patch
+++ b/patches/v8/cherry-pick-5d2b5e7c006c.patch
@@ -1,7 +1,7 @@
-From 5d2b5e7c006c8af13b2d467ce2a38877bad300dc Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nico Hartmann <nicohartmann@chromium.org>
 Date: Mon, 25 Oct 2021 10:58:59 +0200
-Subject: [PATCH] Merged: [TurboFan] Do not use NumberConstant as immediate in x86
+Subject: Merged: [TurboFan] Do not use NumberConstant as immediate in x86
 
 Bug: chromium:1254189
 (cherry picked from commit bdf31d5883607db4377b519d7308fb1e639a0448)
@@ -16,13 +16,12 @@ Reviewed-by: Maya Lekova <mslekova@chromium.org>
 Cr-Commit-Position: refs/branch-heads/9.6@{#22}
 Cr-Branched-From: 0b7bda016178bf438f09b3c93da572ae3663a1f7-refs/heads/9.6.180@{#1}
 Cr-Branched-From: 41a5a247d9430b953e38631e88d17790306f7a4c-refs/heads/main@{#77244}
----
 
 diff --git a/src/compiler/backend/ia32/instruction-selector-ia32.cc b/src/compiler/backend/ia32/instruction-selector-ia32.cc
-index 7eaa807..8c2b585 100644
+index f36fdb293564ed2083cbf1b02ffea9a40de4e2e5..9313ed6751ac945f6353085f4927842b2436436b 100644
 --- a/src/compiler/backend/ia32/instruction-selector-ia32.cc
 +++ b/src/compiler/backend/ia32/instruction-selector-ia32.cc
-@@ -99,11 +99,14 @@
+@@ -99,11 +99,14 @@ class IA32OperandGenerator final : public OperandGenerator {
    bool CanBeImmediate(Node* node) {
      switch (node->opcode()) {
        case IrOpcode::kInt32Constant:

--- a/patches/v8/cherry-pick-5d2b5e7c006c.patch
+++ b/patches/v8/cherry-pick-5d2b5e7c006c.patch
@@ -1,0 +1,40 @@
+From 5d2b5e7c006c8af13b2d467ce2a38877bad300dc Mon Sep 17 00:00:00 2001
+From: Nico Hartmann <nicohartmann@chromium.org>
+Date: Mon, 25 Oct 2021 10:58:59 +0200
+Subject: [PATCH] Merged: [TurboFan] Do not use NumberConstant as immediate in x86
+
+Bug: chromium:1254189
+(cherry picked from commit bdf31d5883607db4377b519d7308fb1e639a0448)
+
+Change-Id: I1d4426fee8392c7a680ad67af4bf2745d04b2e52
+No-Try: true
+No-Presubmit: true
+No-Tree-Checks: true
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3268905
+Commit-Queue: Nico Hartmann <nicohartmann@chromium.org>
+Reviewed-by: Maya Lekova <mslekova@chromium.org>
+Cr-Commit-Position: refs/branch-heads/9.6@{#22}
+Cr-Branched-From: 0b7bda016178bf438f09b3c93da572ae3663a1f7-refs/heads/9.6.180@{#1}
+Cr-Branched-From: 41a5a247d9430b953e38631e88d17790306f7a4c-refs/heads/main@{#77244}
+---
+
+diff --git a/src/compiler/backend/ia32/instruction-selector-ia32.cc b/src/compiler/backend/ia32/instruction-selector-ia32.cc
+index 7eaa807..8c2b585 100644
+--- a/src/compiler/backend/ia32/instruction-selector-ia32.cc
++++ b/src/compiler/backend/ia32/instruction-selector-ia32.cc
+@@ -99,11 +99,14 @@
+   bool CanBeImmediate(Node* node) {
+     switch (node->opcode()) {
+       case IrOpcode::kInt32Constant:
+-      case IrOpcode::kNumberConstant:
+       case IrOpcode::kExternalConstant:
+       case IrOpcode::kRelocatableInt32Constant:
+       case IrOpcode::kRelocatableInt64Constant:
+         return true;
++      case IrOpcode::kNumberConstant: {
++        const double value = OpParameter<double>(node->op());
++        return bit_cast<int64_t>(value) == 0;
++      }
+       case IrOpcode::kHeapConstant: {
+ // TODO(bmeurer): We must not dereference handles concurrently. If we
+ // really have to this here, then we need to find a way to put this


### PR DESCRIPTION
Merged: [TurboFan] Do not use NumberConstant as immediate in x86

Bug: chromium:1254189
(cherry picked from commit bdf31d5883607db4377b519d7308fb1e639a0448)

Change-Id: I1d4426fee8392c7a680ad67af4bf2745d04b2e52
No-Try: true
No-Presubmit: true
No-Tree-Checks: true
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3268905
Commit-Queue: Nico Hartmann <nicohartmann@chromium.org>
Reviewed-by: Maya Lekova <mslekova@chromium.org>
Cr-Commit-Position: refs/branch-heads/9.6@{#22}
Cr-Branched-From: 0b7bda016178bf438f09b3c93da572ae3663a1f7-refs/heads/9.6.180@{#1}
Cr-Branched-From: 41a5a247d9430b953e38631e88d17790306f7a4c-refs/heads/main@{#77244}


Notes: Backported fix for CVE-2021-38007.