### PR TITLE
fix: apply senderFrame details to ipcMain port event

### DIFF
--- a/lib/browser/api/web-contents.ts
+++ b/lib/browser/api/web-contents.ts
@@ -627,6 +627,7 @@ WebContents.prototype._init = function () {
   });
 
   this.on('-ipc-ports' as any, function (event: Electron.IpcMainEvent, internal: boolean, channel: string, message: any, ports: any[]) {
+    addSenderFrameToEvent(event);
     event.ports = ports.map(p => new MessagePortMain(p));
     ipcMain.emit(channel, event, message);
   });

--- a/spec-main/api-ipc-spec.ts
+++ b/spec-main/api-ipc-spec.ts
@@ -212,6 +212,8 @@ describe('ipc module', () => {
       const [ev, msg] = await p;
       expect(msg).to.equal('hi');
       expect(ev.ports).to.have.length(1);
+      expect(ev.senderFrame.parent).to.be.null();
+      expect(ev.senderFrame.routingId).to.equal(w.webContents.mainFrame.routingId);
       const [port] = ev.ports;
       expect(port).to.be.an.instanceOf(EventEmitter);
     });
@@ -226,6 +228,7 @@ describe('ipc module', () => {
       const [ev, msg] = await p;
       expect(msg).to.equal('hi');
       expect(ev.ports).to.deep.equal([]);
+      expect(ev.senderFrame.routingId).to.equal(w.webContents.mainFrame.routingId);
     });
 
     it('can communicate between main and renderer', async () => {
@@ -241,6 +244,7 @@ describe('ipc module', () => {
       }})()`);
       const [ev] = await p;
       expect(ev.ports).to.have.length(1);
+      expect(ev.senderFrame.routingId).to.equal(w.webContents.mainFrame.routingId);
       const [port] = ev.ports;
       port.start();
       port.postMessage(42);


### PR DESCRIPTION
#### Description of Change

Fixes https://github.com/electron/electron/issues/33722

Missed in https://github.com/electron/electron/pull/26764

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: apply senderFrame details to ipcMain port event