### PR TITLE
docs: fix missing dependencies in ipc patterns

### DIFF
--- a/docs/fiddles/ipc/pattern-2/main.js
+++ b/docs/fiddles/ipc/pattern-2/main.js
@@ -1,4 +1,4 @@
-const {app, BrowserWindow, ipcMain,dialog} = require('electron')
+const {app, BrowserWindow, ipcMain, dialog} = require('electron')
 const path = require('path')
 
 async function handleFileOpen() {

--- a/docs/fiddles/ipc/pattern-3/main.js
+++ b/docs/fiddles/ipc/pattern-3/main.js
@@ -1,4 +1,4 @@
-const {app, BrowserWindow, Menu} = require('electron')
+const {app, BrowserWindow, Menu, ipcMain} = require('electron')
 const path = require('path')
 
 function createWindow () {


### PR DESCRIPTION
#### Fix missing dependencies in ipc patterns

- [x] updated `docs/fiddles/ipc/pattern-3/main.js` otherwise it would have thrown "UnhandledPromiseRejectionWarning: ReferenceError: ipcMain is not defined"
- [x] updated `docs/fiddles/ipc/pattern-2/main.js` to adapt coding style 

There is a another bug in `docs/fiddles/ipc/pattern-3/renderer.js` : `event.reply` is `undefined` .
```js
const counter = document.getElementById('counter')

window.electronAPI.handleCounter((event, value) => {
    const oldValue = Number(counter.innerText)
    const newValue = oldValue + value
    counter.innerText = newValue
    event.reply('counter-value', newValue)  // `event.reply` is undefined, `event.sender.send` is available.
})
```
#### Checklist

- [x] relevant documentation is changed or added

#### Release Notes
Notes: none

