### PR TITLE
Handle SIGUSR2

### DIFF
--- a/script/start.js
+++ b/script/start.js
@@ -14,3 +14,4 @@ const handleTerminationSignal = (signal) =>
 
 handleTerminationSignal('SIGINT');
 handleTerminationSignal('SIGTERM');
+handleTerminationSignal('SIGUSR2');


### PR DESCRIPTION
#### Description of Change

`start-server-webpack-plugin` uses `SIGUSR2` to signal an HMR update to a server process: https://github.com/ericclemmons/start-server-webpack-plugin/blob/master/src/StartServerPlugin.js#L70

Note that this signal does not actually kill the child process, but merely functions as a message-passing system.

#### Release Notes

Notes: none
