### PR TITLE
chore: cherry-pick 05e714a87c from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -142,3 +142,4 @@ cherry-pick-1283371.patch
 cherry-pick-1283375.patch
 cherry-pick-1283198.patch
 cherry-pick-1284367.patch
+m98_fs_fix_fileutil_lifetime_issue.patch

--- a/patches/chromium/m98_fs_fix_fileutil_lifetime_issue.patch
+++ b/patches/chromium/m98_fs_fix_fileutil_lifetime_issue.patch
@@ -1,0 +1,67 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Austin Sullivan <asully@chromium.org>
+Date: Thu, 10 Feb 2022 22:18:54 +0000
+Subject: M98: FS: Fix FileUtil lifetime issue
+
+Keeps FileSystemContext alive while while resolving a URL on an open
+file system, removing the possibility of the file system being
+destroyed while a URL is being resolved on it.
+
+(cherry picked from commit 3fdf2adf11b3c716c9015597d30b59bffc7ac91b)
+
+Bug: 1275622, 1289394
+Change-Id: Ic1b97552f9d41a61163d72ff8c605699f673f55f
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3373583
+Reviewed-by: Marijn Kruisselbrink <mek@chromium.org>
+Commit-Queue: Austin Sullivan <asully@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#968470}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3451059
+Auto-Submit: Austin Sullivan <asully@chromium.org>
+Commit-Queue: Marijn Kruisselbrink <mek@chromium.org>
+Cr-Commit-Position: refs/branch-heads/4758@{#1131}
+Cr-Branched-From: 4a2cf4baf90326df19c3ee70ff987960d59a386e-refs/heads/main@{#950365}
+
+diff --git a/storage/browser/file_system/file_system_context.cc b/storage/browser/file_system/file_system_context.cc
+index 4ae64d27f5ef446dca59b89b7fa8f652fb949bdc..f88aa4e0b3c0bf6c9cf25dada88d9af960409e7e 100644
+--- a/storage/browser/file_system/file_system_context.cc
++++ b/storage/browser/file_system/file_system_context.cc
+@@ -418,9 +418,22 @@ void FileSystemContext::OpenFileSystem(const url::Origin& origin,
+     return;
+   }
+ 
++  // Bind `this` to the callback to ensure this instance stays alive while the
++  // URL is resolving.
+   backend->ResolveURL(
+       CreateCrackedFileSystemURL(origin, type, base::FilePath()), mode,
+-      std::move(callback));
++      base::BindOnce(&FileSystemContext::DidResolveURLOnOpenFileSystem, this,
++                     std::move(callback)));
++}
++
++void FileSystemContext::DidResolveURLOnOpenFileSystem(
++    OpenFileSystemCallback callback,
++    const GURL& filesystem_root,
++    const std::string& filesystem_name,
++    base::File::Error error) {
++  DCHECK(io_task_runner_->RunsTasksInCurrentSequence());
++
++  std::move(callback).Run(filesystem_root, filesystem_name, error);
+ }
+ 
+ void FileSystemContext::ResolveURL(const FileSystemURL& url,
+diff --git a/storage/browser/file_system/file_system_context.h b/storage/browser/file_system/file_system_context.h
+index 2f9b043f15b78c8e09bb4e6675bb5ef21fdac90c..789cecb8fd69ef39b050c229fd0668b7269f352b 100644
+--- a/storage/browser/file_system/file_system_context.h
++++ b/storage/browser/file_system/file_system_context.h
+@@ -382,6 +382,11 @@ class COMPONENT_EXPORT(STORAGE_BROWSER) FileSystemContext
+                                       const std::string& filesystem_name,
+                                       base::File::Error error);
+ 
++  void DidResolveURLOnOpenFileSystem(OpenFileSystemCallback callback,
++                                     const GURL& filesystem_root,
++                                     const std::string& filesystem_name,
++                                     base::File::Error error);
++
+   // Returns a FileSystemBackend, used only by test code.
+   SandboxFileSystemBackend* sandbox_backend() const {
+     return sandbox_backend_.get();


### PR DESCRIPTION
M98: FS: Fix FileUtil lifetime issue

Keeps FileSystemContext alive while while resolving a URL on an open
file system, removing the possibility of the file system being
destroyed while a URL is being resolved on it.

(cherry picked from [commit 3fdf2adf11b3c716c9015597d30b59bffc7ac91b](https://chromium-review.googlesource.com/q/commit:3fdf2adf11b3c716c9015597d30b59bffc7ac91b))

Bug: [1275622](https://bugs.chromium.org/p/chromium/issues/detail?id=1275622), [1289394](https://bugs.chromium.org/p/chromium/issues/detail?id=1289394)
Change-Id: [Ic1b97552f9d41a61163d72ff8c605699f673f55f](https://chromium-review.googlesource.com/q/Ic1b97552f9d41a61163d72ff8c605699f673f55f)
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3373583
Reviewed-by: Marijn Kruisselbrink <[mek@chromium.org](mailto:mek@chromium.org)>
Commit-Queue: Austin Sullivan <[asully@chromium.org](mailto:asully@chromium.org)>
Cr-Original-Commit-Position: refs/heads/main@{#968470}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3451059
Auto-Submit: Austin Sullivan <[asully@chromium.org](mailto:asully@chromium.org)>
Commit-Queue: Marijn Kruisselbrink <[mek@chromium.org](mailto:mek@chromium.org)>
Cr-Commit-Position: refs/branch-heads/4758@{#1131}
Cr-Branched-From: 4a2cf4baf90326df19c3ee70ff987960d59a386e-refs/heads/main@{#950365}

Notes: Security: backported fix for chromium:1289394.
