### PR TITLE
docs: left is a valid mode in contents.openDevTools() options

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1612,7 +1612,7 @@ app.whenReady().then(() => {
 
 * `options` Object (optional)
   * `mode` String - Opens the devtools with specified dock state, can be
-    `right`, `bottom`, `undocked`, `detach`. Defaults to last used dock state.
+    `left`, `right`, `bottom`, `undocked`, `detach`. Defaults to last used dock state.
     In `undocked` mode it's possible to dock back. In `detach` mode it's not.
   * `activate` Boolean (optional) - Whether to bring the opened devtools window
     to the foreground. The default is `true`.


### PR DESCRIPTION
Backport of #32372

See that PR for details.

Notes: none