### PR TITLE
chore: cherry-pick f5101995acd2 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -114,3 +114,4 @@ build_disable_partitionalloc_on_mac.patch
 revert_stop_using_nsrunloop_in_renderer_process.patch
 fix_dont_delete_SerialPortManager_on_main_thread.patch
 fix_crash_when_saving_edited_pdf_files.patch
+cherry-pick-f5101995acd2.patch

--- a/patches/chromium/cherry-pick-f5101995acd2.patch
+++ b/patches/chromium/cherry-pick-f5101995acd2.patch
@@ -1,0 +1,39 @@
+From f5101995acd21bd1d1bd8447087112e09bacfcbb Mon Sep 17 00:00:00 2001
+From: Jeremy Rose <jeremya@chromium.org>
+Date: Wed, 26 Jan 2022 23:39:50 +0000
+Subject: [PATCH] fix draggable regions not updating without layout
+
+This fixes draggable regions not being updated when styles change, but there is
+no layout as a result of the style change. Some changes to styles can cause a
+change in draggable regions without causing a layout (e.g. applying the
+`-webkit-app-region: drag` style to an element without changing its size).
+
+Bug: 1051562
+Change-Id: Ifdf835be9e6c762131529b4309c6579366b80d6d
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3416279
+Reviewed-by: Stefan Zager <szager@chromium.org>
+Commit-Queue: Jeremy Apthorp <jeremya@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#963777}
+---
+
+diff --git a/third_party/blink/renderer/core/frame/local_frame_view.cc b/third_party/blink/renderer/core/frame/local_frame_view.cc
+index 2741019..50bbe52 100644
+--- a/third_party/blink/renderer/core/frame/local_frame_view.cc
++++ b/third_party/blink/renderer/core/frame/local_frame_view.cc
+@@ -1841,8 +1841,6 @@
+     }
+   }
+ 
+-  UpdateDocumentAnnotatedRegions();
+-
+   GetLayoutView()->EnclosingLayer()->UpdateLayerPositionsAfterLayout();
+   frame_->Selection().DidLayout();
+ 
+@@ -3172,6 +3170,7 @@
+     PerformPostLayoutTasks(visual_viewport_size_changed);
+     GetFrame().GetDocument()->LayoutUpdated();
+   }
++  UpdateDocumentAnnotatedRegions();
+   UpdateGeometriesIfNeeded();
+ }
+ 

--- a/patches/chromium/cherry-pick-f5101995acd2.patch
+++ b/patches/chromium/cherry-pick-f5101995acd2.patch
@@ -1,7 +1,7 @@
-From f5101995acd21bd1d1bd8447087112e09bacfcbb Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jeremy Rose <jeremya@chromium.org>
 Date: Wed, 26 Jan 2022 23:39:50 +0000
-Subject: [PATCH] fix draggable regions not updating without layout
+Subject: fix draggable regions not updating without layout
 
 This fixes draggable regions not being updated when styles change, but there is
 no layout as a result of the style change. Some changes to styles can cause a
@@ -14,13 +14,12 @@ Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3416279
 Reviewed-by: Stefan Zager <szager@chromium.org>
 Commit-Queue: Jeremy Apthorp <jeremya@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#963777}
----
 
 diff --git a/third_party/blink/renderer/core/frame/local_frame_view.cc b/third_party/blink/renderer/core/frame/local_frame_view.cc
-index 2741019..50bbe52 100644
+index 5f2a765668b093bb600678967470b6371db77c01..e4b244fddc673840e8d47c781964d0146b108d47 100644
 --- a/third_party/blink/renderer/core/frame/local_frame_view.cc
 +++ b/third_party/blink/renderer/core/frame/local_frame_view.cc
-@@ -1841,8 +1841,6 @@
+@@ -1915,8 +1915,6 @@ void LocalFrameView::PerformPostLayoutTasks(bool visual_viewport_size_changed) {
      }
    }
  
@@ -29,7 +28,7 @@ index 2741019..50bbe52 100644
    GetLayoutView()->EnclosingLayer()->UpdateLayerPositionsAfterLayout();
    frame_->Selection().DidLayout();
  
-@@ -3172,6 +3170,7 @@
+@@ -3307,6 +3305,7 @@ void LocalFrameView::UpdateStyleAndLayout() {
      PerformPostLayoutTasks(visual_viewport_size_changed);
      GetFrame().GetDocument()->LayoutUpdated();
    }


### PR DESCRIPTION
fix draggable regions not updating without layout

This fixes draggable regions not being updated when styles change, but there is
no layout as a result of the style change. Some changes to styles can cause a
change in draggable regions without causing a layout (e.g. applying the
`-webkit-app-region: drag` style to an element without changing its size).

Bug: 1051562
Change-Id: Ifdf835be9e6c762131529b4309c6579366b80d6d
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3416279
Reviewed-by: Stefan Zager <szager@chromium.org>
Commit-Queue: Jeremy Apthorp <jeremya@chromium.org>
Cr-Commit-Position: refs/heads/main@{#963777}


Notes: Fixed draggable regions not updating unless a relayout occurs.