### PR TITLE
fix: pointer lock escape handling

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1244,6 +1244,9 @@ bool WebContents::PlatformHandleKeyboardEvent(
 content::KeyboardEventProcessingResult WebContents::PreHandleKeyboardEvent(
     content::WebContents* source,
     const content::NativeWebKeyboardEvent& event) {
+  if (exclusive_access_manager_->HandleUserKeyEvent(event))
+    return content::KeyboardEventProcessingResult::HANDLED;
+
   if (event.GetType() == blink::WebInputEvent::Type::kRawKeyDown ||
       event.GetType() == blink::WebInputEvent::Type::kKeyUp) {
     bool prevent_default = Emit("before-input-event", event);
@@ -1392,6 +1395,17 @@ void WebContents::FindReply(content::WebContents* web_contents,
   Emit("found-in-page", result.GetHandle());
 }
 
+void WebContents::RequestToLockMouse(content::WebContents* web_contents,
+                                     bool user_gesture,
+                                     bool last_unlocked_by_target) {
+  exclusive_access_manager_->mouse_lock_controller()->RequestToLockMouse(
+      web_contents, user_gesture, last_unlocked_by_target);
+}
+
+void WebContents::LostMouseLock() {
+  exclusive_access_manager_->mouse_lock_controller()->LostMouseLock();
+}
+
 void WebContents::RequestKeyboardLock(content::WebContents* web_contents,
                                       bool esc_key_locked) {
   exclusive_access_manager_->keyboard_lock_controller()->RequestKeyboardLock(
@@ -1422,14 +1436,6 @@ void WebContents::RequestMediaAccessPermission(
   auto* permission_helper =
       WebContentsPermissionHelper::FromWebContents(web_contents);
   permission_helper->RequestMediaAccessPermission(request, std::move(callback));
-}
-
-void WebContents::RequestToLockMouse(content::WebContents* web_contents,
-                                     bool user_gesture,
-                                     bool last_unlocked_by_target) {
-  auto* permission_helper =
-      WebContentsPermissionHelper::FromWebContents(web_contents);
-  permission_helper->RequestPointerLockPermission(user_gesture);
 }
 
 content::JavaScriptDialogManager* WebContents::GetJavaScriptDialogManager(

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1395,11 +1395,26 @@ void WebContents::FindReply(content::WebContents* web_contents,
   Emit("found-in-page", result.GetHandle());
 }
 
+void WebContents::RequestExclusivePointerAccess(
+    content::WebContents* web_contents,
+    bool user_gesture,
+    bool last_unlocked_by_target,
+    bool allowed) {
+  if (allowed) {
+    exclusive_access_manager_->mouse_lock_controller()->RequestToLockMouse(
+        web_contents, user_gesture, last_unlocked_by_target);
+  }
+}
+
 void WebContents::RequestToLockMouse(content::WebContents* web_contents,
                                      bool user_gesture,
                                      bool last_unlocked_by_target) {
-  exclusive_access_manager_->mouse_lock_controller()->RequestToLockMouse(
-      web_contents, user_gesture, last_unlocked_by_target);
+  auto* permission_helper =
+      WebContentsPermissionHelper::FromWebContents(web_contents);
+  permission_helper->RequestPointerLockPermission(
+      user_gesture, last_unlocked_by_target,
+      base::BindOnce(&WebContents::RequestExclusivePointerAccess,
+                     base::Unretained(this)));
 }
 
 void WebContents::LostMouseLock() {

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1403,6 +1403,9 @@ void WebContents::RequestExclusivePointerAccess(
   if (allowed) {
     exclusive_access_manager_->mouse_lock_controller()->RequestToLockMouse(
         web_contents, user_gesture, last_unlocked_by_target);
+  } else {
+    web_contents->GotResponseToLockMouseRequest(
+        blink::mojom::PointerLockResult::kPermissionDenied);
   }
 }
 

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -556,6 +556,10 @@ class WebContents : public ExclusiveAccessContext,
                  const gfx::Rect& selection_rect,
                  int active_match_ordinal,
                  bool final_update) override;
+  void RequestExclusivePointerAccess(content::WebContents* web_contents,
+                                     bool user_gesture,
+                                     bool last_unlocked_by_target,
+                                     bool allowed);
   void RequestToLockMouse(content::WebContents* web_contents,
                           bool user_gesture,
                           bool last_unlocked_by_target) override;

--- a/shell/browser/api/electron_api_web_contents.h
+++ b/shell/browser/api/electron_api_web_contents.h
@@ -556,6 +556,10 @@ class WebContents : public ExclusiveAccessContext,
                  const gfx::Rect& selection_rect,
                  int active_match_ordinal,
                  bool final_update) override;
+  void RequestToLockMouse(content::WebContents* web_contents,
+                          bool user_gesture,
+                          bool last_unlocked_by_target) override;
+  void LostMouseLock() override;
   void RequestKeyboardLock(content::WebContents* web_contents,
                            bool esc_key_locked) override;
   void CancelKeyboardLockRequest(content::WebContents* web_contents) override;
@@ -566,9 +570,6 @@ class WebContents : public ExclusiveAccessContext,
       content::WebContents* web_contents,
       const content::MediaStreamRequest& request,
       content::MediaResponseCallback callback) override;
-  void RequestToLockMouse(content::WebContents* web_contents,
-                          bool user_gesture,
-                          bool last_unlocked_by_target) override;
   content::JavaScriptDialogManager* GetJavaScriptDialogManager(
       content::WebContents* source) override;
   void OnAudioStateChanged(bool audible) override;

--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -43,6 +43,16 @@ void MediaAccessAllowed(const content::MediaStreamRequest& request,
     controller.Deny(blink::mojom::MediaStreamRequestResult::PERMISSION_DENIED);
 }
 
+void OnPointerLockResponse(
+    base::OnceCallback<void(content::WebContents*, bool, bool, bool)> callback,
+    content::WebContents* web_contents,
+    bool user_gesture,
+    bool last_unlocked_by_target,
+    bool allowed) {
+  std::move(callback).Run(web_contents, user_gesture, last_unlocked_by_target,
+                          allowed);
+}
+
 void OnPermissionResponse(base::OnceCallback<void(bool)> callback,
                           blink::mojom::PermissionStatus status) {
   if (status == blink::mojom::PermissionStatus::GRANTED)
@@ -143,6 +153,18 @@ void WebContentsPermissionHelper::RequestWebNotificationPermission(
     base::OnceCallback<void(bool)> callback) {
   RequestPermission(content::PermissionType::NOTIFICATIONS,
                     std::move(callback));
+}
+
+void WebContentsPermissionHelper::RequestPointerLockPermission(
+    bool user_gesture,
+    bool last_unlocked_by_target,
+    base::OnceCallback<void(content::WebContents*, bool, bool, bool)>
+        callback) {
+  RequestPermission(
+      static_cast<content::PermissionType>(PermissionType::POINTER_LOCK),
+      base::BindOnce(&OnPointerLockResponse, std::move(callback), web_contents_,
+                     user_gesture, last_unlocked_by_target),
+      user_gesture);
 }
 
 void WebContentsPermissionHelper::RequestOpenExternalPermission(

--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -43,17 +43,6 @@ void MediaAccessAllowed(const content::MediaStreamRequest& request,
     controller.Deny(blink::mojom::MediaStreamRequestResult::PERMISSION_DENIED);
 }
 
-void OnPointerLockResponse(content::WebContents* web_contents, bool allowed) {
-  if (web_contents) {
-    if (allowed)
-      web_contents->GotResponseToLockMouseRequest(
-          blink::mojom::PointerLockResult::kSuccess);
-    else
-      web_contents->GotResponseToLockMouseRequest(
-          blink::mojom::PointerLockResult::kPermissionDenied);
-  }
-}
-
 void OnPermissionResponse(base::OnceCallback<void(bool)> callback,
                           blink::mojom::PermissionStatus status) {
   if (status == blink::mojom::PermissionStatus::GRANTED)
@@ -154,13 +143,6 @@ void WebContentsPermissionHelper::RequestWebNotificationPermission(
     base::OnceCallback<void(bool)> callback) {
   RequestPermission(content::PermissionType::NOTIFICATIONS,
                     std::move(callback));
-}
-
-void WebContentsPermissionHelper::RequestPointerLockPermission(
-    bool user_gesture) {
-  RequestPermission(
-      static_cast<content::PermissionType>(PermissionType::POINTER_LOCK),
-      base::BindOnce(&OnPointerLockResponse, web_contents_), user_gesture);
 }
 
 void WebContentsPermissionHelper::RequestOpenExternalPermission(

--- a/shell/browser/web_contents_permission_helper.cc
+++ b/shell/browser/web_contents_permission_helper.cc
@@ -43,16 +43,6 @@ void MediaAccessAllowed(const content::MediaStreamRequest& request,
     controller.Deny(blink::mojom::MediaStreamRequestResult::PERMISSION_DENIED);
 }
 
-void OnPointerLockResponse(
-    base::OnceCallback<void(content::WebContents*, bool, bool, bool)> callback,
-    content::WebContents* web_contents,
-    bool user_gesture,
-    bool last_unlocked_by_target,
-    bool allowed) {
-  std::move(callback).Run(web_contents, user_gesture, last_unlocked_by_target,
-                          allowed);
-}
-
 void OnPermissionResponse(base::OnceCallback<void(bool)> callback,
                           blink::mojom::PermissionStatus status) {
   if (status == blink::mojom::PermissionStatus::GRANTED)
@@ -162,8 +152,8 @@ void WebContentsPermissionHelper::RequestPointerLockPermission(
         callback) {
   RequestPermission(
       static_cast<content::PermissionType>(PermissionType::POINTER_LOCK),
-      base::BindOnce(&OnPointerLockResponse, std::move(callback), web_contents_,
-                     user_gesture, last_unlocked_by_target),
+      base::BindOnce(std::move(callback), web_contents_, user_gesture,
+                     last_unlocked_by_target),
       user_gesture);
 }
 

--- a/shell/browser/web_contents_permission_helper.h
+++ b/shell/browser/web_contents_permission_helper.h
@@ -36,6 +36,11 @@ class WebContentsPermissionHelper
   void RequestFullscreenPermission(base::OnceCallback<void(bool)> callback);
   void RequestMediaAccessPermission(const content::MediaStreamRequest& request,
                                     content::MediaResponseCallback callback);
+  void RequestPointerLockPermission(
+      bool user_gesture,
+      bool last_unlocked_by_target,
+      base::OnceCallback<void(content::WebContents*, bool, bool, bool)>
+          callback);
   void RequestWebNotificationPermission(
       base::OnceCallback<void(bool)> callback);
   void RequestOpenExternalPermission(base::OnceCallback<void(bool)> callback,

--- a/shell/browser/web_contents_permission_helper.h
+++ b/shell/browser/web_contents_permission_helper.h
@@ -38,7 +38,6 @@ class WebContentsPermissionHelper
                                     content::MediaResponseCallback callback);
   void RequestWebNotificationPermission(
       base::OnceCallback<void(bool)> callback);
-  void RequestPointerLockPermission(bool user_gesture);
   void RequestOpenExternalPermission(base::OnceCallback<void(bool)> callback,
                                      bool user_gesture,
                                      const GURL& url);


### PR DESCRIPTION
#### Description of Change

Fixes an issue where the [Pointer Lock API](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_Lock_API) could be properly engaged but not disengaged. We were not properly routing requests through the `ExclusiveAccessManager` nor handling special override keys for exclusive access in `WebContents::PreHandleKeyboardEvent`. As of this change, [this demo](https://mdn.github.io/dom-examples/pointer-lock/) works identically to Chrome.

cc @nornagon @jkleinsc 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where Pointer Lock behavior could not be properly exited.
