### PR TITLE
fix: ensure external memory adjustments are balanced

### DIFF
--- a/shell/common/api/electron_api_native_image.cc
+++ b/shell/common/api/electron_api_native_image.cc
@@ -109,7 +109,7 @@ base::win::ScopedHICON ReadICOFromPath(int size, const base::FilePath& path) {
 
 NativeImage::NativeImage(v8::Isolate* isolate, const gfx::Image& image)
     : image_(image), isolate_(isolate) {
-  AdjustAmountOfExternalAllocatedMemory(true);
+  UpdateExternalAllocatedMemoryUsage();
 }
 
 #if defined(OS_WIN)
@@ -120,22 +120,27 @@ NativeImage::NativeImage(v8::Isolate* isolate, const base::FilePath& hicon_path)
   electron::util::ReadImageSkiaFromICO(&image_skia, GetHICON(256));
   image_ = gfx::Image(image_skia);
 
-  AdjustAmountOfExternalAllocatedMemory(true);
+  UpdateExternalAllocatedMemoryUsage();
 }
 #endif
 
 NativeImage::~NativeImage() {
-  AdjustAmountOfExternalAllocatedMemory(false);
+  isolate_->AdjustAmountOfExternalAllocatedMemory(-memory_usage_);
 }
 
-void NativeImage::AdjustAmountOfExternalAllocatedMemory(bool add) {
+void NativeImage::UpdateExternalAllocatedMemoryUsage() {
+  int32_t new_memory_usage = 0;
+
   if (image_.HasRepresentation(gfx::Image::kImageRepSkia)) {
     auto* const image_skia = image_.ToImageSkia();
     if (!image_skia->isNull()) {
-      int64_t size = image_skia->bitmap()->computeByteSize();
-      isolate_->AdjustAmountOfExternalAllocatedMemory(add ? size : -size);
+      new_memory_usage = image_skia->bitmap()->computeByteSize();
     }
   }
+
+  isolate_->AdjustAmountOfExternalAllocatedMemory(new_memory_usage -
+                                                  memory_usage_);
+  memory_usage_ = new_memory_usage;
 }
 
 // static

--- a/shell/common/api/electron_api_native_image.h
+++ b/shell/common/api/electron_api_native_image.h
@@ -117,7 +117,7 @@ class NativeImage : public gin::Wrappable<NativeImage> {
   float GetAspectRatio(const absl::optional<float> scale_factor);
   void AddRepresentation(const gin_helper::Dictionary& options);
 
-  void AdjustAmountOfExternalAllocatedMemory(bool add);
+  void UpdateExternalAllocatedMemoryUsage();
 
   // Mark the image as template image.
   void SetTemplateImage(bool setAsTemplate);
@@ -132,6 +132,7 @@ class NativeImage : public gin::Wrappable<NativeImage> {
   gfx::Image image_;
 
   v8::Isolate* isolate_;
+  int32_t memory_usage_ = 0;
 
   DISALLOW_COPY_AND_ASSIGN(NativeImage);
 };


### PR DESCRIPTION
Backport of #33266.

See that PR for details.

Notes: Fixed incorrect external memory allocation tracking in nativeImage module