### PR TITLE
docs: update security guide regarding ctx isolation

### DIFF
--- a/docs/api/context-bridge.md
+++ b/docs/api/context-bridge.md
@@ -35,7 +35,7 @@ page you load in your renderer executes code in this world.
 
 When `contextIsolation` is enabled in your `webPreferences` (this is the default behavior since Electron 12.0.0), your `preload` scripts run in an
 "Isolated World".  You can read more about context isolation and what it affects in the
-[security](../tutorial/security.md#3-enable-context-isolation-for-remote-content) docs.
+[security](../tutorial/security.md#3-enable-context-isolation) docs.
 
 ## Methods
 

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -372,7 +372,7 @@ value.
 In Electron 12, `contextIsolation` will be enabled by default.  To restore
 the previous behavior, `contextIsolation: false` must be specified in WebPreferences.
 
-We [recommend having contextIsolation enabled](tutorial/security.md#3-enable-context-isolation-for-remote-content) for the security of your application.
+We [recommend having contextIsolation enabled](tutorial/security.md#3-enable-context-isolation) for the security of your application.
 
 Another implication is that `require()` cannot be used in the renderer process unless
 `nodeIntegration` is `true` and `contextIsolation` is `false`.

--- a/docs/tutorial/security.md
+++ b/docs/tutorial/security.md
@@ -99,7 +99,7 @@ You should at least follow these steps to improve the security of your applicati
 
 1. [Only load secure content](#1-only-load-secure-content)
 2. [Disable the Node.js integration in all renderers that display remote content](#2-do-not-enable-nodejs-integration-for-remote-content)
-3. [Enable context isolation in all renderers that display remote content](#3-enable-context-isolation-for-remote-content)
+3. [Enable context isolation in all renderers](#3-enable-context-isolation)
 4. [Enable process sandboxing](#4-enable-process-sandboxing)
 5. [Use `ses.setPermissionRequestHandler()` in all sessions that load remote content](#5-handle-session-permission-requests-from-remote-content)
 6. [Do not disable `webSecurity`](#6-do-not-disable-websecurity)
@@ -225,7 +225,7 @@ do consume Node.js modules or features. Preload scripts continue to have access
 to `require` and other Node.js features, allowing developers to expose a custom
 API to remotely loaded content via the [contextBridge API](../api/context-bridge.md).
 
-### 3. Enable Context Isolation for remote content
+### 3. Enable Context Isolation
 
 :::info
 This recommendation is the default behavior in Electron since 12.0.0.


### PR DESCRIPTION
These docs don't align with our recommendations, context isolation should be enabled for all content not just specifically remote content.

Closes #33806

Notes: no-notes