### PR TITLE
fix: Allow x64 arch on Mac Rosetta

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -22,7 +22,8 @@ if (isInstalled()) {
 const platform = process.env.npm_config_platform || process.platform;
 let arch = process.env.npm_config_arch || process.arch;
 
-if (platform === 'darwin' && process.platform === 'darwin' && arch === 'x64') {
+if (platform === 'darwin' && process.platform === 'darwin' && arch === 'x64' &&
+    process.env.npm_config_arch === undefined) {
   // When downloading for macOS ON macOS and we think we need x64 we should
   // check if we're running under rosetta and download the arm64 version if appropriate
   try {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/32147.

If the `npm_config_arch` environment variable is set on Mac, then use the specified architecture rather than overriding it to x64.

Currently, `npm/install.js` overrides the architecture specified in `npm_config_arch` to be `arm64` when running on Mac Rosetta. However, this can break workflows that rely on specific architectures for compatibility with native addons. Some native addons do not yet provide prebuilds for Mac arm64, requiring the use of Electron x64. By installing native addons in a Rosetta environment, the correct x64 prebuilds will be used for native addons, but `npm/install.js` as written will force an install of arm64 Electron, which is incompatible with the x64 addons.

Additionally, it's quite confusing that https://www.electronjs.org/docs/latest/tutorial/installation states the `npm_config_arch` flag can be used to specify an arch, but its value is ignored in Rosetta environments. It seems like the value of this flag should be respected if set, and a best guess can be made when it's not set. An alternative approach here would be to allow setting a third environment variable to prevent the override, but that seemed more confusing than respecting the value of the existing variable.

If I've misunderstood anything above, do let me know!

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Allowed specifying x64 arch on Mac Rosetta via `npm_config_arch`.