### PR TITLE
fix: maximize/unmaximize firing on linux

### DIFF
--- a/shell/browser/ui/x/window_state_watcher.cc
+++ b/shell/browser/ui/x/window_state_watcher.cc
@@ -21,7 +21,9 @@ WindowStateWatcher::WindowStateWatcher(NativeWindowViews* window)
           x11::GetAtom("_NET_WM_STATE_MAXIMIZED_VERT")),
       net_wm_state_maximized_horz_atom_(
           x11::GetAtom("_NET_WM_STATE_MAXIMIZED_HORZ")),
-      net_wm_state_fullscreen_atom_(x11::GetAtom("_NET_WM_STATE_FULLSCREEN")) {
+      net_wm_state_fullscreen_atom_(x11::GetAtom("_NET_WM_STATE_FULLSCREEN")),
+      was_minimized_(window_->IsMinimized()),
+      was_maximized_(window_->IsMaximized()) {
   ui::X11EventSource::GetInstance()->connection()->AddEventObserver(this);
 }
 
@@ -31,9 +33,6 @@ WindowStateWatcher::~WindowStateWatcher() {
 
 void WindowStateWatcher::OnEvent(const x11::Event& x11_event) {
   if (IsWindowStateEvent(x11_event)) {
-    const bool was_minimized_ = window_->IsMinimized();
-    const bool was_maximized_ = window_->IsMaximized();
-
     std::vector<x11::Atom> wm_states;
     if (GetArrayProperty(
             static_cast<x11::Window>(window_->GetAcceleratedWidget()),
@@ -67,6 +66,9 @@ void WindowStateWatcher::OnEvent(const x11::Event& x11_event) {
         else
           window_->NotifyWindowLeaveFullScreen();
       }
+
+      was_minimized_ = is_minimized;
+      was_maximized_ = is_maximized;
     }
   }
 }

--- a/shell/browser/ui/x/window_state_watcher.h
+++ b/shell/browser/ui/x/window_state_watcher.h
@@ -35,6 +35,9 @@ class WindowStateWatcher : public x11::EventObserver {
   const x11::Atom net_wm_state_maximized_vert_atom_;
   const x11::Atom net_wm_state_maximized_horz_atom_;
   const x11::Atom net_wm_state_fullscreen_atom_;
+
+  bool was_minimized_ = false;
+  bool was_maximized_ = false;
 };
 
 }  // namespace electron


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/28699.

Fixes an issue where the 'maximize' and 'unmaximize' events didn't fire properly on linux.

This was happening as a result of changes made in https://github.com/electron/electron/pull/27280 to address CL:2577887 and CL:2585750. In the resultant change, we assigned `was_maximized_` at the top of `WindowStateWatcher::OnEvent` - given that this was being called in the function after the event had taken place, the previous value would match the current value using this logic and thus it would _never_ be the case that `is_minimized != was_minimized_` or `is_maximized != was_maximized_` and thus the events would never fire.

Fix this by assigning `was_minimized_` and `was_maximized_` in places that properly allow the change to be reflected.

Tested with https://gist.github.com/Jelmerro/5a5a8b0cfcf69a24993b47bd7526d242

cc @dsanders11 since this should allow you to better test https://github.com/electron/electron/pull/32438

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the 'maximize' and 'unmaximize' events didn't fire properly on linux. 