### PR TITLE
fix: BrowserWindow.fromWebContents should work in browser-window-created

### DIFF
--- a/shell/common/gin_helper/trackable_object.h
+++ b/shell/common/gin_helper/trackable_object.h
@@ -117,11 +117,11 @@ class TrackableObject : public TrackableObjectBase, public EventEmitter<T> {
   ~TrackableObject() override { RemoveFromWeakMap(); }
 
   void InitWith(v8::Isolate* isolate, v8::Local<v8::Object> wrapper) override {
-    gin_helper::WrappableBase::InitWith(isolate, wrapper);
     if (!weak_map_) {
       weak_map_ = new electron::KeyWeakMap<int32_t>;
     }
     weak_map_->Set(isolate, weak_map_id_, wrapper);
+    gin_helper::WrappableBase::InitWith(isolate, wrapper);
   }
 
  private:

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -1816,6 +1816,18 @@ describe('BrowserWindow module', () => {
       expect(BrowserWindow.fromWebContents(webviewContents)!.id).to.equal(w.id);
       await p;
     });
+
+    it('is usable immediately on browser-window-created', async () => {
+      const w = new BrowserWindow({ show: false });
+      w.loadURL('about:blank');
+      w.webContents.executeJavaScript('window.open(""); null');
+      const [win, winFromWebContents] = await new Promise((resolve) => {
+        app.once('browser-window-created', (e, win) => {
+          resolve([win, BrowserWindow.fromWebContents(win.webContents)]);
+        });
+      });
+      expect(winFromWebContents).to.equal(win);
+    });
   });
 
   describe('BrowserWindow.openDevTools()', () => {


### PR DESCRIPTION
#### Description of Change
Fixes #21608. The object was being added to the weak map only _after_ the
`_init` function was called, meaning that the TrackableObject::FromWrappedClass
method would not work during the `_init` function.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed a bug where `BrowserWindow.fromWebContents` would return `undefined` during the `browser-window-created` event.
