### PR TITLE
fix: avoid double call in OnRefreshComplete on aura platforms (#32052)

### DIFF
--- a/patches/chromium/desktop_media_list.patch
+++ b/patches/chromium/desktop_media_list.patch
@@ -52,7 +52,7 @@ index 98cc4e039ba2b5a467175b15650a7b8ef38e8249..f5aea6a5916b9aa56ee7b81a8de97dc4
    const Source& GetSource(int index) const override;
    DesktopMediaList::Type GetMediaListType() const override;
 diff --git a/chrome/browser/media/webrtc/native_desktop_media_list.cc b/chrome/browser/media/webrtc/native_desktop_media_list.cc
-index c899b52ef01d2c9ea16b281a2b7c4d37f175fa36..a5fc476a52215eba33193012629ab1f73d679c88 100644
+index c899b52ef01d2c9ea16b281a2b7c4d37f175fa36..f752163d4e1951b2f79c7cc1cb4db51c0965472e 100644
 --- a/chrome/browser/media/webrtc/native_desktop_media_list.cc
 +++ b/chrome/browser/media/webrtc/native_desktop_media_list.cc
 @@ -16,7 +16,7 @@
@@ -72,12 +72,15 @@ index c899b52ef01d2c9ea16b281a2b7c4d37f175fa36..a5fc476a52215eba33193012629ab1f7
  const base::Feature kWindowCaptureMacV2{"WindowCaptureMacV2",
                                          base::FEATURE_DISABLED_BY_DEFAULT};
  #endif
-@@ -427,6 +428,8 @@ void NativeDesktopMediaList::RefreshForVizFrameSinkWindows(
+@@ -427,6 +428,11 @@ void NativeDesktopMediaList::RefreshForVizFrameSinkWindows(
          FROM_HERE, base::BindOnce(&Worker::RefreshThumbnails,
                                    base::Unretained(worker_.get()),
                                    std::move(native_ids), thumbnail_size_));
 +  } else {
-+    OnRefreshComplete();
++#if defined(USE_AURA)
++    pending_native_thumbnail_capture_ = true;
++#endif
++    UpdateNativeThumbnailsFinished();
    }
  }
  


### PR DESCRIPTION
Manual backport of #32052

See that PR for details

Notes: Fixed potential crash on Windows and Linux when using `desktopCapturer.getSources`