### PR TITLE
chore: interpret bytes and string args on python3 open

### DIFF
--- a/script/release/uploaders/upload-index-json.py
+++ b/script/release/uploaders/upload-index-json.py
@@ -56,7 +56,7 @@ def main():
 
     new_content = get_content()
 
-    with open(index_json, "w") as f:
+    with open(index_json, "wb") as f:
       f.write(new_content)
 
     store_artifact(OUT_DIR, 'atom-shell/dist', [index_json])


### PR DESCRIPTION
#### Description of Change

Follow up to Python 3 changes, we need to explicitly pass in "binary" as an open option in order to read the file.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
