### PR TITLE
chore: fix patch conflicts from 37b7e347

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -79,6 +79,13 @@ if (is_linux) {
     ]
   }
 
+  # Generates electron_gtk_stubs.h header which contains
+  # stubs for extracting function ptrs from the gtk library.
+  # Function signatures for which stubs are required should be
+  # declared in electron_gtk.sigs, currently this file contains
+  # signatures for the functions used with native file chooser
+  # implementation. In future, this file can be extended to contain
+  # gtk4 stubs to switch gtk version in runtime.
   generate_stubs("electron_gtk_stubs") {
     sigs = [ "shell/browser/ui/electron_gtk.sigs" ]
     extra_header = "shell/browser/ui/electron_gtk.fragment"

--- a/patches/chromium/make_gtk_getlibgtk_public.patch
+++ b/patches/chromium/make_gtk_getlibgtk_public.patch
@@ -7,7 +7,7 @@ Allows embedders to get a handle to the gtk library
 already loaded in the process.
 
 diff --git a/ui/gtk/gtk_compat.cc b/ui/gtk/gtk_compat.cc
-index 7104a0d5f4489c687f3cb9e63bc7cbef59d2fa62..f0b9ed834a3f7310da09377f0b2105cf635ffeb7 100644
+index 0ed04582106639911d9a4e0284ff880be9c3bc74..bfda81b08be52406048be9b96d2de59223d56ee7 100644
 --- a/ui/gtk/gtk_compat.cc
 +++ b/ui/gtk/gtk_compat.cc
 @@ -86,12 +86,6 @@ void* GetLibGtk4(bool check = true) {
@@ -23,7 +23,7 @@ index 7104a0d5f4489c687f3cb9e63bc7cbef59d2fa62..f0b9ed834a3f7310da09377f0b2105cf
  bool LoadGtk3() {
    if (!GetLibGtk3(false))
      return false;
-@@ -133,6 +127,12 @@ gfx::Insets InsetsFromGtkBorder(const GtkBorder& border) {
+@@ -134,6 +128,12 @@ gfx::Insets InsetsFromGtkBorder(const GtkBorder& border) {
  
  }  // namespace
  


### PR DESCRIPTION
#### Description of Change

Fix ci regression caused by 37b7e347fce555836d694f36f6ee5e2ea67db049

#### Release Notes

Notes: no-notes