### PR TITLE
build(deps-dev): bump @types/node to v16

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@electron/get": "^1.13.0",
-    "@types/node": "^14.6.2",
+    "@types/node": "^16.11.26",
     "extract-zip": "^1.0.3"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/klaw": "^3.0.1",
     "@types/minimist": "^1.2.0",
     "@types/mocha": "^7.0.2",
-    "@types/node": "^14.6.2",
+    "@types/node": "^16.11.26",
     "@types/semver": "^7.3.3",
     "@types/send": "^0.14.5",
     "@types/split": "^1.0.0",

--- a/spec-main/api-web-request-spec.ts
+++ b/spec-main/api-web-request-spec.ts
@@ -1,11 +1,12 @@
 import { expect } from 'chai';
+import { Socket, AddressInfo } from 'net';
 import * as http from 'http';
 import * as qs from 'querystring';
 import * as path from 'path';
 import * as url from 'url';
 import * as WebSocket from 'ws';
 import { ipcMain, protocol, session, WebContents, webContents } from 'electron/main';
-import { AddressInfo } from 'net';
+
 import { emittedOnce } from './events-helpers';
 
 const fixturesPath = path.resolve(__dirname, 'fixtures');
@@ -478,10 +479,10 @@ describe('webRequest module', () => {
           }
         });
       });
-      server.on('upgrade', function upgrade (request, socket, head) {
+      server.on('upgrade', function upgrade (request, socket: Socket, head) {
         const pathname = require('url').parse(request.url).pathname;
         if (pathname === '/websocket') {
-          reqHeaders[request.url] = request.headers;
+          reqHeaders[request.url!] = request.headers;
           wss.handleUpgrade(request, socket, head, function done (ws) {
             wss.emit('connection', ws, request);
           });

--- a/spec-main/types-spec.ts
+++ b/spec-main/types-spec.ts
@@ -5,7 +5,6 @@ describe('bundled @types/node', () => {
     expect(require('../npm/package.json').dependencies).to.have.property('@types/node');
     const range = require('../npm/package.json').dependencies['@types/node'];
     expect(range).to.match(/^\^.+/, 'should allow any type dep in a major range');
-    // TODO(codebytere): re-enable after https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52594 is merged.
-    // expect(range.slice(1).split('.')[0]).to.equal(process.versions.node.split('.')[0]);
+    expect(range.slice(1).split('.')[0]).to.equal(process.versions.node.split('.')[0]);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -290,10 +290,10 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
-"@types/express-serve-static-core@*":
-  version "4.17.8"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.8.tgz#b8f7b714138536742da222839892e203df569d1c"
-  integrity sha512-1SJZ+R3Q/7mLkOD9ewCBDYD2k0WyZQtWYqF/2VvoNN2/uhI49J9CDN4OAm+wGMA0DbArA4ef27xl4+JwMtGggw==
+"@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.21":
+  version "4.17.28"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz#c47def9f34ec81dc6328d0b1b5303d1ec98d86b8"
+  integrity sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
@@ -441,15 +441,15 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.22.tgz#91ee88ebfa25072433497f6f3150f84fa8c3a91b"
   integrity sha512-rOsaPRUGTOXbRBOKToy4cgZXY4Y+QSVhxcLwdEveozbk7yuudhWMpxxcaXqYizLMP3VY7OcWCFtx9lGFh5j5kg==
 
-"@types/node@^14.6.2":
-  version "14.6.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.3.tgz#cc4f979548ca4d8e7b90bc0180052ab99ee64224"
-  integrity sha512-pC/hkcREG6YfDfui1FBmj8e20jFU5Exjw4NYDm8kEdrW+mOh0T1Zve8DWKnS7ZIZvgncrctcNCXF4Q2I+loyww==
-
 "@types/node@^16.0.0":
   version "16.4.13"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.4.13.tgz#7dfd9c14661edc65cccd43a29eb454174642370d"
   integrity sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg==
+
+"@types/node@^16.11.26":
+  version "16.11.26"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.26.tgz#63d204d136c9916fb4dcd1b50f9740fe86884e47"
+  integrity sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
#### Description of Change
Bump [@types/node](https://www.npmjs.com/package/@types/node) to major line v16 as we are already using node v16.x.x 

Re-enabling the associated test as the require [PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52594) got merged
cc: @codebytere @MarshallOfSound @dsanders11 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes

Notes: none
