### PR TITLE
Update discord invite url to the new url

### DIFF
--- a/docs/tutorial/support.md
+++ b/docs/tutorial/support.md
@@ -10,7 +10,7 @@ for answers to questions,
 or to join in discussion with other developers who use Electron,
 you can interact with the community in these locations:
 
-* [Electron's Discord server](https://discord.com/invite/APGC3k5yaH) has channels for:
+* [Electron's Discord server](https://discord.gg/electronjs) has channels for:
   * Getting help
   * Ecosystem apps like [Electron Forge](https://github.com/electron-userland/electron-forge) and [Electron Fiddle](https://github.com/electron/fiddle)
   * Sharing ideas with other Electron app developers


### PR DESCRIPTION
#### Description of Change
I clicked on the link for discord and said "Invite Invalid"
![image](https://user-images.githubusercontent.com/11470833/147454575-15b4ca28-6e4b-498d-a71b-f720cb8e063d.png)

When I found the invite to the server and wanted to fix the link.

#### Checklist

- [ ] PR description included and stakeholders cc'd(https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
