### PR TITLE
docs: correct webFrame description

### DIFF
--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -5,8 +5,8 @@
 Process: [Renderer](../glossary.md#renderer-process)
 
 `webFrame` export of the Electron module is an instance of the `WebFrame`
-class representing the top frame of the current `BrowserWindow`. Sub-frames can
-be retrieved by certain properties and methods (e.g. `webFrame.firstChild`).
+class representing the current frame. Sub-frames can be retrieved by
+certain properties and methods (e.g. `webFrame.firstChild`).
 
 An example of zooming current page to 200%.
 


### PR DESCRIPTION
#### Description of Change

The current description incorrectly states that the webFrame export represents the top frame but it actually represents the current frame.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added

#### Release Notes
Notes: none
