### PR TITLE
docs: remove platform notices from tutorial titles

### DIFF
--- a/docs/tutorial/in-app-purchases.md
+++ b/docs/tutorial/in-app-purchases.md
@@ -1,4 +1,11 @@
-# In-App Purchases (macOS)
+---
+title: In-App Purchases
+description: Add in-app purchases to your Mac App Store (MAS) application
+slug: in-app-purchases
+hide_title: true
+---
+
+# In-App Purchases
 
 ## Preparing
 

--- a/docs/tutorial/launch-app-from-url-in-another-app.md
+++ b/docs/tutorial/launch-app-from-url-in-another-app.md
@@ -1,6 +1,6 @@
 ---
 title: Deep Links
-description: Setting your Electron app as the default handler for a specific protocol.
+description: Set your Electron app as the default handler for a specific protocol.
 slug: launch-app-from-url-in-another-app
 hide_title: true
 ---

--- a/docs/tutorial/launch-app-from-url-in-another-app.md
+++ b/docs/tutorial/launch-app-from-url-in-another-app.md
@@ -1,11 +1,11 @@
 ---
-title: Launching Your Electron App From a URL In Another App
-description: This guide will take you through the process of setting your electron app as the default handler for a specific protocol.
+title: Deep Links
+description: Setting your Electron app as the default handler for a specific protocol.
 slug: launch-app-from-url-in-another-app
 hide_title: true
 ---
 
-# Launching Your Electron App From A URL In Another App
+# Deep Links
 
 ## Overview
 

--- a/docs/tutorial/linux-desktop-actions.md
+++ b/docs/tutorial/linux-desktop-actions.md
@@ -1,4 +1,11 @@
-# Desktop Launcher Actions (Linux)
+---
+title: Desktop Launcher Actions
+description: Add actions to the system launcher on Linux environments.
+slug: linux-desktop-actions
+hide_title: true
+---
+
+# Desktop Launcher Actions
 
 ## Overview
 
@@ -42,4 +49,4 @@ parameters. You can find them in your application in the global variable
 
 [unity-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles#Adding_shortcuts_to_a_launcher
 [audacious-launcher]: https://help.ubuntu.com/community/UnityLaunchersAndDesktopFiles?action=AttachFile&do=get&target=shortcuts.png
-[spec]: https://specifications.freedesktop.org/desktop-entry-spec/1.1/ar01s11.html
+[spec]: https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html

--- a/docs/tutorial/macos-dock.md
+++ b/docs/tutorial/macos-dock.md
@@ -1,4 +1,11 @@
-# Dock (macOS)
+---
+title: Dock
+description: Configure your application's Dock presence on macOS.
+slug: macos-dock
+hide_title: true
+---
+
+# Dock
 
 Electron has APIs to configure the app's icon in the macOS Dock. A macOS-only
 API exists to create a custom dock menu, but Electron also uses the app dock
@@ -15,12 +22,6 @@ __Dock menu of Terminal.app:__
 To set your custom dock menu, you need to use the
 [`app.dock.setMenu`](../api/dock.md#docksetmenumenu-macos) API,
 which is only available on macOS.
-
-## Example
-
-Starting with a working application from the
- [Quick Start Guide](quick-start.md), update the `main.js` file with the
- following lines:
 
 ```javascript fiddle='docs/fiddles/features/macos-dock-menu'
 const { app, BrowserWindow, Menu } = require('electron')

--- a/docs/tutorial/progress-bar.md
+++ b/docs/tutorial/progress-bar.md
@@ -1,4 +1,11 @@
-# Taskbar Progress Bar (Windows & macOS)
+---
+title: Progress Bars
+description: Provide progress information to users outside of a BrowserWindow.
+slug: progress-bar
+hide_title: true
+---
+
+# Progress Bars
 
 ## Overview
 

--- a/docs/tutorial/recent-documents.md
+++ b/docs/tutorial/recent-documents.md
@@ -1,4 +1,11 @@
-# Recent Documents (Windows & macOS)
+---
+title: Recent Documents
+description: Provide a list of recent documents via Windows JumpList or macOS Dock
+slug: recent-documents
+hide_title: true
+---
+
+# Recent Documents
 
 ## Overview
 

--- a/docs/tutorial/represented-file.md
+++ b/docs/tutorial/represented-file.md
@@ -1,4 +1,11 @@
-# Representing Files in a BrowserWindow (macOS)
+---
+title: Representing Files in a BrowserWindow
+description: Set a represented file in the macOS title bar.
+slug: represented-file
+hide_title: true
+---
+
+# Representing Files in a BrowserWindow
 
 ## Overview
 

--- a/docs/tutorial/windows-taskbar.md
+++ b/docs/tutorial/windows-taskbar.md
@@ -1,4 +1,11 @@
-# Taskbar Customization (Windows)
+---
+title: Taskbar Customization
+description: Customize the look and feel of your app's Windows taskbar presence.
+slug: windows-taskbar
+hide_title: true
+---
+
+# Taskbar Customization
 
 ## Overview
 


### PR DESCRIPTION
#### Description of Change

This is a companion PR to https://github.com/electron/electronjs.org-new/pull/177.

I'm removing the clunky `(Mac and Windows)` parts of the documentation titles and instead storing that metadata within the sidebars on the website.

The end goal is to have the docs look like this to end users:

![image](https://user-images.githubusercontent.com/16010076/154360282-b1e57d95-6359-4a5d-9a39-5a872dc64a05.png)


cc @electron/wg-ecosystem 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] relevant documentation is changed or added

#### Release Notes

Notes: none
