### PR TITLE
chore: cherry-pick 418c276ef228 from v8

### DIFF
--- a/patches/v8/.patches
+++ b/patches/v8/.patches
@@ -15,3 +15,4 @@ merged_cppgc_fix_marking_of_ephemerons_with_keys_in_construction.patch
 cherry-pick-014e1f857c33.patch
 cherry-pick-feef10137b16.patch
 cherry-pick-5d2b5e7c006c.patch
+cherry-pick-418c276ef228.patch

--- a/patches/v8/cherry-pick-418c276ef228.patch
+++ b/patches/v8/cherry-pick-418c276ef228.patch
@@ -1,0 +1,41 @@
+From 418c276ef228163080a4aed7ea0f4bab3aeeb8a0 Mon Sep 17 00:00:00 2001
+From: Leszek Swirski <leszeks@chromium.org>
+Date: Fri, 10 Dec 2021 15:56:05 +0100
+Subject: [PATCH] Merged: [compiler] Don't elide ChangeTaggedToInt32->ChangeInt31ToTaggedSigned
+
+
+(cherry picked from commit 4fae8b16802a416fe3aab0e7792fabe96cf1ecd8)
+
+(cherry picked from commit f4f11c23ae2eaf9bb4525d0fac7ab842de9b0fe2)
+
+Bug: chromium:1278387
+No-Try: true
+No-Presubmit: true
+No-Tree-Checks: true
+Change-Id: I9b89834c094510e064988aa534ec230309996034
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3329665
+Reviewed-by: Toon Verwaest <verwaest@chromium.org>
+Cr-Original-Commit-Position: refs/branch-heads/9.6@{#40}
+Cr-Original-Branched-From: 0b7bda016178bf438f09b3c93da572ae3663a1f7-refs/heads/9.6.180@{#1}
+Cr-Original-Branched-From: 41a5a247d9430b953e38631e88d17790306f7a4c-refs/heads/main@{#77244}
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3335759
+Commit-Queue: Leszek Swirski <leszeks@chromium.org>
+Owners-Override: Leszek Swirski <leszeks@chromium.org>
+Cr-Commit-Position: refs/branch-heads/9.4@{#56}
+Cr-Branched-From: 3b51863bc25492549a8bf96ff67ce481b1a3337b-refs/heads/9.4.146@{#1}
+Cr-Branched-From: 2890419fc8fb9bdb507fdd801d76fa7dd9f022b5-refs/heads/master@{#76233}
+---
+
+diff --git a/src/compiler/simplified-operator-reducer.cc b/src/compiler/simplified-operator-reducer.cc
+index ea9e9f4..33edd66 100644
+--- a/src/compiler/simplified-operator-reducer.cc
++++ b/src/compiler/simplified-operator-reducer.cc
+@@ -77,7 +77,7 @@
+     case IrOpcode::kChangeInt32ToTagged: {
+       Int32Matcher m(node->InputAt(0));
+       if (m.HasResolvedValue()) return ReplaceNumber(m.ResolvedValue());
+-      if (m.IsChangeTaggedToInt32() || m.IsChangeTaggedSignedToInt32()) {
++      if (m.IsChangeTaggedSignedToInt32()) {
+         return Replace(m.InputAt(0));
+       }
+       break;

--- a/patches/v8/cherry-pick-418c276ef228.patch
+++ b/patches/v8/cherry-pick-418c276ef228.patch
@@ -1,8 +1,8 @@
-From 418c276ef228163080a4aed7ea0f4bab3aeeb8a0 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Leszek Swirski <leszeks@chromium.org>
 Date: Fri, 10 Dec 2021 15:56:05 +0100
-Subject: [PATCH] Merged: [compiler] Don't elide ChangeTaggedToInt32->ChangeInt31ToTaggedSigned
-
+Subject: Merged: [compiler] Don't elide
+ ChangeTaggedToInt32->ChangeInt31ToTaggedSigned
 
 (cherry picked from commit 4fae8b16802a416fe3aab0e7792fabe96cf1ecd8)
 
@@ -24,13 +24,12 @@ Owners-Override: Leszek Swirski <leszeks@chromium.org>
 Cr-Commit-Position: refs/branch-heads/9.4@{#56}
 Cr-Branched-From: 3b51863bc25492549a8bf96ff67ce481b1a3337b-refs/heads/9.4.146@{#1}
 Cr-Branched-From: 2890419fc8fb9bdb507fdd801d76fa7dd9f022b5-refs/heads/master@{#76233}
----
 
 diff --git a/src/compiler/simplified-operator-reducer.cc b/src/compiler/simplified-operator-reducer.cc
-index ea9e9f4..33edd66 100644
+index ea9e9f4ba5dbc89d2f9d700d1a1111b9dda83e15..33edd66b4ff43e4150895bf232d107060876ca08 100644
 --- a/src/compiler/simplified-operator-reducer.cc
 +++ b/src/compiler/simplified-operator-reducer.cc
-@@ -77,7 +77,7 @@
+@@ -77,7 +77,7 @@ Reduction SimplifiedOperatorReducer::Reduce(Node* node) {
      case IrOpcode::kChangeInt32ToTagged: {
        Int32Matcher m(node->InputAt(0));
        if (m.HasResolvedValue()) return ReplaceNumber(m.ResolvedValue());


### PR DESCRIPTION
Merged: [compiler] Don't elide ChangeTaggedToInt32->ChangeInt31ToTaggedSigned


(cherry picked from commit 4fae8b16802a416fe3aab0e7792fabe96cf1ecd8)

(cherry picked from commit f4f11c23ae2eaf9bb4525d0fac7ab842de9b0fe2)

Bug: chromium:1278387
No-Try: true
No-Presubmit: true
No-Tree-Checks: true
Change-Id: I9b89834c094510e064988aa534ec230309996034
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3329665
Reviewed-by: Toon Verwaest <verwaest@chromium.org>
Cr-Original-Commit-Position: refs/branch-heads/9.6@{#40}
Cr-Original-Branched-From: 0b7bda016178bf438f09b3c93da572ae3663a1f7-refs/heads/9.6.180@{#1}
Cr-Original-Branched-From: 41a5a247d9430b953e38631e88d17790306f7a4c-refs/heads/main@{#77244}
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3335759
Commit-Queue: Leszek Swirski <leszeks@chromium.org>
Owners-Override: Leszek Swirski <leszeks@chromium.org>
Cr-Commit-Position: refs/branch-heads/9.4@{#56}
Cr-Branched-From: 3b51863bc25492549a8bf96ff67ce481b1a3337b-refs/heads/9.4.146@{#1}
Cr-Branched-From: 2890419fc8fb9bdb507fdd801d76fa7dd9f022b5-refs/heads/master@{#76233}


Notes: Backported fix for CVE-2021-4102.