### PR TITLE
fix: command string for windows protocol handler

### DIFF
--- a/shell/browser/browser_win.cc
+++ b/shell/browser/browser_win.cc
@@ -67,7 +67,7 @@ bool GetProtocolLaunchPath(gin::Arguments* args, std::wstring* exe) {
   std::vector<std::wstring> launch_args;
   if (args->GetNext(&launch_args) && !launch_args.empty())
     *exe = base::StringPrintf(L"\"%ls\" \"%ls\" \"%%1\"", exe->c_str(),
-                              base::JoinString(launch_args, L" ").c_str());
+                              base::JoinString(launch_args, L"\"  \"").c_str());
   else
     *exe = base::StringPrintf(L"\"%ls\" \"%%1\"", exe->c_str());
   return true;


### PR DESCRIPTION
#### Description of Change

Enclose all arguments in quotation marks so that application can respect the individual arguments.

*Before:*

```ps
"C:\example\node_modules\electron\dist\electron.exe" "c:\example --arg" "%1"
```

*After:*

```ps
"C:\example\node_modules\electron\dist\electron.exe" "c:\example" "--arg" "%1"
```

Refs https://github.com/microsoft/vscode/issues/142685
Fixes #32463 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: fix command string registered via setAsDefaultProtocolClient on windows