### PR TITLE
test: re-enable webview resize events test

### DIFF
--- a/spec/webview-spec.js
+++ b/spec/webview-spec.js
@@ -1214,9 +1214,7 @@ describe('<webview> tag', function () {
 
     const generateSpecs = (description, sandbox) => {
       describe(description, () => {
-        // TODO(nornagon): disabled during chromium roll 2019-06-11 due to a
-        // 'ResizeObserver loop limit exceeded' error on Windows
-        xit('emits resize events', async () => {
+        it('emits resize events', async () => {
           const firstResizeSignal = waitForEvent(webview, 'resize');
           const domReadySignal = waitForEvent(webview, 'dom-ready');
 


### PR DESCRIPTION
#### Description of Change

This is an experimental PR to check in on an old test that we disabled during a Chromium roll awhile back. I came across it this morning and enough time has passed that it seemed like a good step would be to try re-enabling to see if it's still broken, or if anything else has changed in the interim.

#### Checklist

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none