### PR TITLE
fix: stale renderer process on quit

### DIFF
--- a/shell/browser/electron_browser_main_parts.cc
+++ b/shell/browser/electron_browser_main_parts.cc
@@ -458,7 +458,8 @@ void ElectronBrowserMainParts::WillRunMainMessageLoop(
     std::unique_ptr<base::RunLoop>& run_loop) {
   js_env_->OnMessageLoopCreated();
   exit_code_ = content::RESULT_CODE_NORMAL_EXIT;
-  Browser::Get()->SetMainMessageLoopQuitClosure(run_loop->QuitClosure());
+  Browser::Get()->SetMainMessageLoopQuitClosure(
+      run_loop->QuitWhenIdleClosure());
 }
 
 void ElectronBrowserMainParts::PostCreateMainMessageLoop() {


### PR DESCRIPTION
#### Description of Change
Closes #32884.

In the mentioned [Chromium roll](https://github.com/electron/electron/pull/28660/files) I observed the following:
- [`patches/chromium/content_browser_main_loop.patch`](https://github.com/electron/electron/blob/7816fd240fdc552ea29b1d41c3c352d6a5272dad/patches/chromium/content_browser_main_loop.patch) which replaced `QuitClosure()` with `QuitWhenIdleClosure()` got removed
-  this appears again in the modified [`shell/browser/electron_browser_main_parts.cc`](https://github.com/electron/electron/pull/28660/files#diff-aaa10535b05dec71603ff4ab2971c77ec6798e2e25b080742831249f0359c960), but now with `QuitClosure()`

If I replace `QuitClosure()` with `QuitWhenIdleClosure()`, all processes terminate properly as it was the case before the Chromium roll. Since this is Electron code, it would explain why Chromium doesn't suffer from the same issue.

Because I lack context of what exactly this code does, please double-check that this change is fine :). But apparently, regressions were anticipated according to [this commit message](https://github.com/electron/electron/pull/28462/commits/522082974883f7505b46959aba4bfbaa4ad8264f). cc @MarshallOfSound @ckerr 

cc @miniak @deepak1556 @zarubond @dsanders11 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed stale renderer process when application is quit while renderer is busy.
