### PR TITLE
build: Support cygwin in script/lib/util.py

### DIFF
--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -206,6 +206,7 @@ def get_buildtools_executable(name):
     'linux': 'linux64',
     'linux2': 'linux64',
     'win32': 'win',
+    'cygwin': 'win',
   }[sys.platform]
   path = os.path.join(buildtools, chromium_platform, name)
   if sys.platform == 'win32':


### PR DESCRIPTION
Running a build on Cygwin or MSYS2 otherwise fails.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>

- [x] `npm test` passes

#### Release Notes

Notes: None
