### PR TITLE
chore: use pylint-2.7

### DIFF
--- a/script/lint.js
+++ b/script/lint.js
@@ -103,7 +103,7 @@ const LINTERS = [{
     const rcfile = path.join(DEPOT_TOOLS, 'pylintrc');
     const args = ['--rcfile=' + rcfile, ...filenames];
     const env = Object.assign({ PYTHONPATH: path.join(ELECTRON_ROOT, 'script') }, process.env);
-    spawnAndCheckExitCode('pylint', args, { env });
+    spawnAndCheckExitCode('pylint-2.7', args, { env });
   }
 }, {
   key: 'javascript',

--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -208,6 +208,7 @@ def zero_zip_date_time(fname):
     with open(fname, 'r+b') as f:
       _zero_zip_date_time(f)
   except Exception:
+    # pylint: disable=W0707
     raise NonZipFileError(fname)
 
 

--- a/script/run-clang-format.py
+++ b/script/run-clang-format.py
@@ -78,12 +78,14 @@ def make_diff(diff_file, original, reformatted):
 
 class DiffError(Exception):
     def __init__(self, message, errs=None):
+        # pylint: disable=R1725
         super(DiffError, self).__init__(message)
         self.errs = errs or []
 
 
 class UnexpectedError(Exception):
     def __init__(self, message, exc=None):
+        # pylint: disable=R1725
         super(UnexpectedError, self).__init__(message)
         self.formatted_traceback = traceback.format_exc()
         self.exc = exc
@@ -96,6 +98,7 @@ def run_clang_format_diff_wrapper(args, file_name):
     except DiffError:
         raise
     except Exception as e:
+        # pylint: disable=W0707
         raise UnexpectedError('{}: {}: {}'.format(
             file_name, e.__class__.__name__, e), e)
 
@@ -105,6 +108,7 @@ def run_clang_format_diff(args, file_name):
         with io.open(file_name, 'r', encoding='utf-8') as f:
             original = f.readlines()
     except IOError as exc:
+        # pylint: disable=W0707
         raise DiffError(str(exc))
     invocation = [args.clang_format_executable, file_name]
     if args.fix:
@@ -117,6 +121,7 @@ def run_clang_format_diff(args, file_name):
             universal_newlines=True,
             shell=True)
     except OSError as exc:
+        # pylint: disable=W0707
         raise DiffError(str(exc))
     proc_stdout = proc.stdout
     proc_stderr = proc.stderr


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Currently `yarn lint:py` won't run on Apple silicon since it would use Python 2, and Chromium infra doesn't provide a Python 2.7 package:

```
dsanders@Davids-MacBook-Pro electron % yarn lint:py  
yarn run v1.22.17
$ node ./script/lint.js --py
[E2022-03-10T17:14:02.282736-08:00 98290 0 annotate.go:273] original error: no such package: infra/python/wheels/wrapt/mac-arm64_cp27_cp27m

goroutine 100:
#0 go.chromium.org/luci/cipd/client/cipd/client.go:1934 - cipd.(*clientImpl).humanErr()
#1 go.chromium.org/luci/cipd/client/cipd/client.go:929 - cipd.(*clientImpl).ResolveVersion()
#2 go.chromium.org/luci/cipd/client/cipd/resolver.go:176 - cipd.(*Resolver).resolveVersion.func1()
#3 go.chromium.org/luci/common/sync/promise/promise.go:84 - promise.(*Promise).runGen()
#4 runtime/asm_arm64.s:1130 - runtime.goexit()

goroutine 51:
From frame 0 to 0, the following wrappers were found:
  internal reason: MultiError 1/1: following first non-nil error.

#0 go.chromium.org/luci/cipd/client/cipd/ensure/file.go:255 - ensure.(*File).Resolve.func1.1()
  reason: failed to resolve infra/python/wheels/wrapt/mac-arm64_cp27_cp27m@version:1.10.11 (line 0)

#1 go.chromium.org/luci/common/sync/parallel/runner.go:51 - parallel.(*WorkItem).execute()
#2 go.chromium.org/luci/common/sync/parallel/runner.go:149 - parallel.(*Runner).dispatchLoopBody.func2()
#3 runtime/asm_arm64.s:1130 - runtime.goexit()

goroutine 1:
#0 go.chromium.org/luci/vpython/venv/config.go:206 - venv.(*Config).makeEnv()
  reason: failed to resolve packages

#1 go.chromium.org/luci/vpython/venv/venv.go:170 - venv.With()
#2 go.chromium.org/luci/vpython/run.go:60 - vpython.Run()
#3 go.chromium.org/luci/vpython/application/application.go:327 - application.(*application).mainImpl()
#4 go.chromium.org/luci/vpython/application/application.go:416 - application.(*Config).Main.func1()
#5 go.chromium.org/luci/vpython/application/support.go:46 - application.run()
#6 go.chromium.org/luci/vpython/application/application.go:415 - application.(*Config).Main()
#7 vpython/main.go:112 - main.mainImpl()
#8 vpython/main.go:118 - main.main()
#9 runtime/proc.go:225 - runtime.main()
#10 runtime/asm_arm64.s:1130 - runtime.goexit()
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Since Chromium is (slowly) transitioning to Python 3 anyway, this will need to happen sooner or later. `depot_tools` has `pylint-2.6` and `pylint-2.7`, I'm going with the newer one until I know a reason not to.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
