### PR TITLE
chore: bump NMV for Electron 20

### DIFF
--- a/build/args/all.gn
+++ b/build/args/all.gn
@@ -2,7 +2,7 @@ is_electron_build = true
 root_extra_deps = [ "//electron" ]
 
 # Registry of NMVs --> https://github.com/nodejs/node/blob/master/doc/abi_version_registry.json
-node_module_version = 106
+node_module_version = 107
 
 v8_promise_internal_field_count = 1
 v8_typed_array_max_size_in_heap = 0


### PR DESCRIPTION
#### Description of Change

This PR adds a new node version number for Electron 20.

Merged Node PR here: https://github.com/nodejs/node/pull/41814

_NOTE: Please hold until the 19 branch has been cut_

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
