### PR TITLE
fix: maximize/unmaximize firing on linux

### DIFF
--- a/shell/browser/ui/x/window_state_watcher.cc
+++ b/shell/browser/ui/x/window_state_watcher.cc
@@ -21,7 +21,9 @@ WindowStateWatcher::WindowStateWatcher(NativeWindowViews* window)
           x11::GetAtom("_NET_WM_STATE_MAXIMIZED_VERT")),
       net_wm_state_maximized_horz_atom_(
           x11::GetAtom("_NET_WM_STATE_MAXIMIZED_HORZ")),
-      net_wm_state_fullscreen_atom_(x11::GetAtom("_NET_WM_STATE_FULLSCREEN")) {
+      net_wm_state_fullscreen_atom_(x11::GetAtom("_NET_WM_STATE_FULLSCREEN")),
+      was_minimized_(window_->IsMinimized()),
+      was_maximized_(window_->IsMaximized()) {
   ui::X11EventSource::GetInstance()->connection()->AddEventObserver(this);
 }
 
@@ -31,9 +33,6 @@ WindowStateWatcher::~WindowStateWatcher() {
 
 void WindowStateWatcher::OnEvent(const x11::Event& x11_event) {
   if (IsWindowStateEvent(x11_event)) {
-    const bool was_minimized_ = window_->IsMinimized();
-    const bool was_maximized_ = window_->IsMaximized();
-
     std::vector<x11::Atom> wm_states;
     if (GetArrayProperty(
             static_cast<x11::Window>(window_->GetAcceleratedWidget()),
@@ -67,6 +66,9 @@ void WindowStateWatcher::OnEvent(const x11::Event& x11_event) {
         else
           window_->NotifyWindowLeaveFullScreen();
       }
+
+      was_minimized_ = is_minimized;
+      was_maximized_ = is_maximized;
     }
   }
 }

--- a/shell/browser/ui/x/window_state_watcher.h
+++ b/shell/browser/ui/x/window_state_watcher.h
@@ -32,6 +32,9 @@ class WindowStateWatcher : public x11::EventObserver {
   const x11::Atom net_wm_state_maximized_horz_atom_;
   const x11::Atom net_wm_state_fullscreen_atom_;
 
+  bool was_minimized_ = false;
+  bool was_maximized_ = false;
+
   DISALLOW_COPY_AND_ASSIGN(WindowStateWatcher);
 };
 


### PR DESCRIPTION
Backport of #32441.

See that PR for details.

Notes: Fixed an issue where the 'maximize' and 'unmaximize' events didn't fire properly on linux.