### PR TITLE
test: re-enable `test-child-process-stdio-overlapped`

### DIFF
--- a/.circleci/build_config.yml
+++ b/.circleci/build_config.yml
@@ -647,6 +647,13 @@ step-nodejs-headers-build: &step-nodejs-headers-build
       cd src
       ninja -C out/Default third_party/electron_node:headers
 
+step-nodejs-build-test-executable: &step-nodejs-build-test-executable
+  run:
+    name: Build Node.js Test Executables
+    command: |
+      cd src
+      ninja -C out/default third_party/electron_node:overlapped-checker
+
 step-electron-publish: &step-electron-publish
   run:
     name: Publish Electron Dist
@@ -1206,6 +1213,7 @@ steps-test-node: &steps-test-node
     - *step-electron-dist-unzip
     - *step-setup-linux-for-headless-testing
     - *step-fix-known-hosts-linux
+    - *step-nodejs-build-test-executable
     - run:
         name: Run Node Tests
         command: |

--- a/.circleci/build_config.yml
+++ b/.circleci/build_config.yml
@@ -647,13 +647,6 @@ step-nodejs-headers-build: &step-nodejs-headers-build
       cd src
       ninja -C out/Default third_party/electron_node:headers
 
-step-nodejs-build-test-executable: &step-nodejs-build-test-executable
-  run:
-    name: Build Node.js Test Executables
-    command: |
-      cd src
-      ninja -C out/default third_party/electron_node:overlapped-checker
-
 step-electron-publish: &step-electron-publish
   run:
     name: Publish Electron Dist
@@ -681,6 +674,7 @@ step-persist-data-for-tests: &step-persist-data-for-tests
       - src/out/Default/chromedriver.zip
       - src/out/Default/shell_browser_ui_unittests
       - src/out/Default/gen/node_headers
+      - src/out/Default/overlapped-checker
       - src/out/ffmpeg/ffmpeg.zip
       - src/electron
       - src/third_party/electron_node
@@ -817,6 +811,13 @@ step-mksnapshot-build: &step-mksnapshot-build
         ninja -C out/Default electron:electron_mksnapshot_zip -j $NUMBER_OF_NINJA_PROCESSES
         (cd out/Default; zip mksnapshot.zip mksnapshot_args gen/v8/embedded.S)
       fi
+
+step-nodejs-build-test-executable: &step-nodejs-build-test-executable
+  run:
+    name: Build Node.js Test Executables
+    command: |
+      cd src
+      ninja -C out/Default third_party/electron_node:overlapped-checker
 
 step-hunspell-build: &step-hunspell-build
   run:
@@ -1213,7 +1214,6 @@ steps-test-node: &steps-test-node
     - *step-electron-dist-unzip
     - *step-setup-linux-for-headless-testing
     - *step-fix-known-hosts-linux
-    - *step-nodejs-build-test-executable
     - run:
         name: Run Node Tests
         command: |
@@ -1440,6 +1440,9 @@ commands:
 
             # Node.js headers
             - *step-nodejs-headers-build
+
+            # Node.js test executable
+            - *step-nodejs-build-test-executable
 
             - *step-show-goma-stats
 

--- a/patches/node/build_add_gn_build_files.patch
+++ b/patches/node/build_add_gn_build_files.patch
@@ -7,10 +7,10 @@ This adds GN build files for Node, so we don't have to build with GYP.
 
 diff --git a/BUILD.gn b/BUILD.gn
 new file mode 100644
-index 0000000000000000000000000000000000000000..bd5788caa61305fd9af8f9d7f8f1937a224fda83
+index 0000000000000000000000000000000000000000..280cf63cfc1121528452d2095c8d345bb25fd873
 --- /dev/null
 +++ b/BUILD.gn
-@@ -0,0 +1,394 @@
+@@ -0,0 +1,403 @@
 +import("//electron/build/asar.gni")
 +import("//v8/gni/v8.gni")
 +
@@ -189,6 +189,15 @@ index 0000000000000000000000000000000000000000..bd5788caa61305fd9af8f9d7f8f1937a
 +      "NODE_OPENSSL_SYSTEM_CERT_PATH=\"$node_openssl_system_ca_path\"",
 +      "EVP_CTRL_CCM_SET_TAG=EVP_CTRL_GCM_SET_TAG",
 +    ]
++  }
++}
++
++executable("overlapped-checker") {
++  sources = []
++  if (is_win) {
++    sources += [ "test/overlapped-checker/main_win.c" ]
++  } else {
++    sources += [ "test/overlapped-checker/main_unix.c" ]
 +  }
 +}
 +

--- a/patches/node/build_add_gn_build_files.patch
+++ b/patches/node/build_add_gn_build_files.patch
@@ -7,7 +7,7 @@ This adds GN build files for Node, so we don't have to build with GYP.
 
 diff --git a/BUILD.gn b/BUILD.gn
 new file mode 100644
-index 0000000000000000000000000000000000000000..280cf63cfc1121528452d2095c8d345bb25fd873
+index 0000000000000000000000000000000000000000..4afca42d22ee702af50da92aa08c1de897891424
 --- /dev/null
 +++ b/BUILD.gn
 @@ -0,0 +1,403 @@

--- a/script/node-disabled-tests.json
+++ b/script/node-disabled-tests.json
@@ -7,7 +7,6 @@
   "parallel/test-buffer-constructor-node-modules-paths",
   "parallel/test-buffer-constructor-outside-node-modules",
   "parallel/test-child-process-fork-exec-path",
-  "parallel/test-child-process-stdio-overlapped",
   "parallel/test-cli-node-print-help",
   "parallel/test-cluster-bind-privileged-port",
   "parallel/test-cluster-shared-handle-bind-privileged-port",


### PR DESCRIPTION
#### Description of Change

Re-enable disabled `parallel/test-child-process-stdio-overlapped` spec. This was previously disabled owing to the fact that it relied on a small test executable being build in `node.gyp`, which we didn't build. Fixed this by building the executable as a component of the node tests in CI.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none