### PR TITLE
fix: pend bounds change when moving BrowserWindows

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -714,6 +714,13 @@ bool NativeWindowViews::IsFullscreen() const {
 }
 
 void NativeWindowViews::SetBounds(const gfx::Rect& bounds, bool animate) {
+#if defined(OS_WIN)
+  if (is_moving_ || is_resizing_) {
+    pending_bounds_change_ = bounds;
+    return;
+  }
+#endif
+
 #if defined(OS_WIN) || defined(OS_LINUX)
   // On Linux and Windows the minimum and maximum size should be updated with
   // window size when window is not resizable.

--- a/shell/browser/native_window_views.h
+++ b/shell/browser/native_window_views.h
@@ -310,6 +310,8 @@ class NativeWindowViews : public NativeWindow,
   // Whether the window is currently being moved.
   bool is_moving_ = false;
 
+  absl::optional<gfx::Rect> pending_bounds_change_;
+
   // The color to use as the theme and symbol colors respectively for Window
   // Controls Overlay if enabled on Windows.
   SkColor overlay_button_color_;

--- a/shell/browser/native_window_views_win.cc
+++ b/shell/browser/native_window_views_win.cc
@@ -312,6 +312,15 @@ bool NativeWindowViews::PreHandleMSG(UINT message,
         NotifyWindowMoved();
         is_moving_ = false;
       }
+
+      // If the user dragged or moved the window during one or more
+      // calls to window.setBounds(), we want to apply the most recent
+      // one once they are done with the move or resize operation.
+      if (pending_bounds_change_.has_value()) {
+        SetBounds(pending_bounds_change_.value(), false /* animate */);
+        pending_bounds_change_.reset();
+      }
+
       return false;
     }
     case WM_MOVING: {


### PR DESCRIPTION
Backport of #33288.

See that PR for details.

Notes: Fixed an issue where new bounds set via `setBounds` was not correctly applied if the user was moving or resizing the window concurrently on Windows.