### PR TITLE
fix: BrowserView background color in webContents

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1489,11 +1489,13 @@ void WebContents::HandleNewRenderFrame(
   // Set the background color of RenderWidgetHostView.
   auto* web_preferences = WebContentsPreferences::From(web_contents());
   if (web_preferences) {
+    absl::optional<SkColor> maybe_color = web_preferences->GetBackgroundColor();
+    web_contents()->SetPageBaseBackgroundColor(maybe_color);
+
     bool guest = IsGuest() || type_ == Type::kBrowserView;
-    absl::optional<SkColor> color =
-        guest ? SK_ColorTRANSPARENT : web_preferences->GetBackgroundColor();
-    web_contents()->SetPageBaseBackgroundColor(color);
-    SetBackgroundColor(rwhv, color.value_or(SK_ColorWHITE));
+    SkColor color =
+        maybe_color.value_or(guest ? SK_ColorTRANSPARENT : SK_ColorWHITE);
+    SetBackgroundColor(rwhv, color);
   }
 
   if (!background_throttling_)

--- a/spec-main/api-browser-view-spec.ts
+++ b/spec-main/api-browser-view-spec.ts
@@ -62,7 +62,8 @@ describe('BrowserView module', () => {
       }).to.throw(/conversion failure/);
     });
 
-    ifit(process.platform !== 'linux')('sets the background color to transparent if none is set', async () => {
+    // Linux and arm64 platforms (WOA and macOS) do not return any capture sources
+    ifit(process.platform !== 'linux' && process.arch !== 'arm64')('sets the background color to transparent if none is set', async () => {
       const display = screen.getPrimaryDisplay();
       const WINDOW_BACKGROUND_COLOR = '#55ccbb';
 
@@ -85,7 +86,8 @@ describe('BrowserView module', () => {
       expect(areColorsSimilar(centerColor, WINDOW_BACKGROUND_COLOR)).to.be.true();
     });
 
-    ifit(process.platform !== 'linux')('successfully applies the background color', async () => {
+    // Linux and arm64 platforms (WOA and macOS) do not return any capture sources
+    ifit(process.platform !== 'linux' && process.arch !== 'arm64')('successfully applies the background color', async () => {
       const WINDOW_BACKGROUND_COLOR = '#55ccbb';
       const VIEW_BACKGROUND_COLOR = '#ff00ff';
       const display = screen.getPrimaryDisplay();

--- a/spec-main/api-browser-view-spec.ts
+++ b/spec-main/api-browser-view-spec.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { emittedOnce } from './events-helpers';
 import { BrowserView, BrowserWindow, screen, webContents } from 'electron/main';
 import { closeWindow } from './window-helpers';
-import { defer, startRemoteControlApp } from './spec-helpers';
+import { defer, ifit, startRemoteControlApp } from './spec-helpers';
 import { areColorsSimilar, captureScreen, getPixelColor } from './screen-helpers';
 
 describe('BrowserView module', () => {
@@ -62,7 +62,7 @@ describe('BrowserView module', () => {
       }).to.throw(/conversion failure/);
     });
 
-    it('sets the background color to transparent if none is set', async () => {
+    ifit(process.platform !== 'linux')('sets the background color to transparent if none is set', async () => {
       const display = screen.getPrimaryDisplay();
       const WINDOW_BACKGROUND_COLOR = '#55ccbb';
 
@@ -85,7 +85,7 @@ describe('BrowserView module', () => {
       expect(areColorsSimilar(centerColor, WINDOW_BACKGROUND_COLOR)).to.be.true();
     });
 
-    it('successfully applies the background color', async () => {
+    ifit(process.platform !== 'linux')('successfully applies the background color', async () => {
       const WINDOW_BACKGROUND_COLOR = '#55ccbb';
       const VIEW_BACKGROUND_COLOR = '#ff00ff';
       const display = screen.getPrimaryDisplay();


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/33374.

Fixes an issue where backgroundColor would not be applied correctly to a BrowserView on Windows. This was happening because the color was being set on the `RenderWidgetHostView` in webContents, but the color was missing from `webPreferences` and so was transparent every time. We need to ensure the color is set properly on the window as well as the contents every time `setBackgroundColor` is called, as is done on `BrowserWindow`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue with background colors being improperly applied to `BrowserView`s on Windows.
