### PR TITLE
fix: incorrect tray garbage collection

### DIFF
--- a/shell/browser/api/electron_api_tray.cc
+++ b/shell/browser/api/electron_api_tray.cc
@@ -89,8 +89,10 @@ gin::Handle<Tray> Tray::New(gin_helper::ErrorThrower thrower,
   }
 #endif
 
-  return gin::CreateHandle(thrower.isolate(),
-                           new Tray(args->isolate(), image, guid));
+  auto handle = gin::CreateHandle(args->isolate(),
+                                  new Tray(args->isolate(), image, guid));
+  handle->Pin(args->isolate());
+  return handle;
 }
 
 void Tray::OnClicked(const gfx::Rect& bounds,
@@ -180,6 +182,7 @@ void Tray::OnDragEnded() {
 }
 
 void Tray::Destroy() {
+  Unpin();
   menu_.Reset();
   tray_icon_.reset();
 }

--- a/shell/browser/api/electron_api_tray.h
+++ b/shell/browser/api/electron_api_tray.h
@@ -19,6 +19,7 @@
 #include "shell/common/gin_helper/cleaned_up_at_exit.h"
 #include "shell/common/gin_helper/constructible.h"
 #include "shell/common/gin_helper/error_thrower.h"
+#include "shell/common/gin_helper/pinnable.h"
 
 namespace gfx {
 class Image;
@@ -38,6 +39,7 @@ class Tray : public gin::Wrappable<Tray>,
              public gin_helper::EventEmitterMixin<Tray>,
              public gin_helper::Constructible<Tray>,
              public gin_helper::CleanedUpAtExit,
+             public gin_helper::Pinnable<Tray>,
              public TrayIconObserver {
  public:
   // gin_helper::Constructible


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/31564.

Fixes an issue where the Tray could get garbage collected incorrectly under some circumstances.

I bisected this to https://github.com/electron/electron/compare/v10.0.0-nightly.20200310...v10.0.0-nightly.20200311 - which was the diff that removed the [catch-all `HandleScope`](https://github.com/electron/electron/commit/19314d3cafc5ec1c4b1f1316b3f5d9744f8e9604). For some trays, this wasn't an issue - if they had a menu, for example, those are prevented from being GC'd which also prevented Tray GC. We fix this by pinning the Tray, in similar fashion to what's done with, for example, `BrowserView`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the Tray could get garbage collected incorrectly under some circumstances.
