### PR TITLE
docs: fix documented return value for getFocusedWebContents

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -35,7 +35,7 @@ for all windows, webviews, opened devtools, and devtools extension background pa
 
 ### `webContents.getFocusedWebContents()`
 
-Returns `WebContents` - The web contents that is focused in this application, otherwise
+Returns `WebContents` | null - The web contents that is focused in this application, otherwise
 returns `null`.
 
 ### `webContents.fromId(id)`


### PR DESCRIPTION
#### Description of Change

Fixes a small documentation issue -- `webContents.getFocusedWebContents()` can return `null`, so that value should be part of the return type signature. Thanks to @erickzhao for the assist and pointers.

See also: https://github.com/electron/typescript-definitions/issues/202

#### Checklist
- [x] relevant documentation is changed or added

#### Release Notes

Notes: Fixed the documented return value declared by `webContents.getFocusedWebContents()` to include `null`, matching the documented usage of the function.
