### PR TITLE
build: migrate urllib to python3

### DIFF
--- a/script/release/uploaders/upload-index-json.py
+++ b/script/release/uploaders/upload-index-json.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import json
 import os
 import sys
-import urllib2
+from urllib.request import Request, urlopen
 
 sys.path.append(
   os.path.abspath(os.path.dirname(os.path.abspath(__file__)) + "/../.."))
@@ -28,12 +28,12 @@ def is_json(myjson):
 
 def get_content(retry_count = 5):
   try:
-    request = urllib2.Request(
+    request = Request(
       BASE_URL + version,
       headers={"Authorization" : authToken}
     )
 
-    proposed_content = urllib2.urlopen(
+    proposed_content = urlopen(
       request
     ).read()
 


### PR DESCRIPTION
#### Description of Change

Follow up to #33720, which changed scripts to explicitly run with Python 3. The [urllib2](https://docs.python.org/2/library/urllib2.html#module-urllib2) module has been split across several modules in Python 3 named urllib.request and urllib.error. This PR migrates those imports to the Python 3 modules.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
