### PR TITLE
fix: [Mac] Disable MallocNanoZone

### DIFF
--- a/shell/browser/resources/mac/Info.plist
+++ b/shell/browser/resources/mac/Info.plist
@@ -41,6 +41,11 @@
     <false/>
     <key>NSQuitAlwaysKeepsWindows</key>
     <false/>
+    <key>LSEnvironment</key>
+    <dict>
+      <key>MallocNanoZone</key>
+      <string>0</string>
+    </dict>
     <key>NSMicrophoneUsageDescription</key>
     <string>This app needs access to the microphone</string>
     <key>NSCameraUsageDescription</key>

--- a/shell/common/resources/mac/Info.plist
+++ b/shell/common/resources/mac/Info.plist
@@ -14,5 +14,10 @@
 	<true/>
 	<key>CFBundleVersion</key>
 	<string>${ELECTRON_VERSION}</string>
+	<key>LSEnvironment</key>
+	<dict>
+		<key>MallocNanoZone</key>
+		<string>0</string>
+	</dict>
 </dict>
 </plist>

--- a/shell/renderer/resources/mac/Info.plist
+++ b/shell/renderer/resources/mac/Info.plist
@@ -12,5 +12,10 @@
   <true/>
   <key>NSSupportsAutomaticGraphicsSwitching</key>
   <true/>
+  <key>LSEnvironment</key>
+  <dict>
+    <key>MallocNanoZone</key>
+    <string>0</string>
+  </dict>
 </dict>
 </plist>


### PR DESCRIPTION
Upstream change: https://chromium-review.googlesource.com/c/chromium/src/+/1137131/

Not disabling nano malloc zone not only causes the issues listed in https://bugs.chromium.org/p/chromium/issues/detail?id=861939, but also breaks Partition Alloc.

This change should fix #32718 making it possible to get rid of #33114.

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: [Mac] Fixed Partition Alloc related crash in pre-BigSur (macos <= 10.15).
