### PR TITLE
chore: cherry-pick 246c10dede97 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -131,3 +131,4 @@ cherry-pick-1887414c016d.patch
 cherry-pick-6b2643846ae3.patch
 cherry-pick-62142d222a80.patch
 fix_non-client_mouse_tracking_and_message_bubbling_on_windows.patch
+cherry-pick-246c10dede97.patch

--- a/patches/chromium/cherry-pick-246c10dede97.patch
+++ b/patches/chromium/cherry-pick-246c10dede97.patch
@@ -1,0 +1,36 @@
+From 246c10dede97d21787c0ce57fa3032f6470954b3 Mon Sep 17 00:00:00 2001
+From: Tony Herre <toprice@chromium.org>
+Date: Fri, 18 Feb 2022 13:52:01 +0000
+Subject: [PATCH] [CherryPick to 99] Switch to new RequestPermissionsFromCurrentDocument API method for Media Stream Devices
+
+Switch away from the deprecated RequestPermissions() API, as a part of removing a bug where the previously provided request.security_origin param might get destroyed during the method execution.
+
+(cherry picked from commit cb6778fb965e2b010922f157c68480de863c252e)
+
+Bug: 1283402
+Change-Id: I512ce910146ec60d4d35fa1a86a71a3b0983a5d1
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3417436
+Reviewed-by: Florent Castelli <orphis@chromium.org>
+Commit-Queue: Tony Herre <toprice@chromium.org>
+Cr-Original-Commit-Position: refs/heads/main@{#964535}
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3473365
+Cr-Commit-Position: refs/branch-heads/4844@{#655}
+Cr-Branched-From: 007241ce2e6c8e5a7b306cc36c730cd07cd38825-refs/heads/main@{#961656}
+---
+
+diff --git a/components/webrtc/media_stream_devices_controller.cc b/components/webrtc/media_stream_devices_controller.cc
+index 08c1cd49..261a62c 100644
+--- a/components/webrtc/media_stream_devices_controller.cc
++++ b/components/webrtc/media_stream_devices_controller.cc
+@@ -139,9 +139,8 @@
+     }
+   }
+ 
+-  permission_manager->RequestPermissions(
+-      content_settings_types, rfh, request.security_origin,
+-      request.user_gesture,
++  permission_manager->RequestPermissionsFromCurrentDocument(
++      content_settings_types, rfh, request.user_gesture,
+       base::BindOnce(
+           &MediaStreamDevicesController::RequestAndroidPermissionsIfNeeded,
+           web_contents, std::move(controller), will_prompt_for_audio,

--- a/patches/chromium/cherry-pick-246c10dede97.patch
+++ b/patches/chromium/cherry-pick-246c10dede97.patch
@@ -1,7 +1,8 @@
-From 246c10dede97d21787c0ce57fa3032f6470954b3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tony Herre <toprice@chromium.org>
 Date: Fri, 18 Feb 2022 13:52:01 +0000
-Subject: [PATCH] [CherryPick to 99] Switch to new RequestPermissionsFromCurrentDocument API method for Media Stream Devices
+Subject: Switch to new RequestPermissionsFromCurrentDocument API method for
+ Media Stream Devices
 
 Switch away from the deprecated RequestPermissions() API, as a part of removing a bug where the previously provided request.security_origin param might get destroyed during the method execution.
 
@@ -16,13 +17,12 @@ Cr-Original-Commit-Position: refs/heads/main@{#964535}
 Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3473365
 Cr-Commit-Position: refs/branch-heads/4844@{#655}
 Cr-Branched-From: 007241ce2e6c8e5a7b306cc36c730cd07cd38825-refs/heads/main@{#961656}
----
 
 diff --git a/components/webrtc/media_stream_devices_controller.cc b/components/webrtc/media_stream_devices_controller.cc
-index 08c1cd49..261a62c 100644
+index c818458f413ab2afc439ddabb547659b1def3c5a..9f6829c1520f5bf46981de8c9a8c99fc7b40ad34 100644
 --- a/components/webrtc/media_stream_devices_controller.cc
 +++ b/components/webrtc/media_stream_devices_controller.cc
-@@ -139,9 +139,8 @@
+@@ -138,9 +138,8 @@ void MediaStreamDevicesController::RequestPermissions(
      }
    }
  


### PR DESCRIPTION
[CherryPick to 99] Switch to new RequestPermissionsFromCurrentDocument API method for Media Stream Devices

Switch away from the deprecated RequestPermissions() API, as a part of removing a bug where the previously provided request.security_origin param might get destroyed during the method execution.

(cherry picked from commit cb6778fb965e2b010922f157c68480de863c252e)

Bug: 1283402
Change-Id: I512ce910146ec60d4d35fa1a86a71a3b0983a5d1
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3417436
Reviewed-by: Florent Castelli <orphis@chromium.org>
Commit-Queue: Tony Herre <toprice@chromium.org>
Cr-Original-Commit-Position: refs/heads/main@{#964535}
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3473365
Cr-Commit-Position: refs/branch-heads/4844@{#655}
Cr-Branched-From: 007241ce2e6c8e5a7b306cc36c730cd07cd38825-refs/heads/main@{#961656}


Notes: Backported fix for 1283402.