### PR TITLE
fix: uploadData is in webRequest.onBeforeSendHeaders but not shown in api document

### DIFF
--- a/docs/api/web-request.md
+++ b/docs/api/web-request.md
@@ -98,6 +98,7 @@ Some examples of valid `urls`:
     * `resourceType` string - Can be `mainFrame`, `subFrame`, `stylesheet`, `script`, `image`, `font`, `object`, `xhr`, `ping`, `cspReport`, `media`, `webSocket` or `other`.
     * `referrer` string
     * `timestamp` Double
+    * `uploadData` [UploadData[]](structures/upload-data.md) (optional)
     * `requestHeaders` Record<string, string>
   * `callback` Function
     * `beforeSendResponse` Object


### PR DESCRIPTION
#### Description of Change
There are a property  **uploadData[]** in the listener of [webRequest.onBeforeRequest([filter, ]listener)](https://www.electronjs.org/docs/latest/api/web-request#webrequestonbeforerequestfilter-listener).  In addition, the listener is also in [webRequest.onBeforeSendHeaders([filter, ]listener)](https://www.electronjs.org/docs/latest/api/web-request#webrequestonbeforesendheadersfilter-listener), they are also the same Function (except for requestHeaders, which is not in onBeforeRequest's listener).
After testing, I found the **uploadData** is in the listener of [webRequest.onBeforeSendHeaders([filter, ]listener)](https://www.electronjs.org/docs/latest/api/web-request#webrequestonbeforesendheadersfilter-listener) if it's provided in request. So I add it into the document.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added

#### Release Notes
Notes: none