### PR TITLE
docs: mark skipTaskbar as unsupported on Linux

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -174,8 +174,8 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
     mode. On macOS, also whether the maximize/zoom button should toggle full
     screen mode or maximize window. Default is `true`.
   * `simpleFullscreen` boolean (optional) - Use pre-Lion fullscreen on macOS. Default is `false`.
-  * `skipTaskbar` boolean (optional) - Whether to show the window in taskbar. Default is
-    `false`.
+  * `skipTaskbar` boolean (optional) _macOS_ _Windows_ - Whether to show the window in taskbar.
+    Default is `false`.
   * `kiosk` boolean (optional) - Whether the window is in kiosk mode. Default is `false`.
   * `title` string (optional) - Default window title. Default is `"Electron"`. If the HTML tag `<title>` is defined in the HTML file loaded by `loadURL()`, this property will be ignored.
   * `icon` ([NativeImage](native-image.md) | string) (optional) - The window icon. On Windows it is

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -27,9 +27,20 @@ preload scripts _do_ depend on Node, either refactor them to remove Node usage
 from the renderer, or explicitly specify `sandbox: false` for the relevant
 renderers.
 
+### Removed: `skipTaskbar` on Linux
+
+See `skipTaskbar` discussion in 19.0 below. This feature is not available on
+Wayland. Since most modern Linux desktops are transitioning to Wayland, this
+feature will be removed for Linux.
+
 ## Planned Breaking API Changes (19.0)
 
-*None (yet)*
+### Unsupported: `skipTaskbar` on Linux
+
+On X11, `skipTaskbar` sends a `_NET_WM_STATE_SKIP_TASKBAR` message to the X11
+window manager. There is not a direct equivalent for Wayland, and the known
+workarounds have unacceptable tradeoffs (e.g. Window.is_skip_taskbar in GNOME
+requires unsafe mode), so Electron is unable to support this feature on Linux.
 
 ## Planned Breaking API Changes (18.0)
 

--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -291,6 +291,7 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
 #endif
 
 #if defined(USE_X11)
+  // TODO(ckerr): remove in Electron v20.0.0
   // Before the window is mapped the SetWMSpecState can not work, so we have
   // to manually set the _NET_WM_STATE.
   std::vector<x11::Atom> state_atom_list;


### PR DESCRIPTION
BREAKING CHANGE

#### Description of Change

Closes #33124.

`skipTaskbar` has no effect on Wayland. Currently Electron uses `_NET_WM_STATE_SKIP_TASKBAR` to tell the WM to hide an app from the taskbar, and this works fine on X11 but there's no equivalent mechanism in Wayland. There _are_ some workarounds available on different systems, e.g. GNOME and KWin, but they some unacceptable tradeoffs, e.g. `Window.is_skip_taskbar` requires unsafe mode.

tl;dr I don't see a way to support this feature on Linux anymore.

This PR updates the documentation to reflect that it's only supported on macOS / Windows and makes an announcement in "breaking changes" (it's broken already, but better to document it here for visibility).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Marked `.skipTaskbar` as unsupported on Linux.