### PR TITLE
fix: nodeIntegrationInSubframes should imply !sandbox

### DIFF
--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -316,7 +316,7 @@ bool WebContentsPreferences::IsSandboxed() const {
   if (sandbox_)
     return *sandbox_;
   bool sandbox_disabled_by_default =
-      node_integration_ || node_integration_in_worker_ || preload_path_ ||
+      node_integration_ || node_integration_in_worker_ || node_integration_in_subframes_ || preload_path_ ||
       !SessionPreferences::GetValidPreloads(web_contents_->GetBrowserContext())
            .empty();
   return !sandbox_disabled_by_default;

--- a/shell/browser/web_contents_preferences.cc
+++ b/shell/browser/web_contents_preferences.cc
@@ -316,7 +316,8 @@ bool WebContentsPreferences::IsSandboxed() const {
   if (sandbox_)
     return *sandbox_;
   bool sandbox_disabled_by_default =
-      node_integration_ || node_integration_in_worker_ || node_integration_in_subframes_ || preload_path_ ||
+      node_integration_ || node_integration_in_worker_ ||
+      node_integration_in_sub_frames_ || preload_path_ ||
       !SessionPreferences::GetValidPreloads(web_contents_->GetBrowserContext())
            .empty();
   return !sandbox_disabled_by_default;


### PR DESCRIPTION
#### Description of Change
This fixes an omission in https://github.com/electron/electron/pull/30197 which meant that `nodeIntegrationInSubFrames: true` didn't correctly imply `sandbox: false` by default.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed `nodeIntegrationInSubFrames: true` not implying `sandbox: false` by default.
