### PR TITLE
chore: fix pylint-2.7 errors

### DIFF
--- a/script/add-debug-link.py
+++ b/script/add-debug-link.py
@@ -14,8 +14,7 @@ def add_debug_link_into_binaries(directory, target_cpu, debug_dir):
       add_debug_link_into_binary(binary_path, target_cpu, debug_dir)
 
 def add_debug_link_into_binary(binary_path, target_cpu, debug_dir):
-  if PLATFORM == 'linux' and (target_cpu == 'x86' or target_cpu == 'arm' or
-    target_cpu == 'arm64'):
+  if PLATFORM == 'linux' and target_cpu in ('x86', 'arm', 'arm64'):
     # Skip because no objcopy binary on the given target.
     return
 

--- a/script/check-relative-doc-links.py
+++ b/script/check-relative-doc-links.py
@@ -23,7 +23,7 @@ def main():
           filepaths.append(os.path.join(root, f))
   except KeyboardInterrupt:
     print('Keyboard interruption. Please try again.')
-    return
+    return 0
 
   totalBrokenLinks = 0
   for path in filepaths:

--- a/script/copy-debug-symbols.py
+++ b/script/copy-debug-symbols.py
@@ -15,8 +15,7 @@ def copy_debug_from_binaries(directory, out_dir, target_cpu, compress):
       copy_debug_from_binary(binary_path, out_dir, target_cpu, compress)
 
 def copy_debug_from_binary(binary_path, out_dir, target_cpu, compress):
-  if PLATFORM == 'linux' and (target_cpu == 'x86' or target_cpu == 'arm' or
-     target_cpu == 'arm64'):
+  if PLATFORM == 'linux' and target_cpu in ('x86', 'arm', 'arm64'):
     # Skip because no objcopy binary on the given target.
     return    
   debug_name = get_debug_name(binary_path)
@@ -25,7 +24,6 @@ def copy_debug_from_binary(binary_path, out_dir, target_cpu, compress):
     cmd.extend(['--compress-debug-sections'])
   cmd.extend([binary_path, os.path.join(out_dir, debug_name)])
   execute(cmd)
-  return debug_name
 
 def get_debug_name(binary_path):
   return os.path.basename(binary_path) + '.debug'

--- a/script/generate-config-gypi.py
+++ b/script/generate-config-gypi.py
@@ -15,7 +15,7 @@ def run_node_configure(target_cpu):
   configure = os.path.join(NODE_DIR, 'configure.py')
   args = ['--dest-cpu', target_cpu]
   # Enabled in Chromium's V8.
-  if target_cpu == 'arm64' or target_cpu == 'x64':
+  if target_cpu in ('arm64', 'x64'):
     args += ['--experimental-enable-pointer-compression']
 
   # Work around "No acceptable ASM compiler found" error on some System,
@@ -62,4 +62,4 @@ def main(target_file, target_cpu):
     f.write(pprint.pformat(config, indent=2))
 
 if __name__ == '__main__':
-  sys.exit(main(*sys.argv[1:]))
+  sys.exit(main(sys.argv[1], sys.argv[2]))

--- a/script/generate-zip-manifest.py
+++ b/script/generate-zip-manifest.py
@@ -11,4 +11,4 @@ def main(zip_path, manifest_out):
   return 0
 
 if __name__ == '__main__':
-  sys.exit(main(*sys.argv[1:]))
+  sys.exit(main(sys.argv[1], sys.argv[2]))

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -31,8 +31,8 @@ verbose_mode = False
 def get_platform_key():
   if 'MAS_BUILD' in os.environ:
     return 'mas'
-  else:
-    return PLATFORM
+
+  return PLATFORM
 
 
 def get_target_arch():

--- a/script/lib/git.py
+++ b/script/lib/git.py
@@ -233,8 +233,8 @@ def to_utf8(patch):
   """Python 2/3 compatibility: unicode has been renamed to str in Python3"""
   if sys.version_info[0] >= 3:
     return str(patch, "utf-8")
-  else:
-    return unicode(patch, "utf-8")
+
+  return unicode(patch, "utf-8")
 
 
 def export_patches(repo, out_dir, patch_range=None, dry_run=False):
@@ -268,7 +268,7 @@ def export_patches(repo, out_dir, patch_range=None, dry_run=False):
           out_dir, len(bad_patches), "\n-- ".join(bad_patches)
         )
       )
-      exit(1)
+      sys.exit(1)
   else:
     # Remove old patches so that deleted commits are correctly reflected in the
     # patch files (as a removed file)
@@ -291,4 +291,3 @@ def export_patches(repo, out_dir, patch_range=None, dry_run=False):
         ) as f:
           f.write(formatted_patch.encode('utf-8'))
         pl.write(filename + '\n')
-

--- a/script/lib/native_tests.py
+++ b/script/lib/native_tests.py
@@ -69,7 +69,8 @@ class Platform:
     if platform in ('cygwin', 'win32'):
       return Platform.WINDOWS
 
-    assert False, "unexpected current platform '{}'".format(platform)
+    raise AssertionError(
+        "unexpected current platform '{}'".format(platform))
 
   @staticmethod
   def get_all():
@@ -155,7 +156,7 @@ class TestsList():
     if isinstance(value, basestring):
       return {value: None}
 
-    assert False, "unexpected shorthand type: {}".format(type(value))
+    raise AssertionError("unexpected shorthand type: {}".format(type(value)))
 
   @staticmethod
   def __make_a_list(value):
@@ -174,7 +175,8 @@ class TestsList():
       # It looks ugly as hell, but it does the job.
       return [list_item for key in value for list_item in value[key]]
 
-    assert False, "unexpected type for list merging: {}".format(type(value))
+    raise AssertionError(
+        "unexpected type for list merging: {}".format(type(value)))
 
   def __platform_supports(self, binary_name):
     return Platform.get_current() in self.tests[binary_name]['platforms']

--- a/script/lib/util.py
+++ b/script/lib/util.py
@@ -191,9 +191,9 @@ def get_electron_exec():
 
   if sys.platform == 'darwin':
     return '{0}/Electron.app/Contents/MacOS/Electron'.format(out_dir)
-  elif sys.platform == 'win32':
+  if sys.platform == 'win32':
     return '{0}/electron.exe'.format(out_dir)
-  elif sys.platform == 'linux':
+  if sys.platform == 'linux':
     return '{0}/electron'.format(out_dir)
 
   raise Exception(

--- a/script/native-tests.py
+++ b/script/native-tests.py
@@ -97,11 +97,11 @@ def main():
     if args.binary is not None:
       return tests_list.run(args.binary, args.output_dir, args.verbosity,
                             args.disabled_tests_policy)
-    else:
-      return tests_list.run_all(args.output_dir, args.verbosity,
-                                args.disabled_tests_policy)
 
-  assert False, "unexpected command '{}'".format(args.command)
+    return tests_list.run_all(args.output_dir, args.verbosity,
+                              args.disabled_tests_policy)
+
+  raise AssertionError("unexpected command '{}'".format(args.command))
 
 
 if __name__ == '__main__':

--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -160,6 +160,8 @@ def main():
         'toolchain_profile.json')
     upload_electron(release, toolchain_profile_zip, args)
 
+  return 0
+
 def parse_args():
   parser = argparse.ArgumentParser(description='upload distribution file')
   parser.add_argument('-v', '--version', help='Specify the version',
@@ -205,7 +207,7 @@ def zero_zip_date_time(fname):
   try:
     with open(fname, 'r+b') as f:
       _zero_zip_date_time(f)
-  except:
+  except Exception:
     raise NonZipFileError(fname)
 
 

--- a/script/run-clang-format.py
+++ b/script/run-clang-format.py
@@ -287,7 +287,7 @@ def main():
         extensions=args.extensions.split(','))
 
     if not files:
-        return
+        return 0
 
     njobs = args.j
     if njobs == 0:

--- a/script/zip_manifests/check-zip-manifest.py
+++ b/script/zip_manifests/check-zip-manifest.py
@@ -7,7 +7,7 @@ def main(zip_path, manifest_in):
   with open(manifest_in, 'r') as manifest, \
       zipfile.ZipFile(zip_path, 'r', allowZip64=True) as z:
     files_in_zip = set(z.namelist())
-    files_in_manifest = set([l.strip() for l in manifest.readlines()])
+    files_in_manifest = {l.strip() for l in manifest.readlines()}
   added_files = files_in_zip - files_in_manifest
   removed_files = files_in_manifest - files_in_zip
   if added_files:
@@ -18,10 +18,8 @@ def main(zip_path, manifest_in):
     print("Files removed from bundle:")
     for f in sorted(list(removed_files)):
       print('-' + f)
-  if added_files or removed_files:
-    return 1
-  else:
-    return 0
+
+  return 1 if added_files or removed_files else 0
 
 if __name__ == '__main__':
-  sys.exit(main(*sys.argv[1:]))
+  sys.exit(main(sys.argv[1], sys.argv[2]))


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Prerequisite for landing #33232, see that PR for the lint failures this PR fixes.

Most are pretty straight forward, a few I ignored because `pylint-2.7` was suggesting changes which are Python 3 only (`super()` and `raise ... from ...`), and we need to maintain Python 2 compatibility for now. EDIT: I backed out the ignore comments because it created a chicken and egg problem where older `pylint` didn't recognize the codes. I'm attempting to keep updating to `pylint-2.7` separate from this PR just for cleaner separation and it can be reverted separately if need be.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
