### PR TITLE
chore: cherry-pick 891020ed64d4 from angle

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -3,3 +3,4 @@ cherry-pick-1fb846c.patch
 cherry-pick-72473550f6ff.patch
 webgl_make_unsuccessful_links_fail_subsequent_draw_calls.patch
 fix_integer_overflow_in_blocklayoutencoder.patch
+cherry-pick-891020ed64d4.patch

--- a/patches/angle/cherry-pick-891020ed64d4.patch
+++ b/patches/angle/cherry-pick-891020ed64d4.patch
@@ -1,7 +1,7 @@
-From 891020ed64d418a738b867e5c7e7cb1d0e40c892 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jonah Ryan-Davis <jonahr@google.com>
 Date: Mon, 22 Nov 2021 14:30:52 -0500
-Subject: [PATCH] [M96] Ignore the pixel unpack state for compressed textures.
+Subject: Ignore the pixel unpack state for compressed textures.
 
 From OpenGL ES 3 spec: All pixel storage modes are ignored when decoding
 a compressed texture image
@@ -18,13 +18,12 @@ Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
 Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3309097
 Reviewed-by: Jonah Ryan-Davis <jonahr@google.com>
 Reviewed-by: Jamie Madill <jmadill@chromium.org>
----
 
 diff --git a/src/libANGLE/Context.cpp b/src/libANGLE/Context.cpp
-index b3b7f73..94afefd 100644
+index 4c0fbae275812e14d1732be9bc0ae0fd630cbe81..7deca1499ef55aa051ee1839dc7fcbf2e50687e8 100644
 --- a/src/libANGLE/Context.cpp
 +++ b/src/libANGLE/Context.cpp
-@@ -5017,7 +5017,9 @@
+@@ -4873,7 +4873,9 @@ void Context::compressedTexImage2D(TextureTarget target,
  
      Extents size(width, height, 1);
      Texture *texture = getTextureByTarget(target);
@@ -35,7 +34,7 @@ index b3b7f73..94afefd 100644
                                                    internalformat, size, imageSize,
                                                    static_cast<const uint8_t *>(data)));
  }
-@@ -5049,7 +5051,9 @@
+@@ -4905,7 +4907,9 @@ void Context::compressedTexImage3D(TextureTarget target,
  
      Extents size(width, height, depth);
      Texture *texture = getTextureByTarget(target);
@@ -46,7 +45,7 @@ index b3b7f73..94afefd 100644
                                                    internalformat, size, imageSize,
                                                    static_cast<const uint8_t *>(data)));
  }
-@@ -5083,8 +5087,10 @@
+@@ -4939,8 +4943,10 @@ void Context::compressedTexSubImage2D(TextureTarget target,
  
      Box area(xoffset, yoffset, 0, width, height, 1);
      Texture *texture = getTextureByTarget(target);
@@ -59,7 +58,7 @@ index b3b7f73..94afefd 100644
                                                       static_cast<const uint8_t *>(data)));
  }
  
-@@ -5125,8 +5131,10 @@
+@@ -4981,8 +4987,10 @@ void Context::compressedTexSubImage3D(TextureTarget target,
  
      Box area(xoffset, yoffset, zoffset, width, height, depth);
      Texture *texture = getTextureByTarget(target);
@@ -73,10 +72,10 @@ index b3b7f73..94afefd 100644
  }
  
 diff --git a/src/tests/gl_tests/TextureTest.cpp b/src/tests/gl_tests/TextureTest.cpp
-index 4d7ba26..79baa98 100644
+index d238f823c4dd3cd3180a87b97857231b0c8b788e..f6dad3a3df52994284f570ed38f24b8efe37e513 100644
 --- a/src/tests/gl_tests/TextureTest.cpp
 +++ b/src/tests/gl_tests/TextureTest.cpp
-@@ -5201,6 +5201,43 @@
+@@ -4580,6 +4580,43 @@ TEST_P(Texture2DTestES3, TextureCompletenessChangesWithMaxLevel)
      EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::black);
  }
  
@@ -120,7 +119,7 @@ index 4d7ba26..79baa98 100644
  // Test that 3D texture completeness is updated if texture max level changes.
  // GLES 3.0.4 section 3.8.13 Texture completeness
  TEST_P(Texture3DTestES3, Texture3DCompletenessChangesWithMaxLevel)
-@@ -5888,6 +5925,41 @@
+@@ -5259,6 +5296,41 @@ TEST_P(Texture2DTestES3, TextureCOMPRESSEDSRGB8ETC2ImplicitAlpha1)
      EXPECT_PIXEL_ALPHA_EQ(0, 0, 255);
  }
  

--- a/patches/angle/cherry-pick-891020ed64d4.patch
+++ b/patches/angle/cherry-pick-891020ed64d4.patch
@@ -1,0 +1,164 @@
+From 891020ed64d418a738b867e5c7e7cb1d0e40c892 Mon Sep 17 00:00:00 2001
+From: Jonah Ryan-Davis <jonahr@google.com>
+Date: Mon, 22 Nov 2021 14:30:52 -0500
+Subject: [PATCH] [M96] Ignore the pixel unpack state for compressed textures.
+
+From OpenGL ES 3 spec: All pixel storage modes are ignored when decoding
+a compressed texture image
+This was causing a bad access when calling compressedTexImage3D
+with GL_UNPACK_IMAGE_HEIGHT greater than the image height.
+
+Bug: chromium:1267496
+Change-Id: I9b1f4c645548af64f2695fd23262225a1ad07cd7
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3296622
+Commit-Queue: Jonah Ryan-Davis <jonahr@google.com>
+Reviewed-by: Geoff Lang <geofflang@chromium.org>
+Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
+(cherry picked from commit 870f458f507ff7ba0f67b28a30a27955ce79dd3e)
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3309097
+Reviewed-by: Jonah Ryan-Davis <jonahr@google.com>
+Reviewed-by: Jamie Madill <jmadill@chromium.org>
+---
+
+diff --git a/src/libANGLE/Context.cpp b/src/libANGLE/Context.cpp
+index b3b7f73..94afefd 100644
+--- a/src/libANGLE/Context.cpp
++++ b/src/libANGLE/Context.cpp
+@@ -5017,7 +5017,9 @@
+ 
+     Extents size(width, height, 1);
+     Texture *texture = getTextureByTarget(target);
+-    ANGLE_CONTEXT_TRY(texture->setCompressedImage(this, mState.getUnpackState(), target, level,
++    // From OpenGL ES 3 spec: All pixel storage modes are ignored when decoding a compressed texture
++    // image. So we use an empty PixelUnpackState.
++    ANGLE_CONTEXT_TRY(texture->setCompressedImage(this, PixelUnpackState(), target, level,
+                                                   internalformat, size, imageSize,
+                                                   static_cast<const uint8_t *>(data)));
+ }
+@@ -5049,7 +5051,9 @@
+ 
+     Extents size(width, height, depth);
+     Texture *texture = getTextureByTarget(target);
+-    ANGLE_CONTEXT_TRY(texture->setCompressedImage(this, mState.getUnpackState(), target, level,
++    // From OpenGL ES 3 spec: All pixel storage modes are ignored when decoding a compressed texture
++    // image. So we use an empty PixelUnpackState.
++    ANGLE_CONTEXT_TRY(texture->setCompressedImage(this, PixelUnpackState(), target, level,
+                                                   internalformat, size, imageSize,
+                                                   static_cast<const uint8_t *>(data)));
+ }
+@@ -5083,8 +5087,10 @@
+ 
+     Box area(xoffset, yoffset, 0, width, height, 1);
+     Texture *texture = getTextureByTarget(target);
+-    ANGLE_CONTEXT_TRY(texture->setCompressedSubImage(this, mState.getUnpackState(), target, level,
+-                                                     area, format, imageSize,
++    // From OpenGL ES 3 spec: All pixel storage modes are ignored when decoding a compressed texture
++    // image. So we use an empty PixelUnpackState.
++    ANGLE_CONTEXT_TRY(texture->setCompressedSubImage(this, PixelUnpackState(), target, level, area,
++                                                     format, imageSize,
+                                                      static_cast<const uint8_t *>(data)));
+ }
+ 
+@@ -5125,8 +5131,10 @@
+ 
+     Box area(xoffset, yoffset, zoffset, width, height, depth);
+     Texture *texture = getTextureByTarget(target);
+-    ANGLE_CONTEXT_TRY(texture->setCompressedSubImage(this, mState.getUnpackState(), target, level,
+-                                                     area, format, imageSize,
++    // From OpenGL ES 3 spec: All pixel storage modes are ignored when decoding a compressed texture
++    // image. So we use an empty PixelUnpackState.
++    ANGLE_CONTEXT_TRY(texture->setCompressedSubImage(this, PixelUnpackState(), target, level, area,
++                                                     format, imageSize,
+                                                      static_cast<const uint8_t *>(data)));
+ }
+ 
+diff --git a/src/tests/gl_tests/TextureTest.cpp b/src/tests/gl_tests/TextureTest.cpp
+index 4d7ba26..79baa98 100644
+--- a/src/tests/gl_tests/TextureTest.cpp
++++ b/src/tests/gl_tests/TextureTest.cpp
+@@ -5201,6 +5201,43 @@
+     EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::black);
+ }
+ 
++// Test that compressed textures ignore the pixel unpack state.
++// (https://crbug.org/1267496)
++TEST_P(Texture3DTestES3, PixelUnpackStateTexImage)
++{
++    ANGLE_SKIP_TEST_IF(!IsGLExtensionEnabled("GL_EXT_texture_compression_s3tc") &&
++                       !IsGLExtensionEnabled("GL_ANGLE_texture_compression_dxt3"));
++
++    glPixelStorei(GL_UNPACK_IMAGE_HEIGHT, 5);
++    glBindTexture(GL_TEXTURE_2D_ARRAY, mTexture3D);
++
++    uint8_t data[64] = {0};
++    glCompressedTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GL_COMPRESSED_RGBA_S3TC_DXT3_EXT, 4, 4, 4, 0, 64,
++                           data);
++    EXPECT_GL_NO_ERROR();
++}
++
++// Test that compressed textures ignore the pixel unpack state.
++// (https://crbug.org/1267496)
++TEST_P(Texture3DTestES3, PixelUnpackStateTexSubImage)
++{
++    ANGLE_SKIP_TEST_IF(!IsGLExtensionEnabled("GL_EXT_texture_compression_s3tc") &&
++                       !IsGLExtensionEnabled("GL_ANGLE_texture_compression_dxt3"));
++
++    glBindTexture(GL_TEXTURE_2D_ARRAY, mTexture3D);
++
++    uint8_t data[64] = {0};
++    glCompressedTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GL_COMPRESSED_RGBA_S3TC_DXT3_EXT, 4, 4, 4, 0, 64,
++                           data);
++    EXPECT_GL_NO_ERROR();
++
++    glPixelStorei(GL_UNPACK_IMAGE_HEIGHT, 5);
++
++    glCompressedTexSubImage3D(GL_TEXTURE_2D_ARRAY, 0, 0, 0, 0, 4, 4, 4,
++                              GL_COMPRESSED_RGBA_S3TC_DXT3_EXT, 64, data);
++    EXPECT_GL_NO_ERROR();
++}
++
+ // Test that 3D texture completeness is updated if texture max level changes.
+ // GLES 3.0.4 section 3.8.13 Texture completeness
+ TEST_P(Texture3DTestES3, Texture3DCompletenessChangesWithMaxLevel)
+@@ -5888,6 +5925,41 @@
+     EXPECT_PIXEL_ALPHA_EQ(0, 0, 255);
+ }
+ 
++// Test that compressed textures ignore the pixel unpack state.
++// (https://crbug.org/1267496)
++TEST_P(Texture2DTestES3, PixelUnpackStateTexImage)
++{
++    ANGLE_SKIP_TEST_IF(!IsGLExtensionEnabled("GL_EXT_texture_compression_s3tc") &&
++                       !IsGLExtensionEnabled("GL_ANGLE_texture_compression_dxt3"));
++
++    glPixelStorei(GL_UNPACK_ROW_LENGTH, 5);
++    glBindTexture(GL_TEXTURE_2D, mTexture2D);
++
++    uint8_t data[16] = {0};
++    glCompressedTexImage2D(GL_TEXTURE_2D, 0, GL_COMPRESSED_RGBA_S3TC_DXT3_EXT, 4, 4, 0, 16, data);
++    EXPECT_GL_NO_ERROR();
++}
++
++// Test that compressed textures ignore the pixel unpack state.
++// (https://crbug.org/1267496)
++TEST_P(Texture2DTestES3, PixelUnpackStateTexSubImage)
++{
++    ANGLE_SKIP_TEST_IF(!IsGLExtensionEnabled("GL_EXT_texture_compression_s3tc") &&
++                       !IsGLExtensionEnabled("GL_ANGLE_texture_compression_dxt3"));
++
++    glBindTexture(GL_TEXTURE_2D, mTexture2D);
++
++    uint8_t data[16] = {0};
++    glCompressedTexImage2D(GL_TEXTURE_2D, 0, GL_COMPRESSED_RGBA_S3TC_DXT3_EXT, 4, 4, 0, 16, data);
++    EXPECT_GL_NO_ERROR();
++
++    glPixelStorei(GL_UNPACK_ROW_LENGTH, 5);
++
++    glCompressedTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 4, 4, GL_COMPRESSED_RGBA_S3TC_DXT3_EXT, 16,
++                              data);
++    EXPECT_GL_NO_ERROR();
++}
++
+ // Copied from Texture2DTest::TexStorage
+ // Test that glTexSubImage2D works properly when glTexStorage2DEXT has initialized the image with a
+ // default color.


### PR DESCRIPTION
[M96] Ignore the pixel unpack state for compressed textures.

From OpenGL ES 3 spec: All pixel storage modes are ignored when decoding
a compressed texture image
This was causing a bad access when calling compressedTexImage3D
with GL_UNPACK_IMAGE_HEIGHT greater than the image height.

Bug: chromium:1267496
Change-Id: I9b1f4c645548af64f2695fd23262225a1ad07cd7
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3296622
Commit-Queue: Jonah Ryan-Davis <jonahr@google.com>
Reviewed-by: Geoff Lang <geofflang@chromium.org>
Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
(cherry picked from commit 870f458f507ff7ba0f67b28a30a27955ce79dd3e)
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3309097
Reviewed-by: Jonah Ryan-Davis <jonahr@google.com>
Reviewed-by: Jamie Madill <jmadill@chromium.org>


Notes: Backported fix for CVE-2021-4058.