### PR TITLE
fix: IncrementCapturerCount doesn't increase the capturer count

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -3122,8 +3122,9 @@ void WebContents::IncrementCapturerCount(gin::Arguments* args) {
   // get stayAwake arguments if they exist
   args->GetNext(&stay_awake);
 
-  std::ignore =
-      web_contents()->IncrementCapturerCount(size, stay_hidden, stay_awake);
+  std::ignore = web_contents()
+                    ->IncrementCapturerCount(size, stay_hidden, stay_awake)
+                    .Release();
 }
 
 void WebContents::DecrementCapturerCount(gin::Arguments* args) {

--- a/spec-main/api-browser-view-spec.ts
+++ b/spec-main/api-browser-view-spec.ts
@@ -302,4 +302,66 @@ describe('BrowserView module', () => {
       view.webContents.loadFile(path.join(fixtures, 'pages', 'window-open.html'));
     });
   });
+
+  describe('BrowserView.capturePage(rect)', () => {
+    it('returns a Promise with a Buffer', async () => {
+      view = new BrowserView({
+        webPreferences: {
+          backgroundThrottling: false
+        }
+      });
+      w.addBrowserView(view);
+      view.setBounds({
+        ...w.getBounds(),
+        x: 0,
+        y: 0
+      });
+      const image = await view.webContents.capturePage({
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100
+      });
+
+      expect(image.isEmpty()).to.equal(true);
+    });
+
+    xit('resolves after the window is hidden and capturer count is non-zero', async () => {
+      view = new BrowserView({
+        webPreferences: {
+          backgroundThrottling: false
+        }
+      });
+      w.setBrowserView(view);
+      view.setBounds({
+        ...w.getBounds(),
+        x: 0,
+        y: 0
+      });
+      await view.webContents.loadFile(path.join(fixtures, 'pages', 'a.html'));
+
+      view.webContents.incrementCapturerCount();
+      const image = await view.webContents.capturePage();
+      expect(image.isEmpty()).to.equal(false);
+    });
+
+    it('should increase the capturer count', () => {
+      view = new BrowserView({
+        webPreferences: {
+          backgroundThrottling: false
+        }
+      });
+      w.setBrowserView(view);
+      view.setBounds({
+        ...w.getBounds(),
+        x: 0,
+        y: 0
+      });
+
+      view.webContents.incrementCapturerCount();
+      expect(view.webContents.isBeingCaptured()).to.be.true();
+      view.webContents.decrementCapturerCount();
+      expect(view.webContents.isBeingCaptured()).to.be.false();
+    });
+  });
 });

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1417,6 +1417,17 @@ describe('BrowserWindow module', () => {
       expect(hiddenImage.isEmpty()).to.equal(isEmpty);
     });
 
+    it('resolves after the window is hidden and capturer count is non-zero', async () => {
+      const w = new BrowserWindow({ show: false });
+      w.webContents.setBackgroundThrottling(false);
+      w.loadFile(path.join(fixtures, 'pages', 'a.html'));
+      await emittedOnce(w, 'ready-to-show');
+
+      w.webContents.incrementCapturerCount();
+      const image = await w.capturePage();
+      expect(image.isEmpty()).to.equal(false);
+    });
+
     it('preserves transparency', async () => {
       const w = new BrowserWindow({ show: false, transparent: true });
       w.loadFile(path.join(fixtures, 'pages', 'theme-color.html'));
@@ -1429,6 +1440,14 @@ describe('BrowserWindow module', () => {
       // Check the 25th byte in the PNG.
       // Values can be 0,2,3,4, or 6. We want 6, which is RGB + Alpha
       expect(imgBuffer[25]).to.equal(6);
+    });
+
+    it('should increase the capturer count', () => {
+      const w = new BrowserWindow({ show: false });
+      w.webContents.incrementCapturerCount();
+      expect(w.webContents.isBeingCaptured()).to.be.true();
+      w.webContents.decrementCapturerCount();
+      expect(w.webContents.isBeingCaptured()).to.be.false();
     });
   });
 


### PR DESCRIPTION
#### Description of Change

This regression was introduced by commit 22a70eb8. The change done by WebContentsImpl::IncrementCapturerCount() is reverted just before returning in WebContents::IncrementCapturerCount(), so the isBeingCaptured() always returns false. Fixed the issue by not running the close closure returned by web_contents::IncrementCapturerCount().

 Please double-check that this change is fine since I'm not familiar with this code.
 
 cc @ckerr @codebytere  @deepak1556 @MarshallOfSound 
 
 Related #30666 
 
Affected branches: 13-x-y to the current stable branch, please consider backporting this fix to them.

```c++
base::ScopedClosureRunner WebContentsImpl::IncrementCapturerCount(
    const gfx::Size& capture_size,
    bool stay_hidden,
    bool stay_awake) {`
  ....
  return base::ScopedClosureRunner(
      base::BindOnce(&WebContentsImpl::DecrementCapturerCount,
                     weak_factory_.GetWeakPtr(), stay_hidden, stay_awake));
}
```
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix the IncrementCapturerCount regression introduced by 13.0.0-beta.21
