### PR TITLE
fix: `webContents.openDevTools({mode})` not working

### DIFF
--- a/patches/config.json
+++ b/patches/config.json
@@ -3,6 +3,8 @@
 
   "src/electron/patches/boringssl": "src/third_party/boringssl/src",
 
+  "src/electron/patches/devtools_frontend": "src/third_party/devtools-frontend/src",
+
   "src/electron/patches/webrtc": "src/third_party/webrtc",
 
   "src/electron/patches/v8":  "src/v8",

--- a/patches/devtools_frontend/.patches
+++ b/patches/devtools_frontend/.patches
@@ -1,0 +1,1 @@
+fix_expose_globals_to_allow_patching_devtools_dock.patch

--- a/patches/devtools_frontend/fix_expose_globals_to_allow_patching_devtools_dock.patch
+++ b/patches/devtools_frontend/fix_expose_globals_to_allow_patching_devtools_dock.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shelley Vohr <shelley.vohr@gmail.com>
+Date: Wed, 9 Feb 2022 10:55:54 +0100
+Subject: fix: expose globals to allow patching Devtools dock
+
+Electron calls into UI.DockController.instance().setDockSide(side) in
+order to allow users to set the devtools dock position via
+webContents.openDevTools({ mode }). In https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/3310870
+the globals which we used to enable this were removed, and so we need to
+re-expose them to fix this broken functionality. We should look to
+upstream a more durable approach to allowing us to do this, at which
+point this patch can be removed.
+
+diff --git a/front_end/entrypoints/shell/BUILD.gn b/front_end/entrypoints/shell/BUILD.gn
+index bf96adcaa42a2406cf1dd7cd2468802886aa4fd7..cd84442cab4a0da772dd37cd4e921041b3b6173a 100644
+--- a/front_end/entrypoints/shell/BUILD.gn
++++ b/front_end/entrypoints/shell/BUILD.gn
+@@ -31,6 +31,7 @@ devtools_entrypoint("shell") {
+     "../../ui/legacy/components/perf_ui:meta",
+     "../../ui/legacy/components/quick_open:meta",
+     "../../ui/legacy/components/source_frame:meta",
++    "../../ui/legacy:legacy",
+   ]
+ 
+   visibility = [
+diff --git a/front_end/entrypoints/shell/shell.ts b/front_end/entrypoints/shell/shell.ts
+index 89255a0927a647ca32d1a9508853425a3207b441..f0e1e32f80d79e400ad139818edce60aff6aeb89 100644
+--- a/front_end/entrypoints/shell/shell.ts
++++ b/front_end/entrypoints/shell/shell.ts
+@@ -20,6 +20,7 @@ import '../../models/logs/logs-meta.js';
+ import '../main/main-meta.js';
+ import '../../ui/legacy/components/perf_ui/perf_ui-meta.js';
+ import '../../ui/legacy/components/quick_open/quick_open-meta.js';
++import '../../ui/legacy/legacy-legacy.js';
+ import '../../core/sdk/sdk-meta.js';
+ import '../../ui/legacy/components/source_frame/source_frame-meta.js';
+ import '../../panels/console_counters/console_counters-meta.js';
+diff --git a/front_end/ui/legacy/BUILD.gn b/front_end/ui/legacy/BUILD.gn
+index fe7c150cf6ce24b10821fa5a91d55f82cf865222..7177d495ec9e2b31a641c7a531b63584c597cf97 100644
+--- a/front_end/ui/legacy/BUILD.gn
++++ b/front_end/ui/legacy/BUILD.gn
+@@ -182,5 +182,6 @@ devtools_entrypoint("legacy") {
+   visibility = [
+     "../..:legacy_entrypoints",
+     "../../legacy_test_runner/*",
++    "../../entrypoints/shell/*",
+   ]
+ }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/32702.

Electron calls into `UI.DockController.instance().setDockSide(side)` in order to allow users to set the devtools dock position via `webContents.openDevTools({ mode })`. In [this DevTools CL](https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/3310870) the globals which we used to enable this were removed, and so we need to re-expose them to fix this broken functionality. We should look to upstream a more durable approach to allowing us to do this.

Tested by adding `mainWindow.webContents.openDevTools({ mode: 'left' })` to the default stock Fiddle and observing that it no longer errors and the devtools docks appropriately to the left-hand side.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `webContents.openDevTools({ mode })` did not work for certain dock positions.