### PR TITLE
fix: window.open not overriding parent's webPreferences

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -680,16 +680,6 @@ WebContents.prototype._init = function () {
         postBody
       };
       windowOpenOverriddenOptions = this._callWindowOpenHandler(event, details);
-      // if attempting to use this API with the deprecated new-window event,
-      // windowOpenOverriddenOptions will always return null. This ensures
-      // short-term backwards compatibility until new-window is removed.
-      const parsedFeatures = parseFeatures(rawFeatures);
-      const overriddenFeatures: BrowserWindowConstructorOptions = {
-        ...parsedFeatures.options,
-        webPreferences: parsedFeatures.webPreferences
-      };
-      windowOpenOverriddenOptions = windowOpenOverriddenOptions || overriddenFeatures;
-
       if (!event.defaultPrevented) {
         const secureOverrideWebPreferences = windowOpenOverriddenOptions ? {
           // Allow setting of backgroundColor as a webPreference even though
@@ -699,9 +689,19 @@ WebContents.prototype._init = function () {
           transparent: windowOpenOverriddenOptions.transparent,
           ...windowOpenOverriddenOptions.webPreferences
         } : undefined;
-        this._setNextChildWebPreferences(
-          makeWebPreferences({ embedder: event.sender, secureOverrideWebPreferences })
-        );
+        // TODO(zcbenz): The features string is parsed twice: here where it is
+        // passed to C++, and in |makeBrowserWindowOptions| later where it is
+        // not actually used since the WebContents is created here.
+        // We should be able to remove the latter once the |nativeWindowOpen|
+        // option is removed.
+        const { webPreferences: parsedWebPreferences } = parseFeatures(rawFeatures);
+        // Parameters should keep same with |makeBrowserWindowOptions|.
+        const webPreferences = makeWebPreferences({
+          embedder: event.sender,
+          insecureParsedWebPreferences: parsedWebPreferences,
+          secureOverrideWebPreferences
+        });
+        this._setNextChildWebPreferences(webPreferences);
       }
     });
 

--- a/lib/browser/guest-window-manager.ts
+++ b/lib/browser/guest-window-manager.ts
@@ -217,6 +217,10 @@ function makeBrowserWindowOptions ({ embedder, features, overrideOptions }: {
       height: 600,
       ...parsedOptions,
       ...overrideOptions,
+      // Note that for |nativeWindowOpen: true| the WebContents is created in
+      // |api::WebContents::WebContentsCreatedWithFullParams|, with prefs
+      // parsed in the |-will-add-new-contents| event.
+      // The |webPreferences| here is only used by |nativeWindowOpen: false|.
       webPreferences: makeWebPreferences({
         embedder,
         insecureParsedWebPreferences: parsedWebPreferences,

--- a/shell/renderer/electron_render_frame_observer.h
+++ b/shell/renderer/electron_render_frame_observer.h
@@ -44,6 +44,7 @@ class ElectronRenderFrameObserver : public content::RenderFrameObserver {
   void OnTakeHeapSnapshot(IPC::PlatformFileForTransit file_handle,
                           const std::string& channel);
 
+  bool has_delayed_node_initialization_ = false;
   content::RenderFrame* render_frame_;
   RendererClientBase* renderer_client_;
 };

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -813,6 +813,17 @@ describe('chromium features', () => {
       expect(typeofProcessGlobal).to.equal('undefined');
     });
 
+    it('can disable node integration when it is enabled on the parent window with nativeWindowOpen: true', async () => {
+      const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, nativeWindowOpen: true } });
+      w.loadURL('about:blank');
+      w.webContents.executeJavaScript(`
+        { b = window.open('about:blank', '', 'nodeIntegration=no,show=no'); null }
+      `);
+      const [, contents] = await emittedOnce(app, 'web-contents-created');
+      const typeofProcessGlobal = await contents.executeJavaScript('typeof process');
+      expect(typeofProcessGlobal).to.equal('undefined');
+    });
+
     it('disables JavaScript when it is disabled on the parent window', async () => {
       const w = new BrowserWindow({ show: true, webPreferences: { nodeIntegration: true } });
       w.webContents.loadFile(path.resolve(__dirname, 'fixtures', 'blank.html'));

--- a/spec-main/fixtures/crash-cases/setimmediate-window-open-crash/index.html
+++ b/spec-main/fixtures/crash-cases/setimmediate-window-open-crash/index.html
@@ -1,10 +1,12 @@
 <html>
 <body>
 <script>
-// `setImmediate` schedules a function to be run on the next UV tick, which
-//  ensures that `window.open` is run from `UvRunOnce()`.
-setImmediate(async () => {
-  if (!location.hash) {
+if (location.hash) {
+  window.opener.postMessage('foo', '*');
+} else {
+  // `setImmediate` schedules a function to be run on the next UV tick, which
+  //  ensures that `window.open` is run from `UvRunOnce()`.
+  setImmediate(async () => {
     const p = new Promise(resolve => {
       window.addEventListener('message', resolve, { once: true });
     });
@@ -12,10 +14,8 @@ setImmediate(async () => {
     const e = await p;
 
     window.close();
-  } else {
-    window.opener.postMessage('foo', '*');
-  }
-});
+  });
+}
 </script>
 </body>
 </html>


### PR DESCRIPTION
#### Description of Change

This PR fixes an issue that, the feature string passed in `window.open` can not override the parent window's `webPreferences`, close https://github.com/electron/electron/issues/31949.

Please check the comments in `electron_render_frame_observer.cc` for the background of the problem.

Fix PR also fixes an issue introduced by https://github.com/electron/electron/pull/31031 that, the feature string in `window.open` was treated as `windowOpenOverriddenOptions` which would override the `securityWebPreferences`. This problem was hidden by the above bug 31949 because the feature string could not override parent prefs, but with 31949 fixed 31031 would then allow feature string to override security options.

There are also changes to tests as some of them rely on the bug to work.

#### Release Notes

Notes: Fix `window.open` not overriding parent's `webPreferences`.