### PR TITLE
fix: DCHECK when calling app.exit()

### DIFF
--- a/shell/browser/window_list.cc
+++ b/shell/browser/window_list.cc
@@ -109,7 +109,7 @@ void WindowList::DestroyAllWindows() {
       ConvertToWeakPtrVector(GetInstance()->windows_);
 
   for (const auto& window : weak_windows) {
-    if (window)
+    if (window && !window->IsClosed())
       window->CloseImmediately();
   }
 }


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/33034.

Fixes a potential DCKECK resultant of trying to close an already-closed window.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
