### PR TITLE
chore: cherry-pick 2b75a29bf241 from angle

### DIFF
--- a/patches/angle/.patches
+++ b/patches/angle/.patches
@@ -4,3 +4,4 @@ m98_vulkan_fix_vkcmdresolveimage_offsets.patch
 cherry-pick-49e8ff16f1fe.patch
 m99_vulkan_prevent_out_of_bounds_read_in_divisor_emulation_path.patch
 m99_vulkan_streamvertexdatawithdivisor_write_beyond_buffer_boundary.patch
+cherry-pick-2b75a29bf241.patch

--- a/patches/angle/cherry-pick-2b75a29bf241.patch
+++ b/patches/angle/cherry-pick-2b75a29bf241.patch
@@ -1,7 +1,7 @@
-From 2b75a29bf241e2e9cefe768415cd30a2109758ae Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jamie Madill <jmadill@chromium.org>
-Date: Tue, 01 Mar 2022 15:40:38 -0500
-Subject: [PATCH] [M96-LTS] Vulkan: Fix issue with redefining a layered attachment.
+Date: Tue, 1 Mar 2022 15:40:38 -0500
+Subject: Vulkan: Fix issue with redefining a layered attachment.
 
 The fix ensures we complete level redefinition before we get the
 layer render target in TextureVk::getAttachmentRenderTarget.
@@ -13,13 +13,12 @@ Commit-Queue: Jamie Madill <jmadill@chromium.org>
 (cherry picked from commit 348ece42552a99cff88f79c80652b9dd3155ab22)
 Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3513754
 Reviewed-by: Jamie Madill <jmadill@chromium.org>
----
 
 diff --git a/src/libANGLE/renderer/vulkan/TextureVk.cpp b/src/libANGLE/renderer/vulkan/TextureVk.cpp
-index bd4dd14..439bfd6 100644
+index 75cd69adc7839fc05650fc7cc30680ca92102a7f..27902ccdec3c1674110f03df41006558b211576c 100644
 --- a/src/libANGLE/renderer/vulkan/TextureVk.cpp
 +++ b/src/libANGLE/renderer/vulkan/TextureVk.cpp
-@@ -2337,6 +2337,15 @@
+@@ -2325,6 +2325,15 @@ angle::Result TextureVk::getAttachmentRenderTarget(const gl::Context *context,
      ASSERT(mState.hasBeenBoundAsAttachment());
      ANGLE_TRY(ensureRenderable(contextVk));
  
@@ -35,7 +34,7 @@ index bd4dd14..439bfd6 100644
      if (!mImage->valid())
      {
          // Immutable texture must already have a valid image
-@@ -2376,8 +2385,6 @@
+@@ -2364,8 +2373,6 @@ angle::Result TextureVk::getAttachmentRenderTarget(const gl::Context *context,
              mState.getType(), samples, *mImage, useRobustInit));
      }
  
@@ -44,7 +43,7 @@ index bd4dd14..439bfd6 100644
      GLuint layerIndex = 0, layerCount = 0, imageLayerCount = 0;
      GetRenderTargetLayerCountAndIndex(mImage, imageIndex, &layerIndex, &layerCount,
                                        &imageLayerCount);
-@@ -2388,10 +2395,14 @@
+@@ -2376,10 +2383,14 @@ angle::Result TextureVk::getAttachmentRenderTarget(const gl::Context *context,
                                       gl::LevelIndex(imageIndex.getLevelIndex()),
                                       renderToTextureIndex);
  
@@ -64,10 +63,10 @@ index bd4dd14..439bfd6 100644
      else
      {
 diff --git a/src/tests/gl_tests/FramebufferTest.cpp b/src/tests/gl_tests/FramebufferTest.cpp
-index d95f7b5..46740ca 100644
+index d95f7b585f23af246cc65b1d68a1524c62f4024e..46740cae77df7b6e9509093c02b79a332b4f106d 100644
 --- a/src/tests/gl_tests/FramebufferTest.cpp
 +++ b/src/tests/gl_tests/FramebufferTest.cpp
-@@ -4000,6 +4000,25 @@
+@@ -4000,6 +4000,25 @@ TEST_P(FramebufferTest_ES3, BindRenderbufferThenModifySize)
      ASSERT_GL_NO_ERROR();
  }
  

--- a/patches/angle/cherry-pick-2b75a29bf241.patch
+++ b/patches/angle/cherry-pick-2b75a29bf241.patch
@@ -1,0 +1,95 @@
+From 2b75a29bf241e2e9cefe768415cd30a2109758ae Mon Sep 17 00:00:00 2001
+From: Jamie Madill <jmadill@chromium.org>
+Date: Tue, 01 Mar 2022 15:40:38 -0500
+Subject: [PATCH] [M96-LTS] Vulkan: Fix issue with redefining a layered attachment.
+
+The fix ensures we complete level redefinition before we get the
+layer render target in TextureVk::getAttachmentRenderTarget.
+
+Bug: chromium:1296866
+Change-Id: Id7fa8e9fed5e766c30580b09336713c675c4e4f0
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3498283
+Commit-Queue: Jamie Madill <jmadill@chromium.org>
+(cherry picked from commit 348ece42552a99cff88f79c80652b9dd3155ab22)
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3513754
+Reviewed-by: Jamie Madill <jmadill@chromium.org>
+---
+
+diff --git a/src/libANGLE/renderer/vulkan/TextureVk.cpp b/src/libANGLE/renderer/vulkan/TextureVk.cpp
+index bd4dd14..439bfd6 100644
+--- a/src/libANGLE/renderer/vulkan/TextureVk.cpp
++++ b/src/libANGLE/renderer/vulkan/TextureVk.cpp
+@@ -2337,6 +2337,15 @@
+     ASSERT(mState.hasBeenBoundAsAttachment());
+     ANGLE_TRY(ensureRenderable(contextVk));
+ 
++    if (mRedefinedLevels.any())
++    {
++        // If we have redefined levels, we must flush those out to fix the render targets.
++        ANGLE_TRY(respecifyImageStorage(contextVk));
++    }
++
++    // Otherwise, don't flush staged updates here. We'll handle that in FramebufferVk so we can
++    // defer clears.
++
+     if (!mImage->valid())
+     {
+         // Immutable texture must already have a valid image
+@@ -2376,8 +2385,6 @@
+             mState.getType(), samples, *mImage, useRobustInit));
+     }
+ 
+-    // Don't flush staged updates here. We'll handle that in FramebufferVk so it can defer clears.
+-
+     GLuint layerIndex = 0, layerCount = 0, imageLayerCount = 0;
+     GetRenderTargetLayerCountAndIndex(mImage, imageIndex, &layerIndex, &layerCount,
+                                       &imageLayerCount);
+@@ -2388,10 +2395,14 @@
+                                      gl::LevelIndex(imageIndex.getLevelIndex()),
+                                      renderToTextureIndex);
+ 
+-        ASSERT(imageIndex.getLevelIndex() <
+-               static_cast<int32_t>(mSingleLayerRenderTargets[renderToTextureIndex].size()));
+-        *rtOut = &mSingleLayerRenderTargets[renderToTextureIndex][imageIndex.getLevelIndex()]
+-                                           [layerIndex];
++        std::vector<RenderTargetVector> &levelRenderTargets =
++            mSingleLayerRenderTargets[renderToTextureIndex];
++        ASSERT(imageIndex.getLevelIndex() < static_cast<int32_t>(levelRenderTargets.size()));
++
++        RenderTargetVector &layerRenderTargets = levelRenderTargets[imageIndex.getLevelIndex()];
++        ASSERT(imageIndex.getLayerIndex() < static_cast<int32_t>(layerRenderTargets.size()));
++
++        *rtOut = &layerRenderTargets[layerIndex];
+     }
+     else
+     {
+diff --git a/src/tests/gl_tests/FramebufferTest.cpp b/src/tests/gl_tests/FramebufferTest.cpp
+index d95f7b5..46740ca 100644
+--- a/src/tests/gl_tests/FramebufferTest.cpp
++++ b/src/tests/gl_tests/FramebufferTest.cpp
+@@ -4000,6 +4000,25 @@
+     ASSERT_GL_NO_ERROR();
+ }
+ 
++// Tests redefining a layered framebuffer attachment.
++TEST_P(FramebufferTest_ES3, RedefineLayerAttachment)
++{
++    GLTexture texture;
++    glBindTexture(GL_TEXTURE_3D, texture);
++    std::vector<uint8_t> imgData(20480, 0);
++    glTexImage3D(GL_TEXTURE_3D, 0, GL_R8, 8, 8, 8, 0, GL_RED, GL_UNSIGNED_BYTE, imgData.data());
++
++    GLFramebuffer fbo;
++    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
++    glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, texture, 0, 8);
++    glGenerateMipmap(GL_TEXTURE_3D);
++
++    glTexImage3D(GL_TEXTURE_3D, 0, GL_R8UI, 16, 16, 16, 0, GL_RED_INTEGER, GL_UNSIGNED_BYTE,
++                 imgData.data());
++    glCopyTexSubImage3D(GL_TEXTURE_3D, 0, 0, 0, 2, 2, 15, 16, 16);
++    ASSERT_GL_NO_ERROR();
++}
++
+ ANGLE_INSTANTIATE_TEST_ES2(AddMockTextureNoRenderTargetTest);
+ ANGLE_INSTANTIATE_TEST_ES2(FramebufferTest);
+ ANGLE_INSTANTIATE_TEST_ES2_AND_ES3(FramebufferFormatsTest);


### PR DESCRIPTION
[M96-LTS] Vulkan: Fix issue with redefining a layered attachment.

The fix ensures we complete level redefinition before we get the
layer render target in TextureVk::getAttachmentRenderTarget.

Bug: chromium:1296866
Change-Id: Id7fa8e9fed5e766c30580b09336713c675c4e4f0
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3498283
Commit-Queue: Jamie Madill <jmadill@chromium.org>
(cherry picked from commit 348ece42552a99cff88f79c80652b9dd3155ab22)
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/3513754
Reviewed-by: Jamie Madill <jmadill@chromium.org>


Notes: Backported fix for CVE-2022-0976.