### PR TITLE
fix: WCO window hover on window controls on Windows

### DIFF
--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -102,7 +102,7 @@ bool ElectronDesktopWindowTreeHostWin::GetClientAreaInsets(
 bool ElectronDesktopWindowTreeHostWin::HandleMouseEvent(ui::MouseEvent* event) {
   // Call the default implementation of this method to get the event to its
   // proper handler.
-  bool handled = this->views::DesktopWindowTreeHostWin::HandleMouseEvent(event);
+  bool handled = views::DesktopWindowTreeHostWin::HandleMouseEvent(event);
 
   // On WCO-enabled windows, we need to mark non-client mouse moved events as
   // handled so they don't incorrectly propogate back to the OS.

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -99,4 +99,21 @@ bool ElectronDesktopWindowTreeHostWin::GetClientAreaInsets(
   return false;
 }
 
+bool ElectronDesktopWindowTreeHostWin::HandleMouseEvent(ui::MouseEvent* event) {
+  // Call the default implementation of this method to get the event to its
+  // proper handler.
+  bool handled = this->views::DesktopWindowTreeHostWin::HandleMouseEvent(event);
+
+  // On WCO-enabled windows, we need to mark non-client mouse moved events as
+  // handled so they don't incorrectly propogate back to the OS.
+  if (native_window_view_->IsWindowControlsOverlayEnabled() &&
+      event->type() == ui::ET_MOUSE_MOVED &&
+      (event->flags() & ui::EF_IS_NON_CLIENT) != 0) {
+    event->SetHandled();
+    handled = true;
+  }
+
+  return handled;
+}
+
 }  // namespace electron

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
@@ -36,6 +36,7 @@ class ElectronDesktopWindowTreeHostWin
   bool GetDwmFrameInsetsInPixels(gfx::Insets* insets) const override;
   bool GetClientAreaInsets(gfx::Insets* insets,
                            HMONITOR monitor) const override;
+  bool HandleMouseEvent(ui::MouseEvent* event) override;
 
  private:
   NativeWindowViews* native_window_view_;  // weak ref


### PR DESCRIPTION
#### Description of Change

This adds a patch to Chromium that marks [non-client](https://docs.microsoft.com/en-us/windows/win32/gdi/nonclient-area) mouse hover events as handled so they don't get redispatched to the default OS event handler (which is currently immediately "stealing" the mouse every time it moves).

Currently, on Windows with WCO-enabled windows, Win API mouse messages first find their way to `LegacyRenderWidgetHostHWND::OnMouseRange` which, for non-client mouse moved events, will both handle the event normally (through `HWNDMessageHandler::HandleMouseMessage` which eventually bubbles down to `Widget::OnMouseEvent`) as well as redispatch the original message back to the OS default window procedure (via the Win API `DefWndProc`) on the real window handle, depending on some conditions.

Calling `DefWndProc` after we process a non-client area mouse move message seems to cause issues where the system will immediately send a non-client mouse **exit** message to the real window (`HWNDMessageHandler` directly this time, which again flows down to `Widget::OnMouseEvent`) which makes it think the mouse is no longer hovering over the non-client area.

To avoid this, an event should be marked as handled meaning `LegacyRenderWidgetHostHWND` will no longer forward the message to `DefWndProc`. Note that this is how many other mouse events behave in that method, but not hovers currently.

The only open question I haven't figured out is why `DefWndProc` is taking a `WM_NCMOUSEMOVE` message from `LegacyRenderHostHWND` called on `HWNDMessageHandler`'s window handle and then sending a `WM_NCMOUSELEAVE` message (take note: _move_ changed to _leave_) when it invokes `HWNDMessageHandler`'s `WndProc`. My current thought is that we tell the system that the client area covers the full window (i.e. the window has no frame) but also indicate that the mouse is sometimes in non-client area via hit testing (which we have to do to get Snap Assist) and this sort of inconsistency might trick `DefWndProc` into the behavior we're seeing. Not really sure if it's worth confirming though so it might just stay a hypothesis.

In theory this shouldn't affect anything but WCO windows as usually the `LegacyRenderWidgetHostHWND` doesn't cover any non-client area, so I deduce that all other kinds of windows will never send the `LegacyRenderWidgetHostHWND` a non-client mouse message in practice.

Fixes #32360.


#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Fix effect when hovering over window controls on Windows in a WCO-enabled window.
