### PR TITLE
fix: crash when showing item in folder on DevTools

### DIFF
--- a/shell/browser/ui/inspectable_web_contents.cc
+++ b/shell/browser/ui/inspectable_web_contents.cc
@@ -175,6 +175,10 @@ GURL GetDevToolsURL(bool can_dock) {
   return GURL(url_string);
 }
 
+void OnOpenItemComplete(const base::FilePath& path, const std::string& result) {
+  platform_util::ShowItemInFolder(path);
+}
+
 constexpr base::TimeDelta kInitialBackoffDelay =
     base::TimeDelta::FromMilliseconds(250);
 constexpr base::TimeDelta kMaxBackoffDelay = base::TimeDelta::FromSeconds(10);
@@ -738,9 +742,8 @@ void InspectableWebContents::ShowItemInFolder(
     return;
 
   base::FilePath path = base::FilePath::FromUTF8Unsafe(file_system_path);
-
-  // Pass empty callback here; we can ignore errors
-  platform_util::OpenPath(path, platform_util::OpenCallback());
+  platform_util::OpenPath(path.DirName(),
+                          base::BindOnce(&OnOpenItemComplete, path));
 }
 
 void InspectableWebContents::SaveToFile(const std::string& url,


### PR DESCRIPTION
Backport of #33024.

See that PR for details.

Notes: Fixed an issue where clicking "Open in Containing Folder" in the Sources tab in Devtools caused a crash.