### PR TITLE
fix: savePage throw on relative paths

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1856,7 +1856,7 @@ the cursor when dragging.
 
 #### `contents.savePage(fullPath, saveType)`
 
-* `fullPath` string - The full file path.
+* `fullPath` string - The absolute file path.
 * `saveType` string - Specify the save type.
   * `HTMLOnly` - Save only the HTML of the page.
   * `HTMLComplete` - Save complete-html page.

--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -2353,6 +2353,11 @@ v8::Local<v8::Promise> WebContents::SavePage(
   gin_helper::Promise<void> promise(isolate);
   v8::Local<v8::Promise> handle = promise.GetHandle();
 
+  if (!full_file_path.IsAbsolute()) {
+    promise.RejectWithErrorMessage("Path must be absolute");
+    return handle;
+  }
+
   auto* handler = new SavePageHandler(web_contents(), std::move(promise));
   handler->Handle(full_file_path, save_type);
 

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -3431,6 +3431,23 @@ describe('BrowserWindow module', () => {
       } catch {}
     });
 
+    it('should throw when passing relative paths', async () => {
+      const w = new BrowserWindow({ show: false });
+      await w.loadFile(path.join(fixtures, 'pages', 'save_page', 'index.html'));
+
+      await expect(
+        w.webContents.savePage('save_page.html', 'HTMLComplete')
+      ).to.eventually.be.rejectedWith('Path must be absolute');
+
+      await expect(
+        w.webContents.savePage('save_page.html', 'HTMLOnly')
+      ).to.eventually.be.rejectedWith('Path must be absolute');
+
+      await expect(
+        w.webContents.savePage('save_page.html', 'MHTML')
+      ).to.eventually.be.rejectedWith('Path must be absolute');
+    });
+
     it('should save page to disk with HTMLOnly', async () => {
       const w = new BrowserWindow({ show: false });
       await w.loadFile(path.join(fixtures, 'pages', 'save_page', 'index.html'));


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/32696.

Fixes an issue where `webContents.savePage` failed consistently on Windows and Linux and sporadically on macOS when passing a relative path instead of an absolute one. Our version of `savePage` plumbs down to [`content/browser/web_contents/web_contents_impl.cc`](https://source.chromium.org/chromium/chromium/src/+/main:content/browser/web_contents/web_contents_impl.cc;l=4863-4865;drc=cba00174ca338153b9c4f0c31ddbabaac7dd38c7;bpv=1;bpt=1?q=savepage%20webcontents%20-f:out%20&ss=chromium%2Fchromium%2Fsrc), which, per comment:

> Used in automated testing to bypass prompting the user for file names. Instead, the names and paths are hard coded rather than running them through file name sanitation and extension / mime checking.

As a result, there isn't any proper checking for paths being absolute at that layer, since it's a function that assumes what's being passed to it has already been checked and sanitized.

We fix this by performing absolute path checks ourselves.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `webContents.savePage` failed when passing a relative path instead of an absolute one.