### PR TITLE
build: increase ninja processes for forked docs-only PRs

### DIFF
--- a/.circleci/build_config.yml
+++ b/.circleci/build_config.yml
@@ -153,6 +153,10 @@ env-linux-medium: &env-linux-medium
   <<: *env-global
   NUMBER_OF_NINJA_PROCESSES: 3
 
+env-linux-large: &env-linux-large
+  <<: *env-global
+  NUMBER_OF_NINJA_PROCESSES: 8
+
 env-linux-2xlarge: &env-linux-2xlarge
   <<: *env-global
   NUMBER_OF_NINJA_PROCESSES: 34
@@ -1543,9 +1547,9 @@ jobs:
   ts-compile-doc-change:
     executor:
       name: linux-docker
-      size: medium
+      size: xlarge
     environment:
-      <<: *env-linux-medium
+      <<: *env-linux-large
       <<: *env-testing-build
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
     <<: *steps-electron-ts-compile-for-doc-change

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ workflows:
     jobs:
       # Job inherited from path-filtering orb
       - path-filtering/filter:
-          base-revision: main
+          base-revision: << pipeline.git.branch >>
           # Params for mapping; `path-to-test parameter-to-set value-for-parameter` for each row
           mapping: |
             ^((?!docs/).)*$ run-build-mac true

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -12,6 +12,10 @@ This document uses the following convention to categorize breaking changes:
 * **Deprecated:** An API was marked as deprecated. The API will continue to function, but will emit a deprecation warning, and will be removed in a future release.
 * **Removed:** An API or feature was removed, and is no longer supported by Electron.
 
+## Planned Breaking API Changes (19.0)
+
+No planned breaking changes for Electron 19.
+
 ## Planned Breaking API Changes (18.0)
 
 ### Removed: `nativeWindowOpen`


### PR DESCRIPTION
#### Description of Change

We're seeing timeout failures for the ts-compile-doc-change in CircleCI when the job is run on PRs coming from a fork. This may be because forks don't have full cache access, and need a bit more time/power to finish the gclient sync. This PR increases the Docker VM size and ninja processes for ts-compile-doc-change.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
