### PR TITLE
fix: older systems crash when playing media files

### DIFF
--- a/patches/chromium/fix_media_key_usage_with_globalshortcuts.patch
+++ b/patches/chromium/fix_media_key_usage_with_globalshortcuts.patch
@@ -59,45 +59,42 @@ index 9aec54a3263d24491d24013a80b719dfc834ecd4..001a6cb2a5eb701351fa924109b43fab
    // true if register successfully, or false if 1) the specificied |accelerator|
    // has been registered by another caller or other native applications, or
 diff --git a/content/browser/media/media_keys_listener_manager_impl.cc b/content/browser/media/media_keys_listener_manager_impl.cc
-index 5938f75742b793868638e693a9a8c8dc686dfc46..1263d679a5174beb960265989c370dd4a58ae7b4 100644
+index 5938f75742b793868638e693a9a8c8dc686dfc46..afeca1ede732543c4769fe47e5b41a6444a3bf6f 100644
 --- a/content/browser/media/media_keys_listener_manager_impl.cc
 +++ b/content/browser/media/media_keys_listener_manager_impl.cc
-@@ -231,18 +231,24 @@ void MediaKeysListenerManagerImpl::StartListeningForMediaKeysIfNecessary() {
-       media::AudioManager::GetGlobalAppName());
+@@ -232,18 +232,26 @@ void MediaKeysListenerManagerImpl::StartListeningForMediaKeysIfNecessary() {
  #endif
  
--  if (system_media_controls_) {
--    system_media_controls_->AddObserver(this);
--    system_media_controls_notifier_ =
--        std::make_unique<SystemMediaControlsNotifier>(
--            system_media_controls_.get());
+   if (system_media_controls_) {
++    // This is required for proper functioning of MediaMetadata.
+     system_media_controls_->AddObserver(this);
+     system_media_controls_notifier_ =
+         std::make_unique<SystemMediaControlsNotifier>(
+             system_media_controls_.get());
 -  } else {
 -    // If we can't access system media controls, then directly listen for media
 -    // key keypresses instead.
-+  // This is required for proper functioning of MediaMetadata.
-+  system_media_controls_->AddObserver(this);
-+  system_media_controls_notifier_ =
-+      std::make_unique<SystemMediaControlsNotifier>(
-+          system_media_controls_.get());
-+
+-    media_keys_listener_ = ui::MediaKeysListener::Create(
+-        this, ui::MediaKeysListener::Scope::kGlobal);
+-    DCHECK(media_keys_listener_);
+   }
+ 
 +  // Directly listen for media key keypresses when using GlobalShortcuts.
 +#if defined(OS_MACOS)
 +  auto scope = media_key_handling_enabled_ ?
 +    ui::MediaKeysListener::Scope::kGlobal :
 +    ui::MediaKeysListener::Scope::kGlobalRequiresAccessibility;
-     media_keys_listener_ = ui::MediaKeysListener::Create(
--        this, ui::MediaKeysListener::Scope::kGlobal);
--    DCHECK(media_keys_listener_);
--  }
++    media_keys_listener_ = ui::MediaKeysListener::Create(
 +      this, scope);
 +#else
 +  media_keys_listener_ = ui::MediaKeysListener::Create(
 +    this, ui::MediaKeysListener::Scope::kGlobal);
 +#endif
 +  DCHECK(media_keys_listener_);
- 
++
    EnsureAuxiliaryServices();
  }
+ 
 diff --git a/ui/base/accelerators/media_keys_listener.h b/ui/base/accelerators/media_keys_listener.h
 index c2b03328c0e508995bdc135031500783f500ceba..1b6b14dc2999c99445cef6ffc04d49a7c1728a54 100644
 --- a/ui/base/accelerators/media_keys_listener.h


### PR DESCRIPTION
Backport of #32046

See that PR for details.

Notes: Fixed crash when playing media files on Windows 7/8 or macOS 10.11/10.12.