### PR TITLE
fix: missing resource printing DCHECK

### DIFF
--- a/electron_strings.grdp
+++ b/electron_strings.grdp
@@ -24,6 +24,9 @@
   <message name="IDS_DEFAULT_PRINT_DOCUMENT_TITLE" desc="Default title for a print document">
     Untitled Document
   </message>
+  <message name="IDS_UTILITY_PROCESS_PRINT_BACKEND_SERVICE_NAME" desc="The name of the utility process used for backend interactions with printer drivers.">
+    Print Backend Service
+  </message>
 
   <!-- Desktop Capturer API -->
   <message name="IDS_DESKTOP_MEDIA_PICKER_SINGLE_SCREEN_NAME" desc="Name for screens in the desktop media picker UI when there is only one monitor.">

--- a/patches/chromium/printing.patch
+++ b/patches/chromium/printing.patch
@@ -10,6 +10,19 @@ majority of changes originally come from these PRs:
 
 This patch also fixes callback for manual user cancellation and success.
 
+diff --git a/chrome/browser/printing/print_backend_service_manager.cc b/chrome/browser/printing/print_backend_service_manager.cc
+index 7df299afaa8c243b2aa913c8b5daa67efb18ebd2..feacf7ef13ebc1053702d5cb9e56955d397b7da9 100644
+--- a/chrome/browser/printing/print_backend_service_manager.cc
++++ b/chrome/browser/printing/print_backend_service_manager.cc
+@@ -18,7 +18,7 @@
+ #include "base/unguessable_token.h"
+ #include "build/build_config.h"
+ #include "chrome/browser/browser_process.h"
+-#include "chrome/grit/generated_resources.h"
++#include "electron/grit/electron_resources.h"
+ #include "chrome/services/printing/public/mojom/print_backend_service.mojom.h"
+ #include "components/crash/core/common/crash_keys.h"
+ #include "content/public/browser/browser_thread.h"
 diff --git a/chrome/browser/printing/print_job.cc b/chrome/browser/printing/print_job.cc
 index 8d40bbf98d4d58704f118cb42039b0956a9f6639..06196c0fa02012a5faa82471bd39fac087918f54 100644
 --- a/chrome/browser/printing/print_job.cc


### PR DESCRIPTION
#### Description of Change

Resolves https://github.com/electron/electron/issues/33633.

Adds missing resource string resultant of CL:3470185

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
