### PR TITLE
fix: persist BrowserView content bounds when calculating layout

### DIFF
--- a/shell/browser/ui/views/inspectable_web_contents_view_views.cc
+++ b/shell/browser/ui/views/inspectable_web_contents_view_views.cc
@@ -214,7 +214,7 @@ void InspectableWebContentsViewViews::SetTitle(const std::u16string& title) {
 
 void InspectableWebContentsViewViews::Layout() {
   if (!devtools_web_view_->GetVisible()) {
-    contents_web_view_->SetBoundsRect(GetVisibleBounds());
+    contents_web_view_->SetBoundsRect(GetContentsBounds());
     return;
   }
 


### PR DESCRIPTION
#### Description of Change

Closes: https://github.com/electron/electron/issues/31513

This PR reverts the change introduced in PR: https://github.com/electron/electron/pull/30510, to persist the content bounds of a BrowserView when it goes outside it's parent window. For background reference to see why this change was done, see: https://github.com/electron/electron/issues/29778.

The reason for this PR and why we think it's a reasonable change to do is the following:
- We want to have an option to shift a BrowserView to go outside of it's parent window without having the framework limiting it's bounds, which we had before.
- If the color issue can be solved by making sure a BrowserView is inside it's parent window, we would prefer to let the application developer solve this and still allow to have a choice to move a BrowserView outside of it's parent bounds.
- The color issue isn't solved with the introduced change (see: https://github.com/electron/electron/issues/30700).

#### Checklist
- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where BrowserView layout bounds where limited to it's visible bounds.
