### PR TITLE
fix: event propagation after exiting fullscreen on Windows

### DIFF
--- a/shell/browser/api/electron_api_web_contents.cc
+++ b/shell/browser/api/electron_api_web_contents.cc
@@ -1342,6 +1342,11 @@ void WebContents::ExitFullscreenModeForTab(content::WebContents* source) {
   if (!owner_window_)
     return;
 
+  // This needs to be called before we exit fullscreen on the native window,
+  // or the controller will incorrectly think we weren't fullscreen and bail.
+  exclusive_access_manager_->fullscreen_controller()->ExitFullscreenModeForTab(
+      source);
+
   SetHtmlApiFullscreen(false);
 
   if (native_fullscreen_) {
@@ -1350,9 +1355,6 @@ void WebContents::ExitFullscreenModeForTab(content::WebContents* source) {
     // `chrome/browser/ui/exclusive_access/fullscreen_controller.cc`.
     source->GetRenderViewHost()->GetWidget()->SynchronizeVisualProperties();
   }
-
-  exclusive_access_manager_->fullscreen_controller()->ExitFullscreenModeForTab(
-      source);
 }
 
 void WebContents::RendererUnresponsive(


### PR DESCRIPTION
#### Description of Change

Closes https://github.com/electron/electron/issues/33721.

Fixes an issue where `Escape` keyboard events would not be properly propagated to the parent window after entering fullscreen and then exiting it again on Windows.

This was happening as a result of calling `SetHtmlApiFullscreen(false)` _prior_ to calling `exclusive_access_manager_->fullscreen_controller()->ExitFullscreenModeForTab(source)`. This created a race condition, wherein some platforms like macOS would work correctly becuase by the time [`!exclusive_access_context->IsFullscreen()`](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/exclusive_access/fullscreen_controller.cc;l=237) was called, it wouldn't yet be true on macOS, and [`NotifyTabExclusiveAccessLost`](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/exclusive_access/fullscreen_controller.cc;l=254) would relenquish its hold on keyboard event handling. However, on Windows, [`!exclusive_access_context->IsFullscreen()`](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/exclusive_access/fullscreen_controller.cc;l=237) would be true, and thus the controller would continue to eat `Escape` key events. Fix this by adjusting the call order.

Tested with https://gist.github.com/bc382eeeb368b70fbed1e177bcaacfde on multiple platforms.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: Fixed an issue where `Escape` keyboard events would not be properly propagated to the parent window after entering fullscreen and then exiting it again on Windows.
