### PR TITLE
fix: older systems crash when playing media files

### DIFF
--- a/patches/chromium/fix_media_key_usage_with_globalshortcuts.patch
+++ b/patches/chromium/fix_media_key_usage_with_globalshortcuts.patch
@@ -59,7 +59,7 @@ index ad366d0fd4c3a637d75a102ab56984f0d01bfc04..d63eb133fd4bab1ea309bb8c742acf88
    // true if register successfully, or false if 1) the specificied |accelerator|
    // has been registered by another caller or other native applications, or
 diff --git a/content/browser/media/media_keys_listener_manager_impl.cc b/content/browser/media/media_keys_listener_manager_impl.cc
-index 5938f75742b793868638e693a9a8c8dc686dfc46..1137ea6c6b2b14f912b400e3cc43dc6fd0243407 100644
+index 5938f75742b793868638e693a9a8c8dc686dfc46..fdf8dd6a0f4a63badf3aa55181835adc22e4d988 100644
 --- a/content/browser/media/media_keys_listener_manager_impl.cc
 +++ b/content/browser/media/media_keys_listener_manager_impl.cc
 @@ -55,7 +55,12 @@ bool MediaKeysListenerManagerImpl::StartWatchingMediaKey(
@@ -76,32 +76,29 @@ index 5938f75742b793868638e693a9a8c8dc686dfc46..1137ea6c6b2b14f912b400e3cc43dc6f
        !media_keys_listener_->StartWatchingMediaKey(key_code)) {
      return false;
    }
-@@ -231,18 +236,16 @@ void MediaKeysListenerManagerImpl::StartListeningForMediaKeysIfNecessary() {
+@@ -231,19 +236,19 @@ void MediaKeysListenerManagerImpl::StartListeningForMediaKeysIfNecessary() {
        media::AudioManager::GetGlobalAppName());
  #endif
  
--  if (system_media_controls_) {
--    system_media_controls_->AddObserver(this);
--    system_media_controls_notifier_ =
--        std::make_unique<SystemMediaControlsNotifier>(
--            system_media_controls_.get());
++  // This is required for proper functioning of MediaMetadata.
+   if (system_media_controls_) {
+     system_media_controls_->AddObserver(this);
+     system_media_controls_notifier_ =
+         std::make_unique<SystemMediaControlsNotifier>(
+             system_media_controls_.get());
 -  } else {
 -    // If we can't access system media controls, then directly listen for media
 -    // key keypresses instead.
 -    media_keys_listener_ = ui::MediaKeysListener::Create(
 -        this, ui::MediaKeysListener::Scope::kGlobal);
 -    DCHECK(media_keys_listener_);
--  }
-+  // This is required for proper functioning of MediaMetadata.
-+  system_media_controls_->AddObserver(this);
-+  system_media_controls_notifier_ =
-+      std::make_unique<SystemMediaControlsNotifier>(
-+          system_media_controls_.get());
-+
+   }
+ 
 +  // Directly listen for media key keypresses when using GlobalShortcuts.
 +  media_keys_listener_ = ui::MediaKeysListener::Create(
 +    this, ui::MediaKeysListener::Scope::kGlobal);
 +  DCHECK(media_keys_listener_);
- 
++
    EnsureAuxiliaryServices();
  }
+ 

--- a/patches/chromium/fix_media_key_usage_with_globalshortcuts.patch
+++ b/patches/chromium/fix_media_key_usage_with_globalshortcuts.patch
@@ -59,7 +59,7 @@ index ad366d0fd4c3a637d75a102ab56984f0d01bfc04..d63eb133fd4bab1ea309bb8c742acf88
    // true if register successfully, or false if 1) the specificied |accelerator|
    // has been registered by another caller or other native applications, or
 diff --git a/content/browser/media/media_keys_listener_manager_impl.cc b/content/browser/media/media_keys_listener_manager_impl.cc
-index 5938f75742b793868638e693a9a8c8dc686dfc46..fdf8dd6a0f4a63badf3aa55181835adc22e4d988 100644
+index 5938f75742b793868638e693a9a8c8dc686dfc46..7f30f3fdd2c63612232e31c331b26b17ad729efb 100644
 --- a/content/browser/media/media_keys_listener_manager_impl.cc
 +++ b/content/browser/media/media_keys_listener_manager_impl.cc
 @@ -55,7 +55,12 @@ bool MediaKeysListenerManagerImpl::StartWatchingMediaKey(
@@ -76,12 +76,11 @@ index 5938f75742b793868638e693a9a8c8dc686dfc46..fdf8dd6a0f4a63badf3aa55181835adc
        !media_keys_listener_->StartWatchingMediaKey(key_code)) {
      return false;
    }
-@@ -231,19 +236,19 @@ void MediaKeysListenerManagerImpl::StartListeningForMediaKeysIfNecessary() {
-       media::AudioManager::GetGlobalAppName());
+@@ -232,18 +237,18 @@ void MediaKeysListenerManagerImpl::StartListeningForMediaKeysIfNecessary() {
  #endif
  
-+  // This is required for proper functioning of MediaMetadata.
    if (system_media_controls_) {
++    // This is required for proper functioning of MediaMetadata.
      system_media_controls_->AddObserver(this);
      system_media_controls_notifier_ =
          std::make_unique<SystemMediaControlsNotifier>(
@@ -93,7 +92,7 @@ index 5938f75742b793868638e693a9a8c8dc686dfc46..fdf8dd6a0f4a63badf3aa55181835adc
 -        this, ui::MediaKeysListener::Scope::kGlobal);
 -    DCHECK(media_keys_listener_);
    }
- 
+
 +  // Directly listen for media key keypresses when using GlobalShortcuts.
 +  media_keys_listener_ = ui::MediaKeysListener::Create(
 +    this, ui::MediaKeysListener::Scope::kGlobal);

--- a/patches/chromium/fix_media_key_usage_with_globalshortcuts.patch
+++ b/patches/chromium/fix_media_key_usage_with_globalshortcuts.patch
@@ -92,7 +92,7 @@ index 5938f75742b793868638e693a9a8c8dc686dfc46..7f30f3fdd2c63612232e31c331b26b17
 -        this, ui::MediaKeysListener::Scope::kGlobal);
 -    DCHECK(media_keys_listener_);
    }
-
+ 
 +  // Directly listen for media key keypresses when using GlobalShortcuts.
 +  media_keys_listener_ = ui::MediaKeysListener::Create(
 +    this, ui::MediaKeysListener::Scope::kGlobal);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/31762.

Regression caused by https://github.com/electron/electron/pull/31492. On Windows 7 & 8 / macOS 10.11/10.12, `system_media_controls_` is `nullptr` and calling methods on it crashes the process. This PR wraps problematic statements in an if-clause like upstream Chromium does.

I manually checked that MediaMetadata still works on Windows 10 and above.

cc @codebytere @lyswhut @miniak 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes / manually validated
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed crash when playing media files on Windows 7/8 or macOS 10.11/10.12.
