### PR TITLE
fix: gtk_native_dialog_run() calls show() internally

### DIFF
--- a/shell/browser/ui/file_dialog_gtk.cc
+++ b/shell/browser/ui/file_dialog_gtk.cc
@@ -412,9 +412,8 @@ void FileChooserDialog::OnUpdatePreview(GtkFileChooser* chooser) {
 }  // namespace
 
 void ShowFileDialog(const FileChooserDialog& dialog) {
-  if (*supports_gtk_file_chooser_native) {
-    dl_gtk_native_dialog_show(static_cast<void*>(dialog.dialog()));
-  } else {
+  // gtk_native_dialog_run() will call gtk_native_dialog_show() for us.
+  if (!*supports_gtk_file_chooser_native) {
     gtk_widget_show_all(GTK_WIDGET(dialog.dialog()));
   }
 }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

In the synchronous code path, gtk_native_dialog_run() will call
gtk_native_dialog_show(). Previously this was causing an assertion to be
hit at run time.

https://gitlab.gnome.org/GNOME/gtk/-/blob/3.24.30/gtk/gtknativedialog.c#L584

fixes #31997 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Assertion failure happening in the `showSaveDialogSync()` code path has been fixed. (Fixes #31997)
