### PR TITLE
fix: initialize FPS file in network service

### DIFF
--- a/shell/browser/net/system_network_context_manager.cc
+++ b/shell/browser/net/system_network_context_manager.cc
@@ -288,6 +288,10 @@ void SystemNetworkContextManager::OnNetworkServiceCreated(
       base::FeatureList::IsEnabled(features::kAsyncDns),
       default_secure_dns_mode, doh_config, additional_dns_query_types_enabled);
 
+  // Initializes first party sets component
+  // CL: https://chromium-review.googlesource.com/c/chromium/src/+/3449280
+  content::GetNetworkService()->SetFirstPartySets(base::File());
+
   std::string app_name = electron::Browser::Get()->GetName();
 #if BUILDFLAG(IS_MAC)
   KeychainPassword::GetServiceName() = app_name + " Safe Storage";


### PR DESCRIPTION
#### Description of Change

A [recent change in Chromium (CL: #3449280)](https://chromium-review.googlesource.com/c/chromium/src/+/3449280) now requires First Party Sets (FPS) to be fully initialized before queries can be received and responded to. This initialization happened in two parts: receiving the sets from the command line, and parsing the sets file.

This PR passes an empty file to `SetFirstPartySets`, to allow both checks to pass.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where First Party Sets were not correctly loaded on app launch.
