### PR TITLE
fix: optional postMessage transfer arg

### DIFF
--- a/shell/browser/api/electron_api_web_frame_main.cc
+++ b/shell/browser/api/electron_api_web_frame_main.cc
@@ -210,7 +210,7 @@ void WebFrameMain::PostMessage(v8::Isolate* isolate,
   }
 
   std::vector<gin::Handle<MessagePort>> wrapped_ports;
-  if (transfer) {
+  if (transfer && !transfer.value()->IsUndefined()) {
     if (!gin::ConvertFromV8(isolate, *transfer, &wrapped_ports)) {
       isolate->ThrowException(v8::Exception::Error(
           gin::StringToV8(isolate, "Invalid value for transfer")));

--- a/shell/renderer/api/electron_api_ipc_renderer.cc
+++ b/shell/renderer/api/electron_api_ipc_renderer.cc
@@ -146,7 +146,7 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
     }
 
     std::vector<v8::Local<v8::Object>> transferables;
-    if (transfer) {
+    if (transfer && !transfer.value()->IsUndefined()) {
       if (!gin::ConvertFromV8(isolate, *transfer, &transferables)) {
         thrower.ThrowTypeError("Invalid value for transfer");
         return;

--- a/spec-main/api-ipc-spec.ts
+++ b/spec-main/api-ipc-spec.ts
@@ -216,6 +216,18 @@ describe('ipc module', () => {
       expect(port).to.be.an.instanceOf(EventEmitter);
     });
 
+    it('can sent a message without a transfer', async () => {
+      const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, contextIsolation: false } });
+      w.loadURL('about:blank');
+      const p = emittedOnce(ipcMain, 'port');
+      await w.webContents.executeJavaScript(`(${function () {
+        require('electron').ipcRenderer.postMessage('port', 'hi');
+      }})()`);
+      const [ev, msg] = await p;
+      expect(msg).to.equal('hi');
+      expect(ev.ports).to.deep.equal([]);
+    });
+
     it('can communicate between main and renderer', async () => {
       const w = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true, contextIsolation: false } });
       w.loadURL('about:blank');


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/32427.

Fixes an issue where attempts to use `ipcRenderer.postMessage` without the ostensibly optional `transfer` argument would throw `TypeError: Invalid value for transfer`. This was happening because `absl::optional` value checks consider `undefined` a value, so we were incorrectly trying to [convert `undefined` into an array of transferrable objects](https://github.com/electron/electron/blob/b4f2bdaaefcdea4e62d0f0c3f6cfdea517a70936/shell/renderer/api/electron_api_ipc_renderer.cc#L150-L153). This is fixed by checking explicitly for `transfer` being `undefined`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `ipcRenderer.postMessage` would throw errors when the `transfer` argument was not passed.
