### PR TITLE
feat: add nativeTheme.inForcedColorsMode

### DIFF
--- a/docs/api/native-theme.md
+++ b/docs/api/native-theme.md
@@ -67,3 +67,8 @@ or is being instructed to show a high-contrast UI.
 
 A `Boolean` for if the OS / Chromium currently has an inverted color scheme
 or is being instructed to use an inverted color scheme.
+
+### `nativeTheme.inForcedColorsMode` _Windows_ _Readonly_
+
+A `boolean` indicating whether Chromium is in forced colors mode, controlled by system accessibility settings.
+Currently, Windows high contrast is the only system setting that triggers forced colors mode.

--- a/shell/browser/api/electron_api_native_theme.cc
+++ b/shell/browser/api/electron_api_native_theme.cc
@@ -67,6 +67,10 @@ bool NativeTheme::ShouldUseHighContrastColors() {
   return ui_theme_->UserHasContrastPreference();
 }
 
+bool NativeTheme::InForcedColorsMode() {
+  return ui_theme_->InForcedColorsMode();
+}
+
 #if defined(OS_MAC)
 const CFStringRef WhiteOnBlack = CFSTR("whiteOnBlack");
 const CFStringRef UniversalAccessDomain = CFSTR("com.apple.universalaccess");
@@ -106,7 +110,8 @@ gin::ObjectTemplateBuilder NativeTheme::GetObjectTemplateBuilder(
       .SetProperty("shouldUseHighContrastColors",
                    &NativeTheme::ShouldUseHighContrastColors)
       .SetProperty("shouldUseInvertedColorScheme",
-                   &NativeTheme::ShouldUseInvertedColorScheme);
+                   &NativeTheme::ShouldUseInvertedColorScheme)
+      .SetProperty("inForcedColorsMode", &NativeTheme::InForcedColorsMode);
 }
 
 const char* NativeTheme::GetTypeName() {

--- a/shell/browser/api/electron_api_native_theme.h
+++ b/shell/browser/api/electron_api_native_theme.h
@@ -42,6 +42,7 @@ class NativeTheme : public gin::Wrappable<NativeTheme>,
   bool ShouldUseDarkColors();
   bool ShouldUseHighContrastColors();
   bool ShouldUseInvertedColorScheme();
+  bool InForcedColorsMode();
 
   // ui::NativeThemeObserver:
   void OnNativeThemeUpdated(ui::NativeTheme* theme) override;

--- a/spec-main/api-native-theme-spec.ts
+++ b/spec-main/api-native-theme-spec.ts
@@ -109,4 +109,10 @@ describe('nativeTheme module', () => {
       expect(nativeTheme.shouldUseHighContrastColors).to.be.a('boolean');
     });
   });
+
+  describe('nativeTheme.inForcedColorsMode', () => {
+    it('returns a boolean', () => {
+      expect(nativeTheme.inForcedColorsMode).to.be.a('boolean');
+    });
+  });
 });


### PR DESCRIPTION
Backport of #32956

See that PR for details.

Notes: Added `nativeTheme.inForcedColorsMode` API to allow detecting forced color mode.