### PR TITLE
fix: console windows from ELECTRON_RUN_AS_NODE instances

### DIFF
--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -210,8 +210,11 @@ int NodeMain(int argc, char* argv[]) {
       isolate_data = node::CreateIsolateData(isolate, loop, gin_env.platform());
       CHECK_NE(nullptr, isolate_data);
 
-      env = node::CreateEnvironment(isolate_data, gin_env.context(),
-                                    result.args, result.exec_args);
+      uint64_t flags = node::EnvironmentFlags::kDefaultFlags |
+                       node::EnvironmentFlags::kHideConsoleWindows;
+      env = node::CreateEnvironment(
+          isolate_data, gin_env.context(), result.args, result.exec_args,
+          static_cast<node::EnvironmentFlags::Flags>(flags));
       CHECK_NE(nullptr, env);
 
       node::IsolateSettings is;


### PR DESCRIPTION
#### Description of Change

When adopting [16.8.0](https://github.com/electron/electron/pull/30714) our global console window patch was replaced to adopt https://github.com/nodejs/node/pull/39712 but it was not adopted for `ELECTRON_RUN_AS_NODE` instances leading to the creation of console windows when spawning console applications from a forked process.

Refs https://github.com/microsoft/vscode/issues/137481

Gist example: https://gist.github.com/deepak1556/eefed2d47fada30c15ab9077d1532d0b

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix console windows from ELECTRON_RUN_AS_NODE instances