### PR TITLE
build: use gen2 macOS resources for tests

### DIFF
--- a/.circleci/build_config.yml
+++ b/.circleci/build_config.yml
@@ -54,7 +54,7 @@ executors:
         description: "macOS executor size"
         default: large
         type: enum
-        enum: ["medium", "large"]
+        enum: ["macos.x86.medium.gen2", "large"]
     macos:
       xcode: "12.4.0"
     resource_class: << parameters.size >>
@@ -1909,7 +1909,7 @@ jobs:
   osx-testing-x64-gn-check:
     executor:
       name: macos
-      size: medium
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-machine-mac
       <<: *env-testing-build
@@ -1990,7 +1990,7 @@ jobs:
   mas-testing-x64-gn-check:
     executor:
       name: macos
-      size: medium
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-machine-mac
       <<: *env-mas
@@ -2226,7 +2226,7 @@ jobs:
   osx-testing-x64-tests:
     executor:
       name: macos
-      size: medium
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large
       <<: *env-stack-dumping
@@ -2244,7 +2244,7 @@ jobs:
   mas-testing-x64-tests:
     executor:
       name: macos
-      size: medium
+      size: macos.x86.medium.gen2
     environment:
       <<: *env-mac-large
       <<: *env-stack-dumping


### PR DESCRIPTION
This should speed up the run-tests portion of our macOS CI

Notes: no-notes