### PR TITLE
docs: add Bugsnag as a 3rd party crash server

### DIFF
--- a/docs/api/crash-reporter.md
+++ b/docs/api/crash-reporter.md
@@ -27,6 +27,7 @@ Or use a 3rd party hosted solution:
 * [Backtrace](https://backtrace.io/electron/)
 * [Sentry](https://docs.sentry.io/clients/electron)
 * [BugSplat](https://www.bugsplat.com/docs/platforms/electron)
+* [Bugsnag](https://docs.bugsnag.com/platforms/electron/)
 
 Crash reports are stored temporarily before being uploaded in a directory
 underneath the app's user data directory, called 'Crashpad'. You can override


### PR DESCRIPTION
#### Description of Change

Adds Bugsnag to the list of 3rd party crash servers in the `crashReporter` docs ([announcement blog](https://www.bugsnag.com/blog/error-monitoring-stability-electron)).

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added

#### Release Notes

Notes: none