### PR TITLE
docs: add new IPC validation section to the security tutorial

### DIFF
--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -723,6 +723,39 @@ Migrate your app one major version at a time, while referring to Electron's
 [Breaking Changes][breaking-changes] document to see if any code needs to
 be updated.
 
+### 17. Validate the `sender` of all IPC messages
+
+You should always validate incoming IPC messages `sender` property to ensure you
+aren't performing actions or sending information to untrusted renderers.
+
+#### Why?
+
+All Web Frames can in theory send IPC messages to the browser process, this includes
+iframes and child windows in some scenarios.  If you have an IPC message that returns
+user data to the sender via `event.reply` you should ensure you aren't sending that data
+to third party web frames.
+
+#### How?
+
+```js
+// Bad
+ipcMain.handle('get-secrets', () => {
+  return getSecrets();
+});
+
+// Good
+ipcMain.handle('get-secrets', (e) => {
+  if (!validateSender(e.senderFrame)) return null;
+  return getSecrets();
+});
+
+function validateSender(frame) {
+  // Value the host of the URL using an actual URL parser and an allowlist
+  if ((new URL(frame.url)).host === 'electronjs.org') return true;
+  return false;
+}
+```
+
 [breaking-changes]: ../breaking-changes.md
 [browser-window]: ../api/browser-window.md
 [browser-view]: ../api/browser-view.md

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -739,7 +739,7 @@ You should be validating the `sender` of **all** IPC messages by default.
 
 #### How?
 
-```js
+```js title='main.js (Main Process)'
 // Bad
 ipcMain.handle('get-secrets', () => {
   return getSecrets();

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -730,10 +730,10 @@ aren't performing actions or sending information to untrusted renderers.
 
 #### Why?
 
-All Web Frames can in theory send IPC messages to the browser process, this includes
+All Web Frames can in theory send IPC messages to the main process, including
 iframes and child windows in some scenarios.  If you have an IPC message that returns
 user data to the sender via `event.reply` or performs privileged actions that the renderer
-can't natively you should ensure you aren't listening to third party web frames.
+can't natively, you should ensure you aren't listening to third party web frames.
 
 You should be validating the `sender` of **all** IPC messages by default.
 

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -732,8 +732,10 @@ aren't performing actions or sending information to untrusted renderers.
 
 All Web Frames can in theory send IPC messages to the browser process, this includes
 iframes and child windows in some scenarios.  If you have an IPC message that returns
-user data to the sender via `event.reply` you should ensure you aren't sending that data
-to third party web frames.
+user data to the sender via `event.reply` or performs privileged actions that the renderer
+can't natively you should ensure you aren't listening to third party web frames.
+
+You should be validating the `sender` of **all** IPC messages by default.
 
 #### How?
 


### PR DESCRIPTION
Realized that we talk about this a lot but it isn't in the docs anywhere, this adds IPC validation to our security reccomendations

Notes: no-notes