### PR TITLE
fix: Corrupted title of alert dialog #30223

### DIFF
--- a/shell/browser/ui/message_box_win.cc
+++ b/shell/browser/ui/message_box_win.cc
@@ -171,8 +171,9 @@ DialogResult ShowTaskDialogWstr(NativeWindow* parent,
 
   // TaskDialogIndirect doesn't allow empty name, if we set empty title it
   // will show "electron.exe" in title.
+  std::wstring app_name;
   if (title.empty()) {
-    std::wstring app_name = base::UTF8ToWide(Browser::Get()->GetName());
+    app_name = base::UTF8ToWide(Browser::Get()->GetName());
     config.pszWindowTitle = app_name.c_str();
   } else {
     config.pszWindowTitle = base::as_wcstr(title);


### PR DESCRIPTION
#### Description of Change

Fixes #30223.

Fix the issue that the `alert()` dialog title is corrupted. The same issue happens with `showMessageBox` API if no `title` is explicitly given.

The lifetime of `app_name` was inside the `if` block. Thus, `config.pszWindowTitle` referenced already freed memory.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
<!--
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).
-->

#### Release Notes

Notes: Fix an issue that the `alert()` dialog title is corrupted.