### PR TITLE
fix: BrowserView setBackgroundColor needs two calls

### DIFF
--- a/shell/browser/api/electron_api_browser_view.cc
+++ b/shell/browser/api/electron_api_browser_view.cc
@@ -150,6 +150,11 @@ gfx::Rect BrowserView::GetBounds() {
 
 void BrowserView::SetBackgroundColor(const std::string& color_name) {
   view_->SetBackgroundColor(ParseHexColor(color_name));
+
+  if (web_contents()) {
+    auto* wc = web_contents()->web_contents();
+    wc->SetPageBaseBackgroundColor(ParseHexColor(color_name));
+  }
 }
 
 v8::Local<v8::Value> BrowserView::GetWebContents(v8::Isolate* isolate) {


### PR DESCRIPTION
Manual backport of #31863

See that PR for details

Notes: Fixed a potential issue when setting backgroundColor on BrowserViews.