### PR TITLE
fix: do not run dialog callback inside transaction commit

### DIFF
--- a/docs/api/dialog.md
+++ b/docs/api/dialog.md
@@ -273,6 +273,11 @@ If `browserWindow` is not shown dialog will not be attached to it. In such case 
     will result in one button labeled "OK".
   * `defaultId` Integer (optional) - Index of the button in the buttons array which will
     be selected by default when the message box opens.
+  * `signal` AbortSignal (optional) - Pass an instance of [AbortSignal][] to
+    optionally close the message box, the message box will behave as if it was
+    cancelled by the user. On macOS, `signal` does not work with message boxes
+    that do not have a parent window, since those message boxes run
+    synchronously due to platform limitations.
   * `title` String (optional) - Title of the message box, some platforms will not show it.
   * `detail` String (optional) - Extra information of the message.
   * `checkboxLabel` String (optional) - If provided, the message box will
@@ -360,3 +365,5 @@ window is provided.
 
 You can call `BrowserWindow.getCurrentWindow().setSheetOffset(offset)` to change
 the offset from the window frame where sheets are attached.
+
+[AbortSignal]: https://nodejs.org/api/globals.html#globals_class_abortsignal

--- a/lib/browser/api/dialog.ts
+++ b/lib/browser/api/dialog.ts
@@ -22,6 +22,11 @@ enum OpenFileDialogProperties {
   dontAddToRecent = 1 << 8 // Windows
 }
 
+let nextId = 0;
+const getNextId = function () {
+  return ++nextId;
+};
+
 const normalizeAccessKey = (text: string) => {
   if (typeof text !== 'string') return text;
 
@@ -157,6 +162,7 @@ const messageBox = (sync: boolean, window: BrowserWindow | null, options?: Messa
   let {
     buttons = [],
     cancelId,
+    signal,
     checkboxLabel = '',
     checkboxChecked,
     defaultId = -1,
@@ -196,10 +202,21 @@ const messageBox = (sync: boolean, window: BrowserWindow | null, options?: Messa
     }
   }
 
+  // AbortSignal processing.
+  let id: number | undefined;
+  if (signal) {
+    // Generate an ID used for closing the message box.
+    id = getNextId();
+    // Close the message box when signal is aborted.
+    if (signal.aborted) { return Promise.resolve({ cancelId, checkboxChecked }); }
+    signal.addEventListener('abort', () => dialogBinding._closeMessageBox(id));
+  }
+
   const settings = {
     window,
     messageBoxType,
     buttons,
+    id,
     defaultId,
     cancelId,
     noLink,

--- a/script/lint.js
+++ b/script/lint.js
@@ -72,6 +72,7 @@ const LINTERS = [{
       spawnAndCheckExitCode('python', ['script/run-clang-format.py', ...filenames]);
     }
     const filter = [
+      '-readability/braces',
       '-readability/casting',
       '-whitespace/braces',
       '-whitespace/indent',

--- a/shell/browser/api/electron_api_dialog.cc
+++ b/shell/browser/api/electron_api_dialog.cc
@@ -92,6 +92,7 @@ void Initialize(v8::Local<v8::Object> exports,
   gin_helper::Dictionary dict(isolate, exports);
   dict.SetMethod("showMessageBoxSync", &ShowMessageBoxSync);
   dict.SetMethod("showMessageBox", &ShowMessageBox);
+  dict.SetMethod("_closeMessageBox", &electron::CloseMessageBox);
   dict.SetMethod("showErrorBox", &electron::ShowErrorBox);
   dict.SetMethod("showOpenDialogSync", &ShowOpenDialogSync);
   dict.SetMethod("showOpenDialog", &ShowOpenDialog);

--- a/shell/browser/ui/file_dialog_mac.mm
+++ b/shell/browser/ui/file_dialog_mac.mm
@@ -16,6 +16,9 @@
 #include "base/mac/mac_util.h"
 #include "base/mac/scoped_cftyperef.h"
 #include "base/strings/sys_string_conversions.h"
+#include "base/task/post_task.h"
+#include "content/public/browser/browser_task_traits.h"
+#include "content/public/browser/browser_thread.h"
 #include "shell/browser/native_window.h"
 #include "shell/common/gin_converters/file_path_converter.h"
 
@@ -290,6 +293,27 @@ void ReadDialogPaths(NSOpenPanel* dialog, std::vector<base::FilePath>* paths) {
   ReadDialogPathsWithBookmarks(dialog, paths, &ignored_bookmarks);
 }
 
+void ResolvePromiseInNextTick(gin_helper::Promise<v8::Local<v8::Value>> promise,
+                              v8::Local<v8::Value> value) {
+  // The completionHandler runs inside a transaction commit, and we should
+  // not do any runModal inside it. However since we can not control what
+  // users will run in the microtask, we have to delay the resolution until
+  // next tick, otherwise crash like this may happen:
+  // https://github.com/electron/electron/issues/26884
+  base::PostTask(
+      FROM_HERE, {content::BrowserThread::UI},
+      base::BindOnce(
+          [](gin_helper::Promise<v8::Local<v8::Value>> promise,
+             v8::Global<v8::Value> global) {
+            v8::Isolate* isolate = promise.isolate();
+            v8::Locker locker(isolate);
+            v8::HandleScope handle_scope(isolate);
+            v8::Local<v8::Value> value = global.Get(isolate);
+            promise.Resolve(value);
+          },
+          std::move(promise), v8::Global<v8::Value>(promise.isolate(), value)));
+}
+
 }  // namespace
 
 bool ShowOpenDialogSync(const DialogSettings& settings,
@@ -320,7 +344,6 @@ void OpenDialogCompletion(int chosen,
 #if defined(MAS_BUILD)
     dict.Set("bookmarks", std::vector<std::string>());
 #endif
-    promise.Resolve(dict);
   } else {
     std::vector<base::FilePath> paths;
     dict.Set("canceled", false);
@@ -336,8 +359,9 @@ void OpenDialogCompletion(int chosen,
     ReadDialogPaths(dialog, &paths);
     dict.Set("filePaths", paths);
 #endif
-    promise.Resolve(dict);
   }
+  ResolvePromiseInNextTick(promise.As<v8::Local<v8::Value>>(),
+                           dict.GetHandle());
 }
 
 void ShowOpenDialog(const DialogSettings& settings,
@@ -410,7 +434,8 @@ void SaveDialogCompletion(int chosen,
     }
 #endif
   }
-  promise.Resolve(dict);
+  ResolvePromiseInNextTick(promise.As<v8::Local<v8::Value>>(),
+                           dict.GetHandle());
 }
 
 void ShowSaveDialog(const DialogSettings& settings,

--- a/shell/browser/ui/message_box.h
+++ b/shell/browser/ui/message_box.h
@@ -6,10 +6,10 @@
 #define SHELL_BROWSER_UI_MESSAGE_BOX_H_
 
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "base/callback_forward.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
 #include "ui/gfx/image/image_skia.h"
 
 namespace electron {
@@ -24,12 +24,11 @@ enum class MessageBoxType {
   kQuestion,
 };
 
-using DialogResult = std::pair<int, bool>;
-
 struct MessageBoxSettings {
   electron::NativeWindow* parent_window = nullptr;
   MessageBoxType type = electron::MessageBoxType::kNone;
   std::vector<std::string> buttons;
+  absl::optional<int> id;
   int default_id;
   int cancel_id;
   bool no_link = false;
@@ -52,6 +51,8 @@ typedef base::OnceCallback<void(int code, bool checkbox_checked)>
 
 void ShowMessageBox(const MessageBoxSettings& settings,
                     MessageBoxCallback callback);
+
+void CloseMessageBox(int id);
 
 // Like ShowMessageBox with simplest settings, but safe to call at very early
 // stage of application.

--- a/shell/browser/ui/message_box_gtk.cc
+++ b/shell/browser/ui/message_box_gtk.cc
@@ -2,15 +2,19 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-#include "shell/browser/ui/gtk_util.h"
 #include "shell/browser/ui/message_box.h"
 
+#include <map>
+
 #include "base/callback.h"
+#include "base/containers/contains.h"
+#include "base/no_destructor.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "shell/browser/browser.h"
 #include "shell/browser/native_window_observer.h"
 #include "shell/browser/native_window_views.h"
+#include "shell/browser/ui/gtk_util.h"
 #include "shell/browser/unresponsive_suppressor.h"
 #include "ui/base/glib/glib_signal.h"
 #include "ui/gfx/image/image_skia.h"
@@ -38,10 +42,17 @@ MessageBoxSettings::~MessageBoxSettings() = default;
 
 namespace {
 
+// <ID, messageBox> map
+std::map<int, GtkWidget*>& GetDialogsMap() {
+  static base::NoDestructor<std::map<int, GtkWidget*>> dialogs;
+  return *dialogs;
+}
+
 class GtkMessageBox : public NativeWindowObserver {
  public:
   explicit GtkMessageBox(const MessageBoxSettings& settings)
-      : cancel_id_(settings.cancel_id),
+      : id_(settings.id),
+        cancel_id_(settings.cancel_id),
         parent_(static_cast<NativeWindow*>(settings.parent_window)) {
     // Create dialog.
     dialog_ =
@@ -50,6 +61,8 @@ class GtkMessageBox : public NativeWindowObserver {
                                GetMessageType(settings.type),   // type
                                GTK_BUTTONS_NONE,                // no buttons
                                "%s", settings.message.c_str());
+    if (id_)
+      GetDialogsMap()[*id_] = dialog_;
     if (!settings.detail.empty())
       gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog_),
                                                "%s", settings.detail.c_str());
@@ -183,6 +196,9 @@ class GtkMessageBox : public NativeWindowObserver {
  private:
   electron::UnresponsiveSuppressor unresponsive_suppressor_;
 
+  // The id of the dialog.
+  absl::optional<int> id_;
+
   // The id to return when the dialog is closed without pressing buttons.
   int cancel_id_ = 0;
 
@@ -196,6 +212,8 @@ class GtkMessageBox : public NativeWindowObserver {
 };
 
 void GtkMessageBox::OnResponseDialog(GtkWidget* widget, int response) {
+  if (id_)
+    GetDialogsMap().erase(*id_);
   gtk_widget_hide(dialog_);
 
   if (response < 0)
@@ -217,7 +235,18 @@ int ShowMessageBoxSync(const MessageBoxSettings& settings) {
 
 void ShowMessageBox(const MessageBoxSettings& settings,
                     MessageBoxCallback callback) {
+  if (settings.id && base::Contains(GetDialogsMap(), *settings.id))
+    CloseMessageBox(*settings.id);
   (new GtkMessageBox(settings))->RunAsynchronous(std::move(callback));
+}
+
+void CloseMessageBox(int id) {
+  auto it = GetDialogsMap().find(id);
+  if (it == GetDialogsMap().end()) {
+    LOG(ERROR) << "CloseMessageBox called with nonexistent ID";
+    return;
+  }
+  gtk_window_close(GTK_WINDOW(it->second));
 }
 
 void ShowErrorBox(const std::u16string& title, const std::u16string& content) {

--- a/shell/browser/ui/message_box_mac.mm
+++ b/shell/browser/ui/message_box_mac.mm
@@ -17,6 +17,9 @@
 #include "base/mac/scoped_nsobject.h"
 #include "base/no_destructor.h"
 #include "base/strings/sys_string_conversions.h"
+#include "base/task/post_task.h"
+#include "content/public/browser/browser_task_traits.h"
+#include "content/public/browser/browser_thread.h"
 #include "shell/browser/native_window.h"
 #include "skia/ext/skia_utils_mac.h"
 #include "ui/gfx/image/image_skia.h"
@@ -154,20 +157,26 @@ void ShowMessageBox(const MessageBoxSettings& settings,
     __block absl::optional<int> id = std::move(settings.id);
     __block int cancel_id = settings.cancel_id;
 
-    [alert beginSheetModalForWindow:window
-                  completionHandler:^(NSModalResponse response) {
-                    if (id)
-                      GetDialogsMap().erase(*id);
-                    // When the alert is cancelled programmatically, the
-                    // response would be something like -1000. This currently
-                    // only happens when users call CloseMessageBox API, and we
-                    // should return cancelId as result.
-                    if (response < 0)
-                      response = cancel_id;
-                    std::move(callback_).Run(
-                        response, alert.suppressionButton.state == NSOnState);
-                    [alert release];
-                  }];
+    auto handler = ^(NSModalResponse response) {
+      if (id)
+        GetDialogsMap().erase(*id);
+      // When the alert is cancelled programmatically, the response would be
+      // something like -1000. This currently only happens when users call
+      // CloseMessageBox API, and we should return cancelId as result.
+      if (response < 0)
+        response = cancel_id;
+      bool suppressed = alert.suppressionButton.state == NSOnState;
+      [alert release];
+      // The completionHandler runs inside a transaction commit, and we should
+      // not do any runModal inside it. However since we can not control what
+      // users will run in the callback, we have to delay running the callback
+      // until next tick, otherwise crash like this may happen:
+      // https://github.com/electron/electron/issues/26884
+      base::PostTask(
+          FROM_HERE, {content::BrowserThread::UI},
+          base::BindOnce(std::move(callback_), response, suppressed));
+    };
+    [alert beginSheetModalForWindow:window completionHandler:handler];
   }
 }
 

--- a/shell/browser/ui/message_box_win.cc
+++ b/shell/browser/ui/message_box_win.cc
@@ -11,8 +11,11 @@
 #include <map>
 #include <vector>
 
+#include "base/containers/contains.h"
+#include "base/no_destructor.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/synchronization/lock.h"
 #include "base/task/post_task.h"
 #include "base/win/scoped_gdi_object.h"
 #include "shell/browser/browser.h"
@@ -29,6 +32,41 @@ MessageBoxSettings::MessageBoxSettings(const MessageBoxSettings&) = default;
 MessageBoxSettings::~MessageBoxSettings() = default;
 
 namespace {
+
+struct DialogResult {
+  int button_id;
+  bool verification_flag_checked;
+};
+
+// <ID, messageBox> map.
+//
+// Note that the HWND is stored in a unique_ptr, because the pointer of HWND
+// will be passed between threads and we need to ensure the memory of HWND is
+// not changed while dialogs map is modified.
+std::map<int, std::unique_ptr<HWND>>& GetDialogsMap() {
+  static base::NoDestructor<std::map<int, std::unique_ptr<HWND>>> dialogs;
+  return *dialogs;
+}
+
+// Speical HWND used by the dialogs map.
+//
+// - ID is used but window has not been created yet.
+const HWND kHwndReserve = reinterpret_cast<HWND>(-1);
+// - Notification to cancel message box.
+const HWND kHwndCancel = reinterpret_cast<HWND>(-2);
+
+// Lock used for modifying HWND between threads.
+//
+// Note that there might be multiple dialogs being opened at the same time, but
+// we only use one lock for them all, because each dialog is independent from
+// each other and there is no need to use different lock for each one.
+// Also note that the |GetDialogsMap| is only used in the main thread, what is
+// shared between threads is the memory of HWND, so there is no need to use lock
+// when accessing dialogs map.
+base::Lock& GetHWNDLock() {
+  static base::NoDestructor<base::Lock> lock;
+  return *lock;
+}
 
 // Small command ID values are already taken by Windows, we have to start from
 // a large number to avoid conflicts with Windows.
@@ -76,6 +114,31 @@ void MapToCommonID(const std::vector<std::wstring>& buttons,
   }
 }
 
+// Callback of the task dialog. The TaskDialogIndirect API does not provide the
+// HWND of the dialog, and we have to listen to the TDN_CREATED message to get
+// it.
+// Note that this callback runs in dialog thread instead of main thread, so it
+// is possible for CloseMessageBox to be called before or all after the dialog
+// window is created.
+HRESULT CALLBACK
+TaskDialogCallback(HWND hwnd, UINT msg, WPARAM, LPARAM, LONG_PTR data) {
+  if (msg == TDN_CREATED) {
+    HWND* target = reinterpret_cast<HWND*>(data);
+    // Lock since CloseMessageBox might be called.
+    base::AutoLock lock(GetHWNDLock());
+    if (*target == kHwndCancel) {
+      // The dialog is cancelled before it is created, close it directly.
+      ::PostMessage(hwnd, WM_CLOSE, 0, 0);
+    } else if (*target == kHwndReserve) {
+      // Otherwise save the hwnd.
+      *target = hwnd;
+    } else {
+      NOTREACHED();
+    }
+  }
+  return S_OK;
+}
+
 DialogResult ShowTaskDialogWstr(NativeWindow* parent,
                                 MessageBoxType type,
                                 const std::vector<std::wstring>& buttons,
@@ -87,7 +150,8 @@ DialogResult ShowTaskDialogWstr(NativeWindow* parent,
                                 const std::wstring& detail,
                                 const std::wstring& checkbox_label,
                                 bool checkbox_checked,
-                                const gfx::ImageSkia& icon) {
+                                const gfx::ImageSkia& icon,
+                                HWND* hwnd) {
   TASKDIALOG_FLAGS flags =
       TDF_SIZE_TO_CONTENT |           // Show all content.
       TDF_ALLOW_DIALOG_CANCELLATION;  // Allow canceling the dialog.
@@ -170,12 +234,17 @@ DialogResult ShowTaskDialogWstr(NativeWindow* parent,
       config.dwFlags |= TDF_USE_COMMAND_LINKS;  // custom buttons as links.
   }
 
-  int button_id;
+  // Pass a callback to receive the HWND of the message box.
+  if (hwnd) {
+    config.pfCallback = &TaskDialogCallback;
+    config.lpCallbackData = reinterpret_cast<LONG_PTR>(hwnd);
+  }
 
   int id = 0;
-  BOOL verificationFlagChecked = FALSE;
-  TaskDialogIndirect(&config, &id, nullptr, &verificationFlagChecked);
+  BOOL verification_flag_checked = FALSE;
+  TaskDialogIndirect(&config, &id, nullptr, &verification_flag_checked);
 
+  int button_id;
   if (id_map.find(id) != id_map.end())  // common button.
     button_id = id_map[id];
   else if (id >= kIDStart)  // custom button.
@@ -183,10 +252,11 @@ DialogResult ShowTaskDialogWstr(NativeWindow* parent,
   else
     button_id = cancel_id;
 
-  return std::make_pair(button_id, verificationFlagChecked);
+  return {button_id, static_cast<bool>(verification_flag_checked)};
 }
 
-DialogResult ShowTaskDialogUTF8(const MessageBoxSettings& settings) {
+DialogResult ShowTaskDialogUTF8(const MessageBoxSettings& settings,
+                                HWND* hwnd) {
   std::vector<std::wstring> buttons;
   for (const auto& button : settings.buttons)
     buttons.push_back(base::UTF8ToWide(button));
@@ -199,33 +269,67 @@ DialogResult ShowTaskDialogUTF8(const MessageBoxSettings& settings) {
   return ShowTaskDialogWstr(
       settings.parent_window, settings.type, buttons, settings.default_id,
       settings.cancel_id, settings.no_link, title, message, detail,
-      checkbox_label, settings.checkbox_checked, settings.icon);
+      checkbox_label, settings.checkbox_checked, settings.icon, hwnd);
 }
 
 }  // namespace
 
 int ShowMessageBoxSync(const MessageBoxSettings& settings) {
   electron::UnresponsiveSuppressor suppressor;
-  DialogResult result = ShowTaskDialogUTF8(settings);
-  return result.first;
+  DialogResult result = ShowTaskDialogUTF8(settings, nullptr);
+  return result.button_id;
 }
 
 void ShowMessageBox(const MessageBoxSettings& settings,
                     MessageBoxCallback callback) {
-  dialog_thread::Run(base::BindOnce(&ShowTaskDialogUTF8, settings),
-                     base::BindOnce(
-                         [](MessageBoxCallback callback, DialogResult result) {
-                           std::move(callback).Run(result.first, result.second);
-                         },
-                         std::move(callback)));
+  // The dialog is created in a new thread so we don't know its HWND yet, put
+  // kHwndReserve in the dialogs map for now.
+  HWND* hwnd = nullptr;
+  if (settings.id) {
+    if (base::Contains(GetDialogsMap(), *settings.id))
+      CloseMessageBox(*settings.id);
+    auto it = GetDialogsMap().emplace(*settings.id,
+                                      std::make_unique<HWND>(kHwndReserve));
+    hwnd = it.first->second.get();
+  }
+
+  dialog_thread::Run(
+      base::BindOnce(&ShowTaskDialogUTF8, settings, base::Unretained(hwnd)),
+      base::BindOnce(
+          [](MessageBoxCallback callback, absl::optional<int> id,
+             DialogResult result) {
+            if (id)
+              GetDialogsMap().erase(*id);
+            std::move(callback).Run(result.button_id,
+                                    result.verification_flag_checked);
+          },
+          std::move(callback), settings.id));
+}
+
+void CloseMessageBox(int id) {
+  auto it = GetDialogsMap().find(id);
+  if (it == GetDialogsMap().end()) {
+    LOG(ERROR) << "CloseMessageBox called with nonexistent ID";
+    return;
+  }
+  HWND* hwnd = it->second.get();
+  // Lock since the TaskDialogCallback might be saving the dialog's HWND.
+  base::AutoLock lock(GetHWNDLock());
+  DCHECK(*hwnd != kHwndCancel);
+  if (*hwnd == kHwndReserve) {
+    // If the dialog window has not been created yet, tell it to cancel.
+    *hwnd = kHwndCancel;
+  } else {
+    // Otherwise send a message to close it.
+    ::PostMessage(*hwnd, WM_CLOSE, 0, 0);
+  }
 }
 
 void ShowErrorBox(const std::u16string& title, const std::u16string& content) {
   electron::UnresponsiveSuppressor suppressor;
   ShowTaskDialogWstr(nullptr, MessageBoxType::kError, {}, -1, 0, false,
-                     base::UTF8ToWide("Error"), base::UTF16ToWide(title),
-                     base::UTF16ToWide(content), base::UTF8ToWide(""), false,
-                     gfx::ImageSkia());
+                     u"Error", title, content, u"", false, gfx::ImageSkia(),
+                     nullptr);
 }
 
 }  // namespace electron

--- a/shell/common/gin_converters/message_box_converter.cc
+++ b/shell/common/gin_converters/message_box_converter.cc
@@ -4,9 +4,9 @@
 
 #include "shell/common/gin_converters/message_box_converter.h"
 
-#include "gin/dictionary.h"
 #include "shell/common/gin_converters/image_converter.h"
 #include "shell/common/gin_converters/native_window_converter.h"
+#include "shell/common/gin_helper/dictionary.h"
 
 namespace gin {
 
@@ -14,7 +14,7 @@ bool Converter<electron::MessageBoxSettings>::FromV8(
     v8::Isolate* isolate,
     v8::Local<v8::Value> val,
     electron::MessageBoxSettings* out) {
-  gin::Dictionary dict(nullptr);
+  gin_helper::Dictionary dict;
   int type = 0;
   if (!ConvertFromV8(isolate, val, &dict))
     return false;
@@ -22,6 +22,7 @@ bool Converter<electron::MessageBoxSettings>::FromV8(
   dict.Get("messageBoxType", &type);
   out->type = static_cast<electron::MessageBoxType>(type);
   dict.Get("buttons", &out->buttons);
+  dict.GetOptional("id", &out->id);
   dict.Get("defaultId", &out->default_id);
   dict.Get("cancelId", &out->cancel_id);
   dict.Get("title", &out->title);

--- a/shell/common/gin_helper/promise.h
+++ b/shell/common/gin_helper/promise.h
@@ -106,6 +106,12 @@ class Promise : public PromiseBase {
     return resolved.GetHandle();
   }
 
+  // Convert to another type.
+  template <typename NT>
+  Promise<NT> As() {
+    return Promise<NT>(isolate(), GetInner());
+  }
+
   // Promise resolution is a microtask
   // We use the MicrotasksRunner to trigger the running of pending microtasks
   v8::Maybe<bool> Resolve(const RT& value) {

--- a/spec-main/api-dialog-spec.ts
+++ b/spec-main/api-dialog-spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { dialog, BrowserWindow } from 'electron/main';
 import { closeAllWindows } from './window-helpers';
-import { ifit } from './spec-helpers';
+import { ifit, delay } from './spec-helpers';
 
 describe('dialog module', () => {
   describe('showOpenDialog', () => {
@@ -118,6 +118,62 @@ describe('dialog module', () => {
       expect(() => {
         dialog.showMessageBox({ checkboxLabel: false as any, message: '' });
       }).to.throw(/checkboxLabel must be a string/);
+    });
+  });
+
+  describe('showMessageBox with signal', () => {
+    afterEach(closeAllWindows);
+
+    it('closes message box immediately', async () => {
+      const controller = new AbortController();
+      const signal = controller.signal;
+      const w = new BrowserWindow();
+      const p = dialog.showMessageBox(w, { signal, message: 'i am message' });
+      controller.abort();
+      const result = await p;
+      expect(result.response).to.equal(0);
+    });
+
+    it('closes message box after a while', async () => {
+      const controller = new AbortController();
+      const signal = controller.signal;
+      const w = new BrowserWindow();
+      const p = dialog.showMessageBox(w, { signal, message: 'i am message' });
+      await delay(500);
+      controller.abort();
+      const result = await p;
+      expect(result.response).to.equal(0);
+    });
+
+    it('cancels message box', async () => {
+      const controller = new AbortController();
+      const signal = controller.signal;
+      const w = new BrowserWindow();
+      const p = dialog.showMessageBox(w, {
+        signal,
+        message: 'i am message',
+        buttons: ['OK', 'Cancel'],
+        cancelId: 1
+      });
+      controller.abort();
+      const result = await p;
+      expect(result.response).to.equal(1);
+    });
+
+    it('cancels message box after a while', async () => {
+      const controller = new AbortController();
+      const signal = controller.signal;
+      const w = new BrowserWindow();
+      const p = dialog.showMessageBox(w, {
+        signal,
+        message: 'i am message',
+        buttons: ['OK', 'Cancel'],
+        cancelId: 1
+      });
+      await delay(500);
+      controller.abort();
+      const result = await p;
+      expect(result.response).to.equal(1);
     });
   });
 


### PR DESCRIPTION
#### Description of Change

Manual backport of #31606 to 14-x-y. See that PR for more details.

**NOTE:** this backport required #26102, which was a `semver/minor` change, to be cherry-picked first. So we would likely need  workgroup signoff before merging.

#### Checklist

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fix crash when using sync dialog APIs immediately after async dialog APIs.