### PR TITLE
fix: make `process.exit()` synchronous even after the app is ready

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -34,6 +34,15 @@ window manager. There is not a direct equivalent for Wayland, and the known
 workarounds have unacceptable tradeoffs (e.g. Window.is_skip_taskbar in GNOME
 requires unsafe mode), so Electron is unable to support this feature on Linux.
 
+### Behavior Changed: `process.exit()`
+
+Previously, after the `app` emitted the `'ready'` event, `process.exit()` was
+getting monkey patched with the value of `app.exit()` which does not exit the
+app instantly, thus leaving users with no way to exit their apps synchronously.
+However, `process.exit()` is a Node.js API and it is meant to synchronously
+terminate the process with the supplied exit code. In Electron 20, this behavior
+has changed and this API will work as intended.
+
 ## Planned Breaking API Changes (19.0)
 
 None

--- a/lib/browser/init.ts
+++ b/lib/browser/init.ts
@@ -70,9 +70,6 @@ if (process.platform === 'win32') {
   }
 }
 
-// Map process.exit to app.exit, which quits gracefully.
-process.exit = app.exit as () => never;
-
 // Load the RPC server.
 require('@electron/internal/browser/rpc-server');
 

--- a/spec-main/node-spec.ts
+++ b/spec-main/node-spec.ts
@@ -354,6 +354,16 @@ describe('node feature', () => {
     expect(result.status).to.equal(0);
   });
 
+  it('Runs process.exit() synchronously before the app is ready', () => {
+    const result = childProcess.spawnSync(process.execPath, [path.resolve(fixtures, 'api', 'process-exit-before-ready', 'app.asar')], { stdio: 'inherit' });
+    expect(result.status).to.equal(1);
+  });
+
+  it('Runs process.exit() synchronously after the app is ready', () => {
+    const result = childProcess.spawnSync(process.execPath, [path.resolve(fixtures, 'api', 'process-exit-after-ready', 'app.asar')], { stdio: 'inherit' });
+    expect(result.status).to.equal(1);
+  });
+
   ifit(features.isRunAsNodeEnabled())('handles Promise timeouts correctly', async () => {
     const scriptPath = path.join(fixtures, 'module', 'node-promise-timer.js');
     const child = childProcess.spawn(process.execPath, [scriptPath], {

--- a/spec/fixtures/api/process-exit-after-ready/main.js
+++ b/spec/fixtures/api/process-exit-after-ready/main.js
@@ -1,0 +1,22 @@
+const { app } = require('electron');
+
+function tearDown (err) {
+  if (err) {
+    process.exit(1);
+  }
+
+  // this should not get executed
+  process.exit();
+}
+
+process.on('uncaughtException', tearDown);
+process.on('exit', tearDown);
+
+app.on('ready', () => {
+  // eslint-disable-next-line no-constant-condition
+  if (true) {
+    throw new Error('An uncaught exception!');
+  }
+
+  app.quit();
+});

--- a/spec/fixtures/api/process-exit-after-ready/package.json
+++ b/spec/fixtures/api/process-exit-after-ready/package.json
@@ -1,4 +1,4 @@
 {
-  "name": "process-exit-after-ready",
+  "name": "electron-test-process-exit-after-ready",
   "main": "main.js"
 }

--- a/spec/fixtures/api/process-exit-after-ready/package.json
+++ b/spec/fixtures/api/process-exit-after-ready/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "process-exit-after-ready",
+  "main": "main.js"
+}

--- a/spec/fixtures/api/process-exit-before-ready/main.js
+++ b/spec/fixtures/api/process-exit-before-ready/main.js
@@ -1,0 +1,4 @@
+process.exit(1);
+// this should not get executed
+// eslint-disable-next-line no-unreachable
+process.exit(0);

--- a/spec/fixtures/api/process-exit-before-ready/package.json
+++ b/spec/fixtures/api/process-exit-before-ready/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "process-exit-before-ready",
+  "main": "main.js"
+}

--- a/spec/fixtures/api/process-exit-before-ready/package.json
+++ b/spec/fixtures/api/process-exit-before-ready/package.json
@@ -1,4 +1,4 @@
 {
-  "name": "process-exit-before-ready",
+  "name": "electron-test-process-exit-before-ready",
   "main": "main.js"
 }


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

The `process.exit()` function should be synchronous both before and after
the `ready` event gets emitted.

Fixes: https://github.com/electron/electron/issues/32060
Signed-off-by: Darshan Sen <raisinten@gmail.com>

cc @zcbenz because `Browser::Exit()` was introduced in https://github.com/electron/electron/pull/3356

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Makes `process.exit()` synchronous even after the app is ready. <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->