### PR TITLE
fix: webContents.setZoomFactor crash

### DIFF
--- a/shell/browser/web_view_guest_delegate.cc
+++ b/shell/browser/web_view_guest_delegate.cc
@@ -81,7 +81,7 @@ void WebViewGuestDelegate::OnZoomLevelChanged(
       api_web_contents_->GetZoomController()->SetZoomLevel(level);
     }
     // Change the default zoom factor to match the embedders' new zoom level.
-    double zoom_factor = blink::PageZoomFactorToZoomLevel(level);
+    double zoom_factor = blink::PageZoomLevelToZoomFactor(level);
     api_web_contents_->GetZoomController()->SetDefaultZoomFactor(zoom_factor);
   }
 }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
- #20314 included cadf148cea5c78c7f44fe62db2c74f072252b55f, which incorrectly migrated `content::ZoomLevelToZoomFactor` to `blink::PageZoomFactorToZoomLevel` in `shell/browser/web_view_guest_delegate.cc` instead of migrating to the correct `blink::PageZoomLevelToZoomFactor`.  This caused the crash detailed in #30028.
- Fixes #30028

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->Fixed crash when calling `webContents.setZoomFactor(1.0)`.
