### PR TITLE
fix: NOTREACHED when resizing windows frameless bounds

### DIFF
--- a/shell/browser/ui/views/win_frame_view.cc
+++ b/shell/browser/ui/views/win_frame_view.cc
@@ -34,6 +34,13 @@ void WinFrameView::Init(NativeWindowViews* window, views::Widget* frame) {
   window_ = window;
   frame_ = frame;
 
+  // Prevent events from trickling down the views hierarchy here, since
+  // when a given window is frameless we only want to use FramelessView's
+  // ResizingBorderHitTest in ShouldDescendIntoChildForEventHandling.
+  // See https://chromium-review.googlesource.com/c/chromium/src/+/3251980.
+  if (!window_->has_frame())
+    frame_->client_view()->SetCanProcessEventsWithinSubtree(false);
+
   if (window->IsWindowControlsOverlayEnabled()) {
     caption_button_container_ =
         AddChildView(std::make_unique<WinCaptionButtonContainer>(this));

--- a/shell/browser/ui/views/win_frame_view.cc
+++ b/shell/browser/ui/views/win_frame_view.cc
@@ -35,10 +35,11 @@ void WinFrameView::Init(NativeWindowViews* window, views::Widget* frame) {
   frame_ = frame;
 
   // Prevent events from trickling down the views hierarchy here, since
-  // when a given window is frameless we only want to use FramelessView's
-  // ResizingBorderHitTest in ShouldDescendIntoChildForEventHandling.
-  // See https://chromium-review.googlesource.com/c/chromium/src/+/3251980.
-  if (!window_->has_frame())
+  // when a given resizable window is frameless we only want to use
+  // FramelessView's ResizingBorderHitTest in
+  // ShouldDescendIntoChildForEventHandling. See
+  // https://chromium-review.googlesource.com/c/chromium/src/+/3251980.
+  if (!window_->has_frame() && window_->IsResizable())
     frame_->client_view()->SetCanProcessEventsWithinSubtree(false);
 
   if (window->IsWindowControlsOverlayEnabled()) {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/32681.

Fixes a DCHECK encountered when trying to resize frameless windows on Windows.

<details> <summary>Stacktrace</summary>

```
[17168:0131/153326.410:FATAL:native_view_host.cc(248)] Check failed: false. This view is not expected to receive events directly. Event targeting should find the native view as target window instead of the view hierarchy. This is likely due to an overlapping View that receives but is not handling this event. See crbug.com/1263413 and Widget::ShouldDescendIntoChildForEventHandling() for some more leads. If the overlapping view was not intended to receive events, call SetCanProcessEventsWithinSubtree(false) on the overlapping View that paints to a layer. If it's intended to receive some, but not this event, event targeting needs to be fixed for this case.

View: NativeViewHost
Hierarchy:
RootView -> NonClientView -> WinFrameView -> ClientView -> View -> View -> WebView -> NativeViewHost
View created here:
Run with --view-stack-traces to get a stack trace for when this View was created.
Backtrace:
base::debug::CollectStackTrace [0x00007FF66533DA12+18] (o:\base\debug\stack_trace_win.cc:305)
base::debug::StackTrace::StackTrace [0x00007FF66527B262+18] (o:\base\debug\stack_trace.cc:197)
logging::LogMessage::~LogMessage [0x00007FF6652935B5+197] (o:\base\logging.cc:588)
logging::LogMessage::~LogMessage [0x00007FF665294780+16] (o:\base\logging.cc:581)
views::NativeViewHost::OnMousePressed [0x00007FF666F7D240+176] (o:\ui\views\controls\native\native_view_host.cc:259)
views::View::ProcessMousePressed [0x00007FF665F0ED73+207] (o:\ui\views\view.cc:3010)
views::View::OnMouseEvent [0x00007FF665F0EBCC+60] (o:\ui\views\view.cc:1436)
ui::EventDispatcher::DispatchEvent [0x00007FF6658C673F+259] (o:\ui\events\event_dispatcher.cc:191)
ui::EventDispatcher::ProcessEvent [0x00007FF6658C5FE1+475] (o:\ui\events\event_dispatcher.cc:140)
ui::EventDispatcherDelegate::DispatchEventToTarget [0x00007FF6658C5B27+255] (o:\ui\events\event_dispatcher.cc:84)
ui::EventDispatcherDelegate::DispatchEvent [0x00007FF6658C58A2+222] (o:\ui\events\event_dispatcher.cc:55)
views::internal::RootView::OnMousePressed [0x00007FF666F49C55+1269] (o:\ui\views\widget\root_view.cc:419)
views::Widget::OnMouseEvent [0x00007FF665F2315C+860] (o:\ui\views\widget\widget.cc:1526)
views::DesktopNativeWidgetAura::OnMouseEvent [0x00007FF665F3BFA4+500] (o:\ui\views\widget\desktop_aura\desktop_native_widget_aura.cc:1220)
ui::EventDispatcher::DispatchEvent [0x00007FF6658C673F+259] (o:\ui\events\event_dispatcher.cc:191)
ui::EventDispatcher::ProcessEvent [0x00007FF6658C5FE1+475] (o:\ui\events\event_dispatcher.cc:140)
ui::EventDispatcherDelegate::DispatchEventToTarget [0x00007FF6658C5B27+255] (o:\ui\events\event_dispatcher.cc:84)
ui::EventDispatcherDelegate::DispatchEvent [0x00007FF6658C58A2+222] (o:\ui\events\event_dispatcher.cc:55)
ui::EventProcessor::OnEventFromSource [0x00007FF6673F25DF+527] (o:\ui\events\event_processor.cc:49)
ui::EventSource::DeliverEventToSink [0x00007FF6658C6CAA+122] (o:\ui\events\event_source.cc:118)
ui::EventSource::SendEventToSinkFromRewriter [0x00007FF6658C6BB7+367] (o:\ui\events\event_source.cc:146)
ui::EventSource::SendEventToSink [0x00007FF6658C6A3E+16] (o:\ui\events\event_source.cc:112)
views::DesktopWindowTreeHostWin::HandleMouseEvent [0x00007FF665F42F4E+238] (o:\ui\views\widget\desktop_aura\desktop_window_tree_host_win.cc:1024)
views::HWNDMessageHandler::HandleMouseEventInternal [0x00007FF666F6BD66+1630] (o:\ui\views\win\hwnd_message_handler.cc:3157)
views::HWNDMessageHandler::HandleMouseMessage [0x00007FF666F6B6B7+103] (o:\ui\views\win\hwnd_message_handler.cc:1099)
content::LegacyRenderWidgetHostHWND::OnMouseRange [0x00007FF6648E6E4F+301] (o:\content\browser\renderer_host\legacy_render_widget_host_win.cc:318)
content::LegacyRenderWidgetHostHWND::_ProcessWindowMessage [0x00007FF6648E7F33+727] (o:\content\browser\renderer_host\legacy_render_widget_host_win.h:106)
content::LegacyRenderWidgetHostHWND::ProcessWindowMessage [0x00007FF6648E76B6+38] (o:\content\browser\renderer_host\legacy_render_widget_host_win.h:86)
ATL::CWindowImplBaseT<ATL::CWindow,ATL::CWinTraits<1073741824,0> >::WindowProc [0x00007FF6648E815A+170] (o:\third_party\depot_tools\win_toolchain\vs_files\e146e01913\VC\Tools\MSVC\14.26.28801\atlmfc\include\atlwin.h:3572)
(No symbol) [0x00007FFDC59F1028]
CallWindowProcW [0x00007FFDCF9AE7E8+1016]
DispatchMessageW [0x00007FFDCF9AE229+601]
base::MessagePumpForUI::ProcessMessageHelper [0x00007FF665348E78+952] (o:\base\message_loop\message_pump_win.cc:543)
base::MessagePumpForUI::ProcessNextWindowsMessage [0x00007FF665347F4B+459] (o:\base\message_loop\message_pump_win.cc:504)
base::MessagePumpForUI::DoRunLoop [0x00007FF665347AB1+177] (o:\base\message_loop\message_pump_win.cc:215)
base::MessagePumpWin::Run [0x00007FF665346BC3+115] (o:\base\message_loop\message_pump_win.cc:79)
base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run [0x00007FF665FA4293+867] (o:\base\task\sequence_manager\thread_controller_with_message_pump_impl.cc:471)
base::RunLoop::Run [0x00007FF6652DCBBC+1052] (o:\base\run_loop.cc:142)
content::BrowserMainLoop::RunMainMessageLoop [0x00007FF66424341D+213] (o:\content\browser\browser_main_loop.cc:1050)
content::BrowserMainRunnerImpl::Run [0x00007FF66424527F+143] (o:\content\browser\browser_main_runner_impl.cc:154)
content::BrowserMain [0x00007FF6642406CF+295] (o:\content\browser\browser_main.cc:30)
content::RunBrowserProcessMain [0x00007FF661BFE5AA+334] (o:\content\app\content_main_runner_impl.cc:643)
content::ContentMainRunnerImpl::RunBrowser [0x00007FF661C00D39+2501] (o:\content\app\content_main_runner_impl.cc:1157)
content::ContentMainRunnerImpl::Run [0x00007FF661C002ED+877] (o:\content\app\content_main_runner_impl.cc:1027)
content::RunContentProcess [0x00007FF661BFADD3+780] (o:\content\app\content_main.cc:402)
content::ContentMain [0x00007FF661BFB431+84] (o:\content\app\content_main.cc:430)
wWinMain [0x00007FF66190154B+911] (o:\electron\shell\app\electron_main_win.cc:238)
__scrt_common_main_seh [0x00007FF66A5759F2+262] (d:\A01\_work\6\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
BaseThreadInitThunk [0x00007FFDCE9E7034+20]
RtlUserThreadStart [0x00007FFDCFBE2651+33]
Crash keys:
"ui_scheduler_async_stack" = "0x7FF66537AFF6 0x0"
"io_scheduler_async_stack" = "0x7FF6654EEA25 0x7FF6659144C5"
"platform" = "win32"
"process_type" = "browser"

Received fatal exception EXCEPTION_BREAKPOINT
Backtrace:
base::debug::BreakDebuggerAsyncSafe [0x00007FF66533CE8D+13] (o:\base\debug\debugger_win.cc:21)
logging::LogMessage::~LogMessage [0x00007FF6652939E7+1271] (o:\base\logging.cc:890)
logging::LogMessage::~LogMessage [0x00007FF665294780+16] (o:\base\logging.cc:581)
views::NativeViewHost::OnMousePressed [0x00007FF666F7D240+176] (o:\ui\views\controls\native\native_view_host.cc:259)
views::View::ProcessMousePressed [0x00007FF665F0ED73+207] (o:\ui\views\view.cc:3010)
views::View::OnMouseEvent [0x00007FF665F0EBCC+60] (o:\ui\views\view.cc:1436)
ui::EventDispatcher::DispatchEvent [0x00007FF6658C673F+259] (o:\ui\events\event_dispatcher.cc:191)
ui::EventDispatcher::ProcessEvent [0x00007FF6658C5FE1+475] (o:\ui\events\event_dispatcher.cc:140)
ui::EventDispatcherDelegate::DispatchEventToTarget [0x00007FF6658C5B27+255] (o:\ui\events\event_dispatcher.cc:84)
ui::EventDispatcherDelegate::DispatchEvent [0x00007FF6658C58A2+222] (o:\ui\events\event_dispatcher.cc:55)
views::internal::RootView::OnMousePressed [0x00007FF666F49C55+1269] (o:\ui\views\widget\root_view.cc:419)
views::Widget::OnMouseEvent [0x00007FF665F2315C+860] (o:\ui\views\widget\widget.cc:1526)
views::DesktopNativeWidgetAura::OnMouseEvent [0x00007FF665F3BFA4+500] (o:\ui\views\widget\desktop_aura\desktop_native_widget_aura.cc:1220)
ui::EventDispatcher::DispatchEvent [0x00007FF6658C673F+259] (o:\ui\events\event_dispatcher.cc:191)
ui::EventDispatcher::ProcessEvent [0x00007FF6658C5FE1+475] (o:\ui\events\event_dispatcher.cc:140)
ui::EventDispatcherDelegate::DispatchEventToTarget [0x00007FF6658C5B27+255] (o:\ui\events\event_dispatcher.cc:84)
ui::EventDispatcherDelegate::DispatchEvent [0x00007FF6658C58A2+222] (o:\ui\events\event_dispatcher.cc:55)
ui::EventProcessor::OnEventFromSource [0x00007FF6673F25DF+527] (o:\ui\events\event_processor.cc:49)
ui::EventSource::DeliverEventToSink [0x00007FF6658C6CAA+122] (o:\ui\events\event_source.cc:118)
ui::EventSource::SendEventToSinkFromRewriter [0x00007FF6658C6BB7+367] (o:\ui\events\event_source.cc:146)
ui::EventSource::SendEventToSink [0x00007FF6658C6A3E+16] (o:\ui\events\event_source.cc:112)
views::DesktopWindowTreeHostWin::HandleMouseEvent [0x00007FF665F42F4E+238] (o:\ui\views\widget\desktop_aura\desktop_window_tree_host_win.cc:1024)
views::HWNDMessageHandler::HandleMouseEventInternal [0x00007FF666F6BD66+1630] (o:\ui\views\win\hwnd_message_handler.cc:3157)
views::HWNDMessageHandler::HandleMouseMessage [0x00007FF666F6B6B7+103] (o:\ui\views\win\hwnd_message_handler.cc:1099)
content::LegacyRenderWidgetHostHWND::OnMouseRange [0x00007FF6648E6E4F+301] (o:\content\browser\renderer_host\legacy_render_widget_host_win.cc:318)
content::LegacyRenderWidgetHostHWND::_ProcessWindowMessage [0x00007FF6648E7F33+727] (o:\content\browser\renderer_host\legacy_render_widget_host_win.h:106)
content::LegacyRenderWidgetHostHWND::ProcessWindowMessage [0x00007FF6648E76B6+38] (o:\content\browser\renderer_host\legacy_render_widget_host_win.h:86)
ATL::CWindowImplBaseT<ATL::CWindow,ATL::CWinTraits<1073741824,0> >::WindowProc [0x00007FF6648E815A+170] (o:\third_party\depot_tools\win_toolchain\vs_files\e146e01913\VC\Tools\MSVC\14.26.28801\atlmfc\include\atlwin.h:3572)
(No symbol) [0x00007FFDC59F1028]
CallWindowProcW [0x00007FFDCF9AE7E8+1016]
DispatchMessageW [0x00007FFDCF9AE229+601]
base::MessagePumpForUI::ProcessMessageHelper [0x00007FF665348E78+952] (o:\base\message_loop\message_pump_win.cc:543)
base::MessagePumpForUI::ProcessNextWindowsMessage [0x00007FF665347F4B+459] (o:\base\message_loop\message_pump_win.cc:504)
base::MessagePumpForUI::DoRunLoop [0x00007FF665347AB1+177] (o:\base\message_loop\message_pump_win.cc:215)
base::MessagePumpWin::Run [0x00007FF665346BC3+115] (o:\base\message_loop\message_pump_win.cc:79)
base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run [0x00007FF665FA4293+867] (o:\base\task\sequence_manager\thread_controller_with_message_pump_impl.cc:471)
base::RunLoop::Run [0x00007FF6652DCBBC+1052] (o:\base\run_loop.cc:142)
content::BrowserMainLoop::RunMainMessageLoop [0x00007FF66424341D+213] (o:\content\browser\browser_main_loop.cc:1050)
content::BrowserMainRunnerImpl::Run [0x00007FF66424527F+143] (o:\content\browser\browser_main_runner_impl.cc:154)
content::BrowserMain [0x00007FF6642406CF+295] (o:\content\browser\browser_main.cc:30)
content::RunBrowserProcessMain [0x00007FF661BFE5AA+334] (o:\content\app\content_main_runner_impl.cc:643)
content::ContentMainRunnerImpl::RunBrowser [0x00007FF661C00D39+2501] (o:\content\app\content_main_runner_impl.cc:1157)
content::ContentMainRunnerImpl::Run [0x00007FF661C002ED+877] (o:\content\app\content_main_runner_impl.cc:1027)
content::RunContentProcess [0x00007FF661BFADD3+780] (o:\content\app\content_main.cc:402)
content::ContentMain [0x00007FF661BFB431+84] (o:\content\app\content_main.cc:430)
wWinMain [0x00007FF66190154B+911] (o:\electron\shell\app\electron_main_win.cc:238)
__scrt_common_main_seh [0x00007FF66A5759F2+262] (d:\A01\_work\6\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
BaseThreadInitThunk [0x00007FFDCE9E7034+20]
RtlUserThreadStart [0x00007FFDCFBE2651+33]

Electron exited with code 2147483651.
```

</details>

Some explorative spelunking led me to try disabling event processing with `SetCanProcessEventsWithinSubtree` on the subview - I didn't find this to cause any other issues but i'd like some secondary eyes especially from @clavin and @mlaurencin who I believe also encountered this and looked into it a bit!

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none.
