### PR TITLE
fix: crash when showing item in folder on DevTools

### DIFF
--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -175,6 +175,10 @@ GURL GetDevToolsURL(bool can_dock) {
   return GURL(url_string);
 }
 
+void OnOpenItemComplete(const base::FilePath& path, const std::string& result) {
+  platform_util::ShowItemInFolder(path);
+}
+
 constexpr base::TimeDelta kInitialBackoffDelay = base::Milliseconds(250);
 constexpr base::TimeDelta kMaxBackoffDelay = base::Seconds(10);
 
@@ -737,9 +741,8 @@ void InspectableWebContents::ShowItemInFolder(
     return;
 
   base::FilePath path = base::FilePath::FromUTF8Unsafe(file_system_path);
-
-  // Pass empty callback here; we can ignore errors
-  platform_util::OpenPath(path, platform_util::OpenCallback());
+  platform_util::OpenPath(path.DirName(),
+                          base::BindOnce(&OnOpenItemComplete, path));
 }
 
 void InspectableWebContents::SaveToFile(const std::string& url,


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/33023.

Fixes an issue where clicking "Open in Containing Folder" in the Sources tab in Devtools caused a crash. 

We were incorrectly [passing an empty callback](https://github.com/electron/electron/blob/28ada6ea8bd2abeca8812e6d284c1f5f3974286b/shell/browser/ui/inspectable_web_contents.cc#L742) instead of a callback which [calls `ShowItemInFolder`](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/devtools/devtools_file_helper.cc;l=457-460). Chromium's call also opens the directory containing the file in their call to `platform_util::OpenItem`, so we correct that on our end (since we don't pass an option to differentiate) by passing the file's parent directory to `OpenPath`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where clicking "Open in Containing Folder" in the Sources tab in Devtools caused a crash. 
