### PR TITLE
chore: bump chromium in DEPS to 98.0.4758.141

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -15,7 +15,7 @@ gclient_gn_args = [
 
 vars = {
   'chromium_version':
-    '98.0.4758.109',
+    '98.0.4758.141',
   'node_version':
     'v16.13.0',
   'nan_version':

--- a/patches/chromium/build_do_not_depend_on_packed_resource_integrity.patch
+++ b/patches/chromium/build_do_not_depend_on_packed_resource_integrity.patch
@@ -11,7 +11,7 @@ if we ever align our .pak file generation with Chrome we can remove this
 patch.
 
 diff --git a/chrome/BUILD.gn b/chrome/BUILD.gn
-index 3f9990b36dcd0a1e8956dc3f390ed289b6166024..829fb27d568c4e556182523fa5cd9e69f1458916 100644
+index 473af396e95a4e67242c3775866fdcd4ce1f4d41..8fa395626b972e53a4c7abaef94609e5a662eaab 100644
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
 @@ -171,11 +171,16 @@ if (!is_android && !is_mac) {
@@ -33,7 +33,7 @@ index 3f9990b36dcd0a1e8956dc3f390ed289b6166024..829fb27d568c4e556182523fa5cd9e69
          "//base",
          "//build:branding_buildflags",
 diff --git a/chrome/browser/BUILD.gn b/chrome/browser/BUILD.gn
-index 0982cfa1db7233153af8b2ab7cd1c18dfb4dea49..b0f575de4c9dc6e23da5822a1591d78478aeece8 100644
+index 834601238cf5f62f7a43b5a2ccc7a743b85efbfe..d032c1b60fdff2d000f497399ea287a09afd97f0 100644
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
 @@ -4522,7 +4522,7 @@ static_library("browser") {

--- a/patches/chromium/chore_use_electron_resources_not_chrome_for_spellchecker.patch
+++ b/patches/chromium/chore_use_electron_resources_not_chrome_for_spellchecker.patch
@@ -7,10 +7,10 @@ spellchecker uses a few IDS_ resources.  We need to load these from
 Electrons grit header instead of Chromes
 
 diff --git a/chrome/browser/BUILD.gn b/chrome/browser/BUILD.gn
-index f88e5e225c4b4d23b024ba71f4e0742020952519..0982cfa1db7233153af8b2ab7cd1c18dfb4dea49 100644
+index 2c2d7552d158fc4e57691c7eae197c85e286d9c9..834601238cf5f62f7a43b5a2ccc7a743b85efbfe 100644
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -7010,6 +7010,7 @@ static_library("browser") {
+@@ -7014,6 +7014,7 @@ static_library("browser") {
      deps += [
        "//components/spellcheck/browser",
        "//components/spellcheck/common",

--- a/patches/chromium/resource_file_conflict.patch
+++ b/patches/chromium/resource_file_conflict.patch
@@ -52,10 +52,10 @@ Some alternatives to this patch:
 None of these options seems like a substantial maintainability win over this patch to me (@nornagon).
 
 diff --git a/chrome/BUILD.gn b/chrome/BUILD.gn
-index 9e2c48f5bc73375d95cb51e1793b6167fe3fd5fb..3f9990b36dcd0a1e8956dc3f390ed289b6166024 100644
+index 76e5b777539d8fbc2238a96bc0b55975ab2294f2..473af396e95a4e67242c3775866fdcd4ce1f4d41 100644
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -1545,7 +1545,7 @@ if (is_chrome_branded && !is_android) {
+@@ -1550,7 +1550,7 @@ if (is_chrome_branded && !is_android) {
    }
  }
  
@@ -64,7 +64,7 @@ index 9e2c48f5bc73375d95cb51e1793b6167fe3fd5fb..3f9990b36dcd0a1e8956dc3f390ed289
    chrome_paks("packed_resources") {
      if (is_mac) {
        output_dir = "$root_gen_dir/repack"
-@@ -1573,6 +1573,12 @@ if (!is_android) {
+@@ -1578,6 +1578,12 @@ if (!is_android) {
    }
  }
  


### PR DESCRIPTION
Updating Chromium to 98.0.4758.141.

See [all changes in 98.0.4758.109..98.0.4758.141](https://chromium.googlesource.com/chromium/src/+log/98.0.4758.109..98.0.4758.141?n=10000&pretty=fuller)

<!--
Original-Version: 98.0.4758.109
-->

Notes: Updated Chromium to 98.0.4758.141.