### PR TITLE
fix: BrowserViews not reacting to visible bounds changes.

### DIFF
--- a/shell/browser/ui/views/inspectable_web_contents_view_views.cc
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.cc
@@ -170,6 +170,18 @@ bool InspectableWebContentsViewViews::IsDevToolsViewFocused() {
     return false;
 }
 
+bool InspectableWebContentsViewViews::
+    GetNeedsNotificationWhenVisibleBoundsChange() const {
+  return true;
+}
+
+void InspectableWebContentsViewViews::OnVisibleBoundsChanged() {
+  if (visible_bounds_.ApproximatelyEqual(GetVisibleBounds(), 0))
+    return;
+  visible_bounds_ = GetVisibleBounds();
+  Layout();
+}
+
 void InspectableWebContentsViewViews::SetIsDocked(bool docked, bool activate) {
   CloseDevTools();
 

--- a/shell/browser/ui/views/inspectable_web_contents_view_views.h
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.h
@@ -43,6 +43,8 @@ class InspectableWebContentsViewViews : public InspectableWebContentsView,
 
   // views::View:
   void Layout() override;
+  bool GetNeedsNotificationWhenVisibleBoundsChange() const override;
+  void OnVisibleBoundsChanged() override;
 
   InspectableWebContents* inspectable_web_contents() {
     return inspectable_web_contents_;
@@ -60,6 +62,7 @@ class InspectableWebContentsViewViews : public InspectableWebContentsView,
   views::WebView* devtools_web_view_ = nullptr;
 
   DevToolsContentsResizingStrategy strategy_;
+  gfx::Rect visible_bounds_;
   bool devtools_visible_ = false;
   views::WidgetDelegate* devtools_window_delegate_ = nullptr;
   std::u16string title_;


### PR DESCRIPTION
#### Description of Change
Since InspectableWebContentViewViews is using visible bounds to do its
layout, make it react to those bounds changes.

Fixes: #32534

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: Make InspectableWebContentsViewViews layout on visible bounds change.