### PR TITLE
docs: Clarify `will-redirect` event

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -290,7 +290,7 @@ Returns:
 * `frameProcessId` Integer
 * `frameRoutingId` Integer
 
-Emitted as a server side redirect occurs during navigation.  For example a 302
+Emitted when a server side redirect occurs during navigation.  For example a 302
 redirect.
 
 This event will be emitted after `did-start-navigation` and always before the


### PR DESCRIPTION
#### Description of Change
Fixed some odd language in `web-contents.md`. The line was introduced in [the original "add will-redirect" PR](https://github.com/electron/electron/pull/13866/files#diff-18ed6a5b5a9084c976509502962b7f05989a8bd13a2ba3dc02868056938c03b6R194).

#### Release Notes

Notes: none