### PR TITLE
docs: webFrame.insertCSS should mention options arg

### DIFF
--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -110,9 +110,11 @@ webFrame.setSpellCheckProvider('en-US', {
 })
 ```
 
-### `webFrame.insertCSS(css)`
+#### `webFrame.insertCSS(css[, options])`
 
-* `css` string - CSS source code.
+* `css` string
+* `options` Object (optional)
+  * `cssOrigin` string (optional) - Can be either 'user' or 'author'. Sets the [cascade origin](https://www.w3.org/TR/css3-cascade/#cascade-origin) of the inserted stylesheet. Default is 'author'.
 
 Returns `string` - A key for the inserted CSS that can later be used to remove
 the CSS via `webFrame.removeInsertedCSS(key)`.


### PR DESCRIPTION
#### Description of Change
Ref #22055.

This was added in #19268 but wasn't documented. cc @codebytere 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added

#### Release Notes

Notes: none