### PR TITLE
feat: allow `null` when subscribing notification

### DIFF
--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -109,6 +109,8 @@ example values of `event` are:
 * `AppleColorPreferencesChangedNotification`
 * `AppleShowScrollBarsSettingChanged`
 
+If `event` is null, the `NSDistributedNotificationCenter` doesn’t use it as criteria for delivery to the observer. See [docs](https://developer.apple.com/documentation/foundation/nsnotificationcenter/1411723-addobserverforname?language=objc)  for more information.
+
 ### `systemPreferences.subscribeLocalNotification(event, callback)` _macOS_
 
 * `event` string | null
@@ -122,6 +124,8 @@ Returns `number` - The ID of this subscription
 Same as `subscribeNotification`, but uses `NSNotificationCenter` for local defaults.
 This is necessary for events such as `NSUserDefaultsDidChangeNotification`.
 
+If `event` is null, the `NSNotificationCenter` doesn’t use it as criteria for delivery to the observer. See [docs](https://developer.apple.com/documentation/foundation/nsnotificationcenter/1411723-addobserverforname?language=objc) for more information.
+
 ### `systemPreferences.subscribeWorkspaceNotification(event, callback)` _macOS_
 
 * `event` string | null
@@ -134,6 +138,8 @@ Returns `number` - The ID of this subscription
 
 Same as `subscribeNotification`, but uses `NSWorkspace.sharedWorkspace.notificationCenter`.
 This is necessary for events such as `NSWorkspaceDidActivateApplicationNotification`.
+
+If `event` is null, the `NSWorkspaceNotificationCenter` doesn’t use it as criteria for delivery to the observer. See [docs](https://developer.apple.com/documentation/foundation/nsnotificationcenter/1411723-addobserverforname?language=objc) for more information.
 
 ### `systemPreferences.unsubscribeNotification(id)` _macOS_
 

--- a/docs/api/system-preferences.md
+++ b/docs/api/system-preferences.md
@@ -84,7 +84,7 @@ that contains the user information dictionary sent along with the notification.
 
 ### `systemPreferences.subscribeNotification(event, callback)` _macOS_
 
-* `event` string
+* `event` string | null
 * `callback` Function
   * `event` string
   * `userInfo` Record<string, unknown>
@@ -111,7 +111,7 @@ example values of `event` are:
 
 ### `systemPreferences.subscribeLocalNotification(event, callback)` _macOS_
 
-* `event` string
+* `event` string | null
 * `callback` Function
   * `event` string
   * `userInfo` Record<string, unknown>
@@ -124,7 +124,7 @@ This is necessary for events such as `NSUserDefaultsDidChangeNotification`.
 
 ### `systemPreferences.subscribeWorkspaceNotification(event, callback)` _macOS_
 
-* `event` string
+* `event` string | null
 * `callback` Function
   * `event` string
   * `userInfo` Record<string, unknown>

--- a/shell/browser/api/electron_api_system_preferences.h
+++ b/shell/browser/api/electron_api_system_preferences.h
@@ -76,17 +76,17 @@ class SystemPreferences
   void PostNotification(const std::string& name,
                         base::DictionaryValue user_info,
                         gin::Arguments* args);
-  int SubscribeNotification(const std::string& name,
+  int SubscribeNotification(v8::Local<v8::Value> maybe_name,
                             const NotificationCallback& callback);
   void UnsubscribeNotification(int id);
   void PostLocalNotification(const std::string& name,
                              base::DictionaryValue user_info);
-  int SubscribeLocalNotification(const std::string& name,
+  int SubscribeLocalNotification(v8::Local<v8::Value> maybe_name,
                                  const NotificationCallback& callback);
   void UnsubscribeLocalNotification(int request_id);
   void PostWorkspaceNotification(const std::string& name,
                                  base::DictionaryValue user_info);
-  int SubscribeWorkspaceNotification(const std::string& name,
+  int SubscribeWorkspaceNotification(v8::Local<v8::Value> maybe_name,
                                      const NotificationCallback& callback);
   void UnsubscribeWorkspaceNotification(int request_id);
   v8::Local<v8::Value> GetUserDefault(v8::Isolate* isolate,
@@ -130,7 +130,7 @@ class SystemPreferences
   ~SystemPreferences() override;
 
 #if BUILDFLAG(IS_MAC)
-  int DoSubscribeNotification(const std::string& name,
+  int DoSubscribeNotification(v8::Local<v8::Value> maybe_name,
                               const NotificationCallback& callback,
                               NotificationCenterKind kind);
   void DoUnsubscribeNotification(int request_id, NotificationCenterKind kind);

--- a/spec-main/api-system-preferences-spec.ts
+++ b/spec-main/api-system-preferences-spec.ts
@@ -116,6 +116,39 @@ describe('systemPreferences module', () => {
     });
   });
 
+  ifdescribe(process.platform === 'darwin')('systemPreferences.subscribeNotification(event, callback)', () => {
+    it('throws an error if invalid arguments are passed', () => {
+      const badArgs = [123, {}, ['hi', 'bye'], new Date()];
+      for (const bad of badArgs) {
+        expect(() => {
+          systemPreferences.subscribeNotification(bad as any, () => {});
+        }).to.throw('Must pass null or a string');
+      }
+    });
+  });
+
+  ifdescribe(process.platform === 'darwin')('systemPreferences.subscribeLocalNotification(event, callback)', () => {
+    it('throws an error if invalid arguments are passed', () => {
+      const badArgs = [123, {}, ['hi', 'bye'], new Date()];
+      for (const bad of badArgs) {
+        expect(() => {
+          systemPreferences.subscribeNotification(bad as any, () => {});
+        }).to.throw('Must pass null or a string');
+      }
+    });
+  });
+
+  ifdescribe(process.platform === 'darwin')('systemPreferences.subscribeWorkspaceNotification(event, callback)', () => {
+    it('throws an error if invalid arguments are passed', () => {
+      const badArgs = [123, {}, ['hi', 'bye'], new Date()];
+      for (const bad of badArgs) {
+        expect(() => {
+          systemPreferences.subscribeWorkspaceNotification(bad as any, () => {});
+        }).to.throw('Must pass null or a string');
+      }
+    });
+  });
+
   ifdescribe(process.platform === 'darwin')('systemPreferences.getSystemColor(color)', () => {
     it('throws on invalid system colors', () => {
       const color = 'bad-color';


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/33632.

Allows for `systemPreferences.subscribe{Local|Workspace}Notification` methods to take `null` for their event parameters.

Per [documentation](https://developer.apple.com/documentation/foundation/nsdistributednotificationcenter/1414136-addobserver):

> When nil, the notification center doesn’t use a notification’s name to decide whether to deliver it to the observer.

cc @knev 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Enabled `systemPreferences.subscribe{Local|Workspace}Notification` to take a `null` value for the `event` parameter.