### PR TITLE
fix: don't unmaximize on macOS if user set max bounds

### DIFF
--- a/shell/browser/native_window_mac.h
+++ b/shell/browser/native_window_mac.h
@@ -267,6 +267,8 @@ class NativeWindowMac : public NativeWindow,
   // Maximizable window state; necessary for persistence through redraws.
   bool maximizable_ = true;
 
+  bool user_set_bounds_maximized_ = false;
+
   // Simple (pre-Lion) Fullscreen Settings
   bool always_simple_fullscreen_ = false;
   bool is_simple_fullscreen_ = false;

--- a/spec-main/api-browser-window-spec.ts
+++ b/spec-main/api-browser-window-spec.ts
@@ -3634,6 +3634,22 @@ describe('BrowserWindow module', () => {
       expectBoundsEqual(w.getSize(), initialSize);
       expectBoundsEqual(w.getPosition(), initialPosition);
     });
+
+    ifit(process.platform === 'darwin')('should not change size or position of a window which is functionally maximized', async () => {
+      const { workArea } = screen.getPrimaryDisplay();
+
+      const bounds = {
+        x: workArea.x,
+        y: workArea.y,
+        width: workArea.width,
+        height: workArea.height
+      };
+
+      const w = new BrowserWindow(bounds);
+      w.unmaximize();
+      await delay(1000);
+      expectBoundsEqual(w.getBounds(), bounds);
+    });
   });
 
   describe('setFullScreen(false)', () => {


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/33329.

Fixes an issue where a BrowserWindow would inexplicably become tiny if `BrowserWindow.unmaximize()` was called when the last set bounds were the size of the screen.

Per [docs](https://developer.apple.com/documentation/appkit/nswindow/1419513-zoom?language=objc) during `zoom:`:
 > If there’s no saved user state because there has been no previous
> zoom,the size and location of the window don’t change.

However, in classic Apple fashion, this is not the case in practice, and the frame inexplicably becomes very tiny. We should prevent zoom from being called if the window is being unmaximized and its unmaximized window bounds are themselves functionally maximized.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the the window bounds would incorrectly change if `BrowserWindow.unmaximize` was called on a window whose user bounds were maximized.
