### PR TITLE
test: fix crash on image.crop

### DIFF
--- a/spec-main/screen-helpers.ts
+++ b/spec-main/screen-helpers.ts
@@ -41,7 +41,8 @@ const formatHexByte = (val: number): string => {
  * Get the hex color at the given pixel coordinate in an image.
  */
 export const getPixelColor = (image: Electron.NativeImage, point: Electron.Point): string => {
-  const pixel = image.crop({ ...point, width: 1, height: 1 });
+  // image.crop crashes if point is fractional, so round to prevent that crash
+  const pixel = image.crop({ x: Math.round(point.x), y: Math.round(point.y), width: 1, height: 1 });
   // TODO(samuelmaddock): NativeImage.toBitmap() should return the raw pixel
   // color, but it sometimes differs. Why is that?
   const [b, g, r] = pixel.toBitmap();


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
Ran into this causing a test crash on an M1 MBP. The root crash is in a converter, but this works around the test crash now.

@codebytere 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->