### PR TITLE
docs: remove "cache" from app.getPath

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -633,7 +633,6 @@ Returns `string` - The current application directory.
     * `~/Library/Application Support` on macOS
   * `userData` The directory for storing your app's configuration files, which by
     default it is the `appData` directory appended with your app's name.
-  * `cache`
   * `temp` Temporary directory.
   * `exe` The current executable file.
   * `module` The `libchromiumcontent` library.


### PR DESCRIPTION
#### Description of Change

It was accidentally added to public docs in https://github.com/electron/electron/pull/19480 and there is no description of it there. If we really want to expose this path, we should give it a more detailed name as it is hard to tell whether this path points to `/tmp` or `~/.cache`.

Note that `cache` and `userCache` paths were added in Electron a long time ago and there are already some apps using them, so we can not remove them in code. They were not added to public docs because Electron does not support changing path of browser cache so exposing the paths would cause confusions.

#### Release Notes

Notes: none