### PR TITLE
build: add logic for build and publish

### DIFF
--- a/script/release/ci-release-build.js
+++ b/script/release/ci-release-build.js
@@ -110,12 +110,17 @@ async function getCircleCIWorkflowId (pipelineId) {
     switch (pipelineInfo.state) {
       case 'created': {
         const workflows = await circleCIRequest(`${pipelineInfoUrl}/workflow`, 'GET');
-        // The logic below expects two workflow.items: publish [0] & setup [1]
+        // Publish logic expects two workflow jobs: publish & setup
         if (workflows.items.length === 2) {
           workflowId = workflows.items.find(item => item.name.includes('publish')).id;
           break;
         }
-        console.log('Unxpected number of workflows, response was:', pipelineInfo);
+        // Build logic below expects one workflow job: setup
+        if (workflows.items.length === 1) {
+          workflowId = workflows.items[0].id;
+          break;
+        }
+        console.log(`Unxpected number of workflows (found ${workflows.items.length}), response was:`, pipelineInfo);
         workflowId = -1;
         break;
       }


### PR DESCRIPTION
#### Description of Change

Fast-follow to #31741 & #32063. This PR adds logic to check for non-publish builds in our release build script. It also adds a small bit of logging to make it easier to detect how many workflows were triggered.

_Note: These CI changes were merged into main. While the changes were also backported to other branches, they were not merged until a new nightly was successfully kicked off. This commit will be added to the existing backport PRs, hence the "no backport" label._

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
