### PR TITLE
docs: fiddle ipc pattern 2 example update 

### DIFF
--- a/docs/fiddles/ipc/pattern-2/main.js
+++ b/docs/fiddles/ipc/pattern-2/main.js
@@ -1,4 +1,4 @@
-const {app, BrowserWindow, ipcMain} = require('electron')
+const {app, BrowserWindow, ipcMain,dialog} = require('electron')
 const path = require('path')
 
 async function handleFileOpen() {


### PR DESCRIPTION
Fiddle ipc pattern 2 update 
updated main.js such that now it requires dialog otherwise it would have thrown "Error occurred in handler for 'dialog:openFile': ReferenceError: dialog is not defined"

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] relevant documentation is changed or added

#### Release Notes

Notes: none
