### PR TITLE
chore: cherry-pick 0081bb347e67 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -144,3 +144,4 @@ do_not_select_vulkan_device_based_on_the_passed_in_gpu_info_on_linux.patch
 handle_potentiallydanglingmarkup_for_cssimagevalue.patch
 fire_iframe_onload_for_cross-origin-initiated_same-document.patch
 merge_m-97_serial_check_for_detached_buffers_when_writing.patch
+cherry-pick-0081bb347e67.patch

--- a/patches/chromium/cherry-pick-0081bb347e67.patch
+++ b/patches/chromium/cherry-pick-0081bb347e67.patch
@@ -1,0 +1,27 @@
+From 0081bb347e67f820f3b23ee8e45a7dce24e46d11 Mon Sep 17 00:00:00 2001
+From: Matt Reynolds <mattreynolds@google.com>
+Date: Wed, 19 Jan 2022 21:03:08 +0000
+Subject: [PATCH] gamepad: Return an invalid handle after ReportBadMessage
+
+Bug: 1285449
+Change-Id: I746c539577f7bdf69cbe4212ac380e0c92a5c771
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3373944
+Auto-Submit: Matt Reynolds <mattreynolds@chromium.org>
+Reviewed-by: Reilly Grant <reillyg@chromium.org>
+Commit-Queue: Reilly Grant <reillyg@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#961125}
+---
+
+diff --git a/device/gamepad/gamepad_monitor.cc b/device/gamepad/gamepad_monitor.cc
+index ce8ba1e..28082924 100644
+--- a/device/gamepad/gamepad_monitor.cc
++++ b/device/gamepad/gamepad_monitor.cc
+@@ -53,6 +53,8 @@
+   GamepadService* service = GamepadService::GetInstance();
+   if (!service->ConsumerBecameActive(this)) {
+     mojo::ReportBadMessage("GamepadMonitor::GamepadStartPolling failed");
++    std::move(callback).Run(base::ReadOnlySharedMemoryRegion());
++    return;
+   }
+   std::move(callback).Run(service->DuplicateSharedMemoryRegion());
+ }

--- a/patches/chromium/cherry-pick-0081bb347e67.patch
+++ b/patches/chromium/cherry-pick-0081bb347e67.patch
@@ -1,7 +1,7 @@
-From 0081bb347e67f820f3b23ee8e45a7dce24e46d11 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Matt Reynolds <mattreynolds@google.com>
 Date: Wed, 19 Jan 2022 21:03:08 +0000
-Subject: [PATCH] gamepad: Return an invalid handle after ReportBadMessage
+Subject: gamepad: Return an invalid handle after ReportBadMessage
 
 Bug: 1285449
 Change-Id: I746c539577f7bdf69cbe4212ac380e0c92a5c771
@@ -10,13 +10,12 @@ Auto-Submit: Matt Reynolds <mattreynolds@chromium.org>
 Reviewed-by: Reilly Grant <reillyg@chromium.org>
 Commit-Queue: Reilly Grant <reillyg@chromium.org>
 Cr-Commit-Position: refs/heads/main@{#961125}
----
 
 diff --git a/device/gamepad/gamepad_monitor.cc b/device/gamepad/gamepad_monitor.cc
-index ce8ba1e..28082924 100644
+index ce8ba1ef7551e52f8ae4d9a112a08308ab2ce51c..28082924e632a895fc5bc4725bc6de3d6ca120ac 100644
 --- a/device/gamepad/gamepad_monitor.cc
 +++ b/device/gamepad/gamepad_monitor.cc
-@@ -53,6 +53,8 @@
+@@ -53,6 +53,8 @@ void GamepadMonitor::GamepadStartPolling(GamepadStartPollingCallback callback) {
    GamepadService* service = GamepadService::GetInstance();
    if (!service->ConsumerBecameActive(this)) {
      mojo::ReportBadMessage("GamepadMonitor::GamepadStartPolling failed");


### PR DESCRIPTION
gamepad: Return an invalid handle after ReportBadMessage

Bug: 1285449
Change-Id: I746c539577f7bdf69cbe4212ac380e0c92a5c771
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3373944
Auto-Submit: Matt Reynolds <mattreynolds@chromium.org>
Reviewed-by: Reilly Grant <reillyg@chromium.org>
Commit-Queue: Reilly Grant <reillyg@chromium.org>
Cr-Commit-Position: refs/heads/main@{#961125}


Notes: Backported fix for CVE-2022-0610.