### PR TITLE
docs: explicitly allow string for MessageBoxOptions.icon

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -285,7 +285,7 @@ If `browserWindow` is not shown dialog will not be attached to it. In such case 
     include a checkbox with the given label.
   * `checkboxChecked` boolean (optional) - Initial checked state of the
     checkbox. `false` by default.
-  * `icon` [NativeImage](native-image.md) (optional)
+  * `icon` ([NativeImage](native-image.md) | string) (optional)
   * `textWidth` Integer (optional) _macOS_ - Custom width of the text in the message box.
   * `cancelId` Integer (optional) - The index of the button to be used to cancel the dialog, via
     the `Esc` key. By default this is assigned to the first button with "cancel" or "no" as the


### PR DESCRIPTION
#### Description of Change

Fixes #32390. See #19782 for context.

CC @VerteDinde (as a stakeholder via traige), @codebytere (as a stakeholder via NativeImage and Dialog work), and @electron/wg-releases 

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed allowed types in MessageBoxOpitons.icon documentation.