### PR TITLE
fix: non-client mouse events on WCO-enabled windows

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -113,3 +113,4 @@ fix_crash_when_saving_edited_pdf_files.patch
 port_autofill_colors_to_the_color_pipeline.patch
 build_disable_partition_alloc_on_mac.patch
 build_disable_thin_lto_on_mac.patch
+fix_non-client_mouse_tracking_and_message_bubbling_on_windows.patch

--- a/patches/chromium/fix_non-client_mouse_tracking_and_message_bubbling_on_windows.patch
+++ b/patches/chromium/fix_non-client_mouse_tracking_and_message_bubbling_on_windows.patch
@@ -1,0 +1,61 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: clavin <cwatford@slack-corp.com>
+Date: Fri, 11 Feb 2022 15:05:42 -0700
+Subject: fix: non-client mouse tracking and message bubbling on windows
+
+It is not known why, but for some reason calling |DefWindowProc| on the parent
+window handle causes a WM_NCMOUSELEAVE (non-client mouse exit) message to be
+sent to the parent window, even though |TrackMouseEvent| is never called on it.
+
+This patch also adds some boilerplate for properly tracking non-client mouse
+messages in the legacy window handle layer.
+
+These conditions are regularly hit with WCO-enabled windows on Windows.
+
+diff --git a/content/browser/renderer_host/legacy_render_widget_host_win.cc b/content/browser/renderer_host/legacy_render_widget_host_win.cc
+index 4a894ef70eeb1d8489049aef552c9bae4f24ae62..f5049d730a850f2947023f976b25fb772e42107a 100644
+--- a/content/browser/renderer_host/legacy_render_widget_host_win.cc
++++ b/content/browser/renderer_host/legacy_render_widget_host_win.cc
+@@ -288,12 +288,12 @@ LRESULT LegacyRenderWidgetHostHWND::OnMouseRange(UINT message,
+                                                  WPARAM w_param,
+                                                  LPARAM l_param,
+                                                  BOOL& handled) {
+-  if (message == WM_MOUSEMOVE) {
++  if (message == WM_MOUSEMOVE || message == WM_NCMOUSEMOVE) {
+     if (!mouse_tracking_enabled_) {
+       mouse_tracking_enabled_ = true;
+       TRACKMOUSEEVENT tme;
+       tme.cbSize = sizeof(tme);
+-      tme.dwFlags = TME_LEAVE;
++      tme.dwFlags = message == WM_NCMOUSEMOVE ? TME_NONCLIENT | TME_LEAVE : TME_LEAVE;
+       tme.hwndTrack = hwnd();
+       tme.dwHoverTime = 0;
+       TrackMouseEvent(&tme);
+@@ -319,12 +319,11 @@ LRESULT LegacyRenderWidgetHostHWND::OnMouseRange(UINT message,
+         message, w_param, l_param, &msg_handled);
+     handled = msg_handled;
+     // If the parent did not handle non client mouse messages, we call
+-    // DefWindowProc on the message with the parent window handle. This
+-    // ensures that WM_SYSCOMMAND is generated for the parent and we are
+-    // out of the picture.
++    // DefWindowProc on the message. This ensures that WM_SYSCOMMAND is
++    // generated.
+     if (!handled &&
+          (message >= WM_NCMOUSEMOVE && message <= WM_NCXBUTTONDBLCLK)) {
+-      ret = ::DefWindowProc(GetParent(), message, w_param, l_param);
++      ret = ::DefWindowProc(hwnd(), message, w_param, l_param);
+       handled = TRUE;
+     }
+   }
+diff --git a/content/browser/renderer_host/legacy_render_widget_host_win.h b/content/browser/renderer_host/legacy_render_widget_host_win.h
+index 79dffd981f4d461f30bd3796cfba1457eda3a89d..ae378ce95f90989fd0e74c38b57f5f7dc0a1ee29 100644
+--- a/content/browser/renderer_host/legacy_render_widget_host_win.h
++++ b/content/browser/renderer_host/legacy_render_widget_host_win.h
+@@ -105,6 +105,7 @@ class CONTENT_EXPORT LegacyRenderWidgetHostHWND
+     MESSAGE_HANDLER_EX(WM_NCHITTEST, OnNCHitTest)
+     MESSAGE_RANGE_HANDLER(WM_NCMOUSEMOVE, WM_NCXBUTTONDBLCLK,
+                           OnMouseRange)
++    MESSAGE_HANDLER_EX(WM_NCMOUSELEAVE, OnMouseLeave)
+     MESSAGE_HANDLER_EX(WM_NCCALCSIZE, OnNCCalcSize)
+     MESSAGE_HANDLER_EX(WM_SIZE, OnSize)
+     MESSAGE_HANDLER_EX(WM_DESTROY, OnDestroy)

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -99,21 +99,4 @@ bool ElectronDesktopWindowTreeHostWin::GetClientAreaInsets(
   return false;
 }
 
-bool ElectronDesktopWindowTreeHostWin::HandleMouseEvent(ui::MouseEvent* event) {
-  // Call the default implementation of this method to get the event to its
-  // proper handler.
-  bool handled = views::DesktopWindowTreeHostWin::HandleMouseEvent(event);
-
-  // On WCO-enabled windows, we need to mark non-client mouse moved events as
-  // handled so they don't incorrectly propogate back to the OS.
-  if (native_window_view_->IsWindowControlsOverlayEnabled() &&
-      event->type() == ui::ET_MOUSE_MOVED &&
-      (event->flags() & ui::EF_IS_NON_CLIENT) != 0) {
-    event->SetHandled();
-    handled = true;
-  }
-
-  return handled;
-}
-
 }  // namespace electron

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
@@ -36,7 +36,6 @@ class ElectronDesktopWindowTreeHostWin
   bool GetDwmFrameInsetsInPixels(gfx::Insets* insets) const override;
   bool GetClientAreaInsets(gfx::Insets* insets,
                            HMONITOR monitor) const override;
-  bool HandleMouseEvent(ui::MouseEvent* event) override;
 
  private:
   NativeWindowViews* native_window_view_;  // weak ref


### PR DESCRIPTION
#### Description of Change
My change in #32672 caused a regression where WCO-enabled windows (on Windows) could no longer be dragged. This is because in `HWNDMessageHandler::HandleMouseEventInternal`, `HandleMouseEvent` (which is what I patched in the previous PR) is called before `HandleMouseInputForCaption` (which is where the dragging happens I think, from testing). Instead of trying to patch in something to move the marking of the event as handled further down, I opted instead to try and fix the issue with `LegacyRenderWidgetHostHWND`.

This PR introduces a patch that does two things, particularly only for WCO-enabled windows right now:

1. Correctly track non-client mouse events, not just regular mouse events. This is mostly just some boilerplate to include those messages.
2. Instead of falling through to `DefWindowProc` using the parent window handle (`GetParent()`), it is instead called on its own window handle. This seems to avoid the issue with a mysterious `WM_NCMOUSELEAVE` message being generated by the `DefWindowProc`.
3. (It also reverts my changes in the previous PR.)

This should be safe to do since the `LegacyRenderWidgetHostHWND` doesn't normally cover the non-client area in windows without hidden title bars (thus never reaching this code) and for frameless windows this is the same code path. Thus the change should only apply to WCO-enabled windows. I also think the code is still correct since it is the job of `LegacyRenderWidgetHostHWND` to forward messages to its parent window anyways.

I know this is a patch which we usually try to avoid those, however I don't really see an alternative for either possible solution without making a patch. I'll try to upstream this, but if that fails the only other way to remove this patch would be when `LegacyRenderWidgetHostHWND` is finally removed (see [its header comments](https://source.chromium.org/chromium/chromium/src/+/main:content/browser/renderer_host/legacy_render_widget_host_win.h;l=38-53;drc=0e45c020c43b1a9f6d2870ff7f92b30a2f03a458) for more info on that; doesn't look very defined though).

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes (letting CI check)
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed drag regions on WCO windows on Windows
