### PR TITLE
refactor: use process type specific electron imports in default_app

### DIFF
--- a/default_app/default_app.ts
+++ b/default_app/default_app.ts
@@ -1,4 +1,5 @@
-import { app, dialog, BrowserWindow, shell, ipcMain } from 'electron';
+import { shell } from 'electron/common';
+import { app, dialog, BrowserWindow, ipcMain } from 'electron/main';
 import * as path from 'path';
 import * as url from 'url';
 

--- a/default_app/main.ts
+++ b/default_app/main.ts
@@ -1,4 +1,4 @@
-import * as electron from 'electron';
+import * as electron from 'electron/main';
 
 import * as fs from 'fs';
 import * as path from 'path';

--- a/default_app/preload.ts
+++ b/default_app/preload.ts
@@ -1,4 +1,4 @@
-import { ipcRenderer, contextBridge } from 'electron';
+import { ipcRenderer, contextBridge } from 'electron/renderer';
 
 const policy = window.trustedTypes.createPolicy('electron-default-app', {
   // we trust the SVG contents


### PR DESCRIPTION
#### Description of Change
Let's lead by example

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none
