### PR TITLE
ci: disable use-thin-lto on Mac only

### DIFF
--- a/.circleci/build_config.yml
+++ b/.circleci/build_config.yml
@@ -530,7 +530,7 @@ step-electron-build: &step-electron-build
       fi
       cd src
       # Enable if things get really bad
-      # if [ "`uname`" == "Darwin" ]; then
+      # if  [ "$TARGET_ARCH" == "arm64" ] &&[ "`uname`" == "Darwin" ]; then
       #   diskutil erasevolume HFS+ "xcode_disk" `hdiutil attach -nomount ram://12582912`
       #   mv /Applications/Xcode-12.beta.5.app /Volumes/xcode_disk/
       #   ln -s /Volumes/xcode_disk/Xcode-12.beta.5.app /Applications/Xcode-12.beta.5.app

--- a/.circleci/build_config.yml
+++ b/.circleci/build_config.yml
@@ -530,11 +530,11 @@ step-electron-build: &step-electron-build
       fi
       cd src
       # Enable if things get really bad
-      if [ "`uname`" == "Darwin" ]; then
-        diskutil erasevolume HFS+ "xcode_disk" `hdiutil attach -nomount ram://12582912`
-        mv /Applications/Xcode-12.beta.5.app /Volumes/xcode_disk/
-        ln -s /Volumes/xcode_disk/Xcode-12.beta.5.app /Applications/Xcode-12.beta.5.app
-      fi
+      # if [ "`uname`" == "Darwin" ]; then
+      #   diskutil erasevolume HFS+ "xcode_disk" `hdiutil attach -nomount ram://12582912`
+      #   mv /Applications/Xcode-12.beta.5.app /Volumes/xcode_disk/
+      #   ln -s /Volumes/xcode_disk/Xcode-12.beta.5.app /Applications/Xcode-12.beta.5.app
+      # fi
 
       # Lets generate a snapshot and mksnapshot and then delete all the x-compiled generated files to save space
       if [ "$USE_PREBUILT_V8_CONTEXT_SNAPSHOT" == "1" ]; then

--- a/.circleci/build_config.yml
+++ b/.circleci/build_config.yml
@@ -530,11 +530,11 @@ step-electron-build: &step-electron-build
       fi
       cd src
       # Enable if things get really bad
-      # if  [ "$TARGET_ARCH" == "arm64" ] &&[ "`uname`" == "Darwin" ]; then
-      #   diskutil erasevolume HFS+ "xcode_disk" `hdiutil attach -nomount ram://12582912`
-      #   mv /Applications/Xcode-12.beta.5.app /Volumes/xcode_disk/
-      #   ln -s /Volumes/xcode_disk/Xcode-12.beta.5.app /Applications/Xcode-12.beta.5.app
-      # fi
+      if [ "`uname`" == "Darwin" ]; then
+        diskutil erasevolume HFS+ "xcode_disk" `hdiutil attach -nomount ram://12582912`
+        mv /Applications/Xcode-12.beta.5.app /Volumes/xcode_disk/
+        ln -s /Volumes/xcode_disk/Xcode-12.beta.5.app /Applications/Xcode-12.beta.5.app
+      fi
 
       # Lets generate a snapshot and mksnapshot and then delete all the x-compiled generated files to save space
       if [ "$USE_PREBUILT_V8_CONTEXT_SNAPSHOT" == "1" ]; then

--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -35,9 +35,6 @@ enable_pseudolocales = false
 
 is_cfi = false
 
-# This consumes a bit too much disk space on macOS
-use_thin_lto = false
-
 # Make application name configurable at runtime for cookie crypto
 allow_runtime_configurable_key_storage = true
 

--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -112,3 +112,4 @@ feat_add_data_transfer_to_requestsingleinstancelock.patch
 fix_crash_when_saving_edited_pdf_files.patch
 port_autofill_colors_to_the_color_pipeline.patch
 build_disable_partition_alloc_on_mac.patch
+build_disable_thin_lto_on_mac.patch

--- a/patches/chromium/build_disable_thin_lto_on_mac.patch
+++ b/patches/chromium/build_disable_thin_lto_on_mac.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: VerteDinde <vertedinde@electronjs.org>
+Date: Tue, 1 Mar 2022 11:31:59 -0800
+Subject: build: disable thin lto on mac
+
+Ths build disables thin lto for mac, in order to preserve
+disk space on mac without breaking win-ia32.
+The patch can be removed when we have more disk space on CircleCI
+
+diff --git a/build/config/compiler/compiler.gni b/build/config/compiler/compiler.gni
+index 9d25c10587c7ab4e2053f8f69aef3f135ef8e9f9..8d8b8d13c62da1fdd051019c8b726de7d1783113 100644
+--- a/build/config/compiler/compiler.gni
++++ b/build/config/compiler/compiler.gni
+@@ -74,7 +74,7 @@ declare_args() {
+   use_thin_lto =
+       is_cfi ||
+       (is_clang && is_official_build && chrome_pgo_phase != 1 &&
+-       (is_linux || is_win || is_mac ||
++       (is_linux || is_win ||
+         (is_android && target_os != "chromeos") ||
+         ((is_chromeos_ash || is_chromeos_lacros) && is_chromeos_device)))
+ 


### PR DESCRIPTION
#### Description of Change

We recently disabled thin LTO for all builds in order to save disk space on Mac CircleCI jobs. However, this had the unintended side effect of breaking the publish job for Windows ia32.

This PR patches Chromium to disable thin LTO on Mac only.

I had tested using the new CircleCI executors on Mac, but we were still unfortunately running out of disk space. This should unblock our nightlies from failing, pending one other fix. Mac ARM publish jobs are still occasionally failing on a libswiftshader issue that is unrelated to this changes (was introduced in the last Chrome roll)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
