### PR TITLE
docs: fix broken link to GNOME notifications spec

### DIFF
--- a/docs/tutorial/notifications.md
+++ b/docs/tutorial/notifications.md
@@ -146,7 +146,7 @@ desktop environment that follows [Desktop Notifications
 Specification][notification-spec], including Cinnamon, Enlightenment, Unity,
 GNOME, KDE.
 
-[notification-spec]: https://developer.gnome.org/notification-spec/
+[notification-spec]: https://developer-old.gnome.org/notification-spec/
 [app-user-model-id]: https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx
 [set-app-user-model-id]: ../api/app.md#appsetappusermodelidid-windows
 [squirrel-events]: https://github.com/electron/windows-installer/blob/master/README.md#handling-squirrel-events


### PR DESCRIPTION
#### Description of Change

This fixes a broken link to the GNOME Desktop Notifications Specification ([old link](https://developer.gnome.org/notification-spec/) to [new link](https://developer-old.gnome.org/notification-spec/)).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [-] `npm test` passes
- [-] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [-] relevant documentation is changed or added
- [-] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
