### PR TITLE
fix: make windows without rounded corners closable

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -295,12 +295,12 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
 
   NSUInteger styleMask = NSWindowStyleMaskTitled;
 
-  // The NSWindowStyleMaskFullSizeContentView style removes rounded corners
-  // for framless window.
+  // Removing NSWindowStyleMaskTitled removes window title, which removes
+  // rounded corners of window.
   bool rounded_corner = true;
   options.Get(options::kRoundedCorners, &rounded_corner);
   if (!rounded_corner && !has_frame())
-    styleMask = NSWindowStyleMaskFullSizeContentView;
+    styleMask = 0;
 
   if (minimizable)
     styleMask |= NSMiniaturizableWindowMask;
@@ -1349,7 +1349,7 @@ void NativeWindowMac::UpdateVibrancyRadii(bool fullscreen) {
 
   if (vibrantView != nil && !vibrancy_type_.empty()) {
     const bool no_rounded_corner =
-        [window_ styleMask] & NSWindowStyleMaskFullSizeContentView;
+        !([window_ styleMask] & NSWindowStyleMaskTitled);
     if (!has_frame() && !is_modal() && !no_rounded_corner) {
       CGFloat radius;
       if (fullscreen) {

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -111,6 +111,14 @@ describe('BrowserWindow module', () => {
       await closed;
     });
 
+    it('closes window without rounded corners', async () => {
+      await closeWindow(w);
+      w = new BrowserWindow({ show: false, frame: false, roundedCorners: false });
+      const closed = emittedOnce(w, 'closed');
+      w.close();
+      await closed;
+    });
+
     it('should not crash if called after webContents is destroyed', () => {
       w.webContents.destroy();
       w.webContents.on('destroyed', () => w.close());


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/28686.

By default "Close Window" is always disabled when window has no title, this PR makes it possible to close such windows. This fixes the problem that windows with `roundedCorners: false` was not closable, because the option is implemented by removing window's title.

Also note that this PR removes the use of `NSWindowStyleMaskFullSizeContentView` style, it is actually no-op if the window has no title and we don't really need it to implement `roundedCorners: false`.

#### Release Notes

Notes: Fix windows with `roundedCorners: false` unable to be closed.