### PR TITLE
docs: fix missing tag end in clipboard example

### DIFF
--- a/docs/api/clipboard.md
+++ b/docs/api/clipboard.md
@@ -76,7 +76,7 @@ Writes `markup` to the clipboard.
 ```js
 const { clipboard } = require('electron')
 
-clipboard.writeHTML('<b>Hi</b')
+clipboard.writeHTML('<b>Hi</b>')
 ```
 
 ### `clipboard.readImage([type])`


### PR DESCRIPTION
#### Description of Change
Looks like just a typo, missing the final `>` of the HTML tag in the example.

cc @codebytere (examples originally added in #20224)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none