### PR TITLE
docs: fix ipc renderer event

### DIFF
--- a/docs/fiddles/ipc/pattern-3/renderer.js
+++ b/docs/fiddles/ipc/pattern-3/renderer.js
@@ -4,5 +4,5 @@ window.electronAPI.handleCounter((event, value) => {
     const oldValue = Number(counter.innerText)
     const newValue = oldValue + value
     counter.innerText = newValue
-    event.reply('counter-value', newValue)
+    event.sender.send('counter-value', newValue)
 })

--- a/docs/tutorial/ipc.md
+++ b/docs/tutorial/ipc.md
@@ -519,7 +519,7 @@ window.electronAPI.onUpdateCounter((event, value) => {
   const oldValue = Number(counter.innerText)
   const newValue = oldValue + value
   counter.innerText = newValue
-  event.reply('counter-value', newValue)
+  event.sender.send('counter-value', newValue)
 })
 ```
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

`ipcRendererEvent` dose not have `reply` method.
So substitute `ipceRenderer.sender.send` for `ipcRendererEvent.reply` in docs.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none. <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
