### PR TITLE
build: rebuild the `dist_zip`s when the deps get modified

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1393,19 +1393,21 @@ copy("electron_version") {
 }
 
 dist_zip("electron_dist_zip") {
-  deps = [
+  data_deps = [
     ":electron_app",
     ":electron_version",
     ":licenses",
   ]
   if (is_linux) {
-    deps += [ "//sandbox/linux:chrome_sandbox" ]
+    data_deps += [ "//sandbox/linux:chrome_sandbox" ]
   }
+  deps = data_deps
   outputs = [ "$root_build_dir/dist.zip" ]
 }
 
 dist_zip("electron_ffmpeg_zip") {
-  deps = [ "//third_party/ffmpeg" ]
+  data_deps = [ "//third_party/ffmpeg" ]
+  deps = data_deps
   outputs = [ "$root_build_dir/ffmpeg.zip" ]
 }
 
@@ -1422,7 +1424,8 @@ group("electron_chromedriver") {
 
 dist_zip("electron_chromedriver_zip") {
   testonly = true
-  deps = electron_chromedriver_deps
+  data_deps = electron_chromedriver_deps
+  deps = data_deps
   outputs = [ "$root_build_dir/chromedriver.zip" ]
 }
 
@@ -1440,7 +1443,8 @@ group("electron_mksnapshot") {
 }
 
 dist_zip("electron_mksnapshot_zip") {
-  deps = mksnapshot_deps
+  data_deps = mksnapshot_deps
+  deps = data_deps
   outputs = [ "$root_build_dir/mksnapshot.zip" ]
 }
 
@@ -1450,7 +1454,8 @@ copy("hunspell_dictionaries") {
 }
 
 dist_zip("hunspell_dictionaries_zip") {
-  deps = [ ":hunspell_dictionaries" ]
+  data_deps = [ ":hunspell_dictionaries" ]
+  deps = data_deps
   flatten = true
 
   outputs = [ "$root_build_dir/hunspell_dictionaries.zip" ]
@@ -1463,7 +1468,8 @@ copy("libcxx_headers") {
 }
 
 dist_zip("libcxx_headers_zip") {
-  deps = [ ":libcxx_headers" ]
+  data_deps = [ ":libcxx_headers" ]
+  deps = data_deps
   flatten = true
   flatten_relative_to = rebase_path(
           "$target_gen_dir/electron_libcxx_include/buildtools/third_party/libc++/trunk",
@@ -1478,7 +1484,8 @@ copy("libcxxabi_headers") {
 }
 
 dist_zip("libcxxabi_headers_zip") {
-  deps = [ ":libcxxabi_headers" ]
+  data_deps = [ ":libcxxabi_headers" ]
+  deps = data_deps
   flatten = true
   flatten_relative_to = rebase_path(
           "$target_gen_dir/electron_libcxxabi_include/buildtools/third_party/libc++abi/trunk",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1393,19 +1393,19 @@ copy("electron_version") {
 }
 
 dist_zip("electron_dist_zip") {
-  data_deps = [
+  deps = [
     ":electron_app",
     ":electron_version",
     ":licenses",
   ]
   if (is_linux) {
-    data_deps += [ "//sandbox/linux:chrome_sandbox" ]
+    deps += [ "//sandbox/linux:chrome_sandbox" ]
   }
   outputs = [ "$root_build_dir/dist.zip" ]
 }
 
 dist_zip("electron_ffmpeg_zip") {
-  data_deps = [ "//third_party/ffmpeg" ]
+  deps = [ "//third_party/ffmpeg" ]
   outputs = [ "$root_build_dir/ffmpeg.zip" ]
 }
 
@@ -1422,7 +1422,7 @@ group("electron_chromedriver") {
 
 dist_zip("electron_chromedriver_zip") {
   testonly = true
-  data_deps = electron_chromedriver_deps
+  deps = electron_chromedriver_deps
   outputs = [ "$root_build_dir/chromedriver.zip" ]
 }
 
@@ -1440,7 +1440,7 @@ group("electron_mksnapshot") {
 }
 
 dist_zip("electron_mksnapshot_zip") {
-  data_deps = mksnapshot_deps
+  deps = mksnapshot_deps
   outputs = [ "$root_build_dir/mksnapshot.zip" ]
 }
 
@@ -1450,7 +1450,7 @@ copy("hunspell_dictionaries") {
 }
 
 dist_zip("hunspell_dictionaries_zip") {
-  data_deps = [ ":hunspell_dictionaries" ]
+  deps = [ ":hunspell_dictionaries" ]
   flatten = true
 
   outputs = [ "$root_build_dir/hunspell_dictionaries.zip" ]
@@ -1463,7 +1463,7 @@ copy("libcxx_headers") {
 }
 
 dist_zip("libcxx_headers_zip") {
-  data_deps = [ ":libcxx_headers" ]
+  deps = [ ":libcxx_headers" ]
   flatten = true
   flatten_relative_to = rebase_path(
           "$target_gen_dir/electron_libcxx_include/buildtools/third_party/libc++/trunk",
@@ -1478,7 +1478,7 @@ copy("libcxxabi_headers") {
 }
 
 dist_zip("libcxxabi_headers_zip") {
-  data_deps = [ ":libcxxabi_headers" ]
+  deps = [ ":libcxxabi_headers" ]
   flatten = true
   flatten_relative_to = rebase_path(
           "$target_gen_dir/electron_libcxxabi_include/buildtools/third_party/libc++abi/trunk",


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

The `dist.zip` generated by the `electron_dist_zip` action was not getting
updated when changes were being made to the dependencies, like the
source files. It turns out, we were using `data_deps` for the dependencies
instead of `deps`. Here is the difference:

`data_deps`: things needed to ultimately run the thing built by a target
`deps`: things needed to build the target

So the difference in treatment of both sets of dependencies is actually
intentional.

Signed-off-by: Darshan Sen <raisinten@gmail.com>

cc @nornagon @dsanders11 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
