### PR TITLE
chore: cherry-pick 1459675360c1 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -127,3 +127,4 @@ allow_null_skbitmap_to_be_transferred_across_threads.patch
 use_weakptrs_for_the_threadediconloader_s_background_tasks.patch
 cherry-pick-a5f54612590d.patch
 fix_aspect_ratio_with_max_size.patch
+cherry-pick-1459675360c1.patch

--- a/patches/chromium/cherry-pick-1459675360c1.patch
+++ b/patches/chromium/cherry-pick-1459675360c1.patch
@@ -1,7 +1,7 @@
-From 1459675360c1494ade8504e8147ce4df383bfbad Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Khushal <khushalsagar@chromium.org>
-Date: Wed, 06 Oct 2021 19:48:28 +0000
-Subject: [PATCH] viz: Ensure render passes referenced by shared elements are valid.
+Date: Wed, 6 Oct 2021 19:48:28 +0000
+Subject: viz: Ensure render passes referenced by shared elements are valid.
 
 The render pass ids used by shared elements must be present in the
 CompositorFrame. Validate this during deserialization and reject the
@@ -17,10 +17,9 @@ Auto-Submit: Khushal <khushalsagar@chromium.org>
 Reviewed-by: Tom Sepez <tsepez@chromium.org>
 Reviewed-by: vmpstr <vmpstr@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#928819}
----
 
 diff --git a/services/viz/public/cpp/compositing/compositor_frame_mojom_traits.cc b/services/viz/public/cpp/compositing/compositor_frame_mojom_traits.cc
-index 20b9ad3..258f3f6 100644
+index 20b9ad3d90427e502a930b0907dc17151a4301c6..258f3f6ab00bc1dd4cf3c5574c22bfc8dd5c517b 100644
 --- a/services/viz/public/cpp/compositing/compositor_frame_mojom_traits.cc
 +++ b/services/viz/public/cpp/compositing/compositor_frame_mojom_traits.cc
 @@ -8,6 +8,16 @@
@@ -40,7 +39,7 @@ index 20b9ad3..258f3f6 100644
  // static
  bool StructTraits<viz::mojom::CompositorFrameDataView, viz::CompositorFrame>::
      Read(viz::mojom::CompositorFrameDataView data, viz::CompositorFrame* out) {
-@@ -28,6 +38,20 @@
+@@ -28,6 +38,20 @@ bool StructTraits<viz::mojom::CompositorFrameDataView, viz::CompositorFrame>::
    if (!data.ReadMetadata(&out->metadata))
      return false;
  
@@ -62,7 +61,7 @@ index 20b9ad3..258f3f6 100644
      viz::SetDeserializationCrashKeyString(
          "Failed read CompositorFrame::resource_list");
 diff --git a/services/viz/public/cpp/compositing/mojom_traits_unittest.cc b/services/viz/public/cpp/compositing/mojom_traits_unittest.cc
-index 2853fe9..55a8c69 100644
+index d9317611877c3bf1e8383d9cf82f8b4ef3078091..10765eea426b983f4a8e8e5d6b64c1d17307449d 100644
 --- a/services/viz/public/cpp/compositing/mojom_traits_unittest.cc
 +++ b/services/viz/public/cpp/compositing/mojom_traits_unittest.cc
 @@ -21,6 +21,7 @@
@@ -73,7 +72,7 @@ index 2853fe9..55a8c69 100644
  #include "gpu/ipc/common/mailbox_holder_mojom_traits.h"
  #include "gpu/ipc/common/mailbox_mojom_traits.h"
  #include "gpu/ipc/common/sync_token_mojom_traits.h"
-@@ -588,6 +589,39 @@
+@@ -572,6 +573,39 @@ TEST_F(StructTraitsTest, CompositorFrame) {
              out_solid_color_draw_quad->force_anti_aliasing_off);
  }
  

--- a/patches/chromium/cherry-pick-1459675360c1.patch
+++ b/patches/chromium/cherry-pick-1459675360c1.patch
@@ -1,0 +1,115 @@
+From 1459675360c1494ade8504e8147ce4df383bfbad Mon Sep 17 00:00:00 2001
+From: Khushal <khushalsagar@chromium.org>
+Date: Wed, 06 Oct 2021 19:48:28 +0000
+Subject: [PATCH] viz: Ensure render passes referenced by shared elements are valid.
+
+The render pass ids used by shared elements must be present in the
+CompositorFrame. Validate this during deserialization and reject the
+message on failure.
+
+R=vmpstr@chromium.org, tsepez@chromium.org
+
+Bug: 1222498
+Change-Id: I6d38652c67da3cc52fd253803fcecec1f21ae003
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3173660
+Commit-Queue: Khushal <khushalsagar@chromium.org>
+Auto-Submit: Khushal <khushalsagar@chromium.org>
+Reviewed-by: Tom Sepez <tsepez@chromium.org>
+Reviewed-by: vmpstr <vmpstr@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#928819}
+---
+
+diff --git a/services/viz/public/cpp/compositing/compositor_frame_mojom_traits.cc b/services/viz/public/cpp/compositing/compositor_frame_mojom_traits.cc
+index 20b9ad3..258f3f6 100644
+--- a/services/viz/public/cpp/compositing/compositor_frame_mojom_traits.cc
++++ b/services/viz/public/cpp/compositing/compositor_frame_mojom_traits.cc
+@@ -8,6 +8,16 @@
+ 
+ namespace mojo {
+ 
++bool RenderPassExists(viz::CompositorRenderPassId pass_id,
++                      const viz::CompositorRenderPassList& render_passes) {
++  for (const auto& pass : render_passes) {
++    if (pass->id == pass_id)
++      return true;
++  }
++
++  return false;
++}
++
+ // static
+ bool StructTraits<viz::mojom::CompositorFrameDataView, viz::CompositorFrame>::
+     Read(viz::mojom::CompositorFrameDataView data, viz::CompositorFrame* out) {
+@@ -28,6 +38,20 @@
+   if (!data.ReadMetadata(&out->metadata))
+     return false;
+ 
++  // Ensure that all render passes referenced by shared elements are present in
++  // the CompositorFrame.
++  for (const auto& directive : out->metadata.transition_directives) {
++    for (const auto& shared_element : directive.shared_elements()) {
++      if (shared_element.render_pass_id.is_null())
++        continue;
++
++      if (!RenderPassExists(shared_element.render_pass_id,
++                            out->render_pass_list)) {
++        return false;
++      }
++    }
++  }
++
+   if (!data.ReadResources(&out->resource_list)) {
+     viz::SetDeserializationCrashKeyString(
+         "Failed read CompositorFrame::resource_list");
+diff --git a/services/viz/public/cpp/compositing/mojom_traits_unittest.cc b/services/viz/public/cpp/compositing/mojom_traits_unittest.cc
+index 2853fe9..55a8c69 100644
+--- a/services/viz/public/cpp/compositing/mojom_traits_unittest.cc
++++ b/services/viz/public/cpp/compositing/mojom_traits_unittest.cc
+@@ -21,6 +21,7 @@
+ #include "components/viz/common/surfaces/surface_info.h"
+ #include "components/viz/common/surfaces/surface_range.h"
+ #include "components/viz/test/begin_frame_args_test.h"
++#include "components/viz/test/compositor_frame_helpers.h"
+ #include "gpu/ipc/common/mailbox_holder_mojom_traits.h"
+ #include "gpu/ipc/common/mailbox_mojom_traits.h"
+ #include "gpu/ipc/common/sync_token_mojom_traits.h"
+@@ -588,6 +589,39 @@
+             out_solid_color_draw_quad->force_anti_aliasing_off);
+ }
+ 
++TEST_F(StructTraitsTest, CompositorFrameTransitionDirective) {
++  auto frame = CompositorFrameBuilder()
++                   .AddDefaultRenderPass()
++                   .AddDefaultRenderPass()
++                   .AddDefaultRenderPass()
++                   .Build();
++
++  CompositorFrameTransitionDirective::SharedElement element;
++  element.render_pass_id = frame.render_pass_list.front()->id;
++  frame.metadata.transition_directives.push_back(
++      CompositorFrameTransitionDirective(
++          1u, CompositorFrameTransitionDirective::Type::kSave,
++          CompositorFrameTransitionDirective::Effect::kNone,
++          CompositorFrameTransitionDirective::TransitionConfig(), {element}));
++
++  // This ensures de-serialization succeeds if all passes are present.
++  CompositorFrame output;
++  ASSERT_TRUE(mojo::test::SerializeAndDeserialize<mojom::CompositorFrame>(
++      frame, output));
++
++  element.render_pass_id = CompositorRenderPassId(
++      frame.render_pass_list.back()->id.GetUnsafeValue() + 1);
++  frame.metadata.transition_directives.push_back(
++      CompositorFrameTransitionDirective(
++          1u, CompositorFrameTransitionDirective::Type::kSave,
++          CompositorFrameTransitionDirective::Effect::kNone,
++          CompositorFrameTransitionDirective::TransitionConfig(), {element}));
++
++  // This ensures de-serialization fails if a pass is missing.
++  ASSERT_FALSE(mojo::test::SerializeAndDeserialize<mojom::CompositorFrame>(
++      frame, output));
++}
++
+ TEST_F(StructTraitsTest, SurfaceInfo) {
+   const SurfaceId surface_id(
+       FrameSinkId(1234, 4321),


### PR DESCRIPTION
viz: Ensure render passes referenced by shared elements are valid.

The render pass ids used by shared elements must be present in the
CompositorFrame. Validate this during deserialization and reject the
message on failure.

R=vmpstr@chromium.org, tsepez@chromium.org

Bug: 1222498
Change-Id: I6d38652c67da3cc52fd253803fcecec1f21ae003
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3173660
Commit-Queue: Khushal <khushalsagar@chromium.org>
Auto-Submit: Khushal <khushalsagar@chromium.org>
Reviewed-by: Tom Sepez <tsepez@chromium.org>
Reviewed-by: vmpstr <vmpstr@chromium.org>
Cr-Commit-Position: refs/heads/main@{#928819}


Notes: Backported fix for chromium:1222498.