### PR TITLE
ci: fixup gclient cache on ubuntu 20

### DIFF
--- a/.circleci/build_config.yml
+++ b/.circleci/build_config.yml
@@ -890,12 +890,12 @@ step-touch-sync-done: &step-touch-sync-done
 step-maybe-restore-src-cache: &step-maybe-restore-src-cache
   restore_cache:
     keys:
-      - v8-src-cache-{{ checksum "src/electron/.depshash" }}
+      - v12-src-cache-{{ checksum "src/electron/.depshash" }}
     name: Restoring src cache
 step-maybe-restore-src-cache-marker: &step-maybe-restore-src-cache-marker
   restore_cache:
     keys:
-      - v1-src-cache-marker-{{ checksum "src/electron/.depshash" }}
+      - v5-src-cache-marker-{{ checksum "src/electron/.depshash" }}
     name: Restoring src cache marker
 
 # Restore exact or closest git cache based on the hash of DEPS and .circle-sync-done
@@ -904,10 +904,10 @@ step-maybe-restore-src-cache-marker: &step-maybe-restore-src-cache-marker
 step-maybe-restore-git-cache: &step-maybe-restore-git-cache
   restore_cache:
     paths:
-      - ~/.gclient-cache
+      - gclient-cache
     keys:
-      - v2-gclient-cache-{{ checksum "src/electron/.circle-sync-done" }}-{{ checksum "src/electron/DEPS" }}
-      - v2-gclient-cache-{{ checksum "src/electron/.circle-sync-done" }}
+      - v5-gclient-cache-{{ checksum "src/electron/.circle-sync-done" }}-{{ checksum "src/electron/DEPS" }}
+      - v5-gclient-cache-{{ checksum "src/electron/.circle-sync-done" }}
     name: Conditionally restoring git cache
 
 step-restore-out-cache: &step-restore-out-cache
@@ -924,15 +924,15 @@ step-set-git-cache-path: &step-set-git-cache-path
     command: |
       # CircleCI does not support interpolation when setting environment variables.
       # https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-shell-command
-      echo 'export GIT_CACHE_PATH="$HOME/.gclient-cache"' >> $BASH_ENV
+      echo 'export GIT_CACHE_PATH="$PWD/gclient-cache"' >> $BASH_ENV
 
 # Persist the git cache based on the hash of DEPS and .circle-sync-done
 # If the src cache was restored above then this will persist an empty cache
 step-save-git-cache: &step-save-git-cache
   save_cache:
     paths:
-      - ~/.gclient-cache
-    key: v2-gclient-cache-{{ checksum "src/electron/.circle-sync-done" }}-{{ checksum "src/electron/DEPS" }}
+      - gclient-cache
+    key: v5-gclient-cache-{{ checksum "src/electron/.circle-sync-done" }}-{{ checksum "src/electron/DEPS" }}
     name: Persisting git cache
 
 step-save-out-cache: &step-save-out-cache
@@ -977,7 +977,7 @@ step-save-src-cache: &step-save-src-cache
   save_cache:
     paths:
       - /var/portal
-    key: v8-src-cache-{{ checksum "/var/portal/src/electron/.depshash" }}
+    key: v12-src-cache-{{ checksum "/var/portal/src/electron/.depshash" }}
     name: Persisting src cache
 step-make-src-cache-marker: &step-make-src-cache-marker
   run:
@@ -987,7 +987,7 @@ step-save-src-cache-marker: &step-save-src-cache-marker
   save_cache:
     paths:
       - .src-cache-marker
-    key: v1-src-cache-marker-{{ checksum "/var/portal/src/electron/.depshash" }}
+    key: v5-src-cache-marker-{{ checksum "/var/portal/src/electron/.depshash" }}
 
 step-maybe-early-exit-no-doc-change: &step-maybe-early-exit-no-doc-change
   run:
@@ -1352,10 +1352,6 @@ commands:
             - *step-gclient-sync
             - store_artifacts:
                 path: patches
-            - when:
-                condition: << parameters.save-git-cache >>
-                steps:
-                  - *step-save-git-cache
             # These next few steps reset Electron to the correct commit regardless of which cache was restored
             - run:
                 name: Wipe Electron
@@ -1364,6 +1360,11 @@ commands:
             - *step-run-electron-only-hooks
             - *step-generate-deps-hash-cleanly
             - *step-mark-sync-done
+            # Save git cache AFTER sync marked done because other jobs expect that to be the case
+            - when:
+                condition: << parameters.save-git-cache >>
+                steps:
+                  - *step-save-git-cache            
             - *step-minimize-workspace-size-from-checkout
             - *step-delete-git-directories
             - when:

--- a/.circleci/build_config.yml
+++ b/.circleci/build_config.yml
@@ -45,7 +45,7 @@ executors:
         type: enum
         enum: ["medium", "xlarge", "2xlarge+"]
     docker:
-      - image: ghcr.io/electron/build:27db4a3e3512bfd2e47f58cea69922da0835f1d9
+      - image: ghcr.io/electron/build:e6bebd08a51a0d78ec23e5b3fd7e7c0846412328
     resource_class: << parameters.size >>
 
   macos:


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
- #32656 was needed because the gclient cache was not being properly keyed which meant the cache was never restored.  Since the cache was not restored, there was a step called "Fix Sync" that was failing with the following error:
```
cd src/third_party/angle
git remote set-url origin https://chromium.googlesource.com/angle/angle.git
git fetch

error: object directory /home/builduser/.gclient-cache/chromium.googlesource.com-angle-angle/objects does not exist; check .git/objects/info/alternates
remote: Finding sources: 100% (193770/193770)           ects: 1           
error: object directory /home/builduser/.gclient-cache/chromium.googlesource.com-angle-angle/objects does not exist; check .git/objects/info/alternates
remote: Total 193770 (delta 129285), reused 193125 (delta 129285)        
Receiving objects: 100% (193770/193770), 283.91 MiB | 29.34 MiB/s, done.
Resolving deltas: 100% (129285/129285), done.
error: object directory /home/builduser/.gclient-cache/chromium.googlesource.com-angle-angle/objects does not exist; check .git/objects/info/alternates
fatal: bad object 8832c8fe602d060c086fa133f9f3b0cb8ac2ce87
error: https://chromium.googlesource.com/angle/angle.git did not send all necessary objects
```
It turns out the gclient cache was also not being restored when running under Ubuntu 18, but the version of git installed on that docker image still finished this step successfully.

This PR properly keys the gclient cache so that it can be restored.  This fixes the error we were seeing on Ubuntu 20, so this PR also re-enables Ubuntu 20.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
