### PR TITLE
fix: gn check when //printing component is disabled

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -167,7 +167,7 @@
 #if BUILDFLAG(ENABLE_PRINTING)
 #include "components/printing/browser/print_manager_utils.h"
 #include "printing/backend/print_backend.h"  // nogncheck
-#include "printing/mojom/print.mojom.h"
+#include "printing/mojom/print.mojom.h"      // nogncheck
 #include "shell/browser/printing/print_preview_message_handler.h"
 #include "shell/browser/printing/print_view_manager_electron.h"
 


### PR DESCRIPTION
#### Description of Change

Building with following additional args:

```gn
enable_basic_printing=false
enable_pdf=false
enable_print_preview=false
enable_pdf_viewer=false
```

Results in:

```sh
ERROR at //electron/shell/browser/api/electron_api_web_contents.cc:170:11: Can't include this header from here.
#include "printing/mojom/print.mojom.h"
          ^---------------------------
The target:
  //electron:electron_lib
is including a file from the target:
  //printing/mojom:mojom__generator

It's usually best to depend directly on the destination target.
In some cases, the destination target is considered a subcomponent
of an intermediate target. In this case, the intermediate target
should depend publicly on the destination to forward the ability
to include headers.

Dependency chain (there may also be others):
  //electron:electron_lib -->
  //third_party/blink/public:blink -->
  //third_party/blink/public:blink_headers --[private]-->
  //printing/mojom:mojom -->
  //printing/mojom:mojom__generator
```

#### Release Notes

Notes: none