### PR TITLE
build: add stack_trace.h to main delegate

### DIFF
--- a/.circleci/build_config.yml
+++ b/.circleci/build_config.yml
@@ -349,10 +349,10 @@ step-get-more-space-on-mac: &step-get-more-space-on-mac
     command: |
       if [ "`uname`" == "Darwin" ]; then
         sudo mkdir -p $TMPDIR/del-target
-        if [ "$TARGET_ARCH" == "arm64" ]; then
-          # Remount the root volume as writable, don't ask questions plz
-          sudo mount -uw /
-        fi
+
+        # Remount the root volume as writable, don't ask questions plz
+        sudo mount -uw /
+
         tmpify() {
           if [ -d "$1" ]; then
             sudo mv "$1" $TMPDIR/del-target/$(echo $1|shasum -a 256|head -n1|cut -d " " -f1)
@@ -394,33 +394,32 @@ step-get-more-space-on-mac: &step-get-more-space-on-mac
         tmpify /usr/local/Homebrew
         sudo rm -rf $TMPDIR/del-target
 
-        if [ "$TARGET_ARCH" == "arm64" ]; then
-          sudo rm -rf "/System/Library/Desktop Pictures"
-          sudo rm -rf /System/Library/Templates/Data
-          sudo rm -rf /System/Library/Speech/Voices
-          sudo rm -rf "/System/Library/Screen Savers"
-          sudo rm -rf /System/Volumes/Data/Library/Developer/CommandLineTools/SDKs
-          sudo rm -rf "/System/Volumes/Data/Library/Application Support/Apple/Photos/Print Products"
-          sudo rm -rf /System/Volumes/Data/Library/Java
-          sudo rm -rf /System/Volumes/Data/Library/Ruby
-          sudo rm -rf /System/Volumes/Data/Library/Printers
-          sudo rm -rf /System/iOSSupport
-          sudo rm -rf /System/Applications/*.app
-          sudo rm -rf /System/Applications/Utilities/*.app
-          sudo rm -rf /System/Library/LinguisticData
-          sudo rm -rf /System/Volumes/Data/private/var/db/dyld/*
-          # sudo rm -rf /System/Library/Fonts/*
-          # sudo rm -rf /System/Library/PreferencePanes
-          sudo rm -rf /System/Library/AssetsV2/*
-          sudo rm -rf /Applications/Safari.app
-          sudo rm -rf ~/project/src/build/linux
-          sudo rm -rf ~/project/src/third_party/catapult/tracing/test_data
-          sudo rm -rf ~/project/src/third_party/angle/third_party/VK-GL-CTS
+        sudo rm -rf "/System/Library/Desktop Pictures"
+        sudo rm -rf /System/Library/Templates/Data
+        sudo rm -rf /System/Library/Speech/Voices
+        sudo rm -rf "/System/Library/Screen Savers"
+        sudo rm -rf /System/Volumes/Data/Library/Developer/CommandLineTools/SDKs
+        sudo rm -rf "/System/Volumes/Data/Library/Application Support/Apple/Photos/Print Products"
+        sudo rm -rf /System/Volumes/Data/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/
+        sudo rm -rf /System/Volumes/Data/Library/Java
+        sudo rm -rf /System/Volumes/Data/Library/Ruby
+        sudo rm -rf /System/Volumes/Data/Library/Printers
+        sudo rm -rf /System/iOSSupport
+        sudo rm -rf /System/Applications/*.app
+        sudo rm -rf /System/Applications/Utilities/*.app
+        sudo rm -rf /System/Library/LinguisticData
+        sudo rm -rf /System/Volumes/Data/private/var/db/dyld/*
+        # sudo rm -rf /System/Library/Fonts/*
+        # sudo rm -rf /System/Library/PreferencePanes
+        sudo rm -rf /System/Library/AssetsV2/*
+        sudo rm -rf /Applications/Safari.app
+        sudo rm -rf ~/project/src/build/linux
+        sudo rm -rf ~/project/src/third_party/catapult/tracing/test_data
+        sudo rm -rf ~/project/src/third_party/angle/third_party/VK-GL-CTS
 
-          # lipo off some huge binaries arm64 versions to save space
-          strip_arm_deep $(xcode-select -p)/../SharedFrameworks
-          strip_arm_deep /System/Volumes/Data/Library/Developer/CommandLineTools/usr
-        fi
+        # lipo off some huge binaries arm64 versions to save space
+        strip_arm_deep $(xcode-select -p)/../SharedFrameworks
+        strip_arm_deep /System/Volumes/Data/Library/Developer/CommandLineTools/usr
       fi
     background: true
 

--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -34,6 +34,7 @@ libcxx_abi_unstable = false
 enable_pseudolocales = false
 
 is_cfi = false
+
 # This consumes a bit too much disk space on macOS
 use_thin_lto = false
 

--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -34,6 +34,8 @@ libcxx_abi_unstable = false
 enable_pseudolocales = false
 
 is_cfi = false
+# This consumes a bit too much disk space on macOS
+use_thin_lto = false
 
 # Make application name configurable at runtime for cookie crypto
 allow_runtime_configurable_key_storage = true

--- a/shell/app/electron_main_delegate.cc
+++ b/shell/app/electron_main_delegate.cc
@@ -11,6 +11,7 @@
 
 #include "base/base_switches.h"
 #include "base/command_line.h"
+#include "base/debug/stack_trace.h"
 #include "base/environment.h"
 #include "base/files/file_util.h"
 #include "base/logging.h"


### PR DESCRIPTION
#### Description of Change
Fixes an issue with publish jobs on main - the debug header for stack_trace.h seems to be included in the test build, but not the release build. Likely, this header was originally included via another header, and removed during Chromium upstream header #include cleanup.

This PR explicitly adds the header to the file.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
