### PR TITLE
fix: transparent window max/unmax event firing

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -594,6 +594,7 @@ void NativeWindowViews::Unmaximize() {
 #if defined(OS_WIN)
     if (transparent()) {
       SetBounds(restore_bounds_, false);
+      NotifyWindowUnmaximize();
       return;
     }
 #endif

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -187,6 +187,7 @@ void NativeWindowViews::Maximize() {
     auto display = display::Screen::GetScreen()->GetDisplayNearestWindow(
         GetNativeWindow());
     SetBounds(display.work_area(), false);
+    NotifyWindowMaximize();
   }
 }
 

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -3287,9 +3287,11 @@ describe('BrowserWindow module', () => {
         transparent: true
       });
 
+      const maximize = emittedOnce(w, 'maximize');
       const unmaximize = emittedOnce(w, 'unmaximize');
       w.show();
       w.maximize();
+      await maximize;
       w.unmaximize();
       await unmaximize;
     });

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -3249,6 +3249,21 @@ describe('BrowserWindow module', () => {
       await maximize;
     });
 
+    // Transparent window max/unmax uses different logic and does not go through
+    // NativeWindowViews::HandleSizeEvent, so we need to test it separately.
+    ifit(process.platform === 'win32')('emits an event when a transparent window is maximized', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        frame: false,
+        transparent: true
+      });
+
+      const maximize = emittedOnce(w, 'maximize');
+      w.show();
+      w.maximize();
+      await maximize;
+    });
+
     it('emits only one event when frameless window is maximized', () => {
       const w = new BrowserWindow({ show: false, frame: false });
       let emitted = 0;
@@ -3260,6 +3275,22 @@ describe('BrowserWindow module', () => {
 
     it('emits an event when window is unmaximized', async () => {
       const w = new BrowserWindow({ show: false });
+      const unmaximize = emittedOnce(w, 'unmaximize');
+      w.show();
+      w.maximize();
+      w.unmaximize();
+      await unmaximize;
+    });
+
+    // Transparent window max/unmax uses different logic and does not go through
+    // NativeWindowViews::HandleSizeEvent, so we need to test it separately.
+    ifit(process.platform === 'win32')('emits an event when a transparent window is unmaximized', async () => {
+      const w = new BrowserWindow({
+        show: false,
+        frame: false,
+        transparent: true
+      });
+
       const unmaximize = emittedOnce(w, 'unmaximize');
       w.show();
       w.maximize();

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1119,7 +1119,7 @@ describe('BrowserWindow module', () => {
           await unmaximize;
           expectBoundsEqual(w.getNormalBounds(), bounds);
         });
-        it('can check transparent window maximization', async () => {
+        it('correctly checks transparent window maximization state', async () => {
           w.destroy();
           w = new BrowserWindow({
             show: false,
@@ -1128,12 +1128,12 @@ describe('BrowserWindow module', () => {
             transparent: true
           });
 
-          const maximize = emittedOnce(w, 'resize');
+          const maximize = emittedOnce(w, 'maximize');
           w.show();
           w.maximize();
           await maximize;
           expect(w.isMaximized()).to.equal(true);
-          const unmaximize = emittedOnce(w, 'resize');
+          const unmaximize = emittedOnce(w, 'unmaximize');
           w.unmaximize();
           await unmaximize;
           expect(w.isMaximized()).to.equal(false);
@@ -3249,9 +3249,7 @@ describe('BrowserWindow module', () => {
       await maximize;
     });
 
-    // Transparent window max/unmax uses different logic and does not go through
-    // NativeWindowViews::HandleSizeEvent, so we need to test it separately.
-    ifit(process.platform === 'win32')('emits an event when a transparent window is maximized', async () => {
+    it('emits an event when a transparent window is maximized', async () => {
       const w = new BrowserWindow({
         show: false,
         frame: false,
@@ -3282,9 +3280,7 @@ describe('BrowserWindow module', () => {
       await unmaximize;
     });
 
-    // Transparent window max/unmax uses different logic and does not go through
-    // NativeWindowViews::HandleSizeEvent, so we need to test it separately.
-    ifit(process.platform === 'win32')('emits an event when a transparent window is unmaximized', async () => {
+    it('emits an event when a transparent window is unmaximized', async () => {
       const w = new BrowserWindow({
         show: false,
         frame: false,


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/32633.

This PR fixes an issue with transparent windows failing to fire the `maximize` and `unmaximize` events on Windows.

We've made a few fixes to transparent window size events on Windows of late, including https://github.com/electron/electron/pull/28207 and https://github.com/electron/electron/pull/26586. As of now, we set transparent window to maximized by calling [`SetBounds`](https://github.com/electron/electron/blob/a2d993c9b48809128ca0d8a6c61f4c5ff7c8e385/shell/browser/native_window_views_win.cc#L189), which means that `NativeWindowViews::HandleSizeEvent` is not triggered with `SIZE_MAXIMIZED` as it should be. This also presents an issue with unmaximization for similar reasons, and caused the `maximize` and `unmaximize` events not to fire on Windows. We can fix this issue by calling `NotifyWindowMaximize()` and `NotifyWindowUnmaximize()` in the transparency-specific logic blocks of `Maximize()` and `Unmaximize()`. 

cc @dsanders11

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue with transparent windows failing to fire the `maximize` and `unmaximize` events on Windows.