### PR TITLE
fix: some frameless windows showing a frame on Windows

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -329,15 +329,14 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
     // Set Window style so that we get a minimize and maximize animation when
     // frameless.
     DWORD frame_style = WS_CAPTION | WS_OVERLAPPED;
-    if (resizable_)
+    if (resizable_ && thick_frame_)
       frame_style |= WS_THICKFRAME;
     if (minimizable_)
       frame_style |= WS_MINIMIZEBOX;
     if (maximizable_)
       frame_style |= WS_MAXIMIZEBOX;
-    // We should not show a frame for transparent window.
-    if (!thick_frame_)
-      frame_style &= ~(WS_THICKFRAME | WS_CAPTION);
+    if (!thick_frame_ || !has_frame())
+      frame_style &= ~WS_CAPTION;
     ::SetWindowLong(GetAcceleratedWidget(), GWL_STYLE, frame_style);
   }
 


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/30760.

Fixes an issue where frameless windows would show chrome during the loading process when they shouldn't. Cleans up the logic for `SetWindowLong` `GWL_STYLE` application to ensure that `WS_CAPTION` is removed when the window is frameless and not just when `thickFrame` is false.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue where frameless windows on Windows would incorrectly show a small frame during the loading process.
