### PR TITLE
test: disable consistently flaky WOA JS test

### DIFF
--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -825,7 +825,7 @@ describe('chromium features', () => {
       expect(typeofProcessGlobal).to.equal('undefined');
     });
 
-    it('disables JavaScript when it is disabled on the parent window', async () => {
+    ifit(process.platform !== 'win32' || process.arch !== 'arm64')('disables JavaScript when it is disabled on the parent window', async () => {
       const w = new BrowserWindow({ show: true, webPreferences: { nodeIntegration: true } });
       w.webContents.loadFile(path.resolve(__dirname, 'fixtures', 'blank.html'));
       const windowUrl = require('url').format({


### PR DESCRIPTION
Disables flaky

> 'disables JavaScript when it is disabled on the parent window'

test on `17-x-y`. This has previously been disabled on 18 and main.

Notes: none.