### PR TITLE
chore: add ignore revs file for GH blame UI

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Atom --> Electron rename
+d9321f4df751fa32813fab1b6387bbd61bd681d0
+34c4c8d5088fa183f56baea28809de6f2a427e02
+# Enable JS Semicolons
+5d657dece4102e5e5304d42e8004b6ad64c0fcda


### PR DESCRIPTION
Utilizes a new flagged GH feature which exposes the `--ignore-revs-file` option to the git blame UI. This allows us to ignore massive refactor commits from the git blame UI to make tracking down issues easier.  You can still view the blame including these commits locally and on GH if you view the blame from a commit prior to this file being added.

As an example:
* With JS semicolon in blame: https://github.com/electron/electron/blame/main/lib/browser/ipc-main-impl.ts
* Without JS semicolon in blame: https://github.com/electron/electron/blame/ignore-revs/lib/browser/ipc-main-impl.ts

Notes: no-notes
