### PR TITLE
docs: fix relative link in developer documentation

### DIFF
--- a/docs/development/pull-requests.md
+++ b/docs/development/pull-requests.md
@@ -180,7 +180,7 @@ $ git push origin my-branch
 ### Step 9: Opening the Pull Request
 
 From within GitHub, opening a new pull request will present you with a template
-that should be filled out. It can be found [here](../../.github/PULL_REQUEST_TEMPLATE.md).
+that should be filled out. It can be found [here](https://github.com/electron/electron/blob/main/.github/PULL_REQUEST_TEMPLATE.md).
 
 If you do not adequately complete this template, your PR may be delayed in being merged as maintainers
 seek more information or clarify ambiguities.


### PR DESCRIPTION
#### Description of Change

This relative link outside the `/docs` directory is broken on the website. This fixes it to use the GitHub URL directly.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
