### PR TITLE
build: fix numpy package install on mac arm64

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -137,3 +137,4 @@ cherry-pick-905302eb3a2b.patch
 enable_forcesynchronoushtmlparsing_by_default.patch
 remove_incorrect_width_height_adjustments.patch
 set_dpi_correctly_during_main_window_creation.patch
+use_numpy_1_2x_supported_1_for_vpython.patch

--- a/patches/chromium/use_numpy_1_2x_supported_1_for_vpython.patch
+++ b/patches/chromium/use_numpy_1_2x_supported_1_for_vpython.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Brian Ryner <bryner@google.com>
+Date: Thu, 14 Oct 2021 21:15:11 +0000
+Subject: Use numpy 1.2x.supported.1 for vpython
+
+Use a special version of numpy to auto select version based on platform.
+
+Bug: 1295840
+Change-Id: Ic3943a2c022cd4de9d39d9b84d2af55873373e76
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3459767
+Auto-Submit: Chenlin Fan <fancl@chromium.org>
+Reviewed-by: Brian Ryner <bryner@google.com>
+Reviewed-by: Robbie Iannucci <iannucci@chromium.org>
+Commit-Queue: Chenlin Fan <fancl@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#971577}
+
+diff --git a/.vpython3 b/.vpython3
+index 7ce6dc723da1dee4e64971d7c7556560ad86928a..78a87bd28d3c76ac44b4eff15ff8b07551582db8 100644
+--- a/.vpython3
++++ b/.vpython3
+@@ -58,7 +58,7 @@ wheel: <
+ # Chromium tests using Telemetry function properly.
+ wheel: <
+   name: "infra/python/wheels/numpy/${vpython_platform}"
+-  version: "version:1.20.3"
++  version: "version:1.2x.supported.1"
+ >
+ wheel: <
+   name: "infra/python/wheels/psutil/${vpython_platform}"


### PR DESCRIPTION
#### Description of Change
Backport https://chromium-review.googlesource.com/c/chromium/src/+/3459767

Fixes the following issue preventing building on Apple Silicon Macs:
```
#0 go.chromium.org/luci/cipd/client/cipd/ensure/file.go:255 - ensure.(*File).Resolve.func1.1()
  reason: failed to resolve infra/python/wheels/numpy/mac-arm64_cp38_cp38@version:1.20.3 (line 0)
```

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none
