### PR TITLE
fix: #ARGB to #RGBA conversion

### DIFF
--- a/shell/common/color_util.cc
+++ b/shell/common/color_util.cc
@@ -35,17 +35,17 @@ namespace electron {
 SkColor ParseCSSColor(const std::string& color_string) {
   // ParseCssColorString expects RGBA and we historically use ARGB
   // so we need to convert before passing to ParseCssColorString.
-  std::string color_str;
+  std::string converted_color_str;
   if (IsHexFormatWithAlpha(color_string)) {
     std::string temp = color_string;
     int len = color_string.length() == 5 ? 1 : 2;
-    color_str = temp.erase(1, len) + color_string.substr(1, len);
+    converted_color_str = temp.erase(1, len) + color_string.substr(1, len);
   } else {
-    color_str = color_string;
+    converted_color_str = color_string;
   }
 
   SkColor color;
-  if (!content::ParseCssColorString(color_str, &color))
+  if (!content::ParseCssColorString(converted_color_str, &color))
     color = SK_ColorWHITE;
 
   return color;

--- a/shell/common/color_util.cc
+++ b/shell/common/color_util.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "base/cxx17_backports.h"
+#include "base/logging.h"
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
 #include "content/public/common/color_parser.h"
@@ -35,16 +36,11 @@ namespace electron {
 SkColor ParseCSSColor(const std::string& color_string) {
   // ParseCssColorString expects RGBA and we historically use ARGB
   // so we need to convert before passing to ParseCssColorString.
-  std::string color_str = color_string;
-  if (IsHexFormat(color_str)) {
-    if (color_str.length() == 5) {
-      // #ARGB => #RGBA
-      std::swap(color_str[1], color_str[4]);
-    } else {
-      // #AARRGGBB => #RRGGBBAA
-      std::swap(color_str[1], color_str[7]);
-      std::swap(color_str[2], color_str[8]);
-    }
+  std::string color_str;
+  if (IsHexFormat(color_string)) {
+    std::string temp = color_string;
+    int len = color_string.length() == 5 ? 1 : 2;
+    color_str = temp.erase(1, len) + color_string.substr(1, len);
   }
 
   SkColor color;

--- a/shell/common/color_util.cc
+++ b/shell/common/color_util.cc
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "base/cxx17_backports.h"
-#include "base/logging.h"
 #include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
 #include "content/public/common/color_parser.h"
@@ -17,7 +16,7 @@
 
 namespace {
 
-bool IsHexFormat(const std::string& str) {
+bool IsHexFormatWithAlpha(const std::string& str) {
   // Must be either #ARGB or #AARRGGBB.
   bool is_hex_length = str.length() == 5 || str.length() == 9;
   if (str[0] != '#' || !is_hex_length)
@@ -37,10 +36,12 @@ SkColor ParseCSSColor(const std::string& color_string) {
   // ParseCssColorString expects RGBA and we historically use ARGB
   // so we need to convert before passing to ParseCssColorString.
   std::string color_str;
-  if (IsHexFormat(color_string)) {
+  if (IsHexFormatWithAlpha(color_string)) {
     std::string temp = color_string;
     int len = color_string.length() == 5 ? 1 : 2;
     color_str = temp.erase(1, len) + color_string.substr(1, len);
+  } else {
+    color_str = color_string;
   }
 
   SkColor color;


### PR DESCRIPTION
#### Description of Change

Fixes an issue where `#ARGB` ->`#RGBA` and `#AARRGGBB` ->`#RRGGBBAA` were converted improperly when setting background color.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `#ARGB` ->`#RGBA` and `#AARRGGBB` ->`#RRGGBBAA` were converted improperly when setting background color.
