### PR TITLE
fix: max window size defaults to 0

### DIFF
--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -177,7 +177,7 @@ void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
   // By default the window has a default maximum size that prevents it
   // from being resized larger than the screen, so we should only set this
   // if th user has passed in values.
-  if (have_max_height || have_max_width)
+  if (have_max_height || have_max_width || !max_size.IsEmpty())
     size_constraints.set_maximum_size(gfx::Size(max_width, max_height));
 
   if (use_content_size) {

--- a/shell/browser/native_window.cc
+++ b/shell/browser/native_window.cc
@@ -161,16 +161,25 @@ void NativeWindow::InitFromOptions(const gin_helper::Dictionary& options) {
   // On Linux and Window we may already have maximum size defined.
   extensions::SizeConstraints size_constraints(
       use_content_size ? GetContentSizeConstraints() : GetSizeConstraints());
+
   int min_width = size_constraints.GetMinimumSize().width();
   int min_height = size_constraints.GetMinimumSize().height();
   options.Get(options::kMinWidth, &min_width);
   options.Get(options::kMinHeight, &min_height);
   size_constraints.set_minimum_size(gfx::Size(min_width, min_height));
-  int max_width = size_constraints.GetMaximumSize().width();
-  int max_height = size_constraints.GetMaximumSize().height();
-  options.Get(options::kMaxWidth, &max_width);
-  options.Get(options::kMaxHeight, &max_height);
-  size_constraints.set_maximum_size(gfx::Size(max_width, max_height));
+
+  gfx::Size max_size = size_constraints.GetMaximumSize();
+  int max_width = max_size.width() > 0 ? max_size.width() : INT_MAX;
+  int max_height = max_size.height() > 0 ? max_size.height() : INT_MAX;
+  bool have_max_width = options.Get(options::kMaxWidth, &max_width);
+  bool have_max_height = options.Get(options::kMaxHeight, &max_height);
+
+  // By default the window has a default maximum size that prevents it
+  // from being resized larger than the screen, so we should only set this
+  // if th user has passed in values.
+  if (have_max_height || have_max_width)
+    size_constraints.set_maximum_size(gfx::Size(max_width, max_height));
+
   if (use_content_size) {
     SetContentSizeConstraints(size_constraints);
   } else {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/32995.

Fixes an issue where setting window `maxHeight` or `maxWidth` made it so the width and height could no longer be resized.

https://github.com/electron/electron/pull/32628 fixed an issue with `maxWidth` not being respected at all, but also changed defaults such that `max_width` and `max_height` conformed to `size_constraints.GetMaximumSize()`. By default, `size_constraints.GetMaximumSize()` returns `(0, 0)` unless it's been previously set, so this accidentally made it such that the `maxHeight` couldn't be changed if the `maxWidth` was set, and vice versa. This fixes that issue.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where setting window `maxHeight` or `maxWidth` made it so the width and height could no longer be resized.
