### PR TITLE
docs: Remove the latin phrase "Nota Bene"  from docs

### DIFF
--- a/docs/api/dock.md
+++ b/docs/api/dock.md
@@ -28,7 +28,7 @@ When `informational` is passed, the dock icon will bounce for one second.
 However, the request remains active until either the application becomes active
 or the request is canceled.
 
-**Nota Bene:** This method can only be used while the app is not focused; when the app is focused it will return -1.
+**Note:** This method can only be used while the app is not focused; when the app is focused it will return -1.
 
 #### `dock.cancelBounce(id)` _macOS_
 

--- a/docs/api/menu-item.md
+++ b/docs/api/menu-item.md
@@ -124,7 +124,7 @@ When specifying a `role` on macOS, `label` and `accelerator` are the only
 options that will affect the menu item. All other options will be ignored.
 Lowercase `role`, e.g. `toggledevtools`, is still supported.
 
-**Nota Bene:** The `enabled` and `visibility` properties are not available for top-level menu items in the tray on macOS.
+**Note:** The `enabled` and `visibility` properties are not available for top-level menu items in the tray on macOS.
 
 ### Instance Properties
 

--- a/docs/development/build-instructions-gn.md
+++ b/docs/development/build-instructions-gn.md
@@ -136,7 +136,7 @@ $ gn gen out/Release --args="import(\"//electron/build/args/release.gn\") $GN_EX
 ```
 
 **To build, run `ninja` with the `electron` target:**
-Nota Bene: This will also take a while and probably heat up your lap.
+Note: This will also take a while and probably heat up your lap.
 
 For the testing configuration:
 


### PR DESCRIPTION
For the people who only know English, it's very difficult to understand the Latin phrase "Nota Bene". Just to call the reader's attention to a particularly important piece of information, I think we can use "Note" which does the same job for us. It really helps in not distracting the readers flow from the document :)  

**Release Notes**
Notes: none