### PR TITLE
build: fix intermittent compilation failures on macOS

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1077,6 +1077,7 @@ if (is_mac) {
       ":electron_app_plist",
       ":electron_app_resources",
       ":electron_fuses",
+      "//base",
       "//electron/buildflags",
     ]
     if (is_mas_build) {

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1069,7 +1069,6 @@ if (is_mac) {
       "shell/app/electron_main_mac.cc",
       "shell/app/uv_stdio_fix.cc",
       "shell/app/uv_stdio_fix.h",
-      "shell/common/electron_constants.cc",
     ]
     include_dirs = [ "." ]
     deps = [
@@ -1077,7 +1076,6 @@ if (is_mac) {
       ":electron_app_plist",
       ":electron_app_resources",
       ":electron_fuses",
-      "//base",
       "//electron/buildflags",
     ]
     if (is_mas_build) {

--- a/shell/app/electron_main_mac.cc
+++ b/shell/app/electron_main_mac.cc
@@ -30,7 +30,8 @@ int main(int argc, char* argv[]) {
   FixStdioStreams();
 
 #if BUILDFLAG(ENABLE_RUN_AS_NODE)
-  if (electron::fuses::IsRunAsNodeEnabled() && IsEnvSet("ELECTRON_RUN_AS_NODE")) {
+  if (electron::fuses::IsRunAsNodeEnabled() &&
+      IsEnvSet("ELECTRON_RUN_AS_NODE")) {
     return ElectronInitializeICUandStartNode(argc, argv);
   }
 #endif

--- a/shell/app/electron_main_mac.cc
+++ b/shell/app/electron_main_mac.cc
@@ -9,7 +9,6 @@
 #include "electron/fuses.h"
 #include "shell/app/electron_library_main.h"
 #include "shell/app/uv_stdio_fix.h"
-#include "shell/common/electron_constants.h"
 
 #if defined(HELPER_EXECUTABLE) && !defined(MAS_BUILD)
 #include <mach-o/dyld.h>
@@ -31,7 +30,7 @@ int main(int argc, char* argv[]) {
   FixStdioStreams();
 
 #if BUILDFLAG(ENABLE_RUN_AS_NODE)
-  if (electron::fuses::IsRunAsNodeEnabled() && IsEnvSet(electron::kRunAsNode)) {
+  if (electron::fuses::IsRunAsNodeEnabled() && IsEnvSet("ELECTRON_RUN_AS_NODE")) {
     return ElectronInitializeICUandStartNode(argc, argv);
   }
 #endif


### PR DESCRIPTION
#### Description of Change
This is fixing random build failures that we ran into in our internal Electron builds.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes

#### Release Notes
Notes: none