### PR TITLE
fix: strip crashpad_handler binary

### DIFF
--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -14,14 +14,15 @@ PLATFORM = {
 }[sys.platform]
 
 LINUX_BINARIES = [
-  'electron',
   'chrome-sandbox',
-  'libffmpeg.so',
-  'libGLESv2.so',
+  'crashpad_handler',
+  'electron',
   'libEGL.so',
-  'swiftshader/libGLESv2.so',
-  'swiftshader/libEGL.so',
+  'libGLESv2.so',
+  'libffmpeg.so',
   'libvk_swiftshader.so'
+  'swiftshader/libEGL.so',
+  'swiftshader/libGLESv2.so',
 ]
 
 verbose_mode = False


### PR DESCRIPTION
#### Description of Change
\#29719 introduced the crashpad\_handler binary, but did not add it to the
stripped binary list, so it was being shipped with full symbols, to the tune of
15MB. Whoops.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Strip symbols from crashpad_handler binary on Linux, reducing bundle size.
