### PR TITLE
feat: implement chrome.tabs.reload to fix PDF Viewer error

### DIFF
--- a/docs/api/extensions.md
+++ b/docs/api/extensions.md
@@ -99,6 +99,7 @@ Only `chrome.storage.local` is supported; `chrome.storage.sync` and
 The following methods of `chrome.tabs` are supported:
 
 - `chrome.tabs.sendMessage`
+- `chrome.tabs.reload`
 - `chrome.tabs.executeScript`
 - `chrome.tabs.update` (partial support)
   - supported properties: `url`, `muted`.

--- a/shell/browser/extensions/api/tabs/tabs_api.h
+++ b/shell/browser/extensions/api/tabs/tabs_api.h
@@ -46,9 +46,19 @@ class TabsExecuteScriptFunction : public ExecuteCodeInTabFunction {
   DECLARE_EXTENSION_FUNCTION("tabs.executeScript", TABS_EXECUTESCRIPT)
 };
 
+class TabsReloadFunction : public ExtensionFunction {
+  ~TabsReloadFunction() override {}
+
+  ResponseAction Run() override;
+
+  DECLARE_EXTENSION_FUNCTION("tabs.reload", TABS_RELOAD)
+};
+
 class TabsGetFunction : public ExtensionFunction {
   ~TabsGetFunction() override {}
+
   ResponseAction Run() override;
+
   DECLARE_EXTENSION_FUNCTION("tabs.get", TABS_GET)
 };
 

--- a/shell/common/extensions/api/tabs.json
+++ b/shell/common/extensions/api/tabs.json
@@ -121,6 +121,27 @@
     ],
     "functions": [
       {
+        "name": "reload",
+        "type": "function",
+        "description": "Reload a tab.",
+        "parameters": [
+          {"type": "integer", "name": "tabId", "minimum": 0, "optional": true, "description": "The ID of the tab to reload; defaults to the selected tab of the current window."},
+          {
+            "type": "object",
+            "name": "reloadProperties",
+            "optional": true,
+            "properties": {
+              "bypassCache": {
+                "type": "boolean",
+                "optional": true,
+                "description": "Whether using any local cache. Default is false."
+              }
+            }
+          },
+          {"type": "function", "name": "callback", "optional": true, "parameters": []}
+        ]
+      },
+      {
         "name": "get",
         "type": "function",
         "description": "Retrieves details about the specified tab.",


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/33519.

Addresses a failure introduced by CL:3501416, whereby if a PDF failed to load:

<img width="912" alt="Screen Shot 2022-03-31 at 11 06 08 AM" src="https://user-images.githubusercontent.com/2036040/161070182-7b177710-7ce4-414e-a1cd-24fe904abbc0.png">

and a user then clicked the `Reload` button, the following error would be seen in console:

> [86492:0331/154624.774205:INFO:CONSOLE(2251)] "Uncaught TypeError: chrome.tabs.reload is not a function", source: chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai/pdf_viewer_wrapper.js (2251)

This is fixed by implementing `chrome.tabs.reload`. Given it's `semver-minor` as a change, I think we should likely document it as we would if we were implementing it standalone.

Note: needs tests.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where the PDF Viewer would fail if a user attempted to reload.