### PR TITLE
ci: fixup esbuild on macos

### DIFF
--- a/.circleci/build_config.yml
+++ b/.circleci/build_config.yml
@@ -246,7 +246,6 @@ step-depot-tools-get: &step-depot-tools-get
     name: Get depot tools
     command: |
       git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
-      ./depot_tools/update_depot_tools
       # remove ninjalog_uploader_wrapper.py from autoninja since we don't use it and it causes problems
       if [ "`uname`" == "Darwin" ]; then
         sed -i '' '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
@@ -471,6 +470,8 @@ step-fix-sync: &step-fix-sync
 
         # Fix esbuild (wrong binary)
         echo 'infra/3pp/tools/esbuild/${platform}' `gclient getdep --deps-file=src/third_party/devtools-frontend/src/DEPS -r 'third_party/esbuild:infra/3pp/tools/esbuild/${platform}'` > esbuild_ensure_file
+        # Remove extra output from calling gclient getdep which always calls update_depot_tools
+        sed -i '' "s/Updating depot_tools... //g" esbuild_ensure_file
         cipd ensure --root src/third_party/devtools-frontend/src/third_party/esbuild -ensure-file esbuild_ensure_file
       fi
 

--- a/.circleci/build_config.yml
+++ b/.circleci/build_config.yml
@@ -246,6 +246,7 @@ step-depot-tools-get: &step-depot-tools-get
     name: Get depot tools
     command: |
       git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git
+      ./depot_tools/update_depot_tools
       # remove ninjalog_uploader_wrapper.py from autoninja since we don't use it and it causes problems
       if [ "`uname`" == "Darwin" ]; then
         sed -i '' '/ninjalog_uploader_wrapper.py/d' ./depot_tools/autoninja
@@ -469,8 +470,6 @@ step-fix-sync: &step-fix-sync
         python3 src/tools/clang/scripts/update.py
 
         # Fix esbuild (wrong binary)
-        # Run gclient by itself in case depot tools needs an update
-        gclient
         echo 'infra/3pp/tools/esbuild/${platform}' `gclient getdep --deps-file=src/third_party/devtools-frontend/src/DEPS -r 'third_party/esbuild:infra/3pp/tools/esbuild/${platform}'` > esbuild_ensure_file
         cipd ensure --root src/third_party/devtools-frontend/src/third_party/esbuild -ensure-file esbuild_ensure_file
       fi

--- a/.circleci/build_config.yml
+++ b/.circleci/build_config.yml
@@ -469,6 +469,8 @@ step-fix-sync: &step-fix-sync
         python3 src/tools/clang/scripts/update.py
 
         # Fix esbuild (wrong binary)
+        # Run gclient by itself in case depot tools needs an update
+        gclient
         echo 'infra/3pp/tools/esbuild/${platform}' `gclient getdep --deps-file=src/third_party/devtools-frontend/src/DEPS -r 'third_party/esbuild:infra/3pp/tools/esbuild/${platform}'` > esbuild_ensure_file
         cipd ensure --root src/third_party/devtools-frontend/src/third_party/esbuild -ensure-file esbuild_ensure_file
       fi


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
https://chromium-review.googlesource.com/c/chromium/tools/depot_tools/+/3556588 changed depot_tools to echo out a message when updating depot_tools.  Unfortunately this broke our logic to update esbuild on our macOS builds, eg: 
https://app.circleci.com/pipelines/github/electron/electron/51193/workflows/a804e7b5-844e-4a76-824c-cf3b8c90aded/jobs/1170674

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->none
