### PR TITLE
fix: race condition where webContents can be nullptr during re-focus and a multi-window close sequence

### DIFF
--- a/shell/browser/ui/cocoa/electron_inspectable_web_contents_view.mm
+++ b/shell/browser/ui/cocoa/electron_inspectable_web_contents_view.mm
@@ -266,6 +266,7 @@
       inspectableWebContentsView_->inspectable_web_contents();
   DCHECK(inspectable_web_contents);
   auto* webContents = inspectable_web_contents->GetWebContents();
+  if (!webContents) return;
   auto* webContentsView = webContents->GetNativeView().GetNativeNSView();
 
   NSView* view = [notification object];

--- a/shell/browser/ui/cocoa/electron_inspectable_web_contents_view.mm
+++ b/shell/browser/ui/cocoa/electron_inspectable_web_contents_view.mm
@@ -266,7 +266,8 @@
       inspectableWebContentsView_->inspectable_web_contents();
   DCHECK(inspectable_web_contents);
   auto* webContents = inspectable_web_contents->GetWebContents();
-  if (!webContents) return;
+  if (!webContents)
+    return;
   auto* webContentsView = webContents->GetNativeView().GetNativeNSView();
 
   NSView* view = [notification object];


### PR DESCRIPTION
Not 100% sure if this fixes it but I believe this is the race condition.

Notes: Theoretical fix for a crash we're seeing when closing multiple child windows at the same time on macOS