### PR TITLE
chore: cherry-pick b790affce3 and 9c1efd3def from angle

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -4,3 +4,5 @@ cherry-pick-05e69c75905f.patch
 cherry-pick-891020ed64d4.patch
 cherry-pick-2b98abd8cb6c.patch
 cherry-pick-cc44ae61f37b.patch
+m98_vulkan_fix_vkcmdresolveimage_extents.patch
+m98_vulkan_fix_vkcmdresolveimage_offsets.patch

--- a/patches/angle/m98_vulkan_fix_vkcmdresolveimage_extents.patch
+++ b/patches/angle/m98_vulkan_fix_vkcmdresolveimage_extents.patch
@@ -1,0 +1,112 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shahbaz Youssefi <syoussefi@chromium.org>
+Date: Mon, 31 Jan 2022 12:07:43 -0500
+Subject: M98: Vulkan: Fix vkCmdResolveImage extents
+
+The source framebuffer's extents were accidentally used instead of the
+blit area extents.
+
+Bug: chromium:1288020
+Change-Id: I5c6128a191deeea2f972dc7f010be9d40c674ce6
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3457022
+Reviewed-by: Tim Van Patten <timvp@google.com>
+
+diff --git a/src/libANGLE/renderer/vulkan/FramebufferVk.cpp b/src/libANGLE/renderer/vulkan/FramebufferVk.cpp
+index 7d088be90bc7a384ec7d6934bccddea28f8cfa0a..892983bd1ad52c6e0080c977022689c1d6a20ac5 100644
+--- a/src/libANGLE/renderer/vulkan/FramebufferVk.cpp
++++ b/src/libANGLE/renderer/vulkan/FramebufferVk.cpp
+@@ -1459,8 +1459,8 @@ angle::Result FramebufferVk::resolveColorWithCommand(ContextVk *contextVk,
+     resolveRegion.dstOffset.x                   = params.destOffset[0];
+     resolveRegion.dstOffset.y                   = params.destOffset[1];
+     resolveRegion.dstOffset.z                   = 0;
+-    resolveRegion.extent.width                  = params.srcExtents[0];
+-    resolveRegion.extent.height                 = params.srcExtents[1];
++    resolveRegion.extent.width                  = params.blitArea.width;
++    resolveRegion.extent.height                 = params.blitArea.height;
+     resolveRegion.extent.depth                  = 1;
+ 
+     vk::PerfCounters &perfCounters = contextVk->getPerfCounters();
+diff --git a/src/tests/angle_end2end_tests_expectations.txt b/src/tests/angle_end2end_tests_expectations.txt
+index dddb58fd10e4671e179f1db21781c750d7234460..72e32c27efabe8393ae840a9fef4ce37b3c5088c 100644
+--- a/src/tests/angle_end2end_tests_expectations.txt
++++ b/src/tests/angle_end2end_tests_expectations.txt
+@@ -68,6 +68,7 @@
+ // the test says.  The test also fails on Intel/Vulkan/Windows.
+ 6068 INTEL VULKAN : MultiviewRenderPrimitiveTest.LineLoop/* = SKIP
+ 6068 INTEL VULKAN : MultiviewRenderPrimitiveTest.LineStrip/* = SKIP
++6962 WIN INTEL VULKAN : BlitFramebufferTestES31.PartialResolve/* = SKIP
+ 
+ // Mac
+ 6025 MAC AMD OPENGL : IndexBufferOffsetTestES3.UseAsUBOThenUpdateThenUInt8Index/* = SKIP
+diff --git a/src/tests/gl_tests/BlitFramebufferANGLETest.cpp b/src/tests/gl_tests/BlitFramebufferANGLETest.cpp
+index 61f462cf4ce20b6fe14e7cab7c77b1498c1c2aa3..02f7d025d52f50fd067aea1b8ef1057afdfd4657 100644
+--- a/src/tests/gl_tests/BlitFramebufferANGLETest.cpp
++++ b/src/tests/gl_tests/BlitFramebufferANGLETest.cpp
+@@ -2632,6 +2632,67 @@ TEST_P(BlitFramebufferTest, BlitDepthStencilPixelByPixel)
+     EXPECT_PIXEL_RECT_EQ(64, 0, 128, 1, GLColor::blue);
+ }
+ 
++// Regression test for a bug in the Vulkan backend where vkCmdResolveImage was using the src extents
++// as the resolve area instead of the area passed to glBlitFramebuffer.
++TEST_P(BlitFramebufferTestES31, PartialResolve)
++{
++    constexpr GLint kWidth  = 16;
++    constexpr GLint kHeight = 32;
++
++    // Read framebuffer is multisampled.
++    GLTexture readTexture;
++    glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, readTexture);
++    glTexStorage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, 4, GL_RGBA8, kWidth, kHeight, GL_TRUE);
++
++    GLFramebuffer readFbo;
++    glBindFramebuffer(GL_FRAMEBUFFER, readFbo);
++    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D_MULTISAMPLE,
++                           readTexture, 0);
++    ASSERT_GL_NO_ERROR();
++    ASSERT_GL_FRAMEBUFFER_COMPLETE(GL_FRAMEBUFFER);
++
++    glClearColor(1, 0, 0, 1);
++    glClear(GL_COLOR_BUFFER_BIT);
++
++    // Draw framebuffer is single sampled.  It's bound to a texture with base level the same size as
++    // the read framebuffer, but it's bound to mip 1.
++    GLTexture drawTexture;
++    glBindTexture(GL_TEXTURE_2D, drawTexture);
++    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, kWidth, kHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE,
++                 nullptr);
++    glGenerateMipmap(GL_TEXTURE_2D);
++
++    GLFramebuffer drawFbo;
++    glBindFramebuffer(GL_FRAMEBUFFER, drawFbo);
++    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, drawTexture, 1);
++    ASSERT_GL_NO_ERROR();
++    ASSERT_GL_FRAMEBUFFER_COMPLETE(GL_FRAMEBUFFER);
++
++    glClearColor(0, 1, 0, 1);
++    glClear(GL_COLOR_BUFFER_BIT);
++    EXPECT_PIXEL_RECT_EQ(0, 0, kWidth / 2, kHeight / 2, GLColor::green);
++
++    constexpr GLint kResolveX0 = 1;
++    constexpr GLint kResolveY0 = 2;
++    constexpr GLint kResolveX1 = 4;
++    constexpr GLint kResolveY1 = 6;
++
++    // Resolve only a portion of the read framebuffer.
++    glBindFramebuffer(GL_READ_FRAMEBUFFER, readFbo);
++    glBlitFramebuffer(kResolveX0, kResolveY0, kResolveX1, kResolveY1, kResolveX0, kResolveY0,
++                      kResolveX1, kResolveY1, GL_COLOR_BUFFER_BIT, GL_NEAREST);
++    ASSERT_GL_NO_ERROR();
++
++    glBindFramebuffer(GL_READ_FRAMEBUFFER, drawFbo);
++    EXPECT_PIXEL_RECT_EQ(0, 0, kWidth / 2, kResolveY0, GLColor::green);
++    EXPECT_PIXEL_RECT_EQ(0, 0, kResolveX0, kHeight / 2, GLColor::green);
++    EXPECT_PIXEL_RECT_EQ(kResolveX1, 0, kWidth / 2 - kResolveX1, kHeight / 2, GLColor::green);
++    EXPECT_PIXEL_RECT_EQ(0, kResolveY1, kWidth / 2, kHeight / 2 - kResolveY1, GLColor::green);
++
++    EXPECT_PIXEL_RECT_EQ(kResolveX0, kResolveY0, kResolveX1 - kResolveX0, kResolveY1 - kResolveY0,
++                         GLColor::red);
++}
++
+ // Use this to select which configurations (e.g. which renderer, which GLES major version) these
+ // tests should be run against.
+ GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(BlitFramebufferANGLETest);

--- a/patches/angle/m98_vulkan_fix_vkcmdresolveimage_offsets.patch
+++ b/patches/angle/m98_vulkan_fix_vkcmdresolveimage_offsets.patch
@@ -1,0 +1,109 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shahbaz Youssefi <syoussefi@chromium.org>
+Date: Mon, 7 Feb 2022 13:46:46 -0500
+Subject: M98: Vulkan: Fix vkCmdResolveImage offsets
+
+glBlitFramebuffer takes identical regions for src and dst when
+resolving.  vkCmdResolveImage should use the clipped area instead of
+using the actual offsets passed to this function.
+
+Bug: chromium:1292537
+Change-Id: If283a8acbca3249b771facbc30bd9f8080a03656
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3457023
+Reviewed-by: Tim Van Patten <timvp@google.com>
+
+diff --git a/src/libANGLE/renderer/vulkan/FramebufferVk.cpp b/src/libANGLE/renderer/vulkan/FramebufferVk.cpp
+index 892983bd1ad52c6e0080c977022689c1d6a20ac5..7fc8e785af2c9c50f624790eccf5f57ce4af2c87 100644
+--- a/src/libANGLE/renderer/vulkan/FramebufferVk.cpp
++++ b/src/libANGLE/renderer/vulkan/FramebufferVk.cpp
+@@ -1451,13 +1451,13 @@ angle::Result FramebufferVk::resolveColorWithCommand(ContextVk *contextVk,
+     resolveRegion.srcSubresource.mipLevel       = 0;
+     resolveRegion.srcSubresource.baseArrayLayer = params.srcLayer;
+     resolveRegion.srcSubresource.layerCount     = 1;
+-    resolveRegion.srcOffset.x                   = params.srcOffset[0];
+-    resolveRegion.srcOffset.y                   = params.srcOffset[1];
++    resolveRegion.srcOffset.x                   = params.blitArea.x;
++    resolveRegion.srcOffset.y                   = params.blitArea.y;
+     resolveRegion.srcOffset.z                   = 0;
+     resolveRegion.dstSubresource.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+     resolveRegion.dstSubresource.layerCount     = 1;
+-    resolveRegion.dstOffset.x                   = params.destOffset[0];
+-    resolveRegion.dstOffset.y                   = params.destOffset[1];
++    resolveRegion.dstOffset.x                   = params.blitArea.x;
++    resolveRegion.dstOffset.y                   = params.blitArea.y;
+     resolveRegion.dstOffset.z                   = 0;
+     resolveRegion.extent.width                  = params.blitArea.width;
+     resolveRegion.extent.height                 = params.blitArea.height;
+diff --git a/src/tests/angle_end2end_tests_expectations.txt b/src/tests/angle_end2end_tests_expectations.txt
+index 72e32c27efabe8393ae840a9fef4ce37b3c5088c..87041f3b43a9ab50a0ec87ea4c338b498024b1b5 100644
+--- a/src/tests/angle_end2end_tests_expectations.txt
++++ b/src/tests/angle_end2end_tests_expectations.txt
+@@ -15,6 +15,8 @@
+ 6142 VULKAN : BlitFramebufferTest.BlitDepthStencilPixelByPixel/* = SKIP
+ 6153 VULKAN WIN INTEL : GLSLTest_ES31.StructAndArrayEqualOperator/ES3_1_Vulkan_DirectSPIRVGen = SKIP
+ 6153 VULKAN PIXEL4ORXL : GLSLTest_ES31.StructAndArrayEqualOperator/ES3_1_Vulkan_DirectSPIRVGen = SKIP
++6989 OPENGL : BlitFramebufferTestES31.OOBResolve/* = SKIP
++6989 GLES : BlitFramebufferTestES31.OOBResolve/* = SKIP
+ 
+ // SPIR-V generation doesn't yet support bools in interface blocks
+ 4889 VULKAN : GLSLTest.NestedSequenceOperatorWithTernaryInside/ES2_Vulkan_DirectSPIRVGen = SKIP
+diff --git a/src/tests/gl_tests/BlitFramebufferANGLETest.cpp b/src/tests/gl_tests/BlitFramebufferANGLETest.cpp
+index 02f7d025d52f50fd067aea1b8ef1057afdfd4657..ae2844d072ee5ab4c584bfa663b955994c011b0c 100644
+--- a/src/tests/gl_tests/BlitFramebufferANGLETest.cpp
++++ b/src/tests/gl_tests/BlitFramebufferANGLETest.cpp
+@@ -2632,6 +2632,55 @@ TEST_P(BlitFramebufferTest, BlitDepthStencilPixelByPixel)
+     EXPECT_PIXEL_RECT_EQ(64, 0, 128, 1, GLColor::blue);
+ }
+ 
++// Regression test for a bug in the Vulkan backend where vkCmdResolveImage was used with
++// out-of-bounds regions.
++TEST_P(BlitFramebufferTestES31, OOBResolve)
++{
++    constexpr GLint kWidth  = 16;
++    constexpr GLint kHeight = 32;
++
++    // Read framebuffer is multisampled.
++    GLTexture readTexture;
++    glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, readTexture);
++    glTexStorage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, 4, GL_RGBA8, kWidth, kHeight, GL_TRUE);
++
++    GLFramebuffer readFbo;
++    glBindFramebuffer(GL_FRAMEBUFFER, readFbo);
++    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D_MULTISAMPLE,
++                           readTexture, 0);
++    ASSERT_GL_NO_ERROR();
++    ASSERT_GL_FRAMEBUFFER_COMPLETE(GL_FRAMEBUFFER);
++
++    glClearColor(1, 0, 0, 1);
++    glClear(GL_COLOR_BUFFER_BIT);
++
++    // Draw framebuffer is single sampled.
++    GLTexture drawTexture;
++    glBindTexture(GL_TEXTURE_2D, drawTexture);
++    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, kWidth, kHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE,
++                 nullptr);
++    glGenerateMipmap(GL_TEXTURE_2D);
++
++    GLFramebuffer drawFbo;
++    glBindFramebuffer(GL_FRAMEBUFFER, drawFbo);
++    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, drawTexture, 0);
++    ASSERT_GL_NO_ERROR();
++    ASSERT_GL_FRAMEBUFFER_COMPLETE(GL_FRAMEBUFFER);
++
++    glClearColor(0, 1, 0, 1);
++    glClear(GL_COLOR_BUFFER_BIT);
++    EXPECT_PIXEL_RECT_EQ(0, 0, kWidth, kHeight, GLColor::green);
++
++    // Resolve the read framebuffer, using bounds that are outside the size of the image.
++    glBindFramebuffer(GL_READ_FRAMEBUFFER, readFbo);
++    glBlitFramebuffer(-kWidth * 2, -kHeight * 3, kWidth * 11, kHeight * 8, -kWidth * 2,
++                      -kHeight * 3, kWidth * 11, kHeight * 8, GL_COLOR_BUFFER_BIT, GL_NEAREST);
++    ASSERT_GL_NO_ERROR();
++
++    glBindFramebuffer(GL_READ_FRAMEBUFFER, drawFbo);
++    EXPECT_PIXEL_RECT_EQ(0, 0, kWidth, kHeight, GLColor::red);
++}
++
+ // Regression test for a bug in the Vulkan backend where vkCmdResolveImage was using the src extents
+ // as the resolve area instead of the area passed to glBlitFramebuffer.
+ TEST_P(BlitFramebufferTestES31, PartialResolve)


### PR DESCRIPTION
M98: Vulkan: Fix vkCmdResolveImage offsets

glBlitFramebuffer takes identical regions for src and dst when
resolving.  vkCmdResolveImage should use the clipped area instead of
using the actual offsets passed to this function.

Bug: [chromium:1292537](https://bugs.chromium.org/p/chromium/issues/detail?id=1292537)
Change-Id: [If283a8acbca3249b771facbc30bd9f8080a03656](https://chromium-review.googlesource.com/q/If283a8acbca3249b771facbc30bd9f8080a03656)
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3457023
Reviewed-by: Tim Van Patten <[timvp@google.com](mailto:timvp@google.com)>

====================

M98: Vulkan: Fix vkCmdResolveImage extents

The source framebuffer's extents were accidentally used instead of the
blit area extents.

Bug: [chromium:1288020](https://bugs.chromium.org/p/chromium/issues/detail?id=1288020)
Change-Id: [I5c6128a191deeea2f972dc7f010be9d40c674ce6](https://chromium-review.googlesource.com/q/I5c6128a191deeea2f972dc7f010be9d40c674ce6)
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3457022
Reviewed-by: Tim Van Patten <[timvp@google.com](mailto:timvp@google.com)>

Notes: Security: backported fixes to chromium:1292537 and CVE-2022-0606.
