### PR TITLE
docs: Docs rendering issue with rendering on electronjs quick-start

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -463,46 +463,46 @@ The fastest way to distribute your newly created app is using
 1. Add Electron Forge as a development dependency of your app, and use its `import` command to set up
 Forge's scaffolding:
 
-    ```sh npm2yarn
-    npm install --save-dev @electron-forge/cli
-    npx electron-forge import
+```sh npm2yarn
+npm install --save-dev @electron-forge/cli
+npx electron-forge import
 
-    ✔ Checking your system
-    ✔ Initializing Git Repository
-    ✔ Writing modified package.json file
-    ✔ Installing dependencies
-    ✔ Writing modified package.json file
-    ✔ Fixing .gitignore
+✔ Checking your system
+✔ Initializing Git Repository
+✔ Writing modified package.json file
+✔ Installing dependencies
+✔ Writing modified package.json file
+✔ Fixing .gitignore
 
-    We have ATTEMPTED to convert your app to be in a format that electron-forge understands.
+We have ATTEMPTED to convert your app to be in a format that electron-forge understands.
 
-    Thanks for using "electron-forge"!!!
-    ```
+Thanks for using "electron-forge"!!!
+```
 
 1. Create a distributable using Forge's `make` command:
 
-    ```sh npm2yarn
-    npm run make
+```sh npm2yarn
+npm run make
 
-    > my-electron-app@1.0.0 make /my-electron-app
-    > electron-forge make
+> my-electron-app@1.0.0 make /my-electron-app
+> electron-forge make
 
-    ✔ Checking your system
-    ✔ Resolving Forge Config
-    We need to package your application before we can make it
-    ✔ Preparing to Package Application for arch: x64
-    ✔ Preparing native dependencies
-    ✔ Packaging Application
-    Making for the following targets: zip
-    ✔ Making for target: zip - On platform: darwin - For arch: x64
-    ```
+✔ Checking your system
+✔ Resolving Forge Config
+We need to package your application before we can make it
+✔ Preparing to Package Application for arch: x64
+✔ Preparing native dependencies
+✔ Packaging Application
+Making for the following targets: zip
+✔ Making for target: zip - On platform: darwin - For arch: x64
+```
 
-    Electron Forge creates the `out` folder where your package will be located:
+Electron Forge creates the `out` folder where your package will be located:
 
-    ```plain
-    // Example for macOS
-    out/
-    ├── out/make/zip/darwin/x64/my-electron-app-darwin-x64-1.0.0.zip
-    ├── ...
-    └── out/my-electron-app-darwin-x64/my-electron-app.app/Contents/MacOS/my-electron-app
-    ```
+```plain
+// Example for macOS
+out/
+├── out/make/zip/darwin/x64/my-electron-app-darwin-x64-1.0.0.zip
+├── ...
+└── out/my-electron-app-darwin-x64/my-electron-app.app/Contents/MacOS/my-electron-app
+```


### PR DESCRIPTION
there is a issue with rendering on the bottom of page https://www.electronjs.org/docs/v14-x-y/tutorial/quick-start
which looks like this
![](https://dl3.pushbulletusercontent.com/MXsLhjaoKRj1bhu4R73E3WLiuKCBMkgh/image.png)

all id did is remove the spacing and it should fix the issue. sometimes having spaces before a "```" will cause issues

hope this helps!

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
 
#### Release Notes

Notes: no-notes
