### PR TITLE
build: filter symbols/json correctly per arch

### DIFF
--- a/script/release/uploaders/upload.py
+++ b/script/release/uploaders/upload.py
@@ -76,12 +76,12 @@ def main():
   shutil.copy2(os.path.join(OUT_DIR, 'dist.zip'), electron_zip)
   upload_electron(release, electron_zip, args)
   if get_target_arch() != 'mips64el':
-    if get_target_arch() != 'ia32' and PLATFORM != 'win32':
+    if get_target_arch() != 'ia32' or PLATFORM != 'win32':
       symbols_zip = os.path.join(OUT_DIR, SYMBOLS_NAME)
       shutil.copy2(os.path.join(OUT_DIR, 'symbols.zip'), symbols_zip)
       upload_electron(release, symbols_zip, args)
   if PLATFORM == 'darwin':
-    if get_platform_key() == 'darwin' or get_target_arch() == 'x64':
+    if get_platform_key() == 'darwin' and get_target_arch() == 'x64':
       api_path = os.path.join(ELECTRON_DIR, 'electron-api.json')
       upload_electron(release, api_path, args)
 


### PR DESCRIPTION
#### Description of Change

Follow up to #33699 - fixes an `or` in symbol logic that was mistakenly changed on the wrong line during backporting.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
