### PR TITLE
docs: update list of shortcuts that need accessibility permission

### DIFF
--- a/docs/api/global-shortcut.md
+++ b/docs/api/global-shortcut.md
@@ -56,13 +56,16 @@ When the accelerator is already taken by other applications, this call will
 silently fail. This behavior is intended by operating systems, since they don't
 want applications to fight for global shortcuts.
 
-The following accelerators will not be registered successfully on macOS 10.14 Mojave unless
+The following accelerators will not be registered successfully on macOS 10.14 Mojave and macOS 10.15 Big Sur unless
 the app has been authorized as a [trusted accessibility client](https://developer.apple.com/library/archive/documentation/Accessibility/Conceptual/AccessibilityMacOSX/OSXAXTestingApps.html):
 
 * "Media Play/Pause"
 * "Media Next Track"
 * "Media Previous Track"
 * "Media Stop"
+* "Volume Up"
+* "Volume Down"
+* "Volume Mute"
 
 ### `globalShortcut.registerAll(accelerators, callback)`
 
@@ -75,13 +78,16 @@ When a given accelerator is already taken by other applications, this call will
 silently fail. This behavior is intended by operating systems, since they don't
 want applications to fight for global shortcuts.
 
-The following accelerators will not be registered successfully on macOS 10.14 Mojave unless
+The following accelerators will not be registered successfully on macOS 10.14 Mojave and macOS 10.15 Big Sur unless
 the app has been authorized as a [trusted accessibility client](https://developer.apple.com/library/archive/documentation/Accessibility/Conceptual/AccessibilityMacOSX/OSXAXTestingApps.html):
 
 * "Media Play/Pause"
 * "Media Next Track"
 * "Media Previous Track"
 * "Media Stop"
+* "Volume Up"
+* "Volume Down"
+* "Volume Mute"
 
 ### `globalShortcut.isRegistered(accelerator)`
 


### PR DESCRIPTION
Volume control (Up/Down/Mute) also need accessibility permission on macOS 10.14 & 10.15.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] relevant documentation is changed or added

#### Release Notes

None