### PR TITLE
docs: remove extra $ from npm install command

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -66,7 +66,7 @@ Your `package.json` file should look something like this:
 Then, install the `electron` package into your app's `devDependencies`.
 
 ```sh npm2yarn
-$ npm install --save-dev electron
+npm install --save-dev electron
 ```
 
 > Note: If you're encountering any issues with installing Electron, please


### PR DESCRIPTION
remove extra $ from npm install command

#### Description of Change
remove extra $ from npm install command. The $ causes the command to fail when pasted in the terminal to be run.

#### Checklist
minor doc change

#### Release Notes
Notes: none