### PR TITLE
fix: really strip crashpad handler binary

### DIFF
--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -15,7 +15,7 @@ PLATFORM = {
 
 LINUX_BINARIES = [
   'chrome-sandbox',
-  'crashpad_handler',
+  'chrome_crashpad_handler',
   'electron',
   'libEGL.so',
   'libGLESv2.so',


### PR DESCRIPTION
#### Description of Change
Apparently #32540 didn't do the trick. This PR should finally remove the crashpad_handler binary from the linux build.

cc @nornagon 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Strip crashpad_handler binary on Linux, reducing bundle size.
