### PR TITLE
fix: Make ElectronBrowser mojo interface frame associated.

### DIFF
--- a/shell/browser/electron_browser_handler_impl.cc
+++ b/shell/browser/electron_browser_handler_impl.cc
@@ -15,7 +15,7 @@
 namespace electron {
 ElectronBrowserHandlerImpl::ElectronBrowserHandlerImpl(
     content::RenderFrameHost* frame_host,
-    mojo::PendingReceiver<mojom::ElectronBrowser> receiver)
+    mojo::PendingAssociatedReceiver<mojom::ElectronBrowser> receiver)
     : render_process_id_(frame_host->GetProcess()->GetID()),
       render_frame_id_(frame_host->GetRoutingID()) {
   content::WebContents* web_contents =
@@ -135,7 +135,7 @@ content::RenderFrameHost* ElectronBrowserHandlerImpl::GetRenderFrameHost() {
 // static
 void ElectronBrowserHandlerImpl::Create(
     content::RenderFrameHost* frame_host,
-    mojo::PendingReceiver<mojom::ElectronBrowser> receiver) {
+    mojo::PendingAssociatedReceiver<mojom::ElectronBrowser> receiver) {
   new ElectronBrowserHandlerImpl(frame_host, std::move(receiver));
 }
 }  // namespace electron

--- a/shell/browser/electron_browser_handler_impl.h
+++ b/shell/browser/electron_browser_handler_impl.h
@@ -23,10 +23,11 @@ class ElectronBrowserHandlerImpl : public mojom::ElectronBrowser,
  public:
   explicit ElectronBrowserHandlerImpl(
       content::RenderFrameHost* render_frame_host,
-      mojo::PendingReceiver<mojom::ElectronBrowser> receiver);
+      mojo::PendingAssociatedReceiver<mojom::ElectronBrowser> receiver);
 
-  static void Create(content::RenderFrameHost* frame_host,
-                     mojo::PendingReceiver<mojom::ElectronBrowser> receiver);
+  static void Create(
+      content::RenderFrameHost* frame_host,
+      mojo::PendingAssociatedReceiver<mojom::ElectronBrowser> receiver);
 
   // disable copy
   ElectronBrowserHandlerImpl(const ElectronBrowserHandlerImpl&) = delete;
@@ -75,7 +76,7 @@ class ElectronBrowserHandlerImpl : public mojom::ElectronBrowser,
   const int render_process_id_;
   const int render_frame_id_;
 
-  mojo::Receiver<mojom::ElectronBrowser> receiver_{this};
+  mojo::AssociatedReceiver<mojom::ElectronBrowser> receiver_{this};
 
   base::WeakPtrFactory<ElectronBrowserHandlerImpl> weak_factory_{this};
 };

--- a/shell/renderer/api/electron_api_ipc_renderer.cc
+++ b/shell/renderer/api/electron_api_ipc_renderer.cc
@@ -22,7 +22,7 @@
 #include "shell/common/node_bindings.h"
 #include "shell/common/node_includes.h"
 #include "shell/common/v8_value_serializer.h"
-#include "third_party/blink/public/common/browser_interface_broker_proxy.h"
+#include "third_party/blink/public/common/associated_interfaces/associated_interface_provider.h"
 #include "third_party/blink/public/web/web_local_frame.h"
 #include "third_party/blink/public/web/web_message_port_converter.h"
 
@@ -59,8 +59,8 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
         v8::Global<v8::Context>(isolate, isolate->GetCurrentContext());
     weak_context_.SetWeak();
 
-    render_frame->GetBrowserInterfaceBroker()->GetInterface(
-        electron_browser_remote_.BindNewPipeAndPassReceiver());
+    render_frame->GetRemoteAssociatedInterfaces()->GetInterface(
+        &electron_browser_remote_);
   }
 
   void OnDestruct() override { electron_browser_remote_.reset(); }
@@ -223,7 +223,8 @@ class IPCRenderer : public gin::Wrappable<IPCRenderer>,
   }
 
   v8::Global<v8::Context> weak_context_;
-  mojo::Remote<electron::mojom::ElectronBrowser> electron_browser_remote_;
+  mojo::AssociatedRemote<electron::mojom::ElectronBrowser>
+      electron_browser_remote_;
 };
 
 gin::WrapperInfo IPCRenderer::kWrapperInfo = {gin::kEmbedderNativeGin};

--- a/shell/renderer/api/electron_api_web_frame.cc
+++ b/shell/renderer/api/electron_api_web_frame.cc
@@ -34,7 +34,7 @@
 #include "shell/renderer/api/electron_api_context_bridge.h"
 #include "shell/renderer/api/electron_api_spell_check_client.h"
 #include "shell/renderer/renderer_client_base.h"
-#include "third_party/blink/public/common/browser_interface_broker_proxy.h"
+#include "third_party/blink/public/common/associated_interfaces/associated_interface_provider.h"
 #include "third_party/blink/public/common/page/page_zoom.h"
 #include "third_party/blink/public/common/web_cache/web_cache_resource_type_stats.h"
 #include "third_party/blink/public/common/web_preferences/web_preferences.h"
@@ -453,9 +453,9 @@ class WebFrameRenderer : public gin::Wrappable<WebFrameRenderer>,
     if (!MaybeGetRenderFrame(isolate, "setZoomLevel", &render_frame))
       return;
 
-    mojo::Remote<mojom::ElectronBrowser> browser_remote;
-    render_frame->GetBrowserInterfaceBroker()->GetInterface(
-        browser_remote.BindNewPipeAndPassReceiver());
+    mojo::AssociatedRemote<mojom::ElectronBrowser> browser_remote;
+    render_frame->GetRemoteAssociatedInterfaces()->GetInterface(
+        &browser_remote);
     browser_remote->SetTemporaryZoomLevel(level);
   }
 
@@ -465,9 +465,9 @@ class WebFrameRenderer : public gin::Wrappable<WebFrameRenderer>,
     if (!MaybeGetRenderFrame(isolate, "getZoomLevel", &render_frame))
       return result;
 
-    mojo::Remote<mojom::ElectronBrowser> browser_remote;
-    render_frame->GetBrowserInterfaceBroker()->GetInterface(
-        browser_remote.BindNewPipeAndPassReceiver());
+    mojo::AssociatedRemote<mojom::ElectronBrowser> browser_remote;
+    render_frame->GetRemoteAssociatedInterfaces()->GetInterface(
+        &browser_remote);
     browser_remote->DoGetZoomLevel(&result);
     return result;
   }

--- a/shell/renderer/electron_render_frame_observer.cc
+++ b/shell/renderer/electron_render_frame_observer.cc
@@ -22,7 +22,7 @@
 #include "shell/common/options_switches.h"
 #include "shell/common/world_ids.h"
 #include "shell/renderer/renderer_client_base.h"
-#include "third_party/blink/public/common/browser_interface_broker_proxy.h"
+#include "third_party/blink/public/common/associated_interfaces/associated_interface_provider.h"
 #include "third_party/blink/public/common/web_preferences/web_preferences.h"
 #include "third_party/blink/public/platform/web_isolated_world_info.h"
 #include "third_party/blink/public/web/blink.h"
@@ -149,9 +149,8 @@ void ElectronRenderFrameObserver::DraggableRegionsChanged() {
     regions.push_back(std::move(region));
   }
 
-  mojo::Remote<mojom::ElectronBrowser> browser_remote;
-  render_frame_->GetBrowserInterfaceBroker()->GetInterface(
-      browser_remote.BindNewPipeAndPassReceiver());
+  mojo::AssociatedRemote<mojom::ElectronBrowser> browser_remote;
+  render_frame_->GetRemoteAssociatedInterfaces()->GetInterface(&browser_remote);
   browser_remote->UpdateDraggableRegions(std::move(regions));
 }
 
@@ -169,9 +168,9 @@ void ElectronRenderFrameObserver::OnDestruct() {
 void ElectronRenderFrameObserver::DidMeaningfulLayout(
     blink::WebMeaningfulLayout layout_type) {
   if (layout_type == blink::WebMeaningfulLayout::kVisuallyNonEmpty) {
-    mojo::Remote<mojom::ElectronBrowser> browser_remote;
-    render_frame_->GetBrowserInterfaceBroker()->GetInterface(
-        browser_remote.BindNewPipeAndPassReceiver());
+    mojo::AssociatedRemote<mojom::ElectronBrowser> browser_remote;
+    render_frame_->GetRemoteAssociatedInterfaces()->GetInterface(
+        &browser_remote);
     browser_remote->OnFirstNonEmptyLayout();
   }
 }


### PR DESCRIPTION
#### Description of Change
Switch electron implementation of mojo interface to use same message pipe as some if interfaces handling frame in chromium. This will assure proper sequencing of events on browser side wrt electron ipc and frame handling. Otherwise race condition could be seen when objects operating on same models in browser process as standard web api is using, for example:
```
let child = window.open("https://www.example.com/","my_new_child") // cross site
ipcRenderer.send("do_something_with_child", "my_new_child");
```
will be racy without the change and ipc event could be handled before window is created (albeit rarely as it is timing dependent).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed possible race conditions between frame state and electron ipc.
