### PR TITLE
fix: check for single bluetooth listener

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -750,7 +750,7 @@ WebContents.prototype._init = function () {
   });
 
   this.on('select-bluetooth-device', (event, devices, callback) => {
-    if (this.listenerCount('select-bluetooth-device') === 0) {
+    if (this.listenerCount('select-bluetooth-device') === 1) {
       // Cancel it if there are no handlers
       event.preventDefault();
       callback('');


### PR DESCRIPTION
#### Description of Change
 
Fast follow for #32178 - ensures bluetooth devices are not returned by default, checks for a single default listener instead of none.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: No Notes
