### PR TITLE
chore: bump chromium to 96.0.4664.174 (16-x-y)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -15,7 +15,7 @@ gclient_gn_args = [
 
 vars = {
   'chromium_version':
-    '96.0.4664.110',
+    '96.0.4664.174',
   'node_version':
     'v16.9.1',
   'nan_version':

--- a/patches/chromium/can_create_window.patch
+++ b/patches/chromium/can_create_window.patch
@@ -9,10 +9,10 @@ potentially prevent a window from being created.
 TODO(loc): this patch is currently broken.
 
 diff --git a/content/browser/renderer_host/render_frame_host_impl.cc b/content/browser/renderer_host/render_frame_host_impl.cc
-index 193bfd1abc5f9d97f79ded22617f1a9e110175fc..b68c5ee5bd719e15d952a48ff4bc8ef0046e361a 100644
+index 551e75bc26a88206e8af9868163cd5818ebc33e1..19d944da98817b253117c6436099ab4dc7250edb 100644
 --- a/content/browser/renderer_host/render_frame_host_impl.cc
 +++ b/content/browser/renderer_host/render_frame_host_impl.cc
-@@ -6504,6 +6504,7 @@ void RenderFrameHostImpl::CreateNewWindow(
+@@ -6505,6 +6505,7 @@ void RenderFrameHostImpl::CreateNewWindow(
            last_committed_origin_, params->window_container_type,
            params->target_url, params->referrer.To<Referrer>(),
            params->frame_name, params->disposition, *params->features,

--- a/patches/chromium/disable_hidden.patch
+++ b/patches/chromium/disable_hidden.patch
@@ -34,7 +34,7 @@ index da1bc9c7e01c6eef07b1066976e7487767d716f2..5d123c6c48b299745f7524ea8927043e
    // |routing_id| must not be MSG_ROUTING_NONE.
    // If this object outlives |delegate|, DetachDelegate() must be called when
 diff --git a/content/browser/renderer_host/render_widget_host_view_aura.cc b/content/browser/renderer_host/render_widget_host_view_aura.cc
-index 239088813b9fa96e9e9899acee6f02bcb828ecde..7955f2cb725ef4c011bbbce74820d98783d56a0c 100644
+index c9cbda8362ebdf8594a8234c2ad85cacbb653ead..9505a5bfc0c88762bc00ba26774a906c9115282e 100644
 --- a/content/browser/renderer_host/render_widget_host_view_aura.cc
 +++ b/content/browser/renderer_host/render_widget_host_view_aura.cc
 @@ -611,7 +611,7 @@ void RenderWidgetHostViewAura::HideImpl() {

--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -147,7 +147,7 @@ index 288b9f89129de88ea078b2e6d3b2d255dd527a95..e9979d5c9707e94580d4a10b4c48c32c
  }
  
 diff --git a/chrome/browser/printing/print_view_manager_base.cc b/chrome/browser/printing/print_view_manager_base.cc
-index 2011d52338081666b4761e0bf66d01245abd0213..647ac4cd9730c8983868ea165907b7c9a42767aa 100644
+index 5491e04e7eba8ad7a29f1cb3aa51ee13716e0d9d..2f2348f3d2e35bfcf419b654032a799f34d13884 100644
 --- a/chrome/browser/printing/print_view_manager_base.cc
 +++ b/chrome/browser/printing/print_view_manager_base.cc
 @@ -28,10 +28,10 @@
@@ -223,10 +223,10 @@ index 2011d52338081666b4761e0bf66d01245abd0213..647ac4cd9730c8983868ea165907b7c9
 +                                    bool silent,
 +                                    base::Value settings,
 +                                    CompletionCallback callback)  {
-   auto weak_this = weak_ptr_factory_.GetWeakPtr();
-   DisconnectFromCurrentPrintJob();
-   if (!weak_this)
-@@ -369,7 +380,14 @@ bool PrintViewManagerBase::PrintNow(content::RenderFrameHost* rfh) {
+   // Remember the ID for `rfh`, to enable checking that the `RenderFrameHost`
+   // is still valid after a possible inner message loop runs in
+   // `DisconnectFromCurrentPrintJob()`.
+@@ -377,7 +388,14 @@ bool PrintViewManagerBase::PrintNow(content::RenderFrameHost* rfh) {
    // go in `ReleasePrintJob()`.
  
    SetPrintingRFH(rfh);
@@ -242,7 +242,7 @@ index 2011d52338081666b4761e0bf66d01245abd0213..647ac4cd9730c8983868ea165907b7c9
  
    for (auto& observer : GetObservers())
      observer.OnPrintNow(rfh);
-@@ -528,9 +546,9 @@ void PrintViewManagerBase::ScriptedPrintReply(
+@@ -536,9 +554,9 @@ void PrintViewManagerBase::ScriptedPrintReply(
  void PrintViewManagerBase::UpdatePrintingEnabled() {
    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
    // The Unretained() is safe because ForEachFrame() is synchronous.
@@ -255,7 +255,7 @@ index 2011d52338081666b4761e0bf66d01245abd0213..647ac4cd9730c8983868ea165907b7c9
  }
  
  void PrintViewManagerBase::NavigationStopped() {
-@@ -644,12 +662,13 @@ void PrintViewManagerBase::DidPrintDocument(
+@@ -652,12 +670,13 @@ void PrintViewManagerBase::DidPrintDocument(
  void PrintViewManagerBase::GetDefaultPrintSettings(
      GetDefaultPrintSettingsCallback callback) {
    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
@@ -270,7 +270,7 @@ index 2011d52338081666b4761e0bf66d01245abd0213..647ac4cd9730c8983868ea165907b7c9
    content::RenderFrameHost* render_frame_host = GetCurrentTargetFrame();
    auto callback_wrapper =
        base::BindOnce(&PrintViewManagerBase::GetDefaultPrintSettingsReply,
-@@ -667,18 +686,20 @@ void PrintViewManagerBase::UpdatePrintSettings(
+@@ -675,18 +694,20 @@ void PrintViewManagerBase::UpdatePrintSettings(
      base::Value job_settings,
      UpdatePrintSettingsCallback callback) {
    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
@@ -292,7 +292,7 @@ index 2011d52338081666b4761e0bf66d01245abd0213..647ac4cd9730c8983868ea165907b7c9
    content::BrowserContext* context =
        web_contents() ? web_contents()->GetBrowserContext() : nullptr;
    PrefService* prefs =
-@@ -688,6 +709,7 @@ void PrintViewManagerBase::UpdatePrintSettings(
+@@ -696,6 +717,7 @@ void PrintViewManagerBase::UpdatePrintSettings(
      if (value > 0)
        job_settings.SetIntKey(kSettingRasterizePdfDpi, value);
    }
@@ -300,7 +300,7 @@ index 2011d52338081666b4761e0bf66d01245abd0213..647ac4cd9730c8983868ea165907b7c9
  
    content::RenderFrameHost* render_frame_host = GetCurrentTargetFrame();
    auto callback_wrapper =
-@@ -727,7 +749,6 @@ void PrintViewManagerBase::PrintingFailed(int32_t cookie) {
+@@ -735,7 +757,6 @@ void PrintViewManagerBase::PrintingFailed(int32_t cookie) {
    PrintManager::PrintingFailed(cookie);
  
  #if BUILDFLAG(ENABLE_PRINT_PREVIEW)
@@ -308,7 +308,7 @@ index 2011d52338081666b4761e0bf66d01245abd0213..647ac4cd9730c8983868ea165907b7c9
  #endif
  
    ReleasePrinterQuery();
-@@ -742,6 +763,11 @@ void PrintViewManagerBase::RemoveObserver(Observer& observer) {
+@@ -750,6 +771,11 @@ void PrintViewManagerBase::RemoveObserver(Observer& observer) {
  }
  
  void PrintViewManagerBase::ShowInvalidPrinterSettingsError() {
@@ -320,7 +320,7 @@ index 2011d52338081666b4761e0bf66d01245abd0213..647ac4cd9730c8983868ea165907b7c9
    base::ThreadTaskRunnerHandle::Get()->PostTask(
        FROM_HERE, base::BindOnce(&ShowWarningMessageBox,
                                  l10n_util::GetStringUTF16(
-@@ -820,6 +846,11 @@ void PrintViewManagerBase::OnNotifyPrintJobEvent(
+@@ -828,6 +854,11 @@ void PrintViewManagerBase::OnNotifyPrintJobEvent(
  #endif
        break;
      }
@@ -332,7 +332,7 @@ index 2011d52338081666b4761e0bf66d01245abd0213..647ac4cd9730c8983868ea165907b7c9
      case JobEventDetails::JOB_DONE:
        // Printing is done, we don't need it anymore.
        // print_job_->is_job_pending() may still be true, depending on the order
-@@ -889,7 +920,10 @@ bool PrintViewManagerBase::CreateNewPrintJob(
+@@ -897,7 +928,10 @@ bool PrintViewManagerBase::CreateNewPrintJob(
  
    // Disconnect the current |print_job_|.
    auto weak_this = weak_ptr_factory_.GetWeakPtr();
@@ -344,7 +344,7 @@ index 2011d52338081666b4761e0bf66d01245abd0213..647ac4cd9730c8983868ea165907b7c9
    if (!weak_this)
      return false;
  
-@@ -912,8 +946,6 @@ bool PrintViewManagerBase::CreateNewPrintJob(
+@@ -920,8 +954,6 @@ bool PrintViewManagerBase::CreateNewPrintJob(
                          /*source_id=*/"");
  #endif
  
@@ -353,7 +353,7 @@ index 2011d52338081666b4761e0bf66d01245abd0213..647ac4cd9730c8983868ea165907b7c9
    printing_succeeded_ = false;
    return true;
  }
-@@ -965,14 +997,22 @@ void PrintViewManagerBase::ReleasePrintJob() {
+@@ -973,6 +1005,16 @@ void PrintViewManagerBase::ReleasePrintJob() {
    content::RenderFrameHost* rfh = printing_rfh_;
    printing_rfh_ = nullptr;
  
@@ -370,15 +370,16 @@ index 2011d52338081666b4761e0bf66d01245abd0213..647ac4cd9730c8983868ea165907b7c9
    if (!print_job_)
      return;
  
-   if (rfh)
+@@ -983,8 +1025,6 @@ void PrintViewManagerBase::ReleasePrintJob() {
      GetPrintRenderFrame(rfh)->PrintingDone(printing_succeeded_);
+   }
  
 -  registrar_.Remove(this, chrome::NOTIFICATION_PRINT_JOB_EVENT,
 -                    content::Source<PrintJob>(print_job_.get()));
    // Don't close the worker thread.
    print_job_ = nullptr;
  }
-@@ -1010,7 +1050,7 @@ bool PrintViewManagerBase::RunInnerMessageLoop() {
+@@ -1022,7 +1062,7 @@ bool PrintViewManagerBase::RunInnerMessageLoop() {
  }
  
  bool PrintViewManagerBase::OpportunisticallyCreatePrintJob(int cookie) {

--- a/patches/chromium/revert_do_not_display_grammar_error_if_there_it_overlaps_with_spell.patch
+++ b/patches/chromium/revert_do_not_display_grammar_error_if_there_it_overlaps_with_spell.patch
@@ -32,10 +32,10 @@ Reviewed-by: Jing Wang <jiwan@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#946860}
 
 diff --git a/content/browser/renderer_host/render_widget_host_view_aura.cc b/content/browser/renderer_host/render_widget_host_view_aura.cc
-index 7955f2cb725ef4c011bbbce74820d98783d56a0c..fc2c236b8bb9c29cd720225bf14a014f61b01181 100644
+index 9505a5bfc0c88762bc00ba26774a906c9115282e..6736446f085f6854ae704f9edeccd1ec5219993d 100644
 --- a/content/browser/renderer_host/render_widget_host_view_aura.cc
 +++ b/content/browser/renderer_host/render_widget_host_view_aura.cc
-@@ -1627,18 +1627,10 @@ bool RenderWidgetHostViewAura::AddGrammarFragments(
+@@ -1631,18 +1631,10 @@ bool RenderWidgetHostViewAura::AddGrammarFragments(
    if (!input_handler || fragments.empty())
      return false;
  
@@ -54,7 +54,7 @@ index 7955f2cb725ef4c011bbbce74820d98783d56a0c..fc2c236b8bb9c29cd720225bf14a014f
      ui::ImeTextSpan ui_ime_text_span;
      ui_ime_text_span.type = ui::ImeTextSpan::Type::kGrammarSuggestion;
      ui_ime_text_span.start_offset = fragment.range.start();
-@@ -1653,10 +1645,6 @@ bool RenderWidgetHostViewAura::AddGrammarFragments(
+@@ -1657,10 +1649,6 @@ bool RenderWidgetHostViewAura::AddGrammarFragments(
        max_fragment_end = fragment.range.end();
      }
    }

--- a/patches/chromium/webview_fullscreen.patch
+++ b/patches/chromium/webview_fullscreen.patch
@@ -14,7 +14,7 @@ Note that we also need to manually update embedder's
 `api::WebContents::IsFullscreenForTabOrPending` value.
 
 diff --git a/content/browser/renderer_host/render_frame_host_impl.cc b/content/browser/renderer_host/render_frame_host_impl.cc
-index b68c5ee5bd719e15d952a48ff4bc8ef0046e361a..44c089d82fc91462ea986ec63e124ce0cd59e7b7 100644
+index 19d944da98817b253117c6436099ab4dc7250edb..147ce007ac5cdd4814872a5803c0ce721ea26ff8 100644
 --- a/content/browser/renderer_host/render_frame_host_impl.cc
 +++ b/content/browser/renderer_host/render_frame_host_impl.cc
 @@ -5907,6 +5907,15 @@ void RenderFrameHostImpl::EnterFullscreen(

--- a/patches/v8/fix_disable_implies_dcheck_for_node_stream_array_buffers.patch
+++ b/patches/v8/fix_disable_implies_dcheck_for_node_stream_array_buffers.patch
@@ -18,7 +18,7 @@ This patch can be removed when streams support rab/gsab, or
 when support is synchronized across both v8 and node.
 
 diff --git a/src/objects/js-array-buffer.cc b/src/objects/js-array-buffer.cc
-index 07b37dd7f5a76c13fe6f8a55fd4a93fa813d81a6..ad0e4610b7f9adc64d996800e5fdb0c6f1a58562 100644
+index fd9f3133a5fefb6d7b4b310c855cb87c8a84e9aa..b8b93351f0877df27b2dc34a2e149638ca8c9110 100644
 --- a/src/objects/js-array-buffer.cc
 +++ b/src/objects/js-array-buffer.cc
 @@ -72,9 +72,9 @@ void JSArrayBuffer::Attach(std::shared_ptr<BackingStore> backing_store) {


### PR DESCRIPTION
Updating Chromium to 96.0.4664.174.

See [all changes in 96.0.4664.110..96.0.4664.174](https://chromium.googlesource.com/chromium/src/+log/96.0.4664.110..96.0.4664.174?n=10000&pretty=fuller)

<!--
Original-Version: 96.0.4664.110
-->

Notes: Updated Chromium to 96.0.4664.174.