### PR TITLE
docs: separate the dependency list for ubuntu

### DIFF
--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -29,7 +29,17 @@ Follow the guidelines below for building **Electron itself** on Linux, for the p
 * [clang](https://clang.llvm.org/get_started.html) 3.4 or later.
 * Development headers of GTK 3 and libnotify.
 
-On Ubuntu, install the following libraries:
+On Ubuntu >= 20.04, install the following libraries:
+
+```sh
+$ sudo apt-get install build-essential clang libdbus-1-dev libgtk-3-dev \
+                       libnotify-dev libasound2-dev libcap-dev \
+                       libcups2-dev libxtst-dev \
+                       libxss1 libnss3-dev gcc-multilib g++-multilib curl \
+                       gperf bison python3-dbusmock openjdk-8-jre
+```
+
+On Ubuntu < 20.04, install the following libraries:
 
 ```sh
 $ sudo apt-get install build-essential clang libdbus-1-dev libgtk-3-dev \


### PR DESCRIPTION
#### Description of Change
Closes #27704 

[Chromium script](https://chromium.googlesource.com/chromium/src/+/main/build/install-build-deps.sh#527) to install build dependencies seems to suggest that `libgnome-keyring-dev` isn't needed on Ubuntu 20.
And the tests run fine with `python3-dbusmock`

cc: @ckerr @dsanders11 @codebytere 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added

#### Release Notes

Notes: none
