### PR TITLE
chore: cherry-pick a48de319c521 from pdfium

### DIFF
--- a/patches/config.json
+++ b/patches/config.json
@@ -5,6 +5,8 @@
 
   "src/electron/patches/webrtc": "src/third_party/webrtc",
 
+  "src/electron/patches/pdfium": "src/third_party/pdfium",
+
   "src/electron/patches/v8":  "src/v8",
 
   "src/electron/patches/node": "src/third_party/electron_node",

--- a/patches/pdfium/.patches
+++ b/patches/pdfium/.patches
@@ -1,0 +1,1 @@
+cherry-pick-a48de319c521.patch

--- a/patches/pdfium/cherry-pick-a48de319c521.patch
+++ b/patches/pdfium/cherry-pick-a48de319c521.patch
@@ -1,7 +1,7 @@
-From a48de319c5210da726cb3ae7eea0ab0ebf9a2c02 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tom Sepez <tsepez@chromium.org>
 Date: Thu, 16 Dec 2021 23:53:35 +0000
-Subject: [PATCH] Use safe arithmetic in CJBig2_Context::ParseSymbolDict()
+Subject: Use safe arithmetic in CJBig2_Context::ParseSymbolDict()
 
 These should be mitigated by size checks higher up, but it wouldn't
 hurt to be sure.
@@ -11,13 +11,12 @@ Change-Id: I03c46e3d11316a9f9634256bd0e2394548d2681e
 Reviewed-on: https://pdfium-review.googlesource.com/c/pdfium/+/88290
 Reviewed-by: Lei Zhang <thestig@chromium.org>
 Commit-Queue: Tom Sepez <tsepez@chromium.org>
----
 
 diff --git a/core/fxcodec/jbig2/JBig2_Context.cpp b/core/fxcodec/jbig2/JBig2_Context.cpp
-index 2a60cfd..f19c98d 100644
+index 083e95ba4c16c21f5f3934df92e54dbb6ee4fe88..08bdb253f32a2a6c393af6246b88440d837876d9 100644
 --- a/core/fxcodec/jbig2/JBig2_Context.cpp
 +++ b/core/fxcodec/jbig2/JBig2_Context.cpp
-@@ -408,28 +408,31 @@
+@@ -409,28 +409,31 @@ JBig2_Result CJBig2_Context::ParseSymbolDict(CJBig2_Segment* pSegment) {
        return JBig2_Result::kFailure;
    }
    CJBig2_Segment* pLRSeg = nullptr;
@@ -55,7 +54,7 @@ index 2a60cfd..f19c98d 100644
        }
      }
    }
-@@ -622,27 +625,30 @@
+@@ -624,27 +627,30 @@ JBig2_Result CJBig2_Context::ParseTextRegion(CJBig2_Segment* pSegment) {
        return JBig2_Result::kFailure;
    }
  

--- a/patches/pdfium/cherry-pick-a48de319c521.patch
+++ b/patches/pdfium/cherry-pick-a48de319c521.patch
@@ -1,0 +1,94 @@
+From a48de319c5210da726cb3ae7eea0ab0ebf9a2c02 Mon Sep 17 00:00:00 2001
+From: Tom Sepez <tsepez@chromium.org>
+Date: Thu, 16 Dec 2021 23:53:35 +0000
+Subject: [PATCH] Use safe arithmetic in CJBig2_Context::ParseSymbolDict()
+
+These should be mitigated by size checks higher up, but it wouldn't
+hurt to be sure.
+
+Bug: chromium:1280743
+Change-Id: I03c46e3d11316a9f9634256bd0e2394548d2681e
+Reviewed-on: https://pdfium-review.googlesource.com/c/pdfium/+/88290
+Reviewed-by: Lei Zhang <thestig@chromium.org>
+Commit-Queue: Tom Sepez <tsepez@chromium.org>
+---
+
+diff --git a/core/fxcodec/jbig2/JBig2_Context.cpp b/core/fxcodec/jbig2/JBig2_Context.cpp
+index 2a60cfd..f19c98d 100644
+--- a/core/fxcodec/jbig2/JBig2_Context.cpp
++++ b/core/fxcodec/jbig2/JBig2_Context.cpp
+@@ -408,28 +408,31 @@
+       return JBig2_Result::kFailure;
+   }
+   CJBig2_Segment* pLRSeg = nullptr;
+-  pSymbolDictDecoder->SDNUMINSYMS = 0;
++  FX_SAFE_UINT32 dwNumSyms = 0;
+   for (int32_t i = 0; i < pSegment->m_nReferred_to_segment_count; ++i) {
+     CJBig2_Segment* pSeg =
+         FindSegmentByNumber(pSegment->m_Referred_to_segment_numbers[i]);
+     if (pSeg->m_cFlags.s.type == 0) {
+-      pSymbolDictDecoder->SDNUMINSYMS += pSeg->m_SymbolDict->NumImages();
++      dwNumSyms += pSeg->m_SymbolDict->NumImages();
+       pLRSeg = pSeg;
+     }
+   }
++  pSymbolDictDecoder->SDNUMINSYMS = dwNumSyms.ValueOrDie();
+ 
+   std::unique_ptr<CJBig2_Image*, FxFreeDeleter> SDINSYMS;
+   if (pSymbolDictDecoder->SDNUMINSYMS != 0) {
+     SDINSYMS.reset(FX_Alloc(CJBig2_Image*, pSymbolDictDecoder->SDNUMINSYMS));
+-    uint32_t dwTemp = 0;
++    dwNumSyms = 0;
+     for (int32_t i = 0; i < pSegment->m_nReferred_to_segment_count; ++i) {
+       CJBig2_Segment* pSeg =
+           FindSegmentByNumber(pSegment->m_Referred_to_segment_numbers[i]);
+       if (pSeg->m_cFlags.s.type == 0) {
+         const CJBig2_SymbolDict& dict = *pSeg->m_SymbolDict;
+-        for (size_t j = 0; j < dict.NumImages(); ++j)
+-          SDINSYMS.get()[dwTemp + j] = dict.GetImage(j);
+-        dwTemp += dict.NumImages();
++        for (uint32_t j = 0; j < dict.NumImages(); ++j) {
++          uint32_t dwTemp = (dwNumSyms + j).ValueOrDie();
++          SDINSYMS.get()[dwTemp] = dict.GetImage(j);
++        }
++        dwNumSyms += dict.NumImages();
+       }
+     }
+   }
+@@ -622,27 +625,30 @@
+       return JBig2_Result::kFailure;
+   }
+ 
+-  pTRD->SBNUMSYMS = 0;
++  FX_SAFE_UINT32 dwNumSyms = 0;
+   for (int32_t i = 0; i < pSegment->m_nReferred_to_segment_count; ++i) {
+     CJBig2_Segment* pSeg =
+         FindSegmentByNumber(pSegment->m_Referred_to_segment_numbers[i]);
+     if (pSeg->m_cFlags.s.type == 0) {
+-      pTRD->SBNUMSYMS += pSeg->m_SymbolDict->NumImages();
++      dwNumSyms += pSeg->m_SymbolDict->NumImages();
+     }
+   }
++  pTRD->SBNUMSYMS = dwNumSyms.ValueOrDie();
+ 
+   std::unique_ptr<CJBig2_Image*, FxFreeDeleter> SBSYMS;
+   if (pTRD->SBNUMSYMS > 0) {
+     SBSYMS.reset(FX_Alloc(CJBig2_Image*, pTRD->SBNUMSYMS));
+-    dwTemp = 0;
++    dwNumSyms = 0;
+     for (int32_t i = 0; i < pSegment->m_nReferred_to_segment_count; ++i) {
+       CJBig2_Segment* pSeg =
+           FindSegmentByNumber(pSegment->m_Referred_to_segment_numbers[i]);
+       if (pSeg->m_cFlags.s.type == 0) {
+         const CJBig2_SymbolDict& dict = *pSeg->m_SymbolDict;
+-        for (size_t j = 0; j < dict.NumImages(); ++j)
+-          SBSYMS.get()[dwTemp + j] = dict.GetImage(j);
+-        dwTemp += dict.NumImages();
++        for (uint32_t j = 0; j < dict.NumImages(); ++j) {
++          uint32_t dwIndex = (dwNumSyms + j).ValueOrDie();
++          SBSYMS.get()[dwIndex] = dict.GetImage(j);
++        }
++        dwNumSyms += dict.NumImages();
+       }
+     }
+     pTRD->SBSYMS = SBSYMS.get();


### PR DESCRIPTION
Use safe arithmetic in CJBig2_Context::ParseSymbolDict()

These should be mitigated by size checks higher up, but it wouldn't
hurt to be sure.

Bug: chromium:1280743
Change-Id: I03c46e3d11316a9f9634256bd0e2394548d2681e
Reviewed-on: https://pdfium-review.googlesource.com/c/pdfium/+/88290
Reviewed-by: Lei Zhang <thestig@chromium.org>
Commit-Queue: Tom Sepez <tsepez@chromium.org>


Notes: Security: backported fix for chromium:1280743.