### PR TITLE
docs: update discord server URL in tutorial/introduction.md

### DIFF
--- a/docs/tutorial/introduction.md
+++ b/docs/tutorial/introduction.md
@@ -56,4 +56,4 @@ problem. If not, feel free to fill out our bug report template and submit a new 
 [comic]: https://www.google.com/googlebooks/chrome/
 [fiddle]: https://electronjs.org/fiddle
 [issue-tracker]: https://github.com/electron/electron/issues
-[discord]: https://discord.gg/electron
+[discord]: https://discord.gg/electronjs


### PR DESCRIPTION
#### Description of Change
The discord url in [the introduction page](https://www.electronjs.org/docs/latest#getting-help) ([github](https://github.com/electron/electron/blob/main/docs/tutorial/introduction.md)) is discord.gg/electron, which doesn't refer to the electron project. This commit changes the URL to discord.gg/electronjs to ensure people reading this documentation are directed to the correct discord server
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] relevant documentation is changed or added


#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
