### PR TITLE
ci: build python2 from source

### DIFF
--- a/.circleci/build_config.yml
+++ b/.circleci/build_config.yml
@@ -1532,6 +1532,7 @@ commands:
             - *step-depot-tools-get
       - *step-depot-tools-add-to-path
       - *step-restore-brew-cache
+      - *step-install-python2-on-mac
       - *step-get-more-space-on-mac
       - when:
           condition: << parameters.checkout >>

--- a/.circleci/build_config.yml
+++ b/.circleci/build_config.yml
@@ -511,7 +511,8 @@ step-install-python2-on-mac: &step-install-python2-on-mac
     name: Install python2 on macos
     command: |
       if [ "`uname`" == "Darwin" ]; then
-        brew install vertedinde/python2/python@2
+        curl -O https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg
+        sudo installer -pkg python-2.7.18-macosx10.9.pkg -target /
       fi
 
 step-gn-gen-default: &step-gn-gen-default


### PR DESCRIPTION
#### Description of Change

Improves on our previous change to add python2 back into CircleCI images - this PR now builds python2 from source rather than via homebrew, per CircleCI's [updated recommendations](https://discuss.circleci.com/t/xcode-13-3-1-released/43675).

_Note: The publish-mac job is currently failing - this is a known issue with CircleCI's new 13.3.1 image and disk space, and will be fixed on their end._

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant documentation is changed or added
- [x] [PR release notes](https://github.com/electron/clerk/blob/master/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/master/README.md#examples).

#### Release Notes

Notes: none
