### PR TITLE
fix: will-attach-webview handler modifying params.instanceId does not break <webview>

### DIFF
--- a/lib/renderer/web-view/web-view-impl.ts
+++ b/lib/renderer/web-view/web-view-impl.ts
@@ -27,7 +27,6 @@ export class WebViewImpl {
   public hasFocus = false
   public internalInstanceId?: number;
   public resizeObserver?: ResizeObserver;
-  public userAgentOverride?: string;
   public viewInstanceId: number
 
   // on* Event handlers.
@@ -180,8 +179,7 @@ export class WebViewImpl {
 
   buildParams () {
     const params: Record<string, any> = {
-      instanceId: this.viewInstanceId,
-      userAgentOverride: this.userAgentOverride
+      instanceId: this.viewInstanceId
     };
 
     for (const [attributeName, attribute] of this.attributes) {

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -138,6 +138,12 @@ ipcMain.on('prevent-next-will-attach-webview', (event) => {
   event.sender.once('will-attach-webview', event => event.preventDefault());
 });
 
+ipcMain.on('break-next-will-attach-webview', (event, id) => {
+  event.sender.once('will-attach-webview', (event, webPreferences, params) => {
+    params.instanceId = null;
+  });
+});
+
 ipcMain.on('disable-node-on-next-will-attach-webview', (event, id) => {
   event.sender.once('will-attach-webview', (event, webPreferences, params) => {
     params.src = `file://${path.join(__dirname, '..', 'fixtures', 'pages', 'c.html')}`;

--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1164,6 +1164,14 @@ describe('<webview> tag', function () {
       });
     });
 
+    it('handler modifying params.instanceId does not break <webview>', async () => {
+      ipcRenderer.send('break-next-will-attach-webview');
+
+      await startLoadingWebViewAndWaitForMessage(webview, {
+        src: `file://${fixtures}/pages/a.html`
+      });
+    });
+
     it('supports preventing a webview from being created', async () => {
       ipcRenderer.send('prevent-next-will-attach-webview');
 

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -80,7 +80,7 @@ declare namespace Electron {
     attachToIframe(embedderWebContents: Electron.WebContents, embedderFrameId: number): void;
     detachFromOuterFrame(): void;
     setEmbedder(embedder: Electron.WebContents): void;
-    attachParams?: Record<string, any>;
+    attachParams?: { instanceId: number; src: string, opts: LoadURLOptions };
     viewInstanceId: number;
   }
 


### PR DESCRIPTION
Backport of #32386

See that PR for details.

Notes: The `<webview>` implementation was made more robust, it no longer breaks when `will-attach-webview` handler modifies the internal `params.instanceId`.