### PR TITLE
fix: Support running git-[im,ex]port-patches with Python3 too

### DIFF
--- a/script/git-export-patches
+++ b/script/git-export-patches
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import argparse
 import sys

--- a/script/git-import-patches
+++ b/script/git-import-patches
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import argparse
 import sys

--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -229,6 +229,14 @@ def remove_patch_filename(patch):
     force_keep_next_line = l.startswith('Subject: ')
 
 
+def to_utf8(patch):
+  """Python 2/3 compatibility: unicode has been renamed to str in Python3"""
+  if sys.version_info[0] >= 3:
+    return str(patch, "utf-8")
+  else:
+    return unicode(patch, "utf-8")
+
+
 def export_patches(repo, out_dir, patch_range=None, dry_run=False):
   if patch_range is None:
     patch_range, num_patches = guess_base_commit(repo)
@@ -250,7 +258,7 @@ def export_patches(repo, out_dir, patch_range=None, dry_run=False):
     for patch in patches:
       filename = get_file_name(patch)
       filepath = posixpath.join(out_dir, filename)
-      existing_patch = unicode(io.open(filepath, 'rb').read(), "utf-8")
+      existing_patch = to_utf8(io.open(filepath, 'rb').read())
       formatted_patch = join_patch(patch)
       if formatted_patch != existing_patch:
         bad_patches.append(filename)


### PR DESCRIPTION
#### Description of Change

The scripts `git-import-patches` and `git-export-patches` work *almost* out of the box with Python3,
the only issue is that the `unicode` type was renamed to `str` there. For this reason, the interpreter version was hardcoded in #25335.

But the error with Python3 can easily be fixed by aliasing `unicode` to `str`. With that issue fixed, we can switch the shebang line back to the unversioned python command.

This saves one from having to install Python2 just for these scripts when Python3 is already installed on the system.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd

#### Release Notes

Notes: none