### PR TITLE
chore: remove awkward semi-documented preloadURL WebPreference

### DIFF
--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -820,9 +820,6 @@ This event can be used to configure `webPreferences` for the `webContents`
 of a `<webview>` before it's loaded, and provides the ability to set settings
 that can't be set via `<webview>` attributes.
 
-**Note:** The specified `preload` script option will appear as `preloadURL`
-(not `preload`) in the `webPreferences` object emitted with this event.
-
 #### Event: 'did-attach-webview'
 
 Returns:

--- a/docs/api/webview-tag.md
+++ b/docs/api/webview-tag.md
@@ -158,9 +158,6 @@ When the guest page doesn't have node integration this script will still have
 access to all Node APIs, but global objects injected by Node will be deleted
 after this script has finished executing.
 
-**Note:** This option will appear as `preloadURL` (not `preload`) in
-the `webPreferences` specified to the `will-attach-webview` event.
-
 ### `httpreferrer`
 
 ```html

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -562,7 +562,6 @@ app.on('web-contents-created', (event, contents) => {
   contents.on('will-attach-webview', (event, webPreferences, params) => {
     // Strip away preload scripts if unused or verify their location is legitimate
     delete webPreferences.preload
-    delete webPreferences.preloadURL
 
     // Disable Node.js integration
     webPreferences.nodeIntegration = false

--- a/lib/browser/guest-view-manager.ts
+++ b/lib/browser/guest-view-manager.ts
@@ -15,6 +15,7 @@ interface GuestInstance {
 
 const webViewManager = process._linkedBinding('electron_browser_web_view_manager');
 const eventBinding = process._linkedBinding('electron_browser_event');
+const netBinding = process._linkedBinding('electron_browser_net');
 
 const supportedWebViewEvents = Object.keys(webViewEvents);
 
@@ -49,7 +50,7 @@ function makeWebPreferences (embedder: Electron.WebContents, params: Record<stri
   };
 
   if (params.preload) {
-    webPreferences.preloadURL = params.preload;
+    webPreferences.preload = netBinding.fileURLToFilePath(params.preload);
   }
 
   // Security options that guest will always inherit from embedder

--- a/shell/browser/api/electron_api_net.cc
+++ b/shell/browser/api/electron_api_net.cc
@@ -5,11 +5,15 @@
 #include <string>
 
 #include "gin/handle.h"
+#include "net/base/filename_util.h"
 #include "net/base/network_change_notifier.h"
 #include "net/http/http_util.h"
 #include "services/network/public/cpp/features.h"
 #include "shell/browser/api/electron_api_url_loader.h"
+#include "shell/common/gin_converters/file_path_converter.h"
+#include "shell/common/gin_converters/gurl_converter.h"
 #include "shell/common/gin_helper/dictionary.h"
+#include "shell/common/gin_helper/error_thrower.h"
 #include "shell/common/gin_helper/object_template_builder.h"
 
 #include "shell/common/node_includes.h"
@@ -28,6 +32,14 @@ bool IsValidHeaderValue(std::string header_value) {
   return net::HttpUtil::IsValidHeaderValue(header_value);
 }
 
+base::FilePath FileURLToFilePath(v8::Isolate* isolate, const GURL& url) {
+  base::FilePath path;
+  if (!net::FileURLToFilePath(url, &path))
+    gin_helper::ErrorThrower(isolate).ThrowError(
+        "Failed to convert URL to file path");
+  return path;
+}
+
 using electron::api::SimpleURLLoaderWrapper;
 
 void Initialize(v8::Local<v8::Object> exports,
@@ -41,6 +53,7 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("isValidHeaderName", &IsValidHeaderName);
   dict.SetMethod("isValidHeaderValue", &IsValidHeaderValue);
   dict.SetMethod("createURLLoader", &SimpleURLLoaderWrapper::Create);
+  dict.SetMethod("fileURLToFilePath", &FileURLToFilePath);
 }
 
 }  // namespace

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -258,15 +258,6 @@ void WebContentsPreferences::Merge(
     } else {
       LOG(ERROR) << "preload script must have absolute path.";
     }
-  } else if (web_preferences.Get(options::kPreloadURL, &preload_url_str)) {
-    // Translate to file path if there is "preload-url" option.
-    base::FilePath preload;
-    GURL preload_url(preload_url_str);
-    if (net::FileURLToFilePath(preload_url, &preload)) {
-      preload_path_ = preload;
-    } else {
-      LOG(ERROR) << "preload url must be file:// protocol.";
-    }
   }
 
   std::string type;

--- a/shell/common/options_switches.cc
+++ b/shell/common/options_switches.cc
@@ -120,9 +120,6 @@ const char kPreloadScript[] = "preload";
 
 const char kPreloadScripts[] = "preloadScripts";
 
-// Like --preload, but the passed argument is an URL.
-const char kPreloadURL[] = "preloadURL";
-
 // Enable the node integration.
 const char kNodeIntegration[] = "nodeIntegration";
 

--- a/shell/common/options_switches.h
+++ b/shell/common/options_switches.h
@@ -66,7 +66,6 @@ extern const char kOverlayHeight[];
 extern const char kZoomFactor[];
 extern const char kPreloadScript[];
 extern const char kPreloadScripts[];
-extern const char kPreloadURL[];
 extern const char kNodeIntegration[];
 extern const char kContextIsolation[];
 extern const char kExperimentalFeatures[];

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -155,7 +155,6 @@ ipcMain.on('disable-preload-on-next-will-attach-webview', (event, id) => {
   event.sender.once('will-attach-webview', (event, webPreferences, params) => {
     params.src = `file://${path.join(__dirname, '..', 'fixtures', 'pages', 'webview-stripped-preload.html')}`;
     delete webPreferences.preload;
-    delete webPreferences.preloadURL;
   });
 });
 

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -222,6 +222,7 @@ declare namespace NodeJS {
       isOnline(): boolean;
       isValidHeaderName: (headerName: string) => boolean;
       isValidHeaderValue: (headerValue: string) => boolean;
+      fileURLToFilePath: (url: string) => string;
       Net: any;
       net: any;
       createURLLoader(options: CreateURLLoaderOptions): URLLoader;

--- a/typings/internal-electron.d.ts
+++ b/typings/internal-electron.d.ts
@@ -97,7 +97,6 @@ declare namespace Electron {
 
   interface WebPreferences {
     disablePopups?: boolean;
-    preloadURL?: string;
     embedder?: Electron.WebContents;
     type?: 'backgroundPage' | 'window' | 'browserView' | 'remote' | 'webview' | 'offscreen';
   }


### PR DESCRIPTION
#### Description of Change
Ref #21553.

Instead of having a separate semi-documented `preloadURL` WebPreference that
only is ever used for webviews and provides no actual different functionality
from the existing `preload` (it only allows `file://` URLs), resolve the URL to
a file path when we get it from the webview before passing it to
WebPreferences.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Removed the semi-documented `preloadURL` property from WebPreferences.
