### PR TITLE
fix: maxWidth not being respected

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -144,16 +144,16 @@ void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
   // On Linux and Window we may already have maximum size defined.
   extensions::SizeConstraints size_constraints(
       use_content_size ? GetContentSizeConstraints() : GetSizeConstraints());
-  int min_height = 0, min_width = 0;
-  if (options.Get(options::kMinHeight, &min_height) ||
-      options.Get(options::kMinWidth, &min_width)) {
-    size_constraints.set_minimum_size(gfx::Size(min_width, min_height));
-  }
-  int max_height = INT_MAX, max_width = INT_MAX;
-  if (options.Get(options::kMaxHeight, &max_height) ||
-      options.Get(options::kMaxWidth, &max_width)) {
-    size_constraints.set_maximum_size(gfx::Size(max_width, max_height));
-  }
+  int min_width = size_constraints.GetMinimumSize().width();
+  int min_height = size_constraints.GetMinimumSize().height();
+  options.Get(options::kMinWidth, &min_width);
+  options.Get(options::kMinHeight, &min_height);
+  size_constraints.set_minimum_size(gfx::Size(min_width, min_height));
+  int max_width = size_constraints.GetMaximumSize().width();
+  int max_height = size_constraints.GetMaximumSize().height();
+  options.Get(options::kMaxWidth, &max_width);
+  options.Get(options::kMaxHeight, &max_height);
+  size_constraints.set_maximum_size(gfx::Size(max_width, max_height));
   if (use_content_size) {
     SetContentSizeConstraints(size_constraints);
   } else {


### PR DESCRIPTION
#### Description of Change
Fixes #32608.

https://github.com/electron/electron/pull/31982 changed this condition from `|`
to `||`, which broke because `||` short-circuits but `|` does not.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed `maxWidth` not working in BrowserWindow constructor options.
