### PR TITLE
fix: settings not persisting across devtools loads

### DIFF
--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -86,13 +86,6 @@ const char kChromeUIDevToolsRemoteFrontendPath[] = "serve_file";
 const char kDevToolsBoundsPref[] = "electron.devtools.bounds";
 const char kDevToolsZoomPref[] = "electron.devtools.zoom";
 const char kDevToolsPreferences[] = "electron.devtools.preferences";
-const char kDevToolsSyncPreferences[] = "electron.devtools.sync_preferences";
-const char kDevToolsSyncedPreferencesSyncEnabled[] =
-    "electron.devtools.synced_preferences_sync_enabled";
-const char kDevToolsSyncedPreferencesSyncDisabled[] =
-    "electron.devtools.synced_preferences_sync_disabled";
-const char kSyncDevToolsPreferencesFrontendName[] = "electron.sync_preferences";
-const bool kSyncDevToolsPreferencesDefault = false;
 
 const char kFrontendHostId[] = "id";
 const char kFrontendHostMethod[] = "method";
@@ -346,10 +339,6 @@ void InspectableWebContents::RegisterPrefs(PrefRegistrySimple* registry) {
                                    RectToDictionary(gfx::Rect(0, 0, 800, 600)));
   registry->RegisterDoublePref(kDevToolsZoomPref, 0.);
   registry->RegisterDictionaryPref(kDevToolsPreferences);
-  registry->RegisterDictionaryPref(kDevToolsSyncedPreferencesSyncEnabled);
-  registry->RegisterDictionaryPref(kDevToolsSyncedPreferencesSyncDisabled);
-  registry->RegisterBooleanPref(kDevToolsSyncPreferences,
-                                kSyncDevToolsPreferencesDefault);
 }
 
 InspectableWebContents::InspectableWebContents(
@@ -867,97 +856,28 @@ void InspectableWebContents::SendJsonRequest(DispatchCallback callback,
   std::move(callback).Run(nullptr);
 }
 
-void InspectableWebContents::RegisterPreference(
-    const std::string& name,
-    const RegisterOptions& options) {
-  // kSyncDevToolsPreferenceFrontendName is not stored in any of the relevant
-  // dictionaries. Skip registration.
-  if (name == kSyncDevToolsPreferencesFrontendName)
-    return;
-
-  if (options.sync_mode == RegisterOptions::SyncMode::kSync) {
-    synced_setting_names_.insert(name);
-  }
-
-  // Setting might have had a different sync status in the past. Move the
-  // setting to the correct dictionary.
-  const char* dictionary_to_remove_from =
-      options.sync_mode == RegisterOptions::SyncMode::kSync
-          ? kDevToolsPreferences
-          : GetDictionaryNameForSyncedPrefs();
-  const std::string* settings_value =
-      pref_service_->GetDictionary(dictionary_to_remove_from)
-          ->FindStringKey(name);
-  if (!settings_value) {
-    return;
-  }
-
-  const char* dictionary_to_insert_into =
-      GetDictionaryNameForSettingsName(name);
-  // Settings already moved to the synced dictionary on a different device have
-  // precedence.
-  const std::string* already_synced_value =
-      pref_service_->GetDictionary(dictionary_to_insert_into)
-          ->FindStringKey(name);
-  if (dictionary_to_insert_into == kDevToolsPreferences ||
-      !already_synced_value) {
-    DictionaryPrefUpdate insert_update(pref_service_,
-                                       dictionary_to_insert_into);
-    insert_update.Get()->SetKey(name, base::Value(*settings_value));
-  }
-
-  DictionaryPrefUpdate remove_update(pref_service_, dictionary_to_remove_from);
-  remove_update.Get()->RemoveKey(name);
-}
-
 void InspectableWebContents::GetPreferences(DispatchCallback callback) {
-  base::Value settings(base::Value::Type::DICTIONARY);
-  settings.SetBoolKey(kSyncDevToolsPreferencesFrontendName,
-                      pref_service_->GetBoolean(kDevToolsSyncPreferences));
-  settings.MergeDictionary(pref_service_->GetDictionary(kDevToolsPreferences));
-  settings.MergeDictionary(
-      pref_service_->GetDictionary(GetDictionaryNameForSyncedPrefs()));
-
-  std::move(callback).Run(&settings);
+  const base::Value* prefs = pref_service_->GetDictionary(kDevToolsPreferences);
+  std::move(callback).Run(prefs);
 }
 
 void InspectableWebContents::SetPreference(const std::string& name,
                                            const std::string& value) {
-  if (name == kSyncDevToolsPreferencesFrontendName) {
-    pref_service_->SetBoolean(kDevToolsSyncPreferences, value == "true");
-    return;
-  }
-  DictionaryPrefUpdate update(pref_service_,
-                              GetDictionaryNameForSettingsName(name));
+  DictionaryPrefUpdate update(pref_service_, kDevToolsPreferences);
   update.Get()->SetKey(name, base::Value(value));
 }
 
 void InspectableWebContents::RemovePreference(const std::string& name) {
-  if (name == kSyncDevToolsPreferencesFrontendName) {
-    pref_service_->SetBoolean(kDevToolsSyncPreferences,
-                              kSyncDevToolsPreferencesDefault);
-    return;
-  }
-  DictionaryPrefUpdate update(pref_service_,
-                              GetDictionaryNameForSettingsName(name));
+  DictionaryPrefUpdate update(pref_service_, kDevToolsPreferences);
   update.Get()->RemoveKey(name);
 }
 
 void InspectableWebContents::ClearPreferences() {
-  pref_service_->SetBoolean(kDevToolsSyncPreferences,
-                            kSyncDevToolsPreferencesDefault);
   DictionaryPrefUpdate unsynced_update(pref_service_, kDevToolsPreferences);
   unsynced_update.Get()->DictClear();
-  DictionaryPrefUpdate sync_enabled_update(
-      pref_service_, kDevToolsSyncedPreferencesSyncEnabled);
-  sync_enabled_update.Get()->DictClear();
-  DictionaryPrefUpdate sync_disabled_update(
-      pref_service_, kDevToolsSyncedPreferencesSyncDisabled);
-  sync_disabled_update.Get()->DictClear();
 }
 
 void InspectableWebContents::GetSyncInformation(DispatchCallback callback) {
-  // TODO(anyone): do we want devtool syncing in Electron?
   base::Value result(base::Value::Type::DICTIONARY);
   result.SetBoolKey("isSyncActive", false);
   std::move(callback).Run(&result);
@@ -1140,20 +1060,6 @@ void InspectableWebContents::SendMessageAck(int request_id,
                                             const base::Value* arg) {
   base::Value id_value(request_id);
   CallClientFunction("DevToolsAPI.embedderMessageAck", &id_value, arg, nullptr);
-}
-
-const char* InspectableWebContents::GetDictionaryNameForSettingsName(
-    const std::string& name) const {
-  return synced_setting_names_.contains(name)
-             ? kDevToolsSyncedPreferencesSyncEnabled
-             : kDevToolsPreferences;
-}
-
-const char* InspectableWebContents::GetDictionaryNameForSyncedPrefs() const {
-  const bool isDevToolsSyncEnabled =
-      pref_service_->GetBoolean(kDevToolsSyncPreferences);
-  return isDevToolsSyncEnabled ? kDevToolsSyncedPreferencesSyncEnabled
-                               : kDevToolsSyncedPreferencesSyncDisabled;
 }
 
 }  // namespace electron

--- a/shell/browser/ui/inspectable_web_contents.h
+++ b/shell/browser/ui/inspectable_web_contents.h
@@ -140,7 +140,7 @@ class InspectableWebContents
                        const std::string& browser_id,
                        const std::string& url) override;
   void RegisterPreference(const std::string& name,
-                          const RegisterOptions& options) override;
+                          const RegisterOptions& options) override {}
   void GetPreferences(DispatchCallback callback) override;
   void SetPreference(const std::string& name,
                      const std::string& value) override;
@@ -195,9 +195,6 @@ class InspectableWebContents
                           const base::FilePath& path) override;
 
   void SendMessageAck(int request_id, const base::Value* arg1);
-
-  const char* GetDictionaryNameForSettingsName(const std::string& name) const;
-  const char* GetDictionaryNameForSyncedPrefs() const;
 
 #if BUILDFLAG(ENABLE_ELECTRON_EXTENSIONS)
   void AddDevToolsExtensionsToClient();


### PR DESCRIPTION
#### Description of Change

Backports https://github.com/electron/electron/pull/33120

#### Release Notes

Notes: Fixed an issue where Chrome DevTools settings didn't persist between loads.