### PR TITLE
chore: update DesktopMediaList patch

### DIFF
--- a/patches/chromium/desktop_media_list.patch
+++ b/patches/chromium/desktop_media_list.patch
@@ -8,15 +8,16 @@ Subject: desktop_media_list.patch
 * Ensure "OnRefreshComplete()" even if there are no items in the list
 
 diff --git a/chrome/browser/media/webrtc/desktop_media_list.h b/chrome/browser/media/webrtc/desktop_media_list.h
-index 57cfc646f8ea545271c22d79ec158a04b148bc9c..db4d608d3bed841ddf7225d0918e82112c8d08b5 100644
+index 57cfc646f8ea545271c22d79ec158a04b148bc9c..c5339603930f68e7019ca33d8b9f148cf4ac86af 100644
 --- a/chrome/browser/media/webrtc/desktop_media_list.h
 +++ b/chrome/browser/media/webrtc/desktop_media_list.h
-@@ -94,7 +94,7 @@ class DesktopMediaList {
+@@ -94,7 +94,8 @@ class DesktopMediaList {
    // once per DesktopMediaList instance.  It should not be called after
    // StartUpdating(), and StartUpdating() should not be called until |callback|
    // has been called.
 -  virtual void Update(UpdateCallback callback) = 0;
-+  virtual void Update(UpdateCallback callback, bool fetch_thumbnails = false) = 0;
++  virtual void Update(UpdateCallback callback,
++                      bool refresh_thumbnails = false) = 0;
  
    virtual int GetSourceCount() const = 0;
    virtual const Source& GetSource(int index) const = 0;
@@ -49,6 +50,34 @@ index c56bc6dcc73cf0e0d5e0e64d45436ccac833cd66..69aaecca38ede55ee71310698710e3f1
    void StartUpdating(DesktopMediaListObserver* observer) override;
 -  void Update(UpdateCallback callback) override;
 +  void Update(UpdateCallback callback, bool refresh_thumbnails) override;
+   int GetSourceCount() const override;
+   const Source& GetSource(int index) const override;
+   DesktopMediaList::Type GetMediaListType() const override;
+diff --git a/chrome/browser/media/webrtc/fake_desktop_media_list.cc b/chrome/browser/media/webrtc/fake_desktop_media_list.cc
+index b1db454db6b7982962541cef18c09425b8f5fa5a..1e37f85d7f786807af331ccc347d84d9b4d7177c 100644
+--- a/chrome/browser/media/webrtc/fake_desktop_media_list.cc
++++ b/chrome/browser/media/webrtc/fake_desktop_media_list.cc
+@@ -75,7 +75,8 @@ void FakeDesktopMediaList::StartUpdating(DesktopMediaListObserver* observer) {
+   thumbnail_ = gfx::ImageSkia::CreateFrom1xBitmap(bitmap);
+ }
+ 
+-void FakeDesktopMediaList::Update(UpdateCallback callback) {
++void FakeDesktopMediaList::Update(UpdateCallback callback,
++                                  bool refresh_thumbnails) {
+   std::move(callback).Run();
+ }
+ 
+diff --git a/chrome/browser/media/webrtc/fake_desktop_media_list.h b/chrome/browser/media/webrtc/fake_desktop_media_list.h
+index 1e4a652634fbde2ca9a256baca840bbc5a0e001f..546f5bc3a2f79035f0eec196d9e704b849992a6f 100644
+--- a/chrome/browser/media/webrtc/fake_desktop_media_list.h
++++ b/chrome/browser/media/webrtc/fake_desktop_media_list.h
+@@ -32,7 +32,8 @@ class FakeDesktopMediaList : public DesktopMediaList {
+   void SetThumbnailSize(const gfx::Size& thumbnail_size) override;
+   void SetViewDialogWindowId(content::DesktopMediaID dialog_id) override;
+   void StartUpdating(DesktopMediaListObserver* observer) override;
+-  void Update(UpdateCallback callback) override;
++  void Update(UpdateCallback callback,
++              bool refresh_thumbnails = false) override;
    int GetSourceCount() const override;
    const Source& GetSource(int index) const override;
    DesktopMediaList::Type GetMediaListType() const override;


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Two things:
* Make consistent usage of `refresh_thumbnails` parameter name, was `fetch_thumbnails` in one of the headers
* Add parameter to `FakeDesktopMediaList::Update` as well, so that code still compiles if you try to build a different GN target (I'm playing with building the `interactive_ui_tests` target)

cc @deepak1556 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
