### PR TITLE
test: re-enable disabled ScriptOrModule specs

### DIFF
--- a/spec-main/api-web-contents-spec.ts
+++ b/spec-main/api-web-contents-spec.ts
@@ -1857,8 +1857,7 @@ describe('webContents module', () => {
       }
     });
 
-    // TODO(codebytere): Re-enable after Chromium fixes upstream v8_scriptormodule_legacy_lifetime crash.
-    xdescribe('using a large document', () => {
+    describe('using a large document', () => {
       beforeEach(async () => {
         w = new BrowserWindow({ show: false, webPreferences: { sandbox: true } });
         await w.loadFile(path.join(__dirname, 'fixtures', 'api', 'print-to-pdf.html'));

--- a/spec-main/chromium-spec.ts
+++ b/spec-main/chromium-spec.ts
@@ -238,8 +238,7 @@ describe('web security', () => {
     await p;
   });
 
-  // TODO(codebytere): Re-enable after Chromium fixes upstream v8_scriptormodule_legacy_lifetime crash.
-  xit('bypasses CORB when web security is disabled', async () => {
+  it('bypasses CORB when web security is disabled', async () => {
     const w = new BrowserWindow({ show: false, webPreferences: { webSecurity: false, nodeIntegration: true, contextIsolation: false } });
     const p = emittedOnce(ipcMain, 'success');
     await w.loadURL(`data:text/html,


### PR DESCRIPTION
#### Description of Change

Re-enable specs disabled in https://github.com/electron/electron/issues/31555 - Chromium has addressed this issue and these tests now pass locally.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none.
