### PR TITLE
build: use python3 to lint

### DIFF
--- a/docs/development/build-instructions-linux.md
+++ b/docs/development/build-instructions-linux.md
@@ -7,21 +7,7 @@ Follow the guidelines below for building **Electron itself** on Linux, for the p
 ## Prerequisites
 
 * At least 25GB disk space and 8GB RAM.
-* Python 2.7.x. Some distributions like CentOS 6.x still use Python 2.6.x
-  so you may need to check your Python version with `python -V`.
-
-  Please also ensure that your system and Python version support at least TLS 1.2.
-  For a quick test, run the following script:
-
-  ```sh
-  $ npx @electron/check-python-tls
-  ```
-
-  If the script returns that your configuration is using an outdated security
-  protocol, use your system's package manager to update Python to the latest
-  version in the 2.7.x branch. Alternatively, visit https://www.python.org/downloads/
-  for detailed instructions.
-
+* Python >= 3.7.
 * Node.js. There are various ways to install Node. You can download
   source code from [nodejs.org](https://nodejs.org) and compile it.
   Doing so permits installing Node on your own home directory as a standard user.

--- a/docs/development/build-instructions-macos.md
+++ b/docs/development/build-instructions-macos.md
@@ -6,45 +6,12 @@ Follow the guidelines below for building **Electron itself** on macOS, for the p
 
 ## Prerequisites
 
-* macOS >= 10.11.6
-* [Xcode](https://developer.apple.com/technologies/tools/) >= 9.0.0
+* macOS >= 11.6.0
+* [Xcode](https://developer.apple.com/technologies/tools/). The exact version
+  needed depends on what branch you are building, but the latest version of
+  Xcode is generally a good bet for building `main`.
 * [node.js](https://nodejs.org) (external)
-* Python 2.7 with support for TLS 1.2
-
-## Python
-
-Please also ensure that your system and Python version support at least TLS 1.2.
-This depends on both your version of macOS and Python. For a quick test, run:
-
-```sh
-$ npx @electron/check-python-tls
-```
-
-If the script returns that your configuration is using an outdated security
-protocol, you can either update macOS to High Sierra or install a new version
-of Python 2.7.x. To upgrade Python, use [Homebrew](https://brew.sh/):
-
-```sh
-$ brew install python@2 && brew link python@2 --force
-```
-
-If you are using Python as provided by Homebrew, you also need to install
-the following Python modules:
-
-* [pyobjc](https://pypi.org/project/pyobjc/#description)
-
-You can use `pip` to install it:
-
-```sh
-$ pip install pyobjc
-```
-
-## macOS SDK
-
-If you're developing Electron and don't plan to redistribute your
-custom Electron build, you may skip this section.
-
-Official Electron builds are built with [Xcode 12.2](https://download.developer.apple.com/Developer_Tools/Xcode_12.2/Xcode_12.2.xip), and the macOS 11.0 SDK. Building with a newer SDK works too, but the releases currently use the 11.0 SDK.
+* Python >= 3.7
 
 ## Building Electron
 

--- a/docs/development/coding-style.md
+++ b/docs/development/coding-style.md
@@ -28,7 +28,7 @@ For C++ and Python, we follow Chromium's [Coding
 Style](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/styleguide/styleguide.md).
 There is also a script `script/cpplint.py` to check whether all files conform.
 
-The Python version we are using now is Python 2.7.
+The Python version we are using now is Python 3.9.
 
 The C++ code uses a lot of Chromium's abstractions and types, so it's
 recommended to get acquainted with them. A good place to start is

--- a/package.json
+++ b/package.json
@@ -79,14 +79,14 @@
     "generate-version-json": "node script/generate-version-json.js",
     "lint": "node ./script/lint.js && npm run lint:clang-format && npm run lint:docs",
     "lint:js": "node ./script/lint.js --js",
-    "lint:clang-format": "python script/run-clang-format.py -r -c shell/ || (echo \"\\nCode not formatted correctly.\" && exit 1)",
+    "lint:clang-format": "python3 script/run-clang-format.py -r -c shell/ || (echo \"\\nCode not formatted correctly.\" && exit 1)",
     "lint:clang-tidy": "ts-node ./script/run-clang-tidy.ts",
     "lint:cpp": "node ./script/lint.js --cc",
     "lint:objc": "node ./script/lint.js --objc",
     "lint:py": "node ./script/lint.js --py",
     "lint:gn": "node ./script/lint.js --gn",
     "lint:docs": "remark docs -qf && npm run lint:js-in-markdown && npm run create-typescript-definitions && npm run lint:docs-relative-links && npm run lint:markdownlint",
-    "lint:docs-relative-links": "python ./script/check-relative-doc-links.py",
+    "lint:docs-relative-links": "python3 ./script/check-relative-doc-links.py",
     "lint:markdownlint": "markdownlint \"*.md\" \"docs/**/*.md\"",
     "lint:js-in-markdown": "standard-markdown docs",
     "create-api-json": "electron-docs-parser --dir=./",
@@ -117,7 +117,7 @@
       "ts-node script/gen-filenames.ts"
     ],
     "*.{cc,mm,c,h}": [
-      "python script/run-clang-format.py -r -c --fix"
+      "python3 script/run-clang-format.py -r -c --fix"
     ],
     "*.md": [
       "npm run lint:docs"

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     ],
     "*.{gn,gni}": [
       "npm run gn-check",
-      "python script/run-gn-format.py"
+      "python3 script/run-gn-format.py"
     ],
     "*.py": [
       "node script/lint.js --py --fix --only --"

--- a/script/check-relative-doc-links.py
+++ b/script/check-relative-doc-links.py
@@ -41,7 +41,7 @@ def getBrokenLinks(filepath):
   brokenLinks = []
 
   try:
-    f = open(filepath, 'r')
+    f = open(filepath, 'r', encoding="utf-8")
     lines = f.readlines()
   except KeyboardInterrupt:
     print('Keyboard interruption while parsing. Please try again.')
@@ -77,7 +77,7 @@ def getBrokenLinks(filepath):
       tempFile = os.path.join(currentDir, sections[0])
       if os.path.isfile(tempFile):
         try:
-          newFile = open(tempFile, 'r')
+          newFile = open(tempFile, 'r', encoding="utf-8")
           newLines = newFile.readlines()
         except KeyboardInterrupt:
           print('Keyboard interruption while parsing. Please try again.')


### PR DESCRIPTION
#### Description of Change
`python` no longer exists on macOS Monterey.

Notes: none
