### PR TITLE
fix: drop nativeWindowOpen deprecation warning

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -1,4 +1,4 @@
-import { app, ipcMain, session, deprecate, webFrameMain } from 'electron/main';
+import { app, ipcMain, session, webFrameMain } from 'electron/main';
 import type { BrowserWindowConstructorOptions, LoadURLOptions } from 'electron/main';
 
 import * as url from 'url';
@@ -733,11 +733,6 @@ WebContents.prototype._init = function () {
         }
       });
     });
-
-    const prefs = this.getLastWebPreferences() || {};
-    if (prefs.nativeWindowOpen === false) {
-      deprecate.log('Deprecation Warning: Disabling nativeWindowOpen is deprecated. The nativeWindowOpen option will be removed in Electron 18.');
-    }
   }
 
   this.on('login', (event, ...args) => {


### PR DESCRIPTION
#### Description of Change
Fixes a type error in main related to the removal of nativeWindowOpen.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none
