### PR TITLE
chore: add @electron/wg-security to patches/ CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 # https://git-scm.com/docs/gitignore
 
 # Upgrades WG
-/patches/                               @electron/wg-upgrades
+/patches/                               @electron/wg-upgrades @electron/wg-security
 DEPS                                    @electron/wg-upgrades
 
 # Releases WG


### PR DESCRIPTION
#### Description of Change
Previously, @electron/wg-upgrades was the sole CODEOWNER of patches/. However, @electron/wg-security regularly merges patches and should have review power also.

It is left to the reviewer's judgement whether a patch should be reviewed by security or upgrades WG.


Notes: none