### PR TITLE
docs: Update quick-start.md to include reference to 'index.js'

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -106,12 +106,12 @@ During execution, Electron will look for this script in the [`main`][package-jso
 field of the app's `package.json` config, which you should have configured during the
 [app scaffolding](#scaffold-the-project) step.
 
-To initialize the `main` script, create an empty file named `main.js` in the root folder
+To initialize the `main` script, create an empty file named `index.js` in the root folder
 of your project.
 
 > Note: If you run the `start` script again at this point, your app will no longer throw
 > any errors! However, it won't do anything yet because we haven't added any code into
-> `main.js`.
+> `index.js`.
 
 [package-json-main]: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#main
 


### PR DESCRIPTION
References to 'main.js' need to be changed to 'index.js' since this project will not run without 'index.js' being named properly.

Therefore, I have made the changes above, please let me know if this is approved.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
