### PR TITLE
fix: ensure external memory adjustments are balanced

### DIFF
--- a/shell/common/api/electron_api_native_image.h
+++ b/shell/common/api/electron_api_native_image.h
@@ -121,7 +121,7 @@ class NativeImage : public gin::Wrappable<NativeImage> {
   float GetAspectRatio(const absl::optional<float> scale_factor);
   void AddRepresentation(const gin_helper::Dictionary& options);
 
-  void AdjustAmountOfExternalAllocatedMemory(bool add);
+  void UpdateExternalAllocatedMemoryUsage();
 
   // Mark the image as template image.
   void SetTemplateImage(bool setAsTemplate);
@@ -136,6 +136,7 @@ class NativeImage : public gin::Wrappable<NativeImage> {
   gfx::Image image_;
 
   v8::Isolate* isolate_;
+  int32_t memory_usage_ = 0;
 };
 
 }  // namespace api


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

This change is modeled after [how it is done for `ImageBitmap` in Chromium](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/imagebitmap/image_bitmap.cc;l=832-850;drc=d6530d58164c28dfba8e6a8c0f2c17f25afdc016;bpv=0;bpt=0).

The current code has the potential to make unbalanced adjustments, decrementing more memory than it has incremented, which messes with the overall tracking. Currently adding a representation to an empty `nativeImage` doesn't increase the external memory count, but the destructor decrements it, leading to a net negative. If you run that in a loop, you'll eventually turn the total external allocated memory count negative.

I think there are improvements to be made on the general tracking here, especially with multiple representations, but that requires more research and I wanted to start by fixing the bug here which can impact the total external allocated memory count.

cc @miniak

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed incorrect external memory allocation tracking in nativeImage module<!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
