### PR TITLE
chore: add missing GN dep

### DIFF
--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -360,6 +360,7 @@ source_set("plugins") {
     "//ppapi/shared_impl",
     "//services/device/public/mojom",
     "//skia",
+    "//storage/browser",
   ]
 }
 


### PR DESCRIPTION
#### Description of Change

Fixes the following issue seen sporadically in CI:

```
../..\storage/common/file_system/file_system_util.h(16,10): fatal error: 'third_party/blink/public/mojom/quota/quota_types.mojom.h' file not found
#include "third_party/blink/public/mojom/quota/quota_types.mojom.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
[246 processes, 28041/41753 @ 100.5/s : 278.906s] CXX obj/media/mojo/services/services/gpu_mojo_media_client.obj
[245 processes, 28042/41753 @ 100.5/s : 278.911s] CXX obj/media/mojo/mojom/mojom/content_decryption_module.mojom.obj
```

Seen in https://github.com/electron/electron/pull/33704 and previously sent to 18-x-y via https://github.com/electron/electron/pull/33664

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none