### PR TITLE
fix: report more detailed errors in shell.openExternal() on Windows

### DIFF
--- a/shell/common/platform_util_win.cc
+++ b/shell/common/platform_util_win.cc
@@ -251,7 +251,8 @@ std::string OpenExternalOnWorkerThread(
           ShellExecuteW(nullptr, L"open", escaped_url.c_str(), nullptr,
                         working_dir.empty() ? nullptr : working_dir.c_str(),
                         SW_SHOWNORMAL)) <= 32) {
-    return "Failed to open";
+    return "Failed to open: " +
+           logging::SystemErrorCodeToString(logging::GetLastSystemErrorCode());
   }
   return "";
 }


### PR DESCRIPTION
#### Description of Change
Report more detailed errors in `shell.openExternal()` on Windows.

Before:
> Error: Failed to open

After:
> Error: Failed to open: The system cannot find the file specified. (0x2)

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes
Notes: `shell.openExternal()` now reports more detailed errors on Windows.
