### PR TITLE
docs: fix anchors for broken relative links

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -996,7 +996,7 @@ APIs like `win.setSize`.
   is `true`). Default is `#FFF` (white).
 
 Sets the background color of the window. See [Setting
-`backgroundColor`](#setting-backgroundcolor).
+`backgroundColor`](#setting-the-backgroundcolor-property).
 
 #### `win.previewFile(path[, displayName])` _macOS_
 
@@ -1041,7 +1041,7 @@ Returns [`Rectangle`](structures/rectangle.md) - The `bounds` of the window as `
 #### `win.getBackgroundColor()`
 
 Returns `string` - Gets the background color of the window. See [Setting
-`backgroundColor`](#setting-backgroundcolor).
+`backgroundColor`](#setting-the-backgroundcolor-property).
 
 #### `win.setContentBounds(bounds[, animate])`
 

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -122,7 +122,7 @@ Prints Chromium's internal logging to the console.
 
 Setting this variable is the same as passing `--enable-logging`
 on the command line. For more info, see `--enable-logging` in [command-line
-switches](./command-line-switches.md#enable-loggingfile).
+switches](./command-line-switches.md#--enable-loggingfile).
 
 ### `ELECTRON_LOG_FILE`
 
@@ -130,7 +130,7 @@ Sets the file destination for Chromium's internal logging.
 
 Setting this variable is the same as passing `--log-file`
 on the command line. For more info, see `--log-file` in [command-line
-switches](./command-line-switches.md#log-filepath).
+switches](./command-line-switches.md#--log-filepath).
 
 ### `ELECTRON_DEBUG_DRAG_REGIONS`
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Fixes a handful of relative links in the docs which are broken. Appears there's some edge cases the linter for broken relative links isn't catching. For example, the setting background color link broke in 54b44584fa9a1f5a142e8eb6b446084e962cec75 and the linter doesn't catch it.

My VS Code extension flagged them as broken, so at some point I can look at the difference there and try to update the linter to catch these cases.

cc @erickzhao 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
