### PR TITLE
fix: desktop screen capture on macOS not releasing

### DIFF
--- a/patches/chromium/desktop_media_list.patch
+++ b/patches/chromium/desktop_media_list.patch
@@ -82,7 +82,7 @@ index 1e4a652634fbde2ca9a256baca840bbc5a0e001f..546f5bc3a2f79035f0eec196d9e704b8
    const Source& GetSource(int index) const override;
    DesktopMediaList::Type GetMediaListType() const override;
 diff --git a/chrome/browser/media/webrtc/native_desktop_media_list.cc b/chrome/browser/media/webrtc/native_desktop_media_list.cc
-index 04dbc1f44944abd3333e83b603dcdf755c0cb09d..ab2dcc4d5fa19790114cae9611aa815e48386bb7 100644
+index 04dbc1f44944abd3333e83b603dcdf755c0cb09d..d3a722f60c67d6177c3ca0bfc1329b87acf0b622 100644
 --- a/chrome/browser/media/webrtc/native_desktop_media_list.cc
 +++ b/chrome/browser/media/webrtc/native_desktop_media_list.cc
 @@ -17,7 +17,7 @@
@@ -105,7 +105,17 @@ index 04dbc1f44944abd3333e83b603dcdf755c0cb09d..ab2dcc4d5fa19790114cae9611aa815e
  #endif
  
  }  // namespace
-@@ -435,6 +436,11 @@ void NativeDesktopMediaList::RefreshForVizFrameSinkWindows(
+@@ -274,6 +275,9 @@ void NativeDesktopMediaList::Worker::RefreshNextThumbnail() {
+       FROM_HERE,
+       base::BindOnce(&NativeDesktopMediaList::UpdateNativeThumbnailsFinished,
+                      media_list_));
++
++  // This call is necessary to release underlying OS screen capture mechanisms.
++  capturer_.reset();
+ }
+ 
+ void NativeDesktopMediaList::Worker::OnCaptureResult(
+@@ -435,6 +439,11 @@ void NativeDesktopMediaList::RefreshForVizFrameSinkWindows(
          FROM_HERE, base::BindOnce(&Worker::RefreshThumbnails,
                                    base::Unretained(worker_.get()),
                                    std::move(native_ids), thumbnail_size_));


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/32358.

Fixes an issue where calling screen capture on macOS does not properly release underlying OS capture mechanisms. As a result of this issue, calls made to capture screen finish within Electron, but if a user locks their screen they would see the following message until the app itself is quit:

<img width="400" alt="Screen Shot 2022-01-12 at 3 28 12 PM" src="https://user-images.githubusercontent.com/2036040/149160571-f1aa8156-eb66-4aa8-a353-7618c654b144.png">

I bisected this to https://github.com/electron/electron/compare/v16.0.0-nightly.20210903...v16.0.0-nightly.20210906 and then narrowed the culprit to 1dcb8a370ea29dbea02ff5c68b2323a1a16e300c. Within this the change that looked most suspicious was the removal of `capturer_.reset()` and upon restoring it I verified that this fixed the problem.

Tested with https://gist.github.com/7e85744c4a498a6fa210bae966bfc44f.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where calling screen capture on macOS does not properly release underlying OS capture mechanisms.