### PR TITLE
docs: docs: simplify skipTaskbar breaking changes text

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -27,6 +27,13 @@ preload scripts _do_ depend on Node, either refactor them to remove Node usage
 from the renderer, or explicitly specify `sandbox: false` for the relevant
 renderers.
 
+### Removed: `skipTaskbar` on Linux
+
+On X11, `skipTaskbar` sends a `_NET_WM_STATE_SKIP_TASKBAR` message to the X11
+window manager. There is not a direct equivalent for Wayland, and the known
+workarounds have unacceptable tradeoffs (e.g. Window.is_skip_taskbar in GNOME
+requires unsafe mode), so Electron is unable to support this feature on Linux.
+
 ## Planned Breaking API Changes (19.0)
 
 *None (yet)*


### PR DESCRIPTION
#### Description of Change

Manually backport #33479 to 18-x-y. See that PR for details.

#### Checklist

- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none