### PR TITLE
ci: use larger machine for docs only check

### DIFF
--- a/.circleci/build_config.yml
+++ b/.circleci/build_config.yml
@@ -1552,11 +1552,9 @@ commands:
 jobs:
   # Layer 0: Docs. Standalone.
   ts-compile-doc-change:
-    executor:
-      name: linux-docker
-      size: medium
+    executor: linux-docker
     environment:
-      <<: *env-linux-medium
+      <<: *env-linux-2xlarge
       <<: *env-testing-build
       GCLIENT_EXTRA_ARGS: '--custom-var=checkout_arm=True --custom-var=checkout_arm64=True'
     <<: *steps-electron-ts-compile-for-doc-change


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Doc only changes coming from forks were failing on gclient sync.  Forks do not get access to the source/git caches that branches use, so gclient sync is much slower.  Using a larger machine alleviates this problem.

#33140 shows a fork PR successfully running a docs only change at https://app.circleci.com/pipelines/github/electron/electron/50155/workflows/3a2f415d-cd20-4dcf-9d2a-565fbb33204e/jobs/1144884

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
