### PR TITLE
fix: crash when WindowButtonsProxy references cleared NSWindow

### DIFF
--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -326,8 +326,10 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
 
   RegisterDeleteDelegateCallback(base::BindOnce(
       [](NativeWindowMac* window) {
-        if (window->window_)
+        if (window->window_) {
+          window->buttons_proxy_.reset(nil);
           window->window_ = nil;
+        }
       },
       this));
 

--- a/shell/browser/native_window_mac.mm
+++ b/shell/browser/native_window_mac.mm
@@ -326,10 +326,10 @@ NativeWindowMac::NativeWindowMac(const gin_helper::Dictionary& options,
 
   RegisterDeleteDelegateCallback(base::BindOnce(
       [](NativeWindowMac* window) {
-        if (window->window_) {
-          window->buttons_proxy_.reset(nil);
+        if (window->window_)
           window->window_ = nil;
-        }
+        if (window->buttons_proxy_)
+          window->buttons_proxy_.reset();
       },
       this));
 


### PR DESCRIPTION
#### Description of Change

This PR resets the `WindowButtonsProxy` in `NativeWindowMac` when deleting the underlying `NSWindow`. This is needed, because `WindowButtonsProxy` has a reference to `NSWindow`, which is not cleared when `NSWindow` is. This can cause a crash when `WindowButtonsProxy` calls something on the `NSWindow` when that is already cleared.

We ran into this crash at Around only when we were updating our electron app and wanted to quit the application and restart a new one. So it's hard to formulate a repro for this.

#### Checklist

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: Fix crash when WindowButtonsProxy references cleared NSWindow
