### PR TITLE
chore: cherry-pick fix for 1283198 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -136,3 +136,4 @@ cherry-pick-da11d71a0227.patch
 m96_fileapi_move_origin_checks_in_bloburlstore_sooner.patch
 cherry-pick-6bb320d134b1.patch
 cherry-pick-c5571653d932.patch
+cherry-pick-1283198.patch

--- a/patches/chromium/cherry-pick-1283198.patch
+++ b/patches/chromium/cherry-pick-1283198.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Daniel Hosseinian <dhoss@chromium.org>
+Date: Thu, 30 Dec 2021 05:08:29 +0000
+Subject: CHECK page on thumbnail requests
+
+Elevate DCHECK to CHECK.
+
+Fixed: 1283198
+Change-Id: Iacb3da961cfb44f94f7a377e225270a57809ef9c
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3361538
+Auto-Submit: Daniel Hosseinian <dhoss@chromium.org>
+Reviewed-by: K. Moon <kmoon@chromium.org>
+Commit-Queue: K. Moon <kmoon@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#954552}
+
+diff --git a/pdf/pdfium/pdfium_engine.cc b/pdf/pdfium/pdfium_engine.cc
+index 7f70791ceddf298d2c95ca3569799a0f4d3746a3..c7ae1b65d416024a7d90e377a57b5ae1ea3e0c07 100644
+--- a/pdf/pdfium/pdfium_engine.cc
++++ b/pdf/pdfium/pdfium_engine.cc
+@@ -4224,7 +4224,7 @@ void PDFiumEngine::SetLinkUnderCursorForAnnotation(FPDF_ANNOTATION annot,
+ void PDFiumEngine::RequestThumbnail(int page_index,
+                                     float device_pixel_ratio,
+                                     SendThumbnailCallback send_callback) {
+-  DCHECK(PageIndexInBounds(page_index));
++  CHECK(PageIndexInBounds(page_index));
+   pages_[page_index]->RequestThumbnail(device_pixel_ratio,
+                                        std::move(send_callback));
+ }


### PR DESCRIPTION
Subject: CHECK page on thumbnail requests

Elevate DCHECK to CHECK.

Fixed: 1283198

Notes: Security: backported fix for chromium:1283198.
