### PR TITLE
build: account for path-filtering workflow in release-build script

### DIFF
--- a/script/release/ci-release-build.js
+++ b/script/release/ci-release-build.js
@@ -110,8 +110,10 @@ async function getCircleCIWorkflowId (pipelineId) {
     switch (pipelineInfo.state) {
       case 'created': {
         const workflows = await circleCIRequest(`${pipelineInfoUrl}/workflow`, 'GET');
-        if (workflows.items.length === 1) {
-          workflowId = workflows.items[0].id;
+        // The logic below expects two workflow.items: publish [0] & setup [1]
+        if (workflows.items.length === 2) {
+          workflowId = (workflows.items[0].name.includes('publish'))
+            ? workflows.items[0].id : workflows.items[1].id;
           break;
         }
         console.log('Unxpected number of workflows, response was:', pipelineInfo);

--- a/script/release/ci-release-build.js
+++ b/script/release/ci-release-build.js
@@ -112,8 +112,7 @@ async function getCircleCIWorkflowId (pipelineId) {
         const workflows = await circleCIRequest(`${pipelineInfoUrl}/workflow`, 'GET');
         // The logic below expects two workflow.items: publish [0] & setup [1]
         if (workflows.items.length === 2) {
-          workflowId = (workflows.items[0].name.includes('publish'))
-            ? workflows.items[0].id : workflows.items[1].id;
+          workflowId = workflows.items.find(item => item.name.includes('publish')).id;
           break;
         }
         console.log('Unxpected number of workflows, response was:', pipelineInfo);


### PR DESCRIPTION
#### Description of Change

Fast-follow to #31741. In our release build script, we currently hard-check for one workflow job during publish. However, dynamic config and path-filtering add a mandatory additional setup job. This PR adds logic to check and account for that setup job, and return the correct API response.

_Note: These CI changes were merged into main. While the changes were also backported to other branches, they were not merged until a new nightly was successfully kicked off. This commit will be added to the existing backport PRs, hence the "no backport" label._

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
