### PR TITLE
fix: propagate unsafely-treat-insecure-origin-as-secure to renderer children

### DIFF
--- a/shell/browser/electron_browser_client.cc
+++ b/shell/browser/electron_browser_client.cc
@@ -620,8 +620,8 @@ void ElectronBrowserClient::AppendExtraCommandLineSwitches(
     command_line->CopySwitchesFrom(*base::CommandLine::ForCurrentProcess(),
                                    kCommonSwitchNames,
                                    base::size(kCommonSwitchNames));
-    if (process_type == = ::switches::kUtilityProcess ||
-                          content::RenderProcessHost::FromID(process_id)) {
+    if (process_type == ::switches::kUtilityProcess ||
+        content::RenderProcessHost::FromID(process_id)) {
       MaybeAppendSecureOriginsAllowlistSwitch(command_line);
     }
   }


### PR DESCRIPTION
#### Description of Change
Fixes #15448. Modeled after Chrome: https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/chrome_content_browser_client.cc;l=1156;drc=e2cba64c183ae17816143ee344e6f7c81451555a

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added support for the `--unsafely-treat-insecure-origin-as-secure` command-line flag.
