### PR TITLE
docs: Use Node's URL parser in the 5th security recommendation example

### DIFF
--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -279,11 +279,12 @@ security-conscious developers might want to assume the very opposite.
 
 ```js title='main.js (Main Process)'
 const { session } = require('electron')
+const URL = require('url').URL
 
 session
   .fromPartition('some-partition')
   .setPermissionRequestHandler((webContents, permission, callback) => {
-    const url = webContents.getURL()
+    const parsedUrl = new URL(webContents.getURL())
 
     if (permission === 'notifications') {
       // Approves the permissions request
@@ -291,7 +292,7 @@ session
     }
 
     // Verify URL
-    if (!url.startsWith('https://example.com/')) {
+    if (parsedUrl.protocol !== 'https:' || parsedUrl.host !== 'example.com') {
       // Denies the permissions request
       return callback(false)
     }


### PR DESCRIPTION
#### Description of Change

Rule 13 recommends using Node's URL parser for handling url inputs. At
the moment, this is not being followed in the code example for rule 5,
which falls back on checking that the url ends with a '/'. If this was
forgotten when a user copies this code it could introduce security
vulnerabilities if an attacker uses an URL in the following way:

"https://example.com.attacker.com"

Using Node's URL parser fixes this potential missuse and enables the
'/' to be omited from the code example.

Addresses #33192

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] relevant documentation is changed or added

#### Release Notes

Notes: none