### PR TITLE
docs: change China mirror domain to npmmirror.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ const child = proc.spawn(electron)
 
 ### Mirrors
 
-- [China](https://npm.taobao.org/mirrors/electron)
+- [China](https://npmmirror.com/mirrors/electron)
 
 ## Documentation Translations
 

--- a/docs/tutorial/installation.md
+++ b/docs/tutorial/installation.md
@@ -73,7 +73,7 @@ url = ELECTRON_MIRROR + ELECTRON_CUSTOM_DIR + '/' + ELECTRON_CUSTOM_FILENAME
 For instance, to use the China CDN mirror:
 
 ```shell
-ELECTRON_MIRROR="https://cdn.npm.taobao.org/dist/electron/"
+ELECTRON_MIRROR="https://npmmirror.com/mirrors/electron/"
 ```
 
 By default, `ELECTRON_CUSTOM_DIR` is set to `v$VERSION`. To change the format,
@@ -83,12 +83,12 @@ resolves to `version-5.0.0`, `{{ version }}` resolves to `5.0.0`, and
 use the China non-CDN mirror:
 
 ```shell
-ELECTRON_MIRROR="https://npm.taobao.org/mirrors/electron/"
+ELECTRON_MIRROR="https://npmmirror.com/mirrors/electron/"
 ELECTRON_CUSTOM_DIR="{{ version }}"
 ```
 
 The above configuration will download from URLs such as
-`https://npm.taobao.org/mirrors/electron/8.0.0/electron-v8.0.0-linux-x64.zip`.
+`https://npmmirror.com/mirrors/electron/8.0.0/electron-v8.0.0-linux-x64.zip`.
 
 If your mirror serves artifacts with different checksums to the official
 Electron release you may have to set `ELECTRON_USE_REMOTE_CHECKSUMS=1` to


### PR DESCRIPTION
#### Description of Change

Taobao npm mirror domain has been changed to npmmirror.com.
Ref: https://segmentfault.com/a/1190000040936469

#### Release Notes

Notes: no-notes