### PR TITLE
fix: bundle a11y strings in resources

### DIFF
--- a/electron_paks.gni
+++ b/electron_paks.gni
@@ -179,6 +179,7 @@ template("electron_paks") {
       "${root_gen_dir}/device/bluetooth/strings/bluetooth_strings_",
       "${root_gen_dir}/services/strings/services_strings_",
       "${root_gen_dir}/ui/strings/app_locale_settings_",
+      "${root_gen_dir}/ui/strings/ax_strings_",
       "${root_gen_dir}/ui/strings/ui_strings_",
     ]
     deps = [
@@ -188,6 +189,7 @@ template("electron_paks") {
       "//services/strings",
       "//third_party/blink/public/strings",
       "//ui/strings:app_locale_settings",
+      "//ui/strings:ax_strings",
       "//ui/strings:ui_strings",
     ]
 


### PR DESCRIPTION
#### Description of Change
Add strings that were missing in resource pak bundles, resulting in crashes
when starting VoiceOver on macOS (and probably other problems, too).

These were split out in
https://chromium-review.googlesource.com/c/chromium/src/+/3323855, but we
didn't notice straight away.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a crash when starting VoiceOver on macOS.
