### PR TITLE
fix: desktop screen capture on macOS not releasing

### DIFF
--- a/patches/chromium/desktop_media_list.patch
+++ b/patches/chromium/desktop_media_list.patch
@@ -52,7 +52,7 @@ index 98cc4e039ba2b5a467175b15650a7b8ef38e8249..f5aea6a5916b9aa56ee7b81a8de97dc4
    const Source& GetSource(int index) const override;
    DesktopMediaList::Type GetMediaListType() const override;
 diff --git a/chrome/browser/media/webrtc/native_desktop_media_list.cc b/chrome/browser/media/webrtc/native_desktop_media_list.cc
-index c899b52ef01d2c9ea16b281a2b7c4d37f175fa36..f752163d4e1951b2f79c7cc1cb4db51c0965472e 100644
+index c899b52ef01d2c9ea16b281a2b7c4d37f175fa36..5d47550a96e670ce6f0b274e3d683589d8fa3999 100644
 --- a/chrome/browser/media/webrtc/native_desktop_media_list.cc
 +++ b/chrome/browser/media/webrtc/native_desktop_media_list.cc
 @@ -16,7 +16,7 @@
@@ -72,7 +72,17 @@ index c899b52ef01d2c9ea16b281a2b7c4d37f175fa36..f752163d4e1951b2f79c7cc1cb4db51c
  const base::Feature kWindowCaptureMacV2{"WindowCaptureMacV2",
                                          base::FEATURE_DISABLED_BY_DEFAULT};
  #endif
-@@ -427,6 +428,11 @@ void NativeDesktopMediaList::RefreshForVizFrameSinkWindows(
+@@ -273,6 +274,9 @@ void NativeDesktopMediaList::Worker::RefreshNextThumbnail() {
+       FROM_HERE,
+       base::BindOnce(&NativeDesktopMediaList::UpdateNativeThumbnailsFinished,
+                      media_list_));
++
++  // This call is necessary to release underlying OS screen capture mechanisms.
++  capturer_.reset();
+ }
+ 
+ void NativeDesktopMediaList::Worker::OnCaptureResult(
+@@ -427,6 +431,11 @@ void NativeDesktopMediaList::RefreshForVizFrameSinkWindows(
          FROM_HERE, base::BindOnce(&Worker::RefreshThumbnails,
                                    base::Unretained(worker_.get()),
                                    std::move(native_ids), thumbnail_size_));


### PR DESCRIPTION
Backport of #32435.

See that PR for details.

Notes: Fixed an issue where calling screen capture on macOS does not properly release underlying OS capture mechanisms.