### PR TITLE
fix: Don't create console window when creating process

### DIFF
--- a/patches/node/.patches
+++ b/patches/node/.patches
@@ -26,3 +26,4 @@ chore_fix_-wimplicit-fallthrough.patch
 test_add_fixture_trim_option.patch
 fix_crash_caused_by_gethostnamew_on_windows_7.patch
 fix_suppress_clang_-wdeprecated-declarations_in_libuv.patch
+fix_don_t_create_console_window_when_creating_process.patch

--- a/patches/node/fix_don_t_create_console_window_when_creating_process.patch
+++ b/patches/node/fix_don_t_create_console_window_when_creating_process.patch
@@ -7,7 +7,7 @@ This patch prevents console windows from being created during
 execSync calls, or spawnSync calls where shell is true. Otherwise,
 Windows users will see command prompts pop up for those calls.
 
-The patch can be removed when the windowsHide parameter
+The patch has been upstreamed with https://github.com/nodejs/node/pull/41412
 for those calls is changed to have a default value of true.
 
 diff --git a/src/spawn_sync.cc b/src/spawn_sync.cc

--- a/patches/node/fix_don_t_create_console_window_when_creating_process.patch
+++ b/patches/node/fix_don_t_create_console_window_when_creating_process.patch
@@ -7,8 +7,7 @@ This patch prevents console windows from being created during
 execSync calls, or spawnSync calls where shell is true. Otherwise,
 Windows users will see command prompts pop up for those calls.
 
-The patch has been upstreamed with https://github.com/nodejs/node/pull/41412
-for those calls is changed to have a default value of true.
+The patch has been upstreamed at https://github.com/nodejs/node/pull/41412.
 
 diff --git a/src/spawn_sync.cc b/src/spawn_sync.cc
 index 1141aceae984fba6ed07cd272a79d4007b9b03fe..afd08519d7f8974adff4060513f6160519a0b6b3 100644

--- a/patches/node/fix_don_t_create_console_window_when_creating_process.patch
+++ b/patches/node/fix_don_t_create_console_window_when_creating_process.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Raymond Zhao <raymondzhao@microsoft.com>
+Date: Tue, 4 Jan 2022 16:11:41 -0800
+Subject: fix: Don't create console window when creating process
+
+This patch prevents console windows from being created during
+execSync calls, or spawnSync calls where shell is true. Otherwise,
+Windows users will see command prompts pop up for those calls.
+
+The patch can be removed when the windowsHide parameter
+for those calls is changed to have a default value of true.
+
+diff --git a/src/spawn_sync.cc b/src/spawn_sync.cc
+index 1141aceae984fba6ed07cd272a79d4007b9b03fe..afd08519d7f8974adff4060513f6160519a0b6b3 100644
+--- a/src/spawn_sync.cc
++++ b/src/spawn_sync.cc
+@@ -810,6 +810,9 @@ Maybe<int> SyncProcessRunner::ParseOptions(Local<Value> js_value) {
+   if (js_win_hide->BooleanValue(isolate))
+     uv_process_options_.flags |= UV_PROCESS_WINDOWS_HIDE;
+ 
++  if (env()->hide_console_windows())
++    uv_process_options_.flags |= UV_PROCESS_WINDOWS_HIDE_CONSOLE;
++
+   Local<Value> js_wva =
+       js_options->Get(context, env()->windows_verbatim_arguments_string())
+           .ToLocalChecked();


### PR DESCRIPTION
#### Description of Change

Since the `windowsHide` parameters still default to `false`, we need to keep the patch that disables console windows from showing up. Otherwise, for `execSync` calls, or `spawnSync` calls with `shell: true`, console windows still show up for Windows users.

This issue has been occurring since Electron 16.

Downstream issue: https://github.com/microsoft/vscode/issues/138792

CC @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix regression where console windows would open for execSync and some spawnSync calls for Windows users.
