### PR TITLE
ci: update ts-compile-doc-change to properly use src cache

### DIFF
--- a/.circleci/build_config.yml
+++ b/.circleci/build_config.yml
@@ -1547,6 +1547,7 @@ jobs:
     environment:
       <<: *env-linux-medium
       <<: *env-testing-build
+      GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
     <<: *steps-electron-ts-compile-for-doc-change
 
   # Layer 1: Checkout.


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Docs only PRs were timing out (eg see https://app.circleci.com/pipelines/github/electron/electron/48723/workflows/500d13bc-6323-46bf-9b2f-442635beed07/jobs/1108175) because they were not using the proper source cache.  This PR updates the ts-compile-doc-change job to properly use the cached source.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
