### PR TITLE
fix: expose all serial devices to setDevicePermissionHandler

### DIFF
--- a/shell/browser/serial/serial_chooser_context.h
+++ b/shell/browser/serial/serial_chooser_context.h
@@ -82,12 +82,6 @@ class SerialChooserContext : public KeyedService,
       mojo::PendingRemote<device::mojom::SerialPortManager> manager);
   void OnPortManagerConnectionError();
 
-  // Tracks the set of ports to which an origin has access to.
-  std::map<url::Origin, std::set<base::UnguessableToken>> ephemeral_ports_;
-
-  // Holds information about ports in |ephemeral_ports_|.
-  std::map<base::UnguessableToken, base::Value> port_info_;
-
   mojo::Remote<device::mojom::SerialPortManager> port_manager_;
   mojo::Receiver<device::mojom::SerialPortManagerClient> client_receiver_{this};
   base::ObserverList<PortObserver> port_observer_list_;


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Due to logic copied from upstream chromium, not all serial devices are passed along to the handler specified via `session.setDevicePermissionHandler`.  Given that we are giving control to the developer as to which ports are being exposed, we can probably skip this check.
- Resolves #32505

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->fixed issue where not all serial devices were exposed to the handler specified by `session.setDevicePermissionHandler`
