### PR TITLE
fix: patches to use BUILDFLAG(IS_WIN) / BUILDFLAG(IS_MAC) checks

### DIFF
--- a/patches/chromium/feat_add_data_transfer_to_requestsingleinstancelock.patch
+++ b/patches/chromium/feat_add_data_transfer_to_requestsingleinstancelock.patch
@@ -19,7 +19,7 @@ instance, but also so the second instance can send back additional
 data to the first instance if needed.
 
 diff --git a/chrome/browser/process_singleton.h b/chrome/browser/process_singleton.h
-index 8f94cc300b58e8a94b6ca155aa3cf370bcb948d8..4340376f323d24e5e2c5897a81c6a9ebf13adab4 100644
+index 5a64220aaf1309832dc0ad543e353de67fe0a779..a568dd10d1ef8679d66f4cdc6a471c251cbcd4eb 100644
 --- a/chrome/browser/process_singleton.h
 +++ b/chrome/browser/process_singleton.h
 @@ -18,6 +18,7 @@
@@ -49,7 +49,7 @@ index 8f94cc300b58e8a94b6ca155aa3cf370bcb948d8..4340376f323d24e5e2c5897a81c6a9eb
 +                                   const std::vector<const uint8_t> additional_data,
 +                                   const NotificationAckCallback& ack_callback)>;
  
- #if defined(OS_WIN)
+ #if BUILDFLAG(IS_WIN)
    ProcessSingleton(const std::string& program_name,
                     const base::FilePath& user_data_dir,
 +                   const base::span<const uint8_t> additional_data,
@@ -96,7 +96,7 @@ index 8f94cc300b58e8a94b6ca155aa3cf370bcb948d8..4340376f323d24e5e2c5897a81c6a9eb
    // Return true if the given pid is one of our child processes.
    // Assumes that the current pid is the root of all pids of the current
 diff --git a/chrome/browser/process_singleton_posix.cc b/chrome/browser/process_singleton_posix.cc
-index 47e60bfd8239d4a2e292b835c49132bdbb751555..9861a884a15e79b36833e6df58897141acdc6718 100644
+index 7d3a441bdb64268ed5fbfa7bf589fb35a2fd1b75..b23c16fde275fdba559abb1f30e42f65ddbfc332 100644
 --- a/chrome/browser/process_singleton_posix.cc
 +++ b/chrome/browser/process_singleton_posix.cc
 @@ -148,7 +148,7 @@ const char kACKToken[] = "ACK";

--- a/patches/chromium/feat_enable_offscreen_rendering_with_viz_compositor.patch
+++ b/patches/chromium/feat_enable_offscreen_rendering_with_viz_compositor.patch
@@ -226,10 +226,10 @@ index a480befb5d8db36e7e281d5033aeef0bea83d220..4e54acc897d08c87bccc3b44f68634e2
  
 diff --git a/components/viz/service/display_embedder/software_output_device_proxy.cc b/components/viz/service/display_embedder/software_output_device_proxy.cc
 new file mode 100644
-index 0000000000000000000000000000000000000000..4efea02f80f8b6818291321a7c63f0f4815a5b98
+index 0000000000000000000000000000000000000000..88aba74877a6490e08e357266b1ce8461b5b6dff
 --- /dev/null
 +++ b/components/viz/service/display_embedder/software_output_device_proxy.cc
-@@ -0,0 +1,157 @@
+@@ -0,0 +1,158 @@
 +// Copyright 2014 The Chromium Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -239,6 +239,7 @@ index 0000000000000000000000000000000000000000..4efea02f80f8b6818291321a7c63f0f4
 +#include "base/memory/unsafe_shared_memory_region.h"
 +#include "base/threading/thread_checker.h"
 +#include "base/trace_event/trace_event.h"
++#include "build/build_config.h"
 +#include "components/viz/common/resources/resource_sizes.h"
 +#include "components/viz/service/display_embedder/output_device_backing.h"
 +#include "mojo/public/cpp/system/platform_handle.h"
@@ -247,7 +248,7 @@ index 0000000000000000000000000000000000000000..4efea02f80f8b6818291321a7c63f0f4
 +#include "third_party/skia/include/core/SkCanvas.h"
 +#include "ui/gfx/skia_util.h"
 +
-+#if defined(OS_WIN)
++#if BUILDFLAG(IS_WIN)
 +#include "skia/ext/skia_utils_win.h"
 +#include "ui/gfx/gdi_util.h"
 +#include "ui/gfx/win/hwnd_util.h"
@@ -389,10 +390,10 @@ index 0000000000000000000000000000000000000000..4efea02f80f8b6818291321a7c63f0f4
 +}  // namespace viz
 diff --git a/components/viz/service/display_embedder/software_output_device_proxy.h b/components/viz/service/display_embedder/software_output_device_proxy.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..fbc517e164d9bf33256c1ecbe86e31744375097e
+index 0000000000000000000000000000000000000000..a80258d6165e45a3c3d2b551158ff7d2a5778a7c
 --- /dev/null
 +++ b/components/viz/service/display_embedder/software_output_device_proxy.h
-@@ -0,0 +1,92 @@
+@@ -0,0 +1,93 @@
 +// Copyright 2014 The Chromium Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -400,19 +401,20 @@ index 0000000000000000000000000000000000000000..fbc517e164d9bf33256c1ecbe86e3174
 +#ifndef COMPONENTS_VIZ_SERVICE_DISPLAY_EMBEDDER_SOFTWARE_OUTPUT_DEVICE_PROXY_H_
 +#define COMPONENTS_VIZ_SERVICE_DISPLAY_EMBEDDER_SOFTWARE_OUTPUT_DEVICE_PROXY_H_
 +
-+#if defined(OS_WIN)
-+#include <windows.h>
-+#endif
-+
 +#include <memory>
 +
 +#include "base/memory/shared_memory_mapping.h"
 +#include "base/threading/thread_checker.h"
++#include "build/build_config.h"
 +#include "components/viz/host/host_display_client.h"
 +#include "components/viz/service/display/software_output_device.h"
 +#include "components/viz/service/viz_service_export.h"
 +#include "services/viz/privileged/mojom/compositing/display_private.mojom.h"
 +#include "services/viz/privileged/mojom/compositing/layered_window_updater.mojom.h"
++
++#if BUILDFLAG(IS_WIN)
++#include <windows.h>
++#endif
 +
 +namespace viz {
 +

--- a/patches/chromium/fix_media_key_usage_with_globalshortcuts.patch
+++ b/patches/chromium/fix_media_key_usage_with_globalshortcuts.patch
@@ -59,7 +59,7 @@ index ad366d0fd4c3a637d75a102ab56984f0d01bfc04..d63eb133fd4bab1ea309bb8c742acf88
    // true if register successfully, or false if 1) the specificied |accelerator|
    // has been registered by another caller or other native applications, or
 diff --git a/content/browser/media/media_keys_listener_manager_impl.cc b/content/browser/media/media_keys_listener_manager_impl.cc
-index ac923f436cbdd6ded0629da4e4c659d94258e55b..7e603dd5bad2a60b1bd7d9df569a10e838d797bc 100644
+index ac923f436cbdd6ded0629da4e4c659d94258e55b..43f9531075bcef87de8e60f24071f49fe4cd0891 100644
 --- a/content/browser/media/media_keys_listener_manager_impl.cc
 +++ b/content/browser/media/media_keys_listener_manager_impl.cc
 @@ -55,7 +55,12 @@ bool MediaKeysListenerManagerImpl::StartWatchingMediaKey(
@@ -68,9 +68,9 @@ index ac923f436cbdd6ded0629da4e4c659d94258e55b..7e603dd5bad2a60b1bd7d9df569a10e8
    // Tell the underlying MediaKeysListener to listen for the key.
 -  if (should_start_watching && media_keys_listener_ &&
 +  if (
-+#if defined(OS_MAC)
++#if BUILDFLAG(IS_MAC)
 +      !media_key_handling_enabled_ &&
-+#endif  // defined(OS_MAC)
++#endif  // BUILDFLAG(IS_MAC)
 +      should_start_watching &&
 +      media_keys_listener_ &&
        !media_keys_listener_->StartWatchingMediaKey(key_code)) {

--- a/patches/chromium/process_singleton.patch
+++ b/patches/chromium/process_singleton.patch
@@ -24,14 +24,14 @@ This patch adds a few changes to the Chromium code:
    before the browser thread is ready.
 
 diff --git a/chrome/browser/process_singleton.h b/chrome/browser/process_singleton.h
-index 16bb3aa15a5378e8319f75f4b6b72b39177828f4..8f94cc300b58e8a94b6ca155aa3cf370bcb948d8 100644
+index 16bb3aa15a5378e8319f75f4b6b72b39177828f4..5a64220aaf1309832dc0ad543e353de67fe0a779 100644
 --- a/chrome/browser/process_singleton.h
 +++ b/chrome/browser/process_singleton.h
 @@ -102,12 +102,19 @@ class ProcessSingleton {
        base::RepeatingCallback<bool(const base::CommandLine& command_line,
                                     const base::FilePath& current_directory)>;
  
-+#if defined(OS_WIN)
++#if BUILDFLAG(IS_WIN)
 +  ProcessSingleton(const std::string& program_name,
 +                   const base::FilePath& user_data_dir,
 +                   bool is_sandboxed,
@@ -75,7 +75,7 @@ index 16bb3aa15a5378e8319f75f4b6b72b39177828f4..8f94cc300b58e8a94b6ca155aa3cf370
  
  #if BUILDFLAG(IS_MAC)
 diff --git a/chrome/browser/process_singleton_posix.cc b/chrome/browser/process_singleton_posix.cc
-index c9f26ea2d2ea16484d416fdce095ec1b8b885991..47e60bfd8239d4a2e292b835c49132bdbb751555 100644
+index c9f26ea2d2ea16484d416fdce095ec1b8b885991..7d3a441bdb64268ed5fbfa7bf589fb35a2fd1b75 100644
 --- a/chrome/browser/process_singleton_posix.cc
 +++ b/chrome/browser/process_singleton_posix.cc
 @@ -53,6 +53,7 @@
@@ -129,7 +129,7 @@ index c9f26ea2d2ea16484d416fdce095ec1b8b885991..47e60bfd8239d4a2e292b835c49132bd
  }
  
 +bool IsAppSandboxed() {
-+#if defined(OS_MAC)
++#if BUILDFLAG(IS_MAC)
 +  // NB: There is no sane API for this, we have to just guess by
 +  // reading tea leaves
 +  base::FilePath home_dir;
@@ -140,7 +140,7 @@ index c9f26ea2d2ea16484d416fdce095ec1b8b885991..47e60bfd8239d4a2e292b835c49132bd
 +  return home_dir.value().find("Library/Containers") != std::string::npos;
 +#else
 +  return false;
-+#endif  // defined(OS_MAC)
++#endif  // BUILDFLAG(IS_MAC)
 +}
 +
  bool ConnectSocket(ScopedSocket* socket,


### PR DESCRIPTION
#### Description of Change
`#if defined(OS_WIN)` needs to be replaced with `#if BUILDFLAG(IS_WIN)`
`#if defined(OS_MAC)` needs to be replaced with `#if BUILDFLAG(IS_MAC)`

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none
