### PR TITLE
fix: macOS tray icon alternate images

### DIFF
--- a/shell/browser/ui/tray_icon_cocoa.mm
+++ b/shell/browser/ui/tray_icon_cocoa.mm
@@ -93,6 +93,15 @@
 
 - (void)setAlternateImage:(NSImage*)image {
   [[statusItem_ button] setAlternateImage:image];
+
+  // We need to change the button type here because the default button type for
+  // NSStatusItem, NSStatusBarButton, does not display alternate content when
+  // clicked. NSButtonTypeMomentaryChange displays its alternate content when
+  // clicked and returns to its normal content when the user releases it, which
+  // is the behavior users would expect when clicking a button with an alternate
+  // image set.
+  [[statusItem_ button] setButtonType:NSButtonTypeMomentaryChange];
+  [self updateDimensions];
 }
 
 - (void)setIgnoreDoubleClickEvents:(BOOL)ignore {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/33008.

Fixes an issue where `alternateImage`s did not work properly on macOS. To fix this, we need to change the button type when setting an alternate image because the default button type for `NSStatusItem`, `NSStatusBarButton`, does not display alternate content when clicked. [`NSButtonTypeMomentaryChange`](https://developer.apple.com/documentation/appkit/nsbuttontype/nsbuttontypemomentarychange?language=objc) displays its alternate content when clicked and returns to its normal content when the user releases it, which is the behavior users would expect when clicking a button with an alternate image set. After this fix, the tray icon displays the same behavior as it did prior to this breaking. Also tested with context menus etc to ensure nothing else broke by changing this.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixes an issue where `alternateImage`s did not work properly on macOS. 