### PR TITLE
feat: Allow detaching a modal window from the parent window

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1725,7 +1725,8 @@ Returns whether the window can be focused.
 * `parent` BrowserWindow | null
 
 Sets `parent` as current window's parent window, passing `null` will turn
-current window into a top-level window.
+current window into a top-level window. If the current window is a modal one
+then it can be only called with `null` for detaching it from the parent.
 
 #### `win.getParentWindow()`
 

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -738,7 +738,7 @@ void BaseWindow::RemoveMenu() {
 void BaseWindow::SetParentWindow(v8::Local<v8::Value> value,
                                  gin_helper::Arguments* args) {
   if (IsModal() && !(value->IsNull() || value->IsUndefined())) {
-    args->ThrowError("Modal window can be only detached from the parent.");
+    args->ThrowError("Modal window once detached cannot be reattached.");
     return;
   }
 

--- a/shell/browser/api/electron_api_base_window.cc
+++ b/shell/browser/api/electron_api_base_window.cc
@@ -737,8 +737,8 @@ void BaseWindow::RemoveMenu() {
 
 void BaseWindow::SetParentWindow(v8::Local<v8::Value> value,
                                  gin_helper::Arguments* args) {
-  if (IsModal()) {
-    args->ThrowError("Can not be called for modal window");
+  if (IsModal() && !(value->IsNull() || value->IsUndefined())) {
+    args->ThrowError("Modal window can be only detached from the parent.");
     return;
   }
 


### PR DESCRIPTION
#### Description of Change
Allowing such detach extends a modal window lifetime management by the app.
It may be used in cases where a modal window is opened from the BrowserView.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Made a modal window detachable from the parent.