### PR TITLE
chore: cherry-pick efdfe711dc5 from chromium

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -3,3 +3,4 @@ cherry-pick-05e69c75905f.patch
 cherry-pick-891020ed64d4.patch
 cherry-pick-2b98abd8cb6c.patch
 cherry-pick-cc44ae61f37b.patch
+vangle_change_the_default_vulkan_device_choose_logic.patch

--- a/patches/angle/vangle_change_the_default_vulkan_device_choose_logic.patch
+++ b/patches/angle/vangle_change_the_default_vulkan_device_choose_logic.patch
@@ -1,0 +1,81 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Peng Huang <penghuang@chromium.org>
+Date: Mon, 25 Oct 2021 15:45:36 -0400
+Subject: VANGLE: change the default vulkan device choose logic
+
+To match the vulkan device choose logic in chrome, ANGLE will choose
+the default device based on the order of (discret GPU > integrated GPU
+> other GPU)
+
+TODO: for long term, ANGLE should provide a way to let chrome specify
+the physical device.
+
+Bug: chromium:1260869
+Change-Id: Id023138485eb65fcc1d2758103d59a4e6cb2a51d
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3242963
+Reviewed-by: Geoff Lang <geofflang@chromium.org>
+Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
+Commit-Queue: Peng Huang <penghuang@chromium.org>
+
+diff --git a/src/common/vulkan/vulkan_icd.cpp b/src/common/vulkan/vulkan_icd.cpp
+index 0ed7ae2aa058792b700503dfdb6fd91b05bf68fb..df14f5f674b37c49332e43ccba8f1782cb13f495 100644
+--- a/src/common/vulkan/vulkan_icd.cpp
++++ b/src/common/vulkan/vulkan_icd.cpp
+@@ -11,6 +11,7 @@
+ #include <functional>
+ #include <vector>
+ 
++#include "common/Optional.h"
+ #include "common/bitset_utils.h"
+ #include "common/debug.h"
+ #include "common/system_utils.h"
+@@ -94,8 +95,7 @@ ICDFilterFunc GetFilterForICD(vk::ICD preferredICD)
+             const std::string anglePreferredDevice =
+                 angle::GetEnvironmentVar(kANGLEPreferredDeviceEnv);
+             return [anglePreferredDevice](const VkPhysicalDeviceProperties &deviceProperties) {
+-                return (anglePreferredDevice.empty() ||
+-                        anglePreferredDevice == deviceProperties.deviceName);
++                return (anglePreferredDevice == deviceProperties.deviceName);
+             };
+     }
+ }
+@@ -262,9 +262,37 @@ void ChoosePhysicalDevice(const std::vector<VkPhysicalDevice> &physicalDevices,
+             return;
+         }
+     }
+-    WARN() << "Preferred device ICD not found. Using default physicalDevice instead.";
+ 
+-    // Fall back to first device.
++    Optional<VkPhysicalDevice> integratedDevice;
++    VkPhysicalDeviceProperties integratedDeviceProperties;
++    for (const VkPhysicalDevice &physicalDevice : physicalDevices)
++    {
++        vkGetPhysicalDeviceProperties(physicalDevice, physicalDevicePropertiesOut);
++        // If discrete GPU exists, uses it by default.
++        if (physicalDevicePropertiesOut->deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
++        {
++            *physicalDeviceOut = physicalDevice;
++            return;
++        }
++        if (physicalDevicePropertiesOut->deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU &&
++            !integratedDevice.valid())
++        {
++            integratedDevice           = physicalDevice;
++            integratedDeviceProperties = *physicalDevicePropertiesOut;
++            continue;
++        }
++    }
++
++    // If only integrated GPU exists, use it by default.
++    if (integratedDevice.valid())
++    {
++        *physicalDeviceOut           = integratedDevice.value();
++        *physicalDevicePropertiesOut = integratedDeviceProperties;
++        return;
++    }
++
++    WARN() << "Preferred device ICD not found. Using default physicalDevice instead.";
++    // Fallback to the first device.
+     *physicalDeviceOut = physicalDevices[0];
+     vkGetPhysicalDeviceProperties(*physicalDeviceOut, physicalDevicePropertiesOut);
+ }

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -132,3 +132,4 @@ m96_fileapi_move_origin_checks_in_bloburlstore_sooner.patch
 cherry-pick-f781748dcb3c.patch
 cherry-pick-c5571653d932.patch
 fix_crash_when_saving_edited_pdf_files.patch
+do_not_select_vulkan_device_based_on_the_passed_in_gpu_info_on_linux.patch

--- a/patches/chromium/do_not_select_vulkan_device_based_on_the_passed_in_gpu_info_on_linux.patch
+++ b/patches/chromium/do_not_select_vulkan_device_based_on_the_passed_in_gpu_info_on_linux.patch
@@ -1,0 +1,60 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Peng Huang <penghuang@chromium.org>
+Date: Mon, 25 Oct 2021 21:10:55 +0000
+Subject: Do not select vulkan device based on the passed in gpu_info on Linux
+
+On linux dual GPU setup, we cannot detect the active GPU correctly.
+It causes problems for GL and Vulkan interop. So we would to use
+ANGLE vulkan backend when vulkan is enabled. So we can choose the same
+GPU for both vulkan and GL. So for this CL, we will not create vulkan
+device based on passed in gpu_info anymore, instead GPU device will be
+selected by the order of
+(discrete GPU > integrated GPU > virtual GPU > CPU simulated GPU).
+And we will use the same logic in ANGLE vulkan backend as well.
+
+Bug: 1260869
+Change-Id: I6fb79a4e6ce1710e4809cd63a0f7738955a8e2d2
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3242785
+Commit-Queue: Peng Huang <penghuang@chromium.org>
+Commit-Queue: Vasiliy Telezhnikov <vasilyt@chromium.org>
+Auto-Submit: Peng Huang <penghuang@chromium.org>
+Reviewed-by: Vasiliy Telezhnikov <vasilyt@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#934696}
+
+diff --git a/gpu/vulkan/vulkan_device_queue.cc b/gpu/vulkan/vulkan_device_queue.cc
+index e4fe73f613dfe27b2ac6ccd7d31448e0f16ff459..22abed4db134647699d5622c4b92c3a861274f7c 100644
+--- a/gpu/vulkan/vulkan_device_queue.cc
++++ b/gpu/vulkan/vulkan_device_queue.cc
+@@ -11,6 +11,7 @@
+ 
+ #include "base/logging.h"
+ #include "base/strings/stringprintf.h"
++#include "build/build_config.h"
+ #include "gpu/config/gpu_info.h"  // nogncheck
+ #include "gpu/config/vulkan_info.h"
+ #include "gpu/vulkan/vulkan_command_pool.h"
+@@ -77,11 +78,15 @@ bool VulkanDeviceQueue::Initialize(
+     if (device_properties.apiVersion < info.used_api_version)
+       continue;
+ 
++      // In dual-CPU cases, we cannot detect the active GPU correctly on Linux,
++      // so don't select GPU device based on the |gpu_info|.
++#if !defined(OS_LINUX)
+     // If gpu_info is provided, the device should match it.
+     if (gpu_info && (device_properties.vendorID != gpu_info->gpu.vendor_id ||
+                      device_properties.deviceID != gpu_info->gpu.device_id)) {
+       continue;
+     }
++#endif
+ 
+     if (device_properties.deviceType < 0 ||
+         device_properties.deviceType > VK_PHYSICAL_DEVICE_TYPE_CPU) {
+@@ -112,7 +117,7 @@ bool VulkanDeviceQueue::Initialize(
+         break;
+       }
+     }
+-    
++
+     if (!found)
+       continue;
+ 


### PR DESCRIPTION
Subject: Do not select vulkan device based on the passed in gpu_info on Linux

On linux dual GPU setup, we cannot detect the active GPU correctly.
It causes problems for GL and Vulkan interop. So we would to use
ANGLE vulkan backend when vulkan is enabled. So we can choose the same
GPU for both vulkan and GL. So for this CL, we will not create vulkan
device based on passed in gpu_info anymore, instead GPU device will be
selected by the order of
(discrete GPU > integrated GPU > virtual GPU > CPU simulated GPU).
And we will use the same logic in ANGLE vulkan backend as well.

Bug: 1260869
Change-Id: I6fb79a4e6ce1710e4809cd63a0f7738955a8e2d2
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3242785
Commit-Queue: Peng Huang <penghuang@chromium.org>
Commit-Queue: Vasiliy Telezhnikov <vasilyt@chromium.org>
Auto-Submit: Peng Huang <penghuang@chromium.org>
Reviewed-by: Vasiliy Telezhnikov <vasilyt@chromium.org>
Cr-Commit-Position: refs/heads/main@{#934696}

Notes: Security: backported fix for chromium:1260869