### PR TITLE
fix: create `userData` on requestSingleInstanceLock() if needed

### DIFF
--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1148,6 +1148,8 @@ bool App::RequestSingleInstanceLock(gin::Arguments* args) {
 
   base::FilePath user_dir;
   base::PathService::Get(chrome::DIR_USER_DATA, &user_dir);
+  // The user_dir may not have been created yet.
+  base::CreateDirectoryAndGetError(user_dir, nullptr);
 
   auto cb = base::BindRepeating(&App::OnSecondInstance, base::Unretained(this));
   auto wrapped_cb = base::BindRepeating(NotificationCallbackWrapper, cb);

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -228,7 +228,7 @@ describe('app module', () => {
       expect(code1).to.equal(0);
     });
 
-    it.only('returns true when setting non-existent user data folder', async function () {
+    it('returns true when setting non-existent user data folder', async function () {
       const appPath = path.join(fixturesPath, 'api', 'singleton-userdata');
       const instance = cp.spawn(process.execPath, [appPath]);
       const [code] = await emittedOnce(instance, 'exit');

--- a/spec-main/api-app-spec.ts
+++ b/spec-main/api-app-spec.ts
@@ -228,6 +228,13 @@ describe('app module', () => {
       expect(code1).to.equal(0);
     });
 
+    it.only('returns true when setting non-existent user data folder', async function () {
+      const appPath = path.join(fixturesPath, 'api', 'singleton-userdata');
+      const instance = cp.spawn(process.execPath, [appPath]);
+      const [code] = await emittedOnce(instance, 'exit');
+      expect(code).to.equal(0);
+    });
+
     async function testArgumentPassing (testArgs: SingleInstanceLockTestArgs) {
       const appPath = path.join(fixturesPath, 'api', 'singleton-data');
       const first = cp.spawn(process.execPath, [appPath, ...testArgs.args]);

--- a/spec/fixtures/api/singleton-userdata/main.js
+++ b/spec/fixtures/api/singleton-userdata/main.js
@@ -1,0 +1,12 @@
+const { app } = require('electron');
+const fs = require('fs');
+const path = require('path');
+
+// non-existing user data folder should not break requestSingleInstanceLock()
+// ref: https://github.com/electron/electron/issues/33547
+const userDataFolder = path.join(app.getPath('home'), 'singleton-userdata');
+fs.rmSync(userDataFolder, { force: true, recursive: true });
+app.setPath('userData', userDataFolder);
+
+const gotTheLock = app.requestSingleInstanceLock();
+app.exit(gotTheLock ? 0 : 1);

--- a/spec/fixtures/api/singleton-userdata/main.js
+++ b/spec/fixtures/api/singleton-userdata/main.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 // non-existing user data folder should not break requestSingleInstanceLock()
 // ref: https://github.com/electron/electron/issues/33547
-const userDataFolder = path.join(app.getPath('home'), 'singleton-userdata');
+const userDataFolder = path.join(app.getPath('home'), 'electron-test-singleton-userdata');
 fs.rmSync(userDataFolder, { force: true, recursive: true });
 app.setPath('userData', userDataFolder);
 

--- a/spec/fixtures/api/singleton-userdata/main.js
+++ b/spec/fixtures/api/singleton-userdata/main.js
@@ -2,7 +2,7 @@ const { app } = require('electron');
 const fs = require('fs');
 const path = require('path');
 
-// non-existing user data folder should not break requestSingleInstanceLock()
+// non-existent user data folder should not break requestSingleInstanceLock()
 // ref: https://github.com/electron/electron/issues/33547
 const userDataFolder = path.join(app.getPath('home'), 'electron-test-singleton-userdata');
 fs.rmSync(userDataFolder, { force: true, recursive: true });

--- a/spec/fixtures/api/singleton-userdata/package.json
+++ b/spec/fixtures/api/singleton-userdata/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "electron-test-singleton-userdata",
+  "main": "main.js"
+}

--- a/spec/fixtures/api/singleton/main.js
+++ b/spec/fixtures/api/singleton/main.js
@@ -1,8 +1,16 @@
 const { app } = require('electron');
+const fs = require('fs');
+const path = require('path');
 
 app.whenReady().then(() => {
   console.log('started'); // ping parent
 });
+
+// non-existing user data folder should not break requestSingleInstanceLock()
+// ref: https://github.com/electron/electron/issues/33547
+const userDataFolder = path.join(app.getPath('home'), 'electron-userData');
+fs.rmSync(userDataFolder, { force: true, recursive: true });
+app.setPath('userData', userDataFolder);
 
 const gotTheLock = app.requestSingleInstanceLock();
 

--- a/spec/fixtures/api/singleton/main.js
+++ b/spec/fixtures/api/singleton/main.js
@@ -1,16 +1,8 @@
 const { app } = require('electron');
-const fs = require('fs');
-const path = require('path');
 
 app.whenReady().then(() => {
   console.log('started'); // ping parent
 });
-
-// non-existing user data folder should not break requestSingleInstanceLock()
-// ref: https://github.com/electron/electron/issues/33547
-const userDataFolder = path.join(app.getPath('home'), 'electron-userData');
-fs.rmSync(userDataFolder, { force: true, recursive: true });
-app.setPath('userData', userDataFolder);
 
 const gotTheLock = app.requestSingleInstanceLock();
 


### PR DESCRIPTION
#### Description of Change
Closes #33547.

Regression introduced by https://github.com/electron/electron/pull/30594. The patch removed the behavior of [creating the `userData` folder](https://github.com/electron/electron/blob/5554de0237cd029a38806405ca771c57db529fa1/chromium_src/chrome/browser/process_singleton_posix.cc#L720) if needed. Without it, the single instance lock cannot be aquired and `app.requestSingleInstanceLock()` incorrectly returns false on first start of the app.

This PR restores the behavior from Electron 15 and below (= before the refactor landed). Test to prevent future regressions added as well ☺️ .

cc @magom001 @miniak @rzhao271

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed incorrect return value of `app.requestSingleInstanceLock()` when setting non-existent user data folder.
