### PR TITLE
fix: docs fix for `app.getPath(name)`

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -631,12 +631,12 @@ Returns `string` - The current application directory.
 
 * `name` string - You can request the following paths by the name:
   * `home` User's home directory.
-  * `appData` Per-user application data directory, which by default points to:
+  * `userData` Per-user application data directory, which by default points to:
     * `%APPDATA%` on Windows
     * `$XDG_CONFIG_HOME` or `~/.config` on Linux
     * `~/Library/Application Support` on macOS
-  * `userData` The directory for storing your app's configuration files, which by
-    default it is the `appData` directory appended with your app's name.
+  * `appData` The directory for storing your app's configuration files, which by
+    default it is the `userData` directory appended with your app's name.
   * `temp` Temporary directory.
   * `exe` The current executable file.
   * `module` The `libchromiumcontent` library.


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->
swap description of `userData` and `appData` in `app.getPath(name)` as the current implementation (linux) is:
```
app.getPath('appData'):  /home/<user>/.config
app.getPath('userData'):  /home/<user>/.config/Electron
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
