### PR TITLE
fix: pend bounds change when moving BrowserWindows

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -699,6 +699,13 @@ bool NativeWindowViews::IsFullscreen() const {
 }
 
 void NativeWindowViews::SetBounds(const gfx::Rect& bounds, bool animate) {
+#if BUILDFLAG(IS_WIN)
+  if (is_moving_ || is_resizing_) {
+    pending_bounds_change_ = bounds;
+    return;
+  }
+#endif
+
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX)
   // On Linux and Windows the minimum and maximum size should be updated with
   // window size when window is not resizable.

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -8,7 +8,6 @@
 #include "shell/browser/native_window.h"
 
 #include <memory>
-#include <queue>
 #include <set>
 #include <string>
 #include <vector>

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -8,6 +8,7 @@
 #include "shell/browser/native_window.h"
 
 #include <memory>
+#include <queue>
 #include <set>
 #include <string>
 #include <vector>
@@ -302,6 +303,8 @@ class NativeWindowViews : public NativeWindow,
 
   // Whether the window is currently being moved.
   bool is_moving_ = false;
+
+  absl::optional<gfx::Rect> pending_bounds_change_;
 
   // The color to use as the theme and symbol colors respectively for Window
   // Controls Overlay if enabled on Windows.

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -314,6 +314,15 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
         NotifyWindowMoved();
         is_moving_ = false;
       }
+
+      // If the user dragged or moved the window during one or more
+      // calls to window.setBounds(), we want to apply the most recent
+      // one once they are done with the move or resize operation.
+      if (pending_bounds_change_.has_value()) {
+        SetBounds(pending_bounds_change_.value(), false /* animate */);
+        pending_bounds_change_.reset();
+      }
+
       return false;
     }
     case WM_MOVING: {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/33279.
Refs CRBUG:251813

It's the case at present that `widget()->SetBounds(bounds)` does not take effect if the window is currently being moved or resized. This is an open issue on Chromium since 2013, with no real solution implemented upstream but several options suggested, including:

> Drag completes ignoring the bounds update but the bounds update is queued and then executed after drag completes.

In a Chromium context, this might not be ideal, but in an Electron context I believe this is the most expected behavior from a development standpoint. As a result of this PR, the bounds update correctly once the user completes the resize or the drag movements to reflect the new bounds set programmatically. Now, we take the last call to `setBounds` and apply it once the user has finished the move or drag operation.


Tested with https://gist.github.com/6b6ea5cdaa1883656a8bd0bf89195283.

This is unfortunately not directly testable via spec, given that it's dependent on user-initiated movement.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where new bounds set via `setBounds` was not correctly applied if the user was moving or resizing the window concurrently on Windows.
