### PR TITLE
Feat: Enable APNS registration + notification delivery in macOS apps

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1442,6 +1442,16 @@ details.
 
 **Note:** Enable `Secure Keyboard Entry` only when it is needed and disable it when it is no longer needed.
 
+### `app.registerForRemoteNotifications()` _macOS_
+
+Registers this app with Apple Push Notification service (APNS) to receive [Badge, Sound, and Alert](https://developer.apple.com/documentation/appkit/sremotenotificationtype?language=objc) notifications. If registration is successful, the BrowserWindow event `registered-for-remote-notifications` will be emitted with the APNS device token. Otherwise, the event `failed-to-register-for-remote-notifications` will be emitted.
+See: https://developer.apple.com/documentation/appkit/nsapplication/1428476-registerforremotenotificationtyp?language=objc
+
+### `app.unregisterForRemoteNotifications()` _macOS_
+
+Unregisters the app for notifications received from APNS.
+See: https://developer.apple.com/documentation/appkit/nsapplication/1428747-unregisterforremotenotifications?language=objc
+
 ## Properties
 
 ### `app.accessibilitySupportEnabled` _macOS_ _Windows_

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -687,6 +687,33 @@ Emitted when the window has closed a sheet.
 
 Emitted when the native new tab button is clicked.
 
+#### Event: 'registered-for-remote-notifications' _macOS_
+
+Returns:
+
+* `token` String - A token that identifies the device to Apple Push Notification Service (APNS)
+
+Emitted when the app successfully registers to receive remote notifications from APNS.
+See: https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428766-application?language=objc
+
+#### Event: 'failed-to-register-for-remote-notifications' _macOS_
+
+Returns:
+
+* `error` String
+
+Emitted when the app fails to register to receive remote notifications from APNS.
+See: https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428554-application?language=objc
+
+#### Event: 'received-remote-notification' _macOS_
+
+Returns:
+
+* `userInfo` Record<String, any>
+
+Emitted when the app receives a remote notification while running.
+See: https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428430-application?language=objc
+
 #### Event: 'system-context-menu' _Windows_
 
 Returns:

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -1799,6 +1799,12 @@ gin::ObjectTemplateBuilder App::GetObjectTemplateBuilder(v8::Isolate* isolate) {
       .SetMethod("moveToApplicationsFolder", &App::MoveToApplicationsFolder)
       .SetMethod("isInApplicationsFolder", &App::IsInApplicationsFolder)
       .SetMethod("setActivationPolicy", &App::SetActivationPolicy)
+      .SetMethod("registerForRemoteNotifications",
+                 base::BindRepeating(&Browser::RegisterForRemoteNotifications,
+                                     browser))
+      .SetMethod("unregisterForRemoteNotifications",
+                 base::BindRepeating(&Browser::UnregisterForRemoteNotifications,
+                                     browser))
 #endif
       .SetMethod("setAboutPanelOptions",
                  base::BindRepeating(&Browser::SetAboutPanelOptions, browser))

--- a/shell/browser/api/electron_api_app.cc
+++ b/shell/browser/api/electron_api_app.cc
@@ -783,6 +783,21 @@ void App::OnNewWindowForTab() {
 void App::OnDidBecomeActive() {
   Emit("did-become-active");
 }
+
+void App::OnDidRegisterForRemoteNotificationsWithDeviceToken(
+    const std::string& token) {
+  Emit("registered-for-remote-notifications", token);
+}
+
+void App::OnDidFailToRegisterForRemoteNotificationsWithError(
+    const std::string& error) {
+  Emit("failed-to-register-for-remote-notifications", error);
+}
+
+void App::OnDidReceiveRemoteNotification(
+    const base::DictionaryValue& user_info) {
+  Emit("received-remote-notification", user_info);
+}
 #endif
 
 bool App::CanCreateWindow(

--- a/shell/browser/api/electron_api_app.h
+++ b/shell/browser/api/electron_api_app.h
@@ -118,6 +118,12 @@ class App : public ElectronBrowserClient::Delegate,
       const base::DictionaryValue& user_info) override;
   void OnNewWindowForTab() override;
   void OnDidBecomeActive() override;
+  void OnDidRegisterForRemoteNotificationsWithDeviceToken(
+      const std::string& token) override;
+  void OnDidFailToRegisterForRemoteNotificationsWithError(
+      const std::string& error) override;
+  void OnDidReceiveRemoteNotification(
+      const base::DictionaryValue& user_info) override;
 #endif
 
   // content::ContentBrowserClient:

--- a/shell/browser/browser.h
+++ b/shell/browser/browser.h
@@ -227,6 +227,23 @@ class Browser : public WindowListObserver {
   // Set docks' icon.
   void DockSetIcon(v8::Isolate* isolate, v8::Local<v8::Value> icon);
 
+  // Register with APNS
+  void RegisterForRemoteNotifications();
+  void UnregisterForRemoteNotifications();
+
+  // Indicates that APNS registration succeeded, the token can be used to send
+  // notifications.
+  void DidRegisterForRemoteNotificationsWithDeviceToken(
+      const std::string& token);
+
+  // Indicates a failure to register for APNS
+  void DidFailToRegisterForRemoteNotificationsWithError(
+      const std::string& error);
+
+  // Indicates that a new remote notification has been received while the app is
+  // running.
+  void DidReceiveRemoteNotification(const base::DictionaryValue& user_info);
+
 #endif  // BUILDFLAG(IS_MAC)
 
   void ShowAboutPanel();

--- a/shell/browser/browser_mac.mm
+++ b/shell/browser/browser_mac.mm
@@ -532,4 +532,34 @@ void Browser::SetSecureKeyboardEntryEnabled(bool enabled) {
   }
 }
 
+void Browser::RegisterForRemoteNotifications() {
+  [[AtomApplication sharedApplication]
+      registerForRemoteNotificationTypes:NSRemoteNotificationTypeBadge |
+                                         NSRemoteNotificationTypeAlert |
+                                         NSRemoteNotificationTypeSound];
+
+}
+
+void Browser::UnregisterForRemoteNotifications() {
+  [[AtomApplication sharedApplication] unregisterForRemoteNotifications];
+}
+
+void Browser::DidRegisterForRemoteNotificationsWithDeviceToken(
+    const std::string& token) {
+  for (BrowserObserver& observer : observers_)
+    observer.OnDidRegisterForRemoteNotificationsWithDeviceToken(token);
+}
+
+void Browser::DidFailToRegisterForRemoteNotificationsWithError(
+    const std::string& error) {
+  for (BrowserObserver& observer : observers_)
+    observer.OnDidFailToRegisterForRemoteNotificationsWithError(error);
+}
+
+void Browser::DidReceiveRemoteNotification(
+    const base::DictionaryValue& user_info) {
+  for (BrowserObserver& observer : observers_)
+    observer.OnDidReceiveRemoteNotification(user_info);
+}
+
 }  // namespace electron

--- a/shell/browser/browser_observer.h
+++ b/shell/browser/browser_observer.h
@@ -86,6 +86,18 @@ class BrowserObserver : public base::CheckedObserver {
 
   // Browser did become active.
   virtual void OnDidBecomeActive() {}
+
+  // The browser successfully registered for APNS. (macOS only)
+  virtual void OnDidRegisterForRemoteNotificationsWithDeviceToken(
+      const std::string& token) {}
+
+  // The browser failed to register for APNS. (macOS only)
+  virtual void OnDidFailToRegisterForRemoteNotificationsWithError(
+      const std::string& error) {}
+
+  // The browser received a remote notification from APNS (macOS only)
+  virtual void OnDidReceiveRemoteNotification(
+      const base::DictionaryValue& user_info) {}
 #endif
 
  protected:

--- a/shell/browser/mac/electron_application_delegate.mm
+++ b/shell/browser/mac/electron_application_delegate.mm
@@ -191,4 +191,31 @@ static NSDictionary* UNNotificationResponseToNSDictionary(
   electron::Browser::Get()->NewWindowForTab();
 }
 
+- (void)application:(NSApplication*)application
+    didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken {
+  // https://stackoverflow.com/a/16411517
+  const char* tokenData = static_cast<const char*>([deviceToken bytes]);
+  NSMutableString* tokenString = [NSMutableString string];
+  for (NSUInteger i = 0; i < [deviceToken length]; i++) {
+    [tokenString appendFormat:@"%02.2hhX", tokenData[i]];
+  }
+  electron::Browser::Get()->DidRegisterForRemoteNotificationsWithDeviceToken(
+      base::SysNSStringToUTF8(tokenString));
+}
+
+- (void)application:(NSApplication*)application
+    didFailToRegisterForRemoteNotificationsWithError:(NSError*)error {
+  std::string error_message(base::SysNSStringToUTF8(
+      [NSString stringWithFormat:@"%ld %@ %@", [error code], [error domain],
+                                 [error userInfo]]));
+  electron::Browser::Get()->DidFailToRegisterForRemoteNotificationsWithError(
+      error_message);
+}
+
+- (void)application:(NSApplication*)application
+    didReceiveRemoteNotification:(NSDictionary*)userInfo {
+  electron::Browser::Get()->DidReceiveRemoteNotification(
+      electron::NSDictionaryToDictionaryValue(userInfo));
+}
+
 @end


### PR DESCRIPTION
#### Description of Change

Want to pick up on previous attempts https://github.com/electron/electron/pull/13777 and https://github.com/electron/electron/pull/18286 by @frantic and @kevinhu88 to enable APNS in Electron.

My understanding is that @miniak 's https://github.com/electron/electron/pull/18286 was blocked on concerns over supporting `UserNotification` and `NSUserNotifications` at the same time. This subset (APNS registration + notification receipt) doesn't actually seem to reference the `UserNotification` object (the relevant `UserNotification` -related code appears to have been handled in https://github.com/electron/electron/pull/25950.)

I've ported over the remaining functionality to register + receive APNS notifications into a separate fork (as the previous PR appears to be blocked on merge conflicts) and have confirmed successful registration + notification receipt via APNs with [this](https://github.com/electron/electron-quick-start/compare/master...joanx:master) sample app (note, I needed to create a provisioning profile + code-sign this app for successful APNS registration).

Would love to re-start the conversation around what it would take to enable APNS in Electron. Thanks in advance!

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->

Notes: Added support for push notifications from APNs for macOS apps.
