### PR TITLE
test: improve `webContents.savePage()` specs

### DIFF
--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -3419,20 +3419,39 @@ describe('BrowserWindow module', () => {
     const savePageJsPath = path.join(savePageDir, 'save_page_files', 'test.js');
     const savePageCssPath = path.join(savePageDir, 'save_page_files', 'test.css');
 
-    after(() => {
+    afterEach(() => {
+      closeAllWindows();
+
       try {
         fs.unlinkSync(savePageCssPath);
         fs.unlinkSync(savePageJsPath);
         fs.unlinkSync(savePageHtmlPath);
         fs.rmdirSync(path.join(savePageDir, 'save_page_files'));
         fs.rmdirSync(savePageDir);
-      } catch (e) {
-        // Ignore error
-      }
+      } catch {}
     });
-    afterEach(closeAllWindows);
 
-    it('should save page to disk', async () => {
+    it('should save page to disk with HTMLOnly', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadFile(path.join(fixtures, 'pages', 'save_page', 'index.html'));
+      await w.webContents.savePage(savePageHtmlPath, 'HTMLOnly');
+
+      expect(fs.existsSync(savePageHtmlPath)).to.be.true('html path');
+      expect(fs.existsSync(savePageJsPath)).to.be.false('js path');
+      expect(fs.existsSync(savePageCssPath)).to.be.false('css path');
+    });
+
+    it('should save page to disk with MHTML', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadFile(path.join(fixtures, 'pages', 'save_page', 'index.html'));
+      await w.webContents.savePage(savePageHtmlPath, 'MHTML');
+
+      expect(fs.existsSync(savePageHtmlPath)).to.be.true('html path');
+      expect(fs.existsSync(savePageJsPath)).to.be.false('js path');
+      expect(fs.existsSync(savePageCssPath)).to.be.false('css path');
+    });
+
+    it('should save page to disk with HTMLComplete', async () => {
       const w = new BrowserWindow({ show: false });
       await w.loadFile(path.join(fixtures, 'pages', 'save_page', 'index.html'));
       await w.webContents.savePage(savePageHtmlPath, 'HTMLComplete');


### PR DESCRIPTION
#### Description of Change

While triaging https://github.com/electron/electron/issues/32696 this morning i discovered that we don't explicitly test all `saveType` options in our `webContents.savePage` tests. This corrects that.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none.