### PR TITLE
test: fix failing tests of focus/blur events of WebContents

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -516,6 +516,15 @@ Emitted when the `WebContents` loses focus.
 
 Emitted when the `WebContents` gains focus.
 
+Note that on macOS, having focus means the `WebContents` is the first responder
+of window, so switching focus between windows would not trigger the `focus` and
+`blur` events of `WebContents`, as the first responder of each window is not
+changed.
+
+The `focus` and `blur` events of `WebContents` should only be used to detect
+focus change between different `WebContents` and `BrowserView` in the same
+window.
+
 #### Event: 'devtools-opened'
 
 Emitted when DevTools is opened.


### PR DESCRIPTION
#### Description of Change

This PR fixes the tests of focus/blur events of WebContents from https://github.com/electron/electron/pull/25873 which are currently failing on main branch.

I also added a few notes on the events since they are easy to be confused with the ones of BrowserWindow.

#### Release Notes

Notes: none