### PR TITLE
ci: call autoninja without ninjalog_uploader_wrapper.py

### DIFF
--- a/.circleci/build_config.yml
+++ b/.circleci/build_config.yml
@@ -240,6 +240,12 @@ step-depot-tools-get: &step-depot-tools-get
     name: Get depot tools
     command: |
       git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
+      # remove ninjalog_uploader_wrapper.py from autoninja since we don't use it and it causes problems
+      if [ "`uname`" == "Darwin" ]; then
+        sed -i '' '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
+      else
+        sed -i '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
+      fi
 
 step-depot-tools-add-to-path: &step-depot-tools-add-to-path
   run:


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
https://chromium-review.googlesource.com/c/chromium/tools/depot_tools/+/3400398 broke our linux builds because it requires python 3.7 or higher and our docker images have python 3.6.  I've tried updating our docker images to use python 3.7, but using Ubuntu 18.04 with python 3.7 is problematic since 3.6 is already installed. Updating our docker images to Ubuntu 20.04 causes a docker build issue with snapcraft.  In the long term, I'm sure we can update our docker images, but until we do that, this will get linux building again.

Also, the gist of this change is to change the [autoninja ](https://source.chromium.org/chromium/chromium/tools/depot_tools/+/main:autoninja?q=autoninja&ss=chromium)shell script to not invoke ninjalog_uploader_wrapper.py, which if we call it ends up being a noop, so it is technically a little more efficient than calling the regular depot_tools version of autoninja.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
