### PR TITLE
build: remove stale dependency for webrtc desktop capture module

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -632,12 +632,6 @@ source_set("electron_lib") {
   }
 
   if (enable_desktop_capturer) {
-    if (is_component_build && !is_linux) {
-      # On windows the implementation relies on unexported
-      # DxgiDuplicatorController class.  On macOS the implementation
-      # relies on unexported webrtc::GetWindowOwnerPid method.
-      deps += [ "//third_party/webrtc/modules/desktop_capture" ]
-    }
     sources += [
       "shell/browser/api/electron_api_desktop_capturer.cc",
       "shell/browser/api/electron_api_desktop_capturer.h",


### PR DESCRIPTION
#### Description of Change

WebRTC has changed how they integrate into Chromium, they don't expose their dependencies externally anymore.
Instead, one must now go through webrtc_overrides:
https://chromium.googlesource.com/chromium/src.git/+/cbc90fd093956

We're already including webrtc_overrides as a dependency which includes the modules, so this extra deps isn't needed anymore. It didn't apply to regular builds anyway, but it caused an error when attempting component builds.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd

#### Release Notes

Notes: none

CC: @jkleinsc 