### PR TITLE
docs: specify default for BrowserWindow's center option

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -146,7 +146,7 @@ It creates a new `BrowserWindow` with native properties as set by the `options`.
   * `useContentSize` boolean (optional) - The `width` and `height` would be used as web
     page's size, which means the actual window's size will include window
     frame's size and be slightly larger. Default is `false`.
-  * `center` boolean (optional) - Show window in the center of the screen.
+  * `center` boolean (optional) - Show window in the center of the screen. Default is `false`.
   * `minWidth` Integer (optional) - Window's minimum width. Default is `0`.
   * `minHeight` Integer (optional) - Window's minimum height. Default is `0`.
   * `maxWidth` Integer (optional) - Window's maximum width. Default is no limit.


### PR DESCRIPTION
#### Description of Change

Specifies default for `center` in BrowserWindow constructor, every other option has a default value specified but not `center`. Confused me when looking at docs for a second so thought I'd make a PR.

#### Checklist

- [X] PR description included and stakeholders cc'd

#### Release Notes

Notes: none
