### PR TITLE
fix: uses setAspectRatio for frameless window on mac

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -1600,10 +1600,15 @@ void NativeWindowMac::SetAspectRatio(double aspect_ratio,
   NativeWindow::SetAspectRatio(aspect_ratio, extra_size);
 
   // Reset the behaviour to default if aspect_ratio is set to 0 or less.
-  if (aspect_ratio > 0.0)
-    [window_ setContentAspectRatio:NSMakeSize(aspect_ratio, 1.0)];
-  else
+  if (aspect_ratio > 0.0) {
+    NSSize aspect_ratio_size = NSMakeSize(aspect_ratio, 1.0);
+    if (has_frame())
+      [window_ setContentAspectRatio:aspect_ratio_size];
+    else
+      [window_ setAspectRatio:aspect_ratio_size];
+  } else {
     [window_ setResizeIncrements:NSMakeSize(1.0, 1.0)];
+  }
 }
 
 void NativeWindowMac::PreviewFile(const std::string& path,


### PR DESCRIPTION
#### Description of Change

On macOS, NSWindow.setContentAspectRatio was being used to set the aspect ratio. However this works incorrectly for frameless windows, causing a jump in window size, when starting the resize. But using NSWindow.setAspectRatio, it works correctly for frameless windows (but not for framed windows, so we still have to use setContentAspectRatio in that case.)

Before:

https://user-images.githubusercontent.com/1059699/147412510-c6801f44-80bd-48d9-bcc9-d0c72d6d744a.mov

After:

https://user-images.githubusercontent.com/1059699/147412514-bdecfacb-6c8b-4eeb-a6d8-fa2a391d8dc8.mov

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes aspect ratio resize for frameless windows on macOS.