### PR TITLE
fix: gracefully fail if app.configureHostResolver is called before ready

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1630,6 +1630,11 @@ v8::Local<v8::Value> App::GetDockAPI(v8::Isolate* isolate) {
 void ConfigureHostResolver(v8::Isolate* isolate,
                            const gin_helper::Dictionary& opts) {
   gin_helper::ErrorThrower thrower(isolate);
+  if (!Browser::Get()->is_ready()) {
+    thrower.ThrowError(
+        "configureHostResolver cannot be called before the app is ready");
+    return;
+  }
   net::SecureDnsMode secure_dns_mode = net::SecureDnsMode::kOff;
   std::string default_doh_templates;
   if (base::FeatureList::IsEnabled(features::kDnsOverHttps)) {


### PR DESCRIPTION
#### Description of Change
Ref #33045.

This is already documented, but this makes the landing softer when the API is misused.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)

#### Release Notes

Notes: none
