### PR TITLE
feat: Allow creation of new window to be customisable in order to support window.opener in BrowserView.

### DIFF
--- a/docs/api/structures/window-open-handler-response.md
+++ b/docs/api/structures/window-open-handler-response.md
@@ -1,0 +1,6 @@
+# WindowOpenHandlerResponse Object
+
+* `action` string - Can be `allow` or `deny`. Controls whether new window should be created.
+* `overrideBrowserWindowOptions` BrowserWindowConstructorOptions (optional) - Allows customization of the created window.
+* `outlivesOpener` boolean (optional) - Controls whether created window should stay open when its opener was closed.
+* `createWindow` (options: BrowserWindowConstructorOptions) => WebContents (optional) - If specified, will be called instead of `new BrowserWindow` to create the new child window and event [`did-create-window`](../web-contents.md#event-did-create-window) will not be emitted. Constructed child window should use passed `options` object. This can be used for example to have the new window open as a BrowserView instead of in a separate window.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -1287,7 +1287,7 @@ Ignore application menu shortcuts while this web contents is focused.
 
 #### `contents.setWindowOpenHandler(handler)`
 
-* `handler` Function<{action: 'deny'} | {action: 'allow', outlivesOpener?: boolean, overrideBrowserWindowOptions?: BrowserWindowConstructorOptions}>
+* `handler` Function<[WindowOpenHandlerResponse](structures/window-open-handler-response.md)>
   * `details` Object
     * `url` string - The _resolved_ version of the URL passed to `window.open()`. e.g. opening a window with `window.open('foo')` will yield something like `https://the-origin/the/current/path/foo`.
     * `frameName` string - Name of the window provided in `window.open()`
@@ -1302,11 +1302,11 @@ Ignore application menu shortcuts while this web contents is focused.
       be set. If no post data is to be sent, the value will be `null`. Only defined
       when the window is being created by a form that set `target=_blank`.
 
-  Returns `{action: 'deny'} | {action: 'allow', outlivesOpener?: boolean, overrideBrowserWindowOptions?: BrowserWindowConstructorOptions}` - `deny` cancels the creation of the new
-  window. `allow` will allow the new window to be created. Specifying `overrideBrowserWindowOptions` allows customization of the created window.
+  Returns `WindowOpenHandlerResponse` -  When set to `{ action: 'deny' }` cancels the creation of the new
+  window. `{ action: 'allow' }` will allow the new window to be created. Specifying `overrideBrowserWindowOptions` allows customization of the created window.
   By default, child windows are closed when their opener is closed. This can be
-  changed by specifying `outlivesOpener: true`, in which case the opened window
-  will not be closed when its opener is closed.
+  changed by specifying `outlivesOpener: true`, in which case the opened window will not be closed when its opener is closed.
+  Specifying `createWindow` allows to customize the way that window is created.
   Returning an unrecognized value such as a null, undefined, or an object
   without a recognized 'action' value will result in a console error and have
   the same effect as returning `{action: 'deny'}`.
@@ -1316,6 +1316,22 @@ by `window.open()`, a link with `target="_blank"`, shift+clicking on a link, or
 submitting a form with `<form target="_blank">`. See
 [`window.open()`](window-open.md) for more details and how to use this in
 conjunction with `did-create-window`.
+
+An example showing how to customize the process of new `BrowserWindow` creation to be `BrowserView` attached to main window instead:
+
+```javascript
+webContents.setWindowOpenHandler((details) => {
+  return {
+    action: 'allow',
+    createWindow: (options) => {
+      const browserView = new BrowserView(options)
+      mainWindow.addBrowserView(browserView)
+      browserView.setBounds({ x: 0, y: 0, width: 640, height: 480 })
+      return browserView.webContents
+    }
+  }
+})
+```
 
 #### `contents.setAudioMuted(muted)`
 

--- a/filenames.auto.gni
+++ b/filenames.auto.gni
@@ -139,6 +139,7 @@ auto_filenames = {
     "docs/api/structures/web-preferences.md",
     "docs/api/structures/web-request-filter.md",
     "docs/api/structures/web-source.md",
+    "docs/api/structures/window-open-handler-response.md",
   ]
 
   sandbox_bundle_deps = [

--- a/spec/guest-window-manager-spec.ts
+++ b/spec/guest-window-manager-spec.ts
@@ -1,220 +1,380 @@
 import { BrowserWindow, screen } from 'electron';
 import { expect, assert } from 'chai';
 import { areColorsSimilar, captureScreen, HexColors, getPixelColor } from './lib/screen-helpers';
-import { ifit } from './lib/spec-helpers';
+import { ifit, listen } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';
 import { once } from 'node:events';
 import { setTimeout as setTimeoutAsync } from 'node:timers/promises';
+import * as http from 'http';
 
 describe('webContents.setWindowOpenHandler', () => {
-  let browserWindow: BrowserWindow;
-  beforeEach(async () => {
-    browserWindow = new BrowserWindow({ show: false });
-    await browserWindow.loadURL('about:blank');
-  });
+  describe('native window', () => {
+    let browserWindow: BrowserWindow;
+    beforeEach(async () => {
+      browserWindow = new BrowserWindow({ show: false });
+      await browserWindow.loadURL('about:blank');
+    });
 
-  afterEach(closeAllWindows);
+    afterEach(closeAllWindows);
 
-  it('does not fire window creation events if the handler callback throws an error', (done) => {
-    const error = new Error('oh no');
-    const listeners = process.listeners('uncaughtException');
-    process.removeAllListeners('uncaughtException');
-    process.on('uncaughtException', (thrown) => {
-      try {
-        expect(thrown).to.equal(error);
-        done();
-      } catch (e) {
-        done(e);
-      } finally {
-        process.removeAllListeners('uncaughtException');
-        for (const listener of listeners) {
-          process.on('uncaughtException', listener);
+    it('does not fire window creation events if the handler callback throws an error', (done) => {
+      const error = new Error('oh no');
+      const listeners = process.listeners('uncaughtException');
+      process.removeAllListeners('uncaughtException');
+      process.on('uncaughtException', (thrown) => {
+        try {
+          expect(thrown).to.equal(error);
+          done();
+        } catch (e) {
+          done(e);
+        } finally {
+          process.removeAllListeners('uncaughtException');
+          for (const listener of listeners) {
+            process.on('uncaughtException', listener);
+          }
         }
-      }
-    });
-
-    browserWindow.webContents.on('did-create-window', () => {
-      assert.fail('did-create-window should not be called with an overridden window.open');
-    });
-
-    browserWindow.webContents.executeJavaScript("window.open('about:blank', '', 'show=no') && true");
-
-    browserWindow.webContents.setWindowOpenHandler(() => {
-      throw error;
-    });
-  });
-
-  it('does not fire window creation events if the handler callback returns a bad result', async () => {
-    const bad = new Promise((resolve) => {
-      browserWindow.webContents.setWindowOpenHandler(() => {
-        setTimeout(resolve);
-        return [1, 2, 3] as any;
-      });
-    });
-
-    browserWindow.webContents.on('did-create-window', () => {
-      assert.fail('did-create-window should not be called with an overridden window.open');
-    });
-
-    browserWindow.webContents.executeJavaScript("window.open('about:blank', '', 'show=no') && true");
-
-    await bad;
-  });
-
-  it('does not fire window creation events if an override returns action: deny', async () => {
-    const denied = new Promise((resolve) => {
-      browserWindow.webContents.setWindowOpenHandler(() => {
-        setTimeout(resolve);
-        return { action: 'deny' };
-      });
-    });
-
-    browserWindow.webContents.on('did-create-window', () => {
-      assert.fail('did-create-window should not be called with an overridden window.open');
-    });
-
-    browserWindow.webContents.executeJavaScript("window.open('about:blank', '', 'show=no') && true");
-
-    await denied;
-  });
-
-  it('is called when clicking on a target=_blank link', async () => {
-    const denied = new Promise((resolve) => {
-      browserWindow.webContents.setWindowOpenHandler(() => {
-        setTimeout(resolve);
-        return { action: 'deny' };
-      });
-    });
-
-    browserWindow.webContents.on('did-create-window', () => {
-      assert.fail('did-create-window should not be called with an overridden window.open');
-    });
-
-    await browserWindow.webContents.loadURL('data:text/html,<a target="_blank" href="http://example.com" style="display: block; width: 100%; height: 100%; position: fixed; left: 0; top: 0;">link</a>');
-    browserWindow.webContents.sendInputEvent({ type: 'mouseDown', x: 10, y: 10, button: 'left', clickCount: 1 });
-    browserWindow.webContents.sendInputEvent({ type: 'mouseUp', x: 10, y: 10, button: 'left', clickCount: 1 });
-
-    await denied;
-  });
-
-  it('is called when shift-clicking on a link', async () => {
-    const denied = new Promise((resolve) => {
-      browserWindow.webContents.setWindowOpenHandler(() => {
-        setTimeout(resolve);
-        return { action: 'deny' };
-      });
-    });
-
-    browserWindow.webContents.on('did-create-window', () => {
-      assert.fail('did-create-window should not be called with an overridden window.open');
-    });
-
-    await browserWindow.webContents.loadURL('data:text/html,<a href="http://example.com" style="display: block; width: 100%; height: 100%; position: fixed; left: 0; top: 0;">link</a>');
-    browserWindow.webContents.sendInputEvent({ type: 'mouseDown', x: 10, y: 10, button: 'left', clickCount: 1, modifiers: ['shift'] });
-    browserWindow.webContents.sendInputEvent({ type: 'mouseUp', x: 10, y: 10, button: 'left', clickCount: 1, modifiers: ['shift'] });
-
-    await denied;
-  });
-
-  it('fires handler with correct params', async () => {
-    const testFrameName = 'test-frame-name';
-    const testFeatures = 'top=10&left=10&something-unknown&show=no';
-    const testUrl = 'app://does-not-exist/';
-    const details = await new Promise<Electron.HandlerDetails>(resolve => {
-      browserWindow.webContents.setWindowOpenHandler((details) => {
-        setTimeout(() => resolve(details));
-        return { action: 'deny' };
       });
 
-      browserWindow.webContents.executeJavaScript(`window.open('${testUrl}', '${testFrameName}', '${testFeatures}') && true`);
-    });
-    const { url, frameName, features, disposition, referrer } = details;
-    expect(url).to.equal(testUrl);
-    expect(frameName).to.equal(testFrameName);
-    expect(features).to.equal(testFeatures);
-    expect(disposition).to.equal('new-window');
-    expect(referrer).to.deep.equal({
-      policy: 'strict-origin-when-cross-origin',
-      url: ''
-    });
-  });
-
-  it('includes post body', async () => {
-    const details = await new Promise<Electron.HandlerDetails>(resolve => {
-      browserWindow.webContents.setWindowOpenHandler((details) => {
-        setTimeout(() => resolve(details));
-        return { action: 'deny' };
+      browserWindow.webContents.on('did-create-window', () => {
+        assert.fail('did-create-window should not be called with an overridden window.open');
       });
 
-      browserWindow.webContents.loadURL(`data:text/html,${encodeURIComponent(`
-        <form action="http://example.com" target="_blank" method="POST" id="form">
-          <input name="key" value="value"></input>
-        </form>
-        <script>form.submit()</script>
-      `)}`);
-    });
-    const { url, frameName, features, disposition, referrer, postBody } = details;
-    expect(url).to.equal('http://example.com/');
-    expect(frameName).to.equal('');
-    expect(features).to.deep.equal('');
-    expect(disposition).to.equal('foreground-tab');
-    expect(referrer).to.deep.equal({
-      policy: 'strict-origin-when-cross-origin',
-      url: ''
-    });
-    expect(postBody).to.deep.equal({
-      contentType: 'application/x-www-form-urlencoded',
-      data: [{
-        type: 'rawData',
-        bytes: Buffer.from('key=value')
-      }]
-    });
-  });
-
-  it('does fire window creation events if an override returns action: allow', async () => {
-    browserWindow.webContents.setWindowOpenHandler(() => ({ action: 'allow' }));
-
-    setImmediate(() => {
       browserWindow.webContents.executeJavaScript("window.open('about:blank', '', 'show=no') && true");
+
+      browserWindow.webContents.setWindowOpenHandler(() => {
+        throw error;
+      });
     });
 
-    await once(browserWindow.webContents, 'did-create-window');
-  });
+    it('does not fire window creation events if the handler callback returns a bad result', async () => {
+      const bad = new Promise((resolve) => {
+        browserWindow.webContents.setWindowOpenHandler(() => {
+          setTimeout(resolve);
+          return [1, 2, 3] as any;
+        });
+      });
 
-  it('can change webPreferences of child windows', async () => {
-    browserWindow.webContents.setWindowOpenHandler(() => ({ action: 'allow', overrideBrowserWindowOptions: { webPreferences: { defaultFontSize: 30 } } }));
+      browserWindow.webContents.on('did-create-window', () => {
+        assert.fail('did-create-window should not be called with an overridden window.open');
+      });
 
-    const didCreateWindow = once(browserWindow.webContents, 'did-create-window') as Promise<[BrowserWindow, Electron.DidCreateWindowDetails]>;
-    browserWindow.webContents.executeJavaScript("window.open('about:blank', '', 'show=no') && true");
-    const [childWindow] = await didCreateWindow;
+      browserWindow.webContents.executeJavaScript("window.open('about:blank', '', 'show=no') && true");
 
-    await childWindow.webContents.executeJavaScript("document.write('hello')");
-    const size = await childWindow.webContents.executeJavaScript("getComputedStyle(document.querySelector('body')).fontSize");
-    expect(size).to.equal('30px');
-  });
-
-  it('does not hang parent window when denying window.open', async () => {
-    browserWindow.webContents.setWindowOpenHandler(() => ({ action: 'deny' }));
-    browserWindow.webContents.executeJavaScript("window.open('https://127.0.0.1')");
-    expect(await browserWindow.webContents.executeJavaScript('42')).to.equal(42);
-  });
-
-  // Linux and arm64 platforms (WOA and macOS) do not return any capture sources
-  ifit(process.platform === 'darwin' && process.arch === 'x64')('should not make child window background transparent', async () => {
-    browserWindow.webContents.setWindowOpenHandler(() => ({ action: 'allow' }));
-    const didCreateWindow = once(browserWindow.webContents, 'did-create-window');
-    browserWindow.webContents.executeJavaScript("window.open('about:blank') && true");
-    const [childWindow] = await didCreateWindow;
-    const display = screen.getPrimaryDisplay();
-    childWindow.setBounds(display.bounds);
-    await childWindow.webContents.executeJavaScript("const meta = document.createElement('meta'); meta.name = 'color-scheme'; meta.content = 'dark'; document.head.appendChild(meta); true;");
-    await setTimeoutAsync(1000);
-    const screenCapture = await captureScreen();
-    const centerColor = getPixelColor(screenCapture, {
-      x: display.size.width / 2,
-      y: display.size.height / 2
+      await bad;
     });
-    // color-scheme is set to dark so background should not be white
-    expect(areColorsSimilar(centerColor, HexColors.WHITE)).to.be.false();
+
+    it('does not fire window creation events if an override returns action: deny', async () => {
+      const denied = new Promise((resolve) => {
+        browserWindow.webContents.setWindowOpenHandler(() => {
+          setTimeout(resolve);
+          return { action: 'deny' };
+        });
+      });
+
+      browserWindow.webContents.on('did-create-window', () => {
+        assert.fail('did-create-window should not be called with an overridden window.open');
+      });
+
+      browserWindow.webContents.executeJavaScript("window.open('about:blank', '', 'show=no') && true");
+
+      await denied;
+    });
+
+    it('is called when clicking on a target=_blank link', async () => {
+      const denied = new Promise((resolve) => {
+        browserWindow.webContents.setWindowOpenHandler(() => {
+          setTimeout(resolve);
+          return { action: 'deny' };
+        });
+      });
+
+      browserWindow.webContents.on('did-create-window', () => {
+        assert.fail('did-create-window should not be called with an overridden window.open');
+      });
+
+      await browserWindow.webContents.loadURL('data:text/html,<a target="_blank" href="http://example.com" style="display: block; width: 100%; height: 100%; position: fixed; left: 0; top: 0;">link</a>');
+      browserWindow.webContents.sendInputEvent({ type: 'mouseDown', x: 10, y: 10, button: 'left', clickCount: 1 });
+      browserWindow.webContents.sendInputEvent({ type: 'mouseUp', x: 10, y: 10, button: 'left', clickCount: 1 });
+
+      await denied;
+    });
+
+    it('is called when shift-clicking on a link', async () => {
+      const denied = new Promise((resolve) => {
+        browserWindow.webContents.setWindowOpenHandler(() => {
+          setTimeout(resolve);
+          return { action: 'deny' };
+        });
+      });
+
+      browserWindow.webContents.on('did-create-window', () => {
+        assert.fail('did-create-window should not be called with an overridden window.open');
+      });
+
+      await browserWindow.webContents.loadURL('data:text/html,<a href="http://example.com" style="display: block; width: 100%; height: 100%; position: fixed; left: 0; top: 0;">link</a>');
+      browserWindow.webContents.sendInputEvent({ type: 'mouseDown', x: 10, y: 10, button: 'left', clickCount: 1, modifiers: ['shift'] });
+      browserWindow.webContents.sendInputEvent({ type: 'mouseUp', x: 10, y: 10, button: 'left', clickCount: 1, modifiers: ['shift'] });
+
+      await denied;
+    });
+
+    it('fires handler with correct params', async () => {
+      const testFrameName = 'test-frame-name';
+      const testFeatures = 'top=10&left=10&something-unknown&show=no';
+      const testUrl = 'app://does-not-exist/';
+      const details = await new Promise<Electron.HandlerDetails>(resolve => {
+        browserWindow.webContents.setWindowOpenHandler((details) => {
+          setTimeout(() => resolve(details));
+          return { action: 'deny' };
+        });
+
+        browserWindow.webContents.executeJavaScript(`window.open('${testUrl}', '${testFrameName}', '${testFeatures}') && true`);
+      });
+      const { url, frameName, features, disposition, referrer } = details;
+      expect(url).to.equal(testUrl);
+      expect(frameName).to.equal(testFrameName);
+      expect(features).to.equal(testFeatures);
+      expect(disposition).to.equal('new-window');
+      expect(referrer).to.deep.equal({
+        policy: 'strict-origin-when-cross-origin',
+        url: ''
+      });
+    });
+
+    it('includes post body', async () => {
+      const details = await new Promise<Electron.HandlerDetails>(resolve => {
+        browserWindow.webContents.setWindowOpenHandler((details) => {
+          setTimeout(() => resolve(details));
+          return { action: 'deny' };
+        });
+
+        browserWindow.webContents.loadURL(`data:text/html,${encodeURIComponent(`
+          <form action="http://example.com" target="_blank" method="POST" id="form">
+            <input name="key" value="value"></input>
+          </form>
+          <script>form.submit()</script>
+        `)}`);
+      });
+      const { url, frameName, features, disposition, referrer, postBody } = details;
+      expect(url).to.equal('http://example.com/');
+      expect(frameName).to.equal('');
+      expect(features).to.deep.equal('');
+      expect(disposition).to.equal('foreground-tab');
+      expect(referrer).to.deep.equal({
+        policy: 'strict-origin-when-cross-origin',
+        url: ''
+      });
+      expect(postBody).to.deep.equal({
+        contentType: 'application/x-www-form-urlencoded',
+        data: [{
+          type: 'rawData',
+          bytes: Buffer.from('key=value')
+        }]
+      });
+    });
+
+    it('does fire window creation events if an override returns action: allow', async () => {
+      browserWindow.webContents.setWindowOpenHandler(() => ({ action: 'allow' }));
+
+      setImmediate(() => {
+        browserWindow.webContents.executeJavaScript("window.open('about:blank', '', 'show=no') && true");
+      });
+
+      await once(browserWindow.webContents, 'did-create-window');
+    });
+
+    it('can change webPreferences of child windows', async () => {
+      browserWindow.webContents.setWindowOpenHandler(() => ({ action: 'allow', overrideBrowserWindowOptions: { webPreferences: { defaultFontSize: 30 } } }));
+
+      const didCreateWindow = once(browserWindow.webContents, 'did-create-window') as Promise<[BrowserWindow, Electron.DidCreateWindowDetails]>;
+      browserWindow.webContents.executeJavaScript("window.open('about:blank', '', 'show=no') && true");
+      const [childWindow] = await didCreateWindow;
+
+      await childWindow.webContents.executeJavaScript("document.write('hello')");
+      const size = await childWindow.webContents.executeJavaScript("getComputedStyle(document.querySelector('body')).fontSize");
+      expect(size).to.equal('30px');
+    });
+
+    it('does not hang parent window when denying window.open', async () => {
+      browserWindow.webContents.setWindowOpenHandler(() => ({ action: 'deny' }));
+      browserWindow.webContents.executeJavaScript("window.open('https://127.0.0.1')");
+      expect(await browserWindow.webContents.executeJavaScript('42')).to.equal(42);
+    });
+
+    // Linux and arm64 platforms (WOA and macOS) do not return any capture sources
+    ifit(process.platform === 'darwin' && process.arch === 'x64')('should not make child window background transparent', async () => {
+      browserWindow.webContents.setWindowOpenHandler(() => ({ action: 'allow' }));
+      const didCreateWindow = once(browserWindow.webContents, 'did-create-window');
+      browserWindow.webContents.executeJavaScript("window.open('about:blank') && true");
+      const [childWindow] = await didCreateWindow;
+      const display = screen.getPrimaryDisplay();
+      childWindow.setBounds(display.bounds);
+      await childWindow.webContents.executeJavaScript("const meta = document.createElement('meta'); meta.name = 'color-scheme'; meta.content = 'dark'; document.head.appendChild(meta); true;");
+      await setTimeoutAsync(1000);
+      const screenCapture = await captureScreen();
+      const centerColor = getPixelColor(screenCapture, {
+        x: display.size.width / 2,
+        y: display.size.height / 2
+      });
+      // color-scheme is set to dark so background should not be white
+      expect(areColorsSimilar(centerColor, HexColors.WHITE)).to.be.false();
+    });
+  });
+
+  describe('custom window', () => {
+    let browserWindow: BrowserWindow;
+
+    let server: http.Server;
+    let url: string;
+
+    before(async () => {
+      server = http.createServer((request, response) => {
+        switch (request.url) {
+          case '/index':
+            response.statusCode = 200;
+            response.end('<title>Index page</title>');
+            break;
+          case '/child':
+            response.statusCode = 200;
+            response.end('<title>Child page</title>');
+            break;
+          default:
+            throw new Error(`Unsupported endpoint: ${request.url}`);
+        }
+      });
+
+      url = (await listen(server)).url;
+    });
+
+    after(() => {
+      server.close();
+    });
+
+    beforeEach(async () => {
+      browserWindow = new BrowserWindow({ show: false });
+      await browserWindow.loadURL(`${url}/index`);
+    });
+
+    afterEach(closeAllWindows);
+
+    it('throws error when created window uses invalid webcontents', async () => {
+      const listeners = process.listeners('uncaughtException');
+      process.removeAllListeners('uncaughtException');
+      const uncaughtExceptionEmitted = new Promise<void>((resolve, reject) => {
+        process.on('uncaughtException', (thrown) => {
+          try {
+            expect(thrown.message).to.equal('Invalid webContents. Created window should be connected to webContents passed with options object.');
+            resolve();
+          } catch (e) {
+            reject(e);
+          } finally {
+            process.removeAllListeners('uncaughtException');
+            listeners.forEach((listener) => process.on('uncaughtException', listener));
+          }
+        });
+      });
+
+      browserWindow.webContents.setWindowOpenHandler(() => {
+        return {
+          action: 'allow',
+          createWindow: () => {
+            const childWindow = new BrowserWindow({ title: 'New window' });
+            return childWindow.webContents;
+          }
+        };
+      });
+
+      browserWindow.webContents.executeJavaScript("window.open('about:blank', '', 'show=no') && true");
+
+      await uncaughtExceptionEmitted;
+    });
+
+    it('spawns browser window when createWindow is provided', async () => {
+      const browserWindowTitle = 'Child browser window';
+
+      const childWindow = await new Promise<Electron.BrowserWindow>(resolve => {
+        browserWindow.webContents.setWindowOpenHandler(() => {
+          return {
+            action: 'allow',
+            createWindow: (options) => {
+              const childWindow = new BrowserWindow({ ...options, title: browserWindowTitle });
+              resolve(childWindow);
+              return childWindow.webContents;
+            }
+          };
+        });
+
+        browserWindow.webContents.executeJavaScript("window.open('about:blank', '', 'show=no') && true");
+      });
+
+      expect(childWindow.title).to.equal(browserWindowTitle);
+    });
+
+    it('spawns browser window with overriden options', async () => {
+      const childWindow = await new Promise<Electron.BrowserWindow>(resolve => {
+        browserWindow.webContents.setWindowOpenHandler(() => {
+          return {
+            action: 'allow',
+            overrideBrowserWindowOptions: {
+              width: 640,
+              height: 480
+            },
+            createWindow: (options) => {
+              expect(options.width).to.equal(640);
+              expect(options.height).to.equal(480);
+              const childWindow = new BrowserWindow(options);
+              resolve(childWindow);
+              return childWindow.webContents;
+            }
+          };
+        });
+
+        browserWindow.webContents.executeJavaScript("window.open('about:blank', '', 'show=no') && true");
+      });
+
+      const size = childWindow.getSize();
+      expect(size[0]).to.equal(640);
+      expect(size[1]).to.equal(480);
+    });
+
+    it('spawns browser window with access to opener property', async () => {
+      const childWindow = await new Promise<Electron.BrowserWindow>(resolve => {
+        browserWindow.webContents.setWindowOpenHandler(() => {
+          return {
+            action: 'allow',
+            createWindow: (options) => {
+              const childWindow = new BrowserWindow(options);
+              resolve(childWindow);
+              return childWindow.webContents;
+            }
+          };
+        });
+
+        browserWindow.webContents.executeJavaScript(`window.open('${url}/child', '', 'show=no') && true`);
+      });
+
+      await once(childWindow.webContents, 'ready-to-show');
+      const childWindowOpenerTitle = await childWindow.webContents.executeJavaScript('window.opener.document.title');
+      expect(childWindowOpenerTitle).to.equal(browserWindow.title);
+    });
+
+    it('spawns browser window without access to opener property because of noopener attribute ', async () => {
+      const childWindow = await new Promise<Electron.BrowserWindow>(resolve => {
+        browserWindow.webContents.setWindowOpenHandler(() => {
+          return {
+            action: 'allow',
+            createWindow: (options) => {
+              const childWindow = new BrowserWindow(options);
+              resolve(childWindow);
+              return childWindow.webContents;
+            }
+          };
+        });
+        browserWindow.webContents.executeJavaScript(`window.open('${url}/child', '', 'noopener,show=no') && true`);
+      });
+
+      await once(childWindow.webContents, 'ready-to-show');
+      await expect(childWindow.webContents.executeJavaScript('window.opener.document.title')).to.be.rejectedWith('Script failed to execute, this normally means an error was thrown. Check the renderer console for the error.');
+    });
   });
 });

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -70,7 +70,7 @@ declare namespace Electron {
     equal(other: WebContents): boolean;
     browserWindowOptions: BrowserWindowConstructorOptions;
     _windowOpenHandler: ((details: Electron.HandlerDetails) => any) | null;
-    _callWindowOpenHandler(event: any, details: Electron.HandlerDetails): {browserWindowConstructorOptions: Electron.BrowserWindowConstructorOptions | null, outlivesOpener: boolean};
+    _callWindowOpenHandler(event: any, details: Electron.HandlerDetails): {browserWindowConstructorOptions: Electron.BrowserWindowConstructorOptions | null, outlivesOpener: boolean, createWindow?: Electron.CreateWindowFunction};
     _setNextChildWebPreferences(prefs: Partial<Electron.BrowserWindowConstructorOptions['webPreferences']> & Pick<Electron.BrowserWindowConstructorOptions, 'backgroundColor'>): void;
     _send(internal: boolean, channel: string, args: any): boolean;
     _sendInternal(channel: string, ...args: any[]): void;
@@ -104,6 +104,8 @@ declare namespace Electron {
     embedder?: Electron.WebContents;
     type?: 'backgroundPage' | 'window' | 'browserView' | 'remote' | 'webview' | 'offscreen';
   }
+  
+  type CreateWindowFunction = (options: BrowserWindowConstructorOptions) => WebContents;
 
   interface Menu {
     _init(): void;


### PR DESCRIPTION
#### Description of Change
This PR adds a way to manually control the creation of a guest window in `webContents.setWindowOpenHandler`. My main motivation for this change is to have the possibility to properly handle new windows in form of BrowserView (in order to support `window.opener` I need to pass appropriate `WebContents` when creating an instance of it).

I am not an expert so I don't know what important things I could've missed introducing this change but I am hoping that with your guidance we'll be able to work on this PR and make such functionality possible in Electron. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: Extended `webContents.setWindowOpenHandler` to support manual creation of BrowserWindow.
