### PR TITLE
chore: cherry-pick 1665a1d16d46 from chromium

### DIFF
--- a/patches/chromium/.patches
+++ b/patches/chromium/.patches
@@ -166,3 +166,4 @@ remove_incorrect_width_height_adjustments.patch
 fix_non-client_mouse_tracking_and_message_bubbling_on_windows.patch
 fixed_terminate_caused_by_binding_to_wrong_version.patch
 follow_wayland_specification_regarding_xkb_keymap.patch
+cherry-pick-1665a1d16d46.patch

--- a/patches/chromium/cherry-pick-1665a1d16d46.patch
+++ b/patches/chromium/cherry-pick-1665a1d16d46.patch
@@ -1,0 +1,119 @@
+From 1665a1d16d46fc39da7bf220a85c4ee38cd99d25 Mon Sep 17 00:00:00 2001
+From: msw@chromium.org <msw@chromium.org>
+Date: Tue, 01 Feb 2022 21:16:10 +0000
+Subject: [PATCH] Reland "Make web cursor size limits match on browser and renderer"
+
+This reverts commit 38a8343085e53889eba48fcff78a6c2295927333.
+
+Reason for revert: Fix without regressing https://crbug.com/1292426
+(Increased WebCursor limit 128->150px to support DevToolsEyeDropper)
+
+Original change's description:
+> Revert "Make web cursor size limits match on browser and renderer"
+>
+> This reverts commit 868b44dd8b4a1a3b9698f561ca17f75e4ec78dd2.
+>
+> Reason for revert: https://crbug.com/1292426
+>
+> Original change's description:
+> > Make web cursor size limits match on browser and renderer
+> >
+> > Use NSCursor arrowCursor on Mac for ui::mojom::CursorType::kNull.
+> > (i.e. when WebCursor is constructed with an overly large custom cursor)
+> >
+> > Bug: 1246188
+> > Test: Automated unit tests and WPTs
+> > Change-Id: I89627fa13cba96b755b8f80adbc91cfc865b6b1b
+> > Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3413912
+> > Reviewed-by: Henrique Ferreiro <hferreiro@igalia.com>
+> > Reviewed-by: Charlie Harrison <csharrison@chromium.org>
+> > Commit-Queue: Mike Wasserman <msw@chromium.org>
+> > Auto-Submit: Mike Wasserman <msw@chromium.org>
+> > Cr-Commit-Position: refs/heads/main@{#964378}
+>
+> Bug: 1246188
+> Change-Id: Id7b3b88e65c012993537ce96c2b5064b7b76646e
+> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3428347
+> Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
+> Commit-Queue: Mike Wasserman <msw@chromium.org>
+> Cr-Commit-Position: refs/heads/main@{#965475}
+
+Fixed: 1246188
+Bug: 1292426
+Change-Id: I5a490603c3e21e17f3136a3d792a18429eb3f633
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3428624
+Auto-Submit: Mike Wasserman <msw@chromium.org>
+Reviewed-by: Charlie Harrison <csharrison@chromium.org>
+Commit-Queue: Mike Wasserman <msw@chromium.org>
+Reviewed-by: Henrique Ferreiro <hferreiro@igalia.com>
+Cr-Commit-Position: refs/heads/main@{#965857}
+---
+
+diff --git a/content/common/cursors/webcursor.cc b/content/common/cursors/webcursor.cc
+index c8b6b9d..4c80616 100644
+--- a/content/common/cursors/webcursor.cc
++++ b/content/common/cursors/webcursor.cc
+@@ -22,16 +22,19 @@
+ WebCursor::WebCursor(const WebCursor& other) = default;
+ 
+ bool WebCursor::SetCursor(const ui::Cursor& cursor) {
+-  static constexpr int kMaxSize = 1024;
++  // This value is just large enough to accommodate:
++  // - kMaximumCursorSize in Blink's EventHandler
++  // - kCursorSize in Chrome's DevToolsEyeDropper
++  static constexpr int kMaximumCursorSize = 150;
+   if (cursor.image_scale_factor() < 0.01f ||
+       cursor.image_scale_factor() > 100.f ||
+       (cursor.type() == ui::mojom::CursorType::kCustom &&
+-       (cursor.custom_bitmap().width() > kMaxSize ||
+-        cursor.custom_bitmap().height() > kMaxSize ||
++       (cursor.custom_bitmap().width() > kMaximumCursorSize ||
++        cursor.custom_bitmap().height() > kMaximumCursorSize ||
+         cursor.custom_bitmap().width() / cursor.image_scale_factor() >
+-            kMaxSize ||
++            kMaximumCursorSize ||
+         cursor.custom_bitmap().height() / cursor.image_scale_factor() >
+-            kMaxSize))) {
++            kMaximumCursorSize))) {
+     return false;
+   }
+ 
+diff --git a/content/common/cursors/webcursor_mac.mm b/content/common/cursors/webcursor_mac.mm
+index f85c421f..fdc70bd 100644
+--- a/content/common/cursors/webcursor_mac.mm
++++ b/content/common/cursors/webcursor_mac.mm
+@@ -265,6 +265,7 @@
+     case ui::mojom::CursorType::kCustom:
+       return CreateCustomCursor(cursor_);
+     case ui::mojom::CursorType::kNull:
++      return [NSCursor arrowCursor];
+     case ui::mojom::CursorType::kDndNone:
+     case ui::mojom::CursorType::kDndMove:
+     case ui::mojom::CursorType::kDndCopy:
+diff --git a/content/common/cursors/webcursor_unittest.cc b/content/common/cursors/webcursor_unittest.cc
+index 9601f15a..d778630 100644
+--- a/content/common/cursors/webcursor_unittest.cc
++++ b/content/common/cursors/webcursor_unittest.cc
+@@ -122,11 +122,11 @@
+ 
+   // SetCursor should return false when the image width is too large.
+   cursor.set_image_scale_factor(1.f);
+-  cursor.set_custom_bitmap(CreateTestBitmap(1025, 3));
++  cursor.set_custom_bitmap(CreateTestBitmap(151, 3));
+   EXPECT_FALSE(webcursor.SetCursor(cursor));
+ 
+   // SetCursor should return false when the image height is too large.
+-  cursor.set_custom_bitmap(CreateTestBitmap(3, 1025));
++  cursor.set_custom_bitmap(CreateTestBitmap(3, 151));
+   EXPECT_FALSE(webcursor.SetCursor(cursor));
+ 
+   // SetCursor should return false when the scaled image width is too large.
+@@ -136,7 +136,7 @@
+ 
+   // SetCursor should return false when the scaled image height is too large.
+   cursor.set_image_scale_factor(0.1f);
+-  cursor.set_custom_bitmap(CreateTestBitmap(5, 200));
++  cursor.set_custom_bitmap(CreateTestBitmap(5, 20));
+   EXPECT_FALSE(webcursor.SetCursor(cursor));
+ }
+ 


### PR DESCRIPTION
Reland "Make web cursor size limits match on browser and renderer"

This reverts commit 38a8343085e53889eba48fcff78a6c2295927333.

Reason for revert: Fix without regressing https://crbug.com/1292426
(Increased WebCursor limit 128->150px to support DevToolsEyeDropper)

Original change's description:
> Revert "Make web cursor size limits match on browser and renderer"
>
> This reverts commit 868b44dd8b4a1a3b9698f561ca17f75e4ec78dd2.
>
> Reason for revert: https://crbug.com/1292426
>
> Original change's description:
> > Make web cursor size limits match on browser and renderer
> >
> > Use NSCursor arrowCursor on Mac for ui::mojom::CursorType::kNull.
> > (i.e. when WebCursor is constructed with an overly large custom cursor)
> >
> > Bug: 1246188
> > Test: Automated unit tests and WPTs
> > Change-Id: I89627fa13cba96b755b8f80adbc91cfc865b6b1b
> > Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3413912
> > Reviewed-by: Henrique Ferreiro <hferreiro@igalia.com>
> > Reviewed-by: Charlie Harrison <csharrison@chromium.org>
> > Commit-Queue: Mike Wasserman <msw@chromium.org>
> > Auto-Submit: Mike Wasserman <msw@chromium.org>
> > Cr-Commit-Position: refs/heads/main@{#964378}
>
> Bug: 1246188
> Change-Id: Id7b3b88e65c012993537ce96c2b5064b7b76646e
> Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3428347
> Bot-Commit: Rubber Stamper <rubber-stamper@appspot.gserviceaccount.com>
> Commit-Queue: Mike Wasserman <msw@chromium.org>
> Cr-Commit-Position: refs/heads/main@{#965475}

Fixed: 1246188
Bug: 1292426
Change-Id: I5a490603c3e21e17f3136a3d792a18429eb3f633
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3428624
Auto-Submit: Mike Wasserman <msw@chromium.org>
Reviewed-by: Charlie Harrison <csharrison@chromium.org>
Commit-Queue: Mike Wasserman <msw@chromium.org>
Reviewed-by: Henrique Ferreiro <hferreiro@igalia.com>
Cr-Commit-Position: refs/heads/main@{#965857}


Notes: Backported fix for 1292426.