### PR TITLE
feat: add app.isHidden API for macOS

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -584,7 +584,7 @@ Hides all application windows without minimizing them.
 
 ### `app.isHidden()` _macOS_
 
-Whether the application is hidden (e.g. with Command-H).
+Whether the application—including all of its windows—is hidden (e.g. with `Command-H`).
 
 ### `app.show()` _macOS_
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -584,7 +584,7 @@ Hides all application windows without minimizing them.
 
 ### `app.isHidden()` _macOS_
 
-Whether the application—including all of its windows—is hidden (e.g. with `Command-H`).
+Returns `boolean` - `true` if the application—including all of its windows—is hidden (e.g. with `Command-H`), `false` otherwise.
 
 ### `app.show()` _macOS_
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -582,6 +582,10 @@ You should seek to use the `steal` option as sparingly as possible.
 
 Hides all application windows without minimizing them.
 
+### `app.isHidden()` _macOS_
+
+Whether the application is hidden (e.g. with Command-H).
+
 ### `app.show()` _macOS_
 
 Shows application windows after they were hidden. Does not automatically focus

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1741,6 +1741,7 @@ gin::ObjectTemplateBuilder App::GetObjectTemplateBuilder(v8::Isolate* isolate) {
                  base::BindRepeating(&Browser::IsEmojiPanelSupported, browser))
 #if defined(OS_MAC)
       .SetMethod("hide", base::BindRepeating(&Browser::Hide, browser))
+      .SetMethod("isHidden", base::BindRepeating(&Browser::IsHidden, browser))
       .SetMethod("show", base::BindRepeating(&Browser::Show, browser))
       .SetMethod("setUserActivity",
                  base::BindRepeating(&Browser::SetUserActivity, browser))

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -158,6 +158,7 @@ class Browser : public WindowListObserver {
 
   // Hide the application.
   void Hide();
+  bool IsHidden();
 
   // Show the application.
   void Show();

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -117,6 +117,10 @@ void Browser::Hide() {
   [[AtomApplication sharedApplication] hide:nil];
 }
 
+bool Browser::IsHidden() {
+  return [[AtomApplication sharedApplication] isHidden];
+}
+
 void Browser::Show() {
   [[AtomApplication sharedApplication] unhide:nil];
 }

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -1519,6 +1519,20 @@ describe('app module', () => {
     });
   });
 
+  const showHideDescribe = process.platform === 'darwin' ? describe : describe.skip;
+  showHideDescribe('app hide and show API', () => {
+    describe('app.isHidden', () => {
+      it('returns true when the app is hidden', () => {
+        app.hide();
+        expect(app.isHidden()).to.be.true();
+      });
+      it('returns false when the app is shown', () => {
+        app.show();
+        expect(app.isHidden()).to.be.false();
+      });
+    });
+  });
+
   const dockDescribe = process.platform === 'darwin' ? describe : describe.skip;
   dockDescribe('dock APIs', () => {
     after(async () => {

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -9,7 +9,7 @@ import { promisify } from 'util';
 import { app, BrowserWindow, Menu, session, net as electronNet } from 'electron/main';
 import { emittedOnce } from './events-helpers';
 import { closeWindow, closeAllWindows } from './window-helpers';
-import { ifdescribe, ifit } from './spec-helpers';
+import { ifdescribe, ifit, waitUntil } from './spec-helpers';
 import split = require('split')
 
 const fixturesPath = path.resolve(__dirname, '../spec/fixtures');
@@ -1522,13 +1522,17 @@ describe('app module', () => {
   const showHideDescribe = process.platform === 'darwin' ? describe : describe.skip;
   showHideDescribe('app hide and show API', () => {
     describe('app.isHidden', () => {
-      it('returns true when the app is hidden', () => {
+      it('returns true when the app is hidden', async () => {
         app.hide();
-        expect(app.isHidden()).to.be.true();
+        await expect(
+          waitUntil(() => app.isHidden())
+        ).to.eventually.be.fulfilled();
       });
-      it('returns false when the app is shown', () => {
+      it('returns false when the app is shown', async () => {
         app.show();
-        expect(app.isHidden()).to.be.false();
+        await expect(
+          waitUntil(() => !app.isHidden())
+        ).to.eventually.be.fulfilled();
       });
     });
   });

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -1519,8 +1519,7 @@ describe('app module', () => {
     });
   });
 
-  const showHideDescribe = process.platform === 'darwin' ? describe : describe.skip;
-  showHideDescribe('app hide and show API', () => {
+  ifdescribe(process.platform === 'darwin')('app hide and show API', () => {
     describe('app.isHidden', () => {
       it('returns true when the app is hidden', async () => {
         app.hide();


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Refs #30485.

Added an API to check if the app is hidden on macOS. This is a distinct state from the app _windows_ being hidden, and can be used to implement unique behaviour on activation. It is also useful in conjunction with `NSWindow.canHide`, which I will introduce in a follow-up MR if there are no objections.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added `app.isHidden()` to check if the app is hidden (e.g. with Command-H) on macOS.
