### PR TITLE
docs: recommend setting e.returnValue

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -473,7 +473,7 @@ window.onbeforeunload = (e) => {
   // a non-void value will silently cancel the close.
   // It is recommended to use the dialog API to let the user confirm closing the
   // application.
-  e.returnValue = false // equivalent to `return false` but not recommended
+  e.returnValue = false
 }
 ```
 


### PR DESCRIPTION
#### Description of Change

Close https://github.com/electron/electron/issues/33581.

As noticed by https://github.com/electron/electron/issues/33581, the document is both recommending and not recommending to set the `event.returnValue` directly.

#### Release Notes

Notes: none