### PR TITLE
docs: clarify case insensitive dictionary hosting

### DIFF
--- a/docs/api/session.md
+++ b/docs/api/session.md
@@ -903,8 +903,10 @@ setting with the current OS locale.  This setting is persisted across restarts.
 By default Electron will download hunspell dictionaries from the Chromium CDN.  If you want to override this
 behavior you can use this API to point the dictionary downloader at your own hosted version of the hunspell
 dictionaries.  We publish a `hunspell_dictionaries.zip` file with each release which contains the files you need
-to host here, the file server must be **case insensitive** you must upload each file twice, once with the case it
-has in the ZIP file and once with the filename as all lower case.
+to host here.
+
+The file server must be **case insensitive**. If you cannot do this, you must upload each file twice: once with
+the case it has in the ZIP file and once with the filename as all lowercase.
 
 If the files present in `hunspell_dictionaries.zip` are available at `https://example.com/dictionaries/language-code.bdic`
 then you should call this api with `ses.setSpellCheckerDictionaryDownloadURL('https://example.com/dictionaries/')`.  Please


### PR DESCRIPTION
#### Description of Change

You must either (1) have a case-insensitive file server (2) upload files in both casings. See <https://github.com/electron/electron/issues/22482#issuecomment-593617375>. This improves the docs to clarify that.

#### Checklist

- [x] relevant documentation is changed or added

#### Release Notes

Notes: none
