### PR TITLE
build: store last ninja log in artifacts

### DIFF
--- a/.circleci/build_config.yml
+++ b/.circleci/build_config.yml
@@ -1270,6 +1270,7 @@ commands:
             mv_if_exist src/out/Default/hunspell_dictionaries.zip
             mv_if_exist src/cross-arch-snapshots
             mv_if_exist src/out/electron_ninja_log
+            mv_if_exist src/out/Default/.ninja_log
           when: always
       - store_artifacts:
           path: generated_artifacts


### PR DESCRIPTION
Will be useful for debugging failures in the `post_build_ninja_summary` script

Notes: no-notes