### PR TITLE
chore: check if Node.js macros are available for use

### DIFF
--- a/shell/app/node_main.cc
+++ b/shell/app/node_main.cc
@@ -215,7 +215,7 @@ int NodeMain(int argc, char* argv[]) {
       env = node::CreateEnvironment(
           isolate_data, gin_env.context(), result.args, result.exec_args,
           static_cast<node::EnvironmentFlags::Flags>(flags));
-      CHECK_NE(nullptr, env);
+      CHECK_NOT_NULL(env);
 
       node::IsolateSettings is;
       node::SetIsolateUpForNode(isolate, is);


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

At Postman, we were injecting some of our sources which use some of the
Node.js macros into the electron_lib source_set. When we tried to upgrade
from Electron v13 to v16, our builds started failing because the used
macros weren't available anymore. I'm suspecting that the macros got
excluded when https://github.com/electron/electron/pull/30563 landed.

Signed-off-by: Darshan Sen <raisinten@gmail.com>

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->

cc @zcbenz