### PR TITLE
fix: broken OSR transparent option

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -767,8 +767,12 @@ WebContents::WebContents(v8::Isolate* isolate,
 #if BUILDFLAG(ENABLE_OSR)
     }
   } else if (IsOffScreen()) {
-    bool transparent = false;
-    options.Get(options::kTransparent, &transparent);
+    // webPreferences does not have a transparent option, so if the window needs
+    // to be transparent, that will be set at electron_api_browser_window.cc#L57
+    // and we then need to pull it back out and check it here.
+    std::string background_color;
+    options.GetHidden(options::kBackgroundColor, &background_color);
+    bool transparent = ParseHexColor(background_color) == SK_ColorTRANSPARENT;
 
     content::WebContents::CreateParams params(session->browser_context());
     auto* view = new OffScreenWebContentsView(


### PR DESCRIPTION
#### Description of Change
 
Closes https://github.com/electron/electron/issues/32846.

Traced back to https://github.com/electron/electron/pull/30778 - we no longer have a transparent option in `webPreferences`, and so https://github.com/electron/electron/blob/28ada6ea8bd2abeca8812e6d284c1f5f3974286b/shell/browser/api/electron_api_web_contents.cc#L771 would _always_ return false. As of the above PR, we handle transparency in `webPreferences` by propagating it to `webPreferences` in the `BrowserWindow` ctor: https://github.com/electron/electron/blob/28ada6ea8bd2abeca8812e6d284c1f5f3974286b/shell/browser/api/electron_api_browser_window.cc#L56-L57 Therefore, in order to properly instantiate a transparent offscreen window, we need to check for the `backgroundColor` being set to the hex equivalent of `SK_ColorTRANSPARENT` and proceed with that value.

Tested with https://gist.github.com/29850810e9c5892587729d3d64a25761.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed broken transparency option in offscreen window rendering.
