### PR TITLE
feat: add immersive dark mode on windows

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -596,10 +596,7 @@ source_set("electron_lib") {
     ]
   }
   if (is_win) {
-    libs += [
-      "dwmapi.lib",
-      "uxtheme.lib",
-    ]
+    libs += [ "dwmapi.lib" ]
     deps += [
       "//components/crash/core/app:crash_export_thunks",
       "//ui/native_theme:native_theme_browser",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -596,7 +596,10 @@ source_set("electron_lib") {
     ]
   }
   if (is_win) {
-    libs += [ "dwmapi.lib" ]
+    libs += [
+      "dwmapi.lib",
+      "uxtheme.lib",
+    ]
     deps += [
       "//components/crash/core/app:crash_export_thunks",
       "//ui/native_theme:native_theme_browser",
@@ -725,14 +728,6 @@ source_set("electron_lib") {
   }
 
   sources += get_target_outputs(":electron_fuses")
-
-  if (is_win && enable_win_dark_mode_window_ui) {
-    sources += [
-      "shell/browser/win/dark_mode.cc",
-      "shell/browser/win/dark_mode.h",
-    ]
-    libs += [ "uxtheme.lib" ]
-  }
 
   if (allow_runtime_configurable_key_storage) {
     defines += [ "ALLOW_RUNTIME_CONFIGURABLE_KEY_STORAGE" ]

--- a/build/fuses/fuses.json5
+++ b/build/fuses/fuses.json5
@@ -8,5 +8,5 @@
   "node_cli_inspect": "1",
   "embedded_asar_integrity_validation": "0",
   "only_load_app_from_asar": "0",
-  "windows_immersive_dark_mode": "0"
+  "windows_10_immersive_dark_mode": "0"
 }

--- a/build/fuses/fuses.json5
+++ b/build/fuses/fuses.json5
@@ -7,5 +7,6 @@
   "node_options": "1",
   "node_cli_inspect": "1",
   "embedded_asar_integrity_validation": "0",
-  "only_load_app_from_asar": "0"
+  "only_load_app_from_asar": "0",
+  "windows_immersive_dark_mode": "1"
 }

--- a/build/fuses/fuses.json5
+++ b/build/fuses/fuses.json5
@@ -8,5 +8,5 @@
   "node_cli_inspect": "1",
   "embedded_asar_integrity_validation": "0",
   "only_load_app_from_asar": "0",
-  "windows_immersive_dark_mode": "1"
+  "windows_immersive_dark_mode": "0"
 }

--- a/build/fuses/fuses.json5
+++ b/build/fuses/fuses.json5
@@ -7,6 +7,5 @@
   "node_options": "1",
   "node_cli_inspect": "1",
   "embedded_asar_integrity_validation": "0",
-  "only_load_app_from_asar": "0",
-  "windows_10_immersive_dark_mode": "0"
+  "only_load_app_from_asar": "0"
 }

--- a/buildflags/BUILD.gn
+++ b/buildflags/BUILD.gn
@@ -19,7 +19,6 @@ buildflag_header("buildflags") {
     "ENABLE_ELECTRON_EXTENSIONS=$enable_electron_extensions",
     "ENABLE_BUILTIN_SPELLCHECKER=$enable_builtin_spellchecker",
     "ENABLE_PICTURE_IN_PICTURE=$enable_picture_in_picture",
-    "ENABLE_WIN_DARK_MODE_WINDOW_UI=$enable_win_dark_mode_window_ui",
     "OVERRIDE_LOCATION_PROVIDER=$enable_fake_location_provider",
   ]
 }

--- a/buildflags/buildflags.gni
+++ b/buildflags/buildflags.gni
@@ -31,7 +31,4 @@ declare_args() {
 
   # Enable Spellchecker support
   enable_builtin_spellchecker = true
-
-  # Undocumented Windows dark mode API
-  enable_win_dark_mode_window_ui = false
 }

--- a/filenames.gni
+++ b/filenames.gni
@@ -105,6 +105,8 @@ filenames = {
     "shell/browser/ui/win/notify_icon.h",
     "shell/browser/ui/win/taskbar_host.cc",
     "shell/browser/ui/win/taskbar_host.h",
+    "shell/browser/win/dark_mode.cc",
+    "shell/browser/win/dark_mode.h",
     "shell/browser/win/scoped_hstring.cc",
     "shell/browser/win/scoped_hstring.h",
     "shell/common/api/electron_api_native_image_win.cc",

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -6,6 +6,7 @@
 
 #include "base/win/windows_version.h"
 #include "electron/buildflags/buildflags.h"
+#include "electron/fuses.h"
 #include "shell/browser/ui/views/win_frame_view.h"
 #include "shell/browser/win/dark_mode.h"
 #include "ui/base/win/hwnd_metrics.h"

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.cc
@@ -6,7 +6,6 @@
 
 #include "base/win/windows_version.h"
 #include "electron/buildflags/buildflags.h"
-#include "electron/fuses.h"
 #include "shell/browser/ui/views/win_frame_view.h"
 #include "shell/browser/win/dark_mode.h"
 #include "ui/base/win/hwnd_metrics.h"
@@ -27,12 +26,11 @@ bool ElectronDesktopWindowTreeHostWin::PreHandleMSG(UINT message,
                                                     WPARAM w_param,
                                                     LPARAM l_param,
                                                     LRESULT* result) {
-  if (electron::fuses::IsWindowsImmersiveDarkModeEnabled() &&
-      message == WM_NCCREATE) {
+  const bool dark_mode_supported = win::IsDarkModeSupported();
+  if (dark_mode_supported && message == WM_NCCREATE) {
     win::SetDarkModeForWindow(GetAcceleratedWidget());
     ui::NativeTheme::GetInstanceForNativeUi()->AddObserver(this);
-  } else if (electron::fuses::IsWindowsImmersiveDarkModeEnabled() &&
-             message == WM_DESTROY) {
+  } else if (dark_mode_supported && message == WM_DESTROY) {
     ui::NativeTheme::GetInstanceForNativeUi()->RemoveObserver(this);
   }
 

--- a/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
+++ b/shell/browser/ui/win/electron_desktop_window_tree_host_win.h
@@ -12,8 +12,8 @@
 
 namespace electron {
 
-class ElectronDesktopWindowTreeHostWin
-    : public views::DesktopWindowTreeHostWin {
+class ElectronDesktopWindowTreeHostWin : public views::DesktopWindowTreeHostWin,
+                                         public ::ui::NativeThemeObserver {
  public:
   ElectronDesktopWindowTreeHostWin(
       NativeWindowViews* native_window_view,
@@ -36,6 +36,9 @@ class ElectronDesktopWindowTreeHostWin
   bool GetDwmFrameInsetsInPixels(gfx::Insets* insets) const override;
   bool GetClientAreaInsets(gfx::Insets* insets,
                            HMONITOR monitor) const override;
+
+  // ui::NativeThemeObserver:
+  void OnNativeThemeUpdated(ui::NativeTheme* observed_theme) override;
 
  private:
   NativeWindowViews* native_window_view_;  // weak ref

--- a/shell/browser/win/dark_mode.cc
+++ b/shell/browser/win/dark_mode.cc
@@ -6,7 +6,6 @@
 
 #include <dwmapi.h>  // DwmSetWindowAttribute()
 
-#define DARK_MODE_STRING_NAME L"DarkMode_Explorer"
 #define DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1 19
 #define DWMWA_USE_IMMERSIVE_DARK_MODE 20
 
@@ -17,15 +16,10 @@ namespace {
 
 // Use private Windows API to set window theme.
 HRESULT TrySetWindowTheme(HWND hWnd, bool dark) {
-  HRESULT result =
-      SetWindowTheme(hWnd, dark ? DARK_MODE_STRING_NAME : L"", nullptr);
-  if (FAILED(result))
-    return result;
-
   const BOOL isDarkMode = dark;
   if (FAILED(DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
                                    &isDarkMode, sizeof(isDarkMode)))) {
-    result =
+    HRESULT result =
         DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1,
                               &isDarkMode, sizeof(isDarkMode));
     if (FAILED(result))

--- a/shell/browser/win/dark_mode.cc
+++ b/shell/browser/win/dark_mode.cc
@@ -19,8 +19,8 @@ namespace {
 // https://docs.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute
 HRESULT TrySetWindowTheme(HWND hWnd, bool dark) {
   const BOOL isDarkMode = dark;
-  HRESULT result = DwmSetWindowAttribute(
-    hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &isDarkMode, sizeof(isDarkMode));
+  HRESULT result = DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
+                                         &isDarkMode, sizeof(isDarkMode));
 
   if (FAILED(result))
     return result;

--- a/shell/browser/win/dark_mode.cc
+++ b/shell/browser/win/dark_mode.cc
@@ -32,6 +32,11 @@ HRESULT TrySetWindowTheme(HWND hWnd, bool dark) {
       return result;
   }
 
+  // Toggle the nonclient area active state to force a redraw
+  HWND activeWindow = GetActiveWindow();
+  SendMessage(hWnd, WM_NCACTIVATE, hWnd != activeWindow, 0);
+  SendMessage(hWnd, WM_NCACTIVATE, hWnd == activeWindow, 0);
+
   return S_OK;
 }
 

--- a/shell/browser/win/dark_mode.cc
+++ b/shell/browser/win/dark_mode.cc
@@ -29,7 +29,7 @@ HRESULT TrySetWindowThemeOnWin10(HWND hWnd, bool dark) {
       return result;
   }
 
-  // Toggle the nonclient area active state to force a redraw (workaround for Windows 10)
+  // Toggle the nonclient area active state to force a redraw (Win10 workaround)
   HWND activeWindow = GetActiveWindow();
   SendMessage(hWnd, WM_NCACTIVATE, hWnd != activeWindow, 0);
   SendMessage(hWnd, WM_NCACTIVATE, hWnd == activeWindow, 0);
@@ -37,10 +37,11 @@ HRESULT TrySetWindowThemeOnWin10(HWND hWnd, bool dark) {
   return S_OK;
 }
 
-// Docs: https://docs.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute
+// https://docs.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute
 HRESULT TrySetWindowTheme(HWND hWnd, bool dark) {
   const BOOL isDarkMode = dark;
-  return DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &isDarkMode, sizeof(isDarkMode));
+  return DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &isDarkMode,
+                               sizeof(isDarkMode));
 }
 
 }  // namespace

--- a/shell/browser/win/dark_mode.cc
+++ b/shell/browser/win/dark_mode.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Microsoft Inc. All rights reserved.
+// Copyright (c) 2022 Microsoft Inc. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-CHROMIUM file.
 
@@ -6,173 +6,46 @@
 
 #include <dwmapi.h>  // DwmSetWindowAttribute()
 
-#include "base/files/file_path.h"
-#include "base/scoped_native_library.h"
-#include "base/win/pe_image.h"
-#include "base/win/win_util.h"
-#include "base/win/windows_version.h"
+#define DARK_MODE_STRING_NAME L"DarkMode_Explorer"
+#define DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1 19
+#define DWMWA_USE_IMMERSIVE_DARK_MODE 20
 
 // This namespace contains code originally from
-// https://github.com/ysc3839/win32-darkmode/
-// governed by the MIT license and (c) Richard Yu
+// https://github.com/microsoft/terminal
+// governed by the MIT license and (c) Microsoft Corporation.
 namespace {
 
-// 1903 18362
-enum PreferredAppMode { Default, AllowDark, ForceDark, ForceLight, Max };
+// Use private Windows API to set window theme.
+HRESULT TrySetWindowTheme(HWND hWnd, bool dark) {
+  HRESULT result =
+      SetWindowTheme(hWnd, dark ? DARK_MODE_STRING_NAME : L"", nullptr);
+  if (FAILED(result))
+    return result;
 
-bool g_darkModeSupported = false;
-bool g_darkModeEnabled = false;
-DWORD g_buildNumber = 0;
-
-enum WINDOWCOMPOSITIONATTRIB {
-  WCA_USEDARKMODECOLORS = 26  // build 18875+
-};
-struct WINDOWCOMPOSITIONATTRIBDATA {
-  WINDOWCOMPOSITIONATTRIB Attrib;
-  PVOID pvData;
-  SIZE_T cbData;
-};
-
-using fnSetWindowCompositionAttribute =
-    BOOL(WINAPI*)(HWND hWnd, WINDOWCOMPOSITIONATTRIBDATA*);
-fnSetWindowCompositionAttribute _SetWindowCompositionAttribute = nullptr;
-
-bool IsHighContrast() {
-  HIGHCONTRASTW highContrast = {sizeof(highContrast)};
-  if (SystemParametersInfoW(SPI_GETHIGHCONTRAST, sizeof(highContrast),
-                            &highContrast, FALSE))
-    return highContrast.dwFlags & HCF_HIGHCONTRASTON;
-  return false;
-}
-
-void RefreshTitleBarThemeColor(HWND hWnd, bool dark) {
-  LONG ldark = dark;
-  if (g_buildNumber >= 20161) {
-    // DWMA_USE_IMMERSIVE_DARK_MODE = 20
-    DwmSetWindowAttribute(hWnd, 20, &ldark, sizeof dark);
-    return;
-  }
-  if (g_buildNumber >= 18363) {
-    auto data = WINDOWCOMPOSITIONATTRIBDATA{WCA_USEDARKMODECOLORS, &ldark,
-                                            sizeof ldark};
-    _SetWindowCompositionAttribute(hWnd, &data);
-    return;
-  }
-  DwmSetWindowAttribute(hWnd, 0x13, &ldark, sizeof ldark);
-}
-
-void InitDarkMode() {
-  // confirm that we're running on a version of Windows
-  // where the Dark Mode API is known
-  auto* os_info = base::win::OSInfo::GetInstance();
-  g_buildNumber = os_info->version_number().build;
-  auto const version = os_info->version();
-  if ((version < base::win::Version::WIN10_RS5) ||
-      (version > base::win::Version::WIN10_20H1)) {
-    return;
+  const BOOL isDarkMode = dark;
+  if (FAILED(DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
+                                   &isDarkMode, sizeof(isDarkMode)))) {
+    result =
+        DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1,
+                              &isDarkMode, sizeof(isDarkMode));
+    if (FAILED(result))
+      return result;
   }
 
-  // load "SetWindowCompositionAttribute", used in RefreshTitleBarThemeColor()
-  _SetWindowCompositionAttribute =
-      reinterpret_cast<decltype(_SetWindowCompositionAttribute)>(
-          base::win::GetUser32FunctionPointer("SetWindowCompositionAttribute"));
-  if (_SetWindowCompositionAttribute == nullptr) {
-    return;
-  }
-
-  // load the dark mode functions from uxtheme.dll
-  // * RefreshImmersiveColorPolicyState()
-  // * ShouldAppsUseDarkMode()
-  // * AllowDarkModeForApp()
-  // * SetPreferredAppMode()
-  // * AllowDarkModeForApp() (build < 18362)
-  // * SetPreferredAppMode() (build >= 18362)
-
-  base::NativeLibrary uxtheme =
-      base::PinSystemLibrary(FILE_PATH_LITERAL("uxtheme.dll"));
-  if (!uxtheme) {
-    return;
-  }
-  auto ux_pei = base::win::PEImage(uxtheme);
-  auto get_ux_proc_from_ordinal = [&ux_pei](int ordinal, auto* setme) {
-    FARPROC proc = ux_pei.GetProcAddress(reinterpret_cast<LPCSTR>(ordinal));
-    *setme = reinterpret_cast<decltype(*setme)>(proc);
-  };
-
-  // ordinal 104
-  using fnRefreshImmersiveColorPolicyState = VOID(WINAPI*)();
-  fnRefreshImmersiveColorPolicyState _RefreshImmersiveColorPolicyState = {};
-  get_ux_proc_from_ordinal(104, &_RefreshImmersiveColorPolicyState);
-
-  // ordinal 132
-  using fnShouldAppsUseDarkMode = BOOL(WINAPI*)();
-  fnShouldAppsUseDarkMode _ShouldAppsUseDarkMode = {};
-  get_ux_proc_from_ordinal(132, &_ShouldAppsUseDarkMode);
-
-  // ordinal 135, in 1809
-  using fnAllowDarkModeForApp = BOOL(WINAPI*)(BOOL allow);
-  fnAllowDarkModeForApp _AllowDarkModeForApp = {};
-
-  // ordinal 135, in 1903
-  typedef PreferredAppMode(WINAPI *
-                           fnSetPreferredAppMode)(PreferredAppMode appMode);
-  fnSetPreferredAppMode _SetPreferredAppMode = {};
-
-  if (g_buildNumber < 18362) {
-    get_ux_proc_from_ordinal(135, &_AllowDarkModeForApp);
-  } else {
-    get_ux_proc_from_ordinal(135, &_SetPreferredAppMode);
-  }
-
-  // dark mode is supported iff we found the functions
-  g_darkModeSupported = _RefreshImmersiveColorPolicyState &&
-                        _ShouldAppsUseDarkMode &&
-                        (_AllowDarkModeForApp || _SetPreferredAppMode);
-  if (!g_darkModeSupported) {
-    return;
-  }
-
-  // initial setup: allow dark mode to be used
-  if (_AllowDarkModeForApp) {
-    _AllowDarkModeForApp(true);
-  } else if (_SetPreferredAppMode) {
-    _SetPreferredAppMode(AllowDark);
-  }
-  _RefreshImmersiveColorPolicyState();
-
-  // check to see if dark mode is currently enabled
-  g_darkModeEnabled = _ShouldAppsUseDarkMode() && !IsHighContrast();
+  return S_OK;
 }
 
 }  // namespace
 
 namespace electron {
 
-void EnsureInitialized() {
-  static bool initialized = false;
-  if (!initialized) {
-    initialized = true;
-    ::InitDarkMode();
-  }
-}
-
-bool IsDarkPreferred(ui::NativeTheme::ThemeSource theme_source) {
-  switch (theme_source) {
-    case ui::NativeTheme::ThemeSource::kForcedLight:
-      return false;
-    case ui::NativeTheme::ThemeSource::kForcedDark:
-      return g_darkModeSupported;
-    case ui::NativeTheme::ThemeSource::kSystem:
-      return g_darkModeEnabled;
-  }
-}
-
 namespace win {
 
-void SetDarkModeForWindow(HWND hWnd,
-                          ui::NativeTheme::ThemeSource theme_source) {
-  EnsureInitialized();
-  RefreshTitleBarThemeColor(hWnd, IsDarkPreferred(theme_source));
+void SetDarkModeForWindow(HWND hWnd) {
+  ui::NativeTheme* theme = ui::NativeTheme::GetInstanceForNativeUi();
+  bool dark =
+      theme->ShouldUseDarkColors() && !theme->UserHasContrastPreference();
+  TrySetWindowTheme(hWnd, dark);
 }
 
 }  // namespace win

--- a/shell/browser/win/dark_mode.cc
+++ b/shell/browser/win/dark_mode.cc
@@ -17,7 +17,7 @@
 // governed by the MIT license and (c) Microsoft Corporation.
 namespace {
 
-// Use private Windows API to set window theme on Windows 10
+// Use undocumented flags to set window theme on Windows 10
 HRESULT TrySetWindowThemeOnWin10(HWND hWnd, bool dark) {
   const BOOL isDarkMode = dark;
   if (FAILED(DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
@@ -29,7 +29,7 @@ HRESULT TrySetWindowThemeOnWin10(HWND hWnd, bool dark) {
       return result;
   }
 
-  // Toggle the nonclient area active state to force a redraw
+  // Toggle the nonclient area active state to force a redraw (workaround for Windows 10)
   HWND activeWindow = GetActiveWindow();
   SendMessage(hWnd, WM_NCACTIVATE, hWnd != activeWindow, 0);
   SendMessage(hWnd, WM_NCACTIVATE, hWnd == activeWindow, 0);
@@ -37,12 +37,10 @@ HRESULT TrySetWindowThemeOnWin10(HWND hWnd, bool dark) {
   return S_OK;
 }
 
+// Docs: https://docs.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute
 HRESULT TrySetWindowTheme(HWND hWnd, bool dark) {
   const BOOL isDarkMode = dark;
-  HRESULT result = DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
-                                         &isDarkMode, sizeof(isDarkMode));
-
-  return FAILED(result) ? result : S_OK;
+  return DwmSetWindowAttribute(hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &isDarkMode, sizeof(isDarkMode));
 }
 
 }  // namespace

--- a/shell/browser/win/dark_mode.h
+++ b/shell/browser/win/dark_mode.h
@@ -19,6 +19,7 @@ namespace electron {
 
 namespace win {
 
+bool IsDarkModeSupported();
 void SetDarkModeForWindow(HWND hWnd);
 
 }  // namespace win

--- a/shell/browser/win/dark_mode.h
+++ b/shell/browser/win/dark_mode.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Microsoft Inc. All rights reserved.
+// Copyright (c) 2022 Microsoft Inc. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-CHROMIUM file.
 
@@ -19,7 +19,7 @@ namespace electron {
 
 namespace win {
 
-void SetDarkModeForWindow(HWND hWnd, ui::NativeTheme::ThemeSource theme_source);
+void SetDarkModeForWindow(HWND hWnd);
 
 }  // namespace win
 

--- a/shell/common/api/features.cc
+++ b/shell/common/api/features.cc
@@ -54,8 +54,8 @@ bool IsPictureInPictureEnabled() {
   return BUILDFLAG(ENABLE_PICTURE_IN_PICTURE);
 }
 
-bool IsWindowsImmersiveDarkModeEnabled() {
-  return electron::fuses::IsWindowsImmersiveDarkModeEnabled();
+bool IsWindows10ImmersiveDarkModeEnabled() {
+  return electron::fuses::IsWindows10ImmersiveDarkModeEnabled();
 }
 
 bool IsComponentBuild() {
@@ -84,8 +84,8 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("isPictureInPictureEnabled", &IsPictureInPictureEnabled);
   dict.SetMethod("isComponentBuild", &IsComponentBuild);
   dict.SetMethod("isExtensionsEnabled", &IsExtensionsEnabled);
-  dict.SetMethod("isWindowsImmersiveDarkModeEnabled",
-                 &IsWindowsImmersiveDarkModeEnabled);
+  dict.SetMethod("isWindows10ImmersiveDarkModeEnabled",
+                 &IsWindows10ImmersiveDarkModeEnabled);
 }
 
 }  // namespace

--- a/shell/common/api/features.cc
+++ b/shell/common/api/features.cc
@@ -55,7 +55,7 @@ bool IsPictureInPictureEnabled() {
 }
 
 bool IsWindowsImmersiveDarkModeEnabled() {
-  return electron::fuses::IsWindowsImmersiveDarkModeEnabled()
+  return electron::fuses::IsWindowsImmersiveDarkModeEnabled();
 }
 
 bool IsComponentBuild() {

--- a/shell/common/api/features.cc
+++ b/shell/common/api/features.cc
@@ -54,8 +54,8 @@ bool IsPictureInPictureEnabled() {
   return BUILDFLAG(ENABLE_PICTURE_IN_PICTURE);
 }
 
-bool IsWinDarkModeWindowUiEnabled() {
-  return BUILDFLAG(ENABLE_WIN_DARK_MODE_WINDOW_UI);
+bool IsWindowsImmersiveDarkModeEnabled() {
+  return electron::fuses::IsWindowsImmersiveDarkModeEnabled()
 }
 
 bool IsComponentBuild() {
@@ -84,7 +84,8 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("isPictureInPictureEnabled", &IsPictureInPictureEnabled);
   dict.SetMethod("isComponentBuild", &IsComponentBuild);
   dict.SetMethod("isExtensionsEnabled", &IsExtensionsEnabled);
-  dict.SetMethod("isWinDarkModeWindowUiEnabled", &IsWinDarkModeWindowUiEnabled);
+  dict.SetMethod("isWindowsImmersiveDarkModeEnabled",
+                 &IsWindowsImmersiveDarkModeEnabled);
 }
 
 }  // namespace

--- a/shell/common/api/features.cc
+++ b/shell/common/api/features.cc
@@ -54,10 +54,6 @@ bool IsPictureInPictureEnabled() {
   return BUILDFLAG(ENABLE_PICTURE_IN_PICTURE);
 }
 
-bool IsWindows10ImmersiveDarkModeEnabled() {
-  return electron::fuses::IsWindows10ImmersiveDarkModeEnabled();
-}
-
 bool IsComponentBuild() {
 #if defined(COMPONENT_BUILD)
   return true;
@@ -84,8 +80,6 @@ void Initialize(v8::Local<v8::Object> exports,
   dict.SetMethod("isPictureInPictureEnabled", &IsPictureInPictureEnabled);
   dict.SetMethod("isComponentBuild", &IsComponentBuild);
   dict.SetMethod("isExtensionsEnabled", &IsExtensionsEnabled);
-  dict.SetMethod("isWindows10ImmersiveDarkModeEnabled",
-                 &IsWindows10ImmersiveDarkModeEnabled);
 }
 
 }  // namespace

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -27,7 +27,7 @@ declare namespace NodeJS {
     isPictureInPictureEnabled(): boolean;
     isExtensionsEnabled(): boolean;
     isComponentBuild(): boolean;
-    isWindowsImmersiveDarkModeEnabled(): boolean;
+    isWindows10ImmersiveDarkModeEnabled(): boolean;
   }
 
   interface IpcRendererBinding {

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -27,7 +27,6 @@ declare namespace NodeJS {
     isPictureInPictureEnabled(): boolean;
     isExtensionsEnabled(): boolean;
     isComponentBuild(): boolean;
-    isWindows10ImmersiveDarkModeEnabled(): boolean;
   }
 
   interface IpcRendererBinding {

--- a/typings/internal-ambient.d.ts
+++ b/typings/internal-ambient.d.ts
@@ -27,7 +27,7 @@ declare namespace NodeJS {
     isPictureInPictureEnabled(): boolean;
     isExtensionsEnabled(): boolean;
     isComponentBuild(): boolean;
-    isWinDarkModeWindowUiEnabled(): boolean;
+    isWindowsImmersiveDarkModeEnabled(): boolean;
   }
 
   interface IpcRendererBinding {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

Closes #32913, closes #18119.

A refactored implementation of dark mode for Windows, using official API for Windows 11 and undocumented flag on Win 10 >= 20H1. It allows Electron apps to set a dark title bar based on the system preference.

cc @dsanders11 @deermichel @ckerr 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Added immersive dark mode on Windows.
