### PR TITLE
chore: update to latest TypeScript

### DIFF
--- a/default_app/main.ts
+++ b/default_app/main.ts
@@ -92,7 +92,7 @@ function loadApplicationPackage (packagePath: string) {
       try {
         packageJson = require(packageJsonPath);
       } catch (e) {
-        showErrorMessage(`Unable to parse ${packageJsonPath}\n\n${e.message}`);
+        showErrorMessage(`Unable to parse ${packageJsonPath}\n\n${(e as Error).message}`);
         return;
       }
 
@@ -111,7 +111,7 @@ function loadApplicationPackage (packagePath: string) {
       const filePath = Module._resolveFilename(packagePath, module, true);
       app.setAppPath(appPath || path.dirname(filePath));
     } catch (e) {
-      showErrorMessage(`Unable to find Electron app at ${packagePath}\n\n${e.message}`);
+      showErrorMessage(`Unable to find Electron app at ${packagePath}\n\n${(e as Error).message}`);
       return;
     }
 
@@ -119,7 +119,7 @@ function loadApplicationPackage (packagePath: string) {
     Module._load(packagePath, module, true);
   } catch (e) {
     console.error('App threw an error during load');
-    console.error(e.stack || e);
+    console.error((e as Error).stack || e);
     throw e;
   }
 }

--- a/lib/browser/api/auto-updater/squirrel-update-win.ts
+++ b/lib/browser/api/auto-updater/squirrel-update-win.ts
@@ -35,7 +35,7 @@ const spawnUpdate = function (args: string[], detached: boolean, callback: Funct
       spawnedArgs = args || [];
     }
   } catch (error1) {
-    error = error1;
+    error = error1 as Error;
 
     // Shouldn't happen, but still guard it.
     process.nextTick(function () {

--- a/lib/browser/ipc-main-impl.ts
+++ b/lib/browser/ipc-main-impl.ts
@@ -15,7 +15,7 @@ export class IpcMainImpl extends EventEmitter {
       try {
         e._reply(await Promise.resolve(fn(e, ...args)));
       } catch (err) {
-        e._throw(err);
+        e._throw(err as Error);
       }
     });
   }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "timers-browserify": "1.4.2",
     "ts-loader": "^8.0.2",
     "ts-node": "6.2.0",
-    "typescript": "^4.1.3",
+    "typescript": "^4.5.5",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12",
     "wrapper-webpack-plugin": "^2.1.0"

--- a/spec-main/api-context-bridge-spec.ts
+++ b/spec-main/api-context-bridge-spec.ts
@@ -372,7 +372,7 @@ describe('contextBridge', () => {
           try {
             root.example();
           } catch (e) {
-            return e.message;
+            return (e as Error).message;
           }
         });
         expect(result).equal('oh no');

--- a/spec-main/api-ipc-spec.ts
+++ b/spec-main/api-ipc-spec.ts
@@ -24,7 +24,7 @@ describe('ipc module', () => {
         const result = await ipcRenderer.invoke('test', ...args);
         ipcRenderer.send('result', { result });
       } catch (e) {
-        ipcRenderer.send('result', { error: e.message });
+        ipcRenderer.send('result', { error: (e as Error).message });
       }
     }
 

--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -357,7 +357,7 @@ describe('webContents module', () => {
     });
 
     it('sets appropriate error information on rejection', async () => {
-      let err;
+      let err: any;
       try {
         await w.loadURL('file:non-existent');
       } catch (e) {

--- a/spec-main/node-spec.ts
+++ b/spec-main/node-spec.ts
@@ -213,7 +213,7 @@ describe('node feature', () => {
 
   ifdescribe(features.isRunAsNodeEnabled())('inspector', () => {
     let child: childProcess.ChildProcessWithoutNullStreams;
-    let exitPromise: Promise<any[]>;
+    let exitPromise: Promise<any[]> | null;
 
     afterEach(async () => {
       if (child && exitPromise) {

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,8 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "spec-main"
-  },
   "include": [
     "spec-main",
     "typings"

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -294,58 +294,7 @@ declare interface Window {
     }
   };
   WebView: typeof ElectronInternal.WebViewElement;
-  ResizeObserver: ResizeObserver;
   trustedTypes: TrustedTypePolicyFactory;
-}
-
-/**
- * The ResizeObserver interface is used to observe changes to Element's content
- * rect.
- *
- * It is modeled after MutationObserver and IntersectionObserver.
- */
-declare class ResizeObserver {
-  constructor (callback: ResizeObserverCallback);
-
-  /**
-   * Adds target to the list of observed elements.
-   */
-  observe: (target: Element) => void;
-
-  /**
-   * Removes target from the list of observed elements.
-   */
-  unobserve: (target: Element) => void;
-
-  /**
-   * Clears both the observationTargets and activeTargets lists.
-   */
-  disconnect: () => void;
-}
-
-/**
- * This callback delivers ResizeObserver's notifications. It is invoked by a
- * broadcast active observations algorithm.
- */
-interface ResizeObserverCallback {
-  (entries: ResizeObserverEntry[], observer: ResizeObserver): void;
-}
-
-interface ResizeObserverEntry {
-  /**
-   * @param target The Element whose size has changed.
-   */
-  new (target: Element): ResizeObserverEntry;
-
-  /**
-   * The Element whose size has changed.
-   */
-  readonly target: Element;
-
-  /**
-   * Element's content rect when ResizeObserverCallback is invoked.
-   */
-  readonly contentRect: DOMRectReadOnly;
 }
 
 // https://w3c.github.io/webappsec-trusted-types/dist/spec/#trusted-types

--- a/yarn.lock
+++ b/yarn.lock
@@ -7498,10 +7498,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@^4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
#### Description of Change
It should be slightly faster due to https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#faster-load-time-with-realpathsyncnative. `ResizeObserver` is now declared in lib.dom.d.ts

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none