### PR TITLE
build: use gen2 macOS resources for building

### DIFF
--- a/.circleci/build_config.yml
+++ b/.circleci/build_config.yml
@@ -52,7 +52,7 @@ executors:
     parameters:
       size:
         description: "macOS executor size"
-        default: large
+        default: macos.x86.medium.gen2
         type: enum
         enum: ["macos.x86.medium.gen2", "large"]
     macos:


### PR DESCRIPTION
This may be faster even with less cores, let's find out

Notes: no-notes