### PR TITLE
test: re-enable `desktopCapturer` specs

### DIFF
--- a/spec-main/api-desktop-capturer-spec.ts
+++ b/spec-main/api-desktop-capturer-spec.ts
@@ -22,8 +22,7 @@ ifdescribe(!process.arch.includes('arm') && process.platform !== 'win32')('deskt
 
   after(closeAllWindows);
 
-  // TODO(nornagon): figure out why this test is failing on Linux and re-enable it.
-  ifit(process.platform !== 'linux')('should return a non-empty array of sources', async () => {
+  it('should return a non-empty array of sources', async () => {
     const sources = await desktopCapturer.getSources({ types: ['window', 'screen'] });
     expect(sources).to.be.an('array').that.is.not.empty();
   });
@@ -33,8 +32,7 @@ ifdescribe(!process.arch.includes('arm') && process.platform !== 'win32')('deskt
     await expect(promise).to.be.eventually.rejectedWith(Error, 'Invalid options');
   });
 
-  // TODO(nornagon): figure out why this test is failing on Linux and re-enable it.
-  ifit(process.platform !== 'linux')('does not throw an error when called more than once (regression)', async () => {
+  it('does not throw an error when called more than once (regression)', async () => {
     const sources1 = await desktopCapturer.getSources({ types: ['window', 'screen'] });
     expect(sources1).to.be.an('array').that.is.not.empty();
 
@@ -42,7 +40,7 @@ ifdescribe(!process.arch.includes('arm') && process.platform !== 'win32')('deskt
     expect(sources2).to.be.an('array').that.is.not.empty();
   });
 
-  ifit(process.platform !== 'linux')('responds to subsequent calls of different options', async () => {
+  it('responds to subsequent calls of different options', async () => {
     const promise1 = desktopCapturer.getSources({ types: ['window'] });
     await expect(promise1).to.eventually.be.fulfilled();
 
@@ -51,7 +49,7 @@ ifdescribe(!process.arch.includes('arm') && process.platform !== 'win32')('deskt
   });
 
   // Linux doesn't return any window sources.
-  ifit(process.platform !== 'linux')('returns an empty display_id for window sources on Windows and Mac', async () => {
+  ifit(process.platform !== 'linux')('returns an empty display_id for window sources', async () => {
     const w = new BrowserWindow({ width: 200, height: 200 });
     await w.loadURL('about:blank');
 
@@ -63,7 +61,7 @@ ifdescribe(!process.arch.includes('arm') && process.platform !== 'win32')('deskt
     }
   });
 
-  ifit(process.platform !== 'linux')('returns display_ids matching the Screen API on Windows and Mac', async () => {
+  ifit(process.platform !== 'linux')('returns display_ids matching the Screen API', async () => {
     const displays = screen.getAllDisplays();
     const sources = await desktopCapturer.getSources({ types: ['screen'] });
     expect(sources).to.be.an('array').of.length(displays.length);


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/20771.

These appear to work now - I'm fairly certain that the original culprit for these failures was resolved by https://github.com/electron/electron/pull/32435, but at the time we never attempted to re-enable them so we didn't know.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none