### PR TITLE
chore: cleanup spec-main/ambient.d.ts

### DIFF
--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -317,7 +317,6 @@ class WebContents : public ExclusiveAccessContext,
   std::vector<base::FilePath> GetPreloadPaths() const;
 
   // Returns the web preferences of current WebContents.
-  v8::Local<v8::Value> GetWebPreferences(v8::Isolate* isolate) const;
   v8::Local<v8::Value> GetLastWebPreferences(v8::Isolate* isolate) const;
 
   // Returns the owner window.

--- a/spec-main/ambient.d.ts
+++ b/spec-main/ambient.d.ts
@@ -1,14 +1,4 @@
 declare let standardScheme: string;
-
-declare namespace Electron {
-  interface WebContents {
-    getOwnerBrowserWindow(): BrowserWindow | null;
-    getWebPreferences(): WebPreferences | null;
-  }
-
-  interface Session {
-    destroy(): void;
-  }
-}
+declare let serviceWorkerScheme: string;
 
 declare module 'dbus-native';

--- a/spec-main/api-protocol-spec.ts
+++ b/spec-main/api-protocol-spec.ts
@@ -743,7 +743,6 @@ describe('protocol module', () => {
   });
 
   describe('protocol.registerSchemesAsPrivileged allowServiceWorkers', () => {
-    const { serviceWorkerScheme } = global as any;
     protocol.registerStringProtocol(serviceWorkerScheme, (request, cb) => {
       if (request.url.endsWith('.js')) {
         cb({
@@ -773,7 +772,6 @@ describe('protocol module', () => {
   });
 
   describe('protocol.registerSchemesAsPrivileged standard', () => {
-    const standardScheme = (global as any).standardScheme;
     const origin = `${standardScheme}://fake-host`;
     const imageURL = `${origin}/test.png`;
     const filePath = path.join(fixturesPath, 'pages', 'b.html');
@@ -854,7 +852,6 @@ describe('protocol module', () => {
   });
 
   describe('protocol.registerSchemesAsPrivileged cors-fetch', function () {
-    const standardScheme = (global as any).standardScheme;
     let w: BrowserWindow = null as unknown as BrowserWindow;
     beforeEach(async () => {
       w = new BrowserWindow({ show: false });
@@ -957,7 +954,6 @@ describe('protocol module', () => {
     const pagePath = path.join(fixturesPath, 'pages', 'video.html');
     const videoSourceImagePath = path.join(fixturesPath, 'video-source-image.webp');
     const videoPath = path.join(fixturesPath, 'video.webm');
-    const standardScheme = (global as any).standardScheme;
     let w: BrowserWindow = null as unknown as BrowserWindow;
 
     before(async () => {

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -893,7 +893,6 @@ describe('webContents module', () => {
   });
 
   describe('zoom api', () => {
-    const scheme = (global as any).standardScheme;
     const hostZoomMap: Record<string, number> = {
       host1: 0.3,
       host2: 0.7,
@@ -902,7 +901,7 @@ describe('webContents module', () => {
 
     before(() => {
       const protocol = session.defaultSession.protocol;
-      protocol.registerStringProtocol(scheme, (request, callback) => {
+      protocol.registerStringProtocol(standardScheme, (request, callback) => {
         const response = `<script>
                             const {ipcRenderer} = require('electron')
                             ipcRenderer.send('set-zoom', window.location.hostname)
@@ -916,7 +915,7 @@ describe('webContents module', () => {
 
     after(() => {
       const protocol = session.defaultSession.protocol;
-      protocol.unregisterProtocol(scheme);
+      protocol.unregisterProtocol(standardScheme);
     });
 
     afterEach(closeAllWindows);
@@ -1008,7 +1007,7 @@ describe('webContents module', () => {
           if (finalNavigation) {
             done();
           } else {
-            w.loadURL(`${scheme}://host2`);
+            w.loadURL(`${standardScheme}://host2`);
           }
         } catch (e) {
           done(e);
@@ -1025,7 +1024,7 @@ describe('webContents module', () => {
           done(e);
         }
       });
-      w.loadURL(`${scheme}://host1`);
+      w.loadURL(`${standardScheme}://host1`);
     });
 
     it('can propagate zoom level across same session', async () => {
@@ -1037,10 +1036,10 @@ describe('webContents module', () => {
         w2.close();
       });
 
-      await w.loadURL(`${scheme}://host3`);
+      await w.loadURL(`${standardScheme}://host3`);
       w.webContents.zoomLevel = hostZoomMap.host3;
 
-      await w2.loadURL(`${scheme}://host3`);
+      await w2.loadURL(`${standardScheme}://host3`);
       const zoomLevel1 = w.webContents.zoomLevel;
       expect(zoomLevel1).to.equal(hostZoomMap.host3);
 
@@ -1057,7 +1056,7 @@ describe('webContents module', () => {
         }
       });
       const protocol = w2.webContents.session.protocol;
-      protocol.registerStringProtocol(scheme, (request, callback) => {
+      protocol.registerStringProtocol(standardScheme, (request, callback) => {
         callback('hello');
       });
 
@@ -1065,13 +1064,13 @@ describe('webContents module', () => {
         w2.setClosable(true);
         w2.close();
 
-        protocol.unregisterProtocol(scheme);
+        protocol.unregisterProtocol(standardScheme);
       });
 
-      await w.loadURL(`${scheme}://host3`);
+      await w.loadURL(`${standardScheme}://host3`);
       w.webContents.zoomLevel = hostZoomMap.host3;
 
-      await w2.loadURL(`${scheme}://host3`);
+      await w2.loadURL(`${standardScheme}://host3`);
       const zoomLevel1 = w.webContents.zoomLevel;
       expect(zoomLevel1).to.equal(hostZoomMap.host3);
 

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -589,7 +589,6 @@ describe('chromium features', () => {
 
     it('should register for custom scheme', (done) => {
       const customSession = session.fromPartition('custom-scheme');
-      const { serviceWorkerScheme } = global as any;
       customSession.protocol.registerFileProtocol(serviceWorkerScheme, (request, callback) => {
         let file = url.parse(request.url).pathname!;
         if (file[0] === '/' && process.platform === 'win32') file = file.slice(1);
@@ -1294,7 +1293,6 @@ describe('chromium features', () => {
     });
 
     describe('enableWebSQL webpreference', () => {
-      const standardScheme = (global as any).standardScheme;
       const origin = `${standardScheme}://fake-host`;
       const filePath = path.join(fixturesPath, 'pages', 'storage', 'web_sql.html');
       const sqlPartition = 'web-sql-preference-test';


### PR DESCRIPTION
#### Description of Change
Small cleanup to improve type safety. Also removes a few `(global as any)` in the tests.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes
Notes: none