### PR TITLE
fix: crash caused by `app.getLocaleCountryCode()`

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1054,11 +1054,14 @@ std::string App::GetLocaleCountryCode() {
   CFLocaleRef locale = CFLocaleCopyCurrent();
   CFStringRef value = CFStringRef(
       static_cast<CFTypeRef>(CFLocaleGetValue(locale, kCFLocaleCountryCode)));
-  const CFIndex kCStringSize = 128;
-  char temporaryCString[kCStringSize] = {0};
-  CFStringGetCString(value, temporaryCString, kCStringSize,
-                     kCFStringEncodingUTF8);
-  region = temporaryCString;
+  if (value != nil) {
+    char temporaryCString[3];
+    const CFIndex kCStringSize = sizeof(temporaryCString);
+    if (CFStringGetCString(value, temporaryCString, kCStringSize,
+                           kCFStringEncodingUTF8)) {
+      region = temporaryCString;
+    }
+  }
 #else
   const char* locale_ptr = setlocale(LC_TIME, nullptr);
   if (!locale_ptr)


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

CFLocaleGetValue() returned null and crashed the process when
app.getLocaleCountryCode() was run on a CircleCI metal resource class
macOS instance with Xcode 12.5.1. This change fixes that logic and adds
further checks to make the code future-proof.

Here too people are complaining that the returned country code migth be
null: https://stackoverflow.com/questions/15202454/nslocalecountrycode-returns-nil

Signed-off-by: Darshan Sen <darshan.sen@postman.com>

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash caused by app.getLocaleCountryCode(). <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
