### PR TITLE
build: auto add --force and --frozen-lockfile when exec yarn install

### DIFF
--- a/script/yarn.js
+++ b/script/yarn.js
@@ -10,7 +10,13 @@ exports.YARN_VERSION = YARN_VERSION;
 if (process.mainModule === module) {
   const NPX_CMD = process.platform === 'win32' ? 'npx.cmd' : 'npx';
 
-  const child = cp.spawn(NPX_CMD, [`yarn@${YARN_VERSION}`, ...process.argv.slice(2)], {
+  const argv = process.argv.slice(2);
+
+  if (argv.length === 0 || (argv.length === 1 && argv[0] === 'install')) {
+    argv.push('--force', '--frozen-lockfile');
+  }
+
+  const child = cp.spawn(NPX_CMD, [`yarn@${YARN_VERSION}`, ...argv], {
     stdio: 'inherit',
     env: {
       ...process.env,


### PR DESCRIPTION
#### Description of Change

Force the dependencies to be correct each time `yarn install` is executed
cc: @codebytere 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
