### PR TITLE
docs: left is a valid mode in contents.openDevTools() options

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1611,7 +1611,7 @@ app.whenReady().then(() => {
 
 * `options` Object (optional)
   * `mode` string - Opens the devtools with specified dock state, can be
-    `right`, `bottom`, `undocked`, `detach`. Defaults to last used dock state.
+    `left`, `right`, `bottom`, `undocked`, `detach`. Defaults to last used dock state.
     In `undocked` mode it's possible to dock back. In `detach` mode it's not.
   * `activate` boolean (optional) - Whether to bring the opened devtools window
     to the foreground. The default is `true`.


### PR DESCRIPTION
#### Description of Change
Add missing `left` mode to `contents.openDevTools()` options.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added

#### Release Notes
Notes: none