### PR TITLE
fix: revert "fix: some frameless windows showing a frame on Windows"

### DIFF
--- a/shell/browser/native_window_views.cc
+++ b/shell/browser/native_window_views.cc
@@ -340,14 +340,15 @@ NativeWindowViews::NativeWindowViews(const gin_helper::Dictionary& options,
     // Set Window style so that we get a minimize and maximize animation when
     // frameless.
     DWORD frame_style = WS_CAPTION | WS_OVERLAPPED;
-    if (resizable_ && thick_frame_)
+    if (resizable_)
       frame_style |= WS_THICKFRAME;
     if (minimizable_)
       frame_style |= WS_MINIMIZEBOX;
     if (maximizable_)
       frame_style |= WS_MAXIMIZEBOX;
-    if (!thick_frame_ || !has_frame())
-      frame_style &= ~WS_CAPTION;
+    // We should not show a frame for transparent window.
+    if (!thick_frame_)
+      frame_style &= ~(WS_THICKFRAME | WS_CAPTION);
     ::SetWindowLong(GetAcceleratedWidget(), GWL_STYLE, frame_style);
   }
 


### PR DESCRIPTION
Reverts electron/electron#32692

I agree with [this](https://github.com/electron/electron/issues/32981#issuecomment-1083938180), the original bug is solvable by following best practices.  The new bugs are worse and not solvable by end users.

Notes: Fixes issues with frameless window animations and styling