### PR TITLE
docs: remove "marked" from process.getBlinkMemoryInfo()

### DIFF
--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -178,7 +178,6 @@ Returns an object with V8 heap statistics. Note that all statistics are reported
 Returns `Object`:
 
 * `allocated` Integer - Size of all allocated objects in Kilobytes.
-* `marked` Integer - Size of all marked objects in Kilobytes.
 * `total` Integer - Total allocated space in Kilobytes.
 
 Returns an object with Blink memory information.


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

The key was [removed back in Electron 7](https://github.com/electron/electron/blob/main/docs/breaking-changes.md#removed-marked-property-on-getblinkmemoryinfo).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd

#### Release Notes

Notes: none <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
