### PR TITLE
fix: undefined backgroundColor

### DIFF
--- a/shell/browser/api/electron_api_browser_window.cc
+++ b/shell/browser/api/electron_api_browser_window.cc
@@ -37,7 +37,6 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
       gin::Dictionary::CreateEmpty(isolate);
   options.Get(options::kWebPreferences, &web_preferences);
 
-  v8::Local<v8::Value> value;
   bool transparent = false;
   options.Get(options::kTransparent, &transparent);
 
@@ -47,8 +46,9 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
 #endif
 
   // Copy the backgroundColor to webContents.
-  if (options.Get(options::kBackgroundColor, &value)) {
-    web_preferences.SetHidden(options::kBackgroundColor, value);
+  std::string color;
+  if (options.Get(options::kBackgroundColor, &color)) {
+    web_preferences.SetHidden(options::kBackgroundColor, color);
   } else if (!vibrancy_type.empty() || transparent) {
     // If the BrowserWindow is transparent or a vibrancy type has been set,
     // also propagate transparency to the WebContents unless a separate
@@ -79,6 +79,7 @@ BrowserWindow::BrowserWindow(gin::Arguments* args,
   }
 
   // Copy the webContents option to webPreferences.
+  v8::Local<v8::Value> value;
   if (options.Get("webContents", &value)) {
     web_preferences.SetHidden("webContents", value);
   }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/32007.

Fixes an issue where if `backgroundColor` was set to `undefined`, vibrancy failed to work and the `backgroundColor` would show up as white. This was happening because we were converting the background color from an arbitrary `v8::Value`, when we only accept strings. As a result, `undefined` would return `true` from the conversion instead of false as it should. Fix this by expecting the more specific type.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where if `backgroundColor` was set to `undefined`, vibrancy failed to work and the `backgroundColor` would show up as white.