### PR TITLE
refactor: use QuickLookThumbnailing where applicable

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -495,6 +495,7 @@ source_set("electron_lib") {
       "LocalAuthentication.framework",
       "QuartzCore.framework",
       "Quartz.framework",
+      "QuickLookThumbnailing.framework",
       "Security.framework",
       "SecurityInterface.framework",
       "ServiceManagement.framework",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -495,12 +495,13 @@ source_set("electron_lib") {
       "LocalAuthentication.framework",
       "QuartzCore.framework",
       "Quartz.framework",
-      "QuickLookThumbnailing.framework",
       "Security.framework",
       "SecurityInterface.framework",
       "ServiceManagement.framework",
       "StoreKit.framework",
     ]
+
+    weak_frameworks = [ "QuickLookThumbnailing.framework" ]
 
     sources += [
       "shell/browser/ui/views/autofill_popup_view.cc",

--- a/shell/common/api/electron_api_native_image_mac.mm
+++ b/shell/common/api/electron_api_native_image_mac.mm
@@ -73,7 +73,7 @@ v8::Local<v8::Promise> NativeImage::CreateThumbnailFromPath(
                            completionHandler:^(
                                QLThumbnailRepresentation* thumbnail,
                                NSError* error) {
-                             if (error) {
+                             if (error || !thumbnail) {
                                std::string err_msg(
                                    [error.localizedDescription UTF8String]);
                                dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/32455.

Updates code inside `NativeImage::CreateThumbnailFromPath` to conform to new `QuickLookThumbnailing` framework approach outlined by apple [here](https://developer.apple.com/documentation/quicklookthumbnailing?language=objc).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
