### PR TITLE
fix: non-client windows messages on legacy widget host (again)

### DIFF
--- a/patches/chromium/fix_non-client_mouse_tracking_and_message_bubbling_on_windows.patch
+++ b/patches/chromium/fix_non-client_mouse_tracking_and_message_bubbling_on_windows.patch
@@ -13,7 +13,7 @@ messages in the legacy window handle layer.
 These conditions are regularly hit with WCO-enabled windows on Windows.
 
 diff --git a/content/browser/renderer_host/legacy_render_widget_host_win.cc b/content/browser/renderer_host/legacy_render_widget_host_win.cc
-index 4a894ef70eeb1d8489049aef552c9bae4f24ae62..f5049d730a850f2947023f976b25fb772e42107a 100644
+index 4a894ef70eeb1d8489049aef552c9bae4f24ae62..df101c53861a83f107d459270c37b3b497a00cb0 100644
 --- a/content/browser/renderer_host/legacy_render_widget_host_win.cc
 +++ b/content/browser/renderer_host/legacy_render_widget_host_win.cc
 @@ -288,12 +288,12 @@ LRESULT LegacyRenderWidgetHostHWND::OnMouseRange(UINT message,
@@ -31,19 +31,15 @@ index 4a894ef70eeb1d8489049aef552c9bae4f24ae62..f5049d730a850f2947023f976b25fb77
        tme.hwndTrack = hwnd();
        tme.dwHoverTime = 0;
        TrackMouseEvent(&tme);
-@@ -319,12 +319,11 @@ LRESULT LegacyRenderWidgetHostHWND::OnMouseRange(UINT message,
-         message, w_param, l_param, &msg_handled);
-     handled = msg_handled;
-     // If the parent did not handle non client mouse messages, we call
--    // DefWindowProc on the message with the parent window handle. This
--    // ensures that WM_SYSCOMMAND is generated for the parent and we are
--    // out of the picture.
-+    // DefWindowProc on the message. This ensures that WM_SYSCOMMAND is
-+    // generated.
+@@ -324,7 +324,10 @@ LRESULT LegacyRenderWidgetHostHWND::OnMouseRange(UINT message,
+     // out of the picture.
      if (!handled &&
           (message >= WM_NCMOUSEMOVE && message <= WM_NCXBUTTONDBLCLK)) {
 -      ret = ::DefWindowProc(GetParent(), message, w_param, l_param);
-+      ret = ::DefWindowProc(hwnd(), message, w_param, l_param);
++      // Send WM_NCMOUSEMOVE messages using the LegacyRenderWidgetHostHWND's
++      // handle so mouse tracking on non-client areas doesn't break.
++      HWND target = message == WM_NCMOUSEMOVE ? hwnd() : GetParent();
++      ret = ::DefWindowProc(target, message, w_param, l_param);
        handled = TRUE;
      }
    }


### PR DESCRIPTION
#### Description of Change

🥲 #32871 broke the double-click-to-maximize behavior on frameless and WCO windows. As they say, third time's a charm!

To expound a bit more, this patch has been modified to follow the old code path 99% of the time, and the only time it deviates from chrome is on non-client mouse move messages. This is specifically because mouse movements are tracked on the legacy window, not the actual web content (parent) window that you see.

I manually tested all the possible window controls and title bar interactions I could, from drags and double clicks and hovers and system commands (the move and size actions in the window's system menu that you control with your keyboard). Web content below seems to be functioning right as well. Everything I can think of seems to work. Hopefully that means this patch can be upstreamed!


#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).


#### Release Notes

Notes: Fixed maximizing frameless windows by double-clicking on a draggable (title bar) region.
