### PR TITLE
Update launch-app-from-url-in-another-app.md

### DIFF
--- a/docs/tutorial/launch-app-from-url-in-another-app.md
+++ b/docs/tutorial/launch-app-from-url-in-another-app.md
@@ -84,6 +84,7 @@ if (!gotTheLock) {
     createWindow()
   })
 
+  // Isn't this event mac only?
   // Handle the protocol. In this case, we choose to show an Error Box.
   app.on('open-url', (event, url) => {
     dialog.showErrorBox('Welcome Back', `You arrived from: ${url}`)


### PR DESCRIPTION
Under the Windows code section, the `open-url` event is being used while the documentation of the `app module` describes it as mac only (https://www.electronjs.org/docs/latest/api/app#event-open-url-macos)
Do I misunderstand something or it is an inconsistency?

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
