### PR TITLE
fix: settings not persisting across devtools loads

### DIFF
--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -853,18 +853,6 @@ void InspectableWebContents::SendJsonRequest(DispatchCallback callback,
   std::move(callback).Run(nullptr);
 }
 
-void InspectableWebContents::RegisterPreference(
-    const std::string& name,
-    const RegisterOptions& options) {
-  const std::string* settings_value =
-      pref_service_->GetDictionary(kDevToolsPreferences)->FindStringKey(name);
-  if (!settings_value)
-    return;
-
-  DictionaryPrefUpdate insert_update(pref_service_, kDevToolsPreferences);
-  insert_update.Get()->SetKey(name, base::Value(*settings_value));
-}
-
 void InspectableWebContents::GetPreferences(DispatchCallback callback) {
   const base::Value* prefs = pref_service_->GetDictionary(kDevToolsPreferences);
   std::move(callback).Run(prefs);

--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -86,13 +86,6 @@ const char kChromeUIDevToolsRemoteFrontendPath[] = "serve_file";
 const char kDevToolsBoundsPref[] = "electron.devtools.bounds";
 const char kDevToolsZoomPref[] = "electron.devtools.zoom";
 const char kDevToolsPreferences[] = "electron.devtools.preferences";
-const char kDevToolsSyncPreferences[] = "electron.devtools.sync_preferences";
-const char kDevToolsSyncedPreferencesSyncEnabled[] =
-    "electron.devtools.synced_preferences_sync_enabled";
-const char kDevToolsSyncedPreferencesSyncDisabled[] =
-    "electron.devtools.synced_preferences_sync_disabled";
-const char kSyncDevToolsPreferencesFrontendName[] = "electron.sync_preferences";
-const bool kSyncDevToolsPreferencesDefault = false;
 
 const char kFrontendHostId[] = "id";
 const char kFrontendHostMethod[] = "method";
@@ -342,10 +335,6 @@ void InspectableWebContents::RegisterPrefs(PrefRegistrySimple* registry) {
                                    RectToDictionary(gfx::Rect(0, 0, 800, 600)));
   registry->RegisterDoublePref(kDevToolsZoomPref, 0.);
   registry->RegisterDictionaryPref(kDevToolsPreferences);
-  registry->RegisterDictionaryPref(kDevToolsSyncedPreferencesSyncEnabled);
-  registry->RegisterDictionaryPref(kDevToolsSyncedPreferencesSyncDisabled);
-  registry->RegisterBooleanPref(kDevToolsSyncPreferences,
-                                kSyncDevToolsPreferencesDefault);
 }
 
 InspectableWebContents::InspectableWebContents(
@@ -867,78 +856,24 @@ void InspectableWebContents::SendJsonRequest(DispatchCallback callback,
 void InspectableWebContents::RegisterPreference(
     const std::string& name,
     const RegisterOptions& options) {
-  // kSyncDevToolsPreferenceFrontendName is not stored in any of the relevant
-  // dictionaries. Skip registration.
-  if (name == kSyncDevToolsPreferencesFrontendName)
-    return;
-
-  if (options.sync_mode == RegisterOptions::SyncMode::kSync) {
-    synced_setting_names_.insert(name);
-  }
-
-  // Setting might have had a different sync status in the past. Move the
-  // setting to the correct dictionary.
-  const char* dictionary_to_remove_from =
-      options.sync_mode == RegisterOptions::SyncMode::kSync
-          ? kDevToolsPreferences
-          : GetDictionaryNameForSyncedPrefs();
   const std::string* settings_value =
-      pref_service_->GetDictionary(dictionary_to_remove_from)
-          ->FindStringKey(name);
-  if (!settings_value) {
+      pref_service_->GetDictionary(kDevToolsPreferences)->FindStringKey(name);
+  if (!settings_value)
     return;
-  }
 
-  const char* dictionary_to_insert_into =
-      GetDictionaryNameForSettingsName(name);
-  // Settings already moved to the synced dictionary on a different device have
-  // precedence.
-  const std::string* already_synced_value =
-      pref_service_->GetDictionary(dictionary_to_insert_into)
-          ->FindStringKey(name);
-  if (dictionary_to_insert_into == kDevToolsPreferences ||
-      !already_synced_value) {
-    DictionaryPrefUpdate insert_update(pref_service_,
-                                       dictionary_to_insert_into);
-    insert_update.Get()->SetKey(name, base::Value(*settings_value));
-  }
-
-  DictionaryPrefUpdate remove_update(pref_service_, dictionary_to_remove_from);
-  remove_update.Get()->RemoveKey(name);
+  DictionaryPrefUpdate insert_update(pref_service_, kDevToolsPreferences);
+  insert_update.Get()->SetKey(name, base::Value(*settings_value));
 }
 
 void InspectableWebContents::GetPreferences(DispatchCallback callback) {
-  base::Value settings(base::Value::Type::DICTIONARY);
-  settings.SetBoolKey(kSyncDevToolsPreferencesFrontendName,
-                      pref_service_->GetBoolean(kDevToolsSyncPreferences));
-  settings.MergeDictionary(pref_service_->GetDictionary(kDevToolsPreferences));
-  settings.MergeDictionary(
-      pref_service_->GetDictionary(GetDictionaryNameForSyncedPrefs()));
-
-  std::move(callback).Run(&settings);
+  const base::Value* prefs = pref_service_->GetDictionary(kDevToolsPreferences);
+  std::move(callback).Run(prefs);
 }
 
 void InspectableWebContents::GetPreference(DispatchCallback callback,
                                            const std::string& name) {
-  // Handle kSyncDevToolsPreferencesFrontendName
-  if (name == kSyncDevToolsPreferencesFrontendName) {
-    base::Value pref =
-        base::Value(pref_service_->GetBoolean(kDevToolsSyncPreferences));
-    std::move(callback).Run(&pref);
-    return;
-  }
-
-  // Check dev tools prefs
   if (auto* pref =
           pref_service_->GetDictionary(kDevToolsPreferences)->FindKey(name)) {
-    std::move(callback).Run(pref);
-    return;
-  }
-
-  // Check synced prefs
-  if (auto* pref =
-          pref_service_->GetDictionary(GetDictionaryNameForSyncedPrefs())
-              ->FindKey(name)) {
     std::move(callback).Run(pref);
     return;
   }
@@ -950,41 +885,21 @@ void InspectableWebContents::GetPreference(DispatchCallback callback,
 
 void InspectableWebContents::SetPreference(const std::string& name,
                                            const std::string& value) {
-  if (name == kSyncDevToolsPreferencesFrontendName) {
-    pref_service_->SetBoolean(kDevToolsSyncPreferences, value == "true");
-    return;
-  }
-  DictionaryPrefUpdate update(pref_service_,
-                              GetDictionaryNameForSettingsName(name));
+  DictionaryPrefUpdate update(pref_service_, kDevToolsPreferences);
   update.Get()->SetKey(name, base::Value(value));
 }
 
 void InspectableWebContents::RemovePreference(const std::string& name) {
-  if (name == kSyncDevToolsPreferencesFrontendName) {
-    pref_service_->SetBoolean(kDevToolsSyncPreferences,
-                              kSyncDevToolsPreferencesDefault);
-    return;
-  }
-  DictionaryPrefUpdate update(pref_service_,
-                              GetDictionaryNameForSettingsName(name));
+  DictionaryPrefUpdate update(pref_service_, kDevToolsPreferences);
   update.Get()->RemoveKey(name);
 }
 
 void InspectableWebContents::ClearPreferences() {
-  pref_service_->SetBoolean(kDevToolsSyncPreferences,
-                            kSyncDevToolsPreferencesDefault);
   DictionaryPrefUpdate unsynced_update(pref_service_, kDevToolsPreferences);
   unsynced_update.Get()->DictClear();
-  DictionaryPrefUpdate sync_enabled_update(
-      pref_service_, kDevToolsSyncedPreferencesSyncEnabled);
-  sync_enabled_update.Get()->DictClear();
-  DictionaryPrefUpdate sync_disabled_update(
-      pref_service_, kDevToolsSyncedPreferencesSyncDisabled);
-  sync_disabled_update.Get()->DictClear();
 }
 
 void InspectableWebContents::GetSyncInformation(DispatchCallback callback) {
-  // TODO(anyone): do we want devtool syncing in Electron?
   base::Value result(base::Value::Type::DICTIONARY);
   result.SetBoolKey("isSyncActive", false);
   std::move(callback).Run(&result);
@@ -1167,20 +1082,6 @@ void InspectableWebContents::SendMessageAck(int request_id,
                                             const base::Value* arg) {
   base::Value id_value(request_id);
   CallClientFunction("DevToolsAPI.embedderMessageAck", &id_value, arg, nullptr);
-}
-
-const char* InspectableWebContents::GetDictionaryNameForSettingsName(
-    const std::string& name) const {
-  return synced_setting_names_.contains(name)
-             ? kDevToolsSyncedPreferencesSyncEnabled
-             : kDevToolsPreferences;
-}
-
-const char* InspectableWebContents::GetDictionaryNameForSyncedPrefs() const {
-  const bool isDevToolsSyncEnabled =
-      pref_service_->GetBoolean(kDevToolsSyncPreferences);
-  return isDevToolsSyncEnabled ? kDevToolsSyncedPreferencesSyncEnabled
-                               : kDevToolsSyncedPreferencesSyncDisabled;
 }
 
 }  // namespace electron

--- a/shell/browser/ui/inspectable_web_contents.h
+++ b/shell/browser/ui/inspectable_web_contents.h
@@ -140,7 +140,7 @@ class InspectableWebContents
                        const std::string& browser_id,
                        const std::string& url) override;
   void RegisterPreference(const std::string& name,
-                          const RegisterOptions& options) override;
+                          const RegisterOptions& options) override {}
   void GetPreferences(DispatchCallback callback) override;
   void GetPreference(DispatchCallback callback,
                      const std::string& name) override;

--- a/shell/browser/ui/inspectable_web_contents.h
+++ b/shell/browser/ui/inspectable_web_contents.h
@@ -198,9 +198,6 @@ class InspectableWebContents
 
   void SendMessageAck(int request_id, const base::Value* arg1);
 
-  const char* GetDictionaryNameForSettingsName(const std::string& name) const;
-  const char* GetDictionaryNameForSyncedPrefs() const;
-
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   void AddDevToolsExtensionsToClient();
 #endif


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/33102.
Closes https://github.com/electron/electron/issues/31864.

In https://github.com/electron/electron/issues/31317 we adapted to changes in [this crbug](https://bugs.chromium.org/p/chromium/issues/detail?id=1245541), which inadvertently caused issues since we don't support synced settings in Electron. Synced settings are settings which persist across Chrome profiles, which is a concept we don't have in Electron. This removes code related to the synced settings, which caused devtools settings not to persist between loads.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where Chrom DevTools settings didn't persist between loads.